### PR TITLE
ggml-cuda : add defensive VRAM margin to prevent swapping stalls

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -141,6 +141,19 @@ static cudaError_t ggml_cuda_device_malloc(void ** ptr, size_t size, int device)
         }
 #endif // defined(GGML_USE_HIP)
     } else {
+        static size_t free_caches[GGML_CUDA_MAX_DEVICES];
+        GGML_ASSERT(device >= 0 && device < GGML_CUDA_MAX_DEVICES);
+        size_t& free = free_caches[device];
+        if (free < size) {
+            size_t total;
+            CUDA_CHECK(cudaMemGetInfo(&free, &total));
+            free -= std::min(free, (size_t)1 << 28); // Margin: 256MB
+            if (free < size) {
+                return cudaErrorMemoryAllocation;
+            }
+            free = std::min(free, ((size_t)1 << 30) + size); // Grace: 1GB
+        }
+        free -= size;
         err = cudaMalloc(ptr, size);
     }
     return err;


### PR DESCRIPTION
## Overview

This PR adds a defensive VRAM margin in `ggml_cuda_device_malloc` to prevent system instability and computation stalls caused by VRAM overcommit, specifically in WSL2 with ROCm environments.

- **256MB Margin:** Subtracted from reported free VRAM to prevent the OS from initiating aggressive RAM swapping.
- **1GB Grace Interval:** Implemented for `free_caches` to minimize the performance overhead of calling `cudaMemGetInfo`.

## Additional information

In environments like WSL2/ROCm (tested with 7900 XTX), exceeding physical VRAM triggers a "swapping loop" where active inference memory is moved between VRAM and system RAM. This saturates the PCIe bus, causing the GPU computation to stall indefinitely and leading to rapid system RAM exhaustion, even if the process remains active. This PR ensures `llama.cpp` reports a memory allocation error before this stall occurs.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI (Gemini) was used in an assistive capacity to verify C++ implementation details, including operator precedence, type safety for `size_t` calculations, and cross-compiler compatibility. The core logic (Margin and Grace thresholds) and the diagnosis of the swapping-related stall were conceptualized and validated by the human contributor through practical troubleshooting.

Closes #22583