### PR TITLE
CUDA: use fastdiv for batch index split in get_rows

### DIFF
--- a/ggml/src/ggml-cuda/getrows.cu
+++ b/ggml/src/ggml-cuda/getrows.cu
@@ -6,17 +6,18 @@ template<int qk, int qr, dequantize_kernel_t dequantize_kernel, typename dst_t>
 static __global__ void k_get_rows(
         const void * __restrict__ src0, const int32_t * __restrict__ src1, dst_t * __restrict__ dst,
         const int64_t ne00, /*const int64_t ne01, const int64_t ne02, const int64_t ne03,*/
-        /*const int64_t ne10,*/ const int64_t ne11, const int64_t ne12, /*const int64_t ne13,*/
+        /*const int64_t ne10,*/ const int64_t ne11, const uint3 ne12_fdv, /*const int64_t ne13,*/
         /*const size_t s0,*/ const size_t s1, const size_t s2, const size_t s3,
         /*const size_t nb00,*/ const size_t nb01, const size_t nb02, const size_t nb03,
         const size_t s10, const size_t s11, const size_t s12/*, const size_t s13*/) {
 
-    for (int64_t z = blockIdx.z; z < ne11*ne12; z += gridDim.z) {
+    for (int64_t z = blockIdx.z; z < ne11*(int64_t)ne12_fdv.z; z += gridDim.z) {
         for (int64_t i00 = 2*(blockIdx.y*blockDim.x + threadIdx.x); i00 < ne00; i00 += gridDim.y*blockDim.x) {
             // The x and y dimensions of the grid are swapped because the maximum allowed grid size for x is higher.
             const int i10 =  blockIdx.x;
-            const int i11 =  z / ne12; // TODO fastdiv
-            const int i12 =  z % ne12;
+            const uint2 dm  = fast_div_modulo((uint32_t)z, ne12_fdv);
+            const int i11 =  dm.x;
+            const int i12 =  dm.y;
 
             const int i01 = src1[i10*s10 + i11*s11 + i12*s12];
 
@@ -42,17 +43,18 @@ template<typename src0_t, typename dst_t>
 static __global__ void k_get_rows_float(
         const src0_t * __restrict__ src0, const int32_t * __restrict__ src1, dst_t * __restrict__ dst,
         const int64_t ne00, /*const int64_t ne01, const int64_t ne02, const int64_t ne03,*/
-        /*const int64_t ne10,*/ const int64_t ne11, const int64_t ne12, /*const int64_t ne13,*/
+        /*const int64_t ne10,*/ const int64_t ne11, const uint3 ne12_fdv, /*const int64_t ne13,*/
         /*const size_t s0,*/ const size_t s1, const size_t s2, const size_t s3,
         /*const size_t nb00,*/ const size_t nb01, const size_t nb02, const size_t nb03,
         const size_t s10, const size_t s11, const size_t s12/*, const size_t s13*/) {
 
-    for (int64_t z = blockIdx.z; z < ne11*ne12; z += gridDim.z) {
+    for (int64_t z = blockIdx.z; z < ne11*(int64_t)ne12_fdv.z; z += gridDim.z) {
         for (int64_t i00 = blockIdx.y*blockDim.x + threadIdx.x; i00 < ne00; i00 += gridDim.y*blockDim.x) {
             // The x and y dimensions of the grid are swapped because the maximum allowed grid size for x is higher.
             const int i10 = blockIdx.x;
-            const int i11 = z / ne12; // TODO fastdiv
-            const int i12 = z % ne12;
+            const uint2 dm = fast_div_modulo((uint32_t)z, ne12_fdv);
+            const int i11 = dm.x;
+            const int i12 = dm.y;
 
             if (i00 >= ne00) {
                 return;
@@ -115,10 +117,14 @@ static void get_rows_cuda_q(
 
     GGML_ASSERT(ne00 % 2 == 0);
 
+    GGML_ASSERT(ne12 > 0);
+    GGML_ASSERT(ne11 <= std::numeric_limits<uint32_t>::max() / ne12);
+    const uint3 ne12_fdv = init_fastdiv_values(ne12);
+
     k_get_rows<qk, qr, dq><<<block_nums, block_dims, 0, stream>>>(
         src0_d, src1_d, dst_d,
         ne00, /*ne01, ne02, ne03,*/
-        /*ne10,*/ ne11, ne12, /*ne13,*/
+        /*ne10,*/ ne11, ne12_fdv, /*ne13,*/
         /* s0,*/ s1, s2, s3,
         /* nb00,*/ nb01, nb02, nb03,
         s10, s11, s12/*, s13*/);
@@ -146,10 +152,14 @@ static void get_rows_cuda_float(
     const size_t s12 = nb12 / sizeof(int32_t);
     // const size_t s13 = nb13 / sizeof(int32_t);
 
+    GGML_ASSERT(ne12 > 0);
+    GGML_ASSERT(ne11 <= std::numeric_limits<uint32_t>::max() / ne12);
+    const uint3 ne12_fdv = init_fastdiv_values(ne12);
+
     k_get_rows_float<<<block_nums, block_dims, 0, stream>>>(
         src0_d, src1_d, dst_d,
         ne00, /*ne01, ne02, ne03,*/
-        /*ne10,*/ ne11, ne12, /*ne13,*/
+        /*ne10,*/ ne11, ne12_fdv, /*ne13,*/
         /* s0,*/ s1, s2, s3,
         /* nb00,*/ nb01, nb02, nb03,
         s10, s11, s12/*, s13*/);


### PR DESCRIPTION
## Overview

Replace the device-side div/mod used to split the flattened batch index `z` into `(i11, i12)` in `k_get_rows` and `k_get_rows_float` with the `fast_div_modulo` helper from `common.cuh`, removing the existing `// TODO fastdiv` markers.

The two host wrappers (`get_rows_cuda_q`, `get_rows_cuda_float`) precompute `init_fastdiv_values(ne12)` and pass the packed `uint3` to the kernels. This follows the existing fast-div pattern used in `convert.cu`.

## Additional information

This change narrows `int64_t z` to `uint32_t` for the fast-div call, so both host wrappers assert that `ne11 * ne12` fits in `uint32_t` before launching:

```cpp
GGML_ASSERT(ne12 > 0);
GGML_ASSERT(ne11 <= std::numeric_limits<uint32_t>::max() / ne12);
```

`init_fastdiv_values(ne12)` already asserts that `ne12` is non-zero and fits in `uint32_t`; the launch-side asserts cover the flattened `z` range before the cast.

## Test environment

- GPU: NVIDIA RTX PRO 6000 Blackwell Server Edition
- CUDA: 12.9.86
- OS: Ubuntu 22.04.5 LTS
- Build: `-DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release`
- CUDA arch: `120a-real`

## Correctness

```text
./build/bin/test-backend-ops -o GET_ROWS -b CUDA0

12195/12195 PASS
```

## Performance

Command:

```text
./build/bin/test-backend-ops perf -o GET_ROWS -b CUDA0
```

| Case | Master GB/s | Branch GB/s | Speedup |
| --- | ---: | ---: | ---: |
| `GET_ROWS(type=f16,n=256,m=5,r=4,be1=700,be2=100)` | 1154.97 | 1199.88 | 1.039x |
| `GET_ROWS(type=f16,n=256,m=80000,r=70000,be1=2,be2=1)` | 1112.96 | 1173.18 | 1.054x |
| `GET_ROWS(type=f16,n=76800,m=5,r=4,be1=1,be2=2)` | 1015.31 | 1054.69 | 1.039x |
| `GET_ROWS(type=f32,n=1,m=8,r=2,be1=1,be2=1)` | 0.03 | 0.03 | 1.000x |
| `GET_ROWS(type=f32,n=256,m=5,r=4,be1=700,be2=100)` | 1432.46 | 1472.13 | 1.028x |
| `GET_ROWS(type=f32,n=256,m=80000,r=70000,be1=2,be2=1)` | 1330.31 | 1390.40 | 1.045x |
| `GET_ROWS(type=f32,n=76800,m=5,r=4,be1=1,be2=2)` | 1438.89 | 1495.64 | 1.039x |

The measured cases with non-trivial batch dimensions improve by about 3-5%; the tiny `n=1` case is unchanged.

## Requirements



- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

