### PR TITLE
convert : fix block_ff_dim retrieval for lfm2

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -11818,10 +11818,8 @@ class LFM2Model(TextModel):
     model_arch = gguf.MODEL_ARCH.LFM2
 
     def _add_feed_forward_length(self):
-        ff_dim = self.hparams["block_ff_dim"]
-
+        ff_dim = self.find_hparam(["block_ff_dim", "intermediate_size"])
         auto_adjust_ff_dim = self.hparams["block_auto_adjust_ff_dim"]
-        ff_dim = self.hparams["block_ff_dim"]
         ffn_dim_multiplier = self.hparams["block_ffn_dim_multiplier"]
         multiple_of = self.hparams["block_multiple_of"]
 


### PR DESCRIPTION
## Overview

Ensure correct retrieval of `block_ff_dim` value for LFM2.

## Additional information

Recent `transformers` changes pops `block_ff_dim` into `intermediate_size`, see
https://github.com/huggingface/transformers/blob/39f751a538ca67932cab53e6eb5763243674ae2c/src/transformers/models/lfm2/configuration_lfm2.py#L91

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: ei