### PR TITLE
CUDA: initialize NCCL comms lazily

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -26,6 +26,7 @@
 #include <cfloat>
 #include <cstdio>
 #include <map>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -1152,14 +1153,16 @@ struct ggml_cuda_pool_alloc {
 };
 
 #ifdef GGML_USE_NCCL
-static std::map<std::vector<int>, std::vector<ncclComm_t>> comms;
+static std::map<std::vector<int>, std::vector<ncclComm_t>> nccl_comms;
+static std::mutex nccl_mutex;
 
 static std::vector<ncclComm_t> ggml_cuda_get_nccl_comms(const std::vector<int> & devs) {
-    if (comms.find(devs) == comms.end()) {
-        comms[devs].resize(devs.size());
-        NCCL_CHECK(ncclCommInitAll(comms[devs].data(), devs.size(), devs.data()));
+    std::lock_guard lock(nccl_mutex);
+    if (nccl_comms.find(devs) == nccl_comms.end()) {
+        nccl_comms[devs].resize(devs.size());
+        NCCL_CHECK(ncclCommInitAll(nccl_comms[devs].data(), devs.size(), devs.data()));
     }
-    return comms[devs];
+    return nccl_comms[devs];
 }
 #endif // GGML_USE_NCCL
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1152,20 +1152,6 @@ struct ggml_cuda_pool_alloc {
     ggml_cuda_pool_alloc& operator=(ggml_cuda_pool_alloc &&) = delete;
 };
 
-#ifdef GGML_USE_NCCL
-static std::map<std::vector<int>, std::vector<ncclComm_t>> nccl_comms;
-static std::mutex nccl_mutex;
-
-static std::vector<ncclComm_t> ggml_cuda_get_nccl_comms(const std::vector<int> & devs) {
-    std::lock_guard lock(nccl_mutex);
-    if (nccl_comms.find(devs) == nccl_comms.end()) {
-        nccl_comms[devs].resize(devs.size());
-        NCCL_CHECK(ncclCommInitAll(nccl_comms[devs].data(), devs.size(), devs.data()));
-    }
-    return nccl_comms[devs];
-}
-#endif // GGML_USE_NCCL
-
 // backend interface
 
 struct ggml_tensor_extra_gpu {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <cfloat>
 #include <cstdio>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -1092,10 +1093,6 @@ struct ggml_cuda_device_info {
     cuda_device_info devices[GGML_CUDA_MAX_DEVICES] = {};
 
     std::array<float, GGML_CUDA_MAX_DEVICES> default_tensor_split = {};
-
-#ifdef GGML_USE_NCCL
-    ncclComm_t comms[GGML_CUDA_MAX_DEVICES];
-#endif // GGML_USE_NCCL
 };
 
 const ggml_cuda_device_info & ggml_cuda_info();
@@ -1154,6 +1151,17 @@ struct ggml_cuda_pool_alloc {
     ggml_cuda_pool_alloc& operator=(ggml_cuda_pool_alloc &&) = delete;
 };
 
+#ifdef GGML_USE_NCCL
+static std::map<std::vector<int>, std::vector<ncclComm_t>> comms;
+
+static std::vector<ncclComm_t> ggml_cuda_get_nccl_comms(const std::vector<int> & devs) {
+    if (comms.find(devs) == comms.end()) {
+        comms[devs].resize(devs.size());
+        NCCL_CHECK(ncclCommInitAll(comms[devs].data(), devs.size(), devs.data()));
+    }
+    return comms[devs];
+}
+#endif // GGML_USE_NCCL
 
 // backend interface
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1142,15 +1142,18 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
 
     // For small tensors, simply reduce them as FP32.
     // The following heuristic for how "small" a tensor should be is based on RTX 4090s connected via 16x PCIe 4.0.
-    if ((n_backends <= 2 && ne < 32768) || (n_backends == 3 && ne < 131072) || (n_backends >= 4 && ne < 262144)) {
-        NCCL_CHECK(ncclGroupStart());
-        for (size_t i = 0; i < n_backends; ++i) {
-            ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-            NCCL_CHECK(ncclAllReduce(tensors[i]->data, tensors[i]->data, ne, ncclFloat, ncclSum, comms[i], cuda_ctx->stream()));
-        }
-        NCCL_CHECK(ncclGroupEnd());
+    {
+        std::lock_guard lock(nccl_mutex);
+        if ((n_backends <= 2 && ne < 32768) || (n_backends == 3 && ne < 131072) || (n_backends >= 4 && ne < 262144)) {
+            NCCL_CHECK(ncclGroupStart());
+            for (size_t i = 0; i < n_backends; ++i) {
+                ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
+                NCCL_CHECK(ncclAllReduce(tensors[i]->data, tensors[i]->data, ne, ncclFloat, ncclSum, comms[i], cuda_ctx->stream()));
+            }
+            NCCL_CHECK(ncclGroupEnd());
 
-        return true;
+            return true;
+        }
     }
 
     // For large tensors it's faster to compress them to BF16 for the reduction:
@@ -1168,12 +1171,15 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
         CUDA_CHECK(cudaGetLastError());
     }
 
-    NCCL_CHECK(ncclGroupStart());
-    for (size_t i = 0; i < n_backends; ++i) {
-        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-        NCCL_CHECK(ncclAllReduce(tmp[i].get(), tmp[i].get(), ne, ncclBfloat16, ncclSum, comms[i], cuda_ctx->stream()));
+    {
+        std::lock_guard lock(nccl_mutex);
+        NCCL_CHECK(ncclGroupStart());
+        for (size_t i = 0; i < n_backends; ++i) {
+            ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
+            NCCL_CHECK(ncclAllReduce(tmp[i].get(), tmp[i].get(), ne, ncclBfloat16, ncclSum, comms[i], cuda_ctx->stream()));
+        }
+        NCCL_CHECK(ncclGroupEnd());
     }
-    NCCL_CHECK(ncclGroupEnd());
 
     for (size_t i = 0; i < n_backends; ++i) {
         ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -338,14 +338,6 @@ static ggml_cuda_device_info ggml_cuda_init() {
         }
     }
 
-#ifdef GGML_USE_NCCL
-    int dev_ids[GGML_CUDA_MAX_DEVICES];
-    for (int id = 0; id < info.device_count; ++id) {
-        dev_ids[id] = id;
-    }
-    NCCL_CHECK(ncclCommInitAll(info.comms, info.device_count, dev_ids));
-#endif // GGML_USE_NCCL
-
     return info;
 }
 
@@ -1139,7 +1131,14 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
         GGML_ASSERT(ggml_is_contiguously_allocated(tensors[i]));
     }
 
-    const ggml_cuda_device_info info = ggml_cuda_info();
+    const ggml_cuda_device_info & info = ggml_cuda_info();
+    std::vector<int> dev_ids;
+    dev_ids.reserve(n_backends);
+    for (size_t i = 0; i < n_backends; ++i) {
+        ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
+        dev_ids.push_back(cuda_ctx->device);
+    }
+    const std::vector<ncclComm_t> comms = ggml_cuda_get_nccl_comms(dev_ids);
 
     // For small tensors, simply reduce them as FP32.
     // The following heuristic for how "small" a tensor should be is based on RTX 4090s connected via 16x PCIe 4.0.
@@ -1147,7 +1146,7 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
         NCCL_CHECK(ncclGroupStart());
         for (size_t i = 0; i < n_backends; ++i) {
             ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-            NCCL_CHECK(ncclAllReduce(tensors[i]->data, tensors[i]->data, ne, ncclFloat, ncclSum, info.comms[cuda_ctx->device], cuda_ctx->stream()));
+            NCCL_CHECK(ncclAllReduce(tensors[i]->data, tensors[i]->data, ne, ncclFloat, ncclSum, comms[i], cuda_ctx->stream()));
         }
         NCCL_CHECK(ncclGroupEnd());
 
@@ -1172,7 +1171,7 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
     NCCL_CHECK(ncclGroupStart());
     for (size_t i = 0; i < n_backends; ++i) {
         ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;
-        NCCL_CHECK(ncclAllReduce(tmp[i].get(), tmp[i].get(), ne, ncclBfloat16, ncclSum, info.comms[cuda_ctx->device], cuda_ctx->stream()));
+        NCCL_CHECK(ncclAllReduce(tmp[i].get(), tmp[i].get(), ne, ncclBfloat16, ncclSum, comms[i], cuda_ctx->stream()));
     }
     NCCL_CHECK(ncclGroupEnd());
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -566,6 +566,20 @@ std::unique_ptr<ggml_cuda_pool> ggml_backend_cuda_context::new_pool_for_device(i
     return std::unique_ptr<ggml_cuda_pool>(new ggml_cuda_pool_leg(device));
 }
 
+#ifdef GGML_USE_NCCL
+static std::map<std::vector<int>, std::vector<ncclComm_t>> ggml_cuda_nccl_comms;
+static std::mutex ggml_cuda_nccl_mutex;
+
+static std::vector<ncclComm_t> ggml_cuda_get_nccl_comms(const std::vector<int> & devs) {
+    std::lock_guard lock(ggml_cuda_nccl_mutex);
+    if (ggml_cuda_nccl_comms.find(devs) == ggml_cuda_nccl_comms.end()) {
+        ggml_cuda_nccl_comms[devs].resize(devs.size());
+        NCCL_CHECK(ncclCommInitAll(ggml_cuda_nccl_comms[devs].data(), devs.size(), devs.data()));
+    }
+    return ggml_cuda_nccl_comms[devs];
+}
+#endif // GGML_USE_NCCL
+
 // destroying a cuBLAS handle while a graph is being captured in a different thread can result in a CUDA error
 // this lock is used to ensure that no cuBLAS handle is destroyed while a graph is being captured
 
@@ -1143,7 +1157,7 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
     // For small tensors, simply reduce them as FP32.
     // The following heuristic for how "small" a tensor should be is based on RTX 4090s connected via 16x PCIe 4.0.
     {
-        std::lock_guard lock(nccl_mutex);
+        std::lock_guard lock(ggml_cuda_nccl_mutex);
         if ((n_backends <= 2 && ne < 32768) || (n_backends == 3 && ne < 131072) || (n_backends >= 4 && ne < 262144)) {
             NCCL_CHECK(ncclGroupStart());
             for (size_t i = 0; i < n_backends; ++i) {
@@ -1172,7 +1186,7 @@ bool ggml_backend_cuda_allreduce_tensor(ggml_backend_t * backends, struct ggml_t
     }
 
     {
-        std::lock_guard lock(nccl_mutex);
+        std::lock_guard lock(ggml_cuda_nccl_mutex);
         NCCL_CHECK(ncclGroupStart());
         for (size_t i = 0; i < n_backends; ++i) {
             ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backends[i]->context;


### PR DESCRIPTION
Fixes https://github.com/ggml-org/llama.cpp/issues/21692 .
Fixes https://github.com/ggml-org/llama.cpp/issues/21719 .

On master NCCL comms are created for all GPUs eagerly and unconditionally. However, it seems that NCCL comms consume several hundred MB of VRAM per device Also, if only a subset of visible CUDA devices is used this causes the AllReduce to hang indefinitely on master. This PR makes it so that NCCL comms are created lazily and per vector of device ids. The VRAM for them is never freed until the program terminates but this is an issue with the CUDA backend in general.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: debugging