### PR TITLE
Add SVE for simd-gemm.h

### DIFF
--- a/ggml/src/ggml-cpu/simd-gemm.h
+++ b/ggml/src/ggml-cpu/simd-gemm.h
@@ -9,7 +9,7 @@
 
 // TODO: untested on avx512
 // These are in units of GGML_F32_EPR
-#if defined(__AVX512F__) || defined (__ARM_NEON__)
+#if defined(__AVX512F__) || defined (__ARM_NEON)
     static constexpr int GEMM_RM = 4;
     static constexpr int GEMM_RN = 4; // 16+4+1 = 25/32
 #elif defined(__AVX2__) || defined(__AVX__)
@@ -110,6 +110,162 @@ static void simd_gemm(
     }
 }
 
+#elif defined(GGML_SIMD) && defined(__ARM_FEATURE_SVE)
+
+static constexpr int GEMM_RM = 4;
+static constexpr int GEMM_RN = 4; // 16+4+1 = 24/32
+
+#define define_ACC(x) GGML_F32_VEC acc##x##0,acc##x##1,acc##x##2,acc##x##3;
+#define load_i_r(i, r) if constexpr ((i < RM) && (r < RN)) \
+                       acc##i##r = GGML_F32_VEC_LOAD(C + i * N + r * KN)
+#define load4(i) load_i_r(i, 0); \
+                 load_i_r(i, 1); \
+                 load_i_r(i, 2); \
+                 load_i_r(i, 3);
+#define store_i_r(i, r) if constexpr ((i < RM) && (r < RN)) \
+                        GGML_F32_VEC_STORE(C + i * N + r * KN, acc##i##r)
+#define store4(i) store_i_r(i, 0); \
+                 store_i_r(i, 1); \
+                 store_i_r(i, 2); \
+                 store_i_r(i, 3);
+#define load_b(r) if constexpr (r < RN) \
+                  Bv##r = GGML_F32_VEC_LOAD(B + kk * N + r * KN)
+// GGML_F32xt_FMA is svmad_f32_m, which is somehow slower
+#define FMA(i, r) if constexpr ((i < RM) && (r < RN)) \
+                  acc##i##r = svmla_f32_m(DEFAULT_PG, acc##i##r, Bv##r, p)
+#define accum_a(i) p = GGML_F32_VEC_SET1(A[i * K + kk]); \
+                   FMA(i, 0); \
+                   FMA(i, 1); \
+                   FMA(i, 2); \
+                   FMA(i, 3)
+
+template <int KN, int RM, int RN>
+static inline void sve_simd_gemm_ukernel(
+    float       * GGML_RESTRICT C,
+    const float * GGML_RESTRICT A,
+    const float * GGML_RESTRICT B,
+    int K, int N)
+{
+
+    define_ACC(0);
+    define_ACC(1);
+    define_ACC(2);
+    define_ACC(3);
+
+    load4(0);
+    load4(1);
+    load4(2);
+    load4(3);
+    
+    for (int64_t kk = 0; kk < K; kk++) {
+        GGML_F32_VEC Bv0, Bv1, Bv2, Bv3, p;
+        
+        load_b(0);
+        load_b(1);
+        load_b(2);
+        load_b(3);
+
+        accum_a(0);
+        accum_a(1);
+        accum_a(2);
+        accum_a(3);
+    }
+
+    store4(0);
+    store4(1);
+    store4(2);
+    store4(3);
+    
+}
+template<int KN>
+static void sve_simd_gemm_kernel(
+    float       * GGML_RESTRICT C,
+    const float * GGML_RESTRICT A,
+    const float * GGML_RESTRICT B,
+    int M, int K, int N)
+{
+
+    int64_t ii = 0;
+    for (; ii + GEMM_RM <= M; ii += GEMM_RM) {
+        int64_t jj = 0;
+        for (; jj + GEMM_RN * KN <= N; jj += GEMM_RN * KN) {
+            sve_simd_gemm_ukernel<KN, GEMM_RM, GEMM_RN>(C + jj, A, B + jj, K, N);
+        }
+        for (; jj + KN <= N; jj += KN) {
+            sve_simd_gemm_ukernel<KN, GEMM_RM, 1>(C + jj, A, B + jj, K, N);
+        }
+        for (; jj < N; jj++) {
+            for (int64_t i = 0; i < GEMM_RM; i++) {
+                float a = C[i * N + jj];
+                for (int64_t kk = 0; kk < K; kk++) {
+                    a += A[i + kk] * B[kk * N + jj];
+                }
+                C[i * N + jj] = a;
+            }
+        }
+
+        A += GEMM_RM * K;
+        C += GEMM_RM * N;
+    }
+
+    // Tail rows: one at a time
+    for (; ii < M; ii++) {
+        int64_t jj = 0;
+        for (; jj + GEMM_RN * KN <= N; jj += GEMM_RN * KN) {
+            sve_simd_gemm_ukernel<KN, 1, GEMM_RN>(C + jj, A, B + jj, K, N);
+        }
+        for (; jj + KN <= N; jj += KN) {
+            sve_simd_gemm_ukernel<KN, 1, 1>(C + jj, A, B + jj, K, N);
+        }
+        for (; jj < N; jj++) {
+            float a = C[jj];
+            for (int64_t kk = 0; kk < K; kk++) {
+                a += A[kk] * B[kk * N + jj];
+            }
+            C[jj] = a;
+        }
+
+        A += K;
+        C += N;
+    }
+}
+
+static void simd_gemm(
+    float       * GGML_RESTRICT C,
+    const float * GGML_RESTRICT A,
+    const float * GGML_RESTRICT B,
+    int M, int K, int N)
+{
+    int sve_vector_length = svcntb();
+    switch(sve_vector_length){
+        case 16:
+        {
+            sve_simd_gemm_kernel<4>(C, A, B, M, K, N);
+            break;
+        }
+        case 32:
+        {
+            sve_simd_gemm_kernel<8>(C, A, B, M, K, N);
+            break;
+        }
+        case 64:
+        {
+            sve_simd_gemm_kernel<16>(C, A, B, M, K, N);
+            break;
+        }
+        // There's no SVE implementation beyond 512-bit?
+        case 128:
+        {
+            sve_simd_gemm_kernel<32>(C, A, B, M, K, N);
+            break;
+        }
+        default:
+        {
+            sve_simd_gemm_kernel<64>(C, A, B, M, K, N);
+            break;
+        }
+    }
+}
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/ggml/src/ggml-cpu/simd-gemm.h
+++ b/ggml/src/ggml-cpu/simd-gemm.h
@@ -5,7 +5,7 @@
 #include "simd-mappings.h"
 
 // TODO: add support for sizeless vector types
-#if defined(GGML_SIMD) && !defined(__ARM_FEATURE_SVE) && !defined(__riscv_v_intrinsic)
+#if defined(GGML_SIMD) && !defined(__riscv_v_intrinsic)
 
 // TODO: untested on avx512
 // These are in units of GGML_F32_EPR
@@ -20,14 +20,54 @@
     static constexpr int GEMM_RN = 2;
 #endif
 
+#if defined(__ARM_FEATURE_SVE)
+
+#define load_i_r(i, r) if constexpr ((i < RM) && (r < RN)) \
+                       acc##i##r = GGML_F32_VEC_LOAD(C + i * N + r * KN)
+#define load_acc(i) load_i_r(i, 0); load_i_r(i, 1); load_i_r(i, 2); load_i_r(i, 3);
+#define store_i_r(i, r) if constexpr ((i < RM) && (r < RN)) \
+                        GGML_F32_VEC_STORE(C + i * N + r * KN, acc##i##r)
+#define store_acc(i) store_i_r(i, 0); store_i_r(i, 1); store_i_r(i, 2); store_i_r(i, 3);
+#define load_b(r) if constexpr (r < RN) \
+                  Bv##r = GGML_F32_VEC_LOAD(B + kk * N + r * KN)
+#define FMA(i, r) if constexpr ((i < RM) && (r < RN)) \
+                  acc##i##r = svmla_n_f32_m(svptrue_b32(), acc##i##r, Bv##r, A[i * K + kk])
+#define accum(i) FMA(i, 0); FMA(i, 1); FMA(i, 2); FMA(i, 3)
+
 template <int RM, int RN>
 static inline void simd_gemm_ukernel(
     float       * GGML_RESTRICT C,
     const float * GGML_RESTRICT A,
     const float * GGML_RESTRICT B,
-    int K, int N)
+    int K, int N, int KN)
 {
-    static constexpr int KN = GGML_F32_EPR;
+
+    GGML_F32_VEC acc00,acc01,acc02,acc03;
+    GGML_F32_VEC acc10,acc11,acc12,acc13;
+    GGML_F32_VEC acc20,acc21,acc22,acc23;
+    GGML_F32_VEC acc30,acc31,acc32,acc33;
+
+    load_acc(0); load_acc(1); load_acc(2); load_acc(3);
+
+    for (int64_t kk = 0; kk < K; kk++) {
+        GGML_F32_VEC Bv0, Bv1, Bv2, Bv3;
+        load_b(0); load_b(1); load_b(2); load_b(3);
+        accum(0); accum(1); accum(2); accum(3);
+    }
+
+    store_acc(0); store_acc(1); store_acc(2); store_acc(3);
+
+}
+
+#else
+
+template <int RM, int RN>
+static inline void simd_gemm_ukernel(
+    float       * GGML_RESTRICT C,
+    const float * GGML_RESTRICT A,
+    const float * GGML_RESTRICT B,
+    int K, int N, int KN)
+{
 
     GGML_F32_VEC acc[RM][RN];
     for (int64_t i = 0; i < RM; i++) {
@@ -55,7 +95,7 @@ static inline void simd_gemm_ukernel(
         }
     }
 }
-
+#endif
 // C[M x N] += A[M x K] * B[K x N]
 static void simd_gemm(
     float       * GGML_RESTRICT C,
@@ -63,16 +103,20 @@ static void simd_gemm(
     const float * GGML_RESTRICT B,
     int M, int K, int N)
 {
+#if defined(__ARM_FEATURE_SVE)
+    static int KN = svcntw();
+#else
     static constexpr int KN = GGML_F32_EPR;
+#endif
 
     int64_t ii = 0;
     for (; ii + GEMM_RM <= M; ii += GEMM_RM) {
         int64_t jj = 0;
         for (; jj + GEMM_RN * KN <= N; jj += GEMM_RN * KN) {
-            simd_gemm_ukernel<GEMM_RM, GEMM_RN>(C + jj, A, B + jj, K, N);
+            simd_gemm_ukernel<GEMM_RM, GEMM_RN>(C + jj, A, B + jj, K, N, KN);
         }
         for (; jj + KN <= N; jj += KN) {
-            simd_gemm_ukernel<GEMM_RM, 1>(C + jj, A, B + jj, K, N);
+            simd_gemm_ukernel<GEMM_RM, 1>(C + jj, A, B + jj, K, N, KN);
         }
         for (; jj < N; jj++) {
             for (int64_t i = 0; i < GEMM_RM; i++) {
@@ -92,10 +136,10 @@ static void simd_gemm(
     for (; ii < M; ii++) {
         int64_t jj = 0;
         for (; jj + GEMM_RN * KN <= N; jj += GEMM_RN * KN) {
-            simd_gemm_ukernel<1, GEMM_RN>(C + jj, A, B + jj, K, N);
+            simd_gemm_ukernel<1, GEMM_RN>(C + jj, A, B + jj, K, N, KN);
         }
         for (; jj + KN <= N; jj += KN) {
-            simd_gemm_ukernel<1, 1>(C + jj, A, B + jj, K, N);
+            simd_gemm_ukernel<1, 1>(C + jj, A, B + jj, K, N, KN);
         }
         for (; jj < N; jj++) {
             float a = C[jj];
@@ -110,162 +154,6 @@ static void simd_gemm(
     }
 }
 
-#elif defined(GGML_SIMD) && defined(__ARM_FEATURE_SVE)
-
-static constexpr int GEMM_RM = 4;
-static constexpr int GEMM_RN = 4; // 16+4+1 = 24/32
-
-#define define_ACC(x) GGML_F32_VEC acc##x##0,acc##x##1,acc##x##2,acc##x##3;
-#define load_i_r(i, r) if constexpr ((i < RM) && (r < RN)) \
-                       acc##i##r = GGML_F32_VEC_LOAD(C + i * N + r * KN)
-#define load4(i) load_i_r(i, 0); \
-                 load_i_r(i, 1); \
-                 load_i_r(i, 2); \
-                 load_i_r(i, 3);
-#define store_i_r(i, r) if constexpr ((i < RM) && (r < RN)) \
-                        GGML_F32_VEC_STORE(C + i * N + r * KN, acc##i##r)
-#define store4(i) store_i_r(i, 0); \
-                 store_i_r(i, 1); \
-                 store_i_r(i, 2); \
-                 store_i_r(i, 3);
-#define load_b(r) if constexpr (r < RN) \
-                  Bv##r = GGML_F32_VEC_LOAD(B + kk * N + r * KN)
-// GGML_F32xt_FMA is svmad_f32_m, which is somehow slower
-#define FMA(i, r) if constexpr ((i < RM) && (r < RN)) \
-                  acc##i##r = svmla_f32_m(DEFAULT_PG, acc##i##r, Bv##r, p)
-#define accum_a(i) p = GGML_F32_VEC_SET1(A[i * K + kk]); \
-                   FMA(i, 0); \
-                   FMA(i, 1); \
-                   FMA(i, 2); \
-                   FMA(i, 3)
-
-template <int KN, int RM, int RN>
-static inline void sve_simd_gemm_ukernel(
-    float       * GGML_RESTRICT C,
-    const float * GGML_RESTRICT A,
-    const float * GGML_RESTRICT B,
-    int K, int N)
-{
-
-    define_ACC(0);
-    define_ACC(1);
-    define_ACC(2);
-    define_ACC(3);
-
-    load4(0);
-    load4(1);
-    load4(2);
-    load4(3);
-    
-    for (int64_t kk = 0; kk < K; kk++) {
-        GGML_F32_VEC Bv0, Bv1, Bv2, Bv3, p;
-        
-        load_b(0);
-        load_b(1);
-        load_b(2);
-        load_b(3);
-
-        accum_a(0);
-        accum_a(1);
-        accum_a(2);
-        accum_a(3);
-    }
-
-    store4(0);
-    store4(1);
-    store4(2);
-    store4(3);
-    
-}
-template<int KN>
-static void sve_simd_gemm_kernel(
-    float       * GGML_RESTRICT C,
-    const float * GGML_RESTRICT A,
-    const float * GGML_RESTRICT B,
-    int M, int K, int N)
-{
-
-    int64_t ii = 0;
-    for (; ii + GEMM_RM <= M; ii += GEMM_RM) {
-        int64_t jj = 0;
-        for (; jj + GEMM_RN * KN <= N; jj += GEMM_RN * KN) {
-            sve_simd_gemm_ukernel<KN, GEMM_RM, GEMM_RN>(C + jj, A, B + jj, K, N);
-        }
-        for (; jj + KN <= N; jj += KN) {
-            sve_simd_gemm_ukernel<KN, GEMM_RM, 1>(C + jj, A, B + jj, K, N);
-        }
-        for (; jj < N; jj++) {
-            for (int64_t i = 0; i < GEMM_RM; i++) {
-                float a = C[i * N + jj];
-                for (int64_t kk = 0; kk < K; kk++) {
-                    a += A[i + kk] * B[kk * N + jj];
-                }
-                C[i * N + jj] = a;
-            }
-        }
-
-        A += GEMM_RM * K;
-        C += GEMM_RM * N;
-    }
-
-    // Tail rows: one at a time
-    for (; ii < M; ii++) {
-        int64_t jj = 0;
-        for (; jj + GEMM_RN * KN <= N; jj += GEMM_RN * KN) {
-            sve_simd_gemm_ukernel<KN, 1, GEMM_RN>(C + jj, A, B + jj, K, N);
-        }
-        for (; jj + KN <= N; jj += KN) {
-            sve_simd_gemm_ukernel<KN, 1, 1>(C + jj, A, B + jj, K, N);
-        }
-        for (; jj < N; jj++) {
-            float a = C[jj];
-            for (int64_t kk = 0; kk < K; kk++) {
-                a += A[kk] * B[kk * N + jj];
-            }
-            C[jj] = a;
-        }
-
-        A += K;
-        C += N;
-    }
-}
-
-static void simd_gemm(
-    float       * GGML_RESTRICT C,
-    const float * GGML_RESTRICT A,
-    const float * GGML_RESTRICT B,
-    int M, int K, int N)
-{
-    int sve_vector_length = svcntb();
-    switch(sve_vector_length){
-        case 16:
-        {
-            sve_simd_gemm_kernel<4>(C, A, B, M, K, N);
-            break;
-        }
-        case 32:
-        {
-            sve_simd_gemm_kernel<8>(C, A, B, M, K, N);
-            break;
-        }
-        case 64:
-        {
-            sve_simd_gemm_kernel<16>(C, A, B, M, K, N);
-            break;
-        }
-        // There's no SVE implementation beyond 512-bit?
-        case 128:
-        {
-            sve_simd_gemm_kernel<32>(C, A, B, M, K, N);
-            break;
-        }
-        default:
-        {
-            sve_simd_gemm_kernel<64>(C, A, B, M, K, N);
-            break;
-        }
-    }
-}
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/ggml/src/ggml-cpu/simd-gemm.h
+++ b/ggml/src/ggml-cpu/simd-gemm.h
@@ -9,7 +9,7 @@
 
 // TODO: untested on avx512
 // These are in units of GGML_F32_EPR
-#if defined(__AVX512F__) || defined (__ARM_NEON)
+#if defined(__AVX512F__) || defined (__ARM_NEON) || defined(__ARM_NEON__)
     static constexpr int GEMM_RM = 4;
     static constexpr int GEMM_RN = 4; // 16+4+1 = 25/32
 #elif defined(__AVX2__) || defined(__AVX__)


### PR DESCRIPTION
## Overview
Add SVE support for `simd_gemm.h`. The code performs almost equally to a NEON fallback with SVE enabled.

For `FLASH_ATTN_EXT(hsk=72,hsv=72,nh=16,nr23=[1,1],kv=5776,nb=5776,mask=0,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_KV=f16,permute=[0,1,2,3]):` on a X2@2.45GHz+3xA710@2.0 GHz CPU:

| Type| GFLOPS|
|:-|:-|
|No SVE|76.59|
|No SVE in `simd-gemm.h` only|56.95|
|SVE (This PR)|56.08|
|Scalar|9.58|

I've verified my implementation through `llama-perplexity`. This is mostly a copy from the original implementation.

## Additional information

This PR also changes the `__ARM_NEON__` check to `__ARM_NEON`, since it'll set RM and RN=2 before the change (at least on Clang). Also fixes #21854.

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
