### PR TITLE
server: Improve get_datetime tool to return structured ISO-8601 JSON

### DIFF
--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -11,6 +11,8 @@
 #include <cstring>
 #include <climits>
 #include <algorithm>
+#include <ctime>
+#include <string>
 
 namespace fs = std::filesystem;
 
@@ -710,16 +712,34 @@ struct server_tool_get_datetime : server_tool {
             {"type", "function"},
             {"function", {
                 {"name", name},
-                {"description", "Returns the current date and time"},
+                {"description", "Returns current date and time as structured JSON with ISO-8601 format, timezone, and weekday"},
             }},
         };
     }
 
     json invoke(json) override {
-        auto now = std::chrono::system_clock::now();
-        auto time = std::chrono::system_clock::to_time_t(now);
+        using namespace std::chrono;
 
-        return {{"result", std::ctime(&time)}};
+        auto t = system_clock::to_time_t(system_clock::now());
+        tm local{};
+
+        #ifdef _WIN32
+            localtime_s(&local, &t);
+        #else
+            localtime_r(&t, &local);
+        #endif 
+
+
+        char iso[64], wday[32], zone[64];
+        strftime(iso,  sizeof(iso),  "%Y-%m-%dT%H:%M:%S%z", &local);
+        strftime(wday, sizeof(wday), "%A", &local);
+        strftime(zone, sizeof(zone), "%Z", &local);
+
+        std::string s = iso;
+        if (s.size() >= 5 && (s[s.size()-5] == '+' || s[s.size()-5] == '-'))
+            s.insert(s.end()-2, ':');
+
+        return {{"datetime_iso", s}, {"timezone", zone}, {"weekday", wday}};
     }
 };
 


### PR DESCRIPTION
## Overview

This PR improves the `get_datetime` server tool originally introduced in [#22649](https://github.com/ggml-org/llama.cpp/pull/22649). Instead of returning a raw, unstructured C-style time string via `std::ctime()`, it now returns a structured JSON object containing:
- `datetime_iso`: ISO 8601 formatted date and time with timezone offset
- `timezone`: Abbreviated timezone name (e.g., UTC, CEST, EST)
- `weekday`: Full weekday name

### 🔀 Before vs After
**Old output:**
```json
{ "result": "Fri May 08 16:45:59 2026\n" }
```

**New output:**
```json
{
  "datetime_iso": "2026-05-08T16:45:59+02:00",
  "timezone": "CEST",
  "weekday": "Friday"
}
```

## 💡 Why this change?
This improves the output structure by replacing the raw C-style string with a clean JSON object. The new format is richer and more consistent, providing an ISO 8601 timestamp alongside timezone and weekday information, which makes it much easier for LLMs and downstream applications to parse and use reliably.

## 📎 References
- Original implementation: [#22649](https://github.com/ggml-org/llama.cpp/pull/22649)

---
<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I used AI to verify Windows compatibility and to write this PR description
