### PR TITLE
docs: fix duplicated "the" in granitevision and model-conversion docs

### DIFF
--- a/docs/multimodal/granitevision.md
+++ b/docs/multimodal/granitevision.md
@@ -176,7 +176,7 @@ Note that currently you cannot quantize the visual encoder because granite visio
 
 
 ### 5. Running the Model in Llama cpp
-Build llama cpp normally; you should have a target binary named `llama-mtmd-cli`, which you can pass two binaries to. As an example, we pass the the llama.cpp banner.
+Build llama cpp normally; you should have a target binary named `llama-mtmd-cli`, which you can pass two binaries to. As an example, we pass the llama.cpp banner.
 
 ```bash
 $ ./build/bin/llama-mtmd-cli -m $LLM_GGUF_PATH \

--- a/examples/model-conversion/README.md
+++ b/examples/model-conversion/README.md
@@ -335,7 +335,7 @@ $ make perplexity-run-full QUANTIZED_MODEL=~/path/to/quantized/model-Qxx.gguf LO
 
 ## HuggingFace utilities
 The following targets are useful for creating collections and model repositories
-on Hugging Face in the the ggml-org. These can be used when preparing a release
+on Hugging Face in the ggml-org. These can be used when preparing a release
 to script the process for new model releases.
 
 For the following targets a `HF_TOKEN` environment variable is required.


### PR DESCRIPTION
Two one-line fixes for duplicated "the" in documentation:
- `docs/multimodal/granitevision.md` — "the the llama.cpp banner" → "the llama.cpp banner"
- `examples/model-conversion/README.md` — "in the the ggml-org" → "in the ggml-org"

No code/behavior change.