### PR TITLE
ggml-cpu: cmake: append xsmtvdotii march for SpacemiT IME

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -486,21 +486,11 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
                 string(APPEND MARCH_STR "_zihintpause")
             endif()
             if (GGML_CPU_RISCV64_SPACEMIT)
-                # vmadot family lives behind the SpacemiT xsmtvdotii custom
-                # extension. Without this flag GAS rejects the inline asm in
-                # ime1_kernels.cpp with "extension `xsmtvdotii' required".
-                # GCC support for the extension was added in version 15;
-                # earlier toolchains do not understand the march suffix,
-                # so fail fast with a clear message instead of cryptic
-                # assembler errors later.
+                # `xsmtvdotii' is only required for GCC >= 15.
                 if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
-                    CMAKE_C_COMPILER_VERSION VERSION_LESS 15)
-                    message(FATAL_ERROR
-                        "GGML_CPU_RISCV64_SPACEMIT requires GCC >= 15 for "
-                        "the xsmtvdotii extension; current GCC "
-                        "${CMAKE_C_COMPILER_VERSION} does not support it.")
+                    CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+                    string(APPEND MARCH_STR "_xsmtvdotii")
                 endif()
-                string(APPEND MARCH_STR "_xsmtvdotii")
             endif()
 
             list(APPEND ARCH_FLAGS "-march=${MARCH_STR}" -mabi=lp64d)

--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -485,6 +485,23 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
             if (GGML_RV_ZIHINTPAUSE)
                 string(APPEND MARCH_STR "_zihintpause")
             endif()
+            if (GGML_CPU_RISCV64_SPACEMIT)
+                # vmadot family lives behind the SpacemiT xsmtvdotii custom
+                # extension. Without this flag GAS rejects the inline asm in
+                # ime1_kernels.cpp with "extension `xsmtvdotii' required".
+                # GCC support for the extension was added in version 15;
+                # earlier toolchains do not understand the march suffix,
+                # so fail fast with a clear message instead of cryptic
+                # assembler errors later.
+                if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
+                    CMAKE_C_COMPILER_VERSION VERSION_LESS 15)
+                    message(FATAL_ERROR
+                        "GGML_CPU_RISCV64_SPACEMIT requires GCC >= 15 for "
+                        "the xsmtvdotii extension; current GCC "
+                        "${CMAKE_C_COMPILER_VERSION} does not support it.")
+                endif()
+                string(APPEND MARCH_STR "_xsmtvdotii")
+            endif()
 
             list(APPEND ARCH_FLAGS "-march=${MARCH_STR}" -mabi=lp64d)
         else()


### PR DESCRIPTION
When GGML_CPU_RISCV64_SPACEMIT=ON is set, ime1_kernels.cpp contains inline asm for the vmadot family which requires the xsmtvdotii custom extension.(problem can see in some blogs and make sure in K3 platform) The current CMakeLists does not include xsmtvdotii, so any toolchain that honours the explicit -march (tested with SpacemiT GCC 15.2) fails at the assembler stage:

  Error: unrecognized opcode `vmadot v16,v14,v0',
         extension `xsmtvdotii' required

Append _xsmtvdotii to MARCH_STR when GGML_CPU_RISCV64_SPACEMIT is enabled so the IME path can actually build with a capable toolchain. No effect on builds that leave GGML_CPU_RISCV64_SPACEMIT off.

toolchain from https://www.spacemit.com/community/resources-download/Tools
