### PR TITLE
common : add getpwuid fallback for HF cache when HOME is not set

### DIFF
--- a/common/hf-cache.cpp
+++ b/common/hf-cache.cpp
@@ -26,6 +26,8 @@ namespace nl = nlohmann;
 #include <windows.h>
 #else
 #define HOME_DIR "HOME"
+#include <unistd.h>
+#include <pwd.h>
 #endif
 
 namespace hf_cache {
@@ -51,6 +53,13 @@ static fs::path get_cache_directory() {
                 return entry.path.empty() ? base : base / entry.path;
             }
         }
+#ifndef _WIN32
+        const struct passwd * pw = getpwuid(getuid());
+
+        if (pw->pw_dir && *pw->pw_dir) {
+            return fs::path(pw->pw_dir) / ".cache" / "huggingface" / "hub";
+        }
+#endif
         throw std::runtime_error("Failed to determine HF cache directory");
     }();
 


### PR DESCRIPTION
## Overview

Like llama's cache, we need a fallback when HOME is not defined, mostly thanks to `systemd`.

## Additional information

We don't need to check for `__EMSCRIPTEN__`:
```
$ cat test.cpp
#include <iostream>
#include <fstream>
#include <cstdlib>
#include <filesystem>

#include <unistd.h>
#include <pwd.h>

namespace fs = std::filesystem;

int main() {
    const char * home = std::getenv("HOME");
    std::cout << "HOME: " << home << std::endl;

    fs::path file = fs::path(home) / "test.txt";

    std::ofstream out(file);
    out << "something" << std::endl;
    out.close();

    std::ifstream in(file);
    std::string line;

    while (std::getline(in, line)) {
        std::cout << line << std::endl;
    }

    fs::remove(file);
    return 0;
}

$ emcc -std=c++17 test.cpp

$ node a.out.js
HOME: /home/web_user
something
```

If it's ok i can update `fs_get_cache_directory` after.

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
