### PR TITLE
Add missing `buffer` set in allreduce fallback !COMPUTE clear

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1964,6 +1964,7 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
             node_zero->src[0] = node;
             ggml_set_op_params_f32(node_zero, 0, 0.0f);
             node_zero->data = node->data;
+            node_zero->buffer = node->buffer;
             node_zero->flags |= GGML_TENSOR_FLAG_COMPUTE;
 
             step_cgraphs[j] = get_cgraph_aux();


### PR DESCRIPTION
Without this at least the vulkan backend will skip the `* 0` for !COMPUTE tensors, causing corrupt output.

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, claude found this bug while debugging unrelated issues with tensor par.