### PR TITLE
fit : add --fit-show-mem to print probe table at INFO

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2455,6 +2455,22 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_FIT_PARAMS}).set_env("LLAMA_ARG_FIT_ESTIMATE"));
     add_opt(common_arg(
+        { "-fsm", "--fit-show-mem" }, "[on|off]",
+        string_format("print the per-device free-memory probe table at the INFO log level "
+                      "('on' or 'off', default: '%s')",
+                      params.fit_show_mem ? "on" : "off"),
+        [](common_params & params, const std::string & value) {
+            if (is_truthy(value)) {
+                params.fit_show_mem = true;
+            } else if (is_falsey(value)) {
+                params.fit_show_mem = false;
+            } else {
+                throw std::runtime_error(
+                    string_format("error: unknown value for --fit-show-mem: '%s'\n", value.c_str()));
+            }
+        }
+    ).set_env("LLAMA_ARG_FIT_SHOW_MEM"));
+    add_opt(common_arg(
         { "-fitt", "--fit-target" }, "MiB0,MiB1,MiB2,...",
         string_format("target margin per device for --fit, comma-separated list of values, "
             "single value is broadcast across all devices, default: %zu", params.fit_params_target[0]/(1024*1024)),

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1173,7 +1173,8 @@ common_init_result::common_init_result(common_params & params) :
             params.tensor_buft_overrides.data(),
             params.fit_params_target.data(),
             params.fit_params_min_ctx,
-            params.verbosity >= 4 ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
+            params.verbosity >= 4 ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR,
+            params.fit_show_mem);
     }
 
     llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);

--- a/common/common.h
+++ b/common/common.h
@@ -448,6 +448,7 @@ struct common_params {
     float   tensor_split[128]  = {0};   // how split tensors should be distributed across GPUs
     bool    fit_params         = true;  // whether to fit unset model/context parameters to free device memory
     bool    fit_params_print   = false; // print the estimated required memory to run the model
+    bool    fit_show_mem       = false; // print the per-device free-memory probe table at INFO level
     int32_t fit_params_min_ctx = 4096;  // minimum context size to set when trying to reduce memory use
 
     // margin per device in bytes for fitting parameters to free memory:

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -153,7 +153,8 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data(
 static void common_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level) {
+        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level, bool show_mem) {
+    const int probe_verbosity = show_mem ? LOG_LEVEL_INFO : LOG_LEVEL_TRACE;
     if (mparams->split_mode == LLAMA_SPLIT_MODE_TENSOR) {
         throw common_params_fit_exception("llama_params_fit is not implemented for SPLIT_MODE_TENSOR, abort");
     }
@@ -219,7 +220,8 @@ static void common_params_fit_impl(
         }
     } else {
         if (nd > 1) {
-            LOG_TRC("%s: projected memory use with initial parameters [MiB]:\n", __func__);
+            LOG_TMPL(GGML_LOG_LEVEL_INFO, probe_verbosity,
+                "%s: projected memory use with initial parameters [MiB]:\n", __func__);
         }
         for (size_t id = 0; id < nd; id++) {
             const llama_device_memory_data & dmd = dmds_full[id];
@@ -234,12 +236,14 @@ static void common_params_fit_impl(
             sum_projected_model += dmd.mb.model;
 
             if (nd > 1) {
-                LOG_TRC("%s:   - %s: %6" PRId64 " total, %6" PRId64 " used, %6" PRId64 " free vs. target of %6" PRId64 "\n",
+                LOG_TMPL(GGML_LOG_LEVEL_INFO, probe_verbosity,
+                    "%s:   - %s: %6" PRId64 " total, %6" PRId64 " used, %6" PRId64 " free vs. target of %6" PRId64 "\n",
                     __func__, dev_names[id].c_str(), dmd.total/MiB, projected_used/MiB, projected_free/MiB, margins[id]/MiB);
             }
         }
         assert(sum_free >= 0 && sum_projected_used >= 0);
-        LOG_TRC("%s: projected to use %" PRId64 " MiB of device memory vs. %" PRId64 " MiB of free device memory\n",
+        LOG_TMPL(GGML_LOG_LEVEL_INFO, probe_verbosity,
+            "%s: projected to use %" PRId64 " MiB of device memory vs. %" PRId64 " MiB of free device memory\n",
             __func__, sum_projected_used/MiB, sum_free/MiB);
         if (nd == 1) {
             if (projected_free_per_device[0] >= margins[0]) {
@@ -771,11 +775,12 @@ enum common_params_fit_status common_fit_params(
         llama_model_tensor_buft_override * tensor_buft_overrides,
         size_t * margins,
         uint32_t n_ctx_min,
-        ggml_log_level log_level) {
+        ggml_log_level log_level,
+        bool show_mem) {
     const int64_t t0_us = llama_time_us();
     common_params_fit_status status = COMMON_PARAMS_FIT_STATUS_SUCCESS;
     try {
-        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level);
+        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level, show_mem);
         LOG_TRC("%s: successfully fit params to free device memory\n", __func__);
     } catch (const common_params_fit_exception & e) {
         LOG_WRN("%s: failed to fit params to free device memory: %s\n", __func__, e.what());

--- a/common/fit.h
+++ b/common/fit.h
@@ -21,7 +21,8 @@ enum common_params_fit_status common_fit_params(
     struct llama_model_tensor_buft_override * tensor_buft_overrides, // writable buffer for overrides, needs at least llama_max_tensor_buft_overrides elements
                                      size_t * margins,               // margins of memory to leave per device in bytes
                                    uint32_t   n_ctx_min,             // minimum context size to set when trying to reduce memory use
-                        enum ggml_log_level   log_level);            // minimum log level to print during fitting, lower levels go to debug log
+                        enum ggml_log_level   log_level,              // minimum log level to print during fitting, lower levels go to debug log
+                                       bool   show_mem);              // also print the per-device free-memory probe table at INFO level
 
 // print estimated memory to stdout
 void common_fit_print(

--- a/tools/fit-params/fit-params.cpp
+++ b/tools/fit-params/fit-params.cpp
@@ -30,7 +30,7 @@ int main(int argc, char ** argv) {
     if (!params.fit_params_print) {
         const common_params_fit_status status = common_fit_params(params.model.path.c_str(), &mparams, &cparams,
                 params.tensor_split, params.tensor_buft_overrides.data(), params.fit_params_target.data(), params.fit_params_min_ctx,
-                params.verbosity >= 4 ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
+                params.verbosity >= 4 ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR, params.fit_show_mem);
         if (status != COMMON_PARAMS_FIT_STATUS_SUCCESS) {
             LOG_ERR("%s: failed to fit CLI arguments to free memory, exiting...\n", __func__);
             exit(1);

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2242,7 +2242,8 @@ int main(int argc, char ** argv) {
                 fit_overrides.data(),
                 margins.data(),
                 inst.fit_min_ctx,
-                params.verbose ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
+                params.verbose ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR,
+                false);
        }
 
         // keep the same model between tests when possible


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Adds a flag -fsm / --fit-show-mem [on|off] that surfaces the per-device free-memory table from common_params_fit_impl at the INFO log level.

This is the table that used to show up by default before #23021 demoted it to TRACE. I found it really handy when manually adjusting params like tensor splits and context. Being able to see quickly how much VRAM was free per device made iterating on tensor splits to balance vram quicker without going through a full model load each time.

Adding this flag lets this table show and be easily visible without disappearing into the sea of other output when using higher verbose log output.

Personally, I think it should be on by default. I didn't even know it existed until it was showing up in my
terminal output, and others may now miss out on it the same way now that it's hidden behind TRACE. But
since #23021 deliberately moved it, this PR adds it as opt-in rather than overriding that decision.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- YES
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
- YES - I used Claude Opus 4.7 to help implement this and make sure what I was doing was correct and I didn't miss anything.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
