### PR TITLE
vocab : keep DNA k-mer ids distinct from colliding BPE tokens

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1617,6 +1617,11 @@ class TextModel(ModelBase):
         assert max(tokenizer.vocab.values()) < vocab_size  # ty: ignore[unresolved-attribute]
 
         reverse_vocab = {id_: encoded_tok for encoded_tok, id_ in tokenizer.vocab.items()}  # ty: ignore[unresolved-attribute]
+        # k-mers can share text with a base-vocab BPE token (e.g. CCCCCC) and get
+        # dropped by get_vocab(); a reserved marker suffix (U+E000) keeps each
+        # k-mer's own id (llama.cpp strips it on detokenization)
+        for kmer in tokenizer.kmers:  # ty: ignore[unresolved-attribute]
+            reverse_vocab[tokenizer.dna_token_to_id[kmer]] = kmer + "\ue000"  # ty: ignore[unresolved-attribute]
         added_vocab = tokenizer.get_added_vocab()  # ty: ignore[unresolved-attribute]
         added_tokens_decoder = tokenizer.added_tokens_decoder  # ty: ignore[unresolved-attribute]
 

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1581,6 +1581,11 @@ private:
     const llm_tokenizer_plamo2 & tokenizer;
 };
 
+// reserved suffix (U+E000) that keeps DNA k-mers distinct from identical
+// base-vocab BPE tokens (e.g. CCCCCC) in token_to_id; erased from id_to_token
+// text at load
+static const std::string dna_kmer_marker = "\xee\x80\x80";
+
 struct llm_tokenizer_hybriddna_session : llm_tokenizer_bpe_session {
     llm_tokenizer_hybriddna_session(const llama_vocab & vocab, const llm_tokenizer_bpe & tokenizer) : llm_tokenizer_bpe_session{vocab, tokenizer}, vocab{vocab} {}
 
@@ -1636,34 +1641,22 @@ private:
                 c = char(c - 32);
             }
         }
-        auto is_valid_kmer = [](const std::string & s) {
-            for (char c : s) {
-                if (c != 'A' && c != 'C' && c != 'G' && c != 'T') {
-                    return false;
-                }
-            }
-            return true;
+
+        // k-mers carry the reserved marker suffix; a non-ACGT k-mer simply
+        // isn't in the vocab and falls back to <oov>
+        auto kmer_token = [&](const std::string & kmer) {
+            const auto tok = vocab.text_to_token(kmer + dna_kmer_marker);
+            return tok != LLAMA_TOKEN_NULL ? tok : oov_id;
         };
 
         size_t i = 0;
         for (; i + k <= seq.size(); i += k) {
-            const std::string kmer = seq.substr(i, k);
-            if (is_valid_kmer(kmer)) {
-                const auto tok = vocab.text_to_token(kmer);
-                output.push_back(tok != LLAMA_TOKEN_NULL ? tok : oov_id);
-            } else {
-                output.push_back(oov_id);
-            }
+            output.push_back(kmer_token(seq.substr(i, k)));
         }
         if (i < seq.size()) {
             std::string kmer = seq.substr(i);
             kmer.append(k - kmer.size(), 'A');
-            if (is_valid_kmer(kmer)) {
-                const auto tok = vocab.text_to_token(kmer);
-                output.push_back(tok != LLAMA_TOKEN_NULL ? tok : oov_id);
-            } else {
-                output.push_back(oov_id);
-            }
+            output.push_back(kmer_token(kmer));
         }
     }
 
@@ -2356,6 +2349,20 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
         }
     }
     GGML_ASSERT(id_to_token.size() == token_to_id.size());
+
+    // hybriddna: the marker suffix kept k-mer ids distinct in token_to_id; erase
+    // it from id_to_token so the k-mers detokenize to the bare DNA sequence. The
+    // k-mers are the block right after <oov>, so only scan from there.
+    if (tokenizer_model == "hybriddna") {
+        const auto it = token_to_id.find("<oov>");
+        for (size_t i = (it != token_to_id.end() ? it->second + 1 : id_to_token.size()); i < id_to_token.size(); ++i) {
+            std::string & text = id_to_token[i].text;
+            if (text.size() > dna_kmer_marker.size() &&
+                text.compare(text.size() - dna_kmer_marker.size(), dna_kmer_marker.size(), dna_kmer_marker) == 0) {
+                text.erase(text.size() - dna_kmer_marker.size());
+            }
+        }
+    }
 
     init_tokenizer(type);
 

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2354,12 +2354,15 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
     // it from id_to_token so the k-mers detokenize to the bare DNA sequence. The
     // k-mers are the block right after <oov>, so only scan from there.
     if (tokenizer_model == "hybriddna") {
-        const auto it = token_to_id.find("<oov>");
-        for (size_t i = (it != token_to_id.end() ? it->second + 1 : id_to_token.size()); i < id_to_token.size(); ++i) {
-            std::string & text = id_to_token[i].text;
-            if (text.size() > dna_kmer_marker.size() &&
-                text.compare(text.size() - dna_kmer_marker.size(), dna_kmer_marker.size(), dna_kmer_marker) == 0) {
-                text.erase(text.size() - dna_kmer_marker.size());
+        const auto idx = token_to_id.find("<oov>");
+        if (idx != token_to_id.end()) {
+            auto it = id_to_token.begin() + idx->second + 1;
+            for (; it != id_to_token.end(); ++it) {
+                std::string & text = it->text;
+                if (text.size() > dna_kmer_marker.size()
+                        && text.compare(text.size() - dna_kmer_marker.size(), dna_kmer_marker.size(), dna_kmer_marker) == 0) {
+                    text.erase(text.size() - dna_kmer_marker.size());
+                }
             }
         }
     }


### PR DESCRIPTION
## Overview

Follow-up to #23410. The HybridDNA tokenizer gives every DNA k-mer its own id,   but one 6-mer (`CCCCCC`) also exists as a Qwen3 BPE token. Because `get_vocab()`  is keyed by text, the DNA id (154402) was dropped in favor of the BPE id (91443)   and written out as an unused pad — so `<dna>…CCCCCC…</dna>` encoded to the wrong  id and 154402 detokenized to `[PAD154402]`, diverging from the Python tokenizer.

 A naive conversion fix can't work: llama.cpp's vocab is a 1:1 text↔id map, so two  tokens named `CCCCCC` won't load. transformers avoids this by resolving k-mers   through a dedicated DNA map in `<dna>` context. This PR does the same in   `src/llama-vocab.cpp` only: inside `<dna>` a k-mer resolves to its own id by  product-order index (not the shared text→id map), and at load the colliding   k-mer's text is restored from its index so it detokenizes correctly.

Result matches transformers both ways: DNA `CCCCCC` → 154402, plain `CCCCCC` →   91443, both detokenize to `CCCCCC`. Verified with full token-id parity against   `AutoTokenizer(..., trust_remote_code=True)`.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES for comments and refactoring  <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
