### PR TITLE
server : honor --embd-normalize CLI arg

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2787,7 +2787,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.embd_normalize = value;
         }
-    ).set_examples({LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_DEBUG}));
+    ).set_examples({LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_DEBUG}));
     add_opt(common_arg(
         {"--embd-output-format"}, "FORMAT",
         "empty = default, \"array\" = [[],[]...], \"json\" = openai style, \"json+\" = same \"json\" + cosine similarity matrix, \"raw\" = plain whitespace-delimited output (one embedding per line)",

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -4469,7 +4469,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_embeddings_impl(cons
         }
     }
 
-    int embd_normalize = 2; // default to Euclidean/L2 norm
+    int embd_normalize = params.embd_normalize;
     if (body.count("embd_normalize") != 0) {
         embd_normalize = body.at("embd_normalize");
         if (meta->pooling_type == LLAMA_POOLING_TYPE_NONE) {


### PR DESCRIPTION
This PR adds the `--embd-normailize` argument to `llama-server`, making it consistent with `llama-embedding` and `llama-debug` which already support it. Without this CLI flag, changing the output vecor scalling can be done via  the `"embd_normalize":` request argument. 

Changes:
* Add `SERVER` to the `set_examples` list in `arg.cpp`
* Replace the `embd_normalize = 2` in `server-context.cpp` with the CLI value

Tested that the request body argument overrides the CLI argument.

Assisted by Claude Code in researching and addressing this issue. PR description was re-written after being flagged as AI-generated content by the Bot.