### PR TITLE
cmake: fix CMP0194 warning on Windows with MSVC

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.14...3.28) # for add_link_options and implicit 
 # Set to NEW to avoid a warning on CMake 4.1+ with MSVC.
 if (POLICY CMP0194)
     cmake_policy(SET CMP0194 NEW)
-    endif()
+endif()
 project("ggml" C CXX ASM)
 
 ### GGML Version

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -1,4 +1,11 @@
 cmake_minimum_required(VERSION 3.14...3.28) # for add_link_options and implicit target directories.
+
+# ref: https://cmake.org/cmake/help/latest/policy/CMP0194.html
+# MSVC is not a valid assembler for the ASM language.
+# Set to NEW to avoid a warning on CMake 4.1+ with MSVC.
+if (POLICY CMP0194)
+    cmake_policy(SET CMP0194 NEW)
+    endif()
 project("ggml" C CXX ASM)
 
 ### GGML Version


### PR DESCRIPTION
## Overview

Fix CMP0194 CMake policy warning when building with MSVC on Windows and CMake 4.1+.

The `ggml` subproject enables `ASM` globally via `project("ggml" C CXX ASM)` for Metal (macOS) and KleidiAI (ARM) backends. On Windows/MSVC, no assembler sources are used, but CMake 4.1+ warns because `cl.exe` is not a valid ASM compiler.

This sets `CMP0194` to `NEW` before the `project()` call, guarded by `if (POLICY CMP0194)` for backward compatibility with older CMake versions. This follows the same pattern used in `ggml-vulkan/CMakeLists.txt` (CMP0114, CMP0147).

## Additional information

Closes #20311