### PR TITLE
opencl: workaround Adreno LLVM compiler SIGSEGV in subgroup arithmetic ops

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -400,6 +400,7 @@ struct ggml_backend_opencl_context {
     ggml_cl_compiler_version adreno_cl_compiler_version;
 
     int adreno_wave_size;
+    bool adreno_subgroup_bug;
 
     cl_bool non_uniform_workgroups;
     size_t  image_max_buffer_size;
@@ -780,9 +781,10 @@ static cl_program build_program_from_source(cl_context ctx, cl_device_id dev, co
         program_log = (char*) malloc(log_size + 1);
         program_log[log_size] = '\0';
         clGetProgramBuildInfo(p, dev, CL_PROGRAM_BUILD_LOG, log_size + 1, program_log, NULL);
-        GGML_LOG_ERROR("ggml_opencl: kernel compile error:\n\n%s\n", program_log);
+        GGML_LOG_ERROR("ggml_opencl: kernel compile error (err=%d):\n%s\n", err, program_log);
         free(program_log);
-        exit(1);
+        clReleaseProgram(p);
+        return nullptr;
     }
 
     return p;
@@ -800,6 +802,16 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
 
     if (backend_ctx->adreno_use_large_buffer) {
         compile_opts += " -qcom-enable-large-buffer ";
+    }
+
+    // Detect Adreno compiler versions affected by SIGSEGV in
+    // QGPUPeepholeOptimizer::lowerPseudoSubgroupArithOpWithAdvSubgroupFeature.
+    // The define triggers fallback kernels (local-memory reduction) in rms_norm.cl.
+    backend_ctx->adreno_subgroup_bug = (backend_ctx->gpu_family == ADRENO &&
+        !backend_ctx->adreno_cl_compiler_version.newer_than_or_same(E031, 38, 11, 0));
+    if (backend_ctx->adreno_subgroup_bug) {
+        compile_opts += " -DGGML_OPENCL_NO_REQD_SUBGROUP_SIZE";
+        GGML_LOG_WARN("ggml_opencl: Adreno compiler has subgroup bug, disabling reqd_sub_group_size attribute\n");
     }
 
     GGML_LOG_INFO("ggml_opencl: loading OpenCL kernels");
@@ -2042,7 +2054,9 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
     }
 
     // cumsum
-    {
+    // cumsum.cl uses sub_group_scan_* which triggers the same Adreno compiler bug.
+    // Skip compilation entirely on affected devices.
+    if (!backend_ctx->adreno_subgroup_bug) {
 #ifdef GGML_OPENCL_EMBED_KERNELS
         const std::string kernel_src {
             #include "cumsum.cl.h"
@@ -2055,9 +2069,11 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
 
         CL_CHECK((backend_ctx->kernel_cumsum_blk = clCreateKernel(prog, "kernel_cumsum_blk", &err), err));
         CL_CHECK((backend_ctx->kernel_cumsum_add = clCreateKernel(prog, "kernel_cumsum_add", &err), err));
-        GGML_LOG_CONT(".");
         CL_CHECK(clReleaseProgram(prog));
+    } else {
+        GGML_LOG_WARN("ggml_opencl: cumsum kernels skipped (Adreno subgroup bug)\n");
     }
+    GGML_LOG_CONT(".");
 
     // sigmoid
     {
@@ -4114,8 +4130,9 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
             return cols <= max_workgroup_size && op->src[0]->type == GGML_TYPE_F32;
         }
         case GGML_OP_SUM_ROWS:
-        case GGML_OP_CUMSUM:
             return op->src[0]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]);
+        case GGML_OP_CUMSUM:
+            return backend_ctx->kernel_cumsum_blk && op->src[0]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]);
         case GGML_OP_MEAN:
             return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_FLASH_ATTN_EXT:
@@ -6062,10 +6079,12 @@ static ggml_backend_buffer_t ggml_backend_opencl_buffer_type_alloc_buffer(ggml_b
 
     cl_int err;
     cl_mem mem = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, size, NULL, &err);
+#if CL_TARGET_OPENCL_VERSION >= 300
     if (err != CL_SUCCESS && backend_ctx->adreno_use_large_buffer) {
         cl_mem_properties props[] = { 0x41A6 /* CL_LARGE_BUFFER_QCOM */, 1, 0 };
         mem = clCreateBufferWithProperties(backend_ctx->context, props, CL_MEM_READ_WRITE, size, NULL, &err);
     }
+#endif
 
     if (err != CL_SUCCESS) {
         GGML_LOG_INFO("%s: failed to allocate %.2f MiB\n", __func__, size / 1024.0 / 1024.0);
@@ -8031,8 +8050,12 @@ static void ggml_cl_rms_norm(ggml_backend_t backend, const ggml_tensor * src0, c
     CL_CHECK(clSetKernelArg(kernel,  9, sizeof(cl_ulong),  &nb02));
     CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong),  &nb03));
     CL_CHECK(clSetKernelArg(kernel, 11, sizeof(float),     &eps));
-    // This is local memory - the size depends on subgroup size.
-    CL_CHECK(clSetKernelArg(kernel, 12, sizeof(float)*nth/sgs,  NULL));
+    // Local memory size: normally nth/sgs floats (one per subgroup), but the
+    // fallback kernel uses tree reduction and needs nth floats (one per work-item).
+    size_t local_mem_size = backend_ctx->adreno_subgroup_bug
+        ? sizeof(float) * nth
+        : sizeof(float) * nth / sgs;
+    CL_CHECK(clSetKernelArg(kernel, 12, local_mem_size,  NULL));
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
 }
@@ -8143,7 +8166,11 @@ static void ggml_opencl_op_rms_norm_fused(ggml_backend_t backend, ggml_tensor * 
     CL_CHECK(clSetKernelArg(kernel, 21, sizeof(cl_ulong),      &nb2));
     CL_CHECK(clSetKernelArg(kernel, 22, sizeof(cl_ulong),      &nb3));
     CL_CHECK(clSetKernelArg(kernel, 23, sizeof(float),         &eps));
-    CL_CHECK(clSetKernelArg(kernel, 24, sizeof(float)*sgs,     NULL));
+    // Fallback kernel uses tree reduction: needs nth floats instead of sgs.
+    size_t local_mem_rms_mul = backend_ctx->adreno_subgroup_bug
+        ? sizeof(float) * nth
+        : sizeof(float) * sgs;
+    CL_CHECK(clSetKernelArg(kernel, 24, local_mem_rms_mul,     NULL));
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
 }

--- a/ggml/src/ggml-opencl/kernels/group_norm.cl
+++ b/ggml/src/ggml-opencl/kernels/group_norm.cl
@@ -1,5 +1,8 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
+#ifndef GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Normal path: use subgroup operations for reduction
+
 #ifdef cl_intel_subgroups
 #pragma OPENCL EXTENSION cl_intel_subgroups : enable
 #else
@@ -119,3 +122,141 @@ kernel void kernel_group_norm_mul_add(
         dst[j] = ((src0[j] - mean) * scale) * src1[j] + src2[j];
     }
 }
+
+#else // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Fallback path: local-memory tree reduction, no subgroup operations.
+
+#define MAX_LOCAL_SIZE 1024
+
+//------------------------------------------------------------------------------
+// group_norm (fallback)
+//------------------------------------------------------------------------------
+kernel void kernel_group_norm(
+        global float * src0,
+        ulong offset0,
+        global float * dst,
+        ulong offsetd,
+        int ne,
+        int group_size,
+        float eps
+) {
+    src0 = (global float *)((global char *)src0 + offset0);
+    dst  = (global float *)((global char *)dst  + offsetd);
+
+    int lid = get_local_id(0);
+    int lsize = get_local_size(0);
+
+    int start = get_group_id(0) * group_size;
+    int end   = start + group_size;
+    if (end >= ne) {
+        end = ne;
+    }
+
+    __local float lmem[MAX_LOCAL_SIZE];
+
+    // Phase 1: compute sum for mean
+    float tmp = 0.0f;
+    for (int j = start + lid; j < end; j += lsize) {
+        tmp += src0[j];
+    }
+
+    // Tree reduction for sum
+    lmem[lid] = tmp;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lmem[lid] += lmem[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    const float mean = lmem[0] / group_size;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Phase 2: compute variance
+    tmp = 0.0f;
+    for (int j = start + lid; j < end; j += lsize) {
+        float xi = src0[j] - mean;
+        dst[j] = xi;
+        tmp += xi * xi;
+    }
+
+    // Tree reduction for variance
+    lmem[lid] = tmp;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lmem[lid] += lmem[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    const float variance = lmem[0] / group_size;
+    const float scale = 1.0f/sqrt(variance + eps);
+    for (int j = start + lid; j < end; j += lsize) {
+        dst[j] *= scale;
+    }
+}
+
+//------------------------------------------------------------------------------
+// group_norm_mul_add (fallback)
+//------------------------------------------------------------------------------
+kernel void kernel_group_norm_mul_add(
+        global float * src0, ulong offset0,
+        global float * src1, ulong offset1,
+        global float * src2, ulong offset2,
+        global float * dst, ulong offsetd,
+        int ne,
+        int group_size,
+        float eps
+) {
+    src0 = (global float *)((global char *)src0 + offset0);
+    src1 = (global float *)((global char *)src1 + offset1);
+    src2 = (global float *)((global char *)src2 + offset2);
+    dst  = (global float *)((global char *)dst  + offsetd);
+
+    int lid = get_local_id(0);
+    int lsize = get_local_size(0);
+
+    int start = get_group_id(0) * group_size;
+    int end = start + group_size;
+    if (end > ne) {
+        end = ne;
+    }
+
+    __local float lmem[MAX_LOCAL_SIZE];
+    __local float lmem2[MAX_LOCAL_SIZE];
+
+    float sum = 0.0f;
+    float sum_sq = 0.0f;
+
+    for (int j = start + lid; j < end; j += lsize) {
+        float val = src0[j];
+        sum += val;
+        sum_sq += val*val;
+    }
+
+    // Tree reduction for sum and sum_sq
+    lmem[lid] = sum;
+    lmem2[lid] = sum_sq;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lmem[lid] += lmem[lid + s];
+            lmem2[lid] += lmem2[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    sum = lmem[0];
+    sum_sq = lmem2[0];
+
+    const float mean = sum / group_size;
+    const float var = sum_sq / group_size - mean * mean;
+    const float scale = rsqrt(var + eps);
+
+    for (int j = start + lid; j < end; j += lsize) {
+        dst[j] = ((src0[j] - mean) * scale) * src1[j] + src2[j];
+    }
+}
+
+#endif // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE

--- a/ggml/src/ggml-opencl/kernels/mean.cl
+++ b/ggml/src/ggml-opencl/kernels/mean.cl
@@ -1,4 +1,7 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+#ifndef GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Normal path: use subgroup operations
 #pragma OPENCL EXTENSION cl_khr_subgroups : enable
 
 // Most devices have max workgroup size of 1024, so this is enough for subgroup
@@ -138,3 +141,121 @@ kernel void kernel_mean_f32_4(
         dst_row[0] = sumf / ne00;
     }
 }
+
+#else // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Fallback path: local-memory tree reduction, no subgroup operations.
+
+#define MAX_LOCAL_SIZE 1024
+kernel void kernel_mean_f32(
+    global char *  src0,
+    ulong           offset0,
+    global char *  dst,
+    ulong           offsetd,
+    int             ne00,
+    int             ne01,
+    int             ne02,
+    int             ne03,
+    ulong           nb01,
+    ulong           nb02,
+    ulong           nb03,
+    ulong           nb1,
+    ulong           nb2,
+    ulong           nb3
+) {
+    src0 = src0 + offset0;
+    dst  = dst  + offsetd;
+
+    const int i3 = get_group_id(2);
+    const int i2 = get_group_id(1);
+    const int i1 = get_group_id(0);
+
+    const int lid = get_local_id(0);
+    const int lsize = get_local_size(0);
+
+    __local float lmem[MAX_LOCAL_SIZE];
+
+    if (i3 >= ne03 || i2 >= ne02 || i1 >= ne01) {
+        return;
+    }
+
+    global float * src_row = (global float *) (src0 + i1*nb01 + i2*nb02 + i3*nb03);
+    global float * dst_row = (global float *) (dst  + i1*nb1  + i2*nb2  + i3*nb3);
+
+    float sumf = 0.0f;
+
+    for (int i0 = lid; i0 < ne00; i0 += lsize) {
+        sumf += src_row[i0];
+    }
+
+    lmem[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lmem[lid] += lmem[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        dst_row[0] = lmem[0] / ne00;
+    }
+}
+
+kernel void kernel_mean_f32_4(
+    global char *  src0,
+    ulong           offset0,
+    global char *  dst,
+    ulong           offsetd,
+    int             ne00,
+    int             ne01,
+    int             ne02,
+    int             ne03,
+    ulong           nb01,
+    ulong           nb02,
+    ulong           nb03,
+    ulong           nb1,
+    ulong           nb2,
+    ulong           nb3
+) {
+    src0 = src0 + offset0;
+    dst  = dst  + offsetd;
+
+    const int i3 = get_group_id(2);
+    const int i2 = get_group_id(1);
+    const int i1 = get_group_id(0);
+
+    const int lid = get_local_id(0);
+    const int lsize = get_local_size(0);
+
+    __local float lmem[MAX_LOCAL_SIZE];
+
+    if (i3 >= ne03 || i2 >= ne02 || i1 >= ne01) {
+        return;
+    }
+
+    global float4 * src_row = (global float4 *) (src0 + i1*nb01 + i2*nb02 + i3*nb03);
+    global float  * dst_row = (global float  *) (dst  + i1*nb1  + i2*nb2  + i3*nb3);
+
+    float4 sum_vec = (float4)0.0f;
+
+    for (int i0 = lid; i0 < ne00 / 4; i0 += lsize) {
+        sum_vec += src_row[i0];
+    }
+
+    float sumf = dot(sum_vec, (float4)(1.0f));
+
+    lmem[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lmem[lid] += lmem[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        dst_row[0] = lmem[0] / ne00;
+    }
+}
+
+#endif // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE

--- a/ggml/src/ggml-opencl/kernels/rms_norm.cl
+++ b/ggml/src/ggml-opencl/kernels/rms_norm.cl
@@ -1,5 +1,8 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
+#ifndef GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Normal path: use subgroup operations for reduction
+
 #ifdef cl_intel_subgroups
 #pragma OPENCL EXTENSION cl_intel_subgroups : enable
 #else
@@ -188,3 +191,154 @@ kernel void kernel_rms_norm_mul(
         y[i00] = (x[i00] * scale) * f[i00%(ne10/4)];
     }
 }
+
+#else // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Fallback path: pure local-memory tree reduction, no subgroup operations.
+// Used on Adreno drivers with a bug in QGPUPeepholeOptimizer that crashes
+// when compiling sub_group_reduce_add in this specific kernel.
+// Local memory size must be sizeof(float)*get_local_size(0) (one float per work-item).
+
+//------------------------------------------------------------------------------
+// rms_norm (fallback)
+//------------------------------------------------------------------------------
+kernel void kernel_rms_norm(
+        global void * src0,
+        ulong offset0,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        int ne03,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        float eps,
+        local float * sum
+) {
+    src0 = (global void*)((global char*)src0 + offset0);
+    dst = (global float*)((global char*)dst + offsetd);
+
+    int i03 = get_group_id(2);
+    int i02 = get_group_id(1);
+    int i01 = get_group_id(0);
+
+    int lid = get_local_id(0);
+    int lsize = get_local_size(0);
+
+    global float4 * x = (global float4 *) ((global char *) src0 + i03*nb03 + i02*nb02 + i01*nb01);
+    global float * x_scalar = (global float *) x;
+    float4 sumf = 0;
+
+    // parallel sum
+    for (int i00 = lid; i00 < ne00/4; i00 += lsize) {
+        sumf += x[i00] * x[i00];
+    }
+    float partial = sumf.s0 + sumf.s1 + sumf.s2 + sumf.s3;
+
+    // Tree reduction using local memory
+    sum[lid] = partial;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            sum[lid] += sum[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        for (int i = 4 * (ne00 / 4); i < ne00; i++) {
+            sum[0] += x_scalar[i];
+        }
+        sum[0] /= ne00;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const float mean  = sum[0];
+    const float scale = 1.0f/sqrt(mean + eps);
+
+    global float4 * y = (global float4 *) (dst + i03*ne02*ne01*ne00 + i02*ne01*ne00 + i01*ne00);
+    global float * y_scalar = (global float *) y;
+    for (int i00 = lid; i00 < ne00/4; i00 += lsize) {
+        y[i00] = x[i00] * scale;
+    }
+    if (lid == 0) {
+        for (int i00 = 4 * (ne00 / 4); i00 < ne00; i00++) {
+            y_scalar[i00] = x_scalar[i00] * scale;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------
+// rms_norm_mul (fallback)
+//------------------------------------------------------------------------------
+kernel void kernel_rms_norm_mul(
+        global char * src0,
+        ulong offset0,
+        global char * src1,
+        ulong offset1,
+        global char * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        int ne03,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        int ne13,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        ulong nb1,
+        ulong nb2,
+        ulong nb3,
+        float eps,
+        local float * sum
+) {
+    src0 = src0 + offset0;
+    src1 = src1 + offset1;
+    dst  = dst  + offsetd;
+
+    int lid = get_local_id(0);
+    int lsize = get_local_size(0);
+
+    int i03 = get_group_id(2);
+    int i02 = get_group_id(1);
+    int i01 = get_group_id(0);
+
+    global float4 * x = (global float4 *) (src0 + i03*nb03 + i02*nb02 + i01*nb01);
+    global float4 * f = (global float4 *) (src1 + (i03%ne13)*nb13 + (i02%ne12)*nb12 + (i01%ne11)*nb11);
+
+    float sumf = 0;
+
+    // parallel sum
+    for (int i00 = lid; i00 < ne00/4; i00 += lsize) {
+        sumf += dot(x[i00], x[i00]);
+    }
+
+    // Tree reduction using local memory
+    sum[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            sum[lid] += sum[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    sumf = sum[0];
+
+    float mean  = sumf / ne00;
+    float scale = 1.0f/sqrt(mean + eps);
+
+    global float4 * y = (global float4 *) (dst + i03*nb3 + i02*nb2 + i01*nb1);
+    for (int i00 = lid; i00 < ne00/4; i00 += lsize) {
+        y[i00] = (x[i00] * scale) * f[i00%(ne10/4)];
+    }
+}
+
+#endif // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE

--- a/ggml/src/ggml-opencl/kernels/sum_rows.cl
+++ b/ggml/src/ggml-opencl/kernels/sum_rows.cl
@@ -1,4 +1,7 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+#ifndef GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Normal path: use subgroup operations
 #pragma OPENCL EXTENSION cl_khr_subgroups : enable
 
 // Most devices have max workgroup size of 1024, so this is enough for subgroup
@@ -138,3 +141,121 @@ kernel void kernel_sum_rows_f32_4(
         dst_row[0] = sumf;
     }
 }
+
+#else // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE
+// Fallback path: local-memory tree reduction, no subgroup operations.
+
+#define MAX_LOCAL_SIZE 1024
+kernel void kernel_sum_rows_f32(
+    global char *  src0,
+    ulong           offset0,
+    global char *  dst,
+    ulong           offsetd,
+    int             ne00,
+    int             ne01,
+    int             ne02,
+    int             ne03,
+    ulong           nb01,
+    ulong           nb02,
+    ulong           nb03,
+    ulong           nb1,
+    ulong           nb2,
+    ulong           nb3
+) {
+    src0 = src0 + offset0;
+    dst  = dst  + offsetd;
+
+    const int i3 = get_group_id(2);
+    const int i2 = get_group_id(1);
+    const int i1 = get_group_id(0);
+
+    const int lid = get_local_id(0);
+    const int lsize = get_local_size(0);
+
+    __local float lmem[MAX_LOCAL_SIZE];
+
+    if (i3 >= ne03 || i2 >= ne02 || i1 >= ne01) {
+        return;
+    }
+
+    global float * src_row = (global float *) (src0 + i1*nb01 + i2*nb02 + i3*nb03);
+    global float * dst_row = (global float *) (dst  + i1*nb1  + i2*nb2  + i3*nb3);
+
+    float sumf = 0.0f;
+
+    for (int i0 = lid; i0 < ne00; i0 += lsize) {
+        sumf += src_row[i0];
+    }
+
+    lmem[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lmem[lid] += lmem[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        dst_row[0] = lmem[0];
+    }
+}
+
+kernel void kernel_sum_rows_f32_4(
+    global char *  src0,
+    ulong           offset0,
+    global char *  dst,
+    ulong           offsetd,
+    int             ne00,
+    int             ne01,
+    int             ne02,
+    int             ne03,
+    ulong           nb01,
+    ulong           nb02,
+    ulong           nb03,
+    ulong           nb1,
+    ulong           nb2,
+    ulong           nb3
+) {
+    src0 = src0 + offset0;
+    dst  = dst  + offsetd;
+
+    const int i3 = get_group_id(2);
+    const int i2 = get_group_id(1);
+    const int i1 = get_group_id(0);
+
+    const int lid = get_local_id(0);
+    const int lsize = get_local_size(0);
+
+    __local float lmem[MAX_LOCAL_SIZE];
+
+    if (i3 >= ne03 || i2 >= ne02 || i1 >= ne01) {
+        return;
+    }
+
+    global float4 * src_row = (global float4 *) (src0 + i1*nb01 + i2*nb02 + i3*nb03);
+    global float  * dst_row = (global float  *) (dst  + i1*nb1  + i2*nb2  + i3*nb3);
+
+    float4 sum_vec = (float4)0.0f;
+
+    for (int i0 = lid; i0 < ne00 / 4; i0 += lsize) {
+        sum_vec += src_row[i0];
+    }
+
+    float sumf = dot(sum_vec, (float4)(1.0f));
+
+    lmem[lid] = sumf;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int s = lsize / 2; s > 0; s >>= 1) {
+        if (lid < s) {
+            lmem[lid] += lmem[lid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        dst_row[0] = lmem[0];
+    }
+}
+
+#endif // GGML_OPENCL_NO_REQD_SUBGROUP_SIZE


### PR DESCRIPTION
## Overview

> **⚠️ AI Disclosure (upfront):** This PR is **100% AI-generated** using Claude Code (Anthropic). The contributor validated the fix on real hardware (Xiaomi 11T Pro / Adreno 660) but did not write the patch by hand. Submitting with full disclosure per `AGENTS.md`; fully understand the project may reject on that basis.

Qualcomm's Adreno LLVM compiler (versions prior to `E031.38.11.0`) crashes with SIGSEGV in `QGPUPeepholeOptimizer::lowerPseudoSubgroupArithOpWithAdvSubgroupFeature` when compiling OpenCL kernels that use `sub_group_reduce_add` or `sub_group_scan_*`. The crash happens inside `clBuildProgram` during kernel compilation, so the OpenCL backend fails to initialize on affected devices (e.g. Snapdragon 888 / Adreno 660). The trigger is the hardware feature path, not the pragma — disabling the `cl_khr_subgroups` pragma alone is not enough.

This PR adds detection + fallback paths so the OpenCL backend can initialize and run on the affected Adrenos.

**Changes:**
- Detect affected Adreno compiler versions and set an `adreno_subgroup_bug` flag.
- When the flag is active, pass `-DGGML_OPENCL_NO_REQD_SUBGROUP_SIZE` to all kernel compilations.
- Add local-memory tree-reduction fallback paths (guarded by that define) in:
  - `rms_norm.cl`
  - `mean.cl`
  - `sum_rows.cl`
  - `group_norm.cl`
- Skip `cumsum.cl` compilation on affected devices (it uses `sub_group_scan_*` with no easy fallback).
- Check `kernel_cumsum_blk` in `supports_op` before claiming `CUMSUM` support.
- Adjust local-memory allocation for `rms_norm` / `rms_norm_mul` dispatch when using fallback kernels (`nth` floats instead of `nth/sgs`).
- Return `nullptr` instead of `exit(1)` on kernel compile failure for better diagnostics.
- Guard `clCreateBufferWithProperties` behind `CL_TARGET_OPENCL_VERSION >= 300` so OpenCL 2.0 builds still compile.

**Tested on:** Xiaomi 11T Pro (Snapdragon 888, Adreno 660, driver compiler `E031.38.01.08`). Before: backend init fails on the first affected kernel. After: all 131 kernels compile, Gemma-3-E2B loads with 36/36 layers offloaded to GPU and generates tokens.

## Additional information

The fix is scoped to affected Adreno compilers only — unaffected devices keep the existing subgroup-arith fast paths and see no codegen changes. Newer Adreno drivers that already ship the fix will also be unaffected (the version check gates everything).

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES — 100% AI-generated using Claude Code (Anthropic).** The contributor (me) directed the investigation, validated the fix on-device (Xiaomi 11T Pro / Adreno 660), and is responsible for the submitted changes, but did not hand-write the code or this description. Submitting with full disclosure up-front per `AGENTS.md`; happy to close if policy dictates.