### PR TITLE
Update Android link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - Swift [ShenghaiWang/SwiftLlama](https://github.com/ShenghaiWang/SwiftLlama)
 - Delphi [Embarcadero/llama-cpp-delphi](https://github.com/Embarcadero/llama-cpp-delphi)
 - Go (no CGo needed): [hybridgroup/yzma](https://github.com/hybridgroup/yzma)
-- Android: [llama.android](/examples/llama.android)
+- Android: [llama.android](https://github.com/1opp0-org/llama.android)
 
 </details>
 


### PR DESCRIPTION
Add link to new android library on github based on llama.cpp

## Overview

Documentation only - replaces android link from `examples` to a recently created github repo that spins off a new android library: https://github.com/1opp0-org/llama.android
## Additional information

Perharps it's too soon to submit this change, I'm open for feedback but would rather get an accept/decline/comment rather than silence. 

In the following months I plan to considerably expand the JNI bridge and the sample app in the new repo, and use it as a dependency in an experimental feature in https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy. 

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO, I manually typed every character in this PR

