### PR TITLE
fix(chat): graceful degradation for malformed tool call arguments (v2)

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2030,7 +2030,7 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
+                            LOG_WRN("Failed to parse tool call arguments as JSON, keeping as string: %s", e.what());
                         }
                     }
                 }


### PR DESCRIPTION
## DISCLOSURE

This contribution was developed by a human (David @ huckstack) with assistance from an AI coding agent (Hermes). The human reviewed and approved all changes.

## Problem

When models generate malformed JSON in tool call arguments (e.g., unescaped single quotes like `log_dir = '/home/user/.hermes/logs/cron'`), `func_args_not_string()` throws an HTTP 500 error. This causes cascading failures where every subsequent request crashes with `Failed to parse tool call arguments as JSON: unexpected end of input`.

The function was introduced in commit b283f6d5b with `throw`, which converts a recoverable parsing error into a hard server error.

## Fix

Replace `throw` with `LOG_WRN` in `func_args_not_string()`. This converts the hard 500 error into graceful degradation — the server logs a warning and keeps the arguments as a string, allowing the conversation to continue.

## Context

This is a pragmatic workaround, not a root fix. The core issue is that the PEG parser in the TAG_WITH_TAGGED tool format (introduced by PR #21216) fails on malformed JSON in parameter values. See issue #21771 for the full analysis of the parser regression.

**Related:** #21771, #22072, #12068 (hermes-agent)

## Testing

This fix has been validated on:
- Pop!_OS with llama.cpp b8833
- Qwen3.6-35B-A3B local endpoint
- RTX 3060 (12GB VRAM)

The fix prevents the HTTP 500 cascade while allowing the conversation to continue. The warning is logged for debugging purposes.