### PR TITLE
[SYCL] Offload MTP to CPU

### DIFF
--- a/ggml/src/ggml-sycl/gated_delta_net.hpp
+++ b/ggml/src/ggml-sycl/gated_delta_net.hpp
@@ -7,3 +7,6 @@
 
 void ggml_sycl_op_gated_delta_net(ggml_backend_sycl_context & ctx, ggml_tensor * dst);
 void ggml_sycl_gated_delta_net(ggml_backend_sycl_context & ctx, ggml_tensor * dst);
+
+// the kernel for GATED_DELTA_NET does not support K > 1 that is required for MTP
+#define GATED_DELTA_NET_MAX_K 1

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -5276,8 +5276,9 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_RWKV_WKV6:
         case GGML_OP_RWKV_WKV7:
         case GGML_OP_GATED_LINEAR_ATTN:
-        case GGML_OP_GATED_DELTA_NET:
             return true;
+        case GGML_OP_GATED_DELTA_NET:
+            return op->src[5]->ne[1] <= GATED_DELTA_NET_MAX_K;
         case GGML_OP_SSM_CONV:
             return op->type == GGML_TYPE_F32 &&
                    op->src[0]->type == GGML_TYPE_F32 &&


### PR DESCRIPTION
## Overview

Let's offload requests with K > 1 to the CPU backend, as the `GATED_DELTA_NET` kernel currently only supports K=1. 

## Additional information

Related to #23149. If #23174 ends up being good, this PR will be redundant.

CPU offload offers modest improvements on my dated machine:

```diff
-slot print_timing: id  0 | task 0 | n_decoded =    100, tg =   7.83 t/s
+slot print_timing: id  0 | task 0 | n_decoded =    101, tg =  10.77 t/s
+draft acceptance rate = 0.63168 ( 1715 accepted /  2715 generated)
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for the root cause analysis.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
