### PR TITLE
ggml-cuda : fix CDNA2 compute capability constant for gfx90a (MI210)

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -65,7 +65,7 @@
 #define GGML_CUDA_CC_VEGA       (GGML_CUDA_CC_OFFSET_AMD + 0x900)  // Vega56/64, minimum for fp16 dual issue
 #define GGML_CUDA_CC_VEGA20     (GGML_CUDA_CC_OFFSET_AMD + 0x906)  // MI50/Radeon VII, minimum for dp4a
 #define GGML_CUDA_CC_CDNA1      (GGML_CUDA_CC_OFFSET_AMD + 0x908)  // MI100, minimum for MFMA, acc registers
-#define GGML_CUDA_CC_CDNA2      (GGML_CUDA_CC_OFFSET_AMD + 0x910)  // MI210, minimum acc register renameing
+#define GGML_CUDA_CC_CDNA2      (GGML_CUDA_CC_OFFSET_AMD + 0x90a)  // MI210 (gfx90a), minimum acc register renaming
 #define GGML_CUDA_CC_CDNA3      (GGML_CUDA_CC_OFFSET_AMD + 0x942)  // MI300
 
 // RDNA removes MFMA, dp4a, xnack, acc registers, wave size is 32


### PR DESCRIPTION
## Overview

`GGML_CUDA_CC_CDNA2` was defined as `GGML_CUDA_CC_OFFSET_AMD + 0x910`, but `0x910` does not correspond to any real AMD GPU target — gfx90a (CDNA2) is `0x90a`. The typo (`910` vs `90a`) placed the CDNA2 threshold above the actual gfx90a compute capability, causing MI210/MI250/MI250X to be misidentified as CDNA1 by `GGML_CUDA_CC_IS_CDNA2()`.

Fixed by setting the constant to `0x90a` to match the actual gfx90a ISA.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — I mass-prompted the most expensive LLM money can buy, burned millions of tokens over weeks of grueling agentic sessions, and mass-reviewed hundreds of thousands of lines of HIP kernel code, all so it could ultimately tell me to change two hex characters. The ROI on this one is truly staggering.