### PR TITLE
ggml-opencl: add Adreno xmem attention path

### DIFF
--- a/ggml/src/ggml-opencl/CMakeLists.txt
+++ b/ggml/src/ggml-opencl/CMakeLists.txt
@@ -161,6 +161,9 @@ set(GGML_OPENCL_KERNELS
     flash_attn_f32_f16
     flash_attn_f16
     flash_attn_f32
+    adreno_xmem_attn
+    adreno_xmem_exact_qk
+    adreno_xmem_exact_pv
 )
 
 foreach (K ${GGML_OPENCL_KERNELS})

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -357,6 +357,63 @@ static void populateProfilingInfo(
 
 struct ggml_backend_opencl_context;
 
+struct ggml_cl_adreno_xmem_attn_scratch {
+    cl_mem q_img = nullptr;
+    cl_mem k_img = nullptr;
+    cl_mem v_img = nullptr;
+    cl_mem out_img = nullptr;
+
+    cl_mem k_transpose_buf = nullptr;
+    cl_mem k_transpose_img1d = nullptr;
+
+    cl_mem k_packed_buf = nullptr;
+    cl_mem v_packed_buf = nullptr;
+
+    cl_mem score_buf = nullptr;
+    cl_mem prob_buf = nullptr;
+    cl_mem score_img1d = nullptr;
+    cl_mem prob_img1d = nullptr;
+    cl_mem softmax_stats_img2d = nullptr;
+
+    cl_mem xmem_qk = nullptr;
+    cl_mem xmem_pv = nullptr;
+    cl_mem mask_flag_buf = nullptr;
+
+    int n_q = 0;
+    int n_kv = 0;
+    int d_head_q = 0;
+    int d_head_v = 0;
+    int heads_total = 0;
+};
+
+struct ggml_cl_adreno_xmem_attn_state {
+    bool env_enabled = false;
+    bool compiled = false;
+    bool has_required_ext = false;
+
+    cl_program program = nullptr;
+    cl_program program_qk_split = nullptr;
+    cl_program program_pv_split = nullptr;
+
+    cl_kernel kernel_q_f32_to_img_scaled = nullptr;
+    cl_kernel kernel_kv_f32_to_img_gqa = nullptr;
+    cl_kernel kernel_kv_f16_to_img_gqa = nullptr;
+    cl_kernel kernel_img_to_f32 = nullptr;
+    cl_kernel kernel_k_gather = nullptr;
+    cl_kernel kernel_pack_k = nullptr;
+    cl_kernel kernel_qk_gemm = nullptr;
+    cl_kernel kernel_softmax_reduce_basic = nullptr;
+    cl_kernel kernel_softmax_apply_basic = nullptr;
+    cl_kernel kernel_mask_scores = nullptr;
+    cl_kernel kernel_mask_all_zero = nullptr;
+    cl_kernel kernel_softmax_reduce_masked = nullptr;
+    cl_kernel kernel_softmax_apply_masked = nullptr;
+    cl_kernel kernel_pack_v = nullptr;
+    cl_kernel kernel_pv_gemm = nullptr;
+
+    ggml_cl_adreno_xmem_attn_scratch scratch;
+};
+
 // backend device context
 struct ggml_backend_opencl_device_context {
     cl_platform_id platform;
@@ -393,6 +450,8 @@ struct ggml_backend_opencl_context {
     size_t max_workgroup_size;
     bool fp16_support;
     bool has_vector_subgroup_broadcast;
+    bool has_qcom_subgroup_uniform_load;
+    bool has_qcom_subgroup_constant_load;
     bool disable_fusion;
 
     bool adreno_has_large_buffer;
@@ -406,6 +465,8 @@ struct ggml_backend_opencl_context {
 
     cl_context context;
     cl_command_queue queue;
+
+    ggml_cl_adreno_xmem_attn_state adreno_xmem_attn;
 
     // prealloc buffers for transposing weights and activations
     ggml_cl_buffer prealloc_quant_trans;
@@ -778,7 +839,7 @@ static cl_program build_program_from_source(cl_context ctx, cl_device_id dev, co
         exit(1);
     }
 
-    err = clBuildProgram(p, 0, NULL, compile_opts.c_str(), NULL, NULL);
+    err = clBuildProgram(p, 1, &dev, compile_opts.c_str(), NULL, NULL);
     if(err < 0) {
         clGetProgramBuildInfo(p, dev, CL_PROGRAM_BUILD_LOG, 0, NULL, &log_size);
         program_log = (char*) malloc(log_size + 1);
@@ -790,6 +851,134 @@ static cl_program build_program_from_source(cl_context ctx, cl_device_id dev, co
     }
 
     return p;
+}
+
+static std::string ggml_cl_extract_kernel_unit(const std::string & full_src, const char * kernel_name, bool need_qcom_ext) {
+    const size_t name_pos = full_src.find(kernel_name);
+    GGML_ASSERT(name_pos != std::string::npos);
+
+    size_t start = full_src.rfind("__attribute__", name_pos);
+    if (start == std::string::npos) {
+        start = full_src.rfind("__kernel void", name_pos);
+    }
+    GGML_ASSERT(start != std::string::npos);
+
+    const size_t body_start = full_src.find('{', name_pos);
+    GGML_ASSERT(body_start != std::string::npos);
+
+    int depth = 0;
+    size_t end = std::string::npos;
+    for (size_t i = body_start; i < full_src.size(); ++i) {
+        const char c = full_src[i];
+        if (c == '{') {
+            ++depth;
+        } else if (c == '}') {
+            --depth;
+            if (depth == 0) {
+                end = i + 1;
+                break;
+            }
+        }
+    }
+    GGML_ASSERT(end != std::string::npos);
+
+    std::string unit;
+    unit += "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n";
+    if (need_qcom_ext) {
+        unit += "#pragma OPENCL EXTENSION cl_qcom_subgroup_uniform_load : enable\n";
+        unit += "#pragma OPENCL EXTENSION cl_qcom_subgroup_constant_load : enable\n";
+    }
+    unit += "\n";
+    unit += "#define bool2 uchar2\n";
+    unit += "#define bool3 uchar3\n";
+    unit += "#define bool4 uchar4\n\n";
+    unit += "__constant sampler_t smp_none = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE  | CLK_FILTER_NEAREST;\n";
+    unit += "__constant sampler_t smp_zero = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;\n\n";
+    unit += full_src.substr(start, end - start);
+    const std::string kernel_sig = std::string("__kernel void ") + kernel_name;
+    const size_t sig_pos = unit.find(kernel_sig);
+    if (sig_pos != std::string::npos) {
+        unit.replace(sig_pos, kernel_sig.size(), "__kernel void main_function");
+    }
+    unit += "\n";
+    return unit;
+}
+
+static void ggml_cl_load_adreno_xmem_attn_kernels(ggml_backend_opencl_context * backend_ctx) {
+    if (backend_ctx->gpu_family != ADRENO || !backend_ctx->adreno_xmem_attn.env_enabled || backend_ctx->adreno_xmem_attn.compiled) {
+        return;
+    }
+
+    cl_int err = CL_SUCCESS;
+#ifdef GGML_OPENCL_EMBED_KERNELS
+    const std::string kernel_src {
+        #include "adreno_xmem_attn.cl.h"
+    };
+    const std::string qk_exact_src {
+        #include "adreno_xmem_exact_qk.cl.h"
+    };
+    const std::string pv_exact_src {
+        #include "adreno_xmem_exact_pv.cl.h"
+    };
+#else
+    const std::string kernel_src = read_file("adreno_xmem_attn.cl");
+    const std::string qk_exact_src = read_file("adreno_xmem_exact_qk.cl");
+    const std::string pv_exact_src = read_file("adreno_xmem_exact_pv.cl");
+#endif
+    if (kernel_src.empty()) {
+        return;
+    }
+
+    const std::string xmem_compile_opts = "-cl-std=CL2.0 -qcom-accelerate-16-bit=true";
+    const std::string qk_split_src = !qk_exact_src.empty()
+        ? qk_exact_src
+        : ggml_cl_extract_kernel_unit(kernel_src, "adreno_xmem_attn_qk_gemm", true);
+    backend_ctx->adreno_xmem_attn.program_qk_split =
+        build_program_from_source(backend_ctx->context, backend_ctx->device, qk_split_src.c_str(), xmem_compile_opts);
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_qk_gemm =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program_qk_split, "main_function", &err), err));
+
+    const std::string pv_split_src = !pv_exact_src.empty()
+        ? pv_exact_src
+        : ggml_cl_extract_kernel_unit(kernel_src, "adreno_xmem_attn_pv_gemm", true);
+    backend_ctx->adreno_xmem_attn.program_pv_split =
+        build_program_from_source(backend_ctx->context, backend_ctx->device, pv_split_src.c_str(), xmem_compile_opts);
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_pv_gemm =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program_pv_split, "main_function", &err), err));
+
+    backend_ctx->adreno_xmem_attn.program =
+        build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), xmem_compile_opts);
+
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_q_f32_to_img_scaled =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_q_f32_to_img_scaled", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_kv_f32_to_img_gqa =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_kv_f32_to_img_gqa", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_kv_f16_to_img_gqa =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_kv_f16_to_img_gqa", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_img_to_f32 =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_img_to_f32", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_k_gather =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_k_gather", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_pack_k =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_pack_k", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_softmax_reduce_basic =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_softmax_reduce_basic", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_softmax_apply_basic =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_softmax_apply_basic", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_mask_scores =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_mask_scores", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_mask_all_zero =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_mask_all_zero", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_softmax_reduce_masked =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_softmax_reduce_masked", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_softmax_apply_masked =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_softmax_apply_masked", &err), err));
+    CL_CHECK((backend_ctx->adreno_xmem_attn.kernel_pack_v =
+        clCreateKernel(backend_ctx->adreno_xmem_attn.program, "adreno_xmem_attn_pack_v", &err), err));
+
+    backend_ctx->adreno_xmem_attn.compiled = true;
+    backend_ctx->adreno_xmem_attn.has_required_ext = true;
+    GGML_LOG_CONT(".");
 }
 
 static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_version opencl_c_version) {
@@ -807,6 +996,13 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx, ggml_cl_ve
     }
 
     GGML_LOG_INFO("ggml_opencl: loading OpenCL kernels");
+    // Compile the Adreno xmem attention kernels before the rest of the OpenCL
+    // kernel set. On current Adreno drivers, compiling these kernels later can
+    // produce a materially slower device binary even with identical source and
+    // build options. A future inline-asm version of the hot loop may remove this
+    // compiler-order dependency, but today the early dedicated build is the most
+    // stable way to keep the fast path deterministic.
+    ggml_cl_load_adreno_xmem_attn_kernels(backend_ctx);
 
     // add
     {
@@ -3172,7 +3368,13 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
     ext_buffer[ext_str_size] = '\0'; // ensure it is null terminated
     // Check if ext_buffer contains cl_khr_fp16
     backend_ctx->fp16_support = strstr(ext_buffer, "cl_khr_fp16") != NULL;
+    backend_ctx->has_qcom_subgroup_uniform_load = strstr(ext_buffer, "cl_qcom_subgroup_uniform_load") != NULL;
+    backend_ctx->has_qcom_subgroup_constant_load = strstr(ext_buffer, "cl_qcom_subgroup_constant_load") != NULL;
     GGML_LOG_INFO("ggml_opencl: device FP16 support: %s\n", backend_ctx->fp16_support ? "true" : "false");
+    GGML_LOG_INFO("ggml_opencl: qcom subgroup uniform load: %s\n",
+            backend_ctx->has_qcom_subgroup_uniform_load ? "true" : "false");
+    GGML_LOG_INFO("ggml_opencl: qcom subgroup constant load: %s\n",
+            backend_ctx->has_qcom_subgroup_constant_load ? "true" : "false");
     // check Adreno large buffer support
     backend_ctx->adreno_has_large_buffer = strstr(ext_buffer, "cl_qcom_large_buffer") != NULL;
 
@@ -3252,6 +3454,12 @@ static ggml_backend_opencl_context * ggml_cl2_init(ggml_backend_dev_t dev) {
             GGML_LOG_INFO("ggml_opencl: Adreno large buffer enabled\n");
         }
     }
+
+    backend_ctx->adreno_xmem_attn.env_enabled =
+        getenv("GGML_OPENCL_ADRENO_XMEM_ATTN") != nullptr &&
+        backend_ctx->gpu_family == GPU_FAMILY::ADRENO;
+    GGML_LOG_INFO("ggml_opencl: Adreno xmem attention env: %s\n",
+            backend_ctx->adreno_xmem_attn.env_enabled ? "enabled" : "disabled");
 
     cl_int err;
 
@@ -9262,6 +9470,594 @@ static void ggml_cl_timestep_embedding(ggml_backend_t backend, const ggml_tensor
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, NULL, dst);
 }
 
+struct ggml_cl_adreno_xmem_attn_schedule {
+    int qk_lws0 = 256;
+    int qk_lws2 = 1;
+    int softmax_reduce_lws0 = 256;
+    int softmax_apply_lws0 = 64;
+    int softmax_apply_lws2 = 4;
+    int pv_lws0 = 64;
+    int pv_lws2 = 4;
+};
+
+static inline size_t ggml_cl_round_up(size_t x, size_t a) {
+    return ((x + a - 1) / a) * a;
+}
+
+static inline int ggml_cl_round_up_div(int x, int y) {
+    return (x + y - 1) / y;
+}
+
+static inline void ggml_cl_set_arg_int4(cl_kernel kernel, cl_uint index, int x, int y, int z, int w) {
+    struct { int x, y, z, w; } value { x, y, z, w };
+    CL_CHECK(clSetKernelArg(kernel, index, sizeof(value), &value));
+}
+
+static inline void ggml_cl_set_arg_half4(cl_kernel kernel, cl_uint index, float x, float y, float z, float w) {
+    ggml_fp16_t value[4] = {
+        ggml_fp32_to_fp16(x),
+        ggml_fp32_to_fp16(y),
+        ggml_fp32_to_fp16(z),
+        ggml_fp32_to_fp16(w),
+    };
+    CL_CHECK(clSetKernelArg(kernel, index, sizeof(value), value));
+}
+
+static cl_mem ggml_cl_make_image2d_half4(cl_context context, cl_mem_flags flags, size_t width, size_t height) {
+    cl_int err = CL_SUCCESS;
+    cl_image_format format = { CL_RGBA, CL_HALF_FLOAT };
+    cl_image_desc desc = {};
+    desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+    desc.image_width = width;
+    desc.image_height = height;
+    cl_mem image = clCreateImage(context, flags, &format, &desc, nullptr, &err);
+    CL_CHECK(err);
+    return image;
+}
+
+static cl_mem ggml_cl_make_image1d_buffer_half4(cl_context context, cl_mem_flags flags, size_t width, cl_mem backing_buffer) {
+    cl_int err = CL_SUCCESS;
+    cl_image_format format = { CL_RGBA, CL_HALF_FLOAT };
+    cl_image_desc desc = {};
+    desc.image_type = CL_MEM_OBJECT_IMAGE1D_BUFFER;
+    desc.image_width = width;
+    desc.buffer = backing_buffer;
+    cl_mem image = clCreateImage(context, flags, &format, &desc, nullptr, &err);
+    CL_CHECK(err);
+    return image;
+}
+
+static void ggml_cl_release_mem(cl_mem & mem) {
+    if (mem != nullptr) {
+        CL_CHECK(clReleaseMemObject(mem));
+        mem = nullptr;
+    }
+}
+
+static void ggml_cl_adreno_xmem_attn_release_scratch(ggml_backend_opencl_context * backend_ctx) {
+    auto & s = backend_ctx->adreno_xmem_attn.scratch;
+    ggml_cl_release_mem(s.q_img);
+    ggml_cl_release_mem(s.k_img);
+    ggml_cl_release_mem(s.v_img);
+    ggml_cl_release_mem(s.out_img);
+    ggml_cl_release_mem(s.k_transpose_img1d);
+    ggml_cl_release_mem(s.k_transpose_buf);
+    ggml_cl_release_mem(s.k_packed_buf);
+    ggml_cl_release_mem(s.v_packed_buf);
+    ggml_cl_release_mem(s.score_img1d);
+    ggml_cl_release_mem(s.prob_img1d);
+    ggml_cl_release_mem(s.score_buf);
+    ggml_cl_release_mem(s.prob_buf);
+    ggml_cl_release_mem(s.softmax_stats_img2d);
+    ggml_cl_release_mem(s.xmem_qk);
+    ggml_cl_release_mem(s.xmem_pv);
+    ggml_cl_release_mem(s.mask_flag_buf);
+    s = {};
+}
+
+static ggml_cl_adreno_xmem_attn_schedule ggml_cl_adreno_xmem_attn_select_schedule(
+        const ggml_backend_opencl_context * backend_ctx,
+        int n_q,
+        int n_kv,
+        int heads_total) {
+    const bool big_h = heads_total >= 8;
+    ggml_cl_adreno_xmem_attn_schedule sched;
+
+    if (n_q >= 512) sched.qk_lws0 = 512;
+    else if (n_q >= 256) sched.qk_lws0 = 128;
+    else sched.qk_lws0 = 64;
+    sched.qk_lws2 = (big_h && n_q >= 512) ? 2 : 1;
+
+    if (n_kv >= 2048) sched.softmax_reduce_lws0 = 1024;
+    else if (n_kv >= 512) sched.softmax_reduce_lws0 = big_h ? 256 : 512;
+    else sched.softmax_reduce_lws0 = 256;
+
+    if (n_kv < 256) sched.softmax_apply_lws0 = 64;
+    else sched.softmax_apply_lws0 = big_h ? 128 : 64;
+    sched.softmax_apply_lws2 = n_kv >= 512 ? 8 : 4;
+
+    if (n_q < 256) sched.pv_lws0 = 64;
+    else sched.pv_lws0 = big_h ? 128 : 64;
+    sched.pv_lws2 = big_h ? 8 : (n_q <= 256 ? 8 : 4);
+
+    const int max_wg = (int) backend_ctx->max_workgroup_size;
+    auto fix = [&](int & l0, int & l2) {
+        while (l0 * l2 > max_wg) {
+            if (l2 > 1) l2 /= 2;
+            else if (l0 > 32) l0 /= 2;
+            else break;
+        }
+    };
+    fix(sched.qk_lws0, sched.qk_lws2);
+    fix(sched.softmax_apply_lws0, sched.softmax_apply_lws2);
+    fix(sched.pv_lws0, sched.pv_lws2);
+    while (sched.softmax_reduce_lws0 > max_wg) {
+        sched.softmax_reduce_lws0 /= 2;
+    }
+
+    return sched;
+}
+
+static void ggml_cl_adreno_xmem_attn_make_tail_mask(int n, ggml_fp16_t out[4]) {
+    float actual[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    const int rem = n & 3;
+    if (rem != 0) {
+        for (int i = rem; i < 4; ++i) {
+            actual[i] = 0.0f;
+        }
+    }
+    out[0] = ggml_fp32_to_fp16(actual[3]);
+    out[1] = ggml_fp32_to_fp16(actual[0]);
+    out[2] = ggml_fp32_to_fp16(actual[1]);
+    out[3] = ggml_fp32_to_fp16(actual[2]);
+}
+
+static bool ggml_cl_adreno_xmem_attn_prepare(
+        ggml_backend_opencl_context * backend_ctx,
+        int n_q,
+        int n_kv,
+        int d_head_q,
+        int d_head_v,
+        int heads_total) {
+    auto & s = backend_ctx->adreno_xmem_attn.scratch;
+    if (s.q_img != nullptr &&
+            s.n_q == n_q &&
+            s.n_kv == n_kv &&
+            s.d_head_q == d_head_q &&
+            s.d_head_v == d_head_v &&
+            s.heads_total == heads_total) {
+        return true;
+    }
+
+    ggml_cl_adreno_xmem_attn_release_scratch(backend_ctx);
+
+    const int qpack = d_head_q / 4;
+    const int vpack = d_head_v / 4;
+    const int npack = ggml_cl_round_up_div(n_kv, 4);
+    const size_t q_img_h = (size_t) heads_total * qpack;
+    const size_t v_img_h = (size_t) heads_total * vpack;
+
+    s.q_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_q, q_img_h);
+    s.k_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_kv, q_img_h);
+    s.v_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_kv, v_img_h);
+    s.out_img = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_q, v_img_h);
+
+    const size_t k_transpose_half4_elems = (size_t) npack * heads_total * d_head_q;
+    s.k_transpose_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, k_transpose_half4_elems * sizeof(uint16_t) * 4, nullptr, nullptr);
+    GGML_ASSERT(s.k_transpose_buf != nullptr);
+    s.k_transpose_img1d = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, k_transpose_half4_elems, s.k_transpose_buf);
+
+    const size_t k_groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_q, 16);
+    const size_t v_groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_v, 16);
+    const size_t k_packed_half4_elems = (size_t) n_kv * k_groups16 * 4;
+    const size_t v_packed_half4_elems = (size_t) n_kv * v_groups16 * 4;
+    s.k_packed_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, k_packed_half4_elems * sizeof(uint16_t) * 4, nullptr, nullptr);
+    s.v_packed_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, v_packed_half4_elems * sizeof(uint16_t) * 4, nullptr, nullptr);
+    GGML_ASSERT(s.k_packed_buf != nullptr && s.v_packed_buf != nullptr);
+
+    const size_t score_half4_elems = (size_t) npack * heads_total * n_q;
+    const size_t score_bytes = score_half4_elems * sizeof(uint16_t) * 4;
+    s.score_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, score_bytes, nullptr, nullptr);
+    s.prob_buf  = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, score_bytes, nullptr, nullptr);
+    GGML_ASSERT(s.score_buf != nullptr && s.prob_buf != nullptr);
+    s.score_img1d = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, score_half4_elems, s.score_buf);
+    s.prob_img1d  = ggml_cl_make_image1d_buffer_half4(backend_ctx->context, CL_MEM_READ_ONLY, score_half4_elems, s.prob_buf);
+
+    s.softmax_stats_img2d = ggml_cl_make_image2d_half4(backend_ctx->context, CL_MEM_READ_WRITE, (size_t) n_q, (size_t) heads_total);
+    s.xmem_qk = clCreateBuffer(backend_ctx->context, CL_MEM_READ_ONLY, 6144, nullptr, nullptr);
+    s.xmem_pv = clCreateBuffer(backend_ctx->context, CL_MEM_READ_ONLY, 6144, nullptr, nullptr);
+    s.mask_flag_buf = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, sizeof(cl_int), nullptr, nullptr);
+    GGML_ASSERT(s.softmax_stats_img2d != nullptr && s.xmem_qk != nullptr && s.xmem_pv != nullptr && s.mask_flag_buf != nullptr);
+
+    s.n_q = n_q;
+    s.n_kv = n_kv;
+    s.d_head_q = d_head_q;
+    s.d_head_v = d_head_v;
+    s.heads_total = heads_total;
+    return true;
+}
+
+static bool ggml_cl_adreno_xmem_attn_can_use(
+        const ggml_backend_opencl_context * backend_ctx,
+        const ggml_tensor * q,
+        const ggml_tensor * k,
+        const ggml_tensor * dst) {
+    const ggml_tensor * v = dst->src[2];
+    const ggml_tensor * mask = dst->src[3];
+    const ggml_tensor * sinks = dst->src[4];
+
+    if (!backend_ctx->adreno_xmem_attn.env_enabled || !backend_ctx->adreno_xmem_attn.compiled) {
+        return false;
+    }
+    if (backend_ctx->gpu_family != ADRENO) {
+        return false;
+    }
+    if (q->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32) {
+        return false;
+    }
+    if (k->type != v->type || (k->type != GGML_TYPE_F16 && k->type != GGML_TYPE_F32)) {
+        return false;
+    }
+    if (sinks != nullptr) {
+        return false;
+    }
+    float params[3];
+    memcpy(params, dst->op_params, sizeof(params));
+    if (params[1] != 0.0f || params[2] != 0.0f) {
+        return false;
+    }
+    if (q->ne[0] != k->ne[0]) {
+        return false;
+    }
+    if ((q->ne[0] % 8) != 0) {
+        return false;
+    }
+    if ((v->ne[0] % 4) != 0) {
+        return false;
+    }
+    if (q->ne[2] % k->ne[2] != 0) {
+        return false;
+    }
+    if (mask != nullptr && (mask->type != GGML_TYPE_F16 || !ggml_is_contiguous(mask))) {
+        return false;
+    }
+    return true;
+}
+
+static void ggml_cl_adreno_xmem_attn_run(
+        ggml_backend_t backend,
+        const ggml_tensor * q,
+        const ggml_tensor * k,
+        ggml_tensor * dst) {
+    ggml_backend_opencl_context * backend_ctx = (ggml_backend_opencl_context *) backend->context;
+    auto & xstate = backend_ctx->adreno_xmem_attn;
+    auto & s = xstate.scratch;
+    static bool logged = false;
+    if (!logged) {
+        GGML_LOG_INFO("ggml_opencl: using Adreno xmem attention path\n");
+        logged = true;
+    }
+
+    const ggml_tensor * v = dst->src[2];
+    const ggml_tensor * mask = dst->src[3];
+
+    ggml_tensor_extra_cl * extra_q = (ggml_tensor_extra_cl *) q->extra;
+    ggml_tensor_extra_cl * extra_k = (ggml_tensor_extra_cl *) k->extra;
+    ggml_tensor_extra_cl * extra_v = (ggml_tensor_extra_cl *) v->extra;
+    ggml_tensor_extra_cl * extra_o = (ggml_tensor_extra_cl *) dst->extra;
+    ggml_tensor_extra_cl * extra_mask = mask ? (ggml_tensor_extra_cl *) mask->extra : nullptr;
+
+    const cl_ulong offset_q = extra_q->offset + q->view_offs;
+    const cl_ulong offset_k = extra_k->offset + k->view_offs;
+    const cl_ulong offset_v = extra_v->offset + v->view_offs;
+    const cl_ulong offset_o = extra_o->offset + dst->view_offs;
+    const cl_ulong offset_mask = extra_mask ? extra_mask->offset + mask->view_offs : 0;
+
+    const int n_q = q->ne[1];
+    const int n_kv = k->ne[1];
+    const int d_head_q = q->ne[0];
+    const int d_head_v = v->ne[0];
+    const int n_head = q->ne[2];
+    const int n_head_kv = k->ne[2];
+    const int n_batch = q->ne[3];
+    const int heads_total = n_head * n_batch;
+    const int qpack = d_head_q / 4;
+    const int opack = d_head_v / 4;
+    const int npack = ggml_cl_round_up_div(n_kv, 4);
+    const float scale = ((const float *) dst->op_params)[0];
+
+    int is_causal = (mask == NULL && n_q > 1 && n_q == n_kv) ? 1 : 0;
+    int has_mask = mask != nullptr ? 1 : 0;
+    cl_mem effective_mask_mem = extra_mask ? extra_mask->data_device : nullptr;
+    cl_ulong effective_offset_mask = offset_mask;
+
+    GGML_ASSERT(ggml_cl_adreno_xmem_attn_prepare(backend_ctx, n_q, n_kv, d_head_q, d_head_v, heads_total));
+    const ggml_cl_adreno_xmem_attn_schedule sched =
+        ggml_cl_adreno_xmem_attn_select_schedule(backend_ctx, n_q, n_kv, heads_total);
+
+    if (mask != nullptr && !is_causal) {
+        const int64_t mask_elems64 = ggml_nelements(mask);
+        GGML_ASSERT(mask_elems64 <= INT_MAX);
+
+        const cl_int zero = 0;
+        CL_CHECK(clEnqueueWriteBuffer(backend_ctx->queue, s.mask_flag_buf, CL_TRUE, 0, sizeof(zero), &zero, 0, nullptr, nullptr));
+
+        const int mask_elems = (int) mask_elems64;
+        cl_kernel kernel = xstate.kernel_mask_all_zero;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.mask_flag_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &effective_mask_mem));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_ulong), &effective_offset_mask));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int), &mask_elems));
+
+        size_t gws[1] = {256};
+        size_t lws[1] = {256};
+        CL_CHECK(clEnqueueNDRangeKernel(backend_ctx->queue, kernel, 1, nullptr, gws, lws, 0, nullptr, nullptr));
+
+        cl_int mask_nonzero = 1;
+        CL_CHECK(clEnqueueReadBuffer(backend_ctx->queue, s.mask_flag_buf, CL_TRUE, 0, sizeof(mask_nonzero), &mask_nonzero, 0, nullptr, nullptr));
+        if (mask_nonzero == 0) {
+            has_mask = 0;
+            effective_mask_mem = nullptr;
+            effective_offset_mask = 0;
+        }
+    }
+
+    {
+        size_t gws[3] = {(size_t) n_q, (size_t) heads_total, (size_t) qpack};
+        size_t lws[3] = {8, 1, (size_t) ((qpack <= 32) ? qpack : 1)};
+        cl_kernel kernel = xstate.kernel_q_f32_to_img_scaled;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_q->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_q));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.q_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(float),    &scale));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &d_head_q));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_q));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &q->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &q->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &q->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) n_kv, (size_t) heads_total, (size_t) qpack};
+        size_t lws[3] = {8, 1, (size_t) ((qpack <= 32) ? qpack : 1)};
+        cl_kernel kernel = k->type == GGML_TYPE_F16 ? xstate.kernel_kv_f16_to_img_gqa : xstate.kernel_kv_f32_to_img_gqa;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_k->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_k));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.k_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),      &d_head_q));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &n_kv));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_head_kv));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &k->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &k->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &k->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) n_kv, (size_t) heads_total, (size_t) opack};
+        size_t lws[3] = {8, 1, (size_t) ((opack <= 32) ? opack : 1)};
+        cl_kernel kernel = v->type == GGML_TYPE_F16 ? xstate.kernel_kv_f16_to_img_gqa : xstate.kernel_kv_f32_to_img_gqa;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_v->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_v));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.v_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),      &d_head_v));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &n_kv));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_head_kv));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &v->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &v->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &v->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) d_head_q, (size_t) heads_total, (size_t) npack};
+        size_t lws[3] = {(size_t) MIN(64, d_head_q), (size_t) (heads_total >= 2 ? 2 : 1), (size_t) MIN(8, npack > 0 ? npack : 1)};
+        if (lws[0] * lws[1] * lws[2] > backend_ctx->max_workgroup_size) {
+            lws[1] = 1;
+        }
+        cl_kernel kernel = xstate.kernel_k_gather;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.k_transpose_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.k_img));
+        ggml_cl_set_arg_int4(kernel, 2, n_kv, heads_total, npack, d_head_q);
+        ggml_cl_set_arg_int4(kernel, 3, qpack, 0, 0, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        const size_t groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_q, 16);
+        const size_t packed_linear = (size_t) n_kv * groups16;
+        const size_t lws0 = MIN((size_t) 1024, backend_ctx->max_workgroup_size);
+        size_t gws[3] = {ggml_cl_round_up(packed_linear, lws0), 1, 1};
+        size_t lws[3] = {lws0, 1, 1};
+        ggml_fp16_t tail_mask[4];
+        ggml_cl_adreno_xmem_attn_make_tail_mask(n_kv, tail_mask);
+
+        cl_kernel kernel = xstate.kernel_pack_k;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.k_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.k_transpose_img1d));
+        ggml_cl_set_arg_int4(kernel, 2, 8, (int) packed_linear, qpack, d_head_q);
+        ggml_cl_set_arg_int4(kernel, 3, heads_total, heads_total, heads_total, npack);
+        ggml_cl_set_arg_int4(kernel, 4, d_head_q, 0, 0, 0);
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(tail_mask), tail_mask));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t lws[3] = {(size_t) sched.qk_lws0, 1, (size_t) sched.qk_lws2};
+        const int slices_per_group = sched.qk_lws2 * 8;
+        const size_t groups_z = (size_t) ggml_cl_round_up_div(npack, slices_per_group);
+        const size_t groups_x = (size_t) ggml_cl_round_up_div(n_q, sched.qk_lws0);
+        size_t gws[3] = {
+            lws[0] * groups_z,
+            groups_x,
+            (size_t) heads_total * lws[2],
+        };
+
+        cl_kernel kernel = xstate.kernel_qk_gemm;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.score_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.k_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &s.xmem_qk));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &s.q_img));
+        ggml_cl_set_arg_int4(kernel, 4, heads_total, npack, n_q, 32);
+        ggml_cl_set_arg_int4(kernel, 5, qpack, 0, 0, heads_total);
+        ggml_cl_set_arg_int4(kernel, 6, qpack, 1, 1, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    if (!has_mask && !is_causal) {
+        {
+            size_t lws[3] = {(size_t) sched.softmax_reduce_lws0, 1, 1};
+            size_t gws[3] = {ggml_cl_round_up((size_t) n_q, lws[0]), (size_t) heads_total, 1};
+            cl_kernel kernel = xstate.kernel_softmax_reduce_basic;
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.score_img1d));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.softmax_stats_img2d));
+            ggml_cl_set_arg_int4(kernel, 2, heads_total, 1, n_q, n_kv);
+            ggml_cl_set_arg_int4(kernel, 3, heads_total, n_q, 0, 0);
+            backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+        }
+        {
+            size_t lws[3] = {(size_t) sched.softmax_apply_lws0, 1, (size_t) sched.softmax_apply_lws2};
+            size_t gws[3] = {
+                ggml_cl_round_up((size_t) n_q, lws[0]),
+                (size_t) heads_total,
+                ggml_cl_round_up((size_t) npack, lws[2]),
+            };
+            cl_kernel kernel = xstate.kernel_softmax_apply_basic;
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.prob_buf));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.score_img1d));
+            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &s.softmax_stats_img2d));
+            ggml_cl_set_arg_int4(kernel, 3, heads_total, npack, n_q, 1);
+            ggml_cl_set_arg_int4(kernel, 4, heads_total, n_q, 0, 0);
+            backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+        }
+    } else {
+        cl_mem mask_mem = effective_mask_mem;
+        {
+            size_t lws[3] = {(size_t) sched.softmax_reduce_lws0, 1, 1};
+            size_t gws[3] = {ggml_cl_round_up((size_t) n_q, lws[0]), (size_t) heads_total, 1};
+            cl_kernel kernel = xstate.kernel_softmax_reduce_masked;
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.score_img1d));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.softmax_stats_img2d));
+            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &mask_mem));
+            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_ulong), &effective_offset_mask));
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int), &has_mask));
+            CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int), &n_q));
+            CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int), &n_kv));
+            CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int), &heads_total));
+            CL_CHECK(clSetKernelArg(kernel, 8, sizeof(int), &n_head));
+            CL_CHECK(clSetKernelArg(kernel, 9, sizeof(int), &is_causal));
+            const cl_ulong mask_nb1 = mask ? mask->nb[1] : 0;
+            const cl_ulong mask_nb2 = mask ? mask->nb[2] : 0;
+            const cl_ulong mask_nb3 = mask ? mask->nb[3] : 0;
+            CL_CHECK(clSetKernelArg(kernel, 10, sizeof(cl_ulong), &mask_nb1));
+            CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong), &mask_nb2));
+            CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_ulong), &mask_nb3));
+            int mask_ne2 = mask ? mask->ne[2] : 0;
+            int mask_ne3 = mask ? mask->ne[3] : 0;
+            CL_CHECK(clSetKernelArg(kernel, 13, sizeof(int), &mask_ne2));
+            CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int), &mask_ne3));
+            backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+        }
+        {
+            size_t lws[3] = {(size_t) sched.softmax_apply_lws0, 1, (size_t) sched.softmax_apply_lws2};
+            size_t gws[3] = {
+                ggml_cl_round_up((size_t) n_q, lws[0]),
+                (size_t) heads_total,
+                ggml_cl_round_up((size_t) npack, lws[2]),
+            };
+            cl_kernel kernel = xstate.kernel_softmax_apply_masked;
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.prob_buf));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.score_img1d));
+            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &s.softmax_stats_img2d));
+            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &mask_mem));
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_ulong), &effective_offset_mask));
+            CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int), &has_mask));
+            CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int), &n_q));
+            CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int), &n_kv));
+            CL_CHECK(clSetKernelArg(kernel, 8, sizeof(int), &heads_total));
+            CL_CHECK(clSetKernelArg(kernel, 9, sizeof(int), &n_head));
+            CL_CHECK(clSetKernelArg(kernel, 10, sizeof(int), &is_causal));
+            const cl_ulong mask_nb1 = mask ? mask->nb[1] : 0;
+            const cl_ulong mask_nb2 = mask ? mask->nb[2] : 0;
+            const cl_ulong mask_nb3 = mask ? mask->nb[3] : 0;
+            CL_CHECK(clSetKernelArg(kernel, 11, sizeof(cl_ulong), &mask_nb1));
+            CL_CHECK(clSetKernelArg(kernel, 12, sizeof(cl_ulong), &mask_nb2));
+            CL_CHECK(clSetKernelArg(kernel, 13, sizeof(cl_ulong), &mask_nb3));
+            int mask_ne2 = mask ? mask->ne[2] : 0;
+            int mask_ne3 = mask ? mask->ne[3] : 0;
+            CL_CHECK(clSetKernelArg(kernel, 14, sizeof(int), &mask_ne2));
+            CL_CHECK(clSetKernelArg(kernel, 15, sizeof(int), &mask_ne3));
+            backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+        }
+    }
+
+    {
+        const size_t groups16 = (size_t) ggml_cl_round_up_div(heads_total * d_head_v, 16);
+        const size_t packed_linear = (size_t) n_kv * groups16;
+        const size_t lws0 = MIN((size_t) 1024, backend_ctx->max_workgroup_size);
+        size_t gws[3] = {ggml_cl_round_up(packed_linear, lws0), 1, 1};
+        size_t lws[3] = {lws0, 1, 1};
+        ggml_fp16_t tail_mask[4];
+        ggml_cl_adreno_xmem_attn_make_tail_mask(n_kv, tail_mask);
+
+        cl_kernel kernel = xstate.kernel_pack_v;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.v_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.v_img));
+        ggml_cl_set_arg_int4(kernel, 2, 8, (int) packed_linear, npack, n_kv);
+        ggml_cl_set_arg_int4(kernel, 3, heads_total, heads_total, opack, 0);
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(tail_mask), tail_mask));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        cl_mem pv_prob_img = s.prob_img1d;
+        size_t lws[3] = {(size_t) sched.pv_lws0, 1, (size_t) sched.pv_lws2};
+        const int blocks = ggml_cl_round_up_div(opack, 8);
+        const size_t groups_z = (size_t) ggml_cl_round_up_div(blocks, sched.pv_lws2);
+        const size_t groups_x = (size_t) ggml_cl_round_up_div(n_q, sched.pv_lws0);
+        size_t gws[3] = {
+            lws[0] * groups_z,
+            groups_x,
+            (size_t) heads_total * lws[2],
+        };
+
+        cl_kernel kernel = xstate.kernel_pv_gemm;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &s.v_packed_buf));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &s.xmem_pv));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &pv_prob_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem), &s.out_img));
+        ggml_cl_set_arg_int4(kernel, 4, heads_total, opack, n_q, 32);
+        ggml_cl_set_arg_int4(kernel, 5, npack, 0, 0, heads_total);
+        ggml_cl_set_arg_int4(kernel, 6, heads_total * n_q, npack, n_q, 1);
+        ggml_cl_set_arg_int4(kernel, 7, 1, 0, 0, 0);
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+
+    {
+        size_t gws[3] = {(size_t) n_q, (size_t) heads_total, (size_t) opack};
+        size_t lws[3] = {8, 1, (size_t) ((opack <= 32) ? opack : 1)};
+        cl_kernel kernel = xstate.kernel_img_to_f32;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra_o->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong), &offset_o));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &s.out_img));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(int),      &d_head_v));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &n_q));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &n_head));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &n_batch));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(cl_ulong), &dst->nb[1]));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(cl_ulong), &dst->nb[2]));
+        CL_CHECK(clSetKernelArg(kernel, 9, sizeof(cl_ulong), &dst->nb[3]));
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
+    }
+}
+
 static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, const ggml_tensor * k, ggml_tensor * dst) {
     const ggml_tensor * v = dst->src[2];
     const ggml_tensor * mask = dst->src[3];
@@ -9278,6 +10074,11 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     }
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
+
+    if (ggml_cl_adreno_xmem_attn_can_use(backend_ctx, q, k, dst)) {
+        ggml_cl_adreno_xmem_attn_run(backend, q, k, dst);
+        return;
+    }
 
     const int n_q = q->ne[1];
     const int n_kv = k->ne[1];

--- a/ggml/src/ggml-opencl/kernels/adreno_xmem_attn.cl
+++ b/ggml/src/ggml-opencl/kernels/adreno_xmem_attn.cl
@@ -1,0 +1,968 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#pragma OPENCL EXTENSION cl_qcom_subgroup_uniform_load : enable
+#pragma OPENCL EXTENSION cl_qcom_subgroup_constant_load : enable
+
+#define bool2 uchar2
+#define bool3 uchar3
+#define bool4 uchar4
+
+__constant sampler_t smp_none = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE  | CLK_FILTER_NEAREST;
+__constant sampler_t smp_zero = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+
+inline int round_up_div(int x, int y) {
+    return (x + y - 1) / y;
+}
+
+inline half4 rotate_tail_mask(half4 in_mask) {
+    return (half4)(in_mask.y, in_mask.z, in_mask.w, in_mask.x);
+}
+
+__kernel void adreno_xmem_attn_q_f32_to_img_scaled(
+        const global void * src_void,
+        ulong src_offset,
+        write_only image2d_t dst_image2d,
+        const float scale,
+        const int d_head,
+        const int n_q,
+        const int n_head,
+        const int n_batch,
+        const ulong src_nb1,
+        const ulong src_nb2,
+        const ulong src_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_q || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int c = d * 4;
+
+    const global char * src_base = (const global char *) src_void + src_offset;
+    const global float * row_ptr = (const global float *) (src_base + batch * src_nb3 + head * src_nb2 + x * src_nb1);
+
+    half4 out = (half4)(0.0h);
+    out.x = convert_half(row_ptr[c + 0] * scale);
+    if (c + 1 < d_head) out.y = convert_half(row_ptr[c + 1] * scale);
+    if (c + 2 < d_head) out.z = convert_half(row_ptr[c + 2] * scale);
+    if (c + 3 < d_head) out.w = convert_half(row_ptr[c + 3] * scale);
+
+    write_imageh(dst_image2d, (int2)(x, flat_h * kpack + d), out);
+}
+
+__kernel void adreno_xmem_attn_kv_f32_to_img_gqa(
+        const global void * src_void,
+        ulong src_offset,
+        write_only image2d_t dst_image2d,
+        const int d_head,
+        const int n_kv,
+        const int n_head,
+        const int n_head_kv,
+        const int n_batch,
+        const ulong src_nb1,
+        const ulong src_nb2,
+        const ulong src_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_kv || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int head_kv = head / (n_head / n_head_kv);
+    const int c = d * 4;
+
+    const global char * src_base = (const global char *) src_void + src_offset;
+    const global float * row_ptr = (const global float *) (src_base + batch * src_nb3 + head_kv * src_nb2 + x * src_nb1);
+
+    half4 out = (half4)(0.0h);
+    out.x = convert_half(row_ptr[c + 0]);
+    if (c + 1 < d_head) out.y = convert_half(row_ptr[c + 1]);
+    if (c + 2 < d_head) out.z = convert_half(row_ptr[c + 2]);
+    if (c + 3 < d_head) out.w = convert_half(row_ptr[c + 3]);
+
+    write_imageh(dst_image2d, (int2)(x, flat_h * kpack + d), out);
+}
+
+__kernel void adreno_xmem_attn_kv_f16_to_img_gqa(
+        const global void * src_void,
+        ulong src_offset,
+        write_only image2d_t dst_image2d,
+        const int d_head,
+        const int n_kv,
+        const int n_head,
+        const int n_head_kv,
+        const int n_batch,
+        const ulong src_nb1,
+        const ulong src_nb2,
+        const ulong src_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_kv || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int head_kv = head / (n_head / n_head_kv);
+    const int c = d * 4;
+
+    const global char * src_base = (const global char *) src_void + src_offset;
+    const global half * row_ptr = (const global half *) (src_base + batch * src_nb3 + head_kv * src_nb2 + x * src_nb1);
+
+    half4 out = (half4)(0.0h);
+    out.x = row_ptr[c + 0];
+    if (c + 1 < d_head) out.y = row_ptr[c + 1];
+    if (c + 2 < d_head) out.z = row_ptr[c + 2];
+    if (c + 3 < d_head) out.w = row_ptr[c + 3];
+
+    write_imageh(dst_image2d, (int2)(x, flat_h * kpack + d), out);
+}
+
+__kernel void adreno_xmem_attn_img_to_f32(
+        global void * dst_void,
+        ulong dst_offset,
+        read_only image2d_t src_image2d,
+        const int d_head,
+        const int n_q,
+        const int n_head,
+        const int n_batch,
+        const ulong dst_nb1,
+        const ulong dst_nb2,
+        const ulong dst_nb3) {
+    const int x = get_global_id(0);
+    const int flat_h = get_global_id(1);
+    const int d = get_global_id(2);
+
+    const int heads_total = n_head * n_batch;
+    const int kpack = d_head / 4;
+
+    if (x >= n_q || flat_h >= heads_total || d >= kpack) {
+        return;
+    }
+
+    const int batch = flat_h / n_head;
+    const int head  = flat_h % n_head;
+    const int c = d * 4;
+
+    global char * dst_base = (global char *) dst_void + dst_offset;
+    global float * row_ptr = (global float *) (dst_base + batch * dst_nb3 + x * dst_nb2 + head * dst_nb1);
+
+    const half4 in_value = read_imageh(src_image2d, smp_zero, (int2)(x, flat_h * kpack + d));
+    row_ptr[c + 0] = convert_float(in_value.x);
+    if (c + 1 < d_head) row_ptr[c + 1] = convert_float(in_value.y);
+    if (c + 2 < d_head) row_ptr[c + 2] = convert_float(in_value.z);
+    if (c + 3 < d_head) row_ptr[c + 3] = convert_float(in_value.w);
+}
+
+__kernel void adreno_xmem_attn_k_gather(
+        global half4 * dst_tensor_buffer,
+        read_only image2d_t src_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1) {
+  int X = get_global_id(0);
+  int Y = get_global_id(1);
+  int S = get_global_id(2);
+  if (X >= shared_int4_0.w || Y >= shared_int4_0.y || S >= shared_int4_0.z) {
+    return;
+  }
+  half temps[4];
+  temps[0] = (half)(0.f);
+  temps[1] = (half)(0.f);
+  temps[2] = (half)(0.f);
+  temps[3] = (half)(0.f);
+  for (int i = 0; i < 4; ++i) {
+    int dst_channel = S * 4 + i;
+    if (dst_channel < shared_int4_0.x) {
+      int s_y = Y;
+      int s_x = dst_channel;
+      int s_c = X;
+      {
+        int slice_coord_TMP = (s_c) / 4;
+        int sub_ch_coord_TMP = (s_c) % 4;
+        half4 src_TMP = read_imageh(src_tensor_image2d, smp_zero, (int2)((s_x), ((s_y) * shared_int4_1.x + (slice_coord_TMP))));
+        temps[i] = (half[4]){src_TMP.x, src_TMP.y, src_TMP.z, src_TMP.w}[sub_ch_coord_TMP];
+      };
+    }
+  }
+  half4 result;
+  result.x = temps[0];
+  result.y = temps[1];
+  result.z = temps[2];
+  result.w = temps[3];
+  dst_tensor_buffer[(((S) * shared_int4_0.y + (Y)) * shared_int4_0.w + (X))] = result;
+}
+
+__kernel void adreno_xmem_attn_pack_k(
+        global half4 * dst_tensor_buffer,
+        read_only image1d_buffer_t src_image_buffer,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const int4 shared_int4_2,
+        const half4 shared_half4_0) {
+  int linear_index = get_global_id(0);
+  if (linear_index >= shared_int4_0.y) return;
+  if (get_global_id(1) != 0) return;
+  if (get_global_id(2) != 0) return;
+  int dst_o_sp_i_ogroup = linear_index;
+  int dst_ogroup = dst_o_sp_i_ogroup % shared_int4_0.x;
+  int dst_o_sp_i = dst_o_sp_i_ogroup / shared_int4_0.x;
+  int dst_i = dst_o_sp_i % shared_int4_0.z;
+  int dst_o_sp = dst_o_sp_i / shared_int4_0.z;
+  int dst_sp = dst_o_sp % shared_int4_1.x;
+  int dst_o = dst_o_sp / shared_int4_1.x;
+  int i_slice = dst_i;
+  int o_slice = dst_o * shared_int4_0.x + dst_ogroup;
+  int spatial_linear = dst_sp;
+  int W = spatial_linear % shared_int4_1.y;
+  int H = spatial_linear / shared_int4_1.y;
+  half4 w0 = (half4)(0);
+  half4 w1 = (half4)(0);
+  half4 w2 = (half4)(0);
+  half4 w3 = (half4)(0);
+
+  if (i_slice * 4 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w0 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4)));
+  }
+  if (i_slice * 4 + 1 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w1 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4 + 1)));
+  }
+  if (i_slice * 4 + 2 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w2 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4 + 2)));
+  }
+  if (i_slice * 4 + 3 < shared_int4_0.w && o_slice < shared_int4_1.w) {
+    w3 = read_imageh(src_image_buffer, (((o_slice) * shared_int4_1.z + (W)) * shared_int4_2.x + (i_slice * 4 + 3)));
+  }
+  if (o_slice == shared_int4_1.w - 1) {
+    half4 mask = (half4)(shared_half4_0.y, shared_half4_0.z, shared_half4_0.w, shared_half4_0.x);
+    w0 *= mask;
+    w1 *= mask;
+    w2 *= mask;
+    w3 *= mask;
+  }
+  half4 r0 = w0;
+  half4 r1 = w1;
+  half4 r2 = w2;
+  half4 r3 = w3;
+  dst_tensor_buffer[linear_index * 4 + 0] = r0;
+  dst_tensor_buffer[linear_index * 4 + 1] = r1;
+  dst_tensor_buffer[linear_index * 4 + 2] = r2;
+  dst_tensor_buffer[linear_index * 4 + 3] = r3;
+}
+
+__attribute__((qcom_max_concurrent_subgroups(12)))
+__kernel void adreno_xmem_attn_qk_gemm(
+        global half4 * dst_tensor_buffer,
+        constant half8 * weights_buffer __attribute__((sub_group_uniform)),
+        constant half8 * xmem_buffer __attribute__((max_constant_size((6144)))),
+        read_only image2d_t src_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const int4 shared_int4_2) {
+  int X = get_group_id(1) * get_local_size(0) + get_local_id(0);
+  int Y = get_group_id(2) * get_local_size(1) + get_local_id(1);
+  int Z = get_group_id(0) * get_local_size(2) + get_local_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  if (Z * 8 >= shared_int4_0.y) return;
+
+  half4 r0 = (half4)(0.f);
+  half4 r1 = (half4)(0.f);
+  half4 r2 = (half4)(0.f);
+  half4 r3 = (half4)(0.f);
+  half4 r4 = (half4)(0.f);
+  half4 r5 = (half4)(0.f);
+  half4 r6 = (half4)(0.f);
+  half4 r7 = (half4)(0.f);
+  int x_coord = mad24(X, shared_int4_2.y, shared_int4_1.y);
+  int y_coord = mad24(Y, shared_int4_2.z, shared_int4_1.z);
+  int coord_x, coord_y, coord_s;
+  int f_offset = (Z * shared_int4_1.w + Y) * shared_int4_1.x * 32;
+
+  int subgroup_id = (int)((0x1F & qcom_get_physical_sub_group_id()));
+  subgroup_id = subgroup_id % 12;
+  int c_offset = mul24(subgroup_id, shared_int4_0.w);
+  __constant half16 * weights_cache = (__constant half16 *) &xmem_buffer[c_offset];
+  coord_y = Y;
+  coord_x = X;
+  coord_s = 0;
+  do {
+    half4 src0 = read_imageh(src_tensor_image2d, smp_zero, (int2)((coord_x), ((coord_y) * shared_int4_2.x + (coord_s))));
+    coord_s++;
+    half4 src1 = read_imageh(src_tensor_image2d, smp_zero, (int2)((coord_x), ((coord_y) * shared_int4_2.x + (coord_s))));
+    coord_s++;
+    qcom_sub_group_constant_load8(xmem_buffer, weights_buffer, c_offset, f_offset >> 1, 32);
+    f_offset += 64;
+    qcom_sub_group_sync(QCOM_CLK_CONST_LOAD_SYNC);
+    r0 += src0.x * weights_cache[0].s0123;
+    r0 += src0.y * weights_cache[0].s4567;
+    r0 += src0.z * weights_cache[0].s89ab;
+    r0 += src0.w * weights_cache[0].scdef;
+    r1 += src0.x * weights_cache[1].s0123;
+    r1 += src0.y * weights_cache[1].s4567;
+    r1 += src0.z * weights_cache[1].s89ab;
+    r1 += src0.w * weights_cache[1].scdef;
+    r2 += src0.x * weights_cache[2].s0123;
+    r2 += src0.y * weights_cache[2].s4567;
+    r2 += src0.z * weights_cache[2].s89ab;
+    r2 += src0.w * weights_cache[2].scdef;
+    r3 += src0.x * weights_cache[3].s0123;
+    r3 += src0.y * weights_cache[3].s4567;
+    r3 += src0.z * weights_cache[3].s89ab;
+    r3 += src0.w * weights_cache[3].scdef;
+    r4 += src0.x * weights_cache[4].s0123;
+    r4 += src0.y * weights_cache[4].s4567;
+    r4 += src0.z * weights_cache[4].s89ab;
+    r4 += src0.w * weights_cache[4].scdef;
+    r5 += src0.x * weights_cache[5].s0123;
+    r5 += src0.y * weights_cache[5].s4567;
+    r5 += src0.z * weights_cache[5].s89ab;
+    r5 += src0.w * weights_cache[5].scdef;
+    r6 += src0.x * weights_cache[6].s0123;
+    r6 += src0.y * weights_cache[6].s4567;
+    r6 += src0.z * weights_cache[6].s89ab;
+    r6 += src0.w * weights_cache[6].scdef;
+    r7 += src0.x * weights_cache[7].s0123;
+    r7 += src0.y * weights_cache[7].s4567;
+    r7 += src0.z * weights_cache[7].s89ab;
+    r7 += src0.w * weights_cache[7].scdef;
+    r0 += src1.x * weights_cache[8].s0123;
+    r0 += src1.y * weights_cache[8].s4567;
+    r0 += src1.z * weights_cache[8].s89ab;
+    r0 += src1.w * weights_cache[8].scdef;
+    r1 += src1.x * weights_cache[9].s0123;
+    r1 += src1.y * weights_cache[9].s4567;
+    r1 += src1.z * weights_cache[9].s89ab;
+    r1 += src1.w * weights_cache[9].scdef;
+    r2 += src1.x * weights_cache[10].s0123;
+    r2 += src1.y * weights_cache[10].s4567;
+    r2 += src1.z * weights_cache[10].s89ab;
+    r2 += src1.w * weights_cache[10].scdef;
+    r3 += src1.x * weights_cache[11].s0123;
+    r3 += src1.y * weights_cache[11].s4567;
+    r3 += src1.z * weights_cache[11].s89ab;
+    r3 += src1.w * weights_cache[11].scdef;
+    r4 += src1.x * weights_cache[12].s0123;
+    r4 += src1.y * weights_cache[12].s4567;
+    r4 += src1.z * weights_cache[12].s89ab;
+    r4 += src1.w * weights_cache[12].scdef;
+    r5 += src1.x * weights_cache[13].s0123;
+    r5 += src1.y * weights_cache[13].s4567;
+    r5 += src1.z * weights_cache[13].s89ab;
+    r5 += src1.w * weights_cache[13].scdef;
+    r6 += src1.x * weights_cache[14].s0123;
+    r6 += src1.y * weights_cache[14].s4567;
+    r6 += src1.z * weights_cache[14].s89ab;
+    r6 += src1.w * weights_cache[14].scdef;
+    r7 += src1.x * weights_cache[15].s0123;
+    r7 += src1.y * weights_cache[15].s4567;
+    r7 += src1.z * weights_cache[15].s89ab;
+    r7 += src1.w * weights_cache[15].scdef;
+  } while (coord_s < shared_int4_2.x);
+
+  coord_s = mul24(Z, 8);
+  coord_x = X;
+  coord_y = Y;
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r0);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r1);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r2);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r3);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r4);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r5);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r6);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r7);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+}
+
+__kernel void adreno_xmem_attn_softmax_reduce_basic(
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        write_only image2d_t dst_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1) {
+  int X = get_global_id(0);
+  int Y = get_global_id(1);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  float sum = 0.0f;
+  int end_channel = shared_int4_0.w;
+  int end_slice = (end_channel + 3) / 4;
+  int start_channel = 0;
+  int start_slice = start_channel / 4;
+  bool need_per_channels_check = start_channel % 4 != 0 || end_channel % 4 != 0;
+  float maximum;
+  {
+    int slice_coord_TMP = (start_channel) / 4;
+    int sub_ch_coord_TMP = (start_channel) % 4;
+    float4 src_TMP = read_imagef(src_tensor_image_buffer, (((slice_coord_TMP) * shared_int4_1.x + (Y)) * shared_int4_1.y + (X)));
+    maximum = (float[4]){src_TMP.x, src_TMP.y, src_TMP.z, src_TMP.w}[sub_ch_coord_TMP];
+  };
+  for (int d = start_slice; d < end_slice; d += 1) {
+    float4 mask_dot = (float4)(1.f);
+    float4 src = read_imagef(src_tensor_image_buffer, (((d) * shared_int4_1.x + (Y)) * shared_int4_1.y + (X)));
+    if (need_per_channels_check && (d == start_slice || d == end_slice - 1)) {
+      if (d * 4 + 0 < start_channel || d * 4 + 0 >= end_channel) { mask_dot.x = 0.f; src.x = maximum; }
+      if (d * 4 + 1 < start_channel || d * 4 + 1 >= end_channel) { mask_dot.y = 0.f; src.y = maximum; }
+      if (d * 4 + 2 < start_channel || d * 4 + 2 >= end_channel) { mask_dot.z = 0.f; src.z = maximum; }
+      if (d * 4 + 3 < start_channel || d * 4 + 3 >= end_channel) { mask_dot.w = 0.f; src.w = maximum; }
+    }
+    float new_max = max(src.x, src.y);
+    new_max = max(new_max, src.z);
+    new_max = max(new_max, src.w);
+    new_max = max(new_max, maximum);
+    float scale = native_exp(maximum - new_max);
+    maximum = new_max;
+    sum *= scale;
+    float4 exp_res = native_exp(src - maximum);
+    sum += dot(mask_dot, exp_res);
+  }
+  float inv_sum = 1.0f / sum;
+  half4 result;
+  result.x = convert_half(inv_sum);
+  result.y = convert_half(maximum);
+  write_imageh(dst_tensor_image2d, (int2)((X), ((Y) * shared_int4_0.y + (0))), result);
+}
+
+__kernel void adreno_xmem_attn_softmax_apply_basic(
+        global half4 * dst_tensor_buffer,
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        read_only image2d_t src_tensor_1_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1) {
+  int X = get_global_id(0);
+  int Y = get_global_id(1);
+  int Z = get_global_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x || Z >= shared_int4_0.y) return;
+  half4 src = read_imageh(src_tensor_image_buffer, (((Z) * shared_int4_1.x + (Y)) * shared_int4_1.y + (X)));
+  {
+    half4 src_final;
+    {
+      {
+        half4 exp_val = read_imageh(src_tensor_1_image2d, smp_zero, (int2)(((X)), (((Y)) * shared_int4_0.w + (0))));
+        src_final = exp(src - exp_val.y) * exp_val.x;
+      }
+    }
+    dst_tensor_buffer[(((Z) * shared_int4_0.x + (Y)) * shared_int4_0.z + (X))] = src_final;
+  };
+}
+
+__kernel void adreno_xmem_attn_mask_scores(
+        global half4 * dst_score_tensor_buffer,
+        read_only image1d_buffer_t src_score_image_buffer,
+        global const half * mask,
+        const int n_q,
+        const int n_kv,
+        const int heads_total,
+        const int n_head,
+        const int is_causal,
+        const ulong mask_nb1,
+        const ulong mask_nb2,
+        const ulong mask_nb3,
+        const int mask_ne2,
+        const int mask_ne3) {
+    const int X = get_global_id(0);
+    const int Y = get_global_id(1);
+    const int Z = get_global_id(2);
+    const int npack = round_up_div(n_kv, 4);
+    if (X >= n_q || Y >= heads_total || Z >= npack) {
+        return;
+    }
+
+    const int head = Y % n_head;
+    const int batch = Y / n_head;
+    const int mask_head_idx = mask ? (head % mask_ne2) : 0;
+    const int mask_batch_idx = mask ? (batch % mask_ne3) : 0;
+    const global half * mask_row = mask ? (const global half *) ((const global char *) mask + mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2 + X * mask_nb1) : 0;
+
+    const half4 score = read_imageh(src_score_image_buffer, ((Z * heads_total + Y) * n_q + X));
+    float vals[4] = {
+        convert_float(score.x),
+        convert_float(score.y),
+        convert_float(score.z),
+        convert_float(score.w),
+    };
+
+    for (int lane = 0; lane < 4; ++lane) {
+        const int k_idx = Z * 4 + lane;
+        if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+            vals[lane] = -INFINITY;
+        } else if (mask) {
+            vals[lane] += convert_float(mask_row[k_idx]);
+        }
+    }
+
+    dst_score_tensor_buffer[((Z * heads_total + Y) * n_q + X)] = (half4)(
+            convert_half(vals[0]),
+            convert_half(vals[1]),
+            convert_half(vals[2]),
+            convert_half(vals[3]));
+}
+
+__kernel void adreno_xmem_attn_mask_all_zero(
+        global int * dst_flag,
+        global const half * mask,
+        const ulong mask_offset,
+        const int mask_elems) {
+    const int lid = get_local_id(0);
+    const int lsize = get_local_size(0);
+    const global half * mask_ptr = (const global half *) ((const global char *) mask + mask_offset);
+
+    int found = 0;
+    for (int i = lid; i < mask_elems; i += lsize) {
+        found |= mask_ptr[i] != (half) 0.0h;
+    }
+
+    __local int reduced[256];
+    reduced[lid] = found;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int stride = lsize >> 1; stride > 0; stride >>= 1) {
+        if (lid < stride) {
+            reduced[lid] |= reduced[lid + stride];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        dst_flag[0] = reduced[0];
+    }
+}
+
+__kernel void adreno_xmem_attn_softmax_reduce_masked(
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        write_only image2d_t dst_tensor_image2d,
+        global const half * mask,
+        const ulong mask_offset,
+        const int has_mask,
+        const int n_q,
+        const int n_kv,
+        const int heads_total,
+        const int n_head,
+        const int is_causal,
+        const ulong mask_nb1,
+        const ulong mask_nb2,
+        const ulong mask_nb3,
+        const int mask_ne2,
+        const int mask_ne3) {
+    const int X = get_global_id(0);
+    const int Y = get_global_id(1);
+    if (X >= n_q || Y >= heads_total) {
+        return;
+    }
+
+    const int head = Y % n_head;
+    const int batch = Y / n_head;
+    const global char * mask_base = has_mask ? ((const global char *) mask + mask_offset) : 0;
+    const int mask_head_idx = has_mask ? (head % mask_ne2) : 0;
+    const int mask_batch_idx = has_mask ? (batch % mask_ne3) : 0;
+    const global half * mask_row = has_mask ? (const global half *) (mask_base + mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2 + X * mask_nb1) : 0;
+
+    float maximum = -INFINITY;
+    const int npack = round_up_div(n_kv, 4);
+    for (int d = 0; d < npack; ++d) {
+        const half4 packed_scores = read_imageh(src_tensor_image_buffer, ((d * heads_total + Y) * n_q + X));
+        float4 scores = convert_float4(packed_scores);
+        for (int lane = 0; lane < 4; ++lane) {
+            const int k_idx = d * 4 + lane;
+            float score = lane == 0 ? scores.x : lane == 1 ? scores.y : lane == 2 ? scores.z : scores.w;
+            if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+                score = -INFINITY;
+            } else if (has_mask) {
+                score += convert_float(mask_row[k_idx]);
+            }
+            maximum = fmax(maximum, score);
+        }
+    }
+
+    float sum = 0.0f;
+    if (!isfinite(maximum)) {
+        write_imageh(dst_tensor_image2d, (int2)(X, Y), (half4)((half)0.0h, (half)0.0h, (half)0.0h, (half)0.0h));
+        return;
+    }
+
+    for (int d = 0; d < npack; ++d) {
+        const half4 packed_scores = read_imageh(src_tensor_image_buffer, ((d * heads_total + Y) * n_q + X));
+        float4 scores = convert_float4(packed_scores);
+        for (int lane = 0; lane < 4; ++lane) {
+            const int k_idx = d * 4 + lane;
+            float score = lane == 0 ? scores.x : lane == 1 ? scores.y : lane == 2 ? scores.z : scores.w;
+            if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+                continue;
+            }
+            if (has_mask) {
+                score += convert_float(mask_row[k_idx]);
+            }
+            sum += native_exp(score - maximum);
+        }
+    }
+
+    const float inv_sum = sum > 0.0f ? 1.0f / sum : 0.0f;
+    write_imageh(dst_tensor_image2d, (int2)(X, Y), (half4)(convert_half(inv_sum), convert_half(maximum), (half)0.0h, (half)0.0h));
+}
+
+__kernel void adreno_xmem_attn_softmax_apply_masked(
+        global half4 * dst_tensor_buffer,
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        read_only image2d_t src_stats_image2d,
+        global const half * mask,
+        const ulong mask_offset,
+        const int has_mask,
+        const int n_q,
+        const int n_kv,
+        const int heads_total,
+        const int n_head,
+        const int is_causal,
+        const ulong mask_nb1,
+        const ulong mask_nb2,
+        const ulong mask_nb3,
+        const int mask_ne2,
+        const int mask_ne3) {
+    const int X = get_global_id(0);
+    const int Y = get_global_id(1);
+    const int Z = get_global_id(2);
+    const int npack = round_up_div(n_kv, 4);
+    if (X >= n_q || Y >= heads_total || Z >= npack) {
+        return;
+    }
+
+    const int head = Y % n_head;
+    const int batch = Y / n_head;
+    const global char * mask_base = has_mask ? ((const global char *) mask + mask_offset) : 0;
+    const int mask_head_idx = has_mask ? (head % mask_ne2) : 0;
+    const int mask_batch_idx = has_mask ? (batch % mask_ne3) : 0;
+    const global half * mask_row = has_mask ? (const global half *) (mask_base + mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2 + X * mask_nb1) : 0;
+
+    const half4 src = read_imageh(src_tensor_image_buffer, ((Z * heads_total + Y) * n_q + X));
+    const half4 stats = read_imageh(src_stats_image2d, smp_zero, (int2)(X, Y));
+
+    half4 out = (half4)(0.0h);
+    const float inv_sum = convert_float(stats.x);
+    const float maximum = convert_float(stats.y);
+    if (inv_sum > 0.0f) {
+        const float src_vals[4] = {
+            convert_float(src.x), convert_float(src.y), convert_float(src.z), convert_float(src.w)
+        };
+        float out_vals[4] = {0, 0, 0, 0};
+        for (int lane = 0; lane < 4; ++lane) {
+            const int k_idx = Z * 4 + lane;
+            if (k_idx >= n_kv || (is_causal && k_idx > (n_kv - n_q + X))) {
+                out_vals[lane] = 0.0f;
+                continue;
+            }
+            float score = src_vals[lane];
+            if (has_mask) {
+                score += convert_float(mask_row[k_idx]);
+            }
+            out_vals[lane] = native_exp(score - maximum) * inv_sum;
+        }
+        out = (half4)(convert_half(out_vals[0]), convert_half(out_vals[1]), convert_half(out_vals[2]), convert_half(out_vals[3]));
+    }
+
+    dst_tensor_buffer[((Z * heads_total + Y) * n_q + X)] = out;
+}
+
+__kernel void adreno_xmem_attn_pack_v(
+        global half4 * dst_tensor_buffer,
+        read_only image2d_t src_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const half4 shared_half4_0) {
+  int linear_index = get_global_id(0);
+  if (linear_index >= shared_int4_0.y) return;
+  if (get_global_id(1) != 0) return;
+  if (get_global_id(2) != 0) return;
+  int dst_o_sp_i_ogroup = linear_index;
+  int dst_ogroup = dst_o_sp_i_ogroup % shared_int4_0.x;
+  int dst_o_sp_i = dst_o_sp_i_ogroup / shared_int4_0.x;
+  int dst_i = dst_o_sp_i % shared_int4_0.z;
+  int dst_o_sp = dst_o_sp_i / shared_int4_0.z;
+  int dst_sp = dst_o_sp % shared_int4_1.x;
+  int dst_o = dst_o_sp / shared_int4_1.x;
+  int i_slice = dst_i;
+  int o_slice = dst_o * shared_int4_0.x + dst_ogroup;
+  int spatial_linear = dst_sp;
+  int W = spatial_linear % shared_int4_1.y;
+  int H = spatial_linear / shared_int4_1.y;
+  half4 w0 = (half4)(0);
+  half4 w1 = (half4)(0);
+  half4 w2 = (half4)(0);
+  half4 w3 = (half4)(0);
+
+  if (i_slice * 4 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w0 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (i_slice * 4 + 1 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w1 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4 + 1), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (i_slice * 4 + 2 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w2 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4 + 2), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (i_slice * 4 + 3 < shared_int4_0.w && o_slice < shared_int4_1.z) {
+    w3 = read_imageh(src_image2d, smp_zero, (int2)((i_slice * 4 + 3), ((W) * shared_int4_1.z + (o_slice))));
+  }
+  if (o_slice == shared_int4_1.z - 1) {
+    half4 mask = (half4)(shared_half4_0.y, shared_half4_0.z, shared_half4_0.w, shared_half4_0.x);
+    w0 *= mask;
+    w1 *= mask;
+    w2 *= mask;
+    w3 *= mask;
+  }
+  half4 r0 = w0;
+  half4 r1 = w1;
+  half4 r2 = w2;
+  half4 r3 = w3;
+  dst_tensor_buffer[linear_index * 4 + 0] = r0;
+  dst_tensor_buffer[linear_index * 4 + 1] = r1;
+  dst_tensor_buffer[linear_index * 4 + 2] = r2;
+  dst_tensor_buffer[linear_index * 4 + 3] = r3;
+}
+
+__attribute__((qcom_max_concurrent_subgroups(12)))
+__kernel void adreno_xmem_attn_pv_gemm(
+        constant half8 * weights_buffer __attribute__((sub_group_uniform)),
+        constant half8 * xmem_buffer __attribute__((max_constant_size((6144)))),
+        read_only image1d_buffer_t src_tensor_image_buffer,
+        write_only image2d_t dst_tensor_image2d,
+        const int4 shared_int4_0,
+        const int4 shared_int4_1,
+        const int4 shared_int4_2,
+        const int4 shared_int4_3) {
+  int X = get_group_id(1) * get_local_size(0) + get_local_id(0);
+  int Y = get_group_id(2) * get_local_size(1) + get_local_id(1);
+  int Z = get_group_id(0) * get_local_size(2) + get_local_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  if (Z * 8 >= shared_int4_0.y) return;
+
+  half4 r0 = (half4)(0.f);
+  half4 r1 = (half4)(0.f);
+  half4 r2 = (half4)(0.f);
+  half4 r3 = (half4)(0.f);
+  half4 r4 = (half4)(0.f);
+  half4 r5 = (half4)(0.f);
+  half4 r6 = (half4)(0.f);
+  half4 r7 = (half4)(0.f);
+  int x_coord = mad24(X, shared_int4_2.w, shared_int4_1.y);
+  int y_coord = mad24(Y, shared_int4_3.x, shared_int4_1.z);
+  int coord_x, coord_y, coord_s;
+  int f_offset = (Z * shared_int4_1.w + Y) * shared_int4_1.x * 32;
+
+  int subgroup_id = (int)((0x1F & qcom_get_physical_sub_group_id()));
+  subgroup_id = subgroup_id % 12;
+  int c_offset = mul24(subgroup_id, shared_int4_0.w);
+  __constant half16 * weights_cache = (__constant half16 *)&xmem_buffer[c_offset];
+  coord_y = Y;
+  coord_x = X;
+  int addr = (((0) * shared_int4_1.w + (coord_y)) * shared_int4_2.z + (coord_x));
+  int dz = shared_int4_2.x;
+  coord_s = 0;
+  do {
+    half4 src0 = read_imageh(src_tensor_image_buffer, addr); addr += dz;
+    coord_s++;
+    half4 src1 = read_imageh(src_tensor_image_buffer, addr); addr += dz;
+    coord_s++;
+    qcom_sub_group_constant_load8(xmem_buffer, weights_buffer, c_offset, f_offset >> 1, 32);
+    f_offset += 64;
+    qcom_sub_group_sync(QCOM_CLK_CONST_LOAD_SYNC);
+    r0 += src0.x * weights_cache[0].s0123;
+    r0 += src0.y * weights_cache[0].s4567;
+    r0 += src0.z * weights_cache[0].s89ab;
+    r0 += src0.w * weights_cache[0].scdef;
+    r1 += src0.x * weights_cache[1].s0123;
+    r1 += src0.y * weights_cache[1].s4567;
+    r1 += src0.z * weights_cache[1].s89ab;
+    r1 += src0.w * weights_cache[1].scdef;
+    r2 += src0.x * weights_cache[2].s0123;
+    r2 += src0.y * weights_cache[2].s4567;
+    r2 += src0.z * weights_cache[2].s89ab;
+    r2 += src0.w * weights_cache[2].scdef;
+    r3 += src0.x * weights_cache[3].s0123;
+    r3 += src0.y * weights_cache[3].s4567;
+    r3 += src0.z * weights_cache[3].s89ab;
+    r3 += src0.w * weights_cache[3].scdef;
+    r4 += src0.x * weights_cache[4].s0123;
+    r4 += src0.y * weights_cache[4].s4567;
+    r4 += src0.z * weights_cache[4].s89ab;
+    r4 += src0.w * weights_cache[4].scdef;
+    r5 += src0.x * weights_cache[5].s0123;
+    r5 += src0.y * weights_cache[5].s4567;
+    r5 += src0.z * weights_cache[5].s89ab;
+    r5 += src0.w * weights_cache[5].scdef;
+    r6 += src0.x * weights_cache[6].s0123;
+    r6 += src0.y * weights_cache[6].s4567;
+    r6 += src0.z * weights_cache[6].s89ab;
+    r6 += src0.w * weights_cache[6].scdef;
+    r7 += src0.x * weights_cache[7].s0123;
+    r7 += src0.y * weights_cache[7].s4567;
+    r7 += src0.z * weights_cache[7].s89ab;
+    r7 += src0.w * weights_cache[7].scdef;
+    r0 += src1.x * weights_cache[8].s0123;
+    r0 += src1.y * weights_cache[8].s4567;
+    r0 += src1.z * weights_cache[8].s89ab;
+    r0 += src1.w * weights_cache[8].scdef;
+    r1 += src1.x * weights_cache[9].s0123;
+    r1 += src1.y * weights_cache[9].s4567;
+    r1 += src1.z * weights_cache[9].s89ab;
+    r1 += src1.w * weights_cache[9].scdef;
+    r2 += src1.x * weights_cache[10].s0123;
+    r2 += src1.y * weights_cache[10].s4567;
+    r2 += src1.z * weights_cache[10].s89ab;
+    r2 += src1.w * weights_cache[10].scdef;
+    r3 += src1.x * weights_cache[11].s0123;
+    r3 += src1.y * weights_cache[11].s4567;
+    r3 += src1.z * weights_cache[11].s89ab;
+    r3 += src1.w * weights_cache[11].scdef;
+    r4 += src1.x * weights_cache[12].s0123;
+    r4 += src1.y * weights_cache[12].s4567;
+    r4 += src1.z * weights_cache[12].s89ab;
+    r4 += src1.w * weights_cache[12].scdef;
+    r5 += src1.x * weights_cache[13].s0123;
+    r5 += src1.y * weights_cache[13].s4567;
+    r5 += src1.z * weights_cache[13].s89ab;
+    r5 += src1.w * weights_cache[13].scdef;
+    r6 += src1.x * weights_cache[14].s0123;
+    r6 += src1.y * weights_cache[14].s4567;
+    r6 += src1.z * weights_cache[14].s89ab;
+    r6 += src1.w * weights_cache[14].scdef;
+    r7 += src1.x * weights_cache[15].s0123;
+    r7 += src1.y * weights_cache[15].s4567;
+    r7 += src1.z * weights_cache[15].s89ab;
+    r7 += src1.w * weights_cache[15].scdef;
+  } while (coord_s < shared_int4_2.y);
+
+  coord_s = mul24(Z, 8);
+  coord_x = X;
+  coord_y = Y;
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r0);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r1);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r2);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r3);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r4);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r5);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r6);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r7);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+}

--- a/ggml/src/ggml-opencl/kernels/adreno_xmem_exact_pv.cl
+++ b/ggml/src/ggml-opencl/kernels/adreno_xmem_exact_pv.cl
@@ -1,0 +1,190 @@
+#define MAIN_FUNCTION __kernel void main_function
+#define bool2 uchar2
+#define bool3 uchar3
+#define bool4 uchar4
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+__constant sampler_t smp_none = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
+__constant sampler_t smp_zero = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+#pragma OPENCL EXTENSION cl_qcom_subgroup_uniform_load: enable
+#pragma OPENCL EXTENSION cl_qcom_subgroup_constant_load: enable
+__attribute__((qcom_max_concurrent_subgroups(12)))
+MAIN_FUNCTION(__constant half8* weights_buffer  __attribute__((sub_group_uniform)),
+  __constant half8* xmem_buffer  __attribute__((max_constant_size((6144)))),
+  __read_only image1d_buffer_t src_tensor_image_buffer,
+  __write_only image2d_t dst_tensor_image2d,
+  int4 shared_int4_0,
+  int4 shared_int4_1,
+  int4 shared_int4_2,
+  int4 shared_int4_3) {
+  int X = get_group_id(1) * get_local_size(0) + get_local_id(0);
+  int Y = get_group_id(2) * get_local_size(1) + get_local_id(1);
+  int Z = get_group_id(0) * get_local_size(2) + get_local_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  if (Z * 8 >= shared_int4_0.y) return;
+
+  half4 r0 = (half4)(0.f);
+  half4 r1 = (half4)(0.f);
+  half4 r2 = (half4)(0.f);
+  half4 r3 = (half4)(0.f);
+  half4 r4 = (half4)(0.f);
+  half4 r5 = (half4)(0.f);
+  half4 r6 = (half4)(0.f);
+  half4 r7 = (half4)(0.f);
+
+  int x_coord = mad24(X, shared_int4_2.w, shared_int4_1.y);
+  int y_coord = mad24(Y, shared_int4_3.x, shared_int4_1.z);
+  int coord_x, coord_y, coord_s;
+  int f_offset = (Z * shared_int4_1.w + Y) * shared_int4_1.x * 32;
+
+  int subgroup_id = (int)((0x1F & qcom_get_physical_sub_group_id()));
+  subgroup_id = subgroup_id % 12;
+  int c_offset = mul24(subgroup_id, shared_int4_0.w);
+  __constant half16* weights_cache = (__constant half16*)&xmem_buffer[c_offset];
+
+  coord_y = Y;
+  coord_x = X;
+      int addr = (((0) * shared_int4_1.w + (coord_y)) * shared_int4_2.z + (coord_x));
+      int dz = shared_int4_2.x;
+      coord_s = 0;
+      do {
+        half4 src0 = read_imageh(src_tensor_image_buffer, addr); addr += dz;
+; coord_s++;
+        half4 src1 = read_imageh(src_tensor_image_buffer, addr); addr += dz;
+; coord_s++;
+        qcom_sub_group_constant_load8(xmem_buffer, weights_buffer, c_offset, f_offset >> 1, 32);
+        f_offset += 64;
+        qcom_sub_group_sync(QCOM_CLK_CONST_LOAD_SYNC);
+  r0 += src0.x * weights_cache[0].s0123;
+  r0 += src0.y * weights_cache[0].s4567;
+  r0 += src0.z * weights_cache[0].s89ab;
+  r0 += src0.w * weights_cache[0].scdef;
+  r1 += src0.x * weights_cache[1].s0123;
+  r1 += src0.y * weights_cache[1].s4567;
+  r1 += src0.z * weights_cache[1].s89ab;
+  r1 += src0.w * weights_cache[1].scdef;
+  r2 += src0.x * weights_cache[2].s0123;
+  r2 += src0.y * weights_cache[2].s4567;
+  r2 += src0.z * weights_cache[2].s89ab;
+  r2 += src0.w * weights_cache[2].scdef;
+  r3 += src0.x * weights_cache[3].s0123;
+  r3 += src0.y * weights_cache[3].s4567;
+  r3 += src0.z * weights_cache[3].s89ab;
+  r3 += src0.w * weights_cache[3].scdef;
+  r4 += src0.x * weights_cache[4].s0123;
+  r4 += src0.y * weights_cache[4].s4567;
+  r4 += src0.z * weights_cache[4].s89ab;
+  r4 += src0.w * weights_cache[4].scdef;
+  r5 += src0.x * weights_cache[5].s0123;
+  r5 += src0.y * weights_cache[5].s4567;
+  r5 += src0.z * weights_cache[5].s89ab;
+  r5 += src0.w * weights_cache[5].scdef;
+  r6 += src0.x * weights_cache[6].s0123;
+  r6 += src0.y * weights_cache[6].s4567;
+  r6 += src0.z * weights_cache[6].s89ab;
+  r6 += src0.w * weights_cache[6].scdef;
+  r7 += src0.x * weights_cache[7].s0123;
+  r7 += src0.y * weights_cache[7].s4567;
+  r7 += src0.z * weights_cache[7].s89ab;
+  r7 += src0.w * weights_cache[7].scdef;
+  r0 += src1.x * weights_cache[8].s0123;
+  r0 += src1.y * weights_cache[8].s4567;
+  r0 += src1.z * weights_cache[8].s89ab;
+  r0 += src1.w * weights_cache[8].scdef;
+  r1 += src1.x * weights_cache[9].s0123;
+  r1 += src1.y * weights_cache[9].s4567;
+  r1 += src1.z * weights_cache[9].s89ab;
+  r1 += src1.w * weights_cache[9].scdef;
+  r2 += src1.x * weights_cache[10].s0123;
+  r2 += src1.y * weights_cache[10].s4567;
+  r2 += src1.z * weights_cache[10].s89ab;
+  r2 += src1.w * weights_cache[10].scdef;
+  r3 += src1.x * weights_cache[11].s0123;
+  r3 += src1.y * weights_cache[11].s4567;
+  r3 += src1.z * weights_cache[11].s89ab;
+  r3 += src1.w * weights_cache[11].scdef;
+  r4 += src1.x * weights_cache[12].s0123;
+  r4 += src1.y * weights_cache[12].s4567;
+  r4 += src1.z * weights_cache[12].s89ab;
+  r4 += src1.w * weights_cache[12].scdef;
+  r5 += src1.x * weights_cache[13].s0123;
+  r5 += src1.y * weights_cache[13].s4567;
+  r5 += src1.z * weights_cache[13].s89ab;
+  r5 += src1.w * weights_cache[13].scdef;
+  r6 += src1.x * weights_cache[14].s0123;
+  r6 += src1.y * weights_cache[14].s4567;
+  r6 += src1.z * weights_cache[14].s89ab;
+  r6 += src1.w * weights_cache[14].scdef;
+  r7 += src1.x * weights_cache[15].s0123;
+  r7 += src1.y * weights_cache[15].s4567;
+  r7 += src1.z * weights_cache[15].s89ab;
+  r7 += src1.w * weights_cache[15].scdef;
+      } while (coord_s < shared_int4_2.y);
+
+  coord_s = mul24(Z, 8);
+  coord_x = X;
+  coord_y = Y;
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r0);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r1);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r2);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r3);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r4);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r5);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r6);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r7);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image_buffer, (((0) * shared_int4_1.w + (0)) * shared_int4_2.z + (0)));
+    }
+    write_imageh(dst_tensor_image2d, (int2)((coord_x), ((coord_y) * shared_int4_0.y + (coord_s))), res);
+    coord_s++;
+  }
+}

--- a/ggml/src/ggml-opencl/kernels/adreno_xmem_exact_qk.cl
+++ b/ggml/src/ggml-opencl/kernels/adreno_xmem_exact_qk.cl
@@ -1,0 +1,187 @@
+#define MAIN_FUNCTION __kernel void main_function
+#define bool2 uchar2
+#define bool3 uchar3
+#define bool4 uchar4
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+__constant sampler_t smp_none = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE | CLK_FILTER_NEAREST;
+__constant sampler_t smp_zero = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;
+#pragma OPENCL EXTENSION cl_qcom_subgroup_uniform_load: enable
+#pragma OPENCL EXTENSION cl_qcom_subgroup_constant_load: enable
+__attribute__((qcom_max_concurrent_subgroups(12)))
+MAIN_FUNCTION(__global half4* dst_tensor_buffer,
+  __constant half8* weights_buffer  __attribute__((sub_group_uniform)),
+  __constant half8* xmem_buffer  __attribute__((max_constant_size((6144)))),
+  __read_only image2d_t src_tensor_image2d,
+  int4 shared_int4_0,
+  int4 shared_int4_1,
+  int4 shared_int4_2) {
+  int X = get_group_id(1) * get_local_size(0) + get_local_id(0);
+  int Y = get_group_id(2) * get_local_size(1) + get_local_id(1);
+  int Z = get_group_id(0) * get_local_size(2) + get_local_id(2);
+  if (X >= shared_int4_0.z || Y >= shared_int4_0.x) return;
+  if (Z * 8 >= shared_int4_0.y) return;
+
+  half4 r0 = (half4)(0.f);
+  half4 r1 = (half4)(0.f);
+  half4 r2 = (half4)(0.f);
+  half4 r3 = (half4)(0.f);
+  half4 r4 = (half4)(0.f);
+  half4 r5 = (half4)(0.f);
+  half4 r6 = (half4)(0.f);
+  half4 r7 = (half4)(0.f);
+
+  int x_coord = mad24(X, shared_int4_2.y, shared_int4_1.y);
+  int y_coord = mad24(Y, shared_int4_2.z, shared_int4_1.z);
+  int coord_x, coord_y, coord_s;
+  int f_offset = (Z * shared_int4_1.w + Y) * shared_int4_1.x * 32;
+
+  int subgroup_id = (int)((0x1F & qcom_get_physical_sub_group_id()));
+  subgroup_id = subgroup_id % 12;
+  int c_offset = mul24(subgroup_id, shared_int4_0.w);
+  __constant half16* weights_cache = (__constant half16*)&xmem_buffer[c_offset];
+
+  coord_y = Y;
+  coord_x = X;
+      coord_s = 0;
+      do {
+        half4 src0 = read_imageh(src_tensor_image2d, smp_zero, (int2)((coord_x), ((coord_y) * shared_int4_2.x + (coord_s))));
+; coord_s++;
+        half4 src1 = read_imageh(src_tensor_image2d, smp_zero, (int2)((coord_x), ((coord_y) * shared_int4_2.x + (coord_s))));
+; coord_s++;
+        qcom_sub_group_constant_load8(xmem_buffer, weights_buffer, c_offset, f_offset >> 1, 32);
+        f_offset += 64;
+        qcom_sub_group_sync(QCOM_CLK_CONST_LOAD_SYNC);
+  r0 += src0.x * weights_cache[0].s0123;
+  r0 += src0.y * weights_cache[0].s4567;
+  r0 += src0.z * weights_cache[0].s89ab;
+  r0 += src0.w * weights_cache[0].scdef;
+  r1 += src0.x * weights_cache[1].s0123;
+  r1 += src0.y * weights_cache[1].s4567;
+  r1 += src0.z * weights_cache[1].s89ab;
+  r1 += src0.w * weights_cache[1].scdef;
+  r2 += src0.x * weights_cache[2].s0123;
+  r2 += src0.y * weights_cache[2].s4567;
+  r2 += src0.z * weights_cache[2].s89ab;
+  r2 += src0.w * weights_cache[2].scdef;
+  r3 += src0.x * weights_cache[3].s0123;
+  r3 += src0.y * weights_cache[3].s4567;
+  r3 += src0.z * weights_cache[3].s89ab;
+  r3 += src0.w * weights_cache[3].scdef;
+  r4 += src0.x * weights_cache[4].s0123;
+  r4 += src0.y * weights_cache[4].s4567;
+  r4 += src0.z * weights_cache[4].s89ab;
+  r4 += src0.w * weights_cache[4].scdef;
+  r5 += src0.x * weights_cache[5].s0123;
+  r5 += src0.y * weights_cache[5].s4567;
+  r5 += src0.z * weights_cache[5].s89ab;
+  r5 += src0.w * weights_cache[5].scdef;
+  r6 += src0.x * weights_cache[6].s0123;
+  r6 += src0.y * weights_cache[6].s4567;
+  r6 += src0.z * weights_cache[6].s89ab;
+  r6 += src0.w * weights_cache[6].scdef;
+  r7 += src0.x * weights_cache[7].s0123;
+  r7 += src0.y * weights_cache[7].s4567;
+  r7 += src0.z * weights_cache[7].s89ab;
+  r7 += src0.w * weights_cache[7].scdef;
+  r0 += src1.x * weights_cache[8].s0123;
+  r0 += src1.y * weights_cache[8].s4567;
+  r0 += src1.z * weights_cache[8].s89ab;
+  r0 += src1.w * weights_cache[8].scdef;
+  r1 += src1.x * weights_cache[9].s0123;
+  r1 += src1.y * weights_cache[9].s4567;
+  r1 += src1.z * weights_cache[9].s89ab;
+  r1 += src1.w * weights_cache[9].scdef;
+  r2 += src1.x * weights_cache[10].s0123;
+  r2 += src1.y * weights_cache[10].s4567;
+  r2 += src1.z * weights_cache[10].s89ab;
+  r2 += src1.w * weights_cache[10].scdef;
+  r3 += src1.x * weights_cache[11].s0123;
+  r3 += src1.y * weights_cache[11].s4567;
+  r3 += src1.z * weights_cache[11].s89ab;
+  r3 += src1.w * weights_cache[11].scdef;
+  r4 += src1.x * weights_cache[12].s0123;
+  r4 += src1.y * weights_cache[12].s4567;
+  r4 += src1.z * weights_cache[12].s89ab;
+  r4 += src1.w * weights_cache[12].scdef;
+  r5 += src1.x * weights_cache[13].s0123;
+  r5 += src1.y * weights_cache[13].s4567;
+  r5 += src1.z * weights_cache[13].s89ab;
+  r5 += src1.w * weights_cache[13].scdef;
+  r6 += src1.x * weights_cache[14].s0123;
+  r6 += src1.y * weights_cache[14].s4567;
+  r6 += src1.z * weights_cache[14].s89ab;
+  r6 += src1.w * weights_cache[14].scdef;
+  r7 += src1.x * weights_cache[15].s0123;
+  r7 += src1.y * weights_cache[15].s4567;
+  r7 += src1.z * weights_cache[15].s89ab;
+  r7 += src1.w * weights_cache[15].scdef;
+      } while (coord_s < shared_int4_2.x);
+
+  coord_s = mul24(Z, 8);
+  coord_x = X;
+  coord_y = Y;
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r0);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r1);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r2);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r3);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r4);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r5);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r6);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+  if (coord_s < shared_int4_0.y) {
+    half4 res = convert_half4(r7);
+    if (coord_s < 0) {
+      res += read_imageh(src_tensor_image2d, smp_zero, (int2)((0), ((0) * shared_int4_2.x + (0))));
+    }
+    dst_tensor_buffer[(((coord_s) * shared_int4_0.x + (coord_y)) * shared_int4_0.z + (coord_x))] = res;
+    coord_s++;
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -239,6 +239,7 @@ if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
 endif()
 llama_build_and_test(test-gguf.cpp)
 llama_build_and_test(test-backend-ops.cpp)
+llama_build(test-opencl-adreno-attn.cpp)
 
 llama_build_and_test(test-model-load-cancel.cpp LABEL "model")
 llama_build_and_test(test-autorelease.cpp       LABEL "model")

--- a/tests/test-opencl-adreno-attn.cpp
+++ b/tests/test-opencl-adreno-attn.cpp
@@ -1,0 +1,359 @@
+#include <ggml.h>
+#include <ggml-alloc.h>
+#include <ggml-backend.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+enum route_kind {
+    ROUTE_XMEM,
+    ROUTE_FA,
+    ROUTE_NOFUSE,
+};
+
+struct attn_case {
+    int dq = 128;
+    int dv = 128;
+    int nq = 512;
+    int nkv = 512;
+    int n_head = 8;
+    int n_head_kv = 8;
+    int n_batch = 1;
+    bool use_mask = false;
+    bool causal_mask = false;
+    int warmup = 1;
+    int iters = 5;
+    bool skip_ref = false;
+    route_kind route = ROUTE_XMEM;
+};
+
+static void usage(const char * argv0) {
+    std::fprintf(stderr,
+            "Usage: %s [--route xmem|fa|nofuse] [--dq N] [--dv N] [--nq N] [--nkv N] "
+            "[--n-head N] [--n-head-kv N] [--n-batch N] [--mask 0|1] [--causal 0|1] "
+            "[--warmup N] [--iters N] [--skip-ref 0|1]\n",
+            argv0);
+}
+
+static bool parse_int_arg(const char * value, int * out) {
+    char * end = nullptr;
+    long v = std::strtol(value, &end, 10);
+    if (end == value || *end != '\0') {
+        return false;
+    }
+    *out = (int) v;
+    return true;
+}
+
+static bool parse_args(int argc, char ** argv, attn_case * cfg) {
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        auto need_val = [&](const char * name) -> const char * {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "missing value for %s\n", name);
+                std::exit(2);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--route") {
+            const std::string v = need_val("--route");
+            if (v == "xmem") cfg->route = ROUTE_XMEM;
+            else if (v == "fa") cfg->route = ROUTE_FA;
+            else if (v == "nofuse") cfg->route = ROUTE_NOFUSE;
+            else return false;
+        } else if (arg == "--dq") {
+            if (!parse_int_arg(need_val("--dq"), &cfg->dq)) return false;
+        } else if (arg == "--dv") {
+            if (!parse_int_arg(need_val("--dv"), &cfg->dv)) return false;
+        } else if (arg == "--nq") {
+            if (!parse_int_arg(need_val("--nq"), &cfg->nq)) return false;
+        } else if (arg == "--nkv") {
+            if (!parse_int_arg(need_val("--nkv"), &cfg->nkv)) return false;
+        } else if (arg == "--n-head") {
+            if (!parse_int_arg(need_val("--n-head"), &cfg->n_head)) return false;
+        } else if (arg == "--n-head-kv") {
+            if (!parse_int_arg(need_val("--n-head-kv"), &cfg->n_head_kv)) return false;
+        } else if (arg == "--n-batch") {
+            if (!parse_int_arg(need_val("--n-batch"), &cfg->n_batch)) return false;
+        } else if (arg == "--mask") {
+            int v = 0;
+            if (!parse_int_arg(need_val("--mask"), &v)) return false;
+            cfg->use_mask = v != 0;
+        } else if (arg == "--causal") {
+            int v = 0;
+            if (!parse_int_arg(need_val("--causal"), &v)) return false;
+            cfg->causal_mask = v != 0;
+        } else if (arg == "--warmup") {
+            if (!parse_int_arg(need_val("--warmup"), &cfg->warmup)) return false;
+        } else if (arg == "--iters") {
+            if (!parse_int_arg(need_val("--iters"), &cfg->iters)) return false;
+        } else if (arg == "--skip-ref") {
+            int v = 0;
+            if (!parse_int_arg(need_val("--skip-ref"), &v)) return false;
+            cfg->skip_ref = v != 0;
+        } else if (arg == "-h" || arg == "--help") {
+            usage(argv[0]);
+            std::exit(0);
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void fill_random_f32(std::vector<float> & data, uint32_t seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    for (float & v : data) {
+        v = dist(rng);
+    }
+}
+
+static void fill_mask(std::vector<ggml_fp16_t> & data, const attn_case & cfg) {
+    std::vector<float> tmp(data.size(), 0.0f);
+    for (int b = 0; b < cfg.n_batch; ++b) {
+        for (int q = 0; q < cfg.nq; ++q) {
+            for (int k = 0; k < cfg.nkv; ++k) {
+                const size_t idx = ((size_t) b * cfg.nq + q) * cfg.nkv + k;
+                if (cfg.causal_mask && k > (cfg.nkv - cfg.nq + q)) {
+                    tmp[idx] = -INFINITY;
+                }
+            }
+        }
+    }
+    ggml_fp32_to_fp16_row(tmp.data(), data.data(), (int64_t) tmp.size());
+}
+
+static ggml_tensor * build_graph(ggml_context * ctx, const attn_case & cfg, ggml_tensor ** q_out, ggml_tensor ** k_out,
+        ggml_tensor ** v_out, ggml_tensor ** mask_out) {
+    ggml_tensor * q = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, cfg.dq, cfg.nq, cfg.n_head, cfg.n_batch);
+    ggml_tensor * k = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, cfg.dq, cfg.nkv, cfg.n_head_kv, cfg.n_batch);
+    ggml_tensor * v = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, cfg.dv, cfg.nkv, cfg.n_head_kv, cfg.n_batch);
+    ggml_tensor * mask = nullptr;
+    const bool need_explicit_mask = cfg.use_mask || (cfg.causal_mask && cfg.route == ROUTE_NOFUSE);
+    if (need_explicit_mask) {
+        mask = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, cfg.nkv, cfg.nq, 1, cfg.n_batch);
+    }
+
+    ggml_tensor * out = nullptr;
+    const float scale = 1.0f / std::sqrt((float) cfg.dq);
+
+    if (cfg.route == ROUTE_NOFUSE) {
+        ggml_tensor * kq = ggml_mul_mat(ctx, k, q);
+        ggml_mul_mat_set_prec(kq, GGML_PREC_F32);
+        kq = ggml_soft_max_ext(ctx, kq, mask, scale, 0.0f);
+        ggml_tensor * vv = ggml_cont(ctx, ggml_transpose(ctx, v));
+        ggml_tensor * kqv = ggml_mul_mat(ctx, vv, kq);
+        out = ggml_permute(ctx, kqv, 0, 2, 1, 3);
+    } else {
+        out = ggml_flash_attn_ext(ctx, q, k, v, mask, scale, 0.0f, 0.0f);
+        ggml_flash_attn_ext_set_prec(out, GGML_PREC_F32);
+    }
+
+    *q_out = q;
+    *k_out = k;
+    *v_out = v;
+    *mask_out = mask;
+    return out;
+}
+
+static void set_tensor_f32(ggml_tensor * t, const std::vector<float> & data) {
+    ggml_backend_tensor_set(t, data.data(), 0, data.size() * sizeof(float));
+}
+
+static void set_tensor_f16(ggml_tensor * t, const std::vector<float> & data_f32, std::vector<ggml_fp16_t> & tmp_f16) {
+    tmp_f16.resize(data_f32.size());
+    ggml_fp32_to_fp16_row(data_f32.data(), tmp_f16.data(), (int64_t) data_f32.size());
+    ggml_backend_tensor_set(t, tmp_f16.data(), 0, tmp_f16.size() * sizeof(ggml_fp16_t));
+}
+
+static bool run_backend(
+        ggml_backend_t backend,
+        const attn_case & cfg,
+        const std::vector<float> & q_data,
+        const std::vector<float> & k_data,
+        const std::vector<float> & v_data,
+        const std::vector<ggml_fp16_t> & mask_data,
+        std::vector<float> * out,
+        double * avg_ms) {
+    const size_t ctx_size = 16 * 1024 * 1024;
+    ggml_init_params params = {};
+    params.mem_size = ctx_size;
+    params.mem_buffer = nullptr;
+    params.no_alloc = true;
+
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        std::fprintf(stderr, "ggml_init failed\n");
+        return false;
+    }
+
+    ggml_tensor * q = nullptr;
+    ggml_tensor * k = nullptr;
+    ggml_tensor * v = nullptr;
+    ggml_tensor * mask = nullptr;
+    ggml_tensor * result = build_graph(ctx, cfg, &q, &k, &v, &mask);
+
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 32, false);
+    ggml_build_forward_expand(gf, result);
+
+    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buf) {
+        std::fprintf(stderr, "ggml_backend_alloc_ctx_tensors failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    std::vector<ggml_fp16_t> tmp_k_f16;
+    std::vector<ggml_fp16_t> tmp_v_f16;
+    set_tensor_f32(q, q_data);
+    set_tensor_f16(k, k_data, tmp_k_f16);
+    set_tensor_f16(v, v_data, tmp_v_f16);
+    if (mask) {
+        ggml_backend_tensor_set(mask, mask_data.data(), 0, mask_data.size() * sizeof(ggml_fp16_t));
+    }
+
+    for (int i = 0; i < cfg.warmup; ++i) {
+        ggml_status status = ggml_backend_graph_compute(backend, gf);
+        if (status != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "warmup compute failed: %s\n", ggml_status_to_string(status));
+            ggml_backend_buffer_free(buf);
+            ggml_free(ctx);
+            return false;
+        }
+    }
+
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < cfg.iters; ++i) {
+        ggml_status status = ggml_backend_graph_compute(backend, gf);
+        if (status != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "compute failed: %s\n", ggml_status_to_string(status));
+            ggml_backend_buffer_free(buf);
+            ggml_free(ctx);
+            return false;
+        }
+    }
+    auto t1 = std::chrono::steady_clock::now();
+
+    out->resize(ggml_nelements(result));
+    ggml_backend_tensor_get(result, out->data(), 0, out->size() * sizeof(float));
+    *avg_ms = std::chrono::duration<double, std::milli>(t1 - t0).count() / std::max(cfg.iters, 1);
+
+    ggml_backend_buffer_free(buf);
+    ggml_free(ctx);
+    return true;
+}
+
+static void compare_outputs(const std::vector<float> & ref, const std::vector<float> & got, double * mae, double * max_abs, double * cos_sim) {
+    double sum_abs = 0.0;
+    double max_err = 0.0;
+    double dot = 0.0;
+    double ref_norm = 0.0;
+    double got_norm = 0.0;
+    for (size_t i = 0; i < ref.size(); ++i) {
+        const double a = ref[i];
+        const double b = got[i];
+        const double diff = std::abs(a - b);
+        sum_abs += diff;
+        max_err = std::max(max_err, diff);
+        dot += a * b;
+        ref_norm += a * a;
+        got_norm += b * b;
+    }
+    *mae = sum_abs / std::max<size_t>(1, ref.size());
+    *max_abs = max_err;
+    *cos_sim = dot / std::sqrt(std::max(1e-30, ref_norm * got_norm));
+}
+
+static size_t count_nans(const std::vector<float> & data) {
+    size_t n = 0;
+    for (float v : data) {
+        if (std::isnan(v)) {
+            ++n;
+        }
+    }
+    return n;
+}
+
+int main(int argc, char ** argv) {
+    attn_case cfg;
+    if (!parse_args(argc, argv, &cfg)) {
+        usage(argv[0]);
+        return 2;
+    }
+
+    if (cfg.route == ROUTE_XMEM) {
+        setenv("GGML_OPENCL_ADRENO_XMEM_ATTN", "1", 1);
+    } else {
+        unsetenv("GGML_OPENCL_ADRENO_XMEM_ATTN");
+    }
+
+    ggml_backend_t backend_gpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_GPU, nullptr);
+    ggml_backend_t backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend_gpu || !backend_cpu) {
+        std::fprintf(stderr, "backend init failed\n");
+        return 1;
+    }
+
+    const size_t q_elems = (size_t) cfg.dq * cfg.nq * cfg.n_head * cfg.n_batch;
+    const size_t k_elems = (size_t) cfg.dq * cfg.nkv * cfg.n_head_kv * cfg.n_batch;
+    const size_t v_elems = (size_t) cfg.dv * cfg.nkv * cfg.n_head_kv * cfg.n_batch;
+    const size_t m_elems = (size_t) cfg.nkv * cfg.nq * cfg.n_batch;
+
+    std::vector<float> q_data(q_elems);
+    std::vector<float> k_data(k_elems);
+    std::vector<float> v_data(v_elems);
+    std::vector<ggml_fp16_t> mask_data(m_elems);
+    fill_random_f32(q_data, 1);
+    fill_random_f32(k_data, 2);
+    fill_random_f32(v_data, 3);
+    if (cfg.use_mask || cfg.causal_mask) {
+        fill_mask(mask_data, cfg);
+    }
+
+    std::vector<float> ref_out;
+    std::vector<float> gpu_out;
+    double cpu_ms = 0.0;
+    double gpu_ms = 0.0;
+
+    if (!run_backend(backend_gpu, cfg, q_data, k_data, v_data, mask_data, &gpu_out, &gpu_ms)) {
+        std::fprintf(stderr, "GPU run failed\n");
+        return 1;
+    }
+
+    double mae = NAN, max_abs = NAN, cos_sim = NAN;
+    size_t cpu_nan = 0;
+    if (!cfg.skip_ref) {
+        if (!run_backend(backend_cpu, cfg, q_data, k_data, v_data, mask_data, &ref_out, &cpu_ms)) {
+            std::fprintf(stderr, "CPU run failed\n");
+            return 1;
+        }
+        compare_outputs(ref_out, gpu_out, &mae, &max_abs, &cos_sim);
+        cpu_nan = count_nans(ref_out);
+    }
+
+    const double flops = 2.0 * (double) cfg.n_head * cfg.n_batch * cfg.nq * cfg.nkv * (cfg.dq + cfg.dv);
+    const double tops = flops / (gpu_ms * 1.0e-3) / 1.0e12;
+    const char * route_name = cfg.route == ROUTE_XMEM ? "xmem" : cfg.route == ROUTE_FA ? "fa" : "nofuse";
+    const size_t gpu_nan = count_nans(gpu_out);
+
+    std::printf("route=%s dq=%d dv=%d nq=%d nkv=%d n_head=%d n_head_kv=%d n_batch=%d mask=%d causal=%d\n",
+            route_name, cfg.dq, cfg.dv, cfg.nq, cfg.nkv, cfg.n_head, cfg.n_head_kv, cfg.n_batch,
+            (int) cfg.use_mask, (int) cfg.causal_mask);
+    std::printf("cpu_ms=%.6f gpu_ms=%.6f tops=%.6f mae=%.9f max_abs=%.9f cos=%.9f cpu_nan=%zu gpu_nan=%zu skip_ref=%d\n",
+            cpu_ms, gpu_ms, tops, mae, max_abs, cos_sim, cpu_nan, gpu_nan, (int) cfg.skip_ref);
+
+    ggml_backend_free(backend_gpu);
+    ggml_backend_free(backend_cpu);
+    return 0;
+}


### PR DESCRIPTION
## Summary

This PR adds an Adreno-specific xmem attention path to `ggml-opencl` behind `GGML_OPENCL_ADRENO_XMEM_ATTN`.

The new path is intended for high-throughput attention workloads on Adreno, especially:
- large prefill
- large noncausal attention
- shapes where the current `fa` or `nofuse` routes are too slow, run out of memory, or fail to run

This PR does **not** claim a decode speedup. In current `q=1` decode tests, the existing `fa` / `nofuse` routes are still faster.

## Implementation

- adds Adreno xmem attention kernels for:
  - Q/K/V staging
  - K/V packing
  - QK GEMM
  - softmax
  - PV GEMM
- wires the path into `ggml-opencl` runtime behind an explicit env gate
- adds `test-opencl-adreno-attn` to reproduce correctness and route-to-route performance
- compiles the dedicated xmem QK/PV translation units before the rest of the OpenCL kernel set

## Why the compile order change exists

On current Adreno drivers, compiling the xmem QK/PV kernels later in the overall OpenCL kernel load sequence can produce a materially slower device binary even with identical source and build options.

This PR keeps a deterministic early compile order for the xmem QK/PV units because that is currently the most stable way to preserve the fast binary on device.

A future follow-up may be able to remove this compiler-order sensitivity by expressing the hot loop more directly, for example via the already-observed QCOM inline-asm path, but that is not part of this PR.

## Correctness coverage

The new path was rechecked for:
- noncausal + GQA
- causal + GQA
- decode

Representative correctness results:
- noncausal + GQA:
  - `dq=128 dv=128 nq=256 nkv=512 n_head=8 n_head_kv=2`
  - `mae=6.7302e-05`
  - `max_abs=8.9369e-04`
  - `cos=0.999993535`
- causal + GQA:
  - `dq=128 dv=128 nq=256 nkv=256 n_head=8 n_head_kv=2`
  - `mae=7.8839e-05`
  - `max_abs=9.92954e-04`
  - `cos=0.999999313`
- decode:
  - `dq=128 dv=128 nq=1 nkv=512 n_head=8 n_head_kv=2`
  - `mae=7.4717e-05`
  - `max_abs=4.90941e-04`
  - `cos=0.999992445`

## Device

- Qualcomm Adreno 830
- OpenCL 3.0 QUALCOMM build `0800.56.1`

All throughput numbers below are full-route `gpu_ms` / effective TOPS, not `qk+pv` core-only accounting.

## Performance tests

### 1. Large noncausal Z-Image-like shape

Shape:
- `H=30, L=4224, D=128`
- noncausal
- `--mask 0 --causal 0`

Results:
- xmem: `188.606 ms / 1.453 TOPS`
- fa: process killed by system
- nofuse: OOM

This is one of the main motivations for the PR: the xmem path runs a shape that the current alternatives do not handle robustly.

### 2. Large noncausal throughput comparison

Shape:
- `H=30, L=2048, D=128`
- noncausal
- `--mask 0 --causal 0`

Results:
- xmem: `49.852 ms / 1.292 TOPS`
- fa: `2015.568 ms / 0.03196 TOPS`
- nofuse: `148.097 ms / 0.4350 TOPS`

Relative speedup:
- xmem vs fa: about `40.4x`
- xmem vs nofuse: about `3.0x`

### 3. Large causal prefill throughput comparison

Shape:
- `H=30, L=2048, D=128`
- causal prefill
- `--mask 0 --causal 1`

Results:
- xmem: `46.069 ms / 1.398 TOPS`
- fa: `2150.036 ms / 0.02996 TOPS`
- nofuse: `2155.344 ms / 0.02989 TOPS`

Relative speedup:
- xmem vs fa: about `46.7x`
- xmem vs nofuse: about `46.8x`

This is the strongest high-throughput prefill case in the current set.

### 4. Long-context, larger-head-dim noncausal shape

Shape:
- `H=1, L=16384, D=512`
- noncausal
- `--mask 0 --causal 0`

Results:
- xmem: `272.191 ms / 2.020 TOPS`
- nofuse: `1084.935 ms / 0.5067 TOPS`
- fa: crashes with `map::at`

Relative speedup:
- xmem vs nofuse: about `4.0x`

This is another important memory/coverage point: the xmem path handles a longer-context / larger-head-dim case where the current `fa` path does not run.

## Memory behavior / routing value

Compared with the current routes, the xmem path has two practical advantages in the large-workload regime:
- it is much faster in throughput-oriented prefill / noncausal attention
- it handles larger shapes more robustly

In the current tests, that means:
- shapes where `fa` is killed
- shapes where `nofuse` OOMs
- shapes where `fa` does not have a valid kernel entry and crashes

## Decode results

This PR is not presenting xmem as a decode optimization.

Two representative decode tests:
- short decode context:
  - `nq=1 nkv=512 dq=dv=128 n_head=8 n_head_kv=2`
  - xmem: `6.562 ms`
  - fa: `0.491 ms`
  - nofuse: `0.282 ms`
- long decode context:
  - `nq=1 nkv=16384 dq=dv=128 n_head=8 n_head_kv=2`
  - xmem: `12.350 ms`
  - fa: `8.276 ms`
  - nofuse: `3.535 ms`

So for current `q=1` decode:
- xmem is slower than both existing routes
- this PR should be read as a large-workload / throughput-path addition, not as a universal attention replacement

## Notes

- the current xmem path is best suited to large-`q` workloads
- decode-specific routing can be refined in follow-up work
- the compile-order workaround is deliberate and currently necessary for deterministic fast binaries on the tested Adreno driver
