### PR TITLE
server: make get_datetime return a locale-independent format

### DIFF
--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -719,7 +719,42 @@ struct server_tool_get_datetime : server_tool {
         auto now = std::chrono::system_clock::now();
         auto time = std::chrono::system_clock::to_time_t(now);
 
-        return {{"result", std::ctime(&time)}};
+        std::tm local{};
+#ifdef _WIN32
+        localtime_s(&local, &time);
+#else
+        localtime_r(&time, &local);
+#endif
+
+        // strftime returns locale-dependant values for weekdays and months, while IMF requires English
+        static constexpr const char weekdays[7][4] = {
+            "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+        };
+        static constexpr const char months[12][4] = {
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+        };
+
+        // Calculating the timezone is somewhat complex - let's use the strftime for that alone
+        char tz[8];
+        std::strftime(tz, sizeof(tz), "%z", &local);
+
+        char buf[48];
+        std::snprintf(
+            buf,
+            sizeof(buf),
+            "%s, %02d %s %04d %02d:%02d:%02d %s",
+            weekdays[local.tm_wday],
+            local.tm_mday,
+            months[local.tm_mon],
+            local.tm_year + 1900,
+            local.tm_hour,
+            local.tm_min,
+            local.tm_sec,
+            tz
+        );
+
+        return {{"result", buf}};
     }
 };
 


### PR DESCRIPTION
## Overview

It previously returned local time but without letting the model know in what exact timezone, and in a locale-dependant fashion, which was problematic if the model was not trained for the user's local language.

It now returns the date always in the standard Internet Messaging Format or RFC5322, which mandates short-form English and includes timezone information.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. An LLM was used to look for non-locale-dependant date string formatting and implement the snprintf-based approach. I manually checked the [strftime implementation in the glibc](https://elixir.bootlin.com/glibc/glibc-2.1.93/source/time/strftime.c) for any alternatives that would allow using C-locale for a single call but no modifiers exist, and modifying the global locale seems iffy and may have unexpected side effects elsewhere.

