### PR TITLE
speculative : auto-enable swa_full for SWA draft models

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -987,6 +987,15 @@ common_speculative * common_speculative_init(
         llama_context             * ctx_tgt) {
     llama_context * ctx_dft = nullptr;
     if (params.draft.model) {
+        // for SWA draft models, force swa_full on the draft context so prefix
+        // reuse (seq_rm + seq_add) works beyond the SWA window — otherwise the
+        // draft must re-decode from the window edge on every long-context
+        // request and acceptance length degrades significantly
+        if (llama_model_n_swa(params.draft.model) > 0 && !params.draft.cparams.swa_full) {
+            LOG_INF("%s: draft model uses SWA — enabling swa_full for the draft context\n", __func__);
+            params.draft.cparams.swa_full = true;
+        }
+
         ctx_dft = llama_init_from_model(params.draft.model, params.draft.cparams);
         if (ctx_dft == nullptr) {
             LOG_ERR("%s", "failed to create draft context\n");

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -797,6 +797,13 @@ private:
                 return false;
             }
 
+            // for SWA draft models, force swa_full on the draft context so prefix
+            // reuse works beyond the SWA window during speculation
+            if (llama_model_n_swa(model_dft.get()) > 0 && !params_dft.swa_full) {
+                SRV_INF("%s", "draft model uses SWA — enabling swa_full for the draft context\n");
+                params_dft.swa_full = true;
+            }
+
             params_base.speculative.draft.model = model_dft.get();
             params_base.speculative.draft.cparams = common_context_params_to_llama(params_dft);
         }


### PR DESCRIPTION
## Overview

This PR makes speculative decoding enable `swa_full` automatically when the draft model uses SWA layers.

For SWA draft models, the rotating SWA cache can handle speculative cache operations within the sliding window, but it cannot reuse prefixes outside of that window. In long-context speculative decoding, this can force the draft model to re-decode from the SWA window boundary instead of reusing the full prefix, reducing the accepted draft length.

The change detects SWA draft models with `llama_model_n_swa(params.draft.model) > 0` and enables full-size SWA KV allocation for the draft context.

## Additional information

Implementation:

- `common/speculative.cpp`: enable `swa_full` in `common_speculative_init` when the draft model has SWA layers.
- `tools/server/server-context.cpp`: apply the same logic for the server path, since it does not go through `common_speculative_init`.
- Dense draft models are unaffected because `llama_model_n_swa(...) == 0`.

This follows the same direction as the vLLM fix in PR #40898, where the draft model keeps full KV allocation while SWA is still used for compute.

Related:

- vLLM PR #40898: https://github.com/vllm-project/vllm/pull/40898
- llama.cpp PR #22105: https://github.com/ggml-org/llama.cpp/pull/22105
- llama.cpp issue #13747 and PR #13833 for previous SWA speculative cache correctness work

Testing:

- Built on top of current master.
- Tested with Gemma 3 4B target and 270M SWA draft on Apple M3 Max with the Metal backend.
- The new INFO log is emitted and the draft KV cache switches to full-size SWA mode.
- Acceptance rate: 41.9% (132 / 315), consistent with master behavior. This is expected, since ggerganov's earlier cache-level fixes (#13746 / #13833) already make regular SWA speculative paths work correctly. The scenario where this PR is most useful is iSWA dflash drafts (e.g. those introduced in PR #22105); I did not have the target-side resources for an end-to-end run there, but vLLM PR #40898 reports acceptance length improvements on the same stack.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to help inspect the speculative decoding call paths, identify the relevant initialization sites, run local checks, and review the factual accuracy of this PR description. I manually reviewed the code changes and am responsible for the submitted patch.
