### PR TITLE
Add GCN architecture detection fix for MoltenVK (AMD eGPU on macOS)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -292,6 +292,13 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
         }
 
         if (!amd_shader_core_properties || !integer_dot_product || !subgroup_size_control) {
+            // VK_AMD_shader_core_properties is not available in MoltenVK on macOS.
+            // AMD GCN GPUs (e.g. Vega 56/64 via eGPU) use 64-wide wavefronts but
+            // will be misidentified as OTHER (32-wide) without this fix.
+            if (!amd_shader_core_properties && props.vendorID == VK_VENDOR_ID_AMD) {
+                GGML_LOG_DEBUG("ggml_vulkan: VK_AMD_shader_core_properties unavailable (MoltenVK?), assuming AMD_GCN for %s\n", props.deviceName.data());
+                return vk_device_architecture::AMD_GCN;
+            }
             return vk_device_architecture::OTHER;
         }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -292,14 +292,30 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
         }
 
         if (!amd_shader_core_properties || !integer_dot_product || !subgroup_size_control) {
-            // VK_AMD_shader_core_properties is not available in MoltenVK on macOS.
-            // AMD GCN GPUs (e.g. Vega 56/64 via eGPU) use 64-wide wavefronts but
-            // will be misidentified as OTHER (32-wide) without this fix.
-            if (!amd_shader_core_properties && props.vendorID == VK_VENDOR_ID_AMD) {
-                GGML_LOG_DEBUG("ggml_vulkan: VK_AMD_shader_core_properties unavailable (MoltenVK?), assuming AMD_GCN for %s\n", props.deviceName.data());
-                return vk_device_architecture::AMD_GCN;
+            // Not all extensions available — e.g. MoltenVK on macOS never exposes
+            // VK_AMD_shader_core_properties.  Use subgroup size control (if present)
+            // to distinguish GCN (min=max=64) from RDNA (min=32, max=64).
+            if (subgroup_size_control) {
+                vk::PhysicalDeviceProperties2 props2;
+                vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_size_control_props;
+                props2.pNext = &subgroup_size_control_props;
+                device.getProperties2(&props2);
+
+                if (subgroup_size_control_props.maxSubgroupSize == 64 && subgroup_size_control_props.minSubgroupSize == 64) {
+                    GGML_LOG_DEBUG("ggml_vulkan: Detected AMD GCN (min=max=64) for %s\n", props.deviceName.data());
+                    return vk_device_architecture::AMD_GCN;
+                }
+                if (subgroup_size_control_props.maxSubgroupSize == 64 && subgroup_size_control_props.minSubgroupSize == 32) {
+                    // RDNA, but cannot distinguish RDNA1/2/3 without VK_AMD_shader_core_properties
+                    GGML_LOG_DEBUG("ggml_vulkan: Detected AMD RDNA (min=32, max=64) for %s\n", props.deviceName.data());
+                    return vk_device_architecture::AMD_RDNA2;
+                }
+                // Subgroup sizes don't match any known AMD pattern
+                return vk_device_architecture::OTHER;
             }
-            return vk_device_architecture::OTHER;
+            // No subgroup size control — conservatively assume GCN (64-wide wavefronts)
+            GGML_LOG_DEBUG("ggml_vulkan: AMD GPU without extension support, assuming GCN for %s\n", props.deviceName.data());
+            return vk_device_architecture::AMD_GCN;
         }
 
         vk::PhysicalDeviceProperties2 props2;


### PR DESCRIPTION
## Overview

AMD GPUs on macOS via MoltenVK (e.g. Vega 56/64 like Blackmagic eGPU Pro) don't expose `VK_AMD_shader_core_properties`. Without it, `get_device_architecture()` returns `OTHER` and picks 32-wide subgroups. GCN hardware needs 64-wide wavefronts. This is not a performance issue - the attention kernels produce garbage output like infinite <unused> token loops.

Fix: when the extension is missing but `vendorID` is `VK_VENDOR_ID_AMD`, fall back to `AMD_GCN`. RDNA/RDNA2 on native Vulkan always has this extension, so they're not affected.

Tested on macOS 14 and 15, MoltenVK 1.4.1, Mac Mini 2018 + Vega 56 eGPU (Thunderbolt 3). Model runs correctly with the patch (~14 t/s prompt evaluation, ~9.2 t/s generation).

## Additional information

MoltenVK not supporting `VK_AMD_shader_core_properties` is a known upstream limitation, not a llama.cpp issue.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used Claude to research the root cause (wavefront width mismatch). The code fix and all testing is my own work.