### PR TITLE
convert: add Gemma4TextForCausalLM architecture support

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -7917,7 +7917,7 @@ class Gemma3NModel(Gemma3Model):
         yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("Gemma4ForConditionalGeneration")
+@ModelBase.register("Gemma4ForConditionalGeneration", "Gemma4TextForCausalLM")
 class Gemma4Model(Gemma3Model):
     model_arch = gguf.MODEL_ARCH.GEMMA4
 


### PR DESCRIPTION
## Summary

- Register `Gemma4TextForCausalLM` alongside `Gemma4ForConditionalGeneration` in `convert_hf_to_gguf.py`
- This enables GGUF conversion of text-only Gemma 4 models (e.g. fine-tuned from `google/gemma-4-27b-pt`)
- One-line change: the text-only variant uses identical tensor names and config fields as the multimodal variant

## Problem

Converting a `Gemma4TextForCausalLM` model fails with:
```
ValueError: Can not map tensor 'model.layers.26.input_layernorm.weight'
```

This happens because the architecture string `Gemma4TextForCausalLM` (used by HuggingFace transformers 4.57+ for text-only Gemma 4) is not registered in the converter, so it falls back to a wrong model class.

## Test plan

- [x] Created a minimal mock `Gemma4TextForCausalLM` model with matching config and tensor names
- [x] Verified all tensors map correctly (attn_norm, post_attention_norm, ffn_norm, post_ffw_norm, etc.)
- [x] Verified config fields (num_kv_shared_layers, layer_types, global_head_dim, etc.) are read correctly

Fixes #22483

🤖 Generated with [Claude Code](https://claude.com/claude-code)