### PR TITLE
server: guard against reranking with embeddings and add regression tests

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -4110,6 +4110,11 @@ std::unique_ptr<server_res_generator> server_routes::handle_embeddings_impl(cons
         return res;
     }
 
+    if (params.pooling_type == LLAMA_POOLING_TYPE_RANK) {
+        res->error(format_error_response("This server does not support embeddings. Start it with `--embeddings`", ERROR_TYPE_NOT_SUPPORTED));
+        return res;
+    }
+
     if (res_type != TASK_RESPONSE_TYPE_NONE && meta->pooling_type == LLAMA_POOLING_TYPE_NONE) {
         res->error(format_error_response("Pooling type 'none' is not OAI compatible. Please use a different pooling type", ERROR_TYPE_INVALID_REQUEST));
         return res;

--- a/tools/server/tests/unit/test_rerank.py
+++ b/tools/server/tests/unit/test_rerank.py
@@ -144,3 +144,16 @@ def test_rerank_tei_top_n(top_n, expected_len):
     res = server.make_request("POST", "/rerank", data=data)
     assert res.status_code == 200
     assert len(res.body) == expected_len
+
+
+@pytest.mark.parametrize("endpoint", ["/embeddings", "/v1/embeddings"])
+def test_rerank_rejects_embeddings(endpoint):
+    global server
+    server.start()
+
+    res = server.make_request("POST", endpoint, data={
+        "input": "Machine learning is",
+    })
+
+    assert res.status_code == 501
+    assert "does not support embeddings" in res.body["error"]["message"]


### PR DESCRIPTION



## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Starting `llama-server` with `--reranking` now rejects `/embeddings` and `/v1/embeddings` requests instead of accepting them and returning zero vectors.

Fixes Issue #21256 

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
### What changed

- Added a rerank-mode guard in `tools/server/server-context.cpp` so embeddings requests return `ERROR_TYPE_NOT_SUPPORTED` when the server is started with `--reranking`.
- Added a regression test in `tools/server/tests/unit/test_rerank.py` that verifies both embeddings endpoints return HTTP 501 in rerank mode.

### Validation

- `pytest -q tools/server/tests/unit/test_rerank.py -k rerank_rejects_embeddings`
- `pytest -q tools/server/tests/unit/test_embedding.py -k 'pooling_none_oai or embedding_single'`


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
 Yes, claude used to understand file structure.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
