### PR TITLE
server, webui: support continue generation on reasoning models

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1082,13 +1082,6 @@ json oaicompat_chat_params_parse(
             throw std::invalid_argument("Cannot have 2 or more assistant messages at the end of the list.");
         }
 
-        /* TODO: test this properly */
-        inputs.reasoning_format = COMMON_REASONING_FORMAT_NONE;
-
-        if ( inputs.enable_thinking ) {
-            throw std::invalid_argument("Assistant response prefill is incompatible with enable_thinking.");
-        }
-
         inputs.add_generation_prompt = true;
     }
     inputs.force_pure_content = opt.force_pure_content;
@@ -1098,6 +1091,42 @@ json oaicompat_chat_params_parse(
 
     /* Append assistant prefilled message */
     if (prefill_assistant_message) {
+        const bool thinking_active = chat_params.supports_thinking && !chat_params.thinking_end_tag.empty();
+        const bool has_reasoning   = !last_message.reasoning_content.empty();
+        const bool has_content     = !last_message.content.empty() || !last_message.content_parts.empty();
+        const bool mid_reasoning   = has_reasoning && !has_content;
+
+        // some templates inject thinking_start in generation_prompt, others let the model emit it
+        const bool gp_has_think = thinking_active
+            && chat_params.generation_prompt.find(chat_params.thinking_start_tag) != std::string::npos;
+
+        // open the thinking block when reasoning is present and the template did not inject it
+        if (has_reasoning) {
+            if (thinking_active && !gp_has_think) {
+                chat_params.prompt += chat_params.thinking_start_tag;
+            }
+            chat_params.prompt += last_message.reasoning_content;
+        }
+
+        if (thinking_active) {
+            if (mid_reasoning) {
+                // model continues inside the thinking block, keep generation_prompt open on think
+                if (!gp_has_think) {
+                    chat_params.generation_prompt += chat_params.thinking_start_tag;
+                }
+            } else {
+                // close thinking block when reasoning is followed by content, or when the template forced it open
+                if (has_reasoning || gp_has_think) {
+                    chat_params.prompt += chat_params.thinking_end_tag;
+                }
+                // strip thinking_start from generation_prompt so the parser routes model output as content
+                auto pos = chat_params.generation_prompt.rfind(chat_params.thinking_start_tag);
+                if (pos != std::string::npos) {
+                    chat_params.generation_prompt = chat_params.generation_prompt.substr(0, pos);
+                }
+            }
+        }
+
         if (!last_message.content_parts.empty()) {
             for (auto & p : last_message.content_parts) {
                 chat_params.prompt += p.text;

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1082,6 +1082,14 @@ json oaicompat_chat_params_parse(
             throw std::invalid_argument("Cannot have 2 or more assistant messages at the end of the list.");
         }
 
+        // reject reasoning prefill on channel based templates that do not expose explicit thinking tags
+        if (!last_message.reasoning_content.empty() && inputs.enable_thinking) {
+            auto probe_params = common_chat_templates_apply(opt.tmpls.get(), inputs);
+            if (probe_params.supports_thinking && probe_params.thinking_end_tag.empty()) {
+                throw std::invalid_argument("Assistant prefill with reasoning_content is not supported yet for this template.");
+            }
+        }
+
         inputs.add_generation_prompt = true;
     }
     inputs.force_pure_content = opt.force_pure_content;

--- a/tools/server/webui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageAssistant/ChatMessageAssistant.svelte
+++ b/tools/server/webui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageAssistant/ChatMessageAssistant.svelte
@@ -74,7 +74,6 @@
 	const editCtx = getMessageEditContext();
 
 	const isAgentic = $derived(hasAgenticContent(message, toolMessages));
-	const hasReasoning = $derived(!!message.reasoningContent);
 	const processingState = useProcessingState();
 
 	let currentConfig = $derived(config());
@@ -329,7 +328,7 @@
 			{onCopy}
 			{onEdit}
 			{onRegenerate}
-			onContinue={currentConfig.enableContinueGeneration && !hasReasoning ? onContinue : undefined}
+			onContinue={currentConfig.enableContinueGeneration ? onContinue : undefined}
 			{onForkConversation}
 			{onDelete}
 			{onConfirmDelete}

--- a/tools/server/webui/src/lib/constants/settings-registry.ts
+++ b/tools/server/webui/src/lib/constants/settings-registry.ts
@@ -122,7 +122,7 @@ const SETTINGS_REGISTRY: Record<string, SettingsSectionEntry> = {
 			{
 				key: SETTINGS_KEYS.ENABLE_CONTINUE_GENERATION,
 				label: 'Enable "Continue" button',
-				help: 'Enable "Continue" button for assistant messages. Currently works only with non-reasoning models.',
+				help: 'Enable "Continue" button for assistant messages, including reasoning models.',
 				defaultValue: false,
 				type: SettingsFieldType.CHECKBOX,
 				section: SETTINGS_SECTION_SLUGS.GENERAL,

--- a/tools/server/webui/src/lib/stores/chat.svelte.ts
+++ b/tools/server/webui/src/lib/stores/chat.svelte.ts
@@ -674,7 +674,8 @@ class ChatStore {
 			},
 			onReasoningChunk: (chunk: string) => {
 				streamedReasoningContent += chunk;
-				// Update UI to show reasoning is being received
+				// mark streaming state so a stop mid-thinking can persist the partial reasoning
+				this.setChatStreaming(convId, streamedContent, currentMessageId);
 				const idx = conversationsStore.findMessageIndex(currentMessageId);
 				conversationsStore.updateMessageAtIndex(idx, {
 					reasoningContent: streamedReasoningContent
@@ -989,38 +990,51 @@ class ChatStore {
 		const conversationId = convId || conversationsStore.activeConversation?.id;
 		if (!conversationId) return;
 		const streamingState = this.getChatStreaming(conversationId);
-		if (!streamingState || !streamingState.response.trim()) return;
+		if (!streamingState) return;
 		const messages =
 			conversationId === conversationsStore.activeConversation?.id
 				? conversationsStore.activeMessages
 				: await conversationsStore.getConversationMessages(conversationId);
 		if (!messages.length) return;
 		const lastMessage = messages[messages.length - 1];
-		if (lastMessage?.role === MessageRole.ASSISTANT) {
-			try {
-				const updateData: { content: string; timings?: ChatMessageTimings } = {
-					content: streamingState.response
-				};
-				const lastKnownState = this.getProcessingState(conversationId);
-				if (lastKnownState) {
-					updateData.timings = {
-						prompt_n: lastKnownState.promptTokens || 0,
-						prompt_ms: lastKnownState.promptMs,
-						predicted_n: lastKnownState.tokensDecoded || 0,
-						cache_n: lastKnownState.cacheTokens || 0,
-						predicted_ms:
-							lastKnownState.tokensPerSecond && lastKnownState.tokensDecoded
-								? (lastKnownState.tokensDecoded / lastKnownState.tokensPerSecond) * 1000
-								: undefined
-					};
-				}
-				await DatabaseService.updateMessage(lastMessage.id, updateData);
-				lastMessage.content = streamingState.response;
-				if (updateData.timings) lastMessage.timings = updateData.timings;
-			} catch (error) {
-				lastMessage.content = streamingState.response;
-				console.error('Failed to save partial response:', error);
+		if (lastMessage?.role !== MessageRole.ASSISTANT) return;
+
+		const partialContent = streamingState.response;
+		const partialReasoning = lastMessage.reasoningContent || '';
+
+		// nothing to persist when both content and reasoning are empty (e.g. stop before any token)
+		if (!partialContent.trim() && !partialReasoning.trim()) return;
+
+		try {
+			const updateData: {
+				content: string;
+				reasoningContent?: string;
+				timings?: ChatMessageTimings;
+			} = {
+				content: partialContent
+			};
+			if (partialReasoning) {
+				updateData.reasoningContent = partialReasoning;
 			}
+			const lastKnownState = this.getProcessingState(conversationId);
+			if (lastKnownState) {
+				updateData.timings = {
+					prompt_n: lastKnownState.promptTokens || 0,
+					prompt_ms: lastKnownState.promptMs,
+					predicted_n: lastKnownState.tokensDecoded || 0,
+					cache_n: lastKnownState.cacheTokens || 0,
+					predicted_ms:
+						lastKnownState.tokensPerSecond && lastKnownState.tokensDecoded
+							? (lastKnownState.tokensDecoded / lastKnownState.tokensPerSecond) * 1000
+							: undefined
+				};
+			}
+			await DatabaseService.updateMessage(lastMessage.id, updateData);
+			lastMessage.content = partialContent;
+			if (updateData.timings) lastMessage.timings = updateData.timings;
+		} catch (error) {
+			lastMessage.content = partialContent;
+			console.error('Failed to save partial response:', error);
 		}
 	}
 
@@ -1265,7 +1279,11 @@ class ChatStore {
 			const conversationContext = conversationsStore.activeMessages.slice(0, idx);
 			const contextWithContinue = [
 				...conversationContext,
-				{ role: MessageRole.ASSISTANT as const, content: originalContent }
+				{
+					role: MessageRole.ASSISTANT as const,
+					content: originalContent,
+					reasoning_content: originalReasoning || undefined
+				}
 			];
 
 			let appendedContent = '';
@@ -1291,6 +1309,8 @@ class ChatStore {
 					onReasoningChunk: (chunk: string) => {
 						appendedReasoning += chunk;
 						hasReceivedContent = true;
+						// mark streaming state so a stop mid-thinking can persist the partial reasoning
+						this.setChatStreaming(msg.convId, originalContent + appendedContent, msg.id);
 						conversationsStore.updateMessageAtIndex(idx, {
 							reasoningContent: originalReasoning + appendedReasoning
 						});


### PR DESCRIPTION
## Overview

Reasoning models can now use the Continue button. Stopping mid thought saves the partial chain of thought, F5 keeps it, and clicking Continue resumes inside the thinking block instead of restarting from scratch. Same behavior for stops after the thinking ends. Plain content prefill is unchanged.

https://github.com/user-attachments/assets/02a61a8d-c02f-4c00-86f0-f0098fc94dc4

## Additional information

Backend resolves the old TODO in oaicompat_chat_params_parse: removes the throw blocking assistant prefill on reasoning models and the forced reasoning_format = NONE workaround, then orchestrates thinking_start_tag, thinking_end_tag and generation_prompt around the prefilled message so the prompt is rebuilt correctly and the parser introduced in PR #20424 routes the next stream chunks to reasoning_content or content depending on whether the prefill is plain content, mid reasoning, or post reasoning. Bridges the API field from #21036, the parser routing from #20424 and the webui storage from #21249.

Frontend drops the reasoning_content guard on the Continue button, sends reasoning_content with the prefilled assistant message in continueAssistantMessage, persists partial reasoningContent on stop so the CoT survives F5 and Continue, and marks the streaming state on reasoning chunks so savePartialResponseIfNeeded does not early return when stop happens before any content token. Setting hint updated.

### First step toward #21754: covers voluntary stop and reload, full network resilience (SSE resume) is left for a follow up.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Opus 4.7 + local MCP server with rootless pod

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
