### PR TITLE
server : fix wait in test_cancel_requests() test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -85,6 +85,7 @@
 /tools/quantize/                        @ggerganov
 /tools/rpc/                             @ggml-org/ggml-rpc
 /tools/server/*                         @ggml-org/llama-server # no subdir
+/tools/server/tests/                    @ggml-org/llama-server
 /tools/server/webui/                    @ggml-org/llama-webui
 /tools/tokenize/                        @ggerganov
 /tools/tts/                             @ggerganov

--- a/tools/server/tests/unit/test_completion.py
+++ b/tools/server/tests/unit/test_completion.py
@@ -563,7 +563,7 @@ def test_cancel_request():
     except requests.exceptions.ReadTimeout:
         pass # expected
     # make sure the slot is free
-    time.sleep(1) # wait for HTTP_POLLING_SECONDS
+    time.sleep(2)
     res = server.make_request("GET", "/slots")
     assert res.body[0]["is_processing"] == False
 


### PR DESCRIPTION
The wait condition in `test_cancel_request()` is a bit flaky, causing failures with the Metal server runs from time to time:

https://github.com/ggml-org/llama.cpp/actions/runs/23113808739/job/67135730576#step:4:22888

Give the slot a bit more time to finish for sure.