### PR TITLE
common/gemma4 : fix multi-turn tool call parsing with literal <|tool_call> in content

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1191,8 +1191,11 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
                 /* max = */ inputs.parallel_tool_calls ? -1 : 1
             ));
 
-            auto scan_to_toolcall = p.rule("scan-to-toolcall", p.until("<|tool_call>"));
-            auto content = p.rule("content", p.content(p.until_one_of({"<|channel>", "<channel|>", "<|tool_call>"})));
+            // Only stop content/scan at actual tool-call starts (<|tool_call>call:).
+            // This prevents stray <|tool_call> tokens in content (e.g. references to
+            // previous turns) from being greedily consumed by the tool_call rule.
+            auto scan_to_toolcall = p.rule("scan-to-toolcall", p.until("<|tool_call>call:"));
+            auto content = p.rule("content", p.content(p.until_one_of({"<|channel>", "<channel|>", "<|tool_call>call:"})));
             auto message = p.rule("message", thought + content);
             return start + p.zero_or_more(message) + scan_to_toolcall + tool_call;
         }
@@ -1223,7 +1226,7 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
         });
 
         data.grammar_triggers = {
-            { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<|tool_call>" },
+            { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<|tool_call>call:" },
         };
     }
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1342,6 +1342,11 @@ class peg_test_builder {
         return *this;
     }
 
+    peg_test_builder & messages(std::vector<common_chat_msg> msgs) {
+        tc_.params.messages = std::move(msgs);
+        return *this;
+    }
+
     peg_test_builder & json_schema(const std::string & schema) {
         tc_.params.json_schema = schema;
         return *this;
@@ -2143,6 +2148,39 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
             .expect(message_assist)
             .run();
+
+        // Regression test for multi-turn tool calls after round 0.
+        // A stray <|tool_call> token in content (from referencing a previous turn)
+        // must not be consumed before the real tool_call rule can match.
+        {
+            common_chat_msg tool_result;
+            tool_result.role = "tool";
+            tool_result.content = "10:00 AM";
+            tool_result.tool_call_id = "call_1";
+
+            tst.test(
+                    "<|channel>thought\n"
+                    "I need to get the time in Paris\n"
+                    "<channel|>\n"
+                    "Prior turn used the <|tool_call> token.\n"
+                    "Now let me check Paris.\n"
+                    "<|tool_call>call:get_time{city:<|\"|>Paris<|\"|>}<tool_call|>")
+                .tools({ get_time_tool })
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .messages({
+                    {"user", "What time in London?"},
+                    {"assistant", "", {}, {{ "get_time", R"({"city": "London"})" }}},
+                    tool_result,
+                    {"user", "And in Paris?"}
+                })
+                .expect(simple_assist_msg(
+                    "Prior turn used the <|tool_call> token.\n"
+                    "Now let me check Paris.\n",
+                    "I need to get the time in Paris",
+                    "get_time",
+                    R"({"city": "Paris"})"))
+                .run();
+        }
     }
 
     {

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -2181,6 +2181,22 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
                     R"({"city": "Paris"})"))
                 .run();
         }
+
+        // Negative regression: stray <|tool_call> in content with no real tool
+        // call following must round-trip as content with zero tool_calls.
+        tst.test(
+                "<|channel>thought\n"
+                "Considering the user's question\n"
+                "<channel|>\n"
+                "The <|tool_call> token starts a tool call. "
+                "Let me know if you want me to use one.\n")
+            .tools({ get_time_tool })
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .expect(simple_assist_msg(
+                "The <|tool_call> token starts a tool call. "
+                "Let me know if you want me to use one.\n",
+                "Considering the user's question"))
+            .run();
     }
 
     {


### PR DESCRIPTION
Fixes #22371.

The content and scan_to_toolcall parsers used `<|tool_call>` as a delimiter, which is ambiguous. When the model emits a literal `<|tool_call>` inside content (e.g. referencing a previous turn), the parsers prematurely terminate content and try to parse the remaining text as a tool call.

Fix by aligning the delimiters with the actual tool_call rule prefix: change `<|tool_call>` → `<|tool_call>call:` in both the parser and the grammar trigger. This ensures only actual tool calls (which always start with `<|tool_call>call:`) are recognized as boundaries. The same prefix is already used by the template-detection workaround at `common/chat.cpp:2106`, so this aligns the parser with the contract modern Gemma 4 templates already declare.

Regression tests:
- multi-turn conversation where content contains a literal `<|tool_call>` followed by a real tool call (positive case)
- stray `<|tool_call>` in content with no real tool call following — must round-trip as content with zero tool_calls (negative case)

See #22371 for the live `llama-server` reproduction against `unsloth/gemma-4-E2B-it-GGUF`.

---

*Note: PR drafted with AI assistance; reproduction, first-bad-commit verification, and analysis verified by hand against the running model.*
