### PR TITLE
cli: exit conversation mode on stdin EOF

### DIFF
--- a/common/console.cpp
+++ b/common/console.cpp
@@ -67,9 +67,10 @@ namespace console {
     //
 #endif
 
-    static bool         advanced_display = false;
-    static bool         simple_io        = true;
-    static display_type current_display  = DISPLAY_TYPE_RESET;
+    static bool         advanced_display  = false;
+    static bool         simple_io         = true;
+    static bool         last_readline_eof = false;
+    static display_type current_display   = DISPLAY_TYPE_RESET;
 
     static FILE*        out              = stdout;
 
@@ -751,6 +752,8 @@ namespace console {
     } history;
 
     static bool readline_advanced(std::string & line, bool multiline_input) {
+        last_readline_eof = false;
+
         if (out != stdout) {
             fflush(stdout);
         }
@@ -810,6 +813,7 @@ namespace console {
 
             if (input_char == (char32_t) WEOF || input_char == 0x04 /* Ctrl+D */) {
                 end_of_stream = true;
+                last_readline_eof = true;
                 break;
             }
 
@@ -1044,11 +1048,14 @@ namespace console {
     }
 
     static bool readline_simple(std::string & line, bool multiline_input) {
+        last_readline_eof = false;
+
 #if defined(_WIN32)
         std::wstring wline;
         if (!std::getline(std::wcin, wline)) {
             // Input stream is bad or EOF received
             line.clear();
+            last_readline_eof = true;
             GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0);
             return false;
         }
@@ -1060,6 +1067,7 @@ namespace console {
         if (!std::getline(std::cin, line)) {
             // Input stream is bad or EOF received
             line.clear();
+            last_readline_eof = true;
             return false;
         }
 #endif
@@ -1085,6 +1093,10 @@ namespace console {
             return readline_simple(line, multiline_input);
         }
         return readline_advanced(line, multiline_input);
+    }
+
+    bool readline_eof() {
+        return last_readline_eof;
     }
 
     void set_completion_callback(completion_callback cb) {

--- a/common/console.h
+++ b/common/console.h
@@ -22,6 +22,7 @@ namespace console {
     void cleanup();
     void set_display(display_type display);
     bool readline(std::string & line, bool multiline_input);
+    bool readline_eof();
 
     using completion_callback = std::function<std::vector<std::pair<std::string, size_t>>(std::string_view, size_t)>;
     void set_completion_callback(completion_callback cb);

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -468,6 +468,7 @@ int main(int argc, char ** argv) {
 
     while (true) {
         std::string buffer;
+        bool input_eof = false;
         console::set_display(DISPLAY_TYPE_USER_INPUT);
         if (params.prompt.empty()) {
             console::log("\n> ");
@@ -475,7 +476,11 @@ int main(int argc, char ** argv) {
             bool another_line = true;
             do {
                 another_line = console::readline(line, params.multiline_input);
+                input_eof = console::readline_eof();
                 buffer += line;
+                if (input_eof) {
+                    break;
+                }
             } while (another_line);
         } else {
             // process input prompt from args
@@ -511,6 +516,9 @@ int main(int argc, char ** argv) {
 
         // skip empty messages
         if (buffer.empty()) {
+            if (input_eof) {
+                break;
+            }
             continue;
         }
 
@@ -633,7 +641,7 @@ int main(int argc, char ** argv) {
             console::set_display(DISPLAY_TYPE_RESET);
         }
 
-        if (params.single_turn) {
+        if (params.single_turn || input_eof) {
             break;
         }
     }


### PR DESCRIPTION
## Overview
This PR fixes a small `llama-cli -cnv` input handling issue: When stdin reaches EOF, `console::readline()` returns `false` with an empty line. So the CLI will treats it like the user just pressed "Enter" and it keeps printing '>' forever.

This PR makes the console layer remember whether the last readline hit EOF, so llama-cli can exit cleanly while still preserving normal empty-input behavior.

## Additional information
You can reproduce this bug by:
```bash
MODEL=/path/to/yout/model.gguf

rm -f /tmp/eof.out /tmp/eof.err
timeout 30 bash -c './build/bin/llama-cli -m "$0" -ngl 0 -t 2 -c 512 --no-warmup -n 0 -cnv < /dev/null 2> /tmp/eof.err | head -n 120 > /tmp/eof.out' "$MODEL"
echo "prompt_count=$(rg -c '^> ' /tmp/eof.out || true)"
tail -n 30 /tmp/eof.out
```
After this patch, empty user input still continues normally and no ggml or backend code is changed in this PR.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - codex 5.5 was only used to help investigate the reproduction and check coding style.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
