### PR TITLE
ci: fix vulkan workflow referencing non-existent action

### DIFF
--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Setup Vulkan SDK
         if: steps.cache-sdk.outputs.cache-hit != 'true'
-        uses: ./.github/actions/linux-setup-vulkan-llvmpipe
+        uses: ./.github/actions/linux-setup-vulkan
         with:
           path: ./vulkan_sdk
           version: ${{ env.VULKAN_SDK_VERSION }}


### PR DESCRIPTION
## Summary

The `build-vulkan.yml` workflow references the composite action `.github/actions/linux-setup-vulkan-llvmpipe` which does not exist in the repository. The correct action path is `.github/actions/linux-setup-vulkan`.

## Problem

The Vulkan CI job fails immediately with:
```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'.github/actions/linux-setup-vulkan-llvmpipe'
```

## Fix

One-line change: update the action path from `linux-setup-vulkan-llvmpipe` to `linux-setup-vulkan`.

## Verification

Available actions in `.github/actions/`:
- `linux-setup-vulkan/action.yml` ✅ (exists)
- `linux-setup-vulkan-llvmpipe/` ❌ (does not exist)