### PR TITLE
sycl: remove unnecessary wait() in CONCAT and enable graph compatibility

### DIFF
--- a/ggml/src/ggml-sycl/concat.cpp
+++ b/ggml/src/ggml-sycl/concat.cpp
@@ -174,8 +174,8 @@ void concat_impl_sycl(ggml_backend_sycl_context & ctx, ggml_tensor *dst) {
             const size_t size0 = ggml_nbytes(src0);
             const size_t size1 = ggml_nbytes(src1);
 
-            SYCL_CHECK(CHECK_TRY_ERROR(stream->memcpy(dst_d, src0_d, size0).wait()));
-            SYCL_CHECK(CHECK_TRY_ERROR(stream->memcpy(dst_d + size0 / type_size, src1_d, size1).wait()));
+            SYCL_CHECK(CHECK_TRY_ERROR(stream->memcpy(dst_d, src0_d, size0)));
+            SYCL_CHECK(CHECK_TRY_ERROR(stream->memcpy(dst_d + size0 / type_size, src1_d, size1)));
         }
     } else {
         concat_T_sycl_non_cont<T>(stream, (const char *) src0->data, (const char *) src1->data, (char *) dst->data,

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4501,11 +4501,6 @@ static bool check_graph_compatibility(ggml_cgraph * cgraph) {
         switch (node_op) {
             default:
                 break;
-            case GGML_OP_CONCAT:
-                // ggml_sycl_op_concat() does a blocking host wait after memcpy operations,
-                // but wait() can't be called on the events returned by a queue recording
-                // to a graph.
-                [[fallthrough]];
             case GGML_OP_MUL_MAT_ID:
                 // ggml_sycl_mul_mat_id() does a blocking host wait on the sycl queue after
                 // submitting a memcpy operation, but wait() can't be called on a queue that


### PR DESCRIPTION
## Summary

Remove redundant `.wait()` calls from CONCAT memcpy operations and enable SYCL command graph compatibility for CONCAT ops.

## Problem
CONCAT's memcpy submissions were followed by blocking `.wait()` calls, but SYCL in-order queues guarantee ordering implicitly. The waits are redundant and also prevent SYCL command graph recording (wait() cannot be called during graph capture).

## Fix
1. Remove `.wait()` from both memcpy calls in `concat.cpp`
2. Remove CONCAT from the graph incompatibility list in `check_graph_compatibility()`

## Testing
- Arc A770: builds clean, inference correct
- Models with CONCAT ops (e.g., Qwen3.5-9B) can now use SYCL command graphs

## Files changed
- `ggml/src/ggml-sycl/concat.cpp`: remove .wait() calls
- `ggml/src/ggml-sycl/ggml-sycl.cpp`: remove CONCAT from graph exclusion list