### PR TITLE
fix Blackwell sharedMemPerBlockOptin overflow causing SOFT_MAX error

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -282,6 +282,16 @@ static ggml_cuda_device_info ggml_cuda_init() {
                       (size_t)(prop.totalGlobalMem / (1024 * 1024)));
 #else
         info.devices[id].smpbo = prop.sharedMemPerBlockOptin;
+
+        // Workaround: on some Blackwell (compute capability 12.0) GPUs,
+        // sharedMemPerBlockOptin reports a bogus value (0x100000001) which
+        // overflows to 1 when cast to int in cudaFuncSetAttribute(), causing
+        // kernel launches to fail with cudaErrorInvalidValue.
+        // Fall back to sharedMemPerBlock if the value is unreasonably large.
+        if (info.devices[id].smpbo > 1024*1024) {
+            info.devices[id].smpbo = prop.sharedMemPerBlock;
+        }
+
         info.devices[id].cc = 100*prop.major + 10*prop.minor;
         GGML_LOG_INFO("  Device %d: %s, compute capability %d.%d, VMM: %s, VRAM: %zu MiB\n",
                       id, prop.name, prop.major, prop.minor, device_vmm ? "yes" : "no",


### PR DESCRIPTION
TLDR / My use case:
- I dont have enough vram so i want to CPU + GPU split unsloth/Qwen3.5-122B-A10B-GGUF:UD-Q4_K_XL  (MOE model)
- this worked previously on rtx4090 but not on rtx5090 
- somehow my RTX 5090 reported 4294967297 bytes (~4 GB) of shared memory with NVIDIA Driver: 590.48.01

This PR fixes an issue when using: 

```    

./llama.cpp/build/bin/llama-server \
        -hf "unsloth/Qwen3.6-27B-GGUF:UD-Q5_K_XL" \
	--mmproj-url "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/mmproj-F16.gguf?download=true" \
        --host 0.0.0.0 \
        --port 20000 \
        --ctx-size 200000 \
        --n-gpu-layers 999 \
        --flash-attn on \
        --temp 0.6 \
        --top-p 0.95 \
        --top-k 20 \
        --min-p 0.00 \
	--presence_penalty 0.0 \
	--repeat_penalty 1.0 \
        --cache-type-k q8_0 \
        --cache-type-v q8_0 \
        --metrics \
	--parallel 1 \
	--timeout 3600 \
	--cont-batching \
        --jinja
```

built with main branch (at commit 0adede866ddb2e31992b3792eaea31d18ed89acf):
```
rm -rf llama.cpp/build

cmake llama.cpp -B llama.cpp/build \
    -DBUILD_SHARED_LIBS=OFF \
    -DGGML_CUDA=ON \
    -DGGML_RPC=ON \
    -DGGML_NATIVE=ON \
    -DCMAKE_CUDA_ARCHITECTURES="120" \
    -DCMAKE_BUILD_TYPE=Release

cmake --build llama.cpp/build --config Release -j --clean-first --target llama-cli llama-mtmd-cli llama-server llama-gguf-split rpc-server
cp llama.cpp/build/bin/llama-* llama.cpp/build/bin/rpc-server llama.cpp

```

My System:
```
OS: Linux Mint 22.1 (Xia) Linux mint 6.14.0-37-generic #37~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov 20 10:25:38 UTC 2 x86_64 x86_64 x86_64 GNU/Linux

Ryzen 9 9950x3d
RTX5090
DDR5 96GB @ 6000MT (2 dimms)
1tb NVME
```

Driver specs:
```
  - GPU: NVIDIA GeForce RTX 5090 (compute capability 12.0)
  - NVIDIA Driver: 590.48.01
  - CUDA Runtime: 13.1
  - CUDA Toolkit (nvcc): 13.1 (/usr/local/cuda-13.1)
  - Kernel: 6.14.0-37-generic
```


It crash on an initial "hello" prompt from the web-ui:
<img width="1497" height="735" alt="Screenshot from 2026-04-24 12-25-55" src="https://github.com/user-attachments/assets/c90ace59-495c-4d2b-8ea3-94071b1140bd" />
<img width="1165" height="500" alt="Screenshot from 2026-04-24 14-58-56" src="https://github.com/user-attachments/assets/6a884ff4-f013-4748-b554-6129029f59d7" />

--- 

What happens:

1. ggml-cuda.cu reads cudaDeviceProp.sharedMemPerBlockOptin -->> stores it in smpbo (a size_t, 64-bit)
2. On RTX 5090 (Blackwell, compute 12.0), this returns 4294967297 (0x100000001) : what?!...
3. CUDA_SET_SHARED_MEMORY_LIMIT passes smpbo to cudaFuncSetAttribute(..., int)  a 32-bit parameter
4. 0x100000001 truncated to int = 1
5. GPU now thinks max dynamic shared memory is 1 byte
6. Softmax kernel requests 1152 bytes -->> cudaErrorInvalidValue -->> crash

Fix appears to resolve my issue on my setup
