### PR TITLE
tests: Support proxy environment in test-arg-parser

### DIFF
--- a/common/http.h
+++ b/common/http.h
@@ -2,6 +2,8 @@
 
 #include <cpp-httplib/httplib.h>
 
+#include <cstdlib>
+
 struct common_http_url {
     std::string scheme;
     std::string user;
@@ -10,6 +12,91 @@ struct common_http_url {
     int port;
     std::string path;
 };
+
+static common_http_url common_http_parse_url(const std::string & url);
+
+static std::string common_http_get_env(const char * key_upper, const char * key_lower) {
+    const char * val = std::getenv(key_upper);
+    if (val && val[0] != '\0') {
+        return val;
+    }
+
+    val = std::getenv(key_lower);
+    if (val && val[0] != '\0') {
+        return val;
+    }
+
+    return {};
+}
+
+static bool common_http_parse_host_port(const std::string & input, std::string & host, int & port) {
+    if (input.empty()) {
+        return false;
+    }
+
+    std::string host_port = input;
+    size_t      host_begin = 0;
+
+    if (host_port[0] == '[') {
+        size_t host_end = host_port.find(']');
+        if (host_end == std::string::npos || host_end + 1 >= host_port.size() || host_port[host_end + 1] != ':') {
+            return false;
+        }
+        host = host_port.substr(1, host_end - 1);
+        host_begin = host_end + 2;
+    } else {
+        size_t colon_pos = host_port.rfind(':');
+        if (colon_pos == std::string::npos || colon_pos == 0 || colon_pos + 1 >= host_port.size()) {
+            return false;
+        }
+        host = host_port.substr(0, colon_pos);
+        host_begin = colon_pos + 1;
+    }
+
+    const std::string port_str = host_port.substr(host_begin);
+    try {
+        size_t consumed = 0;
+        int parsed_port = std::stoi(port_str, &consumed);
+        if (consumed != port_str.size() || parsed_port <= 0 || parsed_port > 65535) {
+            return false;
+        }
+        port = parsed_port;
+    } catch (...) {
+        return false;
+    }
+
+    return !host.empty();
+}
+
+static bool common_http_parse_proxy_env(const std::string & proxy_env,
+                                        std::string & proxy_host,
+                                        int & proxy_port,
+                                        std::string & proxy_user,
+                                        std::string & proxy_password) {
+    if (proxy_env.empty()) {
+        return false;
+    }
+
+    std::string proxy_url = proxy_env;
+    if (proxy_url.find("://") == std::string::npos) {
+        proxy_url = "http://" + proxy_url;
+    }
+
+    common_http_url proxy_parts;
+    try {
+        proxy_parts = common_http_parse_url(proxy_url);
+    } catch (...) {
+        return false;
+    }
+
+    if (!common_http_parse_host_port(proxy_parts.host, proxy_host, proxy_port)) {
+        return false;
+    }
+
+    proxy_user = proxy_parts.user;
+    proxy_password = proxy_parts.password;
+    return true;
+}
 
 static common_http_url common_http_parse_url(const std::string & url) {
     common_http_url parts;
@@ -84,6 +171,27 @@ static std::pair<httplib::Client, common_http_url> common_http_client(const std:
 #endif
 
     httplib::Client cli(parts.scheme + "://" + parts.host + ":" + std::to_string(parts.port));
+
+    std::string proxy_env;
+    if (parts.scheme == "https") {
+        proxy_env = common_http_get_env("HTTPS_PROXY", "https_proxy");
+        if (proxy_env.empty()) {
+            proxy_env = common_http_get_env("HTTP_PROXY", "http_proxy");
+        }
+    } else {
+        proxy_env = common_http_get_env("HTTP_PROXY", "http_proxy");
+    }
+
+    std::string proxy_host;
+    int         proxy_port = -1;
+    std::string proxy_user;
+    std::string proxy_password;
+    if (common_http_parse_proxy_env(proxy_env, proxy_host, proxy_port, proxy_user, proxy_password)) {
+        cli.set_proxy(proxy_host, proxy_port);
+        if (!proxy_user.empty()) {
+            cli.set_proxy_basic_auth(proxy_user, proxy_password);
+        }
+    }
 
     if (!parts.user.empty()) {
         cli.set_basic_auth(parts.user, parts.password);

--- a/common/http.h
+++ b/common/http.h
@@ -2,8 +2,6 @@
 
 #include <cpp-httplib/httplib.h>
 
-#include <cstdlib>
-
 struct common_http_url {
     std::string scheme;
     std::string user;
@@ -13,15 +11,13 @@ struct common_http_url {
     std::string path;
 };
 
-static common_http_url common_http_parse_url(const std::string & url);
-
-static std::string common_http_get_env(const char * key_upper, const char * key_lower) {
-    const char * val = std::getenv(key_upper);
+static std::string common_http_get_env(const std::string & key_upper, const std::string & key_lower) {
+    const char * val = std::getenv(key_upper.c_str());
     if (val && val[0] != '\0') {
         return val;
     }
 
-    val = std::getenv(key_lower);
+    val = std::getenv(key_lower.c_str());
     if (val && val[0] != '\0') {
         return val;
     }
@@ -29,7 +25,7 @@ static std::string common_http_get_env(const char * key_upper, const char * key_
     return {};
 }
 
-static std::string common_http_parse_scheme(const std::string& url, size_t & scheme_end) {
+static std::string common_http_parse_scheme(const std::string & url, size_t & scheme_end) {
     scheme_end = url.find("://");
 
     if (scheme_end == std::string::npos) {

--- a/common/http.h
+++ b/common/http.h
@@ -29,83 +29,23 @@ static std::string common_http_get_env(const char * key_upper, const char * key_
     return {};
 }
 
-static bool common_http_parse_host_port(const std::string & input, std::string & host, int & port) {
-    if (input.empty()) {
-        return false;
+static std::string common_http_parse_scheme(const std::string& url, size_t & scheme_end) {
+    scheme_end = url.find("://");
+
+    if (scheme_end == std::string::npos) {
+        return {};
     }
-
-    std::string host_port = input;
-    size_t      host_begin = 0;
-
-    if (host_port[0] == '[') {
-        size_t host_end = host_port.find(']');
-        if (host_end == std::string::npos || host_end + 1 >= host_port.size() || host_port[host_end + 1] != ':') {
-            return false;
-        }
-        host = host_port.substr(1, host_end - 1);
-        host_begin = host_end + 2;
-    } else {
-        size_t colon_pos = host_port.rfind(':');
-        if (colon_pos == std::string::npos || colon_pos == 0 || colon_pos + 1 >= host_port.size()) {
-            return false;
-        }
-        host = host_port.substr(0, colon_pos);
-        host_begin = colon_pos + 1;
-    }
-
-    const std::string port_str = host_port.substr(host_begin);
-    try {
-        size_t consumed = 0;
-        int parsed_port = std::stoi(port_str, &consumed);
-        if (consumed != port_str.size() || parsed_port <= 0 || parsed_port > 65535) {
-            return false;
-        }
-        port = parsed_port;
-    } catch (...) {
-        return false;
-    }
-
-    return !host.empty();
-}
-
-static bool common_http_parse_proxy_env(const std::string & proxy_env,
-                                        std::string & proxy_host,
-                                        int & proxy_port,
-                                        std::string & proxy_user,
-                                        std::string & proxy_password) {
-    if (proxy_env.empty()) {
-        return false;
-    }
-
-    std::string proxy_url = proxy_env;
-    if (proxy_url.find("://") == std::string::npos) {
-        proxy_url = "http://" + proxy_url;
-    }
-
-    common_http_url proxy_parts;
-    try {
-        proxy_parts = common_http_parse_url(proxy_url);
-    } catch (...) {
-        return false;
-    }
-
-    if (!common_http_parse_host_port(proxy_parts.host, proxy_host, proxy_port)) {
-        return false;
-    }
-
-    proxy_user = proxy_parts.user;
-    proxy_password = proxy_parts.password;
-    return true;
+    return url.substr(0, scheme_end);
 }
 
 static common_http_url common_http_parse_url(const std::string & url) {
     common_http_url parts;
-    auto scheme_end = url.find("://");
-
-    if (scheme_end == std::string::npos) {
+    size_t scheme_end = 0;
+    auto scheme = common_http_parse_scheme(url, scheme_end);
+    if (scheme.empty()) {
         throw std::runtime_error("invalid URL: no scheme");
     }
-    parts.scheme = url.substr(0, scheme_end);
+    parts.scheme = scheme;
 
     if (parts.scheme != "http" && parts.scheme != "https") {
         throw std::runtime_error("unsupported URL scheme: " + parts.scheme);
@@ -182,14 +122,18 @@ static std::pair<httplib::Client, common_http_url> common_http_client(const std:
         proxy_env = common_http_get_env("HTTP_PROXY", "http_proxy");
     }
 
-    std::string proxy_host;
-    int         proxy_port = -1;
-    std::string proxy_user;
-    std::string proxy_password;
-    if (common_http_parse_proxy_env(proxy_env, proxy_host, proxy_port, proxy_user, proxy_password)) {
-        cli.set_proxy(proxy_host, proxy_port);
-        if (!proxy_user.empty()) {
-            cli.set_proxy_basic_auth(proxy_user, proxy_password);
+    if (!proxy_env.empty()) {
+        size_t proxy_scheme_end = 0;
+        auto scheme = common_http_parse_scheme(proxy_env, proxy_scheme_end);
+        auto proxy_env_revised = proxy_env;
+        if (scheme.empty()) {
+            // No scheme was provided so we assume http://
+            proxy_env_revised = "http://" + proxy_env;
+        }
+        common_http_url proxy_parts = common_http_parse_url(proxy_env_revised);
+        cli.set_proxy(proxy_parts.host, proxy_parts.port);
+        if (!proxy_parts.user.empty()) {
+            cli.set_proxy_basic_auth(proxy_parts.user, proxy_parts.password);
         }
     }
 


### PR DESCRIPTION
We are observing following exception when testing `test-arg-parser`'s [test good URL test case](https://github.com/ggml-org/llama.cpp/blob/d3936498a3d8f41cdb35d9e7d04a19e704b4fc89/tests/test-arg-parser.cpp#L182) under proxy environment causing the test to fail (Windows). This seems like an issue in `common_http_client` where it does not care for proxied environments.

<img width="1873" height="986" alt="image" src="https://github.com/user-attachments/assets/ae7c0154-c8c2-49ba-b3b2-e89d55b78efd" />

This PR adds support for such use cases.

<details>
<summary>Full log of `test-arg-parser` execution on 9e2e2198b (Vulkan backend)</summary>

```
λ ctest -C Debug --output-on-failure -R test-arg-parser
Test project C:/Users/ae/Documents/mnakasak/repo/llama.cpp_mine/build-ci-debug
    Start 25: test-arg-parser
1/1 Test #25: test-arg-parser ..................***Failed  136.45 sec
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Intel(R) Arc(TM) B580 Graphics (Intel Corporation) | uma: 0 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: KHR_coopmat
register_backend: registered backend Vulkan (1 devices)
register_device: registered device Vulkan0 (Intel(R) Arc(TM) B580 Graphics)
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (13th Gen Intel(R) Core(TM) i9-13900K)
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
error while handling argument "-m": expected value for argument

usage:
-m,    --model FNAME                    model path to load
                                        (env: LLAMA_ARG_MODEL)


to show complete usage, run with -h
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
error while handling argument "-ngl": invalid stoi argument

usage:
-ngl,  --gpu-layers, --n-gpu-layers N   max. number of layers to store in VRAM, either an exact number,
                                        'auto', or 'all' (default: auto)
                                        (env: LLAMA_ARG_N_GPU_LAYERS)


to show complete usage, run with -h
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
error while handling argument "-sm": invalid value

usage:
-sm,   --split-mode {none,layer,row}    how to split the model across multiple GPUs, one of:
                                        - none: use one GPU only
                                        - layer (default): split layers and KV across GPUs
                                        - row: split rows across GPUs
                                        (env: LLAMA_ARG_SPLIT_MODE)


to show complete usage, run with -h
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
error: invalid argument: --draft
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
error: --model is required

load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-vulkan.dll
load_backend: failed to find ggml_backend_init in C:\Users\ae\Documents\mnakasak\repo\llama.cpp_mine\build-ci-debug\bin\Debug\ggml-cpu.dll


0% tests passed, 1 tests failed out of 1

Label Time Summary:
main    = 136.45 sec*proc (1 test)

Total Test time (real) = 136.47 sec

The following tests FAILED:
         25 - test-arg-parser (Failed)                          main
Errors while running CTest
```
</details>