### PR TITLE
Convert: Make NVFP4 and MXFP4 HF conversions say NVFP4/MXFP4 instead of BF16

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1150,9 +1150,8 @@ class TextModel(ModelBase):
             self.gguf_writer.add_key_length(head_dim)
             self.gguf_writer.add_value_length(head_dim)
 
-        file_type = gguf.LlamaFileType.MOSTLY_NVFP4 if self._is_nvfp4 else self.ftype
-        self.gguf_writer.add_file_type(file_type)
-        logger.info(f"gguf: file type = {file_type}")
+        self.gguf_writer.add_file_type(self.ftype)
+        logger.info(f"gguf: file type = {self.ftype}")
 
     def write_vocab(self):
         if len(self.gguf_writer.tensors) != 1:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -876,8 +876,11 @@ class ModelBase:
         if self.metadata.name is None:
             self.metadata.name = self.dir_model.name
 
-        if self._is_nvfp4 and self.model_name is None and self.metadata.name is not None and self.metadata.name.endswith(" BF16"):
-            self.metadata.name = f"{self.metadata.name[:-5]} NVFP4"
+        if self.ftype in (gguf.LlamaFileType.ALL_F32, gguf.LlamaFileType.MOSTLY_F16, gguf.LlamaFileType.MOSTLY_BF16):
+            if self._is_nvfp4:
+                self.ftype = gguf.LlamaFileType.MOSTLY_NVFP4
+            elif self._is_mxfp4:
+                self.ftype = gguf.LlamaFileType.MOSTLY_MXFP4_MOE
 
         # Generate parameter weight class (useful for leader boards) if not yet determined
         if self.metadata.size_label is None and total_params > 0:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1022,7 +1022,7 @@ class TextModel(ModelBase):
 
         total_params = self.gguf_writer.get_total_parameter_count()[0]
         # Extract the encoding scheme from the file type name. e.g. 'gguf.LlamaFileType.MOSTLY_Q8_0' --> 'Q8_0'
-        output_type: str = "NVFP4" if self._is_nvfp4 else self.ftype.name.partition("_")[2]
+        output_type: str = self.ftype.name.partition("_")[2]
 
         # Filename Output
         if self.fname_out.is_dir():

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -712,6 +712,7 @@ class ModelBase:
     def prepare_tensors(self):
         # detect NVFP4 quantization (ModelOpt format)
         quant_algo = (self.hparams.get("quantization_config") or {}).get("quant_algo")
+        quant_method = (self.hparams.get("quantization_config") or {}).get("quant_method")
         quant_layers = (self.hparams.get("quantization_config") or {}).get("quantized_layers") or {}
         quant_config_file = self.dir_model / "hf_quant_config.json"
 
@@ -728,6 +729,7 @@ class ModelBase:
                 quant_algo = "NVFP4"
 
         self._is_nvfp4 = quant_algo == "NVFP4"
+        self._is_mxfp4 = quant_method == "mxfp4"
 
         # NVFP4 weights are repacked and written directly to gguf_writer.
         # This must run before dequant_model so NVFP4 tensors are removed
@@ -11127,8 +11129,7 @@ class GptOssModel(TextModel):
 
     # TODO: remove once MXFP4 is supported more generally
     def dequant_model(self):
-        quant_config = self.hparams.get("quantization_config")
-        if quant_config is not None and quant_config.get("quant_method") == "mxfp4":
+        if self._is_mxfp4:
             return
         return super().dequant_model()
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -876,6 +876,9 @@ class ModelBase:
         if self.metadata.name is None:
             self.metadata.name = self.dir_model.name
 
+        if self._is_nvfp4 and self.model_name is None and self.metadata.name is not None and self.metadata.name.endswith(" BF16"):
+            self.metadata.name = f"{self.metadata.name[:-5]} NVFP4"
+
         # Generate parameter weight class (useful for leader boards) if not yet determined
         if self.metadata.size_label is None and total_params > 0:
             self.metadata.size_label = gguf.size_label(total_params, shared_params, expert_params, expert_count)
@@ -1016,7 +1019,7 @@ class TextModel(ModelBase):
 
         total_params = self.gguf_writer.get_total_parameter_count()[0]
         # Extract the encoding scheme from the file type name. e.g. 'gguf.LlamaFileType.MOSTLY_Q8_0' --> 'Q8_0'
-        output_type: str = self.ftype.name.partition("_")[2]
+        output_type: str = "NVFP4" if self._is_nvfp4 else self.ftype.name.partition("_")[2]
 
         # Filename Output
         if self.fname_out.is_dir():
@@ -1144,8 +1147,9 @@ class TextModel(ModelBase):
             self.gguf_writer.add_key_length(head_dim)
             self.gguf_writer.add_value_length(head_dim)
 
-        self.gguf_writer.add_file_type(self.ftype)
-        logger.info(f"gguf: file type = {self.ftype}")
+        file_type = gguf.LlamaFileType.MOSTLY_NVFP4 if self._is_nvfp4 else self.ftype
+        self.gguf_writer.add_file_type(file_type)
+        logger.info(f"gguf: file type = {file_type}")
 
     def write_vocab(self):
         if len(self.gguf_writer.tensors) != 1:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -145,6 +145,7 @@ class ModelBase:
         self.model_name = model_name
         self.dir_model_card = dir_model  # overridden in convert_lora_to_gguf.py
         self._is_nvfp4 = False
+        self._is_mxfp4 = False
 
         # Apply heuristics to figure out typical tensor encoding based on first tensor's dtype
         # NOTE: can't use field "torch_dtype" in config.json, because some finetunes lie.

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -3869,6 +3869,8 @@ class LlamaFileType(IntEnum):
     # MOSTLY_Q4_0_8_8      = 35  # removed from gguf files, use Q4_0 and runtime repack
     MOSTLY_TQ1_0         = 36  # except 1d tensors
     MOSTLY_TQ2_0         = 37  # except 1d tensors
+    MOSTLY_MXFP4_MOE     = 38  # except 1d tensors
+    MOSTLY_NVFP4         = 39  # except 1d tensors
 
     GUESSED              = 1024  # not specified in the model file
 


### PR DESCRIPTION
When converting an NVFP4 or MXFP4 HF model to GGUF, the default behavior is to keep the same name if not specified, so the converted models still are named <model name> BF16:

Before:
```
| model                          |     
| ------------------------------ | 
| qwen35 0.8B BF16               |
```
After:
```
| model                          |     
| ------------------------------ | 
| qwen35 0.8B NVFP4              |
```
  This script edit identifies the file type properly for both NVFP4 and MXFP4 and adds the missing MOSTLY_NVFP4 and missing MOSTLY_MXFP4_MOE from the table in the py constants file.
