### PR TITLE
CUDA: row-per-warp kernel for GATED_DELTA_NET

### DIFF
--- a/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -1,63 +1,33 @@
 #include "gated_delta_net.cuh"
 
-namespace {
-
 constexpr int d_v_per_warp = 4;
 constexpr int num_warps    = 4;
 constexpr int block_dv     = num_warps * d_v_per_warp;  // 16
 
-template <int n> __device__ __forceinline__ void vec_load(float (&reg)[n], const float * ptr) {
-    if constexpr (n == 4) {
-        *reinterpret_cast<float4 *>(&reg[0]) = *reinterpret_cast<const float4 *>(ptr);
-    } else if constexpr (n == 2) {
-        *reinterpret_cast<float2 *>(&reg[0]) = *reinterpret_cast<const float2 *>(ptr);
-    } else if constexpr (n == 8) {
-        *reinterpret_cast<float4 *>(&reg[0]) = *reinterpret_cast<const float4 *>(ptr);
-        *reinterpret_cast<float4 *>(&reg[4]) = *reinterpret_cast<const float4 *>(ptr + 4);
-    } else {
-        reg[0] = ptr[0];
-    }
-}
-
-template <int n> __device__ __forceinline__ void vec_store(float * ptr, const float (&reg)[n]) {
-    if constexpr (n == 4) {
-        *reinterpret_cast<float4 *>(ptr) = *reinterpret_cast<const float4 *>(&reg[0]);
-    } else if constexpr (n == 2) {
-        *reinterpret_cast<float2 *>(ptr) = *reinterpret_cast<const float2 *>(&reg[0]);
-    } else if constexpr (n == 8) {
-        *reinterpret_cast<float4 *>(ptr)     = *reinterpret_cast<const float4 *>(&reg[0]);
-        *reinterpret_cast<float4 *>(ptr + 4) = *reinterpret_cast<const float4 *>(&reg[4]);
-    } else {
-        ptr[0] = reg[0];
-    }
-}
-
-}  // namespace
-
 template <int S_v, bool KDA>
 __global__ void __launch_bounds__(ggml_cuda_get_physical_warp_size() * num_warps, 2) gated_delta_net_cuda(
-    const float * __restrict__ q,
-    const float * __restrict__ k,
-    const float * __restrict__ v,
-    const float * __restrict__ g,
-    const float * __restrict__ beta,
-    const float * __restrict__ curr_state,
-    float * __restrict__ dst,
-    int64_t H,
-    int64_t n_tokens,
-    int64_t n_seqs,
-    int64_t sq1,
-    int64_t sq2,
-    int64_t sq3,
-    int64_t sv1,
-    int64_t sv2,
-    int64_t sv3,
-    int64_t sb1,
-    int64_t sb2,
-    int64_t sb3,
-    uint3   neqk1_magic,
-    uint3   rq3_magic,
-    float   scale) {
+        const float * __restrict__ q,
+        const float * __restrict__ k,
+        const float * __restrict__ v,
+        const float * __restrict__ g,
+        const float * __restrict__ beta,
+        const float * __restrict__ curr_state,
+        float * __restrict__ dst,
+        int64_t H,
+        int64_t n_tokens,
+        int64_t n_seqs,
+        int64_t sq1,
+        int64_t sq2,
+        int64_t sq3,
+        int64_t sv1,
+        int64_t sv2,
+        int64_t sv3,
+        int64_t sb1,
+        int64_t sb2,
+        int64_t sb3,
+        uint3   neqk1_magic,
+        uint3   rq3_magic,
+        float   scale) {
     constexpr int warp_size     = ggml_cuda_get_physical_warp_size();
     constexpr int active_lanes  = (S_v < warp_size) ? S_v : warp_size;
     constexpr int d_qk_per_lane = S_v / active_lanes;
@@ -91,7 +61,7 @@ __global__ void __launch_bounds__(ggml_cuda_get_physical_warp_size() * num_warps
         if constexpr (S_v < warp_size) {
             reg[0] = (lane < active_lanes) ? base[lane] : 0.0f;
         } else {
-            vec_load<d_qk_per_lane>(reg, base + dqk_base);
+            ggml_cuda_memcpy_1<d_qk_per_lane * sizeof(float)>(reg, base + dqk_base);
         }
     };
     auto store_qk_lane = [&] __device__(const float(&reg)[d_qk_per_lane], float * base) {
@@ -100,18 +70,18 @@ __global__ void __launch_bounds__(ggml_cuda_get_physical_warp_size() * num_warps
                 base[lane] = reg[0];
             }
         } else {
-            vec_store<d_qk_per_lane>(base + dqk_base, reg);
+            ggml_cuda_memcpy_1<d_qk_per_lane * sizeof(float)>(base + dqk_base, reg);
         }
     };
 
     // state is stored transposed: M[r][c] = S[c][r]
-    float s_tile[d_v_per_warp][d_qk_per_lane];
+    __align__(16) float s_tile[d_v_per_warp][d_qk_per_lane];
 #pragma unroll
     for (int r = 0; r < d_v_per_warp; ++r) {
         load_qk_lane(s_tile[r], curr_state + (int64_t) (dv_base + r) * S_v);
     }
 
-    float k_reg[d_qk_per_lane];
+    __align__(16) float k_reg[d_qk_per_lane];
     load_qk_lane(k_reg, k + (int64_t) iq3 * sq3 + (int64_t) iq1 * sq1);
 
     for (int t = 0; t < n_tokens; ++t) {
@@ -120,10 +90,10 @@ __global__ void __launch_bounds__(ggml_cuda_get_physical_warp_size() * num_warps
         const int64_t gb_off   = (int64_t) sequence * sb3 + (int64_t) t * sb2 + (int64_t) h_idx * sb1;
         const float   beta_val = beta[gb_off];
 
-        float alpha_lane[d_qk_per_lane];
-        float alpha_scalar = 0.0f;
+        __align__(16) float alpha_lane[d_qk_per_lane];
+        float               alpha_scalar = 0.0f;
         if constexpr (KDA) {
-            float g_reg[d_qk_per_lane];
+            __align__(16) float g_reg[d_qk_per_lane];
             load_qk_lane(g_reg, g + gb_off * S_v);
 #pragma unroll
             for (int c = 0; c < d_qk_per_lane; ++c) {
@@ -171,7 +141,7 @@ __global__ void __launch_bounds__(ggml_cuda_get_physical_warp_size() * num_warps
             load_qk_lane(k_reg, k + (int64_t) iq3 * sq3 + (int64_t) (t + 1) * sq2 + (int64_t) iq1 * sq1);
         }
 
-        float q_reg[d_qk_per_lane];
+        __align__(16) float q_reg[d_qk_per_lane];
         load_qk_lane(q_reg, q + (int64_t) iq3 * sq3 + (int64_t) t * sq2 + (int64_t) iq1 * sq1);
 
         // stage B: attention output
@@ -308,6 +278,10 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     GGML_ASSERT(ggml_is_contiguous(src_g));
     GGML_ASSERT(ggml_is_contiguous(src_beta));
     GGML_ASSERT(ggml_is_contiguous(src_state));
+
+    GGML_ASSERT(nbq1 % 16 == 0);
+    GGML_ASSERT(nbq2 % 16 == 0);
+    GGML_ASSERT(nbq3 % 16 == 0);
 
     // strides in floats (beta strides used for both g and beta offset computation)
     const int64_t sq1 = nbq1 / sizeof(float);

--- a/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -1,199 +1,262 @@
 #include "gated_delta_net.cuh"
 
+namespace {
+
+constexpr int d_v_per_warp = 4;
+constexpr int num_warps    = 4;
+constexpr int block_dv     = num_warps * d_v_per_warp;  // 16
+
+template <int n> __device__ __forceinline__ void vec_load(float (&reg)[n], const float * ptr) {
+    if constexpr (n == 4) {
+        *reinterpret_cast<float4 *>(&reg[0]) = *reinterpret_cast<const float4 *>(ptr);
+    } else if constexpr (n == 2) {
+        *reinterpret_cast<float2 *>(&reg[0]) = *reinterpret_cast<const float2 *>(ptr);
+    } else if constexpr (n == 8) {
+        *reinterpret_cast<float4 *>(&reg[0]) = *reinterpret_cast<const float4 *>(ptr);
+        *reinterpret_cast<float4 *>(&reg[4]) = *reinterpret_cast<const float4 *>(ptr + 4);
+    } else {
+        reg[0] = ptr[0];
+    }
+}
+
+template <int n> __device__ __forceinline__ void vec_store(float * ptr, const float (&reg)[n]) {
+    if constexpr (n == 4) {
+        *reinterpret_cast<float4 *>(ptr) = *reinterpret_cast<const float4 *>(&reg[0]);
+    } else if constexpr (n == 2) {
+        *reinterpret_cast<float2 *>(ptr) = *reinterpret_cast<const float2 *>(&reg[0]);
+    } else if constexpr (n == 8) {
+        *reinterpret_cast<float4 *>(ptr)     = *reinterpret_cast<const float4 *>(&reg[0]);
+        *reinterpret_cast<float4 *>(ptr + 4) = *reinterpret_cast<const float4 *>(&reg[4]);
+    } else {
+        ptr[0] = reg[0];
+    }
+}
+
+}  // namespace
+
 template <int S_v, bool KDA>
-__global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, 2)
-gated_delta_net_cuda(const float * q,
-                                     const float * k,
-                                     const float * v,
-                                     const float * g,
-                                     const float * beta,
-                                     const float * curr_state,
-                                     float *       dst,
-                                     int64_t       H,
-                                     int64_t       n_tokens,
-                                     int64_t       n_seqs,
-                                     int64_t       sq1,
-                                     int64_t       sq2,
-                                     int64_t       sq3,
-                                     int64_t       sv1,
-                                     int64_t       sv2,
-                                     int64_t       sv3,
-                                     int64_t       sb1,
-                                     int64_t       sb2,
-                                     int64_t       sb3,
-                                     const uint3   neqk1_magic,
-                                     const uint3   rq3_magic,
-                                     float         scale) {
+__global__ void __launch_bounds__(ggml_cuda_get_physical_warp_size() * num_warps, 2) gated_delta_net_cuda(
+    const float * __restrict__ q,
+    const float * __restrict__ k,
+    const float * __restrict__ v,
+    const float * __restrict__ g,
+    const float * __restrict__ beta,
+    const float * __restrict__ curr_state,
+    float * __restrict__ dst,
+    int64_t H,
+    int64_t n_tokens,
+    int64_t n_seqs,
+    int64_t sq1,
+    int64_t sq2,
+    int64_t sq3,
+    int64_t sv1,
+    int64_t sv2,
+    int64_t sv3,
+    int64_t sb1,
+    int64_t sb2,
+    int64_t sb3,
+    uint3   neqk1_magic,
+    uint3   rq3_magic,
+    float   scale) {
+    constexpr int warp_size     = ggml_cuda_get_physical_warp_size();
+    constexpr int active_lanes  = (S_v < warp_size) ? S_v : warp_size;
+    constexpr int d_qk_per_lane = S_v / active_lanes;
+    static_assert(d_qk_per_lane >= 1, "S_v must >= 1");
+    static_assert(S_v % active_lanes == 0, "S_v must be a multiple of active_lanes");
+    static_assert(S_v % block_dv == 0, "S_v must be a multiple of block_dv");
+
     const uint32_t h_idx    = blockIdx.x;
     const uint32_t sequence = blockIdx.y;
-    // each warp owns one column, using warp-level primitives to reduce across rows
     const int      lane     = threadIdx.x;
-    const int      col      = blockIdx.z * blockDim.y + threadIdx.y;
+    const int      warp_id  = threadIdx.y;
+
+    // each warp owns d_v_per_warp rows of the state matrix; the warp's lanes shard the QK axis
+    const uint32_t dv_base  = blockIdx.z * block_dv + warp_id * d_v_per_warp;
+    const uint32_t dqk_base = lane * d_qk_per_lane;
 
     const uint32_t iq1 = fastmodulo(h_idx, neqk1_magic);
     const uint32_t iq3 = fastdiv(sequence, rq3_magic);
 
-    const int64_t attn_score_elems = S_v * H * n_tokens * n_seqs;
+    // dst layout: [attn_data | final_state]
+    const int64_t attn_score_elems = (int64_t) S_v * H * n_tokens * n_seqs;
     float *       attn_data        = dst;
-    float *       state            = dst + attn_score_elems;
+    float *       state_out        = dst + attn_score_elems;
 
-    const int64_t state_offset = (sequence * H + h_idx) * S_v * S_v;
-    state += state_offset;
-    curr_state += state_offset + col * S_v;
-    attn_data += (sequence * n_tokens * H + h_idx) * S_v;
+    const int64_t state_off = ((int64_t) sequence * H + h_idx) * S_v * S_v;
+    state_out += state_off;
+    curr_state += state_off;
+    attn_data += ((int64_t) sequence * n_tokens * H + h_idx) * S_v;
 
-    constexpr int warp_size = ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v;
-    static_assert(S_v % warp_size == 0, "S_v must be a multiple of warp_size");
-    constexpr int rows_per_lane = (S_v + warp_size - 1) / warp_size;
-    float         s_shard[rows_per_lane];
-    // state is stored transposed: M[col][i] = S[i][col], row col is contiguous
-
-#pragma unroll
-    for (int r = 0; r < rows_per_lane; r++) {
-        const int i = r * warp_size + lane;
-        s_shard[r]  = curr_state[i];
-    }
-
-    for (int t = 0; t < n_tokens; t++) {
-        const float * q_t = q + iq3 * sq3 + t * sq2 + iq1 * sq1;
-        const float * k_t = k + iq3 * sq3 + t * sq2 + iq1 * sq1;
-        const float * v_t = v + sequence * sv3 + t * sv2 + h_idx * sv1;
-
-        const int64_t gb_offset = sequence * sb3 + t * sb2 + h_idx * sb1;
-        const float * beta_t = beta + gb_offset;
-        const float * g_t    = g    + gb_offset * (KDA ? S_v : 1);
-
-        const float beta_val = *beta_t;
-
-        // Cache k and q in registers
-        float k_reg[rows_per_lane];
-        float q_reg[rows_per_lane];
-#pragma unroll
-        for (int r = 0; r < rows_per_lane; r++) {
-            const int i = r * warp_size + lane;
-            k_reg[r] = k_t[i];
-            q_reg[r] = q_t[i];
+    auto load_qk_lane = [&] __device__(float(&reg)[d_qk_per_lane], const float * base) {
+        if constexpr (S_v < warp_size) {
+            reg[0] = (lane < active_lanes) ? base[lane] : 0.0f;
+        } else {
+            vec_load<d_qk_per_lane>(reg, base + dqk_base);
         }
-
-        if constexpr (!KDA) {
-            const float g_val = expf(*g_t);
-
-            // kv[col] = (S^T @ k)[col] = sum_i S[i][col] * k[i]
-            float kv_shard = 0.0f;
-#pragma unroll
-            for (int r = 0; r < rows_per_lane; r++) {
-                kv_shard += s_shard[r] * k_reg[r];
-            }
-            float kv_col = warp_reduce_sum<warp_size>(kv_shard);
-
-            // delta[col] = (v[col] - g * kv[col]) * beta
-            float delta_col = (v_t[col] - g_val * kv_col) * beta_val;
-
-            // fused: S[i][col] = g * S[i][col] + k[i] * delta[col]
-            // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
-            float attn_partial = 0.0f;
-#pragma unroll
-            for (int r = 0; r < rows_per_lane; r++) {
-                s_shard[r]  = g_val * s_shard[r] + k_reg[r] * delta_col;
-                attn_partial += s_shard[r] * q_reg[r];
-            }
-
-            float attn_col = warp_reduce_sum<warp_size>(attn_partial);
-
-            if (lane == 0) {
-                attn_data[col] = attn_col * scale;
+    };
+    auto store_qk_lane = [&] __device__(const float(&reg)[d_qk_per_lane], float * base) {
+        if constexpr (S_v < warp_size) {
+            if (lane < active_lanes) {
+                base[lane] = reg[0];
             }
         } else {
-            // kv[col] = sum_i g[i] * S[i][col] * k[i]
-            float kv_shard = 0.0f;
+            vec_store<d_qk_per_lane>(base + dqk_base, reg);
+        }
+    };
+
+    // state is stored transposed: M[r][c] = S[c][r]
+    float s_tile[d_v_per_warp][d_qk_per_lane];
 #pragma unroll
-            for (int r = 0; r < rows_per_lane; r++) {
-                const int i = r * warp_size + lane;
-                kv_shard += expf(g_t[i]) * s_shard[r] * k_reg[r];
-            }
+    for (int r = 0; r < d_v_per_warp; ++r) {
+        load_qk_lane(s_tile[r], curr_state + (int64_t) (dv_base + r) * S_v);
+    }
 
-            float kv_col = warp_reduce_sum<warp_size>(kv_shard);
+    float k_reg[d_qk_per_lane];
+    load_qk_lane(k_reg, k + (int64_t) iq3 * sq3 + (int64_t) iq1 * sq1);
 
-            // delta[col] = (v[col] - kv[col]) * beta
-            float delta_col = (v_t[col] - kv_col) * beta_val;
+    for (int t = 0; t < n_tokens; ++t) {
+        const float * v_t = v + (int64_t) sequence * sv3 + (int64_t) t * sv2 + (int64_t) h_idx * sv1;
 
-            // fused: S[i][col] = g[i] * S[i][col] + k[i] * delta[col]
-            // attn[col] = (S^T @ q)[col] = sum_i S[i][col] * q[i]
-            float attn_partial = 0.0f;
+        const int64_t gb_off   = (int64_t) sequence * sb3 + (int64_t) t * sb2 + (int64_t) h_idx * sb1;
+        const float   beta_val = beta[gb_off];
+
+        float alpha_lane[d_qk_per_lane];
+        float alpha_scalar = 0.0f;
+        if constexpr (KDA) {
+            float g_reg[d_qk_per_lane];
+            load_qk_lane(g_reg, g + gb_off * S_v);
 #pragma unroll
-            for (int r = 0; r < rows_per_lane; r++) {
-                const int i = r * warp_size + lane;
-                s_shard[r]  = expf(g_t[i]) * s_shard[r] + k_reg[r] * delta_col;
-                attn_partial += s_shard[r] * q_reg[r];
+            for (int c = 0; c < d_qk_per_lane; ++c) {
+                alpha_lane[c] = expf(g_reg[c]);
             }
+        } else {
+            alpha_scalar = expf(g[gb_off]);
+        }
 
-            float attn_col = warp_reduce_sum<warp_size>(attn_partial);
+        // only first d_v_per_warp lanes hold a real v[dv_base + lane]; broadcast via __shfl_sync
+        float v_local = 0.0f;
+        if (lane < d_v_per_warp) {
+            v_local = v_t[dv_base + lane];
+        }
 
-            if (lane == 0) {
-                attn_data[col] = attn_col * scale;
+        // stage A: state update
+#pragma unroll
+        for (int r = 0; r < d_v_per_warp; ++r) {
+            float partial = 0.0f;
+#pragma unroll
+            for (int c = 0; c < d_qk_per_lane; ++c) {
+                if constexpr (KDA) {
+                    partial += alpha_lane[c] * s_tile[r][c] * k_reg[c];
+                } else {
+                    partial += s_tile[r][c] * k_reg[c];
+                }
+            }
+            partial = warp_reduce_sum<warp_size>(partial);
+
+            const float v_r   = __shfl_sync(0xffffffff, v_local, r, warp_size);
+            const float delta = beta_val * (v_r - (KDA ? 1.0f : alpha_scalar) * partial);
+
+#pragma unroll
+            for (int c = 0; c < d_qk_per_lane; ++c) {
+                if constexpr (KDA) {
+                    s_tile[r][c] = alpha_lane[c] * s_tile[r][c] + delta * k_reg[c];
+                } else {
+                    s_tile[r][c] = alpha_scalar * s_tile[r][c] + delta * k_reg[c];
+                }
             }
         }
 
-        attn_data += S_v * H;
+        // prefetch k for next token while issuing the q load for this token
+        if (t + 1 < n_tokens) {
+            load_qk_lane(k_reg, k + (int64_t) iq3 * sq3 + (int64_t) (t + 1) * sq2 + (int64_t) iq1 * sq1);
+        }
+
+        float q_reg[d_qk_per_lane];
+        load_qk_lane(q_reg, q + (int64_t) iq3 * sq3 + (int64_t) t * sq2 + (int64_t) iq1 * sq1);
+
+        // stage B: attention output
+        float attn_val = 0.0f;
+#pragma unroll
+        for (int r = 0; r < d_v_per_warp; ++r) {
+            float partial = 0.0f;
+#pragma unroll
+            for (int c = 0; c < d_qk_per_lane; ++c) {
+                partial += s_tile[r][c] * q_reg[c];
+            }
+            partial = warp_reduce_sum<warp_size>(partial);
+            if (lane == r) {
+                attn_val = partial;
+            }
+        }
+
+        if (lane < d_v_per_warp) {
+            float * attn_t         = attn_data + (int64_t) t * S_v * H;
+            attn_t[dv_base + lane] = attn_val * scale;
+        }
     }
 
-    // Write state back to global memory (transposed layout)
+    // store final state
 #pragma unroll
-    for (int r = 0; r < rows_per_lane; r++) {
-        const int i          = r * warp_size + lane;
-        state[col * S_v + i] = s_shard[r];
+    for (int r = 0; r < d_v_per_warp; ++r) {
+        store_qk_lane(s_tile[r], state_out + (int64_t) (dv_base + r) * S_v);
     }
 }
 
 template <bool KDA>
-static void launch_gated_delta_net(
-        const float * q_d, const float * k_d, const float * v_d,
-        const float * g_d, const float * b_d, const float * s_d,
-        float * dst_d,
-        int64_t S_v,   int64_t H, int64_t n_tokens, int64_t n_seqs,
-        int64_t sq1,   int64_t sq2, int64_t sq3,
-        int64_t sv1,   int64_t sv2, int64_t sv3,
-        int64_t sb1,   int64_t sb2, int64_t sb3,
-        int64_t neqk1, int64_t rq3,
-        float scale, cudaStream_t stream) {
+static void launch_gated_delta_net(const float * q_d,
+                                   const float * k_d,
+                                   const float * v_d,
+                                   const float * g_d,
+                                   const float * b_d,
+                                   const float * s_d,
+                                   float *       dst_d,
+                                   int64_t       S_v,
+                                   int64_t       H,
+                                   int64_t       n_tokens,
+                                   int64_t       n_seqs,
+                                   int64_t       sq1,
+                                   int64_t       sq2,
+                                   int64_t       sq3,
+                                   int64_t       sv1,
+                                   int64_t       sv2,
+                                   int64_t       sv3,
+                                   int64_t       sb1,
+                                   int64_t       sb2,
+                                   int64_t       sb3,
+                                   int64_t       neqk1,
+                                   int64_t       rq3,
+                                   float         scale,
+                                   cudaStream_t  stream) {
     //TODO: Add chunked kernel for even faster pre-fill
-    const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
-    const int num_warps = 4;
-    dim3      grid_dims(H, n_seqs, (S_v + num_warps - 1) / num_warps);
-    dim3      block_dims(warp_size <= S_v ? warp_size : S_v, num_warps, 1);
-
+    const int   warp_size   = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
+    const int   n_block_dv  = (int) ((S_v + block_dv - 1) / block_dv);
     const uint3 neqk1_magic = init_fastdiv_values(neqk1);
     const uint3 rq3_magic   = init_fastdiv_values(rq3);
 
-    int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
+    dim3 grid_dims((unsigned) H, (unsigned) n_seqs, (unsigned) n_block_dv);
+    dim3 block_dims(warp_size, num_warps, 1);
 
     switch (S_v) {
         case 16:
             gated_delta_net_cuda<16, KDA><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
-                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
-                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3, sb1, sb2, sb3,
+                neqk1_magic, rq3_magic, scale);
             break;
         case 32:
             gated_delta_net_cuda<32, KDA><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
-                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
-                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3, sb1, sb2, sb3,
+                neqk1_magic, rq3_magic, scale);
             break;
-        case 64: {
+        case 64:
             gated_delta_net_cuda<64, KDA><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
-                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
-                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3, sb1, sb2, sb3,
+                neqk1_magic, rq3_magic, scale);
             break;
-        }
-        case 128: {
+        case 128:
             gated_delta_net_cuda<128, KDA><<<grid_dims, block_dims, 0, stream>>>(
-                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H,
-                n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
-                sb1, sb2, sb3, neqk1_magic, rq3_magic, scale);
+                q_d, k_d, v_d, g_d, b_d, s_d, dst_d, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3, sb1, sb2, sb3,
+                neqk1_magic, rq3_magic, scale);
             break;
-        }
         default:
             GGML_ABORT("fatal error");
             break;
@@ -209,12 +272,12 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     ggml_tensor * src_state = dst->src[5];
 
     GGML_TENSOR_LOCALS(int64_t, neq, src_q, ne);
-    GGML_TENSOR_LOCALS(size_t , nbq, src_q, nb);
+    GGML_TENSOR_LOCALS(size_t, nbq, src_q, nb);
     GGML_TENSOR_LOCALS(int64_t, nek, src_k, ne);
-    GGML_TENSOR_LOCALS(size_t , nbk, src_k, nb);
+    GGML_TENSOR_LOCALS(size_t, nbk, src_k, nb);
     GGML_TENSOR_LOCALS(int64_t, nev, src_v, ne);
-    GGML_TENSOR_LOCALS(size_t,  nbv, src_v, nb);
-    GGML_TENSOR_LOCALS(size_t,  nbb, src_beta, nb);
+    GGML_TENSOR_LOCALS(size_t, nbv, src_v, nb);
+    GGML_TENSOR_LOCALS(size_t, nbb, src_beta, nb);
 
     const int64_t S_v      = nev0;
     const int64_t H        = nev1;
@@ -262,12 +325,10 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
     cudaStream_t stream = ctx.stream();
 
     if (kda) {
-        launch_gated_delta_net<true>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d,
-            S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
-            sb1, sb2, sb3, neqk1, rq3, scale, stream);
+        launch_gated_delta_net<true>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d, S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1,
+                                     sv2, sv3, sb1, sb2, sb3, neqk1, rq3, scale, stream);
     } else {
-        launch_gated_delta_net<false>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d,
-            S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
-            sb1, sb2, sb3, neqk1, rq3, scale, stream);
+        launch_gated_delta_net<false>(q_d, k_d, v_d, g_d, b_d, s_d, dst_d, S_v, H, n_tokens, n_seqs, sq1, sq2, sq3, sv1,
+                                      sv2, sv3, sb1, sb2, sb3, neqk1, rq3, scale, stream);
     }
 }


### PR DESCRIPTION
## Overview

I rewrote the autoregressive `GATED_DELTA_NET` CUDA kernel. The old version had each warp working on one output column at a time. I changed it so each warp handles multiple output rows instead.

## Benchmarks

All numbers measured on RTX 5090.

### Kernel microbenchmark

Shape: `S_v = 128, hk = 16, hv = 32, B = 1, kda = 0, dtype = f32`

| L (n_tokens) | master (μs) | this PR (μs) | speedup |
|---:|---:|---:|---:|
|    1 |  28.3 |  24.5 | +15.7% |
|    2 |  24.7 |  24.4 |  +1.3% |
|    4 |  26.1 |  23.0 | +13.3% |
|    8 |  26.3 |  24.7 |  +6.7% |
|   16 |  29.9 |  26.7 | +11.8% |
|   32 |  37.7 |  31.4 | +20.2% |
|   64 |  53.9 |  40.5 | +33.1% |
|  128 |  84.7 |  61.4 | +37.9% |
|  256 | 155.6 | 111.8 | +39.1% |
|  512 | 279.6 | 190.2 | +47.0% |
| 1024 | 525.1 | 346.6 | +51.5% |

### End-to-end (llama-bench, `-ngl 99 -r 10 --delay 5`)

#### Qwen3.5-9B-BF16

| Test | master (t/s) | this PR (t/s) | Δ% |
|:-----|------------:|-------------:|---:|
| pp128     | 5785.0 ± 620.9 | 6031.7 ± 636.0 | +4.3% |
| pp256     | 7639.3 ±  455.8 | 8170.6 ±  386.3 | +7.0% |
| pp512     | 8542.8 ±  237.5 | 8993.8 ±  293.1 | +5.3% |
| pp1024    | 8214.0 ±   52.1 | 8585.7 ±   21.1 | +4.5% |
| pp2048    | 8341.0 ±   43.0 | 8635.0 ±   33.5 | +3.5% |
| tg128     |   82.5 ±    0.1 |   82.1 ±    0.6 | -0.5% |
| tg256     |   82.6 ±    0.3 |   82.9 ±    0.2 | +0.4% |
| tg512     |   82.4 ±    0.2 |   82.4 ±    0.2 | -0.0% |
| pg512+128 |  395.3 ±    0.6 |  395.1 ±    1.6 | -0.0% |

#### Qwen3.5-27B-Q4_K_M

| Test | master (t/s) | this PR (t/s) | Δ% |
|:-----|------------:|-------------:|---:|
| pp128     | 2603.2 ± 293.1 | 2695.8 ± 302.5 | +3.6% |
| pp256     | 3293.6 ±  87.7 | 3464.4 ± 114.5 | +5.2% |
| pp512     | 3608.3 ±  80.2 | 3806.1 ±  78.9 | +5.5% |
| pp1024    | 3496.4 ±  11.4 | 3690.9 ±  21.4 | +5.6% |
| pp2048    | 3483.8 ±  23.7 | 3660.4 ±  14.6 | +5.1% |
| tg128     |   67.8 ±   0.1 |   67.9 ±   0.1 | +0.1% |
| tg256     |   68.0 ±   0.2 |   67.8 ±   0.2 | -0.2% |
| tg512     |   67.6 ±   0.2 |   67.6 ±   0.2 | +0.1% |
| pg512+128 |  313.7 ±   0.4 |  315.2 ±   1.1 | +0.5% |

#### Qwen3.5-35B-A3B-Q4_K_M

| Test | master (t/s) | this PR (t/s) | Δ% |
|:-----|------------:|-------------:|---:|
| pp128     | 2653.8 ± 33.9 | 2751.9 ± 55.5 | +3.7% |
| pp256     | 5264.8 ± 71.1 | 5540.2 ± 86.7 | +5.2% |
| pp512     | 7831.0 ± 89.8 | 8341.0 ± 93.6 | +6.5% |
| pp1024    | 7922.8 ± 48.8 | 8323.1 ± 61.7 | +5.1% |
| pp2048    | 7938.0 ± 47.3 | 8328.9 ± 52.9 | +4.9% |
| tg128     |  200.1 ±  0.6 |  200.8 ±  1.1 | +0.3% |
| tg256     |  204.5 ±  0.6 |  204.7 ±  0.4 | +0.1% |
| tg512     |  201.9 ±  0.9 |  202.6 ±  0.8 | +0.3% |
| pg512+128 |  925.8 ±  7.3 |  939.6 ±  2.7 | +1.5% |

PP improves by +3% to +7% across all three models; TG and mixed (PG)
are within measurement noise.

### Correctness

- `test-backend-ops -o GATED_DELTA_NET` on CUDA0: **18/18 pass** 
- Perplexity (Qwen3.5-0.8B-BF16, wikitext-2 test, `ctx=2048`, 50 chunks):
  master `15.7976 ± 0.2132` vs this PR `15.7935 ± 0.2131`.

## Note on #22400

I saw there's an open PR (#22400) that adds speculative decoding support to the GDN kernel. My new layout should adapt to that pretty naturally. And since spec decode runs multi-token forward passes, the speedup from this PR should help there too.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — I used AI to help understand the codebase structure, run benchmarks, and format the results into tables. The kernel design and implementation are my own.
