### PR TITLE
Install libraries into LLAMA_LIB_INSTALL_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,16 @@ if (LLAMA_STANDALONE)
     list(APPEND CMAKE_VS_GLOBALS EnforceProcessCountAcrossBuilds=true)
 endif()
 
+# Must be set before defining any targets.
+set(LLAMA_LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Location of library files")
+set(LLAMA_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location of binary  files")
+set(LLAMA_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE PATH "Location of header  files")
+
+if (NOT LLAMA_LIB_INSTALL_DIR STREQUAL CMAKE_INSTALL_LIBDIR)
+    set(CMAKE_INSTALL_RPATH "${LLAMA_LIB_INSTALL_DIR}")
+    set(CMAKE_BUILD_RPATH "${CMAKE_BINARY_DIR}/bin")
+endif()
+
 if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set(LLAMA_TOOLS_INSTALL_DEFAULT OFF)
 else()
@@ -235,9 +245,9 @@ endif()
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(LLAMA_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE PATH "Location of header  files")
-set(LLAMA_LIB_INSTALL_DIR     ${CMAKE_INSTALL_LIBDIR}     CACHE PATH "Location of library files")
-set(LLAMA_BIN_INSTALL_DIR     ${CMAKE_INSTALL_BINDIR}     CACHE PATH "Location of binary  files")
+if (NOT LLAMA_LIB_INSTALL_DIR STREQUAL CMAKE_INSTALL_LIBDIR)
+    set(CMAKE_INSTALL_RPATH "${LLAMA_LIB_INSTALL_DIR}")
+endif()
 
 set(LLAMA_PUBLIC_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/llama.h
@@ -247,7 +257,7 @@ set_target_properties(llama
     PROPERTIES
         PUBLIC_HEADER "${LLAMA_PUBLIC_HEADERS}")
 
-install(TARGETS llama LIBRARY PUBLIC_HEADER)
+install(TARGETS llama LIBRARY DESTINATION ${LLAMA_LIB_INSTALL_DIR} PUBLIC_HEADER)
 
 configure_package_config_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/llama-config.cmake.in

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -310,6 +310,10 @@ endif ()
 # install
 #
 
+if (NOT DEFINED GGML_LIB_INSTALL_DIR)
+    set(GGML_LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR} CACHE PATH "Location of library files")
+endif()
+
 include(CMakePackageConfigHelpers)
 
 # all public headers
@@ -337,8 +341,8 @@ set_target_properties(ggml PROPERTIES PUBLIC_HEADER "${GGML_PUBLIC_HEADERS}")
 #if (GGML_METAL)
 #    set_target_properties(ggml PROPERTIES RESOURCE "${CMAKE_CURRENT_SOURCE_DIR}/src/ggml-metal.metal")
 #endif()
-install(TARGETS ggml LIBRARY PUBLIC_HEADER)
-install(TARGETS ggml-base LIBRARY)
+install(TARGETS ggml LIBRARY DESTINATION ${GGML_LIB_INSTALL_DIR} PUBLIC_HEADER)
+install(TARGETS ggml-base LIBRARY DESTINATION ${GGML_LIB_INSTALL_DIR})
 
 if (GGML_STANDALONE)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ggml.pc.in

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -68,7 +68,7 @@ set_target_properties(mtmd
     PROPERTIES
     PRIVATE_HEADER debug/mtmd-debug.h)
 
-install(TARGETS mtmd LIBRARY PUBLIC_HEADER)
+install(TARGETS mtmd LIBRARY DESTINATION ${LLAMA_LIB_INSTALL_DIR} PUBLIC_HEADER)
 
 if (NOT MSVC)
     # for stb_image.h and miniaudio.h


### PR DESCRIPTION
Using the following:

    -DGGML_LIB_INSTALL_DIR=/usr/lib/llama.cpp \
    -DLLAMA_LIB_INSTALL_DIR=/usr/lib/llama.cpp \

Several libraries are still installed into /usr/lib:

    /usr/lib/libggml-base.so.0
    /usr/lib/libggml-base.so.0.9.8
    /usr/lib/libggml.so.0
    /usr/lib/libggml.so.0.9.8
    /usr/lib/libllama.so.0
    /usr/lib/libllama.so.0.0.8508
    /usr/lib/libmtmd.so.0
    /usr/lib/libmtmd.so.0.0.8508

Install all these libraries into LLAMA_LIB_INSTALL_DIR instead, so they don't collide with non-vendored libraries provided by other packages.

Also set the rpath if LLAMA_LIB_INSTALL_DIR is set, so that libraries are properly loaded.

# Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: used pi-coding-agent:kimi-k2.5 to confirm that my hypothesis was correct (LLAMA_LIB_INSTALL_DIR is being applied; no workaround exists with the current flags), and to review if my approach was sound and clean.