### PR TITLE
common: skip comment lines in --api-key-file (#23166)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2989,7 +2989,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             }
             std::string key;
             while (std::getline(key_file, key)) {
-                if (!key.empty()) {
+                if (!key.empty() && key[0] != '#') {
                     params.api_keys.push_back(key);
                 }
             }


### PR DESCRIPTION
Fixes #23166

## What was wrong

The `--api-key-file` option reads a text file and stores every non-empty line as an API key. It did not skip lines starting with `#`, so users who added comment lines (e.g., to organize production vs. staging keys) would see authentication failures because the comment text itself was treated as a key.

## Fix

Added `key[0] != '#'` to the existing guard in the file-reading loop so comment lines are silently ignored, matching standard UNIX config-file conventions. The change is one line and does not affect any other argument parsing.

## Testing

- Wrote a standalone reproduction that creates a key file with comments and verifies only the three actual keys are collected:

```
$ g++ -std=c++17 test_api_key_comment.cpp -o test_api_key_comment.exe
$ ./test_api_key_comment.exe
OK: comment lines correctly skipped
```

- The full `test-arg-parser` target could not be built on this Windows/MinGW host because of an unrelated `THREAD_POWER_THROTTLING_STATE` compilation error in `ggml-cpu.c` (pre-existing MinGW compatibility issue). The affected file (`common/arg.cpp`) compiles cleanly and the parsing logic was verified independently.

## Risk / scope

- Only the `--api-key-file` handler in `common/arg.cpp` is touched.
- No API or behavioral changes for files without comment lines.
- Minimal risk; existing keys remain unaffected and comment support is additive.
