### PR TITLE
hip: bypass memory pool for flash attention f16 temp buffers

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -946,8 +946,37 @@ void launch_fattn(
     const int cc  = ggml_cuda_info().devices[id].cc;
     const int nsm = ggml_cuda_info().devices[id].nsm;
 
+#ifdef GGML_USE_HIP
+    // HIP/ROCm: bypass the memory pool for f16 temp buffers.
+    // The legacy pool (ggml_cuda_pool_leg) retains peak-sized allocations permanently
+    // because free() stores buffers for reuse rather than releasing them.
+    // On HIP without VMM support (RDNA 3/4), this means the f16 dequant temp buffers
+    // for quantized KV stay allocated after use, consuming more VRAM than the KV
+    // compression saves — causing OOM before f16 at equivalent context lengths.
+    // Using raw cudaMalloc/cudaFree ensures memory is released after the kernel completes.
+    // Ref: https://github.com/ggml-org/llama.cpp/issues/22107
+    struct hip_f16_alloc {
+        half * ptr = nullptr;
+        cudaStream_t stream;
+        hip_f16_alloc(cudaStream_t s) : stream(s) {}
+        hip_f16_alloc(const hip_f16_alloc &) = delete;
+        hip_f16_alloc & operator=(const hip_f16_alloc &) = delete;
+        ~hip_f16_alloc() {
+            if (ptr) {
+                cudaStreamSynchronize(stream);
+                cudaFree(ptr);
+            }
+        }
+        void alloc(size_t nelements) {
+            CUDA_CHECK(cudaMalloc(&ptr, nelements * sizeof(half)));
+        }
+    };
+    hip_f16_alloc K_f16(main_stream);
+    hip_f16_alloc V_f16(main_stream);
+#else
     ggml_cuda_pool_alloc<half>   K_f16(pool);
     ggml_cuda_pool_alloc<half>   V_f16(pool);
+#endif
     ggml_cuda_pool_alloc<int>    KV_max(pool);
     ggml_cuda_pool_alloc<float>  dst_tmp(pool);
     ggml_cuda_pool_alloc<float2> dst_tmp_meta(pool);


### PR DESCRIPTION
On HIP/ROCm, bypass the memory pool for flash attention f16 temp buffers to prevent OOM with quantized KV cache types.

## Overview

The legacy memory pool (`ggml_cuda_pool_leg`) retains peak-sized allocations permanently. During flash attention with quantized KV types (q4_0, q8_0), the f16 dequant temp buffers (`K_f16`, `V_f16`) grow proportional to KV cache length. After use, the pool retains them at peak size — consuming more VRAM than the KV compression saves.

On CUDA with VMM, the OS can reclaim unused virtual memory. On HIP, VMM is broken since ROCm 7.0 ([ROCm/rocm-systems#2516](https://github.com/ROCm/rocm-systems/issues/2516), open 4+ months), so all consumer RDNA 3/4 GPUs fall back to the legacy pool where allocations are never freed.

This causes quantized KV to OOM before f16 at equivalent context lengths on stock llama.cpp.

## Fix

Replace pool-based f16 temp buffer allocation with a RAII struct using raw `cudaMalloc`/`cudaFree` on HIP. Memory is released after the FA kernel completes via `cudaStreamSynchronize`.

Single file change: `ggml/src/ggml-cuda/fattn-common.cuh`, scoped to `#ifdef GGML_USE_HIP`. Zero impact on CUDA or Metal.

## Reproducer

Stock llama.cpp, no modifications needed:

```bash
# f16 survives:
llama-bench -m model.gguf -ngl 99 -fa 1 -ctk f16 -ctv f16 -p 512 -n 128 -d 0,32768,65536 -r 1

# q8_0 OOMs (same context, same model, same GPU):
llama-bench -m model.gguf -ngl 99 -fa 1 -ctk q8_0 -ctv q8_0 -p 512 -n 128 -d 0,32768,65536 -r 1
```

## Confirmed hardware

| GPU | Arch | VRAM | Tester | Result |
|-----|------|------|--------|--------|
| RX 7900 XT | gfx1100 | 20GB | ozboss | q8_0 crashed at 64K, f16 survived to 131K |
| RX 9060 XT | gfx1200 | 16GB | Gerporgl | q8_0 crashed at 31K, f16 survived to 39K |
| RX 9070 XT | gfx1201 | 16GB | TheTom, apollo-mg | Patched: q8_0 survives 65K where f16 OOMs |
| Radeon Pro VII | gfx906 | 16GB | Zgate735 | OOM with quantized KV + FA at long context |

## Performance impact

Tested on RX 9070 XT, Qwen2.5-1.5B Q8_0:

| Metric | Base | Patched | Delta |
|--------|------|---------|-------|
| Decode (tg128) | 196.5 t/s | 192.3 t/s | -2.0% (noise) |
| Prefill 32K (pp512@d32768) | 3237 t/s | 3061 t/s | -5.5% |
| f16 (all) | unchanged | unchanged | 0% |

The ~5% prefill overhead is from `cudaStreamSynchronize` in the RAII destructor. Can be eliminated with `hipFreeAsync` (stream-ordered free) in future.

Fixes #22107
Mentions ROCm/rocm-systems#2516

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI used for research and guidance, all code manually reviewed and understood.