### PR TITLE
webui: fix slow mic stop and WAV encode

### DIFF
--- a/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
@@ -528,19 +528,15 @@
 
 		if (isRecording) {
 			isRecording = false;
-			const blobPromise = audioRecorder.stopRecording();
-			// Defer the heavy decode and PCM encode to a new task so the button repaints first
-			setTimeout(async () => {
-				try {
-					const audioBlob = await blobPromise;
-					const wavBlob = await convertToWav(audioBlob);
-					const audioFile = createAudioFile(wavBlob);
+			try {
+				const audioBlob = await audioRecorder.stopRecording();
+				const wavBlob = await convertToWav(audioBlob);
+				const audioFile = createAudioFile(wavBlob);
 
-					onFilesAdd?.([audioFile]);
-				} catch (error) {
-					console.error('Failed to stop recording:', error);
-				}
-			}, 0);
+				onFilesAdd?.([audioFile]);
+			} catch (error) {
+				console.error('Failed to stop recording:', error);
+			}
 		} else {
 			try {
 				await audioRecorder.startRecording();

--- a/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
@@ -527,17 +527,20 @@
 		}
 
 		if (isRecording) {
-			try {
-				const audioBlob = await audioRecorder.stopRecording();
-				const wavBlob = await convertToWav(audioBlob);
-				const audioFile = createAudioFile(wavBlob);
+			isRecording = false;
+			const blobPromise = audioRecorder.stopRecording();
+			// Defer the heavy decode and PCM encode to a new task so the button repaints first
+			setTimeout(async () => {
+				try {
+					const audioBlob = await blobPromise;
+					const wavBlob = await convertToWav(audioBlob);
+					const audioFile = createAudioFile(wavBlob);
 
-				onFilesAdd?.([audioFile]);
-				isRecording = false;
-			} catch (error) {
-				console.error('Failed to stop recording:', error);
-				isRecording = false;
-			}
+					onFilesAdd?.([audioFile]);
+				} catch (error) {
+					console.error('Failed to stop recording:', error);
+				}
+			}, 0);
 		} else {
 			try {
 				await audioRecorder.startRecording();

--- a/tools/server/webui/src/lib/utils/audio-recording.ts
+++ b/tools/server/webui/src/lib/utils/audio-recording.ts
@@ -43,27 +43,48 @@ export class AudioRecorder {
 
 	async stopRecording(): Promise<Blob> {
 		return new Promise((resolve, reject) => {
-			if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') {
+			const recorder = this.mediaRecorder;
+			const chunks = this.audioChunks;
+			const stream = this.stream;
+
+			if (!recorder || recorder.state === 'inactive') {
 				reject(new Error('No active recording to stop'));
 				return;
 			}
 
-			this.mediaRecorder.onstop = () => {
-				const mimeType = this.mediaRecorder?.mimeType || MimeTypeAudio.WAV;
-				const audioBlob = new Blob(this.audioChunks, { type: mimeType });
+			// Detach instance state right away so a new startRecording can take over without race
+			this.mediaRecorder = null;
+			this.audioChunks = [];
+			this.stream = null;
+			this.recordingState = false;
 
-				this.cleanup();
+			recorder.onstop = () => {
+				const audioBlob = new Blob(chunks, {
+					type: recorder.mimeType || MimeTypeAudio.WAV
+				});
+
+				if (stream) {
+					for (const track of stream.getTracks()) {
+						track.stop();
+					}
+				}
 
 				resolve(audioBlob);
 			};
 
-			this.mediaRecorder.onerror = (event) => {
+			recorder.onerror = (event) => {
 				console.error('Recording error:', event);
-				this.cleanup();
+
+				if (stream) {
+					for (const track of stream.getTracks()) {
+						track.stop();
+					}
+				}
+
 				reject(new Error('Recording failed'));
 			};
 
-			this.mediaRecorder.stop();
+			recorder.stop();
 		});
 	}
 

--- a/tools/server/webui/src/lib/utils/audio-recording.ts
+++ b/tools/server/webui/src/lib/utils/audio-recording.ts
@@ -93,10 +93,26 @@ export class AudioRecorder {
 	}
 
 	cancelRecording(): void {
-		if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
-			this.mediaRecorder.stop();
+		const recorder = this.mediaRecorder;
+		const stream = this.stream;
+
+		this.mediaRecorder = null;
+		this.audioChunks = [];
+		this.stream = null;
+		this.recordingState = false;
+
+		if (recorder && recorder.state !== 'inactive') {
+			// Drop the original handlers so the pending stop event does not touch the instance
+			recorder.onstop = null;
+			recorder.onerror = null;
+			recorder.stop();
 		}
-		this.cleanup();
+
+		if (stream) {
+			for (const track of stream.getTracks()) {
+				track.stop();
+			}
+		}
 	}
 
 	private initializeRecorder(stream: MediaStream): void {
@@ -131,19 +147,6 @@ export class AudioRecorder {
 			this.recordingState = false;
 		};
 	}
-
-	private cleanup(): void {
-		if (this.stream) {
-			for (const track of this.stream.getTracks()) {
-				track.stop();
-			}
-
-			this.stream = null;
-		}
-		this.mediaRecorder = null;
-		this.audioChunks = [];
-		this.recordingState = false;
-	}
 }
 
 export async function convertToWav(audioBlob: Blob): Promise<Blob> {
@@ -157,13 +160,12 @@ export async function convertToWav(audioBlob: Blob): Promise<Blob> {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
 
-		const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-
-		const wavBlob = audioBufferToWav(audioBuffer);
-
-		audioContext.close();
-
-		return wavBlob;
+		try {
+			const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+			return audioBufferToWav(audioBuffer);
+		} finally {
+			audioContext.close();
+		}
 	} catch (error) {
 		console.error('Failed to convert audio to WAV:', error);
 		return audioBlob;

--- a/tools/server/webui/src/lib/utils/audio-recording.ts
+++ b/tools/server/webui/src/lib/utils/audio-recording.ts
@@ -203,12 +203,20 @@ function audioBufferToWav(buffer: AudioBuffer): Blob {
 	writeString(36, 'data'); // Subchunk2ID
 	view.setUint32(40, dataSize, true); // Subchunk2Size
 
-	let offset = 44;
+	// Cache channel arrays, write PCM via Int16Array (native little-endian, matches WAV)
+	const channels: Float32Array[] = new Array(numberOfChannels);
+	for (let c = 0; c < numberOfChannels; c++) {
+		channels[c] = buffer.getChannelData(c);
+	}
+
+	const pcm = new Int16Array(arrayBuffer, 44, length * numberOfChannels);
+	let p = 0;
 	for (let i = 0; i < length; i++) {
-		for (let channel = 0; channel < numberOfChannels; channel++) {
-			const sample = Math.max(-1, Math.min(1, buffer.getChannelData(channel)[i]));
-			view.setInt16(offset, sample * 0x7fff, true);
-			offset += 2;
+		for (let c = 0; c < numberOfChannels; c++) {
+			let s = channels[c][i];
+			if (s > 1) s = 1;
+			else if (s < -1) s = -1;
+			pcm[p++] = s * 0x7fff;
 		}
 	}
 


### PR DESCRIPTION
## Overview

### Two fix:

The first one stops the Stop button from feeling stuck after recording.
The UI now flips immediately on tap, MediaRecorder.stop() runs synchronously,
and the heavy work is deferred to a new task. The AudioRecorder also detaches
its state up front so a fast Stop then Rec does not race the previous onstop.

The second one rewrites the WAV PCM encode loop: hoisted channel arrays,
inline clamp, direct Int16Array write. Same output format, around >10x faster
in practice, which turns the freeze into an imperceptible flash.

## Additional information

### Master (freeze bug)
https://github.com/user-attachments/assets/3050cb27-80de-4771-afe2-efd22424f618

### PR, Essentially this commit https://github.com/ggml-org/llama.cpp/pull/22480/changes/ed199bcde57076d4ca1259ee0003d6dd364525d0, the rest is a refactor which is useful for long audio: not to freeze the main thread :

https://github.com/user-attachments/assets/ef61bd9a-5c57-4566-8aac-9fb70e93766c


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES Opus 4.7 Adaptive / MCP / Disposable Debian container.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
