### PR TITLE
ggml-vulkan: use pipeline cache for compute pipelines

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -665,6 +665,8 @@ struct vk_device_struct {
 
     bool pipeline_executable_properties_support {};
 
+    vk::PipelineCache pipeline_cache = VK_NULL_HANDLE;
+
     size_t idx;
 
     bool mul_mat_l[GGML_TYPE_COUNT];
@@ -895,6 +897,11 @@ struct vk_device_struct {
         all_pipelines.clear();
 
         device.destroyDescriptorSetLayout(dsl);
+
+        if (pipeline_cache) {
+            device.destroyPipelineCache(pipeline_cache);
+            pipeline_cache = VK_NULL_HANDLE;
+        }
 
         device.destroy();
     }
@@ -2274,7 +2281,7 @@ static void ggml_vk_create_pipeline_func(vk_device& device, vk_pipeline& pipelin
 #endif
 
     try {
-        pipeline->pipeline = device->device.createComputePipeline(VK_NULL_HANDLE, compute_pipeline_create_info).value;
+        pipeline->pipeline = device->device.createComputePipeline(device->pipeline_cache, compute_pipeline_create_info).value;
     } catch (const vk::SystemError& e) {
         std::cerr << "ggml_vulkan: Compute pipeline creation failed for " << pipeline->name << std::endl;
         std::cerr << "ggml_vulkan: " << e.what() << std::endl;
@@ -5524,6 +5531,9 @@ static vk_device ggml_vk_get_device(size_t idx) {
             .setPEnabledExtensionNames(device_extensions);
         device_create_info.setPNext(&device_features2);
         device->device = device->physical_device.createDevice(device_create_info);
+
+        vk::PipelineCacheCreateInfo pipeline_cache_create_info;
+        device->pipeline_cache = device->device.createPipelineCache(pipeline_cache_create_info);
 
         // Queues
         ggml_vk_create_queue(device, device->compute_queue, compute_queue_family_index, 0, { vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer }, false);


### PR DESCRIPTION
## Overview

Pipelines were being created with a null Vulkan pipeline cache, so startup paid full pipeline compilation cost each run.

A per-device VkPipelineCache was added and initialized during Vulkan device setup, then passed into compute pipeline creation instead of `VK_NULL_HANDLE`.

## Additional information

I attached the benchmark result based on this change:

```
 ❯ ./bench-compare-startup.sh --model ~/model/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf --trials
 3 --no-build
=== Vulkan Startup Benchmark (Pipeline Cache Change) ===
Model:        ~/model/gemma-4-26B-A4B-it-GGUF/gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
Baseline ref:  HEAD~1
Patched tree:  current working tree
Trials/side:   3

Skipping build step (--no-build)

Running timing trials...
Trial 1/3
  baseline...
    7.026979 s
  patched...
    6.712534 s

Trial 2/3
  patched...
    6.583874 s
  baseline...
    6.488025 s

Trial 3/3
  baseline...
    6.417123 s
  patched...
    6.643356 s

=== Summary ===
Baseline samples (s):       7.026979 6.488025 6.417123
Patched samples (s):        6.712534 6.583874 6.643356
Baseline median:             6.488025 s
Patched median:              6.643356 s
Median delta: +2.39% (patched slower startup)

Note: This benchmark isolates cold process startup + first token path.
```

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
