### PR TITLE
fix: ggml_graph_overhead_custom underestimates pool size by one GGML_OBJECT_SIZE

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -7073,7 +7073,7 @@ static size_t ggml_graph_nbytes(size_t size, bool grads) {
 }
 
 size_t ggml_graph_overhead_custom(size_t size, bool grads) {
-    return GGML_OBJECT_SIZE + GGML_PAD(ggml_graph_nbytes(size, grads), GGML_MEM_ALIGN);
+    return 2*GGML_OBJECT_SIZE + GGML_PAD(ggml_graph_nbytes(size, grads), GGML_MEM_ALIGN);
 }
 
 size_t ggml_graph_overhead(void) {


### PR DESCRIPTION
## Overview

Fix `ggml_graph_overhead_custom()` underestimating the context pool
size by exactly one `GGML_OBJECT_SIZE` (112 bytes), causing a
deterministic crash in `ggml_new_object()` during graph allocation.

Related: #22404

## Additional information

`ggml_graph_overhead_custom()` (ggml.c:7071) estimates the pool size as:

```c
GGML_OBJECT_SIZE + GGML_PAD(ggml_graph_nbytes(size, grads), GGML_MEM_ALIGN)
```

But `ggml_new_object()` (ggml.c:1690) checks:

```c
if (cur_end + size_needed + GGML_OBJECT_SIZE > ctx->mem_size)
```

The extra `GGML_OBJECT_SIZE` in the allocation check (the object
header) is not included in the overhead estimate, leaving the pool
exactly `sizeof(struct ggml_object)` = 112 bytes short. This matches
the crash exactly: `1073741936 − 1073741824 = 112`.

Fix:

```c
// ggml.c:7071
- return GGML_OBJECT_SIZE + GGML_PAD(ggml_graph_nbytes(size, grads), GGML_MEM_ALIGN);
+ return 2*GGML_OBJECT_SIZE + GGML_PAD(ggml_graph_nbytes(size, grads), GGML_MEM_ALIGN);
```

Tested locally — resolves the crash.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — used AI assistance to help trace the root cause and draft this PR description