### PR TITLE
server: add reset_idle_timer flag to server_task

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1704,6 +1704,8 @@ Note that the following endpoints are exempt from being considered as incoming t
 - `GET /health`
 - `GET /props`
 - `GET /models`
+- `GET /metrics`
+- `GET /slots`
 
 ## More examples
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3289,7 +3289,7 @@ void server_routes::init_routes() {
     };
 
     this->get_metrics = [this](const server_http_req & req) {
-        auto res = create_response();
+        auto res = create_response(true); // bypass sleep; must not reset idle timer
         if (!params.endpoint_metrics) {
             res->error(format_error_response("This server does not support metrics endpoint. Start it with `--metrics`", ERROR_TYPE_NOT_SUPPORTED));
             return res;
@@ -3299,6 +3299,7 @@ void server_routes::init_routes() {
         {
             server_task task(SERVER_TASK_TYPE_METRICS);
             task.id = res->rd.get_new_id();
+            task.reset_idle_timer = false;
             res->rd.post_task(std::move(task), true); // high-priority task
         }
 
@@ -3394,7 +3395,7 @@ void server_routes::init_routes() {
     };
 
     this->get_slots = [this](const server_http_req & req) {
-        auto res = create_response();
+        auto res = create_response(true); // bypass sleep; must not reset idle timer
         if (!params.endpoint_slots) {
             res->error(format_error_response("This server does not support slots endpoint. Start it with `--slots`", ERROR_TYPE_NOT_SUPPORTED));
             return res;
@@ -3404,6 +3405,7 @@ void server_routes::init_routes() {
         {
             server_task task(SERVER_TASK_TYPE_METRICS);
             task.id = res->rd.get_new_id();
+            task.reset_idle_timer = false;
             res->rd.post_task(std::move(task), true); // high-priority task
         }
 

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -27,19 +27,23 @@ int server_queue::post(server_task && task, bool front) {
         cleanup_pending_task(task.id_target);
     }
     const int task_id = task.id;
+    const bool should_reset_idle = task.reset_idle_timer;
     QUE_DBG("new task, id = %d, front = %d\n", task_id, front);
     if (front) {
         queue_tasks.push_front(std::move(task));
     } else {
         queue_tasks.push_back(std::move(task));
     }
-    time_last_task = ggml_time_ms();
+    if (should_reset_idle) {
+        time_last_task = ggml_time_ms();
+    }
     condition_tasks.notify_one();
     return task_id;
 }
 
 int server_queue::post(std::vector<server_task> && tasks, bool front) {
     std::unique_lock<std::mutex> lock(mutex_tasks);
+    bool should_reset_idle = false;
     for (auto & task : tasks) {
         if (task.id == -1) {
             task.id = id++;
@@ -49,13 +53,18 @@ int server_queue::post(std::vector<server_task> && tasks, bool front) {
             cleanup_pending_task(task.id_target);
         }
         QUE_DBG("new task, id = %d/%d, front = %d\n", task.id, (int) tasks.size(), front);
+        if (task.reset_idle_timer) {
+            should_reset_idle = true;
+        }
         if (front) {
             queue_tasks.push_front(std::move(task));
         } else {
             queue_tasks.push_back(std::move(task));
         }
     }
-    time_last_task = ggml_time_ms();
+    if (should_reset_idle) {
+        time_last_task = ggml_time_ms();
+    }
     condition_tasks.notify_one();
     return 0;
 }
@@ -63,8 +72,11 @@ int server_queue::post(std::vector<server_task> && tasks, bool front) {
 void server_queue::defer(server_task && task) {
     std::unique_lock<std::mutex> lock(mutex_tasks);
     QUE_DBG("defer task, id = %d\n", task.id);
+    const bool should_reset_idle = task.reset_idle_timer;
     queue_tasks_deferred.push_back(std::move(task));
-    time_last_task = ggml_time_ms();
+    if (should_reset_idle) {
+        time_last_task = ggml_time_ms();
+    }
     condition_tasks.notify_one();
 }
 
@@ -76,12 +88,14 @@ int server_queue::get_new_id() {
 
 void server_queue::pop_deferred_task(int id_slot) {
     std::unique_lock<std::mutex> lock(mutex_tasks);
+    bool should_reset_idle = false;
     if (!queue_tasks_deferred.empty()) {
         // try to find a task that uses the specified slot
         bool found = false;
         for (auto it = queue_tasks_deferred.begin(); it != queue_tasks_deferred.end(); ++it) {
             if (it->id_slot == id_slot) {
                 QUE_DBG("pop deferred task (use slot %d), id_task = %d\n", id_slot, it->id);
+                should_reset_idle = it->reset_idle_timer;
                 queue_tasks.emplace_front(std::move(*it));
                 queue_tasks_deferred.erase(it);
                 found = true;
@@ -90,12 +104,15 @@ void server_queue::pop_deferred_task(int id_slot) {
         }
         // if not tasks found using the slot, just pop the first deferred task (default behavior)
         if (!found) {
+            should_reset_idle = queue_tasks_deferred.front().reset_idle_timer;
             QUE_DBG("pop deferred task, id_task = %d\n", queue_tasks_deferred.front().id);
             queue_tasks.emplace_front(std::move(queue_tasks_deferred.front()));
             queue_tasks_deferred.pop_front();
         }
     }
-    time_last_task = ggml_time_ms();
+    if (should_reset_idle) {
+        time_last_task = ggml_time_ms();
+    }
     condition_tasks.notify_one();
 }
 
@@ -139,6 +156,7 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
     while (true) {
         QUE_DBG("%s", "processing new tasks\n");
 
+        bool should_reset_idle = false;
         while (true) {
             std::unique_lock<std::mutex> lock(mutex_tasks);
             if (!running) {
@@ -154,6 +172,9 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
             lock.unlock();
 
             QUE_DBG("processing task, id = %d\n", task.id);
+            if (task.reset_idle_timer) {
+                should_reset_idle = true;
+            }
             callback_new_task(std::move(task));
         }
         // all tasks in the current loop is processed, slots data is now ready
@@ -161,7 +182,7 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
 
         // this will run the main inference process for all slots
         callback_update_slots();
-        {
+        if (should_reset_idle) {
             // update_slots() may take a while to finish, we need to make sure it's not counted as idle
             std::unique_lock<std::mutex> lock(mutex_tasks);
             time_last_task = ggml_time_ms();

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -164,6 +164,8 @@ struct server_task {
     // used by SERVER_TASK_TYPE_METRICS
     bool metrics_reset_bucket = false;
 
+    bool reset_idle_timer = true;
+
     // used by SERVER_TASK_TYPE_SET_LORA
     std::map<int, float> set_lora; // mapping adapter ID -> scale
 

--- a/tools/server/tests/unit/test_sleep.py
+++ b/tools/server/tests/unit/test_sleep.py
@@ -37,3 +37,47 @@ def test_server_sleep():
     res = server.make_request("GET", "/props")
     assert res.status_code == 200
     assert res.body["is_sleeping"] == False
+
+
+def test_metrics_does_not_reset_idle_timer():
+    global server
+    server.sleep_idle_seconds = 2
+    server.server_metrics = True
+    server.start()
+
+    # wait until just before sleep threshold
+    time.sleep(1)
+
+    # query metrics - should NOT reset the idle timer
+    res = server.make_request("GET", "/metrics")
+    assert res.status_code == 200
+
+    # wait for the remaining time so total elapsed > sleep threshold
+    time.sleep(2)
+
+    # server should be sleeping because metrics did not reset the timer
+    res = server.make_request("GET", "/props")
+    assert res.status_code == 200
+    assert res.body["is_sleeping"] == True
+
+
+def test_slots_does_not_reset_idle_timer():
+    global server
+    server.sleep_idle_seconds = 2
+    server.server_slots = True
+    server.start()
+
+    # wait until just before sleep threshold
+    time.sleep(1)
+
+    # query slots - should NOT reset the idle timer
+    res = server.make_request("GET", "/slots")
+    assert res.status_code == 200
+
+    # wait for the remaining time so total elapsed > sleep threshold
+    time.sleep(2)
+
+    # server should be sleeping because slots did not reset the timer
+    res = server.make_request("GET", "/props")
+    assert res.status_code == 200
+    assert res.body["is_sleeping"] == True


### PR DESCRIPTION
This fixes issue #20227 where querying the `/metrics` endpoint would prevent the server from going to sleep, making the  `--sleep-idle-seconds` ineffective when monitoring llama.cpp with e.g Prometheus.

My PR adds a new `reset_idle_timer` field to `server_task` (defaults to true for backwards compatibility). When handlers for `/metrics` and `/slots` create their tasks, they now set this to false so those requests don't count as activity that would reset the sleep timer.

Full disclosure: it's been a while since I've written C++ and I leaned on a coding agent to help review my changes.