### PR TITLE
tests: enable kv_unified for test-backend-sampler

### DIFF
--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -89,6 +89,7 @@ struct test_context {
         cparams.n_batch = 512;
         cparams.samplers = configs.data();
         cparams.n_samplers = configs.size();
+        cparams.kv_unified = true;
 
         // If n_seq_max is not specified, calculate it from configs
         if (n_seq_max < 0) {


### PR DESCRIPTION
While running tests to ensure that my local server is ready to be onboard as a GGML CI runner, I ran into an odd CUDA OOM error for the dist sampling test as shown:

```console
2026-03-15T15:43:18.5103166Z ggml_backend_cuda_buffer_type_alloc_buffer: allocating 5320.00 MiB on device 0: cudaMalloc failed: out of memory
2026-03-15T15:43:18.5103360Z alloc_tensor_range: failed to allocate CUDA0 buffer of size 5578424320
2026-03-15T15:43:18.5103633Z llama_init_from_model: failed to initialize the context: failed to allocate buffer for kv cache
2026-03-15T15:43:18.5103764Z Error running test 'dist': failed to create context
```

~Comparing the dist sampling test across all the other available tests, I noticed that `seq_id = 0` has been used everywhere except `test_backend_dist_sampling`. Setting `seq_id` from `189` to `0` seem to have solved the OOM error.~

~cc: @danbev; please let me know if `seq_id = 189` was intentional or if there is another approach to solving this :)~

Edit: PR has been updated to change only `kv_unified = true` as suggested https://github.com/ggml-org/llama.cpp/pull/20645#issuecomment-4068454078.
