### PR TITLE
vulkan: Refactor vk_queue to use per-instance mutexes and unique handles

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -171,7 +171,7 @@ typedef struct VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR {
     VkBool32           internallySynchronizedQueues;
 } VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR;
 #else
-#define eInternallySynchronizedKHR vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR
+static constexpr vk::DeviceQueueCreateFlagBits eInternallySynchronizedKHR = vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR;
 #endif
 
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6191,9 +6191,6 @@ static vk_device ggml_vk_get_device(size_t idx) {
         }
         vk::DeviceCreateInfo device_create_info{};
         std::vector<const char *> device_extensions;
-        if (device->has_internally_synchronized_queues) {
-            device_extensions.push_back(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME);
-        }
         vk::PhysicalDeviceFeatures device_features = device->physical_device.getFeatures();
 
         VkPhysicalDeviceFeatures2 device_features2;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -745,7 +745,6 @@ struct vk_device_struct {
     bool support_async;
     bool async_use_transfer_queue;
     bool has_internally_synchronized_queues = false;
-    VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_query_features {};
     uint32_t subgroup_size;
     uint32_t subgroup_size_log2;
     uint32_t shader_core_count;
@@ -5992,19 +5991,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 #endif
             } else if (strcmp(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME, properties.extensionName) == 0) {
                 internally_sync_support = true;
-                GGML_LOG_INFO("ggml_vulkan: internally synchronized queues supported");
             }
-        }
-        if (internally_sync_support) {
-            device->sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
-            device->sync_query_features.pNext = nullptr;
-
-            VkPhysicalDeviceFeatures2 device_features2{};
-            device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-            device_features2.pNext = &device->sync_query_features;
-            vkGetPhysicalDeviceFeatures2((VkPhysicalDevice)device->physical_device, &device_features2);
-
-            device->has_internally_synchronized_queues = (device->sync_query_features.internallySynchronizedQueues == VK_TRUE);
         }
 
         vk::PhysicalDeviceProperties2 props2;
@@ -6224,13 +6211,25 @@ static vk_device ggml_vk_get_device(size_t idx) {
         vk12_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
         vk11_features.pNext = &vk12_features;
 
+        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_query_features{};
+        sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
+        sync_query_features.pNext = nullptr;
+        sync_query_features.internallySynchronizedQueues = VK_FALSE;
+
+        if (internally_sync_support) {
+            vk12_features.pNext = &sync_query_features;
+        }
+
         last_struct = (VkBaseOutStructure *)&vk12_features;
 
+        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_enable_features{};
+        sync_enable_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
+        sync_enable_features.pNext = nullptr;
+        sync_enable_features.internallySynchronizedQueues = VK_TRUE;
+
         if (device->has_internally_synchronized_queues) {
-            // Reset pNext after the earlier feature probe before reusing this struct in the create chain.
-            device->sync_query_features.pNext = nullptr;
-            last_struct->pNext = (VkBaseOutStructure *)&device->sync_query_features;
-            last_struct = (VkBaseOutStructure *)&device->sync_query_features;
+            last_struct->pNext = (VkBaseOutStructure *)&sync_enable_features;
+            last_struct = (VkBaseOutStructure *)&sync_enable_features;
         }
 
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;
@@ -6370,6 +6369,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
 #endif
 
         vkGetPhysicalDeviceFeatures2(device->physical_device, &device_features2);
+
+        device->has_internally_synchronized_queues = (internally_sync_support && sync_query_features.internallySynchronizedQueues == VK_TRUE);
 
         device->pipeline_executable_properties_support = pipeline_executable_properties_support;
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6208,15 +6208,6 @@ static vk_device ggml_vk_get_device(size_t idx) {
         vk12_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
         vk11_features.pNext = &vk12_features;
 
-        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_query_features{};
-        sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
-        sync_query_features.pNext = nullptr;
-        sync_query_features.internallySynchronizedQueues = VK_FALSE;
-
-        if (internally_sync_support) {
-            vk12_features.pNext = &sync_query_features;
-        }
-
         last_struct = (VkBaseOutStructure *)&vk12_features;
 
         VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_enable_features{};

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5919,6 +5919,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         bool coopmat2_support = false;
         bool coopmat2_decode_vector_support = false;
         bool pipeline_executable_properties_support = false;
+        bool internally_sync_support = false;
         device->coopmat_support = false;
         device->integer_dot_product = false;
         device->shader_64b_indexing = false;
@@ -5991,7 +5992,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->shader_64b_indexing = true;
 #endif
             } else if (strcmp(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME, properties.extensionName) == 0) {
-                device->has_internally_synchronized_queues = true;
+                internally_sync_support = true;
                 GGML_LOG_INFO("ggml_vulkan: internally synchronized queues supported");
             }
         }
@@ -6219,7 +6220,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
         sync_query_features.pNext = nullptr;
         sync_query_features.internallySynchronizedQueues = VK_FALSE;
-        if (device->has_internally_synchronized_queues) {
+        if (internally_sync_support) {
             last_struct->pNext = (VkBaseOutStructure *)&sync_query_features;
             last_struct = (VkBaseOutStructure *)&sync_query_features;
         }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -173,7 +173,7 @@ typedef struct VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR {
 #else
 // Safe compile-time alias to keep downstream code uniform
 static constexpr vk::DeviceQueueCreateFlagBits eInternallySynchronizedKHR =
-    eInternallySynchronizedKHR;
+    vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR;
 #endif
 
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6213,7 +6213,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_enable_features{};
         sync_enable_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
         sync_enable_features.pNext = nullptr;
-        sync_enable_features.internallySynchronizedQueues = VK_TRUE;
+        sync_enable_features.internallySynchronizedQueues = VK_FALSE;
 
         if (internally_sync_support ) {
             last_struct->pNext = (VkBaseOutStructure *)&sync_enable_features;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1046,8 +1046,8 @@ struct vk_device_struct {
 
         ggml_vk_destroy_buffer(sync_staging);
 
-        compute_queue->cmd_pool.destroy(device);
-        transfer_queue->cmd_pool.destroy(device);
+        if (compute_queue) compute_queue->cmd_pool.destroy(device);
+        if (transfer_queue) transfer_queue->cmd_pool.destroy(device);
 
         for (auto& pipeline : all_pipelines) {
             if (pipeline.expired()) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6359,7 +6359,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         vkGetPhysicalDeviceFeatures2(device->physical_device, &device_features2);
 
-        device->has_internally_synchronized_queues = (internally_sync_support && sync_query_features.internallySynchronizedQueues == VK_TRUE);
+        device->has_internally_synchronized_queues = sync_enable_features.internallySynchronizedQueues;
 
         device->pipeline_executable_properties_support = pipeline_executable_properties_support;
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6203,7 +6203,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         internally_synchronized_queues_features.pNext = nullptr;
         internally_synchronized_queues_features.internallySynchronizedQueues = VK_FALSE;
 
-        if (internally_sync_support ) {
+        if (internally_sync_support) {
             last_struct->pNext = (VkBaseOutStructure *)&internally_synchronized_queues_features;
             last_struct = (VkBaseOutStructure *)&internally_synchronized_queues_features;
             device_extensions.push_back(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6193,6 +6193,32 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         last_struct = (VkBaseOutStructure *)&vk12_features;
 
+        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_query_features;
+        sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
+        sync_query_features.pNext = nullptr;
+        if (device->has_internally_synchronized_queues) {
+            last_struct->pNext = (VkBaseOutStructure *)&sync_query_features;
+            last_struct = (VkBaseOutStructure *)&sync_query_features;
+        }
+
+        vkGetPhysicalDeviceFeatures2((VkPhysicalDevice)device->physical_device, &device_features2);
+        if (device->has_internally_synchronized_queues) {
+            device->has_internally_synchronized_queues = sync_query_features.internallySynchronizedQueues == VK_TRUE;
+            vk12_features.pNext = nullptr;
+            last_struct = (VkBaseOutStructure *)&vk12_features;
+        }
+
+        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR vk_internally_sync_features;
+        vk_internally_sync_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
+        vk_internally_sync_features.pNext = nullptr;
+        vk_internally_sync_features.internallySynchronizedQueues = VK_FALSE;
+
+        if (device->has_internally_synchronized_queues) {
+            vk_internally_sync_features.internallySynchronizedQueues = VK_TRUE;
+            last_struct->pNext = (VkBaseOutStructure *)&vk_internally_sync_features;
+            last_struct = (VkBaseOutStructure *)&vk_internally_sync_features;
+        }
+
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;
         pl_robustness_features.pNext = nullptr;
         pl_robustness_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES_EXT;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -287,25 +287,21 @@ struct vk_command_pool {
 // Prevent simultaneous submissions to the same queue.
 // This could be per vk_queue if we stopped having two vk_queue structures
 // sharing the same vk::Queue.
-static std::mutex queue_mutex;
+
+struct vk_queue_handle {
+    vk::Queue queue;
+    std::mutex mutex;
+};
 
 struct vk_queue {
     uint32_t queue_family_index;
-    vk::Queue queue;
+    std::shared_ptr<vk_queue_handle> handle;
 
     vk_command_pool cmd_pool;
 
     vk::PipelineStageFlags stage_flags;
 
     bool transfer_only;
-
-    // copy everything except the cmd_pool
-    void copyFrom(vk_queue &other) {
-        queue_family_index = other.queue_family_index;
-        queue = other.queue;
-        stage_flags = other.stage_flags;
-        transfer_only = other.transfer_only;
-    }
 };
 
 static const char * ggml_backend_vk_buffer_type_name(ggml_backend_buffer_type_t buft);
@@ -712,8 +708,8 @@ struct vk_device_struct {
     uint32_t vendor_id;
     vk::DriverId driver_id;
     vk_device_architecture architecture;
-    vk_queue compute_queue;
-    vk_queue transfer_queue;
+    std::shared_ptr<vk_queue> compute_queue;
+    std::shared_ptr<vk_queue> transfer_queue;
     bool single_queue;
     bool support_async;
     bool async_use_transfer_queue;
@@ -1019,8 +1015,8 @@ struct vk_device_struct {
 
         ggml_vk_destroy_buffer(sync_staging);
 
-        compute_queue.cmd_pool.destroy(device);
-        transfer_queue.cmd_pool.destroy(device);
+        compute_queue->cmd_pool.destroy(device);
+        transfer_queue->cmd_pool.destroy(device);
 
         for (auto& pipeline : all_pipelines) {
             if (pipeline.expired()) {
@@ -2909,8 +2905,8 @@ static vk_command_buffer* ggml_vk_create_cmd_buffer(vk_device& device, vk_comman
 static void ggml_vk_submit(vk_context& ctx, vk::Fence fence) {
     if (ctx->seqs.empty()) {
         if (fence) {
-            std::lock_guard<std::mutex> guard(queue_mutex);
-            ctx->p->q->queue.submit({}, fence);
+            std::lock_guard<std::mutex> guard(ctx->p->q->handle->mutex);
+            ctx->p->q->handle->queue.submit({}, fence);
         }
         return;
     }
@@ -2979,8 +2975,8 @@ static void ggml_vk_submit(vk_context& ctx, vk::Fence fence) {
         }
     }
 
-    std::lock_guard<std::mutex> guard(queue_mutex);
-    ctx->p->q->queue.submit(submit_infos, fence);
+    std::lock_guard<std::mutex> guard(ctx->p->q->handle->mutex);
+    ctx->p->q->handle->queue.submit(submit_infos, fence);
 
     ctx->seqs.clear();
 }
@@ -3031,18 +3027,21 @@ static uint32_t ggml_vk_find_queue_family_index(std::vector<vk::QueueFamilyPrope
     abort();
 }
 
-static void ggml_vk_create_queue(vk_device& device, vk_queue& q, uint32_t queue_family_index, uint32_t queue_index, vk::PipelineStageFlags&& stage_flags, bool transfer_only) {
+static std::shared_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_t queue_family_index, uint32_t queue_index, vk::PipelineStageFlags&& stage_flags, bool transfer_only) {
     VK_LOG_DEBUG("ggml_vk_create_queue()");
     std::lock_guard<std::recursive_mutex> guard(device->mutex);
 
-    q.queue_family_index = queue_family_index;
-    q.transfer_only = transfer_only;
+    auto q = std::make_shared<vk_queue>();
+    q->queue_family_index = queue_family_index;
+    q->transfer_only = transfer_only;
 
-    q.cmd_pool.init(device, &q);
+    q->handle = std::make_shared<vk_queue_handle>();
+    q->handle->queue = device->device.getQueue(queue_family_index, queue_index);
 
-    q.queue = device->device.getQueue(queue_family_index, queue_index);
+    q->cmd_pool.init(device, q.get());
 
-    q.stage_flags = stage_flags;
+    q->stage_flags = stage_flags;
+    return q;
 }
 
 static vk_context ggml_vk_create_context(ggml_backend_vk_context * ctx, vk_command_pool& p) {
@@ -3107,11 +3106,11 @@ static void ggml_vk_queue_command_pools_cleanup(vk_device& device) {
     // Arbitrary frequency to cleanup/reuse command buffers
     static constexpr uint32_t cleanup_frequency = 10;
 
-    if (device->compute_queue.cmd_pool.buffers_in_use() >= cleanup_frequency) {
-        ggml_vk_command_pool_cleanup(device, device->compute_queue.cmd_pool);
+    if (device->compute_queue->cmd_pool.buffers_in_use() >= cleanup_frequency) {
+        ggml_vk_command_pool_cleanup(device, device->compute_queue->cmd_pool);
     }
-    if (device->transfer_queue.cmd_pool.buffers_in_use() >= cleanup_frequency) {
-        ggml_vk_command_pool_cleanup(device, device->transfer_queue.cmd_pool);
+    if (device->transfer_queue->cmd_pool.buffers_in_use() >= cleanup_frequency) {
+        ggml_vk_command_pool_cleanup(device, device->transfer_queue->cmd_pool);
     }
 }
 
@@ -6566,7 +6565,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->device = device->physical_device.createDevice(device_create_info);
 
         // Queues
-        ggml_vk_create_queue(device, device->compute_queue, compute_queue_family_index, 0, { vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer }, false);
+        device->compute_queue = ggml_vk_create_queue(device, compute_queue_family_index, 0, { vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer }, false);
 
         // Shaders
         // Disable matmul tile sizes early if performance low or not supported
@@ -6668,13 +6667,16 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         if (!device->single_queue) {
             const uint32_t transfer_queue_index = compute_queue_family_index == transfer_queue_family_index ? 1 : 0;
-            ggml_vk_create_queue(device, device->transfer_queue, transfer_queue_family_index, transfer_queue_index, { vk::PipelineStageFlagBits::eTransfer }, true);
+            device->transfer_queue = ggml_vk_create_queue(device, transfer_queue_family_index, transfer_queue_index, { vk::PipelineStageFlagBits::eTransfer }, true);
 
             device->async_use_transfer_queue = prefers_transfer_queue || (getenv("GGML_VK_ASYNC_USE_TRANSFER_QUEUE") != nullptr);
         } else {
-            // TODO: Use pointer or reference to avoid copy
-            device->transfer_queue.copyFrom(device->compute_queue);
-            device->transfer_queue.cmd_pool.init(device, &device->transfer_queue);
+            device->transfer_queue = std::make_shared<vk_queue>();
+            device->transfer_queue->handle = device->compute_queue->handle;
+            device->transfer_queue->queue_family_index = device->compute_queue->queue_family_index;
+            device->transfer_queue->stage_flags = device->compute_queue->stage_flags;
+            device->transfer_queue->transfer_only = device->compute_queue->transfer_only;
+            device->transfer_queue->cmd_pool.init(device, device->transfer_queue.get());
 
             device->async_use_transfer_queue = false;
         }
@@ -7237,7 +7239,7 @@ static void ggml_vk_init(ggml_backend_vk_context * ctx, size_t idx) {
     ctx->fence = ctx->device->device.createFence({});
     ctx->almost_ready_fence = ctx->device->device.createFence({});
 
-    ctx->compute_cmd_pool.init(ctx->device, &ctx->device->compute_queue);
+    ctx->compute_cmd_pool.init(ctx->device, ctx->device->compute_queue.get());
     if (ctx->device->async_use_transfer_queue) {
         vk::SemaphoreTypeCreateInfo tci{ vk::SemaphoreType::eTimeline, 0 };
         vk::SemaphoreCreateInfo ci{};
@@ -7245,7 +7247,7 @@ static void ggml_vk_init(ggml_backend_vk_context * ctx, size_t idx) {
         ctx->transfer_semaphore.s = ctx->device->device.createSemaphore(ci);
         ctx->transfer_semaphore.value = 0;
 
-        ctx->transfer_cmd_pool.init(ctx->device, &ctx->device->transfer_queue);
+        ctx->transfer_cmd_pool.init(ctx->device, ctx->device->transfer_queue.get());
     }
 
     if (vk_perf_logger_enabled) {
@@ -8093,7 +8095,7 @@ static void ggml_vk_buffer_write_2d(vk_buffer& dst, size_t offset, const void * 
     } else {
         std::lock_guard<std::recursive_mutex> guard(dst->device->mutex);
 
-        vk_context subctx = ggml_vk_create_temporary_context(dst->device->transfer_queue.cmd_pool);
+        vk_context subctx = ggml_vk_create_temporary_context(dst->device->transfer_queue->cmd_pool);
         ggml_vk_ctx_begin(dst->device, subctx);
         bool ret = ggml_vk_buffer_write_2d_async(subctx, dst, offset, src, spitch, dpitch, width, height, true);
         GGML_ASSERT(ret);
@@ -8234,7 +8236,7 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     } else {
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
 
-        vk_context subctx = ggml_vk_create_temporary_context(src->device->transfer_queue.cmd_pool);
+        vk_context subctx = ggml_vk_create_temporary_context(src->device->transfer_queue->cmd_pool);
         ggml_vk_ctx_begin(src->device, subctx);
         bool ret = ggml_vk_buffer_read_2d_async(subctx, src, offset, dst, spitch, dpitch, width, height, true);
         GGML_ASSERT(ret);
@@ -8271,7 +8273,7 @@ static void ggml_vk_buffer_copy(vk_buffer& dst, size_t dst_offset, vk_buffer& sr
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
         VK_LOG_DEBUG("ggml_vk_buffer_copy(SINGLE_DEVICE, " << size << ")");
         // Copy within the device
-        vk_context subctx = ggml_vk_create_temporary_context(src->device->transfer_queue.cmd_pool);
+        vk_context subctx = ggml_vk_create_temporary_context(src->device->transfer_queue->cmd_pool);
         ggml_vk_ctx_begin(src->device, subctx);
         ggml_vk_buffer_copy_async(subctx, dst, dst_offset, src, src_offset, size);
         ggml_vk_ctx_end(subctx);
@@ -8314,7 +8316,7 @@ static void ggml_vk_buffer_memset(vk_buffer& dst, size_t offset, uint32_t c, siz
     }
 
     std::lock_guard<std::recursive_mutex> guard(dst->device->mutex);
-    vk_context subctx = ggml_vk_create_temporary_context(dst->device->transfer_queue.cmd_pool);
+    vk_context subctx = ggml_vk_create_temporary_context(dst->device->transfer_queue->cmd_pool);
     ggml_vk_ctx_begin(dst->device, subctx);
     subctx->s->buffer->buf.fillBuffer(dst->buffer, offset, size, c);
     ggml_vk_ctx_end(subctx);
@@ -15840,19 +15842,19 @@ static void ggml_vk_synchronize(ggml_backend_vk_context * ctx) {
                 1, &ctx->transfer_semaphore.value,
                 0, nullptr,
             };
-            vk::PipelineStageFlags stage = ctx->device->transfer_queue.stage_flags;
+            vk::PipelineStageFlags stage = ctx->device->transfer_queue->stage_flags;
             vk::SubmitInfo si{
                 1, &ctx->transfer_semaphore.s, &stage,
                 0, nullptr,
                 0, nullptr,
             };
             si.setPNext(&tl_info);
-            std::lock_guard<std::mutex> guard(queue_mutex);
-            ctx->device->compute_queue.queue.submit({ si }, ctx->fence);
+            std::lock_guard<std::mutex> guard(ctx->device->compute_queue->handle->mutex);
+            ctx->device->compute_queue->handle->queue.submit({ si }, ctx->fence);
             ctx->transfer_semaphore_last_submitted = ctx->transfer_semaphore.value;
         } else {
-            std::lock_guard<std::mutex> guard(queue_mutex);
-            ctx->device->compute_queue.queue.submit({}, ctx->fence);
+            std::lock_guard<std::mutex> guard(ctx->device->compute_queue->handle->mutex);
+            ctx->device->compute_queue->handle->queue.submit({}, ctx->fence);
         }
         ggml_vk_wait_for_fence(ctx);
         ctx->submit_pending = false;
@@ -16414,7 +16416,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         vk::DebugUtilsLabelEXT dul = {};
         dul.pLabelName = "ggml_backend_vk_graph_compute";
         dul.color = std::array<float,4>{1.0f, 1.0f, 1.0f, 1.0f};
-        vk_instance.pfn_vkQueueBeginDebugUtilsLabelEXT(ctx->device->compute_queue.queue, reinterpret_cast<VkDebugUtilsLabelEXT*>(&dul));
+        vk_instance.pfn_vkQueueBeginDebugUtilsLabelEXT(ctx->device->compute_queue->handle->queue, reinterpret_cast<VkDebugUtilsLabelEXT*>(&dul));
     }
 
     ctx->prealloc_size_add_rms_partials_offset = 0;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6210,14 +6210,14 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         last_struct = (VkBaseOutStructure *)&vk12_features;
 
-        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_enable_features{};
-        sync_enable_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
-        sync_enable_features.pNext = nullptr;
-        sync_enable_features.internallySynchronizedQueues = VK_FALSE;
+        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR internally_synchronized_queues_features{};
+        internally_synchronized_queues_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
+        internally_synchronized_queues_features.pNext = nullptr;
+        internally_synchronized_queues_features.internallySynchronizedQueues = VK_FALSE;
 
         if (internally_sync_support ) {
-            last_struct->pNext = (VkBaseOutStructure *)&sync_enable_features;
-            last_struct = (VkBaseOutStructure *)&sync_enable_features;
+            last_struct->pNext = (VkBaseOutStructure *)&internally_synchronized_queues_features;
+            last_struct = (VkBaseOutStructure *)&internally_synchronized_queues_features;
             device_extensions.push_back(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME);
         }
 
@@ -6359,7 +6359,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         vkGetPhysicalDeviceFeatures2(device->physical_device, &device_features2);
 
-        device->has_internally_synchronized_queues = sync_enable_features.internallySynchronizedQueues;
+        device->has_internally_synchronized_queues = internally_synchronized_queues_features.internallySynchronizedQueues;
 
         device->pipeline_executable_properties_support = pipeline_executable_properties_support;
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6227,11 +6227,11 @@ static vk_device ggml_vk_get_device(size_t idx) {
         last_struct = (VkBaseOutStructure *)&vk12_features;
 
         if (device->has_internally_synchronized_queues) {
+            // Reset pNext after the earlier feature probe before reusing this struct in the create chain.
+            device->sync_query_features.pNext = nullptr;
             last_struct->pNext = (VkBaseOutStructure *)&device->sync_query_features;
             last_struct = (VkBaseOutStructure *)&device->sync_query_features;
         }
-
-        vkGetPhysicalDeviceFeatures2((VkPhysicalDevice)device->physical_device, &device_features2);
 
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;
         pl_robustness_features.pNext = nullptr;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3094,6 +3094,7 @@ static std::unique_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_
 }
 
 static std::unique_ptr<vk_queue> ggml_vk_create_aliased_queue(vk_device& device, const std::unique_ptr<vk_queue>& source, vk::PipelineStageFlags stage_flags, bool transfer_only) {
+    std::lock_guard<std::recursive_mutex> guard(device->mutex);
     auto q = std::make_unique<vk_queue>();
     q->handle = source->handle;
     q->queue_family_index = source->queue_family_index;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6218,6 +6218,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         if (internally_sync_support ) {
             last_struct->pNext = (VkBaseOutStructure *)&sync_enable_features;
             last_struct = (VkBaseOutStructure *)&sync_enable_features;
+            device_extensions.push_back(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME);
         }
 
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -156,6 +156,10 @@ typedef struct VkPhysicalDeviceShaderFloat8FeaturesEXT {
 } VkPhysicalDeviceShaderFloat8FeaturesEXT;
 #endif
 
+#ifndef VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME
+#define VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME "VK_KHR_internally_synchronized_queues"
+#endif
+
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))
 #define CEIL_DIV(M, N) (((M) / (N)) + (((M) % (N)) != 0))
 static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
@@ -285,12 +289,25 @@ struct vk_command_pool {
 };
 
 // Prevent simultaneous submissions to the same queue.
-// This could be per vk_queue if we stopped having two vk_queue structures
-// sharing the same vk::Queue.
-
 struct vk_queue_handle {
     vk::Queue queue;
+    virtual void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) = 0;
+    virtual ~vk_queue_handle() = default;
+};
+
+struct vk_queue_handle_synchronized : vk_queue_handle {
     std::mutex mutex;
+    void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) override {
+        std::lock_guard<std::mutex> guard(mutex);
+        queue.submit(submits, fence);
+    }
+};
+
+struct vk_queue_handle_unsynchronized : vk_queue_handle {
+    void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) override {
+        // Driver guarantees internal synchronization via VK_KHR_internally_synchronized_queues
+        queue.submit(submits, fence);
+    }
 };
 
 struct vk_queue {
@@ -713,6 +730,7 @@ struct vk_device_struct {
     bool single_queue;
     bool support_async;
     bool async_use_transfer_queue;
+    bool has_internally_synchronized_queues = false;
     uint32_t subgroup_size;
     uint32_t subgroup_size_log2;
     uint32_t shader_core_count;
@@ -2905,8 +2923,7 @@ static vk_command_buffer* ggml_vk_create_cmd_buffer(vk_device& device, vk_comman
 static void ggml_vk_submit(vk_context& ctx, vk::Fence fence) {
     if (ctx->seqs.empty()) {
         if (fence) {
-            std::lock_guard<std::mutex> guard(ctx->p->q->handle->mutex);
-            ctx->p->q->handle->queue.submit({}, fence);
+            ctx->p->q->handle->submit({}, fence);
         }
         return;
     }
@@ -2975,8 +2992,7 @@ static void ggml_vk_submit(vk_context& ctx, vk::Fence fence) {
         }
     }
 
-    std::lock_guard<std::mutex> guard(ctx->p->q->handle->mutex);
-    ctx->p->q->handle->queue.submit(submit_infos, fence);
+    ctx->p->q->handle->submit(submit_infos, fence);
 
     ctx->seqs.clear();
 }
@@ -3035,12 +3051,34 @@ static std::shared_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_
     q->queue_family_index = queue_family_index;
     q->transfer_only = transfer_only;
 
-    q->handle = std::make_shared<vk_queue_handle>();
-    q->handle->queue = device->device.getQueue(queue_family_index, queue_index);
+    std::shared_ptr<vk_queue_handle> h;
+    vk::DeviceQueueInfo2 queue_info2{};
+    queue_info2.queueFamilyIndex = queue_family_index;
+    queue_info2.queueIndex = queue_index;
+
+    if (device->has_internally_synchronized_queues) {
+        h = std::make_shared<vk_queue_handle_unsynchronized>();
+        queue_info2.flags = vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR;
+    } else {
+        h = std::make_shared<vk_queue_handle_synchronized>();
+    }
+
+    h->queue = device->device.getQueue2(queue_info2);
+    q->handle = h;
 
     q->cmd_pool.init(device, q.get());
 
     q->stage_flags = stage_flags;
+    return q;
+}
+
+static std::shared_ptr<vk_queue> ggml_vk_create_aliased_queue(vk_device& device, std::shared_ptr<vk_queue> source, vk::PipelineStageFlags stage_flags, bool transfer_only) {
+    auto q = std::make_shared<vk_queue>();
+    q->handle = source->handle;
+    q->queue_family_index = source->queue_family_index;
+    q->stage_flags = stage_flags;
+    q->transfer_only = transfer_only;
+    q->cmd_pool.init(device, q.get());
     return q;
 }
 
@@ -5930,6 +5968,9 @@ static vk_device ggml_vk_get_device(size_t idx) {
             } else if (strcmp("VK_EXT_shader_64bit_indexing", properties.extensionName) == 0) {
                 device->shader_64b_indexing = true;
 #endif
+            } else if (strcmp(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME, properties.extensionName) == 0) {
+                device->has_internally_synchronized_queues = true;
+                VK_LOG_INFO("ggml_vulkan: internally synchronized queues supported");
             }
         }
 
@@ -6116,16 +6157,23 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->single_queue = compute_queue_family_index == transfer_queue_family_index && queue_family_props[compute_queue_family_index].queueCount == 1;
 
         std::vector<vk::DeviceQueueCreateInfo> device_queue_create_infos;
+        vk::DeviceQueueCreateFlags queue_flags = device->has_internally_synchronized_queues ?
+                                                vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR :
+                                                vk::DeviceQueueCreateFlags();
+
         if (compute_queue_family_index != transfer_queue_family_index) {
-            device_queue_create_infos.push_back({vk::DeviceQueueCreateFlags(), compute_queue_family_index, 1, priorities});
-            device_queue_create_infos.push_back({vk::DeviceQueueCreateFlags(), transfer_queue_family_index, 1, priorities + 1});
+            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 1, priorities});
+            device_queue_create_infos.push_back({queue_flags, transfer_queue_family_index, 1, priorities + 1});
         } else if(!device->single_queue) {
-            device_queue_create_infos.push_back({vk::DeviceQueueCreateFlags(), compute_queue_family_index, 2, priorities});
+            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 2, priorities});
         } else {
-            device_queue_create_infos.push_back({vk::DeviceQueueCreateFlags(), compute_queue_family_index, 1, priorities});
+            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 1, priorities});
         }
         vk::DeviceCreateInfo device_create_info{};
         std::vector<const char *> device_extensions;
+        if (device->has_internally_synchronized_queues) {
+            device_extensions.push_back(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME);
+        }
         vk::PhysicalDeviceFeatures device_features = device->physical_device.getFeatures();
 
         VkPhysicalDeviceFeatures2 device_features2;
@@ -6671,12 +6719,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
             device->async_use_transfer_queue = prefers_transfer_queue || (getenv("GGML_VK_ASYNC_USE_TRANSFER_QUEUE") != nullptr);
         } else {
-            device->transfer_queue = std::make_shared<vk_queue>();
-            device->transfer_queue->handle = device->compute_queue->handle;
-            device->transfer_queue->queue_family_index = device->compute_queue->queue_family_index;
-            device->transfer_queue->stage_flags = device->compute_queue->stage_flags;
-            device->transfer_queue->transfer_only = device->compute_queue->transfer_only;
-            device->transfer_queue->cmd_pool.init(device, device->transfer_queue.get());
+            device->transfer_queue = ggml_vk_create_aliased_queue(device, device->compute_queue, { vk::PipelineStageFlagBits::eTransfer }, true);
 
             device->async_use_transfer_queue = false;
         }
@@ -15849,12 +15892,10 @@ static void ggml_vk_synchronize(ggml_backend_vk_context * ctx) {
                 0, nullptr,
             };
             si.setPNext(&tl_info);
-            std::lock_guard<std::mutex> guard(ctx->device->compute_queue->handle->mutex);
-            ctx->device->compute_queue->handle->queue.submit({ si }, ctx->fence);
+            ctx->device->compute_queue->handle->submit({ si }, ctx->fence);
             ctx->transfer_semaphore_last_submitted = ctx->transfer_semaphore.value;
         } else {
-            std::lock_guard<std::mutex> guard(ctx->device->compute_queue->handle->mutex);
-            ctx->device->compute_queue->handle->queue.submit({}, ctx->fence);
+            ctx->device->compute_queue->handle->submit({}, ctx->fence);
         }
         ggml_vk_wait_for_fence(ctx);
         ctx->submit_pending = false;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6177,18 +6177,6 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->single_queue = compute_queue_family_index == transfer_queue_family_index && queue_family_props[compute_queue_family_index].queueCount == 1;
 
         std::vector<vk::DeviceQueueCreateInfo> device_queue_create_infos;
-        vk::DeviceQueueCreateFlags queue_flags = device->has_internally_synchronized_queues ?
-                                                eInternallySynchronizedKHR :
-                                                vk::DeviceQueueCreateFlags();
-
-        if (compute_queue_family_index != transfer_queue_family_index) {
-            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 1, priorities});
-            device_queue_create_infos.push_back({queue_flags, transfer_queue_family_index, 1, priorities + 1});
-        } else if(!device->single_queue) {
-            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 2, priorities});
-        } else {
-            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 1, priorities});
-        }
         vk::DeviceCreateInfo device_create_info{};
         std::vector<const char *> device_extensions;
         vk::PhysicalDeviceFeatures device_features = device->physical_device.getFeatures();
@@ -6360,6 +6348,21 @@ static vk_device ggml_vk_get_device(size_t idx) {
         vkGetPhysicalDeviceFeatures2(device->physical_device, &device_features2);
 
         device->has_internally_synchronized_queues = internally_synchronized_queues_features.internallySynchronizedQueues;
+
+        // Build queue create infos only after querying whether internally synchronized queues are enabled.
+        // getQueue2() later uses the same flag, so creation/retrieval must stay consistent.
+        vk::DeviceQueueCreateFlags queue_flags = device->has_internally_synchronized_queues ?
+                                                eInternallySynchronizedKHR :
+                                                vk::DeviceQueueCreateFlags();
+
+        if (compute_queue_family_index != transfer_queue_family_index) {
+            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 1, priorities});
+            device_queue_create_infos.push_back({queue_flags, transfer_queue_family_index, 1, priorities + 1});
+        } else if(!device->single_queue) {
+            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 2, priorities});
+        } else {
+            device_queue_create_infos.push_back({queue_flags, compute_queue_family_index, 1, priorities});
+        }
 
         device->pipeline_executable_properties_support = pipeline_executable_properties_support;
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -738,8 +738,8 @@ struct vk_device_struct {
     uint32_t vendor_id;
     vk::DriverId driver_id;
     vk_device_architecture architecture;
-    std::shared_ptr<vk_queue> compute_queue;
-    std::shared_ptr<vk_queue> transfer_queue;
+    std::unique_ptr<vk_queue> compute_queue;
+    std::unique_ptr<vk_queue> transfer_queue;
     bool single_queue;
     bool support_async;
     bool async_use_transfer_queue;
@@ -1048,6 +1048,11 @@ struct vk_device_struct {
 
         if (compute_queue) compute_queue->cmd_pool.destroy(device);
         if (transfer_queue) transfer_queue->cmd_pool.destroy(device);
+
+        // Explicitly clear to ensure queues drop their shared_ptrs to handles
+        // before the Vulkan logical device instance is destroyed
+        compute_queue.reset();
+        transfer_queue.reset();
 
         for (auto& pipeline : all_pipelines) {
             if (pipeline.expired()) {
@@ -3056,11 +3061,11 @@ static uint32_t ggml_vk_find_queue_family_index(std::vector<vk::QueueFamilyPrope
     abort();
 }
 
-static std::shared_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_t queue_family_index, uint32_t queue_index, vk::PipelineStageFlags&& stage_flags, bool transfer_only) {
+static std::unique_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_t queue_family_index, uint32_t queue_index, vk::PipelineStageFlags&& stage_flags, bool transfer_only) {
     VK_LOG_DEBUG("ggml_vk_create_queue()");
     std::lock_guard<std::recursive_mutex> guard(device->mutex);
 
-    auto q = std::make_shared<vk_queue>();
+    auto q = std::make_unique<vk_queue>();
     q->queue_family_index = queue_family_index;
     q->transfer_only = transfer_only;
 
@@ -3085,8 +3090,8 @@ static std::shared_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_
     return q;
 }
 
-static std::shared_ptr<vk_queue> ggml_vk_create_aliased_queue(vk_device& device, std::shared_ptr<vk_queue> source, vk::PipelineStageFlags stage_flags, bool transfer_only) {
-    auto q = std::make_shared<vk_queue>();
+static std::unique_ptr<vk_queue> ggml_vk_create_aliased_queue(vk_device& device, const std::unique_ptr<vk_queue>& source, vk::PipelineStageFlags stage_flags, bool transfer_only) {
+    auto q = std::make_unique<vk_queue>();
     q->handle = source->handle;
     q->queue_family_index = source->queue_family_index;
     q->stage_flags = stage_flags;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -171,9 +171,7 @@ typedef struct VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR {
     VkBool32           internallySynchronizedQueues;
 } VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR;
 #else
-// Safe compile-time alias to keep downstream code uniform
-static constexpr vk::DeviceQueueCreateFlagBits eInternallySynchronizedKHR =
-    vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR;
+#define eInternallySynchronizedKHR vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR
 #endif
 
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -161,16 +161,19 @@ typedef struct VkPhysicalDeviceShaderFloat8FeaturesEXT {
 #define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR ((VkStructureType)1000504000)
 #define VK_DEVICE_QUEUE_CREATE_INTERNALLY_SYNCHRONIZED_BIT_KHR ((VkDeviceQueueCreateFlagBits)0x00000004)
 
+// Compile-time constant guaranteed; no runtime initialization overhead
+static constexpr vk::DeviceQueueCreateFlagBits eInternallySynchronizedKHR =
+    static_cast<vk::DeviceQueueCreateFlagBits>(0x00000004);
+
 typedef struct VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR {
     VkStructureType    sType;
-    void*              pNext;
+    void* pNext;
     VkBool32           internallySynchronizedQueues;
 } VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR;
-
-namespace vk {
-    static const DeviceQueueCreateFlagBits eInternallySynchronizedKHR =
-        static_cast<DeviceQueueCreateFlagBits>(0x00000004);
-}
+#else
+// Safe compile-time alias to keep downstream code uniform
+static constexpr vk::DeviceQueueCreateFlagBits eInternallySynchronizedKHR =
+    vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR;
 #endif
 
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8286,7 +8286,7 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
         GGML_ASSERT(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
 
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
-        vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
+        vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue->cmd_pool);
         ggml_vk_ctx_begin(src->device, subctx);
         subctx->s->buffer->buf.pipelineBarrier(
             vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -158,6 +158,19 @@ typedef struct VkPhysicalDeviceShaderFloat8FeaturesEXT {
 
 #ifndef VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME
 #define VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME "VK_KHR_internally_synchronized_queues"
+#define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR ((VkStructureType)1000504000)
+#define VK_DEVICE_QUEUE_CREATE_INTERNALLY_SYNCHRONIZED_BIT_KHR ((VkDeviceQueueCreateFlagBits)0x00000004)
+
+typedef struct VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           internallySynchronizedQueues;
+} VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR;
+
+namespace vk {
+    static const DeviceQueueCreateFlagBits eInternallySynchronizedKHR =
+        static_cast<DeviceQueueCreateFlagBits>(0x00000004);
+}
 #endif
 
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6218,6 +6218,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_query_features;
         sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
         sync_query_features.pNext = nullptr;
+        sync_query_features.internallySynchronizedQueues = VK_FALSE;
         if (device->has_internally_synchronized_queues) {
             last_struct->pNext = (VkBaseOutStructure *)&sync_query_features;
             last_struct = (VkBaseOutStructure *)&sync_query_features;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3091,13 +3091,13 @@ static std::unique_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_
     return q;
 }
 
-static std::unique_ptr<vk_queue> ggml_vk_create_aliased_queue(vk_device& device, const std::unique_ptr<vk_queue>& source, vk::PipelineStageFlags stage_flags, bool transfer_only) {
+static std::unique_ptr<vk_queue> ggml_vk_create_aliased_queue(vk_device& device, const std::unique_ptr<vk_queue>& source) {
     std::lock_guard<std::recursive_mutex> guard(device->mutex);
     auto q = std::make_unique<vk_queue>();
     q->handle = source->handle;
     q->queue_family_index = source->queue_family_index;
-    q->stage_flags = stage_flags;
-    q->transfer_only = transfer_only;
+    q->stage_flags = source->stage_flags;
+    q->transfer_only = source->transfer_only;
     q->cmd_pool.init(device, q.get());
     return q;
 }
@@ -6752,7 +6752,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
             device->async_use_transfer_queue = prefers_transfer_queue || (getenv("GGML_VK_ASYNC_USE_TRANSFER_QUEUE") != nullptr);
         } else {
-            device->transfer_queue = ggml_vk_create_aliased_queue(device, device->compute_queue, { vk::PipelineStageFlagBits::eTransfer }, true);
+            device->transfer_queue = ggml_vk_create_aliased_queue(device, device->compute_queue);
 
             device->async_use_transfer_queue = false;
         }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5970,7 +5970,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 #endif
             } else if (strcmp(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME, properties.extensionName) == 0) {
                 device->has_internally_synchronized_queues = true;
-                VK_LOG_INFO("ggml_vulkan: internally synchronized queues supported");
+                GGML_LOG_INFO("ggml_vulkan: internally synchronized queues supported");
             }
         }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6226,11 +6226,13 @@ static vk_device ggml_vk_get_device(size_t idx) {
         }
 
         vkGetPhysicalDeviceFeatures2((VkPhysicalDevice)device->physical_device, &device_features2);
-        if (device->has_internally_synchronized_queues &&
-            sync_query_features.internallySynchronizedQueues != VK_TRUE) {
-            device->has_internally_synchronized_queues = false;
-            vk12_features.pNext = nullptr;
-            last_struct = (VkBaseOutStructure *)&vk12_features;
+        if (internally_sync_support) {
+            device->has_internally_synchronized_queues =
+                sync_query_features.internallySynchronizedQueues == VK_TRUE;
+            if (!device->has_internally_synchronized_queues) {
+                vk12_features.pNext = nullptr;
+                last_struct = (VkBaseOutStructure *)&vk12_features;
+            }
         }
 
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6215,7 +6215,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         sync_enable_features.pNext = nullptr;
         sync_enable_features.internallySynchronizedQueues = VK_TRUE;
 
-        if (device->has_internally_synchronized_queues) {
+        if (internally_sync_support ) {
             last_struct->pNext = (VkBaseOutStructure *)&sync_enable_features;
             last_struct = (VkBaseOutStructure *)&sync_enable_features;
         }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -173,7 +173,7 @@ typedef struct VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR {
 #else
 // Safe compile-time alias to keep downstream code uniform
 static constexpr vk::DeviceQueueCreateFlagBits eInternallySynchronizedKHR =
-    vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR;
+    eInternallySynchronizedKHR;
 #endif
 
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))
@@ -3079,7 +3079,7 @@ static std::unique_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_
 
     if (device->has_internally_synchronized_queues) {
         h = std::make_shared<vk_queue_handle_unsynchronized>();
-        queue_info2.flags = vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR;
+        queue_info2.flags = eInternallySynchronizedKHR;
     } else {
         h = std::make_shared<vk_queue_handle_synchronized>();
     }
@@ -6181,7 +6181,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         std::vector<vk::DeviceQueueCreateInfo> device_queue_create_infos;
         vk::DeviceQueueCreateFlags queue_flags = device->has_internally_synchronized_queues ?
-                                                vk::DeviceQueueCreateFlagBits::eInternallySynchronizedKHR :
+                                                eInternallySynchronizedKHR :
                                                 vk::DeviceQueueCreateFlags();
 
         if (compute_queue_family_index != transfer_queue_family_index) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -745,6 +745,7 @@ struct vk_device_struct {
     bool support_async;
     bool async_use_transfer_queue;
     bool has_internally_synchronized_queues = false;
+    VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_query_features {};
     uint32_t subgroup_size;
     uint32_t subgroup_size_log2;
     uint32_t shader_core_count;
@@ -5994,6 +5995,17 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 GGML_LOG_INFO("ggml_vulkan: internally synchronized queues supported");
             }
         }
+        if (internally_sync_support) {
+            device->sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
+            device->sync_query_features.pNext = nullptr;
+
+            VkPhysicalDeviceFeatures2 device_features2{};
+            device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+            device_features2.pNext = &device->sync_query_features;
+            vkGetPhysicalDeviceFeatures2((VkPhysicalDevice)device->physical_device, &device_features2);
+
+            device->has_internally_synchronized_queues = (device->sync_query_features.internallySynchronizedQueues == VK_TRUE);
+        }
 
         vk::PhysicalDeviceProperties2 props2;
         vk::PhysicalDeviceMaintenance3Properties props3;
@@ -6214,24 +6226,12 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         last_struct = (VkBaseOutStructure *)&vk12_features;
 
-        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR sync_query_features;
-        sync_query_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
-        sync_query_features.pNext = nullptr;
-        sync_query_features.internallySynchronizedQueues = VK_FALSE;
-        if (internally_sync_support) {
-            last_struct->pNext = (VkBaseOutStructure *)&sync_query_features;
-            last_struct = (VkBaseOutStructure *)&sync_query_features;
+        if (device->has_internally_synchronized_queues) {
+            last_struct->pNext = (VkBaseOutStructure *)&device->sync_query_features;
+            last_struct = (VkBaseOutStructure *)&device->sync_query_features;
         }
 
         vkGetPhysicalDeviceFeatures2((VkPhysicalDevice)device->physical_device, &device_features2);
-        if (internally_sync_support) {
-            device->has_internally_synchronized_queues =
-                sync_query_features.internallySynchronizedQueues == VK_TRUE;
-            if (!device->has_internally_synchronized_queues) {
-                vk12_features.pNext = nullptr;
-                last_struct = (VkBaseOutStructure *)&vk12_features;
-            }
-        }
 
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;
         pl_robustness_features.pNext = nullptr;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -306,6 +306,8 @@ struct vk_command_pool {
 struct vk_queue_handle {
     vk::Queue queue;
     virtual void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) = 0;
+    virtual void lock()   {}   // no-op by default (internally synchronized case)
+    virtual void unlock() {}
     virtual ~vk_queue_handle() = default;
 };
 
@@ -315,6 +317,8 @@ struct vk_queue_handle_synchronized : vk_queue_handle {
         std::lock_guard<std::mutex> guard(mutex);
         queue.submit(submits, fence);
     }
+    void lock()   override { mutex.lock(); }
+    void unlock() override { mutex.unlock(); }
 };
 
 struct vk_queue_handle_unsynchronized : vk_queue_handle {
@@ -322,6 +326,7 @@ struct vk_queue_handle_unsynchronized : vk_queue_handle {
         // Driver guarantees internal synchronization via VK_KHR_internally_synchronized_queues
         queue.submit(submits, fence);
     }
+    // lock()/unlock() inherited no-ops
 };
 
 struct vk_queue {
@@ -16490,6 +16495,8 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         vk::DebugUtilsLabelEXT dul = {};
         dul.pLabelName = "ggml_backend_vk_graph_compute";
         dul.color = std::array<float,4>{1.0f, 1.0f, 1.0f, 1.0f};
+
+        std::lock_guard<vk_queue_handle> guard(*ctx->device->compute_queue->handle);
         vk_instance.pfn_vkQueueBeginDebugUtilsLabelEXT(ctx->device->compute_queue->handle->queue, reinterpret_cast<VkDebugUtilsLabelEXT*>(&dul));
     }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6225,21 +6225,11 @@ static vk_device ggml_vk_get_device(size_t idx) {
         }
 
         vkGetPhysicalDeviceFeatures2((VkPhysicalDevice)device->physical_device, &device_features2);
-        if (device->has_internally_synchronized_queues) {
-            device->has_internally_synchronized_queues = sync_query_features.internallySynchronizedQueues == VK_TRUE;
+        if (device->has_internally_synchronized_queues &&
+            sync_query_features.internallySynchronizedQueues != VK_TRUE) {
+            device->has_internally_synchronized_queues = false;
             vk12_features.pNext = nullptr;
             last_struct = (VkBaseOutStructure *)&vk12_features;
-        }
-
-        VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR vk_internally_sync_features;
-        vk_internally_sync_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR;
-        vk_internally_sync_features.pNext = nullptr;
-        vk_internally_sync_features.internallySynchronizedQueues = VK_FALSE;
-
-        if (device->has_internally_synchronized_queues) {
-            vk_internally_sync_features.internallySynchronizedQueues = VK_TRUE;
-            last_struct->pNext = (VkBaseOutStructure *)&vk_internally_sync_features;
-            last_struct = (VkBaseOutStructure *)&vk_internally_sync_features;
         }
 
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Refactor so each vk_queue owns a unique vk::Queue handle, then replace the static queue_mutex with a per-instance std::mutex inside vk_queue.

Before, single_queue devices (where only one physical queue exists) used copyFrom() to copy the compute queue's vk::Queue handle into the transfer queue struct — two vk_queue objects pointing at the same underlying vk::Queue. This made per-queue locking impossible because you couldn't have two separate mutexes guarding one queue (Per-Queue Submission Lock).

It is the prerequisite of Per-Pool Command Buffer Lock

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, finding and implementing<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
