### PR TITLE
common: preserve horizontal whitespace in tool calls

### DIFF
--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -36,6 +36,23 @@ static std::string_view trim(std::string_view sv) {
     return trim_trailing_space(trim_leading_space(sv, 1));
 }
 
+// Strip at most one bounding formatting newline (handles both \n and \r\n)
+static std::string_view trim_bounding_newlines(std::string_view sv) {
+    if (sv.size() >= 2 && sv[0] == '\r' && sv[1] == '\n') {
+        sv.remove_prefix(2);
+    } else if (sv.size() >= 1 && sv[0] == '\n') {
+        sv.remove_prefix(1);
+    }
+
+    if (sv.size() >= 2 && sv[sv.size() - 2] == '\r' && sv.back() == '\n') {
+        sv.remove_suffix(2);
+    } else if (sv.size() >= 1 && sv.back() == '\n') {
+        sv.remove_suffix(1);
+    }
+
+    return sv;
+}
+
 // Count the number of unclosed '{' braces in a JSON-like string,
 // properly skipping braces inside quoted strings.
 static int json_brace_depth(const std::string & s) {
@@ -338,7 +355,7 @@ void common_chat_peg_mapper::map(const common_peg_ast_node & node) {
     }
 
     if ((is_arg_value || is_arg_string_value) && current_tool) {
-        std::string value_content = std::string(trim_trailing_space(trim_leading_space(node.text, 1), 1));
+        std::string value_content = std::string(trim_bounding_newlines(node.text));
 
         std::string value_to_add;
         if (value_content.empty() && is_arg_string_value) {

--- a/tests/test-chat-peg-parser.cpp
+++ b/tests/test-chat-peg-parser.cpp
@@ -498,6 +498,32 @@ static void test_example_qwen3_coder(testing & t) {
             prev = msg;
         }
     });
+
+    t.test("whitespace preservation", [&](testing & t) {
+        std::string input =
+            "<tool_call>\n"
+            "<function=search_knowledge_base>\n"
+            "<parameter=query>    def foo():\n        return bar\n</parameter>\n"
+            "<parameter=category>general</parameter>\n"
+            "</function>\n"
+            "</tool_call>";
+
+        common_peg_parse_context ctx(input);
+        auto                     result = parser.parse(ctx);
+
+        t.assert_true("success", result.success());
+
+        common_chat_msg msg;
+        auto            mapper = common_chat_peg_mapper(msg);
+        mapper.from_ast(ctx.ast, result);
+
+        t.assert_equal("tool calls count", 1u, msg.tool_calls.size());
+        if (!msg.tool_calls.empty()) {
+            t.assert_equal("tool name", "search_knowledge_base", msg.tool_calls[0].name);
+            std::string expected_args = "{\"query\":\"    def foo():\\n        return bar\",\"category\":\"general\"}";
+            t.assert_equal("tool args", expected_args, msg.tool_calls[0].arguments);
+        }
+    });
 }
 
 static void test_example_qwen3_non_coder(testing & t) {


### PR DESCRIPTION
## Overview

The parser was using `trim_leading_space` and `trim_trailing_space` to clean up tool call arguments. If a parameter is on the same line as the tag, this stripped the horizontal indentation. 

Swapped the inline trim calls for a new helper `trim_bounding_newlines` that only checks for and removes `\n` or `\r\n`. 

## Additional information

Fixes #23535
Added a test to `test-chat-peg-parser.cpp`.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO