### PR TITLE
ggml-cuda: better vram to lds loading pipeline in load_tiles_q8_0

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -698,70 +698,50 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     const int txi = warp_size > threads_per_row ? threadIdx.x % threads_per_row : threadIdx.x;
     const int kbx  = txi / QI8_0;
     const int kqsx = txi % QI8_0;
-    
-    // loop size and qs vectors for caching
-    constexpr int iters = mmq_y / (nrows * nwarps);
-    int qs_tmp0[iters];
-    int qs_tmp1[iters];
 
-    //Pointer and offset precomputed outside loop (its the same as doing it inside)
-    const int i_off = (nrows == 1 ? threadIdx.y : threadIdx.y * nrows + threadIdx.x / threads_per_row);
-    const block_q8_0 * bx_base = (const block_q8_0 *)x + kbx0 + kbx;
+#pragma unroll
+    for (int i0 = 0; i0 < mmq_y; i0 += nrows*nwarps) {
+        int i = i0 + (nrows == 1 ? threadIdx.y : threadIdx.y*nrows + threadIdx.x/threads_per_row);
 
-    //loading loop from VRAM --> registers   
-    #pragma unroll
-    for (int i0 = 0; i0 < iters; i0++) {
-        // double counters: i_slot is never clamped to i_max, so i can write on all the slots. i_read is clamped to the i_max, to avoid oob data.
-        const int i_slot = i0 * nrows * nwarps + i_off; 
-        const int i_read = need_check ? min(i_slot, i_max) : i_slot;
-        // fancy mask: -int(true) = -1 is hex 0xFFFFFFFF, while -int(false) = 0x00000000
-        const int mask = need_check ? -(int)(i_slot <= i_max) : -1;  
-        //like upstream, with i_read
-        const block_q8_0 * bxi = bx_base + i_read * stride;
-        //temporary registers to hold the qs, masked
-        qs_tmp0[i0] = get_int_b2(bxi[0].qs,                    kqsx) & mask;
-        qs_tmp1[i0] = get_int_b2(bxi[MMQ_TILE_NE_K/QI8_0].qs,  kqsx) & mask;
-    }
-    
-    //storing loop registers --> LDS, like upstream, with i_slot
-    #pragma unroll
-    for (int i0 = 0; i0 < iters; i0++) {
-        const int i_slot = i0 * nrows * nwarps + i_off;
+        if (need_check) {
+            i = min(i, i_max);
+        }
+
+        const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbx;
+
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
-        x_qs[i_slot*MMQ_MMA_TILE_X_K_Q8_0 + 0             + txi] = qs_tmp0[i0];
-        x_qs[i_slot*MMQ_MMA_TILE_X_K_Q8_0 + MMQ_TILE_NE_K + txi] = qs_tmp1[i0];
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 0             + txi] = get_int_b2(bxi[0].qs,                   kqsx);
+        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + MMQ_TILE_NE_K + txi] = get_int_b2(bxi[MMQ_TILE_NE_K/QI8_0].qs, kqsx);
 #else
-        x_qs[i_slot*(2*MMQ_TILE_NE_K + 1) + 0             + txi] = qs_tmp0[i0];
-        x_qs[i_slot*(2*MMQ_TILE_NE_K + 1) + MMQ_TILE_NE_K + txi] = qs_tmp1[i0];
+#pragma unroll
+        for (int k = 0; k < 2*MMQ_TILE_NE_K; k += threads_per_row) {
+            x_qs[i*(2*MMQ_TILE_NE_K + 1) + k + txi] = get_int_b2(bxi[k/QI8_0].qs, kqsx);
+        }
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     }
 
-    //like upstream
     constexpr int blocks_per_tile_x_row = 2*MMQ_TILE_NE_K / QI8_0;
     constexpr int rows_per_warp = warp_size / blocks_per_tile_x_row;
     const int kbxd = threadIdx.x % blocks_per_tile_x_row;
 
-    //Pointer and offset precomputed outside loop (its the same as doing it inside)
-    const int i_off_d = threadIdx.y * rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
-    const block_q8_0 * bx_d_base = (const block_q8_0 *)x + kbx0 + kbxd;
-
-    //scale loading loop VRAM --> LDS, like upstream
-    #pragma unroll
+#pragma unroll
     for (int i0 = 0; i0 < mmq_y; i0 += nwarps * rows_per_warp) {
-        const int i_slot = i0 + i_off_d;
-        const int i_read = need_check ? min(i_slot, i_max) : i_slot;
-        //like upstream, with i_read
-        const block_q8_0 * bxi = bx_d_base + i_read * stride;
-        //mask
-        const float d_val = (need_check && i_slot > i_max) ? 0.0f : (float)bxi->d;
+        int i = i0 + threadIdx.y * rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
+        
+        if (need_check) {
+            i = min(i, i_max);
+        }
+
+        const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbxd;
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
-        x_df[i_slot*MMQ_MMA_TILE_X_K_Q8_0                 + kbxd] = d_val;
+        x_df[i*MMQ_MMA_TILE_X_K_Q8_0                 + kbxd] = bxi->d;
 #else
-        x_df[i_slot*(2*MMQ_TILE_NE_K/QI8_0) + i_slot/(QI8_0/2) + kbxd] = d_val;
+        x_df[i*(2*MMQ_TILE_NE_K/QI8_0) + i/(QI8_0/2) + kbxd] = bxi->d;
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     }
 }
+
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_mxfp4(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -698,44 +698,67 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     const int txi = warp_size > threads_per_row ? threadIdx.x % threads_per_row : threadIdx.x;
     const int kbx  = txi / QI8_0;
     const int kqsx = txi % QI8_0;
+    
+    // loop size and qs vectors for caching
+    constexpr int iters = mmq_y / (nrows * nwarps);
+    int qs_tmp0[iters];
+    int qs_tmp1[iters];
 
-#pragma unroll
-    for (int i0 = 0; i0 < mmq_y; i0 += nrows*nwarps) {
-        int i = i0 + (nrows == 1 ? threadIdx.y : threadIdx.y*nrows + threadIdx.x/threads_per_row);
+    //Pointer and offset precomputed outside loop (its the same as doing it inside)
+    const int i_off = (nrows == 1 ? threadIdx.y : threadIdx.y * nrows + threadIdx.x / threads_per_row);
+    const block_q8_0 * bx_base = (const block_q8_0 *)x + kbx0 + kbx;
 
-        if (need_check) {
-            i = min(i, i_max);
-        }
-
-        const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbx;
-
+    //loading loop from VRAM --> registers   
+    #pragma unroll
+    for (int i0 = 0; i0 < iters; i0++) {
+        // double counters: i_slot is never clamped to i_max, so i can write on all the slots. i_read is clamped to the i_max, to avoid oob data.
+        const int i_slot = i0 * nrows * nwarps + i_off; 
+        const int i_read = need_check ? min(i_slot, i_max) : i_slot;
+        // fancy mask: -int(true) = -1 is hex 0xFFFFFFFF, while -int(false) = 0x00000000
+        const int mask = need_check ? -(int)(i_slot <= i_max) : -1;  
+        //like upstream, with i_read
+        const block_q8_0 * bxi = bx_base + i_read * stride;
+        //temporary registers to hold the qs, masked
+        qs_tmp0[i0] = get_int_b2(bxi[0].qs,                    kqsx) & mask;
+        qs_tmp1[i0] = get_int_b2(bxi[MMQ_TILE_NE_K/QI8_0].qs,  kqsx) & mask;
+    }
+    
+    //storing loop registers --> LDS, like upstream, with i_slot
+    #pragma unroll
+    for (int i0 = 0; i0 < iters; i0++) {
+        const int i_slot = i0 * nrows * nwarps + i_off;
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
-        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + 0             + txi] = get_int_b2(bxi[0].qs,                   kqsx);
-        x_qs[i*MMQ_MMA_TILE_X_K_Q8_0 + MMQ_TILE_NE_K + txi] = get_int_b2(bxi[MMQ_TILE_NE_K/QI8_0].qs, kqsx);
+        x_qs[i_slot*MMQ_MMA_TILE_X_K_Q8_0 + 0             + txi] = qs_tmp0[i0];
+        x_qs[i_slot*MMQ_MMA_TILE_X_K_Q8_0 + MMQ_TILE_NE_K + txi] = qs_tmp1[i0];
 #else
-        x_qs[i*(2*MMQ_TILE_NE_K + 1) + 0             + txi] = get_int_b2(bxi[0].qs,                   kqsx);
-        x_qs[i*(2*MMQ_TILE_NE_K + 1) + MMQ_TILE_NE_K + txi] = get_int_b2(bxi[MMQ_TILE_NE_K/QI8_0].qs, kqsx);
+        x_qs[i_slot*(2*MMQ_TILE_NE_K + 1) + 0             + txi] = qs_tmp0[i0];
+        x_qs[i_slot*(2*MMQ_TILE_NE_K + 1) + MMQ_TILE_NE_K + txi] = qs_tmp1[i0];
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     }
 
+    //like upstream
     constexpr int blocks_per_tile_x_row = 2*MMQ_TILE_NE_K / QI8_0;
     constexpr int rows_per_warp = warp_size / blocks_per_tile_x_row;
     const int kbxd = threadIdx.x % blocks_per_tile_x_row;
 
-#pragma unroll
+    //Pointer and offset precomputed outside loop (its the same as doing it inside)
+    const int i_off_d = threadIdx.y * rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
+    const block_q8_0 * bx_d_base = (const block_q8_0 *)x + kbx0 + kbxd;
+
+    //scale loading loop VRAM --> LDS, like upstream
+    #pragma unroll
     for (int i0 = 0; i0 < mmq_y; i0 += nwarps * rows_per_warp) {
-        int i = i0 + threadIdx.y * rows_per_warp + threadIdx.x / blocks_per_tile_x_row;
-
-        if (need_check) {
-            i = min(i, i_max);
-        }
-
-        const block_q8_0 * bxi = (const block_q8_0 *) x + kbx0 + i*stride + kbxd;
+        const int i_slot = i0 + i_off_d;
+        const int i_read = need_check ? min(i_slot, i_max) : i_slot;
+        //like upstream, with i_read
+        const block_q8_0 * bxi = bx_d_base + i_read * stride;
+        //mask
+        const float d_val = (need_check && i_slot > i_max) ? 0.0f : (float)bxi->d;
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
-        x_df[i*MMQ_MMA_TILE_X_K_Q8_0                 + kbxd] = bxi->d;
+        x_df[i_slot*MMQ_MMA_TILE_X_K_Q8_0                 + kbxd] = d_val;
 #else
-        x_df[i*(2*MMQ_TILE_NE_K/QI8_0) + i/(QI8_0/2) + kbxd] = bxi->d;
+        x_df[i_slot*(2*MMQ_TILE_NE_K/QI8_0) + i_slot/(QI8_0/2) + kbxd] = d_val;
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     }
 }

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -693,7 +693,14 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 
     // MMQ_ITER_K / (4 * QR8_0) == 64 required. but NV has only 32 threads per warp
+#if defined(GGML_USE_HIP) && defined(RDNA2)
+    constexpr int threads_per_row = 2;
+#elif defined(GGML_USE_HIP) && defined(GCN5)
+    constexpr int threads_per_row = 16;
+#else
     constexpr int threads_per_row = 32;
+#endif
+
     constexpr int nrows = warp_size / threads_per_row;
     const int txi = warp_size > threads_per_row ? threadIdx.x % threads_per_row : threadIdx.x;
     const int kbx  = txi / QI8_0;


### PR DESCRIPTION
## Overview

This pr rewrites some portions of the load_tile_q8_0 function, to get a good performance improvement with the MI50.
It splits the loading tiles loop in two phases, from vram to registers, then from registers to LDS, instead of doing both operations in a single loop. The scale loading loop is like upstream.  Another thing is that when need_check case happens now it masks to zero the oob data writes, not a big deal but maybe cleaner. 

<details>
<summary><strong>Quick bench results:</strong>&nbsp;&nbsp;&nbsp;</summary>

| GPU          | Model                     | Test             | Before (t/s) | After (t/s) | Δ (t/s) | % Δ   |
|--------------|---------------------------|------------------|--------------|-------------|---------|--------|
| **MI50**     | **qwen3.5 4B Q8_0**       | pp512            | 991.15       | **1275.10** | **+283.95** | **+28.6%** |
|              |                           | pp2048           | 1026.70      | **1326.90** | **+300.20** | **+29.2%** |
|              |                           | pp8192           | 902.59       | **1173.84** | **+271.25** | **+30.0%** |
|              |                           | tg128            | 78.41        | 79.33       | +0.92   | +1.2%  |
|              |                           | pp512 @ d8192    | 802.33       | **1017.33** | **+215.00** | **+26.8%** |
|              |                           | pp2048 @ d8192   | 809.52       | **1018.06** | **+208.54** | **+25.8%** |
|              |                           | pp8192 @ d8192   | 752.68       | **939.88**  | **+187.20** | **+24.9%** |
|              |                           | tg128 @ d8192    | 71.00        | **74.14**   | **+3.14** | **+4.4%** |
|              | **qwen3moe 30B.A3B Q8_0** | pp512            | 823.79       | **1122.05** | **+298.26** | **+36.2%** |
|              |                           | pp2048           | 1139.30      | **1474.63** | **+335.33** | **+29.4%** |
|              |                           | pp8192           | 932.11       | **1148.72** | **+216.61** | **+23.2%** |
|              |                           | tg128            | 87.12        | 87.01       | −0.11   | −0.1%  |
|              |                           | pp512 @ d8192    | 584.91       | **715.96**  | **+131.05** | **+22.4%** |
|              |                           | pp2048 @ d8192   | 709.88       | **823.69**  | **+113.81** | **+16.0%** |
|              |                           | pp8192 @ d8192   | 592.83       | **676.08**  | **+83.25**  | **+14.0%** |
|              |                           | tg128 @ d8192    | 76.71        | **77.28**   | **+0.57**   | **+0.7%** |
| **RX 6800 XT** | **qwen3.5 4B Q8_0**     | pp512            | 2857.69      | **2860.56** | +2.87   | +0.1%  |
|              |                           | pp2048           | 2919.32      | **2922.99** | +3.67   | +0.1%  |
|              |                           | pp8192           | 2708.28      | **2713.23** | +4.95   | +0.2%  |
|              |                           | tg128            | 68.43        | **69.17**   | +0.74   | +1.1%  |
|              |                           | pp512 @ d8192    | 2431.01      | **2439.08** | +8.07   | +0.3%  |
|              |                           | pp2048 @ d8192   | 2386.97      | **2392.60** | +5.63   | +0.2%  |
|              |                           | pp8192 @ d8192   | 2252.48      | **2258.32** | +5.84   | +0.3%  |
|              |                           | tg128 @ d8192    | 65.77        | **66.03**   | +0.26   | +0.4%  |

</details>

Mi50 is much faster with this code, while rx6800xt shows no regression. 
Tried different models (qwen3/3.5 4b, 30b, mistral) and it works on both gpus, answers are correct at all ctx lenghts.

For old gpus the only concern that comes in my mind is that maybe now i'm using more VGPRS. I looked at the compilation statistics and there is not any net increase in vgprs...i didnt lose occupancy on any kernel variant. 

I didn't test the tensor path, no idea if it works, but i think it should behave like upstream (there are no changes in the splitted part, just a variable rename). All the changes are commented in code.

curious to see some benchmarks of both older and newer gpus! 

@JohannesGaessler  what do you think ? 

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES , gfx906 fork was originally wrote with llms, i rewrote this code myself and adjusted for the pr.
