### PR TITLE
common : fix gguf selection in common_list_cached_models

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -454,7 +454,9 @@ static gguf_split_info get_gguf_split_info(const std::string & path) {
     std::smatch m;
 
     std::string prefix = path;
-    string_remove_suffix(prefix, ".gguf");
+    if (!string_remove_suffix(prefix, ".gguf")) {
+        return {};
+    }
 
     int index = 1;
     int count = 1;


### PR DESCRIPTION
## Overview

Fix regression that makes `common_list_cached_models()` showing all files

## Additional information

Related to #20994

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
