### PR TITLE
Fix TopK MoE router op fusion failure

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3549,9 +3549,10 @@ static bool ggml_cuda_tensors_overlap(const ggml_tensor * a, const ggml_tensor *
     return b_start < a_end && a_start < b_end;
 }
 
-static bool ggml_cuda_topk_moe_weights_alias_logits(const ggml_tensor * logits, const ggml_tensor * weights) {
-    return ggml_cuda_tensors_overlap(weights, logits);
-}
+struct ggml_cuda_fusion_alias {
+    const ggml_tensor * dst;
+    const ggml_tensor * src;
+};
 
 // returns whether the write (out) nodes overwrite the read nodes in operation
 static bool ggml_cuda_check_fusion_memory_ranges(const ggml_cgraph * cgraph,
@@ -3559,12 +3560,22 @@ static bool ggml_cuda_check_fusion_memory_ranges(const ggml_cgraph * cgraph,
                                                  const int           node_count,
                                                  const int *         out_nodes,
                                                  const int           out_count,
-                                                 const bool          is_topk_moe = false) {
-    bool is_ok = true;
+                                                 const bool          is_topk_moe = false,
+                                                 const std::initializer_list<ggml_cuda_fusion_alias> handled_aliases = {}) {
     // exception for topk-moe, as each row is read entirely before writing
     if (ggml_nrows(cgraph->nodes[node_idx]) == 1 && is_topk_moe) {
         return true;
     }
+
+    const auto alias_is_handled = [&](const ggml_tensor * dst, const ggml_tensor * src) {
+        for (const auto & alias : handled_aliases) {
+            if (alias.dst == dst && alias.src == src) {
+                return true;
+            }
+        }
+
+        return false;
+    };
 
     for (int i = 0; i < out_count; ++i) {
         const ggml_tensor * dst = cgraph->nodes[out_nodes[i]];
@@ -3591,16 +3602,15 @@ static bool ggml_cuda_check_fusion_memory_ranges(const ggml_cgraph * cgraph,
                         }
                     }
 
-                    if (!found) {
-                        is_ok = false;
-                        break;
+                    if (!found && !alias_is_handled(dst, src)) {
+                        return false;
                     }
                 }
             }
         }
     }
 
-    return is_ok;
+    return true;
 }
 
 
@@ -3878,14 +3888,13 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
 
                 weights      = cgraph->nodes[i + ops.size() - 1];
                 out_nodes[1] = i + ops.size() - 1;
-
-                const bool topk_moe_memory_ok =
-                    ggml_cuda_check_fusion_memory_ranges(cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true) ||
-                    ggml_cuda_topk_moe_weights_alias_logits(logits, weights);
+                const ggml_cuda_fusion_alias weights_alias_logits = { weights, logits };
+                args.weights_overlap_logits = ggml_cuda_tensors_overlap(weights, logits);
 
                 if (ggml_can_fuse_subgraph(cgraph, i, ops.size(), ops.data(), out_nodes, 2) &&
                         ggml_cuda_should_use_topk_moe(node, logits, weights, ids) &&
-                        topk_moe_memory_ok) {
+                        ggml_cuda_check_fusion_memory_ranges(
+                            cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true, { weights_alias_logits })) {
                     ggml_cuda_op_topk_moe(*cuda_ctx, logits, weights, ids, clamp, scale, bias, args);
                     return ops.size() - 1;
                 }
@@ -3898,13 +3907,13 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                 const ggml_tensor * softmax = cgraph->nodes[i + 4];
 
                 int out_nodes[2] = { i + 1, i + 5 };
-                const bool topk_moe_memory_ok =
-                    ggml_cuda_check_fusion_memory_ranges(cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true) ||
-                    ggml_cuda_topk_moe_weights_alias_logits(logits, weights);
+                const ggml_cuda_fusion_alias weights_alias_logits = { weights, logits };
+                args.weights_overlap_logits = ggml_cuda_tensors_overlap(weights, logits);
 
                 if (ggml_can_fuse_subgraph(cgraph, i, ops.size(), ops.data(), out_nodes, 2) &&
                         ggml_cuda_should_use_topk_moe(softmax, logits, weights, ids) &&
-                        topk_moe_memory_ok) {
+                        ggml_cuda_check_fusion_memory_ranges(
+                            cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true, { weights_alias_logits })) {
                     ggml_cuda_op_topk_moe(*cuda_ctx, logits, weights, ids, clamp, scale, bias, args);
                     return ops.size() - 1;
                 }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3535,6 +3535,24 @@ static bool ggml_cuda_topk_moe_fusion(const struct ggml_cgraph * cgraph, int nod
     return true;
 }
 
+static bool ggml_cuda_tensors_overlap(const ggml_tensor * a, const ggml_tensor * b) {
+    if (!a || !b || !a->data || !b->data || !a->buffer || !b->buffer) {
+        return false;
+    }
+
+    const int64_t a_start = (int64_t) a->data;
+    const int64_t a_end   = a_start + ggml_backend_buft_get_alloc_size(a->buffer->buft, a);
+
+    const int64_t b_start = (int64_t) b->data;
+    const int64_t b_end   = b_start + ggml_backend_buft_get_alloc_size(b->buffer->buft, b);
+
+    return b_start < a_end && a_start < b_end;
+}
+
+static bool ggml_cuda_topk_moe_weights_alias_logits(const ggml_tensor * logits, const ggml_tensor * weights) {
+    return ggml_cuda_tensors_overlap(weights, logits);
+}
+
 // returns whether the write (out) nodes overwrite the read nodes in operation
 static bool ggml_cuda_check_fusion_memory_ranges(const ggml_cgraph * cgraph,
                                                  const int           node_idx,
@@ -3542,20 +3560,6 @@ static bool ggml_cuda_check_fusion_memory_ranges(const ggml_cgraph * cgraph,
                                                  const int *         out_nodes,
                                                  const int           out_count,
                                                  const bool          is_topk_moe = false) {
-    auto nodes_overlap = [&](const ggml_tensor * a, const ggml_tensor * b) {
-        const int64_t a_start = (int64_t) a->data;
-        const int64_t a_end   = a_start + ggml_backend_buft_get_alloc_size(a->buffer->buft, a);
-
-        const int64_t b_start = (int64_t) b->data;
-        const int64_t b_end   = b_start + ggml_backend_buft_get_alloc_size(b->buffer->buft, b);
-
-        if ((b_start <= a_start && a_start < b_end) || (a_start <= b_start && b_start < a_end)) {
-            return true;
-        }
-
-        return false;
-    };
-
     bool is_ok = true;
     // exception for topk-moe, as each row is read entirely before writing
     if (ggml_nrows(cgraph->nodes[node_idx]) == 1 && is_topk_moe) {
@@ -3577,7 +3581,7 @@ static bool ggml_cuda_check_fusion_memory_ranges(const ggml_cgraph * cgraph,
                     continue;
                 }
 
-                if (nodes_overlap(dst, src)) {
+                if (ggml_cuda_tensors_overlap(dst, src)) {
                     bool found = false;
 
                     for (int k = node_idx; k < j; ++k) {
@@ -3875,9 +3879,13 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                 weights      = cgraph->nodes[i + ops.size() - 1];
                 out_nodes[1] = i + ops.size() - 1;
 
+                const bool topk_moe_memory_ok =
+                    ggml_cuda_check_fusion_memory_ranges(cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true) ||
+                    ggml_cuda_topk_moe_weights_alias_logits(logits, weights);
+
                 if (ggml_can_fuse_subgraph(cgraph, i, ops.size(), ops.data(), out_nodes, 2) &&
                         ggml_cuda_should_use_topk_moe(node, logits, weights, ids) &&
-                        ggml_cuda_check_fusion_memory_ranges(cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true)) {
+                        topk_moe_memory_ok) {
                     ggml_cuda_op_topk_moe(*cuda_ctx, logits, weights, ids, clamp, scale, bias, args);
                     return ops.size() - 1;
                 }
@@ -3890,9 +3898,13 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                 const ggml_tensor * softmax = cgraph->nodes[i + 4];
 
                 int out_nodes[2] = { i + 1, i + 5 };
+                const bool topk_moe_memory_ok =
+                    ggml_cuda_check_fusion_memory_ranges(cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true) ||
+                    ggml_cuda_topk_moe_weights_alias_logits(logits, weights);
+
                 if (ggml_can_fuse_subgraph(cgraph, i, ops.size(), ops.data(), out_nodes, 2) &&
                         ggml_cuda_should_use_topk_moe(softmax, logits, weights, ids) &&
-                        ggml_cuda_check_fusion_memory_ranges(cgraph, i, ops.size(), out_nodes, 2, /*is_topk_moe=*/true)) {
+                        topk_moe_memory_ok) {
                     ggml_cuda_op_topk_moe(*cuda_ctx, logits, weights, ids, clamp, scale, bias, args);
                     return ops.size() - 1;
                 }

--- a/ggml/src/ggml-cuda/topk-moe.cu
+++ b/ggml/src/ggml-cuda/topk-moe.cu
@@ -351,6 +351,13 @@ void ggml_cuda_op_topk_moe(ggml_backend_cuda_context &     ctx,
     GGML_ASSERT(ids->nb[1] / ggml_type_size(ids->type) == (size_t) n_experts);
 
     const int n_expert_used = weights->ne[1];
+    const size_t n_weights = (size_t) n_rows * n_expert_used;
+
+    ggml_cuda_pool_alloc<float> weights_tmp_alloc;
+    float * weights_out_d = weights_d;
+    if (args.weights_overlap_logits) {
+        weights_out_d = weights_tmp_alloc.alloc(ctx.pool(), n_weights);
+    }
 
     const bool with_norm = clamp != nullptr;
 
@@ -365,11 +372,15 @@ void ggml_cuda_op_topk_moe(ggml_backend_cuda_context &     ctx,
     config.delayed_softmax = args.delayed_softmax;
 
     if (bias) {
-        launch_topk_moe_cuda<true>(ctx, logits_d, weights_d, ids_d, bias_d, n_rows, n_experts, n_expert_used, clamp_val,
+        launch_topk_moe_cuda<true>(ctx, logits_d, weights_out_d, ids_d, bias_d, n_rows, n_experts, n_expert_used, clamp_val,
                              scale_val, config);
     } else {
-        launch_topk_moe_cuda<false>(ctx, logits_d, weights_d, ids_d, bias_d, n_rows, n_experts, n_expert_used, clamp_val,
+        launch_topk_moe_cuda<false>(ctx, logits_d, weights_out_d, ids_d, bias_d, n_rows, n_experts, n_expert_used, clamp_val,
                              scale_val, config);
+    }
+
+    if (args.weights_overlap_logits) {
+        CUDA_CHECK(cudaMemcpyAsync(weights_d, weights_out_d, n_weights * sizeof(float), cudaMemcpyDeviceToDevice, ctx.stream()));
     }
 }
 

--- a/ggml/src/ggml-cuda/topk-moe.cuh
+++ b/ggml/src/ggml-cuda/topk-moe.cuh
@@ -10,6 +10,7 @@ struct ggml_cuda_topk_moe_args {
     bool prob_bias{};
     bool norm{};
     bool scale{};
+    bool weights_overlap_logits{};
 };
 
 void ggml_cuda_op_topk_moe(ggml_backend_cuda_context &     ctx,


### PR DESCRIPTION
## Overview

This PR fixes a TopK MoE router fusion failure caused by overly conservative
overlap detection in `ggml_cuda_check_fusion_memory_ranges()`.

In the TopK MoE router path, some tensors may intentionally alias the router
logits buffer. The existing fusion memory range check treats this as a possible
unsafe overwrite and rejects the fusion, even when the overlap is a known case
that can be handled safely by the fused op.

This PR makes two changes:

- Adds a whitelist mechanism to `ggml_cuda_check_fusion_memory_ranges()` so that
  selected, known-safe overlap cases can be handled by the fused CUDA op instead
  of causing fusion to be rejected unconditionally.
- Adds a `weights_alias_logits` path to `ggml_cuda_op_topk_moe` to make the
  aliased-weights case safe at runtime.

## Additional information

- Test device: A100-40G
- Test model: Qwen3-30B-A3B-UD-IQ1_S.gguf
- Test command:
```
./build/bin/llama-bench \
  -m ./models/unsloth-Qwen3-30B-A3B-GGUF/Qwen3-30B-A3B-UD-IQ1_S.gguf \
  -ngl 99 \
  -p 1024,2048,4096,8192 \
  -n 0 \
  -b 2048 \
  -ub 512 \
  -r 20 \
  -o json
```
- Result:

| Test | Samples | Master t/s | Fix t/s | Speedup |
|---|---:|---:|---:|---:|
| pp1024 | 20 | 2946.28 | 2983.94 | +1.28% |
| pp2048 | 20 | 2850.62 | 2901.61 | +1.79% |
| pp4096 | 20 | 2662.66 | 2694.76 | +1.21% |
| pp8192 | 10 | 2293.99 | 2322.65 | +1.25% |

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES  I used AI assistance and reviewed the generated code myself.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
