### PR TITLE
metal: Add FP32 and FP16 support for ADD1 kernel

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1503,14 +1503,13 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin(ggml_metal_l
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_add1(ggml_metal_library_t lib, const ggml_tensor * op) {
     assert(op->op == GGML_OP_ADD1);
 
-    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32);
-    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
-    GGML_ASSERT(op->type         == GGML_TYPE_F32);
+    GGML_ASSERT(op->src[0]->type == op->type);
+    GGML_ASSERT(op->src[0]->type == op->src[1]->type);
 
     char base[256];
     char name[256];
 
-    snprintf(base, 256, "kernel_add1_f32");
+    snprintf(base, 256, "kernel_add1_%s", ggml_type_name(op->src[0]->type));
     snprintf(name, 256, "%s", base);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1504,12 +1504,11 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_add1(ggml_metal_
     assert(op->op == GGML_OP_ADD1);
 
     GGML_ASSERT(op->src[0]->type == op->type);
-    GGML_ASSERT(op->src[0]->type == op->src[1]->type);
 
     char base[256];
     char name[256];
 
-    snprintf(base, 256, "kernel_add1_%s", ggml_type_name(op->src[0]->type));
+    snprintf(base, 256, "kernel_add1_%s_%s", ggml_type_name(op->src[0]->type), ggml_type_name(op->src[1]->type));
     snprintf(name, 256, "%s", base);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1500,6 +1500,27 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin(ggml_metal_l
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_add1(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_ADD1);
+
+    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->type         == GGML_TYPE_F32);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_add1_f32");
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin_one(ggml_metal_library_t lib, ggml_op op) {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -139,6 +139,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort_m
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k             (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k_merge       (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin               (ggml_metal_library_t lib, const struct ggml_tensor * op, int32_t n_fuse );
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_add1              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin_one           (ggml_metal_library_t lib, enum ggml_op op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_l2_norm           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_group_norm        (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1074,9 +1074,9 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_ACC:
             return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]) && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_ADD1:
-            return (op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16) &&
-                   op->src[0]->type == op->src[1]->type &&
-                   op->src[0]->type == op->type;
+            return op->src[0]->type == op->type &&
+                   (op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16) &&
+                   (op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == op->src[0]->type);
         case GGML_OP_REPEAT:
         case GGML_OP_CONV_TRANSPOSE_1D:
             return true;

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1073,6 +1073,10 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_ADD_ID:
         case GGML_OP_ACC:
             return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]) && op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_ADD1:
+            return op->src[0]->type == GGML_TYPE_F32 &&
+                   op->src[1]->type == GGML_TYPE_F32 &&
+                   op->type         == GGML_TYPE_F32;
         case GGML_OP_REPEAT:
         case GGML_OP_CONV_TRANSPOSE_1D:
             return true;

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1074,9 +1074,9 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_ACC:
             return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]) && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_ADD1:
-            return op->src[0]->type == GGML_TYPE_F32 &&
-                   op->src[1]->type == GGML_TYPE_F32 &&
-                   op->type         == GGML_TYPE_F32;
+            return (op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16) &&
+                   op->src[0]->type == op->src[1]->type &&
+                   op->src[0]->type == op->type;
         case GGML_OP_REPEAT:
         case GGML_OP_CONV_TRANSPOSE_1D:
             return true;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -217,6 +217,22 @@ typedef struct {
     uint64_t o1[8];
 } ggml_metal_kargs_bin;
 
+
+typedef struct {
+    int64_t ne0;
+    int64_t ne1;
+    int64_t ne2;
+    int64_t ne3;
+    uint64_t nb0;
+    uint64_t nb1;
+    uint64_t nb2;
+    uint64_t nb3;
+    uint64_t nb00;
+    uint64_t nb01;
+    uint64_t nb02;
+    uint64_t nb03;
+} ggml_metal_kargs_add1;
+
 typedef struct {
     int64_t ne0;
     int64_t ne1;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -278,6 +278,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_add_id(ctx, idx);
             } break;
+        case GGML_OP_ADD1:
+            {
+                n_fuse = ggml_metal_op_add1(ctx, idx);
+            } break;
         case GGML_OP_REPEAT:
             {
                 n_fuse = ggml_metal_op_repeat(ctx, idx);
@@ -2437,6 +2441,67 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
             ggml_metal_encoder_dispatch_threadgroups(enc, (ne01 + nr0*nsg - 1)/(nr0*nsg), (_ne1 + nr1 - 1)/nr1, ne123, 32, nsg, 1);
         }
     }
+
+    return 1;
+}
+
+int ggml_metal_op_add1(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    // GGML_TENSOR_LOCALS(type, prefix, tensor, field) expands to:
+    //   type prefix##0 = tensor->field[0];
+    //   type prefix##1 = tensor->field[1];
+    //   type prefix##2 = tensor->field[2];
+    //   type prefix##3 = tensor->field[3];
+    //
+    // So these give us:
+    //   ne00, ne01, ne02, ne03  — src0 dimensions
+    //   nb00, nb01, nb02, nb03  — src0 byte strides
+    //   ne0,  ne1,  ne2,  ne3   — dst  dimensions
+    //   nb0,  nb1,  nb2,  nb3   — dst  byte strides
+
+    GGML_TENSOR_LOCALS(int64_t,  ne0, op->src[0], ne)
+    GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb)
+    GGML_TENSOR_LOCALS(int64_t,  ne,  op,         ne)
+    GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb)
+
+    GGML_UNUSED(ne00);
+    GGML_UNUSED(ne01);
+    GGML_UNUSED(ne02);
+    GGML_UNUSED(ne03);
+
+    ggml_metal_kargs_add1 args = {
+        /*.ne0  =*/ ne0,
+        /*.ne1  =*/ ne1,
+        /*.ne2  =*/ ne2,
+        /*.ne3  =*/ ne3,
+        /*.nb0  =*/ nb0,
+        /*.nb1  =*/ nb1,
+        /*.nb2  =*/ nb2,
+        /*.nb3  =*/ nb3,
+        /*.nb00 =*/ nb00,
+        /*.nb01 =*/ nb01,
+        /*.nb02 =*/ nb02,
+        /*.nb03 =*/ nb03,
+    };
+
+    auto pipeline = ggml_metal_library_get_pipeline_add1(lib, op);
+
+    const int64_t n = ne0 * ne1 * ne2 * ne3;
+
+    int nth = 256;
+    int ntg = (int)((n + nth - 1) / nth);
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes (enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op),        3);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, ntg, 1, 1, nth, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -67,6 +67,7 @@ int ggml_metal_op_pool_2d           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_mul_mat           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_mul_mat_id        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_add_id            (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_add1              (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_flash_attn_ext    (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_bin               (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_l2_norm           (ggml_metal_op_t ctx, int idx);

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -1287,7 +1287,8 @@ typedef decltype(kernel_bin_fuse_impl<float, float, float>) kernel_bin_fuse_t;
 template [[host_name("kernel_bin_fuse_f32_f32_f32")]]   kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float,  float,  float>;
 template [[host_name("kernel_bin_fuse_f32_f32_f32_4")]] kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float4, float4, float4>;
 
-kernel void kernel_add1_f32(
+template<typename T>
+kernel void kernel_add1(
         constant ggml_metal_kargs_add1 & args,
         device const char * src0,
         device const char * src1,
@@ -1303,11 +1304,16 @@ kernel void kernel_add1_f32(
     const int64_t i2 = (gid / (args.ne0 * args.ne1)) % args.ne2;
     const int64_t i3 = gid / (args.ne0 * args.ne1 * args.ne2);
 
-    const float val0 = *(device const float *)(src0 + i0*args.nb00 + i1*args.nb01 + i2*args.nb02 + i3*args.nb03);
-    const float val1 = *(device const float *)(src1);
+    const T val0 = *(device const T *)(src0 + i0*args.nb00 + i1*args.nb01 + i2*args.nb02 + i3*args.nb03);
+    const T val1 = *(device const T *)(src1);
 
-    *(device float *)(dst + i0*args.nb0 + i1*args.nb1 + i2*args.nb2 + i3*args.nb3) = val0 + val1;
+    *(device T *)(dst + i0*args.nb0 + i1*args.nb1 + i2*args.nb2 + i3*args.nb3) = val0 + val1;
 }
+
+typedef decltype(kernel_add1<float>) kernel_add1_t;
+
+template [[host_name("kernel_add1_f32")]] kernel kernel_add1_t kernel_add1<float>;
+template [[host_name("kernel_add1_f16")]] kernel kernel_add1_t kernel_add1<half>;
 
 kernel void kernel_add_id(
         constant ggml_metal_kargs_add_id & args,

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -1287,7 +1287,7 @@ typedef decltype(kernel_bin_fuse_impl<float, float, float>) kernel_bin_fuse_t;
 template [[host_name("kernel_bin_fuse_f32_f32_f32")]]   kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float,  float,  float>;
 template [[host_name("kernel_bin_fuse_f32_f32_f32_4")]] kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float4, float4, float4>;
 
-template<typename T>
+template<typename T0, typename T1>
 kernel void kernel_add1(
         constant ggml_metal_kargs_add1 & args,
         device const char * src0,
@@ -1304,16 +1304,17 @@ kernel void kernel_add1(
     const int64_t i2 = (gid / (args.ne0 * args.ne1)) % args.ne2;
     const int64_t i3 = gid / (args.ne0 * args.ne1 * args.ne2);
 
-    const T val0 = *(device const T *)(src0 + i0*args.nb00 + i1*args.nb01 + i2*args.nb02 + i3*args.nb03);
-    const T val1 = *(device const T *)(src1);
+    const float val0 = (float) *(device const T0 *)(src0 + i0*args.nb00 + i1*args.nb01 + i2*args.nb02 + i3*args.nb03);
+    const float val1 = (float) *(device const T1 *)(src1);
 
-    *(device T *)(dst + i0*args.nb0 + i1*args.nb1 + i2*args.nb2 + i3*args.nb3) = val0 + val1;
+    *(device T0 *)(dst + i0*args.nb0 + i1*args.nb1 + i2*args.nb2 + i3*args.nb3) = (T0)(val0 + val1);
 }
 
-typedef decltype(kernel_add1<float>) kernel_add1_t;
+typedef decltype(kernel_add1<float, float>) kernel_add1_t;
 
-template [[host_name("kernel_add1_f32")]] kernel kernel_add1_t kernel_add1<float>;
-template [[host_name("kernel_add1_f16")]] kernel kernel_add1_t kernel_add1<half>;
+template [[host_name("kernel_add1_f32_f32")]] kernel kernel_add1_t kernel_add1<float, float>;
+template [[host_name("kernel_add1_f16_f32")]] kernel kernel_add1_t kernel_add1<half,  float>;
+template [[host_name("kernel_add1_f16_f16")]] kernel kernel_add1_t kernel_add1<half,  half>;
 
 kernel void kernel_add_id(
         constant ggml_metal_kargs_add_id & args,

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -1287,6 +1287,28 @@ typedef decltype(kernel_bin_fuse_impl<float, float, float>) kernel_bin_fuse_t;
 template [[host_name("kernel_bin_fuse_f32_f32_f32")]]   kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float,  float,  float>;
 template [[host_name("kernel_bin_fuse_f32_f32_f32_4")]] kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float4, float4, float4>;
 
+kernel void kernel_add1_f32(
+        constant ggml_metal_kargs_add1 & args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        uint gid[[thread_position_in_grid]]) {
+    const int64_t n = args.ne0 * args.ne1 * args.ne2 * args.ne3;
+    if ((int64_t)gid >= n) {
+        return;
+    }
+
+    const int64_t i0 = gid % args.ne0;
+    const int64_t i1 = (gid / args.ne0) % args.ne1;
+    const int64_t i2 = (gid / (args.ne0 * args.ne1)) % args.ne2;
+    const int64_t i3 = gid / (args.ne0 * args.ne1 * args.ne2);
+
+    const float val0 = *(device const float *)(src0 + i0*args.nb00 + i1*args.nb01 + i2*args.nb02 + i3*args.nb03);
+    const float val1 = *(device const float *)(src1);
+
+    *(device float *)(dst + i0*args.nb0 + i1*args.nb1 + i2*args.nb2 + i3*args.nb3) = val0 + val1;
+}
+
 kernel void kernel_add_id(
         constant ggml_metal_kargs_add_id & args,
         device const char * src0,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7888,6 +7888,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     test_cases.emplace_back(new test_add1());
     test_cases.emplace_back(new test_add1(GGML_TYPE_F32, {1024, 1024, 1, 1}));
+    test_cases.emplace_back(new test_add1(GGML_TYPE_F16));
+    test_cases.emplace_back(new test_add1(GGML_TYPE_F16, {1024, 1024, 1, 1}));
     test_cases.emplace_back(new test_scale());
     test_cases.emplace_back(new test_scale(GGML_TYPE_F32, {10, 10, 10, 10}, 2.0f, 1.0f));
     test_cases.emplace_back(new test_scale(GGML_TYPE_F32, {10, 10, 10, 10}, 2.0f, 1.0f, true)); // inplace test

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3132,22 +3132,23 @@ struct test_add_id : public test_case {
 // GGML_OP_ADD1
 struct test_add1 : public test_case {
     const ggml_type type;
+    const ggml_type type_b;
     const std::array<int64_t, 4> ne;
 
     std::string vars() override {
-        return VARS_TO_STR2(type, ne);
+        return VARS_TO_STR3(type, type_b, ne);
     }
 
-    test_add1(ggml_type type = GGML_TYPE_F32,
+    test_add1(ggml_type type = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
             std::array<int64_t, 4> ne = {10, 5, 4, 3})
-        : type(type), ne(ne) {}
+        : type(type), type_b(type_b), ne(ne) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne.data());
         ggml_set_param(a);
         ggml_set_name(a, "a");
 
-        ggml_tensor * b = ggml_new_tensor_1d(ctx, type, 1);
+        ggml_tensor * b = ggml_new_tensor_1d(ctx, type_b, 1);
         // ggml_set_param(b); // TODO: implement
         ggml_set_name(b, "b");
 
@@ -7887,9 +7888,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_bin_bcast(ggml_add, GGML_TYPE_F32, {16, 5, 4, 3}, {1, 1, 1, 1}, 16));
 
     test_cases.emplace_back(new test_add1());
-    test_cases.emplace_back(new test_add1(GGML_TYPE_F32, {1024, 1024, 1, 1}));
-    test_cases.emplace_back(new test_add1(GGML_TYPE_F16));
-    test_cases.emplace_back(new test_add1(GGML_TYPE_F16, {1024, 1024, 1, 1}));
+    test_cases.emplace_back(new test_add1(GGML_TYPE_F32, GGML_TYPE_F32, {1024, 1024, 1, 1}));
+    test_cases.emplace_back(new test_add1(GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_add1(GGML_TYPE_F16, GGML_TYPE_F16, {1024, 1024, 1, 1}));
+    test_cases.emplace_back(new test_add1(GGML_TYPE_F16, GGML_TYPE_F32));
+    test_cases.emplace_back(new test_add1(GGML_TYPE_F16, GGML_TYPE_F32, {1024, 1024, 1, 1}));
     test_cases.emplace_back(new test_scale());
     test_cases.emplace_back(new test_scale(GGML_TYPE_F32, {10, 10, 10, 10}, 2.0f, 1.0f));
     test_cases.emplace_back(new test_scale(GGML_TYPE_F32, {10, 10, 10, 10}, 2.0f, 1.0f, true)); // inplace test


### PR DESCRIPTION
## Overview

Add support for the ADD1 operation on the Metal backend.
Supports FP32/FP16.

## Additional information

Feature Request: Implement missing ops from backends #14909


# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
YES: to quickly implement the fp16 version through redundant checks and templates implementation (second commit).
