### PR TITLE
Windows: raise stdio limit for loading many GGUF shards

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -526,6 +526,17 @@ llama_model_loader::llama_model_loader(
         trace = atoi(getenv("LLAMA_TRACE"));
     }
 
+    #ifdef _WIN32
+        // Cap at MSVC's hard limit of 8192 - https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmaxstdio?view=msvc-160
+        #define _GGML_STDIO_TARGET 2048
+        int _setmaxstdio_ret = _setmaxstdio(_GGML_STDIO_TARGET);
+        if (_setmaxstdio_ret == -1) {
+            LLAMA_LOG_INFO("%s: failed to set max stdio to %d. (setmaxstdio returned -1)\n", __func__, _GGML_STDIO_TARGET);
+        } else {
+            LLAMA_LOG_INFO("%s: max stdio successfully set to %d\n", __func__, _setmaxstdio_ret);
+        }
+    #endif // _WIN32
+
     if (param_overrides_p != nullptr) {
         for (const struct llama_model_kv_override * p = param_overrides_p; p->key[0] != 0; p++) {
             kv_overrides.insert({std::string(p->key), *p});


### PR DESCRIPTION
## Overview

This PR raises the maximum number of stdio handles on Windows at startup so llama.cpp can load models split across many `.gguf` shards without hitting the default Windows/MSVC file handle limit.

On Linux, this is commonly handled externally with `ulimit`, but Windows does not provide the same mechanism for end users. Calling `_setmaxstdio()` in the binary gives Windows builds comparable behavior and avoids shard-loading failures for heavily sharded models.

## Additional information

The new limit is set conservatively to `2048`, which is below MSVC’s documented hard cap of `8192`. If `_setmaxstdio()` fails, the code logs the failure and continues with the default runtime limit.

I have been using this change in a downstream fork for more than 8 months without issues.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI was used to help draft and polish the PR text.

I understand I am responsible for all submitted changes. This project restricts AI-generated content; I have reviewed AGENTS.md and CONTRIBUTING.md and will ensure the submitted code and text comply with them.