### PR TITLE
server: support input_image in function_call_output (#20663)

### DIFF
--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -203,10 +203,22 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
                 } else {
                     json chatcmpl_outputs = item.at("output");
                     for (json & chatcmpl_output : chatcmpl_outputs) {
-                        if (!chatcmpl_output.contains("type") || chatcmpl_output.at("type") != "input_text") {
-                            throw std::invalid_argument("Output of tool call should be 'Input text'");
+                        if (!chatcmpl_output.contains("type") ||
+                            chatcmpl_output.at("type") != "input_text" && chatcmpl_output.at("type") != "input_image"
+                        ) {
+                            throw std::invalid_argument("Output of tool call should be 'Input text' or 'Input image'");
                         }
-                        chatcmpl_output["type"] = "text";
+                        if(chatcmpl_output.at("type") == "input_text") {
+                            chatcmpl_output["type"] = "text";
+                        } else if(chatcmpl_output.at("type") == "input_image") {
+                            if (!chatcmpl_output.contains("image_url")) {
+                                throw std::invalid_argument("'image_url' is required");
+                            }
+                            chatcmpl_output["type"] = "image_url";
+                            chatcmpl_output["image_url"] = json {
+                                {"url", chatcmpl_output.at("image_url")}
+                            };
+                        }
                     }
                     chatcmpl_messages.push_back(json {
                         {"content",      chatcmpl_outputs},

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -208,9 +208,9 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
                         ) {
                             throw std::invalid_argument("Output of tool call should be 'Input text' or 'Input image'");
                         }
-                        if(chatcmpl_output.at("type") == "input_text") {
+                        if (chatcmpl_output.at("type") == "input_text") {
                             chatcmpl_output["type"] = "text";
-                        } else if(chatcmpl_output.at("type") == "input_image") {
+                        } else if (chatcmpl_output.at("type") == "input_image") {
                             if (!chatcmpl_output.contains("image_url")) {
                                 throw std::invalid_argument("'image_url' is required");
                             }

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -203,14 +203,16 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
                 } else {
                     json chatcmpl_outputs = item.at("output");
                     for (json & chatcmpl_output : chatcmpl_outputs) {
-                        if (!chatcmpl_output.contains("type") ||
-                            chatcmpl_output.at("type") != "input_text" && chatcmpl_output.at("type") != "input_image"
-                        ) {
+                        if (!chatcmpl_output.contains("type")) {
+                            throw std::invalid_argument("Output of tool call missing 'type' field");
+                        }
+                        const auto type = chatcmpl_output.at("type");
+                        if (type != "input_text" && type != "input_image") {
                             throw std::invalid_argument("Output of tool call should be 'Input text' or 'Input image'");
                         }
-                        if (chatcmpl_output.at("type") == "input_text") {
+                        if (type == "input_text") {
                             chatcmpl_output["type"] = "text";
-                        } else if (chatcmpl_output.at("type") == "input_image") {
+                        } else if (type == "input_image") {
                             if (!chatcmpl_output.contains("image_url")) {
                                 throw std::invalid_argument("'image_url' is required");
                             }


### PR DESCRIPTION
## Overview

enables multimodal input from tool outputs by supporting the processing of "input_image" in "function_call_output".

## Additional information

related to #20663

tested using the Gemma 4 model.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES (used for translating documentation and seeking advice on development tooling. implementation and testing were performed manually.)