### PR TITLE
CUDA: batch out_prod inner loop with cublasSgemmStridedBatched

### DIFF
--- a/ggml/src/ggml-cuda/out-prod.cu
+++ b/ggml/src/ggml-cuda/out-prod.cu
@@ -54,15 +54,31 @@ void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const int64_t dps2 = ne2 / ne02;
     const int64_t dps3 = ne3 / ne03;
 
-    // TODO batched matrix multiplication
-    for (int64_t i3 = 0; i3 < ne3; ++i3) {
-        for (int64_t i2 = 0; i2 < ne2; ++i2) {
+    if (dps2 == 1 && ne2 > 1) {
+        // src0 has uniform stride s02 along dim 2; batch the inner loop with a strided GEMM
+        GGML_ASSERT(ne2 <= std::numeric_limits<int>::max());
+        const int batch_count = (int) ne2;
+        for (int64_t i3 = 0; i3 < ne3; ++i3) {
             CUBLAS_CHECK(
-                cublasSgemm(handle, CUBLAS_OP_N, src1_cublas_op,
+                cublasSgemmStridedBatched(handle, CUBLAS_OP_N, src1_cublas_op,
                         ne0, ne1, ne01,
-                        &alpha, src0_d + (i3/dps3)*s03 + (i2/dps2)*s02, lda,
-                                src1_d +  i3      *s13 +  i2      *s12, ldb,
-                        &beta,  dst_d  +  i3      *s3  +  i2      *s2,  ldc));
+                        &alpha, src0_d + (i3/dps3)*s03, lda, s02,
+                                src1_d +  i3     *s13, ldb, s12,
+                        &beta,  dst_d  +  i3     *s3,  ldc, s2,
+                        batch_count));
+        }
+    } else {
+        // Fallback: ne2 == 1 (no batching benefit) or dps2 > 1 (src0 broadcast along dim 2
+        // with non-uniform stride; would need cublasSgemmBatched with pointer arrays).
+        for (int64_t i3 = 0; i3 < ne3; ++i3) {
+            for (int64_t i2 = 0; i2 < ne2; ++i2) {
+                CUBLAS_CHECK(
+                    cublasSgemm(handle, CUBLAS_OP_N, src1_cublas_op,
+                            ne0, ne1, ne01,
+                            &alpha, src0_d + (i3/dps3)*s03 + (i2/dps2)*s02, lda,
+                                    src1_d +  i3      *s13 +  i2      *s12, ldb,
+                            &beta,  dst_d  +  i3      *s3  +  i2      *s2,  ldc));
+            }
         }
     }
 }

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -48,6 +48,7 @@
 #define cublasSetMathMode(handle, mode) CUBLAS_STATUS_SUCCESS
 #define cublasSetStream hipblasSetStream
 #define cublasSgemm hipblasSgemm
+#define cublasSgemmStridedBatched hipblasSgemmStridedBatched
 #define cublasStatus_t hipblasStatus_t
 #define cublasOperation_t hipblasOperation_t
 #define cudaDevAttrCooperativeLaunch hipDeviceAttributeCooperativeLaunch

--- a/ggml/src/ggml-cuda/vendors/musa.h
+++ b/ggml/src/ggml-cuda/vendors/musa.h
@@ -32,6 +32,7 @@
 #define cublasSetMathMode mublasSetMathMode
 #define cublasSetStream mublasSetStream
 #define cublasSgemm mublasSgemm
+#define cublasSgemmStridedBatched mublasSgemmStridedBatched
 #define cublasStatus_t mublasStatus_t
 #define cublasOperation_t mublasOperation_t
 #define cublasGetStatusString mublasGetStatusString

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8302,6 +8302,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // ne2 sweep to cover the cublasSgemmStridedBatched path (dps2 == 1, ne2 > 1)
+    for (int64_t ne2 : {1, 8, 16, 32}) {
+        test_cases.emplace_back(new test_out_prod(GGML_TYPE_F32, GGML_TYPE_F32,
+                                                  256, 16, 16, {ne2, 1}, {1, 1}));
+    }
+
     // add_id
     for (ggml_type type_a : {GGML_TYPE_F32}) {
         for (ggml_type type_b : {GGML_TYPE_F32}) {


### PR DESCRIPTION
## Overview

Replace the per-element `cublasSgemm` loop in `ggml_cuda_out_prod` with `cublasSgemmStridedBatched` for the common case (`dps2 == 1 && ne2 > 1`), batching the inner `i2` loop into a single cuBLAS call per `i3` and removing the existing `// TODO batched matrix multiplication` comment.

The original loop is kept for `ne2 == 1` (no batching benefit, and avoids the overhead of `cublasSgemmStridedBatched(..., batchCount=1)`) and for `dps2 > 1` (`src0` is reused/broadcast along dim 2 and cannot be represented as a single fixed-stride batch; the pointer-array `cublasSgemmBatched` variant could cover this in a follow-up).

A small `ne2` sweep is added to `tests/test-backend-ops.cpp` to exercise both the new strided path and the gate boundary at `ne2 == 1`.

## Additional information

The strided path narrows `ne2` from `int64_t` to `int` for the cuBLAS `batchCount` argument, so an assert and named local make this explicit:

```cpp
GGML_ASSERT(ne2 <= std::numeric_limits<int>::max());
const int batch_count = (int) ne2;
```

The benchmark cases use small matrices (`m=256`, `n=16`, `k=16`) where per-call cuBLAS overhead dominates the GPU work. The large speedups below are expected for this small-GEMM / many-batch case; for larger matrices, the speedup should be smaller as the GEMM work amortizes the call overhead.

## Test environment

- GPU: NVIDIA RTX PRO 6000 Blackwell Server Edition
- CUDA: 12.9.86
- OS: Ubuntu 22.04.5 LTS
- Build: `-DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release`
- CUDA arch: `120a-real`

## Correctness

```text
./build/bin/test-backend-ops -o OUT_PROD -b CUDA0

12199/12199 PASS
```

## Performance

Command:

```text
./build/bin/test-backend-ops perf -o OUT_PROD -b CUDA0
```

`ne2` sweep added by this PR, all with `dps2 == 1`:

| Case | Master GB/s | Branch GB/s | Speedup |
| --- | ---: | ---: | ---: |
| `OUT_PROD(m=256,n=16,k=16,bs=[1,1],nr=[1,1])` (`ne2=1`, fallback) | 7.64 | 7.63 | 0.999x |
| `OUT_PROD(m=256,n=16,k=16,bs=[8,1],nr=[1,1])` (`ne2=8`, batched) | 1.79 | 116.37 | 65.0x |
| `OUT_PROD(m=256,n=16,k=16,bs=[16,1],nr=[1,1])` (`ne2=16`, batched) | 1.74 | 233.84 | 134.4x |
| `OUT_PROD(m=256,n=16,k=16,bs=[32,1],nr=[1,1])` (`ne2=32`, batched) | 4.61 | 463.88 | 100.6x |

The `ne2 == 1` case is unchanged, confirming the fallback gate. Larger `ne2` cases show the expected call-overhead amortization from replacing many small `cublasSgemm` calls with one strided-batched call.


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
