### PR TITLE
ggml-backend: expose multi-buffer accessors and make is_multi_buffer NULL-safe

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -67,6 +67,20 @@ extern "C" {
     GGML_API ggml_backend_buffer_type_t     ggml_backend_buffer_get_type      (ggml_backend_buffer_t buffer);
     GGML_API void                           ggml_backend_buffer_reset         (ggml_backend_buffer_t buffer);
 
+    // Multi-buffer wrapper accessors.  Let downstream code operate on each
+    // underlying allocation of a multi-buffer wrapper individually (e.g. to
+    // export a separate CUDA-IPC handle per sub-buffer or to atomically
+    // swap one out).  `is_multi_buffer` is the runtime type check for the
+    // other three accessors; passing a non-multi-buffer returns 0 / NULL /
+    // false as documented in the implementation.  These APIs are not safe
+    // to call concurrently with operations that mutate the buffer (tensor
+    // allocation, `free`, `replace_sub_buffer`); readers can race only
+    // with other readers.
+    GGML_API bool                           ggml_backend_buffer_is_multi_buffer         (ggml_backend_buffer_t buffer);
+    GGML_API size_t                         ggml_backend_multi_buffer_n_sub_buffers     (ggml_backend_buffer_t buffer);
+    GGML_API ggml_backend_buffer_t          ggml_backend_multi_buffer_sub_buffer        (ggml_backend_buffer_t buffer, size_t i);
+    GGML_API bool                           ggml_backend_multi_buffer_replace_sub_buffer(ggml_backend_buffer_t buffer, size_t i, ggml_backend_buffer_t replacement);
+
     // tensor copy between different backends
     GGML_API void ggml_backend_tensor_copy(const struct ggml_tensor * src, struct ggml_tensor * dst);
 

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -81,8 +81,11 @@ extern "C" {
     // multi-buffer
     // buffer that contains a collection of buffers
     GGML_API ggml_backend_buffer_t ggml_backend_multi_buffer_alloc_buffer(ggml_backend_buffer_t * buffers, size_t n_buffers);
-    GGML_API bool                  ggml_backend_buffer_is_multi_buffer(ggml_backend_buffer_t buffer);
     GGML_API void                  ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage);
+    // NOTE: ggml_backend_buffer_is_multi_buffer, ggml_backend_multi_buffer_n_sub_buffers,
+    //       ggml_backend_multi_buffer_sub_buffer, and
+    //       ggml_backend_multi_buffer_replace_sub_buffer are declared in the
+    //       public ggml-backend.h.
 
     //
     // Backend (meta)

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -721,8 +721,70 @@ ggml_backend_buffer_t ggml_backend_multi_buffer_alloc_buffer(ggml_backend_buffer
 }
 
 bool ggml_backend_buffer_is_multi_buffer(ggml_backend_buffer_t buffer) {
-    GGML_ASSERT(buffer);
+    // Public API: NULL is a valid input.  Report "not a multi-buffer"
+    // rather than aborting.  Aborting from a public predicate is a
+    // denial-of-service vector for callers that forgot a NULL check.
+    if (!buffer) {
+        return false;
+    }
     return buffer->iface.free_buffer == ggml_backend_multi_buffer_free_buffer;
+}
+
+// Public enumeration of a multi-buffer wrapper's sub-buffers.  Returns 0
+// if `buffer` is NULL or not a multi-buffer.
+size_t ggml_backend_multi_buffer_n_sub_buffers(ggml_backend_buffer_t buffer) {
+    if (!ggml_backend_buffer_is_multi_buffer(buffer)) {
+        return 0;
+    }
+    ggml_backend_multi_buffer_context * ctx = (ggml_backend_multi_buffer_context *) buffer->context;
+    return ctx->n_buffers;
+}
+
+// Returns the i-th sub-buffer of a multi-buffer wrapper, or NULL if
+// `buffer` is NULL / not a multi-buffer / `i` is out of range.  The
+// returned pointer is owned by the wrapper; callers must not
+// `ggml_backend_buffer_free` it directly.
+ggml_backend_buffer_t ggml_backend_multi_buffer_sub_buffer(ggml_backend_buffer_t buffer, size_t i) {
+    if (!ggml_backend_buffer_is_multi_buffer(buffer)) {
+        return NULL;
+    }
+    ggml_backend_multi_buffer_context * ctx = (ggml_backend_multi_buffer_context *) buffer->context;
+    if (i >= ctx->n_buffers) {
+        return NULL;
+    }
+    return ctx->buffers[i];
+}
+
+// Atomically swap sub-buffer `i` of a multi-buffer wrapper for a replacement
+// and free the old sub-buffer.  The replacement must have the same
+// `ggml_backend_buffer_type_t` as the existing sub-buffer so the wrapper's
+// allocator accounting stays consistent; zero-size buffers of the same
+// `buft` are valid placeholders.  Returns true on success; returns false
+// if `buffer` is NULL / not a multi-buffer, `i` is out of range, or the
+// replacement's `buft` differs from the existing sub-buffer's.  No-op
+// when the replacement already equals the current sub-buffer.
+bool ggml_backend_multi_buffer_replace_sub_buffer(ggml_backend_buffer_t buffer, size_t i, ggml_backend_buffer_t replacement) {
+    if (!ggml_backend_buffer_is_multi_buffer(buffer)) {
+        return false;
+    }
+    ggml_backend_multi_buffer_context * ctx = (ggml_backend_multi_buffer_context *) buffer->context;
+    if (i >= ctx->n_buffers) {
+        return false;
+    }
+    if (ctx->buffers[i] == replacement) {
+        return true;
+    }
+    // Require matching ggml_backend_buffer_type so the wrapper's allocator accounting stays consistent.
+    if (replacement && ctx->buffers[i] &&
+        ggml_backend_buffer_get_type(ctx->buffers[i]) != ggml_backend_buffer_get_type(replacement)) {
+        return false;
+    }
+    ggml_backend_buffer_t old = ctx->buffers[i];
+    ctx->buffers[i] = replacement;
+    if (old) {
+        ggml_backend_buffer_free(old);
+    }
+    return true;
 }
 
 void ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage) {


### PR DESCRIPTION
## Overview

This PR makes four ggml-backend APIs publicly callable.  Three are
new; the fourth (`ggml_backend_buffer_is_multi_buffer`) already
existed but was only declared in the internal header.  Together
they let downstream code look into a "multi-buffer" to see the
individual sub-buffers it wraps, and swap one of those sub-buffers
out at runtime.

The four calls are a runtime predicate that tells you whether a
buffer is a multi-buffer, a count of how many sub-buffers it holds,
an indexed getter for the i-th sub-buffer, and a swap function that
replaces one sub-buffer with a new one.

```c
GGML_API bool                           ggml_backend_buffer_is_multi_buffer         (ggml_backend_buffer_t buffer);
GGML_API size_t                         ggml_backend_multi_buffer_n_sub_buffers     (ggml_backend_buffer_t buffer);
GGML_API ggml_backend_buffer_t          ggml_backend_multi_buffer_sub_buffer        (ggml_backend_buffer_t buffer, size_t i);
GGML_API bool                           ggml_backend_multi_buffer_replace_sub_buffer(ggml_backend_buffer_t buffer, size_t i, ggml_backend_buffer_t replacement);
```

## Additional information

### Motivation

I was looking into running multi-agent LLM systems on local consumer
hardware and noticed that none of the common agent frameworks can
put more than a handful of agents on one GPU today.  Every agent
ends up as its own llama.cpp process, each with its own full weight
copy, and that hits the 16 GB consumer-card VRAM wall very fast.

A multi-buffer groups multiple underlying allocations (e.g., on the
GPU) into one logical buffer.  Until now, downstream code couldn't
address the individual pieces inside it.  That blocks three
concrete use cases:

**CUDA IPC export.**  To share GPU memory between processes, you
need the base pointer of each individual `cudaMalloc` allocation.
A multi-buffer's logical base is not one of those, and until now
the per-sub-buffer bases were only reachable through the internal
header.

**Cross-process weight sharing** (follow-up PR, hard-depends on
this one).  For multiple processes to share one copy of an LLM's
weight tensors, each sub-buffer has to be individually exportable
via IPC and then replaceable with a zero-size placeholder after the
tensors are rebound to the external mapping.

**Defragmentation.**  Any future work that wants to move a tensor's
underlying allocation without rebuilding the whole buffer wrapper
can use `replace_sub_buffer` to swap one allocation for another in
place.

Discussion #21223 ("Share readonly GPU model weights across
multiple llama-\* processes") is where the cross-process case came
up.  The maintainer noted there that the single-process path
already exists at the API level and that the gap is in
multi-process tooling.  This PR adds the enumeration and swap
primitives that the multi-process path needs on top of that
existing single-process base.

### Implementation notes

All four functions are NULL-safe.  Passing a `NULL` or
non-multi-buffer handle returns the documented "not a multi-buffer"
value (`false` / `0` / `NULL`) rather than aborting.  A predicate
that aborts on invalid input is a denial-of-service vector for any
caller that forgot a NULL check.

In detail:

- `ggml_backend_buffer_is_multi_buffer(buf)` returns `false` if
  `buf` is `NULL` or not a multi-buffer wrapper.
- `ggml_backend_multi_buffer_n_sub_buffers(buf)` returns `0` if
  `buf` is `NULL` or not a multi-buffer wrapper.
- `ggml_backend_multi_buffer_sub_buffer(buf, i)` returns `NULL` on
  `NULL` / non-multi-buffer `buf` or out-of-range `i`.  The returned
  pointer is owned by the wrapper; the caller must not
  `ggml_backend_buffer_free` it.
- `ggml_backend_multi_buffer_replace_sub_buffer(buf, i, replacement)`
  frees the old sub-buffer at index `i` (its destructor runs, e.g.
  `cudaFree` on CUDA) and installs `replacement` in its slot.  When
  both the old and new buffer are non-NULL it verifies buffer-type
  compatibility via `ggml_backend_buffer_get_type()` equality so
  the wrapper's allocator accounting stays consistent; a zero-size
  buffer of the same `buft` is a valid placeholder.  A NULL
  `replacement` is accepted and installs a NULL slot (the old
  sub-buffer is still freed); callers that use this idiom must
  repopulate the slot before any further tensor operation touches
  it.  The call returns `false` on a NULL or non-multi-buffer
  `buf`, out-of-range `i`, or type mismatch, and returns `true` on
  a successful swap or when `replacement` already equals the
  current sub-buffer.

Thread-safety is documented inline: these APIs are not safe to
call concurrently with operations that mutate the buffer (tensor
allocation, `buffer_free`, `replace_sub_buffer` by another thread);
concurrent readers are fine.

### Backwards compatibility

**Nothing breaks.**  Only new declarations were added, plus one
safety improvement: `ggml_backend_buffer_is_multi_buffer` previously
aborted via `GGML_ASSERT(buffer)` on `NULL` input; it now returns
`false` gracefully.  Callers that always passed valid buffers keep
working unchanged; callers that accidentally passed `NULL` stop
crashing.  That's the only behavioural change to an existing
symbol, and it strictly widens the set of inputs the function
handles safely.

### Tests

I haven't included automated test cases in this initial step.  I'd
like to get the go-ahead and any API-shape feedback from the
maintainers first.  Once the shape is agreed on, I'll follow up
with tests into `tests/test-backend-*.cpp` covering:

1. A non-multi-buffer via any backend: `is_multi_buffer` returns
   false, `n_sub_buffers` returns 0, `sub_buffer(buf, 0)` returns
   `NULL`.
2. A multi-buffer wrapping three CPU sub-buffers: `is_multi_buffer`
   returns true, `n_sub_buffers` returns 3, `sub_buffer(buf, i)`
   returns the three in order for `i` in {0, 1, 2} and `NULL` for
   `i = 3`.
3. `replace_sub_buffer(buf, 1, replacement)` with a same-type
   zero-size buffer succeeds; the original sub-buffer's destructor
   runs exactly once (verified with a counting allocator).  A
   mismatched-type replacement returns `false` and does not mutate
   the wrapper.
4. NULL-guard paths: `is_multi_buffer(NULL)` returns `false`,
   `n_sub_buffers(NULL)` returns `0`, `sub_buffer(NULL, 0)` returns
   `NULL`, `replace_sub_buffer(NULL, 0, x)` returns `false`.

### Files changed

```
 ggml/include/ggml-backend.h  | 14 +++++++++
 ggml/src/ggml-backend-impl.h |  5 +++-
 ggml/src/ggml-backend.cpp    | 64 +++++++++++++++++++++++++++++++++++++++++-
 3 files changed, 81 insertions(+), 2 deletions(-)
```

### Dependencies

Depends on: nothing.

Downstream impact: unblocks a follow-up PR for llama-model weight-
buffer enumeration + rebind + release, which uses all four of
these accessors for multi-buffer (tensor-split) weight layouts.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES.  Implementation of this patch was
  AI-assisted.  I reviewed every line manually and can defend the
  design decisions in review.  This PR body is my own writing based
  on my understanding of the change.
