### PR TITLE
Fix: support per-layer key/value dimension arrays for Qwen3.5

### DIFF
--- a/src/llama-hparams.cpp
+++ b/src/llama-hparams.cpp
@@ -86,17 +86,17 @@ uint32_t llama_hparams::n_embd_out() const {
 
 uint32_t llama_hparams::n_embd_head_k(uint32_t il) const {
     if (il < n_layer) {
+        if (n_embd_head_k_full_arr[il] != 0) return n_embd_head_k_full_arr[il];
         return is_swa(il) ? n_embd_head_k_swa : n_embd_head_k_full;
     }
-
     GGML_ABORT("fatal error");
 }
 
 uint32_t llama_hparams::n_embd_head_v(uint32_t il) const {
     if (il < n_layer) {
+        if (n_embd_head_v_full_arr[il] != 0) return n_embd_head_v_full_arr[il];
         return is_swa(il) ? n_embd_head_v_swa : n_embd_head_v_full;
     }
-
     GGML_ABORT("fatal error");
 }
 

--- a/src/llama-hparams.h
+++ b/src/llama-hparams.h
@@ -53,6 +53,8 @@ struct llama_hparams {
     uint32_t n_embd_head_v_full; // dimension of values (d_v) aka n_embd_head
     uint32_t n_embd_head_k_swa;
     uint32_t n_embd_head_v_swa;
+    std::array<uint32_t, LLAMA_MAX_LAYERS> n_embd_head_k_full_arr;
+    std::array<uint32_t, LLAMA_MAX_LAYERS> n_embd_head_v_full_arr;
 
     // different RoPE dimensions for full_attention and SWA layers
     uint32_t n_rot_full;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1099,10 +1099,18 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
         // gpt-j n_rot = rotary_dim
 
         hparams.n_embd_head_k_full = hparams.n_embd / hparams.n_head();
-        ml.get_key(LLM_KV_ATTENTION_KEY_LENGTH, hparams.n_embd_head_k_full, false);
+        if (ml.get_key_or_arr(LLM_KV_ATTENTION_KEY_LENGTH, hparams.n_embd_head_k_full_arr, hparams.n_layer, false)) {
+            hparams.n_embd_head_k_full = hparams.n_embd_head_k_full_arr[0];
+        } else {
+            ml.get_key(LLM_KV_ATTENTION_KEY_LENGTH, hparams.n_embd_head_k_full, false);
+        }
 
         hparams.n_embd_head_v_full = hparams.n_embd / hparams.n_head();
-        ml.get_key(LLM_KV_ATTENTION_VALUE_LENGTH, hparams.n_embd_head_v_full, false);
+        if (ml.get_key_or_arr(LLM_KV_ATTENTION_VALUE_LENGTH, hparams.n_embd_head_v_full_arr, hparams.n_layer, false)) {
+            hparams.n_embd_head_v_full = hparams.n_embd_head_v_full_arr[0];
+        } else {
+            ml.get_key(LLM_KV_ATTENTION_VALUE_LENGTH, hparams.n_embd_head_v_full, false);
+        }
 
         // sanity check for n_rot (optional)
         hparams.n_rot_full = hparams.n_embd_head_k_full;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                
                                                            
  Qwen3.5 SSM layers have different key/value head dimensions than full-attention layers.                                                                                                                                                   
  The current code assumes all layers share the same `n_embd_head_k/v`, but newer                                                                                                                                                           
  GGUF format stores **per-layer arrays** for these values.                                                                                                                                                                                 
                                                                                                                                                                                                                                            
  ## Problem                                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  Without per-layer support, mixed-architecture models (SSM + full-attention layers                                                                                                                                                         
  with different head dimensions) fail to load or use wrong dimensions, causing
  incorrect KV cache allocation and garbage output.                                                                                                                                                                                         
                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                            
  1. **Add per-layer arrays** to `llama_hparams`: `n_embd_head_k_full_arr[n_layer]`                                                                                                                                                         
     and `n_embd_head_v_full_arr[n_layer]`                  
                                                                                                                                                                                                                                            
  2. **Prefer per-layer values** in accessors: if `_arr[il] != 0`, use it.                                                                                                                                                                  
     Fall back to global `n_embd_head_k/v` for backward compatibility.                                                                                                                                                                      
                                                                                                                                                                                                                                            
  3. **Parse per-layer arrays** via `get_key_or_arr()`: try per-layer array first,                                                                                                                                                          
     fall back to scalar key for older GGUF files.                                                                                                                                                                                          
                                                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  | File | Change |                                                                                                                                                                                                                         
  |---|---|                                                 
  | `llama-hparams.h` | +2 array fields |                                                                                                                                                                                                   
  | `llama-hparams.cpp` | Check per-layer array in accessors |                                                                                                                                                                              
  | `llama-model.cpp` | Parse per-layer arrays from GGUF metadata |                                                                                                                                                                         
                                                                                                                                                                                                                                            
  ## Compatibility                                                                                                                                                                                                                          
                                                                                                                                                                                                                                            
  Fully backward compatible. Older GGUF files with scalar values still work —                                                                                                                                                               
  per-layer arrays are tried first, scalar is the fallback. 
