### PR TITLE
jinja: fix a bug that empty expressions can trigger null binding in jinja parser (#20911)

### DIFF
--- a/common/jinja/parser.cpp
+++ b/common/jinja/parser.cpp
@@ -540,7 +540,7 @@ private:
             return mk_stmt<slice_expression>(start_pos, std::move(start), std::move(stop), std::move(step));
         }
         if (slices.empty()) {
-            return mk_stmt<noop_statement>(start_pos);
+            return mk_stmt<blank_expression>(start_pos);
         }
         return std::move(slices[0]);
     }

--- a/common/jinja/parser.cpp
+++ b/common/jinja/parser.cpp
@@ -539,6 +539,9 @@ private:
             statement_ptr step = slices.size() > 2 ? std::move(slices[2]) : nullptr;
             return mk_stmt<slice_expression>(start_pos, std::move(start), std::move(stop), std::move(step));
         }
+        if (slices.empty()) {
+            throw parser_exception("Empty member expression arguments", source, peek().pos);
+        }
         return std::move(slices[0]);
     }
 

--- a/common/jinja/parser.cpp
+++ b/common/jinja/parser.cpp
@@ -540,7 +540,7 @@ private:
             return mk_stmt<slice_expression>(start_pos, std::move(start), std::move(stop), std::move(step));
         }
         if (slices.empty()) {
-            throw parser_exception("Empty member expression arguments", source, peek().pos);
+            return mk_stmt<noop_statement>(start_pos);
         }
         return std::move(slices[0]);
     }

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -746,10 +746,6 @@ value member_expression::execute_impl(context & ctx) {
             return slice_func->invoke(args);
         } else {
             property = this->property->execute(ctx);
-            if (property->is_undefined()) {
-                JJ_DEBUG("%s", "Computed member property is undefined, returning undefined");
-                return mk_val<value_undefined>("object_property");
-            }
         }
     } else {
         // syntax: obj.prop
@@ -773,6 +769,10 @@ value member_expression::execute_impl(context & ctx) {
     }
 
     JJ_DEBUG("Member expression on object type %s, property type %s", object->type().c_str(), property->type().c_str());
+    if (property->is_undefined()) {
+        JJ_DEBUG("%s", "Member expression property is undefined, returning undefined");
+        return mk_val<value_undefined>("object_property");
+    }
     ensure_key_type_allowed(property);
 
     value val = mk_val<value_undefined>("object_property");

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -746,6 +746,10 @@ value member_expression::execute_impl(context & ctx) {
             return slice_func->invoke(args);
         } else {
             property = this->property->execute(ctx);
+            if (property->is_undefined()) {
+                JJ_DEBUG("%s", "Computed member property is undefined, returning undefined");
+                return mk_val<value_undefined>("object_property");
+            }
         }
     } else {
         // syntax: obj.prop

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -769,13 +769,14 @@ value member_expression::execute_impl(context & ctx) {
     }
 
     JJ_DEBUG("Member expression on object type %s, property type %s", object->type().c_str(), property->type().c_str());
+    value val = mk_val<value_undefined>("object_property");
+
     if (property->is_undefined()) {
         JJ_DEBUG("%s", "Member expression property is undefined, returning undefined");
-        return mk_val<value_undefined>("object_property");
+        return val;
     }
-    ensure_key_type_allowed(property);
 
-    value val = mk_val<value_undefined>("object_property");
+    ensure_key_type_allowed(property);
 
     if (is_val<value_undefined>(object)) {
         JJ_DEBUG("%s", "Accessing property on undefined object, returning undefined");

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -215,7 +215,7 @@ struct continue_statement : public statement {
 };
 
 // do nothing
-struct noop_statement : public statement {
+struct noop_statement : public expression {
     std::string type() const override { return "Noop"; }
     value execute_impl(context &) override {
         return mk_val<value_undefined>();

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -215,7 +215,7 @@ struct continue_statement : public statement {
 };
 
 // do nothing
-struct noop_statement : public expression {
+struct noop_statement : public statement {
     std::string type() const override { return "Noop"; }
     value execute_impl(context &) override {
         return mk_val<value_undefined>();
@@ -262,6 +262,14 @@ struct comment_statement : public statement {
 };
 
 // Expressions
+
+// Represents an omitted expression in a computed member, e.g. `a[]`.
+struct blank_expression : public expression {
+    std::string type() const override { return "BlankExpression"; }
+    value execute_impl(context &) override {
+        return mk_val<value_undefined>();
+    }
+};
 
 struct member_expression : public expression {
     statement_ptr object;

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -399,6 +399,12 @@ static void test_expressions(testing & t) {
         "True"
     );
 
+    test_template(t, "undefined computed member is undefined",
+        "{{ a[undefined] is undefined }}",
+        {{"a", {{"name", "Bob"}}}},
+        "True"
+    );
+
     test_template(t, "array access",
         "{{ items[1] }}",
         {{"items", json::array({"a", "b", "c"})}},

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -387,6 +387,18 @@ static void test_expressions(testing & t) {
         "Bob"
     );
 
+    test_template(t, "empty computed member defaults to undefined",
+        "{{ a[]|default('fallback') }}",
+        {{"a", {{"name", "Bob"}}}},
+        "fallback"
+    );
+
+    test_template(t, "empty computed member is undefined",
+        "{{ a[] is undefined }}",
+        {{"a", {{"name", "Bob"}}}},
+        "True"
+    );
+
     test_template(t, "array access",
         "{{ items[1] }}",
         {{"items", json::array({"a", "b", "c"})}},


### PR DESCRIPTION
## Overview

This is to fix the bug found by UndefinedBehaviorSanitizer in jinja parser. The patch will reject empty computed member expressions before returning `slices[0]` from `parse_member_expression_arguments()`.  

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
