### PR TITLE
docs: fix dead link to settings config in server README (#23093)

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1843,4 +1843,4 @@ You can specify default preferences for the web UI using `--ui-config <JSON conf
 
 > **Note:** The old flags `--webui-config` and `--webui-config-file` are deprecated but still work as aliases.
 
-You may find available preferences in [settings-config.ts](../ui/src/lib/constants/settings-config.ts).
+You may find available preferences in [settings-registry.ts](../ui/src/lib/constants/settings-registry.ts).


### PR DESCRIPTION
Fixes #23093

## What was wrong

`tools/server/README.md` contained a link to `settings-config.ts` for available UI preferences, but that file was deleted in a prior refactor (see PR #22803). Clicking the link resulted in a 404.

## Fix

Updated the link text and target from `settings-config.ts` to `settings-registry.ts`, which is the current location where UI preference definitions live.

## Testing

- Verified that `tools/ui/src/lib/constants/settings-registry.ts` exists in the current tree.
- Confirmed the relative path `../ui/src/lib/constants/settings-registry.ts` resolves correctly from `tools/server/README.md`.

## Risk / scope

- Docs-only change; zero functional impact.
