### PR TITLE
models: fix linear attention state corruption in recurrent layers

### DIFF
--- a/src/models/kimi-linear.cpp
+++ b/src/models/kimi-linear.cpp
@@ -115,8 +115,6 @@ llm_build_kimi_linear::llm_build_kimi_linear(const llama_model & model, const ll
         cur = build_norm(inpL, layer.attn_norm, NULL, LLM_NORM_RMS, il);
         cb(cur, "attn_norm", il);
 
-        ggml_build_forward_expand(gf, cur);
-
         if (hparams.is_recurrent(il)) {
             // === KDA Layer (Kimi Delta Attention) with Recurrent State ===
             // Reference: vLLM kda.py
@@ -203,7 +201,10 @@ llm_build_kimi_linear::llm_build_kimi_linear(const llama_model & model, const ll
             cur = ggml_mul_mat(ctx0, layer.wo, gated);
             cb(cur, "kda_out", il);
 
+            ggml_build_forward_expand(gf, cur);
         } else {
+            ggml_build_forward_expand(gf, cur);
+
             // === MLA Layer (Multi-head Latent Attention) without KV Cache ===
             // Reference: vLLM mla.py
             // Step 1: Q projection and reshape

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -29,13 +29,15 @@ llm_build_qwen35::llm_build_qwen35(const llama_model & model, const llm_graph_pa
         cur = build_norm(inpL, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, il);
         cb(cur, "attn_norm", il);
 
-        ggml_build_forward_expand(gf, cur);
-
         // Determine layer type and build appropriate attention mechanism
         if (hparams.is_recurrent(il)) {
             // Linear attention layer (gated delta net)
             cur = build_layer_attn_linear(inp->get_recr(), cur, il);
+
+            ggml_build_forward_expand(gf, cur);
         } else {
+            ggml_build_forward_expand(gf, cur);
+
             // Full attention layer
             cur = build_layer_attn(inp->get_attn(), cur, inp_pos, sections, il);
         }

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -29,13 +29,15 @@ llm_build_qwen35moe::llm_build_qwen35moe(const llama_model & model, const llm_gr
         cur = build_norm(inpL, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, il);
         cb(cur, "attn_norm", il);
 
-        ggml_build_forward_expand(gf, cur);
-
         // Determine layer type and build appropriate attention mechanism
         if (hparams.is_recurrent(il)) {
             // Linear attention layer (gated delta net)
             cur = build_layer_attn_linear(inp->get_recr(), cur, il);
+
+            ggml_build_forward_expand(gf, cur);
         } else {
+            ggml_build_forward_expand(gf, cur);
+
             // Full attention layer
             cur = build_layer_attn(inp->get_attn(), cur, inp_pos, sections, il);
         }

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -21,13 +21,15 @@ llm_build_qwen3next::llm_build_qwen3next(const llama_model & model, const llm_gr
         cur = build_norm(inpL, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, il);
         cb(cur, "attn_norm", il);
 
-        ggml_build_forward_expand(gf, cur);
-
         // Determine layer type and build appropriate attention mechanism
         if (hparams.is_recurrent(il)) {
             // Linear attention layer (gated delta net)
             cur = build_layer_attn_linear(inp->get_recr(), cur, il);
+
+            ggml_build_forward_expand(gf, cur);
         } else {
+            ggml_build_forward_expand(gf, cur);
+
             // Full attention layer
             cur = build_layer_attn(inp->get_attn(), cur, inp_pos, il);
         }


### PR DESCRIPTION
Commit 244641955f61 added ggml_build_forward_expand immediately after layer normalization to enable multi-GPU graph partitioning. However, for recurrent linear attention models, this prematurely closed the graph branch before the internal state updates (convolution and SSM states) were fully constructed.

This caused the graph engine to schedule state cache writes out of order or independently, leading to data races or stale reads in the convolution and SSM states. The bug manifested as intermittent generation corruption, such as alignment errors in code generation.

This commit moves the ggml_build_forward_expand call to immediately after the linear attention layer computation for all recurrent branches. This ensures the entire layer computation, including internal state updates, is part of the forward graph before being expanded for partitioning, restoring the correct topological barriers.

This was found and verified with a single GPU only using the synthmerge_bench. The multi GPU split is untested.

Fixes: 244641955f61 ("models : fix graph splits (#19866)")

## Overview

Fixes computation of linear attention with recurrent layers.

## Additional information

While running the synthmerge_bench in parallel with another [synthmerge](https://gitlab.com/aarcange/synthmerge/) testcase, I was getting failures about failed validation of the head context. When validation fails logging shows a diff against the expected output, which looked particulary odd with just an alignment error off by whitespace for all lines. That was not the normal error an LLM does that I would expect. I guessed it was a bad quantization issue first and changing quantization made the synthmerge testcase work fine, until I noticed it wasn't the change of quantization fixing generation, but the restart of llama.cpp.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 

Coded with rg-edit:

rg-edit regexp: ggml_build_forward_expand.{1,500}is_recurrent.*?    \}
rg-edit directive: Rewrite: move expand after the linear attention (gated delta net or KDA) layers, otherwise call the expand before the full attention

All files matching regexp added to gptel-context.