### PR TITLE
fix: add Qwen3.5 MoE in_proj_qkv weight handling for SSM tensor export

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -332,6 +332,10 @@ class Qwen3NextModel(Qwen2MoeModel):
             z = z.permute(1, 0).contiguous()
             yield (self.format_tensor_name(gguf.MODEL_TENSOR.ATTN_QKV,  bid, ".weight"), qkv)
             yield (self.format_tensor_name(gguf.MODEL_TENSOR.ATTN_GATE, bid, ".weight"), z)
+        elif "in_proj_qkv.weight" in name:
+            # Qwen3.5 MoE: merged QKV without z component, already in correct order
+            data_torch = data_torch.permute(1, 0).contiguous()
+            yield (self.format_tensor_name(gguf.MODEL_TENSOR.ATTN_QKV, bid, ".weight"), data_torch)
         else:
             yield from super().modify_tensors(data_torch, name, bid)
 


### PR DESCRIPTION
The Qwen3.5 MoE architecture uses linear_attn.in_proj_qkv.weight (without 'z' component) for linear attention layers, unlike Qwen3Next which uses in_proj_qkvz.weight. Without this patch, the convert script silently drops all SSM tensors and produces only 483 tensors instead of the expected 733 for the qwen35moe architecture.

## Problem
- Qwen3.5 MoE models use merged QKV format for linear attention layers
- Qwen3NextModel.modify_tensors only handles in_proj_qkvz.weight (Qwen3Next format)
- Converting Qwen3.5 MoE drops all 210 SSM tensors, C++ fails with missing ssm_conv1d

## Fix
Add elif branch catching in_proj_qkv.weight and yielding as ATTN_QKV. No additional transformation needed for Qwen3.5 MoE format.

## Verification
Tested with Qwen3.6-35B-A3B-uncensored-heretic: 483 to 733 tensors, 210 SSM tensors restored, all 19 block-0 tensors present matching community GGUF format.