### PR TITLE
speculative : gate MTP draft on slot state, skip unsafe batches

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -16,6 +16,8 @@
 #include <iomanip>
 #include <map>
 #include <cinttypes>
+#include <unordered_map>
+#include <unordered_set>
 
 #define SPEC_VOCAB_MAX_SIZE_DIFFERENCE  128
 #define SPEC_VOCAB_CHECK_START_TOKEN_ID 5
@@ -108,6 +110,107 @@ static bool common_speculative_are_compatible(
 }
 
 using common_speculative_draft_params_vec = std::vector<common_speculative_draft_params>;
+
+bool common_speculative_batch_is_token_only(const llama_batch & batch, std::string * reason) {
+    if (batch.n_tokens <= 0) {
+        if (reason) {
+            *reason = "empty batch";
+        }
+        return false;
+    }
+
+    if (batch.token == nullptr) {
+        if (reason) {
+            *reason = "no token ids";
+        }
+        return false;
+    }
+
+    if (batch.embd != nullptr) {
+        if (reason) {
+            *reason = "embedding batch";
+        }
+        return false;
+    }
+
+    if (batch.pos == nullptr) {
+        if (reason) {
+            *reason = "missing positions";
+        }
+        return false;
+    }
+
+    if (batch.seq_id == nullptr || batch.n_seq_id == nullptr) {
+        if (reason) {
+            *reason = "missing seq ids";
+        }
+        return false;
+    }
+
+    return true;
+}
+
+bool common_speculative_batch_is_mtp_process_safe(const llama_batch & batch, std::string * reason) {
+    if (!common_speculative_batch_is_token_only(batch, reason)) {
+        return false;
+    }
+
+    std::unordered_map<llama_seq_id, llama_pos> last_pos;
+    std::unordered_set<llama_seq_id> closed_seqs;
+    llama_seq_id last_seq = -1;
+    bool have_last_seq = false;
+
+    for (int32_t k = 0; k < batch.n_tokens; ++k) {
+        if (batch.n_seq_id[k] != 1 || batch.seq_id[k] == nullptr) {
+            if (reason) {
+                *reason = "token belongs to zero or multiple sequences";
+            }
+            return false;
+        }
+
+        const llama_seq_id seq = batch.seq_id[k][0];
+        const llama_pos    pos = batch.pos[k];
+
+        if (seq < 0) {
+            if (reason) {
+                *reason = "invalid sequence id";
+            }
+            return false;
+        }
+
+        if (pos < 0) {
+            if (reason) {
+                *reason = "invalid position";
+            }
+            return false;
+        }
+
+        if (have_last_seq && seq != last_seq) {
+            closed_seqs.insert(last_seq);
+        }
+
+        if (closed_seqs.find(seq) != closed_seqs.end()) {
+            if (reason) {
+                *reason = "interleaved sequence rows";
+            }
+            return false;
+        }
+
+        auto it = last_pos.find(seq);
+        if (it != last_pos.end() && pos != it->second + 1) {
+            if (reason) {
+                *reason = "non-consecutive positions for sequence";
+            }
+            return false;
+        }
+
+        last_pos[seq] = pos;
+        last_seq = seq;
+        have_last_seq = true;
+    }
+
+    return true;
+}
 
 // state of an implementation of speculative decoding
 //
@@ -471,12 +574,9 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
     }
 
     bool process(const llama_batch & batch_in) override {
-        if (batch_in.n_tokens <= 0) {
-            return true;
-        }
-
-        // TODO: how to make it work with vision tokens?
-        if (batch_in.token == nullptr || batch_in.embd != nullptr) {
+        std::string reason;
+        if (!common_speculative_batch_is_mtp_process_safe(batch_in, &reason)) {
+            LOG_DBG("%s: MTP process skipped: %s\n", __func__, reason.c_str());
             return true;
         }
 
@@ -487,15 +587,16 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         std::fill(i_batch_end.begin(), i_batch_end.end(), -1);
 
         for (int k = 0; k < n_tokens; ++k) {
-            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                GGML_ASSERT(batch_in.n_seq_id[k] == 1);
+            const llama_seq_id seq_id = batch_in.seq_id[k][0];
+            if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
+                LOG_DBG("%s: MTP process skipped: sequence id %d is outside configured range [0, %u)\n",
+                        __func__, seq_id, n_seq);
+                return true;
+            }
 
-                if (batch_in.seq_id[k][0] == seq_id) {
-                    i_batch_end[seq_id] = k;
-                    if (i_batch_beg[seq_id] < 0) {
-                        i_batch_beg[seq_id] = k;
-                    }
-                }
+            i_batch_end[seq_id] = k;
+            if (i_batch_beg[seq_id] < 0) {
+                i_batch_beg[seq_id] = k;
             }
         }
 
@@ -514,10 +615,16 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         // assumes that the tokens in the batch are sequential for each sequence
         // i.e. we cannot have seq_id like this: [0, 0, 0, 1, 1, 0, 1, 1]
         //                                                       ^--- this is a problem
-        // TODO:this is generally true, but would be nice to assert it
         {
             const float * h_tgt = llama_get_embeddings_pre_norm(ctx_tgt);
-            std::memcpy(batch.embd + (size_t) 1 * n_embd, h_tgt, row_bytes * (n_tokens-1));
+            if (h_tgt == nullptr) {
+                LOG_DBG("%s: MTP process skipped: target pre-norm embeddings are unavailable\n", __func__);
+                return true;
+            }
+
+            if (n_tokens > 1) {
+                std::memcpy(batch.embd + (size_t) 1 * n_embd, h_tgt, row_bytes * (n_tokens - 1));
+            }
 
             //{
             //    // string with seq_ids in the batch

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -73,3 +73,19 @@ struct common_speculative_deleter {
 };
 
 typedef std::unique_ptr<common_speculative, common_speculative_deleter> common_speculative_ptr;
+
+// batch-safety predicates used internally by speculative implementations to
+// skip unsafe batches (embeddings, missing positions, non-consecutive rows,
+// interleaved sequence rows, ...). Exposed primarily for unit tests, but
+// callers may also use them to pre-check a batch before passing it to a
+// speculative implementation. If `reason` is non-null and the helper returns
+// false, it is set to a short human-readable reason.
+//
+// - common_speculative_batch_is_token_only: cheap check that the batch has
+//   token ids (no embeddings) and the basic pointer fields are present.
+// - common_speculative_batch_is_mtp_process_safe: stricter check used by the
+//   MTP draft path: each row must belong to exactly one sequence with a
+//   valid position, sequences must not be interleaved, and positions within
+//   a sequence must be consecutive.
+bool common_speculative_batch_is_token_only      (const llama_batch & batch, std::string * reason);
+bool common_speculative_batch_is_mtp_process_safe(const llama_batch & batch, std::string * reason);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1613,6 +1613,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
     // so accept either present rather than requiring exactly one.
     GGML_ASSERT(batch_inp.token || batch_inp.embd);
 
+    if (cparams.ctx_type == LLAMA_CONTEXT_TYPE_MTP && (!batch_inp.token || !batch_inp.embd)) {
+        LLAMA_LOG_DEBUG("%s: MTP context requires token ids and pre-norm embeddings; incompatible batch token=%p, embd=%p\n",
+                __func__, (const void *) batch_inp.token, (const void *) batch_inp.embd);
+        return -1;
+    }
+
     if (!memory) {
         LLAMA_LOG_DEBUG("%s: cannot decode batches with this context (calling encode() instead)\n", __func__);
         return encode(batch_inp);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,6 +235,7 @@ llama_build_and_test(test-thread-safety.cpp ARGS -m "${MODEL_DEST}" -ngl 99 -p "
 set_tests_properties(test-thread-safety PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 llama_build_and_test(test-arg-parser.cpp)
+llama_build_and_test(test-speculative-batch-safety.cpp)
 
 if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   # TODO: repair known memory leaks

--- a/tests/test-speculative-batch-safety.cpp
+++ b/tests/test-speculative-batch-safety.cpp
@@ -1,0 +1,263 @@
+// Unit tests for the batch-safety helpers used by MTP speculative decoding.
+//
+// These exist primarily to lock in the contract that batches which are unsafe
+// for MTP processing (image embedding batches, batches without token ids,
+// batches with non-consecutive or interleaved sequence rows, ...) are rejected
+// up-front so the MTP draft context cannot crash on them.
+//
+// The helpers live in common/speculative.cpp and are exposed via
+// common/speculative.h for test access. They are otherwise used internally to
+// gate `common_speculative_state_draft_mtp::process()`.
+
+#include "llama.h"
+#include "speculative.h"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Holds owning storage for a llama_batch test fixture so the pointer arrays
+// stay alive for the duration of a single check call.
+struct batch_fixture {
+    std::vector<llama_token>                     tokens;
+    std::vector<float>                           embd;
+    std::vector<llama_pos>                       pos;
+    std::vector<int32_t>                         n_seq_id;
+    std::vector<std::vector<llama_seq_id>>       seq_id_storage;
+    std::vector<llama_seq_id *>                  seq_id_ptrs;
+
+    llama_batch batch{};
+
+    // Build a basic token-only batch:
+    //   - one sequence per row (seq_id supplied or all 0 if empty)
+    //   - positions supplied or generated 0..n-1
+    void build_token_batch(const std::vector<llama_token> & toks,
+                           const std::vector<llama_pos>   & positions = {},
+                           const std::vector<llama_seq_id> & seq_ids  = {}) {
+        tokens = toks;
+        const int32_t n = (int32_t) tokens.size();
+
+        if (positions.empty()) {
+            pos.resize(n);
+            for (int32_t i = 0; i < n; ++i) {
+                pos[i] = i;
+            }
+        } else {
+            pos = positions;
+        }
+
+        n_seq_id.assign(n, 1);
+        seq_id_storage.clear();
+        seq_id_storage.resize(n);
+        seq_id_ptrs.assign(n, nullptr);
+        for (int32_t i = 0; i < n; ++i) {
+            const llama_seq_id sid = seq_ids.empty() ? 0 : seq_ids[i];
+            seq_id_storage[i] = { sid };
+            seq_id_ptrs[i]    = seq_id_storage[i].data();
+        }
+
+        batch          = {};
+        batch.n_tokens = n;
+        batch.token    = tokens.data();
+        batch.embd     = nullptr;
+        batch.pos      = pos.data();
+        batch.n_seq_id = n_seq_id.data();
+        batch.seq_id   = seq_id_ptrs.data();
+    }
+};
+
+void expect_safe(bool ok, const std::string & reason, const char * name) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL: %s expected SAFE, got UNSAFE (%s)\n", name, reason.c_str());
+        std::abort();
+    }
+    std::fprintf(stderr, "  ok: %s -> SAFE\n", name);
+}
+
+void expect_unsafe(bool ok, const std::string & reason, const char * name) {
+    if (ok) {
+        std::fprintf(stderr, "FAIL: %s expected UNSAFE, got SAFE\n", name);
+        std::abort();
+    }
+    if (reason.empty()) {
+        std::fprintf(stderr, "FAIL: %s reason was empty\n", name);
+        std::abort();
+    }
+    std::fprintf(stderr, "  ok: %s -> UNSAFE (%s)\n", name, reason.c_str());
+}
+
+void test_empty_batch() {
+    batch_fixture f;
+    f.batch          = {};
+    f.batch.n_tokens = 0;
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_token_only(f.batch, &reason), reason,
+                  "empty batch (token_only)");
+    reason.clear();
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "empty batch (mtp_safe)");
+}
+
+void test_null_token_pointer() {
+    batch_fixture f;
+    f.build_token_batch({ 1, 2, 3 });
+    f.batch.token = nullptr;  // simulate an embeddings-only batch shape
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_token_only(f.batch, &reason), reason,
+                  "null token ptr (token_only)");
+    reason.clear();
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "null token ptr (mtp_safe)");
+}
+
+void test_embedding_batch() {
+    batch_fixture f;
+    f.build_token_batch({ 1, 2, 3 });
+    // simulate a multimodal embedding batch by attaching an embd buffer
+    f.embd.assign(3, 0.0f);
+    f.batch.embd = f.embd.data();
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_token_only(f.batch, &reason), reason,
+                  "embedding batch (token_only)");
+    reason.clear();
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "embedding batch (mtp_safe)");
+}
+
+void test_single_seq_consecutive() {
+    batch_fixture f;
+    f.build_token_batch({ 10, 11, 12, 13 }, /*positions=*/ { 5, 6, 7, 8 });
+
+    std::string reason;
+    expect_safe(common_speculative_batch_is_token_only(f.batch, &reason), reason,
+                "single seq consecutive (token_only)");
+    reason.clear();
+    expect_safe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                "single seq consecutive (mtp_safe)");
+}
+
+void test_single_seq_non_consecutive() {
+    batch_fixture f;
+    f.build_token_batch({ 10, 11, 12 }, /*positions=*/ { 0, 1, 3 }); // gap at 2
+
+    std::string reason;
+    // token-only check is permissive: it accepts the batch shape
+    expect_safe(common_speculative_batch_is_token_only(f.batch, &reason),
+                reason, "non-consecutive (token_only is permissive)");
+    reason.clear();
+    // mtp-safe check is strict: it must reject
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "single seq non-consecutive (mtp_safe)");
+}
+
+void test_multi_seq_per_seq_consecutive_not_interleaved() {
+    // Two sequences, each consecutive within itself, presented in contiguous
+    // blocks. Conservative policy should accept this since rows are not
+    // interleaved.
+    batch_fixture f;
+    f.build_token_batch(
+        /*tokens=*/    { 10, 11, 20, 21 },
+        /*positions=*/ {  0,  1,  0,  1 },
+        /*seq_ids=*/   {  0,  0,  1,  1 });
+
+    std::string reason;
+    expect_safe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                "multi seq, contiguous blocks, per-seq consecutive (mtp_safe)");
+}
+
+void test_multi_seq_interleaved_rejected() {
+    // Rows interleave [0,0,1,0]. Spec says reject this for current MTP.
+    batch_fixture f;
+    f.build_token_batch(
+        /*tokens=*/    { 10, 11, 20, 12 },
+        /*positions=*/ {  0,  1,  0,  2 },
+        /*seq_ids=*/   {  0,  0,  1,  0 });
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "multi seq interleaved (mtp_safe)");
+}
+
+void test_n_seq_id_not_one_rejected() {
+    // Row claiming multiple seq ids must be rejected by the MTP-safe check.
+    batch_fixture f;
+    f.build_token_batch({ 10, 11 });
+    // override second row to claim 2 seq ids
+    f.seq_id_storage[1] = { 0, 1 };
+    f.seq_id_ptrs[1]    = f.seq_id_storage[1].data();
+    f.n_seq_id[1]       = 2;
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "row with n_seq_id != 1 (mtp_safe)");
+}
+
+void test_negative_seq_id_rejected() {
+    batch_fixture f;
+    f.build_token_batch({ 10, 11 }, {}, { 0, -1 });
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "negative seq id (mtp_safe)");
+}
+
+void test_negative_position_rejected() {
+    batch_fixture f;
+    f.build_token_batch({ 10, 11 }, /*positions=*/ { 0, -1 });
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                  "negative position (mtp_safe)");
+}
+
+void test_missing_seq_id_arrays_rejected() {
+    batch_fixture f;
+    f.build_token_batch({ 10, 11 });
+    f.batch.seq_id   = nullptr;
+
+    std::string reason;
+    expect_unsafe(common_speculative_batch_is_token_only(f.batch, &reason), reason,
+                  "missing seq_id arr (token_only)");
+}
+
+void test_single_token_batch_safe() {
+    batch_fixture f;
+    f.build_token_batch({ 42 });
+
+    std::string reason;
+    expect_safe(common_speculative_batch_is_mtp_process_safe(f.batch, &reason), reason,
+                "single-token batch (mtp_safe)");
+}
+
+} // namespace
+
+int main(int /*argc*/, char ** /*argv*/) {
+    std::fprintf(stderr, "test-speculative-batch-safety: starting\n");
+
+    test_empty_batch();
+    test_null_token_pointer();
+    test_embedding_batch();
+    test_single_seq_consecutive();
+    test_single_seq_non_consecutive();
+    test_multi_seq_per_seq_consecutive_not_interleaved();
+    test_multi_seq_interleaved_rejected();
+    test_n_seq_id_not_one_rejected();
+    test_negative_seq_id_rejected();
+    test_negative_position_rejected();
+    test_missing_seq_id_arrays_rejected();
+    test_single_token_batch_safe();
+
+    std::fprintf(stderr, "test-speculative-batch-safety: all assertions passed\n");
+    return 0;
+}

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -291,6 +291,26 @@ struct server_slot {
         return !!spec;
     }
 
+    bool can_speculative_draft_now() const {
+        if (!can_speculate()) {
+            return false;
+        }
+
+        if (state != SLOT_STATE_GENERATING) {
+            return false;
+        }
+
+        if (!task || !task->need_sampling()) {
+            return false;
+        }
+
+        if (!has_next_token) {
+            return false;
+        }
+
+        return true;
+    }
+
     void add_token(const completion_token_output & token) {
         if (!is_processing()) {
             SLT_WRN(*this, "%s", "slot is not processing\n");
@@ -799,7 +819,7 @@ private:
             cparams.n_rs_seq = 0;
             ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams));
 
-            ctx_dft_seq_rm_type = common_context_can_seq_rm(ctx_dft.get());
+            ctx_dft_seq_rm_type = spec_mtp ? COMMON_CONTEXT_SEQ_RM_TYPE_NO : common_context_can_seq_rm(ctx_dft.get());
 
             params_base.speculative.draft.ctx_tgt = ctx_tgt;
             params_base.speculative.draft.ctx_dft = ctx_dft.get();
@@ -818,7 +838,7 @@ private:
                 return false;
             }
 
-            ctx_dft_seq_rm_type = common_context_can_seq_rm(ctx_dft.get());
+            ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
 
             params_base.speculative.draft.ctx_tgt = ctx_tgt;
             params_base.speculative.draft.ctx_dft = ctx_dft.get();
@@ -1003,6 +1023,12 @@ private:
         }
 
         return true;
+    }
+
+    bool speculative_mtp_enabled() const {
+        return spec && std::find(params_base.speculative.types.begin(),
+                                 params_base.speculative.types.end(),
+                                 COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end();
     }
 
     // unlike load_model(), this is only called once during initialization
@@ -2275,6 +2301,12 @@ private:
         // determine which slots are generating and drafting
         for (auto & slot : slots) {
             if (slot.state != SLOT_STATE_GENERATING) {
+                if (slot.can_speculate()) {
+                    common_speculative_get_draft_params(spec.get(), slot.id).drafting = false;
+                    if (speculative_mtp_enabled() && slot.is_processing()) {
+                        SLT_DBG(slot, "MTP draft skipped: slot is not generating (state = %d)\n", (int) slot.state);
+                    }
+                }
                 continue;
             }
 
@@ -2290,6 +2322,10 @@ private:
             if (spec) {
                 common_speculative_get_draft_params(spec.get(), slot.id).drafting = false;
 
+                if (!slot.can_speculative_draft_now()) {
+                    continue;
+                }
+
                 const bool use_ckpt_tgt = ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
                 const bool use_ckpt_dft = ctx_dft_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
 
@@ -2297,6 +2333,11 @@ private:
 
                 if (n_draft_max > 0) {
                     GGML_ASSERT(slot.can_speculate());
+                    if (speculative_mtp_enabled()) {
+                        SLT_DBG(slot, "MTP draft enabled: slot generating, n_draft_max = %d\n", n_draft_max);
+                    } else {
+                        SLT_DBG(slot, "speculative draft enabled: slot generating, n_draft_max = %d\n", n_draft_max);
+                    }
 
                     if (!slot.spec_draft.empty()) {
                         // we have a previous (partial) draft to reuse
@@ -2771,11 +2812,13 @@ private:
 
                         if (ctx_dft) {
                             // TODO: in the future, figure out how to infuse target embeddings to the images
-                            //       for now, we skip this for simplicity
-                            //       maybe we simply need to call `common_speculative_process()` on the mtmd batches in the `process_chunk` above?
-                            res = input_tokens.process_chunk(ctx_dft.get(), mctx, slot.prompt.n_tokens(), slot.prompt.tokens.pos_next(), slot.id, n_tokens_out);
-                            if (res != 0) {
-                                GGML_ABORT("failed to process multi-modal data on draft context\n");
+                            if (speculative_mtp_enabled()) {
+                                SLT_DBG(slot, "%s", "MTP process skipped: multimodal embedding batch\n");
+                            } else {
+                                res = input_tokens.process_chunk(ctx_dft.get(), mctx, slot.prompt.n_tokens(), slot.prompt.tokens.pos_next(), slot.id, n_tokens_out);
+                                if (res != 0) {
+                                    GGML_ABORT("failed to process multi-modal data on draft context\n");
+                                }
                             }
                         }
 


### PR DESCRIPTION
Make MTP (`--spec-type draft-mtp`) safe to run alongside mmproj/multimodal input. Previously, combining the two flags could trip asserts or feed embedding/non-consecutive batches into the MTP draft context, which expects token-only sequential batches whose hidden state aligns with the target.

Behaviour matrix:

                                 process/sync   draft
  text-only prompt prefill       safe-batch     -
  image embedding batch          -              -
  multimodal text prefill        safe-batch     -
  assistant generation           safe-batch     allowed

Where "safe-batch" means: token ids present, no embeddings, per-row positions valid, each row in exactly one sequence, sequences not interleaved, per-sequence positions consecutive.

Changes

* common/speculative.{h,cpp}
  - Add `common_speculative_batch_is_token_only` and `common_speculative_batch_is_mtp_process_safe` helpers (exposed in the header for unit tests and pre-checks).
  - Replace the ad hoc null-check in `common_speculative_state_draft_mtp::process()` with the strict safety helper. Unsafe batches now return `true` (graceful skip) instead of falling through to a `GGML_ASSERT(n_seq_id==1)` or memcpy on a null pre-norm pointer.
  - Replace the inner `for seq_id ... if seq_id matches` scan with a direct `seq_id = batch_in.seq_id[k][0]` lookup, now that the safety helper has guaranteed n_seq_id==1.
  - Guard `llama_get_embeddings_pre_norm()` against a null return and skip the `n_tokens-1` memcpy when `n_tokens == 1`.

* src/llama-context.cpp
  - At the entry of `llama_context::decode`, reject batches into an MTP-typed context that don't carry both token ids AND pre-norm embeddings. Returns -1 (graceful) instead of asserting downstream. No phase gating here -- that belongs at the executable level.

* tools/server/server-context.cpp
  - Add `server_slot::can_speculative_draft_now()` -- composes `can_speculate`, `state == SLOT_STATE_GENERATING`, `task->need_sampling`, and `has_next_token`. Used to gate draft generation.
  - Force `ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO` for MTP so partial sequence removal can't desync the shared hidden state.
  - In the main scheduling loop:
    + For non-generating slots: set `drafting=false`, log skip reason if MTP.
    + For generating slots: skip draft prep unless `can_speculative_draft_now()` is true.
  - For image chunks, skip `process_chunk(ctx_dft, ...)` when MTP is the draft type (the MTP context cannot consume image embeddings). Non-MTP draft types keep the existing behaviour.

* tests/test-speculative-batch-safety.cpp (new)
  - Unit-test the two batch-safety predicates: empty, null-token, embedding-batch, single/multi sequence consecutive, non-consecutive, interleaved, n_seq_id != 1, negative seq id, negative position, missing arrays, and single-token. Registered in tests/CMakeLists.txt.

Notes

* llama-cli uses `server_context` in this checkout, so it inherits the server-side gating without a separate patch.
* llama-mtmd-cli does not expose `--spec-type`; examples/speculative-simple does not expose `--mmproj`. Other tools (`llama-bench`, `perplexity`, ...) expose neither -- no patch needed. The shared helper protects all callers of `common_speculative_process` regardless.
* `find_slot: non-consecutive token position` warnings are unrelated to this patch (they fire without `--spec-type draft-mtp` as well).

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->Yes. Used to review, debug and write testing scripts. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
