### PR TITLE
quant: warn when quantizing Gemma 4 below Q5_K_M for audio

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -890,6 +890,19 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
 
     quantize_state_impl qs(model, params);
 
+    // warn about quantization sensitivity for multimodal audio models
+    if (model.arch == LLM_ARCH_GEMMA4) {
+        const bool is_low_quant = (ftype == LLAMA_FTYPE_MOSTLY_Q4_K_M || ftype == LLAMA_FTYPE_MOSTLY_Q4_K_S ||
+                                   ftype == LLAMA_FTYPE_MOSTLY_Q4_0   || ftype == LLAMA_FTYPE_MOSTLY_Q4_1   ||
+                                   ftype == LLAMA_FTYPE_MOSTLY_Q3_K_S || ftype == LLAMA_FTYPE_MOSTLY_Q3_K_M ||
+                                   ftype == LLAMA_FTYPE_MOSTLY_Q3_K_L || ftype == LLAMA_FTYPE_MOSTLY_Q2_K);
+        if (is_low_quant) {
+            LLAMA_LOG_WARN("\n%s: WARNING: Gemma 4 audio transcription is sensitive to quantization.\n", __func__);
+            LLAMA_LOG_WARN("%s:          Q5_K_M is the minimum recommended quantization for audio.\n", __func__);
+            LLAMA_LOG_WARN("%s:          Lower quantizations may produce repetitive output on longer audio.\n\n", __func__);
+        }
+    }
+
     if (params->only_copy) {
         ftype = ml.ftype;
     }


### PR DESCRIPTION
## Overview

Add a warning when quantizing Gemma 4 models below Q5_K_M, informing users that audio transcription quality may be degraded.

With the audio encoder fixes from #21421 (BF16-rounded scales, ggml_cont for sigmoid, conv norm swap) and per-layer scaling from #21625, the minimum viable quantization for Gemma 4 audio is **Q5_K_M**. Q4_K_M and below produce repetitive output on longer audio (~17s+) across all backends.

**Test results (with #21421 + #21625 applied, `tools/mtmd/test-2.mp3`):**

| Quant | CPU | CUDA (RTX 3060) |
|-------|-----|-----------------|
| BF16 | ✅ Pass | ✅ Pass |
| Q8_0 | ✅ Pass | ✅ Pass |
| Q6_K | ✅ Pass | ✅ Pass |
| Q5_K_M | ✅ Pass | ✅ Pass |
| Q4_K_M | ❌ Repetition | ❌ Repetition |

**Changes:**
- Warning printed when quantizing Gemma4 to Q4_K_M or below
- No forced type overrides (the previous forced Q6_K on embeddings is no longer needed)

## Additional information

Depends on:
- #21421 (Gemma4 audio encoder)
- #21625 (per-layer embedding scale for multimodal path)

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Claude Code was used to investigate quantization sensitivity and update this PR based on new test results. All code was manually reviewed.