### PR TITLE
server : add custom socket options to disable SO_REUSEPORT

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2808,6 +2808,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PORT"));
     add_opt(common_arg(
+        {"--reuse-port"},
+        string_format("allow multiple sockets to bind to the same port (default: %s)", params.reuse_port ? "enabled" : "disabled"),
+        [](common_params & params) {
+            params.reuse_port = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_REUSE_PORT"));
+    add_opt(common_arg(
         {"--path"}, "PATH",
         string_format("path to serve static files from (default: %s)", params.public_path.c_str()),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -573,6 +573,7 @@ struct common_params {
 
     // server params
     int32_t port                = 8080;          // server listens on this network port
+    bool    reuse_port          = false;         // allow multiple sockets to bind to the same port
     int32_t timeout_read        = 600;           // http read timeout in seconds
     int32_t timeout_write       = timeout_read;  // http write timeout in seconds
     int32_t n_threads_http      = -1;    // number of threads to process HTTP requests (TODO: support threadpool)

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -189,6 +189,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--tags STRING` | set model tags, comma-separated (informational, not used for routing)<br/>(env: LLAMA_ARG_TAGS) |
 | `--host HOST` | ip address to listen, or bind to an UNIX socket if the address ends with .sock (default: 127.0.0.1)<br/>(env: LLAMA_ARG_HOST) |
 | `--port PORT` | port to listen (default: 8080)<br/>(env: LLAMA_ARG_PORT) |
+| `--reuse-port` | allow multiple sockets to bind to the same port (default: disabled)<br/>(env: LLAMA_ARG_REUSE_PORT) |
 | `--path PATH` | path to serve static files from (default: )<br/>(env: LLAMA_ARG_STATIC_PATH) |
 | `--api-prefix PREFIX` | prefix path the server serves from, without the trailing slash (default: )<br/>(env: LLAMA_ARG_API_PREFIX) |
 | `--webui-config JSON` | JSON that provides default WebUI settings (overrides WebUI defaults)<br/>(env: LLAMA_ARG_WEBUI_CONFIG) |

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -111,15 +111,16 @@ bool server_http_context::init(const common_params & params) {
     srv->set_read_timeout (params.timeout_read);
     srv->set_write_timeout(params.timeout_write);
     srv->set_socket_options([reuse_port = params.reuse_port](socket_t sock) {
-#ifdef _WIN32
-        const char opt = 1;
-#else
         int opt = 1;
+#ifdef _WIN32
+        const char * optval = (const char *)&opt;
+#else
+        const void * optval = &opt;
 #endif
-        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, optval, sizeof(opt));
         if (reuse_port) {
 #ifdef SO_REUSEPORT
-            setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt));
+            setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, optval, sizeof(opt));
 #else
             LOG_WRN("%s: SO_REUSEPORT is not supported\n", __func__);
 #endif

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -110,6 +110,14 @@ bool server_http_context::init(const common_params & params) {
     // set timeouts and change hostname and port
     srv->set_read_timeout (params.timeout_read);
     srv->set_write_timeout(params.timeout_write);
+    srv->set_socket_options([](socket_t sock) {
+#ifdef _WIN32
+        const char opt = 1;
+#else
+        int opt = 1;
+#endif
+        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    });
 
     if (params.api_keys.size() == 1) {
         auto key = params.api_keys[0];

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -110,13 +110,20 @@ bool server_http_context::init(const common_params & params) {
     // set timeouts and change hostname and port
     srv->set_read_timeout (params.timeout_read);
     srv->set_write_timeout(params.timeout_write);
-    srv->set_socket_options([](socket_t sock) {
+    srv->set_socket_options([reuse_port = params.reuse_port](socket_t sock) {
 #ifdef _WIN32
         const char opt = 1;
 #else
         int opt = 1;
 #endif
         setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+        if (reuse_port) {
+#ifdef SO_REUSEPORT
+            setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt));
+#else
+            LOG_WRN("%s: SO_REUSEPORT is not supported\n", __func__);
+#endif
+        }
     });
 
     if (params.api_keys.size() == 1) {


### PR DESCRIPTION
## Overview

cpp-httplib uses `SO_REUSEPORT` by default, see #20963

## Additional information

https://github.com/yhirose/cpp-httplib/pull/2409
https://github.com/yhirose/cpp-httplib/pull/2411

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
