### PR TITLE
Adding features to save the final answer and the thinking to their respective files

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -4143,6 +4143,32 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             //params.speculative.ngram_map_k4v.min_hits = 2;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
+    
+    add_opt(common_arg(
+        {"-st", "--save-thinking"}, "FNAME",
+        "Save the model’s thinking to a file while it elaborates the final answer.\n"
+        "It uses the value provided by the --set-thinking-chunk argument to create a backup every thinking_chunk tokens. If that argument is not provided, the default value is 500.",
+        [](common_params & params, const std::string & filename) {
+            params.thinking_filename = filename;
+        }
+    ));
+    add_opt(common_arg(
+        {"-stc", "--set-thinking-chunk"}, "N",
+        "It establishes the value used to create a backup every N generated tokens. Its default value is 500.",
+        [](common_params & params, int value) {
+            if (value <= 0) {
+                throw std::invalid_argument("invalid value: cannot be equal or less than 0");
+            }
+            params.thinking_chunk = value;
+        }
+    ));
+    add_opt(common_arg(
+        {"-sa", "--save-answer"}, "FNAME",
+        "Save the final answer to a file.\n",
+        [](common_params & params, const std::string & filename) {
+            params.answer_filename = filename;
+        }
+    ));
 
     return ctx_arg;
 }

--- a/common/common.h
+++ b/common/common.h
@@ -699,7 +699,7 @@ struct common_params {
     void *                  load_progress_callback_user_data = NULL;
     bool no_alloc = false; // Don't allocate model buffers
     
-    int thinking_chunk = 500; // the LLM thinking is save every 'chunk' generated tokens
+    int thinking_chunk = 500; // the LLM thinking is saved every 'thinking_chunk' of generated tokens
     std::string thinking_filename = ""; // output filename for LLM thinking 
     std::string answer_filename = ""; // output filename for LLM answer
 };

--- a/common/common.h
+++ b/common/common.h
@@ -698,6 +698,10 @@ struct common_params {
     llama_progress_callback load_progress_callback = NULL;
     void *                  load_progress_callback_user_data = NULL;
     bool no_alloc = false; // Don't allocate model buffers
+    
+    int thinking_chunk = 500; // the LLM thinking is save every 'chunk' generated tokens
+    std::string thinking_filename = ""; // output filename for LLM thinking 
+    std::string answer_filename = ""; // output filename for LLM answer
 };
 
 // call once at the start of a program if it uses libcommon

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -77,7 +77,7 @@ struct cli_context {
         verbose_prompt = params.verbose_prompt;
     }
 
-    std::string generate_completion(result_timings & out_timings) {
+    std::string generate_completion(result_timings & out_timings, const common_params & params) {
         server_response_reader rd = ctx_server.get_response_reader();
         auto chat_params = format_chat();
         {
@@ -131,6 +131,21 @@ struct cli_context {
         console::spinner::stop();
         std::string curr_content;
         bool is_thinking = false;
+        
+        int thinking_counter = 0;
+        std::vector<std::string> thinking_array;
+        std::ofstream thinkingFileClear;
+        std::ofstream thinkingFile;
+        if (!params.thinking_filename.empty()) {
+            thinking_array.resize(params.thinking_chunk);
+        
+            thinkingFileClear.open(params.thinking_filename, std::ios::out | std::ios::trunc); // thinking file is now empty
+            if (thinkingFileClear.is_open()) {
+                thinkingFileClear.close(); 
+            }
+            
+            thinkingFile.open(params.thinking_filename, std::ios_base::app); // now it's possible to append text to the thinking file
+        }
 
         while (result) {
             if (should_stop()) {
@@ -156,8 +171,16 @@ struct cli_context {
                             is_thinking = false;
                         }
                         curr_content += diff.content_delta;
-                        console::log("%s", diff.content_delta.c_str());
-                        console::flush();
+                        
+                        if (is_thinking && params.thinking_filename.empty()) {
+                            console::log("%s", diff.content_delta.c_str());
+                            console::flush();
+                        }
+                        
+                        if (!is_thinking && params.answer_filename.empty()) {
+                            console::log("%s", diff.content_delta.c_str());
+                            console::flush();
+                        }   
                     }
                     if (!diff.reasoning_content_delta.empty()) {
                         console::set_display(DISPLAY_TYPE_REASONING);
@@ -165,8 +188,38 @@ struct cli_context {
                             console::log("[Start thinking]\n");
                         }
                         is_thinking = true;
-                        console::log("%s", diff.reasoning_content_delta.c_str());
-                        console::flush();
+                        
+                        if (!params.thinking_filename.empty()) {
+                            thinking_array[thinking_counter] = diff.reasoning_content_delta.c_str();
+                            thinking_counter++;
+                            if (thinking_counter == params.thinking_chunk) {
+                                for(int i=0; i < params.thinking_chunk; ++i) {
+                                    if (thinkingFile.is_open()) {
+                                        thinkingFile << thinking_array[i];
+                                        thinkingFile.flush();
+                                    }
+                                    else {
+                                        console::log("thinking file is not open");
+                                    }
+                                }
+                            
+                                // print a log message to the screen indicating the time of the last backup
+                                auto now = std::chrono::system_clock::now();
+                                std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+                                std::ostringstream oss;
+                                oss << std::put_time(std::localtime(&now_c), "%T");
+                                console::log("Backup at ");
+                                console::log("%s", oss.str().c_str());
+                                console::log("\n");
+                                console::flush();
+                            
+                                thinking_counter = 0;
+                            }
+                        }
+                        else { 
+                            console::log("%s", diff.reasoning_content_delta.c_str());
+                            console::flush();
+                        }
                     }
                 }
             }
@@ -177,6 +230,34 @@ struct cli_context {
             }
             result = rd.next(should_stop);
         }
+        
+        // save the answer to a file
+        if (!params.answer_filename.empty()) {
+            std::ofstream answerFile(params.answer_filename);
+            if (answerFile.is_open()) {
+                answerFile << curr_content;
+                answerFile.flush();
+                answerFile.close();
+            }
+            else {
+                console::log("answer file is not open");
+            }        
+        }
+        
+        // save the last part of the thinking to a file
+        if (!params.thinking_filename.empty()) {
+            if (thinkingFile.is_open()) {
+                for(int i=0; i < thinking_counter; ++i) {
+                    thinkingFile << thinking_array[i];
+                    thinkingFile.flush();
+                }
+                thinkingFile.close();
+            }
+            else {
+                console::log("thinking file is not open");
+            }
+        }
+        
         g_is_interrupted.store(false);
         // server_response_reader automatically cancels pending tasks upon destruction
         return curr_content;
@@ -622,7 +703,7 @@ int llama_cli(int argc, char ** argv) {
             cur_msg.clear();
         }
         result_timings timings;
-        std::string assistant_content = ctx_cli.generate_completion(timings);
+        std::string assistant_content = ctx_cli.generate_completion(timings, params);
         ctx_cli.messages.push_back({
             {"role",    "assistant"},
             {"content", assistant_content}


### PR DESCRIPTION
It adds three CLI flags: 
. to save the model’s answer to a file, 
. to save the model’s thinking to a file, 
. and to save the partial thinking every N generated tokens.

It was essential to solve the problem outlined in https://github.com/donlaiq/minipc/discussions/3. There, I’m basically probing a large LLM model running on a PC with limited resources, and it takes several days to complete the request. Besides, in this case, the model (Kimi 2.6) doesn’t return a separate answer; instead, the answer is part of the final sentences of the reasoning. The saved reasoning also helps to reconstruct context and make a new request in case of an outage.
