### PR TITLE
fix: correct tokenizer2 to decode ids2 instead of ids1 in test-tokenizer-random.py

### DIFF
--- a/tests/test-tokenizer-random.py
+++ b/tests/test-tokenizer-random.py
@@ -449,7 +449,7 @@ def compare_tokenizers(tokenizer1: TokenizerGroundtruth, tokenizer2: TokenizerLl
         t2 = time.perf_counter()
         text1 = tokenizer1.decode(ids1)
         t3 = time.perf_counter()
-        text2 = tokenizer2.decode(ids1)
+        text2 = tokenizer2.decode(ids2)
         t4 = time.perf_counter()
         t_encode1 += t1 - t0
         t_encode2 += t2 - t1


### PR DESCRIPTION
## Description
The `compare_tokenizers` function in `tests/test-tokenizer-random.py` was incorrectly decoding `ids1` (the output of `tokenizer1.encode(text)`) with both tokenizers. This bug caused the decode comparison to always pass incorrectly since it was comparing the same encoded IDs.

## Fix
Changed line 452 from:
```python
text2 = tokenizer2.decode(ids1)
```
to:
```python
text2 = tokenizer2.decode(ids2)
```

This ensures that each tokenizer decodes its own output for accurate comparison.

## Testing
The fix ensures that when comparing tokenizer outputs, both the encode and decode operations are properly tested for each tokenizer.