### PR TITLE
CUDA: lower-case PCI bus id, standardize for ggml

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -169,7 +169,7 @@ extern "C" {
         // device type
         enum ggml_backend_dev_type type;
         // device id
-        //   for PCI devices, this should be the PCI bus id formatted as "domain:bus:device.function" (e.g. "0000:01:00.0")
+        //   for PCI devices, this should be the lower-case PCI bus id formatted as "domain:bus:device.function" (e.g. "0000:c1:00.0")
         //   if the id is unknown, this should be NULL
         const char * device_id;
         // device capabilities

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5434,6 +5434,9 @@ ggml_backend_reg_t ggml_backend_cuda_reg() {
                 char pci_bus_id[32] = {};
                 CUDA_CHECK(cudaDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), i));
                 dev_ctx->pci_bus_id = pci_bus_id;
+                for (char & c : dev_ctx->pci_bus_id) {
+                    c = std::tolower(c);
+                }
                 dev_ctx->op_offload_min_batch_size = min_batch_size;
 
                 ggml_backend_dev_t dev = new ggml_backend_device {


### PR DESCRIPTION
See https://github.com/ggml-org/llama.cpp/pull/22533#issuecomment-4382705046 . 

The function `cudaDeviceGetPCIBusId` can print upper-case hexadecimal characters which then does not match the PCI bus ID string as it was used previously and also does not match the PCI bus ID string as used by the Vulkan backend. This PR replaces the upper-case characters with lower-case characters and makes the PCI bus ID being lower-case part of the spec in `ggml-backend.h` - this was left undefined until now. Lower-case seems to be the more common standard and in particular it is the standard that is used on Linux where capitalization matters for e.g. the files in `/sys/bus/pci/devices`.

@lucyknada @csoren please confirm whether or not you are still having issues with this version.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No
