### PR TITLE
server : skip cached prompts that match the current prompt 100%

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -2071,6 +2071,12 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
             continue;
         }
 
+        // we need a cached prompt that will result in at least 1 token being evaluated
+        // this is to be compatible with recurrent models that cannot seq_rm the last token
+        if (it->tokens.size() == tokens_new.size()) {
+            continue;
+        }
+
         if (f_keep_best < f_keep_cur && sim_best < sim_cur) {
             f_keep_best = f_keep_cur;
             sim_best    = sim_cur;


### PR DESCRIPTION
## Overview

Fix crashes in some cases where using a recurrent model and picking a cached prompt that matches 100% the new input prompt would cause the subsequent `llama_memory_seq_rm()` to fail to erase the last token from the prompt:

https://github.com/ggml-org/llama.cpp/blob/318c568b82d07db3e1f10d242dbd34c2d355cc28/tools/server/server-context.cpp#L2689-L2694

## Additional information

Can be reproduced with the developer setting in the UI for auto pre-filling after response:

<img width="855" height="182" alt="image" src="https://github.com/user-attachments/assets/d8c52658-05d3-4702-9d76-63b53bbe1126" />

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
