### PR TITLE
ggml-cuda: fix ROCm multi-GPU illegal memory access in recurrent state restore

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -98,16 +98,9 @@ void ggml_cuda_error(const char * stmt, const char * func, const char * file, in
     GGML_ABORT(GGML_CUDA_NAME " error");
 }
 
-// this is faster on Windows
-// probably because the Windows CUDA libraries forget to make this check before invoking the drivers
+// always set device explicitly — early-return optimization is unsafe on ROCm multi-GPU
+// with uninitialized thread contexts (see https://github.com/ggml-org/llama.cpp/issues/21140)
 void ggml_cuda_set_device(int device) {
-    int current_device;
-    CUDA_CHECK(cudaGetDevice(&current_device));
-
-    if (device == current_device) {
-        return;
-    }
-
     CUDA_CHECK(cudaSetDevice(device));
 }
 
@@ -2807,6 +2800,7 @@ static void ggml_backend_cuda_set_tensor_async(ggml_backend_t backend, ggml_tens
 
     GGML_ASSERT(buf->buft == ggml_backend_cuda_buffer_type(cuda_ctx->device) && "unsupported buffer type");
 
+    ggml_cuda_set_device(cuda_ctx->device);
     CUDA_CHECK(cudaMemcpyAsync((char *)tensor->data + offset, data, size, cudaMemcpyHostToDevice, cuda_ctx->stream()));
 }
 


### PR DESCRIPTION
Fixes #21140
Tested on: 2x AMD Radeon AI Pro R9700 (gfx1201), ROCm 7.2.0

## Overview

Remove early-return optimization in `ggml_cuda_set_device()` that caused
`hipErrorIllegalAddress` (`current device: -1`) on ROCm multi-GPU setups
when using hybrid recurrent models (Mamba/SSM) in multi-turn agentic
workflows that trigger prompt cache save/restore.

On ROCm multi-GPU, `hipGetDevice()` can return an unexpected value on
threads that have never explicitly initialized a device context. If this
value falsely matches `ctx->device`, `hipSetDevice()` is never called,
and the subsequent `hipMemcpyAsync` fails.

Also adds missing `ggml_cuda_set_device()` in `ggml_backend_cuda_set_tensor_async()`
for consistency with all other `cudaMemcpyAsync` call sites in this file.

## Additional information

Tested on: 2x AMD Radeon AI Pro R9700 (gfx1201), ROCm 7.2.0, dual-GPU
tensor split. Qwen3.5-35B-A3B (hybrid recurrent/MoE) via Hermes Agent.
Previously crashed deterministically on agent 4-5. After fix: multiple
agents, 6 prompts in cache (5.7GB recurrent state), dozens of prompt
cache save/restore cycles — zero crashes.

# Requirements

- I have read and agree with the contributing guidelines. (https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: AI usage disclosure: YES - Claude Code used to trace call chain and identify
root cause. All changes reviewed and tested by submitter.

