### PR TITLE
Add more wav-compatiable MIME types and enhance MIME type normalization

### DIFF
--- a/tools/server/webui/src/lib/enums/files.ts
+++ b/tools/server/webui/src/lib/enums/files.ts
@@ -172,6 +172,10 @@ export enum MimeTypeAudio {
 	MP3 = 'audio/mp3',
 	MP4 = 'audio/mp4',
 	WAV = 'audio/wav',
+	WAVE = 'audio/wave',
+	X_WAV = 'audio/x-wav',
+	X_WAVE = 'audio/x-wave',
+	X_PN_WAV = 'audio/x-pn-wav',
 	WEBM = 'audio/webm',
 	WEBM_OPUS = 'audio/webm;codecs=opus'
 }

--- a/tools/server/webui/src/lib/services/chat.service.ts
+++ b/tools/server/webui/src/lib/services/chat.service.ts
@@ -18,6 +18,22 @@ import type { ApiChatMessageContentPart, ApiChatCompletionToolCall } from '$lib/
 import type { DatabaseMessageExtraMcpPrompt, DatabaseMessageExtraMcpResource } from '$lib/types';
 import { modelsStore } from '$lib/stores/models.svelte';
 
+function getAudioInputFormat(mimeType: string): 'wav' | 'mp3' {
+	const normalizedMimeType = mimeType.toLowerCase();
+
+	if (
+		normalizedMimeType === 'audio/wav' ||
+		normalizedMimeType === 'audio/wave' ||
+		normalizedMimeType === 'audio/x-wav' ||
+		normalizedMimeType === 'audio/x-wave' ||
+		normalizedMimeType === 'audio/x-pn-wav'
+	) {
+		return 'wav';
+	}
+
+	return 'mp3';
+}
+
 export class ChatService {
 	/**
 	 *
@@ -821,7 +837,7 @@ export class ChatService {
 				type: ContentPartType.INPUT_AUDIO,
 				input_audio: {
 					data: audio.base64Data,
-					format: audio.mimeType.includes('wav') ? 'wav' : 'mp3'
+					format: getAudioInputFormat(audio.mimeType)
 				}
 			});
 		}

--- a/tools/server/webui/src/lib/utils/file-type.ts
+++ b/tools/server/webui/src/lib/utils/file-type.ts
@@ -16,8 +16,12 @@ import {
 	MimeTypeText
 } from '$lib/enums';
 
+function normalizeMimeType(mimeType: string): string {
+	return mimeType.trim().toLowerCase();
+}
+
 export function getFileTypeCategory(mimeType: string): FileTypeCategory | null {
-	switch (mimeType) {
+	switch (normalizeMimeType(mimeType)) {
 		// Images
 		case MimeTypeImage.JPEG:
 		case MimeTypeImage.PNG:
@@ -31,6 +35,10 @@ export function getFileTypeCategory(mimeType: string): FileTypeCategory | null {
 		case MimeTypeAudio.MP3:
 		case MimeTypeAudio.MP4:
 		case MimeTypeAudio.WAV:
+		case MimeTypeAudio.WAVE:
+		case MimeTypeAudio.X_WAV:
+		case MimeTypeAudio.X_WAVE:
+		case MimeTypeAudio.X_PN_WAV:
 		case MimeTypeAudio.WEBM:
 		case MimeTypeAudio.WEBM_OPUS:
 			return FileTypeCategory.AUDIO;


### PR DESCRIPTION
## Description

This PR addresses issue in [#21850](https://github.com/ggml-org/llama.cpp/issues/21850) by adding more MIME types in the check logic.

## Changes

Added support to
- audio/wave
- audio/wav
- audio/x-wav
- audio/x-pn-wav

These MIME types are common in medias generated by older audio recording and synthesis software and are binary compatiable to the standard WAV format. Current webui logic will ignore these types silently, resulting to the bug described in #21850 .

It also added a short MIME normalization logic to suppress problems caused by irregular MIME string.

## How to Test

Upload a test audio file  with MIME type `audio/x-wav` using the webui with a model supporting audio modality:

<img width="1176" height="776" alt="image" src="https://github.com/user-attachments/assets/87823e1d-d9d6-4831-a09a-3e19912dce0a" />

Check if it can handle the audio file correctly:



