### PR TITLE
models: add ggml_cont after ggml_transpose before ggml_concat in conv1d input assembly

### DIFF
--- a/src/models/kimi-linear.cpp
+++ b/src/models/kimi-linear.cpp
@@ -33,7 +33,7 @@ static ggml_tensor * causal_conv1d(ggml_cgraph * gf, ggml_context * ctx0, ggml_t
     ggml_tensor * x_3d = ggml_reshape_3d(ctx0, x_proj, d_inner, n_seq_tokens, n_seqs);
 
     // Concat Q conv state and current input: {d_conv-1 + n_seq_tokens, d_inner, n_seqs}
-    ggml_tensor * conv_x = ggml_concat(ctx0, conv_state_x, ggml_transpose(ctx0, x_3d), 0);
+    ggml_tensor * conv_x = ggml_concat(ctx0, conv_state_x, ggml_cont(ctx0, ggml_transpose(ctx0, x_3d)), 0);
 
     // Save last (d_conv-1) columns back to Q conv state
     ggml_tensor * last_conv_x = ggml_view_3d(ctx0, conv_x, d_conv - 1, d_inner, n_seqs,

--- a/src/models/mamba-base.cpp
+++ b/src/models/mamba-base.cpp
@@ -52,7 +52,7 @@ ggml_tensor * llm_build_mamba_base::build_mamba_layer(llm_graph_input_rs * inp,
     // conv
     {
         // => {d_conv - 1 + n_seq_tokens, d_inner, n_seqs}
-        ggml_tensor * conv_x = ggml_concat(ctx0, conv, ggml_transpose(ctx0, x), 0);
+        ggml_tensor * conv_x = ggml_concat(ctx0, conv, ggml_cont(ctx0, ggml_transpose(ctx0, x)), 0);
 
         // copy last (d_conv - 1) columns back into the state cache
         ggml_tensor * last_conv = ggml_view_3d(ctx0, conv_x, d_conv - 1, d_inner, n_seqs, conv_x->nb[1], conv_x->nb[2],
@@ -197,7 +197,7 @@ ggml_tensor * llm_build_mamba_base::build_mamba2_layer(llm_graph_input_rs * inp,
     // conv
     {
         // => {d_conv - 1 + n_seq_tokens, d_inner + 2*n_group*d_state, n_seqs}
-        ggml_tensor * conv_x = ggml_concat(ctx0, conv, ggml_transpose(ctx0, xBC), 0);
+        ggml_tensor * conv_x = ggml_concat(ctx0, conv, ggml_cont(ctx0, ggml_transpose(ctx0, xBC)), 0);
 
         // copy last (d_conv - 1) columns back into the state cache
         ggml_tensor * last_conv = ggml_view_3d(ctx0, conv_x, d_conv - 1, d_inner + 2 * n_group * d_state, n_seqs,

--- a/src/models/plamo2.cpp
+++ b/src/models/plamo2.cpp
@@ -207,7 +207,7 @@ ggml_tensor * llm_build_plamo2::build_plamo2_mamba_layer(llm_graph_input_rs * in
     // conv1d
     {
         // => {d_conv - 1 + n_seq_tokens, d_inner, n_seqs}
-        ggml_tensor * conv_x = ggml_concat(ctx0, conv, ggml_transpose(ctx0, x), 0);
+        ggml_tensor * conv_x = ggml_concat(ctx0, conv, ggml_cont(ctx0, ggml_transpose(ctx0, x)), 0);
         cb(conv_x, "mamba_conv1d_input", il);
 
         // copy last (d_conv - 1) columns back into the state cache

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -257,6 +257,7 @@ ggml_tensor * llm_build_qwen35::build_layer_attn_linear(
     cb(conv_states, "conv_states_reshaped", il);
 
     qkv_mixed = ggml_transpose(ctx0, qkv_mixed);
+    qkv_mixed = ggml_cont(ctx0, qkv_mixed);
     cb(qkv_mixed, "qkv_mixed_transposed", il);
 
     ggml_tensor * conv_input = ggml_concat(ctx0, conv_states, qkv_mixed, 0);

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -257,6 +257,7 @@ ggml_tensor * llm_build_qwen35moe ::build_layer_attn_linear(
     cb(conv_states, "conv_states_reshaped", il);
 
     qkv_mixed = ggml_transpose(ctx0, qkv_mixed);
+    qkv_mixed = ggml_cont(ctx0, qkv_mixed);
     cb(qkv_mixed, "qkv_mixed_transposed", il);
 
     ggml_tensor * conv_input = ggml_concat(ctx0, conv_states, qkv_mixed, 0);

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -341,6 +341,7 @@ ggml_tensor * llm_build_qwen3next::build_layer_attn_linear(
     cb(conv_states, "conv_states_reshaped", il);
 
     qkv_mixed = ggml_transpose(ctx0, qkv_mixed);
+    qkv_mixed = ggml_cont(ctx0, qkv_mixed);
     cb(qkv_mixed, "qkv_mixed_transposed", il);
 
     ggml_tensor * conv_input = ggml_concat(ctx0, conv_states, qkv_mixed, 0);


### PR DESCRIPTION
## Problem

Several models with recurrent layers (Mamba, DeltaNet/Qwen3.5, Kimi-Linear, PLaMo2) build conv1d inputs by concatenating a conv state buffer with a transposed tensor:

```cpp
ggml_tensor * conv_x = ggml_concat(ctx0, conv, ggml_transpose(ctx0, x), 0);
```

`ggml_transpose` returns a zero-copy view -- it does not move any data, just reinterprets the strides. For an 8192-wide tensor, `nb[1] = 32,768 bytes`. When `ggml_concat` iterates over this non-contiguous view, every element requires a 32KB-strided memory access, causing severe cache thrashing.

## Fix

Add `ggml_cont()` between the transpose and concat to materialize contiguous memory:

```cpp
// Before (strided access in concat):
conv_x = ggml_concat(ctx0, conv, ggml_transpose(ctx0, x), 0);

// After (contiguous memcpy in concat):
conv_x = ggml_concat(ctx0, conv, ggml_cont(ctx0, ggml_transpose(ctx0, x)), 0);
```

The `dup` kernel handles strided-to-contiguous copy efficiently via SIMD, and concat then operates on contiguous rows with fast `memcpy`.

Note: `delta-net-base.cpp` and `wavtokenizer-dec.cpp` already use this pattern -- this PR brings the remaining models into line.

## Affected models

| File | Model |
|------|-------|
| `qwen35moe.cpp` | Qwen3.5-MoE |
| `qwen35.cpp` | Qwen3.5 |
| `qwen3next.cpp` | Qwen3Next |
| `mamba-base.cpp` | Mamba1 + Mamba2 (2 instances) |
| `kimi-linear.cpp` | Kimi-Linear |
| `plamo2.cpp` | PLaMo2 |

## Benchmarks

Measured on **Qwen3.5-35B-A3B** (Xeon E5-2697 v2, 11 threads, Metal+BLAS backend):

**Q4_K_M (production quant):**
| Test | Before | After | Change |
|------|:------:|:-----:|:------:|
| pp512 | 43.0 | **46.0** | **+7.0%** |
| tg128 | 11.8 | 11.7 | 0% (noise) |

**Q4_0:**
| Test | Before | After | Change |
|------|:------:|:-----:|:------:|
| pp512 | 40.9 | **42.8** | **+4.6%** |
| tg128 | 13.4 | 13.3 | 0% (noise) |

The improvement scales with the number of DeltaNet/Mamba layers since each layer concatenates transposed QKV/state tensors during prefill. Token generation shows no regression because the conv1d input is only 1 row wide.

## How I found this

Profiling pp4096 with macOS `sample` showed `ggml_compute_forward_concat_f32` consuming **27% of total compute time**. After this fix, concat dropped to **0.3%** -- the time moved to the much faster `dup` kernel.