### PR TITLE
ci: fix labeler.yml v6 syntax — drop `all:` composition

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,21 +75,13 @@ android:
             - examples/llama.android/**
 server/webui:
     - changed-files:
-        - all:
-            - any-glob-to-any-file:
-                - tools/server/webui/**
-                - tools/server/public/**
-            - all-globs-to-all-files:
-                - '!tools/server/webui/**'
-                - '!tools/server/public/**'
+        - any-glob-to-any-file:
+            - tools/server/webui/**
+            - tools/server/public/**
 server:
     - changed-files:
-        - all:
-            - any-glob-to-any-file:
-                - tools/server/**
-            - all-globs-to-all-files:
-                - '!tools/server/webui/**'
-                - '!tools/server/public/**'
+        - any-glob-to-any-file:
+            - tools/server/**
 
 
 


### PR DESCRIPTION
labeler@v6 dropped the v5 `all:` / `any:` composition keys. The `server/webui` and `server` entries here use `all:` to combine predicates and now error on every PR with:

    Unknown config options were under "changed-files": all

Flatten both to `any-glob-to-any-file`. PRs touching both webui and other server files will get both labels instead of just `server/webui`, which seems acceptable. The strict mutex needed v5 composition that v6 dropped.