### PR TITLE
server : only parse empty generation if continuing an assistant message

### DIFF
--- a/common/chat.h
+++ b/common/chat.h
@@ -219,6 +219,7 @@ struct common_chat_parser_params {
     bool                    reasoning_in_content = false;
     std::string             generation_prompt;
     bool                    parse_tool_calls     = true;
+    bool                    is_continuation      = false;
     bool                    echo                 = false;  // Include assistant prefilled msg in output
     bool                    debug                = false;  // Enable debug output for PEG parser
     common_peg_arena        parser               = {};

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -149,7 +149,7 @@ task_result_state::task_result_state(const common_chat_parser_params & chat_pars
     , oai_resp_id("resp_" + random_string())
     , oai_resp_reasoning_id("rs_" + random_string())
     , oai_resp_message_id("msg_" + random_string()) {
-    if (!chat_parser_params.echo) {
+    if (chat_parser_params.is_continuation && !chat_parser_params.echo) {
         // initialize chat_msg to avoid emitting a delta containing the assistant prefill
         chat_msg = common_chat_parse("", true, chat_parser_params);
     }
@@ -431,6 +431,10 @@ task_params server_task::params_from_json_cmpl(
         params.chat_parser_params.parse_tool_calls = json_value(data, "parse_tool_calls", false);
         if (data.contains("chat_parser")) {
             params.chat_parser_params.parser.load(data.at("chat_parser").get<std::string>());
+        }
+        if (data.contains("continue_final_message")) {
+            auto continuation = common_chat_continuation_parse(data.at("continue_final_message"));
+            params.chat_parser_params.is_continuation = continuation != COMMON_CHAT_CONTINUATION_NONE;
         }
         params.chat_parser_params.echo = json_value(data, "echo", false);
     }


### PR DESCRIPTION
## Overview

The server parses an empty generation to exclude the prefix when continuing an assistant message, but that broke when `reasoning_format = none` for chat templates that include the opening thinking tag in the generation prompt. This limits that logic to assistant prefill.

Fixes #23320

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
