### PR TITLE
fix(common): fix fail to run TranslateGemma

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -623,7 +623,7 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         params.speculative.tensor_buft_overrides.push_back({nullptr, nullptr});
     }
 
-    if (!params.chat_template.empty() && !common_chat_verify_template(params.chat_template, params.use_jinja)) {
+    if (!params.force_pure_content_parser && !params.chat_template.empty() && !common_chat_verify_template(params.chat_template, params.use_jinja)) {
         throw std::runtime_error(string_format(
             "error: the supplied chat template is not supported: %s%s\n",
             params.chat_template.c_str(),

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -105,10 +105,16 @@ json common_chat_msg::to_json_oaicompat(bool concat_typed_text) const {
         } else {
             auto & parts = jmsg["content"] = json::array();
             for (const auto & part : content_parts) {
-                parts.push_back({
+                json jpart = {
                     {"type", part.type},
                     {"text", part.text},
-                });
+                };
+                if (part.extra_fields.is_object()) {
+                    for (const auto & [k, v] : part.extra_fields.items()) {
+                        jpart[k] = v;
+                    }
+                }
+                parts.push_back(jpart);
             }
         }
     } else {
@@ -291,6 +297,11 @@ std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const json & messa
                         common_chat_msg_content_part msg_part;
                         msg_part.type = type;
                         msg_part.text = part.at("text");
+                        for (const auto & [k, v] : part.items()) {
+                            if (k != "type" && k != "text") {
+                                msg_part.extra_fields[k] = v;
+                            }
+                        }
                         msg.content_parts.push_back(msg_part);
                     }
                 } else if (!content.is_null()) {

--- a/common/chat.h
+++ b/common/chat.h
@@ -40,6 +40,7 @@ struct common_chat_tool_call {
 struct common_chat_msg_content_part {
     std::string type;
     std::string text;
+    nlohmann::ordered_json extra_fields;
 
     // TODO @ngxson : no known chat templates support reasoning_content in content parts yet
     //                this can be useful for models with interleaved thinking (like Kimi-K2)
@@ -47,7 +48,7 @@ struct common_chat_msg_content_part {
     // std::string reasoning_content;
 
     bool operator==(const common_chat_msg_content_part & other) const {
-        return type == other.type && text == other.text;
+        return type == other.type && text == other.text && extra_fields == other.extra_fields;
     }
 };
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
- Support extra fields for content part.
- Ignore template verify when enable `--skip-chat-parsing`

fix #20305 

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

`common_chat_msgs_parse_oaicompat` will ignore everything except `type` and `text` that `--skip-chat-parsing` is not enough for TranslateGemma

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, use Claude Code to find the bug and human decide how to fix <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
