### PR TITLE
server: redact URL path/query in handle_media INFO log

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -861,7 +861,13 @@ static void handle_media(
         common_remote_params params;
         params.max_size = 1024 * 1024 * 10; // 10MB
         params.timeout  = 10; // seconds
-        SRV_INF("downloading image from '%s'\n", url.c_str());
+        // Log only scheme://host[:port] at INFO to avoid leaking
+        // attacker-controlled path / query strings into operator log pipelines.
+        // The full URL is preserved at DEBUG for incident response.
+        auto url_origin_end = url.find('/', url.find("://") + 3);
+        std::string url_origin = (url_origin_end == std::string::npos) ? url : url.substr(0, url_origin_end);
+        SRV_INF("downloading image from '%s'\n", url_origin.c_str());
+        SRV_DBG("downloading image full URL '%s'\n", url.c_str());
         auto res = common_remote_get_content(url, params);
         if (200 <= res.first && res.first < 300) {
             SRV_INF("downloaded %zu bytes\n", res.second.size());


### PR DESCRIPTION
## Why

`SRV_INF("downloading image from '%s'\n", url.c_str())` logs the full URL of an `image_url` fetch at INFO level, including path and query string. Operators running with elevated log capture (syslog, journald, ELK) end up with attacker-controlled URLs in their log pipeline. URLs commonly carry tokens, signed query parameters, and session identifiers; logging them in the clear creates a downstream PII / credential leak.

## What

Log only `scheme://host[:port]` at INFO. Preserve the full URL at `SRV_DBG` for operators who opt in to DEBUG for incident response.

## Impact

- Default-deployment logs no longer carry attacker URLs.
- DEBUG mode unchanged for investigators.

## Testing

Build and run llama-server, hit `/v1/chat/completions` with an `image_url`, verify the INFO log contains only `http://host:port` and the DEBUG log contains the full URL.