### PR TITLE
server: expose prompt token counts in /slots endpoint

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -506,6 +506,9 @@ struct server_slot {
 
         if (ptask) {
             res["id_task"] = ptask->id;
+            res["n_prompt_tokens"]           = (int32_t) prompt.tokens.size();
+            res["n_prompt_tokens_processed"] = n_prompt_tokens_processed;
+            res["n_prompt_tokens_cache"]     = n_prompt_tokens_cache;
             res["params"] = ptask->params.to_json(only_metrics);
             res["next_token"] = {
                 {


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

`server_slot` already tracks `n_prompt_tokens_processed` and `n_prompt_tokens_cache`, but `to_json()` doesn't include them. This adds those fields plus `n_prompt_tokens` (total) to the `/slots` response so clients can monitor prompt evaluation progress.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Relates to #14685.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes - code analysis, patch suggestion.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
