### PR TITLE
ggml-cuda: honor view_offs in cpy data pointer

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -11,6 +11,10 @@ const int CUDA_CPY_TILE_DIM_2D = 32; // 2D tile dimension for transposed blocks
 const int CUDA_CPY_BLOCK_NM = 8;     // block size of 3rd dimension if available
 const int CUDA_CPY_BLOCK_ROWS = 8;   // block dimension for marching through rows
 
+static char * ggml_cuda_cpy_data(const ggml_tensor * t) {
+    return (char *) (t->view_src ? t->view_src->data : t->data) + t->view_offs;
+}
+
 template <cpy_kernel_t cpy_1>
 static __global__ void cpy_scalar(const char * cx, char * cdst, const int64_t ne,
                                   const int64_t ne00, const int64_t ne01, const int64_t ne02, const int64_t nb00, const int64_t nb01, const int64_t nb02,
@@ -400,8 +404,8 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
 
     cudaStream_t main_stream = ctx.stream();
 
-    char * src0_ddc = (char *) src0->data;
-    char * src1_ddc = (char *) src1->data;
+    char * src0_ddc = ggml_cuda_cpy_data(src0);
+    char * src1_ddc = ggml_cuda_cpy_data(src1);
 
     const bool contiguous_srcs = ggml_is_contiguous(src0) && ggml_is_contiguous(src1);
     const bool can_be_transposed = nb01 == (int64_t)ggml_element_size(src0) &&


### PR DESCRIPTION
$\textcolor{red}{\textbf{(USER WAS BANNED FOR THIS POST)}}$

## Summary

`ggml_cuda_cpy()` was using `src->data` raw, ignoring `view_offs`. For a destination tensor created via `ggml_view_3d` at non-zero offset (e.g., a per-chunk SWA KV cache write at offset `cache_k->nb[1] * kv_start`), the kernel wrote to the wrong location, silently overwriting earlier chunks' data.

This patch adds a small `ggml_cuda_cpy_data()` helper that resolves `view_src + view_offs` correctly, and uses it for both `src0` and `src1` pointers. For non-view tensors `view_offs == 0` so behavior is unchanged.

## Symptom this fixes

Multi-chunk Gemma4 prefill produced silently corrupted KV cache state, causing argmax to return token 0 (or NaN propagation + SIGSEGV on TQ3_0). Diagnosed by stashing/reverting and confirming chunk-1 writes were landing at the wrong offset.

## Diff scope

- `ggml/src/ggml-cuda/cpy.cu` — 6 lines added, 2 removed (one new helper + two call-site swaps)
- No other files touched
- No public-API changes
- No new dependencies

Applies cleanly on current `master`.

## Test plan

- [x] Builds clean against current `master`
- [x] Behaviour unchanged for non-view tensors (`view_offs == 0` preserves the old code path)
- [ ] Maintainers' usual CI

This is a generic bugfix surfaced by long-context prefill with chunked attention; happy to add a regression test if you have a preferred place for one.