### PR TITLE
ai : do not run bash commands in the prompt

### DIFF
--- a/.github/workflows/ai-issues.yml
+++ b/.github/workflows/ai-issues.yml
@@ -26,7 +26,8 @@ jobs:
             {
               "bash": {
                 "*": "deny",
-                "gh issue*": "allow"
+                "gh issue*": "allow",
+                "gh search*": "allow"
               },
               "webfetch": "deny"
             }
@@ -38,11 +39,9 @@ jobs:
 
           Issue number: ${{ github.event.issue.number }}
 
-          Lookup the contents of the issue using the following `gh` command:
+          Lookup the contents of the issue using the following 'gh' command:
 
-          ```bash
           gh issue view ${{ github.event.issue.number }} --json title,body,url,number
-          ```
 
           Next, perform the following task and then post a SINGLE comment (if needed).
 
@@ -50,7 +49,7 @@ jobs:
 
           TASK : FIND RELATED ISSUES
 
-          Using the `gh` CLI tool, search through existing issues on Github.
+          Using the 'gh' CLI tool, search through existing issues on Github.
           Find related or similar issues to the newly created one and list them.
           Do not list the new issue itself (it is #${{ github.event.issue.number }}).
 
@@ -83,5 +82,5 @@ jobs:
             - Do not include the comment tags in your actual comment.
             - Post at most ONE comment combining all findings.
             - If you didn't find issues that are related enough, post nothing.
-            - You have access only to the `gh` CLI tool - don't try to use other tools.
+            - You have access only to the 'gh' CLI tool - don't try to use other tools.
           "


### PR DESCRIPTION
cont #20790 

The prompt for the agent was completely broken because the backticks that I added effectively executed the commands and placed their output inside the prompt text 😐 

Also allow `gh search`.