### PR TITLE
docs: document `usage` object in server timings response

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1322,6 +1322,19 @@ This provides information on the performance of the server. It also allows calcu
 
 The total number of tokens in context is equal to `prompt_n + cache_n + predicted_n`
 
+The response also includes a standard `usage` object:
+
+```js
+"usage": {
+    "completion_tokens": 48,
+    "prompt_tokens": 44,
+    "total_tokens": 92,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    }
+  },
+```
+
 *Reasoning support*
 
 The server supports parsing and returning reasoning via the `reasoning_content` field, similar to Deepseek API.

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1325,14 +1325,17 @@ The total number of tokens in context is equal to `prompt_n + cache_n + predicte
 The response also includes a standard `usage` object:
 
 ```js
-"usage": {
-    "completion_tokens": 48,
-    "prompt_tokens": 44,
-    "total_tokens": 92,
-    "prompt_tokens_details": {
-      "cached_tokens": 0
+{
+    // ...
+    "usage": {
+        "completion_tokens": 48,
+        "prompt_tokens": 44,
+        "total_tokens": 92,
+        "prompt_tokens_details": {
+            "cached_tokens": 0
+        }
     }
-  },
+}
 ```
 
 *Reasoning support*


### PR DESCRIPTION
## Overview

document `usage` object in chat completion server response

[Spec](https://developers.openai.com/api/reference/resources/completions#(resource)%20completions%20%3E%20(model)%20completion_usage%20%3E%20(schema))

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) YES
- AI usage disclosure: YES only generate commit title