### PR TITLE
ui: use password input for API key to prevent browser autofill (#23254)

### DIFF
--- a/tools/ui/src/lib/components/app/server/ServerErrorSplash.svelte
+++ b/tools/ui/src/lib/components/app/server/ServerErrorSplash.svelte
@@ -160,6 +160,8 @@
 						<Input
 							id="api-key-input"
 							placeholder="Enter your API key..."
+							type="password"
+							autocomplete="off"
 							bind:value={apiKeyInput}
 							onkeydown={handleApiKeyKeydown}
 							class="w-full pr-10 {apiKeyState === 'error'

--- a/tools/ui/src/lib/components/app/settings/SettingsChat/SettingsChatFields.svelte
+++ b/tools/ui/src/lib/components/app/settings/SettingsChat/SettingsChatFields.svelte
@@ -79,7 +79,8 @@
 			<div class="relative w-full">
 				<Input
 					id={field.key}
-					type={field.isPositiveInteger ? 'number' : 'text'}
+					type={field.isPositiveInteger ? 'number' : field.key === SETTINGS_KEYS.API_KEY ? 'password' : 'text'}
+					autocomplete={field.key === SETTINGS_KEYS.API_KEY ? 'off' : undefined}
 					{...field.isPositiveInteger ? { min: '1', step: '1' } : {}}
 					value={currentValue}
 					oninput={(e) => {


### PR DESCRIPTION
Fixes #23254

## What was wrong

The WebUI rendered the API key input as a plain `type="text"` field in both the server error splash screen (`ServerErrorSplash.svelte`) and the settings panel (`SettingsChatFields.svelte`). Because the field was a normal text input, browsers saved the value in their autofill history and offered it as a suggestion in clear text on subsequent visits, exposing the secret key.

## Fix

- Changed the API key `<Input>` in `ServerErrorSplash.svelte` to `type="password"` with `autocomplete="off"`.
- Updated `SettingsChatFields.svelte` so that when the field key is `SETTINGS_KEYS.API_KEY`, the rendered input uses `type="password"` and `autocomplete="off"`.
- No logic changes; this is a presentation-only fix that masks the key while typing and prevents the browser from remembering it.

## Testing

- Verified the Svelte syntax is valid and the `<Input>` component forwards both `type` and `autocomplete` to the underlying `<input>` element (confirmed by reading `tools/ui/src/lib/components/ui/input/input.svelte`).
- Full UI build could not be run on this Windows host because Node.js is not installed, but the change is limited to two standard HTML attributes on an existing component.

## Risk / scope

- Only the two API key input fields are affected.
- All other settings inputs continue to render as before.
- No change to how the key is stored, transmitted, or validated.
