### PR TITLE
server : add missing return after validation errors in /infill endpoint

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3710,14 +3710,17 @@ void server_routes::init_routes() {
         if (data.contains("prompt") && !data.at("prompt").is_string()) {
             // prompt is optional
             res->error(format_error_response("\"prompt\" must be a string", ERROR_TYPE_INVALID_REQUEST));
+            return res;
         }
 
         if (!data.contains("input_prefix")) {
             res->error(format_error_response("\"input_prefix\" is required", ERROR_TYPE_INVALID_REQUEST));
+            return res;
         }
 
         if (!data.contains("input_suffix")) {
             res->error(format_error_response("\"input_suffix\" is required", ERROR_TYPE_INVALID_REQUEST));
+            return res;
         }
 
         if (data.contains("input_extra") && !data.at("input_extra").is_array()) {

--- a/tools/server/tests/unit/test_infill.py
+++ b/tools/server/tests/unit/test_infill.py
@@ -57,6 +57,19 @@ def test_invalid_input_extra_req(input_extra):
     assert "error" in res.body
 
 
+@pytest.mark.parametrize("data,expected_msg", [
+    ({"input_suffix": "}\n"}, "input_prefix"),
+    ({"input_prefix": "#include <cstdio>\n"}, "input_suffix"),
+    ({"prompt": 123, "input_prefix": "a", "input_suffix": "b"}, "prompt"),
+])
+def test_infill_missing_required_field(data, expected_msg):
+    global server
+    server.start()
+    res = server.make_request("POST", "/infill", data=data)
+    assert res.status_code == 400
+    assert expected_msg in res.body["error"]["message"]
+
+
 @pytest.mark.skipif(not is_slow_test_allowed(), reason="skipping slow test")
 def test_with_qwen_model():
     global server


### PR DESCRIPTION
## Overview

The /infill endpoint sets error for missing input_prefix,input_suffix but doesn't return, 
so it falls through and throws 500 instead of 400.

Added "return res; "
after the three validation checks and a test for each case.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
