### PR TITLE
Use docker in build-android.yml

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -40,13 +40,9 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v6
-
-      # Disabled due to size (400MB) and always 0 cache hits
-      # - name: ccache
-      #   uses: ggml-org/ccache-action@v1.2.16
-      #   with:
-      #     key: android-build
-      #     evict-old-files: 1d
+        with:
+          fetch-depth: 0
+          lfs: false
 
       - name: Set up JDK
         uses: actions/setup-java@v5
@@ -66,10 +62,15 @@ jobs:
 
   android-ndk:
     runs-on: ubuntu-latest
-
-    env:
-      OPENCL_VERSION: 2025.07.22
-
+    container:                                                                                                                                                                                                                                                               
+      image: 'ghcr.io/snapdragon-toolchain/arm64-android:v0.3'
+    defaults:                                                                                                                                                                                                                                                                
+      run:                                                                                                                                                                                                                                                                   
+        shell: bash                                                                                                                                                                                                                                                          
+    permissions:                                                                                                                                                                                                                                                             
+      id-token: write                                                                                                                                                                                                                                                        
+      packages: read                                                                                                                                                                                                                                                         
+      contents: read     
     strategy:
       matrix:
         include:
@@ -82,59 +83,23 @@ jobs:
       - name: Clone
         id: checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          lfs: false
 
-      - name: Install OpenCL Headers and Libs
-        id: install_opencl
-        if: ${{ matrix.build == 'arm64-snapdragon' }}
-        run: |
-          mkdir opencl
-          curl -L -o opencl/clhpp.tar.gz      https://github.com/KhronosGroup/OpenCL-CLHPP/archive/refs/tags/v${OPENCL_VERSION}.tar.gz
-          curl -L -o opencl/headers.tar.gz    https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v${OPENCL_VERSION}.tar.gz
-          curl -L -o opencl/icd-loader.tar.gz https://github.com/KhronosGroup/OpenCL-ICD-Loader/archive/refs/tags/v${OPENCL_VERSION}.tar.gz
-          tar -xaf opencl/headers.tar.gz    -C opencl
-          tar -xaf opencl/clhpp.tar.gz      -C opencl
-          tar -xaf opencl/icd-loader.tar.gz -C opencl
-          sudo cp -r opencl/OpenCL-Headers-${OPENCL_VERSION}/CL         ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include
-          sudo cp -r opencl/OpenCL-CLHPP-${OPENCL_VERSION}/include/CL/* ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/CL
-          cd opencl/OpenCL-ICD-Loader-${OPENCL_VERSION}
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake -DOPENCL_ICD_LOADER_HEADERS_DIR=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=31 -DANDROID_STL=c++_shared
-          cmake --build build
-          sudo cp build/libOpenCL.so ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android
-          rm -rf opencl
-
-      - name: Install Hexagon SDK
-        id: install_hexsdk
-        if: ${{ matrix.build == 'arm64-snapdragon' }}
-        env:
-          HEXSDK_VER: 6.4.0.2
-          HEXTLS_VER: 19.0.04
-        run: |
-          curl -L -o hex-sdk.tar.gz https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v$HEXSDK_VER/hexagon-sdk-v$HEXSDK_VER-amd64-lnx.tar.xz
-          mkdir hex-sdk
-          tar -xaf hex-sdk.tar.gz -C hex-sdk
-          ls -l hex-sdk
-          sudo mv hex-sdk /opt/hexagon
-          echo "HEXAGON_SDK_ROOT=/opt/hexagon/$HEXSDK_VER"                                     >> "$GITHUB_ENV"
-          echo "HEXAGON_TOOLS_ROOT=/opt/hexagon/$HEXSDK_VER/tools/HEXAGON_Tools/$HEXTLS_VER"   >> "$GITHUB_ENV"
-          echo "DEFAULT_HLOS_ARCH=64"                                                          >> "$GITHUB_ENV"
-          echo "DEFAULT_TOOLS_VARIANT=toolv19"                                                 >> "$GITHUB_ENV"
-          echo "DEFAULT_NO_QURT_INC=0"                                                         >> "$GITHUB_ENV"
-          echo "DEFAULT_DSP_ARCH=v73"                                                          >> "$GITHUB_ENV"
-
-      - name: Update CMake presets
-        id: update_presets
-        if: ${{ matrix.build == 'arm64-snapdragon' }}
-        run: |
-          cp docs/backend/snapdragon/CMakeUserPresets.json .
-
-      - name: Build
-        id: ndk_build
-        run: |
+      - name: Build Llama.CPP for Hexagon Android                                                                                                                                                                                                                            
+        id: build_llama_cpp_hexagon_android                                                                                                                                                                                                                                  
+        run: |                                                                                                                                                                                                                                                               
+          if [[ "${{ matrix.build }}" == "arm64-snapdragon" ]]; then                                                                                                                                                                                                                                
+            cp docs/backend/snapdragon/CMakeUserPresets.json .
+          fi                                                                                                                                                                                                               
           cmake ${{ matrix.defines }} -B build
-          cmake --build build
-          cmake --install build --prefix pkg-adb/llama.cpp
-
-      - name: Test
-        id: cmake_test
-        run: |
-          echo "FIXME: test on devices"
+          cmake --build build                                                                                                                                                                                                                                                        
+          cmake --install build --prefix pkg-adb/llama.cpp                                                                                                                                                                                                      
+      
+      - name: Upload Llama.CPP Hexagon Android Build Artifact                                                                                                                                                                                                                
+        if: ${{ always() && steps.build_llama_cpp_hexagon_android.outcome == 'success' }}                                                                                                                                                                                    
+        uses: actions/upload-artifact@v6                                                                                                                                                                                                                                    
+        with:                                                                                                                                                                                                                                                                
+          name: llama-cpp-android-${{ matrix.build }}                                                                                                                                                                                                                                   
+          path: pkg-adb/llama.cpp                                                                                                                                                                                                                                           

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -62,15 +62,15 @@ jobs:
 
   android-ndk:
     runs-on: ubuntu-latest
-    container:                                                                                                                                                                                                                                                               
+    container:
       image: 'ghcr.io/snapdragon-toolchain/arm64-android:v0.3'
-    defaults:                                                                                                                                                                                                                                                                
-      run:                                                                                                                                                                                                                                                                   
-        shell: bash                                                                                                                                                                                                                                                          
-    permissions:                                                                                                                                                                                                                                                             
-      id-token: write                                                                                                                                                                                                                                                        
-      packages: read                                                                                                                                                                                                                                                         
-      contents: read     
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      id-token: write
+      packages: read
+      contents: read
     strategy:
       matrix:
         include:
@@ -87,19 +87,19 @@ jobs:
           fetch-depth: 0
           lfs: false
 
-      - name: Build Llama.CPP for Hexagon Android                                                                                                                                                                                                                            
-        id: build_llama_cpp_hexagon_android                                                                                                                                                                                                                                  
-        run: |                                                                                                                                                                                                                                                               
-          if [[ "${{ matrix.build }}" == "arm64-snapdragon" ]]; then                                                                                                                                                                                                                                
+      - name: Build Llama.CPP for Hexagon Android
+        id: build_llama_cpp_hexagon_android
+        run: |
+          if [[ "${{ matrix.build }}" == "arm64-snapdragon" ]]; then
             cp docs/backend/snapdragon/CMakeUserPresets.json .
-          fi                                                                                                                                                                                                               
+          fi
           cmake ${{ matrix.defines }} -B build
-          cmake --build build                                                                                                                                                                                                                                                        
-          cmake --install build --prefix pkg-adb/llama.cpp                                                                                                                                                                                                      
-      
-      - name: Upload Llama.CPP Hexagon Android Build Artifact                                                                                                                                                                                                                
-        if: ${{ always() && steps.build_llama_cpp_hexagon_android.outcome == 'success' }}                                                                                                                                                                                    
-        uses: actions/upload-artifact@v6                                                                                                                                                                                                                                    
-        with:                                                                                                                                                                                                                                                                
-          name: llama-cpp-android-${{ matrix.build }}                                                                                                                                                                                                                                   
-          path: pkg-adb/llama.cpp                                                                                                                                                                                                                                           
+          cmake --build build
+          cmake --install build --prefix pkg-adb/llama.cpp
+
+      - name: Upload Llama.CPP Hexagon Android Build Artifact
+        if: ${{ always() && steps.build_llama_cpp_hexagon_android.outcome == 'success' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: llama-cpp-android-${{ matrix.build }}
+          path: pkg-adb/llama.cpp

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -67,10 +67,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    permissions:
-      id-token: write
-      packages: read
-      contents: read
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Overview

The docker is the recommended way to build llama.cpp for hexagon so replacing the workflow to do exactly that. This is cleaner and allows us to maintain the SDK versions in the docker image itself. 


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No