### PR TITLE
convert: set causal_attention=False for Qwen3-ASR

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -5237,6 +5237,9 @@ class Qwen3ASRTextModel(Qwen3VLTextModel):
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
         self.gguf_writer.add_num_deepstack_layers(0)
+        # Qwen3-ASR requires bidirectional attention for audio transcription
+        # The HF config does not include is_causal=False, so we must set it explicitly
+        self.gguf_writer.add_causal_attention(False)
 
     def set_vocab(self):
         super().set_vocab()


### PR DESCRIPTION
## Overview

Qwen3-ASR requires bidirectional (non-causal) attention for audio transcription, but the current `Qwen3ASRTextModel` does not set `causal_attention=False` in the GGUF metadata.

The HuggingFace model config (`Qwen/Qwen3-ASR-1.7B`, `Qwen/Qwen3-ASR-0.6B`) does not include the `is_causal` hyperparameter, so the existing auto-detection from PR #20746 does not take effect. As a result, the GGUF model inherits `causal_attn=true` from `Qwen3VLTextModel`, which is incorrect for ASR.

### Impact

When `causal_attn=true`, llama.cpp limits `n_batch = min(n_ctx, n_batch)` during context initialization. This means `n_batch` is capped at `n_ctx` (2048), which is insufficient for longer audio inputs where `pos_arr = total_len × 4` (multi-plane position encoding). This causes:

1. **#22357**: Repetitive/garbled transcription output — the model enters a degenerate repetition loop due to incorrect attention masking
2. **#21847**: Empty transcription for audio files longer than ~2 minutes — the attention masking prevents the model from attending to the full audio sequence

### Fix

Add `self.gguf_writer.add_causal_attention(False)` in `Qwen3ASRTextModel.set_gguf_parameters()`.

## Additional information

- PR #20746: Added generic `is_causal` detection from HF config, but Qwen3-ASR does not include this field
- PR #20973: Extended `causal_attn` and `pooling_type` to all architectures
- User @cora4 independently identified this issue and provided a patched release ([b8931-patched](https://github.com/cora4/llama.cpp/releases/tag/b8931-patched)) in #22357

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES — AI (Claude) was used to assist with analyzing the root cause and drafting the code change. The fix has been reviewed and verified.