### PR TITLE
server: add --parallel-tool-calling flag to enable by default

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3164,6 +3164,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PREFILL_ASSISTANT"));
     add_opt(common_arg(
+        {"--parallel-tool-calls"},
+        {"--no-parallel-tool-calls"},
+        "enable parallel tool calls by default (default: disabled)",
+        [](common_params & params, bool value) {
+            params.parallel_tool_calls = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PARALLEL_TOOL_CALLS"));
+    add_opt(common_arg(
         {"-sps", "--slot-prompt-similarity"}, "SIMILARITY",
         string_format("how much the prompt of a request must match the prompt of a slot in order to use that slot (default: %.2f, 0.0 = disabled)\n", params.slot_prompt_similarity),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -591,6 +591,7 @@ struct common_params {
     bool use_jinja = true;                                                                                  // NOLINT
     bool enable_chat_template = true;
     bool force_pure_content_parser = false;
+    bool parallel_tool_calls = false;
     common_reasoning_format reasoning_format = COMMON_REASONING_FORMAT_DEEPSEEK;
     int enable_reasoning = -1; // -1 = auto, 0 = disable, 1 = enable
     int reasoning_budget = -1;

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1012,7 +1012,7 @@ json oaicompat_chat_params_parse(
     inputs.json_schema           = json_schema.is_null() ? "" : json_schema.dump();
     inputs.grammar               = grammar;
     inputs.use_jinja             = opt.use_jinja;
-    inputs.parallel_tool_calls   = json_value(body, "parallel_tool_calls", false);
+    inputs.parallel_tool_calls   = json_value(body, "parallel_tool_calls", opt.parallel_tool_calls);
     inputs.add_generation_prompt = json_value(body, "add_generation_prompt", true);
     inputs.reasoning_format      = opt.reasoning_format;
     if (body.contains("reasoning_format")) {

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -290,6 +290,7 @@ struct server_chat_params {
     int  reasoning_budget = -1;
     std::string reasoning_budget_message;
     std::string media_path;
+    bool parallel_tool_calls = false;
     bool force_pure_content = false;
 };
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -939,6 +939,7 @@ private:
                 /* reasoning_budget      */ params_base.reasoning_budget,
                 /* reasoning_budget_msg  */ params_base.reasoning_budget_message,
                 /* media_path            */ params_base.media_path,
+                /* parallel_tool_calls   */ params_base.parallel_tool_calls,
                 /* force_pure_content    */ params_base.force_pure_content_parser
             };
         }


### PR DESCRIPTION
## Overview

Add a `--parallel-tool-calling` / `--no-parallel-tool-calling` command-line flag (and `LLAMA_ARG_PARALLEL_TOOL_CALLS` environment variable) to the server example. When enabled, the server defaults `parallel_tool_calls` to `true` instead of `false`. Clients can still override the default by explicitly setting `parallel_tool_calls` in the request body.

## Additional information

N/A

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO