### PR TITLE
Skip hash probe when no cache is present

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -83,11 +83,16 @@ struct rpc_msg_hello_req {
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
 };
 
+
+// SET_TENSOR_HASH dedup probe: prevents endless probing when no cache is present
+enum {
+    RPC_HELLO_FLAG_NO_CACHE = 1 << 0,
+};
 struct rpc_msg_hello_rsp {
     uint8_t major;
     uint8_t minor;
     uint8_t patch;
-    uint8_t padding;
+    uint8_t flags;
     uint8_t conn_caps[RPC_CONN_CAPS_SIZE];
 };
 
@@ -343,6 +348,8 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
     }
 
     sock->update_caps(response.conn_caps);
+    // If the server has no tensor cache, skip the SET_TENSOR_HASH probe
+    sock->set_skip_tensor_hash((response.flags & RPC_HELLO_FLAG_NO_CACHE) != 0);
     return true;
 }
 
@@ -465,7 +472,7 @@ static enum ggml_status ggml_backend_rpc_buffer_init_tensor(ggml_backend_buffer_
 static void ggml_backend_rpc_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
     ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
     rpc_tensor rpc_tensor = serialize_tensor(tensor);
-    if (size > HASH_THRESHOLD) {
+    if (size > HASH_THRESHOLD && !ctx->sock->skip_tensor_hash()) {
         rpc_msg_set_tensor_hash_req request;
         request.tensor = rpc_tensor;
         request.offset = offset;
@@ -866,7 +873,11 @@ void rpc_server::hello(rpc_msg_hello_rsp & response) {
     response.major = RPC_PROTO_MAJOR_VERSION;
     response.minor = RPC_PROTO_MINOR_VERSION;
     response.patch = RPC_PROTO_PATCH_VERSION;
-    LOG_DBG("[%s] version: %d.%d.%d\n", __func__, response.major, response.minor, response.patch);
+    if (cache_dir == nullptr) {
+        // No tensor cache — no SET_TENSOR_HASH probe
+        response.flags |= RPC_HELLO_FLAG_NO_CACHE;
+    }
+    LOG_DBG("[%s] version: %d.%d.%d, flags: 0x%x\n", __func__, response.major, response.minor, response.patch, response.flags);
 }
 
 bool rpc_server::get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_msg_get_alloc_size_rsp & response) {

--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -135,6 +135,7 @@ struct socket_t::impl {
 #endif // GGML_RPC_RDMA
     bool     use_rdma;
     sockfd_t fd;
+    bool     skip_hash = false;  // server advertised no tensor cache
 };
 
 socket_t::impl::~impl() {
@@ -562,6 +563,14 @@ void socket_t::get_caps(uint8_t * local_caps) {
 
 void socket_t::update_caps(const uint8_t * remote_caps) {
     return pimpl->update_caps(remote_caps);
+}
+
+void socket_t::set_skip_tensor_hash(bool v) {
+    pimpl->skip_hash = v;
+}
+
+bool socket_t::skip_tensor_hash() const {
+    return pimpl->skip_hash;
 }
 
 static bool is_valid_fd(sockfd_t sockfd) {

--- a/ggml/src/ggml-rpc/transport.h
+++ b/ggml/src/ggml-rpc/transport.h
@@ -21,6 +21,10 @@ struct socket_t {
     void get_caps(uint8_t * local_caps);
     void update_caps(const uint8_t * remote_caps);
 
+    // Boolean to skip the SET_TENSOR_HASH dedup probe on this connection. We do this if no cache is present (e.g. RPC connections). 
+    void set_skip_tensor_hash(bool v);
+    bool skip_tensor_hash() const;
+
     static socket_ptr create_server(const char * host, int port);
     static socket_ptr connect(const char * host, int port);
 


### PR DESCRIPTION
## Overview
I noticed long, long transfer times over thunderbolt for large models over an RPC connections. Looks like when part of the model is moved over a tensor hash probe just endlessly runs with no cache. Removing this contributed a ~40% speedup for RPC connections.  A couple seconds was trimmed off of the same model on a single machine.


## Additional information

I tested this using DeepSeek-R1-Distill-Llama-70B-UD-Q8_K_XL via unsloth on both one and two Macs ( M1 Ultra 128 Gb and M3 Max 128 Gb), using the main llama.cpp branch and these tweaks to  the probe cache. For a single machine, the main branch finished in ~12 seconds, the current PR in ~10 seconds. The bigger effect is with RPC, where main was ~16 seconds but this PR was ~10 seconds again. Note that this is with a smaller model - it's a really big difference for larger models like Mini max (at least on my systems). 

## Requirements

This change only impacts a handful of lines in the /ggml/src folder. Main thing is just checking if a cache is present, if not, don't constantly try to probe for differences. There may be use cases for proving without a cache, but not sure what they might be. They should be gated by the presence of a cache. 


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I stumbled across this after a couple days of slow throughputs on my CLI harness when trying to implement with RPC. I did ask Claude Code to design a test to provide a comprehensive json file of all RPC logs which identified the probing bottleneck (earlier I thought it was some cap on TCP speeds). Each session produced ~66 megabytes of json logs to parse through.  I also had Claude create a quick .sh to check these minor changes against the deepseek R1 model.  The prompt is really small - but the primary bottleneck appears to be proving during transfer over thunderbolt. 
