### PR TITLE
mtmd-cli: load GPU backends before arg parsing to fix false 'no GPU' warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ a.out.*
 
 AGENTS.local.md
 .pi/SYSTEM.md
+CMakeUserPresets.json

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -283,6 +283,8 @@ int main(int argc, char ** argv) {
 
     common_init();
 
+    ggml_backend_load_all();
+
     if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_MTMD, show_additional_info)) {
         return 1;
     }
@@ -294,8 +296,6 @@ int main(int argc, char ** argv) {
         LOG_ERR("ERR: Missing --mmproj argument\n");
         return 1;
     }
-
-    ggml_backend_load_all();
 
     mtmd_cli_context ctx(params);
     LOG_INF("%s: loading model: %s\n", __func__, params.model.path.c_str());


### PR DESCRIPTION
## Problem

llama-mtmd-cli prints a misleading 'no usable GPU found' warning even when GPU backends are available and will be used later for inference. This happens because llama_supports_gpu_offload() is called during common_params_parse() (when processing --n_gpu_layers), but ggml_backend_load_all() has not been called yet.

## Fix

Move ggml_backend_load_all() to before common_params_parse() so that GPU backends (CUDA, Vulkan, Metal) are loaded and available when the --n_gpu_layers argument check runs.

## Testing

- Compiled with CUDA support on Windows with RTX 5070 Laptop GPU
- Before: prints 'no usable GPU found' warning
- After: GPU detected correctly, model loads and runs on GPU without false warning