### PR TITLE
cmake: add flag to use system httplib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ else()
 endif()
 
 option(LLAMA_USE_SYSTEM_GGML "Use system libggml" OFF)
+option(LLAMA_USE_SYSTEM_HTTPLIB "Use system cpp-httplib" OFF)
 
 option(LLAMA_WASM_MEM64 "llama: use 64-bit memory in WASM builds" ON)
 
@@ -198,7 +199,13 @@ add_subdirectory(src)
 
 if (LLAMA_BUILD_COMMON)
     add_subdirectory(common)
-    add_subdirectory(vendor/cpp-httplib)
+
+    if (LLAMA_USE_SYSTEM_HTTPLIB)
+        find_package(httplib REQUIRED)
+        add_library(cpp-httplib ALIAS httplib::httplib)
+    else()
+        add_subdirectory(vendor/cpp-httplib)
+    endif()
 endif()
 
 if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ else()
 endif()
 
 option(LLAMA_USE_SYSTEM_GGML "Use system libggml" OFF)
+option(LLAMA_USE_SYSTEM_HTTPLIB "Use system cpp-httplib" OFF)
 
 option(LLAMA_WASM_MEM64 "llama: use 64-bit memory in WASM builds" ON)
 
@@ -228,6 +229,11 @@ add_subdirectory(vendor)
 
 if (LLAMA_BUILD_COMMON)
     add_subdirectory(common)
+
+    if (LLAMA_USE_SYSTEM_HTTPLIB)
+        find_package(httplib REQUIRED)
+        add_library(cpp-httplib ALIAS httplib::httplib)
+    endif()
 endif()
 
 if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -6,6 +6,6 @@ add_subdirectory(sheredom)
 add_subdirectory(stb)
 
 # only used by common
-if (LLAMA_BUILD_COMMON)
+if (LLAMA_BUILD_COMMON AND NOT LLAMA_USE_SYSTEM_HTTPLIB)
     add_subdirectory(cpp-httplib)
 endif()


### PR DESCRIPTION
## Overview

Allow building using the system cpp-httplib. The default behaviour remains the same.

## Additional information

Downstream distributions prefer to use a single copy of libraries like this one, instead of rebuilding it for each project.

# Requirements


- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure.


