### PR TITLE
gguf-py: shrink layers or embedding vectors for reducing model size.

### DIFF
--- a/gguf-py/README.md
+++ b/gguf-py/README.md
@@ -32,6 +32,10 @@ pip install gguf[gui]
 
 [gguf/scripts/gguf_editor_gui.py](https://github.com/ggml-org/llama.cpp/blob/master/gguf-py/gguf/scripts/gguf_editor_gui.py) — Allows for viewing, editing, adding, or removing metadata values within a GGUF file as well as viewing its tensors with a Qt interface.
 
+gguf/scripts/shrink_embd.py — To delete some dimensions in gguf model.
+
+gguf/scripts/shrink_layers.py — To delete some layers in gguf model.
+
 ## Development
 Maintainers who participate in development of this package are advised to install it in editable mode:
 

--- a/gguf-py/gguf/scripts/shrink_embd.py
+++ b/gguf-py/gguf/scripts/shrink_embd.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""
+Shrink the embedding dimension of a GGUF model by slicing along the n_embd axis.
+
+In interactive mode (the default), the script loads a GGUF file, displays the
+current embedding dimension, prompts for how to shrink, and asks for an output name.
+
+Batch mode is also supported by passing --new-embd/--drop-first/--drop-last and -o.
+
+Usage:
+    python shrink_embd.py input.gguf                              # interactive
+    python shrink_embd.py input.gguf -n 500 -o output.gguf        # keep first 500 dims
+    python shrink_embd.py input.gguf -n 500 --offset 500 -o out.gguf  # keep dims 500-999
+    python shrink_embd.py input.gguf --drop-first 500 -o out.gguf     # drop first 500 dims
+    python shrink_embd.py input.gguf --drop-last 500 -o out.gguf      # drop last 500 dims
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+from tqdm import tqdm
+
+# Allow running from the gguf-py directory directly
+if "NO_LOCAL_GGUF" not in os.environ and (Path(__file__).parent.parent / 'gguf').exists():
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import gguf
+from gguf.constants import GGML_QUANT_SIZES, GGMLQuantizationType
+
+logger = logging.getLogger("shrink-embd")
+
+_UNQUANTIZED_TYPES = frozenset({
+    GGMLQuantizationType.F16, GGMLQuantizationType.F32, GGMLQuantizationType.F64,
+    GGMLQuantizationType.I8, GGMLQuantizationType.I16, GGMLQuantizationType.I32,
+    GGMLQuantizationType.I64, GGMLQuantizationType.BF16,
+})
+
+
+def get_field_data(reader: gguf.GGUFReader, key: str):
+    field = reader.get_field(key)
+    return field.contents() if field else None
+
+
+def get_n_embd(reader: gguf.GGUFReader) -> int:
+    """Read the embedding dimension from metadata."""
+    arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
+    n_embd = get_field_data(reader, gguf.Keys.LLM.EMBEDDING_LENGTH.format(arch=arch))
+    if n_embd is None:
+        logger.error(f"Cannot find {arch}.embedding_length in model metadata")
+        sys.exit(1)
+    return n_embd
+
+
+def _is_quantized(qtype: GGMLQuantizationType) -> bool:
+    return qtype not in _UNQUANTIZED_TYPES
+
+
+def _embd_axes(name: str, gguf_shape: list[int], n_embd: int) -> list[int]:
+    """Return the GGUF axes that represent the embedding dimension.
+
+    Uses tensor naming heuristics to avoid misidentifying dimensions that
+    coincidentally equal n_embd (e.g. n_ff == n_embd in some models).
+    """
+    axes = []
+    ndim = len(gguf_shape)
+
+    for axis, dim in enumerate(gguf_shape):
+        if dim != n_embd:
+            continue
+
+        # For 1D tensors, the only dimension is n_embd.
+        if ndim == 1:
+            axes.append(axis)
+            continue
+
+        # -- FFN weight tensors -------------------------------------------
+        # When n_ff == n_embd, we must distinguish them by position:
+        #
+        #   ffn_gate(_exps), ffn_up(_exps): [n_embd, n_ff, ...]
+        #     axis 0 = n_embd,  axis 1 = n_ff (NOT n_embd)
+        #   ffn_down(_exps):                [n_ff, n_embd, ...]
+        #     axis 0 = n_ff (NOT n_embd),  axis 1 = n_embd
+        #
+        if 'ffn_gate' in name or 'ffn_up' in name:
+            # Bias for gate/up: [n_ff, n_expert] – no n_embd dimension at all
+            if name.endswith('.bias'):
+                continue
+            if axis == 1:
+                continue  # axis 1 is n_ff, not n_embd
+
+        elif 'ffn_down' in name:
+            # Bias for down: [n_embd, n_expert] – axis 0 IS n_embd
+            if not name.endswith('.bias'):
+                if axis == 0:
+                    continue  # axis 0 is n_ff, not n_embd
+
+        axes.append(axis)
+
+    return axes
+
+
+def _slice_tensor_data(
+    tensor: gguf.ReaderTensor,
+    n_embd: int,
+    offset: int,
+    new_n_embd: int,
+) -> tuple[np.ndarray, list[int], int]:
+    """
+    Slice a tensor along embedding dimension axes.
+
+    Returns (sliced_data, new_gguf_shape, new_nbytes).
+    """
+    gguf_shape = tensor.shape.tolist()  # [d0, d1, ...] in GGUF order
+
+    # Determine which axes carry the embedding dimension.
+    embd_axes = _embd_axes(tensor.name, gguf_shape, n_embd)
+
+    # Build numpy slice tuple. numpy axes are reversed from GGUF order:
+    #   GGUF [d0, d1, d2]  <->  numpy (d2, d1, d0)
+    ndim = len(gguf_shape)
+    np_slices = [slice(None)] * ndim
+    new_gguf_shape = list(gguf_shape)
+
+    for gguf_axis in embd_axes:
+        np_axis = ndim - 1 - gguf_axis
+        np_slices[np_axis] = slice(offset, offset + new_n_embd)
+        new_gguf_shape[gguf_axis] = new_n_embd
+
+    np_slices = tuple(np_slices)
+
+    if not _is_quantized(tensor.tensor_type):
+        sliced = tensor.data[np_slices].copy()
+        return sliced, new_gguf_shape, sliced.nbytes
+
+    # Quantized: data is uint8 with byte shape.
+    # Only the last numpy axis (first GGUF dim) is block-encoded.
+    block_size, type_size = GGML_QUANT_SIZES[tensor.tensor_type]
+    byte_slices = list(np_slices)
+    num_sliced_axes = 0
+
+    for np_axis in range(ndim):
+        s = np_slices[np_axis]
+        if s == slice(None):
+            continue
+        num_sliced_axes += 1
+        if np_axis == ndim - 1:
+            # Last numpy axis = first GGUF axis = quantized dimension.
+            # Must be block-aligned.
+            start_elems = s.start
+            stop_elems = s.stop
+            if start_elems % block_size != 0:
+                logger.error(
+                    f"Tensor '{tensor.name}': slice start {start_elems} must be "
+                    f"a multiple of {tensor.tensor_type.name} block size ({block_size})"
+                )
+                sys.exit(1)
+            if stop_elems % block_size != 0:
+                logger.error(
+                    f"Tensor '{tensor.name}': slice end {stop_elems} must be "
+                    f"a multiple of {tensor.tensor_type.name} block size ({block_size})"
+                )
+                sys.exit(1)
+            byte_start = (start_elems // block_size) * type_size
+            byte_stop = (stop_elems // block_size) * type_size
+            byte_slices[np_axis] = slice(byte_start, byte_stop)
+
+    if num_sliced_axes == 0:
+        # No change needed
+        sliced = tensor.data.copy()
+        nbytes = tensor.n_bytes
+    else:
+        sliced = tensor.data[tuple(byte_slices)].copy()
+        nbytes = int(np.prod(sliced.shape))
+
+    return sliced, new_gguf_shape, nbytes
+
+
+def shrink_embd(
+    reader: gguf.GGUFReader,
+    writer: gguf.GGUFWriter,
+    n_embd: int,
+    offset: int,
+    new_n_embd: int,
+) -> dict[str, tuple[np.ndarray, int]]:
+    """
+    Copy metadata and slice tensors to reduce embedding dimension.
+
+    Returns a dict mapping tensor name -> (sliced_data, nbytes) for writing.
+    """
+    arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
+    embd_key = gguf.Keys.LLM.EMBEDDING_LENGTH.format(arch=arch)
+    embd_out_key = gguf.Keys.LLM.EMBEDDING_LENGTH_OUT.format(arch=arch)
+    features_key = gguf.Keys.LLM.FEATURES_LENGTH.format(arch=arch)
+
+    logger.info(f"Shrinking embedding dim from {n_embd} to {new_n_embd} (offset={offset})")
+
+    # Copy metadata, adjusting embedding length keys
+    kv_count = 0
+    for field in reader.fields.values():
+        if field.name == gguf.Keys.General.ARCHITECTURE or field.name.startswith('GGUF.'):
+            continue
+
+        val_type = field.types[0]
+        sub_type = field.types[-1] if val_type == gguf.GGUFValueType.ARRAY else None
+        val = field.contents()
+
+        if field.name == embd_key:
+            val = new_n_embd
+        elif field.name == embd_out_key:
+            val = new_n_embd
+        elif field.name == features_key and isinstance(val, int) and val == n_embd:
+            val = new_n_embd
+
+        writer.add_key_value(field.name, val, val_type, sub_type)
+        kv_count += 1
+
+    # Slice and register tensors
+    sliced_data: dict[str, tuple[np.ndarray, int]] = {}
+    kept_count = 0
+    modified_count = 0
+
+    for tensor in reader.tensors:
+        data, new_gguf_shape, new_nbytes = _slice_tensor_data(
+            tensor, n_embd, offset, new_n_embd,
+        )
+
+        # Check if tensor was actually modified
+        if new_gguf_shape != tensor.shape.tolist():
+            modified_count += 1
+        kept_count += 1
+
+        # add_tensor_info expects shape in numpy order (matching tensor.shape convention)
+        writer.add_tensor_info(
+            tensor.name,
+            list(data.shape),
+            data.dtype,
+            new_nbytes,
+            raw_dtype=tensor.tensor_type if _is_quantized(tensor.tensor_type) else None,
+        )
+        sliced_data[tensor.name] = (data, new_nbytes)
+
+    logger.info(f"Metadata keys copied: {kv_count}")
+    logger.info(f"Tensors kept: {kept_count}, modified: {modified_count}")
+
+    return sliced_data
+
+
+def write_output(
+    reader: gguf.GGUFReader,
+    writer: gguf.GGUFWriter,
+    sliced_data: dict[str, tuple[np.ndarray, int]],
+) -> None:
+    """Write the GGUF file with sliced tensor data."""
+    total_bytes = sum(nbytes for _, nbytes in sliced_data.values())
+    bar = tqdm(desc="Writing", total=total_bytes, unit="byte", unit_scale=True)
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_ti_data_to_file()
+
+    for tensor in reader.tensors:
+        data, _ = sliced_data[tensor.name]
+        writer.write_tensor_data(data, tensor_endianess=reader.endianess)
+        bar.update(data.nbytes)
+
+    writer.close()
+    bar.close()
+
+
+def parse_positive_int(s: str) -> int:
+    """Parse a positive integer, raising ValueError on failure."""
+    val = int(s)
+    if val <= 0:
+        raise ValueError(f"Value must be positive, got {val}")
+    return val
+
+
+def resolve_slice_params(
+    args: argparse.Namespace,
+    n_embd: int,
+) -> tuple[int, int]:
+    """Resolve CLI args to (offset, new_n_embd)."""
+    if args.new_embd is not None:
+        # --new-embd N [--offset O]
+        new_n_embd = args.new_embd
+        offset = args.offset
+        if offset + new_n_embd > n_embd:
+            logger.error(
+                f"Slice [{offset}:{offset + new_n_embd}] exceeds n_embd={n_embd}"
+            )
+            sys.exit(1)
+        return offset, new_n_embd
+    elif args.drop_first is not None:
+        drop = args.drop_first
+        if drop >= n_embd:
+            logger.error(f"Cannot drop all {n_embd} embedding dimensions")
+            sys.exit(1)
+        return drop, n_embd - drop
+    elif args.drop_last is not None:
+        drop = args.drop_last
+        if drop >= n_embd:
+            logger.error(f"Cannot drop all {n_embd} embedding dimensions")
+            sys.exit(1)
+        return 0, n_embd - drop
+    else:
+        # Should not reach here if called from main
+        return 0, n_embd
+
+
+def prompt_embd(n_embd: int) -> tuple[int, int]:
+    """Prompt the user for how to shrink the embedding dimension."""
+    print(f"\nCurrent embedding dimension: {n_embd}")
+    print()
+    while True:
+        raw = input(
+            f"How to shrink? (e.g.: 'n=500' keep first 500, "
+            f"'drop-first=500', 'drop-last=500', "
+            f"'n=500,offset=500'): "
+        ).strip()
+        if raw == '':
+            # Default: keep first half
+            new_n = n_embd // 2
+            print(f"Defaulting to: keep first {new_n} dimensions")
+            return 0, new_n
+
+        # Parse key=value pairs
+        kwargs: dict[str, int] = {}
+        for part in raw.split(','):
+            part = part.strip()
+            if '=' not in part:
+                print(f"Invalid format. Use key=value pairs (e.g., 'n=500')")
+                break
+            k, v = part.split('=', 1)
+            k = k.strip().lower()
+            try:
+                kwargs[k] = int(v.strip())
+            except ValueError:
+                print(f"Invalid integer value: {v}")
+                break
+        else:
+            # All parts parsed successfully
+            if 'drop-first' in kwargs:
+                drop = kwargs['drop-first']
+                if drop >= n_embd:
+                    print(f"Cannot drop all {n_embd} dimensions")
+                    continue
+                return drop, n_embd - drop
+            elif 'drop-last' in kwargs:
+                drop = kwargs['drop-last']
+                if drop >= n_embd:
+                    print(f"Cannot drop all {n_embd} dimensions")
+                    continue
+                return 0, n_embd - drop
+            elif 'n' in kwargs:
+                new_n = kwargs['n']
+                offset = kwargs.get('offset', 0)
+                if offset + new_n > n_embd:
+                    print(f"Slice [{offset}:{offset+new_n}] exceeds n_embd={n_embd}")
+                    continue
+                return offset, new_n
+            else:
+                print("Unknown option. Use 'n', 'drop-first', or 'drop-last'.")
+
+
+def prompt_output(input_path: Path) -> Path:
+    """Prompt the user for the output file path."""
+    print()
+    stem = input_path.stem
+    default = input_path.with_name(f"{stem}-shrunk-embd.gguf")
+    raw = input(f"Output file name [{default}]: ").strip()
+    if raw == '':
+        return default
+    out = Path(raw)
+    if out.suffix != '.gguf':
+        out = out.with_suffix('.gguf')
+    return out
+
+
+def run_interactive(input_path: Path, reader: gguf.GGUFReader) -> None:
+    arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
+    n_embd = get_n_embd(reader)
+
+    print(f"\nModel architecture: {arch}")
+    print(f"Current embedding dimension: {n_embd}")
+
+    offset, new_n_embd = prompt_embd(n_embd)
+    output_path = prompt_output(input_path)
+
+    if output_path.exists():
+        ans = input(f"File '{output_path}' already exists. Overwrite? [y/N]: ").strip().lower()
+        if ans != 'y':
+            print("Aborted.")
+            sys.exit(0)
+
+    _do_write(input_path, reader, output_path, n_embd, offset, new_n_embd)
+
+
+def run_batch(
+    input_path: Path,
+    reader: gguf.GGUFReader,
+    output_path: Path,
+    n_embd: int,
+    offset: int,
+    new_n_embd: int,
+) -> None:
+    if output_path.exists():
+        logger.warning(f"File '{output_path}' already exists, will be overwritten")
+    _do_write(input_path, reader, output_path, n_embd, offset, new_n_embd)
+
+
+def _do_write(
+    input_path: Path,
+    reader: gguf.GGUFReader,
+    output_path: Path,
+    n_embd: int,
+    offset: int,
+    new_n_embd: int,
+) -> None:
+    arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
+    alignment = get_field_data(reader, gguf.Keys.General.ALIGNMENT)
+
+    logger.info(f"Writing: {output_path}")
+    writer = gguf.GGUFWriter(str(output_path), arch=arch, endianess=reader.endianess)
+
+    if alignment is not None:
+        writer.data_alignment = alignment
+
+    sliced_data = shrink_embd(reader, writer, n_embd, offset, new_n_embd)
+    write_output(reader, writer, sliced_data)
+    logger.info("Done")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Shrink the embedding dimension of a GGUF model",
+    )
+    parser.add_argument("input", type=Path, help="Input GGUF file")
+    parser.add_argument("-o", "--output", type=Path, default=None, help="Output GGUF file")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-n", "--new-embd", type=parse_positive_int, default=None,
+                       help="New embedding dimension (keep first N dims)")
+    group.add_argument("--drop-first", type=parse_positive_int, default=None,
+                       help="Number of embedding dimensions to drop from the start")
+    group.add_argument("--drop-last", type=parse_positive_int, default=None,
+                       help="Number of embedding dimensions to drop from the end")
+
+    parser.add_argument("--offset", type=int, default=0,
+                        help="Starting dimension offset (used with -n/--new-embd)")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Increase output verbosity")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    if not args.input.is_file():
+        logger.error(f"Input file not found: {args.input}")
+        sys.exit(1)
+
+    logger.info(f"Loading: {args.input}")
+    reader = gguf.GGUFReader(args.input, 'r')
+    n_embd = get_n_embd(reader)
+
+    # Determine batch vs interactive mode
+    has_embd_arg = args.new_embd is not None or args.drop_first is not None or args.drop_last is not None
+
+    if has_embd_arg and args.output is not None:
+        offset, new_n_embd = resolve_slice_params(args, n_embd)
+        logger.info(f"New embedding dim: {new_n_embd} (offset={offset})")
+        run_batch(args.input, reader, args.output, n_embd, offset, new_n_embd)
+    elif has_embd_arg or args.output is not None:
+        parser.error("-n/--new-embd/--drop-first/--drop-last and -o/--output must be used together for batch mode")
+    else:
+        run_interactive(args.input, reader)
+
+
+if __name__ == '__main__':
+    main()

--- a/gguf-py/gguf/scripts/shrink_layers.py
+++ b/gguf-py/gguf/scripts/shrink_layers.py
@@ -12,6 +12,7 @@ Usage:
     python shrink_layers.py input.gguf -l 0 -o output.gguf     # keep layer 0 only
     python shrink_layers.py input.gguf -l 0,5,10 -o out.gguf   # keep layers 0, 5, 10
     python shrink_layers.py input.gguf -d 0,5 -o out.gguf      # delete layers 0, 5
+    python shrink_layers.py model_dir/ -l 0 -o output.gguf     # sharded model directory
 """
 from __future__ import annotations
 
@@ -34,6 +35,8 @@ import gguf
 logger = logging.getLogger("shrink-layers")
 
 BLOB_RE = re.compile(r'^blk\.(\d+)\.')
+
+SPLIT_KEYS = {"split.no", "split.count", "split.tensors.count"}
 
 
 def get_field_data(reader: gguf.GGUFReader, key: str):
@@ -63,28 +66,45 @@ def format_counts(n: int) -> str:
     return str(n)
 
 
-def analyze_model(reader: gguf.GGUFReader) -> tuple[str, int, dict[int, int], dict[int, int]]:
+def find_input_files(path: Path) -> list[Path]:
+    """Return sorted .gguf files from a file or directory path."""
+    if path.is_file():
+        return [path]
+    if path.is_dir():
+        files = sorted(path.glob("*.gguf"))
+        if not files:
+            logger.error(f"No .gguf files found in directory: {path}")
+            sys.exit(1)
+        return files
+    logger.error(f"Input not found: {path}")
+    sys.exit(1)
+
+
+def analyze_model(readers: list[gguf.GGUFReader]) -> tuple[str, int, dict[int, int], dict[int, int]]:
     """Return (arch, block_count, per_layer_params, per_layer_bytes)."""
+    reader = readers[0]
     arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
 
     block_count_key = gguf.Keys.LLM.BLOCK_COUNT.format(arch=arch)
     block_count = get_field_data(reader, block_count_key)
     if block_count is None:
         max_blk = -1
-        for tensor in reader.tensors:
-            m = BLOB_RE.match(tensor.name)
-            if m:
-                max_blk = max(max_blk, int(m.group(1)))
+        for r in readers:
+            for tensor in r.tensors:
+                m = BLOB_RE.match(tensor.name)
+                if m:
+                    max_blk = max(max_blk, int(m.group(1)))
         block_count = max_blk + 1
 
     per_layer_params = defaultdict(int)
     per_layer_bytes = defaultdict(int)
-    for tensor in reader.tensors:
-        m = BLOB_RE.match(tensor.name)
-        if m:
-            idx = int(m.group(1))
-            per_layer_params[idx] += tensor.n_elements
-            per_layer_bytes[idx] += tensor.n_bytes
+    for r in readers:
+        for tensor in r.tensors:
+            m = BLOB_RE.match(tensor.name)
+            if m:
+                idx = int(m.group(1))
+                per_layer_params[idx] += tensor.n_elements
+                per_layer_bytes[idx] += tensor.n_bytes
 
     return arch, block_count, dict(per_layer_params), dict(per_layer_bytes)
 
@@ -105,20 +125,25 @@ def remap_tensor_name(name: str, remap: dict[int, int]) -> str:
     return name.replace(f'blk.{old_idx}.', f'blk.{remap[old_idx]}.', 1)
 
 
-def shrink_layers(reader: gguf.GGUFReader, writer: gguf.GGUFWriter, keep_layers: set[int]) -> None:
+def shrink_layers(readers: list[gguf.GGUFReader], writer: gguf.GGUFWriter, keep_layers: set[int]) -> None:
+    reader = readers[0]
     arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
     block_count_key = gguf.Keys.LLM.BLOCK_COUNT.format(arch=arch)
+    original_block_count = get_field_data(reader, block_count_key)
 
     new_block_count = len(keep_layers)
     remap = build_remap(keep_layers)
-    logger.info(f"Keeping {new_block_count} layer(s): {sorted(keep_layers)}")
+    sorted_keep = sorted(keep_layers)
+    logger.info(f"Keeping {new_block_count} layer(s): {sorted_keep}")
     if remap != {k: k for k in keep_layers}:
         logger.info(f"Layer renumbering: {remap}")
 
-    # Copy metadata, adjusting block count
+    # Copy metadata from first reader, skip split keys since output is a single file
     kv_count = 0
     for field in reader.fields.values():
         if field.name == gguf.Keys.General.ARCHITECTURE or field.name.startswith('GGUF.'):
+            continue
+        if field.name in SPLIT_KEYS:
             continue
 
         val_type = field.types[0]
@@ -133,58 +158,67 @@ def shrink_layers(reader: gguf.GGUFReader, writer: gguf.GGUFWriter, keep_layers:
         if field.name == leading_dense_key:
             val = min(val, new_block_count)
 
+        # Slice per-layer arrays to match kept layers
+        if (original_block_count is not None
+                and hasattr(val, '__len__')
+                and not isinstance(val, (str, bytes))
+                and len(val) == original_block_count):
+            val = [val[i] for i in sorted_keep]
+
         writer.add_key_value(field.name, val, val_type, sub_type)
         kv_count += 1
 
-    # Filter and renumber tensors
+    # Filter and renumber tensors from all readers
     kept_tensors = 0
     removed_tensors = 0
-    for tensor in reader.tensors:
-        new_name = remap_tensor_name(tensor.name, remap)
-        m = BLOB_RE.match(tensor.name)
-        if m:
-            if int(m.group(1)) in keep_layers:
+    for r in readers:
+        for tensor in r.tensors:
+            new_name = remap_tensor_name(tensor.name, remap)
+            m = BLOB_RE.match(tensor.name)
+            if m:
+                if int(m.group(1)) in keep_layers:
+                    kept_tensors += 1
+                    writer.add_tensor_info(
+                        new_name, tensor.data.shape, tensor.data.dtype,
+                        tensor.data.nbytes, tensor.tensor_type,
+                    )
+                else:
+                    removed_tensors += 1
+            else:
                 kept_tensors += 1
                 writer.add_tensor_info(
                     new_name, tensor.data.shape, tensor.data.dtype,
                     tensor.data.nbytes, tensor.tensor_type,
                 )
-            else:
-                removed_tensors += 1
-        else:
-            kept_tensors += 1
-            writer.add_tensor_info(
-                new_name, tensor.data.shape, tensor.data.dtype,
-                tensor.data.nbytes, tensor.tensor_type,
-            )
 
     logger.info(f"Metadata keys copied: {kv_count}")
     logger.info(f"Tensors kept: {kept_tensors}, removed: {removed_tensors}")
 
-    write_output(reader, writer, keep_layers, remap)
+    write_output(readers, writer, keep_layers, remap)
 
 
-def write_output(reader: gguf.GGUFReader, writer: gguf.GGUFWriter,
+def write_output(readers: list[gguf.GGUFReader], writer: gguf.GGUFWriter,
                  keep_layers: set[int], remap: dict[int, int]) -> None:
     is_kept = lambda name: (  # noqa: E731
         (m := BLOB_RE.match(name)) is None or int(m.group(1)) in keep_layers
     )
 
-    total_bytes = sum(tensor.n_bytes for tensor in reader.tensors if is_kept(tensor.name))
+    total_bytes = 0
+    for r in readers:
+        total_bytes += sum(tensor.n_bytes for tensor in r.tensors if is_kept(tensor.name))
     bar = tqdm(desc="Writing", total=total_bytes, unit="byte", unit_scale=True)
 
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
     writer.write_ti_data_to_file()
 
-    # Write tensor data in the same order as add_tensor_info was called.
-    # write_tensor_data pops from the writer's internal dict in order, so we
-    # must iterate reader.tensors in the same sequence.
-    for tensor in reader.tensors:
-        if not is_kept(tensor.name):
-            continue
-        writer.write_tensor_data(tensor.data, tensor_endianess=reader.endianess)
-        bar.update(tensor.n_bytes)
+    for r in readers:
+        for tensor in r.tensors:
+            if not is_kept(tensor.name):
+                continue
+            logger.info(f"  {tensor.name}  ({r.data.filename})")
+            writer.write_tensor_data(tensor.data, tensor_endianess=r.endianess)
+            bar.update(tensor.n_bytes)
 
     writer.close()
     bar.close()
@@ -205,7 +239,7 @@ def parse_layers_arg(s: str) -> set[int]:
     return layers
 
 
-def _parse_and_validate(arg: str, reader: gguf.GGUFReader) -> set[int]:
+def _parse_and_validate(arg: str, readers: list[gguf.GGUFReader]) -> set[int]:
     """Parse a layer arg string and validate against the model's total layers."""
     try:
         layers = parse_layers_arg(arg)
@@ -213,7 +247,7 @@ def _parse_and_validate(arg: str, reader: gguf.GGUFReader) -> set[int]:
         logger.error(f"Invalid layers format: {arg}")
         sys.exit(1)
 
-    _, total_layers, *_ = analyze_model(reader)
+    _, total_layers, *_ = analyze_model(readers)
     invalid = [i for i in layers if i < 0 or i >= total_layers]
     if invalid:
         logger.error(f"Invalid layer indices: {invalid} (valid range: 0-{total_layers - 1})")
@@ -273,8 +307,8 @@ def prompt_output(input_path: Path) -> Path:
     return out
 
 
-def run_interactive(input_path: Path, reader: gguf.GGUFReader) -> None:
-    arch, total_layers, per_layer_params, per_layer_bytes = analyze_model(reader)
+def run_interactive(input_path: Path, readers: list[gguf.GGUFReader]) -> None:
+    arch, total_layers, per_layer_params, per_layer_bytes = analyze_model(readers)
 
     total_params = sum(per_layer_params.values())
     total_bytes = sum(per_layer_bytes.values())
@@ -295,16 +329,17 @@ def run_interactive(input_path: Path, reader: gguf.GGUFReader) -> None:
             print("Aborted.")
             sys.exit(0)
 
-    _do_write(input_path, reader, output_path, keep_layers)
+    _do_write(input_path, readers, output_path, keep_layers)
 
 
-def run_batch(input_path: Path, reader: gguf.GGUFReader, output_path: Path, layers: set[int]) -> None:
+def run_batch(input_path: Path, readers: list[gguf.GGUFReader], output_path: Path, layers: set[int]) -> None:
     if output_path.exists():
         logger.warning(f"File '{output_path}' already exists, will be overwritten")
-    _do_write(input_path, reader, output_path, layers)
+    _do_write(input_path, readers, output_path, layers)
 
 
-def _do_write(input_path: Path, reader: gguf.GGUFReader, output_path: Path, keep_layers: set[int]) -> None:
+def _do_write(input_path: Path, readers: list[gguf.GGUFReader], output_path: Path, keep_layers: set[int]) -> None:
+    reader = readers[0]
     arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
     alignment = get_field_data(reader, gguf.Keys.General.ALIGNMENT)
 
@@ -314,7 +349,7 @@ def _do_write(input_path: Path, reader: gguf.GGUFReader, output_path: Path, keep
     if alignment is not None:
         writer.data_alignment = alignment
 
-    shrink_layers(reader, writer, keep_layers)
+    shrink_layers(readers, writer, keep_layers)
     logger.info("Done")
 
 
@@ -322,7 +357,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Shrink a GGUF model by keeping only selected transformer layers",
     )
-    parser.add_argument("input", type=Path, help="Input GGUF file")
+    parser.add_argument("input", type=Path, help="Input GGUF file or directory with sharded .gguf files")
     parser.add_argument("-o", "--output", type=Path, default=None, help="Output GGUF file")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-l", "--layers", type=str, default=None,
@@ -335,31 +370,29 @@ def main() -> None:
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    if not args.input.is_file():
-        logger.error(f"Input file not found: {args.input}")
-        sys.exit(1)
+    input_files = find_input_files(args.input)
 
-    logger.info(f"Loading: {args.input}")
-    reader = gguf.GGUFReader(args.input, 'r')
+    logger.info(f"Loading {len(input_files)} file(s) from: {args.input}")
+    readers = [gguf.GGUFReader(str(f), 'r') for f in input_files]
 
     # Batch mode: --layers/--delete and --output provided
     if args.layers is not None and args.output is not None:
-        layers = _parse_and_validate(args.layers, reader)
-        run_batch(args.input, reader, args.output, layers)
+        layers = _parse_and_validate(args.layers, readers)
+        run_batch(args.input, readers, args.output, layers)
     elif args.delete is not None and args.output is not None:
-        delete_layers = _parse_and_validate(args.delete, reader)
-        _, total_layers, *_ = analyze_model(reader)
+        delete_layers = _parse_and_validate(args.delete, readers)
+        _, total_layers, *_ = analyze_model(readers)
         keep_layers = set(range(total_layers)) - delete_layers
         if not keep_layers:
             logger.error("Cannot delete all layers")
             sys.exit(1)
         logger.info(f"Deleting {len(delete_layers)} layer(s): {sorted(delete_layers)}")
-        run_batch(args.input, reader, args.output, keep_layers)
+        run_batch(args.input, readers, args.output, keep_layers)
     elif args.layers is not None or args.delete is not None or args.output is not None:
         parser.error("-l/-d and -o must be used together for batch mode")
     else:
         # Interactive mode
-        run_interactive(args.input, reader)
+        run_interactive(args.input, readers)
 
 
 if __name__ == '__main__':

--- a/gguf-py/gguf/scripts/shrink_layers.py
+++ b/gguf-py/gguf/scripts/shrink_layers.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+Shrink a GGUF model by keeping only selected transformer layers.
+
+In interactive mode (the default), the script loads a GGUF file, displays the
+layer structure, prompts for which layers to keep, and asks for an output name.
+
+Batch mode is also supported by passing --layers and the output path.
+
+Usage:
+    python shrink_layers.py input.gguf                         # interactive
+    python shrink_layers.py input.gguf -l 0 -o output.gguf     # keep layer 0 only
+    python shrink_layers.py input.gguf -l 0,5,10 -o out.gguf   # keep layers 0, 5, 10
+    python shrink_layers.py input.gguf -d 0,5 -o out.gguf      # delete layers 0, 5
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from tqdm import tqdm
+
+# Allow running from the gguf-py directory directly
+if "NO_LOCAL_GGUF" not in os.environ and (Path(__file__).parent.parent / 'gguf').exists():
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import gguf
+
+logger = logging.getLogger("shrink-layers")
+
+BLOB_RE = re.compile(r'^blk\.(\d+)\.')
+
+
+def get_field_data(reader: gguf.GGUFReader, key: str):
+    field = reader.get_field(key)
+    return field.contents() if field else None
+
+
+def format_bytes(n: int) -> str:
+    """Return a human-readable byte count."""
+    if n >= 1024 ** 3:
+        return f"{n / 1024 ** 3:.2f} GiB"
+    elif n >= 1024 ** 2:
+        return f"{n / 1024 ** 2:.2f} MiB"
+    elif n >= 1024:
+        return f"{n / 1024:.2f} KiB"
+    return f"{n} B"
+
+
+def format_counts(n: int) -> str:
+    """Return a human-readable parameter count."""
+    if n >= 1000 ** 3:
+        return f"{n / 1000 ** 3:.1f}B"
+    elif n >= 1000 ** 2:
+        return f"{n / 1000 ** 2:.1f}M"
+    elif n >= 1000:
+        return f"{n / 1000:.1f}K"
+    return str(n)
+
+
+def analyze_model(reader: gguf.GGUFReader) -> tuple[str, int, dict[int, int], dict[int, int]]:
+    """Return (arch, block_count, per_layer_params, per_layer_bytes)."""
+    arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
+
+    block_count_key = gguf.Keys.LLM.BLOCK_COUNT.format(arch=arch)
+    block_count = get_field_data(reader, block_count_key)
+    if block_count is None:
+        max_blk = -1
+        for tensor in reader.tensors:
+            m = BLOB_RE.match(tensor.name)
+            if m:
+                max_blk = max(max_blk, int(m.group(1)))
+        block_count = max_blk + 1
+
+    per_layer_params = defaultdict(int)
+    per_layer_bytes = defaultdict(int)
+    for tensor in reader.tensors:
+        m = BLOB_RE.match(tensor.name)
+        if m:
+            idx = int(m.group(1))
+            per_layer_params[idx] += tensor.n_elements
+            per_layer_bytes[idx] += tensor.n_bytes
+
+    return arch, block_count, dict(per_layer_params), dict(per_layer_bytes)
+
+
+def build_remap(keep_layers: set[int]) -> dict[int, int]:
+    """Build a mapping from old layer index to new consecutive index."""
+    return {old: new for new, old in enumerate(sorted(keep_layers))}
+
+
+def remap_tensor_name(name: str, remap: dict[int, int]) -> str:
+    """Rename a block tensor's layer index; returns unchanged if not a block tensor."""
+    m = BLOB_RE.match(name)
+    if m is None:
+        return name
+    old_idx = int(m.group(1))
+    if old_idx not in remap:
+        return name
+    return name.replace(f'blk.{old_idx}.', f'blk.{remap[old_idx]}.', 1)
+
+
+def shrink_layers(reader: gguf.GGUFReader, writer: gguf.GGUFWriter, keep_layers: set[int]) -> None:
+    arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
+    block_count_key = gguf.Keys.LLM.BLOCK_COUNT.format(arch=arch)
+
+    new_block_count = len(keep_layers)
+    remap = build_remap(keep_layers)
+    logger.info(f"Keeping {new_block_count} layer(s): {sorted(keep_layers)}")
+    if remap != {k: k for k in keep_layers}:
+        logger.info(f"Layer renumbering: {remap}")
+
+    # Copy metadata, adjusting block count
+    kv_count = 0
+    for field in reader.fields.values():
+        if field.name == gguf.Keys.General.ARCHITECTURE or field.name.startswith('GGUF.'):
+            continue
+
+        val_type = field.types[0]
+        sub_type = field.types[-1] if val_type == gguf.GGUFValueType.ARRAY else None
+        val = field.contents()
+
+        if field.name == block_count_key:
+            val = new_block_count
+
+        # Cap leading_dense_block_count if present
+        leading_dense_key = gguf.Keys.LLM.LEADING_DENSE_BLOCK_COUNT.format(arch=arch)
+        if field.name == leading_dense_key:
+            val = min(val, new_block_count)
+
+        writer.add_key_value(field.name, val, val_type, sub_type)
+        kv_count += 1
+
+    # Filter and renumber tensors
+    kept_tensors = 0
+    removed_tensors = 0
+    for tensor in reader.tensors:
+        new_name = remap_tensor_name(tensor.name, remap)
+        m = BLOB_RE.match(tensor.name)
+        if m:
+            if int(m.group(1)) in keep_layers:
+                kept_tensors += 1
+                writer.add_tensor_info(
+                    new_name, tensor.data.shape, tensor.data.dtype,
+                    tensor.data.nbytes, tensor.tensor_type,
+                )
+            else:
+                removed_tensors += 1
+        else:
+            kept_tensors += 1
+            writer.add_tensor_info(
+                new_name, tensor.data.shape, tensor.data.dtype,
+                tensor.data.nbytes, tensor.tensor_type,
+            )
+
+    logger.info(f"Metadata keys copied: {kv_count}")
+    logger.info(f"Tensors kept: {kept_tensors}, removed: {removed_tensors}")
+
+    write_output(reader, writer, keep_layers, remap)
+
+
+def write_output(reader: gguf.GGUFReader, writer: gguf.GGUFWriter,
+                 keep_layers: set[int], remap: dict[int, int]) -> None:
+    is_kept = lambda name: (  # noqa: E731
+        (m := BLOB_RE.match(name)) is None or int(m.group(1)) in keep_layers
+    )
+
+    total_bytes = sum(tensor.n_bytes for tensor in reader.tensors if is_kept(tensor.name))
+    bar = tqdm(desc="Writing", total=total_bytes, unit="byte", unit_scale=True)
+
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_ti_data_to_file()
+
+    # Write tensor data in the same order as add_tensor_info was called.
+    # write_tensor_data pops from the writer's internal dict in order, so we
+    # must iterate reader.tensors in the same sequence.
+    for tensor in reader.tensors:
+        if not is_kept(tensor.name):
+            continue
+        writer.write_tensor_data(tensor.data, tensor_endianess=reader.endianess)
+        bar.update(tensor.n_bytes)
+
+    writer.close()
+    bar.close()
+
+
+def parse_layers_arg(s: str) -> set[int]:
+    """Parse a comma-separated list of layer indices."""
+    layers = set()
+    for part in s.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        if '-' in part:
+            a, b = part.split('-', 1)
+            layers.update(range(int(a), int(b) + 1))
+        else:
+            layers.add(int(part))
+    return layers
+
+
+def _parse_and_validate(arg: str, reader: gguf.GGUFReader) -> set[int]:
+    """Parse a layer arg string and validate against the model's total layers."""
+    try:
+        layers = parse_layers_arg(arg)
+    except ValueError:
+        logger.error(f"Invalid layers format: {arg}")
+        sys.exit(1)
+
+    _, total_layers, *_ = analyze_model(reader)
+    invalid = [i for i in layers if i < 0 or i >= total_layers]
+    if invalid:
+        logger.error(f"Invalid layer indices: {invalid} (valid range: 0-{total_layers - 1})")
+        sys.exit(1)
+    if not layers:
+        logger.error("No layers specified")
+        sys.exit(1)
+    return layers
+
+
+def prompt_layers(total_layers: int) -> set[int]:
+    """Prompt the user for which layers to keep (or delete with '-' prefix)."""
+    print()
+    while True:
+        raw = input(f"Layers to keep? (0-{total_layers - 1}, comma-sep, default=0; prefix with '-' to delete): ").strip()
+        if raw == '':
+            return {0}
+
+        delete_mode = raw.startswith('-')
+        if delete_mode:
+            raw = raw[1:].strip()
+
+        try:
+            layers = parse_layers_arg(raw)
+        except ValueError:
+            print(f"Invalid input. Enter comma-separated indices (e.g., '0,1,2' or '0-3', or '-0,5' to delete).")
+            continue
+
+        invalid = [i for i in layers if i < 0 or i >= total_layers]
+        if invalid:
+            print(f"Invalid layer indices: {invalid} (valid range: 0-{total_layers - 1})")
+            continue
+        if not layers:
+            print("No layers specified.")
+            continue
+
+        if delete_mode:
+            keep = set(range(total_layers)) - layers
+            if not keep:
+                print("Cannot delete all layers.")
+                continue
+            return keep
+        return layers
+
+
+def prompt_output(input_path: Path) -> Path:
+    """Prompt the user for the output file path."""
+    print()
+    stem = input_path.stem
+    default = input_path.with_name(f"{stem}-shrunk.gguf")
+    raw = input(f"Output file name [{default}]: ").strip()
+    if raw == '':
+        return default
+    out = Path(raw)
+    if out.suffix != '.gguf':
+        out = out.with_suffix('.gguf')
+    return out
+
+
+def run_interactive(input_path: Path, reader: gguf.GGUFReader) -> None:
+    arch, total_layers, per_layer_params, per_layer_bytes = analyze_model(reader)
+
+    total_params = sum(per_layer_params.values())
+    total_bytes = sum(per_layer_bytes.values())
+
+    # Step 1: display model info
+    print(f"\nModel architecture: {arch}")
+    print(f"Total layers: {total_layers}  |  params/layer: ~{format_counts(total_params // max(total_layers, 1))}  |  size/layer: ~{format_bytes(total_bytes // max(total_layers, 1))}")
+
+    # Step 2: ask which layers to keep
+    keep_layers = prompt_layers(total_layers)
+
+    # Step 3: ask for output name
+    output_path = prompt_output(input_path)
+
+    if output_path.exists():
+        ans = input(f"File '{output_path}' already exists. Overwrite? [y/N]: ").strip().lower()
+        if ans != 'y':
+            print("Aborted.")
+            sys.exit(0)
+
+    _do_write(input_path, reader, output_path, keep_layers)
+
+
+def run_batch(input_path: Path, reader: gguf.GGUFReader, output_path: Path, layers: set[int]) -> None:
+    if output_path.exists():
+        logger.warning(f"File '{output_path}' already exists, will be overwritten")
+    _do_write(input_path, reader, output_path, layers)
+
+
+def _do_write(input_path: Path, reader: gguf.GGUFReader, output_path: Path, keep_layers: set[int]) -> None:
+    arch = get_field_data(reader, gguf.Keys.General.ARCHITECTURE)
+    alignment = get_field_data(reader, gguf.Keys.General.ALIGNMENT)
+
+    logger.info(f"Writing: {output_path}")
+    writer = gguf.GGUFWriter(str(output_path), arch=arch, endianess=reader.endianess)
+
+    if alignment is not None:
+        writer.data_alignment = alignment
+
+    shrink_layers(reader, writer, keep_layers)
+    logger.info("Done")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Shrink a GGUF model by keeping only selected transformer layers",
+    )
+    parser.add_argument("input", type=Path, help="Input GGUF file")
+    parser.add_argument("-o", "--output", type=Path, default=None, help="Output GGUF file")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-l", "--layers", type=str, default=None,
+                       help="Layers to KEEP, comma-separated (e.g. '0' or '0,5,10' or '0-3')")
+    group.add_argument("-d", "--delete", type=str, default=None,
+                       help="Layers to DELETE, comma-separated (e.g. '0,5' or '0-3')")
+    parser.add_argument("-f", "--force", action="store_true", help="Overwrite output file if it exists")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Increase output verbosity")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    if not args.input.is_file():
+        logger.error(f"Input file not found: {args.input}")
+        sys.exit(1)
+
+    logger.info(f"Loading: {args.input}")
+    reader = gguf.GGUFReader(args.input, 'r')
+
+    # Batch mode: --layers/--delete and --output provided
+    if args.layers is not None and args.output is not None:
+        layers = _parse_and_validate(args.layers, reader)
+        run_batch(args.input, reader, args.output, layers)
+    elif args.delete is not None and args.output is not None:
+        delete_layers = _parse_and_validate(args.delete, reader)
+        _, total_layers, *_ = analyze_model(reader)
+        keep_layers = set(range(total_layers)) - delete_layers
+        if not keep_layers:
+            logger.error("Cannot delete all layers")
+            sys.exit(1)
+        logger.info(f"Deleting {len(delete_layers)} layer(s): {sorted(delete_layers)}")
+        run_batch(args.input, reader, args.output, keep_layers)
+    elif args.layers is not None or args.delete is not None or args.output is not None:
+        parser.error("-l/-d and -o must be used together for batch mode")
+    else:
+        # Interactive mode
+        run_interactive(args.input, reader)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Overview

LLM has huge parameters as weights, so, I did some tests to drop layers or embedding vectors nearly a year ago (https://www.researchsquare.com/article/rs-6519153/v1). And recently, I found gguf format is very friendly to do shrinking. And this two script generated by DeepSeek-V4-Pro do the shrinking perfectly. They can be used to reduce model size, and LLM research.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES. the scripts are generated by DeepSeek-V4-Pro/Flash in 3-5 rounds. And I tested these two scripts by reducing gpt-oss-20b-F16.gguf for vary scenarios, e.g. shrink half layers or half embedding dimensions, then test with llama-server on MacBook Air M5. The scripts works perfect.