### PR TITLE
fix(graph): remove duplicate wo_s scale after build_attn (Qwen3, LLaMA)

### DIFF
--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -72,9 +72,6 @@ llm_build_llama<embed>::llm_build_llama(const llama_model & model, const llm_gra
             cur = build_attn(inp_attn,
                     model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                     Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
-            if (model.layers[il].wo_s) {
-                cur = ggml_mul(ctx0, cur, model.layers[il].wo_s);
-            }
             cb(cur, "attn_out", il);
         }
         if (il == n_layer - 1 && inp_out_ids) {

--- a/src/models/qwen3.cpp
+++ b/src/models/qwen3.cpp
@@ -58,9 +58,6 @@ llm_build_qwen3::llm_build_qwen3(const llama_model & model, const llm_graph_para
             cur = build_attn(inp_attn,
                     model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                     Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
-            if (model.layers[il].wo_s) {
-                cur = ggml_mul(ctx0, cur, model.layers[il].wo_s);
-            }
         }
         if (il == n_layer - 1 && inp_out_ids) {
             cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);

--- a/src/models/qwen3moe.cpp
+++ b/src/models/qwen3moe.cpp
@@ -58,9 +58,6 @@ llm_build_qwen3moe::llm_build_qwen3moe(const llama_model & model, const llm_grap
             cur = build_attn(inp_attn,
                     model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                     Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
-            if (model.layers[il].wo_s) {
-                cur = ggml_mul(ctx0, cur, model.layers[il].wo_s);
-            }
         }
         if (il == n_layer - 1 && inp_out_ids) {
             cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);


### PR DESCRIPTION
## Overview

Observed that build_attn present in llama-graph already applies  NVFP4 per tensor scale (wo_s) via
llama-graph.cpp (build_lora_mm(wo, cur, wo_s) or explicit wo_s mul). 
Also observed these model builders(qwen3, qwen3moe, llama) are also multiplied the
result by wo_s again, so wo_s was applied twice whenever companion
blk.*.attn_output.scale tensors were present.
That crushed the attention residual (roughly wo_s^2 per layer) and broke
NVFP4 GGUFs for LLM_ARCH_QWEN3, LLM_ARCH_QWEN3MOE, and LLM_ARCH_LLAMA /
LLM_ARCH_LLAMA_EMBED. 
Remove the redundant ggml_mul blocks in:
- src/models/qwen3.cpp
- src/models/qwen3moe.cpp
- src/models/llama.cpp
Non-NVFP4 GGUFs keep wo_s == nullptr, so behavior is unchanged there.

## Additional information

This issue was observed when running inference on https://huggingface.co/nvidia/Qwen3-8B-NVFP4 converted GGUF model

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
