### PR TITLE
Fix/lfm2 vl tiling v2

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2197,6 +2197,20 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.image_max_tokens = value;
         }
     ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_MAX_TOKENS"));
+    add_opt(common_arg(
+        {"--image-max-pixels-tolerance"}, "N",
+        "tolerance multiplier for tiling threshold in vision models (default: read from model, typically 2.0)",
+        [](common_params & params, const std::string & value) {
+            params.image_max_pixels_tolerance = std::stof(value);
+        }
+    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_MAX_PIXELS_TOLERANCE"));
+    add_opt(common_arg(
+        {"--image-resize-bicubic"},
+        "use bicubic interpolation for image resizing (default: bilinear). bicubic is slower but preserves fine detail",
+        [](common_params & params) {
+            params.image_resize_bicubic = true;
+        }
+    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_RESIZE_BICUBIC"));
     if (llama_supports_rpc()) {
         add_opt(common_arg(
             {"--rpc"}, "SERVERS",

--- a/common/common.h
+++ b/common/common.h
@@ -558,6 +558,8 @@ struct common_params {
     std::vector<std::string> image; // path to image file(s)
     int image_min_tokens = -1;
     int image_max_tokens = -1;
+    float image_max_pixels_tolerance = -1.0f;
+    bool image_resize_bicubic = false;
 
     // finetune
     struct lr_opt lr;

--- a/tools/mtmd/clip-model.h
+++ b/tools/mtmd/clip-model.h
@@ -108,6 +108,7 @@ struct clip_hparams {
     // custom value provided by user, can be undefined if not set
     int32_t custom_image_min_tokens = -1;
     int32_t custom_image_max_tokens = -1;
+    float custom_max_pixels_tolerance = -1.0f;
 
     void set_limit_image_tokens(int n_tokens_min, int n_tokens_max) {
         const int cur_merge = n_merge == 0 ? 1 : n_merge;

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -197,6 +197,14 @@ struct clip_ctx {
         if (ctx_params.image_max_tokens > 0) {
             model.hparams.custom_image_max_tokens = ctx_params.image_max_tokens;
         }
+        if (ctx_params.image_max_pixels_tolerance > 0) {
+            model.hparams.custom_max_pixels_tolerance = ctx_params.image_max_pixels_tolerance;
+        }
+        if (ctx_params.image_resize_bicubic) {
+            model.hparams.image_resize_algo    = RESIZE_ALGO_BICUBIC;
+            model.hparams.image_resize_algo_rf = RESIZE_ALGO_BICUBIC;
+            model.hparams.image_resize_algo_ov = RESIZE_ALGO_BICUBIC;
+        }
 
         backend_ptrs.push_back(backend_cpu);
         backend_buft.push_back(ggml_backend_get_default_buffer_type(backend_cpu));

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -37,6 +37,8 @@ struct clip_context_params {
     enum clip_flash_attn_type flash_attn_type;
     int image_min_tokens;
     int image_max_tokens;
+    float image_max_pixels_tolerance;
+    bool image_resize_bicubic;
     bool warmup;
     ggml_backend_sched_eval_callback cb_eval;
     void * cb_eval_user_data;

--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -908,8 +908,16 @@ mtmd_image_preprocessor_llava_uhd::slice_instructions mtmd_image_preprocessor_lf
     inst.overview_size = img_tool::calc_size_preserved_ratio(
                             original_size, align_size,
                             hparams.image_min_pixels, hparams.image_max_pixels);
-    // tile if either dimension exceeds tile_size with tolerance
-    const bool needs_tiling = original_size.width > tile_size * max_pixels_tolerance || original_size.height > tile_size * max_pixels_tolerance;
+    // tile if pixel area exceeds max_pixels budget with tolerance
+    // matches HuggingFace transformers reference implementation
+    const float tolerance = hparams.custom_max_pixels_tolerance > 0
+        ? hparams.custom_max_pixels_tolerance
+        : max_pixels_tolerance;
+    const int max_pixels_budget = static_cast<int>(hparams.image_max_pixels * tolerance);
+    // round dimensions to align_size before area check (banker's rounding to match Python/HF)
+    const int h_bar = std::max(align_size, static_cast<int>(std::nearbyint(static_cast<float>(original_size.height) / align_size) * align_size));
+    const int w_bar = std::max(align_size, static_cast<int>(std::nearbyint(static_cast<float>(original_size.width)  / align_size) * align_size));
+    const bool needs_tiling = h_bar * w_bar > max_pixels_budget;
 
     if (!needs_tiling) {
         inst.refined_size = clip_image_size{0, 0};

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -115,6 +115,8 @@ mtmd_context_params mtmd_context_params_default() {
         /* warmup            */ true,
         /* image_min_tokens  */ -1,
         /* image_max_tokens  */ -1,
+        /* image_max_pixels_tolerance */ -1.0f,
+        /* image_resize_bicubic       */ false,
         /* cb_eval           */ nullptr,
         /* cb_eval_user_data */ nullptr,
     };
@@ -182,6 +184,8 @@ struct mtmd_context {
             /* flash_attn_type   */ mtmd_get_clip_flash_attn_type(ctx_params.flash_attn_type),
             /* image_min_tokens  */ ctx_params.image_min_tokens,
             /* image_max_tokens  */ ctx_params.image_max_tokens,
+            /* image_max_pixels_tolerance */ ctx_params.image_max_pixels_tolerance,
+            /* image_resize_bicubic       */ ctx_params.image_resize_bicubic,
             /* warmup            */ ctx_params.warmup,
             /* cb_eval           */ ctx_params.cb_eval,
             /* cb_eval_user_data */ ctx_params.cb_eval_user_data,

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -95,6 +95,8 @@ struct mtmd_context_params {
     // limit number of image tokens, only for vision models with dynamic resolution
     int image_min_tokens; // minimum number of tokens for image input (default: read from metadata)
     int image_max_tokens; // maximum number of tokens for image input (default: read from metadata)
+    float image_max_pixels_tolerance; // tolerance multiplier for tiling threshold (default: -1 = use model default 2.0)
+    bool image_resize_bicubic;        // use bicubic interpolation (default: false = bilinear)
 
     // callback function passed over to mtmd proper
     ggml_backend_sched_eval_callback cb_eval;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -708,6 +708,8 @@ private:
             mparams.warmup           = params_base.warmup;
             mparams.image_min_tokens = params_base.image_min_tokens;
             mparams.image_max_tokens = params_base.image_max_tokens;
+            mparams.image_max_pixels_tolerance = params_base.image_max_pixels_tolerance;
+            mparams.image_resize_bicubic = params_base.image_resize_bicubic;
 
             mctx = mtmd_init_from_file(mmproj_path.c_str(), model, mparams);
             if (mctx == nullptr) {


### PR DESCRIPTION
The current LFM2-VL tiling threshold uses a per-dim check (width > 1024 || height > 1024) which doesn't match the HF implementation. This causes slightly different tiling behavior in the 721-1024px range causing early downscaling or upscaling. 

- Fixes the threshold to use an area-based check matching HF: rounded_area > image_max_pixels * tolerance
- Adds --image-max-pixels-tolerance flag to control tiling thresh at runtime
- Adds --image-resize-bicubic flag to opt into bicubic interpolation (training uses bicubic, llama.cpp defaults to bilinear)

Tested with LFM2-VL-450M on Jetson AGX Orin. Tiling now matches HF transformers 5.2.0 exactly (Across 6 different resolution tests). Existing test-mtmd-c-api passes.