### PR TITLE
webui : store reasoning_content so it is sent back in subsequent requests

### DIFF
--- a/tools/server/public/index.html
+++ b/tools/server/public/index.html
@@ -18,7 +18,7 @@
 		<div style="display: contents">
 			<script>
 				{
-					__sveltekit_1wqaxod = {
+					__sveltekit_188gk9g = {
 						base: new URL('.', location).pathname.slice(0, -1)
 					};
 

--- a/tools/server/public/index.html
+++ b/tools/server/public/index.html
@@ -18,7 +18,7 @@
 		<div style="display: contents">
 			<script>
 				{
-					__sveltekit_188gk9g = {
+					__sveltekit_10avopp = {
 						base: new URL('.', location).pathname.slice(0, -1)
 					};
 

--- a/tools/server/webui/src/lib/stores/agentic.svelte.ts
+++ b/tools/server/webui/src/lib/stores/agentic.svelte.ts
@@ -474,6 +474,7 @@ class AgenticStore {
 			sessionMessages.push({
 				role: MessageRole.ASSISTANT,
 				content: turnContent || undefined,
+				reasoning_content: turnReasoningContent || undefined,
 				tool_calls: normalizedCalls
 			});
 

--- a/tools/server/webui/src/lib/types/agentic.d.ts
+++ b/tools/server/webui/src/lib/types/agentic.d.ts
@@ -41,6 +41,7 @@ export type AgenticMessage =
 	| {
 			role: MessageRole.ASSISTANT;
 			content?: string | ApiChatMessageContentPart[];
+			reasoning_content?: string;
 			tool_calls?: AgenticToolCallPayload[];
 	  }
 	| {


### PR DESCRIPTION
## Overview

The `reasoning_content` should be sent back in the assistant message on subsequent requests. It wasn't being saved in the history and therefore lost.

## Additional information

For models that support interleaved thinking, it is important to send back the reasoning during agentic loops.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES to find the gap

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
