### PR TITLE
metal: add opt-in V skip for negligible attention weights

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -224,6 +224,16 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
                 [prep setObject:@"1" forKey:@"GGML_METAL_EMBED_LIBRARY"];
 #endif
 
+                // opt-in Metal flash-attention optimization
+                // enable with GGML_METAL_FA_SKIP_V=1
+                {
+                    const char * env = getenv("GGML_METAL_FA_SKIP_V");
+                    if (env && env[0] == '1') {
+                        [prep setObject:@"1" forKey:@"GGML_METAL_FA_SKIP_V"];
+                        GGML_LOG_INFO("%s: GGML_METAL_FA_SKIP_V enabled\n", __func__);
+                    }
+                }
+
                 MTLCompileOptions * options = [MTLCompileOptions new];
                 options.preprocessorMacros = prep;
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -6725,6 +6725,11 @@ kernel void kernel_flash_attn_ext_vec(
                     }
                 } else {
                     FOR_UNROLL (short cc = 0; cc < C/NE; ++cc) {
+#if GGML_METAL_FA_SKIP_V
+                        // skip V dequant / accumulation for negligible post-softmax weights
+                        const float attn_weight = float(ss[NE*cc + ty]);
+                        if (attn_weight < 1e-6f) continue;
+#endif
                         device const vd4_t * pv4 = (device const vd4_t *) (v + ((ic + NE*cc + ty)*args.nb21));
 
                         FOR_UNROLL (short ii = 0; ii < DV4/NL; ++ii) {


### PR DESCRIPTION
## Summary

Adds an opt-in optimization to the Metal flash attention vec kernel that
skips V dequantization and accumulation for positions where the post-softmax
attention weight is below 1e-6.

Reduces wasted dequant + FMA work when attention is sparse.

Gated by GGML_METAL_FA_SKIP_V=1 environment variable (default: off).
No behavior change unless explicitly enabled.

## Changes

- ggml-metal.metal: threshold check in quantized V accumulation loop
- ggml-metal-device.m: env var gating + log message

## Validation (Apple M5 Max, Qwen3.5-35B-A3B Q8_0)

Perplexity (wikitext-103, 32K context, 50 chunks):

  SKIP_V=0: 7.0638 ± 0.021
  SKIP_V=1: 7.0638 ± 0.021

Delta: 0.000

Decode (llama-bench, q8_0):

  SKIP_V=0: 85.15 tok/s (tg128), 1142.93 tok/s (pp32768+tg128)
  SKIP_V=1: 85.04 tok/s (tg128), 1144.78 tok/s (pp32768+tg128)

Within noise. No regression observed.

## Scope

- Metal only (no CUDA changes)
- Applies to quantized V path in FA vec kernel
- Default off (opt-in via env var)

## Notes

- Threshold (1e-6) produced identical PPL across tested values (1e-4 to 1e-8)
  in this setup
- Effect depends on V dequant cost; minimal difference observed for q8_0
- Also tested on q4_0 KV cache with identical ON/OFF PPL