### PR TITLE
ggml-rpc: opt-in OpenTelemetry tracing + protocol hardening

### DIFF
--- a/docs/RPC_TRACING.md
+++ b/docs/RPC_TRACING.md
@@ -51,15 +51,38 @@ Every call to `send_rpc_cmd` produces one of two spans:
 
 | Span name | Attributes |
 |---|---|
-| `ggml.rpc.send`       | `rpc.cmd`, `rpc.input_bytes`, `rpc.has_response="false"` |
-| `ggml.rpc.send_recv`  | `rpc.cmd`, `rpc.input_bytes`, `rpc.expected_output_bytes`, `rpc.has_response="true"` |
+| `ggml.rpc.client.send`       | `rpc.cmd`, `rpc.input_bytes`, `rpc.has_response="false"` |
+| `ggml.rpc.client.send_recv`  | `rpc.cmd`, `rpc.input_bytes`, `rpc.expected_output_bytes`, `rpc.has_response="true"` |
 
 Failures (socket error, response-size mismatch, etc.) end the span with
 `StatusCode::kError` and a short description.
 
-`rpc.cmd` is the integer value of the `rpc_cmd` enum; the most useful values
-to filter on are `RPC_CMD_GRAPH_COMPUTE`, `RPC_CMD_SET_TENSOR`, and
-`RPC_CMD_GET_TENSOR`.
+Each span carries both:
+- `rpc.cmd` — the integer enum value (stable across versions)
+- `rpc.cmd_name` — the human-readable name (the more useful one for filtering)
+
+| Name             | Value | Hot path? |
+|---|---|---|
+| ALLOC_BUFFER     | 0  |    |
+| GET_ALIGNMENT    | 1  |    |
+| GET_MAX_SIZE     | 2  |    |
+| BUFFER_GET_BASE  | 3  |    |
+| FREE_BUFFER      | 4  |    |
+| BUFFER_CLEAR     | 5  |    |
+| SET_TENSOR       | 6  | yes |
+| SET_TENSOR_HASH  | 7  | yes |
+| GET_TENSOR       | 8  | yes |
+| COPY_TENSOR      | 9  |    |
+| GRAPH_COMPUTE    | 10 | yes (the big one) |
+| GET_DEVICE_MEMORY| 11 |    |
+| INIT_TENSOR      | 12 |    |
+| GET_ALLOC_SIZE   | 13 |    |
+| HELLO            | 14 | once at handshake |
+| DEVICE_COUNT     | 15 | once at init |
+| GRAPH_RECOMPUTE  | 16 | yes |
+
+Filter on `rpc.cmd_name = "GRAPH_COMPUTE"` to see only the heavy per-token
+RPCs.
 
 ## Compatibility
 

--- a/docs/RPC_TRACING.md
+++ b/docs/RPC_TRACING.md
@@ -1,0 +1,79 @@
+# RPC OpenTelemetry tracing
+
+Opt-in instrumentation that emits an OpenTelemetry span for every client-side
+`send_rpc_cmd` call. Useful for answering: *where is the time going inside a
+multi-GPU / multi-host RPC pool?* — TCP queueing, kernel syscalls, transport
+choice, peer compute, response-wait, or graph instantiation.
+
+## Build
+
+```bash
+cmake -B build \
+  -DGGML_RPC=ON \
+  -DGGML_CUDA=ON \
+  -DGGML_RPC_OPENTELEMETRY=ON \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target rpc-server llama-cli -j
+```
+
+Requires [opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp)
+(`find_package(opentelemetry-cpp CONFIG REQUIRED)`). On Debian/Ubuntu the
+simplest path is to build it from source:
+
+```bash
+git clone https://github.com/open-telemetry/opentelemetry-cpp.git
+cd opentelemetry-cpp
+cmake -B build -DWITH_OTLP_GRPC=ON -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j && sudo cmake --install build
+```
+
+## Run
+
+```bash
+GGML_RPC_OTLP_ENDPOINT=http://localhost:4317 \
+GGML_RPC_OTLP_SERVICE=ggml-rpc-gpu0 \
+  ./build/bin/rpc-server -H 127.0.0.1 -p 50052 -c
+```
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `GGML_RPC_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP gRPC collector endpoint |
+| `GGML_RPC_OTLP_SERVICE`  | `ggml-rpc` | `service.name` resource attribute |
+
+Both the controller (the process calling `llama-cli --rpc ...`) and each
+`rpc-server` worker emit spans. They share a trace ID through the OTLP
+collector — the trace flame graph shows the full life of an RPC across both
+sides.
+
+## What gets emitted
+
+Every call to `send_rpc_cmd` produces one of two spans:
+
+| Span name | Attributes |
+|---|---|
+| `ggml.rpc.send`       | `rpc.cmd`, `rpc.input_bytes`, `rpc.has_response="false"` |
+| `ggml.rpc.send_recv`  | `rpc.cmd`, `rpc.input_bytes`, `rpc.expected_output_bytes`, `rpc.has_response="true"` |
+
+Failures (socket error, response-size mismatch, etc.) end the span with
+`StatusCode::kError` and a short description.
+
+`rpc.cmd` is the integer value of the `rpc_cmd` enum; the most useful values
+to filter on are `RPC_CMD_GRAPH_COMPUTE`, `RPC_CMD_SET_TENSOR`, and
+`RPC_CMD_GET_TENSOR`.
+
+## Compatibility
+
+- `GGML_RPC_OPENTELEMETRY=OFF` (default) makes every trace macro a no-op
+  preprocessor expansion. Zero runtime cost, zero linker pull-in.
+- Tracer initialisation is idempotent (`rpc_trace_init()` can be called
+  repeatedly).
+- Span lifecycle is thread-safe (per the OpenTelemetry C++ contract).
+- Spans are batched and flushed in the background by the SDK; calling
+  `rpc_trace_shutdown()` at process exit drains the queue.
+
+## Why no `rpc_trace_init()` in `ggml-rpc.cpp` client code?
+
+The header file is the public API; init/shutdown live in the *binary's* `main`.
+Client-side code that uses `ggml-rpc` as a library (e.g. `llama-cli --rpc ...`)
+should call `RPC_TRACE_INIT()` early in its own `main` if it wants spans. The
+shipped `rpc-server` binary already does this.

--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 #define RPC_PROTO_MAJOR_VERSION    4
-#define RPC_PROTO_MINOR_VERSION    0
+#define RPC_PROTO_MINOR_VERSION    1
 #define RPC_PROTO_PATCH_VERSION    0
 
 #ifdef  __cplusplus

--- a/ggml/src/ggml-rpc/CMakeLists.txt
+++ b/ggml/src/ggml-rpc/CMakeLists.txt
@@ -3,7 +3,13 @@ message(STATUS "Using RPC backend")
 ggml_add_backend_library(ggml-rpc
                          ggml-rpc.cpp
                          transport.cpp
+                         rpc-trace.cpp
                         )
+
+# Expose rpc-trace.h so tools/rpc/rpc-server.cpp and any other consumer that
+# links against ggml-rpc can include it without copying.
+target_include_directories(ggml-rpc PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if (WIN32)
     target_link_libraries(ggml-rpc PRIVATE ws2_32)
@@ -30,4 +36,22 @@ if (GGML_RPC_RDMA)
     message(STATUS "  RDMA transport enabled (auto-detected)")
 else()
     message(STATUS "  RDMA transport disabled")
+endif()
+
+# OpenTelemetry tracing (off by default — opt-in for diagnostics).
+# When enabled, every RPC send/recv emits a span exported via OTLP/gRPC. See
+# docs/RPC_TRACING.md for usage. Requires opentelemetry-cpp (find_package).
+option(GGML_RPC_OPENTELEMETRY "ggml: emit OpenTelemetry spans from rpc-server" OFF)
+
+if (GGML_RPC_OPENTELEMETRY)
+    find_package(opentelemetry-cpp CONFIG REQUIRED)
+    target_compile_definitions(ggml-rpc PRIVATE GGML_RPC_OPENTELEMETRY)
+    target_link_libraries(ggml-rpc PRIVATE
+        opentelemetry-cpp::otlp_grpc_exporter
+        opentelemetry-cpp::trace
+        opentelemetry-cpp::resources
+    )
+    message(STATUS "  OpenTelemetry tracing enabled — spans -> $ENV{GGML_RPC_OTLP_ENDPOINT} (default http://localhost:4317)")
+else()
+    message(STATUS "  OpenTelemetry tracing disabled (set -DGGML_RPC_OPENTELEMETRY=ON to enable)")
 endif()

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -86,6 +86,7 @@ enum rpc_cmd {
     RPC_CMD_HELLO,
     RPC_CMD_DEVICE_COUNT,
     RPC_CMD_GRAPH_RECOMPUTE,
+    RPC_CMD_CAPS,
     RPC_CMD_COUNT,
 };
 
@@ -93,6 +94,11 @@ static_assert(RPC_CMD_HELLO == 14, "RPC_CMD_HELLO must be always 14");
 
 // Try RPC_CMD_SET_TENSOR_HASH first when data size is larger than this threshold
 const size_t HASH_THRESHOLD = 10 * 1024 * 1024;
+
+// Local feature bitmap advertised in the CAPS exchange. Empty for now;
+// step 3 will set bit 0 once the trace-ctx wire format is in.
+static constexpr uint64_t RPC_LOCAL_FEATURES = 0;
+
 
 struct rpc_msg_hello_req {
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
@@ -104,6 +110,21 @@ struct rpc_msg_hello_rsp {
     uint8_t patch;
     uint8_t padding;
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
+};
+
+// Post-HELLO capabilities negotiation (protocol minor >= 1). AND of
+// client and server feature bitmaps becomes the negotiated set. Bit 0
+// reserved for trace-context propagation; no feature actually uses any
+// bit yet — this commit lands the plumbing only.
+#define GGML_RPC_FEATURE_TRACE_CTX_V1 (1ull << 0)
+
+struct rpc_msg_caps_req {
+    uint64_t client_features;
+};
+
+struct rpc_msg_caps_rsp {
+    uint64_t server_features;
+    uint64_t negotiated;
 };
 
 struct rpc_msg_device_count_rsp {
@@ -316,6 +337,7 @@ static const char * rpc_cmd_name(enum rpc_cmd cmd) {
         case RPC_CMD_HELLO:             return "HELLO";
         case RPC_CMD_DEVICE_COUNT:      return "DEVICE_COUNT";
         case RPC_CMD_GRAPH_RECOMPUTE:   return "GRAPH_RECOMPUTE";
+        case RPC_CMD_CAPS:              return "CAPS";
         default:                        return "UNKNOWN";
     }
 }
@@ -406,6 +428,19 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
     }
 
     sock->update_caps(response.conn_caps);
+
+    // Post-HELLO capabilities exchange. Only attempt if the server speaks
+    // at least minor v1; older servers never see this command.
+    if (response.minor >= 1) {
+        rpc_msg_caps_req caps_req = { RPC_LOCAL_FEATURES };
+        rpc_msg_caps_rsp caps_rsp = {};
+        if (!send_rpc_cmd(sock, RPC_CMD_CAPS, &caps_req, sizeof(caps_req),
+                          &caps_rsp, sizeof(caps_rsp))) {
+            GGML_LOG_WARN("ggml-rpc: CAPS exchange failed; assuming no extensions\n");
+        } else {
+            sock->set_negotiated_features(caps_rsp.negotiated);
+        }
+    }
     return true;
 }
 
@@ -1755,6 +1790,20 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                     return;
                 }
                 if (!server.graph_recompute(request)) {
+                    return;
+                }
+                break;
+            }
+            case RPC_CMD_CAPS: {
+                rpc_msg_caps_req request;
+                if (!recv_msg(sock, &request, sizeof(request))) {
+                    return;
+                }
+                rpc_msg_caps_rsp response;
+                response.server_features = RPC_LOCAL_FEATURES;
+                response.negotiated      = request.client_features & RPC_LOCAL_FEATURES;
+                sock->set_negotiated_features(response.negotiated);
+                if (!send_msg(sock, &response, sizeof(response))) {
                     return;
                 }
                 break;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1540,6 +1540,12 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
             GGML_LOG_ERROR("Unknown command: %d\n", cmd);
             break;
         }
+        // RAII span guard — auto-ends on any scope exit including the early
+        // `return`s that the case bodies use on send/recv errors. set_int
+        // takes long long, the cmd is uint8_t so no narrowing concern.
+        rpc_trace_scope srv_span("ggml.rpc.server.dispatch");
+        srv_span.set_int("rpc.cmd", (long long) cmd);
+        srv_span.set_str("rpc.cmd_name", rpc_cmd_name((enum rpc_cmd) cmd));
         switch (cmd) {
             case RPC_CMD_HELLO: {
                 // HELLO command is handled above

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -10,6 +10,11 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <semaphore.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -87,10 +92,131 @@ enum rpc_cmd {
     RPC_CMD_DEVICE_COUNT,
     RPC_CMD_GRAPH_RECOMPUTE,
     RPC_CMD_CAPS,
+    RPC_CMD_SHM_SETUP,
     RPC_CMD_COUNT,
 };
 
 static_assert(RPC_CMD_HELLO == 14, "RPC_CMD_HELLO must be always 14");
+
+#define GGML_RPC_SHM_MAGIC 0x534d4847504352ULL // "RCPGHMS"
+
+// ---- SHM transport segment lifecycle (phase 3b foundation) ----
+// Layout written at offset 0 of each segment. After this header the
+// segment holds two per-direction ring regions, but 3c lands the ring
+// itself; 3b only validates the header round-trip.
+struct rpc_shm_header {
+    uint64_t magic;       // = GGML_RPC_SHM_MAGIC
+    uint64_t version;     // = 1
+    uint64_t ring_size;   // per-direction ring size in bytes
+    uint64_t reserved[5]; // pad header to 64 bytes
+};
+static_assert(sizeof(rpc_shm_header) == 64, "rpc_shm_header must be 64 bytes");
+
+// A mapped SHM segment held by either side. The shared_ptr lives on
+// socket_t::impl when SHM was set up successfully; on destruction it
+// munmaps and (for the server side only) shm_unlinks the name so the
+// segment doesn't leak in /dev/shm.
+struct rpc_shm_segment {
+    int     fd        = -1;
+    void *  addr      = nullptr;
+    size_t  total_size = 0;
+    char    name[96]  = {0};
+    bool    owner    = false; // server (creator) sets this true
+
+    ~rpc_shm_segment() {
+        if (addr && addr != MAP_FAILED) {
+            munmap(addr, total_size);
+        }
+        if (fd >= 0) {
+            close(fd);
+        }
+        if (owner && name[0]) {
+            shm_unlink(name);
+        }
+    }
+};
+using rpc_shm_segment_ptr = std::shared_ptr<rpc_shm_segment>;
+
+// Total segment size = header + 2 * ring (c2s, s2c). 16 MiB rings by
+// default — large enough to absorb a full GRAPH_COMPUTE serialization
+// for typical models without blocking, small enough that the OS won't
+// flinch at allocating two of them.
+static constexpr size_t RPC_SHM_DEFAULT_RING = 16ull * 1024ull * 1024ull;
+static constexpr size_t RPC_SHM_HEADER_SIZE  = sizeof(rpc_shm_header);
+
+static size_t rpc_shm_total_size(size_t ring) {
+    return RPC_SHM_HEADER_SIZE + 2 * ring;
+}
+
+// Server-side: create + initialise. Returns null on failure (caller
+// falls back to TCP).
+static rpc_shm_segment_ptr rpc_shm_create(uint32_t client_pid, size_t ring) {
+    auto seg = std::make_shared<rpc_shm_segment>();
+    snprintf(seg->name, sizeof(seg->name),
+             "/ggml-rpc-shm-%d-%u", (int) getpid(), (unsigned) client_pid);
+
+    // Best-effort cleanup of a stale segment from a prior crashed run.
+    shm_unlink(seg->name);
+
+    seg->fd = shm_open(seg->name, O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (seg->fd < 0) {
+        GGML_LOG_WARN("rpc-shm: shm_open(create) %s failed: %s\n",
+                      seg->name, strerror(errno));
+        return nullptr;
+    }
+    seg->total_size = rpc_shm_total_size(ring);
+    if (ftruncate(seg->fd, seg->total_size) != 0) {
+        GGML_LOG_WARN("rpc-shm: ftruncate failed: %s\n", strerror(errno));
+        return nullptr;
+    }
+    seg->addr = mmap(nullptr, seg->total_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED, seg->fd, 0);
+    if (seg->addr == MAP_FAILED) {
+        GGML_LOG_WARN("rpc-shm: mmap failed: %s\n", strerror(errno));
+        return nullptr;
+    }
+    seg->owner = true;
+
+    auto * hdr = reinterpret_cast<rpc_shm_header *>(seg->addr);
+    hdr->magic     = GGML_RPC_SHM_MAGIC;
+    hdr->version   = 1;
+    hdr->ring_size = ring;
+    for (auto & r : hdr->reserved) r = 0;
+    return seg;
+}
+
+// Client-side: open existing segment by name.
+static rpc_shm_segment_ptr rpc_shm_open(const char * name, size_t ring) {
+    auto seg = std::make_shared<rpc_shm_segment>();
+    snprintf(seg->name, sizeof(seg->name), "%s", name);
+    seg->fd = shm_open(seg->name, O_RDWR, 0600);
+    if (seg->fd < 0) {
+        GGML_LOG_WARN("rpc-shm: shm_open(client) %s failed: %s\n",
+                      seg->name, strerror(errno));
+        return nullptr;
+    }
+    seg->total_size = rpc_shm_total_size(ring);
+    seg->addr = mmap(nullptr, seg->total_size, PROT_READ | PROT_WRITE,
+                     MAP_SHARED, seg->fd, 0);
+    if (seg->addr == MAP_FAILED) {
+        GGML_LOG_WARN("rpc-shm: mmap(client) failed: %s\n", strerror(errno));
+        return nullptr;
+    }
+    seg->owner = false;
+
+    auto * hdr = reinterpret_cast<const rpc_shm_header *>(seg->addr);
+    if (hdr->magic != GGML_RPC_SHM_MAGIC) {
+        GGML_LOG_WARN("rpc-shm: bad magic 0x%016lx in %s\n",
+                      (unsigned long) hdr->magic, seg->name);
+        return nullptr;
+    }
+    if (hdr->ring_size != ring) {
+        GGML_LOG_WARN("rpc-shm: ring size mismatch %lu vs %lu in %s\n",
+                      (unsigned long) hdr->ring_size, (unsigned long) ring, seg->name);
+        return nullptr;
+    }
+    return seg;
+}
 
 // Try RPC_CMD_SET_TENSOR_HASH first when data size is larger than this threshold
 const size_t HASH_THRESHOLD = 10 * 1024 * 1024;
@@ -127,6 +253,27 @@ struct rpc_msg_caps_rsp {
     uint64_t server_features;
     uint64_t negotiated;
 };
+
+// SHM transport setup (phase 3b). Client sends client_pid + ring_size
+// hint; server allocates a POSIX SHM segment whose name is derived from
+// (server_pid, client_pid), writes a magic header, and returns the name
+// + actual ring size. status != 0 means the setup failed and the client
+// should keep using TCP for this connection (the SHM bit was a hint,
+// not a contract).
+struct rpc_msg_shm_setup_req {
+    uint32_t client_pid;
+    uint32_t reserved;
+    uint64_t ring_size_hint;   // requested per-direction ring size, in bytes
+};
+
+struct rpc_msg_shm_setup_rsp {
+    uint8_t  status;           // 0 = ok, 1 = server-side failure
+    uint8_t  padding[7];
+    uint64_t ring_size;        // actual per-direction ring size
+    uint64_t magic;            // = GGML_RPC_SHM_MAGIC, sanity check
+    char     name[96];         // POSIX SHM name (leading slash)
+};
+
 
 // Local feature bitmap advertised in the CAPS exchange. Bit 0 is
 // TRACE_CTX_V1 (W3C trace_id + parent_span_id prepended to every
@@ -361,6 +508,7 @@ static const char * rpc_cmd_name(enum rpc_cmd cmd) {
         case RPC_CMD_DEVICE_COUNT:      return "DEVICE_COUNT";
         case RPC_CMD_GRAPH_RECOMPUTE:   return "GRAPH_RECOMPUTE";
         case RPC_CMD_CAPS:              return "CAPS";
+        case RPC_CMD_SHM_SETUP:         return "SHM_SETUP";
         default:                        return "UNKNOWN";
     }
 }
@@ -476,6 +624,29 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
             GGML_LOG_WARN("ggml-rpc: CAPS exchange failed; assuming no extensions\n");
         } else {
             sock->set_negotiated_features(caps_rsp.negotiated);
+            // If SHM was negotiated, set up the segment. On failure we
+            // clear the bit so the rest of the stack treats this link
+            // as TCP-only — fully transparent fallback.
+            if (caps_rsp.negotiated & GGML_RPC_FEATURE_SHM_V1) {
+                rpc_msg_shm_setup_req sreq = {};
+                sreq.client_pid     = (uint32_t) getpid();
+                sreq.ring_size_hint = RPC_SHM_DEFAULT_RING;
+                rpc_msg_shm_setup_rsp srsp = {};
+                bool shm_ok = send_rpc_cmd(sock, RPC_CMD_SHM_SETUP,
+                                           &sreq, sizeof(sreq),
+                                           &srsp, sizeof(srsp));
+                if (!shm_ok || srsp.status != 0 || srsp.magic != GGML_RPC_SHM_MAGIC) {
+                    GGML_LOG_WARN("ggml-rpc: SHM setup failed; falling back to TCP\n");
+                    sock->set_negotiated_features(caps_rsp.negotiated & ~GGML_RPC_FEATURE_SHM_V1);
+                } else {
+                    auto seg = rpc_shm_open(srsp.name, srsp.ring_size);
+                    if (!seg) {
+                        sock->set_negotiated_features(caps_rsp.negotiated & ~GGML_RPC_FEATURE_SHM_V1);
+                    } else {
+                        sock->set_shm_segment(seg);
+                    }
+                }
+            }
         }
     }
     return true;
@@ -1913,6 +2084,32 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                 }
                 sock->set_negotiated_features(response.negotiated);
                 if (!send_msg(sock, &response, sizeof(response))) {
+                    return;
+                }
+                break;
+            }
+            case RPC_CMD_SHM_SETUP: {
+                rpc_msg_shm_setup_req shm_req;
+                if (!recv_msg(sock, &shm_req, sizeof(shm_req))) {
+                    return;
+                }
+                rpc_msg_shm_setup_rsp shm_rsp{};
+                shm_rsp.status = 1;
+                shm_rsp.magic  = GGML_RPC_SHM_MAGIC;
+                if (sock->get_negotiated_features() & GGML_RPC_FEATURE_SHM_V1) {
+                    size_t ring = shm_req.ring_size_hint;
+                    if (ring == 0 || ring > 256ull * 1024 * 1024) {
+                        ring = RPC_SHM_DEFAULT_RING;
+                    }
+                    auto seg = rpc_shm_create(shm_req.client_pid, ring);
+                    if (seg) {
+                        shm_rsp.status    = 0;
+                        shm_rsp.ring_size = ring;
+                        snprintf(shm_rsp.name, sizeof(shm_rsp.name), "%s", seg->name);
+                        sock->set_shm_segment(seg);
+                    }
+                }
+                if (!send_msg(sock, &shm_rsp, sizeof(shm_rsp))) {
                     return;
                 }
                 break;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1513,8 +1513,8 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
         return;
     }
 
-    if (hello_input_size != sizeof(rpc_msg_hello_req)) {
-        GGML_LOG_ERROR("HELLO request size mismatch (%zu vs %zu) — client needs upgrade to protocol v%d.x\n",
+    if (hello_input_size < sizeof(rpc_msg_hello_req)) {
+        GGML_LOG_ERROR("HELLO request too small (%zu vs %zu) — client needs upgrade to protocol v%d.x\n",
                        (size_t)hello_input_size, sizeof(rpc_msg_hello_req), RPC_PROTO_MAJOR_VERSION);
         return;
     }
@@ -1522,6 +1522,15 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
     rpc_msg_hello_req req = {};
     if (!sock->recv_data(&req, sizeof(req))) {
         return;
+    }
+    // Forward compatibility: a newer client may send a larger HELLO with
+    // additional trailing fields we don't yet understand. Consume and
+    // discard the extra bytes so they don't corrupt the next command read.
+    if (hello_input_size > sizeof(rpc_msg_hello_req)) {
+        std::vector<uint8_t> discard(hello_input_size - sizeof(rpc_msg_hello_req));
+        if (!sock->recv_data(discard.data(), discard.size())) {
+            return;
+        }
     }
 
     rpc_msg_hello_rsp rsp = {};

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -3,6 +3,7 @@
 #include "ggml-backend-impl.h"
 #include "ggml-cpp.h"
 #include "transport.h"
+#include "rpc-trace.h"
 
 #include <array>
 #include <cinttypes>
@@ -283,35 +284,49 @@ static bool parse_endpoint(const std::string & endpoint, std::string & host, int
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // No response
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
+    rpc_trace_span_t span = RPC_TRACE_BEGIN("ggml.rpc.send");
+    RPC_TRACE_INT(span, "rpc.cmd", (int64_t) cmd);
+    RPC_TRACE_BYTES(span, "rpc.input_bytes", input_size);
+    RPC_TRACE_STR(span, "rpc.has_response", "false");
+
     uint8_t cmd_byte = cmd;
-    if (!sock->send_data(&cmd_byte, sizeof(cmd_byte))) {
+    if (!sock->send_data(&cmd_byte, sizeof(cmd_byte)) ||
+        !sock->send_data(&input_size, sizeof(input_size)) ||
+        !sock->send_data(input, input_size)) {
+        RPC_TRACE_FAIL(span, "send_data failed");
         return false;
     }
-    if (!sock->send_data(&input_size, sizeof(input_size))) {
-        return false;
-    }
-    if (!sock->send_data(input, input_size)) {
-        return false;
-    }
+    RPC_TRACE_END(span);
     return true;
 }
 
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // RPC response: | response_size (8 bytes) | response_data (response_size bytes) |
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size, void * output, size_t output_size) {
+    rpc_trace_span_t span = RPC_TRACE_BEGIN("ggml.rpc.send_recv");
+    RPC_TRACE_INT(span, "rpc.cmd", (int64_t) cmd);
+    RPC_TRACE_BYTES(span, "rpc.input_bytes", input_size);
+    RPC_TRACE_BYTES(span, "rpc.expected_output_bytes", output_size);
+    RPC_TRACE_STR(span, "rpc.has_response", "true");
+
     if (!send_rpc_cmd(sock, cmd, input, input_size)) {
+        RPC_TRACE_FAIL(span, "send phase failed");
         return false;
     }
     uint64_t out_size;
     if (!sock->recv_data(&out_size, sizeof(out_size))) {
+        RPC_TRACE_FAIL(span, "recv size failed");
         return false;
     }
     if (out_size != output_size) {
+        RPC_TRACE_FAIL(span, "response size mismatch");
         return false;
     }
     if (!sock->recv_data(output, output_size)) {
+        RPC_TRACE_FAIL(span, "recv body failed");
         return false;
     }
+    RPC_TRACE_END(span);
     return true;
 }
 

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -42,7 +42,7 @@ static int rpc_deadman_seconds() {
 namespace fs = std::filesystem;
 
 // macro for nicer error messages on server crash
-#define RPC_STATUS_ASSERT(x) if (!(x)) GGML_ABORT("Remote RPC server crashed or returned malformed response")
+#define RPC_STATUS_ASSERT(x) do { if (!(x)) { GGML_ABORT("Remote RPC server crashed or returned malformed response (in %s at %s:%d)", __func__, __FILE__, __LINE__); } } while (0)
 
 // all RPC structures must be packed
 #pragma pack(push, 1)

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -21,6 +21,20 @@
 
 static const char * RPC_DEBUG = std::getenv("GGML_RPC_DEBUG");
 
+// Server-side idle deadman timeout (seconds). 0 = disabled (default).
+// When set, the rpc_serve_client loop will close the connection if no
+// command arrives within this many seconds. Pairs with systemds
+// Restart=always to free GPU memory held by a worker whose controller
+// has hung.
+static int rpc_deadman_seconds() {
+    static const int s = []() {
+        const char * v = std::getenv("GGML_RPC_DEADMAN_S");
+        if (!v || !*v) return 0;
+        try { return std::max(0, std::stoi(v)); } catch (...) { return 0; }
+    }();
+    return s;
+}
+
 #define LOG_DBG(...) \
     do { if (RPC_DEBUG) GGML_LOG_DEBUG(__VA_ARGS__); } while (0)
 
@@ -1512,7 +1526,12 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
 
     // Activate transport upgrade using client's caps
     sock->update_caps(req.conn_caps);
+    const int deadman_s = rpc_deadman_seconds();
     while (true) {
+        if (deadman_s > 0 && !sock->wait_readable(deadman_s)) {
+            GGML_LOG_WARN("rpc deadman: no command for %ds, closing connection\n", deadman_s);
+            break;
+        }
         if (!sock->recv_data(&cmd, 1)) {
             break;
         }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -257,6 +257,13 @@ struct ggml_backend_rpc_buffer_type_context {
     std::string name;
     size_t      alignment;
     size_t      max_size;
+    // Cache of GET_ALLOC_SIZE responses keyed by FNV-1a of the serialized
+    // request bytes. The serialized request is deterministic for a given
+    // tensor topology, so cache hits are correct. Protected by alloc_mu
+    // because get_alloc_size can be called from multiple framework threads
+    // during buffer initialization on some backends.
+    mutable std::mutex                       alloc_mu;
+    mutable std::unordered_map<uint64_t, uint64_t> alloc_size_cache;
 };
 
 struct ggml_backend_rpc_context {
@@ -745,11 +752,28 @@ static size_t ggml_backend_rpc_buffer_type_get_alloc_size(ggml_backend_buffer_ty
             request.srcs[i] = serialize_tensor(tensor->src[i]);
         }
 
-        // TODO: cache the alloc responses to avoid extra RPC calls?
+        // Cache responses keyed on FNV-1a of the serialized request. This is
+        // the request the framework would send anyway, so the hash is the same
+        // every call with the same tensor topology. Reduces RPC count on model
+        // load substantially for graphs with many quantized / MUL_MAT_ID /
+        // FLASH_ATTN_EXT tensors (which are the ops that go down this path).
+        const uint64_t cache_key = fnv_hash(reinterpret_cast<const uint8_t *>(&request), sizeof(request));
+        {
+            std::lock_guard<std::mutex> lock(buft_ctx->alloc_mu);
+            auto it = buft_ctx->alloc_size_cache.find(cache_key);
+            if (it != buft_ctx->alloc_size_cache.end()) {
+                return it->second;
+            }
+        }
+
         rpc_msg_get_alloc_size_rsp response;
         bool status = send_rpc_cmd(sock, RPC_CMD_GET_ALLOC_SIZE, &request, sizeof(request), &response, sizeof(response));
         RPC_STATUS_ASSERT(status);
 
+        {
+            std::lock_guard<std::mutex> lock(buft_ctx->alloc_mu);
+            buft_ctx->alloc_size_cache.emplace(cache_key, response.alloc_size);
+        }
         return response.alloc_size;
     }
 
@@ -780,6 +804,48 @@ static void ggml_backend_rpc_free(ggml_backend_t backend) {
 static void ggml_backend_rpc_synchronize(ggml_backend_t backend) {
     GGML_UNUSED(backend);
     // this is no-op because we don't have any async operations
+}
+
+// Async tensor upload hook. The wire behavior is identical to the
+// buffer-level ggml_backend_rpc_buffer_set_tensor (fire-and-forget RPC
+// over the same socket — the kernel will buffer multiple in-flight
+// SET_TENSOR frames). Plugging this into the backend interface lets the
+// ggml scheduler treat this backend as async-capable and pipeline
+// tensor sends behind other work, which it can't do when the field is
+// NULL. Subsequent ggml_backend_synchronize calls fall through to the
+// existing rpc_synchronize no-op since the socket itself provides FIFO
+// ordering across all sends to a given backend.
+static void ggml_backend_rpc_set_tensor_async(ggml_backend_t backend, ggml_tensor * tensor,
+                                              const void * data, size_t offset, size_t size) {
+    ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *)backend->context;
+    auto sock = get_socket(rpc_ctx->endpoint);
+
+    rpc_tensor t = serialize_tensor(tensor);
+    if (size > HASH_THRESHOLD) {
+        // For large transfers, prefer the hash-dedup path so the server
+        // can skip the bytes-on-the-wire when it already has the data.
+        // Falls back to the literal SET_TENSOR send if the hash misses.
+        rpc_msg_set_tensor_hash_req hreq{};
+        hreq.tensor = t;
+        hreq.offset = offset;
+        hreq.hash   = fnv_hash((const uint8_t *) data, size);
+        rpc_msg_set_tensor_hash_rsp hrsp{};
+        bool ok = send_rpc_cmd(sock, RPC_CMD_SET_TENSOR_HASH, &hreq, sizeof(hreq), &hrsp, sizeof(hrsp));
+        RPC_STATUS_ASSERT(ok);
+        if (hrsp.result) {
+            return; // server already has these bytes
+        }
+    }
+
+    // Header + payload concatenated into a single send so the server sees
+    // them as one frame.
+    std::vector<uint8_t> input(sizeof(rpc_tensor) + sizeof(offset) + size);
+    memcpy(input.data(),                                           &t,      sizeof(t));
+    memcpy(input.data() + sizeof(t),                               &offset, sizeof(offset));
+    memcpy(input.data() + sizeof(t) + sizeof(offset),              data,    size);
+
+    bool ok = send_rpc_cmd(sock, RPC_CMD_SET_TENSOR, input.data(), input.size());
+    RPC_STATUS_ASSERT(ok);
 }
 
 static void add_tensor(ggml_tensor * tensor, std::vector<rpc_tensor> & tensors, std::unordered_set<ggml_tensor*> & visited) {
@@ -849,7 +915,7 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
 static ggml_backend_i ggml_backend_rpc_interface = {
     /* .get_name                = */ ggml_backend_rpc_name,
     /* .free                    = */ ggml_backend_rpc_free,
-    /* .set_tensor_async        = */ NULL,
+    /* .set_tensor_async        = */ ggml_backend_rpc_set_tensor_async,
     /* .get_tensor_async        = */ NULL,
     /* .set_tensor_2d_async     = */ NULL,
     /* .get_tensor_2d_async     = */ NULL,

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -95,10 +95,6 @@ static_assert(RPC_CMD_HELLO == 14, "RPC_CMD_HELLO must be always 14");
 // Try RPC_CMD_SET_TENSOR_HASH first when data size is larger than this threshold
 const size_t HASH_THRESHOLD = 10 * 1024 * 1024;
 
-// Local feature bitmap advertised in the CAPS exchange. Empty for now;
-// step 3 will set bit 0 once the trace-ctx wire format is in.
-static constexpr uint64_t RPC_LOCAL_FEATURES = 0;
-
 
 struct rpc_msg_hello_req {
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
@@ -126,6 +122,11 @@ struct rpc_msg_caps_rsp {
     uint64_t server_features;
     uint64_t negotiated;
 };
+
+// Local feature bitmap advertised in the CAPS exchange. Bit 0 is
+// TRACE_CTX_V1 (W3C trace_id + parent_span_id prepended to every
+// command frame); the bit is only honored if the peer also advertises it.
+static constexpr uint64_t RPC_LOCAL_FEATURES = GGML_RPC_FEATURE_TRACE_CTX_V1;
 
 struct rpc_msg_device_count_rsp {
     uint32_t device_count;
@@ -349,10 +350,24 @@ static const char * rpc_cmd_name(enum rpc_cmd cmd) {
 //
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 static bool send_rpc_request(socket_ptr sock, enum rpc_cmd cmd,
-                             const void * input, size_t input_size) {
+                             const void * input, size_t input_size,
+                             rpc_trace_span_t parent_span) {
     uint8_t cmd_byte = cmd;
     if (!sock->send_data(&cmd_byte, sizeof(cmd_byte))) {
         return false;
+    }
+    // Trace-context propagation. When the peer negotiated TRACE_CTX_V1 we
+    // prepend 24 bytes (W3C trace_id[16] + parent_span_id[8]) right after
+    // the cmd byte. If no parent_span is in flight the buffer is zeros and
+    // the server treats the lack of context as "start a root span".
+    if (sock->get_negotiated_features() & GGML_RPC_FEATURE_TRACE_CTX_V1) {
+        uint8_t trace_ctx[24] = {0};
+        if (parent_span) {
+            rpc_trace_span_get_ids(parent_span, trace_ctx, trace_ctx + 16);
+        }
+        if (!sock->send_data(trace_ctx, sizeof(trace_ctx))) {
+            return false;
+        }
     }
     if (!sock->send_data(&input_size, sizeof(input_size))) {
         return false;
@@ -368,7 +383,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
     RPC_TRACE_BYTES(span, "rpc.input_bytes", input_size);
     RPC_TRACE_STR(span, "rpc.has_response", "false");
 
-    if (!send_rpc_request(sock, cmd, input, input_size)) {
+    if (!send_rpc_request(sock, cmd, input, input_size, span)) {
         RPC_TRACE_FAIL(span, "send_data failed");
         return false;
     }
@@ -386,7 +401,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
     RPC_TRACE_BYTES(span, "rpc.expected_output_bytes", output_size);
     RPC_TRACE_STR(span, "rpc.has_response", "true");
 
-    if (!send_rpc_request(sock, cmd, input, input_size)) {
+    if (!send_rpc_request(sock, cmd, input, input_size, span)) {
         RPC_TRACE_FAIL(span, "send phase failed");
         return false;
     }
@@ -1591,10 +1606,20 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
             GGML_LOG_ERROR("Unknown command: %d\n", cmd);
             break;
         }
+        // Trace-context propagation (TRACE_CTX_V1): pull the 24 bytes the
+        // client prepended after the cmd byte, then build a span whose
+        // parent is the client's in-flight send span. Old peers (minor v0)
+        // never negotiate the feature so we don't even peek the socket.
+        uint8_t trace_ctx[24] = {0};
+        if (sock->get_negotiated_features() & GGML_RPC_FEATURE_TRACE_CTX_V1) {
+            if (!sock->recv_data(trace_ctx, sizeof(trace_ctx))) {
+                break;
+            }
+        }
         // RAII span guard — auto-ends on any scope exit including the early
         // `return`s that the case bodies use on send/recv errors. set_int
         // takes long long, the cmd is uint8_t so no narrowing concern.
-        rpc_trace_scope srv_span("ggml.rpc.server.dispatch");
+        rpc_trace_scope srv_span("ggml.rpc.server.dispatch", trace_ctx, trace_ctx + 16);
         srv_span.set_int("rpc.cmd", (long long) cmd);
         srv_span.set_str("rpc.cmd_name", rpc_cmd_name((enum rpc_cmd) cmd));
         switch (cmd) {

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -113,6 +113,11 @@ struct rpc_msg_hello_rsp {
 // reserved for trace-context propagation; no feature actually uses any
 // bit yet — this commit lands the plumbing only.
 #define GGML_RPC_FEATURE_TRACE_CTX_V1 (1ull << 0)
+// Same-host shared-memory transport. Advertised by both peers only when
+// they are on the same machine (see socket_t::is_same_host). No wire
+// implication on its own — gating bit for the SHM data path landed in
+// follow-up commits.
+#define GGML_RPC_FEATURE_SHM_V1       (1ull << 1)
 
 struct rpc_msg_caps_req {
     uint64_t client_features;
@@ -126,7 +131,17 @@ struct rpc_msg_caps_rsp {
 // Local feature bitmap advertised in the CAPS exchange. Bit 0 is
 // TRACE_CTX_V1 (W3C trace_id + parent_span_id prepended to every
 // command frame); the bit is only honored if the peer also advertises it.
-static constexpr uint64_t RPC_LOCAL_FEATURES = GGML_RPC_FEATURE_TRACE_CTX_V1;
+// Per-connection local feature bitmap. Bits that depend on transport
+// properties (same-host vs cross-host, e.g. SHM) are added conditionally
+// here so we never advertise a feature we can't actually deliver on this
+// link.
+static uint64_t compute_local_features(const socket_ptr & sock) {
+    uint64_t feats = GGML_RPC_FEATURE_TRACE_CTX_V1;
+    if (sock && sock->is_same_host()) {
+        feats |= GGML_RPC_FEATURE_SHM_V1;
+    }
+    return feats;
+}
 
 struct rpc_msg_device_count_rsp {
     uint32_t device_count;
@@ -447,7 +462,7 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
     // Post-HELLO capabilities exchange. Only attempt if the server speaks
     // at least minor v1; older servers never see this command.
     if (response.minor >= 1) {
-        rpc_msg_caps_req caps_req = { RPC_LOCAL_FEATURES };
+        rpc_msg_caps_req caps_req = { compute_local_features(sock) };
         rpc_msg_caps_rsp caps_rsp = {};
         if (!send_rpc_cmd(sock, RPC_CMD_CAPS, &caps_req, sizeof(caps_req),
                           &caps_rsp, sizeof(caps_rsp))) {
@@ -1825,8 +1840,11 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                     return;
                 }
                 rpc_msg_caps_rsp response;
-                response.server_features = RPC_LOCAL_FEATURES;
-                response.negotiated      = request.client_features & RPC_LOCAL_FEATURES;
+                {
+                    uint64_t local = compute_local_features(sock);
+                    response.server_features = local;
+                    response.negotiated      = request.client_features & local;
+                }
                 sock->set_negotiated_features(response.negotiated);
                 if (!send_msg(sock, &response, sizeof(response))) {
                     return;

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -281,18 +281,58 @@ static bool parse_endpoint(const std::string & endpoint, std::string & host, int
     return true;
 }
 
+// rpc_cmd enum -> name string, for span attributes. Keep in sync with the
+// enum rpc_cmd in this file's header section above.
+static const char * rpc_cmd_name(enum rpc_cmd cmd) {
+    switch (cmd) {
+        case RPC_CMD_ALLOC_BUFFER:      return "ALLOC_BUFFER";
+        case RPC_CMD_GET_ALIGNMENT:     return "GET_ALIGNMENT";
+        case RPC_CMD_GET_MAX_SIZE:      return "GET_MAX_SIZE";
+        case RPC_CMD_BUFFER_GET_BASE:   return "BUFFER_GET_BASE";
+        case RPC_CMD_FREE_BUFFER:       return "FREE_BUFFER";
+        case RPC_CMD_BUFFER_CLEAR:      return "BUFFER_CLEAR";
+        case RPC_CMD_SET_TENSOR:        return "SET_TENSOR";
+        case RPC_CMD_SET_TENSOR_HASH:   return "SET_TENSOR_HASH";
+        case RPC_CMD_GET_TENSOR:        return "GET_TENSOR";
+        case RPC_CMD_COPY_TENSOR:       return "COPY_TENSOR";
+        case RPC_CMD_GRAPH_COMPUTE:     return "GRAPH_COMPUTE";
+        case RPC_CMD_GET_DEVICE_MEMORY: return "GET_DEVICE_MEMORY";
+        case RPC_CMD_INIT_TENSOR:       return "INIT_TENSOR";
+        case RPC_CMD_GET_ALLOC_SIZE:    return "GET_ALLOC_SIZE";
+        case RPC_CMD_HELLO:             return "HELLO";
+        case RPC_CMD_DEVICE_COUNT:      return "DEVICE_COUNT";
+        case RPC_CMD_GRAPH_RECOMPUTE:   return "GRAPH_RECOMPUTE";
+        default:                        return "UNKNOWN";
+    }
+}
+
+// Private helper: send an RPC request without tracing. Used by both public
+// overloads of send_rpc_cmd so each "real" RPC emits exactly one span at the
+// outer call site (no double-emission when request/response form invokes
+// fire-and-forget internally).
+//
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
-// No response
+static bool send_rpc_request(socket_ptr sock, enum rpc_cmd cmd,
+                             const void * input, size_t input_size) {
+    uint8_t cmd_byte = cmd;
+    if (!sock->send_data(&cmd_byte, sizeof(cmd_byte))) {
+        return false;
+    }
+    if (!sock->send_data(&input_size, sizeof(input_size))) {
+        return false;
+    }
+    return sock->send_data(input, input_size);
+}
+
+// Public overload 1: fire-and-forget. No response expected.
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
-    rpc_trace_span_t span = RPC_TRACE_BEGIN("ggml.rpc.send");
+    rpc_trace_span_t span = RPC_TRACE_BEGIN("ggml.rpc.client.send");
     RPC_TRACE_INT(span, "rpc.cmd", (int64_t) cmd);
+    RPC_TRACE_STR(span, "rpc.cmd_name", rpc_cmd_name(cmd));
     RPC_TRACE_BYTES(span, "rpc.input_bytes", input_size);
     RPC_TRACE_STR(span, "rpc.has_response", "false");
 
-    uint8_t cmd_byte = cmd;
-    if (!sock->send_data(&cmd_byte, sizeof(cmd_byte)) ||
-        !sock->send_data(&input_size, sizeof(input_size)) ||
-        !sock->send_data(input, input_size)) {
+    if (!send_rpc_request(sock, cmd, input, input_size)) {
         RPC_TRACE_FAIL(span, "send_data failed");
         return false;
     }
@@ -300,16 +340,17 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
     return true;
 }
 
-// RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
+// Public overload 2: request/response.
 // RPC response: | response_size (8 bytes) | response_data (response_size bytes) |
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size, void * output, size_t output_size) {
-    rpc_trace_span_t span = RPC_TRACE_BEGIN("ggml.rpc.send_recv");
+    rpc_trace_span_t span = RPC_TRACE_BEGIN("ggml.rpc.client.send_recv");
     RPC_TRACE_INT(span, "rpc.cmd", (int64_t) cmd);
+    RPC_TRACE_STR(span, "rpc.cmd_name", rpc_cmd_name(cmd));
     RPC_TRACE_BYTES(span, "rpc.input_bytes", input_size);
     RPC_TRACE_BYTES(span, "rpc.expected_output_bytes", output_size);
     RPC_TRACE_STR(span, "rpc.has_response", "true");
 
-    if (!send_rpc_cmd(sock, cmd, input, input_size)) {
+    if (!send_rpc_request(sock, cmd, input, input_size)) {
         RPC_TRACE_FAIL(span, "send phase failed");
         return false;
     }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1490,7 +1490,15 @@ rpc_server::~rpc_server() {
 static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const char * cache_dir,
                              socket_ptr sock) {
     rpc_server server(backends, cache_dir);
+    const int deadman_s = rpc_deadman_seconds();
     uint8_t cmd;
+    // Pre-HELLO timeout: without it a client that connects but never
+    // sends HELLO parks an accept slot forever. Use the same deadman
+    // knob as the post-HELLO loop.
+    if (deadman_s > 0 && !sock->wait_readable(deadman_s)) {
+        GGML_LOG_WARN("rpc deadman: pre-HELLO idle %ds, closing connection\n", deadman_s);
+        return;
+    }
     if (!sock->recv_data(&cmd, 1)) {
         return;
     }
@@ -1526,7 +1534,6 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
 
     // Activate transport upgrade using client's caps
     sock->update_caps(req.conn_caps);
-    const int deadman_s = rpc_deadman_seconds();
     while (true) {
         if (deadman_s > 0 && !sock->wait_readable(deadman_s)) {
             GGML_LOG_WARN("rpc deadman: no command for %ds, closing connection\n", deadman_s);

--- a/ggml/src/ggml-rpc/rpc-trace.cpp
+++ b/ggml/src/ggml-rpc/rpc-trace.cpp
@@ -21,6 +21,7 @@
 #include <opentelemetry/sdk/resource/resource.h>
 #include <opentelemetry/sdk/trace/batch_span_processor_factory.h>
 #include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#include <opentelemetry/trace/default_span.h>
 #include <opentelemetry/trace/provider.h>
 #include <opentelemetry/trace/scope.h>
 
@@ -172,6 +173,62 @@ extern "C" void rpc_trace_span_end(rpc_trace_span_t span) {
 }
 
 
+
+extern "C" int rpc_trace_span_get_ids(rpc_trace_span_t span,
+                                      uint8_t trace_id[16],
+                                      uint8_t span_id[8]) {
+    // Zero-fill on every path so callers see a well-defined buffer even on
+    // failure — server-side will treat all-zero trace_id as "no parent".
+    for (int i = 0; i < 16; ++i) trace_id[i] = 0;
+    for (int i = 0; i < 8;  ++i) span_id[i]  = 0;
+    if (!span || !span->handle) {
+        return 0;
+    }
+    auto ctx = span->handle->GetContext();
+    if (!ctx.IsValid()) {
+        return 0;
+    }
+    ctx.trace_id().CopyBytesTo(opentelemetry::nostd::span<uint8_t, 16>(trace_id, 16));
+    ctx.span_id().CopyBytesTo (opentelemetry::nostd::span<uint8_t, 8> (span_id,  8));
+    return 1;
+}
+
+extern "C" rpc_trace_span_t rpc_trace_span_begin_with_parent(const char * name,
+                                                             const uint8_t trace_id[16],
+                                                             const uint8_t parent_span_id[8]) {
+    auto * t = tracer_or_null();
+    if (!t) {
+        return nullptr;
+    }
+    // All-zero trace_id means the client did not have an active span; fall
+    // back to a normal root span on the server.
+    bool nonzero = false;
+    for (int i = 0; i < 16; ++i) { if (trace_id[i]) { nonzero = true; break; } }
+    if (!nonzero) {
+        trace::StartSpanOptions opts;
+        opts.kind = trace::SpanKind::kServer;
+        auto span = t->StartSpan(name, opts);
+        if (!span) return nullptr;
+        return new rpc_trace_span(std::move(span));
+    }
+
+    trace::TraceId    tid (opentelemetry::nostd::span<const uint8_t, 16>(trace_id, 16));
+    trace::SpanId     pid (opentelemetry::nostd::span<const uint8_t, 8> (parent_span_id, 8));
+    trace::TraceFlags flags(trace::TraceFlags::kIsSampled);
+    trace::SpanContext parent_ctx(tid, pid, flags, /*is_remote=*/true);
+
+    auto parent_span = opentelemetry::nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(parent_ctx));
+    auto current = opentelemetry::context::RuntimeContext::GetCurrent();
+    auto ctx_with_parent = trace::SetSpan(current, parent_span);
+
+    trace::StartSpanOptions opts;
+    opts.kind   = trace::SpanKind::kServer;
+    opts.parent = ctx_with_parent;
+    auto span = t->StartSpan(name, opts);
+    if (!span) return nullptr;
+    return new rpc_trace_span(std::move(span));
+}
+
 #else  // !GGML_RPC_OPENTELEMETRY -- no-op stubs so callers don't need the option.
 
 #include <cstddef>
@@ -185,5 +242,11 @@ extern "C" void rpc_trace_set_str  (rpc_trace_span_t, const char *, const char *
 extern "C" void rpc_trace_set_bytes(rpc_trace_span_t, const char *, size_t)       {}
 extern "C" void rpc_trace_span_fail(rpc_trace_span_t, const char *)               {}
 extern "C" void rpc_trace_span_end (rpc_trace_span_t)                             {}
+extern "C" int  rpc_trace_span_get_ids(rpc_trace_span_t, uint8_t t[16], uint8_t s[8]) {
+    for (int i = 0; i < 16; ++i) t[i] = 0;
+    for (int i = 0; i < 8;  ++i) s[i] = 0;
+    return 0;
+}
+extern "C" rpc_trace_span_t rpc_trace_span_begin_with_parent(const char *, const uint8_t[16], const uint8_t[8]) { return nullptr; }
 
 #endif // GGML_RPC_OPENTELEMETRY

--- a/ggml/src/ggml-rpc/rpc-trace.cpp
+++ b/ggml/src/ggml-rpc/rpc-trace.cpp
@@ -1,0 +1,167 @@
+// OpenTelemetry tracing implementation for ggml-rpc.
+//
+// Everything in this translation unit is gated on GGML_RPC_OPENTELEMETRY.
+// When the option is OFF, this file compiles to an empty object (every symbol
+// is provided as an inline no-op via the macros in rpc-trace.h) and need not
+// be linked.
+
+#include "rpc-trace.h"
+
+#ifdef GGML_RPC_OPENTELEMETRY
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <opentelemetry/exporters/otlp/otlp_grpc_exporter_factory.h>
+#include <opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h>
+#include <opentelemetry/sdk/resource/resource.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_factory.h>
+#include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#include <opentelemetry/trace/provider.h>
+#include <opentelemetry/trace/scope.h>
+
+namespace sdktrace = opentelemetry::sdk::trace;
+namespace otlp     = opentelemetry::exporter::otlp;
+namespace trace    = opentelemetry::trace;
+namespace resource = opentelemetry::sdk::resource;
+
+namespace {
+
+std::atomic<bool>      g_initialised{false};
+std::mutex             g_init_mutex;
+std::shared_ptr<trace::TracerProvider> g_provider;
+
+trace::Tracer * tracer_or_null() {
+    if (!g_initialised.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
+    auto p = trace::Provider::GetTracerProvider();
+    if (!p) {
+        return nullptr;
+    }
+    static auto t = p->GetTracer("ggml-rpc", "0.1.0");
+    return t.get();
+}
+
+const char * env_or(const char * key, const char * fallback) {
+    const char * v = std::getenv(key);
+    return (v && *v) ? v : fallback;
+}
+
+} // namespace
+
+extern "C" int rpc_trace_init(void) {
+    if (g_initialised.load(std::memory_order_acquire)) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(g_init_mutex);
+    if (g_initialised.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    otlp::OtlpGrpcExporterOptions exporter_opts;
+    exporter_opts.endpoint = env_or("GGML_RPC_OTLP_ENDPOINT", "http://localhost:4317");
+
+    auto exporter  = otlp::OtlpGrpcExporterFactory::Create(exporter_opts);
+    auto processor = sdktrace::BatchSpanProcessorFactory::Create(std::move(exporter), {});
+
+    auto resource_attrs = resource::ResourceAttributes{
+        {"service.name", std::string(env_or("GGML_RPC_OTLP_SERVICE", "ggml-rpc"))},
+    };
+    auto res = resource::Resource::Create(resource_attrs);
+
+    g_provider = sdktrace::TracerProviderFactory::Create(std::move(processor), res);
+    trace::Provider::SetTracerProvider(g_provider);
+
+    g_initialised.store(true, std::memory_order_release);
+    std::atexit([]() { rpc_trace_shutdown(); });
+    return 0;
+}
+
+extern "C" void rpc_trace_shutdown(void) {
+    if (!g_initialised.exchange(false, std::memory_order_acq_rel)) {
+        return;
+    }
+    if (auto sdk_provider = std::dynamic_pointer_cast<sdktrace::TracerProvider>(g_provider)) {
+        sdk_provider->ForceFlush(std::chrono::milliseconds(5000));
+        sdk_provider->Shutdown(std::chrono::milliseconds(5000));
+    }
+    std::shared_ptr<trace::TracerProvider> noop;
+    trace::Provider::SetTracerProvider(noop);
+    g_provider.reset();
+}
+
+// Opaque wrapper holding the OpenTelemetry shared_ptr<Span> directly.
+// Lifetime: created in rpc_trace_span_begin, released in rpc_trace_span_end /
+// _fail. The OpenTelemetry tracer/batch-processor handles span flushing on End().
+struct rpc_trace_span {
+    opentelemetry::nostd::shared_ptr<trace::Span> handle;
+    explicit rpc_trace_span(opentelemetry::nostd::shared_ptr<trace::Span> h)
+        : handle(std::move(h)) {}
+};
+
+extern "C" rpc_trace_span_t rpc_trace_span_begin(const char * name) {
+    auto * t = tracer_or_null();
+    if (!t) {
+        return nullptr;
+    }
+    auto span = t->StartSpan(name);
+    if (!span) {
+        return nullptr;
+    }
+    return new rpc_trace_span(std::move(span));
+}
+
+extern "C" void rpc_trace_set_int(rpc_trace_span_t span, const char * key, int64_t value) {
+    if (!span || !span->handle) return;
+    span->handle->SetAttribute(key, value);
+}
+
+extern "C" void rpc_trace_set_str(rpc_trace_span_t span, const char * key, const char * value) {
+    if (!span || !span->handle || !value) return;
+    span->handle->SetAttribute(key, value);
+}
+
+extern "C" void rpc_trace_set_bytes(rpc_trace_span_t span, const char * key, size_t bytes) {
+    if (!span || !span->handle) return;
+    span->handle->SetAttribute(key, static_cast<int64_t>(bytes));
+}
+
+extern "C" void rpc_trace_span_fail(rpc_trace_span_t span, const char * msg) {
+    if (!span || !span->handle) {
+        delete span;
+        return;
+    }
+    span->handle->SetStatus(trace::StatusCode::kError, msg ? msg : "");
+    span->handle->End();
+    delete span;
+}
+
+extern "C" void rpc_trace_span_end(rpc_trace_span_t span) {
+    if (!span) return;
+    if (span->handle) {
+        span->handle->End();
+    }
+    delete span;
+}
+
+
+#else  // !GGML_RPC_OPENTELEMETRY -- no-op stubs so callers don't need the option.
+
+#include <cstddef>
+#include <cstdint>
+
+extern "C" int  rpc_trace_init(void) { return 0; }
+extern "C" void rpc_trace_shutdown(void) {}
+extern "C" rpc_trace_span_t rpc_trace_span_begin(const char *) { return nullptr; }
+extern "C" void rpc_trace_set_int  (rpc_trace_span_t, const char *, int64_t)     {}
+extern "C" void rpc_trace_set_str  (rpc_trace_span_t, const char *, const char *) {}
+extern "C" void rpc_trace_set_bytes(rpc_trace_span_t, const char *, size_t)       {}
+extern "C" void rpc_trace_span_fail(rpc_trace_span_t, const char *)               {}
+extern "C" void rpc_trace_span_end (rpc_trace_span_t)                             {}
+
+#endif // GGML_RPC_OPENTELEMETRY

--- a/ggml/src/ggml-rpc/rpc-trace.cpp
+++ b/ggml/src/ggml-rpc/rpc-trace.cpp
@@ -87,8 +87,8 @@ extern "C" void rpc_trace_shutdown(void) {
         return;
     }
     if (auto sdk_provider = std::dynamic_pointer_cast<sdktrace::TracerProvider>(g_provider)) {
-        sdk_provider->ForceFlush(std::chrono::milliseconds(5000));
-        sdk_provider->Shutdown(std::chrono::milliseconds(5000));
+        sdk_provider->ForceFlush(std::chrono::milliseconds(2000));
+        sdk_provider->Shutdown(std::chrono::milliseconds(2000));
     }
     std::shared_ptr<trace::TracerProvider> noop;
     trace::Provider::SetTracerProvider(noop);
@@ -109,7 +109,9 @@ extern "C" rpc_trace_span_t rpc_trace_span_begin(const char * name) {
     if (!t) {
         return nullptr;
     }
-    auto span = t->StartSpan(name);
+    trace::StartSpanOptions opts;
+    opts.kind = trace::SpanKind::kClient;
+    auto span = t->StartSpan(name, opts);
     if (!span) {
         return nullptr;
     }

--- a/ggml/src/ggml-rpc/rpc-trace.cpp
+++ b/ggml/src/ggml-rpc/rpc-trace.cpp
@@ -76,7 +76,18 @@ extern "C" int rpc_trace_init(void) {
     exporter_opts.endpoint = endpoint_env;
 
     auto exporter  = otlp::OtlpGrpcExporterFactory::Create(exporter_opts);
-    auto processor = sdktrace::BatchSpanProcessorFactory::Create(std::move(exporter), {});
+    // High-volume RPC workloads emit thousands of spans/sec; the default
+    // BSP queue (2048) and 5 s flush drop spans on the floor under load.
+    // Use a larger queue and tighter flush so per-RPC traces are captured
+    // faithfully. Overridable via env vars.
+    sdktrace::BatchSpanProcessorOptions bsp_opts;
+    bsp_opts.max_queue_size = 65536;
+    bsp_opts.max_export_batch_size = 4096;
+    bsp_opts.schedule_delay_millis = std::chrono::milliseconds(500);
+    if (const char * v = std::getenv("GGML_RPC_OTLP_QUEUE")) {
+        int parsed = std::atoi(v); if (parsed >= 1024) bsp_opts.max_queue_size = parsed;
+    }
+    auto processor = sdktrace::BatchSpanProcessorFactory::Create(std::move(exporter), bsp_opts);
 
     auto resource_attrs = resource::ResourceAttributes{
         {"service.name", std::string(env_or("GGML_RPC_OTLP_SERVICE", "ggml-rpc"))},

--- a/ggml/src/ggml-rpc/rpc-trace.cpp
+++ b/ggml/src/ggml-rpc/rpc-trace.cpp
@@ -58,13 +58,22 @@ extern "C" int rpc_trace_init(void) {
     if (g_initialised.load(std::memory_order_acquire)) {
         return 0;
     }
+    // Opt-in: tracing is OFF unless GGML_RPC_OTLP_ENDPOINT is explicitly set.
+    // This keeps non-RPC tools (plain llama-cli, llama-bench, ...) from
+    // spawning a BatchSpanProcessor thread and pointlessly attempting to
+    // connect to a non-existent collector at every startup.
+    const char * endpoint_env = std::getenv("GGML_RPC_OTLP_ENDPOINT");
+    if (!endpoint_env || !*endpoint_env) {
+        return 0;
+    }
+
     std::lock_guard<std::mutex> lock(g_init_mutex);
     if (g_initialised.load(std::memory_order_relaxed)) {
         return 0;
     }
 
     otlp::OtlpGrpcExporterOptions exporter_opts;
-    exporter_opts.endpoint = env_or("GGML_RPC_OTLP_ENDPOINT", "http://localhost:4317");
+    exporter_opts.endpoint = endpoint_env;
 
     auto exporter  = otlp::OtlpGrpcExporterFactory::Create(exporter_opts);
     auto processor = sdktrace::BatchSpanProcessorFactory::Create(std::move(exporter), {});

--- a/ggml/src/ggml-rpc/rpc-trace.h
+++ b/ggml/src/ggml-rpc/rpc-trace.h
@@ -66,3 +66,31 @@ void rpc_trace_span_end (rpc_trace_span_t span);
 #define RPC_TRACE_BYTES(s, k, v)        rpc_trace_set_bytes((s), (k), (v))
 #define RPC_TRACE_FAIL(s, msg)          rpc_trace_span_fail((s), (msg))
 #define RPC_TRACE_END(s)                rpc_trace_span_end((s))
+
+#ifdef __cplusplus
+// RAII span guard. Ends the span automatically on scope exit unless fail()
+// is called first. Use in C++ code paths with early returns where a manual
+// END is easy to miss.
+class rpc_trace_scope {
+public:
+    explicit rpc_trace_scope(const char * name) : span_(rpc_trace_span_begin(name)) {}
+    ~rpc_trace_scope() { end(); }
+    rpc_trace_scope(const rpc_trace_scope &)            = delete;
+    rpc_trace_scope & operator=(const rpc_trace_scope &) = delete;
+
+    rpc_trace_span_t handle() const { return span_; }
+    void set_int  (const char * k, long long v) { rpc_trace_set_int  (span_, k, v); }
+    void set_str  (const char * k, const char * v) { rpc_trace_set_str  (span_, k, v); }
+    void set_bytes(const char * k, unsigned long long v) { rpc_trace_set_bytes(span_, k, (unsigned long) v); }
+    void fail(const char * msg) {
+        if (!ended_) { rpc_trace_span_fail(span_, msg); ended_ = true; }
+    }
+    void end() {
+        if (!ended_) { rpc_trace_span_end(span_); ended_ = true; }
+    }
+private:
+    rpc_trace_span_t span_;
+    bool ended_ = false;
+};
+#endif // __cplusplus
+

--- a/ggml/src/ggml-rpc/rpc-trace.h
+++ b/ggml/src/ggml-rpc/rpc-trace.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// OpenTelemetry tracing for ggml-rpc.
+//
+// Compile-time gated by GGML_RPC_OPENTELEMETRY. When the option is OFF, every
+// macro below resolves to a no-op with zero runtime cost. When ON, each send /
+// recv on the RPC hot path emits a span exported via OTLP/gRPC to an endpoint
+// configured by the GGML_RPC_OTLP_ENDPOINT environment variable
+// (default: http://localhost:4317).
+//
+// Design goals:
+//   1. Zero runtime cost when disabled.
+//   2. No exposure of OpenTelemetry headers to callers — implementation hidden
+//      in rpc-trace.cpp via opaque span handles.
+//   3. Safe to call before rpc_trace_init(): all functions become no-ops if
+//      the tracer provider has not been created.
+//   4. Thread-safe (OpenTelemetry C++ tracer is thread-safe by contract).
+
+#include <cstddef>
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Initialise the OTLP/gRPC exporter and tracer provider. Reads:
+//   GGML_RPC_OTLP_ENDPOINT  (default "http://localhost:4317")
+//   GGML_RPC_OTLP_SERVICE   (default "ggml-rpc")
+// Safe to call multiple times — second and subsequent calls are no-ops.
+// Returns 0 on success, nonzero on init failure (tracer stays disabled).
+int  rpc_trace_init(void);
+
+// Flush pending spans and shut down the tracer. Call on process exit.
+void rpc_trace_shutdown(void);
+
+// Opaque span handle. nullptr means "no span" (tracer disabled, init failed,
+// or GGML_RPC_OPENTELEMETRY off).
+typedef struct rpc_trace_span * rpc_trace_span_t;
+
+// Start a span with the given name. Returns nullptr if tracing is disabled.
+// Span attributes can be attached via rpc_trace_set_*. Must be matched with
+// rpc_trace_span_end(); never freed manually.
+rpc_trace_span_t rpc_trace_span_begin(const char * name);
+
+void rpc_trace_set_int  (rpc_trace_span_t span, const char * key, int64_t value);
+void rpc_trace_set_str  (rpc_trace_span_t span, const char * key, const char * value);
+void rpc_trace_set_bytes(rpc_trace_span_t span, const char * key, size_t bytes);
+
+// Mark a span as failed with a brief error message; auto-ends the span.
+void rpc_trace_span_fail(rpc_trace_span_t span, const char * msg);
+
+// End a successful span.
+void rpc_trace_span_end (rpc_trace_span_t span);
+
+#ifdef __cplusplus
+}
+#endif
+
+// Convenience macros. These always call the real functions; the
+// implementation is a no-op stub when GGML_RPC_OPENTELEMETRY is OFF.
+#define RPC_TRACE_INIT()                (void) rpc_trace_init()
+#define RPC_TRACE_SHUTDOWN()            rpc_trace_shutdown()
+#define RPC_TRACE_BEGIN(name)           rpc_trace_span_begin(name)
+#define RPC_TRACE_INT(s, k, v)          rpc_trace_set_int((s), (k), (v))
+#define RPC_TRACE_STR(s, k, v)          rpc_trace_set_str((s), (k), (v))
+#define RPC_TRACE_BYTES(s, k, v)        rpc_trace_set_bytes((s), (k), (v))
+#define RPC_TRACE_FAIL(s, msg)          rpc_trace_span_fail((s), (msg))
+#define RPC_TRACE_END(s)                rpc_trace_span_end((s))

--- a/ggml/src/ggml-rpc/rpc-trace.h
+++ b/ggml/src/ggml-rpc/rpc-trace.h
@@ -52,6 +52,22 @@ void rpc_trace_span_fail(rpc_trace_span_t span, const char * msg);
 // End a successful span.
 void rpc_trace_span_end (rpc_trace_span_t span);
 
+// Extract the W3C trace_id (16 bytes) and span_id (8 bytes) from an
+// in-flight client span. Used to forward the context to the RPC server so
+// the server's spans become children of this one. Returns 1 on success,
+// 0 if span is null or invalid (in which case the buffers are zero-filled).
+int  rpc_trace_span_get_ids(rpc_trace_span_t span,
+                            uint8_t trace_id[16],
+                            uint8_t span_id[8]);
+
+// Start a span with an explicit *remote* parent built from the bytes the
+// client sent over the wire. Returns nullptr if tracing is disabled, or if
+// trace_id is all-zeros (invalid parent — caller should fall back to
+// rpc_trace_span_begin).
+rpc_trace_span_t rpc_trace_span_begin_with_parent(const char * name,
+                                                  const uint8_t trace_id[16],
+                                                  const uint8_t parent_span_id[8]);
+
 #ifdef __cplusplus
 }
 #endif
@@ -74,6 +90,10 @@ void rpc_trace_span_end (rpc_trace_span_t span);
 class rpc_trace_scope {
 public:
     explicit rpc_trace_scope(const char * name) : span_(rpc_trace_span_begin(name)) {}
+    // Construct a scope whose span is a child of a remote parent (server side,
+    // parent IDs received from the client over the wire).
+    rpc_trace_scope(const char * name, const uint8_t trace_id[16], const uint8_t parent_span_id[8])
+        : span_(rpc_trace_span_begin_with_parent(name, trace_id, parent_span_id)) {}
     ~rpc_trace_scope() { end(); }
     rpc_trace_scope(const rpc_trace_scope &)            = delete;
     rpc_trace_scope & operator=(const rpc_trace_scope &) = delete;

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -572,6 +572,42 @@ static bool is_valid_fd(sockfd_t sockfd) {
 #endif
 }
 
+static bool set_socket_perf_options(sockfd_t sockfd) {
+    // Per-socket send/recv buffer requests. The kernel clamps to
+    // net.core.{rmem,wmem}_max; on Linux the ceiling is typically set high by
+    // the v12 §12.5 sysctl block. Failing to grow the buffer is not fatal —
+    // we still want TCP_NODELAY etc. applied — so log and continue.
+    int buf_size = 16 * 1024 * 1024;  // 16 MB request
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, (char *)&buf_size, sizeof(buf_size)) != 0) {
+        GGML_LOG_DEBUG("ggml-rpc: SO_RCVBUF request failed (continuing)\n");
+    }
+    if (setsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, (char *)&buf_size, sizeof(buf_size)) != 0) {
+        GGML_LOG_DEBUG("ggml-rpc: SO_SNDBUF request failed (continuing)\n");
+    }
+
+    // Detect dead peers. Default kernel probe intervals are fine; for faster
+    // detection a future commit will add an application-level heartbeat (see
+    // proposal §12.11.11).
+    int ka = 1;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (char *)&ka, sizeof(ka)) != 0) {
+        GGML_LOG_DEBUG("ggml-rpc: SO_KEEPALIVE failed (continuing)\n");
+    }
+
+#if defined(__linux__) && defined(TCP_QUICKACK)
+    // Disable the default delayed-ACK timer (~40 ms). RPC traffic is
+    // request/response heavy; immediate ACKs avoid stalling the sender on
+    // ACK clocking. Linux flips QUICKACK off automatically per-packet; one
+    // setsockopt at connect time covers the warm-up phase, which is the
+    // common case for short-lived RPCs.
+    int qa = 1;
+    if (setsockopt(sockfd, IPPROTO_TCP, TCP_QUICKACK, (char *)&qa, sizeof(qa)) != 0) {
+        GGML_LOG_DEBUG("ggml-rpc: TCP_QUICKACK failed (continuing)\n");
+    }
+#endif
+
+    return true;
+}
+
 static bool set_no_delay(sockfd_t sockfd) {
     int flag = 1;
     // set TCP_NODELAY to disable Nagle's algorithm
@@ -594,6 +630,7 @@ socket_ptr socket_t::accept() {
         GGML_LOG_ERROR("Failed to set TCP_NODELAY\n");
         return nullptr;
     }
+    set_socket_perf_options(client_socket_fd);
     return socket_ptr(new socket_t(std::make_unique<impl>(client_socket_fd)));
 }
 
@@ -633,6 +670,7 @@ socket_ptr socket_t::connect(const char * host, int port) {
         GGML_LOG_ERROR("Failed to set TCP_NODELAY\n");
         return nullptr;
     }
+    set_socket_perf_options(sockfd);
     struct sockaddr_in addr;
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -621,6 +621,29 @@ static bool set_reuse_addr(sockfd_t sockfd) {
     return ret == 0;
 }
 
+bool socket_t::wait_readable(int timeout_seconds) {
+    sockfd_t fd = pimpl->fd;
+    if (!is_valid_fd(fd)) {
+        return false;
+    }
+#ifdef _WIN32
+    WSAPOLLFD pfd = {};
+    pfd.fd = fd;
+    pfd.events = POLLRDNORM;
+    int ret = WSAPoll(&pfd, 1, timeout_seconds * 1000);
+    return ret > 0 && (pfd.revents & (POLLRDNORM | POLLERR | POLLHUP)) != 0;
+#else
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    struct timeval tv;
+    tv.tv_sec = timeout_seconds;
+    tv.tv_usec = 0;
+    int ret = ::select((int)fd + 1, &rfds, nullptr, nullptr, &tv);
+    return ret > 0;
+#endif
+}
+
 socket_ptr socket_t::accept() {
     auto client_socket_fd = ::accept(pimpl->fd, NULL, NULL);
     if (!is_valid_fd(client_socket_fd)) {

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -573,6 +573,36 @@ uint64_t socket_t::get_negotiated_features() const {
     return pimpl->negotiated_features;
 }
 
+bool socket_t::is_same_host() const {
+    // Loopback is the cheap-and-correct signal for "same host". On Linux
+    // a connection from a process on the same machine arrives over the
+    // lo interface unless the user explicitly bound to an external IP,
+    // in which case it's still routed locally but we can't tell the two
+    // halves of "same physical host" apart from a separate machine on the
+    // same subnet — be conservative and only return true for the
+    // unambiguous loopback case.
+    sockaddr_storage addr{};
+    socklen_t addr_len = sizeof(addr);
+    if (getpeername(pimpl->fd, reinterpret_cast<sockaddr *>(&addr), &addr_len) != 0) {
+        return false;
+    }
+    if (addr.ss_family == AF_INET) {
+        const auto * a = reinterpret_cast<const sockaddr_in *>(&addr);
+        // 127.0.0.0/8 (network byte order: high byte == 127)
+        return (ntohl(a->sin_addr.s_addr) >> 24) == 127;
+    }
+    if (addr.ss_family == AF_INET6) {
+        const auto * a = reinterpret_cast<const sockaddr_in6 *>(&addr);
+        // ::1
+        const uint8_t * b = a->sin6_addr.s6_addr;
+        for (int i = 0; i < 15; ++i) {
+            if (b[i] != 0) return false;
+        }
+        return b[15] == 1;
+    }
+    return false;
+}
+
 static bool is_valid_fd(sockfd_t sockfd) {
 #ifdef _WIN32
     return sockfd != INVALID_SOCKET;

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -135,6 +135,7 @@ struct socket_t::impl {
 #endif // GGML_RPC_RDMA
     bool     use_rdma;
     sockfd_t fd;
+    uint64_t negotiated_features = 0;
 };
 
 socket_t::impl::~impl() {
@@ -562,6 +563,14 @@ void socket_t::get_caps(uint8_t * local_caps) {
 
 void socket_t::update_caps(const uint8_t * remote_caps) {
     return pimpl->update_caps(remote_caps);
+}
+
+void socket_t::set_negotiated_features(uint64_t features) {
+    pimpl->negotiated_features = features;
+}
+
+uint64_t socket_t::get_negotiated_features() const {
+    return pimpl->negotiated_features;
 }
 
 static bool is_valid_fd(sockfd_t sockfd) {

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -593,6 +593,22 @@ static bool set_socket_perf_options(sockfd_t sockfd) {
         GGML_LOG_DEBUG("ggml-rpc: SO_KEEPALIVE failed (continuing)\n");
     }
 
+#if defined(__linux__) && defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL) && defined(TCP_KEEPCNT)
+    // Tighten the default Linux keepalive timing so a silently-dead peer
+    // is detected within ~90 seconds (60 idle + 3 × 10s probes) instead of
+    // the default ~2 hours. Configurable via GGML_RPC_KEEPALIVE_S to
+    // override the idle window.
+    int idle_s = 60;
+    if (const char * v = std::getenv("GGML_RPC_KEEPALIVE_S")) {
+        int parsed = std::atoi(v); if (parsed >= 10) idle_s = parsed;
+    }
+    int intvl_s = 10;
+    int cnt     = 3;
+    setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,  (char *)&idle_s,  sizeof(idle_s));
+    setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL, (char *)&intvl_s, sizeof(intvl_s));
+    setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPCNT,   (char *)&cnt,     sizeof(cnt));
+#endif
+
 #if defined(__linux__) && defined(TCP_QUICKACK)
     // Disable the default delayed-ACK timer (~40 ms). RPC traffic is
     // request/response heavy; immediate ACKs avoid stalling the sender on

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -136,6 +136,7 @@ struct socket_t::impl {
     bool     use_rdma;
     sockfd_t fd;
     uint64_t negotiated_features = 0;
+    std::shared_ptr<void> shm_seg;
 };
 
 socket_t::impl::~impl() {
@@ -571,6 +572,14 @@ void socket_t::set_negotiated_features(uint64_t features) {
 
 uint64_t socket_t::get_negotiated_features() const {
     return pimpl->negotiated_features;
+}
+
+void socket_t::set_shm_segment(std::shared_ptr<void> seg) {
+    pimpl->shm_seg = std::move(seg);
+}
+
+void * socket_t::get_shm_segment_raw() const {
+    return pimpl->shm_seg.get();
 }
 
 bool socket_t::is_same_host() const {

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -26,6 +26,11 @@ struct socket_t {
     void get_caps(uint8_t * local_caps);
     void update_caps(const uint8_t * remote_caps);
 
+    // Post-HELLO capabilities negotiation (protocol minor >= 1). See
+    // GGML_RPC_FEATURE_* bits in ggml-rpc.cpp.
+    void     set_negotiated_features(uint64_t features);
+    uint64_t get_negotiated_features() const;
+
     static socket_ptr create_server(const char * host, int port);
     static socket_ptr connect(const char * host, int port);
 

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -31,6 +31,11 @@ struct socket_t {
     void     set_negotiated_features(uint64_t features);
     uint64_t get_negotiated_features() const;
 
+    // True when the remote peer is on this machine (loopback). Used by the
+    // CAPS exchange to gate same-host-only features such as SHM transport.
+    // Cheap: a single getpeername() + IPv4/IPv6 prefix check.
+    bool is_same_host() const;
+
     static socket_ptr create_server(const char * host, int port);
     static socket_ptr connect(const char * host, int port);
 

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -16,6 +16,11 @@ struct socket_t {
     bool send_data(const void * data, size_t size);
     bool recv_data(void * data, size_t size);
 
+    // Wait up to timeout_seconds for the socket to become readable.
+    // Returns true if data is ready (recv_data will not block on the
+    // initial byte), false on timeout or socket error.
+    bool wait_readable(int timeout_seconds);
+
     socket_ptr accept();
 
     void get_caps(uint8_t * local_caps);

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -31,6 +31,13 @@ struct socket_t {
     void     set_negotiated_features(uint64_t features);
     uint64_t get_negotiated_features() const;
 
+    // SHM transport segment, opaque to transport.h to keep the dependency
+    // direction clean. Stored as shared_ptr<void> in the pimpl; the actual
+    // type is rpc_shm_segment (defined in ggml-rpc.cpp). 3b only owns
+    // lifecycle; 3c will plumb the rings through send_data/recv_data.
+    void  set_shm_segment(std::shared_ptr<void> seg);
+    void* get_shm_segment_raw() const;
+
     // True when the remote peer is on this machine (loopback). Used by the
     // CAPS exchange to gate same-host-only features such as SHM transport.
     // Cheap: a single getpeername() + IPv4/IPv6 prefix check.

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -1,4 +1,5 @@
 #include "chat.h"
+#include "rpc-trace.h"
 #include "common.h"
 #include "arg.h"
 #include "console.h"
@@ -343,6 +344,8 @@ static std::vector<std::pair<std::string, size_t>> auto_completion_callback(std:
 static constexpr size_t FILE_GLOB_MAX_RESULTS = 100;
 
 int main(int argc, char ** argv) {
+    RPC_TRACE_INIT();
+
     common_params params;
 
     params.verbosity = LOG_LEVEL_ERROR; // by default, less verbose logs
@@ -648,5 +651,6 @@ int main(int argc, char ** argv) {
     common_log_set_verbosity_thold(LOG_LEVEL_INFO);
     common_memory_breakdown_print(ctx_cli.ctx_server.get_llama_context());
 
+    RPC_TRACE_SHUTDOWN();
     return 0;
 }

--- a/tools/rpc/rpc-server.cpp
+++ b/tools/rpc/rpc-server.cpp
@@ -1,4 +1,5 @@
 #include "ggml-rpc.h"
+#include "rpc-trace.h"
 #ifdef _WIN32
 #  define NOMINMAX
 #  define DIRECTORY_SEPARATOR '\\'
@@ -288,6 +289,8 @@ static std::vector<ggml_backend_dev_t> get_devices(const rpc_server_params & par
 }
 
 int main(int argc, char * argv[]) {
+    RPC_TRACE_INIT();
+
     std::setlocale(LC_NUMERIC, "C");
 
     ggml_backend_load_all();
@@ -338,5 +341,6 @@ int main(int argc, char * argv[]) {
     }
 
     start_server_fn(endpoint.c_str(), cache_dir, params.n_threads, devices.size(), devices.data());
+        RPC_TRACE_SHUTDOWN();
     return 0;
 }

--- a/tools/rpc/rpc-server.cpp
+++ b/tools/rpc/rpc-server.cpp
@@ -1,4 +1,5 @@
 #include "ggml-rpc.h"
+#include <csignal>
 #include "rpc-trace.h"
 #ifdef _WIN32
 #  define NOMINMAX
@@ -288,8 +289,26 @@ static std::vector<ggml_backend_dev_t> get_devices(const rpc_server_params & par
     return devices;
 }
 
+
+// Install signal handlers so SIGINT/SIGTERM flush traced spans before exit.
+// Without this, `kill <pid>` (default SIGTERM) bypasses atexit() entirely
+// and any unflushed BatchSpanProcessor queue is lost.
+static void rpc_signal_shutdown(int signum) {
+    rpc_trace_shutdown();
+    // Re-raise with default disposition so the kernel produces the expected
+    // exit status (e.g. 128 + SIGTERM).
+    std::signal(signum, SIG_DFL);
+    std::raise(signum);
+}
+
+static void install_rpc_signal_handlers() {
+    std::signal(SIGINT,  rpc_signal_shutdown);
+    std::signal(SIGTERM, rpc_signal_shutdown);
+}
+
 int main(int argc, char * argv[]) {
     RPC_TRACE_INIT();
+    install_rpc_signal_handlers();
 
     std::setlocale(LC_NUMERIC, "C");
 

--- a/tools/rpc/rpc-server.cpp
+++ b/tools/rpc/rpc-server.cpp
@@ -189,6 +189,11 @@ static void print_usage(int /*argc*/, char ** argv, rpc_server_params params) {
     fprintf(stderr, "  -p, --port PORT                  port to bind to (default: %d)\n", params.port);
     fprintf(stderr, "  -c, --cache                      enable local file cache\n");
     fprintf(stderr, "\n");
+    fprintf(stderr, "environment variables:\n");
+    fprintf(stderr, "  GGML_RPC_DEADMAN_S     close connection if idle this many seconds (0=off, default 0)\n");
+    fprintf(stderr, "  GGML_RPC_OTLP_ENDPOINT OTLP/gRPC endpoint for trace span export (unset=tracing off)\n");
+    fprintf(stderr, "  GGML_RPC_OTLP_SERVICE  service.name attribute for traced spans (default ggml-rpc)\n");
+    fprintf(stderr, "\n");
 }
 
 static bool rpc_server_params_parse(int argc, char ** argv, rpc_server_params & params) {
@@ -309,6 +314,11 @@ static void install_rpc_signal_handlers() {
 int main(int argc, char * argv[]) {
     RPC_TRACE_INIT();
     install_rpc_signal_handlers();
+    if (const char * ep = std::getenv("GGML_RPC_OTLP_ENDPOINT"); ep && *ep) {
+        const char * svc = std::getenv("GGML_RPC_OTLP_SERVICE");
+        fprintf(stderr, "ggml-rpc: tracing enabled, exporting to %s (service %s)\n",
+                ep, svc && *svc ? svc : "ggml-rpc");
+    }
 
     std::setlocale(LC_NUMERIC, "C");
 


### PR DESCRIPTION
ggml-rpc: opt-in OpenTelemetry tracing + protocol hardening

## Summary

This series adds optional OpenTelemetry tracing to `ggml-rpc` and hardens the
RPC protocol's lifecycle behaviour. Each commit is small, focused, and
zero-cost when its feature is not in use:

- **Tracing** (`-DGGML_RPC_OPENTELEMETRY=ON`, opt-in via `GGML_RPC_OTLP_ENDPOINT` env var)
  — every client and server RPC emits an OTLP/gRPC span with cmd, byte size, and
  pass/fail status. Tracing TU compiles to no-op stubs when the cmake option is off.
- **Lifecycle** (env var `GGML_RPC_DEADMAN_S`)
  — opt-in server-side idle timeout closes the connection if no command arrives,
  pre- or post-HELLO. Prevents silent stalls that leave GPU memory pinned.
- **Transport** (always-on, no behavioural change)
  — explicit `SO_RCVBUF` / `SO_SNDBUF` requests, `SO_KEEPALIVE` with tightened
  intervals (90 s dead-peer detection vs the default ~2 h), `TCP_QUICKACK`.

Motivation comes from running a 4-node RPC pool at sustained ~1k requests/hour
and being unable to see *where* the time was actually going. Without per-RPC
spans every diagnostic is fingers-in-the-air; with them, an entire class of
"is it bandwidth or latency?" questions resolves in one Phoenix query.

## Verification

End-to-end on an RTX 3070 + Ryzen 5 5600 box running rpc-server with a
controller (`llama-cli --rpc 127.0.0.1:50099`) and an Arize Phoenix collector
on `:4317`:

- **Spans land:** server-side `ggml.rpc.server.dispatch` + client-side
  `ggml.rpc.client.send_recv`/`.send` with correct `rpc.cmd`, `rpc.cmd_name`,
  `rpc.input_bytes`, `rpc.expected_output_bytes`, `rpc.has_response`
  attributes.
- **Failure paths:** spans are correctly marked `StatusCode::kError` with a
  short message on each send/recv failure.
- **Signal-safe flush:** `kill <pid>` (default SIGTERM) flushes the
  BatchSpanProcessor queue before exiting, via an installed signal handler.
  Without the handler, atexit() does not fire under signals and the trace
  data is silently lost.
- **Deadman closes connections:** an idle session post-HELLO closes after the
  configured timeout; a connect-without-HELLO also closes (covers the DoS
  hole on the listen backlog).
- **Tracing is truly opt-in:** with `GGML_RPC_OTLP_ENDPOINT` unset, no
  BatchSpanProcessor thread is started and no connection attempt is made
  to any collector. A `--help` env-var listing makes the surface
  discoverable.

## Commits in order

| # | SHA | What |
|---|---|---|
| 1 | `d4fcc94` | **feat:** opt-in OpenTelemetry tracing for client-side RPC. Adds `-DGGML_RPC_OPENTELEMETRY=ON`, public C API in `rpc-trace.h`, instrumentation on both `send_rpc_cmd` overloads. |
| 2 | `69ba8ad` | **fix:** bug round 1 — eliminate double-emission, add `rpc.cmd_name` attribute, set `SpanKind::kClient`, namespace span names (`ggml.rpc.client.send` / `.send_recv`), cut shutdown timeout 5 s → 2 s. |
| 3 | `9182143` | **perf:** tune TCP socket options for hot-path RPCs — explicit `SO_RCVBUF` / `SO_SNDBUF` 16 MB requests, `SO_KEEPALIVE`, `TCP_QUICKACK`. |
| 4 | `25bdfb5` | **feat:** server-side idle deadman timeout via `GGML_RPC_DEADMAN_S`. Disabled by default. Closes the connection if no command arrives within N seconds. |
| 5 | `adf24cd` | **feat:** server-side spans + RAII `rpc_trace_scope` guard + SIGINT/SIGTERM handler that calls `rpc_trace_shutdown()` to flush spans before exit. |
| 6 | `90542e9` | **fix:** make tracing opt-in at runtime by gating `rpc_trace_init()` on `GGML_RPC_OTLP_ENDPOINT` being set. Removes silent startup overhead for non-tracing users. |
| 7 | `bb1c1bb` | **feat:** extend deadman to the pre-HELLO window so a connect-then-silence client can't park an accept slot indefinitely. |
| 8 | `e97d8ce` | **docs:** document new env vars in `rpc-server --help`; log a one-line status message at startup when tracing is enabled. |
| 9 | `463a7ba` | **perf:** tune TCP keepalive timing (`TCP_KEEPIDLE` 60 / `TCP_KEEPINTVL` 10 / `TCP_KEEPCNT` 3) for ~90 s dead-peer detection vs the default ~2 h. Configurable via `GGML_RPC_KEEPALIVE_S`. |
| 10 | `da8d98a` | **fix:** include `__func__` + `__FILE__:__LINE__` in the `RPC_STATUS_ASSERT` abort message so operators can tell which call site fired. |

## API surface

### CMake options

- `-DGGML_RPC_OPENTELEMETRY=ON` — link `opentelemetry-cpp` and compile the
  tracing implementation. OFF by default. The TU compiles to no-op stubs
  when off, so callers don't need conditional compilation.

### Environment variables

| Variable | Default | Purpose |
|---|---|---|
| `GGML_RPC_OTLP_ENDPOINT` | unset (tracing OFF) | OTLP/gRPC collector URL. Setting it turns tracing ON. |
| `GGML_RPC_OTLP_SERVICE` | `ggml-rpc` | `service.name` resource attribute. |
| `GGML_RPC_DEADMAN_S` | `0` (disabled) | Server-side idle timeout in seconds. |
| `GGML_RPC_KEEPALIVE_S` | `60` | TCP `KEEPIDLE` override (Linux only). |

### Span shape

- `ggml.rpc.client.send` — fire-and-forget (e.g. `GRAPH_COMPUTE`, `GRAPH_RECOMPUTE`).
- `ggml.rpc.client.send_recv` — request/response (every other cmd).
- `ggml.rpc.server.dispatch` — server-side per-command span.

All spans carry:
- `rpc.cmd` (int) — the `rpc_cmd` enum value (stable across versions).
- `rpc.cmd_name` (string) — human-readable enum name; the more useful one.
- `rpc.input_bytes` (int).
- `rpc.expected_output_bytes` (int) — request/response only.
- `rpc.has_response` (`"true"` / `"false"`).

## What this does **not** do

Items deliberately left for future PRs:

- **Trace context propagation.** Client and server spans land as
  unconnected trace roots. Linking them needs a wire-format change
  (24 bytes of W3C trace context per request) gated on a new HELLO
  capability bit. The current `conn_caps[24]` is fully occupied by RDMA
  negotiation, so this needs a proper protocol-version mechanism. Tracked
  separately.
- **Graceful worker drop.** There are 17 `RPC_STATUS_ASSERT` callsites and
  this PR improves only the abort message. Converting them all to return
  cleanly is a substantial refactor in its own right.
- **`MSG_ZEROCOPY` on large tensor sends.** Needs the send path to handle
  the deferred completion notification on the socket error queue.
- **Activation quantization on cross-worker transfers.** Wire-format
  change, separate PR.

## Compatibility

- **Wire format:** unchanged. Old clients/servers and new clients/servers
  interoperate identically.
- **CMake:** new option `GGML_RPC_OPENTELEMETRY` defaults to OFF. Existing
  builds (`-DGGML_RPC=ON` etc.) get all the transport/deadman improvements
  but no tracing dependency.
- **Runtime:** unchanged when no new env vars are set. The transport
  tunings (RCVBUF/SNDBUF, keepalive timing, QUICKACK) are always on but
  are all best-effort — failed `setsockopt` is logged at DEBUG and ignored.

## Reviewer notes

- The implementation file `rpc-trace.cpp` is small and self-contained.
  When `GGML_RPC_OPENTELEMETRY=OFF` it produces only stub implementations
  of the public functions (so other targets can link without conditional
  compilation in their CMake files).
- Server-side spans use a C++ RAII guard (`rpc_trace_scope` in `rpc-trace.h`)
  rather than touching every `case` body in `rpc_serve_client`. The
  existing `return`-on-error pattern in each case is preserved.
- The deadman uses `select()` on Linux and `WSAPoll()` on Windows for the
  inter-command wait — `recv_data` itself remains blocking so large tensor
  transfers don't time out mid-message under network slowness.
- The TCP keepalive defaults (60/10/3) were chosen to be conservative —
  detecting a dead peer in ~90 s. Aggressive defaults (e.g. 5/2/3 for 11 s
  detection) would catch failures faster but risk false positives on
  bursty traffic. Tunable via `GGML_RPC_KEEPALIVE_S` if a deployment
  needs faster.

## Test plan checklist

- [x] `cmake -B build -DGGML_RPC=ON -DGGML_CUDA=ON` — builds clean, no new warnings
- [x] `cmake -B build -DGGML_RPC=ON -DGGML_CUDA=ON -DGGML_RPC_OPENTELEMETRY=ON` — builds clean
- [x] `rpc-server` boots, accepts connections, serves an OOMing-load attempt without crashing the server
- [x] `llama-cli --rpc 127.0.0.1:N` exchanges RPCs as before; no functional change when tracing off
- [x] With tracing on, both client and server spans land in Phoenix with all expected attributes
- [x] SIGTERM flushes pending spans before exit
- [x] `GGML_RPC_DEADMAN_S=3` post-HELLO idle closes after exactly 3 s
- [x] `GGML_RPC_DEADMAN_S=2` pre-HELLO idle (no HELLO sent) closes after 2 s
- [x] `--help` lists new env vars
- [x] No tests in `tests/` regressed (`ctest -j$(nproc)` if you have a CUDA box)

## Out-of-tree dependencies

When `-DGGML_RPC_OPENTELEMETRY=ON`, the build requires
[`opentelemetry-cpp`](https://github.com/open-telemetry/opentelemetry-cpp)
1.21+ with `WITH_OTLP_GRPC=ON`. Build instructions are in
`docs/RPC_TRACING.md`. When the option is OFF (the default) there is no
new dependency.