### PR TITLE
fix(openvino): explicit memset in buffer_context allocation

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -97,6 +97,9 @@ struct ggml_backend_openvino_buffer_context {
             ov_buffer = std::make_shared<ov::intel_gpu::ocl::USMTensor>(std::move(usm_tensor));
         } else {
             data = ggml_aligned_malloc(size);
+            if (data != nullptr) {
+                memset(data, 0, size);
+            }
             ov_buffer = std::make_shared<ov::Tensor>(ov::element::u8, ov::Shape{size}, data);
         }
 

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -97,9 +97,8 @@ struct ggml_backend_openvino_buffer_context {
             ov_buffer = std::make_shared<ov::intel_gpu::ocl::USMTensor>(std::move(usm_tensor));
         } else {
             data = ggml_aligned_malloc(size);
-            if (data != nullptr) {
-                memset(data, 0, size);
-            }
+            GGML_ASSERT(data);
+            memset(data, 0, size);
             ov_buffer = std::make_shared<ov::Tensor>(ov::element::u8, ov::Shape{size}, data);
         }
 


### PR DESCRIPTION
This was causing a variety of Valgrind errors when running locally. Weight-tensor initialization seems to be done via a copy from the GGUF, but non-weight tensor information is done via copies from uninitialized memory. The initialization right here is pretty defensive, but it solves the issue on my end at least