### PR TITLE
ggml-cuda: tune RDNA3 Q6_K MMVQ nwarps

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -359,10 +359,11 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
                 case GGML_TYPE_Q5_1:
                 case GGML_TYPE_Q8_0:
                 case GGML_TYPE_Q4_K:
-                case GGML_TYPE_IQ4_NL:
                     return 8;
                 case GGML_TYPE_Q6_K:
                     return 2;
+                case GGML_TYPE_IQ4_NL:
+                    return 8;  
                 default:
                     return 1;
             }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -363,7 +363,7 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
                 case GGML_TYPE_Q6_K:
                     return 2;
                 case GGML_TYPE_IQ4_NL:
-                    return 8;  
+                    return 8;
                 default:
                     return 1;
             }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -359,9 +359,10 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
                 case GGML_TYPE_Q5_1:
                 case GGML_TYPE_Q8_0:
                 case GGML_TYPE_Q4_K:
-                case GGML_TYPE_Q6_K:
                 case GGML_TYPE_IQ4_NL:
                     return 8;
+                case GGML_TYPE_Q6_K:
+                    return 2;
                 default:
                     return 1;
             }


### PR DESCRIPTION
## Overview

This PR changes the RDNA3 MMVQ warp count selection for `GGML_TYPE_Q6_K` with `ncols_dst == 1` from 8 warps to 2 warps.

The change is limited to the `MMVQ_PARAMETERS_RDNA3_0` path in `ggml/src/ggml-cuda/mmvq.cu`.

It does not change quantization logic or model output math. It only changes the launch geometry used for this RDNA3 Q6_K MMVQ case.

I tested this on an AMD Radeon Pro W7800 (`gfx1100`) with ROCm/HIP. This improved Q6_K decode throughput in repeated local benchmarks.

## Additional information

Test system:

- GPU: AMD Radeon Pro W7800 48GB, `gfx1100`
- ROCm: 7.2.3 container
- Backend: HIP

Models tested:

- Qwen3.6-35B-A3B-UD-Q6_K
- Qwen3-30B-A3B-Instruct-2507-Q6_K
- Llama-3.2-3B-Instruct-Q6_K
- Qwen2.5-1.5B-Instruct-Q6_K

Benchmark results on AMD Radeon Pro W7800 (`gfx1100`), ROCm/HIP, 3 runs:

| Model | Build | Q6_K `n=1` perf | `tg128` | mixed prompt/decode |
| --- | --- | ---: | ---: | ---: |
| Qwen3.6-35B-A3B-UD-Q6_K | baseline, `8` warps | `71.26 us`, `1.65 TFLOPS` | `76.22 +/- 0.14 / 75.53 +/- 0.09 t/s` | `pp4096+tg128 1154.42 +/- 19.00 t/s` |
| Qwen3.6-35B-A3B-UD-Q6_K | patched, `2` warps | `68.26 us`, `1.72 TFLOPS` | `86.08 +/- 0.14 / 85.68 +/- 0.07 t/s` | `pp4096+tg128 1294.05 +/- 4.38 t/s` |
| Qwen3-30B-A3B-Instruct-2507-Q6_K | baseline, `8` warps | `74.05 us`, `1.59 TFLOPS` | `48.93 +/- 0.40 / 49.16 +/- 0.09 t/s` | `pp4096+tg128 590.07 +/- 0.57 t/s` |
| Qwen3-30B-A3B-Instruct-2507-Q6_K | patched, `2` warps | `70.61 us`, `1.66 TFLOPS` | `53.28 +/- 0.46 / 53.47 +/- 0.09 t/s` | `pp4096+tg128 594.41 +/- 12.46 t/s` |
| Llama-3.2-3B-Instruct-Q6_K | baseline, `8` warps | `70.02 us`, `1.68 TFLOPS` | `125.11 +/- 0.18 / 124.12 +/- 0.15 t/s` | `pp1024+tg128 901.24 +/- 2.03 t/s` |
| Llama-3.2-3B-Instruct-Q6_K | patched, `2` warps | `69.07 us`, `1.70 TFLOPS` | `145.05 +/- 0.14 / 144.48 +/- 0.04 t/s` | `pp1024+tg128 1025.25 +/- 0.60 t/s` |
| Qwen2.5-1.5B-Instruct-Q6_K | baseline, `8` warps | `71.56 us`, `1.64 TFLOPS` | `171.04 +/- 0.32 / 170.22 +/- 0.10 t/s` | `pp1024+tg128 1321.98 +/- 1.54 t/s` |
| Qwen2.5-1.5B-Instruct-Q6_K | patched, `2` warps | `67.61 us`, `1.74 TFLOPS` | `209.50 +/- 0.13 / 208.62 +/- 0.44 t/s` | `pp1024+tg128 1576.68 +/- 1.26 t/s` |

The benchmark results show consistent decode improvements across two MoE Q6_K models and two dense Q6_K models.

Correctness check:

- Baseline and patched runs passed `test-backend-ops -o MUL_MAT -b ROCm0 -p q6_K`, `11/11`.

## Requirements

- Yes, I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used assistively for experiment organization and wording review. I reviewed the code change, benchmark results, and final PR text myself, and I can explain the submitted change.