### PR TITLE
docs(build): warn about arch-coverage runtime crashes in MoE kernels

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -212,6 +212,19 @@ GeForce RTX 3070      8.6
 cmake -B build -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="86;89"
 ```
 
+#### 3. Diagnosing arch-coverage runtime crashes
+
+If your binary builds successfully but crashes on the first MoE forward pass with
+`ggml_cuda_compute_forward: MUL_MAT_ID failed / CUDA error: invalid argument`, check
+the `system_info` line in startup logs for `CUDA : ARCHS = <N>`. If `<N>` does not
+include your GPU's compute capability, the binary may have been built without
+SASS coverage for your device — in our experience this manifests as MoE expert-routing
+crashes even when standard matmul/attention paths run normally.
+
+This commonly happens for container builds where `nvcc -arch=native` cannot probe
+a GPU during build. Rebuild with explicit arch coverage as described above, or
+disable native detection with `-DGGML_NATIVE=OFF`.
+
 ### Overriding the CUDA Version
 
 If you have multiple CUDA installations on your system and want to compile llama.cpp for a specific one, e.g. for CUDA 11.7 installed under `/opt/cuda-11.7`:


### PR DESCRIPTION
Adds a runtime-symptom diagnostic subsection to the CUDA build docs.

When a binary is built without SASS coverage for the target GPU (common in container builds where `nvcc -arch=native` cannot probe a device during build), the build succeeds but inference crashes on the first MoE forward pass with a cryptic `MUL_MAT_ID failed / CUDA error: invalid argument`. The existing docs cover how to *set* explicit arch values; this addition covers how to *recognize* the runtime symptom and map it back to the existing guidance via the `system_info ARCHS = <N>` log line.

Context: hit on RTX 3090 (sm_86) running Qwen3.6-35B-A3B from a self-built container — see #21289 for an open issue covering the same crash on sm_120 with prebuilt binaries. Posted my diagnostic notes there as well.