### PR TITLE
chat: preserve media markers for typed-content templates

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -357,6 +357,15 @@ std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const json & messa
     return msgs;
 }
 
+static bool msg_has_media_markers(const common_chat_msg & msg) {
+    for (const auto & part : msg.content_parts) {
+        if (part.type == "media_marker") {
+            return true;
+        }
+    }
+    return false;
+}
+
 static json render_message_to_json(const std::vector<common_chat_msg> & msgs, const jinja::caps & c) {
     if (!c.supports_string_content && !c.supports_typed_content) {
         LOG_WRN("%s: Neither string content nor typed content is supported by the template. This is unexpected and may lead to issues.\n", __func__);
@@ -367,7 +376,24 @@ static json render_message_to_json(const std::vector<common_chat_msg> & msgs, co
 
     json messages = json::array();
     for (const auto & msg : msgs) {
-        if (only_string_accepted) {
+        bool has_media = msg_has_media_markers(msg);
+
+        if (has_media && !only_string_accepted) {
+            // Typed-content templates may output their own image placeholder
+            // (e.g. "<image>") instead of the media marker text, which breaks
+            // mtmd_tokenize. Concatenate all parts so markers survive in the
+            // rendered prompt, wrapping as a typed text array if needed.
+            json jmsg = msg.to_json_oaicompat(/* concat_typed_text= */ true);
+            if (!c.supports_string_content) {
+                jmsg["content"] = json::array({
+                    json{
+                        {"type", "text"},
+                        {"text", jmsg.at("content").get<std::string>()},
+                    }
+                });
+            }
+            messages.push_back(jmsg);
+        } else if (only_string_accepted) {
             json jmsg = msg.to_json_oaicompat(/* concat_typed_text= */ true);
             messages.push_back(jmsg);
         } else if (only_typed_accepted) {


### PR DESCRIPTION
## Summary

Fix "Failed to tokenize prompt" error when using SmolVLM (and other Idefics3-based models) with `--jinja` flag via the OpenAI-compatible chat completions API.

**Root cause:** Typed-content Jinja templates (like SmolVLM's) output their own hardcoded image placeholder (e.g. `<image>`) instead of the media marker text (e.g. `<__media_abc123__>`). When `mtmd_tokenize` tries to split the rendered prompt by the media marker, it can't find it, causing the tokenization failure.

**Fix:** In `render_message_to_json()`, detect messages with `media_marker` content parts. For non-string-only templates, concatenate all parts as text (preserving markers), wrapping as a typed text array `[{"type": "text", "text": "..."}]` when the template doesn't support string content. This ensures media markers survive template rendering and reach `mtmd_tokenize` intact.

**Code flow before the fix:**
1. API receives `image_url` - server converts to `{"type": "media_marker", "text": "<__media_xyz__>"}`
2. Template gets typed content with `media_marker` type - doesn't recognize it
3. Template skips unknown type or (with naive fix) outputs `<image>` instead of marker text
4. `mtmd_tokenize` can't find marker in prompt. Returns error

**Code flow after the fix:**
1. API receives `image_url` - server converts to `{"type": "media_marker", "text": "<__media_xyz__>"}`
2. `render_message_to_json` detects media markers, concatenates all parts as text
3. Template receives `[{"type": "text", "text": "What do you see?<__media_xyz__>"}]`
4. Template outputs text content as-is, preserving the marker
5. `mtmd_tokenize` finds marker and replaces with image embeddings

Fixes #21634

## Test plan

- [x] All `test-chat` unit tests pass (no regressions)
- [x] Manual test with SmolVLM-500M-Instruct-Q8_0 + mmproj via `llama-server --jinja`:
  - Sent multimodal chat completion with base64 PNG image
  - Previously returned `{"error": {"code": 400, "message": "Failed to tokenize prompt"}}`
  - Now returns correct response: `"A blank blue background is shown."`

Assisted-by: Claude <noreply@anthropic.com>