### PR TITLE
save-load-state : refactor tests and improve readability

### DIFF
--- a/.pi/gg/SYSTEM.md
+++ b/.pi/gg/SYSTEM.md
@@ -22,6 +22,7 @@ Pull requests (PRs):
 Commits:
 - On every commit that you make, include a "Assisted-by: llama.cpp:local pi" tag
 - Do not explicitly set the git author in commits - rely on the default git config
+- Always use `--no-gpg-sign` when committing
 
 Resources (read on demand):
 - [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/.pi/gg/SYSTEM.md
+++ b/.pi/gg/SYSTEM.md
@@ -23,6 +23,7 @@ Commits:
 - On every commit that you make, include a "Assisted-by: llama.cpp:local pi" tag
 - Do not explicitly set the git author in commits - rely on the default git config
 - Always use `--no-gpg-sign` when committing
+- Never `git push` without explicit confirmation from the user
 
 Resources (read on demand):
 - [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1160,7 +1160,7 @@ struct common_init_result::impl {
     std::vector<llama_sampler_seq_config> samplers_seq_config;
 };
 
-common_init_result::common_init_result(common_params & params) :
+common_init_result::common_init_result(common_params & params, bool model_only) :
     pimpl(new impl{}) {
     auto mparams = common_model_params_to_llama(params);
     auto cparams = common_context_params_to_llama(params);
@@ -1182,6 +1182,10 @@ common_init_result::common_init_result(common_params & params) :
     }
 
     pimpl->model.reset(model);
+
+    if (model_only) {
+        return;
+    }
 
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
@@ -1309,12 +1313,16 @@ std::vector<llama_adapter_lora_ptr> & common_init_result::lora() {
     return pimpl->lora;
 }
 
-common_init_result_ptr common_init_from_params(common_params & params) {
-    common_init_result_ptr res(new common_init_result(params));
+common_init_result_ptr common_init_from_params(common_params & params, bool model_only) {
+    common_init_result_ptr res(new common_init_result(params, model_only));
 
     llama_model * model = res->model();
     if (model == NULL) {
         LOG_ERR("%s: failed to load model '%s'\n", __func__, params.model.path.c_str());
+        return res;
+    }
+
+    if (model_only) {
         return res;
     }
 

--- a/common/common.h
+++ b/common/common.h
@@ -859,7 +859,7 @@ struct common_sampler;
 
 // note: defines the model, context, samplers, ets. lifetimes
 struct common_init_result {
-    common_init_result(common_params & params);
+    common_init_result(common_params & params, bool model_only = false);
     ~common_init_result();
 
     llama_model * model();
@@ -877,7 +877,7 @@ private:
 
 using common_init_result_ptr = std::unique_ptr<common_init_result>;
 
-common_init_result_ptr common_init_from_params(common_params & params);
+common_init_result_ptr common_init_from_params(common_params & params, bool model_only = false);
 
 struct llama_model_params     common_model_params_to_llama  (      common_params & params);
 struct llama_context_params   common_context_params_to_llama(const common_params & params);

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -6,6 +6,24 @@
 #include <vector>
 #include <cstdio>
 
+struct llama_batch_ptr {
+    llama_batch batch;
+
+    llama_batch_ptr(int32_t n_tokens, int32_t embd, int32_t n_seq_max)
+        : batch{llama_batch_init(n_tokens, embd, n_seq_max)} {}
+
+    ~llama_batch_ptr() { llama_batch_free(batch); }
+
+    llama_batch_ptr(const llama_batch_ptr &) = delete;
+    llama_batch_ptr & operator=(const llama_batch_ptr &) = delete;
+    llama_batch_ptr(llama_batch_ptr &&) = default;
+    llama_batch_ptr & operator=(llama_batch_ptr &&) = default;
+
+    llama_batch * get() { return &batch; }
+    const llama_batch * get() const { return &batch; }
+    llama_batch & operator*() { return batch; }
+    const llama_batch & operator*() const { return batch; }
+};
 
 // Phase 1: tokenize the prompt, decode all but the last token, save state to disk,
 // decode the last token, then generate n_predict tokens.
@@ -27,7 +45,7 @@ static std::string run_baseline_generation(struct llama_model * model, const str
     printf("\nfirst run: %s", params.prompt.c_str());
 
     std::string result;
-    llama_batch batch = llama_batch_init(1, 0, 1);
+    llama_batch_ptr batch(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
@@ -36,18 +54,15 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         printf("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {0}, true);
+        common_batch_clear(*batch);
+        common_batch_add(*batch, next_token, n_past, {0}, true);
 
-        if (llama_decode(ctx.get(), batch)) {
+        if (llama_decode(ctx.get(), *batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
             return {};
         }
         n_past++;
     }
-
-    llama_batch_free(batch);
 
     return result;
 }
@@ -86,7 +101,7 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
 
     // Generate tokens
     std::string result;
-    llama_batch batch = llama_batch_init(1, 0, 1);
+    llama_batch_ptr batch(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
@@ -95,18 +110,15 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
         printf("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {0}, true);
+        common_batch_clear(*batch);
+        common_batch_add(*batch, next_token, n_past, {0}, true);
 
-        if (llama_decode(ctx.get(), batch)) {
+        if (llama_decode(ctx.get(), *batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
             return {};
         }
         n_past++;
     }
-
-    llama_batch_free(batch);
 
     return result;
 }
@@ -168,7 +180,7 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
 
     // Generate tokens on seq 1
     std::string result;
-    llama_batch batch = llama_batch_init(1, 0, 1);
+    llama_batch_ptr batch(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
@@ -177,18 +189,15 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
         printf("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {1}, true);
+        common_batch_clear(*batch);
+        common_batch_add(*batch, next_token, n_past, {1}, true);
 
-        if (llama_decode(ctx.get(), batch)) {
+        if (llama_decode(ctx.get(), *batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
             return {};
         }
         n_past++;
     }
-
-    llama_batch_free(batch);
 
     return result;
 }
@@ -250,7 +259,7 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
 
     // Generate tokens on seq 1
     std::string result;
-    llama_batch batch = llama_batch_init(1, 0, 1);
+    llama_batch_ptr batch(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
@@ -259,18 +268,15 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
         printf("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {1}, true);
+        common_batch_clear(*batch);
+        common_batch_add(*batch, next_token, n_past, {1}, true);
 
-        if (llama_decode(ctx.get(), batch)) {
+        if (llama_decode(ctx.get(), *batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
             return {};
         }
         n_past++;
     }
-
-    llama_batch_free(batch);
 
     return result;
 }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -47,8 +47,12 @@ static std::string generate_tokens(llama_context * ctx, llama_sampler * smpl, in
     return result;
 }
 
-// Phase 1: tokenize the prompt, decode all but the last token, save state to disk,
-// decode the last token, then generate n_predict tokens.
+// Test 1: baseline generation
+// - tokenize the prompt
+// - decode all but the last token
+// - save state to disk
+// - decode the last token
+// - generate n_predict tokens
 static std::string run_baseline_generation(struct llama_model * model, const struct common_params & params) {
     auto ctx = llama_context_ptr{llama_init_from_model(model, common_context_params_to_llama(params))};
 
@@ -64,7 +68,7 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         return {};
     }
 
-    LOG("\n=== Phase 1: baseline generation ===\n");
+    LOG("\n=== Test 1: baseline generation ===\n");
     LOG("%s", params.prompt.c_str());
 
     auto result = generate_tokens(ctx.get(), smpl.get(), n_past, params.n_predict, 0);
@@ -78,8 +82,11 @@ static std::string run_baseline_generation(struct llama_model * model, const str
 }
 
 
-// Phase 2: create a new context, load state from file, replay the last prompt token,
-// then generate n_predict tokens and compare against expected result.
+// Test 2: state restore
+// - create a new context
+// - load state from file
+// - replay the last prompt token
+// - generate n_predict tokens and compare against expected result
 static bool run_state_restore_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto ctx = llama_context_ptr{llama_init_from_model(model, common_context_params_to_llama(params))};
 
@@ -89,7 +96,7 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\n=== Phase 2: state restore ===\n");
+    LOG("\n=== Test 2: state restore ===\n");
     LOG("%s", params.prompt.c_str());
 
     // Load state from file
@@ -126,8 +133,12 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
 }
 
 
-// Phase 3: create a multi-seq context, load state, replay last token, migrate KV cache
-// from seq 0 to seq 1 via the CPU path, then generate n_predict tokens on seq 1.
+// Test 3: sequence migration (CPU)
+// - create a multi-seq context
+// - load state from file
+// - replay the last prompt token
+// - migrate KV cache from seq 0 to seq 1 via the CPU path
+// - generate n_predict tokens on seq 1 and compare against expected result
 static bool run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
@@ -139,7 +150,7 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\n=== Phase 3: seq migration (CPU) ===\n");
+    LOG("\n=== Test 3: seq migration (CPU) ===\n");
     LOG("%s", params.prompt.c_str());
 
     // Load state from file
@@ -197,8 +208,12 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
 }
 
 
-// Phase 4: create a multi-seq context, load state, replay last token, migrate KV cache
-// from seq 0 to seq 1 via the on-device path, then generate n_predict tokens on seq 1.
+// Test 4: sequence migration (on-device)
+// - create a multi-seq context
+// - load state from file
+// - replay the last prompt token
+// - migrate KV cache from seq 0 to seq 1 via the on-device path
+// - generate n_predict tokens on seq 1 and compare against expected result
 static bool run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
@@ -210,7 +225,7 @@ static bool run_seq_migration_ondevice_generation(struct llama_model * model, co
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\n=== Phase 4: seq migration (on-device) ===\n");
+    LOG("\n=== Test 4: seq migration (on-device) ===\n");
     LOG("%s", params.prompt.c_str());
 
     // Load state from file
@@ -301,23 +316,23 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    // Phase 1: baseline generation (saves state to disk)
+    // Test 1: baseline generation (saves state to disk)
     auto result_baseline = run_baseline_generation(model, params);
     if (result_baseline.empty()) {
         return 1;
     }
 
-    // Phase 2: full state restore from file
+    // Test 2: full state restore from file
     if (!run_state_restore_generation(model, params, result_baseline)) {
         return 1;
     }
 
-    // Phase 3: per-sequence KV migration (CPU path)
+    // Test 3: per-sequence KV migration (CPU path)
     if (!run_seq_migration_cpu_generation(model, params, result_baseline)) {
         return 1;
     }
 
-    // Phase 4: per-sequence KV migration (on-device path)
+    // Test 4: per-sequence KV migration (on-device path)
     if (!run_seq_migration_ondevice_generation(model, params, result_baseline)) {
         return 1;
     }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -9,7 +9,7 @@
 
 // Phase 1: tokenize the prompt, decode all but the last token, save state to disk,
 // decode the last token, then generate n_predict tokens.
-static std::string run_baseline_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+static std::string run_baseline_generation(struct llama_model * model, const struct common_params & params) {
     auto * ctx = llama_init_from_model(model, common_context_params_to_llama(params));
 
     auto sparams = llama_sampler_chain_default_params();
@@ -19,7 +19,7 @@ static std::string run_baseline_generation(struct llama_model * model, const str
     auto tokens = common_tokenize(ctx, params.prompt, true);
 
     auto n_past = 0;
-    if (!common_prompt_batch_decode(ctx, tokens, n_past, params.n_batch, state_file, true)) {
+    if (!common_prompt_batch_decode(ctx, tokens, n_past, params.n_batch, params.out_file, true)) {
         fprintf(stderr, "%s : failed to decode prompt\n", __func__);
         llama_sampler_free(smpl);
         llama_free(ctx);
@@ -61,7 +61,7 @@ static std::string run_baseline_generation(struct llama_model * model, const str
 
 // Phase 2: create a new context, load state from file, replay the last prompt token,
 // then generate n_predict tokens.
-static std::string run_state_restore_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+static std::string run_state_restore_generation(struct llama_model * model, const struct common_params & params) {
     auto * ctx = llama_init_from_model(model, common_context_params_to_llama(params));
 
     auto sparams = llama_sampler_chain_default_params();
@@ -76,7 +76,7 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
-    if (!llama_state_load_file(ctx, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+    if (!llama_state_load_file(ctx, params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         fprintf(stderr, "\n%s : failed to load state\n", __func__);
         llama_sampler_free(smpl);
         llama_free(ctx);
@@ -128,7 +128,7 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
 
 // Phase 3: create a multi-seq context, load state, replay last token, migrate KV cache
 // from seq 0 to seq 1 via the CPU path, then generate n_predict tokens on seq 1.
-static std::string run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+static std::string run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
     auto * ctx = llama_init_from_model(model, params_ctx);
@@ -145,7 +145,7 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
-    if (!llama_state_load_file(ctx, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+    if (!llama_state_load_file(ctx, params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         fprintf(stderr, "\n%s : failed to load state\n", __func__);
         llama_sampler_free(smpl);
         llama_free(ctx);
@@ -222,7 +222,7 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
 
 // Phase 4: create a multi-seq context, load state, replay last token, migrate KV cache
 // from seq 0 to seq 1 via the on-device path, then generate n_predict tokens on seq 1.
-static std::string run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+static std::string run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
     auto * ctx = llama_init_from_model(model, params_ctx);
@@ -239,7 +239,7 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
-    if (!llama_state_load_file(ctx, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+    if (!llama_state_load_file(ctx, params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         fprintf(stderr, "\n%s : failed to load state\n", __func__);
         llama_sampler_free(smpl);
         llama_free(ctx);
@@ -319,9 +319,8 @@ int main(int argc, char ** argv) {
 
     common_params params;
     params.prompt = "The quick brown fox";
+    params.out_file = "dump_state.bin";
     params.sampling.seed = 1234;
-
-    const std::string_view state_file = "dump_state.bin";
 
     common_init();
 
@@ -349,7 +348,7 @@ int main(int argc, char ** argv) {
     }
 
     // Phase 1: baseline generation (saves state to disk)
-    auto result_baseline = run_baseline_generation(model, params, state_file);
+    auto result_baseline = run_baseline_generation(model, params);
     if (result_baseline.empty()) {
         return 1;
     }
@@ -357,7 +356,7 @@ int main(int argc, char ** argv) {
     printf("\n\n");
 
     // Phase 2: full state restore from file
-    auto result_restore = run_state_restore_generation(model, params, state_file);
+    auto result_restore = run_state_restore_generation(model, params);
     if (result_restore.empty()) {
         return 1;
     }
@@ -365,13 +364,13 @@ int main(int argc, char ** argv) {
     printf("\n\n");
 
     // Phase 3: per-sequence KV migration (CPU path)
-    auto result_seq_migration_cpu = run_seq_migration_cpu_generation(model, params, state_file);
+    auto result_seq_migration_cpu = run_seq_migration_cpu_generation(model, params);
     if (result_seq_migration_cpu.empty()) {
         return 1;
     }
 
     // Phase 4: per-sequence KV migration (on-device path)
-    auto result_seq_migration_ondevice = run_seq_migration_ondevice_generation(model, params, state_file);
+    auto result_seq_migration_ondevice = run_seq_migration_ondevice_generation(model, params);
     if (result_seq_migration_ondevice.empty()) {
         return 1;
     }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -47,13 +47,13 @@ static std::string generate_tokens(llama_context * ctx, llama_sampler * smpl, in
     return result;
 }
 
-// Test 1: baseline generation
+// Test 1: baseline
 // - tokenize the prompt
 // - decode all but the last token
 // - save state to disk
 // - decode the last token
 // - generate n_predict tokens
-static std::string run_baseline_generation(struct llama_model * model, const struct common_params & params) {
+static std::string test_baseline(struct llama_model * model, const struct common_params & params) {
     auto ctx = llama_context_ptr{llama_init_from_model(model, common_context_params_to_llama(params))};
 
     auto sparams = llama_sampler_chain_default_params();
@@ -68,7 +68,7 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         return {};
     }
 
-    LOG("\n=== Test 1: baseline generation ===\n");
+    LOG("\n=== Test 1: baseline ===\n");
     LOG("%s", params.prompt.c_str());
 
     auto result = generate_tokens(ctx.get(), smpl.get(), n_past, params.n_predict, 0);
@@ -82,12 +82,12 @@ static std::string run_baseline_generation(struct llama_model * model, const str
 }
 
 
-// Test 2: state restore
+// Test 2: state load
 // - create a new context
 // - load state from file
 // - replay the last prompt token
 // - generate n_predict tokens and compare against expected result
-static bool run_state_restore_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
+static bool test_state_load(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto ctx = llama_context_ptr{llama_init_from_model(model, common_context_params_to_llama(params))};
 
     auto sparams = llama_sampler_chain_default_params();
@@ -96,7 +96,7 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\n=== Test 2: state restore ===\n");
+    LOG("\n=== Test 2: state load ===\n");
     LOG("%s", params.prompt.c_str());
 
     // Load state from file
@@ -133,13 +133,13 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
 }
 
 
-// Test 3: sequence migration (CPU)
+// Test 3: seq copy (host)
 // - create a multi-seq context
 // - load state from file
 // - replay the last prompt token
 // - migrate KV cache from seq 0 to seq 1 via the CPU path
 // - generate n_predict tokens on seq 1 and compare against expected result
-static bool run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
+static bool test_seq_cp_host(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
     auto ctx = llama_context_ptr{llama_init_from_model(model, params_ctx)};
@@ -150,7 +150,7 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\n=== Test 3: seq migration (CPU) ===\n");
+    LOG("\n=== Test 3: seq copy (host) ===\n");
     LOG("%s", params.prompt.c_str());
 
     // Load state from file
@@ -208,13 +208,13 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
 }
 
 
-// Test 4: sequence migration (on-device)
+// Test 4: seq copy (device)
 // - create a multi-seq context
 // - load state from file
 // - replay the last prompt token
 // - migrate KV cache from seq 0 to seq 1 via the on-device path
 // - generate n_predict tokens on seq 1 and compare against expected result
-static bool run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
+static bool test_seq_cp_device(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
     auto ctx = llama_context_ptr{llama_init_from_model(model, params_ctx)};
@@ -225,7 +225,7 @@ static bool run_seq_migration_ondevice_generation(struct llama_model * model, co
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\n=== Test 4: seq migration (on-device) ===\n");
+    LOG("\n=== Test 4: seq copy (device) ===\n");
     LOG("%s", params.prompt.c_str());
 
     // Load state from file
@@ -316,24 +316,24 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    // Test 1: baseline generation (saves state to disk)
-    auto result_baseline = run_baseline_generation(model, params);
+    // Test 1: baseline (saves state to disk)
+    auto result_baseline = test_baseline(model, params);
     if (result_baseline.empty()) {
         return 1;
     }
 
-    // Test 2: full state restore from file
-    if (!run_state_restore_generation(model, params, result_baseline)) {
+    // Test 2: state load
+    if (!test_state_load(model, params, result_baseline)) {
         return 1;
     }
 
-    // Test 3: per-sequence KV migration (CPU path)
-    if (!run_seq_migration_cpu_generation(model, params, result_baseline)) {
+    // Test 3: seq copy (host)
+    if (!test_seq_cp_host(model, params, result_baseline)) {
         return 1;
     }
 
-    // Test 4: per-sequence KV migration (on-device path)
-    if (!run_seq_migration_ondevice_generation(model, params, result_baseline)) {
+    // Test 4: seq copy (device)
+    if (!test_seq_cp_device(model, params, result_baseline)) {
         return 1;
     }
 

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -19,10 +19,8 @@ struct llama_batch_ptr {
     llama_batch_ptr(llama_batch_ptr &&) = default;
     llama_batch_ptr & operator=(llama_batch_ptr &&) = default;
 
-    llama_batch * get() { return &batch; }
-    const llama_batch * get() const { return &batch; }
-    llama_batch & operator*() { return batch; }
-    const llama_batch & operator*() const { return batch; }
+    llama_batch & get() { return batch; }
+    const llama_batch & get() const { return batch; }
 };
 
 // Phase 1: tokenize the prompt, decode all but the last token, save state to disk,
@@ -55,10 +53,10 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(*batch);
-        common_batch_add(*batch, next_token, n_past, {0}, true);
+        common_batch_clear(batch.get());
+        common_batch_add(batch.get(), next_token, n_past, {0}, true);
 
-        if (llama_decode(ctx.get(), *batch)) {
+        if (llama_decode(ctx.get(), batch.get())) {
             LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return {};
         }
@@ -114,10 +112,10 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
         LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(*batch);
-        common_batch_add(*batch, next_token, n_past, {0}, true);
+        common_batch_clear(batch.get());
+        common_batch_add(batch.get(), next_token, n_past, {0}, true);
 
-        if (llama_decode(ctx.get(), *batch)) {
+        if (llama_decode(ctx.get(), batch.get())) {
             LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return false;
         }
@@ -200,10 +198,10 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
         LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(*batch);
-        common_batch_add(*batch, next_token, n_past, {1}, true);
+        common_batch_clear(batch.get());
+        common_batch_add(batch.get(), next_token, n_past, {1}, true);
 
-        if (llama_decode(ctx.get(), *batch)) {
+        if (llama_decode(ctx.get(), batch.get())) {
             LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return false;
         }
@@ -286,10 +284,10 @@ static bool run_seq_migration_ondevice_generation(struct llama_model * model, co
         LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
-        common_batch_clear(*batch);
-        common_batch_add(*batch, next_token, n_past, {1}, true);
+        common_batch_clear(batch.get());
+        common_batch_add(batch.get(), next_token, n_past, {1}, true);
 
-        if (llama_decode(ctx.get(), *batch)) {
+        if (llama_decode(ctx.get(), batch.get())) {
             LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return false;
         }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -1,6 +1,6 @@
 #include "arg.h"
 #include "common.h"
-#include "llama.h"
+#include "llama-cpp.h"
 
 #include <clocale>
 #include <vector>
@@ -10,19 +10,17 @@
 // Phase 1: tokenize the prompt, decode all but the last token, save state to disk,
 // decode the last token, then generate n_predict tokens.
 static std::string run_baseline_generation(struct llama_model * model, const struct common_params & params) {
-    auto * ctx = llama_init_from_model(model, common_context_params_to_llama(params));
+    auto ctx = llama_context_ptr{llama_init_from_model(model, common_context_params_to_llama(params))};
 
     auto sparams = llama_sampler_chain_default_params();
-    llama_sampler * smpl = llama_sampler_chain_init(sparams);
-    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+    auto smpl = llama_sampler_ptr{llama_sampler_chain_init(sparams)};
+    llama_sampler_chain_add(smpl.get(), llama_sampler_init_dist(params.sampling.seed));
 
-    auto tokens = common_tokenize(ctx, params.prompt, true);
+    auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
     auto n_past = 0;
-    if (!common_prompt_batch_decode(ctx, tokens, n_past, params.n_batch, params.out_file, true)) {
+    if (!common_prompt_batch_decode(ctx.get(), tokens, n_past, params.n_batch, params.out_file, true)) {
         fprintf(stderr, "%s : failed to decode prompt\n", __func__);
-        llama_sampler_free(smpl);
-        llama_free(ctx);
         return {};
     }
 
@@ -32,8 +30,8 @@ static std::string run_baseline_generation(struct llama_model * model, const str
     llama_batch batch = llama_batch_init(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
-        auto next_token_str = common_token_to_piece(ctx, next_token);
+        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
+        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
         printf("%s", next_token_str.c_str());
         result += next_token_str;
@@ -41,19 +39,15 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         common_batch_clear(batch);
         common_batch_add(batch, next_token, n_past, {0}, true);
 
-        if (llama_decode(ctx, batch)) {
+        if (llama_decode(ctx.get(), batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_sampler_free(smpl);
             llama_batch_free(batch);
-            llama_free(ctx);
             return {};
         }
         n_past++;
     }
 
-    llama_sampler_free(smpl);
     llama_batch_free(batch);
-    llama_free(ctx);
 
     return result;
 }
@@ -62,13 +56,13 @@ static std::string run_baseline_generation(struct llama_model * model, const str
 // Phase 2: create a new context, load state from file, replay the last prompt token,
 // then generate n_predict tokens.
 static std::string run_state_restore_generation(struct llama_model * model, const struct common_params & params) {
-    auto * ctx = llama_init_from_model(model, common_context_params_to_llama(params));
+    auto ctx = llama_context_ptr{llama_init_from_model(model, common_context_params_to_llama(params))};
 
     auto sparams = llama_sampler_chain_default_params();
-    llama_sampler * smpl = llama_sampler_chain_init(sparams);
-    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+    auto smpl = llama_sampler_ptr{llama_sampler_chain_init(sparams)};
+    llama_sampler_chain_add(smpl.get(), llama_sampler_init_dist(params.sampling.seed));
 
-    auto tokens = common_tokenize(ctx, params.prompt, true);
+    auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
     printf("\nsecond run: %s", params.prompt.c_str());
 
@@ -76,10 +70,8 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
-    if (!llama_state_load_file(ctx, params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+    if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         fprintf(stderr, "\n%s : failed to load state\n", __func__);
-        llama_sampler_free(smpl);
-        llama_free(ctx);
         return {};
     }
 
@@ -87,9 +79,7 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
 
     // Replay last token
     int n_past = (int) n_token_count_out;
-    if (!common_replay_last_token(ctx, tokens.back(), n_past)) {
-        llama_sampler_free(smpl);
-        llama_free(ctx);
+    if (!common_replay_last_token(ctx.get(), tokens.back(), n_past)) {
         return {};
     }
     n_past++;
@@ -99,8 +89,8 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
     llama_batch batch = llama_batch_init(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
-        auto next_token_str = common_token_to_piece(ctx, next_token);
+        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
+        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
         printf("%s", next_token_str.c_str());
         result += next_token_str;
@@ -108,19 +98,15 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
         common_batch_clear(batch);
         common_batch_add(batch, next_token, n_past, {0}, true);
 
-        if (llama_decode(ctx, batch)) {
+        if (llama_decode(ctx.get(), batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_sampler_free(smpl);
             llama_batch_free(batch);
-            llama_free(ctx);
             return {};
         }
         n_past++;
     }
 
-    llama_sampler_free(smpl);
     llama_batch_free(batch);
-    llama_free(ctx);
 
     return result;
 }
@@ -131,13 +117,13 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
 static std::string run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
-    auto * ctx = llama_init_from_model(model, params_ctx);
+    auto ctx = llama_context_ptr{llama_init_from_model(model, params_ctx)};
 
     auto sparams = llama_sampler_chain_default_params();
-    llama_sampler * smpl = llama_sampler_chain_init(sparams);
-    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+    auto smpl = llama_sampler_ptr{llama_sampler_chain_init(sparams)};
+    llama_sampler_chain_add(smpl.get(), llama_sampler_init_dist(params.sampling.seed));
 
-    auto tokens = common_tokenize(ctx, params.prompt, true);
+    auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
     printf("\nsingle seq run: %s", params.prompt.c_str());
 
@@ -145,10 +131,8 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
-    if (!llama_state_load_file(ctx, params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+    if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         fprintf(stderr, "\n%s : failed to load state\n", __func__);
-        llama_sampler_free(smpl);
-        llama_free(ctx);
         return {};
     }
 
@@ -156,33 +140,27 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
 
     // Replay last token
     int n_past = (int) n_token_count_out;
-    if (!common_replay_last_token(ctx, tokens.back(), n_past)) {
-        llama_sampler_free(smpl);
-        llama_free(ctx);
+    if (!common_replay_last_token(ctx.get(), tokens.back(), n_past)) {
         return {};
     }
     n_past++;
 
     // Migrate KV cache from seq 0 to seq 1 (CPU path)
     {
-        std::vector<uint8_t> seq_store(llama_state_seq_get_size(ctx, 0));
-        const size_t ncopy = llama_state_seq_get_data(ctx, seq_store.data(), seq_store.size(), 0);
+        std::vector<uint8_t> seq_store(llama_state_seq_get_size(ctx.get(), 0));
+        const size_t ncopy = llama_state_seq_get_data(ctx.get(), seq_store.data(), seq_store.size(), 0);
         if (ncopy != seq_store.size()) {
             fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
-            llama_sampler_free(smpl);
-            llama_free(ctx);
             return {};
         }
         fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
 
-        llama_memory_clear(llama_get_memory(ctx), true);
+        llama_memory_clear(llama_get_memory(ctx.get()), true);
         fprintf(stderr, "%s : kv cache cleared\n", __func__);
 
-        const size_t nset = llama_state_seq_set_data(ctx, seq_store.data(), seq_store.size(), 1);
+        const size_t nset = llama_state_seq_set_data(ctx.get(), seq_store.data(), seq_store.size(), 1);
         if (nset != seq_store.size()) {
             fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
-            llama_sampler_free(smpl);
-            llama_free(ctx);
             return {};
         }
         fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
@@ -193,8 +171,8 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
     llama_batch batch = llama_batch_init(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
-        auto next_token_str = common_token_to_piece(ctx, next_token);
+        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
+        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
         printf("%s", next_token_str.c_str());
         result += next_token_str;
@@ -202,19 +180,15 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
         common_batch_clear(batch);
         common_batch_add(batch, next_token, n_past, {1}, true);
 
-        if (llama_decode(ctx, batch)) {
+        if (llama_decode(ctx.get(), batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_sampler_free(smpl);
             llama_batch_free(batch);
-            llama_free(ctx);
             return {};
         }
         n_past++;
     }
 
-    llama_sampler_free(smpl);
     llama_batch_free(batch);
-    llama_free(ctx);
 
     return result;
 }
@@ -225,13 +199,13 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
 static std::string run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
-    auto * ctx = llama_init_from_model(model, params_ctx);
+    auto ctx = llama_context_ptr{llama_init_from_model(model, params_ctx)};
 
     auto sparams = llama_sampler_chain_default_params();
-    llama_sampler * smpl = llama_sampler_chain_init(sparams);
-    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+    auto smpl = llama_sampler_ptr{llama_sampler_chain_init(sparams)};
+    llama_sampler_chain_add(smpl.get(), llama_sampler_init_dist(params.sampling.seed));
 
-    auto tokens = common_tokenize(ctx, params.prompt, true);
+    auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
     printf("\nsingle seq run: %s", params.prompt.c_str());
 
@@ -239,10 +213,8 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
-    if (!llama_state_load_file(ctx, params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+    if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         fprintf(stderr, "\n%s : failed to load state\n", __func__);
-        llama_sampler_free(smpl);
-        llama_free(ctx);
         return {};
     }
 
@@ -250,33 +222,27 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
 
     // Replay last token
     int n_past = (int) n_token_count_out;
-    if (!common_replay_last_token(ctx, tokens.back(), n_past)) {
-        llama_sampler_free(smpl);
-        llama_free(ctx);
+    if (!common_replay_last_token(ctx.get(), tokens.back(), n_past)) {
         return {};
     }
     n_past++;
 
     // Migrate KV cache from seq 0 to seq 1 (on-device path)
     {
-        std::vector<uint8_t> seq_store(llama_state_seq_get_size_ext(ctx, 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE));
-        const size_t ncopy = llama_state_seq_get_data_ext(ctx, seq_store.data(), seq_store.size(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
+        std::vector<uint8_t> seq_store(llama_state_seq_get_size_ext(ctx.get(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE));
+        const size_t ncopy = llama_state_seq_get_data_ext(ctx.get(), seq_store.data(), seq_store.size(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
         if (ncopy != seq_store.size()) {
             fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
-            llama_sampler_free(smpl);
-            llama_free(ctx);
             return {};
         }
         fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
 
-        llama_memory_clear(llama_get_memory(ctx), true);
+        llama_memory_clear(llama_get_memory(ctx.get()), true);
         fprintf(stderr, "%s : kv cache cleared\n", __func__);
 
-        const size_t nset = llama_state_seq_set_data_ext(ctx, seq_store.data(), seq_store.size(), 1, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
+        const size_t nset = llama_state_seq_set_data_ext(ctx.get(), seq_store.data(), seq_store.size(), 1, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
         if (nset != seq_store.size()) {
             fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
-            llama_sampler_free(smpl);
-            llama_free(ctx);
             return {};
         }
         fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
@@ -287,8 +253,8 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
     llama_batch batch = llama_batch_init(1, 0, 1);
 
     for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
-        auto next_token_str = common_token_to_piece(ctx, next_token);
+        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
+        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
         printf("%s", next_token_str.c_str());
         result += next_token_str;
@@ -296,19 +262,15 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
         common_batch_clear(batch);
         common_batch_add(batch, next_token, n_past, {1}, true);
 
-        if (llama_decode(ctx, batch)) {
+        if (llama_decode(ctx.get(), batch)) {
             fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_sampler_free(smpl);
             llama_batch_free(batch);
-            llama_free(ctx);
             return {};
         }
         n_past++;
     }
 
-    llama_sampler_free(smpl);
     llama_batch_free(batch);
-    llama_free(ctx);
 
     return result;
 }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -308,13 +308,15 @@ int main(int argc, char ** argv) {
 
     ggml_backend_load_all();
 
-    auto llama_init = common_init_from_params(params);
+    auto llama_init = common_init_from_params(params, true);
     auto * model = llama_init->model();
 
     if (model == nullptr) {
         LOG_ERR("%s: failed to init\n", __func__);
         return 1;
     }
+
+    GGML_ASSERT(llama_init->context() == nullptr);
 
     // Test 1: baseline (saves state to disk)
     auto result_baseline = test_baseline(model, params);

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -7,11 +7,317 @@
 #include <cstdio>
 
 
+// Phase 1: tokenize the prompt, decode all but the last token, save state to disk,
+// decode the last token, then generate n_predict tokens.
+static std::string run_baseline_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+    auto * ctx = llama_init_from_model(model, common_context_params_to_llama(params));
+
+    auto sparams = llama_sampler_chain_default_params();
+    llama_sampler * smpl = llama_sampler_chain_init(sparams);
+    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+
+    auto tokens = common_tokenize(ctx, params.prompt, true);
+
+    auto n_past = 0;
+    if (!common_prompt_batch_decode(ctx, tokens, n_past, params.n_batch, state_file, true)) {
+        fprintf(stderr, "%s : failed to decode prompt\n", __func__);
+        llama_sampler_free(smpl);
+        llama_free(ctx);
+        return {};
+    }
+
+    printf("\nfirst run: %s", params.prompt.c_str());
+
+    std::string result;
+    llama_batch batch = llama_batch_init(1, 0, 1);
+
+    for (int i = 0; i < params.n_predict; i++) {
+        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
+        auto next_token_str = common_token_to_piece(ctx, next_token);
+
+        printf("%s", next_token_str.c_str());
+        result += next_token_str;
+
+        common_batch_clear(batch);
+        common_batch_add(batch, next_token, n_past, {0}, true);
+
+        if (llama_decode(ctx, batch)) {
+            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            llama_sampler_free(smpl);
+            llama_batch_free(batch);
+            llama_free(ctx);
+            return {};
+        }
+        n_past++;
+    }
+
+    llama_sampler_free(smpl);
+    llama_batch_free(batch);
+    llama_free(ctx);
+
+    return result;
+}
+
+
+// Phase 2: create a new context, load state from file, replay the last prompt token,
+// then generate n_predict tokens.
+static std::string run_state_restore_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+    auto * ctx = llama_init_from_model(model, common_context_params_to_llama(params));
+
+    auto sparams = llama_sampler_chain_default_params();
+    llama_sampler * smpl = llama_sampler_chain_init(sparams);
+    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+
+    auto tokens = common_tokenize(ctx, params.prompt, true);
+
+    printf("\nsecond run: %s", params.prompt.c_str());
+
+    // Load state from file
+    std::vector<llama_token> unused_sts(tokens.size());
+    size_t n_token_count_out = 0;
+
+    if (!llama_state_load_file(ctx, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+        llama_sampler_free(smpl);
+        llama_free(ctx);
+        return {};
+    }
+
+    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
+
+    // Replay last token
+    int n_past = (int) n_token_count_out;
+    if (!common_replay_last_token(ctx, tokens.back(), n_past)) {
+        llama_sampler_free(smpl);
+        llama_free(ctx);
+        return {};
+    }
+    n_past++;
+
+    // Generate tokens
+    std::string result;
+    llama_batch batch = llama_batch_init(1, 0, 1);
+
+    for (int i = 0; i < params.n_predict; i++) {
+        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
+        auto next_token_str = common_token_to_piece(ctx, next_token);
+
+        printf("%s", next_token_str.c_str());
+        result += next_token_str;
+
+        common_batch_clear(batch);
+        common_batch_add(batch, next_token, n_past, {0}, true);
+
+        if (llama_decode(ctx, batch)) {
+            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            llama_sampler_free(smpl);
+            llama_batch_free(batch);
+            llama_free(ctx);
+            return {};
+        }
+        n_past++;
+    }
+
+    llama_sampler_free(smpl);
+    llama_batch_free(batch);
+    llama_free(ctx);
+
+    return result;
+}
+
+
+// Phase 3: create a multi-seq context, load state, replay last token, migrate KV cache
+// from seq 0 to seq 1 via the CPU path, then generate n_predict tokens on seq 1.
+static std::string run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+    auto params_ctx = common_context_params_to_llama(params);
+    params_ctx.n_seq_max = 2;
+    auto * ctx = llama_init_from_model(model, params_ctx);
+
+    auto sparams = llama_sampler_chain_default_params();
+    llama_sampler * smpl = llama_sampler_chain_init(sparams);
+    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+
+    auto tokens = common_tokenize(ctx, params.prompt, true);
+
+    printf("\nsingle seq run: %s", params.prompt.c_str());
+
+    // Load state from file
+    std::vector<llama_token> unused_sts(tokens.size());
+    size_t n_token_count_out = 0;
+
+    if (!llama_state_load_file(ctx, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+        llama_sampler_free(smpl);
+        llama_free(ctx);
+        return {};
+    }
+
+    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
+
+    // Replay last token
+    int n_past = (int) n_token_count_out;
+    if (!common_replay_last_token(ctx, tokens.back(), n_past)) {
+        llama_sampler_free(smpl);
+        llama_free(ctx);
+        return {};
+    }
+    n_past++;
+
+    // Migrate KV cache from seq 0 to seq 1 (CPU path)
+    {
+        std::vector<uint8_t> seq_store(llama_state_seq_get_size(ctx, 0));
+        const size_t ncopy = llama_state_seq_get_data(ctx, seq_store.data(), seq_store.size(), 0);
+        if (ncopy != seq_store.size()) {
+            fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
+            llama_sampler_free(smpl);
+            llama_free(ctx);
+            return {};
+        }
+        fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
+
+        llama_memory_clear(llama_get_memory(ctx), true);
+        fprintf(stderr, "%s : kv cache cleared\n", __func__);
+
+        const size_t nset = llama_state_seq_set_data(ctx, seq_store.data(), seq_store.size(), 1);
+        if (nset != seq_store.size()) {
+            fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
+            llama_sampler_free(smpl);
+            llama_free(ctx);
+            return {};
+        }
+        fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
+    }
+
+    // Generate tokens on seq 1
+    std::string result;
+    llama_batch batch = llama_batch_init(1, 0, 1);
+
+    for (int i = 0; i < params.n_predict; i++) {
+        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
+        auto next_token_str = common_token_to_piece(ctx, next_token);
+
+        printf("%s", next_token_str.c_str());
+        result += next_token_str;
+
+        common_batch_clear(batch);
+        common_batch_add(batch, next_token, n_past, {1}, true);
+
+        if (llama_decode(ctx, batch)) {
+            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            llama_sampler_free(smpl);
+            llama_batch_free(batch);
+            llama_free(ctx);
+            return {};
+        }
+        n_past++;
+    }
+
+    llama_sampler_free(smpl);
+    llama_batch_free(batch);
+    llama_free(ctx);
+
+    return result;
+}
+
+
+// Phase 4: create a multi-seq context, load state, replay last token, migrate KV cache
+// from seq 0 to seq 1 via the on-device path, then generate n_predict tokens on seq 1.
+static std::string run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params, std::string_view state_file) {
+    auto params_ctx = common_context_params_to_llama(params);
+    params_ctx.n_seq_max = 2;
+    auto * ctx = llama_init_from_model(model, params_ctx);
+
+    auto sparams = llama_sampler_chain_default_params();
+    llama_sampler * smpl = llama_sampler_chain_init(sparams);
+    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
+
+    auto tokens = common_tokenize(ctx, params.prompt, true);
+
+    printf("\nsingle seq run: %s", params.prompt.c_str());
+
+    // Load state from file
+    std::vector<llama_token> unused_sts(tokens.size());
+    size_t n_token_count_out = 0;
+
+    if (!llama_state_load_file(ctx, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
+        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+        llama_sampler_free(smpl);
+        llama_free(ctx);
+        return {};
+    }
+
+    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
+
+    // Replay last token
+    int n_past = (int) n_token_count_out;
+    if (!common_replay_last_token(ctx, tokens.back(), n_past)) {
+        llama_sampler_free(smpl);
+        llama_free(ctx);
+        return {};
+    }
+    n_past++;
+
+    // Migrate KV cache from seq 0 to seq 1 (on-device path)
+    {
+        std::vector<uint8_t> seq_store(llama_state_seq_get_size_ext(ctx, 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE));
+        const size_t ncopy = llama_state_seq_get_data_ext(ctx, seq_store.data(), seq_store.size(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
+        if (ncopy != seq_store.size()) {
+            fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
+            llama_sampler_free(smpl);
+            llama_free(ctx);
+            return {};
+        }
+        fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
+
+        llama_memory_clear(llama_get_memory(ctx), true);
+        fprintf(stderr, "%s : kv cache cleared\n", __func__);
+
+        const size_t nset = llama_state_seq_set_data_ext(ctx, seq_store.data(), seq_store.size(), 1, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
+        if (nset != seq_store.size()) {
+            fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
+            llama_sampler_free(smpl);
+            llama_free(ctx);
+            return {};
+        }
+        fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
+    }
+
+    // Generate tokens on seq 1
+    std::string result;
+    llama_batch batch = llama_batch_init(1, 0, 1);
+
+    for (int i = 0; i < params.n_predict; i++) {
+        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
+        auto next_token_str = common_token_to_piece(ctx, next_token);
+
+        printf("%s", next_token_str.c_str());
+        result += next_token_str;
+
+        common_batch_clear(batch);
+        common_batch_add(batch, next_token, n_past, {1}, true);
+
+        if (llama_decode(ctx, batch)) {
+            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            llama_sampler_free(smpl);
+            llama_batch_free(batch);
+            llama_free(ctx);
+            return {};
+        }
+        n_past++;
+    }
+
+    llama_sampler_free(smpl);
+    llama_batch_free(batch);
+    llama_free(ctx);
+
+    return result;
+}
+
+
 int main(int argc, char ** argv) {
     std::setlocale(LC_NUMERIC, "C");
 
     common_params params;
-
     params.prompt = "The quick brown fox";
     params.sampling.seed = 1234;
 
@@ -24,7 +330,6 @@ int main(int argc, char ** argv) {
     }
 
     if (params.n_parallel == 1) {
-        // the example uses 2 sequences, so when n_parallel == 1, we need to enable unified kv cache
         printf("%s: n_parallel == 1, enabling unified kv cache\n", __func__);
         params.kv_unified = true;
     }
@@ -33,283 +338,58 @@ int main(int argc, char ** argv) {
         params.n_predict = 16;
     }
 
-    auto n_past = 0;
-
-    std::string result0;
-    std::string result1;
-    std::string result2;
-    std::string result3;
-
-    // init
-
     ggml_backend_load_all();
 
     auto llama_init = common_init_from_params(params);
-
     auto * model = llama_init->model();
-    auto * ctx   = llama_init->context();
 
-    if (model == nullptr || ctx == nullptr) {
+    if (model == nullptr) {
         fprintf(stderr, "%s : failed to init\n", __func__);
         return 1;
     }
 
-    auto sparams = llama_sampler_chain_default_params();
-
-    llama_sampler * smpl = llama_sampler_chain_init(sparams);
-
-    llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.sampling.seed));
-
-    // tokenize prompt
-    auto tokens = common_tokenize(ctx, params.prompt, true);
-
-    const bool save_state = true;
-    if (!common_prompt_batch_decode(ctx, tokens, n_past, params.n_batch, state_file, save_state)) {
+    // Phase 1: baseline generation (saves state to disk)
+    auto result_baseline = run_baseline_generation(model, params, state_file);
+    if (result_baseline.empty()) {
         return 1;
-    }
-
-    // first run
-    printf("\nfirst run: %s", params.prompt.c_str());
-
-    llama_batch batch = llama_batch_init(1, 0, 1);
-
-    for (auto i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
-        auto next_token_str = common_token_to_piece(ctx, next_token);
-
-        printf("%s", next_token_str.c_str());
-        result0 += next_token_str;
-
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {0}, true);
-
-        if (llama_decode(ctx, batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
-            return 1;
-        }
-        n_past += 1;
     }
 
     printf("\n\n");
 
-    // make new context
-    llama_context * ctx2 = llama_init_from_model(model, common_context_params_to_llama(params));
-
-    llama_sampler * smpl2 = llama_sampler_chain_init(sparams);
-
-    llama_sampler_chain_add(smpl2, llama_sampler_init_dist(params.sampling.seed));
-
-    printf("\nsecond run: %s", params.prompt.c_str());
-
-    // load state from file
-    std::vector<llama_token> unused_sts(tokens.size()); // unused session tokens.
-    size_t n_token_count_out = 0;
-
-    if (!llama_state_load_file(ctx2, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
-        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+    // Phase 2: full state restore from file
+    auto result_restore = run_state_restore_generation(model, params, state_file);
+    if (result_restore.empty()) {
         return 1;
-    }
-
-    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
-
-    // restore state (last tokens)
-    n_past = n_token_count_out;
-    if (!common_replay_last_token(ctx2, tokens.back(), n_past)) {
-        return 1;
-    }
-    ++n_past;
-
-    // second run
-    for (auto i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl2, ctx2, -1);
-        auto next_token_str = common_token_to_piece(ctx2, next_token);
-
-        printf("%s", next_token_str.c_str());
-        result1 += next_token_str;
-
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {0}, true);
-
-        if (llama_decode(ctx2, batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
-            return 1;
-        }
-        n_past += 1;
     }
 
     printf("\n\n");
 
-    if (result0 != result1) {
-        fprintf(stderr, "\n%s : error : the 2 generations are different\n", __func__);
+    // Phase 3: per-sequence KV migration (CPU path)
+    auto result_seq_migration_cpu = run_seq_migration_cpu_generation(model, params, state_file);
+    if (result_seq_migration_cpu.empty()) {
         return 1;
     }
 
-    // make new context
-    auto params_ctx3 = common_context_params_to_llama(params);
-    params_ctx3.n_seq_max = 2;
-    llama_context * ctx3 = llama_init_from_model(model, params_ctx3);
-
-    llama_sampler * smpl3 = llama_sampler_chain_init(sparams);
-
-    llama_sampler_chain_add(smpl3, llama_sampler_init_dist(params.sampling.seed));
-
-    printf("\nsingle seq run: %s", params.prompt.c_str());
-
-    // load state (rng, logits, embedding and kv_cache) from file
-    n_token_count_out = 0;
-
-    if (!llama_state_load_file(ctx3, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
-        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+    // Phase 4: per-sequence KV migration (on-device path)
+    auto result_seq_migration_ondevice = run_seq_migration_ondevice_generation(model, params, state_file);
+    if (result_seq_migration_ondevice.empty()) {
         return 1;
-    }
-
-    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
-
-    // restore state (last tokens)
-    n_past = n_token_count_out;
-    if (!common_replay_last_token(ctx3, tokens.back(), n_past)) {
-        return 1;
-    }
-    ++n_past;
-
-    // save seq 0 and load into seq 1
-    {
-        // save kv of seq 0
-        std::vector<uint8_t> seq_store(llama_state_seq_get_size(ctx3, 0));
-        const size_t ncopy = llama_state_seq_get_data(ctx3, seq_store.data(), seq_store.size(), 0);
-        if (ncopy != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
-            return 1;
-        }
-        fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
-
-        // erase whole kv
-        llama_memory_clear(llama_get_memory(ctx3), true);
-        fprintf(stderr, "%s : kv cache cleared\n", __func__);
-
-        // restore kv into seq 1
-        const size_t nset = llama_state_seq_set_data(ctx3, seq_store.data(), seq_store.size(), 1);
-        if (nset != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
-            return 1;
-        }
-        fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
-    }
-
-    // third run with seq 1 instead of 0
-    for (auto i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl3, ctx3, -1);
-        auto next_token_str = common_token_to_piece(ctx3, next_token);
-
-        printf("%s", next_token_str.c_str());
-        result2 += next_token_str;
-
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {1}, true);
-
-        if (llama_decode(ctx3, batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
-            return 1;
-        }
-        n_past += 1;
-    }
-
-    // test on-device state save/load
-    auto params_ctx4 = common_context_params_to_llama(params);
-    params_ctx4.n_seq_max = 2;
-    llama_context * ctx4 = llama_init_from_model(model, params_ctx4);
-
-    llama_sampler * smpl4 = llama_sampler_chain_init(sparams);
-
-    llama_sampler_chain_add(smpl4, llama_sampler_init_dist(params.sampling.seed));
-
-    printf("\nsingle seq run: %s", params.prompt.c_str());
-
-    // load state (rng, logits, embedding and kv_cache) from file
-    n_token_count_out = 0;
-
-    if (!llama_state_load_file(ctx4, state_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
-        fprintf(stderr, "\n%s : failed to load state\n", __func__);
-        return 1;
-    }
-
-    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
-
-    // restore state (last tokens)
-    n_past = n_token_count_out;
-    if (!common_replay_last_token(ctx4, tokens.back(), n_past)) {
-        return 1;
-    }
-    ++n_past;
-
-    // save seq 0 and load into seq 1
-    {
-        // save kv of seq 0
-        std::vector<uint8_t> seq_store(llama_state_seq_get_size_ext(ctx4, 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE));
-        const size_t ncopy = llama_state_seq_get_data_ext(ctx4, seq_store.data(), seq_store.size(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
-        if (ncopy != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
-            return 1;
-        }
-        fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
-
-        // erase whole kv
-        llama_memory_clear(llama_get_memory(ctx4), true);
-        fprintf(stderr, "%s : kv cache cleared\n", __func__);
-
-        // restore kv into seq 0
-        const size_t nset = llama_state_seq_set_data_ext(ctx4, seq_store.data(), seq_store.size(), 1, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
-        if (nset != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
-            return 1;
-        }
-        fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
-    }
-
-    // forth run
-    for (auto i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl4, ctx4, -1);
-        auto next_token_str = common_token_to_piece(ctx4, next_token);
-
-        printf("%s", next_token_str.c_str());
-        result3 += next_token_str;
-
-        common_batch_clear(batch);
-        common_batch_add(batch, next_token, n_past, {1}, true);
-
-        if (llama_decode(ctx4, batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
-            llama_batch_free(batch);
-            return 1;
-        }
-        n_past += 1;
     }
 
     printf("\n");
 
-    llama_sampler_free(smpl);
-    llama_sampler_free(smpl2);
-    llama_sampler_free(smpl3);
-    llama_sampler_free(smpl4);
+    // Assertions
+    if (result_baseline != result_restore) {
+        fprintf(stderr, "\n%s : error : the 2 generations are different\n", __func__);
+        return 1;
+    }
 
-    llama_batch_free(batch);
-
-    // this one is managed by common_init_result
-    //llama_free(ctx);
-
-    llama_free(ctx2);
-    llama_free(ctx3);
-    llama_free(ctx4);
-
-    if (result0 != result2) {
+    if (result_baseline != result_seq_migration_cpu) {
         fprintf(stderr, "\n%s : error : the seq restore generation is different\n", __func__);
         return 1;
     }
 
-    if (result0 != result3) {
+    if (result_baseline != result_seq_migration_ondevice) {
         fprintf(stderr, "\n%s : error : the seq restore generation is different\n", __func__);
         return 1;
     }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -23,6 +23,30 @@ struct llama_batch_ptr {
     const llama_batch & get() const { return batch; }
 };
 
+static std::string generate_tokens(llama_context * ctx, llama_sampler * smpl, int & n_past, int32_t n_predict, llama_seq_id seq_id) {
+    std::string result;
+    llama_batch_ptr batch(1, 0, 1);
+
+    for (int i = 0; i < n_predict; i++) {
+        auto next_token     = llama_sampler_sample(smpl, ctx, -1);
+        auto next_token_str = common_token_to_piece(ctx, next_token);
+
+        LOG("%s", next_token_str.c_str());
+        result += next_token_str;
+
+        common_batch_clear(batch.get());
+        common_batch_add(batch.get(), next_token, n_past, {seq_id}, true);
+
+        if (llama_decode(ctx, batch.get())) {
+            LOG_ERR("\n%s: failed to evaluate\n", __func__);
+            return {};
+        }
+        n_past++;
+    }
+
+    return result;
+}
+
 // Phase 1: tokenize the prompt, decode all but the last token, save state to disk,
 // decode the last token, then generate n_predict tokens.
 static std::string run_baseline_generation(struct llama_model * model, const struct common_params & params) {
@@ -43,24 +67,9 @@ static std::string run_baseline_generation(struct llama_model * model, const str
     LOG("\n=== Phase 1: baseline generation ===\n");
     LOG("%s", params.prompt.c_str());
 
-    std::string result;
-    llama_batch_ptr batch(1, 0, 1);
-
-    for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
-        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
-
-        LOG("%s", next_token_str.c_str());
-        result += next_token_str;
-
-        common_batch_clear(batch.get());
-        common_batch_add(batch.get(), next_token, n_past, {0}, true);
-
-        if (llama_decode(ctx.get(), batch.get())) {
-            LOG_ERR("\n%s: failed to evaluate\n", __func__);
-            return {};
-        }
-        n_past++;
+    auto result = generate_tokens(ctx.get(), smpl.get(), n_past, params.n_predict, 0);
+    if (result.empty()) {
+        return {};
     }
 
     LOG("\n");
@@ -102,24 +111,9 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
     n_past++;
 
     // Generate tokens
-    std::string result;
-    llama_batch_ptr batch(1, 0, 1);
-
-    for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
-        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
-
-        LOG("%s", next_token_str.c_str());
-        result += next_token_str;
-
-        common_batch_clear(batch.get());
-        common_batch_add(batch.get(), next_token, n_past, {0}, true);
-
-        if (llama_decode(ctx.get(), batch.get())) {
-            LOG_ERR("\n%s: failed to evaluate\n", __func__);
-            return false;
-        }
-        n_past++;
+    auto result = generate_tokens(ctx.get(), smpl.get(), n_past, params.n_predict, 0);
+    if (result.empty()) {
+        return false;
     }
 
     if (result != expected_result) {
@@ -188,24 +182,9 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
     }
 
     // Generate tokens on seq 1
-    std::string result;
-    llama_batch_ptr batch(1, 0, 1);
-
-    for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
-        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
-
-        LOG("%s", next_token_str.c_str());
-        result += next_token_str;
-
-        common_batch_clear(batch.get());
-        common_batch_add(batch.get(), next_token, n_past, {1}, true);
-
-        if (llama_decode(ctx.get(), batch.get())) {
-            LOG_ERR("\n%s: failed to evaluate\n", __func__);
-            return false;
-        }
-        n_past++;
+    auto result = generate_tokens(ctx.get(), smpl.get(), n_past, params.n_predict, 1);
+    if (result.empty()) {
+        return false;
     }
 
     if (result != expected_result) {
@@ -274,24 +253,9 @@ static bool run_seq_migration_ondevice_generation(struct llama_model * model, co
     }
 
     // Generate tokens on seq 1
-    std::string result;
-    llama_batch_ptr batch(1, 0, 1);
-
-    for (int i = 0; i < params.n_predict; i++) {
-        auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
-        auto next_token_str = common_token_to_piece(ctx.get(), next_token);
-
-        LOG("%s", next_token_str.c_str());
-        result += next_token_str;
-
-        common_batch_clear(batch.get());
-        common_batch_add(batch.get(), next_token, n_past, {1}, true);
-
-        if (llama_decode(ctx.get(), batch.get())) {
-            LOG_ERR("\n%s: failed to evaluate\n", __func__);
-            return false;
-        }
-        n_past++;
+    auto result = generate_tokens(ctx.get(), smpl.get(), n_past, params.n_predict, 1);
+    if (result.empty()) {
+        return false;
     }
 
     if (result != expected_result) {

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -42,7 +42,8 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         return {};
     }
 
-    LOG("\nfirst run: %s", params.prompt.c_str());
+    LOG("\n=== Phase 1: baseline generation ===\n");
+    LOG("%s", params.prompt.c_str());
 
     std::string result;
     llama_batch_ptr batch(1, 0, 1);
@@ -64,6 +65,8 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         n_past++;
     }
 
+    LOG("\n");
+
     return result;
 }
 
@@ -79,7 +82,8 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\nsecond run: %s", params.prompt.c_str());
+    LOG("\n=== Phase 2: state restore ===\n");
+    LOG("%s", params.prompt.c_str());
 
     // Load state from file
     std::vector<llama_token> unused_sts(tokens.size());
@@ -125,7 +129,7 @@ static bool run_state_restore_generation(struct llama_model * model, const struc
         return false;
     }
 
-    LOG_TRC("\n%s: success\n", __func__);
+    LOG("\nPASS\n");
     return true;
 }
 
@@ -143,7 +147,8 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\nsingle seq run: %s", params.prompt.c_str());
+    LOG("\n=== Phase 3: seq migration (CPU) ===\n");
+    LOG("%s", params.prompt.c_str());
 
     // Load state from file
     std::vector<llama_token> unused_sts(tokens.size());
@@ -210,7 +215,7 @@ static bool run_seq_migration_cpu_generation(struct llama_model * model, const s
         return false;
     }
 
-    LOG_TRC("\n%s: success\n", __func__);
+    LOG("\nPASS\n");
     return true;
 }
 
@@ -228,7 +233,8 @@ static bool run_seq_migration_ondevice_generation(struct llama_model * model, co
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    LOG("\nsingle seq run: %s", params.prompt.c_str());
+    LOG("\n=== Phase 4: seq migration (on-device) ===\n");
+    LOG("%s", params.prompt.c_str());
 
     // Load state from file
     std::vector<llama_token> unused_sts(tokens.size());
@@ -295,7 +301,7 @@ static bool run_seq_migration_ondevice_generation(struct llama_model * model, co
         return false;
     }
 
-    LOG_TRC("\n%s: success\n", __func__);
+    LOG("\nPASS\n");
     return true;
 }
 
@@ -354,7 +360,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    LOG_TRC("\n%s: all tests passed\n", __func__);
+    LOG("\nAll tests passed.\n");
 
     return 0;
 }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -69,8 +69,8 @@ static std::string run_baseline_generation(struct llama_model * model, const str
 
 
 // Phase 2: create a new context, load state from file, replay the last prompt token,
-// then generate n_predict tokens.
-static std::string run_state_restore_generation(struct llama_model * model, const struct common_params & params) {
+// then generate n_predict tokens and compare against expected result.
+static bool run_state_restore_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto ctx = llama_context_ptr{llama_init_from_model(model, common_context_params_to_llama(params))};
 
     auto sparams = llama_sampler_chain_default_params();
@@ -87,7 +87,7 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
 
     if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         LOG_ERR("\n%s: failed to load state\n", __func__);
-        return {};
+        return false;
     }
 
     LOG_TRC("%s: loaded state with %zu tokens\n", __func__, n_token_count_out);
@@ -95,7 +95,7 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
     // Replay last token
     int n_past = (int) n_token_count_out;
     if (!common_replay_last_token(ctx.get(), tokens.back(), n_past)) {
-        return {};
+        return false;
     }
     n_past++;
 
@@ -115,18 +115,24 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
 
         if (llama_decode(ctx.get(), *batch)) {
             LOG_ERR("\n%s: failed to evaluate\n", __func__);
-            return {};
+            return false;
         }
         n_past++;
     }
 
-    return result;
+    if (result != expected_result) {
+        LOG_ERR("\n%s: error: generation differs from expected\n", __func__);
+        return false;
+    }
+
+    LOG_TRC("\n%s: success\n", __func__);
+    return true;
 }
 
 
 // Phase 3: create a multi-seq context, load state, replay last token, migrate KV cache
 // from seq 0 to seq 1 via the CPU path, then generate n_predict tokens on seq 1.
-static std::string run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params) {
+static bool run_seq_migration_cpu_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
     auto ctx = llama_context_ptr{llama_init_from_model(model, params_ctx)};
@@ -145,7 +151,7 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
 
     if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         LOG_ERR("\n%s: failed to load state\n", __func__);
-        return {};
+        return false;
     }
 
     LOG_TRC("%s: loaded state with %zu tokens\n", __func__, n_token_count_out);
@@ -153,7 +159,7 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
     // Replay last token
     int n_past = (int) n_token_count_out;
     if (!common_replay_last_token(ctx.get(), tokens.back(), n_past)) {
-        return {};
+        return false;
     }
     n_past++;
 
@@ -163,7 +169,7 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
         const size_t ncopy = llama_state_seq_get_data(ctx.get(), seq_store.data(), seq_store.size(), 0);
         if (ncopy != seq_store.size()) {
             LOG_ERR("\n%s: seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
-            return {};
+            return false;
         }
         LOG_TRC("%s: seq 0 copied, %zd bytes\n", __func__, ncopy);
 
@@ -173,7 +179,7 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
         const size_t nset = llama_state_seq_set_data(ctx.get(), seq_store.data(), seq_store.size(), 1);
         if (nset != seq_store.size()) {
             LOG_ERR("\n%s: seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
-            return {};
+            return false;
         }
         LOG_TRC("%s: seq 1 restored, %zd bytes\n", __func__, nset);
     }
@@ -194,18 +200,24 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
 
         if (llama_decode(ctx.get(), *batch)) {
             LOG_ERR("\n%s: failed to evaluate\n", __func__);
-            return {};
+            return false;
         }
         n_past++;
     }
 
-    return result;
+    if (result != expected_result) {
+        LOG_ERR("\n%s: error: generation differs from expected\n", __func__);
+        return false;
+    }
+
+    LOG_TRC("\n%s: success\n", __func__);
+    return true;
 }
 
 
 // Phase 4: create a multi-seq context, load state, replay last token, migrate KV cache
 // from seq 0 to seq 1 via the on-device path, then generate n_predict tokens on seq 1.
-static std::string run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params) {
+static bool run_seq_migration_ondevice_generation(struct llama_model * model, const struct common_params & params, const std::string & expected_result) {
     auto params_ctx = common_context_params_to_llama(params);
     params_ctx.n_seq_max = 2;
     auto ctx = llama_context_ptr{llama_init_from_model(model, params_ctx)};
@@ -224,7 +236,7 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
 
     if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
         LOG_ERR("\n%s: failed to load state\n", __func__);
-        return {};
+        return false;
     }
 
     LOG_TRC("%s: loaded state with %zu tokens\n", __func__, n_token_count_out);
@@ -232,7 +244,7 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
     // Replay last token
     int n_past = (int) n_token_count_out;
     if (!common_replay_last_token(ctx.get(), tokens.back(), n_past)) {
-        return {};
+        return false;
     }
     n_past++;
 
@@ -242,7 +254,7 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
         const size_t ncopy = llama_state_seq_get_data_ext(ctx.get(), seq_store.data(), seq_store.size(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
         if (ncopy != seq_store.size()) {
             LOG_ERR("\n%s: seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
-            return {};
+            return false;
         }
         LOG_TRC("%s: seq 0 copied, %zd bytes\n", __func__, ncopy);
 
@@ -252,7 +264,7 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
         const size_t nset = llama_state_seq_set_data_ext(ctx.get(), seq_store.data(), seq_store.size(), 1, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
         if (nset != seq_store.size()) {
             LOG_ERR("\n%s: seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
-            return {};
+            return false;
         }
         LOG_TRC("%s: seq 1 restored, %zd bytes\n", __func__, nset);
     }
@@ -273,12 +285,18 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
 
         if (llama_decode(ctx.get(), *batch)) {
             LOG_ERR("\n%s: failed to evaluate\n", __func__);
-            return {};
+            return false;
         }
         n_past++;
     }
 
-    return result;
+    if (result != expected_result) {
+        LOG_ERR("\n%s: error: generation differs from expected\n", __func__);
+        return false;
+    }
+
+    LOG_TRC("\n%s: success\n", __func__);
+    return true;
 }
 
 
@@ -321,47 +339,22 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    LOG("\n\n");
-
     // Phase 2: full state restore from file
-    auto result_restore = run_state_restore_generation(model, params);
-    if (result_restore.empty()) {
+    if (!run_state_restore_generation(model, params, result_baseline)) {
         return 1;
     }
 
-    LOG("\n\n");
-
     // Phase 3: per-sequence KV migration (CPU path)
-    auto result_seq_migration_cpu = run_seq_migration_cpu_generation(model, params);
-    if (result_seq_migration_cpu.empty()) {
+    if (!run_seq_migration_cpu_generation(model, params, result_baseline)) {
         return 1;
     }
 
     // Phase 4: per-sequence KV migration (on-device path)
-    auto result_seq_migration_ondevice = run_seq_migration_ondevice_generation(model, params);
-    if (result_seq_migration_ondevice.empty()) {
+    if (!run_seq_migration_ondevice_generation(model, params, result_baseline)) {
         return 1;
     }
 
-    LOG("\n");
-
-    // Assertions
-    if (result_baseline != result_restore) {
-        LOG_ERR("\n%s: error: the 2 generations are different\n", __func__);
-        return 1;
-    }
-
-    if (result_baseline != result_seq_migration_cpu) {
-        LOG_ERR("\n%s: error: the seq restore generation is different\n", __func__);
-        return 1;
-    }
-
-    if (result_baseline != result_seq_migration_ondevice) {
-        LOG_ERR("\n%s: error: the seq restore generation is different\n", __func__);
-        return 1;
-    }
-
-    LOG_TRC("\n%s: success\n", __func__);
+    LOG_TRC("\n%s: all tests passed\n", __func__);
 
     return 0;
 }

--- a/examples/save-load-state/save-load-state.cpp
+++ b/examples/save-load-state/save-load-state.cpp
@@ -1,10 +1,10 @@
 #include "arg.h"
 #include "common.h"
+#include "log.h"
 #include "llama-cpp.h"
 
 #include <clocale>
 #include <vector>
-#include <cstdio>
 
 struct llama_batch_ptr {
     llama_batch batch;
@@ -38,11 +38,11 @@ static std::string run_baseline_generation(struct llama_model * model, const str
 
     auto n_past = 0;
     if (!common_prompt_batch_decode(ctx.get(), tokens, n_past, params.n_batch, params.out_file, true)) {
-        fprintf(stderr, "%s : failed to decode prompt\n", __func__);
+        LOG_ERR("%s: failed to decode prompt\n", __func__);
         return {};
     }
 
-    printf("\nfirst run: %s", params.prompt.c_str());
+    LOG("\nfirst run: %s", params.prompt.c_str());
 
     std::string result;
     llama_batch_ptr batch(1, 0, 1);
@@ -51,14 +51,14 @@ static std::string run_baseline_generation(struct llama_model * model, const str
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
         auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
-        printf("%s", next_token_str.c_str());
+        LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
         common_batch_clear(*batch);
         common_batch_add(*batch, next_token, n_past, {0}, true);
 
         if (llama_decode(ctx.get(), *batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return {};
         }
         n_past++;
@@ -79,18 +79,18 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    printf("\nsecond run: %s", params.prompt.c_str());
+    LOG("\nsecond run: %s", params.prompt.c_str());
 
     // Load state from file
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
     if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
-        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+        LOG_ERR("\n%s: failed to load state\n", __func__);
         return {};
     }
 
-    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
+    LOG_TRC("%s: loaded state with %zu tokens\n", __func__, n_token_count_out);
 
     // Replay last token
     int n_past = (int) n_token_count_out;
@@ -107,14 +107,14 @@ static std::string run_state_restore_generation(struct llama_model * model, cons
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
         auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
-        printf("%s", next_token_str.c_str());
+        LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
         common_batch_clear(*batch);
         common_batch_add(*batch, next_token, n_past, {0}, true);
 
         if (llama_decode(ctx.get(), *batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return {};
         }
         n_past++;
@@ -137,18 +137,18 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    printf("\nsingle seq run: %s", params.prompt.c_str());
+    LOG("\nsingle seq run: %s", params.prompt.c_str());
 
     // Load state from file
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
     if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
-        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+        LOG_ERR("\n%s: failed to load state\n", __func__);
         return {};
     }
 
-    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
+    LOG_TRC("%s: loaded state with %zu tokens\n", __func__, n_token_count_out);
 
     // Replay last token
     int n_past = (int) n_token_count_out;
@@ -162,20 +162,20 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
         std::vector<uint8_t> seq_store(llama_state_seq_get_size(ctx.get(), 0));
         const size_t ncopy = llama_state_seq_get_data(ctx.get(), seq_store.data(), seq_store.size(), 0);
         if (ncopy != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
+            LOG_ERR("\n%s: seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
             return {};
         }
-        fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
+        LOG_TRC("%s: seq 0 copied, %zd bytes\n", __func__, ncopy);
 
         llama_memory_clear(llama_get_memory(ctx.get()), true);
-        fprintf(stderr, "%s : kv cache cleared\n", __func__);
+        LOG_TRC("%s: kv cache cleared\n", __func__);
 
         const size_t nset = llama_state_seq_set_data(ctx.get(), seq_store.data(), seq_store.size(), 1);
         if (nset != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
+            LOG_ERR("\n%s: seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
             return {};
         }
-        fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
+        LOG_TRC("%s: seq 1 restored, %zd bytes\n", __func__, nset);
     }
 
     // Generate tokens on seq 1
@@ -186,14 +186,14 @@ static std::string run_seq_migration_cpu_generation(struct llama_model * model, 
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
         auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
-        printf("%s", next_token_str.c_str());
+        LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
         common_batch_clear(*batch);
         common_batch_add(*batch, next_token, n_past, {1}, true);
 
         if (llama_decode(ctx.get(), *batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return {};
         }
         n_past++;
@@ -216,18 +216,18 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
 
     auto tokens = common_tokenize(ctx.get(), params.prompt, true);
 
-    printf("\nsingle seq run: %s", params.prompt.c_str());
+    LOG("\nsingle seq run: %s", params.prompt.c_str());
 
     // Load state from file
     std::vector<llama_token> unused_sts(tokens.size());
     size_t n_token_count_out = 0;
 
     if (!llama_state_load_file(ctx.get(), params.out_file.data(), unused_sts.data(), unused_sts.size(), &n_token_count_out)) {
-        fprintf(stderr, "\n%s : failed to load state\n", __func__);
+        LOG_ERR("\n%s: failed to load state\n", __func__);
         return {};
     }
 
-    fprintf(stderr, "%s : loaded state with %zu tokens\n", __func__, n_token_count_out);
+    LOG_TRC("%s: loaded state with %zu tokens\n", __func__, n_token_count_out);
 
     // Replay last token
     int n_past = (int) n_token_count_out;
@@ -241,20 +241,20 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
         std::vector<uint8_t> seq_store(llama_state_seq_get_size_ext(ctx.get(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE));
         const size_t ncopy = llama_state_seq_get_data_ext(ctx.get(), seq_store.data(), seq_store.size(), 0, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
         if (ncopy != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
+            LOG_ERR("\n%s: seq copy data length %zd does not match expected length %zd\n", __func__, ncopy, seq_store.size());
             return {};
         }
-        fprintf(stderr, "%s : seq 0 copied, %zd bytes\n", __func__, ncopy);
+        LOG_TRC("%s: seq 0 copied, %zd bytes\n", __func__, ncopy);
 
         llama_memory_clear(llama_get_memory(ctx.get()), true);
-        fprintf(stderr, "%s : kv cache cleared\n", __func__);
+        LOG_TRC("%s: kv cache cleared\n", __func__);
 
         const size_t nset = llama_state_seq_set_data_ext(ctx.get(), seq_store.data(), seq_store.size(), 1, LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
         if (nset != seq_store.size()) {
-            fprintf(stderr, "\n%s : seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
+            LOG_ERR("\n%s: seq set data length %zd does not match expected length %zd\n", __func__, nset, seq_store.size());
             return {};
         }
-        fprintf(stderr, "%s : seq 1 restored, %zd bytes\n", __func__, nset);
+        LOG_TRC("%s: seq 1 restored, %zd bytes\n", __func__, nset);
     }
 
     // Generate tokens on seq 1
@@ -265,14 +265,14 @@ static std::string run_seq_migration_ondevice_generation(struct llama_model * mo
         auto next_token     = llama_sampler_sample(smpl.get(), ctx.get(), -1);
         auto next_token_str = common_token_to_piece(ctx.get(), next_token);
 
-        printf("%s", next_token_str.c_str());
+        LOG("%s", next_token_str.c_str());
         result += next_token_str;
 
         common_batch_clear(*batch);
         common_batch_add(*batch, next_token, n_past, {1}, true);
 
         if (llama_decode(ctx.get(), *batch)) {
-            fprintf(stderr, "\n%s : failed to evaluate\n", __func__);
+            LOG_ERR("\n%s: failed to evaluate\n", __func__);
             return {};
         }
         n_past++;
@@ -297,7 +297,7 @@ int main(int argc, char ** argv) {
     }
 
     if (params.n_parallel == 1) {
-        printf("%s: n_parallel == 1, enabling unified kv cache\n", __func__);
+        LOG_TRC("%s: n_parallel == 1, enabling unified kv cache\n", __func__);
         params.kv_unified = true;
     }
 
@@ -311,7 +311,7 @@ int main(int argc, char ** argv) {
     auto * model = llama_init->model();
 
     if (model == nullptr) {
-        fprintf(stderr, "%s : failed to init\n", __func__);
+        LOG_ERR("%s: failed to init\n", __func__);
         return 1;
     }
 
@@ -321,7 +321,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    printf("\n\n");
+    LOG("\n\n");
 
     // Phase 2: full state restore from file
     auto result_restore = run_state_restore_generation(model, params);
@@ -329,7 +329,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    printf("\n\n");
+    LOG("\n\n");
 
     // Phase 3: per-sequence KV migration (CPU path)
     auto result_seq_migration_cpu = run_seq_migration_cpu_generation(model, params);
@@ -343,25 +343,25 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    printf("\n");
+    LOG("\n");
 
     // Assertions
     if (result_baseline != result_restore) {
-        fprintf(stderr, "\n%s : error : the 2 generations are different\n", __func__);
+        LOG_ERR("\n%s: error: the 2 generations are different\n", __func__);
         return 1;
     }
 
     if (result_baseline != result_seq_migration_cpu) {
-        fprintf(stderr, "\n%s : error : the seq restore generation is different\n", __func__);
+        LOG_ERR("\n%s: error: the seq restore generation is different\n", __func__);
         return 1;
     }
 
     if (result_baseline != result_seq_migration_ondevice) {
-        fprintf(stderr, "\n%s : error : the seq restore generation is different\n", __func__);
+        LOG_ERR("\n%s: error: the seq restore generation is different\n", __func__);
         return 1;
     }
 
-    fprintf(stderr, "\n%s : success\n", __func__);
+    LOG_TRC("\n%s: success\n", __func__);
 
     return 0;
 }


### PR DESCRIPTION
## Overview

- Refactor the `save-load-state` example for cleaner structure and readability.
- Add `model_only` option to `common_init_from_params` to skip context creation and context-dependent setup.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. llama.cpp + pi