### PR TITLE
ggml-rpc: fix 32-bit ARM (ILP32) serialization bugs

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -415,7 +415,8 @@ static bool recv_data(sockfd_t sockfd, void * data, size_t size) {
 }
 
 static bool send_msg(sockfd_t sockfd, const void * msg, size_t msg_size) {
-    if (!send_data(sockfd, &msg_size, sizeof(msg_size))) {
+    uint64_t size = msg_size;
+    if (!send_data(sockfd, &size, sizeof(size))) {
         return false;
     }
     return send_data(sockfd, msg, msg_size);
@@ -463,7 +464,8 @@ static bool send_rpc_cmd(const std::shared_ptr<socket_t> & sock, enum rpc_cmd cm
     if (!send_data(sock->fd, &cmd_byte, sizeof(cmd_byte))) {
         return false;
     }
-    if (!send_data(sock->fd, &input_size, sizeof(input_size))) {
+    uint64_t size = input_size;
+    if (!send_data(sock->fd, &size, sizeof(size))) {
         return false;
     }
     if (!send_data(sock->fd, input, input_size)) {
@@ -578,8 +580,8 @@ static bool ggml_backend_buffer_is_rpc(ggml_backend_buffer_t buffer) {
 
 static rpc_tensor serialize_tensor(const ggml_tensor * tensor) {
     rpc_tensor result;
+    memset(&result, 0, sizeof(result));
     if (!tensor) {
-        memset(&result, 0, sizeof(result));
         return result;
     }
 
@@ -653,9 +655,10 @@ static void ggml_backend_rpc_buffer_set_tensor(ggml_backend_buffer_t buffer, ggm
     // input serialization format: | rpc_tensor | offset (8 bytes) | data (size bytes)
     size_t input_size = sizeof(rpc_tensor) + sizeof(uint64_t) + size;
     std::vector<uint8_t> input(input_size, 0);
+    uint64_t offset_u64 = offset;
     memcpy(input.data(), &rpc_tensor, sizeof(rpc_tensor));
-    memcpy(input.data() + sizeof(rpc_tensor), &offset, sizeof(offset));
-    memcpy(input.data() + sizeof(rpc_tensor) + sizeof(offset), data, size);
+    memcpy(input.data() + sizeof(rpc_tensor), &offset_u64, sizeof(offset_u64));
+    memcpy(input.data() + sizeof(rpc_tensor) + sizeof(offset_u64), data, size);
     bool status = send_rpc_cmd(ctx->sock, RPC_CMD_SET_TENSOR, input.data(), input.size());
     RPC_STATUS_ASSERT(status);
 }
@@ -859,7 +862,8 @@ static void serialize_graph(uint32_t device, const ggml_cgraph * cgraph, std::ve
     memcpy(dest, &n_nodes, sizeof(n_nodes));
     dest += sizeof(n_nodes);
     for (uint32_t i = 0; i < n_nodes; i++) {
-        memcpy(dest + i * sizeof(uint64_t), &cgraph->nodes[i], sizeof(uint64_t));
+        uint64_t node_ptr = reinterpret_cast<uint64_t>(cgraph->nodes[i]);
+        memcpy(dest + i * sizeof(uint64_t), &node_ptr, sizeof(uint64_t));
     }
     dest += n_nodes * sizeof(uint64_t);
     memcpy(dest, &n_tensors, sizeof(n_tensors));


### PR DESCRIPTION
## Fix RPC backend on 32-bit ARM (ILP32) platforms

### Problem

The RPC backend is completely non-functional on 32-bit ARM (armv7, ILP32) platforms. Any attempt to use `--rpc` causes either a silent hang, server-side "Expected HELLO command" errors, `set_tensor` out-of-bounds crashes, or `graph_compute` failures with corrupted tensor IDs.

Root cause: several places in the RPC serialization code assume `size_t` and pointers are 8 bytes. On 32-bit platforms `size_t` is 4 bytes and pointers are 4 bytes, causing the wire protocol to produce undersized or misaligned data that the receiving side (which reads fixed `uint64_t` fields) cannot parse.

### Fixes

**1. `send_msg` / `send_rpc_cmd`: message size field is 4 bytes instead of 8**

`send_msg()` sends `sizeof(msg_size)` bytes for the size header, where `msg_size` is `size_t` (4 bytes on ILP32). The receiver `recv_msg()` reads `uint64_t` (8 bytes). The receiver blocks forever waiting for the remaining 4 bytes, causing a silent hang on the very first RPC command (HELLO).

**2. `ggml_backend_rpc_buffer_set_tensor`: offset field is 4 bytes instead of 8**

The `offset` parameter is `size_t` but the wire format specifies 8 bytes. The `memcpy` copies only `sizeof(offset)` = 4 bytes, and the subsequent data copy starts at the wrong position. The server reads a garbage 64-bit offset and rejects with "out of buffer bounds".

**3. `serialize_graph`: node pointer memcpy reads 8 bytes from a 4-byte pointer**

`memcpy(dest, &cgraph->nodes[i], sizeof(uint64_t))` reads 8 bytes starting at the address of a 4-byte pointer. The extra 4 bytes are adjacent memory, producing corrupted tensor IDs that fail with "failed to create graph node".

**4. `serialize_tensor`: zero-initialize rpc_tensor struct**

Move `memset` before the null check so all serializations start zeroed, preventing uninitialized upper bytes in `uint64_t` fields assigned from narrower types.

### Platforms affected

All 32-bit platforms where `sizeof(size_t) == 4`:
- ARMv7 / armhf (Android Termux, Raspberry Pi 32-bit, etc.)
- Potentially i686 / x86 32-bit builds

### Testing

Tested on Android ARMv7 (Termux, clang 21) with Qwen2.5-0.5B-Instruct Q4_K_M:
- Before: `llama-cli --rpc` hangs indefinitely with zero output
- After: model loads and runs inference successfully over local RPC