### PR TITLE
[Tensor parallel] Clear tensor-parallel meta backend caches before reusing the buffer

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1407,8 +1407,15 @@ static void ggml_backend_meta_buffer_clear(ggml_backend_buffer_t buffer, uint8_t
 }
 
 static void ggml_backend_meta_buffer_reset(ggml_backend_buffer_t buffer) {
+    GGML_ASSERT(ggml_backend_buffer_is_meta(buffer));
+    ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buffer->context;
+
+    buf_ctx->simple_tensors.clear();
+    buf_ctx->split_state_cache.clear();
+
     const size_t n_buffers = ggml_backend_meta_buffer_n_bufs(buffer);
     for (size_t i = 0; i < n_buffers; i++) {
+        ggml_reset(buf_ctx->buf_configs[i].ctx);
         ggml_backend_buffer_reset(ggml_backend_meta_buffer_simple_buffer(buffer, i));
     }
 }


### PR DESCRIPTION
Call ggml_reset() on each per-device shadow ggml_context.

