### PR TITLE
ggml-cpu : disable tiled matmul on AIX to fix page boundary segfault

### DIFF
--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -3195,7 +3195,7 @@ class tinyBLAS_PPC {
     }
 
     void matmul(int64_t m, int64_t n) {
-        # if defined(_AIX) || defined(__BIG_ENDIAN__)
+        #if defined(_AIX) || defined(__BIG_ENDIAN__)
             mnpack(0, m, 0, n);
         #else
             int64_t mc = 256; int64_t nc = 256; int64_t kc = 256;

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -2321,41 +2321,40 @@ class tinyBLAS_Q0_PPC {
     }
 
     void matmul(int64_t m, int64_t n) {
-        #if defined(_AIX) || defined(__BIG_ENDIAN__)
+    #if defined(_AIX) || defined(__BIG_ENDIAN__)
+        mnpack(0, m, 0, n);
+    #else
+        const int64_t mc = 64;
+        const int64_t kc = 64;
+        int64_t nc = 64;
+        int64_t n_aligned = 0;
+        if (n % 64 == 0) {
+            n_aligned = n;
+        } else if (n == 4) {
+            n_aligned = 4;
+        } else if (n < 64) {
+            n_aligned = (n / 8) * 8;
+        } else {
+            n_aligned = (n / 64) * 64;
+        }
+        if (n_aligned > 0) {
+            if (n_aligned % 64 == 0)      nc = 64;
+            else if (n_aligned == n)      nc = n;
+            else if (n_aligned % 32 == 0) nc = 32;
+            else if (n_aligned % 24 == 0) nc = 24;
+            else if (n_aligned % 16 == 0) nc = 16;
+            else                          nc = 8;
+        }
+        bool can_use_tiled = n_aligned > 0 && (m % mc == 0) && (k % kc == 0);
+        if (can_use_tiled) {
+            matmul_tiled(m, n_aligned, mc, nc, kc);
+            if (n > n_aligned) {
+                mnpack(0, m, n_aligned, n);
+            }
+        } else {
             mnpack(0, m, 0, n);
-        #else
-            const int64_t mc = 64;
-            const int64_t kc = 64;
-            int64_t nc = 64;
-            int64_t n_aligned = 0;
-            if (n % 64 == 0) {
-                n_aligned = n;
-            } else if (n == 4) {
-                n_aligned = 4;
-            } else if (n < 64) {
-                n_aligned = (n / 8) * 8;
-            } else {
-                n_aligned = (n / 64) * 64;
-            }
-
-            if (n_aligned > 0) {
-                if (n_aligned % 64 == 0)      nc = 64;
-                else if (n_aligned == n)      nc = n;
-                else if (n_aligned % 32 == 0) nc = 32;
-                else if (n_aligned % 24 == 0) nc = 24;
-                else if (n_aligned % 16 == 0) nc = 16;
-                else                          nc = 8;
-            }
-            bool can_use_tiled = n_aligned > 0 && (m % mc == 0) && (k % kc == 0);
-            if (can_use_tiled) {
-                matmul_tiled(m, n_aligned, mc, nc, kc);
-                if (n > n_aligned) {
-                    mnpack(0, m, n_aligned, n);
-                }
-            } else {
-                mnpack(0, m, 0, n);
-            }
-        #endif
+        }
+    #endif
     }
 
   private:

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -2321,37 +2321,41 @@ class tinyBLAS_Q0_PPC {
     }
 
     void matmul(int64_t m, int64_t n) {
-        const int64_t mc = 64;
-        const int64_t kc = 64;
-        int64_t nc = 64;
-        int64_t n_aligned = 0;
-        if (n % 64 == 0) {
-            n_aligned = n;
-        } else if (n == 4) {
-            n_aligned = 4;
-        } else if (n < 64) {
-            n_aligned = (n / 8) * 8;
-        } else {
-            n_aligned = (n / 64) * 64;
-        }
-
-        if (n_aligned > 0) {
-            if (n_aligned % 64 == 0)      nc = 64;
-            else if (n_aligned == n)      nc = n;
-            else if (n_aligned % 32 == 0) nc = 32;
-            else if (n_aligned % 24 == 0) nc = 24;
-            else if (n_aligned % 16 == 0) nc = 16;
-            else                          nc = 8;
-        }
-        bool can_use_tiled = n_aligned > 0 && (m % mc == 0) && (k % kc == 0);
-        if (can_use_tiled) {
-            matmul_tiled(m, n_aligned, mc, nc, kc);
-            if (n > n_aligned) {
-                mnpack(0, m, n_aligned, n);
-            }
-        } else {
+        #if defined(_AIX) || defined(__BIG_ENDIAN__)
             mnpack(0, m, 0, n);
-        }
+        #else
+            const int64_t mc = 64;
+            const int64_t kc = 64;
+            int64_t nc = 64;
+            int64_t n_aligned = 0;
+            if (n % 64 == 0) {
+                n_aligned = n;
+            } else if (n == 4) {
+                n_aligned = 4;
+            } else if (n < 64) {
+                n_aligned = (n / 8) * 8;
+            } else {
+                n_aligned = (n / 64) * 64;
+            }
+
+            if (n_aligned > 0) {
+                if (n_aligned % 64 == 0)      nc = 64;
+                else if (n_aligned == n)      nc = n;
+                else if (n_aligned % 32 == 0) nc = 32;
+                else if (n_aligned % 24 == 0) nc = 24;
+                else if (n_aligned % 16 == 0) nc = 16;
+                else                          nc = 8;
+            }
+            bool can_use_tiled = n_aligned > 0 && (m % mc == 0) && (k % kc == 0);
+            if (can_use_tiled) {
+                matmul_tiled(m, n_aligned, mc, nc, kc);
+                if (n > n_aligned) {
+                    mnpack(0, m, n_aligned, n);
+                }
+            } else {
+                mnpack(0, m, 0, n);
+            }
+        #endif
     }
 
   private:
@@ -3191,12 +3195,16 @@ class tinyBLAS_PPC {
     }
 
     void matmul(int64_t m, int64_t n) {
-        int64_t mc = 256; int64_t nc = 256; int64_t kc = 256;
-        if (m % mc == 0 && n % nc == 0 && k % kc == 0) {
-            matmul_tiled(m, n, mc, nc, kc);
-        } else {
+        # if defined(_AIX) || defined(__BIG_ENDIAN__)
             mnpack(0, m, 0, n);
-        }
+        #else
+            int64_t mc = 256; int64_t nc = 256; int64_t kc = 256;
+            if (m % mc == 0 && n % nc == 0 && k % kc == 0) {
+                matmul_tiled(m, n, mc, nc, kc);
+            } else {
+                mnpack(0, m, 0, n);
+            }
+        #endif
     }
 
   private:

--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -3194,16 +3194,16 @@ class tinyBLAS_PPC {
     }
 
     void matmul(int64_t m, int64_t n) {
-        #if defined(_AIX) || defined(__BIG_ENDIAN__)
+    #if defined(_AIX) || defined(__BIG_ENDIAN__)
+        mnpack(0, m, 0, n);
+    #else
+        int64_t mc = 256; int64_t nc = 256; int64_t kc = 256;
+        if (m % mc == 0 && n % nc == 0 && k % kc == 0) {
+            matmul_tiled(m, n, mc, nc, kc);
+        } else {
             mnpack(0, m, 0, n);
-        #else
-            int64_t mc = 256; int64_t nc = 256; int64_t kc = 256;
-            if (m % mc == 0 && n % nc == 0 && k % kc == 0) {
-                matmul_tiled(m, n, mc, nc, kc);
-            } else {
-                mnpack(0, m, 0, n);
-            }
-        #endif
+        }
+    #endif
     }
 
   private:


### PR DESCRIPTION
vec_xst operations in the tiled path crash on AIX when writing near 4KB page boundaries due to strict memory protection. Fall back to mnpack implementation on AIX for stable execution.

## Overview
This patch fixes segmentation faults in q4_0 model inference on AIX PowerPC systems by disabling the tiled matrix multiplication path in llamafile's sgemm implementation.
`vec_xst` operations crash on AIX when writing near 4KB page boundaries due to strict memory protection. The `vec_xst` instruction cannot write across page boundaries on AIX, and when the buffer offset lands at addresses like `0x1100ed000` (exactly at a page boundary), the write operation attempts to access unmapped memory, triggering a segfault.

This issue does not occur on Linux because Linux has more lenient memory management and may have adjacent pages already mapped. On AIX, page boundaries are strictly enforced.
<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
