### PR TITLE
common : move log to llama-common-base

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -33,15 +33,22 @@ else()
     message(WARNING "Git repository not found; to enable automatic generation of build info, make sure Git is installed and the project is a Git repository.")
 endif()
 
-set(TEMPLATE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/build-info.cpp.in")
-set(OUTPUT_FILE   "${CMAKE_CURRENT_BINARY_DIR}/build-info.cpp")
+set(BUILD_INFO_FILE_TMPL "${CMAKE_CURRENT_SOURCE_DIR}/build-info.cpp.in")
+set(BUILD_INFO_FILE_OUT  "${CMAKE_CURRENT_BINARY_DIR}/build-info.cpp")
 
-configure_file(${TEMPLATE_FILE} ${OUTPUT_FILE})
+configure_file(${BUILD_INFO_FILE_TMPL} ${BUILD_INFO_FILE_OUT})
 
 set(TARGET llama-common-base)
-add_library(${TARGET} STATIC ${OUTPUT_FILE})
+add_library(${TARGET} STATIC
+    log.cpp
+    log.h
+    ${BUILD_INFO_FILE_OUT}
+    build-info.h
+)
 
 target_include_directories(${TARGET} PUBLIC .)
+
+target_link_libraries(${TARGET} PUBLIC ggml)
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -80,8 +87,6 @@ add_library(${TARGET}
     json-partial.h
     json-schema-to-grammar.cpp
     llguidance.cpp
-    log.cpp
-    log.h
     ngram-cache.cpp
     ngram-cache.h
     ngram-map.cpp

--- a/common/log.cpp
+++ b/common/log.cpp
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "log.h"
 
 #include <chrono>
@@ -60,6 +59,29 @@ static std::vector<const char *> g_col = {
     "",
     "",
 };
+
+static bool tty_can_use_colors() {
+    // Check NO_COLOR environment variable (https://no-color.org/)
+    if (const char * no_color = std::getenv("NO_COLOR")) {
+        if (no_color[0] != '\0') {
+            return false;
+        }
+    }
+
+    // Check TERM environment variable
+    if (const char * term = std::getenv("TERM")) {
+        if (std::strcmp(term, "dumb") == 0) {
+            return false;
+        }
+    }
+
+    // Check if stdout and stderr are connected to a terminal
+    // We check both because log messages can go to either
+    bool stdout_is_tty = isatty(fileno(stdout));
+    bool stderr_is_tty = isatty(fileno(stderr));
+
+    return stdout_is_tty || stderr_is_tty;
+}
 
 struct common_log_entry {
     enum ggml_log_level level;


### PR DESCRIPTION
## Overview

fix #22142

Move the log functionality to the static `llama-common-base` to resolve destruction order issues on windows.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
