### PR TITLE
Avoid redundant memory_breakdown() computation in device memory probe

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3493,11 +3493,11 @@ void llama_perf_context_reset(llama_context * ctx) {
     ctx->perf_reset();
 }
 
-void llama_memory_breakdown_print(const struct llama_context * ctx) {
+
+void llama_memory_breakdown_print_impl(
+        const struct llama_context * ctx,
+        const std::map<ggml_backend_buffer_type_t, llama_memory_breakdown_data> & memory_breakdown) {
     const auto & devices = ctx->get_model().devices;
-
-    std::map<ggml_backend_buffer_type_t, llama_memory_breakdown_data> memory_breakdown = ctx->memory_breakdown();
-
     std::vector<std::array<std::string, 9>> table_data;
     table_data.reserve(devices.size());
     const std::string template_header = "%s: | %s | %s   %s    %s   %s   %s   %s    %s |\n";
@@ -3627,6 +3627,11 @@ void llama_memory_breakdown_print(const struct llama_context * ctx) {
             __func__, td[1].c_str(), td[2].c_str(), td[3].c_str(), td[4].c_str(), td[5].c_str(),
             td[6].c_str(), td[7].c_str(), td[8].c_str());
     }
+}
+
+void llama_memory_breakdown_print(const struct llama_context * ctx) {
+    const auto memory_breakdown = ctx->memory_breakdown();
+    llama_memory_breakdown_print_impl(ctx, memory_breakdown);
 }
 
 //

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -357,3 +357,7 @@ private:
 
     mutable int32_t n_reused = 0; // number of times the previous graph was reused
 };
+
+void llama_memory_breakdown_print_impl(
+    const struct llama_context * ctx,
+    const std::map<ggml_backend_buffer_type_t, llama_memory_breakdown_data> & memory_breakdown);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -137,7 +137,7 @@ static std::vector<llama_device_memory_data> llama_get_device_memory_data(
     hp_n_ctx_train = model->hparams.n_ctx_train;
     hp_n_expert    = model->hparams.n_expert;
 
-    llama_memory_breakdown_print(ctx); // goes to debug log
+    llama_memory_breakdown_print_impl(ctx, memory_breakdown); // goes to debug log
 
     llama_free(ctx);
     llama_model_free(model);


### PR DESCRIPTION

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
This PR removes a redundant computation of ctx->memory_breakdown() during device memory probing in llama_get_device_memory_data().
## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
### Changes
- Introduce llama_memory_breakdown_print_impl which accepts a precomputed memory_breakdown object.
- Reuse the existing memory_breakdown result from llama_get_device_memory_data() instead of recomputing it in
  llama_memory_breakdown_print()
### Motivation
llama_get_device_memory_data() may be called multiple times during fit/probe workflows (e.g. baseline, context probing, repeated resource checks). Each call currently recomputes memory_breakdown, leading to unnecessary duplicated work.

This change ensures:
- No redundant computation within a single probe
- Consistent snapshot used for both computation and logging
- Slight reduction in overhead in repeated probe scenarios
### Behavior
No functional change is intended.
Output and memory accounting remain identical.

# Requirements
No new requirements introduced by this change.
<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
NO.
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
