### PR TITLE
Add web_search tool

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2864,7 +2864,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--tools"}, "TOOL1,TOOL2,...",
         "experimental: whether to enable built-in tools for AI agents - do not enable in untrusted environments (default: no tools)\n"
         "specify \"all\" to enable all tools\n"
-        "available tools: read_file, file_glob_search, grep_search, exec_shell_command, write_file, edit_file, apply_diff",
+        "available tools: read_file, file_glob_search, grep_search, exec_shell_command, write_file, edit_file, apply_diff,web_search",
         [](common_params & params, const std::string & value) {
             params.server_tools = parse_csv_row(value);
         }

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 target_include_directories(${TARGET} PRIVATE ../mtmd)
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(${TARGET} PUBLIC llama-common mtmd ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PUBLIC llama-common mtmd cpp-httplib ${CMAKE_THREAD_LIBS_INIT})
 
 
 # llama-server executable

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -1,6 +1,8 @@
 #include "server-tools.h"
 
 #include <sheredom/subprocess.h>
+#include <cpp-httplib/httplib.h>
+#include <cstdlib>
 
 #include <filesystem>
 #include <fstream>
@@ -694,6 +696,185 @@ struct server_tool_apply_diff : server_tool {
 };
 
 //
+// web_search: query a SearXNG instance for live web results
+//
+// Enable with:  --tool web_search
+// Configure:    SEARXNG_URL=http://localhost:8888  (env var, default shown)
+//
+
+struct server_tool_web_search : server_tool {
+    std::string srv_host;
+    int         srv_port    = 80;
+    std::string srv_path_pfx;   // e.g. "/searxng" when behind a reverse proxy
+    bool        srv_use_ssl = false;
+
+    server_tool_web_search() {
+        name             = "web_search";
+        display_name     = "Web search";
+        permission_write = false;
+
+        const char * env = std::getenv("SEARXNG_URL");
+        parse_url(env ? env : "http://localhost:8888");
+    }
+
+    void parse_url(const std::string & raw) {
+        std::string s = raw;
+
+        if (s.compare(0, 8, "https://") == 0) {
+            srv_use_ssl = true;
+            srv_port    = 443;
+            s           = s.substr(8);
+        } else if (s.compare(0, 7, "http://") == 0) {
+            s = s.substr(7);
+        }
+
+        // Split off any path prefix (e.g. /searxng in http://host/searxng)
+        auto slash = s.find('/');
+        if (slash != std::string::npos) {
+            srv_path_pfx = s.substr(slash);
+            s            = s.substr(0, slash);
+        }
+
+        // Split host:port
+        auto colon = s.find(':');
+        if (colon != std::string::npos) {
+            srv_host = s.substr(0, colon);
+            try { srv_port = std::stoi(s.substr(colon + 1)); } catch (...) {}
+        } else {
+            srv_host = s;
+        }
+    }
+
+    json get_definition() override {
+        return {
+            {"type", "function"},
+            {"function", {
+                {"name", name},
+                {"description",
+                    "Search the web for up-to-date information. "
+                    "Use this when you need current facts, news, prices, or anything "
+                    "that may not be in your training data. "
+                    "Returns titles, URLs, and short snippets from the top results."},
+                {"parameters", {
+                    {"type", "object"},
+                    {"properties", {
+                        {"query", {
+                            {"type",        "string"},
+                            {"description", "The search query"},
+                        }},
+                        {"num_results", {
+                            {"type",        "integer"},
+                            {"description", "Number of results to return (1-10, default 5)"},
+                            {"default",     5},
+                            {"minimum",     1},
+                            {"maximum",     10},
+                        }},
+                        {"language", {
+                            {"type",        "string"},
+                            {"description", "BCP-47 language code, e.g. 'en', 'de' (default 'en')"},
+                            {"default",     "en"},
+                        }},
+                    }},
+                    {"required", json::array({"query"})},
+                }},
+            }},
+        };
+    }
+
+    json invoke(json params) override {
+        std::string query = params.at("query").get<std::string>();
+        int  n_results    = std::max(1, std::min(10, json_value(params, "num_results", 5)));
+        std::string lang  = json_value(params, "language", std::string("en"));
+
+        // Percent-encode query
+        std::string q_enc;
+        for (unsigned char c : query) {
+            if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+                q_enc += static_cast<char>(c);
+            } else {
+                char buf[4];
+                snprintf(buf, sizeof(buf), "%%%02X", c);
+                q_enc += buf;
+            }
+        }
+
+        std::string path = srv_path_pfx + "/search?q=" + q_enc
+                         + "&format=json&language=" + lang;
+
+        httplib::Headers hdrs = {{"Accept", "application/json"}};
+        httplib::Result  res;
+
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+        if (srv_use_ssl) {
+            httplib::SSLClient cli(srv_host, srv_port);
+            cli.set_connection_timeout(10);
+            cli.set_read_timeout(15);
+            res = cli.Get(path, hdrs);
+        } else {
+            httplib::Client cli(srv_host, srv_port);
+            cli.set_connection_timeout(10);
+            cli.set_read_timeout(15);
+            res = cli.Get(path, hdrs);
+        }
+#else
+        if (srv_use_ssl) {
+            return {{"error",
+                "HTTPS SearXNG URLs require OpenSSL. "
+                "Rebuild with OpenSSL or use an http:// URL."}};
+        }
+        httplib::Client cli(srv_host, srv_port);
+        cli.set_connection_timeout(10);
+        cli.set_read_timeout(15);
+        res = cli.Get(path, hdrs);
+#endif
+
+        if (!res) {
+            return {{"error", "SearXNG request failed: " + httplib::to_string(res.error())}};
+        }
+        if (res->status != 200) {
+            return {{"error", string_format(
+                "SearXNG returned HTTP %d "
+                "(is format=json enabled in SearXNG settings?)", res->status)}};
+        }
+
+        json data;
+        try { data = json::parse(res->body); }
+        catch (const json::exception & e) {
+            return {{"error", std::string("JSON parse error: ") + e.what()}};
+        }
+
+        auto raw = data.value("results", json::array());
+        std::ostringstream out;
+        out << "Search: \"" << query << "\"\n\n";
+
+        int shown = 0;
+        for (const auto & r : raw) {
+            if (shown >= n_results) break;
+            std::string title   = r.value("title",   "");
+            std::string url_s   = r.value("url",     "");
+            std::string snippet = r.value("content", "");
+
+            if (snippet.size() > 400) {
+                snippet = snippet.substr(0, 400) + "...";
+            }
+
+            out << ++shown << ". " << title << "\n"
+                << "   " << url_s << "\n";
+            if (!snippet.empty()) {
+                out << "   " << snippet << "\n";
+            }
+            out << "\n";
+        }
+
+        if (shown == 0) {
+            out << "(no results)\n";
+        }
+
+        return {{"plain_text_response", out.str()}};
+    }
+};
+
+//
 // public API
 //
 
@@ -706,6 +887,7 @@ static std::vector<std::unique_ptr<server_tool>> build_tools() {
     tools.push_back(std::make_unique<server_tool_write_file>());
     tools.push_back(std::make_unique<server_tool_edit_file>());
     tools.push_back(std::make_unique<server_tool_apply_diff>());
+    tools.push_back(std::make_unique<server_tool_web_search>());
     return tools;
 }
 


### PR DESCRIPTION
## Overview

Makes a web_search tool that will call an existing searxng instance. Set the instance with:
`export SEARXNG_URL=http://host:port`
run with:
`--tools web_search` 

No need for an an external MCP server. Written with AI

## Additional information


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. AI used to write the code <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
