### PR TITLE
quant: handle shared-KV layer tensors in imatrix-dependent quantization

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -156,6 +156,22 @@ static bool category_is_attn_v(tensor_category cat) {
            cat == tensor_category::ATTENTION_KV_B;
 }
 
+// check if a tensor belongs to a shared-KV layer (layers that reuse KV cache from earlier layers)
+// in such models, layers >= n_layer_kv_from_start do not use their own attn_k/attn_v weights
+// during inference, so these tensors will never appear in the importance matrix
+static bool tensor_is_in_shared_kv_layer(const std::string & tensor_name, const llama_hparams & hparams) {
+    if (hparams.n_layer_kv_from_start < 0) {
+        return false;  // model does not use shared KV
+    }
+    static const std::regex pattern(R"(blk\.(\d+)\.)");
+    std::smatch match;
+    if (std::regex_search(tensor_name, match, pattern)) {
+        uint32_t layer_idx = std::stoi(match[1]);
+        return !hparams.has_kv(layer_idx);
+    }
+    return false;
+}
+
 //
 // quantization state
 //
@@ -413,6 +429,15 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
 
     // TODO: avoid hardcoded tensor names - use the TN_* constants
     const llm_arch arch = qs.model.arch;
+
+    // for models with shared KV layers, attn_k/attn_v weights in shared layers are unused
+    // during inference (the KV cache is reused from earlier layers). These tensors will not
+    // appear in the importance matrix, so use Q8_0 which doesn't require one.
+    if ((category == tensor_category::ATTENTION_K || category == tensor_category::ATTENTION_V) &&
+            tensor_is_in_shared_kv_layer(name, qs.model.hparams)) {
+        LLAMA_LOG_INFO("(shared-KV layer, unused at inference)\n");
+        return GGML_TYPE_Q8_0;
+    }
 
     auto use_more_bits = [](int i_layer, int n_layers) -> bool {
         return i_layer < n_layers/8 || i_layer >= 7*n_layers/8 || (i_layer - n_layers/8)%3 == 2;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -298,3 +298,6 @@ if (TARGET gguf-model-data)
     target_link_libraries(export-graph-ops PRIVATE gguf-model-data)
     target_compile_definitions(export-graph-ops PRIVATE LLAMA_HF_FETCH)
 endif()
+
+# test-shared-kv-quant-imatrix: regression test for shared-KV models + imatrix-dependent quant
+llama_build_and_test(test-shared-kv-quant-imatrix.cpp)

--- a/tests/test-shared-kv-quant-imatrix.cpp
+++ b/tests/test-shared-kv-quant-imatrix.cpp
@@ -1,0 +1,137 @@
+#include "../src/llama-ext.h"
+#include "../src/llama-model.h"
+#include "ggml-cpp.h"
+#include "llama.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// Regression test for shared-KV models + imatrix-dependent quantization.
+// Models with shared KV layers (where layers >= n_layer_kv_from_start reuse
+// KV cache from earlier layers) have attn_k/attn_v tensors that are unused
+// at inference. The imatrix collector never records data for them, so
+// quantization types that require an imatrix must fall back gracefully.
+
+int main() {
+    printf("test-shared-kv-quant-imatrix: Starting\n");
+
+    // Create a mock model with shared KV layers
+    llama_quant_model_desc desc = {};
+    desc.architecture  = "llama";
+    desc.n_embd        = 2048;
+    desc.n_embd_head_k = 128;
+    desc.n_embd_head_v = 128;
+    desc.n_layer       = 24;
+    desc.n_head        = 16;
+    desc.n_head_kv     = 2;
+    desc.n_ff          = 8192;
+    desc.n_expert      = 0;
+
+    llama_model * model = llama_quant_model_from_metadata(&desc);
+    if (!model) {
+        fprintf(stderr, "FAIL: llama_quant_model_from_metadata returned nullptr\n");
+        return 1;
+    }
+
+    // Simulate shared KV: first 12 layers have KV, layers 12-23 share
+    model->hparams.n_layer_kv_from_start = 12;
+
+    printf("  Model: n_layer=%u, n_layer_kv_from_start=12\n", desc.n_layer);
+
+    // Use an imatrix-dependent quantization type, with no imatrix provided
+    llama_model_quantize_params qparams = llama_model_quantize_default_params();
+    qparams.ftype                  = LLAMA_FTYPE_MOSTLY_IQ2_M;
+    qparams.allow_requantize       = false;
+    qparams.quantize_output_tensor = true;
+    qparams.only_copy              = false;
+    qparams.pure                   = false;
+    qparams.imatrix                = nullptr;  // no imatrix — this is the key scenario
+
+    quantize_state_impl * qs = llama_quant_init(model, &qparams);
+    if (!qs) {
+        fprintf(stderr, "FAIL: llama_quant_init returned nullptr\n");
+        llama_model_free(model);
+        return 1;
+    }
+
+    struct mock_tensor_data {
+        std::string name;
+        int64_t     ne[4];
+    };
+
+    std::vector<mock_tensor_data> tensor_specs = {
+        { "blk.5.attn_k.weight",  { 2048, 256, 1, 1 } },  // non-shared layer
+        { "blk.5.attn_v.weight",  { 2048, 256, 1, 1 } },  // non-shared layer
+        { "blk.15.attn_k.weight", { 2048, 256, 1, 1 } },  // shared-KV layer
+        { "blk.15.attn_v.weight", { 2048, 256, 1, 1 } },  // shared-KV layer
+        { "blk.22.attn_k.weight", { 2048, 256, 1, 1 } },  // shared-KV layer
+    };
+
+    std::vector<ggml_tensor*> tensors;
+    std::vector<ggml_type>    result_types;
+    tensors.reserve(tensor_specs.size());
+    result_types.resize(tensor_specs.size());
+
+    ggml_init_params params = {
+        .mem_size   = 1024 * 1024 * 10,
+        .mem_buffer = nullptr,
+        .no_alloc   = true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        fprintf(stderr, "FAIL: ggml_init failed\n");
+        llama_quant_free(qs);
+        llama_model_free(model);
+        return 1;
+    }
+
+    for (const auto & spec : tensor_specs) {
+        ggml_tensor * t = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, spec.ne[0], spec.ne[1], spec.ne[2], spec.ne[3]);
+        ggml_set_name(t, spec.name.c_str());
+        tensors.push_back(t);
+    }
+
+    // This should not crash — shared-KV tensors should get Q8_0 fallback
+    llama_quant_compute_types(qs, qparams.ftype, tensors.data(), result_types.data(), tensors.size());
+
+    printf("  Results:\n");
+    bool all_ok = true;
+
+    for (size_t i = 0; i < tensors.size(); i++) {
+        const char * name = ggml_get_name(tensors[i]);
+        printf("    %-30s -> %s\n", name, ggml_type_name(result_types[i]));
+
+        int layer = -1;
+        sscanf(name, "blk.%d.", &layer);
+
+        if (layer >= 12) {
+            // shared-KV layer: must get Q8_0 fallback (no imatrix needed)
+            if (result_types[i] != GGML_TYPE_Q8_0) {
+                fprintf(stderr, "FAIL: Expected Q8_0 for %s (shared-KV, unused at inference), got %s\n",
+                        name, ggml_type_name(result_types[i]));
+                all_ok = false;
+            }
+        } else {
+            // non-shared layer: should get a real quantization type
+            if (result_types[i] == GGML_TYPE_F16 || result_types[i] == GGML_TYPE_COUNT) {
+                fprintf(stderr, "FAIL: Unexpected type %s for %s (non-shared layer)\n",
+                        ggml_type_name(result_types[i]), name);
+                all_ok = false;
+            }
+        }
+    }
+
+    ggml_free(ctx);
+    llama_quant_free(qs);
+    llama_model_free(model);
+
+    if (all_ok) {
+        printf("PASS: test-shared-kv-quant-imatrix\n");
+        return 0;
+    } else {
+        fprintf(stderr, "FAIL: test-shared-kv-quant-imatrix\n");
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Models with shared KV layers reuse KV cache from earlier layers for layers
>= `n_layer_kv_from_start`. The `attn_k`/`attn_v` weight tensors for these shared
layers may exist in the GGUF but are never used during inference — which means the
imatrix collector never records importance data for them.

When quantizing such a GGUF to any type that requires an imatrix (IQ1_S, IQ1_M,
IQ2_XXS, IQ2_XS, IQ2_S, IQ2_M, IQ3_XXS, Q2_K_S), the quantizer crashes:

```
Missing importance matrix for tensor blk.N.attn_k.weight in a very low-bit quantization
```

This PR teaches the quantizer to detect shared-KV layer attention tensors using the
existing `hparams.has_kv()` method and assign them Q8_0, which does not require imatrix
data. Since these weights are unused at inference, the quantization type has zero impact
on model quality.

## Relationship to #21739

PR #21739 addressed the **loading** side — making shared-KV tensors optional so llama.cpp
can load newer GGUFs where converters omit them entirely. This PR addresses the
**quantization** side — handling the case where the tensors *are* present (older GGUFs,
alternative converters, re-quantizing existing F16 files).

Both fixes are complementary:

| Scenario | #21739 (load) | This PR (quant) |
|---|---|---|
| GGUF with tensors omitted | Needed | Not triggered |
| GGUF with tensors present | Not triggered | Needed |

## Changes

- `src/llama-quant.cpp`: Add `tensor_is_in_shared_kv_layer()` helper and early return
  in `llama_tensor_get_type_impl()` — assigns Q8_0 to shared-KV attention tensors,
  with an early guard on `n_layer_kv_from_start < 0` so non-shared-KV models are unaffected
- `tests/test-shared-kv-quant-imatrix.cpp`: Regression test with a mock shared-KV model
- `tests/CMakeLists.txt`: Register the new test

## Test plan

- [ ] `cmake --build build && ctest --test-dir build -R shared-kv-quant` passes
- [ ] Quantize a shared-KV model GGUF (with tensors present) to IQ2_M without imatrix —
      should succeed with Q8_0 for shared layers instead of crashing
- [ ] Quantize a non-shared-KV model — no behavior change

## Acknowledgement

Claude Code running Opus 4.6 assisted in writing this PR.