### PR TITLE
ggml-cuda: avoid cudaMemcpyPeerAsync when P2P is unavailable

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1091,6 +1091,9 @@ struct ggml_cuda_device_info {
 
     cuda_device_info devices[GGML_CUDA_MAX_DEVICES] = {};
 
+    // peer_access[i][j] = true if GPU i can directly access GPU j's memory (P2P enabled)
+    bool peer_access[GGML_CUDA_MAX_DEVICES][GGML_CUDA_MAX_DEVICES] = {};
+
     std::array<float, GGML_CUDA_MAX_DEVICES> default_tensor_split = {};
 
 #ifdef GGML_USE_NCCL

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -334,6 +334,7 @@ static ggml_cuda_device_info ggml_cuda_init() {
             CUDA_CHECK(cudaDeviceCanAccessPeer(&can_access_peer, id, id_other));
             if (can_access_peer) {
                 CUDA_CHECK(cudaDeviceEnablePeerAccess(id_other, 0));
+                info.peer_access[id][id_other] = true;
             }
         }
     }
@@ -2978,6 +2979,13 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
 #ifdef GGML_CUDA_NO_PEER_COPY
             return false;
 #else
+            // Use peer copy only if P2P access was actually enabled at init time.
+            // Without P2P, cudaMemcpyPeerAsync stages through host memory and the
+            // CUDA event records only after the source-side DMA, not after the
+            // destination-side write — so the destination GPU can read stale data.
+            if (!ggml_cuda_info().peer_access[cuda_ctx_src->device][cuda_ctx_dst->device]) {
+                return false;
+            }
             CUDA_CHECK(cudaMemcpyPeerAsync(dst->data, cuda_ctx_dst->device, src->data, cuda_ctx_src->device, ggml_nbytes(dst), cuda_ctx_src->stream()));
 #endif // GGML_CUDA_NO_PEER_COPY
         }


### PR DESCRIPTION
## Overview

Fixes corrupted multi-GPU output on systems where CUDA peer access is not available between devices.

## Additional information

Cross-device copies used cudaMemcpyPeerAsync even when P2P was unavailable. On non-P2P topologies this can route through host staging, and stream event ordering can allow destination-side reads before data is fully visible, causing stale recurrent state reads and garbled tokens.