### PR TITLE
sampling: add segment-level repetition loop detection

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -241,6 +241,10 @@ struct common_params_sampling {
     float   dry_base           = 1.75f;  // 0.0 = disabled;      multiplier * base ^ (length of sequence before token - allowed length)
     int32_t dry_allowed_length = 2;      // tokens extending repetitions beyond this receive penalty
     int32_t dry_penalty_last_n = -1;     // how many tokens to scan for repetitions (0 = disable penalty, -1 = context size)
+    int32_t repeat_line_window     = 0;           // 0 = disabled; number of past segments to compare against
+    int32_t repeat_line_min_length = 20;          // ignore segments shorter than this (avoids false positives like "Ok.")
+    std::string repeat_line_delimiters = "\n.!?:"; // characters that end a segment
+    float   repeat_line_temp_boost = 0.50f;       // temperature boost when loop detected
     float   adaptive_target    = -1.0f;  // select tokens near this probability (valid range 0.0 to 1.0; negative = disabled)
     float   adaptive_decay     = 0.90f;  // EMA decay for adaptation; history ≈ 1/(1-decay) tokens (0.0 - 0.99)
     int32_t mirostat           = 0;      // 0 = disabled, 1 = mirostat, 2 = mirostat 2.0

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -377,6 +377,12 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         llama_sampler_chain_add(chain, smpl);
     }
 
+    if (params.repeat_line_window > 0) {
+        llama_sampler_chain_add(chain,
+            llama_sampler_init_repeat_line(vocab, params.repeat_line_window, params.repeat_line_min_length,
+                params.repeat_line_delimiters.c_str(), params.repeat_line_temp_boost));
+    }
+
     if (grmr && params.backend_sampling) {
         LOG_WRN("%s: backend sampling is not compatible with grammar, disabling\n", __func__);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -1417,6 +1417,24 @@ extern "C" {
                           const char ** seq_breakers,
                               size_t    num_breakers);
 
+    /// repeat-line: segment-level loop detection.
+    ///
+    /// detects when the model repeats the same sentence/segment (which token-level repeat_penalty cannot catch).
+    /// when a repeated segment is detected, temperature is temporarily boosted.
+    ///
+    /// params:
+    ///   vocab       - vocabulary (for token decoding)
+    ///   window      - number of past segments to compare against (0 = disabled)
+    ///   min_length  - ignore segments shorter than this (default 10, avoids false positives like "Ok.")
+    ///   delimiters  - characters that end a segment (default "\n.!?:")
+    ///   temp_boost  - temperature boost applied when a loop is detected (default 0.3)
+    LLAMA_API struct llama_sampler * llama_sampler_init_repeat_line(
+            const struct llama_vocab * vocab,
+                             int32_t   window,
+                             int32_t   min_length,
+                          const char * delimiters,
+                               float   temp_boost);
+
     /// adaptive-p: select tokens near a configurable target probability over time.
     ///
     /// the adaptive-p sampler transforms the token probability distribution to favor tokens

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -3423,6 +3423,143 @@ struct llama_sampler * llama_sampler_init_adaptive_p(
     );
 }
 
+// repeat-line
+
+struct llama_sampler_repeat_line {
+    const llama_vocab * vocab;
+
+    const int32_t     window;      // number of past segments to compare against (0 = disabled)
+    const int32_t     min_length;  // ignore segments shorter than this
+    const std::string delimiters;  // characters that end a segment
+    const float       temp_boost;  // temperature boost when loop detected
+
+    std::string              current_segment;
+    std::deque<std::string>  past_segments;
+    bool                     loop_active = false;
+
+    std::vector<char>        token_buf;
+
+    llama_sampler_repeat_line(const llama_vocab * vocab, int32_t window, int32_t min_length, const char * delimiters, float temp_boost)
+        : vocab(vocab), window(window), min_length(min_length > 0 ? min_length : 20),
+          delimiters(delimiters ? delimiters : "\n.!?:"),
+          temp_boost(temp_boost > 0.0f ? temp_boost : 0.5f), token_buf(256) {}
+};
+
+static const char * llama_sampler_repeat_line_name(const struct llama_sampler * /*smpl*/) {
+    return "repeat-line";
+}
+
+static void llama_sampler_repeat_line_accept(struct llama_sampler * smpl, llama_token token) {
+    auto * ctx = (llama_sampler_repeat_line *) smpl->ctx;
+    if (ctx->window <= 0) {
+        return;
+    }
+
+    // decode token to text
+    int len = ctx->vocab->token_to_piece(token, ctx->token_buf.data(), (int) ctx->token_buf.size(), 0, false);
+    if (len < 0) {
+        // buffer too small — resize and retry
+        ctx->token_buf.resize(-len);
+        len = ctx->vocab->token_to_piece(token, ctx->token_buf.data(), (int) ctx->token_buf.size(), 0, false);
+    }
+    if (len <= 0) {
+        return;
+    }
+
+    for (int i = 0; i < len; i++) {
+        char ch = ctx->token_buf[i];
+        ctx->current_segment += ch;
+
+        if (ctx->delimiters.find(ch) != std::string::npos) {
+            // segment complete — strip and check
+            std::string seg = ctx->current_segment;
+            // trim whitespace
+            size_t s = seg.find_first_not_of(" \t\r\n");
+            size_t e = seg.find_last_not_of(" \t\r\n");
+            seg = (s == std::string::npos) ? "" : seg.substr(s, e - s + 1);
+
+            if ((int) seg.size() >= ctx->min_length) {
+                ctx->loop_active = false;
+                for (const auto & past : ctx->past_segments) {
+                    if (past == seg) {
+                        ctx->loop_active = true;
+                        break;
+                    }
+                }
+
+                if (ctx->loop_active) {
+                    LLAMA_LOG_INFO("repeat-line: loop detected, boosting temperature by %.2f\n", (double)ctx->temp_boost);
+                } else {
+                    LLAMA_LOG_DEBUG("repeat-line: segment=%zu [%s]\n", ctx->past_segments.size(), seg.c_str());
+                }
+
+                ctx->past_segments.push_back(seg);
+                if ((int) ctx->past_segments.size() > ctx->window) {
+                    ctx->past_segments.pop_front();
+                }
+            }
+
+            ctx->current_segment.clear();
+        }
+    }
+}
+
+static void llama_sampler_repeat_line_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
+    const auto * ctx = (const llama_sampler_repeat_line *) smpl->ctx;
+    if (ctx->window <= 0 || !ctx->loop_active || ctx->temp_boost <= 0.0f) {
+        return;
+    }
+    // boost temperature: scale logits by 1/(1+boost)  (higher temp = flatter distribution)
+    const float inv_temp = 1.0f / (1.0f + ctx->temp_boost);
+    LLAMA_LOG_DEBUG("repeat-line: apply boost inv_temp=%.3f\n", (double)inv_temp);
+    for (size_t i = 0; i < cur_p->size; i++) {
+        cur_p->data[i].logit *= inv_temp;
+    }
+}
+
+static void llama_sampler_repeat_line_reset(struct llama_sampler * smpl) {
+    auto * ctx = (llama_sampler_repeat_line *) smpl->ctx;
+    ctx->current_segment.clear();
+    ctx->past_segments.clear();
+    ctx->loop_active = false;
+}
+
+static struct llama_sampler * llama_sampler_repeat_line_clone(const struct llama_sampler * smpl) {
+    const auto * ctx = (const llama_sampler_repeat_line *) smpl->ctx;
+    return llama_sampler_init_repeat_line(ctx->vocab, ctx->window, ctx->min_length, ctx->delimiters.c_str(), ctx->temp_boost);
+}
+
+static void llama_sampler_repeat_line_free(struct llama_sampler * smpl) {
+    delete (llama_sampler_repeat_line *) smpl->ctx;
+}
+
+static struct llama_sampler_i llama_sampler_repeat_line_i = {
+    /* .name              = */ llama_sampler_repeat_line_name,
+    /* .accept            = */ llama_sampler_repeat_line_accept,
+    /* .apply             = */ llama_sampler_repeat_line_apply,
+    /* .reset             = */ llama_sampler_repeat_line_reset,
+    /* .clone             = */ llama_sampler_repeat_line_clone,
+    /* .free              = */ llama_sampler_repeat_line_free,
+    /* .backend_init      = */ nullptr,
+    /* .backend_accept    = */ nullptr,
+    /* .backend_apply     = */ nullptr,
+    /* .backend_set_input = */ nullptr,
+};
+
+struct llama_sampler * llama_sampler_init_repeat_line(
+        const struct llama_vocab * vocab,
+                         int32_t   window,
+                         int32_t   min_length,
+                      const char * delimiters,
+                           float   temp_boost) {
+    LLAMA_LOG_DEBUG("repeat-line: init window=%d min_length=%d delimiters=[%s] temp_boost=%.2f\n",
+        window, min_length, delimiters ? delimiters : "(null)", (double)temp_boost);
+    return new llama_sampler {
+        /* .iface = */ &llama_sampler_repeat_line_i,
+        /* .ctx   = */ new llama_sampler_repeat_line(vocab, window, min_length, delimiters, temp_boost),
+    };
+}
+
 // logit-bias
 
 struct llama_sampler_logit_bias : public llama_sampler_backend {

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -58,6 +58,10 @@ json task_params::to_json(bool only_metrics) const {
             {"dry_base",                  sampling.dry_base},
             {"dry_allowed_length",        sampling.dry_allowed_length},
             {"dry_penalty_last_n",        sampling.dry_penalty_last_n},
+            {"repeat_line_window",        sampling.repeat_line_window},
+            {"repeat_line_min_length",    sampling.repeat_line_min_length},
+            {"repeat_line_delimiters",    sampling.repeat_line_delimiters},
+            {"repeat_line_temp_boost",    sampling.repeat_line_temp_boost},
             {"mirostat",                  sampling.mirostat},
             {"mirostat_tau",              sampling.mirostat_tau},
             {"mirostat_eta",              sampling.mirostat_eta},
@@ -115,6 +119,10 @@ json task_params::to_json(bool only_metrics) const {
         {"dry_allowed_length",        sampling.dry_allowed_length},
         {"dry_penalty_last_n",        sampling.dry_penalty_last_n},
         {"dry_sequence_breakers",     sampling.dry_sequence_breakers},
+        {"repeat_line_window",        sampling.repeat_line_window},
+        {"repeat_line_min_length",    sampling.repeat_line_min_length},
+        {"repeat_line_delimiters",    sampling.repeat_line_delimiters},
+        {"repeat_line_temp_boost",    sampling.repeat_line_temp_boost},
         {"mirostat",                  sampling.mirostat},
         {"mirostat_tau",              sampling.mirostat_tau},
         {"mirostat_eta",              sampling.mirostat_eta},
@@ -288,11 +296,15 @@ task_params server_task::params_from_json_cmpl(
     params.sampling.penalty_repeat     = json_value(data, "repeat_penalty",      defaults.sampling.penalty_repeat);
     params.sampling.penalty_freq       = json_value(data, "frequency_penalty",   defaults.sampling.penalty_freq);
     params.sampling.penalty_present    = json_value(data, "presence_penalty",    defaults.sampling.penalty_present);
-    params.sampling.dry_multiplier     = json_value(data, "dry_multiplier",      defaults.sampling.dry_multiplier);
-    params.sampling.dry_base           = json_value(data, "dry_base",            defaults.sampling.dry_base);
-    params.sampling.dry_allowed_length = json_value(data, "dry_allowed_length",  defaults.sampling.dry_allowed_length);
-    params.sampling.dry_penalty_last_n = json_value(data, "dry_penalty_last_n",  defaults.sampling.dry_penalty_last_n);
-    params.sampling.mirostat           = json_value(data, "mirostat",            defaults.sampling.mirostat);
+    params.sampling.dry_multiplier         = json_value(data, "dry_multiplier",         defaults.sampling.dry_multiplier);
+    params.sampling.dry_base               = json_value(data, "dry_base",               defaults.sampling.dry_base);
+    params.sampling.dry_allowed_length     = json_value(data, "dry_allowed_length",     defaults.sampling.dry_allowed_length);
+    params.sampling.dry_penalty_last_n     = json_value(data, "dry_penalty_last_n",     defaults.sampling.dry_penalty_last_n);
+    params.sampling.repeat_line_window     = json_value(data, "repeat_line_window",     defaults.sampling.repeat_line_window);
+    params.sampling.repeat_line_min_length = json_value(data, "repeat_line_min_length", defaults.sampling.repeat_line_min_length);
+    params.sampling.repeat_line_delimiters = json_value(data, "repeat_line_delimiters", defaults.sampling.repeat_line_delimiters);
+    params.sampling.repeat_line_temp_boost = json_value(data, "repeat_line_temp_boost", defaults.sampling.repeat_line_temp_boost);
+    params.sampling.mirostat               = json_value(data, "mirostat",               defaults.sampling.mirostat);
     params.sampling.mirostat_tau       = json_value(data, "mirostat_tau",        defaults.sampling.mirostat_tau);
     params.sampling.mirostat_eta       = json_value(data, "mirostat_eta",        defaults.sampling.mirostat_eta);
     params.sampling.adaptive_target    = json_value(data, "adaptive_target",     defaults.sampling.adaptive_target);


### PR DESCRIPTION
## Problem

Thinking models (and other models at low temperature) can enter infinite repetition loops where the same sentence or paragraph repeats endlessly. The existing `repeat_penalty` operates on token-level n-grams and cannot reliably break multi-token phrase repetition — the penalty window would need to cover the entire repeated phrase to be effective, which is impractical.

## Solution

Adds a new sampler `llama_sampler_init_repeat_line()` that tracks completed segments (delimited by configurable characters) and temporarily boosts the temperature when a repeated segment is detected, nudging the model out of the loop.

This is a port of [ollama/ollama#15212](https://github.com/ollama/ollama/pull/15212).

## New parameters

| Parameter | Type | Default | Description |
|---|---|---|---|
| `repeat_line_window` | int | 0 (disabled) | Number of past segments to track |
| `repeat_line_min_length` | int | 20 | Minimum segment length (avoids false positives from short phrases) |
| `repeat_line_delimiters` | string | `"\n.!?:"` | Characters that end a segment |
| `repeat_line_temp_boost` | float | 0.5 | Temperature boost when a loop is detected |

All parameters are exposed via the server API (`/v1/chat/completions` and `/completion`).

## Caveats

The feature works well in our Ollama deployment. The llama.cpp port is fresh — production testing in this context is still pending.