### PR TITLE
Move to backend sampling for MTP draft path

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3592,6 +3592,15 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_P_MIN"));
     add_opt(common_arg(
+        {"--spec-draft-backend-sampling"},
+        {"--no-spec-draft-backend-sampling"},
+        string_format("offload draft sampling to the backend (default: %s)",
+                      params.speculative.draft.backend_sampling ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.speculative.draft.backend_sampling = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_BACKEND_SAMPLING"));
+    add_opt(common_arg(
         {"--spec-draft-device", "-devd", "--device-draft"}, "<dev1,dev2,..>",
         "comma-separated list of devices to use for offloading the draft model (none = don't offload)\n"
         "use --list-devices to see a list of available devices",

--- a/common/common.h
+++ b/common/common.h
@@ -305,6 +305,8 @@ struct common_params_speculative_draft {
     float p_split = 0.1f; // speculative decoding split probability
     float p_min   = 0.0f; // minimum speculative decoding probability (greedy)
 
+    bool backend_sampling = true; // offload draft sampling to the backend (default: on)
+
     common_params_model mparams;
 
     llama_context * ctx_tgt = nullptr;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -414,6 +414,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
     std::vector<common_sampler_ptr> smpls;
 
+    // backend sampler chain per seq, attached to ctx_dft
+    std::vector<llama_sampler *> backend_chains;
+
     int32_t n_embd = 0;
 
     // Per-sequence cross-batch carryover: pair (h_p, x_{p+1}) at MTP pos p+1.
@@ -469,6 +472,20 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             s.reset(common_sampler_init(llama_get_model(ctx_dft), sparams));
         }
 
+        // offload draft sampling to the backend
+        backend_chains.assign(n_seq, nullptr);
+        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+            llama_sampler * chain = llama_sampler_chain_init(llama_sampler_chain_default_params());
+            llama_sampler_chain_add(chain, llama_sampler_init_top_k(10));
+
+            if (!llama_set_sampler(ctx_dft, seq_id, chain)) {
+                LOG_WRN("%s: backend offload failed for seq_id=%d; using CPU sampler\n", __func__, (int) seq_id);
+                llama_sampler_free(chain);
+                chain = nullptr;
+            }
+            backend_chains[seq_id] = chain;
+        }
+
         llama_set_embeddings_pre_norm(ctx_tgt, true, /*masked*/ false);
         llama_set_embeddings_pre_norm(ctx_dft, true, /*masked*/ true);
 
@@ -484,6 +501,18 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     }
 
     ~common_speculative_impl_draft_mtp() override {
+        auto * ctx_dft = this->params.ctx_dft;
+        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) backend_chains.size(); ++seq_id) {
+            if (backend_chains[seq_id] == nullptr) {
+                continue;
+            }
+            if (ctx_dft) {
+                llama_set_sampler(ctx_dft, seq_id, nullptr);
+            }
+            llama_sampler_free(backend_chains[seq_id]);
+        }
+        backend_chains.clear();
+
         if (batch.token != nullptr) {
             free(batch.token);
             batch.token = nullptr;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -448,7 +448,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         n_embd = llama_model_n_embd(llama_get_model(ctx_dft));
 
         LOG_INF("%s: adding speculative implementation 'draft-mtp'\n", __func__);
-        LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f, n_embd=%d\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min, n_embd);
+        LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f, n_embd=%d, backend_sampling=%d\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min, n_embd, (int) this->params.backend_sampling);
         LOG_INF("%s: - gpu_layers=%d, cache_k=%s, cache_v=%s, ctx_tgt=%s, ctx_dft=%s, devices=[%s]\n", __func__,
                 this->params.n_gpu_layers,
                 ggml_type_name(this->params.cache_type_k),
@@ -474,16 +474,18 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         // offload draft sampling to the backend
         backend_chains.assign(n_seq, nullptr);
-        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-            llama_sampler * chain = llama_sampler_chain_init(llama_sampler_chain_default_params());
-            llama_sampler_chain_add(chain, llama_sampler_init_top_k(10));
+        if (this->params.backend_sampling) {
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                llama_sampler * chain = llama_sampler_chain_init(llama_sampler_chain_default_params());
+                llama_sampler_chain_add(chain, llama_sampler_init_top_k(10));
 
-            if (!llama_set_sampler(ctx_dft, seq_id, chain)) {
-                LOG_WRN("%s: backend offload failed for seq_id=%d; using CPU sampler\n", __func__, (int) seq_id);
-                llama_sampler_free(chain);
-                chain = nullptr;
+                if (!llama_set_sampler(ctx_dft, seq_id, chain)) {
+                    LOG_WRN("%s: backend offload failed for seq_id=%d; using CPU sampler\n", __func__, (int) seq_id);
+                    llama_sampler_free(chain);
+                    chain = nullptr;
+                }
+                backend_chains[seq_id] = chain;
             }
-            backend_chains[seq_id] = chain;
         }
 
         llama_set_embeddings_pre_norm(ctx_tgt, true, /*masked*/ false);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1137,6 +1137,19 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
 
     LLAMA_LOG_DEBUG("%s: seq_id = %d, sampler = %p\n", __func__, (int) seq_id, (void *) sampler);
 
+    if (sampler && model.split_mode() == LLAMA_SPLIT_MODE_TENSOR) {
+        static bool warned = false;
+        if (!warned) {
+            LLAMA_LOG_WARN("%s: backend sampling not supported with SPLIT_MODE_TENSOR; using CPU\n", __func__);
+            warned = true;
+        }
+        if (sampling.samplers.count(seq_id) > 0) {
+            sched_need_reserve = true;
+        }
+        sampling.samplers.erase(seq_id);
+        return false;
+    }
+
     const bool can_offload =
         sampler &&
         sampler->iface->backend_init &&
@@ -1146,7 +1159,15 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
     if (sampler && can_offload) {
         auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
 
-        sampler->iface->backend_init(sampler, buft);
+        if (!sampler->iface->backend_init(sampler, buft)) {
+            LLAMA_LOG_WARN("%s: sampler '%s' for seq_id = %d, backend_init failed\n",
+                    __func__, llama_sampler_name(sampler), seq_id);
+            if (sampling.samplers.count(seq_id) > 0) {
+                sched_need_reserve = true;
+            }
+            sampling.samplers.erase(seq_id);
+            return false;
+        }
 
         sampling.samplers[seq_id] = sampler;
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1159,15 +1159,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
     if (sampler && can_offload) {
         auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
 
-        if (!sampler->iface->backend_init(sampler, buft)) {
-            LLAMA_LOG_WARN("%s: sampler '%s' for seq_id = %d, backend_init failed\n",
-                    __func__, llama_sampler_name(sampler), seq_id);
-            if (sampling.samplers.count(seq_id) > 0) {
-                sched_need_reserve = true;
-            }
-            sampling.samplers.erase(seq_id);
-            return false;
-        }
+        sampler->iface->backend_init(sampler, buft);
 
         sampling.samplers[seq_id] = sampler;
 

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -698,6 +698,8 @@ static bool llama_sampler_chain_backend_init(
 
     GGML_ASSERT(chain->is_init == false && "llama_sampler_chain_backend_init() called twice");
 
+    chain->is_init = true;
+
     bool res = true;
 
     for (auto & smpl : chain->samplers) {
@@ -717,15 +719,6 @@ static bool llama_sampler_chain_backend_init(
         smpl.is_backend = res_cur;
 
         res = res && res_cur;
-    }
-
-    if (res) {
-        chain->is_init = true;
-    } else {
-        // partial failure - force CPU path for all samplers
-        for (auto & smpl : chain->samplers) {
-            smpl.is_backend = false;
-        }
     }
 
     return res;

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -698,8 +698,6 @@ static bool llama_sampler_chain_backend_init(
 
     GGML_ASSERT(chain->is_init == false && "llama_sampler_chain_backend_init() called twice");
 
-    chain->is_init = true;
-
     bool res = true;
 
     for (auto & smpl : chain->samplers) {
@@ -719,6 +717,15 @@ static bool llama_sampler_chain_backend_init(
         smpl.is_backend = res_cur;
 
         res = res && res_cur;
+    }
+
+    if (res) {
+        chain->is_init = true;
+    } else {
+        // partial failure - force CPU path for all samplers
+        for (auto & smpl : chain->samplers) {
+            smpl.is_backend = false;
+        }
     }
 
     return res;


### PR DESCRIPTION
The observation was that MTP draft is quite small, and for this reason, draft sampling can dominate the draft execution time. This PR tries to optimize the MTP draft sampling.

Replace D2H logit copies and CPU-side sort with argmax on the backend.

Make backend sampling more robust and fallback to CPU on failure cases, such as with "-sm tensor" or when a backend doesn't support ARG_MAX.

Introduce a new sampler in API that is greedy, but doesn't expose logits: `llama_sampler_init_greedy_token_only`.

Performance on 2x RTX 5090 with Qwen3.6-35B-A3B-UD-Q4_K_M.gguf and `--spec-draft-n-max 3` improves by ~7%.

Command: `./llama-server -m Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --spec-type draft-mtp --spec-draft-n-max 3`

Master:
```
python3 mtp-bench.py
  code_python        pred= 192 draft= 177 acc= 131 rate=0.740 tok/s=279.4
  code_cpp           pred= 192 draft= 210 acc= 121 rate=0.576 tok/s=244.6
  explain_concept    pred= 192 draft= 204 acc= 121 rate=0.593 tok/s=244.9
  summarize          pred= 192 draft= 170 acc= 134 rate=0.788 tok/s=296.3
  qa_factual         pred= 192 draft= 171 acc= 133 rate=0.778 tok/s=293.9
  translation        pred= 192 draft= 186 acc= 128 rate=0.688 tok/s=272.9
  creative_short     pred= 192 draft= 203 acc= 122 rate=0.601 tok/s=249.6
  stepwise_math      pred= 192 draft= 182 acc= 130 rate=0.714 tok/s=278.3
  long_code_review   pred= 192 draft= 192 acc= 126 rate=0.656 tok/s=261.3
```

PR
```
python3 mtp-bench.py
  code_python        pred= 192 draft= 177 acc= 131 rate=0.740 tok/s=298.4
  code_cpp           pred= 192 draft= 210 acc= 121 rate=0.576 tok/s=262.0
  explain_concept    pred= 192 draft= 204 acc= 121 rate=0.593 tok/s=262.2
  summarize          pred= 192 draft= 170 acc= 134 rate=0.788 tok/s=315.7
  qa_factual         pred= 192 draft= 171 acc= 133 rate=0.778 tok/s=313.9
  translation        pred= 192 draft= 186 acc= 128 rate=0.688 tok/s=291.5
  creative_short     pred= 192 draft= 203 acc= 122 rate=0.601 tok/s=266.1
  stepwise_math      pred= 192 draft= 182 acc= 130 rate=0.714 tok/s=297.6
  long_code_review   pred= 192 draft= 192 acc= 126 rate=0.656 tok/s=280.1
```
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, code review and further iteration on the code were done with AI after initial implementation.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
