### PR TITLE
fix(chat): graceful degradation for malformed tool call arguments

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2190,7 +2190,7 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
+                            LOG_WRN("Failed to parse tool call arguments as JSON, keeping as string: %s\n", e.what());
                         }
                     }
                 }
@@ -2198,7 +2198,6 @@ static void func_args_not_string(json & messages) {
         }
     }
 }
-
 }
 
 static json common_chat_extra_context() {


### PR DESCRIPTION
## Problem

When models generate malformed JSON in tool call arguments (e.g., unescaped single quotes like `log_dir = '/home/huckstack/.hermes/logs/cron'`), `func_args_not_string()` throws an HTTP 500 error. This causes cascading failures where every subsequent request crashes with `Failed to parse tool call arguments as JSON: unexpected end of input`.

The function was introduced in commit b283f6d5b with `throw`, which converts a recoverable parsing error into a hard server error.

## Fix

Replace `throw std::runtime_error(...)` with `LOG_WRN(...)` in `func_args_not_string()`. This converts the hard 500 error into a graceful degradation — the server logs a warning and keeps the arguments as a string, allowing the conversation to continue.

## Context

This is related to issue #21771 which reports the same symptom. The root cause there is the PEG parser failing on `array<object>` parameter values, but the symptom (HTTP 500 from `func_args_not_string`) is the same. This fix addresses the symptom by making the error handling more robust.

## Diff

```diff
- throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
+ LOG_WRN("Failed to parse tool call arguments as JSON, keeping as string: %s\n", e.what());
```