### PR TITLE
Relax prefill parser to allow space.

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -112,7 +112,7 @@ common_peg_arena autoparser::build_parser(const generation_params & inputs) cons
         } else {
             parser = content.build_parser(ctx);
         }
-        return p.prefix(inputs.generation_prompt, reasoning.start) + parser;
+        return p.prefix(inputs.generation_prompt, reasoning.start) << parser;
     });
 }
 

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -100,6 +100,7 @@ common_peg_arena autoparser::build_parser(const generation_params & inputs) cons
 
         bool has_tools           = inputs.tools.is_array() && !inputs.tools.empty();
         bool has_response_format = inputs.json_schema.is_object() && !inputs.json_schema.empty();
+        bool pure_content        = reasoning.mode == reasoning_mode::NONE;
 
         if (has_response_format) {
             auto response_format = p.rule("response-format", p.content(p.schema(p.json(), "response-format-schema", inputs.json_schema)));
@@ -107,12 +108,14 @@ common_peg_arena autoparser::build_parser(const generation_params & inputs) cons
                 p.literal("```json") + p.space() + response_format + p.space() + p.literal("```"),
                 response_format
             }) + p.end();
+            pure_content = false;
         } else if (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE && jinja_caps.supports_tool_calls) {
             parser = tools.build_parser(ctx);
+            pure_content = false;
         } else {
             parser = content.build_parser(ctx);
         }
-        return p.prefix(inputs.generation_prompt, reasoning.start) << parser;
+        return pure_content ? p.prefix(inputs.generation_prompt, reasoning.start) + parser : p.prefix(inputs.generation_prompt, reasoning.start) << parser;
     });
 }
 

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -807,9 +807,9 @@ common_peg_parser common_chat_peg_builder::prefix(const std::string & s, const s
         return eps();
     }
     if (delimiter.empty()) {
-        return literal(s);
+        return literal(s) + space();
     }
-    return literal(s.substr(0, s.rfind(delimiter)));
+    return literal(s.substr(0, s.rfind(delimiter))) + space();
 }
 
 common_peg_parser common_chat_peg_builder::standard_json_tools(

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -807,9 +807,9 @@ common_peg_parser common_chat_peg_builder::prefix(const std::string & s, const s
         return eps();
     }
     if (delimiter.empty()) {
-        return literal(s) + space();
+        return literal(s);
     }
-    return literal(s.substr(0, s.rfind(delimiter))) + space();
+    return literal(s.substr(0, s.rfind(delimiter)));
 }
 
 common_peg_parser common_chat_peg_builder::standard_json_tools(

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1627,7 +1627,7 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         data.format                    = COMMON_CHAT_FORMAT_PEG_NATIVE;
         data.generation_prompt         = params.generation_prompt;
         auto parser                    = build_chat_peg_parser([&params](common_chat_peg_builder &p) {
-            return p.prefix(params.generation_prompt) + p.content(p.rest());
+            return p.prefix(params.generation_prompt) << p.content(p.rest());
         });
         data.parser                    = parser.save();
         return data;


### PR DESCRIPTION
## Overview

As in title.

## Additional information

Prefill parser was strictly requiring the reasoning marker at the very start of the message, which interfered with models that liked to insert eg. a newline there.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
