### PR TITLE
common: skip reasoning budget sampler when no budget is requested

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -287,8 +287,8 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         }
     }
 
-    // reasoning budget sampler
-    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty()) {
+    // reasoning budget sampler (skip when budget is unlimited to avoid per-token overhead)
+    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && params.reasoning_budget_tokens >= 0) {
         rbudget = common_reasoning_budget_init(
             vocab,
             params.reasoning_budget_start,

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -287,8 +287,8 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         }
     }
 
-    // reasoning budget sampler (skip when budget is unlimited to avoid per-token overhead)
-    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && params.reasoning_budget_tokens >= 0) {
+    // reasoning budget sampler (skip when budget is unlimited unless a lazy grammar is active, which needs rbudget for thinking-block suppression)
+    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0)) {
         rbudget = common_reasoning_budget_init(
             vocab,
             params.reasoning_budget_start,


### PR DESCRIPTION
## Overview

After I added thinking_start_tag / thinking_end_tag for gemma4 in #21697, the reasoning budget sampler gets unconditionally created even if no budget is configured. The same applies to kimi_k2, lfm2, lfm2_5, and ministral_3 which also set these tags. The budget gets converted to INT_MAX, so the sampler never actually forces any tokens but still runs per-token checks (start tag matching in IDLE state, token-to-piece conversion + UTF-8 checks in COUNTING state).

More importantly, the existence of the sampler (i.e., non-null rbudget) disables backend sampling. Backend sampling lets the GPU select tokens directly, avoiding a full logits transfer from GPU to CPU every token. This could potentially explain the 30% speed regression reported in #21784 (98 t/s to 70 t/s on Vulkan).

So I added a reasoning_budget_tokens >= 0 check to the sampler creation condition. When the budget is unlimited, the sampler is not created, backend sampling stays enabled, and no per-token overhead is added. When a budget is explicitly set (0, 128, 1024, etc.), the sampler is created and works as before.

Should fix #21784

## Additional information

Note that I do not have a Vulkan environment so I can replicate neither the original degradation nor that the fix works in terms of performance. However, I did play with the backend-sampling flag myself manually on CUDA and my commit gave me around 5% improvement (~215t/s vs ~225t/s). In any case, it is logically cleaner and should be an improvement in all cases.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES: I asked my local agent to identify the potential sources of the performance regression on Vulkan, and then I manually validated and tested and validated the logic.