### PR TITLE
Expose build_info in router mode

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -926,7 +926,8 @@ void server_models_routes::init_routes() {
             res_ok(res, {
                 // TODO: add support for this on web UI
                 {"role",          "router"},
-                {"max_instances", 4}, // dummy value for testing
+                {"max_instances", params.models_max},
+                {"models_autoload", params.models_autoload},
                 // this is a dummy response to make sure webui doesn't break
                 {"model_alias", "llama-server"},
                 {"model_path",  "none"},
@@ -935,6 +936,7 @@ void server_models_routes::init_routes() {
                     {"n_ctx",  0},
                 }},
                 {"webui_settings", webui_settings},
+                {"build_info",     build_info},
             });
             return res;
         }

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -9,6 +9,19 @@ def create_server():
     server = ServerPreset.router()
 
 
+def test_router_props():
+    global server
+    server.models_max = 2
+    server.no_models_autoload = True
+    server.start()
+    res = server.make_request("GET", "/props")
+    assert res.status_code == 200
+    assert res.body["role"] == "router"
+    assert res.body["max_instances"] == 2
+    assert res.body["models_autoload"] is False
+    assert res.body["build_info"].startswith("b")
+
+
 @pytest.mark.parametrize(
     "model,success",
     [


### PR DESCRIPTION
## Overview

- Include the `build_info` in llama-server 's /prop endpoint when running in router mode;
- also expose params.models_max instead of dummy value and params.models_autoload

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES (code review)


------

For context, with this change, in router mode, for `GET /props`

**BEFORE**


```
{
  "role":"router",
  "max_instances":4,
  "model_alias":"llama-server",
  "model_path":"none",
  "default_generation_settings":{"params":null,"n_ctx":0},
  "webui_settings":{}
}
```

**AFTER**

```
{
  "role":"router",
  "max_instances":4,
  "models_autoload":true,
  "model_alias":"llama-server",
  "model_path":"none",
  "default_generation_settings":{"params":null,"n_ctx":0},
  "webui_settings":{},
  "build_info":"b8771-9ef1fab9c"
}
```
