### PR TITLE
fix: initialize `embeddings_pre_norm_masked=false` in `llama_context`

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -64,8 +64,9 @@ llama_context::llama_context(
     cparams.yarn_attn_factor = params.yarn_attn_factor >= 0.0f ? params.yarn_attn_factor : hparams.yarn_attn_factor;
     cparams.yarn_beta_fast   = params.yarn_beta_fast   >= 0.0f ? params.yarn_beta_fast   : hparams.yarn_beta_fast;
     cparams.yarn_beta_slow   = params.yarn_beta_slow   >= 0.0f ? params.yarn_beta_slow   : hparams.yarn_beta_slow;
-    cparams.embeddings       = params.embeddings;
-    cparams.embeddings_pre_norm = false;
+    cparams.embeddings                  = params.embeddings;
+    cparams.embeddings_pre_norm         = false;
+    cparams.embeddings_pre_norm_masked  = false;
     cparams.offload_kqv      = params.offload_kqv;
     cparams.no_perf          = params.no_perf;
     cparams.pooling_type     = params.pooling_type;


### PR DESCRIPTION
## Overview

This PR fixes a bug introduced in #23198 by the new `embeddings_pre_norm_masked` struct member for `llama_context`. When left uninitialised `embeddings_pre_norm_masked` caused a bug in the construction of Qwen3.5 graphs where `get_rows_f32` failed in an assert because it tried to grab an invalid row index.

## Additional information

[Failing CI run with the relevant assert](https://github.com/abetlen/llama-cpp-python/actions/runs/26019550305/job/76477517913)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, gpt 5.5 xhigh was used through the codex cli to find the root cause of this bug when the CI job failed.
