### PR TITLE
llama-bench: Fix to reduce very high ± variability

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2193,18 +2193,22 @@ int main(int argc, char ** argv) {
         llama_attach_threadpool(ctx, threadpool, NULL);
 
         // warmup run
+#define NUM_BENCH_WARMUPS 4 // 4 stabilizes results without adding significant delay
         if (!params.no_warmup) {
             if (t.n_prompt > 0) {
                 if (params.progress) {
                     fprintf(stderr, "llama-bench: benchmark %d/%zu: warmup prompt run\n", params_idx, params_count);
                 }
                 //test_prompt(ctx, std::min(t.n_batch, std::min(t.n_prompt, 32)), 0, t.n_batch, t.n_threads);
-                bool res = test_prompt(ctx, t.n_prompt, t.n_batch, t.n_threads);
-                if (!res) {
-                    fprintf(stderr, "%s: error: failed to run prompt warmup\n", __func__);
-                    llama_free(ctx);
-                    llama_model_free(lmodel);
-                    exit(1);
+                for (int i = 0; i < NUM_BENCH_WARMUPS; i++) {
+                    llama_memory_clear(llama_get_memory(ctx), false);
+                    bool res = test_prompt(ctx, t.n_prompt, t.n_batch, t.n_threads);
+                    if (!res) {
+                        fprintf(stderr, "%s: error: failed to run prompt warmup\n", __func__);
+                        llama_free(ctx);
+                        llama_model_free(lmodel);
+                        exit(1);
+                    }
                 }
             }
             if (t.n_gen > 0) {


### PR DESCRIPTION
## Overview
After the implementation of PR #19754 , `llama-bench` started to show very high variability for most bench runs.  That can still be avoided by adding repeats, eg, `-r 5` or `-r 10`.  This change fixes llama-bench's high variability/noise by adding 4 warmup runs (easy to adjust),  which seems to be the sweet spot of not adding too much delay from the extra run, but still substantially reducing variability.  
There still may be some variance from one run to another based on system load or other factors, but this new default setting helps to prevent that and is more consistent with the output.
## Additional information
Example `llama-bench` before/after change in output on some models I've tested, without flags:
| Model | Test | Before | After |
|--|--|--|--|
| Qwen3.5 0.8B Q4_K_M | pp512 | 25231.96 ± 17262.95 | 42934.98 ± 240.28 |
| Qwen3.5 0.8B Q4_K_M | tg128 | 496.66 ± 2.32 | 496.70 ± 4.56 |
| Qwen3.5 0.8B NVFP4 | pp512 | 27147.01 ± 1477 | 46399.96 ± 144.82 |
| Qwen3.5 0.8B NVFP4 | tg128 | 404.41 ± 1.87| 394.96 ± 1.38 |
| Cascade 31B MXFP4 | pp512 | 8609.84 ± 4706.08 | 10613.82 ± 28.14 |
| Cascade 31B MXFP4 | tg128 | 201.45 ± 9.3 | 205.84 ± 4.34 |
| Cascade 31B NVFP4 | pp512 | 9052.70 ± 4221.99 | 10986.75 ± 22.5 |
| Cascade 31B NVFP4 | tg128 | 195.93 ± 3.98 | 199.45 ± 0.58 |
# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
Yes
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
Yes - helped locate the best position to put in the fix.
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->