### PR TITLE
ggml-webgpu: reset CPU/GPU profiling time when freeing context

### DIFF
--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -607,6 +607,8 @@ static void ggml_backend_webgpu_free(ggml_backend_t backend) {
         double pct = (total_cpu > 0.0) ? (kv.second / total_cpu * 100.0) : 0.0;
         std::cout << "ggml_webgpu:  " << kv.first << ": " << kv.second << " ms (" << pct << "%)\n";
     }
+    ctx->webgpu_ctx->global_ctx->cpu_time_ms.clear();
+    ctx->webgpu_ctx->global_ctx->cpu_detail_ms.clear();
 #endif
 
 #ifdef GGML_WEBGPU_GPU_PROFILE
@@ -622,6 +624,7 @@ static void ggml_backend_webgpu_free(ggml_backend_t backend) {
         std::cout << "ggml_webgpu:  " << kv.first << ": " << kv.second << " ms (" << std::fixed << std::setprecision(2)
                   << pct << "%)\n";
     }
+    ctx->webgpu_ctx->global_ctx->shader_gpu_time_ms.clear();
 #endif
 
 #if defined(GGML_WEBGPU_CPU_PROFILE) && defined(GGML_WEBGPU_GPU_PROFILE)

--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -204,16 +204,12 @@ struct webgpu_global_context_struct {
     wgpu::Buffer    memset_params_buf;
     webgpu_pipeline memset_pipeline;
 
+    // TODO: We should rework the CPU profiling time handling to make it more useful. ref: https://github.com/ggml-org/llama.cpp/pull/22050
 #ifdef GGML_WEBGPU_CPU_PROFILE
     // Profiling: labeled CPU time in ms (total)
     std::unordered_map<std::string, double> cpu_time_ms;
     // Profiling: detailed CPU time in ms
     std::unordered_map<std::string, double> cpu_detail_ms;
-#endif
-
-#ifdef GGML_WEBGPU_GPU_PROFILE
-    // Profiling: per-shader GPU time in ms
-    std::unordered_map<std::string, double> shader_gpu_time_ms;
 #endif
 
 #ifdef GGML_WEBGPU_DEBUG
@@ -261,10 +257,12 @@ struct webgpu_context_struct {
     size_t memset_bytes_per_thread;
 
 #ifdef GGML_WEBGPU_GPU_PROFILE
-    wgpu::Buffer   profile_timestamp_dev_buf;
-    wgpu::Buffer   profile_timestamp_host_buf;
-    wgpu::QuerySet profile_timestamp_query_set;
-    uint32_t       profile_timestamp_query_count = 0;
+    // Profiling: per-shader GPU time in ms
+    std::unordered_map<std::string, double> shader_gpu_time_ms;
+    wgpu::Buffer                            profile_timestamp_dev_buf;
+    wgpu::Buffer                            profile_timestamp_host_buf;
+    wgpu::QuerySet                          profile_timestamp_query_set;
+    uint32_t                                profile_timestamp_query_count = 0;
 #endif
 
     ~webgpu_context_struct() {
@@ -607,24 +605,21 @@ static void ggml_backend_webgpu_free(ggml_backend_t backend) {
         double pct = (total_cpu > 0.0) ? (kv.second / total_cpu * 100.0) : 0.0;
         std::cout << "ggml_webgpu:  " << kv.first << ": " << kv.second << " ms (" << pct << "%)\n";
     }
-    ctx->webgpu_ctx->global_ctx->cpu_time_ms.clear();
-    ctx->webgpu_ctx->global_ctx->cpu_detail_ms.clear();
 #endif
 
 #ifdef GGML_WEBGPU_GPU_PROFILE
     std::cout << "\n[ggml_webgpu gpu profiling summary]\n";
     double total_gpu = 0.0;
-    for (const auto & kv : ctx->webgpu_ctx->global_ctx->shader_gpu_time_ms) {
+    for (const auto & kv : ctx->webgpu_ctx->shader_gpu_time_ms) {
         total_gpu += kv.second;
     }
     std::cout << "ggml_webgpu: total gpu time (all shaders): " << total_gpu << " ms\n";
     std::cout << "\nggml_webgpu: gpu breakdown:\n";
-    for (const auto & kv : ctx->webgpu_ctx->global_ctx->shader_gpu_time_ms) {
+    for (const auto & kv : ctx->webgpu_ctx->shader_gpu_time_ms) {
         double pct = (total_gpu > 0.0) ? (kv.second / total_gpu * 100.0) : 0.0;
         std::cout << "ggml_webgpu:  " << kv.first << ": " << kv.second << " ms (" << std::fixed << std::setprecision(2)
                   << pct << "%)\n";
     }
-    ctx->webgpu_ctx->global_ctx->shader_gpu_time_ms.clear();
 #endif
 
 #if defined(GGML_WEBGPU_CPU_PROFILE) && defined(GGML_WEBGPU_GPU_PROFILE)
@@ -2788,7 +2783,7 @@ static void ggml_backend_webgpu_collect_profile_results(webgpu_context &        
     for (size_t i = 0; i < pipeline_names.size(); ++i) {
         // WebGPU timestamps are in ns; convert to ms.
         const double elapsed_ms = double(ts_data[2 * i + 1] - ts_data[2 * i]) * 1e-6;
-        ctx->global_ctx->shader_gpu_time_ms[pipeline_names[i]] += elapsed_ms;
+        ctx->shader_gpu_time_ms[pipeline_names[i]] += elapsed_ms;
     }
 
     ctx->profile_timestamp_host_buf.Unmap();


### PR DESCRIPTION
## Overview

This PR fixes https://github.com/ggml-org/llama.cpp/issues/22049.

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

When I ran the command as in the above issue, the result is as follows, and we can see that the profiling times are reset for each test.

result:
```
$ llama-bench -m Llama-3.2-3B-Instruct-Q4_K_M.gguf -fa 1 -p 0,1,512 -n 0,1,128 -r 3
ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.012 sec
ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
ggml_metal_device_init: GPU name:   MTL0
ggml_metal_device_init: GPU family: MTLGPUFamilyApple8  (1008)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal4  (5002)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = false
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 26800.60 MB
ggml_webgpu: adapter_info: vendor_id: 4203 | vendor: apple | architecture: metal-3 | device_id: 0 | name: Apple M2 Pro | device_desc: Metal driver on macOS Version 26.4.1 (Build 25E253)
| model                          |       size |     params | backend    | threads | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | -: | --------------: | -------------------: |
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | MTL,WebGPU,BLAS |       8 |  1 |             pp1 |         52.06 ± 0.78 |

[ggml_webgpu cpu profiling summary]
ggml_webgpu: total cpu time: 96.3405 ms
ggml_webgpu: cpu breakdown:
ggml_webgpu:  graph_compute: 46.5671 ms (48.336%)
ggml_webgpu:  clear: 0.354792 ms (0.368269%)
ggml_webgpu:  set_tensor: 44.8501 ms (46.5537%)
ggml_webgpu:  get_tensor: 0.84225 ms (0.874243%)
ggml_webgpu:  reg_get_device: 3.72625 ms (3.86779%)

[ggml_webgpu gpu profiling summary]
ggml_webgpu: total gpu time (all shaders): 30.6045 ms

ggml_webgpu: gpu breakdown:
ggml_webgpu:  rms_norm_inplace: 0.056409 ms (0.18%)
ggml_webgpu:  get_rows_f32_vec: 0.05 ms (0.16%)
ggml_webgpu:  glu_swiglu_f32_split: 0.09 ms (0.31%)
ggml_webgpu:  flash_attn_f16_mask_kvdirect_blk_hsqk128_hsv128: 0.49 ms (1.60%)
ggml_webgpu:  flash_attn_vec_blk_qt1_kvt32_wg1024: 0.37 ms (1.22%)
ggml_webgpu:  ADD_f32_inplace: 0.18 ms (0.60%)
ggml_webgpu:  flash_attn_vec_reduce_hsv128_wg128: 0.11 ms (0.37%)
ggml_webgpu:  rope_f32_ff: 0.16 ms (0.51%)
ggml_webgpu:  set_rows_dstf16_vec4_i64idx: 0.12 ms (0.39%)
ggml_webgpu:  MUL_f32_inplace: 0.18 ms (0.60%)
ggml_webgpu:  mul_mat_f32_q4_K: 11.76 ms (38.41%)
ggml_webgpu:  mul_mat_vec_q6_K_f32: 16.70 ms (54.58%)
ggml_webgpu:  rms_norm: 0.33 ms (1.06%)
ggml_webgpu: gpu/cpu ratio: 0.32
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | MTL,WebGPU,BLAS |       8 |  1 |           pp512 |        671.49 ± 0.23 |

[ggml_webgpu cpu profiling summary]
ggml_webgpu: total cpu time: 745.93 ms
ggml_webgpu: cpu breakdown:
ggml_webgpu:  get_tensor: 0.78 ms (0.10%)
ggml_webgpu:  set_tensor: 2.65 ms (0.36%)
ggml_webgpu:  graph_compute: 742.47 ms (99.54%)
ggml_webgpu:  clear: 0.03 ms (0.00%)

[ggml_webgpu gpu profiling summary]
ggml_webgpu: total gpu time (all shaders): 711.01 ms

ggml_webgpu: gpu breakdown:
ggml_webgpu:  rms_norm_inplace: 0.05 ms (0.01%)
ggml_webgpu:  mul_mat_f32_q4_K: 1.87 ms (0.26%)
ggml_webgpu:  get_rows_f32_vec: 0.04 ms (0.01%)
ggml_webgpu:  glu_swiglu_f32_split: 2.48 ms (0.35%)
ggml_webgpu:  ADD_f32_inplace: 3.34 ms (0.47%)
ggml_webgpu:  mul_mat_vec_q6_K_f32: 13.94 ms (1.96%)
ggml_webgpu:  flash_attn_f16_mask_kvdirect_hsqk128_hsv128: 20.89 ms (2.94%)
ggml_webgpu:  mul_mat_subgroup_matrix_q6_K_f32: 212.27 ms (29.85%)
ggml_webgpu:  set_rows_dstf16_vec4_i64idx: 0.51 ms (0.07%)
ggml_webgpu:  rope_f32_ff: 1.57 ms (0.22%)
ggml_webgpu:  mul_mat_subgroup_matrix_q4_K_f32: 448.22 ms (63.04%)
ggml_webgpu:  MUL_f32_inplace: 4.15 ms (0.58%)
ggml_webgpu:  rms_norm: 1.67 ms (0.23%)
ggml_webgpu: gpu/cpu ratio: 0.95
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | MTL,WebGPU,BLAS |       8 |  1 |             tg1 |         52.21 ± 0.39 |

[ggml_webgpu cpu profiling summary]
ggml_webgpu: total cpu time: 44.51 ms
ggml_webgpu: cpu breakdown:
ggml_webgpu:  get_tensor: 0.75 ms (1.69%)
ggml_webgpu:  set_tensor: 0.05 ms (0.11%)
ggml_webgpu:  graph_compute: 43.67 ms (98.12%)
ggml_webgpu:  clear: 0.04 ms (0.08%)

[ggml_webgpu gpu profiling summary]
ggml_webgpu: total gpu time (all shaders): 29.62 ms

ggml_webgpu: gpu breakdown:
ggml_webgpu:  rms_norm_inplace: 0.05 ms (0.17%)
ggml_webgpu:  get_rows_f32_vec: 0.04 ms (0.15%)
ggml_webgpu:  glu_swiglu_f32_split: 0.08 ms (0.27%)
ggml_webgpu:  ADD_f32_inplace: 0.17 ms (0.58%)
ggml_webgpu:  flash_attn_vec_reduce_hsv128_wg128: 0.10 ms (0.35%)
ggml_webgpu:  flash_attn_f16_mask_kvdirect_blk_hsqk128_hsv128: 0.48 ms (1.61%)
ggml_webgpu:  flash_attn_vec_blk_qt1_kvt32_wg1024: 0.36 ms (1.22%)
ggml_webgpu:  mul_mat_vec_q6_K_f32: 16.04 ms (54.17%)
ggml_webgpu:  set_rows_dstf16_vec4_i64idx: 0.11 ms (0.38%)
ggml_webgpu:  rope_f32_ff: 0.16 ms (0.56%)
ggml_webgpu:  mul_mat_f32_q4_K: 11.52 ms (38.89%)
ggml_webgpu:  MUL_f32_inplace: 0.18 ms (0.60%)
ggml_webgpu:  rms_norm: 0.31 ms (1.05%)
ggml_webgpu: gpu/cpu ratio: 0.67
| llama 3B Q4_K - Medium         |   1.87 GiB |     3.21 B | MTL,WebGPU,BLAS |       8 |  1 |           tg128 |         52.44 ± 0.50 |

[ggml_webgpu cpu profiling summary]
ggml_webgpu: total cpu time: 3351.19 ms
ggml_webgpu: cpu breakdown:
ggml_webgpu:  get_tensor: 76.87 ms (2.29%)
ggml_webgpu:  set_tensor: 4.86 ms (0.14%)
ggml_webgpu:  graph_compute: 3269.41 ms (97.56%)
ggml_webgpu:  clear: 0.05 ms (0.00%)

[ggml_webgpu gpu profiling summary]
ggml_webgpu: total gpu time (all shaders): 2864.17 ms

ggml_webgpu: gpu breakdown:
ggml_webgpu:  rms_norm_inplace: 5.05 ms (0.18%)
ggml_webgpu:  get_rows_f32_vec: 4.49 ms (0.16%)
ggml_webgpu:  glu_swiglu_f32_split: 7.70 ms (0.27%)
ggml_webgpu:  ADD_f32_inplace: 17.15 ms (0.60%)
ggml_webgpu:  flash_attn_vec_reduce_hsv128_wg128: 10.42 ms (0.36%)
ggml_webgpu:  flash_attn_f16_mask_kvdirect_blk_hsqk128_hsv128: 45.25 ms (1.58%)
ggml_webgpu:  flash_attn_vec_blk_qt1_kvt32_wg1024: 35.65 ms (1.24%)
ggml_webgpu:  mul_mat_vec_q6_K_f32: 1552.61 ms (54.21%)
ggml_webgpu:  set_rows_dstf16_vec4_i64idx: 11.59 ms (0.40%)
ggml_webgpu:  rope_f32_ff: 15.99 ms (0.56%)
ggml_webgpu:  mul_mat_f32_q4_K: 1109.63 ms (38.74%)
ggml_webgpu:  MUL_f32_inplace: 18.47 ms (0.65%)
ggml_webgpu:  rms_norm: 30.16 ms (1.05%)
ggml_webgpu: gpu/cpu ratio: 0.85

build: 30dce2cf2 (8826)
```

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used AI to analyze the profiling data. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
