### PR TITLE
fix(openvino): explicit ov::Tensor frees in ggml_backend_openvino_free

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -598,6 +598,15 @@ bool ggml_backend_buft_is_openvino_host(ggml_backend_buffer_type_t buft) {
 
 static void ggml_backend_openvino_free(ggml_backend_t backend) {
     ggml_backend_openvino_context * ctx = (ggml_backend_openvino_context *) backend->context;
+
+    if (ctx->runtime_context) {
+        auto r_ctx = std::static_pointer_cast<ov_runtime_context>(ctx->runtime_context);
+        r_ctx->backend_count--;
+        if (r_ctx->backend_count == 0) {
+            r_ctx->clear_caches();
+        }
+    }
+
     delete ctx;
     delete backend;
 }
@@ -667,6 +676,7 @@ GGML_BACKEND_API ggml_backend_t ggml_backend_openvino_init(int device) {
     std::shared_ptr<ov_runtime_context> r_ctx = std::static_pointer_cast<ov_runtime_context>(ctx->runtime_context);
     r_ctx->device = ggml_openvino_get_device_name();
     r_ctx->stateful = getenv("GGML_OPENVINO_STATEFUL_EXECUTION") && !ggml_openvino_is_npu();
+    r_ctx->backend_count++;
 
     ggml_backend_t openvino_backend = new ggml_backend{
         /* .guid      = */ ggml_backend_openvino_guid(),

--- a/ggml/src/ggml-openvino/utils.h
+++ b/ggml/src/ggml-openvino/utils.h
@@ -53,11 +53,21 @@ struct ov_runtime_context {
     //      Simultanous stateful inference request support to be added.
     size_t stateful_kv_size;
     std::map<std::string, std::string> kv_state_input_name_map;
+    int backend_count;
 
     ov_runtime_context() :
         device("CPU"),
         stateful(false),
-        stateful_kv_size(0) {}
+        stateful_kv_size(0),
+        backend_count(0) {}
+
+    void clear_caches() {
+        decoder_cache.clear();
+        infer_request_cache.clear();
+        infer_request_cache_prefill.clear();
+        ov_input_names_cache.clear();
+        ov_output_names_cache.clear();
+    }
 };
 
 enum ggml_status ov_graph_compute(struct ggml_cgraph * cgraph, ggml_backend_t backend);


### PR DESCRIPTION
## Overview

The following throws a segmentation fault on exit.

```
export GGML_OPENVINO_DEVICE=NPU
./bin/llama-cli -m Llama-3.2-1B-Instruct-Q4_0.gguf -ngl 99 -np 1 -c 512 --simple-io --single-turn -n 1 -p hi
```

Root-caused to a use-after-free involving OpenVINO's `ZeroMemPool`. Goes like this
1. `ZeroMemPool::allocate_zero_memory()` returns `std::shared_ptr<ZeroMem>`
2. `std::shared_ptr<ZeroMem>` has a custom destructor method of the form `[this](ZeroMem *ptr) { delete_pool_entry(ptr); }` (where `delete_pool_entry` is a non-static member function of `ZeroMemPool`)
3. `this` is invalid by the time the destructor runs because RAII does not clean up `std::shared_ptr<ZeroMem>` consistently

This is downstream of `std::shared_ptr<void>` being used for `runtime_context` not propagating the destructor call to class members.

Went ahead and defined a `clear_caches` method that does this destruction explicitly (but not using `std::shared_ptr<void>` seems like a better approach considering the failure mode here, will leave that to the maintainers unless they suggest I change that here).

## Additional information

This PR (and all other PRs I'll file in this space) use a recent from-source build of OpenVINO. I do work at Intel but not on the team owning this.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I threw an AI at this, but I have a solid understanding of the mechanics at play and the fix is targeted enough to not cause collateral issues.