### PR TITLE
mtmd: also support LLAMA_ROPE_TYPE_NONE

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -195,6 +195,7 @@ struct mtmd_context {
 
         auto decoder_rope_type = llama_model_rope_type(text_model);
         switch (decoder_rope_type) {
+            case LLAMA_ROPE_TYPE_NONE:
             case LLAMA_ROPE_TYPE_NORM:
             case LLAMA_ROPE_TYPE_NEOX:
                 {


### PR DESCRIPTION
## Overview

I initially thought that `LLAMA_ROPE_TYPE_NONE` is only used by embedding models (which we don't support in mtmd), but turns out recurrent models also use this type.

Thanks @danbev for spotting this bug.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
