### PR TITLE
vulkan: skip cooperative matrix on integrated AMD GPUs (driver bug workaround)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -16332,6 +16332,17 @@ static bool ggml_vk_khr_cooperative_matrix_support(const vk::PhysicalDevicePrope
         return arch == vk_device_architecture::INTEL_XE2;
     case VK_VENDOR_ID_AMD:
         if (driver_props.driverID == vk::DriverId::eAmdProprietary || driver_props.driverID == vk::DriverId::eAmdOpenSource) {
+            // AMD's Vulkan driver (amdvlk64.dll, reported as either
+            // eAmdProprietary or eAmdOpenSource depending on packaging)
+            // crashes inside vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR
+            // on integrated GPUs (observed on Radeon 860M / RDNA 3.5 Strix
+            // Point) even though VK_KHR_cooperative_matrix and the
+            // cooperativeMatrix feature are advertised. Skip cooperative
+            // matrix on integrated devices to avoid the access violation.
+            // See https://github.com/GPUOpen-Drivers/AMDVLK/issues/422.
+            if (props.deviceType == vk::PhysicalDeviceType::eIntegratedGpu) {
+                return false;
+            }
             // Workaround for AMD proprietary driver reporting support on all GPUs
             return arch == vk_device_architecture::AMD_RDNA3;
         }


### PR DESCRIPTION
## Bug

On Windows AMD integrated GPUs, the Vulkan driver advertises `VK_KHR_cooperative_matrix` and the `cooperativeMatrix` feature, but `vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR` access-violates inside `amdvlk64.dll` on its first invocation. ggml-vulkan crashes the host process inside `ggml_vk_get_device` before any model loads.

Reproduced on Radeon 860M (RDNA 3.5, Strix Point) under Windows 11 with current AMD Adrenalin (`driverInfo: 26.3.1 (LLPC)`, `driverVersion: 2.0.388`). The first count-only call (with `pProperties=nullptr`) returns cleanly with `cm_props_num=4`; the access violation surfaces immediately after, between the count and the fill call. The driver reports as `VK_DRIVER_ID_AMD_PROPRIETARY` on this hardware, although the actual loaded ICD is `amdvlk64.dll`.

Upstream driver bug filed at AMDVLK: https://github.com/GPUOpen-Drivers/AMDVLK/issues/422.

## Fix

Extend the AMD branch of `ggml_vk_khr_cooperative_matrix_support` to return false when `props.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU`, regardless of driver ID. Discrete AMD paths are unchanged.

## Verification

Pre-patch: `ggml_vk_get_device` crashes the host process the first time it is reached on the iGPU. Captured a full memory dump via Sysinternals ProcDump on a `RelWithDebInfo` build of `b9016`; Visual Studio 2022 resolved the call stack to `amdvlk64.dll` with the caller at `ggml-vulkan.cpp:5476` (the `cm_props.resize(cm_props_num)` between the two property-query calls).

Post-patch: model loads on the same iGPU through Vulkan, shaders compile, BERT inference runs, embeddings produce the expected 384-dim output. The cooperative-matrix property query is no longer reached for integrated AMD devices.

Same hardware, same `multilingual-e5-small-Q8_0.gguf` (132 MB) model. Crash dump from the pre-patch run available on request.

## Note on NVIDIA Blackwell

A separate but spec-similar driver bug affects NVIDIA's Blackwell GPUs (RTX 5050 Laptop, sm_120, `driverInfo: 591.74`) in both `vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR` and `vkGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV`. Filed upstream with NVIDIA: https://forums.developer.nvidia.com/t/blackwell-rtx-5050-laptop-sm-120-vulkan-driver-crashes-in-cooperative-matrix-property-queries/369162/1.

Not addressed in this PR; the existing `GGML_VK_DISABLE_COOPMAT` and `GGML_VK_DISABLE_COOPMAT2` env-var escape hatches work around it. A follow-up PR can add deviceID-based gating once a stable Blackwell-detection signal is identified.
