### PR TITLE
sycl: fix VER_GEN12/VER_GEN13 device detection thresholds

### DIFF
--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -87,8 +87,8 @@ extern int g_ggml_sycl_enable_flash_attention;
 #define __SYCL_ARCH__ DPCT_COMPATIBILITY_TEMP
 #define VER_4VEC 610 // todo for hardware optimize.
 #define VER_GEN9 700 // todo for hardware optimize.
-#define VER_GEN12 1000000 // todo for hardware optimize.
-#define VER_GEN13 (VER_GEN12 + 1030) // todo for hardware optimize.
+#define VER_GEN12 1200 // Intel discrete GPUs (DG2/Alchemist, major=12)
+#define VER_GEN13 1300 // Intel Xe2/Battlemage GPUs (major=13)
 
 #define GGML_SYCL_MAX_NODES 8192 // TODO: adapt to hardwares
 


### PR DESCRIPTION
## Summary

Fix VER_GEN12 and VER_GEN13 macros from unreachable placeholder values (1000000 and 1001030) to correct values (1200 and 1300) for Intel discrete GPU detection.

## Problem
All Intel Arc discrete GPUs (DG2/Alchemist, compute capability ~1255 for A770) were falling through to the VER_GEN9 path in MMQ kernel tile selection because VER_GEN12 was set to an unreachable 1000000.

## Fix
- `VER_GEN12`: 1000000 → 1200 (Intel discrete GPUs, DG2/Alchemist)
- `VER_GEN13`: 1001030 → 1300 (Intel Xe2/Battlemage GPUs)

## Testing
- Arc A770 (cc=1255): correctly classified as VER_GEN12 after fix
- Build: clean with `-DGGML_SYCL=ON`
- Performance: neutral on 9B dense model (correct fix, not a tuning change)

## Files changed
- `ggml/src/ggml-sycl/common.hpp`: threshold values