### PR TITLE
Enhance Hexagon build process and implement TurboQuant for KV cache

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -387,6 +387,7 @@ const std::vector<ggml_type> kv_cache_types = {
     GGML_TYPE_IQ4_NL,
     GGML_TYPE_Q5_0,
     GGML_TYPE_Q5_1,
+    GGML_TYPE_TURBO4_0,
 };
 
 static ggml_type kv_cache_type_from_str(const std::string & s) {

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -429,7 +429,8 @@ extern "C" {
         GGML_TYPE_MXFP4   = 39, // MXFP4 (1 block)
         GGML_TYPE_NVFP4   = 40, // NVFP4 (4 blocks, E4M3 scale)
         GGML_TYPE_Q1_0    = 41,
-        GGML_TYPE_COUNT   = 42,
+        GGML_TYPE_TURBO4_0 = 42, // TurboQuant 4-bit PolarQuant (KV cache compression, experimental)
+        GGML_TYPE_COUNT   = 43,
     };
 
     // precision

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -205,6 +205,7 @@ add_library(ggml-base
             ggml-threading.h
             ggml-quants.c
             ggml-quants.h
+            ggml-turbo-quant.c
             gguf.cpp)
 
 set_target_properties(ggml-base PROPERTIES

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -277,6 +277,18 @@ typedef struct {
 } block_tq2_0;
 static_assert(sizeof(block_tq2_0) == sizeof(ggml_half) + QK_K / 4, "wrong tq2_0 block size/padding");
 
+// TurboQuant 4-bit: PolarQuant with 16 optimal centroids + WHT rotation
+// Block size = 128 (one block per rotation group = head_dim)
+// Per block: norm(fp16) + rnorm(fp16, reserved) + 4-bit indices (64 bytes)
+// = 68 bytes per 128 values = 4.25 bits/value -> 3.8x compression vs fp16
+#define QK_TURBO4 128
+typedef struct {
+    ggml_half  norm;                    //  2 bytes: corrected L2 norm
+    ggml_half  rnorm;                   //  2 bytes: reserved (zero)
+    uint8_t    qs[QK_TURBO4 / 2];      // 64 bytes: 4-bit PolarQuant indices (nibble packed)
+} block_turbo4_0;                       // 68 bytes total
+static_assert(sizeof(block_turbo4_0) == 68, "wrong turbo4_0 block size");
+
 //
 // Super-block quantization structures
 //

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -396,6 +396,11 @@ static const struct ggml_type_traits_cpu type_traits_cpu[GGML_TYPE_COUNT] = {
         .vec_dot_type             = GGML_TYPE_Q8_K,
         .nrows                    = 1,
     },
+    [GGML_TYPE_TURBO4_0] = {
+        .from_float               = quantize_row_turbo4_0,
+        .vec_dot_type             = GGML_TYPE_F32,
+        .nrows                    = 1,
+    },
     [GGML_TYPE_I32] = {
         .from_float               = (ggml_from_float_t) ggml_cpu_fp32_to_i32,
     },

--- a/ggml/src/ggml-cpu/quants.h
+++ b/ggml/src/ggml-cpu/quants.h
@@ -33,6 +33,8 @@ void quantize_row_q8_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, in
 void quantize_row_tq1_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_tq2_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
+void quantize_row_turbo4_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+
 void quantize_row_iq4_nl (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_iq4_xs (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 

--- a/ggml/src/ggml-hexagon/CMakeLists.txt
+++ b/ggml/src/ggml-hexagon/CMakeLists.txt
@@ -60,13 +60,17 @@ target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ht
 
 # Build HTP skels
 set(HTP_SKELS)
+set(HTP_SKELETON_TARGETS)
 function(build_htp_skel V)
-    ExternalProject_Add(htp-${V}
+    set(HTP_SKELETON_TARGET htp-${V})
+
+    ExternalProject_Add(${HTP_SKELETON_TARGET}
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/htp BUILD_ALWAYS ON
         BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/libggml-htp-${V}.so
         CMAKE_ARGS
             -DCMAKE_BUILD_TYPE=Release
             -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/htp/cmake-toolchain.cmake
+            -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
             -DCMAKE_INSTALL_LIBDIR=${CMAKE_CURRENT_BINARY_DIR}
             -DHEXAGON_SDK_ROOT=${HEXAGON_SDK_ROOT}
             -DHEXAGON_TOOLS_ROOT=${HEXAGON_TOOLS_ROOT}
@@ -74,7 +78,10 @@ function(build_htp_skel V)
             -DGGML_HEXAGON_FP32_QUANTIZE_GROUP_SIZE=${GGML_HEXAGON_FP32_QUANTIZE_GROUP_SIZE}
             -DDSP_VERSION=${V}
             -DPREBUILT_LIB_DIR="toolv19_${V}")
+
+    list(APPEND HTP_SKELETON_TARGETS ${HTP_SKELETON_TARGET})
     list(APPEND HTP_SKELS ${CMAKE_CURRENT_BINARY_DIR}/libggml-htp-${V}.so)
+    set(HTP_SKELETON_TARGETS ${HTP_SKELETON_TARGETS} PARENT_SCOPE)
     set(HTP_SKELS ${HTP_SKELS} PARENT_SCOPE)
 endfunction()
 
@@ -84,6 +91,14 @@ build_htp_skel(v73)
 build_htp_skel(v75)
 build_htp_skel(v79)
 build_htp_skel(v81)
+
+# Build skels whenever ggml-hexagon is built.
+add_dependencies(${TARGET_NAME} ${HTP_SKELETON_TARGETS})
+
+# Place skels next to libggml-hexagon.so so Android packaging can include them.
+add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HTP_SKELS} $<TARGET_FILE_DIR:${TARGET_NAME}>
+    COMMENT "copying Hexagon HTP skels to target output directory")
 
 # Install Hexagon skels required at runtime
 install(FILES ${HTP_SKELS} TYPE LIB)

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -1646,8 +1646,9 @@ void ggml_hexagon_session::allocate(int dev_id) noexcept(false) {
         u.enable = 1;
         int err  = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE, (void *) &u, sizeof(u));
         if (err != AEE_SUCCESS) {
-            GGML_LOG_ERROR("ggml-hex: failed to enable unsigned PD for session %d : error 0x%x\n", dev_id, err);
-            throw std::runtime_error("ggml-hex: remote_session_control(unsign) failed (see log for details)");
+            // Some devices/firmware disallow unsigned PD control. Continue and attempt to
+            // open the session anyway, which can still work with signed/skel-compatible flows.
+            GGML_LOG_WARN("ggml-hex: failed to enable unsigned PD for session %d : error 0x%x (continuing)\n", dev_id, err);
         }
     }
 
@@ -3322,6 +3323,13 @@ static ggml_backend_buffer_type_t * ggml_backend_hexagon_device_get_extra_buffer
     return bufts;
 }
 
+// Aggressively offload every op the NPU can handle.
+// Without this callback (NULL), the scheduler only offloads ops whose tensor
+// size exceeds an internal threshold, leaving many small-but-supported ops on CPU.
+static bool ggml_backend_hexagon_device_offload_op(ggml_backend_dev_t dev, const struct ggml_tensor * op) {
+    return ggml_backend_hexagon_device_supports_op(dev, op);
+}
+
 static const struct ggml_backend_device_i ggml_backend_hexagon_device_i = {
     /* .get_name             = */ ggml_backend_hexagon_device_get_name,
     /* .get_description      = */ ggml_backend_hexagon_device_get_description,
@@ -3334,7 +3342,7 @@ static const struct ggml_backend_device_i ggml_backend_hexagon_device_i = {
     /* .buffer_from_host_ptr = */ NULL,  // ggml_backend_hexagon_device_buffer_from_ptr,
     /* .supports_op          = */ ggml_backend_hexagon_device_supports_op,
     /* .supports_buft        = */ ggml_backend_hexagon_device_supports_buft,
-    /* .offload_op           = */ NULL,  // ggml_backend_hexagon_device_offload_op,
+    /* .offload_op           = */ ggml_backend_hexagon_device_offload_op,
     /* .event_new            = */ NULL,
     /* .event_free           = */ NULL,
     /* .event_synchronize    = */ NULL,

--- a/ggml/src/ggml-hexagon/htp-drv.cpp
+++ b/ggml/src/ggml-hexagon/htp-drv.cpp
@@ -19,6 +19,100 @@
 #    include <dlfcn.h>
 #    include <unistd.h>
 #endif
+#ifdef __ANDROID__
+#    include <android/dlext.h>
+#    include <elf.h>
+#    include <link.h>
+// android_get_exported_namespace is in libdl_android.so but not in public NDK headers
+typedef struct android_namespace_t * (*android_get_exported_namespace_pfn_t)(const char *);
+
+// Resolve a symbol from an already-loaded library by parsing its ELF dynamic
+// symbol table via dl_iterate_phdr.  This bypasses dlsym namespace restrictions.
+struct elf_sym_lookup {
+    const char * library;
+    const char * symbol;
+    void *       result;
+};
+
+static int elf_sym_lookup_cb(struct dl_phdr_info * info, size_t /*size*/, void * data) {
+    auto * ctx = static_cast<elf_sym_lookup *>(data);
+    if (!info->dlpi_name || !strstr(info->dlpi_name, ctx->library)) {
+        return 0;  // not the library we want
+    }
+
+    // Find PT_DYNAMIC segment
+    const ElfW(Dyn) * dyn_start = nullptr;
+    for (ElfW(Half) i = 0; i < info->dlpi_phnum; i++) {
+        if (info->dlpi_phdr[i].p_type == PT_DYNAMIC) {
+            dyn_start = reinterpret_cast<const ElfW(Dyn) *>(
+                info->dlpi_addr + info->dlpi_phdr[i].p_vaddr);
+            break;
+        }
+    }
+    if (!dyn_start) return 0;
+
+    // Extract symbol table, string table, and hash table from dynamic section.
+    // d_un.d_ptr values may be unrelocated VAs — add load bias if they look
+    // like small offsets (i.e. less than the library's base address).
+    const ElfW(Sym) * symtab = nullptr;
+    const char *       strtab = nullptr;
+    const ElfW(Word) * hashtab = nullptr;
+    const uint32_t *   gnu_hash = nullptr;
+    auto dyn_ptr = [&](ElfW(Addr) val) -> uintptr_t {
+        return (val < static_cast<ElfW(Addr)>(info->dlpi_addr))
+             ? (info->dlpi_addr + val) : val;
+    };
+
+    for (const ElfW(Dyn) * d = dyn_start; d->d_tag != DT_NULL; d++) {
+        switch (d->d_tag) {
+            case DT_SYMTAB:   symtab   = reinterpret_cast<const ElfW(Sym) *>(dyn_ptr(d->d_un.d_ptr)); break;
+            case DT_STRTAB:   strtab   = reinterpret_cast<const char *>(dyn_ptr(d->d_un.d_ptr));      break;
+            case DT_HASH:     hashtab  = reinterpret_cast<const ElfW(Word) *>(dyn_ptr(d->d_un.d_ptr)); break;
+            case DT_GNU_HASH: gnu_hash = reinterpret_cast<const uint32_t *>(dyn_ptr(d->d_un.d_ptr));   break;
+        }
+    }
+    if (!symtab || !strtab) return 0;
+
+    // Determine number of symbols from DT_HASH (nchain == nsyms)
+    size_t nsyms = 0;
+    if (hashtab) {
+        nsyms = hashtab[1];  // hashtab[0]=nbuckets, hashtab[1]=nchain
+    } else if (gnu_hash) {
+        // Approximate: scan GNU hash to find max symndx
+        uint32_t nbuckets  = gnu_hash[0];
+        uint32_t symoffset = gnu_hash[1];
+        uint32_t bloom_sz  = gnu_hash[2];
+        const uint32_t * buckets =
+            reinterpret_cast<const uint32_t *>(&gnu_hash[4] + bloom_sz * (sizeof(ElfW(Addr))/4));
+        uint32_t max_idx = symoffset;
+        for (uint32_t i = 0; i < nbuckets; i++) {
+            if (buckets[i] > max_idx) max_idx = buckets[i];
+        }
+        // Walk chain from max_idx until we find the end marker (LSB set)
+        const uint32_t * chain = buckets + nbuckets - symoffset;
+        while (!(chain[max_idx] & 1)) max_idx++;
+        nsyms = max_idx + 1;
+    } else {
+        nsyms = 256;  // small fallback
+    }
+
+    for (size_t i = 0; i < nsyms; i++) {
+        if (symtab[i].st_shndx == SHN_UNDEF) continue;
+        if (strcmp(strtab + symtab[i].st_name, ctx->symbol) == 0) {
+            ctx->result = reinterpret_cast<void *>(
+                info->dlpi_addr + symtab[i].st_value);
+            return 1;  // found, stop iteration
+        }
+    }
+    return 0;
+}
+
+static void * elf_find_symbol(const char * lib_name, const char * sym_name) {
+    elf_sym_lookup ctx { lib_name, sym_name, nullptr };
+    dl_iterate_phdr(elf_sym_lookup_cb, &ctx);
+    return ctx.result;
+}
+#endif
 #include "ggml-impl.h"
 #include "htp-drv.h"
 #include "libdl.h"
@@ -311,18 +405,64 @@ int htpdrv_init() {
 #ifdef _WIN32
     std::string drv_path = get_driver_path() + "\\" + "libcdsprpc.dll";
 #else
-    std::string drv_path = "libcdsprpc.so";
+    const char * vendor_lib = getenv("GGML_HEXAGON_VENDOR_LIB");
+    std::string drv_path = (vendor_lib && vendor_lib[0] != '\0')
+                         ? vendor_lib
+                         : "libcdsprpc.so";
 #endif
     if (initialized) {
         GGML_LOG_INFO("ggml-hex: Driver already loaded\n");
         return AEE_SUCCESS;
     }
-    GGML_LOG_INFO("ggml-hex: Loading driver %s\n", drv_path.c_str());
 
-    fs::path path{ drv_path.c_str() };
-    dl_handle_ptr handle { dl_load_library(path) };
+    // When loading a vendor lib from a custom path, try android_dlopen_ext with
+    // the "sphal" namespace which has vendor/lib64 in its search paths and links
+    // to vndk for transitive deps (libhidlbase, libcutils, libhardware, etc.).
+    dl_handle_ptr handle { nullptr };
+#ifdef __ANDROID__
+    if (vendor_lib && vendor_lib[0] != '\0') {
+        // Load directly from /vendor/lib64 via sphal namespace which has
+        // vendor search paths and vndk linkage for transitive deps.
+        drv_path = "libcdsprpc.so";
+        GGML_LOG_INFO("ggml-hex: Trying sphal namespace for vendor FastRPC lib\n");
+
+        // Resolve android_get_exported_namespace by parsing ELF symtab of the
+        // already-loaded libdl_android.so — this bypasses dlsym namespace
+        // restrictions that prevent apps from calling private linker APIs.
+        auto get_ns = (android_get_exported_namespace_pfn_t)
+            elf_find_symbol("libdl_android.so", "android_get_exported_namespace");
+
+        if (get_ns) {
+            GGML_LOG_INFO("ggml-hex: resolved android_get_exported_namespace via ELF parsing\n");
+            struct android_namespace_t * sphal_ns = get_ns("sphal");
+            if (sphal_ns) {
+                android_dlextinfo extinfo = {};
+                extinfo.flags = ANDROID_DLEXT_USE_NAMESPACE;
+                extinfo.library_namespace = sphal_ns;
+                void * h = android_dlopen_ext(drv_path.c_str(),
+                                              RTLD_NOW | RTLD_LOCAL, &extinfo);
+                if (h) {
+                    handle.reset(static_cast<dl_handle *>(h));
+                    GGML_LOG_INFO("ggml-hex: Loaded vendor lib via sphal namespace\n");
+                } else {
+                    GGML_LOG_WARN("ggml-hex: sphal dlopen failed: %s\n", dlerror());
+                }
+            } else {
+                GGML_LOG_WARN("ggml-hex: sphal namespace not found\n");
+            }
+        } else {
+            GGML_LOG_WARN("ggml-hex: could not resolve android_get_exported_namespace\n");
+        }
+    }
+#endif
+
     if (!handle) {
-        GGML_LOG_ERROR("ggml-hex: failed to load %s: %s\n", path.u8string().c_str(), dl_error());
+        GGML_LOG_INFO("ggml-hex: Loading driver %s (standard dlopen)\n", drv_path.c_str());
+        fs::path path{ drv_path.c_str() };
+        handle.reset(dl_load_library(path));
+    }
+    if (!handle) {
+        GGML_LOG_ERROR("ggml-hex: failed to load %s: %s\n", drv_path.c_str(), dl_error());
         return AEE_EUNABLETOLOAD;
     }
 

--- a/ggml/src/ggml-hexagon/htp/CMakeLists.txt
+++ b/ggml/src/ggml-hexagon/htp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22.2)
+cmake_minimum_required(VERSION 3.22.1)
 project(ggml-htp C CXX ASM)
 
 include(${HEXAGON_SDK_ROOT}/build/cmake/hexagon_fun.cmake)

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -35,6 +35,8 @@ GGML_API void quantize_row_q8_K_ref(const float * GGML_RESTRICT x, block_q8_K * 
 GGML_API void quantize_row_tq1_0_ref(const float * GGML_RESTRICT x, block_tq1_0 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_tq2_0_ref(const float * GGML_RESTRICT x, block_tq2_0 * GGML_RESTRICT y, int64_t k);
 
+GGML_API void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * GGML_RESTRICT y, int64_t k);
+
 GGML_API void quantize_row_iq3_xxs_ref(const float * GGML_RESTRICT x, block_iq3_xxs * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_iq4_nl_ref (const float * GGML_RESTRICT x, block_iq4_nl  * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_iq4_xs_ref (const float * GGML_RESTRICT x, block_iq4_xs  * GGML_RESTRICT y, int64_t k);
@@ -63,6 +65,8 @@ GGML_API void dequantize_row_q8_K(const block_q8_K * GGML_RESTRICT x, float * GG
 GGML_API void dequantize_row_tq1_0(const block_tq1_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_tq2_0(const block_tq2_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
+GGML_API void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+
 GGML_API void dequantize_row_iq2_xxs(const block_iq2_xxs * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_iq2_xs (const block_iq2_xs  * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_iq2_s  (const block_iq2_s   * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
@@ -85,6 +89,8 @@ GGML_API size_t quantize_iq4_xs (const float * GGML_RESTRICT src, void * GGML_RE
 GGML_API size_t quantize_iq3_s  (const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API size_t quantize_tq1_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+GGML_API size_t quantize_turbo4_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+
 GGML_API size_t quantize_tq2_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API size_t quantize_q2_K(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);

--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -1,0 +1,234 @@
+// TurboQuant 4-bit PolarQuant (ICLR 2026, arXiv 2504.19874)
+// Implements GGML_TYPE_TURBO4_0: 4-bit KV cache compression using
+// PolarQuant with Walsh-Hadamard Transform rotation.
+//
+// Quantize: extract L2 norm -> normalize -> WHT rotation -> 4-bit centroid -> pack
+// Dequantize: unpack -> centroid lookup -> scale by norm -> inverse WHT
+//
+// Dequant includes inverse WHT for CPU correctness without graph modifications.
+
+#include "ggml-impl.h"
+#include "ggml-quants.h"
+
+#define GGML_COMMON_IMPL_C
+#include "ggml-common.h"
+
+#include <math.h>
+#include <string.h>
+#include <assert.h>
+
+// 16 optimal Lloyd-Max centroids for unit-norm Gaussian (PolarQuant paper Table 1)
+static const float CENTROIDS_4BIT[16] = {
+    -0.173926f, -0.117195f, -0.089527f, -0.068756f,
+    -0.051262f, -0.035597f, -0.020989f, -0.006938f,
+     0.006938f,  0.020989f,  0.035597f,  0.051262f,
+     0.068756f,  0.089527f,  0.117195f,  0.173926f,
+};
+
+// Walsh-Hadamard Transform sign arrays (length 128)
+// Pseudo-random +/-1 sequences for randomized WHT rotation
+static const float turbo_cpu_s1[128] = {
+     1, 1,-1,-1, 1, 1, 1, 1,-1, 1,-1,-1,-1,-1,-1,-1,
+     1, 1, 1,-1,-1, 1, 1,-1, 1,-1,-1,-1,-1, 1, 1,-1,
+     1, 1, 1,-1, 1, 1,-1,-1, 1,-1,-1,-1, 1, 1,-1, 1,
+     1,-1, 1, 1, 1, 1,-1,-1,-1, 1,-1,-1, 1,-1,-1,-1,
+    -1,-1,-1,-1,-1, 1, 1,-1,-1, 1, 1, 1, 1,-1,-1,-1,
+    -1, 1, 1, 1,-1,-1,-1, 1, 1,-1, 1, 1, 1, 1, 1, 1,
+    -1,-1,-1,-1, 1,-1, 1, 1,-1,-1, 1,-1, 1,-1, 1,-1,
+     1,-1, 1,-1, 1, 1, 1, 1,-1,-1, 1, 1, 1,-1,-1,-1,
+};
+
+static const float turbo_cpu_s2[128] = {
+    -1,-1,-1, 1, 1,-1,-1,-1, 1,-1, 1,-1,-1,-1, 1,-1,
+     1, 1,-1,-1,-1,-1, 1,-1, 1,-1,-1, 1,-1, 1,-1, 1,
+     1, 1, 1, 1,-1, 1,-1,-1,-1, 1, 1,-1,-1,-1, 1, 1,
+     1,-1,-1,-1,-1, 1, 1,-1,-1, 1, 1,-1, 1, 1,-1,-1,
+    -1,-1,-1,-1, 1,-1, 1, 1,-1,-1, 1,-1, 1,-1,-1,-1,
+     1, 1, 1,-1,-1, 1,-1, 1,-1,-1,-1, 1,-1, 1,-1, 1,
+     1,-1, 1, 1,-1, 1, 1, 1,-1,-1, 1,-1, 1,-1, 1,-1,
+    -1, 1, 1, 1,-1,-1, 1, 1, 1, 1, 1, 1, 1,-1, 1, 1,
+};
+
+// 1/sqrt(128) for normalization after Hadamard butterfly
+#define INV_SQRT_128 0.08838834764831845f
+
+// Forward WHT: y = (1/sqrt(N)) * S2 * H * S1 * x
+static void turbo_fwht_forward(float * x, int n) {
+    for (int i = 0; i < n; i++) {
+        x[i] *= turbo_cpu_s1[i];
+    }
+    for (int h = 1; h < n; h *= 2) {
+        for (int i = 0; i < n; i += h * 2) {
+            for (int j = i; j < i + h; j++) {
+                float a = x[j];
+                float b = x[j + h];
+                x[j]     = a + b;
+                x[j + h] = a - b;
+            }
+        }
+    }
+    for (int i = 0; i < n; i++) {
+        x[i] *= INV_SQRT_128 * turbo_cpu_s2[i];
+    }
+}
+
+// Inverse WHT: x = (1/sqrt(N)) * S1 * H * S2 * y
+// WHT is self-inverse up to scaling; inverse just swaps s1 and s2
+static void turbo_fwht_inverse(float * x, int n) {
+    for (int i = 0; i < n; i++) {
+        x[i] *= turbo_cpu_s2[i];
+    }
+    for (int h = 1; h < n; h *= 2) {
+        for (int i = 0; i < n; i += h * 2) {
+            for (int j = i; j < i + h; j++) {
+                float a = x[j];
+                float b = x[j + h];
+                x[j]     = a + b;
+                x[j + h] = a - b;
+            }
+        }
+    }
+    for (int i = 0; i < n; i++) {
+        x[i] *= INV_SQRT_128 * turbo_cpu_s1[i];
+    }
+}
+
+// Binary tree search for nearest centroid (4 comparisons for 16 centroids)
+// Uses midpoints between consecutive centroids for optimal assignment
+static inline uint8_t nearest_centroid_4bit(float x) {
+    if (x < 0.0f) {
+        if (x < -0.060009f) {
+            if (x < -0.103361f) {
+                return (x < -0.145561f) ? 0 : 1;
+            } else {
+                return (x < -0.079142f) ? 2 : 3;
+            }
+        } else {
+            if (x < -0.028293f) {
+                return (x < -0.043430f) ? 4 : 5;
+            } else {
+                return (x < -0.013964f) ? 6 : 7;
+            }
+        }
+    } else {
+        if (x < 0.060009f) {
+            if (x < 0.028293f) {
+                return (x < 0.013964f) ? 8 : 9;
+            } else {
+                return (x < 0.043430f) ? 10 : 11;
+            }
+        } else {
+            if (x < 0.103361f) {
+                return (x < 0.079142f) ? 12 : 13;
+            } else {
+                return (x < 0.145561f) ? 14 : 15;
+            }
+        }
+    }
+}
+
+// Quantize a single row of floats to turbo4_0 blocks
+// Each block covers QK_TURBO4 (128) values = one rotation group
+void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TURBO4 == 0);
+    const int nb = (int)(k / QK_TURBO4);
+
+    for (int block = 0; block < nb; block++) {
+        const float * src = x + block * QK_TURBO4;
+        float tmp[QK_TURBO4];
+
+        // Step 1: compute L2 norm
+        float sum_sq = 0.0f;
+        for (int i = 0; i < QK_TURBO4; i++) {
+            sum_sq += src[i] * src[i];
+        }
+        float norm = sqrtf(sum_sq);
+
+        if (norm < 1e-10f) {
+            y[block].norm  = GGML_FP32_TO_FP16(0.0f);
+            y[block].rnorm = GGML_FP32_TO_FP16(0.0f);
+            memset(y[block].qs, 0, QK_TURBO4 / 2);
+            continue;
+        }
+
+        // Step 2: normalize to unit vector
+        float inv_norm = 1.0f / norm;
+        for (int i = 0; i < QK_TURBO4; i++) {
+            tmp[i] = src[i] * inv_norm;
+        }
+
+        // Step 3: forward WHT rotation
+        turbo_fwht_forward(tmp, QK_TURBO4);
+
+        // Step 4: 4-bit centroid quantization
+        float recon_sq = 0.0f;
+        uint8_t indices[QK_TURBO4];
+        for (int i = 0; i < QK_TURBO4; i++) {
+            uint8_t idx = nearest_centroid_4bit(tmp[i]);
+            indices[i] = idx;
+            recon_sq += CENTROIDS_4BIT[idx] * CENTROIDS_4BIT[idx];
+        }
+
+        // Nibble pack: low nibble = even index, high nibble = odd index
+        for (int i = 0; i < QK_TURBO4 / 2; i++) {
+            y[block].qs[i] = indices[2 * i] | (indices[2 * i + 1] << 4);
+        }
+
+        // Step 5: norm correction
+        // corrected_norm = original_norm / reconstruction_norm
+        float recon_norm = sqrtf(recon_sq);
+        float corrected_norm = (recon_norm > 1e-10f) ? (norm / recon_norm) : norm;
+        y[block].norm  = GGML_FP32_TO_FP16(corrected_norm);
+        y[block].rnorm = GGML_FP32_TO_FP16(0.0f);
+    }
+}
+
+// Dequantize turbo4_0 blocks back to float
+// Performs inverse WHT for CPU correctness (no graph modifications needed)
+void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_TURBO4 == 0);
+    const int nb = (int)(k / QK_TURBO4);
+
+    for (int block = 0; block < nb; block++) {
+        float corrected_norm = GGML_FP16_TO_FP32(x[block].norm);
+        float * dst = y + block * QK_TURBO4;
+
+        // Step 1: unpack nibbles and look up centroids
+        for (int i = 0; i < QK_TURBO4 / 2; i++) {
+            uint8_t packed = x[block].qs[i];
+            dst[2 * i]     = CENTROIDS_4BIT[packed & 0x0F];
+            dst[2 * i + 1] = CENTROIDS_4BIT[(packed >> 4) & 0x0F];
+        }
+
+        // Step 2: inverse WHT to recover original domain
+        turbo_fwht_inverse(dst, QK_TURBO4);
+
+        // Step 3: scale by corrected norm
+        for (int i = 0; i < QK_TURBO4; i++) {
+            dst[i] *= corrected_norm;
+        }
+    }
+}
+
+// CPU backend from_float wrapper: (const float *, void *, int64_t) signature
+// Used by type_traits_cpu for set_rows and other CPU ops
+void quantize_row_turbo4_0(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k) {
+    quantize_row_turbo4_0_ref(x, (block_turbo4_0 *)vy, k);
+}
+
+// Multi-row quantize wrapper (used by ggml_quantize_chunk)
+size_t quantize_turbo4_0(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
+                         int64_t nrows, int64_t n_per_row,
+                         const float * imatrix) {
+    (void)imatrix; // importance matrix not used for KV cache quantization
+    assert(n_per_row % QK_TURBO4 == 0);
+    const size_t row_size = (n_per_row / QK_TURBO4) * sizeof(block_turbo4_0);
+    for (int64_t row = 0; row < nrows; row++) {
+        quantize_row_turbo4_0_ref(
+            src + row * n_per_row,
+            (block_turbo4_0 *)((char *)dst + row * row_size),
+            n_per_row
+        );
+    }
+    return nrows * row_size;
+}

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -912,6 +912,14 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .type_size                = 0,
         .is_quantized             = false,
     },
+    [GGML_TYPE_TURBO4_0] = {
+        .type_name                = "turbo4_0",
+        .blck_size                = QK_TURBO4,
+        .type_size                = sizeof(block_turbo4_0),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_turbo4_0,
+        .from_float_ref           = (ggml_from_float_t) quantize_row_turbo4_0_ref,
+    },
 };
 
 const struct ggml_type_traits * ggml_get_type_traits(enum ggml_type type) {
@@ -7662,6 +7670,7 @@ size_t ggml_quantize_chunk(
 
     switch (type) {
         case GGML_TYPE_Q1_0:    result = quantize_q1_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_TURBO4_0: result = quantize_turbo4_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q4_0:    result = quantize_q4_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q4_1:    result = quantize_q4_1(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q5_0:    result = quantize_q5_0(src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;


### PR DESCRIPTION
This pull request introduces a new experimental quantization type, TurboQuant 4-bit (PolarQuant), and improves Hexagon backend support, especially for Android environments. The most notable changes are the addition of the TurboQuant quantization format and enhanced handling and deployment of Hexagon HTP skeletons and vendor libraries. Below are the key changes grouped by theme:

**TurboQuant 4-bit Quantization Support:**

* Added new quantization type `GGML_TYPE_TURBO4_0` for TurboQuant 4-bit PolarQuant, including its definition, block structure (`block_turbo4_0`), and associated quantization/dequantization functions in the quantization headers and CPU implementation. [[1]](diffhunk://#diff-7dea3e94fe52f756a218321acc77042d0a333fd3d7e4c35160920ce6e86cb400L432-R433) [[2]](diffhunk://#diff-7dcd867325506dfe5ad4e4bfb9fd586a590c6104e7e99154f62ead097754976bR280-R291) [[3]](diffhunk://#diff-c6a1e06a6fde28f814f6a4033b2f1da6ae192513a8bb2130c021d39f670874acR38-R39) [[4]](diffhunk://#diff-c6a1e06a6fde28f814f6a4033b2f1da6ae192513a8bb2130c021d39f670874acR68-R69) [[5]](diffhunk://#diff-c6a1e06a6fde28f814f6a4033b2f1da6ae192513a8bb2130c021d39f670874acR92-R93) [[6]](diffhunk://#diff-3dfb056f1ce5ee9bb5ab48336c48127b2ae765dd68716b75a13eee5cecdd6a93R399-R403) [[7]](diffhunk://#diff-c60adeaa9d046107defeeff214aa3e2cc9502eaf217ab7a1b8a4ca5c76d4dd1aR36-R37) [[8]](diffhunk://#diff-f3a359c2393a8c0bf7cb0cbe9e4622c62366566bb4956ebf8d56e1bd196f8fe7R390) [[9]](diffhunk://#diff-d4bb67eec77d05ad8d4056c50492de104bd17dc6e0b0f9919854aeeaa5002842R208)

**Hexagon Backend and Android Vendor Library Improvements:**

* Enhanced Hexagon HTP skeleton build process to ensure skeletons are built and copied alongside `libggml-hexagon.so`, simplifying Android packaging and deployment. [[1]](diffhunk://#diff-9c7f1683a535314f5b02151d494da2f342068dd79a5d802e86ad5f32a3800a49R63-R84) [[2]](diffhunk://#diff-9c7f1683a535314f5b02151d494da2f342068dd79a5d802e86ad5f32a3800a49R95-R102)
* Improved vendor library loading on Android by using the `sphal` namespace and ELF symbol table parsing to resolve private linker APIs, allowing more robust loading of vendor-specific FastRPC libraries. [[1]](diffhunk://#diff-20e202d0e1cca6350cb97f308715c25a77054b45f54b31f46eb2d0eb799c8da2R22-R115) [[2]](diffhunk://#diff-20e202d0e1cca6350cb97f308715c25a77054b45f54b31f46eb2d0eb799c8da2L314-R465)

**Hexagon Backend Robustness and Offloading:**

* Changed session initialization to log a warning instead of throwing an error if unsigned PD control fails, allowing fallback to signed/skel-compatible flows.
* Aggressively offload all supported operations to the NPU by implementing and enabling the `offload_op` callback in the Hexagon backend. [[1]](diffhunk://#diff-3fab5ceb81226b859a7d06cb46c62d6cc026104fd95971743f0927621135d1baR3326-R3332) [[2]](diffhunk://#diff-3fab5ceb81226b859a7d06cb46c62d6cc026104fd95971743f0927621135d1baL3337-R3345)

**Build System:**

* Minor update to the CMake minimum version in the HTP subdirectory.
