### PR TITLE
server: always include usage in streaming responses

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -897,19 +897,17 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat_stream() {
         {"object",             "chat.completion.chunk"},
     });
 
-    if (include_usage) {
-        // OpenAI API spec for chat.completion.chunks specifies an empty `choices` array for the last chunk when including usage
-        // https://platform.openai.com/docs/api-reference/chat_streaming/streaming#chat_streaming/streaming-choices
-        deltas.push_back({
-            {"choices", json::array()},
-            {"created",            t},
-            {"id",                 oaicompat_cmpl_id},
-            {"model",              oaicompat_model},
-            {"system_fingerprint", std::string(llama_build_info())},
-            {"object",             "chat.completion.chunk"},
-            {"usage",              usage_json_oaicompat()},
-        });
-    }
+    // Always include usage in the final chunk (per OpenAI spec, empty choices array for usage-only chunk)
+    // https://platform.openai.com/docs/api-reference/chat_streaming/streaming#chat_streaming/streaming-choices
+    deltas.push_back({
+        {"choices", json::array()},
+        {"created",            t},
+        {"id",                 oaicompat_cmpl_id},
+        {"model",              oaicompat_model},
+        {"system_fingerprint", std::string(llama_build_info())},
+        {"object",             "chat.completion.chunk"},
+        {"usage",              usage_json_oaicompat()},
+    });
 
     if (timings.prompt_n >= 0) {
         deltas.back().push_back({"timings", timings.to_json()});
@@ -1486,6 +1484,9 @@ json server_task_result_cmpl_partial::to_json_oaicompat() {
         res.push_back({"prompt_progress", progress.to_json()});
     }
 
+    // Always include usage for OpenAI-compatible clients
+    res.push_back({"usage", usage_json_oaicompat()});
+
     return res;
 }
 
@@ -1539,6 +1540,9 @@ json server_task_result_cmpl_partial::to_json_oaicompat_chat() {
         if (is_progress) {
             last_json.push_back({"prompt_progress", progress.to_json()});
         }
+
+        // Always include usage for OpenAI-compatible clients
+        last_json.push_back({"usage", usage_json_oaicompat()});
     }
 
     return deltas;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -463,6 +463,16 @@ struct server_task_result_cmpl_partial : server_task_result {
     json to_json_oaicompat_asr();
 
     json to_json_anthropic();
+
+    // Usage helper for OpenAI-compatible usage object
+    json usage_json_oaicompat() const {
+        return json {
+            {"completion_tokens", n_decoded},
+            {"prompt_tokens",     n_prompt_tokens},
+            {"total_tokens",      n_decoded + n_prompt_tokens},
+            {"prompt_tokens_details", json { {"cached_tokens", n_prompt_tokens_cache} }},
+        };
+    }
 };
 
 struct server_task_result_embd : server_task_result {


### PR DESCRIPTION
## Summary

Always include standard OpenAI-compatible `usage` objects in all streaming SSE chunks, not just gated behind the `include_usage` request parameter.

Previously, the final streaming chunk's usage object was only sent when clients explicitly passed `include_usage=true`. Most clients (including OpenClaw) don't send this parameter, resulting in zero token counts — which breaks autocompaction and usage tracking.

Per the [OpenAI API spec](https://platform.openai.com/docs/api-reference/chat_streaming/streaming#chat_streaming/streaming-choices), usage can be included in any streaming chunk.

## Changes

- **`server-task.h`**: Added `usage_json_oaicompat()` helper to `server_task_result_cmpl_partial` (was only on `cmpl_final`)
- **`server-task.cpp`**: Removed `include_usage` gate on final streaming chunk — always include usage with empty choices array
- **`server-task.cpp`**: Added `usage` to intermediate text completion chunks (`to_json_oaicompat`)
- **`server-task.cpp`**: Added `usage` to intermediate chat completion chunks (`to_json_oaicompat_chat`)

## Usage object format

```json
{
  "completion_tokens": 123,
  "prompt_tokens": 45,
  "total_tokens": 168,
  "prompt_tokens_details": {
    "cached_tokens": 30
  }
}
```

This matches the standard OpenAI API format and is parseable by clients like OpenClaw that expect these field names for token counting and autocompaction.