### PR TITLE
webui: fix syntax highlighting lost after streaming for non-common languages

### DIFF
--- a/tools/server/public/index.html
+++ b/tools/server/public/index.html
@@ -18,7 +18,7 @@
 		<div style="display: contents">
 			<script>
 				{
-					__sveltekit_10avopp = {
+					__sveltekit_1ppa22i = {
 						base: new URL('.', location).pathname.slice(0, -1)
 					};
 

--- a/tools/server/webui/src/lib/components/app/content/MarkdownContent.svelte
+++ b/tools/server/webui/src/lib/components/app/content/MarkdownContent.svelte
@@ -4,6 +4,7 @@
 	import remarkGfm from 'remark-gfm';
 	import remarkMath from 'remark-math';
 	import rehypeHighlight from 'rehype-highlight';
+	import { all as lowlightAll } from 'lowlight';
 	import remarkRehype from 'remark-rehype';
 	import rehypeKatex from 'rehype-katex';
 	import rehypeStringify from 'rehype-stringify';
@@ -96,6 +97,7 @@
 
 		return proc
 			.use(rehypeHighlight, {
+				languages: lowlightAll,
 				aliases: { [FileTypeText.XML]: [FileTypeText.SVELTE, FileTypeText.VUE] }
 			}) // Add syntax highlighting
 			.use(rehypeRestoreTableHtml) // Restore limited HTML (e.g., <br>, <ul>) inside Markdown tables


### PR DESCRIPTION
## Overview

Code blocks for languages like Haskell, Elixir, Dart, Scala, etc. show
proper syntax highlighting while streaming but lose all color once the
closing fence arrives.

The streaming path uses `highlight.js` directly, which supports 192
languages. The completed-block path uses `rehype-highlight`, which
internally uses `lowlight` — and lowlight's default `common` bundle only
includes 37 languages. For unrecognized languages, lowlight silently
outputs plain unformatted text.

The fix passes lowlight's full language set to `rehype-highlight` so both
rendering paths support the same languages. `lowlight` is already a
transitive dependency, so no new packages are added.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, AI was used to help diagnose the root cause and draft the PR.