### PR TITLE
Speed up claude-code by prevent adding system message that starts with 'x-anthropic-'

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1435,8 +1435,11 @@ json convert_anthropic_to_oai(const json & body) {
             system_content = system_param.get<std::string>();
         } else if (system_param.is_array()) {
             for (const auto & block : system_param) {
-                if (json_value(block, "type", std::string()) == "text") {
-                    system_content += json_value(block, "text", std::string());
+                 if (json_value(block, "type", std::string()) == "text") {
+                    std::string content_block = json_value(block, "text", std::string());
+                    if (!string_starts_with(content_block, "x-anthropic-")) {
+                        system_content += content_block;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Claude code send messages like this now:

```
{
  "system": [
    {"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.37.0d9; cc_entrypoint=cli; cch=fa690;"},
    {"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."},
    {"type": "text", "text": "...full system prompt..."}
  ],
  "messages": [{"role": "user", "content": "hey"}]
}
```

In the first system message, `cch` change for every request.

This PR will significantly increase the prompt cache hit rate and speed up claude-code.