### PR TITLE
sycl: tune DMMV_X and MMV_Y for Intel Arc GPUs

### DIFF
--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -103,10 +103,10 @@ extern int g_ggml_sycl_enable_flash_attention;
 
 // dmmv = dequantize_mul_mat_vec
 #ifndef GGML_SYCL_DMMV_X
-#define GGML_SYCL_DMMV_X 32
+#define GGML_SYCL_DMMV_X 64
 #endif
 #ifndef GGML_SYCL_MMV_Y
-#define GGML_SYCL_MMV_Y 1
+#define GGML_SYCL_MMV_Y 2
 #endif
 
 typedef sycl::queue *queue_ptr;

--- a/ggml/src/ggml-sycl/presets.hpp
+++ b/ggml/src/ggml-sycl/presets.hpp
@@ -54,10 +54,10 @@
 
 // dmmv = dequantize_mul_mat_vec
 #ifndef GGML_SYCL_DMMV_X
-#define GGML_SYCL_DMMV_X 32
+#define GGML_SYCL_DMMV_X 64
 #endif
 #ifndef GGML_SYCL_MMV_Y
-#define GGML_SYCL_MMV_Y 1
+#define GGML_SYCL_MMV_Y 2
 #endif
 
 #ifndef K_QUANTS_PER_ITERATION


### PR DESCRIPTION
## Summary

Increase DMMV work parameters for better GPU utilization on Intel Arc.

## Changes
- `GGML_SYCL_DMMV_X`: 32 → 64 (more data per thread iteration)
- `GGML_SYCL_MMV_Y`: 1 → 2 (more rows per workgroup)

Both values are defined in `presets.hpp` and duplicated in `common.hpp`.

## Rationale
DMMV_X=64 doubles the data processed per thread, improving memory coalescing. All common model widths (4096, 5120, 6656, 8192, 14336) are divisible by 64.

MMV_Y=2 doubles rows per workgroup, amortizing launch overhead.

## Testing
- Arc A770: builds clean, all widths divisible by 64 verified
- Performance: neutral on Qwen3.5-9B (model fits in VRAM, DMMV path not heavily exercised)
- Larger models or batch processing should see more benefit

## Files changed
- `ggml/src/ggml-sycl/presets.hpp`
- `ggml/src/ggml-sycl/common.hpp`