### PR TITLE
ggml-virtgpu: fix transitive dependency in headers

### DIFF
--- a/ggml/src/ggml-virtgpu/virtgpu-shm.cpp
+++ b/ggml/src/ggml-virtgpu/virtgpu-shm.cpp
@@ -1,6 +1,7 @@
 #include "virtgpu-shm.h"
 
 #include "virtgpu.h"
+#include "ggml-remoting.h"
 
 #include <assert.h>
 

--- a/ggml/src/ggml-virtgpu/virtgpu.cpp
+++ b/ggml/src/ggml-virtgpu/virtgpu.cpp
@@ -1,4 +1,5 @@
 #include "virtgpu.h"
+#include "ggml-remoting.h"
 
 #include <stdio.h>
 #include <unistd.h>

--- a/ggml/src/ggml-virtgpu/virtgpu.h
+++ b/ggml/src/ggml-virtgpu/virtgpu.h
@@ -18,8 +18,6 @@
 
 #include <cstring>
 
-#include "ggml-remoting.h"
-
 #define VIRGL_RENDERER_UNSTABLE_APIS 1
 #include "apir_hw.h"
 #include <drm/virtgpu_drm.h>


### PR DESCRIPTION
## Overview

This PR fixes a transitive dependency between the `ggml-remoting.h` and `virtgpu.cpp` files.

## Additional information

I discovered a really cool repo analysis tool called [sentrux](https://github.com/sentrux/sentrux)

Sentrux found some transitive dependencies that could cause issues, including some very complex ones. 
I started simple with a small loop that it caught, making it an accessible first step for a beginner like me. 
I fixed it by adjusting the imports.
I have successfully recompiled the project to verify the fix.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
  - Antigravity used to help me navigate the repo.
  - AI used to translate this PR description into English (originally written in French by me).
  - Discussed with AI to understand the dependency logic: the preprocessor macros used in `virtgpu.cpp` are defined in `ggml-remoting.h`, which is why I added the `#includes`.