### PR TITLE
cli : Use acquire/release semantics for stopping logic

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -12,17 +12,21 @@
 #include <array>
 #include <atomic>
 #include <algorithm>
+#include <csignal>
 #include <filesystem>
 #include <fstream>
 #include <thread>
-#include <signal.h>
 
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX
 #   define NOMINMAX
 #endif
+#include <io.h>
+#include <stdio.h>
 #include <windows.h>
+#elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#include <unistd.h>
 #endif
 
 const char * LLAMA_ASCII_LOGO = R"(
@@ -49,9 +53,13 @@ static void signal_handler(int) {
     if (already_interrupted) {
         // second Ctrl+C - exit immediately
         // make sure to clear colors before exiting (not using LOG or console.cpp here to avoid deadlock)
-        fprintf(stdout, "\033[0m\n");
-        fflush(stdout);
-        std::exit(130);
+        static constexpr char color_reset[] = "\033[0m\n";
+#if defined(_WIN32)
+        _write(_fileno(stdout), color_reset, sizeof(color_reset) - 1);
+#else
+        [[maybe_unused]] ssize_t ret = write(STDOUT_FILENO, color_reset, sizeof(color_reset) - 1);
+#endif
+        _exit(128 + SIGINT);
     }
 }
 #endif

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -37,19 +37,22 @@ const char * LLAMA_ASCII_LOGO = R"(
 
 static std::atomic<bool> g_is_interrupted = false;
 static bool should_stop() {
-    return g_is_interrupted.load();
+    return g_is_interrupted.load(std::memory_order_acquire);
+}
+static void reset_stop() {
+    g_is_interrupted.store(false, std::memory_order_release);
 }
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__)) || defined (_WIN32)
 static void signal_handler(int) {
-    if (g_is_interrupted.load()) {
+    const bool already_interrupted = g_is_interrupted.exchange(true, std::memory_order_acq_rel);
+    if (already_interrupted) {
         // second Ctrl+C - exit immediately
         // make sure to clear colors before exiting (not using LOG or console.cpp here to avoid deadlock)
         fprintf(stdout, "\033[0m\n");
         fflush(stdout);
         std::exit(130);
     }
-    g_is_interrupted.store(true);
 }
 #endif
 
@@ -59,9 +62,6 @@ struct cli_context {
     std::vector<raw_buffer> input_files;
     task_params defaults;
     bool verbose_prompt;
-
-    // thread for showing "loading" animation
-    std::atomic<bool> loading_show;
 
     cli_context(const common_params & params) {
         defaults.sampling    = params.sampling;
@@ -150,10 +150,7 @@ struct cli_context {
         std::string curr_content;
         bool is_thinking = false;
 
-        while (result) {
-            if (should_stop()) {
-                break;
-            }
+        while (result && !should_stop()) {
             if (result->is_error()) {
                 json err_data = result->to_json();
                 if (err_data.contains("message")) {
@@ -195,7 +192,7 @@ struct cli_context {
             }
             result = rd.next(should_stop);
         }
-        g_is_interrupted.store(false);
+        reset_stop();
         // server_response_reader automatically cancels pending tasks upon destruction
         return curr_content;
     }
@@ -527,7 +524,7 @@ int llama_cli(int argc, char ** argv) {
         console::log("\n");
 
         if (should_stop()) {
-            g_is_interrupted.store(false);
+            reset_stop();
             break;
         }
 


### PR DESCRIPTION
## Overview

`Ctrl+C` stopping logic was done correctly using atomics - but sequential CST ordering has no benefits in this case. Using Acq/Rel is slightly faster, which helps since `should_stop` is queried every output token. In addition, I added a utility function for resetting the stop request (makes code more readable) and used an exchange operation for the signal handler to simplify the code.

The variable `loading_show` was unused, so I removed it.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
