### PR TITLE
server : reduce VRAM reservation for logits buffer in graph_reserve

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1357,6 +1357,16 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_KV_UNIFIED").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_PERPLEXITY, LLAMA_EXAMPLE_BATCHED, LLAMA_EXAMPLE_BENCH, LLAMA_EXAMPLE_PARALLEL}));
     add_opt(common_arg(
+        {"--logits-all"},
+        {"--no-logits-all"},
+        string_format("reserve logits buffer for all tokens in the batch, not just the last token per sequence (default: %s)\n"
+            "disable to save VRAM on big-vocab models when per-token logits are not needed (e.g. chat/completion workloads)",
+            params.logits_all ? "true" : "false"),
+        [](common_params & params, bool value) {
+            params.logits_all = value;
+        }
+    ).set_env("LLAMA_ARG_LOGITS_ALL").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_PERPLEXITY, LLAMA_EXAMPLE_BATCHED, LLAMA_EXAMPLE_BENCH, LLAMA_EXAMPLE_PARALLEL}));
+    add_opt(common_arg(
         {"--cache-idle-slots"},
         {"--no-cache-idle-slots"},
         "save and clear idle slots on new task (default: enabled, requires unified KV and cache-ram)",

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1566,6 +1566,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.op_offload        = !params.no_op_offload;
     cparams.swa_full          = params.swa_full;
     cparams.kv_unified        = params.kv_unified;
+    cparams.logits_all        = params.logits_all;
 
     cparams.type_k = params.cache_type_k;
     cparams.type_v = params.cache_type_v;

--- a/common/common.h
+++ b/common/common.h
@@ -543,6 +543,7 @@ struct common_params {
     bool ctx_shift         = false; // context shift on infinite text generation
     bool swa_full          = false; // use full-size SWA cache (https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055)
     bool kv_unified        = false; // enable unified KV cache
+    bool logits_all        = true;  // see llama_context_params.logits_all
 
     bool input_prefix_bos  = false; // prefix BOS to user inputs, preceding input_prefix
     bool use_mmap          = true;  // enable mmap to use filesystem cache

--- a/include/llama.h
+++ b/include/llama.h
@@ -381,6 +381,8 @@ extern "C" {
         bool kv_unified;  // use a unified buffer across the input sequences when computing the attention
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
+        bool logits_all;  // if false, reserve logits buffer for n_seqs outputs only (saves VRAM on big-vocab models);
+                          // set true when per-token logits are needed (e.g. perplexity)
 
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -184,6 +184,7 @@ llama_context::llama_context(
 
     cparams.op_offload = params.op_offload;
     cparams.kv_unified = params.kv_unified;
+    cparams.logits_all = params.logits_all;
 
     // initialized later
     cparams.pipeline_parallel = false;
@@ -571,6 +572,9 @@ void llama_context::sched_reserve() {
     }
 
     // reserve worst-case graph
+    // when logits_all is false, reserve for n_seqs outputs only to save VRAM on big-vocab models
+    const int n_outputs_pp = (cparams.logits_all || cparams.ctx_type == LLAMA_CONTEXT_TYPE_MTP) ? (int)n_tokens : (int)n_seqs;
+
     int n_splits_pp = -1;
     int n_nodes_pp  = -1;
 
@@ -579,14 +583,14 @@ void llama_context::sched_reserve() {
 
     // reserve pp (prompt processing) graph first so that buffers are only allocated once
     {
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get(),
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get(),
                 model.hparams.no_alloc, model.hparams.no_alloc ? backend_buf_exp_size.data() : nullptr);
         if (!gf) {
             if (cparams.pipeline_parallel) {
                 LLAMA_LOG_WARN("%s: compute buffer allocation failed, retrying without pipeline parallelism\n", __func__);
                 cparams.pipeline_parallel = false;
                 sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, false, cparams.op_offload));
-                gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get());
+                gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
             }
             if (!gf) {
                 throw std::runtime_error("failed to allocate compute pp buffers");
@@ -612,9 +616,9 @@ void llama_context::sched_reserve() {
     {
         // TODO: not sure if the following graph would be worst case for multi-stream KV caches:
         //
-        // auto * gf = graph_reserve(n_tokens, 1, n_tokens, mctx.get());
+        // auto * gf = graph_reserve(n_tokens, 1, n_outputs_pp, mctx.get());
         //
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get(), model.hparams.no_alloc);
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get(), model.hparams.no_alloc);
         if (!gf) {
             throw std::runtime_error("failed to allocate compute pp buffers");
         }
@@ -774,7 +778,8 @@ bool llama_context::memory_update(bool optimize) {
         const uint32_t n_seqs = cparams.n_seq_max;
         const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
 
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get());
+        const int n_outputs_pp = (cparams.logits_all || cparams.ctx_type == LLAMA_CONTEXT_TYPE_MTP) ? (int)n_tokens : (int)n_seqs;
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
         if (!gf) {
             LLAMA_LOG_ERROR("%s: failed to reserve graph after the memory update\n", __func__);
         }
@@ -1780,6 +1785,13 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
             // needs to happen before the graph is built
             n_outputs = n_outputs_new;
+
+            if (!cparams.logits_all && !warned_logits_all && n_outputs > (int32_t)cparams.n_seq_max) {
+                warned_logits_all = true;
+                LLAMA_LOG_WARN("%s: --no-logits-all is set but batch requested %d outputs (> n_seq_max = %d); "
+                               "consider removing --no-logits-all for this workload\n",
+                               __func__, n_outputs, cparams.n_seq_max);
+            }
         }
 
         ggml_status status;
@@ -3364,6 +3376,7 @@ llama_context_params llama_context_default_params() {
         /*.op_offload                  =*/ true,
         /*.swa_full                    =*/ true,
         /*.kv_unified                  =*/ false,
+        /*.logits_all                  =*/ true,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
     };

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -356,7 +356,8 @@ private:
     // keep copies of the per-sequence memory on the device
     std::map<llama_seq_id, llama_memory_buffers> mem_storage;
 
-    bool has_evaluated_once = false;
+    bool has_evaluated_once    = false;
+    bool warned_logits_all     = false;
 
     // env: LLAMA_GRAPH_REUSE_DISABLE
     bool graph_reuse_disable = false;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -41,6 +41,7 @@ struct llama_cparams {
     bool warmup;
     bool op_offload;
     bool kv_unified;
+    bool logits_all;
     bool pipeline_parallel;
 
     enum llama_context_type ctx_type;


### PR DESCRIPTION
## Overview

`llama_context::sched_reserve` calls `graph_reserve(n_tokens, n_seqs, n_tokens, ...)` where the third argument sets the logit buffer size for every token in the ubatch. In chat/completion workloads only one logit per sequence is needed, so on big-vocab models (like Qwen, vocab ~151k) with large ubatches (`-ub 4096`) this uses ~2 GB of VRAM at idle.

This fix adds a `logits_all` flag to `llama_context_params` (default `true`, fully backward-compatible). When set to `false`, the pp graph reservation uses `n_seqs` outputs instead of `n_tokens`. A `--logits-all` / `--no-logits-all` CLI arg is exposed so users can opt in to the savings explicitly.

Tested on RTX 5070 with Qwen2.5-0.5B (same flags as the issue):

| | VRAM delta at startup |
|---|---|
| `--logits-all` (default) | +3,172 MiB |
| `--no-logits-all` | +1,198 MiB |
| **saved** | **~1,974 MiB** |

## Additional information

If `--no-logits-all` is used on a workload that requests more outputs than `n_seqs` at runtime (e.g. perplexity), ggml-alloc re-allocates to the larger size and a one-time warning is emitted. This is the "explicit opt-in" design @JohannesGaessler described, the caller accepts the re-allocation risk.

To avoid spamming the log, a `warned_logits_all` member on `llama_context` limits the warning to firing once. Open to alternatives: keep the member (current) or fire on every decode (kinda spammy but no header change needed).

Fixes #23527

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - for general code hygiene. I fully understand the fix and take responsibility for it. (Edit: This was set as NO when i first submitted as i copied the template from a previous PR that had 'NO')
