### PR TITLE
server : fix n_predict=-2 (generate until context full)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -277,10 +277,13 @@ struct server_slot {
 
         n_remaining = -1;
 
-        if (task->params.n_predict != -1) {
-            n_remaining = task->params.n_predict - n_decoded;
-        } else if (global_params.n_predict != -1) {
-            n_remaining = global_params.n_predict - n_decoded;
+        const int32_t n_predict = task->params.n_predict != -1 ? task->params.n_predict : global_params.n_predict;
+
+        if (n_predict == -2) {
+            // generate until context is full
+            n_remaining = n_ctx - prompt.n_tokens();
+        } else if (n_predict >= 0) {
+            n_remaining = n_predict - n_decoded;
         }
 
         return n_remaining > 0; // no budget
@@ -2173,6 +2176,22 @@ private:
                     send_error(slot, "context shift is disabled", ERROR_TYPE_SERVER);
                     slot.release();
                     continue;
+                }
+
+                // n_predict == -2: context exhaustion is the limit, do not shift
+                {
+                    const int32_t n_predict = slot.task->params.n_predict != -1 ? slot.task->params.n_predict : params_base.n_predict;
+                    if (n_predict == -2) {
+                        SLT_DBG(slot, "stopped by n_predict = -2 (context full), prompt.n_tokens() = %d, n_decoded = %d, n_ctx = %d\n",
+                                slot.prompt.n_tokens(), slot.n_decoded, slot.n_ctx);
+                        slot.stop      = STOP_TYPE_LIMIT;
+                        slot.truncated = true;
+                        slot.print_timings();
+                        send_final_response(slot);
+                        metrics.on_prediction(slot);
+                        slot.release();
+                        continue;
+                    }
                 }
 
                 if (mctx) {

--- a/tools/server/tests/unit/test_ctx_shift.py
+++ b/tools/server/tests/unit/test_ctx_shift.py
@@ -87,3 +87,44 @@ def test_ctx_shift_disabled_stream():
         else:
             assert choice["finish_reason"] is None
             content += choice["text"]
+
+
+@pytest.mark.parametrize("endpoint,n_predict_key", [
+    ("/completion", "n_predict"),
+    ("/v1/completions", "max_tokens"),
+])
+def test_n_predict_minus_2(endpoint: str, n_predict_key: str):
+    """n_predict == -2: generate until context is full, then stop (no ctx shift)."""
+    global server
+    server.n_predict = -1  # global: unlimited, request-level -2 overrides
+    server.enable_ctx_shift = True  # enabled, but -2 should stop instead of shifting
+    server.start()
+    res = server.make_request("POST", endpoint, data={
+        n_predict_key: -2,
+        "prompt": "Hi how are you",
+    })
+    assert res.status_code == 200
+    # "Hi how are you" is 8 tokens, slot ctx = 512/2 = 256, expect ~248 generated
+    if "timings" in res.body:
+        n_predicted = res.body["timings"]["predicted_n"]
+        assert res.body["truncated"] is True
+        assert res.body["stopped_limit"] is True
+    else:
+        n_predicted = res.body["usage"]["completion_tokens"]
+    assert n_predicted == 248, f"n_predict=-2 should fill context (expected 248), got {n_predicted}"
+
+
+def test_n_predict_minus_2_global():
+    """n_predict == -2 set globally (via server CLI) should also work."""
+    global server
+    server.n_predict = -2
+    server.enable_ctx_shift = True
+    server.start()
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "Hi how are you",
+    })
+    assert res.status_code == 200
+    n_predicted = res.body["timings"]["predicted_n"]
+    assert res.body["truncated"] is True
+    assert res.body["stopped_limit"] is True
+    assert n_predicted == 248, f"global n_predict=-2 should fill context (expected 248), got {n_predicted}"


### PR DESCRIPTION
## Overview

Fixes #9933

`n_predict=-2` should generate tokens until the context is full, then stop. Currently, the server ignores this value and defaults to unlimited generation with context shifting, producing unexpected output lengths.

Two changes:

1. **Budget calculation** (`has_budget`): when `n_predict == -2`, set `n_remaining = n_ctx - prompt_tokens` instead of falling through to the unlimited path.

2. **Context shift guard** (`update_slots`): when `n_predict == -2` and the context is full, stop generation with `STOP_TYPE_LIMIT` + `truncated = true` instead of triggering a context shift.

The per-request parameter takes priority over the global `--n-predict` flag.

See also #9938 (earlier partial attempt).

## Additional information

Tests in `tools/server/tests/unit/test_ctx_shift.py`:
- `test_n_predict_minus_2` — per-request `-2` via `/completion` and `/v1/completions`
- `test_n_predict_minus_2_global` — global `-2` via server CLI flag

Both verify that generation stops at exactly `n_ctx - prompt_tokens` with `truncated=true` and `stopped_limit=true`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — used Claude for initial implementation, then reviewed and tested manually.