### PR TITLE
ci : free disk space for rocm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,6 +618,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free up disk space
+        uses: ggml-org/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+
       - name: ccache
         uses: ggml-org/ccache-action@v1.2.21
         with:


### PR DESCRIPTION
## Overview

Fix `Release` by freeing up disk space on rocm runner image.

## Additional information

Recent failures:
https://github.com/ggml-org/llama.cpp/actions/runs/24517121219/job/71664214247
https://github.com/ggml-org/llama.cpp/actions/runs/24519578715/job/71673240602

Test run:
https://github.com/CISC/llama.cpp/actions/runs/24532094214/job/71717682951

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 不用