### PR TITLE
Make compile time cache directory configurable

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -848,9 +848,13 @@ std::string fs_get_cache_directory() {
         }
         return p;
     };
-    if (getenv("LLAMA_CACHE")) {
-        cache_directory = std::getenv("LLAMA_CACHE");
+    const char * cache_env = std::getenv("LLAMA_CACHE");
+    if (cache_env) {
+        cache_directory = std::string(cache_env);
     } else {
+#if defined(LLAMA_CACHE)
+        cache_directory = LLAMA_CACHE;
+#else
 #if defined(__linux__) || defined(__FreeBSD__) || defined(_AIX) || \
         defined(__OpenBSD__) || defined(__NetBSD__)
         if (std::getenv("XDG_CACHE_HOME")) {
@@ -881,6 +885,7 @@ std::string fs_get_cache_directory() {
 #endif
         cache_directory = ensure_trailing_slash(cache_directory);
         cache_directory += "llama.cpp";
+#endif /* defined(LLAMA_CACHE) */
     }
     return ensure_trailing_slash(cache_directory);
 }


### PR DESCRIPTION
## Overview

The cache directory is either defined by the `LLAMA_CACHE` environment variable or, if this does not exist, resolved to a user-dependent path. The latter introduces redundancies in multi-user environments (if multiple users use the same model, it is download and saved for each user) and, as the cache directory contains large files but is slightly hidden inside the home directory, easily takes much space. Therefore, introducing an optional configuration option gives more control.

## Additional information

The implementation checks for a `LLAMA_CACHE` definition at compile time, which can be defined using `/DLLAMA_CACHE="/path/to/custom/cache"`. If it is not defined, the existing logic is kept. In parcticular, the environment variable `LLAMA_CACHE` is used with higher priority if is defined at runtime. In this case, the environment is only read once (return value of `std::getenv("LLAMA_CACHE")` is cached). Everything else stays exactly the same.

Finally, we could also update the copied code inside `rpc-server.cpp`, still we focused on  `common.cpp` here.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No