### PR TITLE
tests : remove test-jinja-py

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -192,7 +192,8 @@ endif()
 
 llama_build_and_test(test-chat-peg-parser.cpp peg-parser/simple-tokenize.cpp)
 llama_build_and_test(test-jinja.cpp)
-llama_test(test-jinja NAME test-jinja-py ARGS -py LABEL python)
+# TODO: remove
+#llama_test(test-jinja NAME test-jinja-py ARGS -py LABEL python)
 llama_build_and_test(test-chat-auto-parser.cpp WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 llama_build_and_test(test-chat-template.cpp)
 llama_build_and_test(test-json-partial.cpp)


### PR DESCRIPTION
I think this is no longer needed as we don't use jinja? Suggest to remove it, instead of having to `pip install jinja2`

Noticed this error on the new mac self-hosted runner:

https://github.com/ggml-org/llama.cpp/actions/runs/23115539071/job/67140337984#step:4:6366