### PR TITLE
[AI Policy Violation] fix: guard cpy_scalar_transpose against strided dst in ggml-cuda cpy dispatch

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -404,8 +404,10 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
     char * src1_ddc = (char *) src1->data;
 
     const bool contiguous_srcs = ggml_is_contiguous(src0) && ggml_is_contiguous(src1);
+    // cpy_scalar_transpose writes dst contiguously and does not account for dst strides.
     const bool can_be_transposed = nb01 == (int64_t)ggml_element_size(src0) &&
-        src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0);
+        src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0) &&
+        ggml_is_contiguous(src1);
 
     if (src0->type == src1->type && contiguous_srcs) {
         GGML_ASSERT(ggml_nbytes(src0) == ggml_nbytes(src1));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2956,6 +2956,53 @@ struct test_cpy : public test_case {
     }
 };
 
+struct test_cpy_view_dst : public test_case {
+    static constexpr int64_t max_t  = 8;
+    static constexpr int64_t d_head = 4;
+    static constexpr int64_t pos    = 3;
+
+    ggml_tensor * cache = nullptr;
+
+    std::string vars() override {
+        return VARS_TO_STR3(max_t, d_head, pos);
+    }
+
+    bool run_whole_graph() override { return true; }
+
+    std::vector<ggml_tensor *> fusion_test_nodes() override {
+        return { cache };
+    }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * src = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, d_head);
+        ggml_set_param(src);
+        ggml_set_name(src, "src");
+
+        cache = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, max_t, d_head);
+        ggml_set_param(cache);
+        ggml_set_name(cache, "cache");
+
+        ggml_tensor * slot = ggml_view_2d(ctx, cache, 1, d_head, cache->nb[1], pos*cache->nb[0]);
+        ggml_set_name(slot, "slot");
+
+        ggml_tensor * out = ggml_cpy(ctx, src, slot);
+        ggml_set_name(out, "out");
+
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        ggml_tensor * src   = ggml_get_tensor(ctx, "src");
+        ggml_tensor * cache = ggml_get_tensor(ctx, "cache");
+
+        const std::array<float, d_head> src_data = { 1.0f, 2.0f, 3.0f, 4.0f };
+        const std::array<float, max_t*d_head> cache_data = {};
+
+        ggml_backend_tensor_set(src, src_data.data(), 0, ggml_nbytes(src));
+        ggml_backend_tensor_set(cache, cache_data.data(), 0, ggml_nbytes(cache));
+    }
+};
+
 // GGML_OP_CONT
 struct test_cont : public test_case {
     const ggml_type type;
@@ -8076,6 +8123,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_cpy(GGML_TYPE_I32, GGML_TYPE_I32, {256, 4, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}, true));
     test_cases.emplace_back(new test_cpy(GGML_TYPE_I32, GGML_TYPE_I32, {256, 1, 4, 1}, {1, 2, 0, 3}, {0, 0, 0, 0}));
     test_cases.emplace_back(new test_cpy(GGML_TYPE_F32, GGML_TYPE_F32, {256, 1, 4, 1}, {1, 2, 0, 3}, {0, 0, 0, 0}));
+    test_cases.emplace_back(new test_cpy_view_dst());
 
     for (ggml_type type_dst : { GGML_TYPE_F32, GGML_TYPE_I32, GGML_TYPE_F16, GGML_TYPE_BF16 }) {
         for (bool use_view_slice : { true, false }) {


### PR DESCRIPTION
## Summary

Land the reporter's minimal guard in `ggml/src/ggml-cuda/cpy.cu` against `ggml-org/llama.cpp`. Change the `can_be_transposed` predicate so the fast transpose dispatch is selected only when the destination is contiguous, falling through to the general `cpy_scalar` kernel (which already uses `nb10/nb11/nb12/nb13` correctly) when the destination is a strided view.

```diff
 const bool contiguous_srcs = ggml_is_contiguous(src0) && ggml_is_contiguous(src1);
+// cpy_scalar_transpose writes dst contiguously (no nb1[i] strides) — it is only
+// correct when dst itself is contiguous. Without this guard, a strided dst
+// (e.g. view_2d into a KV-cache slot) gets its source bytes packed at the
+// offset instead of distributed across rows.
 const bool can_be_transposed = nb01 == (int64_t)ggml_element_size(src0) &&
-    src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0);
+    src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0) &&
+    ggml_is_contiguous(src1);
```

The fast transpose path is preserved for its intended case (contiguous-to-contiguous transpose, which is what `cpy_scalar_transpose` was designed for: F32 transpose tiled at 32x32). Strided destinations fall through to `cpy_scalar` which already correctly indexes via `nb10/nb11/nb12/nb13`.

Add a regression test under `tests/test-backend-ops.cpp` in the existing `CPY` test family: build the reporter's `view_2d` slot pattern with `MAX_T=8, D_HEAD=4, POS=3` and assert CUDA matches CPU at every output cell. Match the existing `test_cases.emplace_back(new test_cpy(...))` style. Keep the test small (one shape) so it runs in the parameterized `test-backend-ops` battery without bloating runtime.

Submit against `ggml-org/llama.cpp` per the CONTRIBUTING.md routing (and per ggerganov's standing guidance on #1467 that changes propagate from llama.cpp to the ggml mirror). Reference issue ggml-org/ggml#1497 in the PR body and credit @OriPekelman as the reporter and patch author. Keep the PR additive: the predicate guard plus one test case, no kernel changes.

## Why this matters

`ggml_cpy` on the CUDA backend silently writes a contiguous block of source bytes into a strided `view_2d` destination, ignoring `nb1`. Symptom (from reporter OriPekelman, repro on CUDA 13.0, sm_121a Blackwell): a `view_2d` slot meant to hold one column of a `(d_head, max_T)` V-cache receives `[1 2 3 4]` packed contiguously at the offset instead of one value per row separated by `nb1`. The CPU backend handles the same call correctly. Reporter bisected the issue to the dispatch logic at `ggml/src/ggml-cuda/cpy.cu:406-408`: `can_be_transposed` is computed from `src0`'s strides only (`nb01 == element_size && src0->ne[3] == 1 && nb02 == ne00*ne01*element_size`). For a KV-write the matmul result `src0` has `ne=[1, d_head]` and trivially satisfies this. The `cpy_scalar_transpose` kernel (lines 43-90) writes `dst[imat*n + (ty+j)*ne00 + tx] = tile2[col]` — a contiguous packing keyed off `ne00`/`ne01` with no `nb1[i]` strides — which is only correct when `dst` is also contiguous. Reporter posted a verified one-line patch on 2026-05-19 (require `ggml_is_contiguous(src1)` in `can_be_transposed`). End-to-end transformer parity on Qwen2.5-1.5B at every layer 1..28 post-patch, and the existing 16-op CUDA parity battery is unaffected. The repo's CONTRIBUTING.md routes core ggml PRs to `ggml-org/llama.cpp`; the same file exists there at `ggml/src/ggml-cuda/cpy.cu` and the fix is unchanged. No duplicate PR open in either repo as of 2026-05-19.

## Testing

- New `test_backend_ops` case `test_cpy_strided_view_dst` builds `V = new_tensor_2d(F32, MAX_T=8, D_HEAD=4)` zeroed, `src = new_tensor_2d(F32, 1, 4)` with values `{1,2,3,4}`, `slot = view_2d(V, ne0=1, ne1=4, nb1=8*sizeof(float), offset=3*sizeof(float))`, and `ggml_cpy(src, slot)`. After compute on CUDA, assert `V[k][3] == k+1` for `k=0..3` and all other cells are zero. Same case on CPU backend must pass identically (was already correct).
- Existing parameterized `CPY` test cases in `test-backend-ops.cpp` still pass: contiguous F32->F32, F32->BF16, F32->F16, F32->Q8_0, F32->Q4_0 and the existing transpose-eligible shapes (`src0` contiguous AND `dst` contiguous) continue to dispatch to `cpy_scalar_transpose` and produce the same bit-exact output as before. Verify by re-running `./bin/test-backend-ops test -o CPY -b CUDA0` and confirming pass-count unchanged on the pre-existing cases plus +1 new pass.
- Performance no-regression: the fast transpose kernel still fires for its intended caller (F32 contiguous-to-contiguous transpose used in graph reshape/permute folding). Run `./bin/test-backend-ops perf -o CPY -b CUDA0` before and after and confirm the contiguous-to-contiguous F32 transpose throughput is unchanged (within run-to-run noise; the new predicate adds one `ggml_is_contiguous(src1)` call per dispatch, O(1)).
- Existing CUDA `MUL_MAT`, `FLASH_ATTN_EXT`, and KV-cache-using ops continue to pass — they don't hit the strided-dst path, but the dispatch change is in the hot copy path and a bad refactor would break them.
- Reporter's end-to-end transformer (Qwen2.5-1.5B-F32, 28 layers, view_2d+cpy V-cache write idiom): CUDA output matches CPU at every probed layer N ∈ {1, 2, 4, 8, 16, 28}. Confirmed by reporter on their fork pre-patch; cite in PR body as third-party verification.

Fixes #1497

AI was used for assistance.
