### PR TITLE
webui: add "Send message on Enter" setting

### DIFF
--- a/tools/server/public/index.html
+++ b/tools/server/public/index.html
@@ -18,7 +18,7 @@
 		<div style="display: contents">
 			<script>
 				{
-					__sveltekit_6n4hpv = {
+					__sveltekit_1ao0o9h = {
 						base: new URL('.', location).pathname.slice(0, -1)
 					};
 

--- a/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
@@ -294,11 +294,16 @@
 		}
 
 		if (event.key === KeyboardKey.ENTER && !event.shiftKey && !isIMEComposing(event)) {
-			event.preventDefault();
+			const isModifier = event.ctrlKey || event.metaKey;
+			const sendOnEnter = currentConfig.sendOnEnter !== false;
 
-			if (!canSubmit || disabled || isLoading || hasLoadingAttachments) return;
+			if (sendOnEnter || isModifier) {
+				event.preventDefault();
 
-			onSubmit?.();
+				if (!canSubmit || disabled || isLoading || hasLoadingAttachments) return;
+
+				onSubmit?.();
+			}
 		}
 	}
 

--- a/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatFormHelperText.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatFormHelperText.svelte
@@ -1,17 +1,30 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
+	import { config } from '$lib/stores/settings.svelte';
+
 	interface Props {
 		class?: string;
 		show?: boolean;
 	}
 
 	let { class: className = '', show = true }: Props = $props();
+
+	let sendOnEnter = $derived(config().sendOnEnter !== false);
+	let modKey = browser && /Mac|iPhone|iPad|iPod/.test(navigator.platform) ? 'Cmd' : 'Ctrl';
 </script>
 
 {#if show}
 	<div class="mt-6 items-center justify-center {className} hidden md:flex">
-		<p class="text-xs text-muted-foreground">
-			Press <kbd class="rounded bg-muted px-1 py-0.5 font-mono text-xs">Enter</kbd> to send,
-			<kbd class="rounded bg-muted px-1 py-0.5 font-mono text-xs">Shift + Enter</kbd> for new line
-		</p>
+		{#if sendOnEnter}
+			<p class="text-xs text-muted-foreground">
+				Press <kbd class="rounded bg-muted px-1 py-0.5 font-mono text-xs">Enter</kbd> to send,
+				<kbd class="rounded bg-muted px-1 py-0.5 font-mono text-xs">Shift + Enter</kbd> for new line
+			</p>
+		{:else}
+			<p class="text-xs text-muted-foreground">
+				Press <kbd class="rounded bg-muted px-1 py-0.5 font-mono text-xs">{modKey} + Enter</kbd> to send,
+				<kbd class="rounded bg-muted px-1 py-0.5 font-mono text-xs">Enter</kbd> for new line
+			</p>
+		{/if}
 	</div>
 {/if}

--- a/tools/server/webui/src/lib/components/app/chat/ChatSettings/ChatSettings.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatSettings/ChatSettings.svelte
@@ -65,6 +65,11 @@
 					type: SettingsFieldType.INPUT
 				},
 				{
+					key: SETTINGS_KEYS.SEND_ON_ENTER,
+					label: 'Send message on Enter',
+					type: SettingsFieldType.CHECKBOX
+				},
+				{
 					key: SETTINGS_KEYS.COPY_TEXT_ATTACHMENTS_AS_PLAIN_TEXT,
 					label: 'Copy text attachments as plain text',
 					type: SettingsFieldType.CHECKBOX

--- a/tools/server/webui/src/lib/constants/settings-config.ts
+++ b/tools/server/webui/src/lib/constants/settings-config.ts
@@ -22,6 +22,7 @@ export const SETTING_CONFIG_DEFAULT: Record<string, string | number | boolean | 
 	renderUserContentAsMarkdown: false,
 	alwaysShowSidebarOnDesktop: false,
 	autoShowSidebarOnNewChat: true,
+	sendOnEnter: true,
 	autoMicOnEmpty: false,
 	fullHeightCodeBlocks: false,
 	showRawModelNames: false,
@@ -126,6 +127,8 @@ export const SETTING_CONFIG_INFO: Record<string, string> = {
 		'Always keep the sidebar visible on desktop instead of auto-hiding it.',
 	autoShowSidebarOnNewChat:
 		'Automatically show sidebar when starting a new chat. Disable to keep the sidebar hidden until you click on it.',
+	sendOnEnter:
+		'Use Enter to send messages and Shift + Enter for new lines. When disabled, Ctrl/Cmd + Enter sends instead.',
 	autoMicOnEmpty:
 		'Automatically show microphone button instead of send button when textarea is empty for models with audio modality support.',
 	fullHeightCodeBlocks:

--- a/tools/server/webui/src/lib/constants/settings-config.ts
+++ b/tools/server/webui/src/lib/constants/settings-config.ts
@@ -128,7 +128,7 @@ export const SETTING_CONFIG_INFO: Record<string, string> = {
 	autoShowSidebarOnNewChat:
 		'Automatically show sidebar when starting a new chat. Disable to keep the sidebar hidden until you click on it.',
 	sendOnEnter:
-		'Use Enter to send messages and Shift + Enter for new lines. When disabled, Ctrl/Cmd + Enter sends instead.',
+		'Use Enter to send messages and Shift + Enter for new lines. When disabled, use Ctrl/Cmd + Enter.',
 	autoMicOnEmpty:
 		'Automatically show microphone button instead of send button when textarea is empty for models with audio modality support.',
 	fullHeightCodeBlocks:

--- a/tools/server/webui/src/lib/constants/settings-keys.ts
+++ b/tools/server/webui/src/lib/constants/settings-keys.ts
@@ -11,6 +11,7 @@ export const SETTINGS_KEYS = {
 	SYSTEM_MESSAGE: 'systemMessage',
 	PASTE_LONG_TEXT_TO_FILE_LEN: 'pasteLongTextToFileLen',
 	COPY_TEXT_ATTACHMENTS_AS_PLAIN_TEXT: 'copyTextAttachmentsAsPlainText',
+	SEND_ON_ENTER: 'sendOnEnter',
 	ENABLE_CONTINUE_GENERATION: 'enableContinueGeneration',
 	PDF_AS_IMAGE: 'pdfAsImage',
 	ASK_FOR_TITLE_CONFIRMATION: 'askForTitleConfirmation',

--- a/tools/server/webui/src/lib/services/parameter-sync.service.ts
+++ b/tools/server/webui/src/lib/services/parameter-sync.service.ts
@@ -239,6 +239,12 @@ export const SYNCABLE_PARAMETERS: SyncableParameter[] = [
 		serverKey: 'excludeReasoningFromContext',
 		type: SyncableParameterType.BOOLEAN,
 		canSync: true
+	},
+	{
+		key: 'sendOnEnter',
+		serverKey: 'sendOnEnter',
+		type: SyncableParameterType.BOOLEAN,
+		canSync: true
 	}
 ];
 

--- a/tools/server/webui/src/lib/stores/settings.svelte.ts
+++ b/tools/server/webui/src/lib/stores/settings.svelte.ts
@@ -34,10 +34,10 @@
 import { browser } from '$app/environment';
 import {
 	CONFIG_LOCALSTORAGE_KEY,
-	DEFAULT_MOBILE_BREAKPOINT,
 	SETTING_CONFIG_DEFAULT,
 	USER_OVERRIDES_LOCALSTORAGE_KEY
 } from '$lib/constants';
+import { IsMobile } from '$lib/hooks/is-mobile.svelte';
 import { ParameterSyncService } from '$lib/services/parameter-sync.service';
 import { serverStore } from '$lib/stores/server.svelte';
 import {
@@ -125,10 +125,7 @@ class SettingsStore {
 
 			// Default sendOnEnter to false on mobile when the user has no saved preference
 			if (!('sendOnEnter' in savedVal)) {
-				const isMobile = window.matchMedia(
-					`(max-width: ${DEFAULT_MOBILE_BREAKPOINT - 1}px)`
-				).matches;
-				if (isMobile) {
+				if (new IsMobile().current) {
 					this.config.sendOnEnter = false;
 				}
 			}

--- a/tools/server/webui/src/lib/stores/settings.svelte.ts
+++ b/tools/server/webui/src/lib/stores/settings.svelte.ts
@@ -34,6 +34,7 @@
 import { browser } from '$app/environment';
 import {
 	CONFIG_LOCALSTORAGE_KEY,
+	DEFAULT_MOBILE_BREAKPOINT,
 	SETTING_CONFIG_DEFAULT,
 	USER_OVERRIDES_LOCALSTORAGE_KEY
 } from '$lib/constants';
@@ -121,6 +122,16 @@ class SettingsStore {
 				...SETTING_CONFIG_DEFAULT,
 				...savedVal
 			};
+
+			// Default sendOnEnter to false on mobile when the user has no saved preference
+			if (!('sendOnEnter' in savedVal)) {
+				const isMobile = window.matchMedia(
+					`(max-width: ${DEFAULT_MOBILE_BREAKPOINT - 1}px)`
+				).matches;
+				if (isMobile) {
+					this.config.sendOnEnter = false;
+				}
+			}
 
 			// Load user overrides
 			const savedOverrides = JSON.parse(


### PR DESCRIPTION
## Overview

In our current webui, pressing Enter sends a message and pressing Shift+Enter inserts a newline on all platforms. This makes it impossible to format messages on mobile, since touch keyboards don't include a Shift key. A common solution apps tend to use for this is to hardcode Enter to send on web, and Enter for newline on mobile.

**This PR makes "Send message on Enter" behavior a user setting.** 

1. When enabled, the old Enter to send behavior is used. (set to default for web)
2. When disabled, Enter inserts a newline and Ctrl/Cmd+Enter sends a message. (set to default for mobile)

The chat form text helper will also detect Mac/PC in order to show the applicable Ctrl/Cmd modifier key in its text.

## Additional information

This behavior was also asked in feature request #16839.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, mainly for automated review and Mac Cmd detection as I own no Apple devices to test.


