### PR TITLE
rpc: rdma: default max_inline_data to 0 for portability

### DIFF
--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -287,7 +287,7 @@ bool socket_t::impl::rdma_probe() {
     qia.cap.max_recv_wr     = RDMA_RX_DEPTH + 4;
     qia.cap.max_send_sge    = 1;
     qia.cap.max_recv_sge    = 1;
-    qia.cap.max_inline_data = 256;
+    qia.cap.max_inline_data = 0;  // 0 is portable: non-Mellanox RoCE (e.g. Intel E810 irdma) rejects inline > 0
 
     rdma->qp = ibv_create_qp(rdma->pd, &qia);
     if (!rdma->qp) return false;


### PR DESCRIPTION
Non-Mellanox RoCE providers (notably Intel E810's `irdma` driver) reject `ibv_create_qp` requests where `qia.cap.max_inline_data > 0`. The current value of `256` works on Mellanox/ConnectX NICs but prevents the RPC RDMA transport from initializing on Intel E810 (and presumably other non-Mellanox RoCEv2 implementations).

Setting `max_inline_data` to `0` is universally accepted. Providers that support inline data simply don't use the fast path for sends, which has negligible perf impact for the RPC payloads here — all tensor transfers go via `RDMA_WRITE` and are far above any practical inline threshold.

## Tested on

- **Intel E810-XXV 25 GbE SFP28** (kernel `irdma` driver, RoCEv2) between two AMD workstations
  - Before: `llama-server --rpc` aborts at startup with `ibv_create_qp failed`
  - After: RDMA transport negotiates and runs to completion; verified end-to-end inference over RoCEv2 with Nemotron-3-Super and MiniMax-M2 models

## Diff

Single line in `ggml/src/ggml-rpc/transport.cpp`:

```diff
-    qia.cap.max_inline_data = 256;
+    qia.cap.max_inline_data = 0;  // 0 is portable: non-Mellanox RoCE (e.g. Intel E810 irdma) rejects inline > 0
```

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: used to draft the commit message and this PR body; the patch itself came from hands-on Intel E810 hardware debugging