### PR TITLE
common/chat : preserve media markers for typed-content templates

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -357,6 +357,15 @@ std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const json & messa
     return msgs;
 }
 
+static bool msg_has_media_markers(const common_chat_msg & msg) {
+    for (const auto & part : msg.content_parts) {
+        if (part.type == "media_marker") {
+            return true;
+        }
+    }
+    return false;
+}
+
 static json render_message_to_json(const std::vector<common_chat_msg> & msgs, const jinja::caps & c) {
     if (!c.supports_string_content && !c.supports_typed_content) {
         LOG_WRN("%s: Neither string content nor typed content is supported by the template. This is unexpected and may lead to issues.\n", __func__);
@@ -367,7 +376,24 @@ static json render_message_to_json(const std::vector<common_chat_msg> & msgs, co
 
     json messages = json::array();
     for (const auto & msg : msgs) {
-        if (only_string_accepted) {
+        bool has_media = msg_has_media_markers(msg);
+
+        if (has_media && !only_string_accepted) {
+            // Typed-content templates may output their own image placeholder
+            // (e.g. "<image>") instead of the media marker text, which breaks
+            // mtmd_tokenize. Concatenate all parts so markers survive in the
+            // rendered prompt, wrapping as a typed text array if needed.
+            json jmsg = msg.to_json_oaicompat(/* concat_typed_text= */ true);
+            if (!c.supports_string_content) {
+                jmsg["content"] = json::array({
+                    json{
+                        {"type", "text"},
+                        {"text", jmsg.at("content").get<std::string>()},
+                    }
+                });
+            }
+            messages.push_back(jmsg);
+        } else if (only_string_accepted) {
             json jmsg = msg.to_json_oaicompat(/* concat_typed_text= */ true);
             messages.push_back(jmsg);
         } else if (only_typed_accepted) {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -80,7 +80,7 @@ json common_chat_msg::to_json_oaicompat(bool concat_typed_text) const {
     if (!content.empty()) {
         jmsg["content"] = content;
     } else if (!content_parts.empty()) {
-        if (concat_typed_text) {
+        if (concat_typed_text || contains_media()) {
             std::string text;
             bool last_was_media_marker = false;
             // join parts with newline, do not add newline before or after media markers
@@ -357,15 +357,6 @@ std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const json & messa
     return msgs;
 }
 
-static bool msg_has_media_markers(const common_chat_msg & msg) {
-    for (const auto & part : msg.content_parts) {
-        if (part.type == "media_marker") {
-            return true;
-        }
-    }
-    return false;
-}
-
 static json render_message_to_json(const std::vector<common_chat_msg> & msgs, const jinja::caps & c) {
     if (!c.supports_string_content && !c.supports_typed_content) {
         LOG_WRN("%s: Neither string content nor typed content is supported by the template. This is unexpected and may lead to issues.\n", __func__);
@@ -376,24 +367,7 @@ static json render_message_to_json(const std::vector<common_chat_msg> & msgs, co
 
     json messages = json::array();
     for (const auto & msg : msgs) {
-        bool has_media = msg_has_media_markers(msg);
-
-        if (has_media && !only_string_accepted) {
-            // Typed-content templates may output their own image placeholder
-            // (e.g. "<image>") instead of the media marker text, which breaks
-            // mtmd_tokenize. Concatenate all parts so markers survive in the
-            // rendered prompt, wrapping as a typed text array if needed.
-            json jmsg = msg.to_json_oaicompat(/* concat_typed_text= */ true);
-            if (!c.supports_string_content) {
-                jmsg["content"] = json::array({
-                    json{
-                        {"type", "text"},
-                        {"text", jmsg.at("content").get<std::string>()},
-                    }
-                });
-            }
-            messages.push_back(jmsg);
-        } else if (only_string_accepted) {
+        if (only_string_accepted) {
             json jmsg = msg.to_json_oaicompat(/* concat_typed_text= */ true);
             messages.push_back(jmsg);
         } else if (only_typed_accepted) {

--- a/common/chat.h
+++ b/common/chat.h
@@ -94,6 +94,15 @@ struct common_chat_msg {
                tool_name.empty() && tool_call_id.empty();
     }
 
+    bool contains_media() const {
+        for (const auto & part : content_parts) {
+            if (part.type == "media_marker") {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void set_tool_call_ids(std::vector<std::string> &           ids_cache,
                            const std::function<std::string()> & gen_tool_call_id) {
         for (auto i = 0u; i < tool_calls.size(); i++) {


### PR DESCRIPTION
## Overview

Always concatenate content parts if the message contains media markers.

Supersedes #22563

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
