### PR TITLE
tests: Fix unit test failing when built with ICX on Windows

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -706,6 +706,11 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
 
     if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
         # The compiler automatically enables "-ffast-math" which can cause NaNs in tests due to "-fassociative-math"
-        target_compile_options(${GGML_CPU_NAME} PRIVATE "-fno-associative-math")
+        if (MSVC)
+            # IntelLLVM in clang-cl mode needs /clang: to forward LLVM-style flags.
+            target_compile_options(${GGML_CPU_NAME} PRIVATE "/clang:-fno-associative-math")
+        else()
+            target_compile_options(${GGML_CPU_NAME} PRIVATE "-fno-associative-math")
+        endif()
     endif()
 endfunction()


### PR DESCRIPTION
## Overview
When using ICX (Intel oneAPI DPC++/C++ Compiler) on Windows, we were seeing mismatch on following unit tests

```
[EXP] inf mismatch: Vulkan0=inf CPU=11304.000000   EXP(type=f16,ne_a=[128,2,2,2],v=0): FAIL
[EXP] inf mismatch: Vulkan0=inf CPU=13.148438   EXP(type=f16,ne_a=[5,7,11,13],v=0): FAIL
```
The build log was showing following warning so I fixed the cmake file to pass the options correctly.

```
icx: warning: unknown argument ignored in clang-cl: '-fno-associative-math' [-Wunknown-argument]
```

All `test-backend-ops` are passing now.

```
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Intel(R) Arc(TM) B580 Graphics (Intel Corporation) | uma: 0 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: KHR_coopmat
Testing 3 devices

Backend 1/3: SYCL0
  Skipping
Backend 2/3: Vulkan0
  Device description: Intel(R) Arc(TM) B580 Graphics
  Device memory: 12118 MB (11323 MB free)

  ABS(type=f16,ne_a=[128,2,2,2],v=0): ESC[1;32mOKESC[0m
  ABS(type=f16,ne_a=[5,7,11,13],v=0): ESC[1;32mOKESC[0m
...
  GATED_DELTA_NET(type=f32,head_count=4,head_size=64,n_seq_tokens=4,n_seqs=2,v_repeat=1,permuted=0,kda=1): OK
  GATED_DELTA_NET(type=f32,head_count=8,head_size=32,n_seq_tokens=4,n_seqs=2,v_repeat=2,permuted=0,kda=1): OK
  GATED_DELTA_NET(type=f32,head_count=4,head_size=64,n_seq_tokens=4,n_seqs=2,v_repeat=1,permuted=1,kda=1): OK
  GATED_DELTA_NET(type=f32,head_count=4,head_size=16,n_seq_tokens=4,n_seqs=2,v_repeat=1,permuted=1,kda=1): not supported [Vulkan0]
  12075/12075 tests passed
  Backend Vulkan0: OK
Backend 3/3: CPU
  Skipping
3/3 backends passed
OK
```


<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

### How to reproduce
Install [Intel Deep Learning Essentials](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?packages=dl-essentials&dl-essentials-os=linux&dl-lin=offline) and run the following.
## 
```
$ "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
$ cmake -B build_vk_ninja_icx -G "Ninja Multi-Config" -DGGML_VULKAN=ON -DLLAMA_CURL=OFF -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icx
$ cmake --build build_vk_ninja_icx\ --config Release -j
$ build_vk_ninja_icx\bin\Release\test-backend-ops.exe -o EXP(type=f16,ne_a=[128,2,2,2],v=0),EXP(type=f16,ne_a=[5,7,11,13],v=0)
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Intel(R) Arc(TM) B580 Graphics (Intel Corporation) | uma: 0 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: KHR_coopmat
Testing 2 devices

Backend 1/2: Vulkan0
  Device description: Intel(R) Arc(TM) B580 Graphics
  Device memory: 12118 MB (11349 MB free)

[EXP] inf mismatch: Vulkan0=inf CPU=11304.000000   EXP(type=f16,ne_a=[128,2,2,2],v=0): FAIL
[EXP] inf mismatch: Vulkan0=inf CPU=13.148438   EXP(type=f16,ne_a=[5,7,11,13],v=0): FAIL
  0/2 tests passed

Failing tests:
  EXP(type=f16,ne_a=[128,2,2,2],v=0)
  EXP(type=f16,ne_a=[5,7,11,13],v=0)
  Backend Vulkan0: FAIL
Backend 2/2: CPU
  Skipping CPU backend
1/2 backends passed
FAIL
```

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES (GitHub copilot). Used for analysis and solution proposal.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
