### PR TITLE
cmake : skip project() when consumed as a subdirectory (#20415)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.14...3.28) # for add_link_options and implicit target directories.
-project("llama.cpp" C CXX)
+
+# Only call project() when llama.cpp is the top-level build. When consumed as
+# a subdirectory, a second project() would re-run toolchain detection and can
+# override parent-project settings. See:
+# https://github.com/ggml-org/llama.cpp/issues/20415
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    project("llama.cpp" C CXX)
+endif()
+
 include(CheckIncludeFileCXX)
 
 #set(CMAKE_WARN_DEPRECATED YES)

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -6,7 +6,16 @@ cmake_minimum_required(VERSION 3.14...3.28) # for add_link_options and implicit 
 if (POLICY CMP0194)
     cmake_policy(SET CMP0194 NEW)
 endif()
-project("ggml" C CXX ASM)
+
+# Only call project() when ggml is the top-level build. When consumed as a
+# subdirectory (FetchContent, CPM, etc.), a second project() would re-run
+# toolchain detection and can clobber parent-project settings such as
+# CMAKE_OSX_ARCHITECTURES, CMAKE_OSX_SYSROOT or CMAKE_ASM_COMPILER during
+# cross-compilation (iOS, Android NDK, arm64/x86_64 hosts).
+# See: https://github.com/ggml-org/llama.cpp/issues/20415
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    project("ggml" C CXX ASM)
+endif()
 
 ### GGML Version
 set(GGML_VERSION_MAJOR 0)


### PR DESCRIPTION
## Summary

Fixes #20415.

Both `CMakeLists.txt` (llama) and `ggml/CMakeLists.txt` call `project()` unconditionally. When llama.cpp is pulled into another CMake project via `add_subdirectory` / `FetchContent` / `CPM`, those calls re-run toolchain detection inside the nested scope. For `C`/`CXX` this is mostly a no-op, but **ggml's `project(... ASM)` triggers an ASM compiler identification pass** that can overwrite parent-scope toolchain variables and, on cross-compilation toolchains (iOS, Android NDK, arm64↔x86_64 hosts), pick a different sysroot/architecture than the parent configured.

The fix follows the CMake convention of guarding `project()` with the standalone check so it only fires for top-level builds. The existing `LLAMA_STANDALONE` / `GGML_STANDALONE` variables continue to work because they are computed with the same predicate. No assembly sources live at the top-level of ggml — all ASM usage is gated behind `enable_language(ASM)` inside the backend that needs it (Metal, Hexagon HTP), so dropping `ASM` from the embedded `project()` call is safe.

## Repro (before the fix)

Minimal parent project:

```cmake
cmake_minimum_required(VERSION 3.20)
project(parent_app C CXX)                # parent enables C/CXX only, no ASM
add_subdirectory(/path/to/llama.cpp llama_build)
```

```
$ cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 ...
-- The C compiler identification is AppleClang
-- The CXX compiler identification is AppleClang
...
-- The ASM compiler identification is AppleClang       ← re-triggered by ggml's project()
-- Found assembler: /usr/bin/cc                         ← leaks into parent scope
```

After the fix those two lines no longer appear — the parent's toolchain state is preserved.

## Test plan

- [x] Standalone llama.cpp build still configures and compiles end-to-end (`cmake -B build && cmake --build build --target llama-cli`), version reported correctly (`built with AppleClang … for Darwin arm64`).
- [x] Minimal parent project with `add_subdirectory(llama.cpp)` + `-DCMAKE_OSX_ARCHITECTURES=x86_64` now configures without triggering ASM identification and without clobbering `CMAKE_ASM_COMPILER` in the parent scope.
- [x] `GGML_SYSTEM_ARCH` is still detected correctly (`x86` in the cross-compile repro).
- [x] CI `ggml-ci`, Android build, and standalone builds should remain green — only the `project()` invocation is guarded; everything below it runs unchanged.


# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. Patch drafting and PR description were AI-assisted; the subdirectory repro was built and the standalone build verified locally before submission.
