### PR TITLE
CUDA: Check PTX version on host side to guard PDL dispatch

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1564,38 +1564,23 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
     struct cache_key_hash {
         // MurmurHash3 mixing function for better hash distribution (vs. just std::hash which in some implementations simply returns the identity)
         static std::size_t hash_mix(std::size_t x) {
-            // 64-bit path
-            if constexpr (sizeof(std::size_t) >= 8) {
-                std::uint64_t y = x;
-                const std::uint64_t m = 0xe9846af9b1a615d;
+            std::uint64_t y = x;
+            const std::uint64_t m = 0xe9846af9b1a615d;
 
-                y ^= y >> 32;
-                y *= m;
-                y ^= y >> 32;
-                y *= m;
-                y ^= y >> 28;
+            y ^= y >> 32;
+            y *= m;
+            y ^= y >> 32;
+            y *= m;
+            y ^= y >> 28;
 
-                return static_cast<std::size_t>(y);
-            } else {
-                // 32-bit path
-                std::uint32_t y = x;
-                const std::uint32_t m1 = 0x21f0aaad;
-                const std::uint32_t m2 = 0x735a2d97;
-
-                y ^= y >> 16;
-                y *= m1;
-                y ^= y >> 15;
-                y *= m2;
-                y ^= y >> 15;
-
-                return static_cast<std::size_t>(y);
-            }
+            return static_cast<std::size_t>(y);
         }
 
         std::size_t operator()(const cache_key & key) const {
-            std::size_t h = 0;
-            h = hash_mix(h + std::hash<int>{}(key.device));
-            h = hash_mix(h + std::hash<const void *>{}(key.kernel));
+            // Use a nonzero seed to avoid mapping all-zero keys to zero
+            std::size_t h = 42;
+            h = hash_mix(h + key.device);
+            h = hash_mix(h + reinterpret_cast<std::size_t>(key.kernel));
             return h;
         }
     };

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1564,7 +1564,7 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
     struct cache_key_hash {
         // MurmurHash3 mixing function for better hash distribution (vs. just std::hash which in some implementations simply returns the identity)
         static std::size_t hash_mix(std::size_t x) {
-            std::uint64_t y = x;
+            std::uint64_t       y = x;
             const std::uint64_t m = 0xe9846af9b1a615d;
 
             y ^= y >> 32;
@@ -1579,8 +1579,8 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
         std::size_t operator()(const cache_key & key) const {
             // Use a nonzero seed to avoid mapping all-zero keys to zero
             std::size_t h = 42;
-            h = hash_mix(h + key.device);
-            h = hash_mix(h + reinterpret_cast<std::size_t>(key.kernel));
+            h             = hash_mix(h + key.device);
+            h             = hash_mix(h + reinterpret_cast<std::size_t>(key.kernel));
             return h;
         }
     };

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1563,7 +1563,7 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
 
     struct cache_key_hash {
         // MurmurHash3 mixing function for better hash distribution (vs. just std::hash which in some implementations simply returns the identity)
-        static std::size_t hash_mix(std::size_t x) {
+        static size_t hash_mix(size_t x) {
             std::uint64_t       y = x;
             const std::uint64_t m = 0xe9846af9b1a615d;
 
@@ -1573,14 +1573,14 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
             y *= m;
             y ^= y >> 28;
 
-            return static_cast<std::size_t>(y);
+            return static_cast<size_t>(y);
         }
 
-        std::size_t operator()(const cache_key & key) const {
+        size_t operator()(const cache_key & key) const {
             // Use a nonzero seed to avoid mapping all-zero keys to zero
-            std::size_t h = 42;
-            h             = hash_mix(h + key.device);
-            h             = hash_mix(h + reinterpret_cast<std::size_t>(key.kernel));
+            size_t h = 42;
+            h        = hash_mix(h + key.device);
+            h        = hash_mix(h + reinterpret_cast<size_t>(key.kernel));
             return h;
         }
     };

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1562,8 +1562,41 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
     };
 
     struct cache_key_hash {
+        // MurmurHash3 mixing function for better hash distribution
+        static std::size_t hash_mix(std::size_t x) {
+            // 64-bit path
+            if constexpr (sizeof(std::size_t) >= 8) {
+                std::uint64_t y = x;
+                const std::uint64_t m = 0xe9846af9b1a615d;
+
+                y ^= y >> 32;
+                y *= m;
+                y ^= y >> 32;
+                y *= m;
+                y ^= y >> 28;
+
+                return static_cast<std::size_t>(y);
+            } else {
+                // 32-bit path
+                std::uint32_t y = x;
+                const std::uint32_t m1 = 0x21f0aaad;
+                const std::uint32_t m2 = 0x735a2d97;
+
+                y ^= y >> 16;
+                y *= m1;
+                y ^= y >> 15;
+                y *= m2;
+                y ^= y >> 15;
+
+                return static_cast<std::size_t>(y);
+            }
+        }
+
         std::size_t operator()(const cache_key & key) const {
-            return std::hash<int>{}(key.device) ^ (std::hash<const void *>{}(key.kernel) << 1);
+            std::size_t h = 0;
+            h = hash_mix(h + std::hash<int>{}(key.device));
+            h = hash_mix(h + std::hash<const void *>{}(key.kernel));
+            return h;
         }
     };
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <mutex>
 
 #if defined(GGML_USE_HIP)
 #define GGML_COMMON_DECL_HIP
@@ -1549,6 +1550,44 @@ struct ggml_cuda_pdl_config {
     ggml_cuda_pdl_config& operator=(ggml_cuda_pdl_config&&) = delete;
 
 };
+
+static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
+    const int device = ggml_cuda_get_device();
+
+    struct cache_key {
+        int          device;
+        const void * kernel;
+
+        bool operator==(const cache_key & other) const { return device == other.device && kernel == other.kernel; }
+    };
+
+    struct cache_key_hash {
+        std::size_t operator()(const cache_key & key) const {
+            return std::hash<int>{}(key.device) ^ (std::hash<const void *>{}(key.kernel) << 1);
+        }
+    };
+
+    static std::mutex                                          cache_mutex;
+    static std::unordered_map<cache_key, bool, cache_key_hash> cache;
+
+    const cache_key             key = { device, kernel };
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    const auto                  it = cache.find(key);
+    if (it != cache.end()) {
+        return it->second;
+    }
+
+    cudaFuncAttributes attr = {};
+    CUDA_CHECK(cudaFuncGetAttributes(&attr, kernel));
+
+    // PDL device-side primitives are emitted only for PTX versions >= 90.
+    // We have to guard on a loaded kernel's PTX version so a kernel forward-JIT'ed
+    // from pre-Hopper PTX to a Hopper-or-newer GPU does not opt into PDL.
+    const bool can_use_pdl = attr.ptxVersion >= 90;
+    cache.emplace(key, can_use_pdl);
+    return can_use_pdl;
+}
+
 #endif //defined(GGML_CUDA_USE_PDL)
 
 
@@ -1561,8 +1600,7 @@ static __inline__ void ggml_cuda_kernel_launch(Kernel kernel, const ggml_cuda_ke
         return env == nullptr || std::atoi(env) != 0;
     }();
 
-    const int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
-    if (env_pdl_enabled && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_HOPPER) {
+    if (env_pdl_enabled && ggml_cuda_kernel_can_use_pdl(reinterpret_cast<const void *>(kernel))) {
         auto pdl_cfg = ggml_cuda_pdl_config(launch_params);
 
         CUDA_CHECK(cudaLaunchKernelEx(&pdl_cfg.cfg, kernel, std::forward<Args>(args)... ));

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1562,7 +1562,7 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
     };
 
     struct cache_key_hash {
-        // MurmurHash3 mixing function for better hash distribution
+        // MurmurHash3 mixing function for better hash distribution (vs. just std::hash which in some implementations simply returns the identity)
         static std::size_t hash_mix(std::size_t x) {
             // 64-bit path
             if constexpr (sizeof(std::size_t) >= 8) {


### PR DESCRIPTION
## Overview

Checking on `__CUDA_ARCH_LIST__` alone is insufficient for JIT, as this variable doesn't differentiate between compiling for say sm_90, sm_90a or sm_90f (so forward-jittable PTX vs. arch/family-specific PTX).

Thus, one can have a bug when compiling with
`DCMAKE_CUDA_ARCHITECTURES="89;90a"`, where current code would wrongly dispatch to PDL on sm_90/sm_120 in forward-JIT mode.

This PR fixes this issue by checking `cudaFuncAttributes::ptxVersion` of the incoming kernel at runtime. A check on ptxVersion alone is sufficient, as device-codes will always be >= ptxVersion (and any violation of this would be a severe bug in CUDA/nvcc), see:
 https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#gpu-code-code-code

## Additional information

Follow-up to #23471 that implements a more complete fix.

To verify, apply

```diff
diff --git a/ggml/src/ggml-cuda/common.cuh b/ggml/src/ggml-cuda/common.cuh
index 20b1846c0..19dd53a72 100644
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1584,6 +1584,9 @@ static bool ggml_cuda_kernel_can_use_pdl(const void * kernel) {
     // We have to guard on a loaded kernel's PTX version so a kernel forward-JIT'ed
     // from pre-Hopper PTX to a Hopper-or-newer GPU does not opt into PDL.
     const bool can_use_pdl = attr.ptxVersion >= 90;
+    printf("Kernel %p on device %d has PTX version %d -> can_use_pdl = %d, highest compiled_arch = %d\n", kernel,
+           device, attr.ptxVersion, can_use_pdl,
+           ggml_cuda_highest_compiled_arch(ggml_cuda_info().devices[ggml_cuda_get_device()].cc));
     cache.emplace(key, can_use_pdl);
     return can_use_pdl;
 }
```
& compile with something like

```
cmake -S . -B build_test_ptx -G Ninja \                                
  -DLLAMA_FATAL_WARNINGS=ON \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CUDA_ARCHITECTURES="89;90a" \
  -DGGML_CUDA=ON
```

Running `test-backend-ops -o MUL_MAT` on a CC > 9.0 GPU will now correctly disable PDL, and show logs like
`Kernel 0x7cf22ed84aa0 on device 0 has PTX version 89 -> can_use_pdl = 0, highest compiled_arch = 900`
 
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - paired with codex on this. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
