### PR TITLE
Stop qwen3.6 from outputting empty <think> blocks

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -631,6 +631,32 @@ common_chat_templates_ptr common_chat_templates_init(const struct llama_model * 
                            "{%- if false %}");
     }
 
+    // Temporary workaround until fixed by Qwen
+    // even when reasoning_content is empty, on Qwen3.6, preserve_thinking wraps every past
+    // assistant turn with <think>. When preserve_thinking=true empty thinking blocks may thus appear in long conversations.
+    if (default_template_src.find("{%- if (preserve_thinking is defined and preserve_thinking is true) "
+                                  "or (loop.index0 > ns.last_query_index) %}") != std::string::npos
+        && default_template_src.find("{%- set reasoning_content = reasoning_content|trim %}") != std::string::npos) {
+        LOG_WRN(
+            "common_chat_templates_init: Qwen3.6 preserve_thinking template detected, applying workaround\n");
+        string_replace_all(default_template_src,
+                           "{%- if (preserve_thinking is defined and preserve_thinking is true) "
+                           "or (loop.index0 > ns.last_query_index) %}",
+                           "{%- if ((preserve_thinking is defined and preserve_thinking is true) "
+                           "or (loop.index0 > ns.last_query_index)) and reasoning_content %}");
+    }
+    if (template_tool_use_src.find("{%- if (preserve_thinking is defined and preserve_thinking is true) "
+                                   "or (loop.index0 > ns.last_query_index) %}") != std::string::npos
+        && template_tool_use_src.find("{%- set reasoning_content = reasoning_content|trim %}") != std::string::npos) {
+        LOG_WRN(
+            "common_chat_templates_init: Qwen3.6 preserve_thinking template detected, applying workaround\n");
+        string_replace_all(template_tool_use_src,
+                           "{%- if (preserve_thinking is defined and preserve_thinking is true) "
+                           "or (loop.index0 > ns.last_query_index) %}",
+                           "{%- if ((preserve_thinking is defined and preserve_thinking is true) "
+                           "or (loop.index0 > ns.last_query_index)) and reasoning_content %}");
+    }
+    
     std::string token_bos = bos_token_override;
     std::string token_eos = eos_token_override;
     bool        add_bos   = false;


### PR DESCRIPTION
This should hopefully solve #22398, see also #22255 for related issues
This workaround will stop rendering empty  `<think>` and `</think>` tags when the actual reasoning content is blank.

Inside the Qwen3.6 chat template, when `preserved_thinking == true`, it will create an extra set of think tags in all cases, even if reasoning content is blank.
This then leads to:
```
<think>


</think>

...content...
```

This is the actual template:
```
{%- set reasoning_content = reasoning_content|trim %}
{%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
    {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
```

Which you can see when starting the server:

```
srv          init: init: idle slots will be saved to prompt cache and cleared upon starting a new task
init: chat template, example_format: '<|im_start|>system
You are a helpful assistant<|im_end|>
<|im_start|>user
Hello<|im_end|>
<|im_start|>assistant
<think>

</think>

Hi there<|im_end|>
<|im_start|>user
How are you?<|im_end|>
<|im_start|>assistant
<think>
'
srv          init: init: chat template, thinking = 1
main: model loaded
main: server is listening
```
This fix retains the preserved_thinking feature but only when there's reasoning_content actually there to show.
The empty thinking blocks will accumulate after repeated messages and while it's hard to say what exactly that would do, it's likely affecting the model negatively which could explain some of the behavior reported.

Yes, AI assisted me in fixing this bug and finding where the issue came from. I  reproduced it myself and tested the fix and re-wrote its suggested code.
