### PR TITLE
vulkan: fix flash attention garbage output on MoltenVK with AMD GPUs

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2950,8 +2950,13 @@ static vk_fa_tuning_params get_fa_tuning_params_scalar(const vk_device& device, 
     vk_fa_tuning_params result{};
     result.path = FA_SCALAR;
 
-    if (device->vendor_id == VK_VENDOR_ID_INTEL) {
-        // Disable subgroup use due to performance issues when enforcing subgroup sizes
+    if (device->vendor_id == VK_VENDOR_ID_INTEL
+#ifdef __APPLE__
+        || (device->vendor_id == VK_VENDOR_ID_AMD && device->driver_id == vk::DriverId::eMoltenvk)
+#endif
+    ) {
+        // Disable subgroup use — Intel has performance issues with subgroup sizes,
+        // MoltenVK/AMD has broken subgroupShuffleXor (Metal translation bug)
         result.subgroup_size = 32;
         result.disable_subgroups = true;
     } else if (device->vendor_id == VK_VENDOR_ID_AMD && device->architecture != AMD_GCN) {
@@ -5240,22 +5245,21 @@ static vk_device ggml_vk_get_device(size_t idx) {
                                  (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eBasic);
         device->subgroup_arithmetic = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
                                       (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eArithmetic);
+        device->subgroup_shuffle = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
+                                   (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eShuffle);
+        device->subgroup_clustered = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
+                                     (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eClustered);
+        device->subgroup_ballot = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
+                                  (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eBallot);
+        device->subgroup_vote = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
+                                (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eVote);
+
 #ifdef __APPLE__
         // Workaround for subgroup arithmetic failing on MoltenVK with AMD GPUs (issue 15846)
         if (device->vendor_id == VK_VENDOR_ID_AMD) {
             device->subgroup_arithmetic = false;
         }
 #endif
-        device->subgroup_shuffle = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
-                                   (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eShuffle);
-        device->subgroup_clustered = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
-                                     (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eClustered);
-
-        device->subgroup_ballot = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
-                                  (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eBallot);
-
-        device->subgroup_vote = (vk11_props.subgroupSupportedStages & vk::ShaderStageFlagBits::eCompute) &&
-                                (vk11_props.subgroupSupportedOperations & vk::SubgroupFeatureFlagBits::eVote);
 
         const bool force_disable_f16 = getenv("GGML_VK_DISABLE_F16") != nullptr;
 


### PR DESCRIPTION
Fixes #20029

## Problem

Scalar flash attention produces garbled output on macOS with AMD GPUs through MoltenVK. The issue was introduced in b8143 (PR #19625) which refactored the scalar FA shader to use `subgroupShuffleXor` for reductions instead of shared memory.

MoltenVK reports `subgroupShuffle` as supported but the Metal translation of `subgroupShuffleXor` is broken, producing incorrect shuffle results.

Reproduction: any model on Mac x86 with AMD GPU (RDNA1/RDNA2) through MoltenVK produces garbage when flash attention is enabled.

## Root Cause

Commit aa6f918c1 (b8143) replaced the shared memory XOR reduction with `subgroupShuffleXor` in the scalar flash attention shader. The `SubGroupSize > 0` branch uses subgroup shuffles for row-max, row-sum, and output accumulation reductions. On MoltenVK these produce incorrect results.

## Fix

The shader already has a fallback path for `SubGroupSize == 0` that uses shared memory XOR reductions (the pre-b8143 approach). This fix disables subgroup use for MoltenVK+AMD in `get_fa_tuning_params_scalar()`, forcing the shared memory path which produces correct results.

This is analogous to the existing Intel workaround in the same function which disables subgroups due to performance issues with subgroup sizes.

## Testing

Tested on Intel Mac with AMD Radeon Pro 5500M (RDNA1) through MoltenVK:
- Before fix: garbled output (repetitive loops like `"go go go go"`)
- After fix: correct output, ~35 tok/s with Qwen3-4B-Instruct-2507