### PR TITLE
fix tensor stride for quantized types in create_tensor

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1195,8 +1195,11 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         for (size_t dim = 0; dim < GGML_MAX_DIMS; dim++) {
             t_meta.ne[dim] = dim < ne.size() ? ne.begin()[dim] : 1;
             GGML_ASSERT(t_meta.ne[dim] >= 1);
-            t_meta.nb[dim] = dim == 0 ? ggml_type_size(type) : t_meta.ne[dim-1]*t_meta.nb[dim-1];
-            GGML_ASSERT(t_meta.nb[dim] >= 1);
+        }
+        t_meta.nb[0] = ggml_type_size(type);
+        t_meta.nb[1] = t_meta.nb[0] * (t_meta.ne[0] / ggml_blck_size(type));
+        for (size_t dim = 2; dim < GGML_MAX_DIMS; dim++) {
+            t_meta.nb[dim] = t_meta.nb[dim-1] * t_meta.ne[dim-1];
         }
         ggml_set_name(&t_meta, tn.str().c_str());
 


### PR DESCRIPTION
## Overview

nb[1] was missing division by `ggml_blck_size` causing wrong strides for quantized types..

When I ran on 32 bit system, it overflows and cause Vulkan to reject all MUL_MAT operations and fall backs to CPU.

Tested on Samsung Galaxy Watch 4 Classic

## Additional information
Current Code Bug Screenshots:
<img width="1431" height="561" alt="Screenshot 2026-04-03 at 9 04 40 AM" src="https://github.com/user-attachments/assets/274cc484-9a84-4b14-9bb2-c794ea2935cc" />
<img width="1433" height="705" alt="Screenshot 2026-04-03 at 7 26 35 AM" src="https://github.com/user-attachments/assets/05b9c72b-24ea-4f18-a389-1964b41a181e" />

After Fix Screenshots:
<img width="1106" height="507" alt="Screenshot 2026-04-03 at 7 27 38 AM" src="https://github.com/user-attachments/assets/60d46ece-3940-4288-a67c-68a14f51dd3b" />

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, used for log analysis and debugging. Changes, testing and Verification were done manually