### PR TITLE
fix: add openssl to nix dependencies (#21353)

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -16,7 +16,7 @@
   rocmPackages,
   vulkan-headers,
   vulkan-loader,
-  curl,
+  openssl,
   shaderc,
   useBlas ?
     builtins.all (x: !x) [
@@ -160,7 +160,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ++ optionals useMpi [ mpi ]
     ++ optionals useRocm rocmBuildInputs
     ++ optionals useBlas [ blas ]
-    ++ optionals useVulkan vulkanBuildInputs;
+    ++ optionals useVulkan vulkanBuildInputs
+    ++ [ openssl ];
 
   cmakeFlags =
     [


### PR DESCRIPTION
## Overview

Closes #21353. Error was:

`llama-cli -hf unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_XL` ->

```
HTTPS is not supported. Please rebuild with one of:
  -DLLAMA_BUILD_BORINGSSL=ON
  -DLLAMA_BUILD_LIBRESSL=ON
  -DLLAMA_OPENSSL=ON (default, requires OpenSSL dev files installed)
```

## Additional information

This just slaps in openssl as a dependency. llama.cpp supports other libraries, but openssl is the default and thus no further configuration is needed.

I guess you could make the nix package configurable to use other ssl libraries, but I am not sure that folks would even care.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no