### PR TITLE
server: support thinking type "disabled" in chat completions

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1633,13 +1633,15 @@ json convert_anthropic_to_oai(const json & body) {
         }
     }
 
-    // Handle Anthropic-specific thinking param
+    // Handle thinking param (Anthropic-compatible)
     if (body.contains("thinking")) {
         json thinking = json_value(body, "thinking", json::object());
         std::string thinking_type = json_value(thinking, "type", std::string());
         if (thinking_type == "enabled") {
             int budget_tokens = json_value(thinking, "budget_tokens", 10000);
             oai_body["thinking_budget_tokens"] = budget_tokens;
+        } else if (thinking_type == "disabled") {
+            oai_body["thinking_budget_tokens"] = 0;
         }
     }
 


### PR DESCRIPTION
## Overview

The existing Anthropic-compatible `thinking` param handler only supports `type: "enabled"`. When clients send `type: "disabled"`, it is silently ignored and thinking stays on.

This adds a 2-line `else if` that sets `thinking_budget_tokens = 0` when `type: "disabled"`, matching the Anthropic API behavior.

## The change

```cpp
} else if (thinking_type == "disabled") {
    oai_body["thinking_budget_tokens"] = 0;
}
```

## Why

The `--reasoning off` CLI flag crashes `llama-server` on Gemma 4 (works on `llama-cli`). This gives per-request control via the API instead, which is more flexible and does not require a server restart.

## Testing

Tested with Gemma 4 E4B (Q4_K_M):
- Without: ~8.6s per request, ~900 chars reasoning
- With `thinking: {type: "disabled"}`: ~1.3s per request, ~0-200 chars reasoning  
- Server stays stable across 100+ requests
- No impact on `type: "enabled"` path (unchanged)

## Requirements
- I have read and agree with the contributing guidelines
- AI usage disclosure: YES — Claude assisted with identifying and testing the fix