### PR TITLE
common/speculative : fix nullptr crash in get_devices_str

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -33,16 +33,15 @@ const std::map<std::string, common_speculative_type> common_speculative_type_fro
 };
 
 static std::string common_speculative_get_devices_str(const std::vector<ggml_backend_dev_t> & devices) {
-    if (devices.empty()) {
-        return "default";
-    }
-
     std::string result;
     for (size_t i = 0; i < devices.size(); i++) {
-        if (i > 0) result += ", ";
+        if (devices[i] == nullptr) {
+            continue;
+        }
+        if (!result.empty()) result += ", ";
         result += ggml_backend_dev_name(devices[i]);
     }
-    return result;
+    return result.empty() ? "default" : result;
 }
 
 struct common_speculative_config {


### PR DESCRIPTION
## Overview

Fix crash when `ggml_backend_dev_name` is called on a nullptr sentinel entry.
`ggml_backend_dev_by_name` always appends a nullptr at the end of the devices
vector, which caused an assertion failure in the speculative devices string
helper.

## Additional information

- Fix for [discussion #23269](https://github.com/ggml-org/llama.cpp/pull/23269#discussion_r3269506766)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. llama.cpp + pi