### PR TITLE
common : respect specified tag, only fallback when tag is empty

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -596,9 +596,12 @@ static hf_cache::hf_file find_best_model(const hf_cache::hf_files & files,
         }
     }
 
-    for (const auto & f : files) {
-        if (gguf_filename_is_model(f.path)) {
-            return f;
+    // fallback to first available model only if tag is empty
+    if (tag.empty()) {
+        for (const auto & f : files) {
+            if (gguf_filename_is_model(f.path)) {
+                return f;
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

Respect specified tag, only fallback when tag is empty

## Additional information

Should fix https://github.com/ggml-org/llama.cpp/issues/21364#issuecomment-4184994923

With this commit:
```
$ build/bin/llama-server -hf unsloth/Qwen3.5-35B-A3B-GGUF:Q4_K_XL --offline
migrate_old_cache_to_hf_cache: skipping migration in offline mode (will run when online)
common_download_file_single: required file is not available in cache (offline mode): /home/angt/.cache/llama.cpp/unsloth_Qwen3.5-35B-A3B-GGUF_preset.ini
no remote preset found, skipping
get_hf_plan: no GGUF files found in repository unsloth/Qwen3.5-35B-A3B-GGUF
Available GGUF files:
 - mmproj-BF16.gguf
 - Qwen3.5-35B-A3B-UD-Q6_K_XL.gguf
error: failed to download model from Hugging Face
```

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
