### PR TITLE
common: mark --split-mode tensor as experimental

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2353,7 +2353,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "- none: use one GPU only\n"
         "- layer (default): split layers and KV across GPUs (pipelined)\n"
         "- row: split weight across GPUs by rows (parallelized)\n"
-        "- tensor: split weights and KV across GPUs (parallelized)",
+        "- tensor: split weights and KV across GPUs (parallelized, EXPERIMENTAL)",
         [](common_params & params, const std::string & value) {
             if (value == "none") {
                 params.split_mode = LLAMA_SPLIT_MODE_NONE;


### PR DESCRIPTION
Fixup to https://github.com/ggml-org/llama.cpp/pull/19378 . Since there are probably still a lot of cases where `--split-mode tensor` doesn't yet work correctly I marked the PR as experimental. But I forgot to also do this in the `--help`.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No