### PR TITLE
fix: support non-ASCII (Unicode) file paths on Windows

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -17,6 +17,7 @@
 #   define NOMINMAX
 #endif
 #include <windows.h>
+#include <shellapi.h>
 #endif
 
 #define JSON_ASSERT GGML_ASSERT
@@ -877,7 +878,50 @@ bool common_params_to_map(int argc, char ** argv, llama_example ex, std::map<com
     return true;
 }
 
+#ifdef _WIN32
+// On Windows, argv is encoded in the system's ANSI code page, which cannot
+// represent non-ASCII characters such as Cyrillic, CJK, etc.  Re-obtain the
+// command line as UTF-16 via CommandLineToArgvW and convert to UTF-8 so that
+// file paths with Unicode characters are handled correctly.
+struct utf8_argv {
+    std::vector<std::string> buf;
+    std::vector<char *>      ptrs;
+};
+
+static utf8_argv make_utf8_argv() {
+    utf8_argv out;
+    int wargc = 0;
+    LPWSTR * wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    if (!wargv) { return out; }
+
+    out.buf.reserve(wargc);
+    for (int i = 0; i < wargc; ++i) {
+        int n = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+                                    wargv[i], -1, nullptr, 0, nullptr, nullptr);
+        if (n <= 0) { out.buf.emplace_back(); continue; }
+        auto & s = out.buf.emplace_back();
+        s.resize(static_cast<size_t>(n - 1));
+        (void)WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1,
+                                  s.data(), n, nullptr, nullptr);
+    }
+    LocalFree(wargv);
+
+    out.ptrs.reserve(out.buf.size() + 1);
+    for (auto & s : out.buf) { out.ptrs.push_back(s.data()); }
+    out.ptrs.push_back(nullptr);
+    return out;
+}
+#endif
+
 bool common_params_parse(int argc, char ** argv, common_params & params, llama_example ex, void(*print_usage)(int, char **)) {
+#ifdef _WIN32
+    auto utf8 = make_utf8_argv();
+    if (!utf8.ptrs.empty()) {
+        argc = static_cast<int>(utf8.buf.size());
+        argv = utf8.ptrs.data();
+    }
+#endif
+
     auto ctx_arg = common_params_parser_init(params, ex, print_usage);
     const common_params params_org = ctx_arg.params; // the example can modify the default params
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -585,18 +585,15 @@ FILE * ggml_fopen(const char * fname, const char * mode) {
     // convert fname (UTF-8)
     wchar_t * wfname = ggml_mbstowcs(fname);
     if (wfname) {
-        // convert mode (ANSI)
-        wchar_t * wmode = GGML_MALLOC((strlen(mode) + 1) * sizeof(wchar_t));
-        wchar_t * wmode_p = wmode;
-        do {
-            *wmode_p++ = (wchar_t)*mode;
-        } while (*mode++);
-
-        // open file
-        file = _wfopen(wfname, wmode);
+        // convert mode (UTF-8)
+        wchar_t * wmode = ggml_mbstowcs(mode);
+        if (wmode) {
+            // open file
+            file = _wfopen(wfname, wmode);
+            GGML_FREE(wmode);
+        }
 
         GGML_FREE(wfname);
-        GGML_FREE(wmode);
     }
 
     return file;


### PR DESCRIPTION
Fixes #18571

Revives and combines the work from #16611 (by @kuguma, approved by @ggerganov) and #16589 (by @LunarTiger), both of which went stale.

## Problem

On Windows, `argv` strings are encoded in the system's ANSI code page, which cannot represent characters outside the current locale — Cyrillic, CJK, Arabic, etc. This causes model loading to fail with `gguf_init_from_file: failed to open GGUF file` when the path contains such characters (e.g. `D:\Загрузки\models\model.gguf`).

## Changes

### 1. `common/arg.cpp` — UTF-8 argv on Windows

Re-obtain the command line via `CommandLineToArgvW` and convert each argument from UTF-16 to UTF-8 at the entry point of `common_params_parse`. This ensures all file paths are correctly encoded before reaching any file I/O.

### 2. `ggml/src/ggml.c` — fix `ggml_fopen` mode conversion

The `mode` parameter (e.g. `"rb"`) was converted from `char*` to `wchar_t*` by a manual byte-by-byte cast, which is technically unsafe for multi-byte locales. Replaced with the existing `ggml_mbstowcs` helper, consistent with how `fname` is already converted.

## Test Plan

- [x] Place a `.gguf` model in a path with Cyrillic characters (e.g. `D:\Загрузки\`)
- [x] Load the model — should succeed instead of failing with "failed to open"
- [x] Paths with only ASCII characters work as before (no behavior change)