### PR TITLE
vulkan: Tweak Xe2 warptile configuration

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -267,6 +267,7 @@ enum vk_device_architecture {
     AMD_RDNA2,
     AMD_RDNA3,
     INTEL_XE2,
+    INTEL_XE3,
     NVIDIA_PRE_TURING,
     NVIDIA_TURING,
 };
@@ -341,11 +342,16 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
         device.getProperties2(&props2);
 
         if (subgroup_size_control_props.minSubgroupSize == 16) {
-            // Xe2 architecture uses SIMD16 while previous Xe and Gen architecture uses SIMD8.
+            // Xe2+ architectures uses SIMD16 while previous Xe and Gen architecture uses SIMD8.
             // Minimum subgroup size matches the SIMD width so we distinguish architecture by checking this value.
             // https://www.intel.com/content/www/us/en/content-details/824434/2024-intel-tech-tour-xe2-and-lunar-lake-s-gpu.html
             // https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2025-0/intel-xe-gpu-architecture.html
-            return vk_device_architecture::INTEL_XE2;
+            // Xe3 increased the maximum compute subgroups from 64 to 80, so we use that to detect Xe3.
+            if (subgroup_size_control_props.maxComputeWorkgroupSubgroups == 80) {
+                return vk_device_architecture::INTEL_XE3;
+            } else if (subgroup_size_control_props.maxComputeWorkgroupSubgroups == 64) {
+                return vk_device_architecture::INTEL_XE2;
+            }
         }
     } else if (props.vendorID == VK_VENDOR_ID_NVIDIA) {
         const std::vector<vk::ExtensionProperties> ext_props = device.enumerateDeviceExtensionProperties();
@@ -3297,7 +3303,11 @@ static void ggml_vk_load_shaders(vk_device& device) {
             l_warptile_mmq = l_warptile_mmq_int = { 256, 128, 128, 32, subgroup_size_8, 64, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq_int_k = { 256, 128, 128, 32, subgroup_size_16, 64, 1, 4, 2, 1, subgroup_size_16 };
         } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support && device->architecture == INTEL_XE2) {
-            // Xe2/Xe3 with coopmat enabled - warptile performance tuning
+            // Xe2 with coopmat enabled - warptile performance tuning
+            l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
+            l_warptile_mmq = { 512, 128, 128, 32, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
+        } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support && device->architecture == INTEL_XE3) {
+            // Xe3 with coopmat enabled - warptile performance tuning
             l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq = { 512, 128, 128, 32, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
         }
@@ -3981,7 +3991,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
         m_wg_denoms = { 64,  64, 1 };
         s_wg_denoms = { 32,  32, 1 };
 
-        if (device->vendor_id == VK_VENDOR_ID_INTEL && device->architecture == INTEL_XE2) {
+        if (device->architecture == INTEL_XE2 || device->architecture == INTEL_XE3) {
             // Xe2/Xe3 - bf16 warptile performance tuning
             l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, 4, 4, 1, subgroup_size_8 };
         }
@@ -5436,6 +5446,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         // Shaders
         // Disable matmul tile sizes early if performance low or not supported
         for (uint32_t i = 0; i < GGML_TYPE_COUNT; ++i) {
+            bool intel_xe2_or_later = device->architecture == INTEL_XE2 || device->architecture == INTEL_XE3;
             switch (device->vendor_id) {
 #ifndef GGML_VULKAN_RUN_TESTS
             case VK_VENDOR_ID_AMD:
@@ -5446,8 +5457,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->mul_mat_id_m[i] = true;
                 device->mul_mat_id_s[i] = true;
                 break;
-            case VK_VENDOR_ID_INTEL:
-                if (!device->coopmat_support || device->architecture != INTEL_XE2) {
+            case VK_VENDOR_ID_INTEL: {
+                if (!device->coopmat_support || !intel_xe2_or_later) {
                     device->mul_mat_l[i] = false;
                     device->mul_mat_id_l[i] = false;
                 } else {
@@ -5459,6 +5470,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->mul_mat_id_m[i] = true;
                 device->mul_mat_id_s[i] = true;
                 break;
+            }
             case VK_VENDOR_ID_APPLE:
                 device->mul_mat_l[i] = false;
                 device->mul_mat_m[i] = true;
@@ -8949,7 +8961,8 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
     uint32_t split_k = 1;
 
     // Intel Alchemist prefers more workgroups
-    const uint32_t shader_core_count_multiplier = (ctx->device->vendor_id == VK_VENDOR_ID_INTEL && ctx->device->architecture != INTEL_XE2) ? 2 : 1;
+    bool intel_xe2_or_later = ctx->device->architecture == INTEL_XE2 || ctx->device->architecture == INTEL_XE3;
+    const uint32_t shader_core_count_multiplier = (!intel_xe2_or_later) ? 2 : 1;
 
     // Use a placeholder core count if one isn't available. split_k is a big help for perf.
     const uint32_t shader_core_count = ctx->device->shader_core_count ? ctx->device->shader_core_count * shader_core_count_multiplier : 16;
@@ -16015,9 +16028,9 @@ static bool ggml_vk_device_is_supported(const vk::PhysicalDevice & vkdev) {
 static bool ggml_vk_khr_cooperative_matrix_support(const vk::PhysicalDeviceProperties& props, const vk::PhysicalDeviceDriverProperties& driver_props, vk_device_architecture arch) {
     switch (props.vendorID) {
     case VK_VENDOR_ID_INTEL:
-        // Only allowing Xe2 GPU at the moment since Xe2 GPU can gain significant performance boost,
+        // Only allowing Xe2+ GPU at the moment since Xe2 GPU can gain significant performance boost,
         // while some older hardware (ex. Arc A770) has performance regressions
-        return arch == vk_device_architecture::INTEL_XE2;
+        return arch == vk_device_architecture::INTEL_XE2 || arch == vk_device_architecture::INTEL_XE3;
     case VK_VENDOR_ID_AMD:
         if (driver_props.driverID == vk::DriverId::eAmdProprietary || driver_props.driverID == vk::DriverId::eAmdOpenSource) {
             // Workaround for AMD proprietary driver reporting support on all GPUs

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3293,6 +3293,13 @@ static void ggml_vk_load_shaders(vk_device& device) {
         m_warptile_mmqid_int_k = { 128,                      64,  64, 32, mul_mat_subgroup_size_16,     32, 1, 2, 2, 1, mul_mat_subgroup_size_16 };
         s_warptile_mmqid_int_k = { mul_mat_subgroup_size_32, 32,  32, 32, s_warptile_wm,                32, 1, 2, 1, 1, mul_mat_subgroup_size_16 };
 
+        l_mmq_wg_denoms = l_wg_denoms = {128, 128, 1 };
+        m_mmq_wg_denoms = m_wg_denoms = { 64,  64, 1 };
+        s_mmq_wg_denoms = s_wg_denoms = { 32,  32, 1 };
+        l_align = 128;
+        m_align =  64;
+        s_align =  32;
+
         // chip specific tuning
         if ((device->architecture == AMD_GCN) && (device->driver_id != vk::DriverId::eAmdProprietary)) {
             m_warptile_mmq = m_warptile_mmq_int = { 256, 64, 64, 32, 16, 16, 2, 2, 2, 1, 16 };
@@ -3304,20 +3311,14 @@ static void ggml_vk_load_shaders(vk_device& device) {
             l_warptile_mmq_int_k = { 256, 128, 128, 32, subgroup_size_16, 64, 1, 4, 2, 1, subgroup_size_16 };
         } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support && device->architecture == INTEL_XE2) {
             // Xe2 with coopmat enabled - warptile performance tuning
-            l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
+            l_warptile = { 512, 128, 64, 16, subgroup_size_8, 16, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
+            l_wg_denoms = {128, 64, 1};
             l_warptile_mmq = { 512, 128, 128, 32, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
         } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support && device->architecture == INTEL_XE3) {
             // Xe3 with coopmat enabled - warptile performance tuning
             l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq = { 512, 128, 128, 32, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
         }
-
-        l_mmq_wg_denoms = l_wg_denoms = {128, 128, 1 };
-        m_mmq_wg_denoms = m_wg_denoms = { 64,  64, 1 };
-        s_mmq_wg_denoms = s_wg_denoms = { 32,  32, 1 };
-        l_align = 128;
-        m_align =  64;
-        s_align =  32;
 
         for (uint32_t i = 0; i < GGML_TYPE_COUNT; ++i) {
             ggml_type t = (ggml_type)i;


### PR DESCRIPTION
```
    vulkan: Tweak Xe2 warptile configuration

    On native float matmul shaders, the existing warptile configuration
    for Xe2 ended up spilling quite some registers. By tweaking the
    warptile config we can drive spills to zero and we get a
    substantial speedup in BF16 models, and a small one in others.

    Using the mesa anv driver with the load combining and LICM fix from
    https://gitlab.freedesktop.org/mesa/mesa/-/work_items/15162 and the
    spill-reduction improvements from
    https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/40796 on
    mesa 26.0.3,

    On a single Arc Pro B60:
     * gpt-oss 20B MXFP4 MoE
       pp512: 1356.08 ± 34.83 -> 1378.53 ± 15.17
       pp2048: 1311.92 ± 1.20 -> 1331.65 ± 4.11 (+2%)
       matmul_f16_l spill 75 -> 0, cycles 237414 -> 97336
       tg128: 52.01 ± 0.01 -> 51.88 ± 0.23
     * qwen35moe 35B.A3B Q4_K - Medium:
       pp512: 899.38 ± 16.84 -> 903.65 ± 14.92
       pp2048: 897.72 ± 1.91 -> 900.93 ± 1.83
       matmul_f32_f32_aligned_l spill 66 -> 0, cycles 159052 -> 58102
       matmul_f16_aligned_l spill 68 -> 0, cycles 158332 -> 55054
       matmul_f16_f32_f16acc_aligned_l spill 0 -> 0, cycles 80040 -> 54872
       tg128: 49.31 ± 0.02 -> 49.50 ± 0.01
     * qwen35 9B BF16:
       pp512: 509.34 ± 79.17 -> 844.24 ± 64.5 (+66%)
       pp2048: 564.64 ± 0.95 -> 949.35 ± 1.39 (+68%)
       matmul_bf16_aligned_l spill 47 -> 0, cycles 127438 -> 39124
       tg128: 22.12 ± 0.02 -> 22.12 ± 0.02

    Across four Arc Pro B60s:
     * qwen35moe 122B.A10B Q5_K - Small
       pp512: 268.06 ± 8.07 -> 269.08 ± 7.45
       pp2048: 318.88 ± 4.69 ->  320.80 ± 1.98
       matmul_f32_f32_aligned_l spill 66 -> 0, cycles 159052 -> 58102
       matmul_f16_aligned_l spill 68 -> 0, cycles 158332 -> 55054
       matmul_f16_f32_f16acc_aligned_l spill 0 -> 0, cycles 80040 -> 54872
       tg128: 26.20 ± 0.01 -> 26.40 ± 0.01
     * gemma4 31B BF16
       pp512: 141.92 ± 4.77 -> 222.61 ± 4.58 (+57%)
       pp2048: 162.35 ± 1.42 -> 268.07 ± 6.41 (+65%)
       matmul_bf16_aligned_l spill 48 -> 0, cycles 116834 -> 39124
       tg128: 6.40 ± 0.00 -> 6.41 ± 0.00
```

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Claude suggested this as a part of a larger re-tuning of the parameters, but after doing my own benchmarks Claude's larger suggestions weren't as good as the more minimal fix here, and its first fix was invalid anyway.