### PR TITLE
Fix: Use next(iter()) instead of awkward list comprehension in gguf_writer.py

### DIFF
--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -425,8 +425,7 @@ class GGUFWriter:
         fout = self.fout[file_id]
 
         # pop the first tensor info
-        # TODO: cleaner way to get the first key
-        first_tensor_name = [name for name, _ in zip(self.tensors[file_id].keys(), range(1))][0]
+        first_tensor_name = next(iter(self.tensors[file_id].keys()))
         ti = self.tensors[file_id].pop(first_tensor_name)
         assert ti.nbytes == tensor.nbytes
 


### PR DESCRIPTION
## Description

In `gguf-py/gguf/gguf_writer.py`, the code used an awkward list comprehension to get the first key of a dictionary:

```python
first_tensor_name = [name for name, _ in zip(self.tensors[file_id].keys(), range(1))][0]
```

This is inefficient (creates a list just to get the first element) and hard to read. This PR replaces it with the cleaner and more Pythonic:

```python
first_tensor_name = next(iter(self.tensors[file_id].keys()))
```

This also removes the TODO comment as the issue is now resolved.

## Changes
- Replace awkward list comprehension with `next(iter())` for getting first dict key
- Remove the TODO comment as the issue is resolved

## Testing
The change is a simple refactor that does not change the functionality.