### PR TITLE
hip: direct alloc for FA f16 temp buffers

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1153,6 +1153,38 @@ struct ggml_cuda_pool_alloc {
     ggml_cuda_pool_alloc& operator=(ggml_cuda_pool_alloc &&) = delete;
 };
 
+#ifdef GGML_USE_HIP
+// Direct alloc/free, avoids legacy pool retention on HIP without VMM
+template<typename T>
+struct ggml_cuda_direct_alloc {
+    T * ptr = nullptr;
+    cudaStream_t stream;
+
+    ggml_cuda_direct_alloc() = default;
+    explicit ggml_cuda_direct_alloc(cudaStream_t s) : stream(s) {}
+
+    ~ggml_cuda_direct_alloc() {
+        if (ptr) {
+            cudaStreamSynchronize(stream);
+            cudaFree(ptr);
+        }
+    }
+
+    T * alloc(size_t size) {
+        GGML_ASSERT(ptr == nullptr);
+        CUDA_CHECK(cudaMalloc(&ptr, size * sizeof(T)));
+        return ptr;
+    }
+
+    T * get() { return ptr; }
+
+    ggml_cuda_direct_alloc(const ggml_cuda_direct_alloc &) = delete;
+    ggml_cuda_direct_alloc(ggml_cuda_direct_alloc &&) = delete;
+    ggml_cuda_direct_alloc& operator=(const ggml_cuda_direct_alloc &) = delete;
+    ggml_cuda_direct_alloc& operator=(ggml_cuda_direct_alloc &&) = delete;
+};
+#endif
+
 
 // backend interface
 

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -946,8 +946,13 @@ void launch_fattn(
     const int cc  = ggml_cuda_info().devices[id].cc;
     const int nsm = ggml_cuda_info().devices[id].nsm;
 
+#ifdef GGML_USE_HIP
+    ggml_cuda_direct_alloc<half> K_f16(main_stream);
+    ggml_cuda_direct_alloc<half> V_f16(main_stream);
+#else
     ggml_cuda_pool_alloc<half>   K_f16(pool);
     ggml_cuda_pool_alloc<half>   V_f16(pool);
+#endif
     ggml_cuda_pool_alloc<int>    KV_max(pool);
     ggml_cuda_pool_alloc<float>  dst_tmp(pool);
     ggml_cuda_pool_alloc<float2> dst_tmp_meta(pool);


### PR DESCRIPTION
Fixes #22107. On HIP without VMM, the legacy pool holds FA f16 temp
buffers at peak size after use, so quantized KV OOMs before f16 at
the same context length.

Adds ggml_cuda_direct_alloc<T> in common.cuh (mirrors pool_alloc
interface) and uses it for K_f16/V_f16 in launch_fattn. HIP-only,
two files changed.

Complements #22155 which is approved as a general pool OOM safety net.
This avoids the OOM in the first place so the flush-retry path
doesn't trigger. Tested both side by side, no perf regression at
depth.

Tested on gfx1100 (RX 7900 XTX), gfx1200 (RX 9060 XT), gfx1201
(RX 9070 XT) by multiple community testers.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO