### PR TITLE
llama-bench: fix accumulated load_time in perf timings

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2267,6 +2267,7 @@ int main(int argc, char ** argv) {
         test t(inst, lmodel, ctx);
 
         llama_memory_clear(llama_get_memory(ctx), false);
+        llama_perf_context_reset(ctx);
 
         // cool off before the test
         if (params.delay) {


### PR DESCRIPTION
## Overview

Fix accumulated load_time in llama_perf_context_print when running llama-bench with multiple parameter sets (e.g. `-n 4,8,16,32`).

The load_time keeps growing because each new context inherits t_start_us from the model's original load timestamp, but the model is reused across runs. Added llama_perf_context_reset(ctx) after context creation to reset the timing baseline per iteration.
Fixes #9286

## Additional information

Spotted this while benchmarking with verbose output — the load_time went from ~1s to ~33s across 7 runs even though the model was only loaded once.

# Requirements

- I have read and agree with the contributing guidelines(https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No
