### PR TITLE
support min32gw

### DIFF
--- a/vendor/cpp-httplib/httplib.cpp
+++ b/vendor/cpp-httplib/httplib.cpp
@@ -1464,9 +1464,16 @@ bool mmap::open(const char *path) {
   auto wpath = u8string_to_wstring(path);
   if (wpath.empty()) { return false; }
 
+#if defined(__MINGW32__)
+  // MinGW does not provide CreateFile2, use CreateFileW instead
+  hFile_ = ::CreateFileW(wpath.c_str(), GENERIC_READ,
+                         FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                         OPEN_EXISTING, FILE_ATTRIBUTE_READONLY, NULL);
+#else
   hFile_ =
       ::CreateFile2(wpath.c_str(), GENERIC_READ,
                     FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, NULL);
+#endif
 
   if (hFile_ == INVALID_HANDLE_VALUE) { return false; }
 


### PR DESCRIPTION
  1. vendor/cpp-httplib/httplib.cpp（1467-1476 ）                                                    
                  
  hFile_ =                                                                                             
      ::CreateFile2(wpath.c_str(), GENERIC_READ,
                    FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, NULL);

change to：
  #if defined(__MINGW32__)
    // MinGW does not provide CreateFile2, use CreateFileW instead
    hFile_ = ::CreateFileW(wpath.c_str(), GENERIC_READ,
                           FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
                           OPEN_EXISTING, FILE_ATTRIBUTE_READONLY, NULL);
  #else
    hFile_ =
        ::CreateFile2(wpath.c_str(), GENERIC_READ,
                      FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, NULL);