### PR TITLE
CUDA: use float instead of int64_t for MMQ bounds

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -3575,8 +3575,10 @@ static __global__ void mul_mat_q(
     constexpr int blocks_per_iter = ITER_K / qk;
 
     // kbc == k block continuous, current index in continuous ijk space.
-    int kbc      = int64_t(blockIdx.x)    *(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
-    int kbc_stop = int64_t(blockIdx.x + 1)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+    constexpr float eps = 1e-5f;
+    const int kbc_sup = nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z; // kbc supremum
+    int kbc      = blockIdx.x     == 0         ? 0       : (float(blockIdx.x)     + eps) * kbc_sup / gridDim.x;
+    int kbc_stop = blockIdx.x + 1 == gridDim.x ? kbc_sup : (float(blockIdx.x + 1) + eps) * kbc_sup / gridDim.x;
 
     kbc      -= fastmodulo(kbc,      blocks_per_ne00) % blocks_per_iter;
     kbc_stop -= fastmodulo(kbc_stop, blocks_per_ne00) % blocks_per_iter;
@@ -3741,8 +3743,10 @@ static __global__ void mul_mat_q_stream_k_fixup(
     const int bidx0 = blockIdx.x;
 
     // kbc == k block continuous, current index in continuous ijk space.
-    int kbc0      = int64_t(blockIdx.x)    *(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
-    int kbc0_stop = int64_t(blockIdx.x + 1)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+    constexpr float eps = 1e-5f;
+    const int kbc0_sup = nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z; // kbc0 supremum
+    int kbc0      = blockIdx.x     == 0         ? 0        : (float(blockIdx.x)     + eps) * kbc0_sup / gridDim.x;
+    int kbc0_stop = blockIdx.x + 1 == gridDim.x ? kbc0_sup : (float(blockIdx.x + 1) + eps) * kbc0_sup / gridDim.x;
 
     kbc0      -= fastmodulo(kbc0,      blocks_per_ne00) % blocks_per_iter;
     kbc0_stop -= fastmodulo(kbc0_stop, blocks_per_ne00) % blocks_per_iter;
@@ -3761,7 +3765,7 @@ static __global__ void mul_mat_q_stream_k_fixup(
     int bidx = bidx0 - 1;
     int kbc_stop = kbc0;
     while(true) {
-        int kbc = int64_t(bidx)*(nsamples_y.z*nchannels_y.z*ntx.z*nty*blocks_per_ne00.z) / gridDim.x;
+        int kbc = bidx == 0 ? 0 : (float(bidx) + eps) * kbc0_sup / gridDim.x;
         kbc -= fastmodulo(kbc, blocks_per_ne00) % blocks_per_iter;
 
         if (kbc == kbc_stop) { // Did not have any data.


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/pull/22298#issuecomment-4327122709 .

This PR replaces the 64 bit integer arithmetic with 32 floating-point arithmetic. Maybe a little bit faster but will require more precise measurements to determine with sufficient precision.

cc: @ORippler 

<details>

| GPU      | Model         |   Microbatch size | Test   |   t/s 665abc609 |   t/s de73ade30 |   Speedup |
|:---------|:--------------|------------------:|:-------|----------------:|----------------:|----------:|
| RTX 3090 | llama 8B Q4_0 |                16 | pp2048 |         1394.11 |         1405.56 |      1.01 |
| RTX 3090 | llama 8B Q4_0 |                32 | pp2048 |         2156.87 |         2155.41 |      1.00 |
| RTX 3090 | llama 8B Q4_0 |                64 | pp2048 |         3065.35 |         3095.17 |      1.01 |
| RTX 3090 | llama 8B Q4_0 |               128 | pp2048 |         3670.35 |         3634.18 |      0.99 |
| RTX 3090 | llama 8B Q4_0 |               256 | pp2048 |         4115.79 |         4064.56 |      0.99 |
| RTX 3090 | llama 8B Q4_0 |               512 | pp2048 |         4421.89 |         4467.34 |      1.01 |
| RTX 3090 | llama 8B Q4_0 |              1024 | pp2048 |         4564.83 |         4595.57 |      1.01 |
| RTX 3090 | llama 8B Q4_0 |              2048 | pp2048 |         4613.93 |         4712.67 |      1.02 |
| RTX 4090 | llama 8B Q4_0 |                16 | pp2048 |         2024.85 |         2060.13 |      1.02 |
| RTX 4090 | llama 8B Q4_0 |                32 | pp2048 |         3591.18 |         3619.28 |      1.01 |
| RTX 4090 | llama 8B Q4_0 |                64 | pp2048 |         6005.87 |         6049.69 |      1.01 |
| RTX 4090 | llama 8B Q4_0 |               128 | pp2048 |         7754.14 |         7718.34 |      1.00 |
| RTX 4090 | llama 8B Q4_0 |               256 | pp2048 |         9983.60 |         9970.69 |      1.00 |
| RTX 4090 | llama 8B Q4_0 |               512 | pp2048 |        11639.48 |        11620.14 |      1.00 |
| RTX 4090 | llama 8B Q4_0 |              1024 | pp2048 |        11969.33 |        11958.34 |      1.00 |
| RTX 4090 | llama 8B Q4_0 |              2048 | pp2048 |        12390.51 |        12399.94 |      1.00 |
| RTX 5090 | llama 8B Q4_0 |                16 | pp2048 |         2539.62 |         2590.16 |      1.02 |
| RTX 5090 | llama 8B Q4_0 |                32 | pp2048 |         4157.45 |         4242.64 |      1.02 |
| RTX 5090 | llama 8B Q4_0 |                64 | pp2048 |         6417.62 |         6483.86 |      1.01 |
| RTX 5090 | llama 8B Q4_0 |               128 | pp2048 |         7555.27 |         7438.92 |      0.98 |
| RTX 5090 | llama 8B Q4_0 |               256 | pp2048 |        10700.24 |        10704.16 |      1.00 |
| RTX 5090 | llama 8B Q4_0 |               512 | pp2048 |        13621.11 |        13622.82 |      1.00 |
| RTX 5090 | llama 8B Q4_0 |              1024 | pp2048 |        14910.65 |        14889.15 |      1.00 |
| RTX 5090 | llama 8B Q4_0 |              2048 | pp2048 |        16025.56 |        15967.39 |      1.00 |

</details>

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No