### PR TITLE
fix: include API key in CORS proxy requests for MCP connections

### DIFF
--- a/tools/server/webui/src/lib/services/mcp.service.ts
+++ b/tools/server/webui/src/lib/services/mcp.service.ts
@@ -42,6 +42,7 @@ import type {
 import {
 	buildProxiedUrl,
 	buildProxiedHeaders,
+	getAuthHeaders,
 	throwIfAborted,
 	isAbortError,
 	createBase64DataUrl
@@ -125,6 +126,13 @@ export class MCPService {
 
 		if (config.headers) {
 			requestInit.headers = buildProxiedHeaders(config.headers);
+		}
+
+		if (useProxy) {
+			requestInit.headers = {
+				...getAuthHeaders(),
+				...(requestInit.headers as Record<string, string>)
+			};
 		}
 
 		if (config.credentials) {

--- a/tools/server/webui/src/lib/services/mcp.service.ts
+++ b/tools/server/webui/src/lib/services/mcp.service.ts
@@ -125,7 +125,7 @@ export class MCPService {
 		const requestInit: RequestInit = {};
 
 		if (config.headers) {
-			requestInit.headers = buildProxiedHeaders(config.headers);
+			requestInit.headers = config.useProxy ? buildProxiedHeaders(config.headers) : config.headers;
 		}
 
 		if (useProxy) {


### PR DESCRIPTION
When a WebUI MCP server is configured with authentication headers and `useProxy` is enabled, the CORS proxy requests were being sent without the API key. This caused 401 errors for protected MCP servers even when credentials were correctly configured.

The fix merges auth headers from `getAuthHeaders()` into the request before it goes through the proxy, so the API key is forwarded correctly. Also adjusts the conditional so `buildProxiedHeaders` is only called when `useProxy` is actually set, avoiding unnecessary header transformation for direct connections.

Tested against an MCP server behind API key auth with the CORS proxy enabled - requests now go through correctly.