### PR TITLE
gemma4: derive attn_soft_cap from GGUF instead of hardcoding

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1186,14 +1186,13 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 uint32_t swa_period = 2;
                 ml.get_key_or_arr(LLM_KV_ATTENTION_SLIDING_WINDOW_PATTERN, swa_period, false);
                 hparams.set_swa_pattern(swa_period);
-                hparams.attn_soft_cap = true;
                 hparams.rope_freq_base_train_swa  = hparams.rope_freq_base_train;
                 hparams.rope_freq_scale_train_swa = hparams.rope_freq_scale_train;
 
                 ml.get_key(LLM_KV_ROPE_FREQ_BASE_SWA,          hparams.rope_freq_base_train_swa, false);
                 ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW,    hparams.n_swa, false);
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
-                ml.get_key(LLM_KV_ATTN_LOGIT_SOFTCAPPING,      hparams.f_attn_logit_softcapping, false);
+                hparams.attn_soft_cap = ml.get_key(LLM_KV_ATTN_LOGIT_SOFTCAPPING, hparams.f_attn_logit_softcapping, false);
                 ml.get_key(LLM_KV_FINAL_LOGIT_SOFTCAPPING,     hparams.f_final_logit_softcapping, false);
 
                 switch (hparams.n_layer) {


### PR DESCRIPTION
## Overview

The shared gemma2-iswa hparam loader hardcodes `attn_soft_cap = true`, which is correct for Gemma 2 (has `attn_logit_softcapping = 50.0` in GGUF) but incorrect for Gemma 4 which does not use attention logit softcapping.

Use the return value of `ml.get_key()` to set `attn_soft_cap` based on whether the GGUF actually contains the `LLM_KV_ATTN_LOGIT_SOFTCAPPING` key. Gemma 2 GGUFs are unaffected (key exists, returns true). Gemma 4 GGUFs now correctly skip attention softcapping (key absent, returns false).

## Additional information

Split from #21421 per reviewer request.

**Test results** (Gemma 2 2B Q4_K_M and Gemma 4 E2B Q4_K_M, `-n 200 --single-turn`):

| Backend | Gemma 2 (softcap=true) | Gemma 4 (softcap=false) |
|---------|------------------------|-------------------------|
| CPU | Pass (18.5 t/s) | Pass (18.1 t/s) |
| Vulkan (Intel Iris Xe) | Pass (10.1 t/s) | Pass (9.5 t/s) |
| CUDA (RTX 3060) | Pass (133.9 t/s) | Pass (133.5 t/s) |

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Claude Code was used to assist with splitting this fix from the parent PR, running tests, and drafting the description. The change was manually reviewed and verified.