### PR TITLE
sycl: fix performance regression by caching getenv

### DIFF
--- a/ggml/src/ggml-sycl/common.cpp
+++ b/ggml/src/ggml-sycl/common.cpp
@@ -86,7 +86,8 @@ int64_t downsample_sycl_global_range(int64_t accumulate_block_num, int64_t block
 
 #ifdef GGML_SYCL_SUPPORT_LEVEL_ZERO
 static bool ggml_sycl_use_level_zero_device_alloc(sycl::queue &q) {
-    return ggml_sycl_get_env("GGML_SYCL_ENABLE_LEVEL_ZERO", 1) &&
+    static const int enable_level_zero = ggml_sycl_get_env("GGML_SYCL_ENABLE_LEVEL_ZERO", 1);
+    return enable_level_zero &&
         q.get_device().is_gpu() &&
         q.get_backend() == sycl::backend::ext_oneapi_level_zero;
 }


### PR DESCRIPTION
## Overview

This PR fixes the SYCL performance regression (a drop from 32 t/s to 25 t/s) reported after the server-intel-b9159 update.

The issue was introduced by 9ed6e19b9 which started checking `ggml_sycl_use_level_zero_device_alloc()` on every tensor allocation. `ggml_sycl_get_env()` was performing a `getenv()` call on every allocation creating a bottleneck.

This PR simply caches the environment variable check as a static const so it only evaluates once, removing the CPU bottleneck.

## Additional information

Fixes #23160 

@devedse I'm on a CUDA setup at the moment, could you pull this and verify if your speeds return to the expected 32 t/s?

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used an AI assistant to help profile the git history and locate the getenv bottleneck, but I fully understand the fix and take responsibility for it.<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
