### PR TITLE
server: skip device enumeration in router mode to avoid creating CUDA…

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -372,7 +372,7 @@ void common_init() {
     llama_log_set(common_log_default_callback, NULL);
 }
 
-void common_params_print_info(const common_params & params) {
+void common_params_print_info(const common_params & params, bool print_devices) {
 #ifdef NDEBUG
     const char * build_type = "";
 #else
@@ -381,12 +381,16 @@ void common_params_print_info(const common_params & params) {
     LOG_TRC("%s: build %d (%s) with %s for %s%s\n", __func__, llama_build_number(), llama_commit(), llama_compiler(), llama_build_target(), build_type);
 
     LOG_INF("log_info: verbosity = %d (adjust with the `-lv N` CLI arg)\n", common_log_get_verbosity_thold());
-    LOG_INF("device_info:\n");
-    for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
-        auto * dev = ggml_backend_dev_get(i);
-        size_t free, total;
-        ggml_backend_dev_memory(dev, &free, &total);
-        LOG_INF("  - %-8s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev), total / 1024 / 1024, free / 1024 / 1024);
+
+    // device enumeration creates a primary context on CUDA backends, skip it when the caller does not own any device
+    if (print_devices) {
+        LOG_INF("device_info:\n");
+        for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+            auto * dev = ggml_backend_dev_get(i);
+            size_t free, total;
+            ggml_backend_dev_memory(dev, &free, &total);
+            LOG_INF("  - %-8s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev), total / 1024 / 1024, free / 1024 / 1024);
+        }
     }
     LOG_INF("%s\n", common_params_get_system_info(params).c_str());
 }

--- a/common/common.h
+++ b/common/common.h
@@ -698,7 +698,7 @@ struct common_params {
 // initializes the logging system and prints info about the build
 void common_init();
 
-void common_params_print_info(const common_params & params);
+void common_params_print_info(const common_params & params, bool print_devices = true);
 std::string common_params_get_system_info(const common_params & params);
 
 bool parse_cpu_range(const std::string & range, bool(&boolmask)[GGML_MAX_N_THREADS]);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -86,7 +86,10 @@ int main(int argc, char ** argv) {
     llama_backend_init();
     llama_numa_init(params.numa);
 
-    common_params_print_info(params);
+    // router server never loads a model and must not touch the GPU
+    // skip device enumeration so the CUDA primary context stays uncreated
+    const bool is_router_server = params.model.path.empty();
+    common_params_print_info(params, !is_router_server);
 
     // validate batch size for embeddings
     // embeddings require all tokens to be processed in a single ubatch
@@ -126,7 +129,6 @@ int main(int argc, char ** argv) {
     server_routes routes(params, ctx_server);
     server_tools tools;
 
-    bool is_router_server = params.model.path.empty();
     std::optional<server_models_routes> models_routes{};
     if (is_router_server) {
         // setup server instances manager


### PR DESCRIPTION
## Overview

In router mode (no model loaded), the parent llama-server eats 500MiB of VRAM per CUDA device. (The pre-allocated memory amount is related to GPU SMs number. The GPU with more SMs requires a larger memory)

### Fix this
<img width="740" height="319" alt="2CUDA" src="https://github.com/user-attachments/assets/68fa5991-05cc-4009-a927-876f1fad18c8" />

## Additional information

Regression from #23021, which moved the device info log into common_params_print_info and wired it in main before the router mode gets detected.

The culprit is ggml_backend_dev_memory inside the loop: on CUDA it lands in cudaSetDevice + cudaMemGetInfo, which materialize the primary context on each device. The router parent never touches the GPU, so the context is pure waste and the PID shows up in nvidia-smi. Invisible on Metal because of unified memory, which is why it slipped through.

Fix adds an optional print_devices flag (default true, no other caller touched). Router passes false. Build info, verbosity and system_info still log normally, only the device loop is skipped.

Same class of bug previously fixed in #20595 (closes #20582). Closes #23120.

### router log
```
0.01.397.131 I log_info: verbosity = 3 (adjust with the `-lv N` CLI arg)
0.01.397.185 I system_info: n_threads = 16 ... CUDA : ARCHS = 1200 ...
0.01.397.189 I srv main: n_parallel is set to auto ...
```

### child log
```
[43773] 0.00.043.822 I log_info: verbosity = 3 ...
[43773] 0.00.043.824 I device_info:
[43773] 0.00.121.335 I   - CUDA0   : NVIDIA RTX PRO 6000 Blackwell ... (97247 MiB, 96689 MiB free)
[43773] 0.00.121.343 I   - CPU     : AMD Ryzen 9 9950X3D 16-Core Processor (94190 MiB, ...)
[43773] 0.00.121.414 I system_info: ...
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES Opus 4.7 + GPU pod

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
