### PR TITLE
gguf-py: Read and write empty array.

### DIFF
--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -243,6 +243,9 @@ class GGUFReader:
             offs += int(alen.nbytes)
             aparts: list[npt.NDArray[Any]] = [raw_itype, alen]
             data_idxs: list[int] = []
+            # If empty array
+            if alen[0] == 0:
+                types.append(GGUFValueType(raw_itype[0]))
             # FIXME: Handle multi-dimensional arrays properly instead of flattening
             for idx in range(alen[0]):
                 curr_size, curr_parts, curr_idxs, curr_types = self._get_field_parts(offs, raw_itype[0])

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -1298,13 +1298,12 @@ class GGUFWriter:
             if not isinstance(val, Sequence):
                 raise ValueError("Invalid GGUF metadata array, expecting sequence")
 
-            if len(val) == 0:
-                raise ValueError("Invalid GGUF metadata array. Empty array")
-
             if sub_type is not None:
                 ltype = sub_type
             elif isinstance(val, bytes):
                 ltype = GGUFValueType.UINT8
+            elif len(val) == 0:
+                raise ValueError("Invalid GGUF metadata array. Empty array")
             else:
                 ltype = GGUFValueType.get_type(val[0])
                 if not all(GGUFValueType.get_type(i) is ltype for i in val[1:]):


### PR DESCRIPTION
## Overview

When modifying model parameters with gguf-py, you cannot copy the empty arrays from the original model.
This revision will allow copying empty arrays:
- Obtain the subtype even if the array is empty during reading.
- The write operation fails only when the array is empty and no subtype is specified.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No