### PR TITLE
ggml-cpu/x86: fix unused changemask warning in repack

### DIFF
--- a/ggml/src/ggml-cpu/arch/x86/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/x86/repack.cpp
@@ -531,7 +531,6 @@ static void gemv_q4_b32_8x8_q8_0_lut_avx(int n, float * GGML_RESTRICT s, size_t 
 
     UNUSED(bs);
 
-    __m128i changemask = _mm_set_epi8(15, 14, 7, 6, 13, 12, 5, 4, 11, 10, 3, 2, 9, 8, 1, 0);
     __m256i finalpermutemask = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
 
     // Permute mask used for easier vector processing at later stages
@@ -580,6 +579,7 @@ static void gemv_q4_b32_8x8_q8_0_lut_avx(int n, float * GGML_RESTRICT s, size_t 
                 if constexpr (
                         std::is_same_v<block_tx8, block_q4_0x8> ||
                         std::is_same_v<block_tx8, block_iq4_nlx8>) {
+                    const __m128i changemask = _mm_set_epi8(15, 14, 7, 6, 13, 12, 5, 4, 11, 10, 3, 2, 9, 8, 1, 0);
                     col_scale_f32 = GGML_F32Cx8_REARRANGE_LOAD(b_ptr[b].d, changemask);
                 } else if constexpr (std::is_same_v<block_tx8, block_mxfp4x8>) {
                     // Load 8 E8M0 exponents and convert to float via LUT


### PR DESCRIPTION
## Summary

Fix an `-Wunused-but-set-variable` warning in `ggml/src/ggml-cpu/arch/x86/repack.cpp`.

`changemask` was declared unconditionally in `gemv_q4_b32_8x8_q8_0_lut_avx`, but it is only used in the `block_q4_0x8` / `block_iq4_nlx8` path. For the `block_mxfp4x8` template instantiation, that branch is discarded by `if constexpr`, which leaves `changemask` unused and triggers the warning.

This change moves the declaration into the branch where it is used.

## Testing

- Built locally with CMake and verified the warning no longer appears.