### PR TITLE
server : fix ngram parameter clamp logic in server-task.cpp

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -322,9 +322,9 @@ task_params server_task::params_from_json_cmpl(
     params.speculative.ngram_size_m     = json_value(data, "speculative.ngram_size_m", defaults.speculative.ngram_size_m);
     params.speculative.ngram_min_hits   = json_value(data, "speculative.ngram_m_hits", defaults.speculative.ngram_min_hits);
 
-    params.speculative.ngram_size_n     = std::max(std::min(1, (int) params.speculative.ngram_size_n),     1024);
-    params.speculative.ngram_size_m     = std::max(std::min(1, (int) params.speculative.ngram_size_m),     1024);
-    params.speculative.ngram_min_hits   = std::max(std::min(1, (int) params.speculative.ngram_min_hits),   1024);
+    params.speculative.ngram_size_n     = std::min(std::max(1, (int) params.speculative.ngram_size_n),     1024);
+    params.speculative.ngram_size_m     = std::min(std::max(1, (int) params.speculative.ngram_size_m),     1024);
+    params.speculative.ngram_min_hits   = std::min(std::max(1, (int) params.speculative.ngram_min_hits),   1024);
 
     // Use OpenAI API logprobs only if n_probs wasn't provided
     if (data.contains("logprobs") && params.sampling.n_probs == defaults.sampling.n_probs){


### PR DESCRIPTION
## Summary

The ngram clamp expressions in `tools/server/server-task.cpp` use `std::max(std::min(1, x), 1024)`, which always evaluates to `1024` regardless of `x`. As a result, `speculative.ngram_size_n`, `speculative.ngram_size_m`, and `speculative.ngram_min_hits` are silently overridden to `1024` for every request, ignoring the caller-provided values.

The bug:
```cpp
params.speculative.ngram_size_n   = std::max(std::min(1, (int) params.speculative.ngram_size_n),     1024);
params.speculative.ngram_size_m   = std::max(std::min(1, (int) params.speculative.ngram_size_m),     1024);
params.speculative.ngram_min_hits = std::max(std::min(1, (int) params.speculative.ngram_min_hits),   1024);
```

`std::min(1, x)` is at most `1`, then `std::max(<=1, 1024)` is always `1024`. The intended clamp is `[1, 1024]`, which requires the opposite nesting.

The fix swaps the calls so the value is clamped to `[1, 1024]`:
```cpp
params.speculative.ngram_size_n   = std::min(std::max(1, (int) params.speculative.ngram_size_n),     1024);
params.speculative.ngram_size_m   = std::min(std::max(1, (int) params.speculative.ngram_size_m),     1024);
params.speculative.ngram_min_hits = std::min(std::max(1, (int) params.speculative.ngram_min_hits),   1024);
```

Fixes #22414.

## Test plan

- [ ] Build llama-server, send a request with `speculative.ngram_size_n` < 1024 and confirm the value is preserved (previously snapped to 1024).
- [ ] Confirm values >1024 are still capped at 1024 and values <1 are bumped to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)