### PR TITLE
server: add optional JSONL HTTP trace logging (--http-trace-dir)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3010,6 +3010,19 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--http-trace-dir"}, "PATH",
+        "directory for writing HTTP request/response JSONL trace logs, one rotating file per day: trace-YYYYMMDD.jsonl (default: disabled)",
+        [](common_params & params, const std::string & value) {
+            params.http_trace_dir = value;
+            if (!fs_is_directory(params.http_trace_dir)) {
+                throw std::invalid_argument("not a directory: " + value);
+            }
+            if (!params.http_trace_dir.empty() && params.http_trace_dir[params.http_trace_dir.size() - 1] != DIRECTORY_SEPARATOR) {
+                params.http_trace_dir += DIRECTORY_SEPARATOR;
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--media-path"}, "PATH",
         "directory for loading local media files; files can be accessed via file:// URLs using relative paths (default: disabled)",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -626,6 +626,7 @@ struct common_params {
     bool log_json = false;
 
     std::string slot_save_path;
+    std::string http_trace_dir; // directory for JSONL HTTP trace logs (empty = disabled)
     std::string media_path; // path to directory for loading media files
 
     float slot_prompt_similarity = 0.1f;

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -34,6 +34,8 @@ set(TARGET_SRCS
     server.cpp
     server-http.cpp
     server-http.h
+    server-trace.cpp
+    server-trace.h
     server-models.cpp
     server-models.h
 )

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -211,6 +211,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--props` | enable changing global properties via POST /props (default: disabled)<br/>(env: LLAMA_ARG_ENDPOINT_PROPS) |
 | `--slots, --no-slots` | expose slots monitoring endpoint (default: enabled)<br/>(env: LLAMA_ARG_ENDPOINT_SLOTS) |
 | `--slot-save-path PATH` | path to save slot kv cache (default: disabled) |
+| `--http-trace-dir PATH` | directory for writing HTTP request/response JSONL trace logs; one rotating file per day: `trace-YYYYMMDD.jsonl` (default: disabled) |
 | `--media-path PATH` | directory for loading local media files; files can be accessed via file:// URLs using relative paths (default: disabled) |
 | `--models-dir PATH` | directory containing models for the router server (default: disabled)<br/>(env: LLAMA_ARG_MODELS_DIR) |
 | `--models-preset PATH` | path to INI file containing model presets for the router server (default: disabled)<br/>(env: LLAMA_ARG_MODELS_PRESET) |

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -1,9 +1,11 @@
 #include "common.h"
 #include "server-http.h"
 #include "server-common.h"
+#include "server-trace.h"
 
 #include <cpp-httplib/httplib.h>
 
+#include <chrono>
 #include <functional>
 #include <string>
 #include <thread>
@@ -23,6 +25,7 @@
 class server_http_context::Impl {
 public:
     std::unique_ptr<httplib::Server> srv;
+    std::unique_ptr<http_tracer>     tracer; // null when tracing is disabled
 };
 
 server_http_context::server_http_context()
@@ -296,6 +299,13 @@ bool server_http_context::init(const common_params & params) {
 #endif
         }
     }
+
+    // Initialise HTTP trace logger if requested
+    if (!params.http_trace_dir.empty()) {
+        SRV_INF("http trace logging enabled, writing to: %s\n", params.http_trace_dir.c_str());
+        pimpl->tracer = std::make_unique<http_tracer>(params.http_trace_dir);
+    }
+
     return true;
 }
 
@@ -420,7 +430,8 @@ static void process_handler_response(server_http_req_ptr && request, server_http
 }
 
 void server_http_context::get(const std::string & path, const server_http_context::handler_t & handler) const {
-    pimpl->srv->Get(path_prefix + path, [handler](const httplib::Request & req, httplib::Response & res) {
+    http_tracer * tracer = pimpl->tracer.get(); // null if tracing is disabled
+    pimpl->srv->Get(path_prefix + path, [handler, tracer](const httplib::Request & req, httplib::Response & res) {
         server_http_req_ptr request = std::make_unique<server_http_req>(server_http_req{
             get_params(req),
             get_headers(req),
@@ -429,13 +440,34 @@ void server_http_context::get(const std::string & path, const server_http_contex
             req.body,
             req.is_connection_closed
         });
+
+        auto        t_start = std::chrono::steady_clock::now();
+        std::string req_id;
+        if (tracer) {
+            req_id = tracer->new_request_id();
+            tracer->log_request(req_id, req.method, request->path, request->headers, request->body);
+        }
+
         server_http_res_ptr response = handler(*request);
+
+        if (tracer && response) {
+            if (response->is_stream()) {
+                tracer->log_stream_start(req_id);
+                tracer->wrap_streaming_response(req_id, t_start, response->next);
+            } else {
+                auto    t_end = std::chrono::steady_clock::now();
+                int64_t ms    = std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count();
+                tracer->log_response(req_id, response->status, ms, response->data, response->content_type, response->headers);
+            }
+        }
+
         process_handler_response(std::move(request), response, res);
     });
 }
 
 void server_http_context::post(const std::string & path, const server_http_context::handler_t & handler) const {
-    pimpl->srv->Post(path_prefix + path, [handler](const httplib::Request & req, httplib::Response & res) {
+    http_tracer * tracer = pimpl->tracer.get(); // null if tracing is disabled
+    pimpl->srv->Post(path_prefix + path, [handler, tracer](const httplib::Request & req, httplib::Response & res) {
         server_http_req_ptr request = std::make_unique<server_http_req>(server_http_req{
             get_params(req),
             get_headers(req),
@@ -444,7 +476,27 @@ void server_http_context::post(const std::string & path, const server_http_conte
             req.body,
             req.is_connection_closed
         });
+
+        auto        t_start = std::chrono::steady_clock::now();
+        std::string req_id;
+        if (tracer) {
+            req_id = tracer->new_request_id();
+            tracer->log_request(req_id, req.method, request->path, request->headers, request->body);
+        }
+
         server_http_res_ptr response = handler(*request);
+
+        if (tracer && response) {
+            if (response->is_stream()) {
+                tracer->log_stream_start(req_id);
+                tracer->wrap_streaming_response(req_id, t_start, response->next);
+            } else {
+                auto    t_end = std::chrono::steady_clock::now();
+                int64_t ms    = std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count();
+                tracer->log_response(req_id, response->status, ms, response->data, response->content_type, response->headers);
+            }
+        }
+
         process_handler_response(std::move(request), response, res);
     });
 }

--- a/tools/server/server-trace.cpp
+++ b/tools/server/server-trace.cpp
@@ -1,0 +1,308 @@
+#include "server-trace.h"
+#include "server-common.h" // json, safe_json_to_str, SRV_WRN, string_format
+
+#include <algorithm>  // std::min, std::transform
+#include <cctype>     // std::tolower
+#include <cinttypes>  // PRIx64
+#include <cstdio>     // std::snprintf
+#include <ctime>      // std::strftime, gmtime_r / gmtime_s
+#include <set>        // std::set
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// FNV-1a 64-bit hash. Fast, dependency-free, good enough for body fingerprints.
+static uint64_t fnv1a_64(const std::string & data) {
+    uint64_t h = UINT64_C(14695981039346656037); // offset basis
+    for (unsigned char c : data) {
+        h ^= static_cast<uint64_t>(c);
+        h *= UINT64_C(1099511628211); // FNV prime
+    }
+    return h;
+}
+
+// Format a system_clock point as ISO-8601 UTC with milliseconds.
+// Example: "2024-01-15T10:30:45.123Z"
+static std::string format_iso_timestamp(std::chrono::system_clock::time_point tp) {
+    auto t  = std::chrono::system_clock::to_time_t(tp);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()) % 1000;
+
+    struct tm tm_buf = {};
+#ifdef _WIN32
+    gmtime_s(&tm_buf, &t);
+#else
+    gmtime_r(&t, &tm_buf);
+#endif
+    char ts[28];
+    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", &tm_buf);
+
+    char result[36];
+    std::snprintf(result, sizeof(result), "%s.%03dZ", ts, (int)ms.count());
+    return result;
+}
+
+// Format a system_clock point as YYYYMMDD (used for log file rotation).
+static std::string format_date(std::chrono::system_clock::time_point tp) {
+    auto t = std::chrono::system_clock::to_time_t(tp);
+    struct tm tm_buf = {};
+#ifdef _WIN32
+    gmtime_s(&tm_buf, &t);
+#else
+    gmtime_r(&t, &tm_buf);
+#endif
+    char buf[12];
+    std::strftime(buf, sizeof(buf), "%Y%m%d", &tm_buf);
+    return buf;
+}
+
+// Return the first max_len printable characters of body as a UTF-8 safe excerpt.
+// Non-printable bytes are replaced with '?'; trailing "..." added if truncated.
+static std::string make_excerpt(const std::string & body, size_t max_len = 200) {
+    if (body.empty()) {
+        return "";
+    }
+    size_t len = std::min(body.size(), max_len);
+    std::string result;
+    result.reserve(len + 3);
+    for (size_t i = 0; i < len; ++i) {
+        unsigned char c = body[i];
+        if (c >= 0x20 && c < 0x7f) {
+            result += static_cast<char>(c);
+        } else if (c == '\t' || c == '\n' || c == '\r') {
+            result += ' ';
+        } else {
+            result += '?';
+        }
+    }
+    if (body.size() > max_len) {
+        result += "...";
+    }
+    return result;
+}
+
+// Build a JSON object with a safe subset of the provided headers.
+// Authorization / X-Api-Key values are replaced with "[REDACTED]" to avoid
+// leaking credentials into the log files.
+static json safe_headers(const std::map<std::string, std::string> & hdrs) {
+    static const std::set<std::string> allow_verbatim = {
+        "content-type", "content-length", "user-agent",
+        "accept", "accept-encoding", "transfer-encoding"
+    };
+    static const std::set<std::string> allow_redacted = {
+        "authorization", "x-api-key"
+    };
+
+    json out = json::object();
+    for (const auto & [k, v] : hdrs) {
+        std::string lk = k;
+        std::transform(lk.begin(), lk.end(), lk.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        if (allow_verbatim.count(lk)) {
+            out[lk] = v;
+        } else if (allow_redacted.count(lk)) {
+            out[lk] = "[REDACTED]";
+        }
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// http_tracer
+// ---------------------------------------------------------------------------
+
+http_tracer::http_tracer(const std::string & dir)
+    : trace_dir(dir) {}
+
+http_tracer::~http_tracer() = default;
+
+std::string http_tracer::new_request_id() {
+    // "<16-hex ms timestamp>-<8-hex monotonic counter>"
+    // Lexicographically sortable by arrival time; unique within a process.
+    auto now = std::chrono::system_clock::now();
+    uint64_t ms = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count()
+    );
+    uint64_t n = counter.fetch_add(1, std::memory_order_relaxed);
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%016" PRIx64 "-%08" PRIx64, ms, n & 0xFFFFFFFFULL);
+    return buf;
+}
+
+void http_tracer::log_request(
+    const std::string & req_id,
+    const std::string & method,
+    const std::string & path,
+    const std::map<std::string, std::string> & headers,
+    const std::string & body
+) {
+    // Emitted before calling the handler so the request is always recorded,
+    // even if the handler fails. Whether the response streams is left implicit:
+    // a "stream_start" record follows if streaming, a "response" record if not.
+    auto now = std::chrono::system_clock::now();
+    json rec = {
+        {"type",       "request"},
+        {"request_id", req_id},
+        {"timestamp",  format_iso_timestamp(now)},
+        {"method",     method},
+        {"path",       path},
+        {"headers",    safe_headers(headers)},
+        {"body_size",  body.size()},
+        {"body_hash",  string_format("0x%016" PRIx64, fnv1a_64(body))},
+    };
+    if (!body.empty()) {
+        rec["body_excerpt"] = make_excerpt(body);
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
+    ensure_file_open();
+    write_line(safe_json_to_str(rec));
+}
+
+void http_tracer::log_stream_start(const std::string & req_id) {
+    // Emitted once the handler has returned a streaming response, before the
+    // first chunk is pulled. Marks the transition from request to stream phase.
+    auto now = std::chrono::system_clock::now();
+    json rec = {
+        {"type",       "stream_start"},
+        {"request_id", req_id},
+        {"timestamp",  format_iso_timestamp(now)},
+    };
+
+    std::lock_guard<std::mutex> lock(mtx);
+    ensure_file_open();
+    write_line(safe_json_to_str(rec));
+}
+
+void http_tracer::log_response(
+    const std::string & req_id,
+    int status,
+    int64_t duration_ms,
+    const std::string & body,
+    const std::string & content_type,
+    const std::map<std::string, std::string> & headers
+) {
+    auto now = std::chrono::system_clock::now();
+    // Always include content-type in the response headers
+    json res_headers = safe_headers(headers);
+    res_headers["content-type"] = content_type;
+
+    json rec = {
+        {"type",        "response"},
+        {"request_id",  req_id},
+        {"timestamp",   format_iso_timestamp(now)},
+        {"status",      status},
+        {"duration_ms", duration_ms},
+        {"headers",     res_headers},
+        {"body_size",   body.size()},
+        {"body_hash",   string_format("0x%016" PRIx64, fnv1a_64(body))},
+    };
+    if (!body.empty()) {
+        rec["body_excerpt"] = make_excerpt(body);
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
+    ensure_file_open();
+    write_line(safe_json_to_str(rec));
+}
+
+void http_tracer::wrap_streaming_response(
+    const std::string & req_id,
+    std::chrono::steady_clock::time_point t_start,
+    std::function<bool(std::string &)> & next_fn
+) {
+    // Take ownership of the original generator
+    auto orig_next = std::move(next_fn);
+
+    // Shared state across chunk callbacks (called from one httplib worker thread,
+    // but the lambda may outlive the outer scope, hence shared_ptr).
+    //
+    // seq counts only non-empty chunks so that:
+    //   - chunk record seq numbers are dense (0, 1, 2, ...)
+    //   - stream_end total_chunks == number of "chunk" records in the log
+    // httplib may invoke next() with an empty result (e.g. a trailing flush
+    // call), which must not skew the counters.
+    auto seq         = std::make_shared<uint64_t>(0);
+    auto total_bytes = std::make_shared<size_t>(0);
+
+    next_fn = [this, req_id, t_start,
+               orig_next = std::move(orig_next),
+               seq, total_bytes]
+              (std::string & chunk) mutable -> bool
+    {
+        bool has_next = orig_next(chunk);
+
+        *total_bytes += chunk.size();
+
+        if (!chunk.empty()) {
+            uint64_t chunk_seq = (*seq)++;   // advance only for non-empty chunks
+            auto now = std::chrono::system_clock::now();
+            json rec = {
+                {"type",       "chunk"},
+                {"request_id", req_id},
+                {"timestamp",  format_iso_timestamp(now)},
+                {"seq",        chunk_seq},
+                {"chunk_size", chunk.size()},
+            };
+            std::lock_guard<std::mutex> lock(mtx);
+            ensure_file_open();
+            write_line(safe_json_to_str(rec));
+        }
+
+        if (!has_next) {
+            // Stream finished: emit a summary record with total stats
+            auto t_end = std::chrono::steady_clock::now();
+            int64_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                t_end - t_start).count();
+            auto now = std::chrono::system_clock::now();
+            json rec = {
+                {"type",         "stream_end"},
+                {"request_id",   req_id},
+                {"timestamp",    format_iso_timestamp(now)},
+                {"total_chunks", *seq},  // number of non-empty chunks logged
+                {"total_bytes",  *total_bytes},
+                {"duration_ms",  ms},
+            };
+            std::lock_guard<std::mutex> lock(mtx);
+            ensure_file_open();
+            write_line(safe_json_to_str(rec));
+        }
+
+        return has_next;
+    };
+}
+
+void http_tracer::ensure_file_open() {
+    // Must be called with mtx held.
+    auto now  = std::chrono::system_clock::now();
+    std::string date = format_date(now);
+
+    if (date == current_date && trace_file.is_open()) {
+        return; // Still writing to today's file
+    }
+
+    if (trace_file.is_open()) {
+        trace_file.close();
+    }
+
+    std::string path = trace_dir + "trace-" + date + ".jsonl";
+    // Open in append mode so multiple server restarts on the same day accumulate
+    trace_file.open(path, std::ios::app | std::ios::out);
+    if (!trace_file.is_open()) {
+        SRV_WRN("http_tracer: failed to open trace file: %s\n", path.c_str());
+        return;
+    }
+    current_date = date;
+}
+
+void http_tracer::write_line(const std::string & line) {
+    // Must be called with mtx held and ensure_file_open() already done.
+    if (!trace_file.is_open()) {
+        return;
+    }
+    // flush() after each line keeps records visible immediately and avoids
+    // partial-line corruption if the process is killed.
+    trace_file << line << '\n';
+    trace_file.flush();
+}

--- a/tools/server/server-trace.h
+++ b/tools/server/server-trace.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+
+// Optional JSONL trace logger for all HTTP requests and responses.
+//
+// When enabled (non-empty directory), each request/response pair is logged as
+// structured JSON records to a rotating daily file:
+//   <trace_dir>/trace-YYYYMMDD.jsonl
+//
+// Record types sharing a request_id:
+//   "request"    - emitted when the request arrives at the handler
+//   "response"   - emitted when a non-streaming response is complete
+//   "chunk"      - emitted per non-empty chunk for streaming responses
+//   "stream_end" - emitted when a streaming response finishes
+//
+// Thread-safe: a mutex serialises all file writes.
+// Zero cost when disabled: all methods check the enabled flag inline.
+struct http_tracer {
+    // dir must be a valid, existing directory path with a trailing separator.
+    explicit http_tracer(const std::string & dir);
+    ~http_tracer();
+
+    // Returns a unique, roughly time-sortable request ID.
+    std::string new_request_id();
+
+    // Emit a "request" record. Always called before the handler runs, so the
+    // request is logged even if the handler fails to produce a response.
+    void log_request(
+        const std::string & req_id,
+        const std::string & method,
+        const std::string & path,
+        const std::map<std::string, std::string> & headers,
+        const std::string & body
+    );
+
+    // Emit a "stream_start" record once it is known the response will stream.
+    // Emitted immediately after the handler returns and before wrapping next().
+    void log_stream_start(const std::string & req_id);
+
+    // Emit a "response" record for a completed non-streaming response.
+    void log_response(
+        const std::string & req_id,
+        int status,
+        int64_t duration_ms,
+        const std::string & body,
+        const std::string & content_type,
+        const std::map<std::string, std::string> & headers
+    );
+
+    // Replace next_fn with a wrapper that emits "chunk" records for each
+    // non-empty chunk and a "stream_end" record when the stream closes.
+    // Call this before handing the response to the HTTP layer.
+    void wrap_streaming_response(
+        const std::string & req_id,
+        std::chrono::steady_clock::time_point t_start,
+        std::function<bool(std::string &)> & next_fn
+    );
+
+private:
+    std::string   trace_dir;
+    std::mutex    mtx;
+    std::ofstream trace_file;
+    std::string   current_date; // YYYYMMDD of currently open file
+    std::atomic<uint64_t> counter{0};
+
+    // Open (or rotate) the trace file for the current date.
+    // Must be called with mtx held.
+    void ensure_file_open();
+
+    // Append a single JSON line. Must be called with mtx held.
+    void write_line(const std::string & line);
+};

--- a/tools/server/tests/unit/test_http_trace.py
+++ b/tools/server/tests/unit/test_http_trace.py
@@ -1,0 +1,241 @@
+import json
+import os
+import tempfile
+import pytest
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+    server.temperature = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def read_trace_records(trace_dir: str) -> list[dict]:
+    """Read all JSONL records from the first (and only) trace file in trace_dir."""
+    files = [f for f in os.listdir(trace_dir) if f.startswith("trace-") and f.endswith(".jsonl")]
+    assert len(files) == 1, f"Expected exactly one trace file, found: {files}"
+    records = []
+    with open(os.path.join(trace_dir, files[0])) as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def records_for(request_id: str, records: list[dict]) -> list[dict]:
+    return [r for r in records if r.get("request_id") == request_id]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_trace_non_streaming():
+    """Non-streaming request produces a request + response record pair."""
+    global server
+    with tempfile.TemporaryDirectory() as trace_dir:
+        server.http_trace_dir = trace_dir
+        server.start()
+
+        res = server.make_request("POST", "/completion", data={
+            "prompt": "Say hello",
+            "n_predict": 5,
+            "stream": False,
+        })
+        assert res.status_code == 200
+
+        server.stop()
+
+        records = read_trace_records(trace_dir)
+        req_records  = [r for r in records if r["type"] == "request"]
+        resp_records = [r for r in records if r["type"] == "response"]
+
+        assert len(req_records)  >= 1
+        assert len(resp_records) >= 1
+
+        # Find the /completion pair
+        completion_reqs = [r for r in req_records if r["path"] == "/completion"]
+        assert len(completion_reqs) == 1
+        req = completion_reqs[0]
+
+        # Verify request record fields
+        assert "request_id"  in req
+        assert "timestamp"   in req
+        assert req["method"] == "POST"
+        assert req["path"]   == "/completion"
+        assert "body_size"   in req
+        assert "body_hash"   in req
+        assert req["body_size"] > 0
+        assert "body_excerpt" in req
+
+        req_id = req["request_id"]
+        paired = [r for r in resp_records if r["request_id"] == req_id]
+        assert len(paired) == 1, "Response record must share request_id with request record"
+        resp = paired[0]
+
+        # Verify response record fields
+        assert resp["status"]      == 200
+        assert resp["duration_ms"] >= 0
+        assert "body_hash"         in resp
+        assert "body_size"         in resp
+        assert resp["body_size"]   > 0
+        assert "body_excerpt"      in resp
+
+        # Streaming records must NOT appear for this request
+        for r in records_for(req_id, records):
+            assert r["type"] not in ("stream_start", "chunk", "stream_end"), \
+                "Non-streaming request should not produce stream records"
+
+
+def test_trace_streaming():
+    """Streaming request produces request + stream_start + chunk(s) + stream_end."""
+    global server
+    with tempfile.TemporaryDirectory() as trace_dir:
+        server.http_trace_dir = trace_dir
+        server.start()
+
+        res = server.make_request("POST", "/completion", data={
+            "prompt": "Count to five",
+            "n_predict": 10,
+            "stream": True,
+        })
+        assert res.status_code == 200
+
+        server.stop()
+
+        records = read_trace_records(trace_dir)
+
+        req_records = [r for r in records if r["type"] == "request" and r["path"] == "/completion"]
+        assert len(req_records) == 1
+        req_id = req_records[0]["request_id"]
+
+        by_type = {r["type"]: r for r in records_for(req_id, records)}
+        all_types = [r["type"] for r in records_for(req_id, records)]
+
+        assert "request"      in by_type, "Missing request record"
+        assert "stream_start" in by_type, "Missing stream_start record"
+        assert "stream_end"   in by_type, "Missing stream_end record"
+        assert "chunk"        in all_types, "Missing at least one chunk record"
+
+        # "response" must NOT appear for a streaming request
+        assert "response" not in by_type, "Streaming request should not produce a response record"
+
+        # Chunks must have monotonically increasing seq numbers
+        chunks = sorted(
+            [r for r in records_for(req_id, records) if r["type"] == "chunk"],
+            key=lambda r: r["seq"],
+        )
+        for i, chunk in enumerate(chunks):
+            assert chunk["seq"]        == i
+            assert chunk["chunk_size"]  > 0
+
+        # stream_end totals must be consistent
+        end = by_type["stream_end"]
+        assert end["total_chunks"] == len(chunks)
+        assert end["total_bytes"]  == sum(c["chunk_size"] for c in chunks)
+        assert end["duration_ms"]  >= 0
+
+        # stream_start must appear before the first chunk in the file
+        stream_start_idx = next(i for i, r in enumerate(records) if r.get("request_id") == req_id and r["type"] == "stream_start")
+        first_chunk_idx  = next(i for i, r in enumerate(records) if r.get("request_id") == req_id and r["type"] == "chunk")
+        assert stream_start_idx < first_chunk_idx
+
+
+def test_trace_request_ids_are_unique():
+    """Each request must receive a distinct request_id."""
+    global server
+    with tempfile.TemporaryDirectory() as trace_dir:
+        server.http_trace_dir = trace_dir
+        server.start()
+
+        n = 5
+        for _ in range(n):
+            res = server.make_request("POST", "/completion", data={
+                "prompt": "Hi",
+                "n_predict": 3,
+                "stream": False,
+            })
+            assert res.status_code == 200
+
+        server.stop()
+
+        records = read_trace_records(trace_dir)
+        req_ids = [r["request_id"] for r in records if r["type"] == "request" and r["path"] == "/completion"]
+        assert len(req_ids) == n
+        assert len(set(req_ids)) == n, "Request IDs must be unique across requests"
+
+
+def test_trace_error_response():
+    """A malformed request still produces a request record followed by a response record."""
+    global server
+    with tempfile.TemporaryDirectory() as trace_dir:
+        server.http_trace_dir = trace_dir
+        server.start()
+
+        # Send invalid JSON to trigger a 400 error
+        res = server.make_request("POST", "/completion", data="not-json",
+                                  headers={"Content-Type": "application/json"})
+        assert res.status_code >= 400
+
+        server.stop()
+
+        records = read_trace_records(trace_dir)
+        error_reqs = [r for r in records if r["type"] == "request" and r["path"] == "/completion"]
+        assert len(error_reqs) >= 1, "Request record must be written even for failed requests"
+
+        req_id = error_reqs[0]["request_id"]
+        resp_records = [r for r in records_for(req_id, records) if r["type"] == "response"]
+        assert len(resp_records) == 1
+        assert resp_records[0]["status"] >= 400
+
+
+def test_trace_disabled_by_default():
+    """Without --http-trace-dir no trace files are produced."""
+    global server
+    # server.http_trace_dir is None — flag is not passed
+    with tempfile.TemporaryDirectory() as trace_dir:
+        # Start server normally (no trace flag)
+        server.start()
+
+        server.make_request("POST", "/completion", data={
+            "prompt": "Hello",
+            "n_predict": 3,
+        })
+
+        server.stop()
+
+        # Nothing should be written to trace_dir since we never passed the flag
+        files = [f for f in os.listdir(trace_dir) if f.startswith("trace-")]
+        assert len(files) == 0, "Trace files must not be created when flag is absent"
+
+
+def test_trace_headers_redaction():
+    """Authorization header value must be redacted in the request record."""
+    global server
+    with tempfile.TemporaryDirectory() as trace_dir:
+        server.http_trace_dir = trace_dir
+        server.api_key = "supersecretkey"
+        server.start()
+
+        res = server.make_request("POST", "/completion",
+                                  data={"prompt": "Hi", "n_predict": 3, "stream": False},
+                                  headers={"Authorization": "Bearer supersecretkey"})
+        assert res.status_code == 200
+
+        server.stop()
+
+        records = read_trace_records(trace_dir)
+        req = next(r for r in records if r["type"] == "request" and r["path"] == "/completion")
+
+        auth = req.get("headers", {}).get("authorization", "")
+        assert "supersecretkey" not in auth, "Raw API key must not appear in trace logs"
+        assert auth == "[REDACTED]"

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -70,6 +70,7 @@ class ServerProcess:
     n_predict: int | None = None
     n_prompts: int | None = 0
     slot_save_path: str | None = None
+    http_trace_dir: str | None = None
     id_slot: int | None = None
     cache_prompt: bool | None = None
     n_slots: int | None = None
@@ -198,6 +199,8 @@ class ServerProcess:
             server_args.extend(["--n-predict", self.n_predict])
         if self.slot_save_path:
             server_args.extend(["--slot-save-path", self.slot_save_path])
+        if self.http_trace_dir:
+            server_args.extend(["--http-trace-dir", self.http_trace_dir])
         if self.n_ga:
             server_args.extend(["--grp-attn-n", self.n_ga])
         if self.n_ga_w:


### PR DESCRIPTION
Fixes #21356

Adds `--http-trace-dir <path>` to llama-server. When set, every HTTP request and response is written as structured JSONL records to a rotating daily file: `<dir>/trace-YYYYMMDD.jsonl`

Record types:
- "request"      emitted before the handler runs (always logged)
- "stream_start" emitted when the response is identified as streaming
- "chunk"        emitted per non-empty SSE chunk (seq is dense)
- "stream_end"   emitted at stream close with total_chunks/bytes/ms
- "response"     emitted for completed non-streaming responses

Design notes:
- Hook is in `server_http_context::get()/post()`, covering all routes
- Zero overhead when disabled (single null-pointer check per request)
- FNV-1a 64-bit hash for body fingerprinting (no extra dependencies)
- Authorization/X-Api-Key header values are redacted
- Mutex-protected append writes with `flush()` per line
- File rotates daily; append mode survives server restarts

Includes pytest tests (6 cases) and README documentation.

## Overview

Adds optional structured HTTP trace logging to llama-server, useful for debugging API compatibility and streaming issues without needing an external proxy. Addresses #21356.

When `--http-trace-dir /path/to/logs` is set, each request produces a sequence of JSONL records keyed by a unique `request_id`. For non-streaming requests this is a request + response pair; for streaming it is request → stream_start → chunk... → stream_end. The request record is always written before the handler runs, so it is preserved even if the handler returns an error.

The feature is entirely opt-in. No allocations or file I/O occur when the flag is absent.

## Additional information

Example output for a streaming chat completion:                               
  ```
  {"type":"request","request_id":"0195e4d9b0a0-00000000","timestamp":"2024-04-03
  T10:30:45.123Z","method":"POST","path":"/v1/chat/completions","headers":{"cont
  ent-type":"application/json","authorization":"[REDACTED]"},"body_size":78,"bod
  y_hash":"0xa3f1c2d4e5b6a789","body_excerpt":"{\"model\":\"...\",\"messages\":[
  ...],\"stream\":true}"}
  {"type":"stream_start","request_id":"0195e4d9b0a0-00000000","timestamp":"2024-
  04-03T10:30:45.130Z"}                                                         
  {"type":"chunk","request_id":"0195e4d9b0a0-00000000","timestamp":"2024-04-03T1
  0:30:45.234Z","seq":0,"chunk_size":87}                                        
  {"type":"chunk","request_id":"0195e4d9b0a0-00000000","timestamp":"2024-04-03T1
  0:30:45.267Z","seq":1,"chunk_size":52}                                        
  {"type":"stream_end","request_id":"0195e4d9b0a0-00000000","timestamp":"2024-04
  -03T10:30:45.891Z","total_chunks":18,"total_bytes":1432,"duration_ms":768} 
```
# Requirements


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used Claude to accelerate code understanding,
  write comments, and for code autocomplete. All code was written and reviewed  
  by me.        
