### PR TITLE
mmproj: handle missing image_mean/image_std in preprocessor config

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2225,8 +2225,15 @@ class MmprojModel(ModelBase):
             self.gguf_writer.add_vision_head_count(self.find_vparam(["num_attention_heads", "num_heads", "heads", "vt_num_attention_heads"]))
 
             # preprocessor config
-            image_mean = _MISTRAL_COMMON_DATASET_MEAN if self.is_mistral_format else self.preprocessor_config["image_mean"]
-            image_std = _MISTRAL_COMMON_DATASET_STD if self.is_mistral_format else self.preprocessor_config["image_std"]
+            image_mean = _MISTRAL_COMMON_DATASET_MEAN if self.is_mistral_format else self.preprocessor_config.get("image_mean")
+            image_std = _MISTRAL_COMMON_DATASET_STD if self.is_mistral_format else self.preprocessor_config.get("image_std")
+
+            if image_mean is None or image_std is None:
+                logger.warning(
+                    "Missing image_mean/image_std in preprocessor config, falling back to Mistral common defaults"
+                )
+                image_mean = image_mean or _MISTRAL_COMMON_DATASET_MEAN
+                image_std = image_std or _MISTRAL_COMMON_DATASET_STD
 
             self.gguf_writer.add_vision_image_mean(image_mean)
             self.gguf_writer.add_vision_image_std(image_std)


### PR DESCRIPTION
## Overview

Fix mmproj conversion when `image_mean` or `image_std` is missing from the preprocessor config.

Use `preprocessor_config.get(...)` instead of indexing directly, and fall back to the existing common default image stats when either value is absent. Also emit a warning so the fallback is visible during conversion.

Fixes #21775.

## Additional information

This avoids failing on models that omit these fields from the preprocessor config while preserving the existing behavior for configs that define them.

# Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES
