### PR TITLE
sycl: add TQ1_0 / TQ2_0 dequant fallback (fix ternary model crash)

### DIFF
--- a/ggml/src/ggml-sycl/convert.cpp
+++ b/ggml/src/ggml-sycl/convert.cpp
@@ -338,6 +338,40 @@ static void dequantize_row_iq1_m_sycl(const void *vx, dst_t *y, const int64_t k,
 }
 
 template <typename dst_t>
+static void dequantize_row_tq2_0_sycl(const void * vx, dst_t * y, const int64_t k,
+                                      dpct::queue_ptr stream) {
+    const int64_t nb = k / QK_K;
+    {
+        dpct::has_capability_or_fail(stream->get_device(), {sycl::aspect::fp16});
+
+        stream->submit([&](sycl::handler &cgh) {
+            cgh.parallel_for(sycl::nd_range<3>(sycl::range<3>(1, 1, nb) * sycl::range<3>(1, 1, 32),
+                                               sycl::range<3>(1, 1, 32)),
+                             [=](sycl::nd_item<3> item_ct1) {
+                                 dequantize_block_tq2_0(vx, y, item_ct1);
+                             });
+        });
+    }
+}
+
+template <typename dst_t>
+static void dequantize_row_tq1_0_sycl(const void * vx, dst_t * y, const int64_t k,
+                                      dpct::queue_ptr stream) {
+    const int64_t nb = k / QK_K;
+    {
+        dpct::has_capability_or_fail(stream->get_device(), {sycl::aspect::fp16});
+
+        stream->submit([&](sycl::handler &cgh) {
+            cgh.parallel_for(sycl::nd_range<3>(sycl::range<3>(1, 1, nb) * sycl::range<3>(1, 1, 32),
+                                               sycl::range<3>(1, 1, 32)),
+                             [=](sycl::nd_item<3> item_ct1) {
+                                 dequantize_block_tq1_0(vx, y, item_ct1);
+                             });
+        });
+    }
+}
+
+template <typename dst_t>
 static void dequantize_row_iq2_xxs_sycl(const void *vx, dst_t *y, const int64_t k,
                                         dpct::queue_ptr stream) {
     const int64_t nb = k / QK_K;
@@ -668,6 +702,10 @@ to_fp16_sycl_t ggml_get_to_fp16_sycl(ggml_type type, ggml_tensor * dst) {
             return dequantize_row_iq4_xs_sycl;
         case GGML_TYPE_IQ4_NL:
             return dequantize_row_iq4_nl_sycl;
+        case GGML_TYPE_TQ1_0:
+            return dequantize_row_tq1_0_sycl;
+        case GGML_TYPE_TQ2_0:
+            return dequantize_row_tq2_0_sycl;
         case GGML_TYPE_MXFP4:
             return dequantize_row_mxfp4_sycl;
         case GGML_TYPE_NVFP4:
@@ -743,6 +781,10 @@ to_fp32_sycl_t ggml_get_to_fp32_sycl(ggml_type type, ggml_tensor *dst) {
             return dequantize_row_iq4_xs_sycl;
         case GGML_TYPE_IQ4_NL:
             return dequantize_row_iq4_nl_sycl;
+        case GGML_TYPE_TQ1_0:
+            return dequantize_row_tq1_0_sycl;
+        case GGML_TYPE_TQ2_0:
+            return dequantize_row_tq2_0_sycl;
         case GGML_TYPE_MXFP4:
             return dequantize_row_mxfp4_sycl;
         case GGML_TYPE_NVFP4:

--- a/ggml/src/ggml-sycl/dequantize.hpp
+++ b/ggml/src/ggml-sycl/dequantize.hpp
@@ -823,6 +823,93 @@ dequantize_block_iq1_m(const void *__restrict__ vx, dst_t *__restrict__ yy,
 
 template <typename dst_t>
 __dpct_inline__ static void
+dequantize_block_tq2_0(const void * __restrict__ vx, dst_t * __restrict__ yy,
+                       const sycl::nd_item<3> & item_ct1) {
+
+    const int64_t i = item_ct1.get_group(2);
+    const block_tq2_0 * x = (const block_tq2_0 *) vx;
+
+    const int64_t tid = item_ct1.get_local_id(2);  // 0..31
+    const float d = (float) x[i].d;
+
+    // 256 outputs per block, 32 threads, 8 outputs/thread.
+    // Thread tid handles outputs at indices {tid + g*32 : g = 0..7}.
+    // For output g*32+tid: source byte qs[(g/4)*32 + tid], shift (g%4)*2, code in {0,1,2,3}.
+    dst_t * y = yy + i * QK_K + tid;
+#pragma unroll
+    for (int g = 0; g < 8; ++g) {
+        const int jq = ((g >> 2) << 5) | tid;
+        const int sh = (g & 3) << 1;
+        const int code = (int) ((x[i].qs[jq] >> sh) & 0x3);
+        y[g * 32] = (dst_t) ((float) (code - 1) * d);
+    }
+}
+
+template <typename dst_t>
+__dpct_inline__ static void
+dequantize_block_tq1_0(const void * __restrict__ vx, dst_t * __restrict__ yy,
+                       const sycl::nd_item<3> & item_ct1) {
+
+    const int64_t i = item_ct1.get_group(2);
+    const block_tq1_0 * x = (const block_tq1_0 *) vx;
+
+    const int64_t tid = item_ct1.get_local_id(2);  // 0..31
+    const float d = (float) x[i].d;
+
+    // Per QK_K=256 block, three output regions (matches CPU dequantize_row_tq1_0):
+    //   A: out [  0, 160) -- byte qs[m]    , m=tid    , n in 0..4
+    //   B: out [160, 240) -- byte qs[32+m] , m=0..15  , n in 0..4
+    //   C: out [240, 256) -- byte qh[j]    , j=0..3   , n in 0..3
+    // Encoding: q = (byte * pow3[n]) & 0xFF; xi = (q * 3) >> 8; value = (xi - 1) * d, xi in {0,1,2}.
+    // Each thread handles 8 outputs at indices {tid + g*32 : g = 0..7}.
+
+    const uint16_t pow3[5] = { 1, 3, 9, 27, 81 };
+
+    auto decode = [&](const uint8_t byte, const int n) -> int {
+        const uint8_t q = (uint8_t) ((uint16_t) byte * pow3[n]);  // 8-bit truncation matches CPU ref
+        return (int) (((uint16_t) q * 3) >> 8) - 1;               // result in {-1, 0, +1}
+    };
+
+    dst_t * y = yy + i * QK_K;
+
+    // g = 0..4: region A, out = g*32 + tid, byte = qs[tid], n = g.
+#pragma unroll
+    for (int g = 0; g < 5; ++g) {
+        const int xi = decode(x[i].qs[tid], g);
+        y[g * 32 + tid] = (dst_t) ((float) xi * d);
+    }
+
+    // g = 5: out = 160..191 (region B); n = 0 (tid<16) or 1 (tid>=16); m = tid % 16.
+    {
+        const int n  = (tid < 16) ? 0 : 1;
+        const int m  = (int) (tid & 15);
+        const int xi = decode(x[i].qs[32 + m], n);
+        y[160 + tid] = (dst_t) ((float) xi * d);
+    }
+    // g = 6: out = 192..223 (region B); n = 2 (tid<16) or 3.
+    {
+        const int n  = (tid < 16) ? 2 : 3;
+        const int m  = (int) (tid & 15);
+        const int xi = decode(x[i].qs[32 + m], n);
+        y[192 + tid] = (dst_t) ((float) xi * d);
+    }
+    // g = 7: out = 224..255; tid<16 region B n=4, tid>=16 region C.
+    {
+        int xi;
+        if (tid < 16) {
+            xi = decode(x[i].qs[32 + tid], 4);
+        } else {
+            const int local = (int) (tid - 16);  // 0..15
+            const int n     = local >> 2;        // 0..3
+            const int j     = local & 3;         // 0..3
+            xi = decode(x[i].qh[j], n);
+        }
+        y[224 + tid] = (dst_t) ((float) xi * d);
+    }
+}
+
+template <typename dst_t>
+__dpct_inline__ static void
 dequantize_block_iq4_nl(const void *__restrict__ vx, dst_t *__restrict__ yy,
                         const sycl::nd_item<3> &item_ct1) {
 

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -3663,6 +3663,11 @@ static bool can_use_dequantize_mul_mat_vec(const ggml_tensor * src0, const ggml_
 }
 
 static bool can_use_mul_mat_vec_q(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
+    // TQ1_0 / TQ2_0 have no native mul_mat_vec_q8_1 kernel; route them through the
+    // dequantize -> FP16 fallback path instead of crashing in the MMVQ dispatch.
+    if (src0->type == GGML_TYPE_TQ1_0 || src0->type == GGML_TYPE_TQ2_0) {
+        return false;
+    }
     return ggml_is_quantized(src0->type) && src1->type == GGML_TYPE_F32 && dst->type == GGML_TYPE_F32 &&
            src1->ne[1] <= MMVQ_MAX_BATCH_SIZE;
 }


### PR DESCRIPTION
## Summary

- Fixes a hard abort when loading a TQ1_0 or TQ2_0 quantized model on the SYCL backend (`fatal error: unsupport data type=tq2_0` in `convert.cpp` and `mmvq.cpp`)
- Adds SYCL dequant kernels for both formats, mirroring the generic dequant→FP16 path that Vulkan already uses (no native `mul_mat_vec_q8_1` kernel for TQ exists in any GPU backend upstream)
- MMVQ dispatch is bypassed for TQ types so they fall through to `ggml_sycl_op_mul_mat_sycl` + the new dequant

## Why

BitNet b1.58 ternary models are distributed as TQ2_0 GGUF and currently crash on first decode when loaded with the SYCL backend. Vulkan, CUDA, and Metal all handle this via the generic `to_float` dequant path. SYCL was the only GPU backend without an equivalent fallback.

This is a **fallback PR**, not a tuned native kernel PR — it just closes the gap so SYCL users can run TQ models, at performance comparable to Vulkan's same-pattern implementation.

## What changed

| File | Change |
|---|---|
| `ggml/src/ggml-sycl/dequantize.hpp` | Two new device-side kernels: `dequantize_block_tq2_0`, `dequantize_block_tq1_0` |
| `ggml/src/ggml-sycl/convert.cpp` | Two new wrappers + cases in `ggml_get_to_fp16_sycl` and `ggml_get_to_fp32_sycl` |
| `ggml/src/ggml-sycl/ggml-sycl.cpp` | `can_use_mul_mat_vec_q` now returns false for TQ types so they route through the dequant fallback |

134 lines added, 0 removed. No regression to any non-TQ path — both dispatch tables only get new cases inserted.

## Performance (Intel Arc Pro B60, Xe2/Battlemage, Llama3-8B-1.58 TQ2_0)

| Test | Before patch | After patch | SYCL Q4_K_M ref | Vulkan TQ2_0 ref |
|------|---|---|---|---|
| pp16 | crash (`convert.cpp:757`) | **114.93 t/s** | 97.22 t/s | 75.73 t/s |
| tg32 | crash (`mmvq.cpp:1194`)   | 7.44 t/s       | 52.85 t/s | 7.33 t/s  |

**Honest framing — prefill vs decode behave very differently:**

- **Prefill (pp16) is great**: SYCL TQ2_0 is now the fastest config in the panorama at this M, beating SYCL Q4_K_M by 1.18×. Both Q4_K_M and TQ2_0 route through the dequant→FP16 path here (M=16 > `MMVQ_MAX_BATCH_SIZE`=8), so TQ2_0's 2.2× lower weight bandwidth is the deciding factor.

- **Decode (tg32) is at parity with Vulkan, not with Q4_K_M MMVQ.** SYCL Q4_K_M decode = 52.85 t/s thanks to its tuned `mul_mat_vec_q4_K_q8_1` MMVQ kernel; SYCL TQ2_0 decode is 7.44 t/s, ~7× slower, because the dequant→FP16 path materializes the full FP16 weight tensor for what is effectively a single-column matmul. Vulkan TQ2_0 decode (7.33 t/s) shows the same characteristic — this is inherent to the dequant fallback approach, not SYCL-specific.

A future native `mul_mat_vec_tq{1,2}_0_q8_1_sycl` kernel could close the decode gap, but that's a substantially larger change and not a prerequisite for users running TQ models without crashing today.

## Test plan

- [x] Build clean on icpx 2025.3 (no new warnings on `ggml-sycl` target)
- [x] `test-backend-ops MUL_MAT` 911/911 PASS on SYCL backend (TQ types are not currently swept upstream — see `tests/test-backend-ops.cpp:7431,7456` `// TODO: implement for all backends` — but no regression on existing types)
- [x] `llama-bench` pp16 + tg32 on Llama3-8B-1.58 TQ2_0 — both modes complete without abort
- [x] Spec/code cross-check against `ggml/src/ggml-quants.c` `dequantize_row_tq{1,2}_0` reference (exhaustive verification of all 256 outputs per block, including the irregular TQ1_0 region boundary at out=160 and 240)
- [ ] Reviewer suggestion welcome on whether to also uncomment the `GGML_TYPE_TQ{1,2}_0` cases in `tests/test-backend-ops.cpp:7431,7456` now that SYCL supports them — would require checking other backends in the same PR or a follow-up
- [ ] TQ1_0 path is implemented identically to TQ2_0 but I do not have a TQ1_0 model on hand to runtime-test; the dequant logic was verified by walking through against the CPU reference for all 256 outputs, but a TQ1_0 runtime test from another reviewer would be welcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)