### PR TITLE
RPC GRAPH_COMPUTE Arbitrary RCE patch

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1443,7 +1443,9 @@ ggml_tensor * rpc_server::create_node(uint64_t id,
     const rpc_tensor * tensor = it_ptr->second;
 
     struct ggml_tensor * result = deserialize_tensor(ctx, tensor);
-    if (result == nullptr) {
+    if (result == nullptr || result->buffer == nullptr) {
+        GGML_LOG_ERROR("[%s] invalid tensor: null %s (id=%" PRIu64 ")\n",
+                       __func__, result == nullptr ? "tensor" : "buffer", id);
         return nullptr;
     }
     tensor_map[id] = result;


### PR DESCRIPTION
This fix prevents an existing RCE chain where deserialize_tensor() skips all validations when the incoming rpce_tensor.buffer field is set to null. Currently we only check if result==null, however this does not sufficiently cover the case for result->buffer. This prevents attackers from gaining arbitrary read and write. 