### PR TITLE
feat: Support d_conv=15 for ssm-conv.cu

### DIFF
--- a/ggml/src/ggml-cuda/ssm-conv.cu
+++ b/ggml/src/ggml-cuda/ssm-conv.cu
@@ -140,11 +140,12 @@ static void ssm_conv_f32_cuda(const float * src0, const float * src1, const floa
     };
 
     switch (nc) {
-        case 3: launch_kernel(std::integral_constant<int, 3>{}); break;
-        case 4: launch_kernel(std::integral_constant<int, 4>{}); break;
-        case 5: launch_kernel(std::integral_constant<int, 5>{}); break;
-        case 9: launch_kernel(std::integral_constant<int, 9>{}); break;
-        default: GGML_ABORT("Only support kernel sizes 3, 4, 5, 9 right now.");
+        case 3:  launch_kernel(std::integral_constant<int, 3 >{}); break;
+        case 4:  launch_kernel(std::integral_constant<int, 4 >{}); break;
+        case 5:  launch_kernel(std::integral_constant<int, 5 >{}); break;
+        case 9:  launch_kernel(std::integral_constant<int, 9 >{}); break;
+        case 15: launch_kernel(std::integral_constant<int, 15>{}); break;
+        default: GGML_ABORT("Only support kernel sizes 3, 4, 5, 9, 15 right now.");
     }
 }
 


### PR DESCRIPTION
## Overview

Closes #23015 

This PR adds the missing kernel dispatch for `d_conv=15` for Granite Speech 4.0 and 4.1 mmproj QFormer projectors.

## Additional information

```sh
llama-cli -hf ibm-granite/granite-speech-4.1-2b-GGUF:Q8_0 --audio audio/multilingual_sample.wav -p "can you transcribe the speech into a written format?"
```

```
for timothy was a spoiled cat, and he allowed no one to interfere. everybody waited upon him, moving their chairs even, for he was monarch of the hearth. dinarzade la nuit suivante appela sa soeur quand il en fut temps. "si vous ne dormez pas, ma soeur", lui dit-elle, "je vous prie en attendant le jour qui paraîtra bientôt de continuer le conte du pêcheur."
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO (the fix was easier than writing the prompt 😉)