### PR TITLE
devops: add missing GGML_BACKEND_DL and GGML_CPU_ALL_VARIANTS to Dockerfiles (#23292)

### DIFF
--- a/.devops/cann.Dockerfile
+++ b/.devops/cann.Dockerfile
@@ -46,6 +46,8 @@ RUN source /usr/local/Ascend/ascend-toolkit/set_env.sh --force \
         -DCMAKE_BUILD_TYPE=Release \
         -DSOC_TYPE=ascend${CHIP_TYPE} \
         -DUSE_ACL_GRAPH=ON \
+        -DGGML_BACKEND_DL=ON \
+        -DGGML_CPU_ALL_VARIANTS=ON \
         . && \
     cmake --build build --config Release -j$(nproc)
 

--- a/.devops/openvino.Dockerfile
+++ b/.devops/openvino.Dockerfile
@@ -68,7 +68,9 @@ COPY . .
 RUN bash -c "source ${OpenVINO_DIR}/setupvars.sh && \
     cmake -B build/ReleaseOV -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
-        -DGGML_OPENVINO=ON && \
+        -DGGML_OPENVINO=ON \
+        -DGGML_BACKEND_DL=ON \
+        -DGGML_CPU_ALL_VARIANTS=ON && \
     cmake --build build/ReleaseOV -j$(nproc)"
 
 # Copy all necessary libraries


### PR DESCRIPTION
Fixes #23292

## What was wrong

PR #12749 added `-DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON` to most backend Dockerfiles to enable dynamic backend loading and all CPU architecture variants. However, `.devops/openvino.Dockerfile` and `.devops/cann.Dockerfile` were omitted, making their builds inconsistent with the rest.

## Fix

Added the two missing CMake flags to both Dockerfiles:
- `.devops/openvino.Dockerfile`
- `.devops/cann.Dockerfile`

This aligns them with `cpu`, `cuda`, `rocm`, `vulkan`, `intel`, `musa`, and `s390x` images.

## Testing

- Verified the `cmake` command syntax is valid in both files.
- Confirmed the flags match exactly what was added in PR #12749 for the other Dockerfiles.
- No functional code changes; this is a build-configuration-only fix.

## Risk / scope

- Only affects the OpenVINO and CANN container builds.
- The flags are already proven in all other backend images, so risk is minimal.
