### PR TITLE
gguf : reject empty metadata key names during parsing

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -508,6 +508,10 @@ struct gguf_context * gguf_init_from_file_ptr(FILE * file, struct gguf_init_para
                 GGML_LOG_ERROR("%s: encountered bad_alloc error while reading key %" PRIi64 "\n", __func__, i);
                 ok = false;
             }
+            if (ok && key.empty()) {
+                GGML_LOG_ERROR("%s: empty key name at KV pair %" PRIi64 "\n", __func__, i);
+                ok = false;
+            }
             for (size_t j = 0; ok && j < ctx->kv.size(); ++j) {
                 if (key == ctx->kv[j].key) {
                     GGML_LOG_ERROR("%s: duplicate key '%s' for tensors %zu and %" PRIi64 " \n", __func__, key.c_str(), j, i);

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -29,6 +29,9 @@ enum handcrafted_file_type {
     HANDCRAFTED_KV_BAD_TYPE                =  20 + offset_has_kv,
     // HANDCRAFTED_KV_BAD_VALUE_SIZE          =  30 + offset_has_kv, // removed because it can result in allocations > 1 TB (default sanitizer limit)
     HANDCRAFTED_KV_DUPLICATE_KEY           =  40 + offset_has_kv,
+    HANDCRAFTED_KV_EMPTY_KEY               =  45 + offset_has_kv,
+    HANDCRAFTED_KV_EMPTY_KEY_ONLY_FIRST    =  46 + offset_has_kv,
+    HANDCRAFTED_KV_EMPTY_KEY_ONLY_MID      =  47 + offset_has_kv,
     HANDCRAFTED_KV_BAD_ALIGN               =  50 + offset_has_kv,
     HANDCRAFTED_KV_SUCCESS                 = 800 + offset_has_kv,
 
@@ -66,6 +69,9 @@ static std::string handcrafted_file_type_name(const enum handcrafted_file_type h
         case HANDCRAFTED_KV_BAD_KEY_SIZE:            return "KV_BAD_KEY_SIZE";
         case HANDCRAFTED_KV_BAD_TYPE:                return "KV_BAD_TYPE";
         case HANDCRAFTED_KV_DUPLICATE_KEY:           return "KV_DUPLICATE_KEY";
+        case HANDCRAFTED_KV_EMPTY_KEY:               return "KV_EMPTY_KEY";
+        case HANDCRAFTED_KV_EMPTY_KEY_ONLY_FIRST:    return "KV_EMPTY_KEY_ONLY_FIRST";
+        case HANDCRAFTED_KV_EMPTY_KEY_ONLY_MID:      return "KV_EMPTY_KEY_ONLY_MID";
         case HANDCRAFTED_KV_BAD_ALIGN:               return "KV_BAD_ALIGN";
         case HANDCRAFTED_KV_SUCCESS:                 return "KV_RANDOM_KV";
 
@@ -250,14 +256,24 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
 
         const std::string key = "my_key_" + std::to_string((hft == HANDCRAFTED_KV_DUPLICATE_KEY ? i/2 : i));
 
-        if (hft == HANDCRAFTED_KV_BAD_KEY_SIZE) {
+        const bool empty_key_this_iter =
+            hft == HANDCRAFTED_KV_EMPTY_KEY ||
+            (hft == HANDCRAFTED_KV_EMPTY_KEY_ONLY_FIRST && i == 0) ||
+            (hft == HANDCRAFTED_KV_EMPTY_KEY_ONLY_MID   && i == int(kv_types.size()) / 2);
+
+        if (empty_key_this_iter) {
+            const uint64_t n = 0;
+            helper_write(file, n);
+        } else if (hft == HANDCRAFTED_KV_BAD_KEY_SIZE) {
             const uint64_t n = -1;
             helper_write(file, n);
         } else {
             const uint64_t n = key.length();
             helper_write(file, n);
         }
-        helper_write(file, key.data(), key.length());
+        if (!empty_key_this_iter) {
+            helper_write(file, key.data(), key.length());
+        }
 
         {
             const int32_t type32 = int32_t(type);
@@ -698,6 +714,9 @@ static std::pair<int, int> test_handcrafted_file(const unsigned int seed) {
         HANDCRAFTED_KV_BAD_KEY_SIZE,
         HANDCRAFTED_KV_BAD_TYPE,
         HANDCRAFTED_KV_DUPLICATE_KEY,
+        HANDCRAFTED_KV_EMPTY_KEY,
+        HANDCRAFTED_KV_EMPTY_KEY_ONLY_FIRST,
+        HANDCRAFTED_KV_EMPTY_KEY_ONLY_MID,
         HANDCRAFTED_KV_BAD_ALIGN,
         HANDCRAFTED_KV_SUCCESS,
 


### PR DESCRIPTION
## Summary

Fix #20873 — malformed GGUF files with zero-length key strings trigger `GGML_ASSERT(!key.empty())` in the `gguf_kv` constructor, causing an abort. The parser should reject such files gracefully with an error log instead.

## Root Cause

In `ggml/src/gguf.cpp`, `gguf_init_from_file_ptr` reads a key string from the file and passes it directly to the `gguf_kv` constructor without checking for empty keys. The constructor asserts non-empty, which aborts in debug builds and is UB in release.

There is already validation for duplicate keys and bad key sizes, but no check for the zero-length key case.

## Fix

Add a guard immediately after the key is read (after the existing `bad_alloc` catch), before the duplicate-key loop:

```cpp
if (ok && key.empty()) {
    GGML_LOG_ERROR("%s: empty key name at KV pair %" PRIi64 "\n", __func__, i);
    ok = false;
}
```

This follows the same pattern as the existing duplicate-key validation.

## Changes

| File | Change |
|------|--------|
| `ggml/src/gguf.cpp` | Reject empty key names with error log |
| `tests/test-gguf.cpp` | 3 new handcrafted test cases |

## Test Plan

Three new handcrafted GGUF file types exercise the fix:

| Test case | Description |
|-----------|-------------|
| `KV_EMPTY_KEY` | All KV pairs have empty keys |
| `KV_EMPTY_KEY_ONLY_FIRST` | Only the first KV pair has an empty key |
| `KV_EMPTY_KEY_ONLY_MID` | A middle KV pair has an empty key |

All three should fail gracefully (parser returns `nullptr` / error count incremented) without triggering `GGML_ASSERT`.