### PR TITLE
fix: Add build step using build workflow to publish workflow

### DIFF
--- a/.github/workflows/ui-publish.yml
+++ b/.github/workflows/ui-publish.yml
@@ -13,8 +13,13 @@ on:
         required: true
 
 jobs:
+  build:
+    name: Build static output
+    uses: ./.github/workflows/ui-build.yml
+
   publish:
     name: Publish UI Static Output
+    needs: build
     runs-on: ubuntu-24.04-arm
 
     permissions:


### PR DESCRIPTION
## Overview

Fixes the publish workflow by adding the build step (previously we ran build workflow prior to all release workflows and downloaded the artifacts at the end, but now for the binary builds we depend on running the `npm run build` as a part of `cmake` build)

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
