### PR TITLE
ggml/cpu: skip zero-scale blocks in TQ1_0 and TQ2_0 vec_dot kernels

### DIFF
--- a/ggml/src/ggml-cpu/arch/arm/quants.c
+++ b/ggml/src/ggml-cpu/arch/arm/quants.c
@@ -1340,6 +1340,8 @@ void ggml_vec_dot_tq1_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
     const uint8x16_t shift = vld1q_u8(k_shift);
 
     for (int i = 0; i < nb; ++i) {
+        if (!x[i].d) continue; // all weights in block are zero, skip
+
 #if defined(__ARM_FEATURE_DOTPROD)
         int32x4_t sumi0 = vdupq_n_s32(0);
         int32x4_t sumi1 = vdupq_n_s32(0);
@@ -1515,6 +1517,8 @@ void ggml_vec_dot_tq2_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
     const uint8x16_t m3 = vdupq_n_u8(3);
 
     for (int i = 0; i < nb; ++i) {
+        if (!x[i].d) continue; // all weights in block are zero, skip
+
 #if defined(__ARM_FEATURE_DOTPROD)
         int32x4_t sumi0 = vdupq_n_s32(0);
         int32x4_t sumi1 = vdupq_n_s32(0);

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -1251,6 +1251,8 @@ void ggml_vec_dot_tq1_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
     __m256 sumf = _mm256_setzero_ps();
 
     for (int i = 0; i < nb; ++i) {
+        if (!x[i].d) continue; // all weights in block are zero, skip
+
         // 16-bit sums
         __m256i sumi0 = _mm256_setzero_si256();
         __m256i sumi1 = _mm256_setzero_si256();
@@ -1383,6 +1385,8 @@ void ggml_vec_dot_tq2_0_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
     __m256 sumf = _mm256_setzero_ps();
 
     for (int i = 0; i < nb; ++i) {
+        if (!x[i].d) continue; // all weights in block are zero, skip
+
         // 16-bit sums, because 256*127 still fits
         __m256i sumi0 = _mm256_setzero_si256();
         __m256i sumi1 = _mm256_setzero_si256();

--- a/ggml/src/ggml-cpu/quants.c
+++ b/ggml/src/ggml-cpu/quants.c
@@ -444,6 +444,8 @@ void ggml_vec_dot_tq1_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, 
     float sumf = 0.0f;
 
     for (int i = 0; i < nb; ++i) {
+        if (!x[i].d) continue; // all weights in block are zero, skip
+
         int sum = 0;
 
         for (size_t j = 0; j < sizeof(x->qs) - sizeof(x->qs) % 32; j += 32) {
@@ -493,6 +495,8 @@ void ggml_vec_dot_tq2_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, 
     float sumf = 0.0f;
 
     for (int i = 0; i < nb; ++i) {
+        if (!x[i].d) continue; // all weights in block are zero, skip
+
         int32_t sumi = 0;
 
         for (size_t j = 0; j < sizeof(x->qs); j += 32) {


### PR DESCRIPTION
## Summary

In the `ggml_vec_dot_tq1_0_q8_K` and `ggml_vec_dot_tq2_0_q8_K` kernels (generic, ARM NEON, and x86 AVX2), each block carries a scale factor `d` (`ggml_fp16_t`). When `d == 0`, every weight in that 256-element block is zero — the inner loop accumulates nothing and the block's contribution to the dot product is exactly zero.

This adds a one-line early-exit at the top of each block loop across all three implementations:

```c
if (!x[i].d) continue; // all weights in block are zero, skip
```

## Why it's correct

`ggml_fp16_t` is `uint16_t`. The IEEE 754 fp16 representation of `0.0` is `0x0000`, so `!x[i].d` is equivalent to checking exact zero — no false positives from subnormals or negative zero (fp16 `-0.0` is `0x8000`, which is non-zero as a uint16).

The final accumulation is `sumf += sumi * x[i].d * y[i].d`. If `x[i].d == 0` the entire contribution is zero regardless of `sumi`, so skipping the inner loops is always numerically equivalent.

## When it fires

BitNet b1.58 and similar ternary-weight models can produce all-zero blocks in:
- FFN layers after convergence (regularization drives weak blocks to zero)
- Pruned or distilled checkpoints
- MoE layers where expert slots are uninitialized

The check costs one integer comparison per block of 256 weights — negligible when blocks are non-zero, free when they are.

## Files changed

| File | Kernels |
|------|---------|
| `ggml/src/ggml-cpu/quants.c` | `tq1_0_generic`, `tq2_0_generic` |
| `ggml/src/ggml-cpu/arch/arm/quants.c` | `tq1_0` (NEON), `tq2_0` (NEON) |
| `ggml/src/ggml-cpu/arch/x86/quants.c` | `tq1_0` (AVX2), `tq2_0` (AVX2) |

12 lines added, 0 deleted.