### PR TITLE
common : fix **/x glob matching

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -703,7 +703,6 @@ static inline bool glob_match(const char * pattern, const char * str) {
     }
     if (pattern[0] == '*' && pattern[1] == '*') {
         const char * p = pattern + 2;
-        if (*p == '/') p++;
         if (glob_match(p, str)) return true;
         if (*str != '\0') return glob_match(pattern, str + 1);
         return false;


### PR DESCRIPTION
## Overview

Globbing `**/x` was broken, basically matching `**/*x`.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: nix