### PR TITLE
hexagon: fix OpenCL not found error when building hexagon backend

### DIFF
--- a/docs/backend/snapdragon/CMakeUserPresets.json
+++ b/docs/backend/snapdragon/CMakeUserPresets.json
@@ -19,6 +19,8 @@
             "CMAKE_PREFIX_PATH":  "$env{OPENCL_SDK_ROOT}",
             "HEXAGON_SDK_ROOT":   "$env{HEXAGON_SDK_ROOT}",
             "HEXAGON_TOOLS_ROOT": "$env{HEXAGON_TOOLS_ROOT}",
+            "OpenCL_LIBRARY":    "$env{OpenCL_LIBRARY}",
+            "OpenCL_INCLUDE_DIR": "$env{OpenCL_INCLUDE_DIR}",
             "PREBUILT_LIB_DIR": "android_aarch64",
             "GGML_OPENMP":      "OFF",
             "GGML_LLAMAFILE":   "OFF",


### PR DESCRIPTION
## Overview

Fix compile error for hexagon backend

## Additional information

Fixes #22945 


Add OpenCL libs when compile hexagon backend. 

1. Download the OpenCL from Qualcomm website or KhronosGroup
2. Add the OpenCL dir to environ and run the command below
```bash
export ANDROID_NDK_ROOT=/home/tom/codes/android-ndk-r27d
export OpenCL_LIBRARY=/path/to/opencl-sdk/libs/Android/libOpenCL.so
export OpenCL_INCLUDE_DIR=/path/to/opencl-sdk/inc
export HEXAGON_SDK_ROOT=/path/to/Hexagon_SDK/6.4.0.2
export HEXAGON_TOOLS_ROOT=/path/to/Hexagon_SDK/6.4.0.2/tools/HEXAGON_Tools/19.0.04

mkdir -p build-snapdragon
cp docs/backend/snapdragon/CMakeUserPresets.json .
cmake --preset arm64-android-snapdragon-release -B build-snapdragon
cmake --build build-snapdragon
```

## Requirements



- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
