### PR TITLE
spec : save the dynamic ngram cache file

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1984,9 +1984,6 @@ struct common_speculative_impl_ngram_cache : public common_speculative_impl {
 
     uint16_t n_draft;
 
-    bool save_dynamic;
-    bool save_static;
-
     struct seq_info {
         size_t cache_size = 0; // number of tokens in n-gram cache
 
@@ -2002,14 +1999,10 @@ struct common_speculative_impl_ngram_cache : public common_speculative_impl {
             uint32_t n_seq,
             uint16_t n_draft,
             const std::string & path_static,
-            const std::string & path_dynamic,
-            bool save_dynamic,
-            bool save_static)
+            const std::string & path_dynamic)
         : common_speculative_impl(COMMON_SPECULATIVE_TYPE_NGRAM_CACHE, n_seq)
         , params(params.ngram_cache)
         , n_draft(n_draft)
-        , save_dynamic(save_dynamic)
-        , save_static(save_static)
     {
         SPC_TRC("%s", "adding speculative implementation 'ngram-cache'\n");
         SPC_TRC("- n_draft=%d, cache_static=%s, cache_dynamic=%s\n",
@@ -2041,9 +2034,21 @@ struct common_speculative_impl_ngram_cache : public common_speculative_impl {
                 }
             } catch (...) {
                 SPC_ERR("failed to open dynamic lookup cache: %s", path_dynamic.c_str());
-                GGML_ABORT("Couldn't read dynamic lookup cache");
             }
         }
+    }
+
+    ~common_speculative_impl_ngram_cache() override {
+        if (params.lookup_cache_dynamic.empty() || sinfos.empty()) {
+            return;
+        }
+
+        auto & dynamic_cache = sinfos.front().ngram_cache_dynamic;
+        for (auto & sinfo : sinfos) {
+            common_ngram_cache_merge(dynamic_cache, sinfo.ngram_cache_context);
+        }
+
+        common_ngram_cache_save(dynamic_cache, params.lookup_cache_dynamic);
     }
 
     void begin(llama_seq_id /*seq_id*/, const llama_tokens & /*prompt*/) override {
@@ -2143,20 +2148,14 @@ static common_ngram_map get_common_ngram_map(
     return common_ngram_map(size_key, size_value, key_only, min_hits);
 }
 
-static common_speculative_impl_ngram_cache create_state_ngram_cache(
+static std::unique_ptr<common_speculative_impl_ngram_cache> create_state_ngram_cache(
         const common_speculative_config & config,
         uint32_t n_seq,
         const std::string & path_static,
         const std::string & path_dynamic) {
     uint16_t n_draft = 8; // TODO get from config?
 
-    // TODO bool param in common/common.h to set save_static/save_dynamic?
-    bool save_static = false;
-    bool save_dynamic = false;
-
-    common_speculative_impl_ngram_cache state(config.params, n_seq, n_draft, path_static, path_dynamic, save_static, save_dynamic);
-
-    return state;
+    return std::make_unique<common_speculative_impl_ngram_cache>(config.params, n_seq, n_draft, path_static, path_dynamic);
 }
 
 std::string common_speculative_type_name_str(const std::vector<common_speculative_type> & types) {
@@ -2476,7 +2475,7 @@ common_speculative * common_speculative_init(common_params_speculative & params,
                         config, n_seq,
                         params.ngram_cache.lookup_cache_static,
                         params.ngram_cache.lookup_cache_dynamic);
-                impls.push_back(std::make_unique<common_speculative_impl_ngram_cache>(state));
+                impls.push_back(std::move(state));
                 break;
             }
             default:


### PR DESCRIPTION
## Overview

* When we select the `COMMON_SPECULATIVE_TYPE_NGRAM_CACHE` speculative implementation we create a new `common_speculative_state_ngram_cache` state using `create_state_ngram_cache`, where we instantiate the new state by specifying various parameters (e.g, `n_draft`, `save_static` and `save_dynamic`) by hardcoding them. 

* Instead we remove those options and only depend on the existence of lookup_cache_dynamic and lookup_cache_static (both user provided) for enabling the saving and updating the dynamic cache into a file.

* on object destruction check if the above functionality is supported (i.e. if the lookup_cache_dynamic path is provided by the user) then merge all of the ngram_cache_context from each sequence info and save the final common_ngram_cache to a file using common_ngram_cache_save.

* catch std::ifstream::failure the way llama-lookup does, so a permission/read failure cannot replace the file

## Additional information

Add self‑speculative decoding (no draft model required)#18471

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
