### PR TITLE
Support for Codex CLI by skipping unsupported Responses tools

### DIFF
--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1741,6 +1741,47 @@ static void test_convert_responses_to_chatcmpl() {
 
         assert_equals(false, result.contains("tools"));
     }
+
+    // Test Codex built-in apply_patch still fails for gpt-oss model aliases
+    {
+        json input = json::parse(R"({
+            "input": "Hello",
+            "model": "gpt-oss-20b",
+            "tools": [
+                {
+                    "type": "custom",
+                    "name": "apply_patch"
+                }
+            ]
+        })");
+
+        bool threw = false;
+        try {
+            server_chat_convert_responses_to_chatcmpl(input);
+        } catch (const std::invalid_argument & err) {
+            threw = true;
+            assert_equals(std::string("'type' of tool must be 'function'"), std::string(err.what()));
+        }
+        assert_equals(true, threw);
+    }
+
+    // Test renamed gpt-oss aliases can skip non-function apply_patch
+    {
+        json input = json::parse(R"({
+            "input": "Hello",
+            "model": "renamed-model",
+            "tools": [
+                {
+                    "type": "custom",
+                    "name": "apply_patch"
+                }
+            ]
+        })");
+
+        json result = server_chat_convert_responses_to_chatcmpl(input);
+
+        assert_equals(false, result.contains("tools"));
+    }
 }
 
 static void test_template_output_peg_parsers(bool detailed_debug) {

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1741,47 +1741,6 @@ static void test_convert_responses_to_chatcmpl() {
 
         assert_equals(false, result.contains("tools"));
     }
-
-    // Test Codex built-in apply_patch still fails for gpt-oss model aliases
-    {
-        json input = json::parse(R"({
-            "input": "Hello",
-            "model": "gpt-oss-20b",
-            "tools": [
-                {
-                    "type": "custom",
-                    "name": "apply_patch"
-                }
-            ]
-        })");
-
-        bool threw = false;
-        try {
-            server_chat_convert_responses_to_chatcmpl(input);
-        } catch (const std::invalid_argument & err) {
-            threw = true;
-            assert_equals(std::string("'type' of tool must be 'function'"), std::string(err.what()));
-        }
-        assert_equals(true, threw);
-    }
-
-    // Test renamed gpt-oss aliases can skip non-function apply_patch
-    {
-        json input = json::parse(R"({
-            "input": "Hello",
-            "model": "renamed-model",
-            "tools": [
-                {
-                    "type": "custom",
-                    "name": "apply_patch"
-                }
-            ]
-        })");
-
-        json result = server_chat_convert_responses_to_chatcmpl(input);
-
-        assert_equals(false, result.contains("tools"));
-    }
 }
 
 static void test_template_output_peg_parsers(bool detailed_debug) {

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1664,6 +1664,83 @@ static void test_convert_responses_to_chatcmpl() {
         assert_equals(false, result.contains("max_output_tokens"));
         assert_equals(100, result.at("max_tokens").get<int>());
     }
+
+    // Test mixed Responses tools: convert only function tools
+    {
+        json input = json::parse(R"({
+            "input": "Hello",
+            "model": "test-model",
+            "tools": [
+                {
+                    "type": "web_search"
+                },
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get weather for a location",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["location"]
+                    }
+                },
+                {
+                    "type": "image_generation"
+                },
+                {
+                    "type": "mcp",
+                    "server_label": "test-server"
+                },
+                {
+                    "type": "namespace",
+                    "name": "browser"
+                }
+            ]
+        })");
+
+        json result = server_chat_convert_responses_to_chatcmpl(input);
+
+        assert_equals(true, result.contains("tools"));
+        assert_equals(true, result.at("tools").is_array());
+        assert_equals((size_t)1, result.at("tools").size());
+
+        const auto & tool = result.at("tools")[0];
+        assert_equals(std::string("function"), tool.at("type").get<std::string>());
+        assert_equals(std::string("get_weather"), tool.at("function").at("name").get<std::string>());
+        assert_equals(true, tool.at("function").at("strict").get<bool>());
+    }
+
+    // Test non-function Responses tools are ignored
+    {
+        json input = json::parse(R"({
+            "input": "Hello",
+            "model": "test-model",
+            "tools": [
+                {
+                    "type": "web_search"
+                },
+                {
+                    "type": "image_generation"
+                },
+                {
+                    "type": "mcp",
+                    "server_label": "test-server"
+                },
+                {
+                    "type": "namespace",
+                    "name": "browser"
+                }
+            ]
+        })");
+
+        json result = server_chat_convert_responses_to_chatcmpl(input);
+
+        assert_equals(false, result.contains("tools"));
+    }
 }
 
 static void test_template_output_peg_parsers(bool detailed_debug) {

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -258,7 +258,8 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
             json chatcmpl_tool;
 
             if (json_value(resp_tool, "type", std::string()) != "function") {
-                throw std::invalid_argument("'type' of tool must be 'function'");
+                // Non-function Responses tools have no Chat Completions equivalent.
+                continue;
             }
             resp_tool.erase("type");
             chatcmpl_tool["type"] = "function";
@@ -270,7 +271,9 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
             chatcmpl_tools.push_back(chatcmpl_tool);
         }
         chatcmpl_body.erase("tools");
-        chatcmpl_body["tools"] = chatcmpl_tools;
+        if (!chatcmpl_tools.empty()) {
+            chatcmpl_body["tools"] = chatcmpl_tools;
+        }
     }
 
     if (response_body.contains("max_output_tokens")) {

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -253,17 +253,12 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
         if (!response_body.at("tools").is_array()) {
             throw std::invalid_argument("'tools' must be an array of objects");
         }
-        const std::string model = json_value(response_body, "model", std::string());
         std::vector<json> chatcmpl_tools;
         for (json resp_tool : response_body.at("tools")) {
             json chatcmpl_tool;
 
             const std::string type = json_value(resp_tool, "type", std::string());
             if (type != "function") {
-                const std::string name = json_value(resp_tool, "name", std::string());
-                if (model.find("gpt-oss") != std::string::npos && name == "apply_patch") {
-                    throw std::invalid_argument("'type' of tool must be 'function'");
-                }
                 // Non-function Responses tools have no Chat Completions equivalent.
                 SRV_WRN("unsupported Responses tool type '%s' skipped\n", type.c_str());
                 continue;

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -253,12 +253,19 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
         if (!response_body.at("tools").is_array()) {
             throw std::invalid_argument("'tools' must be an array of objects");
         }
+        const std::string model = json_value(response_body, "model", std::string());
         std::vector<json> chatcmpl_tools;
         for (json resp_tool : response_body.at("tools")) {
             json chatcmpl_tool;
 
-            if (json_value(resp_tool, "type", std::string()) != "function") {
+            const std::string type = json_value(resp_tool, "type", std::string());
+            if (type != "function") {
+                const std::string name = json_value(resp_tool, "name", std::string());
+                if (model.find("gpt-oss") != std::string::npos && name == "apply_patch") {
+                    throw std::invalid_argument("'type' of tool must be 'function'");
+                }
                 // Non-function Responses tools have no Chat Completions equivalent.
+                SRV_WRN("unsupported Responses tool type '%s' skipped\n", type.c_str());
                 continue;
             }
             resp_tool.erase("type");


### PR DESCRIPTION
## Overview

This enables support for codex CLI, which now uses the Responses API. As per https://platform.openai.com/docs/guides/tools?api-mode=responses type's can be beyond just `function`, like `file_search`, `web_search` , `mcp`, `image_generation`, `namespace`, etc. llama.cpp can't support each type but instead of breaking down entirely, we only pass the ones we can support to the backend. The patch is intentionally minimal as there isn't a full implementation of Responses in llama.cpp as far as I can tell. This is merely making the compatibility shim (Responses <-> Chat completion) less brittle.

Issue faced by users @ https://github.com/ggml-org/llama.cpp/issues/20156

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Codex 5.5 (API) medium used to rapidly query/understand the high level flow and cross-verify  Responses API vs Chat Completion API handling within llama.cpp. The unit tests were entirely written by Codex as per guidance to cover both +ve and -ve cases.
