### PR TITLE
model: discover hybrid layer types via tensor presence

### DIFF
--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -12,13 +12,11 @@ void llama_model_qwen35::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_SSM_TIME_STEP_RANK, hparams.ssm_dt_rank);
     ml.get_key(LLM_KV_SSM_GROUP_COUNT,    hparams.ssm_n_group);
 
-    // Mark recurrent layers (linear attention layers)
-    {
-        uint32_t full_attn_interval = 4;
-        ml.get_key(LLM_KV_FULL_ATTENTION_INTERVAL, full_attn_interval, false);
-        for (uint32_t i = 0; i < hparams.n_layer; ++i) {
-            hparams.recurrent_layer_arr[i] = ((i + 1) % full_attn_interval != 0);
-        }
+    // Mark recurrent layers (discover based on tensor presence)
+    for (uint32_t i = 0; i < hparams.n_layer; ++i) {
+        char buf[256];
+        snprintf(buf, sizeof(buf), "blk.%u.ssm_conv1d.weight", i);
+        hparams.recurrent_layer_arr[i] = (ml.get_tensor_meta(buf) != nullptr);
     }
 
     switch (hparams.n_layer) {

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -15,13 +15,11 @@ void llama_model_qwen35moe::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_SSM_TIME_STEP_RANK, hparams.ssm_dt_rank);
     ml.get_key(LLM_KV_SSM_GROUP_COUNT,    hparams.ssm_n_group);
 
-    // Mark recurrent layers (linear attention layers)
-    {
-        uint32_t full_attn_interval = 4;
-        ml.get_key(LLM_KV_FULL_ATTENTION_INTERVAL, full_attn_interval, false);
-        for (uint32_t i = 0; i < hparams.n_layer; ++i) {
-            hparams.recurrent_layer_arr[i] = ((i + 1) % full_attn_interval != 0);
-        }
+    // Mark recurrent layers (discover based on tensor presence)
+    for (uint32_t i = 0; i < hparams.n_layer; ++i) {
+        char buf[256];
+        snprintf(buf, sizeof(buf), "blk.%u.ssm_conv1d.weight", i);
+        hparams.recurrent_layer_arr[i] = (ml.get_tensor_meta(buf) != nullptr);
     }
 
     switch (hparams.n_layer) {


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Fix a thingy where technically invalid sizes for layers on Qwen 3.5 are completely rejected

## Additional information
What happened before:
<img width="806" height="226" alt="image" src="https://github.com/user-attachments/assets/d65540e0-6d63-48c3-add6-37445d900c34" />

What happens now:
<img width="810" height="430" alt="image" src="https://github.com/user-attachments/assets/bf54f5bd-8785-489c-bf1f-df2fd2b2d7bb" />
(I didn't finetune it properly, kinda rushed so the model isnt great

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Model Information:
    Base: Qwen-3.5 0.8B
    Modifications to model: Added 6 layers, which is invalid in the architecture but works.
    Parameters: Base 0.8B, Modified 0.9B

## Requirements


<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes - I used it to find the bug and apply the patch. I have not used it to modify the source code innapropriately
