### PR TITLE
common : enable reasoning budget sampler for gemma4

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1104,9 +1104,9 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
         auto start = p.rule("start", p.prefix(inputs.generation_prompt, "<|channel>"));
 
         if (extract_reasoning) {
-            p.rule("thought", p.literal("<|channel>thought") + p.optional(p.literal("\n")) + p.reasoning(p.until("<channel|>")) + p.literal("<channel|>"));
+            p.rule("thought", p.literal("<|channel>thought") + p.space() + p.reasoning(p.until("<channel|>")) + p.literal("<channel|>"));
         } else {
-            p.rule("thought", p.content(p.literal("<|channel>thought") + p.optional(p.literal("\n")) + p.until("<channel|>") + p.literal("<channel|>")));
+            p.rule("thought", p.content(p.literal("<|channel>thought") + p.space() + p.until("<channel|>") + p.literal("<channel|>")));
         }
 
         auto thought = (p.peek(p.literal("<|channel>")) + p.ref("thought")) | p.negate(p.literal("<|channel>"));

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1083,7 +1083,9 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
 
     data.prompt            = common_chat_template_direct_apply_impl(tmpl, inputs);
     data.format            = COMMON_CHAT_FORMAT_PEG_GEMMA4;
-    data.supports_thinking = true;
+    data.supports_thinking  = true;
+    data.thinking_start_tag = "<|channel>thought";
+    data.thinking_end_tag   = "<channel|>";
 
     data.preserved_tokens = {
         "<|channel>",
@@ -1102,9 +1104,9 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
         auto start = p.rule("start", p.prefix(inputs.generation_prompt, "<|channel>"));
 
         if (extract_reasoning) {
-            p.rule("thought", p.literal("<|channel>thought\n") + p.reasoning(p.until("<channel|>")) + p.literal("<channel|>"));
+            p.rule("thought", p.literal("<|channel>thought") + p.optional(p.literal("\n")) + p.reasoning(p.until("<channel|>")) + p.literal("<channel|>"));
         } else {
-            p.rule("thought", p.content(p.literal("<|channel>thought\n") + p.until("<channel|>") + p.literal("<channel|>")));
+            p.rule("thought", p.content(p.literal("<|channel>thought") + p.optional(p.literal("\n")) + p.until("<channel|>") + p.literal("<channel|>")));
         }
 
         auto thought = (p.peek(p.literal("<|channel>")) + p.ref("thought")) | p.negate(p.literal("<|channel>"));

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1988,6 +1988,13 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect(message_assist_thoughts)
             .run();
 
+        // Empty reasoning (budget=0: sampler forces end tag before newline)
+        tst.test(
+                "<|channel>thought<channel|>Hello, world!\nWhat's up?")
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .expect(simple_assist_msg("Hello, world!\nWhat's up?", ""))
+            .run();
+
         // Reasoning and content with reasoning_format = none
         tst.test(
                 "<|channel>thought\nI'm\nthinking<channel|>Hello, world!\nWhat's up?")


### PR DESCRIPTION
## Overview

As #21487 also reports, gemma4 thinking budget doesn't work. I noticed that `common_chat_params_init_gemma4()` sets `supports_thinking = true` but never populates `thinking_start_tag` / `thinking_end_tag`. The budget sampler in `server-common.cpp` works conditional on `thinking_end_tag` being non-empty, so it skips gemma4 entirely.

So I added the missing tags. The main fix is just two lines (chat.cpp:1087-1088). The rest of the diff is about making budget=0 work cleanly: while testing for my personal use (see the details of the local testing environment below), I found that budget=0 causes a PEG parse error because the sampler forces the end tag before the model emits a newline after "thought". Even though `--reasoning off` already handles the no-thinking case, I didn't want to introduce a parse error at that edge case. I made the newline optional in the parser, and added a test case for it.

Fixes #21487

## Changes

- Set `thinking_start_tag = "<|channel>thought"` and `thinking_end_tag = "<channel|>"` in `common_chat_params_init_gemma4()`
- Make `\n` optional after `thought` in both PEG parser rules (extract and non-extract paths) so the parser handles empty thinking blocks
- Add test case for empty thinking block (budget=0 scenario)

## Testing

Unit tests: `test-reasoning-budget` (5/5), `test-chat` (all passed).

Integration tested on RTX 5090 with `gemma-4-26B-A4B-it-Q4_K_M.gguf` (ggml-org), llama.cpp b8718, CUDA 13.0:

| Config | Thinking tokens |
|--------|----------------|
| `--reasoning-budget -1` (unlimited) | 1,447 |
| `--reasoning-budget 1024` | 1,024 |
| `--reasoning-budget 0` | 0 |
| Per-request `thinking_budget_tokens: 256` | 256 |

I didn't run perplexity/bench since my PR simply allows the existing sampler that already works for other models to also apply to gemma4. Default behavior (`--reasoning-budget -1`) is unchanged so the only people affected are those who explicitly set a reasoning budget (and don't get it). (Also the CI test uses Qwen3 so my diff wouldn't be on the code path that gets exercised.)

Note on the start tag: the tag omits the trailing `\n` because gemma4 generates a double-newline token (`\n\n`, token 108) after "thought", not the single-newline token (`\n`, token 107) that the tokenizer produces for `"thought\n"`. Without this, the sampler's token matcher fails on the third token and never activates.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: AI assisted with locating the root cause in the source code and suggested a fix. Fix was reviewed and tested manually, and extensively both for this PR and for my own local projects as well.
