### PR TITLE
llama-model: read final_logit_softcapping for Gemma 4

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1279,6 +1279,7 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 ml.get_key(LLM_KV_EMBEDDING_LENGTH_PER_LAYER,  hparams.n_embd_per_layer);
                 ml.get_key(LLM_KV_ATTENTION_KEY_LENGTH_SWA,    hparams.n_embd_head_k_swa);
                 ml.get_key(LLM_KV_ATTENTION_VALUE_LENGTH_SWA,  hparams.n_embd_head_v_swa);
+                ml.get_key(LLM_KV_FINAL_LOGIT_SOFTCAPPING,     hparams.f_final_logit_softcapping, false);
 
                 switch (hparams.n_layer) {
                     case 35: type = LLM_TYPE_E2B; break;


### PR DESCRIPTION
The `LLM_ARCH_GEMMA4` block in `llama-model.cpp` was never reading `final_logit_softcapping` from the GGUF, so the value was always stuck at the hardcoded default of `30.0f`. This meant editing the GGUF key or using `--override-kv gemma4.final_logit_softcapping=float:X` had no effect on inference.

Adding the missing `ml.get_key` call (optional, so older GGUFs without the key fall back gracefully to `30.0f`) is all that's needed, the softcapping logic in `gemma4-iswa.cpp` is already correct.

Fix for the issue #21388.