### PR TITLE
common: skip empty default preset from preset.ini metadata

### DIFF
--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -348,6 +348,12 @@ common_presets common_preset_context::load_from_ini(const std::string & path, co
             }
         }
 
+        // A file-level version key is parsed into the implicit default section.
+        // Do not expose it as an empty default preset.
+        if (preset.name == COMMON_PRESET_DEFAULT_NAME && preset.options.empty()) {
+            continue;
+        }
+
         if (preset.name == "*") {
             // handle global preset
             global = preset;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,6 +234,7 @@ llama_build_and_test(test-thread-safety.cpp ARGS -m "${MODEL_DEST}" -ngl 99 -p "
 set_tests_properties(test-thread-safety PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 llama_build_and_test(test-arg-parser.cpp)
+llama_build_and_test(test-preset.cpp)
 
 if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   # TODO: repair known memory leaks

--- a/tests/test-preset.cpp
+++ b/tests/test-preset.cpp
@@ -1,0 +1,116 @@
+#include "preset.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#undef NDEBUG
+#include <cassert>
+
+static std::filesystem::path write_ini(const std::string & contents) {
+    static int counter = 0;
+    const auto id = std::chrono::steady_clock::now().time_since_epoch().count() + counter++;
+    const auto path = std::filesystem::temp_directory_path() /
+        ("llama-test-preset-" + std::to_string(id) + ".ini");
+
+    std::ofstream file(path);
+    assert(file.good());
+    file << contents;
+    file.close();
+
+    return path;
+}
+
+static common_presets load_ini(
+        const common_preset_context & ctx,
+        const std::string & contents,
+        common_preset & global) {
+    const auto path = write_ini(contents);
+    auto presets = ctx.load_from_ini(path.string(), global);
+    std::filesystem::remove(path);
+
+    return presets;
+}
+
+static void test_metadata_only_default_is_skipped() {
+    common_preset_context ctx(LLAMA_EXAMPLE_SERVER);
+    common_preset global;
+
+    auto presets = load_ini(ctx,
+        "version = 1\n"
+        "\n"
+        "[first]\n"
+        "model = /tmp/first.gguf\n"
+        "\n"
+        "[second]\n"
+        "model = /tmp/second.gguf\n",
+        global);
+
+    assert(presets.size() == 2);
+    assert(presets.find(COMMON_PRESET_DEFAULT_NAME) == presets.end());
+    assert(presets.find("first") != presets.end());
+    assert(presets.find("second") != presets.end());
+
+    std::string value;
+    assert(presets.at("first").get_option("LLAMA_ARG_MODEL", value));
+    assert(value == "/tmp/first.gguf");
+    assert(presets.at("second").get_option("LLAMA_ARG_MODEL", value));
+    assert(value == "/tmp/second.gguf");
+}
+
+static void test_default_with_options_is_kept() {
+    common_preset_context ctx(LLAMA_EXAMPLE_SERVER);
+    common_preset global;
+
+    auto presets = load_ini(ctx,
+        "version = 1\n"
+        "model = /tmp/default.gguf\n"
+        "\n"
+        "[named]\n"
+        "model = /tmp/named.gguf\n",
+        global);
+
+    assert(presets.size() == 2);
+    assert(presets.find(COMMON_PRESET_DEFAULT_NAME) != presets.end());
+    assert(presets.find("named") != presets.end());
+
+    std::string value;
+    assert(presets.at(COMMON_PRESET_DEFAULT_NAME).get_option("LLAMA_ARG_MODEL", value));
+    assert(value == "/tmp/default.gguf");
+    assert(presets.at("named").get_option("LLAMA_ARG_MODEL", value));
+    assert(value == "/tmp/named.gguf");
+}
+
+static void test_global_preset_is_kept() {
+    common_preset_context ctx(LLAMA_EXAMPLE_SERVER);
+    common_preset global;
+
+    auto presets = load_ini(ctx,
+        "version = 1\n"
+        "\n"
+        "[*]\n"
+        "ctx-size = 4096\n"
+        "\n"
+        "[named]\n"
+        "model = /tmp/named.gguf\n",
+        global);
+
+    assert(presets.size() == 1);
+    assert(presets.find(COMMON_PRESET_DEFAULT_NAME) == presets.end());
+    assert(presets.find("named") != presets.end());
+    assert(global.name == "*");
+
+    std::string value;
+    assert(global.get_option("LLAMA_ARG_CTX_SIZE", value));
+    assert(value == "4096");
+}
+
+int main(void) {
+    test_metadata_only_default_is_skipped();
+    test_default_with_options_is_kept();
+    test_global_preset_is_kept();
+
+    printf("test-preset: all tests OK\n");
+}


### PR DESCRIPTION
Fixes #22364

`load_from_ini()` starts parsing INI files in the implicit `default` section. Because of that, a file-level metadata key like `version = 1` created a `default` section internally.

The `version` key is skipped later as metadata, but the now-empty `default` preset was still added to the preset map. In router mode this showed up as an unexpected `default` model in `/models`.

This change skips only empty implicit `default` presets after metadata has been processed.

Added regression coverage for:
- top-level `version = 1` not creating a `default` preset
- real implicit default presets with options still being kept
- `[*]` global presets still being preserved

Tested with:

```sh
cmake --build build-test-preset --target test-preset -j$(nproc)
ctest --test-dir build-test-preset -R '^test-preset$' --output-on-failure\ngit diff --check\n```