### PR TITLE
CUDA: allow F32 mul_mat to use fp16 cuBLAS path on Volta/CDNA/RDNA4

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1649,9 +1649,19 @@ static void ggml_cuda_op_mul_mat_cublas(
     const bool supports_bf16 = GGML_CUDA_CC_IS_NVIDIA(cc) || GGML_CUDA_CC_IS_AMD(cc) ||
         (GGML_CUDA_CC_IS_MTHREADS(cc) && cc >= GGML_CUDA_CC_QY2);
 
+    const auto & force_compute_type = ggml_cuda_cublas_get_force_compute_type();
+
+    // Volta and CDNA/RDNA4 don't have a TF32-style fast path for fp32 matmul,
+    // so it's cheaper to downcast F32 inputs to fp16 and use the matrix cores.
+    const bool f32_prefers_fp16_path =
+        src0->type == GGML_TYPE_F32 &&
+        !force_compute_type.fp16 &&
+        (GGML_CUDA_CC_IS_CDNA(cc) || GGML_CUDA_CC_IS_RDNA4(cc) ||
+         cc == GGML_CUDA_CC_VOLTA || force_compute_type.fp32);
+
     const bool use_fp16 =
         src0->type != GGML_TYPE_NVFP4 &&
-        (src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type)) &&
+        (src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type) || f32_prefers_fp16_path) &&
         ggml_is_contiguous(src0) &&
         row_diff == src0->ne[1] &&
         dst->op_params[0] == GGML_PREC_DEFAULT;


### PR DESCRIPTION
# CUDA: allow F32 mul_mat to use fp16 cuBLAS path on Volta/CDNA/RDNA4

Routes F32 → F32 matmuls through fp16 cuBLAS on architectures without a fast F32 matrix path (Volta, CDNA, RDNA 4). The new branch only fires when `src0` is `GGML_TYPE_F32`, so dense model performance remains unchanged (see Llama 8B rows below). MoE models hit it on the F32 router GEMM and produce modest PP improvements.

I tested on my AMD R9700 (gfx1201, RDNA 4, 32 GB) rig under ROCm 7.2.3. I have no Volta or CDNA hardware available to test. The architecture gating (Volta / CDNA / RDNA 4) follows the same reasoning as #19959 and #20078. If anyone can confirm on Volta or CDNA before merge, it would be welcome, but I don't think it's strictly necessary.

- Baseline `master`: `4c1c3ac09`
- Compare `cuda-f32-fp16-path`: `d745985ff`

## Performance

```
llama-bench -m {model.gguf} \
  -ngl 99 -fa 1 -ub 2048 --mmap 0 -dio 1 \
  -p 2048 -n 32 -d 0,4096,8192,16384,32768 \
  -o sql -oe md
```

19 quants (5 Llama-3.1-8B-Instruct, 7 Nemotron-3-Nano-30B-A3B, 7 Qwen3.6-35B-A3B — all Q4 variants), 10 measurement points each (pp2048 + tg32 × 5 depths), 5 reps + warmup. Table generated by upstream `scripts/compare-llama-bench.py`.

| Model                                      | Test          |   t/s master |   t/s cuda-f32-fp16-path |   Speedup |
|:-------------------------------------------|:--------------|-------------:|-------------------------:|----------:|
| llama 8B IQ4_NL - 4.5 bpw                  | pp2048        |      5035.29 |                  4943.73 |      0.98 |
| llama 8B IQ4_NL - 4.5 bpw                  | pp2048@d4096  |      3805.26 |                  3735.84 |      0.98 |
| llama 8B IQ4_NL - 4.5 bpw                  | pp2048@d8192  |      3018.96 |                  2988.20 |      0.99 |
| llama 8B IQ4_NL - 4.5 bpw                  | pp2048@d16384 |      2080.44 |                  2058.64 |      0.99 |
| llama 8B IQ4_NL - 4.5 bpw                  | pp2048@d32768 |      1285.01 |                  1278.61 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw                  | tg32          |       106.59 |                   106.16 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw                  | tg32@d4096    |        97.38 |                    97.12 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw                  | tg32@d8192    |        89.87 |                    89.67 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw                  | tg32@d16384   |        77.86 |                    77.81 |      1.00 |
| llama 8B IQ4_NL - 4.5 bpw                  | tg32@d32768   |        61.58 |                    61.59 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | pp2048        |      4925.35 |                  4910.18 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | pp2048@d4096  |      3727.68 |                  3722.52 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | pp2048@d8192  |      2974.11 |                  2974.85 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | pp2048@d16384 |      2056.38 |                  2053.86 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | pp2048@d32768 |      1276.32 |                  1276.10 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | tg32          |       110.58 |                   110.58 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | tg32@d4096    |       100.94 |                   100.87 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | tg32@d8192    |        92.91 |                    92.88 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | tg32@d16384   |        80.20 |                    80.23 |      1.00 |
| llama 8B IQ4_XS - 4.25 bpw                 | tg32@d32768   |        63.06 |                    63.07 |      1.00 |
| llama 8B Q4_K_M                            | pp2048        |      3774.77 |                  3780.04 |      1.00 |
| llama 8B Q4_K_M                            | pp2048@d4096  |      3027.04 |                  3028.62 |      1.00 |
| llama 8B Q4_K_M                            | pp2048@d8192  |      2515.99 |                  2516.41 |      1.00 |
| llama 8B Q4_K_M                            | pp2048@d16384 |      1826.00 |                  1825.41 |      1.00 |
| llama 8B Q4_K_M                            | pp2048@d32768 |      1183.50 |                  1182.95 |      1.00 |
| llama 8B Q4_K_M                            | tg32          |        95.35 |                    95.25 |      1.00 |
| llama 8B Q4_K_M                            | tg32@d4096    |        88.35 |                    88.33 |      1.00 |
| llama 8B Q4_K_M                            | tg32@d8192    |        82.38 |                    82.35 |      1.00 |
| llama 8B Q4_K_M                            | tg32@d16384   |        72.42 |                    72.44 |      1.00 |
| llama 8B Q4_K_M                            | tg32@d32768   |        58.33 |                    58.36 |      1.00 |
| llama 8B Q4_K_S                            | pp2048        |      4110.27 |                  4113.30 |      1.00 |
| llama 8B Q4_K_S                            | pp2048@d4096  |      3240.62 |                  3241.28 |      1.00 |
| llama 8B Q4_K_S                            | pp2048@d8192  |      2657.58 |                  2657.82 |      1.00 |
| llama 8B Q4_K_S                            | pp2048@d16384 |      1899.69 |                  1904.04 |      1.00 |
| llama 8B Q4_K_S                            | pp2048@d32768 |      1214.69 |                  1214.70 |      1.00 |
| llama 8B Q4_K_S                            | tg32          |        99.35 |                    99.50 |      1.00 |
| llama 8B Q4_K_S                            | tg32@d4096    |        91.65 |                    91.87 |      1.00 |
| llama 8B Q4_K_S                            | tg32@d8192    |        85.29 |                    85.47 |      1.00 |
| llama 8B Q4_K_S                            | tg32@d16384   |        74.59 |                    74.77 |      1.00 |
| llama 8B Q4_K_S                            | tg32@d32768   |        59.74 |                    59.86 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | pp2048        |      4593.45 |                  4679.61 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | pp2048@d4096  |      4359.16 |                  4436.38 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | pp2048@d8192  |      4128.99 |                  4203.67 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | pp2048@d16384 |      3722.99 |                  3788.85 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | pp2048@d32768 |      3139.61 |                  3169.94 |      1.01 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | tg32          |       127.71 |                   127.70 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | tg32@d4096    |       128.09 |                   128.01 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | tg32@d8192    |       126.69 |                   126.60 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | tg32@d16384   |       124.68 |                   124.69 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_NL - 4.5 bpw  | tg32@d32768   |       120.77 |                   120.89 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | pp2048        |      4578.44 |                  4678.89 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | pp2048@d4096  |      4345.47 |                  4428.81 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | pp2048@d8192  |      4130.00 |                  4206.56 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | pp2048@d16384 |      3727.22 |                  3785.93 |      1.02 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | pp2048@d32768 |      3133.01 |                  3176.37 |      1.01 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | tg32          |       127.94 |                   127.71 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | tg32@d4096    |       128.07 |                   128.11 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | tg32@d8192    |       126.61 |                   126.79 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | tg32@d16384   |       124.63 |                   124.83 |      1.00 |
| nemotron_h_moe 31B.A3.5B IQ4_XS - 4.25 bpw | tg32@d32768   |       120.79 |                   121.02 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_0              | pp2048        |      4419.84 |                  4511.25 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_0              | pp2048@d4096  |      4205.10 |                  4282.52 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_0              | pp2048@d8192  |      4003.30 |                  4070.08 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_0              | pp2048@d16384 |      3623.64 |                  3682.49 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_0              | pp2048@d32768 |      3058.66 |                  3095.49 |      1.01 |
| nemotron_h_moe 31B.A3.5B Q4_0              | tg32          |       129.98 |                   129.87 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_0              | tg32@d4096    |       130.22 |                   130.19 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_0              | tg32@d8192    |       128.64 |                   128.89 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_0              | tg32@d16384   |       126.70 |                   126.84 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_0              | tg32@d32768   |       122.76 |                   123.04 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_1              | pp2048        |      4107.90 |                  4180.07 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_1              | pp2048@d4096  |      3915.60 |                  3974.09 |      1.01 |
| nemotron_h_moe 31B.A3.5B Q4_1              | pp2048@d8192  |      3730.61 |                  3793.14 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_1              | pp2048@d16384 |      3401.91 |                  3450.93 |      1.01 |
| nemotron_h_moe 31B.A3.5B Q4_1              | pp2048@d32768 |      2899.57 |                  2940.19 |      1.01 |
| nemotron_h_moe 31B.A3.5B Q4_1              | tg32          |       128.03 |                   128.07 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_1              | tg32@d4096    |       128.38 |                   128.33 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_1              | tg32@d8192    |       126.93 |                   127.08 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_1              | tg32@d16384   |       125.01 |                   125.13 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_1              | tg32@d32768   |       121.16 |                   121.43 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | pp2048        |      4410.65 |                  4500.98 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | pp2048@d4096  |      4193.99 |                  4269.48 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | pp2048@d8192  |      3986.69 |                  4053.82 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | pp2048@d16384 |      3608.21 |                  3665.44 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | pp2048@d32768 |      3050.99 |                  3087.96 |      1.01 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | tg32          |       119.40 |                   119.39 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | tg32@d4096    |       119.73 |                   119.64 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | tg32@d8192    |       118.59 |                   118.50 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | tg32@d16384   |       116.81 |                   116.78 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_M            | tg32@d32768   |       113.48 |                   113.49 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | pp2048        |      4296.11 |                  4371.57 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | pp2048@d4096  |      4089.87 |                  4153.85 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | pp2048@d8192  |      3889.97 |                  3956.57 |      1.02 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | pp2048@d16384 |      3538.98 |                  3585.15 |      1.01 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | pp2048@d32768 |      2996.36 |                  3033.01 |      1.01 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | tg32          |       123.38 |                   123.04 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | tg32@d4096    |       123.64 |                   123.59 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | tg32@d8192    |       122.40 |                   122.21 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | tg32@d16384   |       120.46 |                   120.36 |      1.00 |
| nemotron_h_moe 31B.A3.5B Q4_K_S            | tg32@d32768   |       116.80 |                   116.92 |      1.00 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | pp2048        |      4398.22 |                  4656.43 |      1.06 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | pp2048@d4096  |      3575.76 |                  3747.39 |      1.05 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | pp2048@d8192  |      3009.95 |                  3134.14 |      1.04 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | pp2048@d16384 |      2292.91 |                  2363.00 |      1.03 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | pp2048@d32768 |      1568.99 |                  1599.96 |      1.02 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | tg32          |        85.58 |                    85.19 |      1.00 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | tg32@d4096    |        84.95 |                    85.00 |      1.00 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | tg32@d8192    |        83.44 |                    83.44 |      1.00 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | tg32@d16384   |        81.08 |                    81.06 |      1.00 |
| qwen35moe 35B.A3B IQ4_NL - 4.5 bpw         | tg32@d32768   |        76.48 |                    76.51 |      1.00 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | pp2048        |      4418.44 |                  4663.84 |      1.06 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | pp2048@d4096  |      3591.92 |                  3761.80 |      1.05 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | pp2048@d8192  |      3021.13 |                  3148.49 |      1.04 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | pp2048@d16384 |      2303.61 |                  2365.60 |      1.03 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | pp2048@d32768 |      1572.05 |                  1603.03 |      1.02 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | tg32          |        82.85 |                    82.95 |      1.00 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | tg32@d4096    |        82.19 |                    82.30 |      1.00 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | tg32@d8192    |        80.71 |                    80.78 |      1.00 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | tg32@d16384   |        78.58 |                    78.52 |      1.00 |
| qwen35moe 35B.A3B IQ4_XS - 4.25 bpw        | tg32@d32768   |        74.13 |                    74.24 |      1.00 |
| qwen35moe 35B.A3B Q4_0                     | pp2048        |      4299.04 |                  4537.14 |      1.06 |
| qwen35moe 35B.A3B Q4_0                     | pp2048@d4096  |      3516.20 |                  3674.92 |      1.05 |
| qwen35moe 35B.A3B Q4_0                     | pp2048@d8192  |      2973.89 |                  3081.52 |      1.04 |
| qwen35moe 35B.A3B Q4_0                     | pp2048@d16384 |      2266.20 |                  2333.04 |      1.03 |
| qwen35moe 35B.A3B Q4_0                     | pp2048@d32768 |      1557.46 |                  1586.10 |      1.02 |
| qwen35moe 35B.A3B Q4_0                     | tg32          |        85.81 |                    86.44 |      1.01 |
| qwen35moe 35B.A3B Q4_0                     | tg32@d4096    |        85.79 |                    85.91 |      1.00 |
| qwen35moe 35B.A3B Q4_0                     | tg32@d8192    |        84.31 |                    84.18 |      1.00 |
| qwen35moe 35B.A3B Q4_0                     | tg32@d16384   |        81.81 |                    81.79 |      1.00 |
| qwen35moe 35B.A3B Q4_0                     | tg32@d32768   |        77.20 |                    77.11 |      1.00 |
| qwen35moe 35B.A3B Q4_1                     | pp2048        |      4005.84 |                  4211.78 |      1.05 |
| qwen35moe 35B.A3B Q4_1                     | pp2048@d4096  |      3321.31 |                  3464.40 |      1.04 |
| qwen35moe 35B.A3B Q4_1                     | pp2048@d8192  |      2831.06 |                  2931.00 |      1.04 |
| qwen35moe 35B.A3B Q4_1                     | pp2048@d16384 |      2187.33 |                  2246.33 |      1.03 |
| qwen35moe 35B.A3B Q4_1                     | pp2048@d32768 |      1518.28 |                  1547.56 |      1.02 |
| qwen35moe 35B.A3B Q4_1                     | tg32          |        86.14 |                    86.02 |      1.00 |
| qwen35moe 35B.A3B Q4_1                     | tg32@d4096    |        85.52 |                    85.58 |      1.00 |
| qwen35moe 35B.A3B Q4_1                     | tg32@d8192    |        83.88 |                    83.85 |      1.00 |
| qwen35moe 35B.A3B Q4_1                     | tg32@d16384   |        81.55 |                    81.34 |      1.00 |
| qwen35moe 35B.A3B Q4_1                     | tg32@d32768   |        76.88 |                    76.83 |      1.00 |
| qwen35moe 35B.A3B Q4_K_M                   | pp2048        |      3737.93 |                  3924.45 |      1.05 |
| qwen35moe 35B.A3B Q4_K_M                   | pp2048@d4096  |      3129.42 |                  3258.07 |      1.04 |
| qwen35moe 35B.A3B Q4_K_M                   | pp2048@d8192  |      2691.44 |                  2780.72 |      1.03 |
| qwen35moe 35B.A3B Q4_K_M                   | pp2048@d16384 |      2104.83 |                  2159.19 |      1.03 |
| qwen35moe 35B.A3B Q4_K_M                   | pp2048@d32768 |      1479.62 |                  1506.56 |      1.02 |
| qwen35moe 35B.A3B Q4_K_M                   | tg32          |        78.09 |                    78.02 |      1.00 |
| qwen35moe 35B.A3B Q4_K_M                   | tg32@d4096    |        77.83 |                    77.67 |      1.00 |
| qwen35moe 35B.A3B Q4_K_M                   | tg32@d8192    |        76.49 |                    76.41 |      1.00 |
| qwen35moe 35B.A3B Q4_K_M                   | tg32@d16384   |        74.52 |                    74.40 |      1.00 |
| qwen35moe 35B.A3B Q4_K_M                   | tg32@d32768   |        70.56 |                    70.53 |      1.00 |
| qwen35moe 35B.A3B Q4_K_S                   | pp2048        |      4041.83 |                  4257.52 |      1.05 |
| qwen35moe 35B.A3B Q4_K_S                   | pp2048@d4096  |      3338.57 |                  3490.58 |      1.05 |
| qwen35moe 35B.A3B Q4_K_S                   | pp2048@d8192  |      2842.44 |                  2952.27 |      1.04 |
| qwen35moe 35B.A3B Q4_K_S                   | pp2048@d16384 |      2194.10 |                  2259.88 |      1.03 |
| qwen35moe 35B.A3B Q4_K_S                   | pp2048@d32768 |      1524.41 |                  1554.13 |      1.02 |
| qwen35moe 35B.A3B Q4_K_S                   | tg32          |        76.05 |                    75.95 |      1.00 |
| qwen35moe 35B.A3B Q4_K_S                   | tg32@d4096    |        75.60 |                    75.54 |      1.00 |
| qwen35moe 35B.A3B Q4_K_S                   | tg32@d8192    |        74.38 |                    74.28 |      1.00 |
| qwen35moe 35B.A3B Q4_K_S                   | tg32@d16384   |        72.40 |                    72.31 |      1.00 |
| qwen35moe 35B.A3B Q4_K_S                   | tg32@d32768   |        68.78 |                    68.65 |      1.00 |

## Numerical equivalence (KL divergence)

```
# Pass 1 — baseline records reference logits
llama-perplexity -m {model.gguf} -f wiki.test.raw \
  -c 4096 -fa 1 -ub 2048 -b 8192 -ngl 99 \
  --kl-divergence-base ref.kld

# Pass 2 — patched binary measures divergence vs the reference
llama-perplexity -m {model.gguf} -f wiki.test.raw \
  -c 4096 -fa 1 -ub 2048 -b 8192 -ngl 99 \
  --kl-divergence-base ref.kld --kl-divergence
```

Method mirrors the upstream LLaMA-3 8B Scoreboard in [`tools/perplexity/README.md`](https://github.com/ggml-org/llama.cpp/blob/master/tools/perplexity/README.md#llama-3-8b-scoreboard). The Scoreboard's `f16` line (a 16-bit storage roundtrip on the reference logits) sits at KLD ≈ 5.5×10⁻⁴ and RMS Δp ≈ 0.79 % — that's the floor below which a change is indistinguishable from noise.

| Model | PPL `master` | PPL `cuda-f32-fp16-path` | ΔPPL | KLD | Mean Δp | RMS Δp | Same top p |
|---|---:|---:|---:|---:|---:|---:|---:|
| `Llama-3.1-8B-Instruct-Q4_K_M` | 6.350720 ± 0.038254 | 6.351111 ± 0.038263  | +0.000391 ± 0.000186 | 0.000000 ± 0.000000 | +0.000 ± 0.000 % | 0.001 ± 0.000 % | 99.998 ± 0.001 % |
| `Qwen3.6-35B-A3B-Q4_K_M` | 5.783283 ± 0.035809 | 5.784954 ± 0.035836  | +0.001670 ± 0.002165 | 0.007058 ± 0.000158 | -0.007 ± 0.006 % | 2.470 ± 0.045 % | 96.777 ± 0.046 % |
| `Nemotron-3-Nano-30B-A3B-Q4_K_M` | 6.884376 ± 0.044917 | 6.891916 ± 0.045031  | +0.007540 ± 0.002200 | 0.005231 ± 0.000042 | -0.004 ± 0.005 % | 1.962 ± 0.020 % | 96.858 ± 0.045 % |

### Δp percentiles

Distribution of per-token correct-probability change (patched − baseline). Symmetric tails ≈ pure noise; asymmetric tails (i.e. the negative side larger than the positive side) would indicate systematic degradation.

| Percentile | `Llama-3.1-8B-Instruct-Q4_K_M` | `Qwen3.6-35B-A3B-Q4_K_M` | `Nemotron-3-Nano-30B-A3B-Q4_K_M` |
|---|---:|---:|---:|
| 99.9 % Δp | +0.004 % | +17.176 % | +13.857 % |
| 99.0 % Δp | +0.002 % | +6.675 % | +5.773 % |
| 95.0 % Δp | +0.001 % | +2.736 % | +2.606 % |
| 90.0 % Δp | +0.000 % | +1.561 % | +1.480 % |
| 75.0 % Δp | +0.000 % | +0.322 % | +0.290 % |
| 25.0 % Δp | +0.000 % | -0.319 % | -0.296 % |
| 10.0 % Δp | -0.000 % | -1.566 % | -1.493 % |
| 5.0 % Δp | -0.001 % | -2.787 % | -2.603 % |
| 1.0 % Δp | -0.002 % | -6.716 % | -5.984 % |
| 0.1 % Δp | -0.004 % | -18.460 % | -13.519 % |

