### PR TITLE
ci : bump gguf publish python version

### DIFF
--- a/.github/workflows/gguf-publish.yml
+++ b/.github/workflows/gguf-publish.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.9.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         cd gguf-py


### PR DESCRIPTION
cont #20980

Didn't notice that poetry dropped 3.9 support, let's bump Python instead of lowering poetry.