### PR TITLE
server: add `hidden` preset option to filter models from /models endpoint

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3865,6 +3865,12 @@ void common_params_add_preset_options(std::vector<common_arg> & args) {
         [](common_params &, int) { /* unused */ }
     ).set_env(COMMON_ARG_PRESET_STOP_TIMEOUT).set_preset_only());
 
+    args.push_back(common_arg(
+        {"hidden"},
+        "in server router mode, hide this model from the /models endpoint",
+        [](common_params &) { /* unused */ }
+    ).set_env(COMMON_ARG_PRESET_HIDDEN).set_preset_only());
+
     // args.push_back(common_arg(
     //     {"pin"},
     //     "in server router mode, do not unload this model if models_max is exceeded",

--- a/common/arg.h
+++ b/common/arg.h
@@ -11,6 +11,7 @@
 // pseudo-env variable to identify preset-only arguments
 #define COMMON_ARG_PRESET_LOAD_ON_STARTUP "__PRESET_LOAD_ON_STARTUP"
 #define COMMON_ARG_PRESET_STOP_TIMEOUT    "__PRESET_STOP_TIMEOUT"
+#define COMMON_ARG_PRESET_HIDDEN          "__PRESET_HIDDEN"
 
 //
 // CLI argument parsing

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1553,6 +1553,7 @@ The precedence rule for preset options is as follows:
 We also offer additional options that are exclusive to presets (these aren't treated as command-line arguments):
 - `load-on-startup` (boolean): Controls whether the model loads automatically when the server starts
 - `stop-timeout` (int, seconds): After requested unload, wait for this many seconds before forcing termination (default: 10)
+- `hidden` (boolean): When true, excludes the model from the `GET /models` response; the model is still loadable and usable via the API (useful with `[*]` to hide all by default)
 
 ### Routing requests
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -351,6 +351,14 @@ void server_models::load_models() {
         }
     }
 
+    // handle custom hidden option
+    for (auto & [name, inst] : mapping) {
+        std::string val;
+        if (inst.meta.preset.get_option(COMMON_ARG_PRESET_HIDDEN, val)) {
+            inst.meta.hidden = common_arg_utils::is_truthy(val);
+        }
+    }
+
     // load any autoload models
     std::vector<std::string> models_to_load;
     for (const auto & [name, inst] : mapping) {
@@ -948,6 +956,9 @@ void server_models_routes::init_routes() {
         auto all_models = models.get_all_meta();
         std::time_t t = std::time(0);
         for (const auto & meta : all_models) {
+            if (meta.hidden) {
+                continue;
+            }
             json status {
                 {"value",  server_model_status_to_string(meta.status)},
                 {"args",   meta.args},

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -60,6 +60,7 @@ struct server_model_meta {
     std::vector<std::string> args; // args passed to the model instance, will be populated by render_args()
     int exit_code = 0; // exit code of the model instance process (only valid if status == FAILED)
     int stop_timeout = 0; // seconds to wait before force-killing the model instance during shutdown
+    bool hidden = false;  // if true, exclude from /models endpoint
 
     bool is_active() const {
         return status == SERVER_MODEL_STATUS_LOADED || status == SERVER_MODEL_STATUS_LOADING;


### PR DESCRIPTION
Closes #18609

## Problem

In router mode with `--models-preset`, `GET /models` returns **all** discovered models (cached, from `--models-dir`, and from the preset file). This clutters the web UI and the API with models the user does not want to expose (e.g. reranker models, or models with long GGUF names).

## Solution

Add a per-model `hidden` boolean option for the preset INI file. When set, the model is excluded from the `GET /models` / `GET /v1/models` response, while remaining fully loadable and usable via direct API calls.

The `[*]` global selector can be used to hide everything by default and opt individual models back in:

```ini
[*]
hidden = true        ; hide all models by default

[my-chat-model]
hf-repo = user/chat-model
hidden = false       ; explicitly visible

[my-reranker]
hf-repo = user/reranker
; inherits hidden = true from [*] → stays hidden
```

## Changes

| File | Change |
|------|--------|
| `common/arg.h` | Add `COMMON_ARG_PRESET_HIDDEN` constant |
| `common/arg.cpp` | Register `hidden` as a preset-only option (follows `load-on-startup` / `stop-timeout` patterns) |
| `tools/server/server-models.h` | Add `bool hidden = false` field to `server_model_meta` |
| `tools/server/server-models.cpp` | Read `hidden` from preset in `load_models()`; skip hidden models in `get_router_models` |

## Notes

- Hidden models are **only** excluded from the listing endpoints. They can still be loaded and used via `/completions`, `/chat/completions`, etc.
- The `[*]` cascading is handled by the existing `ctx_preset.cascade(global, ...)` logic — no changes needed there.
- Follows the exact same patterns as the existing `load-on-startup` and `stop-timeout` preset-only options.