### PR TITLE
grammar: make MAX_REPETITION_THRESHOLD configurable via env var

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -10,7 +10,16 @@
 #include <set>
 #include <stdexcept>
 
-#define MAX_REPETITION_THRESHOLD 2000
+#define MAX_REPETITION_THRESHOLD_DEFAULT 2000
+
+static uint64_t get_max_repetition_threshold() {
+    const char * env = getenv("LLAMA_GRAMMAR_MAX_REPETITIONS");
+    if (env) {
+        uint64_t val = strtoull(env, nullptr, 10);
+        return val > 0 ? val : MAX_REPETITION_THRESHOLD_DEFAULT;
+    }
+    return MAX_REPETITION_THRESHOLD_DEFAULT;
+}
 //
 // helpers
 //
@@ -491,7 +500,7 @@ const char * llama_grammar_parser::parse_sequence(
             total_rules = min_times;
         }
 
-        if (n_prev_rules * total_rules >= MAX_REPETITION_THRESHOLD) {
+        if (n_prev_rules * total_rules >= get_max_repetition_threshold()) {
             throw std::runtime_error("number of rules that are going to be repeated multiplied by the new repetition exceeds sane defaults, please reduce the number of repetitions or rule complexity");
         }
 
@@ -649,7 +658,8 @@ const char * llama_grammar_parser::parse_sequence(
                 throw std::runtime_error(std::string("expecting ',' at ") + pos);
             }
             bool has_max = max_times != UINT64_MAX;
-            if (min_times > MAX_REPETITION_THRESHOLD || (has_max && max_times > MAX_REPETITION_THRESHOLD)) {
+            const uint64_t max_rep = get_max_repetition_threshold();
+            if (min_times > max_rep || (has_max && max_times > max_rep)) {
                 throw std::runtime_error(std::string("number of repetitions exceeds sane defaults, please reduce the number of repetitions"));
             }
             handle_repetitions(min_times, max_times);


### PR DESCRIPTION
The hardcoded threshold of 2000 causes grammar parsing to fail for legitimate tool-calling schemas with many optional parameters.

Add LLAMA_GRAMMAR_MAX_REPETITIONS env var to override the default. When unset, behaviour is unchanged (default 2000).

May fix grammar failures reported in openclaw/openclaw#32916, openclaw/openclaw#38569, openclaw/openclaw#38899.

AI was used in an assistive capacity to identify the threshold constant and review the approach. The code change and testing were done manually.

## Overview

Adds a helper function that reads LLAMA_GRAMMAR_MAX_REPETITIONS from the environment, replacing the hardcoded MAX_REPETITION_THRESHOLD macro. Three call sites updated. No API changes, fully backwards compatible.

## Additional information

Tested on with Qwen3.5-122B-A10B and 21 OpenClaw tools (message tool: 109 optional params, browser: 48). Default threshold (2000): grammar fails on every request. Threshold at 20000: grammar parses successfully.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used to locate the threshold constant and review the approach. Code and testing done manually.
