### PR TITLE
fix: minja upper/lower filter fails on array type values

### DIFF
--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -797,6 +797,8 @@ const func_builtins & value_bool_t::get_builtins() const {
 const func_builtins & value_array_t::get_builtins() const {
     static const func_builtins builtins = {
         {"default", default_value},
+        {"upper", empty_value_fn<value_string>},
+        {"lower", empty_value_fn<value_string>},
         {"list", [](const func_args & args) -> value {
             args.ensure_vals<value_array>();
             const auto & arr = args.get_pos(0)->as_array();


### PR DESCRIPTION
## Overview

When using Gemma 4 models with tool calling (tested Gemma-4-31B-It, unsloth gguf), requests to /v1/chat/completions or /v1/responses fail with a 500 error:

  While executing FilterExpression at line 18, column 34 in source:
  ...if -%}
      {%- if value['type'] | upper == 'STRING' -%}
                             ^
  Error: Unknown (built-in) filter 'upper' for type Array

This happens because Gemma 4's chat template (both the GGUF-embedded template and the new gemma4.jinja template from #21326) uses value['type'] | upper to check JSON Schema parameter types. Minja's value_array_t had no upper (or lower) method, causing the exception.

Reported in a comment on #21326: https://github.com/ggml-org/llama.cpp/pull/21326#issuecomment-4180568307

### Fix

Add upper and lower to value_array_t::get_builtins() in common/jinja/value.cpp, returning an empty string — the same fallback behavior already used by value_undefined_t.

## Additional information

[ch10299342](https://github.com/ch10299342) proposed fixing the template itself in #21326.

Valid, would preserve type-specific formatting for nullable params. The runtime fix is simpler and more defensive. 
The two approaches are not mutually exclusive — a template fix could be applied on top.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, root cause analysis and search for existing PRs

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
