### PR TITLE
convert : apply Q/K RoPE permutation in NVFP4 repack path

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2889,6 +2889,20 @@ class LlamaModel(TextModel):
                 .swapaxes(1, 2)
                 .reshape(weights.shape))
 
+    def _repack_nvfp4(self, name: str, weight: Tensor, scale: Tensor, scale2: Tensor, input_scale: Tensor):
+        # Mirror the BF16 Q/K RoPE permutation site in modify_tensors; the NVFP4 path bypasses it.
+        if self.undo_permute:
+            n_head = self.find_hparam(["n_heads", "num_attention_heads"], optional=True)
+            n_kv_head = self.find_hparam(["n_kv_heads", "num_key_value_heads"], optional=True)
+            if n_head is not None:
+                if name.endswith("q_proj.weight"):
+                    weight = LlamaModel.permute(weight, n_head, n_head)
+                    scale  = LlamaModel.permute(scale, n_head, n_head)
+                elif name.endswith("k_proj.weight"):
+                    weight = LlamaModel.permute(weight, n_head, n_kv_head)
+                    scale  = LlamaModel.permute(scale, n_head, n_kv_head)
+        super()._repack_nvfp4(name, weight, scale, scale2, input_scale)
+
     _experts: list[dict[str, Tensor]] | None = None
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:


### PR DESCRIPTION
## Overview

NVFP4 GGUFs produced by `convert_hf_to_gguf.py` for Llama-architecture models output gibberish at inference (e.g. `Certainlyrics|assistant|assistant|...` for "The capital of France is"). Root cause: `ModelBase._repack_nvfp4` writes weights directly and bypasses `LlamaModel.modify_tensors`, so the axis-0 row permutation that GGML's RoPE convention requires for `q_proj.weight` / `k_proj.weight` is never applied. Attention heads end up scrambled.

This PR mirrors `LlamaModel.permute` inside `_repack_nvfp4` and applies it to both the nibble-packed weight tensor and the per-block scale tensor when the module is `q_proj`/`k_proj` and `arch == "llama"`.

### Reproducer (TinyLlama-1.1B)

| Build | Perplexity (wikitext-2 slice) |
|---|---|
| BF16 reference | 44.0 |
| NVFP4 GGUF, `master` (no fix) | **4419** (gibberish) |
| NVFP4 GGUF, this PR | **43.9** |

Also end-to-end verified on a 40B Llama-arch model (BSC ALIA-40b-instruct-2601, NVFP4-quantized via NVIDIA ModelOpt then converted with the patched script). Multilingual generation in Spanish/Catalan/Basque/Galician is coherent with the fix; gibberish without.

### Why inline rather than calling `LlamaModel.permute`

`_repack_nvfp4` lives on `ModelBase`; `permute` is a `LlamaModel` (subclass) staticmethod. Calling a subclass staticmethod from the parent is awkward. Extracting `permute` to a module-level helper would invite a larger refactor than this bug warrants. The duplication is 6 lines of math with a one-line comment referencing the canonical BF16 site.

## Additional Information

Related: #19769 (which added `GGML_TYPE_NVFP4` and the conversion path that this PR fixes).

Affects any Llama-architecture model (Llama 1/2/3, Mistral, Qwen2 derivatives that subclass `LlamaModel`, BSC ALIA, etc.) when quantized through the NVFP4 path. The BF16 path is unaffected.

## Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR

- [x] I have read the contributing guidelines
- Self-reported review complexity:
  - [x] Low
  - [ ] Medium
  - [ ] High
