### PR TITLE
ngram-mod: Reset i_last when low acceptance streak occurs

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -749,6 +749,7 @@ struct common_speculative_state_ngram_mod : public common_speculative_state {
 
                     mod.reset();
                     n_low = 0;
+                    i_last = 0;
                 }
             } else {
                 n_low = 0;


### PR DESCRIPTION
## Overview
By resetting i_last to zero, we will include the current context when rebuilding the speculative map.

The existing behavior would skip the current context, thereby often losing the benefit of speculative decoding during later parts of the generation. 

The effect of this seems to depend on both the model and the speculation parameters.

Benchmark: 
`vllm bench serve --model google/gemma-4-26B-A4B-it --host 127.0.0.1 --port 9876 --num-prompts 96 --dataset-name hf --dataset-path vdaita/edit_5k_char --backend openai-chat --endpoint '/v1/chat/completions' --max-concurrency 1`

Gemma 4 26B-A4B: 
- Baseline: 97.57 t/s (peak 108)
- without i_last = 0: 141.08 t/s (peak 1032)
- with i_last = 0: 155.10 t/s (peak 1032)

Qwen 3.6 35B-A3B:
- Baseline: 112.54 t/s (peak 127)
- without i_last = 0: 148.56 t/s (peak 774)
- with i_last = 0: 153.65 t/s (peak 768)

As we can see, the effect isn't huge but at 3% to 9% it is still measurable.
The price we pay for it is 1 line of code and a moment longer for speculative map repopulation whenever a low acceptance streak occours. 


# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Used to help understand the ngram-mod flow.