### PR TITLE
devops: add an intel mkl container

### DIFF
--- a/.devops/intel.blas.Dockerfile
+++ b/.devops/intel.blas.Dockerfile
@@ -1,0 +1,96 @@
+ARG ONEAPI_VERSION=2025.2.2-0-devel-ubuntu24.04
+
+## Build Image
+
+FROM intel/deep-learning-essentials:$ONEAPI_VERSION AS build
+
+RUN apt-get update && \
+    apt-get install -y git libssl-dev
+
+WORKDIR /app
+
+COPY . .
+
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ] || [ -z "$TARGETARCH" ]; then \
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icpx -DCMAKE_C_COMPILER=icx -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=Intel10_64lp -DGGML_BLAS_USE_MKL=ON -DLLAMA_BUILD_TESTS=OFF; \
+    else \
+        echo "Unsupported architecture"; \
+        exit 1; \
+    fi && \
+    cmake --build build -j $(nproc)
+
+
+RUN mkdir -p /app/lib && \
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
+
+RUN mkdir -p /app/full \
+    && cp build/bin/* /app/full \
+    && cp *.py /app/full \
+    && cp -r gguf-py /app/full \
+    && cp -r requirements /app/full \
+    && cp requirements.txt /app/full \
+    && cp .devops/tools.sh /app/full/tools.sh
+
+FROM intel/deep-learning-essentials:$ONEAPI_VERSION AS base
+
+RUN apt-get update \
+    && apt-get install -y libgomp1 curl\
+    && apt autoremove -y \
+    && apt clean -y \
+    && rm -rf /tmp/* /var/tmp/* \
+    && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
+    && find /var/cache -type f -delete
+
+### Full
+FROM base AS full
+
+COPY --from=build /app/lib/ /app
+COPY --from=build /app/full /app
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        python3 \
+        python3-pip \
+        python3-venv && \
+    python3 -m venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    pip install --upgrade pip setuptools wheel && \
+    pip install -r requirements.txt && \
+    apt autoremove -y && \
+    apt clean -y && \
+    rm -rf /tmp/* /var/tmp/* && \
+    find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete && \
+    find /var/cache -type f -delete
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+ENTRYPOINT ["/app/tools.sh"]
+
+### Light, CLI only
+FROM base AS light
+
+COPY --from=build /app/lib/ /app
+COPY --from=build /app/full/llama-cli /app/full/llama-completion /app
+
+WORKDIR /app
+
+ENTRYPOINT [ "/app/llama-cli" ]
+
+### Server, Server only
+FROM base AS server
+
+ENV LLAMA_ARG_HOST=0.0.0.0
+
+COPY --from=build /app/lib/ /app
+COPY --from=build /app/full/llama-server /app
+
+WORKDIR /app
+
+HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+
+ENTRYPOINT [ "/app/llama-server" ]
+


### PR DESCRIPTION
- Adding a intel.MKL container for .devops.

**Verification locally**

```
podman build -f .devops/intel.blas.Dockerfile -t quay.io/kevin-oss/llama-intel --target full .
```

```
podman run -v /home/kehannon/.cache/llama.cpp/:/models:Z -it quay.io/kevin-oss/llama-intel --bench -m /models/ggml-org_Qwen3-0.6B-GGUF_Qwen3-0.6B-Q4_0.gguf -fa 1
| model                          |       size |     params | backend    | threads | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | -: | --------------: | -------------------: |
| qwen3 0.6B Q4_0                | 403.42 MiB |   751.63 M | BLAS       |       8 |  1 |           pp512 |        971.03 ± 4.68 |
| qwen3 0.6B Q4_0                | 403.42 MiB |   751.63 M | BLAS       |       8 |  1 |           tg128 |        111.84 ± 1.25 |
```

