### PR TITLE
ci : limit requirements versions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -54,4 +54,3 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           pip install -r requirements/requirements-all.txt -r tools/server/tests/requirements.txt
-          pip install flake8 pyright pre-commit

--- a/.github/workflows/gguf-publish.yml
+++ b/.github/workflows/gguf-publish.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         cd gguf-py
-        python -m pip install poetry
+        python -m pip install poetry==2.3.2
         poetry install
 
     - name: Build package

--- a/requirements/requirements-pydantic.txt
+++ b/requirements/requirements-pydantic.txt
@@ -1,3 +1,3 @@
 docstring_parser~=0.15
 pydantic~=2.11.7
-requests
+requests~=2.32.3


### PR DESCRIPTION
## Overview

Limit Python package versions installed during CI runs.

## Additional information

How hard-line should we be? We have a few packages where we set upper/lower bounds on the version, and most of the packages use `~=`, which basically means any compatible version, changing this would likely be dependency hell and break all sorts of things.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: nope