### PR TITLE
webui: fix Tailwind v4 utility classes missing when built via cmake

### DIFF
--- a/tools/ui/src/app.css
+++ b/tools/ui/src/app.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@source ".";
 
 @import 'tw-animate-css';
 


### PR DESCRIPTION
## Overview
Building with -DLLAMA_BUILD_UI=ON produces a broken web UI - no styling at all, just unstyled HTML. The CSS file is generated but only contains ~209 class selectors, missing basically all Tailwind utility classes like .flex, .grid, etc.

The issue is that Tailwind v4's auto source detection works fine in CI but produces an empty scan when npm is run as a cmake subprocess (As with AUR/pkgbuild). So the generated bundle.css has no utility classes and the UI looks completely broken.

## Expected changes
Add @source "."; to tools/ui/src/app.css to explicitly tell the Tailwind scanner where to look.

With the fix, bundle.css goes from ~405 KB to ~505 KB and the UI renders correctly.

Doesn't affect CI or running npm run build manually - the directive is just making the scan explicit instead of relying on auto-detection.