### PR TITLE
 kv-cache : fix crash in state save/restore

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1982,6 +1982,9 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
         const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
 
         auto * k = layer.k_stream[cr.strm];
+        if (!k || !k->data) {
+            continue;
+        }
 
         // Write key type
         const int32_t k_type_i = (int32_t) k->type;
@@ -2006,7 +2009,7 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
             const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
 
             auto * v = layer.v_stream[cr.strm];
-            if (!v) {
+            if (!v || !v->data) {
                 continue;
             }
 
@@ -2035,7 +2038,7 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
             const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
 
             auto * v = layer.v_stream[cr.strm];
-            if (!v) {
+            if (!v || !v->data) {
                 continue;
             }
 
@@ -2214,6 +2217,9 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
         const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
 
         auto * k = layer.k_stream[strm];
+        if (!k || !k->data) {
+            continue;
+        }
 
         // Read type of key
         int32_t k_type_i_ref;
@@ -2255,7 +2261,7 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
             const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
 
             auto * v = layer.v_stream[strm];
-            if (!v) {
+            if (!v || !v->data) {
                 continue;
             }
 
@@ -2299,7 +2305,7 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
             const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
 
             auto * v = layer.v_stream[strm];
-            if (!v) {
+            if (!v || !v->data) {
                 continue;
             }
 


### PR DESCRIPTION
> **Status (2026-07-12): draft, superseded. Do not merge.**
>
> The guards described below stop the assert, but they silently omit one layer's K and V from the saved state. Measured on current master: exactly 151,576 bytes missing, which is one layer's K plus V. The root cause is an uninitialised view after a Vulkan buffer split (`suballocation_block_size`, default 1 GiB), and it should be fixed in the allocator.
>
> Full reproduction, instrumentation and measurements: https://github.com/ggml-org/llama.cpp/pull/21576#issuecomment-4950623433
>
> Kept open as a tracker until a root fix lands (@Yoshi4470's `99655d5` or an equivalent). See also #23737 and #19839.

---

K and V tensors in `layer.k_stream`/`v_stream` can have `tensor->data == NULL` if the tensor object exists but has no GPU memory allocated. The existing V loops guarded for `!v` but not `!v->data`, and the K loops had no guard at all, causing `GGML_ASSERT(tensor->data != NULL)` in `ggml_backend_tensor_get` during cache state save/restore.

Add `!tensor->data` null guards matching the existing pattern for both K and V tensors in `state_write_data` and `state_read_data`.

## Overview

Related to #21468

I ran into this running Gemma 4 26B-A4B with cache reuse and multiple slots. The server would crash with SIGABRT every few minutes. Both write and read paths in `llama_kv_cache` iterate all layers but some K/V tensors have `data == NULL`. The write path for V already had `if (!v) continue` but K had no guard. Both lacked a check for `tensor->data`.

## Additional information

Tested on Gemma 4 26B-A4B, Vulkan backend, 4 slots, cache reuse enabled. 20/20 multi-turn requests stable, previously crashed every 4-5 min.

No impact on models without iSWA since all tensors are fully allocated and the guards never trigger.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted in finding the root cause and setting up local testing.