### PR TITLE
server: ensure prompt caching for SWA models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2344,7 +2344,7 @@ private:
                             const auto n_swa = std::max(0, llama_model_n_swa(model));
 
                             // the largest pos_min required for a checkpoint to be useful
-                            const auto pos_min_thold = std::max(0, pos_next - n_swa);
+                            const auto pos_min_thold = params_base.swa_full ? 0 : std::max(0, pos_next - n_swa);
 
                             if (n_past > 0 && n_past < slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx), slot.id);
@@ -2396,7 +2396,7 @@ private:
                                     SLT_WRN(slot, "%s\n", st1.str().c_str());
                                 }
 
-                                if (pos_min >= pos_min_thold) {
+                                if (pos_min >= pos_min_thold && !params_base.swa_full) {
                                     SLT_WRN(slot, "n_past = %d, slot.prompt.tokens.size() = %d, seq_id = %d, pos_min = %d, n_swa = %d\n", n_past, (int) slot.prompt.tokens.size(), slot.id, pos_min, n_swa);
 
                                     // search for a context checkpoint


### PR DESCRIPTION
## Overview

When using `--swa-full` with Gemma 4 and other SWA models, the server can sometimes incorrectly force full prompt re-processing on every request, even though `--swa-full` allocates a full-size SWA cache where tokens are not pruned.

Fixed by:
- Setting pos_min_thold = 0 when swa_full is enabled (any cached position is useful)
- Skipping checkpoint restoration logic when swa_full is enabled (unnecessary since cache is full-size)

In short, this makes inference faster for SWA models when using prompt caching.

Closes #21468

## Additional information

I was trying to debug a prompt caching issue: slot update_slots: id  0 | task 76 | forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)

1. I've read those issues and other PRs (to no avail):
- #21379
- #13194
- #14163

2. But I could not find a solution to my problem, so I traced the error message to `tools/server/server-context.cpp`
3. Then found pos_min_thold that determines the minimum position that must be present in cache for restoration to work. It was always calculated as `pos_next - n_swa`, which for Gemma 4 means `pos_next - 1024`. I believe this is incorrect for swa_full, as with full-size cache, ANY cached position should be valid.
4. There was also a condition checking if checkpoint restoration was needed, but it didn't account for swa_full. With swa_full, the cache is never pruned so checkpoint restoration is unnecessary.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

