### PR TITLE
jinja : fix clang compile warnings

### DIFF
--- a/common/jinja/caps.cpp
+++ b/common/jinja/caps.cpp
@@ -1,4 +1,3 @@
-#include "log.h"
 #include "value.h"
 #include "runtime.h"
 #include "caps.h"

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -69,7 +69,7 @@ struct context {
 
     context(const context & parent) : context() {
         // inherit variables (for example, when entering a new scope)
-        auto & pvar = parent.env->as_ordered_object();
+        const auto & pvar = parent.env->as_ordered_object();
         for (const auto & pair : pvar) {
             set_val(pair.first, pair.second);
         }
@@ -107,7 +107,12 @@ struct statement {
     virtual ~statement() = default;
     virtual std::string type() const { return "Statement"; }
     // execute_impl must be overridden by derived classes
-    virtual value execute_impl(context &) { throw std::runtime_error("cannot exec " + type()); }
+    virtual value execute_impl(context & /* ctx */) {
+        if ((false)) {
+            return {};
+        }
+        throw std::runtime_error("cannot exec " + type());
+    }
     // execute is the public method to execute a statement with error handling
     value execute(context &);
 };
@@ -143,7 +148,7 @@ struct program : public statement {
     program() = default;
     explicit program(statements && body) : body(std::move(body)) {}
     std::string type() const override { return "Program"; }
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context & /* ctx */) override {
         throw std::runtime_error("Cannot execute program directly, use jinja::runtime instead");
     }
 };
@@ -195,7 +200,7 @@ struct break_statement : public statement {
         }
     };
 
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context & /* ctx */) override {
         throw break_statement::signal();
     }
 };
@@ -209,7 +214,7 @@ struct continue_statement : public statement {
         }
     };
 
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context & /* ctx */) override {
         throw continue_statement::signal();
     }
 };
@@ -217,7 +222,7 @@ struct continue_statement : public statement {
 // do nothing
 struct noop_statement : public statement {
     std::string type() const override { return "Noop"; }
-    value execute_impl(context &) override {
+    value execute_impl(context & /* ctx */) override {
         return mk_val<value_undefined>();
     }
 };
@@ -245,7 +250,9 @@ struct macro_statement : public statement {
     macro_statement(statement_ptr && name, statements && args, statements && body)
         : name(std::move(name)), args(std::move(args)), body(std::move(body)) {
         chk_type<identifier>(this->name);
-        for (const auto& arg : this->args) chk_type<expression>(arg);
+        for (const auto & arg : this->args) {
+            chk_type<expression>(arg);
+        }
     }
 
     std::string type() const override { return "Macro"; }
@@ -256,7 +263,7 @@ struct comment_statement : public statement {
     std::string val;
     explicit comment_statement(const std::string & v) : val(v) {}
     std::string type() const override { return "Comment"; }
-    value execute_impl(context &) override {
+    value execute_impl(context & /* ctx */) override {
         return mk_val<value_undefined>();
     }
 };
@@ -266,7 +273,7 @@ struct comment_statement : public statement {
 // Represents an omitted expression in a computed member, e.g. `a[]`.
 struct blank_expression : public expression {
     std::string type() const override { return "BlankExpression"; }
-    value execute_impl(context &) override {
+    value execute_impl(context & /* ctx */) override {
         return mk_val<value_undefined>();
     }
 };
@@ -292,7 +299,9 @@ struct call_expression : public expression {
     call_expression(statement_ptr && callee, statements && args)
         : callee(std::move(callee)), args(std::move(args)) {
         chk_type<expression>(this->callee);
-        for (const auto& arg : this->args) chk_type<expression>(arg);
+        for (const auto & arg : this->args) {
+            chk_type<expression>(arg);
+        }
     }
     std::string type() const override { return "CallExpression"; }
     value execute_impl(context & ctx) override;
@@ -314,7 +323,7 @@ struct integer_literal : public expression {
     int64_t val;
     explicit integer_literal(int64_t val) : val(val) {}
     std::string type() const override { return "IntegerLiteral"; }
-    value execute_impl(context &) override {
+    value execute_impl(context & /* ctx */) override {
         return mk_val<value_int>(val);
     }
 };
@@ -323,7 +332,7 @@ struct float_literal : public expression {
     double val;
     explicit float_literal(double val) : val(val) {}
     std::string type() const override { return "FloatLiteral"; }
-    value execute_impl(context &) override {
+    value execute_impl(context & /* ctx */) override {
         return mk_val<value_float>(val);
     }
 };
@@ -332,7 +341,7 @@ struct string_literal : public expression {
     std::string val;
     explicit string_literal(const std::string & val) : val(val) {}
     std::string type() const override { return "StringLiteral"; }
-    value execute_impl(context &) override {
+    value execute_impl(context & /* ctx */) override {
         return mk_val<value_string>(val);
     }
 };
@@ -340,7 +349,9 @@ struct string_literal : public expression {
 struct array_literal : public expression {
     statements val;
     explicit array_literal(statements && val) : val(std::move(val)) {
-        for (const auto& item : this->val) chk_type<expression>(item);
+        for (const auto & item : this->val) {
+            chk_type<expression>(item);
+        }
     }
     std::string type() const override { return "ArrayLiteral"; }
     value execute_impl(context & ctx) override {
@@ -355,7 +366,9 @@ struct array_literal : public expression {
 struct tuple_literal : public expression {
     statements val;
     explicit tuple_literal(statements && val) : val(std::move(val)) {
-        for (const auto& item : this->val) chk_type<expression>(item);
+        for (const auto & item : this->val) {
+            chk_type<expression>(item);
+        }
     }
     std::string type() const override { return "TupleLiteral"; }
     value execute_impl(context & ctx) override {
@@ -363,7 +376,7 @@ struct tuple_literal : public expression {
         for (const auto & item_stmt : val) {
             arr->push_back(item_stmt->execute(ctx));
         }
-        return mk_val<value_tuple>(std::move(arr->as_array()));
+        return mk_val<value_tuple>(arr->as_array());
     }
 };
 
@@ -509,7 +522,7 @@ struct slice_expression : public expression {
         chk_type<expression>(this->step_expr);
     }
     std::string type() const override { return "SliceExpression"; }
-    value execute_impl(context &) override {
+    [[noreturn]] value execute_impl(context & /* ctx */) override {
         throw std::runtime_error("must be handled by MemberExpression");
     }
 };
@@ -543,7 +556,9 @@ struct call_statement : public statement {
     call_statement(statement_ptr && call, statements && caller_args, statements && body)
         : call(std::move(call)), caller_args(std::move(caller_args)), body(std::move(body)) {
         chk_type<call_expression>(this->call);
-        for (const auto & arg : this->caller_args) chk_type<expression>(arg);
+        for (const auto & arg : this->caller_args) {
+            chk_type<expression>(arg);
+        }
     }
     std::string type() const override { return "CallStatement"; }
 };

--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -852,6 +852,7 @@ const func_builtins & value_string_t::get_builtins() const {
             return res;
         }},
         {"join", [](const func_args &) -> value {
+            if ((false)) return {};
             throw not_implemented_exception("String join builtin not implemented");
         }},
     };
@@ -1085,6 +1086,7 @@ const func_builtins & value_array_t::get_builtins() const {
             return is_val<value_tuple>(val) ? mk_val<value_tuple>(std::move(arr)) : mk_val<value_array>(std::move(arr));
         }},
         {"unique", [](const func_args &) -> value {
+            if ((false)) return {};
             throw not_implemented_exception("Array unique builtin not implemented");
         }},
     };
@@ -1184,6 +1186,7 @@ const func_builtins & value_object_t::get_builtins() const {
             return result;
         }},
         {"join", [](const func_args &) -> value {
+            if ((false)) return {};
             throw not_implemented_exception("object join not implemented");
         }},
     };

--- a/common/jinja/value.h
+++ b/common/jinja/value.h
@@ -129,27 +129,28 @@ struct value_t {
     // Note: only for debugging and error reporting purposes
     virtual std::string type() const { return ""; }
 
-    virtual int64_t as_int() const { throw std::runtime_error(type() + " is not an int value"); }
-    virtual double as_float() const { throw std::runtime_error(type() + " is not a float value"); }
-    virtual string as_string() const { throw std::runtime_error(type() + " is not a string value"); }
-    virtual bool as_bool() const { throw std::runtime_error(type() + " is not a bool value"); }
-    virtual const std::vector<value> & as_array() const { throw std::runtime_error(type() + " is not an array value"); }
-    virtual const std::vector<std::pair<value, value>> & as_ordered_object() const { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value invoke(const func_args &) const { throw std::runtime_error(type() + " is not a function value"); }
+    virtual int64_t as_int() const { if ((false)) return {}; throw std::runtime_error(type() + " is not an int value"); }
+    virtual double as_float() const { if ((false)) return {}; throw std::runtime_error(type() + " is not a float value"); }
+    virtual string as_string() const { if ((false)) return {}; throw std::runtime_error(type() + " is not a string value"); }
+    virtual bool as_bool() const { if ((false)) return {}; throw std::runtime_error(type() + " is not a bool value"); }
+    virtual const std::vector<value> & as_array() const { if ((false)) { static std::vector<value> dummy; return dummy; } throw std::runtime_error(type() + " is not an array value"); }
+    virtual const std::vector<std::pair<value, value>> & as_ordered_object() const { if ((false)) { static std::vector<std::pair<value, value>> dummy; return dummy; } throw std::runtime_error(type() + " is not an object value"); }
+    virtual value invoke(const func_args & /* args */) const { if ((false)) return {}; throw std::runtime_error(type() + " is not a function value"); }
     virtual bool is_none() const { return false; }
     virtual bool is_undefined() const { return false; }
     virtual const func_builtins & get_builtins() const {
+        if ((false)) { static const func_builtins dummy; return dummy; }
         throw std::runtime_error("No builtins available for type " + type());
     }
 
-    virtual bool has_key(const value &) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual void insert(const value & /* key */, const value & /* val */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const value & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const value & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const std::string & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(const std::string & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
-    virtual value & at(int64_t /* idx */, value & /* default_val */) { throw std::runtime_error(type() + " is not an array value"); }
-    virtual value & at(int64_t /* idx */) { throw std::runtime_error(type() + " is not an array value"); }
+    virtual bool has_key(const value & /* key */) { if ((false)) return {}; throw std::runtime_error(type() + " is not an object value"); }
+    virtual void insert(const value & /* key */, const value & /* val */) { if ((false)) {} throw std::runtime_error(type() + " is not an object value"); }
+    virtual value & at(const value & /* key */, value & /* default_val */) { if ((false)) { static value dummy; return dummy; } throw std::runtime_error(type() + " is not an object value"); }
+    virtual value & at(const value & /* key */) { if ((false)) { static value dummy; return dummy; } throw std::runtime_error(type() + " is not an object value"); }
+    virtual value & at(const std::string & /* key */, value & /* default_val */) { if ((false)) { static value dummy; return dummy; } throw std::runtime_error(type() + " is not an object value"); }
+    virtual value & at(const std::string & /* key */) { if ((false)) { static value dummy; return dummy; } throw std::runtime_error(type() + " is not an object value"); }
+    virtual value & at(int64_t /* idx */, value & /* default_val */) { if ((false)) { static value dummy; return dummy; } throw std::runtime_error(type() + " is not an array value"); }
+    virtual value & at(int64_t /* idx */) { if ((false)) { static value dummy; return dummy; } throw std::runtime_error(type() + " is not an array value"); }
 
     virtual bool is_numeric() const { return false; }
     virtual bool is_hashable() const { return false; }


### PR DESCRIPTION
## Overview

With clang 21.0.0 the jinja code generates the following warnings:

```
In file included from /llama.cpp/common/chat-peg-parser.cpp:1:
In file included from /llama.cpp/common/chat-peg-parser.h:3:
In file included from /llama.cpp/common/chat.h:7:
In file included from /llama.cpp/common/jinja/parser.h:4:
In file included from /llama.cpp/common/jinja/runtime.h:4:
/llama.cpp/common/jinja/value.h:132:21: warning: function 'as_int' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  132 |     virtual int64_t as_int() const { throw std::runtime_error(type() + " is not an int value"); }
      |                     ^
/llama.cpp/common/jinja/value.h:133:20: warning: function 'as_float' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  133 |     virtual double as_float() const { throw std::runtime_error(type() + " is not a float value"); }
      |                    ^
/llama.cpp/common/jinja/value.h:134:20: warning: function 'as_string' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  134 |     virtual string as_string() const { throw std::runtime_error(type() + " is not a string value"); }
      |                    ^
/llama.cpp/common/jinja/value.h:135:18: warning: function 'as_bool' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  135 |     virtual bool as_bool() const { throw std::runtime_error(type() + " is not a bool value"); }
      |                  ^
/llama.cpp/common/jinja/value.h:136:40: warning: function 'as_array' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  136 |     virtual const std::vector<value> & as_array() const { throw std::runtime_error(type() + " is not an array value"); }
      |                                        ^
/llama.cpp/common/jinja/value.h:137:58: warning: function 'as_ordered_object' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  137 |     virtual const std::vector<std::pair<value, value>> & as_ordered_object() const { throw std::runtime_error(type() + " is not an object value"); }
      |                                                          ^
/llama.cpp/common/jinja/value.h:138:19: warning: function 'invoke' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  138 |     virtual value invoke(const func_args &) const { throw std::runtime_error(type() + " is not a function value"); }
      |                   ^
/llama.cpp/common/jinja/value.h:141:35: warning: function 'get_builtins' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  141 |     virtual const func_builtins & get_builtins() const {
      |                                   ^
/llama.cpp/common/jinja/value.h:145:18: warning: function 'has_key' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  145 |     virtual bool has_key(const value &) { throw std::runtime_error(type() + " is not an object value"); }
      |                  ^
/llama.cpp/common/jinja/value.h:146:18: warning: function 'insert' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  146 |     virtual void insert(const value & /* key */, const value & /* val */) { throw std::runtime_error(type() + " is not an object value"); }
      |                  ^
/llama.cpp/common/jinja/value.h:147:21: warning: function 'at' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  147 |     virtual value & at(const value & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
      |                     ^
/llama.cpp/common/jinja/value.h:148:21: warning: function 'at' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  148 |     virtual value & at(const value & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
      |                     ^
/llama.cpp/common/jinja/value.h:149:21: warning: function 'at' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  149 |     virtual value & at(const std::string & /* key */, value & /* default_val */) { throw std::runtime_error(type() + " is not an object value"); }
      |                     ^
/llama.cpp/common/jinja/value.h:150:21: warning: function 'at' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  150 |     virtual value & at(const std::string & /* key */) { throw std::runtime_error(type() + " is not an object value"); }
      |                     ^
/llama.cpp/common/jinja/value.h:151:21: warning: function 'at' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  151 |     virtual value & at(int64_t /* idx */, value & /* default_val */) { throw std::runtime_error(type() + " is not an array value"); }
      |                     ^
/llama.cpp/common/jinja/value.h:152:21: warning: function 'at' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
  152 |     virtual value & at(int64_t /* idx */) { throw std::runtime_error(type() + " is not an array value"); }
      |                     ^
In file included from /llama.cpp/common/chat-peg-parser.cpp:1:
In file included from /llama.cpp/common/chat-peg-parser.h:3:
In file included from /llama.cpp/common/chat.h:7:
In file included from /llama.cpp/common/jinja/parser.h:4:
```

These are quite difficult to fix. It seems like the case of default implementation of a `virtual` method throwing a "not implemented" exception was not considered compatible with `-Wmissing-noreturn`.

The only semi-reasonable workaround that I found is this https://dev.to/martinlicht/-disables-code-when-clang-warns-about-unreachable-code-47ml. It's ugly, but it does the job.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
