### PR TITLE
Fix: model loader array length check should not throw when optional

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -453,7 +453,10 @@ namespace GGUFMeta {
                 GGUFMeta::GKV<GGUFMeta::ArrayInfo>::get_kv(metadata, kid);
 
             if (n != arr_info.length) {
-                throw std::runtime_error(format("key %s has wrong array length; expected %u, got %u", key.c_str(), n, (uint32_t) arr_info.length));
+                if (required) {
+                    throw std::runtime_error(format("key %s has wrong array length; expected %u, got %u", key.c_str(), n, (uint32_t) arr_info.length));
+                }
+                return false;
             }
 
             return get_arr(key, result, required);


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                
                                                            
  `get_key_or_arr()` unconditionally throws when array length doesn't match, even when                                                                                                                                                      
  `required=false`. This breaks optional per-layer array loads for mixed-architecture                                                                                                                                                       
  models where the array length varies per model variant.                                                                                                                                                                                   
                                                                                                                                                                                                                                            
  ## Problem                                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  When loading an optional per-layer array (`get_key_or_arr(key, arr, n_layer, false)`),                                                                                                                                                    
  a length mismatch between the expected layer count and the actual array length throws
  a hard error. With `required=false`, the function should return `false` instead —                                                                                                                                                         
  the caller handles the fallback.                                                                                                                                                                                                          
                                                                                                                                                                                                                                            
  This blocks Qwen3.5 models where per-layer dimension arrays have different                                                                                                                                                                
  lengths depending on the variant (7B vs 9B vs 14B vs 72B).                                                                                                                                                                                
                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                            
  Guard the length-mismatch throw with `if (required)`. When `required=false`,                                                                                                                                                              
  return `false` instead of throwing. The caller falls back to the global scalar value.
                                                                                                                                                                                                                                            
  ## Change                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                            
  `src/llama-model-loader.cpp`: 1 line — wrap `throw` in `if (required)` block.                                                                                                                                                             
                                                            
  ## Compatibility                                                                                                                                                                                                                          
                                                            
  Zero impact on existing code. All `required=true` callers (the common case)                                                                                                                                                               
  throw as before. Only `required=false` callers are affected — they now
  gracefully fall back instead of crashing.  