### PR TITLE
fix(chat): graceful degradation for malformed tool call arguments

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2190,7 +2190,7 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
+                            LOG_WRN("Failed to parse tool call arguments as JSON, keeping as string: %s", e.what());
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

When the LLM generates tool call arguments with unescaped single quotes or other JSON parsing issues, llama.cpp throws a  and crashes the server, resulting in HTTP 500 errors. This breaks cron jobs and any automated workflow that depends on llama.cpp.

## Root Cause

In , the  function parses tool call arguments as JSON. When parsing fails (e.g., due to unescaped quotes), it throws an exception:

# 0 "<stdin>"
# 0 "<built-in>"
# 0 "<command-line>"
# 1 "/usr/include/stdc-predef.h" 1 3 4
# 0 "<command-line>" 2
# 1 "<stdin>"

## Fix

Replace the throw with a warning log and keep the arguments as a string, allowing the server to continue operating:

# 0 "<stdin>"
# 0 "<built-in>"
# 0 "<command-line>"
# 1 "/usr/include/stdc-predef.h" 1 3 4
# 0 "<command-line>" 2
# 1 "<stdin>"

This provides graceful degradation — the malformed arguments are preserved as-is rather than crashing the server.

## Testing

- Verified with Qwen3.6-35B-A3B model which frequently generates unescaped single quotes in tool call arguments
- Cron jobs using llama.cpp no longer fail with HTTP 500 errors when this occurs