### PR TITLE
GGML: Allow static build with dynamic loaded backends

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -185,10 +185,6 @@ endif()
 
 # ggml
 
-if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
-    message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
-endif()
-
 add_library(ggml-base
             ../include/ggml.h
             ../include/ggml-alloc.h
@@ -216,6 +212,9 @@ set_target_properties(ggml-base PROPERTIES
 target_include_directories(ggml-base PRIVATE .)
 if (GGML_BACKEND_DL)
     target_compile_definitions(ggml-base PUBLIC GGML_BACKEND_DL)
+    # When using dynamic backends, ggml-base needs to be compiled with -fPIC
+    # even if it's a static library, because backends will link against it
+    set_target_properties(ggml-base PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if (GGML_SCHED_NO_REALLOC)


### PR DESCRIPTION
## Overview

This PR removes a restriction from the GGML build system. Previously, static builds (`BUILD_SHARED_LIBS=OFF`) could not use `GGML_BACKEND_DL=ON`. Now they can--the result is a static base library (e.g. for statically-linked applications) which dynamically finds & loads backends at runtime.

## Additional information

This change is motivated by a rust wrapper I am working on for a GGML-based model, where the standard in rust applications is generally to keep things statically linked if possible (and GGML lends itself well to static linkage.)

I have tested that the build succeeds with `BUILD_SHARED_LIBS=OFF` and `GGML_BACKEND_DL=ON` and correctly links with my rust program and runs.

# Requirements

- [X] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [X] AI usage disclosure: YES, I am a human but this change was suggested by Claude code. However it is very short and I understand every line.