### PR TITLE
tests : fix globstar compatibility on macOS default Bash 3.2

### DIFF
--- a/tests/test-tokenizers-repo.sh
+++ b/tests/test-tokenizers-repo.sh
@@ -32,12 +32,24 @@ else
     fi
 fi
 
-shopt -s globstar
-for gguf in $folder/**/*.gguf; do
-    if [ -f $gguf.inp ] && [ -f $gguf.out ]; then
-        $toktest $gguf
-    else
-        printf "Found \"$gguf\" without matching inp/out files, ignoring...\n"
-    fi
-done
+# globstar is unavailable in Bash < 4.0 (e.g., macOS default Bash 3.2)
+# use find for portable recursive matching
+if [ "${BASH_VERSINFO[0]}" -ge 4 ] 2>/dev/null; then
+    shopt -s globstar
+    for gguf in "$folder"/**/*.gguf; do
+        if [ -f "$gguf.inp" ] && [ -f "$gguf.out" ]; then
+            $toktest "$gguf"
+        else
+            printf "Found \"%s\" without matching inp/out files, ignoring...\n" "$gguf"
+        fi
+    done
+else
+    find "$folder" -name '*.gguf' -print0 | while IFS= read -r -d '' gguf; do
+        if [ -f "$gguf.inp" ] && [ -f "$gguf.out" ]; then
+            $toktest "$gguf"
+        else
+            printf "Found \"%s\" without matching inp/out files, ignoring...\n" "$gguf"
+        fi
+    done
+fi
 


### PR DESCRIPTION
## Summary

Fixes #23427

The `tests/test-tokenizers-repo.sh` script used `shopt -s globstar` and `**` glob patterns, which are Bash 4.0+ features unavailable on macOS default Bash 3.2. This caused the `test-tokenizers-ggml-vocabs` test to fail on macOS with:

```
shopt: globstar: invalid shell option name
```

## Changes

- Added a Bash version check:
  - **Bash >= 4.0**: retains the existing `globstar` approach
  - **Bash < 4.0** (e.g., macOS stock Bash): falls back to `find -name '*.gguf' -print0` for portable recursive matching
- Added quotes around path variables to correctly handle directories/files containing spaces

## Testing

Verified on macOS 26.4.1 with Apple M4 Pro (default Bash 3.2.57):

1. Created a mock vocab directory structure with `.gguf` + `.inp`/`.out` files in nested subdirectories
2. Ran the patched script — no `globstar` error, all files discovered recursively, unmatched files correctly ignored:
   ```
   TOKTEST: /tmp/mock-vocabs/subdir1/b.gguf
   TOKTEST: /tmp/mock-vocabs/a.gguf
   Found "/tmp/mock-vocabs/subdir2/c.gguf" without matching inp/out files, ignoring...
   ```

## Impact

- **Scope**: Single test script (`tests/test-tokenizers-repo.sh`)
- **Risk**: Very low — only changes file-discovery logic; preserves original behavior on Bash 4.0+ systems
- **Benefit**: Restores macOS compatibility without requiring users to install newer Bash versions
