### PR TITLE
ggml-zendnn : add Q8_0 quantization support

### DIFF
--- a/ggml/src/ggml-zendnn/CMakeLists.txt
+++ b/ggml/src/ggml-zendnn/CMakeLists.txt
@@ -28,7 +28,7 @@ if (NOT ZENDNN_ROOT OR ZENDNN_ROOT STREQUAL "" OR ZENDNN_ROOT STREQUAL "OFF")
     ExternalProject_Add(
         zendnn
         GIT_REPOSITORY https://github.com/amd/ZenDNN.git
-        GIT_TAG ac9e580d9434b7b98985f2627a7ebfb5eba4bb0d    # ZenDNN-2026-WW17
+        GIT_TAG 253b94ce0d7e9284c265fefb485714944caff9d3    # ZenDNN-2026-WW19
         PREFIX      ${ZENDNN_PREFIX}
         SOURCE_DIR  ${ZENDNN_SOURCE_DIR}
         BINARY_DIR  ${ZENDNN_BUILD_DIR}

--- a/ggml/src/ggml-zendnn/ggml-zendnn.cpp
+++ b/ggml/src/ggml-zendnn/ggml-zendnn.cpp
@@ -5,7 +5,7 @@
 #include "zendnnl.hpp"
 
 #include <cstring>
-
+#include "ggml-quants.h"
 
 struct ggml_backend_zendnn_context {
     int n_threads = GGML_DEFAULT_N_THREADS;
@@ -19,6 +19,8 @@ zendnnl::common::data_type_t ggml_to_zendnn_type() {
         return zendnnl::common::data_type_t::f32;
     } else if constexpr (std::is_same_v<T, ggml_bf16_t>) {
         return zendnnl::common::data_type_t::bf16;
+    } else if constexpr (std::is_same_v<T, block_q8_0>) {
+        return zendnnl::common::data_type_t::s8;
     } else {
         return zendnnl::common::data_type_t::none;
     }
@@ -48,6 +50,18 @@ static bool ggml_zendnn_matmul(ggml_backend_zendnn_context * ctx, int64_t m, int
     params.num_threads = ctx->n_threads;
 
     zendnnl::lowoha::matmul::matmul_batch_params_t batch_params;
+
+    if constexpr (std::is_same_v<TA, block_q8_0>){
+        params.dtypes.compute = zendnnl::common::data_type_t::s8;
+
+        const int64_t num_groups = k / QK8_0;
+        params.dynamic_quant = true;
+        params.quant_params.src_scale.buff = nullptr;
+        params.quant_params.src_scale.dt   = zendnnl::common::data_type_t::bf16;
+        params.quant_params.src_scale.dims = {static_cast<int>(n), static_cast<int>(num_groups)};        
+        params.packing.pack_format_b = 1;
+    }
+
     zendnnl::error_handling::status_t status = zendnnl::lowoha::matmul::matmul_direct(
         'r', false, true,   // row-major, don't transpose B, transpose A (because it's column-major)
         n,                  // M: rows of B and C
@@ -84,6 +98,14 @@ static bool ggml_zendnn_sgemm(ggml_backend_zendnn_context * ctx, int64_t m, int6
 
     // categorize types
     switch (Atype) {
+        case GGML_TYPE_Q8_0:
+            if (Btype != GGML_TYPE_F32 || Ctype != GGML_TYPE_F32)
+                return false;
+            return ggml_zendnn_matmul<block_q8_0, float, float>(
+                ctx, m, n, k,
+                (const block_q8_0 *)A, lda,
+                (const float *)B, ldb,
+                (float *)C, ldc);
         case GGML_TYPE_F32:
             if (Btype != GGML_TYPE_F32 || Ctype != GGML_TYPE_F32)
                 return false;
@@ -145,7 +167,7 @@ static void ggml_zendnn_compute_forward_mul_mat(
     const int64_t r3 = ne13/ne03;
 
     void * work_data = ctx->work_data.get();
-    if (src1->type != vec_dot_type) {
+    if (src1->type != vec_dot_type && src0->type != GGML_TYPE_Q8_0) {
         const size_t nbw1 = ggml_row_size(vec_dot_type, ne10);
         const size_t nbw2 = nbw1 * ne11;
         const size_t nbw3 = nbw2 * ne12;
@@ -171,7 +193,7 @@ static void ggml_zendnn_compute_forward_mul_mat(
 
     for (int64_t i13 = 0; i13 < ne13; i13++) {
         for (int64_t i12 = 0; i12 < ne12; i12++) {
-            const void* wdata = src1->type == vec_dot_type ? src1->data : work_data;
+            const void* wdata = (src1->type == vec_dot_type || src0->type == GGML_TYPE_Q8_0) ? src1->data : work_data;
             const size_t row_size = ggml_row_size(vec_dot_type, ne10);
             if (!ggml_zendnn_sgemm(ctx,
                                   ne01,     // m
@@ -184,7 +206,7 @@ static void ggml_zendnn_compute_forward_mul_mat(
                                   static_cast<char *>(dst->data) + i12*nb2 + i13*nb3,
                                   ne01,     // ldc
                                   src0->type,
-                                  vec_dot_type,
+                                  src0->type == GGML_TYPE_Q8_0 ? GGML_TYPE_F32 : vec_dot_type,
                                   dst->type))
                 GGML_ABORT("%s: ZenDNN sgemm failed\n", __func__);
         }
@@ -261,10 +283,15 @@ static void ggml_zendnn_compute_forward_mul_mat_id(
     const size_t nbw1 = row_size;
     const size_t nbw2 = nbw1 * ne11;
     const size_t nbw3 = nbw2 * ne12;
-    const size_t src1_conv_size = (src1->type != vec_dot_type) ? ne13 * nbw3 : 0;
+    const size_t src1_conv_size = (src1->type != vec_dot_type && src0->type != GGML_TYPE_Q8_0) ? ne13 * nbw3 : 0;
+
+    // For Q8_0, src1 is always F32; the gather buffer must hold F32 rows (ne10*4 bytes),
+    // not Q8_0-encoded rows (row_size ≈ ne10/32*34 bytes) — they differ by ~4x.
+    const size_t f32_row_size = (size_t)ne10 * sizeof(float);
+    const size_t gather_row_size = (src0->type == GGML_TYPE_Q8_0) ? f32_row_size : row_size;
 
     // size for MoE gather/scatter buffers
-    const size_t wdata_cur_size = max_rows * row_size;
+    const size_t wdata_cur_size = max_rows * gather_row_size;
     const size_t dst_cur_size = max_rows * ggml_row_size(dst->type, ne01);
 
     // allocate single buffer for all needs
@@ -279,7 +306,7 @@ static void ggml_zendnn_compute_forward_mul_mat_id(
     char * wdata_cur = work_data + src1_conv_size;
     char * dst_cur = wdata_cur + wdata_cur_size;
 
-    if (src1->type != vec_dot_type) {
+    if (src1->type != vec_dot_type && src0->type != GGML_TYPE_Q8_0) {
         GGML_ASSERT(src1->type == GGML_TYPE_F32);
 
         #pragma omp parallel for collapse(3) num_threads(ctx->n_threads) schedule(static)
@@ -294,7 +321,7 @@ static void ggml_zendnn_compute_forward_mul_mat_id(
         }
     }
 
-    const void * wdata = src1->type == vec_dot_type ? src1->data : work_data;
+    const void * wdata = (src1->type == vec_dot_type || src0->type == GGML_TYPE_Q8_0) ? src1->data : work_data;
 
     // process each expert with gather -> gemm -> scatter pattern
     for (int64_t cur_a = 0; cur_a < n_as; ++cur_a) {
@@ -315,9 +342,9 @@ static void ggml_zendnn_compute_forward_mul_mat_id(
             const int64_t i12 = row_mapping.i2;
 
             std::memcpy(
-                wdata_cur + ir1 * row_size,
-                (const char *) wdata + (i11 + i12*ne11) * row_size,
-                row_size
+                wdata_cur + ir1 * gather_row_size,
+                (const char *) wdata + (i11 + i12*ne11) * gather_row_size,
+                gather_row_size
             );
         }
 
@@ -333,7 +360,7 @@ static void ggml_zendnn_compute_forward_mul_mat_id(
                               dst_cur,
                               ne01,       // ldc
                               src0->type,
-                              vec_dot_type,
+                              src0->type == GGML_TYPE_Q8_0 ? GGML_TYPE_F32 : vec_dot_type,
                               dst->type)) {
             GGML_ABORT("%s: ZenDNN sgemm failed\n", __func__);
         }
@@ -577,6 +604,7 @@ static bool ggml_backend_zendnn_device_supports_op(ggml_backend_dev_t dev, const
             switch (weights->type) {
                 case GGML_TYPE_F32:
                 case GGML_TYPE_BF16:
+                case GGML_TYPE_Q8_0:
                     return true;
                 default:
                     return false;

--- a/ggml/src/ggml-zendnn/ggml-zendnn.cpp
+++ b/ggml/src/ggml-zendnn/ggml-zendnn.cpp
@@ -2,10 +2,14 @@
 
 #include "ggml-backend-impl.h"
 #include "ggml-impl.h"
+
+#define GGML_COMMON_DECL_CPP
+#include "ggml-common.h"
+
 #include "zendnnl.hpp"
 
 #include <cstring>
-#include "ggml-quants.h"
+
 
 struct ggml_backend_zendnn_context {
     int n_threads = GGML_DEFAULT_N_THREADS;
@@ -51,14 +55,13 @@ static bool ggml_zendnn_matmul(ggml_backend_zendnn_context * ctx, int64_t m, int
 
     zendnnl::lowoha::matmul::matmul_batch_params_t batch_params;
 
-    if constexpr (std::is_same_v<TA, block_q8_0>){
+    if constexpr (std::is_same_v<TA, block_q8_0>) {
         params.dtypes.compute = zendnnl::common::data_type_t::s8;
-
         const int64_t num_groups = k / QK8_0;
         params.dynamic_quant = true;
         params.quant_params.src_scale.buff = nullptr;
         params.quant_params.src_scale.dt   = zendnnl::common::data_type_t::bf16;
-        params.quant_params.src_scale.dims = {static_cast<int>(n), static_cast<int>(num_groups)};        
+        params.quant_params.src_scale.dims = {n, num_groups};
         params.packing.pack_format_b = 1;
     }
 
@@ -98,14 +101,6 @@ static bool ggml_zendnn_sgemm(ggml_backend_zendnn_context * ctx, int64_t m, int6
 
     // categorize types
     switch (Atype) {
-        case GGML_TYPE_Q8_0:
-            if (Btype != GGML_TYPE_F32 || Ctype != GGML_TYPE_F32)
-                return false;
-            return ggml_zendnn_matmul<block_q8_0, float, float>(
-                ctx, m, n, k,
-                (const block_q8_0 *)A, lda,
-                (const float *)B, ldb,
-                (float *)C, ldc);
         case GGML_TYPE_F32:
             if (Btype != GGML_TYPE_F32 || Ctype != GGML_TYPE_F32)
                 return false;
@@ -130,6 +125,14 @@ static bool ggml_zendnn_sgemm(ggml_backend_zendnn_context * ctx, int64_t m, int6
                     (const ggml_bf16_t *)B, ldb,
                     (float *)C, ldc);
             return false;
+        case GGML_TYPE_Q8_0:
+            if (Btype != GGML_TYPE_F32 || Ctype != GGML_TYPE_F32)
+                return false;
+            return ggml_zendnn_matmul<block_q8_0, float, float>(
+                ctx, m, n, k,
+                (const block_q8_0 *)A, lda,
+                (const float *)B, ldb,
+                (float *)C, ldc);
         default:
             return false; // unsupported type
     }
@@ -167,6 +170,8 @@ static void ggml_zendnn_compute_forward_mul_mat(
     const int64_t r3 = ne13/ne03;
 
     void * work_data = ctx->work_data.get();
+
+    // ZenDNN requires FP32 for dynamic quantization, so conversion is skipped
     if (src1->type != vec_dot_type && src0->type != GGML_TYPE_Q8_0) {
         const size_t nbw1 = ggml_row_size(vec_dot_type, ne10);
         const size_t nbw2 = nbw1 * ne11;
@@ -306,6 +311,7 @@ static void ggml_zendnn_compute_forward_mul_mat_id(
     char * wdata_cur = work_data + src1_conv_size;
     char * dst_cur = wdata_cur + wdata_cur_size;
 
+    // ZenDNN requires FP32 for dynamic quantization, so conversion is skipped
     if (src1->type != vec_dot_type && src0->type != GGML_TYPE_Q8_0) {
         GGML_ASSERT(src1->type == GGML_TYPE_F32);
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This PR adds Q8_0 quantization support in the ggml-zendnn backend.

The implementation enables ZenDNN execution paths for Q8_0 models and integrates the required handling for quantized weights and matmul operations.

Key changes:
- Added Q8_0 support in ggml-zendnn backend
- Enabled ZenDNN execution path for Q8_0 quantized matmul operations
- Added handling for Q8_0 tensor layouts and conversions
- Integrated backend execution support for Q8_0 models
- Also pointing to the latest ZenDNN 
 
## Benchmark Results

Benchmark configuration:
- threads = 96
- type_k = bf16
- type_v = bf16

### Llama-3.1-8B-Instruct Q8_0
| Prompt Size | GGML_CPU_Q8_0 t/s | ZenDNN_Q8_0 t/s | Gain |
|-------------|-------------------|-----------------|------|
| 256 | 472.28 | 730.87 | 54.75% |
| 512 | 450.86 | 832.48 | 84.64% |
| 768 | 446.81 | 864.52 | 93.49% |
| 1024 | 439.58 | 800.15 | 82.03% |
| 2048 | 405.07 | 778.34 | 92.15% |
| tg128 | 33.08 | 33.14 | 0.18% |

### Mixtral-8x7B Q8_0
| Prompt Size | GGML_CPU_Q8_0 t/s | ZenDNN_Q8_0 t/s | Gain |
|-------------|-------------------|-----------------|------|
| 256 | 156.09 | 297.67 | 90.70% |
| 512 | 156.63 | 389.44 | 148.64% |
| 768 | 156.76 | 417.38 | 166.25% |
| 1024 | 154.70 | 438.73 | 183.60% |
| 2048 | 150.11 | 470.41 | 213.38% |
| tg128 | 20.95 | 20.92 | -0.14% |

### gemma4 31B Q8_0
| Prompt Size | GGML_CPU_Q8_0 t/s | ZenDNN_Q8_0 t/s | Gain |
|-------------|-------------------|-----------------|------|
| 256 | 116.05 | 195.02 | 68.05% |
| 512 | 112.53 | 229.12 | 103.61% |
| 768 | 111.96 | 239.02 | 113.49% |
| 1024 | 110.93 | 238.03 | 114.58% |
| 2048 | 106.37 | 222.32 | 109.01% |
| tg128 | 8.50 | 8.47 | -0.35% |

### gemma-4-26B-A4B-it Q8_0
| Prompt Size | GGML_CPU_Q8_0 t/s | ZenDNN_Q8_0 t/s | Gain |
|-------------|-------------------|-----------------|------|
| 256 | 570.87 | 597.84 | 4.72% |
| 512 | 581.80 | 666.18 | 14.50% |
| 768 | 588.67 | 683.91 | 16.18% |
| 1024 | 574.79 | 684.13 | 19.02% |
| 2048 | 562.26 | 642.08 | 14.20% |
| tg128 | 33.96	| 33.83 | -0.38% |

## Observations

- Significant prompt-processing gains are observed for larger prompt sizes
- Decoding (`tg128`) performance remains comparable to ggml-cpu

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Validated on:
- Llama-3.1-8B-Instruct Q8_0
- Mixtral-8x7B Q8_0
- gemma4 31B Q8_0
- gemma-4-26B-A4B-it Q8_0

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->