### PR TITLE
Add TurboQuant KV cache scaffolding (Sprint 1)

### DIFF
--- a/docs/turboquant-kv-design.md
+++ b/docs/turboquant-kv-design.md
@@ -1,0 +1,143 @@
+# TurboQuant KV Cache Compression — Design Document
+
+**Status:** Draft (Sprint 1 scaffolding, no functional implementation yet)
+**Author:** Andrew H. Bond <agi.hpc@gmail.com>
+**Branch:** `feature/turboquant-kv-cache`
+**Reference:** [turboquant-pro v0.7.0](https://github.com/ahb-sjsu/turboquant-pro)
+
+## Motivation
+
+Long-context inference (32K+ tokens) is VRAM-bound. A 7B model at 32K context with fp16 KV cache uses ~16 GB just for KV — half the VRAM of a 32 GB GPU. Existing KV quantization in `llama.cpp` (Q4_0, Q5_0, Q8_0) reduces this but with quality penalties at lower bit widths.
+
+TurboQuant provides higher compression at better quality by adding a random orthogonal rotation before scalar quantization:
+
+| Method | Compression | Cosine Sim | PPL Loss vs F16 |
+|--------|-------------|------------|-----------------|
+| F16 (baseline) | 1.0× | 1.000 | 0% |
+| Q8_0 (current) | 2.0× | 0.998 | ~0.1% |
+| Q4_0 (current) | 3.5× | 0.971 | ~1-2% |
+| **TQ KV3 (new)** | **5.1×** | **>0.978** | **<0.5%** |
+| **TQ KV4 (new)** | **3.8×** | **>0.995** | **<0.2%** |
+| **TQ KV2 (new)** | **7.9×** | **>0.926** | **<2%** |
+
+Quality numbers from Zandieh et al. (ICLR 2026) "PolarQuant + QJL" and the existing Python implementation in `turboquant-pro/turboquant_pro/_kv_cache.py`.
+
+## Algorithm
+
+PolarQuant compresses each `head_dim`-sized vector (K or V row) in three steps:
+
+1. **Extract L2 norm** — store `||v||_2` as fp32 (per-vector, ~4 bytes overhead per head_dim values)
+2. **Rotate to unit hypersphere** — multiply unit vector by random orthogonal matrix `Π`. After rotation, coordinates are approximately i.i.d. Gaussian. For `head_dim ≤ 4096`: precomputed QR-decomposed rotation matrix. For larger: structured sign-flip + permutation (O(d) memory and apply cost).
+3. **Scalar quantize each coordinate** — Lloyd-Max optimal codebook for N(0, 1/√d), with bit-packing (8 × 3-bit = 3 bytes for TQ KV3).
+
+Decompression inverts: unpack indices → look up centroid → unrotate → scale by stored norm.
+
+## Architecture
+
+### New ggml Types
+
+Add to `ggml/include/ggml.h`:
+
+```c
+enum ggml_type {
+    /* ... existing types ... */
+    GGML_TYPE_TQ_KV3  = 42,  // TurboQuant KV cache, 3-bit
+    GGML_TYPE_TQ_KV4  = 43,  // TurboQuant KV cache, 4-bit
+    GGML_TYPE_TQ_KV2  = 44,  // TurboQuant KV cache, 2-bit (extreme compression)
+    GGML_TYPE_COUNT   = 45,  // bump
+};
+```
+
+### Block Structure
+
+Each block stores one quantized vector of length `head_dim`:
+
+```c
+// TQ_KV3: 3 bits per element + per-vector L2 norm
+typedef struct {
+    float    norm;                       // L2 norm of original vector (4 bytes)
+    uint8_t  indices[(HEAD_DIM*3 + 7)/8]; // bit-packed 3-bit indices (3*HEAD_DIM/8 bytes)
+} block_tq_kv3;
+
+// TQ_KV4: 4 bits per element + per-vector norm
+typedef struct {
+    float    norm;
+    uint8_t  indices[HEAD_DIM/2];
+} block_tq_kv4;
+```
+
+For typical `head_dim=128`: TQ KV3 = 4 + 48 = 52 bytes vs fp16's 256 bytes (4.9× compression) vs Q4_0's ~72 bytes.
+
+### Rotation Matrix Storage
+
+A single rotation matrix is shared across **all** KV blocks for a given `head_dim` (deterministic from a seed). Stored once per model context, not per block. Memory: `4 * head_dim²` bytes (e.g. 64 KB for `head_dim=128`).
+
+Initialized lazily on first KV insertion: `init_rotation(head_dim, seed=42)`.
+
+### CLI Integration
+
+Modify `common/arg.cpp` `kv_cache_types` vector:
+
+```cpp
+const std::vector<ggml_type> kv_cache_types = {
+    /* ... existing ... */
+    GGML_TYPE_TQ_KV2,
+    GGML_TYPE_TQ_KV3,
+    GGML_TYPE_TQ_KV4,
+};
+```
+
+User invocation:
+```bash
+./llama-cli --cache-type-k tq_kv3 --cache-type-v tq_kv4 ...
+```
+
+## Integration Points
+
+| File | Lines | Change |
+|------|-------|--------|
+| `ggml/include/ggml.h` | ~431 | Add `GGML_TYPE_TQ_KV{2,3,4}` enum values |
+| `ggml/src/ggml-quants.h` | various | Declare `quantize_tq_kv{2,3,4}_row()`, `dequantize_tq_kv{2,3,4}_row()` |
+| `ggml/src/ggml-quants.c` | various | Implement quantize/dequantize (CPU reference, Sprint 2) |
+| `ggml/src/ggml-cuda/turboquant.cu` | new | CUDA kernels (Sprint 3) |
+| `ggml/src/ggml.c` | type_traits | Register new types in `type_traits` table (block size, name, dot product) |
+| `common/arg.cpp` | 383-393 | Add new types to `kv_cache_types` |
+| `src/llama-kv-turboquant.{h,cpp}` | new | TurboQuant-specific helpers (rotation init, hot/cold tiering) |
+| `src/llama-kv-cache.cpp` | various | Use TQ helpers when `type_k`/`type_v` is TQ |
+| `tests/test-tq-kv.cpp` | new | Unit tests (Sprint 2) |
+
+## Hot/Cold Tiering (Sprint 4)
+
+Mirroring `TurboQuantKVCache` from `turboquant-pro`:
+
+- **Hot tier** — last N tokens stored uncompressed (fp16). Default N=512, configurable via `--kv-hot-window`.
+- **Cold tier** — older tokens stored TQ-compressed. Auto-flush from hot to cold when hot window exceeds threshold.
+- During attention: hot tier read directly; cold tier blocks decompressed on-demand into a scratch buffer.
+
+This amortizes compression cost (only happens at flush time, not per-token) and gives full fp16 precision for the recent tokens that matter most.
+
+## Performance Targets (Sprint 3 acceptance)
+
+| Metric | Target | Baseline (F16) |
+|--------|--------|----------------|
+| Inference throughput | within 2× of F16 | 100% |
+| KV memory at 32K context | <30% of F16 | 100% |
+| Perplexity on WikiText-2 | <0.5% loss vs F16 | — |
+| First-token latency | within 1.5× of F16 | — |
+
+## Out of Scope (Future Issues)
+
+- **Differential KV** ([turboquant-pro#22](https://github.com/ahb-sjsu/turboquant-pro/issues/22)) — delta-encoding adjacent tokens before PolarQuant
+- **Attention-aware eviction** ([#23](https://github.com/ahb-sjsu/turboquant-pro/issues/23)) — drop low-attention tokens
+- **FP8/NVFP4 native paths** ([#24](https://github.com/ahb-sjsu/turboquant-pro/issues/24)) — Hopper/Blackwell
+- **Quantization-aware micro-LoRA** ([#25](https://github.com/ahb-sjsu/turboquant-pro/issues/25)) — for weight quantization (different problem)
+
+## Roadmap
+
+| Sprint | Status | Deliverable |
+|--------|--------|-------------|
+| 1 | **In progress** | Fork + design doc + scaffolding + issues |
+| 2 | TODO | CPU reference implementation |
+| 3 | TODO | CUDA kernels (Volta/Ampere) |
+| 4 | TODO | Hot/cold tiering |
+| 5 | TODO | Documentation + upstream PR |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(llama
             llama-io.cpp
             llama-kv-cache.cpp
             llama-kv-cache-iswa.cpp
+            llama-kv-turboquant.cpp
             llama-memory.cpp
             llama-memory-hybrid.cpp
             llama-memory-hybrid-iswa.cpp

--- a/src/llama-kv-turboquant.cpp
+++ b/src/llama-kv-turboquant.cpp
@@ -1,0 +1,51 @@
+// TurboQuant KV cache compression — stub implementation (Sprint 1)
+//
+// This file contains TODO stubs for the TurboQuant KV cache API.
+// All functions throw runtime_error("not implemented") for now.
+// Real implementation lands in Sprint 2 (CPU) and Sprint 3 (CUDA).
+//
+// See: docs/turboquant-kv-design.md
+
+#include "llama-kv-turboquant.h"
+
+#include <stdexcept>
+
+namespace llama_kv_tq {
+
+rotation_matrix init_rotation(int /*head_dim*/, uint32_t /*seed*/) {
+    // TODO(sprint-2): implement QR decomposition for head_dim <= 4096,
+    // structured sign-flip + permutation for head_dim > 4096.
+    // Reference: turboquant-pro/turboquant_pro/_kv_cache.py:init_rotation
+    throw std::runtime_error(
+        "llama_kv_tq::init_rotation not implemented (Sprint 2)"
+    );
+}
+
+compressed_block compress_vector(
+    const float *           /*vec*/,
+    int                     /*head_dim*/,
+    bits                    /*b*/,
+    const rotation_matrix & /*rot*/
+) {
+    // TODO(sprint-2): rotate vec, compute L2 norm, scalar quantize,
+    // bit-pack indices.
+    throw std::runtime_error(
+        "llama_kv_tq::compress_vector not implemented (Sprint 2)"
+    );
+}
+
+void decompress_vector(
+    const compressed_block & /*block*/,
+    int                      /*head_dim*/,
+    bits                     /*b*/,
+    const rotation_matrix &  /*rot*/,
+    float *                  /*out*/
+) {
+    // TODO(sprint-2): unpack indices, look up centroids, unrotate,
+    // scale by norm.
+    throw std::runtime_error(
+        "llama_kv_tq::decompress_vector not implemented (Sprint 2)"
+    );
+}
+
+}  // namespace llama_kv_tq

--- a/src/llama-kv-turboquant.h
+++ b/src/llama-kv-turboquant.h
@@ -1,0 +1,102 @@
+#pragma once
+
+// TurboQuant KV cache compression — scaffolding (Sprint 1)
+//
+// This header declares the public API for TurboQuant KV cache
+// compression. Implementation in subsequent sprints.
+//
+// See: docs/turboquant-kv-design.md
+// Reference: https://github.com/ahb-sjsu/turboquant-pro
+
+#include "ggml.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace llama_kv_tq {
+
+// Bit widths supported. Maps to GGML_TYPE_TQ_KV{2,3,4}.
+enum bits {
+    BITS_2 = 2,
+    BITS_3 = 3,
+    BITS_4 = 4,
+};
+
+// Random orthogonal rotation matrix.
+// For head_dim <= 4096: full QR factorization (memory: 4 * D^2 bytes).
+// For head_dim  > 4096: structured sign-flip + permutation (O(D) memory).
+struct rotation_matrix {
+    int  head_dim;
+    bool structured;
+
+    // QR mode (head_dim <= 4096)
+    std::vector<float> Pi;     // (D, D) row-major
+    std::vector<float> Pi_T;   // (D, D) row-major, precomputed transpose
+
+    // Structured mode (head_dim > 4096)
+    std::vector<int8_t>  sign_flip;  // (D,) elements in {-1, +1}
+    std::vector<int32_t> perm;       // (D,) permutation
+    std::vector<int32_t> inv_perm;   // (D,) inverse permutation
+};
+
+// Compressed vector: bit-packed indices + L2 norm.
+// One block per quantized vector of length head_dim.
+struct compressed_block {
+    float                norm;     // L2 norm of original vector
+    std::vector<uint8_t> indices;  // bit-packed b-bit indices
+};
+
+// Initialize rotation matrix for a given head_dim.
+// Cached per (head_dim, seed) — call once per model context.
+//
+// TODO(sprint-2): implement
+rotation_matrix init_rotation(int head_dim, uint32_t seed = 42);
+
+// Compress a single vector of length head_dim.
+//
+// TODO(sprint-2): implement
+compressed_block compress_vector(
+    const float *           vec,
+    int                     head_dim,
+    bits                    b,
+    const rotation_matrix & rot
+);
+
+// Decompress a single vector into out (length head_dim).
+//
+// TODO(sprint-2): implement
+void decompress_vector(
+    const compressed_block & block,
+    int                      head_dim,
+    bits                     b,
+    const rotation_matrix &  rot,
+    float *                  out
+);
+
+// Compute storage size (bytes) for a compressed vector of given head_dim.
+inline std::size_t block_size_bytes(int head_dim, bits b) {
+    return sizeof(float) + (head_dim * static_cast<int>(b) + 7) / 8;
+}
+
+// Compute compression ratio vs fp16 storage.
+inline double compression_ratio(int head_dim, bits b) {
+    const auto compressed = static_cast<double>(block_size_bytes(head_dim, b));
+    const auto fp16       = static_cast<double>(head_dim * 2);
+    return fp16 / compressed;
+}
+
+// Map a TurboQuant ggml_type to its bit width.
+// Returns -1 if not a TurboQuant type.
+//
+// TODO(sprint-2): wire up after adding GGML_TYPE_TQ_KV{2,3,4} to
+// ggml/include/ggml.h and registering them in ggml_type_traits.
+inline int ggml_type_to_bits(ggml_type /*t*/) {
+    // Will return 2/3/4 for GGML_TYPE_TQ_KV{2,3,4}, -1 otherwise.
+    return -1;
+}
+
+inline bool is_turboquant_kv_type(ggml_type t) {
+    return ggml_type_to_bits(t) > 0;
+}
+
+}  // namespace llama_kv_tq


### PR DESCRIPTION
Foundation for upstream PR adding PolarQuant + Lloyd-Max KV cache compression. Achieves 5.1x compression at >0.978 cosine similarity (3-bit) — better quality and ratio than current Q4_0/Q5_0.

This commit:
- docs/turboquant-kv-design.md — full design doc with architecture, integration points, performance targets, and 5-sprint roadmap
- src/llama-kv-turboquant.h — public C++ API (rotation_matrix, compressed_block, compress/decompress signatures)
- src/llama-kv-turboquant.cpp — TODO stubs throwing runtime_error
- src/CMakeLists.txt — register new source file

Subsequent sprints will:
- Sprint 2: CPU reference impl (port from turboquant-pro Python)
- Sprint 3: CUDA kernels (Volta/Ampere/Hopper)
- Sprint 4: Hot/cold tiering integration with llama_kv_cache
- Sprint 5: Documentation, examples, upstream PR

Reference: https://github.com/ahb-sjsu/turboquant-pro
Theory: Zandieh et al. (ICLR 2026) "PolarQuant + QJL"

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
