### PR TITLE
server : fix the log message when using SSL

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -99,6 +99,7 @@ bool server_http_context::init(const common_params & params) {
         srv.reset(
             new httplib::SSLServer(params.ssl_file_cert.c_str(), params.ssl_file_key.c_str())
         );
+        is_ssl = true;
     } else {
         SRV_INF("%s", "running without SSL\n");
         srv.reset(new httplib::Server());
@@ -378,8 +379,8 @@ bool server_http_context::start() {
     thread = std::thread([this]() { pimpl->srv->listen_after_bind(); });
     srv->wait_until_ready();
 
-    listening_address = is_sock ? string_format("unix://%s",    hostname.c_str())
-                                : string_format("http://%s:%d", hostname.c_str(), port);
+    listening_address = is_sock ? string_format("unix://%s", hostname.c_str())
+                                : string_format("%s://%s:%d", is_ssl ? "https" : "http", hostname.c_str(), port);
     return true;
 }
 

--- a/tools/server/server-http.h
+++ b/tools/server/server-http.h
@@ -74,6 +74,7 @@ struct server_http_context {
     std::string path_prefix;
     std::string hostname;
     int port;
+    bool is_ssl = false;
 
     server_http_context();
     ~server_http_context();


### PR DESCRIPTION
When llama-server is started with SSL key and cert, the log says that it listens on http instead of https. This patch fixes this.

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, opus 4.7
