### PR TITLE
model-loader : fix GGUF bool array conversion

### DIFF
--- a/src/llama-impl.cpp
+++ b/src/llama-impl.cpp
@@ -128,7 +128,7 @@ static std::string gguf_data_to_str(enum gguf_type type, const void * data, int 
         case GGUF_TYPE_INT64:   return std::to_string(((const int64_t  *)data)[i]);
         case GGUF_TYPE_FLOAT32: return std::to_string(((const float    *)data)[i]);
         case GGUF_TYPE_FLOAT64: return std::to_string(((const double   *)data)[i]);
-        case GGUF_TYPE_BOOL:    return ((const bool *)data)[i] ? "true" : "false";
+        case GGUF_TYPE_BOOL:    return ((const int8_t *)data)[i] != 0 ? "true" : "false";
         default:                return format("unknown type %d", type);
     }
 }

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -374,8 +374,9 @@ namespace GGUFMeta {
             }
         } else {
             if (arr_info.gt == GGUF_TYPE_BOOL) {
-                std::transform((const bool *)arr_info.data, (const bool *)arr_info.data + arr_info.length, result.begin(), [](bool x) {
-                    return static_cast<T>(x);
+                const int8_t * values = (const int8_t *) arr_info.data;
+                std::transform(values, values + arr_info.length, result.begin(), [](int8_t x) {
+                    return static_cast<T>(x != 0);
                 });
             } else {
                 std::copy((const T*)arr_info.data, (const T *)arr_info.data + arr_info.length, result.begin());

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -515,7 +515,7 @@ static std::string gguf_data_to_str(enum gguf_type type, const void * data, int 
         case GGUF_TYPE_INT64:   return std::to_string(((const int64_t  *)data)[i]);
         case GGUF_TYPE_FLOAT32: return std::to_string(((const float    *)data)[i]);
         case GGUF_TYPE_FLOAT64: return std::to_string(((const double   *)data)[i]);
-        case GGUF_TYPE_BOOL:    return ((const bool *)data)[i] ? "true" : "false";
+        case GGUF_TYPE_BOOL:    return ((const int8_t *)data)[i] != 0 ? "true" : "false";
         default:                return string_format("unknown type %d", type);
     }
 }


### PR DESCRIPTION
## Overview

GGUF stores bool arrays as int8_t, but the model loader was reading raw array data as const bool *

This changes the bool-array path in src/llama-model-loader.cpp to read const int8_t * and normalize entries with x != 0 before converting to the destination type.

This matches the GGUF definition in 'ggml/include/gguf.h': All bool values are stored as int8_t

## Additional information

This fixes a Gemma 4 load failure caused by incorrect parsing of attention.sliding_window_pattern, which could change SWA layer selection and lead to tensor shape mismatches during model load. In practice this likely only reproduced on a minority of builds, depending on how the incorrect bool * reinterpretation was handled.

Validated locally by rebuilding and successfully loading a Gemma 4 GGUF that previously failed.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Codex assisted with the initial debugging and located the cause of the issue

Edit: Should fix [#21434](https://github.com/ggml-org/llama.cpp/issues/21434) and [#21457](https://github.com/ggml-org/llama.cpp/issues/21457)