### PR TITLE
server: add null check for context to prevent segfault on init failure

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -759,6 +759,11 @@ private:
             return false;
         }
 
+        if (ctx == nullptr) {
+            SRV_ERR("failed to create context for model, '%s'\n", params_base.model.path.c_str());
+            return false;
+        }
+
         vocab = llama_model_get_vocab(model);
 
         n_ctx = llama_n_ctx(ctx);


### PR DESCRIPTION
## Overview

Fixes a segfault when llama_context creation fails.
In `server-context.cpp::load_model`, the return from `common_init_from_params` is checked for a null model but not a null context. When context creation fails, `llama_n_ctx(ctx)` dereferences null and crashes.
This adds a null check for ctx matching the existing model check.

Ref: #21450

### Reproduction Steps:
On Apple Silicon,
```
 ./build/bin/llama-server -hf LiquidAI/LFM2.5-1.2B-Instruct-GGUF:Q4_K_M \
  --ctx-size 32768 \
  -ngl 99 \
  -fa auto \
  --cache-type-k q4_0 \
  --cache-type-v q4_0
```

It segfaulted before. Now it clean exits with an error message.

Also verified ```--cache-type-k q4_0 --cache-type-v q4_0``` still works normally.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
