### PR TITLE
common : preserve original Gemma 4 tool responses even when JSON-like

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1732,17 +1732,7 @@ struct gemma4_model_turn_builder {
     void collect_result(const json & curr) {
         json response;
         if (curr.contains("content")) {
-            const auto & content = curr.at("content");
-            if (content.is_string()) {
-                // Try to parse the content as JSON; fall back to raw string
-                try {
-                    response = json::parse(content.get<std::string>());
-                } catch (...) {
-                    response = content;
-                }
-            } else {
-                response = content;
-            }
+            response = curr.at("content");
         }
 
         std::string name;


### PR DESCRIPTION
## Overview

Before this PR, llama.cpp Gemma 4 specialized parser (#21418) would attempt to parse the string-typed tool responses as JSON; and convert it to an object if successful.  It would then be minified by the template:
```jinja
{%- if tool_response['response'] is mapping -%}
    {{- 'response:' + tool_response['name'] | default('unknown') + '{' -}}
    {%- for key, value in tool_response['response'] | dictsort -%}
        {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
        {%- if not loop.last %},{% endif -%}
    {%- endfor -%}
    {{- '}' -}}
{%- else -%}
    {{- 'response:' + tool_response['name'] | default('unknown') + '{value:' + format_argument(tool_response['response'], escape_keys=False) + '}' -}}
{%- endif -%}
```

This means that anything that looks like JSON would get unexpectedly altered.
I encountered this with Gemma 4 failing to edit a JSON file; it was getting confused as the inconsistent line numbers and indentations between what it read and what it attempted to write/edit.

## Additional information

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
