### PR TITLE
docs: fix typo in build.md (emdawbwebgpu -> emdawnwebgpu)

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -741,7 +741,7 @@ cmake --build build --config Release
 
 WebGPU allows cross-platform access to the GPU from supported browsers. We utilize [Emscripten](https://emscripten.org/) to compile ggml's WebGPU backend to WebAssembly. Emscripten does not officially support WebGPU bindings yet, but Dawn currently maintains its own WebGPU bindings called emdawnwebgpu.
 
-Follow the instructions [here](https://dawn.googlesource.com/dawn/+/refs/heads/main/src/emdawnwebgpu/) to download or build the emdawnwebgpu package (Note that it might be safer to build the emdawbwebgpu package locally, so that it stays in sync with the version of Dawn you have installed above). When building using CMake, the path to the emdawnwebgpu port file needs to be set with the flag `EMDAWNWEBGPU_DIR`.
+Follow the instructions [here](https://dawn.googlesource.com/dawn/+/refs/heads/main/src/emdawnwebgpu/) to download or build the emdawnwebgpu package (Note that it might be safer to build the emdawnwebgpu package locally, so that it stays in sync with the version of Dawn you have installed above). When building using CMake, the path to the emdawnwebgpu port file needs to be set with the flag `EMDAWNWEBGPU_DIR`.
 
 ## IBM Z & LinuxONE
 


### PR DESCRIPTION
Fix typo in WebGPU Browser Support section of `docs/build.md`: "emdawbwebgpu" should be "emdawnwebgpu" (Dawn WebGPU bindings package name).

## Overview

Simple one-character typo fix: `emdawbwebgpu` → `emdawnwebgpu` (letter 'b' should be 'n').

The package name references Dawn's WebGPU bindings and should match the actual directory name in the Dawn repository (`dawn/src/emdawnwebgpu/`).

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO