### PR TITLE
Make `llama_token_to_piece` return `INT32_MIN` for invalid tokens

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1687,6 +1687,9 @@ std::string common_detokenize(const struct llama_vocab * vocab, const std::vecto
     std::string text;
     text.resize(std::max(text.capacity(), tokens.size()));
     int32_t n_chars = llama_detokenize(vocab, tokens.data(), (int32_t)tokens.size(), &text[0], (int32_t)text.size(), false, special);
+    if (n_chars == std::numeric_limits<int32_t>::min()) {
+        throw std::runtime_error("Detokenization failed: some supplied token is invalid");
+    }
     if (n_chars < 0) {
         text.resize(-n_chars);
         n_chars = llama_detokenize(vocab, tokens.data(), (int32_t)tokens.size(), &text[0], (int32_t)text.size(), false, special);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1662,6 +1662,9 @@ std::string common_token_to_piece(const struct llama_vocab * vocab, llama_token 
     std::string piece;
     piece.resize(piece.capacity());  // using string internal cache, 15 bytes + '\n'
     const int n_chars = llama_token_to_piece(vocab, token, &piece[0], piece.size(), 0, special);
+    if (n_chars == std::numeric_limits<int32_t>::min()) {
+        throw std::runtime_error("Token to piece failed: supplied token is invalid");
+    }
     if (n_chars < 0) {
         piece.resize(-n_chars);
         int check = llama_token_to_piece(vocab, token, &piece[0], piece.size(), 0, special);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <cstring>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <cinttypes>
 

--- a/examples/batched.swift/Sources/main.swift
+++ b/examples/batched.swift/Sources/main.swift
@@ -224,6 +224,9 @@ private func tokenize(text: String, add_bos: Bool) -> [llama_token] {
 private func token_to_piece(token: llama_token, buffer: inout [CChar]) -> String? {
     var result = [CChar](repeating: 0, count: 8)
     let nTokens = llama_token_to_piece(vocab, token, &result, Int32(result.count), 0, false)
+    if nTokens == Int32.min {
+        return nil
+    }
     if nTokens < 0 {
         let actualTokensCount = -Int(nTokens)
         result = .init(repeating: 0, count: actualTokensCount)

--- a/examples/batched.swift/Sources/main.swift
+++ b/examples/batched.swift/Sources/main.swift
@@ -225,7 +225,8 @@ private func token_to_piece(token: llama_token, buffer: inout [CChar]) -> String
     var result = [CChar](repeating: 0, count: 8)
     let nTokens = llama_token_to_piece(vocab, token, &result, Int32(result.count), 0, false)
     if nTokens == Int32.min {
-        return nil
+        print("llama_token_to_piece() failed")
+        exit(1)
     }
     if nTokens < 0 {
         let actualTokensCount = -Int(nTokens)

--- a/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
+++ b/examples/llama.swiftui/llama.cpp.swift/LibLlama.swift
@@ -319,7 +319,9 @@ actor LlamaContext {
             result.deallocate()
         }
         let nTokens = llama_token_to_piece(vocab, token, result, 8, 0, false)
-
+        if nTokens == Int32.min {
+            return []
+        }
         if nTokens < 0 {
             let newResult = UnsafeMutablePointer<Int8>.allocate(capacity: Int(-nTokens))
             newResult.initialize(repeating: Int8(0), count: Int(-nTokens))

--- a/include/llama.h
+++ b/include/llama.h
@@ -1150,6 +1150,7 @@ extern "C" {
     /// @param text The char pointer must be large enough to hold the resulting text.
     /// @return Returns the number of chars/bytes on success, no more than text_len_max.
     /// @return Returns a negative number on failure - the number of chars/bytes that would have been returned.
+    /// @return Returns INT32_MIN if any of the tokens is not in the vocabulary
     /// @param remove_special Allow to remove BOS and EOS tokens if model is configured to do so.
     /// @param unparse_special If true, special tokens are rendered in the output.
     LLAMA_API int32_t llama_detokenize(

--- a/include/llama.h
+++ b/include/llama.h
@@ -1135,7 +1135,7 @@ extern "C" {
     /// Does not write null terminator to the buffer.
     /// @return Returns the number of chars/bytes on success, no more than length.
     /// @return Returns a negative number on failure - the number of chars/bytes that would have been returned.
-    /// @return Returns INT32_MIN if the token is not in the vocabulary
+    /// @return Returns INT32_MIN if the token is not in the vocabulary.
     /// @param lstrip User can skip up to 'lstrip' leading spaces before copying (useful when encoding/decoding multiple tokens with 'add_space_prefix')
     /// @param special If true, special tokens are rendered in the output.
     LLAMA_API int32_t llama_token_to_piece(
@@ -1150,7 +1150,7 @@ extern "C" {
     /// @param text The char pointer must be large enough to hold the resulting text.
     /// @return Returns the number of chars/bytes on success, no more than text_len_max.
     /// @return Returns a negative number on failure - the number of chars/bytes that would have been returned.
-    /// @return Returns INT32_MIN if any of the tokens is not in the vocabulary
+    /// @return Returns INT32_MIN if any of the tokens is not in the vocabulary.
     /// @param remove_special Allow to remove BOS and EOS tokens if model is configured to do so.
     /// @param unparse_special If true, special tokens are rendered in the output.
     LLAMA_API int32_t llama_detokenize(

--- a/include/llama.h
+++ b/include/llama.h
@@ -1133,7 +1133,9 @@ extern "C" {
     /// Token Id -> Piece.
     /// Uses the vocabulary in the provided context.
     /// Does not write null terminator to the buffer.
-    /// User can skip up to 'lstrip' leading spaces before copying (useful when encoding/decoding multiple tokens with 'add_space_prefix')
+    /// @return Returns the number of chars/bytes on success, no more than length.
+    /// @return Returns a negative number on failure - the number of chars/bytes that would have been returned.
+    /// @param lstrip User can skip up to 'lstrip' leading spaces before copying (useful when encoding/decoding multiple tokens with 'add_space_prefix')
     /// @param special If true, special tokens are rendered in the output.
     LLAMA_API int32_t llama_token_to_piece(
               const struct llama_vocab * vocab,

--- a/include/llama.h
+++ b/include/llama.h
@@ -1130,11 +1130,11 @@ extern "C" {
                             bool   add_special,
                             bool   parse_special);
 
-    // Token Id -> Piece.
-    // Uses the vocabulary in the provided context.
-    // Does not write null terminator to the buffer.
-    // User can skip up to 'lstrip' leading spaces before copying (useful when encoding/decoding multiple tokens with 'add_space_prefix')
-    // @param special If true, special tokens are rendered in the output.
+    /// Token Id -> Piece.
+    /// Uses the vocabulary in the provided context.
+    /// Does not write null terminator to the buffer.
+    /// User can skip up to 'lstrip' leading spaces before copying (useful when encoding/decoding multiple tokens with 'add_space_prefix')
+    /// @param special If true, special tokens are rendered in the output.
     LLAMA_API int32_t llama_token_to_piece(
               const struct llama_vocab * vocab,
                            llama_token   token,

--- a/include/llama.h
+++ b/include/llama.h
@@ -1135,6 +1135,7 @@ extern "C" {
     /// Does not write null terminator to the buffer.
     /// @return Returns the number of chars/bytes on success, no more than length.
     /// @return Returns a negative number on failure - the number of chars/bytes that would have been returned.
+    /// @return Returns INT32_MIN if the token is not in the vocabulary
     /// @param lstrip User can skip up to 'lstrip' leading spaces before copying (useful when encoding/decoding multiple tokens with 'add_space_prefix')
     /// @param special If true, special tokens are rendered in the output.
     LLAMA_API int32_t llama_token_to_piece(

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -3676,6 +3676,9 @@ static void llama_sampler_infill_apply(struct llama_sampler * smpl, llama_token_
             }
 
             int len0 = ctx->vocab->token_to_piece(cur_p->data[i0].id, ctx->buf0.data(), ctx->buf0.size(), 0, false);
+            if (len0 == std::numeric_limits<int32_t>::min()) {
+                throw std::runtime_error("Token to piece failed: supplied token is invalid");
+            }
             if (len0 < 0) {
                 ctx->buf0.resize(len0);
                 len0 = ctx->vocab->token_to_piece(cur_p->data[i0].id, ctx->buf0.data(), ctx->buf0.size(), 0, false);
@@ -3683,6 +3686,9 @@ static void llama_sampler_infill_apply(struct llama_sampler * smpl, llama_token_
             }
 
             int len1 = ctx->vocab->token_to_piece(cur_p->data[i1].id, ctx->buf1.data(), ctx->buf1.size(), 0, false);
+            if (len1 == std::numeric_limits<int32_t>::min()) {
+                throw std::runtime_error("Token to piece failed: supplied token is invalid");
+            }
             if (len1 < 0) {
                 ctx->buf1.resize(len1);
                 len1 = ctx->vocab->token_to_piece(cur_p->data[i1].id, ctx->buf1.data(), ctx->buf1.size(), 0, false);

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3137,6 +3137,9 @@ std::string llama_vocab::impl::token_to_piece_for_cache(llama_token token, bool 
     std::string piece;
     piece.resize(piece.capacity());  // using string internal cache
     const int n_chars = vocab.token_to_piece(token, &piece[0], piece.size(), 0, special);
+    if (n_chars == std::numeric_limits<int32_t>::min()) {
+        throw std::runtime_error("Token to piece failed: supplied token is invalid");
+    }
     if (n_chars < 0) {
         piece.resize(-n_chars);
         int check = vocab.token_to_piece(token, &piece[0], piece.size(), 0, special);

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3422,82 +3422,80 @@ int32_t llama_vocab::impl::token_to_piece(llama_token token, char * buf, int32_t
         }
     }
 
-    if (0 <= token && token < (int32_t) id_to_token.size()) {
-        const std::string & token_text = id_to_token[token].text;
-        switch (get_type()) {
-            case LLAMA_VOCAB_TYPE_WPM:
-            case LLAMA_VOCAB_TYPE_SPM:
-            case LLAMA_VOCAB_TYPE_UGM: {
-                // NOTE: we accept all unsupported token types,
-                // suppressing them like CONTROL tokens.
-                if (attr & (attr_special | LLAMA_TOKEN_ATTR_USER_DEFINED)) {
-                    return _try_copy(token_text.data(), token_text.size());
-                }
-                if (attr & LLAMA_TOKEN_ATTR_NORMAL) {
+    const std::string & token_text = id_to_token[token].text;
+    switch (get_type()) {
+        case LLAMA_VOCAB_TYPE_WPM:
+        case LLAMA_VOCAB_TYPE_SPM:
+        case LLAMA_VOCAB_TYPE_UGM: {
+            // NOTE: we accept all unsupported token types,
+            // suppressing them like CONTROL tokens.
+            if (attr & (attr_special | LLAMA_TOKEN_ATTR_USER_DEFINED)) {
+                return _try_copy(token_text.data(), token_text.size());
+            }
+            if (attr & LLAMA_TOKEN_ATTR_NORMAL) {
+                std::string result = token_text;
+                llama_unescape_whitespace(result);
+                return _try_copy(result.data(), result.size());
+            }
+            if (attr & LLAMA_TOKEN_ATTR_BYTE) {
+                char byte = (char) token_to_byte(token);
+                return _try_copy((char*) &byte, 1);
+            }
+            break;
+        }
+        case LLAMA_VOCAB_TYPE_BPE: {
+            // NOTE: we accept all unsupported token types,
+            // suppressing them like CONTROL tokens.
+            if (attr & (attr_special | LLAMA_TOKEN_ATTR_USER_DEFINED)) {
+                return _try_copy(token_text.data(), token_text.size());
+            }
+            if (attr & LLAMA_TOKEN_ATTR_NORMAL) {
+                if (escape_whitespaces) {
+                    // SPM-style BPE: tokens contain ▁ for spaces
                     std::string result = token_text;
                     llama_unescape_whitespace(result);
                     return _try_copy(result.data(), result.size());
                 }
-                if (attr & LLAMA_TOKEN_ATTR_BYTE) {
-                    char byte = (char) token_to_byte(token);
-                    return _try_copy((char*) &byte, 1);
-                }
-                break;
-            }
-            case LLAMA_VOCAB_TYPE_BPE: {
-                // NOTE: we accept all unsupported token types,
-                // suppressing them like CONTROL tokens.
-                if (attr & (attr_special | LLAMA_TOKEN_ATTR_USER_DEFINED)) {
-                    return _try_copy(token_text.data(), token_text.size());
-                }
-                if (attr & LLAMA_TOKEN_ATTR_NORMAL) {
-                    if (escape_whitespaces) {
-                        // SPM-style BPE: tokens contain ▁ for spaces
-                        std::string result = token_text;
-                        llama_unescape_whitespace(result);
-                        return _try_copy(result.data(), result.size());
-                    }
-                    std::string result = llama_decode_text(token_text);
-                    return _try_copy(result.data(), result.size());
-                }
-                if (attr & LLAMA_TOKEN_ATTR_BYTE) {
-                    char byte = (char) token_to_byte(token);
-                    return _try_copy((char*) &byte, 1);
-                }
-                break;
-            }
-            case LLAMA_VOCAB_TYPE_RWKV: {
-                std::vector<uint8_t> result = llama_unescape_rwkv_token(token_text);
-
-                // If we don't have enough space, return an error
-                if (result.size() > (size_t)length) {
-                    return -(int)result.size();
-                }
-
-                memcpy(buf, result.data(), result.size());
-                return (int)result.size();
-            }
-            case LLAMA_VOCAB_TYPE_PLAMO2: {
-                // PLaMo-2 uses similar token handling as BPE/SPM
-                if (vocab.is_byte(token)) {
-                    // Handle byte tokens like <0xXX>
-                    if (token_text.length() == 6 && token_text.substr(0, 3) == "<0x" && token_text.back() == '>') {
-                        int hex_val = std::stoi(token_text.substr(3, 2), nullptr, 16);
-                        if (length < 1) {
-                            return -1;
-                        }
-                        buf[0] = static_cast<char>(hex_val);
-                        return 1;
-                    }
-                }
-
-                // Normal token - just copy the text
-                std::string result = token_text;
+                std::string result = llama_decode_text(token_text);
                 return _try_copy(result.data(), result.size());
             }
-            default:
-                GGML_ABORT("fatal error");
+            if (attr & LLAMA_TOKEN_ATTR_BYTE) {
+                char byte = (char) token_to_byte(token);
+                return _try_copy((char*) &byte, 1);
+            }
+            break;
         }
+        case LLAMA_VOCAB_TYPE_RWKV: {
+            std::vector<uint8_t> result = llama_unescape_rwkv_token(token_text);
+
+            // If we don't have enough space, return an error
+            if (result.size() > (size_t)length) {
+                return -(int)result.size();
+            }
+
+            memcpy(buf, result.data(), result.size());
+            return (int)result.size();
+        }
+        case LLAMA_VOCAB_TYPE_PLAMO2: {
+            // PLaMo-2 uses similar token handling as BPE/SPM
+            if (vocab.is_byte(token)) {
+                // Handle byte tokens like <0xXX>
+                if (token_text.length() == 6 && token_text.substr(0, 3) == "<0x" && token_text.back() == '>') {
+                    int hex_val = std::stoi(token_text.substr(3, 2), nullptr, 16);
+                    if (length < 1) {
+                        return -1;
+                    }
+                    buf[0] = static_cast<char>(hex_val);
+                    return 1;
+                }
+            }
+
+            // Normal token - just copy the text
+            std::string result = token_text;
+            return _try_copy(result.data(), result.size());
+        }
+        default:
+            GGML_ABORT("fatal error");
     }
 
     return 0;

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3545,6 +3545,9 @@ int32_t llama_vocab::impl::detokenize(
         GGML_ASSERT(avail >= 0);
         int32_t n_chars = token_to_piece(tokens[i], text, avail, remove_space, unparse_special);
         remove_space = false;
+        if (n_chars == std::numeric_limits<int32_t>::min()) {
+            return std::numeric_limits<int32_t>::min();
+        }
         if (n_chars < 0) {
             avail = 0;
             total -= n_chars;
@@ -3970,6 +3973,9 @@ std::string llama_vocab::detokenize(const std::vector<llama_token> & tokens, boo
     std::string text;
     text.resize(std::max(text.capacity(), tokens.size()));
     int32_t n_chars = detokenize(tokens.data(), (int32_t)tokens.size(), &text[0], (int32_t)text.size(), false, special);
+    if (n_chars == std::numeric_limits<int32_t>::min()) {
+        throw std::runtime_error("Detokenization failed: some supplied token is invalid");
+    }
     if (n_chars < 0) {
         text.resize(-n_chars);
         n_chars = detokenize(tokens.data(), (int32_t)tokens.size(), &text[0], (int32_t)text.size(), false, special);

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -3382,6 +3382,11 @@ std::vector<llama_token> llama_vocab::impl::tokenize(
 }
 
 int32_t llama_vocab::impl::token_to_piece(llama_token token, char * buf, int32_t length, int32_t lstrip, bool special) const {
+    if (token < 0 || token >= (int32_t) id_to_token.size()) {
+        LLAMA_LOG_ERROR("%s: invalid token %d\n", __func__, token);
+        return std::numeric_limits<int32_t>::min();
+    }
+
     // ref: https://github.com/ggml-org/llama.cpp/pull/7587#discussion_r1620983843
     static const int attr_special = LLAMA_TOKEN_ATTR_UNKNOWN | LLAMA_TOKEN_ATTR_CONTROL;
     const llama_token_attr attr = token_get_attr(token);

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -250,6 +250,9 @@ struct test_context {
         std::string piece;
         piece.resize(piece.capacity());  // using string internal cache, 15 bytes + '\n'
         const int n_chars = llama_token_to_piece(vocab, token, &piece[0], piece.size(), 0, special);
+        if (n_chars == std::numeric_limits<int32_t>::min()) {
+            throw std::runtime_error("Token to piece failed: supplied token is invalid");
+        }
         if (n_chars < 0) {
             piece.resize(-n_chars);
             int check = llama_token_to_piece(vocab, token, &piece[0], piece.size(), 0, special);

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -8,6 +8,7 @@
 #undef NDEBUG
 #endif
 
+#include <limits>
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>

--- a/tests/test-tokenizer-random.py
+++ b/tests/test-tokenizer-random.py
@@ -110,6 +110,8 @@ class LibLlamaModel:
         for i, id in enumerate(ids):
             self.token_ids[i] = id
         num = self.lib.llama_detokenize(self.model, self.token_ids, len(ids), self.text_buff, len(self.text_buff), remove_special, unparse_special)
+        if num == - (1 << 31):
+            raise RuntimeError("error: detokenization failed: some supplied token is invalid")
         while num < 0 and len(self.text_buff) < (16 << 20):
             self.text_buff = self.ffi.new("uint8_t[]", -2 * num)
             num = self.lib.llama_detokenize(self.model, self.token_ids, len(ids), self.text_buff, len(self.text_buff), remove_special, unparse_special)

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -16,6 +16,7 @@
 #include <windows.h>
 #endif
 
+#include <limits>
 #include <algorithm>
 #include <cerrno>
 #include <cstdio>

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -619,6 +619,9 @@ private:
         std::string piece;
         piece.resize(piece.capacity());  // using string internal cache, 15 bytes + '\n'
         const int n_chars = llama_token_to_piece(vocab, token, &piece[0], piece.size(), 0, special);
+        if (n_chars == std::numeric_limits<int32_t>::min()) {
+            throw std::runtime_error("Token to piece failed: supplied token is invalid");
+        }
         if (n_chars < 0) {
             piece.resize(-n_chars);
             int check = llama_token_to_piece(vocab, token, &piece[0], piece.size(), 0, special);


### PR DESCRIPTION
## Overview

The `llama_token_to_piece` function currently throws `std::out_of_range` for invalid token inputs. This is supposed to be a C interface, but this exception cannot be caught from C. It also does not look like this was a deliberate choice, since it happens on a `std::vector` access done indirectly via `token_get_attr`. Furthermore, `llama_token_to_piece` has a bounds check further down, but this can never trigger since it already throws on the access in `token_get_attr`.

This PR moves the existing bounds check to the very beginning of `llama_token_to_piece` which logs the error and returns `INT32_MIN` if the token is invalid. This is in analogy to another unrecoverable error condition in `llama_tokenize`. I clarified the existing docstring and added documentation for the new behavior.

## Additional information

There is some previous discussion in https://github.com/ggml-org/llama.cpp/pull/9359.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, exclusively for exploring the code base