### PR TITLE
server : validate --tools CLI argument against known tool names

### DIFF
--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <cstring>
 #include <climits>
+#include <algorithm>
 
 namespace fs = std::filesystem;
 
@@ -713,6 +714,24 @@ void server_tools::setup(const std::vector<std::string> & enabled_tools) {
     if (!enabled_tools.empty()) {
         std::unordered_set<std::string> enabled_set(enabled_tools.begin(), enabled_tools.end());
         auto all_tools = build_tools();
+
+        // collect all known tool names for validation
+        std::vector<std::string> known_names;
+        known_names.reserve(all_tools.size());
+        for (const auto & t : all_tools) {
+            known_names.push_back(t->name);
+        }
+
+        // validate that every requested tool is known
+        for (const auto & name : enabled_tools) {
+            if (name == "all") continue;
+            if (std::find(known_names.begin(), known_names.end(), name) == known_names.end()) {
+                throw std::runtime_error(string_format(
+                    "unknown tool \"%s\". available tools: %s",
+                    name.c_str(),
+                    string_join(known_names, ", ").c_str()));
+            }
+        }
 
         tools.clear();
         for (auto & t : all_tools) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -215,7 +215,12 @@ int main(int argc, char ** argv) {
     }
     // EXPERIMENTAL built-in tools
     if (!params.server_tools.empty()) {
-        tools.setup(params.server_tools);
+        try {
+            tools.setup(params.server_tools);
+        } catch (const std::exception & e) {
+            LOG_ERR("%s: tools setup failed: %s\n", __func__, e.what());
+            return 1;
+        }
         SRV_WRN("%s", "-----------------\n");
         SRV_WRN("%s", "Built-in tools are enabled, do not expose server to untrusted environments\n");
         SRV_WRN("%s", "This feature is EXPERIMENTAL and may be changed in the future\n");


### PR DESCRIPTION
## Overview

The `--tools` CLI argument currently silently ignores unknown tool names. This PR adds validation so that unrecognized tool names cause the server to exit with a clear error message listing the available tools.

**Before:** `llama-server --tools read_file,typo_tool` would silently start with only `read_file` enabled.

**After:** The server exits with:
```
error: tools setup failed: unknown tool "typo_tool". available tools: read_file, file_glob_search, grep_search, exec_shell_command, write_file, edit_file, apply_diff
```

## Additional information

Changes:
- `server-tools.cpp`: validate each tool name in `server_tools::setup()` against the known tools from `build_tools()`, throwing `std::runtime_error` for unknown names
- `server.cpp`: wrap `tools.setup()` in try-catch to report the error cleanly and exit

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. llama.cpp + pi
