### PR TITLE
Optimize reduction stage of dot product of q4_L/q5_K to q8_K on AVX2

### DIFF
--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -1941,8 +1941,16 @@ void ggml_vec_dot_q4_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const voi
         const __m256i mins_and_scales = _mm256_cvtepu8_epi16(_mm_set_epi32(utmp[3], utmp[2], utmp[1], utmp[0]));
 
         const __m256i q8sums = _mm256_loadu_si256((const __m256i*)y[i].bsums);
-        const __m128i q8s = _mm_hadd_epi16(_mm256_extracti128_si256(q8sums, 0), _mm256_extracti128_si256(q8sums, 1));
-        const __m128i prod = _mm_madd_epi16(_mm256_extracti128_si256(mins_and_scales, 1), q8s);
+        const __m256i ones = _mm256_set1_epi16(1);
+        __m256i q8s_32 = _mm256_madd_epi16(q8sums, ones);
+        __m128i m128 = _mm256_extracti128_si256(mins_and_scales, 1);
+        __m256i m256 = _mm256_cvtepi16_epi32(m128);
+        __m256i prod_256 = _mm256_mullo_epi32(q8s_32, m256);
+        __m128i pL = _mm256_castsi256_si128(prod_256);
+        __m128i pH = _mm256_extracti128_si256(prod_256, 1);
+        __m128i even = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(pL), _mm_castsi128_ps(pH), _MM_SHUFFLE(2, 0, 2, 0)));
+        __m128i odd  = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(pL), _mm_castsi128_ps(pH), _MM_SHUFFLE(3, 1, 3, 1)));
+        __m128i prod = _mm_add_epi32(even, odd);
         acc_m = _mm_fmadd_ps(_mm_set1_ps(dmin), _mm_cvtepi32_ps(prod), acc_m);
 
         const __m128i sc128  = _mm256_extracti128_si256(mins_and_scales, 0);
@@ -2121,10 +2129,19 @@ void ggml_vec_dot_q5_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const voi
         const __m256i mins_and_scales = _mm256_cvtepu8_epi16(_mm_set_epi32(utmp[3], utmp[2], utmp[1], utmp[0]));
 
         const __m256i q8sums = _mm256_loadu_si256((const __m256i*)y[i].bsums);
-        const __m128i q8s = _mm_hadd_epi16(_mm256_extracti128_si256(q8sums, 0), _mm256_extracti128_si256(q8sums, 1));
-        const __m128i prod = _mm_madd_epi16(_mm256_extracti128_si256(mins_and_scales, 1), q8s);
-        const __m128i hsum = _mm_hadd_epi32(_mm_hadd_epi32(prod, mzero), mzero);
-        summs += dmin * _mm_extract_epi32(hsum, 0);
+        const __m256i ones = _mm256_set1_epi16(1);
+        __m256i q8s_32 = _mm256_madd_epi16(q8sums, ones);
+        __m128i m128 = _mm256_extracti128_si256(mins_and_scales, 1);
+        __m256i m256 = _mm256_cvtepi16_epi32(m128);
+        __m256i prod_256 = _mm256_mullo_epi32(q8s_32, m256);
+        __m128i pL = _mm256_castsi256_si128(prod_256);
+        __m128i pH = _mm256_extracti128_si256(prod_256, 1);
+        __m128i sum128 = _mm_add_epi32(pL, pH);
+        __m128i upper = _mm_shuffle_epi32(sum128, _MM_SHUFFLE(1, 0, 3, 2));
+        __m128i sum64 = _mm_add_epi32(sum128, upper);
+        __m128i upper32 = _mm_shuffle_epi32(sum64, _MM_SHUFFLE(1, 1, 1, 1));
+        __m128i final_sum = _mm_add_epi32(sum64, upper32);
+        summs += dmin * _mm_cvtsi128_si32(final_sum);
 
         const __m128i sc128  = _mm256_extracti128_si256(mins_and_scales, 0);
         const __m256i scales = MM256_SET_M128I(sc128, sc128);


### PR DESCRIPTION
## Overview

This PR optimizes the reduction stage of the dot product kernels for AVX2, specifically targeting the logic used in Q4_K/Q8_K and Q5_K/Q8_K interactions (_i.e._, `ggml_vec_dot_q4_K_q8_K` and `ggml_vec_dot_q5_K_q8_K`).

The primary change is replacing the SSSE3 instruction for horizontal add instruction _mm_hadd_epi16 (VPHADDW) with the AVX2 "equivalent" approach using _mm256_madd_epi16 and specialized shuffles. When running a large model on my CPU (`qwen3.6-35b-a3b` with `q4_K` weights and `q4_0` kv cache), I noticed that these functions (`ggml_vec_dot_q4_K_q8_K` and `ggml_vec_dot_q5_K_q8_K` taking a substantial amount of time in my processor (7.45% and 4.66% respectively) and when looking at the `perf top` annotations, it seemed that `vphaddw` was taking a big chunk of those operations as well (9.01% on the q4_k one). Although other functions consumed more time, I felt this seemed like a low hanging fruit since AVX2 offers better performing alternatives for operations like this reduction.

## Key Technical Changes:
- **Elimination of VPHADDW**: Horizontal instructions are poorly pipelined on many x86 architectures (Intel and AMD), requiring multiple micro-ops and causing execution stalls.
- **Vertical Pairwise Summation**: Uses a multiply-by-one strategy with madd to perform sums on standard FMA units, which are heavily optimized and fully pipelined.
- **Improved Reduction Path**: Restructured the final summation using _mm_shuffle_ps and _mm_shuffle_epi32. This reduces port pressure and allows for better Instruction Level Parallelism (ILP).

## Performance Impact:

Profiling via perf on modern AVX2 hardware showed that the. With this patch, end-to-end inference speed improved by a bit (from 14.5-15.2 t/s to 15.8-16.2 t/s on my machine.

## Additional information

- Architecture: While tested primarily on Zen 4 (Ryzen 5 7600), these improvements are fundamentally more efficient for all AVX2-capable processors (Haswell through modern architectures) because they move work from specialized horizontal units to the general-purpose SIMD execution pipeline.
- Accuracy: The logic should maintain bit-level parity with the original implementation (save it for some odd microcode innacuracy or IEEE754 non-compliance);

# Requirements

I have read and agree with the contributing guidelines

AI usage disclosure: YES. Although I have generally kept up with the theoretical advances in SIMD instruction sets, I have not done much in terms of low level SIMD programming myself since 2013 (CUDA and SSE2). I have asked an LLM to help me generate a snippet for executing these instructions. But I inspected the functions to make sure they were bit-level equal to the original and test ran the llm afterwards.