### PR TITLE
Gbnf - literal token filtering for non-control tokens.

### DIFF
--- a/grammars/README.md
+++ b/grammars/README.md
@@ -69,15 +69,71 @@ Parentheses `()` can be used to group sequences, which allows for embedding alte
 
 ## Tokens
 
-Tokens allow grammars to match specific tokenizer tokens rather than character sequences. This is useful for constraining outputs based on special tokens (like `<think>` or `</think>`).
+The terminals described so far (`"abc"`, `[a-z]`, `.`) match **character sequences** in the model's output. A *token* terminal instead matches **a single tokenizer token by id**, regardless of what bytes that token decodes to.
 
-Tokens can be specified in two ways:
+This is useful when you want to constrain the model's output in terms of its own vocabulary — for example, requiring it to emit a specific control token like `<think>`, or forbidding a particular token mid-sequence.
 
-1. **Token ID**: Use angle brackets with the token ID in square brackets: `<[token-id]>`. For example, `<[1000]>` matches the token with ID 1000.
+There are three ways to write a token terminal:
 
-2. **Token string**: Use angle brackets with the token text directly: `<token>`. For example, `<think>` will match the token whose text is exactly `<think>`. This only works if the string tokenizes to exactly one token in the vocabulary, otherwise the grammar will fail to parse.
+### 1. By token id — `<[N]>`
 
-You can negate token matches using the `!` prefix: `!<[1000]>` or `!<think>` matches any token *except* the specified one.
+`<[N]>` matches the token whose id is `N`.
+
+```
+root ::= <[1000]>     # matches token id 1000
+```
+
+This is the most explicit form and works without a tokenizer being present.
+
+### 2. By literal text including the brackets — `<text>`
+
+`<text>` looks up the token whose vocabulary text is **literally** `<text>` — angle brackets included. This is the form to use for special tokens that store the brackets as part of their name (most chat-template control tokens do):
+
+```
+root ::= <think> .* </think>     # matches the special tokens <think> and </think>
+```
+
+Internally the grammar parser passes the full slice — angle brackets and all — to the model's tokenizer and requires it to resolve to exactly one token. If it doesn't, grammar parsing fails.
+
+### 3. By literal text without the brackets — `<{text}>`
+
+`<{text}>` looks up the token whose text is exactly `text` (no brackets). Use this for ordinary tokens, or for special tokens whose vocabulary name does not contain angle brackets:
+
+```
+root ::= <{Hello}> <{ world}>    # matches the tokens "Hello" and " world"
+```
+
+Inside `<{...}>`, the standard GBNF string escapes are accepted (`\\`, `\"`, `\[`, `\]`, `\t`, `\r`, `\n`, `\xXX`, `\uXXXX`, `\UXXXXXXXX`), plus `\}` for a literal closing brace.
+
+As with form 2, the inner text must tokenize to exactly one token or grammar parsing fails.
+
+### Negation — `!`
+
+Prefix any of the three forms with `!` to match *any token except* the specified one:
+
+```
+thinking  ::= !</think>*         # any tokens except the </think> special token
+not-hello ::= !<{Hello}>         # any single token that is not "Hello"
+not-1000  ::= !<[1000]>          # any single token whose id is not 1000
+```
+
+### Requirements and caveats
+
+- Forms 2 and 3 require a tokenizer to be available at grammar build time (i.e. the grammar must be loaded against a model). Form 1 does not.
+- All three forms match exactly one token at a time. Use sequencing or repetition to match multiple.
+- Token terminals and character terminals can be freely mixed in the same rule.
+
+### Choosing between the forms
+
+| You want to match…                                        | Use         |
+| --------------------------------------------------------- | ----------- |
+| A specific token id you already know                      | `<[N]>`     |
+| A special token whose vocab text contains angle brackets  | `<text>`    |
+| Any other token, by its literal text                      | `<{text}>`  |
+
+Behind the scenes all three forms compile to the same internal representation (a token-id match), so they are interchangeable wherever they resolve to the same id.
+
+### Example
 
 ```
 # Match a thinking block: <think>...</think>

--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -91,6 +91,39 @@ static std::pair<std::vector<uint32_t>, llama_partial_utf8> decode_utf8(
     return std::make_pair(std::move(code_points), llama_partial_utf8{ value, n_remain });
 }
 
+static void encode_utf8(uint32_t cp, std::string & out) {
+    if (cp < 0x80) {
+        out.push_back(static_cast<char>(cp));
+    } else if (cp < 0x800) {
+        out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp < 0x10000) {
+        out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else {
+        out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+}
+
+// Tokenize `text` (length `text_len`) and require exactly 1 token. The
+// `src_slice` / `src_slice_len` pair is only used to format the error
+// message so the grammar author sees the original source form.
+static llama_token tokenize_exactly_one(
+        const llama_vocab * vocab,
+        const char * text, size_t text_len,
+        const char * src_slice, size_t src_slice_len) {
+    llama_token tokens[2];
+    int32_t n_tokens = vocab->tokenize(text, static_cast<int32_t>(text_len), tokens, 2, false, true);
+    if (n_tokens != 1) {
+        throw std::runtime_error("invalid token '" + std::string(src_slice, src_slice_len) + "'");
+    }
+    return tokens[0];
+}
+
 static bool is_digit_char(char c) {
     return '0' <= c && c <= '9';
 }
@@ -172,6 +205,7 @@ static std::pair<uint32_t, const char *> parse_char(const char * src) {
             case '"':
             case '[':
             case ']':
+            case '}':
                       return std::make_pair(src[1], src + 2);
             default:
                       throw std::runtime_error(std::string("unknown escape at ") + src);
@@ -206,6 +240,30 @@ static std::pair<uint32_t, const char *> parse_token(const llama_vocab * vocab, 
         return std::make_pair(token_id, pos);
     }
 
+    // Parse <{TEXT}> — tokenize TEXT (no brackets); require exactly 1 token.
+    if (*pos == '{') {
+        pos++;
+        std::string buf;
+        while (*pos != 0 && *pos != '}') {
+            auto [cp, next] = parse_char(pos);
+            encode_utf8(cp, buf);
+            pos = next;
+        }
+        if (*pos != '}') {
+            throw std::runtime_error(std::string("expecting '}' at ") + pos);
+        }
+        pos++;
+        if (*pos != '>') {
+            throw std::runtime_error(std::string("expecting '>' at ") + pos);
+        }
+        pos++;
+
+        if (vocab == nullptr) {
+            throw std::runtime_error(std::string("no vocab to parse token at ") + src);
+        }
+        return std::make_pair(tokenize_exactly_one(vocab, buf.data(), buf.size(), src, pos - src), pos);
+    }
+
     if (vocab == nullptr) {
         throw std::runtime_error(std::string("no vocab to parse token at ") + src);
     }
@@ -219,13 +277,7 @@ static std::pair<uint32_t, const char *> parse_token(const llama_vocab * vocab, 
     }
     pos++;
 
-    llama_token tokens[2];
-    int32_t n_tokens = vocab->tokenize(src, static_cast<int32_t>(pos - src), tokens, 2, false, true);
-    if (n_tokens != 1) {
-        // must tokenize to exactly 1 token
-        throw std::runtime_error("invalid token '" + std::string(src, pos - src) + "'");
-    }
-    return std::make_pair(tokens[0], pos);
+    return std::make_pair(tokenize_exactly_one(vocab, src, pos - src, src, pos - src), pos);
 }
 
 static void print_grammar_char(FILE * file, uint32_t c) {

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -1476,6 +1476,14 @@ static void test_json_schema() {
     );
 }
 
+static void test_token_string_filter_failure_modes() {
+    fprintf(stderr, "Testing <{TEXT}> failure modes (no vocab in this test binary)\n");
+    assert(test_build_grammar_fails("root ::= <{Hello}>"));   // null vocab
+    assert(test_build_grammar_fails("root ::= <{abc"));       // unterminated
+    assert(test_build_grammar_fails("root ::= <{abc}"));      // missing '>'
+    assert(test_build_grammar_fails("root ::= <{a}b>"));      // characters between '}' and '>'
+}
+
 int main() {
     fprintf(stdout, "Running grammar integration tests...\n");
     test_simple_grammar();
@@ -1488,6 +1496,7 @@ int main() {
     test_failure_missing_root_symbol();
     test_custom_root_symbol_check();
     test_json_schema();
+    test_token_string_filter_failure_modes();
     fprintf(stdout, "All tests passed.\n");
     return 0;
 }

--- a/tests/test-grammar-parser.cpp
+++ b/tests/test-grammar-parser.cpp
@@ -519,6 +519,19 @@ int main()
         {LLAMA_GRETYPE_END, 0},
     });
 
+    // Char terminals must accept \} as a literal '}' (extension required by <{TEXT}> token form).
+    verify_parsing(R"""(
+        root ::= "a\}b"
+    )""", {
+        {"root", 0}
+    }, {
+        // root (index 0)
+        {LLAMA_GRETYPE_CHAR, 'a'},
+        {LLAMA_GRETYPE_CHAR, '}'},
+        {LLAMA_GRETYPE_CHAR, 'b'},
+        {LLAMA_GRETYPE_END, 0},
+    });
+
     // <[1000]> = "<think>"
     // <[1001]> = "</think>"
     verify_parsing(R"""(
@@ -532,6 +545,14 @@ int main()
         {LLAMA_GRETYPE_TOKEN, 1001},
         {LLAMA_GRETYPE_END, 0},
     });
+
+    // <{TEXT}> token-string form: dispatch should fail cleanly on missing vocab and on syntax errors.
+    // Without a vocab, all three of these end up failing — they exist to lock in clean failure
+    // behavior of the new dispatch branch and catch crashes/regressions.
+    verify_failure(R"""(root ::= <{Hello}>)""");      // null vocab
+    verify_failure(R"""(root ::= <{abc)""");          // unterminated: missing '}'
+    verify_failure(R"""(root ::= <{abc})""");         // missing closing '>'
+    verify_failure(R"""(root ::= <{a}b>)""");         // characters between '}' and '>'
 
     return 0;
 }


### PR DESCRIPTION
## Overview

Small but meaningful improvement to gbnf grammar. 

Currently a token `<text>` is matched to the token with the **exact** string `<text>`.
This works perfectly well when filtering for control tokens, but fails if the tokens do not start and end with `<` and `>`.

This PR addresses this in a way that preserves functionality with minimal changes.

Keeping in line with the notation for gbnf token values  `<[N]>`, it adds `<{text}>` to search for the exact text inside.
This preserves existing grammars that use control tokens unchanged (except for the small edge case where a control token has the initial shape  `<{`.

For these situations, this new implementation adds `\` as an escape character and accepts control characters. 

## Additional information

| You want to match…                                        | Use         |
| --------------------------------------------------------- | ----------- |
| A specific token id you already know                      | `<[N]>`     |
| A special token whose vocab text contains angle brackets  | `<text>`    |
| Any other token, by its literal text  (new)                  | `<{text}>`  |

Tested with gemma-4-26B-A4B-it-Q4_K_M and llama-cpp built with CUDA.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Used to prototype code and to clean up the English and formatting in md file. All AI geenerated code was reviewed

