### PR TITLE
rpc : track last graph uid per (endpoint, device), not per backend context

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -211,8 +211,17 @@ struct ggml_backend_rpc_context {
     std::string endpoint;
     uint32_t    device;
     std::string name;
-    uint64_t    last_graph_uid;
 };
+
+// Tracks the uid of the last graph sent to a given (endpoint, device) pair.
+// The server keeps one stored_graphs slot per (TCP connection, device), and
+// get_socket coalesces all backends pointing at the same endpoint onto a
+// single connection. Tracking per backend context goes stale when two
+// backends, e.g. main and draft models in speculative decoding, alternate
+// graphs over the same connection and one overwrites the other on the server.
+static std::mutex                                                g_server_graph_state_mutex;
+static std::unordered_map<std::string,
+                          std::unordered_map<uint32_t, uint64_t>> g_server_graph_uid;
 
 struct ggml_backend_rpc_buffer_context {
     std::shared_ptr<socket_t> sock;
@@ -693,7 +702,15 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
     ggml_backend_rpc_context * rpc_ctx = (ggml_backend_rpc_context *)backend->context;
 
     GGML_ASSERT(cgraph->n_nodes > 0);
-    bool reuse = cgraph->uid != 0 && rpc_ctx->last_graph_uid == cgraph->uid;
+    bool reuse = false;
+    {
+        std::lock_guard<std::mutex> lock(g_server_graph_state_mutex);
+        uint64_t & server_uid = g_server_graph_uid[rpc_ctx->endpoint][rpc_ctx->device];
+        reuse = cgraph->uid != 0 && server_uid == cgraph->uid;
+        if (!reuse) {
+            server_uid = cgraph->uid;
+        }
+    }
     if (reuse) {
         rpc_msg_graph_recompute_req request;
         request.device = rpc_ctx->device;
@@ -701,7 +718,6 @@ static enum ggml_status ggml_backend_rpc_graph_compute(ggml_backend_t backend, g
         bool status = send_rpc_cmd(sock, RPC_CMD_GRAPH_RECOMPUTE, &request, sizeof(request));
         RPC_STATUS_ASSERT(status);
     } else {
-        rpc_ctx->last_graph_uid = cgraph->uid;
         std::vector<uint8_t> input;
         serialize_graph(rpc_ctx->device, cgraph, input);
         auto sock = get_socket(rpc_ctx->endpoint);
@@ -767,10 +783,9 @@ ggml_backend_buffer_type_t ggml_backend_rpc_buffer_type(const char * endpoint, u
 ggml_backend_t ggml_backend_rpc_init(const char * endpoint, uint32_t device) {
     std::string dev_name = "RPC" + std::to_string(device) + "[" + std::string(endpoint) + "]";
     ggml_backend_rpc_context * ctx = new ggml_backend_rpc_context {
-        /* .endpoint       = */ endpoint,
-        /* .device         = */ device,
-        /* .name           = */ dev_name,
-        /* .last_graph_uid = */ 0,
+        /* .endpoint = */ endpoint,
+        /* .device   = */ device,
+        /* .name     = */ dev_name,
     };
     auto reg = ggml_backend_rpc_add_server(endpoint);
     ggml_backend_t backend = new ggml_backend {


### PR DESCRIPTION
The GRAPH_RECOMPUTE fast path was caching the last graph uid on each rpc backend context, but the RPC server only keeps one stored graph per (connection, device) and get_socket coalesces all backends pointing at the same endpoint onto a single connection. When a main model and a draft model in speculative decoding alternate graphs over that shared connection, the second graph overwrites the first on the server, then the next compute by the first backend still matches its stale per-context uid and asks for a recompute, which now points at the other backend's graph and crashes with an illegal memory access on CUDA. The fix moves the tracking to a process-wide (endpoint, device) keyed map so every backend sharing a connection agrees on what is currently stored server side, and keeps the existing wire protocol unchanged. Fixes #23242. 