### PR TITLE
server: fix --cache-ram not preventing RAM OOM

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -113,12 +113,14 @@ struct server_slot {
         const size_t cur_size_tgt =           llama_state_seq_get_size_ext(ctx_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
         const size_t cur_size_dft = ctx_dft ? llama_state_seq_get_size_ext(ctx_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE) : 0;
 
-        const size_t cur_size = cur_size_tgt + cur_size_dft;
+        const size_t cur_size_ckpt = prompt.size();
+        const size_t cur_size = cur_size_tgt + cur_size_dft + cur_size_ckpt;
 
-        SRV_WRN(" - saving prompt with length %d, total state size = %.3f MiB (draft: %.3f MiB)\n",
-                (int) prompt.tokens.size(), cur_size / (1024.0 * 1024.0), cur_size_dft / (1024.0 * 1024.0));
+        SRV_WRN(" - saving prompt with length %d, total state size = %.3f MiB (kv: %.3f MiB, draft: %.3f MiB, ckpt: %.3f MiB)\n",
+                (int) prompt.tokens.size(), cur_size / (1024.0 * 1024.0),
+                cur_size_tgt / (1024.0 * 1024.0), cur_size_dft / (1024.0 * 1024.0), cur_size_ckpt / (1024.0 * 1024.0));
 
-        auto * cur = prompt_cache.alloc(prompt, cur_size_tgt, cur_size_dft);
+        auto * cur = prompt_cache.alloc(prompt, cur_size_tgt, cur_size_dft, cur_size_ckpt);
         if (cur == nullptr) {
             return;
         }

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -2025,6 +2025,20 @@ server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t 
     std::vector<uint8_t> state_data_tgt;
     std::vector<uint8_t> state_data_dft;
 
+    const size_t new_size = state_size_tgt + state_size_dft;
+
+    // if a single state exceeds the limit, skip caching to avoid OOM
+    if (limit_size > 0 && new_size > limit_size) {
+        SRV_WRN(" - single state (%.3f MiB) exceeds cache limit (%.3f MiB), skipping cache\n",
+                new_size / (1024.0 * 1024.0), limit_size / (1024.0 * 1024.0));
+        return nullptr;
+    }
+
+    // evict old entries before allocating to avoid exceeding the limit
+    if (limit_size > 0 && (size() + new_size > limit_size)) {
+        update();
+    }
+
     // check if we can allocate enough memory for the new state
     try {
         state_data_tgt.resize(state_size_tgt);

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1998,7 +1998,11 @@ size_t server_prompt_cache::n_tokens() const {
     return res;
 }
 
-server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t state_size_tgt, size_t state_size_dft) {
+server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t state_size_tgt, size_t state_size_dft, size_t state_size_ckpt) {
+    // account for checkpoint data to match the actual entry size
+
+    const size_t new_alloc_size = state_size_tgt + state_size_dft + state_size_ckpt;
+
     // first check if the current state is contained fully in the cache
     for (auto it = states.begin(); it != states.end(); ++it) {
         const int cur_lcp_len = it->tokens.get_common_prefix(prompt.tokens);
@@ -2025,33 +2029,25 @@ server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t 
     std::vector<uint8_t> state_data_tgt;
     std::vector<uint8_t> state_data_dft;
 
-    const size_t new_size = state_size_tgt + state_size_dft;
-
     // if a single state exceeds the limit, skip caching to avoid OOM
-    if (limit_size > 0 && new_size > limit_size) {
+    if (limit_size > 0 && new_alloc_size > limit_size) {
         SRV_WRN(" - single state (%.3f MiB) exceeds cache limit (%.3f MiB), skipping cache\n",
-                new_size / (1024.0 * 1024.0), limit_size / (1024.0 * 1024.0));
+                new_alloc_size / (1024.0 * 1024.0), limit_size / (1024.0 * 1024.0));
         return nullptr;
     }
 
     // evict old entries before allocating to avoid exceeding the limit
-    if (limit_size > 0 && (size() + new_size > limit_size)) {
-        update();
+    if (limit_size > 0 && (size() + new_alloc_size > limit_size)) {
+        update(new_alloc_size, prompt.tokens.size());
     }
 
-    // check if we can allocate enough memory for the new state
+
+    // allocate memory for the new state; catch system-level OOM
     try {
         state_data_tgt.resize(state_size_tgt);
         state_data_dft.resize(state_size_dft);
     } catch (const std::bad_alloc & e) {
         SRV_ERR("failed to allocate memory for prompt cache state: %s\n", e.what());
-
-        limit_size = std::max<size_t>(1, 0.4*size());
-
-        SRV_WRN(" - cache size limit reduced to %.3f MiB\n", limit_size / (1024.0 * 1024.0));
-
-        update();
-
         return nullptr;
     }
 
@@ -2142,16 +2138,11 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
     return true;
 }
 
-void server_prompt_cache::update() {
+void server_prompt_cache::update(size_t new_alloc_size, int new_alloc_tokens) {
     if (limit_size > 0) {
-        // always keep at least one state, regardless of the limits
-        while (states.size() > 1 && size() > limit_size) {
-            if (states.empty()) {
-                break;
-            }
-
+        // evict until new prompt fits; it will be allocated immediately, so clearing is safe
+        while ((size() + new_alloc_size) > limit_size) {
             SRV_WRN(" - cache size limit reached, removing oldest entry (size = %.3f MiB)\n", states.front().size() / (1024.0 * 1024.0));
-
             states.pop_front();
         }
     }
@@ -2163,11 +2154,7 @@ void server_prompt_cache::update() {
     const size_t limit_tokens_cur = limit_size > 0 ? std::max<size_t>(limit_tokens, limit_size/size_per_token) : limit_tokens;
 
     if (limit_tokens > 0) {
-        while (states.size() > 1 && n_tokens() > limit_tokens_cur) {
-            if (states.empty()) {
-                break;
-            }
-
+        while ((n_tokens() + new_alloc_tokens) > limit_tokens_cur) {
             SRV_WRN(" - cache token limit (%zu, est: %zu) reached, removing oldest entry (size = %.3f MiB)\n",
                     limit_tokens, limit_tokens_cur, states.front().size() / (1024.0 * 1024.0));
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -620,9 +620,9 @@ struct server_prompt_cache {
 
     size_t n_tokens() const;
 
-    server_prompt * alloc(const server_prompt & prompt, size_t state_size_main, size_t state_size_drft);
+    server_prompt * alloc(const server_prompt & prompt, size_t state_size_main, size_t state_size_drft, size_t state_size_ckpt);
 
     bool load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_main, llama_context * ctx_drft, int32_t id_slot);
 
-    void update();
+    void update(size_t new_alloc_size = 0, int new_alloc_tokens = 0);
 };


### PR DESCRIPTION
## Overview
Fix RAM OOM crash in `server_prompt_cache` when saving prompt cache with `--cache-ram` limit.

A previous fix added pre-allocation checks, but checkpoint data was not included in the cache size calculation, so the real cache size could still exceed `--cache-ram`.

Also, `update()` did not account for the pending allocation, and the `states.size() > 1` guard skipped eviction when only one entry existed.

Fixed:
- include checkpoint data in the cache size calculation
- pass pending allocation size and token count to `update()` so it evicts until the new entry fits
- remove `states.size() > 1` guard
- remove `catch(bad_alloc)` recovery

## Additional information
`alloc()` checked the limit using only KV cache and draft state sizes, and the `try` block only allocated those. But the cache entry also included checkpoint data, so actual RAM usage could still exceed the configured limit and trigger OOM.

Before fix:
```shell
saving prompt with length 146764, total state size = 5332.813 MiB (draft: 307.363 MiB)
oom-kill: ... task=llama-server,pid=92787
Out of memory: Killed process 92787 (llama-server) ...
```

After fix:
```shell
saving prompt with length 72820, total state size = 2721.372 MiB (draft: 152.505 MiB)
single state (2721.372 MiB) exceeds cache limit (360.000 MiB), skipping cache
```

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, llama.cpp + claude code, used for checking code style
