### PR TITLE
Extend LoRA hotswapping support

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1402,6 +1402,10 @@ void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adap
     std::vector<float> scales;
 
     for (auto & la: lora) {
+        // skip unloaded adapters (null ptr)
+        if (la.ptr == nullptr) {
+            continue;
+        }
         loras.push_back(la.ptr);
         scales.push_back(la.scale);
     }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1097,6 +1097,11 @@ private:
     std::vector<common_adapter_lora_info> construct_lora_list(const std::map<int, float> & config) const {
         std::vector<common_adapter_lora_info> output = params_base.lora_adapters; // copy
         for (size_t i = 0; i < output.size(); ++i) {
+            // unloaded adapters (null ptr) must stay at scale 0
+            if (output[i].ptr == nullptr) {
+                output[i].scale = 0.0f;
+                continue;
+            }
             auto it = config.find(i);
             if (it != config.end()) {
                 output[i].scale = it->second;
@@ -1983,6 +1988,116 @@ private:
                     params_base.lora_adapters = new_loras;
                     auto res = std::make_unique<server_task_result_apply_lora>();
                     res->id = task.id;
+                    queue_results.send(std::move(res));
+                } break;
+            case SERVER_TASK_TYPE_LOAD_LORA:
+                {
+                    const std::string & path = task.load_lora.path;
+
+                    SRV_INF("loading lora adapter '%s'\n", path.c_str());
+
+                    llama_adapter_lora * adapter = llama_adapter_lora_init(model, path.c_str());
+                    if (!adapter) {
+                        send_error(task, "failed to load lora adapter: " + path);
+                        break;
+                    }
+
+                    // extract metadata
+                    char buf[1024] = {0};
+                    common_adapter_lora_info info;
+                    info.path  = path;
+                    info.scale = task.load_lora.scale;
+                    info.ptr   = adapter;
+
+                    if (llama_adapter_meta_val_str(adapter, "adapter.lora.task_name", buf, sizeof(buf)) >= 0) {
+                        info.task_name = buf;
+                    }
+                    buf[0] = '\0';
+                    if (llama_adapter_meta_val_str(adapter, "adapter.lora.prompt_prefix", buf, sizeof(buf)) >= 0) {
+                        info.prompt_prefix = buf;
+                    }
+
+                    // transfer ownership to keep adapter alive
+                    llama_adapter_lora_ptr ptr(adapter);
+
+                    // reuse first null slot, or append
+                    int32_t id_new = -1;
+                    for (int32_t i = 0; i < (int32_t) params_base.lora_adapters.size(); ++i) {
+                        if (params_base.lora_adapters[i].ptr == nullptr) {
+                            id_new = i;
+                            break;
+                        }
+                    }
+
+                    if (id_new >= 0) {
+                        params_base.lora_adapters[id_new] = info;
+
+                        // find and replace the null ownership entry
+                        auto & lora_ptrs = llama_init->lora();
+                        bool replaced = false;
+                        for (auto & lp : lora_ptrs) {
+                            if (lp == nullptr) {
+                                lp = std::move(ptr);
+                                replaced = true;
+                                break;
+                            }
+                        }
+                        if (!replaced) {
+                            lora_ptrs.emplace_back(std::move(ptr));
+                        }
+                    } else {
+                        id_new = (int32_t) params_base.lora_adapters.size();
+                        params_base.lora_adapters.push_back(info);
+                        llama_init->lora().emplace_back(std::move(ptr));
+                    }
+
+                    SRV_INF("loaded lora adapter idx=%d path='%s' scale=%f\n", id_new, path.c_str(), info.scale);
+
+                    auto res = std::make_unique<server_task_result_load_lora>();
+                    res->id      = task.id;
+                    res->id_lora = id_new;
+                    res->path    = path;
+                    res->scale   = info.scale;
+                    queue_results.send(std::move(res));
+                } break;
+            case SERVER_TASK_TYPE_UNLOAD_LORA:
+                {
+                    int32_t id_lora = task.unload_lora_id;
+                    auto & loras = params_base.lora_adapters;
+
+                    if (id_lora < 0 || id_lora >= (int32_t) loras.size() || loras[id_lora].ptr == nullptr) {
+                        send_error(task, "invalid or already unloaded lora adapter id: " + std::to_string(id_lora), ERROR_TYPE_NOT_FOUND);
+                        break;
+                    }
+
+                    llama_adapter_lora * adapter = loras[id_lora].ptr;
+
+                    SRV_INF("unloading lora adapter idx=%d path='%s'\n", id_lora, loras[id_lora].path.c_str());
+
+                    // deactivate on all slots
+                    for (auto & slot : slots) {
+                        if (id_lora < (int32_t) slot.lora.size()) {
+                            slot.lora[id_lora].ptr   = nullptr;
+                            slot.lora[id_lora].scale = 0.0f;
+                        }
+                    }
+
+                    // null out the registry entry (don't erase, keeps IDs stable)
+                    loras[id_lora].ptr   = nullptr;
+                    loras[id_lora].scale = 0.0f;
+
+                    // release ownership, which calls llama_adapter_lora_free
+                    auto & lora_ptrs = llama_init->lora();
+                    for (auto & lp : lora_ptrs) {
+                        if (lp.get() == adapter) {
+                            lp.reset();
+                            break;
+                        }
+                    }
+
+                    auto res = std::make_unique<server_task_result_unload_lora>();
+                    res->id      = task.id;
+                    res->id_lora = id_lora;
                     queue_results.send(std::move(res));
                 } break;
         }
@@ -4066,6 +4181,73 @@ void server_routes::init_routes() {
         }
 
         GGML_ASSERT(dynamic_cast<server_task_result_apply_lora*>(result.get()) != nullptr);
+        res->ok(result->to_json());
+        return res;
+    };
+
+    this->post_lora_adapters_load = [this](const server_http_req & req) {
+        auto res = create_response();
+        const json body = json::parse(req.body);
+
+        if (!body.contains("path") || !body.at("path").is_string()) {
+            res->error(format_error_response("\"path\" is required and must be a string", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+
+        auto & rd = res->rd;
+        {
+            server_task task(SERVER_TASK_TYPE_LOAD_LORA);
+            task.id              = rd.get_new_id();
+            task.load_lora.path  = body.at("path").get<std::string>();
+            task.load_lora.scale = json_value(body, "scale", 1.0f);
+            rd.post_task(std::move(task));
+        }
+
+        auto result = rd.next(req.should_stop);
+        if (!result) {
+            GGML_ASSERT(req.should_stop());
+            return res;
+        }
+
+        if (result->is_error()) {
+            res->error(result->to_json());
+            return res;
+        }
+
+        GGML_ASSERT(dynamic_cast<server_task_result_load_lora*>(result.get()) != nullptr);
+        res->ok(result->to_json());
+        return res;
+    };
+
+    this->post_lora_adapters_unload = [this](const server_http_req & req) {
+        auto res = create_response();
+        const json body = json::parse(req.body);
+
+        if (!body.contains("id") || !body.at("id").is_number_integer()) {
+            res->error(format_error_response("\"id\" is required and must be an integer", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+
+        auto & rd = res->rd;
+        {
+            server_task task(SERVER_TASK_TYPE_UNLOAD_LORA);
+            task.id              = rd.get_new_id();
+            task.unload_lora_id  = body.at("id").get<int32_t>();
+            rd.post_task(std::move(task));
+        }
+
+        auto result = rd.next(req.should_stop);
+        if (!result) {
+            GGML_ASSERT(req.should_stop());
+            return res;
+        }
+
+        if (result->is_error()) {
+            res->error(result->to_json());
+            return res;
+        }
+
+        GGML_ASSERT(dynamic_cast<server_task_result_unload_lora*>(result.get()) != nullptr);
         res->ok(result->to_json());
         return res;
     };

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -123,6 +123,8 @@ struct server_routes {
     server_http_context::handler_t post_rerank;
     server_http_context::handler_t get_lora_adapters;
     server_http_context::handler_t post_lora_adapters;
+    server_http_context::handler_t post_lora_adapters_load;
+    server_http_context::handler_t post_lora_adapters_unload;
 private:
     std::unique_ptr<server_res_generator> handle_completions_impl(
             const server_http_req & req,

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1963,6 +1963,29 @@ json server_task_result_apply_lora::to_json() {
 }
 
 //
+// server_task_result_load_lora
+//
+
+json server_task_result_load_lora::to_json() {
+    return json {
+        { "id",    id_lora },
+        { "path",  path },
+        { "scale", scale },
+    };
+}
+
+//
+// server_task_result_unload_lora
+//
+
+json server_task_result_unload_lora::to_json() {
+    return json {
+        { "id",      id_lora },
+        { "success", true },
+    };
+}
+
+//
 // server_prompt_cache
 //
 size_t server_prompt_cache::size() const {

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -26,6 +26,8 @@ enum server_task_type {
     SERVER_TASK_TYPE_SLOT_ERASE,
     SERVER_TASK_TYPE_GET_LORA,
     SERVER_TASK_TYPE_SET_LORA,
+    SERVER_TASK_TYPE_LOAD_LORA,
+    SERVER_TASK_TYPE_UNLOAD_LORA,
 };
 
 // TODO: change this to more generic "response_format" to replace the "format_response_*" in server-common
@@ -167,6 +169,16 @@ struct server_task {
 
     // used by SERVER_TASK_TYPE_SET_LORA
     std::map<int, float> set_lora; // mapping adapter ID -> scale
+
+    // used by SERVER_TASK_TYPE_LOAD_LORA
+    struct load_lora {
+        std::string path;
+        float       scale = 1.0f;
+    };
+    load_lora load_lora;
+
+    // used by SERVER_TASK_TYPE_UNLOAD_LORA
+    int32_t unload_lora_id = -1;
 
     server_task() = default;
 
@@ -562,6 +574,20 @@ struct server_task_result_get_lora : server_task_result {
 };
 
 struct server_task_result_apply_lora : server_task_result {
+    virtual json to_json() override;
+};
+
+struct server_task_result_load_lora : server_task_result {
+    int32_t     id_lora;
+    std::string path;
+    float       scale;
+
+    virtual json to_json() override;
+};
+
+struct server_task_result_unload_lora : server_task_result {
+    int32_t id_lora;
+
     virtual json to_json() override;
 };
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -201,9 +201,13 @@ int main(int argc, char ** argv) {
     ctx_http.post("/tokenize",                 ex_wrapper(routes.post_tokenize));
     ctx_http.post("/detokenize",               ex_wrapper(routes.post_detokenize));
     ctx_http.post("/apply-template",           ex_wrapper(routes.post_apply_template));
+ 
     // LoRA adapters hotswap
-    ctx_http.get ("/lora-adapters",            ex_wrapper(routes.get_lora_adapters));
-    ctx_http.post("/lora-adapters",            ex_wrapper(routes.post_lora_adapters));
+    ctx_http.get ("/lora-adapters",        ex_wrapper(routes.get_lora_adapters));
+    ctx_http.post("/lora-adapters",        ex_wrapper(routes.post_lora_adapters));
+    ctx_http.post("/lora-adapters/load",   ex_wrapper(routes.post_lora_adapters_load));
+    ctx_http.post("/lora-adapters/unload", ex_wrapper(routes.post_lora_adapters_unload));
+
     // Save & load slots
     ctx_http.get ("/slots",                    ex_wrapper(routes.get_slots));
     ctx_http.post("/slots/:id_slot",           ex_wrapper(routes.post_slots));

--- a/tools/server/tests/unit/test_lora_hotload.py
+++ b/tools/server/tests/unit/test_lora_hotload.py
@@ -1,0 +1,220 @@
+import os
+import pytest
+from utils import *
+
+server = ServerPreset.stories15m_moe()
+
+
+# override the module-level fixture that tries to download all models
+@pytest.fixture(scope="module", autouse=True)
+def do_something():
+    pass
+
+LORA_FILE_URL = "https://huggingface.co/ggml-org/stories15M_MOE/resolve/main/moe_shakespeare15M.gguf"
+MODEL_FILE_URL = "https://huggingface.co/ggml-org/stories15M_MOE/resolve/main/stories15M_MOE-F16.gguf"
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.stories15m_moe()
+    # use local model file to avoid requiring HTTPS support in the server
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    server.model_file = get_model_path()
+    server.offline = False
+
+
+def get_model_path():
+    return os.path.abspath(download_file(MODEL_FILE_URL))
+
+
+def get_lora_path():
+    return os.path.abspath(download_file(LORA_FILE_URL))
+
+
+def test_lora_hotload_and_activate():
+    """Load a lora at runtime, activate it, and verify it changes model behavior."""
+    global server
+    server.start()
+
+    # no adapters loaded initially
+    res = server.make_request("GET", "/lora-adapters")
+    assert res.status_code == 200
+    assert len(res.body) == 0
+
+    # load lora at runtime
+    res = server.make_request("POST", "/lora-adapters/load", data={
+        "path": get_lora_path(),
+        "scale": 1.0,
+    })
+    assert res.status_code == 200
+    assert res.body["id"] == 0
+    assert res.body["scale"] == 1.0
+
+    # verify it appears in the adapter list
+    res = server.make_request("GET", "/lora-adapters")
+    assert res.status_code == 200
+    assert len(res.body) == 1
+    assert res.body[0]["id"] == 0
+
+    # activate and generate, should produce shakespeare-like text
+    res = server.make_request("POST", "/lora-adapters", data=[
+        {"id": 0, "scale": 1.0}
+    ])
+    assert res.status_code == 200
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "Look in thy glass",
+    })
+    assert res.status_code == 200
+    assert match_regex("(eye|love|glass|sun)+", res.body["content"])
+
+
+def test_lora_hotload_scale_zero():
+    """Load a lora but keep scale at 0, model should behave normally."""
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/lora-adapters/load", data={
+        "path": get_lora_path(),
+        "scale": 0.0,
+    })
+    assert res.status_code == 200
+
+    # with scale 0, should produce normal bedtime story text
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "Look in thy glass",
+    })
+    assert res.status_code == 200
+    assert match_regex("(little|girl|three|years|old)+", res.body["content"])
+
+
+def test_lora_hotload_unload():
+    """Load a lora, verify it works, unload it, verify it's gone."""
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/lora-adapters/load", data={
+        "path": get_lora_path(),
+    })
+    assert res.status_code == 200
+    lora_id = res.body["id"]
+
+    # activate it
+    res = server.make_request("POST", "/lora-adapters", data=[
+        {"id": lora_id, "scale": 1.0}
+    ])
+    assert res.status_code == 200
+
+    # unload it
+    res = server.make_request("POST", "/lora-adapters/unload", data={
+        "id": lora_id,
+    })
+    assert res.status_code == 200
+    assert res.body["success"] == True
+
+    # adapter list should show it as unloaded (ptr null, scale 0)
+    res = server.make_request("GET", "/lora-adapters")
+    assert res.status_code == 200
+    assert res.body[0]["scale"] == 0.0
+
+    # generation should revert to normal
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "Look in thy glass",
+    })
+    assert res.status_code == 200
+    assert match_regex("(little|girl|three|years|old)+", res.body["content"])
+
+
+def test_lora_hotload_multiple():
+    """Load the same lora twice, verify both get unique IDs."""
+    global server
+    server.start()
+
+    res1 = server.make_request("POST", "/lora-adapters/load", data={
+        "path": get_lora_path(),
+    })
+    assert res1.status_code == 200
+    assert res1.body["id"] == 0
+
+    res2 = server.make_request("POST", "/lora-adapters/load", data={
+        "path": get_lora_path(),
+    })
+    assert res2.status_code == 200
+    assert res2.body["id"] == 1
+
+    # both should appear in the list
+    res = server.make_request("GET", "/lora-adapters")
+    assert res.status_code == 200
+    assert len(res.body) == 2
+
+
+def test_lora_hotload_invalid_path():
+    """Loading a nonexistent file should return an error."""
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/lora-adapters/load", data={
+        "path": "/nonexistent/path/fake.gguf",
+    })
+    assert res.status_code != 200
+
+
+def test_lora_hotload_missing_path():
+    """Missing path field should return 400."""
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/lora-adapters/load", data={
+        "scale": 1.0,
+    })
+    assert res.status_code != 200
+
+
+def test_lora_unload_invalid_id():
+    """Unloading a nonexistent ID should return an error."""
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/lora-adapters/unload", data={
+        "id": 999,
+    })
+    assert res.status_code != 200
+
+
+def test_lora_hotload_per_request():
+    """Load lora at runtime, then use per-request scale control."""
+    global server
+    server.n_slots = 2
+    server.start()
+
+    res = server.make_request("POST", "/lora-adapters/load", data={
+        "path": get_lora_path(),
+    })
+    assert res.status_code == 200
+    lora_id = res.body["id"]
+
+    # parallel requests: one with lora, one without
+    tasks = [
+        (server.make_request, ("POST", "/completion", {
+            "prompt": "Look in thy glass",
+            "lora": [{"id": lora_id, "scale": 0.0}],
+            "seed": 42,
+            "temperature": 0.0,
+            "cache_prompt": False,
+        })),
+        (server.make_request, ("POST", "/completion", {
+            "prompt": "Look in thy glass",
+            "lora": [{"id": lora_id, "scale": 1.0}],
+            "seed": 42,
+            "temperature": 0.0,
+            "cache_prompt": False,
+        })),
+    ]
+    results = parallel_function_calls(tasks)
+
+    assert all([res.status_code == 200 for res in results])
+    # scale 0 should be bedtime story
+    assert match_regex("(little|girl|three|years|old)+", results[0].body["content"])
+    # scale 1 should be shakespeare
+    assert match_regex("(eye|love|glass|sun)+", results[1].body["content"])


### PR DESCRIPTION
## Overview

This PR adds the ability to load and unload LoRAs during runtime and not just on initialization while managing the lifecycle  of the loaded LoRAs. This extends the existing hot swap support to not only adjust weights, but to load/unload LoRAs without restarting.

## Additional information

By adding 2 new endpoints for load/unload in addition to the existing list/adjust weights endpoints, we can effectively allow the LLM itself or external tooling to identify and load/unload appropriate LoRAs at inference time, allowing hardware constrained models to support JIT expertise among other uses.

Technically the API should be DELETE and POST methods on `/lora-adapters` and move the existing `post_lora_adapters` to PUT/PATCH, but to maintain compatibility and existing methods, I added load/unload POST commands which match the existing API.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - For some test coverage and to find/fix a nullptr and scale issue.
