### PR TITLE
ggml: fix SCHED_DEBUG output when logging with timestamps

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <algorithm>
+#include <string>
 #include <vector>
 
 #ifdef __APPLE__
@@ -947,16 +948,20 @@ static void ggml_backend_sched_print_assignments(ggml_backend_sched_t sched, str
     for (int i = 0; i < graph->n_nodes; i++) {
         if (cur_split < sched->n_splits && i == sched->splits[cur_split].i_start) {
             ggml_backend_t split_backend = sched->backends[sched->splits[cur_split].backend_id];
-            GGML_LOG_DEBUG("\n## SPLIT #%d: %s # %d inputs", cur_split, ggml_backend_name(split_backend),
-                sched->splits[cur_split].n_inputs);
+
+            std::string formatted_inputs;
+            char        tmp[64];
             for (int j = 0; j < sched->splits[cur_split].n_inputs; j++) {
                 if (j == 0) {
-                    GGML_LOG_DEBUG(": ");
+                    formatted_inputs.append(": ");
                 }
-                GGML_LOG_DEBUG("[%s (%5.5s)] ", sched->splits[cur_split].inputs[j]->name,
-                    fmt_size(ggml_nbytes(sched->splits[cur_split].inputs[j])));
+                snprintf(tmp, sizeof(tmp), "[%s (%5.5s)] ", sched->splits[cur_split].inputs[j]->name,
+                         fmt_size(ggml_nbytes(sched->splits[cur_split].inputs[j])));
+                formatted_inputs.append(tmp);
             }
             GGML_LOG_DEBUG("\n");
+            GGML_LOG_DEBUG("## SPLIT #%d: %s # %d inputs %s\n", cur_split, ggml_backend_name(split_backend),
+                           sched->splits[cur_split].n_inputs, formatted_inputs.c_str());
             cur_split++;
         }
         struct ggml_tensor * node = graph->nodes[i];
@@ -965,19 +970,24 @@ static void ggml_backend_sched_print_assignments(ggml_backend_sched_t sched, str
         }
         if (sched->debug > 1) {
             ggml_backend_t tensor_backend = ggml_backend_sched_get_tensor_backend(sched, node);
-            GGML_LOG_DEBUG("node #%3d (%10.10s): %20.20s (%5.5s) [%5.5s %8.8s] use=%d,c=%d:", i, ggml_op_desc(node), node->name,
-                fmt_size(ggml_nbytes(node)), tensor_backend ? ggml_backend_name(tensor_backend) : "NULL", GET_CAUSE(node),
-                graph->use_counts[ggml_hash_find(&graph->visited_hash_set, node)], node->flags & GGML_TENSOR_FLAG_COMPUTE ? 1 : 0);
+            std::string    formatted_inputs;
+            char           tmp[64];
             for (int j = 0; j < GGML_MAX_SRC; j++) {
                 struct ggml_tensor * src = node->src[j];
                 if (src == NULL) {
                     continue;
                 }
                 ggml_backend_t src_backend = ggml_backend_sched_get_tensor_backend(sched, src);
-                GGML_LOG_DEBUG(" %20.20s (%5.5s) [%5.5s %8.8s]", src->name,
-                    fmt_size(ggml_nbytes(src)), src_backend ? ggml_backend_name(src_backend) : "NULL", GET_CAUSE(src));
+
+                snprintf(tmp, sizeof(tmp), " %20.20s (%5.5s) [%5.5s %8.8s]", src->name, fmt_size(ggml_nbytes(src)),
+                         src_backend ? ggml_backend_name(src_backend) : "NULL", GET_CAUSE(src));
+                formatted_inputs.append(tmp);
             }
-            GGML_LOG_DEBUG("\n");
+            GGML_LOG_DEBUG("node #%3d (%10.10s): %20.20s (%5.5s) [%5.5s %8.8s] use=%d,c=%d: %s\n", i,
+                           ggml_op_desc(node), node->name, fmt_size(ggml_nbytes(node)),
+                           tensor_backend ? ggml_backend_name(tensor_backend) : "NULL", GET_CAUSE(node),
+                           graph->use_counts[ggml_hash_find(&graph->visited_hash_set, node)],
+                           node->flags & GGML_TENSOR_FLAG_COMPUTE ? 1 : 0, formatted_inputs.c_str());
         }
     }
 }


### PR DESCRIPTION
## Overview

Because GGML_SCHED_DEBUG output calls GGML_LOG_DEBUG multiple times to output a line, when logging with timestamps (e.g. with llama-server recently), the log lines will have extra timestamps inserted. This pr changes it to assemble the input descriptions in a temp string and emit the whole line with a single log.

Before:
```
## SPLIT #0: CPU # 0 inputs0.30.384.132 D
0.30.384.133 D node #  0 (  GET_ROWS):      mtp_tok_embd-64 (  40K) [  CPU         ] use=1,c=1:0.30.384.133 D     token_embd.weight (2425M) [ BLAS         ]0.30.384.133 D                leaf_4 (   0K) [  CPU         ]0.30.384.133 D
0.30.384.133 D
## SPLIT #1: Metalium # 2 inputs0.30.384.134 D : 0.30.384.134 D [mtp_tok_embd-64 (  40K)] 0.30.384.134 D [mtp_h_input (  40K)] 0.30.384.134 D
0.30.384.135 D node #  1 (  RMS_NORM):              norm-64 (  40K) [Metal         ] use=1,c=1:0.30.384.135 D  Metalium#mtp_tok_emb (  40K) [ NULL         ]0.30.384.135 D
0.30.384.135 D node #  2 (       MUL):         mtp_enorm-64 (  40K) [Metal         ] use=1,c=1:0.30.384.136 D               norm-64 (  40K) [Metal         ]0.30.384.136 D  blk.64.nextn.enorm.w (  20K) [Metal         ]0.30.384.136 D
0.30.384.136 D node #  3 (  RMS_NORM):              norm-64 (  40K) [Metal         ] use=1,c=1:0.30.384.137 D  Metalium#mtp_h_input (  40K) [ NULL         ]0.30.384.137 D
0.30.384.137 D node #  4 (       MUL):         mtp_hnorm-64 (  40K) [Metal         ] use=1,c=1:0.30.384.138 D               norm-64 (  40K) [Metal         ]0.30.384.138 D  blk.64.nextn.hnorm.w (  20K) [Metal         ]0.30.384.138 D
0.30.384.138 D node #  5 (    CONCAT):        mtp_concat-64 (  80K) [Metal         ] use=1,c=1:0.30.384.138 D          mtp_enorm-64 (  40K) [Metal         ]0.30.384.139 D          mtp_hnorm-64 (  40K) [Metal         ]0.30.384.139 D
0.30.384.139 D node #  6 (   MUL_MAT):       mtp_eh_proj-64 (  40K) [Metal         ] use=2,c=1:0.30.384.139 D  blk.64.nextn.eh_proj (  53M) [Metal         ]0.30.384.139 D         mtp_concat-64 (  80K) [Metal         ]0.30.384.139 D
0.30.384.140 D
## SPLIT #2: CUDA0 # 7 inputs0.30.384.140 D : 0.30.384.140 D [mtp_eh_proj-64 (  40K)] 0.30.384.140 D [leaf_10 (   0K)] 0.30.384.140 D [attn_inp_k_rot ( 256K)] 0.30.384.140 D [attn_inp_v_rot (  16K)] 0.30.384.141 D [leaf_15 (   0K)] 0.30.384.141 D [leaf_17 (   0K)] 0.30.384.141 D [attn_inp_kq_mask (   2K)] 0.30.384.141 D
```

After:
```
0.29.954.704 D ## SPLIT #0: CPU # 0 inputs
0.29.954.708 D node #  0 (  GET_ROWS):      mtp_tok_embd-64 (  40K) [  CPU         ] use=1,c=1:     token_embd.weight (2425M) [ BLAS         ]               leaf_4 (   0K) [  CPU         ]
0.29.954.709 D
0.29.954.709 D ## SPLIT #1: Metalium # 2 inputs : [mtp_tok_embd-64 (  40K)] [mtp_h_input (  40K)]
0.29.954.711 D node #  1 (  RMS_NORM):              norm-64 (  40K) [Metal         ] use=1,c=1:  Metalium#mtp_tok_emb (  40K) [ NULL         ]
0.29.954.712 D node #  2 (       MUL):         mtp_enorm-64 (  40K) [Metal         ] use=1,c=1:               norm-64 (  40K) [Metal         ] blk.64.nextn.enorm.w (  20K) [Metal         ]
0.29.954.713 D node #  3 (  RMS_NORM):              norm-64 (  40K) [Metal         ] use=1,c=1:  Metalium#mtp_h_input (  40K) [ NULL         ]
0.29.954.714 D node #  4 (       MUL):         mtp_hnorm-64 (  40K) [Metal         ] use=1,c=1:               norm-64 (  40K) [Metal         ] blk.64.nextn.hnorm.w (  20K) [Metal         ]
0.29.954.715 D node #  5 (    CONCAT):        mtp_concat-64 (  80K) [Metal         ] use=1,c=1:          mtp_enorm-64 (  40K) [Metal         ]         mtp_hnorm-64 (  40K) [Metal         ]
0.29.954.716 D node #  6 (   MUL_MAT):       mtp_eh_proj-64 (  40K) [Metal         ] use=2,c=1:  blk.64.nextn.eh_proj (  53M) [Metal         ]        mtp_concat-64 (  80K) [Metal         ]
0.29.954.717 D
0.29.954.718 D ## SPLIT #2: CUDA0 # 7 inputs : [mtp_eh_proj-64 (  40K)] [leaf_10 (   0K)] [attn_inp_k_rot ( 256K)] [attn_inp_v_rot (  16K)] [leaf_15 (   0K)] [leaf_17 (   0K)] [attn_inp_kq_mask (   2K)]
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, better autocomplete
