### PR TITLE
model: HY-Embodied model support

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1230,7 +1230,9 @@ class TextModel(ModelBase):
         from transformers import AutoTokenizer
         tokenizer = AutoTokenizer.from_pretrained(self.dir_model)
         vocab_size = self.hparams.get("vocab_size", len(tokenizer.vocab))  # ty: ignore[unresolved-attribute]
-        assert max(tokenizer.vocab.values()) < vocab_size  # ty: ignore[unresolved-attribute]
+
+        # REVERT THIS CHANGE BEFORE MERGE
+        # assert max(tokenizer.vocab.values()) < vocab_size  # ty: ignore[unresolved-attribute]
 
         tokpre = self.get_vocab_base_pre(tokenizer)
 
@@ -11926,6 +11928,34 @@ class HunYuanModel(TextModel):
             return
 
         yield from super().modify_tensors(data_torch, name, bid)
+
+
+@ModelBase.register("HunYuanVLMoTForConditionalGeneration")
+class HunYuanMoTModel(HunYuanModel):
+    model_arch = gguf.MODEL_ARCH.HUNYUAN_DENSE
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        name = name.replace("model.language_model.", "")
+
+        if name == "lm_head.weight":
+            if self.hparams.get("tie_word_embeddings", False):
+                logger.info("Skipping tied output layer 'lm_head.weight'")
+                return
+
+        if name.startswith("model.visual."):
+            return
+
+        # handle mapping MoT tensor names
+        if "mlp_v" in name:
+            name = name.replace("mlp_v", "mlp")
+            name = name.replace(".weight", ".v.weight")
+            name = name.replace(".bias", ".v.bias")
+        else:
+            name = name.replace("_v.weight", ".v.weight")
+            name = name.replace("_v.bias", ".v.bias")
+
+        mapped_name = self.map_tensor_name(name, (".weight", ".bias", ".v.weight", ".v.bias"))
+        yield (mapped_name, data_torch)
 
 
 @ModelBase.register("HunYuanVLForConditionalGeneration")

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -7126,24 +7126,29 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                         output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, TENSOR_DUPLICATED);
                     }
 
-                    for (int i = 0; i < n_layer; ++i) {
+                    for (int idx = 0; idx < n_layer * 2; ++idx) {
+                        bool is_v = idx >= n_layer;
+                        const char * suffix = is_v ? "v.weight" : "weight";
+                        auto i = idx % n_layer;
                         auto & layer = layers[i];
 
-                        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
+                        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, suffix, i), {n_embd}, 0);
 
-                        layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   "weight", i), {n_embd, n_embd_head_k * n_head}, 0);
-                        layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   "weight", i), {n_embd, n_embd_k_gqa}, 0);
-                        layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   "weight", i), {n_embd, n_embd_v_gqa}, 0);
-                        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_k * n_head, n_embd}, 0);
+                        if (!is_v) {
+                            layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, suffix, i), {n_embd_head_k}, 0);
+                            layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, suffix, i), {n_embd_head_k}, 0);
+                        }
 
-                        layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k}, 0);
-                        layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k}, 0);
+                        layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q,   suffix, i), {n_embd, n_embd_head_k * n_head}, 0);
+                        layer.wk = create_tensor(tn(LLM_TENSOR_ATTN_K,   suffix, i), {n_embd, n_embd_k_gqa}, 0);
+                        layer.wv = create_tensor(tn(LLM_TENSOR_ATTN_V,   suffix, i), {n_embd, n_embd_v_gqa}, 0);
+                        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, suffix, i), {n_embd_head_k * n_head, n_embd}, 0);
 
-                        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
+                        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, suffix, i), {n_embd}, 0);
 
-                        layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, 0);
-                        layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, 0);
-                        layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff}, 0);
+                        layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, suffix, i), {n_embd,   n_ff}, 0);
+                        layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, suffix, i), {  n_ff, n_embd}, 0);
+                        layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   suffix, i), {n_embd,   n_ff}, 0);
 
                     }
                 } break;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -555,6 +555,8 @@ struct llama_model {
 
     std::vector<llama_layer> layers;
 
+    std::vector<llama_layer> layers_v; // HY-Embodied MoT
+
     //Dense linear projections for SentenceTransformers models like embeddinggemma
     // For Sentence Transformers models structure see
     // https://sbert.net/docs/sentence_transformer/usage/custom_models.html#structure-of-sentence-transformer-models


### PR DESCRIPTION
## Overview

Add support for https://huggingface.co/tencent/HY-Embodied-0.5

Still WIP, not working. Conversion script need to be hacked (temporary) because the original weight is not loadable via latest `transformers`

<img width="630" height="255" alt="image" src="https://github.com/user-attachments/assets/5efe3c23-6480-49b8-bcf9-cf52dce24e7f" />


TODO:
- [ ] Text model is not working, not sure why, maybe something about RoPE
- [ ] Implement mixture-of-transformers (MoT) on model's cgraph (AFAIU, it should only be used when input is vision)

## Additional information

The model uses mixture-of-transformers, it's quite simple: each layer has double the Q/K/V and double FFN; depending on text or vision is being processed, it will select the correct set of Q/K/V/FFN

I employ a trick that allow loading storing/loading model weights without too much changes to `libllama`, by using different prefixes: `.weight` for normal tensors, and `.v.weight` for vision-related tensors

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
