### PR TITLE
cmake : error when LLAMA_BUILD_APP=ON and LLAMA_BUILD_TOOLS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,9 @@ if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TOOLS)
 endif()
 
 if (LLAMA_BUILD_APP)
+    if (NOT LLAMA_BUILD_TOOLS)
+        message(FATAL_ERROR "LLAMA_BUILD_APP requires LLAMA_BUILD_TOOLS to be enabled")
+    endif()
     add_subdirectory(app)
 endif()
 


### PR DESCRIPTION
## Overview

LLAMA_BUILD_APP=ON silently fails to compile when LLAMA_BUILD_TOOLS=OFF because the app/ targets depend on impl targets defined in tools/ (e.g. llama-server-impl, llama-cli-impl). The error manifests as a missing build-info.h header, which is misleading and hard to diagnose.

This PR adds an explicit FATAL_ERROR when the incompatible combination is used, so the user gets a clear message instead of a cryptic compiler error.

## Additional information

Tested with CMake 4.3.0 on Fedora 44 (Linux 7.0.9-205.fc44.x86_64). 
With LLAMA_BUILD_APP=ON and LLAMA_BUILD_TOOLS=OFF, CMake now exits immediately with:
LLAMA_BUILD_APP requires LLAMA_BUILD_TOOLS to be enabled

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES — I used Claude Code (claude.ai/code) to help identify the root cause of the issue and suggest the fix (see below, "alternative fix"). The small fix and this description were written and reviewed by me.

## Alternative fix
Claude suggested a more user-friendly approach:
if (LLAMA_BUILD_APP AND NOT LLAMA_BUILD_TOOLS)
message(WARNING "LLAMA_BUILD_APP requires LLAMA_BUILD_TOOLS, enabling it automatically")
set(LLAMA_BUILD_TOOLS ON CACHE BOOL "" FORCE)
endif()