### PR TITLE
Modality conditional adapters

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2504,7 +2504,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "path to LoRA adapter (use comma-separated values to load multiple adapters)",
         [](common_params & params, const std::string & value) {
             for (const auto & item : parse_csv_row(value)) {
-                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr, true, {} });
+                params.lora_adapters.push_back({ item, 1.0, {}, nullptr, true });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
@@ -2519,7 +2519,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 if (parts.size() != 2) {
                     throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
                 }
-                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr, true, {} });
+                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), {}, nullptr, true });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
@@ -2556,8 +2556,6 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
 
             // Validate and store modality strings
             auto & lora_info = params.lora_adapters[adapter_idx];
-            lora_info.mmlora_modality_types.clear();
-
             for (auto mod_str : modality_strs) {
                 // Strip whitespace
                 const auto start_index = mod_str.find_first_not_of(" \t\r\n");
@@ -2569,7 +2567,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 if (mod_str != "image" && mod_str != "audio") {
                     throw std::invalid_argument("Invalid modality type: " + mod_str + " (must be 'image' or 'audio')");
                 }
-                lora_info.mmlora_modality_types.push_back(mod_str);
+                // NOTE: For modality tasks, no prompt prefix is given
+                lora_info.task_prompt_prefixes[mod_str] = "";
             }
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2504,7 +2504,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "path to LoRA adapter (use comma-separated values to load multiple adapters)",
         [](common_params & params, const std::string & value) {
             for (const auto & item : parse_csv_row(value)) {
-                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr, {} });
+                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr, true, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
@@ -2519,7 +2519,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 if (parts.size() != 2) {
                     throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
                 }
-                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr, {} });
+                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr, true, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2504,7 +2504,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "path to LoRA adapter (use comma-separated values to load multiple adapters)",
         [](common_params & params, const std::string & value) {
             for (const auto & item : parse_csv_row(value)) {
-                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr });
+                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
@@ -2519,11 +2519,60 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 if (parts.size() != 2) {
                     throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
                 }
-                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr });
+                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
     ).set_examples({LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA}));
+    add_opt(common_arg(
+        {"--lora-modality"}, "INDEX:MODALITY[,MODALITY...]",
+        "Bind LoRA adapter to modality type(s). Adapter activates when any specified modality is present.\n"
+        "INDEX is the 0-based adapter index (order of --lora arguments).\n"
+        "MODALITY can be: image, audio (comma-separated for multiple).\n"
+        "Example: --lora-modality 0:image,audio",
+        [](common_params & params, const std::string & value) {
+            // Parse "INDEX:MODALITY[,MODALITY...]"
+            size_t colon_pos = value.find(':');
+            if (colon_pos == std::string::npos) {
+                throw std::invalid_argument("Invalid format for --lora-modality. Expected INDEX:MODALITY");
+            }
+
+            // Parse the index value
+            std::string index_str = value.substr(0, colon_pos);
+            const auto start_index = index_str.find_first_not_of(" \t\r\n");
+            if (start_index != std::string::npos) {
+                const auto end_index = index_str.find_last_not_of(" \t\r\n");
+                index_str = index_str.substr(start_index, end_index - start_index + 1);
+            }
+
+            int adapter_idx = std::stoi(index_str);
+            if (adapter_idx < 0 || adapter_idx >= (int)params.lora_adapters.size()) {
+                throw std::invalid_argument("Invalid adapter index: " + index_str);
+            }
+
+            // Parse comma-separated modalities
+            std::string modalities_str = value.substr(colon_pos + 1);
+            std::vector<std::string> modality_strs = string_split<std::string>(modalities_str, ',');
+
+            // Validate and store modality strings
+            auto & lora_info = params.lora_adapters[adapter_idx];
+            lora_info.mmlora_modality_types.clear();
+
+            for (auto mod_str : modality_strs) {
+                // Strip whitespace
+                const auto start_index = mod_str.find_first_not_of(" \t\r\n");
+                if (start_index != std::string::npos) {
+                    auto end_index = mod_str.find_last_not_of(" \t\r\n");
+                    mod_str = mod_str.substr(start_index, end_index - start_index + 1);
+                }
+                // Validate the string (simple string validation, enum conversion happens later)
+                if (mod_str != "image" && mod_str != "audio") {
+                    throw std::invalid_argument("Invalid modality type: " + mod_str + " (must be 'image' or 'audio')");
+                }
+                lora_info.mmlora_modality_types.push_back(mod_str);
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"--control-vector"}, "FNAME",
         "add a control vector\nnote: use comma-separated values to add multiple control vectors",

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2490,7 +2490,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "path to LoRA adapter (use comma-separated values to load multiple adapters)",
         [](common_params & params, const std::string & value) {
             for (const auto & item : parse_csv_row(value)) {
-                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr, {} });
+                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr, true, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
@@ -2505,7 +2505,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 if (parts.size() != 2) {
                     throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
                 }
-                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr, {} });
+                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr, true, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2490,7 +2490,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "path to LoRA adapter (use comma-separated values to load multiple adapters)",
         [](common_params & params, const std::string & value) {
             for (const auto & item : parse_csv_row(value)) {
-                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr });
+                params.lora_adapters.push_back({ item, 1.0, "", "", nullptr, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
@@ -2505,11 +2505,60 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                 if (parts.size() != 2) {
                     throw std::invalid_argument("lora-scaled format: FNAME:SCALE");
                 }
-                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr });
+                params.lora_adapters.push_back({ parts[0], std::stof(parts[1]), "", "", nullptr, {} });
             }
         }
         // we define this arg on both COMMON and EXPORT_LORA, so when showing help message of export-lora, it will be categorized as "example-specific" arg
     ).set_examples({LLAMA_EXAMPLE_COMMON, LLAMA_EXAMPLE_EXPORT_LORA}));
+    add_opt(common_arg(
+        {"--lora-modality"}, "INDEX:MODALITY[,MODALITY...]",
+        "Bind LoRA adapter to modality type(s). Adapter activates when any specified modality is present.\n"
+        "INDEX is the 0-based adapter index (order of --lora arguments).\n"
+        "MODALITY can be: image, audio (comma-separated for multiple).\n"
+        "Example: --lora-modality 0:image,audio",
+        [](common_params & params, const std::string & value) {
+            // Parse "INDEX:MODALITY[,MODALITY...]"
+            size_t colon_pos = value.find(':');
+            if (colon_pos == std::string::npos) {
+                throw std::invalid_argument("Invalid format for --lora-modality. Expected INDEX:MODALITY");
+            }
+
+            // Parse the index value
+            std::string index_str = value.substr(0, colon_pos);
+            const auto start_index = index_str.find_first_not_of(" \t\r\n");
+            if (start_index != std::string::npos) {
+                const auto end_index = index_str.find_last_not_of(" \t\r\n");
+                index_str = index_str.substr(start_index, end_index - start_index + 1);
+            }
+
+            int adapter_idx = std::stoi(index_str);
+            if (adapter_idx < 0 || adapter_idx >= (int)params.lora_adapters.size()) {
+                throw std::invalid_argument("Invalid adapter index: " + index_str);
+            }
+
+            // Parse comma-separated modalities
+            std::string modalities_str = value.substr(colon_pos + 1);
+            std::vector<std::string> modality_strs = string_split<std::string>(modalities_str, ',');
+
+            // Validate and store modality strings
+            auto & lora_info = params.lora_adapters[adapter_idx];
+            lora_info.mmlora_modality_types.clear();
+
+            for (auto mod_str : modality_strs) {
+                // Strip whitespace
+                const auto start_index = mod_str.find_first_not_of(" \t\r\n");
+                if (start_index != std::string::npos) {
+                    auto end_index = mod_str.find_last_not_of(" \t\r\n");
+                    mod_str = mod_str.substr(start_index, end_index - start_index + 1);
+                }
+                // Validate the string (simple string validation, enum conversion happens later)
+                if (mod_str != "image" && mod_str != "audio") {
+                    throw std::invalid_argument("Invalid modality type: " + mod_str + " (must be 'image' or 'audio')");
+                }
+                lora_info.mmlora_modality_types.push_back(mod_str);
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"--control-vector"}, "FNAME",
         "add a control vector\nnote: use comma-separated values to add multiple control vectors",

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1181,6 +1181,18 @@ common_init_result::common_init_result(common_params & params) :
         la.task_name = buf;
         llama_adapter_meta_val_str(la.ptr, "adapter.lora.prompt_prefix", buf, sizeof(buf));
         la.prompt_prefix = buf;
+
+        // Validate MMLoRA configuration
+        if (!la.mmlora_modality_types.empty()) {
+            // Check for aLoRA conflict
+            const uint64_t n_alora_tokens = llama_adapter_get_alora_n_invocation_tokens(la.ptr);
+            if (n_alora_tokens > 0) {
+                LOG_ERR("%s: adapter '%s' cannot be both MMLoRA and aLoRA\n", __func__, la.path.c_str());
+                pimpl->model.reset(model);
+                return;
+            }
+        }
+
         pimpl->lora.emplace_back(std::move(lora)); // copy to list of loaded adapters
     }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1452,7 +1452,8 @@ void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adap
 
     for (auto & la: lora) {
         loras.push_back(la.ptr);
-        scales.push_back(la.scale);
+        // set scale to 0 if disabled
+        scales.push_back(la.enabled ? la.scale : 0.0);
     }
 
     llama_set_adapters_lora(ctx, loras.data(), loras.size(), scales.data());

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1175,22 +1175,15 @@ common_init_result::common_init_result(common_params & params) :
             return;
         }
 
+        // Set task_prompt_prefix from internal adapter metadata
         char buf[1024];
         la.ptr = lora.get();
         llama_adapter_meta_val_str(la.ptr, "adapter.lora.task_name", buf, sizeof(buf));
-        la.task_name = buf;
+        std::string task_name = buf;
         llama_adapter_meta_val_str(la.ptr, "adapter.lora.prompt_prefix", buf, sizeof(buf));
-        la.prompt_prefix = buf;
-
-        // Validate MMLoRA configuration
-        if (!la.mmlora_modality_types.empty()) {
-            // Check for aLoRA conflict
-            const uint64_t n_alora_tokens = llama_adapter_get_alora_n_invocation_tokens(la.ptr);
-            if (n_alora_tokens > 0) {
-                LOG_ERR("%s: adapter '%s' cannot be both MMLoRA and aLoRA\n", __func__, la.path.c_str());
-                pimpl->model.reset(model);
-                return;
-            }
+        std::string prompt_prefix = buf;
+        if (!task_name.empty()) {
+            la.task_prompt_prefixes[task_name] = prompt_prefix;
         }
 
         pimpl->lora.emplace_back(std::move(lora)); // copy to list of loaded adapters

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1451,7 +1451,8 @@ void common_set_adapter_lora(struct llama_context * ctx, std::vector<common_adap
 
     for (auto & la: lora) {
         loras.push_back(la.ptr);
-        scales.push_back(la.scale);
+        // set scale to 0 if disabled
+        scales.push_back(la.enabled ? la.scale : 0.0);
     }
 
     llama_set_adapters_lora(ctx, loras.data(), loras.size(), scales.data());

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1180,6 +1180,18 @@ common_init_result::common_init_result(common_params & params) :
         la.task_name = buf;
         llama_adapter_meta_val_str(la.ptr, "adapter.lora.prompt_prefix", buf, sizeof(buf));
         la.prompt_prefix = buf;
+
+        // Validate MMLoRA configuration
+        if (!la.mmlora_modality_types.empty()) {
+            // Check for aLoRA conflict
+            const uint64_t n_alora_tokens = llama_adapter_get_alora_n_invocation_tokens(la.ptr);
+            if (n_alora_tokens > 0) {
+                LOG_ERR("%s: adapter '%s' cannot be both MMLoRA and aLoRA\n", __func__, la.path.c_str());
+                pimpl->model.reset(model);
+                return;
+            }
+        }
+
         pimpl->lora.emplace_back(std::move(lora)); // copy to list of loaded adapters
     }
 

--- a/common/common.h
+++ b/common/common.h
@@ -45,6 +45,9 @@ struct common_adapter_lora_info {
 
     struct llama_adapter_lora * ptr;
 
+    // used to toggle on/off programmatically without changing scale
+    bool enabled;
+
     // Multi-Modal LoRA activation (MMLoRA)
     // Empty vector = not an MMLoRA adapter (always active)
     // Non-empty = MMLoRA adapter (activates if ANY specified modality present - OR logic)

--- a/common/common.h
+++ b/common/common.h
@@ -40,22 +40,19 @@ struct common_adapter_lora_info {
     std::string path;
     float scale;
 
-    std::string task_name;
-    std::string prompt_prefix;
+    // Each adapter may be qualified with one or more task names. Each task may
+    // have a prompt prefix used to stimulate the task's behavior.
+    //
+    // A task name may also map to a well-known modality enum
+    // (mtmd.h:mtmd_input_chunk_type) through the mtmd_modality_type_from_str
+    // mapping. Modality names will trigger special logic to auto-enable
+    // adapters in the presence of tokens for the given modality.
+    std::unordered_map<std::string, std::string> task_prompt_prefixes;
 
     struct llama_adapter_lora * ptr;
 
     // used to toggle on/off programmatically without changing scale
     bool enabled;
-
-    // Multi-Modal LoRA activation (MMLoRA)
-    // Empty vector = not an MMLoRA adapter (always active)
-    // Non-empty = MMLoRA adapter (activates if ANY specified modality present - OR logic)
-    // Modality types stored as strings: "image", "audio"
-    std::vector<std::string> mmlora_modality_types;
-
-    // Helper to check if this is an MMLoRA adapter
-    bool is_mmlora() const { return !mmlora_modality_types.empty(); }
 };
 
 using llama_tokens = std::vector<llama_token>;

--- a/common/common.h
+++ b/common/common.h
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <vector>
 #include <map>
+#include <unordered_map>
 
 #if defined(_WIN32) && !defined(_WIN32_WINNT)
 #define _WIN32_WINNT 0x0A00

--- a/common/common.h
+++ b/common/common.h
@@ -44,6 +44,15 @@ struct common_adapter_lora_info {
     std::string prompt_prefix;
 
     struct llama_adapter_lora * ptr;
+
+    // Multi-Modal LoRA activation (MMLoRA)
+    // Empty vector = not an MMLoRA adapter (always active)
+    // Non-empty = MMLoRA adapter (activates if ANY specified modality present - OR logic)
+    // Modality types stored as strings: "image", "audio"
+    std::vector<std::string> mmlora_modality_types;
+
+    // Helper to check if this is an MMLoRA adapter
+    bool is_mmlora() const { return !mmlora_modality_types.empty(); }
 };
 
 using llama_tokens = std::vector<llama_token>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -263,6 +263,9 @@ endif()
 set(LLAMA_TEST_NAME test-mtmd-c-api)
 llama_build_and_test(test-mtmd-c-api.c)
 target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
+set(LLAMA_TEST_NAME test-mmlora)
+llama_build_and_test(test-mmlora.cpp)
+target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
 unset(LLAMA_TEST_NAME)
 
 # GGUF model data fetcher library for tests that need real model metadata

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -261,6 +261,9 @@ endif()
 set(LLAMA_TEST_NAME test-mtmd-c-api)
 llama_build_and_test(test-mtmd-c-api.c)
 target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
+set(LLAMA_TEST_NAME test-mmlora)
+llama_build_and_test(test-mmlora.cpp)
+target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
 unset(LLAMA_TEST_NAME)
 
 # GGUF model data fetcher library for tests that need real model metadata

--- a/tests/test-mmlora.cpp
+++ b/tests/test-mmlora.cpp
@@ -1,0 +1,118 @@
+// Tests for Multi-Modal LoRA (MMLoRA) functionality
+#include "mtmd.h"
+#include "mtmd-helper.h"
+#include "common.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <string>
+
+#undef NDEBUG
+#include <cassert>
+
+#define LOG_INF(...) printf(__VA_ARGS__)
+
+#define TEST(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "TEST FAILED: %s at %s:%d\n", #cond, __FILE__, __LINE__); \
+        return 1; \
+    } \
+} while(0)
+
+// Test string↔enum conversion functions
+static int test_mmlora_modality_type_conversion() {
+LOG_INF("Testing modality type string conversions...\n");
+
+    // Test enum to string
+    TEST(strcmp(mtmd_modality_type_to_str(MTMD_INPUT_CHUNK_TYPE_IMAGE), "image") == 0);
+    TEST(strcmp(mtmd_modality_type_to_str(MTMD_INPUT_CHUNK_TYPE_AUDIO), "audio") == 0);
+    TEST(strcmp(mtmd_modality_type_to_str(MTMD_INPUT_CHUNK_TYPE_TEXT), "text") == 0);
+    TEST(strcmp(mtmd_modality_type_to_str(MTMD_INPUT_CHUNK_TYPE_UNKNOWN), "unknown") == 0);
+    TEST(strcmp(mtmd_modality_type_to_str((enum mtmd_input_chunk_type)999), "unknown") == 0);
+
+    // Test string to enum
+    TEST(mtmd_modality_type_from_str("image") == MTMD_INPUT_CHUNK_TYPE_IMAGE);
+    TEST(mtmd_modality_type_from_str("audio") == MTMD_INPUT_CHUNK_TYPE_AUDIO);
+    TEST(mtmd_modality_type_from_str("text") == MTMD_INPUT_CHUNK_TYPE_TEXT);
+    TEST(mtmd_modality_type_from_str("unknown") == MTMD_INPUT_CHUNK_TYPE_UNKNOWN);
+    TEST(mtmd_modality_type_from_str("invalid") == MTMD_INPUT_CHUNK_TYPE_UNKNOWN);
+
+    // Test validation
+    TEST(mtmd_is_valid_modality_str("image") == true);
+    TEST(mtmd_is_valid_modality_str("audio") == true);
+    TEST(mtmd_is_valid_modality_str("text") == false);
+    TEST(mtmd_is_valid_modality_str("unknown") == false);
+    TEST(mtmd_is_valid_modality_str("invalid") == false);
+    TEST(mtmd_is_valid_modality_str(NULL) == false);
+
+    LOG_INF("  Passed modality type conversions\n");
+    return 0;
+}
+
+// Test common_adapter_lora_info MMLoRA helpers
+static int test_mmlora_info_helpers() {
+    LOG_INF("Testing MMLoRA info helpers...\n");
+
+    // Test is_mmlora() with empty vector (not MMLoRA)
+    common_adapter_lora_info regular_lora;
+    TEST(regular_lora.is_mmlora() == false);
+    TEST(regular_lora.mmlora_modality_types.empty() == true);
+
+    // Test is_mmlora() with single modality
+    common_adapter_lora_info image_lora;
+    image_lora.mmlora_modality_types.push_back("image");
+    TEST(image_lora.is_mmlora() == true);
+    TEST(image_lora.mmlora_modality_types.size() == 1);
+
+    // Test is_mmlora() with multiple modalities
+    common_adapter_lora_info multi_lora;
+    multi_lora.mmlora_modality_types.push_back("image");
+    multi_lora.mmlora_modality_types.push_back("audio");
+    TEST(multi_lora.is_mmlora() == true);
+    TEST(multi_lora.mmlora_modality_types.size() == 2);
+
+    LOG_INF("  Passed MMLoRA info helpers\n");
+    return 0;
+}
+
+// Test CLI argument parsing (simulated)
+static int test_mmlora_arg_parsing() {LOG_INF("Testing MMLoRA argument parsing logic...\n");
+
+    // Simulate parsing "0:image,audio"
+    std::string value = "0:image,audio";
+    size_t colon_pos = value.find(':');
+    TEST(colon_pos != std::string::npos);
+
+    std::string index_str = value.substr(0, colon_pos);
+    std::string modalities_str = value.substr(colon_pos + 1);
+
+    TEST(index_str == "0");
+    std::vector<std::string> modality_strs = string_split<std::string>(modalities_str, ',');
+    TEST(modality_strs.size() == 2);
+    TEST(modality_strs[0] == "image");
+    TEST(modality_strs[1] == "audio");
+
+    // Validate modalities
+    for (const auto & mod : modality_strs) {
+        TEST(mod == "image" || mod == "audio");
+    }
+
+    LOG_INF("  Passed argument parsing logic\n");
+    return 0;
+}
+
+int main(int argc, char ** argv) {
+    (void)argc;
+    (void)argv;
+
+    LOG_INF("MMLoRA unit tests starting...\n");
+
+    int result = 0;
+    result += test_mmlora_modality_type_conversion();
+    result += test_mmlora_info_helpers();
+    result += test_mmlora_arg_parsing();
+
+    LOG_INF("MMLoRA unit tests %s!\n", result == 0 ? "passed" : "failed");
+    return result;
+}

--- a/tests/test-mmlora.cpp
+++ b/tests/test-mmlora.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <vector>
 #include <string>
+#include <cstring>
 
 #undef NDEBUG
 #include <cassert>

--- a/tests/test-mmlora.cpp
+++ b/tests/test-mmlora.cpp
@@ -51,32 +51,6 @@ LOG_INF("Testing modality type string conversions...\n");
     return 0;
 }
 
-// Test common_adapter_lora_info MMLoRA helpers
-static int test_mmlora_info_helpers() {
-    LOG_INF("Testing MMLoRA info helpers...\n");
-
-    // Test is_mmlora() with empty vector (not MMLoRA)
-    common_adapter_lora_info regular_lora;
-    TEST(regular_lora.is_mmlora() == false);
-    TEST(regular_lora.mmlora_modality_types.empty() == true);
-
-    // Test is_mmlora() with single modality
-    common_adapter_lora_info image_lora;
-    image_lora.mmlora_modality_types.push_back("image");
-    TEST(image_lora.is_mmlora() == true);
-    TEST(image_lora.mmlora_modality_types.size() == 1);
-
-    // Test is_mmlora() with multiple modalities
-    common_adapter_lora_info multi_lora;
-    multi_lora.mmlora_modality_types.push_back("image");
-    multi_lora.mmlora_modality_types.push_back("audio");
-    TEST(multi_lora.is_mmlora() == true);
-    TEST(multi_lora.mmlora_modality_types.size() == 2);
-
-    LOG_INF("  Passed MMLoRA info helpers\n");
-    return 0;
-}
-
 // Test CLI argument parsing (simulated)
 static int test_mmlora_arg_parsing() {LOG_INF("Testing MMLoRA argument parsing logic...\n");
 
@@ -111,7 +85,6 @@ int main(int argc, char ** argv) {
 
     int result = 0;
     result += test_mmlora_modality_type_conversion();
-    result += test_mmlora_info_helpers();
     result += test_mmlora_arg_parsing();
 
     LOG_INF("MMLoRA unit tests %s!\n", result == 0 ? "passed" : "failed");

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -535,3 +535,26 @@ mtmd_bitmap * mtmd_helper_bitmap_init_from_file(mtmd_context * ctx, const char *
 
     return mtmd_helper_bitmap_init_from_buf(ctx, buf.data(), buf.size());
 }
+
+// Modality type string↔enum conversion functions
+const char * mtmd_modality_type_to_str(enum mtmd_input_chunk_type type) {
+    switch (type) {
+        case MTMD_INPUT_CHUNK_TYPE_IMAGE: return "image";
+        case MTMD_INPUT_CHUNK_TYPE_AUDIO: return "audio";
+        case MTMD_INPUT_CHUNK_TYPE_TEXT:  return "text";
+        default: return "unknown";
+    }
+}
+
+enum mtmd_input_chunk_type mtmd_modality_type_from_str(const char * str) {
+    if (strcmp(str, "image") == 0) {
+        return MTMD_INPUT_CHUNK_TYPE_IMAGE;
+    } else if (strcmp(str, "audio") == 0) {
+        return MTMD_INPUT_CHUNK_TYPE_AUDIO;
+    }
+    return MTMD_INPUT_CHUNK_TYPE_TEXT; // default/invalid
+}
+
+bool mtmd_is_valid_modality_str(const char * str) {
+    return str && (strcmp(str, "image") == 0 || strcmp(str, "audio") == 0);
+}

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -551,8 +551,10 @@ enum mtmd_input_chunk_type mtmd_modality_type_from_str(const char * str) {
         return MTMD_INPUT_CHUNK_TYPE_IMAGE;
     } else if (strcmp(str, "audio") == 0) {
         return MTMD_INPUT_CHUNK_TYPE_AUDIO;
+    } else if (strcmp(str, "text") == 0) {
+        return MTMD_INPUT_CHUNK_TYPE_TEXT;
     }
-    return MTMD_INPUT_CHUNK_TYPE_TEXT; // default/invalid
+    return MTMD_INPUT_CHUNK_TYPE_UNKNOWN; // default/invalid
 }
 
 bool mtmd_is_valid_modality_str(const char * str) {

--- a/tools/mtmd/mtmd-helper.h
+++ b/tools/mtmd/mtmd-helper.h
@@ -89,6 +89,16 @@ MTMD_API int32_t mtmd_helper_decode_image_chunk(mtmd_context * ctx,
                                                 int32_t n_batch,
                                                 llama_pos * new_n_past);
 
+// Convert modality type enum to string
+MTMD_API const char * mtmd_modality_type_to_str(enum mtmd_input_chunk_type type);
+
+// Convert string to modality type enum
+// Returns MTMD_INPUT_CHUNK_TYPE_TEXT on invalid input
+MTMD_API enum mtmd_input_chunk_type mtmd_modality_type_from_str(const char * str);
+
+// Validate if string is a valid modality type (image or audio)
+MTMD_API bool mtmd_is_valid_modality_str(const char * str);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -54,6 +54,7 @@ enum mtmd_input_chunk_type {
     MTMD_INPUT_CHUNK_TYPE_TEXT,
     MTMD_INPUT_CHUNK_TYPE_IMAGE,
     MTMD_INPUT_CHUNK_TYPE_AUDIO,
+    MTMD_INPUT_CHUNK_TYPE_UNKNOWN,
 };
 
 // opaque types

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -344,26 +344,23 @@ const mtmd::input_chunk_ptr & server_tokens::find_chunk(size_t idx) const {
     throw std::runtime_error("Chunk not found");
 }
 
-bool server_tokens::has_modality_type(const std::string & modality_type) const {
-    if (!has_mtmd) {
-        return false;
-    }
-
-    enum mtmd_input_chunk_type target_type = mtmd_modality_type_from_str(modality_type.c_str());
-
+bool server_tokens::has_modality_type(const enum mtmd_input_chunk_type modality_type) const {
     for (const auto & [idx, chunk_ptr] : map_idx_to_media) {
         if (!chunk_ptr) continue;
         enum mtmd_input_chunk_type chunk_type = mtmd_input_chunk_get_type(chunk_ptr.get());
-        if (chunk_type == target_type) {
+        if (chunk_type == modality_type) {
             return true;
         }
     }
     return false;
 }
 
-bool server_tokens::has_any_modality_type(const std::vector<std::string> & modality_types) const {
-    for (const auto & mod_type : modality_types) {
-        if (has_modality_type(mod_type)) {
+bool server_tokens::has_any_modality_type(const std::unordered_map<std::string, std::string> & task_prompt_prefixes) const {
+    for (const auto & task_pair : task_prompt_prefixes) {
+        const auto & modality_type = mtmd_modality_type_from_str(task_pair.first.c_str());
+        if (modality_type != MTMD_INPUT_CHUNK_TYPE_UNKNOWN &&
+            modality_type != MTMD_INPUT_CHUNK_TYPE_TEXT &&
+            has_modality_type(modality_type)) {
             return true;
         }
     }

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -344,6 +344,32 @@ const mtmd::input_chunk_ptr & server_tokens::find_chunk(size_t idx) const {
     throw std::runtime_error("Chunk not found");
 }
 
+bool server_tokens::has_modality_type(const std::string & modality_type) const {
+    if (!has_mtmd) {
+        return false;
+    }
+
+    enum mtmd_input_chunk_type target_type = mtmd_modality_type_from_str(modality_type.c_str());
+
+    for (const auto & [idx, chunk_ptr] : map_idx_to_media) {
+        if (!chunk_ptr) continue;
+        enum mtmd_input_chunk_type chunk_type = mtmd_input_chunk_get_type(chunk_ptr.get());
+        if (chunk_type == target_type) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool server_tokens::has_any_modality_type(const std::vector<std::string> & modality_types) const {
+    for (const auto & mod_type : modality_types) {
+        if (has_modality_type(mod_type)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void server_tokens::push_back(llama_token tok) {
     if (tok == LLAMA_TOKEN_NULL) {
         throw std::runtime_error("Invalid token");

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -179,8 +179,8 @@ public:
     const mtmd::input_chunk_ptr & find_chunk(size_t idx) const;
 
     // Check if request contains any of the specified modality types
-    bool has_modality_type(const std::string & modality_type) const;
-    bool has_any_modality_type(const std::vector<std::string> & modality_types) const;
+    bool has_modality_type(const enum mtmd_input_chunk_type modality_type) const;
+    bool has_any_modality_type(const std::unordered_map<std::string, std::string> & task_prompt_prefixes) const;
 
     void push_back(llama_token tok);
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -178,6 +178,10 @@ public:
 
     const mtmd::input_chunk_ptr & find_chunk(size_t idx) const;
 
+    // Check if request contains any of the specified modality types
+    bool has_modality_type(const std::string & modality_type) const;
+    bool has_any_modality_type(const std::vector<std::string> & modality_types) const;
+
     void push_back(llama_token tok);
 
     // will create a copy of the chunk if it contains non-text data

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1284,9 +1284,9 @@ private:
         for (size_t i = 0; i < slot.lora.size(); ++i) {
             auto & lora = slot.lora[i];
 
-            if (!lora.mmlora_modality_types.empty()) {
+            if (!lora.task_prompt_prefixes.empty()) {
                 // Check if request has any of the required modalities (OR logic)
-                const bool has_modality = task.tokens.has_any_modality_type(lora.mmlora_modality_types);
+                const bool has_modality = task.tokens.has_any_modality_type(lora.task_prompt_prefixes);
 
                 if (!has_modality) {
                     SLT_DBG(slot, "MMLoRA %zu requires modality but not found, deactivating\n", i);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1280,6 +1280,24 @@ private:
             }
         }
 
+        // Handle Multi-Modal LoRA (MMLoRA) activation
+        for (size_t i = 0; i < slot.lora.size(); ++i) {
+            auto & lora = slot.lora[i];
+
+            if (!lora.mmlora_modality_types.empty()) {
+                // Check if request has any of the required modalities (OR logic)
+                const bool has_modality = task.tokens.has_any_modality_type(lora.mmlora_modality_types);
+
+                if (!has_modality) {
+                    SLT_DBG(slot, "MMLoRA %zu requires modality but not found, deactivating\n", i);
+                    lora.enabled = false;
+                } else {
+                    SLT_DBG(slot, "MMLoRA %zu activated (modality present)\n", i);
+                    lora.enabled = true;
+                }
+            }
+        }
+
         if (!task.tokens.validate(ctx)) {
             send_error(task, "Prompt contains invalid tokens", ERROR_TYPE_INVALID_REQUEST);
             return false;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1279,6 +1279,24 @@ private:
             }
         }
 
+        // Handle Multi-Modal LoRA (MMLoRA) activation
+        for (size_t i = 0; i < slot.lora.size(); ++i) {
+            auto & lora = slot.lora[i];
+
+            if (!lora.mmlora_modality_types.empty()) {
+                // Check if request has any of the required modalities (OR logic)
+                const bool has_modality = task.tokens.has_any_modality_type(lora.mmlora_modality_types);
+
+                if (!has_modality) {
+                    SLT_DBG(slot, "MMLoRA %zu requires modality but not found, deactivating\n", i);
+                    lora.enabled = false;
+                } else {
+                    SLT_DBG(slot, "MMLoRA %zu activated (modality present)\n", i);
+                    lora.enabled = true;
+                }
+            }
+        }
+
         if (!task.tokens.validate(ctx)) {
             send_error(task, "Prompt contains invalid tokens", ERROR_TYPE_INVALID_REQUEST);
             return false;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1952,6 +1952,9 @@ json server_task_result_get_lora::to_json() {
             entry["alora_invocation_string"] = lora.alora_invocation_string;
             entry["alora_invocation_tokens"] = lora.alora_invocation_tokens;
         }
+        if (!lora.info.mmlora_modality_types.empty()) {
+            entry["mmlora_modality_types"] = lora.info.mmlora_modality_types;
+        }
         result.push_back(std::move(entry));
     }
     return result;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1945,15 +1945,28 @@ json server_task_result_get_lora::to_json() {
             {"id",            i},
             {"path",          lora.info.path},
             {"scale",         lora.info.scale},
-            {"task_name",     lora.info.task_name},
-            {"prompt_prefix", lora.info.prompt_prefix},
         };
+        // Handle tasks and prompt prefixes as follows for backwards compatibility:
+        // - if unset or single-valued, use top-level "task_name" / "prompt_prefix"
+        //   to maintain backwards compatibility
+        // - if multi-values, present a dict under "task_prompt_prefixes"
+        if (lora.info.task_prompt_prefixes.empty()) {
+            entry["task_name"] = "";
+            entry["prompt_prefix"] = "";
+        } else if (lora.info.task_prompt_prefixes.size() == 1) {
+            const auto & task_entry_pair = lora.info.task_prompt_prefixes.begin();
+            entry["task_name"] = task_entry_pair->first;
+            entry["prompt_prefix"] = task_entry_pair->second;
+        } else {
+            json task_prompt_prefixes = {};
+            for (const auto & task_entry_pair : lora.info.task_prompt_prefixes) {
+                task_prompt_prefixes[task_entry_pair.first] = task_entry_pair.second;
+            }
+            entry["task_prompt_prefixes"] = task_prompt_prefixes;
+        }
         if (!lora.alora_invocation_tokens.empty()) {
             entry["alora_invocation_string"] = lora.alora_invocation_string;
             entry["alora_invocation_tokens"] = lora.alora_invocation_tokens;
-        }
-        if (!lora.info.mmlora_modality_types.empty()) {
-            entry["mmlora_modality_types"] = lora.info.mmlora_modality_types;
         }
         result.push_back(std::move(entry));
     }

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1951,6 +1951,9 @@ json server_task_result_get_lora::to_json() {
             entry["alora_invocation_string"] = lora.alora_invocation_string;
             entry["alora_invocation_tokens"] = lora.alora_invocation_tokens;
         }
+        if (!lora.info.mmlora_modality_types.empty()) {
+            entry["mmlora_modality_types"] = lora.info.mmlora_modality_types;
+        }
         result.push_back(std::move(entry));
     }
     return result;


### PR DESCRIPTION
## Overview

This PR introduces a new mechanism for automatic LoRA adapter toggling based on the presence of one-or-more modalities that are tied to the adapter. This is a required feature for serving modular models such as [ibm-granite/granite-speech-3.3-2b](https://huggingface.co/ibm-granite/granite-speech-3.3-2b) and [ibm-granite/granite-4.0-3b-vision](https://huggingface.co/ibm-granite/granite-4.0-3b-vision) where the base LLM is preserved and the modality support is added through the adapter. Without this, a modular model must be booted in either text-mode or modality-mode. With this change, the model can be booted once and used in either mode based on the presence of the modality.

## Related Work

The existing PR (https://github.com/ggml-org/llama.cpp/pull/22101) by @ReinforcedKnowledge for Granite Speech adds support for [ibm-granite/granite-speech-3.3-2b](https://huggingface.co/ibm-granite/granite-speech-3.3-2b). I'm not aware of any other models that use this pattern and are already supported, so while this PR is still in review, there are no existing test models to verify the functionality with.

## Testing

I have a temporary merge point between this branch and #22101 where I've tested the ability for `granite-speech-3.3-2b` to leverage its conditional adapter. With this combination (using the conversion steps in my comment [here](https://github.com/ggml-org/llama.cpp/pull/22101#issuecomment-4281408264)), I've tested the following scenarios:

**Text Only Request**

```sh
curl http://localhost:9696/chat/completions -d '{"model": "granite-speech-3.3-2B-BF16.gguf", "temperature": 0.0, "messages": [{"role": "user", "content": "Tell me a story about a developer and their dog"}]}' | jq -r ".choices[0].message.content"
```

**ASR Request**

```sh
# NOTE: Using inline python to get around curl request length limit
python -c 'import base64, requests, json
from pathlib import Path
audio = base64.b64encode(open(Path("~/models/ibm-granite/granite-4.0-1b-speech/multilingual_sample.wav").expanduser(), "rb").read()).decode("utf-8")
print(requests.post("http://localhost:9696/chat/completions", json={
    "model": "granite-speech-3.3-2B-BF16.gguf",
    "temperature": 0.0,
    "messages": [{
        "role": "user",
        "content": [
            {
                "type": "input_audio",
                "input_audio": {
                    "data": audio,
                    "format": "wav"
                }
            },
            {"type": "text", "text": "can you transcribe the speech into a written format?"}
        ]
    }]
}).json()["choices"][0]["message"]["content"])'
```

### Run without adapter -> Good Text / Bad ASR

```sh
./bin/llama-server -m ~/models/granite-speech-3.3-2b/granite-speech-3.3-2B-BF16.gguf --mmproj ~/models/granite-speech-3.3-2b/mmproj-granite-speech-3.3-2b-BF16.gguf --port 9696 --lora ~/models/granite-speech-3.3-2b/granite-speech-3.3-2B-BF16-LoRA.gguf
```

**Text Response**

```
Once upon a time, in the bustling city of San Francisco, lived a brilliant developer named Alex. Alex was known for their exceptional skills in coding and creating innovative software solutions. However, what many didn't know was Alex's equally endearing companion, a golden retriever named Max.

Max was not just any dog; he was Alex's constant coding companion. While other developers might take breaks to socialize or exercise, Alex would often bring Max to their workspace. Max would sit patiently at Alex's feet, his tail wagging in anticipation as his owner typed away at their keyboard.

One day, Alex was working on a complex project involving machine learning algorithms. The task was daunting, and the deadlines were looming. As Alex delved deeper into the code, they found themselves stuck in a rut, unable to make progress.

Max, sensing his owner's frustration, nudged his paw against Alex's hand. With a sigh, Alex decided to take a break and spent the afternoon playing fetch with Max in the nearby park. The fresh air and exercise did wonders for Alex's mind.

Returning to the office, Alex felt refreshed and reinvigorated. They approached the problem with a new perspective, and after a few more hours of focused work, they finally cracked the code. The solution was elegant, efficient, and had never occurred to Alex when they were focused on the problem.

Word of Alex's innovative solution spread throughout the tech community. The project was a success, and Alex's reputation as a developer soared. But more importantly, Max became a symbol of the creative spark that could emerge from even the most mundane activities, like playing fetch in the park.

From then on, Max was no longer just a loyal canine companion but a co-creator, a source of inspiration, and a reminder that sometimes, the best ideas come from taking a break and allowing our minds to wander. And so, the developer and their dog continued their partnership, crafting innovative software and sharing countless adventures in the heart of San Francisco.
```

**ASR Response**

```
Sure, I'd be happy to transcribe the speech into written format. Here's the transcription:

---

For Timothy was a spoiled cat, and he allowed no one to interfere. Everybody waited upon him, moving their chairs even, for he was the monarch of the hearth.

The next night, Timothy's sister called him when he was still awake. "Sister," he said, "if you don't sleep, I beg you, wait until the day that will soon appear to continue the tale of the pecker."

---

This transcription maintains the original rhythm and tone of the text, preserving the poetic language and the sense of formality in the dialogue.
```

### Run with unconditional adapter -> Bad Text / Good ASR

```sh
./bin/llama-server -m ~/models/granite-speech-3.3-2b/granite-speech-3.3-2B-BF16.gguf --mmproj ~/models/granite-speech-3.3-2b/mmproj-granite-speech-3.3-2b-BF16.gguf --port 9696 --lora ~/models/granite-speech-3.3-2b/granite-speech-3.3-2B-BF16-LoRA.gguf
```

**Text Response**

(empty newline)
```


```

**ASR Response**

```
for timothy was a spoiled cat and he allowed no one to interfere everybody waited upon him moving their chairs even for he was monarch of the hearth dinarzade la nuit suivante appela sa soeur quand il en fut temps si vous ne dormez pas ma soeur lui dit-elle je vous prie en attendant le jour qui paraîtra bientôt de continuer le compte du pêcheur
```

### Run with conditional adapter -> Good Text / Good ASR

```sh
./bin/llama-server -m ~/models/granite-speech-3.3-2b/granite-speech-3.3-2B-BF16.gguf --mmproj ~/models/granite-speech-3.3-2b/mmproj-granite-speech-3.3-2b-BF16.gguf --port 9696 --lora ~/models/granite-speech-3.3-2b/granite-speech-3.3-2B-BF16-LoRA.gguf --lora-modality 0:audio
```

**Text Response**

```
Once upon a time, in the bustling city of San Francisco, lived a brilliant developer named Alex. Alex was known for their exceptional skills in coding and creating innovative software solutions. However, what many didn't know was Alex's equally endearing companion, a golden retriever named Max.

Max was not just any dog; he was Alex's constant coding companion. While other developers might take breaks to socialize or exercise, Alex would often bring Max to their workspace. Max would sit patiently at Alex's feet, his tail wagging in anticipation as his owner typed away at their keyboard.

One day, Alex was working on a complex project involving machine learning algorithms. The task was daunting, and the deadlines were looming. As Alex delved deeper into the code, they found themselves stuck in a rut, unable to make progress.

Max, sensing his owner's frustration, nudged his paw against Alex's hand. With a sigh, Alex decided to take a break and spent the afternoon playing fetch with Max in the nearby park. The fresh air and exercise did wonders for Alex's mind.

Returning to the office, Alex felt refreshed and reinvigorated. They approached the problem with a new perspective, and after a few more hours of focused work, they finally cracked the code. The solution was elegant, efficient, and had never occurred to Alex when they were focused on the problem.

Word of Alex's innovative solution spread throughout the tech community. The project was a success, and Alex's reputation as a developer soared. But more importantly, Max became a symbol of the creative spark that could emerge from even the most mundane activities, like playing fetch in the park.

From then on, Max was no longer just a loyal canine companion but a co-creator, a source of inspiration, and a reminder that sometimes, the best ideas come from taking a break and allowing our minds to wander. And so, the developer and their dog continued their partnership, crafting innovative software and sharing countless adventures in the heart of San Francisco.
```

**ASR Response**

```
for timothy was a spoiled cat and he allowed no one to interfere everybody waited upon him moving their chairs even for he was monarch of the hearth dinarzade la nuit suivante appela sa soeur quand il en fut temps si vous ne dormez pas ma soeur lui dit-elle je vous prie en attendant le jour qui paraîtra bientôt de continuer le compte du pêcheur
```

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): YES
- AI usage disclosure: YES

## AI Usage Disclosure

For this work, I used a combination of IBM Bob and Open Code with `qwen3.5:122b` running in Ollama. Bob was used primarily for planning while OC+qwen3.5 was used primarily for implementation.

I annotated each commit with `AI-usage: [full, draft, none] (<agent>)` based on how I used my assistants (`full` -> unaltered agent output, `draft` -> edited agent output, `none` -> no agent usage). This is a convention I've been using to track my ownership. Every commit, regardless of agent generation, was fully reviewed and (if needed) edited before committing. I have a small tool [git-ai-stats](https://gist.github.com/gabe-l-hart/719b9ac11b3e50576bf146fec247dcb9) to track the breakdown of commits by agent, usage type, and lines of code.

<details>
<summary>git-ai-stats output</summary>

```
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          7
IBM Bob, OpenCode + qwen3.5:122b |          6
---------------------------------------------
TOTAL                          |         13

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          7
draft                          |          3
full                           |          3
---------------------------------------------
TOTAL                          |         13

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
none                      |          7 |        808 |          6
IBM Bob, OpenCode + qwen3.5:122b |          6 |        277 |          2
------------------------------------------------------------
TOTAL                     |         13 |       1085 |          8

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          7 |        808 |          6
draft                |          3 |         93 |          2
full                 |          3 |        184 |          0
-------------------------------------------------------
TOTAL                |         13 |       1085 |          8
```

</details>