### PR TITLE
ui: Correct links in `tools/ui/README.md` [no ci]

### DIFF
--- a/tools/ui/README.md
+++ b/tools/ui/README.md
@@ -681,6 +681,6 @@ tools/ui/
 
 ## Related Documentation
 
-- [llama.cpp Server README](../README.md) - Full server documentation
-- [Multimodal Documentation](../../../docs/multimodal.md) - Image and audio support
-- [Function Calling](../../../docs/function-calling.md) - Tool use capabilities
+- [llama.cpp Server README](../server/README.md) - Full server documentation
+- [Multimodal Documentation](../../docs/multimodal.md) - Image and audio support
+- [Function Calling](../../docs/function-calling.md) - Tool use capabilities


### PR DESCRIPTION
In [`tools/ui/README.md`](https://github.com/ggml-org/llama.cpp/blob/master/tools/ui/README.md#related-documentation), update the relative links, now that the `README.md` file has been moved from `tools/server/webui/` to `tools/ui/` by commit https://github.com/ggml-org/llama.cpp/commit/59778f0196a82db32580bb649d5d839355d6d7bf.