### PR TITLE
Update server README.md to clarify cache directory choice behavior

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1468,11 +1468,21 @@ llama-server
 ### Model sources
 
 There are 3 possible sources for model files:
-1. Cached models (controlled by the `LLAMA_CACHE` environment variable)
+1. Cached models (controlled by environment variables)
 2. Custom model directory (set via the `--models-dir` argument)
 3. Custom preset (set via the `--models-preset` argument)
 
-By default, the router looks for models in the cache. You can add Hugging Face models to the cache with:
+By default, the router looks for models in the cache. The router checks the following environment variables for a cache directory and picks the first extant and non-empty one:
+
+- `LLAMA_CACHE`
+- `HF_HUB_CACHE`
+- `HUGGINGFACE_HUB_CACHE`
+- `HF_HOME`
+- `XDG_CACHE_HOME`
+
+If none of the above exist or all are empty, the router picks `~/.cache/huggingface/hub` if it exists. 
+
+You can add Hugging Face models to the cache with:
 
 ```sh
 llama-server -hf <user>/<model>:<tag>


### PR DESCRIPTION
## Overview

Update /tools/server/README.md to list where the server will check for a cache directory and in which order it'll choose one.

## Additional information

[The readme for the completion tool](https://github.com/ggml-org/llama.cpp/edit/master/tools/completion/README.md) may also need to be updated; I've confirmed the server tool checks HF envars for a model cache, but have not confirmed the completion tool does the same. 

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): YES
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
