### PR TITLE
webgpu : fix f16 xielu

### DIFF
--- a/ggml/src/ggml-webgpu/wgsl-shaders/unary.wgsl
+++ b/ggml/src/ggml-webgpu/wgsl-shaders/unary.wgsl
@@ -147,15 +147,13 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                                -9.010913, 9.010913)));
 #endif
 #ifdef XIELU
-    let res =
-        select(((exp(min(src[params.offset_src + src_idx], TYPE(params.eps))) - 1.0) -
-                src[params.offset_src + src_idx]) *
-                   TYPE(params.alpha_n) +
-               TYPE(params.beta) * src[params.offset_src + src_idx],
-               TYPE(params.alpha_p) * src[params.offset_src + src_idx] *
-                   src[params.offset_src + src_idx] +
-                   TYPE(params.beta) * src[params.offset_src + src_idx],
+    let src_f32 = f32(src[params.offset_src + src_idx]);
+    let result =
+        select(((exp(min(src_f32, params.eps)) - 1.0) - src_f32) *
+               params.alpha_n + params.beta * src_f32,
+               params.alpha_p * src_f32 * src_f32 + params.beta * src_f32,
                src[params.offset_src + src_idx] > 0.0);
+    let res = TYPE(result);
 #endif
 #ifdef SOFTPLUS
     let src_f32 = f32(src[params.offset_src + src_idx]);

--- a/ggml/src/ggml-webgpu/wgsl-shaders/unary.wgsl
+++ b/ggml/src/ggml-webgpu/wgsl-shaders/unary.wgsl
@@ -152,7 +152,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         select(((exp(min(src_f32, params.eps)) - 1.0) - src_f32) *
                params.alpha_n + params.beta * src_f32,
                params.alpha_p * src_f32 * src_f32 + params.beta * src_f32,
-               src[params.offset_src + src_idx] > 0.0);
+               src_f32 > 0.0);
     let res = TYPE(result);
 #endif
 #ifdef SOFTPLUS


### PR DESCRIPTION
## Overview

Fix `XIELU` with `F16` src tensor.

## Additional information

Downcasting parameters and using `F16` precision throughout was not sufficient, cast src to `F32` instead.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 唔係