### PR TITLE
cmake: use MATH_LIBRARY variable instead of hardcoded 'm' for ggml-base

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -473,7 +473,7 @@ target_link_libraries(ggml-base PRIVATE Threads::Threads)
 find_library(MATH_LIBRARY m)
 if (MATH_LIBRARY)
     if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
-        target_link_libraries(ggml-base PRIVATE m)
+        target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
     endif()
 endif()
 


### PR DESCRIPTION
## Summary

Fixes #22237.

`find_library(MATH_LIBRARY m)` correctly detects the system math library, but the result variable `MATH_LIBRARY` was never used — the `target_link_libraries` call hardcoded the literal `m` instead.

This prevents users from overriding the math library via `-DMATH_LIBRARY=/path/to/libalm.so` (e.g., when using AMD AOCL for optimal performance on Zen architectures).

## Changes

```cmake
# Before
target_link_libraries(ggml-base PRIVATE m)

# After
target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
```

This is a one-line fix that makes the code consistent: the variable detected by `find_library` is now the one actually linked.

## Testing

- Default behavior is unchanged: `find_library(MATH_LIBRARY m)` still finds `libm` and links it as before.
- Users can now override with `-DMATH_LIBRARY=/path/to/libalm.so` without patching source.