### PR TITLE
server : fix image blocks in tool_result being dropped during Anthropic→OpenAI conversion

### DIFF
--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -426,22 +426,70 @@ json server_chat_convert_anthropic_to_oai(const json & body) {
                     std::string tool_use_id = json_value(block, "tool_use_id", std::string());
 
                     auto result_content = json_value(block, "content", json());
-                    std::string result_text;
                     if (result_content.is_string()) {
-                        result_text = result_content.get<std::string>();
+                        tool_results.push_back({
+                            {"role", "tool"},
+                            {"tool_call_id", tool_use_id},
+                            {"content", result_content.get<std::string>()}
+                        });
                     } else if (result_content.is_array()) {
+                        // Single-pass: build both text and content_parts, decide format at the end
+                        std::string result_text;
+                        json content_parts = json::array();
+                        bool has_images = false;
+
                         for (const auto & c : result_content) {
-                            if (json_value(c, "type", std::string()) == "text") {
-                                result_text += json_value(c, "text", std::string());
+                            std::string c_type = json_value(c, "type", std::string());
+                            if (c_type == "text") {
+                                std::string text = json_value(c, "text", std::string());
+                                result_text += text;
+                                content_parts.push_back({
+                                    {"type", "text"},
+                                    {"text", text}
+                                });
+                            } else if (c_type == "image") {
+                                has_images = true;
+                                json source = json_value(c, "source", json::object());
+                                std::string source_type = json_value(source, "type", std::string());
+                                if (source_type == "base64") {
+                                    std::string media_type = json_value(source, "media_type", std::string("image/jpeg"));
+                                    std::string data = json_value(source, "data", std::string());
+                                    std::string url = "data:" + media_type + ";base64," + data;
+                                    content_parts.push_back({
+                                        {"type", "image_url"},
+                                        {"image_url", {{"url", url}}}
+                                    });
+                                } else if (source_type == "url") {
+                                    content_parts.push_back({
+                                        {"type", "image_url"},
+                                        {"image_url", {{"url", json_value(source, "url", std::string())}}}
+                                    });
+                                }
                             }
                         }
-                    }
 
-                    tool_results.push_back({
-                        {"role", "tool"},
-                        {"tool_call_id", tool_use_id},
-                        {"content", result_text}
-                    });
+                        if (!has_images) {
+                            // Text-only: collapse to a plain string for maximum compatibility
+                            tool_results.push_back({
+                                {"role", "tool"},
+                                {"tool_call_id", tool_use_id},
+                                {"content", result_text}
+                            });
+                        } else {
+                            // Mixed or image-only: use array content parts (OpenAI multimodal tool format)
+                            tool_results.push_back({
+                                {"role", "tool"},
+                                {"tool_call_id", tool_use_id},
+                                {"content", content_parts}
+                            });
+                        }
+                    } else {
+                        tool_results.push_back({
+                            {"role", "tool"},
+                            {"tool_call_id", tool_use_id},
+                            {"content", ""}
+                        });
+                    }
                 }
             }
 

--- a/tools/server/tests/unit/test_compat_anthropic.py
+++ b/tools/server/tests/unit/test_compat_anthropic.py
@@ -402,6 +402,65 @@ def test_anthropic_tool_result_with_text():
     assert len(res.body["content"]) > 0
 
 
+def test_anthropic_tool_result_with_image():
+    """Test tool result containing mixed text and image blocks
+
+    Verifies that image blocks inside Anthropic tool_result content are
+    properly converted to OpenAI image_url format rather than being
+    silently dropped. With a non-multimodal model, the converted image
+    triggers a clear error message instead of being ignored.
+    """
+    server.jinja = True
+    server.start()
+
+    # Small 1x1 red PNG image in base64 (same as vision tests)
+    red_pixel_png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+
+    res = server.make_request("POST", "/v1/messages", data={
+        "model": "test",
+        "max_tokens": 100,
+        "messages": [
+            {"role": "user", "content": "What is in this image?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool_1",
+                        "name": "read",
+                        "input": {"file": "test.png"}
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool_1",
+                        "content": [
+                            {"type": "text", "text": "File: test.png"},
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": red_pixel_png
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    })
+
+    # Without the fix, image block would cause "unsupported content[].type"
+    # With the fix, image is converted to image_url but tinyllama doesn't support images
+    assert res.status_code == 500
+    assert "image input is not supported" in res.body.get("error", {}).get("message", "").lower()
+
+
 def test_anthropic_tool_result_error():
     """Test tool result with error flag"""
     server.jinja = True


### PR DESCRIPTION
## Overview

`server_chat_convert_anthropic_to_oai()` silently drops image blocks when converting Anthropic `tool_result` content to OpenAI format. This breaks clients that expect tools to return images (e.g. Claude Code) — the model behaves as if no image was provided at all.

When `tool_result` contains image blocks, convert the content to OpenAI multimodal content parts (text + image array). Plain text results remain plain strings for maximum backward compatibility.

This change is safe because `oaicompat_chat_params_parse()` already uniformly handles `image_url` across all message roles — extracting media to `out_files` and replacing it with `media_marker` placeholders for the chat template.

### Key Changes

In `server_chat_convert_anthropic_to_oai()`:
- **Detect images**: Scan `tool_result` content blocks for those with `type == "image"`.
- **Pure text path (unchanged)**: If no images are found, concatenate all text blocks into a normal string — this preserves existing behavior for non-multimodal tool results.
- **Multimodal path (new)**: If there are images, build a JSON array of content parts:
  - Text blocks → `{"type": "text", "text": "..."}`
  - Image blocks with `source.type == "base64"` → Build a data URI (`data:<media_type>;base64,<data>`) and emit `{"type": "image_url", "image_url": {"url": "..."}}`
  - Image blocks with `source.type == "url"` → Pass the URL directly as `{"type": "image_url", "image_url": {"url": "..."}}`

## Testing

### Test script

```bash
#!/bin/bash
# Reproduce: tool_result with image is silently dropped

IMG_BASE64=$(base64 -w 0 ./a.jpeg)

cat > /tmp/test_image_tool.json << EOF
{
  "model": "qwen3.6",
  "messages": [
    {"role": "user", "content": "What is in this image?"},
    {"role": "assistant", "content": [{"type": "tool_use", "id": "tool_1", "name": "read", "input": {"file": "a.jpeg"}}]},
    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tool_1", "content": [{"type": "text", "text": "File: a.jpeg"}, {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "$IMG_BASE64"}}]}]}
  ],
  "max_tokens": 4096,
  "stream": false
}
EOF

curl -s -X POST http://localhost:8848/v1/messages \
  -H "Content-Type: application/json" \
  -H "x-api-key: no-key" \
  -d @/tmp/test_image_tool.json | jq -r '.content[] | select(.type == "text") | .text'
```

### Before
```
I've received the image file `a.jpeg`. Since I don't have direct visual access to view or analyze images in this text-based interface, could you please describe what's in the image?
```
### After
```
This image shows a dense field of tall, bright yellow wildflowers, which appear to be goldenrod, dominating the foreground and middle ground. Below the flowers, there is lush green foliage.

In the background, you can see:
*   Left side: Dark green trees or bushes.
*   Right side: A tall, thin, grey utility pole or mast stretching up into the sky.
*   Sky: The sky is a pale, hazy white-blue, suggesting it might be a misty morning or a smoggy day.
```

Tested locally with Qwen3.6-27B Q8 + Claude Code read tool.

## Requirements
 - [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: NO — The core fix was authored by a human contributor. AI was used solely for code relocation assistance due to upstream refactoring (function moved from server-common.cpp to server-chat.cpp), and for grammar suggestions on the human-written PR description.