### PR TITLE
ggml : revert to -lm linking instead of find_library

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -471,7 +471,11 @@ endforeach()
 target_link_libraries(ggml-base PRIVATE Threads::Threads)
 
 if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
-    target_link_libraries(ggml-base PRIVATE m)
+    if (DEFINED MATH_LIBRARY)
+        target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
+    else()
+        target_link_libraries(ggml-base PRIVATE m)
+    endif()
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Android")

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -470,11 +470,8 @@ endforeach()
 
 target_link_libraries(ggml-base PRIVATE Threads::Threads)
 
-find_library(MATH_LIBRARY m)
-if (MATH_LIBRARY)
-    if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
-        target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
-    endif()
+if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
+    target_link_libraries(ggml-base PRIVATE m)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Android")

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -470,12 +470,10 @@ endforeach()
 
 target_link_libraries(ggml-base PRIVATE Threads::Threads)
 
-if (NOT WIN32 AND NOT DEFINED ENV{ONEAPI_ROOT})
-    if (DEFINED MATH_LIBRARY)
-        target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
-    else()
-        target_link_libraries(ggml-base PRIVATE m)
-    endif()
+if (DEFINED MATH_LIBRARY)
+    target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
+elseif (NOT WIN32 AND NOT DEFINED ENV{ONEAPI_ROOT})
+    target_link_libraries(ggml-base PRIVATE m)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Android")

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -470,7 +470,7 @@ endforeach()
 
 target_link_libraries(ggml-base PRIVATE Threads::Threads)
 
-if (NOT WIN32 OR NOT DEFINED ENV{ONEAPI_ROOT})
+if (NOT WIN32 AND NOT DEFINED ENV{ONEAPI_ROOT})
     if (DEFINED MATH_LIBRARY)
         target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
     else()


### PR DESCRIPTION

## Overview

`find_library(MATH_LIBRARY m)` was introduced recently, but it breaks CUDA compilation with GGML_STATIC. I could not find any valid use case where we would prefer `find_library` over the standard `-lm` approach.

This commit is also meant to start a discussion if there is a valid reason to keep `find_library(MATH_LIBRARY m)`, we should clarify what problem it was solving and find an alternative fix that does not break CUDA with GGML_STATIC.

## Additional information

Found with installama.sh: https://github.com/angt/installama.sh/actions/runs/24885620138/job/72864816848

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
