### PR TITLE
server: use random media marker

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -109,7 +109,7 @@ mtmd_context_params mtmd_context_params_default() {
         /* use_gpu           */ true,
         /* print_timings     */ true,
         /* n_threads         */ 4,
-        /* image_marker      */ MTMD_DEFAULT_IMAGE_MARKER,
+        /* image_marker      */ nullptr,
         /* media_marker      */ mtmd_default_marker(),
         /* flash_attn_type   */ LLAMA_FLASH_ATTN_TYPE_AUTO,
         /* warmup            */ true,
@@ -169,7 +169,7 @@ struct mtmd_context {
         media_marker (ctx_params.media_marker),
         n_embd_text  (llama_model_n_embd_inp(text_model))
     {
-        if (std::string(ctx_params.image_marker) != MTMD_DEFAULT_IMAGE_MARKER) {
+        if (ctx_params.image_marker != nullptr) {
             throw std::runtime_error("custom image_marker is not supported anymore, use media_marker instead");
         }
 
@@ -584,9 +584,6 @@ struct mtmd_tokenizer {
         parse_special = text->parse_special;
         input_text    = text->text;
         vocab         = llama_model_get_vocab(ctx->text_model);
-
-        // for compatibility, we convert image marker to media marker
-        string_replace_all(input_text, MTMD_DEFAULT_IMAGE_MARKER, ctx->media_marker);
     }
 
     int32_t tokenize(mtmd_input_chunks * output) {

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -46,9 +46,6 @@
 #    define MTMD_API
 #endif
 
-// deprecated marker, use mtmd_default_marker() instead
-#define MTMD_DEFAULT_IMAGE_MARKER "<__image__>"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -88,13 +88,13 @@ std::string gen_chatcmplid() {
 }
 
 std::string gen_tool_call_id() {
-    return random_string(true);
+    return random_string();
 }
 
 static std::string media_marker = "";
 const char * get_media_marker() {
     if (media_marker.empty()) {
-        media_marker = "<__media_" + random_string() + "__>";
+        media_marker = "<__media_" + random_string(true) + "__>";
     }
     return media_marker.c_str();
 }

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -61,15 +61,8 @@ json format_error_response(const std::string & message, const enum error_type ty
 // random string / id
 //
 
-std::string random_string(bool include_special) {
-    static const std::string str_no_special(
-        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-    );
-    static const std::string str_with_special(
-        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*()-_=+[]{}|;:,.<>?/~`"
-    );
-
-    auto & str = include_special ? str_with_special : str_no_special;
+std::string random_string() {
+    static const std::string str("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
 
     std::random_device rd;
     std::mt19937 generator(rd());
@@ -94,7 +87,7 @@ std::string gen_tool_call_id() {
 static std::string media_marker = "";
 const char * get_media_marker() {
     if (media_marker.empty()) {
-        media_marker = "<__media_" + random_string(true) + "__>";
+        media_marker = "<__media_" + random_string() + "__>";
     }
     return media_marker.c_str();
 }

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -61,8 +61,15 @@ json format_error_response(const std::string & message, const enum error_type ty
 // random string / id
 //
 
-std::string random_string() {
-    static const std::string str("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+std::string random_string(bool include_special) {
+    static const std::string str_no_special(
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    );
+    static const std::string str_with_special(
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*()-_=+[]{}|;:,.<>?/~`"
+    );
+
+    auto & str = include_special ? str_with_special : str_no_special;
 
     std::random_device rd;
     std::mt19937 generator(rd());
@@ -81,7 +88,15 @@ std::string gen_chatcmplid() {
 }
 
 std::string gen_tool_call_id() {
-    return random_string();
+    return random_string(true);
+}
+
+static std::string media_marker = "";
+const char * get_media_marker() {
+    if (media_marker.empty()) {
+        media_marker = "<__media_" + random_string() + "__>";
+    }
+    return media_marker.c_str();
 }
 
 //
@@ -975,7 +990,7 @@ json oaicompat_chat_params_parse(
                 handle_media(out_files, image_url, opt.media_path);
 
                 p["type"] = "media_marker";
-                p["text"] = mtmd_default_marker();
+                p["text"] = get_media_marker();
                 p.erase("image_url");
 
             } else if (type == "input_audio") {
@@ -996,7 +1011,7 @@ json oaicompat_chat_params_parse(
                 // TODO: add audio_url support by reusing handle_media()
 
                 p["type"] = "media_marker";
-                p["text"] = mtmd_default_marker();
+                p["text"] = get_media_marker();
                 p.erase("input_audio");
 
             } else if (type != "text") {
@@ -1460,7 +1475,7 @@ json convert_transcriptions_to_chatcmpl(
     if (!language.empty()) {
         prompt += string_format(" (language: %s)", language.c_str());
     }
-    prompt += mtmd_default_marker();
+    prompt += get_media_marker();
 
     json chatcmpl_body = inp_body; // copy all fields
     chatcmpl_body["messages"] = json::array({

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -88,9 +88,12 @@ json format_error_response(const std::string & message, const enum error_type ty
 // random string / id
 //
 
-std::string random_string();
+std::string random_string(bool include_special = false);
 std::string gen_chatcmplid();
 std::string gen_tool_call_id();
+
+// get a random marker; note: each time the server restarts, the marker will be different
+const char * get_media_marker();
 
 //
 // lora utils

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -88,7 +88,7 @@ json format_error_response(const std::string & message, const enum error_type ty
 // random string / id
 //
 
-std::string random_string(bool include_special = false);
+std::string random_string();
 std::string gen_chatcmplid();
 std::string gen_tool_call_id();
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -708,6 +708,7 @@ private:
             mparams.warmup           = params_base.warmup;
             mparams.image_min_tokens = params_base.image_min_tokens;
             mparams.image_max_tokens = params_base.image_max_tokens;
+            mparams.media_marker     = get_media_marker();
 
             mctx = mtmd_init_from_file(mmproj_path.c_str(), model, mparams);
             if (mctx == nullptr) {


### PR DESCRIPTION
## Overview

Fix https://github.com/ggml-org/llama.cpp/issues/21955

Generate a random media marker each time we launch the server. The string is random enough that collision is impossible to happen in practice

How random? 32 characters, 0-9a-zA-Z, making it 62^32 combinations. And according to [math stackexchange](https://math.stackexchange.com/questions/2129541/number-of-32-character-alphanumeric-strings-with-certain-conditions):

<img width="1147" height="173" alt="image" src="https://github.com/user-attachments/assets/2bd7227f-70cd-4960-a151-9266b347e1c8" />


# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
