### PR TITLE
convert: fix dequantizing some fp8 models

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -417,8 +417,11 @@ class ModelBase:
             elif quant_method == "fp8":
                 block_size = quant_config.get("weight_block_size")
                 for name in self.model_tensors.keys():
-                    if name.endswith("_scale_inv"):
+                    if name.endswith(".input_scale"):
+                        tensors_to_remove.append(name)
+                    if name.endswith(("_scale_inv", ".weight_scale")):
                         weight_name = name.removesuffix("_scale_inv")
+                        weight_name = name.removesuffix("_scale")
                         w = self.model_tensors[weight_name]
                         s = self.model_tensors[name]
                         self.model_tensors[weight_name] = lambda w=w, s=s, bs=block_size: dequant_simple(w(), s(), bs)


### PR DESCRIPTION
## Overview
Allow dequantizing some fp8 models.

## Additional information
- input_scale is only used for quantization when mapping to the limited range of FP8 [#22346](https://github.com/ggml-org/llama.cpp/issues/22346#issuecomment-4322421319)
- #14810 fixed [EXAONE-4.0-1.2B-FP8](https://huggingface.co/LGAI-EXAONE/EXAONE-4.0-1.2B-FP8/blob/main/model.safetensors) but is named `weight_scale` in models like [Qwen2-0.5B-Instruct-FP8](https://huggingface.co/RedHatAI/Qwen2-0.5B-Instruct-FP8/blob/main/model.safetensors)
## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: None