### PR TITLE
Add IP whitelist with CIDR support to llama-server

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2910,7 +2910,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_API_KEY"));
     add_opt(common_arg(
-        {"--whitelist"}, "IP1,IP2,...",
+        {"--whitelist"}, "IP1,IP2,CIDR...",
         "comma-separated list of allowed client IP addresses",
         [](common_params & params, const std::string & value) {
             params.whitelist_ips.clear();

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2910,6 +2910,25 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_API_KEY"));
     add_opt(common_arg(
+        {"--whitelist"}, "IP1,IP2,...",
+        "comma-separated list of allowed client IP addresses",
+        [](common_params & params, const std::string & value) {
+            params.whitelist_ips.clear();
+            for (auto ip : parse_csv_row(value)) {
+                ip.erase(ip.begin(), std::find_if(ip.begin(), ip.end(), [](unsigned char ch) {
+                    return !std::isspace(ch);
+                }));
+                ip.erase(std::find_if(ip.rbegin(), ip.rend(), [](unsigned char ch) {
+                    return !std::isspace(ch);
+                }).base(), ip.end());
+
+                if (!ip.empty()) {
+                    params.whitelist_ips.push_back(ip);
+                }
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_WHITELIST"));    
+    add_opt(common_arg(
         {"--api-key-file"}, "FNAME",
         "path to file containing API keys (default: none)",
         [](common_params & params, const std::string & value) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2910,6 +2910,33 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_API_KEY"));
     add_opt(common_arg(
+        {"--trusted-proxy"}, "IP1,IP2,CIDR,...",
+        "comma-separated list of trusted reverse proxy IP addresses or CIDR ranges",
+        [](common_params & params, const std::string & value) {
+            params.trusted_proxy_ips.clear();
+
+            for (auto ip : parse_csv_row(value)) {
+                ip.erase(ip.begin(), std::find_if(ip.begin(), ip.end(), [](unsigned char ch) {
+                    return !std::isspace(ch);
+                }));
+                ip.erase(std::find_if(ip.rbegin(), ip.rend(), [](unsigned char ch) {
+                    return !std::isspace(ch);
+                }).base(), ip.end());
+
+                if (!ip.empty()) {
+                    params.trusted_proxy_ips.push_back(ip);
+                }
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_TRUSTED_PROXY"));
+    add_opt(common_arg(
+        {"--use-forwarded-for"},
+        "use X-Forwarded-For header only when request comes from a trusted proxy",
+        [](common_params & params) {
+            params.use_forwarded_for = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_USE_FORWARDED_FOR"));    
+    add_opt(common_arg(
         {"--whitelist"}, "IP1,IP2,CIDR...",
         "comma-separated list of allowed client IP addresses",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -586,6 +586,7 @@ struct common_params {
     int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
 
     std::vector<std::string> api_keys;
+    std::vector<std::string> whitelist_ips;
 
     std::string ssl_file_key  = "";                                                                         // NOLINT
     std::string ssl_file_cert = "";                                                                         // NOLINT

--- a/common/common.h
+++ b/common/common.h
@@ -587,6 +587,8 @@ struct common_params {
 
     std::vector<std::string> api_keys;
     std::vector<std::string> whitelist_ips;
+    std::vector<std::string> trusted_proxy_ips;
+    bool use_forwarded_for = false;
 
     std::string ssl_file_key  = "";                                                                         // NOLINT
     std::string ssl_file_cert = "";                                                                         // NOLINT

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -33,6 +33,30 @@ server_http_context::server_http_context()
 
 server_http_context::~server_http_context() = default;
 
+static std::string first_ip_from_x_forwarded_for(const httplib::Request & req) {
+    std::string forwarded = req.get_header_value("X-Forwarded-For");
+
+    if (forwarded.empty()) {
+        return "";
+    }
+
+    const size_t comma = forwarded.find(',');
+    if (comma != std::string::npos) {
+        forwarded = forwarded.substr(0, comma);
+    }
+
+    // trim
+    forwarded.erase(forwarded.begin(), std::find_if(forwarded.begin(), forwarded.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+
+    forwarded.erase(std::find_if(forwarded.rbegin(), forwarded.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), forwarded.end());
+
+    return forwarded;
+}
+
 static void log_server_request(const httplib::Request & req, const httplib::Response & res) {
     // skip logging requests that are regularly sent, to avoid log spam
     if (req.path == "/health"
@@ -53,42 +77,14 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
     SRV_DBG("response: %s\n", res.body.c_str());
 }
 
-static std::string first_forwarded_for_ip(const httplib::Request & req) {
-    std::string forwarded = req.get_header_value("X-Forwarded-For");
-
-    if (forwarded.empty()) {
-        return "";
+static bool ipv4_to_u32(const std::string & ip, uint32_t & out) {
+    struct in_addr addr;
+    if (inet_pton(AF_INET, ip.c_str(), &addr) != 1) {
+        return false;
     }
 
-    const size_t comma = forwarded.find(',');
-    if (comma != std::string::npos) {
-        forwarded = forwarded.substr(0, comma);
-    }
-
-    return trim_copy(forwarded);
-}
-
-static std::string get_client_ip(
-        const httplib::Request & req,
-        bool use_forwarded_for,
-        const std::vector<std::string> & trusted_proxy_ips) {
-    const std::string remote_ip = trim_copy(req.remote_addr);
-
-    if (!use_forwarded_for) {
-        return remote_ip;
-    }
-
-    if (!is_ip_allowed(remote_ip, trusted_proxy_ips)) {
-        return remote_ip;
-    }
-
-    const std::string forwarded_ip = first_forwarded_for_ip(req);
-
-    if (forwarded_ip.empty()) {
-        return remote_ip;
-    }
-
-    return forwarded_ip;
+    out = ntohl(addr.s_addr);
+    return true;
 }
 
 static std::string trim_copy(std::string value) {
@@ -101,16 +97,6 @@ static std::string trim_copy(std::string value) {
     }).base(), value.end());
 
     return value;
-}
-
-static bool ipv4_to_u32(const std::string & ip, uint32_t & out) {
-    struct in_addr addr;
-    if (inet_pton(AF_INET, ip.c_str(), &addr) != 1) {
-        return false;
-    }
-
-    out = ntohl(addr.s_addr);
-    return true;
 }
 
 static bool ip_in_cidr(const std::string & ip, const std::string & cidr) {
@@ -148,6 +134,21 @@ static bool ip_in_cidr(const std::string & ip, const std::string & cidr) {
     return (ip_val & mask) == (base_val & mask);
 }
 
+static std::string first_forwarded_for_ip(const httplib::Request & req) {
+    std::string forwarded = req.get_header_value("X-Forwarded-For");
+
+    if (forwarded.empty()) {
+        return "";
+    }
+
+    const size_t comma = forwarded.find(',');
+    if (comma != std::string::npos) {
+        forwarded = forwarded.substr(0, comma);
+    }
+
+    return trim_copy(forwarded);
+}
+
 static bool is_ip_allowed(const std::string & client_ip, const std::vector<std::string> & whitelist_ips) {
     for (const auto & entry_raw : whitelist_ips) {
         const std::string entry = trim_copy(entry_raw);
@@ -169,6 +170,30 @@ static bool is_ip_allowed(const std::string & client_ip, const std::vector<std::
 
     return false;
 }
+
+static std::string get_client_ip(
+        const httplib::Request & req,
+        bool use_forwarded_for,
+        const std::vector<std::string> & trusted_proxy_ips) {
+    const std::string remote_ip = trim_copy(req.remote_addr);
+
+    if (!use_forwarded_for) {
+        return remote_ip;
+    }
+
+    if (!is_ip_allowed(remote_ip, trusted_proxy_ips)) {
+        return remote_ip;
+    }
+
+    const std::string forwarded_ip = first_forwarded_for_ip(req);
+
+    if (forwarded_ip.empty()) {
+        return remote_ip;
+    }
+
+    return forwarded_ip;
+}
+
 
 bool server_http_context::init(const common_params & params) {
     path_prefix = params.api_prefix;

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -274,56 +274,9 @@ bool server_http_context::init(const common_params & params) {
         LOG_INF("%s: whitelist: %zu entries loaded\n", __func__, params.whitelist_ips.size());
     }
 
-    if (params.api_keys.size() == 1) {
-        auto key = params.api_keys[0];
-        std::string substr = key.substr(std::max((int)(key.length() - 4), 0));
-        LOG_INF("%s: api_keys: ****%s\n", __func__, substr.c_str());
-    } 
-    if (params.whitelist_ips.size() == 1) {
-        LOG_INF("%s: whitelist: 1 IP loaded\n", __func__);
-    } else if (params.api_keys.size() > 1) {
-        LOG_INF("%s: api_keys: %zu keys loaded\n", __func__, params.api_keys.size());
-    }
-
     //
     // Middlewares
     //
-
-    auto middleware_validate_whitelist = [ whitelist_ips = params.whitelist_ips,trusted_proxy_ips = params.trusted_proxy_ips, use_forwarded_for = params.use_forwarded_for](const httplib::Request & req, httplib::Response & res) {
-        if (whitelist_ips.empty()) {
-            return true;
-        }
-
-        const std::string client_ip = get_client_ip(
-            req,
-            params.use_forwarded_for,
-            params.trusted_proxy_ips
-        );
-
-	if (use_forwarded_for && is_ip_allowed(req.remote_addr, trusted_proxies)) {
-            client_ip = first_ip_from_x_forwarded_for(req);
-        }
-
-        if (is_ip_allowed(client_ip, whitelist_ips)) {
-            return true;
-        }
-
-        res.status = 403;
-        res.set_content(
-            safe_json_to_str(json {
-                {"error", {
-                    {"message", "Access Denied."},
-                    {"type", "permission_error"},
-                    {"code", 403}
-                }}
-            }),
-            "application/json; charset=utf-8"
-        );
-
-        LOG_WRN("Forbidden: IP not whitelisted: %s\n", client_ip.c_str());
-        return false;
-    };
-
 	auto middleware_validate_whitelist = [
     	whitelist_ips = params.whitelist_ips,
 	    trusted_proxy_ips = params.trusted_proxy_ips,

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -33,30 +33,6 @@ server_http_context::server_http_context()
 
 server_http_context::~server_http_context() = default;
 
-static std::string first_ip_from_x_forwarded_for(const httplib::Request & req) {
-    std::string forwarded = req.get_header_value("X-Forwarded-For");
-
-    if (forwarded.empty()) {
-        return "";
-    }
-
-    const size_t comma = forwarded.find(',');
-    if (comma != std::string::npos) {
-        forwarded = forwarded.substr(0, comma);
-    }
-
-    // trim
-    forwarded.erase(forwarded.begin(), std::find_if(forwarded.begin(), forwarded.end(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }));
-
-    forwarded.erase(std::find_if(forwarded.rbegin(), forwarded.rend(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }).base(), forwarded.end());
-
-    return forwarded;
-}
-
 static void log_server_request(const httplib::Request & req, const httplib::Response & res) {
     // skip logging requests that are regularly sent, to avoid log spam
     if (req.path == "/health"
@@ -171,6 +147,21 @@ static bool is_ip_allowed(const std::string & client_ip, const std::vector<std::
     return false;
 }
 
+static std::string first_ip_from_x_forwarded_for(const httplib::Request & req) {
+    std::string forwarded = req.get_header_value("X-Forwarded-For");
+
+    if (forwarded.empty()) {
+        return "";
+    }
+
+    const size_t comma = forwarded.find(',');
+    if (comma != std::string::npos) {
+        forwarded = forwarded.substr(0, comma);
+    }
+
+    return trim_copy(forwarded);
+}
+
 static std::string get_client_ip(
         const httplib::Request & req,
         bool use_forwarded_for,
@@ -185,7 +176,7 @@ static std::string get_client_ip(
         return remote_ip;
     }
 
-    const std::string forwarded_ip = first_forwarded_for_ip(req);
+    const std::string forwarded_ip = first_ip_from_x_forwarded_for(req);
 
     if (forwarded_ip.empty()) {
         return remote_ip;
@@ -333,6 +324,41 @@ bool server_http_context::init(const common_params & params) {
         return false;
     };
 
+	auto middleware_validate_whitelist = [
+    	whitelist_ips = params.whitelist_ips,
+	    trusted_proxy_ips = params.trusted_proxy_ips,
+	    use_forwarded_for = params.use_forwarded_for
+	](const httplib::Request & req, httplib::Response & res) {
+	    if (whitelist_ips.empty()) {
+	        return true;
+	    }
+
+	    const std::string client_ip = get_client_ip(
+	        req,
+	        use_forwarded_for,
+	        trusted_proxy_ips
+    	);
+
+	    if (is_ip_allowed(client_ip, whitelist_ips)) {
+    	    return true;
+	    }
+
+	    res.status = 403;
+	    res.set_content(
+    	    safe_json_to_str(json {
+        	    {"error", {
+            	    {"message", "Access Denied"},
+                	{"type", "permission_error"},
+	                {"code", 403}
+	            }}
+	        }),
+    	    "application/json; charset=utf-8"
+	    );
+
+    	LOG_WRN("Forbidden: IP not whitelisted: %s\n", client_ip.c_str());
+	    return false;
+	};
+	
     auto middleware_validate_api_key = [api_keys = params.api_keys](const httplib::Request & req, httplib::Response & res) {
         static const std::unordered_set<std::string> public_endpoints = {
             "/health",

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -53,6 +53,44 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
     SRV_DBG("response: %s\n", res.body.c_str());
 }
 
+static std::string first_forwarded_for_ip(const httplib::Request & req) {
+    std::string forwarded = req.get_header_value("X-Forwarded-For");
+
+    if (forwarded.empty()) {
+        return "";
+    }
+
+    const size_t comma = forwarded.find(',');
+    if (comma != std::string::npos) {
+        forwarded = forwarded.substr(0, comma);
+    }
+
+    return trim_copy(forwarded);
+}
+
+static std::string get_client_ip(
+        const httplib::Request & req,
+        bool use_forwarded_for,
+        const std::vector<std::string> & trusted_proxy_ips) {
+    const std::string remote_ip = trim_copy(req.remote_addr);
+
+    if (!use_forwarded_for) {
+        return remote_ip;
+    }
+
+    if (!is_ip_allowed(remote_ip, trusted_proxy_ips)) {
+        return remote_ip;
+    }
+
+    const std::string forwarded_ip = first_forwarded_for_ip(req);
+
+    if (forwarded_ip.empty()) {
+        return remote_ip;
+    }
+
+    return forwarded_ip;
+}
+
 static std::string trim_copy(std::string value) {
     value.erase(value.begin(), std::find_if(value.begin(), value.end(), [](unsigned char ch) {
         return !std::isspace(ch);
@@ -221,12 +259,20 @@ bool server_http_context::init(const common_params & params) {
     // Middlewares
     //
 
-    auto middleware_validate_whitelist = [whitelist_ips = params.whitelist_ips](const httplib::Request & req, httplib::Response & res) {
+    auto middleware_validate_whitelist = [ whitelist_ips = params.whitelist_ips,trusted_proxy_ips = params.trusted_proxy_ips, use_forwarded_for = params.use_forwarded_for](const httplib::Request & req, httplib::Response & res) {
         if (whitelist_ips.empty()) {
             return true;
         }
 
-        const std::string client_ip = trim_copy(req.remote_addr);
+        const std::string client_ip = get_client_ip(
+            req,
+            params.use_forwarded_for,
+            params.trusted_proxy_ips
+        );
+
+	if (use_forwarded_for && is_ip_allowed(req.remote_addr, trusted_proxies)) {
+            client_ip = first_ip_from_x_forwarded_for(req);
+        }
 
         if (is_ip_allowed(client_ip, whitelist_ips)) {
             return true;

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -248,6 +248,20 @@ bool server_http_context::init(const common_params & params) {
         auto key = params.api_keys[0];
         std::string substr = key.substr(std::max((int)(key.length() - 4), 0));
         LOG_INF("%s: api_keys: ****%s\n", __func__, substr.c_str());
+    } else if (params.api_keys.size() > 1) {
+        LOG_INF("%s: api_keys: %zu keys loaded\n", __func__, params.api_keys.size());
+    }
+
+    if (params.whitelist_ips.size() == 1) {
+        LOG_INF("%s: whitelist: 1 entry loaded\n", __func__);
+    } else if (params.whitelist_ips.size() > 1) {
+        LOG_INF("%s: whitelist: %zu entries loaded\n", __func__, params.whitelist_ips.size());
+    }
+
+    if (params.api_keys.size() == 1) {
+        auto key = params.api_keys[0];
+        std::string substr = key.substr(std::max((int)(key.length() - 4), 0));
+        LOG_INF("%s: api_keys: ****%s\n", __func__, substr.c_str());
     } 
     if (params.whitelist_ips.size() == 1) {
         LOG_INF("%s: whitelist: 1 IP loaded\n", __func__);
@@ -393,13 +407,13 @@ bool server_http_context::init(const common_params & params) {
             res.set_content("", "text/html"); // blank response, no data
             return httplib::Server::HandlerResponse::Handled; // skip further processing
         }
-        if (!middleware_server_state(req, res)) {
-            return httplib::Server::HandlerResponse::Handled;
-        }
         if (!middleware_validate_whitelist(req, res)) {
             return httplib::Server::HandlerResponse::Handled;
         }
-	if (!middleware_validate_api_key(req, res)) {
+        if (!middleware_validate_api_key(req, res)) {
+            return httplib::Server::HandlerResponse::Handled;
+        }
+        if (!middleware_server_state(req, res)) {
             return httplib::Server::HandlerResponse::Handled;
         }
         return httplib::Server::HandlerResponse::Unhandled;

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "server-http.h"
 #include "server-common.h"
+#include <cctype>
 
 #include <cpp-httplib/httplib.h>
 
@@ -49,6 +50,18 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
 
     SRV_DBG("request:  %s\n", req.body.c_str());
     SRV_DBG("response: %s\n", res.body.c_str());
+}
+
+static std::string trim_copy(std::string value) {
+    value.erase(value.begin(), std::find_if(value.begin(), value.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+
+    value.erase(std::find_if(value.rbegin(), value.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), value.end());
+
+    return value;
 }
 
 bool server_http_context::init(const common_params & params) {
@@ -129,6 +142,9 @@ bool server_http_context::init(const common_params & params) {
         auto key = params.api_keys[0];
         std::string substr = key.substr(std::max((int)(key.length() - 4), 0));
         LOG_INF("%s: api_keys: ****%s\n", __func__, substr.c_str());
+    } 
+    if (params.whitelist_ips.size() == 1) {
+        LOG_INF("%s: whitelist: 1 IP loaded\n", __func__);
     } else if (params.api_keys.size() > 1) {
         LOG_INF("%s: api_keys: %zu keys loaded\n", __func__, params.api_keys.size());
     }
@@ -136,6 +152,32 @@ bool server_http_context::init(const common_params & params) {
     //
     // Middlewares
     //
+
+    auto middleware_validate_whitelist = [whitelist_ips = params.whitelist_ips](const httplib::Request & req, httplib::Response & res) {
+        if (whitelist_ips.empty()) {
+            return true;
+        }
+
+        const std::string client_ip = trim_copy(req.remote_addr);
+
+        if (std::find(whitelist_ips.begin(), whitelist_ips.end(), client_ip) != whitelist_ips.end()) {
+            return true;
+        }
+
+        res.status = 403;
+        res.set_content(
+            safe_json_to_str(json {
+                {"error", {
+                    {"message", "Access Denied"},
+                    {"type", "permission_error"},
+                    {"code", 403}
+                }}
+            }),
+            "application/json; charset=utf-8"
+        );
+        LOG_WRN("Forbidden: IP not whitelisted: %s\n", client_ip.c_str());
+        return false;
+    };
 
     auto middleware_validate_api_key = [api_keys = params.api_keys](const httplib::Request & req, httplib::Response & res) {
         static const std::unordered_set<std::string> public_endpoints = {
@@ -226,7 +268,7 @@ bool server_http_context::init(const common_params & params) {
     };
 
     // register server middlewares
-    srv->set_pre_routing_handler([middleware_validate_api_key, middleware_server_state](const httplib::Request & req, httplib::Response & res) {
+    srv->set_pre_routing_handler([middleware_validate_whitelist, middleware_validate_api_key, middleware_server_state](const httplib::Request & req, httplib::Response & res) {		    
         res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
         // If this is OPTIONS request, skip validation because browsers don't include Authorization header
         if (req.method == "OPTIONS") {
@@ -239,7 +281,10 @@ bool server_http_context::init(const common_params & params) {
         if (!middleware_server_state(req, res)) {
             return httplib::Server::HandlerResponse::Handled;
         }
-        if (!middleware_validate_api_key(req, res)) {
+        if (!middleware_validate_whitelist(req, res)) {
+            return httplib::Server::HandlerResponse::Handled;
+        }
+	if (!middleware_validate_api_key(req, res)) {
             return httplib::Server::HandlerResponse::Handled;
         }
         return httplib::Server::HandlerResponse::Unhandled;

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include "server-http.h"
 #include "server-common.h"
+#include <arpa/inet.h>
 #include <cctype>
 
 #include <cpp-httplib/httplib.h>
@@ -62,6 +63,73 @@ static std::string trim_copy(std::string value) {
     }).base(), value.end());
 
     return value;
+}
+
+static bool ipv4_to_u32(const std::string & ip, uint32_t & out) {
+    struct in_addr addr;
+    if (inet_pton(AF_INET, ip.c_str(), &addr) != 1) {
+        return false;
+    }
+
+    out = ntohl(addr.s_addr);
+    return true;
+}
+
+static bool ip_in_cidr(const std::string & ip, const std::string & cidr) {
+    const size_t slash = cidr.find('/');
+    if (slash == std::string::npos) {
+        return false;
+    }
+
+    const std::string base_ip = trim_copy(cidr.substr(0, slash));
+    const std::string prefix_str = trim_copy(cidr.substr(slash + 1));
+
+    if (prefix_str.empty()) {
+        return false;
+    }
+
+    int prefix = 0;
+    try {
+        prefix = std::stoi(prefix_str);
+    } catch (...) {
+        return false;
+    }
+
+    if (prefix < 0 || prefix > 32) {
+        return false;
+    }
+
+    uint32_t ip_val = 0;
+    uint32_t base_val = 0;
+
+    if (!ipv4_to_u32(ip, ip_val) || !ipv4_to_u32(base_ip, base_val)) {
+        return false;
+    }
+
+    const uint32_t mask = (prefix == 0) ? 0 : (0xFFFFFFFFu << (32 - prefix));
+    return (ip_val & mask) == (base_val & mask);
+}
+
+static bool is_ip_allowed(const std::string & client_ip, const std::vector<std::string> & whitelist_ips) {
+    for (const auto & entry_raw : whitelist_ips) {
+        const std::string entry = trim_copy(entry_raw);
+
+        if (entry.empty()) {
+            continue;
+        }
+
+        if (entry.find('/') != std::string::npos) {
+            if (ip_in_cidr(client_ip, entry)) {
+                return true;
+            }
+        } else {
+            if (client_ip == entry) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 bool server_http_context::init(const common_params & params) {
@@ -160,7 +228,7 @@ bool server_http_context::init(const common_params & params) {
 
         const std::string client_ip = trim_copy(req.remote_addr);
 
-        if (std::find(whitelist_ips.begin(), whitelist_ips.end(), client_ip) != whitelist_ips.end()) {
+        if (is_ip_allowed(client_ip, whitelist_ips)) {
             return true;
         }
 
@@ -168,13 +236,14 @@ bool server_http_context::init(const common_params & params) {
         res.set_content(
             safe_json_to_str(json {
                 {"error", {
-                    {"message", "Access Denied"},
+                    {"message", "Access Denied."},
                     {"type", "permission_error"},
                     {"code", 403}
                 }}
             }),
             "application/json; charset=utf-8"
         );
+
         LOG_WRN("Forbidden: IP not whitelisted: %s\n", client_ip.c_str());
         return false;
     };


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->

This PR introduces support for IP-based access control (whitelisting) in the llama-server.

A new CLI argument `--whitelist `was added, allowing users to restrict access to the HTTP server to a specific set of client IP addresses.

## Features
- New CLI argument:
`--whitelist IP1,IP2,CIDR,...`

- Environment variable support:
`LLAMA_ARG_WHITELIST`

- Middleware-based validation integrated into the existing HTTP pipeline (set_pre_routing_handler)
- Consistent behavior with existing server middleware (API key, server state)
- Returns structured JSON error when access is denied:

```JSON
{
  "error": {
    "message": "Access Denied",
    "type": "permission_error",
    "code": 403
  }
}
```

### Implementation details

- Added whitelist_ips to common_params
- Registered new argument in common/arg.cpp
- Parsed input using parse_csv_row() (consistent with existing parsing utilities)
- Implemented middleware in tools/server/server-http.cpp
- Validation occurs before API key checks, ensuring early rejection
- CIDR ranges added

```
10.0.0.0/24
192.168.0.0/16
```

### Behavior

- If `--whitelist `is **not provided** → no restriction (default behavior unchanged)
- If provided → only listed IPs are allowed
- All other requests return HTTP 403


```BASH
./llama-server \
  -m model.gguf \
  --host 0.0.0.0 \
  --port 8080 \
  --whitelist 127.0.0.1,192.168.1.12,.192.168.0.0/24
```
OR

```BASH
export LLAMA_ARG_WHITELIST="192.168.0.213"
./llama-server \
  -m model.gguf \
  --host 0.0.0.0 \
  --port 8080 \
```

### Motivation

This feature improves security for production deployments, especially when exposing the server over a network, by allowing simple and efficient network-level access control without requiring external proxies or firewalls.
