### PR TITLE
model: add Yuan3.0 (YuanForCausalLM) support

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -4304,6 +4304,48 @@ class InternVisionModel(MmprojModel):
                 yield from super().modify_tensors(data_torch, name, bid)
 
 
+@ModelBase.register("YuanVLChatModel")
+class YuanVisionModel(InternVisionModel):
+    def set_gguf_parameters(self):
+        assert self.hparams_vision is not None
+        if isinstance(self.hparams_vision['image_size'], list):
+            self.hparams_vision['image_size'] = self.hparams_vision['image_size'][0]
+        if isinstance(self.hparams_vision['patch_size'], list):
+            self.hparams_vision['patch_size'] = self.hparams_vision['patch_size'][0]
+        # call grandparent (MmprojModel) set_gguf_parameters, skip InternVisionModel's
+        super(InternVisionModel, self).set_gguf_parameters()
+
+        hparams = self.hparams
+        self.gguf_writer.add_clip_projector_type(gguf.VisionProjectorType.YUANVL)
+        self.gguf_writer.add_vision_attention_layernorm_eps(hparams["layer_norm_eps"])
+        # InternViT 300M uses GELU activation
+        if hparams["hidden_act"] == "silu":
+            self.gguf_writer.add_vision_use_silu(True)
+        elif hparams["hidden_act"] == "gelu":
+            self.gguf_writer.add_vision_use_gelu(True)
+        else:
+            raise ValueError(f"Unsupported hidden_act: {hparams['hidden_act']}")
+        # downsample_ratio
+        downsample_ratio = self.global_config.get("downsample_ratio")
+        assert downsample_ratio is not None
+        self.gguf_writer.add_vision_projector_scale_factor(int(1.0 / downsample_ratio))
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # handle imagemlp and imagemlp_layernorm projector tensors
+        if name.startswith("imagemlp_layernorm") or name.startswith("imagemlp."):
+            if not name.endswith(".weight"):
+                name += ".weight"
+            yield from super(InternVisionModel, self).modify_tensors(data_torch, name, bid)
+            return
+
+        # skip language model tensors
+        if name.startswith("language_model."):
+            return
+
+        # delegate vision_model tensors to InternVisionModel (handles QKV split, etc.)
+        yield from super().modify_tensors(data_torch, name, bid)
+
+
 @ModelBase.register(
     "NemotronH_Nano_VL_V2",
     "RADIOModel",
@@ -12500,8 +12542,13 @@ def get_model_architecture(hparams: dict[str, Any], model_type: ModelType) -> st
     # if "architectures" is found in the sub-config, use that instead
     if model_type == ModelType.TEXT and text_config.get("architectures") is not None:
         arch = text_config["architectures"][0]
-    elif model_type == ModelType.MMPROJ and vision_config.get("architectures") is not None:
-        arch = vision_config["architectures"][0]
+    elif model_type == ModelType.MMPROJ:
+        # prefer top-level architecture if it's registered as MMPROJ (e.g. YuanVLChatModel)
+        # otherwise fall back to vision_config architecture (e.g. InternVisionModel)
+        if arch is not None and arch in ModelBase._model_classes.get(ModelType.MMPROJ, {}):
+            pass  # keep the top-level arch
+        elif vision_config.get("architectures") is not None:
+            arch = vision_config["architectures"][0]
     if arch is None:
         raise ValueError("Failed to detect model architecture")
     return arch

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -877,7 +877,7 @@ class ModelBase:
         try:
             # for security reason, we don't allow loading remote code by default
             # if a model need remote code, we will fallback to config.json
-            config = AutoConfig.from_pretrained(dir_model, trust_remote_code=False).to_dict()
+            config = AutoConfig.from_pretrained(dir_model, trust_remote_code=True).to_dict()
         except Exception as e:
             logger.warning(f"Failed to load model config from {dir_model}: {e}")
             logger.warning("Trying to load config.json instead")
@@ -12305,6 +12305,126 @@ def split_str_to_n_bytes(split_str: str) -> int:
         raise ValueError(f"Invalid split size: {split_str}, must be positive")
 
     return n
+
+
+@ModelBase.register("YuanForCausalLM")
+class YuanModel(TextModel):
+    model_arch = gguf.MODEL_ARCH.YUAN
+
+    def set_vocab(self):
+        self._set_vocab_sentencepiece()
+
+    def set_gguf_parameters(self):
+        super().set_gguf_parameters()
+        hparams = self.hparams
+
+        self.gguf_writer.add_vocab_size(hparams["vocab_size"])
+
+        # Yuan uses rotary_percent to determine rope dimension
+        # head_dim * rotary_percent = rope_dim
+        head_dim = hparams.get("head_dim", 256)
+        rotary_percent = hparams.get("rotary_percent", 0.5)
+        rope_dim = int(head_dim * rotary_percent)
+        self.gguf_writer.add_rope_dimension_count(rope_dim)
+
+        if (rope_base := hparams.get("rotary_base")) is not None:
+            self.gguf_writer.add_rope_freq_base(rope_base)
+
+        # head_dim differs from hidden_size / num_heads due to attention_projection_size
+        self.gguf_writer.add_key_length(head_dim)
+        self.gguf_writer.add_value_length(head_dim)
+
+        # MoE parameters from nested moe_config
+        moe_config = hparams.get("moe_config", {})
+        if moe_config:
+            n_experts = moe_config.get("moe_num_experts", 0)
+            n_experts_used = moe_config.get("moe_top_k", 0)
+            if n_experts:
+                self.gguf_writer.add_expert_count(n_experts)
+            if n_experts_used:
+                self.gguf_writer.add_expert_used_count(n_experts_used)
+            ffn_size = moe_config.get("ffn_hidden_size", hparams.get("intermediate_size"))
+            if ffn_size:
+                self.gguf_writer.add_expert_feed_forward_length(ffn_size)
+            if moe_config.get("norm_topk_prob", False):
+                self.gguf_writer.add_expert_weights_norm(True)
+
+    _experts: list[dict[str, Tensor]] | None = None
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # skip vision and image projection tensors
+        if name.startswith("vision_model.") or name.startswith("imagemlp") or name.startswith("imagemlp_layernorm"):
+            return
+
+        # strip "language_model." prefix
+        if name.startswith("language_model."):
+            name = name.removeprefix("language_model.")
+
+        # split fused query+key into separate Q and K
+        if name.endswith(".self_attn.get_query_key.weight"):
+            # get_query_key shape: [2 * num_heads * head_dim, hidden_size]
+            # split into q_proj and k_proj
+            half = data_torch.shape[0] // 2
+            q_data = data_torch[:half]
+            k_data = data_torch[half:]
+
+            name_q = name.replace("get_query_key", "q_proj")
+            name_k = name.replace("get_query_key", "k_proj")
+
+            yield from super().modify_tensors(q_data, name_q, bid)
+            yield from super().modify_tensors(k_data, name_k, bid)
+            return
+
+        # handle MoE expert tensors: collect, split fused w1, and merge
+        if "mlp.experts" in name and "router" not in name:
+            moe_config = self.hparams.get("moe_config", {})
+            n_experts = moe_config.get("moe_num_experts", 32)
+            assert bid is not None
+
+            if self._experts is None:
+                self._experts = [{} for _ in range(self.block_count)]
+
+            self._experts[bid][name] = data_torch
+
+            # Each expert has w1 and w2, so wait for all n_experts * 2 tensors
+            if len(self._experts[bid]) >= n_experts * 2:
+                for w_name, split_names in [
+                    # w1 is fused gate+up: [2*ffn_size, hidden] -> gate [ffn_size, hidden] + up [ffn_size, hidden]
+                    ("w1", ("gate_proj", "up_proj")),
+                    # w2 is down: [hidden, ffn_size]
+                    ("w2", ("down_proj",)),
+                ]:
+                    datas_per_split: list[list[Tensor]] = [[] for _ in split_names]
+
+                    for xid in range(n_experts):
+                        ename = f"model.layers.{bid}.mlp.experts.{w_name}.{xid}.weight"
+                        expert_data = self._experts[bid][ename]
+                        del self._experts[bid][ename]
+
+                        if len(split_names) == 2:
+                            # split fused gate+up
+                            half = expert_data.shape[0] // 2
+                            datas_per_split[0].append(expert_data[:half])
+                            datas_per_split[1].append(expert_data[half:])
+                        else:
+                            datas_per_split[0].append(expert_data)
+
+                    for split_name, datas in zip(split_names, datas_per_split):
+                        merged = torch.stack(datas, dim=0)
+                        merged_name = f"model.layers.{bid}.mlp.experts.{split_name}.weight"
+                        yield from super().modify_tensors(merged, merged_name, bid)
+                return
+            else:
+                return
+
+        yield from super().modify_tensors(data_torch, name, bid)
+
+    def prepare_tensors(self):
+        super().prepare_tensors()
+
+        if self._experts is not None:
+            remaining = sum(len(e) for e in self._experts)
+            assert remaining == 0, f"Unprocessed expert tensors: {remaining}"
 
 
 def get_model_architecture(hparams: dict[str, Any], model_type: ModelType) -> str:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -4329,6 +4329,12 @@ class YuanVisionModel(InternVisionModel):
         downsample_ratio = self.global_config.get("downsample_ratio")
         assert downsample_ratio is not None
         self.gguf_writer.add_vision_projector_scale_factor(int(1.0 / downsample_ratio))
+        # dynamic resolution: max_dynamic_patch -> image_max_pixels
+        max_dynamic_patch = self.global_config.get("max_dynamic_patch", 1)
+        image_size = self.hparams_vision["image_size"]
+        if isinstance(image_size, list):
+            image_size = image_size[0]
+        self.gguf_writer.add_vision_max_pixels(max_dynamic_patch * image_size * image_size)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         # handle imagemlp and imagemlp_layernorm projector tensors

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -877,7 +877,7 @@ class ModelBase:
         try:
             # for security reason, we don't allow loading remote code by default
             # if a model need remote code, we will fallback to config.json
-            config = AutoConfig.from_pretrained(dir_model, trust_remote_code=True).to_dict()
+            config = AutoConfig.from_pretrained(dir_model, trust_remote_code=False).to_dict()
         except Exception as e:
             logger.warning(f"Failed to load model config from {dir_model}: {e}")
             logger.warning("Trying to load config.json instead")
@@ -12314,28 +12314,67 @@ class YuanModel(TextModel):
     def set_vocab(self):
         self._set_vocab_sentencepiece()
 
+    def _create_vocab_sentencepiece(self):
+        from sentencepiece import SentencePieceProcessor
+
+        tokens, scores, toktypes = super()._create_vocab_sentencepiece()
+
+        # The SP model doesn't include added special tokens like <|Assistant|>,
+        # <think>, etc. and added_tokens_decoder is empty, so they remain as
+        # [PAD...] placeholders. Patch them in from additional_special_tokens.
+        tokenizer_path = self.dir_model / 'tokenizer.model'
+        tokenizer = SentencePieceProcessor()
+        tokenizer.LoadFromFile(str(tokenizer_path))
+        sp_vocab_size = tokenizer.vocab_size()
+
+        tokenizer_config_file = self.dir_model / 'tokenizer_config.json'
+        if tokenizer_config_file.is_file():
+            with open(tokenizer_config_file, "r", encoding="utf-8") as f:
+                tokenizer_config = json.load(f)
+            added_special = tokenizer_config.get("additional_special_tokens", [])
+            next_id = sp_vocab_size
+            for tok in added_special:
+                if tokenizer.PieceToId(tok) != tokenizer.unk_id() or tok == '<unk>':
+                    continue
+                if next_id < len(tokens):
+                    tokens[next_id] = tok.encode("utf-8")
+                    scores[next_id] = -1000.0
+                    toktypes[next_id] = SentencePieceTokenTypes.CONTROL
+                next_id += 1
+
+        return tokens, scores, toktypes
+
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
         hparams = self.hparams
 
-        self.gguf_writer.add_vocab_size(hparams["vocab_size"])
+        # Yuan VL models have nested llm_config for text model parameters
+        # Use llm_config if available, otherwise fall back to top-level hparams
+        llm_config = hparams.get("llm_config", {})
+        if not llm_config:
+            llm_config = hparams
+
+        # vocab_size may be in llm_config or top-level
+        vocab_size = llm_config.get("vocab_size") or hparams.get("vocab_size")
+        if vocab_size:
+            self.gguf_writer.add_vocab_size(vocab_size)
 
         # Yuan uses rotary_percent to determine rope dimension
         # head_dim * rotary_percent = rope_dim
-        head_dim = hparams.get("head_dim", 256)
-        rotary_percent = hparams.get("rotary_percent", 0.5)
+        head_dim = llm_config.get("head_dim", 256)
+        rotary_percent = llm_config.get("rotary_percent", 0.5)
         rope_dim = int(head_dim * rotary_percent)
         self.gguf_writer.add_rope_dimension_count(rope_dim)
 
-        if (rope_base := hparams.get("rotary_base")) is not None:
+        if (rope_base := llm_config.get("rotary_base")) is not None:
             self.gguf_writer.add_rope_freq_base(rope_base)
 
         # head_dim differs from hidden_size / num_heads due to attention_projection_size
         self.gguf_writer.add_key_length(head_dim)
         self.gguf_writer.add_value_length(head_dim)
 
-        # MoE parameters from nested moe_config
-        moe_config = hparams.get("moe_config", {})
+        # MoE parameters from nested moe_config (in llm_config for VL models)
+        moe_config = llm_config.get("moe_config", {})
         if moe_config:
             n_experts = moe_config.get("moe_num_experts", 0)
             n_experts_used = moe_config.get("moe_top_k", 0)
@@ -12343,7 +12382,7 @@ class YuanModel(TextModel):
                 self.gguf_writer.add_expert_count(n_experts)
             if n_experts_used:
                 self.gguf_writer.add_expert_used_count(n_experts_used)
-            ffn_size = moe_config.get("ffn_hidden_size", hparams.get("intermediate_size"))
+            ffn_size = moe_config.get("ffn_hidden_size", llm_config.get("intermediate_size"))
             if ffn_size:
                 self.gguf_writer.add_expert_feed_forward_length(ffn_size)
             if moe_config.get("norm_topk_prob", False):
@@ -12363,10 +12402,18 @@ class YuanModel(TextModel):
         # split fused query+key into separate Q and K
         if name.endswith(".self_attn.get_query_key.weight"):
             # get_query_key shape: [2 * num_heads * head_dim, hidden_size]
-            # split into q_proj and k_proj
-            half = data_torch.shape[0] // 2
-            q_data = data_torch[:half]
-            k_data = data_torch[half:]
+            # HF splits per-head: view as [num_heads, 2*head_dim] then split on last dim
+            # so the layout is [Q_h0, K_h0, Q_h1, K_h1, ...] interleaved per head
+            llm_config = self.hparams.get("llm_config", {})
+            if not llm_config:
+                llm_config = self.hparams
+            num_heads = llm_config["num_attention_heads"]
+            head_dim = llm_config.get("head_dim", data_torch.shape[0] // (2 * num_heads))
+            hidden_size = data_torch.shape[1]
+
+            data_torch = data_torch.view(num_heads, 2 * head_dim, hidden_size)
+            q_data = data_torch[:, :head_dim, :].reshape(num_heads * head_dim, hidden_size)
+            k_data = data_torch[:, head_dim:, :].reshape(num_heads * head_dim, hidden_size)
 
             name_q = name.replace("get_query_key", "q_proj")
             name_k = name.replace("get_query_key", "k_proj")
@@ -12416,6 +12463,17 @@ class YuanModel(TextModel):
                 return
             else:
                 return
+
+        # reshape Conv2d weights from 4D [out_ch, in_ch, 2, 1] to 2D [2*out_ch, in_ch]
+        # PyTorch Conv2d cross-correlation with prepended zero padding:
+        #   output[t] = weight[:,:,1] @ input[t] + weight[:,:,0] @ input[t-1]
+        # GGML expects: first block = current token, second block = previous token
+        # So we store [kernel_pos_1, kernel_pos_0] (swapped)
+        if "lf_gate.conv1.weight" in name or "lf_gate.conv2.weight" in name:
+            data_torch = data_torch.squeeze(-1)       # [out_ch, in_ch, 2]
+            w_current  = data_torch[:, :, 1]           # kernel pos 1 → current token
+            w_previous = data_torch[:, :, 0]           # kernel pos 0 → previous token
+            data_torch = torch.cat([w_current, w_previous], dim=0)  # [2*out_ch, in_ch]
 
         yield from super().modify_tensors(data_torch, name, bid)
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -484,6 +484,7 @@ class MODEL_ARCH(IntEnum):
     LLAMA_EMBED      = auto()
     MAINCODER        = auto()
     KIMI_LINEAR      = auto()
+    YUAN             = auto()
 
 
 class VISION_PROJECTOR_TYPE(IntEnum):
@@ -691,6 +692,10 @@ class MODEL_TENSOR(IntEnum):
     INDEXER_PROJ         = auto()
     INDEXER_ATTN_K       = auto()
     INDEXER_ATTN_Q_B     = auto()
+    ATTN_LF_CONV1        = auto() # yuan localized filtering
+    ATTN_LF_CONV2        = auto() # yuan localized filtering
+    ATTN_LF_NORM         = auto() # yuan localized filtering
+    FFN_GATE_INP_QKV     = auto() # yuan attention-based MoE router
     # vision
     V_MMPROJ             = auto()
     V_MMPROJ_FC          = auto()
@@ -930,6 +935,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.LLAMA_EMBED:      "llama-embed",
     MODEL_ARCH.MAINCODER:        "maincoder",
     MODEL_ARCH.KIMI_LINEAR:      "kimi-linear",
+    MODEL_ARCH.YUAN:             "yuan",
 }
 
 VISION_PROJECTOR_TYPE_NAMES: dict[VISION_PROJECTOR_TYPE, str] = {
@@ -1065,6 +1071,10 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.CHANNEL_MIX_KEY:           "blk.{bid}.channel_mix_key",
     MODEL_TENSOR.CHANNEL_MIX_RECEPTANCE:    "blk.{bid}.channel_mix_receptance",
     MODEL_TENSOR.CHANNEL_MIX_VALUE:         "blk.{bid}.channel_mix_value",
+    MODEL_TENSOR.ATTN_LF_CONV1:             "blk.{bid}.attn_lf_conv1",
+    MODEL_TENSOR.ATTN_LF_CONV2:             "blk.{bid}.attn_lf_conv2",
+    MODEL_TENSOR.ATTN_LF_NORM:              "blk.{bid}.attn_lf_norm",
+    MODEL_TENSOR.FFN_GATE_INP_QKV:          "blk.{bid}.ffn_gate_inp_qkv",
     MODEL_TENSOR.ATTN_Q_A:                  "blk.{bid}.attn_q_a",
     MODEL_TENSOR.ATTN_Q_B:                  "blk.{bid}.attn_q_b",
     MODEL_TENSOR.ATTN_KV_A_MQA:             "blk.{bid}.attn_kv_a_mqa",
@@ -3660,6 +3670,24 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_GATE_SHEXP,
         MODEL_TENSOR.FFN_DOWN_SHEXP,
         MODEL_TENSOR.FFN_UP_SHEXP,
+    ],
+    MODEL_ARCH.YUAN: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT_NORM,
+        MODEL_TENSOR.OUTPUT,
+        MODEL_TENSOR.ATTN_NORM,
+        MODEL_TENSOR.ATTN_Q,
+        MODEL_TENSOR.ATTN_K,
+        MODEL_TENSOR.ATTN_V,
+        MODEL_TENSOR.ATTN_OUT,
+        MODEL_TENSOR.ATTN_LF_CONV1,
+        MODEL_TENSOR.ATTN_LF_CONV2,
+        MODEL_TENSOR.ATTN_LF_NORM,
+        MODEL_TENSOR.FFN_NORM,
+        MODEL_TENSOR.FFN_GATE_INP_QKV,
+        MODEL_TENSOR.FFN_GATE_EXP,
+        MODEL_TENSOR.FFN_DOWN_EXP,
+        MODEL_TENSOR.FFN_UP_EXP,
     ],
     # TODO
 }

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -3934,6 +3934,7 @@ class VisionProjectorType:
     GLM4V = "glm4v"
     YOUTUVL = "youtuvl"
     NEMOTRON_V2_VL = "nemotron_v2_vl"
+    YUANVL = "yuanvl"
 
 
 # Items here are (block size, type size)

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -1590,6 +1590,7 @@ class TensorNameMap:
 
         MODEL_TENSOR.V_MM_POST_NORM: (
             "visual.merger.post_projection_norm", # glm4v
+            "imagemlp_layernorm", # yuanvl
         ),
 
         MODEL_TENSOR.V_MM_INP_PROJ: (
@@ -1685,16 +1686,19 @@ class TensorNameMap:
         MODEL_TENSOR.V_MM_UP: (
             "model.vision.linear_proj.dense_h_to_4h", # cogvlm
             "visual.merger.up_proj", # glm4v
+            "imagemlp.up_proj", # yuanvl
         ),
 
         MODEL_TENSOR.V_MM_DOWN: (
             "model.vision.linear_proj.dense_4h_to_h", # cogvlm
             "visual.merger.down_proj", # glm4v
+            "imagemlp.down_proj", # yuanvl
         ),
 
         MODEL_TENSOR.V_MM_GATE: (
             "model.vision.linear_proj.gate_proj", # cogvlm
             "visual.merger.gate_proj", # glm4v
+            "imagemlp.gate_proj", # yuanvl
         ),
 
         MODEL_TENSOR.V_TOK_BOI: (

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -571,6 +571,22 @@ class TensorNameMap:
             "model.layers.{bid}.mlp.experts.gate_up_proj",
         ),
 
+        # Yuan localized filtering attention
+        MODEL_TENSOR.ATTN_LF_CONV1: (
+            "model.layers.{bid}.self_attn.lf_gate.conv1",  # yuan
+        ),
+        MODEL_TENSOR.ATTN_LF_CONV2: (
+            "model.layers.{bid}.self_attn.lf_gate.conv2",  # yuan
+        ),
+        MODEL_TENSOR.ATTN_LF_NORM: (
+            "model.layers.{bid}.self_attn.lf_gate.output_layernorm",  # yuan
+        ),
+
+        # Yuan attention-based MoE router
+        MODEL_TENSOR.FFN_GATE_INP_QKV: (
+            "model.layers.{bid}.mlp.router.query_key_value",  # yuan
+        ),
+
         MODEL_TENSOR.MOE_LATENT_DOWN: (
             "backbone.layers.{bid}.mixer.fc1_latent_proj",                 # nemotron 3 super
         ),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ add_library(llama
             models/t5-enc.cpp
             models/wavtokenizer-dec.cpp
             models/xverse.cpp
+            models/yuan.cpp
             )
 
 set_target_properties(llama PROPERTIES

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -129,6 +129,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_LLAMA_EMBED,      "llama-embed"      },
     { LLM_ARCH_MAINCODER,        "maincoder"        },
     { LLM_ARCH_KIMI_LINEAR,      "kimi-linear"      },
+    { LLM_ARCH_YUAN,             "yuan"             },
     { LLM_ARCH_UNKNOWN,          "(unknown)"        },
 };
 
@@ -439,6 +440,10 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
     { LLM_TENSOR_NEXTN_HNORM,                            "blk.%d.nextn.hnorm" },
     { LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD,                 "blk.%d.nextn.shared_head_head" },
     { LLM_TENSOR_NEXTN_SHARED_HEAD_NORM,                 "blk.%d.nextn.shared_head_norm" },
+    { LLM_TENSOR_ATTN_LF_CONV1,                         "blk.%d.attn_lf_conv1" },
+    { LLM_TENSOR_ATTN_LF_CONV2,                         "blk.%d.attn_lf_conv2" },
+    { LLM_TENSOR_ATTN_LF_NORM,                          "blk.%d.attn_lf_norm" },
+    { LLM_TENSOR_FFN_GATE_INP_QKV,                      "blk.%d.ffn_gate_inp_qkv" },
     { LLM_TENSOR_ATTN_SUB_NORM,                          "blk.%d.attn_sub_norm" },
     { LLM_TENSOR_FFN_SUB_NORM,                           "blk.%d.ffn_sub_norm" },
     { LLM_TENSOR_DEC_OUTPUT_NORM,                        "dec.output_norm" },
@@ -2543,6 +2548,25 @@ static std::set<llm_tensor> llm_get_tensor_names(llm_arch arch) {
                 LLM_TENSOR_ATTN_V_B,
                 LLM_TENSOR_ATTN_KV_A_NORM,
             };
+        case LLM_ARCH_YUAN:
+            return {
+                LLM_TENSOR_TOKEN_EMBD,
+                LLM_TENSOR_OUTPUT_NORM,
+                LLM_TENSOR_OUTPUT,
+                LLM_TENSOR_ATTN_NORM,
+                LLM_TENSOR_ATTN_Q,
+                LLM_TENSOR_ATTN_K,
+                LLM_TENSOR_ATTN_V,
+                LLM_TENSOR_ATTN_OUT,
+                LLM_TENSOR_ATTN_LF_CONV1,
+                LLM_TENSOR_ATTN_LF_CONV2,
+                LLM_TENSOR_ATTN_LF_NORM,
+                LLM_TENSOR_FFN_NORM,
+                LLM_TENSOR_FFN_GATE_INP_QKV,
+                LLM_TENSOR_FFN_GATE_EXPS,
+                LLM_TENSOR_FFN_DOWN_EXPS,
+                LLM_TENSOR_FFN_UP_EXPS,
+            };
         default:
             GGML_ABORT("unknown architecture for tensor mapping");
     }
@@ -2704,6 +2728,11 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
     {LLM_TENSOR_FFN_GATE_CHEXPS,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
     {LLM_TENSOR_FFN_UP_CHEXPS,              {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
     {LLM_TENSOR_FFN_EXP_PROBS_B,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_ADD}},
+    // yuan localized filtering + attention router
+    {LLM_TENSOR_ATTN_LF_CONV1,              {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+    {LLM_TENSOR_ATTN_LF_CONV2,              {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+    {LLM_TENSOR_ATTN_LF_NORM,               {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL}},
+    {LLM_TENSOR_FFN_GATE_INP_QKV,           {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     // altup / laurel (gemma 3n)
     {LLM_TENSOR_PER_LAYER_TOKEN_EMBD,       {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_GET_ROWS}},
     {LLM_TENSOR_PER_LAYER_MODEL_PROJ,       {LLM_TENSOR_LAYER_OUTPUT,    GGML_OP_MUL_MAT}},

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -2887,6 +2887,7 @@ bool llm_arch_is_hybrid(const llm_arch & arch) {
         case LLM_ARCH_KIMI_LINEAR:
         case LLM_ARCH_QWEN35:
         case LLM_ARCH_QWEN35MOE:
+        case LLM_ARCH_YUAN:
             return true;
         default:
             return false;

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -133,6 +133,7 @@ enum llm_arch {
     LLM_ARCH_LLAMA_EMBED,
     LLM_ARCH_MAINCODER,
     LLM_ARCH_KIMI_LINEAR,
+    LLM_ARCH_YUAN,
     LLM_ARCH_UNKNOWN,
 };
 
@@ -543,6 +544,10 @@ enum llm_tensor {
     LLM_TENSOR_NEXTN_HNORM,
     LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD,
     LLM_TENSOR_NEXTN_SHARED_HEAD_NORM,
+    LLM_TENSOR_ATTN_LF_CONV1,       // yuan localized filtering
+    LLM_TENSOR_ATTN_LF_CONV2,       // yuan localized filtering
+    LLM_TENSOR_ATTN_LF_NORM,        // yuan localized filtering
+    LLM_TENSOR_FFN_GATE_INP_QKV,    // yuan attention-based MoE router
 };
 
 enum llm_tensor_layer {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -993,6 +993,17 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                     default: type = LLM_TYPE_UNKNOWN;
                 }
             } break;
+        case LLM_ARCH_YUAN:
+            {
+                ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+                ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,  hparams.n_ff_exp, false);
+                ml.get_key(LLM_KV_EXPERT_WEIGHTS_NORM,         hparams.expert_weights_norm, false);
+
+                switch (hparams.n_layer) {
+                    case 24: type = LLM_TYPE_UNKNOWN; break;
+                    default: type = LLM_TYPE_UNKNOWN;
+                }
+            } break;
         case LLM_ARCH_QWEN3:
             {
                 ml.get_key(LLM_KV_POOLING_TYPE, hparams.pooling_type, false);
@@ -3622,6 +3633,49 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                         layer.ffn_gate_shexp = create_tensor(tn(LLM_TENSOR_FFN_GATE_SHEXP, "weight", i), {    n_embd, n_ff_shexp}, 0);
                         layer.ffn_down_shexp = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), {n_ff_shexp,     n_embd}, 0);
                         layer.ffn_up_shexp   = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,   "weight", i), {    n_embd, n_ff_shexp}, 0);
+                    }
+                } break;
+            case LLM_ARCH_YUAN:
+                {
+                    tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
+
+                    // output
+                    output_norm = create_tensor(tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd}, 0);
+                    output      = create_tensor(tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, 0);
+
+                    const int64_t n_embd_head_k = hparams.n_embd_head_k();
+                    const int64_t n_ff_exp = hparams.n_ff_exp ? hparams.n_ff_exp : n_ff;
+
+                    for (int i = 0; i < n_layer; ++i) {
+                        auto & layer = layers[i];
+
+                        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
+
+                        // Q, K, V projections (head_dim=256, n_head=16, projection_size=4096)
+                        layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_head * n_embd_head_k}, 0);
+                        layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_head_kv * n_embd_head_k}, 0);
+                        layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_head_kv * n_embd_head_k}, 0);
+                        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_head * n_embd_head_k, n_embd}, 0);
+
+                        // localized filtering (Conv2d weights reshaped to 2D: [in_ch, 2*out_ch])
+                        // first out_ch rows = W0 (kernel pos 0, current), next out_ch rows = W1 (kernel pos 1, previous)
+                        const int64_t lf_mid = n_embd / 2;
+                        layer.attn_lf_conv1   = create_tensor(tn(LLM_TENSOR_ATTN_LF_CONV1, "weight", i), {n_embd, 2*lf_mid}, 0);
+                        layer.attn_lf_conv1_b = create_tensor(tn(LLM_TENSOR_ATTN_LF_CONV1, "bias",   i), {lf_mid}, 0);
+                        layer.attn_lf_conv2   = create_tensor(tn(LLM_TENSOR_ATTN_LF_CONV2, "weight", i), {lf_mid, 2*n_embd}, 0);
+                        layer.attn_lf_conv2_b = create_tensor(tn(LLM_TENSOR_ATTN_LF_CONV2, "bias",   i), {n_embd}, 0);
+                        layer.attn_lf_norm    = create_tensor(tn(LLM_TENSOR_ATTN_LF_NORM,  "weight", i), {n_embd}, 0);
+
+                        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
+
+                        // MoE attention-based router
+                        // router QKV weight: [3 * n_expert, n_embd] -> used for attention routing
+                        layer.ffn_gate_inp_qkv = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP_QKV, "weight", i), {n_embd, 3 * n_expert}, 0);
+
+                        // expert FFN weights
+                        layer.ffn_gate_exps = create_tensor(tn(LLM_TENSOR_FFN_GATE_EXPS, "weight", i), {  n_embd, n_ff_exp, n_expert}, 0);
+                        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {n_ff_exp,   n_embd, n_expert}, 0);
+                        layer.ffn_up_exps   = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,   "weight", i), {  n_embd, n_ff_exp, n_expert}, 0);
                     }
                 } break;
             case LLM_ARCH_QWEN3:
@@ -8247,6 +8301,10 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
             {
                 llm = std::make_unique<llm_build_qwen2moe>(*this, params);
             } break;
+        case LLM_ARCH_YUAN:
+            {
+                llm = std::make_unique<llm_build_yuan>(*this, params);
+            } break;
         case LLM_ARCH_QWEN3:
             {
                 llm = std::make_unique<llm_build_qwen3>(*this, params);
@@ -8878,6 +8936,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
         case LLM_ARCH_QWEN3NEXT:
         case LLM_ARCH_MIMO2:
         case LLM_ARCH_STEP35:
+        case LLM_ARCH_YUAN:
             return LLAMA_ROPE_TYPE_NEOX;
 
         case LLM_ARCH_QWEN2VL:

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -999,6 +999,19 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,  hparams.n_ff_exp, false);
                 ml.get_key(LLM_KV_EXPERT_WEIGHTS_NORM,         hparams.expert_weights_norm, false);
 
+                // Yuan uses a double causal Conv2d (kernel_size=2) for localized filtering.
+                // We cache 2 previous pre-LF hidden states per layer via the recurrent state infrastructure.
+                // ssm_d_conv=3 → n_embd_r = (3-1)*n_embd = 2*n_embd (two cached states)
+                // ssm_d_inner=n_embd, ssm_d_state=0 → n_embd_s = 0 (no SSM state)
+                // The two cached states allow exact computation of both conv1 and conv2
+                // at sequence boundaries (conv2 needs the previous conv1 output, which in
+                // turn needs two consecutive pre-LF hidden states).
+                hparams.ssm_d_conv  = 3;
+                hparams.ssm_d_inner = hparams.n_embd;
+
+                // All layers have both attention and recurrent (conv) components
+                std::fill(hparams.recurrent_layer_arr.begin(), hparams.recurrent_layer_arr.end(), true);
+
                 switch (hparams.n_layer) {
                     case 24: type = LLM_TYPE_UNKNOWN; break;
                     default: type = LLM_TYPE_UNKNOWN;
@@ -7845,7 +7858,8 @@ void llama_model::print_info() const {
         arch == LLM_ARCH_QWEN35 ||
         arch == LLM_ARCH_QWEN35MOE ||
         arch == LLM_ARCH_NEMOTRON_H ||
-        arch == LLM_ARCH_NEMOTRON_H_MOE) {
+        arch == LLM_ARCH_NEMOTRON_H_MOE ||
+        arch == LLM_ARCH_YUAN) {
         LLAMA_LOG_INFO("%s: ssm_d_conv            = %u\n",     __func__, hparams.ssm_d_conv);
         LLAMA_LOG_INFO("%s: ssm_d_inner           = %u\n",     __func__, hparams.ssm_d_inner);
         LLAMA_LOG_INFO("%s: ssm_d_state           = %u\n",     __func__, hparams.ssm_d_state);
@@ -8080,7 +8094,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                     // layer filters, so pick the right one here
                     llama_memory_hybrid::layer_filter_cb filter_attn = nullptr;
                     llama_memory_hybrid::layer_filter_cb filter_recr = nullptr;
-                    if (arch == LLM_ARCH_FALCON_H1) {
+                    if (arch == LLM_ARCH_FALCON_H1 || arch == LLM_ARCH_YUAN) {
                         filter_attn = [&](int32_t) { return true; };
                         filter_recr = [&](int32_t) { return true; };
                     } else if (arch == LLM_ARCH_NEMOTRON_H || arch == LLM_ARCH_NEMOTRON_H_MOE) {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -418,6 +418,16 @@ struct llama_layer {
     struct ggml_tensor * laurel_r             = nullptr;
     struct ggml_tensor * laurel_post_norm     = nullptr;
 
+    // yuan localized filtering
+    struct ggml_tensor * attn_lf_conv1   = nullptr;
+    struct ggml_tensor * attn_lf_conv1_b = nullptr;
+    struct ggml_tensor * attn_lf_conv2   = nullptr;
+    struct ggml_tensor * attn_lf_conv2_b = nullptr;
+    struct ggml_tensor * attn_lf_norm    = nullptr;
+
+    // yuan attention-based MoE router
+    struct ggml_tensor * ffn_gate_inp_qkv = nullptr;
+
     // openai-moe
     struct ggml_tensor * attn_sinks = nullptr;
 

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -515,6 +515,10 @@ struct llm_build_qwen2moe : public llm_graph_context {
     llm_build_qwen2moe(const llama_model & model, const llm_graph_params & params);
 };
 
+struct llm_build_yuan : public llm_graph_context {
+    llm_build_yuan(const llama_model & model, const llm_graph_params & params);
+};
+
 struct llm_build_qwen2vl : public llm_graph_context {
     llm_build_qwen2vl(const llama_model & model, const llm_graph_params & params);
 };

--- a/src/models/yuan.cpp
+++ b/src/models/yuan.cpp
@@ -1,5 +1,8 @@
 #include "models.h"
 
+#include "llama-memory-hybrid.h"
+#include "llama-memory-recurrent.h"
+
 llm_build_yuan::llm_build_yuan(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
     const int64_t n_embd_head = hparams.n_embd_head_v();
 
@@ -13,9 +16,16 @@ llm_build_yuan::llm_build_yuan(const llama_model & model, const llm_graph_params
     // inp_pos - contains the positions
     ggml_tensor * inp_pos = build_inp_pos();
 
-    auto * inp_attn = build_attn_inp_kv();
+    // hybrid memory: KV cache (attention) + recurrent state cache (conv states)
+    auto * inp = build_inp_mem_hybrid();
 
     ggml_tensor * inp_out_ids = build_inp_out_ids();
+
+    const auto * mctx_cur = static_cast<const llama_memory_hybrid_context *>(mctx);
+    const auto * mctx_recr = mctx_cur->get_recr();
+    const auto   kv_head = mctx_recr->get_head();
+    const int64_t n_seqs = ubatch.n_seqs;
+    const int64_t n_seq_tokens = ubatch.n_seq_tokens;
 
     for (int il = 0; il < n_layer; ++il) {
         ggml_tensor * inpSA = inpL;
@@ -30,64 +40,109 @@ llm_build_yuan::llm_build_yuan(const llama_model & model, const llm_graph_params
         ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
         cb(Vcur, "Vcur", il);
 
-        // localized filtering (causal conv2d with kernel_size=2)
-        // output[t] = W0 @ input[t] + W1 @ input[t-1] + bias  (input[-1] = 0)
+        // localized filtering (double causal Conv2d, kernel_size=2)
+        // Uses 2 cached pre-LF hidden states for exact causal continuity.
         //
-        // Weight stored as [in_ch, 2*out_ch]: W0||W1 concatenated in output dim.
-        // One matmul produces both parts, then we split and shift W1's part.
+        // Cache layout: [n_embd, 2] per layer per sequence = two previous hidden states.
+        // With 2 cached states we can exactly compute:
+        //   - conv1 boundary output (from cached[-2] and cached[-1])
+        //   - conv2 with proper previous conv1 output at sequence boundary
         {
             const int64_t lf_mid = n_embd / 2;
-            const int64_t n_seq = cur->ne[1];  // actual sequence length
+            const int64_t n_embd_r = hparams.n_embd_r(); // 2 * n_embd
 
-            // conv1: cur [n_embd, n_seq] @ weight [n_embd, 2*lf_mid] -> [2*lf_mid, n_seq]
-            ggml_tensor * conv1_full = ggml_mul_mat(ctx0, model.layers[il].attn_lf_conv1, cur);
+            // load 2 cached pre-LF hidden states: [2*n_embd, n_seqs] -> [n_embd, 2, n_seqs]
+            ggml_tensor * conv_states_all = mctx_recr->get_r_l(il);
+            ggml_tensor * conv_state = build_rs(inp->get_recr(), conv_states_all, n_embd_r, n_seqs);
+            conv_state = ggml_reshape_3d(ctx0, conv_state, n_embd, 2, n_seqs);
+
+            // reshape cur to 3D: [n_embd, n_seq_tokens, n_seqs]
+            ggml_tensor * cur_3d = ggml_reshape_3d(ctx0, cur, n_embd, n_seq_tokens, n_seqs);
+
+            // prepend 2 cached states: [n_embd, 2+n_seq_tokens, n_seqs]
+            ggml_tensor * cur_ext = ggml_concat(ctx0, conv_state, cur_3d, 1);
+
+            // save last 2 pre-LF hidden states back to cache
+            ggml_tensor * last_states = ggml_view_3d(ctx0, cur_ext,
+                    n_embd, 2, n_seqs,
+                    cur_ext->nb[1], cur_ext->nb[2],
+                    n_seq_tokens * cur_ext->nb[1]);
+            ggml_build_forward_expand(gf,
+                    ggml_cpy(ctx0, last_states,
+                        ggml_view_1d(ctx0, conv_states_all,
+                            n_embd_r * n_seqs,
+                            kv_head * n_embd_r * ggml_element_size(conv_states_all))));
+
+            // conv1 on extended sequence [n_embd, 2+n_seq_tokens, n_seqs]
+            // Weight [n_embd, 2*lf_mid]: W_current || W_previous in output dim
+            ggml_tensor * cur_ext_2d = ggml_reshape_2d(ctx0, cur_ext, n_embd, (2 + n_seq_tokens) * n_seqs);
+            ggml_tensor * conv1_full = ggml_mul_mat(ctx0, model.layers[il].attn_lf_conv1, cur_ext_2d);
+            conv1_full = ggml_reshape_3d(ctx0, conv1_full, 2 * lf_mid, 2 + n_seq_tokens, n_seqs);
             cb(conv1_full, "lf_conv1_full", il);
 
-            // split: part0 = W0@cur [lf_mid, n_seq], part1 = W1@cur [lf_mid, n_seq]
-            ggml_tensor * c1_part0 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv1_full,
-                    lf_mid, n_seq, conv1_full->nb[1], 0));
-            ggml_tensor * c1_part1 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv1_full,
-                    lf_mid, n_seq, conv1_full->nb[1],
-                    lf_mid * ggml_element_size(conv1_full)));
+            // part0[i] = W_current @ ext[i], part1[i] = W_previous @ ext[i]
+            ggml_tensor * c1_part0 = ggml_view_3d(ctx0, conv1_full,
+                    lf_mid, 2 + n_seq_tokens, n_seqs,
+                    conv1_full->nb[1], conv1_full->nb[2], 0);
+            ggml_tensor * c1_part1 = ggml_view_3d(ctx0, conv1_full,
+                    lf_mid, 2 + n_seq_tokens, n_seqs,
+                    conv1_full->nb[1], conv1_full->nb[2],
+                    lf_mid * ggml_element_size(conv1_full));
 
-            ggml_tensor * conv1_out;
-            if (n_seq > 1) {
-                // causal shift: shifted[0] = 0, shifted[t] = part1[t-1]
-                ggml_tensor * c1_zero = ggml_scale(ctx0, ggml_view_2d(ctx0, c1_part0,
-                        lf_mid, 1, c1_part0->nb[1], 0), 0.0f);
-                ggml_tensor * c1_prev = ggml_view_2d(ctx0, c1_part1,
-                        lf_mid, n_seq - 1, c1_part1->nb[1], 0);
-                ggml_tensor * c1_shifted = ggml_concat(ctx0, c1_zero, c1_prev, 1);
-                conv1_out = ggml_add(ctx0, c1_part0, c1_shifted);
-            } else {
-                // single token: W1 contribution is zero (no previous token)
-                conv1_out = c1_part0;
-            }
+            // conv1 boundary output (for conv2's causal shift):
+            //   boundary = W_current @ ext[1] + W_previous @ ext[0] + bias
+            //            = W_current @ cached[-1] + W_previous @ cached[-2] + bias
+            ggml_tensor * c1_bnd_cur = ggml_cont(ctx0, ggml_view_3d(ctx0, c1_part0,
+                    lf_mid, 1, n_seqs, c1_part0->nb[1], c1_part0->nb[2],
+                    1 * c1_part0->nb[1]));
+            ggml_tensor * c1_bnd_prev = ggml_cont(ctx0, ggml_view_3d(ctx0, c1_part1,
+                    lf_mid, 1, n_seqs, c1_part1->nb[1], c1_part1->nb[2], 0));
+            ggml_tensor * conv1_boundary = ggml_add(ctx0, c1_bnd_cur, c1_bnd_prev);
+            conv1_boundary = ggml_add(ctx0, conv1_boundary, model.layers[il].attn_lf_conv1_b);
+
+            // conv1 real outputs for positions 0..n_seq_tokens-1:
+            //   out[t] = W_current @ ext[t+2] + W_previous @ ext[t+1] + bias
+            ggml_tensor * c1_cur = ggml_cont(ctx0, ggml_view_3d(ctx0, c1_part0,
+                    lf_mid, n_seq_tokens, n_seqs,
+                    c1_part0->nb[1], c1_part0->nb[2],
+                    2 * c1_part0->nb[1]));
+            ggml_tensor * c1_prev = ggml_cont(ctx0, ggml_view_3d(ctx0, c1_part1,
+                    lf_mid, n_seq_tokens, n_seqs,
+                    c1_part1->nb[1], c1_part1->nb[2],
+                    1 * c1_part1->nb[1]));
+            ggml_tensor * conv1_out = ggml_add(ctx0, c1_cur, c1_prev);
             conv1_out = ggml_add(ctx0, conv1_out, model.layers[il].attn_lf_conv1_b);
             cb(conv1_out, "lf_conv1_out", il);
 
-            // conv2: conv1_out [lf_mid, n_seq] @ weight [lf_mid, 2*n_embd] -> [2*n_embd, n_seq]
-            ggml_tensor * conv2_full = ggml_mul_mat(ctx0, model.layers[il].attn_lf_conv2, conv1_out);
+            // conv2: prepend boundary conv1 output for causal shift
+            // [lf_mid, 1+n_seq_tokens, n_seqs]
+            ggml_tensor * conv1_ext = ggml_concat(ctx0, conv1_boundary, conv1_out, 1);
+
+            ggml_tensor * conv1_ext_2d = ggml_reshape_2d(ctx0, conv1_ext, lf_mid, (1 + n_seq_tokens) * n_seqs);
+            ggml_tensor * conv2_full = ggml_mul_mat(ctx0, model.layers[il].attn_lf_conv2, conv1_ext_2d);
+            conv2_full = ggml_reshape_3d(ctx0, conv2_full, 2 * n_embd, 1 + n_seq_tokens, n_seqs);
             cb(conv2_full, "lf_conv2_full", il);
 
-            ggml_tensor * c2_part0 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv2_full,
-                    n_embd, n_seq, conv2_full->nb[1], 0));
-            ggml_tensor * c2_part1 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv2_full,
-                    n_embd, n_seq, conv2_full->nb[1],
-                    n_embd * ggml_element_size(conv2_full)));
+            // conv2 output: out[t] = W_current @ conv1_ext[t+1] + W_previous @ conv1_ext[t]
+            ggml_tensor * c2_part0 = ggml_view_3d(ctx0, conv2_full,
+                    n_embd, 1 + n_seq_tokens, n_seqs,
+                    conv2_full->nb[1], conv2_full->nb[2], 0);
+            ggml_tensor * c2_part1 = ggml_view_3d(ctx0, conv2_full,
+                    n_embd, 1 + n_seq_tokens, n_seqs,
+                    conv2_full->nb[1], conv2_full->nb[2],
+                    n_embd * ggml_element_size(conv2_full));
 
-            ggml_tensor * conv2_out;
-            if (n_seq > 1) {
-                ggml_tensor * c2_zero = ggml_scale(ctx0, ggml_view_2d(ctx0, c2_part0,
-                        n_embd, 1, c2_part0->nb[1], 0), 0.0f);
-                ggml_tensor * c2_prev = ggml_view_2d(ctx0, c2_part1,
-                        n_embd, n_seq - 1, c2_part1->nb[1], 0);
-                ggml_tensor * c2_shifted = ggml_concat(ctx0, c2_zero, c2_prev, 1);
-                conv2_out = ggml_add(ctx0, c2_part0, c2_shifted);
-            } else {
-                conv2_out = c2_part0;
-            }
+            ggml_tensor * c2_cur = ggml_cont(ctx0, ggml_view_3d(ctx0, c2_part0,
+                    n_embd, n_seq_tokens, n_seqs,
+                    c2_part0->nb[1], c2_part0->nb[2],
+                    1 * c2_part0->nb[1]));
+            ggml_tensor * c2_prev = ggml_cont(ctx0, ggml_view_3d(ctx0, c2_part1,
+                    n_embd, n_seq_tokens, n_seqs,
+                    c2_part1->nb[1], c2_part1->nb[2], 0));
+
+            ggml_tensor * conv2_out = ggml_add(ctx0, c2_cur, c2_prev);
             conv2_out = ggml_add(ctx0, conv2_out, model.layers[il].attn_lf_conv2_b);
+            conv2_out = ggml_reshape_2d(ctx0, conv2_out, n_embd, n_tokens);
             cb(conv2_out, "lf_conv2_out", il);
 
             // residual + RMSNorm
@@ -126,14 +181,9 @@ llm_build_yuan::llm_build_yuan(const llama_model & model, const llm_graph_params
             cb(Kcur, "Kcur", il);
             cb(Vcur, "Vcur", il);
 
-            cur = build_attn(inp_attn,
+            cur = build_attn(inp->get_attn(),
                     model.layers[il].wo, NULL,
                     Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
-        }
-
-        if (il == n_layer - 1 && inp_out_ids) {
-            cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
-            inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
         }
 
         ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
@@ -191,6 +241,10 @@ llm_build_yuan::llm_build_yuan(const llama_model & model, const llm_graph_params
         cb(cur, "ffn_moe_out", il);
 
         cur = ggml_add(ctx0, cur, ffn_inp);
+
+        if (il == n_layer - 1 && inp_out_ids) {
+            cur = ggml_get_rows(ctx0, cur, inp_out_ids);
+        }
 
         cur = build_cvec(cur, il);
         cb(cur, "l_out", il);

--- a/src/models/yuan.cpp
+++ b/src/models/yuan.cpp
@@ -1,0 +1,218 @@
+#include "models.h"
+
+llm_build_yuan::llm_build_yuan(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+    const int64_t n_embd_head = hparams.n_embd_head_v();
+
+    GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
+
+    ggml_tensor * cur;
+    ggml_tensor * inpL;
+
+    inpL = build_inp_embd(model.tok_embd);
+
+    // inp_pos - contains the positions
+    ggml_tensor * inp_pos = build_inp_pos();
+
+    auto * inp_attn = build_attn_inp_kv();
+
+    ggml_tensor * inp_out_ids = build_inp_out_ids();
+
+    for (int il = 0; il < n_layer; ++il) {
+        ggml_tensor * inpSA = inpL;
+
+        // norm
+        cur = build_norm(inpL,
+                model.layers[il].attn_norm, NULL,
+                LLM_NORM_RMS, il);
+        cb(cur, "attn_norm", il);
+
+        // V is projected from pre-LF hidden states (before localized filtering)
+        ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
+        cb(Vcur, "Vcur", il);
+
+        // localized filtering (causal conv2d with kernel_size=2)
+        // output[t] = W0 @ input[t] + W1 @ input[t-1] + bias  (input[-1] = 0)
+        //
+        // Weight stored as [in_ch, 2*out_ch]: W0||W1 concatenated in output dim.
+        // One matmul produces both parts, then we split and shift W1's part.
+        {
+            const int64_t lf_mid = n_embd / 2;
+            const int64_t n_seq = cur->ne[1];  // actual sequence length
+
+            // conv1: cur [n_embd, n_seq] @ weight [n_embd, 2*lf_mid] -> [2*lf_mid, n_seq]
+            ggml_tensor * conv1_full = ggml_mul_mat(ctx0, model.layers[il].attn_lf_conv1, cur);
+            cb(conv1_full, "lf_conv1_full", il);
+
+            // split: part0 = W0@cur [lf_mid, n_seq], part1 = W1@cur [lf_mid, n_seq]
+            ggml_tensor * c1_part0 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv1_full,
+                    lf_mid, n_seq, conv1_full->nb[1], 0));
+            ggml_tensor * c1_part1 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv1_full,
+                    lf_mid, n_seq, conv1_full->nb[1],
+                    lf_mid * ggml_element_size(conv1_full)));
+
+            ggml_tensor * conv1_out;
+            if (n_seq > 1) {
+                // causal shift: shifted[0] = 0, shifted[t] = part1[t-1]
+                ggml_tensor * c1_zero = ggml_scale(ctx0, ggml_view_2d(ctx0, c1_part0,
+                        lf_mid, 1, c1_part0->nb[1], 0), 0.0f);
+                ggml_tensor * c1_prev = ggml_view_2d(ctx0, c1_part1,
+                        lf_mid, n_seq - 1, c1_part1->nb[1], 0);
+                ggml_tensor * c1_shifted = ggml_concat(ctx0, c1_zero, c1_prev, 1);
+                conv1_out = ggml_add(ctx0, c1_part0, c1_shifted);
+            } else {
+                // single token: W1 contribution is zero (no previous token)
+                conv1_out = c1_part0;
+            }
+            conv1_out = ggml_add(ctx0, conv1_out, model.layers[il].attn_lf_conv1_b);
+            cb(conv1_out, "lf_conv1_out", il);
+
+            // conv2: conv1_out [lf_mid, n_seq] @ weight [lf_mid, 2*n_embd] -> [2*n_embd, n_seq]
+            ggml_tensor * conv2_full = ggml_mul_mat(ctx0, model.layers[il].attn_lf_conv2, conv1_out);
+            cb(conv2_full, "lf_conv2_full", il);
+
+            ggml_tensor * c2_part0 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv2_full,
+                    n_embd, n_seq, conv2_full->nb[1], 0));
+            ggml_tensor * c2_part1 = ggml_cont(ctx0, ggml_view_2d(ctx0, conv2_full,
+                    n_embd, n_seq, conv2_full->nb[1],
+                    n_embd * ggml_element_size(conv2_full)));
+
+            ggml_tensor * conv2_out;
+            if (n_seq > 1) {
+                ggml_tensor * c2_zero = ggml_scale(ctx0, ggml_view_2d(ctx0, c2_part0,
+                        n_embd, 1, c2_part0->nb[1], 0), 0.0f);
+                ggml_tensor * c2_prev = ggml_view_2d(ctx0, c2_part1,
+                        n_embd, n_seq - 1, c2_part1->nb[1], 0);
+                ggml_tensor * c2_shifted = ggml_concat(ctx0, c2_zero, c2_prev, 1);
+                conv2_out = ggml_add(ctx0, c2_part0, c2_shifted);
+            } else {
+                conv2_out = c2_part0;
+            }
+            conv2_out = ggml_add(ctx0, conv2_out, model.layers[il].attn_lf_conv2_b);
+            cb(conv2_out, "lf_conv2_out", il);
+
+            // residual + RMSNorm
+            cur = ggml_add(ctx0, conv2_out, cur);
+            cur = build_norm(cur,
+                    model.layers[il].attn_lf_norm, NULL,
+                    LLM_NORM_RMS, il);
+            cb(cur, "lf_output", il);
+        }
+
+        // self-attention (Q, K from post-LF cur; V from pre-LF, already computed above)
+        {
+            ggml_tensor * Qcur = build_lora_mm(model.layers[il].wq, cur);
+            cb(Qcur, "Qcur", il);
+
+            ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
+            cb(Kcur, "Kcur", il);
+
+            Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
+            Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+            Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
+
+            Qcur = ggml_rope_ext(
+                    ctx0, Qcur, inp_pos, nullptr,
+                    n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow
+                    );
+
+            Kcur = ggml_rope_ext(
+                    ctx0, Kcur, inp_pos, nullptr,
+                    n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow
+                    );
+
+            cb(Qcur, "Qcur", il);
+            cb(Kcur, "Kcur", il);
+            cb(Vcur, "Vcur", il);
+
+            cur = build_attn(inp_attn,
+                    model.layers[il].wo, NULL,
+                    Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
+        }
+
+        if (il == n_layer - 1 && inp_out_ids) {
+            cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
+            inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
+        }
+
+        ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+        cb(ffn_inp, "ffn_inp", il);
+
+        // MoE with attention-based routing
+        cur = build_norm(ffn_inp,
+                model.layers[il].ffn_norm, NULL,
+                LLM_NORM_RMS, il);
+        cb(cur, "ffn_norm", il);
+
+        // attention-based router
+        ggml_tensor * router_qkv = ggml_mul_mat(ctx0, model.layers[il].ffn_gate_inp_qkv, cur);
+        cb(router_qkv, "router_qkv", il);
+        router_qkv = ggml_cast(ctx0, router_qkv, GGML_TYPE_F32);
+
+        const int64_t n_cur = router_qkv->ne[1];
+
+        ggml_tensor * router_q = ggml_cont(ctx0, ggml_view_2d(ctx0, router_qkv,
+                n_expert, n_cur, router_qkv->nb[1], 0));
+        ggml_tensor * router_k = ggml_cont(ctx0, ggml_view_2d(ctx0, router_qkv,
+                n_expert, n_cur, router_qkv->nb[1],
+                n_expert * ggml_element_size(router_qkv)));
+        ggml_tensor * router_v = ggml_cont(ctx0, ggml_view_2d(ctx0, router_qkv,
+                n_expert, n_cur, router_qkv->nb[1],
+                2 * n_expert * ggml_element_size(router_qkv)));
+
+        // per-token outer product attention
+        router_q = ggml_reshape_3d(ctx0, router_q, 1, n_expert, n_cur);
+        router_k = ggml_reshape_3d(ctx0, router_k, 1, n_expert, n_cur);
+        router_v = ggml_reshape_3d(ctx0, router_v, n_expert, 1, n_cur);
+
+        // outer product: mul_mat(K, Q) -> [z, z, n_cur], softmax along ne[0]
+        ggml_tensor * router_attn = ggml_mul_mat(ctx0, router_k, router_q);
+        router_attn = ggml_soft_max(ctx0, router_attn);
+        cb(router_attn, "router_attn", il);
+
+        // attn @ V -> [z, 1, n_cur] -> [z, n_cur]
+        ggml_tensor * router_out = ggml_mul_mat(ctx0, router_attn, router_v);
+        router_out = ggml_reshape_2d(ctx0, router_out, n_expert, n_cur);
+        cb(router_out, "router_logits", il);
+
+        cur = build_moe_ffn(cur,
+                /*gate_inp*/ nullptr,
+                model.layers[il].ffn_up_exps,
+                model.layers[il].ffn_gate_exps,
+                model.layers[il].ffn_down_exps,
+                nullptr,
+                n_expert, n_expert_used,
+                LLM_FFN_SILU, hparams.expert_weights_norm,
+                hparams.expert_weights_scale,
+                LLAMA_EXPERT_GATING_FUNC_TYPE_SOFTMAX_WEIGHT,
+                il,
+                router_out);
+        cb(cur, "ffn_moe_out", il);
+
+        cur = ggml_add(ctx0, cur, ffn_inp);
+
+        cur = build_cvec(cur, il);
+        cb(cur, "l_out", il);
+
+        // input for next layer
+        inpL = cur;
+    }
+
+    cur = inpL;
+
+    cur = build_norm(cur,
+            model.output_norm, NULL,
+            LLM_NORM_RMS, -1);
+
+    cb(cur, "result_norm", -1);
+    res->t_embd = cur;
+
+    // lm_head
+    cur = build_lora_mm(model.output, cur);
+
+    cb(cur, "result_output", -1);
+    res->t_logits = cur;
+
+    ggml_build_forward_expand(gf, cur);
+}

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(mtmd
             models/siglip.cpp
             models/whisper-enc.cpp
             models/mobilenetv5.cpp
+            models/yuanvl.cpp
             models/youtuvl.cpp
             )
 

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -239,6 +239,7 @@ enum projector_type {
     PROJECTOR_TYPE_YOUTUVL,
     PROJECTOR_TYPE_KIMIK25,
     PROJECTOR_TYPE_NEMOTRON_V2_VL,
+    PROJECTOR_TYPE_YUANVL,
     PROJECTOR_TYPE_UNKNOWN,
 };
 
@@ -276,6 +277,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_YOUTUVL,   "youtuvl"},
     { PROJECTOR_TYPE_KIMIK25,   "kimik25"},
     { PROJECTOR_TYPE_NEMOTRON_V2_VL, "nemotron_v2_vl"},
+    { PROJECTOR_TYPE_YUANVL,    "yuanvl"},
 };
 
 static projector_type clip_projector_type_from_string(const std::string & str) {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -822,6 +822,10 @@ static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32
             {
                 builder = std::make_unique<clip_graph_internvl>(ctx, img);
             } break;
+        case PROJECTOR_TYPE_YUANVL:
+            {
+                builder = std::make_unique<clip_graph_yuanvl>(ctx, img);
+            } break;
         case PROJECTOR_TYPE_NEMOTRON_V2_VL:
             {
                 builder = std::make_unique<clip_graph_nemotron_v2_vl>(ctx, img);
@@ -1131,6 +1135,7 @@ struct clip_model_loader {
                     } break;
                 case PROJECTOR_TYPE_INTERNVL:
                 case PROJECTOR_TYPE_NEMOTRON_V2_VL:
+                case PROJECTOR_TYPE_YUANVL:
                     {
                         get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
                     } break;
@@ -1803,6 +1808,15 @@ struct clip_model_loader {
                     model.mm_1_b = get_tensor(string_format(TN_MVLM_PROJ_MLP, 1, "bias"));
                     model.mm_3_w = get_tensor(string_format(TN_MVLM_PROJ_MLP, 3, "weight"));
                     model.mm_3_b = get_tensor(string_format(TN_MVLM_PROJ_MLP, 3, "bias"));
+                } break;
+            case PROJECTOR_TYPE_YUANVL:
+                {
+                    // SwiGLU MLP projector (no bias)
+                    model.mm_ffn_up_w   = get_tensor(string_format(TN_MM_UP,   "weight"));
+                    model.mm_ffn_gate_w = get_tensor(string_format(TN_MM_GATE, "weight"));
+                    model.mm_ffn_down_w = get_tensor(string_format(TN_MM_DOWN, "weight"));
+                    // RMSNorm after projector
+                    model.mm_post_norm_w = get_tensor(string_format(TN_MM_POST_NORM, "weight"));
                 } break;
             case PROJECTOR_TYPE_NEMOTRON_V2_VL:
                 {
@@ -3140,6 +3154,7 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
         case PROJECTOR_TYPE_GEMMA3:
         case PROJECTOR_TYPE_INTERNVL: // TODO @ngxson : support dynamic resolution
         case PROJECTOR_TYPE_NEMOTRON_V2_VL:
+        case PROJECTOR_TYPE_YUANVL:
             {
                 clip_image_u8 resized_image;
                 int sz = params.image_size;
@@ -3454,6 +3469,7 @@ int clip_n_output_tokens(const struct clip_ctx * ctx, struct clip_image_f32 * im
         case PROJECTOR_TYPE_IDEFICS3:
         case PROJECTOR_TYPE_INTERNVL:
         case PROJECTOR_TYPE_NEMOTRON_V2_VL:
+        case PROJECTOR_TYPE_YUANVL:
         case PROJECTOR_TYPE_LLAMA4:
             {
                 // both X and Y are downscaled by the scale factor
@@ -3894,6 +3910,7 @@ bool clip_image_batch_encode(clip_ctx * ctx, const int n_threads, const clip_ima
         case PROJECTOR_TYPE_IDEFICS3:
         case PROJECTOR_TYPE_INTERNVL:
         case PROJECTOR_TYPE_NEMOTRON_V2_VL:
+        case PROJECTOR_TYPE_YUANVL:
         case PROJECTOR_TYPE_QWEN2A:
         case PROJECTOR_TYPE_GLMA:
         case PROJECTOR_TYPE_ULTRAVOX:
@@ -4077,6 +4094,7 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
         case PROJECTOR_TYPE_LFM2A:
             return ctx->model.position_embeddings->ne[0];
         case PROJECTOR_TYPE_GLM4V:
+        case PROJECTOR_TYPE_YUANVL:
             return ctx->model.mm_ffn_down_w->ne[1];
         default:
             GGML_ABORT("Unknown projector type");

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1135,9 +1135,13 @@ struct clip_model_loader {
                     } break;
                 case PROJECTOR_TYPE_INTERNVL:
                 case PROJECTOR_TYPE_NEMOTRON_V2_VL:
+                    {
+                        get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
+                    } break;
                 case PROJECTOR_TYPE_YUANVL:
                     {
                         get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
+                        get_u32(KEY_IMAGE_MAX_PIXELS, hparams.image_max_pixels, false);
                     } break;
                 case PROJECTOR_TYPE_IDEFICS3:
                     {
@@ -3154,15 +3158,99 @@ bool clip_image_preprocess(struct clip_ctx * ctx, const clip_image_u8 * img, str
         case PROJECTOR_TYPE_GEMMA3:
         case PROJECTOR_TYPE_INTERNVL: // TODO @ngxson : support dynamic resolution
         case PROJECTOR_TYPE_NEMOTRON_V2_VL:
-        case PROJECTOR_TYPE_YUANVL:
             {
                 clip_image_u8 resized_image;
                 int sz = params.image_size;
                 img_tool::resize(*img, resized_image, {sz, sz}, img_tool::RESIZE_ALGO_BILINEAR);
                 clip_image_f32_ptr img_f32(clip_image_f32_init());
-                //clip_image_save_to_bmp(resized_image, "resized.bmp");
                 normalize_image_u8_to_f32(resized_image, *img_f32, params.image_mean, params.image_std);
                 res_imgs->entries.push_back(std::move(img_f32));
+            } break;
+
+        case PROJECTOR_TYPE_YUANVL:
+            {
+                const int sz = params.image_size; // 448
+                const int max_num = params.image_max_pixels > 0
+                    ? params.image_max_pixels / (sz * sz)
+                    : 1; // fallback to single tile if not configured
+
+                if (max_num <= 1 || (original_size.width <= sz && original_size.height <= sz)) {
+                    // single tile: just resize to image_size x image_size
+                    clip_image_u8 resized_image;
+                    img_tool::resize(*img, resized_image, {sz, sz}, img_tool::RESIZE_ALGO_BICUBIC);
+                    clip_image_f32_ptr img_f32(clip_image_f32_init());
+                    normalize_image_u8_to_f32(resized_image, *img_f32, params.image_mean, params.image_std);
+                    res_imgs->entries.push_back(std::move(img_f32));
+                } else {
+                    // InternVL-style dynamic resolution
+                    // Step 1: find best aspect ratio grid
+                    const float aspect_ratio = (float)original_size.width / original_size.height;
+                    int best_grid_w = 1, best_grid_h = 1;
+                    float best_ratio_diff = 1e9f;
+                    for (int n = 1; n <= max_num; n++) {
+                        for (int gw = 1; gw <= n; gw++) {
+                            for (int gh = 1; gh <= n; gh++) {
+                                if (gw * gh > max_num || gw * gh < 1) continue;
+                                float target_ar = (float)gw / gh;
+                                float ratio_diff = std::abs(aspect_ratio - target_ar);
+                                float size_diff = std::abs(
+                                    ((float)(gw * sz + gh * sz) - (original_size.width + original_size.height))
+                                    / (original_size.width + original_size.height));
+                                if (size_diff > 1.0f) continue; // threshold=1
+                                if (ratio_diff < best_ratio_diff) {
+                                    best_ratio_diff = ratio_diff;
+                                    best_grid_w = gw;
+                                    best_grid_h = gh;
+                                } else if (ratio_diff == best_ratio_diff) {
+                                    if (original_size.width * original_size.height > 0.5f * sz * sz * gw * gh) {
+                                        best_grid_w = gw;
+                                        best_grid_h = gh;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    const int target_width  = sz * best_grid_w;
+                    const int target_height = sz * best_grid_h;
+                    const int n_tiles = best_grid_w * best_grid_h;
+
+                    LOG_INF("%s: dynamic resolution: %dx%d -> %dx%d grid (%d tiles)\n",
+                            __func__, original_size.width, original_size.height,
+                            best_grid_w, best_grid_h, n_tiles);
+
+                    // Step 2: resize to grid dimensions
+                    clip_image_u8 resized;
+                    img_tool::resize(*img, resized, {target_width, target_height}, img_tool::RESIZE_ALGO_BICUBIC);
+
+                    // Step 3: split into tiles
+                    for (int i = 0; i < n_tiles; i++) {
+                        int tile_x = (i % best_grid_w) * sz;
+                        int tile_y = (i / best_grid_w) * sz;
+
+                        clip_image_u8 tile;
+                        tile.nx = sz;
+                        tile.ny = sz;
+                        tile.buf.resize(sz * sz * 3);
+                        for (int y = 0; y < sz; y++) {
+                            memcpy(tile.buf.data() + y * sz * 3,
+                                   resized.buf.data() + (tile_y + y) * target_width * 3 + tile_x * 3,
+                                   sz * 3);
+                        }
+                        clip_image_f32_ptr img_f32(clip_image_f32_init());
+                        normalize_image_u8_to_f32(tile, *img_f32, params.image_mean, params.image_std);
+                        res_imgs->entries.push_back(std::move(img_f32));
+                    }
+
+                    // Step 4: add thumbnail (whole image resized to image_size x image_size)
+                    if (n_tiles > 1) {
+                        clip_image_u8 thumbnail;
+                        img_tool::resize(*img, thumbnail, {sz, sz}, img_tool::RESIZE_ALGO_BICUBIC);
+                        clip_image_f32_ptr img_f32(clip_image_f32_init());
+                        normalize_image_u8_to_f32(thumbnail, *img_f32, params.image_mean, params.image_std);
+                        res_imgs->entries.push_back(std::move(img_f32));
+                    }
+                }
             } break;
 
         case PROJECTOR_TYPE_GEMMA3NV:

--- a/tools/mtmd/models/models.h
+++ b/tools/mtmd/models/models.h
@@ -42,6 +42,11 @@ struct clip_graph_internvl : clip_graph {
     ggml_cgraph * build() override;
 };
 
+struct clip_graph_yuanvl : clip_graph {
+    clip_graph_yuanvl(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
+    ggml_cgraph * build() override;
+};
+
 struct clip_graph_nemotron_v2_vl : clip_graph {
     clip_graph_nemotron_v2_vl(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
     ggml_cgraph * build() override;

--- a/tools/mtmd/models/yuanvl.cpp
+++ b/tools/mtmd/models/yuanvl.cpp
@@ -1,0 +1,96 @@
+#include "models.h"
+
+ggml_cgraph * clip_graph_yuanvl::build() {
+    GGML_ASSERT(model.class_embedding != nullptr);
+    GGML_ASSERT(model.position_embeddings != nullptr);
+
+    const int n_pos = n_patches + 1;
+    ggml_tensor * inp = build_inp();
+
+    // add CLS token
+    inp = ggml_concat(ctx0, inp, model.class_embedding, 1);
+
+    // InternViT 300M uses layer norm
+    norm_type norm_t = NORM_TYPE_NORMAL;
+
+    ggml_tensor * cur = build_vit(
+                            inp, n_pos,
+                            norm_t,
+                            hparams.ffn_op,
+                            model.position_embeddings,
+                            nullptr);
+
+    // remove CLS token
+    cur = ggml_view_2d(ctx0, cur,
+        n_embd, n_patches,
+        ggml_row_size(cur->type, n_embd), 0);
+
+    // PixelUnshuffle (torch.nn.PixelUnshuffle with downscale_factor=2)
+    //
+    // Yuan uses PixelUnshuffle which differs from InternVL's pixel_shuffle
+    // in channel ordering. Both merge the same 2x2 spatial blocks, but:
+    //   InternVL groups:  [all_C_block0, all_C_block1, all_C_block2, all_C_block3]
+    //   PixelUnshuffle:   [b0_c0, b1_c0, b2_c0, b3_c0, b0_c1, b1_c1, ...]
+    //
+    // We first do InternVL-style merging, then fix the channel ordering with
+    // a reshape+permute: (r*r, C, tokens) -> permute(1,0,2) -> (C, r*r, tokens)
+    {
+        const int scale_factor = model.hparams.n_merge;
+        const int bsz    = 1;
+        const int height = n_patches_y;
+        const int width  = n_patches_x;
+        GGML_ASSERT(scale_factor > 0);
+
+        // InternVL-style spatial merging
+        cur = ggml_reshape_4d(ctx0, cur, n_embd * scale_factor, height / scale_factor, width, bsz);
+        cur = ggml_permute(ctx0, cur, 0, 2, 1, 3);
+        cur = ggml_cont_4d(ctx0, cur,
+            n_embd * scale_factor * scale_factor,
+            height / scale_factor,
+            width / scale_factor,
+            bsz);
+        cur = ggml_permute(ctx0, cur, 0, 2, 1, 3);
+        // flatten to 2D: (n_embd * r * r, n_output_patches)
+        cur = ggml_cont_2d(ctx0, cur,
+            n_embd * scale_factor * scale_factor,
+            cur->ne[1] * cur->ne[2]);
+
+        // Fix channel ordering: InternVL -> PixelUnshuffle
+        // reshape (r*r * C, tokens) -> (r*r, C, tokens)
+        const int n_out_patches = cur->ne[1];
+        const int r2 = scale_factor * scale_factor;
+        cur = ggml_reshape_3d(ctx0, cur, n_embd, r2, n_out_patches);
+        // permute to (C, r*r, tokens) -- ggml dim order, so permute(1, 0, 2)
+        cur = ggml_permute(ctx0, cur, 1, 0, 2, 3);
+        cur = ggml_cont_2d(ctx0, cur, n_embd * r2, n_out_patches);
+    }
+
+    // projector: SwiGLU MLP + RMSNorm
+    // ref: Yuan3.0-Flash modeling_yuanvl_chat.py YuanImageMLP
+    //   x1 = up_proj(x)       # 4096 -> 8192
+    //   x2 = gate_proj(x)     # 4096 -> 8192
+    //   x3 = silu(x1) * x2    # SwiGLU
+    //   x  = down_proj(x3)    # 8192 -> 2048
+    //   x  = rms_norm(x)
+    //
+    // Note: Yuan applies silu to up_proj (not gate_proj like standard LLaMA).
+    // In build_ffn, silu is applied to the 'gate' parameter, so we swap:
+    //   gate param = up_proj weight (gets silu)
+    //   up param   = gate_proj weight (multiplied)
+    {
+        cur = build_ffn(cur,
+            model.mm_ffn_gate_w, nullptr,  // 'up' param = gate_proj (no silu)
+            model.mm_ffn_up_w, nullptr,    // 'gate' param = up_proj (gets silu)
+            model.mm_ffn_down_w, nullptr,
+            FFN_SILU,
+            -1);
+
+        // RMSNorm (imagemlp_layernorm)
+        cur = build_norm(cur, model.mm_post_norm_w, nullptr, NORM_TYPE_RMS, 1e-6, -1);
+    }
+
+    // build the graph
+    ggml_build_forward_expand(gf, cur);
+
+    return gf;
+}

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -861,7 +861,8 @@ int32_t mtmd_encode(mtmd_context * ctx, const mtmd_image_tokens * image_tokens) 
 
     if (clip_is_llava(ctx_clip)
         || clip_is_minicpmv(ctx_clip)
-        || clip_is_glm(ctx_clip)) {
+        || clip_is_glm(ctx_clip)
+        || image_tokens->batch_f32.entries.size() > 1) {
         // TODO @ngxson : llava does not support batched encoding ; this should be fixed inside clip_image_batch_encode()
         const auto & entries = image_tokens->batch_f32.entries;
         for (size_t i = 0; i < entries.size(); i++) {

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -305,6 +305,11 @@ struct mtmd_context {
             img_beg = "<img>";
             img_end = "</img>";
 
+        } else if (proj == PROJECTOR_TYPE_YUANVL) {
+            // <IMAGE> ... (image embeddings) ... </IMAGE>
+            img_beg = "<IMAGE>";
+            img_end = "</IMAGE>";
+
         } else if (proj == PROJECTOR_TYPE_LIGHTONOCR) {
             // <|im_start|> ... (image embeddings) ... <|im_end|>
             img_beg = "<|im_start|>";


### PR DESCRIPTION
## Summary

- Add full Yuan3.0-Flash (YuanForCausalLM) support: GGUF converter, architecture definition, and inference graph
- Yuan3.0 features: Localized Filtering (double causal Conv2d) before Q/K projection, attention-based MoE routing, partial RoPE (rotary_percent=0.5), fused Q+K weight interleaving
- Converter handles: per-head Q/K deinterleaving, Conv2d kernel weight reordering for GGML, SentencePiece tokenizer with additional_special_tokens patching, VL model nested config
- Conv state caching via hybrid memory (KV cache + recurrent state) for exact causal continuity during token-by-token generation — reuses existing Mamba/Falcon-H1 recurrent state infrastructure

Resolves #19342

## Key implementation details

- **Localized Filtering**: Caches 2 pre-LF hidden states per layer (~384KB total) to compute exact conv1+conv2 outputs at sequence boundaries
- **V projection order**: V is projected from pre-LF hidden states (before filtering), while Q/K come from post-LF
- **MoE router**: Custom attention-based routing (Q/K/V outer product → softmax → weighted sum) with `inp_out_ids` filtering placed after the MoE block to avoid zero-token crashes
- **Weight conversion**: HF fused Q+K layout `[Q_h0, K_h0, Q_h1, K_h1, ...]` is deinterleaved per-head; Conv2d kernel positions swapped for PyTorch cross-correlation semantics

## Test plan

- [x] Q4_K_M quantized model loads and generates coherent text
- [x] F16 model loads and generates coherent text  
- [x] Works with both `llama-cli` and `llama-completion`
- [x] Conv state caching produces exact results (no approximation)
- [x] Special tokens (1047 additional_special_tokens) correctly mapped
- [ ] Perplexity comparison with HuggingFace reference
- [ ] Multi-sequence / parallel generation testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)