### PR TITLE
server: fix heap-buffer-overflow from negative n_discard (CVE-2026-21869)

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -269,7 +269,7 @@ task_params server_task::params_from_json_cmpl(
     params.n_predict        = json_value(data,       "n_predict",          json_value(data, "max_completion_tokens", max_tokens));
     params.n_indent         = json_value(data,       "n_indent",           defaults.n_indent);
     params.n_keep           = json_value(data,       "n_keep",             defaults.n_keep);
-    params.n_discard        = json_value(data, "n_discard", defaults.n_discard);
+    params.n_discard        = json_value(data,       "n_discard", defaults.n_discard);
     params.n_discard        = std::max(0, params.n_discard);
     params.n_cmpl           = json_value(data,       "n_cmpl",             json_value(data, "n", 1));
     params.n_cache_reuse    = json_value(data,       "n_cache_reuse",      defaults.n_cache_reuse);

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -269,7 +269,7 @@ task_params server_task::params_from_json_cmpl(
     params.n_predict        = json_value(data,       "n_predict",          json_value(data, "max_completion_tokens", max_tokens));
     params.n_indent         = json_value(data,       "n_indent",           defaults.n_indent);
     params.n_keep           = json_value(data,       "n_keep",             defaults.n_keep);
-    params.n_discard        = json_value(data,       "n_discard",          defaults.n_discard);
+    params.n_discard        = std::max(0, json_value(data, "n_discard", defaults.n_discard));
     params.n_cmpl           = json_value(data,       "n_cmpl",             json_value(data, "n", 1));
     params.n_cache_reuse    = json_value(data,       "n_cache_reuse",      defaults.n_cache_reuse);
     //params.t_max_prompt_ms  = json_value(data,       "t_max_prompt_ms",    defaults.t_max_prompt_ms); // TODO: implement

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -269,7 +269,8 @@ task_params server_task::params_from_json_cmpl(
     params.n_predict        = json_value(data,       "n_predict",          json_value(data, "max_completion_tokens", max_tokens));
     params.n_indent         = json_value(data,       "n_indent",           defaults.n_indent);
     params.n_keep           = json_value(data,       "n_keep",             defaults.n_keep);
-    params.n_discard        = std::max(0, json_value(data, "n_discard", defaults.n_discard));
+    params.n_discard        = json_value(data, "n_discard", defaults.n_discard);
+    params.n_discard        = std::max(0, params.n_discard);
     params.n_cmpl           = json_value(data,       "n_cmpl",             json_value(data, "n", 1));
     params.n_cache_reuse    = json_value(data,       "n_cache_reuse",      defaults.n_cache_reuse);
     //params.t_max_prompt_ms  = json_value(data,       "t_max_prompt_ms",    defaults.t_max_prompt_ms); // TODO: implement

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -269,7 +269,7 @@ task_params server_task::params_from_json_cmpl(
     params.n_predict        = json_value(data,       "n_predict",          json_value(data, "max_completion_tokens", max_tokens));
     params.n_indent         = json_value(data,       "n_indent",           defaults.n_indent);
     params.n_keep           = json_value(data,       "n_keep",             defaults.n_keep);
-    params.n_discard        = json_value(data,       "n_discard", defaults.n_discard);
+    params.n_discard        = json_value(data,       "n_discard",          defaults.n_discard);
     params.n_discard        = std::max(0, params.n_discard);
     params.n_cmpl           = json_value(data,       "n_cmpl",             json_value(data, "n", 1));
     params.n_cache_reuse    = json_value(data,       "n_cache_reuse",      defaults.n_cache_reuse);


### PR DESCRIPTION
## Overview

Proposing a fix for [GHSA-8947-pfff-2f3c](https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-8947-pfff-2f3c) (CVE-2026-21869, CWE-787, CVSS 8.8 High).

**This vulnerability is still present on current master (`0d0764dfd257`, 2026-04-22)** — every `llama-server` deployment with context shift enabled is exploitable by any unauthenticated remote client. The fix is a single-line `std::max(0, ...)` clamp on `n_discard` at the JSON parse boundary.

### Proposed Fix
Check the commit.

Since `n_discard = 0` already triggers the auto-discard path (`n_left / 2` at the context shift site), clamping negative values to zero preserves all existing semantics with no behavior change for valid inputs.

## Additional Information

### Root Cause Analysis

The vulnerability is a missing non-negative check on a client-controlled integer parameter that is later used in array index arithmetic.

## Reproduction

ASan output on current master (`0d0764df`):

```
slot update_slots: id  0 | task 0 | slot context shift, n_keep = 65, n_left = 190, n_discard = -32
=================================================================
==34914==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x519000055983
WRITE of size 16 at 0x519000055983 thread T0
    #0 in server_context_impl::update_slots() llama-server+0x435ee0
    #1 in server_queue::start_loop(long)      llama-server+0x57696d
    #2 in main                                llama-server+0x2e8ca7

0x519000055983 is located 7 bytes after 1020-byte region [0x519000055580,0x51900005597c)
```

PoC payload:

```json
{
    "prompt": "The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.",
    "stream": false,
    "cache_prompt": true,
    "n_predict": 512,
    "n_keep": 64,
    "n_discard": -32,
    "temperature": 0.0
}
```

We provide the following Docker image with ASan-instrumented build and minimal GGUF for independent verification:

```bash
docker pull songtli/secb.eval.x86_64.llama-cpp.cve-2026-21869:patch
```

Post-fix: same PoC runs clean under both ASan and Valgrind, `n_discard` normalizes to auto-discard. No new cppcheck warnings.

## Requirements

- [x] I have read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI: **YES** — Claude helped me to perform some debuggings. The vulnerability analysis, root cause investigation, fix design, and validation were performed by humans. The one-line fix (`std::max(0, ...)`) was human-conceived. Every line can be independently explained and defended.

> [!NOTE]
> If this PR has been created by an AI agent on behalf of a contributor, the contributor is
> still responsible for the PR and must review and understand the changes being proposed.
> The contributor must also be able to explain and defend the changes when questioned.
>
> llama.cpp restricts AI-generated contributions. See [AGENTS.md](AGENTS.md) and
> [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

---

*Columbia University Security Research Team*