### PR TITLE
common : add LLAMA_ARG_SPEC_TYPE

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3494,7 +3494,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 throw std::invalid_argument("unknown speculative decoding type without draft model");
             }
         }
-    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_TYPE"));
     add_opt(common_arg(
         {"--spec-ngram-size-n"}, "N",
         string_format("ngram size N for ngram-simple/ngram-map speculative decoding, length of lookup n-gram (default: %d)", params.speculative.ngram_size_n),


### PR DESCRIPTION
Allow specifying speculative decoding type via environment variable `LLAMA_ARG_SPEC_TYPE`.

ref #18471