### PR TITLE
docker: fix locale crash in containers by installing en_US.UTF-8

### DIFF
--- a/.devops/cpu.Dockerfile
+++ b/.devops/cpu.Dockerfile
@@ -52,12 +52,15 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.source=$IMAGE_SOURCE
 
 RUN apt-get update \
-    && apt-get install -y libgomp1 curl \
+    && apt-get install -y libgomp1 curl locales \
+    && locale-gen en_US.UTF-8 \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 COPY --from=build /app/lib/ /app
 

--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -58,12 +58,15 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.source=$IMAGE_SOURCE
 
 RUN apt-get update \
-    && apt-get install -y libgomp1 curl \
+    && apt-get install -y libgomp1 curl locales \
+    && locale-gen en_US.UTF-8 \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 COPY --from=build /app/lib/ /app
 

--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -74,12 +74,15 @@ RUN mkdir /tmp/neo/ && cd /tmp/neo/ \
   && dpkg --install *.deb
 
 RUN apt-get update \
-    && apt-get install -y libgomp1 curl \
+    && apt-get install -y libgomp1 curl locales \
+    && locale-gen en_US.UTF-8 \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 ### Full
 FROM base AS full

--- a/.devops/musa.Dockerfile
+++ b/.devops/musa.Dockerfile
@@ -63,12 +63,15 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.source=$IMAGE_SOURCE
 
 RUN apt-get update \
-    && apt-get install -y libgomp1 curl \
+    && apt-get install -y libgomp1 curl locales \
+    && locale-gen en_US.UTF-8 \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 COPY --from=build /app/lib/ /app
 

--- a/.devops/openvino.Dockerfile
+++ b/.devops/openvino.Dockerfile
@@ -106,12 +106,15 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.source=$IMAGE_SOURCE
 
 RUN apt-get update \
-    && apt-get install -y libgomp1 libtbb12 curl wget ocl-icd-libopencl1 \
+    && apt-get install -y libgomp1 libtbb12 curl wget ocl-icd-libopencl1 locales \
+    && locale-gen en_US.UTF-8 \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 # Install GPU drivers
 ARG IGC_VERSION

--- a/.devops/rocm.Dockerfile
+++ b/.devops/rocm.Dockerfile
@@ -75,12 +75,15 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.source=$IMAGE_SOURCE
 
 RUN apt-get update \
-    && apt-get install -y libgomp1 curl \
+    && apt-get install -y libgomp1 curl locales \
+    && locale-gen en_US.UTF-8 \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 COPY --from=build /app/lib/ /app
 

--- a/.devops/s390x.Dockerfile
+++ b/.devops/s390x.Dockerfile
@@ -74,12 +74,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt install -y --no-install-recommends \
         # WARNING: Do not use libopenblas-openmp-dev. libopenblas-dev is faster.
         # See: https://github.com/ggml-org/llama.cpp/pull/15915#issuecomment-3317166506
-        curl libgomp1 libopenblas-dev && \
+        curl libgomp1 libopenblas-dev locales && \
+    locale-gen en_US.UTF-8 && \
     apt autoremove -y && \
     apt clean -y && \
     rm -rf /tmp/* /var/tmp/* && \
     find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete && \
     find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 # Copy llama.cpp libraries
 COPY --from=collector /llama.cpp/lib /usr/lib/s390x-linux-gnu

--- a/.devops/vulkan.Dockerfile
+++ b/.devops/vulkan.Dockerfile
@@ -49,12 +49,15 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 
 RUN apt-get update \
     && apt-get install -y libgomp1 curl libvulkan1 mesa-vulkan-drivers \
-    libglvnd0 libgl1 libglx0 libegl1 libgles2 \
+    libglvnd0 libgl1 libglx0 libegl1 libgles2 locales \
+    && locale-gen en_US.UTF-8 \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+ENV LANG=en_US.UTF-8
 
 COPY --from=build /app/lib/ /app
 


### PR DESCRIPTION
## Summary

Fixes #6267 — Running embedding models in Docker containers causes `locale::facet::_S_create_c_locale name not valid` crash because Ubuntu base images ship without generated locales.

## Changes

Added `locales` package installation and `locale-gen en_US.UTF-8` to the base stage across all 8 Ubuntu-based Dockerfiles in `.devops/`:

- `cpu.Dockerfile`
- `cuda.Dockerfile`  
- `rocm.Dockerfile`
- `vulkan.Dockerfile`
- `intel.Dockerfile`
- `openvino.Dockerfile`
- `musa.Dockerfile`
- `s390x.Dockerfile`

Each modified Dockerfile now:
1. Installs the `locales` package
2. Runs `locale-gen en_US.UTF-8`
3. Sets `ENV LANG=en_US.UTF-8`

CANN-based Dockerfiles were excluded as they use OpenEuler (not Ubuntu).

## Testing

The `locale-gen en_US.UTF-8` command is standard on Ubuntu and generates the locale at build time. The `LANG` env var ensures all processes in the container use the correct locale, preventing the `std::locale` facet crash when embedding models initialize.