### PR TITLE
completion: fix segfault on model load failure

### DIFF
--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -146,12 +146,18 @@ int main(int argc, char ** argv) {
 
     ctx   = llama_init->context();
     model = llama_init->model();
-    smpl  = llama_init->sampler(0);
 
     if (ctx == NULL) {
         LOG_ERR("%s: error: unable to create context\n", __func__);
         return 1;
     }
+
+    if (model == NULL) {
+        LOG_ERR("%s: error: unable to load model\n", __func__);
+        return 1;
+    }
+
+    smpl = llama_init->sampler(0);
 
     llama_memory_t mem = llama_get_memory(ctx);
     const llama_vocab * vocab = llama_model_get_vocab(model);


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
When common_init_from_params fails to load a model (e.g. invalid path),
  the returned common_init_result contains null members. Calling
  context() and model() safely return null, but sampler() dereferences
  an internal unique_ptr that is null, causing a segfault.

  Move the sampler access after null checks for ctx and model so we
  exit cleanly instead of crashing.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
