### PR TITLE
Tensor-parallel: Fix delayed AllReduce on Gemma-4 MoE

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1661,6 +1661,24 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
 
                 ggml_tensor * node = cgraph->nodes[id];
                 int32_t n_used = ggml_node_get_use_count(cgraph, id);
+
+                // Skip MIRRORED nodes that don't consume node
+                auto skip_unrelated = [&]() {
+                    while (id + 1 < cgraph->n_nodes) {
+                        ggml_tensor * next = cgraph->nodes[id+1];
+                        bool uses_node = false;
+                        for (int s = 0; s < GGML_MAX_SRC; s++) {
+                            if (next->src[s] == node) { uses_node = true; break; }
+                        }
+                        if (uses_node) break;
+                        if (ggml_backend_meta_get_split_state(next, false).axis != GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                            break;
+                        }
+                        id++;
+                    }
+                };
+
+                skip_unrelated();
                 if (id + 1 >= cgraph->n_nodes) {
                     return idr;
                 }
@@ -1675,10 +1693,12 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                         n_used = ggml_node_get_use_count(cgraph, id);
                     }
                 }
-                if (id + 1 >= cgraph->n_nodes) {
-                    return idr;
-                }
-                {
+                // Chain of MULs with MIRRORED src[1]
+                while (true) {
+                    skip_unrelated();
+                    if (id + 1 >= cgraph->n_nodes) {
+                        return idr;
+                    }
                     ggml_tensor * next = cgraph->nodes[id+1];
                     if (next->op == GGML_OP_MUL && next->src[0] == node &&
                             ggml_backend_meta_get_split_state(next->src[1], false).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
@@ -1686,6 +1706,8 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                         id++;
                         idr = id;
                         n_used = ggml_node_get_use_count(cgraph, id);
+                    } else {
+                        break;
                     }
                 }
 

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1666,25 +1666,26 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                 auto skip_unrelated = [&]() {
                     while (id + 1 < cgraph->n_nodes) {
                         ggml_tensor * next = cgraph->nodes[id+1];
-                        bool uses_node = false;
-                        for (int s = 0; s < GGML_MAX_SRC; s++) {
-                            if (next->src[s] == node) { uses_node = true; break; }
-                        }
-                        if (uses_node) break;
                         if (ggml_backend_meta_get_split_state(next, false).axis != GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
                             break;
                         }
-                        
-                        bool all_srcs_mirrored = true;
+                        bool safe = true;
                         for (int s = 0; s < GGML_MAX_SRC; s++) {
-                            if (next->src[s] == nullptr) continue;
-                            if (ggml_backend_meta_get_split_state(next->src[s], false).axis
-                                    != GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
-                                all_srcs_mirrored = false;
+                            if (next->src[s] == nullptr) {
+                                continue;
+                            }
+                            if (next->src[s] == node) {
+                                safe = false;
+                                break;
+                            }
+                            if (ggml_backend_meta_get_split_state(next->src[s], false).axis != GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                                safe = false;
                                 break;
                             }
                         }
-                        if (!all_srcs_mirrored) break;
+                        if (!safe) {
+                            break;
+                        }
                         id++;
                     }
                 };

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1674,6 +1674,17 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                         if (ggml_backend_meta_get_split_state(next, false).axis != GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
                             break;
                         }
+                        
+                        bool all_srcs_mirrored = true;
+                        for (int s = 0; s < GGML_MAX_SRC; s++) {
+                            if (next->src[s] == nullptr) continue;
+                            if (ggml_backend_meta_get_split_state(next->src[s], false).axis
+                                    != GGML_BACKEND_SPLIT_AXIS_MIRRORED) {
+                                all_srcs_mirrored = false;
+                                break;
+                            }
+                        }
+                        if (!all_srcs_mirrored) break;
                         id++;
                     }
                 };


### PR DESCRIPTION
Skip forward past nodes that don't consume the current node, and allow a chain of MULs.

When `down_exps_s` is set, build_moe_ffn pulls the scale tensor in via reshape/repeat/get_rows. Topological sort places those between `mul_mat_id` and the MUL that consumes it, so the existing nodes[id+1] check never sees an ADD_ID or MUL and fails.

The scale MUL is followed by a second MUL; the old code only accepted one.

Performance on 2x 5090:

model | test | t/s - d5b780a67 | t/s - PR | Speed-up
-- | -- | -- | -- | --
gemma4 26B.A4B Q8_0 | pp512 | 3473.35 | 7202.7 | 2.07
gemma4 26B.A4B Q8_0 | tg128 | 164.29 | 202.45 | 1.23


# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, took help in identifying the root cause