### PR TITLE
docs: clarify machine translation ban [no ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If AI is used to generate any portion of the code, contributors must adhere to t
 1. Explicitly disclose the manner in which AI was employed.
 2. Perform a comprehensive manual review prior to submitting the pull request.
 3. Be prepared to explain every line of code they submitted when asked about it by a maintainer.
-4. It is **strictly prohibited** to use AI to write your posts for you (bug reports, feature requests, pull request descriptions, Github discussions, responding to humans, ...). **This includes machine translation of any kind.**
+4. It is **strictly prohibited** to use AI to write or edit your posts for you (bug reports, feature requests, pull request descriptions, Github discussions, responding to humans, ...). **This includes machine translation of any kind.**
 
 For more info, please refer to the [AGENTS.md](AGENTS.md) file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If AI is used to generate any portion of the code, contributors must adhere to t
 1. Explicitly disclose the manner in which AI was employed.
 2. Perform a comprehensive manual review prior to submitting the pull request.
 3. Be prepared to explain every line of code they submitted when asked about it by a maintainer.
-4. It is strictly prohibited to use AI to write your posts for you (bug reports, feature requests, pull request descriptions, Github discussions, responding to humans, ...).
+4. It is **strictly prohibited** to use AI to write your posts for you (bug reports, feature requests, pull request descriptions, Github discussions, responding to humans, ...). **This includes machine translation of any kind.**
 
 For more info, please refer to the [AGENTS.md](AGENTS.md) file.
 


### PR DESCRIPTION
This PR explicitly disallows the use of language models for machine translation. In the last few weeks it has happened multiple times that I was reviewing contributions where the posts seemed machine generated. Upon questioning the contributors replied that they used machine translation because their English is not good. But I would rather read poorly written English than to have to doubt whether or not the contained information is correct. So I think that we should clarify that machine translation of any kind is not permitted (since realistically a lot of services will be using language models nowadays).