### PR TITLE
Adding tokenizer for deepseek_r1_distill_llama_8b model

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1374,6 +1374,9 @@ class TextModel(ModelBase):
         if chkhsh == "0fe1cf6eda062318a1af7270f3331a85c539a01778ff948e24388e949c5282f4":
             # ref: https://huggingface.co/evilfreelancer/ruGPT3XL
             res = "gpt-2"
+        if chkhsh == "a63e0d2191069e2b760b155e39a0d9a348ec29a6ee47e8beb24a1174a4b8f197":
+            # ref: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+            res = "llama-bpe"
         if chkhsh == "0ef9807a4087ebef797fc749390439009c3b9eda9ad1a097abbe738f486c01e5":
             # ref: https://huggingface.co/meta-llama/Meta-Llama-3-8B
             res = "llama-bpe"

--- a/convert_hf_to_gguf_update.py
+++ b/convert_hf_to_gguf_update.py
@@ -181,6 +181,7 @@ pre_computed_hashes = [
     # jina-v2-de variants
     {"name": "jina-v2-de", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/aari1995/German_Semantic_V3", "chkhsh": "b3d1dd861f1d4c5c0d2569ce36baf3f90fe8a102db3de50dd71ff860d91be3df"},
     {"name": "gpt-2", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/evilfreelancer/ruGPT3XL", "chkhsh": "0fe1cf6eda062318a1af7270f3331a85c539a01778ff948e24388e949c5282f4"},
+    {"name": "llama-bpe", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B", "chkhsh": "a63e0d2191069e2b760b155e39a0d9a348ec29a6ee47e8beb24a1174a4b8f197"},
 ]
 
 


### PR DESCRIPTION
## Overview

Adding tokenizer for DeepSeek-R1-Distill-Llama-8B model (https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B).
SHA hash for that model was precomputed with the following code:
```python
chktok = tokenizer.encode(chktxt)
chkhsh = sha256(str(chktok).encode()).hexdigest()
```
The chkhsh was taken from conversion/base.py file.
Firstly I added entry to convert_hf_to_gguf_update.py file, and then i run:
```bash
python3 convert_hf_to_gguf_update.py --check-missing
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  Yes - AI was used for explaining how current code and tokenizer selection logic works. 

