### PR TITLE
document that only one on-device state can be saved per sequence

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -874,7 +874,8 @@ extern "C" {
 // work only with partial states, such as SWA KV cache or recurrent cache (e.g. Mamba)
 #define LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY 1
 
-// keeps the tensor data on device buffers (i.e. not accessible in host memory, but faster save/load)
+// Keeps the tensor data on device buffers (i.e. not accessible in host memory, but faster save/load).
+// Getting the state for a seq_id with this flag invalidates all prior states gotten for that seq_id with this flag.
 #define LLAMA_STATE_SEQ_FLAGS_ON_DEVICE 2
 
     typedef uint32_t llama_state_seq_flags;


### PR DESCRIPTION
## Overview

When using `LLAMA_STATE_SEQ_FLAGS_ON_DEVICE`, the on-device state is associated with the original sequence ID. A later call to `get_data` with that flag overwrites any previously saved state, effectively invalidating all prior states gotten with this flag.

That is not behavior I would have expected, and I only noticed because I was wondering how the lifetime of the on-device buffers is managed. 

Since I had to look at the source code to figure out how to use this API properly, I'm sending a PR to improve the documentation as suggested in `CONTRIBUTING.md`.

(I'm mildly interested in making the API work with user-managed on-device buffer lifetimes. The best idea I had so far is adding `LLAMA_STATE_SEQ_FLAGS_ON_DEVICE_ALLOC 6` which allocates new buffers and increments a counter on each `get_data` call, storing the buffers in `mem_storage` associated with the counter. That would also need a `llama_state_seq_dealloc_on_device_data` or something).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
