### PR TITLE
ggml-vulkan/CMakeLists: add a check for SPIRV-Headers

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -117,6 +117,12 @@ if [ ! -z ${GG_BUILD_VULKAN} ]; then
     # if on Mac, disable METAL
     if [[ "$OSTYPE" == "darwin"* ]]; then
         CMAKE_EXTRA="${CMAKE_EXTRA} -DGGML_METAL=OFF -DGGML_BLAS=OFF"
+
+        MACOS_RUNNER_CUSTOM_VULKAN_CMAKE_LOCATION="/usr/local/lib/cmake/vulkan"
+        MACOS_RUNNER_CUSTOM_SPIRV_HEADERS_LOCATION="${MACOS_RUNNER_CUSTOM_VULKAN_CMAKE_LOCATION}/SPIRV-Headers/SPIRV-HeadersConfig.cmake"
+        if [[ -f "${MACOS_RUNNER_CUSTOM_SPIRV_HEADERS_LOCATION}" || -h "${MACOS_RUNNER_CUSTOM_SPIRV_HEADERS_LOCATION}" ]]; then
+            CMAKE_EXTRA="${CMAKE_EXTRA} -DSPIRV-Headers_DIR=${MACOS_RUNNER_CUSTOM_VULKAN_CMAKE_LOCATION}/SPIRV-Headers"
+        fi
     fi
 
     # Build shared libs on Windows

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 
 find_package(Vulkan COMPONENTS glslc REQUIRED)
 
+find_package(SPIRV-Headers REQUIRED)
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Parallel build object files
     add_definitions(/MP)


### PR DESCRIPTION
## Overview

This makes the build fail at configure time instead of build time in case any of the sysroots included does not contain SPIRV-Headers. Generally it is preferred to fail as quickly as possible if a required dependency is not available.

Files related to this package are installed as part of the SPIRV-Headers project (both cmake files as well as a pkg-config file).
```
-- Installing: PREFIX/share/cmake/SPIRV-Headers/SPIRV-HeadersConfigVersion.cmake
-- Installing: PREFIX/share/cmake/SPIRV-Headers/SPIRV-HeadersConfig.cmake
-- Installing: PREFIX/share/pkgconfig/SPIRV-Headers.pc
```

I have verified this with cross-compilation from Linux to Windows as that is what I'm mostly poking at right now. I expect this to also work on Linux as at least Fedora ([spirv-headers-devel](https://koji.fedoraproject.org/koji/rpminfo?fileStart=50&rpmID=46244889&fileOrder=name&buildrootOrder=-id&buildrootStart=0#filelist)) and Ubuntu ([spirv-headers](https://packages.ubuntu.com/noble-updates/all/spirv-headers/filelist)) package these files. I tried to check whether these files are contained within the LunarG Windows Vulkan SDK package, but at least `vulkansdk-windows-X64-1.4.341.0.exe` and `vulkansdk-windows-X64-1.4.341.1.exe` only seem to contain the `Bin` directory inside and no clear extractable archives :/ .

If this check fails with the Windows Vulkan SDK (this should be check'able by the CI), then a compiler check with the exact header inclusion logic as in `ggml-vulkan.cpp` can be done instead.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: AI was **NOT** used in the context of this PR
