### PR TITLE
[SYCL] Add BF16 support to GET_ROWS operation

### DIFF
--- a/ggml/src/ggml-sycl/getrows.cpp
+++ b/ggml/src/ggml-sycl/getrows.cpp
@@ -183,6 +183,10 @@ void ggml_sycl_op_get_rows(ggml_backend_sycl_context & ctx, ggml_tensor * dst) {
             get_rows_sycl_float(ctx, dst->src[0], dst->src[1], dst, (const sycl::half *)dst->src[0]->data,
                                 src1_i32, (float *)dst->data, ctx.stream());
             break;
+        case GGML_TYPE_BF16:
+            get_rows_sycl_float(ctx, dst->src[0], dst->src[1], dst, (const sycl::ext::oneapi::bfloat16 *)dst->src[0]->data,
+                                src1_i32, (float *)dst->data, ctx.stream());
+            break;
         case GGML_TYPE_F32:
             get_rows_sycl_float(ctx, dst->src[0], dst->src[1], dst, (const float *)dst->src[0]->data,
             src1_i32, (float *)dst->data, ctx.stream());

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4695,6 +4695,7 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
             {
                 switch (op->src[0]->type) {
                     case GGML_TYPE_F16:
+                    case GGML_TYPE_BF16:
                     case GGML_TYPE_F32:
                     case GGML_TYPE_Q4_0:
                     case GGML_TYPE_Q4_1:


### PR DESCRIPTION
## Summary

Add `GGML_TYPE_BF16` support to the SYCL backend's `GET_ROWS` operation. Currently `GET_ROWS` supports F16, F32, and several quantized types but **not BF16**, causing models with BF16 tensors to fall back to CPU for this operation — triggering catastrophic performance degradation due to full GPU→CPU tensor transfers on every token.

> **Disclosure:** This PR was authored with the assistance of AI (GitHub Copilot / Claude). The bug was discovered through systematic debug log analysis of real-world performance issues.

## Problem

The SYCL backend's `ggml_backend_sycl_device_supports_op()` does not list `GGML_TYPE_BF16` in the `GGML_OP_GET_ROWS` switch. When a model has BF16 tensors that require `GET_ROWS`, the scheduler falls back to CPU, which requires downloading the **entire tensor** from GPU to CPU via PCIe every single token.

### Real-World Impact: Gemma4 on Intel Arc GPUs

Gemma4 models (e.g., `gemma4:12b-it-qat-q4_0`) use a unique **per-layer embedding** tensor (`per_layer_token_embd.weight`) stored as BF16 with shape `[8960, 262144]` = **4.4 GiB**. This tensor lives on the GPU but requires `GET_ROWS` for token embedding lookup.

Because SYCL's `GET_ROWS` doesn't support BF16:
1. The entire 4.4 GiB tensor is downloaded GPU→CPU via PCIe **every single token**
2. CPU performs the trivial row lookup (extracts a single 35 KB row)
3. The 35 KB result is uploaded back to GPU

This results in **~2 tok/s** instead of the expected **~15-30+ tok/s** — the PCIe transfer alone takes ~440-550ms at ~8-10 GB/s effective bandwidth.

### Evidence from Debug Logs (`GGML_SYCL_DEBUG=1`)

**Compute graph showing the forced CPU split:**
```
compute graph: nodes=1578, splits=4
  SYCL0: 316.5 MiB   (all attention/FFN layers - fast)
  CPU:   4.4 GiB     (per_layer_token_embd.weight GET_ROWS - slow!)
```

**Per-token GPU→CPU transfer observed:**
```
[SYCL] ggml_backend_sycl_buffer_get_tensor:
  tensor='per_layer_token_embd.weight' type=bf16
  ne=[8960, 262144, 1, 1]  size=4697620480  ← 4.4 GiB downloaded EVERY token
```

**Token timing confirming PCIe bottleneck:**
```
Average: ~505ms/token ≈ 1.98 tok/s
(matches expected ~440-550ms for 4.4 GiB PCIe transfer)
```

## The Oversight

Notably, `SET_ROWS` already supports BF16 (added in #14883), but `GET_ROWS` was not updated at the same time:

```cpp
// SET_ROWS - BF16 IS supported ✓
case GGML_OP_SET_ROWS:
    return ((op->type == GGML_TYPE_F32 || op->type == GGML_TYPE_F16 ||
             op->type == GGML_TYPE_BF16 || ...));

// GET_ROWS - BF16 is MISSING ✗ (before this PR)
case GGML_OP_GET_ROWS:
    switch (op->src[0]->type) {
        case GGML_TYPE_F16:
        // case GGML_TYPE_BF16:  ← MISSING
        case GGML_TYPE_F32:
        ...
    }
```

BF16-to-F32 conversion support was also added in #17780 (for `ggml_get_to_fp32_sycl` etc.), confirming the SYCL backend can already handle BF16 data — it's just the `GET_ROWS` op declaration and dispatch that were missed.

## Fix

Two minimal changes:

1. **`ggml-sycl.cpp`** — Add `GGML_TYPE_BF16` to the `GET_ROWS` case in `ggml_backend_sycl_device_supports_op()`
2. **`getrows.cpp`** — Add `GGML_TYPE_BF16` dispatch case in `ggml_sycl_op_get_rows()`, using `sycl::ext::oneapi::bfloat16` with the existing `get_rows_sycl_float` template (same pattern used for `sycl::half`/F16)

The `get_rows_sycl_float<src0_t>` template already handles the conversion generically — the kernel does `dst_row[i00] = src0_row[i00]` where `src0_t` → `float` conversion is implicit for both `sycl::half` and `sycl::ext::oneapi::bfloat16`.

## Related Issues & PRs

- #14883 — Added BF16 to `SET_ROWS` `supports_op` (but not `GET_ROWS` — origin of the oversight)
- #17780 — Added BF16 conversion support (`ggml_get_to_fp32_sycl`, `ggml_get_to_fp16_sycl`)
- #19247 — BF16 CPU segfault fix (tangentially related)
- #18808 — Reports slow performance on same hardware (Intel Arc Pro B50) — may be partially explained by this bug

## Testing

- Hardware: Intel Arc Pro B50 (Battlemage), 15.1 GiB VRAM
- Model: Gemma4 12B Q4_K_M (uses BF16 `per_layer_token_embd.weight`)
- Build: `intel/oneapi-basekit:2025.1.1-0-devel-ubuntu24.04` via Docker (sycl-ollama)
- Before fix: ~2 tok/s (4.4 GiB PCIe transfer per token)
- Expected after fix: ~15-30+ tok/s (all ops on GPU, no PCIe bottleneck)

Note: I have not been able to compile-test this change on a SYCL-capable machine locally (requires Intel oneAPI SDK). The change is minimal and follows the exact same pattern as the existing F16 support path. CI validation with a SYCL build would be appreciated.