### PR TITLE
fix: use cpu_get_num_math() instead of hardware_concurrency() for --threads

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -32,7 +32,6 @@
 #include <regex>
 #include <set>
 #include <string>
-#include <thread> // for hardware_concurrency
 #include <vector>
 
 #ifndef __EMSCRIPTEN__
@@ -1117,7 +1116,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams.n_threads = value;
             if (params.cpuparams.n_threads <= 0) {
-                params.cpuparams.n_threads = std::thread::hardware_concurrency();
+                params.cpuparams.n_threads = cpu_get_num_math();
             }
         }
     ).set_env("LLAMA_ARG_THREADS"));
@@ -1127,7 +1126,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams_batch.n_threads = value;
             if (params.cpuparams_batch.n_threads <= 0) {
-                params.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                params.cpuparams_batch.n_threads = cpu_get_num_math();
             }
         }
     ));
@@ -3337,7 +3336,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.cpuparams.n_threads = value;
             if (params.speculative.cpuparams.n_threads <= 0) {
-                params.speculative.cpuparams.n_threads = std::thread::hardware_concurrency();
+                params.speculative.cpuparams.n_threads = cpu_get_num_math();
             }
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER}));
@@ -3347,7 +3346,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.cpuparams_batch.n_threads = value;
             if (params.speculative.cpuparams_batch.n_threads <= 0) {
-                params.speculative.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                params.speculative.cpuparams_batch.n_threads = cpu_get_num_math();
             }
         }
     ).set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER}));


### PR DESCRIPTION
When `--threads` is set to -1 or 0, the arg parser falls back to `std::thread::hardware_concurrency()` which counts logical cores (i.e. includes hyperthreads). On HT-enabled CPUs this oversaturates and tanks throughput — see the reddit thread linked in #19110 where someone went from 9 tok/s to 2.5 tok/s.

There's already `cpu_get_num_math()` in common.h that returns physical cores (and handles Intel hybrid P/E-core detection). The default init path in common.cpp:274 already uses it. This just makes the CLI parser consistent with that.

Changes `hardware_concurrency()` -> `cpu_get_num_math()` in all four thread args (`--threads`, `--threads-batch`, `--threads-draft`, `--threads-batch-draft`).

Fixes #19110