### PR TITLE
common: improve GGUF quantization tag regex

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -508,7 +508,7 @@ struct gguf_split_info {
 
 static gguf_split_info get_gguf_split_info(const std::string & path) {
     static const std::regex re_split("^(.+)-([0-9]{5})-of-([0-9]{5})$", std::regex::icase);
-    static const std::regex re_tag("[-.]([A-Z0-9_]+)$", std::regex::icase);
+    static const std::regex re_tag("[-.]((?:[A-Z]+-)?[A-Z][0-9][A-Z0-9_]*)$", std::regex::icase);
     std::smatch m;
 
     std::string prefix = path;


### PR DESCRIPTION
## Summary
Update the GGUF quantization tag regex to correctly identify tags with prefixes.

## Motivation
The previous regex `[-.]([A-Z0-9_]+)$` was too simple and could fail to correctly identify quantization tags that include prefixes or specific patterns. For example, models like `unsloth/gemma-4-31B-it-GGUF:UD-Q8_K_XL` use tags like `UD-Q8_K_XL`, which the previous regex might not have handled optimally or consistently across different naming conventions.

The new regex `[-.]((?:[A-Z]+-)?[A-Z][0-9][A-Z0-9_]*)$` allows for an optional uppercase prefix followed by a hyphen, ensuring that tags like `UD-Q8_K_XL` are correctly captured as the quantization tag.