### PR TITLE
llama-quantize: fix tensor-type logic

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -673,8 +673,10 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, const llama_mod
 
     // get more optimal quantization type based on the tensor shape, layer, etc.
     if (!params->pure && ggml_is_quantized(default_type)) {
-        // if the user provided tensor types - use those
-        bool manual = false;
+        // use the standard logic for choosing the quantization type based on the selected mixture
+        new_type = llama_tensor_get_type_impl(qs, new_type, tensor, params->ftype, tm.category);
+
+        // if the user provided tensor types - use those instead
         if (!qs.tensor_type_patterns.empty()) {
             const std::string tensor_name(tensor->name);
             for (const auto & [pattern, qtype] : qs.tensor_type_patterns) {
@@ -688,11 +690,6 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, const llama_mod
                     }
                 }
             }
-        }
-
-        // if not manual - use the standard logic for choosing the quantization type based on the selected mixture
-        if (!manual) {
-            new_type = llama_tensor_get_type_impl(qs, new_type, tensor, params->ftype, tm.category);
         }
 
         // incompatible tensor shapes are handled here - fallback to a compatible type

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -685,7 +685,6 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, const llama_mod
                         LLAMA_LOG_WARN("%s: %-36s - applying manual override: %s -> %s\n",
                                        __func__, tensor_name.c_str(), ggml_type_name(new_type), ggml_type_name(qtype));
                         new_type = qtype;
-                        manual = true;
                         break;
                     }
                 }


### PR DESCRIPTION
## Overview

Fix quantization type selection with `--tensor-type` when the requested type is the same as the base type.

## Additional information

For example, when quantizing to Q4_K_M, using `--tensor-type ffn_down=Q4_K` fails to get applied at all because in the current code, the condition `qtype != new_type` would evaluate to false, only to get overridden with the `llama_tensor_get_type_impl` call.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->