### PR TITLE
cuda: LRU eviction + overalloc for legacy pool

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1105,7 +1105,7 @@ int ggml_cuda_get_device();
 struct ggml_cuda_pool {
     virtual ~ggml_cuda_pool() = default;
 
-    virtual void * alloc(size_t size, size_t * actual_size) = 0;
+    virtual void * alloc(size_t size, size_t * actual_size, float lookahead = 1.05f) = 0;
     virtual void free(void * ptr, size_t size) = 0;
 };
 
@@ -1131,10 +1131,10 @@ struct ggml_cuda_pool_alloc {
     }
 
     // size is in number of elements
-    T * alloc(size_t size) {
+    T * alloc(size_t size, float lookahead = 1.05f) {
         GGML_ASSERT(pool != nullptr);
         GGML_ASSERT(ptr == nullptr);
-        ptr = (T *) pool->alloc(size * sizeof(T), &this->actual_size);
+        ptr = (T *) pool->alloc(size * sizeof(T), &this->actual_size, lookahead);
         return ptr;
     }
 

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -966,7 +966,7 @@ void launch_fattn(
         const size_t bs = ggml_blck_size(K->type);
         const size_t ts = ggml_type_size(K->type);
 
-        K_f16.alloc(ggml_nelements(K));
+        K_f16.alloc(ggml_nelements(K), 2.0f);
         if (ggml_is_contiguously_allocated(K)) {
             to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(K->type);
             to_fp16(K_data, K_f16.ptr, ggml_nelements(K), main_stream);
@@ -999,7 +999,7 @@ void launch_fattn(
             const size_t bs = ggml_blck_size(V->type);
             const size_t ts = ggml_type_size(V->type);
 
-            V_f16.alloc(ggml_nelements(V));
+            V_f16.alloc(ggml_nelements(V), 2.0f);
             if (ggml_is_contiguously_allocated(V)) {
                 to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(V->type);
                 to_fp16(V_data, V_f16.ptr, ggml_nelements(V), main_stream);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -358,10 +358,12 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
     struct ggml_cuda_buffer {
         void * ptr = nullptr;
         size_t size = 0;
+        uint64_t last_use = 0;
     };
 
     ggml_cuda_buffer buffer_pool[MAX_BUFFERS] = {};
     size_t pool_size = 0;
+    uint64_t usage_counter = 0;
 
     explicit ggml_cuda_pool_leg(int device) :
         device(device) {
@@ -385,7 +387,7 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
         }
     }
 
-    void * alloc(size_t size, size_t * actual_size) override {
+    void * alloc(size_t size, size_t * actual_size, float lookahead = 1.05f) override {
 #ifdef DEBUG_CUDA_MALLOC
         int nnz = 0;
         size_t max_size = 0;
@@ -424,20 +426,48 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
             return ptr;
         }
         void * ptr;
-        size_t look_ahead_size = (size_t) (1.05 * size);
+        size_t look_ahead_size = (size_t) (lookahead * size);
         look_ahead_size = 256 * ((look_ahead_size + 255)/256);
         ggml_cuda_set_device(device);
         cudaError_t err = ggml_cuda_device_malloc(&ptr, look_ahead_size, device);
         if (err == cudaErrorMemoryAllocation) {
             (void)cudaGetLastError();
-            const size_t cached_bytes = pool_size;
-            GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: alloc of %.2f MiB failed, flushing %.2f MiB of cached buffers and retrying\n",
-                           device, look_ahead_size/1024.0/1024.0, cached_bytes/1024.0/1024.0);
+            GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: alloc of %.2f MiB failed, evicting LRU from %.2f MiB cached\n",
+                           device, look_ahead_size/1024.0/1024.0, pool_size/1024.0/1024.0);
             CUDA_CHECK(cudaDeviceSynchronize());
-            clear_pool();
+            // evict LRU buffers up to 3x the requested size
+            size_t freed = 0;
+            size_t evict_target = 3 * look_ahead_size;
+            while (freed < evict_target) {
+                int oldest = -1;
+                uint64_t oldest_use = UINT64_MAX;
+                for (int i = 0; i < MAX_BUFFERS; ++i) {
+                    if (buffer_pool[i].ptr != nullptr && buffer_pool[i].last_use < oldest_use) {
+                        oldest_use = buffer_pool[i].last_use;
+                        oldest = i;
+                    }
+                }
+                if (oldest < 0) {
+                    break;
+                }
+                ggml_cuda_buffer & b = buffer_pool[oldest];
+                CUDA_CHECK(cudaFree(b.ptr));
+                freed += b.size;
+                pool_size -= b.size;
+                b.ptr = nullptr;
+                b.size = 0;
+            }
             err = ggml_cuda_device_malloc(&ptr, look_ahead_size, device);
+            if (err == cudaErrorMemoryAllocation) {
+                // LRU eviction wasn't enough, flush everything
+                (void)cudaGetLastError();
+                GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: LRU freed %.2f MiB, still OOM, flushing all\n",
+                               device, freed/1024.0/1024.0);
+                clear_pool();
+                err = ggml_cuda_device_malloc(&ptr, look_ahead_size, device);
+            }
             if (err == cudaSuccess) {
-                GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: retry succeeded\n", device);
+                GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: retry succeeded after eviction\n", device);
             }
         }
         CUDA_CHECK(err);
@@ -456,6 +486,7 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
             if (b.ptr == nullptr) {
                 b.ptr = ptr;
                 b.size = size;
+                b.last_use = ++usage_counter;
                 return;
             }
         }
@@ -499,7 +530,8 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         }
     }
 
-    void * alloc(size_t size, size_t * actual_size) override {
+    void * alloc(size_t size, size_t * actual_size, float lookahead = 1.05f) override {
+        GGML_UNUSED(lookahead);
         // round up the allocation size to the alignment to ensure that all allocations are aligned for all data types
         const size_t alignment = 128;
         size = alignment * ((size + alignment - 1) / alignment);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -435,39 +435,55 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
             GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: alloc of %.2f MiB failed, evicting LRU from %.2f MiB cached\n",
                            device, look_ahead_size/1024.0/1024.0, pool_size/1024.0/1024.0);
             CUDA_CHECK(cudaDeviceSynchronize());
-            // evict LRU buffers up to 3x the requested size
-            size_t freed = 0;
-            size_t evict_target = 3 * look_ahead_size;
-            while (freed < evict_target) {
-                int oldest = -1;
-                uint64_t oldest_use = UINT64_MAX;
-                for (int i = 0; i < MAX_BUFFERS; ++i) {
-                    if (buffer_pool[i].ptr != nullptr && buffer_pool[i].last_use < oldest_use) {
-                        oldest_use = buffer_pool[i].last_use;
-                        oldest = i;
-                    }
-                }
-                if (oldest < 0) {
-                    break;
-                }
-                ggml_cuda_buffer & b = buffer_pool[oldest];
-                CUDA_CHECK(cudaFree(b.ptr));
-                freed += b.size;
-                pool_size -= b.size;
-                b.ptr = nullptr;
-                b.size = 0;
-            }
-            err = ggml_cuda_device_malloc(&ptr, look_ahead_size, device);
-            if (err == cudaErrorMemoryAllocation) {
-                // LRU eviction wasn't enough, flush everything
-                (void)cudaGetLastError();
-                GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: LRU freed %.2f MiB, still OOM, flushing all\n",
-                               device, freed/1024.0/1024.0);
+#if defined(GGML_USE_HIP)
+            // ROCm/rocm-systems#4817: LRU free/realloc cycles amplify a
+            // hipMemcpyAsync host-mapping race on multi-GPU.  Fall back to
+            // the original clear_pool() path to avoid the timing change.
+            if (ggml_backend_cuda_get_device_count() > 1) {
+                GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: HIP multi-GPU, flushing %.2f MiB cached\n",
+                               device, pool_size/1024.0/1024.0);
                 clear_pool();
                 err = ggml_cuda_device_malloc(&ptr, look_ahead_size, device);
-            }
-            if (err == cudaSuccess) {
-                GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: retry succeeded after eviction\n", device);
+                if (err == cudaSuccess) {
+                    GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: retry succeeded\n", device);
+                }
+            } else
+#endif
+            {
+                // evict LRU buffers up to 3x the requested size
+                size_t freed = 0;
+                size_t evict_target = 3 * look_ahead_size;
+                while (freed < evict_target) {
+                    int oldest = -1;
+                    uint64_t oldest_use = UINT64_MAX;
+                    for (int i = 0; i < MAX_BUFFERS; ++i) {
+                        if (buffer_pool[i].ptr != nullptr && buffer_pool[i].last_use < oldest_use) {
+                            oldest_use = buffer_pool[i].last_use;
+                            oldest = i;
+                        }
+                    }
+                    if (oldest < 0) {
+                        break;
+                    }
+                    ggml_cuda_buffer & b = buffer_pool[oldest];
+                    CUDA_CHECK(cudaFree(b.ptr));
+                    freed += b.size;
+                    pool_size -= b.size;
+                    b.ptr = nullptr;
+                    b.size = 0;
+                }
+                err = ggml_cuda_device_malloc(&ptr, look_ahead_size, device);
+                if (err == cudaErrorMemoryAllocation) {
+                    // LRU eviction wasn't enough, flush everything
+                    (void)cudaGetLastError();
+                    GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: LRU freed %.2f MiB, still OOM, flushing all\n",
+                                   device, freed/1024.0/1024.0);
+                    clear_pool();
+                    err = ggml_cuda_device_malloc(&ptr, look_ahead_size, device);
+                }
+                if (err == cudaSuccess) {
+                    GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: retry succeeded after eviction\n", device);
+                }
             }
         }
         CUDA_CHECK(err);


### PR DESCRIPTION
Fixes #22107. Per #22193 (comment).

On OOM, evict LRU buffers first. FA temps use 2x overalloc.
Tested on gfx1201, q8_0 @ d40000: 369 t/s (was OOM).

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage: no