### PR TITLE
server: Add flag to only expose models configured in the model presets INI

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3065,6 +3065,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_AUTOLOAD"));
     add_opt(common_arg(
+        {"--only-ini-presets"},
+        {"--no-only-ini-presets"},
+        string_format("for router server, only expose models defined in the INI file (default: %s)", params.only_ini_presets ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.only_ini_presets = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ONLY_INI_PRESETS"));
+    add_opt(common_arg(
         {"--jinja"},
         {"--no-jinja"},
         string_format("whether to use jinja template engine for chat (default: %s)", params.use_jinja ? "enabled" : "disabled"),

--- a/common/common.h
+++ b/common/common.h
@@ -622,6 +622,7 @@ struct common_params {
     std::string models_preset = ""; // directory containing model presets for the router server
     int models_max = 4;             // maximum number of models to load simultaneously
     bool models_autoload = true;    // automatically load models when requested via the router server
+    bool only_ini_presets = false;  // only expose models in the model presets for the router server
 
     bool log_json = false;
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -311,13 +311,13 @@ void server_models::load_models() {
 
     // remove models not defined in INI
     if (base_params.only_ini_presets) {
-	for (auto it = final_presets.begin(); it != final_presets.end(); ) {
-	    if (custom_presets.find(it->first) == custom_presets.end()) {
-		it = final_presets.erase(it);
-	    } else {
-		++it;
-	    }
-	}
+        for (auto it = final_presets.begin(); it != final_presets.end(); ) {
+            if (custom_presets.find(it->first) == custom_presets.end()) {
+                it = final_presets.erase(it);
+            } else {
+                ++it;
+            }
+        }
     }
 
     // Helpers that read `mapping` — must be called while holding the lock.

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -309,6 +309,17 @@ void server_models::load_models() {
         preset.merge(base_preset);
     }
 
+    // remove models not defined in INI
+    if (base_params.only_ini_presets) {
+	for (auto it = final_presets.begin(); it != final_presets.end(); ) {
+	    if (custom_presets.find(it->first) == custom_presets.end()) {
+		it = final_presets.erase(it);
+	    } else {
+		++it;
+	    }
+	}
+    }
+
     // Helpers that read `mapping` — must be called while holding the lock.
     std::unordered_set<std::string> custom_names;
     for (const auto & [name, preset] : custom_presets) custom_names.insert(name);

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -253,3 +253,37 @@ def test_router_reload_models():
         assert "model-reload-c" in ids, "newly added model should appear"
     finally:
         os.remove(preset_path)
+
+
+def test_router_only_ini_presets():
+    """GET /models to confirm only models listed the INI preset are in the model list."""
+    global server
+
+    preset_path = os.path.join(TMP_DIR, "test_presets.ini")
+
+    # Initial preset: two models
+    with open(preset_path, "w") as f:
+        f.write(
+            "version = 1\n"
+            "\n"
+            "[*]\n"
+            "c = 2048\n"
+            "\n"
+            "[model-a]\n"
+            "hf-repo = ggml-org/test-model-stories260K\n"
+            "\n"
+            "[model-b]\n"
+            "hf-repo = ggml-org/test-model-stories260K-infill\n"
+        )
+
+    server.models_preset = preset_path
+    server.only_ini_presets = True
+    server.start()
+
+    ids = _get_model_ids(is_reload=False)
+    assert "model-a" in ids
+    assert "model-b" in ids
+    assert 3 == len(ids), "Expected only 3 ids (model-a, model-b, default)"
+    assert "ggml-org/tinygemma3-GGUF:Q8_0" not in ids, "Model without ini config should not appear"
+
+    os.remove(preset_path)

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -90,6 +90,7 @@ class ServerProcess:
     models_max: int | None = None
     models_preset: str | None = None
     no_models_autoload: bool | None = None
+    only_ini_presets: bool | None = None
     lora_files: List[str] | None = None
     enable_ctx_shift: int | None = False
     spec_draft_n_min: int | None = None
@@ -166,6 +167,8 @@ class ServerProcess:
             server_args.extend(["--models-max", self.models_max])
         if self.models_preset:
             server_args.extend(["--models-preset", self.models_preset])
+        if self.only_ini_presets:
+            server_args.append("--only-ini-presets")
         if self.n_batch:
             server_args.extend(["--batch-size", self.n_batch])
         if self.n_ubatch:


### PR DESCRIPTION
## Overview

For llama-server router, adds a flag (--only-ini-presets) to only expose models in the presets INI. Preset flags from the server and custom model directory are still included for models that are exposed.

I often have others models that I am experimenting with or old models (e.g., q4 vs q6 quants) that I do not want to llama-server to expose. I do not expect llama-server to expose all ggufs in the HF cache if I have configured a models.ini presets file only describing a subset of models.  

## Additional information

Comparison with and without flag:
<img width="1679" height="683" alt="Screenshot From 2026-05-13 22-33-43" src="https://github.com/user-attachments/assets/6b3b0dfe-1176-445a-9098-41aa750ee318" />

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes
- AI usage disclosure: No, code by me.

