### PR TITLE
json-schema: prevent out-of-bounds and stack overflow in regex parsing for GBNF

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -362,7 +362,11 @@ private:
             auto s = ls.first;
             return is_literal ? "\"" + s + "\"" : s;
         };
-        std::function<literal_or_rule()> transform = [&]() -> literal_or_rule {
+        std::function<literal_or_rule(int)> transform = [&](int depth) -> literal_or_rule {
+            if (depth > 100) {
+                _errors.push_back("Pattern too deeply nested");
+                return std::make_pair("", false);
+            }
             size_t start = i;
             std::vector<literal_or_rule> seq;
 
@@ -423,20 +427,20 @@ private:
                             // lookahead/lookbehind (?=, ?!, ?<=, ?<!) - not supported
                             _warnings.push_back("Unsupported pattern syntax");
                             // skip to matching ')' to avoid UB on empty seq
-                            int depth = 1;
-                            while (i < length && depth > 0) {
+                            int group_depth = 1;
+                            while (i < length && group_depth > 0) {
                                 if (sub_pattern[i] == '\\' && i + 1 < length) {
                                     i += 2; // skip escaped character
                                 } else {
-                                    if (sub_pattern[i] == '(') depth++;
-                                    else if (sub_pattern[i] == ')') depth--;
+                                    if (sub_pattern[i] == '(') group_depth++;
+                                    else if (sub_pattern[i] == ')') group_depth--;
                                     i++;
                                 }
                             }
                             continue;
                         }
                     }
-                    seq.emplace_back("(" + to_rule(transform()) + ")", false);
+                    seq.emplace_back("(" + to_rule(transform(depth + 1)) + ")", false);
                 } else if (c == ')') {
                     i++;
                     if (start > 0 && sub_pattern[start - 1] != '(' && (start < 2 || sub_pattern[start - 2] != '?' || sub_pattern[start - 1] != ':')) {
@@ -465,6 +469,10 @@ private:
                     seq.emplace_back("|", false);
                     i++;
                 } else if (c == '*' || c == '+' || c == '?') {
+                    if (seq.empty()) {
+                        _errors.push_back(std::string("Quantifier '") + c + "' appears without preceding token");
+                        return std::make_pair("", false);
+                    }
                     seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
                     i++;
                 } else if (c == '{') {
@@ -497,6 +505,10 @@ private:
                         }
                     } catch (const std::invalid_argument & e) {
                         _errors.push_back("Invalid number in curly brackets");
+                        return std::make_pair("", false);
+                    }
+                    if (seq.empty()) {
+                        _errors.push_back("Quantifier '" + curly_brackets + "' appears without preceding token");
                         return std::make_pair("", false);
                     }
                     auto &last = seq.back();
@@ -551,7 +563,7 @@ private:
             }
             return join_seq();
         };
-        return _add_rule(name, "\"\\\"\" (" + to_rule(transform()) + ") \"\\\"\" space");
+        return _add_rule(name, "\"\\\"\" (" + to_rule(transform(0)) + ") \"\\\"\" space");
     }
 
     /*


### PR DESCRIPTION

## Overview

By experimenting with structured outputs, I noticed that `llama-server` crashes via Segfault if it receives a malformed regex pattern in a JSON schema (e.g., `pattern: "^+[a-z]$"` or `pattern: "^{2}times$"`).

The crash happens in `common_schema_converter::_visit_pattern` because the quantifier branches evaluate before ensuring the `seq` vector has elements, leading to `seq.back()` accessing unallocated memory. Additionally, deeply nested parentheses can cause the recursive `transform` lambda to exhaust the call stack.

**Changes in this PR:**

* Added `if (seq.empty())` bounds checks for `*`, `+`, `?`, and `{` branches, returning a descriptive error.

* Added a `depth` parameter to the recursive `transform()` lambda, capping nesting at 100 to gracefully return an error instead of overflowing the stack.

## Additional information

Reproduction Script

This Python script consistently crashes the unpatched server by passing a malformed regex in the `response_format` JSON schema. With this patch, the server gracefully returns a 400 error indicating the pattern is invalid.

```python
import requests
import json

payload = {
    "model": "local-model",
    "messages":[{"role": "user", "content": "Extract the street name"}],
    "response_format": {
        "type": "json_schema",
        "json_schema": {
            "name": "geocoding_extraction",
            "schema": {
                "type": "object",
                "properties": {
                    "street_name": {
                        "type": "string",
                        "pattern": "^+[a-zA-Z0-9 ]$"  # The trigger
                        #"pattern": "^{2}times$"      # Another payload
                    }
                }
            }
        }
    }
}

try:
    requests.post("http://127.0.0.1:8080/v1/chat/completions", json=payload)
    print("Request processed successfully.")
except requests.exceptions.ConnectionError:
    print("Server crashed.")
```

After patching, the server returns error messages for wrong payloads:

**"^+[a-zA-Z0-9 ]$"**
```
operator (): got exception: {"error":{"code":400,"message":"JSON schema conversion failed:\nQuantifier '+' appears without preceding token","type":"invalid_request_error"}}
```

**"^{2}times$"**
```
operator (): got exception: {"error":{"code":400,"message":"JSON schema conversion failed:\nQuantifier '{2}' appears without preceding token","type":"invalid_request_error"}}
```

Tested on Windows 10 x64, Gemma-4 model.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: NO - The core fix was authored by a human contributor. AI was used to double-check that everything was fixed, and for grammar suggestions on the PR description.
