### PR TITLE
server : fix prompt-cache reuse for hybrid/recurrent models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2554,6 +2554,12 @@ private:
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             LOG_INF("slot %12.*s: id %2d | task %d | Checking checkpoint with [%d, %d] against %d...\n", 12,
                                                 func_name, (slot).id, ((slot).task ? (slot).task->id : -1), cur.pos_min, cur.pos_max, pos_min_thold);
+                                            // for hybrid/recurrent models (DeltaNet, Mamba), pos_min always equals
+                                            // the full sequence length, so the SWA-based pos_min check always fails.
+                                            // use pos_max <= pos_next instead to find the most recent valid checkpoint.
+                                            if (llama_model_is_recurrent(model_tgt) || llama_model_is_hybrid(model_tgt)) {
+                                                return cur.pos_max <= pos_next;
+                                            }
                                             return cur.pos_min < pos_min_thold || cur.pos_min == 0;
                                         }
                                     );
@@ -2626,12 +2632,17 @@ private:
                     SLT_INF(slot, "n_tokens = %d, memory_seq_rm [%d, end)\n", slot.prompt.n_tokens(), p0);
 
                     if (!llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, p0, -1)) {
-                        SLT_WRN(slot, "failed to truncate tokens with position >= %d - clearing the memory\n", p0);
+                        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL && slot.n_prompt_tokens_cache > 0) {
+                            // hybrid/recurrent: partial seq_rm always fails, but checkpoint restored valid state
+                            SLT_INF(slot, "seq_rm failed (expected for hybrid) - keeping %d cached tokens from checkpoint\n", slot.n_prompt_tokens_cache);
+                        } else {
+                            SLT_WRN(slot, "failed to truncate tokens with position >= %d - clearing the memory\n", p0);
 
-                        slot.prompt_clear(true);
+                            slot.prompt_clear(true);
 
-                        // there is no common part left
-                        slot.n_prompt_tokens_cache = 0;
+                            // there is no common part left
+                            slot.n_prompt_tokens_cache = 0;
+                        }
                     } else {
                        if (ctx_dft && !llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), slot.id, p0, -1)) {
                            GGML_ABORT("failed to truncate draft context\n");


### PR DESCRIPTION
My Nemotron model was super slow on every message because the server kept reprocessing the whole conversation. Found out this is a known bug on hybrid Mamba+attention models — caching is broken upstream.

Someone named Tongas fixed this on his fork a while ago ([spiritbuun/buun-llama-cpp#26](https://github.com/spiritbuun/buun-llama-cpp/pull/26)), and Alexey ([sanmai](https://github.com/sanmai)) combined that with another change from the closed [#22534](https://github.com/ggml-org/llama.cpp/pull/22534) into a single commit ([sanmai/llama.cpp@e0b8388](https://github.com/sanmai/llama.cpp/commit/e0b83880ad838752cf8b21dd8a6b4154fd4e4e37)). Both their PRs were against forks, never landed upstream.

I just got their patches working on the current master code. Had to rename two variables (`model` → `model_tgt`, `ctx_seq_rm_type` → `ctx_tgt_seq_rm_type`) because the project moved stuff around since their patches were written. Diff is +18 / -5 in one file.

Tested on my Jetson AGX Xavier running [Nemotron-Elastic-12B-A2B i1-Q5_K_M](https://huggingface.co/mradermacher/NVIDIA-Nemotron-Labs-3-Elastic-12B-A2B-i1-GGUF/blob/main/NVIDIA-Nemotron-Labs-3-Elastic-12B-A2B.i1-Q5_K_M.gguf). Before the fix, every message reprocessed everything from scratch (the server logs `forcing full prompt re-processing due to lack of cache data`). After the fix, message 2 only processed the new tokens. Tongas had the same result on Qwen3-Next variants on his RTX 3090 — 11 seconds down to 115 milliseconds.

This affects anyone running hybrid models like Nemotron, Jamba, or Qwen3.5+. Related reports: [#22384](https://github.com/ggml-org/llama.cpp/issues/22384), [#16416](https://github.com/ggml-org/llama.cpp/issues/16416), [#14625](https://github.com/ggml-org/llama.cpp/issues/14625), [#19794](https://github.com/ggml-org/llama.cpp/issues/19794), [#20225](https://github.com/ggml-org/llama.cpp/issues/20225).

Happy to add a test if useful. Can also walk through the code or run more reproductions.

AI usage: used Claude to help me find which closed PRs and forks had the relevant patches and to draft a first version of this description, which the bot caught and I rewrote by hand. Code is human work I rebased. I can defend every line without AI.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Claude helped me find the relevant prior closed PRs and forks. The first draft of this description was AI-assisted (which the automated checker correctly flagged), so I rewrote it in my own words. The code itself is human-authored prior work by @Tongas and @sanmai that I rebased onto current master.
