### PR TITLE
metal : pair rsets_add with rsets_rm on buffer free (fix #22593)

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1373,6 +1373,16 @@ static void ggml_metal_buffer_rset_free(ggml_metal_buffer_t buf) {
         if (buf->rset) {
             [buf->rset endResidency];
             [buf->rset removeAllAllocations];
+            // Symmetric pairing for ggml_metal_device_rsets_add (called from
+            // ggml_metal_buffer_rset_init): the device-side collection holds
+            // a reference to this rset so the keep-alive heartbeat thread can
+            // requestResidency on it. Without removing it here, the device's
+            // rsets->data array retains a (about-to-be-released) reference,
+            // and ggml_metal_rsets_free on device shutdown asserts
+            // [rsets->data count] == 0 deterministically. (Issue: assertion
+            // fires on macOS 15+ for any consumer that allocates buffers
+            // and then tears down the device.)
+            ggml_metal_device_rsets_rm(buf->dev, buf->rset);
             [buf->rset release];
         }
     }


### PR DESCRIPTION
Fixes #22593.

\`ggml_metal_device_rsets_add\` is called from \`ggml_metal_buffer_rset_init\` (line 1467) for every buffer when residency sets are active. The symmetric \`ggml_metal_device_rsets_rm\` API exists (line 911) but was **defined and never called from anywhere in the tree** — so the device's \`rsets->data\` array always retained references the per-buffer \`rset_free\` had just released. On \`ggml_metal_device_free\` → \`ggml_metal_rsets_free\` the assertion \`[rsets->data count] == 0\` fires deterministically.

Reproducible on macOS 15+ for any consumer that allocates buffers and tears down the device. Confirmed on Apple M5 Pro / macOS 15+ via a downstream consumer.

The fix is one line: pair the add with a remove in the buffer's \`rset_free\` path, before release. \`buf->dev\` is already populated by the time \`rset_free\` runs (\`struct ggml_metal_buffer.dev\`, line 1303) so no plumbing is needed. Build-tested locally on M5 Pro / macOS 15.

The residency-sets API was added in #17766; the remove-side wiring was missed in that PR. This commit closes that asymmetry.

### Why not the env-var workaround

\`GGML_METAL_NO_RESIDENCY=1\` (line 775) bypasses the entire feature — but that throws away the keep-alive heartbeat #17766 was specifically optimizing for. On Metal-perf-critical consumers that's the wrong shape; this PR keeps the optimization and removes the assertion.