### PR TITLE
sampling: use in-place partition for min_p filtering

### DIFF
--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1551,24 +1551,26 @@ static void llama_sampler_min_p_apply(struct llama_sampler * smpl, llama_token_d
 
     // if the cur_p aren't sorted, try the unsorted implementation first
     if (!cur_p->sorted) {
-        std::vector<llama_token_data> filtered_tokens;
-
         float max_logit = -FLT_MAX;
         for (size_t i = 0; i < cur_p->size; ++i) {
             max_logit = std::max(max_logit, cur_p->data[i].logit);
         }
         const float min_logit = max_logit + logf(ctx->p); // min logit for p_i >= p * p_max
 
+        // in-place partition: swap qualifying tokens to the front
+        size_t n_keep = 0;
         for (size_t i = 0; i < cur_p->size; ++i) {
             if (cur_p->data[i].logit >= min_logit) {
-                filtered_tokens.push_back(cur_p->data[i]);
+                if (n_keep != i) {
+                    std::swap(cur_p->data[n_keep], cur_p->data[i]);
+                }
+                n_keep++;
             }
         }
 
         // if we have enough values the operation was a success
-        if (!filtered_tokens.empty() && filtered_tokens.size() >= ctx->min_keep) {
-            std::copy(filtered_tokens.begin(), filtered_tokens.end(), cur_p->data);
-            cur_p->size = filtered_tokens.size();
+        if (n_keep > 0 && n_keep >= ctx->min_keep) {
+            cur_p->size = n_keep;
             min_p_applied = true;
         }
     }


### PR DESCRIPTION
The unsorted min_p path was allocating a temporary vector, copying qualifying tokens into it, then copying them back into the original array. For large-vocab models (128k+ tokens), that's a heap allocation and ~1.5MB of copies every time a token is sampled.

Switched to an in-place swap partition — qualifying tokens get swapped to the front of the existing array. Same filtering result, no allocations.

## Benchmarks

All sampling tests pass (`test-sampling`, `test-backend-sampler`).

## AI Disclosure

AI was used for initial codebase exploration to identify the optimization opportunity, and formatting. The implementation and benchmarking were done by me.
