### PR TITLE
build: install shared library DLLs on Windows (add RUNTIME to install rules)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,10 +247,10 @@ set_target_properties(llama
     PROPERTIES
         PUBLIC_HEADER "${LLAMA_PUBLIC_HEADERS}")
 
-install(TARGETS llama LIBRARY PUBLIC_HEADER)
+install(TARGETS llama LIBRARY RUNTIME PUBLIC_HEADER)
 
 if (LLAMA_BUILD_COMMON)
-    install(TARGETS llama-common LIBRARY)
+    install(TARGETS llama-common LIBRARY RUNTIME)
 endif()
 
 configure_package_config_file(


### PR DESCRIPTION
## Overview

Add `RUNTIME` to the `install(TARGETS)` rules for `llama` and `llama-common` so that DLLs are installed on Windows when building with `BUILD_SHARED_LIBS=ON`.

On DLL platforms (Windows), CMake's `LIBRARY` keyword covers `.so`/`.dylib` (non-DLL platforms) but does __not__ cover `.dll` files — those require the `RUNTIME` keyword. Without it, `cmake --install` skips the DLLs, causing `STATUS_DLL_NOT_FOUND` (`0xc0000135`) at runtime.

This became user-visible after `common` was changed from always-STATIC to following `BUILD_SHARED_LIBS` (renamed to `llama-common`), introducing a new `llama-common.dll` dependency that was never installed.

On non-DLL platforms, `RUNTIME` applies only to executables and has no effect on shared libraries, so this is safe across all platforms.

## Additional information

CMake docs reference: [install(TARGETS)](https://cmake.org/cmake/help/latest/command/install.html#targets) — *"For shared libraries on DLL platforms, the DLL part is treated as a RUNTIME target"*.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI (Opus 4.6) was used to diagnose the root cause and draft the fix and PR description. All changes were reviewed and approved by a human.
