### PR TITLE
Hexagon: Bump HMX Frequency to Max Corner

### DIFF
--- a/ggml/src/ggml-hexagon/htp/hmx-matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/hmx-matmul-ops.c
@@ -1683,7 +1683,7 @@ int mat_mul_qk_0_d16a32_out_stationary(struct htp_context *ctx, float *restrict 
     __fp16  *vtcm_scales     = (__fp16 *) vtcm_seq_alloc(&vtcm_ptr, 256);
     assert((size_t)(vtcm_ptr - (uint8_t *)ctx->vtcm_base) <= vtcm_budget);
 
-    FARF(HIGH, "hmx-mm: m=%d k=%d n=%d wtype=%d block M=%zu N=%zu K=%zu vtcm=%zu/%zu", __func__, m, k, n, weight_type,
+    FARF(HIGH, "hmx-mm: m=%d k=%d n=%d wtype=%d block M=%zu N=%zu K=%zu vtcm=%zu/%zu", m, k, n, weight_type,
          M_BLOCK_SIZE, N_BLOCK_SIZE, K_BLOCK_SIZE, (size_t) (vtcm_ptr - (uint8_t *) ctx->vtcm_base), vtcm_budget);
 
     // initialize eye tile (32x32 identity matrix)

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -101,6 +101,24 @@ AEEResult htp_iface_open(const char * uri, remote_handle64 * handle) {
         }
     }
 
+    {
+        // Set HMX clock
+        HAP_power_request_t request;
+        memset(&request, 0, sizeof(HAP_power_request_t));
+        request.type = HAP_power_set_HMX_v2;
+        request.hmx_v2.set_clock = TRUE;
+        request.hmx_v2.target_corner = HAP_DCVS_EXP_VCORNER_MAX;
+        request.hmx_v2.min_corner = HAP_DCVS_EXP_VCORNER_MAX;
+        request.hmx_v2.max_corner = HAP_DCVS_EXP_VCORNER_MAX;
+        request.hmx_v2.perf_mode = HAP_CLK_PERF_HIGH;
+        FARF(ALWAYS, "Setting HMX clock\n");
+        err = HAP_power_set((void *) &ctx, &request);
+        if (err != AEE_SUCCESS) {
+            FARF(ERROR, "Error setting HMX clock.");
+            return err;
+        }
+    }
+
     return AEE_SUCCESS;
 }
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
HMX is currently running at the lowest frequency corner, this PR bumps HMX Frequency to max corner.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
Should give a nice boost to prefill TPS

Results from Snapdragon Gen 5

Llama-3.1-8B-Instruct-Q4_0
```
Before:
common_perf_print: prompt eval time =    2193.53 ms /   256 tokens (    8.57 ms per token,   116.71 tokens per second)
common_perf_print:        eval time =    2314.84 ms /    31 runs   (   74.67 ms per token,    13.39 tokens per second)

After:
common_perf_print: prompt eval time =    1721.29 ms /   256 tokens (    6.72 ms per token,   148.73 tokens per second)
common_perf_print:        eval time =    2327.55 ms /    31 runs   (   75.08 ms per token,    13.32 tokens per second)
``` 

Llama-3.2-1B-Instruct-Q4_0
```
Before:
common_perf_print: prompt eval time =     383.28 ms /   256 tokens (    1.50 ms per token,   667.93 tokens per second)
common_perf_print:        eval time =     489.70 ms /    31 runs   (   15.80 ms per token,    63.30 tokens per second)

After:
common_perf_print: prompt eval time =     287.79 ms /   256 tokens (    1.12 ms per token,   889.54 tokens per second)
common_perf_print:        eval time =     480.15 ms /    31 runs   (   15.49 ms per token,    64.56 tokens per second)
``` 

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->