### PR TITLE
vulkan: add Arc 140T (Arrow Lake H) device-ID override for Xe2

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -302,6 +302,14 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
             return vk_device_architecture::OTHER;
         }
 
+        // Arrow Lake H (Arc 140T) misreports minSubgroupSize=8 despite being Xe2.
+        // Device-ID override to force Xe2 classification.
+        // See: https://github.com/ggml-org/llama.cpp/issues/20776
+        const uint32_t devid = props.deviceID;
+        if (devid == 0x7D51 || devid == 0x7D45) {
+            return vk_device_architecture::INTEL_XE2;
+        }
+
         vk::PhysicalDeviceProperties2 props2;
         vk::PhysicalDeviceShaderCorePropertiesAMD shader_core_props_amd;
         vk::PhysicalDeviceShaderIntegerDotProductPropertiesKHR integer_dot_props;
@@ -339,6 +347,14 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
 
         if (!subgroup_size_control) {
             return vk_device_architecture::OTHER;
+        }
+
+        // Arrow Lake H (Arc 140T) misreports minSubgroupSize=8 despite being Xe2.
+        // Device-ID override to force Xe2 classification.
+        // See: https://github.com/ggml-org/llama.cpp/issues/20776
+        const uint32_t devid = props.deviceID;
+        if (devid == 0x7D51 || devid == 0x7D45) {
+            return vk_device_architecture::INTEL_XE2;
         }
 
         vk::PhysicalDeviceProperties2 props2;


### PR DESCRIPTION
## Summary

Intel Arc 140T (Arrow Lake H) GPUs report `minSubgroupSize=8` instead of the expected 16 for Xe2 devices. The Vulkan backend uses `minSubgroupSize` to detect Xe2 architecture, so the 140T is misclassified as `OTHER`, disabling cooperative matrix and all dependent optimizations.

## Fix
Add a device-ID check for Arrow Lake H (0x7D51, 0x7D45) before the `minSubgroupSize` check, returning `INTEL_XE2` directly.

Applied to both the EXT and KHR code paths in `get_device_architecture()`.

## Testing
- Not tested on Arc 140T hardware (no device available)
- No effect on other Intel GPUs or non-Intel GPUs

Refs: https://github.com/ggml-org/llama.cpp/issues/20776

## Files changed
- `ggml/src/ggml-vulkan/ggml-vulkan.cpp`