### PR TITLE
CUDA: add fast walsh-hadamard transform

### DIFF
--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -1,0 +1,98 @@
+#include "common.cuh"
+#include "fwht.cuh"
+
+template <size_t N> __global__ void fwht_cuda(const float * src, float * dst, const int64_t n_rows, const float scale) {
+    const int64_t r = (int64_t) blockIdx.x * blockDim.y + threadIdx.y;
+
+    if (r >= n_rows) {
+        return;
+    }
+
+    src += r * N;
+    dst += r * N;
+
+    static constexpr size_t el_w = N / WARP_SIZE;
+    float                   reg[el_w];
+    const int               lane = threadIdx.x;
+
+#pragma unroll
+    for (int i = 0; i < el_w; ++i) {
+        reg[i] = src[i * WARP_SIZE + lane] * scale;
+    }
+
+    for (int h = 1; h < WARP_SIZE; h *= 2) {
+#pragma unroll
+        for (int j = 0; j < el_w; j++) {
+            const float val  = reg[j];
+            const float val2 = __shfl_xor_sync(0xFFFFFFFF, val, h, WARP_SIZE);
+
+            reg[j] = (lane & h) == 0 ? val + val2 : val2 - val;
+        }
+    }
+
+    for (int h = WARP_SIZE; h < N; h *= 2) {
+        const int step = h / WARP_SIZE;
+        for (int j = 0; j < el_w; j += 2 * step) {
+            for (int k = 0; k < step; k++) {
+                const float x = reg[j + k];
+                const float y = reg[j + k + step];
+
+                reg[j + k]        = x + y;
+                reg[j + k + step] = x - y;
+            }
+        }
+    }
+
+#pragma unroll
+    for (int i = 0; i < el_w; ++i) {
+        dst[i * WARP_SIZE + lane] = reg[i];
+    }
+}
+
+void ggml_cuda_op_fwht(ggml_backend_cuda_context & ctx, const ggml_tensor * src, ggml_tensor * dst) {
+    GGML_ASSERT(ggml_are_same_shape(src, dst));
+    GGML_ASSERT(ggml_is_contiguous(src));
+    GGML_ASSERT(ggml_is_contiguous(dst));
+    const int     n    = src->ne[0];
+    const int64_t rows = ggml_nrows(src);
+
+    const float * src_d = (const float *) src->data;
+    float *       dst_d = (float *) dst->data;
+
+    const int rows_per_block = 4;
+
+    const int64_t num_blocks = (rows + rows_per_block - 1) / rows_per_block;
+
+    cudaStream_t                         stream = ctx.stream();
+    dim3                                 grid_dims(num_blocks, 1, 1);
+    dim3                                 block_dims(WARP_SIZE, rows_per_block, 1);
+    const ggml_cuda_kernel_launch_params launch_params =
+        ggml_cuda_kernel_launch_params(grid_dims, block_dims, 0, stream);
+
+    const float scale = 1 / sqrtf(n);
+
+    switch (n) {
+        case 64:
+            {
+                ggml_cuda_kernel_launch(fwht_cuda<64>, launch_params, src_d, dst_d, rows, scale);
+                break;
+            }
+        case 128:
+            {
+                ggml_cuda_kernel_launch(fwht_cuda<128>, launch_params, src_d, dst_d, rows, scale);
+                break;
+            }
+        case 256:
+            {
+                ggml_cuda_kernel_launch(fwht_cuda<256>, launch_params, src_d, dst_d, rows, scale);
+                break;
+            }
+        case 512:
+            {
+                ggml_cuda_kernel_launch(fwht_cuda<512>, launch_params, src_d, dst_d, rows, scale);
+                break;
+            }
+        default:
+            GGML_ABORT("fatal error");
+    }
+}

--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -1,7 +1,11 @@
 #include "common.cuh"
 #include "fwht.cuh"
 
-template <int N> __launch_bounds__(4*WARP_SIZE, 1) __global__ void fwht_cuda(const float * src, float * dst, const int64_t n_rows, const float scale) {
+template <int N>
+__launch_bounds__(4*ggml_cuda_get_physical_warp_size(), 1)
+__global__ void fwht_cuda(const float * src, float * dst, const int64_t n_rows, const float scale) {
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+
     const int64_t r = (int64_t) blockIdx.x * blockDim.y + threadIdx.y;
 
     if (r >= n_rows) {
@@ -11,29 +15,29 @@ template <int N> __launch_bounds__(4*WARP_SIZE, 1) __global__ void fwht_cuda(con
     src += r * N;
     dst += r * N;
 
-    static constexpr int el_w = N / WARP_SIZE;
+    static constexpr int el_w = N / warp_size;
     float     reg[el_w];
     const int lane = threadIdx.x;
 
 #pragma unroll
     for (int i = 0; i < el_w; ++i) {
-        reg[i] = src[i * WARP_SIZE + lane] * scale;
+        reg[i] = src[i * warp_size + lane] * scale;
     }
 
 #pragma unroll
-    for (int h = 1; h < WARP_SIZE; h *= 2) {
+    for (int h = 1; h < warp_size; h *= 2) {
 #pragma unroll
         for (int j = 0; j < el_w; j++) {
             const float val  = reg[j];
-            const float val2 = __shfl_xor_sync(0xFFFFFFFF, val, h, WARP_SIZE);
+            const float val2 = __shfl_xor_sync(0xFFFFFFFF, val, h, warp_size);
 
             reg[j] = (lane & h) == 0 ? val + val2 : val2 - val;
         }
     }
 
 #pragma unroll
-    for (int h = WARP_SIZE; h < N; h *= 2) {
-        const int step = h / WARP_SIZE;
+    for (int h = warp_size; h < N; h *= 2) {
+        const int step = h / warp_size;
 #pragma unroll
         for (int j = 0; j < el_w; j += 2 * step) {
 #pragma unroll
@@ -49,7 +53,7 @@ template <int N> __launch_bounds__(4*WARP_SIZE, 1) __global__ void fwht_cuda(con
 
 #pragma unroll
     for (int i = 0; i < el_w; ++i) {
-        dst[i * WARP_SIZE + lane] = reg[i];
+        dst[i * warp_size + lane] = reg[i];
     }
 }
 
@@ -63,13 +67,15 @@ void ggml_cuda_op_fwht(ggml_backend_cuda_context & ctx, const ggml_tensor * src,
     const float * src_d = (const float *) src->data;
     float *       dst_d = (float *) dst->data;
 
+    const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
+    GGML_ASSERT(n % warp_size == 0);
     const int rows_per_block = 4;
 
     const int64_t num_blocks = (rows + rows_per_block - 1) / rows_per_block;
 
     cudaStream_t                         stream = ctx.stream();
     dim3                                 grid_dims(num_blocks, 1, 1);
-    dim3                                 block_dims(WARP_SIZE, rows_per_block, 1);
+    dim3                                 block_dims(warp_size, rows_per_block, 1);
     const ggml_cuda_kernel_launch_params launch_params =
         ggml_cuda_kernel_launch_params(grid_dims, block_dims, 0, stream);
 

--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -1,7 +1,7 @@
 #include "common.cuh"
 #include "fwht.cuh"
 
-template <size_t N> __global__ void fwht_cuda(const float * src, float * dst, const int64_t n_rows, const float scale) {
+template <int N> __launch_bounds__(4*WARP_SIZE, 1) __global__ void fwht_cuda(const float * src, float * dst, const int64_t n_rows, const float scale) {
     const int64_t r = (int64_t) blockIdx.x * blockDim.y + threadIdx.y;
 
     if (r >= n_rows) {
@@ -11,15 +11,16 @@ template <size_t N> __global__ void fwht_cuda(const float * src, float * dst, co
     src += r * N;
     dst += r * N;
 
-    static constexpr size_t el_w = N / WARP_SIZE;
-    float                   reg[el_w];
-    const int               lane = threadIdx.x;
+    static constexpr int el_w = N / WARP_SIZE;
+    float     reg[el_w];
+    const int lane = threadIdx.x;
 
 #pragma unroll
     for (int i = 0; i < el_w; ++i) {
         reg[i] = src[i * WARP_SIZE + lane] * scale;
     }
 
+#pragma unroll
     for (int h = 1; h < WARP_SIZE; h *= 2) {
 #pragma unroll
         for (int j = 0; j < el_w; j++) {
@@ -30,9 +31,12 @@ template <size_t N> __global__ void fwht_cuda(const float * src, float * dst, co
         }
     }
 
+#pragma unroll
     for (int h = WARP_SIZE; h < N; h *= 2) {
         const int step = h / WARP_SIZE;
+#pragma unroll
         for (int j = 0; j < el_w; j += 2 * step) {
+#pragma unroll
             for (int k = 0; k < step; k++) {
                 const float x = reg[j + k];
                 const float y = reg[j + k + step];

--- a/ggml/src/ggml-cuda/fwht.cuh
+++ b/ggml/src/ggml-cuda/fwht.cuh
@@ -1,0 +1,3 @@
+#include "common.cuh"
+
+void ggml_cuda_op_fwht(ggml_backend_cuda_context & ctx, const ggml_tensor * src, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -24,6 +24,7 @@
 #include "ggml-cuda/diagmask.cuh"
 #include "ggml-cuda/diag.cuh"
 #include "ggml-cuda/fattn.cuh"
+#include "ggml-cuda/fwht.cuh"
 #include "ggml-cuda/getrows.cuh"
 #include "ggml-cuda/im2col.cuh"
 #include "ggml-cuda/mmf.cuh"
@@ -2593,6 +2594,13 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
     bool use_batched_cublas_f16  = src0->type == GGML_TYPE_F16 && (src1->type == GGML_TYPE_F16 || !any_gpus_with_slow_fp16);
     bool use_batched_cublas_bf16 = src0->type == GGML_TYPE_BF16 && bf16_mma_hardware_available(cc);
     bool use_batched_cublas_f32  = src0->type == GGML_TYPE_F32;
+
+    const int32_t hint = ggml_get_op_params_i32(dst, 1);
+    if (hint == GGML_HINT_SRC0_IS_HADAMARD) {
+        GGML_ASSERT(!split);
+        ggml_cuda_op_fwht(ctx, src1, dst);
+        return;
+    }
 
     if (!split && use_mul_mat_vec_f) {
         // the custom F16 vector kernel can be used over batched cuBLAS GEMM

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8308,6 +8308,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 64, 1, 64));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 256, 1, 256));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 128, 32, 128));
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 128, 4, 128, {2, 3}));
 
 #if 0
     // > 4GB A matrix. Too slow to be enabled by default.


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Implement FWHT for CUDA, speed-up for cases when we quantize the kv-cache.  

Performance on a 5090 with `-ctk q8_0 -ctv q8_0`
| Model                 | Test          |   t/s master |   t/s cuda-fwt |   Speedup |
|:----------------------|:--------------|-------------:|---------------:|----------:|
| gemma4 26B.A4B Q4_K_M | pp2048        |     13587.89 |       13809.20 |      1.02 |
| gemma4 26B.A4B Q4_K_M | pp2048@d1024  |     12425.01 |       12553.32 |      1.01 |
| gemma4 26B.A4B Q4_K_M | pp2048@d2048  |     12158.21 |       12291.42 |      1.01 |
| gemma4 26B.A4B Q4_K_M | pp2048@d4096  |     11710.89 |       11913.97 |      1.02 |
| gemma4 26B.A4B Q4_K_M | pp2048@d8192  |     10982.21 |       11214.12 |      1.02 |
| gemma4 26B.A4B Q4_K_M | pp2048@d16384 |      9702.60 |        9776.75 |      1.01 |
| gemma4 26B.A4B Q4_K_M | tg128         |       223.81 |         243.90 |      1.09 |
| gemma4 26B.A4B Q4_K_M | tg128@d1024   |       210.06 |         228.02 |      1.09 |
| gemma4 26B.A4B Q4_K_M | tg128@d2048   |       217.53 |         235.28 |      1.08 |
| gemma4 26B.A4B Q4_K_M | tg128@d4096   |       216.76 |         234.05 |      1.08 |
| gemma4 26B.A4B Q4_K_M | tg128@d8192   |       209.40 |         226.06 |      1.08 |
| gemma4 26B.A4B Q4_K_M | tg128@d16384  |       204.54 |         219.74 |      1.07 |


## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, for review after initial implementation 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
