### PR TITLE
fix: re-throw raised_exception in statement::execute without wrapping

### DIFF
--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -60,9 +60,15 @@ value statement::execute(context & ctx) {
         throw;
     } catch (const rethrown_exception & /* ex */) {
         throw;
+    } catch (const raised_exception & /* ex */) {
+        throw;
     } catch (const not_implemented_exception & /* ex */) {
         throw;
     } catch (const std::exception & e) {
+        if (std::string(e.what()).find("Jinja Exception: ") != std::string::npos) {
+            throw;
+        }
+
         const std::string & source = *ctx.src;
         if (source.empty()) {
             std::ostringstream oss;


### PR DESCRIPTION
## Summary

Fix #11402 — `raised_exception` thrown by Jinja templates (e.g. `raise_exception` in Ministral's chat template) is caught by the generic `std::exception` handler in `statement::execute()` and wrapped into a `rethrown_exception` with extra source-location formatting. This corrupts the template state and produces garbled output.

## Root Cause

In `common/jinja/runtime.cpp`, the `statement::execute()` catch chain handles `rethrown_exception` and `not_implemented_exception` with dedicated re-throw clauses, but `raised_exception` falls through to the generic `catch (const std::exception &)` handler which wraps it with formatting and throws a `rethrown_exception` instead of propagating the original error cleanly.

## Fix

Add a `catch (const raised_exception &)` clause before the `std::exception` handler, matching the existing pattern for `rethrown_exception` and `not_implemented_exception`. Also re-throw any exception whose message contains `"Jinja Exception: "` as a safety net.

## Test Plan

The existing fuzz tests in `test-jinja.cpp` exercise template execution with random inputs and verify no crashes occur. This fix ensures `raised_exception` propagates cleanly instead of being reformatted.

To reproduce the original issue with a Ministral model that uses `raise_exception` in its chat template:

1. Load a Ministral model with a multi-user-turn conversation that violates the template's role constraints
2. Without this fix: garbled output due to corrupted template state
3. With this fix: clean error propagation