### PR TITLE
convert : fix Pixtral 12B --mistral-format conversion (3 bugs)

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -2865,8 +2865,12 @@ class LlamaModel(TextModel):
         # fix for SmolVLM2, missing `num_attention_heads` in config.json
         if self.hf_arch == "VLlama3ForCausalLM":
             self.hparams["num_attention_heads"] = self.hparams.get("num_attention_heads", 32)
-        hparams = ModelBase.load_hparams(self.dir_model, is_mistral_format=False)
-        self.origin_hf_arch = hparams.get('architectures', [None])[0]
+        # Mistral consolidated format has no config.json; origin_hf_arch is HF-only.
+        if self.is_mistral_format:
+            self.origin_hf_arch = None
+        else:
+            hparams = ModelBase.load_hparams(self.dir_model, is_mistral_format=False)
+            self.origin_hf_arch = hparams.get('architectures', [None])[0]
 
     def set_vocab(self):
         if self.origin_hf_arch == "GlmasrModel":
@@ -13409,7 +13413,7 @@ class PixtralModel(LlavaVisionModel):
         self.gguf_writer.add_vision_use_silu(True)
 
         # spatial_merge_size
-        if self.find_vparam(["mm_projector_id"]) == "patch_merge":
+        if self.find_vparam(["mm_projector_id"], optional=True) == "patch_merge":
             self.gguf_writer.add_vision_spatial_merge_size(
                 self.find_vparam(["spatial_merge_size"])
             )
@@ -13417,8 +13421,12 @@ class PixtralModel(LlavaVisionModel):
     def map_tensor_name(self, name: str, try_suffixes: Sequence[str] = (".weight", ".bias")) -> str:
         if name == "vision_language_adapter.w_in.weight":
             return "mm.1.weight"
+        elif name == "vision_language_adapter.w_in.bias":
+            return "mm.1.bias"
         elif name == "vision_language_adapter.w_out.weight":
             return "mm.2.weight"
+        elif name == "vision_language_adapter.w_out.bias":
+            return "mm.2.bias"
         return super().map_tensor_name(name, try_suffixes)
 
 


### PR DESCRIPTION
## Summary

Three small fixes in `convert_hf_to_gguf.py` to make `--mistral-format` work
end-to-end on Pixtral 12B (2409) consolidated weights. Without these,
conversion crashes before writing the GGUF; with them, F16 -> Q4_K_M -> mtmd
inference produces correct image output. No inference-side changes required --
`tools/mtmd/clip.cpp` already reads the bias tensors when present.

## Bugs

### 1. `LlamaModel.__init__` crashes on mistral-format input (line ~2867)

`ModelBase.load_hparams(self.dir_model, is_mistral_format=False)` is called
unconditionally to read `architectures` for `origin_hf_arch` (used downstream
to detect SmolVLM2 etc.). Mistral consolidated layouts have no `config.json`,
so this raises `FileNotFoundError` for any `--mistral-format` run.

Fix: skip the HF-only lookup when `self.is_mistral_format` is True and set
`self.origin_hf_arch = None`. The field is only consulted by HF-specific
branches, so `None` is safe in the mistral path.

### 2. `PixtralModel.set_gguf_parameters` requires `mm_projector_id` (line ~13321)

`self.find_vparam([mm_projector_id])` is mandatory, but Pixtral 12B 2409
uses a plain linear projector and ships no `mm_projector_id` in `params.json`
-- only the newer Mistral Small 3.1 sets it to `patch_merge`. Result: KeyError
on every Pixtral 12B conversion.

Fix: pass `optional=True`. The body inside the `if` only runs when the value
equals `patch_merge`, so `None` short-circuits correctly and the existing
patch-merge path is unaffected.

### 3. `PixtralModel.map_tensor_name` rejects adapter biases (line ~13330)

Only `.weight` is mapped for `vision_language_adapter.w_in` / `w_out`; `.bias`
falls through to `super().map_tensor_name` and raises. Pixtral 12B 2409's
`consolidated.safetensors` ships both biases.

Fix: add the two `.bias` branches mapping to `mm.1.bias` / `mm.2.bias`. The
inference side already supports this -- see `tools/mtmd/clip.cpp:2143-2148`,
which loads `mm.1.bias` / `mm.2.bias` with the optional flag set. The GGUF
writer was simply refusing tensors the runtime is happy to consume.

## Reproduction

```
python convert_hf_to_gguf.py \
    /path/to/pixtral-12b-2409 \
    --mistral-format --outtype f16 \
    --outfile pixtral-12b-2409-f16.gguf
```

against the official Mistral release of Pixtral-12B-2409 (consolidated
safetensors layout, no `config.json`). Pre-patch this fails at
`LlamaModel.__init__` (FileNotFoundError on `config.json`). After bypassing
that it fails at `set_gguf_parameters` (KeyError `mm_projector_id`). After
bypassing that it fails inside `map_tensor_name` on
`vision_language_adapter.w_in.bias`.

## Verification

- F16 GGUF written successfully from `consolidated.safetensors` +
  `params.json` + `tekken.json`.
- Q4_K_M produced via `llama-quantize`, loads cleanly.
- `llama-mtmd-cli` smoke test on a test image returned correct,
  image-grounded output. CUDA inference at ~47 tok/s eval on RTX 3090.
- No upstream files touched besides `convert_hf_to_gguf.py`.

## Inference side

`tools/mtmd/clip.cpp:2143-2148` already calls
`get_tensor(TN_MM_INP_PROJ_B, /*optional=*/true)` and
`get_tensor(TN_MM_OUTP_PROJ_B, /*optional=*/true)` for `mm.1.bias` and
`mm.2.bias`, so the converter change makes existing runtime behavior
reachable. No C++ change is included or needed.