### PR TITLE
grammar: reject GBNF repeat ranges where max < min (#23108)

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -464,6 +464,9 @@ const char * llama_grammar_parser::parse_sequence(
         if (last_sym_start == rule.size()) {
             throw std::runtime_error(std::string("expecting preceding item to */+/?/{ at ") + pos);
         }
+        if (!no_max && max_times < min_times) {
+            throw std::runtime_error(std::string("max repetition must be >= min repetition at ") + pos);
+        }
 
         // apply transformation to previous symbol (last_sym_start to end) according to
         // the following rewrite rules:

--- a/tests/test-grammar-integration.cpp
+++ b/tests/test-grammar-integration.cpp
@@ -882,6 +882,16 @@ static void test_failure_left_recursion() {
     fprintf(stderr, "  ✅︎ Passed\n");
 }
 
+static void test_failure_invalid_repeat_range() {
+    fprintf(stderr, "⚫ Testing invalid repeat range:\n");
+
+    // max < min should be rejected
+    assert(test_build_grammar_fails(R"""(root ::= "a"{5,0})"""));
+    assert(test_build_grammar_fails(R"""(root ::= "a"{10,3})"""));
+
+    fprintf(stderr, "  ✅︎ Passed\n");
+}
+
 static void test_failure_missing_root_symbol() {
     fprintf(stderr, "⚫ Testing missing root symbol:\n");
 
@@ -1485,6 +1495,7 @@ int main() {
     test_failure_missing_root();
     test_failure_missing_reference();
     test_failure_left_recursion();
+    test_failure_invalid_repeat_range();
     test_failure_missing_root_symbol();
     test_custom_root_symbol_check();
     test_json_schema();


### PR DESCRIPTION
$\textcolor{red}{\textbf{(USER WAS BANNED FOR (PRESUMABLY) SPAMMING AUTOMATED PULL REQUESTS)}}$

Fixes #23108

## What was wrong

A malformed GBNF repetition range like `"a"{5,0}` (where max < min) caused an unsigned integer underflow in `handle_repetitions`:

```cpp
auto n_opt = no_max ? 1 : max_times - min_times;  // 0 - 5 underflows to UINT64_MAX
```

The parser then tried to synthesize that many grammar rules, leading to unbounded memory allocation and OOM.

## Fix

Added a guard clause inside `handle_repetitions` that throws a parse error when `max_times < min_times` (for bounded ranges). This catches the invalid input early, before any subtraction or rule generation.

## Testing

- Added two failure test cases in `tests/test-grammar-integration.cpp`:
  - `root ::= "a"{5,0}`  (max < min)
  - `root ::= "a"{10,3}` (max < min)
- Full test build could not be run on this Windows/MinGW host due to pre-existing build issues (`cpp-httplib` Windows version check, `THREAD_POWER_THROTTLING_STATE` missing in MinGW headers), but the change is localized to the grammar parser and the test cases follow the existing pattern.

## Risk / scope

- Only affects GBNF grammar parsing.
- Valid ranges (max >= min) are unchanged.
- The fix runs before any memory allocation for repeated rules.
