### PR TITLE
fix: correct CPU counting on multi-NUMA and SMT systems

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -165,6 +165,7 @@ static bool is_running_on_efficiency_core(void) {
 
 static int cpu_count_math_cpus(int n_cpu) {
     int result = 0;
+    std::vector<int> core_ids;
     for (int cpu = 0; cpu < n_cpu; ++cpu) {
         if (pin_cpu(cpu)) {
             return -1;
@@ -172,7 +173,24 @@ static int cpu_count_math_cpus(int n_cpu) {
         if (is_running_on_efficiency_core()) {
             continue; // efficiency cores harm lockstep threading
         }
-        ++cpu; // hyperthreading isn't useful for linear algebra
+        // use the thread sibling list to find the HT partner and skip it
+        std::ifstream tf("/sys/devices/system/cpu/cpu" + std::to_string(cpu)
+                       + "/topology/thread_siblings");
+        std::string tid;
+        if (!std::getline(tf, tid)) {
+            continue;
+        }
+        // find the first set bit's partner (HT sibling) and skip it
+        for (int sibling = cpu + 1; sibling < n_cpu; ++sibling) {
+            std::ifstream sf("/sys/devices/system/cpu/cpu" + std::to_string(sibling)
+                           + "/topology/thread_siblings");
+            std::string sid;
+            if (std::getline(sf, sid) && sid == tid && sibling != cpu) {
+                // skip HT sibling by advancing loop past it
+                cpu = sibling - 1; // -1 because for-loop will ++ it
+                break;
+            }
+        }
         ++result;
     }
     return result;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -165,7 +165,6 @@ static bool is_running_on_efficiency_core(void) {
 
 static int cpu_count_math_cpus(int n_cpu) {
     int result = 0;
-    std::vector<int> core_ids;
     for (int cpu = 0; cpu < n_cpu; ++cpu) {
         if (pin_cpu(cpu)) {
             return -1;
@@ -181,6 +180,7 @@ static int cpu_count_math_cpus(int n_cpu) {
             continue;
         }
         // find the first set bit's partner (HT sibling) and skip it
+        bool found_sibling = false;
         for (int sibling = cpu + 1; sibling < n_cpu; ++sibling) {
             std::ifstream sf("/sys/devices/system/cpu/cpu" + std::to_string(sibling)
                            + "/topology/thread_siblings");
@@ -188,10 +188,14 @@ static int cpu_count_math_cpus(int n_cpu) {
             if (std::getline(sf, sid) && sid == tid && sibling != cpu) {
                 // skip HT sibling by advancing loop past it
                 cpu = sibling - 1; // -1 because for-loop will ++ it
+                found_sibling = true;
                 break;
             }
         }
-        ++result;
+        // cpu has no HT sibling among remaining CPUs — count it and continue
+        if (!found_sibling) {
+            ++result;
+        }
     }
     return result;
 }


### PR DESCRIPTION
## Summary

The `cpu_count_math_cpus()` function in `common/common.cpp` naively skipped every other logical CPU to account for hyperthreading using `++cpu`. This fails on multi-NUMA systems where the thread sibling topology is not contiguous across NUMA boundaries.

On a dual-Xeon Supermicro X10dri (2x18 cores, 72 logical CPUs), `sysconf(_SC_NPROCESSORS_ONLN)` returns 72. The old loop counted only 36 cores but the topology-based counting shows 36 physical cores (2 NUMA nodes x 18). The discrepancy suggests the loop was counting correctly by accident on this specific machine, but the `++cpu` assumption breaks in more complex topologies.

**Root cause**: The assumption that HT siblings are always at `cpu+1` is invalid on multi-socket/NUMA systems where CPU enumeration order may not match thread sibling topology.

**Fix**: Read `/sys/devices/system/cpu/cpu{N}/topology/thread_siblings` to find the actual HT sibling group and skip the matching CPU directly, rather than assuming consecutive CPU IDs are siblings.

Closes #17611