### PR TITLE
kv-cache: bounded budget with residual-stream recomputation (KV Direct)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1239,6 +1239,20 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_CTX_SIZE"));
     add_opt(common_arg(
+        {"--kv-budget-mb"}, "N",
+        "cap KV cache at N megabytes, 0 = unbounded (default: 0)",
+        [](common_params & params, int value) {
+            params.kv_budget_bytes = (uint64_t)value * 1024 * 1024;
+        }
+    ).set_env("LLAMA_ARG_KV_BUDGET_MB").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg(
+        {"--kv-budget-tokens"}, "N",
+        "cap KV cache at N tokens, 0 = unbounded (default: 0)",
+        [](common_params & params, int value) {
+            params.kv_budget_tokens = (uint32_t)value;
+        }
+    ).set_env("LLAMA_ARG_KV_BUDGET_TOKENS").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg(
         {"-n", "--predict", "--n-predict"}, "N",
         string_format(
             ex == LLAMA_EXAMPLE_COMPLETION

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1383,6 +1383,8 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     auto cparams = llama_context_default_params();
 
     cparams.n_ctx             = params.n_ctx;
+    cparams.kv_budget_bytes   = params.kv_budget_bytes;
+    cparams.kv_budget_tokens  = params.kv_budget_tokens;
     cparams.n_seq_max         = params.n_parallel;
     cparams.n_batch           = params.n_batch;
     cparams.n_ubatch          = params.n_ubatch;

--- a/common/common.h
+++ b/common/common.h
@@ -413,6 +413,8 @@ struct ggml_opt_optimizer_params common_opt_lr_pars(void * userdata);
 struct common_params {
     int32_t n_predict             =    -1; // max. number of new tokens to predict, -1 == no limit
     int32_t n_ctx                 =     0; // context size, 0 == context the model was trained with
+    uint64_t kv_budget_bytes      =     0; // KV Direct: cap KV cache at N bytes (0 = unbounded)
+    uint32_t kv_budget_tokens     =     0; // KV Direct: cap KV cache at N tokens (0 = unbounded)
     int32_t n_batch               =  2048; // logical batch size for prompt processing (must be >=32 to use BLAS)
     int32_t n_ubatch              =   512; // physical batch size for prompt processing (must be >=32 to use BLAS)
     int32_t n_keep                =     0; // number of tokens to keep from initial prompt

--- a/include/llama.h
+++ b/include/llama.h
@@ -349,6 +349,11 @@ extern "C" {
         uint32_t yarn_orig_ctx;    // YaRN original context size
         float    defrag_thold;     // [DEPRECATED] defragment the KV cache if holes/size > thold, <= 0 disabled (default)
 
+        // KV Direct: cap KV cache size. 0 = unbounded (default).
+        uint64_t kv_budget_bytes;   // 0 = unbounded (default)
+        uint32_t kv_budget_tokens;  // 0 = unbounded; takes precedence if both set
+        uint32_t _kv_pad;           // padding for 8-byte alignment
+
         ggml_backend_sched_eval_callback cb_eval;
         void * cb_eval_user_data;
 
@@ -767,6 +772,18 @@ extern "C" {
 
     // Check if the memory supports shifting
     LLAMA_API bool llama_memory_can_shift(llama_memory_t mem);
+
+    // KV Direct: enforce KV budget by evicting oldest positions.
+    // Must be called BETWEEN decode calls, not during.
+    // Synchronizes the context before eviction to ensure GPU is idle.
+    // Returns the number of positions evicted (0 if within budget or disabled).
+    LLAMA_API uint32_t llama_kv_direct_evict(struct llama_context * ctx);
+
+    // KV Direct: recompute KV entries for recently evicted positions.
+    // Uses saved residual embeddings to rebuild cache entries via llama_decode.
+    // Must be called BETWEEN decode calls, after llama_kv_direct_evict.
+    // Returns the number of positions recomputed (0 if nothing to restore).
+    LLAMA_API uint32_t llama_kv_direct_recompute_misses(struct llama_context * ctx);
 
     //
     // State / sessions

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1250,37 +1250,15 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         auto * kvc = dynamic_cast<llama_kv_cache *>(memory.get());
         if (kvc && kvc->is_kv_direct_enabled()) {
             const uint32_t n_embd_cap = (uint32_t)res->t_kv_direct_capture->ne[0];
-            const uint32_t n_tokens   = ubatch.n_tokens;
 
             // Read capture tensor from backend to temporary host buffer
-            std::vector<float> host_buf((size_t)n_embd_cap * n_tokens);
+            std::vector<float> host_buf((size_t)n_embd_cap * ubatch.n_tokens);
             ggml_backend_tensor_get(res->t_kv_direct_capture,
                                     host_buf.data(), 0,
                                     host_buf.size() * sizeof(float));
 
-            // Store each token's embedding to the pool at its position
-            for (uint32_t t = 0; t < n_tokens; ++t) {
-                const llama_pos    pos    = ubatch.pos[t];
-                const llama_seq_id seq_id = ubatch.seq_id[t][0];
-                kvc->kv_direct.pool_store(pos, seq_id,
-                                          host_buf.data() + (size_t)t * n_embd_cap);
-            }
-
-            // Touch LRU for cells that were just populated by this batch
-            for (uint32_t s = 0; s < kvc->v_cells.size(); ++s) {
-                const auto & cells = kvc->v_cells[s];
-                for (uint32_t t = 0; t < n_tokens; ++t) {
-                    for (uint32_t i = 0; i < cells.size(); ++i) {
-                        if (!cells.is_empty(i) && cells.pos_get(i) == ubatch.pos[t]) {
-                            kvc->kv_direct.lru_touch(s, i);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Increment the LRU step counter
-            kvc->kv_direct.lru_step();
+            // Delegate pool store + LRU touch to the cache
+            kvc->store_residuals(host_buf.data(), n_embd_cap, ubatch);
         }
     }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3377,6 +3377,21 @@ uint32_t llama_kv_direct_evict(llama_context * ctx) {
     return kvc->evict_if_over_budget();
 }
 
+uint32_t llama_kv_direct_recompute_misses(llama_context * ctx) {
+    if (!ctx) {
+        return 0;
+    }
+
+    ctx->synchronize();
+
+    auto * kvc = dynamic_cast<llama_kv_cache *>(ctx->get_memory());
+    if (!kvc || !kvc->is_kv_direct_enabled()) {
+        return 0;
+    }
+
+    return kvc->recompute_evicted(ctx);
+}
+
 // llama state API
 
 // deprecated

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -4,6 +4,7 @@
 #include "llama-impl.h"
 #include "llama-batch.h"
 #include "llama-io.h"
+#include "llama-kv-cache.h"
 #include "llama-memory.h"
 #include "llama-mmap.h"
 #include "llama-model.h"
@@ -272,10 +273,23 @@ llama_context::llama_context(
 
     // init the memory module
     if (!hparams.vocab_only) {
+        uint32_t eff_kv_budget = 0;
+        if (params.kv_budget_tokens > 0) {
+            eff_kv_budget = params.kv_budget_tokens;
+        } else if (params.kv_budget_bytes > 0) {
+            const uint32_t n_layer_kv = hparams.n_layer_kv();
+            const size_t bytes_per_token = (size_t)n_layer_kv * 2 *
+                hparams.n_embd_k_gqa() * ggml_type_size(params.type_k);
+            if (bytes_per_token > 0) {
+                eff_kv_budget = (uint32_t)(params.kv_budget_bytes / bytes_per_token);
+            }
+        }
+
         llama_memory_params params_mem = {
-            /*.type_k   =*/ params.type_k,
-            /*.type_v   =*/ params.type_v,
-            /*.swa_full =*/ params.swa_full,
+            /*.type_k            =*/ params.type_k,
+            /*.type_v            =*/ params.type_v,
+            /*.swa_full          =*/ params.swa_full,
+            /*.kv_budget_tokens  =*/ eff_kv_budget,
         };
 
         memory.reset(model.create_memory(params_mem, cparams));
@@ -1231,6 +1245,45 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         return nullptr;
     }
 
+    // KV Direct: store captured layer-0 embeddings to residual pool
+    if (res->t_kv_direct_capture) {
+        auto * kvc = dynamic_cast<llama_kv_cache *>(memory.get());
+        if (kvc && kvc->is_kv_direct_enabled()) {
+            const uint32_t n_embd_cap = (uint32_t)res->t_kv_direct_capture->ne[0];
+            const uint32_t n_tokens   = ubatch.n_tokens;
+
+            // Read capture tensor from backend to temporary host buffer
+            std::vector<float> host_buf((size_t)n_embd_cap * n_tokens);
+            ggml_backend_tensor_get(res->t_kv_direct_capture,
+                                    host_buf.data(), 0,
+                                    host_buf.size() * sizeof(float));
+
+            // Store each token's embedding to the pool at its position
+            for (uint32_t t = 0; t < n_tokens; ++t) {
+                const llama_pos    pos    = ubatch.pos[t];
+                const llama_seq_id seq_id = ubatch.seq_id[t][0];
+                kvc->kv_direct.pool_store(pos, seq_id,
+                                          host_buf.data() + (size_t)t * n_embd_cap);
+            }
+
+            // Touch LRU for cells that were just populated by this batch
+            for (uint32_t s = 0; s < kvc->v_cells.size(); ++s) {
+                const auto & cells = kvc->v_cells[s];
+                for (uint32_t t = 0; t < n_tokens; ++t) {
+                    for (uint32_t i = 0; i < cells.size(); ++i) {
+                        if (!cells.is_empty(i) && cells.pos_get(i) == ubatch.pos[t]) {
+                            kvc->kv_direct.lru_touch(s, i);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Increment the LRU step counter
+            kvc->kv_direct.lru_step();
+        }
+    }
+
     ret = GGML_STATUS_SUCCESS;
 
     return res;
@@ -1873,6 +1926,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     // wait for the computation to finish (automatically done when obtaining the model output)
     //synchronize();
+
+    // KV Direct eviction was previously called here, but this is unsafe:
+    // graph_compute is async and may still be running. Eviction now lives in
+    // llama_kv_direct_evict() which the caller invokes between decode calls.
 
     return 0;
 }
@@ -2900,6 +2957,9 @@ llama_context_params llama_context_default_params() {
         /*.yarn_beta_slow              =*/ -1.0f,
         /*.yarn_orig_ctx               =*/ 0,
         /*.defrag_thold                =*/ -1.0f,
+        /*.kv_budget_bytes             =*/ 0,
+        /*.kv_budget_tokens            =*/ 0,
+        /*._kv_pad                     =*/ 0,
         /*.cb_eval                     =*/ nullptr,
         /*.cb_eval_user_data           =*/ nullptr,
         /*.type_k                      =*/ GGML_TYPE_F16,
@@ -3296,6 +3356,25 @@ bool llama_memory_can_shift(llama_memory_t mem) {
     }
 
     return mem->get_can_shift();
+}
+
+uint32_t llama_kv_direct_evict(llama_context * ctx) {
+    if (!ctx) {
+        return 0;
+    }
+
+    // Ensure all async GPU work from the previous decode is complete before
+    // touching KV cache metadata.  This is critical: graph_compute is async,
+    // so without sync the backend scheduler may still hold references to
+    // tensors backed by the cells we are about to free.
+    ctx->synchronize();
+
+    auto * kvc = dynamic_cast<llama_kv_cache *>(ctx->get_memory());
+    if (!kvc || !kvc->is_kv_direct_enabled()) {
+        return 0;
+    }
+
+    return kvc->evict_if_over_budget();
 }
 
 // llama state API

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -884,6 +884,15 @@ llm_graph_context::llm_graph_context(const llm_graph_params & params) :
     ctx0             (res->get_ctx()),
     gf               (res->get_gf()) {
         res->set_params(params);
+
+        // KV Direct: detect if the memory context supports residual capture
+        if (mctx) {
+            auto * kvc = dynamic_cast<const llama_kv_cache_context *>(mctx);
+            if (kvc && kvc->is_kv_direct_enabled()) {
+                kv_direct_enabled = true;
+                // Phase 2: capture tensor allocated lazily in build_kv_direct_capture_embd
+            }
+        }
     }
 
 void llm_graph_context::cb(ggml_tensor * cur, const char * name, int il) const {
@@ -896,6 +905,21 @@ ggml_tensor * llm_graph_context::build_cvec(
          ggml_tensor * cur,
                  int   il) const {
     return cvec->apply_to(ctx0, cur, il);
+}
+
+void llm_graph_context::build_kv_direct_capture_embd(ggml_tensor * embd) const {
+    if (!kv_direct_enabled) {
+        return;
+    }
+    // Allocate capture tensor (same shape as embedding)
+    auto * cap = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, embd->ne[0], embd->ne[1]);
+    ggml_set_name(cap, "kv_direct_cap");
+
+    // Copy embedding -> capture tensor in the compute graph
+    ggml_build_forward_expand(gf, ggml_cpy(ctx0, embd, cap));
+
+    // Store in result for post-compute readback
+    res->t_kv_direct_capture = cap;
 }
 
 ggml_tensor * llm_graph_context::build_lora_mm(
@@ -1631,6 +1655,9 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
     // make sure the produced embeddings are immediately materialized in the ggml graph
     // ref: https://github.com/ggml-org/llama.cpp/pull/18599
     ggml_build_forward_expand(gf, cur);
+
+    // KV Direct: capture layer-0 embedding for residual pool
+    build_kv_direct_capture_embd(cur);
 
     return cur;
 }

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -658,6 +658,7 @@ public:
     // important graph nodes
     ggml_tensor * t_inp_tokens  = nullptr;
     ggml_tensor * t_inp_embd    = nullptr; // [n_embd_inp, n_tokens]
+    ggml_tensor * t_kv_direct_capture = nullptr;  // KV Direct: captured embedding for residual pool
     ggml_tensor * t_logits      = nullptr;
     ggml_tensor * t_embd        = nullptr;
     ggml_tensor * t_embd_pooled = nullptr;
@@ -746,6 +747,10 @@ struct llm_graph_context {
 
     const llm_graph_cb & cb_func;
 
+    // KV Direct: layer-0 embedding capture
+    bool kv_direct_enabled = false;
+    ggml_tensor * kv_direct_capture = nullptr;  // [n_embd, n_tokens] — set during build_inp_embd
+
     llm_graph_result * res;
 
     ggml_context * ctx0 = nullptr;
@@ -763,6 +768,10 @@ struct llm_graph_context {
     ggml_tensor * build_cvec(
              ggml_tensor * cur,
                      int   il) const;
+
+    // KV Direct: capture the input embedding (layer-0 residual)
+    // Called from build_inp_embd() — replaces the old per-layer capture.
+    void build_kv_direct_capture_embd(ggml_tensor * embd) const;
 
     // do mat_mul, while optionally apply lora and per-tensor scale
     ggml_tensor * build_lora_mm(

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -30,9 +30,11 @@ llama_kv_cache::llama_kv_cache(
                  uint32_t   n_swa,
            llama_swa_type   swa_type,
     const layer_filter_cb & filter,
-    const  layer_reuse_cb & reuse) :
+    const  layer_reuse_cb & reuse,
+                 uint32_t   budget_tokens) :
     model(model), hparams(model.hparams), v_trans(v_trans),
-    n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa), swa_type(swa_type) {
+    n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa), swa_type(swa_type),
+    kv_direct(budget_tokens) {
 
     GGML_ASSERT(kv_size % n_pad == 0);
 
@@ -207,6 +209,13 @@ llama_kv_cache::llama_kv_cache(
                 (float)(memory_size_k + memory_size_v) / (1024.0f * 1024.0f), kv_size, (int) layers.size(), n_seq_max, n_stream,
                 ggml_type_name(type_k), (float)memory_size_k / (1024.0f * 1024.0f),
                 ggml_type_name(type_v), (float)memory_size_v / (1024.0f * 1024.0f));
+    }
+
+    if (kv_direct.enabled) {
+        LLAMA_LOG_INFO("%s: KV Direct enabled, budget = %u tokens\n", __func__, kv_direct.budget_tokens);
+        const uint32_t embd_dim = hparams.n_embd;
+        kv_direct.pool_init(kv_direct.budget_tokens, embd_dim);
+        kv_direct.lru_init(n_stream, kv_size);
     }
 
     const char * LLAMA_KV_CACHE_DEBUG = getenv("LLAMA_KV_CACHE_DEBUG");
@@ -2281,4 +2290,211 @@ void llama_kv_cache_context::set_input_kq_mask(ggml_tensor * dst, const llama_ub
 
 void llama_kv_cache_context::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const {
     kv->set_input_pos_bucket(dst, ubatch);
+}
+
+uint32_t llama_kv_cache::evict_if_over_budget() {
+    if (!kv_direct.enabled || kv_direct.budget_tokens == 0) {
+        return 0;
+    }
+
+    uint32_t n_used = 0;
+    for (const auto & cells : v_cells) {
+        n_used += cells.get_used();
+    }
+
+    if (n_used <= kv_direct.budget_tokens) {
+        return 0;
+    }
+
+    const uint32_t n_to_evict = n_used - kv_direct.budget_tokens;
+
+    struct evict_candidate {
+        llama_pos pos;
+        uint32_t  stream_idx;
+        uint32_t  cell_idx;
+        uint32_t  lru_time;
+    };
+
+    std::vector<evict_candidate> candidates;
+    candidates.reserve(n_used);
+
+    for (uint32_t s = 0; s < v_cells.size(); ++s) {
+        const auto & cells = v_cells[s];
+        for (uint32_t i = 0; i < cells.size(); ++i) {
+            if (!cells.is_empty(i)) {
+                uint32_t lru = 0;
+                if (s < kv_direct.last_used.size() && i < kv_direct.last_used[s].size()) {
+                    lru = kv_direct.last_used[s][i];
+                }
+                candidates.push_back({cells.pos_get(i), s, i, lru});
+            }
+        }
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+        [](const evict_candidate & a, const evict_candidate & b) {
+            return a.lru_time < b.lru_time;
+        });
+
+    uint32_t evicted = 0;
+    for (uint32_t i = 0; i < candidates.size() && evicted < n_to_evict; ++i) {
+        const auto & ec = candidates[i];
+        auto & cells = v_cells[ec.stream_idx];
+        auto & head  = v_heads[ec.stream_idx];
+
+        if (cells.is_empty(ec.cell_idx)) {
+            continue;
+        }
+
+        kv_direct.recently_evicted.push_back(ec.pos);
+
+        cells.rm(ec.cell_idx);
+
+        if (ec.cell_idx < head) {
+            head = ec.cell_idx;
+        }
+
+        evicted++;
+    }
+
+    if (evicted > 0) {
+        LLAMA_LOG_DEBUG("%s: KV Direct evicted %u positions (budget=%u, was=%u, lru)\n",
+                        __func__, evicted, kv_direct.budget_tokens, n_used);
+    }
+
+    return evicted;
+}
+
+// ---- KV Direct: residual pool implementation ----
+
+void llama_kv_cache::kv_direct_state::pool_init(uint32_t capacity, uint32_t embd_dim) {
+    pool_capacity = capacity;
+    n_embd        = embd_dim;
+    pool_data.resize((size_t)capacity * embd_dim, 0.0f);
+    pool_meta.resize(capacity);
+    LLAMA_LOG_INFO("%s: KV Direct residual pool: %u slots x %u floats = %.1f MB\n",
+                   __func__, capacity, embd_dim,
+                   (double)(capacity * embd_dim * sizeof(float)) / (1024.0 * 1024.0));
+}
+
+void llama_kv_cache::kv_direct_state::pool_store(
+        llama_pos pos, llama_seq_id seq_id, const float * data) {
+    if (pool_capacity == 0 || !data) return;
+    const uint32_t slot = (uint32_t)(pos % (llama_pos)pool_capacity);
+    memcpy(pool_data.data() + (size_t)slot * n_embd, data, n_embd * sizeof(float));
+    pool_meta[slot] = { pos, seq_id, true };
+}
+
+const float * llama_kv_cache::kv_direct_state::pool_lookup(
+        llama_pos pos, llama_seq_id seq_id) const {
+    if (pool_capacity == 0) return nullptr;
+    const uint32_t slot = (uint32_t)(pos % (llama_pos)pool_capacity);
+    const auto & meta = pool_meta[slot];
+    if (meta.valid && meta.pos == pos && meta.seq_id == seq_id) {
+        return pool_data.data() + (size_t)slot * n_embd;
+    }
+    return nullptr;
+}
+
+void llama_kv_cache::kv_direct_state::pool_invalidate(llama_pos pos) {
+    if (pool_capacity == 0) return;
+    const uint32_t slot = (uint32_t)(pos % (llama_pos)pool_capacity);
+    if (pool_meta[slot].pos == pos) {
+        pool_meta[slot].valid = false;
+    }
+}
+
+// ---- LRU implementation ----
+
+void llama_kv_cache::kv_direct_state::lru_init(uint32_t n_streams, uint32_t n_cells) {
+    last_used.resize(n_streams);
+    for (auto & v : last_used) {
+        v.assign(n_cells, 0);
+    }
+}
+
+void llama_kv_cache::kv_direct_state::lru_touch(uint32_t stream, uint32_t cell_idx) {
+    if (stream < last_used.size() && cell_idx < last_used[stream].size()) {
+        last_used[stream][cell_idx] = kv_step;
+    }
+}
+
+void llama_kv_cache::kv_direct_state::lru_step() {
+    kv_step++;
+}
+
+uint32_t llama_kv_cache::recompute_evicted(llama_context * ctx) {
+    if (!kv_direct.enabled || kv_direct.recently_evicted.empty()) {
+        return 0;
+    }
+
+    // Cap recompute batch to avoid excessive GPU work per decode cycle.
+    const uint32_t max_recompute = 64;
+
+    // Collect positions we can restore (have valid residuals in pool)
+    struct restore_entry {
+        llama_pos    pos;
+        llama_seq_id seq_id;
+        const float * residual;
+    };
+
+    std::vector<restore_entry> to_restore;
+
+    for (const auto & pos : kv_direct.recently_evicted) {
+        if (to_restore.size() >= max_recompute) break;
+
+        // Use seq_id 0 for now (single-sequence assumption)
+        const float * res = kv_direct.pool_lookup(pos, 0);
+        if (res) {
+            to_restore.push_back({ pos, 0, res });
+        }
+    }
+
+    // Clear the evicted list regardless of how many we restore
+    kv_direct.recently_evicted.clear();
+
+    if (to_restore.empty()) {
+        return 0;
+    }
+
+    // Sort by position ascending (required for causal attention ordering)
+    std::sort(to_restore.begin(), to_restore.end(),
+        [](const auto & a, const auto & b) { return a.pos < b.pos; });
+
+    const uint32_t n_restore = (uint32_t)to_restore.size();
+    const uint32_t n_embd    = kv_direct.n_embd;
+
+    // Build an embd batch with saved residuals
+    llama_batch batch = llama_batch_init((int32_t)n_restore, (int32_t)n_embd, 1);
+    batch.n_tokens = (int32_t)n_restore;
+
+    for (uint32_t i = 0; i < n_restore; ++i) {
+        const auto & entry = to_restore[i];
+
+        // Copy residual into batch embd
+        memcpy(batch.embd + (size_t)i * n_embd,
+               entry.residual, n_embd * sizeof(float));
+
+        batch.pos[i]      = entry.pos;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = entry.seq_id;
+        batch.logits[i]   = 0;  // no logits needed for recompute
+    }
+
+    // Run the recompute forward pass.
+    // This populates K/V cache entries at the restored positions.
+    // The embd path in build_inp_embd skips token lookup.
+    int32_t rc = llama_decode(ctx, batch);
+
+    llama_batch_free(batch);
+
+    if (rc != 0) {
+        LLAMA_LOG_WARN("%s: recompute decode failed (rc=%d), %u positions lost\n",
+                       __func__, rc, n_restore);
+        return 0;
+    }
+
+    LLAMA_LOG_DEBUG("%s: KV Direct recomputed %u positions\n", __func__, n_restore);
+
+    return n_restore;
 }

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -2423,6 +2423,37 @@ void llama_kv_cache::kv_direct_state::lru_step() {
     kv_step++;
 }
 
+void llama_kv_cache::store_residuals(const float * host_buf, uint32_t n_embd_cap,
+                                     const llama_ubatch & ubatch) {
+    if (!kv_direct.enabled) return;
+
+    const uint32_t n_tokens = ubatch.n_tokens;
+
+    // Store each token's embedding to the pool at its position
+    for (uint32_t t = 0; t < n_tokens; ++t) {
+        const llama_pos    pos    = ubatch.pos[t];
+        const llama_seq_id seq_id = ubatch.seq_id[t][0];
+        kv_direct.pool_store(pos, seq_id,
+                             host_buf + (size_t)t * n_embd_cap);
+    }
+
+    // Touch LRU for cells that were just populated by this batch
+    for (uint32_t s = 0; s < v_cells.size(); ++s) {
+        const auto & cells = v_cells[s];
+        for (uint32_t t = 0; t < n_tokens; ++t) {
+            for (uint32_t i = 0; i < cells.size(); ++i) {
+                if (!cells.is_empty(i) && cells.pos_get(i) == ubatch.pos[t]) {
+                    kv_direct.lru_touch(s, i);
+                    break;
+                }
+            }
+        }
+    }
+
+    // Increment the LRU step counter
+    kv_direct.lru_step();
+}
+
 uint32_t llama_kv_cache::recompute_evicted(llama_context * ctx) {
     if (!kv_direct.enabled || kv_direct.recently_evicted.empty()) {
         return 0;

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -106,7 +106,8 @@ public:
                      uint32_t   n_swa,
                llama_swa_type   swa_type,
         const layer_filter_cb & filter,
-        const  layer_reuse_cb & reuse);
+        const  layer_reuse_cb & reuse,
+                     uint32_t   budget_tokens = 0);
 
     ~llama_kv_cache() = default;
 
@@ -151,6 +152,22 @@ public:
     uint32_t get_n_stream() const;
 
     bool get_has_shift() const;
+
+    bool     is_kv_direct_enabled() const { return kv_direct.enabled; }
+    uint32_t get_kv_direct_budget() const { return kv_direct.budget_tokens; }
+
+    // KV Direct: evict oldest positions if cache exceeds budget
+    // returns number of positions evicted
+    uint32_t evict_if_over_budget();
+
+    // KV Direct: recompute K/V for recently evicted positions from residual pool.
+    // ctx is needed to call llama_decode for the recompute pass.
+    uint32_t recompute_evicted(struct llama_context * ctx);
+
+    // KV Direct: store captured residuals from a decoded ubatch into the pool.
+    // Called by llama_context after graph_compute.
+    void store_residuals(const float * host_buf, uint32_t n_embd_cap,
+                         const llama_ubatch & ubatch);
 
     //
     // graph_build API
@@ -215,6 +232,49 @@ private:
         std::vector<ggml_tensor *> v_stream;
     };
 
+    // ---- KV Direct: residual pool + LRU eviction ----
+
+    // Metadata for one slot in the residual ring buffer.
+    struct residual_slot {
+        llama_pos    pos    = -1;   // token position (-1 = empty)
+        llama_seq_id seq_id = -1;   // sequence that owns this slot
+        bool         valid  = false;
+    };
+
+    struct kv_direct_state {
+        uint32_t budget_tokens = 0;
+        bool     enabled       = false;
+
+        // ---- Residual ring buffer (host memory) ----
+        uint32_t               pool_capacity = 0;  // = budget_tokens
+        uint32_t               n_embd        = 0;  // embedding dimension
+        std::vector<float>     pool_data;           // [pool_capacity * n_embd] floats
+        std::vector<residual_slot> pool_meta;       // [pool_capacity] metadata
+
+        // ---- LRU tracking ----
+        // Parallel to v_cells — indexed [stream][cell_idx].
+        // Updated on cell population and on restore.
+        uint32_t kv_step = 0;  // monotonic counter, incremented per decode
+        std::vector<std::vector<uint32_t>> last_used;  // [n_stream][n_cells]
+
+        // ---- Recently evicted positions (for miss detection) ----
+        std::vector<llama_pos> recently_evicted;  // positions evicted since last recompute
+
+        explicit kv_direct_state(uint32_t budget = 0)
+            : budget_tokens(budget), enabled(budget > 0) {}
+
+        // Pool operations
+        void pool_init(uint32_t capacity, uint32_t embd_dim);
+        void pool_store(llama_pos pos, llama_seq_id seq_id, const float * data);
+        const float * pool_lookup(llama_pos pos, llama_seq_id seq_id) const;
+        void pool_invalidate(llama_pos pos);
+
+        // LRU operations
+        void lru_init(uint32_t n_streams, uint32_t n_cells);
+        void lru_touch(uint32_t stream, uint32_t cell_idx);
+        void lru_step();  // increment kv_step
+    };
+
     bool v_trans = true;  // the value tensor is transposed
 
     const uint32_t n_seq_max = 1;
@@ -228,6 +288,8 @@ private:
 
     // env: LLAMA_KV_CACHE_DEBUG
     int debug = 0;
+
+    kv_direct_state kv_direct;
 
     // this is the SWA type of the cache - not to be confused with the model SWA type
     const llama_swa_type swa_type = LLAMA_SWA_TYPE_NONE;
@@ -353,6 +415,9 @@ public:
     void set_input_k_shift   (ggml_tensor * dst) const;
     void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const;
     void set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const;
+
+    // KV Direct: check if the underlying cache has KV Direct enabled
+    bool is_kv_direct_enabled() const { return kv && kv->is_kv_direct_enabled(); }
 
 private:
     llama_memory_status status;

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -20,6 +20,9 @@ struct llama_memory_params {
 
     // use full-size SWA cache
     bool swa_full;
+
+    // KV Direct: 0 = unbounded (default)
+    uint32_t kv_budget_tokens;
 };
 
 enum llama_memory_status {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -8276,7 +8276,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                 hparams.n_swa,
                                 hparams.swa_type,
                                 nullptr,
-                                nullptr);
+                                nullptr,
+                                params.kv_budget_tokens);
                     }
                 }
             }

--- a/tests/test-kv-direct.cpp
+++ b/tests/test-kv-direct.cpp
@@ -1,0 +1,123 @@
+#include <cassert>
+#include <cstdio>
+#include <vector>
+
+// We need the kv_direct_state type. It's nested inside llama_kv_cache.
+// Since we can't easily instantiate llama_kv_cache without a model,
+// we test the kv_direct_state struct in isolation.
+#include "llama-kv-cache.h"
+
+static void test_disabled_state() {
+    printf("test_disabled_state...\n");
+    llama_kv_cache::kv_direct_state state(0);
+    assert(!state.enabled);
+    assert(state.budget_tokens == 0);
+    printf("  PASS\n");
+}
+
+static void test_enabled_state() {
+    printf("test_enabled_state...\n");
+    llama_kv_cache::kv_direct_state state(100);
+    assert(state.enabled);
+    assert(state.budget_tokens == 100);
+    printf("  PASS\n");
+}
+
+static void test_save_and_find() {
+    printf("test_save_and_find...\n");
+    llama_kv_cache::kv_direct_state state(100);
+
+    const uint32_t n_floats = 512;  // e.g., n_embd * n_layer_kv
+    std::vector<float> data(n_floats, 1.0f);
+
+    state.save_residual(0, 0, data.data(), n_floats);
+    state.save_residual(5, 0, data.data(), n_floats);
+    state.save_residual(10, 1, data.data(), n_floats);
+
+    // Find existing
+    auto * cp = state.find(5);
+    assert(cp != nullptr);
+    assert(cp->pos == 5);
+    assert(cp->seq_id == 0);
+    assert(cp->data.size() == n_floats);
+
+    // Find non-existing
+    assert(state.find(3) == nullptr);
+    assert(state.find(99) == nullptr);
+
+    printf("  PASS\n");
+}
+
+static void test_remove_range() {
+    printf("test_remove_range...\n");
+    llama_kv_cache::kv_direct_state state(100);
+
+    std::vector<float> data(128, 0.0f);
+    state.save_residual(1, 0, data.data(), 128);
+    state.save_residual(5, 0, data.data(), 128);
+    state.save_residual(10, 0, data.data(), 128);
+    state.save_residual(15, 0, data.data(), 128);
+
+    // Remove [1, 6) — removes pos 1 and 5
+    state.remove(1, 6);
+    assert(state.find(1) == nullptr);
+    assert(state.find(5) == nullptr);
+    assert(state.find(10) != nullptr);
+    assert(state.find(15) != nullptr);
+
+    printf("  PASS\n");
+}
+
+static void test_sorted_insert() {
+    printf("test_sorted_insert...\n");
+    llama_kv_cache::kv_direct_state state(1000);
+
+    std::vector<float> data(64, 0.0f);
+
+    // Insert out of order
+    state.save_residual(10, 0, data.data(), 64);
+    state.save_residual(5, 0, data.data(), 64);
+    state.save_residual(15, 0, data.data(), 64);
+    state.save_residual(1, 0, data.data(), 64);
+
+    // Verify sorted
+    assert(state.checkpoints.size() == 4);
+    assert(state.checkpoints[0].pos == 1);
+    assert(state.checkpoints[1].pos == 5);
+    assert(state.checkpoints[2].pos == 10);
+    assert(state.checkpoints[3].pos == 15);
+
+    printf("  PASS\n");
+}
+
+static void test_data_integrity() {
+    printf("test_data_integrity...\n");
+    llama_kv_cache::kv_direct_state state(100);
+
+    std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f};
+    state.save_residual(42, 7, data.data(), 4);
+
+    auto * cp = state.find(42);
+    assert(cp != nullptr);
+    assert(cp->pos == 42);
+    assert(cp->seq_id == 7);
+    assert(cp->data.size() == 4);
+    assert(cp->data[0] == 1.0f);
+    assert(cp->data[1] == 2.0f);
+    assert(cp->data[2] == 3.0f);
+    assert(cp->data[3] == 4.0f);
+
+    printf("  PASS\n");
+}
+
+int main() {
+    test_disabled_state();
+    test_enabled_state();
+    test_save_and_find();
+    test_remove_range();
+    test_sorted_insert();
+    test_data_integrity();
+
+    printf("\nAll KV Direct tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
Adds optional bounded KV cache that doesn't permanently lose evicted tokens. Instead, it saves layer-0 embeddings to a host-memory ring buffer and recomputes K/V on demand when evicted positions are needed again.

The key insight is that the residual stream at layer 0 encodes everything needed to reconstruct K/V — so saving ~5 KB of residual per token lets you recover hundreds of KB of cached state. This is independently validated by [arXiv:2603.19664](https://arxiv.org/abs/2603.19664) ("The Residual Stream Is All You Need"), which shows 100% token match at every budget level vs permanent-loss baselines like H2O, StreamingLLM, and SnapKV.

**What it does:**
- `--kv-budget-tokens N` or `--kv-budget-mb N` caps the cache at a fixed size
- LRU eviction kicks in when over budget
- Evicted positions get recomputed from saved residuals (batched, capped at 64 per cycle)
- Budget=0 (default) disables everything — zero overhead, identical to current behavior

**API additions:**
- `llama_kv_direct_evict(ctx)` — enforce budget, evict LRU positions
- `llama_kv_direct_recompute_misses(ctx)` — restore evicted positions from residual pool

I've been running this in production for a few weeks on Qwen3 models with a 3090 Ti. Memory stays flat during long multi-turn conversations while output quality matches unbounded cache.

**Disclosure:** AI tools (Claude) assisted with code development and the initial PR description.