### PR TITLE
test-backend-ops: add more fields to csv output.

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1093,6 +1093,15 @@ struct csv_printer : public printer {
             "test_mode",
             "backend_reg_name",
             "backend_name",
+            "test_time",
+            "build_commit",
+            "passed",
+            "time_us",
+            "flops",
+            "bandwidth_gb_s",
+            "memory_kb",
+            "n_runs",
+            "device_description",
         };
     }
 


### PR DESCRIPTION
## Overview

Currently, csv output at `test-backend-ops` binary doesn't report time/tflops/nruns/etc, which makes it not very helpful for automated perf evaluation.
Here I add fields from sql output to csv.

## Additional information

Example run: `./build/bin/test-backend-ops perf -o MUL_MAT_ID -p "type_a=mxfp4" --output csv`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
