### PR TITLE
opencl: Q4_K batch GEMM — SOA path for OpenCL 3.0, qst+packed paths for legacy OpenCL 1.2

### DIFF
--- a/ggml/src/ggml-opencl/CMakeLists.txt
+++ b/ggml/src/ggml-opencl/CMakeLists.txt
@@ -71,6 +71,7 @@ set(GGML_OPENCL_KERNELS
     get_rows
     glu
     group_norm
+    gated_delta_net
     solve_tri
     im2col_f32
     im2col_f16
@@ -90,6 +91,7 @@ set(GGML_OPENCL_KERNELS
     mul_mv_q4_1_f32_flat
     mul_mv_q4_k_f32
     mul_mv_q4_k_f32_flat
+    mul_mv_q5_0_f32_flat
     mul_mv_q6_k_f32
     mul_mv_q6_k_f32_flat
     mul_mv_q8_0_f32

--- a/ggml/src/ggml-opencl/CMakeLists.txt
+++ b/ggml/src/ggml-opencl/CMakeLists.txt
@@ -112,6 +112,10 @@ set(GGML_OPENCL_KERNELS
     mul_mm_q8_0_f32_l4_lm
     mul_mm_q4_k_f32_l4_lm
     mul_mm_q6_k_f32_l4_lm
+    mul_mm_q4_k_f32_l4_lm
+    mul_mm_q4_k_f32_l4_lm_packed
+    mul_mm_q4_k_f32_l4_lm_qst
+    mul_mm_q4_k_f32_l4_lm_qst_n32
     mul_mm_q8_0_f32_8x4
     gemv_noshuffle_q4_1_f32
     gemm_noshuffle_q4_1_f32

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -29,6 +29,8 @@
 #include <string>
 #include <cmath>
 #include <map>
+#include <unordered_map>
+#include <unordered_set>
 #include <memory>
 #include <charconv>
 #include <mutex>
@@ -424,6 +426,9 @@ struct ggml_backend_opencl_context {
 
     std::string driver_version;
 
+    // Compiler options stored for lazy kernel compilation after init
+    std::string kernel_compile_opts;
+
     GPU_FAMILY gpu_family;
     bool use_adreno_kernels;
     bool use_no_subgroups_compat;
@@ -456,6 +461,12 @@ struct ggml_backend_opencl_context {
     // prealloc buffers for src0 and src1
     ggml_cl_buffer prealloc_src0;
     ggml_cl_buffer prealloc_src1;
+
+    // Global tracking for Q4_K qs_t budget: must be computed against the
+    // TOTAL pool (all chunks) not per-chunk, otherwise each chunk gets its
+    // own budget and the total qs_t far exceeds available GPU memory.
+    size_t total_pool_bytes = 0;  // sum of all alloc_buffer sizes
+    size_t total_qs_t_bytes = 0;  // sum of qs_t across all buf ctxs
 
     cl_program program_add;
     cl_program program_add_id;
@@ -633,6 +644,9 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_mul_mm_q8_0_f32_l4_lm;
     cl_kernel kernel_mul_mm_q4_k_f32_l4_lm;
     cl_kernel kernel_mul_mm_q6_k_f32_l4_lm;
+    cl_kernel kernel_mul_mm_q4_k_f32_l4_lm_packed = nullptr;
+    cl_kernel kernel_mul_mm_q4_k_f32_l4_lm_qst     = nullptr;
+    cl_kernel kernel_mul_mm_q4_k_f32_l4_lm_qst_n32 = nullptr;
 
     std::vector<ProfilingInfo> profiling_info;
 
@@ -1060,6 +1074,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         GGML_LOG_WARN("ggml_opencl: building kernels with no-subgroups compatibility mode for '%s'\n",
             backend_ctx->device_name.c_str());
     }
+
+    backend_ctx->kernel_compile_opts = compile_opts;
+
 
     GGML_LOG_INFO("ggml_opencl: loading OpenCL kernels");
 
@@ -1822,7 +1839,8 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         GGML_LOG_CONT(".");
     }
 
-    // mul_mm_q4_k_f32_l4_lm
+    // mul_mm_q4_k_f32_l4_lm (non-SOA fallback — only compiled when SOA_Q is disabled)
+#ifndef GGML_OPENCL_SOA_Q
     {
 #ifdef GGML_OPENCL_EMBED_KERNELS
         const std::string kernel_src {
@@ -1838,6 +1856,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         CL_CHECK(clReleaseProgram(prog));
         GGML_LOG_CONT(".");
     }
+#endif // !GGML_OPENCL_SOA_Q
 
     // mul_mm_q6_k_f32_l4_lm
     {
@@ -1855,6 +1874,34 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         CL_CHECK(clReleaseProgram(prog));
         GGML_LOG_CONT(".");
     }
+
+    // mul_mm_q4_k_f32_l4_lm (SOA batch GEMM for Q4_K on NVIDIA only)
+    // Only compiled on NVIDIA: soa_q4_K_tensors is only populated for NVIDIA
+    // devices in buffer_set_tensor, so this kernel is never dispatched on
+    // Adreno, Apple, or Intel.  Skipping on non-NVIDIA saves ~20-50 MB of
+    // driver-managed GPU memory for the compiled kernel binary.
+#ifdef GGML_OPENCL_SOA_Q
+    if (backend_ctx->device_name.find("NVIDIA") != std::string::npos) {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src_q4k_mm {
+            #include "mul_mm_q4_k_f32_l4_lm.cl.h"
+        };
+#else
+        const std::string kernel_src_q4k_mm = read_file("mul_mm_q4_k_f32_l4_lm.cl");
+#endif
+        cl_program prog_q4k_mm =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_q4k_mm.c_str(), compile_opts);
+        CL_CHECK((backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm = clCreateKernel(prog_q4k_mm, "kernel_mul_mm_q4_k_f32_l4_lm", &err), err));
+        CL_CHECK(clReleaseProgram(prog_q4k_mm));
+        GGML_LOG_CONT(".");
+    }
+#endif // GGML_OPENCL_SOA_Q
+
+    // mul_mm_q4_k_f32_l4_lm_packed, _qst, and _qst_n32 are all compiled lazily
+    // (see ggml_opencl_ensure_q4k_qst_kernels) on the first Q4_K GEMM dispatch.
+    // These kernels are not needed for model loading or KV allocation.
+    // Deferring them frees ~300-500 MB of driver-managed GPU memory at init time,
+    // which allows 7B+ models (pool ~4 GB) to allocate the KV cache successfully.
 
     // mul_mm_f16_f32_kq_kqv
     {
@@ -3117,6 +3164,65 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
 // XXX    static bool initialized = false;
 // XXX    static ggml_backend_opencl_context *backend_ctx = nullptr;
 
+// Lazily compile Q4_K GEMM kernels (packed / qst / qst_n32) on first dispatch.
+// These kernels are not needed until the first Q4_K matrix-multiply, so we
+// defer their compilation to avoid consuming ~300-500 MB of driver-managed GPU
+// memory during init.  This allows 7B+ models (pool ~4 GB) to fit in GPU
+// memory alongside the KV cache and compute buffers.
+static void ggml_opencl_ensure_q4k_gemm_kernels(ggml_backend_opencl_context * backend_ctx) {
+    if (backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm_packed != nullptr) {
+        return;  // already compiled
+    }
+    GGML_LOG_INFO("ggml_opencl: lazy-compiling Q4_K GEMM kernels (packed/qst/qst_n32)\n");
+    cl_int err;
+    const std::string & compile_opts = backend_ctx->kernel_compile_opts;
+
+    // mul_mm_q4_k_f32_l4_lm_packed (packed AoS fallback, used when qs_t unavailable)
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "mul_mm_q4_k_f32_l4_lm_packed.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("mul_mm_q4_k_f32_l4_lm_packed.cl");
+#endif
+        cl_program prog =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+        CL_CHECK((backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm_packed = clCreateKernel(prog, "kernel_mul_mm_q4_k_f32_l4_lm_packed", &err), err));
+        CL_CHECK(clReleaseProgram(prog));
+    }
+
+    // mul_mm_q4_k_f32_l4_lm_qst (coalesced qs_t GEMM, used when qs_t available)
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "mul_mm_q4_k_f32_l4_lm_qst.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("mul_mm_q4_k_f32_l4_lm_qst.cl");
+#endif
+        cl_program prog =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+        CL_CHECK((backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm_qst = clCreateKernel(prog, "kernel_mul_mm_q4_k_f32_l4_lm_qst", &err), err));
+        CL_CHECK(clReleaseProgram(prog));
+    }
+
+    // mul_mm_q4_k_f32_l4_lm_qst_n32 (narrow BN=32 qst variant)
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "mul_mm_q4_k_f32_l4_lm_qst_n32.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("mul_mm_q4_k_f32_l4_lm_qst_n32.cl");
+#endif
+        cl_program prog =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+        CL_CHECK((backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm_qst_n32 = clCreateKernel(prog, "kernel_mul_mm_q4_k_f32_l4_lm_qst_n32", &err), err));
+        CL_CHECK(clReleaseProgram(prog));
+    }
+}
+
 static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev);
 
 namespace /* anonymous */ {
@@ -3624,9 +3730,13 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
                           required_B_d_bytes, max_B_d_bytes);
         }
 
-        backend_ctx->prealloc_quant_trans.allocate(context, max_A_q_d_bytes);
-        backend_ctx->prealloc_scales_trans.allocate(context, max_A_s_d_bytes);
         backend_ctx->prealloc_act_trans.allocate(context, max_B_d_bytes);
+
+        // prealloc_quant_trans / prealloc_scales_trans / prealloc_quant_src /
+        // prealloc_scales_src are all allocated lazily in buffer_set_tensor on
+        // first use.  Do NOT preallocate here: for large models (7B+) the pool
+        // already uses ~4 GB, and reserving 350+ MB at init pushes the total
+        // over the GPU memory limit causing context-creation failure.
     }
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
@@ -4715,6 +4825,9 @@ struct ggml_backend_opencl_buffer_context {
         for (ggml_tensor_extra_cl_q6_K * e : temp_tensor_extras_q6_K_in_use) {
             delete e;
         }
+        for (auto & kv : q4k_qs_t_buffers) {
+            if (kv.second) { CL_CHECK(clReleaseMemObject(kv.second)); }
+        }
     }
 
     ggml_tensor_extra_cl * ggml_opencl_alloc_temp_tensor_extra() {
@@ -4896,6 +5009,16 @@ struct ggml_backend_opencl_buffer_context {
     std::vector<ggml_tensor_extra_cl_q8_0 *> temp_tensor_extras_q8_0_in_use;
     std::vector<ggml_tensor_extra_cl_q4_K *> temp_tensor_extras_q4_K;
     std::vector<ggml_tensor_extra_cl_q4_K *> temp_tensor_extras_q4_K_in_use;
+
+    // Tracks tensors whose Q4_K data was successfully converted to SOA format.
+    // When a tensor is NOT in this set (e.g., SOA allocation failed due to OOM),
+    // mul_mat falls back to the packed kernel using the pool buffer.
+    std::unordered_set<const ggml_tensor *> soa_q4_K_tensors;
+
+    // Per-tensor qs_t buffer: qs in [batch, nb, ne01, 128] order for coalesced
+    // GEMM access on Apple M1 (no SOA).  The original packed buffer is kept
+    // for GEMV; this buffer is freed when the buffer context is destroyed.
+    std::unordered_map<const ggml_tensor *, cl_mem> q4k_qs_t_buffers;
     std::vector<ggml_tensor_extra_cl_q6_K *> temp_tensor_extras_q6_K;
     std::vector<ggml_tensor_extra_cl_q6_K *> temp_tensor_extras_q6_K_in_use;
 
@@ -5009,6 +5132,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 
     cl_context context = backend_ctx->context;
     cl_command_queue queue = backend_ctx->queue;
+
 
 #ifdef GGML_OPENCL_SOA_Q
     // We separate the quantized bits and scale from block_q4_0 by using an
@@ -5577,6 +5701,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 
             // Transpose weights
             size_t q_size_bytes = K * M / 4 * sizeof(float);
+            backend_ctx->prealloc_quant_trans.allocate(context, q_size_bytes);
             cl_buffer_region region;
             region.origin = 0;
             region.size = q_size_bytes;
@@ -5626,6 +5751,7 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 
             // Transpose scales
             size_t d_size_bytes = M * (K / 32) * 2;
+            backend_ctx->prealloc_scales_trans.allocate(context, d_size_bytes);
             region.origin = 0;
             region.size = d_size_bytes;
             cl_mem dT_d = clCreateSubBuffer(
@@ -5699,7 +5825,24 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
 
         return;
     }
-    if (tensor->type == GGML_TYPE_Q4_K) {
+    if (tensor->type == GGML_TYPE_Q4_K &&
+        offset == 0 && size == ggml_nbytes(tensor) &&
+        backend_ctx->device_name.find("NVIDIA") != std::string::npos) {
+        // Only convert full tensor writes (weight loading).  Partial writes
+        // (e.g. KV-cache updates) bypass SOA and fall through to the pool write.
+        //
+        // Apple M1 is excluded: SOA doubles Q4_K GPU memory (packed AoS + 4 SOA
+        // sub-buffers coexist during conversion), causing OOM on 3B+ models
+        // (max_mem_alloc=1024 MB).  Apple M1 uses the packed-format GEMM kernel
+        // (kernel_mul_mm_q4_k_f32_l4_lm_packed) instead.
+        //
+        // Adreno is intentionally excluded: benchmarks show the flat kernel is
+        // ~40% slower than the packed Adreno kernel (56 t/s vs 95 t/s on 1B
+        // Q4_K_M) even after coalescing the thread mapping (ix=lid/16) and
+        // rewriting scale decode to use 3 aligned ushort reads instead of
+        // divergent byte reads.  The packed Adreno kernel uses image-based
+        // access patterns that the flat SOA kernel cannot replicate.  Additionally,
+        // SOA buffers double Q4_K GPU memory → OOM risk on 7B+ with Q6_K tensors.
         ggml_tensor_extra_cl * extra_orig = (ggml_tensor_extra_cl *)tensor->extra;
         GGML_ASSERT(extra_orig && "Tensors in OpenCL backend should have been allocated and initialized");
 
@@ -5846,6 +5989,79 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
     #endif // GGML_OPENCL_USE_ADRENO_KERNELS
         }
         return;
+    }
+    // Non-NVIDIA Q4_K: build qs_t buffer in [batch, nb, ne01, 128] order for
+    // coalesced GEMM tile loads.  Adjacent threads read stride-128-byte-apart
+    // addresses instead of the packed format's nb*144 = 1728-byte stride.
+    // The original packed buffer is preserved in the pool for GEMV.
+    if (tensor->type == GGML_TYPE_Q4_K &&
+        offset == 0 && size == ggml_nbytes(tensor) &&
+        backend_ctx->device_name.find("NVIDIA") == std::string::npos) {
+
+        const int ne01_t = tensor->ne[1];
+        const int ne23   = tensor->ne[2] * tensor->ne[3];
+        const int nb_row = tensor->ne[0] / 256;   // super-blocks per row (QK_K=256)
+        const size_t n_blocks  = (size_t)ne01_t * ne23 * nb_row;
+        const size_t size_qs_t = n_blocks * 128;
+
+        // Reorganize qs on the CPU into [ne23, nb_row, ne01, 128] layout
+        std::vector<uint8_t> qs_t_cpu(size_qs_t);
+        const uint8_t * src_data = (const uint8_t *)data;
+
+        for (int b23 = 0; b23 < ne23; b23++) {
+            for (int r = 0; r < ne01_t; r++) {
+                for (int ib = 0; ib < nb_row; ib++) {
+                    // Source: packed block at row-major index
+                    const uint8_t * bp = src_data +
+                        (size_t)(b23 * ne01_t * nb_row + r * nb_row + ib) * 144; // BLOCK_Q4_K_SZ
+                    // Destination: [b23, ib, r] in qs_t
+                    uint8_t * dst_qs = qs_t_cpu.data() +
+                        (size_t)(b23 * nb_row * ne01_t + ib * ne01_t + r) * 128;
+                    memcpy(dst_qs, bp + 16, 128);
+                }
+            }
+        }
+
+        ggml_backend_opencl_buffer_context * buf_ctx =
+            (ggml_backend_opencl_buffer_context *) buffer->context;
+
+        // Cap qs_t allocation so that (total_pool + total_qs_t) stays below
+        // ~4 GB, leaving headroom for KV cache and compute buffers.
+        // IMPORTANT: budget must be computed against the TOTAL pool across all
+        // pool chunks (backend_ctx->total_pool_bytes), NOT the per-chunk size
+        // (buffer->size). Each pool chunk is < max_alloc_size (≈2 GB), so using
+        // buffer->size gives a falsely positive budget even for 7B models where
+        // the true total pool (> 4 GB) leaves no room for qs_t buffers.
+        static constexpr size_t QST_POOL_PLUS_QST_LIMIT =
+            4ULL * 1024 * 1024 * 1024; // 4.0 GB
+        const size_t total_pool = backend_ctx->total_pool_bytes;
+        const size_t qs_t_budget = (total_pool < QST_POOL_PLUS_QST_LIMIT)
+                                 ? (QST_POOL_PLUS_QST_LIMIT - total_pool)
+                                 : 0;
+        if (backend_ctx->total_qs_t_bytes + size_qs_t > qs_t_budget) {
+            GGML_LOG_DEBUG("ggml_opencl: Q4_K qs_t budget exhausted "
+                           "(pool=%.1f GB, qs_t=%.1f GB, limit=%.1f GB) — packed GEMM\n",
+                           total_pool / 1073741824.0,
+                           (double)backend_ctx->total_qs_t_bytes / 1073741824.0,
+                           QST_POOL_PLUS_QST_LIMIT / 1073741824.0);
+            // Fall through: packed data is still written to pool buffer (for GEMV)
+        } else {
+            cl_int err;
+            cl_mem qs_t_buf = clCreateBuffer(
+                backend_ctx->context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                size_qs_t, qs_t_cpu.data(), &err);
+            if (err == CL_SUCCESS) {
+                buf_ctx->q4k_qs_t_buffers[tensor] = qs_t_buf;
+                backend_ctx->total_qs_t_bytes += size_qs_t;
+                GGML_LOG_DEBUG("ggml_opencl: Q4_K qs_t buffer created (%.1f MB, total %.1f MB)\n",
+                               size_qs_t / 1048576.0,
+                               (double)backend_ctx->total_qs_t_bytes / 1048576.0);
+            } else {
+                GGML_LOG_WARN("ggml_opencl: Q4_K qs_t buffer allocation failed (%.1f MB) — "
+                              "falling back to packed GEMM\n", size_qs_t / 1048576.0);
+            }
+        }
+        // Fall through: packed data is still written to pool buffer (for GEMV)
     }
     if (tensor->type == GGML_TYPE_Q6_K) {
         ggml_tensor_extra_cl * extra_orig = (ggml_tensor_extra_cl *)tensor->extra;
@@ -6548,17 +6764,19 @@ static ggml_backend_buffer_t ggml_backend_opencl_buffer_type_alloc_buffer(ggml_b
 
     cl_int err;
     cl_mem mem = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, size, NULL, &err);
-#ifndef __APPLE__
     if (err != CL_SUCCESS && backend_ctx->adreno_use_large_buffer) {
         cl_mem_properties props[] = { 0x41A6 /* CL_LARGE_BUFFER_QCOM */, 1, 0 };
         mem = clCreateBufferWithProperties(backend_ctx->context, props, CL_MEM_READ_WRITE, size, NULL, &err);
     }
-#endif
     if (err != CL_SUCCESS) {
         GGML_LOG_INFO("%s: failed to allocate %.2f MiB (err = %d, context = %p)\n",
                 __func__, size / 1024.0 / 1024.0, err, (void *) backend_ctx->context);
         return nullptr;
     }
+
+    // Accumulate total pool bytes so the global Q4_K qs_t budget can be
+    // computed correctly across all pool chunks (each chunk is a separate call).
+    backend_ctx->total_pool_bytes += size;
 
     ggml_backend_opencl_buffer_context * ctx = new ggml_backend_opencl_buffer_context(mem);
 
@@ -11704,50 +11922,6 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
                 return;
             }
-            case GGML_TYPE_Q4_K: {
-                if (ne11 < 32) {
-                    break;
-                }
-                if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1)) {
-                    break;
-                }
-
-                kernel = backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm;
-                nth0 = 128; // calculated as (BM*BN)/(TM*TN)
-
-                int batch_stride_a = ne00*ne01;
-                int batch_stride_b = ne10*ne11;
-                int batch_stride_d = ne0*ne1;
-
-                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_K->qs));
-                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_K->scales));
-                CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q4_K->d));
-                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q4_K->dmin));
-                CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
-                CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offset1));
-                CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
-                CL_CHECK(clSetKernelArg(kernel,  7, sizeof(cl_ulong), &offsetd));
-                CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
-                CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
-                CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int),      &ne02));
-                CL_CHECK(clSetKernelArg(kernel, 11, sizeof(int),      &ne11));
-                CL_CHECK(clSetKernelArg(kernel, 12, sizeof(int),      &ne12));
-                CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne10)); // stride_a
-                CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int),      &ne10)); // stride_b
-                CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &ne01)); // stride_d
-                CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &batch_stride_a));
-                CL_CHECK(clSetKernelArg(kernel, 17, sizeof(int),      &batch_stride_b));
-                CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),      &batch_stride_d));
-                CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int),      &r2));
-                CL_CHECK(clSetKernelArg(kernel, 20, sizeof(int),      &r3));
-
-                // 64 is block tile size BM and BN - change here when BM and BN in the kernel are changed.
-                size_t global_work_size[] = {(size_t)(CEIL_DIV(ne01, 64)*nth0), (size_t)(CEIL_DIV(ne11, 64)), (size_t)ne12*ne13};
-                size_t local_work_size[] = {(size_t)nth0, 1, 1};
-
-                backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
-                return;
-            }
             case GGML_TYPE_Q6_K: {
                 if (ne11 < 32) {
                     break;
@@ -11791,6 +11965,145 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
 
                 backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
                 return;
+            }
+            case GGML_TYPE_Q4_K: {
+                if (ne11 < 32) {
+                    break;
+                }
+                if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1)) {
+                    break;
+                }
+#ifdef GGML_OPENCL_SOA_Q
+                {
+                    // NVIDIA SOA path: tensor was converted to 4 separate buffers at load time.
+                    if (src0->buffer != nullptr &&
+                        ((ggml_backend_opencl_buffer_context*)src0->buffer->context)->soa_q4_K_tensors.count(src0) > 0) {
+
+                        kernel = backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm;
+                        nth0 = 128; // (BM*BN)/(TM*TN) = (64*64)/(4*8)
+
+                        int batch_stride_b = ne10*ne11;
+                        int batch_stride_d = ne0*ne1;
+
+                        CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_K->qs));
+                        CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_K->scales));
+                        CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q4_K->d));
+                        CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q4_K->dmin));
+                        CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
+                        CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offset1));
+                        CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
+                        CL_CHECK(clSetKernelArg(kernel,  7, sizeof(cl_ulong), &offsetd));
+                        CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
+                        CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
+                        CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int),      &ne02));
+                        CL_CHECK(clSetKernelArg(kernel, 11, sizeof(int),      &ne11));
+                        CL_CHECK(clSetKernelArg(kernel, 12, sizeof(int),      &ne12));
+                        CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne10)); // stride_b
+                        CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int),      &ne01)); // stride_d
+                        CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &batch_stride_b));
+                        CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &batch_stride_d));
+                        CL_CHECK(clSetKernelArg(kernel, 17, sizeof(int),      &r2));
+                        CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),      &r3));
+
+                        size_t global_work_size_q4k[] = {(size_t)(CEIL_DIV(ne01, 64)*nth0), (size_t)(CEIL_DIV(ne11, 64)), (size_t)ne12*ne13};
+                        size_t local_work_size_q4k[]  = {(size_t)nth0, 1, 1};
+                        backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size_q4k, local_work_size_q4k, dst);
+                        return;
+                    }
+
+                    // Non-NVIDIA (Apple M1 etc.): prefer qst kernel (coalesced qs access),
+                    // fall back to packed GEMM if qs_t buffer was not created (OOM).
+                    // For 32 ≤ ne11 < 64, use the narrow BN=32 variant to avoid half-empty tiles.
+                    auto & qst_map = ((ggml_backend_opencl_buffer_context*)src0->buffer->context)->q4k_qs_t_buffers;
+                    const bool have_qst = src0->buffer != nullptr && qst_map.count(src0) > 0;
+                    const bool use_n32  = have_qst && ne11 < 64;  // BN=32 path for PP32..63
+
+                    // Q4_K GEMM kernels are compiled lazily (not at init) to save GPU memory.
+                    // This call is a no-op after the first dispatch.
+                    ggml_opencl_ensure_q4k_gemm_kernels(backend_ctx);
+
+                    int nth0_q4k = 128;
+                    int batch_stride_b = ne10 * ne11;
+                    int batch_stride_d = ne0 * ne1;
+
+                    // BN=32 path: tile N width = 32
+                    if (use_n32) {
+                        cl_kernel kq = backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm_qst_n32;
+                        cl_mem qs_t  = qst_map.at(src0);
+                        size_t gws[] = {(size_t)(CEIL_DIV(ne01, 64)*nth0_q4k), (size_t)(CEIL_DIV(ne11, 32)), (size_t)ne12*ne13};
+                        size_t lws[] = {(size_t)nth0_q4k, 1, 1};
+                        CL_CHECK(clSetKernelArg(kq,  0, sizeof(cl_mem),   &extra0->data_device));
+                        CL_CHECK(clSetKernelArg(kq,  1, sizeof(cl_ulong), &offset0));
+                        CL_CHECK(clSetKernelArg(kq,  2, sizeof(cl_mem),   &qs_t));
+                        CL_CHECK(clSetKernelArg(kq,  3, sizeof(cl_mem),   &extra1->data_device));
+                        CL_CHECK(clSetKernelArg(kq,  4, sizeof(cl_ulong), &offset1));
+                        CL_CHECK(clSetKernelArg(kq,  5, sizeof(cl_mem),   &extrad->data_device));
+                        CL_CHECK(clSetKernelArg(kq,  6, sizeof(cl_ulong), &offsetd));
+                        CL_CHECK(clSetKernelArg(kq,  7, sizeof(int),      &ne00));
+                        CL_CHECK(clSetKernelArg(kq,  8, sizeof(int),      &ne01));
+                        CL_CHECK(clSetKernelArg(kq,  9, sizeof(int),      &ne02));
+                        CL_CHECK(clSetKernelArg(kq, 10, sizeof(int),      &ne11));
+                        CL_CHECK(clSetKernelArg(kq, 11, sizeof(int),      &ne12));
+                        CL_CHECK(clSetKernelArg(kq, 12, sizeof(int),      &ne10));
+                        CL_CHECK(clSetKernelArg(kq, 13, sizeof(int),      &ne01));
+                        CL_CHECK(clSetKernelArg(kq, 14, sizeof(int),      &batch_stride_b));
+                        CL_CHECK(clSetKernelArg(kq, 15, sizeof(int),      &batch_stride_d));
+                        CL_CHECK(clSetKernelArg(kq, 16, sizeof(int),      &r2));
+                        CL_CHECK(clSetKernelArg(kq, 17, sizeof(int),      &r3));
+                        backend_ctx->enqueue_ndrange_kernel(kq, 3, gws, lws, dst);
+                        return;
+                    }
+
+                    size_t gws[] = {(size_t)(CEIL_DIV(ne01, 64)*nth0_q4k), (size_t)(CEIL_DIV(ne11, 64)), (size_t)ne12*ne13};
+                    size_t lws[] = {(size_t)nth0_q4k, 1, 1};
+
+                    if (have_qst) {
+                        cl_kernel kq = backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm_qst;
+                        cl_mem qs_t  = qst_map.at(src0);
+                        CL_CHECK(clSetKernelArg(kq,  0, sizeof(cl_mem),   &extra0->data_device)); // meta
+                        CL_CHECK(clSetKernelArg(kq,  1, sizeof(cl_ulong), &offset0));
+                        CL_CHECK(clSetKernelArg(kq,  2, sizeof(cl_mem),   &qs_t));
+                        CL_CHECK(clSetKernelArg(kq,  3, sizeof(cl_mem),   &extra1->data_device));
+                        CL_CHECK(clSetKernelArg(kq,  4, sizeof(cl_ulong), &offset1));
+                        CL_CHECK(clSetKernelArg(kq,  5, sizeof(cl_mem),   &extrad->data_device));
+                        CL_CHECK(clSetKernelArg(kq,  6, sizeof(cl_ulong), &offsetd));
+                        CL_CHECK(clSetKernelArg(kq,  7, sizeof(int),      &ne00));
+                        CL_CHECK(clSetKernelArg(kq,  8, sizeof(int),      &ne01));
+                        CL_CHECK(clSetKernelArg(kq,  9, sizeof(int),      &ne02));
+                        CL_CHECK(clSetKernelArg(kq, 10, sizeof(int),      &ne11));
+                        CL_CHECK(clSetKernelArg(kq, 11, sizeof(int),      &ne12));
+                        CL_CHECK(clSetKernelArg(kq, 12, sizeof(int),      &ne10)); // stride_b
+                        CL_CHECK(clSetKernelArg(kq, 13, sizeof(int),      &ne01)); // stride_d
+                        CL_CHECK(clSetKernelArg(kq, 14, sizeof(int),      &batch_stride_b));
+                        CL_CHECK(clSetKernelArg(kq, 15, sizeof(int),      &batch_stride_d));
+                        CL_CHECK(clSetKernelArg(kq, 16, sizeof(int),      &r2));
+                        CL_CHECK(clSetKernelArg(kq, 17, sizeof(int),      &r3));
+                        backend_ctx->enqueue_ndrange_kernel(kq, 3, gws, lws, dst);
+                    } else {
+                        // Packed fallback (qs_t buffer unavailable)
+                        cl_kernel kp = backend_ctx->kernel_mul_mm_q4_k_f32_l4_lm_packed;
+                        CL_CHECK(clSetKernelArg(kp,  0, sizeof(cl_mem),   &extra0->data_device));
+                        CL_CHECK(clSetKernelArg(kp,  1, sizeof(cl_ulong), &offset0));
+                        CL_CHECK(clSetKernelArg(kp,  2, sizeof(cl_mem),   &extra1->data_device));
+                        CL_CHECK(clSetKernelArg(kp,  3, sizeof(cl_ulong), &offset1));
+                        CL_CHECK(clSetKernelArg(kp,  4, sizeof(cl_mem),   &extrad->data_device));
+                        CL_CHECK(clSetKernelArg(kp,  5, sizeof(cl_ulong), &offsetd));
+                        CL_CHECK(clSetKernelArg(kp,  6, sizeof(int),      &ne00));
+                        CL_CHECK(clSetKernelArg(kp,  7, sizeof(int),      &ne01));
+                        CL_CHECK(clSetKernelArg(kp,  8, sizeof(int),      &ne02));
+                        CL_CHECK(clSetKernelArg(kp,  9, sizeof(int),      &ne11));
+                        CL_CHECK(clSetKernelArg(kp, 10, sizeof(int),      &ne12));
+                        CL_CHECK(clSetKernelArg(kp, 11, sizeof(int),      &ne10)); // stride_b
+                        CL_CHECK(clSetKernelArg(kp, 12, sizeof(int),      &ne01)); // stride_d
+                        CL_CHECK(clSetKernelArg(kp, 13, sizeof(int),      &batch_stride_b));
+                        CL_CHECK(clSetKernelArg(kp, 14, sizeof(int),      &batch_stride_d));
+                        CL_CHECK(clSetKernelArg(kp, 15, sizeof(int),      &r2));
+                        CL_CHECK(clSetKernelArg(kp, 16, sizeof(int),      &r3));
+                        backend_ctx->enqueue_ndrange_kernel(kp, 3, gws, lws, dst);
+                    }
+                    return;
+                }
+#endif
             }
             default:
                 break;
@@ -12312,9 +12625,6 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 ndst = 4;
             } else if (backend_ctx->gpu_family == INTEL) {
                 // nth0=16 for both true Intel and Apple M1 compat mode.
-                // In compat mode the kernel overrides BLOCK_STRIDE to 2 so
-                // that ix ∈ {0,1} (lid/8 with 16 threads) covers all
-                // super-blocks, and uses lm[N_DST*16] for the tree-reduction.
                 nth0 = 16;
                 nth1 = 1;
                 ndst = 4;

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -13,7 +13,11 @@
 #include "ggml-backend-impl.h"
 #include "ggml.h"
 
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 #include <inttypes.h>
 #include <string.h>
@@ -52,6 +56,11 @@
 //------------------------------------------------------------------------------
 
 bool ggml_cl_compute_forward(ggml_backend_t backend, struct ggml_tensor * tensor);
+struct ggml_backend_opencl_context;
+static cl_command_queue ggml_opencl_create_queue(ggml_backend_opencl_context * backend_ctx);
+static void ggml_cl_set_rows_quantized_host_fallback(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
+static bool ggml_cl_can_mul_mat(const struct ggml_tensor * src0, const struct ggml_tensor * src1, struct ggml_tensor * dst);
+static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
 
 // See https://gmplib.org/~tege/divcnst-pldi94.pdf figure 4.1.
 // Precompute mp (m' in the paper) and L such that division
@@ -86,9 +95,14 @@ static fastdiv_vals init_fastdiv_values(uint64_t d_64) {
 
 enum GPU_FAMILY {
     ADRENO,
+    APPLE,
     INTEL,
     UNKNOWN,
 };
+
+static inline bool ggml_cl_gpu_family_is_intel_like(GPU_FAMILY gpu_family) {
+    return gpu_family == INTEL || gpu_family == APPLE;
+}
 
 enum ADRENO_GPU_GEN {
     ADRENO_UNKNOWN,
@@ -179,7 +193,7 @@ static ggml_cl_version get_opencl_platform_version(cl_platform_id platform) {
 static ggml_cl_version get_opencl_c_version(ggml_cl_version platform_version, cl_device_id device) {
     size_t param_size;
 
-#if CL_TARGET_OPENCL_VERSION >= 300
+#if defined(CL_VERSION_3_0) && CL_TARGET_OPENCL_VERSION >= 300
     if (platform_version.major >= 3) {
         CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_ALL_VERSIONS, 0, nullptr, &param_size));
         if (!param_size) {
@@ -199,7 +213,7 @@ static ggml_cl_version get_opencl_c_version(ggml_cl_version platform_version, cl
     }
 #else
     GGML_UNUSED(platform_version);
-#endif  // CL_TARGET_OPENCL_VERSION >= 300
+#endif  // defined(CL_VERSION_3_0) && CL_TARGET_OPENCL_VERSION >= 300
 
     CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_OPENCL_C_VERSION, 0, nullptr, &param_size));
     if (!param_size) {
@@ -294,6 +308,7 @@ struct ggml_cl_buffer {
 struct ProfilingInfo {
     std::string op_name;
     std::string kernel_name;
+    std::string command_type;
 
     cl_kernel kernel;
     cl_event evt;
@@ -329,6 +344,7 @@ static void populateProfilingInfo(
     info.op_name     = tensor->name;
     info.kernel      = kernel;
     info.evt         = evt;
+    info.command_type = "kernel";
 
     // 0 means not specified, e.g., 2D workgroup, or NULL for driver to choose
     info.local_size[0] = 0;
@@ -353,6 +369,29 @@ static void populateProfilingInfo(
     info.output_size[1] = tensor->ne[1];
     info.output_size[2] = tensor->ne[2];
     info.output_size[3] = tensor->ne[3];
+}
+
+static void populateProfilingInfoCommand(
+        ProfilingInfo & info, cl_event evt, const char * command_name,
+        const ggml_tensor * tensor, size_t bytes) {
+    info.op_name = tensor ? tensor->name : "";
+    info.kernel_name = command_name ? command_name : "<command>";
+    info.command_type = "command";
+    info.kernel = nullptr;
+    info.evt = evt;
+
+    info.local_size[0] = 0;
+    info.local_size[1] = 0;
+    info.local_size[2] = 0;
+
+    info.global_size[0] = bytes;
+    info.global_size[1] = 0;
+    info.global_size[2] = 0;
+
+    info.output_size[0] = tensor ? tensor->ne[0] : bytes;
+    info.output_size[1] = tensor ? tensor->ne[1] : 0;
+    info.output_size[2] = tensor ? tensor->ne[2] : 0;
+    info.output_size[3] = tensor ? tensor->ne[3] : 0;
 }
 
 struct ggml_backend_opencl_context;
@@ -386,6 +425,8 @@ struct ggml_backend_opencl_context {
     std::string driver_version;
 
     GPU_FAMILY gpu_family;
+    bool use_adreno_kernels;
+    bool use_no_subgroups_compat;
     ADRENO_GPU_GEN adreno_gen;
 
     cl_int alignment;
@@ -436,6 +477,7 @@ struct ggml_backend_opencl_context {
     cl_program program_mul_mv_q4_0_f32_1d_8x_flat;
     cl_program program_mul_mv_q4_0_f32_1d_16x_flat;
     cl_program program_mul_mv_q6_K;
+    cl_program program_mul_mv_q5_0_f32_flat;
     cl_program program_mul_mv_q8_0_f32, program_mul_mv_q8_0_f32_flat;
     cl_program program_mul_mv_mxfp4_f32;
     cl_program program_mul_mv_mxfp4_f32_flat;
@@ -530,6 +572,7 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_mul_mat_q4_0_f32, kernel_mul_mat_q4_0_f32_v;
     cl_kernel kernel_convert_block_q4_0, kernel_restore_block_q4_0;
     cl_kernel kernel_convert_block_q4_1, kernel_restore_block_q4_1;
+    cl_kernel kernel_convert_block_q5_0, kernel_restore_block_q5_0;
     cl_kernel kernel_convert_block_mxfp4, kernel_convert_block_mxfp4_trans, kernel_restore_block_mxfp4, kernel_restore_block_mxfp4_trans;
     cl_kernel kernel_convert_block_q8_0, kernel_restore_block_q8_0, kernel_restore_block_q8_0_trans;
     cl_kernel kernel_convert_block_q6_K_noshuffle, kernel_restore_block_q6_K_noshuffle;
@@ -545,12 +588,14 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_mul_mat_q4_0_f32_1d_8x_flat, kernel_mul_mat_q4_0_f32_1d_16x_flat;
     cl_kernel kernel_mul_mv_q4_1_f32;
     cl_kernel kernel_mul_mv_q4_1_f32_flat;
+    cl_kernel kernel_mul_mv_q5_0_f32_flat;
     cl_kernel kernel_mul_mv_q4_K_f32;
     cl_kernel kernel_mul_mv_q4_K_f32_flat;
     cl_kernel kernel_mul_mv_q6_K_f32;
     cl_kernel kernel_mul_mv_q6_K_f32_flat;
     cl_kernel kernel_mul_mv_mxfp4_f32, kernel_mul_mv_mxfp4_f32_flat;
     cl_kernel kernel_mul_mv_q8_0_f32, kernel_mul_mv_q8_0_f32_flat;
+    cl_kernel kernel_gated_delta_net_f32;
     cl_kernel kernel_solve_tri_f32;
     cl_kernel kernel_im2col_f32, kernel_im2col_f16;
     cl_kernel kernel_argsort_f32_i32;
@@ -598,6 +643,12 @@ struct ggml_backend_opencl_context {
             return;
         }
 
+        double total_queued_ms   = 0.0;
+        double total_submit_ms   = 0.0;
+        double total_exec_ms     = 0.0;
+        double total_complete_ms = 0.0;
+        double total_end_to_end_ms = 0.0;
+
         // Populate profiling info
         for (ProfilingInfo & info : profiling_info) {
             cl_ulong cmd_queued;
@@ -615,14 +666,20 @@ struct ggml_backend_opencl_context {
                 info.evt, CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &cmd_start, NULL));
             CL_CHECK(clGetEventProfilingInfo(
                 info.evt, CL_PROFILING_COMMAND_END, sizeof(cl_ulong), &cmd_end, NULL));
+        #ifdef CL_PROFILING_COMMAND_COMPLETE
             CL_CHECK(clGetEventProfilingInfo(
                 info.evt, CL_PROFILING_COMMAND_COMPLETE, sizeof(cl_ulong), &cmd_complete, NULL));
+        #else
+            cmd_complete = cmd_end;
+        #endif
             CL_CHECK(clReleaseEvent(info.evt));
 
-            char kernel_name[512];
-            CL_CHECK(clGetKernelInfo(info.kernel, CL_KERNEL_FUNCTION_NAME,
-                sizeof(kernel_name), kernel_name, NULL));
-            info.kernel_name = kernel_name;
+            if (info.kernel != nullptr) {
+                char kernel_name[512];
+                CL_CHECK(clGetKernelInfo(info.kernel, CL_KERNEL_FUNCTION_NAME,
+                    sizeof(kernel_name), kernel_name, NULL));
+                info.kernel_name = kernel_name;
+            }
 
             info.cmd_queued = cmd_queued;
             info.cmd_submit = cmd_submit;
@@ -634,19 +691,40 @@ struct ggml_backend_opencl_context {
             info.cmd_duration_ns            = cmd_end       - cmd_start;
             info.cmd_complete_duration_ns   = cmd_complete  - cmd_end;
             info.cmd_total_duration_ns      = cmd_complete  - cmd_queued;
+
+            total_queued_ms   += info.cmd_queued_duration_ns   / 1.e6;
+            total_submit_ms   += info.cmd_submit_duration_ns   / 1.e6;
+            total_exec_ms     += info.cmd_duration_ns          / 1.e6;
+            total_complete_ms += info.cmd_complete_duration_ns / 1.e6;
+            total_end_to_end_ms += info.cmd_total_duration_ns  / 1.e6;
         }
 
         // Dump a csv
-        fprintf(fperf, "op name, kernel name, exec duration (ms), global size, local size, output size\n");
+        fprintf(fperf,
+            "op name, kernel name, command type, queued duration (ms), submit duration (ms), exec duration (ms), complete duration (ms), total duration (ms), global size, local size, output size\n");
         for (const ProfilingInfo & info : profiling_info) {
-            fprintf(fperf, "%s,%s,%f,%zux%zux%zu,%zux%zux%zu,%zux%zux%zux%zu\n",
+            fprintf(fperf, "%s,%s,%s,%f,%f,%f,%f,%f,%zux%zux%zu,%zux%zux%zu,%zux%zux%zux%zu\n",
                 info.op_name.c_str(), info.kernel_name.c_str(),
+                info.command_type.c_str(),
+                info.cmd_queued_duration_ns/1.e6f,
+                info.cmd_submit_duration_ns/1.e6f,
                 info.cmd_duration_ns/1.e6f,
+                info.cmd_complete_duration_ns/1.e6f,
+                info.cmd_total_duration_ns/1.e6f,
                 info.global_size[0], info.global_size[1], info.global_size[2],
                 info.local_size[0], info.local_size[1], info.local_size[2],
                 info.output_size[0], info.output_size[1], info.output_size[2], info.output_size[3]);
         }
         fclose(fperf);
+
+        GGML_LOG_INFO(
+            "ggml_opencl: profiling summary: kernels=%zu queued=%.3f ms submit=%.3f ms exec=%.3f ms complete=%.3f ms total=%.3f ms\n",
+            profiling_info.size(),
+            total_queued_ms,
+            total_submit_ms,
+            total_exec_ms,
+            total_complete_ms,
+            total_end_to_end_ms);
 
         // Dump a simple chrome trace
         FILE* ftrace = fopen("cl_trace.json", "w");
@@ -657,15 +735,15 @@ struct ggml_backend_opencl_context {
 
         fprintf(ftrace, "[\n");
         for (const ProfilingInfo & info : profiling_info) {
-            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"OpenCL\", \"ph\": \"B\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Host\"},\n",
-                info.kernel_name.c_str(), info.cmd_queued/1000);
-            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"OpenCL\", \"ph\": \"E\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Host\"},\n",
-                info.kernel_name.c_str(), info.cmd_submit/1000);
+            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"%s\", \"ph\": \"B\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Host\"},\n",
+                info.kernel_name.c_str(), info.command_type.c_str(), info.cmd_queued/1000);
+            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"%s\", \"ph\": \"E\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Host\"},\n",
+                info.kernel_name.c_str(), info.command_type.c_str(), info.cmd_submit/1000);
 
-            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"OpenCL\", \"ph\": \"B\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Device\"},\n",
-                info.kernel_name.c_str(), info.cmd_start/1000);
-            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"OpenCL\", \"ph\": \"E\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Device\"},\n",
-                info.kernel_name.c_str(), info.cmd_end/1000);
+            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"%s\", \"ph\": \"B\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Device\"},\n",
+                info.kernel_name.c_str(), info.command_type.c_str(), info.cmd_start/1000);
+            fprintf(ftrace, "{\"name\": \"%s\", \"cat\": \"%s\", \"ph\": \"E\", \"ts\": %" PRIu64 ", \"pid\": \"\", \"tid\": \"Device\"},\n",
+                info.kernel_name.c_str(), info.command_type.c_str(), info.cmd_end/1000);
         }
         fclose(ftrace);
     }
@@ -681,15 +759,69 @@ struct ggml_backend_opencl_context {
     }
 
     void enqueue_ndrange_kernel(cl_kernel kernel, cl_uint work_dim, size_t *global_work_size, size_t *local_work_size, const ggml_tensor * tensor) {
+        cl_int kernel_name_status = CL_SUCCESS;
+        size_t kernel_name_size = 0;
+        std::string kernel_name = "<unknown>";
+        kernel_name_status = clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME, 0, nullptr, &kernel_name_size);
+        if (kernel_name_status == CL_SUCCESS && kernel_name_size > 1) {
+            std::vector<char> kernel_name_buf(kernel_name_size);
+            kernel_name_status = clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME, kernel_name_size, kernel_name_buf.data(), nullptr);
+            if (kernel_name_status == CL_SUCCESS) {
+                kernel_name.assign(kernel_name_buf.data());
+            }
+        }
+
 #ifdef GGML_OPENCL_PROFILING
         cl_event evt;
-        CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, work_dim, NULL, global_work_size, local_work_size, 0, NULL, &evt));
+        cl_int err = clEnqueueNDRangeKernel(queue, kernel, work_dim, NULL, global_work_size, local_work_size, 0, NULL, &evt);
+        if (err != CL_SUCCESS) {
+            GGML_LOG_ERROR("%s: enqueue failed for kernel '%s' (work_dim=%u, global=[%zu,%zu,%zu], local=%s[%zu,%zu,%zu], tensor=%s)\n",
+                __func__,
+                kernel_name.c_str(),
+                work_dim,
+                global_work_size ? global_work_size[0] : 0,
+                global_work_size ? global_work_size[1] : 0,
+                global_work_size ? global_work_size[2] : 0,
+                local_work_size ? "" : "null ",
+                local_work_size ? local_work_size[0] : 0,
+                local_work_size ? local_work_size[1] : 0,
+                local_work_size ? local_work_size[2] : 0,
+                tensor ? ggml_op_name(tensor->op) : "<null>");
+        }
+        CL_CHECK(err);
 
         profiling_info.emplace_back();
         populateProfilingInfo(profiling_info.back(), evt, kernel, work_dim, global_work_size, local_work_size, tensor);
 #else
         GGML_UNUSED(tensor);
-        CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, work_dim, NULL, global_work_size, local_work_size, 0, NULL, NULL));
+        cl_int err = clEnqueueNDRangeKernel(queue, kernel, work_dim, NULL, global_work_size, local_work_size, 0, NULL, NULL);
+        if (err != CL_SUCCESS) {
+            GGML_LOG_ERROR("%s: enqueue failed for kernel '%s' (work_dim=%u, global=[%zu,%zu,%zu], local=%s[%zu,%zu,%zu])\n",
+                __func__,
+                kernel_name.c_str(),
+                work_dim,
+                global_work_size ? global_work_size[0] : 0,
+                global_work_size ? global_work_size[1] : 0,
+                global_work_size ? global_work_size[2] : 0,
+                local_work_size ? "" : "null ",
+                local_work_size ? local_work_size[0] : 0,
+                local_work_size ? local_work_size[1] : 0,
+                local_work_size ? local_work_size[2] : 0);
+        }
+        CL_CHECK(err);
+#endif
+    }
+
+    void enqueue_copy_buffer(cl_mem src_buffer, cl_mem dst_buffer, size_t src_offset, size_t dst_offset, size_t cb, const ggml_tensor * tensor, const char * command_name = "clEnqueueCopyBuffer") {
+#ifdef GGML_OPENCL_PROFILING
+        cl_event evt;
+        CL_CHECK(clEnqueueCopyBuffer(queue, src_buffer, dst_buffer, src_offset, dst_offset, cb, 0, NULL, &evt));
+        profiling_info.emplace_back();
+        populateProfilingInfoCommand(profiling_info.back(), evt, command_name, tensor, cb);
+#else
+        GGML_UNUSED(tensor);
+        GGML_UNUSED(command_name);
+        CL_CHECK(clEnqueueCopyBuffer(queue, src_buffer, dst_buffer, src_offset, dst_offset, cb, 0, NULL, NULL));
 #endif
     }
 
@@ -726,6 +858,10 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_gemm_noshuffle_q4_k_f32;
     cl_kernel kernel_gemv_noshuffle_q6_K_f32;
     cl_kernel kernel_gemm_noshuffle_q6_K_f32;
+
+    // Apple-specific buffer-based Q4_0 GEMV (no image1d_buffer_t)
+    cl_program program_gemv_noshuffle_apple;
+    cl_kernel  kernel_gemv_q4_0_f32_apple;
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
     void free() {
@@ -741,6 +877,50 @@ struct ggml_backend_opencl_context {
 
 // All registered devices with a default device in the front.
 static std::vector<ggml_backend_device> g_ggml_backend_opencl_devices;
+
+static bool ggml_opencl_uses_local_subgroup_compat(const ggml_backend_opencl_context * backend_ctx) {
+    return backend_ctx->use_no_subgroups_compat ||
+           backend_ctx->device_name.find("NVIDIA") != std::string::npos;
+}
+
+static size_t ggml_opencl_copy_buffer_min_bytes(void) {
+    static const size_t default_min_bytes = 64 * 1024;
+    static const size_t min_bytes = []() -> size_t {
+        const char * env = getenv("GGML_OPENCL_COPY_BUFFER_MIN_BYTES");
+        if (env == nullptr || env[0] == '\0') {
+            return default_min_bytes;
+        }
+
+        size_t value = default_min_bytes;
+        auto result = std::from_chars(env, env + strlen(env), value);
+        if (result.ec != std::errc{} || result.ptr == env) {
+            GGML_LOG_WARN("%s: ignoring invalid GGML_OPENCL_COPY_BUFFER_MIN_BYTES='%s'\n", __func__, env);
+            return default_min_bytes;
+        }
+
+        return value;
+    }();
+
+    return min_bytes;
+}
+
+static bool ggml_opencl_use_copy_buffer_fast_path(const ggml_backend_opencl_context * backend_ctx, size_t size) {
+    if (getenv("GGML_OPENCL_FORCE_COPY_BUFFER_FAST_PATH") != nullptr) {
+        return true;
+    }
+
+    // Apple's OpenCL runtime accepts clEnqueueCopyBuffer here, but on M1 it
+    // shifts copy cost into large unprofiled runtime overhead and regresses
+    // end-to-end throughput versus the existing cpy kernels.
+    if (backend_ctx->device_name.find("Apple") != std::string::npos) {
+        return false;
+    }
+
+    // For small contiguous copies, the OpenCL copy command itself can dominate
+    // end-to-end latency. Prefer the existing copy kernels until the payload is
+    // large enough to amortize the driver submission cost.
+    return size >= ggml_opencl_copy_buffer_min_bytes();
+}
 
 inline std::string read_file(const std::string &path) {
   std::ifstream ifs(path);
@@ -761,10 +941,86 @@ static cl_program build_program_from_source(cl_context ctx, cl_device_id dev, co
     size_t program_size;
     size_t log_size;
     int err;
+    std::string source = program_buffer;
 
-    program_size = strlen(program_buffer);
+    size_t device_name_size = 0;
+    CL_CHECK(clGetDeviceInfo(dev, CL_DEVICE_NAME, 0, nullptr, &device_name_size));
+    std::string device_name(device_name_size, '\0');
+    CL_CHECK(clGetDeviceInfo(dev, CL_DEVICE_NAME, device_name_size, device_name.data(), nullptr));
 
-    p = clCreateProgramWithSource(ctx, 1, (const char**)&program_buffer, &program_size, &err);
+    const bool use_no_subgroups_compat =
+        compile_opts.find("GGML_OPENCL_NO_SUBGROUPS_COMPAT=1") != std::string::npos;
+
+    if (device_name.find("Apple") != std::string::npos) {
+        source.insert(0, "#define APPLE_GPU 1\n");
+    }
+
+    // Also always stub subgroup builtins for Apple (OpenCL 1.2 has no cl_khr_subgroups)
+    const bool is_apple = device_name.find("Apple") != std::string::npos;
+    if (device_name.find("NVIDIA") != std::string::npos || use_no_subgroups_compat || is_apple) {
+        static const char * subgroup_compat_prelude =
+            "// Experimental OpenCL no-subgroups compatibility prelude\n"
+            "#define NVIDIA_GPU 1\n"
+            "#ifndef INTEL_GPU\n"
+            "#define INTEL_GPU 1\n"
+            "#endif\n"
+            "#ifndef REQD_SUBGROUP_SIZE_16\n"
+            "#define REQD_SUBGROUP_SIZE_16\n"
+            "#endif\n"
+            "#ifndef REQD_SUBGROUP_SIZE_32\n"
+            "#define REQD_SUBGROUP_SIZE_32\n"
+            "#endif\n"
+            "#ifndef REQD_SUBGROUP_SIZE_64\n"
+            "#define REQD_SUBGROUP_SIZE_64\n"
+            "#endif\n"
+            "#ifndef REQD_SUBGROUP_SIZE_128\n"
+            "#define REQD_SUBGROUP_SIZE_128\n"
+            "#endif\n"
+            // sub_group builtins: map lane/warp operations to workgroup equivalents.
+            // get_sub_group_local_id → get_local_id(0): correct when nth0==warp width
+            // get_sub_group_id → 0: correct when N_SIMDGROUP==1 (one warp per WG)
+            // sub_group_reduce_add: NOT stubbed here; NVIDIA paths use __local reduction.
+            "#ifndef get_sub_group_id\n"
+            "#define get_sub_group_id() (0)\n"
+            "#endif\n"
+            "#ifndef get_sub_group_local_id\n"
+            "#define get_sub_group_local_id() (get_local_id(0))\n"
+            "#endif\n"
+            "#ifndef get_max_sub_group_size\n"
+            "#define get_max_sub_group_size() (get_local_size(0))\n"
+            "#endif\n"
+            "#ifndef get_sub_group_size\n"
+            "#define get_sub_group_size() (get_local_size(0))\n"
+            "#endif\n"
+            "#ifndef get_num_sub_groups\n"
+            "#define get_num_sub_groups() (1)\n"
+            "#endif\n"
+            // sub_group_reduce_add / sub_group_broadcast: keep identity stubs only for
+            // kernels that run with nth0=1 (single-thread WG). Hot kernels (Q4_K, Q6_K)
+            // override this with explicit __local tree-reduction inside NVIDIA_GPU blocks.
+            "#ifndef sub_group_reduce_add\n"
+            "#define sub_group_reduce_add(x) (x)\n"
+            "#endif\n"
+            "#ifndef sub_group_reduce_max\n"
+            "#define sub_group_reduce_max(x) (x)\n"
+            "#endif\n"
+            "#ifndef sub_group_scan_inclusive_add\n"
+            "#define sub_group_scan_inclusive_add(x) (x)\n"
+            "#endif\n"
+            "#ifndef sub_group_scan_exclusive_add\n"
+            "#define sub_group_scan_exclusive_add(x) (0)\n"
+            "#endif\n"
+            "#ifndef sub_group_broadcast\n"
+            "#define sub_group_broadcast(x, lane) (x)\n"
+            "#endif\n";
+
+        source.insert(0, subgroup_compat_prelude);
+    }
+
+    program_size = source.size();
+    const char * source_buffer = source.c_str();
+
+    p = clCreateProgramWithSource(ctx, 1, &source_buffer, &program_size, &err);
     if(err < 0) {
         GGML_LOG_ERROR("OpenCL error creating program");
         exit(1);
@@ -786,16 +1042,23 @@ static cl_program build_program_from_source(cl_context ctx, cl_device_id dev, co
 
 static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_version opencl_c_version) {
     cl_int err;
+    const bool use_local_subgroup_compat = ggml_opencl_uses_local_subgroup_compat(backend_ctx);
 
     // compiler options for general kernels
     auto opencl_c_std =
         std::string("CL") + std::to_string(opencl_c_version.major) + "." + std::to_string(opencl_c_version.minor);
     std::string compile_opts = std::string("-cl-std=") + opencl_c_std +
                                " -cl-mad-enable -cl-unsafe-math-optimizations"
-                               " -cl-finite-math-only -cl-fast-relaxed-math";
+                               " -cl-finite-math-only -cl-fast-relaxed-math"
+                               " -DGGML_OPENCL_USE_NATIVE_FP16_MATH=" + std::to_string(backend_ctx->fp16_support ? 1 : 0);
 
     if (backend_ctx->adreno_use_large_buffer) {
         compile_opts += " -qcom-enable-large-buffer ";
+    }
+    if (backend_ctx->use_no_subgroups_compat) {
+        compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        GGML_LOG_WARN("ggml_opencl: building kernels with no-subgroups compatibility mode for '%s'\n",
+            backend_ctx->device_name.c_str());
     }
 
     GGML_LOG_INFO("ggml_opencl: loading OpenCL kernels");
@@ -927,9 +1190,13 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         CL_CHECK((backend_ctx->kernel_restore_block_q4_1_noshuffle = clCreateKernel(backend_ctx->program_cvt, "kernel_restore_block_q4_1_noshuffle", &err), err));
         CL_CHECK((backend_ctx->kernel_convert_block_q4_1  = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_q4_1", &err), err));
         CL_CHECK((backend_ctx->kernel_restore_block_q4_1  = clCreateKernel(backend_ctx->program_cvt, "kernel_restore_block_q4_1", &err), err));
+        CL_CHECK((backend_ctx->kernel_convert_block_q5_0  = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_q5_0", &err), err));
+        CL_CHECK((backend_ctx->kernel_restore_block_q5_0  = clCreateKernel(backend_ctx->program_cvt, "kernel_restore_block_q5_0", &err), err));
         CL_CHECK((backend_ctx->kernel_convert_block_mxfp4 = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_mxfp4", &err), err));
-        CL_CHECK((backend_ctx->kernel_convert_block_mxfp4_trans = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_mxfp4_trans", &err), err));
-        CL_CHECK((backend_ctx->kernel_restore_block_mxfp4_trans = clCreateKernel(backend_ctx->program_cvt, "kernel_restore_block_mxfp4_trans", &err), err));
+        if (!use_local_subgroup_compat) {
+            CL_CHECK((backend_ctx->kernel_convert_block_mxfp4_trans = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_mxfp4_trans", &err), err));
+            CL_CHECK((backend_ctx->kernel_restore_block_mxfp4_trans = clCreateKernel(backend_ctx->program_cvt, "kernel_restore_block_mxfp4_trans", &err), err));
+        }
         CL_CHECK((backend_ctx->kernel_restore_block_mxfp4 = clCreateKernel(backend_ctx->program_cvt, "kernel_restore_block_mxfp4", &err), err));
         CL_CHECK((backend_ctx->kernel_convert_block_q8_0  = clCreateKernel(backend_ctx->program_cvt, "kernel_convert_block_q8_0", &err), err));
         CL_CHECK((backend_ctx->kernel_restore_block_q8_0  = clCreateKernel(backend_ctx->program_cvt, "kernel_restore_block_q8_0", &err), err));
@@ -1057,6 +1324,23 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
             build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
 
         CL_CHECK((backend_ctx->kernel_solve_tri_f32 = clCreateKernel(prog, "kernel_solve_tri_f32", &err), err));
+        GGML_LOG_CONT(".");
+        CL_CHECK(clReleaseProgram(prog));
+    }
+
+    // gated_delta_net_f32
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "gated_delta_net.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("gated_delta_net.cl");
+#endif
+        cl_program prog =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_gated_delta_net_f32 = clCreateKernel(prog, "kernel_gated_delta_net_f32", &err), err));
         GGML_LOG_CONT(".");
         CL_CHECK(clReleaseProgram(prog));
     }
@@ -1314,6 +1598,22 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         GGML_LOG_CONT(".");
     }
 
+    // mul_mv_q5_0_f32_flat
+    {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "mul_mv_q5_0_f32_flat.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("mul_mv_q5_0_f32_flat.cl");
+#endif
+        backend_ctx->program_mul_mv_q5_0_f32_flat =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_mul_mv_q5_0_f32_flat = clCreateKernel(backend_ctx->program_mul_mv_q5_0_f32_flat, "kernel_mul_mv_q5_0_f32_flat", &err), err));
+        GGML_LOG_CONT(".");
+    }
+
     // mul_mv_mxfp4_f32
     {
 #ifdef GGML_OPENCL_EMBED_KERNELS
@@ -1558,20 +1858,22 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
 
     // mul_mm_f16_f32_kq_kqv
     {
+        if (!use_local_subgroup_compat) {
 #ifdef GGML_OPENCL_EMBED_KERNELS
-        const std::string kernel_src {
-            #include "mul_mm_f16_f32_kq_kqv.cl.h"
-        };
+            const std::string kernel_src {
+                #include "mul_mm_f16_f32_kq_kqv.cl.h"
+            };
 #else
-        const std::string kernel_src = read_file("mul_mm_f16_f32_kq_kqv.cl");
+            const std::string kernel_src = read_file("mul_mm_f16_f32_kq_kqv.cl");
 #endif
-        backend_ctx->program_mul_mm_f16_f32_kqv =
-            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts+" -DKQV ");
-        backend_ctx->program_mul_mm_f16_f32_kq =
-            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+            backend_ctx->program_mul_mm_f16_f32_kqv =
+                build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts+" -DKQV ");
+            backend_ctx->program_mul_mm_f16_f32_kq =
+                build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
 
-        CL_CHECK((backend_ctx->kernel_mul_mm_f16_f32_kqv = clCreateKernel(backend_ctx->program_mul_mm_f16_f32_kqv, "mul_mm_f16_f32_kqv", &err), err));
-        CL_CHECK((backend_ctx->kernel_mul_mm_f16_f32_kq = clCreateKernel(backend_ctx->program_mul_mm_f16_f32_kq, "mul_mm_f16_f32_kq", &err), err));
+            CL_CHECK((backend_ctx->kernel_mul_mm_f16_f32_kqv = clCreateKernel(backend_ctx->program_mul_mm_f16_f32_kqv, "mul_mm_f16_f32_kqv", &err), err));
+            CL_CHECK((backend_ctx->kernel_mul_mm_f16_f32_kq = clCreateKernel(backend_ctx->program_mul_mm_f16_f32_kq, "mul_mm_f16_f32_kq", &err), err));
+        }
         GGML_LOG_CONT(".");
     }
 
@@ -1803,7 +2105,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
 
         if (!kernel_src_f16.empty() && !kernel_src_f32.empty() && !kernel_src_f32_f16.empty()) {
             const struct { int dk; int dv; int bm; int bn; } fa_dims[] = {
-                { 40,  40, 32, 32}, { 64,  64, 64, 64}, { 80,  80, 64, 32}, { 96,  96, 64, 32},
+                { 40,  40, 32, 32}, { 64,  64, 32, 32}, { 80,  80, 32, 32}, { 96,  96, 32, 32},
                 {112, 112, 32, 32}, {128, 128, 32, 32}, {192, 128, 16, 16},
                 {192, 192, 16, 16}, {256, 256, 16, 16},
             };
@@ -2281,7 +2583,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
                 const std::string kernel_src = read_file("conv2d.cl");
                 const std::string kernel_src_f16_f32 = read_file("conv2d_f16_f32.cl");
         #endif
-                if (!kernel_src.empty()) {
+                if (!use_local_subgroup_compat && !kernel_src.empty()) {
                     backend_ctx->program_conv_2d_f16 =
                         build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), (std::string(compile_opts) + " -DUSE_FP16=1").c_str());
                     CL_CHECK((backend_ctx->kernel_conv_2d_f16 = clCreateKernel(backend_ctx->program_conv_2d_f16, "kernel_conv_2d", &err), err));
@@ -2297,7 +2599,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
                     backend_ctx->program_conv_2d_f32 = nullptr;
                     backend_ctx->kernel_conv_2d_f32 = nullptr;
                 }
-                if (!kernel_src_f16_f32.empty()) {
+                if (!use_local_subgroup_compat && !kernel_src_f16_f32.empty()) {
                     backend_ctx->program_conv_2d_f16_f32 =
                         build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_f16_f32.c_str(), compile_opts);
                     CL_CHECK((backend_ctx->kernel_conv_2d_f16_f32 = clCreateKernel(backend_ctx->program_conv_2d_f16_f32, "kernel_conv_2d", &err), err));
@@ -2409,6 +2711,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
 
     // Adreno kernels
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+    if (backend_ctx->use_adreno_kernels) {
     // transpose
     {
 #ifdef GGML_OPENCL_EMBED_KERNELS
@@ -2437,6 +2740,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
                                        " -cl-mad-enable "
                                        " -DSIMDGROUP_WIDTH=" +
                                        std::to_string(backend_ctx->adreno_wave_size);
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
         if (backend_ctx->has_vector_subgroup_broadcast) {
             CL_gemv_compile_opts += " -DVECTOR_SUB_GROUP_BROADCAT ";
         }
@@ -2452,7 +2758,38 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         backend_ctx->program_CL_gemv_general = build_program_from_source(
             backend_ctx->context, backend_ctx->device, kernel_src_CL_gemv_general.c_str(), CL_gemv_compile_opts);
 
-        CL_CHECK((backend_ctx->CL_mul_mat_vec_q4_0_f32_1d_4x_flat_general = clCreateKernel(backend_ctx->program_CL_gemv_general, "kernel_gemv_noshuffle", &err), err));
+        // kernel_gemv_noshuffle is excluded on Apple (#ifndef APPLE_GPU guard in .cl);
+        // Apple uses kernel_gemv_q4_0_f32_apple from program_gemv_noshuffle_apple instead.
+        if (backend_ctx->gpu_family != GPU_FAMILY::APPLE) {
+            CL_CHECK((backend_ctx->CL_mul_mat_vec_q4_0_f32_1d_4x_flat_general = clCreateKernel(backend_ctx->program_CL_gemv_general, "kernel_gemv_noshuffle", &err), err));
+        }
+        GGML_LOG_CONT(".");
+    }
+
+    // gemv_noshuffle_apple — buffer-based Q4_0 GEMV for Apple (no images, local-memory src1)
+    if (backend_ctx->gpu_family == GPU_FAMILY::APPLE) {
+        std::string CL_gemv_compile_opts = std::string("-cl-std=") + opencl_c_std +
+                                       " -cl-mad-enable "
+                                       " -DAPPLE_GPU=1 "
+                                       " -DSIMDGROUP_WIDTH=" +
+                                       std::to_string(backend_ctx->adreno_wave_size);
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
+
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src_apple {
+            #include "gemv_noshuffle_general.cl.h"
+        };
+#else
+        const std::string kernel_src_apple = read_file("gemv_noshuffle_general.cl");
+#endif
+
+        backend_ctx->program_gemv_noshuffle_apple = build_program_from_source(
+            backend_ctx->context, backend_ctx->device, kernel_src_apple.c_str(), CL_gemv_compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_gemv_q4_0_f32_apple =
+            clCreateKernel(backend_ctx->program_gemv_noshuffle_apple, "kernel_gemv_noshuffle_apple", &err), err));
         GGML_LOG_CONT(".");
     }
 
@@ -2465,6 +2802,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
             " -DBLOCK_STRIDE_A=16384 "
             " -DSIMDGROUP_WIDTH=" +
             std::to_string(backend_ctx->adreno_wave_size);
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
         if (backend_ctx->has_vector_subgroup_broadcast) {
             CL_gemv_compile_opts += " -DVECTOR_SUB_GROUP_BROADCAT ";
         }
@@ -2489,6 +2829,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
             " -DBLOCK_STRIDE_A=16384 "
             " -DSIMDGROUP_WIDTH=" +
             std::to_string(backend_ctx->adreno_wave_size);
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
         if (backend_ctx->has_vector_subgroup_broadcast) {
             CL_gemv_compile_opts += " -DVECTOR_SUB_GROUP_BROADCAT ";
         }
@@ -2505,6 +2848,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
             " -DBLOCK_STRIDE_A=44032 "
             " -DSIMDGROUP_WIDTH=" +
             std::to_string(backend_ctx->adreno_wave_size);
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
         if (backend_ctx->has_vector_subgroup_broadcast) {
             CL_gemv_compile_opts += " -DVECTOR_SUB_GROUP_BROADCAT ";
         }
@@ -2521,6 +2867,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
             " -DBLOCK_STRIDE_A=128000 "
             " -DSIMDGROUP_WIDTH=" +
             std::to_string(backend_ctx->adreno_wave_size);
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
 
         if (backend_ctx->has_vector_subgroup_broadcast) {
             CL_gemv_compile_opts += " -DVECTOR_SUB_GROUP_BROADCAT ";
@@ -2565,6 +2914,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
     {
         std::string CL_gemv_compile_opts = std::string("-cl-std=") + opencl_c_std +
                                        " -cl-mad-enable ";
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
         if (backend_ctx->has_vector_subgroup_broadcast) {
             CL_gemv_compile_opts += " -DVECTOR_SUB_GROUP_BROADCAT ";
         }
@@ -2587,15 +2939,19 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
 
     // mul_mm_q8_0_f32_8x4
     {
+        if (backend_ctx->gpu_family == GPU_FAMILY::ADRENO) {
 #ifdef GGML_OPENCL_EMBED_KERNELS
-        const std::string kernel_src_q8_8x4_gemm {
-            #include "mul_mm_q8_0_f32_8x4.cl.h"
-       };
+            const std::string kernel_src_q8_8x4_gemm {
+                #include "mul_mm_q8_0_f32_8x4.cl.h"
+           };
 #else
-        const std::string kernel_src_q8_8x4_gemm = read_file("mul_mm_q8_0_f32_8x4.cl");
+            const std::string kernel_src_q8_8x4_gemm = read_file("mul_mm_q8_0_f32_8x4.cl");
 #endif
-        backend_ctx->program_CL_gemm = build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_q8_8x4_gemm.c_str(), compile_opts);
-        CL_CHECK((backend_ctx->kernel_mul_mm_q8_0_f32_8x4 = clCreateKernel(backend_ctx->program_CL_gemm, "kernel_mul_mm_q8_0_f32_8x4", &err), err));
+            backend_ctx->program_CL_gemm = build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src_q8_8x4_gemm.c_str(), compile_opts);
+            CL_CHECK((backend_ctx->kernel_mul_mm_q8_0_f32_8x4 = clCreateKernel(backend_ctx->program_CL_gemm, "kernel_mul_mm_q8_0_f32_8x4", &err), err));
+        } else {
+            backend_ctx->kernel_mul_mm_q8_0_f32_8x4 = nullptr;
+        }
         GGML_LOG_CONT(".");
     }
 
@@ -2605,6 +2961,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
                                        " -cl-mad-enable "
                                        " -DSIMDGROUP_WIDTH=" +
                                        std::to_string(backend_ctx->adreno_wave_size);
+        if (backend_ctx->use_no_subgroups_compat) {
+            CL_gemv_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+        }
         if (backend_ctx->has_vector_subgroup_broadcast) {
             CL_gemv_compile_opts += " -DVECTOR_SUB_GROUP_BROADCAT ";
         }
@@ -2667,36 +3026,43 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
     std::string CL_moe_compile_opts = std::string("-cl-std=") + opencl_c_std +
             " -cl-mad-enable "
             " -cl-fast-relaxed-math";
+    if (backend_ctx->use_no_subgroups_compat) {
+        CL_moe_compile_opts += " -DGGML_OPENCL_NO_SUBGROUPS_COMPAT=1";
+    }
 
     // gemv_moe_mxfp4_f32
     {
+        if (!use_local_subgroup_compat) {
 #ifdef GGML_OPENCL_EMBED_KERNELS
-        const std::string kernel_src {
-            #include "gemv_moe_mxfp4_f32.cl.h"
-        };
+            const std::string kernel_src {
+                #include "gemv_moe_mxfp4_f32.cl.h"
+            };
 #else
-        const std::string kernel_src = read_file("gemv_moe_mxfp4_f32.cl");
+            const std::string kernel_src = read_file("gemv_moe_mxfp4_f32.cl");
 #endif
-        backend_ctx->program_gemv_moe_mxfp4_f32 =
-            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), CL_moe_compile_opts);
+            backend_ctx->program_gemv_moe_mxfp4_f32 =
+                build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), CL_moe_compile_opts);
 
-        CL_CHECK((backend_ctx->kernel_gemv_moe_mxfp4_f32 = clCreateKernel(backend_ctx->program_gemv_moe_mxfp4_f32, "kernel_gemv_moe_mxfp4_f32", &err), err));
+            CL_CHECK((backend_ctx->kernel_gemv_moe_mxfp4_f32 = clCreateKernel(backend_ctx->program_gemv_moe_mxfp4_f32, "kernel_gemv_moe_mxfp4_f32", &err), err));
+        }
         GGML_LOG_CONT(".");
     }
 
     // gemm_moe_mxfp4_f32
     {
+        if (!use_local_subgroup_compat) {
 #ifdef GGML_OPENCL_EMBED_KERNELS
-        const std::string kernel_src {
-            #include "gemm_moe_mxfp4_f32.cl.h"
-        };
+            const std::string kernel_src {
+                #include "gemm_moe_mxfp4_f32.cl.h"
+            };
 #else
-        const std::string kernel_src = read_file("gemm_moe_mxfp4_f32.cl");
+            const std::string kernel_src = read_file("gemm_moe_mxfp4_f32.cl");
 #endif
-        backend_ctx->program_gemm_moe_mxfp4_f32 =
-            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), CL_moe_compile_opts);
+            backend_ctx->program_gemm_moe_mxfp4_f32 =
+                build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), CL_moe_compile_opts);
 
-        CL_CHECK((backend_ctx->kernel_gemm_moe_mxfp4_f32 = clCreateKernel(backend_ctx->program_gemm_moe_mxfp4_f32, "kernel_gemm_moe_mxfp4_f32", &err), err));
+            CL_CHECK((backend_ctx->kernel_gemm_moe_mxfp4_f32 = clCreateKernel(backend_ctx->program_gemm_moe_mxfp4_f32, "kernel_gemm_moe_mxfp4_f32", &err), err));
+        }
         GGML_LOG_CONT(".");
     }
 
@@ -2735,9 +3101,14 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
         cl_program prog =
             build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), CL_moe_compile_opts);
 
-        CL_CHECK((backend_ctx->kernel_gemm_noshuffle_q6_K_f32 = clCreateKernel(prog, "kernel_gemm_noshuffle_q6_K_f32", &err), err));
+        // kernel_gemm_noshuffle_q6_K_f32 is inside #ifdef ADRENO_GPU in the .cl file;
+        // on Apple the function is not compiled, so skip creating the handle.
+        if (backend_ctx->gpu_family != GPU_FAMILY::APPLE) {
+            CL_CHECK((backend_ctx->kernel_gemm_noshuffle_q6_K_f32 = clCreateKernel(prog, "kernel_gemm_noshuffle_q6_K_f32", &err), err));
+        }
         GGML_LOG_CONT(".");
     }
+    } // if (backend_ctx->use_adreno_kernels)
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
     GGML_LOG_CONT("\n");
 }
@@ -2998,6 +3369,8 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
     auto backend_ctx        = std::make_unique<ggml_backend_opencl_context>();
     backend_ctx->device     = dev_ctx->device;
     backend_ctx->gpu_family = GPU_FAMILY::UNKNOWN;
+    backend_ctx->use_adreno_kernels = false;
+    backend_ctx->use_no_subgroups_compat = false;
 
     // ref_count get increased in ggml_backend_opencl_device_init
     // This function is also used to retrieve backend context, so we don't want
@@ -3009,6 +3382,7 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
         strstr(dev_ctx->device_name.c_str(), "Qualcomm") ||
         strstr(dev_ctx->device_version.c_str(), "Adreno")) {
         backend_ctx->gpu_family = GPU_FAMILY::ADRENO;
+        backend_ctx->use_adreno_kernels = true;
         // Usually device version contains the detailed device name
         backend_ctx->adreno_gen = get_adreno_gpu_gen(dev_ctx->device_version.c_str());
         if (backend_ctx->adreno_gen == ADRENO_GPU_GEN::ADRENO_UNKNOWN) {
@@ -3019,6 +3393,19 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
         backend_ctx->adreno_wave_size = 64;
     } else if (strstr(dev_ctx->device_name.c_str(), "Intel")) {
         backend_ctx->gpu_family = GPU_FAMILY::INTEL;
+    } else if (strstr(dev_ctx->device_name.c_str(), "Apple") ||
+               strstr(dev_ctx->platform_name.c_str(), "Apple")) {
+        GGML_LOG_INFO("ggml_opencl: Apple GPU detected: '%s'\n",
+            dev_ctx->device_name.c_str());
+        backend_ctx->gpu_family = GPU_FAMILY::APPLE;
+        backend_ctx->adreno_wave_size = 32;  // Apple Silicon SIMD group width
+    } else if (strstr(dev_ctx->device_name.c_str(), "NVIDIA") ||
+               strstr(dev_ctx->platform_name.c_str(), "NVIDIA")) {
+        // Experimental: route NVIDIA OpenCL devices through the existing
+        // non-Adreno code path so we can validate basic functionality.
+        GGML_LOG_WARN("ggml_opencl: treating NVIDIA device '%s' as generic OpenCL/Intel-like for experimental support\n",
+            dev_ctx->device_name.c_str());
+        backend_ctx->gpu_family = GPU_FAMILY::INTEL;
     } else {
         GGML_LOG_ERROR("Unsupported GPU: %s\n", dev_ctx->device_name.c_str());
         backend_ctx->gpu_family = GPU_FAMILY::UNKNOWN;
@@ -3026,10 +3413,9 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
     }
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
-    if (backend_ctx->gpu_family != GPU_FAMILY::ADRENO) {
-        GGML_LOG_ERROR("ggml_opencl: Adreno-specific kernels should not be enabled for non-Adreno GPUs; "
-            "run on an Adreno GPU or recompile with CMake option `-DGGML_OPENCL_USE_ADRENO_KERNELS=OFF`\n");
-        return nullptr;
+    if (!backend_ctx->use_adreno_kernels) {
+        GGML_LOG_WARN("ggml_opencl: Adreno-specific kernels are compiled in but disabled for non-Adreno device '%s'\n",
+            dev_ctx->device_name.c_str());
     }
 #endif
 
@@ -3041,11 +3427,22 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
 
     ggml_cl_version platform_version = get_opencl_platform_version(dev_ctx->platform);
 
-    // Check device OpenCL version, OpenCL 2.0 or above is required
+    const bool experimental_apple =
+        strstr(dev_ctx->device_name.c_str(), "Apple") ||
+        strstr(dev_ctx->platform_name.c_str(), "Apple");
+
+    // Check device OpenCL version. OpenCL 1.2 runtimes can still work through
+    // the experimental no-subgroups compatibility path on non-Adreno devices.
     ggml_cl_version opencl_c_version = get_opencl_c_version(platform_version, device);
     if (opencl_c_version.major < 2) {
-        GGML_LOG_ERROR("ggml_opencl: OpenCL 2.0 or above is required\n");
-        return nullptr;
+        if (!backend_ctx->use_adreno_kernels &&
+            opencl_c_version.major == 1 && opencl_c_version.minor >= 2) {
+            GGML_LOG_WARN("ggml_opencl: allowing experimental OpenCL %d.%d runtime for '%s'\n",
+                opencl_c_version.major, opencl_c_version.minor, dev_ctx->device_name.c_str());
+        } else {
+            GGML_LOG_ERROR("ggml_opencl: OpenCL 2.0 or above is required\n");
+            return nullptr;
+        }
     }
 
     // Check driver version
@@ -3071,23 +3468,48 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
     ext_buffer[ext_str_size] = '\0'; // ensure it is null terminated
     // Check if ext_buffer contains cl_khr_fp16
     backend_ctx->fp16_support = strstr(ext_buffer, "cl_khr_fp16") != NULL;
+    const bool has_subgroups =
+        strstr(ext_buffer, "cl_khr_subgroups") != NULL ||
+        strstr(ext_buffer, "cl_intel_subgroups") != NULL;
     GGML_LOG_INFO("ggml_opencl: device FP16 support: %s\n", backend_ctx->fp16_support ? "true" : "false");
     // check Adreno large buffer support
     backend_ctx->adreno_has_large_buffer = strstr(ext_buffer, "cl_qcom_large_buffer") != NULL;
 
-    // fp16 is required
+    // Experimental NVIDIA path: some runtimes may not advertise cl_khr_fp16
+    // even though the hardware can execute half operations. Allow continuing
+    // so we can see whether kernel compilation/runtime succeeds in practice.
     if (!backend_ctx->fp16_support) {
-        GGML_LOG_ERROR("ggml_opencl: device does not support FP16\n");
-        return nullptr;
+        if (experimental_apple ||
+            strstr(dev_ctx->device_name.c_str(), "NVIDIA") ||
+            strstr(dev_ctx->platform_name.c_str(), "NVIDIA")) {
+            GGML_LOG_WARN("ggml_opencl: FP16 extension not reported for '%s'; continuing experimentally\n",
+                dev_ctx->device_name.c_str());
+        } else {
+            GGML_LOG_ERROR("ggml_opencl: device does not support FP16\n");
+            return nullptr;
+        }
+    }
+
+    backend_ctx->use_no_subgroups_compat =
+        !backend_ctx->use_adreno_kernels &&
+        ((opencl_c_version.major == 1 && opencl_c_version.minor >= 2) ||
+         (opencl_c_version.major == 3 && !has_subgroups));
+    if (backend_ctx->use_no_subgroups_compat) {
+        GGML_LOG_WARN("ggml_opencl: enabling no-subgroups compatibility mode for '%s'\n",
+            dev_ctx->device_name.c_str());
     }
 
     // If OpenCL 3.0 is supported, then check for cl_khr_subgroups, which becomes
     // optional in OpenCL 3.0 (cl_khr_subgroup is mandatory in OpenCL 2.x)
-    if (opencl_c_version.major == 3 && strstr(ext_buffer, "cl_khr_subgroups") == NULL &&
-        strstr(ext_buffer, "cl_intel_subgroups") == NULL) {
-        GGML_LOG_ERROR("ggml_opencl: device does not support subgroups (cl_khr_subgroups or cl_intel_subgroups) "
-            "(note that subgroups is an optional feature in OpenCL 3.0)\n");
-        return nullptr;
+    if (opencl_c_version.major == 3 && !has_subgroups) {
+        if (backend_ctx->use_no_subgroups_compat) {
+            GGML_LOG_WARN("ggml_opencl: subgroup extensions not reported for '%s'; continuing experimentally\n",
+                dev_ctx->device_name.c_str());
+        } else {
+            GGML_LOG_ERROR("ggml_opencl: device does not support subgroups (cl_khr_subgroups or cl_intel_subgroups) "
+                "(note that subgroups is an optional feature in OpenCL 3.0)\n");
+            return nullptr;
+        }
     }
 
     cl_uint base_align_in_bits;
@@ -3106,29 +3528,39 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
     GGML_LOG_INFO("ggml_opencl: device max workgroup size: %lu\n", backend_ctx->max_workgroup_size);
 
     // Check SVM.
-    cl_device_svm_capabilities svm_caps;
-    CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_SVM_CAPABILITIES, sizeof(cl_device_svm_capabilities), &svm_caps, 0));
-    GGML_LOG_INFO("ggml_opencl: SVM coarse grain buffer support: %s\n",
-        svm_caps & CL_DEVICE_SVM_COARSE_GRAIN_BUFFER ? "true" : "false");
-    GGML_LOG_INFO("ggml_opencl: SVM fine grain buffer support: %s\n",
-        svm_caps & CL_DEVICE_SVM_FINE_GRAIN_BUFFER ? "true" : "false");
-    GGML_LOG_INFO("ggml_opencl: SVM fine grain system support: %s\n",
-        svm_caps & CL_DEVICE_SVM_FINE_GRAIN_SYSTEM ? "true" : "false");
-    GGML_LOG_INFO("ggml_opencl: SVM atomics support: %s\n",
-        svm_caps & CL_DEVICE_SVM_ATOMICS ? "true" : "false");
+    #if defined(CL_DEVICE_SVM_CAPABILITIES) && defined(CL_DEVICE_SVM_COARSE_GRAIN_BUFFER) && defined(CL_DEVICE_SVM_FINE_GRAIN_BUFFER) && defined(CL_DEVICE_SVM_FINE_GRAIN_SYSTEM) && defined(CL_DEVICE_SVM_ATOMICS)
+    if (opencl_c_version.major >= 2) {
+        cl_device_svm_capabilities svm_caps;
+        CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_SVM_CAPABILITIES, sizeof(cl_device_svm_capabilities), &svm_caps, 0));
+        GGML_LOG_INFO("ggml_opencl: SVM coarse grain buffer support: %s\n",
+            svm_caps & CL_DEVICE_SVM_COARSE_GRAIN_BUFFER ? "true" : "false");
+        GGML_LOG_INFO("ggml_opencl: SVM fine grain buffer support: %s\n",
+            svm_caps & CL_DEVICE_SVM_FINE_GRAIN_BUFFER ? "true" : "false");
+        GGML_LOG_INFO("ggml_opencl: SVM fine grain system support: %s\n",
+            svm_caps & CL_DEVICE_SVM_FINE_GRAIN_SYSTEM ? "true" : "false");
+        GGML_LOG_INFO("ggml_opencl: SVM atomics support: %s\n",
+            svm_caps & CL_DEVICE_SVM_ATOMICS ? "true" : "false");
+    } else {
+        GGML_LOG_INFO("ggml_opencl: SVM support unavailable on OpenCL %d.%d runtime\n",
+            opencl_c_version.major, opencl_c_version.minor);
+    }
+    #else
+    GGML_LOG_INFO("ggml_opencl: SVM capability query unavailable in this OpenCL SDK\n");
+    #endif
 
     if (opencl_c_version.major >= 3) {
         // Assume it is not available for 3.0, since it is optional in 3.0.
         // If compiling against 3.0, then we can query.
         backend_ctx->non_uniform_workgroups = false;
-#if CL_TARGET_OPENCL_VERSION >= 300
+#if defined(CL_VERSION_3_0) && defined(CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT) && CL_TARGET_OPENCL_VERSION >= 300
         CL_CHECK(clGetDeviceInfo(device, CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT, sizeof(cl_bool),
                                  &backend_ctx->non_uniform_workgroups, 0));
 #endif
-    } else {
-        GGML_ASSERT(opencl_c_version.major == 2);
+    } else if (opencl_c_version.major == 2) {
         // Non-uniform workgroup sizes is mandatory feature in v2.x.
         backend_ctx->non_uniform_workgroups = true;
+    } else {
+        backend_ctx->non_uniform_workgroups = false;
     }
 
     // Print out configurations
@@ -3137,7 +3569,9 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
 #endif // GGML_OPENCL_SOA_Q
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
-    GGML_LOG_INFO("ggml_opencl: using kernels optimized for Adreno (GGML_OPENCL_USE_ADRENO_KERNELS)\n");
+    if (backend_ctx->use_adreno_kernels) {
+        GGML_LOG_INFO("ggml_opencl: using kernels optimized for Adreno (GGML_OPENCL_USE_ADRENO_KERNELS)\n");
+    }
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
     // determine whether to use large buffer for Adreno
@@ -3161,41 +3595,39 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
     //    (err != CL_INVALID_QUEUE_PROPERTIES && err != CL_INVALID_VALUE ? err :
     //    (queue = clCreateCommandQueue(context, device, 0, &err), err)
     //)));
-    cl_command_queue_properties command_queue_props = 0;
-#ifdef GGML_OPENCL_PROFILING
-    command_queue_props |= CL_QUEUE_PROFILING_ENABLE;
-#endif
-    CL_CHECK((backend_ctx->queue = clCreateCommandQueue(context, device, command_queue_props, &err), err));
+    backend_ctx->queue = ggml_opencl_create_queue(backend_ctx.get());
 
     // Load kernels
     load_cl_kernels(backend_ctx.get(), opencl_c_version);
 
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
-    // Allocate intermediate buffers and images
-    size_t required_A_q_d_bytes = 311164928;
-    size_t required_A_s_d_bytes = 38895616;
-    size_t required_B_d_bytes = 45088768;
+    if (backend_ctx->use_adreno_kernels) {
+        // Allocate intermediate buffers and images
+        size_t required_A_q_d_bytes = 311164928;
+        size_t required_A_s_d_bytes = 38895616;
+        size_t required_B_d_bytes = 45088768;
 
-    // Ensure buffer sizes do not exceed the maximum allocation size
-    size_t max_A_q_d_bytes = MIN(required_A_q_d_bytes, backend_ctx->max_alloc_size);
-    size_t max_A_s_d_bytes = MIN(required_A_s_d_bytes, backend_ctx->max_alloc_size);
-    size_t max_B_d_bytes   = MIN(required_B_d_bytes, backend_ctx->max_alloc_size);
-    if (required_A_q_d_bytes > backend_ctx->max_alloc_size) {
-        GGML_LOG_WARN("ggml_opencl: A_q_d buffer size reduced from %zu to %zu due to device limitations.\n",
-                      required_A_q_d_bytes, max_A_q_d_bytes);
-    }
-    if (required_A_s_d_bytes > backend_ctx->max_alloc_size) {
-        GGML_LOG_WARN("ggml_opencl: A_s_d buffer size reduced from %zu to %zu due to device limitations.\n",
-                      required_A_s_d_bytes, max_A_s_d_bytes);
-    }
-    if (required_B_d_bytes > backend_ctx->max_alloc_size) {
-        GGML_LOG_WARN("ggml_opencl: B_d buffer size reduced from %zu to %zu due to device limitations.\n",
-                      required_B_d_bytes, max_B_d_bytes);
-    }
+        // Ensure buffer sizes do not exceed the maximum allocation size
+        size_t max_A_q_d_bytes = MIN(required_A_q_d_bytes, backend_ctx->max_alloc_size);
+        size_t max_A_s_d_bytes = MIN(required_A_s_d_bytes, backend_ctx->max_alloc_size);
+        size_t max_B_d_bytes   = MIN(required_B_d_bytes, backend_ctx->max_alloc_size);
+        if (required_A_q_d_bytes > backend_ctx->max_alloc_size) {
+            GGML_LOG_WARN("ggml_opencl: A_q_d buffer size reduced from %zu to %zu due to device limitations.\n",
+                          required_A_q_d_bytes, max_A_q_d_bytes);
+        }
+        if (required_A_s_d_bytes > backend_ctx->max_alloc_size) {
+            GGML_LOG_WARN("ggml_opencl: A_s_d buffer size reduced from %zu to %zu due to device limitations.\n",
+                          required_A_s_d_bytes, max_A_s_d_bytes);
+        }
+        if (required_B_d_bytes > backend_ctx->max_alloc_size) {
+            GGML_LOG_WARN("ggml_opencl: B_d buffer size reduced from %zu to %zu due to device limitations.\n",
+                          required_B_d_bytes, max_B_d_bytes);
+        }
 
-    backend_ctx->prealloc_quant_trans.allocate(context, max_A_q_d_bytes);
-    backend_ctx->prealloc_scales_trans.allocate(context, max_A_s_d_bytes);
-    backend_ctx->prealloc_act_trans.allocate(context, max_B_d_bytes);
+        backend_ctx->prealloc_quant_trans.allocate(context, max_A_q_d_bytes);
+        backend_ctx->prealloc_scales_trans.allocate(context, max_A_s_d_bytes);
+        backend_ctx->prealloc_act_trans.allocate(context, max_B_d_bytes);
+    }
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
     backend_ctx->disable_fusion = getenv("GGML_OPENCL_DISABLE_FUSION") != nullptr;
@@ -3218,7 +3650,10 @@ static void ggml_cl2_free(ggml_backend_t backend) {
     }
 
     if (should_release_opencl) {
-        CL_CHECK(clReleaseContext(ctx->context));
+        // Experimental NVIDIA bring-up:
+        // letting the process tear down the shared OpenCL context is more stable
+        // than trying to release it here, because this backend shares the context
+        // across multiple objects with non-obvious lifetime ordering.
     }
 }
 
@@ -3257,11 +3692,15 @@ static void transpose_2d(
         global_size, local_size, 0, NULL, NULL));
 
     if (blocking) {
-        CL_CHECK(clEnqueueCopyBuffer(backend_ctx->queue, trans, dst, 0, 0, size, 0, NULL, &evt));
+        backend_ctx->enqueue_copy_buffer(trans, dst, 0, 0, size, nullptr, "transpose_copy");
+#ifdef GGML_OPENCL_PROFILING
+        evt = backend_ctx->profiling_info.back().evt;
         CL_CHECK(clWaitForEvents(1, &evt));
-        CL_CHECK(clReleaseEvent(evt));
+#else
+        CL_CHECK(clFinish(backend_ctx->queue));
+#endif
     } else {
-        CL_CHECK(clEnqueueCopyBuffer(backend_ctx->queue, trans, dst, 0, 0, size, 0, NULL, NULL));
+        backend_ctx->enqueue_copy_buffer(trans, dst, 0, 0, size, nullptr, "transpose_copy");
     }
 
     CL_CHECK(clReleaseMemObject(trans));
@@ -3418,6 +3857,38 @@ struct ggml_tensor_extra_cl_q4_1 {
     }
 };
 
+struct ggml_tensor_extra_cl_q5_0 {
+    cl_mem q = nullptr;
+    cl_mem qh = nullptr;
+    cl_mem d = nullptr;
+
+    size_t size_q = 0;
+    size_t size_qh = 0;
+    size_t size_d = 0;
+
+    ~ggml_tensor_extra_cl_q5_0() {
+        reset();
+    }
+
+    void reset() {
+        if (q != nullptr) {
+            CL_CHECK(clReleaseMemObject(q));
+            q = nullptr;
+        }
+        if (qh != nullptr) {
+            CL_CHECK(clReleaseMemObject(qh));
+            qh = nullptr;
+        }
+        if (d != nullptr) {
+            CL_CHECK(clReleaseMemObject(d));
+            d = nullptr;
+        }
+        size_q = 0;
+        size_qh = 0;
+        size_d = 0;
+    }
+};
+
 struct ggml_tensor_extra_cl_mxfp4 {
     // Quantized values.
     cl_mem q = nullptr;
@@ -3497,36 +3968,24 @@ struct ggml_tensor_extra_cl_q8_0 {
 };
 
 struct ggml_tensor_extra_cl_q4_K {
-    // Quantized values
-    cl_mem q = nullptr;
-    // Scales for each super block.
-    cl_mem s  = nullptr;
-    // Scales
-    cl_mem d = nullptr;
-    // Min
-    cl_mem dm  = nullptr;
+    cl_mem qs   = nullptr;  // 4-bit quantized weights (128 bytes/block)
+    cl_mem scales = nullptr;// scales (12 bytes/block)
+    cl_mem d    = nullptr;  // super-block scale (half/block)
+    cl_mem dmin = nullptr;  // super-block min   (half/block)
 
-    ~ggml_tensor_extra_cl_q4_K() {
-        reset();
-    }
+    size_t size_qs    = 0;
+    size_t size_scales = 0;
+    size_t size_d     = 0;
+    size_t size_dmin  = 0;
+
+    ~ggml_tensor_extra_cl_q4_K() { reset(); }
 
     void reset() {
-        if (q != nullptr) {
-            CL_CHECK(clReleaseMemObject(q));
-            q = nullptr;
-        }
-        if (s != nullptr) {
-            CL_CHECK(clReleaseMemObject(s));
-            s = nullptr;
-        }
-        if (d != nullptr) {
-            CL_CHECK(clReleaseMemObject(d));
-            d = nullptr;
-        }
-        if (dm != nullptr) {
-            CL_CHECK(clReleaseMemObject(dm));
-            dm = nullptr;
-        }
+        if (qs)     { CL_CHECK(clReleaseMemObject(qs));     qs     = nullptr; }
+        if (scales) { CL_CHECK(clReleaseMemObject(scales)); scales = nullptr; }
+        if (d)      { CL_CHECK(clReleaseMemObject(d));      d      = nullptr; }
+        if (dmin)   { CL_CHECK(clReleaseMemObject(dmin));   dmin   = nullptr; }
+        size_qs = size_scales = size_d = size_dmin = 0;
     }
 };
 
@@ -3591,6 +4050,17 @@ static void ggml_backend_opencl_free(ggml_backend_t backend) {
     ggml_cl2_free(backend);
 }
 
+static cl_command_queue ggml_opencl_create_queue(ggml_backend_opencl_context * backend_ctx) {
+    cl_int err;
+    cl_command_queue_properties command_queue_props = 0;
+#ifdef GGML_OPENCL_PROFILING
+    command_queue_props |= CL_QUEUE_PROFILING_ENABLE;
+#endif
+    cl_command_queue queue = clCreateCommandQueue(backend_ctx->context, backend_ctx->device, command_queue_props, &err);
+    CL_CHECK(err);
+    return queue;
+}
+
 static void ggml_backend_opencl_set_tensor_async(ggml_backend_t backend, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     GGML_UNUSED(backend);
     GGML_UNUSED(tensor);
@@ -3616,11 +4086,7 @@ static bool ggml_backend_opencl_cpy_tensor_async(ggml_backend_t backend, const g
 
 static void ggml_backend_opencl_synchronize(ggml_backend_t backend) {
     auto * backend_ctx = static_cast<ggml_backend_opencl_context *>(backend->context);
-
-    cl_event evt;
-    CL_CHECK(clEnqueueBarrierWithWaitList(backend_ctx->queue, 0, nullptr, &evt));
-    CL_CHECK(clWaitForEvents(1, &evt));
-    CL_CHECK(clReleaseEvent(evt));
+    CL_CHECK(clFinish(backend_ctx->queue));
 }
 
 // Synchronizes the 'backend_ctx's device with others so that commands
@@ -3721,12 +4187,66 @@ static bool ggml_opencl_can_fuse(const struct ggml_cgraph * cgraph, int node_idx
     return true;
 }
 
+static bool ggml_opencl_can_fuse_cont_mul_mat(const struct ggml_cgraph * cgraph, int node_idx) {
+    if (!ggml_can_fuse_subgraph(cgraph, node_idx, { GGML_OP_CONT, GGML_OP_MUL_MAT }, { node_idx + 1 }) ||
+        !ggml_check_edges(cgraph, node_idx, { { 1, 1, 0 } })) {
+        return false;
+    }
+
+    const ggml_tensor * cont = cgraph->nodes[node_idx];
+    const ggml_tensor * mul  = cgraph->nodes[node_idx + 1];
+    const ggml_tensor * src1 = cont->src[0];
+
+    GGML_ASSERT(cont == mul->src[1]);
+
+    // This fusion only elides CONT when it is reshaping an already-contiguous
+    // PERMUTE view before a matmul. The common generation-time kqv_out path in
+    // non-FA attention matches this pattern on Qwen3, so we can reuse the
+    // existing flat matmul kernels without materializing the temporary buffer.
+    if (src1 == nullptr || src1->op != GGML_OP_PERMUTE || !ggml_is_contiguous(src1)) {
+        return false;
+    }
+
+    if (src1->type != cont->type || cont->type != mul->src[1]->type) {
+        return false;
+    }
+
+    if (ggml_nbytes(src1) != ggml_nbytes(cont)) {
+        return false;
+    }
+
+    if (mul->src[0]->type != GGML_TYPE_Q4_0 || mul->src[1]->type != GGML_TYPE_F32 || mul->type != GGML_TYPE_F32) {
+        return false;
+    }
+
+    if (!ggml_is_contiguous(mul->src[0])) {
+        return false;
+    }
+
+    return ggml_cl_can_mul_mat(mul->src[0], cont, const_cast<ggml_tensor *>(mul));
+}
+
+static void ggml_opencl_op_cont_mul_mat_fused(ggml_backend_t backend, ggml_tensor * cont_tensor, ggml_tensor * mul_tensor) {
+    GGML_ASSERT(cont_tensor != nullptr);
+    GGML_ASSERT(mul_tensor != nullptr);
+    GGML_ASSERT(cont_tensor == mul_tensor->src[1]);
+
+    ggml_tensor reshaped_src1 = *cont_tensor->src[0];
+
+    for (int i = 0; i < GGML_MAX_DIMS; ++i) {
+        reshaped_src1.ne[i] = cont_tensor->ne[i];
+        reshaped_src1.nb[i] = cont_tensor->nb[i];
+    }
+
+    ggml_cl_mul_mat(backend, mul_tensor->src[0], &reshaped_src1, mul_tensor);
+}
+
 static void ggml_opencl_op_rms_norm_fused(ggml_backend_t backend, ggml_tensor * rms_norm_tensor, ggml_tensor * mul_tensor);
 static void ggml_opencl_op_norm_fused(ggml_backend_t backend, ggml_tensor * norm_tensor, ggml_tensor * mul_tensor, ggml_tensor * add_tensor);
 static void ggml_opencl_op_group_norm_fused(ggml_backend_t backend, ggml_tensor * gn_tensor, ggml_tensor * mul_tensor, ggml_tensor * add_tensor);
 
 static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
-    ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
+    ggml_backend_opencl_context * backend_ctx = (ggml_backend_opencl_context *) backend->context;
 
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
@@ -3756,6 +4276,11 @@ static ggml_status ggml_backend_opencl_graph_compute(ggml_backend_t backend, ggm
         }
         if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL })) {
             ggml_opencl_op_rms_norm_fused(backend, node, cgraph->nodes[i+1]);
+            i++;
+            continue;
+        }
+        if (!backend_ctx->disable_fusion && ggml_opencl_can_fuse_cont_mul_mat(cgraph, i)) {
+            ggml_opencl_op_cont_mul_mat_fused(backend, node, cgraph->nodes[i+1]);
             i++;
             continue;
         }
@@ -3943,10 +4468,14 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
             } else if (op->src[0]->type == GGML_TYPE_F32) {
                 return op->src[1]->type == GGML_TYPE_F32;
             } else if (op->src[0]->type == GGML_TYPE_Q4_0  || op->src[0]->type == GGML_TYPE_Q4_1 ||
-                       op->src[0]->type == GGML_TYPE_MXFP4 ||
                        op->src[0]->type == GGML_TYPE_Q4_K  ||
                        op->src[0]->type == GGML_TYPE_Q6_K) {
                 return op->src[1]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]) && ggml_is_contiguous(op->src[1]);
+            } else if (op->src[0]->type == GGML_TYPE_MXFP4) {
+                return op->src[1]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]) && ggml_is_contiguous(op->src[1]);
+            } else if (op->src[0]->type == GGML_TYPE_Q5_0) {
+                return backend_ctx->device_name.find("NVIDIA") != std::string::npos &&
+                       op->src[1]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]) && ggml_is_contiguous(op->src[1]);
             } else if (op->src[0]->type == GGML_TYPE_Q8_0) {
                 return op->src[1]->type == GGML_TYPE_F32;
             }
@@ -3991,6 +4520,34 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
         }
         case GGML_OP_SOLVE_TRI:
             return op->src[0]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]);
+        case GGML_OP_GATED_DELTA_NET: {
+            const ggml_tensor * q     = op->src[0];
+            const ggml_tensor * k     = op->src[1];
+            const ggml_tensor * v     = op->src[2];
+            const ggml_tensor * g     = op->src[3];
+            const ggml_tensor * beta  = op->src[4];
+            const ggml_tensor * state = op->src[5];
+
+            const int64_t S_v = v->ne[0];
+            const bool kda = g->ne[0] == S_v;
+
+            return q->type == GGML_TYPE_F32 &&
+                   k->type == GGML_TYPE_F32 &&
+                   v->type == GGML_TYPE_F32 &&
+                   g->type == GGML_TYPE_F32 &&
+                   beta->type == GGML_TYPE_F32 &&
+                   state->type == GGML_TYPE_F32 &&
+                   op->type == GGML_TYPE_F32 &&
+                   (S_v == 32 || S_v == 64 || S_v == 128) &&
+                   ggml_is_contiguous_rows(q) &&
+                   ggml_is_contiguous_rows(k) &&
+                   ggml_is_contiguous_rows(v) &&
+                   ggml_are_same_stride(q, k) &&
+                   (g->ne[0] == 1 || kda) &&
+                   ggml_is_contiguous(g) &&
+                   ggml_is_contiguous(beta) &&
+                   ggml_is_contiguous(state);
+        }
         case GGML_OP_IM2COL:
             return true;
         case GGML_OP_ARGSORT: {
@@ -4077,6 +4634,7 @@ static ggml_backend_i ggml_backend_opencl_i = {
 ggml_backend_t ggml_backend_opencl_init(void) {
     ggml_backend_dev_t dev = ggml_backend_reg_dev_get(ggml_backend_opencl_reg(), 0);
     ggml_backend_opencl_context *backend_ctx = ggml_cl2_init(dev);
+    backend_ctx->ref_count++;
 
     ggml_backend_t backend = new ggml_backend {
         /* .guid    = */ ggml_backend_opencl_guid(),
@@ -4125,6 +4683,12 @@ struct ggml_backend_opencl_buffer_context {
             delete e;
         }
         for (ggml_tensor_extra_cl_q4_0 * e : temp_tensor_extras_q4_0_in_use) {
+            delete e;
+        }
+        for (ggml_tensor_extra_cl_q5_0 * e : temp_tensor_extras_q5_0) {
+            delete e;
+        }
+        for (ggml_tensor_extra_cl_q5_0 * e : temp_tensor_extras_q5_0_in_use) {
             delete e;
         }
         for (ggml_tensor_extra_cl_mxfp4 * e : temp_tensor_extras_mxfp4) {
@@ -4198,6 +4762,21 @@ struct ggml_backend_opencl_buffer_context {
         return extra;
     }
 
+    ggml_tensor_extra_cl_q5_0 * ggml_opencl_alloc_temp_tensor_extra_q5_0() {
+        ggml_tensor_extra_cl_q5_0 * extra;
+        if (temp_tensor_extras_q5_0.empty()) {
+            extra = new ggml_tensor_extra_cl_q5_0();
+        } else {
+            extra = temp_tensor_extras_q5_0.back();
+            temp_tensor_extras_q5_0.pop_back();
+        }
+
+        temp_tensor_extras_q5_0_in_use.push_back(extra);
+
+        extra->reset();
+        return extra;
+    }
+
     ggml_tensor_extra_cl_mxfp4 * ggml_opencl_alloc_temp_tensor_extra_mxfp4() {
         ggml_tensor_extra_cl_mxfp4 * extra;
         if (temp_tensor_extras_mxfp4.empty()) {
@@ -4236,9 +4815,7 @@ struct ggml_backend_opencl_buffer_context {
             extra = temp_tensor_extras_q4_K.back();
             temp_tensor_extras_q4_K.pop_back();
         }
-
         temp_tensor_extras_q4_K_in_use.push_back(extra);
-
         extra->reset();
         return extra;
     }
@@ -4274,6 +4851,11 @@ struct ggml_backend_opencl_buffer_context {
         }
         temp_tensor_extras_q4_1_in_use.clear();
 
+        for (ggml_tensor_extra_cl_q5_0 * e : temp_tensor_extras_q5_0_in_use) {
+            temp_tensor_extras_q5_0.push_back(e);
+        }
+        temp_tensor_extras_q5_0_in_use.clear();
+
         for (ggml_tensor_extra_cl_mxfp4 * e : temp_tensor_extras_mxfp4_in_use) {
             temp_tensor_extras_mxfp4.push_back(e);
         }
@@ -4306,6 +4888,8 @@ struct ggml_backend_opencl_buffer_context {
     std::vector<ggml_tensor_extra_cl_q4_0 *> temp_tensor_extras_q4_0_in_use;
     std::vector<ggml_tensor_extra_cl_q4_1 *> temp_tensor_extras_q4_1;
     std::vector<ggml_tensor_extra_cl_q4_1 *> temp_tensor_extras_q4_1_in_use;
+    std::vector<ggml_tensor_extra_cl_q5_0 *> temp_tensor_extras_q5_0;
+    std::vector<ggml_tensor_extra_cl_q5_0 *> temp_tensor_extras_q5_0_in_use;
     std::vector<ggml_tensor_extra_cl_mxfp4 *> temp_tensor_extras_mxfp4;
     std::vector<ggml_tensor_extra_cl_mxfp4 *> temp_tensor_extras_mxfp4_in_use;
     std::vector<ggml_tensor_extra_cl_q8_0 *> temp_tensor_extras_q8_0;
@@ -4387,6 +4971,10 @@ static enum ggml_status ggml_backend_opencl_buffer_init_tensor(ggml_backend_buff
 // The optimized gemm and gemv kernels are used for large matrices without batch.
 // tensor is the quantized weights matrix.
 inline bool use_adreno_kernels(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
+    if (!backend_ctx->use_adreno_kernels) {
+        return false;
+    }
+
     int64_t threshold_ne0 = 512;
     int64_t threshold_ne1 = 512;
     if (!backend_ctx->adreno_cl_compiler_version.newer_than_or_same(E031, 38, 11, 0) &&
@@ -4399,7 +4987,10 @@ inline bool use_adreno_kernels(const ggml_backend_opencl_context *backend_ctx, c
 }
 
 inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
-    GGML_UNUSED(backend_ctx);
+    if (!backend_ctx->use_adreno_kernels) {
+        return false;
+    }
+
     int ne01 = tensor->ne[1];
     return ((strstr(tensor->name, "ffn") != NULL) || (strstr(tensor->name, "as") != NULL)) && (ne01 % 64 == 0);
 }
@@ -4462,25 +5053,13 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         // into the general backend code.
         // Does this create misaligned subbuffers (alignment is 1024) in certain
         // cases ?
-        cl_buffer_region region;
-
         // The original tensor memory is divided into scales and quants, i.e.,
         // we first store scales, then quants.
-        // Create subbuffer for scales.
-        region.origin = align_to(extra_orig->offset + tensor->view_offs + offset, backend_ctx->alignment);
-        region.size = size_d;
-        extra->d = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        // Allocate separate buffers for each SoA component to avoid subbuffer
+        // alignment gaps that can push origins past the tensor's allocated region.
+        extra->d = clCreateBuffer(context, CL_MEM_READ_WRITE, size_d, NULL, &err);
         CL_CHECK(err);
-        auto previous_origin = region.origin;
-
-        // Create subbuffer for quants.
-        region.origin = align_to(previous_origin + size_d, backend_ctx->alignment);
-        region.size = size_q;
-        extra->q = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        extra->q = clCreateBuffer(context, CL_MEM_READ_WRITE, size_q, NULL, &err);
         CL_CHECK(err);
 
         //cl_kernel kernel = backend_ctx->kernel_convert_block_q4_0;
@@ -4498,8 +5077,12 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
 
-        size_t global_work_size[] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
-        size_t local_work_size[] = {64, 1, 1};
+        size_t num_blocks_q4_0 = (size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type);
+        size_t lws_q4_0 = 64;
+        while (lws_q4_0 > num_blocks_q4_0) { lws_q4_0 /= 2; }
+        if (lws_q4_0 == 0) { lws_q4_0 = 1; }
+        size_t global_work_size[] = {num_blocks_q4_0, 1, 1};
+        size_t local_work_size[] = {lws_q4_0, 1, 1};
 
         cl_event evt;
         CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
@@ -4647,16 +5230,22 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK(clWaitForEvents(1, &evt));
         // <----------------------------------------------------------------------------------> //
 
-        // copy transposed buffer contents to original buffers
-        // <----------------------------------------------------------------------------------> //
-        // weights
-        CL_CHECK(clEnqueueCopyBuffer(queue, qT_d, extra->q, 0, 0, q_size_bytes, 0, NULL, &evt));
+        // Copy transposed data into the sub-buffers (clEnqueueCopyBuffer to
+        // a sub-buffer is valid even on Qualcomm).
+        backend_ctx->enqueue_copy_buffer(qT_d, extra->q, 0, 0, q_size_bytes, tensor, "quant_transpose_q_copy");
+#ifdef GGML_OPENCL_PROFILING
+        evt = backend_ctx->profiling_info.back().evt;
         CL_CHECK(clWaitForEvents(1, &evt));
-
-        // scales
-        CL_CHECK(clEnqueueCopyBuffer(queue, dT_d, extra->d, 0, 0, d_size_bytes, 0, NULL, &evt));
+#else
+        CL_CHECK(clFinish(queue));
+#endif
+        backend_ctx->enqueue_copy_buffer(dT_d, extra->d, 0, 0, d_size_bytes, tensor, "quant_transpose_d_copy");
+#ifdef GGML_OPENCL_PROFILING
+        evt = backend_ctx->profiling_info.back().evt;
         CL_CHECK(clWaitForEvents(1, &evt));
-        // <----------------------------------------------------------------------------------> //
+#else
+        CL_CHECK(clFinish(queue));
+#endif
 
         // deallocate transpose buffers
         // <----------------------------------------------------------------------------------> //
@@ -4698,34 +5287,15 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
             queue, data_device, CL_TRUE, 0,
             ggml_nbytes(tensor), data, 0, NULL, NULL));
 
-        cl_buffer_region region;
-
         // The original tensor memory is divided into scales and quants, i.e.,
         // we first store scales, mins, then quants.
-        // Create subbuffer for scales.
-        region.origin = align_to(extra_orig->offset + tensor->view_offs + offset, backend_ctx->alignment);
-        region.size = size_d;
-        extra->d = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        // Allocate separate buffers for each SoA component to avoid subbuffer
+        // alignment gaps that can push origins past the tensor's allocated region.
+        extra->d = clCreateBuffer(context, CL_MEM_READ_WRITE, size_d, NULL, &err);
         CL_CHECK(err);
-        auto previous_origin = region.origin;
-
-        // Create subbuffer for mins.
-        region.origin = align_to(previous_origin + size_d, backend_ctx->alignment);
-        region.size = size_m;
-        extra->m = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        extra->m = clCreateBuffer(context, CL_MEM_READ_WRITE, size_m, NULL, &err);
         CL_CHECK(err);
-        previous_origin = region.origin;
-
-        // Create subbuffer for quants.
-        region.origin = align_to(previous_origin + size_m, backend_ctx->alignment);
-        region.size = size_q;
-        extra->q = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        extra->q = clCreateBuffer(context, CL_MEM_READ_WRITE, size_q, NULL, &err);
         CL_CHECK(err);
 
     #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
@@ -4742,8 +5312,12 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
         CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->m));
 
-        size_t global_work_size[] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
-        size_t local_work_size[] = {64, 1, 1};
+        size_t num_blocks_q4_1 = (size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type);
+        size_t lws_q4_1 = 64;
+        while (lws_q4_1 > num_blocks_q4_1) { lws_q4_1 /= 2; }
+        if (lws_q4_1 == 0) { lws_q4_1 = 1; }
+        size_t global_work_size[] = {num_blocks_q4_1, 1, 1};
+        size_t local_work_size[] = {lws_q4_1, 1, 1};
 
         cl_event evt;
         CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
@@ -4768,6 +5342,67 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
             transpose_2d_as_16b(backend_ctx, extra->m, extra->m, size_m, K/32, M);
         }
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
+        return;
+    }
+    if (tensor->type == GGML_TYPE_Q5_0) {
+        ggml_tensor_extra_cl * extra_orig = (ggml_tensor_extra_cl *)tensor->extra;
+        GGML_ASSERT(extra_orig && "Tesnors in OpenCL backend should have been allocated and initialized");
+
+        ggml_backend_opencl_buffer_context * ctx = (ggml_backend_opencl_buffer_context *) buffer->context;
+        ggml_tensor_extra_cl_q5_0 * extra = ctx->ggml_opencl_alloc_temp_tensor_extra_q5_0();
+
+        size_t size_d  = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
+        size_t size_qh = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(uint32_t);
+        size_t size_q  = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*(ggml_blck_size(tensor->type)/2);
+        GGML_ASSERT(size_d + size_qh + size_q == ggml_nbytes(tensor) && "Incorrect tensor size");
+
+        cl_int err;
+        cl_mem data_device = clCreateBuffer(context, CL_MEM_READ_WRITE, ggml_nbytes(tensor), NULL, &err);
+        CL_CHECK(err);
+        CL_CHECK(clEnqueueWriteBuffer(queue, data_device, CL_TRUE, 0, ggml_nbytes(tensor), data, 0, NULL, NULL));
+
+        cl_buffer_region region;
+
+        region.origin = align_to(extra_orig->offset + tensor->view_offs + offset, backend_ctx->alignment);
+        region.size = size_d;
+        extra->d = clCreateSubBuffer(extra_orig->data_device, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        CL_CHECK(err);
+        auto previous_origin = region.origin;
+
+        region.origin = align_to(previous_origin + size_d, backend_ctx->alignment);
+        region.size = size_qh;
+        extra->qh = clCreateSubBuffer(extra_orig->data_device, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        CL_CHECK(err);
+        previous_origin = region.origin;
+
+        region.origin = align_to(previous_origin + size_qh, backend_ctx->alignment);
+        region.size = size_q;
+        extra->q = clCreateSubBuffer(extra_orig->data_device, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+        CL_CHECK(err);
+
+        cl_kernel kernel = backend_ctx->kernel_convert_block_q5_0;
+
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->qh));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->d));
+
+        size_t num_blocks_q5_0 = (size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type);
+        size_t lws_q5_0 = 64;
+        while (lws_q5_0 > num_blocks_q5_0) { lws_q5_0 /= 2; }
+        if (lws_q5_0 == 0) { lws_q5_0 = 1; }
+        size_t global_work_size[] = {num_blocks_q5_0, 1, 1};
+        size_t local_work_size[] = {lws_q5_0, 1, 1};
+
+        cl_event evt;
+        CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
+        CL_CHECK(clWaitForEvents(1, &evt));
+        CL_CHECK(clReleaseMemObject(data_device));
+
+        extra->size_d = size_d;
+        extra->size_qh = size_qh;
+        extra->size_q = size_q;
+        tensor->extra = extra;
         return;
     }
     if (tensor->type == GGML_TYPE_MXFP4) {
@@ -4842,8 +5477,12 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->e));
 
-        size_t global_work_size[3] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
-        size_t local_work_size[3] = {64, 1, 1};
+        size_t num_blocks_mxfp4 = (size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type);
+        size_t lws_mxfp4 = 64;
+        while (lws_mxfp4 > num_blocks_mxfp4) { lws_mxfp4 /= 2; }
+        if (lws_mxfp4 == 0) { lws_mxfp4 = 1; }
+        size_t global_work_size[3] = {num_blocks_mxfp4, 1, 1};
+        size_t local_work_size[3] = {lws_mxfp4, 1, 1};
 
         cl_event evt;
         CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
@@ -4910,8 +5549,12 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
 
-        size_t global_work_size[] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
-        size_t local_work_size[] = {64, 1, 1};
+        size_t num_blocks_q8_0 = (size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type);
+        size_t lws_q8_0 = 64;
+        while (lws_q8_0 > num_blocks_q8_0) { lws_q8_0 /= 2; }
+        if (lws_q8_0 == 0) { lws_q8_0 = 1; }
+        size_t global_work_size[] = {num_blocks_q8_0, 1, 1};
+        size_t local_work_size[] = {lws_q8_0, 1, 1};
 
         cl_event evt;
         CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
@@ -5028,11 +5671,21 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
             CL_CHECK(clWaitForEvents(1, &evt));
 
             // copy transposed buffer contents to original buffers
-            CL_CHECK(clEnqueueCopyBuffer(queue, qT_d, extra->q, 0, 0, q_size_bytes, 0, NULL, &evt));
+            backend_ctx->enqueue_copy_buffer(qT_d, extra->q, 0, 0, q_size_bytes, tensor, "quant_transpose_q_copy");
+#ifdef GGML_OPENCL_PROFILING
+            evt = backend_ctx->profiling_info.back().evt;
             CL_CHECK(clWaitForEvents(1, &evt));
+#else
+            CL_CHECK(clFinish(queue));
+#endif
 
-            CL_CHECK(clEnqueueCopyBuffer(queue, dT_d, extra->d, 0, 0, d_size_bytes, 0, NULL, &evt));
+            backend_ctx->enqueue_copy_buffer(dT_d, extra->d, 0, 0, d_size_bytes, tensor, "quant_transpose_d_copy");
+#ifdef GGML_OPENCL_PROFILING
+            evt = backend_ctx->profiling_info.back().evt;
             CL_CHECK(clWaitForEvents(1, &evt));
+#else
+            CL_CHECK(clFinish(queue));
+#endif
 
             CL_CHECK(clReleaseMemObject(qT_d));
             CL_CHECK(clReleaseMemObject(dT_d));
@@ -5048,106 +5701,150 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
     }
     if (tensor->type == GGML_TYPE_Q4_K) {
         ggml_tensor_extra_cl * extra_orig = (ggml_tensor_extra_cl *)tensor->extra;
-        GGML_ASSERT(extra_orig && "Tesnors in OpenCL backend should have been allocated and initialized");
+        GGML_ASSERT(extra_orig && "Tensors in OpenCL backend should have been allocated and initialized");
 
-        // Allocate the new extra and create aliases from the original.
         ggml_backend_opencl_buffer_context * ctx = (ggml_backend_opencl_buffer_context *) buffer->context;
         ggml_tensor_extra_cl_q4_K * extra = ctx->ggml_opencl_alloc_temp_tensor_extra_q4_K();
 
-        size_t size_d = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
-        size_t size_dm = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
-        size_t size_s = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*(3 * ggml_blck_size(tensor->type) / 64);
-        size_t size_q = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*ggml_blck_size(tensor->type)/2;
-        GGML_ASSERT(size_d + size_dm + size_s + size_q == ggml_nbytes(tensor) && "Incorrect tensor size");
+        if (backend_ctx->device_name.find("NVIDIA") != std::string::npos) {
+            // NVIDIA path: allocate separate SOA buffers
+            size_t n_blocks   = (size_t)ggml_nelements(tensor) / ggml_blck_size(tensor->type);
+            size_t size_qs    = n_blocks * 128;   // QK_K/2
+            size_t size_scales = n_blocks * 12;   // K_SCALE_SIZE
+            size_t size_d     = n_blocks * sizeof(ggml_fp16_t);
+            size_t size_dmin  = n_blocks * sizeof(ggml_fp16_t);
+            GGML_ASSERT(size_qs + size_scales + size_d + size_dmin == ggml_nbytes(tensor) &&
+                "Incorrect Q4_K tensor size");
 
-        cl_int err;
-        cl_mem data_device = clCreateBuffer(context, CL_MEM_READ_WRITE,
-            ggml_nbytes(tensor), NULL, &err);
-        CL_CHECK(err);
-        CL_CHECK(clEnqueueWriteBuffer(
-            queue, data_device, CL_TRUE, 0,
-            ggml_nbytes(tensor), data, 0, NULL, NULL));
+            cl_int err;
+            cl_mem data_device = clCreateBuffer(context, CL_MEM_READ_WRITE,
+                ggml_nbytes(tensor), NULL, &err);
+            CL_CHECK(err);
+            CL_CHECK(clEnqueueWriteBuffer(queue, data_device, CL_TRUE, 0,
+                ggml_nbytes(tensor), data, 0, NULL, NULL));
 
-        cl_buffer_region region;
+            extra->qs     = clCreateBuffer(context, CL_MEM_READ_WRITE, size_qs,     NULL, &err); CL_CHECK(err);
+            extra->scales = clCreateBuffer(context, CL_MEM_READ_WRITE, size_scales, NULL, &err); CL_CHECK(err);
+            extra->d      = clCreateBuffer(context, CL_MEM_READ_WRITE, size_d,      NULL, &err); CL_CHECK(err);
+            extra->dmin   = clCreateBuffer(context, CL_MEM_READ_WRITE, size_dmin,   NULL, &err); CL_CHECK(err);
 
-        // Create subbuffer for d.
-        region.origin = align_to(extra_orig->offset + tensor->view_offs + offset, backend_ctx->alignment);
-        region.size = size_d;
-        extra->d = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
-        CL_CHECK(err);
-        auto previous_origin = region.origin;
+            cl_kernel kernel = backend_ctx->kernel_convert_block_q4_K;
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->d));
+            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->dmin));
+            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->scales));
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &extra->qs));
 
-        // Create subbuffer for mins.
-        region.origin = align_to(previous_origin + size_d, backend_ctx->alignment);
-        region.size = size_dm;
-        extra->dm = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
-        CL_CHECK(err);
-        previous_origin = region.origin;
+            size_t gws[] = {n_blocks, 1, 1};
 
-        // Create subbuffer for s.
-        region.origin = align_to(previous_origin + size_dm, backend_ctx->alignment);
-        region.size = size_s;
-        extra->s = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
-        CL_CHECK(err);
-        previous_origin = region.origin;
+            cl_event evt;
+            CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, gws, NULL, 0, NULL, &evt));
+            CL_CHECK(clWaitForEvents(1, &evt));
+            CL_CHECK(clReleaseMemObject(data_device));
 
-        // Create subbuffer for quants.
-        region.origin = align_to(previous_origin + size_s, backend_ctx->alignment);
-        region.size = size_q;
-        extra->q = clCreateSubBuffer(
-            extra_orig->data_device, CL_MEM_READ_WRITE,
-            CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
-        CL_CHECK(err);
+            extra->size_qs     = size_qs;
+            extra->size_scales = size_scales;
+            extra->size_d      = size_d;
+            extra->size_dmin   = size_dmin;
 
-        #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
-        cl_kernel kernel = backend_ctx->kernel_convert_block_q4_K;
-        if (use_adreno_kernels(backend_ctx, tensor)) {
-            kernel = backend_ctx->kernel_convert_block_q4_K_noshuffle;
+            tensor->extra = extra;
+        } else {
+            // Adreno/Intel path: subbuffer-based init
+            size_t size_d  = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
+            size_t size_dmin = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
+            size_t size_scales = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*(3 * ggml_blck_size(tensor->type) / 64);
+            size_t size_qs = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*ggml_blck_size(tensor->type)/2;
+            GGML_ASSERT(size_d + size_dmin + size_scales + size_qs == ggml_nbytes(tensor) && "Incorrect tensor size");
+
+            cl_int err;
+            cl_mem data_device = clCreateBuffer(context, CL_MEM_READ_WRITE,
+                ggml_nbytes(tensor), NULL, &err);
+            CL_CHECK(err);
+            CL_CHECK(clEnqueueWriteBuffer(
+                queue, data_device, CL_TRUE, 0,
+                ggml_nbytes(tensor), data, 0, NULL, NULL));
+
+            cl_buffer_region region;
+
+            // Create subbuffer for d.
+            region.origin = align_to(extra_orig->offset + tensor->view_offs + offset, backend_ctx->alignment);
+            region.size = size_d;
+            extra->d = clCreateSubBuffer(
+                extra_orig->data_device, CL_MEM_READ_WRITE,
+                CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+            CL_CHECK(err);
+            auto previous_origin = region.origin;
+
+            // Create subbuffer for mins.
+            region.origin = align_to(previous_origin + size_d, backend_ctx->alignment);
+            region.size = size_dmin;
+            extra->dmin = clCreateSubBuffer(
+                extra_orig->data_device, CL_MEM_READ_WRITE,
+                CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+            CL_CHECK(err);
+            previous_origin = region.origin;
+
+            // Create subbuffer for scales.
+            region.origin = align_to(previous_origin + size_dmin, backend_ctx->alignment);
+            region.size = size_scales;
+            extra->scales = clCreateSubBuffer(
+                extra_orig->data_device, CL_MEM_READ_WRITE,
+                CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+            CL_CHECK(err);
+            previous_origin = region.origin;
+
+            // Create subbuffer for quants.
+            region.origin = align_to(previous_origin + size_scales, backend_ctx->alignment);
+            region.size = size_qs;
+            extra->qs = clCreateSubBuffer(
+                extra_orig->data_device, CL_MEM_READ_WRITE,
+                CL_BUFFER_CREATE_TYPE_REGION, &region, &err);
+            CL_CHECK(err);
+
+            #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+            cl_kernel kernel = backend_ctx->kernel_convert_block_q4_K;
+            if (use_adreno_kernels(backend_ctx, tensor)) {
+                kernel = backend_ctx->kernel_convert_block_q4_K_noshuffle;
+            }
+            #else
+            cl_kernel kernel = backend_ctx->kernel_convert_block_q4_K;
+            #endif
+
+            cl_uchar mask_0F = 0x0F;
+            cl_uchar mask_F0 = 0xF0;
+
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->qs));
+            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->scales));
+            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->d));
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &extra->dmin));
+            CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_uchar), &mask_0F));
+            CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_uchar), &mask_F0));
+
+            size_t global_work_size[] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
+            size_t local_work_size[] = {64, 1, 1};
+
+            cl_event evt;
+            CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
+            CL_CHECK(clWaitForEvents(1, &evt));
+            CL_CHECK(clReleaseMemObject(data_device));
+
+            tensor->extra  = extra;
+    #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+            if (use_adreno_kernels(backend_ctx, tensor)) {
+
+                int M = tensor->ne[1];
+                int K = tensor->ne[0];
+
+                GGML_ASSERT(K % 32 == 0);
+
+                // Transpose qs, d, dmin as ushort
+                transpose_2d_as_16b(backend_ctx, extra->qs,   extra->qs,   size_qs,   K/4, M);
+                transpose_2d_as_16b(backend_ctx, extra->d,    extra->d,    size_d,    K/256, M);
+                transpose_2d_as_16b(backend_ctx, extra->dmin, extra->dmin, size_dmin, K/256, M);
+            }
+    #endif // GGML_OPENCL_USE_ADRENO_KERNELS
         }
-        #else
-        cl_kernel kernel = backend_ctx->kernel_convert_block_q4_K;
-        #endif
-
-        cl_uchar mask_0F = 0x0F;
-        cl_uchar mask_F0 = 0xF0;
-
-        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &data_device));
-        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->q));
-        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->s));
-        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->d));
-        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &extra->dm));
-        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_uchar), &mask_0F));
-        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_uchar), &mask_F0));
-
-        size_t global_work_size[] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
-        size_t local_work_size[] = {64, 1, 1};
-
-        cl_event evt;
-        CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
-        CL_CHECK(clWaitForEvents(1, &evt));
-        CL_CHECK(clReleaseMemObject(data_device));
-
-        tensor->extra  = extra;
-#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
-        if (use_adreno_kernels(backend_ctx, tensor)) {
-
-            int M = tensor->ne[1];
-            int K = tensor->ne[0];
-
-            GGML_ASSERT(K % 32 == 0);
-
-            // Transpose q, d, dm as ushort
-            transpose_2d_as_16b(backend_ctx, extra->q, extra->q, size_q, K/4, M);
-            transpose_2d_as_16b(backend_ctx, extra->d, extra->d, size_d, K/256, M);
-            transpose_2d_as_16b(backend_ctx, extra->dm, extra->dm, size_dm, K/256, M);
-        }
-#endif // GGML_OPENCL_USE_ADRENO_KERNELS
         return;
     }
     if (tensor->type == GGML_TYPE_Q6_K) {
@@ -5170,31 +5867,20 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK((data_device = clCreateBuffer(context, CL_MEM_READ_WRITE, ggml_nbytes(tensor), NULL, &err), err));
         CL_CHECK(clEnqueueWriteBuffer(queue, data_device, CL_TRUE, 0, ggml_nbytes(tensor), data, 0, NULL, NULL));
 
-        cl_buffer_region region;
-
-        // Subbuffer for ql
-        region.origin = align_to(extra_orig->offset + tensor->view_offs + offset, backend_ctx->alignment);
-        region.size = size_ql;
-        CL_CHECK((extra->ql = clCreateSubBuffer(extra_orig->data_device, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
-        auto previous_origin = region.origin;
-
-        // Subbuffer for qh
-        region.origin = align_to(previous_origin + size_ql, backend_ctx->alignment);
-        region.size = size_qh;
-        CL_CHECK((extra->qh = clCreateSubBuffer(extra_orig->data_device, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
-        previous_origin = region.origin;
-
-        // Subbuffer for scales
-        region.origin = align_to(previous_origin + size_qh, backend_ctx->alignment);
-        region.size = size_s;
-        CL_CHECK((extra->s = clCreateSubBuffer(extra_orig->data_device, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
-        previous_origin = region.origin;
-
-        // Create subbuffer for d.
-        region.origin = align_to(previous_origin + size_s, backend_ctx->alignment);
-        region.size = size_d;
-        CL_CHECK((extra->d = clCreateSubBuffer(extra_orig->data_device, CL_MEM_READ_WRITE, CL_BUFFER_CREATE_TYPE_REGION, &region, &err), err));
-        previous_origin = region.origin;
+        // Allocate separate buffers for each SoA component.
+        // We do not use subbuffers of the original tensor buffer here because
+        // subbuffers require aligned origins, and the cumulative alignment gaps
+        // can push a subbuffer origin past the tensor's allocated region,
+        // causing it to alias into an adjacent tensor's memory (which would
+        // then corrupt the SoA data when that tensor is written).
+        extra->ql = clCreateBuffer(context, CL_MEM_READ_WRITE, size_ql, NULL, &err);
+        CL_CHECK(err);
+        extra->qh = clCreateBuffer(context, CL_MEM_READ_WRITE, size_qh, NULL, &err);
+        CL_CHECK(err);
+        extra->s  = clCreateBuffer(context, CL_MEM_READ_WRITE, size_s,  NULL, &err);
+        CL_CHECK(err);
+        extra->d  = clCreateBuffer(context, CL_MEM_READ_WRITE, size_d,  NULL, &err);
+        CL_CHECK(err);
 
         // Flatten the weights
         cl_kernel kernel;
@@ -5217,13 +5903,19 @@ static void ggml_backend_opencl_buffer_set_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_uchar), &mask));
         CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_ulong), &n_blk));
 
-        size_t global_work_size[] = {(size_t)CEIL_DIV(n_blk, 64)*64, 1, 1};
-        size_t local_work_size[] = {64, 1, 1};
+        size_t num_blocks_q6 = (size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type);
+        size_t lws_q6 = 64;
+        // local work size must not exceed global work size (required by OpenCL spec)
+        while (lws_q6 > num_blocks_q6) { lws_q6 /= 2; }
+        if (lws_q6 == 0) { lws_q6 = 1; }
+        size_t global_work_size[] = {num_blocks_q6, 1, 1};
+        size_t local_work_size[] = {lws_q6, 1, 1};
 
         cl_event evt;
         CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
         CL_CHECK(clWaitForEvents(1, &evt));
         CL_CHECK(clReleaseMemObject(data_device));
+
 
         extra->size_ql = size_ql;
         extra->size_qh = size_qh;
@@ -5471,6 +6163,29 @@ static void ggml_backend_opencl_buffer_get_tensor(ggml_backend_buffer_t buffer, 
         CL_CHECK(clReleaseMemObject(data_device));
         return;
     }
+    if (tensor->type == GGML_TYPE_Q5_0) {
+        ggml_tensor_extra_cl_q5_0 * extra = (ggml_tensor_extra_cl_q5_0 *)tensor->extra;
+
+        cl_int err;
+        cl_mem data_device = clCreateBuffer(context, CL_MEM_READ_WRITE, ggml_nbytes(tensor), NULL, &err);
+        CL_CHECK(err);
+
+        cl_kernel kernel = backend_ctx->kernel_restore_block_q5_0;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->q));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->qh));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &data_device));
+
+        size_t global_work_size[] = {(size_t) ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
+        size_t local_work_size[] = {1, 1, 1};
+
+        cl_event evt;
+        CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL, global_work_size, local_work_size, 0, NULL, &evt));
+        CL_CHECK(clWaitForEvents(1, &evt));
+        CL_CHECK(clEnqueueReadBuffer(queue, data_device, CL_TRUE, offset, size, data, 0, NULL, NULL));
+        CL_CHECK(clReleaseMemObject(data_device));
+        return;
+    }
     if (tensor->type == GGML_TYPE_MXFP4) {
         ggml_tensor_extra_cl_mxfp4 * extra = (ggml_tensor_extra_cl_mxfp4 *)tensor->extra;
 
@@ -5596,28 +6311,28 @@ static void ggml_backend_opencl_buffer_get_tensor(ggml_backend_buffer_t buffer, 
             int M = tensor->ne[1];
             int K = tensor->ne[0];
 
-            size_t size_q  = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*ggml_blck_size(tensor->type)/2;
-            size_t size_d  = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
-            size_t size_dm = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
+            size_t size_qs   = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*ggml_blck_size(tensor->type)/2;
+            size_t size_d    = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
+            size_t size_dmin = ggml_nelements(tensor)/ggml_blck_size(tensor->type)*sizeof(ggml_fp16_t);
 
-            static ggml_cl_buffer buf_trans_q;
+            static ggml_cl_buffer buf_trans_qs;
             static ggml_cl_buffer buf_trans_d;
-            static ggml_cl_buffer buf_trans_dm;
+            static ggml_cl_buffer buf_trans_dmin;
 
-            buf_trans_q.allocate(backend_ctx->context, size_q);
+            buf_trans_qs.allocate(backend_ctx->context, size_qs);
             buf_trans_d.allocate(backend_ctx->context, size_d);
-            buf_trans_dm.allocate(backend_ctx->context, size_dm);
+            buf_trans_dmin.allocate(backend_ctx->context, size_dmin);
 
-            // Transpose q, d, dm back
-            transpose_2d_as_16b(backend_ctx, extra->q,  buf_trans_q.buffer,  size_q,  M, K/4);
-            transpose_2d_as_16b(backend_ctx, extra->d,  buf_trans_d.buffer,  size_d,  M, K/256);
-            transpose_2d_as_16b(backend_ctx, extra->dm, buf_trans_dm.buffer, size_dm, M, K/256);
+            // Transpose qs, d, dmin back
+            transpose_2d_as_16b(backend_ctx, extra->qs,   buf_trans_qs.buffer,   size_qs,   M, K/4);
+            transpose_2d_as_16b(backend_ctx, extra->d,    buf_trans_d.buffer,    size_d,    M, K/256);
+            transpose_2d_as_16b(backend_ctx, extra->dmin, buf_trans_dmin.buffer, size_dmin, M, K/256);
 
             cl_kernel kernel = backend_ctx->kernel_restore_block_q4_K_noshuffle;
-            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &buf_trans_q.buffer));
-            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->s));
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &buf_trans_qs.buffer));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->scales));
             CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &buf_trans_d.buffer));
-            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &buf_trans_dm.buffer));
+            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &buf_trans_dmin.buffer));
             CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &data_device));
             CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_uchar), &mask_0F));
             CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_uchar), &mask_F0));
@@ -5635,13 +6350,42 @@ static void ggml_backend_opencl_buffer_get_tensor(ggml_backend_buffer_t buffer, 
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
         cl_kernel kernel = backend_ctx->kernel_restore_block_q4_K;
-        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->q));
-        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->s));
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->qs));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->scales));
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->d));
-        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->dm));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->dmin));
         CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &data_device));
         CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_uchar), &mask_0F));
         CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_uchar), &mask_F0));
+
+        size_t global_work_size[] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
+        size_t local_work_size[] = {1, 1, 1};
+
+        cl_event evt;
+        CL_CHECK(clEnqueueNDRangeKernel(queue, kernel, 3, NULL,
+            global_work_size, local_work_size, 0, NULL, &evt));
+        CL_CHECK(clWaitForEvents(1, &evt));
+        CL_CHECK(clEnqueueReadBuffer(
+            queue, data_device, CL_TRUE, offset,
+            size, data, 0, NULL, NULL));
+        CL_CHECK(clReleaseMemObject(data_device));
+        return;
+    }
+    if (tensor->type == GGML_TYPE_Q4_K &&
+        ggml_opencl_uses_local_subgroup_compat(backend_ctx)) {
+        ggml_tensor_extra_cl_q4_K * extra = (ggml_tensor_extra_cl_q4_K *)tensor->extra;
+
+        cl_int err;
+        cl_mem data_device = clCreateBuffer(context, CL_MEM_READ_WRITE,
+            ggml_nbytes(tensor), NULL, &err);
+        CL_CHECK(err);
+
+        cl_kernel kernel = backend_ctx->kernel_restore_block_q4_K;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->d));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->dmin));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &extra->scales));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &extra->qs));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem), &data_device));
 
         size_t global_work_size[] = {(size_t)ggml_nelements(tensor)/ggml_blck_size(tensor->type), 1, 1};
         size_t local_work_size[] = {1, 1, 1};
@@ -5760,8 +6504,11 @@ static void ggml_backend_opencl_buffer_clear(ggml_backend_buffer_t buffer, uint8
     cl_command_queue queue = backend_ctx->queue;
 
     ggml_backend_opencl_buffer_context * ctx = (ggml_backend_opencl_buffer_context *) buffer->context;
-    for (cl_mem buf : ctx->buffer) {
-        CL_CHECK(clEnqueueFillBuffer(queue, buf, &value, sizeof(value), 0, buffer->size, 0, NULL, NULL));
+    for (size_t i = 0; i < ctx->buffer.size(); ++i) {
+        cl_mem buf = ctx->buffer[i];
+        size_t mem_size = 0;
+        CL_CHECK(clGetMemObjectInfo(buf, CL_MEM_SIZE, sizeof(mem_size), &mem_size, NULL));
+        CL_CHECK(clEnqueueFillBuffer(queue, buf, &value, sizeof(value), 0, mem_size, 0, NULL, NULL));
     }
     CL_CHECK(clFinish(queue));
 }
@@ -5801,13 +6548,15 @@ static ggml_backend_buffer_t ggml_backend_opencl_buffer_type_alloc_buffer(ggml_b
 
     cl_int err;
     cl_mem mem = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, size, NULL, &err);
+#ifndef __APPLE__
     if (err != CL_SUCCESS && backend_ctx->adreno_use_large_buffer) {
         cl_mem_properties props[] = { 0x41A6 /* CL_LARGE_BUFFER_QCOM */, 1, 0 };
         mem = clCreateBufferWithProperties(backend_ctx->context, props, CL_MEM_READ_WRITE, size, NULL, &err);
     }
-
+#endif
     if (err != CL_SUCCESS) {
-        GGML_LOG_INFO("%s: failed to allocate %.2f MiB\n", __func__, size / 1024.0 / 1024.0);
+        GGML_LOG_INFO("%s: failed to allocate %.2f MiB (err = %d, context = %p)\n",
+                __func__, size / 1024.0 / 1024.0, err, (void *) backend_ctx->context);
         return nullptr;
     }
 
@@ -6216,6 +6965,14 @@ static void ggml_cl_copy_to_contiguous(ggml_backend_t backend, const ggml_tensor
     cl_ulong offset0 = extra->offset + src->view_offs;
     cl_ulong offsetd = 0;
 
+    const size_t size = ggml_nbytes(src);
+    if (ggml_is_contiguous(src) && ggml_opencl_use_copy_buffer_fast_path(backend_ctx, size)) {
+        if (size > 0) {
+            backend_ctx->enqueue_copy_buffer(extra->data_device, dst, offset0, offsetd, size, src, "cpy_contiguous_buffer");
+        }
+        return;
+    }
+
     cl_kernel kernel;
 
     switch (src->type) {
@@ -6324,14 +7081,28 @@ static void ggml_cl_get_rows(ggml_backend_t backend, const ggml_tensor * src0, c
     CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_ulong), &nb2));
     CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_ulong), &nb3));
 
-    int max_workgroup_size = backend_ctx->get_kernel_workgroup_size(kernel);
-    int nth = 1;
-    while (nth < ne00 && 2*nth <= max_workgroup_size) {
-        nth *= 2;
-    }
-
-    size_t global_work_size[] = {(size_t)ne10*nth, (size_t)ne11, (size_t)ne12};
-    size_t local_work_size[] = {(size_t)nth, 1, 1};
+    // Dispatch policy:
+    //   ne_per_row >= 64 (typical: ne00=2560 for F32/F16, ne00/16=160 for Q4_0):
+    //     Chunk scheme — local_size=64, num_chunks = ceil(ne_per_row/64) groups per row.
+    //     F32/F16: each thread handles 4 elements (float4/half4→float4), so
+    //       ne_per_row = ne00/4.  For ne10=1, ne00=2560: 10 groups × 2 warps = 20 warps.
+    //     Q4_0: ne_per_row = ne00/16 (float16 block per thread), unchanged.
+    //     group_id / num_chunks and group_id % num_chunks are workgroup-uniform, so
+    //     NVIDIA emits a single scalar divide per block rather than a per-lane divide.
+    //     Thread 0 per workgroup reads r and stores row offsets to local memory;
+    //     all other threads read from local memory instead of issuing global loads.
+    //   ne_per_row < 64 (small rows):
+    //     Row-oriented fallback — one group per row, local_size = ne_per_row.
+    //     Avoids over-chunking with mostly-idle workgroups.
+    // F32/F16 kernels process 4 elements per thread (float4); ne00 must be divisible
+    // by 4, which holds for all standard embedding dimensions.
+    const size_t ne_per_row = (src0->type == GGML_TYPE_Q4_0) ? (size_t)ne00 / 16
+                            : (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16) ? (size_t)ne00 / 4
+                            : (size_t)ne00;
+    const size_t local_size = (ne_per_row >= 64) ? 64 : ne_per_row;
+    const size_t num_chunks = (ne_per_row + local_size - 1) / local_size;
+    size_t global_work_size[] = {(size_t)ne10 * num_chunks * local_size, (size_t)ne11, (size_t)ne12};
+    size_t local_work_size[] = {local_size, 1, 1};
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
 }
@@ -7271,10 +8042,14 @@ static void ggml_cl_ssm_conv(ggml_backend_t backend, const ggml_tensor * src0, c
     cl_ulong nb2 = dst->nb[2];
 
     cl_kernel kernel = backend_ctx->kernel_ssm_conv_f32_f32;
-
-    if (ne10 % 4 == 0) {
-        kernel = backend_ctx->kernel_ssm_conv_f32_f32_4;
-    }
+    const bool can_vectorize_src0 =
+        ((offset0 % 16) == 0) &&
+        ((nb00 % 16) == 0) &&
+        ((nb01 % 16) == 0) &&
+        ((nb02 % 16) == 0);
+    const bool can_vectorize_src1 =
+        ((offset1 % 16) == 0) &&
+        ((nb11 % 16) == 0);
 
     CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0->data_device));
     CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_ulong), &offset0));
@@ -7290,6 +8065,10 @@ static void ggml_cl_ssm_conv(ggml_backend_t backend, const ggml_tensor * src0, c
     CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong), &nb0));
     CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_ulong), &nb1));
     CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_ulong), &nb2));
+
+    if (ne10 % 4 == 0 && can_vectorize_src0 && can_vectorize_src1) {
+        kernel = backend_ctx->kernel_ssm_conv_f32_f32_4;
+    }
 
     size_t global_work_size[] = {(size_t)ne01, (size_t)ne1, (size_t)ne2};
     size_t local_work_size[]  = {64, 1, 1};
@@ -7771,7 +8550,7 @@ static void ggml_cl_rms_norm(ggml_backend_t backend, const ggml_tensor * src0, c
     CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong),  &nb03));
     CL_CHECK(clSetKernelArg(kernel, 11, sizeof(float),     &eps));
     // This is local memory - the size depends on subgroup size.
-    CL_CHECK(clSetKernelArg(kernel, 12, sizeof(float)*nth/sgs,  NULL));
+    CL_CHECK(clSetKernelArg(kernel, 12, sizeof(float)*nth,  NULL));
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
 }
@@ -7882,7 +8661,10 @@ static void ggml_opencl_op_rms_norm_fused(ggml_backend_t backend, ggml_tensor * 
     CL_CHECK(clSetKernelArg(kernel, 21, sizeof(cl_ulong),      &nb2));
     CL_CHECK(clSetKernelArg(kernel, 22, sizeof(cl_ulong),      &nb3));
     CL_CHECK(clSetKernelArg(kernel, 23, sizeof(float),         &eps));
-    CL_CHECK(clSetKernelArg(kernel, 24, sizeof(float)*sgs,     NULL));
+    // NVIDIA uses __local tree reduction over nth elements; non-NVIDIA uses
+    // sub-group reduction over at most nth/sgs elements.  Allocate nth floats
+    // so both paths have enough room.
+    CL_CHECK(clSetKernelArg(kernel, 24, sizeof(float)*nth,     NULL));
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
 }
@@ -8092,6 +8874,7 @@ static void ggml_cl_l2_norm(ggml_backend_t backend, const ggml_tensor * src0, co
 
     GGML_TENSOR_LOCALS(int,      ne0, src0, ne);
     GGML_TENSOR_LOCALS(cl_ulong, nb0, src0, nb);
+    GGML_TENSOR_LOCALS(cl_ulong, db,  dst,  nb);
 
     size_t sgs;
     if (backend_ctx->gpu_family == ADRENO) {
@@ -8120,8 +8903,11 @@ static void ggml_cl_l2_norm(ggml_backend_t backend, const ggml_tensor * src0, co
     CL_CHECK(clSetKernelArg(kernel,  8, sizeof(cl_ulong),  &nb01));
     CL_CHECK(clSetKernelArg(kernel,  9, sizeof(cl_ulong),  &nb02));
     CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong),  &nb03));
-    CL_CHECK(clSetKernelArg(kernel, 11, sizeof(float),     &eps));
-    CL_CHECK(clSetKernelArg(kernel, 12, sizeof(float)*nth/sgs,  NULL));
+    CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong),  &db1));
+    CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_ulong),  &db2));
+    CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_ulong),  &db3));
+    CL_CHECK(clSetKernelArg(kernel, 14, sizeof(float),     &eps));
+    CL_CHECK(clSetKernelArg(kernel, 15, sizeof(float)*nth, NULL));
 
     size_t global_work_size[] = {(size_t)ne01*nth, (size_t)ne02, (size_t)ne03};
     size_t local_work_size[] = {(size_t)nth, 1, 1};
@@ -9216,7 +10002,7 @@ static void ggml_cl_conv_2d(ggml_backend_t backend, const ggml_tensor * src0, co
 
     if (src0->type == GGML_TYPE_F16 && src1->type == GGML_TYPE_F16) {
         kernel = backend_ctx->kernel_conv_2d_f16;
-        shmem_size = (size_t)(BS_K * BS_CRS * sizeof(cl_half) + BS_CRS * (BS_NPQ / VEC_SIZE) * sizeof(cl_half4));
+        shmem_size = (size_t)(BS_K * BS_CRS * sizeof(cl_half) + BS_CRS * (BS_NPQ / VEC_SIZE) * (4 * sizeof(cl_half)));
     } else if (src0->type == GGML_TYPE_F32 && src1->type == GGML_TYPE_F32) {
         kernel = backend_ctx->kernel_conv_2d_f32;
         shmem_size = (size_t)(BS_K * BS_CRS * sizeof(cl_float) + BS_CRS * (BS_NPQ / VEC_SIZE) * sizeof(cl_float4));
@@ -9865,7 +10651,7 @@ static void ggml_cl_mul_mat_q4_k_f32_adreno(ggml_backend_t backend, const ggml_t
         memset(&img_desc, 0, sizeof(img_desc));
         img_desc.image_type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
         img_desc.image_width = M * K / 2 / 4;
-        img_desc.buffer = extra0_q4_k->q;
+        img_desc.buffer = extra0_q4_k->qs;
         CL_CHECK((q_img = clCreateImage(context, CL_MEM_READ_ONLY, &img_fmt, &img_desc, NULL, &err), err));
 
         // subbuffer for activations
@@ -9885,8 +10671,8 @@ static void ggml_cl_mul_mat_q4_k_f32_adreno(ggml_backend_t backend, const ggml_t
 
         CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &q_img));
         CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem),   &extra0_q4_k->d));
-        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &extra0_q4_k->dm));
-        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem),   &extra0_q4_k->s));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &extra0_q4_k->dmin));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem),   &extra0_q4_k->scales));
         CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem),   &b_img));
         CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem),   &extrad->data_device));
         CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_ulong), &offsetd));
@@ -9968,10 +10754,10 @@ static void ggml_cl_mul_mat_q4_k_f32_adreno(ggml_backend_t backend, const ggml_t
         kernel = backend_ctx->kernel_gemm_noshuffle_q4_k_f32;
         int padded_N = N + padding;
 
-        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra0_q4_k->q));
-        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem),   &extra0_q4_k->s));
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra0_q4_k->qs));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem),   &extra0_q4_k->scales));
         CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &extra0_q4_k->d));
-        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem),   &extra0_q4_k->dm));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem),   &extra0_q4_k->dmin));
         CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem),   &b_img_trans));
         CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_mem),   &extrad->data_device));
         CL_CHECK(clSetKernelArg(kernel, 6, sizeof(cl_ulong), &offsetd));
@@ -10214,6 +11000,7 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
 #ifdef GGML_OPENCL_SOA_Q
     ggml_tensor_extra_cl_q4_0 * extra0_q4_0 = (ggml_tensor_extra_cl_q4_0 *)src0->extra;
     ggml_tensor_extra_cl_q4_1 * extra0_q4_1 = (ggml_tensor_extra_cl_q4_1 *)src0->extra;
+    ggml_tensor_extra_cl_q5_0 * extra0_q5_0 = (ggml_tensor_extra_cl_q5_0 *)src0->extra;
     ggml_tensor_extra_cl_mxfp4 * extra0_mxfp4 = (ggml_tensor_extra_cl_mxfp4 *)src0->extra;
     ggml_tensor_extra_cl_q8_0 * extra0_q8_0 = (ggml_tensor_extra_cl_q8_0 *)src0->extra;
     ggml_tensor_extra_cl_q4_K * extra0_q4_K = (ggml_tensor_extra_cl_q4_K *)src0->extra;
@@ -10259,7 +11046,8 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
     cl_context context = backend_ctx->context;
 
-    if(src0t == GGML_TYPE_F16 && src1t == GGML_TYPE_F32){
+    if (backend_ctx->gpu_family == GPU_FAMILY::ADRENO &&
+        src0t == GGML_TYPE_F16 && src1t == GGML_TYPE_F32) {
         if (ne01 >= 64 && ne1 >= 32 && ne00 >= 16 && (ne12 % ne02) == 0  &&
             // dst is wrapped with image1d_buffer, the size limit applies, also src0
             (ne0 * ne1 * dst->ne[2] * dst->nb[0] / 4 <= backend_ctx->image_max_buffer_size)) {
@@ -10283,6 +11071,41 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             }
         }
     }
+
+    // Q4_0 x fp32 — Apple buffer path (no image1d_buffer_t)
+#ifdef GGML_OPENCL_SOA_Q
+    if (src0t == GGML_TYPE_Q4_0 && src1t == GGML_TYPE_F32 &&
+        backend_ctx->gpu_family == GPU_FAMILY::APPLE && ne11 == 1) {
+        int M_a = ne01;
+        cl_kernel apple_kernel = backend_ctx->kernel_gemv_q4_0_f32_apple;
+        cl_uint k_arg = 0;
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(cl_mem),   &extra0_q4_0->q));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(cl_mem),   &extra0_q4_0->d));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(cl_mem),   &extra1->data_device));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(cl_ulong), &offset1));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(cl_mem),   &extrad->data_device));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(cl_ulong), &offsetd));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &ne00));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &ne01));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &ne02));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &ne10));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &ne12));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &ne0));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &ne1));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &r2));
+        CL_CHECK(clSetKernelArg(apple_kernel, k_arg++, sizeof(int),      &r3));
+
+        size_t wavesize = (size_t)backend_ctx->adreno_wave_size;  // 32 for Apple
+        size_t global_work_size[3] = {
+            ((size_t)(M_a / 2) + wavesize - 1) / wavesize * wavesize,
+            4,  // N_SIMDGROUP
+            1
+        };
+        size_t local_work_size[3] = { wavesize, 4, 1 };
+        backend_ctx->enqueue_ndrange_kernel(apple_kernel, 3, global_work_size, local_work_size, dst);
+        return;
+    }
+#endif // GGML_OPENCL_SOA_Q
 
     if (ne01 && ne1 && use_adreno_kernels(backend_ctx, src0)) {
 
@@ -10313,8 +11136,10 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
     // a limit check, but q4_0 / q4_1 tensors are very unlikely to exceed that
     // limit, so the check is omitted.
 
-    // q4_1 x fp32
-    if (src0t == GGML_TYPE_Q4_1 && src1t == GGML_TYPE_F32) {
+    // q4_1 x fp32 — Adreno-specific path; NVIDIA uses the flat kernel in the switch below
+    if (src0t == GGML_TYPE_Q4_1 && src1t == GGML_TYPE_F32 &&
+        !backend_ctx->use_no_subgroups_compat &&
+        backend_ctx->device_name.find("NVIDIA") == std::string::npos) {
             ggml_cl_mul_mat_q4_1_f32_adreno(backend, src0, src1, dst);
             return;
     }
@@ -10338,8 +11163,10 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         return;
     }
 
-    // q4_0 x fp32
-    if(src0t == GGML_TYPE_Q4_0 && src1t == GGML_TYPE_F32) {
+    // q4_0 x fp32 — Adreno-specific image path; NVIDIA uses the flat kernel in the switch below
+    if(src0t == GGML_TYPE_Q4_0 && src1t == GGML_TYPE_F32 &&
+       !backend_ctx->use_no_subgroups_compat &&
+       backend_ctx->device_name.find("NVIDIA") == std::string::npos) {
         // TODO: remove duplicate definitions of image description + format -- move to top
 
         // create an image for A
@@ -10892,10 +11719,10 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 int batch_stride_b = ne10*ne11;
                 int batch_stride_d = ne0*ne1;
 
-                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_K->q));
-                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_K->s));
+                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_K->qs));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_K->scales));
                 CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q4_K->d));
-                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q4_K->dm));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q4_K->dmin));
                 CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
                 CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offset1));
                 CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
@@ -10986,7 +11813,9 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         !ggml_is_transposed(src1) &&
         src1t == GGML_TYPE_F32 &&
         ne00%32 == 0 &&
-        ne11 > 2) {
+        ne11 > 2 &&
+        !backend_ctx->use_no_subgroups_compat &&
+        backend_ctx->device_name.find("NVIDIA") == std::string::npos) {
 #ifdef GGML_OPENCL_SOA_Q
         // Set up kernel.
         switch(src0t) {
@@ -11105,8 +11934,12 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             }
 
             if (src1t == GGML_TYPE_F32) {
+                const bool use_local_subgroup_compat = ggml_opencl_uses_local_subgroup_compat(backend_ctx);
                 if (ne11 * ne12 < 4) {
                     kernel = backend_ctx->kernel_mul_mat_f16_f32_1row;
+                } else if (use_local_subgroup_compat) {
+                    kernel = backend_ctx->kernel_mul_mat_f16_f32;
+                    nrows = 4;
                 } else if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
                     kernel = backend_ctx->kernel_mul_mat_f16_f32_l4;
                     nrows = ne11;
@@ -11150,18 +11983,17 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             GGML_ASSERT(ne01 == ne0);
 
 #ifdef GGML_OPENCL_SOA_Q
-            if (backend_ctx->gpu_family == INTEL) {
+            kernel = backend_ctx->kernel_mul_mat_q4_0_f32_8x_flat;
+            ndst = 8;
+            if (ggml_opencl_uses_local_subgroup_compat(backend_ctx)) {
+                nth0 = 32; // one warp; __local float8 tree-reduction inside kernel
+                nth1 = 1;
+            } else if (backend_ctx->gpu_family == INTEL) {
                 nth0 = 16;
                 nth1 = 1;
-
-                kernel = backend_ctx->kernel_mul_mat_q4_0_f32_8x_flat;
-                ndst = 8;
             } else if (backend_ctx->gpu_family == ADRENO) {
                 nth0 = 64;
                 nth1 = 1;
-
-                kernel = backend_ctx->kernel_mul_mat_q4_0_f32_8x_flat;
-                ndst =8;
             } else {
                 GGML_ASSERT(false && "TODO: Unknown GPU");
             }
@@ -11221,19 +12053,20 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             break;
         case GGML_TYPE_Q4_1: {
 #ifdef GGML_OPENCL_SOA_Q
-            if (backend_ctx->gpu_family == INTEL) {
+            kernel = backend_ctx->kernel_mul_mv_q4_1_f32_flat;
+            ndst = 4;
+            if (ggml_opencl_uses_local_subgroup_compat(backend_ctx)) {
+                nth0 = 32; // one warp; __local float4 tree-reduction inside kernel
+                nth1 = 1;
+            } else if (backend_ctx->gpu_family == INTEL) {
                 nth0 = 16;
                 nth1 = 1;
-                ndst = 4;
             } else if (backend_ctx->gpu_family == ADRENO) {
                 nth0 = 64;
                 nth1 = 1;
-                ndst = 4;
             } else {
                 GGML_ASSERT(false && "TODO: Unknown GPU");
             }
-
-            kernel = backend_ctx->kernel_mul_mv_q4_1_f32_flat;
 
             CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_1->q));
             CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_1->d));
@@ -11284,6 +12117,40 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
 #endif // GGML_OPENCL_SOA_Q
             break;
         }
+        case GGML_TYPE_Q5_0: {
+#ifdef GGML_OPENCL_SOA_Q
+            GGML_ASSERT(backend_ctx->device_name.find("NVIDIA") != std::string::npos);
+
+            kernel = backend_ctx->kernel_mul_mv_q5_0_f32_flat;
+            nth0 = 1;
+            nth1 = 1;
+            ndst = 4;
+
+            CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q5_0->q));
+            CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q5_0->qh));
+            CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q5_0->d));
+            CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra1->data_device));
+            CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_ulong), &offset1));
+            CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_mem),   &extrad->data_device));
+            CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_ulong), &offsetd));
+            CL_CHECK(clSetKernelArg(kernel,  7, sizeof(int),      &ne00));
+            CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne01));
+            CL_CHECK(clSetKernelArg(kernel,  9, sizeof(cl_ulong), &nb01));
+            CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &nb02));
+            CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong), &nb03));
+            CL_CHECK(clSetKernelArg(kernel, 12, sizeof(int),      &ne12));
+            CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_ulong), &nb11));
+            CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_ulong), &nb12));
+            CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_ulong), &nb13));
+            CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &ne0));
+            CL_CHECK(clSetKernelArg(kernel, 17, sizeof(int),      &ne1));
+            CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),      &r2));
+            CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int),      &r3));
+#else
+            GGML_ASSERT(false && "Q5_0 OpenCL matmul requires GGML_OPENCL_SOA_Q");
+#endif
+            break;
+        }
         case GGML_TYPE_Q8_0: {
 #ifdef GGML_OPENCL_SOA_Q
             kernel = backend_ctx->kernel_mul_mv_q8_0_f32_flat;
@@ -11291,7 +12158,11 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             // nth0 - subgroup size
             // nth1 - number of subgroups per workgroup
             // ndst - number of output values per workgroup = output per subgroup * number of subgroups
-            if (backend_ctx->gpu_family == INTEL) {
+            if (ggml_opencl_uses_local_subgroup_compat(backend_ctx)) {
+                nth0 = 32; // N_SIMDWIDTH (warp size)
+                nth1 = 1;  // N_SG_Q8_0
+                ndst = 4;  // N_R0_Q8_0
+            } else if (backend_ctx->gpu_family == INTEL) {
                 nth0 = 16;
                 nth1 = 2;
                 ndst = nth1*4;
@@ -11366,45 +12237,84 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K: {
 #ifdef GGML_OPENCL_SOA_Q
-            kernel = backend_ctx->kernel_mul_mv_q4_K_f32_flat;
-
-            if (backend_ctx->gpu_family == INTEL) {
-                nth0 = 16;
+            if (src0t == GGML_TYPE_Q4_K && ggml_opencl_uses_local_subgroup_compat(backend_ctx)) {
+                kernel = backend_ctx->kernel_mul_mv_q4_K_f32_flat;
+                nth0 = 32;  // one warp; __local tree-reduction
                 nth1 = 1;
                 ndst = 4;
-            } else if (backend_ctx->gpu_family == ADRENO) {
-                nth0 = 64;
-                nth1 = 2;
-                ndst = 16;
-            } else {
-                GGML_ASSERT(false && "TODO: Unknown GPU");
-            }
 
-            CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_K->q));
-            CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_K->s));
-            CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q4_K->d));
-            CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q4_K->dm));
-            CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
-            CL_CHECK(clSetKernelArg(kernel,  5, sizeof(int),      &offset1));
-            CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
-            CL_CHECK(clSetKernelArg(kernel,  7, sizeof(int),      &offsetd));
-            CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
-            CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
-            CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &nb01));
-            CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong), &nb02));
-            CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_ulong), &nb03));
-            CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne12));
-            CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_ulong), &nb11));
-            CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_ulong), &nb12));
-            CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_ulong), &nb13));
-            CL_CHECK(clSetKernelArg(kernel, 17, sizeof(int),      &ne0));
-            CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),      &ne1));
-            CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int),      &r2));
-            CL_CHECK(clSetKernelArg(kernel, 20, sizeof(int),      &r3));
-#else
+                int ne02_i = (int)src0->ne[2];
+                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_K->qs));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_K->scales));
+                CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q4_K->d));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q4_K->dmin));
+                CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  5, sizeof(int),      &offset1));
+                CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  7, sizeof(int),      &offsetd));
+                CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
+                CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
+                CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int),      &ne02_i));
+                CL_CHECK(clSetKernelArg(kernel, 11, sizeof(int),      &ne12));
+                CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_ulong), &nb11));
+                CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_ulong), &nb12));
+                CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_ulong), &nb13));
+                CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &ne0));
+                CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &ne1));
+                CL_CHECK(clSetKernelArg(kernel, 17, sizeof(int),      &r2));
+                CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),      &r3));
+                break;
+            } else {
+                kernel = backend_ctx->kernel_mul_mv_q4_K_f32_flat;
+
+                if (backend_ctx->gpu_family == INTEL) {
+                    nth0 = 16;
+                    nth1 = 1;
+                    ndst = 4;
+                } else if (backend_ctx->gpu_family == ADRENO) {
+                    nth0 = 64;
+                    nth1 = 2;
+                    ndst = 16;
+                } else {
+                    GGML_ASSERT(false && "TODO: Unknown GPU");
+                }
+
+                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q4_K->qs));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q4_K->scales));
+                CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q4_K->d));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q4_K->dmin));
+                CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  5, sizeof(int),      &offset1));
+                CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  7, sizeof(int),      &offsetd));
+                CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
+                CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
+                CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &nb01));
+                CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong), &nb02));
+                CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_ulong), &nb03));
+                CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne12));
+                CL_CHECK(clSetKernelArg(kernel, 14, sizeof(cl_ulong), &nb11));
+                CL_CHECK(clSetKernelArg(kernel, 15, sizeof(cl_ulong), &nb12));
+                CL_CHECK(clSetKernelArg(kernel, 16, sizeof(cl_ulong), &nb13));
+                CL_CHECK(clSetKernelArg(kernel, 17, sizeof(int),      &ne0));
+                CL_CHECK(clSetKernelArg(kernel, 18, sizeof(int),      &ne1));
+                CL_CHECK(clSetKernelArg(kernel, 19, sizeof(int),      &r2));
+                CL_CHECK(clSetKernelArg(kernel, 20, sizeof(int),      &r3));
+                break;
+            }
+#else // GGML_OPENCL_SOA_Q
+
             kernel = backend_ctx->kernel_mul_mv_q4_K_f32;
 
-            if (backend_ctx->gpu_family == INTEL) {
+            if (ggml_opencl_uses_local_subgroup_compat(backend_ctx)) {
+                nth0 = 32;
+                nth1 = 1;
+                ndst = 4;
+            } else if (backend_ctx->gpu_family == INTEL) {
+                // nth0=16 for both true Intel and Apple M1 compat mode.
+                // In compat mode the kernel overrides BLOCK_STRIDE to 2 so
+                // that ix ∈ {0,1} (lid/8 with 16 threads) covers all
+                // super-blocks, and uses lm[N_DST*16] for the tree-reduction.
                 nth0 = 16;
                 nth1 = 1;
                 ndst = 4;
@@ -11441,37 +12351,78 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         case GGML_TYPE_Q5_K:
         case GGML_TYPE_Q6_K:
 #ifdef GGML_OPENCL_SOA_Q
-            kernel = backend_ctx->kernel_mul_mv_q6_K_f32_flat;
+            if (ggml_opencl_uses_local_subgroup_compat(backend_ctx)) {
+                kernel = backend_ctx->kernel_mul_mv_q6_K_f32_flat;
+                nth0 = 32; // one warp (32 lanes); __local tree-reduction inside kernel
+                nth1 = 1;  // N_SIMDGROUP=1 for NVIDIA (overridden in kernel source)
+                ndst = 4;
 
-            if (backend_ctx->gpu_family == INTEL) {
+                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q6_K->ql));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q6_K->qh));
+                CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q6_K->s));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q6_K->d));
+                CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offset1));
+                CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  7, sizeof(cl_ulong), &offsetd));
+                CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
+                CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
+                CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int),      &ne02));
+                CL_CHECK(clSetKernelArg(kernel, 11, sizeof(int),      &ne10));
+                CL_CHECK(clSetKernelArg(kernel, 12, sizeof(int),      &ne12));
+                CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne0));
+                CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int),      &ne1));
+                CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &r2));
+                CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &r3));
+            } else if (backend_ctx->gpu_family == INTEL) {
+                kernel = backend_ctx->kernel_mul_mv_q6_K_f32_flat;
                 nth0 = 16;
                 nth1 = 2;
                 ndst = 4;
+
+                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q6_K->ql));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q6_K->qh));
+                CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q6_K->s));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q6_K->d));
+                CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offset1));
+                CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  7, sizeof(cl_ulong), &offsetd));
+                CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
+                CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
+                CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int),      &ne02));
+                CL_CHECK(clSetKernelArg(kernel, 11, sizeof(int),      &ne10));
+                CL_CHECK(clSetKernelArg(kernel, 12, sizeof(int),      &ne12));
+                CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne0));
+                CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int),      &ne1));
+                CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &r2));
+                CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &r3));
             } else if (backend_ctx->gpu_family == ADRENO) {
+                kernel = backend_ctx->kernel_mul_mv_q6_K_f32_flat;
                 nth0 = 64;
                 nth1 = 2;
                 ndst = 4;
+
+                CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q6_K->ql));
+                CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q6_K->qh));
+                CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q6_K->s));
+                CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q6_K->d));
+                CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offset1));
+                CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
+                CL_CHECK(clSetKernelArg(kernel,  7, sizeof(cl_ulong), &offsetd));
+                CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
+                CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
+                CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int),      &ne02));
+                CL_CHECK(clSetKernelArg(kernel, 11, sizeof(int),      &ne10));
+                CL_CHECK(clSetKernelArg(kernel, 12, sizeof(int),      &ne12));
+                CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne0));
+                CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int),      &ne1));
+                CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &r2));
+                CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &r3));
             } else {
                 GGML_ASSERT(false && "TODO: Unknown GPU");
             }
-
-            CL_CHECK(clSetKernelArg(kernel,  0, sizeof(cl_mem),   &extra0_q6_K->ql));
-            CL_CHECK(clSetKernelArg(kernel,  1, sizeof(cl_mem),   &extra0_q6_K->qh));
-            CL_CHECK(clSetKernelArg(kernel,  2, sizeof(cl_mem),   &extra0_q6_K->s));
-            CL_CHECK(clSetKernelArg(kernel,  3, sizeof(cl_mem),   &extra0_q6_K->d));
-            CL_CHECK(clSetKernelArg(kernel,  4, sizeof(cl_mem),   &extra1->data_device));
-            CL_CHECK(clSetKernelArg(kernel,  5, sizeof(cl_ulong), &offset1));
-            CL_CHECK(clSetKernelArg(kernel,  6, sizeof(cl_mem),   &extrad->data_device));
-            CL_CHECK(clSetKernelArg(kernel,  7, sizeof(cl_ulong), &offsetd));
-            CL_CHECK(clSetKernelArg(kernel,  8, sizeof(int),      &ne00));
-            CL_CHECK(clSetKernelArg(kernel,  9, sizeof(int),      &ne01));
-            CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int),      &ne02));
-            CL_CHECK(clSetKernelArg(kernel, 11, sizeof(int),      &ne10));
-            CL_CHECK(clSetKernelArg(kernel, 12, sizeof(int),      &ne12));
-            CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int),      &ne0));
-            CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int),      &ne1));
-            CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &r2));
-            CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &r3));
 #else
             kernel = backend_ctx->kernel_mul_mv_q6_K_f32;
 
@@ -11509,7 +12460,13 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             kernel = backend_ctx->kernel_mul_mv_mxfp4_f32_flat;
 
             cl_mem q;
-            if (backend_ctx->gpu_family == INTEL) {
+            if (backend_ctx->device_name.find("NVIDIA") != std::string::npos) {
+                nth0 = 1;
+                nth1 = 1;
+                ndst = 2;
+
+                q = extra0_mxfp4->q;
+            } else if (backend_ctx->gpu_family == INTEL) {
                 nth0 = 16;
                 nth1 = 2;
                 ndst = nth1*2;
@@ -11922,7 +12879,13 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
             kernel = backend_ctx->kernel_mul_mv_id_mxfp4_f32_flat;
 
             cl_mem q;
-            if (backend_ctx->gpu_family == INTEL) {
+            if (backend_ctx->device_name.find("NVIDIA") != std::string::npos) {
+                sgs  = 1;
+                nsg  = 1;
+                ndst = 2;
+
+                q = extra0_mxfp4->q;
+            } else if (backend_ctx->gpu_family == INTEL) {
                 sgs  = 16;
                 nsg  = 2;
                 ndst = 2;
@@ -12094,6 +13057,23 @@ static void ggml_cl_cpy(ggml_backend_t backend, const ggml_tensor * src0, const 
 
     cl_ulong offset0 = extra0->offset + src0->view_offs;
     cl_ulong offset1 = extra1->offset + src1->view_offs;
+
+    if (src0t == src1t &&
+        ggml_is_contiguous(src0) &&
+        ggml_is_contiguous(src1) &&
+        ggml_nbytes(src0) == ggml_nbytes(src1)) {
+        if (extra0->data_device == extra1->data_device && offset0 == offset1) {
+            return;
+        }
+
+        const size_t size = ggml_nbytes(src0);
+        if (ggml_opencl_use_copy_buffer_fast_path(backend_ctx, size)) {
+            if (size > 0) {
+                backend_ctx->enqueue_copy_buffer(extra0->data_device, extra1->data_device, offset0, offset1, size, src1, "cpy_same_type_buffer");
+            }
+            return;
+        }
+    }
 
     cl_kernel kernel;
 
@@ -12728,8 +13708,135 @@ static void ggml_cl_solve_tri(ggml_backend_t backend, const ggml_tensor * src0, 
     CL_CHECK(clSetKernelArg(kernel, 18, sizeof(cl_ulong),&nb2));
     CL_CHECK(clSetKernelArg(kernel, 19, sizeof(cl_ulong),&nb3));
 
-    size_t global_work_size[3]= { (size_t)k, (size_t)dst->ne[2], (size_t)dst->ne[3]};
-    size_t local_work_size[] = {16, 4, 1};
+    size_t global_work_size[3] = { (size_t)k, (size_t)dst->ne[2], (size_t)dst->ne[3] };
+    size_t local_work_size[3] = {
+        MIN((size_t)16, global_work_size[0]),
+        MIN((size_t)4,  global_work_size[1]),
+        1,
+    };
+
+    size_t * local_work_size_ptr = local_work_size;
+    if ((global_work_size[0] % local_work_size[0] != 0 ||
+         global_work_size[1] % local_work_size[1] != 0 ||
+         global_work_size[2] % local_work_size[2] != 0) &&
+        !backend_ctx->non_uniform_workgroups) {
+        local_work_size_ptr = nullptr;
+    }
+
+    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size_ptr, dst);
+}
+
+static void ggml_cl_gated_delta_net(ggml_backend_t backend, ggml_tensor * dst) {
+    ggml_tensor * src_q     = dst->src[0];
+    ggml_tensor * src_k     = dst->src[1];
+    ggml_tensor * src_v     = dst->src[2];
+    ggml_tensor * src_g     = dst->src[3];
+    ggml_tensor * src_beta  = dst->src[4];
+    ggml_tensor * src_state = dst->src[5];
+
+    GGML_ASSERT(src_q && src_k && src_v && src_g && src_beta && src_state && dst);
+    GGML_ASSERT(src_q->extra && src_k->extra && src_v->extra && src_g->extra && src_beta->extra && src_state->extra && dst->extra);
+
+    GGML_ASSERT(src_q->type == GGML_TYPE_F32);
+    GGML_ASSERT(src_k->type == GGML_TYPE_F32);
+    GGML_ASSERT(src_v->type == GGML_TYPE_F32);
+    GGML_ASSERT(src_g->type == GGML_TYPE_F32);
+    GGML_ASSERT(src_beta->type == GGML_TYPE_F32);
+    GGML_ASSERT(src_state->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
+
+    GGML_ASSERT(ggml_is_contiguous_rows(src_q));
+    GGML_ASSERT(ggml_is_contiguous_rows(src_k));
+    GGML_ASSERT(ggml_is_contiguous_rows(src_v));
+    GGML_ASSERT(ggml_are_same_stride(src_q, src_k));
+    GGML_ASSERT(ggml_is_contiguous(src_g));
+    GGML_ASSERT(ggml_is_contiguous(src_beta));
+    GGML_ASSERT(ggml_is_contiguous(src_state));
+    GGML_ASSERT(ggml_is_contiguous(dst));
+
+    ggml_backend_opencl_context * backend_ctx = (ggml_backend_opencl_context *) backend->context;
+    cl_kernel kernel = backend_ctx->kernel_gated_delta_net_f32;
+    GGML_ASSERT(kernel != nullptr);
+
+    ggml_tensor_extra_cl * extra_q     = (ggml_tensor_extra_cl *) src_q->extra;
+    ggml_tensor_extra_cl * extra_k     = (ggml_tensor_extra_cl *) src_k->extra;
+    ggml_tensor_extra_cl * extra_v     = (ggml_tensor_extra_cl *) src_v->extra;
+    ggml_tensor_extra_cl * extra_g     = (ggml_tensor_extra_cl *) src_g->extra;
+    ggml_tensor_extra_cl * extra_beta  = (ggml_tensor_extra_cl *) src_beta->extra;
+    ggml_tensor_extra_cl * extra_state = (ggml_tensor_extra_cl *) src_state->extra;
+    ggml_tensor_extra_cl * extra_dst   = (ggml_tensor_extra_cl *) dst->extra;
+
+    cl_ulong offset_q     = extra_q->offset     + src_q->view_offs;
+    cl_ulong offset_k     = extra_k->offset     + src_k->view_offs;
+    cl_ulong offset_v     = extra_v->offset     + src_v->view_offs;
+    cl_ulong offset_g     = extra_g->offset     + src_g->view_offs;
+    cl_ulong offset_beta  = extra_beta->offset  + src_beta->view_offs;
+    cl_ulong offset_state = extra_state->offset + src_state->view_offs;
+    cl_ulong offset_dst   = extra_dst->offset   + dst->view_offs;
+
+    const int64_t S_v      = src_v->ne[0];
+    const int64_t H        = src_v->ne[1];
+    const int64_t n_tokens = src_v->ne[2];
+    const int64_t n_seqs   = src_v->ne[3];
+    const bool kda = src_g->ne[0] == S_v;
+
+    GGML_ASSERT(S_v == 32 || S_v == 64 || S_v == 128);
+    GGML_ASSERT(src_g->ne[0] == 1 || kda);
+
+    const int rq1 = (int) (src_v->ne[1] / src_q->ne[1]);
+    const int rq3 = (int) (src_v->ne[3] / src_q->ne[3]);
+
+    const cl_ulong sq1 = src_q->nb[1];
+    const cl_ulong sq2 = src_q->nb[2];
+    const cl_ulong sq3 = src_q->nb[3];
+    const cl_ulong sv1 = src_v->nb[1];
+    const cl_ulong sv2 = src_v->nb[2];
+    const cl_ulong sv3 = src_v->nb[3];
+    const cl_ulong sb1 = src_beta->nb[1];
+    const cl_ulong sb2 = src_beta->nb[2];
+    const cl_ulong sb3 = src_beta->nb[3];
+
+    const int iH = (int) H;
+    const int in_tokens = (int) n_tokens;
+    const int in_seqs = (int) n_seqs;
+    const int iS_v = (int) S_v;
+    const int ikda = kda ? 1 : 0;
+    const float scale = 1.0f / sqrtf((float) S_v);
+
+    CL_CHECK(clSetKernelArg(kernel, 0,  sizeof(cl_mem),   &extra_q->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 1,  sizeof(cl_ulong), &offset_q));
+    CL_CHECK(clSetKernelArg(kernel, 2,  sizeof(cl_mem),   &extra_k->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 3,  sizeof(cl_ulong), &offset_k));
+    CL_CHECK(clSetKernelArg(kernel, 4,  sizeof(cl_mem),   &extra_v->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 5,  sizeof(cl_ulong), &offset_v));
+    CL_CHECK(clSetKernelArg(kernel, 6,  sizeof(cl_mem),   &extra_g->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 7,  sizeof(cl_ulong), &offset_g));
+    CL_CHECK(clSetKernelArg(kernel, 8,  sizeof(cl_mem),   &extra_beta->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 9,  sizeof(cl_ulong), &offset_beta));
+    CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_mem),   &extra_state->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong), &offset_state));
+    CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_mem),   &extra_dst->data_device));
+    CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_ulong), &offset_dst));
+    CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int),      &iH));
+    CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int),      &in_tokens));
+    CL_CHECK(clSetKernelArg(kernel, 16, sizeof(int),      &in_seqs));
+    CL_CHECK(clSetKernelArg(kernel, 17, sizeof(cl_ulong), &sq1));
+    CL_CHECK(clSetKernelArg(kernel, 18, sizeof(cl_ulong), &sq2));
+    CL_CHECK(clSetKernelArg(kernel, 19, sizeof(cl_ulong), &sq3));
+    CL_CHECK(clSetKernelArg(kernel, 20, sizeof(cl_ulong), &sv1));
+    CL_CHECK(clSetKernelArg(kernel, 21, sizeof(cl_ulong), &sv2));
+    CL_CHECK(clSetKernelArg(kernel, 22, sizeof(cl_ulong), &sv3));
+    CL_CHECK(clSetKernelArg(kernel, 23, sizeof(cl_ulong), &sb1));
+    CL_CHECK(clSetKernelArg(kernel, 24, sizeof(cl_ulong), &sb2));
+    CL_CHECK(clSetKernelArg(kernel, 25, sizeof(cl_ulong), &sb3));
+    CL_CHECK(clSetKernelArg(kernel, 26, sizeof(int),      &rq1));
+    CL_CHECK(clSetKernelArg(kernel, 27, sizeof(int),      &rq3));
+    CL_CHECK(clSetKernelArg(kernel, 28, sizeof(int),      &iS_v));
+    CL_CHECK(clSetKernelArg(kernel, 29, sizeof(int),      &ikda));
+    CL_CHECK(clSetKernelArg(kernel, 30, sizeof(float),    &scale));
+
+    size_t global_work_size[3] = { (size_t) S_v, (size_t) H, (size_t) n_seqs };
+    size_t local_work_size[3] = { (size_t) S_v, 1, 1 };
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
 }
@@ -13138,7 +14245,11 @@ static void ggml_cl_glu(ggml_backend_t backend, const ggml_tensor * src0, const 
     }
 
     const size_t nrows = ggml_nrows(src0);
-    size_t nth = 512;
+    const size_t kernel_max_workgroup_size = backend_ctx->get_kernel_workgroup_size(kernel);
+    size_t nth = MIN((size_t)512, (size_t)ne0);
+    nth = MIN(nth, kernel_max_workgroup_size);
+    nth = MIN(nth, backend_ctx->max_workgroup_size);
+    GGML_ASSERT(nth > 0);
     size_t global_work_size[] = {nrows*nth, 1, 1};
     size_t local_work_size[] = {nth, 1, 1};
 
@@ -13459,6 +14570,12 @@ bool ggml_cl_compute_forward(ggml_backend_t backend, struct ggml_tensor * tensor
             }
             func = ggml_cl_solve_tri;
             break;
+        case GGML_OP_GATED_DELTA_NET:
+            if (!any_on_device) {
+                return false;
+            }
+            ggml_cl_gated_delta_net(backend, tensor);
+            return true;
         case GGML_OP_IM2COL:
             if (!any_on_device) {
                 return false;

--- a/ggml/src/ggml-opencl/kernels/add.cl
+++ b/ggml/src/ggml-opencl/kernels/add.cl
@@ -137,13 +137,13 @@ kernel void kernel_add_f16(
 
         half v0, v1;
         if (type_src0 == 1) {
-            v0 = convert_half(*((global float *)(src0_ptr + i0*nb00)));
+            v0 = (half)(*((global float *)(src0_ptr + i0*nb00)));
         } else {
             v0 = *((global half *)(src0_ptr + i0*nb00));
         }
 
         if (type_src1 == 1) {
-            v1 = convert_half(*((global float *)(src1_ptr + i10*nb10)));
+            v1 = (half)(*((global float *)(src1_ptr + i10*nb10)));
         } else {
             v1 = *((global half *)(src1_ptr + i10*nb10));
         }
@@ -172,7 +172,8 @@ kernel void kernel_add_row_f16(
     half4 v0, v1;
     if (type_src0 == 1) {
         global float4* src0_f32 = (global float4*)((global char*)src0 + offset0);
-        v0 = convert_half4(src0_f32[gid]);
+        float4 tmp0 = src0_f32[gid];
+        v0 = (half4)((half)tmp0.x, (half)tmp0.y, (half)tmp0.z, (half)tmp0.w);
     } else {
         global half4* src0_f16 = (global half4*)((global char*)src0 + offset0);
         v0 = src0_f16[gid];
@@ -180,7 +181,8 @@ kernel void kernel_add_row_f16(
 
     if (type_src1 == 1) {
         global float4* src1_f32 = (global float4*)((global char*)src1 + offset1);
-        v1 = convert_half4(src1_f32[idx1]);
+        float4 tmp1 = src1_f32[idx1];
+        v1 = (half4)((half)tmp1.x, (half)tmp1.y, (half)tmp1.z, (half)tmp1.w);
     } else {
         global half4* src1_f16 = (global half4*)((global char*)src1 + offset1);
         v1 = src1_f16[idx1];

--- a/ggml/src/ggml-opencl/kernels/conv2d.cl
+++ b/ggml/src/ggml-opencl/kernels/conv2d.cl
@@ -143,8 +143,13 @@ kernel void kernel_conv_2d(
 
             for (uint npq_l_vec_reg = 0; npq_l_vec_reg < TS_NPQ_VEC; ++npq_l_vec_reg) {
                 T_FLOAT4 regB = Bsh[crs_l * BS_NPQ_VEC + lid_npq * TS_NPQ_VEC + npq_l_vec_reg];
+#ifdef USE_FP16
+                float4 regBf = (float4)((float)regB.s0, (float)regB.s1, (float)regB.s2, (float)regB.s3);
+#else
+                float4 regBf = regB;
+#endif
                 for (uint k_l_reg = 0; k_l_reg < TS_K; ++k_l_reg) {
-                    regC[k_l_reg][npq_l_vec_reg] = mad(convert_float(regA[k_l_reg]), convert_float4(regB), regC[k_l_reg][npq_l_vec_reg]);
+                    regC[k_l_reg][npq_l_vec_reg] = mad((float) regA[k_l_reg], regBf, regC[k_l_reg][npq_l_vec_reg]);
                 }
             }
         }

--- a/ggml/src/ggml-opencl/kernels/conv2d_f16_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/conv2d_f16_f32.cl
@@ -135,7 +135,7 @@ kernel void kernel_conv_2d(
             for (uint npq_l_vec_reg = 0; npq_l_vec_reg < TS_NPQ_VEC; ++npq_l_vec_reg) {
                 float4 regB = Bsh[crs_l * BS_NPQ_VEC + lid_npq * TS_NPQ_VEC + npq_l_vec_reg];
                 for (uint k_l_reg = 0; k_l_reg < TS_K; ++k_l_reg) {
-                    regC[k_l_reg][npq_l_vec_reg] = mad(convert_float(regA[k_l_reg]), regB, regC[k_l_reg][npq_l_vec_reg]);
+                    regC[k_l_reg][npq_l_vec_reg] = mad((float) regA[k_l_reg], regB, regC[k_l_reg][npq_l_vec_reg]);
                 }
             }
         }

--- a/ggml/src/ggml-opencl/kernels/cvt.cl
+++ b/ggml/src/ggml-opencl/kernels/cvt.cl
@@ -357,6 +357,56 @@ typedef struct {
     char qs[QK8_0]; // quants
 } block_q8_0;
 
+//------------------------------------------------------------------------------
+// block_q5_0
+//------------------------------------------------------------------------------
+#define QK5_0 32
+typedef struct {
+    half  d;           // delta
+    uchar qh[4];       // 5-th bit of quants
+    uchar qs[QK5_0/2]; // nibbles / quants
+} block_q5_0;
+
+kernel void kernel_convert_block_q5_0(
+    global block_q5_0 * src0,
+    global uchar * dst_q,
+    global uchar * dst_qh,
+    global half  * dst_d
+) {
+    global block_q5_0 * b  = (global block_q5_0 *) src0 + get_global_id(0);
+    global uchar      * q  = (global uchar *) dst_q  + (QK5_0/2)*get_global_id(0);
+    global uchar      * qh = (global uchar *) dst_qh + 4*get_global_id(0);
+    global half       * d  = (global half *)  dst_d  + get_global_id(0);
+
+    *d = b->d;
+    for (int i = 0; i < 4; ++i) {
+        qh[i] = b->qh[i];
+    }
+    for (int i = 0; i < QK5_0/2; ++i) {
+        q[i] = b->qs[i];
+    }
+}
+
+kernel void kernel_restore_block_q5_0(
+    global uchar * src_q,
+    global uchar * src_qh,
+    global half  * src_d,
+    global block_q5_0 * dst
+) {
+    global block_q5_0 * b  = (global block_q5_0 *) dst + get_global_id(0);
+    global uchar      * q  = (global uchar *) src_q  + (QK5_0/2)*get_global_id(0);
+    global uchar      * qh = (global uchar *) src_qh + 4*get_global_id(0);
+    global half       * d  = (global half *)  src_d  + get_global_id(0);
+
+    b->d = *d;
+    for (int i = 0; i < 4; ++i) {
+        b->qh[i] = qh[i];
+    }
+    for (int i = 0; i < QK5_0/2; ++i) {
+        b->qs[i] = q[i];
+    }
+}
+
 kernel void kernel_convert_block_q8_0(
     global block_q8_0 * src0,
     global uchar * dst_q,
@@ -552,8 +602,19 @@ kernel void kernel_restore_block_q4_K_noshuffle(
 // This kernel does not deshuffle the bits.
 // Each thread processes a super block.
 //------------------------------------------------------------------------------
+// Block layout (all fields at fixed byte offsets, total 210 bytes):
+//   ql:     offset 0,   size QK_K/2   (128 bytes)
+//   qh:     offset 128, size QK_K/4   (64 bytes)
+//   scales: offset 192, size QK_K/16  (16 bytes)
+//   d:      offset 208, size 2 bytes  (half)
+#define BLOCK_Q6_K_SIZE      210
+#define BLOCK_Q6_K_QL_OFF    0
+#define BLOCK_Q6_K_QH_OFF    128
+#define BLOCK_Q6_K_S_OFF     192
+#define BLOCK_Q6_K_D_OFF     208
+
 kernel void kernel_convert_block_q6_K(
-    global struct block_q6_K * src0,
+    global uchar * src0,
     global uchar * dst_ql,
     global uchar * dst_qh,
     global char  * dst_s,
@@ -561,25 +622,90 @@ kernel void kernel_convert_block_q6_K(
     uchar          mask_lsb_8,
     ulong          n_blk
 ) {
-    if (get_global_id(0) >= n_blk) {
-        return;
-    }
-    global struct block_q6_K * b = (global struct block_q6_K *) src0 + get_global_id(0);
-    global uchar * ql = (global uchar *) dst_ql + QK_K/2*get_global_id(0);
-    global uchar * qh = (global uchar *) dst_qh + QK_K/4*get_global_id(0);
-    global char  * s  = (global char  *) dst_s  + QK_K/16*get_global_id(0);
-    global half  * d  = (global half  *) dst_d  + get_global_id(0);
+    int gid = get_global_id(0);
+    global uchar * blk = src0 + (size_t)gid * BLOCK_Q6_K_SIZE;
+    global uchar * ql = dst_ql + (size_t)gid * (QK_K/2);
+    global uchar * qh = dst_qh + (size_t)gid * (QK_K/4);
+    global char  * s  = (global char  *)(dst_s) + (size_t)gid * (QK_K/16);
+    global half  * d  = dst_d + gid;
 
-    *d = b->d;
+    vstore_half(vload_half(0, (global half *)(blk + BLOCK_Q6_K_D_OFF)), 0, d);
 
     for (int i = 0; i < QK_K/2; ++i) {
-        ql[i] = b->ql[i];
+        ql[i] = blk[BLOCK_Q6_K_QL_OFF + i];
     }
     for (int i = 0; i < QK_K/4; ++i) {
-        qh[i] = b->qh[i];
+        qh[i] = blk[BLOCK_Q6_K_QH_OFF + i];
     }
     for (int i = 0; i < QK_K/16; ++i) {
-        s[i] = b->scales[i];
+        s[i] = (char)blk[BLOCK_Q6_K_S_OFF + i];
+    }
+}
+
+//------------------------------------------------------------------------------
+// kernel_convert_block_q4_K
+// Convert block_q4_K AOS -> SOA (separate d, dmin, scales, qs arrays).
+// Each thread processes one super block.
+// Block layout (total 144 bytes):
+//   d:      offset 0,  size 2 bytes (half)
+//   dmin:   offset 2,  size 2 bytes (half)
+//   scales: offset 4,  size 12 bytes (K_SCALE_SIZE)
+//   qs:     offset 16, size 128 bytes (QK_K/2)
+//------------------------------------------------------------------------------
+#define BLOCK_Q4_K_SIZE     144
+#define BLOCK_Q4_K_D_OFF    0
+#define BLOCK_Q4_K_DMIN_OFF 2
+#define BLOCK_Q4_K_S_OFF    4
+#define BLOCK_Q4_K_QS_OFF   16
+#define K_SCALE_SIZE_4K     12
+#define QK_K_HALF           128  // QK_K/2
+
+kernel void kernel_convert_block_q4_K(
+    global uchar * src0,
+    global half  * dst_d,
+    global half  * dst_dmin,
+    global uchar * dst_scales,
+    global uchar * dst_qs
+) {
+    int gid = get_global_id(0);
+    global uchar * blk    = src0       + (size_t)gid * BLOCK_Q4_K_SIZE;
+    global half  * d      = dst_d      + gid;
+    global half  * dmin   = dst_dmin   + gid;
+    global uchar * sc     = dst_scales + (size_t)gid * K_SCALE_SIZE_4K;
+    global uchar * qs     = dst_qs     + (size_t)gid * QK_K_HALF;
+
+    vstore_half(vload_half(0, (global half *)(blk + BLOCK_Q4_K_D_OFF)),    0, d);
+    vstore_half(vload_half(0, (global half *)(blk + BLOCK_Q4_K_DMIN_OFF)), 0, dmin);
+    for (int i = 0; i < K_SCALE_SIZE_4K; ++i) {
+        sc[i] = blk[BLOCK_Q4_K_S_OFF + i];
+    }
+    for (int i = 0; i < QK_K_HALF; ++i) {
+        qs[i] = blk[BLOCK_Q4_K_QS_OFF + i];
+    }
+}
+
+//------------------------------------------------------------------------------
+// kernel_restore_block_q4_K
+// Convert block_q4_K SOA -> AOS (reconstruct original struct layout).
+// Each thread processes one super block.
+//------------------------------------------------------------------------------
+kernel void kernel_restore_block_q4_K(
+    global half  * src_d,
+    global half  * src_dmin,
+    global uchar * src_scales,
+    global uchar * src_qs,
+    global uchar * dst
+) {
+    int gid = get_global_id(0);
+    global uchar * blk = dst + (size_t)gid * BLOCK_Q4_K_SIZE;
+
+    vstore_half(vload_half(0, src_d    + gid), 0, (global half *)(blk + BLOCK_Q4_K_D_OFF));
+    vstore_half(vload_half(0, src_dmin + gid), 0, (global half *)(blk + BLOCK_Q4_K_DMIN_OFF));
+    for (int i = 0; i < K_SCALE_SIZE_4K; ++i) {
+        blk[BLOCK_Q4_K_S_OFF + i] = src_scales[(size_t)gid * K_SCALE_SIZE_4K + i];
+    }
+    for (int i = 0; i < QK_K_HALF; ++i) {
+        blk[BLOCK_Q4_K_QS_OFF + i] = src_qs[(size_t)gid * QK_K_HALF + i];
     }
 }
 

--- a/ggml/src/ggml-opencl/kernels/exp.cl
+++ b/ggml/src/ggml-opencl/kernels/exp.cl
@@ -13,7 +13,8 @@ kernel void kernel_exp_f32(
     src0 = (global float*)((global char*)src0 + offset0);
     dst  = (global float*)((global char*)dst + offsetd);
 
-    dst[get_global_id(0)] = exp(src0[get_global_id(0)]);
+    const float x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = exp(x);
 }
 
 kernel void kernel_exp_f32_4(
@@ -29,7 +30,8 @@ kernel void kernel_exp_f32_4(
     src0 = (global float4*)((global char*)src0 + offset0);
     dst  = (global float4*)((global char*)dst + offsetd);
 
-    dst[get_global_id(0)] = exp(src0[get_global_id(0)]);
+    float4 x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = exp(x);
 }
 
 kernel void kernel_exp_f16(
@@ -45,7 +47,12 @@ kernel void kernel_exp_f16(
     src0 = (global half*)((global char*)src0 + offset0);
     dst  = (global half*)((global char*)dst + offsetd);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
     dst[get_global_id(0)] = exp(src0[get_global_id(0)]);
+#else
+    const float x = (float) src0[get_global_id(0)];
+    dst[get_global_id(0)] = (half) exp(x);
+#endif
 }
 
 kernel void kernel_exp_f16_4(
@@ -61,7 +68,14 @@ kernel void kernel_exp_f16_4(
     src0 = (global half4*)((global char*)src0 + offset0);
     dst  = (global half4*)((global char*)dst + offsetd);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
     dst[get_global_id(0)] = exp(src0[get_global_id(0)]);
+#else
+    half4 h = src0[get_global_id(0)];
+    float4 x = (float4)((float)h.s0, (float)h.s1, (float)h.s2, (float)h.s3);
+    float4 y = exp(x);
+    dst[get_global_id(0)] = (half4)((half)y.s0, (half)y.s1, (half)y.s2, (half)y.s3);
+#endif
 }
 
 kernel void kernel_exp_f32_nc(
@@ -120,6 +134,10 @@ kernel void kernel_exp_f16_nc(
         global const half * x = (global const half *)(src0 + i3*nb03 + i2*nb02 + i1*nb01 + i0*nb00);
         global       half * y = (global       half *)(dst  + i3*nb3  + i2*nb2  + i1*nb1  + i0*nb0);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
         *y = exp(*x);
+#else
+        *y = (half) exp((float) *x);
+#endif
     }
 }

--- a/ggml/src/ggml-opencl/kernels/expm1.cl
+++ b/ggml/src/ggml-opencl/kernels/expm1.cl
@@ -37,7 +37,12 @@ kernel void kernel_expm1_f16(
     src0 = (global half*)((global char*)src0 + offset0);
     dst  = (global half*)((global char*)dst + offsetd);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
     dst[get_global_id(0)] = exp(src0[get_global_id(0)]) - 1.0h;
+#else
+    const float x = (float) src0[get_global_id(0)];
+    dst[get_global_id(0)] = (half) (exp(x) - 1.0f);
+#endif
 }
 
 kernel void kernel_expm1_f16_4(
@@ -49,7 +54,14 @@ kernel void kernel_expm1_f16_4(
     src0 = (global half4*)((global char*)src0 + offset0);
     dst  = (global half4*)((global char*)dst + offsetd);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
     dst[get_global_id(0)] = exp(src0[get_global_id(0)]) - 1.0h;
+#else
+    half4 h = src0[get_global_id(0)];
+    float4 x = (float4)((float)h.s0, (float)h.s1, (float)h.s2, (float)h.s3);
+    float4 y = exp(x) - 1.0f;
+    dst[get_global_id(0)] = (half4)((half)y.s0, (half)y.s1, (half)y.s2, (half)y.s3);
+#endif
 }
 
 kernel void kernel_expm1_f32_nc(
@@ -108,6 +120,10 @@ kernel void kernel_expm1_f16_nc(
         global const half * x = (global const half *)(src0 + i3*nb03 + i2*nb02 + i1*nb01 + i0*nb00);
         global       half * y = (global       half *)(dst  + i3*nb3  + i2*nb2  + i1*nb1  + i0*nb0);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
         *y = exp(*x) - 1.0f;
+#else
+        *y = (half) (exp((float) *x) - 1.0f);
+#endif
     }
 }

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f16.cl
@@ -4,8 +4,8 @@
 #define ACC_TYPE4 float4
 #define DATA_TYPE half
 #define DATA_TYPE4 half4
-#define CONVERT_ACC4(x) convert_float4(x)
-#define CONVERT_DATA4(x) convert_half4(x)
+#define CONVERT_ACC4(x) ((float4)((float)(x).s0, (float)(x).s1, (float)(x).s2, (float)(x).s3))
+#define CONVERT_DATA4(x) ((half4)((half)(x).s0, (half)(x).s1, (half)(x).s2, (half)(x).s3))
 
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -7,7 +7,7 @@
 #define O_DATA_TYPE4 float4
 #define MASK_DATA_TYPE half
 #define CONVERT_Q_ACC4(x) (x)
-#define CONVERT_KV_ACC4(x) convert_float4(x)
+#define CONVERT_KV_ACC4(x) ((float4)((float)(x).s0, (float)(x).s1, (float)(x).s2, (float)(x).s3))
 #define CONVERT_O_DATA4(x) (x)
 
 #define DK_VEC (DK/4)

--- a/ggml/src/ggml-opencl/kernels/gated_delta_net.cl
+++ b/ggml/src/ggml-opencl/kernels/gated_delta_net.cl
@@ -1,0 +1,114 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+//------------------------------------------------------------------------------
+// gated_delta_net
+//------------------------------------------------------------------------------
+kernel void kernel_gated_delta_net_f32(
+        global uchar * q,
+        ulong offset_q,
+        global uchar * k,
+        ulong offset_k,
+        global uchar * v,
+        ulong offset_v,
+        global uchar * g,
+        ulong offset_g,
+        global uchar * beta,
+        ulong offset_beta,
+        global uchar * state_in,
+        ulong offset_state_in,
+        global uchar * dst,
+        ulong offset_dst,
+        int H,
+        int n_tokens,
+        int n_seqs,
+        ulong sq1,
+        ulong sq2,
+        ulong sq3,
+        ulong sv1,
+        ulong sv2,
+        ulong sv3,
+        ulong sb1,
+        ulong sb2,
+        ulong sb3,
+        int rq1,
+        int rq3,
+        int S_v,
+        int kda,
+        float scale) {
+    const int col      = get_global_id(0);
+    const int h_idx    = get_global_id(1);
+    const int sequence = get_global_id(2);
+
+    if (col >= S_v || h_idx >= H || sequence >= n_seqs) {
+        return;
+    }
+
+    const int iq1 = h_idx / rq1;
+    const int iq3 = sequence / rq3;
+
+    global uchar * q_base = q + offset_q;
+    global uchar * k_base = k + offset_k;
+    global uchar * v_base = v + offset_v;
+    global uchar * g_base = g + offset_g;
+    global uchar * b_base = beta + offset_beta;
+    global uchar * state_base = state_in + offset_state_in;
+    global uchar * dst_base = dst + offset_dst;
+
+    const ulong state_offset_elems = ((ulong)sequence * (ulong)H + (ulong)h_idx) * (ulong)S_v * (ulong)S_v;
+    const ulong attn_score_elems   = (ulong)S_v * (ulong)H * (ulong)n_tokens * (ulong)n_seqs;
+
+    global float * state_out = (global float *)(dst_base + attn_score_elems * sizeof(float)) + state_offset_elems;
+    global const float * curr_state = (global const float *)state_base + state_offset_elems;
+    global float * attn_data = (global float *)dst_base + (((ulong)sequence * (ulong)n_tokens * (ulong)H + (ulong)h_idx) * (ulong)S_v);
+
+    float s_private[128];
+    for (int i = 0; i < S_v; ++i) {
+        s_private[i] = curr_state[i * S_v + col];
+    }
+
+    for (int t = 0; t < n_tokens; ++t) {
+        global const float * q_t = (global const float *)(q_base + (ulong)iq3 * sq3 + (ulong)t * sq2 + (ulong)iq1 * sq1);
+        global const float * k_t = (global const float *)(k_base + (ulong)iq3 * sq3 + (ulong)t * sq2 + (ulong)iq1 * sq1);
+        global const float * v_t = (global const float *)(v_base + (ulong)sequence * sv3 + (ulong)t * sv2 + (ulong)h_idx * sv1);
+
+        const ulong gb_offset = (ulong)sequence * sb3 + (ulong)t * sb2 + (ulong)h_idx * sb1;
+        global const float * beta_t = (global const float *)(b_base + gb_offset);
+        global const float * g_t    = (global const float *)(g_base + gb_offset * (ulong)(kda ? S_v : 1));
+
+        const float beta_val = *beta_t;
+
+        float kv_col = 0.0f;
+        if (!kda) {
+            const float g_val = exp(*g_t);
+            for (int i = 0; i < S_v; ++i) {
+                kv_col += s_private[i] * k_t[i];
+            }
+
+            const float delta_col = (v_t[col] - g_val * kv_col) * beta_val;
+            float attn_col = 0.0f;
+            for (int i = 0; i < S_v; ++i) {
+                s_private[i] = g_val * s_private[i] + k_t[i] * delta_col;
+                attn_col += s_private[i] * q_t[i];
+            }
+            attn_data[col] = attn_col * scale;
+        } else {
+            for (int i = 0; i < S_v; ++i) {
+                kv_col += exp(g_t[i]) * s_private[i] * k_t[i];
+            }
+
+            const float delta_col = (v_t[col] - kv_col) * beta_val;
+            float attn_col = 0.0f;
+            for (int i = 0; i < S_v; ++i) {
+                s_private[i] = exp(g_t[i]) * s_private[i] + k_t[i] * delta_col;
+                attn_col += s_private[i] * q_t[i];
+            }
+            attn_data[col] = attn_col * scale;
+        }
+
+        attn_data += S_v * H;
+    }
+
+    for (int i = 0; i < S_v; ++i) {
+        state_out[i * S_v + col] = s_private[i];
+    }
+}

--- a/ggml/src/ggml-opencl/kernels/gemv_noshuffle_general.cl
+++ b/ggml/src/ggml-opencl/kernels/gemv_noshuffle_general.cl
@@ -188,6 +188,7 @@
     total_sums.s1 += (((bits4.s7 & 0x0F00) >> 8) - 8) * scale.s1 * shared_y.s6; \
     total_sums.s1 += (((bits4.s7 & 0xF000) >> 12) - 8) * scale.s1 * shared_y.s7; \
 
+#ifndef APPLE_GPU
 #ifdef ADRENO_GPU
 REQD_SUBGROUP_SIZE_64
 #endif
@@ -272,3 +273,154 @@ __kernel void kernel_gemv_noshuffle(
     }
 
 }
+#endif // !APPLE_GPU
+
+#ifdef APPLE_GPU
+// Q4_0 GEMV for Apple GPUs.
+// Uses plain __global buffers instead of images: Apple's OpenCL driver does not
+// benefit from the texture cache that justifies image1d_buffer_t on Adreno.
+// src1 is loaded cooperatively into local memory (one float per lane, perfectly
+// coalesced) so no sub_group_broadcast is needed, which also makes the kernel
+// compatible with Apple's OpenCL 1.2 (no cl_khr_subgroups required).
+
+#define dequantizeBlockAccum_apple_hi(total_sums, bits4, scale, ylm) \
+    total_sums.s0 += ((bits4.s0 & 0x000F) - 8) * scale.s0 * ylm[0];  \
+    total_sums.s1 += ((bits4.s1 & 0x000F) - 8) * scale.s1 * ylm[0];  \
+    total_sums.s0 += (((bits4.s0 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[1]; \
+    total_sums.s1 += (((bits4.s1 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[1]; \
+    total_sums.s0 += (((bits4.s0 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[2]; \
+    total_sums.s1 += (((bits4.s1 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[2]; \
+    total_sums.s0 += (((bits4.s0 & 0xF000) >> 12) - 8) * scale.s0 * ylm[3]; \
+    total_sums.s1 += (((bits4.s1 & 0xF000) >> 12) - 8) * scale.s1 * ylm[3]; \
+    total_sums.s0 += ((bits4.s2 & 0x000F) - 8) * scale.s0 * ylm[4];  \
+    total_sums.s1 += ((bits4.s3 & 0x000F) - 8) * scale.s1 * ylm[4];  \
+    total_sums.s0 += (((bits4.s2 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[5]; \
+    total_sums.s1 += (((bits4.s3 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[5]; \
+    total_sums.s0 += (((bits4.s2 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[6]; \
+    total_sums.s1 += (((bits4.s3 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[6]; \
+    total_sums.s0 += (((bits4.s2 & 0xF000) >> 12) - 8) * scale.s0 * ylm[7]; \
+    total_sums.s1 += (((bits4.s3 & 0xF000) >> 12) - 8) * scale.s1 * ylm[7]; \
+    total_sums.s0 += ((bits4.s4 & 0x000F) - 8) * scale.s0 * ylm[8];  \
+    total_sums.s1 += ((bits4.s5 & 0x000F) - 8) * scale.s1 * ylm[8];  \
+    total_sums.s0 += (((bits4.s4 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[9]; \
+    total_sums.s1 += (((bits4.s5 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[9]; \
+    total_sums.s0 += (((bits4.s4 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[10]; \
+    total_sums.s1 += (((bits4.s5 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[10]; \
+    total_sums.s0 += (((bits4.s4 & 0xF000) >> 12) - 8) * scale.s0 * ylm[11]; \
+    total_sums.s1 += (((bits4.s5 & 0xF000) >> 12) - 8) * scale.s1 * ylm[11]; \
+    total_sums.s0 += ((bits4.s6 & 0x000F) - 8) * scale.s0 * ylm[12]; \
+    total_sums.s1 += ((bits4.s7 & 0x000F) - 8) * scale.s1 * ylm[12]; \
+    total_sums.s0 += (((bits4.s6 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[13]; \
+    total_sums.s1 += (((bits4.s7 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[13]; \
+    total_sums.s0 += (((bits4.s6 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[14]; \
+    total_sums.s1 += (((bits4.s7 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[14]; \
+    total_sums.s0 += (((bits4.s6 & 0xF000) >> 12) - 8) * scale.s0 * ylm[15]; \
+    total_sums.s1 += (((bits4.s7 & 0xF000) >> 12) - 8) * scale.s1 * ylm[15];
+
+#define dequantizeBlockAccum_apple_lo(total_sums, bits4, scale, ylm) \
+    total_sums.s0 += ((bits4.s0 & 0x000F) - 8) * scale.s0 * ylm[16]; \
+    total_sums.s1 += ((bits4.s1 & 0x000F) - 8) * scale.s1 * ylm[16]; \
+    total_sums.s0 += (((bits4.s0 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[17]; \
+    total_sums.s1 += (((bits4.s1 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[17]; \
+    total_sums.s0 += (((bits4.s0 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[18]; \
+    total_sums.s1 += (((bits4.s1 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[18]; \
+    total_sums.s0 += (((bits4.s0 & 0xF000) >> 12) - 8) * scale.s0 * ylm[19]; \
+    total_sums.s1 += (((bits4.s1 & 0xF000) >> 12) - 8) * scale.s1 * ylm[19]; \
+    total_sums.s0 += ((bits4.s2 & 0x000F) - 8) * scale.s0 * ylm[20]; \
+    total_sums.s1 += ((bits4.s3 & 0x000F) - 8) * scale.s1 * ylm[20]; \
+    total_sums.s0 += (((bits4.s2 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[21]; \
+    total_sums.s1 += (((bits4.s3 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[21]; \
+    total_sums.s0 += (((bits4.s2 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[22]; \
+    total_sums.s1 += (((bits4.s3 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[22]; \
+    total_sums.s0 += (((bits4.s2 & 0xF000) >> 12) - 8) * scale.s0 * ylm[23]; \
+    total_sums.s1 += (((bits4.s3 & 0xF000) >> 12) - 8) * scale.s1 * ylm[23]; \
+    total_sums.s0 += ((bits4.s4 & 0x000F) - 8) * scale.s0 * ylm[24]; \
+    total_sums.s1 += ((bits4.s5 & 0x000F) - 8) * scale.s1 * ylm[24]; \
+    total_sums.s0 += (((bits4.s4 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[25]; \
+    total_sums.s1 += (((bits4.s5 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[25]; \
+    total_sums.s0 += (((bits4.s4 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[26]; \
+    total_sums.s1 += (((bits4.s5 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[26]; \
+    total_sums.s0 += (((bits4.s4 & 0xF000) >> 12) - 8) * scale.s0 * ylm[27]; \
+    total_sums.s1 += (((bits4.s5 & 0xF000) >> 12) - 8) * scale.s1 * ylm[27]; \
+    total_sums.s0 += ((bits4.s6 & 0x000F) - 8) * scale.s0 * ylm[28]; \
+    total_sums.s1 += ((bits4.s7 & 0x000F) - 8) * scale.s1 * ylm[28]; \
+    total_sums.s0 += (((bits4.s6 & 0x00F0) >> 4) - 8) * scale.s0 * ylm[29]; \
+    total_sums.s1 += (((bits4.s7 & 0x00F0) >> 4) - 8) * scale.s1 * ylm[29]; \
+    total_sums.s0 += (((bits4.s6 & 0x0F00) >> 8) - 8) * scale.s0 * ylm[30]; \
+    total_sums.s1 += (((bits4.s7 & 0x0F00) >> 8) - 8) * scale.s1 * ylm[30]; \
+    total_sums.s0 += (((bits4.s6 & 0xF000) >> 12) - 8) * scale.s0 * ylm[31]; \
+    total_sums.s1 += (((bits4.s7 & 0xF000) >> 12) - 8) * scale.s1 * ylm[31];
+
+__kernel void kernel_gemv_noshuffle_apple(
+        __global const uint  * src0_q,   // quantized weight matrix (same index space as image variant)
+        __global const half2 * src0_d,   // weight scales
+        __global const float * src1,     // input vector
+        ulong offset1,                   // byte offset into src1
+        __global float * dst,
+        ulong offsetd,
+        int ne00,               // K
+        int ne01,               // M
+        int ne02,
+        int ne10,
+        int ne12,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3)
+{
+    uint groupId = get_local_id(1);
+    uint gid     = get_global_id(0);
+    ushort slid  = (ushort)get_local_id(0);  // no cl_khr_subgroups on Apple 1.2
+
+    uint K = ne00;
+    uint M = ne01;
+    uint LINE_STRIDE_A  = M / 2;
+    uint BLOCK_STRIDE_A = N_SIMDGROUP * M;
+
+    __private uint4  regA;
+    __private half2  regS;
+    __private float2 totalSum = (float2)(0.0f);
+
+    // Each subgroup caches its own QK4_0-element slice of src1 in local memory.
+    // With SIMDGROUP_WIDTH == QK4_0 == 32, every lane loads exactly one float —
+    // a perfectly coalesced global read.
+    __local float src1_lm[N_SIMDGROUP * QK4_0];
+    __local float * ylm = src1_lm + groupId * QK4_0;
+
+    const ulong src1_base = offset1 / sizeof(float);
+
+    for (uint k = groupId; k < (K / QK4_0); k += N_SIMDGROUP) {
+        ylm[slid] = src1[src1_base + k * QK4_0 + slid];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        regS = src0_d[gid + k * LINE_STRIDE_A];
+
+        regA.s0 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 0];
+        regA.s1 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 1];
+        regA.s2 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 2];
+        regA.s3 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 3];
+        dequantizeBlockAccum_apple_hi(totalSum, as_ushort8(regA), regS, ylm);
+
+        regA.s0 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 4];
+        regA.s1 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 5];
+        regA.s2 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 6];
+        regA.s3 = src0_q[gid + k * BLOCK_STRIDE_A + LINE_STRIDE_A * 7];
+        dequantizeBlockAccum_apple_lo(totalSum, as_ushort8(regA), regS, ylm);
+    }
+
+    // Cross-subgroup reduction in local memory (N_SIMDGROUP == 4).
+    __local float2 reduceLM[SIMDGROUP_WIDTH * 3];
+    if (groupId == 1) reduceLM[SIMDGROUP_WIDTH * 0 + slid] = totalSum;
+    if (groupId == 2) reduceLM[SIMDGROUP_WIDTH * 1 + slid] = totalSum;
+    if (groupId == 3) reduceLM[SIMDGROUP_WIDTH * 2 + slid] = totalSum;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (groupId == 0) totalSum += reduceLM[SIMDGROUP_WIDTH * 0 + slid];
+    if (groupId == 0) totalSum += reduceLM[SIMDGROUP_WIDTH * 1 + slid];
+    if (groupId == 0) totalSum += reduceLM[SIMDGROUP_WIDTH * 2 + slid];
+
+    if (groupId == 0) {
+        dst = (global float*)((global char*)dst + offsetd);
+        vstore2(totalSum, 0, &(dst[gid * 2]));
+    }
+}
+#endif // APPLE_GPU

--- a/ggml/src/ggml-opencl/kernels/get_rows.cl
+++ b/ggml/src/ggml-opencl/kernels/get_rows.cl
@@ -58,6 +58,24 @@ void dequantize_q4_0_f32(global struct block_q4_0 * xb, short il, float16 * reg)
 
 //------------------------------------------------------------------------------
 // get_rows
+//
+// Dispatch layout (all three kernels):
+//   dim 0 : ne10 * num_chunks groups, local_size threads each
+//           num_chunks = ceil(ne_per_row / local_size)
+//             ne_per_row = ne00/4 for f32/f16 (float4 vectorized)
+//             ne_per_row = ne00/16 for q4_0 (float16 block per thread)
+//   dim 1 : ne11
+//   dim 2 : ne12
+//
+// Within each workgroup:
+//   - grp / num_chunks -> i10 (row index, workgroup-uniform)
+//   - grp % num_chunks -> chunk (which slice of the row, workgroup-uniform)
+//   - chunk * local_size + lid -> ind (element index in ne_per_row units)
+//   - thread 0 reads r from src1 and stores the row byte offsets in
+//     local memory so every other thread avoids a redundant global load
+//
+// f32/f16: each thread processes 4 contiguous elements (float4 / half4→float4).
+//          Requires ne00 % 4 == 0, which holds for all practical embedding dims.
 //------------------------------------------------------------------------------
 kernel void kernel_get_rows_f32(
         global void * src0,
@@ -82,22 +100,38 @@ kernel void kernel_get_rows_f32(
     src1 = (global int*)((global char*)src1 + offset1);
     dst = (global float*)((global char*)dst + offsetd);
 
-    int i10 = get_group_id(0);
-    int i11 = get_group_id(1);
-    int i12 = get_group_id(2);
+    local ulong src_row_off;
+    local ulong dst_row_off;
 
-    int r = ((global int *) ((global char *) src1 + i12*nb12 + i11*nb11 + i10*nb10))[0];
+    int lsz    = (int)get_local_size(0);
+    int grp    = (int)get_group_id(0);
+    int i11    = (int)get_group_id(1);
+    int i12    = (int)get_group_id(2);
+    int lid    = (int)get_local_id(0);
 
-    int i02 = i11;
-    int i03 = i12;
+    // Each thread handles 4 floats (float4).  ne00_4 is the number of float4
+    // elements per row; both the dispatch and this kernel use ne00_4 as the
+    // work unit so num_chunks stays workgroup-uniform (no per-lane divides).
+    int ne00_4 = ne00 / 4;
+    int num_chunks = (ne00_4 + lsz - 1) / lsz;
+    int i10   = grp / num_chunks;
+    int chunk = grp % num_chunks;
 
-    for (int ind = get_local_id(0); ind < ne00; ind += get_local_size(0)) {
-        if (ind >= ne00) {
-            return;
-        }
-        ((global float *) ((global char *) dst + i12*nb3 + i11*nb2 + i10*nb1))[ind] =
-            ((global float *) ((global char *) src0 + r*nb01 + i02*nb02 + i03*nb03))[ind];
+    // Thread 0 reads r from src1 (one global load per workgroup instead of lsz)
+    // and precomputes the row byte offsets shared by all threads.
+    if (lid == 0 && i10 < ne10) {
+        int r = ((global int *)((global char *)src1
+                    + (ulong)i12*nb12 + (ulong)i11*nb11 + (ulong)i10*nb10))[0];
+        src_row_off = (ulong)r * nb01 + (ulong)i11 * nb02 + (ulong)i12 * nb03;
+        dst_row_off = (ulong)i12 * nb3 + (ulong)i11 * nb2 + (ulong)i10 * nb1;
     }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int ind = chunk * lsz + lid;
+    if (i10 >= ne10 || ind >= ne00_4) return;
+
+    ((global float4 *)((global char *)dst + dst_row_off))[ind] =
+        ((global const float4 *)((global const char *)src0 + src_row_off))[ind];
 }
 
 kernel void kernel_get_rows_f16(
@@ -123,22 +157,36 @@ kernel void kernel_get_rows_f16(
     src1 = (global int*)((global char*)src1 + offset1);
     dst = (global float*)((global char*)dst + offsetd);
 
-    int i10 = get_group_id(0);
-    int i11 = get_group_id(1);
-    int i12 = get_group_id(2);
+    local ulong src_row_off;
+    local ulong dst_row_off;
 
-    int r = ((global int32_t *) ((global char *) src1 + i12*nb12 + i11*nb11 + i10*nb10))[0];
+    int lsz    = (int)get_local_size(0);
+    int grp    = (int)get_group_id(0);
+    int i11    = (int)get_group_id(1);
+    int i12    = (int)get_group_id(2);
+    int lid    = (int)get_local_id(0);
 
-    int i02 = i11;
-    int i03 = i12;
+    // Each thread converts 4 halves to 4 floats (half4 → float4).
+    int ne00_4 = ne00 / 4;
+    int num_chunks = (ne00_4 + lsz - 1) / lsz;
+    int i10   = grp / num_chunks;
+    int chunk = grp % num_chunks;
 
-    for (int ind = get_local_id(0); ind < ne00; ind += get_local_size(0)) {
-        if (ind >= ne00) {
-            return;
-        }
-        ((global float *) ((global char *) dst + i12*nb3 + i11*nb2 + i10*nb1))[ind] =
-            ((global half *) ((global char *) src0 + r*nb01 + i02*nb02 + i03*nb03))[ind];
+    if (lid == 0 && i10 < ne10) {
+        int r = ((global int32_t *)((global char *)src1
+                    + (ulong)i12*nb12 + (ulong)i11*nb11 + (ulong)i10*nb10))[0];
+        src_row_off = (ulong)r * nb01 + (ulong)i11 * nb02 + (ulong)i12 * nb03;
+        dst_row_off = (ulong)i12 * nb3 + (ulong)i11 * nb2 + (ulong)i10 * nb1;
     }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int ind = chunk * lsz + lid;
+    if (i10 >= ne10 || ind >= ne00_4) return;
+
+    global const half4 *src_row = (global const half4 *)((global const char *)src0 + src_row_off);
+    global float4      *dst_row = (global float4 *)((global char *)dst + dst_row_off);
+    half4 h = src_row[ind];
+    dst_row[ind] = (float4)((float)h.x, (float)h.y, (float)h.z, (float)h.w);
 }
 
 kernel void kernel_get_rows_q4_0(
@@ -164,24 +212,36 @@ kernel void kernel_get_rows_q4_0(
     src1 = (global int*)((global char*)src1 + offset1);
     dst = (global float*)((global char*)dst + offsetd);
 
+    local ulong src_row_off;
+    local ulong dst_row_off;
+
     const int NL = 2;
+    const int ne00_16 = ne00 / 16;  // number of float16 output blocks per row
 
-    int i10 = get_group_id(0);
-    int i11 = get_group_id(1);
-    int i12 = get_group_id(2);
+    int lsz  = (int)get_local_size(0);
+    int grp  = (int)get_group_id(0);
+    int i11  = (int)get_group_id(1);
+    int i12  = (int)get_group_id(2);
+    int lid  = (int)get_local_id(0);
 
-    int r = ((global int32_t *) ((global char *) src1 + i12*nb12 + i11*nb11 + i10*nb10))[0];
+    int num_chunks = (ne00_16 + lsz - 1) / lsz;
+    int i10   = grp / num_chunks;
+    int chunk = grp % num_chunks;
 
-    int i02 = i11;
-    int i03 = i12;
-
-    for (int ind = get_local_id(0); ind < ne00/16; ind += get_local_size(0)) {
-        float16 temp;
-        if (ind >= ne00) {
-            return;
-        }
-        dequantize_q4_0_f32(
-            ((global struct block_q4_0 *) ((global char *) src0 + r*nb01 + i02*nb02 + i03*nb03)) + ind/NL, ind%NL, &temp);
-        *(((global float16 *) ((global char *) dst + i12*nb3 + i11*nb2 + i10*nb1)) + ind) = temp;
+    if (lid == 0 && i10 < ne10) {
+        int r = ((global int32_t *)((global char *)src1
+                    + (ulong)i12*nb12 + (ulong)i11*nb11 + (ulong)i10*nb10))[0];
+        src_row_off = (ulong)r * nb01 + (ulong)i11 * nb02 + (ulong)i12 * nb03;
+        dst_row_off = (ulong)i12 * nb3 + (ulong)i11 * nb2 + (ulong)i10 * nb1;
     }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int ind = chunk * lsz + lid;
+    if (i10 >= ne10 || ind >= ne00_16) return;
+
+    float16 temp;
+    dequantize_q4_0_f32(
+        ((global struct block_q4_0 *)((global const char *)src0 + src_row_off)) + ind/NL,
+        ind%NL, &temp);
+    *(((global float16 *)((global char *)dst + dst_row_off)) + ind) = temp;
 }

--- a/ggml/src/ggml-opencl/kernels/glu.cl
+++ b/ggml/src/ggml-opencl/kernels/glu.cl
@@ -196,7 +196,12 @@ kernel void kernel_swiglu_f16(
         const half x0 = src0_row[i0];
         const half x1 = src1_row[i0];
 
-        const half silu = x0 / (1.0f + exp(-x0));
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
+        const half silu = x0 / (1.0h + exp(-x0));
+#else
+        const float x0f = (float)x0;
+        const half silu = (half)(x0f / (1.0f + exp(-x0f)));
+#endif
 
         dst_row[i0] = silu*x1;
     }

--- a/ggml/src/ggml-opencl/kernels/l2_norm.cl
+++ b/ggml/src/ggml-opencl/kernels/l2_norm.cl
@@ -1,24 +1,7 @@
-#ifdef cl_intel_required_subgroup_size
-#pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
-#define INTEL_GPU 1
-#define REQD_SUBGROUP_SIZE_16 __attribute__((intel_reqd_sub_group_size(16)))
-#define REQD_SUBGROUP_SIZE_32 __attribute__((intel_reqd_sub_group_size(32)))
-#elif defined(cl_qcom_reqd_sub_group_size)
-#pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
-#define ADRENO_GPU 1
-#define REQD_SUBGROUP_SIZE_64  __attribute__((qcom_reqd_sub_group_size("half")))
-#define REQD_SUBGROUP_SIZE_128 __attribute__((qcom_reqd_sub_group_size("full")))
-#endif
-
-#ifdef INTEL_GPU
-REQD_SUBGROUP_SIZE_32
-#elif defined (ADRENO_GPU)
-REQD_SUBGROUP_SIZE_64
-#endif
 kernel void kernel_l2_norm_f32(
         global void * src0,
         ulong offset0,
-        global float * dst,
+        global void * dst,
         ulong offsetd,
         int ne00,
         int ne01,
@@ -27,45 +10,43 @@ kernel void kernel_l2_norm_f32(
         ulong nb01,
         ulong nb02,
         ulong nb03,
+        ulong db1,
+        ulong db2,
+        ulong db3,
         float eps,
         local float * sum
 ) {
     src0 = (global void*)((global char*)src0 + offset0);
-    dst = (global float*)((global char*)dst + offsetd);
+    dst = (global void*)((global char*)dst + offsetd);
 
     int i03 = get_group_id(2);
     int i02 = get_group_id(1);
     int i01 = get_group_id(0);
 
     global float * x = (global float *) ((global char *) src0 + i03*nb03 + i02*nb02 + i01*nb01);
-    global float * y = (global float *) (dst + i03*ne02*ne01*ne00 + i02*ne01*ne00 + i01*ne00);
+    global float * y = (global float *) ((global char *) dst + i03*db3 + i02*db2 + i01*db1);
 
     float sumf = 0;
 
-    // parallel sum
-    for (int i00 = get_local_id(0); i00 < ne00; i00 += get_local_size(0)) {
+    const int lid = get_local_id(0);
+    const int lsize = get_local_size(0);
+
+    for (int i00 = lid; i00 < ne00; i00 += lsize) {
         sumf += x[i00] * x[i00];
     }
-    sumf = sub_group_reduce_add(sumf);
-
-    if (get_sub_group_local_id() == 0) {
-        sum[get_sub_group_id()] = sumf;
-    }
-
+    sum[lid] = sumf;
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    // broadcast
-    for (uint i = get_local_size(0) / get_max_sub_group_size() / 2; i > 0; i /= 2) {
-       if (get_local_id(0) < i) {
-           sum[get_local_id(0)] += sum[get_local_id(0) + i];
+    for (int stride = lsize / 2; stride > 0; stride /= 2) {
+       if (lid < stride) {
+           sum[lid] += sum[lid + stride];
        }
+       barrier(CLK_LOCAL_MEM_FENCE);
     }
 
-    barrier(CLK_LOCAL_MEM_FENCE);
+    const float scale = 1.0f/fmax(sqrt(sum[0]), eps);
 
-    const float scale = 1.0f/max(sqrt(sum[0]), eps);
-
-    for (int i00 = get_local_id(0); i00 < ne00; i00 += get_local_size(0)) {
+    for (int i00 = lid; i00 < ne00; i00 += lsize) {
         y[i00] = x[i00] * scale;
     }
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mat_f16_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mat_f16_f32.cl
@@ -63,7 +63,8 @@ __kernel void mul_mat_f16_f32(
 
         if (global_row_a < M && k_vec_start_a < K) {
             if (k_vec_start_a + 3 < K) {
-                Alocal[load_row_a][load_vec_k_a] = vload4(0, A + global_row_a * K + k_vec_start_a);
+                const int a_idx = global_row_a * K + k_vec_start_a;
+                Alocal[load_row_a][load_vec_k_a] = (half4)(A[a_idx + 0], A[a_idx + 1], A[a_idx + 2], A[a_idx + 3]);
             } else {
                 half4 tempA = (half4)(0.0h);
                 if (k_vec_start_a < K) tempA.s0 = A[global_row_a * K + k_vec_start_a];
@@ -77,7 +78,7 @@ __kernel void mul_mat_f16_f32(
 
         if (global_row_b < N && k_vec_start_b < K) {
             if (k_vec_start_b + 3 < K) {
-                Blocal[load_row_b][load_vec_k_b] = vload4(0, B + global_row_b * K + k_vec_start_b);
+                Blocal[load_row_b][load_vec_k_b] = vload4(0, (__global const float *)(B + global_row_b * K + k_vec_start_b));
             } else {
                 float4 tempB = (float4)(0.0f);
                 if (k_vec_start_b < K) tempB.s0 = B[global_row_b * K + k_vec_start_b];
@@ -96,7 +97,8 @@ __kernel void mul_mat_f16_f32(
             float4 a_fvecs[OPTM];
             int current_row_a = lidm;
             for (int wm = 0; wm < OPTM; wm++) {
-                a_fvecs[wm] = convert_float4(Alocal[current_row_a][k_vec]);
+                half4 a_half = Alocal[current_row_a][k_vec];
+                a_fvecs[wm] = (float4)((float)a_half.s0, (float)a_half.s1, (float)a_half.s2, (float)a_half.s3);
                 current_row_a += WG_M;
             }
 

--- a/ggml/src/ggml-opencl/kernels/mul_mm_f16_f32_l4_lm.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mm_f16_f32_l4_lm.cl
@@ -124,7 +124,7 @@ kernel void kernel_mul_mm_f16_f32_l4_lm(
             for (int cc = 0; cc < TN; cc++) {
                 for (int cr = 0; cr < TM; cr++) {
                     const int sums_idx = cc*TM + cr;
-                    sums[sums_idx] = mad(convert_float(cache_a[cr]), cache_b[cc], sums[sums_idx]);
+                    sums[sums_idx] = mad((float) cache_a[cr], cache_b[cc], sums[sums_idx]);
                 }
             }
         }

--- a/ggml/src/ggml-opencl/kernels/mul_mm_q4_k_f32_l4_lm_packed.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mm_q4_k_f32_l4_lm_packed.cl
@@ -1,22 +1,27 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-// Q4_K × F32 batch GEMM  (SOA flat format, local-memory tiling)
+// Q4_K × F32 batch GEMM — packed AoS format (no SOA conversion needed)
 //
-// Weight layout (SOA, 4 separate buffers per super-block of 256 elements):
-//   src0_qs     — 128 bytes/block: nibble pairs for 8 scale-groups of 32 elements each
-//     qs[   0..31]: lo nibble = element   0..31 (sg=0), hi nibble = element  32..63 (sg=1)
-//     qs[  32..63]: lo nibble = element  64..95 (sg=2), hi nibble = element  96..127 (sg=3)
-//     qs[  64..95]: lo nibble = element 128..159 (sg=4), hi nibble = element 160..191 (sg=5)
-//     qs[ 96..127]: lo nibble = element 192..223 (sg=6), hi nibble = element 224..255 (sg=7)
-//   src0_scales — 12 bytes/block: packed 6-bit scale/min pairs (get_scale_min_k4 layout)
-//   src0_d      — 1 half/block:   super-block scale
-//   src0_dmin   — 1 half/block:   super-block min-scale
+// Weight format: packed block_q4_K structs, 144 bytes per super-block of 256 elements:
+//   offset  0 :  half d        — super-block scale
+//   offset  2 :  half dmin     — super-block min-scale
+//   offset  4 :  uchar scales[12] — packed 6-bit scale/min pairs
+//   offset 16 :  uchar qs[128]    — 4-bit quantized weights
+//
+// qs nibble layout (same as SOA, 8 scale-groups of 32 elements each):
+//   qs[  0..31]: lo nibble = element   0..31 (sg=0), hi nibble = element  32..63 (sg=1)
+//   qs[ 32..63]: lo nibble = element  64..95 (sg=2), hi nibble = element  96..127 (sg=3)
+//   qs[ 64..95]: lo nibble = element 128..159 (sg=4), hi nibble = element 160..191 (sg=5)
+//   qs[ 96..127]:lo nibble = element 192..223 (sg=6), hi nibble = element 224..255 (sg=7)
 //
 // Dequantization:  w[k] = d * scale[sg(k)] * nibble[k]  -  dmin * smin[sg(k)]
 //
-// Tile sizes:  BM=BN=64, BK=32, TM=4, TN=8, LOAD_VEC_A=8, 128 threads per work-group.
-// BK=32 aligns with one Q4_K scale-group (32 elements each), so each BK step uses
-// exactly one (scale, smin) pair — no cross-group mixing inside a tile load.
+// Tile: BM=BN=64, BK=32, TM=4, TN=8, LOAD_VEC_A=8, 128 threads.
+// BK=32 = exactly one Q4_K scale-group, so each BK step uses one (scale, smin).
+//
+// Optimization: d, dmin, and scales[] are the same for all 8 BK steps within a
+// super-block.  Each thread caches them in private registers on sg==0 and reuses
+// them for sg=1..7, saving 7/8 of the d/dmin/scales global reads.
 
 #define LOAD_VEC_A 8
 #define LOAD_VEC_B 4
@@ -27,19 +32,18 @@
 #define TM 4
 #define TN 8
 
-#define QK_K         256
-#define K_SCALE_SIZE 12
+#define QK_K          256
+#define K_SCALE_SIZE  12
+#define BLOCK_Q4_K_SZ 144  // sizeof(block_q4_K) = 2+2+12+128
 
-kernel void kernel_mul_mm_q4_k_f32_l4_lm(
-    global uchar  * src0_qs,      // nibbles:     128 bytes per super-block
-    global uchar  * src0_scales,  // scales/mins: 12 bytes per super-block
-    global half   * src0_d,       // super-block scale: 1 half per super-block
-    global half   * src0_dmin,    // super-block min:   1 half per super-block
-    global float4 * src1,         // activations (F32), shape [ne10=ne00][ne11][ne12][ne13]
+kernel void kernel_mul_mm_q4_k_f32_l4_lm_packed(
+    global char   * src0,       // packed block_q4_K, each 144 bytes
+    ulong           offset0,    // byte offset into src0
+    global float4 * src1,
     ulong           offset1,
     global float  * dst,
     ulong           offsetd,
-    int ne00,           // K  (weight columns, must be divisible by QK_K=256)
+    int ne00,           // K  (must be divisible by QK_K=256)
     int ne01,           // M  (weight rows)
     int ne02,           // batch dim of weights
     int ne11,           // N  (activation tokens)
@@ -51,6 +55,7 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
     int r2,
     int r3
 ) {
+    src0 = src0 + offset0;
     src1 = (global float4*)((global char*)src1 + offset1);
     dst  = (global float *)((global char*)dst  + offsetd);
 
@@ -71,15 +76,13 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
     const int th_r = tid % (BM / TM);  // 0..15
     const int th_c = tid / (BM / TM);  // 0..7
 
-    // Loading roles: each thread loads LOAD_VEC_A elements of A and LOAD_VEC_B of B.
-    const int loadr_a = tid % (BK / LOAD_VEC_A);  // 0..3  (which 8-element chunk in BK)
-    const int loadc_a = tid / (BK / LOAD_VEC_A);  // 0..31 (which row in BM)
+    const int loadr_a = tid % (BK / LOAD_VEC_A);  // 0..3
+    const int loadc_a = tid / (BK / LOAD_VEC_A);  // 0..31
     const int loadr_b = tid % (BK / LOAD_VEC_B);  // 0..7
     const int loadc_b = tid / (BK / LOAD_VEC_B);  // 0..15
 
-    // Number of rows covered per load iteration.
-    const int loadstride_a = get_local_size(0) * LOAD_VEC_A / BK;  // 128*8/32 = 32
-    const int loadstride_b = get_local_size(0) * LOAD_VEC_B / BK;  // 128*4/32 = 16
+    const int loadstride_a = get_local_size(0) * LOAD_VEC_A / BK;  // 32
+    const int loadstride_b = get_local_size(0) * LOAD_VEC_B / BK;  // 16
 
     int pos_b = (batch_idx * batch_stride_b + ic * BN * stride_b) / LOAD_VEC_B;
 
@@ -91,42 +94,58 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
 
     for (int i = 0; i < TM * TN; i++) sums[i] = 0.0f;
 
+    // Private register cache for d, dmin, scales per row.
+    // Each thread handles at most 2 rows (l=0 and l=loadstride_a).
+    // Reloaded only when sg==0 (start of each new super-block).
+    float priv_dall[2];
+    float priv_dmin[2];
+    uchar priv_sc[2][K_SCALE_SIZE];  // 12 bytes per row
+
     for (int block = 0; block < ne00; block += BK) {
-        // Which super-block and which scale-group within it this BK step covers.
-        const int ib_in_row   = block / QK_K;       // super-block index along K
-        const int sg          = (block / BK) % 8;   // scale-group 0..7 (32 elem each)
-        // Byte offset into qs[0..127] for this thread's 8 elements.
+        const int ib_in_row   = block / QK_K;
+        const int sg          = (block / BK) % 8;   // scale-group 0..7
         const int qs_byte_off = (sg / 2) * 32 + loadr_a * 8;
-        const int nibble_hi   = sg & 1;             // 0 = lo nibble, 1 = hi nibble
+        const int nibble_hi   = sg & 1;
+        const int sg_m4 = sg < 4 ? sg : sg - 4;     // safe index for speculative eval
 
-        // Scale extraction helper: sg-4 must be clamped to avoid OOB in speculative eval.
-        // On GPUs both branches of a ternary may be evaluated; use sg_m4 as safe index.
-        const int sg_m4 = sg < 4 ? sg : sg - 4;    // always in {0..3}
-
-        // ---- Load tile of A (weight matrix) ----
+        // ---- Load tile of A (Q4_K weights, packed format) ----
         for (int l = 0; l < BM; l += loadstride_a) {
             const int row = ir * BM + loadc_a + l;
+            const int li  = l / loadstride_a;  // 0 or 1
             if (row < ne01) {
-                // Flat super-block index (across batch, rows, and K).
+                // Flat super-block index
                 ulong bi = (ulong)batch_idx_a * ne01 * nb
                          + (ulong)row * nb
                          + ib_in_row;
 
-                uchar8 q = vload8(0, src0_qs + bi * 128 + qs_byte_off);
+                // Pointer to the packed block_q4_K struct
+                global char * bp = src0 + bi * BLOCK_Q4_K_SZ;
+
+                // Cache d, dmin, scales once per super-block (sg==0).
+                // All 8 BK steps within a super-block share the same d/dmin/sc.
+                if (sg == 0) {
+                    priv_dall[li] = (float)vload_half(0, (global half*)bp);
+                    priv_dmin[li] = (float)vload_half(1, (global half*)bp);
+                    global uchar * sc_g = (global uchar*)(bp + 4);
+                    for (int i = 0; i < K_SCALE_SIZE; i++) {
+                        priv_sc[li][i] = sc_g[i];
+                    }
+                }
+
+                // Scale/min decode following get_scale_min_k4, using cached data
+                float scale = sg < 4
+                    ? (float)(priv_sc[li][sg]   & 63)
+                    : (float)((priv_sc[li][sg + 4] & 0x0F) | ((priv_sc[li][sg_m4] >> 6) << 4));
+                float smin  = sg < 4
+                    ? (float)(priv_sc[li][sg + 4] & 63)
+                    : (float)((priv_sc[li][sg + 4] >>   4) | ((priv_sc[li][sg]   >> 6) << 4));
+                float ds = priv_dall[li] * scale;
+                float dm = priv_dmin[li] * smin;
+
+                // qs at offset 16, then scale-group section, then thread's 8 bytes
+                uchar8 q = vload8(0, (global uchar*)(bp + 16) + qs_byte_off);
                 uchar8 nibbles = nibble_hi ? (q >> (uchar8)4) : (q & (uchar8)0x0F);
 
-                // Decode scale and min for this scale-group (get_scale_min_k4 layout).
-                global uchar * sc = src0_scales + bi * K_SCALE_SIZE;
-                float scale = sg < 4 ? (float)(sc[sg]   & 63)
-                                     : (float)((sc[sg + 4] & 0x0F) | ((sc[sg_m4] >> 6) << 4));
-                float smin  = sg < 4 ? (float)(sc[sg + 4] & 63)
-                                     : (float)((sc[sg + 4] >>   4) | ((sc[sg]   >> 6) << 4));
-                float dall   = (float)vload_half(0, src0_d    + bi);
-                float dmin_v = (float)vload_half(0, src0_dmin + bi);
-                float ds = dall   * scale;
-                float dm = dmin_v * smin;
-
-                // Dequantize: w[k] = d*scale*q[k] - dmin*smin
                 buf_a[(loadr_a * 8 + 0) * BM + loadc_a + l] = ds * (float)nibbles.s0 - dm;
                 buf_a[(loadr_a * 8 + 1) * BM + loadc_a + l] = ds * (float)nibbles.s1 - dm;
                 buf_a[(loadr_a * 8 + 2) * BM + loadc_a + l] = ds * (float)nibbles.s2 - dm;
@@ -147,7 +166,7 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
             }
         }
 
-        // ---- Load tile of B (activation matrix, F32) ----
+        // ---- Load tile of B (activations, F32) ----
         for (int l = 0; l < BN; l += loadstride_b) {
             if (ic * BN + loadc_b + l < ne11) {
                 int idx = pos_b + (loadc_b + l) * stride_b / LOAD_VEC_B + loadr_b;
@@ -169,12 +188,8 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
 
         // ---- Compute tile product ----
         for (int i = 0; i < BK; i++) {
-            for (int j = 0; j < TM; j++) {
-                cache_a[j] = buf_a[i * BM + th_r * TM + j];
-            }
-            for (int j = 0; j < TN; j++) {
-                cache_b[j] = buf_b[i * BN + th_c * TN + j];
-            }
+            for (int j = 0; j < TM; j++) cache_a[j] = buf_a[i * BM + th_r * TM + j];
+            for (int j = 0; j < TN; j++) cache_b[j] = buf_b[i * BN + th_c * TN + j];
             for (int cc = 0; cc < TN; cc++) {
                 for (int cr = 0; cr < TM; cr++) {
                     sums[cc * TM + cr] = mad(cache_a[cr], cache_b[cc], sums[cc * TM + cr]);

--- a/ggml/src/ggml-opencl/kernels/mul_mm_q4_k_f32_l4_lm_qst.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mm_q4_k_f32_l4_lm_qst.cl
@@ -1,22 +1,23 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-// Q4_K × F32 batch GEMM  (SOA flat format, local-memory tiling)
+// Q4_K × F32 batch GEMM — reorganized qs buffer (coalesced for Apple M1)
 //
-// Weight layout (SOA, 4 separate buffers per super-block of 256 elements):
-//   src0_qs     — 128 bytes/block: nibble pairs for 8 scale-groups of 32 elements each
-//     qs[   0..31]: lo nibble = element   0..31 (sg=0), hi nibble = element  32..63 (sg=1)
-//     qs[  32..63]: lo nibble = element  64..95 (sg=2), hi nibble = element  96..127 (sg=3)
-//     qs[  64..95]: lo nibble = element 128..159 (sg=4), hi nibble = element 160..191 (sg=5)
-//     qs[ 96..127]: lo nibble = element 192..223 (sg=6), hi nibble = element 224..255 (sg=7)
-//   src0_scales — 12 bytes/block: packed 6-bit scale/min pairs (get_scale_min_k4 layout)
-//   src0_d      — 1 half/block:   super-block scale
-//   src0_dmin   — 1 half/block:   super-block min-scale
+// Two-buffer design:
+//   src0_meta : original packed block_q4_K (144 bytes/block), used ONLY for
+//               d, dmin, and scales metadata — these 16 bytes/block are read
+//               once per super-block and cached in private registers for the
+//               remaining 7 BK steps.
+//   src0_qs_t : qs data in [batch, nb, ne01, 128] order — block-major,
+//               row-minor — so threads working on the same tile (same ib_in_row
+//               but consecutive rows) access stride-128-byte-apart addresses
+//               instead of the packed format's stride-1728-byte gap.
 //
-// Dequantization:  w[k] = d * scale[sg(k)] * nibble[k]  -  dmin * smin[sg(k)]
+// Memory coalescing improvement:
+//   Packed : stride = nb * 144 = 12 * 144 = 1728 bytes between adjacent rows
+//   qst    : stride = 128 bytes between adjacent rows (fully coalesced)
 //
-// Tile sizes:  BM=BN=64, BK=32, TM=4, TN=8, LOAD_VEC_A=8, 128 threads per work-group.
-// BK=32 aligns with one Q4_K scale-group (32 elements each), so each BK step uses
-// exactly one (scale, smin) pair — no cross-group mixing inside a tile load.
+// See mul_mm_q4_k_f32_l4_lm_packed.cl for the packed fallback.
+// Tile: BM=BN=64, BK=32, TM=4, TN=8, LOAD_VEC_A=8, 128 threads.
 
 #define LOAD_VEC_A 8
 #define LOAD_VEC_B 4
@@ -27,19 +28,19 @@
 #define TM 4
 #define TN 8
 
-#define QK_K         256
-#define K_SCALE_SIZE 12
+#define QK_K          256
+#define K_SCALE_SIZE  12
+#define BLOCK_Q4_K_SZ 144  // sizeof(block_q4_K) = 2+2+12+128
 
-kernel void kernel_mul_mm_q4_k_f32_l4_lm(
-    global uchar  * src0_qs,      // nibbles:     128 bytes per super-block
-    global uchar  * src0_scales,  // scales/mins: 12 bytes per super-block
-    global half   * src0_d,       // super-block scale: 1 half per super-block
-    global half   * src0_dmin,    // super-block min:   1 half per super-block
-    global float4 * src1,         // activations (F32), shape [ne10=ne00][ne11][ne12][ne13]
+kernel void kernel_mul_mm_q4_k_f32_l4_lm_qst(
+    global char   * src0_meta,  // packed block_q4_K for metadata only (d, dmin, scales)
+    ulong           offset0,
+    global uchar  * src0_qs_t,  // qs in [batch, nb, ne01, 128] order (coalesced)
+    global float4 * src1,
     ulong           offset1,
     global float  * dst,
     ulong           offsetd,
-    int ne00,           // K  (weight columns, must be divisible by QK_K=256)
+    int ne00,           // K  (must be divisible by QK_K=256)
     int ne01,           // M  (weight rows)
     int ne02,           // batch dim of weights
     int ne11,           // N  (activation tokens)
@@ -51,6 +52,7 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
     int r2,
     int r3
 ) {
+    src0_meta = src0_meta + offset0;
     src1 = (global float4*)((global char*)src1 + offset1);
     dst  = (global float *)((global char*)dst  + offsetd);
 
@@ -71,15 +73,13 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
     const int th_r = tid % (BM / TM);  // 0..15
     const int th_c = tid / (BM / TM);  // 0..7
 
-    // Loading roles: each thread loads LOAD_VEC_A elements of A and LOAD_VEC_B of B.
-    const int loadr_a = tid % (BK / LOAD_VEC_A);  // 0..3  (which 8-element chunk in BK)
-    const int loadc_a = tid / (BK / LOAD_VEC_A);  // 0..31 (which row in BM)
+    const int loadr_a = tid % (BK / LOAD_VEC_A);  // 0..3
+    const int loadc_a = tid / (BK / LOAD_VEC_A);  // 0..31
     const int loadr_b = tid % (BK / LOAD_VEC_B);  // 0..7
     const int loadc_b = tid / (BK / LOAD_VEC_B);  // 0..15
 
-    // Number of rows covered per load iteration.
-    const int loadstride_a = get_local_size(0) * LOAD_VEC_A / BK;  // 128*8/32 = 32
-    const int loadstride_b = get_local_size(0) * LOAD_VEC_B / BK;  // 128*4/32 = 16
+    const int loadstride_a = get_local_size(0) * LOAD_VEC_A / BK;  // 32
+    const int loadstride_b = get_local_size(0) * LOAD_VEC_B / BK;  // 16
 
     int pos_b = (batch_idx * batch_stride_b + ic * BN * stride_b) / LOAD_VEC_B;
 
@@ -89,44 +89,59 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
     float cache_a[TM];
     float cache_b[TN];
 
+    #pragma unroll
     for (int i = 0; i < TM * TN; i++) sums[i] = 0.0f;
 
+    // Private register cache for d, dmin, scales per row.
+    // Each thread handles at most 2 rows (l=0 and l=loadstride_a).
+    // Reloaded from src0_meta only when sg==0 (start of each new super-block).
+    float priv_dall[2];
+    float priv_dmin[2];
+    uchar priv_sc[2][K_SCALE_SIZE];
+
     for (int block = 0; block < ne00; block += BK) {
-        // Which super-block and which scale-group within it this BK step covers.
-        const int ib_in_row   = block / QK_K;       // super-block index along K
-        const int sg          = (block / BK) % 8;   // scale-group 0..7 (32 elem each)
-        // Byte offset into qs[0..127] for this thread's 8 elements.
+        const int ib_in_row   = block / QK_K;
+        const int sg          = (block / BK) % 8;   // scale-group 0..7
         const int qs_byte_off = (sg / 2) * 32 + loadr_a * 8;
-        const int nibble_hi   = sg & 1;             // 0 = lo nibble, 1 = hi nibble
+        const int nibble_hi   = sg & 1;
+        const int sg_m4 = sg < 4 ? sg : sg - 4;
 
-        // Scale extraction helper: sg-4 must be clamped to avoid OOB in speculative eval.
-        // On GPUs both branches of a ternary may be evaluated; use sg_m4 as safe index.
-        const int sg_m4 = sg < 4 ? sg : sg - 4;    // always in {0..3}
-
-        // ---- Load tile of A (weight matrix) ----
+        // ---- Load tile of A (Q4_K weights) ----
         for (int l = 0; l < BM; l += loadstride_a) {
             const int row = ir * BM + loadc_a + l;
+            const int li  = l / loadstride_a;  // 0 or 1
             if (row < ne01) {
-                // Flat super-block index (across batch, rows, and K).
-                ulong bi = (ulong)batch_idx_a * ne01 * nb
-                         + (ulong)row * nb
-                         + ib_in_row;
-
-                uchar8 q = vload8(0, src0_qs + bi * 128 + qs_byte_off);
+                // qs from coalesced [batch, nb, ne01, 128] buffer:
+                // stride between adjacent rows = 128 bytes (vs 1728 for packed)
+                ulong qs_t_idx = ((ulong)batch_idx_a * nb + ib_in_row) * ne01 + row;
+                uchar8 q = vload8(0, src0_qs_t + qs_t_idx * 128 + qs_byte_off);
                 uchar8 nibbles = nibble_hi ? (q >> (uchar8)4) : (q & (uchar8)0x0F);
 
-                // Decode scale and min for this scale-group (get_scale_min_k4 layout).
-                global uchar * sc = src0_scales + bi * K_SCALE_SIZE;
-                float scale = sg < 4 ? (float)(sc[sg]   & 63)
-                                     : (float)((sc[sg + 4] & 0x0F) | ((sc[sg_m4] >> 6) << 4));
-                float smin  = sg < 4 ? (float)(sc[sg + 4] & 63)
-                                     : (float)((sc[sg + 4] >>   4) | ((sc[sg]   >> 6) << 4));
-                float dall   = (float)vload_half(0, src0_d    + bi);
-                float dmin_v = (float)vload_half(0, src0_dmin + bi);
-                float ds = dall   * scale;
-                float dm = dmin_v * smin;
+                // Reload d/dmin/scales cache from src0_meta only at start of each
+                // new super-block. All 8 BK steps share the same metadata.
+                if (sg == 0) {
+                    ulong bi = (ulong)batch_idx_a * ne01 * nb
+                             + (ulong)row * nb
+                             + ib_in_row;
+                    global char * bp = src0_meta + bi * BLOCK_Q4_K_SZ;
+                    priv_dall[li] = (float)vload_half(0, (global half*)bp);
+                    priv_dmin[li] = (float)vload_half(1, (global half*)bp);
+                    global uchar * sc_g = (global uchar*)(bp + 4);
+                    for (int i = 0; i < K_SCALE_SIZE; i++) {
+                        priv_sc[li][i] = sc_g[i];
+                    }
+                }
 
-                // Dequantize: w[k] = d*scale*q[k] - dmin*smin
+                // Scale/min decode (get_scale_min_k4), using cached private data
+                float scale = sg < 4
+                    ? (float)(priv_sc[li][sg]   & 63)
+                    : (float)((priv_sc[li][sg + 4] & 0x0F) | ((priv_sc[li][sg_m4] >> 6) << 4));
+                float smin  = sg < 4
+                    ? (float)(priv_sc[li][sg + 4] & 63)
+                    : (float)((priv_sc[li][sg + 4] >>   4) | ((priv_sc[li][sg]   >> 6) << 4));
+                float ds = priv_dall[li] * scale;
+                float dm = priv_dmin[li] * smin;
+
                 buf_a[(loadr_a * 8 + 0) * BM + loadc_a + l] = ds * (float)nibbles.s0 - dm;
                 buf_a[(loadr_a * 8 + 1) * BM + loadc_a + l] = ds * (float)nibbles.s1 - dm;
                 buf_a[(loadr_a * 8 + 2) * BM + loadc_a + l] = ds * (float)nibbles.s2 - dm;
@@ -147,7 +162,7 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
             }
         }
 
-        // ---- Load tile of B (activation matrix, F32) ----
+        // ---- Load tile of B (activations, F32) ----
         for (int l = 0; l < BN; l += loadstride_b) {
             if (ic * BN + loadc_b + l < ne11) {
                 int idx = pos_b + (loadc_b + l) * stride_b / LOAD_VEC_B + loadr_b;
@@ -168,14 +183,16 @@ kernel void kernel_mul_mm_q4_k_f32_l4_lm(
         pos_b += BK / LOAD_VEC_B;
 
         // ---- Compute tile product ----
+        // Unroll only the small inner loops (TM=4, TN=8 are compile-time constants).
+        // Do NOT unroll the outer BK=32 loop — it causes register spill on Apple M1.
         for (int i = 0; i < BK; i++) {
-            for (int j = 0; j < TM; j++) {
-                cache_a[j] = buf_a[i * BM + th_r * TM + j];
-            }
-            for (int j = 0; j < TN; j++) {
-                cache_b[j] = buf_b[i * BN + th_c * TN + j];
-            }
+            #pragma unroll
+            for (int j = 0; j < TM; j++) cache_a[j] = buf_a[i * BM + th_r * TM + j];
+            #pragma unroll
+            for (int j = 0; j < TN; j++) cache_b[j] = buf_b[i * BN + th_c * TN + j];
+            #pragma unroll
             for (int cc = 0; cc < TN; cc++) {
+                #pragma unroll
                 for (int cr = 0; cr < TM; cr++) {
                     sums[cc * TM + cr] = mad(cache_a[cr], cache_b[cc], sums[cc * TM + cr]);
                 }

--- a/ggml/src/ggml-opencl/kernels/mul_mm_q4_k_f32_l4_lm_qst_n32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mm_q4_k_f32_l4_lm_qst_n32.cl
@@ -1,0 +1,206 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+// Q4_K × F32 batch GEMM — narrow-tile qst variant for small N (Apple M1)
+//
+// Identical to mul_mm_q4_k_f32_l4_lm_qst.cl except BN=32 (half width):
+//
+//   BM=64 BN=32 → BN=64 tile would be half-empty for PP32 (ne11=32),
+//   wasting half the threads.  This kernel dispatches for 32 ≤ ne11 < 64.
+//
+// Tile parameters:
+//   BM=64, BN=32, BK=32
+//   TM=4,  TN=4              (BM/TM)*(BN/TN) = 16*8 = 128 threads
+//   LOAD_VEC_A=8             same A load as BN=64 variant
+//   LOAD_VEC_B=4             B loadstride_b=16 → 2 iterations covering BN=32
+//
+// Local memory: (64+32)*32*4 = 12 KB  (vs 16 KB for BN=64 → 1 extra WG/CU)
+
+#define LOAD_VEC_A 8
+#define LOAD_VEC_B 4
+
+#define BM 64
+#define BN 32
+#define BK 32
+#define TM 4
+#define TN 4
+
+#define QK_K          256
+#define K_SCALE_SIZE  12
+#define BLOCK_Q4_K_SZ 144
+
+kernel void kernel_mul_mm_q4_k_f32_l4_lm_qst_n32(
+    global char   * src0_meta,
+    ulong           offset0,
+    global uchar  * src0_qs_t,
+    global float4 * src1,
+    ulong           offset1,
+    global float  * dst,
+    ulong           offsetd,
+    int ne00,
+    int ne01,
+    int ne02,
+    int ne11,
+    int ne12,
+    int stride_b,
+    int stride_d,
+    int batch_stride_b,
+    int batch_stride_d,
+    int r2,
+    int r3
+) {
+    src0_meta = src0_meta + offset0;
+    src1 = (global float4*)((global char*)src1 + offset1);
+    dst  = (global float *)((global char*)dst  + offsetd);
+
+    local float buf_a[BM * BK];  // 64*32*4 =  8 KB
+    local float buf_b[BN * BK];  // 32*32*4 =  4 KB  (total 12 KB)
+
+    const int batch_idx = get_global_id(2);
+    const int i13 = batch_idx / ne12;
+    const int i12 = batch_idx % ne12;
+    const int i03 = i13 / r3;
+    const int i02 = i12 / r2;
+    const int batch_idx_a = i03 * ne02 + i02;
+
+    const int ir  = get_group_id(0);
+    const int ic  = get_group_id(1);
+    const int tid = get_local_id(0);
+
+    // (BM/TM) = 16 threads in the M dimension, (BN/TN) = 8 in the N dimension
+    const int th_r = tid % (BM / TM);  // 0..15
+    const int th_c = tid / (BM / TM);  // 0..7
+
+    // A load: same as BN=64 kernel (A tile only depends on BM and BK)
+    const int loadr_a     = tid % (BK / LOAD_VEC_A);  // 0..3
+    const int loadc_a     = tid / (BK / LOAD_VEC_A);  // 0..31
+    const int loadstride_a = get_local_size(0) * LOAD_VEC_A / BK;  // 32
+
+    // B load: BN=32, LOAD_VEC_B=4 → loadstride_b=16, loop 2×
+    const int loadr_b     = tid % (BK / LOAD_VEC_B);  // 0..7
+    const int loadc_b     = tid / (BK / LOAD_VEC_B);  // 0..15
+    const int loadstride_b = get_local_size(0) * LOAD_VEC_B / BK;  // 16
+
+    int pos_b = (batch_idx * batch_stride_b + ic * BN * stride_b) / LOAD_VEC_B;
+
+    const int nb = ne00 / QK_K;
+
+    float sums[TM * TN];
+    float cache_a[TM];
+    float cache_b[TN];
+
+    #pragma unroll
+    for (int i = 0; i < TM * TN; i++) sums[i] = 0.0f;
+
+    float priv_dall[2];
+    float priv_dmin[2];
+    uchar priv_sc[2][K_SCALE_SIZE];
+
+    for (int block = 0; block < ne00; block += BK) {
+        const int ib_in_row   = block / QK_K;
+        const int sg          = (block / BK) % 8;
+        const int qs_byte_off = (sg / 2) * 32 + loadr_a * 8;
+        const int nibble_hi   = sg & 1;
+        const int sg_m4 = sg < 4 ? sg : sg - 4;
+
+        // ---- Load tile of A (Q4_K weights, same as BN=64 kernel) ----
+        for (int l = 0; l < BM; l += loadstride_a) {
+            const int row = ir * BM + loadc_a + l;
+            const int li  = l / loadstride_a;
+            if (row < ne01) {
+                ulong qs_t_idx = ((ulong)batch_idx_a * nb + ib_in_row) * ne01 + row;
+                uchar8 q = vload8(0, src0_qs_t + qs_t_idx * 128 + qs_byte_off);
+                uchar8 nibbles = nibble_hi ? (q >> (uchar8)4) : (q & (uchar8)0x0F);
+
+                if (sg == 0) {
+                    ulong bi = (ulong)batch_idx_a * ne01 * nb
+                             + (ulong)row * nb
+                             + ib_in_row;
+                    global char * bp = src0_meta + bi * BLOCK_Q4_K_SZ;
+                    priv_dall[li] = (float)vload_half(0, (global half*)bp);
+                    priv_dmin[li] = (float)vload_half(1, (global half*)bp);
+                    global uchar * sc_g = (global uchar*)(bp + 4);
+                    for (int i = 0; i < K_SCALE_SIZE; i++) priv_sc[li][i] = sc_g[i];
+                }
+
+                float scale = sg < 4
+                    ? (float)(priv_sc[li][sg]   & 63)
+                    : (float)((priv_sc[li][sg + 4] & 0x0F) | ((priv_sc[li][sg_m4] >> 6) << 4));
+                float smin  = sg < 4
+                    ? (float)(priv_sc[li][sg + 4] & 63)
+                    : (float)((priv_sc[li][sg + 4] >>   4) | ((priv_sc[li][sg]   >> 6) << 4));
+                float ds = priv_dall[li] * scale;
+                float dm = priv_dmin[li] * smin;
+
+                buf_a[(loadr_a * 8 + 0) * BM + loadc_a + l] = ds * (float)nibbles.s0 - dm;
+                buf_a[(loadr_a * 8 + 1) * BM + loadc_a + l] = ds * (float)nibbles.s1 - dm;
+                buf_a[(loadr_a * 8 + 2) * BM + loadc_a + l] = ds * (float)nibbles.s2 - dm;
+                buf_a[(loadr_a * 8 + 3) * BM + loadc_a + l] = ds * (float)nibbles.s3 - dm;
+                buf_a[(loadr_a * 8 + 4) * BM + loadc_a + l] = ds * (float)nibbles.s4 - dm;
+                buf_a[(loadr_a * 8 + 5) * BM + loadc_a + l] = ds * (float)nibbles.s5 - dm;
+                buf_a[(loadr_a * 8 + 6) * BM + loadc_a + l] = ds * (float)nibbles.s6 - dm;
+                buf_a[(loadr_a * 8 + 7) * BM + loadc_a + l] = ds * (float)nibbles.s7 - dm;
+            } else {
+                buf_a[(loadr_a * 8 + 0) * BM + loadc_a + l] = 0.0f;
+                buf_a[(loadr_a * 8 + 1) * BM + loadc_a + l] = 0.0f;
+                buf_a[(loadr_a * 8 + 2) * BM + loadc_a + l] = 0.0f;
+                buf_a[(loadr_a * 8 + 3) * BM + loadc_a + l] = 0.0f;
+                buf_a[(loadr_a * 8 + 4) * BM + loadc_a + l] = 0.0f;
+                buf_a[(loadr_a * 8 + 5) * BM + loadc_a + l] = 0.0f;
+                buf_a[(loadr_a * 8 + 6) * BM + loadc_a + l] = 0.0f;
+                buf_a[(loadr_a * 8 + 7) * BM + loadc_a + l] = 0.0f;
+            }
+        }
+
+        // ---- Load tile of B (activations, F32) — BN=32 ----
+        for (int l = 0; l < BN; l += loadstride_b) {
+            if (ic * BN + loadc_b + l < ne11) {
+                int idx = pos_b + (loadc_b + l) * stride_b / LOAD_VEC_B + loadr_b;
+                buf_b[(loadr_b * LOAD_VEC_B + 0) * BN + loadc_b + l] = src1[idx].s0;
+                buf_b[(loadr_b * LOAD_VEC_B + 1) * BN + loadc_b + l] = src1[idx].s1;
+                buf_b[(loadr_b * LOAD_VEC_B + 2) * BN + loadc_b + l] = src1[idx].s2;
+                buf_b[(loadr_b * LOAD_VEC_B + 3) * BN + loadc_b + l] = src1[idx].s3;
+            } else {
+                buf_b[(loadr_b * LOAD_VEC_B + 0) * BN + loadc_b + l] = 0.0f;
+                buf_b[(loadr_b * LOAD_VEC_B + 1) * BN + loadc_b + l] = 0.0f;
+                buf_b[(loadr_b * LOAD_VEC_B + 2) * BN + loadc_b + l] = 0.0f;
+                buf_b[(loadr_b * LOAD_VEC_B + 3) * BN + loadc_b + l] = 0.0f;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        pos_b += BK / LOAD_VEC_B;
+
+        // ---- Compute tile product (TN=4 instead of 8) ----
+        for (int i = 0; i < BK; i++) {
+            #pragma unroll
+            for (int j = 0; j < TM; j++) cache_a[j] = buf_a[i * BM + th_r * TM + j];
+            #pragma unroll
+            for (int j = 0; j < TN; j++) cache_b[j] = buf_b[i * BN + th_c * TN + j];
+            #pragma unroll
+            for (int cc = 0; cc < TN; cc++) {
+                #pragma unroll
+                for (int cr = 0; cr < TM; cr++) {
+                    sums[cc * TM + cr] = mad(cache_a[cr], cache_b[cc], sums[cc * TM + cr]);
+                }
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    // ---- Write output ----
+    const int dr      = ir * BM + th_r * TM;
+    const int dc      = ic * BN + th_c * TN;
+    const int offsets = batch_idx * batch_stride_d;
+
+    #pragma unroll
+    for (int cc = 0; cc < TN; cc++) {
+        #pragma unroll
+        for (int cr = 0; cr < TM; cr++) {
+            if (dr + cr < ne01 && dc + cc < ne11) {
+                dst[offsets + (dc + cc) * stride_d + dr + cr] = sums[cc * TM + cr];
+            }
+        }
+    }
+}

--- a/ggml/src/ggml-opencl/kernels/mul_mv_f16_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_f16_f16.cl
@@ -64,6 +64,29 @@ kernel void kernel_mul_mat_f16_f16(
 
     global half * x = (global half *) (src0 + offset_src0);
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0) {
+        return;
+    }
+
+    for (int row = 0; row < N_F16_F16; ++row) {
+        int r1 = rb + row;
+        if (r1 >= ne11) {
+            break;
+        }
+
+        ulong offset_src1 = r1*nb11 + (i12   )*nb12 + (i13   )*nb13;
+        global half * y = (global half *) (src1 + offset_src1);
+
+        float all_sum_nv = 0.0f;
+        for (int i = 0; i < ne00; ++i) {
+            all_sum_nv += (float) x[i] * (float) y[i];
+        }
+        dst[im*ne1*ne0 + r1*ne0 + r0] = all_sum_nv;
+    }
+    return;
+#endif
+
     if (ne00 < 128) {
         for (int row = 0; row < N_F16_F16; ++row) {
             int r1 = rb + row;

--- a/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32.cl
@@ -64,6 +64,30 @@ kernel void kernel_mul_mat_f16_f32(
 
     global half * x = (global half *) (src0 + offset_src0);
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0) {
+        return;
+    }
+
+    for (int row = 0; row < N_F16_F32; ++row) {
+        int r1 = rb + row;
+        if (r1 >= ne11) {
+            break;
+        }
+
+        ulong offset_src1 = r1*nb11 + (i12   )*nb12 + (i13   )*nb13;
+
+        float all_sum_nv = 0.0f;
+        for (int i = 0; i < ne00; ++i) {
+            global half  * x_elem = (global half  *) (src0 + offset_src0 + (ulong) i * nb00);
+            global float * y_elem = (global float *) (src1 + offset_src1 + (ulong) i * nb10);
+            all_sum_nv += (float) x_elem[0] * y_elem[0];
+        }
+        dst[im*ne1*ne0 + r1*ne0 + r0] = all_sum_nv;
+    }
+    return;
+#endif
+
     if (ne00 < 128) {
         for (int row = 0; row < N_F16_F32; ++row) {
             int r1 = rb + row;
@@ -77,7 +101,7 @@ kernel void kernel_mul_mat_f16_f32(
 
             float sumf = 0;
             for (int i = get_sub_group_local_id(); i < ne00; i += get_max_sub_group_size()) {
-                sumf += convert_float(x[i]) * y[i];
+                sumf += (float) x[i] * y[i];
             }
 
             float all_sum = sub_group_reduce_add(sumf);
@@ -100,10 +124,10 @@ kernel void kernel_mul_mat_f16_f32(
 
             float sumf = 0;
             for (int i = get_sub_group_local_id(); i < ne00/4; i += get_max_sub_group_size()) {
-                sumf += convert_float(x4[i].s0) * y4[i].s0;
-                sumf += convert_float(x4[i].s1) * y4[i].s1;
-                sumf += convert_float(x4[i].s2) * y4[i].s2;
-                sumf += convert_float(x4[i].s3) * y4[i].s3;
+                sumf += (float) x4[i].s0 * y4[i].s0;
+                sumf += (float) x4[i].s1 * y4[i].s1;
+                sumf += (float) x4[i].s2 * y4[i].s2;
+                sumf += (float) x4[i].s3 * y4[i].s3;
             }
 
             float all_sum = sub_group_reduce_add(sumf);

--- a/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_1row.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_1row.cl
@@ -64,6 +64,21 @@ kernel void kernel_mul_mat_f16_f32_1row(
     global half  * x = (global half  *) (src0 + offset_src0);
     global float * y = (global float *) (src1 + offset_src1);
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0) {
+        return;
+    }
+
+    float all_sum_nv = 0.0f;
+    for (int i = 0; i < ne00; ++i) {
+        global half  * x_elem = (global half  *) (src0 + offset_src0 + (ulong) i * nb00);
+        global float * y_elem = (global float *) (src1 + offset_src1 + (ulong) i * nb10);
+        all_sum_nv += (float) x_elem[0] * y_elem[0];
+    }
+    dst[im*ne1*ne0 + r1*ne0 + r0] = all_sum_nv;
+    return;
+#endif
+
     float sumf = 0;
     if (ne00 < 128) {
         for (int i = get_sub_group_local_id(); i < ne00; i += get_max_sub_group_size()) {

--- a/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_l4.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_l4.cl
@@ -63,6 +63,41 @@ kernel void kernel_mul_mat_f16_f32_l4(
 
     global half4 * x4 = (global half4 *) (src0 + offset_src0);
 
+#ifdef NVIDIA_GPU
+    // Parallel local-memory reduction: all 32 threads collaborate on each dot product.
+    // Replaces the original single-threaded path (thread 0 only) for Apple M1 OpenCL.
+    __local float lm[32];
+    int lid = get_local_id(0);
+
+    for (int r1 = 0; r1 < nrows; ++r1) {
+        ulong offset_src1 = r1*nb11 + (i12)*nb12 + (i13)*nb13;
+        global float4 * y4 = (global float4 *)(src1 + offset_src1);
+
+        float sumf = 0.0f;
+        for (int i = lid; i < ne00/4; i += 32) {
+            sumf += (float)x4[i].s0 * y4[i].s0;
+            sumf += (float)x4[i].s1 * y4[i].s1;
+            sumf += (float)x4[i].s2 * y4[i].s2;
+            sumf += (float)x4[i].s3 * y4[i].s3;
+        }
+
+        lm[lid] = sumf;
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int s = 16; s > 0; s >>= 1) {
+            if (lid < s) {
+                lm[lid] += lm[lid + s];
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+
+        if (lid == 0) {
+            dst[im*ne1*ne0 + r1*ne0 + r0] = lm[0];
+        }
+    }
+    return;
+#else
+    // Subgroup path for Adreno and other GPUs with native subgroup support.
     for (int r1 = 0; r1 < nrows; ++r1) {
         ulong offset_src1 = r1*nb11 + (i12   )*nb12 + (i13   )*nb13;
 
@@ -70,10 +105,10 @@ kernel void kernel_mul_mat_f16_f32_l4(
 
         float sumf = 0;
         for (int i = get_sub_group_local_id(); i < ne00/4; i += get_max_sub_group_size()) {
-            sumf += convert_float(x4[i].s0) * y4[i].s0;
-            sumf += convert_float(x4[i].s1) * y4[i].s1;
-            sumf += convert_float(x4[i].s2) * y4[i].s2;
-            sumf += convert_float(x4[i].s3) * y4[i].s3;
+            sumf += (float) x4[i].s0 * y4[i].s0;
+            sumf += (float) x4[i].s1 * y4[i].s1;
+            sumf += (float) x4[i].s2 * y4[i].s2;
+            sumf += (float) x4[i].s3 * y4[i].s3;
         }
 
         float all_sum = sub_group_reduce_add(sumf);
@@ -81,4 +116,5 @@ kernel void kernel_mul_mat_f16_f32_l4(
             dst[im*ne1*ne0 + r1*ne0 + r0] = all_sum;
         }
     }
+#endif
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mv_f32_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_f32_f32.cl
@@ -64,6 +64,74 @@ kernel void kernel_mul_mat_f32_f32(
 
     global float * x = (global float *) (src0 + offset_src0);
 
+#ifdef NVIDIA_GPU
+    // NVIDIA: cl_khr_subgroups unavailable; use __local tree-reduction.
+    // Local work size = 32 (one warp); N_F32_F32 rows reduced independently.
+    __local float lm[N_F32_F32 * 32];
+    int lid = get_local_id(0);
+
+    float sumf_rows[N_F32_F32];
+    for (int row = 0; row < N_F32_F32; ++row) {
+        sumf_rows[row] = 0.0f;
+    }
+
+    if (ne00 < 128) {
+        for (int row = 0; row < N_F32_F32; ++row) {
+            int r1 = rb + row;
+            if (r1 >= ne11) break;
+            ulong offset_src1 = r1*nb11 + i12*nb12 + i13*nb13;
+            global float * y = (global float *) (src1 + offset_src1);
+            float sumf = 0;
+            for (int i = lid; i < ne00; i += 32) {
+                sumf += x[i] * y[i];
+            }
+            sumf_rows[row] = sumf;
+        }
+    } else {
+        global float4 * x4 = (global float4 *)x;
+        for (int row = 0; row < N_F32_F32; ++row) {
+            int r1 = rb + row;
+            if (r1 >= ne11) break;
+            ulong offset_src1 = r1*nb11 + i12*nb12 + i13*nb13;
+            global float4 * y4 = (global float4 *) (src1 + offset_src1);
+            float sumf = 0;
+            for (int i = lid; i < ne00/4; i += 32) {
+                float4 xi = x4[i], yi = y4[i];
+                sumf += xi.s0*yi.s0 + xi.s1*yi.s1 + xi.s2*yi.s2 + xi.s3*yi.s3;
+            }
+            sumf_rows[row] = sumf;
+        }
+    }
+
+    for (int row = 0; row < N_F32_F32; ++row) {
+        lm[row * 32 + lid] = sumf_rows[row];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = 16; s > 0; s >>= 1) {
+        if (lid < s) {
+            for (int row = 0; row < N_F32_F32; ++row) {
+                lm[row * 32 + lid] += lm[row * 32 + lid + s];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        for (int row = 0; row < N_F32_F32; ++row) {
+            int r1 = rb + row;
+            if (r1 >= ne11) break;
+            float result = lm[row * 32];
+            // add tail elements for the float4 path
+            if (ne00 >= 128) {
+                ulong offset_src1 = r1*nb11 + i12*nb12 + i13*nb13;
+                global float * y = (global float *) (src1 + offset_src1);
+                for (int i = 4*(ne00/4); i < ne00; ++i) {
+                    result += x[i] * y[i];
+                }
+            }
+            dst[im*ne1*ne0 + r1*ne0 + r0] = result;
+        }
+    }
+#else
     if (ne00 < 128) {
         for (int row = 0; row < N_F32_F32; ++row) {
             int r1 = rb + row;
@@ -115,4 +183,5 @@ kernel void kernel_mul_mat_f32_f32(
             }
         }
     }
+#endif
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mv_id_mxfp4_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_id_mxfp4_f32_flat.cl
@@ -54,6 +54,23 @@ static inline float e8m0_to_fp32(uchar x) {
     return as_float(bits);
 }
 
+constant static float kvalues_mxfp4_f[16] = {
+    0, .5f, 1.f, 1.5f, 2.f, 3.f, 4.f, 6.f, -0, -.5f, -1.f, -1.5f, -2.f, -3.f, -4.f, -6.f
+};
+
+#ifdef NVIDIA_GPU
+static inline float block_mxfp4_dot_y_ref(global uchar * q, uchar e, global float * y) {
+    const float d = 0.5f * e8m0_to_fp32(e);
+    float sum = 0.0f;
+    for (int i = 0; i < QK_MXFP4/2; ++i) {
+        const uchar packed = q[i];
+        sum += kvalues_mxfp4_f[packed & 0x0F] * y[i];
+        sum += kvalues_mxfp4_f[packed >> 4]   * y[i + QK_MXFP4/2];
+    }
+    return sum * d;
+}
+#endif
+
 #ifdef INTEL_GPU
 #define N_R0_MXFP4 2 // number of rows each subgroup works on
 #define N_SG_MXFP4 2 // number of subgroups in a work group
@@ -135,6 +152,36 @@ kernel void kernel_mul_mv_id_mxfp4_f32_flat(
 
     src1 = src1 + offset1 + i11 * nb11 + iid1 * nb12;
     global float * y   = (global float *) (src1 + r1 * nb11);
+
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0 || get_local_id(1) != 0) {
+        return;
+    }
+
+    const int first_row_nv = r0 * N_R0_MXFP4;
+    global float * dst_f32_nv = (global float *)dst + (ulong)r1 * ne0;
+
+    for (int row = 0; row < N_R0_MXFP4; ++row) {
+        if (first_row_nv + row >= ne0) {
+            continue;
+        }
+
+        uint offset_src0_nv = first_row_nv * nb01;
+        offset_src0_nv /= 17;
+
+        global uchar * row_q = src0_q + (src0_off + offset_src0_nv + row * nb) * 16;
+        global uchar * row_e = src0_e +  src0_off + offset_src0_nv + row * nb;
+
+        float total = 0.0f;
+        for (int ib = 0; ib < nb; ++ib) {
+            total += block_mxfp4_dot_y_ref(row_q + ib * 16, row_e[ib], y + ib * QK_MXFP4);
+        }
+
+        dst_f32_nv[first_row_nv + row] = total;
+    }
+    return;
+#endif
+
     global float * yb = y + ix * QK_MXFP4 + it * 8;
 
     for (int ib = ix; ib < nb; ib += N_SIMDWIDTH / 2) {

--- a/ggml/src/ggml-opencl/kernels/mul_mv_mxfp4_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_mxfp4_f32_flat.cl
@@ -54,6 +54,23 @@ static inline float e8m0_to_fp32(uchar x) {
     return as_float(bits);
 }
 
+constant static float kvalues_mxfp4_f[16] = {
+    0, .5f, 1.f, 1.5f, 2.f, 3.f, 4.f, 6.f, -0, -.5f, -1.f, -1.5f, -2.f, -3.f, -4.f, -6.f
+};
+
+#ifdef NVIDIA_GPU
+static inline float block_mxfp4_dot_y_ref(global uchar * q, uchar e, global float * y) {
+    float sum = 0.0f;
+    const float d = e8m0_to_fp32(e);
+    for (int i = 0; i < QK_MXFP4/2; ++i) {
+        const uchar packed = q[i];
+        sum += kvalues_mxfp4_f[packed & 0x0F] * y[i];
+        sum += kvalues_mxfp4_f[packed >> 4]   * y[i + QK_MXFP4/2];
+    }
+    return sum * d;
+}
+#endif
+
 #ifdef INTEL_GPU
 #define N_R0_MXFP4 2 // number of rows each subgroup works on
 #define N_SG_MXFP4 2 // number of subgroups in a work group
@@ -120,6 +137,35 @@ kernel void kernel_mul_mv_mxfp4_f32_flat(
 
     ulong offset_src1 = r1 * nb11 + i12 * nb12 + i13 * nb13;
     global float * y = (global float *)(src1 + offset_src1);
+
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0 || get_local_id(1) != 0) {
+        return;
+    }
+
+    const int first_row_nv = r0 * N_R0_MXFP4;
+    global float * dst_f32_nv = (global float *) dst + (ulong)im*ne0*ne1 + (ulong)r1*ne0;
+
+    for (int row = 0; row < N_R0_MXFP4; ++row) {
+        if (first_row_nv + row >= ne0) {
+            continue;
+        }
+
+        uint offset_src0_nv = (first_row_nv + row)*nb01 + (i12/r2)*nb02 + (i13/r3)*nb03;
+        offset_src0_nv /= 17;
+
+        global uchar * row_q = src0_q + offset_src0_nv * 16;
+        global uchar * row_e = src0_e + offset_src0_nv;
+
+        float total = 0.0f;
+        for (int ib = 0; ib < nb; ++ib) {
+            total += block_mxfp4_dot_y_ref(row_q + ib * 16, row_e[ib], y + ib * QK_MXFP4);
+        }
+
+        dst_f32_nv[first_row_nv + row] = total;
+    }
+    return;
+#endif
 
     const short ix = get_sub_group_local_id() >> 1;  // 0...15
     const short it = get_sub_group_local_id() & 1;  // 0 or 1

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q4_0_f32_8x_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q4_0_f32_8x_flat.cl
@@ -101,6 +101,12 @@ inline float block_q_4_0_dot_y_flat(
 #define N_SIMDWIDTH 64
 #endif
 
+// NVIDIA: warp width = 32; N_SIMDGROUP=1 (one warp per WG)
+#ifdef NVIDIA_GPU
+#undef N_SIMDWIDTH
+#define N_SIMDWIDTH 32
+#endif
+
 inline void mul_vec_q_n_f32_8x_flat(
         global uchar * src0_q,
         global half  * src0_d,
@@ -114,7 +120,8 @@ inline void mul_vec_q_n_f32_8x_flat(
         int ne0,
         int ne1,
         int r2,
-        int r3
+        int r3,
+        local float8 * lm
 ) {
     const ulong nb = ne00/QK4_0;
 
@@ -207,6 +214,26 @@ inline void mul_vec_q_n_f32_8x_flat(
         yb += QK4_0 * (N_SIMDWIDTH/2);
     }
 
+#ifdef NVIDIA_GPU
+    // NVIDIA: cl_khr_subgroups unavailable; use __local tree-reduction.
+    int lid = get_local_id(0);
+    lm[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = 16; s > 0; s >>= 1) {
+        if (lid < s) lm[lid] += lm[lid + s];
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        if (first_row + 0 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = lm[0].s0;
+        if (first_row + 1 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = lm[0].s1;
+        if (first_row + 2 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = lm[0].s2;
+        if (first_row + 3 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = lm[0].s3;
+        if (first_row + 4 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 4] = lm[0].s4;
+        if (first_row + 5 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 5] = lm[0].s5;
+        if (first_row + 6 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 6] = lm[0].s6;
+        if (first_row + 7 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 7] = lm[0].s7;
+    }
+#else
     float8 tot = (float8)(
         sub_group_reduce_add(sumf.s0), sub_group_reduce_add(sumf.s1),
         sub_group_reduce_add(sumf.s2), sub_group_reduce_add(sumf.s3),
@@ -215,32 +242,16 @@ inline void mul_vec_q_n_f32_8x_flat(
     );
 
     if (get_sub_group_local_id() == 0) {
-        if (first_row + 0 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = tot.s0;
-        }
-        if (first_row + 1 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = tot.s1;
-        }
-        if (first_row + 2 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = tot.s2;
-        }
-        if (first_row + 3 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = tot.s3;
-        }
-
-        if (first_row + 4 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 4] = tot.s4;
-        }
-        if (first_row + 5 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 5] = tot.s5;
-        }
-        if (first_row + 6 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 6] = tot.s6;
-        }
-        if (first_row + 7 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 7] = tot.s7;
-        }
+        if (first_row + 0 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = tot.s0;
+        if (first_row + 1 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = tot.s1;
+        if (first_row + 2 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = tot.s2;
+        if (first_row + 3 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = tot.s3;
+        if (first_row + 4 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 4] = tot.s4;
+        if (first_row + 5 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 5] = tot.s5;
+        if (first_row + 6 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 6] = tot.s6;
+        if (first_row + 7 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 7] = tot.s7;
     }
+#endif
 }
 
 #ifdef INTEL_GPU
@@ -268,5 +279,6 @@ kernel void kernel_mul_mat_q4_0_f32_8x_flat(
     src1 = (global float*)((global char*)src1 + offset1);
     dst = (global float*)((global char*)dst + offsetd);
 
-    mul_vec_q_n_f32_8x_flat(src0_q, src0_d, src1, dst, ne00, ne01, ne02, ne10, ne12, ne0, ne1, r2, r3);
+    local float8 lm[32];
+    mul_vec_q_n_f32_8x_flat(src0_q, src0_d, src1, dst, ne00, ne01, ne02, ne10, ne12, ne0, ne1, r2, r3, lm);
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q4_1_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q4_1_f32_flat.cl
@@ -77,6 +77,12 @@ inline float block_q4_1_dot_y_flat(
 #define N_SIMDWIDTH 64
 #endif
 
+// NVIDIA: warp width = 32; N_SIMDGROUP=1 (one warp per WG)
+#ifdef NVIDIA_GPU
+#undef N_SIMDWIDTH
+#define N_SIMDWIDTH 32
+#endif
+
 inline void mul_vec_q_n_f32_flat(
         global void * src0_q,
         global void * src0_d,
@@ -91,7 +97,8 @@ inline void mul_vec_q_n_f32_flat(
         int ne0,
         int ne1,
         int r2,
-        int r3
+        int r3,
+        local float4 * lm
 ) {
     const ulong nb = ne00/QK4_1;
 
@@ -178,25 +185,34 @@ inline void mul_vec_q_n_f32_flat(
         yb += QK4_1 * (N_SIMDWIDTH/2);
     }
 
+#ifdef NVIDIA_GPU
+    // NVIDIA: cl_khr_subgroups unavailable; use __local tree-reduction.
+    int lid = get_local_id(0);
+    lm[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = 16; s > 0; s >>= 1) {
+        if (lid < s) lm[lid] += lm[lid + s];
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        if (first_row + 0 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = lm[0].s0;
+        if (first_row + 1 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = lm[0].s1;
+        if (first_row + 2 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = lm[0].s2;
+        if (first_row + 3 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = lm[0].s3;
+    }
+#else
     float4 tot = (float4)(
         sub_group_reduce_add(sumf.s0), sub_group_reduce_add(sumf.s1),
         sub_group_reduce_add(sumf.s2), sub_group_reduce_add(sumf.s3)
     );
 
     if (get_sub_group_local_id() == 0) {
-        if (first_row + 0 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = tot.s0;
-        }
-        if (first_row + 1 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = tot.s1;
-        }
-        if (first_row + 2 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = tot.s2;
-        }
-        if (first_row + 3 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = tot.s3;
-        }
+        if (first_row + 0 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = tot.s0;
+        if (first_row + 1 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = tot.s1;
+        if (first_row + 2 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = tot.s2;
+        if (first_row + 3 < ne01) dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = tot.s3;
     }
+#endif
 }
 
 #ifdef INTEL_GPU
@@ -225,5 +241,6 @@ kernel void kernel_mul_mv_q4_1_f32_flat(
     src1 = (global float*)((global char*)src1 + offset1);
     dst = (global float*)((global char*)dst + offsetd);
 
-    mul_vec_q_n_f32_flat(src0_q, src0_d, src0_m, src1, dst, ne00, ne01, ne02, ne10, ne12, ne0, ne1, r2, r3);
+    local float4 lm[32];
+    mul_vec_q_n_f32_flat(src0_q, src0_d, src0_m, src1, dst, ne00, ne01, ne02, ne10, ne12, ne0, ne1, r2, r3, lm);
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32.cl
@@ -40,10 +40,27 @@ typedef struct {
 #define N_SIMDWIDTH 64
 #endif
 
+// NVIDIA: override to warp width so all 32 lanes participate.
+// Apple M1 no-subgroups compat mode defines both NVIDIA_GPU and INTEL_GPU;
+// that path uses nth0=16, so BLOCK_STRIDE is overridden to 2 below so that
+// ix ∈ {0,1} covers all super-blocks without changing the dispatch size.
+#ifdef NVIDIA_GPU
+#undef N_SIMDWIDTH
+#define N_SIMDWIDTH 32
+#endif
+
 #undef  BLOCK_STRIDE
 // number of (super) blocks each subgroup processes
 // each thread in a subgroup processes a block (32 weights)
 #define BLOCK_STRIDE (N_SIMDWIDTH/8)
+
+// Apple M1 compat (NVIDIA_GPU && INTEL_GPU, nth0=16): ix ∈ {0,1} only.
+// Override BLOCK_STRIDE to 2 so both ix values together cover all super-blocks
+// (stride 2: ix=0→blocks 0,2,4,...; ix=1→blocks 1,3,5,...).
+#if defined(NVIDIA_GPU) && defined(INTEL_GPU)
+#undef  BLOCK_STRIDE
+#define BLOCK_STRIDE 2
+#endif
 
 #ifdef INTEL_GPU
 REQD_SUBGROUP_SIZE_16
@@ -79,8 +96,15 @@ kernel void kernel_mul_mv_q4_K_f32(
     ushort kmask2 = 0x0f0f;
     ushort kmask3 = 0xc0c0;
 
+    // In the NVIDIA path (including Apple M1 no-subgroups compat), subgroup
+    // functions are unavailable; use get_local_id(0) directly.
+#ifdef NVIDIA_GPU
+    int ix = get_local_id(0)/8;
+    int it = get_local_id(0)%8;
+#else
     int ix = get_sub_group_local_id()/8;  // super block index
     int it = get_sub_group_local_id()%8;  // block index (inside super block)
+#endif
     int iq = it/4;     // 0 or 1 - first or second half of the super block
     int ir = it%4;     // 0...3 - block index in the half super block
 
@@ -89,7 +113,12 @@ kernel void kernel_mul_mv_q4_K_f32(
     int r0 = get_group_id(0);
     int r1 = get_group_id(1);
     int im = get_group_id(2);
+#ifdef NVIDIA_GPU
+    // N_SIMDGROUP=1 in NVIDIA/compat path; no sub_group_id call needed.
+    int first_row = r0 * N_DST;
+#else
     int first_row = (r0 * N_SIMDGROUP + get_sub_group_id()) * N_DST;
+#endif
 
     int i12 = im%ne12;
     int i13 = im/ne12;
@@ -151,8 +180,8 @@ kernel void kernel_mul_mv_q4_K_f32(
                 acc2.s3 += yh[i+9] * (q2[i/2] & 0xF000);
             }
 
-            float dall = dh[0];
-            float dmin = dh[1];
+            float dall = vload_half(0, dh);
+            float dmin = vload_half(1, dh);
             sumf[row] += dall * ((acc1.s0 + 1.f/256.f * acc1.s1) * sc8[0] +
                                  (acc1.s2 + 1.f/256.f * acc1.s3) * sc8[1] * 1.f/16.f +
                                  (acc2.s0 + 1.f/256.f * acc2.s1) * sc8[4] +
@@ -169,6 +198,58 @@ kernel void kernel_mul_mv_q4_K_f32(
 
     global float * dst_f32 = (global float *) dst + im*ne0*ne1 + r1*ne0;
 
+#ifdef NVIDIA_GPU
+    // cl_khr_subgroups is unavailable on NVIDIA/compat OpenCL.
+    // Use __local tree-reduction instead.
+    int lid = get_local_id(0);
+#if defined(INTEL_GPU)
+    // Apple M1 compat: nth0=16, BLOCK_STRIDE=2, all super-blocks processed.
+    // Use lm[N_DST*16] to match the actual work-group size and avoid reading
+    // uninitialized memory that would arise from a larger lm[N_DST*32] array.
+    __local float lm[N_DST * 16];
+    for (int row = 0; row < N_DST; ++row) {
+        lm[row * 16 + lid] = sumf[row];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = 8; s > 0; s >>= 1) {
+        if (lid < s) {
+            for (int row = 0; row < N_DST; ++row) {
+                lm[row * 16 + lid] += lm[row * 16 + lid + s];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        for (int row = 0; row < N_DST; ++row) {
+            if (first_row + row < ne01) {
+                dst_f32[first_row + row] = lm[row * 16];
+            }
+        }
+    }
+#else
+    // True NVIDIA: nth0=32 (N_SIMDWIDTH=32), BLOCK_STRIDE=4.
+    __local float lm[N_DST * N_SIMDWIDTH];
+    for (int row = 0; row < N_DST; ++row) {
+        lm[row * N_SIMDWIDTH + lid] = sumf[row];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = N_SIMDWIDTH / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            for (int row = 0; row < N_DST; ++row) {
+                lm[row * N_SIMDWIDTH + lid] += lm[row * N_SIMDWIDTH + lid + s];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        for (int row = 0; row < N_DST; ++row) {
+            if (first_row + row < ne01) {
+                dst_f32[first_row + row] = lm[row * N_SIMDWIDTH];
+            }
+        }
+    }
+#endif
+#else
     for (int row = 0; row < N_DST; ++row) {
         all_sum = sub_group_reduce_add(sumf[row]);
         if (first_row + row < ne01) {
@@ -177,4 +258,5 @@ kernel void kernel_mul_mv_q4_K_f32(
             }
         }
     }
+#endif
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32_flat.cl
@@ -230,6 +230,16 @@ kernel void kernel_mul_mv_q4_K_f32_flat(
 
 #define N_SIMDWIDTH 32
 
+// Apple M1 no-subgroups compat mode defines BOTH NVIDIA_GPU and INTEL_GPU.
+// Override N_SIMDWIDTH to 32 to match the nth0=32 workgroup dispatch used for
+// this GPU — with nth0=16 (INTEL path default), lm[N_SIMDWIDTH] would be
+// under-sized and threads lid=16..31 would write out of bounds.
+// BLOCK_STRIDE = 32/16 = 2 so ix ∈ {0,1} covers all super-blocks correctly.
+#if defined(NVIDIA_GPU) && defined(INTEL_GPU)
+#undef  N_SIMDWIDTH
+#define N_SIMDWIDTH 32
+#endif
+
 // 16 threads collaborate on one super-block, BLOCK_STRIDE super-blocks per iteration
 #define BLOCK_STRIDE (N_SIMDWIDTH/16)
 

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32_flat.cl
@@ -1,5 +1,7 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
+#ifndef NVIDIA_GPU
+
 #ifdef cl_intel_subgroups
 #pragma OPENCL EXTENSION cl_intel_subgroups : enable
 #else
@@ -192,5 +194,220 @@ kernel void kernel_mul_mv_q4_K_f32_flat(
                 dst_f32[first_row + row] = all_sum;
             }
         }
+    }
+}
+
+#endif // !NVIDIA_GPU
+
+// NVIDIA OpenCL does not expose cl_khr_subgroups as a compile-time extension
+// macro, so we skip the #pragma here and use __local tree-reduction instead.
+
+// SOA flat kernel for Q4_K x f32 matrix-vector multiply.
+// NVIDIA only: N_SIMDWIDTH=32 (warp), BLOCK_STRIDE=2, __local tree-reduction.
+//
+// Q4_K qs byte layout (SOA, 128 bytes per super-block = QK_K/2):
+//   qs[ 0..31]: lo nibble = element   0..31  (sg=0),  hi nibble = element  32..63  (sg=1)
+//   qs[32..63]: lo nibble = element  64..95  (sg=2),  hi nibble = element  96..127 (sg=3)
+//   qs[64..95]: lo nibble = element 128..159 (sg=4),  hi nibble = element 160..191 (sg=5)
+//   qs[96..127]:lo nibble = element 192..223 (sg=6),  hi nibble = element 224..255 (sg=7)
+//
+// Thread mapping (16 threads per super-block):
+//   tid = lid / BLOCK_STRIDE  (0..15)   role within super-block
+//   ix  = lid % BLOCK_STRIDE  (0..BLOCK_STRIDE-1)  which super-block this thread handles
+//   ip  = tid / 8  (0..1)   first or second 64-byte qs section
+//   il  = tid % 8  (0..7)   8-byte segment within section
+//   sg_lo = 4*ip + 2*(il/4)   scale-group for lo nibbles (0,2,4,6)
+//   sg_hi = sg_lo + 1          scale-group for hi nibbles (1,3,5,7)
+//   q_off    = 64*ip + 8*il   byte offset into qs[0..127]
+//   y_lo_off = 32*sg_lo + 8*(il&3)
+//   y_hi_off = y_lo_off + 32
+//
+// Scale decode follows get_scale_min_k4 from ggml-quants.c.
+
+#define QK_K         256
+#define K_SCALE_SIZE 12
+#define N_DST        4
+
+#define N_SIMDWIDTH 32
+
+// 16 threads collaborate on one super-block, BLOCK_STRIDE super-blocks per iteration
+#define BLOCK_STRIDE (N_SIMDWIDTH/16)
+
+kernel void kernel_mul_mv_q4_K_f32_flat(
+    global uchar * src0_qs,
+    global uchar * src0_scales,
+    global half  * src0_d,
+    global half  * src0_dmin,
+    global char  * src1,
+    int            offset1,
+    global char  * dst,
+    int            offsetd,
+    int            ne00,
+    int            ne01,
+    int            ne02,
+    int            ne12,
+    ulong          nb11,
+    ulong          nb12,
+    ulong          nb13,
+    int            ne0,
+    int            ne1,
+    int            r2,
+    int            r3
+) {
+    src1 = src1 + offset1;
+    dst  = dst  + offsetd;
+
+    int nb = ne00 / QK_K;
+
+    int r0 = get_group_id(0);
+    int r1 = get_group_id(1);
+    int im = get_group_id(2);
+
+    int first_row = r0 * N_DST;
+    int i12 = im % ne12;
+    int i13 = im / ne12;
+
+    ulong offset_src1 = (ulong)r1*nb11 + (ulong)i12*nb12 + (ulong)i13*nb13;
+    global float * y = (global float *)(src1 + offset_src1);
+
+    // Flat block index base for src0 (in units of super-blocks).
+    // Layout: [ne02][ne01][nb] super-blocks, with GQA broadcasting via r2/r3.
+    ulong offset_src0 = (ulong)first_row * nb
+                      + (ulong)(i12/r2) * ((ulong)nb * ne01)
+                      + (ulong)(i13/r3) * ((ulong)nb * ne01 * ne02);
+
+    int lid = get_local_id(0);
+    int tid = lid / BLOCK_STRIDE;  // 0..15: role within a super-block
+    int ix  = lid % BLOCK_STRIDE;  // 0..BLOCK_STRIDE-1: which super-block per iter
+
+    int ip  = tid / 8;             // 0 or 1 (which 64-byte qs section)
+    int il  = tid % 8;             // 0..7  (8-byte segment within section)
+
+    // Scale groups for lo and hi nibbles of this thread's 8 qs bytes.
+    int sg_lo = 4*ip + 2*(il/4);  // in {0,2,4,6}
+    int sg_hi = sg_lo + 1;        // in {1,3,5,7}
+    // Clamped versions for safe speculative evaluation in ternary false-branch
+    // (GPU evaluates both branches; negative index -> page fault).
+    int sg_lo_m4 = max(sg_lo - 4, 0);  // safe substitute for sg_lo-4
+    int sg_hi_m4 = max(sg_hi - 4, 0);  // safe substitute for sg_hi-4
+
+    // Byte offset into qs[0..127] for this thread's 8 bytes.
+    int q_off = 64*ip + 8*il;
+
+    // Y element offsets.
+    int y_lo_off = 32*sg_lo + 8*(il & 3);
+    int y_hi_off = y_lo_off + 32;
+
+    float4 sumf = (float4)(0.f);
+
+    for (int ib = ix; ib < nb; ib += BLOCK_STRIDE) {
+        global float * yb = y + (ulong)ib * QK_K;
+
+        float4 ylo0 = vload4(0, yb + y_lo_off);      // y[y_lo_off..y_lo_off+3]
+        float4 ylo1 = vload4(0, yb + y_lo_off + 4);  // y[y_lo_off+4..y_lo_off+7]
+        float4 yhi0 = vload4(0, yb + y_hi_off);
+        float4 yhi1 = vload4(0, yb + y_hi_off + 4);
+
+        float sumy_lo = dot(ylo0 + ylo1, (float4)(1.f));
+        float sumy_hi = dot(yhi0 + yhi1, (float4)(1.f));
+
+        if (first_row + 0 < ne01) {
+            ulong bi = offset_src0 + (ulong)0*nb + ib;
+            uchar4 qa = vload4(0, src0_qs + bi*(ulong)128 + q_off);
+            uchar4 qb = vload4(0, src0_qs + bi*(ulong)128 + q_off + 4);
+            float dotq_lo = dot(ylo0, convert_float4(qa & (uchar4)0x0F))
+                          + dot(ylo1, convert_float4(qb & (uchar4)0x0F));
+            float dotq_hi = dot(yhi0, convert_float4(qa >> (uchar)4))
+                          + dot(yhi1, convert_float4(qb >> (uchar)4));
+            global uchar * sc = src0_scales + bi*(ulong)K_SCALE_SIZE;
+            float scale_lo = sg_lo < 4 ? (float)(sc[sg_lo]   & 63)
+                                       : (float)((sc[sg_lo+4] & 0x0F) | ((sc[sg_lo_m4] >> 6) << 4));
+            float scale_hi = sg_hi < 4 ? (float)(sc[sg_hi]   & 63)
+                                       : (float)((sc[sg_hi+4] & 0x0F) | ((sc[sg_hi_m4] >> 6) << 4));
+            float smin_lo  = sg_lo < 4 ? (float)(sc[sg_lo+4] & 63)
+                                       : (float)((sc[sg_lo+4] >>    4) | ((sc[sg_lo  ] >> 6) << 4));
+            float smin_hi  = sg_hi < 4 ? (float)(sc[sg_hi+4] & 63)
+                                       : (float)((sc[sg_hi+4] >>    4) | ((sc[sg_hi  ] >> 6) << 4));
+            sumf.s0 += vload_half(0, src0_d    + bi) * (scale_lo * dotq_lo + scale_hi * dotq_hi)
+                     - vload_half(0, src0_dmin  + bi) * (smin_lo  * sumy_lo + smin_hi  * sumy_hi);
+        }
+        if (first_row + 1 < ne01) {
+            ulong bi = offset_src0 + (ulong)1*nb + ib;
+            uchar4 qa = vload4(0, src0_qs + bi*(ulong)128 + q_off);
+            uchar4 qb = vload4(0, src0_qs + bi*(ulong)128 + q_off + 4);
+            float dotq_lo = dot(ylo0, convert_float4(qa & (uchar4)0x0F))
+                          + dot(ylo1, convert_float4(qb & (uchar4)0x0F));
+            float dotq_hi = dot(yhi0, convert_float4(qa >> (uchar)4))
+                          + dot(yhi1, convert_float4(qb >> (uchar)4));
+            global uchar * sc = src0_scales + bi*(ulong)K_SCALE_SIZE;
+            float scale_lo = sg_lo < 4 ? (float)(sc[sg_lo]   & 63)
+                                       : (float)((sc[sg_lo+4] & 0x0F) | ((sc[sg_lo_m4] >> 6) << 4));
+            float scale_hi = sg_hi < 4 ? (float)(sc[sg_hi]   & 63)
+                                       : (float)((sc[sg_hi+4] & 0x0F) | ((sc[sg_hi_m4] >> 6) << 4));
+            float smin_lo  = sg_lo < 4 ? (float)(sc[sg_lo+4] & 63)
+                                       : (float)((sc[sg_lo+4] >>    4) | ((sc[sg_lo  ] >> 6) << 4));
+            float smin_hi  = sg_hi < 4 ? (float)(sc[sg_hi+4] & 63)
+                                       : (float)((sc[sg_hi+4] >>    4) | ((sc[sg_hi  ] >> 6) << 4));
+            sumf.s1 += vload_half(0, src0_d    + bi) * (scale_lo * dotq_lo + scale_hi * dotq_hi)
+                     - vload_half(0, src0_dmin  + bi) * (smin_lo  * sumy_lo + smin_hi  * sumy_hi);
+        }
+        if (first_row + 2 < ne01) {
+            ulong bi = offset_src0 + (ulong)2*nb + ib;
+            uchar4 qa = vload4(0, src0_qs + bi*(ulong)128 + q_off);
+            uchar4 qb = vload4(0, src0_qs + bi*(ulong)128 + q_off + 4);
+            float dotq_lo = dot(ylo0, convert_float4(qa & (uchar4)0x0F))
+                          + dot(ylo1, convert_float4(qb & (uchar4)0x0F));
+            float dotq_hi = dot(yhi0, convert_float4(qa >> (uchar)4))
+                          + dot(yhi1, convert_float4(qb >> (uchar)4));
+            global uchar * sc = src0_scales + bi*(ulong)K_SCALE_SIZE;
+            float scale_lo = sg_lo < 4 ? (float)(sc[sg_lo]   & 63)
+                                       : (float)((sc[sg_lo+4] & 0x0F) | ((sc[sg_lo_m4] >> 6) << 4));
+            float scale_hi = sg_hi < 4 ? (float)(sc[sg_hi]   & 63)
+                                       : (float)((sc[sg_hi+4] & 0x0F) | ((sc[sg_hi_m4] >> 6) << 4));
+            float smin_lo  = sg_lo < 4 ? (float)(sc[sg_lo+4] & 63)
+                                       : (float)((sc[sg_lo+4] >>    4) | ((sc[sg_lo  ] >> 6) << 4));
+            float smin_hi  = sg_hi < 4 ? (float)(sc[sg_hi+4] & 63)
+                                       : (float)((sc[sg_hi+4] >>    4) | ((sc[sg_hi  ] >> 6) << 4));
+            sumf.s2 += vload_half(0, src0_d    + bi) * (scale_lo * dotq_lo + scale_hi * dotq_hi)
+                     - vload_half(0, src0_dmin  + bi) * (smin_lo  * sumy_lo + smin_hi  * sumy_hi);
+        }
+        if (first_row + 3 < ne01) {
+            ulong bi = offset_src0 + (ulong)3*nb + ib;
+            uchar4 qa = vload4(0, src0_qs + bi*(ulong)128 + q_off);
+            uchar4 qb = vload4(0, src0_qs + bi*(ulong)128 + q_off + 4);
+            float dotq_lo = dot(ylo0, convert_float4(qa & (uchar4)0x0F))
+                          + dot(ylo1, convert_float4(qb & (uchar4)0x0F));
+            float dotq_hi = dot(yhi0, convert_float4(qa >> (uchar)4))
+                          + dot(yhi1, convert_float4(qb >> (uchar)4));
+            global uchar * sc = src0_scales + bi*(ulong)K_SCALE_SIZE;
+            float scale_lo = sg_lo < 4 ? (float)(sc[sg_lo]   & 63)
+                                       : (float)((sc[sg_lo+4] & 0x0F) | ((sc[sg_lo_m4] >> 6) << 4));
+            float scale_hi = sg_hi < 4 ? (float)(sc[sg_hi]   & 63)
+                                       : (float)((sc[sg_hi+4] & 0x0F) | ((sc[sg_hi_m4] >> 6) << 4));
+            float smin_lo  = sg_lo < 4 ? (float)(sc[sg_lo+4] & 63)
+                                       : (float)((sc[sg_lo+4] >>    4) | ((sc[sg_lo  ] >> 6) << 4));
+            float smin_hi  = sg_hi < 4 ? (float)(sc[sg_hi+4] & 63)
+                                       : (float)((sc[sg_hi+4] >>    4) | ((sc[sg_hi  ] >> 6) << 4));
+            sumf.s3 += vload_half(0, src0_d    + bi) * (scale_lo * dotq_lo + scale_hi * dotq_hi)
+                     - vload_half(0, src0_dmin  + bi) * (smin_lo  * sumy_lo + smin_hi  * sumy_hi);
+        }
+    }
+
+    global float * dst_f32 = (global float *)dst + (ulong)im*ne0*ne1 + (ulong)r1*ne0;
+
+    // NVIDIA: cl_khr_subgroups is not exposed as a compile-time extension macro,
+    // so use __local tree-reduction instead of sub_group_reduce_add.
+    __local float4 lm[N_SIMDWIDTH];
+    lm[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = N_SIMDWIDTH/2; s > 0; s >>= 1) {
+        if (lid < s) lm[lid] += lm[lid + s];
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        if (first_row + 0 < ne01) dst_f32[first_row + 0] = lm[0].s0;
+        if (first_row + 1 < ne01) dst_f32[first_row + 1] = lm[0].s1;
+        if (first_row + 2 < ne01) dst_f32[first_row + 2] = lm[0].s2;
+        if (first_row + 3 < ne01) dst_f32[first_row + 3] = lm[0].s3;
     }
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q5_0_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q5_0_f32_flat.cl
@@ -1,0 +1,81 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+#define QK5_0 32
+#define N_R0_Q5_0 4
+
+kernel void kernel_mul_mv_q5_0_f32_flat(
+    global uchar * src0_q,
+    global uchar * src0_qh,
+    global half  * src0_d,
+    global char  * src1,
+    ulong         offset1,
+    global char  * dst,
+    ulong         offsetd,
+    int           ne00,
+    int           ne01,
+    ulong         nb01,
+    ulong         nb02,
+    ulong         nb03,
+    int           ne12,
+    ulong         nb11,
+    ulong         nb12,
+    ulong         nb13,
+    int           ne0,
+    int           ne1,
+    int           r2,
+    int           r3
+) {
+    src1 = (global char *) ((global char *) src1 + offset1);
+    dst  = (global char *) ((global char *) dst  + offsetd);
+
+    if (get_local_id(0) != 0 || get_local_id(1) != 0) {
+        return;
+    }
+
+    const int nb = ne00 / QK5_0;
+
+    const int r0 = get_group_id(0);
+    const int r1 = get_group_id(1);
+    const int im = get_group_id(2);
+
+    const int first_row = r0 * N_R0_Q5_0;
+
+    const uint i12 = im % ne12;
+    const uint i13 = im / ne12;
+
+    const ulong offset_src1 = r1*nb11 + i12*nb12 + i13*nb13;
+    global float * y = (global float *) (src1 + offset_src1);
+    global float * dst_f32 = (global float *) dst + (ulong) im*ne0*ne1 + (ulong) r1*ne0;
+
+    for (int row = 0; row < N_R0_Q5_0; ++row) {
+        if (first_row + row >= ne01) {
+            continue;
+        }
+
+        const ulong row_offset = (ulong) (first_row + row)*nb01 + (ulong) (i12/r2)*nb02 + (ulong) (i13/r3)*nb03;
+        const ulong block_index = row_offset / 22;
+
+        global uchar * ax  = src0_q  + block_index*(QK5_0/2);
+        global uchar * axh = src0_qh + block_index*4;
+        global half  * ad  = src0_d  + block_index;
+
+        float total = 0.0f;
+        for (int ib = 0; ib < nb; ++ib) {
+            const uchar4 qh4 = vload4(0, axh + ib*4);
+            const uint qh = (uint) qh4.s0 | ((uint) qh4.s1 << 8) | ((uint) qh4.s2 << 16) | ((uint) qh4.s3 << 24);
+            global uchar * qs = ax + ib*(QK5_0/2);
+
+            float sum = 0.0f;
+            for (int j = 0; j < QK5_0/2; ++j) {
+                const int x0 = ((qs[j] & 0x0Fu) | (((qh >> j)      & 0x1u) << 4)) - 16;
+                const int x1 = ((qs[j] >> 4)    | (((qh >> (j+16)) & 0x1u) << 4)) - 16;
+                sum += (float) x0 * y[ib*QK5_0 + j];
+                sum += (float) x1 * y[ib*QK5_0 + QK5_0/2 + j];
+            }
+
+            total += sum * vload_half(0, ad + ib);
+        }
+
+        dst_f32[first_row + row] = total;
+    }
+}

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q6_k_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q6_k_f32.cl
@@ -52,6 +52,39 @@ typedef struct {
     half d;             // super-block scale
 } block_q6_K;
 
+#ifdef NVIDIA_GPU
+inline float block_q6_K_dot_y_aos_ref(global block_q6_K * blk, global float * y) {
+    const float d = vload_half(0, &blk->d);
+
+    global uchar * ql = blk->ql;
+    global uchar * qh = blk->qh;
+    global char  * sc = blk->scales;
+
+    float sum = 0.0f;
+
+    for (int n = 0; n < QK_K; n += 128) {
+        for (int l = 0; l < 32; ++l) {
+            const int is = l / 16;
+            const int q1 = (int)((ql[l +  0] & 0xF) | (((qh[l] >> 0) & 3) << 4)) - 32;
+            const int q2 = (int)((ql[l + 32] & 0xF) | (((qh[l] >> 2) & 3) << 4)) - 32;
+            const int q3 = (int)((ql[l +  0] >> 4) | (((qh[l] >> 4) & 3) << 4)) - 32;
+            const int q4 = (int)((ql[l + 32] >> 4) | (((qh[l] >> 6) & 3) << 4)) - 32;
+
+            sum += d * (float) sc[is + 0] * (float) q1 * y[n + l +  0];
+            sum += d * (float) sc[is + 2] * (float) q2 * y[n + l + 32];
+            sum += d * (float) sc[is + 4] * (float) q3 * y[n + l + 64];
+            sum += d * (float) sc[is + 6] * (float) q4 * y[n + l + 96];
+        }
+
+        ql += 64;
+        qh += 32;
+        sc += 8;
+    }
+
+    return sum;
+}
+#endif
+
 //------------------------------------------------------------------------------
 // kernel_mul_mv_q6_K_f32
 //------------------------------------------------------------------------------
@@ -125,6 +158,27 @@ kernel void kernel_mul_mv_q6_K_f32(
 
     float sumf = 0;
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0 || get_local_id(1) != 0) {
+        return;
+    }
+
+    row = r0;
+    if (row >= ne01) {
+        return;
+    }
+
+    x = (global block_q6_K *) src0 + row*nb + offset_src0;
+
+    float total = 0.0f;
+    for (int ib = 0; ib < nb; ++ib) {
+        total += block_q6_K_dot_y_aos_ref(&x[ib], yy + ib * QK_K);
+    }
+
+    dst[r1*ne0 + im*ne0*ne1 + row] = total;
+    return;
+#endif
+
     // For Q6_K quantization, 16 values forms a subblock, 16 subblock forms a
     // block. Values in a subblock shares a scale that is quantized with 8 bits;
     // the entire block shares a single floating point scale.
@@ -160,7 +214,7 @@ kernel void kernel_mul_mv_q6_K_f32(
 
         global float * y = yy + i * QK_K + y_offset;
 
-        float dall = x[i].d;
+        float dall = vload_half(0, &x[i].d);
 
         float4 sums = {0.f, 0.f, 0.f, 0.f};
 

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q6_k_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q6_k_f32_flat.cl
@@ -28,6 +28,7 @@
 
 #define QK_K       256
 
+
 inline float block_q_6_K_dot_y_flat(
     global uchar * blk_ql,
     global uchar * blk_qh,
@@ -50,7 +51,7 @@ inline float block_q_6_K_dot_y_flat(
 
     global float * y = yy + ib * QK_K + y_offset;
 
-    float dall = blk_d[ib];
+    float dall = vload_half(0, blk_d + ib);
 
     float  sumf = 0;
     float4 sums = {0.f, 0.f, 0.f, 0.f};
@@ -80,6 +81,7 @@ inline float block_q_6_K_dot_y_flat(
     return sumf;
 }
 
+
 #undef N_DST
 #undef N_SIMDGROUP
 #undef N_SIMDWIDTH
@@ -92,6 +94,14 @@ inline float block_q_6_K_dot_y_flat(
 #define N_DST 4
 #define N_SIMDGROUP 2
 #define N_SIMDWIDTH 64
+#endif
+
+// NVIDIA: warp width = 32; N_SIMDGROUP=1 (one warp per WG, __local reduction)
+#ifdef NVIDIA_GPU
+#undef N_SIMDWIDTH
+#define N_SIMDWIDTH 32
+#undef N_SIMDGROUP
+#define N_SIMDGROUP 1
 #endif
 
 #define BLOCK_STRIDE (N_SIMDWIDTH/16) // number of blocks each subgroup processes
@@ -153,9 +163,76 @@ kernel void kernel_mul_mv_q6_K_f32_flat(
     int n   = 4;       // 4 scales at a time (and 4 sums)
     int l0  = n*il;    // offset into half-block, 0..28
     int is  = 8*ip + l0/16; // 0, 1, 8, 9
+    int q_offset_l = 64*ip + l0;
+    int q_offset_h = 32*ip + l0;
+    int y_offset   = 128*ip + l0;
 
     float4 sumf = 0;
 
+#ifdef NVIDIA_GPU
+    // Vectorized path: load y once per block and reuse for all 4 rows.
+    // Uses vload4+dot() instead of 4 separate scalar multiply-adds per element.
+    for (int ib = ix; ib < nb; ib += BLOCK_STRIDE) {
+        global float * yb = yy + (ulong)ib * QK_K + y_offset;
+        float4 y0  = vload4(0, yb +  0);
+        float4 y32 = vload4(0, yb + 32);
+        float4 y64 = vload4(0, yb + 64);
+        float4 y96 = vload4(0, yb + 96);
+
+        if (first_row + 0 < ne01) {
+            uchar4 q1 = vload4(0, blk_ql + (ulong)0*nb*128 + (ulong)ib*128 + q_offset_l);
+            uchar4 q2 = vload4(0, blk_ql + (ulong)0*nb*128 + (ulong)ib*128 + q_offset_l + QK_K/8);
+            uchar4 qh = vload4(0, blk_qh + (ulong)0*nb*64  + (ulong)ib*64  + q_offset_h);
+            float dall = vload_half(0, blk_d + (ulong)0*nb + ib);
+            global char * sc = blk_scales + (ulong)0*nb*16 + (ulong)ib*16 + is;
+            float4 dl  = convert_float4(q1 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x03) << 4) - 32.f;
+            float4 d2l = convert_float4(q2 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x0C) << 2) - 32.f;
+            float4 dh  = convert_float4(q1 >> 4)           + convert_float4( qh & (uchar4)0x30)       - 32.f;
+            float4 d2h = convert_float4(q2 >> 4)           + convert_float4((qh & (uchar4)0xC0) >> 2) - 32.f;
+            sumf.s0 += dall * (dot(y0, dl) *(float)sc[0] + dot(y32, d2l)*(float)sc[2] +
+                               dot(y64, dh)*(float)sc[4] + dot(y96, d2h)*(float)sc[6]);
+        }
+        if (first_row + 1 < ne01) {
+            uchar4 q1 = vload4(0, blk_ql + (ulong)1*nb*128 + (ulong)ib*128 + q_offset_l);
+            uchar4 q2 = vload4(0, blk_ql + (ulong)1*nb*128 + (ulong)ib*128 + q_offset_l + QK_K/8);
+            uchar4 qh = vload4(0, blk_qh + (ulong)1*nb*64  + (ulong)ib*64  + q_offset_h);
+            float dall = vload_half(0, blk_d + (ulong)1*nb + ib);
+            global char * sc = blk_scales + (ulong)1*nb*16 + (ulong)ib*16 + is;
+            float4 dl  = convert_float4(q1 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x03) << 4) - 32.f;
+            float4 d2l = convert_float4(q2 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x0C) << 2) - 32.f;
+            float4 dh  = convert_float4(q1 >> 4)           + convert_float4( qh & (uchar4)0x30)       - 32.f;
+            float4 d2h = convert_float4(q2 >> 4)           + convert_float4((qh & (uchar4)0xC0) >> 2) - 32.f;
+            sumf.s1 += dall * (dot(y0, dl) *(float)sc[0] + dot(y32, d2l)*(float)sc[2] +
+                               dot(y64, dh)*(float)sc[4] + dot(y96, d2h)*(float)sc[6]);
+        }
+        if (first_row + 2 < ne01) {
+            uchar4 q1 = vload4(0, blk_ql + (ulong)2*nb*128 + (ulong)ib*128 + q_offset_l);
+            uchar4 q2 = vload4(0, blk_ql + (ulong)2*nb*128 + (ulong)ib*128 + q_offset_l + QK_K/8);
+            uchar4 qh = vload4(0, blk_qh + (ulong)2*nb*64  + (ulong)ib*64  + q_offset_h);
+            float dall = vload_half(0, blk_d + (ulong)2*nb + ib);
+            global char * sc = blk_scales + (ulong)2*nb*16 + (ulong)ib*16 + is;
+            float4 dl  = convert_float4(q1 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x03) << 4) - 32.f;
+            float4 d2l = convert_float4(q2 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x0C) << 2) - 32.f;
+            float4 dh  = convert_float4(q1 >> 4)           + convert_float4( qh & (uchar4)0x30)       - 32.f;
+            float4 d2h = convert_float4(q2 >> 4)           + convert_float4((qh & (uchar4)0xC0) >> 2) - 32.f;
+            sumf.s2 += dall * (dot(y0, dl) *(float)sc[0] + dot(y32, d2l)*(float)sc[2] +
+                               dot(y64, dh)*(float)sc[4] + dot(y96, d2h)*(float)sc[6]);
+        }
+        if (first_row + 3 < ne01) {
+            uchar4 q1 = vload4(0, blk_ql + (ulong)3*nb*128 + (ulong)ib*128 + q_offset_l);
+            uchar4 q2 = vload4(0, blk_ql + (ulong)3*nb*128 + (ulong)ib*128 + q_offset_l + QK_K/8);
+            uchar4 qh = vload4(0, blk_qh + (ulong)3*nb*64  + (ulong)ib*64  + q_offset_h);
+            float dall = vload_half(0, blk_d + (ulong)3*nb + ib);
+            global char * sc = blk_scales + (ulong)3*nb*16 + (ulong)ib*16 + is;
+            float4 dl  = convert_float4(q1 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x03) << 4) - 32.f;
+            float4 d2l = convert_float4(q2 & (uchar4)0x0F) + convert_float4((qh & (uchar4)0x0C) << 2) - 32.f;
+            float4 dh  = convert_float4(q1 >> 4)           + convert_float4( qh & (uchar4)0x30)       - 32.f;
+            float4 d2h = convert_float4(q2 >> 4)           + convert_float4((qh & (uchar4)0xC0) >> 2) - 32.f;
+            sumf.s3 += dall * (dot(y0, dl) *(float)sc[0] + dot(y32, d2l)*(float)sc[2] +
+                               dot(y64, dh)*(float)sc[4] + dot(y96, d2h)*(float)sc[6]);
+        }
+    }
+#else
     for (int ib = ix; ib < nb; ib += BLOCK_STRIDE) {
         if (first_row + 0 < ne01) {
             sumf.s0 += block_q_6_K_dot_y_flat(blk_ql + 0*nb*128, blk_qh + 0*nb*64, blk_scales + 0*nb*16, blk_d + 0*nb, yy, ib, ip, is, l0);
@@ -170,7 +247,28 @@ kernel void kernel_mul_mv_q6_K_f32_flat(
             sumf.s3 += block_q_6_K_dot_y_flat(blk_ql + 3*nb*128, blk_qh + 3*nb*64, blk_scales + 3*nb*16, blk_d + 3*nb, yy, ib, ip, is, l0);
         }
     }
+#endif
 
+#ifdef NVIDIA_GPU
+    // cl_khr_subgroups unavailable on NVIDIA OpenCL: use __local tree-reduction.
+    // N_SIMDWIDTH==32 (warp), N_SIMDGROUP==1, local size = 32x1.
+    __local float4 lm[N_SIMDWIDTH];
+    int lid = get_local_id(0);
+    lm[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = N_SIMDWIDTH / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lm[lid] += lm[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        if (first_row + 0 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = lm[0].s0; }
+        if (first_row + 1 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = lm[0].s1; }
+        if (first_row + 2 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = lm[0].s2; }
+        if (first_row + 3 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = lm[0].s3; }
+    }
+#else
     float4 tot = (float4)(
         sub_group_reduce_add(sumf.s0),
         sub_group_reduce_add(sumf.s1),
@@ -178,17 +276,10 @@ kernel void kernel_mul_mv_q6_K_f32_flat(
         sub_group_reduce_add(sumf.s3)
     );
     if (get_sub_group_local_id() == 0) {
-        if (first_row + 0 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = tot.s0;
-        }
-        if (first_row + 1 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = tot.s1;
-        }
-        if (first_row + 2 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = tot.s2;
-        }
-        if (first_row + 3 < ne01) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = tot.s3;
-        }
+        if (first_row + 0 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 0] = tot.s0; }
+        if (first_row + 1 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 1] = tot.s1; }
+        if (first_row + 2 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 2] = tot.s2; }
+        if (first_row + 3 < ne01) { dst[r1*ne0 + im*ne0*ne1 + first_row + 3] = tot.s3; }
     }
+#endif
 }

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q8_0_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q8_0_f32.cl
@@ -107,7 +107,7 @@ kernel void kernel_mul_mv_q8_0_f32(
             for (short iq = 0; iq < NB_Q8_0; ++iq) {
                 sumq += qs[iq] * yl[iq];
             }
-            sumf[row] += sumq*ax[row][ib].d;
+            sumf[row] += sumq*vload_half(0, &ax[row][ib].d);
         }
 
         yb += N_SIMDWIDTH*NB_Q8_0;

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q8_0_f32_flat.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q8_0_f32_flat.cl
@@ -36,6 +36,16 @@ typedef struct {
 #define N_SIMDWIDTH 64
 #endif
 
+// NVIDIA: use one warp (32 lanes) per workgroup.
+#ifdef NVIDIA_GPU
+#undef N_R0_Q8_0
+#undef N_SG_Q8_0
+#undef N_SIMDWIDTH
+#define N_R0_Q8_0  4
+#define N_SG_Q8_0  1
+#define N_SIMDWIDTH 32
+#endif
+
 #ifdef INTEL_GPU
 REQD_SUBGROUP_SIZE_16
 #elif defined (ADRENO_GPU)
@@ -91,17 +101,31 @@ kernel void kernel_mul_mv_q8_0_f32_flat(
     ax0 = (global char *) ((global char *) src0_q + offset_src0*sizeof(char)*QK8_0);
     ad0 = (global half *) ((global char *) src0_d + offset_src0*sizeof(half));
 
+    // NVIDIA: clamp OOB rows to row 0 — NVIDIA errors on OOB reads even when
+    // the corresponding write is guarded. Intel/Adreno tolerate OOB reads.
+#ifdef NVIDIA_GPU
+    offset_src0 = offset_src0_base + (first_row+1 < ne01 ? (uint)nb01 : 0u);
+#else
     offset_src0 = offset_src0_base + 1*nb01;
+#endif
     offset_src0 = offset_src0/34;
     ax1 = (global char *) ((global char *) src0_q + offset_src0*sizeof(char)*QK8_0);
     ad1 = (global half *) ((global char *) src0_d + offset_src0*sizeof(half));
 
+#ifdef NVIDIA_GPU
+    offset_src0 = offset_src0_base + (first_row+2 < ne01 ? (uint)(2*nb01) : 0u);
+#else
     offset_src0 = offset_src0_base + 2*nb01;
+#endif
     offset_src0 = offset_src0/34;
     ax2 = (global char *) ((global char *) src0_q + offset_src0*sizeof(char)*QK8_0);
     ad2 = (global half *) ((global char *) src0_d + offset_src0*sizeof(half));
 
+#ifdef NVIDIA_GPU
+    offset_src0 = offset_src0_base + (first_row+3 < ne01 ? (uint)(3*nb01) : 0u);
+#else
     offset_src0 = offset_src0_base + 3*nb01;
+#endif
     offset_src0 = offset_src0/34;
     ax3 = (global char *) ((global char *) src0_q + offset_src0*sizeof(char)*QK8_0);
     ad3 = (global half *) ((global char *) src0_d + offset_src0*sizeof(half));
@@ -177,6 +201,34 @@ kernel void kernel_mul_mv_q8_0_f32_flat(
     }
 
     global float * dst_f32 = (global float *) dst + (ulong)im*ne0*ne1 + (ulong)r1*ne0;
+
+#ifdef NVIDIA_GPU
+    // cl_khr_subgroups unavailable on NVIDIA OpenCL: use __local tree-reduction.
+    // N_SIMDWIDTH==32 (warp width), N_SG_Q8_0==1, so local work size = 32x1.
+    __local float lm[N_R0_Q8_0 * N_SIMDWIDTH];
+    int lid = get_local_id(0);
+    lm[0*N_SIMDWIDTH + lid] = sumf.s0;
+    lm[1*N_SIMDWIDTH + lid] = sumf.s1;
+    lm[2*N_SIMDWIDTH + lid] = sumf.s2;
+    lm[3*N_SIMDWIDTH + lid] = sumf.s3;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = N_SIMDWIDTH/2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lm[0*N_SIMDWIDTH + lid] += lm[0*N_SIMDWIDTH + lid + s];
+            lm[1*N_SIMDWIDTH + lid] += lm[1*N_SIMDWIDTH + lid + s];
+            lm[2*N_SIMDWIDTH + lid] += lm[2*N_SIMDWIDTH + lid + s];
+            lm[3*N_SIMDWIDTH + lid] += lm[3*N_SIMDWIDTH + lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        if (first_row + 0 < ne01) dst_f32[first_row + 0] = lm[0*N_SIMDWIDTH];
+        if (first_row + 1 < ne01) dst_f32[first_row + 1] = lm[1*N_SIMDWIDTH];
+        if (first_row + 2 < ne01) dst_f32[first_row + 2] = lm[2*N_SIMDWIDTH];
+        if (first_row + 3 < ne01) dst_f32[first_row + 3] = lm[3*N_SIMDWIDTH];
+    }
+    return;
+#endif
 
     float4 tot = (float4)(
         sub_group_reduce_add(sumf.s0),

--- a/ggml/src/ggml-opencl/kernels/rms_norm.cl
+++ b/ggml/src/ggml-opencl/kernels/rms_norm.cl
@@ -54,6 +54,36 @@ kernel void kernel_rms_norm(
     float4 sumf = 0;
     float all_sum = 0;
 
+#ifdef NVIDIA_GPU
+    // Full-workgroup parallel reduction via __local tree reduction.
+    // sum[] has get_local_size(0) entries (allocated by host as sizeof(float)*nth).
+    const int lid = (int)get_local_id(0);
+    const int lsz = (int)get_local_size(0);
+
+    float partial = 0.0f;
+    for (int i = lid; i < ne00; i += lsz) {
+        float v = x_scalar[i];
+        partial += v * v;
+    }
+    sum[lid] = partial;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int s = lsz/2; s > 0; s >>= 1) {
+        if (lid < s) {
+            sum[lid] += sum[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    const float scale_nv = rsqrt(sum[0] / (float)ne00 + eps);
+
+    global float * y_nv = dst + i03*ne02*ne01*ne00 + i02*ne01*ne00 + i01*ne00;
+    for (int i = lid; i < ne00; i += lsz) {
+        y_nv[i] = x_scalar[i] * scale_nv;
+    }
+    return;
+#endif
+
     // parallel sum
     for (int i00 = get_local_id(0); i00 < ne00/4; i00 += get_local_size(0)) {
         sumf += x[i00] * x[i00];
@@ -151,6 +181,41 @@ kernel void kernel_rms_norm_mul(
     global float4 * f = (global float4 *) (src1 + (i03%ne13)*nb13 + (i02%ne12)*nb12 + (i01%ne11)*nb11);
 
     float sumf = 0;
+
+#ifdef NVIDIA_GPU
+    // Full-workgroup parallel reduction via __local tree reduction.
+    // sum[] has get_local_size(0) entries (allocated by host as sizeof(float)*nth).
+    const int lid = (int)get_local_id(0);
+    const int lsz = (int)get_local_size(0);
+
+    // Use scalar pointers to avoid float4 alignment requirements when nb01 is
+    // not a multiple of 16 bytes (e.g. views with non-contiguous rows).
+    global float * x_nv = (global float *) x;
+    global float * y_nv = (global float *)(dst + i03*nb3 + i02*nb2 + i01*nb1);
+    global float * f_nv = (global float *) f;
+
+    float partial = 0.0f;
+    for (int i = lid; i < ne00; i += lsz) {
+        float v = x_nv[i];
+        partial += v * v;
+    }
+    sum[lid] = partial;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int s = lsz/2; s > 0; s >>= 1) {
+        if (lid < s) {
+            sum[lid] += sum[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    const float scale_nv = rsqrt(sum[0] / (float)ne00 + eps);
+
+    for (int i = lid; i < ne00; i += lsz) {
+        y_nv[i] = (x_nv[i] * scale_nv) * f_nv[i % ne10];
+    }
+    return;
+#endif
 
     // parallel sum
     for (int i00 = get_local_id(0); i00 < ne00/4; i00 += get_local_size(0)) {

--- a/ggml/src/ggml-opencl/kernels/set_rows.cl
+++ b/ggml/src/ggml-opencl/kernels/set_rows.cl
@@ -46,8 +46,13 @@ kernel void kernel_set_rows_f32_i64(
 
     //int i12 = i03%ne12;
     //int i11 = i02%ne11;
+#ifdef NVIDIA_GPU
+    int i12 = i03 % ne12.s2;
+    int i11 = i02 % ne11.s2;
+#else
     int i12 = fastmod(i03, ne12);
     int i11 = fastmod(i02, ne11);
+#endif
 
     int i10 = i01;
     long i1 = ((global long *)(src1 + i10*nb10 + i11*nb11 + i12*nb12))[0];
@@ -95,8 +100,13 @@ kernel void kernel_set_rows_f16_i64(
 
     //int i12 = i03%ne12;
     //int i11 = i02%ne11;
+#ifdef NVIDIA_GPU
+    int i12 = i03 % ne12.s2;
+    int i11 = i02 % ne11.s2;
+#else
     int i12 = fastmod(i03, ne12);
     int i11 = fastmod(i02, ne11);
+#endif
 
     int i10 = i01;
     long i1 = ((global long *)(src1 + i10*nb10 + i11*nb11 + i12*nb12))[0];
@@ -144,8 +154,13 @@ kernel void kernel_set_rows_f32_i32(
 
     //int i12 = i03%ne12;
     //int i11 = i02%ne11;
+#ifdef NVIDIA_GPU
+    int i12 = i03 % ne12.s2;
+    int i11 = i02 % ne11.s2;
+#else
     int i12 = fastmod(i03, ne12);
     int i11 = fastmod(i02, ne11);
+#endif
 
     int i10 = i01;
     int i1  = ((global int *)(src1 + i10*nb10 + i11*nb11 + i12*nb12))[0];
@@ -193,8 +208,13 @@ kernel void kernel_set_rows_f16_i32(
 
     //int i12 = i03%ne12;
     //int i11 = i02%ne11;
+#ifdef NVIDIA_GPU
+    int i12 = i03 % ne12.s2;
+    int i11 = i02 % ne11.s2;
+#else
     int i12 = fastmod(i03, ne12);
     int i11 = fastmod(i02, ne11);
+#endif
 
     int i10 = i01;
     int i1  = ((global int *)(src1 + i10*nb10 + i11*nb11 + i12*nb12))[0];

--- a/ggml/src/ggml-opencl/kernels/sigmoid.cl
+++ b/ggml/src/ggml-opencl/kernels/sigmoid.cl
@@ -13,7 +13,8 @@ kernel void kernel_sigmoid_f32(
     src0 = (global float*)((global char*)src0 + offset0);
     dst = (global float*)((global char*)dst + offsetd);
 
-    dst[get_global_id(0)] = 1.0f / (1.0f + exp(-src0[get_global_id(0)]));
+    const float x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = 1.0f / (1.0f + exp(-x));
 }
 
 kernel void kernel_sigmoid_f16(
@@ -25,5 +26,10 @@ kernel void kernel_sigmoid_f16(
     src0 = (global half*)((global char*)src0 + offset0);
     dst = (global half*)((global char*)dst + offsetd);
 
-    dst[get_global_id(0)] = 1.0f / (1.0f + exp(-src0[get_global_id(0)]));
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
+    dst[get_global_id(0)] = 1.0h / (1.0h + exp(-src0[get_global_id(0)]));
+#else
+    const float x = (float) src0[get_global_id(0)];
+    dst[get_global_id(0)] = (half) (1.0f / (1.0f + exp(-x)));
+#endif
 }

--- a/ggml/src/ggml-opencl/kernels/silu.cl
+++ b/ggml/src/ggml-opencl/kernels/silu.cl
@@ -13,7 +13,8 @@ kernel void kernel_silu(
     dst = (global float*)((global char*)dst + offsetd);
 
     float x = src0[get_global_id(0)];
-    dst[get_global_id(0)] = x / (1.0f + exp(-x));
+    const float xf = (float)x;
+    dst[get_global_id(0)] = xf / (1.0f + exp(-xf));
 }
 
 kernel void kernel_silu_4(
@@ -26,5 +27,6 @@ kernel void kernel_silu_4(
     dst = (global float4*)((global char*)dst + offsetd);
 
     float4 x = src0[get_global_id(0)];
-    dst[get_global_id(0)] = x / (1.0f + exp(-x));
+    const float4 xf = x;
+    dst[get_global_id(0)] = xf / (1.0f + exp(-xf));
 }

--- a/ggml/src/ggml-opencl/kernels/softmax_4_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/softmax_4_f16.cl
@@ -78,10 +78,53 @@ kernel void kernel_soft_max_4_f16(
         slope = pow(base, exp);
     }
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0) {
+        return;
+    }
+
+    float max_nv = psrc2 ? psrc2[i02] : -INFINITY;
+    for (int i00 = 0; i00 < ne00/4; ++i00) {
+        float4 mask4 = 0.0f;
+        if (pmask) {
+            half4 hmask4 = pmask[i00];
+            mask4 = (float4)((float)hmask4.s0, (float)hmask4.s1, (float)hmask4.s2, (float)hmask4.s3);
+        }
+        float4 v = psrc4[i00]*scale + slope*mask4;
+        max_nv = fmax(max_nv, fmax(fmax(v.s0, v.s1), fmax(v.s2, v.s3)));
+    }
+
+    float sum_nv = 0.0f;
+    for (int i00 = 0; i00 < ne00/4; ++i00) {
+        float4 mask4 = 0.0f;
+        if (pmask) {
+            half4 hmask4 = pmask[i00];
+            mask4 = (float4)((float)hmask4.s0, (float)hmask4.s1, (float)hmask4.s2, (float)hmask4.s3);
+        }
+        float4 exp_psrc4 = exp((psrc4[i00]*scale + slope*mask4) - max_nv);
+        pdst4[i00] = exp_psrc4;
+        sum_nv += exp_psrc4.s0 + exp_psrc4.s1 + exp_psrc4.s2 + exp_psrc4.s3;
+    }
+
+    if (psrc2) {
+        sum_nv += exp(psrc2[i02] - max_nv);
+    }
+
+    for (int i00 = 0; i00 < ne00/4; ++i00) {
+        pdst4[i00] /= sum_nv;
+    }
+    return;
+#endif
+
     // parallel max
     float4 lmax4 = psrc2 ? psrc2[i02] : -INFINITY;
     for (int i00 = get_local_id(0); i00 < ne00/4; i00 += get_local_size(0)) {
-        lmax4 = fmax(lmax4, psrc4[i00]*scale + slope*(pmask ? convert_float4(pmask[i00]) : 0.0f));
+        float4 mask4 = 0.0f;
+        if (pmask) {
+            half4 hmask4 = pmask[i00];
+            mask4 = (float4)((float)hmask4.s0, (float)hmask4.s1, (float)hmask4.s2, (float)hmask4.s3);
+        }
+        lmax4 = fmax(lmax4, psrc4[i00]*scale + slope*mask4);
     }
     float lmax = fmax(fmax(lmax4.s0, lmax4.s1), fmax(lmax4.s2, lmax4.s3));
 
@@ -90,7 +133,12 @@ kernel void kernel_soft_max_4_f16(
     // parallel sum
     float4 lsum4 = 0.0f;
     for (int i00 = get_local_id(0); i00 < ne00/4; i00 += get_local_size(0)) {
-        const float4 exp_psrc4 = exp((psrc4[i00]*scale + slope*(pmask ? convert_float4(pmask[i00]) : 0.0f)) - max);
+        float4 mask4 = 0.0f;
+        if (pmask) {
+            half4 hmask4 = pmask[i00];
+            mask4 = (float4)((float)hmask4.s0, (float)hmask4.s1, (float)hmask4.s2, (float)hmask4.s3);
+        }
+        const float4 exp_psrc4 = exp((psrc4[i00]*scale + slope*mask4) - max);
         lsum4 += exp_psrc4;
         pdst4[i00] = exp_psrc4;
     }

--- a/ggml/src/ggml-opencl/kernels/softmax_4_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/softmax_4_f32.cl
@@ -78,6 +78,34 @@ kernel void kernel_soft_max_4(
         slope = pow(base, exp);
     }
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0) {
+        return;
+    }
+
+    float max_nv = psrc2 ? psrc2[i02] : -INFINITY;
+    for (int i00 = 0; i00 < ne00/4; ++i00) {
+        float4 v = psrc4[i00]*scale + (pmask ? slope*pmask[i00] : 0.0f);
+        max_nv = fmax(max_nv, fmax(fmax(v.s0, v.s1), fmax(v.s2, v.s3)));
+    }
+
+    float sum_nv = 0.0f;
+    for (int i00 = 0; i00 < ne00/4; ++i00) {
+        float4 exp_psrc4 = exp((psrc4[i00]*scale + (pmask ? slope*pmask[i00] : 0.0f)) - max_nv);
+        pdst4[i00] = exp_psrc4;
+        sum_nv += exp_psrc4.s0 + exp_psrc4.s1 + exp_psrc4.s2 + exp_psrc4.s3;
+    }
+
+    if (psrc2) {
+        sum_nv += exp(psrc2[i02] - max_nv);
+    }
+
+    for (int i00 = 0; i00 < ne00/4; ++i00) {
+        pdst4[i00] /= sum_nv;
+    }
+    return;
+#endif
+
     // parallel max
     float4 lmax4 = psrc2 ? psrc2[i02] : -INFINITY;
     for (int i00 = get_local_id(0); i00 < ne00/4; i00 += get_local_size(0)) {

--- a/ggml/src/ggml-opencl/kernels/softmax_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/softmax_f16.cl
@@ -78,6 +78,33 @@ kernel void kernel_soft_max_f16(
         slope = pow(base, exp);
     }
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0) {
+        return;
+    }
+
+    float max_nv = psrc2 ? psrc2[i02] : -INFINITY;
+    for (int i00 = 0; i00 < ne00; ++i00) {
+        max_nv = fmax(max_nv, psrc0[i00]*scale + (pmask ? slope*(float)pmask[i00] : 0.0f));
+    }
+
+    float sum_nv = 0.0f;
+    for (int i00 = 0; i00 < ne00; ++i00) {
+        float exp_psrc0 = exp((psrc0[i00]*scale + (pmask ? slope*(float)pmask[i00] : 0.0f)) - max_nv);
+        pdst[i00] = exp_psrc0;
+        sum_nv += exp_psrc0;
+    }
+
+    if (psrc2) {
+        sum_nv += exp(psrc2[i02] - max_nv);
+    }
+
+    for (int i00 = 0; i00 < ne00; ++i00) {
+        pdst[i00] /= sum_nv;
+    }
+    return;
+#endif
+
     // parallel max
     float lmax = psrc2 ? psrc2[i02] : -INFINITY;
     for (int i00 = get_local_id(0); i00 < ne00; i00 += get_local_size(0)) {

--- a/ggml/src/ggml-opencl/kernels/softmax_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/softmax_f32.cl
@@ -78,6 +78,33 @@ kernel void kernel_soft_max(
         slope = pow(base, exp);
     }
 
+#ifdef NVIDIA_GPU
+    if (get_local_id(0) != 0) {
+        return;
+    }
+
+    float max_nv = psrc2 ? psrc2[i02] : -INFINITY;
+    for (int i00 = 0; i00 < ne00; ++i00) {
+        max_nv = fmax(max_nv, psrc0[i00]*scale + (pmask ? slope*pmask[i00] : 0.0f));
+    }
+
+    float sum_nv = 0.0f;
+    for (int i00 = 0; i00 < ne00; ++i00) {
+        float exp_psrc0 = exp((psrc0[i00]*scale + (pmask ? slope*pmask[i00] : 0.0f)) - max_nv);
+        pdst[i00] = exp_psrc0;
+        sum_nv += exp_psrc0;
+    }
+
+    if (psrc2) {
+        sum_nv += exp(psrc2[i02] - max_nv);
+    }
+
+    for (int i00 = 0; i00 < ne00; ++i00) {
+        pdst[i00] /= sum_nv;
+    }
+    return;
+#endif
+
     // parallel max
     float lmax = psrc2 ? psrc2[i02] : -INFINITY;
     for (int i00 = get_local_id(0); i00 < ne00; i00 += get_local_size(0)) {

--- a/ggml/src/ggml-opencl/kernels/softplus.cl
+++ b/ggml/src/ggml-opencl/kernels/softplus.cl
@@ -37,8 +37,13 @@ kernel void kernel_softplus_f16(
     src0 = (global half*)((global char*)src0 + offset0);
     dst  = (global half*)((global char*)dst + offsetd);
 
-    const float x = convert_float(src0[get_global_id(0)]);
-    dst[get_global_id(0)] = convert_half_rte((x > 20.0f) ? x : log(1.0f + exp(x)));
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
+    const half x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = (x > 20.0h) ? x : log(1.0h + exp(x));
+#else
+    const float x = (float) src0[get_global_id(0)];
+    dst[get_global_id(0)] = (half) ((x > 20.0f) ? x : log(1.0f + exp(x)));
+#endif
 }
 
 kernel void kernel_softplus_f16_4(
@@ -50,8 +55,15 @@ kernel void kernel_softplus_f16_4(
     src0 = (global half4*)((global char*)src0 + offset0);
     dst  = (global half4*)((global char*)dst + offsetd);
 
-    const float4 x = convert_float4(src0[get_global_id(0)]);
-    dst[get_global_id(0)] = convert_half4_rte((x > 20.0f) ? x : log(1.0f + exp(x)));
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
+    half4 x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = (x > 20.0h) ? x : log(1.0h + exp(x));
+#else
+    half4 h = src0[get_global_id(0)];
+    float4 x = (float4)((float)h.s0, (float)h.s1, (float)h.s2, (float)h.s3);
+    float4 y = (x > 20.0f) ? x : log(1.0f + exp(x));
+    dst[get_global_id(0)] = (half4)((half)y.s0, (half)y.s1, (half)y.s2, (half)y.s3);
+#endif
 }
 
 kernel void kernel_softplus_f32_nc(
@@ -110,7 +122,12 @@ kernel void kernel_softplus_f16_nc(
         global const half * hx = (global const half *)(src0 + i3*nb03 + i2*nb02 + i1*nb01 + i0*nb00);
         global       half * hy = (global       half *)(dst  + i3*nb3  + i2*nb2  + i1*nb1  + i0*nb0);
 
-        const float x = convert_float(*hx);
-        *hy = convert_half_rte((x > 20.0f) ? x : log(1.0f + exp(x)));
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
+        const half x = *hx;
+        *hy = (x > 20.0h) ? x : log(1.0h + exp(x));
+#else
+        const float x = (float) *hx;
+        *hy = (half) ((x > 20.0f) ? x : log(1.0f + exp(x)));
+#endif
     }
 }

--- a/ggml/src/ggml-opencl/kernels/sqrt.cl
+++ b/ggml/src/ggml-opencl/kernels/sqrt.cl
@@ -36,7 +36,11 @@ kernel void kernel_sqrt_cont_f16(
     dst  = (global half*)((global char*)dst + offsetd);
 
     uint gid = get_global_id(0);
-    dst[gid] = convert_half(sqrt(convert_float(src0[gid])));
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
+    dst[gid] = sqrt(src0[gid]);
+#else
+    dst[gid] = (half) sqrt((float) src0[gid]);
+#endif
 }
 
 kernel void kernel_sqrt_cont_f16_4(
@@ -49,5 +53,12 @@ kernel void kernel_sqrt_cont_f16_4(
     dst  = (global half4*)((global char*)dst + offsetd);
 
     uint gid = get_global_id(0);
-    dst[gid] = convert_half4(sqrt(convert_float4(src0[gid])));
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
+    dst[gid] = sqrt(src0[gid]);
+#else
+    half4 h = src0[gid];
+    float4 f = (float4)((float)h.s0, (float)h.s1, (float)h.s2, (float)h.s3);
+    float4 r = sqrt(f);
+    dst[gid] = (half4)((half)r.s0, (half)r.s1, (half)r.s2, (half)r.s3);
+#endif
 }

--- a/ggml/src/ggml-opencl/kernels/tanh.cl
+++ b/ggml/src/ggml-opencl/kernels/tanh.cl
@@ -9,7 +9,8 @@ kernel void kernel_tanh_f32(
     src0 = (global float*)((global char*)src0 + offset0);
     dst  = (global float*)((global char*)dst + offsetd);
 
-    dst[get_global_id(0)] = tanh(src0[get_global_id(0)]);
+    const float x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = tanh(x);
 }
 
 kernel void kernel_tanh_f32_4(
@@ -21,7 +22,8 @@ kernel void kernel_tanh_f32_4(
     src0 = (global float4*)((global char*)src0 + offset0);
     dst  = (global float4*)((global char*)dst + offsetd);
 
-    dst[get_global_id(0)] = tanh(src0[get_global_id(0)]);
+    float4 x = src0[get_global_id(0)];
+    dst[get_global_id(0)] = tanh(x);
 }
 
 kernel void kernel_tanh_f16(
@@ -33,7 +35,12 @@ kernel void kernel_tanh_f16(
     src0 = (global half*)((global char*)src0 + offset0);
     dst  = (global half*)((global char*)dst + offsetd);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
     dst[get_global_id(0)] = tanh(src0[get_global_id(0)]);
+#else
+    const float x = (float) src0[get_global_id(0)];
+    dst[get_global_id(0)] = (half) tanh(x);
+#endif
 }
 
 kernel void kernel_tanh_f16_4(
@@ -45,7 +52,14 @@ kernel void kernel_tanh_f16_4(
     src0 = (global half4*)((global char*)src0 + offset0);
     dst  = (global half4*)((global char*)dst + offsetd);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
     dst[get_global_id(0)] = tanh(src0[get_global_id(0)]);
+#else
+    half4 h = src0[get_global_id(0)];
+    float4 x = (float4)((float)h.s0, (float)h.s1, (float)h.s2, (float)h.s3);
+    float4 y = tanh(x);
+    dst[get_global_id(0)] = (half4)((half)y.s0, (half)y.s1, (half)y.s2, (half)y.s3);
+#endif
 }
 
 kernel void kernel_tanh_f32_nc(
@@ -104,6 +118,10 @@ kernel void kernel_tanh_f16_nc(
         global const half * x = (global const half *)(src0 + i3*nb03 + i2*nb02 + i1*nb01 + i0*nb00);
         global       half * y = (global       half *)(dst  + i3*nb3  + i2*nb2  + i1*nb1  + i0*nb0);
 
+#if GGML_OPENCL_USE_NATIVE_FP16_MATH
         *y = tanh(*x);
+#else
+        *y = (half) tanh((float) *x);
+#endif
     }
 }


### PR DESCRIPTION
## Summary

Add three Q4_K GEMM kernel variants and dispatch logic for batch prompt processing:

- **`mul_mm_q4_k_f32_l4_lm`**: SOA (separate qs/scales/d/dmin buffers) GEMM for OpenCL 3.0 devices without subgroup extensions. Tensor converted to SOA at `buffer_set_tensor`; dispatch checks `soa_q4_K_tensors` membership.
- **`mul_mm_q4_k_f32_l4_lm_qst`**: transposed-qs layout GEMM for legacy OpenCL 1.2 devices; coalesced `qs_t` buffer created at first dispatch. Adjacent threads read stride-128-byte-apart addresses instead of the packed format's 1728-byte stride.
- **`mul_mm_q4_k_f32_l4_lm_qst_n32`**: BN=32 narrow-tile variant for `32 ≤ ne11 < 64`.
- **`mul_mm_q4_k_f32_l4_lm_packed`**: packed fallback when `qs_t` allocation fails (OOM).

All three lazy kernels (qst, qst_n32, packed) are compiled on first dispatch rather than at init to avoid consuming ~300–500 MB of driver-managed GPU memory at startup. A global pool budget (`QST_POOL_PLUS_QST_LIMIT = 4 GB`) caps `qs_t` allocation to avoid OOM on 7B+ models.

## Dependencies

Stacked on #21310. Incremental diff is only the Q4_K GEMM additions.

## Test plan

- Tested on Adreno X1-85: Q4_K PP performance matches or exceeds reference across Qwen3-0.6B, Llama-1B/3B, Phi-3.5-mini, Phi-4-mini, gemma-2-2b, Mistral-7B, Qwen2.5-7B