### PR TITLE
Fix KleidiAI FetchContent build failure on AGP CMake 3.22.1

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -572,9 +572,11 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
 
         set(KLEIDIAI_FETCH_ARGS
             URL ${KLEIDIAI_DOWNLOAD_URL}
-            DOWNLOAD_EXTRACT_TIMESTAMP NEW
             URL_HASH MD5=${KLEIDIAI_ARCHIVE_MD5}
         )
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+            list(APPEND KLEIDIAI_FETCH_ARGS DOWNLOAD_EXTRACT_TIMESTAMP NEW)
+        endif()
 
         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
             FetchContent_Declare(KleidiAI_Download


### PR DESCRIPTION
Using `GGML_CPU_KLEIDIAI=ON` with AGP (CMake 3.22.1) fails because `DOWNLOAD_EXTRACT_TIMESTAMP` is passed unconditionally (this is only supported in newer cmake).