### PR TITLE
common : call ggml_backend_load_all before llama_supports_rpc

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2220,6 +2220,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.image_max_tokens = value;
         }
     ).set_examples(mmproj_examples).set_env("LLAMA_ARG_IMAGE_MAX_TOKENS"));
+    ggml_backend_load_all();
     if (llama_supports_rpc()) {
         add_opt(common_arg(
             {"--rpc"}, "SERVERS",


### PR DESCRIPTION
## Overview

`llama_supports_rpc()` requires `ggml_backend_load_all()`

## Additional information

PR #22290 missed this one

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
