### PR TITLE
common: make --fit validate shared UMA memory budgets

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1148,12 +1148,16 @@ common_init_result::common_init_result(common_params & params) :
 
     if (params.fit_params) {
         LOG_INF("%s: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on\n", __func__);
-        common_fit_params(params.model.path.c_str(), &mparams, &cparams,
+        const common_params_fit_status fit_status = common_fit_params(params.model.path.c_str(), &mparams, &cparams,
             params.tensor_split,
             params.tensor_buft_overrides.data(),
             params.fit_params_target.data(),
             params.fit_params_min_ctx,
             params.verbosity >= 4 ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
+        if (fit_status != COMMON_PARAMS_FIT_STATUS_SUCCESS) {
+            LOG_ERR("%s: --fit failed, aborting model load instead of continuing with unsafe parameters\n", __func__);
+            return;
+        }
     }
 
     llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -1,16 +1,39 @@
 #include "fit.h"
 
+#include "llama.h"
 #include "log.h"
 
 #include "../src/llama-ext.h"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
 #include <stdexcept>
 #include <cinttypes>
+#include <limits>
+#include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
+
+#if defined(_WIN32)
+#   ifndef WIN32_LEAN_AND_MEAN
+#       define WIN32_LEAN_AND_MEAN
+#   endif
+#   ifndef NOMINMAX
+#       define NOMINMAX
+#   endif
+#   include <windows.h>
+#elif defined(__linux__)
+#   include <unistd.h>
+#elif defined(__APPLE__) && defined(__MACH__)
+#   include <mach/mach.h>
+#   include <sys/sysctl.h>
+#endif
 
 // this enum is only used in llama_params_fit_impl but needs to be defined outside of it to fix a Windows compilation issue
 // enum to identify part of a layer for distributing its tensors:
@@ -25,6 +48,411 @@ enum common_layer_fraction_t {
 class common_params_fit_exception : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
+
+static constexpr int64_t COMMON_FIT_MIB = 1024LL*1024LL;
+static constexpr int64_t COMMON_FIT_GIB = 1024LL*COMMON_FIT_MIB;
+
+static std::string common_fit_lower(std::string s) {
+    for (char & c : s) {
+        c = char(std::tolower((unsigned char) c));
+    }
+    return s;
+}
+
+static bool common_fit_contains(const std::string & text, const char * needle) {
+    return text.find(needle) != std::string::npos;
+}
+
+static bool common_fit_env_flag_enabled(const char * name) {
+    const char * value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0') {
+        return false;
+    }
+
+    const std::string normalized = common_fit_lower(value);
+    return normalized != "0" && normalized != "false" && normalized != "no" && normalized != "off";
+}
+
+static bool common_fit_totals_are_close(const size_t a, const size_t b) {
+    if (a == 0 || b == 0) {
+        return false;
+    }
+
+    const long double lo = std::min(a, b);
+    const long double hi = std::max(a, b);
+    return lo / hi >= 0.90L;
+}
+
+static std::string common_fit_dev_text(ggml_backend_dev_t dev) {
+    if (dev == nullptr) {
+        return "";
+    }
+
+    const char * name_c = ggml_backend_dev_name(dev);
+    const char * desc_c = ggml_backend_dev_description(dev);
+    const std::string name = common_fit_lower(name_c ? name_c : "");
+    const std::string desc = common_fit_lower(desc_c ? desc_c : "");
+    return name + " " + desc;
+}
+
+static bool common_fit_dev_overlaps_host_budget(
+        ggml_backend_dev_t dev,
+        const llama_device_memory_data & dmd_dev,
+        const llama_device_memory_data & dmd_host) {
+    if (dev == nullptr || ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_CPU) {
+        return false;
+    }
+
+    // CUDA unified memory intentionally makes device allocations compete with the
+    // system-memory pool. Treat it like an overlapping budget even on discrete GPUs.
+    if (common_fit_env_flag_enabled("GGML_CUDA_ENABLE_UNIFIED_MEMORY")) {
+        return true;
+    }
+
+    const std::string text = common_fit_dev_text(dev);
+
+    // Backends do not currently expose a portable "this heap is system backed"
+    // flag here, so keep the explicit part conservative and vendor-neutral.
+    // The generic "Graphics" suffix alone is not enough: some discrete GPUs use
+    // broad marketing names. It becomes a UMA signal only when it is paired with
+    // an APU/iGPU string or a device budget that is essentially the host budget.
+    const bool text_declares_uma =
+        common_fit_contains(text, "integrated") ||
+        common_fit_contains(text, "igpu")       ||
+        common_fit_contains(text, "apu")        ||
+        common_fit_contains(text, "uma")        ||
+        common_fit_contains(text, "unified")    ||
+        common_fit_contains(text, "shared")     ||
+        common_fit_contains(text, "strx_halo")  ||
+        common_fit_contains(text, "strix_halo") ||
+        common_fit_contains(text, "strix halo") ||
+        common_fit_contains(text, "uhd graphics") ||
+        common_fit_contains(text, "iris")       ||
+        common_fit_contains(text, "xe graphics") ||
+        common_fit_contains(text, "radeon 8060s") ||
+        common_fit_contains(text, "radeon 8050s") ||
+        common_fit_contains(text, "radeon 890m")  ||
+        common_fit_contains(text, "radeon 880m")  ||
+        common_fit_contains(text, "radeon 780m")  ||
+        common_fit_contains(text, "radeon 680m");
+
+    if (text_declares_uma) {
+        return true;
+    }
+
+    const bool device_budget_looks_like_host_budget = common_fit_totals_are_close(dmd_dev.total, dmd_host.total);
+    const bool generic_integrated_name =
+        common_fit_contains(text, "graphics") &&
+        (common_fit_contains(text, "intel") || common_fit_contains(text, "radeon") || common_fit_contains(text, "amd"));
+
+    return device_budget_looks_like_host_budget && generic_integrated_name;
+}
+
+static int64_t common_fit_memory_total_i64(const llama_memory_breakdown_data & mb) {
+    return int64_t(mb.total());
+}
+
+static int64_t common_fit_clamp_i64(const int64_t value, const int64_t lo, const int64_t hi) {
+    return std::max(lo, std::min(value, hi));
+}
+
+struct common_fit_host_memory_status {
+    size_t available = 0;
+    size_t total     = 0;
+    size_t watermark = 0;
+    const char * source = "";
+};
+
+#if defined(__linux__)
+static size_t common_fit_get_linux_zone_high_watermark() {
+    std::ifstream zoneinfo("/proc/zoneinfo");
+    if (!zoneinfo.is_open()) {
+        return 0;
+    }
+
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        return 0;
+    }
+
+    uint64_t high_pages = 0;
+    std::string key;
+    uint64_t value = 0;
+    while (zoneinfo >> key) {
+        if (key == "high" && (zoneinfo >> value)) {
+            high_pages += value;
+        }
+    }
+
+    return size_t(high_pages * uint64_t(page_size));
+}
+#endif
+
+static bool common_fit_get_os_host_memory(common_fit_host_memory_status & status) {
+#if defined(_WIN32)
+    MEMORYSTATUSEX statex;
+    statex.dwLength = sizeof(statex);
+    if (!GlobalMemoryStatusEx(&statex)) {
+        return false;
+    }
+    status.available = size_t(statex.ullAvailPhys);
+    status.total     = size_t(statex.ullTotalPhys);
+    status.source    = "GlobalMemoryStatusEx";
+    return status.available > 0 && status.total > 0;
+#elif defined(__linux__)
+    std::ifstream meminfo("/proc/meminfo");
+    if (!meminfo.is_open()) {
+        return false;
+    }
+
+    uint64_t mem_total_kib = 0;
+    uint64_t mem_available_kib = 0;
+    std::string key;
+    uint64_t value = 0;
+    std::string unit;
+    while (meminfo >> key >> value >> unit) {
+        if (key == "MemTotal:") {
+            mem_total_kib = value;
+        } else if (key == "MemAvailable:") {
+            mem_available_kib = value;
+        }
+    }
+    if (mem_total_kib == 0 || mem_available_kib == 0) {
+        return false;
+    }
+
+    status.available = size_t(mem_available_kib * 1024ULL);
+    status.total     = size_t(mem_total_kib     * 1024ULL);
+    status.watermark = common_fit_get_linux_zone_high_watermark();
+    status.source    = "/proc/meminfo MemAvailable";
+    return true;
+#elif defined(__APPLE__) && defined(__MACH__)
+    uint64_t mem_total = 0;
+    size_t mem_total_len = sizeof(mem_total);
+    if (sysctlbyname("hw.memsize", &mem_total, &mem_total_len, nullptr, 0) != 0 || mem_total == 0) {
+        return false;
+    }
+
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    vm_statistics64_data_t vmstat;
+    if (host_statistics64(mach_host_self(), HOST_VM_INFO64, reinterpret_cast<host_info64_t>(&vmstat), &count) != KERN_SUCCESS) {
+        return false;
+    }
+
+    vm_size_t page_size = 0;
+    if (host_page_size(mach_host_self(), &page_size) != KERN_SUCCESS || page_size == 0) {
+        return false;
+    }
+
+    const uint64_t reusable_pages = uint64_t(vmstat.free_count)
+        + uint64_t(vmstat.inactive_count)
+        + uint64_t(vmstat.speculative_count);
+    status.available = size_t(reusable_pages * uint64_t(page_size));
+    status.total     = size_t(mem_total);
+    status.source    = "host_statistics64";
+    return status.available > 0 && status.total > 0;
+#else
+    (void) status;
+    return false;
+#endif
+}
+
+static bool common_fit_get_file_size(const char * path, uint64_t & size) {
+    size = 0;
+    if (path == nullptr || path[0] == '\0') {
+        return false;
+    }
+
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    const std::streampos end = file.tellg();
+    if (end <= 0) {
+        return false;
+    }
+
+    size = static_cast<uint64_t>(end);
+    return true;
+}
+
+static void common_fit_probe_load_precheck(const char * path_model, const llama_model_params * mparams) {
+    if (mparams == nullptr || mparams->use_mmap) {
+        return;
+    }
+
+    common_fit_host_memory_status os_host_memory;
+    if (!common_fit_get_os_host_memory(os_host_memory) || os_host_memory.available == 0) {
+        LOG_WRN("%s: cannot pre-check --no-mmap probe-load risk because OS host-memory availability is unknown\n", __func__);
+        return;
+    }
+
+    uint64_t model_size = 0;
+    if (!common_fit_get_file_size(path_model, model_size) || model_size == 0) {
+        LOG_WRN("%s: cannot pre-check --no-mmap probe-load risk because model file size is unknown\n", __func__);
+        return;
+    }
+
+    const uint64_t available = static_cast<uint64_t>(os_host_memory.available);
+    const uint64_t guard = static_cast<uint64_t>(std::min<size_t>(
+        std::max<size_t>(os_host_memory.available / 16, size_t(512)*COMMON_FIT_MIB),
+        size_t(4)*COMMON_FIT_GIB));
+
+    if (model_size > available || guard > available - model_size) {
+        throw common_params_fit_exception(std::string("--fit probe-load precheck failed: --no-mmap model file is ")
+            + std::to_string(model_size/COMMON_FIT_MIB) + " MiB, available host memory is "
+            + std::to_string(available/COMMON_FIT_MIB) + " MiB, required preflight guard is "
+            + std::to_string(guard/COMMON_FIT_MIB)
+            + " MiB; refusing to make the fit probe the first unsafe allocation point");
+    }
+
+    LOG_DBG("%s: --no-mmap probe-load precheck passed: model=%" PRIu64 " MiB, host available=%" PRIu64 " MiB, guard=%" PRIu64 " MiB (%s)\n",
+        __func__, model_size/COMMON_FIT_MIB, available/COMMON_FIT_MIB, guard/COMMON_FIT_MIB, os_host_memory.source);
+}
+
+struct common_fit_shared_margin_result {
+    int64_t margin           = 0;
+    int64_t guard            = 0;
+    int64_t kernel_watermark = 0;
+    const char * profile     = "generic";
+};
+
+static common_fit_shared_margin_result common_fit_shared_host_memory_margin(
+        int64_t shared_total,
+        int64_t requested_margin,
+        int64_t os_watermark,
+        bool has_rocm_overlap,
+        bool has_vulkan_overlap) {
+
+    const int64_t GiB = COMMON_FIT_GIB;
+
+    common_fit_shared_margin_result result;
+    result.margin = requested_margin;
+
+    if (shared_total <= 0) {
+        return result;
+    }
+
+    // Budget group 2 is the overlapping UMA / unified-memory pool. Keep the
+    // base reserve backend-neutral and easy to reason about: choose a small
+    // system-RAM reserve by host-memory class, then add the kernel watermark
+    // when the OS exposes one. This avoids both extremes:
+    //   - no UMA headroom on small shared-memory systems
+    //   - a huge shared_total/N penalty on large UMA systems
+    // The final steady-state memory and startup transient reserve are modeled
+    // separately below.
+    const char * profile =
+        has_rocm_overlap   ? "rocm-uma-system-reserve-tiered" :
+        has_vulkan_overlap ? "vulkan-uma-system-reserve-tiered" :
+                             "uma-system-reserve-tiered";
+
+    int64_t shared_budget_guard = 3*GiB;
+    if (shared_total >= 192*GiB) {
+        shared_budget_guard = 9*GiB;
+    } else if (shared_total >= 96*GiB) {
+        shared_budget_guard = 6*GiB;
+    }
+
+    // Linux zone high watermarks are added on top when available, because those
+    // pages are not usable allocation headroom. Users can still request a larger
+    // target explicitly via --fit-target.
+    const int64_t kernel_watermark = os_watermark > 0 ? 2*os_watermark : 0;
+
+    result.guard            = shared_budget_guard;
+    result.kernel_watermark = kernel_watermark;
+    result.profile          = profile;
+    result.margin           = std::max(requested_margin, shared_budget_guard + kernel_watermark);
+    return result;
+}
+
+struct common_fit_shared_memory_components {
+    int64_t model   = 0;
+    int64_t context = 0;
+    int64_t compute = 0;
+
+    int64_t total() const {
+        return model + context + compute;
+    }
+};
+
+struct common_fit_shared_peak_guard_result {
+    // Additional headroom required while the real loader reaches the steady
+    // state measured by memory_breakdown. This is a reserve, not an assertion
+    // that final steady memory is larger.
+    int64_t guard         = 0;
+    int64_t compute_guard = 0;
+    int64_t context_guard = 0;
+    int64_t model_guard   = 0;
+    int64_t min_guard     = 0;
+    int64_t max_guard     = 0;
+    int64_t context_div   = 0;
+    int64_t model_div     = 0;
+    const char * model_profile = "steady-model-fragmentation";
+};
+
+static common_fit_shared_peak_guard_result common_fit_shared_peak_guard(
+        const common_fit_shared_memory_components & c,
+        int64_t shared_total,
+        const llama_model_params * mparams) {
+    const int64_t GiB = COMMON_FIT_GIB;
+
+    common_fit_shared_peak_guard_result result;
+
+    // The no_alloc probe gives a steady-state memory breakdown. The real startup
+    // has an additional load/upload phase before it reaches that steady state.
+    // On UMA this phase is charged to the same shared RAM budget as the final
+    // device buffers, so fit needs an explicit transient headroom model.
+    //
+    // Keep the steady-state prediction exact and account for a small generic
+    // loader/upload window separately. This avoids treating the transient load
+    // phase as permanent model memory while still protecting UMA budgets where
+    // upload/staging pressure competes with the final device buffers.
+    int64_t default_model_div = 32;
+    result.model_profile = "mmap-loader-window";
+    if (mparams != nullptr && !mparams->use_mmap) {
+        default_model_div = mparams->use_direct_io ? 20 : 16;
+        result.model_profile = mparams->use_direct_io ? "direct-io-loader-window" : "non-mmap-loader-window";
+    } else if (mparams != nullptr && mparams->use_direct_io) {
+        default_model_div = 24;
+        result.model_profile = "direct-io-mmap-loader-window";
+    }
+
+    result.context_div = 16;
+    result.model_div   = default_model_div;
+
+    result.min_guard = 512*COMMON_FIT_MIB;
+    result.max_guard = shared_total > 0 ? std::min<int64_t>(shared_total / 8, 16*GiB) : 16*GiB;
+    result.max_guard = std::max(result.max_guard, result.min_guard);
+
+    result.compute_guard = std::max<int64_t>(0, c.compute);
+    result.context_guard = std::max<int64_t>(0, c.context / result.context_div);
+    result.model_guard   = std::max<int64_t>(0, c.model   / result.model_div);
+
+    int64_t guard = std::max(result.min_guard, std::max(result.compute_guard, std::max(result.context_guard, result.model_guard)));
+
+
+    result.guard = common_fit_clamp_i64(guard, result.min_guard, result.max_guard);
+    return result;
+}
+
+static void common_fit_reserve_probe_graph(llama_model * model, llama_context * ctx, const llama_context_params * cparams) {
+    uint32_t n_tokens = 1;
+    if (llama_model_has_decoder(model)) {
+        const uint32_t n_batch = cparams->n_batch == 0 ? 1 : cparams->n_batch;
+        n_tokens = std::max<uint32_t>(1, std::min<uint32_t>(2, n_batch));
+    }
+
+    if (llama_graph_reserve(ctx, n_tokens, 1, n_tokens) == nullptr) {
+        throw common_params_fit_exception("failed to reserve compute graph for fit probe");
+    }
+}
+
+// The fit probe must measure the same steady-state buffers that real startup will
+// require, but it must not execute a decode. Reserving the graph is enough to
+// materialize the compute-buffer reservation in the memory breakdown without
+// mutating generation state; startup/load transients are still modeled separately
+// for shared-memory UMA budgets below.
 
 static std::vector<llama_device_memory_data> common_get_device_memory_data(
         const char * path_model,
@@ -46,34 +474,44 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data(
     llama_log_get(&ud.original_logger.callback, &ud.original_logger.user_data);
     ud.min_level = log_level;
 
+    struct log_restore_t {
+        ggml_log_callback callback;
+        void * user_data;
+
+        ~log_restore_t() {
+            llama_log_set(callback, user_data);
+        }
+    } log_restore { ud.original_logger.callback, ud.original_logger.user_data };
+
     llama_log_set([](ggml_log_level level, const char * text, void * user_data) {
         const user_data_t * ud = (const user_data_t *) user_data;
         const ggml_log_level level_eff = level >= ud->min_level ? level : GGML_LOG_LEVEL_DEBUG;
         ud->original_logger.callback(level_eff, text, ud->original_logger.user_data);
     }, &ud);
 
+    common_fit_probe_load_precheck(path_model, mparams);
+
     llama_model_params mparams_copy = *mparams;
     mparams_copy.no_alloc  = true;
-    mparams_copy.use_mmap  = false;
+    mparams_copy.use_mmap  = mparams->use_mmap;
     mparams_copy.use_mlock = false;
 
-    llama_model * model = llama_model_load_from_file(path_model, mparams_copy);
+    std::unique_ptr<llama_model, decltype(&llama_model_free)> model(llama_model_load_from_file(path_model, mparams_copy), llama_model_free);
     if (model == nullptr) {
-        llama_log_set(ud.original_logger.callback, ud.original_logger.user_data);
         throw std::runtime_error("failed to load model");
     }
 
-    llama_context * ctx = llama_init_from_model(model, *cparams);
+    std::unique_ptr<llama_context, decltype(&llama_free)> ctx(llama_init_from_model(model.get(), *cparams), llama_free);
     if (ctx == nullptr) {
-        llama_model_free(model);
-        llama_log_set(ud.original_logger.callback, ud.original_logger.user_data);
         throw std::runtime_error("failed to create llama_context from model");
     }
 
-    const size_t nd = llama_model_n_devices(model);
+    common_fit_reserve_probe_graph(model.get(), ctx.get(), cparams);
+
+    const size_t nd = llama_model_n_devices(model.get());
     std::vector<llama_device_memory_data> ret(nd + 1);
 
-    llama_memory_breakdown memory_breakdown = llama_get_memory_breakdown(ctx);
+    llama_memory_breakdown memory_breakdown = llama_get_memory_breakdown(ctx.get());
 
     for (const auto & [buft, mb] : memory_breakdown) {
         if (ggml_backend_buft_is_host(buft)) {
@@ -88,7 +526,7 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data(
             continue;
         }
         for (size_t i = 0; i < nd; i++) {
-            if (dev == llama_model_get_device(model, i)) {
+            if (dev == llama_model_get_device(model.get(), i)) {
                 ret[i].mb.model   += mb.model;
                 ret[i].mb.context += mb.context;
                 ret[i].mb.compute += mb.compute;
@@ -105,39 +543,54 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data(
         size_t free;
         size_t total;
         ggml_backend_dev_memory(cpu_dev, &free, &total);
+
+        common_fit_host_memory_status os_host_memory;
+        if (common_fit_get_os_host_memory(os_host_memory)) {
+            if (free == 0 || os_host_memory.available < free) {
+                LOG_INF("%s: host available memory from %s limits fit budget to %zu MiB (backend reported %zu MiB)\n",
+                    __func__, os_host_memory.source, os_host_memory.available/COMMON_FIT_MIB, free/COMMON_FIT_MIB);
+                free = os_host_memory.available;
+            } else {
+                LOG_DBG("%s: host available memory from %s is %zu MiB (backend reported %zu MiB)\n",
+                    __func__, os_host_memory.source, os_host_memory.available/COMMON_FIT_MIB, free/COMMON_FIT_MIB);
+            }
+
+            if (total == 0 || os_host_memory.total < total) {
+                total = os_host_memory.total;
+            }
+            if (os_host_memory.watermark > 0) {
+                LOG_DBG("%s: OS memory watermark from %s is %zu MiB\n",
+                    __func__, os_host_memory.source, os_host_memory.watermark/COMMON_FIT_MIB);
+            }
+        }
+
         ret.back().free  = free;
         ret.back().total = total;
     }
     for (size_t i = 0; i < nd; i++) {
         size_t free;
         size_t total;
-        ggml_backend_dev_memory(llama_model_get_device(model, i), &free, &total);
+        ggml_backend_dev_t dev = llama_model_get_device(model.get(), i);
+        ggml_backend_dev_memory(dev, &free, &total);
 
-        // devices can return 0 bytes for free and total memory if they do not
-        // have any to report. in this case, we will use the host memory as a fallback
-        // fixes: https://github.com/ggml-org/llama.cpp/issues/18577
         if (free == 0 && total == 0) {
-            free  = ret.back().free;
-            total = ret.back().total;
+            throw common_params_fit_exception(std::string("device ") + ggml_backend_dev_name(dev)
+                + " did not report memory; cannot safely fit to an unknown device budget");
         }
         ret[i].free  = free;
         ret[i].total = total;
     }
 
     devs.clear();
-    for (int i = 0; i < llama_model_n_devices(model); i++) {
-        devs.push_back(llama_model_get_device(model, i));
+    for (int i = 0; i < llama_model_n_devices(model.get()); i++) {
+        devs.push_back(llama_model_get_device(model.get(), i));
     }
 
-    hp_ngl         = llama_model_n_layer(model);
-    hp_n_ctx_train = llama_model_n_ctx_train(model);
-    hp_n_expert    = llama_model_n_expert(model);
+    hp_ngl         = llama_model_n_layer(model.get());
+    hp_n_ctx_train = llama_model_n_ctx_train(model.get());
+    hp_n_expert    = llama_model_n_expert(model.get());
 
-    common_memory_breakdown_print(ctx);
-
-    llama_free(ctx);
-    llama_model_free(model);
-    llama_log_set(ud.original_logger.callback, ud.original_logger.user_data);
+    common_memory_breakdown_print(ctx.get());
 
     return ret;
 }
@@ -161,6 +614,7 @@ static void common_params_fit_impl(
     // step 1: get data for default parameters and check whether any changes are necessary in the first place
 
     LOG_INF("%s: getting device memory data for initial parameters:\n", __func__);
+    LOG_INF("%s: fitting uses memory budget groups 0/1/2 with frozen/min-observed budgets\n", __func__);
     const dmds_t dmds_full = common_get_device_memory_data(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
     const size_t nd = devs.size(); // number of devices
 
@@ -173,6 +627,314 @@ static void common_params_fit_impl(
             margins.push_back(margins_s[id]);
         }
     }
+
+    const char * const log_fn = __func__;
+
+    std::vector<bool> dev_overlaps_host_budget;
+    dev_overlaps_host_budget.reserve(nd);
+    bool has_overlapping_budget = false;
+    bool has_rocm_overlap = false;
+    bool has_vulkan_overlap = false;
+    for (size_t id = 0; id < nd; id++) {
+        const bool overlaps = common_fit_dev_overlaps_host_budget(devs[id], dmds_full[id], dmds_full.back());
+        const std::string dev_text = common_fit_dev_text(devs[id]);
+        dev_overlaps_host_budget.push_back(overlaps);
+        has_overlapping_budget = has_overlapping_budget || overlaps;
+        if (overlaps) {
+            has_rocm_overlap   = has_rocm_overlap   || common_fit_contains(dev_text, "rocm") || common_fit_contains(dev_text, "hip");
+            has_vulkan_overlap = has_vulkan_overlap || common_fit_contains(dev_text, "vulkan") || common_fit_contains(dev_text, "radv");
+            LOG_INF("%s: budget group 2 enabled: device %zu (%s) overlaps the host/system-memory budget\n",
+                log_fn, id, ggml_backend_dev_name(devs[id]));
+        }
+    }
+
+    const int64_t requested_host_margin = margins.empty() ? int64_t(margins_s[0]) : *std::max_element(margins.begin(), margins.end());
+    int64_t shared_overlap_margin = requested_host_margin;
+    if (has_overlapping_budget) {
+        common_fit_host_memory_status os_host_memory;
+        const bool have_os_host_memory = common_fit_get_os_host_memory(os_host_memory);
+
+        int64_t shared_total = dmds_full.back().total;
+        int64_t requested_shared_margin = requested_host_margin;
+        for (size_t id = 0; id < nd; id++) {
+            if (!dev_overlaps_host_budget[id]) {
+                continue;
+            }
+            if (dmds_full[id].total > 0) {
+                shared_total = shared_total > 0 ? std::min(shared_total, int64_t(dmds_full[id].total)) : int64_t(dmds_full[id].total);
+            }
+            requested_shared_margin = std::max(requested_shared_margin, margins[id]);
+        }
+
+        const common_fit_shared_margin_result shared_margin = common_fit_shared_host_memory_margin(
+            shared_total, requested_shared_margin, have_os_host_memory ? int64_t(os_host_memory.watermark) : 0,
+            has_rocm_overlap, has_vulkan_overlap);
+        shared_overlap_margin = shared_margin.margin;
+
+        LOG_INF("%s: budget group 0 = physical/API-reported device budget; group 1 = host budget; group 2 = shared/overlapping budget\n", log_fn);
+        if (shared_overlap_margin > requested_shared_margin) {
+            LOG_INF("%s: budget group 2 margin is %" PRId64 " MiB (requested %" PRId64 " MiB, shared total %" PRId64 " MiB, guard %" PRId64 " MiB, watermark %" PRId64 " MiB, profile %s)\n",
+                log_fn, shared_overlap_margin/MiB, requested_shared_margin/MiB, shared_total/MiB,
+                shared_margin.guard/MiB, shared_margin.kernel_watermark/MiB, shared_margin.profile);
+            LOG_INF("%s: budget group 2 guard uses tiered UMA reserve: 3 GiB below 96 GiB, 6 GiB from 96 GiB, 9 GiB from 192 GiB shared memory\n",
+                log_fn);
+            if (have_os_host_memory && os_host_memory.watermark > 0) {
+                LOG_INF("%s: OS-reported kernel watermark is %zu MiB\n",
+                    log_fn, os_host_memory.watermark/COMMON_FIT_MIB);
+            }
+            if (has_rocm_overlap || has_vulkan_overlap) {
+                LOG_INF("%s: budget group 2 also applies a candidate-dependent startup transient reserve for UMA load/upload/allocator pressure\n",
+                    log_fn);
+            }
+        } else {
+            LOG_INF("%s: budget group 2 using requested shared margin of %" PRId64 " MiB\n",
+                log_fn, shared_overlap_margin/MiB);
+        }
+    }
+
+    enum common_fit_budget_group_kind {
+        COMMON_FIT_BUDGET_GROUP_DEVICE_API = 0,
+        COMMON_FIT_BUDGET_GROUP_HOST       = 1,
+        COMMON_FIT_BUDGET_GROUP_SHARED     = 2,
+    };
+
+    struct common_fit_budget_group_budget_floor {
+        common_fit_budget_group_kind kind;
+        int device = -1;
+        int64_t free = 0;
+    };
+
+    std::vector<common_fit_budget_group_budget_floor> budget_free_floors;
+
+    auto stabilized_budget_free = [&](common_fit_budget_group_kind kind, int device, const std::string & name, int64_t free) -> int64_t {
+        if (free <= 0) {
+            return free;
+        }
+
+        for (auto & floor : budget_free_floors) {
+            if (floor.kind != kind || floor.device != device) {
+                continue;
+            }
+
+            if (free < floor.free) {
+                LOG_INF("%s: budget stabilization: observed lower budget for %s: %" PRId64 " -> %" PRId64 " MiB; using the lower value for this fit decision\n",
+                    log_fn, name.c_str(), floor.free/COMMON_FIT_MIB, free/COMMON_FIT_MIB);
+                floor.free = free;
+            } else if (free > floor.free) {
+                const int64_t delta = free - floor.free;
+                if (delta >= 128*COMMON_FIT_MIB) {
+                    LOG_INF("%s: budget stabilization: current budget for %s is %" PRId64 " MiB, but frozen fit budget is %" PRId64 " MiB; ignoring +%" PRId64 " MiB drift\n",
+                        log_fn, name.c_str(), free/COMMON_FIT_MIB, floor.free/COMMON_FIT_MIB, delta/COMMON_FIT_MIB);
+                }
+            }
+            return floor.free;
+        }
+
+        budget_free_floors.push_back({kind, device, free});
+        LOG_INF("%s: budget stabilization: frozen initial budget for %s at %" PRId64 " MiB\n",
+            log_fn, name.c_str(), free/COMMON_FIT_MIB);
+        return free;
+    };
+
+    struct common_fit_budget_group_status {
+        common_fit_budget_group_kind kind;
+        int device = -1;
+        std::string name;
+        int64_t free        = 0;
+        int64_t used        = 0; // charged use: final steady-state use plus any startup transient reserve
+        int64_t steady_used = 0;
+        int64_t peak_guard  = 0;
+        int64_t margin      = 0;
+        common_fit_shared_memory_components shared_components;
+
+        int64_t surplus() const {
+            return free - used - margin;
+        }
+
+        int64_t required_margin() const {
+            return margin;
+        }
+    };
+
+    auto usable_budget_free = [&](const llama_device_memory_data & dmd, common_fit_budget_group_kind kind, int device) -> int64_t {
+        if (dmd.free > 0) {
+            return int64_t(dmd.free);
+        }
+
+        if (kind == COMMON_FIT_BUDGET_GROUP_HOST && dmd.total > 0) {
+            LOG_WRN("%s: host backend did not report free memory; using total host memory as a last-resort fit budget\n",
+                log_fn);
+            return int64_t(dmd.total);
+        }
+
+        throw common_params_fit_exception("device " + std::to_string(device)
+            + " did not report free memory; cannot safely fit to an unknown device budget");
+    };
+
+    auto collect_budget_groups = [&](const dmds_t & dmds) {
+        std::vector<common_fit_budget_group_status> groups;
+        groups.reserve(nd + 2);
+
+        auto make_group = [&](
+                common_fit_budget_group_kind kind,
+                int device,
+                std::string name,
+                int64_t free,
+                int64_t steady_used,
+                int64_t peak_guard,
+                int64_t margin,
+                common_fit_shared_memory_components shared_components = {}) {
+            common_fit_budget_group_status group;
+            group.kind              = kind;
+            group.device            = device;
+            const int64_t stable_free = stabilized_budget_free(kind, device, name, free);
+            group.name              = std::move(name);
+            group.free              = stable_free;
+            group.steady_used        = steady_used;
+            group.peak_guard         = peak_guard;
+            group.used               = steady_used + peak_guard;
+            group.margin             = margin;
+            group.shared_components  = shared_components;
+            return group;
+        };
+
+        if (nd == 0) {
+            const int64_t host_used = common_fit_memory_total_i64(dmds.back().mb);
+            groups.push_back(make_group(
+                COMMON_FIT_BUDGET_GROUP_HOST,
+                -1,
+                "budget group 1 / host",
+                usable_budget_free(dmds.back(), COMMON_FIT_BUDGET_GROUP_HOST, -1),
+                host_used,
+                0,
+                margins[0]));
+            return groups;
+        }
+
+        for (size_t id = 0; id < nd; id++) {
+            const int64_t dev_used = common_fit_memory_total_i64(dmds[id].mb);
+            groups.push_back(make_group(
+                COMMON_FIT_BUDGET_GROUP_DEVICE_API,
+                int(id),
+                "budget group 0 / device " + std::to_string(id),
+                usable_budget_free(dmds[id], COMMON_FIT_BUDGET_GROUP_DEVICE_API, int(id)),
+                dev_used,
+                0,
+                margins[id]));
+        }
+
+        const int64_t host_used = common_fit_memory_total_i64(dmds.back().mb);
+        groups.push_back(make_group(
+            COMMON_FIT_BUDGET_GROUP_HOST,
+            -1,
+            "budget group 1 / host",
+            usable_budget_free(dmds.back(), COMMON_FIT_BUDGET_GROUP_HOST, -1),
+            host_used,
+            0,
+            requested_host_margin));
+
+        if (has_overlapping_budget) {
+            int64_t shared_free = usable_budget_free(dmds.back(), COMMON_FIT_BUDGET_GROUP_HOST, -1);
+            common_fit_shared_memory_components shared;
+            shared.model   += int64_t(dmds.back().mb.model);
+            shared.context += int64_t(dmds.back().mb.context);
+            shared.compute += int64_t(dmds.back().mb.compute);
+
+            for (size_t id = 0; id < nd; id++) {
+                if (!dev_overlaps_host_budget[id]) {
+                    continue;
+                }
+                const int64_t dev_free = usable_budget_free(dmds[id], COMMON_FIT_BUDGET_GROUP_DEVICE_API, int(id));
+                shared_free = shared_free > 0 ? std::min(shared_free, dev_free) : dev_free;
+                shared.model   += int64_t(dmds[id].mb.model);
+                shared.context += int64_t(dmds[id].mb.context);
+                shared.compute += int64_t(dmds[id].mb.compute);
+            }
+
+            const common_fit_shared_peak_guard_result peak = common_fit_shared_peak_guard(shared, shared_free, mparams);
+            groups.push_back(make_group(
+                COMMON_FIT_BUDGET_GROUP_SHARED,
+                -1,
+                "budget group 2 / shared-overlap",
+                shared_free,
+                shared.total(),
+                peak.guard,
+                shared_overlap_margin,
+                shared));
+        }
+
+        return groups;
+    };
+
+    auto find_matching_budget_group = [&](const dmds_t & dmds, const common_fit_budget_group_status & ref) {
+        const std::vector<common_fit_budget_group_status> groups = collect_budget_groups(dmds);
+        for (const auto & group : groups) {
+            if (group.kind == ref.kind && group.device == ref.device) {
+                return group;
+            }
+        }
+        throw std::runtime_error("internal fit error: matching memory budget group not found");
+    };
+
+    auto limiting_budget_group = [&](const dmds_t & dmds) {
+        const std::vector<common_fit_budget_group_status> groups = collect_budget_groups(dmds);
+        assert(!groups.empty());
+        common_fit_budget_group_status worst = groups.front();
+        for (const auto & group : groups) {
+            if (group.surplus() < worst.surplus()) {
+                worst = group;
+            }
+        }
+        return worst;
+    };
+
+    auto log_budget_group = [&](const common_fit_budget_group_status & group, const char * reason) {
+        const int64_t headroom = group.free - group.used;
+        if (group.peak_guard > 0) {
+            const common_fit_shared_peak_guard_result peak = common_fit_shared_peak_guard(group.shared_components, group.free, mparams);
+            LOG_INF("%s: %s: %s charged steady+transient %" PRId64 " MiB (final steady %" PRId64 " MiB + startup reserve %" PRId64 " MiB), budget %" PRId64 " MiB, headroom %" PRId64 " MiB, target %" PRId64 " MiB, surplus %" PRId64 " MiB\n",
+                log_fn, reason, group.name.c_str(), group.used/MiB, group.steady_used/MiB, group.peak_guard/MiB,
+                group.free/COMMON_FIT_MIB, headroom/MiB, group.margin/MiB, group.surplus()/MiB);
+            LOG_INF("%s: %s startup reserve detail: compute=%" PRId64 " MiB, context/%" PRId64 "=%" PRId64 " MiB, model/%" PRId64 "=%" PRId64 " MiB (%s), min=%" PRId64 " MiB, max=%" PRId64 " MiB\n",
+                log_fn, group.name.c_str(),
+                peak.compute_guard/MiB,
+                peak.context_div, peak.context_guard/MiB,
+                peak.model_div, peak.model_guard/MiB, peak.model_profile,
+                peak.min_guard/MiB, peak.max_guard/MiB);
+        } else {
+            LOG_INF("%s: %s: %s used %" PRId64 " MiB, budget %" PRId64 " MiB, headroom %" PRId64 " MiB, target %" PRId64 " MiB, surplus %" PRId64 " MiB\n",
+                log_fn, reason, group.name.c_str(), group.used/MiB, group.free/COMMON_FIT_MIB, headroom/MiB, group.margin/MiB, group.surplus()/MiB);
+        }
+    };
+
+    auto targets_met = [&](const dmds_t & dmds, bool verbose) -> bool {
+        bool ok = true;
+        const std::vector<common_fit_budget_group_status> groups = collect_budget_groups(dmds);
+        for (const auto & group : groups) {
+            if (verbose) {
+                log_budget_group(group, "budget check");
+            }
+
+            const int64_t deficit = group.surplus();
+            if (deficit < 0) {
+                if (verbose) {
+                    LOG_INF("%s: %s is still short by %" PRId64 " MiB against target\n",
+                        log_fn, group.name.c_str(), -deficit/MiB);
+                }
+                ok = false;
+            }
+        }
+        return ok;
+    };
+
+    auto verify_current_fit = [&](const char * stage) {
+        const dmds_t dmds_verify = common_get_device_memory_data(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
+        if (!targets_met(dmds_verify, true)) {
+            throw common_params_fit_exception(std::string(stage) + " did not pass budget-group verification, abort");
+        }
+        LOG_INF("%s: %s verified against budget groups 0/1%s\n",
+            __func__, stage, has_overlapping_budget ? "/2" : "");
+    };
 
     std::vector<std::string> dev_names;
     {
@@ -191,22 +953,18 @@ static void common_params_fit_impl(
         }
     }
 
-    int64_t sum_free            = 0;
-    int64_t sum_projected_free  = 0;
-    int64_t sum_projected_used  = 0;
-    int64_t sum_projected_model = 0;
+    int64_t sum_free           = 0;
+    int64_t sum_projected_used = 0;
     std::vector<int64_t> projected_free_per_device;
     projected_free_per_device.reserve(nd);
 
     if (nd == 0) {
         sum_projected_used = dmds_full.back().mb.total();
-        sum_free           = dmds_full.back().total;
-        sum_projected_free = sum_free - sum_projected_used;
-        LOG_INF("%s: projected to use %" PRId64 " MiB of host memory vs. %" PRId64 " MiB of total host memory\n",
-            __func__, sum_projected_used/MiB, sum_free/MiB);
-        if (sum_projected_free >= margins[0]) {
-            LOG_INF("%s: will leave %" PRId64 " >= %" PRId64 " MiB of system memory, no changes needed\n",
-                __func__, sum_projected_free/MiB, margins[0]/MiB);
+        sum_free           = usable_budget_free(dmds_full.back(), COMMON_FIT_BUDGET_GROUP_HOST, -1);
+        LOG_INF("%s: projected to use %" PRId64 " MiB of host memory vs. %" PRId64 " MiB of available host budget\n",
+            __func__, sum_projected_used/MiB, sum_free/COMMON_FIT_MIB);
+        if (targets_met(dmds_full, false)) {
+            LOG_INF("%s: host budget target can be met, no changes needed\n", __func__);
             return;
         }
     } else {
@@ -217,113 +975,186 @@ static void common_params_fit_impl(
             const llama_device_memory_data & dmd = dmds_full[id];
 
             const int64_t projected_used = dmd.mb.total();
-            const int64_t projected_free = dmd.free - projected_used;
+            const int64_t projected_free = int64_t(dmd.free) - projected_used;
             projected_free_per_device.push_back(projected_free);
 
-            sum_free            += dmd.free;
-            sum_projected_used  += projected_used;
-            sum_projected_free  += projected_free;
-            sum_projected_model += dmd.mb.model;
+            sum_free           += dmd.free;
+            sum_projected_used += projected_used;
 
             if (nd > 1) {
                 LOG_INF("%s:   - %s: %6" PRId64 " total, %6" PRId64 " used, %6" PRId64 " free vs. target of %6" PRId64 "\n",
-                    __func__, dev_names[id].c_str(), dmd.total/MiB, projected_used/MiB, projected_free/MiB, margins[id]/MiB);
+                    __func__, dev_names[id].c_str(), dmd.total/MiB, projected_used/MiB, projected_free/COMMON_FIT_MIB, margins[id]/MiB);
             }
         }
         assert(sum_free >= 0 && sum_projected_used >= 0);
         LOG_INF("%s: projected to use %" PRId64 " MiB of device memory vs. %" PRId64 " MiB of free device memory\n",
-            __func__, sum_projected_used/MiB, sum_free/MiB);
-        if (nd == 1) {
-            if (projected_free_per_device[0] >= margins[0]) {
+            __func__, sum_projected_used/MiB, sum_free/COMMON_FIT_MIB);
+        if (targets_met(dmds_full, false)) {
+            if (nd == 1) {
                 LOG_INF("%s: will leave %" PRId64 " >= %" PRId64 " MiB of free device memory, no changes needed\n",
                     __func__, projected_free_per_device[0]/MiB, margins[0]/MiB);
-                return;
-            }
-        } else {
-            bool changes_needed = false;
-            for (size_t id = 0; id < nd; id++) {
-                if (projected_free_per_device[id] < margins[id]) {
-                    changes_needed = true;
-                    break;
-                }
-            }
-            if (!changes_needed) {
+            } else {
                 LOG_INF("%s: targets for free memory can be met on all devices, no changes needed\n", __func__);
-                return;
             }
+            if (has_overlapping_budget) {
+                LOG_INF("%s: shared/overlapping budget target can also be met, no changes needed\n", __func__);
+            }
+            return;
         }
     }
 
     // step 2: try reducing memory use by reducing the context size
 
     {
-        int64_t global_surplus = sum_projected_free;
-        if (nd == 0) {
-            global_surplus -= margins[0];
-        } else {
-            for (size_t id = 0; id < nd; id++) {
-                global_surplus -= margins[id];
-            }
-        }
-        if (global_surplus < 0) {
-            if (nd <= 1) {
-                LOG_INF("%s: cannot meet free memory target of %" PRId64 " MiB, need to reduce device memory by %" PRId64 " MiB\n",
-                    __func__, margins[0]/MiB, -global_surplus/MiB);
-            } else {
-                LOG_INF(
-                    "%s: cannot meet free memory targets on all devices, need to use %" PRId64 " MiB less in total\n",
-                    __func__, -global_surplus/MiB);
-            }
+        const common_fit_budget_group_status limiting_full = limiting_budget_group(dmds_full);
+        if (limiting_full.surplus() < 0) {
+            log_budget_group(limiting_full, "limiting budget");
+            LOG_INF("%s: cannot meet %s target, need to reduce memory by %" PRId64 " MiB\n",
+                __func__, limiting_full.name.c_str(), -limiting_full.surplus()/MiB);
+
             if (cparams->n_ctx == 0) {
                 if (hp_nct > n_ctx_min) {
-                    int64_t sum_used_target = sum_free;
-                    if (nd == 0) {
-                        sum_used_target -= margins[0];
-                    } else {
-                        for (size_t id = 0; id < nd; id++) {
-                            sum_used_target -= margins[id];
-                        }
-                    }
-                    if (nd > 1) {
-                        // for multiple devices we need to be more conservative in terms of how much context we think can fit:
-                        //   - for dense models only whole layers can be assigned to devices
-                        //   - for MoE models only whole tensors can be assigned to devices, which we estimate to be <= 1/3 of a layer
-                        //   - on average we expect a waste of 0.5 layers/tensors per device
-                        //   - use slightly more than the expected average for nd devices to be safe
-                        const int64_t model_per_layer = sum_projected_model / std::min(uint32_t(mparams->n_gpu_layers), hp_ngl);
-                        sum_used_target -= (nd + 1) * model_per_layer / (hp_nex == 0 ? 2 : 6);
-                    }
+                    const int64_t limiting_used_target = limiting_full.free - limiting_full.required_margin();
 
-                    int64_t sum_projected_used_min_ctx = 0;
                     cparams->n_ctx = n_ctx_min;
                     const dmds_t dmds_min_ctx = common_get_device_memory_data(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
-                    if (nd == 0) {
-                        sum_projected_used_min_ctx = dmds_min_ctx.back().mb.total();
-                    } else {
-                        for (size_t id = 0; id < nd; id++) {
-                            sum_projected_used_min_ctx += dmds_min_ctx[id].mb.total();
-                        }
-                    }
-                    if (sum_used_target > sum_projected_used_min_ctx) {
-                        // linear interpolation between minimum and maximum context size:
-                        cparams->n_ctx += (hp_nct - n_ctx_min) * (sum_used_target - sum_projected_used_min_ctx)
-                            / (sum_projected_used - sum_projected_used_min_ctx);
-                        cparams->n_ctx = std::max(cparams->n_ctx - cparams->n_ctx % 256, n_ctx_min); // round down context for CUDA backend
+                    const common_fit_budget_group_status limiting_min_ctx = find_matching_budget_group(dmds_min_ctx, limiting_full);
 
-                        const int64_t bytes_per_ctx = (sum_projected_used - sum_projected_used_min_ctx) / (hp_nct - n_ctx_min);
+                    const int64_t used_full = limiting_full.used;
+                    const int64_t used_min  = limiting_min_ctx.used;
+                    const int64_t ctx_fit_denom = used_full - used_min;
+
+                    if (limiting_used_target > used_min && ctx_fit_denom > 0) {
+                        // Build a measured demand model from two real probes of the same
+                        // limiting budget group. The result is only a candidate; every
+                        // enabled budget group is re-probed and verified before success.
+                        const int64_t bytes_per_ctx = ctx_fit_denom / std::max<uint32_t>(1, hp_nct - n_ctx_min);
+                        const uint32_t ctx_candidate = n_ctx_min
+                            + uint32_t((uint64_t(hp_nct - n_ctx_min) * uint64_t(limiting_used_target - used_min))
+                                / uint64_t(ctx_fit_denom));
+
+                        cparams->n_ctx = std::max(ctx_candidate - ctx_candidate % 256, n_ctx_min); // round down context for CUDA backend
+
                         const int64_t memory_reduction = (hp_nct - cparams->n_ctx) * bytes_per_ctx;
-                        LOG_INF("%s: context size reduced from %" PRIu32 " to %" PRIu32 " -> need %" PRId64 " MiB less memory in total\n",
-                            __func__, hp_nct, cparams->n_ctx, memory_reduction/MiB);
-                        if (nd <= 1) {
-                            LOG_INF("%s: entire model can be fit by reducing context\n", __func__);
-                            return;
-                        }
-                        LOG_INF("%s: entire model should be fit across devices by reducing context\n", __func__);
+                        LOG_INF("%s: measured steady+transient context demand for %s: min_ctx=%" PRIu32 " steady+transient %" PRId64 " MiB, full_ctx=%" PRIu32 " steady+transient %" PRId64 " MiB, slope=%" PRId64 " KiB/token\n",
+                            __func__, limiting_full.name.c_str(), n_ctx_min, used_min/MiB, hp_nct, used_full/MiB, bytes_per_ctx/1024);
+                        LOG_INF("%s: demand-based context candidate: target=%" PRId64 " MiB -> n_ctx=%" PRIu32 " (%" PRId64 " MiB less than full context)\n",
+                            __func__, limiting_used_target/MiB, cparams->n_ctx, memory_reduction/MiB);
                     } else {
-                        const int64_t memory_reduction = sum_projected_used - sum_projected_used_min_ctx;
-                        LOG_INF("%s: context size reduced from %" PRIu32 " to %" PRIu32 " -> need %" PRId64 " MiB less memory in total\n",
-                            __func__, hp_nct, cparams->n_ctx, memory_reduction/MiB);
+                        const int64_t memory_reduction = used_full - used_min;
+                        LOG_INF("%s: only minimum context can be tried for %s -> n_ctx=%" PRIu32 ", %" PRId64 " MiB less than full context\n",
+                            __func__, limiting_full.name.c_str(), cparams->n_ctx, memory_reduction/MiB);
                     }
+
+                    dmds_t dmds_reduced_ctx = cparams->n_ctx == n_ctx_min
+                        ? dmds_min_ctx
+                        : common_get_device_memory_data(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
+
+                    if (!targets_met(dmds_reduced_ctx, true) && cparams->n_ctx > n_ctx_min && targets_met(dmds_min_ctx, false)) {
+                        const uint32_t ctx_initial = cparams->n_ctx;
+                        LOG_INF("%s: measured context candidate did not pass all budget groups, binary-searching lower verified context\n", __func__);
+
+                        uint32_t ctx_lo = n_ctx_min;
+                        uint32_t ctx_hi = ctx_initial;
+                        dmds_t dmds_lo = dmds_min_ctx;
+
+                        while (ctx_hi > ctx_lo + 256) {
+                            uint32_t ctx_mid = ctx_lo + ((ctx_hi - ctx_lo) / 512) * 256;
+                            if (ctx_mid <= ctx_lo) {
+                                ctx_mid = ctx_lo + 256;
+                            }
+                            if (ctx_mid >= ctx_hi) {
+                                ctx_mid = ctx_hi - 256;
+                            }
+
+                            cparams->n_ctx = ctx_mid;
+                            const dmds_t dmds_mid = common_get_device_memory_data(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
+                            if (targets_met(dmds_mid, false)) {
+                                ctx_lo  = ctx_mid;
+                                dmds_lo = dmds_mid;
+                            } else {
+                                ctx_hi = ctx_mid;
+                            }
+                        }
+
+                        cparams->n_ctx = ctx_lo;
+                        dmds_reduced_ctx = dmds_lo;
+                        LOG_INF("%s: context size verified after backoff from %" PRIu32 " to %" PRIu32 "\n",
+                            __func__, ctx_initial, cparams->n_ctx);
+                    }
+
+                    if (targets_met(dmds_reduced_ctx, true)) {
+                        // The demand interpolation above is intentionally conservative: it uses two
+                        // real probes and then rounds down. With UMA budgets the candidate can become
+                        // even more conservative because the startup transient reserve is nonlinear
+                        // (it is max(compute, context/N, model/M, min)). Do not accept the first
+                        // passing point as final when a higher context can be verified directly.
+                        // Instead, binary-search upward and keep only re-probed candidates that pass
+                        // every active budget group. This recovers context generically
+                        // without weakening group 0/1/2 accounting or relying on
+                        // backend-specific constants.
+                        const uint32_t ctx_first_verified = cparams->n_ctx;
+                        if (cparams->n_ctx + 256 <= hp_nct) {
+                            const int max_upward_probes = 12;
+
+                            LOG_INF("%s: first context candidate passed; searching upward for highest verified context using frozen/min-observed budgets (max %d probes)\n",
+                                __func__, max_upward_probes);
+
+                            uint32_t ctx_lo = cparams->n_ctx;
+                            uint32_t ctx_hi = hp_nct;
+                            dmds_t dmds_lo = dmds_reduced_ctx;
+                            int probe_count = 0;
+
+                            while (ctx_hi > ctx_lo + 256 && probe_count < max_upward_probes) {
+                                uint32_t ctx_mid = ctx_lo + ((ctx_hi - ctx_lo) / 512) * 256;
+                                if (ctx_mid <= ctx_lo) {
+                                    ctx_mid = ctx_lo + 256;
+                                }
+                                if (ctx_mid >= ctx_hi) {
+                                    ctx_mid = ctx_hi - 256;
+                                }
+
+                                cparams->n_ctx = ctx_mid;
+                                const dmds_t dmds_mid = common_get_device_memory_data(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
+                                probe_count++;
+
+                                if (targets_met(dmds_mid, false)) {
+                                    ctx_lo  = ctx_mid;
+                                    dmds_lo = dmds_mid;
+                                } else {
+                                    ctx_hi = ctx_mid;
+                                }
+                            }
+
+                            cparams->n_ctx = ctx_lo;
+                            dmds_reduced_ctx = dmds_lo;
+
+                            if (ctx_lo > ctx_first_verified) {
+                                LOG_INF("%s: reclaimed context by verified upward search: n_ctx %" PRIu32 " -> %" PRIu32 " after %d probes\n",
+                                    __func__, ctx_first_verified, ctx_lo, probe_count);
+                            } else {
+                                LOG_INF("%s: upward search kept first verified context n_ctx=%" PRIu32 " after %d probes\n",
+                                    __func__, ctx_lo, probe_count);
+                            }
+                            if (probe_count >= max_upward_probes && ctx_hi > ctx_lo + 256) {
+                                LOG_INF("%s: upward context search stopped at probe limit with remaining interval [%" PRIu32 ", %" PRIu32 "]\n",
+                                    __func__, ctx_lo, ctx_hi);
+                            }
+
+                            // Print the final accepted candidate after the upward search, because this
+                            // is the value that will be committed to the real init path. It should still
+                            // have positive surplus.
+                            targets_met(dmds_reduced_ctx, true);
+                        }
+
+                        if (nd <= 1) {
+                            LOG_INF("%s: entire model can be fit by reducing context (highest verified against frozen/min-observed budget groups)\n", __func__);
+                        } else {
+                            LOG_INF("%s: entire model can be fit across devices by reducing context (highest verified against frozen/min-observed budget groups)\n", __func__);
+                        }
+                        return;
+                    }
+                    LOG_INF("%s: context reduction alone did not pass budget-group verification, trying weight placement changes\n", __func__);
                 } else {
                     if (n_ctx_min == UINT32_MAX) {
                         LOG_INF("%s: user has requested full context size of %" PRIu32 " -> no change\n", __func__, hp_nct);
@@ -526,7 +1357,7 @@ static void common_params_fit_impl(
     std::vector<int64_t> targets; // maximum acceptable memory use per device
     targets.reserve(nd);
     for (size_t id = 0; id < nd; id++) {
-        targets.push_back(dmds_full[id].free - margins[id]);
+        targets.push_back(int64_t(dmds_full[id].free) - margins[id]);
         LOG_INF("%s: id=%zu, target=%" PRId64 " MiB\n", __func__, id, targets[id]/MiB);
     }
 
@@ -538,6 +1369,12 @@ static void common_params_fit_impl(
 
     std::vector<ngl_t> ngl_per_device(nd);
     std::vector<int64_t> mem = get_memory_for_layers(__func__, ngl_per_device, overflow_bufts);
+    for (size_t id = 0; id < nd; id++) {
+        if (mem[id] > targets[id]) {
+            throw common_params_fit_exception("device " + std::to_string(id)
+                + " already exceeds the free-memory target before assigning model layers; cannot safely fit");
+        }
+    }
 
     // optimize the number of layers per device using the method of false position:
     //   - ngl_per_device has 0 layers for each device, lower bound
@@ -551,7 +1388,8 @@ static void common_params_fit_impl(
     } else {
         LOG_INF("%s: filling dense-only layers back-to-front:\n", __func__);
     }
-    for (int id = nd - 1; id >= 0; id--) {
+    for (size_t id_rev = nd; id_rev-- > 0;) {
+        const size_t id = id_rev;
         uint32_t n_unassigned = hp_ngl + 1;
         for (size_t jd = id + 1; jd < nd; ++jd) {
             assert(n_unassigned >= ngl_per_device[jd].n_layer);
@@ -561,14 +1399,14 @@ static void common_params_fit_impl(
         std::vector<ngl_t> ngl_per_device_high = ngl_per_device;
         ngl_per_device_high[id].n_layer = n_unassigned;
         if (hp_nex > 0) {
-            ngl_per_device_high[id].n_part = size_t(id) < nd - 1 ? ngl_per_device_high[id].n_layer : ngl_per_device_high[id].n_layer - 1;
+            ngl_per_device_high[id].n_part = id < nd - 1 ? ngl_per_device_high[id].n_layer : ngl_per_device_high[id].n_layer - 1;
         }
         if (ngl_per_device_high[id].n_layer > 0) {
             std::vector<int64_t> mem_high = get_memory_for_layers(__func__, ngl_per_device_high, overflow_bufts);
             if (mem_high[id] > targets[id]) {
                 assert(ngl_per_device_high[id].n_layer > ngl_per_device[id].n_layer);
                 uint32_t delta = ngl_per_device_high[id].n_layer - ngl_per_device[id].n_layer;
-                LOG_INF("%s: start filling device %" PRIu32 ", delta=%" PRIu32 "\n", __func__, id, delta);
+                LOG_INF("%s: start filling device %zu, delta=%" PRIu32 "\n", __func__, id, delta);
                 while (delta > 1) {
                     uint32_t step_size = int64_t(delta) * (targets[id] - mem[id]) / (mem_high[id] - mem[id]);
                     step_size = std::max(step_size, uint32_t(1));
@@ -585,11 +1423,11 @@ static void common_params_fit_impl(
                     if (mem_test[id] <= targets[id]) {
                         ngl_per_device = ngl_per_device_test;
                         mem            = mem_test;
-                        LOG_INF("%s: set ngl_per_device[%d].n_layer=%" PRIu32 "\n", __func__, id, ngl_per_device[id].n_layer);
+                        LOG_INF("%s: set ngl_per_device[%zu].n_layer=%" PRIu32 "\n", __func__, id, ngl_per_device[id].n_layer);
                     } else {
                         ngl_per_device_high = ngl_per_device_test;
                         mem_high            = mem_test;
-                        LOG_INF("%s: set ngl_per_device_high[%d].n_layer=%" PRIu32 "\n", __func__, id, ngl_per_device_high[id].n_layer);
+                        LOG_INF("%s: set ngl_per_device_high[%zu].n_layer=%" PRIu32 "\n", __func__, id, ngl_per_device_high[id].n_layer);
                     }
                     delta = ngl_per_device_high[id].n_layer - ngl_per_device[id].n_layer;
                 }
@@ -597,17 +1435,18 @@ static void common_params_fit_impl(
                 assert(ngl_per_device_high[id].n_layer == n_unassigned);
                 ngl_per_device = ngl_per_device_high;
                 mem            = mem_high;
-                LOG_INF("%s: set ngl_per_device[%d].n_layer=%" PRIu32 "\n", __func__, id, ngl_per_device[id].n_layer);
+                LOG_INF("%s: set ngl_per_device[%zu].n_layer=%" PRIu32 "\n", __func__, id, ngl_per_device[id].n_layer);
             }
         }
 
-        const int64_t projected_margin = dmds_full[id].free - mem[id];
+        const int64_t projected_margin = int64_t(dmds_full[id].free) - mem[id];
         LOG_INF(
             "%s:   - %s: %2" PRIu32 " layers, %6" PRId64 " MiB used, %6" PRId64 " MiB free\n",
             __func__, dev_names[id].c_str(), ngl_per_device[id].n_layer, mem[id]/MiB, projected_margin/MiB);
     }
     if (hp_nex == 0 || global_surplus_cpu_moe <= 0) {
         set_ngl_tensor_split_tbo(ngl_per_device, overflow_bufts, *mparams);
+        verify_current_fit("layer placement");
         return;
     }
 
@@ -617,7 +1456,8 @@ static void common_params_fit_impl(
     // also, try fitting at least part of one more layer to reduce waste for "small" GPUs with e.g. 24 GiB VRAM
 
     size_t id_dense_start = nd;
-    for (int id = nd - 1; id >= 0; id--) {
+    for (size_t id_rev = nd; id_rev-- > 0;) {
+        const size_t id = id_rev;
         if (ngl_per_device[id].n_layer > 0) {
             id_dense_start = id;
             continue;
@@ -738,7 +1578,7 @@ static void common_params_fit_impl(
             }
         }
 
-        const int64_t projected_margin = dmds_full[id].free - mem[id];
+        const int64_t projected_margin = int64_t(dmds_full[id].free) - mem[id];
         LOG_INF(
             "%s:   - %s: %2" PRIu32 " layers (%2" PRIu32 " overflowing), %6" PRId64 " MiB used, %6" PRId64 " MiB free\n",
             __func__, dev_names[id].c_str(), ngl_per_device[id].n_layer, ngl_per_device[id].n_part, mem[id]/MiB, projected_margin/MiB);
@@ -746,13 +1586,14 @@ static void common_params_fit_impl(
 
     // print info for devices that were not changed during the conversion from dense only to full layers:
     for (size_t id = id_dense_start + 1; id < nd; id++) {
-        const int64_t projected_margin = dmds_full[id].free - mem[id];
+        const int64_t projected_margin = int64_t(dmds_full[id].free) - mem[id];
         LOG_INF(
             "%s:   - %s: %2" PRIu32 " layers (%2" PRIu32 " overflowing), %6" PRId64 " MiB used, %6" PRId64 " MiB free\n",
             __func__, dev_names[id].c_str(), ngl_per_device[id].n_layer, ngl_per_device[id].n_part, mem[id]/MiB, projected_margin/MiB);
     }
 
     set_ngl_tensor_split_tbo(ngl_per_device, overflow_bufts, *mparams);
+    verify_current_fit("layer placement");
 }
 
 enum common_params_fit_status common_fit_params(
@@ -766,8 +1607,44 @@ enum common_params_fit_status common_fit_params(
         ggml_log_level log_level) {
     const int64_t t0_us = llama_time_us();
     common_params_fit_status status = COMMON_PARAMS_FIT_STATUS_SUCCESS;
+    if (path_model == nullptr || path_model[0] == '\0' || mparams == nullptr || cparams == nullptr || margins == nullptr) {
+        LOG_ERR("%s: invalid arguments passed to --fit; aborting fit before mutating parameters\n", __func__);
+        const int64_t t1_us = llama_time_us();
+        LOG_INF("%s: fitting params to free memory took %.2f seconds\n", __func__, (t1_us - t0_us) * 1e-6);
+        return COMMON_PARAMS_FIT_STATUS_ERROR;
+    }
     try {
-        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level);
+        llama_model_params   mparams_fit = *mparams;
+        llama_context_params cparams_fit = *cparams;
+
+        std::vector<float> tensor_split_fit;
+        float * tensor_split_ptr = tensor_split;
+        if (tensor_split != nullptr) {
+            tensor_split_fit.assign(tensor_split, tensor_split + llama_max_devices());
+            tensor_split_ptr = tensor_split_fit.data();
+        }
+
+        std::vector<llama_model_tensor_buft_override> tensor_buft_overrides_fit;
+        llama_model_tensor_buft_override * tensor_buft_overrides_ptr = tensor_buft_overrides;
+        if (tensor_buft_overrides != nullptr) {
+            tensor_buft_overrides_fit.assign(tensor_buft_overrides, tensor_buft_overrides + llama_max_tensor_buft_overrides());
+            tensor_buft_overrides_ptr = tensor_buft_overrides_fit.data();
+        }
+
+        common_params_fit_impl(path_model, &mparams_fit, &cparams_fit,
+            tensor_split_ptr, tensor_buft_overrides_ptr, margins, n_ctx_min, log_level);
+
+        if (!tensor_split_fit.empty() && mparams_fit.tensor_split == tensor_split_fit.data()) {
+            std::copy(tensor_split_fit.begin(), tensor_split_fit.end(), tensor_split);
+            mparams_fit.tensor_split = tensor_split;
+        }
+        if (!tensor_buft_overrides_fit.empty() && mparams_fit.tensor_buft_overrides == tensor_buft_overrides_fit.data()) {
+            std::copy(tensor_buft_overrides_fit.begin(), tensor_buft_overrides_fit.end(), tensor_buft_overrides);
+            mparams_fit.tensor_buft_overrides = tensor_buft_overrides;
+        }
+
+        *mparams = mparams_fit;
+        *cparams = cparams_fit;
         LOG_INF("%s: successfully fit params to free device memory\n", __func__);
     } catch (const common_params_fit_exception & e) {
         LOG_WRN("%s: failed to fit params to free device memory: %s\n", __func__, e.what());

--- a/common/fit.h
+++ b/common/fit.h
@@ -8,8 +8,12 @@ enum common_params_fit_status {
     COMMON_PARAMS_FIT_STATUS_ERROR   = 2, // a hard error occurred, e.g. because no model could be found at the specified path
 };
 
-// fits mparams and cparams to free device memory (assumes system memory is unlimited)
-//   - returns true if the parameters could be successfully modified to fit device memory
+// fits mparams and cparams to free memory budgets
+//   - budget group 0: physical/API-reported device budget per device
+//   - budget group 1: host budget
+//   - budget group 2: shared/overlapping budget for UMA/unified-memory devices
+//   - returns SUCCESS only if the fitted parameters pass verification for every enabled budget group
+//   - commits fitted params and writable output buffers only on SUCCESS; FAILURE/ERROR leaves inputs unchanged
 //   - this function is NOT thread safe because it modifies the global llama logger state
 //   - only parameters that have the same value as in llama_default_model_params are modified
 //     with the exception of the context size which is modified if and only if equal to 0


### PR DESCRIPTION
Closes #22592

## Overview

This PR makes `--fit` validate memory against explicit budget groups before accepting fitted parameters

The most important change is that UMA / integrated GPU systems are no longer treated like discrete GPU systems where device memory and host memory are independent pools. On UMA systems, both device-labeled and host-labeled allocations can pressure the same physical memory. The fit logic now handles that:

The fit path tracks:

```text
budget group 0: physical or API-reported device budget
budget group 1: host budget
budget group 2: shared / overlapping UMA budget
````

Candidate fit results are also verified against the selected parameters before they are committed. In particular, context reduction is no longer accepted purely from aggregate interpolation.

## Main changes

This PR updates the --fit path to:

* abort startup when `common_fit_params()` returns FAILURE or ERROR
* keep fitting transactional and only commit parameter changes after success
* avoid falling back from invalid 0/0 device-memory reports to host memory for device budgets
* validate reduced-context candidates with a real fit probe before accepting them
* preserve the existing weight-placement fallback path when the full model cannot remain on the device
* account for UMA / APU shared-memory overlap instead of treating host and device memory as independent
* add a simple tiered shared-memory reserve for UMA systems

The UMA reserve is intentionally simple and bounded. It avoids an unbounded percentage penalty on large shared-memory systems while still leaving room for OS pressure and backend startup allocations.

Currently:

```text
~32 GiB shared memory class   -> 3 GiB reserve
~128 GiB shared memory class  -> 6 GiB reserve
~256 GiB shared memory class  -> 9 GiB reserve
```

This should be easy to adjust later if more hardware data suggests better thresholds.

## Bugs / failure modes addressed

### Confirmed by local logs

The following cases are covered by local logs and the main motivation for this PR:

1. **UMA / APU shared-budget overcommit**

   On ROCm and Vulkan UMA systems, --fit could approve parameters based on the API-reported device budget while not correctly charging host/shared allocations against the same physical memory pool.

   The new budget group 2 fixes this class by validating the shared / overlapping UMA budget directly.
[llama-fit-128k-times-10_rocm_gfx1151.log](https://github.com/user-attachments/files/27293811/llama-fit-128k-times-10_rocm_gfx1151.log)
[llama-fit-128k-times-10-vulkan_gfx11.log](https://github.com/user-attachments/files/27293812/llama-fit-128k-times-10-vulkan_gfx11.log)


2. **Weights/load pressure OOM before cache allocation**

   The updated accounting avoids approving configurations that fit only in the final-looking device budget but still overcommit the shared memory pool during load/startup pressure. Here is the fixed log in contrast to the issue.
[llama-fit-128k-times-10-vulkan_weights_loading_error.log](https://github.com/user-attachments/files/27293833/llama-fit-128k-times-10-vulkan_weights_loading_error.log)


### Direct code-level fixes

The following are direct control-flow / correctness fixes in the fit path:

* `common_fit_params()` failure is no longer ignored by the caller
* fit parameter updates are transactional instead of leaving partial mutations on failure
* invalid 0/0 device-memory reports are not silently treated as host memory for device budgets
* reduced context candidates are re-measured before being accepted
* the weight-placement fallback path is preserved for cases where full device placement does not fit

### Improved but may need more backend coverage

The verified candidate re-probe also improves the broader class of cases where aggregate interpolation was too optimistic, especially on multi-device and lifecycle-sensitive paths.

I have not exhaustively tested every backend combination. The intent is to preserve existing dGPU behavior by keeping device and host budget groups separate unless shared/overlapping memory accounting is needed.

## Testing

Tested locally on AMD Strix Halo / gfx1151.

ROCm and Vulkan, see logs above.

Model: GLM-4.5-Air-GGUF / UD-Q4_K_XL

I also tested that dGPU cases are still running fine on a RTX 5090 and a context which is "too huge":
`
--override-kv glm4moe.context_length=int:1310720`

Model: Qwen3.6-27B-GGUF/UD-Q4_K_XL

## Notes for reviewers

The key behavioral change is not that --fit simply adds a larger safety margin. The important part is that the fit decision now validates the correct memory budget on UMA systems.

For dGPU-style systems, device and host memory remain separate budget groups.

For UMA / integrated GPU systems, the shared / overlapping memory group prevents fit from treating host and device allocations as independent when they are backed by the same physical RAM.

## AI usage disclosure

AI assistance was used during investigation and review to help compare logs, organize the bug analysis, and discuss possible fit-accounting approaches.

The submitted code was manually reviewed, tested locally, and I am prepared to explain the changes during review.