### PR TITLE
docs/android.md: Add dependency `libandroid-spawn` for building on termux

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -29,7 +29,7 @@ With Termux, you can install and run `llama.cpp` as if the environment were Linu
 
 ```
 $ apt update && apt upgrade -y
-$ apt install git cmake
+$ apt install git cmake libandroid-spawn
 ```
 
 Then, follow the [build instructions](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md), specifically for CMake.


### PR DESCRIPTION

## Overview
Without `libandroid-spawn` compilation fails on termux with:
```
fatal error: 'spawn.h' file not found
```
<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information
Fixes https://github.com/ggml-org/llama.cpp/issues/18615
Fixes https://github.com/ggml-org/llama.cpp/issues/19388
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> No

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
