### PR TITLE
server : fix logging of build + system info

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -108,10 +108,8 @@ int main(int argc, char ** argv) {
     llama_backend_init();
     llama_numa_init(params.numa);
 
-    LOG_INF("system info: n_threads = %d, n_threads_batch = %d, total_threads = %d\n", params.cpuparams.n_threads, params.cpuparams_batch.n_threads, std::thread::hardware_concurrency());
-    LOG_INF("\n");
+    LOG_INF("build_info: %s\n", build_info.c_str());
     LOG_INF("%s\n", common_params_get_system_info(params).c_str());
-    LOG_INF("\n");
 
     server_http_context ctx_http;
     if (!ctx_http.init(params)) {


### PR DESCRIPTION
This PR changes the logging that occurs at startup of llama-server. Currently, it is redundant (including CPU information twice) and it is missing the build + commit info (helpful for debugging).

## Motivation

### Before PR:

<img width="1512" height="137" alt="Screenshot 2026-04-04 at 11 49 48 PM" src="https://github.com/user-attachments/assets/6d0c98b3-6bd3-4822-b3be-09d6ab023964" />

### After PR:

<img width="1512" height="102" alt="Screenshot 2026-04-04 at 11 56 43 PM" src="https://github.com/user-attachments/assets/f24aee63-9975-4d98-a1ef-0f007b949377" />

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO