### PR TITLE
ggml-rpc: serialize send_rpc_cmd per socket to fix concurrent-send race

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -304,9 +304,24 @@ static bool parse_endpoint(const std::string & endpoint, std::string & host, int
     return true;
 }
 
+// Per-socket lock so concurrent set_tensor/etc calls from multiple
+// threads don't interleave their bytes on the shared cached socket
+// (which corrupts the protocol and trips "Remote RPC server crashed
+// or returned malformed response"). Local TCP loopback is fast enough
+// that the race window rarely opens, but WAN latency widens it.
+// recursive_mutex because the response variant calls the no-response
+// variant from inside an already-locked section.
+static std::recursive_mutex & socket_send_mutex(const std::shared_ptr<socket_t> & sock) {
+    static std::mutex map_mutex;
+    static std::unordered_map<socket_t *, std::recursive_mutex> mutexes;
+    std::lock_guard<std::mutex> lk(map_mutex);
+    return mutexes[sock.get()];
+}
+
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // No response
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
+    std::lock_guard<std::recursive_mutex> lk(socket_send_mutex(sock));
     uint8_t cmd_byte = cmd;
     if (!sock->send_data(&cmd_byte, sizeof(cmd_byte))) {
         return false;
@@ -323,6 +338,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // RPC response: | response_size (8 bytes) | response_data (response_size bytes) |
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size, void * output, size_t output_size) {
+    std::lock_guard<std::recursive_mutex> lk(socket_send_mutex(sock));
     if (!send_rpc_cmd(sock, cmd, input, input_size)) {
         return false;
     }


### PR DESCRIPTION
 What this fixes                                        

  I was building a thing that uses llama.cpp's RPC backend across              
  networks (tunneling rpc-server through a WebSocket relay so two
  machines on different ISPs can split a model's layers). Hit a bug            
  where weight loading over WAN would either hang or trip "Remote RPC
  server crashed or returned malformed response." Took a few days to           
  find.                                                     
                                                                               
  The race only fires under WAN latency. On localhost, the OS write            
  buffer drains so fast that one thread is done before the next starts.
  Over WAN, the buffer takes longer to drain — the window opens, and           
  bytes from concurrent SET_TENSOR writes interleave mid-frame. The            
  receiver reads what it thinks is a length field but is actually the          
  middle of another command's payload. Protocol broken from there on.          
                                                                               
  llama-server's tensor loader fires those concurrent SET_TENSOR calls         
  from multiple threads on the same cached socket. There's no                  
  synchronization on the write side.                                           
                                                                               
  The fix                                                                   
                                                            
  Per-socket `std::recursive_mutex` keyed on `socket_t *`, locked at           
  the top of each `send_rpc_cmd` body. Recursive because the response
  variant calls the no-response variant from inside its own locked             
  section — non-recursive deadlocks there.                  
                                                                               
  Testing                                                
                                                                               
  Tunneled rpc-server traffic over a WebSocket relay between two Macs          
  on different ISPs (RTT ~30-80ms). Before: load fails within the first
  few hundred MB. After: 1.2 GB Phi-3-mini weights load in 122s and            
  chat completes correctly.                                 
                                                                               
  LAN behavior unchanged.                                   
                                                                               
  Disclosure                                                                
   
  I used Claude to help draft this description (which is what triggered        
  the AI-content flag — fair). The patch itself, the bug investigation,
  and the WAN testing are mine.                                                
                                                                               
  Open to                                                                   
                                                                               
  If you want different scoping (cleanup of the mutex map on socket
  destruction, or refactoring to avoid recursive_mutex), happy to
  adjust.