### PR TITLE
kv-cache: add LLAMA_STATE_SEQ_FLAGS_APPEND for incremental state restore

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -872,6 +872,9 @@ extern "C" {
 // work only with partial states, such as SWA KV cache or recurrent cache (e.g. Mamba)
 #define LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY 1
 
+// restore without clearing existing sequence data (append to existing KV cache entries)
+#define LLAMA_STATE_SEQ_FLAGS_APPEND 2
+
     typedef uint32_t llama_state_seq_flags;
 
     LLAMA_API size_t llama_state_seq_get_size_ext(

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1722,7 +1722,7 @@ void llama_kv_cache::state_read(llama_io_read_i & io, llama_seq_id seq_id, llama
         slot_info sinfo;
 
         bool res = true;
-        res = res && state_read_meta(io, strm, cell_count, sinfo, seq_id);
+        res = res && state_read_meta(io, strm, cell_count, sinfo, seq_id, flags);
         res = res && state_read_data(io, strm, cell_count, sinfo);
 
         if (!res) {
@@ -1868,13 +1868,15 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
     }
 }
 
-bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32_t cell_count, slot_info & sinfo, llama_seq_id dest_seq_id) {
+bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32_t cell_count, slot_info & sinfo, llama_seq_id dest_seq_id, llama_state_seq_flags flags) {
     auto & cells = v_cells[strm];
     auto & head  = v_heads[strm];
 
     if (dest_seq_id != -1) {
         // single sequence
-        seq_rm(dest_seq_id, -1, -1);
+        if (!(flags & LLAMA_STATE_SEQ_FLAGS_APPEND)) {
+            seq_rm(dest_seq_id, -1, -1);
+        }
 
         llama_batch_allocr balloc(hparams.n_pos_per_embd());
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -280,7 +280,7 @@ private:
     void state_write_meta(llama_io_write_i & io, const cell_ranges_t & cr, llama_seq_id seq_id = -1) const;
     void state_write_data(llama_io_write_i & io, const cell_ranges_t & cr) const;
 
-    bool state_read_meta(llama_io_read_i & io, uint32_t strm, uint32_t cell_count,       slot_info & sinfo, llama_seq_id dest_seq_id = -1);
+    bool state_read_meta(llama_io_read_i & io, uint32_t strm, uint32_t cell_count,       slot_info & sinfo, llama_seq_id dest_seq_id = -1, llama_state_seq_flags flags = 0);
     bool state_read_data(llama_io_read_i & io, uint32_t strm, uint32_t cell_count, const slot_info & sinfo);
 };
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

`state_read_meta` unconditionally calls `seq_rm(dest_seq_id, -1, -1)` before restoring so every `state_seq_set_data_ext` wipes the sequence first, making chunk by chunk restore impossible (e.g. restoring chunk 1 destroys chunk 0) 

This PR adds a new flag `LLAMA_STATE_SEQ_FLAGS_APPEND` (value `2`) that skips the `seq_rm` call, allowing repeated `state_seq_set_data_ext` calls to append to the same sequence, using the existing `llama_state_seq_flags` mechanism (precedent`LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY` is from #16382).    

Exact changes:                                                                                                                                                                                  
  - `include/llama.h`: add `#define LLAMA_STATE_SEQ_FLAGS_APPEND 2`
  - `src/llama-kv-cache.h`: add `flags` param to `state_read_meta`                                                                                                                          
  - `src/llama-kv-cache.cpp`: thread `flags` through `state_read` → `state_read_meta`, gate `seq_rm` on `!(flags & APPEND)`   

default behavior (`flags=0`) is unchanged.                                                                                                                                                

 **motivation:** this enables external KV cache systems (e.g. [LMCache](https://github.com/LMCache/LMCache)) to store and restore opaque state blobs one chunk at a time, without reassembling into a single monolithic blob or parsing the internal serialization format.
                  

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected  OK!-->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md I'm NOT-->
