### PR TITLE
llama_params_fit: set n_ctx to training context size when memory is abundant

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -215,6 +215,9 @@ static void common_params_fit_impl(
         if (sum_projected_free >= margins[0]) {
             LOG_TRC("%s: will leave %" PRId64 " >= %" PRId64 " MiB of system memory, no changes needed\n",
                 __func__, sum_projected_free/MiB, margins[0]/MiB);
+            if (cparams->n_ctx == 0) {
+                cparams->n_ctx = hp_nct;
+            }
             return;
         }
     } else {
@@ -245,6 +248,9 @@ static void common_params_fit_impl(
             if (projected_free_per_device[0] >= margins[0]) {
                 LOG_TRC("%s: will leave %" PRId64 " >= %" PRId64 " MiB of free device memory, no changes needed\n",
                     __func__, projected_free_per_device[0]/MiB, margins[0]/MiB);
+                if (cparams->n_ctx == 0) {
+                    cparams->n_ctx = hp_nct;
+                }
                 return;
             }
         } else {
@@ -257,6 +263,9 @@ static void common_params_fit_impl(
             }
             if (!changes_needed) {
                 LOG_TRC("%s: targets for free memory can be met on all devices, no changes needed\n", __func__);
+                if (cparams->n_ctx == 0) {
+                    cparams->n_ctx = hp_nct;
+                }
                 return;
             }
         }


### PR DESCRIPTION
When cparams->n_ctx == 0 and the model fits in device memory without requiring any changes, llama_params_fit_impl() returned early without ever writing to n_ctx, leaving it as 0 and forcing callers into corrective workarounds (see #20878). Per the documented contract in llama.h, the context size is modified if and only if it equals 0. Both early-return paths (single-device and multi-device) now assign hp_nct, the model's training context size, already computed at that point to cparams->n_ctx before returning, making behaviour consistent whether memory is scarce or abundant.