### PR TITLE
hexagon: use DIRID 13 in libggml-htp.inf for modern InfVerif

### DIFF
--- a/ggml/src/ggml-hexagon/libggml-htp.inf
+++ b/ggml/src/ggml-hexagon/libggml-htp.inf
@@ -8,7 +8,7 @@ CatalogFile = libggml-htp.cat
 PnpLockDown = 1
 
 [DestinationDirs]
-Drivers_Dir = 6
+Drivers_Dir = 13
 
 [SourceDisksNames]
 1 = %DiskId%


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
`libggml-htp.inf` is used by the WoS build to produce and sign `libggml-htp.cat` for the HTP skel `.so` files (see `ggml/src/ggml-hexagon/CMakeLists.txt`). When the signed package was submitted to the Microsoft signing team, `InfVerif` rejected it because:

- `DIRID 6` historically referred to a legacy/root directory and is no longer a valid `DestinationDirs` value under the current InfVerif rules (Windows 11 build >= 10.0.27871).
- The recommended destination for file-copy-only / extension driver packages is `DIRID 13`, i.e. `%DriverStore%\FileRepository\<inf>_<hash>\`.

This is also consistent with how Qualcomm's own `qcadsprpc` driver is deployed on WoS — `htp-drv.cpp` already resolves `libcdsprpc.dll` out of `\SystemRoot\System32\DriverStore\FileRepository\qcadsprpc...`.

## Verification

- [x] With DIRID 13, `InfVerif` accepts the package and the MS signing pipeline succeeds (DIRID 6 was previously rejected).
- [x] The WoS build still produces and signs `libggml-htp.cat` without issue.
- [x] Already used the signed package (installed via the updated inf) to run inference on WoS end-to-end — FastRPC successfully resolves `libggml-htp-vXX.so` from the DriverStore location at runtime, so the move does not break the skel lookup path.

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
NO
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
