### PR TITLE
server : add --slot-context for per-slot context size configuration

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3242,6 +3242,29 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--slot-context"}, "SLOT_CONTEXTS",
+        "assign custom context sizes to specific slots; comma-separated list of <slot_id>=<ctx_size> pairs (e.g. \"0=4096,1=8192\"); unlisted slots share the remaining context equally",
+        [](common_params & params, const std::string & value) {
+            std::istringstream ss(value);
+            std::string token;
+            while (std::getline(ss, token, ',')) {
+                const auto eq = token.find('=');
+                if (eq == std::string::npos) {
+                    throw std::invalid_argument("error: invalid --slot-context pair (expected <slot_id>=<ctx_size>): " + token + "\n");
+                }
+                const int    slot_id  = std::stoi(token.substr(0, eq));
+                const int32_t ctx_size = std::stoi(token.substr(eq + 1));
+                if (slot_id < 0) {
+                    throw std::invalid_argument("error: --slot-context slot_id must be non-negative\n");
+                }
+                if (ctx_size <= 0) {
+                    throw std::invalid_argument("error: --slot-context ctx_size must be positive\n");
+                }
+                params.slot_ctx_sizes[slot_id] = ctx_size;
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--lora-init-without-apply"},
         string_format("load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: %s)", params.lora_init_without_apply ? "enabled" : "disabled"),
         [](common_params & params) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3243,7 +3243,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"--slot-context"}, "SLOT_CONTEXTS",
-        "assign custom context sizes to specific slots; comma-separated list of <slot_id>=<ctx_size> pairs (e.g. \"0=4096,1=8192\"); unlisted slots share the remaining context equally",
+        "assign custom context sizes to specific slots; comma-separated list of <slot_id>=<ctx_size> pairs (e.g. \"0=4096,1=8192\"); unlisted slots share the remaining context equally; to allow a slot to exceed the default equal-split physical KV limit, --kv-unified must also be set",
         [](common_params & params, const std::string & value) {
             std::istringstream ss(value);
             std::string token;

--- a/common/common.h
+++ b/common/common.h
@@ -650,6 +650,9 @@ struct common_params {
 
     float slot_prompt_similarity = 0.1f;
 
+    // per-slot context sizes: slot_id -> n_ctx. slots not listed get equal share of remaining context.
+    std::map<int, int32_t> slot_ctx_sizes;
+
     // batched-bench params
     bool is_pp_shared   = false;
     bool is_tg_separate = false;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -896,6 +896,46 @@ private:
             n_ctx_slot = n_ctx_train;
         }
 
+        // compute per-slot context sizes (may differ when --slot-context is provided)
+        const int n_ctx_total = llama_n_ctx(ctx_tgt);
+        std::vector<int32_t> slot_ctx_vec(params_base.n_parallel, 0);
+
+        if (!params_base.slot_ctx_sizes.empty()) {
+            // validate slot ids and accumulate configured context
+            int32_t configured_sum = 0;
+            for (const auto & kv : params_base.slot_ctx_sizes) {
+                const int id = kv.first;
+                const int32_t sz = kv.second;
+                if (id >= params_base.n_parallel) {
+                    SRV_ERR("--slot-context: slot_id %d is out of range (n_parallel = %d)\n", id, params_base.n_parallel);
+                    return false;
+                }
+                configured_sum += sz;
+                slot_ctx_vec[id] = sz;
+            }
+            if (configured_sum > n_ctx_total) {
+                SRV_ERR("--slot-context: sum of configured slot contexts (%d) exceeds total context (%d)\n", configured_sum, n_ctx_total);
+                return false;
+            }
+            // distribute remaining context equally among unconfigured slots
+            const int n_unconfigured = params_base.n_parallel - (int) params_base.slot_ctx_sizes.size();
+            const int n_ctx_remaining = n_ctx_total - configured_sum;
+            const int n_ctx_per_remaining = n_unconfigured > 0 ? n_ctx_remaining / n_unconfigured : 0;
+            for (int i = 0; i < params_base.n_parallel; i++) {
+                if (slot_ctx_vec[i] == 0) {
+                    slot_ctx_vec[i] = n_ctx_per_remaining;
+                }
+                if (slot_ctx_vec[i] > n_ctx_train) {
+                    SRV_WRN("slot %d context (%d) exceeds training context (%d) - capping\n", i, slot_ctx_vec[i], n_ctx_train);
+                    slot_ctx_vec[i] = n_ctx_train;
+                }
+            }
+        } else {
+            for (int i = 0; i < params_base.n_parallel; i++) {
+                slot_ctx_vec[i] = n_ctx_slot;
+            }
+        }
+
         slots.clear();
 
         ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
@@ -934,7 +974,7 @@ private:
             slot.ctx_tgt = ctx_tgt;
             slot.ctx_dft = ctx_dft.get();
             slot.spec    = spec.get();
-            slot.n_ctx   = n_ctx_slot;
+            slot.n_ctx   = slot_ctx_vec[i];
 
             slot.mctx                   = mctx;
             slot.prompt.tokens.has_mtmd = mctx != nullptr;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -917,6 +917,15 @@ private:
                 SRV_ERR("--slot-context: sum of configured slot contexts (%d) exceeds total context (%d)\n", configured_sum, n_ctx_total);
                 return false;
             }
+            // warn if any slot exceeds the equal-split physical limit without --kv-unified
+            if (!params_base.kv_unified) {
+                for (const auto & kv : params_base.slot_ctx_sizes) {
+                    if (kv.second > n_ctx_slot) {
+                        SRV_WRN("--slot-context: slot %d context (%d) exceeds the physical KV cache limit per slot (%d) -- add --kv-unified to pool the KV cache, otherwise the slot will exhaust at %d tokens\n",
+                                kv.first, kv.second, n_ctx_slot, n_ctx_slot);
+                    }
+                }
+            }
             // distribute remaining context equally among unconfigured slots
             const int n_unconfigured = params_base.n_parallel - (int) params_base.slot_ctx_sizes.size();
             const int n_ctx_remaining = n_ctx_total - configured_sum;


### PR DESCRIPTION
## Motivation

When running `llama-server` with multiple slots (`-np N`), the total context is divided equally among all slots. This is suboptimal when workloads are heterogeneous — e.g. one slot handles long-context retrieval while others serve short chat turns.

**Example: coordinator + subagent pattern in
[OpenCode](https://fillumina.wordpress.com/2026/05/12/optimize-opencode-for-better-parallelism-and-efficiency-with-llama-server/)**

OpenCode allows pinning its main agent and subagents to separate slots via `id_slot`. The main (coordinator) agent accumulates a long conversation history and benefits from a larger context window, while subagents (`general`, `explore`, `summary`, `compaction`, `title`) each start fresh per task and typically need far less context. With equal slot sizing, the coordinator's large context budget is wasted on slots that will never use it. `--slot-context` lets you right-size each slot for its actual workload — e.g. give the coordinator slot the lion's share of tokens and split the remainder among the subagent slots.

**General case**: any scenario where one slot handles long-context retrieval or a persistent session while others serve short, stateless requests benefits from asymmetric slot sizing.

## Changes

- **`common/common.h`**: adds `std::map<int, int32_t> slot_ctx_sizes` to `common_params`
- **`common/arg.cpp`**: adds `--slot-context SLOT_CONTEXTS` argument (server-only), parsed as comma-separated `<slot_id>=<ctx_size>` pairs; `--kv-unified` requirement noted in help text
- **`tools/server/server-context.cpp`**: slot initialisation uses per-slot sizes when `--slot-context` is provided; unlisted slots share the remaining context equally; emits a warning when a
  configured slot size exceeds the physical per-slot KV cache limit without `--kv-unified`

## Behaviour

```
# example: 4 slots, 10000 total context, slot 0 explicitly assigned 4000
llama-server -np 4 --ctx-size 10000 --slot-context "0=4000"

# resulting slot contexts:
slot 0 → 4000   (configured)
slot 1 → 2000   (remaining 6000 / 3)
slot 2 → 2000
slot 3 → 2000
```

If `--slot-context` is not provided, existing behaviour is preserved (equal split).

## `--kv-unified` requirement

Without `--kv-unified`, the KV cache is physically pre-partitioned into equal segments at startup (`total_ctx / n_parallel` per slot). `--slot-context` sets a software limit on each slot, but the physical segment size is a hard ceiling — a slot configured to be larger than `total_ctx / n_parallel` will exhaust its physical KV cache before reaching its software limit.
 
To allow a slot to actually use more than the equal-split amount, `--kv-unified` must be enabled. This pools the KV cache so slots draw from it dynamically up to their individual limit. Slots remain isolated by sequence ID — one slot's tokens are never visible to or evictable by another.

The server emits a warning at startup if `--slot-context` expands any slot beyond the physical limit without `--kv-unified`:
```
W --slot-context: slot 0 context (2000) exceeds the physical KV cache limit per slot (1536)
    -- add --kv-unified to pool the KV cache, otherwise the slot will exhaust at 1536 tokens
```

## Validation

- `slot_id` out of range (≥ n_parallel): server exits with error
- sum of configured contexts exceeds total context: server exits with error  
- negative or zero ctx_size: rejected at argument parse time
- malformed pair (missing `=`): rejected at argument parse time

## Requirements

-  I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI disclosure: Claude Code was used in an assistive capacity during implementation, under the author's direction and with manual review of every change.