### PR TITLE
fix: duplicated "the" in compare-llama-bench and minicpmv-surgery comments

### DIFF
--- a/scripts/compare-llama-bench.py
+++ b/scripts/compare-llama-bench.py
@@ -351,7 +351,7 @@ class LlamaBenchDataSQLite3(LlamaBenchData):
 
             if self.build_len_min != self.build_len_max:
                 logger.warning("Data contains commit hashes of differing lengths. It's possible that the wrong commits will be compared. "
-                               "Try purging the the database of old commits.")
+                               "Try purging the database of old commits.")
                 self.cursor.execute(f"UPDATE {self.table_name} SET build_commit = SUBSTRING(build_commit, 1, {self.build_len_min});")
 
             builds = self.cursor.execute(f"SELECT DISTINCT build_commit FROM {self.table_name};").fetchall()

--- a/tools/mtmd/legacy-models/minicpmv-surgery.py
+++ b/tools/mtmd/legacy-models/minicpmv-surgery.py
@@ -7,7 +7,7 @@ ap = argparse.ArgumentParser()
 ap.add_argument("-m", "--model", help="Path to MiniCPM-V model")
 args = ap.parse_args()
 
-# find the model part that includes the the multimodal projector weights
+# find the model part that includes the multimodal projector weights
 model = AutoModel.from_pretrained(args.model, trust_remote_code=True, local_files_only=True, torch_dtype=torch.bfloat16)
 checkpoint = model.state_dict()
 


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in Python script comments/strings:
- `scripts/compare-llama-bench.py` — "purging the the database" → "purging the database"
- `tools/mtmd/legacy-models/minicpmv-surgery.py` — "the the multimodal projector" → "the multimodal projector"

No code/behavior change.