### PR TITLE
Add HRM-Text architecture patch placeholder

### DIFF
--- a/runtime/llama.cpp-hrm_text.patch
+++ b/runtime/llama.cpp-hrm_text.patch
@@ -1,0 +1,22 @@
+# HRM-Text architecture patch placeholder
+
+This file contains a placeholder description and instructions for applying the HRM Text architecture patch to llama.cpp. The full patch adds a new `hrm_text` architecture with a hierarchical recurrent graph and causal generation support.
+
+The complete patch is available in the HRM Text 1B GGUF repository at:
+https://huggingface.co/sinimiini/HRM-Text-1B-GGUF/blob/main/runtime/llama.cpp-hrm_text.patch
+
+It was created against ggml‑org/llama.cpp commit 6a257d44633d4a752183ed778b88d2924d0a6b9d. The patch implements:
+
+- new GGUF constants and tensor mapping for `hrm_text`
+- architecture registration (`LLM_ARCH_HRM_TEXT`) and hyperparameter loading
+- a graph builder with hierarchical recurrent loops for the H and L decoder stacks
+- helpers for GGUF conversion and validation
+
+To apply the patch:
+
+```
+# from the llama.cpp repo root
+git apply runtime/llama.cpp-hrm_text.patch
+```
+
+This PR includes this placeholder file as part of the upstream discussion. A follow up PR should include the actual code changes or merge the patch contents directly.


### PR DESCRIPTION
## Summary

This PR adds a placeholder file (`runtime/llama.cpp-hrm_text.patch`) that points maintainers to the full HRM Text patch hosted in the HRM‑Text‑1B‑GGUF repository on Hugging Face and explains how to apply it.

HRM‑Text is a 1B model with a hierarchical recurrent architecture. The patch was built against commit 6a257d44633d4a752183ed778b88d2924d0a6b9d of ggml‑org/llama.cpp and implements:

- `hrm_text` GGUF metadata and tensor name mapping
- `LLM_ARCH_HRM_TEXT` architecture registration and hyperparameter loading
- a graph builder that runs H/L decoder stacks through hierarchical recurrent cycles for causal generation
- helpers for GGUF conversion and validation

Prefix‑LM bidirectional `token_type_ids` are not yet supported.

## Validation

The HRM‑Text‑1B‑GGUF repository includes validation reports showing that the BF16 GGUF and Q8_0/Q6_K/Q5_K_M quantizations match the Transformers baseline: 259/259 tensors are validated and top‑1/top‑10 token predictions align.

## Scope

This PR is intended as a starting point for discussion and documentation. It does not include any source code changes. Instead, it provides instructions on where to obtain the patch and how to apply it. A follow‑up PR can integrate the actual code changes into the llama.cpp codebase or include the full patch contents.

## Applying the patch

```
# from the root of your llama.cpp checkout
hf download sinimiini/HRM-Text-1B-GGUF --local-dir HRM-Text-1B-GGUF
git checkout 6a257d44633d4a752183ed778b88d2924d0a6b9d
git apply HRM-Text-1B-GGUF/runtime/llama.cpp-hrm_text.patch
cmake -B build -S . -DGGML_NATIVE=OFF
cmake --build build --config Release --target llama-cli
```

Thanks!
