### PR TITLE
convert : fix RuntimeError when stripping FP8 KV-cache scales

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -710,7 +710,7 @@ class ModelBase:
                 self._repack_nvfp4(name, weight, scale, scale2, input_scale)
 
         # Flush any remaining experts (fallback if n_experts was unknown)
-        for bid, proj_type in expert_blocks.keys():
+        for bid, proj_type in list(expert_blocks.keys()):
             self._flush_nvfp4_experts((bid, proj_type), expert_blocks, expert_scales, expert_input_scales, expert_shapes, bid, proj_type)
 
         # Remove consumed tensors so get_tensors/modify_tensors won't see them

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -718,7 +718,7 @@ class ModelBase:
             self.model_tensors.pop(name, None)
 
         # Remove any remaining unused auxiliary tensors
-        for name in self.model_tensors.keys():
+        for name in list(self.model_tensors.keys()):
             if name.endswith((".k_scale", ".v_scale")):
                 del self.model_tensors[name]
 


### PR DESCRIPTION
## Bug

`convert_hf_to_gguf.py` raises `RuntimeError: dictionary changed size during iteration` for any ModelOpt-quantised NVFP4 checkpoint that also has FP8 KV-cache scales — e.g. [`mmangkad/Qwen3.6-35B-A3B-NVFP4`](https://huggingface.co/mmangkad/Qwen3.6-35B-A3B-NVFP4) (and any `hf_quant_config.json` with `kv_cache_quant_algo: FP8`).

```
File "convert_hf_to_gguf.py", line 721, in _generate_nvfp4_tensors
    for name in self.model_tensors.keys():
RuntimeError: dictionary changed size during iteration
```

## Cause

In `ModelBase._generate_nvfp4_tensors` the final cleanup loop iterates `self.model_tensors.keys()` while calling `del self.model_tensors[name]` on the same dict. As soon as the first `.k_scale` / `.v_scale` tensor is found, the iterator invalidates.

The earlier loops in the same function avoid this by collecting names into `consumed` and popping them after iteration; this trailing loop was missed.

## Fix

Wrap `.keys()` in `list()` so the deletions happen against a snapshot. One-line change.

## Repro

```bash
hf download mmangkad/Qwen3.6-35B-A3B-NVFP4 --local-dir model-nvfp4
python convert_hf_to_gguf.py model-nvfp4 --outfile out.gguf --outtype auto
```

Without the patch: crashes after repacking experts. With the patch: writes `out.gguf` cleanly (973 tensors, 22 GB). Verified the resulting GGUF loads in `llama-bench` / `llama-perplexity` and gives sensible results on RTX PRO 4000 Blackwell (sm_120, native NVFP4).