### PR TITLE
gguf-py: add type and range validation to GGUFWriter.add_key_value

### DIFF
--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -274,11 +274,66 @@ class GGUFWriter:
             fout.flush()
         self.state = WriterState.TI_DATA
 
+    _expected_python_types: dict[GGUFValueType, tuple[type, ...]] = {
+        GGUFValueType.UINT8:   (int, np.integer),
+        GGUFValueType.INT8:    (int, np.integer),
+        GGUFValueType.UINT16:  (int, np.integer),
+        GGUFValueType.INT16:   (int, np.integer),
+        GGUFValueType.UINT32:  (int, np.integer),
+        GGUFValueType.INT32:   (int, np.integer),
+        GGUFValueType.FLOAT32: (float, int, np.floating, np.integer),
+        GGUFValueType.UINT64:  (int, np.integer),
+        GGUFValueType.INT64:   (int, np.integer),
+        GGUFValueType.FLOAT64: (float, int, np.floating, np.integer),
+        GGUFValueType.BOOL:    (bool, np.bool_),
+        GGUFValueType.STRING:  (str, bytes, bytearray),
+        GGUFValueType.ARRAY:   (list, tuple, bytes, bytearray, np.ndarray),
+    }
+
+    _int_ranges: dict[GGUFValueType, tuple[int, int]] = {
+        GGUFValueType.UINT8:   (0, (1 << 8) - 1),
+        GGUFValueType.INT8:    (-(1 << 7), (1 << 7) - 1),
+        GGUFValueType.UINT16:  (0, (1 << 16) - 1),
+        GGUFValueType.INT16:   (-(1 << 15), (1 << 15) - 1),
+        GGUFValueType.UINT32:  (0, (1 << 32) - 1),
+        GGUFValueType.INT32:   (-(1 << 31), (1 << 31) - 1),
+        GGUFValueType.UINT64:  (0, (1 << 64) - 1),
+        GGUFValueType.INT64:   (-(1 << 63), (1 << 63) - 1),
+    }
+
     def add_key_value(self, key: str, val: Any, vtype: GGUFValueType, sub_type: GGUFValueType | None = None) -> None:
         if any(key in kv_data for kv_data in self.kv_data):
             logger.warning(f'Duplicated key name {key!r}, overwriting it with new value {val!r} of type {vtype.name}')
 
+        self._validate_key_value(key, val, vtype)
+
         self.kv_data[0][key] = GGUFValue(value=val, type=vtype, sub_type=sub_type)
+
+    def _validate_key_value(self, key: str, val: Any, vtype: GGUFValueType) -> None:
+        # bool must be checked before int since bool is a subclass of int in Python
+        if vtype != GGUFValueType.BOOL and isinstance(val, bool):
+            raise TypeError(
+                f"Expected numeric value for key {key!r} (GGUF type {vtype.name}), "
+                f"but got bool. Use add_bool() for boolean values."
+            )
+
+        expected = self._expected_python_types.get(vtype)
+        if expected is not None and not isinstance(val, expected):
+            type_names = " or ".join(t.__name__ for t in expected if t.__module__ == "builtins") or vtype.name
+            raise TypeError(
+                f"Invalid type for key {key!r}: expected {type_names} for GGUF type "
+                f"{vtype.name}, but got {type(val).__name__}: {val!r}"
+            )
+
+        int_range = self._int_ranges.get(vtype)
+        if int_range is not None and isinstance(val, (int, np.integer)):
+            lo, hi = int_range
+            int_val = int(val)
+            if not (lo <= int_val <= hi):
+                raise ValueError(
+                    f"Value {int_val} out of range for key {key!r} "
+                    f"(GGUF type {vtype.name}): valid range is [{lo}, {hi}]"
+                )
 
     def add_uint8(self, key: str, val: int) -> None:
         self.add_key_value(key,val, GGUFValueType.UINT8)


### PR DESCRIPTION
### Summary

Adds early type and range validation to `GGUFWriter.add_key_value()` so that mismatches between Python values and declared GGUF types are caught at insertion time with clear error messages, instead of failing deep inside `_pack_val()` during serialization with opaque `struct.pack` errors.

This was discussed in [PR #9074](https://github.com/ggml-org/llama.cpp/pull/9074#issuecomment-2296799118) where a `license` field coming through as a `list` on a `STRING` code path caused a confusing `TypeError` at write time.

### Changes

**`gguf-py/gguf/gguf_writer.py`**

- **Type validation:** A `_expected_python_types` mapping defines which Python types are valid for each `GGUFValueType`. `add_key_value()` now raises `TypeError` with a clear message (including the key name, expected types, and actual type) when a value doesn't match.

- **Range validation:** A `_int_ranges` mapping defines valid min/max for each integer `GGUFValueType` (UINT8, INT8, ..., INT64). Catches overflow/underflow at insertion time instead of at `struct.pack` time.

- **Bool/int disambiguation:** Since `bool` is a subclass of `int` in Python, passing `True` to an integer field (e.g. `add_uint32("key", True)`) is now caught and flagged with a suggestion to use `add_bool()`.

- **NumPy compatibility:** `np.integer`, `np.floating`, `np.bool_`, and `np.ndarray` are accepted alongside native Python types, since many conversion scripts produce numpy scalars.

### Error message examples

```
TypeError: Invalid type for key 'tokenizer.ggml.model': expected str or bytes or bytearray
for GGUF type STRING, but got list: ['llama', 'gpt2']

ValueError: Value 256 out of range for key 'general.quantization_version'
(GGUF type UINT8): valid range is [0, 255]

TypeError: Expected numeric value for key 'general.file_type' (GGUF type UINT32),
but got bool. Use add_bool() for boolean values.
```

### Testing

Validated locally against all existing `add_*` convenience methods with both native Python and numpy scalar types. All valid patterns continue to work; invalid patterns now fail early with actionable messages.

Fixes #9095