### PR TITLE
server: hide embedding/rerank models from chat model selector

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1004,15 +1004,29 @@ void server_models_routes::init_routes() {
                 status["exit_code"] = meta.exit_code;
                 status["failed"]    = true;
             }
+            // Determine capabilities from preset flags
+            json capabilities = json::array();
+            std::string tmp_val;
+            if (meta.preset.get_option("LLAMA_ARG_EMBEDDINGS", tmp_val) ||
+                    meta.preset.get_option("LLAMA_ARG_RERANKING", tmp_val)) {
+                capabilities.push_back("embedding");
+                std::string rerank_val;
+                if (meta.preset.get_option("LLAMA_ARG_RERANKING", rerank_val)) {
+                    capabilities.push_back("rerank");
+                }
+            } else {
+                capabilities.push_back("completion");
+            }
+
             models_json.push_back(json {
-                {"id",       meta.name},
-                {"aliases",  meta.aliases},
-                {"tags",     meta.tags},
-                {"object",   "model"},    // for OAI-compat
-                {"owned_by", "llamacpp"}, // for OAI-compat
-                {"created",  t},          // for OAI-compat
-                {"status",   status},
-                // TODO: add other fields, may require reading GGUF metadata
+                {"id",           meta.name},
+                {"aliases",      meta.aliases},
+                {"tags",         meta.tags},
+                {"object",       "model"},    // for OAI-compat
+                {"owned_by",     "llamacpp"}, // for OAI-compat
+                {"created",      t},          // for OAI-compat
+                {"status",       status},
+                {"capabilities", capabilities},
             });
         }
         res_ok(res, {

--- a/tools/server/tests/unit/test_model_capabilities.py
+++ b/tools/server/tests/unit/test_model_capabilities.py
@@ -1,0 +1,203 @@
+"""
+Tests for model capabilities in the /models endpoint response.
+
+Verifies that:
+- Regular (chat/completion) models get capabilities: ["completion"]
+- Embedding models (--embedding flag) get capabilities: ["embedding"]
+- Reranking models (--reranking flag) get capabilities: ["embedding", "rerank"]
+- Capabilities field is always present in /models response
+- Single-model and router-mode endpoints both return capabilities
+"""
+import pytest
+from utils import *
+
+
+server: ServerProcess
+
+
+# ==============================================================================
+# Single-model mode tests
+# ==============================================================================
+
+
+class TestSingleModelCapabilities:
+    """Test capabilities in /models response for single-model server mode."""
+
+    @pytest.fixture(autouse=True)
+    def create_server(self):
+        global server
+
+    def test_completion_model_has_completion_capability(self):
+        """A standard chat/completion model should report capabilities: ["completion"]."""
+        global server
+        server = ServerPreset.tinyllama2()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        assert len(res.body["data"]) == 1
+        model = res.body["data"][0]
+        assert "capabilities" in model or "capabilities" in res.body.get("models", [{}])[0], \
+            "capabilities field must be present in /models response"
+        # Check in the appropriate location
+        if "models" in res.body and len(res.body["models"]) > 0:
+            caps = res.body["models"][0].get("capabilities", [])
+        else:
+            caps = model.get("capabilities", [])
+        assert "completion" in caps, \
+            f"Completion model should have 'completion' capability, got: {caps}"
+
+    def test_embedding_model_has_embedding_capability(self):
+        """A model started with --embedding should report capabilities: ["embedding"]."""
+        global server
+        server = ServerPreset.bert_bge_small()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        assert len(res.body["data"]) == 1
+        if "models" in res.body and len(res.body["models"]) > 0:
+            caps = res.body["models"][0].get("capabilities", [])
+        else:
+            caps = res.body["data"][0].get("capabilities", [])
+        assert "embedding" in caps, \
+            f"Embedding model should have 'embedding' capability, got: {caps}"
+        assert "completion" not in caps, \
+            f"Embedding model should NOT have 'completion' capability, got: {caps}"
+
+    def test_reranking_model_has_rerank_capability(self):
+        """A model started with --reranking should report capabilities including 'rerank'."""
+        global server
+        server = ServerPreset.jina_reranker_tiny()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        assert len(res.body["data"]) == 1
+        if "models" in res.body and len(res.body["models"]) > 0:
+            caps = res.body["models"][0].get("capabilities", [])
+        else:
+            caps = res.body["data"][0].get("capabilities", [])
+        assert "rerank" in caps, \
+            f"Reranking model should have 'rerank' capability, got: {caps}"
+        assert "embedding" in caps, \
+            f"Reranking model should also have 'embedding' capability, got: {caps}"
+        assert "completion" not in caps, \
+            f"Reranking model should NOT have 'completion' capability, got: {caps}"
+
+    def test_capabilities_field_is_array(self):
+        """The capabilities field should always be a JSON array."""
+        global server
+        server = ServerPreset.tinyllama2()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        if "models" in res.body and len(res.body["models"]) > 0:
+            caps = res.body["models"][0].get("capabilities")
+        else:
+            caps = res.body["data"][0].get("capabilities")
+        assert isinstance(caps, list), \
+            f"capabilities should be a list, got: {type(caps)}"
+
+    def test_capabilities_contains_only_strings(self):
+        """All entries in capabilities array should be strings."""
+        global server
+        server = ServerPreset.tinyllama2()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        if "models" in res.body and len(res.body["models"]) > 0:
+            caps = res.body["models"][0].get("capabilities", [])
+        else:
+            caps = res.body["data"][0].get("capabilities", [])
+        for cap in caps:
+            assert isinstance(cap, str), \
+                f"Each capability should be a string, got: {type(cap)} ({cap})"
+
+
+# ==============================================================================
+# OAI compatibility tests
+# ==============================================================================
+
+
+class TestOAICompatibility:
+    """Test that /v1/models endpoint also returns capabilities."""
+
+    @pytest.fixture(autouse=True)
+    def create_server(self):
+        global server
+
+    def test_v1_models_completion(self):
+        """The /v1/models endpoint should also include capabilities for completion models."""
+        global server
+        server = ServerPreset.tinyllama2()
+        server.start()
+        res = server.make_request("GET", "/v1/models")
+        assert res.status_code == 200
+        assert "data" in res.body
+        assert len(res.body["data"]) >= 1
+
+    def test_v1_models_embedding(self):
+        """The /v1/models endpoint should also include capabilities for embedding models."""
+        global server
+        server = ServerPreset.bert_bge_small()
+        server.start()
+        res = server.make_request("GET", "/v1/models")
+        assert res.status_code == 200
+        assert "data" in res.body
+        assert len(res.body["data"]) >= 1
+
+
+# ==============================================================================
+# Response structure tests
+# ==============================================================================
+
+
+class TestModelsResponseStructure:
+    """Test the overall structure of /models response with capabilities."""
+
+    @pytest.fixture(autouse=True)
+    def create_server(self):
+        global server
+
+    def test_completion_model_does_not_have_embedding(self):
+        """A standard completion model should not list embedding in its capabilities."""
+        global server
+        server = ServerPreset.tinyllama2()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        if "models" in res.body and len(res.body["models"]) > 0:
+            caps = res.body["models"][0].get("capabilities", [])
+        else:
+            caps = res.body["data"][0].get("capabilities", [])
+        assert "embedding" not in caps, \
+            f"Completion model should NOT have 'embedding', got: {caps}"
+        assert "rerank" not in caps, \
+            f"Completion model should NOT have 'rerank', got: {caps}"
+
+    def test_embedding_model_does_not_have_rerank(self):
+        """An embedding-only model (no --reranking) should not have 'rerank' capability."""
+        global server
+        server = ServerPreset.bert_bge_small()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        if "models" in res.body and len(res.body["models"]) > 0:
+            caps = res.body["models"][0].get("capabilities", [])
+        else:
+            caps = res.body["data"][0].get("capabilities", [])
+        assert "rerank" not in caps, \
+            f"Embedding-only model should NOT have 'rerank', got: {caps}"
+
+    def test_model_id_and_capabilities_coexist(self):
+        """Model response should include both id and capabilities fields."""
+        global server
+        server = ServerPreset.tinyllama2()
+        server.start()
+        res = server.make_request("GET", "/models")
+        assert res.status_code == 200
+        model = res.body["data"][0]
+        assert "id" in model, "Model response must include 'id' field"
+        # capabilities may be in data[0] or models[0] depending on endpoint
+        has_caps = "capabilities" in model
+        if "models" in res.body and len(res.body["models"]) > 0:
+            has_caps = has_caps or "capabilities" in res.body["models"][0]
+        assert has_caps, "Model response must include 'capabilities' field"

--- a/tools/server/webui/src/lib/components/app/models/ModelsSelector.svelte
+++ b/tools/server/webui/src/lib/components/app/models/ModelsSelector.svelte
@@ -45,8 +45,16 @@
 	let options = $derived(
 		modelOptions().filter((option) => {
 			const modelProps = modelsStore.getModelProps(option.model);
+			if (modelProps?.webui === false) return false;
 
-			return modelProps?.webui !== false;
+			// Hide embedding/rerank-only models from chat selector
+			// If capabilities are present, require "completion" capability
+			// If capabilities are absent (legacy), show the model (backwards compat)
+			if (option.capabilities.length > 0 && !option.capabilities.includes('completion')) {
+				return false;
+			}
+
+			return true;
 		})
 	);
 	let loading = $derived(modelsLoading());

--- a/tools/server/webui/tests/unit/model-capabilities-filter.test.ts
+++ b/tools/server/webui/tests/unit/model-capabilities-filter.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from 'vitest';
+import type { ModelOption } from '$lib/types/models';
+
+/**
+ * Tests for capability-based model filtering in the chat model selector.
+ *
+ * The ModelsSelector component filters models based on their `capabilities` array:
+ * - Models with capabilities that include "completion" are shown
+ * - Models with capabilities that do NOT include "completion" are hidden
+ * - Models with empty capabilities (legacy/backwards compat) are shown
+ *
+ * This mirrors the filtering logic in ModelsSelector.svelte (lines 45-58).
+ */
+
+function makeModel(overrides: Partial<ModelOption> & { id: string; model: string }): ModelOption {
+	return {
+		name: overrides.model.split('/').pop() || overrides.model,
+		capabilities: [],
+		...overrides,
+	};
+}
+
+/**
+ * Pure implementation of the capability filter from ModelsSelector.svelte.
+ * We test this logic in isolation since Svelte component tests require
+ * the browser environment and full store setup.
+ */
+function filterByCapabilities(
+	options: ModelOption[],
+	getModelProps?: (model: string) => { webui?: boolean } | undefined
+): ModelOption[] {
+	return options.filter((option) => {
+		const modelProps = getModelProps?.(option.model);
+		if (modelProps?.webui === false) return false;
+
+		// Hide embedding/rerank-only models from chat selector
+		// If capabilities are present, require "completion" capability
+		// If capabilities are absent (legacy), show the model (backwards compat)
+		if (option.capabilities.length > 0 && !option.capabilities.includes('completion')) {
+			return false;
+		}
+
+		return true;
+	});
+}
+
+describe('model capability filtering', () => {
+	describe('happy paths', () => {
+		it('shows a model with completion capability', () => {
+			const models = [
+				makeModel({ id: 'chat-model', model: 'org/chat-model', capabilities: ['completion'] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('chat-model');
+		});
+
+		it('hides a model with only embedding capability', () => {
+			const models = [
+				makeModel({ id: 'embed-model', model: 'org/embed-model', capabilities: ['embedding'] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(0);
+		});
+
+		it('hides a model with embedding and rerank capabilities (no completion)', () => {
+			const models = [
+				makeModel({
+					id: 'rerank-model',
+					model: 'org/rerank-model',
+					capabilities: ['embedding', 'rerank'],
+				}),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(0);
+		});
+
+		it('shows a model with empty capabilities (legacy/backwards compat)', () => {
+			const models = [
+				makeModel({ id: 'legacy-model', model: 'org/legacy-model', capabilities: [] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('legacy-model');
+		});
+
+		it('filters a mixed list of models correctly', () => {
+			const models = [
+				makeModel({ id: 'chat1', model: 'org/llama-3', capabilities: ['completion'] }),
+				makeModel({ id: 'embed1', model: 'org/bge-small', capabilities: ['embedding'] }),
+				makeModel({ id: 'chat2', model: 'org/gemma-3', capabilities: ['completion'] }),
+				makeModel({
+					id: 'rerank1',
+					model: 'org/jina-reranker',
+					capabilities: ['embedding', 'rerank'],
+				}),
+				makeModel({ id: 'legacy1', model: 'org/old-model', capabilities: [] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(3);
+			expect(result.map((m) => m.id)).toEqual(['chat1', 'chat2', 'legacy1']);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('returns empty array when given empty input', () => {
+			const result = filterByCapabilities([]);
+			expect(result).toHaveLength(0);
+		});
+
+		it('returns empty array when all models are embedding-only', () => {
+			const models = [
+				makeModel({ id: 'embed1', model: 'org/embed-1', capabilities: ['embedding'] }),
+				makeModel({ id: 'embed2', model: 'org/embed-2', capabilities: ['embedding'] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(0);
+		});
+
+		it('shows model when capabilities is empty (no capabilities from server)', () => {
+			const models = [
+				makeModel({ id: 'no-cap', model: 'org/model', capabilities: [] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(1);
+		});
+
+		it('hides model with only rerank capability (no embedding)', () => {
+			// Edge case: rerank without embedding listed
+			const models = [
+				makeModel({ id: 'rerank-only', model: 'org/reranker', capabilities: ['rerank'] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(0);
+		});
+
+		it('shows model with completion among other capabilities', () => {
+			// Future-proofing: model has multiple capabilities including completion
+			const models = [
+				makeModel({
+					id: 'multi',
+					model: 'org/multi-model',
+					capabilities: ['completion', 'embedding'],
+				}),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('multi');
+		});
+
+		it('handles unknown capability strings gracefully', () => {
+			// Model with unrecognized capability but no "completion"
+			const models = [
+				makeModel({
+					id: 'unknown-cap',
+					model: 'org/experimental',
+					capabilities: ['transcription'],
+				}),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(0);
+		});
+
+		it('treats capabilities check as case-sensitive', () => {
+			// "Completion" (capitalized) should NOT match "completion"
+			const models = [
+				makeModel({
+					id: 'wrong-case',
+					model: 'org/model',
+					capabilities: ['Completion'],
+				}),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe('webui property interaction', () => {
+		it('hides model when webui is false even with completion capability', () => {
+			const models = [
+				makeModel({ id: 'hidden', model: 'org/hidden', capabilities: ['completion'] }),
+			];
+			const getProps = () => ({ webui: false });
+			const result = filterByCapabilities(models, getProps);
+			expect(result).toHaveLength(0);
+		});
+
+		it('shows model when webui is true and has completion capability', () => {
+			const models = [
+				makeModel({ id: 'visible', model: 'org/visible', capabilities: ['completion'] }),
+			];
+			const getProps = () => ({ webui: true });
+			const result = filterByCapabilities(models, getProps);
+			expect(result).toHaveLength(1);
+		});
+
+		it('hides embedding model even when webui is not set', () => {
+			const models = [
+				makeModel({ id: 'embed', model: 'org/embed', capabilities: ['embedding'] }),
+			];
+			const getProps = () => undefined;
+			const result = filterByCapabilities(models, getProps);
+			expect(result).toHaveLength(0);
+		});
+
+		it('hides model with webui=false and no capabilities (webui takes precedence)', () => {
+			const models = [
+				makeModel({ id: 'no-webui', model: 'org/internal', capabilities: [] }),
+			];
+			const getProps = () => ({ webui: false });
+			const result = filterByCapabilities(models, getProps);
+			expect(result).toHaveLength(0);
+		});
+
+		it('applies both webui and capabilities filters together', () => {
+			const models = [
+				makeModel({ id: 'chat', model: 'org/chat', capabilities: ['completion'] }),
+				makeModel({ id: 'embed', model: 'org/embed', capabilities: ['embedding'] }),
+				makeModel({ id: 'hidden', model: 'org/hidden', capabilities: ['completion'] }),
+				makeModel({ id: 'legacy', model: 'org/legacy', capabilities: [] }),
+			];
+			const getProps = (model: string) => {
+				if (model === 'org/hidden') return { webui: false };
+				return undefined;
+			};
+			const result = filterByCapabilities(models, getProps);
+			expect(result).toHaveLength(2);
+			expect(result.map((m) => m.id)).toEqual(['chat', 'legacy']);
+		});
+	});
+
+	describe('capability parsing from API response', () => {
+		it('filters non-string values from raw capabilities', () => {
+			// The store filters capabilities with: rawCapabilities.filter(v => Boolean(v))
+			// Simulating what the store produces after filtering
+			const rawCapabilities: unknown[] = ['embedding', null, undefined, '', 0, false];
+			const filtered = rawCapabilities.filter(
+				(value: unknown): value is string => Boolean(value)
+			);
+			expect(filtered).toEqual(['embedding']);
+		});
+
+		it('produces empty capabilities when API returns no capabilities field', () => {
+			const details = undefined;
+			const rawCapabilities = Array.isArray(details) ? details : [];
+			expect(rawCapabilities).toEqual([]);
+		});
+
+		it('produces empty capabilities when API returns null capabilities', () => {
+			const details = { capabilities: null };
+			const rawCapabilities = Array.isArray(details.capabilities)
+				? details.capabilities
+				: [];
+			expect(rawCapabilities).toEqual([]);
+		});
+
+		it('correctly extracts capabilities when API returns valid array', () => {
+			const details = { capabilities: ['completion'] };
+			const rawCapabilities = Array.isArray(details.capabilities)
+				? details.capabilities
+				: [];
+			const capabilities = rawCapabilities.filter(
+				(value: unknown): value is string => Boolean(value)
+			);
+			expect(capabilities).toEqual(['completion']);
+		});
+
+		it('correctly extracts multiple capabilities', () => {
+			const details = { capabilities: ['embedding', 'rerank'] };
+			const rawCapabilities = Array.isArray(details.capabilities)
+				? details.capabilities
+				: [];
+			const capabilities = rawCapabilities.filter(
+				(value: unknown): value is string => Boolean(value)
+			);
+			expect(capabilities).toEqual(['embedding', 'rerank']);
+		});
+	});
+
+	describe('ordering preservation', () => {
+		it('preserves original order of models after filtering', () => {
+			const models = [
+				makeModel({ id: 'z-model', model: 'org/z-chat', capabilities: ['completion'] }),
+				makeModel({ id: 'embed', model: 'org/embed', capabilities: ['embedding'] }),
+				makeModel({ id: 'a-model', model: 'org/a-chat', capabilities: ['completion'] }),
+				makeModel({ id: 'rerank', model: 'org/rerank', capabilities: ['embedding', 'rerank'] }),
+				makeModel({ id: 'm-model', model: 'org/m-legacy', capabilities: [] }),
+			];
+			const result = filterByCapabilities(models);
+			expect(result.map((m) => m.id)).toEqual(['z-model', 'a-model', 'm-model']);
+		});
+	});
+
+	describe('single model remaining after filter', () => {
+		it('returns only the completion model when mixed with embedding models', () => {
+			const models = [
+				makeModel({ id: 'embed1', model: 'org/embed-1', capabilities: ['embedding'] }),
+				makeModel({ id: 'embed2', model: 'org/embed-2', capabilities: ['embedding'] }),
+				makeModel({ id: 'chat', model: 'org/chat', capabilities: ['completion'] }),
+				makeModel({
+					id: 'rerank',
+					model: 'org/reranker',
+					capabilities: ['embedding', 'rerank'],
+				}),
+			];
+			const result = filterByCapabilities(models);
+			expect(result).toHaveLength(1);
+			expect(result[0].id).toBe('chat');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #21545

In router mode (multi-model), the WebUI model selector shows all loaded models including embedding and reranking models. Users can select an embedding model for chat, which doesn't work.

- **Server-side (`server-models.cpp`)**: Add `capabilities` field to the router `/models` endpoint response. Capabilities are derived from preset flags (`--embedding` → `["embedding"]`, `--rerank` → `["embedding", "rerank"]`, otherwise → `["completion"]`).
- **Client-side (`ModelsSelector.svelte`)**: Filter models in the chat selector dropdown — only show models with `"completion"` capability or with no capabilities listed (backwards compatibility with older servers).

## Test plan

- [ ] **Router mode with mixed models**: Start server with one chat model and one embedding model (`--embedding` flag). Verify only the chat model appears in the WebUI dropdown. Verify `/models` returns correct capabilities for each.
- [ ] **Reranking model**: Add a model with `--rerank` flag. Verify it is hidden from the chat selector and has `capabilities: ["embedding", "rerank"]`.
- [ ] **Single model mode (regression)**: Start server with a single model. Verify model selector works as before.
- [ ] **Backwards compatibility**: Verify models with empty capabilities array are still shown (legacy server support).
- [ ] **All embedding models**: If all loaded models are embedding-only, the chat selector should be empty (no chat-capable models available).
- [ ] Run new unit tests: `tools/server/tests/unit/test_model_capabilities.py` and `tools/server/webui/tests/unit/model-capabilities-filter.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)