### PR TITLE
cli : use get_media_marker

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -4,6 +4,7 @@
 #include "console.h"
 // #include "log.h"
 
+#include "server-common.h"
 #include "server-context.h"
 #include "server-task.h"
 
@@ -194,7 +195,7 @@ struct cli_context {
             raw_buffer buf;
             buf.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
             input_files.push_back(std::move(buf));
-            return mtmd_default_marker();
+            return get_media_marker();
         } else {
             std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
             return content;


### PR DESCRIPTION
## Overview

cont #21962
Fixes #22010

## Additional information

`llama-cli` still used `mtmd_default_marker` which returns the old static marker.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: không