### PR TITLE
ggml-backend: skip NULL data assert for device-only tensors in ggml_backend_tensor_get

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -345,9 +345,16 @@ void ggml_backend_tensor_get(const struct ggml_tensor * tensor, void * data, siz
         return;
     }
 
-    GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
-    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+    // tensor->data may be NULL for device-only buffers (e.g. Vulkan with unified memory)
+    // where tensor data lives exclusively on the device. The backend get_tensor iface
+    // handles the device-to-host transfer without needing a host data pointer.
+    if (tensor->data == NULL) {
+        GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
+        buf->iface.get_tensor(buf, tensor, data, offset, size);
+        return;
+    }
 
+    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
     buf->iface.get_tensor(buf, tensor, data, offset, size);
 }
 


### PR DESCRIPTION
## Problem

When using Vulkan with device-only (unified) memory, some KV cache tensors have a valid backend buffer but a **NULL host-side `tensor->data` pointer** — the data lives exclusively on the device. This is specifically triggered by models using hybrid attention architectures (e.g. Qwen3.5's MLA + SWA layers).

`ggml_backend_tensor_get()` unconditionally asserted `tensor->data != NULL`, causing an **ABRT crash** whenever `llama-server` tried to serialize KV cache state for prompt caching (slot LCP reuse).

### Crash backtrace

```
ggml/src/ggml-backend.cpp:348: GGML_ASSERT(tensor->data != NULL && "tensor not allocated") failed
  ggml_backend_tensor_get()
  llama_io_write_buffer::write_tensor()         [src/llama-context.cpp]
  llama_kv_cache::state_write_data()            [src/llama-kv-cache.cpp]
  llama_memory_hybrid::state_write()
  llama_context::state_seq_get_data()
  server prompt_save (slot LCP reuse)
```

### Reproducer

```bash
llama-server \
  --device Vulkan0 \
  --kv-unified \
  -m Qwen3.5-122B-A10B-UD-IQ4_XS.gguf \
  -np 8 -c 2097152 --jinja --fa on \
  --ctk q8_0 --ctv q8_0
# Send 2+ sequential requests → crashes after first completes
```

Tested on: AMD Ryzen AI MAX+ 395 (Radeon 8060S, 121GB unified VRAM), Ubuntu 24.04, llama.cpp b8893–b8953.

## Fix

Check for NULL `tensor->data` before the assert and delegate directly to the backend's `get_tensor` iface. The Vulkan backend's `get_tensor` implementation handles device-to-host transfer via the buffer iface without needing a host pointer — so skipping the assert is safe and correct.

```cpp
// tensor->data may be NULL for device-only buffers (e.g. Vulkan with unified memory)
// where tensor data lives exclusively on the device.
if (tensor->data == NULL) {
    GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
    buf->iface.get_tensor(buf, tensor, data, offset, size);
    return;
}
```

## Testing

After applying this patch, prompt caching works correctly with Qwen3.5 122B on Vulkan:
- Multiple sequential requests complete without crash
- Slot LCP similarity and `prompt_save` succeed
- `reasoning_content` and `content` both populated correctly with `--reasoning auto`

The `buf != NULL` assert (which fires before this code path) still guards against truly unallocated tensors, so this does not weaken safety for CPU/CUDA backends.