### PR TITLE
graph : handle non-contiguous Q/K/V in mul_mat_aux

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -65,7 +65,7 @@ static ggml_tensor * ggml_mul_mat_aux(
 
     ggml_tensor * res;
 
-    res = ggml_reshape_2d(ctx, cur, n, ggml_nelements(cur)/n);
+    res = ggml_cont_2d   (ctx, cur, n, ggml_nelements(cur)/n);
     res = ggml_mul_mat   (ctx, rot, res);
     res = ggml_reshape_4d(ctx, res, cur->ne[0], cur->ne[1], cur->ne[2], cur->ne[3]);
 

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -65,7 +65,11 @@ static ggml_tensor * ggml_mul_mat_aux(
 
     ggml_tensor * res;
 
-    res = ggml_cont_2d   (ctx, cur, n, ggml_nelements(cur)/n);
+    if (!ggml_is_contiguous(cur)) {
+        res = ggml_cont_2d   (ctx, cur, n, ggml_nelements(cur)/n);
+    } else {
+        res = ggml_reshape_2d(ctx, cur, n, ggml_nelements(cur)/n);
+    }
     res = ggml_mul_mat   (ctx, rot, res);
     res = ggml_reshape_4d(ctx, res, cur->ne[0], cur->ne[1], cur->ne[2], cur->ne[3]);
 


### PR DESCRIPTION
## Overview

Fixes #22627

## Additional information

Q/K/V may not always be contiguous, V never is with fused QKV, but sometimes Q/K neither.

As this incurs redundant `cont`s it may make sense to do this conditionally, or would a view be safe/optimal, unsure?

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: não