### PR TITLE
vulkan : fix MoltenVK device init, memory limits, and subgroup size for AMD GCN on macOS

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2497,6 +2497,11 @@ static constexpr uint32_t RDNA_DEFAULT_SUBGROUP_SIZE = 32;
 // Define configurations for different GPUs.
 static std::vector<GpuPipelineConfig> gpu_pipeline_configs = {
     {
+        vk_device_architecture::AMD_GCN,
+        {},   // no per-pipeline overrides; GCN uses fixed wavefront of 64
+        64    // default_subgroup_size = wavefront size
+    },
+    {
         vk_device_architecture::AMD_RDNA1,
         {
             rdna1_pipelines,
@@ -4098,6 +4103,27 @@ static vk_device ggml_vk_get_device(size_t idx) {
             device->max_buffer_size = device->max_memory_allocation_size;
         }
 
+#ifdef __APPLE__
+        // MoltenVK on non-Apple GPUs (e.g. AMD Polaris) returns 0 for
+        // maxMemoryAllocationSize and maxBufferSize. Fall back to the largest
+        // VRAM heap so that buffer allocations are not blocked by a zero limit.
+        if (device->max_memory_allocation_size == 0 || device->max_buffer_size == 0) {
+            const vk::PhysicalDeviceMemoryProperties mem_props =
+                device->physical_device.getMemoryProperties();
+            uint64_t max_heap = 0;
+            for (uint32_t i = 0; i < mem_props.memoryHeapCount; i++) {
+                max_heap = std::max(max_heap,
+                                    static_cast<uint64_t>(mem_props.memoryHeaps[i].size));
+            }
+            if (device->max_memory_allocation_size == 0) {
+                device->max_memory_allocation_size = max_heap;
+            }
+            if (device->max_buffer_size == 0) {
+                device->max_buffer_size = max_heap;
+            }
+        }
+#endif
+
         const char* GGML_VK_SUBALLOCATION_BLOCK_SIZE = getenv("GGML_VK_SUBALLOCATION_BLOCK_SIZE");
 
         if (GGML_VK_SUBALLOCATION_BLOCK_SIZE != nullptr) {
@@ -4109,6 +4135,22 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->suballocation_block_size = std::min(device->suballocation_block_size, device->max_memory_allocation_size);
 
         device->subgroup_size = subgroup_props.subgroupSize;
+#ifdef __APPLE__
+        // MoltenVK on AMD GPUs: fix architecture classification and subgroup size.
+        // MoltenVK lacks VK_AMD_shader_core_properties, so get_device_architecture
+        // returns OTHER for all AMD hardware. All AMD GPUs shipped in Mac hardware
+        // (Polaris GCN, Vega GCN) have 64-wide wavefronts; reclassify them and
+        // patch the subgroupSize that MoltenVK incorrectly reports as 0.
+        if (device->vendor_id == VK_VENDOR_ID_AMD) {
+            if (device->architecture == vk_device_architecture::OTHER) {
+                device->architecture = vk_device_architecture::AMD_GCN;
+            }
+            if (device->subgroup_size == 0 &&
+                device->architecture == vk_device_architecture::AMD_GCN) {
+                device->subgroup_size = 64;
+            }
+        }
+#endif
         device->uma = device->properties.deviceType == vk::PhysicalDeviceType::eIntegratedGpu;
         if (sm_builtins) {
             device->shader_core_count = sm_props.shaderSMCount;
@@ -4266,8 +4308,69 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         vkGetPhysicalDeviceFeatures2(device->physical_device, &device_features2);
 
+#ifdef __APPLE__
+        // MoltenVK on non-Apple GPUs (e.g. AMD Polaris/GCN) has two related issues:
+        // 1. It rejects many Vulkan 1.1/1.2 core features at vkCreateDevice even though
+        //    vkGetPhysicalDeviceFeatures2 reports them available (VK_ERROR_FEATURE_NOT_PRESENT).
+        // 2. Long pNext chains cause some fields (e.g. storageBuffer16BitAccess) to be
+        //    populated incorrectly (returned as FALSE when they are actually TRUE).
+        // Safest fix: zero all VkBool32 fields in both structs (preserving sType/pNext),
+        // then re-query with a short isolated chain to get accurate values for the
+        // features we actually need and know MoltenVK supports on non-Apple GPUs.
+        // fp16 remains enabled through the VK_KHR_shader_float16_int8 extension path.
+        if (device->vendor_id != VK_VENDOR_ID_APPLE) {
+            // Two separate single-struct queries — MoltenVK fills storageBuffer16BitAccess
+            // correctly only when vk11_features is the sole struct in the chain (pNext=null).
+            // Chaining vk12_features after vk11_features causes MoltenVK to return FALSE
+            // for storageBuffer16BitAccess even though the feature is actually supported.
+            VkPhysicalDeviceFeatures2 simple_query {};
+            simple_query.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+
+            VkPhysicalDeviceVulkan11Features simple_vk11 {};
+            simple_vk11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
+            simple_vk11.pNext = nullptr;
+            simple_query.pNext = &simple_vk11;
+            vkGetPhysicalDeviceFeatures2(device->physical_device, &simple_query);
+
+            VkPhysicalDeviceVulkan12Features simple_vk12 {};
+            simple_vk12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+            simple_vk12.pNext = nullptr;
+            simple_query.pNext = &simple_vk12;
+            vkGetPhysicalDeviceFeatures2(device->physical_device, &simple_query);
+
+            VkStructureType t11 = vk11_features.sType;
+            void *n11 = vk11_features.pNext;
+            memset(&vk11_features, 0, sizeof(vk11_features));
+            vk11_features.sType = t11;
+            vk11_features.pNext = n11;
+
+            VkStructureType t12 = vk12_features.sType;
+            void *n12 = vk12_features.pNext;
+            memset(&vk12_features, 0, sizeof(vk12_features));
+            vk12_features.sType = t12;
+            vk12_features.pNext = n12;
+
+            // storageBuffer16BitAccess: MoltenVK on AMD Polaris returns FALSE for the
+            // core Vulkan 1.1 feature even though VK_KHR_16bit_storage is fully supported.
+            // Use the extension presence (fp16_storage flag, set from ext enumeration) as
+            // the authoritative source instead of the broken core feature query.
+            vk11_features.storageBuffer16BitAccess = fp16_storage ? VK_TRUE
+                                                   : simple_vk11.storageBuffer16BitAccess;
+            vk12_features.bufferDeviceAddress      = simple_vk12.bufferDeviceAddress;
+            // shaderFloat16 intentionally omitted; fp16 uses VK_KHR_shader_float16_int8.
+        }
+#endif
+
         device->pipeline_executable_properties_support = pipeline_executable_properties_support;
 
+        // On MoltenVK with non-Apple GPU, shaderFloat16 as a Vulkan 1.2 core feature
+        // is unavailable (zeroed above), but fp16 arithmetic works through the
+        // VK_KHR_shader_float16_int8 extension (fp16_compute flag above).
+#ifdef __APPLE__
+        if (device->vendor_id != VK_VENDOR_ID_APPLE) {
+            // fp16 was already set from extension detection; leave it unchanged.
+        } else
+#endif
         device->fp16 = device->fp16 && vk12_features.shaderFloat16;
 
 #if defined(VK_KHR_shader_bfloat16)
@@ -13294,6 +13397,14 @@ void ggml_backend_vk_get_device_memory(int device, size_t * free, size_t * total
 
             if (membudget_supported && i < budgetprops.heapUsage.size()) {
                 *free = budgetprops.heapBudget[i] - budgetprops.heapUsage[i];
+#ifdef __APPLE__
+                // MoltenVK on non-Apple GPUs (e.g. AMD Polaris) returns
+                // heapBudget=0 and heapUsage=0. Fall back to heap.size so the
+                // layer planner can allocate GPU layers.
+                if (*free == 0 && heap.size > 0) {
+                    *free = heap.size;
+                }
+#endif
             } else {
                 *free = heap.size;
             }


### PR DESCRIPTION
## Summary

On macOS with an AMD Radeon Pro 580 (MoltenVK 1.4.1), the Vulkan backend crashes at startup with `VK_ERROR_FEATURE_NOT_PRESENT` before any model loads. This makes the Vulkan backend unusable on this hardware.

Tested on AMD Radeon Pro 580 (0x67df rev 0x00c0, GCN/Polaris, 8 GB), iMac18,3, MoltenVK 1.4.1, macOS 13.7. Change is guarded with `#ifdef __APPLE__` and `vendor_id != VK_VENDOR_ID_APPLE` — no impact on native AMD drivers on Linux or Windows, and no impact on Apple Silicon.

## Fix

`vkGetPhysicalDeviceFeatures2` reports several VK1.1/VK1.2 core features as supported, but `vkCreateDevice` rejects them with `VK_ERROR_FEATURE_NOT_PRESENT`. Zeroing `vk11_features` and `vk12_features` before the device creation call and restoring only confirmed-working fields (`storageBuffer16BitAccess`, `bufferDeviceAddress`) stops the crash.

## Test results

- 858/858 `test-backend-ops` MUL_MAT tests pass against CPU reference
- Meta-Llama-3.1-8B-Instruct-Q4_K_M runs correctly end-to-end with `-ngl 99`

## AI disclosure

I used Claude Code as a development aid during implementation. The code was written and reviewed by me; I'm responsible for its correctness.