### PR TITLE
convert : support is_causal hyperparameter

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1062,6 +1062,10 @@ class TextModel(ModelBase):
             self.gguf_writer.add_head_count_kv(n_head_kv)
             logger.info(f"gguf: key-value head count = {n_head_kv}")
 
+        if (causal_attention := self.find_hparam(["is_causal"], optional=True)) is not None:
+            self.gguf_writer.add_causal_attention(causal_attention)
+            logger.info(f"gguf: causal attention = {causal_attention}")
+
         # TODO: Handle "sliding_attention" similarly when models start implementing it
         rope_params = self.rope_parameters.get("full_attention", self.rope_parameters)
         if (rope_type := rope_params.get("rope_type")) is not None:

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1064,7 +1064,7 @@ class TextModel(ModelBase):
 
         if self.hparams.get("is_causal") is False:
             self.gguf_writer.add_causal_attention(False)
-            logger.info(f"gguf: causal attention = False")
+            logger.info("gguf: causal attention = False")
 
         # TODO: Handle "sliding_attention" similarly when models start implementing it
         rope_params = self.rope_parameters.get("full_attention", self.rope_parameters)

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1062,9 +1062,9 @@ class TextModel(ModelBase):
             self.gguf_writer.add_head_count_kv(n_head_kv)
             logger.info(f"gguf: key-value head count = {n_head_kv}")
 
-        if (causal_attention := self.find_hparam(["is_causal"], optional=True)) is not None:
-            self.gguf_writer.add_causal_attention(causal_attention)
-            logger.info(f"gguf: causal attention = {causal_attention}")
+        if self.hparams.get("is_causal") is False:
+            self.gguf_writer.add_causal_attention(False)
+            logger.info(f"gguf: causal attention = False")
 
         # TODO: Handle "sliding_attention" similarly when models start implementing it
         rope_params = self.rope_parameters.get("full_attention", self.rope_parameters)


### PR DESCRIPTION
Check for the `is_causal` attribute in the Hugging Face model configuration and include it in the GGUF metadata.

The transformers library added the 'is_causal' option in version 5.2.0, which enables all decoder-only models to function as encoders. It would be useful to link this option to the 'gguf_writer.add_causal_attention' method.

## Related PR

[Allow bi-directional attention for all models](https://github.com/huggingface/transformers/pull/43705)

## Related Docs

https://huggingface.co/docs/transformers/main/en/attention_interface#bidirectional-attention

Try using my model for testing. [mykor/pplx-embed-v1-0.6b](https://huggingface.co/mykor/pplx-embed-v1-0.6b)

