### PR TITLE
server : fix json_schema response_format ignored by some chat templates

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1083,23 +1083,32 @@ json oaicompat_chat_params_parse(
 
     llama_params["chat_format"] = static_cast<int>(chat_params.format);
     llama_params["prompt"]      = chat_params.prompt;
-    if (!chat_params.grammar.empty()) {
-        llama_params["grammar"]      = chat_params.grammar;
-        llama_params["grammar_type"] = std::string("tool_calls");
+
+    // json_schema fallback: if the chat template did not produce a grammar, pass json_schema
+    // through to server-task.cpp and skip template grammar artifacts to avoid conflicts.
+    bool json_schema_passthrough = !json_schema.is_null() && chat_params.grammar.empty();
+
+    if (json_schema_passthrough) {
+        llama_params["json_schema"] = json_schema;
+    } else {
+        if (!chat_params.grammar.empty()) {
+            llama_params["grammar"]      = chat_params.grammar;
+            llama_params["grammar_type"] = std::string("tool_calls");
+        }
+        llama_params["grammar_lazy"] = chat_params.grammar_lazy;
+        auto grammar_triggers        = json::array();
+        for (const auto & trigger : chat_params.grammar_triggers) {
+            server_grammar_trigger ct(trigger);
+            grammar_triggers.push_back(ct.to_json());
+        }
+        llama_params["grammar_triggers"]  = grammar_triggers;
+        llama_params["preserved_tokens"]  = chat_params.preserved_tokens;
     }
-    llama_params["grammar_lazy"] = chat_params.grammar_lazy;
-    auto grammar_triggers        = json::array();
-    for (const auto & trigger : chat_params.grammar_triggers) {
-        server_grammar_trigger ct(trigger);
-        grammar_triggers.push_back(ct.to_json());
-    }
-    llama_params["grammar_triggers"]  = grammar_triggers;
-    llama_params["preserved_tokens"]  = chat_params.preserved_tokens;
-    llama_params["generation_prompt"] = chat_params.generation_prompt;
+    llama_params["generation_prompt"] = json_schema_passthrough ? "" : chat_params.generation_prompt;
     for (const auto & stop : chat_params.additional_stops) {
         llama_params["stop"].push_back(stop);
     }
-    if (!chat_params.parser.empty()) {
+    if (!chat_params.parser.empty() && !json_schema_passthrough) {
         llama_params["chat_parser"] = chat_params.parser;
     }
 


### PR DESCRIPTION
## Overview

`response_format` with `type: json_schema` is silently ignored when the active chat template's specialized handler does not process the `json_schema` field. The model generates unconstrained text instead of schema-valid JSON.

Affected handlers include at least the LFM2 and LFM2.5 ones. Possibly more... basically any that do not explicitly handle `json_schema` and write it back into `llama_params` so it doesn't get lost.

When `json_schema` is present but the chat template produced an empty grammar for it, pass `json_schema` through to `server-task.cpp`'s existing `json_schema_to_grammar` path. Also skip the template's grammar triggers, preserved tokens, generation prompt, and chat parser to avoid conflicts.

Handlers that already handle `json_schema` (GPT-OSS, Gemma4, Ministral, autoparser, legacy) produce a non-empty grammar, so the fallback never activates for them.

## Additional information

You can reproduce the issue and verify the fix via below command:

```
llama-server -hf unsloth/LFM2.5-1.2B-Instruct-GGUF:Q8_K_XL --jinja

curl -s http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "test",
    "messages": [{"role":"user","content":"Say hi"}],
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "name": "Test",
        "schema": {
          "type": "object",
          "properties": {"greeting": {"type": "string"}},
          "required": ["greeting"],
          "additionalProperties": false
        }
      }
    }
  }'


# Before: "content": "Hello! How can I help you today?"
# After: "content": "{ \"greeting\": \"Hi there!\" }"
```

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI was used to help trace the bug through the codebase. Fix was applied by AI after identification and testing done manually.