### PR TITLE
Add path validation and exit code error handling to bench script

### DIFF
--- a/scripts/snapdragon/windows/run-bench.ps1
+++ b/scripts/snapdragon/windows/run-bench.ps1
@@ -1,48 +1,63 @@
-
 #!/usr/bin/env pwsh
 
-# Basedir on device
 $basedir=".\pkg-snapdragon"
-
 $cli_opts=$args
-
 $model="Llama-3.2-3B-Instruct-Q4_0.gguf"
 if ($null -ne $env:M) {
     $model=$env:M
 }
-
 $device="HTP0"
 if ($null -ne $env:D) {
     $device=$env:D
 }
-
 if ($null -ne $env:V) {
     $env:GGML_HEXAGON_VERBOSE=$env:V
 }
-
 if ($null -ne $env:PROF) {
     $env:GGML_HEXAGON_PROFILE=$env:PROF
 }
-
 if ($null -ne $env:OPSTAGE) {
     $env:GGML_HEXAGON_OPSTAGE=$env:OPSTAGE
 }
-
 if ($null -ne $env:NHVX) {
     $env:GGML_HEXAGON_NHVX=$env:NHVX
 }
-
 if ($null -ne $env:NDEV) {
     $env:GGML_HEXAGON_NDEV=$env:NDEV
 }
-
 if ($null -ne $env:HB) {
     $env:GGML_HEXAGON_HOSTBUF=$env:HB
 }
 
+$binary    = "$basedir\bin\llama-bench.exe"
+$modelPath = "$basedir\..\..\gguf\$model"
+$libPath   = "$basedir\lib"
+
+if (-not (Test-Path $basedir)) {
+    Write-Error "Base directory not found: $basedir"
+    exit 1
+}
+if (-not (Test-Path $binary)) {
+    Write-Error "Binary not found: $binary"
+    exit 1
+}
+if (-not (Test-Path $modelPath)) {
+    Write-Error "Model file not found: $modelPath"
+    exit 1
+}
+if (-not (Test-Path $libPath)) {
+    Write-Error "Lib directory not found: $libPath"
+    exit 1
+}
+
 $env:ADSP_LIBRARY_PATH="$basedir\lib"
 
-& "$basedir\bin\llama-bench.exe" `
-    --mmap 0 -m $basedir\..\..\gguf\$model `
+& "$binary" `
+    --mmap 0 -m $modelPath `
     --poll 1000 -t 6 --cpu-mask 0xfc --cpu-strict 1 `
     --batch-size 128 -ngl 99 --device $device $cli_opts
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "llama-bench.exe failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}

--- a/scripts/snapdragon/windows/run-bench.ps1
+++ b/scripts/snapdragon/windows/run-bench.ps1
@@ -1,5 +1,5 @@
 #!/usr/bin/env pwsh
-
+# Basedir on device
 $basedir=".\pkg-snapdragon"
 $cli_opts=$args
 $model="Llama-3.2-3B-Instruct-Q4_0.gguf"
@@ -53,7 +53,7 @@ if (-not (Test-Path $libPath)) {
 $env:ADSP_LIBRARY_PATH="$basedir\lib"
 
 & "$binary" `
-    --mmap 0 -m $modelPath `
+    --mmap 0 -m "$modelPath" `
     --poll 1000 -t 6 --cpu-mask 0xfc --cpu-strict 1 `
     --batch-size 128 -ngl 99 --device $device $cli_opts
 


### PR DESCRIPTION
## Summary
Add error handling to run-bench.ps1

Previously the script would pass invalid paths silently to llama-bench.exe
and produce cryptic errors. It also had no way to detect if the binary
itself failed.

Changes:
- Extract binary, model, and lib paths into variables to avoid repetition
- Validate that basedir, binary, model file, and lib directory all exist
  before running, with a clear error message for each missing path
- Check $LASTEXITCODE after llama-bench.exe exits and propagate it so
  callers can detect failure


## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)