### PR TITLE
CUDA: use LRU based eviction for cuda graphs

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -28,6 +28,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <deque>
 
 #if defined(GGML_USE_HIP)
 #include "vendors/hip.h"
@@ -151,6 +152,7 @@ static int ggml_cuda_highest_compiled_arch(const int arch) {
 #define MATRIX_ROW_PADDING 512 // last row of quant. matrices is a multiple of this to avoid out-of-bounds memory accesses
 
 #define GGML_CUDA_MAX_STREAMS 8
+#define GGML_CUDA_MAX_GRAPHS 64
 
 [[noreturn]]
 void ggml_cuda_error(const char * stmt, const char * func, const char * file, int line, const char * msg);
@@ -1367,11 +1369,17 @@ struct ggml_backend_cuda_context {
     // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)
     std::unordered_map<const void *, std::unique_ptr<ggml_cuda_graph>> cuda_graphs;
+    std::deque<const void *> graph_roots;
 
     ggml_cuda_graph * cuda_graph(const void * first_node_ptr) {
         auto it = cuda_graphs.find(first_node_ptr);
         if (it == cuda_graphs.end()) {
+            if (graph_roots.size() >= GGML_CUDA_MAX_GRAPHS) {
+                cuda_graphs.erase(graph_roots.front());
+                graph_roots.pop_front();
+            }
             cuda_graphs[first_node_ptr] = std::make_unique<ggml_cuda_graph>();
+            graph_roots.push_back(first_node_ptr);
             return cuda_graphs[first_node_ptr].get();
         }
         return it->second.get();

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -28,7 +28,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <deque>
+#include <queue>
 
 #if defined(GGML_USE_HIP)
 #include "vendors/hip.h"
@@ -152,7 +152,6 @@ static int ggml_cuda_highest_compiled_arch(const int arch) {
 #define MATRIX_ROW_PADDING 512 // last row of quant. matrices is a multiple of this to avoid out-of-bounds memory accesses
 
 #define GGML_CUDA_MAX_STREAMS 8
-#define GGML_CUDA_MAX_GRAPHS  128
 
 [[noreturn]]
 void ggml_cuda_error(const char * stmt, const char * func, const char * file, int line, const char * msg);
@@ -1369,18 +1368,41 @@ struct ggml_backend_cuda_context {
     // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)
     std::unordered_map<const void *, std::unique_ptr<ggml_cuda_graph>> cuda_graphs;
-    std::deque<const void *> graph_roots;
+
+    // pair of timestamp and node ptr
+    std::priority_queue<
+        std::pair<int64_t, const void *>,
+        std::vector<std::pair<int64_t, const void *>>,
+        std::greater<>
+    > graph_roots;
+
+    std::unordered_map<const void *, int64_t> graph_last_used_time;
 
     ggml_cuda_graph * cuda_graph(const void * first_node_ptr) {
+        int64_t time_now = ggml_time_us();
+
+        // delete all graph elements older than 10 seconds
+        while (!graph_roots.empty() && time_now - graph_roots.top().first >= 10'000'000) {
+            const auto & [ts, node_ptr] = graph_roots.top();
+            graph_roots.pop();
+
+            // lazy delete
+            if (ts == graph_last_used_time.at(node_ptr)) {
+                cuda_graphs.erase(node_ptr);
+                graph_last_used_time.erase(node_ptr);
+            }
+        }
+
         auto it = cuda_graphs.find(first_node_ptr);
         if (it == cuda_graphs.end()) {
-            if (graph_roots.size() >= GGML_CUDA_MAX_GRAPHS) {
-                cuda_graphs.erase(graph_roots.front());
-                graph_roots.pop_front();
-            }
-            cuda_graphs[first_node_ptr] = std::make_unique<ggml_cuda_graph>();
-            graph_roots.push_back(first_node_ptr);
-            return cuda_graphs[first_node_ptr].get();
+            it = cuda_graphs.emplace(first_node_ptr, std::make_unique<ggml_cuda_graph>()).first;
+        }
+
+        // throttle re-pushes into the lru queue by 1s per entry
+        auto last_it = graph_last_used_time.find(first_node_ptr);
+        if (last_it == graph_last_used_time.end() || time_now - last_it->second >= 1'000'000) {
+            graph_last_used_time[first_node_ptr] = time_now;
+            graph_roots.emplace(time_now, first_node_ptr);
         }
         return it->second.get();
     }

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -152,7 +152,7 @@ static int ggml_cuda_highest_compiled_arch(const int arch) {
 #define MATRIX_ROW_PADDING 512 // last row of quant. matrices is a multiple of this to avoid out-of-bounds memory accesses
 
 #define GGML_CUDA_MAX_STREAMS 8
-#define GGML_CUDA_MAX_GRAPHS 64
+#define GGML_CUDA_MAX_GRAPHS  128
 
 [[noreturn]]
 void ggml_cuda_error(const char * stmt, const char * func, const char * file, int line, const char * msg);

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -28,7 +28,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <queue>
 
 #if defined(GGML_USE_HIP)
 #include "vendors/hip.h"
@@ -1188,6 +1187,7 @@ struct ggml_cuda_graph {
     bool disable_due_to_gpu_arch = false;
     bool warmup_complete = false;
     uint64_t uid = 0;
+    int64_t last_used_time = 0;
     struct node_properties {
         ggml_tensor node;
         void *   node_src_data_ptrs[GGML_MAX_SRC];
@@ -1369,28 +1369,20 @@ struct ggml_backend_cuda_context {
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)
     std::unordered_map<const void *, std::unique_ptr<ggml_cuda_graph>> cuda_graphs;
 
-    // pair of timestamp and node ptr
-    std::priority_queue<
-        std::pair<int64_t, const void *>,
-        std::vector<std::pair<int64_t, const void *>>,
-        std::greater<>
-    > graph_lru_cache;
-
-    std::unordered_map<const void *, int64_t> graph_last_used_time;
+    int64_t last_graph_eviction_sweep = 0;
 
     ggml_cuda_graph * cuda_graph(const void * first_node_ptr) {
-        int64_t time_now = ggml_time_us();
+        const int64_t time_now = ggml_time_us();
 
-        // delete all cuda graphs older than 10 seconds
-        while (!graph_lru_cache.empty() && time_now - graph_lru_cache.top().first >= 10'000'000) {
-            const auto & [ts, node_ptr] = graph_lru_cache.top();
-            graph_lru_cache.pop();
-
-            // lazy delete
-            auto it = graph_last_used_time.find(node_ptr);
-            if (it != graph_last_used_time.end() && ts == it->second) {
-                cuda_graphs.erase(node_ptr);
-                graph_last_used_time.erase(node_ptr);
+        // sweep every 5s, evicting cuda graphs unused for >=10s
+        if (time_now - last_graph_eviction_sweep >= 5'000'000) {
+            last_graph_eviction_sweep = time_now;
+            for (auto it = cuda_graphs.begin(); it != cuda_graphs.end(); ) {
+                if (time_now - it->second->last_used_time >= 10'000'000) {
+                    it = cuda_graphs.erase(it);
+                } else {
+                    ++it;
+                }
             }
         }
 
@@ -1398,13 +1390,7 @@ struct ggml_backend_cuda_context {
         if (it == cuda_graphs.end()) {
             it = cuda_graphs.emplace(first_node_ptr, std::make_unique<ggml_cuda_graph>()).first;
         }
-
-        // throttle re-pushes into the lru queue by 1s per entry
-        auto last_it = graph_last_used_time.find(first_node_ptr);
-        if (last_it == graph_last_used_time.end() || time_now - last_it->second >= 1'000'000) {
-            graph_last_used_time[first_node_ptr] = time_now;
-            graph_lru_cache.emplace(time_now, first_node_ptr);
-        }
+        it->second->last_used_time = time_now;
         return it->second.get();
     }
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1374,20 +1374,21 @@ struct ggml_backend_cuda_context {
         std::pair<int64_t, const void *>,
         std::vector<std::pair<int64_t, const void *>>,
         std::greater<>
-    > graph_roots;
+    > graph_lru_cache;
 
     std::unordered_map<const void *, int64_t> graph_last_used_time;
 
     ggml_cuda_graph * cuda_graph(const void * first_node_ptr) {
         int64_t time_now = ggml_time_us();
 
-        // delete all graph elements older than 10 seconds
-        while (!graph_roots.empty() && time_now - graph_roots.top().first >= 10'000'000) {
-            const auto & [ts, node_ptr] = graph_roots.top();
-            graph_roots.pop();
+        // delete all cuda graphs older than 10 seconds
+        while (!graph_lru_cache.empty() && time_now - graph_lru_cache.top().first >= 10'000'000) {
+            const auto & [ts, node_ptr] = graph_lru_cache.top();
+            graph_lru_cache.pop();
 
             // lazy delete
-            if (ts == graph_last_used_time.at(node_ptr)) {
+            auto it = graph_last_used_time.find(node_ptr);
+            if (it != graph_last_used_time.end() && ts == it->second) {
                 cuda_graphs.erase(node_ptr);
                 graph_last_used_time.erase(node_ptr);
             }
@@ -1402,7 +1403,7 @@ struct ggml_backend_cuda_context {
         auto last_it = graph_last_used_time.find(first_node_ptr);
         if (last_it == graph_last_used_time.end() || time_now - last_it->second >= 1'000'000) {
             graph_last_used_time[first_node_ptr] = time_now;
-            graph_roots.emplace(time_now, first_node_ptr);
+            graph_lru_cache.emplace(time_now, first_node_ptr);
         }
         return it->second.get();
     }


### PR DESCRIPTION
## Overview

Since introducing graphs per node to enable multiple splits to have cuda graphs in #18934, there are cases when the node pointers in ggml_cgraph keep changing and it leads to the map being unbounded leading to memory leaks (e.g #20315) 

This PR fixes the memory leaks

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
