### PR TITLE
server: fix prompt_load not clearing slot when no cache match found

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2556,6 +2556,17 @@ private:
                                     n_past = std::min(n_past, slot.alora_invocation_start - 1);
                                 }
 
+                                // clear stale cache if common prefix is too small
+                                if (slot.prompt.tokens.size() > 0 && (float)n_past / slot.prompt.tokens.size() < 0.25f) {
+                                    common_context_seq_rm(ctx_tgt, slot.id, -1, -1);
+                                    if (ctx_dft) {
+                                        common_context_seq_rm(ctx_dft.get(), slot.id, -1, -1);
+                                    }
+                                    slot.prompt.tokens.clear();
+                                    slot.prompt.checkpoints.clear();
+                                    n_past = 0;
+                                }
+
                                 const auto n_cache_reuse = slot.task->params.n_cache_reuse;
 
                                 const bool can_cache_reuse =

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -2123,6 +2123,12 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
         prompt = std::move(*it_best);
 
         states.erase(it_best);
+        return true;
+    }
+
+    // no better cache entry found, return false if slot's data is a poor match so caller can clear the slot
+    if (!prompt.tokens.empty() && f_keep_best < 0.25f) {
+        return false;
     }
 
     return true;


### PR DESCRIPTION
## Overview

When `--cache-ram` is set and a slot is reused via LRU selection for a completely different conversation, `server_prompt_cache::load()` always returns `true` even when no matching cache entry is found. This prevents `prompt_clear()` from being called, leaving stale KV cache and prompt tokens from the previous conversation in the slot.

On the new conversation, the common prefix is minimal (e.g. `n_past = 3` for system prompt only), but `pos_min` from the stale KV cache is large (e.g. `pos_min = 53849`). All checkpoints fail the search, forcing full prompt reprocessing.

## Additional information

 Two-part fix:                                                                     
                                                                                   
 - Primary: prompt_load() returns false when f_keep < 0.25 and no better cache entry found, allowing caller to invoke prompt_clear()                           
 - Safety net: update_slots() clears cache when n_past / prompt.size() < 0.25, covering cases without --cache-ram

same threshold as existing prompt_load logic:

```cpp  
        // don't trash large prompts
        if (f_keep_cur < 0.25f) {
            continue;
        }
```  

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, identify the root causes and prototyping.