### PR TITLE
llama : add --hugepages for HugeTLB-backed weight loading (Linux)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -574,6 +574,21 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         throw std::invalid_argument("error: --prompt-cache-all not supported in interactive mode yet\n");
     }
 
+    // --hugepages compatibility checks. PR #1 covers weights on the --mmap path only;
+    // --no-mmap and --direct-io both route around the hugetlb branch, so surface the
+    // conflict at the user rather than silently ignoring the request. Linux-only.
+    if (params.use_hugepages) {
+#ifndef __linux__
+        throw std::invalid_argument("error: --hugepages is Linux only.\n");
+#endif
+        if (!params.use_mmap) {
+            throw std::invalid_argument("error: --hugepages requires --mmap. Coverage for --no-mmap is added in a follow-up PR. Drop --no-mmap to use --hugepages.\n");
+        }
+        if (params.use_direct_io) {
+            throw std::invalid_argument("error: --hugepages and --direct-io are incompatible. Drop one.\n");
+        }
+    }
+
     // handle model and download
     if (!skip_model_download) {
         auto res = common_params_handle_model(params.model, params.hf_token, params.offline);
@@ -2225,6 +2240,15 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.use_mmap = value;
         }
     ).set_env("LLAMA_ARG_MMAP"));
+    add_opt(common_arg(
+        {"--hugepages"},
+        "back model weights with anonymous hugetlb 2 MiB pages (Linux only).\n"
+        "reserve the pool first with e.g. `sysctl -w vm.nr_hugepages=N` — no reboot required.\n"
+        "pinned in RAM, bypasses swap and page cache; primary win is vmemmap reclamation via HVO",
+        [](common_params & params) {
+            params.use_hugepages = true;
+        }
+    ).set_env("LLAMA_ARG_HUGEPAGES"));
     add_opt(common_arg(
         {"-dio", "--direct-io"},
         {"-ndio", "--no-direct-io"},

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1421,6 +1421,7 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
     mparams.tensor_split    = params.tensor_split;
     mparams.use_mmap        = params.use_mmap;
     mparams.use_direct_io   = params.use_direct_io;
+    mparams.use_hugepages   = params.use_hugepages;
     mparams.use_mlock       = params.use_mlock;
     mparams.check_tensors   = params.check_tensors;
     mparams.use_extra_bufts = !params.no_extra_bufts;

--- a/common/common.h
+++ b/common/common.h
@@ -534,6 +534,7 @@ struct common_params {
     bool input_prefix_bos  = false; // prefix BOS to user inputs, preceding input_prefix
     bool use_mmap          = true;  // enable mmap to use filesystem cache
     bool use_direct_io     = false; // read from disk without buffering
+    bool use_hugepages     = false; // back weight mappings with anonymous hugetlb pages (Linux only)
     bool use_mlock         = false; // use mlock to keep model in memory
     bool verbose_prompt    = false; // print prompt tokens before generation
     bool display_prompt    = true;  // print prompt before generation

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -606,6 +606,8 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
 struct ggml_backend_cuda_buffer_context {
     int device;
     void * dev_ptr = nullptr;
+    void * host_ptr = nullptr;
+    bool   owned    = true;
     std::string name;
 
     ggml_backend_cuda_buffer_context(int device, void * dev_ptr) :
@@ -614,7 +616,12 @@ struct ggml_backend_cuda_buffer_context {
     }
 
     ~ggml_backend_cuda_buffer_context() {
-        CUDA_CHECK(cudaFree(dev_ptr));
+        if (owned) {
+            CUDA_CHECK(cudaFree(dev_ptr));
+        } else {
+            // host_ptr was registered via cudaHostRegister; dev_ptr aliases it and is not ours to free.
+            CUDA_CHECK(cudaHostUnregister(host_ptr));
+        }
     }
 };
 
@@ -645,10 +652,16 @@ static enum ggml_status ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer
         const size_t original_size = ggml_nbytes(tensor);
         const size_t padded_size = ggml_backend_buft_get_alloc_size(buffer->buft, tensor);
 
-        if (padded_size > original_size) {
+        if (padded_size > original_size && ctx->owned) {
             ggml_cuda_set_device(ctx->device);
             CUDA_CHECK(cudaMemset((char *)tensor->data + original_size, 0, padded_size - original_size));
         }
+        // For externally-owned buffers (buffer_from_host_ptr), the memset is
+        // skipped: hipMemset through a hipHostGetDevicePointer-derived address
+        // is unsupported on ROCm integrated GPUs, and the padding region may
+        // extend past the registered host range for the final tensor. GGUF
+        // files zero-pad between tensors by convention, so the padding bytes
+        // in the mmap'd region are already zero.
     }
     return GGML_STATUS_SUCCESS;
 }
@@ -4653,10 +4666,24 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
     bool events = true;
 #endif
 
+    // buffer_from_host_ptr is currently enabled only on HIP integrated GPUs
+    // (validated on Strix Halo / ROCm 7.2.0). NVIDIA Jetson reports
+    // prop.integrated == 1 too and may benefit from the same path, but it
+    // has not been tested on that platform; #15034's cuda_host-buffer
+    // corruption is in a different code path (see ggml-cuda.cu:243) and
+    // is not expected to apply here, but validation is required before
+    // extending beyond HIP.
+    bool buffer_from_host_ptr = false;
+#if defined(GGML_USE_HIP)
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, ctx->device));
+    buffer_from_host_ptr = prop.integrated > 0;
+#endif
+
     props->caps = {
         /* .async                 = */ true,
         /* .host_buffer           = */ host_buffer,
-        /* .buffer_from_host_ptr  = */ false,
+        /* .buffer_from_host_ptr  = */ buffer_from_host_ptr,
         /* .events                = */ events,
     };
 }
@@ -4676,6 +4703,53 @@ static ggml_backend_buffer_type_t ggml_backend_cuda_device_get_host_buffer_type(
     GGML_UNUSED(dev);
     return ggml_backend_cuda_host_buffer_type();
 }
+
+#if defined(GGML_USE_HIP)
+// HIP-only for now; see comment at the capability flag in get_props().
+// TODO: extend to CUDA / Jetson after validating that #15034's corruption
+// mode does not apply to this code path.
+static ggml_backend_buffer_t ggml_backend_cuda_device_buffer_from_host_ptr(
+        ggml_backend_dev_t dev, void * ptr, size_t size, size_t max_tensor_size) {
+    GGML_UNUSED(max_tensor_size);
+
+    ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
+    ggml_cuda_set_device(ctx->device);
+
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, ctx->device));
+    if (prop.integrated <= 0) {
+        return nullptr;
+    }
+
+    // ReadOnly is intentionally not set: ggml_backend_cuda_buffer_init_tensor
+    // uses cudaMemset to zero quantized-tensor padding, which would be
+    // rejected for a read-only-registered region.
+    cudaError_t err = cudaHostRegister(ptr, size,
+        cudaHostRegisterPortable | cudaHostRegisterMapped);
+    if (err != cudaSuccess) {
+        (void)cudaGetLastError();
+        GGML_LOG_ERROR("%s: cudaHostRegister failed: %s\n", __func__, cudaGetErrorString(err));
+        return nullptr;
+    }
+
+    void * dev_ptr = nullptr;
+    err = cudaHostGetDevicePointer(&dev_ptr, ptr, 0);
+    if (err != cudaSuccess) {
+        (void)cudaGetLastError();
+        cudaHostUnregister(ptr);
+        GGML_LOG_ERROR("%s: cudaHostGetDevicePointer failed: %s\n", __func__, cudaGetErrorString(err));
+        return nullptr;
+    }
+
+    ggml_backend_cuda_buffer_context * buf_ctx = new ggml_backend_cuda_buffer_context(ctx->device, dev_ptr);
+    buf_ctx->host_ptr = ptr;
+    buf_ctx->owned    = false;
+
+    return ggml_backend_buffer_init(
+        ggml_backend_cuda_device_get_buffer_type(dev),
+        ggml_backend_cuda_buffer_interface, buf_ctx, size);
+}
+#endif // GGML_USE_HIP
 
 // TODO: move these functions here
 static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const ggml_tensor * op) {
@@ -5126,7 +5200,11 @@ static const ggml_backend_device_i ggml_backend_cuda_device_interface = {
     /* .init_backend            = */ ggml_backend_cuda_device_init_backend,
     /* .get_buffer_type         = */ ggml_backend_cuda_device_get_buffer_type,
     /* .get_host_buffer_type    = */ ggml_backend_cuda_device_get_host_buffer_type,
+#if defined(GGML_USE_HIP)
+    /* .buffer_from_host_ptr    = */ ggml_backend_cuda_device_buffer_from_host_ptr,
+#else
     /* .buffer_from_host_ptr    = */ NULL,
+#endif
     /* .supports_op             = */ ggml_backend_cuda_device_supports_op,
     /* .supports_buft           = */ ggml_backend_cuda_device_supports_buft,
     /* .offload_op              = */ ggml_backend_cuda_device_offload_op,

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -74,7 +74,9 @@
 #define cudaGetDeviceProperties hipGetDeviceProperties
 #define cudaGetErrorString hipGetErrorString
 #define cudaGetLastError hipGetLastError
+#define cudaHostGetDevicePointer hipHostGetDevicePointer
 #define cudaHostRegister hipHostRegister
+#define cudaHostRegisterMapped hipHostRegisterMapped
 #define cudaHostRegisterPortable hipHostRegisterPortable
 #define cudaHostRegisterReadOnly hipHostRegisterReadOnly
 #define cudaHostUnregister hipHostUnregister

--- a/include/llama.h
+++ b/include/llama.h
@@ -314,6 +314,7 @@ extern "C" {
         bool vocab_only;      // only load the vocabulary, no weights
         bool use_mmap;        // use mmap if possible
         bool use_direct_io;   // use direct io, takes precedence over use_mmap when supported
+        bool use_hugepages;   // back model memory with anonymous hugetlb pages (Linux only)
         bool use_mlock;       // force system to keep model in RAM
         bool check_tensors;   // validate model tensor data
         bool use_extra_bufts; // use extra buffer types (used for weight repacking)

--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -40,6 +40,20 @@
 #include <TargetConditionals.h>
 #endif
 
+#ifdef __linux__
+// Older glibc headers may miss these; upstream kernel has had them for years.
+#ifndef MAP_HUGETLB
+#define MAP_HUGETLB 0x40000
+#endif
+#ifndef MAP_HUGE_2MB
+#define MAP_HUGE_2MB (21 << MAP_HUGE_SHIFT)
+#endif
+#endif
+
+// 2 MiB hugepage size, used for both the hugetlb mmap length and the
+// unmap_fragment alignment granularity when the mapping is hugetlb-backed.
+static constexpr size_t LLAMA_HUGE_PAGE_SIZE = 2ull * 1024 * 1024;
+
 // TODO: consider moving to llama-impl.h if needed in more places
 #if defined(_WIN32)
 static std::string llama_format_win_err(DWORD err) {
@@ -437,6 +451,35 @@ struct llama_mmap::impl {
     impl(struct llama_file * file, size_t prefetch, bool numa, bool hugetlb) {
         size = file->size();
         int fd = file->file_id();
+#ifdef __linux__
+        if (hugetlb) {
+            // Anonymous hugetlb mapping rounded up to 2 MiB. PROT_WRITE lets
+            // load_all_data pread the file in (downgraded to PROT_READ after);
+            // MAP_POPULATE surfaces pool-exhaustion here, not mid-load.
+            mmap_size = (size + LLAMA_HUGE_PAGE_SIZE - 1) & ~(LLAMA_HUGE_PAGE_SIZE - 1);
+            addr = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | MAP_POPULATE, -1, 0);
+            if (addr == MAP_FAILED) {
+                int saved = errno;
+                if (saved == ENOMEM) {
+                    size_t need = mmap_size / LLAMA_HUGE_PAGE_SIZE;
+                    long   have = -1;
+                    if (FILE * f = std::fopen("/sys/kernel/mm/hugepages/hugepages-2048kB/free_hugepages", "r")) {
+                        if (std::fscanf(f, "%ld", &have) != 1) { have = -1; }
+                        std::fclose(f);
+                    }
+                    throw std::runtime_error(format("hugetlb mmap failed: need %zu free 2 MiB pages, pool has %ld. "
+                                                    "Try: sudo sysctl -w vm.nr_hugepages=%zu", need, have, need));
+                }
+                throw std::runtime_error(format("hugetlb mmap failed: %s", strerror(saved)));
+            }
+            is_hugetlb_ = true;
+            mapped_fragments.emplace_back(0, mmap_size);
+            return;
+        }
+#else
+        (void) hugetlb;
+#endif
         int flags = MAP_SHARED;
         if (numa) { prefetch = 0; }
 #ifdef __linux__
@@ -480,7 +523,9 @@ struct llama_mmap::impl {
     }
 
     void unmap_fragment(size_t first, size_t last) {
-        int page_size = sysconf(_SC_PAGESIZE);
+        // Hugetlb munmaps must be 2 MiB-aligned; the file-backed path uses
+        // the kernel base page size as before.
+        size_t page_size = is_hugetlb_ ? LLAMA_HUGE_PAGE_SIZE : (size_t) sysconf(_SC_PAGESIZE);
         align_range(&first, &last, page_size);
         size_t len = last - first;
 
@@ -607,8 +652,8 @@ struct llama_mmap::impl {
     }
 #endif
 
-    void * addr;
-    size_t size;
+    void * addr = nullptr;
+    size_t size = 0;
     // Hugetlb: physical mapping length (file size rounded up to 2 MiB) used
     // by munmap; `size` continues to report the underlying file length.
     size_t mmap_size = 0;

--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -434,7 +434,7 @@ struct llama_mmap::impl {
 #ifdef _POSIX_MAPPED_FILES
     std::vector<std::pair<size_t, size_t>> mapped_fragments;
 
-    impl(struct llama_file * file, size_t prefetch, bool numa) {
+    impl(struct llama_file * file, size_t prefetch, bool numa, bool hugetlb) {
         size = file->size();
         int fd = file->file_id();
         int flags = MAP_SHARED;
@@ -525,8 +525,9 @@ struct llama_mmap::impl {
 #elif defined(_WIN32)
     HANDLE hMapping = nullptr;
 
-    impl(struct llama_file * file, size_t prefetch, bool numa) {
+    impl(struct llama_file * file, size_t prefetch, bool numa, bool hugetlb) {
         GGML_UNUSED(numa);
+        GGML_UNUSED(hugetlb);
 
         size = file->size();
 
@@ -589,10 +590,11 @@ struct llama_mmap::impl {
         }
     }
 #else
-    impl(struct llama_file * file, size_t prefetch, bool numa) {
+    impl(struct llama_file * file, size_t prefetch, bool numa, bool hugetlb) {
         GGML_UNUSED(file);
         GGML_UNUSED(prefetch);
         GGML_UNUSED(numa);
+        GGML_UNUSED(hugetlb);
 
         throw std::runtime_error("mmap not supported");
     }
@@ -607,13 +609,19 @@ struct llama_mmap::impl {
 
     void * addr;
     size_t size;
+    // Hugetlb: physical mapping length (file size rounded up to 2 MiB) used
+    // by munmap; `size` continues to report the underlying file length.
+    size_t mmap_size = 0;
+    bool   is_hugetlb_ = false;
 };
 
-llama_mmap::llama_mmap(struct llama_file * file, size_t prefetch, bool numa) : pimpl(std::make_unique<impl>(file, prefetch, numa)) {}
+llama_mmap::llama_mmap(struct llama_file * file, size_t prefetch, bool numa, bool hugetlb) : pimpl(std::make_unique<impl>(file, prefetch, numa, hugetlb)) {}
 llama_mmap::~llama_mmap() = default;
 
 size_t llama_mmap::size() const { return pimpl->size; }
+size_t llama_mmap::mmap_size() const { return pimpl->mmap_size ? pimpl->mmap_size : pimpl->size; }
 void * llama_mmap::addr() const { return pimpl->addr; }
+bool   llama_mmap::is_hugetlb() const { return pimpl->is_hugetlb_; }
 
 void llama_mmap::unmap_fragment(size_t first, size_t last) { pimpl->unmap_fragment(first, last); }
 

--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -42,11 +42,13 @@ private:
 
 struct llama_mmap {
     llama_mmap(const llama_mmap &) = delete;
-    llama_mmap(struct llama_file * file, size_t prefetch = (size_t) -1, bool numa = false);
+    llama_mmap(struct llama_file * file, size_t prefetch = (size_t) -1, bool numa = false, bool hugetlb = false);
     ~llama_mmap();
 
     size_t size() const;
+    size_t mmap_size() const; // physical mapping length (>= size() when hugetlb-rounded)
     void * addr() const;
+    bool   is_hugetlb() const;
 
     void unmap_fragment(size_t first, size_t last);
 

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -516,6 +516,7 @@ llama_model_loader::llama_model_loader(
         FILE * file,
         bool use_mmap,
         bool use_direct_io,
+        bool use_hugepages,
         bool check_tensors,
         bool no_alloc,
         const llama_model_kv_override * param_overrides_p,
@@ -814,6 +815,7 @@ llama_model_loader::llama_model_loader(
 
     this->use_mmap = use_mmap;
     this->use_direct_io = use_direct_io;
+    this->use_hugepages = use_hugepages;
     this->check_tensors = check_tensors;
     this->no_alloc = no_alloc;
 }

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1341,7 +1341,7 @@ void llama_model_loader::init_mappings(bool prefetch, llama_mlocks * mlock_mmaps
                 }
             }
 
-            std::unique_ptr<llama_mmap> mapping = std::make_unique<llama_mmap>(file.get(), prefetch ? -1 : 0, is_numa);
+            std::unique_ptr<llama_mmap> mapping = std::make_unique<llama_mmap>(file.get(), prefetch ? -1 : 0, is_numa, use_hugepages);
             mmaps_used.emplace_back(mapping->size(), 0);
             if (mlock_mmaps) {
                 std::unique_ptr<llama_mlock> mlock_mmap(new llama_mlock());

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -7,11 +7,16 @@
 
 #include <algorithm>
 #include <array>
+#include <cerrno>
 #include <cinttypes>
 #include <cstdint>
 #include <cstring>
 #include <future>
 #include <regex>
+
+#ifdef __linux__
+#include <sys/mman.h>
+#endif
 
 static const size_t kiB = 1024;
 static const size_t MiB = 1024*kiB;
@@ -1536,6 +1541,14 @@ bool llama_model_loader::load_all_data(
             }
             uint8_t * data = (uint8_t *) mapping->addr() + weight->offs;
 
+            // Hugetlb mappings are anonymous and zero-filled; populate the
+            // region per-tensor before check_tensors / view alloc consume it.
+            if (mapping->is_hugetlb()) {
+                const auto & file = files.at(weight->idx);
+                file->seek(weight->offs, SEEK_SET);
+                file->read_raw(data, n_size);
+            }
+
             if (check_tensors) {
                 validation_result.emplace_back(std::async(std::launch::async, [cur, data, n_size] {
                     return std::make_pair(cur, ggml_validate_row_data(cur->type, data, n_size));
@@ -1666,6 +1679,16 @@ bool llama_model_loader::load_all_data(
             for (uint32_t idx = 0; idx < mappings.size(); idx++) {
                 const auto & mmap_used = mmaps_used.at(idx);
                 auto & mapping = mappings.at(idx);
+#ifdef __linux__
+                // Downgrade the hugetlb region to PROT_READ while it is still
+                // fully mapped — unmap_fragment below may drop 2 MiB chunks
+                // from the head/tail, so mprotect must come first.
+                if (mapping->is_hugetlb()) {
+                    if (mprotect(mapping->addr(), mapping->mmap_size(), PROT_READ)) {
+                        LLAMA_LOG_WARN("warning: mprotect(PROT_READ) failed: %s\n", strerror(errno));
+                    }
+                }
+#endif
                 mapping->unmap_fragment(0, mmap_used.first);
                 if (mmap_used.second != 0) {
                     mapping->unmap_fragment(mmap_used.second, mapping->size());

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -77,6 +77,7 @@ struct llama_model_loader {
 
     bool use_mmap = false;
     bool use_direct_io = false;
+    bool use_hugepages = false;
     bool check_tensors;
     bool no_alloc;
 
@@ -128,6 +129,7 @@ struct llama_model_loader {
         FILE * file,
         bool use_mmap,
         bool use_direct_io,
+        bool use_hugepages,
         bool check_tensors,
         bool no_alloc,
         const llama_model_kv_override * param_overrides_p,

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -9302,6 +9302,7 @@ llama_model_params llama_model_default_params() {
         /*.vocab_only                  =*/ false,
         /*.use_mmap                    =*/ true,
         /*.use_direct_io               =*/ false,
+        /*.use_hugepages               =*/ false,
         /*.use_mlock                   =*/ false,
         /*.check_tensors               =*/ false,
         /*.use_extra_bufts             =*/ true,

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -879,7 +879,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
     const llama_model_kv_override * kv_overrides = params->kv_overrides;
     std::vector<std::string> splits = {};
     llama_model_loader ml(/*metadata*/ nullptr, /*set_tensor_data*/ nullptr, /*set_tensor_data_ud*/ nullptr,
-        fname_inp, splits, /*file*/ nullptr, use_mmap, /*use_direct_io*/ false, /*check_tensors*/ true, /*no_alloc*/ false, kv_overrides, nullptr);
+        fname_inp, splits, /*file*/ nullptr, use_mmap, /*use_direct_io*/ false, /*use_hugepages*/ false, /*check_tensors*/ true, /*no_alloc*/ false, kv_overrides, nullptr);
     ml.init_mappings(false); // no prefetching
 
     llama_model model(llama_model_default_params());

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -845,7 +845,7 @@ static int llama_model_load(struct gguf_context * metadata, llama_model_set_tens
 
     try {
         llama_model_loader ml(metadata, set_tensor_data, set_tensor_data_ud, fname, splits, file, params.use_mmap, params.use_direct_io,
-            params.check_tensors, params.no_alloc, params.kv_overrides, params.tensor_buft_overrides);
+            params.use_hugepages, params.check_tensors, params.no_alloc, params.kv_overrides, params.tensor_buft_overrides);
 
         ml.print_info();
 


### PR DESCRIPTION
## Overview

Addresses #2251 (partially — weights via `--mmap` path only; I hope to address `--no-mmap` and KV cache in a follow-up). I realize this is a non-trivial change (even though the implementation itself it just one file / two blocks), so I'm going into a bit more detail than I usually would with a PR. :)

### Summary

Adds a new `--hugepages` CLI flag (env: `LLAMA_ARG_HUGEPAGES`) that backs model weight memory with anonymous 2 MiB HugeTLB pages on Linux.

**Motivation: vmemmap reclamation**
(not TLB speedup,v though it may facilitate future work in this area)

When HugeTLB Vmemmap Optimization (HVO, `CONFIG_HUGETLB_PAGE_OPTIMIZE_VMEMMAP=y`) is enabled, the kernel frees the per-4 KiB `struct page` metadata within each hugepage. On a 128 GiB system this recovers **~1.75 GiB** of kernel memory — enough to turn a tight-ceiling workload from OOM into working (which is what was happening to me).

The flag is opt-in at runtime, so there's no cost to anyone who doesn't use it.

```bash
# reserve the pool (runtime, no reboot for 2 MiB pages)
sudo sysctl -w vm.nr_hugepages=65536   # 65536 x 2 MiB = 128 GiB

# run with the flag
./llama-cli --hugepages -m model.gguf ...
```

### Why?

Each 4 KiB page costs ~64 bytes of `struct page` metadata. With 128 GiB, that's ~2 GiB just to track pages. HugeTLB with HVO reduces this; a 2 MiB hugepage is only 4 KiB instead of 32 KiB.

| System RAM | Approx. Benefit |
|---|---|
| 16 GiB | ~224 MiB |
| 64 GiB | ~896 MiB |
| 128 GiB | ~1.75 GiB |

Here's my real-life example: Strix APU with 128 GiB RAM (unified in my case) running MiniMax m2.5 IQ4_XS. The total footprint ~127,910 MiB against ~127,342 MiB available ("normal" pages). Saving 1,792 MiB pushes available memory to ~129,134 MiB, so now the model fits with ~1 GiB to spare.

Transparent Huge Pages (`MADV_HUGEPAGE`) don't help here, as THP remaps existing 4 KiB pages under a 2 MiB entry for TLB efficiency, but the `struct page` array stays intact (and saves no memory). Only explicit HugeTLB pool allocation with HVO addresses this.

~~I do want to be clear that currently this only works with CPU inference; that's because I haven't tackled hipMalloc. (That would open the door to directly passing memory to the GPU without reallocating.) I also am unsure of how this would work with other unified memory systems.~~
As of the latest commit, this works not only with CPU inference, but also with HIP / ROCm via ***buffer_from_host_ptr***. Vulkan support should also be possible but will require a bit more digging. NVIDIA support is a bit more difficult, as I don't have an NVIDIA integrated chipset, and there is at least one known issue with the Jetson and this approach (https://github.com/ggml-org/llama.cpp/issues/15034, https://github.com/ggml-org/llama.cpp/issues/15923).

### Approach

In #2251, @slaren suggested adding `MAP_HUGETLB` to the existing `mmap` call. @qdacsvx noted the kernel rejects `MAP_HUGETLB` on regular descriptors (`EINVAL`). This PR implements what @slaren had in mind:

1. `llama_mmap` allocates an anonymous region with `MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | MAP_POPULATE`
2. `load_all_data` populates the region per-tensor via `file->seek` + `file->read_raw` (same pattern as the existing `--no-mmap` branch)
3. After all tensors are loaded, `mprotect` downgrades to `PROT_READ`

`MAP_POPULATE` forces atomic pool allocation at mmap time, so if the pool is insufficient, it yields a clean `ENOMEM` (with a friendly diagnostic including `sysctl` guidance), not a SIGBUS during load.

Arg-parse rejects `--hugepages` combined with `--no-mmap` (wording points at a followup PR), `--direct-io` (the loader's existing conflict resolver would silently bypass our code), and non-Linux platforms.

Anonymous mapping is the only path to HugeTLB-backed weight memory without requiring a hugetlbfs mount, copying the model, and recompiling, a la *PR #12521  #12552* (issue #12444), which isn't especially user-friendly. This PR avoids all of that — just `sysctl` + `--hugepages`.

*PR #7420* also used anonymous mappings inside `llama_mmap`, but for direct-I/O bypass rather than hugepage backing. A concern raised there was that anonymous memory can swap under pressure. That doesn't apply here, since HugeTLB pages are inherently pinned by the kernel and cannot be swapped, reclaimed, or migrated regardless of memory pressure or `RLIMIT_MEMLOCK` settings. The can be relinquished / reused, though.

### Tradeoffs

Warm-load time increases because `--mmap` normally shares page-cache pages zero-copy, while `--hugepages` must `read_raw` file into the anonymous region.

Measured on qwen3-235B-Q4 (19.4 GB), Strix Halo, Linux 6.17:

| Path | Cold | Warm |
|---|---|---|
| `--mmap` baseline | 3843 ms | 547 ms |
| `--hugepages` | 5030 ms | 2319 ms |
| Slowdown | 1.31x | 4.24x |

The warm 4.24x is driven by Strix Halo's `copy_to_user` bandwidth (~8.5 GB/s on LPDDR5X). Other platforms may see less. At the 128 GiB target scale,
warm-load adds ~11 seconds per session — in exchange for the model actually fitting.

### Changes

There are three primary changes (in these three commits):
- Adding the CLI parameter `--hugepages` (and LLAMA_ARG_HUGEPAGES)
- Modifying function signatures & data structure to accommodate hugepages tracking
- Implementation of the hugepages allocation (llama-mmap.cpp)

### Testing

- Builds clean on Linux x86_64, GCC 14.2, both CPU-only and HIP/ROCm configurations                                                                                
- End-to-end verified on Strix Halo (gfx1151, ROCm 7.2.0, Linux 6.17):
    model loads with `--hugepages`, inference produces correct output                                                                                                
    (39 t/s prompt, 8.2 t/s generation on qwen3 19.4 GB)
- `--help` shows the flag with env var
- Arg-parse rejections verified (`--hugepages --no-mmap`, `--hugepages -dio`)
- Standalone harness validated the core mechanism on Strix Halo with a 19.4 GB GGUF:
  - Pool accounting exact (9424 x 2 MiB pages consumed/restored)
  - `VmRSS` confirms vmemmap reclamation: 3872 kB under `--hugepages` vs 19.30 GB baseline
  - No SIGBUS under `MAP_POPULATE`
  - `read_raw` EINTR/short-read handling inherited from existing code

### HVO verification

For users to confirm HVO is active:

```bash
# compiled in?
grep CONFIG_HUGETLB_PAGE_OPTIMIZE_VMEMMAP /boot/config-$(uname -r)
# → CONFIG_HUGETLB_PAGE_OPTIMIZE_VMEMMAP=y

# enabled at runtime?
cat /proc/sys/vm/hugetlb_optimize_vmemmap
# → 1  (if 0: sudo sysctl -w vm.hugetlb_optimize_vmemmap=1)

# pool state
grep -i huge /proc/meminfo
```

### Follow-ups (future work / not this PR)

- **`--no-mmap` path + KV cache + compute buffers** via a new `ggml_backend_cpu_hugetlb_buffer_type` (parallel to the existing HBM pattern). Reuses
the `--hugepages` flag.
- Multi-threaded `read_raw` for load parallelism
- `posix_fadvise(POSIX_FADV_DONTNEED)` on the source page cache after load
- `buffer_from_host_ptr` is hardcoded `false` for CUDA/HIP (`ggml-cuda.cu:4710`). This PR is forward-compatible with a future flip for zero-copy on unified-memory APUs.

cc @ggerganov @slaren — per prior comments in #2251, I was hoping you could let me know what your take is on this approach. I know this issue matters for me. I've done my best to simplify / minimize code changes, but I am always happy to reconsider my approach as needed. (I hope it's OK to tag you; sorry if I missed a policy against it.)

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used in the process of preparing these commits.

AI was used to identify the appropriate strategy, draft a harness, and draft initial code snippets. Every line was reviewed, edited as appropriate, and included in commits (with sections of code separated manually into different commits with specific focus to ensure clarity and appropriate review (e.g., CLI parameter setup, data structures / call signatures, and final implementation were all separated into separate commits during review and manual processing.)