### PR TITLE
llama-diffusion-cli: read n_ctx back after making llama_context so the cli doesn't reject all input without -c

### DIFF
--- a/examples/diffusion/diffusion-cli.cpp
+++ b/examples/diffusion/diffusion-cli.cpp
@@ -602,8 +602,8 @@ int main(int argc, char ** argv) {
 
     int n_input = input_tokens.size();
 
-    if (n_input >= params.n_ctx) {
-        LOG_ERR("error: input too long (%d tokens), max context is %d\n", n_input, params.n_ctx);
+    if (static_cast<uint32_t>(n_input) >= llama_n_ctx(ctx)) {
+        LOG_ERR("error: input too long (%d tokens), max context is %d\n", n_input, llama_n_ctx(ctx));
         llama_free(ctx);
         llama_model_free(model);
         return 1;


### PR DESCRIPTION
## Overview

Read back via `llama_n_ctx` the context window size that `llama_init_from_model` determines, as mentioned in comments for `llama_n_ctx`. The prevents the cli from rejecting all inputs because it thinks the context window is 0 length. 

## Additional information

I ran into the issue described in https://github.com/ggml-org/llama.cpp/issues/20407 myself and the fix seemed straightforward, so I did it. @am17an - sorry for the random PR, it's very minor.

Tested on a mac like so: 

`./build/bin/llama-diffusion-cli -m Dream-v0-Instruct-7B-Q4_K_M.gguf -p "Why did the chicken cross the road?" --temp 0.2 --diffusion-algorithm 0 --diffusion-alg-temp 0.2 -ngl 99 --top_p 0.95 --diffusion-steps 128 --diffusion-eps 0.001
`

Before: 
`error: input too long (27 tokens), max context is 0`

After: 
`To get to the other side.`

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO, I somehow typed all 20 chars of it by myself.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
