### PR TITLE
mtmd: correct mtmd_decode_use_mrope()

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -1052,7 +1052,7 @@ bool mtmd_decode_use_non_causal(const mtmd_context * ctx, const mtmd_input_chunk
 }
 
 bool mtmd_decode_use_mrope(const mtmd_context * ctx) {
-    return ctx->pos_type;
+    return ctx->pos_type == MTMD_POS_TYPE_MROPE;
 }
 
 bool mtmd_support_vision(const mtmd_context * ctx) {


### PR DESCRIPTION
## Overview

A small mistake from https://github.com/ggml-org/llama.cpp/pull/22175

Funny though, without this fix, things still work magically just because the type `MTMD_POS_TYPE_NORMAL` is `0`, which evaluates to `false`

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, AI spotted this mistake <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
