### PR TITLE
Tests: improve split-max-size coverage

### DIFF
--- a/tools/gguf-split/README.md
+++ b/tools/gguf-split/README.md
@@ -7,4 +7,8 @@ CLI to split / merge GGUF files.
 - `--split`: split GGUF to multiple GGUF, default operation.
 - `--split-max-size`: max size per split in `M` or `G`, f.ex. `500M` or `2G`.
 - `--split-max-tensors`: maximum tensors in each split: default(128)
+### Example
+
+```bash
+./llama-gguf-split --split-max-size 500M model.gguf split-model
 - `--merge`: merge multiple GGUF to a single GGUF. You only need to specify the name of the first GGUF to merge, the name of the merged GGUF, and the CLI will find the other GGUFs it needs within the same folder.

--- a/tools/gguf-split/tests.sh
+++ b/tools/gguf-split/tests.sh
@@ -85,5 +85,22 @@ $MAIN -no-cnv --model $WORK_PATH/ggml-model-split-500M-00001-of-00002.gguf -p "I
 echo PASS
 echo
 
+# 6c. Verify split shard files were generated
+ls $WORK_PATH/ggml-model-split-500M-*.gguf
+echo PASS
+echo
+
+# 7. Split with very small size strategy
+$SPLIT --split-max-size 1M $WORK_PATH/ggml-model-merge.gguf $WORK_PATH/ggml-model-split-1M
+echo PASS
+echo
+
+# 7b. Test the sharded model is loading properly
+FIRST_SHARD=$(ls $WORK_PATH/ggml-model-split-1M-*.gguf | head -n 1)
+
+$MAIN -no-cnv --model $FIRST_SHARD -p "I believe the meaning of life is" --n-predict 16
+echo PASS
+echo
+
 # Clean up
 rm -f $WORK_PATH/ggml-model-split*.gguf $WORK_PATH/ggml-model-merge*.gguf


### PR DESCRIPTION
## Overview

This PR improves test coverage and documentation for `--split-max-size` in `gguf-split`.

### Changes

* Added validation to verify split shard files are generated correctly.
* Added a small-size split test case (`1M`) to improve edge-case coverage.
* Added README example usage for `--split-max-size`.

## Additional information

Related to:

* #6259
* #6654

AI usage disclosure: YES — used AI assistance for repository navigation and workflow guidance.