### PR TITLE
ggml-webgpu: silence subgroup_uniformity diagnostic in mul_mat_vec

### DIFF
--- a/ggml/src/ggml-webgpu/wgsl-shaders/mul_mat_vec.wgsl
+++ b/ggml/src/ggml-webgpu/wgsl-shaders/mul_mat_vec.wgsl
@@ -1,4 +1,5 @@
 #ifdef USE_SUBGROUP_REDUCTION
+diagnostic(off, subgroup_uniformity);
 enable subgroups;
 #endif
 enable f16;


### PR DESCRIPTION
## Overview

Adds the `diagnostic(off, subgroup_uniformity);` directive to `mul_mat_vec.wgsl` so it matches the pattern already used by the other subgroup-using shaders in the directory. Without it, stricter Dawn builds reject the shader at validation time and all mat-vec pipelines fail to compile on those systems.

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

The `subgroupAdd` call in the row-reduction loop (`mul_mat_vec.wgsl:831`) sits inside a for-loop whose trip count depends on `num_subgroups`, which WGSL's uniformity analysis conservatively treats as potentially non-uniform. Some Dawn builds (observed on AMD/RADV with Mesa 25.2.8, Dawn `3f101040aa`) escalate this to a shader validation error, blocking all mat-vec pipelines at shader compile time.

The other subgroup-using shaders in this directory (`flash_attn.wgsl`, `flash_attn_vec_*.wgsl`) already opt out via `diagnostic(off, subgroup_uniformity);`. `mul_mat_vec.wgsl` was missing it.

The directive is placed inside the `USE_SUBGROUP_REDUCTION` guard so it only applies when subgroups are enabled. No behavior change on platforms where validation was already passing (verified locally on Intel Arc B580 + Mesa 25.2.8). Confirmed to unblock the failing path on AMD Radeon RX 7900 XT (RADV NAVI31, Mesa 25.2.8, Dawn `3f101040aa`). After the fix, `llama-bench` runs cleanly on Q4_0 (663 tok/s pp, 223 tok/s tg) and IQ1_S (460 tok/s pp, 29 tok/s tg) where both previously errored at shader compile time.

## Reproduction

Without this patch, on AMD/RADV, the following command fails at shader compile time with `'subgroupAdd' must only be called from uniform control flow`:
```
LD_LIBRARY_PATH=build/bin build/bin/llama-bench \
  -m models/Llama-3.2-1B-Instruct-Q4_0.gguf -p 64 -n 128 -r 1 -ngl 99
```

With this patch, the same command runs to completion. Also reproduced across IQ1_S, IQ1_M, IQ2_XXS, IQ3_XXS, IQ4_NL, IQ4_XS (all failed identically before, all pass after).

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
