### PR TITLE
fix no timeout flag handling in router mode

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1484,9 +1484,16 @@ server_http_proxy::server_http_proxy(
 
     // setup Client
     cli->set_follow_location(true);
-    cli->set_connection_timeout(timeout_read, 0); // use --timeout value instead of hardcoded 5 s
-    cli->set_write_timeout(timeout_read, 0); // reversed for cli (client) vs srv (server)
-    cli->set_read_timeout(timeout_write, 0);
+    // httplib treats {0,0} as immediate select() timeout, but in server terms
+    // timeout_read/timeout_write == 0 means "no timeout". Skip setting in that
+    // case to keep httplib's built-in defaults (connection: 300s, write: 5s, read: 300s).
+    if (timeout_read > 0) {
+        cli->set_connection_timeout(timeout_read, 0);
+        cli->set_write_timeout(timeout_read, 0); // reversed for cli (client) vs srv (server)
+    }
+    if (timeout_write > 0) {
+        cli->set_read_timeout(timeout_write, 0);
+    }
     this->status = 500; // to be overwritten upon response
     this->cleanup = [pipe]() {
         pipe->close_read();


### PR DESCRIPTION
## Overview

When running llama-server in router mode with --timeout 0, every proxied request fails with:

`proxy error: Failed to read connection`

 ## Root Cause

The router proxy reuses timeout_read/timeout_write for its internal HTTP client (httplib::ClientImpl), which uses poll() - where {0, 0} means "return immediately", not "no timeout". This differs from the non-router server, which uses setsockopt(SO_RCVTIMEO) where {0, 0} correctly disables the timeout (blocking mode).

## Fix

Skip setting httplib timeouts when the value is 0, falling back to httplib's built-in defaults (connection_timeout: 300s, write_timeout: 5s, read_timeout: 300s). Note that --timeout 0 in router mode therefore does not mean "no timeout" - users who need longer timeouts should set an explicit value like --timeout 86400.

## Additional information

Commit ff6b1062a (PR #22003) replaced the hardcoded 5-second connection timeout in server_http_proxy with the user-configurable timeout_read value:

`cli->set_connection_timeout(timeout_read, 0); // was: (5, 0)`

The same issue affects set_write_timeout(timeout_read, 0) and set_read_timeout(timeout_write, 0).

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: AI was used in an assistive capacity during debugging and implementation. I do fully understand the code and can explain it.

