### PR TITLE
Restore NVFP4 per-tensor scale precision 

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -1422,6 +1422,20 @@ extern "C" {
             struct ggml_tensor  * b,
             struct ggml_tensor  * ids);
 
+    GGML_API void ggml_mul_mat_add_scale(
+            struct ggml_tensor * a,
+            struct ggml_tensor * scale);
+
+    GGML_API const struct ggml_tensor * ggml_mul_mat_get_scale(
+            const struct ggml_tensor * a);
+
+    GGML_API void ggml_mul_mat_id_add_scale(
+            struct ggml_tensor * a,
+            struct ggml_tensor * scale);
+
+    GGML_API const struct ggml_tensor * ggml_mul_mat_id_get_scale(
+            const struct ggml_tensor * a);
+
     // A: m columns, n rows,
     // B: p columns, n rows,
     // result is m columns, p rows

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -1222,6 +1222,16 @@ static void ggml_compute_forward_mul_mat_one_chunk(
 
                 for (int64_t ir0 = iir0; ir0 < iir0 + blck_0 && ir0 < ir0_end; ir0 += num_rows_per_vec_dot) {
                     vec_dot(ne00, &tmp[ir0 - iir0], (num_rows_per_vec_dot > 1 ? 16 : 0), src0_row + ir0 * nb01, (num_rows_per_vec_dot > 1 ? nb01 : 0), src1_col, (num_rows_per_vec_dot > 1 ? src1_col_stride : 0), num_rows_per_vec_dot);
+
+                    // NVFP4's per tensor scale needs to be applied with the vecdot
+                    // this should be put into a future traits based approach to be cleaner
+                    if (src0->type == GGML_TYPE_NVFP4 && dst->src[2]) {
+                        float nvfp4_t_s = ((const float *) dst->src[2]->data)[0];
+                        if (dst->src[2]->ne[0] > 1) {
+                            nvfp4_t_s = ((const float *) dst->src[2]->data)[i02];
+                        }
+                        tmp[ir0 - iir0] = tmp[ir0 - iir0] * nvfp4_t_s;
+                    }
                 }
 
                 for (int cn = 0; cn < num_rows_per_vec_dot; ++cn) {
@@ -1490,6 +1500,14 @@ static void ggml_compute_forward_mul_mat_id_one_chunk(
 
                 for (int64_t ir0 = iir0; ir0 < iir0 + blck_0 && ir0 < ir0_end; ++ir0) {
                     vec_dot(ne00, &tmp[ir0 - iir0], 0, src0_cur + ir0*nb01, 0, src1_col, 0, 1);
+
+                    if (src0->type == GGML_TYPE_NVFP4 && dst->src[3]) {
+                        float nvfp4_t_s = ((const float *) dst->src[3]->data)[0];
+                        if (dst->src[3]->ne[0] > 1) {
+                            nvfp4_t_s = ((const float *) dst->src[3]->data)[cur_a];
+                        }
+                        tmp[ir0 - iir0] = tmp[ir0 - iir0] * nvfp4_t_s;
+                    }
                 }
 
                 memcpy(&dst_col[iir0], tmp, (MIN(iir0 + blck_0, ir0_end) - iir0)*sizeof(float));

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -1225,10 +1225,10 @@ static void ggml_compute_forward_mul_mat_one_chunk(
 
                     // NVFP4's per tensor scale needs to be applied with the vecdot
                     // this should be put into a future traits based approach to be cleaner
-                    if (src0->type == GGML_TYPE_NVFP4 && dst->src[2]) {
-                        float nvfp4_t_s = ((const float *) dst->src[2]->data)[0];
-                        if (dst->src[2]->ne[0] > 1) {
-                            nvfp4_t_s = ((const float *) dst->src[2]->data)[i02];
+                    if (src0->type == GGML_TYPE_NVFP4) {
+                        float nvfp4_t_s = ((const float *) ggml_mul_mat_get_scale(dst)->data)[0];
+                        if (ggml_mul_mat_get_scale(dst)->ne[0] > 1) {
+                            nvfp4_t_s = ((const float *) ggml_mul_mat_get_scale(dst)->data)[i02];
                         }
                         tmp[ir0 - iir0] = tmp[ir0 - iir0] * nvfp4_t_s;
                     }
@@ -1501,10 +1501,10 @@ static void ggml_compute_forward_mul_mat_id_one_chunk(
                 for (int64_t ir0 = iir0; ir0 < iir0 + blck_0 && ir0 < ir0_end; ++ir0) {
                     vec_dot(ne00, &tmp[ir0 - iir0], 0, src0_cur + ir0*nb01, 0, src1_col, 0, 1);
 
-                    if (src0->type == GGML_TYPE_NVFP4 && dst->src[3]) {
-                        float nvfp4_t_s = ((const float *) dst->src[3]->data)[0];
-                        if (dst->src[3]->ne[0] > 1) {
-                            nvfp4_t_s = ((const float *) dst->src[3]->data)[cur_a];
+                    if (src0->type == GGML_TYPE_NVFP4) {
+                        float nvfp4_t_s = ((const float *) ggml_mul_mat_id_get_scale(dst)->data)[0];
+                        if (ggml_mul_mat_id_get_scale(dst)->ne[0] > 1) {
+                            nvfp4_t_s = ((const float *) ggml_mul_mat_id_get_scale(dst)->data)[cur_a];
                         }
                         tmp[ir0 - iir0] = tmp[ir0 - iir0] * nvfp4_t_s;
                     }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -3280,6 +3280,28 @@ struct ggml_tensor * ggml_mul_mat_id(
     return result;
 }
 
+GGML_API void ggml_mul_mat_add_scale(
+        struct ggml_tensor * a,
+        struct ggml_tensor * scale) {
+    a->src[2] = scale;
+}
+
+GGML_API const struct ggml_tensor * ggml_mul_mat_get_scale(
+        const struct ggml_tensor * a) {
+    return a->src[2];
+}
+
+GGML_API void ggml_mul_mat_id_add_scale(
+        struct ggml_tensor * a,
+        struct ggml_tensor * scale) {
+    a->src[3] = scale;
+}
+
+GGML_API const struct ggml_tensor * ggml_mul_mat_id_get_scale(
+        const struct ggml_tensor * a) {
+    return a->src[3];
+}
+
 // ggml_out_prod
 
 static inline bool ggml_can_out_prod(const struct ggml_tensor * t0, const struct ggml_tensor * t1) {

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -904,7 +904,7 @@ ggml_tensor * llm_graph_context::build_lora_mm(
           ggml_tensor * w_s) const {
     ggml_tensor * res = ggml_mul_mat(ctx0, w, cur);
     if (w_s && w->type == GGML_TYPE_NVFP4) {
-        res->src[2] = w_s; // Save the NVFP4 per tensor scale so it can be applied earlier to vecdot
+        ggml_mul_mat_add_scale(res, w_s); // Save the NVFP4 per tensor scale so it can be applied earlier to vecdot
         w_s = nullptr; // Clear the scale so it doesnt get applied here, to preserve precision
     }
 
@@ -1416,7 +1416,7 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
         // separate gate and up path
         up = build_lora_mm_id(up_exps, cur, selected_experts); // [n_ff, n_expert_used, n_tokens]
         if (up_exps->type == GGML_TYPE_NVFP4) {
-            up->src[3] = up_exps_s; // Save the expert tensor scale 
+            ggml_mul_mat_id_add_scale(up, up_exps_s); // Save the expert tensor scale
             up_exps_s = nullptr; // Clear so it doesn't get applied here, to avoid precision loss
         }
         cb(up, "ffn_moe_up", il);
@@ -1438,7 +1438,7 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
         if (gate_exps) {
             cur = build_lora_mm_id(gate_exps, cur, selected_experts); // [n_ff, n_expert_used, n_tokens]
             if (gate_exps->type == GGML_TYPE_NVFP4) {
-                cur->src[3] = gate_exps_s;
+                ggml_mul_mat_id_add_scale(cur, gate_exps_s);
                 gate_exps_s = nullptr;
             }
             cb(cur, "ffn_moe_gate", il);
@@ -1532,7 +1532,7 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
 
     experts = build_lora_mm_id(down_exps, cur, selected_experts); // [n_embd, n_expert_used, n_tokens]
     if (down_exps->type == GGML_TYPE_NVFP4) {
-        experts->src[3] = down_exps_s;
+        ggml_mul_mat_id_add_scale(experts, down_exps_s);
         down_exps_s = nullptr;
     }
     cb(experts, "ffn_moe_down", il);

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -903,6 +903,10 @@ ggml_tensor * llm_graph_context::build_lora_mm(
           ggml_tensor * cur,
           ggml_tensor * w_s) const {
     ggml_tensor * res = ggml_mul_mat(ctx0, w, cur);
+    if (w_s && w->type == GGML_TYPE_NVFP4) {
+        res->src[2] = w_s; // Save the NVFP4 per tensor scale so it can be applied earlier to vecdot
+        w_s = nullptr; // Clear the scale so it doesnt get applied here, to preserve precision
+    }
 
     for (const auto & lora : *loras) {
         llama_adapter_lora_weight * lw = lora.first->get_weight(w);
@@ -1007,7 +1011,13 @@ ggml_tensor * llm_graph_context::build_ffn(
      llm_ffn_op_type   type_op,
    llm_ffn_gate_type   type_gate,
                  int   il) const {
-    ggml_tensor * tmp = up ? build_lora_mm(up, cur) : cur;
+    ggml_tensor * tmp = cur;
+    if (up && up->type == GGML_TYPE_NVFP4) {
+        tmp = build_lora_mm(up, cur, up_s);
+        up_s = nullptr;
+    } else if (up) {
+        tmp = build_lora_mm(up, cur);
+    }
     cb(tmp, "ffn_up", il);
 
     if (up_b) {
@@ -1024,12 +1034,22 @@ ggml_tensor * llm_graph_context::build_ffn(
         switch (type_gate) {
             case LLM_FFN_SEQ:
                 {
-                    cur = build_lora_mm(gate, tmp);
+                    if (gate->type == GGML_TYPE_NVFP4) {
+                        cur = build_lora_mm(gate, tmp, gate_s);
+                        gate_s = nullptr;
+                    } else {
+                        cur = build_lora_mm(gate, tmp);
+                    }
                     cb(cur, "ffn_gate", il);
                 } break;
             case LLM_FFN_PAR:
                 {
-                    cur = build_lora_mm(gate, cur);
+                    if (gate->type == GGML_TYPE_NVFP4) {
+                        cur = build_lora_mm(gate, cur, gate_s);
+                        gate_s = nullptr;
+                    } else {
+                        cur = build_lora_mm(gate, cur);
+                    }
                     cb(cur, "ffn_gate", il);
                 } break;
         }
@@ -1133,7 +1153,12 @@ ggml_tensor * llm_graph_context::build_ffn(
     }
 
     if (down) {
-        cur = build_lora_mm(down, cur);
+        if (down->type == GGML_TYPE_NVFP4) {
+            cur = build_lora_mm(down, cur, down_s);
+            down_s = nullptr;
+        } else {
+            cur = build_lora_mm(down, cur);
+        }
         if (arch == LLM_ARCH_GLM4 || arch == LLM_ARCH_GLM4_MOE || arch == LLM_ARCH_JAIS2) {
             // GLM4, GLM4_MOE, and JAIS2 seem to have numerical issues with half-precision accumulators
             ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
@@ -1390,6 +1415,10 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
     } else {
         // separate gate and up path
         up = build_lora_mm_id(up_exps, cur, selected_experts); // [n_ff, n_expert_used, n_tokens]
+        if (up_exps->type == GGML_TYPE_NVFP4) {
+            up->src[3] = up_exps_s; // Save the expert tensor scale 
+            up_exps_s = nullptr; // Clear so it doesn't get applied here, to avoid precision loss
+        }
         cb(up, "ffn_moe_up", il);
 
         if (up_exps_b) {
@@ -1408,6 +1437,10 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
 
         if (gate_exps) {
             cur = build_lora_mm_id(gate_exps, cur, selected_experts); // [n_ff, n_expert_used, n_tokens]
+            if (gate_exps->type == GGML_TYPE_NVFP4) {
+                cur->src[3] = gate_exps_s;
+                gate_exps_s = nullptr;
+            }
             cb(cur, "ffn_moe_gate", il);
         } else {
             cur = up;
@@ -1498,6 +1531,10 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
     }
 
     experts = build_lora_mm_id(down_exps, cur, selected_experts); // [n_embd, n_expert_used, n_tokens]
+    if (down_exps->type == GGML_TYPE_NVFP4) {
+        experts->src[3] = down_exps_s;
+        down_exps_s = nullptr;
+    }
     cb(experts, "ffn_moe_down", il);
 
     if (down_exps_b) {


### PR DESCRIPTION
This PR is a pre-requisite for the  PR [https://github.com/ggml-org/llama.cpp/pull/20644](https://github.com/ggml-org/llama.cpp/pull/20644) which will introduce basic CUDA support (mmvq/dp4a only) for NVFP4. 
NVFP4 is currently unique in that it has a dual scaling design using a float scale per tensor in addition to the per-subblock scale.  
These NVFP4 tensor scales are critical with 4-bit NVFP4 being low precision, and they need to be part of the initial weight interpretation at the first `ggml_mul_mat`.
The current implementation is applying some tensor scales through `build_lora_mm` and `build_lora_mm_id`:
```
res = ggml_mul(ctx0, res, w_s);`
```
This effectively means NVFP4's per-tensor scale is applied **after** the entire _mul_mat_ is complete.  But that is not OK: the late application loses precision because the operation is done just once after accumulation.  Effectively, to get the most precision, the 4-bit weight needs the full 32-bit tensor scale applied to it without any loss of precision of that tensor scale itself.
This PR changes the application of the NVFP4 per tensor scale so it can be applied **as part of** the _mul_mat_.
It does this by saving the tensor scale in `build_lora_mm` to `src[2]` ([3] for ids) so that it's not lost and can be used later at the time of the vec_dot:

```
float nvfp4_t_s = ((const float *) dst->src[2]->data)[0];
if (dst->src[2]->ne[0] > 1) {
  nvfp4_t_s = ((const float *) dst->src[2]->data)[i02];
 }
tmp[ir0 - iir0] = tmp[ir0 - iir0] * nvfp4_t_s;
```

On the CPU version of NVFP4, there is no significant observed difference with this fix, but it makes a very significant difference on GPU with the F16 path, and even more significantly with models like Qwen3.5 and Nemotron that have special experts:

| Test| Baseline | After fix | Change |
| --- | ---: | ---: | --- |
| Runtime CPU capture RMS | 0.00377982258 | 0.00377982791 | +0.00% |
| Q8 float accumulation RMS | 0.00377982258 | 0.00377982791 | +0.00% |
| F16 accumulation RMS | inf | 0.0059391915 | Stops Overflow  |
| F32 accumulation RMS | 0.000148721874 | 0.000217344128 | +46% (Normal GPU) |
| dot magnitude   | 71785.6172 | 12.3097782 | Normal |

On Qwen3.5-0.8B:
```
After accmulation:
- attn_qkv:  baseline16_rms=inf, fix_f16_rms=0.386774
- attn_gate: baseline16_rms=inf, fix_f16_rms=0.0511276
- ssm_out:  baseline16_rms=inf, fix_f16_rms=0.403415
- ssm_alpha: baseline16_rms=inf, fix_f16_rms=0.0546128
- ssm_beta:  baseline16_rms=inf, fix_f16_rms=0.0458366

F16 conversions would result in unscaled exact dot of about -71785.6 causing _inf_ and exceeding half_max_finite=65504

Baseline CPU:
- Mean PPL(Q)   = 21.000743
- Mean KLD      = 0.094119
- Maximum KLD   = 7.885083
- RMS Delta p   = 7.233
- Same top p    = 84.245%
Fix CPU:
--Tested only for 8 chunks:100% equivalence
(Full kld via cpu >12 hours and previously done with near-identical pre-PR))

Fix CUDA: 
- Mean PPL(Q)   = 21.007698
- Mean KLD      = 0.093654
- Maximum KLD   = 7.336067
- RMS Delta p   = 7.223
- Same top p    = 84.337%
```
For Qwen3.5-0.8B-Base:
```
Baseline (CUDA):
Mean PPL(Q) = 16.354339
Mean KLD = 0.164407
Maximum KLD = 12.685198
RMS Δp = 10.490
Same top p = 79.721%

Fix (CUDA):
Mean PPL(Q) = 15.226978
Mean PPL(base) = 13.932563
Mean KLD = 0.088797
Maximum KLD = 5.984150
RMS Δp = 7.439
Same top p = 84.707%
```

For Qwen3-4B:
```
Baseline CUDA:
- Mean PPL(Q)   = 15.508894
- Mean KLD      = 0.566403
- Maximum KLD   = 31.852549
- RMS Delta p   = 20.417
- Same top p    = 72.481%

With fix CUDA:
- Mean PPL(Q)   = 14.936430
- Mean KLD      = 0.522256
- Maximum KLD   = 31.771683
- RMS Delta p   = 19.369
- Same top p    = 73.774%
```
Also tested with Qwen3.5-35B, Qwen3.5-27B, Nemotron3-30B, Polaris-4B.
Anecdotally, the conversations with the models also seem "better", with Qwen3.5 in particular giving answers closer to the BF16 model with more emojis and less terseness.

This fix could be better integrated without branching specifically for NVFP4, but it would require more re-work and a bigger refactor to find a place to store and apply the per-tensor scales, as currently there is no easy way to do this without either having a separate `ggml_vec_dot_t` or changing args that would affect every other quant as well as where to save the scale.
AI assistance and code was used write the in-run test functions to capture RMS (not included) and help evaluate the error and clean up my code under my direction.