### PR TITLE
ci : add AMD ZenDNN label to PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,6 +27,11 @@ IBM zDNN:
         - any-glob-to-any-file:
             - ggml/include/ggml-zdnn.h
             - ggml/src/ggml-zdnn/**
+AMD CPU:
+    - changed-files:
+        - any-glob-to-any-file:
+            - ggml/include/ggml-zendnn.h
+            - ggml/src/ggml-zendnn/**
 documentation:
     - changed-files:
         - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,7 +27,7 @@ IBM zDNN:
         - any-glob-to-any-file:
             - ggml/include/ggml-zdnn.h
             - ggml/src/ggml-zdnn/**
-AMD CPU:
+AMD ZenDNN:
     - changed-files:
         - any-glob-to-any-file:
             - ggml/include/ggml-zendnn.h


### PR DESCRIPTION
This PR adds a new "AMD ZenDNN" label to automatically tag pull requests that modify ZenDNN backend files, making it easier to track changes to AMD's EPYC CPU acceleration support.

cc: @amukho @avinashcpandey @taronaeo @danbev