### PR TITLE
server: systemd socket activation support

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -343,7 +343,17 @@ bool server_http_context::start() {
     auto & srv = pimpl->srv;
     bool was_bound = false;
     bool is_sock = false;
-    if (string_ends_with(std::string(hostname), ".sock")) {
+
+    // systemd socket activation: use pre-bound socket if available
+    const char * listen_fds = std::getenv("LISTEN_FDS");
+    const char * listen_pid = std::getenv("LISTEN_PID");
+    if (listen_fds && listen_pid && atoi(listen_pid) == getpid() && atoi(listen_fds) >= 1) {
+        srv->set_socket(3); // SD_LISTEN_FDS_START
+        was_bound = true;
+        unsetenv("LISTEN_FDS");
+        unsetenv("LISTEN_PID");
+        SRV_INF("%s", "using systemd socket activation (fd 3)\n");
+    } else if (string_ends_with(std::string(hostname), ".sock")) {
         is_sock = true;
         SRV_INF("%s", "setting address family to AF_UNIX\n");
         srv->set_address_family(AF_UNIX);

--- a/vendor/cpp-httplib/httplib.h
+++ b/vendor/cpp-httplib/httplib.h
@@ -1726,6 +1726,7 @@ public:
 
   Server &set_websocket_max_missed_pongs(int count);
 
+  bool set_socket(socket_t sock) { svr_sock_ = sock; return true; }
   bool bind_to_port(const std::string &host, int port, int socket_flags = 0);
   int bind_to_any_port(const std::string &host, int socket_flags = 0);
   bool listen_after_bind();


### PR DESCRIPTION
Adds systemd socket activation to llama-server. When `LISTEN_FDS` is set by systemd, the server uses the pre-bound socket (fd 3) instead of creating its own.

**Changes:**
- `tools/server/server-http.cpp`: check LISTEN_FDS/LISTEN_PID before bind
- `vendor/cpp-httplib/httplib.h`: add `set_socket()` method (1 line)

**Why:**
Idle RAM drops from ~1.4GB to ~112KB. Server starts on-demand when a connection arrives. Useful for home servers, VPS, or any deployment where the LLM isn't used 24/7.

**Backward compatible:** No behavior change without systemd. Falls back to normal bind.

**Tested:** Running in production as [bitnet-server](https://github.com/123Satyajeet123/bitnet-server) PPA package on Ubuntu 24.04.

Closes #23213