### PR TITLE
common: fix --help for --verbosity

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3363,7 +3363,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             " - 1: error\n"
             " - 2: warning\n"
             " - 3: info\n"
-            " - 4: debug\n"
+            " - 4: trace (more info)\n"
+            " - 5: debug\n"
             "(default: %d)\n", params.verbosity),
         [](common_params & params, int value) {
             params.verbosity = value;


### PR DESCRIPTION
To my understanding the `--help` for `--verbosity` is wrong on master. 4 is trace, 5 is debug.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No