### PR TITLE
arch : add missing ROPE_FACTORS_LONG/SHORT for MiniCPM

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -557,6 +557,8 @@ static std::set<llm_tensor> llm_get_tensor_names(llm_arch arch) {
                 LLM_TENSOR_OUTPUT_NORM,
                 LLM_TENSOR_OUTPUT,
                 LLM_TENSOR_ROPE_FREQS,
+                LLM_TENSOR_ROPE_FACTORS_LONG,
+                LLM_TENSOR_ROPE_FACTORS_SHORT,
                 LLM_TENSOR_ATTN_NORM,
                 LLM_TENSOR_ATTN_Q,
                 LLM_TENSOR_ATTN_K,


### PR DESCRIPTION
## Overview

Fixes #21146

## Additional information

`LLM_TENSOR_ROPE_FACTORS_LONG/SHORT` was missing after merging the MiniCPM arch with others in #20503 causing load failure.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: nei