### PR TITLE
cli: Add quiet mode

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -438,9 +438,6 @@ static bool parse_bool_value(const std::string & value) {
 static bool common_params_parse_ex(int argc, char ** argv, common_params_context & ctx_arg) {
     common_params & params = ctx_arg.params;
 
-    // setup log directly from params.verbosity: see tools/cli/cli.cpp
-    common_log_set_verbosity_thold(params.verbosity);
-
     std::unordered_map<std::string, std::pair<common_arg *, bool>> arg_to_options;
     for (auto & opt : ctx_arg.options) {
         for (const auto & arg : opt.args) {
@@ -1021,6 +1018,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     } else if (ex == LLAMA_EXAMPLE_SERVER) {
         params.n_parallel = -1;     // auto by default
     }
+
+    // Set log verbosity before other functions (they might log).
+    common_log_set_verbosity_thold(params.verbosity);
 
     params.use_color = tty_can_use_colors();
 

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1525,6 +1525,15 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
+        {"-q", "--quiet"},
+        "suppress non-model output (banner, loading messages, prompts, etc.)\n"
+        "only model-generated text is printed to stdout\n"
+        "(default: false)",
+        [](common_params & params) {
+            params.quiet = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_CLI}));
+    add_opt(common_arg(
         {"-i", "--interactive"},
         string_format("run in interactive mode (default: %s)", params.interactive ? "true" : "false"),
         [](common_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -554,6 +554,7 @@ struct common_params {
     bool no_host           = false; // bypass host buffer allowing extra buffers to be used
 
     bool single_turn       = false; // single turn chat conversation
+    bool quiet             = false; // suppress non-model output (banner, prompts, etc.)
 
     ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K
     ggml_type cache_type_v = GGML_TYPE_F16; // KV cache data type for the V

--- a/common/console.cpp
+++ b/common/console.cpp
@@ -69,6 +69,7 @@ namespace console {
 
     static bool         advanced_display = false;
     static bool         simple_io        = true;
+    static bool         quiet            = false;
     static display_type current_display  = DISPLAY_TYPE_RESET;
 
     static FILE*        out              = stdout;
@@ -1107,7 +1108,7 @@ namespace console {
         }
         void start() {
             std::unique_lock<std::mutex> lock(mtx);
-            if (simple_io || running) {
+            if (simple_io || quiet || running) {
                 return;
             }
             common_log_flush(common_log_main());
@@ -1143,7 +1144,21 @@ namespace console {
         }
     }
 
+    void set_quiet(bool value) {
+        quiet = value;
+    }
+
     void log(const char * fmt, ...) {
+        if (quiet) {
+            return;
+        }
+        va_list args;
+        va_start(args, fmt);
+        vfprintf(out, fmt, args);
+        va_end(args);
+    }
+
+    void output(const char * fmt, ...) {
         va_list args;
         va_start(args, fmt);
         vfprintf(out, fmt, args);

--- a/common/console.h
+++ b/common/console.h
@@ -31,13 +31,22 @@ namespace console {
         void stop();
     }
 
+    // Enable/disable quiet mode. When quiet, log() is suppressed but output() still prints.
+    void set_quiet(bool quiet);
+
     // note: the logging API below output directly to stdout
     // it can negatively impact performance if used on inference thread
     // only use in in a dedicated CLI thread
     // for logging in inference thread, use log.h instead
 
+    // Informational/chrome messages (banner, prompts, status).
+    // Suppressed when quiet mode is enabled via set_quiet(true).
     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
     void log(const char * fmt, ...);
+
+    // Model-generated output. Always printed regardless of quiet mode.
+    LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
+    void output(const char * fmt, ...);
 
     LLAMA_COMMON_ATTRIBUTE_FORMAT(1, 2)
     void error(const char * fmt, ...);

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -151,21 +151,21 @@ struct cli_context {
                 for (const auto & diff : res_partial->oaicompat_msg_diffs) {
                     if (!diff.content_delta.empty()) {
                         if (is_thinking) {
-                            console::log("\n[End thinking]\n\n");
+                            console::output("\n[End thinking]\n\n");
                             console::set_display(DISPLAY_TYPE_RESET);
                             is_thinking = false;
                         }
                         curr_content += diff.content_delta;
-                        console::log("%s", diff.content_delta.c_str());
+                        console::output("%s", diff.content_delta.c_str());
                         console::flush();
                     }
                     if (!diff.reasoning_content_delta.empty()) {
                         console::set_display(DISPLAY_TYPE_REASONING);
                         if (!is_thinking) {
-                            console::log("[Start thinking]\n");
+                            console::output("[Start thinking]\n");
                         }
                         is_thinking = true;
-                        console::log("%s", diff.reasoning_content_delta.c_str());
+                        console::output("%s", diff.reasoning_content_delta.c_str());
                         console::flush();
                     }
                 }
@@ -368,6 +368,8 @@ int main(int argc, char ** argv) {
     // TODO: avoid using atexit() here by making `console` a singleton
     console::init(params.simple_io, params.use_color);
     atexit([]() { console::cleanup(); });
+
+    console::set_quiet(params.quiet);
 
     console::set_display(DISPLAY_TYPE_RESET);
     console::set_completion_callback(auto_completion_callback);
@@ -624,7 +626,7 @@ int main(int argc, char ** argv) {
             {"role",    "assistant"},
             {"content", assistant_content}
         });
-        console::log("\n");
+        console::output("\n"); // final newline after model output
 
         if (params.show_timings) {
             console::set_display(DISPLAY_TYPE_INFO);
@@ -645,8 +647,10 @@ int main(int argc, char ** argv) {
     inference_thread.join();
 
     // bump the log level to display timings
-    common_log_set_verbosity_thold(LOG_LEVEL_INFO);
-    common_memory_breakdown_print(ctx_cli.ctx_server.get_llama_context());
+    if (!params.quiet) {
+        common_log_set_verbosity_thold(LOG_LEVEL_INFO);
+        common_memory_breakdown_print(ctx_cli.ctx_server.get_llama_context());
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Overview

Allows to get just model output. Fixes #8507.

See also https://github.com/ggml-org/llama.cpp/discussions/777#discussioncomment-16855281

This was impossible until now:

* The banner was always printed: https://github.com/ggml-org/llama.cpp/issues/8507#issuecomment-4408729309
* `llama-mtmd-cli` has silent output but does not support `--reasoning off`.
* `llama-completion` does not support `--image`.

## Additional information

* I tested this on top of version `8983` because that's the one currently in `nixpkgs` that I can test best, in a sandboxed build.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I used Claude Opus 4.6 to implement the new flag. I reviewed and tested the code.