### PR TITLE
devops: SYCL: upgrade compute-runtime

### DIFF
--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -33,6 +33,23 @@ RUN mkdir -p /app/full \
 
 FROM intel/deep-learning-essentials:$ONEAPI_VERSION AS base
 
+ARG IGC_VERSION=v2.30.1
+ARG IGC_VERSION_FULL=2_2.30.1+20950
+ARG COMPUTE_RUNTIME_VERSION=26.09.37435.1
+ARG COMPUTE_RUNTIME_VERSION_FULL=26.09.37435.1-0
+ARG IGDGMM_VERSION=22.9.0
+RUN mkdir /tmp/neo/ && cd /tmp/neo/ \
+  && wget https://github.com/intel/intel-graphics-compiler/releases/download/$IGC_VERSION/intel-igc-core-${IGC_VERSION_FULL}_amd64.deb \
+  && wget https://github.com/intel/intel-graphics-compiler/releases/download/$IGC_VERSION/intel-igc-opencl-${IGC_VERSION_FULL}_amd64.deb \
+  && wget https://github.com/intel/compute-runtime/releases/download/$COMPUTE_RUNTIME_VERSION/intel-ocloc-dbgsym_${COMPUTE_RUNTIME_VERSION_FULL}_amd64.ddeb \
+  && wget https://github.com/intel/compute-runtime/releases/download/$COMPUTE_RUNTIME_VERSION/intel-ocloc_${COMPUTE_RUNTIME_VERSION_FULL}_amd64.deb \
+  && wget https://github.com/intel/compute-runtime/releases/download/$COMPUTE_RUNTIME_VERSION/intel-opencl-icd-dbgsym_${COMPUTE_RUNTIME_VERSION_FULL}_amd64.ddeb \
+  && wget https://github.com/intel/compute-runtime/releases/download/$COMPUTE_RUNTIME_VERSION/intel-opencl-icd_${COMPUTE_RUNTIME_VERSION_FULL}_amd64.deb \
+  && wget https://github.com/intel/compute-runtime/releases/download/$COMPUTE_RUNTIME_VERSION/libigdgmm12_${IGDGMM_VERSION}_amd64.deb \
+  && wget https://github.com/intel/compute-runtime/releases/download/$COMPUTE_RUNTIME_VERSION/libze-intel-gpu1-dbgsym_${COMPUTE_RUNTIME_VERSION_FULL}_amd64.ddeb \
+  && wget https://github.com/intel/compute-runtime/releases/download/$COMPUTE_RUNTIME_VERSION/libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION_FULL}_amd64.deb \
+  && dpkg --install *.deb
+
 RUN apt-get update \
     && apt-get install -y libgomp1 curl\
     && apt autoremove -y \


### PR DESCRIPTION
## Overview

This Pull Requests makes the `intel.Dockerfile` manually install compute-runtime. The versions can be configurable. Installing the latest compute-runtime brings more performance

## Additional information

Before:
| Model Name | Parameters | Quantization | pp512 | tg128 |
| :--- | :--- | :--- | :--- | :--- |
| gpt-oss-20b | 20.91B | Q4_K_M | 418.85 ± 122.90 | 18.44 ± 0.10 |
| gpt-oss-20b | 20.91B | Q2_K | 650.17 ± 14.30 | 17.36 ± 0.15 |
| Qwen2.5-Coder-14B-Instruct | 14.77B | Q4_K_M | 419.46 ± 1.72 | 31.62 ± 0.08 |
| Qwen3-14B | 14.77B | Q4_K_M | 422.07 ± 3.47 | 31.05 ± 0.45 |
| Qwen3.5-9B | 8.95B | Q8_0 | 661.90 ± 6.73 | 10.17 ± 0.32 |
| Qwen3.5-9B | 8.95B | Q4_K_M | 629.68 ± 4.40 | 36.01 ± 0.25 |
| omnicoder-9b | 8.95B | Q4_K_M | 664.33 ± 4.70 | 39.07 ± 0.40 |
| Qwen3-8B | 8.19B | Q4_K_M | 777.85 ± 6.03 | 47.87 ± 0.54 |
| Qwen2.5-Coder-7B-Instruct | 7.62B | Q4_K_M | 855.79 ± 1.57 | 56.17 ± 0.60 |
| Qwen3.5-4B | 4.21B | BF16 | 1115.91 ± 4.36 | 7.36 ± 0.07 |
| Qwen3.5-4B | 4.21B | F16 | 1071.68 ± 9.38 | 35.50 ± 0.61 |
| Qwen3.5-4B | 4.21B | Q8_0 | 1085.59 ± 4.45 | 18.81 ± 0.25 |
| Qwen3.5-4B | 4.21B | Q4_K_M | 1126.62 ± 6.22 | 58.75 ± 0.17 |
| Qwen3-4B-Instruct-2507 | 4.02B | Q4_K_M | 1357.17 ± 12.63 | 75.00 ± 0.20 |
| Qwen2.5-Coder-3B-Instruct | 3.09B | Q4_K_M | 1890.10 ± 8.86 | 88.61 ± 0.08 |
| Qwen3.5-2B | 1.88B | BF16 | 2604.98 ± 2.98 | 16.25 ± 0.00 |
| Qwen3.5-2B | 1.88B | F16 | 2662.87 ± 24.81 | 66.73 ± 0.05 |
| Qwen3.5-2B | 1.88B | Q8_0 | 2707.19 ± 20.45 | 39.21 ± 0.16 |
| Qwen3.5-2B | 1.88B | Q4_K_M | 2831.33 ± 32.70 | 103.31 ± 0.17 |
| Qwen3.5-0.8B | 752.39M | BF16 | 4467.43 ± 518.12 | 41.91 ± 0.03 |
| Qwen3.5-0.8B | 752.39M | F16 | 5052.75 ± 7.71 | 123.99 ± 0.40 |
| Qwen3.5-0.8B | 752.39M | Q8_0 | 5186.29 ± 5.57 | 79.18 ± 0.07 |
| Qwen3.5-0.8B | 752.39M | Q4_K_M | 5331.16 ± 5.11 | 141.06 ± 2.32 |
| Qwen3-Embedding-0.6B | 595.78M | Q8_0 | 7591.63 ± 62.93 | 90.12 ± 1.44 |

[message (3).txt](https://github.com/user-attachments/files/26316047/message.3.txt)
<br>

After:
| Model Name | Parameters | Quantization | pp512 | tg128 |
| :--- | :--- | :--- | :--- | :--- |
| gpt-oss-20b | 20.91B | Q4_K_M | 602.93 ± 27.97 | 24.26 ± 0.09 |
| gpt-oss-20b | 20.91B | Q2_K | 668.24 ± 12.80 | 22.71 ± 0.52 |
| Qwen2.5-Coder-14B-Instruct | 14.77B | Q4_K_M | 423.65 ± 0.45 | 35.24 ± 0.19 |
| Qwen3-14B | 14.77B | Q4_K_M | 424.88 ± 1.12 | 35.81 ± 0.13 |
| Qwen3.5-9B | 8.95B | Q8_0 | 671.02 ± 5.56 | 10.49 ± 0.26 |
| Qwen3.5-9B | 8.95B | Q4_K_M | 632.40 ± 4.51 | 41.55 ± 0.56 |
| omnicoder-9b | 8.95B | Q4_K_M | 682.40 ± 6.17 | 44.73 ± 0.52 |
| Qwen3-8B | 8.19B | Q4_K_M | 781.95 ± 5.12 | 55.09 ± 0.65 |
| Qwen2.5-Coder-7B-Instruct | 7.62B | Q4_K_M | 859.96 ± 2.57 | 66.10 ± 0.16 |
| Qwen3.5-4B | 4.21B | BF16 | 1120.41 ± 0.55 | 7.49 ± 0.01 |
| Qwen3.5-4B | 4.21B | F16 | 1057.17 ± 5.07 | 39.36 ± 0.01 |
| Qwen3.5-4B | 4.21B | Q8_0 | 1099.29 ± 4.42 | 19.64 ± 0.27 |
| Qwen3.5-4B | 4.21B | Q4_K_M | 1124.47 ± 6.13 | 67.02 ± 0.49 |
| Qwen3-4B-Instruct-2507 | 4.02B | Q4_K_M | 1395.60 ± 10.99 | 81.71 ± 0.88 |
| Qwen2.5-Coder-3B-Instruct | 3.09B | Q4_K_M | 1907.42 ± 9.89 | 113.55 ± 0.29 |
| Qwen3.5-2B | 1.88B | BF16 | 2617.66 ± 1.92 | 16.87 ± 0.01 |
| Qwen3.5-2B | 1.88B | F16 | 2700.13 ± 22.90 | 75.94 ± 0.03 |
| Qwen3.5-2B | 1.88B | Q8_0 | 2762.62 ± 17.78 | 42.30 ± 0.01 |
| Qwen3.5-2B | 1.88B | Q4_K_M | 2854.65 ± 34.59 | 131.51 ± 0.09 |
| Qwen3.5-0.8B | 752.39M | BF16 | 4843.73 ± 10.87 | 45.27 ± 0.02 |
| Qwen3.5-0.8B | 752.39M | F16 | 5122.87 ± 16.95 | 160.76 ± 0.11 |
| Qwen3.5-0.8B | 752.39M | Q8_0 | 5259.07 ± 19.40 | 93.03 ± 0.03 |
| Qwen3.5-0.8B | 752.39M | Q4_K_M | 5418.57 ± 10.59 | 182.09 ± 1.53 |
| Qwen3-Embedding-0.6B | 595.78M | Q8_0 | 7831.38 ± 23.01 | 107.29 ± 0.66 |

[message (4).txt](https://github.com/user-attachments/files/26316055/message.4.txt)
<br>


# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
