### PR TITLE
server : fix null task dereference after image processing failure

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2616,7 +2616,7 @@ private:
                             SLT_ERR(slot, "failed to process image, res = %d\n", res);
                             send_error(slot, "failed to process image", ERROR_TYPE_SERVER);
                             slot.release();
-                            continue;
+                            break;
                         }
 
                         slot.n_prompt_tokens_processed += n_tokens_out;
@@ -2628,6 +2628,10 @@ private:
                         }
 
                         has_mtmd = true;
+                    }
+
+                    if (!slot.is_processing()) {
+                        continue;
                     }
 
                     // add prompt tokens for processing in the current batch


### PR DESCRIPTION
This fixes a crash in `llama-server` when multimodal image chunk processing fails during a mixed image and text request.

In this failure path, `slot.release()` resets `slot.task` to `nullptr`, but the per-slot processing loop could still continue and later access `slot.task->n_tokens()`. This change stops further processing for that slot once the task has been released, so the server does not dereference a null task.

Fixes #22603