### PR TITLE
Make debug build possible on Windows with HIP backend.

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -11,8 +11,19 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH  ${ROCM_PATH})
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}/lib64/cmake")
 
-if (NOT DEFINED CMAKE_HIP_FLAGS_DEBUG)
-    set(CMAKE_HIP_FLAGS_DEBUG "-g -O2")
+if (WIN32)
+	# CMake on Windows doesn't support the HIP language yet
+	if (NOT DEFINED CMAKE_CXX_FLAGS_DEBUG)
+		set(CMAKE_CXX_FLAGS_DEBUG "-g -O2")
+	else()
+		string(REPLACE "-O0" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+		message(WARNING "Replaced CXX compiler's debug flag '-O0' with '-O2' due to bug at HIP compiler.")
+		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+	endif()
+else()
+	if (NOT DEFINED CMAKE_HIP_FLAGS_DEBUG)
+		set(CMAKE_HIP_FLAGS_DEBUG "-g -O2")
+	endif()
 endif()
 
 # CMake on Windows doesn't support the HIP language yet

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -11,19 +11,8 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH  ${ROCM_PATH})
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}/lib64/cmake")
 
-if (WIN32)
-	# CMake on Windows doesn't support the HIP language yet
-	if (NOT DEFINED CMAKE_CXX_FLAGS_DEBUG)
-		set(CMAKE_CXX_FLAGS_DEBUG "-g -O2")
-	else()
-		string(REPLACE "-O0" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-		message(WARNING "Replaced CXX compiler's debug flag '-O0' with '-O2' due to bug at HIP compiler.")
-		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
-	endif()
-else()
-	if (NOT DEFINED CMAKE_HIP_FLAGS_DEBUG)
-		set(CMAKE_HIP_FLAGS_DEBUG "-g -O2")
-	endif()
+if (NOT DEFINED CMAKE_HIP_FLAGS_DEBUG)
+    set(CMAKE_HIP_FLAGS_DEBUG "-g -O2")
 endif()
 
 # CMake on Windows doesn't support the HIP language yet
@@ -143,6 +132,11 @@ endif()
 
 if (CXX_IS_HIPCC)
     set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES LANGUAGE CXX)
+    if (WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+        # CMake on Windows doesn't support the HIP language yet.
+        # Therefore we workaround debug build's failure on HIP backend this way.
+        set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES COMPILE_FLAGS "-O2 -g")
+    endif()
     target_link_libraries(ggml-hip PRIVATE hip::device)
 else()
     set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES LANGUAGE HIP)


### PR DESCRIPTION
# What is it?

Debug build for HIP backend fails on Windows. It is known problem (see https://github.com/ROCm/ROCm/issues/5826) and was [previously fixed for Linux build](https://github.com/ggml-org/llama.cpp/pull/20392). However, CMakeFiles.txt on Windows treat HIP files as CXX files, therefore one should provide extra treatment for Windows build.

Fix is to explicitly set "-O2" option for HIP source files at Windows debug build.

If this correction is good enough to be accepted, I will also make PRs for [ggml](https://github.com/ggml-org/ggml) and [whisper.cpp](https://github.com/ggml-org/whisper.cpp) repos.

# Ways to test and reproduce.
I found this issue while trying to build llama.cpp for Strix Halo (architecture gfx1151). Most likely this error occurs not only on Strix Halo and can be reproduced at any RDNA 2/3/4 AMD GPU.

```powershell
git clone https://github.com/ggml-org/llama.cpp.git
cd llama.cpp
cmake -G Ninja -B build -DGGML_HIP=ON -DGGML_HIP_ROCWMMA_FATTN=OFF -DGGML_OPENMP=OFF -DAMDGPU_TARGETS=gfx1151 -DCMAKE_RC_COMPILER="C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/rc.exe" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DCURL_LIBRARY=C:/vcpkg_github/vcpkg/installed/x64-windows/lib/libcurl.lib -DCURL_INCLUDE_DIR=C:/vcpkg_github/vcpkg/installed/x64-windows/include
cmake --build build
```

# Additional tests.
Not needed, current ones are good.