### PR TITLE
ggml: Vulkan build -- output error string for errno on fork failure (#20868)

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -137,6 +137,7 @@ void execute_command(std::vector<std::string>& command, std::string& stdout_str,
 
     pid_t pid = fork();
     if (pid < 0) {
+        std::cerr << strerror(errno) << "\n";
         throw std::runtime_error("Failed to fork process");
     }
 


### PR DESCRIPTION
This is a one-line change to `ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp`:
```
     if (pid < 0) {
+        std::cerr << strerror(errno) << "\n";
         throw std::runtime_error("Failed to fork process");
     }
```
Outputting `strerror(errno) ` to standard error is done elsewhere in this file, so it's not introducing any new mechanics.

This changes the build message from a fork failure from this:
```
      [ 15%] Generate vulkan shaders for mul_mm.comp
      Error executing command for matmul_id_subgroup_q8_0_f32_aligned_fp32: Failed to fork process
      Error executing command for matmul_id_subgroup_q8_0_f16_fp32: Failed to fork process
      [..]
```
To this:
```
      [  2%] Generate vulkan shaders for mul_mm.comp
      Cannot allocate memory
      Error executing command for matmul_id_subgroup_q4_k_f16_fp32: Failed to fork process
      Cannot allocate memory
      Error executing command for matmul_id_subgroup_q4_k_f16_aligned_fp32: Failed to fork process
      [..]
```
I tested this with a full build that completes, as well as a build that fails with not enough memory (4 GB in a virtual machine).