### PR TITLE
ggml-cpu: add RVV implementation for q1_0 x q8_0 vec dot

### DIFF
--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -203,7 +203,6 @@
 #elif defined(__riscv)
 // quants.c
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
-#define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x1_generic ggml_quantize_mat_q8_0_4x1
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4

--- a/ggml/src/ggml-cpu/arch/riscv/quants.c
+++ b/ggml/src/ggml-cpu/arch/riscv/quants.c
@@ -274,6 +274,56 @@ void ggml_vec_dot_q4_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
 #endif
 }
 
+void ggml_vec_dot_q1_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+#if defined(__riscv_v)
+    const int qk = QK1_0;
+    const int nb = n / qk;
+    const size_t vl = 8;
+
+    assert(n % qk == 0);
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+
+    const block_q1_0 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    float sumf = 0.0f;
+
+    for (int ib = 0; ib < nb; ++ib) {
+        const float d0 = GGML_CPU_FP16_TO_FP32(x[ib].d);
+        float sumi = 0.0f;
+
+        for (int k = 0; k < 4; ++k) {
+            const block_q8_0 * GGML_RESTRICT yb = &y[ib * 4 + k];
+            const float d1 = GGML_CPU_FP16_TO_FP32(yb->d);
+            int sumi_block = 0;
+            const uint8_t * GGML_RESTRICT bits = &x[ib].qs[k * 4];
+
+            for (int b = 0; b < 4; ++b) {
+                vbool8_t m_positive = __riscv_vlm_v_b8(bits + b, vl);
+                vint8m1_t v_q8 = __riscv_vle8_v_i8m1(yb->qs + b * 8, vl);
+                vint8m1_t v_q8_neg = __riscv_vsub_vv_i8m1(__riscv_vmv_v_x_i8m1(0, vl), v_q8, vl);
+                vint8m1_t v_q8_signed = __riscv_vmerge_vvm_i8m1(v_q8_neg, v_q8, m_positive, vl);
+
+                vint16m1_t v_sum = __riscv_vwredsum_vs_i8m1_i16m1(v_q8_signed, __riscv_vmv_v_x_i16m1(0, 1), vl);
+                sumi_block += __riscv_vmv_x_s_i16m1_i16(v_sum);
+            }
+
+            sumi += d1 * sumi_block;
+        }
+
+        sumf += d0 * sumi;
+    }
+
+    *s = sumf;
+#else
+    ggml_vec_dot_q1_0_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
+#endif
+}
+
 void ggml_vec_dot_q4_1_q8_1(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
 #if defined(__riscv_v)
     const int qk = QK8_1;

--- a/ggml/src/ggml-cpu/arch/riscv/quants.c
+++ b/ggml/src/ggml-cpu/arch/riscv/quants.c
@@ -278,9 +278,12 @@ void ggml_vec_dot_q1_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
 #if defined(__riscv_v)
     const int qk = QK1_0;
     const int nb = n / qk;
-    const size_t vl = 8;
+    // A single q8_0 block always contains 32 int8 values. With e8,m4 this
+    // maps to vl=32 on any spec-compliant RVV target (minimum VLEN is 64-bit).
+    const size_t vl = __riscv_vsetvl_e8m4(32);
 
     assert(n % qk == 0);
+    assert(vl == 32);
     assert(nrc == 1);
     UNUSED(nrc);
     UNUSED(bx);
@@ -289,6 +292,7 @@ void ggml_vec_dot_q1_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
 
     const block_q1_0 * GGML_RESTRICT x = vx;
     const block_q8_0 * GGML_RESTRICT y = vy;
+    const vint16m1_t v_zero_sum = __riscv_vmv_v_x_i16m1(0, 1);
 
     float sumf = 0.0f;
 
@@ -299,18 +303,13 @@ void ggml_vec_dot_q1_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
         for (int k = 0; k < 4; ++k) {
             const block_q8_0 * GGML_RESTRICT yb = &y[ib * 4 + k];
             const float d1 = GGML_CPU_FP16_TO_FP32(yb->d);
-            int sumi_block = 0;
             const uint8_t * GGML_RESTRICT bits = &x[ib].qs[k * 4];
-
-            for (int b = 0; b < 4; ++b) {
-                vbool8_t m_positive = __riscv_vlm_v_b8(bits + b, vl);
-                vint8m1_t v_q8 = __riscv_vle8_v_i8m1(yb->qs + b * 8, vl);
-                vint8m1_t v_q8_neg = __riscv_vsub_vv_i8m1(__riscv_vmv_v_x_i8m1(0, vl), v_q8, vl);
-                vint8m1_t v_q8_signed = __riscv_vmerge_vvm_i8m1(v_q8_neg, v_q8, m_positive, vl);
-
-                vint16m1_t v_sum = __riscv_vwredsum_vs_i8m1_i16m1(v_q8_signed, __riscv_vmv_v_x_i16m1(0, 1), vl);
-                sumi_block += __riscv_vmv_x_s_i16m1_i16(v_sum);
-            }
+            vbool2_t m_positive = __riscv_vlm_v_b2(bits, vl);
+            vint8m4_t v_q8 = __riscv_vle8_v_i8m4(yb->qs, vl);
+            vint8m4_t v_q8_neg = __riscv_vsub_vv_i8m4(__riscv_vmv_v_x_i8m4(0, vl), v_q8, vl);
+            vint8m4_t v_q8_signed = __riscv_vmerge_vvm_i8m4(v_q8_neg, v_q8, m_positive, vl);
+            vint16m1_t v_sum = __riscv_vwredsum_vs_i8m4_i16m1(v_q8_signed, v_zero_sum, vl);
+            const int sumi_block = __riscv_vmv_x_s_i16m1_i16(v_sum);
 
             sumi += d1 * sumi_block;
         }


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This PR adds an RVV-specific implementation of `ggml_vec_dot_q1_0_q8_0` for RISC-V.

This PR is a follow-up to #21273 and #21636, and my changes here are based on the work from those PRs. Thanks to the authors for laying the groundwork.

**Benchmark results for Bonsai 1.7B** (Due to runtime constraints on the K1, the benchmark was limited to 64 token)
| threads | test | generic tok/s | RVV tok/s | speedup |
| --- | --- | ---: | ---: | ---: |
| 4 | pp64 | 0.561362 +- 0.000273 | 2.462494 +- 0.007606 | 4.39x |
| 4 | tg64 | 0.442725 +- 0.000522 | 1.872843 +- 0.005062 | 4.23x |
| 8 | pp64 | 0.880189 +- 0.002553 | 3.418164 +- 0.015693 | 3.88x |
| 8 | tg64 | 0.367250 +- 0.005271 | 0.796739 +- 0.005334 | 2.17x |

**Perplexity summary style table:**
| Metric | RVV (K1) |
| --- | ---: |
| Same top p | 99.294 +- 0.235 % |
| Mean KLD | 0.000222 +- 0.000009 |
| Maximum KLD | 0.004316 |
| 99.9% KLD | 0.004056 |
| 99.0% KLD | 0.001395 |
| Median KLD | 0.000137 |
| 1.0% KLD | -0.000012 |
| Minimum KLD | -0.000051 |
| Mean Delta p | -0.007 +- 0.010 % |
| Maximum Delta p | 2.477 % |
| 99.9% Delta p | 2.177 % |
| 99.0% Delta p | 1.180 % |
| 95.0% Delta p | 0.460 % |
| Median Delta p | -0.000 % |
| 5.0% Delta p | -0.546 % |
| 1.0% Delta p | -1.088 % |
| 0.1% Delta p | -1.604 % |
| Minimum Delta p | -1.646 % |
| RMS Delta p | 0.346 +- 0.017 % |

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
Use AI to help me with testing and data collection.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
