### PR TITLE
llama-bench: fix numerical instability in stdev() calculation

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -107,10 +107,19 @@ template <typename T> static T stdev(const std::vector<T> & v) {
     if (v.size() <= 1) {
         return 0;
     }
-    T mean   = avg(v);
-    T sq_sum = std::inner_product(v.begin(), v.end(), v.begin(), T(0));
-    T stdev  = std::sqrt(sq_sum / (T) (v.size() - 1) - mean * mean * (T) v.size() / (T) (v.size() - 1));
-    return stdev;
+    // Two-pass algorithm: compute deviations from the mean directly.
+    // The one-pass formula (sq_sum/(n-1) - mean^2*n/(n-1)) suffers from
+    // catastrophic cancellation when values are large and nearly equal
+    // (e.g. nanosecond timestamps), causing sqrt() to receive a small
+    // negative number and return NaN or a wildly inaccurate result.
+    // See: https://github.com/ggml-org/llama.cpp/issues/22300
+    double mean   = (double) avg(v);
+    double sq_dev = 0.0;
+    for (const auto & x : v) {
+        double d  = (double) x - mean;
+        sq_dev   += d * d;
+    }
+    return (T) std::sqrt(sq_dev / (double) (v.size() - 1));
 }
 
 static std::string get_cpu_info() {


### PR DESCRIPTION
The previous one-pass formula computed:
  sqrt(sq_sum/(n-1) - mean^2 * n/(n-1))

When benchmarking on fast hardware, all sample values are large (e.g. 12e9 ns) and nearly identical. The subtraction of two nearly-equal large values causes catastrophic cancellation in floating-point, leaving a small negative number under the square root. This causes sqrt() to return NaN, or produce a result that is orders of magnitude wrong (reported: 25x too large in issue #22300).

Replace with a two-pass algorithm that computes deviations from the mean directly. This is numerically stable because the intermediate values (x - mean) are small relative to x, preserving precision.

Fixes: https://github.com/ggml-org/llama.cpp/issues/22300

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
