### PR TITLE
server: include api_prefix in public_endpoints set

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -137,17 +137,21 @@ bool server_http_context::init(const common_params & params) {
     // Middlewares
     //
 
-    auto middleware_validate_api_key = [api_keys = params.api_keys](const httplib::Request & req, httplib::Response & res) {
-        static const std::unordered_set<std::string> public_endpoints = {
-            "/health",
-            "/v1/health",
-            "/models",
-            "/v1/models",
-            "/",
-            "/index.html",
-            "/bundle.js",
-            "/bundle.css",
-        };
+    // Public endpoints (skip --api-key validation). Built at init time so the
+    // set reflects --api-prefix; otherwise paths under a non-empty prefix
+    // (e.g. /myapi/index.html) wouldn't match and the WebUI would 401.
+    const std::unordered_set<std::string> public_endpoints = {
+        params.api_prefix + "/health",
+        params.api_prefix + "/v1/health",
+        params.api_prefix + "/models",
+        params.api_prefix + "/v1/models",
+        params.api_prefix + "/",
+        params.api_prefix + "/index.html",
+        params.api_prefix + "/bundle.js",
+        params.api_prefix + "/bundle.css",
+    };
+
+    auto middleware_validate_api_key = [api_keys = params.api_keys, public_endpoints = public_endpoints](const httplib::Request & req, httplib::Response & res) {
 
         // If API key is not set, skip validation
         if (api_keys.empty()) {


### PR DESCRIPTION
### Summary

Fixes #22474: when `--api-key` and `--api-prefix` are both set, the bundled WebUI cannot load in a browser. Static file paths and `/health` requests served under the prefix (e.g. `/myapi/index.html`, `/myapi/health`) are not in the public endpoints allowlist, so the auth middleware returns 401 for everything.

### Changes

`tools/server/server-http.cpp`: prepend `params.api_prefix` to each entry of the `public_endpoints` set used by `middleware_validate_api_key`. The set is now constructed at server init time (instead of being a `static const` inside the lambda) so it reads runtime params, and is captured by value into the lambda.

### Backward compatibility

When `--api-prefix` is unset (the default empty string), each prefixed path resolves to the original hardcoded value (`"" + "/health" == "/health"`, etc.). No behavior change for existing setups.

### Testing

Built locally and ran:

```bash
llama-server -m <small-model.gguf> --host 127.0.0.1 --port 8080 \
    --api-prefix /test --api-key probe-token
```

Verified:

| Request | Before | After |
|---|---|---|
| `GET /test/health` (no auth) | 401 | **200** ✓ |
| `GET /test/` HTML (no auth) | 401 | **200** ✓ |
| `GET /test/bundle.js` (no auth) | 401 | **200** ✓ |
| `GET /test/v1/models` (no auth, public) | 401 | **200** ✓ |
| `GET /test/v1/embeddings` (no auth) | 401 | 401 ✓ (still gated as expected) |
| `GET /test/v1/embeddings` (correct bearer) | 200 | 200 ✓ |
| `GET /test/v1/embeddings` (wrong bearer) | 401 | 401 ✓ |
| `GET /health` (no `--api-prefix`, default behavior) | 200 | 200 ✓ |

The WebUI loads in a browser as expected, and `/v1/*` endpoints remain protected. No regression for the no-prefix path.
