### PR TITLE
webui: [ChatFormPickerPopover][a11y] add tabindex and aria-hidden to popover trigger

### DIFF
--- a/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatFormPickers/ChatFormPicker/ChatFormPickerPopover.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatForm/ChatFormPickers/ChatFormPicker/ChatFormPickerPopover.svelte
@@ -29,7 +29,11 @@
 		}
 	}}
 >
-	<Popover.Trigger class="pointer-events-none absolute inset-0 opacity-0">
+	<Popover.Trigger
+		class="pointer-events-none absolute inset-0 opacity-0"
+		tabindex={-1}
+		aria-hidden="true"
+	>
 		<span class="sr-only">{srLabel}</span>
 	</Popover.Trigger>
 


### PR DESCRIPTION
## Overview

I was using my keyboard to navigate the webUI (`Tab` and `Shift+Tab`). There was a hidden `<button data-slot="popover-trigger">` in `ChatFormPickerPopover` that you couldn't see, but you could still `tab` to it and screen readers would announce it.

When `Enter` is clicked the popover would seemingly open out of nowhere saying: `No MCP resources available`. The button has to stick around because bits-ui uses it as the positioning anchor for the popover content, so removing it isn't an option.

Adding `tabindex={-1}` takes it out of the tab order, and `aria-hidden="true"` hides it from screen readers. Together, it's now invisible to every keyboard interaction and the a11y tree for screen readers, while still doing its positioning job :) 

## Additional information

You can reproduce this issue in the local Storybook instance: `ChatScreenForm > Default`. Hit `Shift+Tab`, then hit `Enter`. check `document.activeElement` in the console. For keyboard users this behavior is unusual and does not flow naturally through the order of focusable elements.

<img width="553" height="253" alt="image" src="https://github.com/user-attachments/assets/c6a982d9-a1ca-40bb-aa3c-4d733210f308" />

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) - Yes
- AI usage disclosure: Yes, AI helped me understand the `webui/` repo's structure and made the diff after I picked the most viable fix.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->