### PR TITLE
fix(opencl): free host buffers after MoE MXFP4 router table reorder

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -10960,6 +10960,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                 CL_CHECK(clReleaseMemObject(src1_sub_buffer));
                 CL_CHECK(clReleaseMemObject(buf_src1_image));
                 CL_CHECK(clReleaseMemObject(buf_src2));
+                free(host_src2);
+                free(host_src2_reorder);
                 return;
             } // else fallback to generic kernel
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -10916,7 +10916,9 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                             }
                         }
                     }
+                    free(host_src2);
                     buf_src2 = clCreateBuffer(backend_ctx->context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, ne20 * ne21 * 4 * num_tiles_per_expert * sizeof(short), host_src2_reorder, &status);
+                    free(host_src2_reorder);
                     CL_CHECK(status);
 
                     // set thread grid
@@ -10960,8 +10962,6 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                 CL_CHECK(clReleaseMemObject(src1_sub_buffer));
                 CL_CHECK(clReleaseMemObject(buf_src1_image));
                 CL_CHECK(clReleaseMemObject(buf_src2));
-                free(host_src2);
-                free(host_src2_reorder);
                 return;
             } // else fallback to generic kernel
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS


### PR DESCRIPTION
## Summary

In `ggml/src/ggml-opencl/ggml-opencl.cpp`, the MoE MXFP4 gemm path allocates two host buffers (`host_src2_reorder` and `host_src2`) to preprocess the router table, then copies the data into a CL buffer via `CL_MEM_COPY_HOST_PTR`. After the kernel launch, the CL memory objects are released but the two host `malloc` buffers are never freed.

This leaks `ne20 * ne21 * 4 * num_tiles_per_expert * sizeof(short)` + `ne21 * nb21` bytes on every MoE matmul dispatch on OpenCL/Adreno.

## Fix

Added `free(host_src2)` and `free(host_src2_reorder)` after the CL memory objects are released and before the `return`.

## AI Disclosure

The bug was identified using static analysis tooling with AI assistance (pattern matching for `malloc` without corresponding `free` in the same scope). The two-line fix was written by hand after reading the surrounding code to verify the buffers are not used after `clCreateBuffer` copies their contents.