### PR TITLE
llama-quant : honor --tensor-type override when it matches the global ftype

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -683,9 +683,9 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, const llama_mod
                         LLAMA_LOG_WARN("%s: %-36s - applying manual override: %s -> %s\n",
                                        __func__, tensor_name.c_str(), ggml_type_name(new_type), ggml_type_name(qtype));
                         new_type = qtype;
-                        manual = true;
-                        break;
                     }
+                    manual = true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #22544.

When a user supplies an explicit `--tensor-type "<pattern>=<type>"` mapping that happens to match the requested global ftype, the user's intent (lock that tensor to that exact type) is silently dropped and the imatrix/heuristic path is allowed to override it.

### Root cause

`llama_tensor_get_type` only set `manual = true` from inside the `qtype != new_type` branch:

```cpp
for (const auto & [pattern, qtype] : qs.tensor_type_patterns) {
    if (std::regex_search(tensor_name, pattern)) {
        if (qtype != new_type) {
            LLAMA_LOG_WARN(...);
            new_type = qtype;
            manual = true;
            break;
        }
        // pattern matched but qtype == new_type:
        //   no break, no manual = true
        //   loop continues, manual stays false
    }
}

// since !manual:
new_type = llama_tensor_get_type_impl(...);  // overrides the user's choice
```

So invoking `llama-quantize` with `--tensor-type "^blk\.0\.attn_qkv\.weight$=iq4_xs"` and global ftype `iq4_xs` falls through to the heuristic, which can pick a different type (e.g. `q5_K`) — exactly what `--tensor-type` is meant to prevent.

This was introduced by 1dab5f5 (refactor type selection), reported in #22544.

### Fix

Set `manual = true` and `break` unconditionally once a pattern matches. Only emit the "applying manual override" log line when the requested type actually differs from the current one:

```cpp
if (std::regex_search(tensor_name, pattern)) {
    if (qtype != new_type) {
        LLAMA_LOG_WARN(...);
        new_type = qtype;
    }
    manual = true;
    break;
}
```

A pattern match is the user pinning that tensor — it should suppress the heuristic regardless of whether it changes the type.

## Test plan

- [ ] `./llama-quantize --imatrix model.imatrix.gguf --tensor-type "^blk\.0\.attn_qkv\.weight$=iq4_xs" model.gguf out.gguf iq4_xs 8` — `attn_qkv` should now be reported as `iq4_xs` (no longer redirected to `q5_K`).
- [ ] Existing override case (`qtype != new_type`) still emits the log line and switches type.
- [ ] No regressions when `--tensor-type` is not supplied (`tensor_type_patterns.empty()` → unchanged path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
