### PR TITLE
ggml-cuda: tune RDNA3 Q4_K MMVQ nwarps

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -358,7 +358,6 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
                 case GGML_TYPE_Q5_0:
                 case GGML_TYPE_Q5_1:
                 case GGML_TYPE_Q8_0:
-                case GGML_TYPE_Q4_K:
                     return 8;
                 case GGML_TYPE_Q6_K:
                     return 2;


### PR DESCRIPTION
## Overview

This is a narrow RDNA3_0 MMVQ launch-geometry change in:

```text
ggml/src/ggml-cuda/mmvq.cu
```

Current behavior places `GGML_TYPE_Q4_K` in the RDNA3_0 `return 8` group for `ncols_dst == 1`.

This change removes `GGML_TYPE_Q4_K` from that group so it falls through to the existing default:

```cpp
default:
    return 1;
```

This does **not** change quantization, arithmetic, memory layout, or output semantics.

## Scope

This change:

- affects only RDNA3_0
- affects only `GGML_TYPE_Q4_K`
- affects only `ncols_dst == 1`
- leaves `Q6_K`, `IQ4_NL`, `Q8_0`, and non-RDNA3 tables unchanged
- does not change quantization, arithmetic, memory layout, or output semantics

## Motivation

On AMD Radeon Pro W7800 48GB / `gfx1100` with ROCm 7.2.3, using `nwarps=1` improves Q4_K_S/M/L decode and `pp+tg` benchmark results across the following validation models:

- Qwen2.5-1.5B
- Llama-3.2-3B
- Marco-Nano

MUL_MAT correctness is preserved.

## Correctness

Tested on:

```text
GPU:  AMD Radeon Pro W7800 48GB
Arch: gfx1100
ROCm: 7.2.3
```

Command:

```bash
test-backend-ops -o MUL_MAT -b ROCm0 -p q4_K
```

Result:

```text
41/41 tests passed
Backend ROCm0: OK
```

## Benchmark setup

Benchmark command shape:

```bash
llama-bench \
  -ngl 99 -fa 1 -ctk q8_0 -ctv f16 \
  -b 2048 -ub 2048 -t 4 --poll 0 -r 3 \
  -pg 0,128 -pg 1024,128
```

## Q4_K_S / Q4_K_M / Q4_K_L validation 

| Model / quant | tg128 nwarps=1 | tg128 nwarps=8 | tg gain | pp1024+tg128 nwarps=1 | pp1024+tg128 nwarps=8 | pp+tg gain |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Qwen2.5-1.5B Q4_K_S | 248.47 | 185.88 | +33.7% | 1872.20 | 1456.53 | +28.5% |
| Qwen2.5-1.5B Q4_K_M | 220.41 | 170.65 | +29.2% | 1691.27 | 1349.67 | +25.3% |
| Qwen2.5-1.5B Q4_K_L | 225.55 | 178.75 | +26.2% | 1789.27 | 1401.40 | +27.7% |
| Llama-3.2-3B Q4_K_S | 163.66 | 140.01 | +16.9% | 1162.83 | 1018.16 | +14.2% |
| Llama-3.2-3B Q4_K_M | 150.31 | 129.98 | +15.6% | 1077.37 | 952.15 | +13.2% |
| Llama-3.2-3B Q4_K_L | 157.31 | 134.44 | +17.0% | 1130.83 | 985.86 | +14.7% |
| Marco-Nano Q4_K_S | 205.08 | 182.36 | +12.5% | 1526.34 | 1379.21 | +10.7% |
| Marco-Nano Q4_K_M | 182.86 | 164.70 | +11.0% | 1396.13 | 1272.19 | +9.7% |

`Marco-Nano Q4_K_L` was not available in the static non-imatrix GGUF set used for validation.

## Notes

This was measured on W7800 / `gfx1100`.

**Important:** Additional W7900/RDNA3 confirmation would be useful before treating this as universal RDNA3 behavior.

I can also run a follow-up sweep for the other RDNA3_0 `return 8` types (`Q4_0`, `Q4_1`, `Q5_0`, `Q5_1`, `Q8_0`, `IQ4_NL`) if maintainers want broader table validation. I kept this PR scoped to `Q4_K` because that is the type validated across Q4_K_S/M/L.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used assistively for experiment organization and wording review. I reviewed the code change, benchmark results, and I can explain the submitted change.