### PR TITLE
qwen35: fix tensor loading for Qwen3.5 GGUFs with per-layer KV heads and vision encoder tensors

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1313,9 +1313,12 @@ struct ggml_tensor * llama_model_loader::create_tensor_as_view(struct ggml_conte
 }
 
 void llama_model_loader::done_getting_tensors() const {
-    if (n_created != n_tensors) {
+    if (n_created > n_tensors) {
         throw std::runtime_error(format("%s: wrong number of tensors; expected %d, got %d", __func__, n_tensors, n_created));
     }
+    if (n_created < n_tensors) {
++        LLAMA_LOG_WARN("%s: %d tensors in file were not loaded (likely vision encoder tensors)\n", __func__, n_tensors - n_created);
++   }
     if (n_tensors_moved > 0) {
         LLAMA_LOG_DEBUG("%s: tensor '%s' (%s) (and %zu others) cannot be used with preferred buffer type %s, using %s instead\n",
             __func__, first_tensor_moved_name.c_str(), first_tensor_moved_type_name.c_str(), n_tensors_moved - 1,

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -3,8 +3,7 @@
 
 void llama_model_qwen35::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
-    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
-
+    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 3, true);
     // Load linear attention (gated delta net) parameters
     ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);
     ml.get_key(LLM_KV_SSM_INNER_SIZE,     hparams.ssm_d_inner);
@@ -60,7 +59,7 @@ void llama_model_qwen35::load_arch_tensors(llama_model_loader &) {
 
         if (!hparams.is_recurrent(i)) {
             // Attention layers
-            create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, 0);
+            create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head * 2, hparams.n_embd_k_gqa(i), hparams.n_embd_v_gqa(i), 0);
             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), { n_embd_head_k * n_head, n_embd }, 0);
 
             // Q/K normalization for attention layers
@@ -72,7 +71,7 @@ void llama_model_qwen35::load_arch_tensors(llama_model_loader &) {
             layer.wqkv           = create_tensor(tn(LLM_TENSOR_ATTN_QKV,       "weight", i), { n_embd, key_dim * 2 + value_dim }, TENSOR_NOT_REQUIRED);
             layer.wqkv_gate      = create_tensor(tn(LLM_TENSOR_ATTN_GATE,      "weight", i), { n_embd, value_dim }, TENSOR_NOT_REQUIRED);
             layer.ssm_conv1d     = create_tensor(tn(LLM_TENSOR_SSM_CONV1D,     "weight", i), { hparams.ssm_d_conv, conv_dim }, 0);
-            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   i), { hparams.ssm_dt_rank }, 0);
+            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,                   i), { hparams.ssm_dt_rank }, 0);
             layer.ssm_a          = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,             i), { hparams.ssm_dt_rank }, 0);
             layer.ssm_beta       = create_tensor(tn(LLM_TENSOR_SSM_BETA,       "weight", i), { n_embd, n_v_heads }, 0);
             layer.ssm_alpha      = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,      "weight", i), { n_embd, n_v_heads }, 0);
@@ -233,7 +232,7 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn(
     cb(Vcur, "Vcur", il);
 
     // Apply K normalization
-    Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+    Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, hparams.n_head_kv(il), n_tokens);
     Kcur = build_norm(Kcur, model.layers[il].attn_k_norm, nullptr, LLM_NORM_RMS, il);
     cb(Kcur, "Kcur_normed", il);
 
@@ -244,8 +243,7 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn(
     gate = ggml_cont_2d(ctx0, gate, n_embd_head * n_head, n_tokens);
     cb(gate, "gate_reshaped", il);
 
-    Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
-
+    Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, hparams.n_head_kv(il), n_tokens);
     // Apply MRoPE
     Qcur = ggml_rope_multi(
             ctx0, Qcur, inp_pos, nullptr,


### PR DESCRIPTION
This PR fixes several bugs in qwen35.cpp that prevented Qwen3.5 models from loading, and relaxes the tensor count check in llama-model-loader.cpp to allow text-only loading of multimodal GGUFs.

  Background

  Qwen3.5 is a hybrid SSM/attention architecture (gated delta net). Attention layers appear every 4th layer, so only 8 out of 32 layers are full attention layers. The remaining 24 are SSM (recurrent) layers with 0 KV heads. This per-layer variation exposed several places where the code incorrectly used global/layer-0 defaults.

  Additionally, some Qwen3.5 GGUFs (e.g., those exported by Ollama) are multimodal — they embed a vision encoder (v.blk.* tensors) that the text-only qwen35.cpp implementation does not load.

  Fixes

  src/models/qwen35.cpp

  1. RoPE dimension sections: 4 → 3

  - ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS, hparams.rope_sections, 4, true);
  + ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS, hparams.rope_sections, 3, true);

  The GGUF stores 3 RoPE dimension section values, not 4. Passing 4 caused the key lookup to fail or read out of bounds.

  2. ssm_dt tensor name: remove spurious "bias" suffix

  - layer.ssm_dt = create_tensor(tn(LLM_TENSOR_SSM_DT, "bias", i), { hparams.ssm_dt_rank }, 0);
  + layer.ssm_dt = create_tensor(tn(LLM_TENSOR_SSM_DT,          i), { hparams.ssm_dt_rank }, 0);

  The tensor is named blk.N.ssm_dt in the GGUF, not blk.N.ssm_dt.bias. The "bias" suffix was incorrect and caused missing tensor errors for every SSM layer.

  3. Per-layer KV dimensions in create_tensor_qkv

  - create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, 0);
  + create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head * 2, hparams.n_embd_k_gqa(i), hparams.n_embd_v_gqa(i), 0);

  LLAMA_LOAD_LOCALS expands n_embd_k_gqa / n_embd_v_gqa as scalars initialized from hparams.n_embd_k_gqa() (no argument), which returns the
  value for layer 0 — a SSM layer with 0 KV heads. Attention layers (every 4th) have n_head_kv = 4 and require the actual per-layer values.

  4. Per-layer KV head count in build_layer_attn (Kcur and Vcur reshape)

  - Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
  + Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, hparams.n_head_kv(il), n_tokens);

  - Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
  + Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, hparams.n_head_kv(il), n_tokens);

  llm_graph_context::n_head_kv is initialized from hparams.n_head_kv() (layer 0 = 0), causing a ggml_reshape_3d assertion failure when building attention graphs for layers with n_head_kv > 0. Using hparams.n_head_kv(il) correctly resolves the per-layer value.

  src/llama-model-loader.cpp

  5. Allow loading fewer tensors than present in the GGUF

  - if (n_created != n_tensors) {
  -     throw std::runtime_error(...);
  - }
  + if (n_created > n_tensors) {
  +     throw std::runtime_error(...);
  + }
  + if (n_created < n_tensors) {
  +     LLAMA_LOG_WARN("%s: %d tensors in file were not loaded (likely vision encoder tensors)\n", ...);
  + }

  Some GGUFs contain tensors for components not loaded by the text-only model (e.g., vision encoder tensors). Previously this triggered a hard error. The new behavior demotes it to a warning so that text-only inference can proceed normally. Creating more tensors than the file contains remains an error.

  Testing

  Tested with Qwen3.5 9B (Q4_K_M GGUF from Ollama, which embeds a vision encoder). The model now loads and runs correctly with 128k context, q4_0 KV quantization, ~7 GB VRAM on a 12 GB GPU.