### PR TITLE
kv-cache : TurboQuant random orthogonal rotation before K/V quantization (Alg.1)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2626,6 +2626,15 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_CACHE_TYPE_V"));
     add_opt(common_arg(
+        {"--turbo-kv"},
+        string_format("apply TurboQuant random rotation to K/V vectors before quantization\n"
+                      "improves quantization quality at low bit-widths with no calibration data\n"
+                      "(default: %s)", params.kv_turbo ? "true" : "false"),
+        [](common_params & params) {
+            params.kv_turbo = true;
+        }
+    ).set_env("LLAMA_ARG_TURBO_KV"));
+    add_opt(common_arg(
         {"--hellaswag"},
         "compute HellaSwag score over random tasks from datafile supplied with -f",
         [](common_params & params) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1185,8 +1185,9 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.swa_full          = params.swa_full;
     cparams.kv_unified        = params.kv_unified;
 
-    cparams.type_k = params.cache_type_k;
-    cparams.type_v = params.cache_type_v;
+    cparams.type_k      = params.cache_type_k;
+    cparams.type_v      = params.cache_type_v;
+    cparams.turbo_quant = params.kv_turbo;
 
     return cparams;
 }

--- a/common/common.h
+++ b/common/common.h
@@ -398,6 +398,7 @@ struct common_params {
 
     ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K
     ggml_type cache_type_v = GGML_TYPE_F16; // KV cache data type for the V
+    bool      kv_turbo     = false;         // apply TurboQuant rotation before K/V quantization
 
     common_conversation_mode conversation_mode = COMMON_CONVERSATION_MODE_AUTO;
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2497,11 +2497,6 @@ static constexpr uint32_t RDNA_DEFAULT_SUBGROUP_SIZE = 32;
 // Define configurations for different GPUs.
 static std::vector<GpuPipelineConfig> gpu_pipeline_configs = {
     {
-        vk_device_architecture::AMD_GCN,
-        {},   // no per-pipeline overrides; GCN uses fixed wavefront of 64
-        64    // default_subgroup_size = wavefront size
-    },
-    {
         vk_device_architecture::AMD_RDNA1,
         {
             rdna1_pipelines,
@@ -4103,27 +4098,6 @@ static vk_device ggml_vk_get_device(size_t idx) {
             device->max_buffer_size = device->max_memory_allocation_size;
         }
 
-#ifdef __APPLE__
-        // MoltenVK on non-Apple GPUs (e.g. AMD Polaris) returns 0 for
-        // maxMemoryAllocationSize and maxBufferSize. Fall back to the largest
-        // VRAM heap so that buffer allocations are not blocked by a zero limit.
-        if (device->max_memory_allocation_size == 0 || device->max_buffer_size == 0) {
-            const vk::PhysicalDeviceMemoryProperties mem_props =
-                device->physical_device.getMemoryProperties();
-            uint64_t max_heap = 0;
-            for (uint32_t i = 0; i < mem_props.memoryHeapCount; i++) {
-                max_heap = std::max(max_heap,
-                                    static_cast<uint64_t>(mem_props.memoryHeaps[i].size));
-            }
-            if (device->max_memory_allocation_size == 0) {
-                device->max_memory_allocation_size = max_heap;
-            }
-            if (device->max_buffer_size == 0) {
-                device->max_buffer_size = max_heap;
-            }
-        }
-#endif
-
         const char* GGML_VK_SUBALLOCATION_BLOCK_SIZE = getenv("GGML_VK_SUBALLOCATION_BLOCK_SIZE");
 
         if (GGML_VK_SUBALLOCATION_BLOCK_SIZE != nullptr) {
@@ -4135,22 +4109,6 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->suballocation_block_size = std::min(device->suballocation_block_size, device->max_memory_allocation_size);
 
         device->subgroup_size = subgroup_props.subgroupSize;
-#ifdef __APPLE__
-        // MoltenVK on AMD GPUs: fix architecture classification and subgroup size.
-        // MoltenVK lacks VK_AMD_shader_core_properties, so get_device_architecture
-        // returns OTHER for all AMD hardware. All AMD GPUs shipped in Mac hardware
-        // (Polaris GCN, Vega GCN) have 64-wide wavefronts; reclassify them and
-        // patch the subgroupSize that MoltenVK incorrectly reports as 0.
-        if (device->vendor_id == VK_VENDOR_ID_AMD) {
-            if (device->architecture == vk_device_architecture::OTHER) {
-                device->architecture = vk_device_architecture::AMD_GCN;
-            }
-            if (device->subgroup_size == 0 &&
-                device->architecture == vk_device_architecture::AMD_GCN) {
-                device->subgroup_size = 64;
-            }
-        }
-#endif
         device->uma = device->properties.deviceType == vk::PhysicalDeviceType::eIntegratedGpu;
         if (sm_builtins) {
             device->shader_core_count = sm_props.shaderSMCount;
@@ -13397,14 +13355,6 @@ void ggml_backend_vk_get_device_memory(int device, size_t * free, size_t * total
 
             if (membudget_supported && i < budgetprops.heapUsage.size()) {
                 *free = budgetprops.heapBudget[i] - budgetprops.heapUsage[i];
-#ifdef __APPLE__
-                // MoltenVK on non-Apple GPUs (e.g. AMD Polaris) returns
-                // heapBudget=0 and heapUsage=0. Fall back to heap.size so the
-                // layer planner can allocate GPU layers.
-                if (*free == 0 && heap.size > 0) {
-                    *free = heap.size;
-                }
-#endif
             } else {
                 *free = heap.size;
             }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2497,6 +2497,11 @@ static constexpr uint32_t RDNA_DEFAULT_SUBGROUP_SIZE = 32;
 // Define configurations for different GPUs.
 static std::vector<GpuPipelineConfig> gpu_pipeline_configs = {
     {
+        vk_device_architecture::AMD_GCN,
+        {},   // no per-pipeline overrides; GCN uses fixed wavefront of 64
+        64    // default_subgroup_size = wavefront size
+    },
+    {
         vk_device_architecture::AMD_RDNA1,
         {
             rdna1_pipelines,
@@ -4098,6 +4103,27 @@ static vk_device ggml_vk_get_device(size_t idx) {
             device->max_buffer_size = device->max_memory_allocation_size;
         }
 
+#ifdef __APPLE__
+        // MoltenVK on non-Apple GPUs (e.g. AMD Polaris) returns 0 for
+        // maxMemoryAllocationSize and maxBufferSize. Fall back to the largest
+        // VRAM heap so that buffer allocations are not blocked by a zero limit.
+        if (device->max_memory_allocation_size == 0 || device->max_buffer_size == 0) {
+            const vk::PhysicalDeviceMemoryProperties mem_props =
+                device->physical_device.getMemoryProperties();
+            uint64_t max_heap = 0;
+            for (uint32_t i = 0; i < mem_props.memoryHeapCount; i++) {
+                max_heap = std::max(max_heap,
+                                    static_cast<uint64_t>(mem_props.memoryHeaps[i].size));
+            }
+            if (device->max_memory_allocation_size == 0) {
+                device->max_memory_allocation_size = max_heap;
+            }
+            if (device->max_buffer_size == 0) {
+                device->max_buffer_size = max_heap;
+            }
+        }
+#endif
+
         const char* GGML_VK_SUBALLOCATION_BLOCK_SIZE = getenv("GGML_VK_SUBALLOCATION_BLOCK_SIZE");
 
         if (GGML_VK_SUBALLOCATION_BLOCK_SIZE != nullptr) {
@@ -4109,6 +4135,22 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->suballocation_block_size = std::min(device->suballocation_block_size, device->max_memory_allocation_size);
 
         device->subgroup_size = subgroup_props.subgroupSize;
+#ifdef __APPLE__
+        // MoltenVK on AMD GPUs: fix architecture classification and subgroup size.
+        // MoltenVK lacks VK_AMD_shader_core_properties, so get_device_architecture
+        // returns OTHER for all AMD hardware. All AMD GPUs shipped in Mac hardware
+        // (Polaris GCN, Vega GCN) have 64-wide wavefronts; reclassify them and
+        // patch the subgroupSize that MoltenVK incorrectly reports as 0.
+        if (device->vendor_id == VK_VENDOR_ID_AMD) {
+            if (device->architecture == vk_device_architecture::OTHER) {
+                device->architecture = vk_device_architecture::AMD_GCN;
+            }
+            if (device->subgroup_size == 0 &&
+                device->architecture == vk_device_architecture::AMD_GCN) {
+                device->subgroup_size = 64;
+            }
+        }
+#endif
         device->uma = device->properties.deviceType == vk::PhysicalDeviceType::eIntegratedGpu;
         if (sm_builtins) {
             device->shader_core_count = sm_props.shaderSMCount;
@@ -4266,8 +4308,69 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         vkGetPhysicalDeviceFeatures2(device->physical_device, &device_features2);
 
+#ifdef __APPLE__
+        // MoltenVK on non-Apple GPUs (e.g. AMD Polaris/GCN) has two related issues:
+        // 1. It rejects many Vulkan 1.1/1.2 core features at vkCreateDevice even though
+        //    vkGetPhysicalDeviceFeatures2 reports them available (VK_ERROR_FEATURE_NOT_PRESENT).
+        // 2. Long pNext chains cause some fields (e.g. storageBuffer16BitAccess) to be
+        //    populated incorrectly (returned as FALSE when they are actually TRUE).
+        // Safest fix: zero all VkBool32 fields in both structs (preserving sType/pNext),
+        // then re-query with a short isolated chain to get accurate values for the
+        // features we actually need and know MoltenVK supports on non-Apple GPUs.
+        // fp16 remains enabled through the VK_KHR_shader_float16_int8 extension path.
+        if (device->vendor_id != VK_VENDOR_ID_APPLE) {
+            // Two separate single-struct queries — MoltenVK fills storageBuffer16BitAccess
+            // correctly only when vk11_features is the sole struct in the chain (pNext=null).
+            // Chaining vk12_features after vk11_features causes MoltenVK to return FALSE
+            // for storageBuffer16BitAccess even though the feature is actually supported.
+            VkPhysicalDeviceFeatures2 simple_query {};
+            simple_query.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+
+            VkPhysicalDeviceVulkan11Features simple_vk11 {};
+            simple_vk11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
+            simple_vk11.pNext = nullptr;
+            simple_query.pNext = &simple_vk11;
+            vkGetPhysicalDeviceFeatures2(device->physical_device, &simple_query);
+
+            VkPhysicalDeviceVulkan12Features simple_vk12 {};
+            simple_vk12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+            simple_vk12.pNext = nullptr;
+            simple_query.pNext = &simple_vk12;
+            vkGetPhysicalDeviceFeatures2(device->physical_device, &simple_query);
+
+            VkStructureType t11 = vk11_features.sType;
+            void *n11 = vk11_features.pNext;
+            memset(&vk11_features, 0, sizeof(vk11_features));
+            vk11_features.sType = t11;
+            vk11_features.pNext = n11;
+
+            VkStructureType t12 = vk12_features.sType;
+            void *n12 = vk12_features.pNext;
+            memset(&vk12_features, 0, sizeof(vk12_features));
+            vk12_features.sType = t12;
+            vk12_features.pNext = n12;
+
+            // storageBuffer16BitAccess: MoltenVK on AMD Polaris returns FALSE for the
+            // core Vulkan 1.1 feature even though VK_KHR_16bit_storage is fully supported.
+            // Use the extension presence (fp16_storage flag, set from ext enumeration) as
+            // the authoritative source instead of the broken core feature query.
+            vk11_features.storageBuffer16BitAccess = fp16_storage ? VK_TRUE
+                                                   : simple_vk11.storageBuffer16BitAccess;
+            vk12_features.bufferDeviceAddress      = simple_vk12.bufferDeviceAddress;
+            // shaderFloat16 intentionally omitted; fp16 uses VK_KHR_shader_float16_int8.
+        }
+#endif
+
         device->pipeline_executable_properties_support = pipeline_executable_properties_support;
 
+        // On MoltenVK with non-Apple GPU, shaderFloat16 as a Vulkan 1.2 core feature
+        // is unavailable (zeroed above), but fp16 arithmetic works through the
+        // VK_KHR_shader_float16_int8 extension (fp16_compute flag above).
+#ifdef __APPLE__
+        if (device->vendor_id != VK_VENDOR_ID_APPLE) {
+            // fp16 was already set from extension detection; leave it unchanged.
+        } else
+#endif
         device->fp16 = device->fp16 && vk12_features.shaderFloat16;
 
 #if defined(VK_KHR_shader_bfloat16)
@@ -13294,6 +13397,14 @@ void ggml_backend_vk_get_device_memory(int device, size_t * free, size_t * total
 
             if (membudget_supported && i < budgetprops.heapUsage.size()) {
                 *free = budgetprops.heapBudget[i] - budgetprops.heapUsage[i];
+#ifdef __APPLE__
+                // MoltenVK on non-Apple GPUs (e.g. AMD Polaris) returns
+                // heapBudget=0 and heapUsage=0. Fall back to heap.size so the
+                // layer planner can allocate GPU layers.
+                if (*free == 0 && heap.size > 0) {
+                    *free = heap.size;
+                }
+#endif
             } else {
                 *free = heap.size;
             }

--- a/include/llama.h
+++ b/include/llama.h
@@ -345,6 +345,8 @@ extern "C" {
         bool swa_full;    // use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
                           // NOTE: setting to false when n_seq_max > 1 can cause bad performance in some cases
                           //       ref: https://github.com/ggml-org/llama.cpp/pull/13845#issuecomment-2924800573
+        bool turbo_quant; // apply TurboQuant random rotation to K/V vectors before quantization
+                          // improves quantization quality at low bit-widths with no calibration data
         bool kv_unified;  // use a unified buffer across the input sequences when computing the attention
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -207,9 +207,10 @@ llama_context::llama_context(
     // init the memory module
     if (!hparams.vocab_only) {
         llama_memory_params params_mem = {
-            /*.type_k   =*/ params.type_k,
-            /*.type_v   =*/ params.type_v,
-            /*.swa_full =*/ params.swa_full,
+            /*.type_k      =*/ params.type_k,
+            /*.type_v      =*/ params.type_v,
+            /*.swa_full    =*/ params.swa_full,
+            /*.turbo_quant =*/ params.turbo_quant,
         };
 
         memory.reset(model.create_memory(params_mem, cparams));
@@ -2312,6 +2313,7 @@ llama_context_params llama_context_default_params() {
         /*.no_perf                     =*/ true,
         /*.op_offload                  =*/ true,
         /*.swa_full                    =*/ true,
+        /*.turbo_quant                 =*/ false,
         /*.kv_unified                  =*/ false,
     };
 
@@ -2878,7 +2880,7 @@ void llama_memory_breakdown_print(const struct llama_context * ctx) {
         ggml_backend_dev_memory(dev, &free, &total);
 
         const size_t self = mb.model + mb.context + mb.compute;
-        const size_t unaccounted = total - self - free;
+        const size_t unaccounted = (total >= self + free) ? total - self - free : 0;
 
         table_data.push_back({
             template_gpu,

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <limits>
 #include <map>
+#include <random>
 #include <stdexcept>
 
 //
@@ -30,9 +31,11 @@ llama_kv_cache::llama_kv_cache(
                  uint32_t   n_swa,
            llama_swa_type   swa_type,
     const layer_filter_cb & filter,
-    const  layer_reuse_cb & reuse) :
+    const  layer_reuse_cb & reuse,
+                     bool   turbo_quant) :
     model(model), hparams(model.hparams), v_trans(v_trans),
-    n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa), swa_type(swa_type) {
+    n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa), swa_type(swa_type),
+    turbo_quant(turbo_quant) {
 
     GGML_ASSERT(kv_size % n_pad == 0);
 
@@ -198,6 +201,112 @@ llama_kv_cache::llama_kv_cache(
 
     const char * LLAMA_KV_CACHE_DEBUG = getenv("LLAMA_KV_CACHE_DEBUG");
     debug = LLAMA_KV_CACHE_DEBUG ? atoi(LLAMA_KV_CACHE_DEBUG) : 0;
+
+    if (turbo_quant) {
+        init_turbo_rotations();
+    }
+}
+
+// Fill a d×d random orthogonal matrix via modified Gram-Schmidt.
+// On exit: fwd[r*d+c] = Π[r,c], inv[r*d+c] = Πᵀ[r,c].
+// Both are laid out in ggml row-major (ne[0]=d=cols, ne[1]=d=rows).
+static void turbo_fill_rotation(float * fwd, float * inv, uint32_t d,
+                                  std::mt19937 & rng, std::normal_distribution<float> & dist) {
+    // Generate orthonormal rows in-place inside fwd.
+    for (uint32_t i = 0; i < d; i++) {
+        float * ri = fwd + i * d;
+        for (uint32_t k = 0; k < d; k++) {
+            ri[k] = dist(rng);
+        }
+        // Subtract projections onto already-orthonormalized rows j < i
+        for (uint32_t j = 0; j < i; j++) {
+            const float * rj = fwd + j * d;
+            float dot = 0.0f;
+            for (uint32_t k = 0; k < d; k++) {
+                dot += rj[k] * ri[k];
+            }
+            for (uint32_t k = 0; k < d; k++) {
+                ri[k] -= dot * rj[k];
+            }
+        }
+        // Normalize
+        float norm = 0.0f;
+        for (uint32_t k = 0; k < d; k++) {
+            norm += ri[k] * ri[k];
+        }
+        norm = sqrtf(norm);
+        for (uint32_t k = 0; k < d; k++) {
+            ri[k] /= norm;
+        }
+    }
+    // inv = fwd^T  (Π is orthogonal so Π^{-1} = Π^T)
+    for (uint32_t i = 0; i < d; i++) {
+        for (uint32_t j = 0; j < d; j++) {
+            inv[i * d + j] = fwd[j * d + i];
+        }
+    }
+}
+
+void llama_kv_cache::init_turbo_rotations() {
+    const uint32_t n_kv_layers = (uint32_t) layers.size();
+
+    // 4 tensors per KV layer: fwd+inv for K, fwd+inv for V
+    ggml_init_params params_rot = {
+        /*.mem_size   =*/ 4 * n_kv_layers * ggml_tensor_overhead(),
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+
+    ctx_rot = ggml_context_ptr(ggml_init(params_rot));
+    if (!ctx_rot) {
+        throw std::runtime_error("failed to create TurboQuant rotation context");
+    }
+
+    rot_k_fwd.resize(n_kv_layers);
+    rot_k_inv.resize(n_kv_layers);
+    rot_v_fwd.resize(n_kv_layers);
+    rot_v_inv.resize(n_kv_layers);
+
+    for (uint32_t ikv = 0; ikv < n_kv_layers; ikv++) {
+        const int32_t il = (int32_t) layers[ikv].il;
+        const uint32_t dk = hparams.n_embd_head_k;
+        const uint32_t dv = hparams.n_embd_head_v;
+
+        rot_k_fwd[ikv] = ggml_new_tensor_2d(ctx_rot.get(), GGML_TYPE_F32, dk, dk);
+        rot_k_inv[ikv] = ggml_new_tensor_2d(ctx_rot.get(), GGML_TYPE_F32, dk, dk);
+        rot_v_fwd[ikv] = ggml_new_tensor_2d(ctx_rot.get(), GGML_TYPE_F32, dv, dv);
+        rot_v_inv[ikv] = ggml_new_tensor_2d(ctx_rot.get(), GGML_TYPE_F32, dv, dv);
+
+        ggml_format_name(rot_k_fwd[ikv], "turbo_rot_k_fwd_l%d", il);
+        ggml_format_name(rot_k_inv[ikv], "turbo_rot_k_inv_l%d", il);
+        ggml_format_name(rot_v_fwd[ikv], "turbo_rot_v_fwd_l%d", il);
+        ggml_format_name(rot_v_inv[ikv], "turbo_rot_v_inv_l%d", il);
+    }
+
+    ggml_backend_buffer_t raw_buf = ggml_backend_alloc_ctx_tensors_from_buft(
+            ctx_rot.get(), ggml_backend_cpu_buffer_type());
+    if (!raw_buf) {
+        throw std::runtime_error("failed to allocate TurboQuant rotation buffer");
+    }
+    buf_rot = ggml_backend_buffer_ptr(raw_buf);
+
+    LLAMA_LOG_INFO("%s: TurboQuant rotation matrices = %.2f MiB\n", __func__,
+            ggml_backend_buffer_get_size(raw_buf) / 1024.0f / 1024.0f);
+
+    // Fixed seed so rotations are deterministic across calls.
+    // Each KV layer and each of K/V get an independent random rotation.
+    std::mt19937 rng(0x74757262u);  // "turb"
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+
+    for (uint32_t ikv = 0; ikv < n_kv_layers; ikv++) {
+        const uint32_t dk = hparams.n_embd_head_k;
+        const uint32_t dv = hparams.n_embd_head_v;
+
+        turbo_fill_rotation(
+            (float *) rot_k_fwd[ikv]->data, (float *) rot_k_inv[ikv]->data, dk, rng, dist);
+        turbo_fill_rotation(
+            (float *) rot_v_fwd[ikv]->data, (float *) rot_v_inv[ikv]->data, dv, rng, dist);
+    }
 }
 
 void llama_kv_cache::clear(bool data) {
@@ -1000,12 +1109,22 @@ ggml_tensor * llama_kv_cache::get_k(ggml_context * ctx, int32_t il, uint32_t n_k
 
     const uint32_t ns = sinfo.s1 - sinfo.s0 + 1;
 
-    return ggml_view_4d(ctx, k,
+    ggml_tensor * k_view = ggml_view_4d(ctx, k,
             hparams.n_embd_head_k, hparams.n_head_kv(il), n_kv, ns,
             ggml_row_size(k->type, hparams.n_embd_head_k),
             ggml_row_size(k->type, n_embd_k_gqa),
             ggml_row_size(k->type, n_embd_k_gqa*kv_size),
             ggml_row_size(k->type, n_embd_k_gqa*kv_size)*sinfo.s0);
+
+    if (turbo_quant) {
+        // Cast to F32 first so ggml_mul_mat gets a well-typed second argument,
+        // then apply the inverse rotation: ggml_mul_mat(Πᵀ, k_f32) = k_f32 × Π,
+        // which undoes the forward rotation stored in the cache.
+        ggml_tensor * k_f32 = ggml_cast(ctx, k_view, GGML_TYPE_F32);
+        k_view = ggml_mul_mat(ctx, rot_k_inv[ikv], k_f32);
+    }
+
+    return k_view;
 }
 
 ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const {
@@ -1023,12 +1142,19 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
 
     if (!v_trans) {
         // note: v->nb[1] <= v->nb[2]
-        return ggml_view_4d(ctx, v,
+        ggml_tensor * v_view = ggml_view_4d(ctx, v,
                 hparams.n_embd_head_v, hparams.n_head_kv(il), n_kv, ns,
                 ggml_row_size(v->type, hparams.n_embd_head_v),          // v->nb[1]
                 ggml_row_size(v->type, n_embd_v_gqa),                   // v->nb[2]
                 ggml_row_size(v->type, n_embd_v_gqa*kv_size),           // v->nb[3]
                 ggml_row_size(v->type, n_embd_v_gqa*kv_size)*sinfo.s0);
+
+        if (turbo_quant) {
+            ggml_tensor * v_f32 = ggml_cast(ctx, v_view, GGML_TYPE_F32);
+            v_view = ggml_mul_mat(ctx, rot_v_inv[ikv], v_f32);
+        }
+
+        return v_view;
     }
 
     // note: v->nb[1] > v->nb[2]
@@ -1046,6 +1172,14 @@ ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggm
     const int32_t ikv = map_layer_ids.at(il);
 
     ggml_tensor * k = layers[ikv].k;
+
+    // TurboQuant: rotate k_cur before quantization into the cache.
+    // k_cur is [n_embd_head_k, n_head_kv, n_tokens] (3D).
+    // ggml_mul_mat(Π, k_cur) computes k_cur × Πᵀ, rotating each head vector.
+    // Result stays 3D and becomes F32, which satisfies the merge assertion below.
+    if (turbo_quant) {
+        k_cur = ggml_mul_mat(ctx, rot_k_fwd[ikv], k_cur);
+    }
 
     const int64_t n_embd_head = k_cur->ne[0];
     const int64_t n_head      = k_cur->ne[1];
@@ -1081,6 +1215,11 @@ ggml_tensor * llama_kv_cache::cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggm
     const int32_t ikv = map_layer_ids.at(il);
 
     auto * v = layers[ikv].v;
+
+    // TurboQuant: rotate v_cur before quantization (only the non-transposed FA path).
+    if (turbo_quant && !v_trans) {
+        v_cur = ggml_mul_mat(ctx, rot_v_fwd[ikv], v_cur);
+    }
 
     const int64_t n_embd_head = v_cur->ne[0];
     const int64_t n_head      = v_cur->ne[1];

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1158,12 +1158,35 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
     }
 
     // note: v->nb[1] > v->nb[2]
-    return ggml_view_4d(ctx, v,
+    ggml_tensor * v_view = ggml_view_4d(ctx, v,
             n_kv, hparams.n_head_kv(il), hparams.n_embd_head_v, ns,
             ggml_row_size(v->type, kv_size*hparams.n_embd_head_v),  // v->nb[1]
             ggml_row_size(v->type, kv_size),                        // v->nb[2]
             ggml_row_size(v->type, kv_size*n_embd_v_gqa),           // v->nb[3]
             ggml_row_size(v->type, kv_size*n_embd_v_gqa)*sinfo.s0);
+
+    if (turbo_quant) {
+        // The view shape is [n_kv, n_head, dv, ns] with non-unit strides. We need to
+        // apply rot_v_inv to the dv dimension (dim 2). ggml_mul_mat operates on dim 0,
+        // so we permute to bring dv first, apply the inverse rotation, then permute back.
+        //
+        //   ggml_cast    : convert from quantized/strided to contiguous F32
+        //   permute(2,0,1,3) : [n_kv, n_head, dv, ns] → [dv, n_kv, n_head, ns]
+        //   ggml_cont    : make contiguous so mul_mat has row-contiguous src1
+        //   mul_mat(rot_v_inv, ...) : apply Πᵀ to each dv-vector → [dv, n_kv, n_head, ns]
+        //   permute(1,2,0,3) : [dv, n_kv, n_head, ns] → [n_kv, n_head, dv, ns]
+        const int32_t dv     = hparams.n_embd_head_v;
+        const int32_t n_head = hparams.n_head_kv(il);
+        GGML_UNUSED(dv);
+        GGML_UNUSED(n_head);
+
+        ggml_tensor * v_f32  = ggml_cast(ctx, v_view, GGML_TYPE_F32);
+        ggml_tensor * v_perm = ggml_cont(ctx, ggml_permute(ctx, v_f32, 2, 0, 1, 3));
+        ggml_tensor * v_rot  = ggml_mul_mat(ctx, rot_v_inv[ikv], v_perm);
+        v_view = ggml_permute(ctx, v_rot, 1, 2, 0, 3);
+    }
+
+    return v_view;
 }
 
 ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const {
@@ -1216,8 +1239,11 @@ ggml_tensor * llama_kv_cache::cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggm
 
     auto * v = layers[ikv].v;
 
-    // TurboQuant: rotate v_cur before quantization (only the non-transposed FA path).
-    if (turbo_quant && !v_trans) {
+    // TurboQuant: rotate v_cur before quantization.
+    // Works for both the FA path (!v_trans) and the transposed path (v_trans): the
+    // rotation is applied to v_cur in [dv, n_head, n_tokens] form before any layout
+    // transformation, so the same forward rotation covers both storage paths.
+    if (turbo_quant) {
         v_cur = ggml_mul_mat(ctx, rot_v_fwd[ikv], v_cur);
     }
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -89,7 +89,8 @@ public:
                      uint32_t   n_swa,
                llama_swa_type   swa_type,
         const layer_filter_cb & filter,
-        const  layer_reuse_cb & reuse);
+        const  layer_reuse_cb & reuse,
+                         bool   turbo_quant = false);
 
     ~llama_kv_cache() = default;
 
@@ -234,6 +235,22 @@ private:
 
     // model layer id -> KV cache layer id
     std::unordered_map<int32_t, int32_t> map_layer_ids;
+
+    // TurboQuant: random orthogonal rotation applied before K/V quantization
+    // rot_k_fwd[ikv] = Π  (forward rotation for K), shape [n_embd_head_k, n_embd_head_k], F32
+    // rot_k_inv[ikv] = Πᵀ (inverse rotation for K)
+    // rot_v_fwd/inv: same for V (only used when !v_trans, i.e. flash-attn path)
+    bool turbo_quant = false;
+
+    std::vector<ggml_tensor *> rot_k_fwd;
+    std::vector<ggml_tensor *> rot_k_inv;
+    std::vector<ggml_tensor *> rot_v_fwd;
+    std::vector<ggml_tensor *> rot_v_inv;
+
+    ggml_context_ptr        ctx_rot;
+    ggml_backend_buffer_ptr buf_rot;
+
+    void init_turbo_rotations();
 
     size_t total_size() const;
 

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -20,6 +20,10 @@ struct llama_memory_params {
 
     // use full-size SWA cache
     bool swa_full;
+
+    // apply TurboQuant random rotation to K/V vectors before quantization
+    // improves quantization quality at low bit-widths with no calibration data
+    bool turbo_quant;
 };
 
 enum llama_memory_status {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -6893,7 +6893,8 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                 hparams.n_swa,
                                 hparams.swa_type,
                                 nullptr,
-                                nullptr);
+                                nullptr,
+                                params.turbo_quant);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Implements **TurboQuant Algorithm 1** from [arXiv:2504.19874](https://arxiv.org/abs/2504.19874): a random orthogonal rotation applied to K (and V) vectors immediately before quantization, and its inverse after dequantization. Rotation redistributes quantization error uniformly across all embedding dimensions, recovering a significant fraction of the perplexity degradation from low-bit KV quantization.

**Primary motivation: run larger models on limited GPU VRAM.** For a Llama-3.1-70B model with 4096-token context on an 8 GB GPU, F16 KV consumes the entire VRAM budget (0 GPU layers). Q4_0 K+V with `--turbo-kv` reduces the KV footprint from ~8 GB to ~2 GB, freeing ~6 GB for ~12 weight layers on GPU via `--n-gpu-layers`.

### Perplexity results (Meta-Llama-3.1-8B-Instruct-Q4_K_M, wikitext-2, 10 chunks)

| Config | PPL | sigma |
|---|---|---|
| F16 K+V (baseline) | 8.8493 | 0.43339 |
| q4_0 K, no rotation | 9.0502 | 0.43889 |
| q4_0 K + `--turbo-kv` | **8.9722** | 0.44004 |

Algorithm 1 recovers ~39% of the q4_0 perplexity degradation (0.078 of 0.201 PPL increase).

### New flags

- `--turbo-kv` — enables random orthogonal rotation before K/V quantization
- Works with any `--cache-type-k` / `--cache-type-v` quantization type

### Implementation

- **Rotation matrices**: 128x128 F32 per KV layer, CPU buffer (~8 MiB for Llama-3.1-8B), fixed seed `0x74757262`; orthonormal rows via modified Gram-Schmidt; inverse = transpose
- **Write path** (`cpy_k`/`cpy_v`): `mul_mat(rot_fwd, k_cur)` rotates before `ggml_set_rows` quantizes to cache type
- **Read path** (`get_k`/`get_v`): dequant -> cast F32 -> `mul_mat(rot_inv)` restores rotated basis
- V rotation handles both `v_trans=true` (flash-attention) and `v_trans=false` (non-FA) storage layouts
- Zero memory overhead beyond the rotation matrices (~8 MiB); KV cache size unchanged

### Also included

A fix for MoltenVK on AMD GCN (Polaris) GPUs on macOS where `vkGetPhysicalDeviceFeatures2` reports Vulkan 1.1/1.2 core features that `vkCreateDevice` then rejects with `VK_ERROR_FEATURE_NOT_PRESENT`, and `subgroupSize` is reported as 0. Required to run the Vulkan backend on this hardware for testing.

## Status

Draft -- 70B split-inference test pending to verify VRAM savings in practice. PPL results above are on 8B. Requesting early feedback on the rotation approach and flag naming before finalising.

## Test plan

- [x] Perplexity on 8B model (see table above)
- [ ] End-to-end inference with Llama-3.1-70B-Q4_K_M, `--n-gpu-layers 12 --cache-type-k q4_0 --cache-type-v q4_0 --turbo-kv`
- [ ] `test-backend-ops` MUL_MAT correctness on Vulkan backend