### PR TITLE
cuda: optimize KV cache dequant workspace to eliminate VRAM growth in flash attention

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -972,7 +972,7 @@ void launch_fattn(
         const size_t bs = ggml_blck_size(K->type);
         const size_t ts = ggml_type_size(K->type);
 
-        K_f16.alloc(ggml_nelements(K));
+        K_f16.alloc(ggml_nelements(K->view_src ? K->view_src : K));
         if (ggml_is_contiguously_allocated(K)) {
             to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(K->type);
             to_fp16(K_data, K_f16.ptr, ggml_nelements(K), main_stream);
@@ -1005,7 +1005,7 @@ void launch_fattn(
             const size_t bs = ggml_blck_size(V->type);
             const size_t ts = ggml_type_size(V->type);
 
-            V_f16.alloc(ggml_nelements(V));
+            V_f16.alloc(ggml_nelements(V->view_src ? V->view_src : V));
             if (ggml_is_contiguously_allocated(V)) {
                 to_fp16_cuda_t to_fp16 = ggml_get_to_fp16_cuda(V->type);
                 to_fp16(V_data, V_f16.ptr, ggml_nelements(V), main_stream);


### PR DESCRIPTION
## Summary

Flash attention with quantized KV cache (`--cache-type-k q8_0 --cache-type-v q8_0`) exhibits unbounded VRAM growth during generation. Each decode step allocates a new workspace buffer at a slightly larger size, and the CUDA pool allocator cannot reuse the old ones — stranding them until OOM.

The fix is **2 lines**: use the underlying buffer size (`view_src`) instead of the view size for `K_f16`/`V_f16` workspace allocations.

## Root Cause

In `ggml/src/ggml-cuda/fattn-common.cuh`, `K_f16.alloc(ggml_nelements(K))` allocates based on the view's `nelements`, which tracks the current `n_kv` (growing by 1 each decode step). The KV cache tensor is a view; `K->view_src` points to the fixed-size underlying buffer.

The CUDA pool allocator (legacy path) uses best-fit: each new allocation is strictly larger than the previous one, so old buffers are never reused. After 256 unique sizes the pool overflows, stranding all prior buffers. Community measurements show approximately **1 MB per 600 tokens** of cumulative VRAM growth, with full 131k context accumulating ~500 MB of stranded allocations.

### Why this is not "expected behavior"

The workspace does need to grow with context — that part is expected. The bug is that it **never reuses** previous allocations. Each allocation at size N+1 is a fresh allocation; the old one at size N sits stranded in the pool forever. The fix doesn't reduce VRAM usage; it makes the allocation **reusable** by always requesting the max buffer size, so the pool returns the same buffer every call.

## Fix

```diff
- K_f16.alloc(ggml_nelements(K));
+ K_f16.alloc(ggml_nelements(K->view_src ? K->view_src : K));

- V_f16.alloc(ggml_nelements(V));
+ V_f16.alloc(ggml_nelements(V->view_src ? V->view_src : V));
```

The `view_src` size is constant across the session (max context window), so the pool reuses the same allocation on every call. The `view_src ? view_src : tensor` pattern is already used elsewhere in `ggml-cuda.cu` (lines 3139, 3148, 3158, 3169, 4583-4584) for the same purpose.

### VMM pool benefit

On GPUs with VMM support (GH200, H100, Blackwell), the VMM pool is less susceptible to buffer stranding. However, the fix still eliminates repeated `cuMemCreate`/`cuMemRelease` cycles at page granularity, reducing kernel driver overhead.

## Scope

This fix addresses the KV cache dequant workspace in `launch_fattn`. It does **not** address separate VRAM behavior in the multimodal/vision pipeline reported in #23446 — that is a different code path (mmproj/CLIP) with its own allocation patterns, tracked separately in #23422.

## Verification

- **GH200 (Grace Hopper, sm_90)**: instrumented build confirms `nelements` differs from `view_src` before fix (32K vs 4.19M), and matches `view_src` after fix — 48 allocations, all correct.
- **Community** (issue #23446): 5 users confirmed the VRAM growth on RTX 2080Ti, 3090, 5090; 2 users confirmed the fix eliminates the growth. Also reproduced on Vulkan backend, confirming it's not CUDA-specific.

Fixes #23446