### PR TITLE
peg : return NEED_MORE_INPUT for partial delimiter match in LENIENT mode

### DIFF
--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -771,7 +771,14 @@ struct parser_executor {
             }
 
             if (match == trie::PARTIAL_MATCH) {
-                // Found a partial match extending to end of input, return everything before it
+                // Found a partial match extending to end of input, return everything before it.
+                // In LENIENT (streaming) mode, the partial delimiter match means we don't yet
+                // know whether this is actually the delimiter or just content that happens to
+                // start with the same characters (e.g. "<" partial-matching "</think>").
+                // Return NEED_MORE_INPUT so the AST node isn't marked as definitive.
+                if (ctx.is_lenient()) {
+                    return common_peg_parse_result(COMMON_PEG_PARSE_RESULT_NEED_MORE_INPUT, start_pos, pos);
+                }
                 return common_peg_parse_result(COMMON_PEG_PARSE_RESULT_SUCCESS, start_pos, pos);
             }
 


### PR DESCRIPTION
until() returned SUCCESS when a delimiter was partially matched at end
of input (e.g. '<' partial-matching '</think>'). In LENIENT (streaming)
mode this is incorrect: we don't yet know if the partial match will
complete or if it's just content that starts with the same characters.

Noticed while auditing streaming behavior for templates with
<think>...</think> reasoning tags. Model output containing '<'
(comparisons, HTML, code) would cause the until() parser to mark the
AST node as definitive when it should be tentative. Currently masked
by the outer sequence, but becomes observable when until() is terminal
in a sequence or when choice() selects a branch based on the SUCCESS.

Test:

  cmake -B build -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_TOOLS=OFF
  cmake --build build --target test-chat
  ./build/bin/test-chat" && git push --force origin fix-until-partial-match-lenient
