### PR TITLE
model: add missing build_cvec to plamo2

### DIFF
--- a/src/models/plamo2.cpp
+++ b/src/models/plamo2.cpp
@@ -71,6 +71,9 @@ llm_build_plamo2::llm_build_plamo2(const llama_model & model, const llm_graph_pa
         cur = ggml_add(ctx0, cur, residual);
         cb(cur, "ffn_residual", il);
 
+        cur = build_cvec(cur, il);
+        cb(cur, "l_out", il);
+
         // input for next layer
         inpL = cur;
     }


### PR DESCRIPTION
## Summary

PLaMo-2 is missing the `build_cvec()` call in its graph builder, causing `--control-vector` to be silently ignored.

## Root Cause

PR #20653 ("model: add control vector support where missing") touched both `plamo2.cpp` and `plamo3.cpp`, but the plamo2 change was incomplete.

Comparing the diffs from #20653:

**plamo3.cpp** — correct (3 lines added):
```cpp
        cur = build_cvec(cur, il);
        cb(cur, "l_out", il);

        // input for next layer
```

**plamo2.cpp** — incomplete (only the comment was added):
```cpp
        // input for next layer
```

The actual `build_cvec()` and `cb()` calls were missed.

## Fix

Adds the missing two lines, matching the pattern in `plamo3.cpp` and all other 100+ model implementations:

```cpp
        cur = build_cvec(cur, il);
        cb(cur, "l_out", il);
```

## Impact

- **Without fix:** `--control-vector` silently does nothing on PLaMo-2
- **With fix:** Control vectors are applied per-layer as intended
- **Risk:** Zero — `build_cvec` is a no-op when no control vector is loaded, so normal inference is completely unaffected