### PR TITLE
fix: correct Granite template tool_call role + add Granite 4.0 Jinja template

### DIFF
--- a/models/templates/ibm-granite-granite-4.0-tiny-preview.jinja
+++ b/models/templates/ibm-granite-granite-4.0-tiny-preview.jinja
@@ -1,0 +1,45 @@
+{# Granite 4.0 Chat Template #}
+{# Alias tools -> available_tools for OpenAI-compatible API #}
+{%- if tools and not available_tools -%}
+    {%- set available_tools = tools -%}
+{%- endif -%}
+{%- if messages[0]['role'] == 'system' %}
+     {%- set system_message = messages[0]['content'] %}
+     {%- set loop_messages = messages[1:] %}
+ {%- else %}
+     {%- set system_message = "Knowledge Cutoff Date: April 2025. Today's Date: " + strftime_now('%B %d, %Y') + ". You are Granite, developed by IBM." %}
+     {%- if available_tools %}
+         {%- set system_message = system_message + " You are a helpful assistant with access to the following tools. When a tool is required to answer the user's query, respond only with <|tool_call|> followed by a JSON list of tools used. If a tool does not exist in the provided list of tools, notify the user that you do not have the ability to fulfill the request." %}
+     {%- else %}
+         {%- set system_message = system_message + " You are a helpful AI assistant." %}
+     {%- endif %}
+     {%- set loop_messages = messages %}
+ {%- endif %}
+ {{- '<|start_of_role|>system<|end_of_role|>' + system_message + '<|end_of_text|>
+' }}
+ {%- if available_tools %}
+     {{- '<|start_of_role|>available_tools<|end_of_role|>' }}
+     {{- available_tools | tojson(indent=4) }}
+     {{- '<|end_of_text|>
+' }}
+ {%- endif %}
+ {%- for message in loop_messages %}
+     {%- if message['role'] == 'assistant' and message.get('tool_calls') %}
+         {{- '<|start_of_role|>assistant<|end_of_role|><|tool_call|>' }}
+         {{- message['tool_calls'] | tojson }}
+         {{- '<|end_of_text|>
+' }}
+     {%- elif message['role'] == 'assistant_tool_call' %}
+         {{- '<|start_of_role|>assistant<|end_of_role|><|tool_call|>' + message['content'] + '<|end_of_text|>
+' }}
+     {%- elif message['role'] == 'tool' or message['role'] == 'tool_response' %}
+         {{- '<|start_of_role|>tool_response<|end_of_role|>' + message['content'] + '<|end_of_text|>
+' }}
+     {%- else %}
+         {{- '<|start_of_role|>' + message['role'] + '<|end_of_role|>' + message['content'] + '<|end_of_text|>
+' }}
+     {%- endif %}
+     {%- if loop.last and add_generation_prompt %}
+         {{- '<|start_of_role|>assistant<|end_of_role|>' }}
+     {%- endif %}
+ {%- endfor %}

--- a/src/llama-chat.cpp
+++ b/src/llama-chat.cpp
@@ -612,12 +612,16 @@ int32_t llm_chat_apply_template(
             }
         }
     } else if (tmpl == LLM_CHAT_TEMPLATE_GRANITE) {
-        // IBM Granite template
+        // IBM Granite template (3.x / 4.x)
+        // ref: https://huggingface.co/ibm-granite/granite-3.3-2B-Instruct
+        // ref: https://huggingface.co/ibm-granite/granite-4.0-tiny-preview
         for (const auto & message : chat) {
             std::string role(message->role);
-            ss << "<|start_of_role|>" << role << "<|end_of_role|>";
             if (role == "assistant_tool_call") {
-                ss << "<|tool_call|>";
+                // Tool call messages use the "assistant" role with a <|tool_call|> prefix
+                ss << "<|start_of_role|>assistant<|end_of_role|><|tool_call|>";
+            } else {
+                ss << "<|start_of_role|>" << role << "<|end_of_role|>";
             }
             ss << message->content << "<|end_of_text|>\n";
         }


### PR DESCRIPTION
## Summary

- **Fix wrong role name for tool call messages in the C++ Granite template.** The hardcoded template was emitting `<|start_of_role|>assistant_tool_call<|end_of_role|><|tool_call|>` but the model was trained with `<|start_of_role|>assistant<|end_of_role|><|tool_call|>`. This mismatch breaks tool calling, especially at lower quantization levels where the model has less capacity to generalize across formatting variants.
- **Add a Granite 4.0 Jinja template** (`models/templates/ibm-granite-granite-4.0-tiny-preview.jinja`) that uses the correct `available_tools` role for tool definitions instead of `<tools>` XML in the system message, matching the format the model was fine-tuned with.

## Background

IBM Granite 4 models are extremely sensitive to chat template formatting when quantized ([community reports](https://www.reddit.com/r/LocalLLaMA/comments/1nzozpg/)). The root cause is a divergence between the C++ hardcoded template and the Jinja template the model was trained with:

1. **Bug in `llama-chat.cpp`**: The `assistant_tool_call` role was passed through literally as the role name, but the Jinja template maps it to `assistant` with a `<|tool_call|>` prefix.
2. **Missing Granite 4 Jinja template**: The legacy C++ template path cannot inject tool definitions (no `tools` parameter in `llm_chat_apply_template`), so `--jinja` is required for full tool calling support. Adding the Jinja template file ensures it's available when `--jinja` is used.

## Test plan

- [ ] Verify `assistant_tool_call` messages now produce `<|start_of_role|>assistant<|end_of_role|><|tool_call|>...` (not `<|start_of_role|>assistant_tool_call<|end_of_role|>...`)
- [ ] Run `test-chat-template` to confirm existing Granite 3.0 test still passes
- [ ] Test tool calling with Granite 4 model using `--jinja` flag and the new template
- [ ] Test basic chat (no tools) still works with the C++ template path

🤖 Generated with [Claude Code](https://claude.com/claude-code)