### PR TITLE
ggml-webgpu: Support GPU profiling beyond the maximum query count

### DIFF
--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -3148,6 +3148,16 @@ static ggml_status ggml_backend_webgpu_graph_compute(ggml_backend_t backend, str
             }
             ctx->param_arena.reset();
             commands.clear();
+#ifdef GGML_WEBGPU_GPU_PROFILE
+            // flush before the next batch can overflow the QuerySet
+            if (ctx->profile_timestamp_query_count + 2 * ctx->global_ctx->command_submit_batch_size >=
+                WEBGPU_MAX_PROFILE_QUERY_COUNT) {
+                ggml_backend_webgpu_collect_profile_results(ctx, profile_pipeline_names, num_inflight_batches);
+                // reset profile timestamp state
+                ctx->profile_timestamp_query_count = 0;
+                profile_pipeline_names.clear();
+            }
+#endif
         }
 
         node_idx += num_encoded_ops;


### PR DESCRIPTION
## Overview

This PR fixes the bug described in the Additional Information section.

- Flush timestamp slots and reset the timestamp state when the number of used timestamp slots is nearly full.

I confirmed that GPU profiles can now be collected for `Qwen3.5-35B-A3B-GGUF` and several other models (Qwen3.5, Qwen3.6, Gemma 4, and Llama 3).

## Additional Information

I noticed that [`unsloth/Qwen3.5-35B-A3B-GGUF`](https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF) overflowed the timestamp `QuerySet` when I tried to collect a GPU profile:

```bash
llama.cpp/ggml/src/ggml-webgpu/ggml-webgpu.cpp:571: GGML_ASSERT(ctx->profile_timestamp_query_count + 2 <= WEBGPU_MAX_PROFILE_QUERY_COUNT) failed
```

This suggests that we need logic to allow profile collection even when a model requires more than 4096 timestamp queries.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES - I used AI to investigate WebGPU specification

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
