### PR TITLE
metal: add ADD1 support

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -226,6 +226,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_unary(ggml_metal
         case GGML_OP_SIN:        op_num = OP_UNARY_NUM_SIN;        break;
         case GGML_OP_COS:        op_num = OP_UNARY_NUM_COS;        break;
         case GGML_OP_LOG:        op_num = OP_UNARY_NUM_LOG;        break;
+        case GGML_OP_ADD1:       op_num = OP_UNARY_NUM_ADD1;       break;
         case GGML_OP_LEAKY_RELU: op_num = OP_UNARY_NUM_LEAKY_RELU; break;
         case GGML_OP_UNARY:
             switch (ggml_get_unary_op(op)) {

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1015,6 +1015,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_FILL:
         case GGML_OP_CLAMP:
         case GGML_OP_SQR:
+        case GGML_OP_ADD1:
         case GGML_OP_SQRT:
         case GGML_OP_SIN:
         case GGML_OP_COS:

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -102,6 +102,7 @@
 #define OP_UNARY_NUM_COS        16
 #define OP_UNARY_NUM_LOG        17
 #define OP_UNARY_NUM_LEAKY_RELU 18
+#define OP_UNARY_NUM_ADD1       19
 
 #define OP_UNARY_NUM_TANH        100
 #define OP_UNARY_NUM_RELU        101

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -468,6 +468,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_count_equal(ctx, idx);
             } break;
+        case GGML_OP_ADD1:
+            {
+                n_fuse = ggml_metal_op_unary(ctx, idx);
+            } break;
         default:
             {
                 GGML_LOG_ERROR("%s: error: node %3d, op = %8s not implemented\n", __func__, idx, ggml_op_name(node->op));
@@ -776,6 +780,10 @@ int ggml_metal_op_unary(ggml_metal_op_t ctx, int idx) {
     if (op->op == GGML_OP_SCALE) {
         args.scale = ggml_get_op_params_f32(op, 0);
         args.bias  = ggml_get_op_params_f32(op, 1);
+    }
+
+    if (op->op == GGML_OP_ADD1) {
+    args.val = *(float *) op->src[1]->data;
     }
 
     if (op->op == GGML_OP_FILL) {

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -994,6 +994,10 @@ kernel void kernel_unary_impl(
             dst_ptr[i0] = (T) (args.scale * x + args.bias);
         }
 
+        if (FC_OP == OP_UNARY_NUM_ADD1) {
+            dst_ptr[i0] = (T) (x + args.val);
+        }
+
         if (FC_OP == OP_UNARY_NUM_FILL) {
             dst_ptr[i0] = (T) args.val;
         }


### PR DESCRIPTION
## Overview
Implement GGML_OP_ADD1 for the Metal backend using the existing
kernel_unary_impl infrastructure.
#14909
## Additional information

https://github.com/ggml-org/llama.cpp/issues/14909

# Requirements
The requirement comes directly from issue #14909:

"Feature parity between backends is always desirable"

The goal is simple — every GGML operation should work on every backend. ADD1 worked on CPU and CUDA but not on Metal. That means any model graph containing an ADD1 op on an Apple Silicon Mac would force that operation to fall back from GPU to CPU, causing a memory copy round-trip and killing performance.

test-backend-ops -o ADD1:

```
 ./build/bin/test-backend-ops -o ADD1
ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.026 sec
ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
ggml_metal_device_init: GPU name:   MTL0
ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal4  (5002)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = false
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 19069.67 MB
Testing 3 devices

ggml_metal_init: allocating
ggml_metal_init: found device: Apple M3
ggml_metal_init: picking default device: Apple M3
ggml_metal_init: use fusion         = true
ggml_metal_init: use concurrency    = true
ggml_metal_init: use graph optimize = true
Backend 1/3: MTL0
  Device description: Apple M3
  Device memory: 18186 MB (18185 MB free)

ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_unary_f32_f32', name = 'kernel_unary_f32_f32_op=19_cnt=1'
ggml_metal_library_compile_pipeline: loaded kernel_unary_f32_f32_op=19_cnt=1              0x105bb6c90 | th_max = 1024 | th_width =   32
  ADD1(type=f32,ne=[10,5,4,3]): OK
ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_unary_f32_f32_4', name = 'kernel_unary_f32_f32_4_op=19_cnt=0'
ggml_metal_library_compile_pipeline: loaded kernel_unary_f32_f32_4_op=19_cnt=0            0x105bb4990 | th_max = 1024 | th_width =   32
  ADD1(type=f32,ne=[1024,1024,1,1]): OK
  2/2 tests passed
  Backend MTL0: OK
ggml_metal_free: deallocating
Backend 2/3: BLAS
  Device description: Accelerate
  Device memory: 0 MB (0 MB free)

  ADD1(type=f32,ne=[10,5,4,3]): not supported [BLAS] 
  ADD1(type=f32,ne=[1024,1024,1,1]): not supported [BLAS] 
  0/0 tests passed
  Backend BLAS: OK
Backend 3/3: CPU
  Skipping CPU backend
3/3 backends passed
OK
```
```
./build/bin/test-backend-ops perf -o ADD1
ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.027 sec
ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
ggml_metal_device_init: GPU name:   MTL0
ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal4  (5002)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = false
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 19069.67 MB
Testing 3 devices

ggml_metal_init: allocating
ggml_metal_init: found device: Apple M3
ggml_metal_init: picking default device: Apple M3
ggml_metal_init: use fusion         = true
ggml_metal_init: use concurrency    = true
ggml_metal_init: use graph optimize = true
Backend 1/3: MTL0
  Device description: Apple M3
  Device memory: 18186 MB (18185 MB free)

  Backend MTL0: OK
ggml_metal_free: deallocating
Backend 2/3: BLAS
  Device description: Accelerate
  Device memory: 0 MB (0 MB free)

  Backend BLAS: OK
Backend 3/3: CPU
  Skipping CPU backend
3/3 backends passed
OK
```
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 
Yes , PR commit message and description only
