### PR TITLE
vocab : add byte token handling to BPE detokenizer for Gemma4

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2805,7 +2805,9 @@ uint8_t llama_vocab::impl::token_to_byte(llama_token id) const {
             return strtol(buf.c_str(), NULL, 16);
         }
         case LLAMA_VOCAB_TYPE_BPE: {
-            GGML_ABORT("fatal error");
+            // Gemma4 uses BPE with SPM-style byte fallback tokens (<0xXX>)
+            auto buf = token_data.text.substr(3, 2);
+            return strtol(buf.c_str(), NULL, 16);
         }
         case LLAMA_VOCAB_TYPE_WPM: {
             GGML_ABORT("fatal error");
@@ -3285,6 +3287,10 @@ int32_t llama_vocab::impl::token_to_piece(llama_token token, char * buf, int32_t
                     }
                     std::string result = llama_decode_text(token_text);
                     return _try_copy(result.data(), result.size());
+                }
+                if (attr & LLAMA_TOKEN_ATTR_BYTE) {
+                    char byte = (char) token_to_byte(token);
+                    return _try_copy((char*) &byte, 1);
                 }
                 break;
             }


### PR DESCRIPTION
## Overview

Looks like the change in #21343 changed the detokenizer path which wasn't handling unicode properly.

Fixes #21423

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I only have a high-level understanding in this area. I fed Claude the following prompt:
```
Run the following command:

cmake --build build-user-reldebug -t llama-completion && .\build-user-reldebug\bin\llama-completion.exe -m E:\LLM\Models\gemma-4-31B\gemma-4-e2b-it-Q8_0.gguf -f bad-prompt.txt -no-cnv

Notice how the model does _not_ emit the white pawn unicode.
This was a regression introduced in commit b069b10.

Figure out why. If I revert back a commit and run this, it works as intended.
```
To my surprise, it spat out something that seems reasonable... Please scrutinize heavily.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
