### PR TITLE
nemotron : support non-standard GQA, BPE tokenizer and domyn-small pre-type

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1338,6 +1338,9 @@ class TextModel(ModelBase):
         if chkhsh == "1431a23e583c97432bc230bff598d103ddb5a1f89960c8f1d1051aaa944d0b35":
             # ref: https://huggingface.co/sapienzanlp/Minerva-7B-base-v1.0
             res = "minerva-7b"
+        if chkhsh == "6e4d72c6e5260b90606e26a0931fa15e4b42ec6e97719d12919f2b1f93478262":
+            # ref: https://huggingface.co/domyn/Domyn-Small-v1.0
+            res = "domyn-small"
         if chkhsh == "7e57df22b1fe23a7b1e1c7f3dc4e3f96d43a4eb0836d0c6bdc3436d7b2f1c664":
             # ref: https://huggingface.co/tencent/Hunyuan-A13B-Instruct
             res = "hunyuan"

--- a/conversion/nemotron.py
+++ b/conversion/nemotron.py
@@ -112,9 +112,12 @@ class NemotronModel(TextModel):
     model_arch = gguf.MODEL_ARCH.NEMOTRON
 
     def set_vocab(self):
-        self._set_vocab_sentencepiece()
-        self.gguf_writer.add_pad_token_id(0)
-        self.gguf_writer.add_unk_token_id(1)
+        if (self.dir_model / "tokenizer.model").exists():
+            self._set_vocab_sentencepiece()
+            self.gguf_writer.add_pad_token_id(0)
+            self.gguf_writer.add_unk_token_id(1)
+        else:
+            self._set_vocab_gpt2()
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
@@ -128,7 +131,11 @@ class NemotronModel(TextModel):
         rot_pct = self.find_hparam(["partial_rotary_factor", "rope_pct", "rope_percent"])
         n_embd = self.find_hparam(["hidden_size", "n_embd"])
         n_head = self.find_hparam(["num_attention_heads", "n_head"])
-        self.gguf_writer.add_rope_dimension_count(int(rot_pct * n_embd) // n_head)
+        # Use explicit head_dim when available; fallback keeps standard Nemotron working.
+        # Without this, models where n_head * head_dim != n_embd (e.g. 48 heads, head_dim=128)
+        # produce the wrong rope dimension count.
+        head_dim = self.hparams.get("head_dim") or n_embd // n_head
+        self.gguf_writer.add_rope_dimension_count(int(rot_pct * head_dim))
 
         # * RopeScaling for Nemotron
         if "rope_scaling" not in self.hparams or self.hparams["rope_scaling"] is None:

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -353,6 +353,7 @@ struct llm_tokenizer_bpe : llm_tokenizer {
             case LLAMA_VOCAB_PRE_TYPE_CODESHELL:
             case LLAMA_VOCAB_PRE_TYPE_EXAONE:
             case LLAMA_VOCAB_PRE_TYPE_MINERVA:
+            case LLAMA_VOCAB_PRE_TYPE_DOMYN_SMALL:
                 regex_exprs = {
                     "\\p{N}",
                     "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)",
@@ -2106,6 +2107,10 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             } else if (
                 tokenizer_pre == "minerva-7b") {
                 pre_type = LLAMA_VOCAB_PRE_TYPE_MINERVA;
+            } else if (
+                tokenizer_pre == "domyn-small") {
+                pre_type = LLAMA_VOCAB_PRE_TYPE_DOMYN_SMALL;
+                escape_whitespaces = true;
             } else if (
                 tokenizer_pre == "megrez") {
                 pre_type = LLAMA_VOCAB_PRE_TYPE_QWEN2;

--- a/src/llama-vocab.h
+++ b/src/llama-vocab.h
@@ -60,6 +60,7 @@ enum llama_vocab_pre_type {
     LLAMA_VOCAB_PRE_TYPE_JAIS2           = 49,
     LLAMA_VOCAB_PRE_TYPE_GEMMA4          = 50,
     LLAMA_VOCAB_PRE_TYPE_SARVAM_MOE      = 51,
+    LLAMA_VOCAB_PRE_TYPE_DOMYN_SMALL     = 52,
 };
 
 struct LLM_KV;

--- a/src/models/nemotron.cpp
+++ b/src/models/nemotron.cpp
@@ -24,8 +24,11 @@ void llama_model_nemotron::load_arch_tensors(llama_model_loader &) {
         layer.attn_norm   = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
         layer.attn_norm_b = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "bias", i), {n_embd}, 0);
 
-        create_tensor_qkv(layer, i, n_embd, n_embd, n_embd_gqa, n_embd_gqa, 0);
-        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd, n_embd}, 0);
+        // n_embd_head_k * n_head equals n_embd for standard Nemotron (32 heads),
+        // but differs for models with non-standard GQA (e.g. 48 Q heads, head_dim=128).
+        const int64_t n_embd_q = n_embd_head_k * n_head;
+        create_tensor_qkv(layer, i, n_embd, n_embd_q, n_embd_gqa, n_embd_gqa, 0);
+        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_q, n_embd}, 0);
 
         // optional bias tensors
         layer.wo_b = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "bias", i), {n_embd}, TENSOR_NOT_REQUIRED);


### PR DESCRIPTION
## Overview

This PR adds support for `domyn/Domyn-Small-v1.0`, fixing issues in both the vocab decoder and the Nemotron model loader/converter.

Vocab decoder: without a dedicated pre-tokenizer type, the current code routes the Domyn-Small tokenizer through the generic GPT-2 BPE decode path, which cannot handle Metaspace-encoded spaces (▁ U+2581) and produces corrupted output for every space-prefixed token. This PR adds `LLAMA_VOCAB_PRE_TYPE_DOMYN_SMALL = 52` in `llama-vocab.h` and a new branch in `llama-vocab.cpp` that sets `escape_whitespaces = true`. Domyn-Small shares the same regex rules as minerva-7b (same tokenizer family), but we kept that path untouched and added a new key.

Nemotron model loader: `create_tensor_qkv` was called with n_embd for the Q-projection width and` layer.wo` was shaped as `{n_embd, n_embd}`. For a 48-head model like Domyn-Small this causes a tensor shape mismatch crash on load. Fixed to use `n_embd_head_k * n_head `explicitly for both.

Nemotron converter: the formula `int(rot_pct * n_embd) // n_head` produces 42 for a 48-head model instead of the correct 64. Fixed to read `head_dim `from the model config (falling back to `n_embd // n_head `if absent). Additionally, `NemotronModel.set_vocab() `unconditionally called `_set_vocab_sentencepiece()`, crashing when no `tokenizer.model` file is present. Added a fallback to `_set_vocab_gpt2()` for BPE-only tokenizers, and registered the Domyn-Small tokenizer hash in `get_vocab_base_pre()`.

## Additional information

Tested with domyn/Domyn-Small-v1.0 (BF16 GGUF, 45/45 CTest pass).

Note that this PR only affects models that already have tokenizer.ggml.pre = "domyn-small" in their GGUF.

Hugging Face model link at https://huggingface.co/domyn/Domyn-Small-v1.0

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: Yes, I used Claude Code to help locate relevant code paths and draft this PR description. All changes were reviewed and tested by me.