### PR TITLE
Handle ModelOpt produced mixed precision model during convert to GGUF

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -743,12 +743,28 @@ class ModelBase:
         quant_method = (self.hparams.get("quantization_config") or {}).get("quant_method")
         quant_layers = (self.hparams.get("quantization_config") or {}).get("quantized_layers") or {}
         quant_config_file = self.dir_model / "hf_quant_config.json"
+        producer_name = None
 
         if (not quant_algo or not quant_layers) and quant_config_file.is_file():
             with open(quant_config_file, "r", encoding="utf-8") as f:
-                quant_config = json.load(f).get("quantization") or {}
+                hf_quant_config = json.load(f)
+                quant_config = hf_quant_config.get("quantization") or {}
+                producer = hf_quant_config.get("producer")
+                if isinstance(producer, dict):
+                    name = producer.get("name")
+                    if isinstance(name, str):
+                        producer_name = name.casefold()
                 quant_algo = quant_config.get("quant_algo", quant_algo)
                 quant_layers = quant_config.get("quantized_layers", quant_layers) or {}
+
+        # hf_quant_config.json (ModelOpt schema) carries quant_algo but not
+        # quant_method. If the producer is ModelOpt and .weight_scale tensors
+        # are present (e.g. lm_head FP8 in mixed NVFP4 models), route them
+        # through the existing "modelopt" branch of dequant_model.
+        if quant_method is None and producer_name == "modelopt" \
+                and any(k.endswith(".weight_scale") for k in self.model_tensors):
+            self.hparams.setdefault("quantization_config", {})["quant_method"] = "modelopt"
+            quant_method = "modelopt"
 
         # Some models use per-tensor quant_algo (e.g. "MIXED_PRECISION" with
         # per-layer NVFP4/FP8) instead of a single global "NVFP4" value.

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -755,15 +755,6 @@ class ModelBase:
                 quant_algo = quant_config.get("quant_algo", quant_algo)
                 quant_layers = quant_config.get("quantized_layers", quant_layers) or {}
 
-        # hf_quant_config.json (ModelOpt schema) carries quant_algo but not
-        # quant_method. If the producer is ModelOpt and .weight_scale tensors
-        # are present (e.g. lm_head FP8 in mixed NVFP4 models), route them
-        # through the existing "modelopt" branch of dequant_model.
-        if quant_method is None and producer_name == "modelopt" \
-                and any(k.endswith(".weight_scale") for k in self.model_tensors):
-            self.hparams.setdefault("quantization_config", {})["quant_method"] = "modelopt"
-            quant_method = "modelopt"
-
         # Some models use per-tensor quant_algo (e.g. "MIXED_PRECISION" with
         # per-layer NVFP4/FP8) instead of a single global "NVFP4" value.
         if quant_algo != "NVFP4":

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -743,17 +743,15 @@ class ModelBase:
         quant_method = (self.hparams.get("quantization_config") or {}).get("quant_method")
         quant_layers = (self.hparams.get("quantization_config") or {}).get("quantized_layers") or {}
         quant_config_file = self.dir_model / "hf_quant_config.json"
-        producer_name = None
 
         if (not quant_algo or not quant_layers) and quant_config_file.is_file():
             with open(quant_config_file, "r", encoding="utf-8") as f:
                 hf_quant_config = json.load(f)
                 quant_config = hf_quant_config.get("quantization") or {}
-                producer = hf_quant_config.get("producer")
-                if isinstance(producer, dict):
-                    name = producer.get("name")
-                    if isinstance(name, str):
-                        producer_name = name.casefold()
+                producer = hf_quant_config.get("producer") or {}
+                producer_name = (producer.get("name") or "").lower()
+                if quant_method is None:
+                    self.hparams.setdefault("quantization_config", {})["quant_method"] = producer_name
                 quant_algo = quant_config.get("quant_algo", quant_algo)
                 quant_layers = quant_config.get("quantized_layers", quant_layers) or {}
 


### PR DESCRIPTION
## Overview

Observed some issues while converting ModelOpt produced mixed precision NvFp4 models to GGUF. Looks like the dequantization path for unsupported dtype(Fp8) is dependent on quant_method, "quant_method" is not present in hf_quant_config.json for ModelOpt exported NvFP4 checkpoint.
The hf_quant_config.json does contain producer information which specifies ModelOpt as producer. The fix for handling mixed precision model is to populate the quant_method as "modelopt" based on the producer name, if quant_method is none and the producer is modelopt.
## Additional information

See this for reference: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/raw/main/hf_quant_config.json 
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: AI was used to review the change and cleanup

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
