### PR TITLE
mtmd : add MERaLiON-2 multimodal audio support

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -11279,6 +11279,55 @@ class UltravoxWhisperEncoderModel(WhisperEncoderModel):
         self.gguf_writer.add_audio_stack_factor(self.global_config["stack_factor"])
 
 
+@ModelBase.register("MERaLiON2ForConditionalGeneration")
+class MERaLiONWhisperEncoderModel(WhisperEncoderModel):
+    has_vision_encoder = False
+    has_audio_encoder = True
+
+    def get_audio_config(self) -> dict[str, Any] | None:
+        return self.global_config.get("speech_config")
+
+    def set_gguf_parameters(self):
+        super().set_gguf_parameters()
+        self.gguf_writer.add_clip_projector_type(gguf.VisionProjectorType.MERALION)
+        # scale_factor = 15: stacks 15 frames → 1 token (1500 → 100 timesteps)
+        self.gguf_writer.add_audio_stack_factor(self.global_config.get("speech_mlp_scale_factor", 15))
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # Skip text decoder tensors
+        if name.startswith("text_decoder."):
+            return
+
+        # Map speech_encoder.* → audio_tower.*
+        if name.startswith("speech_encoder."):
+            name = name.replace("speech_encoder.", "audio_tower.")
+
+        # Map ln_speech.* → audio.multi_modal_projector.ln_pre.*
+        if name.startswith("ln_speech."):
+            name = name.replace("ln_speech.", "audio.multi_modal_projector.ln_pre.")
+
+        # Map speech_audio_adapter.* → audio.multi_modal_projector.*
+        # Use indexed linear_{bid} naming to fit A_MMPROJ tensor mapping:
+        #   linear_0 = frame compression (19200 → 6400) + SiLU
+        #   linear_1 = gate_proj (6400 → 6400) for GLU
+        #   linear_2 = pool_proj (6400 → 6400) for GLU
+        #   linear_3 = out_proj  (6400 → 3584)
+        if name.startswith("speech_audio_adapter."):
+            name = name.replace("speech_audio_adapter.", "audio.multi_modal_projector.")
+            if ".mlp_adapter.0." in name:
+                name = name.replace(".mlp_adapter.0.", ".linear_0.")
+            elif ".gate_proj." in name:
+                name = name.replace(".gate_proj.", ".linear_1.")
+            elif ".pool_proj." in name:
+                name = name.replace(".pool_proj.", ".linear_2.")
+            elif ".out_proj." in name:
+                name = name.replace(".out_proj.", ".linear_3.")
+
+        # Note: conv bias unsqueeze is handled by parent WhisperEncoderModel
+
+        yield from super().modify_tensors(data_torch, name, bid)
+
+
 @ModelBase.register("VoxtralForConditionalGeneration")
 class VoxtralWhisperEncoderModel(WhisperEncoderModel):
     has_vision_encoder = False # no vision encoder

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -11298,20 +11298,25 @@ class MERaLiONWhisperEncoderModel(WhisperEncoderModel):
 
         if name.startswith("speech_encoder."):
             name = name.replace("speech_encoder.", "audio_tower.")
+            yield from super().modify_tensors(data_torch, name, bid)
+            return
+
+        suffix = "." + name.rsplit(".", 1)[-1]
 
         if name.startswith("ln_speech."):
-            name = name.replace("ln_speech.", "audio.multi_modal_projector.ln_pre.")
+            yield (self.format_tensor_name(gguf.MODEL_TENSOR.A_MM_NORM_PRE, suffix=suffix), data_torch)
+            return
 
         if name.startswith("speech_audio_adapter."):
-            name = name.replace("speech_audio_adapter.", "audio.multi_modal_projector.")
             if ".mlp_adapter.0." in name:
-                name = name.replace(".mlp_adapter.0.", ".linear_0.")
+                yield (self.format_tensor_name(gguf.MODEL_TENSOR.A_MMPROJ, 0, suffix=suffix), data_torch)
             elif ".gate_proj." in name:
-                name = name.replace(".gate_proj.", ".linear_1.")
+                yield (self.format_tensor_name(gguf.MODEL_TENSOR.A_MMPROJ, 1, suffix=suffix), data_torch)
             elif ".pool_proj." in name:
-                name = name.replace(".pool_proj.", ".linear_2.")
+                yield (self.format_tensor_name(gguf.MODEL_TENSOR.A_MMPROJ, 2, suffix=suffix), data_torch)
             elif ".out_proj." in name:
-                name = name.replace(".out_proj.", ".linear_3.")
+                yield (self.format_tensor_name(gguf.MODEL_TENSOR.A_MMPROJ, 3, suffix=suffix), data_torch)
+            return
 
         yield from super().modify_tensors(data_torch, name, bid)
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -11290,28 +11290,18 @@ class MERaLiONWhisperEncoderModel(WhisperEncoderModel):
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
         self.gguf_writer.add_clip_projector_type(gguf.VisionProjectorType.MERALION)
-        # scale_factor = 15: stacks 15 frames → 1 token (1500 → 100 timesteps)
         self.gguf_writer.add_audio_stack_factor(self.global_config.get("speech_mlp_scale_factor", 15))
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        # Skip text decoder tensors
         if name.startswith("text_decoder."):
             return
 
-        # Map speech_encoder.* → audio_tower.*
         if name.startswith("speech_encoder."):
             name = name.replace("speech_encoder.", "audio_tower.")
 
-        # Map ln_speech.* → audio.multi_modal_projector.ln_pre.*
         if name.startswith("ln_speech."):
             name = name.replace("ln_speech.", "audio.multi_modal_projector.ln_pre.")
 
-        # Map speech_audio_adapter.* → audio.multi_modal_projector.*
-        # Use indexed linear_{bid} naming to fit A_MMPROJ tensor mapping:
-        #   linear_0 = frame compression (19200 → 6400) + SiLU
-        #   linear_1 = gate_proj (6400 → 6400) for GLU
-        #   linear_2 = pool_proj (6400 → 6400) for GLU
-        #   linear_3 = out_proj  (6400 → 3584)
         if name.startswith("speech_audio_adapter."):
             name = name.replace("speech_audio_adapter.", "audio.multi_modal_projector.")
             if ".mlp_adapter.0." in name:
@@ -11322,8 +11312,6 @@ class MERaLiONWhisperEncoderModel(WhisperEncoderModel):
                 name = name.replace(".pool_proj.", ".linear_2.")
             elif ".out_proj." in name:
                 name = name.replace(".out_proj.", ".linear_3.")
-
-        # Note: conv bias unsqueeze is handled by parent WhisperEncoderModel
 
         yield from super().modify_tensors(data_torch, name, bid)
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -4115,6 +4115,7 @@ class VisionProjectorType:
     GLMA = "glma" # audio
     QWEN25O = "qwen2.5o" # omni
     VOXTRAL = "voxtral"
+    MERALION = "meralion"  # audio: Whisper + gated MLP adaptor
     LFM2 = "lfm2"
     KIMIVL = "kimivl"
     PADDLEOCR = "paddleocr"

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -2041,7 +2041,7 @@ class TensorNameMap:
         # this prefix is added in the conversion code in modify_tensors()
 
         MODEL_TENSOR.A_MMPROJ: (
-            "audio.multi_modal_projector.linear_{bid}", # ultravox
+            "audio.multi_modal_projector.linear_{bid}", # ultravox, meralion
             "audio_adapter.model.{bid}" # lfm2
         ),
 

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -259,6 +259,7 @@ enum projector_type {
     PROJECTOR_TYPE_GLMA,
     PROJECTOR_TYPE_QWEN25O, // will be replaced by QWEN2A or QWEN25VL depending on clip_ctx
     PROJECTOR_TYPE_VOXTRAL,
+    PROJECTOR_TYPE_MERALION,
     PROJECTOR_TYPE_MUSIC_FLAMINGO,
     PROJECTOR_TYPE_LFM2,
     PROJECTOR_TYPE_KIMIVL,
@@ -302,6 +303,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_GLMA,      "glma"},
     { PROJECTOR_TYPE_QWEN25O,   "qwen2.5o"},
     { PROJECTOR_TYPE_VOXTRAL,   "voxtral"},
+    { PROJECTOR_TYPE_MERALION,  "meralion"},
     { PROJECTOR_TYPE_MUSIC_FLAMINGO, "musicflamingo"},
     { PROJECTOR_TYPE_LFM2,      "lfm2"},
     { PROJECTOR_TYPE_KIMIVL,    "kimivl"},

--- a/tools/mtmd/clip-model.h
+++ b/tools/mtmd/clip-model.h
@@ -467,7 +467,8 @@ struct clip_model {
 
     bool audio_has_stack_frames() const {
         return proj_type == PROJECTOR_TYPE_ULTRAVOX
-            || proj_type == PROJECTOR_TYPE_VOXTRAL;
+            || proj_type == PROJECTOR_TYPE_VOXTRAL
+            || proj_type == PROJECTOR_TYPE_MERALION;
     }
 };
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -890,6 +890,7 @@ static ggml_cgraph * clip_image_build_graph(clip_ctx * ctx, const clip_image_f32
         case PROJECTOR_TYPE_VOXTRAL:
         case PROJECTOR_TYPE_QWEN2A:
         case PROJECTOR_TYPE_GLMA:
+        case PROJECTOR_TYPE_MERALION:
         case PROJECTOR_TYPE_MUSIC_FLAMINGO:
             {
                 builder = std::make_unique<clip_graph_whisper_enc>(ctx, img);
@@ -1399,10 +1400,12 @@ struct clip_model_loader {
                 case PROJECTOR_TYPE_QWEN2A:
                 case PROJECTOR_TYPE_GLMA:
                 case PROJECTOR_TYPE_VOXTRAL:
+                case PROJECTOR_TYPE_MERALION:
                 case PROJECTOR_TYPE_MUSIC_FLAMINGO:
                     {
                         bool require_stack = model.proj_type == PROJECTOR_TYPE_ULTRAVOX ||
                                              model.proj_type == PROJECTOR_TYPE_VOXTRAL ||
+                                             model.proj_type == PROJECTOR_TYPE_MERALION ||
                                              model.proj_type == PROJECTOR_TYPE_GLMA;
                         get_u32(KEY_A_PROJ_STACK_FACTOR, hparams.proj_stack_factor, require_stack);
                         hparams.ffn_op = FFN_GELU_ERF;
@@ -2016,6 +2019,30 @@ struct clip_model_loader {
                     model.mm_2_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 2, "weight"));
                     model.mm_norm_pre_w = get_tensor(string_format(TN_MM_NORM_PRE, "weight"));
                     model.mm_norm_mid_w = get_tensor(string_format(TN_MM_NORM_MID, "weight"));
+                } break;
+            case PROJECTOR_TYPE_MERALION:
+                {
+                    // Whisper encoder conv layers
+                    model.conv1d_1_w = get_tensor(string_format(TN_CONV1D, 1, "weight"));
+                    model.conv1d_1_b = get_tensor(string_format(TN_CONV1D, 1, "bias"));
+                    model.conv1d_2_w = get_tensor(string_format(TN_CONV1D, 2, "weight"));
+                    model.conv1d_2_b = get_tensor(string_format(TN_CONV1D, 2, "bias"));
+                    // MERaLiON adaptor: 4 linear layers + ln_pre
+                    // linear_0 = frame compression (19200→6400) + SiLU
+                    // linear_1 = gate_proj (6400→6400) for GLU
+                    // linear_2 = pool_proj (6400→6400) for GLU
+                    // linear_3 = out_proj  (6400→3584)
+                    model.mm_0_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 0, "weight"));
+                    model.mm_0_b = get_tensor(string_format(TN_MM_AUDIO_MLP, 0, "bias"));
+                    model.mm_1_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 1, "weight"));
+                    model.mm_1_b = get_tensor(string_format(TN_MM_AUDIO_MLP, 1, "bias"));
+                    model.mm_2_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 2, "weight"));
+                    model.mm_2_b = get_tensor(string_format(TN_MM_AUDIO_MLP, 2, "bias"));
+                    model.mm_3_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 3, "weight"));
+                    model.mm_3_b = get_tensor(string_format(TN_MM_AUDIO_MLP, 3, "bias"));
+                    // ln_speech (LayerNorm before adaptor)
+                    model.mm_norm_pre_w = get_tensor(string_format(TN_MM_NORM_PRE, "weight"));
+                    model.mm_norm_pre_b = get_tensor(string_format(TN_MM_NORM_PRE, "bias"));
                 } break;
             case PROJECTOR_TYPE_QWEN2A:
                 {
@@ -2809,6 +2836,7 @@ int clip_n_output_tokens(const struct clip_ctx * ctx, struct clip_image_f32 * im
         case PROJECTOR_TYPE_VOXTRAL:
         case PROJECTOR_TYPE_ULTRAVOX:
         case PROJECTOR_TYPE_QWEN2A:
+        case PROJECTOR_TYPE_MERALION:
         case PROJECTOR_TYPE_MUSIC_FLAMINGO:
             {
                 n_patches = img->nx;
@@ -3298,6 +3326,7 @@ bool clip_image_batch_encode(clip_ctx * ctx, const int n_threads, const clip_ima
         case PROJECTOR_TYPE_ULTRAVOX:
         case PROJECTOR_TYPE_LFM2:
         case PROJECTOR_TYPE_VOXTRAL:
+        case PROJECTOR_TYPE_MERALION:
         case PROJECTOR_TYPE_MUSIC_FLAMINGO:
         case PROJECTOR_TYPE_JANUS_PRO:
         case PROJECTOR_TYPE_PHI4:
@@ -3463,6 +3492,8 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
         case PROJECTOR_TYPE_VOXTRAL:
         case PROJECTOR_TYPE_MUSIC_FLAMINGO:
             return ctx->model.mm_2_w->ne[1];
+        case PROJECTOR_TYPE_MERALION:
+            return ctx->model.mm_3_w->ne[1]; // out_proj output dim
         case PROJECTOR_TYPE_INTERNVL:
         case PROJECTOR_TYPE_NEMOTRON_V2_VL:
             return ctx->model.mm_3_w->ne[1];
@@ -3523,6 +3554,7 @@ bool clip_has_whisper_encoder(const struct clip_ctx * ctx) {
         case PROJECTOR_TYPE_QWEN2A:
         case PROJECTOR_TYPE_GLMA:
         case PROJECTOR_TYPE_VOXTRAL:
+        case PROJECTOR_TYPE_MERALION:
         case PROJECTOR_TYPE_MUSIC_FLAMINGO:
             return true;
         default:

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2028,10 +2028,10 @@ struct clip_model_loader {
                     model.conv1d_2_w = get_tensor(string_format(TN_CONV1D, 2, "weight"));
                     model.conv1d_2_b = get_tensor(string_format(TN_CONV1D, 2, "bias"));
                     // MERaLiON adaptor: 4 linear layers + ln_pre
-                    // linear_0 = frame compression (19200→6400) + SiLU
-                    // linear_1 = gate_proj (6400→6400) for GLU
-                    // linear_2 = pool_proj (6400→6400) for GLU
-                    // linear_3 = out_proj  (6400→3584)
+                    // linear_0 = frame compression (19200->6400) + SiLU
+                    // linear_1 = gate_proj (6400->6400) for GLU
+                    // linear_2 = pool_proj (6400->6400) for GLU
+                    // linear_3 = out_proj  (6400->3584)
                     model.mm_0_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 0, "weight"));
                     model.mm_0_b = get_tensor(string_format(TN_MM_AUDIO_MLP, 0, "bias"));
                     model.mm_1_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 1, "weight"));

--- a/tools/mtmd/models/whisper-enc.cpp
+++ b/tools/mtmd/models/whisper-enc.cpp
@@ -95,6 +95,33 @@ ggml_cgraph * clip_graph_whisper_enc::build() {
             FFN_GELU_ERF,
             -1);
 
+    } else if (proj_type == PROJECTOR_TYPE_MERALION) {
+        // MERaLiON adaptor: ln_speech → reshape/stack → Linear+SiLU → GLU(gate,pool) → out_proj
+        // ln_speech (LayerNorm before adaptor)
+        cur = ggml_norm(ctx0, cur, hparams.eps);
+        cur = ggml_mul(ctx0, cur, model.mm_norm_pre_w);
+        cur = ggml_add(ctx0, cur, model.mm_norm_pre_b);
+
+        // Frame stacking is already done by build_stack above (scale_factor=15)
+        // linear_0: frame compression (19200 → 6400) + SiLU
+        cur = ggml_mul_mat(ctx0, model.mm_0_w, cur);
+        cur = ggml_add(ctx0, cur, model.mm_0_b);
+        cur = ggml_silu(ctx0, cur);
+
+        // GLU: silu(gate_proj(x)) * pool_proj(x)
+        ggml_tensor * gate = ggml_mul_mat(ctx0, model.mm_1_w, cur);
+        gate = ggml_add(ctx0, gate, model.mm_1_b);
+        gate = ggml_silu(ctx0, gate);
+
+        ggml_tensor * pool = ggml_mul_mat(ctx0, model.mm_2_w, cur);
+        pool = ggml_add(ctx0, pool, model.mm_2_b);
+
+        cur = ggml_mul(ctx0, gate, pool);
+
+        // linear_3: out_proj (6400 → 3584)
+        cur = ggml_mul_mat(ctx0, model.mm_3_w, cur);
+        cur = ggml_add(ctx0, cur, model.mm_3_b);
+
     } else if (proj_type == PROJECTOR_TYPE_GLMA) {
             cur = ggml_norm(ctx0, cur, hparams.eps);
             cur = ggml_mul(ctx0, cur, model.mm_norm_pre_w);

--- a/tools/mtmd/models/whisper-enc.cpp
+++ b/tools/mtmd/models/whisper-enc.cpp
@@ -96,19 +96,15 @@ ggml_cgraph * clip_graph_whisper_enc::build() {
             -1);
 
     } else if (proj_type == PROJECTOR_TYPE_MERALION) {
-        // MERaLiON adaptor: ln_speech → reshape/stack → Linear+SiLU → GLU(gate,pool) → out_proj
-        // ln_speech (LayerNorm before adaptor)
+        // stack (above) -> ln -> linear0+silu -> GLU -> out
         cur = ggml_norm(ctx0, cur, hparams.eps);
         cur = ggml_mul(ctx0, cur, model.mm_norm_pre_w);
         cur = ggml_add(ctx0, cur, model.mm_norm_pre_b);
 
-        // Frame stacking is already done by build_stack above (scale_factor=15)
-        // linear_0: frame compression (19200 → 6400) + SiLU
         cur = ggml_mul_mat(ctx0, model.mm_0_w, cur);
         cur = ggml_add(ctx0, cur, model.mm_0_b);
         cur = ggml_silu(ctx0, cur);
 
-        // GLU: silu(gate_proj(x)) * pool_proj(x)
         ggml_tensor * gate = ggml_mul_mat(ctx0, model.mm_1_w, cur);
         gate = ggml_add(ctx0, gate, model.mm_1_b);
         gate = ggml_silu(ctx0, gate);
@@ -118,7 +114,6 @@ ggml_cgraph * clip_graph_whisper_enc::build() {
 
         cur = ggml_mul(ctx0, gate, pool);
 
-        // linear_3: out_proj (6400 → 3584)
         cur = ggml_mul_mat(ctx0, model.mm_3_w, cur);
         cur = ggml_add(ctx0, cur, model.mm_3_b);
 

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -476,6 +476,7 @@ struct mtmd_context {
                 } break;
             case PROJECTOR_TYPE_ULTRAVOX:
             case PROJECTOR_TYPE_GLMA:
+            case PROJECTOR_TYPE_MERALION:
                 {
                     audio_preproc = std::make_unique<mtmd_audio_preprocessor_whisper>(ctx_a);
                 } break;


### PR DESCRIPTION
This adds support for MERaLiON-2 to mtmd. MERaLiON-2 is a speech-text model developed by I2R, A*STAR Singapore, available in 3B and 10B variants. It uses a Whisper large-v2 encoder paired with a Gemma2 decoder.

New projector type: `PROJECTOR_TYPE_MERALION`

The audio adaptor stacks 15 encoder frames per output token, then runs a layer norm followed by a 4-layer MLP: compression Linear+SiLU, a GLU block (gate and pool projections), and a final out_proj to match the decoder embedding dim. The implementation reuses the existing `linear_{bid}` / `mm_norm_pre` tensor naming so the change to tensor_mapping.py is just a comment update.

The mmproj is generated with `convert_hf_to_gguf.py --mmproj` on the full MERaLiON-2 model directory. The text decoder is a standalone Gemma2 model — weights are stored with a `text_decoder.` prefix that gets stripped before standard Gemma2 conversion.

Tested on ASR benchmarks in EN, ZH, MS, TA. English WER delta vs the bf16 HuggingFace baseline is under 0.002 absolute, confirming the inference graph is correct.

Model: https://huggingface.co/MERaLiON/MERaLiON-2-3B