### PR TITLE
webui: page title use app name variable

### DIFF
--- a/tools/server/webui/src/routes/(chat)/chat/[id]/+page.svelte
+++ b/tools/server/webui/src/routes/(chat)/chat/[id]/+page.svelte
@@ -10,6 +10,7 @@
 		activeMessages
 	} from '$lib/stores/conversations.svelte';
 	import { modelsStore, modelOptions, selectedModelId } from '$lib/stores/models.svelte';
+	import { APP_NAME } from '$lib/constants/ui';
 
 	let chatId = $derived(page.params.id);
 	let currentChatId: string | undefined = undefined;
@@ -166,7 +167,7 @@
 </script>
 
 <svelte:head>
-	<title>{activeConversation()?.name || 'Chat'} - llama.cpp</title>
+	<title>{activeConversation()?.name || 'Chat'} - {APP_NAME}</title>
 </svelte:head>
 
 <DialogModelNotAvailable


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

The webui page title it currently hardcoded to `llama.cpp`. Elsewhere in the code there is an APP_NAME variable which is used in labels. This PR changes the hardcoded page title to also depend on the APP_NAME variable.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

This can be tested by creating `tools/server/webui/.env` and adding a line `VITE_PUBLIC_APP_NAME=MyApp`.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Claude Sonnet was used to find and replace the hardcoded page title.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
