### PR TITLE
fix: free ctx_copy in ggml_opt_free to plug per-training-session leak

### DIFF
--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -589,12 +589,6 @@ void ggml_opt_free(ggml_opt_context_t opt_ctx) {
     ggml_backend_buffer_free(opt_ctx->buf_cpu);
     ggml_free(opt_ctx->ctx_static);
     ggml_free(opt_ctx->ctx_cpu);
-    // ctx_copy is re-allocated by ggml_opt_alloc whenever the graph
-    // shape changes (see the ggml_free+ggml_init pair near the top of
-    // that function). The last allocation survives into ggml_opt_free,
-    // so we must release it here — otherwise the final per-batch
-    // context (~900 KB for typical GNN training) leaks per opt_ctx.
-    // Safe when ctx_copy == nullptr; ggml_free guards against NULL.
     ggml_free(opt_ctx->ctx_copy);
     delete opt_ctx;
 }

--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -589,6 +589,13 @@ void ggml_opt_free(ggml_opt_context_t opt_ctx) {
     ggml_backend_buffer_free(opt_ctx->buf_cpu);
     ggml_free(opt_ctx->ctx_static);
     ggml_free(opt_ctx->ctx_cpu);
+    // ctx_copy is re-allocated by ggml_opt_alloc whenever the graph
+    // shape changes (see the ggml_free+ggml_init pair near the top of
+    // that function). The last allocation survives into ggml_opt_free,
+    // so we must release it here — otherwise the final per-batch
+    // context (~900 KB for typical GNN training) leaks per opt_ctx.
+    // Safe when ctx_copy == nullptr; ggml_free guards against NULL.
+    ggml_free(opt_ctx->ctx_copy);
     delete opt_ctx;
 }
 


### PR DESCRIPTION
## Overview

ggml_opt_alloc populates opt_ctx->ctx_copy via a free+init pair every time the allocated graph shape changes. The last ctx_copy from the final ggml_opt_alloc call survives until ggml_opt_free is invoked, but ggml_opt_free was only freeing ctx_static and ctx_cpu, never ctx_copy. Each opt_ctx lifetime therefore leaks the final per-batch context — ~900 KB for a typical GNN training session in sindarin-pkg-tensor, surfaced via AddressSanitizer.

ctx_copy is nullptr-initialized and ggml_free() handles NULL safely, so the new release is guard-free.

## Additional information

This is actively being used to develop: https://github.com/SindarinSDK/sindarin-pkg-tensor

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

This PR was rolled by a human :)