### PR TITLE
android: extract GgufMetadataReader factory to break cyclic dependency

### DIFF
--- a/examples/llama.android/app/src/main/java/com/example/llama/MainActivity.kt
+++ b/examples/llama.android/app/src/main/java/com/example/llama/MainActivity.kt
@@ -17,6 +17,7 @@ import com.arm.aichat.AiChat
 import com.arm.aichat.InferenceEngine
 import com.arm.aichat.gguf.GgufMetadata
 import com.arm.aichat.gguf.GgufMetadataReader
+import com.arm.aichat.gguf.create
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job

--- a/examples/llama.android/lib/src/main/java/com/arm/aichat/gguf/GgufMetadataReader.kt
+++ b/examples/llama.android/lib/src/main/java/com/arm/aichat/gguf/GgufMetadataReader.kt
@@ -2,7 +2,6 @@ package com.arm.aichat.gguf
 
 import android.content.Context
 import android.net.Uri
-import com.arm.aichat.internal.gguf.GgufMetadataReaderImpl
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -42,34 +41,11 @@ interface GgufMetadataReader {
     suspend fun readStructuredMetadata(input: InputStream): GgufMetadata
 
     companion object {
-        private val DEFAULT_SKIP_KEYS = setOf(
+        val DEFAULT_SKIP_KEYS = setOf(
             "tokenizer.chat_template",
             "tokenizer.ggml.scores",
             "tokenizer.ggml.tokens",
             "tokenizer.ggml.token_type"
-        )
-
-        /**
-         * Creates a default GgufMetadataReader instance
-         */
-        fun create(): GgufMetadataReader = GgufMetadataReaderImpl(
-            skipKeys = DEFAULT_SKIP_KEYS,
-            arraySummariseThreshold = 1_000
-        )
-
-        /**
-         * Creates a GgufMetadataReader with custom configuration
-         *
-         * @param skipKeys Keys whose value should be skipped entirely (not kept in the result map)
-         * @param arraySummariseThreshold If ≥0, arrays longer get summarised, not materialised;
-         *                                If -1, never summarise.
-         */
-        fun create(
-            skipKeys: Set<String> = DEFAULT_SKIP_KEYS,
-            arraySummariseThreshold: Int = 1_000
-        ): GgufMetadataReader = GgufMetadataReaderImpl(
-            skipKeys = skipKeys,
-            arraySummariseThreshold = arraySummariseThreshold
         )
     }
 }

--- a/examples/llama.android/lib/src/main/java/com/arm/aichat/gguf/GgufMetadataReaderFactory.kt
+++ b/examples/llama.android/lib/src/main/java/com/arm/aichat/gguf/GgufMetadataReaderFactory.kt
@@ -1,0 +1,26 @@
+package com.arm.aichat.gguf
+
+import com.arm.aichat.internal.gguf.GgufMetadataReaderImpl
+
+/**
+ * Creates a default GgufMetadataReader instance
+ */
+fun GgufMetadataReader.Companion.create(): GgufMetadataReader = GgufMetadataReaderImpl(
+    skipKeys = DEFAULT_SKIP_KEYS,
+    arraySummariseThreshold = 1_000
+)
+
+/**
+ * Creates a GgufMetadataReader with custom configuration
+ *
+ * @param skipKeys Keys whose value should be skipped entirely (not kept in the result map)
+ * @param arraySummariseThreshold If ≥0, arrays longer get summarised, not materialised;
+ *                                If -1, never summarise.
+ */
+fun GgufMetadataReader.Companion.create(
+    skipKeys: Set<String> = DEFAULT_SKIP_KEYS,
+    arraySummariseThreshold: Int = 1_000
+): GgufMetadataReader = GgufMetadataReaderImpl(
+    skipKeys = skipKeys,
+    arraySummariseThreshold = arraySummariseThreshold
+)


### PR DESCRIPTION
## Overview

This PR fixes a dependency cycle between `GgufMetadataReader.kt` and `GgufMetadataReaderImpl.kt` by creating the `GgufMetadataReaderFactory.kt` file.

## Additional Information

The Sentrux software was used to find the cycle via their algorithm.

This PR simply moves a portion of the code into a new file to break the cycle. There are no internal logic modifications. 
The change required adding `import com.arm.aichat.gguf.create` in `MainActivity.kt`.
In `GgufMetadataReader.kt` (line 45), the `private` modifier was removed in favor of `val DEFAULT_SKIP_KEYS = setOf(` so that `GgufMetadataReaderFactory.kt` can access `GgufMetadataReader.DEFAULT_SKIP_KEYS`.

Here is more information about the mutual import between the two files:

In `GgufMetadataReader.kt`, line 5:
```kotlin 
import com.arm.aichat.internal.gguf.GgufMetadataReaderImpl
```
To use it at line 55:
```kotlin
fun create(): GgufMetadataReader = GgufMetadataReaderImpl(
    skipKeys = DEFAULT_SKIP_KEYS,
    arraySummariseThreshold = 1_000
)
```

In `GgufMetadataReaderImpl.kt`, line 6:
```kotlin
import com.arm.aichat.gguf.GgufMetadataReader
```
To use it at line 20:
```kotlin
internal class GgufMetadataReaderImpl(...) : GgufMetadataReader {...
```

I performed the tests by compiling it myself. The compilation was successful:

```bash
:~/github/llama.cpp/examples/llama.android$ ./gradlew :lib:compileDebugKotlin :app:compileDebugKotlin
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details

> Configure project :app
WARNING: BuildType 'debug' is both debuggable and has 'isMinifyEnabled' set to true.
All code optimizations and obfuscation are disabled for debuggable builds.

BUILD SUCCESSFUL in 47s
28 actionable tasks: 1 executed, 27 up-to-date
```

## Requirements

- I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
  - To understand how to approach fixing the cycle.
  - To translate the PR into English (written by hand in French) and improve readability :)
  - I used antigravity to work on this PR.