### PR TITLE
ggml-cuda : implement FWHT for KV rotation (#22759)

### DIFF
--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -1,0 +1,92 @@
+#include "fwht.cuh"
+
+template <int N>
+static __global__ void fwht_f32_kernel(
+    const char * src1_data, char * dst_data,
+    int64_t ne11, int64_t ne12,
+    size_t nb11, size_t nb12, size_t nb13,
+    size_t nb1,  size_t nb2,  size_t nb3,
+    float scale)
+{
+    __shared__ float smem[N];
+
+    const int64_t r = blockIdx.x;
+    const int tid = threadIdx.x;
+
+    const int64_t i13 = r / (ne11 * ne12);
+    const int64_t i12 = (r - i13 * ne11 * ne12) / ne11;
+    const int64_t i11 = r - i13 * ne11 * ne12 - i12 * ne11;
+
+    const float * src_row = (const float *) (src1_data + i11 * nb11 + i12 * nb12 + i13 * nb13);
+    float * dst_row       = (float *)       (dst_data  + i11 * nb1  + i12 * nb2  + i13 * nb3);
+
+    smem[tid]         = src_row[tid] * scale;
+    smem[tid + N / 2] = src_row[tid + N / 2] * scale;
+    __syncthreads();
+
+    #pragma unroll
+    for (int len = 1; len < N; len <<= 1) {
+        int pair_dist = len;
+        int group = tid / pair_dist;
+        int local = tid % pair_dist;
+
+        int i = group * pair_dist * 2 + local;
+        int j = i + pair_dist;
+
+        float u = smem[i];
+        float v = smem[j];
+
+        smem[i] = u + v;
+        smem[j] = u - v;
+
+        __syncthreads();
+    }
+
+    dst_row[tid]         = smem[tid];
+    dst_row[tid + N / 2] = smem[tid + N / 2];
+}
+
+void ggml_cuda_forward_fwht_f32(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src1 = dst->src[1];
+
+    GGML_ASSERT(src1->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type  == GGML_TYPE_F32);
+
+    const int64_t n = src1->ne[0];
+    GGML_ASSERT((n & (n - 1)) == 0);
+    GGML_ASSERT(n <= 1024);
+
+    const int64_t nr = src1->ne[1] * src1->ne[2] * src1->ne[3];
+    const float scale = 1.0f / sqrtf((float)n);
+
+    const char * src1_data = (const char *) src1->data;
+    char * dst_data = (char *) dst->data;
+
+    cudaStream_t stream = ctx.stream();
+
+    dim3 blocks(nr);
+    dim3 threads(n / 2);
+
+    switch (n) {
+        case 64:
+            fwht_f32_kernel<64><<<blocks, threads, 0, stream>>>(
+                src1_data, dst_data, src1->ne[1], src1->ne[2],
+                src1->nb[1], src1->nb[2], src1->nb[3],
+                dst->nb[1], dst->nb[2], dst->nb[3], scale);
+            break;
+        case 128:
+            fwht_f32_kernel<128><<<blocks, threads, 0, stream>>>(
+                src1_data, dst_data, src1->ne[1], src1->ne[2],
+                src1->nb[1], src1->nb[2], src1->nb[3],
+                dst->nb[1], dst->nb[2], dst->nb[3], scale);
+            break;
+        case 256:
+            fwht_f32_kernel<256><<<blocks, threads, 0, stream>>>(
+                src1_data, dst_data, src1->ne[1], src1->ne[2],
+                src1->nb[1], src1->nb[2], src1->nb[3],
+                dst->nb[1], dst->nb[2], dst->nb[3], scale);
+            break;
+        default:
+            GGML_ABORT("FWHT CUDA: unsupported n %lld\n", (long long)n);
+    }
+}

--- a/ggml/src/ggml-cuda/fwht.cuh
+++ b/ggml/src/ggml-cuda/fwht.cuh
@@ -1,0 +1,4 @@
+#pragma once
+#include "common.cuh"
+
+void ggml_cuda_forward_fwht_f32(ggml_backend_cuda_context & ctx, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -23,6 +23,7 @@
 #include "ggml-cuda/diagmask.cuh"
 #include "ggml-cuda/diag.cuh"
 #include "ggml-cuda/fattn.cuh"
+#include "ggml-cuda/fwht.cuh"
 #include "ggml-cuda/getrows.cuh"
 #include "ggml-cuda/im2col.cuh"
 #include "ggml-cuda/mmf.cuh"
@@ -2383,6 +2384,12 @@ static bool ggml_cuda_should_fuse_mul_mat_vec_q(const ggml_tensor * tensor) {
 }
 
 static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
+    int32_t hint;
+    memcpy(&hint, dst->op_params, sizeof(int32_t));
+    if (hint == GGML_HINT_SRC0_IS_HADAMARD) {
+        ggml_cuda_forward_fwht_f32(ctx, dst);
+        return;
+    }
     const bool split = ggml_backend_buft_is_cuda_split(src0->buffer->buft);
 
     // If src0 is a temporary compute buffer it may have some padding that needs to be cleared for mul_mat_vec_q or mul_mat_q.


### PR DESCRIPTION
## Overview

This PR implements the CUDA backend for the Fast Walsh-Hadamard Transform (FWHT) for KV cache rotation, translating the CPU reference implementation from #22631.
Resolves #22759 for the `ggml-cuda` backend.

## Additional information

### Benchmarks
Tested on an NVIDIA GeForce RTX 4070 Laptop GPU / CUDA 8.9 / GCC 14. 
Model: Gemma-4-E4B (Q8_K_P)

**Q4_0 KV Cache:**

*Master (Baseline):*
| model | size | params | backend | ngl | type_k | type_v | fa | test | t/s |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q4_0 | q4_0 | 1 | pp512 | 1897.54 ± 138.68 |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q4_0 | q4_0 | 1 | tg128 | 42.02 ± 0.06 |

*This PR (CUDA FWHT):*
| model | size | params | backend | ngl | type_k | type_v | fa | test | t/s |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q4_0 | q4_0 | 1 | pp512 | 1813.74 ± 174.09 |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q4_0 | q4_0 | 1 | tg128 | 42.01 ± 0.04 |

**Q8_0 KV Cache:**

*Master (Baseline):*
| model | size | params | backend | ngl | type_k | type_v | fa | test | t/s |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q8_0 | q8_0 | 1 | pp512 | 2362.26 ± 207.33 |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q8_0 | q8_0 | 1 | tg128 | 42.47 ± 0.07 |

*This PR (CUDA FWHT):*
| model | size | params | backend | ngl | type_k | type_v | fa | test | t/s |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q8_0 | q8_0 | 1 | pp512 | 2051.80 ± 184.42 |
| gemma4 E4B Q8_0 | 7.56 GiB | 7.52 B | CUDA | 99 | q8_0 | q8_0 | 1 | tg128 | 42.36 ± 0.05 |

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Used an AI agent to assist in porting the C reference to CUDA kernel.
