### PR TITLE
fix: mtmd "v.patch_embd" quant and unsupported im2col ops on Metal for deepseek-ocr

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -6988,6 +6988,8 @@ class DeepseekOCRVisionModel(MmprojModel):
             return gguf.GGMLQuantizationType.F32
         if ".rel_pos_h" in name or '.rel_pos_w' in name:
             return gguf.GGMLQuantizationType.F32
+        if ".neck." in name or ".net_" in name:
+            return gguf.GGMLQuantizationType.F32
         return super().tensor_force_quant(name, new_name, bid, n_dims)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -345,9 +345,11 @@ static bool tensor_allows_quantization(const llama_model_quantize_params * param
 
     // do not quantize specific multimodal tensors
     quantize &= name.find(".position_embd") == std::string::npos;
-    quantize &= name.find("sam.patch_embd") == std::string::npos;
     quantize &= name.find("sam.pos_embd")   == std::string::npos;
+    quantize &= name.find("sam.neck.")      == std::string::npos;
+    quantize &= name.find("sam.net_")       == std::string::npos;
     quantize &= name.find(".rel_pos")       == std::string::npos;
+    quantize &= name.find(".patch_embd")    == std::string::npos;
 
     return quantize;
 }

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -350,6 +350,7 @@ static bool tensor_allows_quantization(const llama_model_quantize_params * param
     quantize &= name.find("sam.net_")       == std::string::npos;
     quantize &= name.find(".rel_pos")       == std::string::npos;
     quantize &= name.find(".patch_embd")    == std::string::npos;
+    quantize &= name.find(".patch_merger")  == std::string::npos;
 
     return quantize;
 }


### PR DESCRIPTION
## Bug Fixes

This PR fixes two issues affecting vision models:

1. **Quantization of `v.patch_embd`**
2. **Unsupported `im2col` (bf16) ops on Metal for DeepSeek-OCR**

---

## Details

### Vision Models — `v.patch_embd` Quantization

**Issue**
`v.patch_embd` was incorrectly quantized, causing inference failure when quantizing vision (mmproj) model.

**Fix**
Exclude `v.patch_embd` from quantization across all vision models.

**Validated on**

* `moonshotai/Kimi-VL-A3B-Instruct`
* `OpenGVLab/InternVL3-2B`
* `deepseek-ai/DeepSeek-OCR`

---

### DeepSeek-OCR — Metal bf16 `im2col`

**Issue**
Metal backend does not support `im2col` for bf16, causing `ggml_conv_2d` failures in DeepSeek-OCR vision-model.

**Fix**
Avoid unsupported bf16 `im2col` paths on Metal by using f32 type in conversion and exclude the involved tensors from quantization.

---

## Summary

* Fixes a systemic vision quantization issue (`v.patch_embd`)
* Restores DeepSeek-OCR execution on Metal (bf16)
