### PR TITLE
sycl: increase vdr_mmvq for Q4_0, Q4_K, Q6_K quantized types

### DIFF
--- a/ggml/src/ggml-sycl/quants.hpp
+++ b/ggml/src/ggml-sycl/quants.hpp
@@ -44,7 +44,7 @@ template <> struct block_q_t<GGML_TYPE_Q4_0> {
         static constexpr uint32_t qk       = QK4_0;
         static constexpr uint32_t qi       = QI4_0;
         static constexpr uint32_t qr       = QR4_0;
-        static constexpr uint32_t vdr_mmvq = 2;
+        static constexpr uint32_t vdr_mmvq = 4; // was 2: more blocks per subgroup reduces dp4a overhead
     };
 
     static constexpr std::pair<int, int> get_block_offset(const int block_index, const int /* nblocks */) {
@@ -63,7 +63,7 @@ template <> struct block_q_t<GGML_TYPE_Q4_K> {
         static constexpr uint32_t qk       = QK_K;
         static constexpr uint32_t qi       = QI4_K;
         static constexpr uint32_t qr       = QR4_K;
-        static constexpr uint32_t vdr_mmvq = 2;
+        static constexpr uint32_t vdr_mmvq = 4; // was 2: more blocks per subgroup reduces dp4a overhead
     };
 
     static constexpr std::pair<int, int> get_block_offset(const int block_index, const int /* nblocks */) {
@@ -84,7 +84,7 @@ template <> struct block_q_t<GGML_TYPE_Q6_K> {
         static constexpr uint32_t qk       = QK_K;
         static constexpr uint32_t qi       = QI6_K;
         static constexpr uint32_t qr       = QR6_K;
-        static constexpr uint32_t vdr_mmvq = 1;
+        static constexpr uint32_t vdr_mmvq = 2; // was 1: doubled for better dp4a utilization
     };
 
     static constexpr std::pair<int, int> get_block_offset(const int block_index, const int n_blocks) {


### PR DESCRIPTION
## Summary

Increase the "vector dot product rows per MMVQ" parameter for three quant types, yielding significant token generation improvements on Intel Arc.

## Changes
- **Q4_0**: vdr_mmvq 2 → 4 (**+18% token generation**)
- **Q4_K**: vdr_mmvq 2 → 4 (**+19% token generation on Q4_K_M**)
- **Q6_K**: vdr_mmvq 1 → 2 (conservative increase, build-tested)

## Rationale
Q4_0 and Q4_K are dp4a-compute-bound on Intel Arc. Nibble extraction in Q4_0 requires 2 dp4a per byte vs Q8_0's 1 dp4a per byte. Increasing vdr_mmvq processes more blocks per subgroup iteration, shifting the bottleneck from dp4a throughput toward memory bandwidth.

Q8_0 is memory-bandwidth-bound and is not changed (already at vdr=4).

Q6_K uses a conservative vdr=2 (doubled from 1) — no Q6_K model was available for full benchmarking.

## Benchmark (Arc A770 16GB, Qwen3.5-9B)
| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Q4_0 tg128 | 31.4 t/s | 37.1 t/s | +18% |
| Q4_K_M tg128 | 25.3 t/s | 30.0 t/s | +19% |

## Files changed
- `ggml/src/ggml-sycl/quants.hpp`