### PR TITLE
CUDA: opt-in managed pool + OOM fallback for alloc_buffer

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -116,10 +116,10 @@ int ggml_cuda_get_device() {
     return id;
 }
 
-static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device) {
+static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device, bool force_managed = false) {
     ggml_cuda_set_device(device);
     cudaError_t err;
-    if (getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {
+    if (force_managed || getenv("GGML_CUDA_ENABLE_UNIFIED_MEMORY") != nullptr) {
         err = cudaMallocManaged(ptr, size);
 #if defined(GGML_USE_HIP)
         if (err == hipSuccess) {
@@ -421,7 +421,23 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
         size_t look_ahead_size = (size_t) (1.05 * size);
         look_ahead_size = 256 * ((look_ahead_size + 255)/256);
         ggml_cuda_set_device(device);
-        CUDA_CHECK(ggml_cuda_device_malloc(&ptr, look_ahead_size, device));
+        static const bool pool_use_managed = getenv("GGML_CUDA_POOL_USE_MANAGED") != nullptr;
+        if (pool_use_managed) {
+            // Reached the growth path — every idle buffer in the pool is strictly smaller
+            // than this request. Under managed memory they live in system RAM and will
+            // never serve a request >= this size, so they're dead weight: they inflate
+            // pool_size and trigger PCIe page-faults during later TG. Release them now.
+            for (int i = 0; i < MAX_BUFFERS; ++i) {
+                ggml_cuda_buffer& b = buffer_pool[i];
+                if (b.ptr != nullptr) {
+                    cudaFree(b.ptr);
+                    pool_size -= b.size;
+                    b.ptr  = nullptr;
+                    b.size = 0;
+                }
+            }
+        }
+        CUDA_CHECK(ggml_cuda_device_malloc(&ptr, look_ahead_size, device, pool_use_managed));
         *actual_size = look_ahead_size;
         pool_size += look_ahead_size;
 #ifdef DEBUG_CUDA_MALLOC
@@ -758,10 +774,21 @@ static ggml_backend_buffer_t ggml_backend_cuda_buffer_type_alloc_buffer(ggml_bac
     void * dev_ptr;
     cudaError_t err = ggml_cuda_device_malloc(&dev_ptr, size, buft_ctx->device);
     if (err != cudaSuccess) {
-        // clear the error
+        // On OOM, retry once with managed memory so the overflowing buffer (typically
+        // the KV cache at high context) can spill to system RAM instead of aborting.
+        // Buffers that fit in VRAM already landed on the device via the first attempt;
+        // only the one that overflowed uses managed memory. hipMallocManaged pages hot
+        // regions onto the device on demand, so the common TG working set stays on GPU.
         (void)cudaGetLastError();
-        GGML_LOG_ERROR("%s: allocating %.2f MiB on device %d: cudaMalloc failed: %s\n", __func__, size / 1024.0 / 1024.0, buft_ctx->device, cudaGetErrorString(err));
-        return nullptr;
+        GGML_LOG_WARN("%s: allocating %.2f MiB on device %d: cudaMalloc failed (%s); retrying with managed memory (will page to system RAM on demand)\n",
+                      __func__, size / 1024.0 / 1024.0, buft_ctx->device, cudaGetErrorString(err));
+        err = ggml_cuda_device_malloc(&dev_ptr, size, buft_ctx->device, /*force_managed=*/true);
+        if (err != cudaSuccess) {
+            (void)cudaGetLastError();
+            GGML_LOG_ERROR("%s: managed fallback also failed for %.2f MiB: %s\n",
+                           __func__, size / 1024.0 / 1024.0, cudaGetErrorString(err));
+            return nullptr;
+        }
     }
 
     ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(buft_ctx->device, dev_ptr);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -774,12 +774,20 @@ static ggml_backend_buffer_t ggml_backend_cuda_buffer_type_alloc_buffer(ggml_bac
     void * dev_ptr;
     cudaError_t err = ggml_cuda_device_malloc(&dev_ptr, size, buft_ctx->device);
     if (err != cudaSuccess) {
-        // On OOM, retry once with managed memory so the overflowing buffer (typically
-        // the KV cache at high context) can spill to system RAM instead of aborting.
-        // Buffers that fit in VRAM already landed on the device via the first attempt;
-        // only the one that overflowed uses managed memory. hipMallocManaged pages hot
-        // regions onto the device on demand, so the common TG working set stays on GPU.
+        // Opt-in OOM fallback: retry once with managed memory so the overflowing buffer
+        // (typically the KV cache at high context) can spill to system RAM instead of
+        // aborting. Buffers that fit in VRAM already landed on the device via the first
+        // attempt; only the one that overflowed uses managed memory. hipMallocManaged
+        // pages hot regions onto the device on demand, so the common TG working set
+        // stays on GPU. Gated because ROCm doesn't spill by design — users opt in to
+        // trade raw throughput for not aborting.
+        static const bool alloc_fallback_managed = getenv("GGML_CUDA_ALLOC_FALLBACK_MANAGED") != nullptr;
         (void)cudaGetLastError();
+        if (!alloc_fallback_managed) {
+            GGML_LOG_ERROR("%s: allocating %.2f MiB on device %d: cudaMalloc failed: %s\n",
+                           __func__, size / 1024.0 / 1024.0, buft_ctx->device, cudaGetErrorString(err));
+            return nullptr;
+        }
         GGML_LOG_WARN("%s: allocating %.2f MiB on device %d: cudaMalloc failed (%s); retrying with managed memory (will page to system RAM on demand)\n",
                       __func__, size / 1024.0 / 1024.0, buft_ctx->device, cudaGetErrorString(err));
         err = ggml_cuda_device_malloc(&dev_ptr, size, buft_ctx->device, /*force_managed=*/true);


### PR DESCRIPTION
## Summary

Two **opt-in** escape hatches for users hitting OOM on small-VRAM AMD cards running long-context models. **Not a bug fix** — as noted on #21376, ROCm doesn't spill to system RAM by design, and this PR doesn't change that default. Both paths are gated behind env vars; with neither set, behavior is byte-for-byte identical to master.

Motivating case: gfx1201 (16 GB) on ROCm without HIP VMM (`system_info` reports `NO_VMM=1`), where the legacy pool grows monotonically and the user has no way to trade raw throughput for "don't abort."

### 1. `GGML_CUDA_POOL_USE_MANAGED=1` (opt-in)

Routes the legacy pool's grow path through `cudaMallocManaged` (→ `hipMallocManaged` on ROCm). On the grow path we also free the pool's idle smaller buffers — under managed memory those otherwise sit in system RAM, inflate `pool_size`, and cause PCIe page-faults during later TG.

### 2. `GGML_CUDA_ALLOC_FALLBACK_MANAGED=1` (opt-in)

When set, `ggml_backend_cuda_buffer_type_alloc_buffer` retries once with managed memory if plain `cudaMalloc` OOMs, so the overflowing buffer (typically the KV cache at high context) spills instead of aborting. With the flag unset, OOM behavior is unchanged — logs the original error and returns `nullptr`. Buffers that fit already landed on device via the first attempt; only the one that overflowed pages on demand, so the common TG working set stays on GPU.

## Motivation

Reproduces with Qwen3.6-35B-A3B (Unsloth IQ3_S) at `-c 262144 -ctk q4_0 -ctv q4_0 -b 1024 -ub 128 -fa` on 16 GB gfx1201. Previously crashed at ~41k PP tokens:

- `ggml_cuda_pool_leg::alloc` at `ggml-cuda.cu:410` OOMs during FA tile scratch growth.
- `ggml_backend_cuda_buffer_type_alloc_buffer` OOMs on KV cache alloc.

Refs #21376.

## Behavior matrix

| Flags | Pool grow path | `alloc_buffer` OOM |
|---|---|---|
| (none) | `cudaMalloc` | log + return nullptr (master behavior) |
| `GGML_CUDA_POOL_USE_MANAGED=1` | `cudaMallocManaged` + drop idle buffers | log + return nullptr |
| `GGML_CUDA_ALLOC_FALLBACK_MANAGED=1` | `cudaMalloc` | retry once with `cudaMallocManaged` |
| both | `cudaMallocManaged` + drop idle buffers | retry once with `cudaMallocManaged` |

## Test plan

- [x] Build on ROCm (gfx1201), run Qwen3.6-35B-A3B IQ3_S at the repro params with both flags — no longer aborts, PP continues past 41k.
- [ ] Sanity run on CUDA (NVIDIA) with both flags unset to confirm no behavior change.
- [ ] Sanity run with each flag individually.

## Notes

Draft while I gather more numbers across configurations and GPU vendors. Feedback welcome on: (a) whether the idle-buffer drop heuristic on the managed grow path should be its own flag, (b) whether the two env vars should be merged into one, and (c) naming.
