### PR TITLE
common : support schema-constrained decoding for Gemma 4 tool calls

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1233,8 +1233,8 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
         if (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE) {
             // Gemma4 tool calling syntax
             // Rules should match traversal logic in gemma4_to_json()
-            p.rule("gemma4-string-content", p.until("<|\"|>"));
-            p.rule("gemma4-string", p.literal("<|\"|>") + p.ref("gemma4-string-content") + p.literal("<|\"|>"));
+            p.trigger_rule("gemma4-string-content", p.until("<|\"|>"));
+            p.trigger_rule("gemma4-string", p.literal("<|\"|>") + p.ref("gemma4-string-content") + p.literal("<|\"|>"));
             p.rule("gemma4-bool", p.json_bool());
             p.rule("gemma4-null", p.json_null());
             p.rule("gemma4-number", p.json_number());
@@ -1270,12 +1270,11 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
             foreach_function(inputs.tools, [&](const json & tool) {
                 const auto & function = tool.at("function");
                 std::string  name     = function.at("name");
-                // TODO @aldehir : need to extend json-schema-to-grammar to produce more than JSON rules
-                // const auto & params   = function.at("parameters");
+                const auto & params   = function.at("parameters");
 
                 tool_choice |= p.rule("tool-" + name, p.tool(p.sequence({
                     p.tool_open(p.tool_name(p.literal(name)) + p.peek(p.literal("{"))),
-                    p.tool_args(p.ref("gemma4-dict")),
+                    p.tool_args(p.schema(p.ref("gemma4-dict"), "tool-" + name + "-schema", params)),
                 })));
             });
 
@@ -1303,6 +1302,8 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
 
     if (include_grammar) {
         data.grammar_lazy = !(has_response_format || (has_tools && inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED));
+        common_grammar_options options;
+        options.dialect = COMMON_SCHEMA_DIALECT_GEMMA4;
         data.grammar      = build_grammar([&](const common_grammar_builder & builder) {
             foreach_function(inputs.tools, [&](const json & tool) {
                 const auto & function = tool.at("function");
@@ -1314,7 +1315,7 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
                 builder.resolve_refs(schema);
             }
             parser.build_grammar(builder, data.grammar_lazy);
-        });
+        }, options);
 
         data.grammar_triggers = {
             { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<|tool_call>" },

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1233,8 +1233,8 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
         if (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE) {
             // Gemma4 tool calling syntax
             // Rules should match traversal logic in gemma4_to_json()
-            p.trigger_rule("gemma4-string-content", p.until("<|\"|>"));
-            p.trigger_rule("gemma4-string", p.literal("<|\"|>") + p.ref("gemma4-string-content") + p.literal("<|\"|>"));
+            p.rule("gemma4-string-content", p.until("<|\"|>"));
+            p.rule("gemma4-string", p.literal("<|\"|>") + p.ref("gemma4-string-content") + p.literal("<|\"|>"));
             p.rule("gemma4-bool", p.json_bool());
             p.rule("gemma4-null", p.json_null());
             p.rule("gemma4-number", p.json_number());

--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -315,6 +315,7 @@ private:
     friend std::string build_grammar(const std::function<void(const common_grammar_builder &)> & cb, const common_grammar_options & options);
     std::function<json(const std::string &)> _fetch_json;
     bool _dotall;
+    common_schema_dialect _dialect;
     std::map<std::string, std::string> _rules;
     std::unordered_map<std::string, json> _refs;
     std::unordered_set<std::string> _refs_being_resolved;
@@ -654,7 +655,9 @@ private:
             std::string prop_rule_name = visit(prop_schema, name + (name.empty() ? "" : "-") + prop_name);
             prop_kv_rule_names[prop_name] = _add_rule(
                 name + (name.empty() ? "" : "-") + prop_name + "-kv",
-                format_literal(json(prop_name).dump()) + " space \":\" space " + prop_rule_name
+                (_dialect == COMMON_SCHEMA_DIALECT_GEMMA4
+                     ? format_literal(prop_name)
+                     : format_literal(json(prop_name).dump())) + " space \":\" space " + prop_rule_name
             );
             if (required.find(prop_name) != required.end()) {
                 required_props.push_back(prop_name);
@@ -752,8 +755,9 @@ private:
 public:
     common_schema_converter(
         const std::function<json(const std::string &)> & fetch_json,
-        bool dotall)
-          : _fetch_json(fetch_json), _dotall(dotall)
+        bool dotall,
+        common_schema_dialect dialect = COMMON_SCHEMA_DIALECT_JSON)
+          : _fetch_json(fetch_json), _dotall(dotall), _dialect(dialect)
     {
         _rules["space"] = SPACE_RULE;
     }
@@ -1001,6 +1005,9 @@ public:
             // Per JSON Schema semantics this is equivalent to {} and accepts any value.
             return _add_rule(rule_name, _add_primitive("value", PRIMITIVE_RULES.at("value")));
         }
+        if (_dialect == COMMON_SCHEMA_DIALECT_GEMMA4 && schema_type == "string") {
+            return _add_rule(rule_name == "root" ? "root" : rule_name, "gemma4-string");
+        }
         if (!schema_type.is_string() || PRIMITIVE_RULES.find(schema_type.get<std::string>()) == PRIMITIVE_RULES.end()) {
             _errors.push_back("Unrecognized schema: " + schema.dump());
             return "";
@@ -1155,7 +1162,7 @@ bool common_schema_info::resolves_to_string(const nlohmann::ordered_json & schem
     return check(schema);
 }
 
-std::string json_schema_to_grammar(const json & schema, bool force_gbnf) {
+std::string json_schema_to_grammar(const json & schema, bool force_gbnf, common_schema_dialect dialect) {
 #ifdef LLAMA_USE_LLGUIDANCE
     if (!force_gbnf) {
         return "%llguidance {}\nstart: %json " + schema.dump();
@@ -1163,15 +1170,17 @@ std::string json_schema_to_grammar(const json & schema, bool force_gbnf) {
 #else
     (void)force_gbnf;
 #endif // LLAMA_USE_LLGUIDANCE
+    common_grammar_options options;
+    options.dialect = dialect;
     return build_grammar([&](const common_grammar_builder & callbacks) {
         auto copy = schema;
         callbacks.resolve_refs(copy);
         callbacks.add_schema("", copy);
-    });
+    }, options);
 }
 
 std::string build_grammar(const std::function<void(const common_grammar_builder &)> & cb, const common_grammar_options & options) {
-    common_schema_converter converter([&](const std::string &) { return json(); }, options.dotall);
+    common_schema_converter converter([&](const std::string &) { return json(); }, options.dotall, options.dialect);
     common_grammar_builder builder {
         /* .add_rule = */ [&](const std::string & name, const std::string & rule) {
             return converter._add_rule(name, rule);

--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -669,8 +669,8 @@ private:
             prop_kv_rule_names[prop_name] = _add_rule(
                 name + (name.empty() ? "" : "-") + prop_name + "-kv",
                 (_dialect == COMMON_SCHEMA_DIALECT_GEMMA4
-                     ? format_literal(prop_name)
-                     : format_literal(json(prop_name).dump())) + " space \":\" space " + prop_rule_name
+                     ? format_literal(prop_name) + " \":\" space "
+                     : format_literal(json(prop_name).dump()) + " space \":\" space ") + prop_rule_name
             );
             if (required.find(prop_name) != required.end()) {
                 required_props.push_back(prop_name);
@@ -852,7 +852,12 @@ public:
         visit_refs(schema);
     }
 
-    static std::string _generate_constant_rule(const json & value) {
+    static std::string _generate_constant_rule(const json & value, common_schema_dialect dialect = COMMON_SCHEMA_DIALECT_JSON) {
+        // Gemma 4 emits string values with the <|"|> special-token delimiter instead of JSON quotes,
+        // so enum/const values that are strings need to match the gemma4-string framing.
+        if (dialect == COMMON_SCHEMA_DIALECT_GEMMA4 && value.is_string()) {
+            return "<|\"|> " + format_literal(value.get<std::string>()) + " <|\"|>";
+        }
         return format_literal(value.dump());
     }
 
@@ -878,12 +883,12 @@ public:
             return _add_rule(rule_name, _generate_union_rule(name, schema_types));
         }
         if (schema.contains("const")) {
-            return _add_rule(rule_name, _generate_constant_rule(schema["const"]) + " space");
+            return _add_rule(rule_name, _generate_constant_rule(schema["const"], _dialect) + " space");
         }
         if (schema.contains("enum")) {
             std::vector<std::string> enum_values;
             for (const auto & v : schema["enum"]) {
-                enum_values.push_back(_generate_constant_rule(v));
+                enum_values.push_back(_generate_constant_rule(v, _dialect));
             }
             return _add_rule(rule_name, "(" + string_join(enum_values, " | ") + ") space");
         }
@@ -926,7 +931,7 @@ public:
                     }
                 } else if (comp_schema.contains("enum")) {
                     for (const auto & v : comp_schema["enum"]) {
-                        const auto rule = _generate_constant_rule(v);
+                        const auto rule = _generate_constant_rule(v, _dialect);
                         if (enum_values.find(rule) == enum_values.end()) {
                             enum_values[rule] = 0;
                         }

--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -247,6 +247,16 @@ static std::unordered_map<std::string, BuiltinRule> PRIMITIVE_RULES = {
     {"null", {"\"null\" space", {}}},
 };
 
+// Gemma 4 uses the special token <|"|> as its string delimiter, matched via the GBNF token construct.
+static std::unordered_map<std::string, BuiltinRule> GEMMA4_PRIMITIVE_RULES = {
+    {"gemma4-char",   {"[^\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]", {}}},
+    {"gemma4-string", {"<|\"|> gemma4-char* <|\"|> space", {"gemma4-char"}}},
+    {"gemma4-key",    {"[^:}]+", {}}},
+    {"gemma4-value",  {"gemma4-object | gemma4-array | gemma4-string | number | boolean | null", {"gemma4-object", "gemma4-array", "gemma4-string", "number", "boolean", "null"}}},
+    {"gemma4-object", {"\"{\" space ( gemma4-key \":\" space gemma4-value (\",\" space gemma4-key \":\" space gemma4-value)* )? \"}\" space", {"gemma4-key", "gemma4-value"}}},
+    {"gemma4-array",  {"\"[\" space ( gemma4-value (\",\" space gemma4-value)* )? \"]\" space", {"gemma4-value"}}},
+};
+
 static std::unordered_map<std::string, BuiltinRule> STRING_FORMAT_RULES = {
     {"date", {"[0-9]{4} \"-\" ( \"0\" [1-9] | \"1\" [0-2] ) \"-\" ( \"0\" [1-9] | [1-2] [0-9] | \"3\" [0-1] )", {}}},
     {"time", {"([01] [0-9] | \"2\" [0-3]) \":\" [0-5] [0-9] \":\" [0-5] [0-9] ( \".\" [0-9]{3} )? ( \"Z\" | ( \"+\" | \"-\" ) ( [01] [0-9] | \"2\" [0-3] ) \":\" [0-5] [0-9] )", {}}},
@@ -264,6 +274,9 @@ static bool is_reserved_name(const std::string & name) {
             s.insert(p.first);
         }
         for (const auto & p : STRING_FORMAT_RULES) {
+            s.insert(p.first);
+        }
+        for (const auto & p : GEMMA4_PRIMITIVE_RULES) {
             s.insert(p.first);
         }
         return s;
@@ -741,8 +754,11 @@ private:
             if (it == PRIMITIVE_RULES.end()) {
                 it = STRING_FORMAT_RULES.find(dep);
                 if (it == STRING_FORMAT_RULES.end()) {
-                    _errors.push_back("Rule " + dep + " not known");
-                    continue;
+                    it = GEMMA4_PRIMITIVE_RULES.find(dep);
+                    if (it == GEMMA4_PRIMITIVE_RULES.end()) {
+                        _errors.push_back("Rule " + dep + " not known");
+                        continue;
+                    }
                 }
             }
             if (_rules.find(dep) == _rules.end()) {
@@ -997,6 +1013,21 @@ public:
             out << ") space";
             return _add_rule(rule_name, out.str());
         }
+        if (_dialect == COMMON_SCHEMA_DIALECT_GEMMA4) {
+            // Route the object / array / value fallbacks through Gemma 4 primitives so nested strings use <|"|>
+            if (schema.empty() || schema_type == "object") {
+                return _add_primitive(rule_name == "root" ? "root" : "gemma4-object", GEMMA4_PRIMITIVE_RULES.at("gemma4-object"));
+            }
+            if (schema_type.is_null() && schema.is_object()) {
+                return _add_primitive(rule_name == "root" ? "root" : "gemma4-value", GEMMA4_PRIMITIVE_RULES.at("gemma4-value"));
+            }
+            if (schema_type == "string") {
+                return _add_primitive(rule_name == "root" ? "root" : "gemma4-string", GEMMA4_PRIMITIVE_RULES.at("gemma4-string"));
+            }
+            if (schema_type == "array") {
+                return _add_primitive(rule_name == "root" ? "root" : "gemma4-array", GEMMA4_PRIMITIVE_RULES.at("gemma4-array"));
+            }
+        }
         if (schema.empty() || schema_type == "object") {
             return _add_rule(rule_name, _add_primitive("object", PRIMITIVE_RULES.at("object")));
         }
@@ -1004,9 +1035,6 @@ public:
             // No type constraint and no recognized structural keywords (e.g. {"description": "..."}).
             // Per JSON Schema semantics this is equivalent to {} and accepts any value.
             return _add_rule(rule_name, _add_primitive("value", PRIMITIVE_RULES.at("value")));
-        }
-        if (_dialect == COMMON_SCHEMA_DIALECT_GEMMA4 && schema_type == "string") {
-            return _add_rule(rule_name == "root" ? "root" : rule_name, "gemma4-string");
         }
         if (!schema_type.is_string() || PRIMITIVE_RULES.find(schema_type.get<std::string>()) == PRIMITIVE_RULES.end()) {
             _errors.push_back("Unrecognized schema: " + schema.dump());

--- a/common/json-schema-to-grammar.h
+++ b/common/json-schema-to-grammar.h
@@ -6,8 +6,14 @@
 #include <memory>
 #include <string>
 
+enum common_schema_dialect {
+    COMMON_SCHEMA_DIALECT_JSON,
+    COMMON_SCHEMA_DIALECT_GEMMA4
+};
+
 std::string json_schema_to_grammar(const nlohmann::ordered_json & schema,
-                                   bool force_gbnf = false);
+                                   bool force_gbnf = false,
+                                   common_schema_dialect dialect = COMMON_SCHEMA_DIALECT_JSON);
 
 class common_schema_converter;
 
@@ -36,6 +42,7 @@ struct common_grammar_builder {
 
 struct common_grammar_options {
     bool dotall = false;
+    common_schema_dialect dialect = COMMON_SCHEMA_DIALECT_JSON;
 };
 
 std::string gbnf_format_literal(const std::string & literal);

--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -1536,6 +1536,33 @@ static std::string gbnf_excluding_pattern(const std::vector<std::string> & strin
     return "(" + pattern + ")*";
 }
 
+// A schema parser delegates to its child (rather than emitting JSON-schema-derived GBNF)
+// when there's no schema attached, or when the schema is one of the raw-tagged primitives
+// the PEG parser handles directly (strings, enums, nullable-strings). Reachability and
+// GBNF emission both stop at non-delegating schema boundaries.
+static bool peg_schema_delegates(const common_peg_schema_parser & s) {
+    if (!s.schema) {
+        return true;
+    }
+    if (s.raw && s.schema->contains("type")) {
+        const auto & type_val = s.schema->at("type");
+        if (type_val.is_string() && type_val == "string") {
+            return true;
+        }
+        if (type_val.is_array()) {
+            for (const auto & t : type_val) {
+                if (t.is_string() && t.get<std::string>() != "null") {
+                    return t.get<std::string>() == "string";
+                }
+            }
+        }
+    }
+    if (s.raw && !s.schema->contains("type") && s.schema->contains("enum")) {
+        return true;
+    }
+    return false;
+}
+
 static std::unordered_set<std::string> collect_reachable_rules(
     const common_peg_arena & arena,
     const common_peg_parser_id & rule
@@ -1572,9 +1599,14 @@ static std::unordered_set<std::string> collect_reachable_rules(
                                  std::is_same_v<T, common_peg_not_parser> ||
                                  std::is_same_v<T, common_peg_tag_parser> ||
                                  std::is_same_v<T, common_peg_atomic_parser> ||
-                                 std::is_same_v<T, common_peg_gbnf_parser> ||
-                                 std::is_same_v<T, common_peg_schema_parser>) {
+                                 std::is_same_v<T, common_peg_gbnf_parser>) {
                 visit(p.child);
+            } else if constexpr (std::is_same_v<T, common_peg_schema_parser>) {
+                // Mirror to_gbnf: when the schema is going to be emitted as JSON-schema-derived
+                // GBNF, the child ref is replaced and its rules are not reachable
+                if (peg_schema_delegates(p)) {
+                    visit(p.child);
+                }
             } else if constexpr (std::is_same_v<T, common_peg_rule_parser>) {
                 if (visited.find(p.name) == visited.end()) {
                     visited.insert(p.name);
@@ -1597,31 +1629,7 @@ static std::unordered_set<std::string> collect_reachable_rules(
 
 // GBNF generation implementation
 void common_peg_arena::build_grammar(const common_grammar_builder & builder, bool lazy) const {
-    auto schema_delegates = [](const common_peg_schema_parser & s) -> bool {
-        if (!s.schema) {
-            return true;
-        }
-        if (s.raw && s.schema->contains("type")) {
-            const auto & type_val = s.schema->at("type");
-            if (type_val.is_string() && type_val == "string") {
-                return true;
-            }
-            // Handle nullable types like ["string", "null"] - delegate when the
-            // non-null type is string, since the tagged format uses raw text
-            if (type_val.is_array()) {
-                for (const auto & t : type_val) {
-                    if (t.is_string() && t.get<std::string>() != "null") {
-                        return t.get<std::string>() == "string";
-                    }
-                }
-            }
-        }
-        // Delegate for enum schemas in raw mode - enum values are literal strings
-        if (s.raw && !s.schema->contains("type") && s.schema->contains("enum")) {
-            return true;
-        }
-        return false;
-    };
+    auto schema_delegates = &peg_schema_delegates;
 
     // Unwrap the parser so we can properly check if it's a sequence or choice
     auto effective_parser = [&](common_peg_parser_id id) -> const common_peg_parser_variant & {
@@ -1792,16 +1800,6 @@ void common_peg_arena::build_grammar(const common_grammar_builder & builder, boo
     } else {
         // Collect rules reachable from root
         reachable_rules = collect_reachable_rules(*this, root_);
-        for (const auto & [name, id] : rules_) {
-            const auto & parser = parsers_.at(id);
-            if (auto rule = std::get_if<common_peg_rule_parser>(&parser)) {
-                if (rule->trigger) {
-                    reachable_rules.insert(name);
-                    auto add_rules = collect_reachable_rules(*this, id);
-                    reachable_rules.insert(add_rules.begin(), add_rules.end());
-                }
-            }
-        }
     }
 
     // Create GBNF rules for all reachable rules

--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -1792,6 +1792,16 @@ void common_peg_arena::build_grammar(const common_grammar_builder & builder, boo
     } else {
         // Collect rules reachable from root
         reachable_rules = collect_reachable_rules(*this, root_);
+        for (const auto & [name, id] : rules_) {
+            const auto & parser = parsers_.at(id);
+            if (auto rule = std::get_if<common_peg_rule_parser>(&parser)) {
+                if (rule->trigger) {
+                    reachable_rules.insert(name);
+                    auto add_rules = collect_reachable_rules(*this, id);
+                    reachable_rules.insert(add_rules.begin(), add_rules.end());
+                }
+            }
+        }
     }
 
     // Create GBNF rules for all reachable rules

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -12,6 +12,7 @@
 #include "chat.h"
 #include "common.h"
 #include "ggml.h"
+#include "llama.h"
 #include "log.h"
 
 #include <algorithm>
@@ -140,9 +141,60 @@ static common_chat_templates_ptr read_templates(const std::string & path) {
     return common_chat_templates_ptr(common_chat_templates_init(/* model= */ nullptr, read_file(path)));
 }
 
-static std::unique_ptr<llama_grammar> build_grammar(const std::string & grammar_str) {
+// Lazy-loaded vocab fixtures: any template whose grammar uses GBNF token constructs
+// (e.g. Gemma 4's <|"|> string delimiter) needs a real vocab to parse the grammar and
+// to tokenize test inputs. Fixtures live in models/ggml-vocab-*.gguf.
+static std::string vocab_path_for_template(const std::string & template_path) {
+    struct mapping { const char * marker; const char * vocab; };
+    static const mapping mappings[] = {
+        { "gemma-4", "models/ggml-vocab-gemma-4.gguf" },
+    };
+    for (const auto & m : mappings) {
+        if (template_path.find(m.marker) != std::string::npos) {
+            return m.vocab;
+        }
+    }
+    return "";
+}
+
+static const llama_vocab * load_vocab(const std::string & vocab_path) {
+    if (vocab_path.empty()) {
+        return nullptr;
+    }
+    static std::map<std::string, llama_model *> cache;
+    static bool backend_initialized = false;
+    static const bool register_atexit = [] {
+        std::atexit([] {
+            for (auto & kv : cache) {
+                llama_model_free(kv.second);
+            }
+            cache.clear();
+        });
+        return true;
+    }();
+    (void) register_atexit;
+
+    auto it = cache.find(vocab_path);
+    if (it != cache.end()) {
+        return llama_model_get_vocab(it->second);
+    }
+    if (!backend_initialized) {
+        llama_backend_init();
+        backend_initialized = true;
+    }
+    auto mparams = llama_model_default_params();
+    mparams.vocab_only = true;
+    llama_model * model = llama_model_load_from_file(vocab_path.c_str(), mparams);
+    if (!model) {
+        return nullptr;
+    }
+    cache[vocab_path] = model;
+    return llama_model_get_vocab(model);
+}
+
+static std::unique_ptr<llama_grammar> build_grammar(const llama_vocab * vocab, const std::string & grammar_str) {
     return std::unique_ptr<llama_grammar>(
-        llama_grammar_init_impl(nullptr, grammar_str.c_str(), "root", false, nullptr, 0, nullptr, 0));
+        llama_grammar_init_impl(vocab, grammar_str.c_str(), "root", false, nullptr, 0, nullptr, 0));
 }
 
 // Helper to format a code point as a readable string
@@ -280,8 +332,66 @@ struct grammar_match_result {
     bool        incomplete = false;          // True if matched all input but grammar expects more
 };
 
+// Token-aware variant: tokenize input (with parse_special) and feed each token through the
+// grammar. Needed for grammars that contain GBNF token constructs like <|"|> — they match
+// by token id, not by byte sequence.
+static grammar_match_result match_tokens_detailed(const std::string & input, llama_grammar * grammar, const llama_vocab * vocab) {
+    grammar_match_result result;
+    result.total_bytes      = input.size();
+    result.total_codepoints = unicode_cpts_from_utf8(input).size();
+
+    auto &       stacks_cur = llama_grammar_get_stacks(grammar);
+    const auto & rules      = llama_grammar_get_rules(grammar);
+
+    std::vector<llama_token> tokens(input.size() + 1);
+    int32_t n = llama_tokenize(vocab, input.c_str(), (int32_t) input.size(), tokens.data(), (int32_t) tokens.size(), /* add_special = */ false, /* parse_special = */ true);
+    if (n < 0) {
+        tokens.resize(-n);
+        n = llama_tokenize(vocab, input.c_str(), (int32_t) input.size(), tokens.data(), (int32_t) tokens.size(), false, true);
+    }
+    tokens.resize(n);
+
+    size_t byte_pos = 0;
+    for (llama_token tok : tokens) {
+        char piece_buf[256];
+        int32_t piece_len = llama_token_to_piece(vocab, tok, piece_buf, (int32_t) sizeof(piece_buf), 0, /* special = */ true);
+        std::string piece = piece_len > 0 ? std::string(piece_buf, piece_len) : std::string();
+
+        std::string expected_before = get_expected_description(rules, stacks_cur);
+        bool failed = false;
+        try {
+            llama_grammar_accept_token(*grammar, tok, piece);
+        } catch (const std::runtime_error &) {
+            failed = true;
+        }
+        if (failed || stacks_cur.empty()) {
+            result.matched_bytes        = byte_pos;
+            result.matched_codepoints   = unicode_cpts_from_utf8(input.substr(0, byte_pos)).size();
+            result.matched_prefix       = input.substr(0, byte_pos);
+            result.failing_char         = "<token " + std::to_string(tok) + " `" + piece + "`>";
+            result.expected_description = expected_before;
+            return result;
+        }
+        byte_pos += piece.size();
+    }
+
+    result.matched_bytes      = input.size();
+    result.matched_codepoints = result.total_codepoints;
+    result.matched_prefix     = input;
+    if (std::any_of(stacks_cur.begin(), stacks_cur.end(), [](const auto & stack) { return stack.empty(); })) {
+        result.success = true;
+    } else {
+        result.incomplete           = true;
+        result.expected_description = get_expected_description(rules, stacks_cur);
+    }
+    return result;
+}
+
 // Detailed version of match_string that returns failure information
-static grammar_match_result match_string_detailed(const std::string & input, llama_grammar * grammar) {
+static grammar_match_result match_string_detailed(const std::string & input, llama_grammar * grammar, const llama_vocab * vocab = nullptr) {
+    if (vocab) {
+        return match_tokens_detailed(input, grammar, vocab);
+    }
     grammar_match_result result;
     result.total_bytes = input.size();
 
@@ -1003,6 +1113,7 @@ static std::string g_template_filter;
 static bool g_force_reconstruction_test = false;
 
 static void test_peg_parser(common_chat_templates *                      tmpls,
+                            const llama_vocab *                          vocab,
                             const std::function<void(peg_test_case &)> & init,
                             bool                                         detailed_debug) {
     // UTF-8-safe truncation helper (same as in test_parser_with_streaming)
@@ -1106,7 +1217,7 @@ static void test_peg_parser(common_chat_templates *                      tmpls,
 
     // Test grammar if present in params
     if (!parser.params_.grammar.empty()) {
-        auto grammar = build_grammar(parser.params_.grammar);
+        auto grammar = build_grammar(vocab, parser.params_.grammar);
         if (!grammar) {
             throw std::runtime_error("Failed to build grammar: " + parser.params_.grammar);
         }
@@ -1265,7 +1376,7 @@ static void test_peg_parser(common_chat_templates *                      tmpls,
 
         // Test the constrained portion against the grammar
         if (grammar_triggered && !tc.is_partial) {
-            auto result = match_string_detailed(constrained, grammar.get());
+            auto result = match_string_detailed(constrained, grammar.get(), vocab);
             if (!result.success) {
                 std::string error_msg;
                 if (result.incomplete) {
@@ -1352,6 +1463,7 @@ class peg_test_builder;
 class peg_tester {
     common_chat_templates_ptr tmpls_;
     std::string               template_path_;
+    const llama_vocab *       vocab_ = nullptr;
     bool                      detailed_debug_;
     friend class peg_test_builder;
 
@@ -1359,6 +1471,7 @@ class peg_tester {
     explicit peg_tester(const std::string & template_path, const bool detailed_debug = false) :
         tmpls_(read_templates(template_path)),
         template_path_(template_path),
+        vocab_(load_vocab(vocab_path_for_template(template_path))),
         detailed_debug_(detailed_debug) {}
 
     const std::string & template_path() const { return template_path_; }
@@ -1469,7 +1582,7 @@ class peg_test_builder {
             }
         }
         LOG_INF("\n\x1b[38;5;126m[%s]\x1b[0m\n%s\n\n", tester_.template_path().c_str(), tc_.input.c_str());
-        test_peg_parser(tester_.tmpls_.get(), [this](peg_test_case & t) { t = tc_; }, tester_.detailed_debug_);
+        test_peg_parser(tester_.tmpls_.get(), tester_.vocab_, [this](peg_test_case & t) { t = tc_; }, tester_.detailed_debug_);
     }
 };
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -2702,6 +2702,29 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect(message_with_tool_calls("special_function", R"({"arg1": 42})"))
             .run();
 
+        // Tool call with enum on a string property — both grammar generation and parse-back
+        // must use the <|"|> delimiter, not JSON quotes.
+        {
+            common_chat_tool kanban_create_tool{
+                /* .name = */ "kanban_create",
+                /* .description = */ "Create a kanban ticket",
+                /* .parameters = */ R"({
+                    "type": "object",
+                    "properties": {
+                        "assignee": { "type": "string", "enum": ["ventes", "compta", "support", "rh"] },
+                        "body":     { "type": "string" }
+                    },
+                    "required": ["assignee", "body"]
+                })",
+            };
+            tst.test(
+                    "<|tool_call>call:kanban_create{assignee:<|\"|>compta<|\"|>,body:<|\"|>Hello<|\"|>}<tool_call|>")
+                .tools({ kanban_create_tool })
+                .expect(message_with_tool_calls("kanban_create",
+                        R"({"assignee": "compta", "body": "Hello"})"))
+                .run();
+        }
+
         // Tool call with negative number argument
         tst.test(
                 "<|tool_call>call:special_function{arg1:-7}<tool_call|>")

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -1547,14 +1547,14 @@ static void test_gemma4_dialect() {
             "required": ["absolutePath"]
         })""",
         R"""(
-            absolutePath-kv ::= "absolutePath" space ":" space gemma4-string
+            absolutePath-kv ::= "absolutePath" ":" space gemma4-string
             gemma4-char ::= [^\x00-\x08\x0B\x0C\x0E-\x1F\x7F]
             gemma4-string ::= <|"|> gemma4-char* <|"|> space
             integer ::= ("-"? integral-part) space
             integral-part ::= [0] | [1-9] [0-9]{0,15}
             root ::= "{" space absolutePath-kv ( "," space ( startLine-kv ) )? "}" space
             space ::= | " " | "\n"{1,2} [ \t]{0,20}
-            startLine-kv ::= "startLine" space ":" space integer
+            startLine-kv ::= "startLine" ":" space integer
         )"""
     });
 
@@ -1574,7 +1574,53 @@ static void test_gemma4_dialect() {
             root ::= "{" space todos-kv "}" space
             space ::= | " " | "\n"{1,2} [ \t]{0,20}
             todos ::= "[" space (gemma4-string ("," space gemma4-string)*)? "]" space
-            todos-kv ::= "todos" space ":" space todos
+            todos-kv ::= "todos" ":" space todos
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "gemma4 string enum",
+        R"""({
+            "enum": ["ventes", "compta", "support", "rh"]
+        })""",
+        R"""(
+            root ::= (<|"|> "ventes" <|"|> | <|"|> "compta" <|"|> | <|"|> "support" <|"|> | <|"|> "rh" <|"|>) space
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "gemma4 enum on string property",
+        R"""({
+            "type": "object",
+            "properties": {
+                "assignee": { "type": "string", "enum": ["ventes", "compta", "support", "rh"] },
+                "body":     { "type": "string" }
+            },
+            "required": ["assignee", "body"]
+        })""",
+        R"""(
+            assignee ::= (<|"|> "ventes" <|"|> | <|"|> "compta" <|"|> | <|"|> "support" <|"|> | <|"|> "rh" <|"|>) space
+            assignee-kv ::= "assignee" ":" space assignee
+            body-kv ::= "body" ":" space gemma4-string
+            gemma4-char ::= [^\x00-\x08\x0B\x0C\x0E-\x1F\x7F]
+            gemma4-string ::= <|"|> gemma4-char* <|"|> space
+            root ::= "{" space assignee-kv "," space body-kv "}" space
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "gemma4 string const",
+        R"""({
+            "const": "kanban_create"
+        })""",
+        R"""(
+            root ::= <|"|> "kanban_create" <|"|> space
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
         )"""
     });
 

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -1509,11 +1509,62 @@ static void test_resolves_to_string() {
     fprintf(stderr, "All resolves_to_string tests passed!\n");
 }
 
+static void test_gemma4_dialect() {
+    fprintf(stderr, "#\n# Testing JSON schema conversion (Gemma 4 Dialect)\n#\n");
+    auto test = [](const TestCase & tc) {
+        fprintf(stderr, "- %s\n", tc.name.c_str());
+        try {
+            tc.verify(json_schema_to_grammar(nlohmann::ordered_json::parse(tc.schema), true, COMMON_SCHEMA_DIALECT_GEMMA4));
+            tc.verify_status(SUCCESS);
+        } catch (const std::invalid_argument & ex) {
+            fprintf(stderr, "Error: %s\n", ex.what());
+            tc.verify_status(FAILURE);
+        }
+    };
+
+    test({
+        SUCCESS,
+        "gemma4 basic string",
+        R"""({
+            "type": "string"
+        })""",
+        R"""(
+            root ::= gemma4-string
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "gemma4 object with keys",
+        R"""({
+            "type": "object",
+            "properties": {
+                "absolutePath": { "type": "string" },
+                "startLine": { "type": "integer" }
+            },
+            "required": ["absolutePath"]
+        })""",
+        R"""(
+            absolutePath ::= gemma4-string
+            absolutePath-kv ::= "absolutePath" space ":" space absolutePath
+            integer ::= ("-"? integral-part) space
+            integral-part ::= [0] | [1-9] [0-9]{0,15}
+            root ::= "{" space absolutePath-kv ( "," space ( startLine-kv ) )? "}" space
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+            startLine-kv ::= "startLine" space ":" space integer
+        )"""
+    });
+
+    fprintf(stderr, "All Gemma 4 dialect tests passed!\n");
+}
+
 int main() {
     fprintf(stderr, "LLAMA_NODE_AVAILABLE = %s\n", getenv("LLAMA_NODE_AVAILABLE") ? "true" : "false");
     fprintf(stderr, "LLAMA_PYTHON_AVAILABLE = %s\n", getenv("LLAMA_PYTHON_AVAILABLE") ? "true" : "false");
 
     test_resolves_to_string();
+    test_gemma4_dialect();
 
     test_all("C++", [](const TestCase & tc) {
         try {

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -1529,7 +1529,8 @@ static void test_gemma4_dialect() {
             "type": "string"
         })""",
         R"""(
-            root ::= gemma4-string
+            gemma4-char ::= [^\x00-\x08\x0B\x0C\x0E-\x1F\x7F]
+            root ::= <|"|> gemma4-char* <|"|> space
             space ::= | " " | "\n"{1,2} [ \t]{0,20}
         )"""
     });
@@ -1546,13 +1547,34 @@ static void test_gemma4_dialect() {
             "required": ["absolutePath"]
         })""",
         R"""(
-            absolutePath ::= gemma4-string
-            absolutePath-kv ::= "absolutePath" space ":" space absolutePath
+            absolutePath-kv ::= "absolutePath" space ":" space gemma4-string
+            gemma4-char ::= [^\x00-\x08\x0B\x0C\x0E-\x1F\x7F]
+            gemma4-string ::= <|"|> gemma4-char* <|"|> space
             integer ::= ("-"? integral-part) space
             integral-part ::= [0] | [1-9] [0-9]{0,15}
             root ::= "{" space absolutePath-kv ( "," space ( startLine-kv ) )? "}" space
             space ::= | " " | "\n"{1,2} [ \t]{0,20}
             startLine-kv ::= "startLine" space ":" space integer
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "gemma4 array of strings",
+        R"""({
+            "type": "object",
+            "properties": {
+                "todos": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["todos"]
+        })""",
+        R"""(
+            gemma4-char ::= [^\x00-\x08\x0B\x0C\x0E-\x1F\x7F]
+            gemma4-string ::= <|"|> gemma4-char* <|"|> space
+            root ::= "{" space todos-kv "}" space
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+            todos ::= "[" space (gemma4-string ("," space gemma4-string)*)? "]" space
+            todos-kv ::= "todos" space ":" space todos
         )"""
     });
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
This adds support for Gemma 4's token-delimited tool calling dialect call:tool{key:<|"|>value<|"|>}.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
While testing Gemma 4 4B with llama-server and a custom harness (Android Studio), I noticed quite a few tool calls with incorrect arguments ("absolute.absolutePath"), taking the model a few turns to correct. This did not happen with LiteRT-LM, so I started looking into how they handled strings, and how the grammar was handled on the llama.cpp side.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES, navigating the llama.cpp codebase and tracing the code paths for a Gemma 4 run.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
