### PR TITLE
common : only warn when using unsupported kv cache types

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -398,7 +398,13 @@ static ggml_type kv_cache_type_from_str(const std::string & s) {
             return type;
         }
     }
-    throw std::runtime_error("Unsupported cache type: " + s);
+
+    auto type = ggml_name_to_type(s.c_str());
+    if (type == GGML_TYPE_COUNT) {
+        throw std::runtime_error("Unsupported cache type: " + s);
+    }
+    LOG_WRN("Unsupported cache type: %s\n", s.c_str());
+    return type;
 }
 
 static std::string get_all_kv_cache_types() {

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -754,6 +754,8 @@ extern "C" {
     // TODO: temporary until model loading of ggml examples is refactored
     GGML_API enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype);
 
+    GGML_API enum ggml_type ggml_name_to_type(const char * name);
+
     GGML_API bool ggml_is_transposed(const struct ggml_tensor * tensor);
     GGML_API bool ggml_is_permuted  (const struct ggml_tensor * tensor);
     GGML_API bool ggml_is_empty     (const struct ggml_tensor * tensor);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1421,6 +1421,18 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
     return wtype;
 }
 
+enum ggml_type ggml_name_to_type(const char * name) {
+    enum ggml_type type = GGML_TYPE_COUNT;
+    ggml_get_type_traits(type);
+
+    for (int i = 0; i < GGML_TYPE_COUNT; i++) {
+        if (strcmp(type_traits[i].type_name, name) == 0) {
+            return (enum ggml_type)i;
+        }
+    }
+    return GGML_TYPE_COUNT;
+}
+
 size_t ggml_tensor_overhead(void) {
     return GGML_OBJECT_SIZE + GGML_TENSOR_SIZE;
 }


### PR DESCRIPTION
## Overview

Add a name (string) to ggml type helper and only warn when kv cache quantization is set to an unsupported type.

## Additional information

Thanks to the new kv rotation if quantized, the lower bound to what seems reasonable for kv quantization has fallen. Also with turboquant prs still coming in, we should just look at existing quants first.

Opening this more as a discussion with numbers with code attached, than an actual code pr.

For unsupported types, you need to either offload the kvcache to cpu (`-nkvo` + `-fa on`) or only partially offload the model (slower `-ngl 1`).

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

---

Some numbers. Some where previously posed here: https://github.com/ggml-org/llama.cpp/pull/21273#issuecomment-4192469220 .

## Perplexity
This metric is ok to use when comparing the same model with itself.

### wikitext2-test 512 !! first 8 chunks only !!
very slow, since its mostly cpu fallback or cuda throwing NaNs.

#### llama2 7b Q4_K_M
| k   | v   | rot | ppl |
|-----|-----|-----|------|
| f16  | f16  | 0 | 6.3123 |
| q4_0 | q4_0 | 0 | 6.4648 |
| q4_0 | q4_0 | 1 | 6.3243 |
| q4_0 | q1_0 | 0 | 207.91 |
| q4_0 | q1_0 | 1 | **9.9382** |
| q1_0 | q1_0 | 1 | 199.33 |

### wikitext2-test 512

#### gemma3 4b pt q4_0
| k   | v   | rot | ppl | size (base + swa) |
|-----|-----|-----|------|---|
| f16  | f16  | 0 | 7.8551 +/- 0.05036 | 40.00 MiB + 232.00 MiB |
| q8_0 | q8_0 | 1 | 7.8569 +/- 0.05037 | 21.25 MiB + 123.25 MiB |
| q4_0 | q4_0 | 1 | 7.9506 +/- 0.05103 | 11.25 MiB + 65.25 MiB |
| q4_0 | q1_0 | 1 | 9.2384 +/- 0.06022 | 7.03 MiB + 40.78 MiB |
| q3_K | q2_K | 1 | 8.2374 +/- 0.05307 | 7.58 MiB + 43.95 MiB |

### hellaswag (400)
A little better at showing the models performance, but its only using a short context.

#### llama2 7b Q4_K
| k    |   v  | rot | score    | 95% confidence interval |
|------|------|---|----------|----------------------|
| f16  | f16  | 0 | 77.0000% | [72.6307%, 80.8556%] |
| q8_0 | q8_0 | 1 | 76.7500% | [72.3677%, 80.6234%] |
| q4_0 | q4_0 | 0 | 76.0000% | [71.5800%, 79.9254%] |
| q4_0 | q4_0 | 1 | 76.7500% | [72.3677%, 80.6234%] |
| q4_0 | q1_0 | 0 | 29.0000% | [24.7697%, 33.6299%] |
| q4_0 | q1_0 | 1 | 65.2500% | [60.4585%, 69.7514%] |
| q1_0 | q1_0 | 0 | 28.5000% | [24.2971%, 33.1120%] |
| q1_0 | q1_0 | 1 | 30.2500% | [25.9539%, 34.9218%] |

<details><summary>example command</summary>

```
$ LLAMA_ATTN_ROT_DISABLE=1 result/bin/llama-perplexity -m models/llama-2-7b.Q4_K_M.gguf -f hellaswag_val_full.txt --hellaswag -ctk q4_0 -ctv q1_0 -ngl 99 -nkvo -fa on
```

</details> 

30% hellaswag score is apparently somewhat of a lower bound, since q1_0 without rotation is very unusable.

#### gemma3 4b pt q4_0 (qat?)
| k    |   v  | rot | score    | 95% confidence interval |
|------|------|---|----------|----------------------|
| f16  | f16  | 0 | 73.0000% | [68.4457%, 77.1167%] |
| q8_0 | q8_0 | 1 | 73.0000% | [68.4457%, 77.1167%] |
| q4_0 | q4_0 | 0 | 72.2500% | [67.6661%, 76.4106%] |
| q4_0 | q4_0 | 1 | 72.2500% | [67.6661%, 76.4106%] |
| q4_0 | q1_0 | 0 | 46.0000% | [41.1770%, 50.8991%] |
| q4_0 | q1_0 | 1 | **70.0000%** | [65.3363%, 74.2832%] |
| iq4_nl | iq4_nl | 1 | 73.0000% | [68.4457%, 77.1167%]
| iq4_nl | q1_0 | 1 | 68.5000% | [63.7901%, 72.8579%] |
| **q3_K** | **q2_K** | 1 | **73.7500%** | [69.2268%, 77.8213%] |
| **q3_K** | q1_0 | 1 | **69.2500%** | [64.5625%, 73.5713%] |
| q2_K | q2_K | 1 | 69.0000% | [64.3049%, 73.3336%] |
| q1_0 | q1_0 | 1 | 35.2500% | [30.7287%, 40.0519%] |

gemma3 4b has swa, which is quantized in this commit.

## hellaswag (5000)

More taks to get the confidence interval smaller. With 400 its rather large, and a lower quant score was better than f16.

#### gemma3 4b pt q4_0 (qat?)
| k    |   v  | rot | score    | 95% confidence interval |
|------|------|---|----------|----------------------|
| f16  | f16  | 0 | 72.9200% | [71.6710%, 74.1338%]
| q8_0 | q8_0 | 1 | 72.7800% | [71.5292%, 73.9959%]
| q8_0 | q2_K | 1 | 72.5000% | [71.2454%, 73.7200%]
| q4_0 | q4_0 | 1 | 72.4600% | [71.2049%, 73.6806%]
| q4_0 | q2_K | 1 | 72.1000% | [70.8402%, 73.3258%]
| q4_0 | tq1_0 | 1 | 64.5800% | [63.2436%, 65.8940%]
| q4_0 | q1_0 | 1 | 69.1200% | [67.8252%, 70.3855%]
| iq4_nl | iq4_nl | 1 | 72.5600% | [71.3062%, 73.7791%]
| iq4_nl | q2_K | 1 | 72.5000% | [71.2454%, 73.7200%]
| iq4_nl | q1_0 | 1 | 68.9800% | [67.6837%, 70.2472%]
| q4_K | q2_K | 1 | 72.4400% | [71.1846%, 73.6609%]
| q3_K | q3_K | 1 | 72.0600% | [70.7997%, 73.2864%]
| q3_K | q2_K | 1 | 72.1200% | [70.8605%, 73.3456%]
| q2_K | q3_K | 1 | 68.1400% | [66.8350%, 69.4171%]

## multiple choice - ARC (easy+challange?) validation
869 tasks
needs `-np 5`

#### llama2 7b Q4_K_M
| k | v | rot | score |
|---|---|-----|-------|
| f16  | f16  | 0 | 53.8550 +/- 1.6921 |
| q4_0 | q4_0 | 1 | 54.0852 +/- 1.6914 |
| q4_0 | q1_0 | 1 | 44.3038 +/- 1.6861 |
| rand | rand |   | 25 |

#### gemma3 4b pt q4_0
| k      | v    | rot | score |
|--------|------|-----|-------|
| f16    | f16  | 0 | 66.7434 +/- 1.5991 |
| q8_0   | q8_0 | 1 | 66.6283 +/- 1.6005 |
| q4_0   | q4_0 | 1 | 65.8228 +/- 1.6099 |
| q4_0   | q1_0 | 1 | 61.3349 +/- 1.6529 |
| iq4_nl | q1_0 | 1 | 63.0610 +/- 1.6382 |
| q3_K   | q2_K | 0 | 66.2831 +/- 1.6046 |
| q3_K   | q2_K | 1 | 66.9735 +/- 1.5963 |
| q1_0   | q1_0 | 0 | 27.0426 +/- 1.5076 |
| q1_0   | q1_0 | 1 | 43.0380 +/- 1.6806 |
| rand   | rand |   | 25 |

<details><summary>example command</summary>

```
$ result/bin/llama-perplexity -m models/gemma-3-4b-pt-q4_0.gguf -bf ../hf/validation-datasets-for-llama.cpp/arc-combined-validation.bin --multiple-choice -ctk q4_0 -ctv q1_0 -ngl 99 -nkvo -fa on -np 5
```

</details> 

#### Magidonia 24b v4.3 Q5_K_M
| k    | v    | rot | score | kvcache size |
|------|------|---|-------|----|
| f16  | f16  | 0 | 72.1519 +/- 1.5215 | 1040.00 MiB
| q8_0 | q8_0 | 1 | 71.6916 +/- 1.5291 | 552.50 MiB
| q4_0 | q4_0 | 1 | 71.5765 +/- 1.5310 | 292.50 MiB
| q4_0 | q1_0 | 1 | 65.1323 +/- 1.6175 | 182.81 MiB
| rand | rand |   | 25 | |

#### Bonsai 8B q1_0
Nice 1gig file.
| k    | v    | rot | score | kvcache size |
|------|------|---|-------|----|
| f16  | f16  | 0 | 60.2992 +/- 1.6607 | 360.00 MiB
| q8_0 | q8_0 | 1 | 60.5293 +/- 1.6591 | 191.25 MiB
| q8_0 | q1_0 | 1 | 50.8631 +/- 1.6969 | 108.28 MiB
| q4_0 | q4_0 | 1 | 59.4937 +/- 1.6662 | 101.25 MiB
| q4_0 | q1_0 | 1 | 51.2083 +/- 1.6966 | 63.28 MiB
| iq4_nl | iq4_nl | 1 | 60.0690 +/- 1.6623 | 101.25 MiB
| rand | rand |   | 25 | |

## multiple choice - MMLU test
13943 tasks
(takes a while, might use the val set in the future)

#### gemma3 4b pt q4_0
| k | v | rot | score |
|---|---|-----|-------|
| f16  | f16  | 0 | 39.9914 +/- 0.4149 |
| q8_0 | q8_0 | 1 | 39.9771 +/- 0.4149 |
| q4_0 | q4_0 | 1 | 39.6543 +/- 0.4143 |
| q4_0 | q1_0 | 1 | 37.3306 +/- 0.4096 |
| iq4_nl | iq4_nl | 1 | 39.6328 +/- 0.4143 |
| q3_K | q2_K | 1 | 39.1666 +/- 0.4134 |
| rand | rand |   | 25 |

<details><summary>example command</summary>

```
$ result/bin/llama-perplexity -m models/gemma-3-4b-pt-q4_0.gguf -bf ../hf/validation-datasets-for-llama.cpp/mmlu-test.bin --multiple-choice -ctk q3_K -ctv q2_K -ngl 99 -nkvo -fa on
```

</details> 

#### Bonsai 8B q1_0
`-np 13` -> 6656
| k | v | rot | score | size |
|---|---|-----|-------|------|
| f16  | f16  | 0 | 34.1533 +/- 0.4016 | 936.00 MiB
| q8_0 | q8_0 | 1 | 34.1390 +/- 0.4016 | 497.25 MiB
| q4_0 | q4_0 | 1 | 34.0816 +/- 0.4014 | 263.25 MiB
| q4_0 | q1_0 | 1 | 32.5970 +/- 0.3970 | 164.53 MiB
| rand | rand |   | 25 |

## multiple choice - MMLU redux 2.0 ok+expert
5362 tasks
https://huggingface.co/datasets/Green-Sky/mmlu-redux-2.0-for-llama.cpp/blob/main/mmlu-redux-2-ok%2Bexpert.bin

#### gemma3 4b pt q4_0
| k | v | rot | score |
|---|---|-----|-------|
| f16  | f16  | 0 | 53.4709 +/- 0.6833
| q8_0 | q8_0 | 1 | 53.3771 +/- 0.6834
| q4_0 | q4_0 | 1 | 53.0206 +/- 0.6837
| q4_0 | q3_K | 1 | 52.6829 +/- 0.6839
| q4_0 | q2_K | 1 | 50.6004 +/- 0.6849
| q4_0 | q1_0 | 1 | 42.2889 +/- 0.6767
| q4_K | q4_K | 1 | 52.2139 +/- 0.6843
| q4_K | q3_K | 1 | 52.2702 +/- 0.6842
| q4_K | q2_K | 1 | 52.1388 +/- 0.6843
| iq4_nl| iq4_nl| 1 | 51.8574 +/- 0.6845
| iq4_nl| q3_K | 1 | 53.1332 +/- 0.6836
| iq4_nl| q2_K | 1 | 50.8443 +/- 0.6848
| iq4_xs| q4_0 | 1 | 53.0019 +/- 0.6837
| q3_K | q2_K | 1 | 48.3490 +/- 0.6846
| rand | rand |   | 25 |

#### gemma4 e2b it (basically 4b) q8_0
| k | v | rot | score |
|---|---|-----|-------|
| bf16   | bf16   | 0 | 59.4554 +/- 0.6706
| f16    | f16    | 0 | 59.6046 +/- 0.6702
| q8_0   | q8_0   | 1 | 59.5860 +/- 0.6702
| q8_0   | q4_0   | 1 | 59.1011 +/- 0.6715
| q4_0   | q8_0   | 1 | 58.9519 +/- 0.6719
| q4_0   | q4_0   | 1 | 59.4554 +/- 0.6706
| q4_0   | q1_0   | 1 | 41.9247 +/- 0.6739
| q4_K   | q4_K   | 1 | 59.2689 +/- 0.6710
| q4_K   | q3_K   | 1 | 58.8027 +/- 0.6722
| iq4_nl | iq4_nl | 1 | 58.9519 +/- 0.6719
| iq4_nl | q3_K   | 1 | 58.4110 +/- 0.6732
| q3_K   | q2_K   | 1 | 57.2921 +/- 0.6756
| rand | rand |   | 25 |

#### Bonsai 8B q1_0
| k | v | rot | score |
|---|---|-----|-------|
| f16  | f16  | 0 | 60.1641 +/- 0.6686
| q8_0 | q8_0 | 1 | 60.2574 +/- 0.6684
| q4_0 | q4_0 | 1 | 60.0895 +/- 0.6688
| q4_0 | q1_0 | 1 | 46.8109 +/- 0.6815
| rand | rand |   | 25 |

#### Bonsai 4B q1_0
| k | v | rot | score |
|---|---|-----|-------|
| f16  | f16  | 0 | 52.5550 +/- 0.6820
| q8_0 | q8_0 | 1 | 52.3685 +/- 0.6821
| q4_0 | q4_0 | 0 | 50.8765 +/- 0.6828
| q4_0 | q4_0 | 1 | 51.4174 +/- 0.6826
| q4_0 | q1_0 | 1 | 39.0712 +/- 0.6664
| rand | rand |   | 25

#### Bonsai 27B q1_0
They claim higher kv qant resistance, specifically for this model.
| k | v | rot | score |
|---|---|-----|-------|
| f16  | f16  | 0 | 67.3816 +/- 0.6403
| q8_0 | q8_0 | 0 | 67.3443 +/- 0.6405
| q8_0 | q8_0 | 1 | 67.3070 +/- 0.6407
| q5_0 | q5_0 | 1 | 67.3256 +/- 0.6406
| q4_0 | q4_0 | 0 | 67.4562 +/- 0.6399
| q4_0 | q4_0 | 1 | 67.1764 +/- 0.6413
| rand | rand |   | 25

## kv cache sizes

### gemma3 4b pt q4_0 2k context
K and V sizes behave the same, so the size corresponds to only 1 of 2 contributors of the kv cache.
| type | size for context size 2048 (base + swa) |
|------|------|
| f16  | 20.00 MiB + 116.00 MiB |
| q8_0 | 10.62 MiB + 61.62 MiB |
| q5_0 | 6.88 MiB + 39.88 MiB |
| q4_0 | 5.62 MiB + 32.62 MiB |
| q4_K | 5.62 MiB + 32.62 MiB |
| iq4_nl | 5.62 MiB + 32.62 MiB |
| q3_K | 4.30 MiB + 24.92 MiB |
| q2_K | 3.28 MiB + 19.03 MiB |
| tq1_0 | 2.11 MiB + 12.23 MiB |
| q1_0 | 1.41 MiB + 8.16 MiB |

---

> [!NOTE]
> Important to note is that the model's head embedding dimension needs to be a multiple of the desired quant block size. For example llama2 7b has 128, so k quants with a block size of 256 wont work there.
