### PR TITLE
ggml: count new split inputs before appending node (fixes #21730)

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1272,27 +1272,43 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
             // check if we should start a new split based on the sources of the current node
             bool need_new_split = false;
             if (node_backend_id == cur_backend_id && split->n_inputs > 0) {
+                int n_new_inputs = 0;
+                size_t new_input_ids[GGML_MAX_SRC];
                 for (int j = 0; j < GGML_MAX_SRC; j++) {
                     struct ggml_tensor * src = node->src[j];
                     if (src == NULL) {
                         continue;
                     }
+
+                    const size_t id = hash_id(src);
+                    const int src_backend_id = sched->hv_tensor_backend_ids[id];
+                    GGML_ASSERT(src_backend_id != -1);
+                    const bool supported = ggml_backend_sched_buffer_supported(sched, src, cur_backend_id);
+
                     // check if a weight is on a different and incompatible backend
                     // by starting a new split, the memory of the previously offloaded weights can be reused
                     if (src->buffer != NULL && src->buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS) {
-                        int src_backend_id = tensor_backend_id(src);
-                        if (src_backend_id != cur_backend_id && !ggml_backend_sched_buffer_supported(sched, src, cur_backend_id)) {
+                        if (src_backend_id != cur_backend_id && !supported) {
                             need_new_split = true;
                             break;
                         }
                     }
-                    // check if the split has too many inputs
-                    // FIXME: count the number of inputs instead of only checking when full
-                    if (split->n_inputs == GGML_SCHED_MAX_SPLIT_INPUTS) {
-                        const size_t id = hash_id(src);
-                        int src_backend_id = sched->hv_tensor_backend_ids[id];
-                        bool supported = ggml_backend_sched_buffer_supported(sched, src, cur_backend_id);
-                        if (src_backend_id != cur_backend_id && tensor_id_copy(id, cur_backend_id, 0) == NULL && !supported) {
+
+                    // check if keeping this node in the current split would require too many copied inputs
+                    if (src_backend_id != cur_backend_id && tensor_id_copy(id, cur_backend_id, 0) == NULL && !supported) {
+                        bool already_counted = false;
+                        for (int k = 0; k < n_new_inputs; k++) {
+                            if (new_input_ids[k] == id) {
+                                already_counted = true;
+                                break;
+                            }
+                        }
+                        if (already_counted) {
+                            continue;
+                        }
+
+                        new_input_ids[n_new_inputs++] = id;
+                        if (split->n_inputs + n_new_inputs > GGML_SCHED_MAX_SPLIT_INPUTS) {
                             need_new_split = true;
                             break;
                         }


### PR DESCRIPTION
## Overview

Implemented the proper new-input-counting described in the FIXME. When `split->n_inputs` is close to `GGML_SCHED_MAX_SPLIT_INPUTS` (e.g. 29) and a candidate node has more than 1 input which requires a copy (such as a flash attention node when KV cache is fully offloaded to host memory), this will cause an assertion to fail and llama-server to crash. Now, the code first counts how many new copied inputs a node would add to the existing split and checks whether `GGML_SCHED_MAX_SPLIT_INPUTS` would be exceeded. This should fix issue #21730.

## Additional information

While testing gemma 4 e4b, I needed VRAM for another process and started llama-server with `--fit-target 8192` on my 4070 Ti (12GB). While trying to load the model, llama-server crashed due to a failed assertion:

<details>
<summary>logs</summary>

```text
$ ./run_llama_cpp.sh 
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 11873 MiB):
  Device 0: NVIDIA GeForce RTX 4070 Ti, compute capability 8.9, VMM: yes, VRAM: 11873 MiB
load_backend: loaded CUDA backend from /app/libggml-cuda.so
load_backend: loaded CPU backend from /app/libggml-cpu-haswell.so
build_info: b8763-ff5ef8278
system_info: n_threads = 12 (n_threads_batch = 12) / 24 | CUDA : ARCHS = 750,800,860,890,1200,1210 | USE_GRAPHS = 1 | PEER_MAX_BATCH_SIZE = 128 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
Running without SSL
init: using 23 threads for HTTP server
start: binding port with default address family
main: loading model
srv    load_model: loading model '/models/gemma-4-E4B-it-Q4_K_M.gguf'
common_init_result: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on
llama_params_fit_impl: projected to use 4610 MiB of device memory vs. 9028 MiB of free device memory
llama_params_fit_impl: cannot meet free memory target of 8192 MiB, need to reduce device memory by 3773 MiB
llama_params_fit_impl: context size set by user to 65536 -> no change
llama_params_fit_impl: filling dense layers back-to-front:
/app/ggml/src/ggml-backend.cpp:1365: GGML_ASSERT(n_inputs < GGML_SCHED_MAX_SPLIT_INPUTS) failed
libggml-base.so.0(+0x19c36)[0x7f63e1585c36]
libggml-base.so.0(ggml_print_backtrace+0x21a)[0x7f63e158609a]
libggml-base.so.0(ggml_abort+0x15b)[0x7f63e158627b]
libggml-base.so.0(ggml_backend_sched_split_graph+0x222b)[0x7f63e15a247b]
libllama.so.0(_ZN13llama_context13graph_reserveEjjjPK22llama_memory_context_ibPm+0x676)[0x7f63e16fe7f6]
libllama.so.0(_ZN13llama_context13sched_reserveEv+0xd80)[0x7f63e1700610]
libllama.so.0(_ZN13llama_contextC2ERK11llama_model20llama_context_params+0xa99)[0x7f63e1701c99]
libllama.so.0(llama_init_from_model+0x134)[0x7f63e1702a84]
libllama.so.0(+0xa0a42)[0x7f63e16d8a42]
libllama.so.0(+0xa1304)[0x7f63e16d9304]
libllama.so.0(+0xa347d)[0x7f63e16db47d]
libllama.so.0(llama_params_fit+0x52)[0x7f63e16dda62]
/app/llama-server(+0x286d3c)[0x55795091ad3c]
/app/llama-server(+0x28950a)[0x55795091d50a]
/app/llama-server(+0x18db4c)[0x557950821b4c]
/app/llama-server(+0xd35c0)[0x5579507675c0]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7f63e0fef1ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7f63e0fef28b]
/app/llama-server(+0xdb835)[0x55795076f835]

$ echo $?
139

$ cat run_llama_cpp.sh
#!/usr/bin/env bash
set -euo pipefail

podman run --rm \
  --gpus all \
  -v /mnt/C/models:/models \
  -p 0.0.0.0:11424:8080 \
  --entrypoint /app/llama-server \
  local/llama.cpp:full-cuda \
  -m "/models/gemma-4-E4B-it-Q4_K_M.gguf" \
  --host 0.0.0.0 \
  --port 8080 \
  -np 1 \
  -c 65536 \
  --reasoning-format auto \
  --fit-target 8192
```

</details>

There is an existing [issue](https://github.com/ggml-org/llama.cpp/issues/21730) with people having the same traceback on the same model. They mention `--fit off` and "forcing the model on a single gpu" fixing the problem. I found the FIXME and after implementing it, the model now loads and runs fine on my machine.

While debugging, I added some temporary logs right before the assertion failed, which showed that `cache_v_l22` (offloaded to CPU) was responsible for bringing n_inputs from 29 to 31 along with another operand which I believe to be `cache_k_l22` (technically didn't confirm this but the alternative -- the freshly computed query -- doesn't make much sense).
This triggered the assertion error because `GGML_SCHED_MAX_SPLIT_INPUTS` is 30 and because previously, the function was checking that `split->n_inputs` had not exceeded the limit of 30 yet... twice, without updating `split->n_inputs`. With both K and V cache being copied from host memory with 29 existing inputs, we hit the case the FIXME warns about.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, to help me understand the codebase more quickly, and to review changes.
