### PR TITLE
grammar: optimize big grammar matching by using left-factorization / optimize grammar cloning

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -952,6 +952,188 @@ static llama_grammar_candidates llama_grammar_reject_candidates(
     return rejects;
 }
 
+// Left-factor grammar rules to reduce redundant parallel stacks.
+//
+// When a rule has many alternates (e.g. tool-choice ::= tc0 | tc1 | ... | tc119)
+// and the referenced rules share a common element-content prefix, extract that
+// prefix so the parser processes it once instead of N times.
+//
+// Handles two cases:
+// 1. Inline common prefix: rule = "ab1" | "ab2" → rule = "ab" rule', rule' = "1" | "2"
+// 2. Cross-rule prefix: rule = A | B | C where A,B,C start with same elements
+//    → rule = common_prefix rule', rule' = A_suffix | B_suffix | C_suffix
+static void llama_grammar_left_factor(llama_grammar_rules & rules) {
+    auto elem_eq = [](const llama_grammar_element & a, const llama_grammar_element & b) {
+        return a.type == b.type && a.value == b.value;
+    };
+
+    struct alt_info {
+        size_t rule_idx;
+        size_t start;
+        size_t end;
+    };
+
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        const size_t n_rules = rules.size();
+
+        for (size_t ri = 0; ri < n_rules; ri++) {
+            const auto & rule = rules[ri];
+
+            // Split rule into alternates
+            std::vector<std::pair<size_t, size_t>> alt_ranges;
+            size_t alt_start = 0;
+            for (size_t j = 0; j < rule.size(); j++) {
+                if (rule[j].type == LLAMA_GRETYPE_ALT || rule[j].type == LLAMA_GRETYPE_END) {
+                    alt_ranges.push_back({alt_start, j});
+                    alt_start = j + 1;
+                }
+            }
+
+            if (alt_ranges.size() < 4) {
+                continue;
+            }
+
+            // Resolve each alternate: if it's a single RULE_REF, follow it to get the
+            // actual element sequence from the referenced rule.
+            std::vector<alt_info> resolved;
+            resolved.reserve(alt_ranges.size());
+            bool all_single_refs = true;
+
+            for (const auto & [astart, aend] : alt_ranges) {
+                size_t len = aend - astart;
+                if (len == 1 && rule[astart].type == LLAMA_GRETYPE_RULE_REF) {
+                    size_t ref_id = static_cast<size_t>(rule[astart].value);
+                    if (ref_id < rules.size()) {
+                        size_t ref_end = 0;
+                        for (size_t k = 0; k < rules[ref_id].size(); k++) {
+                            if (rules[ref_id][k].type == LLAMA_GRETYPE_ALT ||
+                                rules[ref_id][k].type == LLAMA_GRETYPE_END) {
+                                ref_end = k;
+                                break;
+                            }
+                        }
+                        bool single_alt = (rules[ref_id][ref_end].type == LLAMA_GRETYPE_END);
+                        if (single_alt) {
+                            resolved.push_back({ref_id, 0, ref_end});
+                            continue;
+                        }
+                    }
+                }
+                all_single_refs = false;
+                resolved.push_back({ri, astart, aend});
+            }
+
+            if (!all_single_refs) {
+                // Inline-only factoring
+                size_t prefix_len = 0;
+                bool prefix_match = true;
+                while (prefix_match) {
+                    const auto & first = alt_ranges[0];
+                    if (first.first + prefix_len >= first.second) {
+                        break;
+                    }
+                    const auto & ref_elem = rule[first.first + prefix_len];
+                    for (size_t ai = 1; ai < alt_ranges.size(); ai++) {
+                        const auto & alt = alt_ranges[ai];
+                        if (alt.first + prefix_len >= alt.second ||
+                            !elem_eq(rule[alt.first + prefix_len], ref_elem)) {
+                            prefix_match = false;
+                            break;
+                        }
+                    }
+                    if (prefix_match) {
+                        prefix_len++;
+                    }
+                }
+
+                if (prefix_len == 0) {
+                    continue;
+                }
+
+                uint32_t suffix_rule_id = static_cast<uint32_t>(rules.size());
+                llama_grammar_rule suffix_rule;
+                for (size_t ai = 0; ai < alt_ranges.size(); ai++) {
+                    if (ai > 0) {
+                        suffix_rule.push_back({LLAMA_GRETYPE_ALT, 0});
+                    }
+                    const auto & alt = alt_ranges[ai];
+                    for (size_t j = alt.first + prefix_len; j < alt.second; j++) {
+                        suffix_rule.push_back(rule[j]);
+                    }
+                }
+                suffix_rule.push_back({LLAMA_GRETYPE_END, 0});
+
+                llama_grammar_rule new_rule;
+                for (size_t j = 0; j < prefix_len; j++) {
+                    new_rule.push_back(rule[alt_ranges[0].first + j]);
+                }
+                new_rule.push_back({LLAMA_GRETYPE_RULE_REF, suffix_rule_id});
+                new_rule.push_back({LLAMA_GRETYPE_END, 0});
+
+                rules.push_back(std::move(suffix_rule));
+                rules[ri] = std::move(new_rule);
+                changed = true;
+                continue;
+            }
+
+            // Cross-rule factoring: all alternates are single RULE_REFs to single-alternate rules.
+            size_t prefix_len = 0;
+            bool prefix_match = true;
+            while (prefix_match) {
+                const auto & first = resolved[0];
+                if (first.start + prefix_len >= first.end) {
+                    break;
+                }
+                const auto & ref_elem = rules[first.rule_idx][first.start + prefix_len];
+
+                for (size_t ai = 1; ai < resolved.size(); ai++) {
+                    const auto & alt = resolved[ai];
+                    if (alt.start + prefix_len >= alt.end ||
+                        !elem_eq(rules[alt.rule_idx][alt.start + prefix_len], ref_elem)) {
+                        prefix_match = false;
+                        break;
+                    }
+                }
+                if (prefix_match) {
+                    prefix_len++;
+                }
+            }
+
+            if (prefix_len == 0) {
+                continue;
+            }
+
+            uint32_t suffix_choice_id = static_cast<uint32_t>(rules.size());
+            llama_grammar_rule suffix_choice;
+
+            for (size_t ai = 0; ai < resolved.size(); ai++) {
+                if (ai > 0) {
+                    suffix_choice.push_back({LLAMA_GRETYPE_ALT, 0});
+                }
+                const auto & alt = resolved[ai];
+                for (size_t j = alt.start + prefix_len; j < alt.end; j++) {
+                    suffix_choice.push_back(rules[alt.rule_idx][j]);
+                }
+            }
+            suffix_choice.push_back({LLAMA_GRETYPE_END, 0});
+
+            llama_grammar_rule new_rule;
+            const auto & first = resolved[0];
+            for (size_t j = 0; j < prefix_len; j++) {
+                new_rule.push_back(rules[first.rule_idx][first.start + j]);
+            }
+            new_rule.push_back({LLAMA_GRETYPE_RULE_REF, suffix_choice_id});
+            new_rule.push_back({LLAMA_GRETYPE_END, 0});
+
+            rules.push_back(std::move(suffix_choice));
+            rules[ri] = std::move(new_rule);
+            changed = true;
+        }
+    }
+}
+
 static bool llama_grammar_detect_left_recursion(
         const llama_grammar_rules & rules,
         size_t rule_index,
@@ -1139,11 +1321,15 @@ struct llama_grammar * llama_grammar_init_impl(
         vec_rules[i].push_back({LLAMA_GRETYPE_END, 0});
     }
 
-    // Check for left recursion
-    std::vector<bool> rules_visited(n_rules);
-    std::vector<bool> rules_in_progress(n_rules);
-    std::vector<bool> rules_may_be_empty(n_rules);
-    for (size_t i = 0; i < n_rules; i++) {
+    // Left-factor rules to reduce redundant parallel stacks
+    llama_grammar_left_factor(vec_rules);
+
+    // Check for left recursion (use post-factoring rule count)
+    const size_t n_rules_total = vec_rules.size();
+    std::vector<bool> rules_visited(n_rules_total);
+    std::vector<bool> rules_in_progress(n_rules_total);
+    std::vector<bool> rules_may_be_empty(n_rules_total);
+    for (size_t i = 0; i < n_rules_total; i++) {
         if (rules_visited[i]) {
             continue;
         }
@@ -1232,11 +1418,15 @@ struct llama_grammar * llama_grammar_init_impl(
         vec_rules[i].push_back({LLAMA_GRETYPE_END, 0});
     }
 
-    // Check for left recursion
-    std::vector<bool> rules_visited(n_rules);
-    std::vector<bool> rules_in_progress(n_rules);
-    std::vector<bool> rules_may_be_empty(n_rules);
-    for (size_t i = 0; i < n_rules; i++) {
+    // Left-factor rules to reduce redundant parallel stacks
+    llama_grammar_left_factor(vec_rules);
+
+    // Check for left recursion (use post-factoring rule count)
+    const size_t n_rules_total = vec_rules.size();
+    std::vector<bool> rules_visited(n_rules_total);
+    std::vector<bool> rules_in_progress(n_rules_total);
+    std::vector<bool> rules_may_be_empty(n_rules_total);
+    for (size_t i = 0; i < n_rules_total; i++) {
         if (rules_visited[i]) {
             continue;
         }
@@ -1320,14 +1510,15 @@ struct llama_grammar * llama_grammar_clone_impl(const struct llama_grammar & gra
         grammar.trigger_patterns,
     };
 
-    // redirect elements in stacks to point to new rules
-    for (size_t is = 0; is < result->stacks.size(); is++) {
-        for (size_t ie = 0; ie < result->stacks[is].size(); ie++) {
-            for (size_t ir0 = 0; ir0 < grammar.rules.size(); ir0++) {
-                for (size_t ir1 = 0; ir1 < grammar.rules[ir0].size(); ir1++) {
-                    if (grammar.stacks[is][ie] == &grammar.rules[ir0][ir1]) {
-                        result->stacks[is][ie] =  &result->rules[ir0][ir1];
-                    }
+    // redirect elements in stacks to point to new rules using per-rule pointer offsets
+    for (auto & stack : result->stacks) {
+        for (auto & elem : stack) {
+            for (size_t ir = 0; ir < grammar.rules.size(); ir++) {
+                const auto & old_rule = grammar.rules[ir];
+                if (!old_rule.empty() && elem >= old_rule.data() && elem < old_rule.data() + old_rule.size()) {
+                    size_t offset = static_cast<size_t>(elem - old_rule.data());
+                    elem = result->rules[ir].data() + offset;
+                    break;
                 }
             }
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,6 +153,7 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     llama_build_and_test(test-grammar-parser.cpp)
     llama_build_and_test(test-grammar-integration.cpp)
     llama_build_and_test(test-llama-grammar.cpp)
+    llama_build(test-grammar-perf.cpp)
     llama_build_and_test(test-chat.cpp WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     # TODO: disabled on loongarch64 because the ggml-ci node lacks Python 3.8
     if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "loongarch64")

--- a/tests/test-grammar-perf.cpp
+++ b/tests/test-grammar-perf.cpp
@@ -1,0 +1,487 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include "../src/unicode.h"
+#include "../src/llama-grammar.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <sys/resource.h>
+static long get_peak_rss_kb() {
+    struct rusage usage;
+    getrusage(RUSAGE_SELF, &usage);
+#if defined(__APPLE__)
+    return usage.ru_maxrss / 1024; // macOS reports bytes
+#else
+    return usage.ru_maxrss;        // Linux reports KB
+#endif
+}
+#else
+static long get_peak_rss_kb() { return 0; }
+#endif
+
+// ---------------------------------------------------------------------------
+// Token/piece helpers (same as test-grammar-integration.cpp)
+// ---------------------------------------------------------------------------
+
+struct token_and_piece {
+    llama_token token;
+    std::string piece;
+};
+
+static std::vector<token_and_piece> parse_tokens(const std::string & input) {
+    std::vector<token_and_piece> result;
+    result.reserve(input.size());
+    size_t offset = 0;
+    while (offset < input.size()) {
+        try {
+            if (static_cast<unsigned char>(input[offset]) == 0xff) {
+                if (offset + 5 > input.size()) {
+                    throw std::runtime_error("not enough bytes for token id");
+                }
+                uint32_t val =
+                    (static_cast<unsigned char>(input[offset + 1]) << 24) |
+                    (static_cast<unsigned char>(input[offset + 2]) << 16) |
+                    (static_cast<unsigned char>(input[offset + 3]) << 8)  |
+                    (static_cast<unsigned char>(input[offset + 4]));
+                auto piece = "<[" + std::to_string(val) + "]>";
+                result.push_back({static_cast<llama_token>(val), piece});
+                offset += 5;
+            } else {
+                uint32_t cpt = unicode_cpt_from_utf8(input, offset);
+                result.push_back({0, unicode_cpt_to_utf8(cpt)});
+            }
+        } catch (const std::invalid_argument &) {
+            ++offset;
+            result.push_back({0, unicode_cpt_to_utf8(0xFFFD)});
+        }
+    }
+    return result;
+}
+
+static bool match_string(const std::string & input, llama_grammar * grammar) {
+    const auto parsed = parse_tokens(input);
+    auto & stacks_cur = llama_grammar_get_stacks(grammar);
+
+    for (const auto & in : parsed) {
+        try {
+            llama_grammar_accept_token(*grammar, in.token, in.piece);
+        } catch (const std::runtime_error &) {
+            return false;
+        }
+        if (stacks_cur.empty()) {
+            return false;
+        }
+    }
+
+    for (const auto & stack : stacks_cur) {
+        if (stack.empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Grammar generation — 50 tool schemas with parallel tool calls
+// ---------------------------------------------------------------------------
+
+// Each tool has: name, 2-4 typed parameters (string/integer/boolean/number).
+// The grammar enforces JSON structure for each tool's arguments.
+
+struct tool_param {
+    std::string name;
+    std::string type; // "string", "integer", "boolean", "number"
+};
+
+struct tool_def {
+    std::string name;
+    std::vector<tool_param> params;
+};
+
+// GBNF identifiers can't contain underscores; replace with hyphens
+static std::string gbnf_name(const std::string & name) {
+    std::string result = name;
+    for (auto & c : result) {
+        if (c == '_') c = '-';
+    }
+    return result;
+}
+
+static std::string json_rule_for_type(const std::string & type) {
+    if (type == "string")  return "string";
+    if (type == "integer") return "integer";
+    if (type == "boolean") return "boolean";
+    if (type == "number")  return "number";
+    return "string";
+}
+
+static std::string generate_grammar(const std::vector<tool_def> & tools) {
+    std::string g;
+
+    // Primitives
+    g += "# Primitive types\n";
+    g += "ws ::= [ \\t\\n]*\n";
+    g += "string ::= \"\\\"\" [^\"\\\\]* \"\\\"\" \n";
+    g += "integer ::= \"-\"? [0-9]+\n";
+    g += "number ::= \"-\"? [0-9]+ (\".\" [0-9]+)?\n";
+    g += "boolean ::= \"true\" | \"false\"\n";
+    g += "\n";
+
+    // Root: parallel tool calls
+    g += "root ::= \"<tool_calls>\" ws tool-call+ ws \"</tool_calls>\"\n";
+    g += "tool-call ::= ws \"<tool>\" ws tool-body ws \"</tool>\" ws\n";
+    g += "tool-body ::= ";
+
+    for (size_t i = 0; i < tools.size(); ++i) {
+        if (i > 0) g += " | ";
+        g += "tool-" + gbnf_name(tools[i].name);
+    }
+    g += "\n\n";
+
+    // Per-tool rules
+    for (const auto & tool : tools) {
+        g += "tool-" + gbnf_name(tool.name) + " ::= \"{\" ws ";
+        g += "\"\\\"name\\\": \\\"" + tool.name + "\\\",\" ws ";
+        g += "\"\\\"arguments\\\": {\" ws ";
+
+        for (size_t j = 0; j < tool.params.size(); ++j) {
+            if (j > 0) g += "\",\" ws ";
+            g += "\"\\\"" + tool.params[j].name + "\\\": \" ";
+            g += json_rule_for_type(tool.params[j].type) + " ws ";
+        }
+
+        g += "\"}\" ws \"}\" \n";
+    }
+
+    return g;
+}
+
+// Generate a grammar with high ambiguity: many alternatives share a long common
+// prefix so the grammar engine must maintain many parallel stacks simultaneously.
+// This stresses advance_stack deduplication heavily.
+static std::string generate_ambiguous_grammar(int n_tools) {
+    std::string g;
+
+    g += "ws ::= [ \\t\\n]*\n";
+    g += "string ::= \"\\\"\" [^\"\\\\]* \"\\\"\" \n";
+    g += "integer ::= \"-\"? [0-9]+\n";
+    g += "boolean ::= \"true\" | \"false\"\n";
+    g += "\n";
+
+    // Each tool shares the same outer structure; disambiguation happens only
+    // at the very end of the arguments object where a distinguishing key appears.
+    // This forces the grammar to track all n_tools stacks in parallel through
+    // the entire shared prefix.
+    g += "root ::= \"{\" ws \"\\\"tool\\\":\" ws tool-choice ws \"}\"\n";
+    g += "tool-choice ::= ";
+    for (int i = 0; i < n_tools; ++i) {
+        if (i > 0) g += " | ";
+        g += "tc" + std::to_string(i);
+    }
+    g += "\n\n";
+
+    // All tools share: {"name": "...", "args": {"shared_a": <string>, "shared_b": <int>, ..., "unique_X": <val>}}
+    // The shared prefix is long (several key-value pairs), the unique key differs per tool.
+    for (int i = 0; i < n_tools; ++i) {
+        g += "tc" + std::to_string(i) + " ::= ";
+        g += "\"{\" ws ";
+        g += "\"\\\"name\\\": \\\"tool\\\"\" ws \",\" ws ";           // same name for all!
+        g += "\"\\\"args\\\": {\" ws ";
+        // 5 shared key-value pairs
+        g += "\"\\\"alpha\\\": \" string ws \",\" ws ";
+        g += "\"\\\"beta\\\": \" integer ws \",\" ws ";
+        g += "\"\\\"gamma\\\": \" boolean ws \",\" ws ";
+        g += "\"\\\"delta\\\": \" string ws \",\" ws ";
+        g += "\"\\\"epsilon\\\": \" integer ws \",\" ws ";
+        // Unique key that disambiguates (only the key name differs)
+        g += "\"\\\"unique-" + std::to_string(i) + "\\\": \" string ws ";
+        g += "\"}\" ws \"}\" \n";
+    }
+
+    return g;
+}
+
+static std::string make_ambiguous_tool_call(int tool_idx) {
+    std::string s;
+    s += "{\"tool\": {\"name\": \"tool\", \"args\": {";
+    s += "\"alpha\": \"hello\", ";
+    s += "\"beta\": 123, ";
+    s += "\"gamma\": true, ";
+    s += "\"delta\": \"world\", ";
+    s += "\"epsilon\": 456, ";
+    s += "\"unique-" + std::to_string(tool_idx) + "\": \"done\"";
+    s += "}}}";
+    return s;
+}
+
+static std::vector<tool_def> make_tools(int n) {
+    // Realistic-ish tool names and parameter patterns
+    static const char * prefixes[] = {
+        "search", "get", "create", "update", "delete",
+        "list", "fetch", "send", "check", "run",
+        "query", "remove", "modify", "inspect",
+    };
+    static const int n_prefixes = sizeof(prefixes) / sizeof(prefixes[0]);
+    static const char * domains[] = {
+        "users", "files", "messages", "tasks", "events",
+        "logs", "configs", "sessions", "tokens", "roles",
+        "alerts", "metrics", "reports", "schemas", "hooks",
+    };
+    static const int n_domains = sizeof(domains) / sizeof(domains[0]);
+
+    // Param templates per tool type
+    static const std::vector<std::vector<tool_param>> param_templates = {
+        {{"query", "string"}, {"limit", "integer"}, {"offset", "integer"}},
+        {{"id", "string"}, {"verbose", "boolean"}},
+        {{"name", "string"}, {"description", "string"}, {"priority", "integer"}, {"active", "boolean"}},
+        {{"id", "string"}, {"field", "string"}, {"value", "string"}},
+        {{"id", "string"}},
+    };
+
+    std::vector<tool_def> tools;
+    tools.reserve(n);
+
+    for (int i = 0; i < n; ++i) {
+        const char * prefix = prefixes[i % n_prefixes];
+        const char * domain = domains[(i / n_prefixes) % n_domains];
+        std::string name = std::string(prefix) + "_" + domain + "_" + std::to_string(i);
+
+        const auto & params = param_templates[i % param_templates.size()];
+        // Slightly vary param names per tool to increase grammar complexity
+        std::vector<tool_param> tool_params;
+        for (const auto & p : params) {
+            tool_params.push_back({p.name + "_" + std::to_string(i), p.type});
+        }
+        tools.push_back({name, tool_params});
+    }
+    return tools;
+}
+
+static std::string make_valid_tool_call(const tool_def & tool) {
+    std::string s;
+    s += "{\"name\": \"" + tool.name + "\", \"arguments\": {";
+    for (size_t j = 0; j < tool.params.size(); ++j) {
+        if (j > 0) s += ", ";
+        s += "\"" + tool.params[j].name + "\": ";
+        if (tool.params[j].type == "string") {
+            s += "\"example_value\"";
+        } else if (tool.params[j].type == "integer") {
+            s += "42";
+        } else if (tool.params[j].type == "boolean") {
+            s += "true";
+        } else if (tool.params[j].type == "number") {
+            s += "3.14";
+        }
+    }
+    s += "}}";
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Timing helpers
+// ---------------------------------------------------------------------------
+
+using hrclock = std::chrono::high_resolution_clock;
+
+static double ms_since(hrclock::time_point t0) {
+    return std::chrono::duration<double, std::milli>(hrclock::now() - t0).count();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+static void bench_init(const std::string & grammar_str, int iters) {
+    fprintf(stderr, "\n--- Grammar init benchmark (%d iterations) ---\n", iters);
+
+    auto t0 = hrclock::now();
+    for (int i = 0; i < iters; ++i) {
+        auto * g = llama_grammar_init_impl(nullptr, grammar_str.c_str(), "root",
+                                           false, nullptr, 0, nullptr, 0);
+        assert(g != nullptr);
+        llama_grammar_free_impl(g);
+    }
+    double elapsed = ms_since(t0);
+    fprintf(stderr, "  Total: %.1f ms  |  Per-iter: %.3f ms\n", elapsed, elapsed / iters);
+}
+
+static void bench_match(const std::string & grammar_str,
+                         const std::vector<std::string> & test_strings,
+                         int iters) {
+    fprintf(stderr, "\n--- String match benchmark (%d iterations x %zu strings) ---\n",
+            iters, test_strings.size());
+
+    auto * grammar = llama_grammar_init_impl(nullptr, grammar_str.c_str(), "root",
+                                             false, nullptr, 0, nullptr, 0);
+    assert(grammar != nullptr);
+
+    const llama_grammar_stacks stacks_orig = llama_grammar_get_stacks(grammar);
+    llama_grammar_stacks & stacks_cur = llama_grammar_get_stacks(grammar);
+
+    // Warm-up: verify strings actually match
+    for (const auto & s : test_strings) {
+        bool ok = match_string(s, grammar);
+        if (!ok) {
+            fprintf(stderr, "  ERROR: string failed to match during warm-up!\n");
+            fprintf(stderr, "  String (first 200 chars): %.200s\n", s.c_str());
+            assert(false && "warm-up match failed");
+        }
+        stacks_cur = stacks_orig;
+    }
+
+    auto t0 = hrclock::now();
+    for (int i = 0; i < iters; ++i) {
+        for (const auto & s : test_strings) {
+            match_string(s, grammar);
+            stacks_cur = stacks_orig;
+        }
+    }
+    double elapsed = ms_since(t0);
+    double per_string = elapsed / (iters * test_strings.size());
+    fprintf(stderr, "  Total: %.1f ms  |  Per-string: %.3f ms\n", elapsed, per_string);
+
+    llama_grammar_free_impl(grammar);
+}
+
+static void bench_clone(const std::string & grammar_str, int iters) {
+    fprintf(stderr, "\n--- Grammar clone benchmark (%d iterations) ---\n", iters);
+
+    auto * grammar = llama_grammar_init_impl(nullptr, grammar_str.c_str(), "root",
+                                             false, nullptr, 0, nullptr, 0);
+    assert(grammar != nullptr);
+
+    auto t0 = hrclock::now();
+    for (int i = 0; i < iters; ++i) {
+        auto * cloned = llama_grammar_clone_impl(*grammar);
+        llama_grammar_free_impl(cloned);
+    }
+    double elapsed = ms_since(t0);
+    fprintf(stderr, "  Total: %.1f ms  |  Per-iter: %.3f ms\n", elapsed, elapsed / iters);
+
+    llama_grammar_free_impl(grammar);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+int main() {
+    fprintf(stderr, "=== Grammar Performance Benchmark ===\n\n");
+
+    long rss_start = get_peak_rss_kb();
+
+    // ---------------------------------------------------------------
+    // Benchmark 1: 50-tool grammar (low ambiguity, realistic)
+    // ---------------------------------------------------------------
+    {
+        fprintf(stderr, "========================================\n");
+        fprintf(stderr, "Benchmark 1: 50-tool grammar (low ambiguity)\n");
+        fprintf(stderr, "========================================\n");
+
+        auto tools = make_tools(50);
+        std::string grammar_str = generate_grammar(tools);
+        fprintf(stderr, "Grammar size: %zu bytes, %zu tools\n", grammar_str.size(), tools.size());
+
+        std::vector<std::string> test_strings;
+        for (int i = 0; i < 10; ++i) {
+            std::string s = "<tool_calls> <tool> " + make_valid_tool_call(tools[i * 5]) + " </tool> </tool_calls>";
+            test_strings.push_back(s);
+        }
+        for (int i = 0; i < 5; ++i) {
+            std::string s = "<tool_calls>";
+            int n_tools = 2 + (i % 3);
+            for (int j = 0; j < n_tools; ++j) {
+                s += " <tool> " + make_valid_tool_call(tools[(i * 7 + j * 3) % 50]) + " </tool>";
+            }
+            s += " </tool_calls>";
+            test_strings.push_back(s);
+        }
+
+        size_t total_len = 0;
+        for (const auto & s : test_strings) {
+            total_len += s.size();
+        }
+        fprintf(stderr, "Test strings: %zu (avg length: %zu chars)\n",
+                test_strings.size(), total_len / test_strings.size());
+
+        bench_init(grammar_str, 200);
+        bench_match(grammar_str, test_strings, 50);
+        bench_clone(grammar_str, 5000);
+    }
+
+    // ---------------------------------------------------------------
+    // Benchmark 2: High-ambiguity grammar (50 tools, shared prefix)
+    // All alternatives share the same structure until the final key.
+    // This forces the grammar to maintain 50 parallel stacks.
+    // ---------------------------------------------------------------
+    {
+        fprintf(stderr, "\n========================================\n");
+        fprintf(stderr, "Benchmark 2: 50-tool grammar (HIGH ambiguity)\n");
+        fprintf(stderr, "========================================\n");
+
+        std::string grammar_str = generate_ambiguous_grammar(50);
+        fprintf(stderr, "Grammar size: %zu bytes\n", grammar_str.size());
+
+        std::vector<std::string> test_strings;
+        for (int i = 0; i < 15; ++i) {
+            test_strings.push_back(make_ambiguous_tool_call(i * 3 % 50));
+        }
+
+        size_t total_len = 0;
+        for (const auto & s : test_strings) {
+            total_len += s.size();
+        }
+        fprintf(stderr, "Test strings: %zu (avg length: %zu chars)\n",
+                test_strings.size(), total_len / test_strings.size());
+
+        bench_init(grammar_str, 200);
+        bench_match(grammar_str, test_strings, 50);
+        bench_clone(grammar_str, 5000);
+    }
+
+    // ---------------------------------------------------------------
+    // Benchmark 3: 120-tool high-ambiguity grammar
+    // Same shared-prefix structure, but 120 parallel stacks.
+    // ---------------------------------------------------------------
+    {
+        fprintf(stderr, "\n========================================\n");
+        fprintf(stderr, "Benchmark 3: 120-tool grammar (HIGH ambiguity)\n");
+        fprintf(stderr, "========================================\n");
+
+        std::string grammar_str = generate_ambiguous_grammar(120);
+        fprintf(stderr, "Grammar size: %zu bytes\n", grammar_str.size());
+
+        std::vector<std::string> test_strings;
+        test_strings.reserve(15);
+        for (int i = 0; i < 15; ++i) {
+            test_strings.push_back(make_ambiguous_tool_call(i * 7 % 120));
+        }
+
+        size_t total_len = 0;
+        for (const auto & s : test_strings) {
+            total_len += s.size();
+        }
+        fprintf(stderr, "Test strings: %zu (avg length: %zu chars)\n",
+                test_strings.size(), total_len / test_strings.size());
+
+        bench_init(grammar_str, 200);
+        bench_match(grammar_str, test_strings, 50);
+        bench_clone(grammar_str, 5000);
+    }
+
+    long rss_end = get_peak_rss_kb();
+    fprintf(stderr, "\n--- Memory ---\n");
+    fprintf(stderr, "  Peak RSS: %ld KB (delta from start: %ld KB)\n", rss_end, rss_end - rss_start);
+
+    fprintf(stderr, "\n=== Benchmark complete ===\n");
+    return 0;
+}


### PR DESCRIPTION
## Overview

Reduce complexity of parsing for huge grammars by using left-factorization of rules + refactor cloning to use pointer offsets to avoid the four-level loop.

## Additional information

Pre-factorizes grammar branches to reduce number of alternate routes. On big and ambiguous grammars, the speed gain is up to 50x. Uses  Adds a performance test for grammar parsing.

Hopefully helps alleviate cases such as https://github.com/ggml-org/llama.cpp/issues/20879, to be paired with a PR parametrizing `MAX_REPETITION_THRESHOLD`.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, told Claude to try various optimization passes at grammar, picked the ones with minimum code change + maximum effect.