### PR TITLE
cmake: fix persistent ARM CPU detection warning on Clang/macOS

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -132,12 +132,22 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
                 if (NOT ARM_MCPU_RESULT)
                     string(REGEX MATCH "-mcpu=[^ ']+" ARM_MCPU_FLAG "${ARM_MCPU}")
                     string(REGEX MATCH "-march=[^ ']+" ARM_MARCH_FLAG "${ARM_MCPU}")
-
                     # on some old GCC we need to read -march=
                     if (ARM_MARCH_FLAG AND NOT "${ARM_MARCH_FLAG}" STREQUAL "-march=native")
                         set(ARM_NATIVE_FLAG "${ARM_MARCH_FLAG}")
                     elseif(ARM_MCPU_FLAG AND NOT "${ARM_MCPU_FLAG}" STREQUAL "-mcpu=native")
                         set(ARM_NATIVE_FLAG "${ARM_MCPU_FLAG}")
+                    endif()
+
+                    if (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR
+		       CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+                        # clang shows the resolved cpu as:
+                        #  -target-cpu <name>
+                        string(REGEX MATCH "-target-cpu [^ '\"]+" ARM_TARGET_CPU_FLAG "${ARM_MCPU}")
+                        if(ARM_TARGET_CPU_FLAG)
+                            string(REGEX REPLACE ".*-target-cpu ([^ '\"]+).*" "-mcpu=\\1" ARM_MCPU_FLAG "${ARM_TARGET_CPU_FLAG}")
+                            set(ARM_NATIVE_FLAG "${ARM_MCPU_FLAG}")
+                        endif()
                     endif()
                 endif()
 


### PR DESCRIPTION
## Overview
On Clang (especially on macOS), the current detection logic consistently triggers a warning because neither `-mcpu=` nor `-march=` can be matched in the output of `-mcpu=native -E -v -`. As a result, the existing regex fails and always falls back to `-mcpu=native`, leading to a persistent warning.

This change adds a fallback by parsing `-target-cpu <name>` from Clang’s output and converting it into a standard `-mcpu=<name>` flag.


# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
