### PR TITLE
ui: Fix handling of MCP resource template parameters

### DIFF
--- a/tools/ui/src/lib/utils/uri-template.ts
+++ b/tools/ui/src/lib/utils/uri-template.ts
@@ -160,7 +160,7 @@ export function expandTemplate(template: string, values: Record<string, string>)
 								(name: string, i: number) =>
 									`${encodeURIComponent(name)}=${encodeURIComponent(expandedParts[i])}`
 							)
-							.join(URI_TEMPLATE_SEPARATORS.COMMA)
+							.join(URI_TEMPLATE_SEPARATORS.QUERY_CONTINUATION)
 					);
 				case URI_TEMPLATE_OPERATORS.FORM_CONTINUATION:
 					// Form-style query continuation

--- a/tools/ui/tests/unit/uri-template.test.ts
+++ b/tools/ui/tests/unit/uri-template.test.ts
@@ -107,6 +107,12 @@ describe('expandTemplate', () => {
 		expect(result).toBe('http://example.com?q=search%20term');
 	});
 
+    it('expands multiple query parameters', () => {
+        const result = expandTemplate('http://example.com{?q,sort}', { q: 'search term', sort: 'descending' });
+        expect(result).toBe('http://example.com?q=search%20term&sort=descending');
+    });
+
+
 	it('keeps static parts unchanged', () => {
 		const result = expandTemplate('http://example.com/static', {});
 		expect(result).toBe('http://example.com/static');

--- a/tools/ui/tests/unit/uri-template.test.ts
+++ b/tools/ui/tests/unit/uri-template.test.ts
@@ -107,11 +107,13 @@ describe('expandTemplate', () => {
 		expect(result).toBe('http://example.com?q=search%20term');
 	});
 
-    it('expands multiple query parameters', () => {
-        const result = expandTemplate('http://example.com{?q,sort}', { q: 'search term', sort: 'descending' });
-        expect(result).toBe('http://example.com?q=search%20term&sort=descending');
-    });
-
+	it('expands multiple query parameters', () => {
+		const result = expandTemplate('http://example.com{?q,sort}', {
+			q: 'search term',
+			sort: 'descending'
+		});
+		expect(result).toBe('http://example.com?q=search%20term&sort=descending');
+	});
 
 	it('keeps static parts unchanged', () => {
 		const result = expandTemplate('http://example.com/static', {});


### PR DESCRIPTION
## Overview

This PR fixes handling of multiple query parameters in a MCP resource template path.

In the resource uri definition (for instance: `history://{ticker}/csv{?period,interval}`), query parameters are indeed separated by a comma. However, on expansion, they should be separated by an ampersand (`&`), thus giving: `history://AAPL/csv?period=1mo&interval=1d`

## Additional information
Llama.cpp's WebUI tested using FastMCP -> https://github.com/kubawoo/super-trader-mcp-server (with commit `449d7f80a84a7259f66a5a566fbb2247a1b3e0f5`)

MCP server side tested with MCP inspector (https://github.com/modelcontextprotocol/inspector) - works fine, both parameters are set correctly, data is returned.

Details on MCP Resource Template query parameters handling can be found here: https://gofastmcp.com/servers/resources#query-parameters

### Current behavior
When trying to add a sample CSV resource via WebUI (for instance `ticker=AAPL`, `period=1mo`, `interval=1d`), MCP server fails with the following error:
```
AAPL: Period '1mo,interval=1d' is invalid, must be one of: 1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max
```
Thus, the `period` and `interval` parameters are not sent properly by llama.cpp - `history://AAPL/csv?period=1mo,interval=1d`

### Expected behavior
Llama.cpp's WebUI should use `&` for query parameters separator, sending the following resource uri: `history://AAPL/csv?period=1mo&interval=1d`

Then the MCP server responds with actual data:
```
event: message
data: {"jsonrpc":"2.0","id":36,"result":{"contents":[{"uri":"history://AAPL/csv?period=1mo&interval=1d","mimeType":"text/plain","text":"Date,Open,High,Low,Close,....
```


## Requirements


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO


