### PR TITLE
fix(server): Print free memory as a signed integer to indicate VRAM spillover into host memory

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3550,7 +3550,7 @@ void llama_memory_breakdown_print(const struct llama_context * ctx) {
             template_gpu,
             "  - " + name + " (" + desc + ")",
             std::to_string(total / MiB),
-            std::to_string(free / MiB),
+            std::to_string(static_cast<int64_t>(free) / static_cast<int64_t>(MiB)),
             std::to_string(self / MiB),
             std::to_string(mb.model / MiB),
             std::to_string(mb.context / MiB),


### PR DESCRIPTION
## Summary

Exceeding VRAM usage with the Vulkan backend causes the free memory statistic printed upon termination to underflow, resulting in something like:

```console
^Csrv    operator(): operator(): cleaning up before exit...
llama_memory_breakdown_print: | memory breakdown [MiB]                  | total            free     self   model   context   compute    unaccounted |
llama_memory_breakdown_print: |   - Vulkan0 (RX 9060 XT (RADV GFX1200)) | 16304 = 17592186039468 + (21233 = 18856 +    1837 +     540) +          17 |
llama_memory_breakdown_print: |   - Host                                |                           29477 = 29341 +       0 +     136                |
```

This is because the free memory statistic is the result of subtracting the used heap memory from the total memory (which is smaller): https://github.com/ggml-org/llama.cpp/blob/3306dbaef7553da03971c617e48cd27d00328bb4/ggml/src/ggml-vulkan/ggml-vulkan.cpp#L15030

## Fix

As a workaround, print just the free memory as a signed value. The calculation above is still valid and its magnitude will be the amount spilled into host memory, like so:

```console
^Csrv    operator(): operator(): cleaning up before exit...
llama_memory_breakdown_print: | memory breakdown [MiB]                  | total   freee     self   model   context   compute    unaccounted |
llama_memory_breakdown_print: |   - Vulkan0 (RX 9060 XT (RADV GFX1200)) | 16304 = -4947 + (21233 = 18856 +    1837 +     540) +          17 |
llama_memory_breakdown_print: |   - Host                                |                  29477 = 29341 +       0 +     136                |
```

## AI disclosure

AI was used to localize the bug, and the fix was written by hand.