### PR TITLE
vulkan: fix GDN shader on MoltenVK by replacing gl_SubgroupInvocationID with gl_LocalInvocationIndex

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/gated_delta_net.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/gated_delta_net.comp
@@ -1,7 +1,9 @@
 #version 450
 
 #extension GL_EXT_control_flow_attributes : require
+#if USE_SUBGROUP_CLUSTERED || USE_SUBGROUP_ADD
 #extension GL_KHR_shader_subgroup_basic : enable
+#endif
 #if USE_SUBGROUP_CLUSTERED
 #extension GL_KHR_shader_subgroup_clustered : enable
 #endif
@@ -47,7 +49,7 @@ shared FLOAT_TYPE temp[SUBGROUP_SIZE];
 
 // This does a reduction across groups of LANES_PER_COLUMN
 FLOAT_TYPE reduce_add_shmem(FLOAT_TYPE partial) {
-    const uint lane = gl_SubgroupInvocationID;
+    const uint lane = gl_LocalInvocationIndex;
     temp[lane] = partial;
     barrier();
     [[unroll]] for (uint s = LANES_PER_COLUMN / 2u; s > 0; s >>= 1u) {
@@ -95,8 +97,8 @@ FLOAT_TYPE reduce_partial(FLOAT_TYPE partial) {
 void main() {
     const uint head_id = gl_WorkGroupID.x;
     const uint seq_id = gl_WorkGroupID.y;
-    const uint lane = gl_SubgroupInvocationID % LANES_PER_COLUMN;
-    const uint col = gl_WorkGroupID.z * COLS_PER_WG + (gl_SubgroupInvocationID / LANES_PER_COLUMN);
+    const uint lane = gl_LocalInvocationIndex % LANES_PER_COLUMN;
+    const uint col = gl_WorkGroupID.z * COLS_PER_WG + (gl_LocalInvocationIndex / LANES_PER_COLUMN);
 
     const uint iq1 = head_id % neq1;
     const uint iq3 = seq_id / rq3;


### PR DESCRIPTION
The GDN compute shader used gl_SubgroupInvocationID for lane identification,
which is part of the GL_KHR_shader_subgroup_basic extension. On MoltenVK
(Vulkan on top of Metal) with AMD GPUs, this extension produces incorrect
values due to broken Metal translation of 64-wide subgroup operations.

Fix:
- Replace gl_SubgroupInvocationID with gl_LocalInvocationIndex (Vulkan 1.0
  core built-in, always available, no extension required)
- Guard GL_KHR_shader_subgroup_basic extension behind USE_SUBGROUP_CLUSTERED
  || USE_SUBGROUP_ADD since it is only needed for subgroup collective ops

This keeps the GDN fused kernel running on GPU without any fallback to CPU.

Tested on macOS + MoltenVK + AMD Radeon Pro 5500M: ~30 tok/s with correct
reasoning output on Qwen3.5-4B-Q4_K_M.