### PR TITLE
Check granite hybrid expert count to set type as LLM_TYPE_7B_A1B or LLM_TYPE_1B

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2058,7 +2058,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
 
                 switch (hparams.n_embd) {
                     case 768: type = LLM_TYPE_350M; break;
-                    case 1536: type = (hparams.n_embd == 2048 ? LLM_TYPE_7B_A1B : LLM_TYPE_1B); break;
+                    case 1536: type = (hparams.n_expert == 64 ? LLM_TYPE_7B_A1B : LLM_TYPE_1B); break;
                     case 2048: case 2560: type = LLM_TYPE_3B; break;
                     case 4096: type = LLM_TYPE_32B; break;
                     default: type = LLM_TYPE_UNKNOWN;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2058,7 +2058,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
 
                 switch (hparams.n_embd) {
                     case 768: type = LLM_TYPE_350M; break;
-                    case 1536: type = (hparams.n_expert == 64 ? LLM_TYPE_7B_A1B : LLM_TYPE_1B); break;
+                    case 1536: type = (hparams.n_ff() == 512 ? LLM_TYPE_7B_A1B : LLM_TYPE_1B); break;
                     case 2048: case 2560: type = LLM_TYPE_3B; break;
                     case 4096: type = LLM_TYPE_32B; break;
                     default: type = LLM_TYPE_UNKNOWN;


### PR DESCRIPTION
Fix to log correctly if we are using LLM_TYPE_7B_A1B or LLM_TYPE_1B granite hybrid model.
Based on checking the number of _expert_count_ (https://ollama.com/ibm/granite4:1b-h/blobs/f29248184ca7, https://ollama.com/ibm/granite4:7b-a1b-h/blobs/491ba81786c4).

I have validated with the official GGUF [granite-4.0-h-1b-GGUF](https://huggingface.co/ibm-granite/granite-4.0-h-1b-GGUF) and [granite-4.0-h-tiny-GGUF](https://huggingface.co/ibm-granite/granite-4.0-h-tiny-GGUF).

**Before the fix**, for `granite-4.0-h-1b-GGUF` `llama-server` correctly reported:
```
print_info: model type            = 1B
print_info: model params          = 1.46 B
print_info: general.name          = Granite 4.0 H 1b
```

but for `granite-4.0-h-tiny-GGUF` it incorrectly reported `model type` as `1B`, instead of `7B.A1B`:
```
print_info: model type            = 1B
print_info: model params          = 6.94 B
print_info: general.name          = Granite 4.0 H Tiny
```

**After the fix**, model type is correctly reported for both, in particular for `granite-4.0-h-tiny-GGUF` :
```
print_info: model type            = 7B.A1B
print_info: model params          = 6.94 B
print_info: general.name          = Granite 4.0 H Tiny
```

Commands to reproduce:
```
./build/bin/llama-server -hf ibm-granite/granite-4.0-h-1b-GGUF:Q2_K 
./build/bin/llama-server -hf ibm-granite/granite-4.0-h-tiny-GGUF:Q2_K
```

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
