### PR TITLE
llama-server: fix model params not propagated

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -632,7 +632,7 @@ private:
 
     // load the model and initialize llama_context
     // this may also be called to resume from sleeping state
-    bool load_model(const common_params & params) {
+    bool load_model(common_params & params) {
         bool is_resume = sleeping;
 
         SRV_INF("loading model '%s'\n", params.model.path.c_str());
@@ -640,6 +640,9 @@ private:
         params_base = params;
 
         llama_init = common_init_from_params(params_base);
+
+        // propagate model-metadata sampling defaults back to caller
+        params.sampling = params_base.sampling;
 
         model = llama_init->model();
         ctx   = llama_init->context();
@@ -2978,7 +2981,7 @@ private:
 server_context::server_context() : impl(new server_context_impl()) {}
 server_context::~server_context() = default;
 
-bool server_context::load_model(const common_params & params) {
+bool server_context::load_model(common_params & params) {
     return impl->load_model(params);
 }
 

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -56,7 +56,7 @@ struct server_context {
 
     // load the model and initialize llama_context
     // returns true on success
-    bool load_model(const common_params & params);
+    bool load_model(common_params & params);
 
     // this function will block main thread until termination
     void start_loop();


### PR DESCRIPTION
Cont: https://github.com/ggml-org/llama.cpp/pull/17120
Fixes: https://github.com/ggml-org/llama.cpp/discussions/17088#discussioncomment-16222105

## Overview

This PR fixes an issue where model-embedded sampling parameters are not being propagated to `llama-server` causing default sampling parameters to be used instead of the model-embedded sampling parameters.

## Verification

I will be using the Deepseek R1 Distill Qwen 1.5B model where the model creators recommend the following sampling parameters:
1. `temperature`: 0.6
2. `top-p`: 0.95

### Model-Embedded Sampling Parameters

```console
$ python3 gguf-py/gguf/scripts/gguf_dump.py ~/Documents/hf_models/deepseek-r1-distill-qwen-1.5b-bf16.gguf | grep -E "temp|top_p"

INFO:gguf-dump:* Loading: /Users/taronaeo/Documents/hf_models/deepseek-r1-distill-qwen-1.5b-bf16.gguf
      6: FLOAT32    |        1 | general.sampling.top_p = 0.949999988079071
      7: FLOAT32    |        1 | general.sampling.temp = 0.6000000238418579
```

### Upstream `/props`

```json
$ curl -s http://localhost:8080/props | jq -c 'pick(.default_generation_settings.params.temperature, .default_generation_settings.params.top_p)' | jq -s .

[
  {
    "default_generation_settings": {
      "params": {
        "temperature": 0.800000011920929,  # using default common_params_sampling
        "top_p": 0.949999988079071
      }
    }
  }
]
```

### PR `/props`

```json
$ curl -s http://localhost:8080/props | jq -c 'pick(.default_generation_settings.params.temperature, .default_generation_settings.params.top_p)' | jq -s .

[
  {
    "default_generation_settings": {
      "params": {
        "temperature": 0.6000000238418579,  # using model-embedded sampling
        "top_p": 0.949999988079071
      }
    }
  }
]
```

cc: @thilomichael

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. Claude Opus was used to identify the problem and fix it.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
