### PR TITLE
common: Fix type casting for unaccounted memory calculation

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -856,7 +856,7 @@ void common_memory_breakdown_print(const struct llama_context * ctx) {
         ggml_backend_dev_memory(dev, &free, &total);
 
         const size_t self = mb.model + mb.context + mb.compute;
-        const size_t unaccounted = total - self - free;
+        const int64_t unaccounted = static_cast<int64_t>(total) - static_cast<int64_t>(free) - static_cast<int64_t>(self);
 
         table_data.push_back({
             template_gpu,
@@ -867,7 +867,7 @@ void common_memory_breakdown_print(const struct llama_context * ctx) {
             std::to_string(mb.model / MiB),
             std::to_string(mb.context / MiB),
             std::to_string(mb.compute / MiB),
-            std::to_string(unaccounted / MiB)});
+            std::to_string(unaccounted / static_cast<int64_t>(MiB))});
     }
 
     // print memory breakdown for host:


### PR DESCRIPTION
## Overview

fix unaccounted mem showing huge numbers (like 2^44, 2^44 = 2^64/1024/1024) when running llama-server --fit on.
changed unaccounted from size_t to int64_t so it can show negative values properly. 

## Additional information

before pr:
common_params_fit_impl: getting device memory data for initial parameters:
common_memory_breakdown_print: | memory breakdown [MiB]     | total    free     self   model   context   compute       unaccounted |
common_memory_breakdown_print: |   - CUDA0 (P100-PCIE-16GB) | 16269 = 15935 + (25732 =  5528 +    1099 +   19104) + 17592186019018 |
common_memory_breakdown_print: |   - CUDA1 (P100-PCIE-16GB) | 16269 = 15951 + (15604 =  5017 +    1594 +    8992) + 17592186029129 |
common_memory_breakdown_print: |   - CUDA2 (P100-PCIE-16GB) | 16269 = 15943 + (15107 =  5024 +    1091 +    8992) + 17592186029634 |
common_memory_breakdown_print: |   - CUDA3 (P100-PCIE-16GB) | 16269 = 15959 + (18992 =  5013 +    1586 +   12392) + 17592186025733 |
common_memory_breakdown_print: |   - Host                   |                  16963 =   515 +       0 +   16448                   |

now:
common_memory_breakdown_print: | memory breakdown [MiB]     | total    free     self   model   context   compute    unaccounted |
common_memory_breakdown_print: |   - CUDA0 (P100-PCIE-16GB) | 16269 = 15935 + (25732 =  5528 +    1099 +   19104) +      -25397 |
common_memory_breakdown_print: |   - CUDA1 (P100-PCIE-16GB) | 16269 = 15951 + (15604 =  5017 +    1594 +    8992) +      -15286 |
common_memory_breakdown_print: |   - CUDA2 (P100-PCIE-16GB) | 16269 = 15943 + (15107 =  5024 +    1091 +    8992) +      -14781 |
common_memory_breakdown_print: |   - CUDA3 (P100-PCIE-16GB) | 16269 = 15959 + (18992 =  5013 +    1586 +   12392) +      -18682 |
common_memory_breakdown_print: |   - Host                   |                  16963 =   515 +       0 +   16448                |

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES,Qwen3.6-27B,  AI helped analyze the code issue and suggest the fix; user implemented and tested.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
