### PR TITLE
vulkan: optimize conv2d and implement coopmat1 support

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4872,8 +4872,21 @@ static void ggml_vk_load_shaders(vk_device& device) {
                 conv2d_BS.CRS);  // CRS block size should be capped at subgroup size for correctness when shuffle is used.
         }
 
+        // Stage the cm2 accumulator through shmem before the global store.
+        // Wins consistently on smaller tile shapes (replaces the per-elem
+        // callback in coopMatPerElementNV with a coalesced cooperative
+        // shmem->global pass). On the 128x128 shape the Csh footprint
+        // (32 KB fp16) halves occupancy, which loses more than the better
+        // stores save on workloads big enough to use that occupancy.
+        const uint32_t conv2d_csh_store = (device->coopmat2 && s != CONV_SHAPE_128x128) ? 1u : 0u;
+
+        // SHMEM_TYPE in the shader is fp16 on the cm2 path (where the Csh
+        // staging buffer also lives, when csh_store==1) and fp32 on the
+        // scalar path (no Csh).
+        const uint32_t conv2d_shmem_elem_size = device->coopmat2 ? (uint32_t)sizeof(uint16_t) : (uint32_t)sizeof(float);
+        const uint32_t conv2d_csh_elems       = conv2d_csh_store ? conv2d_BS.K * conv2d_BS.NPQ : 0u;
         uint32_t conv2d_shmem_req =
-            (conv2d_BS.K * (conv2d_BS.CRS + conv2d_SHMEM_PAD) + conv2d_BS.CRS * (conv2d_BS.NPQ + conv2d_SHMEM_PAD)) * sizeof(float);
+            (conv2d_BS.K * (conv2d_BS.CRS + conv2d_SHMEM_PAD) + conv2d_BS.CRS * (conv2d_BS.NPQ + conv2d_SHMEM_PAD) + conv2d_csh_elems) * conv2d_shmem_elem_size;
         if (device->properties.limits.maxComputeSharedMemorySize < conv2d_shmem_req) {
             conv2d_BS.CRS = 8;
             if (use_collectives) {
@@ -4897,6 +4910,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
             spec_constants_cpy.push_back(state.KW); \
             spec_constants_cpy.push_back(state.KH); \
             spec_constants_cpy.push_back(state.aligned); \
+            spec_constants_cpy.push_back(conv2d_csh_store); \
             ggml_vk_create_pipeline( \
                 device, c.second, #name #type_suffix, \
                 name##type_suffix##spv_suffix##_len, name##type_suffix##spv_suffix##_data, "main", 3, \

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -401,6 +401,7 @@ enum vk_conv_shapes {
     CONV_SHAPE_128x128,
     CONV_SHAPE_64x32,
     CONV_SHAPE_32x256,
+    CONV_SHAPE_64x128,
     CONV_SHAPE_COUNT,
 };
 
@@ -415,6 +416,7 @@ vk_conv_block_size vk_conv_block_sizes[CONV_SHAPE_COUNT] = {
     { 128, 128, 16 }, // CONV_SHAPE_128x128
     {  64,  32, 32 }, // CONV_SHAPE_64x32
     {  32, 256, 16 }, // CONV_SHAPE_32x256
+    {  64, 128, 16 }, // CONV_SHAPE_64x128
 };
 
 enum dmmv_wg_sizes {
@@ -9350,6 +9352,8 @@ static vk_conv_shapes ggml_vk_conv_select_shape(ggml_backend_vk_context * ctx, u
         return CONV_SHAPE_128x128;
     } else if (K <= 32 && n_tiles(CONV_SHAPE_32x256) >= shader_core_count * 2) {
         return CONV_SHAPE_32x256;
+    } else if (K <= 64 && n_tiles(CONV_SHAPE_64x128) >= shader_core_count * 2) {
+        return CONV_SHAPE_64x128;
     } else {
         return CONV_SHAPE_64x32;
     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -452,14 +452,17 @@ struct vk_fa_pipeline_state {
 };
 
 struct vk_conv2d_pipeline_state {
-    vk_conv2d_pipeline_state(uint32_t s0, uint32_t s1, uint32_t p0, uint32_t p1, uint32_t d0, uint32_t d1, uint32_t KW, uint32_t KH)
-        : s0(s0), s1(s1), p0(p0), p1(p1), d0(d0), d1(d1), KW(KW), KH(KH) {}
+    vk_conv2d_pipeline_state(uint32_t s0, uint32_t s1, uint32_t p0, uint32_t p1, uint32_t d0, uint32_t d1, uint32_t KW, uint32_t KH, uint32_t aligned)
+        : s0(s0), s1(s1), p0(p0), p1(p1), d0(d0), d1(d1), KW(KW), KH(KH), aligned(aligned) {}
 
     uint32_t s0, s1, p0, p1, d0, d1, KW, KH;
+    // 1 if K/CRS/NPQ are exact multiples of the corresponding tile sizes (BS_K/BS_CRS/BS_NPQ),
+    // allowing the shader to skip K/CRS/NPQ bounds checks and the load address clamps. 0 otherwise.
+    uint32_t aligned;
 
     bool operator<(const vk_conv2d_pipeline_state &b) const {
-        return std::tie(s0, s1, p0, p1, d0, d1, KW, KH) <
-               std::tie(b.s0, b.s1, b.p0, b.p1, b.d0, b.d1, b.KW, b.KH);
+        return std::tie(s0, s1, p0, p1, d0, d1, KW, KH, aligned) <
+               std::tie(b.s0, b.s1, b.p0, b.p1, b.d0, b.d1, b.KW, b.KH, b.aligned);
     }
 };
 
@@ -4889,6 +4892,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
             spec_constants_cpy.push_back(state.d1); \
             spec_constants_cpy.push_back(state.KW); \
             spec_constants_cpy.push_back(state.KH); \
+            spec_constants_cpy.push_back(state.aligned); \
             ggml_vk_create_pipeline( \
                 device, c.second, #name #type_suffix, \
                 name##type_suffix##spv_suffix##_len, name##type_suffix##spv_suffix##_data, "main", 3, \
@@ -9880,7 +9884,19 @@ static vk_pipeline ggml_vk_op_get_pipeline(ggml_backend_vk_context * ctx, const 
             uint32_t p1 = !transpose ? (uint32_t)ggml_get_op_params_i32(dst, 3) : 0;
             uint32_t d0 = !transpose ? (uint32_t)ggml_get_op_params_i32(dst, 4) : 1;
             uint32_t d1 = !transpose ? (uint32_t)ggml_get_op_params_i32(dst, 5) : 1;
-            vk_conv2d_pipeline_state conv2d_pipeline_state(s0, s1, p0, p1, d0, d1, KW, KH);
+
+            // Detect whether K/CRS/NPQ are exact multiples of the tile sizes, so the
+            // shader can skip the corresponding bounds checks and address clamps.
+            const uint32_t Cin = (uint32_t)src1->ne[2];
+            const uint32_t CRS = Cin * KW * KH;
+            const uint32_t BS_K   = vk_conv_block_sizes[shape].K;
+            const uint32_t BS_CRS = vk_conv_block_sizes[shape].CRS;
+            const uint32_t BS_NPQ = vk_conv_block_sizes[shape].NPQ;
+            const uint32_t aligned = ((K   % BS_K   == 0) &&
+                                      (CRS % BS_CRS == 0) &&
+                                      (NPQ % BS_NPQ == 0)) ? 1u : 0u;
+
+            vk_conv2d_pipeline_state conv2d_pipeline_state(s0, s1, p0, p1, d0, d1, KW, KH, aligned);
 
             std::map<vk_conv2d_pipeline_state, vk_pipeline> *pipelines = nullptr;
             if (op == GGML_OP_CONV_2D) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4829,7 +4829,11 @@ static void ggml_vk_load_shaders(vk_device& device) {
 
     // conv2d, conv_transpose_2d
     for (uint32_t s = 0; s < CONV_SHAPE_COUNT; ++s) {
-        uint32_t conv2d_WG_SIZE  = 256;
+        // The 64x32 fallback shape is used for small problems where each WG has
+        // very little compute and we're limited by warp-level latency hiding rather
+        // than total tile count. Halving WG_SIZE doubles per-thread work but lets
+        // more WGs run concurrently per SM, which improves latency hiding.
+        uint32_t conv2d_WG_SIZE  = (s == CONV_SHAPE_64x32) ? 128 : 256;
         uint32_t use_collectives = 0;  // Enables subgroup ops for preventing the re-calculation of indices.
         uint32_t conv2d_TS_K     = (s == CONV_SHAPE_64x32) ? 4 : 8;
         uint32_t conv2d_SHMEM_PAD = 4;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4868,22 +4868,29 @@ static void ggml_vk_load_shaders(vk_device& device) {
                 conv2d_BS.CRS);  // CRS block size should be capped at subgroup size for correctness when shuffle is used.
         }
 
-        // cm1 is used only when cm2 is unavailable; capped at 64x128 (due to shared memory size)
+        // cm1 is used only when cm2 is unavailable; capped at 64x128 (due to shared memory size).
+        // Requires 16x16x16 f16-acc since that's the fragment shape hard-coded in the shader.
+        // Subgroup size must be 32 or 64 (to keep WG_SIZE sane) and we need
+        // subgroup_size_control to force the driver to actually use it.
         bool conv2d_use_cm1 = false;
 #if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
         conv2d_use_cm1 = !device->coopmat2 &&
-                         device->coopmat_support && device->coopmat_acc_f16_support &&
+                         device->coopmat_support && device->coopmat_support_16x16x16_f16acc &&
+                         device->subgroup_size_control &&
+                         (device->subgroup_size == 32 || device->subgroup_size == 64) &&
                          s != CONV_SHAPE_128x128;
 #endif
 
         uint32_t conv2d_WM = 16, conv2d_WN = 16;  // cm1 subgroup tile, ignored otherwise
         if (conv2d_use_cm1) {
             conv2d_SHMEM_PAD = 8;
-            // 16x16x16 fragments; pick WM/WN to give 8 subgroups per WG
+            // 16x16x16 fragments; pick WM/WN to keep WG_SIZE at 256
+            // (i.e. 8 subgroups for sg=32, 4 subgroups for sg=64).
+            const bool sg64 = (device->subgroup_size == 64);
             switch (s) {
-                case CONV_SHAPE_64x32:   conv2d_WM = 16; conv2d_WN = 16; break;
-                case CONV_SHAPE_64x128:  conv2d_WM = 32; conv2d_WN = 32; break;
-                case CONV_SHAPE_32x256:  conv2d_WM = 32; conv2d_WN = 32; break;
+                case CONV_SHAPE_64x32:   conv2d_WM = sg64 ? 32 : 16; conv2d_WN = 16; break;
+                case CONV_SHAPE_64x128:  conv2d_WM = 32; conv2d_WN = sg64 ? 64 : 32; break;
+                case CONV_SHAPE_32x256:  conv2d_WM = sg64 ? 16 : 32; conv2d_WN = sg64 ? 128 : 32; break;
                 default: break;
             }
             const uint32_t warps_M = conv2d_BS.K / conv2d_WM;
@@ -4920,6 +4927,9 @@ static void ggml_vk_load_shaders(vk_device& device) {
         std::array<uint32_t, 3> wg_denoms = { conv2d_BS.K, 1, 1 };
         std::vector<uint32_t> spec_constants = { conv2d_WG_SIZE, conv2d_BS.K, conv2d_BS.CRS, conv2d_BS.NPQ, conv2d_TS_K, use_collectives, conv2d_SHMEM_PAD };
 
+        // cm1 needs a fixed subgroup width to match the WG_SIZE we computed
+        const uint32_t conv2d_required_subgroup_size = conv2d_use_cm1 ? device->subgroup_size : 0;
+
 #define CREATE_CONV(name, type_suffix, spv_suffix) \
         for (auto &c : device->pipeline_##name##type_suffix[s]) { \
             const vk_conv2d_pipeline_state &state = c.first;  \
@@ -4939,7 +4949,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
             ggml_vk_create_pipeline( \
                 device, c.second, #name #type_suffix, \
                 name##type_suffix##spv_suffix##_len, name##type_suffix##spv_suffix##_data, "main", 3, \
-                sizeof(vk_op_conv2d_push_constants), wg_denoms, spec_constants_cpy, 1, true, use_collectives);    \
+                sizeof(vk_op_conv2d_push_constants), wg_denoms, spec_constants_cpy, 1, true, use_collectives || conv2d_required_subgroup_size, conv2d_required_subgroup_size);    \
         }
 #define CREATE_CONVS(spv_suffix) \
         CREATE_CONV(conv2d, _f32, spv_suffix) \

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4872,18 +4872,53 @@ static void ggml_vk_load_shaders(vk_device& device) {
                 conv2d_BS.CRS);  // CRS block size should be capped at subgroup size for correctness when shuffle is used.
         }
 
+        // Determine whether we'll use cm1 for this shape. cm1 is only used
+        // when cm2 is unavailable (cm2 is always preferred when present), and
+        // we cap cm1 at the 64x128 tile because the 128x128 register pressure
+        // is brutal for the subgroup-tile coopmat layout.
+        bool conv2d_use_cm1 = false;
+#if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+        conv2d_use_cm1 = !device->coopmat2 &&
+                         device->coopmat_support && device->coopmat_acc_f16_support &&
+                         s != CONV_SHAPE_128x128;
+#endif
+
+        // cm1 needs fp16 shmem padding like cm2, plus its own WG sizing so
+        // that warps_M * warps_N * subgroup_size == WG_SIZE.
+        uint32_t conv2d_WM = 16, conv2d_WN = 16;  // ignored unless cm1
+        if (conv2d_use_cm1) {
+            conv2d_SHMEM_PAD = 8;
+            // 16x16x16 fragments. Pick subgroup-tile sizes so we end up with 8
+            // subgroups per WG (i.e. WG = 8 * subgroup_size, typically 256 on
+            // NV/RDNA-32 or 512 on AMD-CDNA-64).
+            switch (s) {
+                case CONV_SHAPE_64x32:   conv2d_WM = 16; conv2d_WN = 16; break;  // warps 4x2, cms 1x1
+                case CONV_SHAPE_64x128:  conv2d_WM = 32; conv2d_WN = 32; break;  // warps 2x4, cms 2x2
+                case CONV_SHAPE_32x256:  conv2d_WM = 32; conv2d_WN = 32; break;  // warps 1x8, cms 2x2
+                default: break;
+            }
+            const uint32_t warps_M = conv2d_BS.K / conv2d_WM;
+            const uint32_t warps_N = conv2d_BS.NPQ / conv2d_WN;
+            conv2d_WG_SIZE         = warps_M * warps_N * device->subgroup_size;
+        }
+
         // Stage the cm2 accumulator through shmem before the global store.
         // Wins consistently on smaller tile shapes (replaces the per-elem
         // callback in coopMatPerElementNV with a coalesced cooperative
         // shmem->global pass). On the 128x128 shape the Csh footprint
         // (32 KB fp16) halves occupancy, which loses more than the better
-        // stores save on workloads big enough to use that occupancy.
-        const uint32_t conv2d_csh_store = (device->coopmat2 && s != CONV_SHAPE_128x128) ? 1u : 0u;
+        // stores save on workloads big enough to use that occupancy. cm1
+        // always uses the staged path (no per-elem callback equivalent).
+        uint32_t conv2d_csh_store = (device->coopmat2 && s != CONV_SHAPE_128x128) ? 1u : 0u;
+        if (conv2d_use_cm1) {
+            conv2d_csh_store = 1;
+        }
 
-        // SHMEM_TYPE in the shader is fp16 on the cm2 path (where the Csh
-        // staging buffer also lives, when csh_store==1) and fp32 on the
+        // SHMEM_TYPE in the shader is fp16 on the cm2/cm1 paths (where the
+        // Csh staging buffer also lives, when csh_store==1) and fp32 on the
         // scalar path (no Csh).
-        const uint32_t conv2d_shmem_elem_size = device->coopmat2 ? (uint32_t)sizeof(uint16_t) : (uint32_t)sizeof(float);
+        const bool     conv2d_use_fp16_shmem = device->coopmat2 || conv2d_use_cm1;
+        const uint32_t conv2d_shmem_elem_size = conv2d_use_fp16_shmem ? (uint32_t)sizeof(uint16_t) : (uint32_t)sizeof(float);
         const uint32_t conv2d_csh_elems       = conv2d_csh_store ? conv2d_BS.K * conv2d_BS.NPQ : 0u;
         uint32_t conv2d_shmem_req =
             (conv2d_BS.K * (conv2d_BS.CRS + conv2d_SHMEM_PAD) + conv2d_BS.CRS * (conv2d_BS.NPQ + conv2d_SHMEM_PAD) + conv2d_csh_elems) * conv2d_shmem_elem_size;
@@ -4911,6 +4946,8 @@ static void ggml_vk_load_shaders(vk_device& device) {
             spec_constants_cpy.push_back(state.KH); \
             spec_constants_cpy.push_back(state.aligned); \
             spec_constants_cpy.push_back(conv2d_csh_store); \
+            spec_constants_cpy.push_back(conv2d_WM); \
+            spec_constants_cpy.push_back(conv2d_WN); \
             ggml_vk_create_pipeline( \
                 device, c.second, #name #type_suffix, \
                 name##type_suffix##spv_suffix##_len, name##type_suffix##spv_suffix##_data, "main", 3, \
@@ -4924,6 +4961,11 @@ static void ggml_vk_load_shaders(vk_device& device) {
 #if defined(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
         if (device->coopmat2) {
             CREATE_CONVS(_cm2)
+        } else
+#endif
+#if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+        if (conv2d_use_cm1) {
+            CREATE_CONVS(_cm1)
         } else
 #endif
         if (conv2d_UNROLL) {
@@ -9370,11 +9412,25 @@ static vk_conv_shapes ggml_vk_conv_select_shape(ggml_backend_vk_context * ctx, u
     // so small convolutions will still choose a smaller tile.
     const uint32_t shader_core_count = ctx->device->shader_core_count > 0 ? ctx->device->shader_core_count : 32;
 
-    if (K > 64 && n_tiles(CONV_SHAPE_128x128) >= shader_core_count * 2) {
+    // The 128x128 tile isn't built on cm1-only devices (register pressure with
+    // subgroup-tile coopmats is prohibitive); fall through to a smaller tile.
+    bool allow_128x128 = true;
+#if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+    if (!ctx->device->coopmat2 && ctx->device->coopmat_support && ctx->device->coopmat_acc_f16_support) {
+        allow_128x128 = false;
+    }
+#endif
+
+    if (allow_128x128 && K > 64 && n_tiles(CONV_SHAPE_128x128) >= shader_core_count * 2) {
         return CONV_SHAPE_128x128;
     } else if (K <= 32 && n_tiles(CONV_SHAPE_32x256) >= shader_core_count * 2) {
         return CONV_SHAPE_32x256;
     } else if (K <= 64 && n_tiles(CONV_SHAPE_64x128) >= shader_core_count * 2) {
+        return CONV_SHAPE_64x128;
+    } else if (!allow_128x128 && K > 64 && n_tiles(CONV_SHAPE_64x128) >= shader_core_count * 2) {
+        // When 128x128 isn't built (cm1 path), large-K problems should still
+        // get the biggest available tile rather than dropping all the way to
+        // the small 64x32 fallback.
         return CONV_SHAPE_64x128;
     } else {
         return CONV_SHAPE_64x32;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -456,8 +456,7 @@ struct vk_conv2d_pipeline_state {
         : s0(s0), s1(s1), p0(p0), p1(p1), d0(d0), d1(d1), KW(KW), KH(KH), aligned(aligned) {}
 
     uint32_t s0, s1, p0, p1, d0, d1, KW, KH;
-    // 1 if K/CRS/NPQ are exact multiples of the corresponding tile sizes (BS_K/BS_CRS/BS_NPQ),
-    // allowing the shader to skip K/CRS/NPQ bounds checks and the load address clamps. 0 otherwise.
+    // when set, shader can skip K/CRS/NPQ bounds checks and address clamps
     uint32_t aligned;
 
     bool operator<(const vk_conv2d_pipeline_state &b) const {
@@ -4829,10 +4828,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
 
     // conv2d, conv_transpose_2d
     for (uint32_t s = 0; s < CONV_SHAPE_COUNT; ++s) {
-        // The 64x32 fallback shape is used for small problems where each WG has
-        // very little compute and we're limited by warp-level latency hiding rather
-        // than total tile count. Halving WG_SIZE doubles per-thread work but lets
-        // more WGs run concurrently per SM, which improves latency hiding.
+        // smaller WG for the small-tile fallback gives more concurrent WGs per SM
         uint32_t conv2d_WG_SIZE  = (s == CONV_SHAPE_64x32) ? 128 : 256;
         uint32_t use_collectives = 0;  // Enables subgroup ops for preventing the re-calculation of indices.
         uint32_t conv2d_TS_K     = (s == CONV_SHAPE_64x32) ? 4 : 8;
@@ -4872,10 +4868,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
                 conv2d_BS.CRS);  // CRS block size should be capped at subgroup size for correctness when shuffle is used.
         }
 
-        // Determine whether we'll use cm1 for this shape. cm1 is only used
-        // when cm2 is unavailable (cm2 is always preferred when present), and
-        // we cap cm1 at the 64x128 tile because the 128x128 register pressure
-        // is brutal for the subgroup-tile coopmat layout.
+        // cm1 is used only when cm2 is unavailable; capped at 64x128 (due to shared memory size)
         bool conv2d_use_cm1 = false;
 #if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
         conv2d_use_cm1 = !device->coopmat2 &&
@@ -4883,18 +4876,14 @@ static void ggml_vk_load_shaders(vk_device& device) {
                          s != CONV_SHAPE_128x128;
 #endif
 
-        // cm1 needs fp16 shmem padding like cm2, plus its own WG sizing so
-        // that warps_M * warps_N * subgroup_size == WG_SIZE.
-        uint32_t conv2d_WM = 16, conv2d_WN = 16;  // ignored unless cm1
+        uint32_t conv2d_WM = 16, conv2d_WN = 16;  // cm1 subgroup tile, ignored otherwise
         if (conv2d_use_cm1) {
             conv2d_SHMEM_PAD = 8;
-            // 16x16x16 fragments. Pick subgroup-tile sizes so we end up with 8
-            // subgroups per WG (i.e. WG = 8 * subgroup_size, typically 256 on
-            // NV/RDNA-32 or 512 on AMD-CDNA-64).
+            // 16x16x16 fragments; pick WM/WN to give 8 subgroups per WG
             switch (s) {
-                case CONV_SHAPE_64x32:   conv2d_WM = 16; conv2d_WN = 16; break;  // warps 4x2, cms 1x1
-                case CONV_SHAPE_64x128:  conv2d_WM = 32; conv2d_WN = 32; break;  // warps 2x4, cms 2x2
-                case CONV_SHAPE_32x256:  conv2d_WM = 32; conv2d_WN = 32; break;  // warps 1x8, cms 2x2
+                case CONV_SHAPE_64x32:   conv2d_WM = 16; conv2d_WN = 16; break;
+                case CONV_SHAPE_64x128:  conv2d_WM = 32; conv2d_WN = 32; break;
+                case CONV_SHAPE_32x256:  conv2d_WM = 32; conv2d_WN = 32; break;
                 default: break;
             }
             const uint32_t warps_M = conv2d_BS.K / conv2d_WM;
@@ -4902,21 +4891,15 @@ static void ggml_vk_load_shaders(vk_device& device) {
             conv2d_WG_SIZE         = warps_M * warps_N * device->subgroup_size;
         }
 
-        // Stage the cm2 accumulator through shmem before the global store.
-        // Wins consistently on smaller tile shapes (replaces the per-elem
-        // callback in coopMatPerElementNV with a coalesced cooperative
-        // shmem->global pass). On the 128x128 shape the Csh footprint
-        // (32 KB fp16) halves occupancy, which loses more than the better
-        // stores save on workloads big enough to use that occupancy. cm1
-        // always uses the staged path (no per-elem callback equivalent).
+        // stage cm2 accumulator through shmem for coalesced global stores;
+        // skipped on 128x128 where the extra Csh footprint hurts occupancy.
+        // cm1 always uses the staged path.
         uint32_t conv2d_csh_store = (device->coopmat2 && s != CONV_SHAPE_128x128) ? 1u : 0u;
         if (conv2d_use_cm1) {
             conv2d_csh_store = 1;
         }
 
-        // SHMEM_TYPE in the shader is fp16 on the cm2/cm1 paths (where the
-        // Csh staging buffer also lives, when csh_store==1) and fp32 on the
-        // scalar path (no Csh).
+        // shmem is fp16 on cm2/cm1 (matches Csh), fp32 on scalar
         const bool     conv2d_use_fp16_shmem = device->coopmat2 || conv2d_use_cm1;
         const uint32_t conv2d_shmem_elem_size = conv2d_use_fp16_shmem ? (uint32_t)sizeof(uint16_t) : (uint32_t)sizeof(float);
         const uint32_t conv2d_csh_elems       = conv2d_csh_store ? conv2d_BS.K * conv2d_BS.NPQ : 0u;
@@ -4927,6 +4910,11 @@ static void ggml_vk_load_shaders(vk_device& device) {
             if (use_collectives) {
                 conv2d_BS.CRS = std::min(device->subgroup_size, conv2d_BS.CRS);
             }
+            // cm1's Csh allocation doesn't shrink with BS_CRS, so fall back to
+            // scalar to guarantee we fit (matters on 16 KB-shmem devices).
+            conv2d_use_cm1 = false;
+            conv2d_csh_store = 0;
+            conv2d_WM = conv2d_WN = 16;
         }
 
         std::array<uint32_t, 3> wg_denoms = { conv2d_BS.K, 1, 1 };
@@ -9412,8 +9400,7 @@ static vk_conv_shapes ggml_vk_conv_select_shape(ggml_backend_vk_context * ctx, u
     // so small convolutions will still choose a smaller tile.
     const uint32_t shader_core_count = ctx->device->shader_core_count > 0 ? ctx->device->shader_core_count : 32;
 
-    // The 128x128 tile isn't built on cm1-only devices (register pressure with
-    // subgroup-tile coopmats is prohibitive); fall through to a smaller tile.
+    // 128x128 isn't used with cm1 due to shared memory size; fall through to a smaller tile.
     bool allow_128x128 = true;
 #if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
     if (!ctx->device->coopmat2 && ctx->device->coopmat_support && ctx->device->coopmat_acc_f16_support) {
@@ -9428,9 +9415,7 @@ static vk_conv_shapes ggml_vk_conv_select_shape(ggml_backend_vk_context * ctx, u
     } else if (K <= 64 && n_tiles(CONV_SHAPE_64x128) >= shader_core_count * 2) {
         return CONV_SHAPE_64x128;
     } else if (!allow_128x128 && K > 64 && n_tiles(CONV_SHAPE_64x128) >= shader_core_count * 2) {
-        // When 128x128 isn't built (cm1 path), large-K problems should still
-        // get the biggest available tile rather than dropping all the way to
-        // the small 64x32 fallback.
+        // cm1 fallback for large K when 128x128 isn't available
         return CONV_SHAPE_64x128;
     } else {
         return CONV_SHAPE_64x32;
@@ -9959,8 +9944,7 @@ static vk_pipeline ggml_vk_op_get_pipeline(ggml_backend_vk_context * ctx, const 
             uint32_t d0 = !transpose ? (uint32_t)ggml_get_op_params_i32(dst, 4) : 1;
             uint32_t d1 = !transpose ? (uint32_t)ggml_get_op_params_i32(dst, 5) : 1;
 
-            // Detect whether K/CRS/NPQ are exact multiples of the tile sizes, so the
-            // shader can skip the corresponding bounds checks and address clamps.
+            // tile-aligned shapes let the shader skip bounds checks
             const uint32_t Cin = (uint32_t)src1->ne[2];
             const uint32_t CRS = Cin * KW * KH;
             const uint32_t BS_K   = vk_conv_block_sizes[shape].K;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4881,9 +4881,23 @@ static void ggml_vk_load_shaders(vk_device& device) {
                          s != CONV_SHAPE_128x128;
 #endif
 
+        const uint32_t conv2d_cm1_shmem_pad = 8;
+
+        auto shmem_req = [&](uint32_t pad, bool csh_store, bool fp16_shmem) {
+            const uint32_t elem_size = fp16_shmem ? (uint32_t)sizeof(uint16_t) : (uint32_t)sizeof(float);
+            const uint32_t csh_elems = csh_store ? conv2d_BS.K * conv2d_BS.NPQ : 0u;
+            return (conv2d_BS.K * (conv2d_BS.CRS + pad) + conv2d_BS.CRS * (conv2d_BS.NPQ + pad) + csh_elems) * elem_size;
+        };
+
+        // coopmat1 needs to store the output through shared memory, so check up front
+        // whether it'll fit and disable it before applying coopmat1 parameters.
+        if (conv2d_use_cm1 && device->properties.limits.maxComputeSharedMemorySize < shmem_req(conv2d_cm1_shmem_pad, true, true)) {
+            conv2d_use_cm1 = false;
+        }
+
         uint32_t conv2d_WM = 16, conv2d_WN = 16;  // cm1 subgroup tile, ignored otherwise
         if (conv2d_use_cm1) {
-            conv2d_SHMEM_PAD = 8;
+            conv2d_SHMEM_PAD = conv2d_cm1_shmem_pad;
             // 16x16x16 fragments; pick WM/WN to keep WG_SIZE at 256
             // (i.e. 8 subgroups for sg=32, 4 subgroups for sg=64).
             const bool sg64 = (device->subgroup_size == 64);
@@ -4907,21 +4921,16 @@ static void ggml_vk_load_shaders(vk_device& device) {
         }
 
         // shmem is fp16 on cm2/cm1 (matches Csh), fp32 on scalar
-        const bool     conv2d_use_fp16_shmem = device->coopmat2 || conv2d_use_cm1;
-        const uint32_t conv2d_shmem_elem_size = conv2d_use_fp16_shmem ? (uint32_t)sizeof(uint16_t) : (uint32_t)sizeof(float);
-        const uint32_t conv2d_csh_elems       = conv2d_csh_store ? conv2d_BS.K * conv2d_BS.NPQ : 0u;
-        uint32_t conv2d_shmem_req =
-            (conv2d_BS.K * (conv2d_BS.CRS + conv2d_SHMEM_PAD) + conv2d_BS.CRS * (conv2d_BS.NPQ + conv2d_SHMEM_PAD) + conv2d_csh_elems) * conv2d_shmem_elem_size;
-        if (device->properties.limits.maxComputeSharedMemorySize < conv2d_shmem_req) {
+        const bool conv2d_use_fp16_shmem = device->coopmat2 || conv2d_use_cm1;
+
+        // shrink CRS if the non-cm1 config still doesn't fit
+        if (device->properties.limits.maxComputeSharedMemorySize < shmem_req(conv2d_SHMEM_PAD, conv2d_csh_store, conv2d_use_fp16_shmem)) {
+            GGML_ASSERT(!conv2d_use_cm1);
             conv2d_BS.CRS = 8;
             if (use_collectives) {
                 conv2d_BS.CRS = std::min(device->subgroup_size, conv2d_BS.CRS);
             }
-            // cm1's Csh allocation doesn't shrink with BS_CRS, so fall back to
-            // scalar to guarantee we fit (matters on 16 KB-shmem devices).
-            conv2d_use_cm1 = false;
             conv2d_csh_store = 0;
-            conv2d_WM = conv2d_WN = 16;
         }
 
         std::array<uint32_t, 3> wg_denoms = { conv2d_BS.K, 1, 1 };
@@ -9413,7 +9422,7 @@ static vk_conv_shapes ggml_vk_conv_select_shape(ggml_backend_vk_context * ctx, u
     // 128x128 isn't used with cm1 due to shared memory size; fall through to a smaller tile.
     bool allow_128x128 = true;
 #if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
-    if (!ctx->device->coopmat2 && ctx->device->coopmat_support && ctx->device->coopmat_acc_f16_support) {
+    if (!ctx->device->coopmat2 && ctx->device->coopmat_support && ctx->device->coopmat_support_16x16x16_f16acc) {
         allow_128x128 = false;
     }
 #endif

--- a/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
@@ -77,6 +77,27 @@ layout(constant_id = 12) const uint d1             = 1;
 // Kernel spatial sizes
 layout(constant_id = 13) const uint KW             = 1;
 layout(constant_id = 14) const uint KH             = 1;
+// 1 if K/CRS/NPQ are exact multiples of BS_K/BS_CRS/BS_NPQ. When set, K/CRS/NPQ
+// bounds checks and the matA/matB address clamps and store guards are elided.
+layout(constant_id = 15) const uint aligned        = 0;
+
+// H/W bounds on matB are unnecessary in the non-TRANSPOSE case when there is no
+// padding: with p0 == p1 == 0, the standard OH/OW formulas guarantee
+// 0 <= H_idx < H and 0 <= W_idx < W. TRANSPOSE has different bounds reasoning
+// (H_idx_x_s1 can underflow), so we keep its checks unconditionally.
+#ifdef TRANSPOSE
+const bool hw_in_bounds = false;
+#else
+const bool hw_in_bounds = (p0 == 0) && (p1 == 0);
+#endif
+
+// TRANSPOSE stride alignment checks reduce to (H_idx_x_s1 % s1 == 0). They're
+// trivially satisfied when s == 1.
+#ifdef TRANSPOSE
+const bool stride_in_bounds = (s0 == 1) && (s1 == 1);
+#else
+const bool stride_in_bounds = true;
+#endif
 
 uint32_t       tid     = gl_LocalInvocationID.x;
 const uint32_t WG_SIZE = gl_WorkGroupSize.x;
@@ -161,7 +182,7 @@ ACC_TYPE perElemOpStore(const in uint32_t r, const in uint32_t c, const in ACC_T
     uint32_t OH_idx  = fastdiv(NPQ_idx - N_idx * p.OH * p.OW, p.OWmp, p.OWL); // divide by p.OW;
     uint32_t OW_idx  = NPQ_idx - N_idx * p.OH * p.OW - OH_idx * p.OW;
     uint32_t dst_idx = OW_idx + OH_idx * p.nb1 + K_idx * p.nb2 + N_idx * p.nb3;
-    if (K_idx < K && NPQ_idx < NPQ) {
+    if (aligned != 0 || (K_idx < K && NPQ_idx < NPQ)) {
         dst_data[dst_idx] = D_TYPE(elem);
     }
     return elem;
@@ -228,12 +249,15 @@ void main() {
             uint32_t B_lx    = Ac;
             uint32_t K_idx   = B_idx_K * BS_K + B_ly; /* Global K_idx (row index of A)*/
 #ifdef TRANSPOSE
-            uint32_t knl_idx = min(KW_idx_a + KH_idx_a * p.nb01 + K_idx * p.nb02 + Cin_idx_a * p.nb03, K * CRS - 1);
+            uint32_t knl_idx = KW_idx_a + KH_idx_a * p.nb01 + K_idx * p.nb02 + Cin_idx_a * p.nb03;
 #else
-            uint32_t knl_idx = min(KW_idx_a + KH_idx_a * p.nb01 + Cin_idx_a * p.nb02 + K_idx * p.nb03, K * CRS - 1);
+            uint32_t knl_idx = KW_idx_a + KH_idx_a * p.nb01 + Cin_idx_a * p.nb02 + K_idx * p.nb03;
 #endif
+            if (aligned == 0) {
+                knl_idx = min(knl_idx, K * CRS - 1);
+            }
             float    val     = knl_data[knl_idx];
-            if (K_idx >= K || CRS_idx_a >= CRS) {
+            if (aligned == 0 && (K_idx >= K || CRS_idx_a >= CRS)) {
                 val = 0.0;
             }
             Ash[B_ly * Ash_stride + B_lx] = SHMEM_TYPE(val);
@@ -282,15 +306,30 @@ void main() {
             uint32_t H_idx = OH_idx * s1 + KH_idx_b * d1 - p1;
             uint32_t W_idx = OW_idx * s0 + KW_idx_b * d0 - p0;
 #endif
-            uint32_t src_idx =
-                min(max(W_idx + H_idx * p.nb11 + Cin_idx_b * p.nb12 + N_idx * p.nb13, 0), p.Cin * p.N * p.W * p.H - 1);
+            uint32_t src_idx = W_idx + H_idx * p.nb11 + Cin_idx_b * p.nb12 + N_idx * p.nb13;
+            // Only clamp when an out-of-bounds address is actually possible. With
+            // aligned == 1 the CRS/NPQ checks below disappear, and with hw_in_bounds
+            // the H/W checks disappear -- so the address is guaranteed in range and
+            // no clamp is needed.
+            if (aligned == 0 || !hw_in_bounds || !stride_in_bounds) {
+                src_idx = min(max(src_idx, 0), p.Cin * p.N * p.W * p.H - 1);
+            }
             float val = src_data[src_idx];
-            if (CRS_idx_b >= CRS || NPQ_idx >= NPQ
-                || H_idx >= p.H || W_idx >= p.W // Lower bound checks aren't necessary. (idx >= 0x80000000 for such case)
+            bool oob = false;
+            if (aligned == 0 && (CRS_idx_b >= CRS || NPQ_idx >= NPQ)) {
+                oob = true;
+            }
+            // H/W bounds (also implicitly catches lower-bound underflow: idx >= 0x80000000).
+            if (!hw_in_bounds && (H_idx >= p.H || W_idx >= p.W)) {
+                oob = true;
+            }
 #ifdef TRANSPOSE
-                || (H_idx_x_s1 - H_idx * s1 != 0) || (W_idx_x_s0 - W_idx * s0 != 0)
+            if (!stride_in_bounds &&
+                ((H_idx_x_s1 - H_idx * s1 != 0) || (W_idx_x_s0 - W_idx * s0 != 0))) {
+                oob = true;
+            }
 #endif
-                ) {
+            if (oob) {
                 val = 0.0;
             }
             Bsh[B_ly * Bsh_stride + B_lx] = SHMEM_TYPE(val);
@@ -337,7 +376,7 @@ void main() {
                 uint32_t OH_idx  = fastdiv(NPQ_idx - N_idx * p.OH * p.OW, p.OWmp, p.OWL); // divide by p.OW;
                 uint32_t OW_idx  = NPQ_idx - N_idx * p.OH * p.OW - OH_idx * p.OW;
                 uint32_t dst_idx = OW_idx + OH_idx * p.nb1 + K_idx * p.nb2 + N_idx * p.nb3;
-                if (K_idx < K && NPQ_idx < NPQ) {
+                if (aligned != 0 || (K_idx < K && NPQ_idx < NPQ)) {
                     dst_data[dst_idx] = regC[T_ly][T_lx];
                 }
             }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
@@ -80,6 +80,11 @@ layout(constant_id = 14) const uint KH             = 1;
 // 1 if K/CRS/NPQ are exact multiples of BS_K/BS_CRS/BS_NPQ. When set, K/CRS/NPQ
 // bounds checks and the matA/matB address clamps and store guards are elided.
 layout(constant_id = 15) const uint aligned        = 0;
+// 1 to stage the cm2 accumulator through shmem (Csh) before global store; 0 to
+// use coopMatPerElementNV directly. Trades shmem footprint for more coalesced
+// global stores. Worth it for small tiles only -- on big tiles like 128x128 the
+// Csh cost hurts occupancy.
+layout(constant_id = 16) const uint csh_store      = 0;
 
 // H/W bounds on matB are unnecessary in the non-TRANSPOSE case when there is no
 // padding: with p0 == p1 == 0, the standard OH/OW formulas guarantee
@@ -132,6 +137,17 @@ const uint32_t Bsh_len = BS_CRS * Bsh_stride;
 
 shared SHMEM_TYPE Ash[Ash_len];  // K x CRS
 shared SHMEM_TYPE Bsh[Bsh_len];  // CRS x NPQ
+
+#ifdef COOPMAT2
+// Stage matC through shmem so the global stores can be issued in row-major
+// (NPQ-contiguous) order rather than via coopMatPerElementNV's hardware-defined
+// fragment ordering. This trades extra shmem and a barrier for better store
+// coalescing, which matters for shapes whose OW < BS_NPQ (so each matrix row
+// fragments into multiple short OW runs in dst).
+const uint32_t Csh_stride = BS_NPQ;
+const uint32_t Csh_len    = csh_store != 0 ? BS_K * Csh_stride : 1;
+shared SHMEM_TYPE Csh[Csh_len];  // K x NPQ
+#endif
 
 // Threadtile sizes
 const uint32_t TS_NPQ = BS_K * BS_NPQ / WG_SIZE / TS_K;
@@ -365,7 +381,35 @@ void main() {
     }
     /* Save C* */
 #ifdef COOPMAT2
-    coopMatPerElementNV(matC, matC, perElemOpStore);
+    if (csh_store != 0) {
+        // Place the accumulator into Csh, then have the WG store it to dst with
+        // NPQ-contiguous coalesced stores.
+        coopMatStore(matC, Csh, 0, Csh_stride, gl_CooperativeMatrixLayoutRowMajor);
+        barrier();
+
+        // Cooperative shmem -> global store. Each iteration covers
+        // store_rows_per_iter rows of the K dim with all WG threads spread
+        // across BS_NPQ. Adjacent threads write adjacent NPQ_idx (contiguous
+        // OW within an OH row), which is the contiguous direction of dst.
+        const uint32_t store_rows_per_iter = WG_SIZE / BS_NPQ;
+        const uint32_t store_iters         = BS_K / store_rows_per_iter;
+        const uint32_t k_thread_offset     = tid / BS_NPQ;
+        const uint32_t npq_thread          = tid % BS_NPQ;
+        [[unroll]] for (uint32_t i = 0; i < store_iters; i++) {
+            uint32_t k_local = i * store_rows_per_iter + k_thread_offset;
+            uint32_t K_idx   = B_idx_K * BS_K + k_local;
+            uint32_t NPQ_idx = B_idx_NPQ * BS_NPQ + npq_thread;
+            uint32_t N_idx   = fastdiv(NPQ_idx, p.OWOHmp, p.OWOHL);
+            uint32_t OH_idx  = fastdiv(NPQ_idx - N_idx * p.OH * p.OW, p.OWmp, p.OWL);
+            uint32_t OW_idx  = NPQ_idx - N_idx * p.OH * p.OW - OH_idx * p.OW;
+            uint32_t dst_idx = OW_idx + OH_idx * p.nb1 + K_idx * p.nb2 + N_idx * p.nb3;
+            if (aligned != 0 || (K_idx < K && NPQ_idx < NPQ)) {
+                dst_data[dst_idx] = D_TYPE(Csh[k_local * Csh_stride + npq_thread]);
+            }
+        }
+    } else {
+        coopMatPerElementNV(matC, matC, perElemOpStore);
+    }
 #else
     if (T_y * TS_K < K) {
         for (uint32_t T_ly = 0; T_ly < TS_K; T_ly++) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
@@ -84,21 +84,15 @@ layout(constant_id = 12) const uint d1             = 1;
 // Kernel spatial sizes
 layout(constant_id = 13) const uint KW             = 1;
 layout(constant_id = 14) const uint KH             = 1;
-// 1 if K/CRS/NPQ are exact multiples of BS_K/BS_CRS/BS_NPQ. When set, K/CRS/NPQ
-// bounds checks and the matA/matB address clamps and store guards are elided.
+// when set, skip bounds checks and address clamps (K/CRS/NPQ are tile-aligned)
 layout(constant_id = 15) const uint aligned        = 0;
-// 1 to stage the cm2 accumulator through shmem (Csh) before global store; 0 to
-// use coopMatPerElementNV directly. Trades shmem footprint for more coalesced
-// global stores. Worth it for small tiles only -- on big tiles like 128x128 the
-// Csh cost hurts occupancy. (cm1 always uses Csh and ignores this.)
+// stage cm2 result through shmem (Csh) for coalesced stores. cm1 always does this.
 layout(constant_id = 16) const uint csh_store      = 0;
 
 #ifdef COOPMAT
-// cm1 subgroup-tile sizes. Each subgroup owns a WM x WN region of the BS_K x
-// BS_NPQ workgroup tile and computes it as a (WM/TM) x (WN/TN) grid of TMxTNxTK
-// fragments. Constraints: WM % TM == 0, WN % TN == 0, BS_K % WM == 0,
-// BS_NPQ % WN == 0, BS_CRS % TK == 0, and the workgroup must be sized to
-// (BS_K/WM) * (BS_NPQ/WN) * subgroup_size threads.
+// cm1 subgroup tile: each subgroup computes a WM x WN region as a grid of
+// TM x TN x TK fragments. Requires WM%TM == WN%TN == BS_K%WM == BS_NPQ%WN ==
+// BS_CRS%TK == 0, and WG_SIZE == (BS_K/WM) * (BS_NPQ/WN) * subgroup_size.
 layout(constant_id = 17) const uint WM             = 32;
 layout(constant_id = 18) const uint WN             = 32;
 const uint TM = 16;
@@ -110,18 +104,14 @@ const uint warps_M     = BS_K / WM;
 const uint warps_N     = BS_NPQ / WN;
 #endif
 
-// H/W bounds on matB are unnecessary in the non-TRANSPOSE case when there is no
-// padding: with p0 == p1 == 0, the standard OH/OW formulas guarantee
-// 0 <= H_idx < H and 0 <= W_idx < W. TRANSPOSE has different bounds reasoning
-// (H_idx_x_s1 can underflow), so we keep its checks unconditionally.
+// without padding, H_idx/W_idx are in bounds by construction (non-TRANSPOSE only)
 #ifdef TRANSPOSE
 const bool hw_in_bounds = false;
 #else
 const bool hw_in_bounds = (p0 == 0) && (p1 == 0);
 #endif
 
-// TRANSPOSE stride alignment checks reduce to (H_idx_x_s1 % s1 == 0). They're
-// trivially satisfied when s == 1.
+// TRANSPOSE stride alignment is trivially satisfied for stride 1
 #ifdef TRANSPOSE
 const bool stride_in_bounds = (s0 == 1) && (s1 == 1);
 #else
@@ -163,11 +153,7 @@ shared SHMEM_TYPE Ash[Ash_len];  // K x CRS
 shared SHMEM_TYPE Bsh[Bsh_len];  // CRS x NPQ
 
 #if defined(COOPMAT2) || defined(COOPMAT)
-// Stage matC through shmem so the global stores can be issued in row-major
-// (NPQ-contiguous) order rather than via coopMatPerElementNV's hardware-defined
-// fragment ordering. This trades extra shmem and a barrier for better store
-// coalescing, which matters for shapes whose OW < BS_NPQ (so each matrix row
-// fragments into multiple short OW runs in dst).
+// stage matC through shmem so global stores are row-major (NPQ-contiguous)
 const uint32_t Csh_stride = BS_NPQ;
 #ifdef COOPMAT
 const uint32_t Csh_len    = BS_K * Csh_stride;
@@ -358,10 +344,7 @@ void main() {
             uint32_t W_idx = OW_idx * s0 + KW_idx_b * d0 - p0;
 #endif
             uint32_t src_idx = W_idx + H_idx * p.nb11 + Cin_idx_b * p.nb12 + N_idx * p.nb13;
-            // Only clamp when an out-of-bounds address is actually possible. With
-            // aligned == 1 the CRS/NPQ checks below disappear, and with hw_in_bounds
-            // the H/W checks disappear -- so the address is guaranteed in range and
-            // no clamp is needed.
+            // skip clamp when address can't go OOB
             if (aligned == 0 || !hw_in_bounds || !stride_in_bounds) {
                 src_idx = min(max(src_idx, 0), p.Cin * p.N * p.W * p.H - 1);
             }
@@ -370,7 +353,7 @@ void main() {
             if (aligned == 0 && (CRS_idx_b >= CRS || NPQ_idx >= NPQ)) {
                 oob = true;
             }
-            // H/W bounds (also implicitly catches lower-bound underflow: idx >= 0x80000000).
+            // also catches lower-bound underflow (idx wraps to 0x80000000+)
             if (!hw_in_bounds && (H_idx >= p.H || W_idx >= p.W)) {
                 oob = true;
             }
@@ -394,8 +377,7 @@ void main() {
         coopMatLoad(matB, Bsh, 0, Bsh_stride, gl_CooperativeMatrixLayoutRowMajor);
         matC = coopMatMulAdd(matA, matB, matC);
 #elif defined(COOPMAT)
-        // Walk the BS_CRS dim in TK-sized chunks; each subgroup multiplies its
-        // (cms_per_row x cms_per_col) grid of TMxTNxTK fragments per chunk.
+        // each subgroup multiplies its grid of fragments per TK-sized CRS chunk
         [[unroll]] for (uint k_step = 0; k_step < BS_CRS / TK; k_step++) {
             coopmat<float16_t, gl_ScopeSubgroup, TM, TK, gl_MatrixUseA> cache_a[cms_per_row];
             [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
@@ -434,9 +416,7 @@ void main() {
     }
     /* Save C* */
 #if defined(COOPMAT2) || defined(COOPMAT)
-    // cm1 always uses the staged path; cm2 uses it iff csh_store==1. Both
-    // paths first place the accumulator into Csh, then have the WG store it
-    // to dst with NPQ-contiguous coalesced stores.
+    // stage matC into Csh, then write to dst with coalesced NPQ-contiguous stores
 #ifdef COOPMAT
     const bool use_staged_store = true;
 #else
@@ -444,8 +424,7 @@ void main() {
 #endif
     if (use_staged_store) {
 #ifdef COOPMAT
-        // cm1: each subgroup stores its (cms_per_row x cms_per_col) grid of
-        // fragments into the shared Csh slot for its (warp_r, warp_c) tile.
+        // cm1: each subgroup stores its fragment grid into its Csh slot
         [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
             [[unroll]] for (uint cm_col = 0; cm_col < cms_per_col; cm_col++) {
                 const uint csh_off = (warp_r * WM + cm_row * TM) * Csh_stride + warp_c * WN + cm_col * TN;
@@ -457,10 +436,8 @@ void main() {
 #endif
         barrier();
 
-        // Cooperative shmem -> global store. Each iteration covers
-        // store_rows_per_iter rows of the K dim with all WG threads spread
-        // across BS_NPQ. Adjacent threads write adjacent NPQ_idx (contiguous
-        // OW within an OH row), which is the contiguous direction of dst.
+        // cooperative shmem->global: WG threads spread across BS_NPQ (the
+        // contiguous direction of dst), each iter covers store_rows_per_iter K-rows
         const uint32_t store_rows_per_iter = WG_SIZE / BS_NPQ;
         const uint32_t store_iters         = BS_K / store_rows_per_iter;
         const uint32_t k_thread_offset     = tid / BS_NPQ;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/conv2d_mm.comp
@@ -7,6 +7,13 @@
 #extension GL_KHR_memory_scope_semantics : enable
 #endif
 
+#ifdef COOPMAT
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_KHR_memory_scope_semantics : enable
+#endif
+
 #ifdef USE_COLLECTIVES
 #    extension GL_KHR_shader_subgroup_shuffle : enable
 #endif
@@ -83,8 +90,25 @@ layout(constant_id = 15) const uint aligned        = 0;
 // 1 to stage the cm2 accumulator through shmem (Csh) before global store; 0 to
 // use coopMatPerElementNV directly. Trades shmem footprint for more coalesced
 // global stores. Worth it for small tiles only -- on big tiles like 128x128 the
-// Csh cost hurts occupancy.
+// Csh cost hurts occupancy. (cm1 always uses Csh and ignores this.)
 layout(constant_id = 16) const uint csh_store      = 0;
+
+#ifdef COOPMAT
+// cm1 subgroup-tile sizes. Each subgroup owns a WM x WN region of the BS_K x
+// BS_NPQ workgroup tile and computes it as a (WM/TM) x (WN/TN) grid of TMxTNxTK
+// fragments. Constraints: WM % TM == 0, WN % TN == 0, BS_K % WM == 0,
+// BS_NPQ % WN == 0, BS_CRS % TK == 0, and the workgroup must be sized to
+// (BS_K/WM) * (BS_NPQ/WN) * subgroup_size threads.
+layout(constant_id = 17) const uint WM             = 32;
+layout(constant_id = 18) const uint WN             = 32;
+const uint TM = 16;
+const uint TN = 16;
+const uint TK = 16;
+const uint cms_per_row = WM / TM;
+const uint cms_per_col = WN / TN;
+const uint warps_M     = BS_K / WM;
+const uint warps_N     = BS_NPQ / WN;
+#endif
 
 // H/W bounds on matB are unnecessary in the non-TRANSPOSE case when there is no
 // padding: with p0 == p1 == 0, the standard OH/OW formulas guarantee
@@ -120,7 +144,7 @@ uint32_t n_elems_out = K * NPQ;
 // Number of blocktiles per input
 uint32_t NB_CRS = splitWork(CRS, BS_CRS);
 
-#ifdef COOPMAT2
+#if defined(COOPMAT2) || defined(COOPMAT)
 #define SHMEM_TYPE float16_t
 #else
 #define SHMEM_TYPE float
@@ -138,14 +162,18 @@ const uint32_t Bsh_len = BS_CRS * Bsh_stride;
 shared SHMEM_TYPE Ash[Ash_len];  // K x CRS
 shared SHMEM_TYPE Bsh[Bsh_len];  // CRS x NPQ
 
-#ifdef COOPMAT2
+#if defined(COOPMAT2) || defined(COOPMAT)
 // Stage matC through shmem so the global stores can be issued in row-major
 // (NPQ-contiguous) order rather than via coopMatPerElementNV's hardware-defined
 // fragment ordering. This trades extra shmem and a barrier for better store
 // coalescing, which matters for shapes whose OW < BS_NPQ (so each matrix row
 // fragments into multiple short OW runs in dst).
 const uint32_t Csh_stride = BS_NPQ;
+#ifdef COOPMAT
+const uint32_t Csh_len    = BS_K * Csh_stride;
+#else
 const uint32_t Csh_len    = csh_store != 0 ? BS_K * Csh_stride : 1;
+#endif
 shared SHMEM_TYPE Csh[Csh_len];  // K x NPQ
 #endif
 
@@ -213,6 +241,13 @@ void main() {
 #ifdef COOPMAT2
     coopmat<ACC_TYPE, gl_ScopeWorkgroup, BS_K, BS_NPQ, gl_MatrixUseAccumulator> matC;
     matC = coopmat<ACC_TYPE, gl_ScopeWorkgroup, BS_K, BS_NPQ, gl_MatrixUseAccumulator>(0.0);
+#elif defined(COOPMAT)
+    coopmat<float16_t, gl_ScopeSubgroup, TM, TN, gl_MatrixUseAccumulator> sums[cms_per_row * cms_per_col];
+    [[unroll]] for (uint i = 0; i < cms_per_row * cms_per_col; i++) {
+        sums[i] = coopmat<float16_t, gl_ScopeSubgroup, TM, TN, gl_MatrixUseAccumulator>(0.0);
+    }
+    const uint warp_r = gl_SubgroupID / warps_N;
+    const uint warp_c = gl_SubgroupID % warps_N;
 #else
     float regC[TS_K][TS_NPQ];
     for (uint32_t T_ly = 0; T_ly < TS_K; T_ly++) {
@@ -358,6 +393,24 @@ void main() {
         coopMatLoad(matA, Ash, 0, Ash_stride, gl_CooperativeMatrixLayoutRowMajor);
         coopMatLoad(matB, Bsh, 0, Bsh_stride, gl_CooperativeMatrixLayoutRowMajor);
         matC = coopMatMulAdd(matA, matB, matC);
+#elif defined(COOPMAT)
+        // Walk the BS_CRS dim in TK-sized chunks; each subgroup multiplies its
+        // (cms_per_row x cms_per_col) grid of TMxTNxTK fragments per chunk.
+        [[unroll]] for (uint k_step = 0; k_step < BS_CRS / TK; k_step++) {
+            coopmat<float16_t, gl_ScopeSubgroup, TM, TK, gl_MatrixUseA> cache_a[cms_per_row];
+            [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
+                const uint a_off = (warp_r * WM + cm_row * TM) * Ash_stride + k_step * TK;
+                coopMatLoad(cache_a[cm_row], Ash, a_off, Ash_stride, gl_CooperativeMatrixLayoutRowMajor);
+            }
+            [[unroll]] for (uint cm_col = 0; cm_col < cms_per_col; cm_col++) {
+                coopmat<float16_t, gl_ScopeSubgroup, TK, TN, gl_MatrixUseB> cache_b;
+                const uint b_off = k_step * TK * Bsh_stride + warp_c * WN + cm_col * TN;
+                coopMatLoad(cache_b, Bsh, b_off, Bsh_stride, gl_CooperativeMatrixLayoutRowMajor);
+                [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
+                    sums[cm_col * cms_per_row + cm_row] = coopMatMulAdd(cache_a[cm_row], cache_b, sums[cm_col * cms_per_row + cm_row]);
+                }
+            }
+        }
 #else
         if (T_y * TS_K < K) {
             UNROLL for (uint32_t CRS_lidx = 0; CRS_lidx < BS_CRS; CRS_lidx++) {
@@ -380,11 +433,28 @@ void main() {
         barrier();
     }
     /* Save C* */
-#ifdef COOPMAT2
-    if (csh_store != 0) {
-        // Place the accumulator into Csh, then have the WG store it to dst with
-        // NPQ-contiguous coalesced stores.
+#if defined(COOPMAT2) || defined(COOPMAT)
+    // cm1 always uses the staged path; cm2 uses it iff csh_store==1. Both
+    // paths first place the accumulator into Csh, then have the WG store it
+    // to dst with NPQ-contiguous coalesced stores.
+#ifdef COOPMAT
+    const bool use_staged_store = true;
+#else
+    const bool use_staged_store = (csh_store != 0);
+#endif
+    if (use_staged_store) {
+#ifdef COOPMAT
+        // cm1: each subgroup stores its (cms_per_row x cms_per_col) grid of
+        // fragments into the shared Csh slot for its (warp_r, warp_c) tile.
+        [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
+            [[unroll]] for (uint cm_col = 0; cm_col < cms_per_col; cm_col++) {
+                const uint csh_off = (warp_r * WM + cm_row * TM) * Csh_stride + warp_c * WN + cm_col * TN;
+                coopMatStore(sums[cm_col * cms_per_row + cm_row], Csh, csh_off, Csh_stride, gl_CooperativeMatrixLayoutRowMajor);
+            }
+        }
+#else
         coopMatStore(matC, Csh, 0, Csh_stride, gl_CooperativeMatrixLayoutRowMajor);
+#endif
         barrier();
 
         // Cooperative shmem -> global store. Each iteration covers
@@ -407,9 +477,12 @@ void main() {
                 dst_data[dst_idx] = D_TYPE(Csh[k_local * Csh_stride + npq_thread]);
             }
         }
-    } else {
+    }
+#ifdef COOPMAT2
+    else {
         coopMatPerElementNV(matC, matC, perElemOpStore);
     }
+#endif
 #else
     if (T_y * TS_K < K) {
         for (uint32_t T_ly = 0; T_ly < TS_K; T_ly++) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -998,8 +998,16 @@ void process_shaders() {
                 string_to_spv(name + (unroll ? "_unroll" : ""), "conv2d_mm.comp", defines);
 #if defined(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
                 if (unroll) {
-                    defines["COOPMAT2"] = "1";
-                    string_to_spv(name, "conv2d_mm.comp", defines, true, false, true);
+                    auto cm2_defines = defines;
+                    cm2_defines["COOPMAT2"] = "1";
+                    string_to_spv(name, "conv2d_mm.comp", cm2_defines, true, false, true);
+                }
+#endif
+#if defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+                if (unroll) {
+                    auto cm1_defines = defines;
+                    cm1_defines["COOPMAT"] = "1";
+                    string_to_spv(name, "conv2d_mm.comp", cm1_defines, true, true, false);
                 }
 #endif
             }


### PR DESCRIPTION
## Overview

This change does some tuning for coopmat2 conv2d, and also adds support for coopmat1 conv2d. The different tuning optimizations are split into separate commits to make reviewing easier. There's a new tile size, some ALU optimizations when bounds checking isn't needed, and storing the result through shared memory to improve the access pattern. Storing through shared memory also happened to be the only tricky part left to support coopmat1, so at that point it made sense to add that too.

Perf on RTX 5090:

```
coopmat2 before:

  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                   1116 runs -   896.08 us/run - 137.42 GFLOP/run - 153.36 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              225148 runs -     4.45 us/run - 133.69 MFLOP/run -  30.07 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              178354 runs -     5.62 us/run - 135.78 MFLOP/run -  24.17 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                524288 runs -     1.92 us/run - 642.82 kFLOP/run - 335.00 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               172296 runs -     5.80 us/run -  20.90 MFLOP/run -   3.60 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               188416 runs -     5.42 us/run -   2.78 MFLOP/run - 513.85 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                71824 runs -    14.73 us/run -  22.28 MFLOP/run -   1.51 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              142188 runs -     7.06 us/run - 115.40 MFLOP/run -  16.35 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               56789 runs -    17.63 us/run - 923.24 MFLOP/run -  52.35 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    25630 runs -    39.02 us/run -   1.85 GFLOP/run -  47.38 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     606 runs -  1653.05 us/run -  86.60 GFLOP/run -  52.39 TFLOPS
  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                   1195 runs -   836.83 us/run - 137.42 GFLOP/run - 164.22 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              238612 runs -     4.20 us/run - 133.69 MFLOP/run -  31.87 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              186461 runs -     5.38 us/run - 135.78 MFLOP/run -  25.24 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                557056 runs -     1.81 us/run - 642.82 kFLOP/run - 354.66 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               177082 runs -     5.74 us/run -  20.90 MFLOP/run -   3.64 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               188416 runs -     5.38 us/run -   2.78 MFLOP/run - 517.87 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                71824 runs -    14.72 us/run -  22.28 MFLOP/run -   1.51 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              149991 runs -     6.71 us/run - 115.40 MFLOP/run -  17.21 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               58642 runs -    17.08 us/run - 923.24 MFLOP/run -  54.06 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    28380 runs -    35.27 us/run -   1.85 GFLOP/run -  52.42 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     742 runs -  1351.01 us/run -  86.60 GFLOP/run -  64.10 TFLOPS
  
coopmat2 after:

  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                   1303 runs -   767.98 us/run - 137.42 GFLOP/run - 178.94 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              246092 runs -     4.07 us/run - 133.69 MFLOP/run -  32.83 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              185724 runs -     5.39 us/run - 135.78 MFLOP/run -  25.19 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                499712 runs -     2.03 us/run - 642.82 kFLOP/run - 316.17 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               196226 runs -     5.17 us/run -  20.90 MFLOP/run -   4.04 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               262144 runs -     3.93 us/run -   2.78 MFLOP/run - 709.45 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                89780 runs -    11.37 us/run -  22.28 MFLOP/run -   1.96 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              161262 runs -     6.23 us/run - 115.40 MFLOP/run -  18.53 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               69433 runs -    14.43 us/run - 923.24 MFLOP/run -  64.00 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    32230 runs -    31.08 us/run -   1.85 GFLOP/run -  59.49 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     994 runs -  1007.64 us/run -  86.60 GFLOP/run -  85.94 TFLOPS
  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                   1371 runs -   729.71 us/run - 137.42 GFLOP/run - 188.32 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              264792 runs -     3.78 us/run - 133.69 MFLOP/run -  35.33 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              196042 runs -     5.11 us/run - 135.78 MFLOP/run -  26.56 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                516096 runs -     1.96 us/run - 642.82 kFLOP/run - 328.65 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               196226 runs -     5.17 us/run -  20.90 MFLOP/run -   4.04 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               262144 runs -     3.89 us/run -   2.78 MFLOP/run - 715.29 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                89780 runs -    11.37 us/run -  22.28 MFLOP/run -   1.96 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              166464 runs -     6.03 us/run - 115.40 MFLOP/run -  19.14 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               70305 runs -    14.24 us/run - 923.24 MFLOP/run -  64.85 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    33550 runs -    29.81 us/run -   1.85 GFLOP/run -  62.03 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     944 runs -  1060.31 us/run -  86.60 GFLOP/run -  81.67 TFLOPS
  
coopmat1 before:

  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    331 runs -  3023.53 us/run - 137.42 GFLOP/run -  45.45 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              145112 runs -     6.91 us/run - 133.69 MFLOP/run -  19.35 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              109076 runs -     9.23 us/run - 135.78 MFLOP/run -  14.70 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                524288 runs -     1.92 us/run - 642.82 kFLOP/run - 335.64 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               205798 runs -     4.97 us/run -  20.90 MFLOP/run -   4.21 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               229376 runs -     4.51 us/run -   2.78 MFLOP/run - 617.81 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                89780 runs -    11.57 us/run -  22.28 MFLOP/run -   1.92 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              111843 runs -     8.97 us/run - 115.40 MFLOP/run -  12.87 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               30193 runs -    33.23 us/run - 923.24 MFLOP/run -  27.78 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    13145 runs -    76.08 us/run -   1.85 GFLOP/run -  24.30 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     334 runs -  3009.34 us/run -  86.60 GFLOP/run -  28.78 TFLOPS
  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    343 runs -  2921.80 us/run - 137.42 GFLOP/run -  47.03 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              146608 runs -     6.84 us/run - 133.69 MFLOP/run -  19.53 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              109813 runs -     9.13 us/run - 135.78 MFLOP/run -  14.87 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                565248 runs -     1.79 us/run - 642.82 kFLOP/run - 358.66 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               201012 runs -     5.06 us/run -  20.90 MFLOP/run -   4.13 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               221184 runs -     4.63 us/run -   2.78 MFLOP/run - 601.80 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                89780 runs -    11.63 us/run -  22.28 MFLOP/run -   1.92 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              116178 runs -     8.66 us/run - 115.40 MFLOP/run -  13.33 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               29103 runs -    34.51 us/run - 923.24 MFLOP/run -  26.76 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    13420 runs -    74.77 us/run -   1.85 GFLOP/run -  24.73 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     356 runs -  2810.03 us/run -  86.60 GFLOP/run -  30.82 TFLOPS

coopmat1 after:
  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                   1012 runs -   989.07 us/run - 137.42 GFLOP/run - 138.94 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              249832 runs -     4.01 us/run - 133.69 MFLOP/run -  33.36 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              201938 runs -     4.96 us/run - 135.78 MFLOP/run -  27.37 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                524288 runs -     1.92 us/run - 642.82 kFLOP/run - 334.50 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               177082 runs -     5.72 us/run -  20.90 MFLOP/run -   3.65 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               286720 runs -     3.56 us/run -   2.78 MFLOP/run - 782.75 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               103247 runs -     9.90 us/run -  22.28 MFLOP/run -   2.25 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              171666 runs -     5.85 us/run - 115.40 MFLOP/run -  19.72 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               71395 runs -    14.01 us/run - 923.24 MFLOP/run -  65.91 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    31295 runs -    31.99 us/run -   1.85 GFLOP/run -  57.80 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f32,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     916 runs -  1093.62 us/run -  86.60 GFLOP/run -  79.18 TFLOPS
  CONV_2D(ne_input=[19,19,256,16],ne_kernel=[4,4,256,4096],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                   1067 runs -   937.79 us/run - 137.42 GFLOP/run - 146.54 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,128],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              264792 runs -     3.78 us/run - 133.69 MFLOP/run -  35.33 TFLOPS
  CONV_2D(ne_input=[19,19,8,16],ne_kernel=[4,4,8,130],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              210045 runs -     4.77 us/run - 135.78 MFLOP/run -  28.45 TFLOPS
  CONV_2D(ne_input=[19,19,4,16],ne_kernel=[2,2,4,4],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                573440 runs -     1.77 us/run - 642.82 kFLOP/run - 364.18 GFLOPS
  CONV_2D(ne_input=[224,224,3,1],ne_kernel=[3,3,3,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               181868 runs -     5.52 us/run -  20.90 MFLOP/run -   3.79 TFLOPS
  CONV_2D(ne_input=[224,224,1,1],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               286720 runs -     3.58 us/run -   2.78 MFLOP/run - 777.62 GFLOPS
  CONV_2D(ne_input=[224,224,1,8],ne_kernel=[2,2,1,8],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               103247 runs -     9.87 us/run -  22.28 MFLOP/run -   2.26 TFLOPS
  CONV_2D(ne_input=[58,58,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):              181203 runs -     5.52 us/run - 115.40 MFLOP/run -  20.90 TFLOPS
  CONV_2D(ne_input=[58,58,32,8],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):               67035 runs -    14.93 us/run - 923.24 MFLOP/run -  61.82 TFLOPS
  CONV_2D(ne_input=[16,16,128,8],ne_kernel=[3,3,128,512],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                    32670 runs -    30.61 us/run -   1.85 GFLOP/run -  60.39 TFLOPS
  CONV_2D(ne_input=[1536,1536,32,1],ne_kernel=[3,3,32,64],type_kernel=f16,stride0=1,stride1=1,padding0=0,padding1=0,dilation0=1,dilation1=1,cwhn=0):                     926 runs -  1081.27 us/run -  86.60 GFLOP/run -  80.09 TFLOPS
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, mostly written through Cursor/Claude.
