### PR TITLE
[AI Policy Violation] Use password input type for WebUI API key field to prevent browser autofill in clear text

### DIFF
--- a/tools/ui/src/lib/components/app/server/ServerErrorSplash.svelte
+++ b/tools/ui/src/lib/components/app/server/ServerErrorSplash.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import { AlertTriangle, RefreshCw, Key, CheckCircle, XCircle } from '@lucide/svelte';
+	import {
+		AlertTriangle,
+		RefreshCw,
+		Key,
+		CheckCircle,
+		XCircle,
+		Eye,
+		EyeOff
+	} from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
@@ -39,6 +47,7 @@
 
 	let apiKeyInput = $state('');
 	let showApiKeyInput = $state(false);
+	let showApiKeyValue = $state(false);
 	let apiKeyState = $state<'idle' | 'validating' | 'success' | 'error'>('idle');
 	let apiKeyError = $state('');
 
@@ -52,6 +61,7 @@
 
 	function handleShowApiKeyInput() {
 		showApiKeyInput = true;
+		showApiKeyValue = false;
 		// Pre-fill with current API key if it exists
 		const currentConfig = config();
 		apiKeyInput = currentConfig.apiKey?.toString() || '';
@@ -159,10 +169,13 @@
 					<div class="relative">
 						<Input
 							id="api-key-input"
+							type={showApiKeyValue ? 'text' : 'password'}
+							autocomplete="off"
+							spellcheck="false"
 							placeholder="Enter your API key..."
 							bind:value={apiKeyInput}
 							onkeydown={handleApiKeyKeydown}
-							class="w-full pr-10 {apiKeyState === 'error'
+							class="w-full pr-16 {apiKeyState === 'error'
 								? 'border-destructive'
 								: apiKeyState === 'success'
 									? 'border-green-500'
@@ -170,24 +183,37 @@
 							disabled={apiKeyState === 'validating'}
 						/>
 						{#if apiKeyState === 'validating'}
-							<div class="absolute top-1/2 right-3 -translate-y-1/2">
+							<div class="absolute top-1/2 right-10 -translate-y-1/2">
 								<RefreshCw class="h-4 w-4 animate-spin text-muted-foreground" />
 							</div>
 						{:else if apiKeyState === 'success'}
 							<div
-								class="absolute top-1/2 right-3 -translate-y-1/2"
+								class="absolute top-1/2 right-10 -translate-y-1/2"
 								in:scale={{ duration: 200, start: 0.8 }}
 							>
 								<CheckCircle class="h-4 w-4 text-green-500" />
 							</div>
 						{:else if apiKeyState === 'error'}
 							<div
-								class="absolute top-1/2 right-3 -translate-y-1/2"
+								class="absolute top-1/2 right-10 -translate-y-1/2"
 								in:scale={{ duration: 200, start: 0.8 }}
 							>
 								<XCircle class="h-4 w-4 text-destructive" />
 							</div>
 						{/if}
+						<button
+							type="button"
+							onclick={() => (showApiKeyValue = !showApiKeyValue)}
+							class="absolute top-1/2 right-3 inline-flex h-4 w-4 -translate-y-1/2 items-center justify-center text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+							aria-label={showApiKeyValue ? 'Hide API key' : 'Show API key'}
+							disabled={apiKeyState === 'validating'}
+						>
+							{#if showApiKeyValue}
+								<EyeOff class="h-4 w-4" />
+							{:else}
+								<Eye class="h-4 w-4" />
+							{/if}
+						</button>
 					</div>
 					{#if apiKeyError}
 						<p class="text-sm text-destructive" in:fly={{ y: -10, duration: 200 }}>
@@ -220,6 +246,7 @@
 					<Button
 						onclick={() => {
 							showApiKeyInput = false;
+							showApiKeyValue = false;
 							apiKeyState = 'idle';
 							apiKeyError = '';
 						}}

--- a/tools/ui/src/lib/constants/settings-registry.ts
+++ b/tools/ui/src/lib/constants/settings-registry.ts
@@ -78,6 +78,7 @@ const SETTINGS_REGISTRY: Record<string, SettingsSectionEntry> = {
 				help: `Set the API Key if you are using <code> ${CLI_FLAGS.API_KEY} </code> option for the server.`,
 				defaultValue: '',
 				type: SettingsFieldType.INPUT,
+				isSensitive: true,
 				section: SETTINGS_SECTION_SLUGS.GENERAL
 			},
 			{
@@ -746,6 +747,7 @@ export const SETTINGS_CHAT_SECTIONS: SettingsSection[] = [
 			type: s.type,
 			isExperimental: s.isExperimental,
 			isPositiveInteger: s.isPositiveInteger,
+			isSensitive: s.isSensitive,
 			help: s.help,
 			options: s.options
 		}))

--- a/tools/ui/tests/stories/ServerErrorSplash.stories.svelte
+++ b/tools/ui/tests/stories/ServerErrorSplash.stories.svelte
@@ -1,0 +1,34 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import { expect } from 'storybook/test';
+	import ServerErrorSplash from '$lib/components/app/server/ServerErrorSplash.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Components/Server/ServerErrorSplash',
+		component: ServerErrorSplash,
+		parameters: {
+			layout: 'fullscreen'
+		}
+	});
+</script>
+
+<Story
+	name="ApiKeyInput"
+	args={{
+		error: '401 Unauthorized',
+		showRetry: false
+	}}
+	play={async ({ canvas, userEvent }) => {
+		const showInputButton = await canvas.findByRole('button', { name: 'Enter API Key' });
+		await userEvent.click(showInputButton);
+
+		const apiKeyInput = await canvas.findByLabelText('API Key');
+		await expect(apiKeyInput).toHaveAttribute('type', 'password');
+		await expect(apiKeyInput).toHaveAttribute('autocomplete', 'off');
+
+		const showValueButton = await canvas.findByRole('button', { name: 'Show API key' });
+		await userEvent.click(showValueButton);
+
+		await expect(apiKeyInput).toHaveAttribute('type', 'text');
+	}}
+/>


### PR DESCRIPTION
## Summary

1. **ServerErrorSplash.svelte**: replace the plain `<Input>` for `apiKeyInput` with `type={showApiKeyInput ? 'text' : 'password'}` and add `autocomplete="off"` plus `spellcheck="false"`. Keep the existing show/hide toggle (eye icon) — masking is already the default state. Confirm the bound model still drives `currentConfig.apiKey` unchanged.
2. **settings-registry.ts**: change the API Key entry's `type` from the default text variant to a `password` / sensitive variant (the registry already has a way to mark sensitive fields — `apiKey` is excluded from non-sensitive export in `tools/ui/src/lib/stores/settings.svelte.ts`, so a `type: 'password'` flag is the right knob; if no such variant exists yet, add `sensitive: true` and have the settings renderer use `type="password"` + `autocomplete="off"` when set).
3. **Tests**: extend the existing Storybook/Playwright fixtures under `tools/ui/tests/stories/` to assert the API-key input element renders with `type="password"` and `autocomplete="off"` by default, and that the visibility toggle flips the type to `text`. Keep the test minimal — one new spec block in the closest existing test file for `ServerErrorSplash`.

Notes:

- Do not change how `apiKey` is stored or transmitted; this is a presentation-only fix.
- The Svelte input wrapper (`<Input>` from `tools/ui/src/lib/components/ui/input/input.svelte`) already forwards `type` and `autocomplete` to the underlying element — no component change needed.
- Per `CONTRIBUTING.md`, CPU/UI-only change, no third-party deps, no ggml impact, easy to review.
- This is a defect fix for a security-adjacent UX bug, exactly the kind of low-touch contribution the repo accepts.

## Why this matters

Issue #23254 reports that the llama-server WebUI API-key input renders as a normal text input. After saving an API key and reopening the page (or clearing cookies), the browser exposes the previously entered API key as an autofill suggestion in clear text inside the input. The reporter ran b9210 on Linux/Chromium 148.

Two surfaces collect the API key:

1. `tools/ui/src/lib/components/app/server/ServerErrorSplash.svelte` — the splash shown when the server returns an auth error. It binds `apiKeyInput` to a plain `<Input>` and toggles `showApiKeyInput` for visibility.
2. `tools/ui/src/lib/constants/settings-registry.ts` — the API Key field rendered in the settings dialog, currently registered as a normal text setting.

Browsers (including Chromium 148) only redact autofill suggestions when the underlying input is `type="password"` with `autocomplete="current-password"` (or `off`). The current implementation does neither.

## Testing

1. **Manual repro from the issue**: build webui, start server with `--api-key-file`, open in Chromium, enter a key, save, clear cookies, reopen. The API key field must show no autofill suggestion (browser must not surface the previously typed value as a hint).
2. **Show/hide toggle**: clicking the visibility toggle flips between dots and the actual value without losing the bound model.
3. **Settings dialog**: API key field in settings dialog renders masked; export-without-sensitive still excludes the key.
4. **Unit/story test**: `ServerErrorSplash` story asserts `<input type="password" autocomplete="off">` is in the DOM by default.
5. **Regression**: existing Playwright `tools/ui/tests/` flows that interact with the API key input still pass (locate by label, not by type attribute).

AI usage disclosure (per CONTRIBUTING.md): planning and scaffolding used Claude as an assistive tool; the implementing contributor must hand-author the diff, manually verify reproduction, and be prepared to defend every line per the project's AI policy.

Fixes #23254

AI was used for assistance.
