### PR TITLE
kleidiai : fix MUL_MAT support for batched (3D) inputs

### DIFF
--- a/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
+++ b/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
@@ -1447,9 +1447,8 @@ class extra_buffer_type : ggml::cpu::extra_buffer_type {
         const int slot_total = kleidiai_collect_kernel_chain(op, kernel_chain);
         if ((op->op == GGML_OP_MUL_MAT || op->op == GGML_OP_GET_ROWS) &&
             (op->src[0]->type == GGML_TYPE_Q4_0 || op->src[0]->type == GGML_TYPE_Q8_0) &&
-            op->src[0]->buffer &&
             (ggml_n_dims(op->src[0]) == 2) &&
-            op->src[0]->buffer->buft == ggml_backend_cpu_kleidiai_buffer_type() &&
+            (!op->src[0]->buffer || op->src[0]->buffer->buft == ggml_backend_cpu_kleidiai_buffer_type()) &&
             slot_total > 0) {
             if (op->src[0]->type == GGML_TYPE_Q4_0 && ctx.kernels_q4 == nullptr) {
                 return false;
@@ -1460,8 +1459,7 @@ class extra_buffer_type : ggml::cpu::extra_buffer_type {
             if (op->src[1]->buffer && !ggml_backend_buft_is_host(op->src[1]->buffer->buft)) {
                 return false;
             }
-            if ((op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == GGML_TYPE_I32) &&
-                ggml_ne(op->src[1], 2) == 1 && ggml_ne(op->src[1], 3) == 1) {
+            if (op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == GGML_TYPE_I32) {
                 return true;
             }
         }

--- a/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
+++ b/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
@@ -1447,8 +1447,9 @@ class extra_buffer_type : ggml::cpu::extra_buffer_type {
         const int slot_total = kleidiai_collect_kernel_chain(op, kernel_chain);
         if ((op->op == GGML_OP_MUL_MAT || op->op == GGML_OP_GET_ROWS) &&
             (op->src[0]->type == GGML_TYPE_Q4_0 || op->src[0]->type == GGML_TYPE_Q8_0) &&
+            op->src[0]->buffer &&
             (ggml_n_dims(op->src[0]) == 2) &&
-            (!op->src[0]->buffer || op->src[0]->buffer->buft == ggml_backend_cpu_kleidiai_buffer_type()) &&
+            op->src[0]->buffer->buft == ggml_backend_cpu_kleidiai_buffer_type() &&
             slot_total > 0) {
             if (op->src[0]->type == GGML_TYPE_Q4_0 && ctx.kernels_q4 == nullptr) {
                 return false;
@@ -1459,7 +1460,8 @@ class extra_buffer_type : ggml::cpu::extra_buffer_type {
             if (op->src[1]->buffer && !ggml_backend_buft_is_host(op->src[1]->buffer->buft)) {
                 return false;
             }
-            if (op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == GGML_TYPE_I32) {
+            if ((op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == GGML_TYPE_I32) &&
+                ggml_ne(op->src[1], 3) == 1) {
                 return true;
             }
         }


### PR DESCRIPTION
The supports_op() check incorrectly rejected MUL_MAT operations with 3D inputs (ne[2] > 1), but the actual compute_forward_qx() implementation handles batched inputs correctly via a loop over ne12.

This caused models with Q4_0/Q8_0 weights to crash during graph scheduling when n_seq_max > 1, because weights were placed in KLEIDIAI buffers during loading (tested with 2D inputs) but the runtime used 3D inputs.

~Also relax the buffer check to allow supports_op() to be called during weight loading when src[0]->buffer is NULL.~

Fixes #20608

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

update: Ah, I just read the contributing guidelines above. I used an AI while tracking this down. I reviewed and tested the changes, and then pared it down to the minimal set of changes needed for the fix, but it would be "considered AI-generated" according to the contribution guidelines.

Feel free to close this PR if needed, but the root cause for the bug and this fix for it both work and make sense to me now. 
