### PR TITLE
server : handle unsuccessful sink.write in chunked stream provider

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -397,8 +397,9 @@ static void process_handler_response(server_http_req_ptr && request, server_http
             std::string chunk;
             bool has_next = response->next(chunk);
             if (!chunk.empty()) {
-                // TODO: maybe handle sink.write unsuccessful? for now, we rely on is_connection_closed()
-                sink.write(chunk.data(), chunk.size());
+                if (!sink.write(chunk.data(), chunk.size())) {
+                    return false;
+                }
                 SRV_DBG("http: streamed chunk: %s\n", chunk.c_str());
             }
             if (!has_next) {


### PR DESCRIPTION
Handle the return value of `sink.write()` in the chunked content provider and return `false` when the write fails, matching `cpp-httplib`'s own streaming contract.

### Changes
- Check the return value of `sink.write()` in `process_handler_response()`
- Return `false` from the content provider when the write is rejected
- Only log a chunk as sent when the write actually succeeds

### Result
The server now properly aborts streaming when the sink rejects a write (e.g. client disconnect), instead of continuing to attempt sends and logging them as successful.