### PR TITLE
common/download: prevent duplicate MTP draft model downloads

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -579,10 +579,16 @@ static hf_cache::hf_file find_best_sibling(const hf_cache::hf_files & files,
     auto model_bits = extract_quant_bits(model);
     auto model_parts = string_split<std::string>(model, '/');
     auto model_dir = model_parts.end() - 1;
+    auto model_split = get_gguf_split_info(model);
 
     for (const auto & f : files) {
         if (!string_ends_with(f.path, ".gguf") ||
             f.path.find(keyword) == std::string::npos) {
+            continue;
+        }
+
+        auto sib_split = get_gguf_split_info(f.path);
+        if (sib_split.prefix == model_split.prefix) {
             continue;
         }
 


### PR DESCRIPTION
## Overview

When `--spec-type draft-mtp` is passed and the primary model's filename contains the keyword `mtp-` (e.g. `asmr-qwen3.5-9b-zh-tw-echo-mtp-gguf-v0.1-q4_k_m.gguf`), `llama-server` mistakenly queues the primary model as the draft model. This causes duplicate concurrent download tasks targeting the same `.tmp` cache file, crashing the server with rename errors.

## Additional information

I added a `gguf_split_info` check to `find_best_sibling` so it explicitly skips the primary model (and all of its chunks). The logic now correctly forces it to either find a true sibling draft model, or fall back to extracting MTP heads from the main model as intended.

Fixes #23479

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

