### PR TITLE
ci : add approval gate to remaining workflows

### DIFF
--- a/.github/workflows/approval.yml
+++ b/.github/workflows/approval.yml
@@ -1,0 +1,20 @@
+name: Approval
+
+on:
+  workflow_call:
+
+jobs:
+  approval-auto:
+    if: github.ref_name == 'master'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Auto-approve (master branch)
+        run: echo "Running on master branch - auto-approved"
+
+  approval-manual:
+    if: github.ref_name != 'master'
+    runs-on: ubuntu-slim
+    environment: ci-approval
+    steps:
+      - name: Approved after review
+        run: echo "Non-master branch - approved after manual review"

--- a/.github/workflows/build-3rd-party.yml
+++ b/.github/workflows/build-3rd-party.yml
@@ -27,7 +27,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ubuntu-24-llguidance:
+    needs: [approval]
     runs-on: ${{ 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     steps:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -32,7 +32,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   android:
+    needs: [approval]
     runs-on: ubuntu-latest
 
     steps:
@@ -59,6 +63,7 @@ jobs:
           ./gradlew build --no-daemon
 
   android-ndk:
+    needs: [approval]
     runs-on: ubuntu-latest
     container:
       image: 'ghcr.io/snapdragon-toolchain/arm64-android:v0.3'

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -37,7 +37,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   macOS-latest-ios:
+    needs: [approval]
     runs-on: macos-latest
 
     steps:
@@ -71,6 +75,7 @@ jobs:
           cmake --build build --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
 
   macos-latest-ios-xcode:
+    needs: [approval]
     runs-on: macos-latest
 
     steps:
@@ -118,6 +123,7 @@ jobs:
           xcodebuild -project examples/llama.swiftui/llama.swiftui.xcodeproj -scheme llama.swiftui -sdk iphoneos CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= -destination 'generic/platform=iOS' FRAMEWORK_FOLDER_PATH=./build-ios build
 
   macOS-latest-tvos:
+    needs: [approval]
     runs-on: macos-latest
 
     steps:
@@ -151,6 +157,7 @@ jobs:
           cmake --build build --config Release -j $(sysctl -n hw.logicalcpu) -- CODE_SIGNING_ALLOWED=NO
 
   macOS-latest-visionos:
+    needs: [approval]
     runs-on: macos-latest
 
     steps:
@@ -178,7 +185,7 @@ jobs:
 
   macOS-latest-swift:
     runs-on: macos-latest
-    needs: macos-latest-ios-xcode
+    needs: [approval, macos-latest-ios-xcode]
 
     strategy:
       matrix:

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -10,7 +10,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ubuntu-24-vulkan-cache:
+    needs: [approval]
     runs-on: ubuntu-24.04
 
     steps:
@@ -64,6 +68,7 @@ jobs:
   #        version: ${{ env.SPACEMIT_IME_TOOLCHAIN_VERSION }}
 
   ubuntu-24-openvino-cache:
+    needs: [approval]
     runs-on: ubuntu-24.04
 
     env:
@@ -92,6 +97,7 @@ jobs:
           version_full: ${{ env.OPENVINO_VERSION_FULL }}
 
   windows-2022-rocm-cache:
+    needs: [approval]
     runs-on: windows-2022
 
     env:

--- a/.github/workflows/build-cann.yml
+++ b/.github/workflows/build-cann.yml
@@ -34,7 +34,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   openEuler-latest-cann:
+    needs: [approval]
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -21,6 +21,9 @@ concurrency:
 
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   # ubuntu-24-riscv64-cpu-cross:
   #   runs-on: ubuntu-24.04
 
@@ -159,6 +162,7 @@ jobs:
   #         cmake --build build --config Release -j $(nproc)
 
   debian-13-loongarch64-cpu-cross:
+    needs: [approval]
     runs-on: ${{ 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     container: debian@sha256:653dfb9f86c3782e8369d5f7d29bb8faba1f4bff9025db46e807fa4c22903671
 
@@ -214,6 +218,7 @@ jobs:
           cmake --build build --config Release -j $(nproc)
 
   debian-13-loongarch64-vulkan-cross:
+    needs: [approval]
     runs-on: ${{ 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     container: debian@sha256:653dfb9f86c3782e8369d5f7d29bb8faba1f4bff9025db46e807fa4c22903671
 
@@ -273,6 +278,7 @@ jobs:
           cmake --build build --config Release -j $(nproc)
 
   ubuntu-24-riscv64-cpu-spacemit-ime-cross:
+    needs: [approval]
     runs-on: ubuntu-24.04
 
     env:

--- a/.github/workflows/build-msys.yml
+++ b/.github/workflows/build-msys.yml
@@ -20,7 +20,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   windows-msys2:
+    needs: [approval]
     runs-on: windows-2025
 
     strategy:

--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -34,7 +34,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ubuntu-24-openvino:
+    needs: [approval]
     name: ubuntu-24-openvino-${{ matrix.openvino_device }}
 
     concurrency:

--- a/.github/workflows/build-riscv.yml
+++ b/.github/workflows/build-riscv.yml
@@ -34,7 +34,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ubuntu-riscv64-native-sanitizer:
+    needs: [approval]
     runs-on: ubuntu-24.04-riscv
 
     continue-on-error: true

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -27,7 +27,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ubuntu-latest-sanitizer:
+    needs: [approval]
     runs-on: ubuntu-latest
 
     continue-on-error: true

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -55,7 +55,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   determine-tag:
+    needs: [approval]
     name: Determine tag name
     runs-on: ubuntu-slim
     outputs:

--- a/.github/workflows/build-sycl.yml
+++ b/.github/workflows/build-sycl.yml
@@ -34,8 +34,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
 
   ubuntu-24-sycl:
+    needs: [approval]
     strategy:
       matrix:
         build: [fp32, fp16]
@@ -108,6 +111,7 @@ jobs:
           time cmake --build build --config Release -j $(nproc)
 
   windows-latest-sycl:
+    needs: [approval]
     runs-on: windows-2022
 
     defaults:

--- a/.github/workflows/build-virtgpu.yml
+++ b/.github/workflows/build-virtgpu.yml
@@ -27,7 +27,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ubuntu-24-virtgpu:
+    needs: [approval]
     runs-on: ${{ 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     steps:

--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -36,7 +36,11 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ubuntu-24-vulkan-llvmpipe:
+    needs: [approval]
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,15 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   build-cmake-pkg:
+    needs: [approval]
     uses: ./.github/workflows/build-cmake-pkg.yml
 
   macOS-latest-arm64:
+    needs: [approval]
     runs-on: macos-latest
 
     steps:
@@ -97,6 +102,7 @@ jobs:
           ctest -L main -E "test-llama-archs" --verbose --timeout 900
 
   macOS-latest-x64:
+    needs: [approval]
     runs-on: macos-15-intel
 
     steps:
@@ -133,6 +139,7 @@ jobs:
           ctest -L main --verbose --timeout 900
 
   macOS-latest-arm64-webgpu:
+    needs: [approval]
     runs-on: macos-latest
 
     steps:
@@ -174,6 +181,7 @@ jobs:
           ctest -L main --verbose --timeout 900
 
   ubuntu-cpu:
+    needs: [approval]
     strategy:
       matrix:
         include:
@@ -268,6 +276,7 @@ jobs:
           ./bin/llama-completion -m stories260K-be.gguf -p "One day, Lily met a Shoggoth" -n 500 -c 256
 
   android-arm64:
+    needs: [approval]
     runs-on: ubuntu-latest
 
     env:
@@ -318,6 +327,7 @@ jobs:
           time cmake --build build --config Release -j $(nproc)
 
   ubuntu-latest-rpc:
+    needs: [approval]
     runs-on: ubuntu-latest
 
     continue-on-error: true
@@ -349,6 +359,7 @@ jobs:
           ctest -L main --verbose
 
   ubuntu-24-vulkan:
+    needs: [approval]
     strategy:
       matrix:
         include:
@@ -388,6 +399,7 @@ jobs:
           time cmake --build build -j $(nproc)
 
   ubuntu-24-webgpu:
+    needs: [approval]
     runs-on: ubuntu-24.04
 
     steps:
@@ -460,6 +472,7 @@ jobs:
           ctest -L main -E test-backend-ops --verbose --timeout 900
 
   ubuntu-24-webgpu-wasm:
+    needs: [approval]
     runs-on: ${{ 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     steps:
@@ -496,6 +509,7 @@ jobs:
           time cmake --build build-wasm --config Release --target test-backend-ops -j $(nproc)
 
   ubuntu-22-hip:
+    needs: [approval]
     runs-on: ubuntu-22.04
     container: rocm/dev-ubuntu-22.04:6.1.2
 
@@ -528,6 +542,7 @@ jobs:
           cmake --build build --config Release -j $(nproc)
 
   ubuntu-22-musa:
+    needs: [approval]
     runs-on: ubuntu-22.04
     container: mthreads/musa:rc4.3.0-devel-ubuntu22.04-amd64
 
@@ -558,6 +573,7 @@ jobs:
 
 
   windows-latest:
+    needs: [approval]
     runs-on: windows-2025
 
     env:
@@ -680,6 +696,7 @@ jobs:
       #     & $sde -future -- ctest -L main -C Release --verbose --timeout 900
 
   ubuntu-latest-cuda:
+    needs: [approval]
     runs-on: ubuntu-latest
     container: nvidia/cuda:12.6.2-devel-ubuntu24.04
 
@@ -716,6 +733,7 @@ jobs:
             cmake --build build
 
   windows-2022-cuda:
+    needs: [approval]
     runs-on: windows-2022
 
     strategy:
@@ -766,6 +784,7 @@ jobs:
 
 
   windows-latest-hip:
+    needs: [approval]
     runs-on: windows-2022
 
     env:
@@ -834,6 +853,7 @@ jobs:
           cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
 
   ubuntu-cpu-riscv64-native:
+    needs: [approval]
     runs-on: ubuntu-24.04-riscv
 
     steps:
@@ -906,6 +926,7 @@ jobs:
 # TODO: simplify the following workflows using a matrix
 # TODO: run lighter CI on PRs and the full CI only on master (if needed)
   ggml-ci-x64-cpu-low-perf:
+    needs: [approval]
     runs-on: ubuntu-22.04
 
     steps:
@@ -932,6 +953,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-low-perf:
+    needs: [approval]
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -958,6 +980,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-x64-cpu-high-perf:
+    needs: [approval]
     runs-on: ubuntu-22.04
 
     steps:
@@ -984,6 +1007,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-high-perf:
+    needs: [approval]
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -1010,6 +1034,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 GG_BUILD_NO_SVE=1 GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-high-perf-sve:
+    needs: [approval]
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -1036,6 +1061,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-kleidiai:
+     needs: [approval]
      runs-on: ubuntu-22.04-arm
 
      steps:
@@ -1062,6 +1088,7 @@ jobs:
            GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-kleidiai-graviton4:
+     needs: [approval]
      runs-on: ah-ubuntu_22_04-c8g_8x
 
      steps:

--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -36,7 +36,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   server:
+    needs: [approval]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/server-self-hosted.yml
+++ b/.github/workflows/server-self-hosted.yml
@@ -39,7 +39,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   server-metal:
+    needs: [approval]
     runs-on: [self-hosted, llama-server, macOS, ARM64]
 
     name: server-metal (${{ matrix.wf_name }})
@@ -132,6 +136,7 @@ jobs:
   #          pytest -v -x -m "not slow"
 
   server-kleidiai:
+    needs: [approval]
     runs-on: ah-ubuntu_22_04-c8g_8x
 
     name: server-kleidiai (${{ matrix.wf_name }})

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -54,7 +54,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   server:
+    needs: [approval]
     runs-on: ubuntu-latest
 
     name: server (${{ matrix.wf_name }})
@@ -132,6 +136,7 @@ jobs:
           SLOW_TESTS=1 pytest -v -x
 
   server-windows:
+    needs: [approval]
     runs-on: windows-2022
 
     steps:

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -34,7 +34,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approval:
+    uses: ./.github/workflows/approval.yml
+
   ui-build:
+    needs: [approval]
     name: Build static output
     uses: ./.github/workflows/ui-build.yml
 


### PR DESCRIPTION
## Overview

Extend the manual CI approval gate (from `approval.yml`) to all remaining workflows that were missed in the initial rollout. This prevents expensive CI runs on non-master branches from executing without manual approval via the `ci-approval` environment.

**Covered workflows (17 files):**
- `build-3rd-party`, `build-android`, `build-cache`, `build-cann`, `build-cross`
- `build-msys`, `build-openvino`, `build-riscv`, `build-sanitize`
- `build-self-hosted`, `build-sycl`, `build-virtgpu`, `build-vulkan`
- `server`, `server-sanitize`, `server-self-hosted`
- `ui-ci`

`ui-build.yml` and `ui-publish.yml` are skipped as they're only triggered via `workflow_call` and inherit the gate from their caller.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES. llama.cpp + pi + Qwen3.6-27B-MTP:Q4_K
