### PR TITLE
kleidiai: added kleidiai-server to server-self-hosted workflow

### DIFF
--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -123,3 +123,41 @@ jobs:
   #          pip install -r requirements.txt
   #          export ${{ matrix.extra_args }}
   #          pytest -v -x -m "not slow"
+
+  server-kleidiai:
+    runs-on: [self-hosted, llama-server, Linux, ARM64]
+
+    name: server-kleidiai (${{ matrix.wf_name }})
+    strategy:
+      matrix:
+        include:
+          - build_type: Release
+            extra_build_flags: "-DGGML_CPU_KLEIDIAI=ON"
+            extra_args: ""
+            wf_name:    "CPUx1, kleidiai"
+      fail-fast: false
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.sha || github.event.pull_request.head.sha || github.sha || github.head_ref || github.ref_name }}
+
+      - name: Build
+        id: cmake_build
+        run: |
+          cmake -B build -DGGML_SCHED_NO_REALLOC=ON ${{ matrix.extra_build_flags }}
+          cmake --build build --config ${{ matrix.build_type }} -j $(sysctl -n hw.logicalcpu) --target llama-server
+
+      - name: Tests
+        id: server_integration_tests
+        if: ${{ (!matrix.disabled_on_pr || !github.event.pull_request) }}
+        run: |
+          cd tools/server/tests
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+          export ${{ matrix.extra_args }}
+          pytest -v -x -m "not slow"

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -125,7 +125,7 @@ jobs:
   #          pytest -v -x -m "not slow"
 
   server-kleidiai:
-    runs-on: [self-hosted, llama-server, Linux, ARM64]
+    runs-on: ah-ubuntu_22_04-c8g_8x
 
     name: server-kleidiai (${{ matrix.wf_name }})
     strategy:

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -149,7 +149,7 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build -DGGML_SCHED_NO_REALLOC=ON ${{ matrix.extra_build_flags }}
-          cmake --build build --config ${{ matrix.build_type }} -j $(sysctl -n hw.logicalcpu) --target llama-server
+          cmake --build build --config ${{ matrix.build_type }} -j $(nproc) --target llama-server
 
       - name: Tests
         id: server_integration_tests


### PR DESCRIPTION
## Overview

The patch adds a KleidiAI-enabled Arm64 Linux llama-server CI integration test workflow into the `server-self-hosted.yml` configuration file.

## Additional information

Adding a server-based CI workflow as per the discussion under this PR: [https://github.com/ggml-org/llama.cpp/pull/19357#discussion_r2826512140](https://github.com/ggml-org/llama.cpp/pull/19357#discussion_r2826512140).

## Requirements


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - consultation about GitHub actions syntax (no directly AI-generated code) <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
