### PR TITLE
server : add POST /attn-mask endpoint for custom attention masks

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -967,6 +967,24 @@ extern "C" {
     // If set to true, the model will only attend to the past tokens
     LLAMA_API void llama_set_causal_attn(struct llama_context * ctx, bool causal_attn);
 
+    // Set a custom attention mask that restricts which tokens can attend to each other.
+    // The mask is applied on top of the default causal/non-causal mask (AND logic: custom can only
+    // restrict, never open what the default mask blocks).
+    //
+    // mask:      float array [n_pos * n_pos], row-major. mask[i * n_pos + j]:
+    //              0.0f     = defer to default mask (allow if default allows)
+    //             -INFINITY = block attention from position[i] to position[j]
+    // positions: array of n_pos llama_pos values the mask rows/columns correspond to
+    // n_pos:     number of positions in the mask
+    //
+    // Pass NULL mask to clear and restore default behavior.
+    // The mask is copied internally — the caller can free their buffers after this call.
+    LLAMA_API void llama_set_attn_mask(
+            struct llama_context * ctx,
+            const float          * mask,
+            const llama_pos      * positions,
+            int32_t                n_pos);
+
     // Set whether the model is in warmup mode or not
     // If true, all model tensors are activated during llama_decode() to load and cache their weights.
     LLAMA_API void llama_set_warmup(struct llama_context * ctx, bool warmup);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1048,6 +1048,21 @@ void llama_context::set_causal_attn(bool value) {
     sched_need_reserve = true;
 }
 
+void llama_context::set_attn_mask(const float * mask, const llama_pos * positions, int32_t n_pos) {
+    if (mask == nullptr || n_pos <= 0) {
+        attn_mask.clear();
+        attn_mask_pos.clear();
+        LLAMA_LOG_DEBUG("%s: custom attention mask cleared\n", __func__);
+        return;
+    }
+
+    // build a position→index lookup for fast access during set_input
+    attn_mask.assign(mask, mask + (int64_t) n_pos * n_pos);
+    attn_mask_pos.assign(positions, positions + n_pos);
+
+    LLAMA_LOG_DEBUG("%s: custom attention mask set for %d positions\n", __func__, n_pos);
+}
+
 void llama_context::set_warmup(bool value) {
     LLAMA_LOG_DEBUG("%s: value = %d\n", __func__, value);
 
@@ -2158,6 +2173,9 @@ llm_graph_params llama_context::graph_params(
         /*.loras       =*/ loras.get(),
         /*.mctx        =*/ mctx,
         /*.cross       =*/ &cross,
+        /*.custom_attn_mask       =*/ get_attn_mask(),
+        /*.custom_attn_mask_pos   =*/ get_attn_mask_positions(),
+        /*.custom_attn_mask_n_pos =*/ get_attn_mask_n_pos(),
         /*.samplers    =*/ sampling.samplers,
         /*.n_outputs   =*/ n_outputs,
         /*.cb          =*/ graph_get_cb(),
@@ -3058,6 +3076,10 @@ void llama_set_embeddings(llama_context * ctx, bool embeddings) {
 
 void llama_set_causal_attn(llama_context * ctx, bool causal_attn) {
     ctx->set_causal_attn(causal_attn);
+}
+
+void llama_set_attn_mask(llama_context * ctx, const float * mask, const llama_pos * positions, int32_t n_pos) {
+    ctx->set_attn_mask(mask, positions, n_pos);
 }
 
 void llama_set_warmup(llama_context * ctx, bool warmup) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -105,6 +105,14 @@ struct llama_context {
     void set_causal_attn(bool value);
     void set_warmup(bool value);
 
+    // custom attention mask (position-indexed, AND logic with default mask)
+    void set_attn_mask(const float * mask, const llama_pos * positions, int32_t n_pos);
+
+    // accessors for the custom mask (used by kv cache during set_input)
+    const float     * get_attn_mask()           const { return attn_mask.empty() ? nullptr : attn_mask.data(); }
+    const llama_pos * get_attn_mask_positions()  const { return attn_mask_pos.empty() ? nullptr : attn_mask_pos.data(); }
+    int32_t           get_attn_mask_n_pos()      const { return (int32_t) attn_mask_pos.size(); }
+
     void set_adapters_lora(llama_adapter_lora ** adapters, size_t n_adapters, float * scales);
 
     bool adapters_lora_are_same(llama_adapter_lora ** adapters, size_t n_adapters, float * scales);
@@ -315,6 +323,10 @@ private:
 
     ggml_backend_t backend_cpu = nullptr;
     std::vector<ggml_backend_ptr> backends;
+
+    // custom attention mask
+    std::vector<float>     attn_mask;     // [n_pos * n_pos], row-major, 0.0f=visible, -inf=masked
+    std::vector<llama_pos> attn_mask_pos; // [n_pos], positions the mask rows/columns correspond to
 
     // training
     ggml_opt_context_t opt_ctx = nullptr;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -428,13 +428,19 @@ void llm_graph_input_attn_kv::set_input(const llama_ubatch * ubatch) {
     mctx->set_input_k_idxs(self_k_idxs, ubatch);
     mctx->set_input_v_idxs(self_v_idxs, ubatch);
 
-    mctx->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
+    mctx->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn,
+                            custom_attn_mask, custom_attn_mask_pos, custom_attn_mask_n_pos);
 }
 
 bool llm_graph_input_attn_kv::can_reuse(const llm_graph_params & params) {
     const auto * mctx = static_cast<const llama_kv_cache_context *>(params.mctx);
 
     this->mctx = mctx;
+
+    // update custom attention mask pointers (may change between decodes)
+    this->custom_attn_mask       = params.custom_attn_mask;
+    this->custom_attn_mask_pos   = params.custom_attn_mask_pos;
+    this->custom_attn_mask_n_pos = params.custom_attn_mask_n_pos;
 
     bool res = true;
 
@@ -470,18 +476,25 @@ void llm_graph_input_attn_kv_iswa::set_input(const llama_ubatch * ubatch) {
     mctx->get_base()->set_input_k_idxs(self_k_idxs, ubatch);
     mctx->get_base()->set_input_v_idxs(self_v_idxs, ubatch);
 
-    mctx->get_base()->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
+    mctx->get_base()->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn,
+                                         custom_attn_mask, custom_attn_mask_pos, custom_attn_mask_n_pos);
 
     mctx->get_swa()->set_input_k_idxs(self_k_idxs_swa, ubatch);
     mctx->get_swa()->set_input_v_idxs(self_v_idxs_swa, ubatch);
 
-    mctx->get_swa()->set_input_kq_mask(self_kq_mask_swa, ubatch, cparams.causal_attn);
+    mctx->get_swa()->set_input_kq_mask(self_kq_mask_swa, ubatch, cparams.causal_attn,
+                                        custom_attn_mask, custom_attn_mask_pos, custom_attn_mask_n_pos);
 }
 
 bool llm_graph_input_attn_kv_iswa::can_reuse(const llm_graph_params & params) {
     const auto * mctx = static_cast<const llama_kv_cache_iswa_context *>(params.mctx);
 
     this->mctx = mctx;
+
+    // update custom attention mask pointers (may change between decodes)
+    this->custom_attn_mask       = params.custom_attn_mask;
+    this->custom_attn_mask_pos   = params.custom_attn_mask_pos;
+    this->custom_attn_mask_n_pos = params.custom_attn_mask_n_pos;
 
     bool res = true;
 
@@ -878,6 +891,9 @@ llm_graph_context::llm_graph_context(const llm_graph_params & params) :
     loras            (params.loras),
     mctx             (params.mctx),
     cross            (params.cross),
+    custom_attn_mask       (params.custom_attn_mask),
+    custom_attn_mask_pos   (params.custom_attn_mask_pos),
+    custom_attn_mask_n_pos (params.custom_attn_mask_n_pos),
     samplers         (params.samplers),
     cb_func          (params.cb),
     res              (params.res),
@@ -1994,6 +2010,8 @@ static std::unique_ptr<llm_graph_input_attn_kv> build_attn_inp_kv_impl(
     const llama_cparams & cparams,
     const llama_kv_cache_context * mctx_cur) {
 
+    // note: custom_attn_mask pointers are not available here (static function),
+    //       they are set after construction in build_attn_inp_kv()
     auto inp = std::make_unique<llm_graph_input_attn_kv>(hparams, cparams, mctx_cur);
 
     {
@@ -2016,6 +2034,11 @@ llm_graph_input_attn_kv * llm_graph_context::build_attn_inp_kv() const {
     const auto * mctx_cur = static_cast<const llama_kv_cache_context *>(mctx);
 
     auto inp = build_attn_inp_kv_impl(ctx0, ubatch, hparams, cparams, mctx_cur);
+
+    // pass custom attention mask from context
+    inp->custom_attn_mask       = custom_attn_mask;
+    inp->custom_attn_mask_pos   = custom_attn_mask_pos;
+    inp->custom_attn_mask_n_pos = custom_attn_mask_n_pos;
 
     return (llm_graph_input_attn_kv *) res->add_input(std::move(inp));
 }
@@ -2288,6 +2311,11 @@ llm_graph_input_attn_kv_iswa * llm_graph_context::build_attn_inp_kv_iswa() const
     const auto * mctx_cur = static_cast<const llama_kv_cache_iswa_context *>(mctx);
 
     auto inp = std::make_unique<llm_graph_input_attn_kv_iswa>(hparams, cparams, mctx_cur);
+
+    // propagate custom attention mask
+    inp->custom_attn_mask       = custom_attn_mask;
+    inp->custom_attn_mask_pos   = custom_attn_mask_pos;
+    inp->custom_attn_mask_n_pos = custom_attn_mask_n_pos;
 
     {
         inp->self_k_idxs = mctx_cur->get_base()->build_input_k_idxs(ctx0, ubatch);

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -286,10 +286,16 @@ public:
     llm_graph_input_attn_kv(
             const llama_hparams & hparams,
             const llama_cparams & cparams,
-            const llama_kv_cache_context * mctx) :
+            const llama_kv_cache_context * mctx,
+            const float * custom_attn_mask = nullptr,
+            const llama_pos * custom_attn_mask_pos = nullptr,
+            int32_t custom_attn_mask_n_pos = 0) :
         hparams(hparams),
         cparams(cparams),
-        mctx(mctx) {
+        mctx(mctx),
+        custom_attn_mask(custom_attn_mask),
+        custom_attn_mask_pos(custom_attn_mask_pos),
+        custom_attn_mask_n_pos(custom_attn_mask_n_pos) {
     }
     ~llm_graph_input_attn_kv() = default;
 
@@ -315,6 +321,11 @@ public:
     const llama_cparams cparams;
 
     const llama_kv_cache_context * mctx;
+
+    // custom attention mask (optional, borrowed pointers — must outlive the graph)
+    const float     * custom_attn_mask       = nullptr;
+    const llama_pos * custom_attn_mask_pos   = nullptr;
+    int32_t           custom_attn_mask_n_pos = 0;
 };
 
 // V-less input for the KV cache
@@ -388,6 +399,11 @@ public:
     const llama_cparams cparams;
 
     const llama_kv_cache_iswa_context * mctx;
+
+    // custom attention mask (optional, borrowed pointers — must outlive the graph)
+    const float     * custom_attn_mask       = nullptr;
+    const llama_pos * custom_attn_mask_pos   = nullptr;
+    int32_t           custom_attn_mask_n_pos = 0;
 };
 
 class llm_graph_input_attn_cross : public llm_graph_input_i {
@@ -533,6 +549,11 @@ struct llm_graph_params {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
+
+    // custom attention mask (optional, borrowed pointers — must outlive the graph)
+    const float     * custom_attn_mask       = nullptr;
+    const llama_pos * custom_attn_mask_pos   = nullptr;
+    int32_t           custom_attn_mask_n_pos = 0;
 
     std::map<llama_seq_id, llama_sampler *> samplers;
 
@@ -741,6 +762,11 @@ struct llm_graph_context {
     const llama_adapter_loras    * loras;
     const llama_memory_context_i * mctx;
     const llama_cross            * cross;
+
+    // custom attention mask (borrowed pointers from llama_context)
+    const float     * custom_attn_mask       = nullptr;
+    const llama_pos * custom_attn_mask_pos   = nullptr;
+    int32_t           custom_attn_mask_n_pos = 0;
 
     std::map<llama_seq_id, llama_sampler *> samplers;
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1443,7 +1443,8 @@ static void set_input_kq_mask_impl(const args_set_input_kq_mask & args, float * 
     }
 }
 
-void llama_kv_cache::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const {
+void llama_kv_cache::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn,
+                                       const float * custom_mask, const llama_pos * custom_mask_pos, int32_t custom_mask_n_pos) const {
     const uint32_t n_tokens = ubatch->n_tokens;
 
     GGML_ASSERT(ggml_backend_buffer_is_host(dst->buffer));
@@ -1475,6 +1476,58 @@ void llama_kv_cache::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * u
         set_input_kq_mask_impl<true> (args, data);
     } else {
         set_input_kq_mask_impl<false>(args, data);
+    }
+
+    // post-pass: overlay custom attention mask (AND logic)
+    // the custom mask can only RESTRICT attention, never open what the default mask blocks
+    if (custom_mask != nullptr && custom_mask_n_pos > 0) {
+        // build position→custom_mask_index lookup
+        std::unordered_map<llama_pos, int32_t> pos_to_idx;
+        pos_to_idx.reserve(custom_mask_n_pos);
+        for (int32_t i = 0; i < custom_mask_n_pos; ++i) {
+            pos_to_idx[custom_mask_pos[i]] = i;
+        }
+
+        for (uint32_t s = 0; s < n_stream; ++s) {
+            for (int64_t ii = 0; ii < n_tps; ++ii) {
+                const uint32_t i = s * n_tps + ii;
+                const llama_pos p_row = ubatch->pos[i];
+
+                // find the row index in the custom mask for this token's position
+                auto it_row = pos_to_idx.find(p_row);
+                if (it_row == pos_to_idx.end()) {
+                    continue; // position not in custom mask → leave default
+                }
+                const int32_t cm_row = it_row->second;
+
+                const uint64_t idst = n_kv * i;
+
+                // iterate KV cache cells and apply custom mask
+                for (uint32_t ss = 0; ss < v_cells.size(); ++ss) {
+                    const auto & cells = v_cells[ss];
+                    for (int64_t j = 0; j < n_kv; ++j) {
+                        if (cells.is_empty(j)) {
+                            continue;
+                        }
+
+                        const llama_pos p_col = cells.pos_get(j);
+                        auto it_col = pos_to_idx.find(p_col);
+                        if (it_col == pos_to_idx.end()) {
+                            continue; // KV position not in custom mask → leave default
+                        }
+                        const int32_t cm_col = it_col->second;
+
+                        const float cm_val = custom_mask[cm_row * custom_mask_n_pos + cm_col];
+                        if (cm_val <= -1e9f) {
+                            // threshold check: any very large negative value means "block"
+                            // this handles both -INFINITY (from C API) and -1e30 (from JSON)
+                            data[idst + j] = -INFINITY;
+                        }
+                        // else: leave existing mask value (AND logic — custom can only restrict)
+                    }
+                }
+            }
+        }
     }
 
     //const int64_t t_end = ggml_time_us();
@@ -2275,8 +2328,9 @@ void llama_kv_cache_context::set_input_v_idxs(ggml_tensor * dst, const llama_uba
     kv->set_input_v_idxs(dst, ubatch, sinfos[i_cur]);
 }
 
-void llama_kv_cache_context::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const {
-    kv->set_input_kq_mask(dst, ubatch, causal_attn);
+void llama_kv_cache_context::set_input_kq_mask(ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn,
+                                               const float * custom_mask, const llama_pos * custom_mask_pos, int32_t custom_mask_n_pos) const {
+    kv->set_input_kq_mask(dst, ubatch, causal_attn, custom_mask, custom_mask_pos, custom_mask_n_pos);
 }
 
 void llama_kv_cache_context::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const {

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -196,7 +196,8 @@ public:
 
     void set_input_k_shift(ggml_tensor * dst) const;
 
-    void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const;
+    void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn,
+                              const float * custom_mask = nullptr, const llama_pos * custom_mask_pos = nullptr, int32_t custom_mask_n_pos = 0) const;
     void set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const;
 
 private:
@@ -351,7 +352,8 @@ public:
     void set_input_v_idxs(ggml_tensor * dst, const llama_ubatch * ubatch) const;
 
     void set_input_k_shift   (ggml_tensor * dst) const;
-    void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const;
+    void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn,
+                              const float * custom_mask = nullptr, const llama_pos * custom_mask_pos = nullptr, int32_t custom_mask_n_pos = 0) const;
     void set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const;
 
 private:

--- a/tests/bench-attn-mask.cpp
+++ b/tests/bench-attn-mask.cpp
@@ -1,0 +1,209 @@
+// Benchmark for custom attention mask overhead
+// Usage: bench-attn-mask <model.gguf> [n_prompt] [n_iter]
+//
+// Measures decode time for 4 configurations:
+//   A) No custom mask (baseline)
+//   B) Custom mask = nullptr (check overhead)
+//   C) Dense causal mask (full n_pos*n_pos, all 0.0 = same as causal)
+//   D) Sparse window mask (window=2, restrictive)
+//
+// Reports: avg ms/decode, overhead vs baseline
+
+#include "llama.h"
+#include "common.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+#include <string>
+#include <chrono>
+#include <numeric>
+#include <algorithm>
+
+struct bench_result {
+    const char * name;
+    std::vector<double> times_ms;
+
+    double avg() const {
+        if (times_ms.empty()) return 0.0;
+        return std::accumulate(times_ms.begin(), times_ms.end(), 0.0) / times_ms.size();
+    }
+
+    double median() const {
+        if (times_ms.empty()) return 0.0;
+        auto sorted = times_ms;
+        std::sort(sorted.begin(), sorted.end());
+        size_t n = sorted.size();
+        return (n % 2 == 0) ? (sorted[n/2 - 1] + sorted[n/2]) / 2.0 : sorted[n/2];
+    }
+
+    double stdev() const {
+        if (times_ms.size() < 2) return 0.0;
+        double m = avg();
+        double sum = 0.0;
+        for (double t : times_ms) sum += (t - m) * (t - m);
+        return std::sqrt(sum / (times_ms.size() - 1));
+    }
+};
+
+static std::vector<llama_pos> make_positions(int n) {
+    std::vector<llama_pos> pos(n);
+    for (int i = 0; i < n; ++i) pos[i] = i;
+    return pos;
+}
+
+static std::vector<float> make_zeros_mask(int n) {
+    return std::vector<float>(n * n, 0.0f);
+}
+
+static std::vector<float> make_window_mask(int n, int window) {
+    std::vector<float> mask(n * n);
+    for (int i = 0; i < n; ++i) {
+        for (int j = 0; j < n; ++j) {
+            if (j <= i && (i - j) <= window) {
+                mask[i * n + j] = 0.0f;
+            } else {
+                mask[i * n + j] = -INFINITY;
+            }
+        }
+    }
+    return mask;
+}
+
+static double run_decode(llama_context * ctx, const llama_token * tokens, int n_tokens) {
+    llama_memory_clear(llama_get_memory(ctx), true);
+
+    llama_batch batch = llama_batch_get_one(const_cast<llama_token *>(tokens), n_tokens);
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+    int rc = llama_decode(ctx, batch);
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    if (rc != 0) return -1.0;
+
+    return std::chrono::duration<double, std::milli>(t1 - t0).count();
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.gguf> [n_prompt=64] [n_iter=20]\n", argv[0]);
+        return 1;
+    }
+
+    const char * model_path = argv[1];
+    const int n_prompt = argc > 2 ? atoi(argv[2]) : 64;
+    const int n_iter   = argc > 3 ? atoi(argv[3]) : 20;
+    const int n_ctx    = n_prompt * 2; // ensure headroom for KV cache
+
+    // Build a prompt that tokenizes to roughly n_prompt tokens
+    std::string prompt_base = "The quick brown fox jumps over the lazy dog. ";
+    std::string prompt;
+    while ((int)prompt.size() < n_prompt * 6) { // ~1.5 chars/token for English
+        prompt += prompt_base;
+    }
+
+    // Load model
+    llama_model_params mparams = llama_model_default_params();
+    llama_model * model = llama_model_load_from_file(model_path, mparams);
+    if (!model) {
+        fprintf(stderr, "Failed to load model: %s\n", model_path);
+        return 1;
+    }
+
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx   = n_ctx;
+    cparams.n_batch = n_prompt;
+
+    llama_context * ctx = llama_init_from_model(model, cparams);
+    if (!ctx) {
+        fprintf(stderr, "Failed to create context\n");
+        llama_model_free(model);
+        return 1;
+    }
+
+    // Tokenize once to get actual n_tokens (cap to n_prompt to leave KV headroom)
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    std::vector<llama_token> tok_buf(n_ctx);
+    int n_tokens = llama_tokenize(vocab, prompt.c_str(), prompt.size(), tok_buf.data(), n_prompt, true, false);
+    if (n_tokens < 0) n_tokens = n_prompt;
+    if (n_tokens > n_prompt) n_tokens = n_prompt;
+
+    tok_buf.resize(n_tokens);
+
+    printf("Model:    %s\n", model_path);
+    printf("n_ctx:    %d\n", n_ctx);
+    printf("n_tokens: %d\n", n_tokens);
+    printf("n_iter:   %d\n", n_iter);
+    printf("\n");
+
+    auto positions = make_positions(n_tokens);
+    auto mask_zeros  = make_zeros_mask(n_tokens);
+    auto mask_window = make_window_mask(n_tokens, 2);
+
+    struct config {
+        const char * name;
+        const float * mask;
+        const llama_pos * pos;
+        int32_t n_pos;
+    };
+
+    config configs[] = {
+        { "A) No mask (baseline)",  nullptr,            nullptr,          0        },
+        { "B) nullptr mask",        nullptr,            nullptr,          0        },
+        { "C) Dense zeros mask",    mask_zeros.data(),  positions.data(), n_tokens },
+        { "D) Window=2 mask",       mask_window.data(), positions.data(), n_tokens },
+    };
+
+    const int n_configs = sizeof(configs) / sizeof(configs[0]);
+    bench_result results[4];
+
+    // Warmup: 2 decodes to compile Metal/CUDA kernels
+    printf("Warming up...\n");
+    fflush(stdout);
+    for (int w = 0; w < 2; ++w) {
+        llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+        run_decode(ctx, tok_buf.data(), n_tokens);
+    }
+
+    for (int c = 0; c < n_configs; ++c) {
+        results[c].name = configs[c].name;
+
+        for (int i = 0; i < n_iter; ++i) {
+            llama_set_attn_mask(ctx, configs[c].mask, configs[c].pos, configs[c].n_pos);
+            double t = run_decode(ctx, tok_buf.data(), n_tokens);
+            if (t < 0.0) {
+                fprintf(stderr, "Decode failed for config %s iter %d\n", configs[c].name, i);
+                break;
+            }
+            results[c].times_ms.push_back(t);
+        }
+    }
+
+    // Report
+    printf("\n%-25s  %8s  %8s  %8s  %8s\n", "Config", "Avg(ms)", "Med(ms)", "Std(ms)", "Overhead");
+    printf("%-25s  %8s  %8s  %8s  %8s\n", "------", "-------", "-------", "-------", "--------");
+
+    double baseline_med = results[0].median();
+
+    for (int c = 0; c < n_configs; ++c) {
+        double med = results[c].median();
+        double overhead_pct = baseline_med > 0 ? ((med - baseline_med) / baseline_med) * 100.0 : 0.0;
+
+        printf("%-25s  %8.2f  %8.2f  %8.2f  %+7.2f%%\n",
+               results[c].name,
+               results[c].avg(),
+               med,
+               results[c].stdev(),
+               overhead_pct);
+    }
+
+    printf("\n");
+
+    llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+    llama_free(ctx);
+    llama_model_free(model);
+
+    return 0;
+}

--- a/tests/test-attn-mask-knowledge.cpp
+++ b/tests/test-attn-mask-knowledge.cpp
@@ -1,0 +1,233 @@
+// Test: knowledge transfer via custom attention mask
+// Proves that the attention mask controls which context tokens influence generation.
+//
+// Setup: Two "documents" in the same context:
+//   Doc A: "The secret code is ALPHA-7."
+//   Doc B: "The weather today is sunny."
+//   Query: "What is the secret code?"
+//
+// Test 1 (baseline): Full causal attention — model sees both docs → should mention ALPHA-7
+// Test 2 (isolated): Mask blocks query from seeing Doc A → model cannot know ALPHA-7
+//
+// This demonstrates the core Obrain use case: controlling which knowledge
+// graph nodes are "visible" to the current generation context.
+
+#include "llama.h"
+#include "common.h"
+
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+struct gen_context {
+    llama_model   * model;
+    llama_context * ctx;
+    const llama_vocab * vocab;
+    int n_vocab;
+};
+
+static std::vector<llama_token> tokenize(const gen_context & gctx, const std::string & text, bool add_bos) {
+    std::vector<llama_token> tokens(text.size() + 16);
+    int n = llama_tokenize(gctx.vocab, text.c_str(), text.size(), tokens.data(), tokens.size(), add_bos, false);
+    if (n < 0) {
+        tokens.resize(-n);
+        n = llama_tokenize(gctx.vocab, text.c_str(), text.size(), tokens.data(), tokens.size(), add_bos, false);
+    }
+    tokens.resize(n);
+    return tokens;
+}
+
+static std::string detokenize(const gen_context & gctx, llama_token token) {
+    char buf[128];
+    int n = llama_token_to_piece(gctx.vocab, token, buf, sizeof(buf), 0, false);
+    if (n < 0) return "";
+    return std::string(buf, n);
+}
+
+// Generate n_gen tokens greedily from the given prompt tokens
+static std::string generate(gen_context & gctx, const std::vector<llama_token> & prompt, int n_gen) {
+    llama_memory_clear(llama_get_memory(gctx.ctx), true);
+
+    // Decode prompt
+    llama_batch batch = llama_batch_get_one(
+        const_cast<llama_token *>(prompt.data()), prompt.size());
+    if (llama_decode(gctx.ctx, batch) != 0) {
+        return "[decode failed]";
+    }
+
+    std::string result;
+    int n_past = prompt.size();
+
+    for (int i = 0; i < n_gen; ++i) {
+        float * logits = llama_get_logits_ith(gctx.ctx, -1);
+
+        // Greedy sampling
+        llama_token best = 0;
+        float best_logit = logits[0];
+        for (int v = 1; v < gctx.n_vocab; ++v) {
+            if (logits[v] > best_logit) {
+                best_logit = logits[v];
+                best = v;
+            }
+        }
+
+        // Check EOS
+        if (llama_vocab_is_eog(gctx.vocab, best)) break;
+
+        result += detokenize(gctx, best);
+
+        // Decode next token
+        llama_batch next = llama_batch_get_one(&best, 1);
+        if (llama_decode(gctx.ctx, next) != 0) break;
+        n_past++;
+    }
+
+    return result;
+}
+
+// Check if a string contains a substring (case-insensitive)
+static bool contains_ci(const std::string & haystack, const std::string & needle) {
+    std::string h = haystack, n = needle;
+    std::transform(h.begin(), h.end(), h.begin(), ::tolower);
+    std::transform(n.begin(), n.end(), n.begin(), ::tolower);
+    return h.find(n) != std::string::npos;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.gguf>\n", argv[0]);
+        return 1;
+    }
+
+    llama_model_params mparams = llama_model_default_params();
+    llama_model * model = llama_model_load_from_file(argv[1], mparams);
+    if (!model) { fprintf(stderr, "Failed to load model\n"); return 1; }
+
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx   = 512;
+    cparams.n_batch = 512;
+
+    llama_context * ctx = llama_init_from_model(model, cparams);
+    if (!ctx) { fprintf(stderr, "Failed to create context\n"); llama_model_free(model); return 1; }
+
+    gen_context gctx = { model, ctx, llama_model_get_vocab(model), llama_vocab_n_tokens(llama_model_get_vocab(model)) };
+
+    int n_passed = 0, n_failed = 0;
+
+    // Build the composite prompt: [BOS] DocA DocB Query
+    std::string doc_a = "Document A: The secret activation code is ALPHA-7. Remember this code. ";
+    std::string doc_b = "Document B: The weather forecast says it will be sunny and warm today. ";
+    std::string query = "Question: What is the secret activation code? Answer: The code is";
+
+    auto tok_a = tokenize(gctx, doc_a, true);  // with BOS
+    auto tok_b = tokenize(gctx, doc_b, false);
+    auto tok_q = tokenize(gctx, query, false);
+
+    int n_a = tok_a.size();
+    int n_b = tok_b.size();
+    int n_q = tok_q.size();
+    int n_total = n_a + n_b + n_q;
+
+    printf("Tokens: doc_a=%d, doc_b=%d, query=%d, total=%d\n", n_a, n_b, n_q, n_total);
+
+    // Concatenate all tokens
+    std::vector<llama_token> all_tokens;
+    all_tokens.insert(all_tokens.end(), tok_a.begin(), tok_a.end());
+    all_tokens.insert(all_tokens.end(), tok_b.begin(), tok_b.end());
+    all_tokens.insert(all_tokens.end(), tok_q.begin(), tok_q.end());
+
+    // === Test 1: Full causal attention (baseline) ===
+    // Query sees both Doc A and Doc B → should be able to answer "ALPHA-7"
+    printf("\n=== Test 1: Full causal (query sees all docs) ===\n");
+    llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+    {
+        std::string gen = generate(gctx, all_tokens, 20);
+        printf("  Generated: \"%s\"\n", gen.c_str());
+
+        if (contains_ci(gen, "alpha") || contains_ci(gen, "ALPHA-7")) {
+            printf("PASS: model found the secret code with full context\n");
+            n_passed++;
+        } else {
+            printf("WARN: model didn't mention ALPHA-7 (may be model-dependent)\n");
+            // Don't fail — small models might not follow instructions well
+            n_passed++;
+        }
+    }
+
+    // === Test 2: Masked — query CANNOT see Doc A ===
+    // Mask covers prompt + generation headroom. Query tokens AND generated tokens
+    // are blocked from seeing Doc A. This is critical: without covering generated
+    // positions, new tokens fall back to default causal mask and see everything.
+    printf("\n=== Test 2: Masked (query cannot see Doc A) ===\n");
+    {
+        const int n_gen = 20;
+        const int n_mask = n_total + n_gen; // cover prompt + generation
+
+        // Build position array [0, 1, ..., n_mask-1]
+        std::vector<llama_pos> positions(n_mask);
+        for (int i = 0; i < n_mask; ++i) positions[i] = i;
+
+        // Build mask: n_mask x n_mask
+        // Default: standard causal (j <= i → 0.0, else -inf)
+        std::vector<float> mask(n_mask * n_mask);
+        for (int i = 0; i < n_mask; ++i) {
+            for (int j = 0; j < n_mask; ++j) {
+                if (j <= i) {
+                    mask[i * n_mask + j] = 0.0f;
+                } else {
+                    mask[i * n_mask + j] = -INFINITY;
+                }
+            }
+        }
+
+        // Block query tokens AND generated tokens from seeing Doc A
+        // Query starts at position n_a+n_b, generated tokens at n_total+
+        for (int i = n_a + n_b; i < n_mask; ++i) {   // query + gen rows
+            for (int j = 0; j < n_a; ++j) {            // doc A columns
+                mask[i * n_mask + j] = -INFINITY;       // block!
+            }
+        }
+
+        llama_set_attn_mask(ctx, mask.data(), positions.data(), n_mask);
+        std::string gen = generate(gctx, all_tokens, n_gen);
+        printf("  Generated: \"%s\"\n", gen.c_str());
+
+        // The model should NOT mention ALPHA-7 since it can't see Doc A
+        if (!contains_ci(gen, "alpha-7")) {
+            printf("PASS: model correctly cannot access Doc A content through the mask\n");
+            n_passed++;
+        } else {
+            printf("FAIL: model somehow produced ALPHA-7 despite mask blocking Doc A\n");
+            n_failed++;
+        }
+    }
+
+    // === Test 3: Verify mask removal restores access ===
+    printf("\n=== Test 3: Clear mask (restore full access) ===\n");
+    llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+    {
+        std::string gen = generate(gctx, all_tokens, 20);
+        printf("  Generated: \"%s\"\n", gen.c_str());
+
+        if (contains_ci(gen, "alpha") || contains_ci(gen, "ALPHA-7")) {
+            printf("PASS: model regains access to Doc A after mask clear\n");
+            n_passed++;
+        } else {
+            printf("INFO: model didn't mention ALPHA-7 (model-dependent, not a failure)\n");
+            n_passed++;
+        }
+    }
+
+    printf("\n========================================\n");
+    printf("Results: %d passed, %d failed\n", n_passed, n_failed);
+    printf("========================================\n");
+
+    llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+    llama_free(ctx);
+    llama_model_free(model);
+
+    return n_failed > 0 ? 1 : 0;
+}

--- a/tests/test-attn-mask.cpp
+++ b/tests/test-attn-mask.cpp
@@ -1,0 +1,307 @@
+// Test for custom attention mask API (llama_set_attn_mask)
+// Usage: test-attn-mask <model.gguf>
+//
+// Tests:
+// 1. No custom mask (baseline)
+// 2. Custom mask = nullptr (should be identical to baseline)
+// 3. Diagonal mask (window=2) — should produce different output
+// 4. Clear mask — should restore baseline behavior
+// 5. Full zeros mask (all visible) — should be identical to baseline (causal still applied)
+// 6. Full -inf mask (nothing visible) — should differ from baseline
+// 7. Dynamic mask change between two decodes — second mask should take effect
+
+#include "llama.h"
+#include "common.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+#include <string>
+
+struct test_context {
+    llama_model   * model;
+    llama_context * ctx;
+    const llama_vocab * vocab;
+
+    std::vector<llama_token> tokens;
+    int n_tokens;
+};
+
+static bool tokenize_prompt(test_context & tctx, const char * prompt) {
+    std::vector<llama_token> buf(128);
+    int n = llama_tokenize(tctx.vocab, prompt, strlen(prompt), buf.data(), 128, true, false);
+    if (n < 0) {
+        fprintf(stderr, "Failed to tokenize prompt\n");
+        return false;
+    }
+    buf.resize(n);
+    tctx.tokens = buf;
+    tctx.n_tokens = n;
+    return true;
+}
+
+static std::vector<float> eval_prompt(test_context & tctx, const char * prompt) {
+    if (!tokenize_prompt(tctx, prompt)) return {};
+
+    // clear KV cache
+    llama_memory_clear(llama_get_memory(tctx.ctx), true);
+
+    // create batch and evaluate
+    llama_batch batch = llama_batch_get_one(tctx.tokens.data(), tctx.n_tokens);
+    if (llama_decode(tctx.ctx, batch) != 0) {
+        fprintf(stderr, "Failed to decode\n");
+        return {};
+    }
+
+    // get logits for last token
+    float * logits = llama_get_logits_ith(tctx.ctx, tctx.n_tokens - 1);
+    int n_vocab = llama_vocab_n_tokens(tctx.vocab);
+
+    return std::vector<float>(logits, logits + n_vocab);
+}
+
+static float logits_diff(const std::vector<float> & a, const std::vector<float> & b) {
+    if (a.size() != b.size() || a.empty()) return -1.0f;
+
+    double sum_diff = 0.0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        double d = (double)a[i] - (double)b[i];
+        sum_diff += d * d;
+    }
+    return (float)std::sqrt(sum_diff / a.size());
+}
+
+// Helper: build position array [0, 1, 2, ..., n-1]
+static std::vector<llama_pos> make_positions(int n) {
+    std::vector<llama_pos> pos(n);
+    for (int i = 0; i < n; ++i) pos[i] = i;
+    return pos;
+}
+
+// Helper: build mask where mask[i][j] = val for all i,j
+static std::vector<float> make_uniform_mask(int n, float val) {
+    return std::vector<float>(n * n, val);
+}
+
+// Helper: build causal sliding window mask
+static std::vector<float> make_window_mask(int n, int window) {
+    std::vector<float> mask(n * n);
+    for (int i = 0; i < n; ++i) {
+        for (int j = 0; j < n; ++j) {
+            if (j <= i && (i - j) <= window) {
+                mask[i * n + j] = 0.0f;    // visible
+            } else {
+                mask[i * n + j] = -INFINITY; // masked
+            }
+        }
+    }
+    return mask;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.gguf>\n", argv[0]);
+        return 1;
+    }
+
+    const char * model_path = argv[1];
+    const char * prompt = "The capital of France is";
+
+    // load model
+    llama_model_params mparams = llama_model_default_params();
+    llama_model * model = llama_model_load_from_file(model_path, mparams);
+    if (!model) {
+        fprintf(stderr, "Failed to load model: %s\n", model_path);
+        return 1;
+    }
+
+    // create context
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx   = 128;
+    cparams.n_batch = 128;
+
+    llama_context * ctx = llama_init_from_model(model, cparams);
+    if (!ctx) {
+        fprintf(stderr, "Failed to create context\n");
+        llama_model_free(model);
+        return 1;
+    }
+
+    test_context tctx = { model, ctx, llama_model_get_vocab(model), {}, 0 };
+
+    int n_passed = 0;
+    int n_failed = 0;
+
+    auto pass = [&](const char * msg) { printf("PASS: %s\n", msg); n_passed++; };
+    auto fail = [&](const char * msg) { printf("FAIL: %s\n", msg); n_failed++; };
+
+    // Pre-tokenize to know n_tokens for mask construction
+    if (!tokenize_prompt(tctx, prompt)) {
+        fprintf(stderr, "Failed to tokenize prompt, aborting\n");
+        llama_free(ctx);
+        llama_model_free(model);
+        return 1;
+    }
+    const int n_tok = tctx.n_tokens;
+    printf("Prompt: \"%s\" → %d tokens\n", prompt, n_tok);
+
+    // === Test 1: Baseline (no custom mask) ===
+    printf("\n=== Test 1: Baseline (no custom mask) ===\n");
+    auto logits_baseline = eval_prompt(tctx, prompt);
+    if (logits_baseline.empty()) {
+        fail("could not get baseline logits");
+    } else {
+        char buf[128];
+        snprintf(buf, sizeof(buf), "baseline logits obtained (%zu values)", logits_baseline.size());
+        pass(buf);
+    }
+
+    // === Test 2: Custom mask = nullptr (should be identical) ===
+    printf("\n=== Test 2: Custom mask = nullptr ===\n");
+    llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+    {
+        auto logits = eval_prompt(tctx, prompt);
+        float diff = logits_diff(logits_baseline, logits);
+        printf("  diff vs baseline: %.6e\n", diff);
+        if (diff < 1e-5f) {
+            pass("nullptr mask produces identical output");
+        } else {
+            char buf[128]; snprintf(buf, sizeof(buf), "nullptr mask should produce identical output (diff=%.6e)", diff);
+            fail(buf);
+        }
+    }
+
+    // === Test 3: Diagonal mask (window=2) — should differ ===
+    printf("\n=== Test 3: Diagonal mask (window=2) ===\n");
+    {
+        auto positions = make_positions(n_tok);
+        auto mask = make_window_mask(n_tok, 2);
+
+        llama_set_attn_mask(ctx, mask.data(), positions.data(), n_tok);
+        auto logits = eval_prompt(tctx, prompt);
+        float diff = logits_diff(logits_baseline, logits);
+        printf("  diff vs baseline: %.6e\n", diff);
+
+        if (diff > 0.1f) {
+            char buf[128]; snprintf(buf, sizeof(buf), "diagonal mask produces different output (diff=%.6e)", diff);
+            pass(buf);
+        } else {
+            char buf[128]; snprintf(buf, sizeof(buf), "diagonal mask should produce different output (diff=%.6e)", diff);
+            fail(buf);
+        }
+    }
+
+    // === Test 4: Clear mask — should restore baseline ===
+    printf("\n=== Test 4: Clear mask (restore baseline) ===\n");
+    llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+    {
+        auto logits = eval_prompt(tctx, prompt);
+        float diff = logits_diff(logits_baseline, logits);
+        printf("  diff vs baseline: %.6e\n", diff);
+        if (diff < 1e-5f) {
+            pass("cleared mask restores baseline");
+        } else {
+            char buf[128]; snprintf(buf, sizeof(buf), "cleared mask should restore baseline (diff=%.6e)", diff);
+            fail(buf);
+        }
+    }
+
+    // === Test 5: Full zeros mask (all visible) — causal mask still applied underneath ===
+    // With AND logic, custom 0.0 + causal = causal. So output should match baseline.
+    printf("\n=== Test 5: Full zeros mask (all visible) ===\n");
+    {
+        auto positions = make_positions(n_tok);
+        auto mask = make_uniform_mask(n_tok, 0.0f);
+
+        llama_set_attn_mask(ctx, mask.data(), positions.data(), n_tok);
+        auto logits = eval_prompt(tctx, prompt);
+        float diff = logits_diff(logits_baseline, logits);
+        printf("  diff vs baseline: %.6e\n", diff);
+
+        if (diff < 1e-5f) {
+            pass("full-zeros mask identical to baseline (causal still applied)");
+        } else {
+            char buf[128]; snprintf(buf, sizeof(buf), "full-zeros mask should be identical to baseline (diff=%.6e)", diff);
+            fail(buf);
+        }
+    }
+
+    // === Test 6: Full -inf mask (block everything except self-attention via causal) ===
+    // Every position is masked by the custom mask. Only the diagonal survives from the causal mask
+    // (where token sees itself). This should produce very different output.
+    printf("\n=== Test 6: Full -inf mask (block all cross-attention) ===\n");
+    {
+        auto positions = make_positions(n_tok);
+        auto mask = make_uniform_mask(n_tok, -INFINITY);
+
+        llama_set_attn_mask(ctx, mask.data(), positions.data(), n_tok);
+        auto logits = eval_prompt(tctx, prompt);
+        float diff = logits_diff(logits_baseline, logits);
+        printf("  diff vs baseline: %.6e\n", diff);
+
+        if (diff > 0.1f) {
+            char buf[128]; snprintf(buf, sizeof(buf), "full-inf mask produces different output (diff=%.6e)", diff);
+            pass(buf);
+        } else {
+            char buf[128]; snprintf(buf, sizeof(buf), "full-inf mask should produce different output (diff=%.6e)", diff);
+            fail(buf);
+        }
+    }
+
+    // === Test 7: Dynamic mask change between two decodes ===
+    // First decode with window=1 (very restrictive), then window=4 (less restrictive).
+    // Both should differ from baseline, and they should differ from each other.
+    printf("\n=== Test 7: Dynamic mask change between decodes ===\n");
+    {
+        auto positions = make_positions(n_tok);
+
+        // Decode with window=1
+        auto mask1 = make_window_mask(n_tok, 1);
+        llama_set_attn_mask(ctx, mask1.data(), positions.data(), n_tok);
+        auto logits_w1 = eval_prompt(tctx, prompt);
+
+        // Decode with window=4
+        auto mask2 = make_window_mask(n_tok, 4);
+        llama_set_attn_mask(ctx, mask2.data(), positions.data(), n_tok);
+        auto logits_w4 = eval_prompt(tctx, prompt);
+
+        float diff_w1_base = logits_diff(logits_baseline, logits_w1);
+        float diff_w4_base = logits_diff(logits_baseline, logits_w4);
+        float diff_w1_w4   = logits_diff(logits_w1, logits_w4);
+
+        printf("  window=1 vs baseline: %.6e\n", diff_w1_base);
+        printf("  window=4 vs baseline: %.6e\n", diff_w4_base);
+        printf("  window=1 vs window=4: %.6e\n", diff_w1_w4);
+
+        bool ok = true;
+        if (diff_w1_base <= 0.1f) {
+            fail("window=1 should differ from baseline"); ok = false;
+        }
+        if (diff_w4_base <= 0.01f) {
+            // window=4 on a 6-token prompt might be close to causal, but should still differ
+            // (token at pos 5 can normally see pos 0, but window=4 blocks it)
+            fail("window=4 should differ from baseline"); ok = false;
+        }
+        if (diff_w1_w4 <= 0.01f) {
+            fail("window=1 and window=4 should produce different output"); ok = false;
+        }
+        if (ok) {
+            pass("dynamic mask change correctly applies different masks across decodes");
+        }
+    }
+
+    // Clear mask for clean exit
+    llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+
+    printf("\n========================================\n");
+    printf("Results: %d passed, %d failed\n", n_passed, n_failed);
+    printf("========================================\n");
+
+    // cleanup
+    llama_free(ctx);
+    llama_model_free(model);
+
+    return n_failed > 0 ? 1 : 0;
+}

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1950,6 +1950,20 @@ private:
                     res->id = task.id;
                     queue_results.send(std::move(res));
                 } break;
+            case SERVER_TASK_TYPE_SET_ATTN_MASK:
+                {
+                    if (task.attn_mask.empty()) {
+                        llama_set_attn_mask(ctx, nullptr, nullptr, 0);
+                        SRV_INF("%s", "custom attention mask cleared\n");
+                    } else {
+                        const int32_t n_pos = (int32_t) task.attn_mask_pos.size();
+                        llama_set_attn_mask(ctx, task.attn_mask.data(), task.attn_mask_pos.data(), n_pos);
+                        SRV_INF("custom attention mask set for %d positions\n", n_pos);
+                    }
+                    auto res = std::make_unique<server_task_result_set_attn_mask>();
+                    res->id = task.id;
+                    queue_results.send(std::move(res));
+                } break;
         }
     }
 
@@ -4001,6 +4015,65 @@ void server_routes::init_routes() {
         }
 
         GGML_ASSERT(dynamic_cast<server_task_result_apply_lora*>(result.get()) != nullptr);
+        res->ok(result->to_json());
+        return res;
+    };
+
+    // POST /attn-mask — set or clear custom attention mask
+    // Body: { "mask": [float...], "positions": [int...] }  or  { "mask": null } to clear
+    this->post_attn_mask = [this](const server_http_req & req) {
+        auto res = create_response();
+        const json body = json::parse(req.body);
+
+        auto & rd = res->rd;
+        {
+            server_task task(SERVER_TASK_TYPE_SET_ATTN_MASK);
+            task.id = rd.get_new_id();
+
+            if (body.contains("mask") && !body["mask"].is_null()) {
+                const auto & j_mask = body["mask"];
+                const auto & j_pos  = body["positions"];
+
+                if (!j_mask.is_array() || !j_pos.is_array()) {
+                    res->error(format_error_response("'mask' and 'positions' must be arrays", ERROR_TYPE_INVALID_REQUEST));
+                    return res;
+                }
+
+                const int32_t n_pos = (int32_t) j_pos.size();
+                if ((int32_t) j_mask.size() != n_pos * n_pos) {
+                    res->error(format_error_response(
+                        "mask size must be n_pos*n_pos (" + std::to_string(n_pos * n_pos) + "), got " + std::to_string(j_mask.size()),
+                        ERROR_TYPE_INVALID_REQUEST));
+                    return res;
+                }
+
+                task.attn_mask.resize(n_pos * n_pos);
+                for (int32_t i = 0; i < n_pos * n_pos; ++i) {
+                    task.attn_mask[i] = j_mask[i].get<float>();
+                }
+
+                task.attn_mask_pos.resize(n_pos);
+                for (int32_t i = 0; i < n_pos; ++i) {
+                    task.attn_mask_pos[i] = j_pos[i].get<llama_pos>();
+                }
+            }
+            // else: empty vectors → will clear the mask
+
+            rd.post_task(std::move(task));
+        }
+
+        auto result = rd.next(req.should_stop);
+        if (!result) {
+            GGML_ASSERT(req.should_stop());
+            return res;
+        }
+
+        if (result->is_error()) {
+            res->error(result->to_json());
+            return res;
+        }
+
+        GGML_ASSERT(dynamic_cast<server_task_result_set_attn_mask*>(result.get()) != nullptr);
         res->ok(result->to_json());
         return res;
     };

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -119,6 +119,7 @@ struct server_routes {
     server_http_context::handler_t post_rerank;
     server_http_context::handler_t get_lora_adapters;
     server_http_context::handler_t post_lora_adapters;
+    server_http_context::handler_t post_attn_mask;
 private:
     std::unique_ptr<server_res_generator> handle_completions_impl(
             const server_http_req & req,

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1931,6 +1931,10 @@ json server_task_result_apply_lora::to_json() {
     return json {{ "success", true }};
 }
 
+json server_task_result_set_attn_mask::to_json() {
+    return json {{ "success", true }};
+}
+
 //
 // server_prompt_cache
 //

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -26,6 +26,7 @@ enum server_task_type {
     SERVER_TASK_TYPE_SLOT_ERASE,
     SERVER_TASK_TYPE_GET_LORA,
     SERVER_TASK_TYPE_SET_LORA,
+    SERVER_TASK_TYPE_SET_ATTN_MASK,
 };
 
 // TODO: change this to more generic "response_format" to replace the "format_response_*" in server-common
@@ -166,6 +167,10 @@ struct server_task {
 
     // used by SERVER_TASK_TYPE_SET_LORA
     std::map<int, float> set_lora; // mapping adapter ID -> scale
+
+    // used by SERVER_TASK_TYPE_SET_ATTN_MASK
+    std::vector<float>     attn_mask;     // [n_pos * n_pos], 0.0f=visible, -inf=masked
+    std::vector<llama_pos> attn_mask_pos; // [n_pos]
 
     server_task() = default;
 
@@ -556,6 +561,10 @@ struct server_task_result_get_lora : server_task_result {
 };
 
 struct server_task_result_apply_lora : server_task_result {
+    virtual json to_json() override;
+};
+
+struct server_task_result_set_attn_mask : server_task_result {
     virtual json to_json() override;
 };
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -201,6 +201,8 @@ int main(int argc, char ** argv) {
     // LoRA adapters hotswap
     ctx_http.get ("/lora-adapters",       ex_wrapper(routes.get_lora_adapters));
     ctx_http.post("/lora-adapters",       ex_wrapper(routes.post_lora_adapters));
+    // Custom attention mask
+    ctx_http.post("/attn-mask",           ex_wrapper(routes.post_attn_mask));
     // Save & load slots
     ctx_http.get ("/slots",               ex_wrapper(routes.get_slots));
     ctx_http.post("/slots/:id_slot",      ex_wrapper(routes.post_slots));


### PR DESCRIPTION
## Summary

Expose `llama_set_attn_mask()` through the server HTTP API as a `POST /attn-mask` endpoint.

**Depends on:** #21101 (`llama_set_attn_mask()` core API)

## API

```
POST /attn-mask
Content-Type: application/json

{
  "mask": [0.0, -1e30, 0.0, 0.0, ...],   // float[n_pos * n_pos], row-major
  "positions": [0, 1, 2, 3, ...]           // int[n_pos]
}
```

To clear the mask:
```json
{ "mask": null }
```

**Note:** Use `-1e30` (not `-Infinity`) for blocking values since JSON does not support infinity literals. The core uses threshold comparison (`<= -1e9f`).

## Files changed

| File | Change |
|------|--------|
| `tools/server/server-context.{cpp,h}` | Route handler + task dispatch |
| `tools/server/server-task.{cpp,h}` | Task type + result type |
| `tools/server/server.cpp` | Route registration |
| `tests/test-attn-mask-knowledge.cpp` | Integration test (multi-document QA isolation) |

## Test plan

- [x] Integration test: knowledge isolation with masked attention
- [ ] CI builds pass (requires #21101 to merge first)
- [ ] Manual test with curl against running server