### PR TITLE
llama-mmap: add MADV_HUGEPAGE hint for THP on Linux

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -451,6 +451,20 @@ struct llama_mmap::impl {
             throw std::runtime_error(format("mmap failed: %s", strerror(errno)));
         }
 
+#ifdef __linux__
+        // Hint the kernel to back this region with 2MB huge pages where possible.
+        // For a 1 GB model weights map this can drop the number of pages from ~262K
+        // 4KB pages to ~512 2MB pages, reducing TLB pressure and (critically)
+        // reducing the number of re-faults when pages get evicted under memory
+        // pressure. No-op if THP is not enabled / supported.
+        if (!numa) {
+            if (madvise(addr, file->size(), MADV_HUGEPAGE)) {
+                LLAMA_LOG_DEBUG("note: madvise(.., MADV_HUGEPAGE) not applied: %s\n",
+                        strerror(errno));
+            }
+        }
+#endif
+
         if (prefetch > 0) {
             if (posix_madvise(addr, std::min(file->size(), prefetch), POSIX_MADV_WILLNEED)) {
                 LLAMA_LOG_WARN("warning: posix_madvise(.., POSIX_MADV_WILLNEED) failed: %s\n",


### PR DESCRIPTION
Calls madvise(MADV_HUGEPAGE) on the read-only mmap region used for model weights on Linux.

When THP is in 'madvise' mode (the default on many desktop distros), this opts the mapping
into transparent huge page promotion. For a 4-5 GB model weight map the page count drops from
~1M 4 KB pages to ~2K 2 MB pages, which reduces TLB pressure and the number of minor faults
on the hot inference path.

No configuration required. The call is advisory: if THP is disabled
(transparent_hugepage/enabled == never) or pages cannot be promoted, madvise returns EINVAL
and a debug-level log message is emitted. NUMA-aware allocations are skipped (existing !numa
guard). Guarded by defined(MADV_HUGEPAGE) for portability.

Tested on Linux x86_64 with THP=madvise. Neutral on an unloaded machine (pages stay resident);
reduces re-fault latency spikes under memory pressure.

Complements #21821 which adds HugeTLB support; that approach requires pre-allocated pages in
the HugeTLB pool, while THP requires no system configuration.
