### PR TITLE
ggml-cuda: Add NVFP4 dp4a kernel

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -932,6 +932,13 @@ struct ggml_cuda_type_traits<GGML_TYPE_MXFP4> {
 };
 
 template<>
+struct ggml_cuda_type_traits<GGML_TYPE_NVFP4> {
+    static constexpr int qk = QK_NVFP4;
+    static constexpr int qr = QR_NVFP4;
+    static constexpr int qi = QI_NVFP4;
+};
+
+template<>
 struct ggml_cuda_type_traits<GGML_TYPE_Q2_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_K;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -799,54 +799,14 @@ static __device__ __forceinline__ float ggml_cuda_e8m0_to_fp32(uint8_t x) {
 #endif // CUDART_VERSION >= 12050
 }
 
-__device__ __forceinline__ float ggml_cuda_ue4m3_to_fp32(uint8_t x) {
-#if defined(__CUDA_ARCH__)
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && defined(CUDART_VERSION) && CUDART_VERSION >= 12050 // This matches cuda_fp8.h's version gate.
-    // This uses the same fp8 conversion that __nv_fp8_e4m3 uses internally.
-    __half h = __half(__nv_cvt_fp8_to_halfraw((__nv_fp8_storage_t) x, __NV_E4M3));
-    unsigned short hb = __half_as_ushort(h) - 0x0400u; // Built in 0.5f op.
-    float f = __half2float(__ushort_as_half(hb));
-
-    // __nv_fp8_e4m3 is signed but UE4M3
-    if (x == 0u || x == 0x7Fu) { // force 0x7F and 0x00 to 0.0f
-        f = 0.0f;
-    }
-
-    return f;
+static __device__ __forceinline__ float ggml_cuda_ue4m3_to_fp32(uint8_t x) { 
+#if CUDART_VERSION >= 11080 || defined(GGML_USE_HIP) 
+    const uint32_t bits = x * (x != 0x7F && x != 0xFF); // Convert NaN to 0.0f to match CPU implementation. 
+    const __nv_fp8_e4m3 xf = *reinterpret_cast<const __nv_fp8_e4m3 *>(&bits); 
+    return static_cast<float>(xf) / 2; 
 #else
-    if (x == 0u || x == 0x7Fu) {
-        return 0.0f;
-    }
-
-    const uint32_t exp  = x >> 3;
-    const uint32_t mant = x & 0x7u;
-    uint32_t bits;
-
-    if (exp != 0u) {
-        bits = ((exp + 119u) << 23) | (mant << 20);
-    } else {
-        uint32_t p;
-        if (mant < 2u) {
-            p = 0u;
-        } else if (mant < 4u) {
-            p = 1u;
-        } else {
-            p = 2u;
-        }
-
-        const uint32_t r = mant - (1u << p);
-        const uint32_t exp32  = p + 117u;
-        const uint32_t mant32 = r << (23u - p);
-        bits = (exp32 << 23) | mant32;
-    }
-
-    float f;
-    memcpy(&f, &bits, sizeof(f)); // 0.5f is baked in.
-    return f;
-#endif
-#else
-    return ggml_ue4m3_to_fp32(x);
-#endif
+    NO_DEVICE_CODE;
+#endif // CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
 }
 
 __device__ __forceinline__ uint8_t ggml_cuda_float_to_fp4_e2m1(float x, float e) {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -800,13 +800,13 @@ static __device__ __forceinline__ float ggml_cuda_e8m0_to_fp32(uint8_t x) {
 }
 
 static __device__ __forceinline__ float ggml_cuda_ue4m3_to_fp32(uint8_t x) {
-#if CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
+#ifdef FP8_AVAILABLE
     const uint32_t bits = x * (x != 0x7F && x != 0xFF); // Convert NaN to 0.0f to match CPU implementation.
     const __nv_fp8_e4m3 xf = *reinterpret_cast<const __nv_fp8_e4m3 *>(&bits);
     return static_cast<float>(xf) / 2;
 #else
     NO_DEVICE_CODE;
-#endif // CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
+#endif // FP8_AVAILABLE
 }
 
 __device__ __forceinline__ uint8_t ggml_cuda_float_to_fp4_e2m1(float x, float e) {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -799,11 +799,11 @@ static __device__ __forceinline__ float ggml_cuda_e8m0_to_fp32(uint8_t x) {
 #endif // CUDART_VERSION >= 12050
 }
 
-static __device__ __forceinline__ float ggml_cuda_ue4m3_to_fp32(uint8_t x) { 
-#if CUDART_VERSION >= 11080 || defined(GGML_USE_HIP) 
-    const uint32_t bits = x * (x != 0x7F && x != 0xFF); // Convert NaN to 0.0f to match CPU implementation. 
-    const __nv_fp8_e4m3 xf = *reinterpret_cast<const __nv_fp8_e4m3 *>(&bits); 
-    return static_cast<float>(xf) / 2; 
+static __device__ __forceinline__ float ggml_cuda_ue4m3_to_fp32(uint8_t x) {
+#if CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
+    const uint32_t bits = x * (x != 0x7F && x != 0xFF); // Convert NaN to 0.0f to match CPU implementation.
+    const __nv_fp8_e4m3 xf = *reinterpret_cast<const __nv_fp8_e4m3 *>(&bits);
+    return static_cast<float>(xf) / 2;
 #else
     NO_DEVICE_CODE;
 #endif // CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -799,6 +799,56 @@ static __device__ __forceinline__ float ggml_cuda_e8m0_to_fp32(uint8_t x) {
 #endif // CUDART_VERSION >= 12050
 }
 
+__device__ __forceinline__ float ggml_cuda_ue4m3_to_fp32(uint8_t x) {
+#if defined(__CUDA_ARCH__)
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && defined(CUDART_VERSION) && CUDART_VERSION >= 12050 // This matches cuda_fp8.h's version gate.
+    // This uses the same fp8 conversion that __nv_fp8_e4m3 uses internally.
+    __half h = __half(__nv_cvt_fp8_to_halfraw((__nv_fp8_storage_t) x, __NV_E4M3));
+    unsigned short hb = __half_as_ushort(h) - 0x0400u; // Built in 0.5f op.
+    float f = __half2float(__ushort_as_half(hb));
+
+    // __nv_fp8_e4m3 is signed but UE4M3
+    if (x == 0u || x == 0x7Fu) { // force 0x7F and 0x00 to 0.0f
+        f = 0.0f;
+    }
+
+    return f;
+#else
+    if (x == 0u || x == 0x7Fu) {
+        return 0.0f;
+    }
+
+    const uint32_t exp  = x >> 3;
+    const uint32_t mant = x & 0x7u;
+    uint32_t bits;
+
+    if (exp != 0u) {
+        bits = ((exp + 119u) << 23) | (mant << 20);
+    } else {
+        uint32_t p;
+        if (mant < 2u) {
+            p = 0u;
+        } else if (mant < 4u) {
+            p = 1u;
+        } else {
+            p = 2u;
+        }
+
+        const uint32_t r = mant - (1u << p);
+        const uint32_t exp32  = p + 117u;
+        const uint32_t mant32 = r << (23u - p);
+        bits = (exp32 << 23) | mant32;
+    }
+
+    float f;
+    memcpy(&f, &bits, sizeof(f)); // 0.5f is baked in.
+    return f;
+#endif
+#else
+    return ggml_ue4m3_to_fp32(x);
+#endif
+}
+
 __device__ __forceinline__ uint8_t ggml_cuda_float_to_fp4_e2m1(float x, float e) {
     const uint8_t sign_bit = (x < 0.0f) << 3;
     float         ax       = fabsf(x) * e;

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -621,12 +621,12 @@ template <typename dst_t>
 static __global__ void dequantize_block_nvfp4(
         const void * __restrict__ vx,
         dst_t * __restrict__ yy,
-        const int64_t k) {
+        const int64_t ne) {
     const int64_t i = blockIdx.x;
     const int     tid = threadIdx.x;
 
     const int64_t base = i * QK_NVFP4;
-    if (base >= k) {
+    if (base >= ne) {
         return;
     }
 

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -636,7 +636,7 @@ static __global__ void dequantize_block_nvfp4(
     const int sub = tid / (QK_NVFP4_SUB / 2);
     const int j = tid % (QK_NVFP4_SUB / 2);
 
-    const float d = ggml_cuda_cast<float>(ue4m3{xb.d[sub]});
+    const float d = ggml_cuda_ue4m3_to_fp32(xb.d[sub]);
     const uint8_t q = xb.qs[sub * (QK_NVFP4_SUB / 2) + j];
 
     const int64_t y0 = base + sub * QK_NVFP4_SUB + j;

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -617,6 +617,45 @@ static void dequantize_row_mxfp4_cuda(const void * vx, dst_t * y, const int64_t 
     dequantize_block_mxfp4<<<nb, 32, 0, stream>>>(vx, y);
 }
 
+template <typename dst_t>
+static __global__ void dequantize_block_nvfp4(
+        const void * __restrict__ vx,
+        dst_t * __restrict__ yy,
+        const int64_t k) {
+    const int64_t i = blockIdx.x;
+    const int     tid = threadIdx.x;
+
+    const int64_t base = i * QK_NVFP4;
+    if (base >= k) {
+        return;
+    }
+
+    const block_nvfp4 * x = (const block_nvfp4 *) vx;
+    const block_nvfp4 & xb = x[i];
+
+    const int sub = tid / (QK_NVFP4_SUB / 2);
+    const int j = tid % (QK_NVFP4_SUB / 2);
+
+    const float d = ggml_cuda_cast<float>(ue4m3{xb.d[sub]});
+    const uint8_t q = xb.qs[sub * (QK_NVFP4_SUB / 2) + j];
+
+    const int64_t y0 = base + sub * QK_NVFP4_SUB + j;
+    const int64_t y1 = y0 + QK_NVFP4_SUB / 2;
+
+    yy[y0] = ggml_cuda_cast<dst_t>(d * kvalues_mxfp4[q & 0x0F]);
+    yy[y1] = ggml_cuda_cast<dst_t>(d * kvalues_mxfp4[q >> 4]);
+}
+
+template <typename dst_t>
+static void dequantize_row_nvfp4_cuda(
+        const void * vx,
+        dst_t * y,
+        const int64_t k,
+        cudaStream_t stream) {
+    GGML_ASSERT(k % QK_NVFP4 == 0);
+    const int nb = k / QK_NVFP4;
+    dequantize_block_nvfp4<<<nb, 32, 0, stream>>>(vx, y, k);
+}
 template <typename src_t, typename dst_t>
 static __global__ void convert_unary(
         const void * __restrict__ vx, dst_t * __restrict__ y, const int64_t ne00, const int64_t ne01,
@@ -715,6 +754,8 @@ to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
             return dequantize_row_iq3_s_cuda;
         case GGML_TYPE_MXFP4:
             return dequantize_row_mxfp4_cuda;
+        case GGML_TYPE_NVFP4:
+            return dequantize_row_nvfp4_cuda;
         case GGML_TYPE_F32:
             return convert_unary_cont_cuda<float>;
         case GGML_TYPE_BF16:
@@ -766,6 +807,8 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type) {
             return dequantize_row_iq3_s_cuda;
         case GGML_TYPE_MXFP4:
             return dequantize_row_mxfp4_cuda;
+        case GGML_TYPE_NVFP4:
+            return dequantize_row_nvfp4_cuda;
         case GGML_TYPE_F16:
             return convert_unary_cont_cuda<half>;
         case GGML_TYPE_BF16:

--- a/ggml/src/ggml-cuda/convert.cuh
+++ b/ggml/src/ggml-cuda/convert.cuh
@@ -62,8 +62,8 @@ template<typename dst_t, typename src_t>
 #else
         return {x.x, x.y};
 #endif // GGML_USE_HIP
-    } else if constexpr (std::is_same_v<src_t, ue4m3>) {
-#if defined(__CUDA_ARCH__)
+    } else if constexpr (std::is_same_v<src_t, ue4m3> && std::is_same_v<dst_t, float>) {
+    #if defined(__CUDA_ARCH__)
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && defined(CUDART_VERSION) && CUDART_VERSION >= 12050 // This matches cuda_fp8.h's version gate.
         // This uses the same fp8 conversion that __nv_fp8_e4m3 uses internally.
         __half h = __half(__nv_cvt_fp8_to_halfraw((__nv_fp8_storage_t) x.x, __NV_E4M3));

--- a/ggml/src/ggml-cuda/convert.cuh
+++ b/ggml/src/ggml-cuda/convert.cuh
@@ -31,6 +31,10 @@ to_fp32_nc_cuda_t ggml_get_to_fp32_nc_cuda(ggml_type type);
 to_fp16_nc_cuda_t ggml_get_to_fp16_nc_cuda(ggml_type type);
 to_bf16_nc_cuda_t ggml_get_to_bf16_nc_cuda(ggml_type type);
 
+struct ue4m3 {
+    uint8_t x;
+};
+
 template<typename dst_t, typename src_t>
  __host__ __device__ inline dst_t ggml_cuda_cast(src_t x) {
     if constexpr (std::is_same_v<dst_t, src_t>) {
@@ -58,6 +62,54 @@ template<typename dst_t, typename src_t>
 #else
         return {x.x, x.y};
 #endif // GGML_USE_HIP
+    } else if constexpr (std::is_same_v<src_t, ue4m3>) {
+#if defined(__CUDA_ARCH__)
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && defined(CUDART_VERSION) && CUDART_VERSION >= 12050 // This matches cuda_fp8.h's version gate.
+        // This uses the same fp8 conversion that __nv_fp8_e4m3 uses internally.
+        __half h = __half(__nv_cvt_fp8_to_halfraw((__nv_fp8_storage_t) x.x, __NV_E4M3));
+        unsigned short hb = __half_as_ushort(h) - 0x0400u; // Built in 0.5f op.
+        float f = __half2float(__ushort_as_half(hb));
+
+        // __nv_fp8_e4m3 is signed but UE4M3
+        if (x.x == 0u || x.x == 0x7Fu) { // force 0x7F and 0x00 to 0.0f
+            f = 0.0f;
+        }
+
+        return f;
+#else
+        if (x.x == 0u || x.x == 0x7Fu) {
+            return 0.0f;
+        }
+
+        const uint32_t exp  = x.x >> 3;
+        const uint32_t mant = x.x & 0x7u;
+        uint32_t bits;
+
+        if (exp != 0u) {
+            bits = ((exp + 119u) << 23) | (mant << 20);
+        } else {
+            uint32_t p;
+            if (mant < 2u) {
+                p = 0u;
+            } else if (mant < 4u) {
+                p = 1u;
+            } else {
+                p = 2u;
+            }
+
+            const uint32_t r = mant - (1u << p);
+            const uint32_t exp32  = p + 117u;
+            const uint32_t mant32 = r << (23u - p);
+            bits = (exp32 << 23) | mant32;
+        }
+
+        float f;
+        memcpy(&f, &bits, sizeof(f)); // 0.5f is baked in.
+        return f;
+#endif
+#else
+        return ggml_ue4m3_to_fp32(x.x);
+#endif
     } else if constexpr(std::is_same_v<dst_t, int32_t>) {
         return int32_t(x);
     } else {

--- a/ggml/src/ggml-cuda/convert.cuh
+++ b/ggml/src/ggml-cuda/convert.cuh
@@ -31,10 +31,6 @@ to_fp32_nc_cuda_t ggml_get_to_fp32_nc_cuda(ggml_type type);
 to_fp16_nc_cuda_t ggml_get_to_fp16_nc_cuda(ggml_type type);
 to_bf16_nc_cuda_t ggml_get_to_bf16_nc_cuda(ggml_type type);
 
-struct ue4m3 {
-    uint8_t x;
-};
-
 template<typename dst_t, typename src_t>
  __host__ __device__ inline dst_t ggml_cuda_cast(src_t x) {
     if constexpr (std::is_same_v<dst_t, src_t>) {
@@ -62,54 +58,6 @@ template<typename dst_t, typename src_t>
 #else
         return {x.x, x.y};
 #endif // GGML_USE_HIP
-    } else if constexpr (std::is_same_v<src_t, ue4m3> && std::is_same_v<dst_t, float>) {
-    #if defined(__CUDA_ARCH__)
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && defined(CUDART_VERSION) && CUDART_VERSION >= 12050 // This matches cuda_fp8.h's version gate.
-        // This uses the same fp8 conversion that __nv_fp8_e4m3 uses internally.
-        __half h = __half(__nv_cvt_fp8_to_halfraw((__nv_fp8_storage_t) x.x, __NV_E4M3));
-        unsigned short hb = __half_as_ushort(h) - 0x0400u; // Built in 0.5f op.
-        float f = __half2float(__ushort_as_half(hb));
-
-        // __nv_fp8_e4m3 is signed but UE4M3
-        if (x.x == 0u || x.x == 0x7Fu) { // force 0x7F and 0x00 to 0.0f
-            f = 0.0f;
-        }
-
-        return f;
-#else
-        if (x.x == 0u || x.x == 0x7Fu) {
-            return 0.0f;
-        }
-
-        const uint32_t exp  = x.x >> 3;
-        const uint32_t mant = x.x & 0x7u;
-        uint32_t bits;
-
-        if (exp != 0u) {
-            bits = ((exp + 119u) << 23) | (mant << 20);
-        } else {
-            uint32_t p;
-            if (mant < 2u) {
-                p = 0u;
-            } else if (mant < 4u) {
-                p = 1u;
-            } else {
-                p = 2u;
-            }
-
-            const uint32_t r = mant - (1u << p);
-            const uint32_t exp32  = p + 117u;
-            const uint32_t mant32 = r << (23u - p);
-            bits = (exp32 << 23) | mant32;
-        }
-
-        float f;
-        memcpy(&f, &bits, sizeof(f)); // 0.5f is baked in.
-        return f;
-#endif
-#else
-        return ggml_ue4m3_to_fp32(x.x);
-#endif
     } else if constexpr(std::is_same_v<dst_t, int32_t>) {
         return int32_t(x);
     } else {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1297,7 +1297,12 @@ static void ggml_cuda_op_mul_mat_cublas(
     const bool supports_bf16 = GGML_CUDA_CC_IS_NVIDIA(cc) || GGML_CUDA_CC_IS_AMD(cc) ||
         (GGML_CUDA_CC_IS_MTHREADS(cc) && cc >= GGML_CUDA_CC_QY2);
 
-    const bool use_fp16 = (src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type)) && ggml_is_contiguous(src0) && row_diff == src0->ne[1] && dst->op_params[0] == GGML_PREC_DEFAULT;
+    const bool use_fp16 =
+        src0->type != GGML_TYPE_NVFP4 && 
+        (src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type)) &&
+        ggml_is_contiguous(src0) &&
+        row_diff == src0->ne[1] &&
+        dst->op_params[0] == GGML_PREC_DEFAULT;
 
     if (supports_bf16 && src0->type == GGML_TYPE_BF16 && ggml_is_contiguous(src0) && row_diff == src0->ne[1]) {
         ggml_cuda_pool_alloc<nv_bfloat16> src1_as_bf16(ctx.pool(id));
@@ -2281,6 +2286,11 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         any_gpus_with_slow_fp16 = any_gpus_with_slow_fp16   || !fast_fp16_hardware_available(cc);
     }
 
+    // temporarily block MMQ for NVFP4
+    if (src0->type == GGML_TYPE_NVFP4) {
+        use_mul_mat_q = false;
+    }
+
     // debug helpers
     //printf("src0: %8d %8d %8d %8d\n", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
     //printf("      %8d %8d %8d %8d\n", src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3]);
@@ -2350,10 +2360,15 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
             }
         }
 
+        // this is temporary to block MMQ for now
+    if (src0->type != GGML_TYPE_NVFP4) {
         if (ggml_cuda_should_use_mmq(src0->type, cc, ne12, /*n_experts=*/ne02)) {
             ggml_cuda_mul_mat_q(ctx, src0, src1, ids, dst);
             return;
         }
+        
+    }
+
 
         if (ggml_cuda_should_use_mmf(src0->type, cc, WARP_SIZE, src0->ne, src0->nb, src1->ne[2], /*mul_mat_id=*/true)) {
             ggml_cuda_mul_mat_f(ctx, src0, src1, ids, dst);
@@ -2453,6 +2468,7 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
         ggml_tensor dst_slice;
         memset(&dst_slice, 0, sizeof(dst_slice));
         dst_slice.buffer = dst->buffer;
+        dst_slice.op     = GGML_OP_MUL_MAT;
         dst_slice.type   = type_dst_sorted;
         dst_slice.ne[0]  = ne0;
         dst_slice.ne[1]  = tokens_per_expert[i02];
@@ -3847,7 +3863,7 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
 
                             const ggml_tensor * src0 = up_n->src[0];
                             const ggml_tensor * src1 = up_n->src[1];
-                            const ggml_tensor * ids  = up_n->src[2];
+                            const ggml_tensor * ids  = op == GGML_OP_MUL_MAT_ID ? up_n->src[2] : nullptr;
 
                             if (ggml_cuda_should_fuse_mul_mat_vec_f(up_n)) {
                                 ggml_cuda_mm_fusion_args_host fusion_data{};
@@ -4781,6 +4797,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_MXFP4:
+                    case GGML_TYPE_NVFP4:
                     case GGML_TYPE_Q2_K:
                     case GGML_TYPE_Q3_K:
                     case GGML_TYPE_Q4_K:

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1298,7 +1298,7 @@ static void ggml_cuda_op_mul_mat_cublas(
         (GGML_CUDA_CC_IS_MTHREADS(cc) && cc >= GGML_CUDA_CC_QY2);
 
     const bool use_fp16 =
-        src0->type != GGML_TYPE_NVFP4 && 
+        src0->type != GGML_TYPE_NVFP4 &&
         (src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type)) &&
         ggml_is_contiguous(src0) &&
         row_diff == src0->ne[1] &&
@@ -2360,7 +2360,7 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
             ggml_cuda_mul_mat_q(ctx, src0, src1, ids, dst);
             return;
         }
-        
+
         if (ggml_cuda_should_use_mmf(src0->type, cc, WARP_SIZE, src0->ne, src0->nb, src1->ne[2], /*mul_mat_id=*/true)) {
             ggml_cuda_mul_mat_f(ctx, src0, src1, ids, dst);
             return;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2286,10 +2286,6 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         any_gpus_with_slow_fp16 = any_gpus_with_slow_fp16   || !fast_fp16_hardware_available(cc);
     }
 
-    // temporarily block MMQ for NVFP4
-    if (src0->type == GGML_TYPE_NVFP4) {
-        use_mul_mat_q = false;
-    }
 
     // debug helpers
     //printf("src0: %8d %8d %8d %8d\n", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
@@ -2360,16 +2356,11 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
             }
         }
 
-        // this is temporary to block MMQ for now
-    if (src0->type != GGML_TYPE_NVFP4) {
         if (ggml_cuda_should_use_mmq(src0->type, cc, ne12, /*n_experts=*/ne02)) {
             ggml_cuda_mul_mat_q(ctx, src0, src1, ids, dst);
             return;
         }
         
-    }
-
-
         if (ggml_cuda_should_use_mmf(src0->type, cc, WARP_SIZE, src0->ne, src0->nb, src1->ne[2], /*mul_mat_id=*/true)) {
             ggml_cuda_mul_mat_f(ctx, src0, src1, ids, dst);
             return;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4787,7 +4787,9 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_MXFP4:
+#if CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
                     case GGML_TYPE_NVFP4:
+#endif // CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
                     case GGML_TYPE_Q2_K:
                     case GGML_TYPE_Q3_K:
                     case GGML_TYPE_Q4_K:

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2468,7 +2468,6 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
         ggml_tensor dst_slice;
         memset(&dst_slice, 0, sizeof(dst_slice));
         dst_slice.buffer = dst->buffer;
-        dst_slice.op     = GGML_OP_MUL_MAT;
         dst_slice.type   = type_dst_sorted;
         dst_slice.ne[0]  = ne0;
         dst_slice.ne[1]  = tokens_per_expert[i02];
@@ -3863,7 +3862,7 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
 
                             const ggml_tensor * src0 = up_n->src[0];
                             const ggml_tensor * src1 = up_n->src[1];
-                            const ggml_tensor * ids  = op == GGML_OP_MUL_MAT_ID ? up_n->src[2] : nullptr;
+                            const ggml_tensor * ids  = up_n->src[2];
 
                             if (ggml_cuda_should_fuse_mul_mat_vec_f(up_n)) {
                                 ggml_cuda_mm_fusion_args_host fusion_data{};

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4786,9 +4786,9 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_MXFP4:
-#if CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
+#ifdef FP8_AVAILABLE
                     case GGML_TYPE_NVFP4:
-#endif // CUDART_VERSION >= 11080 || defined(GGML_USE_HIP)
+#endif // FP8_AVAILABLE
                     case GGML_TYPE_Q2_K:
                     case GGML_TYPE_Q3_K:
                     case GGML_TYPE_Q4_K:

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2286,7 +2286,6 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         any_gpus_with_slow_fp16 = any_gpus_with_slow_fp16   || !fast_fp16_hardware_available(cc);
     }
 
-
     // debug helpers
     //printf("src0: %8d %8d %8d %8d\n", src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3]);
     //printf("      %8d %8d %8d %8d\n", src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3]);

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -15,6 +15,7 @@ static constexpr __device__ vec_dot_q_cuda_t get_vec_dot_q_cuda(ggml_type type) 
         case GGML_TYPE_Q5_1:    return vec_dot_q5_1_q8_1;
         case GGML_TYPE_Q8_0:    return vec_dot_q8_0_q8_1;
         case GGML_TYPE_MXFP4:   return vec_dot_mxfp4_q8_1;
+        case GGML_TYPE_NVFP4:   return vec_dot_nvfp4_q8_1;
         case GGML_TYPE_Q2_K:    return vec_dot_q2_K_q8_1;
         case GGML_TYPE_Q3_K:    return vec_dot_q3_K_q8_1;
         case GGML_TYPE_Q4_K:    return vec_dot_q4_K_q8_1;
@@ -41,6 +42,7 @@ static constexpr __host__ __device__ int get_vdr_mmvq(ggml_type type) {
         case GGML_TYPE_Q5_1:    return VDR_Q5_1_Q8_1_MMVQ;
         case GGML_TYPE_Q8_0:    return VDR_Q8_0_Q8_1_MMVQ;
         case GGML_TYPE_MXFP4:   return VDR_MXFP4_Q8_1_MMVQ;
+        case GGML_TYPE_NVFP4:   return VDR_NVFP4_Q8_1_MMVQ;
         case GGML_TYPE_Q2_K:    return VDR_Q2_K_Q8_1_MMVQ;
         case GGML_TYPE_Q3_K:    return VDR_Q3_K_Q8_1_MMVQ;
         case GGML_TYPE_Q4_K:    return VDR_Q4_K_Q8_1_MMVQ;
@@ -622,6 +624,12 @@ static void mul_mat_vec_q_switch_type(
             break;
         case GGML_TYPE_MXFP4:
             mul_mat_vec_q_switch_ncols_dst<GGML_TYPE_MXFP4>
+                (vx, vy, ids, fusion, dst, ncols_x, nrows_x, ncols_dst, stride_row_x, stride_col_y, stride_col_dst,
+                 nchannels_x, nchannels_y, nchannels_dst, stride_channel_x, stride_channel_y, stride_channel_dst,
+                 nsamples_x, nsamples_dst, stride_sample_x, stride_sample_y, stride_sample_dst, ids_stride, stream);
+            break;
+        case GGML_TYPE_NVFP4:
+            mul_mat_vec_q_switch_ncols_dst<GGML_TYPE_NVFP4>
                 (vx, vy, ids, fusion, dst, ncols_x, nrows_x, ncols_dst, stride_row_x, stride_col_y, stride_col_dst,
                  nchannels_x, nchannels_y, nchannels_dst, stride_channel_x, stride_channel_y, stride_channel_dst,
                  nsamples_x, nsamples_dst, stride_sample_x, stride_sample_y, stride_sample_dst, ids_stride, stream);

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -328,27 +328,27 @@ static __device__ __forceinline__ float vec_dot_mxfp4_q8_1(
 static __device__ __forceinline__ float vec_dot_nvfp4_q8_1(
                                         const void * __restrict__ vbq,
                                         const block_q8_1 * __restrict__ bq8_1,
-                                        const int & kbx,
-                                        const int & iqs) {
+                                        const int32_t & kbx,
+                                        const int32_t & iqs) {
 
     const block_nvfp4 * bq4 = (const block_nvfp4 *) vbq + kbx;
     float sum = 0.0f;
 #pragma unroll
     for (int i = 0; i < VDR_NVFP4_Q8_1_MMVQ/2; i++) {
-        const int iqs0 = iqs + 2*i;
-        const int iqs1 = iqs0 + 1;
-        const int is = iqs0 >> 1;
+        const int32_t iqs0 = iqs + 2*i;
+        const int32_t iqs1 = iqs0 + 1;
+        const int32_t is = iqs0 >> 1;
         const int2 v0 = get_int_from_table_16(get_int_b4(bq4->qs, iqs0), kvalues_mxfp4);
         const int2 v1 = get_int_from_table_16(get_int_b4(bq4->qs, iqs1), kvalues_mxfp4);
         const block_q8_1 * bq8 = bq8_1 + (is >> 1);
-        const int i8 = ((is & 1) << 2);
+        const int32_t i8 = ((is & 1) << 2);
 
         int sumi = ggml_cuda_dp4a(v0.x, get_int_b4(bq8->qs, i8 + 0), 0);
         sumi = ggml_cuda_dp4a(v0.y, get_int_b4(bq8->qs, i8 + 2), sumi);
         sumi = ggml_cuda_dp4a(v1.x, get_int_b4(bq8->qs, i8 + 1), sumi);
         sumi = ggml_cuda_dp4a(v1.y, get_int_b4(bq8->qs, i8 + 3), sumi);
 
-        const float d = ggml_cuda_cast<float>(ue4m3{bq4->d[is]}) * __low2float(bq8->ds);
+        const float d = ggml_cuda_ue4m3_to_fp32(bq4->d[is]) * __low2float(bq8->ds);
         sum += d * float(sumi);
     }
 

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "convert.cuh"
+#include "common.cuh"
 
 #include <cstdint>
 

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "common.cuh"
+#include "convert.cuh"
 
 #include <cstdint>
 
@@ -322,6 +322,38 @@ static __device__ __forceinline__ float vec_dot_mxfp4_q8_1(
     return d * sumi;
 }
 
+#define VDR_NVFP4_Q8_1_MMVQ 4
+#define VDR_NVFP4_Q8_1_MMQ  8
+
+static __device__ __forceinline__ float vec_dot_nvfp4_q8_1(
+                                        const void * __restrict__ vbq,
+                                        const block_q8_1 * __restrict__ bq8_1,
+                                        const int & kbx,
+                                        const int & iqs) {
+
+    const block_nvfp4 * bq4 = (const block_nvfp4 *) vbq + kbx;
+    float sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < VDR_NVFP4_Q8_1_MMVQ/2; i++) {
+        const int iqs0 = iqs + 2*i;
+        const int iqs1 = iqs0 + 1;
+        const int is = iqs0 >> 1;
+        const int2 v0 = get_int_from_table_16(get_int_b4(bq4->qs, iqs0), kvalues_mxfp4);
+        const int2 v1 = get_int_from_table_16(get_int_b4(bq4->qs, iqs1), kvalues_mxfp4);
+        const block_q8_1 * bq8 = bq8_1 + (is >> 1);
+        const int i8 = ((is & 1) << 2);
+
+        int sumi = ggml_cuda_dp4a(v0.x, get_int_b4(bq8->qs, i8 + 0), 0);
+        sumi = ggml_cuda_dp4a(v0.y, get_int_b4(bq8->qs, i8 + 2), sumi);
+        sumi = ggml_cuda_dp4a(v1.x, get_int_b4(bq8->qs, i8 + 1), sumi);
+        sumi = ggml_cuda_dp4a(v1.y, get_int_b4(bq8->qs, i8 + 3), sumi);
+
+        const float d = ggml_cuda_cast<float>(ue4m3{bq4->d[is]}) * __low2float(bq8->ds);
+        sum += d * float(sumi);
+    }
+
+    return sum;
+}
 #define VDR_Q2_K_Q8_1_MMVQ 1
 #define VDR_Q2_K_Q8_1_MMQ  4
 

--- a/ggml/src/ggml-cuda/vendors/cuda.h
+++ b/ggml/src/ggml-cuda/vendors/cuda.h
@@ -6,9 +6,10 @@
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 
-#if CUDART_VERSION >= 12050
+#if CUDART_VERSION >= 11080
 #include <cuda_fp8.h>
-#endif // CUDART_VERSION >= 12050
+#define FP8_AVAILABLE
+#endif // CUDART_VERSION >= 11080
 
 #if CUDART_VERSION >= 12080
 #include <cuda_fp4.h>

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -235,6 +235,7 @@
 
 typedef __hip_bfloat16 nv_bfloat16;
 typedef __hip_bfloat162 nv_bfloat162;
+typedef __hip_fp8_e4m3 __nv_fp8_e4m3;
 
 typedef int8_t int8x4_t __attribute__((ext_vector_type(4)));
 typedef uint8_t uint8x4_t __attribute__((ext_vector_type(4)));

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -5,7 +5,6 @@
 #include <hipblas/hipblas.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
-#include <hip/hip_fp8.h>
 
 #if defined(GGML_HIP_ROCWMMA_FATTN)
 #include <rocwmma/rocwmma-version.hpp>
@@ -235,7 +234,12 @@
 
 typedef __hip_bfloat16 nv_bfloat16;
 typedef __hip_bfloat162 nv_bfloat162;
+
+#if HIP_VERSION >= 60200000
+#include <hip/hip_fp8.h>
 typedef __hip_fp8_e4m3 __nv_fp8_e4m3;
+#define FP8_AVAILABLE
+#endif // HIP_VERSION >= 60200000
 
 typedef int8_t int8x4_t __attribute__((ext_vector_type(4)));
 typedef uint8_t uint8x4_t __attribute__((ext_vector_type(4)));

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -5,6 +5,7 @@
 #include <hipblas/hipblas.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
+#include <hip/hip_fp8.h>
 
 #if defined(GGML_HIP_ROCWMMA_FATTN)
 #include <rocwmma/rocwmma-version.hpp>

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7279,7 +7279,7 @@ static const ggml_type all_types[] = {
     GGML_TYPE_Q4_0, GGML_TYPE_Q4_1,
     GGML_TYPE_Q5_0, GGML_TYPE_Q5_1,
     GGML_TYPE_Q8_0,
-    GGML_TYPE_MXFP4,
+    GGML_TYPE_MXFP4, GGML_TYPE_NVFP4,
     GGML_TYPE_Q2_K, GGML_TYPE_Q3_K,
     GGML_TYPE_Q4_K, GGML_TYPE_Q5_K,
     GGML_TYPE_Q6_K,
@@ -7295,7 +7295,7 @@ static const ggml_type base_types[] = {
     GGML_TYPE_Q4_0,
     GGML_TYPE_Q4_1, // for I8MM tests
     GGML_TYPE_Q4_K,
-    GGML_TYPE_MXFP4, // TODO: or "other"
+    GGML_TYPE_MXFP4, GGML_TYPE_NVFP4, // TODO: or "other"
     GGML_TYPE_IQ2_XXS
 };
 


### PR DESCRIPTION
This PR brings in the initial plumbing for basic CUDA support for NVFP4 - it includes one NVFP4xQ8_1 dp4a kernel.  MMA or Blackwell kernels are not included here and were kept out for a separate PR.  

`vec_dot_mma` is is linked up the dp4a kernel so it still runs dp4a even when BLACKWELL_MMA_AVAILABLE.
There is a branch for NVFP4 in `mmq_write_back_mma` to push it back to the dp4a layout which will be removed when the MMA kernel is wired in.

It was tuned to bring as much performance as possible for DP4A. Comparisons below.  
**CPU vs DP4A**

| Model | CPU (pp64) | DP4A (pp64) | Speedup | CPU (tg16) | DP4A (tg16) | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| Qwen3.5-0.8B | 59.63 | 3557.08 | **59.65x** | 32.33 | 329.60 | **10.19x** |
| Qwen3.5-27B | 1.27 | 594.14 | **467.83x** | 1.08 | 52.65 | **48.75x** |

**pp512 / tg128**

| Model | pp512 t/s | tg128 t/s |
|---|---:|---:|
| Qwen3-4B |  9031.22 | 271.69 |
| Qwen3-8B | 4909.27 | 175.93 |
| Qwen3.5-27B| 1482.89 | 63.47 |
| Qwen3.5-0.8B | 25596.92 | 388.12 |
| Qwen3.5-0.8B-Q4_K_M | 38339.57 | 521.69 |

AI assistance was used in refactoring and writing some of this code.  Each line has been scrutinized and this was hand-edited to be as neat and as minimal as possible.  Test-backend-ops passes; CPU<>GPU parity was tested with a separate tool and is exact across multiple tile sizes, and kld/ppl was verified on several models and is as expected (tested on GPU only, CPU too slow).