### PR TITLE
fix: include API key in CORS proxy requests for MCP connections

### DIFF
--- a/tools/server/webui/src/lib/services/mcp.service.ts
+++ b/tools/server/webui/src/lib/services/mcp.service.ts
@@ -42,6 +42,7 @@ import type {
 import {
 	buildProxiedUrl,
 	buildProxiedHeaders,
+	getAuthHeaders,
 	throwIfAborted,
 	isAbortError,
 	createBase64DataUrl
@@ -125,6 +126,13 @@ export class MCPService {
 
 		if (config.headers) {
 			requestInit.headers = buildProxiedHeaders(config.headers);
+		}
+
+		if (useProxy) {
+			requestInit.headers = {
+				...getAuthHeaders(),
+				...(requestInit.headers as Record<string, string>)
+			};
 		}
 
 		if (config.credentials) {

--- a/tools/server/webui/src/lib/services/mcp.service.ts
+++ b/tools/server/webui/src/lib/services/mcp.service.ts
@@ -125,7 +125,7 @@ export class MCPService {
 		const requestInit: RequestInit = {};
 
 		if (config.headers) {
-			requestInit.headers = buildProxiedHeaders(config.headers);
+			requestInit.headers = config.useProxy ? buildProxiedHeaders(config.headers) : config.headers;
 		}
 
 		if (useProxy) {


### PR DESCRIPTION
## Problem

When `llama-server` is started with both `--api-key-file` and `--webui-mcp-proxy`, the `/cors-proxy` endpoint is subject to the global API key validation middleware. MCP connections configured with "Use Proxy" fail with a 401 because the WebUI does not include the `Authorization` header in its requests to `/cors-proxy`.

Fixes #21167

## Root Cause

In `MCPService.createTransport()`, `requestInit.headers` was only populated with `buildProxiedHeaders(config.headers)` — which wraps the target MCP server's headers using the `X-Proxy-Header-*` convention. The `Authorization: Bearer <api-key>` header needed to authenticate the request against llama-server itself was never included.

## Fix

Import the existing `getAuthHeaders()` utility and spread it into `requestInit.headers` when `useProxy` is true:

```ts
if (useProxy) {
    requestInit.headers = {
        ...getAuthHeaders(),
        ...(requestInit.headers as Record<string, string>)
    };
}
```

`getAuthHeaders()` returns `{ Authorization: 'Bearer <key>' }` when an API key is configured, or an empty object otherwise — so there is no regression when no API key is set.

## Testing

1. Start `llama-server` with `--api-key-file <file> --webui-mcp-proxy`
2. Authenticate with the WebUI using the API key
3. Add an MCP server with "Use Proxy" enabled
4. Connection succeeds (previously failed with 401)