### PR TITLE
llama-bench: add VRAM and RAM reporting

### DIFF
--- a/tools/llama-bench/CMakeLists.txt
+++ b/tools/llama-bench/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TARGET llama-bench)
 add_executable(${TARGET} llama-bench.cpp)
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(${TARGET} PRIVATE llama-common llama ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -25,6 +25,7 @@
 #include "fit.h"
 #include "ggml.h"
 #include "llama.h"
+#include "llama-ext.h"
 
 #ifdef _WIN32
 #    define WIN32_LEAN_AND_MEAN
@@ -355,6 +356,7 @@ struct cmd_params {
     bool                             verbose;
     bool                             progress;
     bool                             no_warmup;
+    bool                             memory;
     output_formats                   output_format;
     output_formats                   output_format_stderr;
 };
@@ -399,6 +401,7 @@ static const cmd_params cmd_params_defaults = {
     /* verbose              */ false,
     /* progress             */ false,
     /* no_warmup            */ false,
+    /* memory               */ false,
     /* output_format        */ MARKDOWN,
     /* output_format_stderr */ NONE,
 };
@@ -418,6 +421,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -v, --verbose                               verbose output\n");
     printf("  --progress                                  print test progress indicators\n");
     printf("  --no-warmup                                 skip warmup runs before benchmarking\n");
+    printf("  -mm, --memory                               report VRAM and RAM usage\n");
     printf("  -fitt, --fit-target <MiB>                   fit model to device memory with this margin per device in MiB (default: off)\n");
     printf("  -fitc, --fit-ctx <n>                        minimum ctx size for --fit-target (default: 4096)\n");
     if (llama_supports_rpc()) {
@@ -513,6 +517,7 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     params.delay                = cmd_params_defaults.delay;
     params.progress             = cmd_params_defaults.progress;
     params.no_warmup            = cmd_params_defaults.no_warmup;
+    params.memory               = cmd_params_defaults.memory;
 
     if (const char * env = getenv("HF_TOKEN")) {
         params.hf_token = env;
@@ -970,6 +975,8 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 params.progress = true;
             } else if (arg == "--no-warmup") {
                 params.no_warmup = true;
+            } else if (arg == "-mm" || arg == "--memory") {
+                params.memory = true;
             } else if (arg == "-fitt" || arg == "--fit-target") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1149,6 +1156,7 @@ struct cmd_params_instance {
     bool               no_host;
     size_t             fit_target;
     uint32_t           fit_min_ctx;
+    bool               memory;
 
     llama_model_params to_llama_mparams() const {
         llama_model_params mparams = llama_model_default_params();
@@ -1295,6 +1303,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .no_host      = */ noh,
                 /* .fit_target   = */ fpt,
                 /* .fit_min_ctx  = */ fpc,
+                /* .memory       = */ params.memory,
             };
             instances.push_back(instance);
         }
@@ -1332,6 +1341,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .no_host      = */ noh,
                 /* .fit_target   = */ fpt,
                 /* .fit_min_ctx  = */ fpc,
+                /* .memory       = */ params.memory,
             };
             instances.push_back(instance);
         }
@@ -1369,6 +1379,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .no_host      = */ noh,
                 /* .fit_target   = */ fpt,
                 /* .fit_min_ctx  = */ fpc,
+                /* .memory       = */ params.memory,
             };
             instances.push_back(instance);
         }
@@ -1387,6 +1398,8 @@ struct test {
     std::string              model_type;
     uint64_t                 model_size;
     uint64_t                 model_n_params;
+    std::string              vram;
+    std::string              ram;
     int                      n_batch;
     int                      n_ubatch;
     int                      n_threads;
@@ -1411,6 +1424,7 @@ struct test {
     bool                     no_host;
     size_t                   fit_target;
     uint32_t                 fit_min_ctx;
+    bool                     memory;
     int                      n_prompt;
     int                      n_gen;
     int                      n_depth;
@@ -1451,6 +1465,7 @@ struct test {
         no_host        = inst.no_host;
         fit_target     = inst.fit_target;
         fit_min_ctx    = inst.fit_min_ctx;
+        memory         = inst.memory;
         n_prompt       = inst.n_prompt;
         n_gen          = inst.n_gen;
         n_depth        = inst.n_depth;
@@ -1459,7 +1474,43 @@ struct test {
         std::strftime(buf, sizeof(buf), "%FT%TZ", gmtime(&t));
         test_time = buf;
 
-        (void) ctx;
+        if (memory) {
+            constexpr size_t MiB = 1024 * 1024;
+
+            llama_memory_breakdown memory_breakdown = llama_get_memory_breakdown(ctx);
+
+            std::map<ggml_backend_dev_t, size_t> dev_vram;
+            size_t host_mem = 0;
+
+            for (const auto & entry : memory_breakdown) {
+                ggml_backend_buffer_type_t buft = entry.first;
+                const llama_memory_breakdown_data & mb = entry.second;
+                if (ggml_backend_buft_is_host(buft)) {
+                    host_mem += mb.model + mb.context + mb.compute;
+                } else {
+                    ggml_backend_dev_t dev = ggml_backend_buft_get_device(buft);
+                    if (dev) {
+                        dev_vram[dev] += mb.model + mb.context + mb.compute;
+                    }
+                }
+            }
+
+            if (dev_vram.empty()) {
+                vram = "0";
+            } else {
+                std::vector<std::string> parts;
+                for (const auto & [dev, mem] : dev_vram) {
+                    parts.push_back(std::to_string(mem / MiB));
+                }
+                vram = join(parts, "/");
+            }
+
+            if (host_mem == 0) {
+                ram = "0";
+            } else {
+                ram = std::to_string(host_mem / MiB);
+            }
+        }
     }
 
     uint64_t avg_ns() const { return ::avg(samples_ns); }
@@ -1503,7 +1554,8 @@ struct test {
     static const std::vector<std::string> & get_fields() {
         static const std::vector<std::string> fields = {
             "build_commit",   "build_number",   "cpu_info",      "gpu_info",       "backends",
-            "model_filename", "model_type",     "model_size",    "model_n_params", "n_batch",
+            "model_filename", "model_type",     "model_size",    "model_n_params", "vram",
+            "ram",           "n_batch",
             "n_ubatch",       "n_threads",      "cpu_mask",      "cpu_strict",     "poll",
             "type_k",         "type_v",         "n_gpu_layers",  "n_cpu_moe",      "split_mode",
             "main_gpu",       "no_kv_offload",  "flash_attn",    "devices",        "tensor_split",
@@ -1581,6 +1633,8 @@ struct test {
                                             model_type,
                                             std::to_string(model_size),
                                             std::to_string(model_n_params),
+                                            vram,
+                                            ram,
                                             std::to_string(n_batch),
                                             std::to_string(n_ubatch),
                                             std::to_string(n_threads),
@@ -1760,6 +1814,12 @@ struct markdown_printer : public printer {
         if (field == "size" || field == "params") {
             return 10;
         }
+        if (field == "vram") {
+            return -12;
+        }
+        if (field == "ram") {
+            return -10;
+        }
         if (field == "n_gpu_layers") {
             return 3;
         }
@@ -1812,6 +1872,12 @@ struct markdown_printer : public printer {
         if (field == "n_gpu_layers") {
             return "ngl";
         }
+        if (field == "vram") {
+            return "VRAM";
+        }
+        if (field == "ram") {
+            return "RAM";
+        }
         if (field == "split_mode") {
             return "sm";
         }
@@ -1863,6 +1929,10 @@ struct markdown_printer : public printer {
         fields.emplace_back("size");
         fields.emplace_back("params");
         fields.emplace_back("backend");
+        if (params.memory) {
+            fields.emplace_back("vram");
+            fields.emplace_back("ram");
+        }
         bool is_cpu_backend = test::get_backend().find("CPU") != std::string::npos ||
                               test::get_backend().find("BLAS") != std::string::npos ||
                               test::get_backend().find("ZenDNN") != std::string::npos;
@@ -1979,6 +2049,10 @@ struct markdown_printer : public printer {
                 value = buf;
             } else if (field == "backend") {
                 value = test::get_backend();
+            } else if (field == "vram") {
+                value = t.vram.empty() || t.vram == "0" ? "0 MiB" : t.vram + " MiB";
+            } else if (field == "ram") {
+                value = t.ram.empty() || t.ram == "0" ? "0 MiB" : t.ram + " MiB";
             } else if (field == "test") {
                 if (t.n_prompt > 0 && t.n_gen == 0) {
                     snprintf(buf, sizeof(buf), "pp%d", t.n_prompt);


### PR DESCRIPTION
## Overview

Add VRAM and RAM memory reporting to `llama-bench` output. Uses `llama_get_memory_breakdown()` to break down memory by backend buffer type, reporting device VRAM (in MiB, per-device if multiple) and host RAM separately. These two additional metrics are hidden behind the cli option `-mm` / `--memory` to preserve backward compatibility.

Changes:
- `llama-bench.cpp`: adds `vram` and `ram` fields to the `test` struct, populates them via `llama_memory_breakdown`, and prints them in both CSV and markdown table output
- `CMakeLists.txt`: adds `src/` include path to access `llama-ext.h`

## Additional information

Useful for benchmarking memory usage across different model configurations and backends.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES (GLM 5.1 helped with with code and testing)


## Examples

Without `-mm` (legacy behavior):
```
user@7940hs:~/Projects/llama.cpp$ build/bin/llama-bench -hf TheBloke/Llama-2-7B-GGUF:Q4_0 -ngl 99 -fa 0,1 -p 512,1024,2048,4096,8192,16384,32768 -n 128,256,512,1024,2048
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 24126 MiB):
  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes, VRAM: 24126 MiB
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  0 |           pp512 |      5168.88 ± 90.47 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  0 |          pp1024 |      4866.68 ± 12.33 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  0 |          pp2048 |       4498.31 ± 8.00 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       |  99 |  0 |          pp4096 |       3927.92 ± 1.63 |
^C
```


With the new `-mm` parameter:
```
user@7940hs:~/Projects/llama.cpp$ build/bin/llama-bench -hf TheBloke/Llama-2-7B-GGUF:Q4_0 -ngl 99 -fa 0,1 -p 512,1024,2048,4096,8192,16384,32768 -n 128,256,512,1024,2048 -mm
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 24126 MiB):
  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes, VRAM: 24126 MiB
| model                          |       size |     params | backend    | VRAM         | RAM        | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------------ | ---------- | --: | -: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | 3931 MiB     | 103 MiB    |  99 |  0 |           pp512 |     5141.78 ± 104.10 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | 4203 MiB     | 104 MiB    |  99 |  0 |          pp1024 |      4853.83 ± 10.23 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | 4781 MiB     | 106 MiB    |  99 |  0 |          pp2048 |       4491.95 ± 3.50 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | CUDA       | 5937 MiB     | 110 MiB    |  99 |  0 |          pp4096 |       3928.64 ± 2.29 |
^C
```