### PR TITLE
server : fix CUDA non-determinism with fixed seed (#2838)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2342,6 +2342,13 @@ private:
                                 // reuse any previously computed tokens that are common with the new prompt
                                 n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
 
+                                // skip cache reuse when a seed is explicitly set to avoid non-deterministic
+                                // output from batch-size-dependent FP ordering in CUDA FA (see #2838)
+                                const bool deterministic_mode = slot.task->params.sampling.seed != LLAMA_DEFAULT_SEED;
+                                if (deterministic_mode) {
+                                    n_past = 0;
+                                }
+
                                 // if there is an alora invoked, don't cache after the invocation start
                                 if (slot.alora_invocation_start > 0) {
                                     SLT_DBG(slot, "only caching to alora invocation start (n_past = %d, alora_invocation_start = %d)\n", n_past, slot.alora_invocation_start);
@@ -2359,7 +2366,7 @@ private:
                                 }
 
                                 // reuse chunks from the cached prompt by shifting their KV cache in the new position
-                                if (can_cache_reuse && n_cache_reuse > 0) {
+                                if (can_cache_reuse && n_cache_reuse > 0 && !deterministic_mode) {
                                     GGML_ASSERT(!slot.prompt.tokens.has_mtmd);
 
                                     size_t head_c = n_past; // cache


### PR DESCRIPTION
## Overview

Fixes #2838. When a seed is explicitly set, `llama-server` produces non-deterministic output on CUDA backends due to prompt cache reuse changing the effective batch size between evaluations, which exposes batch-size-dependent FP ordering in CUDA Flash Attention.

## Additional information

Analysis and reproduction script are in the issue discussion: [https://github.com/ggml-org/llama.cpp/issues/2838#issuecomment-4097120776](https://github.com/ggml-org/llama.cpp/issues/2838#issuecomment-4097120776)

Together with an open discussion about the trade offs that this change implies in terms of performance.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Analysis and reproduction script are my own (see discussion). AI assistance (Claude) used for porting the original fix to the current code structure after rebase, extending coverage to the chunk-based cache reuse path.