### PR TITLE
ggml: improve SPIR-V headers detection with __has_include while preserving original _WIN32 logic

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -20,12 +20,22 @@ DispatchLoaderDynamic & ggml_vk_default_dispatcher();
 #define VULKAN_HPP_DEFAULT_DISPATCHER ggml_vk_default_dispatcher()
 
 #include <vulkan/vulkan.hpp>
-// SPIRV-Headers: LunarG Windows SDK uses Include/spirv-headers/spirv.hpp (not spirv/unified1/). MinGW/MSYS2 and
-// Linux packages use Khronos layout spirv/unified1/spirv.hpp. See docs/build.md#vulkan.
-#if defined(_WIN32) && !defined(__MINGW32__)
-#include <spirv-headers/spirv.hpp>
+
+// SPIR-V Headers: different SDK installations expose different include paths.
+// LunarG Vulkan SDK on Windows typically provides <spirv-headers/spirv.hpp>,
+// while Linux packages, MSYS2 and MinGW often use the Khronos layout
+// <spirv/unified1/spirv.hpp>. We prefer __has_include for better portability,
+// falling back to the original platform logic for maximum compatibility.
+#if __has_include(<spirv/unified1/spirv.hpp>)
+#    include <spirv/unified1/spirv.hpp>
+#elif __has_include(<spirv-headers/spirv.hpp>)
+#    include <spirv-headers/spirv.hpp>
+#elif __has_include(<spirv.hpp>)
+#    include <spirv.hpp>
+#elif defined(_WIN32) && !defined(__MINGW32__)
+#    include <spirv-headers/spirv.hpp>
 #else
-#include <spirv/unified1/spirv.hpp>
+#    include <spirv/unified1/spirv.hpp>
 #endif
 
 #include <algorithm>

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -22,20 +22,29 @@ DispatchLoaderDynamic & ggml_vk_default_dispatcher();
 #include <vulkan/vulkan.hpp>
 
 // SPIR-V Headers: different SDK installations expose different include paths.
-// LunarG Vulkan SDK on Windows typically provides <spirv-headers/spirv.hpp>,
-// while Linux packages, MSYS2 and MinGW often use the Khronos layout
-// <spirv/unified1/spirv.hpp>. We prefer __has_include for better portability,
-// falling back to the original platform logic for maximum compatibility.
-#if __has_include(<spirv/unified1/spirv.hpp>)
-#    include <spirv/unified1/spirv.hpp>
-#elif __has_include(<spirv-headers/spirv.hpp>)
-#    include <spirv-headers/spirv.hpp>
-#elif __has_include(<spirv.hpp>)
-#    include <spirv.hpp>
-#elif defined(_WIN32) && !defined(__MINGW32__)
-#    include <spirv-headers/spirv.hpp>
+// LunarG Vulkan SDK on Windows typically provides <spirv-headers/spirv.hpp>.
+// Linux packages, MSYS2 and MinGW often use the Khronos layout <spirv/unified1/spirv.hpp>.
+// FreeBSD typically uses <spirv_cross/spirv.hpp>.
+#if defined(__has_include)
+#    if __has_include(<spirv/unified1/spirv.hpp>)
+#        include <spirv/unified1/spirv.hpp>
+#    elif __has_include(<spirv-headers/spirv.hpp>)
+#        include <spirv-headers/spirv.hpp>
+#    elif __has_include(<spirv_cross/spirv.hpp>)
+#        include <spirv_cross/spirv.hpp>
+#    elif __has_include(<spirv.hpp>)
+#        include <spirv.hpp>
+#    else
+// Fallback to let the compiler throw a standard "file not found" error
+#        include <spirv/unified1/spirv.hpp>
+#    endif
 #else
-#    include <spirv/unified1/spirv.hpp>
+// Fallback logic for older compilers that do not support __has_include
+#    if defined(_WIN32) && !defined(__MINGW32__)
+#        include <spirv-headers/spirv.hpp>
+#    else
+#        include <spirv/unified1/spirv.hpp>
+#    endif
 #endif
 
 #include <algorithm>

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -24,24 +24,15 @@ DispatchLoaderDynamic & ggml_vk_default_dispatcher();
 // SPIR-V Headers: different SDK installations expose different include paths.
 // LunarG Vulkan SDK on Windows typically provides <spirv-headers/spirv.hpp>.
 // Linux packages, MSYS2 and MinGW often use the Khronos layout <spirv/unified1/spirv.hpp>.
-#if defined(__has_include)
-#    if __has_include(<spirv/unified1/spirv.hpp>)
-#        include <spirv/unified1/spirv.hpp>
-#    elif __has_include(<spirv-headers/spirv.hpp>)
-#        include <spirv-headers/spirv.hpp>
-#    elif __has_include(<spirv.hpp>)
-#        include <spirv.hpp>
-#    else
-         // Fallback to let the compiler throw a standard "file not found" error
-#        include <spirv/unified1/spirv.hpp>
-#    endif
+#if __has_include(<spirv/unified1/spirv.hpp>)
+#    include <spirv/unified1/spirv.hpp>
+#elif __has_include(<spirv-headers/spirv.hpp>)
+#    include <spirv-headers/spirv.hpp>
+#elif __has_include(<spirv.hpp>)
+#    include <spirv.hpp>
 #else
-// Fallback logic for older compilers that do not support __has_include
-#    if defined(_WIN32) && !defined(__MINGW32__)
-#        include <spirv-headers/spirv.hpp>
-#    else
-#        include <spirv/unified1/spirv.hpp>
-#    endif
+     // Fallback to let the compiler throw a standard "file not found" error
+#    include <spirv/unified1/spirv.hpp>
 #endif
 
 #include <algorithm>

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -24,18 +24,15 @@ DispatchLoaderDynamic & ggml_vk_default_dispatcher();
 // SPIR-V Headers: different SDK installations expose different include paths.
 // LunarG Vulkan SDK on Windows typically provides <spirv-headers/spirv.hpp>.
 // Linux packages, MSYS2 and MinGW often use the Khronos layout <spirv/unified1/spirv.hpp>.
-// FreeBSD typically uses <spirv_cross/spirv.hpp>.
 #if defined(__has_include)
 #    if __has_include(<spirv/unified1/spirv.hpp>)
 #        include <spirv/unified1/spirv.hpp>
 #    elif __has_include(<spirv-headers/spirv.hpp>)
 #        include <spirv-headers/spirv.hpp>
-#    elif __has_include(<spirv_cross/spirv.hpp>)
-#        include <spirv_cross/spirv.hpp>
 #    elif __has_include(<spirv.hpp>)
 #        include <spirv.hpp>
 #    else
-// Fallback to let the compiler throw a standard "file not found" error
+         // Fallback to let the compiler throw a standard "file not found" error
 #        include <spirv/unified1/spirv.hpp>
 #    endif
 #else


### PR DESCRIPTION
## Overview

Fix SPIR-V header include detection in `ggml-vulkan.cpp` to support a wider range of real-world build environments.

The previous platform-specific check:
`_WIN32 && !__MINGW32__`
fails in several valid configurations and can lead to missing header errors.

This PR introduces a `__has_include`-based detection mechanism that probes available include paths at compile time and selects the correct one automatically.

Since `llama.cpp` requires C++17, this implementation relies entirely on standard `__has_include` and removes outdated platform-specific fallback logic, resulting in cleaner code.

This primarily improves downstream integration of llama.cpp as a library.

---

## Additional information

### Problem

The existing logic breaks in multiple real-world scenarios:

- custom Qt / CMake projects  
- MinGW / llvm-mingw with official LunarG Vulkan SDK  
- different Linux package layouts  

Example build error:

```
fatal error: 'spirv/unified1/spirv.hpp' file not found
```

### Solution

Use `__has_include` to detect SPIR-V headers in a portable way:

- `<spirv/unified1/spirv.hpp>`  
- `<spirv-headers/spirv.hpp>`  
- `<spirv.hpp>`  

If none are found, it defaults to the standard Khronos layout to let the compiler throw a proper "file not found" error.
This approach is:

- toolchain-independent  
- robust across SDK layouts  
- compatible with custom build systems  
- strictly C++17 compliant

### Testing

Tested on:

- Windows 11 (64-bit)  
  - Qt Creator 19.0.0  
  - Qt 6.11.0 (llvm-mingw 64-bit)  
  - Vulkan SDK 1.4.341.1 (official LunarG)  

### Impact

- Fixes build failures outside official CMake builds  
- No functional changes for standard builds  
- Fully backward compatible  

---

# Requirements

I have read and agree with the contributing guidelines  

AI usage disclosure:

The code changes, testing, PR description  were performed by the author.