### PR TITLE
server: respect per-request enable_thinking toggle via extra_body

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -93,7 +93,7 @@ common_peg_arena autoparser::build_parser(const generation_params & inputs) cons
     }
     return build_chat_peg_parser([&](common_chat_peg_builder & p) {
         parser_build_context ctx(p, inputs);
-        bool                 extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+        bool                 extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE && inputs.enable_thinking;
 
         ctx.extracting_reasoning = extract_reasoning && reasoning.mode != reasoning_mode::NONE;
         ctx.content              = &content;

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2210,7 +2210,9 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         struct autoparser::autoparser autoparser;
         autoparser.analyze_template(tmpl);
         auto auto_params = autoparser::peg_generator::generate_parser(tmpl, params, autoparser);
-        auto_params.supports_thinking = autoparser.reasoning.mode != autoparser::reasoning_mode::NONE;
+        // Only enable thinking support if both the template supports it AND enable_thinking is true
+        bool template_supports_thinking = autoparser.reasoning.mode != autoparser::reasoning_mode::NONE;
+        auto_params.supports_thinking   = template_supports_thinking && params.enable_thinking;
         if (auto_params.supports_thinking) {
             auto_params.thinking_start_tag = autoparser.reasoning.start;
             auto_params.thinking_end_tag   = autoparser.reasoning.end;

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1057,14 +1057,33 @@ json oaicompat_chat_params_parse(
         inputs.chat_template_kwargs[item.key()] = item.value().dump();
     }
 
-    // parse the "enable_thinking" kwarg to override the default value
-    auto enable_thinking_kwarg = json_value(inputs.chat_template_kwargs, "enable_thinking", std::string(""));
+    // parse the "enable_thinking" kwarg from extra_body or chat_template_kwargs
+    auto enable_thinking_kwarg = std::string("");
+    if (body.contains("extra_body") && body["extra_body"].is_object()) {
+        auto extra_body = body["extra_body"];
+        if (extra_body.contains("enable_thinking")) {
+            auto val = extra_body["enable_thinking"];
+            if (val.is_boolean()) {
+                enable_thinking_kwarg = val.get<bool>() ? "true" : "false";
+                // also copy into chat_template_kwargs so the template can use it
+                inputs.chat_template_kwargs["enable_thinking"] = enable_thinking_kwarg;
+            }
+        }
+    }
+    if (enable_thinking_kwarg.empty()) {
+        enable_thinking_kwarg = json_value(inputs.chat_template_kwargs, "enable_thinking", std::string(""));
+    }
     if (enable_thinking_kwarg == "true") {
         inputs.enable_thinking = true;
     } else if (enable_thinking_kwarg == "false") {
         inputs.enable_thinking = false;
     } else if (!enable_thinking_kwarg.empty() && enable_thinking_kwarg[0] == '"') {
         throw std::invalid_argument("invalid type for \"enable_thinking\" (expected boolean, got string)");
+    }
+
+    // pass enable_thinking to the slot so it can override the server default
+    if (!enable_thinking_kwarg.empty()) {
+        llama_params["enable_thinking"] = inputs.enable_thinking;
     }
 
     // if the assistant message appears at the end of list, we do not add end-of-turn token


### PR DESCRIPTION
## Overview

Fixes `enable_thinking` being ignored when set per-request via `extra_body` or `chat_template_kwargs`. Previously the server only checked `chat_template_kwargs`, but OpenAI-compatible clients (and tools like Opencode) send it in `extra_body`. This caused `enable_thinking: false` to be silently ignored across all shells.

## Changes

### `tools/server/server-common.cpp`
Read `enable_thinking` from `extra_body` first (OpenAI-compatible path), then fall back to `chat_template_kwargs`. Pass the value to the slot so it can override the server default.

### `common/chat.cpp`
`supports_thinking` now requires both template-level reasoning detection AND `enable_thinking == true`. Prevents thinking tags from being injected when the user explicitly toggles thinking off.

### `common/chat-auto-parser-generator.cpp`
`extract_reasoning` also gated by `enable_thinking`, ensuring the PEG parser does not extract reasoning block markers when thinking is disabled.

## Fixes
- #20182 — `enable_thinking` param cannot turn off thinking for qwen3.5
- #20196 — disabling reasoning does not work anymore on certain models
- #20409 — `enable_thinking=false` ignored across all shells
- #20861 — Qwen3.5 with Opencode assistant prefill incompatible

## Testing
- Build verified (Release, Linux, `cmake --build . -j$(nproc)`)
- Existing `test-chat` and `test-chat-peg-parser` pass
- No new server integration tests added (change is minimal and targeted)

## AI Usage Disclosure

YES — AI (OpenCode with Qwen3.6-35B) assisted with code formatting, searching related issues on GitHub, verifying CI compliance against `.github/workflows/server.yml`, and drafting this PR description. All code changes, logic design, and review were performed by the contributor.