### PR TITLE
metal : add CROSS_ENTROPY_LOSS and CROSS_ENTROPY_LOSS_BACK ops

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1913,7 +1913,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_opt_step_sgd(ggm
 }
 
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_memset(ggml_metal_library_t lib, const ggml_tensor *  op) {
-    GGML_ASSERT(op->type == GGML_TYPE_I64);
+    GGML_ASSERT(op->type == GGML_TYPE_I64 || op->type == GGML_TYPE_F32);
 
     char base[256];
     char name[256];
@@ -1965,6 +1965,40 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_count_equal(ggml
 
     res.smem = 32 * sizeof(int32_t);
     res.nsg  = nsg;
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cross_entropy_loss(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_CROSS_ENTROPY_LOSS);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_cross_entropy_loss");
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cross_entropy_loss_back(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_CROSS_ENTROPY_LOSS_BACK);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_cross_entropy_loss_back");
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
 
     return res;
 }

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -158,6 +158,8 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_opt_step_
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_opt_step_sgd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_memset            (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_count_equal       (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cross_entropy_loss     (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cross_entropy_loss_back(ggml_metal_library_t lib, const struct ggml_tensor * op);
 
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_flash_attn_ext_pad(
         ggml_metal_library_t lib,

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1097,6 +1097,16 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_GROUP_NORM:
         case GGML_OP_L2_NORM:
             return has_simdgroup_reduction && ggml_is_contiguous_rows(op->src[0]);
+        case GGML_OP_CROSS_ENTROPY_LOSS:
+            return has_simdgroup_reduction &&
+                ggml_is_contiguous_rows(op->src[0]) &&
+                ggml_is_contiguous_rows(op->src[1]) &&
+                op->src[0]->type == GGML_TYPE_F32;
+        case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
+            return has_simdgroup_reduction &&
+                ggml_is_contiguous_rows(op->src[1]) &&
+                ggml_is_contiguous_rows(op->src[2]) &&
+                op->src[1]->type == GGML_TYPE_F32;
         case GGML_OP_COUNT_EQUAL:
             return has_simdgroup_reduction &&
                 op->src[0]->type == GGML_TYPE_I32 &&

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -701,6 +701,21 @@ typedef struct {
 } ggml_metal_kargs_sum;
 
 typedef struct {
+    int32_t  ne00;
+    uint64_t nb01;
+    uint64_t nb11;
+    int32_t  nrows;
+} ggml_metal_kargs_cross_entropy_loss;
+
+typedef struct {
+    int32_t  ne00;
+    uint64_t nb01;
+    uint64_t nb11;
+    uint64_t nb1;
+    int32_t  nrows;
+} ggml_metal_kargs_cross_entropy_loss_back;
+
+typedef struct {
     int64_t  ne00;
     int64_t  ne01;
     int64_t  ne02;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -468,6 +468,14 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_count_equal(ctx, idx);
             } break;
+        case GGML_OP_CROSS_ENTROPY_LOSS:
+            {
+                n_fuse = ggml_metal_op_cross_entropy_loss(ctx, idx);
+            } break;
+        case GGML_OP_CROSS_ENTROPY_LOSS_BACK:
+            {
+                n_fuse = ggml_metal_op_cross_entropy_loss_back(ctx, idx);
+            } break;
         default:
             {
                 GGML_LOG_ERROR("%s: error: node %3d, op = %8s not implemented\n", __func__, idx, ggml_op_name(node->op));
@@ -4531,6 +4539,111 @@ int ggml_metal_op_count_equal(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
         ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne02, ne03, nth, 1, 1);
     }
+
+    return 1;
+}
+
+int ggml_metal_op_cross_entropy_loss(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_ASSERT(ggml_is_contiguous_rows(op->src[0]));
+    GGML_ASSERT(ggml_is_contiguous_rows(op->src[1]));
+
+    const int32_t ne00  = op->src[0]->ne[0];
+    const int32_t nrows = ggml_nrows(op->src[0]);
+
+    // step 1: zero the scalar output
+    {
+        ggml_metal_kargs_memset args = { /*.val =*/ 0 };
+
+        auto pipeline = ggml_metal_library_get_pipeline_memset(lib, op);
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes(enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op), 1);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, 1, 1, 1, 1, 1, 1);
+    }
+
+    ggml_metal_op_concurrency_reset(ctx);
+
+    // step 2: per-row cross-entropy, atomic accumulate into dst
+    {
+        ggml_metal_kargs_cross_entropy_loss args = {
+            /*.ne00  =*/ ne00,
+            /*.nb01  =*/ op->src[0]->nb[1],
+            /*.nb11  =*/ op->src[1]->nb[1],
+            /*.nrows =*/ nrows,
+        };
+
+        auto pipeline = ggml_metal_library_get_pipeline_cross_entropy_loss(lib, op);
+
+        int nth = 32;
+        while (nth < ne00 && nth < ggml_metal_pipeline_max_theads_per_threadgroup(pipeline)) {
+            nth *= 2;
+        }
+        nth = std::min(nth, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+
+        const int nsg = (nth + 31) / 32;
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
+
+        ggml_metal_encoder_set_threadgroup_memory_size(enc, nsg * sizeof(float), 0);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, nrows, 1, 1, nth, 1, 1);
+    }
+
+    return 1;
+}
+
+int ggml_metal_op_cross_entropy_loss_back(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    // src[0] = grad (scalar), src[1] = logits, src[2] = labels
+    GGML_ASSERT(ggml_is_contiguous_rows(op->src[1]));
+    GGML_ASSERT(ggml_is_contiguous_rows(op->src[2]));
+
+    const int32_t ne00  = op->src[1]->ne[0];
+    const int32_t nrows = ggml_nrows(op->src[1]);
+
+    ggml_metal_kargs_cross_entropy_loss_back args = {
+        /*.ne00  =*/ ne00,
+        /*.nb01  =*/ op->src[1]->nb[1],
+        /*.nb11  =*/ op->src[2]->nb[1],
+        /*.nb1   =*/ op->nb[1],
+        /*.nrows =*/ nrows,
+    };
+
+    auto pipeline = ggml_metal_library_get_pipeline_cross_entropy_loss_back(lib, op);
+
+    int nth = 32;
+    while (nth < ne00 && nth < ggml_metal_pipeline_max_theads_per_threadgroup(pipeline)) {
+        nth *= 2;
+    }
+    nth = std::min(nth, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+
+    const int nsg = (nth + 31) / 32;
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[2]), 3);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         4);
+
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, nsg * sizeof(float), 0);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, nrows, 1, 1, nth, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -90,6 +90,8 @@ int ggml_metal_op_tri               (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_adamw    (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_sgd      (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_count_equal       (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_cross_entropy_loss     (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_cross_entropy_loss_back(ggml_metal_op_t ctx, int idx);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -10299,6 +10299,9 @@ typedef decltype(kernel_memset<int64_t>) kernel_memset_t;
 
 template [[host_name("kernel_memset_i64")]] kernel kernel_memset_t kernel_memset<int64_t>;
 
+typedef decltype(kernel_memset<float>) kernel_memset_f32_t;
+template [[host_name("kernel_memset_f32")]] kernel kernel_memset_f32_t kernel_memset<float>;
+
 constant short FC_count_equal_nsg [[function_constant(FC_COUNT_EQUAL + 0)]];
 
 template<typename T>
@@ -10358,3 +10361,173 @@ kernel void kernel_count_equal(
 typedef decltype(kernel_count_equal<int32_t>) kernel_count_equal_t;
 
 template [[host_name("kernel_count_equal_i32")]] kernel kernel_count_equal_t kernel_count_equal<int32_t>;
+
+kernel void kernel_cross_entropy_loss(
+        constant ggml_metal_kargs_cross_entropy_loss & args,
+        device const char  * src0,
+        device const char  * src1,
+        device       float * dst,
+        threadgroup  float * buf [[threadgroup(0)]],
+        uint   tgpig[[threadgroup_position_in_grid]],
+        ushort tpitg[[thread_position_in_threadgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort   ntg[[threads_per_threadgroup]]) {
+    const int row = tgpig;
+
+    device const float * logits = (device const float *) (src0 + row * args.nb01);
+    device const float * labels = (device const float *) (src1 + row * args.nb11);
+
+    // 1. find per-row max for numerical stability
+    float lmax = -INFINITY;
+    for (int i = tpitg; i < args.ne00; i += ntg) {
+        lmax = max(lmax, logits[i]);
+    }
+
+    float max_val = simd_max(lmax);
+
+    if (ntg > N_SIMDWIDTH) {
+        if (sgitg == 0) {
+            buf[tiisg] = -INFINITY;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiisg == 0) {
+            buf[sgitg] = max_val;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        max_val = buf[tiisg];
+        max_val = simd_max(max_val);
+    }
+
+    // 2. compute sum(exp(logit - max))
+    float lsum = 0.0f;
+    for (int i = tpitg; i < args.ne00; i += ntg) {
+        lsum += exp(logits[i] - max_val);
+    }
+
+    float sum_exp = simd_sum(lsum);
+
+    if (ntg > N_SIMDWIDTH) {
+        if (sgitg == 0) {
+            buf[tiisg] = 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiisg == 0) {
+            buf[sgitg] = sum_exp;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        sum_exp = buf[tiisg];
+        sum_exp = simd_sum(sum_exp);
+    }
+
+    const float log_sum_exp = log(sum_exp);
+
+    // 3. compute loss = sum(labels * log_softmax)
+    float lloss = 0.0f;
+    for (int i = tpitg; i < args.ne00; i += ntg) {
+        lloss += (logits[i] - max_val - log_sum_exp) * labels[i];
+    }
+
+    float loss = simd_sum(lloss);
+
+    if (ntg > N_SIMDWIDTH) {
+        if (sgitg == 0) {
+            buf[tiisg] = 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiisg == 0) {
+            buf[sgitg] = loss;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        loss = buf[tiisg];
+        loss = simd_sum(loss);
+    }
+
+    // 4. accumulate -loss / nrows into dst[0]
+    if (tpitg == 0) {
+        // NOTE: this relies on dst[0] being zeroed before kernel launch
+        atomic_fetch_add_explicit((device atomic<float> *) dst, -loss / args.nrows, memory_order_relaxed);
+    }
+}
+
+kernel void kernel_cross_entropy_loss_back(
+        constant ggml_metal_kargs_cross_entropy_loss_back & args,
+        device const char  * grad,
+        device const char  * src0,
+        device const char  * src1,
+        device       char  * dst,
+        threadgroup  float * buf [[threadgroup(0)]],
+        uint   tgpig[[threadgroup_position_in_grid]],
+        ushort tpitg[[thread_position_in_threadgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort   ntg[[threads_per_threadgroup]]) {
+    const int row = tgpig;
+
+    device const float * logits = (device const float *) (src0 + row * args.nb01);
+    device const float * labels = (device const float *) (src1 + row * args.nb11);
+    device       float * dst_row = (device float *)      (dst  + row * args.nb1);
+
+    const float d_by_nrows = ((device const float *) grad)[0] / args.nrows;
+
+    // 1. find per-row max
+    float lmax = -INFINITY;
+    for (int i = tpitg; i < args.ne00; i += ntg) {
+        lmax = max(lmax, logits[i]);
+    }
+
+    float max_val = simd_max(lmax);
+
+    if (ntg > N_SIMDWIDTH) {
+        if (sgitg == 0) {
+            buf[tiisg] = -INFINITY;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiisg == 0) {
+            buf[sgitg] = max_val;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        max_val = buf[tiisg];
+        max_val = simd_max(max_val);
+    }
+
+    // 2. compute sum(exp(logit - max))
+    float lsum = 0.0f;
+    for (int i = tpitg; i < args.ne00; i += ntg) {
+        const float e = exp(logits[i] - max_val);
+        lsum += e;
+        dst_row[i] = e;
+    }
+
+    float sum_exp = simd_sum(lsum);
+
+    if (ntg > N_SIMDWIDTH) {
+        if (sgitg == 0) {
+            buf[tiisg] = 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiisg == 0) {
+            buf[sgitg] = sum_exp;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        sum_exp = buf[tiisg];
+        sum_exp = simd_sum(sum_exp);
+    }
+
+    const float inv_sum = 1.0f / sum_exp;
+
+    // 3. dst = (softmax - labels) * grad / nrows
+    for (int i = tpitg; i < args.ne00; i += ntg) {
+        dst_row[i] = (dst_row[i] * inv_sum - labels[i]) * d_by_nrows;
+    }
+}


### PR DESCRIPTION
## Overview

Add Metal support for CROSS_ENTROPY_LOSS and CROSS_ENTROPY_LOSS_BACK.
This keeps the loss computation on-GPU on Apple Silicon, avoiding a
CPU round-trip for forward and backward loss evaluation.

**Forward** — two-pass dispatch (same pattern as COUNT_EQUAL):

1. `kernel_memset_f32` (new template instantiation) zeros dst
2. One threadgroup per row runs three strided loops over ne00:
   `simd_max` → threadgroup shmem → `simd_max` for the row max,
   same reduction for `sum(exp(x - max))`, then `sum(labels * (x - max - log_sum_exp))`.
   Thread 0 accumulates via `atomic_fetch_add_explicit` on `device atomic<float>`.

**Backward** — single pass, one threadgroup per row, no atomics.
Writes `exp(x - max)` into dst as scratch during the sum-exp reduction,
scales by `1/sum`, then overwrites with `(softmax[i] - labels[i]) * grad[0] / nrows`.
Matches the CUDA `cross_entropy_loss_back_f32` kernel.

Mentioned in #14909

## Testing

M4 Pro:

- [x] `test-backend-ops test -o CROSS_ENTROPY_LOSS` — 2/2 passed
- [x] `test-backend-ops test -o CROSS_ENTROPY_LOSS_BACK` — 2/2 passed

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO