### PR TITLE
server: preserve context checkpoint coverage

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1833,13 +1833,34 @@ private:
     // n_tokens_cur: the number of tokens added to the batch for the current slot
     void create_checkpoint(server_slot & slot, const int64_t n_tokens_cur, llama_pos pos_min, llama_pos pos_max) {
         while (slot.prompt.checkpoints.size() >= (size_t) params_base.n_ctx_checkpoints) {
-            // make room for the new checkpoint, if needed
-            const auto & cur = slot.prompt.checkpoints.front();
+            auto & checkpoints = slot.prompt.checkpoints;
 
-            SLT_WRN(slot, "erasing old context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
-                    cur.pos_min, cur.pos_max, cur.n_tokens, (float) cur.data.size() / 1024 / 1024);
+            auto erase_it = checkpoints.begin();
 
-            slot.prompt.checkpoints.erase(slot.prompt.checkpoints.begin());
+            if (checkpoints.size() >= 3) {
+                auto prev = checkpoints.begin();
+                auto it   = prev; ++it;
+                auto next = it;   ++next;
+
+                erase_it = it;
+                llama_pos best_gap = next->n_tokens - prev->n_tokens;
+
+                for (; next != checkpoints.end(); ++prev, ++it, ++next) {
+                    const llama_pos gap = next->n_tokens - prev->n_tokens;
+
+                    if (gap < best_gap) {
+                        best_gap = gap;
+                        erase_it = it;
+                    }
+                }
+            }
+
+            const auto & old = *erase_it;
+
+            SLT_WRN(slot, "erasing redundant context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
+                    old.pos_min, old.pos_max, old.n_tokens, (float) old.data.size() / 1024 / 1024);
+
+            checkpoints.erase(erase_it);
         }
 
         auto & cur = slot.prompt.checkpoints.emplace_back();


### PR DESCRIPTION
Instead of always removing the oldest context checkpoint when the checkpoint limit is reached, remove the checkpoint that appears most redundant based on the distance between its neighbors.

## Overview

This is my attempt to fix `forcing full prompt re-processing due to lack of cache data`

This changes the checkpoint removal policy: when the limit is reached, it removes an interior checkpoint whose neighboring checkpoints are closest together.

## Additional information

I use the following arguments: `--ctx-checkpoints 24 --checkpoint-every-n-tokens 8192 --cache-ram 65536`

After just a few prompts in a pi coding agent, I see:

```
slot launch_slot_: id  0 | task 6130 | processing task, is_child = 0
slot update_slots: id  0 | task 6130 | new prompt, n_ctx_slot = 200192, n_keep = 4096, task.n_tokens = 31544
slot update_slots: id  0 | task 6130 | n_past = 3579, slot.prompt.tokens.size() = 33081, seq_id = 0, pos_min = 33080, n_swa = 0
slot update_slots: id  0 | task 6130 | Checking checkpoint with [32656, 32656] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [32531, 32531] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [32436, 32436] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [32361, 32361] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [31837, 31837] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [31325, 31325] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [30750, 30750] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [30660, 30660] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [30473, 30473] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [30371, 30371] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [30008, 30008] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [29496, 29496] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [29027, 29027] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [28942, 28942] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [28830, 28830] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [28278, 28278] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [27757, 27757] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [27188, 27188] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [26676, 26676] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [23367, 23367] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [23187, 23187] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [21341, 21341] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [20918, 20918] against 3579...
slot update_slots: id  0 | task 6130 | Checking checkpoint with [20479, 20479] against 3579...
slot update_slots: id  0 | task 6130 | forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
```

the server needed a checkpoint around `n_past = 3579`, but all available checkpoints were much later, from `20479` to `32656`, causing full prompt re-processing.

The root cause seems to be that checkpoints are not only created at the `--checkpoint-every-n-tokens` interval. Additional checkpoints can be created near prompt/request boundaries, and with the previous FIFO removal policy these dense recent checkpoints can erase older checkpoints.

I first tried disabling the additional checkpoint creation, but that did not work well. 

I tested this change with `--ctx-checkpoints 8` to trigger checkpoint removal sooner and I could not reproduce the `forcing full prompt re-processing due to lack of cache data`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - initial research and final code polish