### PR TITLE
server : do not cap slot context to training context (#22140)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -759,10 +759,11 @@ private:
 
         const int n_ctx_train = llama_model_n_ctx_train(model);
 
-        int n_ctx_slot = llama_n_ctx_seq(ctx);
+        const int n_ctx_slot = llama_n_ctx_seq(ctx);
         if (n_ctx_slot > n_ctx_train) {
-            SRV_WRN("the slot context (%d) exceeds the training context of the model (%d) - capping\n", n_ctx_slot, n_ctx_train);
-            n_ctx_slot = n_ctx_train;
+            SRV_WRN("the slot context (%d) exceeds the training context of the model (%d) - "
+                    "generation quality may degrade beyond the training context unless RoPE scaling is configured\n",
+                    n_ctx_slot, n_ctx_train);
         }
 
         slots.clear();


### PR DESCRIPTION
## Summary

Fixes #22140.

`server_context` silently capped each slot's `n_ctx` to the model's training context, so any user who extended the context via RoPE scaling (YaRN) — the whole point of models like Qwen3 — effectively had their `--ctx-size` ignored once the slot was created, even though the KV cache had already been sized for the full `n_ctx_seq`.

This PR drops the cap and keeps only the warning. `llama_context` itself already logs `"n_ctx_seq (...) > n_ctx_train (...) -- possible training context overflow"`, so users still see the safety signal.

## Before

```
llama_context: n_ctx_seq     = 4096
llama_kv_cache: size =    2.50 MiB (  4096 cells, ...)
srv    load_model: the slot context (4096) exceeds the training context of the model (2048) - capping
slot   load_model: id  0 | task -1 | new slot, n_ctx = 2048   ← halved
```

## After

```
llama_context: n_ctx_seq     = 4096
llama_kv_cache: size =    2.50 MiB (  4096 cells, ...)
srv    load_model: the slot context (4096) exceeds the training context of the model (2048) - generation quality may degrade beyond the training context unless RoPE scaling is configured
slot   load_model: id  0 | task -1 | new slot, n_ctx = 4096  ← as requested
```

`/props` now reports `default_generation_settings.n_ctx = 4096` (previously `2048`).

## Test plan

- [x] Reproduced the bug on master with `stories260K.gguf` (`n_ctx_train = 2048`) and `-c 4096`.
- [x] Verified the patched build preserves the user-requested `n_ctx` in both the slot init log and the `/props` endpoint.
- [x] `/completion` still returns correctly after the change (20 tokens, stop=true, coherent output).


---



# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. This PR was produced in an AI-assisted workflow — an agent helped surface the candidate issue, drafted the patch, and wrote this description; the fix and reproduction were reviewed and verified locally (bug reproduced on master, fix built cleanly, slot `n_ctx` and `/completion` checked) before submitting. Human review and validation in the loop.
