### PR TITLE
fix: zero-copy host_ptr for CPU tensors to avoid double model loading on memory-constrained devices

### DIFF
--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -78,6 +78,7 @@ extern "C" {
 
     GGML_API struct gguf_context * gguf_init_empty(void);
     GGML_API struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_params params);
+    GGML_API struct gguf_context * gguf_init_from_mem(const void * buf, size_t size, struct gguf_init_params params);
     //GGML_API struct gguf_context * gguf_init_from_buffer(..);
 
     GGML_API void gguf_free(struct gguf_context * ctx);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -863,6 +863,8 @@ struct vk_device_struct {
     bool disable_host_visible_vidmem;
     bool allow_sysmem_fallback;
     bool disable_graph_optimize;
+    vk::PipelineCache pipeline_cache;
+    std::string       pipeline_cache_path;
 
     std::unique_ptr<vk_memory_logger> memory_logger;
 
@@ -887,6 +889,18 @@ struct vk_device_struct {
         all_pipelines.clear();
 
         device.destroyDescriptorSetLayout(dsl);
+
+        // Save pipeline cache to disk
+        if (pipeline_cache && !pipeline_cache_path.empty()) {
+            auto data = device.getPipelineCacheData(pipeline_cache);
+            if (!data.empty()) {
+                if (FILE* f = fopen(pipeline_cache_path.c_str(), "wb")) {
+                    fwrite(data.data(), 1, data.size(), f);
+                    fclose(f);
+                }
+            }
+            device.destroyPipelineCache(pipeline_cache);
+        }
 
         device.destroy();
     }
@@ -2011,7 +2025,7 @@ void vk_memory_logger::log_allocation(vk_buffer_ref buf_ref, size_t size) {
     allocations[buf->buffer] = size;
     total_device += device ? size : 0;
     total_host += device ? 0 : size;
-    VK_LOG_MEMORY(buf->device->name << ": +" << format_size(size) << " " << type << " at " << buf->buffer << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
+    VK_LOG_MEMORY(buf->device->name << ": +" << format_size(size) << " " << type << " at " << (VkBuffer)buf->buffer << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
 }
 
 void vk_memory_logger::log_deallocation(vk_buffer_ref buf_ref) {
@@ -2027,10 +2041,10 @@ void vk_memory_logger::log_deallocation(vk_buffer_ref buf_ref) {
     total_device -= device ? it->second : 0;
     total_host -= device ? 0 : it->second;
     if (it != allocations.end()) {
-        VK_LOG_MEMORY(buf->device->name << ": -" << format_size(it->second) << " " << type << " at " << buf->buffer << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
+        VK_LOG_MEMORY(buf->device->name << ": -" << format_size(it->second) << " " << type << " at " << (VkBuffer)buf->buffer << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
         allocations.erase(it);
     } else {
-        VK_LOG_MEMORY("ERROR " << buf->device->name << ": Attempted to deallocate unknown " << type << " memory at " << buf->buffer);
+        VK_LOG_MEMORY("ERROR " << buf->device->name << ": Attempted to deallocate unknown " << type << " memory at " << (VkBuffer)buf->buffer);
     }
 }
 
@@ -2196,7 +2210,7 @@ static void ggml_vk_create_pipeline_func(vk_device& device, vk_pipeline& pipelin
 #endif
 
     try {
-        pipeline->pipeline = device->device.createComputePipeline(VK_NULL_HANDLE, compute_pipeline_create_info).value;
+        pipeline->pipeline = device->device.createComputePipeline(device->pipeline_cache, compute_pipeline_create_info).value;
     } catch (const vk::SystemError& e) {
         std::cerr << "ggml_vulkan: Compute pipeline creation failed for " << pipeline->name << std::endl;
         std::cerr << "ggml_vulkan: " << e.what() << std::endl;
@@ -4774,6 +4788,11 @@ static vk_device ggml_vk_get_device(size_t idx) {
         vk_device device = std::make_shared<vk_device_struct>();
         vk_instance.devices[idx] = device;
 
+        const char* vk_cache_dir = getenv("GGML_VK_CACHE_DIR");
+        if (vk_cache_dir) {
+            device->pipeline_cache_path = std::string(vk_cache_dir) + "/vk_pipeline_cache_" + std::to_string(idx) + ".bin";
+        }
+
         device->memory_logger = std::unique_ptr<vk_memory_logger>(new vk_memory_logger());
 
         size_t dev_num = vk_instance.device_indices[idx];
@@ -5421,6 +5440,35 @@ static vk_device ggml_vk_get_device(size_t idx) {
         };
         device_create_info.setPNext(&device_features2);
         device->device = device->physical_device.createDevice(device_create_info);
+
+        // Load pipeline cache from disk
+        {
+            vk::PipelineCacheCreateInfo cache_info;
+            std::vector<uint8_t> cache_data;
+            if (!device->pipeline_cache_path.empty()) {
+                if (FILE* f = fopen(device->pipeline_cache_path.c_str(), "rb")) {
+                    fseek(f, 0, SEEK_END);
+                    cache_data.resize((size_t)ftell(f));
+                    fseek(f, 0, SEEK_SET);
+                    fread(cache_data.data(), 1, cache_data.size(), f);
+                    fclose(f);
+                    // Validate UUID — discard cache if device/driver changed
+                    if (cache_data.size() >= 32) {
+                        auto props = device->physical_device.getProperties();
+                        if (memcmp(cache_data.data() + 16, props.pipelineCacheUUID, VK_UUID_SIZE) != 0) {
+                            cache_data.clear();
+                        }
+                    } else {
+                        cache_data.clear();
+                    }
+                    if (!cache_data.empty()) {
+                        cache_info.setInitialDataSize(cache_data.size());
+                        cache_info.setPInitialData(cache_data.data());
+                    }
+                }
+            }
+            device->pipeline_cache = device->device.createPipelineCache(cache_info);
+        }
 
         // Queues
         ggml_vk_create_queue(device, device->compute_queue, compute_queue_family_index, 0, { vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer }, false);
@@ -6493,7 +6541,7 @@ static void ggml_vk_dispatch_pipeline(ggml_backend_vk_context* ctx, vk_context& 
     const uint32_t wg2 = CEIL_DIV(elements[2], pipeline->wg_denoms[2]);
     VK_LOG_DEBUG("ggml_vk_dispatch_pipeline(" << pipeline->name << ", {";
     for (auto& buffer : descriptor_buffer_infos) {
-        std::cerr << "(" << buffer.buffer << ", " << buffer.offset << ", " << buffer.range << "), ";
+        std::cerr << "(" << (VkBuffer)buffer.buffer << ", " << buffer.offset << ", " << buffer.range << "), ";
     }
     std::cerr << "}, (" << wg0 << "," << wg1 << "," << wg2 << "))");
     GGML_ASSERT(wg0 <= ctx->device->properties.limits.maxComputeWorkGroupCount[0] &&
@@ -7080,7 +7128,7 @@ static void ggml_vk_matmul(
         uint32_t batch_stride_a, uint32_t batch_stride_b, uint32_t batch_stride_d,
         uint32_t split_k, uint32_t batch, uint32_t ne02, uint32_t ne12, uint32_t broadcast2, uint32_t broadcast3,
         uint32_t padded_n) {
-        VK_LOG_DEBUG("ggml_vk_matmul(a: (" << a.buffer->buffer << ", " << a.offset << ", " << a.size << "), b: (" << b.buffer->buffer << ", " << b.offset << ", " << b.size << "), d: (" << d.buffer->buffer << ", " << d.offset << ", " << d.size << "), split_k: (" << (split_k_buffer.buffer != nullptr ? split_k_buffer.buffer->buffer : VK_NULL_HANDLE) << ", " << split_k_buffer.offset << ", " << split_k_buffer.size << "), m: " << m << ", n: " << n << ", k: " << k << ", stride_a: " << stride_a << ", stride_b: " << stride_b << ", stride_d: " << stride_d << ", batch_stride_a: " << batch_stride_a << ", batch_stride_b: " << batch_stride_b << ", batch_stride_d: " << batch_stride_d << ", split_k: " << split_k << ", batch: " << batch << ", ne02: " << ne02 << ", ne12: " << ne12 << ", broadcast2: " << broadcast2 << ", broadcast3: " << broadcast3 << ", padded_n: " << padded_n << ")");
+        VK_LOG_DEBUG("ggml_vk_matmul(a: (" << (VkBuffer)a.buffer->buffer << ", " << a.offset << ", " << a.size << "), b: (" << (VkBuffer)b.buffer->buffer << ", " << b.offset << ", " << b.size << "), d: (" << (VkBuffer)d.buffer->buffer << ", " << d.offset << ", " << d.size << "), split_k: (" << (split_k_buffer.buffer != nullptr ? (VkBuffer)(split_k_buffer.buffer->buffer) : VK_NULL_HANDLE) << ", " << split_k_buffer.offset << ", " << split_k_buffer.size << "), m: " << m << ", n: " << n << ", k: " << k << ", stride_a: " << stride_a << ", stride_b: " << stride_b << ", stride_d: " << stride_d << ", batch_stride_a: " << batch_stride_a << ", batch_stride_b: " << batch_stride_b << ", batch_stride_d: " << batch_stride_d << ", split_k: " << split_k << ", batch: " << batch << ", ne02: " << ne02 << ", ne12: " << ne12 << ", broadcast2: " << broadcast2 << ", broadcast3: " << broadcast3 << ", padded_n: " << padded_n << ")");
     if (split_k == 1) {
         ggml_pipeline_request_descriptor_sets(ctx, pipeline, CEIL_DIV(batch, ctx->device->properties.limits.maxComputeWorkGroupCount[2]));
 
@@ -7160,7 +7208,7 @@ static void ggml_vk_matmul_id(
         uint32_t batch_stride_a, uint32_t batch_stride_b, uint32_t batch_stride_d,
         uint32_t n_as, uint32_t nei0, uint32_t nei1, uint32_t nbi1, uint32_t ne11,
         uint32_t padded_n) {
-    VK_LOG_DEBUG("ggml_vk_matmul_id(a: (" << a.buffer->buffer << ", " << a.offset << ", " << a.size << "), b: (" << b.buffer->buffer << ", " << b.offset << ", " << b.size << "), d: (" << d.buffer->buffer << ", " << d.offset << ", " << d.size << "), ids: (" << ids.buffer->buffer << ", " << ids.offset << ", " << ids.size << "), expert_count: (" << expert_count_buf.buffer->buffer << ", " << expert_count_buf.offset << ", " << expert_count_buf.size << "), " <<
+    VK_LOG_DEBUG("ggml_vk_matmul_id(a: (" << (VkBuffer)a.buffer->buffer << ", " << a.offset << ", " << a.size << "), b: (" << (VkBuffer)b.buffer->buffer << ", " << b.offset << ", " << b.size << "), d: (" << (VkBuffer)d.buffer->buffer << ", " << d.offset << ", " << d.size << "), ids: (" << (VkBuffer)ids.buffer->buffer << ", " << ids.offset << ", " << ids.size << "), expert_count: (" << (VkBuffer)expert_count_buf.buffer->buffer << ", " << expert_count_buf.offset << ", " << expert_count_buf.size << "), " <<
         "m: " << m << ", n: " << n << ", k: " << k << ", stride_a: " << stride_a << ", stride_b: " << stride_b << ", stride_d: " << stride_d << ", " <<
         "batch_stride_a: " << batch_stride_a << ", batch_stride_b: " << batch_stride_b << ", batch_stride_d: " << batch_stride_d << ", " <<
         "n_as: " << n_as << ", nei0: " << nei0 << ", nei1: " << nei1 << ", nbi1: " << nbi1 << ", ne11: " << ne11 << ")");

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -853,6 +853,17 @@ struct gguf_context * gguf_init_from_file(const char * fname, struct gguf_init_p
     return result;
 }
 
+struct gguf_context * gguf_init_from_mem(const void * buf, size_t size, struct gguf_init_params params) {
+    FILE * file = fmemopen((void *)buf, size, "rb");
+    if (!file) {
+        GGML_LOG_ERROR("%s: fmemopen failed errno=%d\n", __func__, errno);
+        return nullptr;
+    }
+    struct gguf_context * result = gguf_init_from_file_impl(file, params);
+    fclose(file);
+    return result;
+}
+
 void gguf_free(struct gguf_context * ctx) {
     if (ctx == nullptr) {
         return;

--- a/include/llama.h
+++ b/include/llama.h
@@ -308,6 +308,11 @@ extern "C" {
         // override key-value pairs of the model meta data
         const struct llama_model_kv_override * kv_overrides;
 
+        // host pointer for user-loaded models (zero-copy CPU tensors)
+        void * host_ptr;        // mmap base pointer
+        size_t host_ptr_offset; // data offset within host_ptr
+        size_t host_ptr_size;   // size of tensor data region
+
         // Keep the booleans together to avoid misalignment during copy-by-value.
         bool vocab_only;      // only load the vocabulary, no weights
         bool use_mmap;        // use mmap if possible

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1364,6 +1364,8 @@ bool llama_model_loader::load_all_data(
         void * progress_callback_user_data) {
     if (files.empty()) {
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            // skip CPU tensors — they point directly at host_ptr (zero copy)
+            if (host_ptr && ggml_backend_buffer_is_host(t->buffer)) continue;
             set_tensor_data(t, set_tensor_data_ud);
         }
         return true;

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -77,6 +77,9 @@ struct llama_model_loader {
 
     bool use_mmap = false;
     bool use_direct_io = false;
+    void *  host_ptr        = nullptr;
+    size_t  host_ptr_offset = 0;
+    size_t  host_ptr_size   = 0;
     bool check_tensors;
     bool no_alloc;
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -7562,7 +7562,16 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
         bool is_default_buft = buft == ggml_backend_dev_buffer_type(dev);
 
         std::vector<ggml_backend_buffer_ptr> bufs;
-        if (ml.use_mmap && use_mmap_buffer && buffer_from_host_ptr_supported && is_default_buft) {
+        if (ml.host_ptr && use_mmap_buffer && buffer_from_host_ptr_supported && is_default_buft) {
+            GGML_ASSERT(!ml.no_alloc);
+            const size_t max_size = ggml_get_max_tensor_size(ctx);
+            ggml_backend_buffer_t buf = ggml_backend_dev_buffer_from_host_ptr(dev, (char*)ml.host_ptr + ml.host_ptr_offset, ml.host_ptr_size, max_size);
+            if (buf == nullptr) {
+                throw std::runtime_error(format("unable to allocate host_ptr buffer for %s", ggml_backend_buft_name(buft)));
+            }
+            bufs.emplace_back(buf);
+            buf_map.emplace(0, buf);
+        } else if (ml.use_mmap && use_mmap_buffer && buffer_from_host_ptr_supported && is_default_buft) {
             GGML_ASSERT(!ml.no_alloc);
             for (uint32_t idx = 0; idx < ml.files.size(); idx++) {
                 // only the mmap region containing the tensors in the model is mapped to the backend buffer
@@ -8703,6 +8712,9 @@ llama_model_params llama_model_default_params() {
         /*.progress_callback           =*/ nullptr,
         /*.progress_callback_user_data =*/ nullptr,
         /*.kv_overrides                =*/ nullptr,
+        /*.host_ptr                    =*/ nullptr,
+        /*.host_ptr_offset             =*/ 0,
+        /*.host_ptr_size               =*/ 0,
         /*.vocab_only                  =*/ false,
         /*.use_mmap                    =*/ true,
         /*.use_direct_io               =*/ false,

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -840,6 +840,10 @@ static int llama_model_load(struct gguf_context * metadata, llama_model_set_tens
         llama_model_loader ml(metadata, set_tensor_data, set_tensor_data_ud, fname, splits, params.use_mmap, params.use_direct_io,
             params.check_tensors, params.no_alloc, params.kv_overrides, params.tensor_buft_overrides);
 
+        ml.host_ptr        = params.host_ptr;
+        ml.host_ptr_offset = params.host_ptr_offset;
+        ml.host_ptr_size   = params.host_ptr_size;
+
         ml.print_info();
 
         model.hparams.vocab_only = params.vocab_only;


### PR DESCRIPTION
## Problem

On memory-constrained devices (e.g. Samsung Galaxy Watch 4 Classic, 380MB free RAM), 
loading a 270MB model caused 524MB peak RAM usage. The root cause is double allocation: 
the APK's AssetManager already mmaps the model file, but llama_model_load allocates a 
second copy for CPU tensors — effectively paying 2× for the same data.

## Fix

Add `host_ptr`, `host_ptr_offset`, and `host_ptr_size` to `llama_model_params`. When 
set, CPU tensors point directly into the caller's pre-mapped memory region instead of 
allocating new buffers. GPU tensors are unaffected and still allocate normally.

Also adds `gguf_init_from_mem()` to parse GGUF metadata directly from an in-memory 
buffer without a file descriptor, enabling fully zero-copy model loading from APK assets.

Also adds Vulkan pipeline cache support via `GGML_VK_CACHE_DIR` environment variable, 
which persists compiled shaders across runs — useful on devices with no system shader cache.

## Results (Samsung Galaxy Watch 4 Classic, Mali G68, armeabi-v7a)

| Metric | Before | After |
|--------|--------|-------|
| Peak RAM | 524 MB | 142 MB (-74%) |
| Cold boot | 19s | 11s |
| Warm boot | 19s | ~2.5s |

## Changes

- `include/llama.h` — add `host_ptr`, `host_ptr_offset`, `host_ptr_size` to `llama_model_params`
- `src/llama-model-loader.h/.cpp` — accept host_ptr; skip CPU tensors in `load_all_data` when using host_ptr
- `src/llama-model.cpp` — add host_ptr buffer allocation path, restricted to CPU device only
- `src/llama.cpp` — pass host_ptr params to model loader
- `ggml/include/gguf.h` — declare `gguf_init_from_mem`
- `ggml/src/gguf.cpp` — implement `gguf_init_from_mem` using `fmemopen`
- `ggml/src/ggml-vulkan/ggml-vulkan.cpp` — pipeline cache + 32-bit pointer cast fixes

## Results

### Before
<img width="859" height="522" alt="Screenshot 2026-04-02 at 9 24 34 AM" src="https://github.com/user-attachments/assets/37a9d8c5-cbec-4354-9fe0-12db2631ac91" />

### After  
<img width="860" height="227" alt="Screenshot 2026-04-02 at 9 24 14 AM" src="https://github.com/user-attachments/assets/44280746-0bdf-4837-bef3-38c6bc095aef" />

## AI Assistance Disclosure

I used Claude (Anthropic) as a debugging assistant during investigation — 
specifically to help trace the root cause through the codebase via log 
analysis and code reading. The PR description was also drafted with AI 
assistance. The bug discovery, hardware testing, patch design, and 
validation were done by me on real hardware (Samsung Galaxy Watch 4 
Classic). All code changes were written and verified by me.
