### PR TITLE
llama-model-loader: print warning when using overrides with mmap

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1117,7 +1117,6 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         }
 
         ggml_backend_buffer_type_t buft = nullptr;
-        bool buft_from_override = false;
 
         // check overrides
         if (tensor_buft_overrides) {
@@ -1128,10 +1127,15 @@ struct ggml_tensor * llama_model_loader::create_tensor(
                     if (overrides->buft == ggml_backend_cpu_buffer_type()) {
                         // when overriding to a CPU buffer, consider the extra buffer types
                         buft = select_weight_buft(hparams, t_meta, op, buft_list_cpu);
+                        if (use_mmap) {
+                            static std::once_flag once;
+                            std::call_once(once, [] {
+                                LLAMA_LOG_WARN("llama_model_loader: tensor overrides to CPU are used with mmap enabled - consider using --no-mmap for better performance\n");
+                            });
+                        }
                     } else {
                         buft = overrides->buft;
                     }
-                    buft_from_override = true;
 
                     LLAMA_LOG_DEBUG("tensor %s (%zu MiB %s) buffer type overridden to %s\n",
                             tensor_name.c_str(),
@@ -1150,9 +1154,8 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         }
 
         // avoid using a host buffer when using mmap
-        // but keep host buffers for overridden tensors - they need the host buffer for pinned memory
         auto * buft_dev = ggml_backend_buft_get_device(buft);
-        if (use_mmap && !buft_from_override && buft_dev && buft == ggml_backend_dev_host_buffer_type(buft_dev)) {
+        if (use_mmap && buft_dev && buft == ggml_backend_dev_host_buffer_type(buft_dev)) {
             auto * cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
             if (!cpu_dev) {
                 throw std::runtime_error("no CPU backend found");

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1117,6 +1117,7 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         }
 
         ggml_backend_buffer_type_t buft = nullptr;
+        bool buft_from_override = false;
 
         // check overrides
         if (tensor_buft_overrides) {
@@ -1130,6 +1131,7 @@ struct ggml_tensor * llama_model_loader::create_tensor(
                     } else {
                         buft = overrides->buft;
                     }
+                    buft_from_override = true;
 
                     LLAMA_LOG_DEBUG("tensor %s (%zu MiB %s) buffer type overridden to %s\n",
                             tensor_name.c_str(),
@@ -1148,8 +1150,9 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         }
 
         // avoid using a host buffer when using mmap
+        // but keep host buffers for overridden tensors - they need the host buffer for pinned memory
         auto * buft_dev = ggml_backend_buft_get_device(buft);
-        if (use_mmap && buft_dev && buft == ggml_backend_dev_host_buffer_type(buft_dev)) {
+        if (use_mmap && !buft_from_override && buft_dev && buft == ggml_backend_dev_host_buffer_type(buft_dev)) {
             auto * cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
             if (!cpu_dev) {
                 throw std::runtime_error("no CPU backend found");


### PR DESCRIPTION
## Overview

When using `mmap` which is enabled by default, tensor overrides don't get pinned memory. This PR skips the downgrade for overriden tensors. 

## Additional information

Before 

| model                          |       size |     params | backend    | ngl | n_ubatch | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -------: | ---: | --------------: | -------------------: |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      128 |    0 |          pp2048 |        543.68 ± 4.84 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      256 |    0 |          pp2048 |       973.01 ± 10.10 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      512 |    0 |          pp2048 |      1700.75 ± 22.03 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     1024 |    0 |          pp2048 |      2827.85 ± 18.51 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     2048 |    0 |          pp2048 |      4097.78 ± 75.23 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      128 |    1 |          pp2048 |        298.28 ± 4.26 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      256 |    1 |          pp2048 |        546.08 ± 4.33 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      512 |    1 |          pp2048 |        979.02 ± 4.78 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     1024 |    1 |          pp2048 |      1708.17 ± 27.07 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     2048 |    1 |          pp2048 |      2756.34 ± 36.39 |

After

| model                          |       size |     params | backend    | ngl | n_ubatch | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -------: | ---: | --------------: | -------------------: |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      128 |    0 |          pp2048 |        539.51 ± 7.29 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      256 |    0 |          pp2048 |       977.11 ± 10.41 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      512 |    0 |          pp2048 |      1713.08 ± 16.35 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     1024 |    0 |          pp2048 |      2838.30 ± 23.96 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     2048 |    0 |          pp2048 |      4123.53 ± 36.17 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      128 |    1 |          pp2048 |        548.10 ± 1.81 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      256 |    1 |          pp2048 |       972.36 ± 26.46 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |      512 |    1 |          pp2048 |      1737.46 ± 10.71 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     1024 |    1 |          pp2048 |      2814.28 ± 29.08 |
| gpt-oss 20B MXFP4 MoE          |  11.27 GiB |    20.91 B | CUDA       |  99 |     2048 |    1 |          pp2048 |      4114.94 ± 54.93 |


# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, asked it to implement the fix after identifying the reason

