### PR TITLE
llama : fix print_info

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -8150,7 +8150,7 @@ void llama_model::print_info() const {
             }
             ss << "]";
         } else {
-            ss << v[0];
+            ss << std::to_string(v[0]);
         }
 
         return ss.str();


### PR DESCRIPTION
fix print_f stream raw int appending

## Overview

The `print_info` function contains critical bug which causes my application to fall into segfault.

## Additional information

GDB backtrace:
```
#0  0x00007fff9ee99691 in char32_t std::(anonymous namespace)::read_utf8_code_point<char>(std::(anonymous namespace)::range<char const, true>&, unsigned long) () from /home/flodareltih/localhost/example-project/example-module/build/bin/libggml-cuda.so.0
#1  0x00007fff9ee9a5aa in std::codecvt_base::result std::(anonymous namespace)::utf16_in<char, char16_t>(std::(anonymous namespace)::range<char const, true>&, std::(anonymous namespace)::range<char16_t, true>&, unsigned long, std::codecvt_mode) ()
   from /home/flodareltih/localhost/example-project/example-module/build/bin/libggml-cuda.so.0
#2  0x00007fff9ee9a6ef in std::codecvt<char16_t, char, __mbstate_t>::do_in(__mbstate_t&, char const*, char const*, char const*&, char16_t*, char16_t*, char16_t*&) const () from /home/flodareltih/localhost/example-project/example-module/build/bin/libggml-cuda.so.0
#3  0x00007fff9ee69951 in std::basic_ostream<char, std::char_traits<char> >& std::basic_ostream<char, std::char_traits<char> >::_M_insert<unsigned long>(unsigned long) () from /home/flodareltih/localhost/example-project/example-module/build/bin/libggml-cuda.so.0
#4  0x00007fffa0f5887e in operator() (__closure=0x7fffffff896f, f=..., n=36) at /home/flodareltih/localhost/example-project/example-module/submodules/llama.cpp/src/llama-model.cpp:8153
#5  0x00007fffa0f58c18 in llama_model::print_info (this=0x55555889ef50) at /home/flodareltih/localhost/example-project/example-module/submodules/llama.cpp/src/llama-model.cpp:8169
#6  0x00007fffa0dbf2a7 in llama_model_load (metadata=0x0, set_tensor_data=0x0, set_tensor_data_ud=0x0, fname="/home/flodareltih/remotehost/huggingface.co/Qwen/Qwen3-Embedding-8B/Qwen3-Embedding-8B-Q4_K_M.gguf", splits=std::vector of length 0, capacity 0, file=0x0, model=..., 
    params=...) at /home/flodareltih/localhost/example-project/example-module/submodules/llama.cpp/src/llama.cpp:153
#7  0x00007fffa0dc08a8 in llama_model_load_from_file_impl (metadata=0x0, set_tensor_data=0x0, set_tensor_data_ud=0x0, path_model="/home/flodareltih/remotehost/huggingface.co/Qwen/Qwen3-Embedding-8B/Qwen3-Embedding-8B-Q4_K_M.gguf", splits=std::vector of length 0, capacity 0, file=0x0, 
    params=...) at /home/flodareltih/localhost/example-project/example-module/submodules/llama.cpp/src/llama.cpp:368
#8  0x00007fffa0dc0d22 in llama_model_load_from_file (path_model=0x5555586aca40 "/home/flodareltih/remotehost/huggingface.co/Qwen/Qwen3-Embedding-8B/Qwen3-Embedding-8B-Q4_K_M.gguf", params=...) at /home/flodareltih/localhost/example-project/example-module/submodules/llama.cpp/src/llama.cpp:407
```

```
$ g++ -v
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitea.artixlinux.org/packages/gcc/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.2.1 20260209 (GCC)
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO