### PR TITLE
ggml: update SCHED_DEBUG output to use ggml_op_desc()

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -965,7 +965,7 @@ static void ggml_backend_sched_print_assignments(ggml_backend_sched_t sched, str
         }
         if (sched->debug > 1) {
             ggml_backend_t tensor_backend = ggml_backend_sched_get_tensor_backend(sched, node);
-            GGML_LOG_DEBUG("node #%3d (%10.10s): %20.20s (%5.5s) [%5.5s %8.8s] use=%d,c=%d:", i, ggml_op_name(node->op), node->name,
+            GGML_LOG_DEBUG("node #%3d (%10.10s): %20.20s (%5.5s) [%5.5s %8.8s] use=%d,c=%d:", i, ggml_op_desc(node), node->name,
                 fmt_size(ggml_nbytes(node)), tensor_backend ? ggml_backend_name(tensor_backend) : "NULL", GET_CAUSE(node),
                 graph->use_counts[ggml_hash_find(&graph->visited_hash_set, node)], node->flags & GGML_TENSOR_FLAG_COMPUTE ? 1 : 0);
             for (int j = 0; j < GGML_MAX_SRC; j++) {


### PR DESCRIPTION
## Overview

Update SCHED_DEBUG format to use ggml_op_desc(). 
Makes the output more readable for UNARY and GLU ops.

```
node # 28 (     UNARY):   conv_output_silu-0 (  24K) [  CPU   ] use=3,c=1:    conv_output_raw-0 (  24K) [ HTP0 ]
```

```
node # 28 (      SILU):   conv_output_silu-0 (  24K) [  CPU   ] use=3,c=1:    conv_output_raw-0 (  24K) [ HTP0 ]
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
