### PR TITLE
ggml: fix AVX-512 BF16 build with clang-cl

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -70,12 +70,13 @@ uint64_t ggml_graph_next_uid(void) {
 
 // Needed for ggml_fp32_to_bf16_row()
 #if defined(__AVX512BF16__)
-#if defined(_MSC_VER)
+// clang-cl needs the explicit immintrin.h include like gcc/clang
+#if defined(_MSC_VER) && !defined(__clang__)
 #define m512i(p) p
 #else
 #include <immintrin.h>
 #define m512i(p) (__m512i)(p)
-#endif // defined(_MSC_VER)
+#endif // defined(_MSC_VER) && !defined(__clang__)
 #endif // defined(__AVX512BF16__)
 
 #if defined(__linux__) || \


### PR DESCRIPTION
## Overview

This patch fixes a crash when compiling llama.cpp using clang-cl with AVX-512 enabled.

Uses explicit headers for clang-cl, forcing inclusion of `<immintrin.h>`


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES - Claude helped draft fix