### PR TITLE
fix: create_tensor returns non-null for missing TENSOR_NOT_REQUIRED tensors when using llama_model_init_from_user

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1174,8 +1174,17 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         if (flags & TENSOR_SKIP_IF_VIRTUAL) {
             return nullptr;
         }
-        ggml_type type = GGML_TYPE_F32;
         const int64_t tid = gguf_find_tensor(metadata, tn.str().c_str());
+
+        // when tensor is not found in metadata and not required, return nullptr
+        // this is needed for tied embeddings: output.weight shares token_embd.weight data,
+        // so output.weight is not present in the GGUF file. returning nullptr here allows
+        // the caller to fall through to the TENSOR_DUPLICATED branch.
+        if (tid == -1 && (flags & TENSOR_NOT_REQUIRED)) {
+            return nullptr;
+        }
+
+        ggml_type type = GGML_TYPE_F32;
         if (tid != -1) {
             type = gguf_get_tensor_type(metadata, tid);
         }


### PR DESCRIPTION
## Problem

When loading a model via `llama_model_init_from_user()` (i.e., the user-managed tensor data path where files is empty), the `create_tensor` function in `llama-model-loader.cpp` does not correctly handle the `TENSOR_NOT_REQUIRED` flag for tensors that are absent from the GGUF metadata.

Specifically, in the `if (files.empty())` branch, when `gguf_find_tensor()` returns `-1` (tensor not found in metadata), the code falls through and creates a tensor with a default type of `GGML_TYPE_F32`, returning a non-null pointer. This breaks the tied embeddings logic in `llama-model.cpp`:

```cpp
// llama-model.cpp
output = create_tensor(tn(LLM_TENSOR_OUTPUT, "weight"), {n_embd, n_vocab}, TENSOR_NOT_REQUIRED);

// if output is NULL, init from the input tok embed (tied embeddings)
if (output == NULL) {
    output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, TENSOR_DUPLICATED);
}
```

Many models (e.g., Qwen, LLaMA with tied embeddings) do not have a separate `output.weight` tensor in the GGUF file — they share `token_embd.weight` for both input embeddings and the output projection. The `TENSOR_NOT_REQUIRED` + `TENSOR_DUPLICATED` pattern above is designed to handle this: `create_tensor` should return `nullptr` when `output.weight` is missing, so the code falls through to the `TENSOR_DUPLICATED` branch which reuses `token_embd.weight`.

However, in the `files.empty()` path (used by `llama_model_init_from_user`), the missing tensor is incorrectly created as an F32 tensor instead of returning `nullptr`. This causes:

1. **Wrong tensor type**: The output tensor is created as F32 instead of the correct quantized type (e.g., Q4_K_M matching `token_embd.weight`).
2. **Uninitialized data**: The `set_tensor_data` callback cannot find `output.weight` in the GGUF metadata, so the tensor data is never populated.
3. **Incorrect inference results**: The model produces garbage output because the output projection layer has uninitialized weights.

## Fix

Add an early return of `nullptr` when `tid == -1` and `TENSOR_NOT_REQUIRED` is set, in the `files.empty()` branch of `create_tensor`:

```cpp
if (files.empty()) {
    if (flags & TENSOR_SKIP_IF_VIRTUAL) {
        return nullptr;
    }
    const int64_t tid = gguf_find_tensor(metadata, tn.str().c_str());

    // when tensor is not found in metadata and not required, return nullptr
    // this is needed for tied embeddings: output.weight shares token_embd.weight data,
    // so output.weight is not present in the GGUF file. returning nullptr here allows
    // the caller to fall through to the TENSOR_DUPLICATED branch.
    if (tid == -1 && (flags & TENSOR_NOT_REQUIRED)) {
        return nullptr;
    }

    // ... rest of the function
}
```

This makes the `files.empty()` path behave consistently with the normal file-based loading path, where `get_tensor_meta()` would return `nullptr` for a missing tensor, and `buft_for_tensor()` would then return `nullptr` when `TENSOR_NOT_REQUIRED` is set.

## Impact

- **Affected API**: `llama_model_init_from_user()` — the user-managed tensor data loading path
- **Affected models**: Any model with tied embeddings (shared `token_embd.weight` / `output.weight`), including LLaMA, Qwen, and many others
- **No impact on normal loading**: The normal file-based loading path (`llama_model_load_from_file`) is unaffected since `files` is not empty