### PR TITLE
Fix server includes common/build-info.h +  `noreturn` attribute warnings

### DIFF
--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -107,7 +107,7 @@ struct statement {
     virtual ~statement() = default;
     virtual std::string type() const { return "Statement"; }
     // execute_impl must be overridden by derived classes
-    virtual value execute_impl(context &) { throw std::runtime_error("cannot exec " + type()); }
+    [[noreturn]] virtual value execute_impl(context &) { throw std::runtime_error("cannot exec " + type()); }
     // execute is the public method to execute a statement with error handling
     value execute(context &);
 };
@@ -143,7 +143,7 @@ struct program : public statement {
     program() = default;
     explicit program(statements && body) : body(std::move(body)) {}
     std::string type() const override { return "Program"; }
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context &) override {
         throw std::runtime_error("Cannot execute program directly, use jinja::runtime instead");
     }
 };
@@ -195,7 +195,7 @@ struct break_statement : public statement {
         }
     };
 
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context &) override {
         throw break_statement::signal();
     }
 };
@@ -209,7 +209,7 @@ struct continue_statement : public statement {
         }
     };
 
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context &) override {
         throw continue_statement::signal();
     }
 };
@@ -509,7 +509,7 @@ struct slice_expression : public expression {
         chk_type<expression>(this->step_expr);
     }
     std::string type() const override { return "SliceExpression"; }
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context &) override {
         throw std::runtime_error("must be handled by MemberExpression");
     }
 };

--- a/common/jinja/value.h
+++ b/common/jinja/value.h
@@ -129,27 +129,28 @@ struct value_t {
     // Note: only for debugging and error reporting purposes
     virtual std::string type() const { return ""; }
 
-    virtual int64_t as_int() const { throw std::runtime_error(type() + " is not an int value"); }
-    virtual double as_float() const { throw std::runtime_error(type() + " is not a float value"); }
-    virtual string as_string() const { throw std::runtime_error(type() + " is not a string value"); }
-    virtual bool as_bool() const { throw std::runtime_error(type() + " is not a bool value"); }
-    virtual const std::vector<value> & as_array() const { throw std::runtime_error(type() + " is not an array value"); }
-    virtual const std::vector<std::pair<value, value>> & as_ordered_object() const { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value invoke(const func_args &) const { throw std::runtime_error(type() + " is not a function value"); }
+
+    [[noreturn]] virtual int64_t as_int() const { throw std::runtime_error(type() + " is not an int value"); }
+    [[noreturn]] virtual double as_float() const { throw std::runtime_error(type() + " is not a float value"); }
+    [[noreturn]] virtual string as_string() const { throw std::runtime_error(type() + " is not a string value"); }
+    [[noreturn]] virtual bool as_bool() const { throw std::runtime_error(type() + " is not a bool value"); }
+    [[noreturn]] virtual const std::vector<value> & as_array() const { throw std::runtime_error(type() + " is not an array value"); }
+    [[noreturn]] virtual const std::vector<std::pair<value, value>> & as_ordered_object() const { throw std::runtime_error(type() + " is not an object value"); }
+    [[noreturn]] virtual value invoke(const func_args &) const { throw std::runtime_error(type() + " is not a function value"); }
     virtual bool is_none() const { return false; }
     virtual bool is_undefined() const { return false; }
-    virtual const func_builtins & get_builtins() const {
+    [[noreturn]] virtual const func_builtins & get_builtins() const {
         throw std::runtime_error("No builtins available for type " + type());
     }
 
-    virtual bool has_key(const value &) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual void insert(const value & /* key */, const value & /* val */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const value & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const value & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const std::string & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const std::string & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(int64_t /* idx */, value & /* default_val */) { throw std::runtime_error(type() + " is not an array value"); }
-    virtual value & at(int64_t /* idx */) { throw std::runtime_error(type() + " is not an array value"); }
+    [[noreturn]] virtual bool has_key(const value &) { throw std::runtime_error(type() + " is not an object value"); }
+    [[noreturn]] virtual void insert(const value & /* key */, const value & /* val */) { throw std::runtime_error(type() + " is not an object value"); }
+    [[noreturn]] virtual value & at(const value & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
+    [[noreturn]] virtual value & at(const value & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
+    [[noreturn]] virtual value & at(const std::string & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
+    [[noreturn]] virtual value & at(const std::string & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
+    [[noreturn]] virtual value & at(int64_t /* idx */, value & /* default_val */) { throw std::runtime_error(type() + " is not an array value"); }
+    [[noreturn]] virtual value & at(int64_t /* idx */) { throw std::runtime_error(type() + " is not an array value"); }
 
     virtual bool is_numeric() const { return false; }
     virtual bool is_hashable() const { return false; }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -5,7 +5,7 @@
 #include "server-task.h"
 #include "server-queue.h"
 
-#include "build-info.h"
+#include "common/build-info.h"
 #include "common.h"
 #include "llama.h"
 #include "log.h"

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1,7 +1,7 @@
 #include "server-common.h"
 #include "server-models.h"
 
-#include "build-info.h"
+#include "common/build-info.h"
 #include "preset.h"
 #include "download.h"
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1,6 +1,6 @@
 #include "server-task.h"
 
-#include "build-info.h"
+#include "common/build-info.h"
 #include "chat.h"
 #include "common.h"
 #include "json-schema-to-grammar.h"

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -5,7 +5,7 @@
 #include "server-tools.h"
 
 #include "arg.h"
-#include "build-info.h"
+#include "common/build-info.h"
 #include "common.h"
 #include "llama.h"
 #include "log.h"


### PR DESCRIPTION
## Overview

I had an error building the llama-server  after the lib common rename (`git bisect` pointed to  6990e2f1f7581d332a6a1f34d6c567be70138184)

The fix is just to moves the servers includes from "build-info.h" to "common/build-info.h"

I also fixed warnings on `noreturn` attribute functions.

## Additional information

I build on Linux using:
```sh
cmake -B build \
    -DGGML_VULKAN=ON \
    -DGGML_USE_OPENMP=ON \
    -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_AVX_VNNI=ON -DGGML_AVX_BMI=ON -DGGML_FMA=ON \
    -DGGML_SSE42=ON -DGGML_F16C=ON \
    -DGGML_NATIVE=ON

cmake --build build --config Release -t llama-server --parallel 16
```


# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO 