### PR TITLE
model: add Zamba2 architecture support

### DIFF
--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -253,6 +253,7 @@ TEXT_MODEL_MAP: dict[str, str] = {
     "XLMRobertaModel": "bert",
     "XverseForCausalLM": "xverse",
     "YoutuForCausalLM": "deepseek",
+    "Zamba2ForCausalLM": "zamba2",
     "YoutuVLForConditionalGeneration": "deepseek",
     "modeling_grove_moe.GroveMoeForCausalLM": "grovemoe",
     "modeling_sarvam_moe.SarvamMoEForCausalLM": "bailingmoe",

--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -275,6 +275,7 @@ TEXT_MODEL_MAP: dict[str, str] = {
     "XLMRobertaModel": "bert",
     "XverseForCausalLM": "xverse",
     "YoutuForCausalLM": "deepseek",
+    "Zamba2ForCausalLM": "zamba2",
     "YoutuVLForConditionalGeneration": "deepseek",
     "modeling_grove_moe.GroveMoeForCausalLM": "grovemoe",
     "modeling_sarvam_moe.SarvamMoEForCausalLM": "bailingmoe",

--- a/conversion/mamba.py
+++ b/conversion/mamba.py
@@ -116,7 +116,7 @@ class Mamba2Model(TextModel):
         self.d_model = self.find_hparam(["hidden_size", "d_model", "dim"])
         self.expand = self.find_hparam(["mamba_expand", "expand"], optional=True) or 2
         self.d_inner = self.find_hparam(["mamba_d_ssm", "intermediate_size", "d_inner"], optional=True) or self.expand * self.d_model
-        self.n_group = self.find_hparam(["n_groups"], optional=True) or 1
+        self.n_group = self.find_hparam(["n_groups", "mamba_ngroups"], optional=True) or 1
 
     def set_vocab(self):
         vocab_size = self.hparams["vocab_size"]

--- a/conversion/mamba.py
+++ b/conversion/mamba.py
@@ -118,7 +118,7 @@ class Mamba2Model(TextModel):
         self.d_model = self.find_hparam(["hidden_size", "d_model", "dim"])
         self.expand = self.find_hparam(["mamba_expand", "expand"], optional=True) or 2
         self.d_inner = self.find_hparam(["mamba_d_ssm", "intermediate_size", "d_inner"], optional=True) or self.expand * self.d_model
-        self.n_group = self.find_hparam(["n_groups"], optional=True) or 1
+        self.n_group = self.find_hparam(["n_groups", "mamba_ngroups"], optional=True) or 1
 
     def set_vocab(self):
         vocab_size = self.hparams["vocab_size"]

--- a/conversion/zamba2.py
+++ b/conversion/zamba2.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import re
+
+from typing import Iterable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+from .base import ModelBase, gguf
+from .mamba import Mamba2Model
+
+
+@ModelBase.register("Zamba2ForCausalLM")
+class Zamba2Model(Mamba2Model):
+    model_arch = gguf.MODEL_ARCH.ZAMBA2
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Zamba2's SSM d_inner is mamba_expand * hidden_size (intermediate_size is the FFN dim)
+        mamba_expand = self.find_hparam(["mamba_expand"], optional=True) or 2
+        self.d_inner = int(mamba_expand * self.d_model)
+
+        # Layer classification from config
+        block_types = self.hparams.get("layers_block_type", [])
+        self._hybrid_layers: list[int] = [
+            i for i, t in enumerate(block_types) if t == "hybrid"
+        ]
+        self._num_mem_blocks: int = self.hparams.get("num_mem_blocks", 1)
+
+        # Map shared block index -> list of hybrid layer indices that use it.
+        # Hybrid visit N uses shared block (N % num_mem_blocks).
+        self._shared_block_layers: dict[int, list[int]] = {}
+        for visit_idx, layer_idx in enumerate(self._hybrid_layers):
+            block_idx = visit_idx % self._num_mem_blocks
+            self._shared_block_layers.setdefault(block_idx, []).append(layer_idx)
+
+        # Source layers: first num_mem_blocks hybrid layers store the shared weights
+        self._shared_block_src: list[int] = self._hybrid_layers[:self._num_mem_blocks]
+
+        # Pre-load per-layer adapter weights for merging into shared transformer
+        # weights. Zamba2 has rank-128 LoRA-style adapters that are integral to
+        # the architecture (not optional fine-tuning). Each adapter is a
+        # Sequential(Linear(in, 128), Linear(128, out)), stored as:
+        #   adapter_list.{visit_idx}.0.weight  (down projection)
+        #   adapter_list.{visit_idx}.1.weight  (up projection)
+        # The merged weight = shared_weight + up @ down
+        self._adapter_cache: dict[str, Tensor] = {}
+        self._use_attn_adapters = self.hparams.get("use_shared_attention_adapter", False)
+        self._use_mlp_adapters = self.hparams.get("use_shared_mlp_adapter", True)
+
+        adapter_pattern = re.compile(
+            r"model\.layers\.(\d+)\.shared_transformer\."
+            r"(?:self_attn\.(linear_[qkv]_adapter_list)|feed_forward\.(gate_up_proj_adapter_list))"
+            r"\.(\d+)\.([01])\.weight"
+        )
+        for tname in list(self.model_tensors.keys()):
+            m = adapter_pattern.match(tname)
+            if m:
+                layer_idx = int(m.group(1))
+                adapter_type = m.group(2) or m.group(3)
+                visit_idx = int(m.group(4))
+                seq_idx = int(m.group(5))  # 0=down, 1=up
+                # Only cache from source layers (avoid duplicates from weight ties)
+                if layer_idx in self._shared_block_src:
+                    key = f"{layer_idx}.{adapter_type}.{visit_idx}.{seq_idx}"
+                    self._adapter_cache[key] = self.model_tensors[tname]()
+
+    def _get_adapter_contribution(self, src_layer: int, adapter_type: str, visit_idx: int) -> Tensor | None:
+        """Compute up @ down for a given adapter, returning the additive correction."""
+        down_key = f"{src_layer}.{adapter_type}.{visit_idx}.0"
+        up_key = f"{src_layer}.{adapter_type}.{visit_idx}.1"
+        down = self._adapter_cache.get(down_key)
+        up = self._adapter_cache.get(up_key)
+        if down is None or up is None:
+            return None
+        # Merge in float32 for precision, result will be cast by caller
+        return (up.float() @ down.float())
+
+    def set_vocab(self):
+        # Zamba2 uses LlamaTokenizer (sentencepiece); tokenizer.json may be the
+        # only file present (no tokenizer.model).  Follow JambaModel's pattern.
+        if (self.dir_model / "tokenizer.model").is_file():
+            self._set_vocab_sentencepiece()
+        elif (self.dir_model / "tokenizer.json").is_file():
+            self._set_vocab_llama_hf()
+        else:
+            self._set_vocab_builtin("gpt-neox", self.hparams["vocab_size"])
+
+    def set_gguf_parameters(self):
+        hparams = self.hparams
+        n_head = hparams["num_attention_heads"]
+        n_kv   = hparams.get("num_key_value_heads", n_head)
+        block_types = hparams.get("layers_block_type", [])
+
+        # Per-layer KV head count: 0 for mamba-only, n_kv for hybrid
+        n_kv_vec = [n_kv if t == "hybrid" else 0 for t in block_types]
+
+        head_dim = hparams.get("attention_head_dim",
+                               hparams.get("attention_hidden_size", 2 * self.d_model) // n_head)
+
+        self.gguf_writer.add_block_count(self.block_count)
+        self.gguf_writer.add_embedding_length(self.d_model)
+        self.gguf_writer.add_head_count(n_head)
+        self.gguf_writer.add_head_count_kv(n_kv_vec)
+        self.gguf_writer.add_key_length(head_dim)
+        self.gguf_writer.add_value_length(head_dim)
+        self.gguf_writer.add_feed_forward_length(
+            hparams.get("ffn_hidden_size", hparams.get("intermediate_size")))
+        self.gguf_writer.add_layer_norm_rms_eps(hparams.get("rms_norm_eps", 1e-5))
+        self.gguf_writer.add_context_length(hparams.get("max_position_embeddings", 4096))
+        self.gguf_writer.add_vocab_size(hparams["vocab_size"])
+
+        # RoPE (only when use_mem_rope is enabled)
+        if hparams.get("use_mem_rope", False):
+            self.gguf_writer.add_rope_dimension_count(head_dim)
+            self.gguf_writer.add_rope_freq_base(hparams.get("rope_theta", 10000.0))
+        else:
+            self.gguf_writer.add_rope_dimension_count(0)
+
+        # Mamba-2 SSM parameters
+        d_conv  = hparams.get("mamba_d_conv", 4)
+        d_state = hparams.get("mamba_d_state", 64)
+        headdim = hparams.get("mamba_headdim", 64)
+        n_heads = self.d_inner // headdim
+
+        self.gguf_writer.add_ssm_conv_kernel(d_conv)
+        self.gguf_writer.add_ssm_inner_size(self.d_inner)
+        self.gguf_writer.add_ssm_state_size(d_state)
+        self.gguf_writer.add_ssm_time_step_rank(n_heads)
+        self.gguf_writer.add_ssm_group_count(self.n_group)
+
+        self.gguf_writer.add_file_type(self.ftype)
+
+    # Map from shared weight tail names to their adapter type names
+    _ADAPTER_MAP: dict[str, str] = {
+        "self_attn.q_proj.weight": "linear_q_adapter_list",
+        "self_attn.k_proj.weight": "linear_k_adapter_list",
+        "self_attn.v_proj.weight": "linear_v_adapter_list",
+        "feed_forward.gate_up_proj.weight": "gate_up_proj_adapter_list",
+    }
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # Skip adapter weights — they are pre-merged into shared weights below
+        if "adapter" in name.lower():
+            return
+
+        # Shared transformer tensors: duplicate to all hybrid layers using this block,
+        # merging per-layer adapter corrections where applicable.
+        if "shared_transformer" in name:
+            if bid is None or bid not in self._shared_block_src:
+                return
+            block_idx = self._shared_block_src.index(bid)
+            target_layers = self._shared_block_layers[block_idx]
+
+            # Strip the shared_transformer prefix so names match the standard HF layout
+            tail = name.partition("shared_transformer.")[2]
+
+            # input_layernorm sits before the attention-on-concat block, so it maps
+            # to ATTN_POST_NORM rather than the default ATTN_NORM.  Handle explicitly.
+            if tail == "input_layernorm.weight":
+                for target_bid in target_layers:
+                    yield (self.format_tensor_name(gguf.MODEL_TENSOR.ATTN_POST_NORM, target_bid), data_torch)
+                return
+
+            # Check if this weight has a corresponding adapter type
+            adapter_type = self._ADAPTER_MAP.get(tail)
+            use_adapter = False
+            if adapter_type:
+                if adapter_type.startswith("linear_") and self._use_attn_adapters:
+                    use_adapter = True
+                elif adapter_type == "gate_up_proj_adapter_list" and self._use_mlp_adapters:
+                    use_adapter = True
+
+            # Delegate to the parent's tensor-name mapping, once per target layer.
+            for visit_local, target_bid in enumerate(target_layers):
+                # Compute the global visit index for this target layer
+                global_visit = self._hybrid_layers.index(target_bid)
+
+                if use_adapter and adapter_type is not None:
+                    correction = self._get_adapter_contribution(bid, adapter_type, global_visit)
+                    if correction is not None:
+                        # Merge: per-layer weight = shared + adapter_up @ adapter_down
+                        merged = data_torch.float() + correction
+                        layer_data = merged.to(data_torch.dtype)
+                    else:
+                        layer_data = data_torch
+                else:
+                    layer_data = data_torch
+
+                rewritten = f"model.layers.{target_bid}.{tail}"
+                yield from super().modify_tensors(layer_data, rewritten, target_bid)
+            return
+
+        # Linear mixing weight (hybrid layers)
+        if name.endswith(".linear.weight"):
+            if bid is not None:
+                yield (self.format_tensor_name(gguf.MODEL_TENSOR.SSM_MIX, bid), data_torch)
+            return
+
+        # Mamba/SSM tensors: strip mamba_decoder prefix then delegate to parent
+        # Parent handles: dt_bias rename, map_tensor_name, conv1d squeeze,
+        #   A_log -> -exp, A/D reshape, NORM reshape
+        if ".mamba_decoder." in name:
+            name = name.replace(".mamba_decoder.", ".")
+
+        yield from super().modify_tensors(data_torch, name, bid)

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -481,6 +481,7 @@ class MODEL_ARCH(IntEnum):
     MAMBA            = auto()
     MAMBA2           = auto()
     JAMBA            = auto()
+    ZAMBA2           = auto()
     XVERSE           = auto()
     COMMAND_R        = auto()
     COHERE2          = auto()
@@ -671,6 +672,7 @@ class MODEL_TENSOR(IntEnum):
     SSM_BETA             = auto() # Kimi Linear qwen3.5
     SSM_G_A              = auto() # Kimi Linear
     SSM_G_B              = auto() # Kimi Linear
+    SSM_MIX              = auto() # zamba2
     TIME_MIX_W0          = auto()
     TIME_MIX_W1          = auto()
     TIME_MIX_W2          = auto()
@@ -1092,6 +1094,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.MAMBA:            "mamba",
     MODEL_ARCH.MAMBA2:           "mamba2",
     MODEL_ARCH.JAMBA:            "jamba",
+    MODEL_ARCH.ZAMBA2:           "zamba2",
     MODEL_ARCH.XVERSE:           "xverse",
     MODEL_ARCH.COMMAND_R:        "command-r",
     MODEL_ARCH.COHERE2:          "cohere2",
@@ -1271,6 +1274,7 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.SSM_D:                     "blk.{bid}.ssm_d",
     MODEL_TENSOR.SSM_NORM:                  "blk.{bid}.ssm_norm",
     MODEL_TENSOR.SSM_OUT:                   "blk.{bid}.ssm_out",
+    MODEL_TENSOR.SSM_MIX:                   "blk.{bid}.ssm_mix",
     MODEL_TENSOR.SSM_ALPHA:                 "blk.{bid}.ssm_alpha",            # qwen3.5
     MODEL_TENSOR.SSM_BETA_ALPHA:            "blk.{bid}.ssm_ba",
     MODEL_TENSOR.SSM_CONV1D_Q:              "blk.{bid}.ssm_conv1d_q",         # Kimi Linear
@@ -2993,6 +2997,28 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_GATE_EXP,
         MODEL_TENSOR.FFN_DOWN_EXP,
         MODEL_TENSOR.FFN_UP_EXP,
+    ],
+    MODEL_ARCH.ZAMBA2: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT_NORM,
+        MODEL_TENSOR.OUTPUT,
+        MODEL_TENSOR.ATTN_NORM,
+        MODEL_TENSOR.ATTN_POST_NORM,
+        MODEL_TENSOR.ATTN_Q,
+        MODEL_TENSOR.ATTN_K,
+        MODEL_TENSOR.ATTN_V,
+        MODEL_TENSOR.ATTN_OUT,
+        MODEL_TENSOR.SSM_IN,
+        MODEL_TENSOR.SSM_CONV1D,
+        MODEL_TENSOR.SSM_DT,
+        MODEL_TENSOR.SSM_A,
+        MODEL_TENSOR.SSM_D,
+        MODEL_TENSOR.SSM_NORM,
+        MODEL_TENSOR.SSM_OUT,
+        MODEL_TENSOR.SSM_MIX,
+        MODEL_TENSOR.FFN_NORM,
+        MODEL_TENSOR.FFN_DOWN,
+        MODEL_TENSOR.FFN_UP,
     ],
     MODEL_ARCH.XVERSE: [
         MODEL_TENSOR.TOKEN_EMBD,

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -539,6 +539,7 @@ class MODEL_ARCH(IntEnum):
     MAMBA            = auto()
     MAMBA2           = auto()
     JAMBA            = auto()
+    ZAMBA2           = auto()
     XVERSE           = auto()
     COMMAND_R        = auto()
     COHERE2          = auto()
@@ -748,6 +749,7 @@ class MODEL_TENSOR(IntEnum):
     FFN_ROUTED_DOWN      = auto() # Kimi K3 (latent MoE: hidden -> latent)
     FFN_ROUTED_UP        = auto() # Kimi K3 (latent MoE: latent -> hidden)
     FFN_ROUTED_NORM      = auto() # Kimi K3 (latent MoE: norm on expert output)
+    SSM_MIX              = auto() # zamba2
     TIME_MIX_W0          = auto()
     TIME_MIX_W1          = auto()
     TIME_MIX_W2          = auto()
@@ -1287,6 +1289,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.MAMBA:            "mamba",
     MODEL_ARCH.MAMBA2:           "mamba2",
     MODEL_ARCH.JAMBA:            "jamba",
+    MODEL_ARCH.ZAMBA2:           "zamba2",
     MODEL_ARCH.XVERSE:           "xverse",
     MODEL_ARCH.COMMAND_R:        "command-r",
     MODEL_ARCH.COHERE2:          "cohere2",
@@ -1478,6 +1481,7 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
     MODEL_TENSOR.SSM_D:                     "blk.{bid}.ssm_d",
     MODEL_TENSOR.SSM_NORM:                  "blk.{bid}.ssm_norm",
     MODEL_TENSOR.SSM_OUT:                   "blk.{bid}.ssm_out",
+    MODEL_TENSOR.SSM_MIX:                   "blk.{bid}.ssm_mix",
     MODEL_TENSOR.SSM_ALPHA:                 "blk.{bid}.ssm_alpha",            # qwen3.5
     MODEL_TENSOR.SSM_BETA_ALPHA:            "blk.{bid}.ssm_ba",
     MODEL_TENSOR.SSM_CONV1D_Q:              "blk.{bid}.ssm_conv1d_q",         # Kimi Linear
@@ -3466,6 +3470,28 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_GATE_EXP,
         MODEL_TENSOR.FFN_DOWN_EXP,
         MODEL_TENSOR.FFN_UP_EXP,
+    ],
+    MODEL_ARCH.ZAMBA2: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT_NORM,
+        MODEL_TENSOR.OUTPUT,
+        MODEL_TENSOR.ATTN_NORM,
+        MODEL_TENSOR.ATTN_POST_NORM,
+        MODEL_TENSOR.ATTN_Q,
+        MODEL_TENSOR.ATTN_K,
+        MODEL_TENSOR.ATTN_V,
+        MODEL_TENSOR.ATTN_OUT,
+        MODEL_TENSOR.SSM_IN,
+        MODEL_TENSOR.SSM_CONV1D,
+        MODEL_TENSOR.SSM_DT,
+        MODEL_TENSOR.SSM_A,
+        MODEL_TENSOR.SSM_D,
+        MODEL_TENSOR.SSM_NORM,
+        MODEL_TENSOR.SSM_OUT,
+        MODEL_TENSOR.SSM_MIX,
+        MODEL_TENSOR.FFN_NORM,
+        MODEL_TENSOR.FFN_DOWN,
+        MODEL_TENSOR.FFN_UP,
     ],
     MODEL_ARCH.XVERSE: [
         MODEL_TENSOR.TOKEN_EMBD,

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -516,6 +516,7 @@ class TensorNameMap:
             "encoder.layers.{bid}.mlp.dense_h_to_4h",                 # chatglm
             "transformer.h.{bid}.mlp.c_fc_1",                         # exaone
             "model.layers.{bid}.feed_forward.up_proj",                # llama4 jamba granite-hybrid
+            "model.layers.{bid}.feed_forward.gate_up_proj",           # zamba2 (fused)
             "transformer_encoder.{bid}.ffn.w12",                      # neobert
             "model.layers.{bid}.block_sparse_moe.up",                 # smallthinker
             "model.transformer.blocks.{bid}.up_proj",                 # llada
@@ -880,6 +881,10 @@ class TensorNameMap:
             "model.layers.{bid}.mamba.out_proj",         # jamba falcon-h1 granite-hybrid
             "model.layers.{bid}.linear_attn.out_proj",   # qwen3next
             "model.layers.layers.{bid}.mixer.out_proj",  # plamo2
+        ),
+
+        MODEL_TENSOR.SSM_MIX: (
+            "model.layers.{bid}.linear",  # zamba2
         ),
 
         MODEL_TENSOR.SSM_ALPHA: (

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -524,6 +524,7 @@ class TensorNameMap:
             "encoder.layers.{bid}.mlp.dense_h_to_4h",                 # chatglm
             "transformer.h.{bid}.mlp.c_fc_1",                         # exaone
             "model.layers.{bid}.feed_forward.up_proj",                # llama4 jamba granite-hybrid
+            "model.layers.{bid}.feed_forward.gate_up_proj",           # zamba2 (fused)
             "transformer_encoder.{bid}.ffn.w12",                      # neobert
             "model.layers.{bid}.block_sparse_moe.up",                 # smallthinker
             "model.transformer.blocks.{bid}.up_proj",                 # llada
@@ -892,6 +893,10 @@ class TensorNameMap:
             "model.layers.{bid}.mamba.out_proj",         # jamba falcon-h1 granite-hybrid
             "model.layers.{bid}.linear_attn.out_proj",   # qwen3next
             "model.layers.layers.{bid}.mixer.out_proj",  # plamo2
+        ),
+
+        MODEL_TENSOR.SSM_MIX: (
+            "model.layers.{bid}.linear",  # zamba2
         ),
 
         MODEL_TENSOR.SSM_ALPHA: (

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -63,6 +63,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_MAMBA2,           "mamba2"           },
     { LLM_ARCH_JAMBA,            "jamba"            },
     { LLM_ARCH_FALCON_H1,        "falcon-h1"        },
+    { LLM_ARCH_ZAMBA2,           "zamba2"           },
     { LLM_ARCH_XVERSE,           "xverse"           },
     { LLM_ARCH_COMMAND_R,        "command-r"        },
     { LLM_ARCH_COHERE2,          "cohere2"          },
@@ -438,6 +439,7 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
     { LLM_TENSOR_SSM_IN,                                 "blk.%d.ssm_in" },
     { LLM_TENSOR_SSM_NORM,                               "blk.%d.ssm_norm" },
     { LLM_TENSOR_SSM_OUT,                                "blk.%d.ssm_out" },
+    { LLM_TENSOR_SSM_MIX,                                "blk.%d.ssm_mix" },
     { LLM_TENSOR_ROPE_FACTORS_LONG,                      "rope_factors_long" },
     { LLM_TENSOR_ROPE_FACTORS_SHORT,                     "rope_factors_short" },
     { LLM_TENSOR_SSM_X,                                  "blk.%d.ssm_x" },
@@ -709,6 +711,7 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
     {LLM_TENSOR_SSM_X,                      {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_DT,                     {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_OUT,                    {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+    {LLM_TENSOR_SSM_MIX,                    {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_ALPHA,                  {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_BETA_ALPHA,             {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_TIME_MIX_W1,                {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
@@ -957,6 +960,7 @@ bool llm_arch_is_recurrent(const llm_arch & arch) {
 bool llm_arch_is_hybrid(const llm_arch & arch) {
     switch (arch) {
         case LLM_ARCH_JAMBA:
+        case LLM_ARCH_ZAMBA2:
         case LLM_ARCH_FALCON_H1:
         case LLM_ARCH_PLAMO2:
         case LLM_ARCH_GRANITE_HYBRID:

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -64,6 +64,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_MAMBA2,           "mamba2"           },
     { LLM_ARCH_JAMBA,            "jamba"            },
     { LLM_ARCH_FALCON_H1,        "falcon-h1"        },
+    { LLM_ARCH_ZAMBA2,           "zamba2"           },
     { LLM_ARCH_XVERSE,           "xverse"           },
     { LLM_ARCH_COMMAND_R,        "command-r"        },
     { LLM_ARCH_COHERE2,          "cohere2"          },
@@ -481,6 +482,7 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
     { LLM_TENSOR_SSM_IN,                                 "blk.%d.ssm_in" },
     { LLM_TENSOR_SSM_NORM,                               "blk.%d.ssm_norm" },
     { LLM_TENSOR_SSM_OUT,                                "blk.%d.ssm_out" },
+    { LLM_TENSOR_SSM_MIX,                                "blk.%d.ssm_mix" },
     { LLM_TENSOR_ROPE_FACTORS_LONG,                      "rope_factors_long" },
     { LLM_TENSOR_ROPE_FACTORS_SHORT,                     "rope_factors_short" },
     { LLM_TENSOR_SSM_X,                                  "blk.%d.ssm_x" },
@@ -800,6 +802,7 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
     {LLM_TENSOR_SSM_X,                      {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_DT,                     {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_OUT,                    {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
+    {LLM_TENSOR_SSM_MIX,                    {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_ALPHA,                  {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_SSM_BETA_ALPHA,             {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
     {LLM_TENSOR_TIME_MIX_W1,                {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
@@ -1062,6 +1065,7 @@ bool llm_arch_is_recurrent(const llm_arch & arch) {
 bool llm_arch_is_hybrid(const llm_arch & arch) {
     switch (arch) {
         case LLM_ARCH_JAMBA:
+        case LLM_ARCH_ZAMBA2:
         case LLM_ARCH_FALCON_H1:
         case LLM_ARCH_PLAMO2:
         case LLM_ARCH_GRANITE_HYBRID:

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -68,6 +68,7 @@ enum llm_arch {
     LLM_ARCH_MAMBA2,
     LLM_ARCH_JAMBA,
     LLM_ARCH_FALCON_H1,
+    LLM_ARCH_ZAMBA2,
     LLM_ARCH_XVERSE,
     LLM_ARCH_COMMAND_R,
     LLM_ARCH_COHERE2,
@@ -471,6 +472,7 @@ enum llm_tensor {
     LLM_TENSOR_SSM_D,
     LLM_TENSOR_SSM_NORM,
     LLM_TENSOR_SSM_OUT,
+    LLM_TENSOR_SSM_MIX,  // zamba2: linear mixing between transformer and mamba
     LLM_TENSOR_SSM_BETA_ALPHA,      // qwen3next
     LLM_TENSOR_SSM_ALPHA,           // qwen3.5
     // Kimi Linear KDA (using SSM_ prefix for consistency)

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -69,6 +69,7 @@ enum llm_arch {
     LLM_ARCH_MAMBA2,
     LLM_ARCH_JAMBA,
     LLM_ARCH_FALCON_H1,
+    LLM_ARCH_ZAMBA2,
     LLM_ARCH_XVERSE,
     LLM_ARCH_COMMAND_R,
     LLM_ARCH_COHERE2,
@@ -513,6 +514,7 @@ enum llm_tensor {
     LLM_TENSOR_SSM_D,
     LLM_TENSOR_SSM_NORM,
     LLM_TENSOR_SSM_OUT,
+    LLM_TENSOR_SSM_MIX,  // zamba2: linear mixing between transformer and mamba
     LLM_TENSOR_SSM_BETA_ALPHA,      // qwen3next
     LLM_TENSOR_SSM_ALPHA,           // qwen3.5
     // Kimi Linear KDA (using SSM_ prefix for consistency)

--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -141,9 +141,23 @@ uint32_t llama_hparams::n_embd_v_gqa(uint32_t il) const {
 }
 
 bool llama_hparams::is_n_embd_k_gqa_variable() const {
-    const uint32_t val = n_embd_k_gqa();
+    // Skip layers with n_head_kv=0 (e.g. Mamba layers in Zamba2 hybrid models)
+    // to avoid falsely reporting variable KV embedding sizes.
+    // Without this, layer 0 (Mamba, n_head_kv=0) gives n_embd_k_gqa=0 as the
+    // reference, and attention layers (n_head_kv>0) differ, returning true.
+    // This incorrectly disables KV cache quantization rotation (attn_rot_k/v).
+    uint32_t ref_val = 0;
+    bool found_ref = false;
     for (uint32_t il = 0; il < n_layer_all; ++il) {
-        if (val != n_embd_k_gqa(il)) {
+        if (n_head_kv(il) == 0) {
+            continue;
+        }
+        if (!found_ref) {
+            ref_val = n_embd_k_gqa(il);
+            found_ref = true;
+            continue;
+        }
+        if (ref_val != n_embd_k_gqa(il)) {
             return true;
         }
     }
@@ -152,9 +166,19 @@ bool llama_hparams::is_n_embd_k_gqa_variable() const {
 }
 
 bool llama_hparams::is_n_embd_v_gqa_variable() const {
-    const uint32_t val = n_embd_v_gqa();
+    // Same fix as is_n_embd_k_gqa_variable: skip non-KV layers (n_head_kv=0)
+    uint32_t ref_val = 0;
+    bool found_ref = false;
     for (uint32_t il = 0; il < n_layer_all; ++il) {
-        if (val != n_embd_v_gqa(il)) {
+        if (n_head_kv(il) == 0) {
+            continue;
+        }
+        if (!found_ref) {
+            ref_val = n_embd_v_gqa(il);
+            found_ref = true;
+            continue;
+        }
+        if (ref_val != n_embd_v_gqa(il)) {
             return true;
         }
     }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -156,6 +156,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
             return new llama_model_mamba2(params);
         case LLM_ARCH_JAMBA:
             return new llama_model_jamba(params);
+        case LLM_ARCH_ZAMBA2:
+            return new llama_model_zamba2(params);
         case LLM_ARCH_XVERSE:
             return new llama_model_xverse(params);
         case LLM_ARCH_COMMAND_R:
@@ -2244,6 +2246,10 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                     if (arch == LLM_ARCH_FALCON_H1) {
                         filter_attn = [&](uint32_t) { return true; };
                         filter_recr = [&](uint32_t) { return true; };
+                    } else if (arch == LLM_ARCH_ZAMBA2) {
+                        // Zamba2: attention only on hybrid layers, recurrent state on ALL layers
+                        filter_attn = [&](uint32_t il) { return hparams.n_head_kv(il) > 0; };
+                        filter_recr = [&](uint32_t) { return true; };
                     } else if (arch == LLM_ARCH_NEMOTRON_H || arch == LLM_ARCH_NEMOTRON_H_MOE) {
                         filter_attn = [&](uint32_t il) {
                             return !hparams.is_recr(il) && hparams.n_ff(il) == 0;
@@ -2677,6 +2683,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
         case LLM_ARCH_LAGUNA:
         case LLM_ARCH_QWEN3NEXT:
         case LLM_ARCH_MIMO2:
+        case LLM_ARCH_ZAMBA2:
         case LLM_ARCH_STEP35:
         case LLM_ARCH_TALKIE:
         case LLM_ARCH_MELLUM:

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -164,6 +164,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
             return new llama_model_mamba2(params);
         case LLM_ARCH_JAMBA:
             return new llama_model_jamba(params);
+        case LLM_ARCH_ZAMBA2:
+            return new llama_model_zamba2(params);
         case LLM_ARCH_XVERSE:
             return new llama_model_xverse(params);
         case LLM_ARCH_COMMAND_R:
@@ -2461,6 +2463,10 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                     if (arch == LLM_ARCH_FALCON_H1) {
                         filter_attn = [&](uint32_t) { return true; };
                         filter_recr = [&](uint32_t) { return true; };
+                    } else if (arch == LLM_ARCH_ZAMBA2) {
+                        // Zamba2: attention only on hybrid layers, recurrent state on ALL layers
+                        filter_attn = [&](uint32_t il) { return hparams.n_head_kv(il) > 0; };
+                        filter_recr = [&](uint32_t) { return true; };
                     } else if (arch == LLM_ARCH_NEMOTRON_H || arch == LLM_ARCH_NEMOTRON_H_MOE) {
                         filter_attn = [&](uint32_t il) {
                             return !hparams.is_recr(il) && hparams.n_ff(il) == 0;
@@ -2935,6 +2941,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
         case LLM_ARCH_LAGUNA:
         case LLM_ARCH_QWEN3NEXT:
         case LLM_ARCH_MIMO2:
+        case LLM_ARCH_ZAMBA2:
         case LLM_ARCH_STEP35:
         case LLM_ARCH_TALKIE:
         case LLM_ARCH_MELLUM:

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -344,6 +344,7 @@ struct llama_layer {
     struct ggml_tensor * ssm_x   = nullptr;
     struct ggml_tensor * ssm_dt  = nullptr;
     struct ggml_tensor * ssm_out = nullptr;
+    struct ggml_tensor * ssm_mix = nullptr;
 
     // mamba
     struct ggml_tensor * ssm_conv1d = nullptr;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -374,6 +374,7 @@ struct llama_layer {
     struct ggml_tensor * ssm_x   = nullptr;
     struct ggml_tensor * ssm_dt  = nullptr;
     struct ggml_tensor * ssm_out = nullptr;
+    struct ggml_tensor * ssm_mix = nullptr;
 
     // mamba
     struct ggml_tensor * ssm_conv1d = nullptr;

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -2233,5 +2233,3 @@ struct llama_model_step35 : public llama_model_base {
 
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
 };
-
-

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -678,6 +678,17 @@ struct llama_model_plamo3 : public llama_model_base {
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
 };
 
+struct llama_model_zamba2 : public llama_model_base {
+    llama_model_zamba2(const struct llama_model_params & params) : llama_model_base(params) {}
+    void load_arch_hparams(llama_model_loader & ml) override;
+    void load_arch_tensors(llama_model_loader & ml) override;
+
+    struct graph : public llm_build_mamba_base {
+        graph(const llama_model & model, const llm_graph_params & params);
+    };
+
+    std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
+};
 
 struct llama_model_gpt2 : public llama_model_base {
     llama_model_gpt2(const struct llama_model_params & params) : llama_model_base(params) {}
@@ -2222,3 +2233,5 @@ struct llama_model_step35 : public llama_model_base {
 
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
 };
+
+

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -702,6 +702,17 @@ struct llama_model_plamo3 : public llama_model_base {
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
 };
 
+struct llama_model_zamba2 : public llama_model_base {
+    llama_model_zamba2(const struct llama_model_params & params) : llama_model_base(params) {}
+    void load_arch_hparams(llama_model_loader & ml) override;
+    void load_arch_tensors(llama_model_loader & ml) override;
+
+    struct graph : public llm_build_mamba_base {
+        graph(const llama_model & model, const llm_graph_params & params);
+    };
+
+    std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
+};
 
 struct llama_model_gpt2 : public llama_model_base {
     llama_model_gpt2(const struct llama_model_params & params) : llama_model_base(params) {}
@@ -2543,3 +2554,5 @@ struct llama_model_step35 : public llama_model_base {
 
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
 };
+
+

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -2554,5 +2554,3 @@ struct llama_model_step35 : public llama_model_base {
 
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
 };
-
-

--- a/src/models/zamba2.cpp
+++ b/src/models/zamba2.cpp
@@ -9,9 +9,9 @@ void llama_model_zamba2::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_SSM_GROUP_COUNT,    hparams.ssm_n_group);
 
     // All layers have Mamba-2 (recurrent state needed for all)
-    std::fill(hparams.recurrent_layer_arr.begin(), hparams.recurrent_layer_arr.end(), true);
+    std::fill(hparams.is_recr_impl.begin(), hparams.is_recr_impl.end(), true);
 
-    switch (hparams.n_layer) {
+    switch (hparams.n_layer()) {
         case 38: type = LLM_TYPE_1B; break;
         case 54: type = LLM_TYPE_3B; break;
         case 76: type = LLM_TYPE_7B; break;

--- a/src/models/zamba2.cpp
+++ b/src/models/zamba2.cpp
@@ -1,0 +1,230 @@
+#include "models.h"
+
+void llama_model_zamba2::load_arch_hparams(llama_model_loader & ml) {
+    ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+    ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);
+    ml.get_key(LLM_KV_SSM_INNER_SIZE,     hparams.ssm_d_inner);
+    ml.get_key(LLM_KV_SSM_STATE_SIZE,     hparams.ssm_d_state);
+    ml.get_key(LLM_KV_SSM_TIME_STEP_RANK, hparams.ssm_dt_rank);
+    ml.get_key(LLM_KV_SSM_GROUP_COUNT,    hparams.ssm_n_group);
+
+    // All layers have Mamba-2 (recurrent state needed for all)
+    std::fill(hparams.recurrent_layer_arr.begin(), hparams.recurrent_layer_arr.end(), true);
+
+    switch (hparams.n_layer) {
+        case 38: type = LLM_TYPE_1B; break;
+        case 54: type = LLM_TYPE_3B; break;
+        case 76: type = LLM_TYPE_7B; break;
+        default: type = LLM_TYPE_UNKNOWN;
+    }
+}
+
+void llama_model_zamba2::load_arch_tensors(llama_model_loader &) {
+    LLAMA_LOAD_LOCALS;
+
+    const int64_t d_conv     = hparams.ssm_d_conv;
+    const int64_t d_inner    = hparams.ssm_d_inner;
+    const int64_t d_state    = hparams.ssm_d_state;
+    const int64_t n_head_ssm = hparams.ssm_dt_rank;
+    const int64_t n_group    = hparams.ssm_n_group;
+    const int64_t d_conv_dim = d_inner + 2*n_group*d_state;
+    const int64_t d_proj     = d_inner + d_conv_dim + n_head_ssm;
+
+    const auto TENSOR_NOT_REQUIRED = llama_model_loader::TENSOR_NOT_REQUIRED;
+
+    tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
+
+    output_norm = create_tensor(tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd}, 0);
+    output = create_tensor(tn(LLM_TENSOR_OUTPUT, "weight"), {n_embd, n_vocab}, TENSOR_NOT_REQUIRED);
+    if (output == NULL) {
+        output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, TENSOR_DUPLICATED);
+    }
+
+    for (int i = 0; i < n_layer; ++i) {
+        const int64_t n_head_kv_i = hparams.n_head_kv(i);
+        auto & layer = layers[i];
+
+        // Pre-mamba norm (all layers)
+        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
+
+        // SSM tensors (all layers have Mamba-2)
+        layer.ssm_in      = create_tensor(tn(LLM_TENSOR_SSM_IN,     "weight", i), {n_embd, d_proj}, 0);
+        layer.ssm_conv1d   = create_tensor(tn(LLM_TENSOR_SSM_CONV1D, "weight", i), {d_conv, d_conv_dim}, 0);
+        layer.ssm_conv1d_b = create_tensor(tn(LLM_TENSOR_SSM_CONV1D, "bias",   i), {d_conv_dim}, 0);
+        layer.ssm_dt_b     = create_tensor(tn(LLM_TENSOR_SSM_DT,     "bias",   i), {n_head_ssm}, 0);
+        layer.ssm_a        = create_tensor(tn(LLM_TENSOR_SSM_A,               i), {1, n_head_ssm}, 0);
+        layer.ssm_d        = create_tensor(tn(LLM_TENSOR_SSM_D,               i), {1, n_head_ssm}, 0);
+        layer.ssm_norm     = create_tensor(tn(LLM_TENSOR_SSM_NORM,  "weight", i), {d_inner/n_group, n_group}, TENSOR_NOT_REQUIRED);
+        layer.ssm_out      = create_tensor(tn(LLM_TENSOR_SSM_OUT,   "weight", i), {d_inner, n_embd}, 0);
+
+        if (n_head_kv_i > 0) {
+            // Hybrid layer: attention + FFN + linear mixing
+            const int64_t attn_hidden = 2 * n_embd;
+
+            // Pre-attention norm (4096-dim, operates on concat)
+            layer.attn_post_norm = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM, "weight", i), {attn_hidden}, 0);
+
+            // Attention weights (input is 4096-dim concat)
+            layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), {attn_hidden, attn_hidden}, 0);
+            layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), {attn_hidden, attn_hidden}, 0);
+            layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {attn_hidden, attn_hidden}, 0);
+            layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT,  "weight", i), {attn_hidden, n_embd}, 0);
+
+            // FFN
+            layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
+            layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd, n_ff}, 0);
+            layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd, n_ff}, 0);
+            layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {n_ff, n_embd}, 0);
+
+            // Linear mixing (transformer output -> mamba input adjustment)
+            layer.ssm_mix = create_tensor(tn(LLM_TENSOR_SSM_MIX, "weight", i), {n_embd, n_embd}, 0);
+        }
+    }
+}
+
+std::unique_ptr<llm_graph_context> llama_model_zamba2::build_arch_graph(const llm_graph_params & params) const {
+    return std::make_unique<graph>(*this, params);
+}
+
+llama_model_zamba2::graph::graph(const llama_model & model, const llm_graph_params & params) :
+    llm_build_mamba_base(params) {
+    const int64_t n_embd_head = hparams.n_embd_head_v();
+
+    ggml_tensor * cur;
+    ggml_tensor * inpL;
+
+    // Embed tokens
+    inpL = build_inp_embd(model.tok_embd);
+
+    // Store original embeddings for concat at hybrid layers
+    // Cast to F32 to avoid type mismatch with evolved hidden states
+    ggml_tensor * inpOrig = ggml_cast(ctx0, inpL, GGML_TYPE_F32);
+    cb(inpOrig, "inpOrig", -1);
+
+    // Position embeddings for RoPE (skip if n_rot=0, i.e. use_mem_rope=false)
+    ggml_tensor * inp_pos = (n_rot > 0) ? build_inp_pos() : nullptr;
+
+    // Build hybrid memory (KV cache + recurrent state)
+    auto * inp = build_inp_mem_hybrid();
+
+    const float kq_scale = 1.0f / sqrtf(float(n_embd_head));
+
+    ggml_tensor * inp_out_ids = build_inp_out_ids();
+
+    for (int il = 0; il < n_layer; ++il) {
+        const int64_t n_head_kv_il = hparams.n_head_kv(il);
+        const bool is_hybrid = (n_head_kv_il > 0);
+
+        ggml_tensor * residual = inpL;
+
+        if (is_hybrid) {
+            // ============ HYBRID LAYER ============
+            // Step 1: Shared transformer (attention + FFN)
+            // Concat current hidden states with original embeddings
+            cur = ggml_concat(ctx0, inpL, inpOrig, 0);
+            cb(cur, "attn_concat", il);
+
+            // Pre-attention norm (operates on 4096-dim concat)
+            cur = build_norm(cur, model.layers[il].attn_post_norm, NULL, LLM_NORM_RMS, il);
+            cb(cur, "attn_norm_concat", il);
+
+            // Self-attention on concat input
+            const int64_t n_head_il = hparams.n_head(il);
+            auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,
+                    n_embd_head, n_head_il, n_head_kv_il, il);
+
+            // RoPE (conditional: Zamba2 models with use_mem_rope=false have n_rot=0)
+            if (n_rot > 0) {
+                Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, nullptr,
+                    n_rot, hparams.rope_type, n_ctx_orig,
+                    freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow);
+                Kcur = ggml_rope_ext(ctx0, Kcur, inp_pos, nullptr,
+                    n_rot, hparams.rope_type, n_ctx_orig,
+                    freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow);
+            }
+
+            cb(Qcur, "Qcur", il);
+            cb(Kcur, "Kcur", il);
+            cb(Vcur, "Vcur", il);
+
+            // Build attention (O projects from n_heads*head_dim to n_embd)
+            cur = build_attn(inp->get_attn(),
+                    model.layers[il].wo, NULL, model.layers[il].wo_s,
+                    Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
+            cb(cur, "attn_out", il);
+
+            // Step 2: FFN (operates on n_embd-dim output from attention)
+            cur = build_norm(cur, model.layers[il].ffn_norm, NULL, LLM_NORM_RMS, il);
+            cb(cur, "ffn_norm", il);
+
+            cur = build_ffn(cur,
+                    model.layers[il].ffn_up,   NULL, NULL,
+                    NULL,                      NULL, NULL,
+                    model.layers[il].ffn_down, NULL, NULL,
+                    NULL, LLM_FFN_GEGLU, LLM_FFN_SEQ, il);
+            cb(cur, "ffn_out", il);
+
+            // Step 3: Linear mixing (transformer output projection)
+            cur = build_lora_mm(model.layers[il].ssm_mix, cur);
+            cb(cur, "ssm_mix", il);
+
+            // Step 4: Mamba-2 with transformer residual
+            ggml_tensor * mamba_input = ggml_add(ctx0, inpL, cur);
+            cb(mamba_input, "mamba_input", il);
+
+            // Pre-mamba norm
+            cur = build_norm(mamba_input, model.layers[il].attn_norm, NULL, LLM_NORM_RMS, il);
+            cb(cur, "mamba_norm", il);
+
+            // Mamba-2 layer
+            cur = build_mamba2_layer(inp->get_recr(), cur, model, ubatch, il);
+            cb(cur, "mamba_out", il);
+
+            // Residual: original hidden + mamba output
+            if (il == n_layer - 1 && inp_out_ids) {
+                cur      = ggml_get_rows(ctx0, cur, inp_out_ids);
+                residual = ggml_get_rows(ctx0, residual, inp_out_ids);
+            }
+
+            cur = ggml_add(ctx0, residual, cur);
+
+        } else {
+            // ============ PURE MAMBA LAYER ============
+            // Pre-mamba norm
+            cur = build_norm(inpL, model.layers[il].attn_norm, NULL, LLM_NORM_RMS, il);
+            cb(cur, "attn_norm", il);
+
+            // Mamba-2 layer
+            cur = build_mamba2_layer(inp->get_recr(), cur, model, ubatch, il);
+            cb(cur, "mamba_out", il);
+
+            // Residual
+            if (il == n_layer - 1 && inp_out_ids) {
+                cur      = ggml_get_rows(ctx0, cur, inp_out_ids);
+                residual = ggml_get_rows(ctx0, residual, inp_out_ids);
+            }
+
+            cur = ggml_add(ctx0, residual, cur);
+        }
+
+        cur = build_cvec(cur, il);
+        cb(cur, "l_out", il);
+
+        // Input for next layer
+        inpL = cur;
+    }
+
+    // Final norm
+    cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
+    cb(cur, "result_norm", -1);
+    res->t_embd = cur;
+
+    // LM head
+    cur = build_lora_mm(model.output, cur);
+    cb(cur, "result_output", -1);
+    res->t_logits = cur;
+
+    ggml_build_forward_expand(gf, cur);
+}

--- a/src/models/zamba2.cpp
+++ b/src/models/zamba2.cpp
@@ -70,10 +70,9 @@ void llama_model_zamba2::load_arch_tensors(llama_model_loader &) {
             layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {attn_hidden, attn_hidden}, 0);
             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT,  "weight", i), {attn_hidden, n_embd}, 0);
 
-            // FFN
+            // FFN (fused gate+up, split internally by GEGLU)
             layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
-            layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd, n_ff}, 0);
-            layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd, n_ff}, 0);
+            layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd, 2*n_ff}, 0);
             layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {n_ff, n_embd}, 0);
 
             // Linear mixing (transformer output -> mamba input adjustment)

--- a/src/models/zamba2.cpp
+++ b/src/models/zamba2.cpp
@@ -65,9 +65,7 @@ void llama_model_zamba2::load_arch_tensors(llama_model_loader &) {
             layer.attn_post_norm = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM, "weight", i), {attn_hidden}, 0);
 
             // Attention weights (input is 4096-dim concat)
-            layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), {attn_hidden, attn_hidden}, 0);
-            layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), {attn_hidden, attn_hidden}, 0);
-            layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {attn_hidden, attn_hidden}, 0);
+            create_tensor_qkv(layer, i, attn_hidden, attn_hidden, attn_hidden, attn_hidden, 0);
             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT,  "weight", i), {attn_hidden, n_embd}, 0);
 
             // FFN (fused gate+up, split internally by GEGLU)

--- a/src/models/zamba2.cpp
+++ b/src/models/zamba2.cpp
@@ -17,6 +17,10 @@ void llama_model_zamba2::load_arch_hparams(llama_model_loader & ml) {
         case 76: type = LLM_TYPE_7B; break;
         default: type = LLM_TYPE_UNKNOWN;
     }
+
+    // Zamba2 uses (head_dim/2)^(-0.5) attention scaling
+    // Ref: transformers/models/zamba2/modeling_zamba2.py Zamba2Attention.__init__
+    hparams.f_attention_scale = 1.0f / sqrtf(float(hparams.n_embd_head_v_full) / 2.0f);
 }
 
 void llama_model_zamba2::load_arch_tensors(llama_model_loader &) {
@@ -104,7 +108,7 @@ llama_model_zamba2::graph::graph(const llama_model & model, const llm_graph_para
     // Build hybrid memory (KV cache + recurrent state)
     auto * inp = build_inp_mem_hybrid();
 
-    const float kq_scale = 1.0f / sqrtf(float(n_embd_head));
+    const float kq_scale = hparams.f_attention_scale;
 
     ggml_tensor * inp_out_ids = build_inp_out_ids();
 


### PR DESCRIPTION
> [!NOTE]
> AI coding tools ([Claude Code](https://claude.com/claude-code)) were used in an assistive capacity during development. The author designed the architecture mapping, tensor layout, and debugging strategy based on direct experience compressing every tensor in the Zamba2 model family with [HXQ](https://github.com/echo313unfolding/helix-substrate). Claude Code assisted with C++ implementation under the author's direction. All code was reviewed, tested, and verified by the author on local hardware (RTX 3090, Quadro T2000).

## Summary

Add Zamba2 architecture support, validated on the **1.2B** and **2.7B** variants. The 7B `num_mem_blocks=2` converter path remains untested and requires the extension noted below.

Zamba2 is a hybrid architecture from [Zyphra](https://www.zyphra.com/zamba2) combining Mamba-2 SSM layers with shared transformer attention blocks and per-layer LoRA adapters.

This has been requested since July 2024 (see #8795). All building blocks already exist in llama.cpp (Mamba-2 from Falcon-H1, hybrid memory from Jamba) — this PR wires them together for Zamba2's specific architecture.

### Architecture Overview

Zamba2-1.2B has 38 layers:
- **32 pure Mamba-2 layers**: norm → mamba2 → residual
- **6 hybrid layers** (at positions 5,11,17,23,29,35): shared transformer → linear mix → mamba2 → residual

Key differences from existing hybrids:
- **Concatenated attention input**: `concat(hidden_states[2048], original_embeddings[2048])` → 4096-dim input to attention. The original token embeddings are stored and reused at every hybrid layer.
- **Shared transformer with LoRA**: One attention+FFN block shared across all 6 hybrid positions, with per-position LoRA adapters (rank=128). The GGUF converter pre-applies LoRA (`W_eff = W_shared + B @ A`) and emits independent per-layer tensors.
- **Linear mixing**: A learned `[2048, 2048]` projection at each hybrid layer maps transformer output to the Mamba-2 input space.
- **All layers are recurrent**: Every layer has Mamba-2 state, including hybrid layers (which run attention THEN mamba).
- **Nonstandard attention scaling**: Zamba2 uses `(head_dim/2)^(-0.5)` instead of `head_dim^(-0.5)`. Set via `f_attention_scale` in `load_arch_hparams`, following the Gemma4/Granite convention.

### Numerical Equivalence (Zamba2-1.2B)

F32 logit comparison against unmodified HF `Zamba2ForCausalLM` (CPU, deterministic, prompt: "The capital of France is"):

| Metric | Value |
|--------|-------|
| Max absolute logit error | 0.008009 |
| Minimum cosine similarity | 0.9999998885 |
| Top-1 agreement | 6/6 steps |
| Greedy path match | `Paris . \n \n Par is` |

Preregistered thresholds: max_abs < 0.01, min_cos > 0.9999, all top-1 match. **PASS.**

The attention scaling mismatch (`1/sqrt(head_dim)` vs correct `1/sqrt(head_dim/2)`) was identified via causal intervention: patching the HF reference to the wrong scale collapsed the discrepancy, confirming root cause. Corrected in this PR and validated by the numerical-equivalence test above.

### Changes

| File | Change | Description |
|------|--------|-------------|
| `conversion/zamba2.py` | +208 | GGUF converter (extends `Mamba2Model`): shared-block duplication, LoRA pre-merge, per-layer KV heads |
| `conversion/__init__.py` | +1 | Registry entry |
| `conversion/mamba.py` | +1 -1 | `mamba_ngroups` hparam alias for Zamba2 configs |
| `gguf-py/gguf/constants.py` | +26 | `MODEL_ARCH.ZAMBA2`, tensor enums |
| `gguf-py/gguf/tensor_mapping.py` | +5 | Tensor name mappings |
| `src/llama-arch.{h,cpp}` | +6 | `LLM_ARCH_ZAMBA2`, `LLM_TENSOR_SSM_MIX` |
| `src/llama-hparams.cpp` | +28 -5 | Skip `n_head_kv=0` layers in variable GQA check |
| `src/llama-model.{h,cpp}` | +8 | `ssm_mix` field, factory entry, hybrid memory filter, rope type |
| `src/models/models.h` | +11 | `llama_model_zamba2` class declaration |
| `src/models/zamba2.cpp` | +231 | Full model: hparams, tensor loading, forward pass |

Total: 12 files, **+525 -5**.

### GGUF Conversion

Integrated in `conversion/zamba2.py` (extends `Mamba2Model`):
- LoRA adapter pre-merge: `W_effective = W_shared + B @ A` (per hybrid visit)
- Fused `gate_up_proj` → single `FFN_UP` at `{n_embd, 2*n_ff}` (GEGLU split handled by `ggml_geglu`)
- `A_log → A` conversion: `-exp(A_log)`, reshaped to `[n_heads, 1]`
- Per-layer `n_head_kv` array (0 for Mamba, 32 for hybrid)
- Tied `lm_head` → `output` weight handling

### Performance

**Zamba2-1.2B-Instruct, RTX 3090:**

| Quantization | Model Size | VRAM | Prompt Eval | Generation |
|---|---|---|---|---|
| F32 | 6.59 GB | 7.16 GB | 517 tok/s | 100 tok/s |
| Q8_0 | 1.75 GB | 2.32 GB | 2,379 tok/s | 227 tok/s |
| Q4_0 | 946 MB | 1.52 GB | 2,509 tok/s | 292 tok/s |

**Zamba2-2.7B-Instruct, Quadro T2000 (4 GB):** Q4_0 at 10.1 tok/s generation, 91.7 tok/s prompt eval.

### Known Limitations

- F16 GGUF requires F32 cast for `inpOrig` (original embeddings) due to type mismatch in concat. Works correctly but adds one cast op.
- 7B variant (`num_mem_blocks=2`, two shared transformer blocks cycling) needs minor converter extension — untested.

### Test Plan

- [x] F32 logit equivalence vs HF reference for 1.2B (max_abs=0.008, cos>0.999999)
- [x] GEGLU negative control (half-swap detected, confirms harness sensitivity)
- [x] Greedy decode path matches HF across 6 autoregressive steps (1.2B)
- [x] F32/Q8_0/Q4_0 GGUF load and generate coherent text
- [x] CPU-only backend verified (equivalence proof ran on CPU)
- [x] 2.7B generation quality verified (Q4_0, Quadro T2000)
- [ ] 7B variant testing
- [ ] Perplexity evaluation (WikiText-2)
- [ ] 2.7B numerical equivalence vs HF

Ref: #8795 — @compilade @awgr