### PR TITLE
server : expose model architecture (modalities) in /v1/models

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -939,9 +939,17 @@ std::string common_docker_resolve_model(const std::string & docker) {
 
 std::vector<common_cached_model_info> common_list_cached_models() {
     std::unordered_set<std::string> seen;
+    std::unordered_set<std::string> vision_repos;
     std::vector<common_cached_model_info> result;
 
     auto files = hf_cache::get_cached_files();
+
+    for (const auto & f : files) {
+        if (f.path.find("mmproj") != std::string::npos &&
+            string_ends_with(f.path, ".gguf")) {
+            vision_repos.insert(f.repo_id);
+        }
+    }
 
     for (const auto & f : files) {
         auto split = get_gguf_split_info(f.path);
@@ -950,7 +958,11 @@ std::vector<common_cached_model_info> common_list_cached_models() {
             continue;
         }
         if (seen.insert(f.repo_id + ":" + split.tag).second) {
-            result.push_back({f.repo_id, split.tag});
+            common_cached_model_info info;
+            info.repo = f.repo_id;
+            info.tag = split.tag;
+            info.input_modalities_image = vision_repos.count(f.repo_id) > 0;
+            result.push_back(std::move(info));
         }
     }
 

--- a/common/download.h
+++ b/common/download.h
@@ -42,6 +42,7 @@ std::pair<std::string, std::string> common_download_split_repo_tag(const std::st
 struct common_cached_model_info {
     std::string repo;
     std::string tag;
+    bool input_modalities_image = false; // true if the repo also contains an mmproj file
     std::string to_string() const {
         return repo + ":" + tag;
     }

--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -161,6 +161,8 @@ void common_preset::merge(const common_preset & other) {
     for (const auto & [opt, val] : other.options) {
         options[opt] = val; // overwrite existing options
     }
+    // capability flags are OR-ed so they survive cascade
+    input_modalities_image = input_modalities_image || other.input_modalities_image;
 }
 
 void common_preset::apply_to_params(common_params & params) const {
@@ -366,6 +368,7 @@ common_presets common_preset_context::load_from_cache() const {
     for (const auto & model : cached_models) {
         common_preset preset;
         preset.name = model.to_string();
+        preset.input_modalities_image = model.input_modalities_image;
         preset.set_option(*this, "LLAMA_ARG_HF_REPO", model.to_string());
         out[preset.name] = preset;
     }
@@ -434,6 +437,7 @@ common_presets common_preset_context::load_from_models_dir(const std::string & m
     for (const auto & model : models) {
         common_preset preset;
         preset.name = model.name;
+        preset.input_modalities_image = !model.path_mmproj.empty();
         preset.set_option(*this, "LLAMA_ARG_MODEL", model.path);
         if (!model.path_mmproj.empty()) {
             preset.set_option(*this, "LLAMA_ARG_MMPROJ", model.path_mmproj);

--- a/common/preset.h
+++ b/common/preset.h
@@ -19,6 +19,9 @@ struct common_preset_context;
 struct common_preset {
     std::string name;
 
+    // true if the underlying model has a multimodal projector (mmproj) available
+    bool input_modalities_image = false;
+
     // options are stored as common_arg to string mapping, representing CLI arg and its value
     std::map<common_arg, std::string> options;
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1176,14 +1176,23 @@ void server_models_routes::init_routes() {
                 status["exit_code"] = meta.exit_code;
                 status["failed"]    = true;
             }
+            json input_modalities = json::array({"text"});
+            if (meta.preset.input_modalities_image) {
+                input_modalities.push_back("image");
+            }
+            json architecture {
+                {"input_modalities",  input_modalities},
+                {"output_modalities", json::array({"text"})},
+            };
             models_json.push_back(json {
-                {"id",       meta.name},
-                {"aliases",  meta.aliases},
-                {"tags",     meta.tags},
-                {"object",   "model"},    // for OAI-compat
-                {"owned_by", "llamacpp"}, // for OAI-compat
-                {"created",  t},          // for OAI-compat
-                {"status",   status},
+                {"id",           meta.name},
+                {"aliases",      meta.aliases},
+                {"tags",         meta.tags},
+                {"object",       "model"},    // for OAI-compat
+                {"owned_by",     "llamacpp"}, // for OAI-compat
+                {"created",      t},          // for OAI-compat
+                {"status",       status},
+                {"architecture", architecture},
                 // TODO: add other fields, may require reading GGUF metadata
             });
         }


### PR DESCRIPTION
## Overview

Adds an `architecture` object to each entry returned by `/v1/models`:

```json
"architecture": {
  "input_modalities":  ["text", "image"],
  "output_modalities": ["text"]
}
```

`image` is included when the model's HF repo (or local model directory) contains an mmproj file. `output_modalities` is currently always `["text"]`.


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Claude Code was used in an assistive capacity to apply edits, locate call sites, and trace the cascade/merge bug. Field naming, where to populate the flag, JSON shape, and verification against the running server were driven by me. I take full responsibility for the submitted code.