### PR TITLE
server: enhance FIFO prompt cache eviction with second-chance algorithm

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -174,6 +174,7 @@ struct server_slot {
         }
 
         prompt.tokens.clear();
+        prompt.score = 1;
     }
 
     std::vector<common_adapter_lora_info> lora;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -2055,6 +2055,7 @@ server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t 
             /*.drft =*/ std::move(state_data_dft),
         },
         /*.checkpoints =*/ prompt.checkpoints,
+        /*.score       =*/ prompt.score,
     });
 
     return &states.back();
@@ -2092,6 +2093,9 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
 
     if (it_best != states.end()) {
         SRV_INF(" - found better prompt with f_keep = %.3f, sim = %.3f\n", f_keep_best, sim_best);
+
+        // reward cache hit
+        it_best->score = std::min((uint8_t)(it_best->score + 1), (uint8_t)4);
 
         {
             auto & data = it_best->data.main;
@@ -2136,16 +2140,41 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
 }
 
 void server_prompt_cache::update() {
+    // second-chance eviction: decay score and rotate to back, evict when score <= 1
+    auto evict_one = [this]() {
+        if (states.size() <= 1) {
+            return;
+        }
+
+        // hard iteration cap to prevent infinite loops when all entries have max score
+        const size_t max_iter = states.size() * 5;
+        size_t iter = 0;
+
+        while (states.size() > 1) {
+            if (iter++ >= max_iter) {
+                SRV_WRN(" - cache size limit reached, removing oldest entry (size = %.3f MiB)\n", states.front().size() / (1024.0 * 1024.0));
+                states.pop_front();
+                return;
+            }
+
+            if (states.front().score <= 1) {
+                // score has decayed, safe to evict
+                SRV_WRN(" - cache limit reached, evicting unused/decayed entry (size = %.3f MiB)\n",
+                        states.front().size() / (1024.0 * 1024.0));
+                states.pop_front();
+                return;
+            }
+
+            // second chance: decay score and rotate to back
+            states.front().score--;
+            states.splice(states.end(), states, states.begin());
+        }
+    };
+
     if (limit_size > 0) {
         // always keep at least one state, regardless of the limits
         while (states.size() > 1 && size() > limit_size) {
-            if (states.empty()) {
-                break;
-            }
-
-            SRV_WRN(" - cache size limit reached, removing oldest entry (size = %.3f MiB)\n", states.front().size() / (1024.0 * 1024.0));
-
-            states.pop_front();
+            evict_one();
         }
     }
 
@@ -2157,14 +2186,7 @@ void server_prompt_cache::update() {
 
     if (limit_tokens > 0) {
         while (states.size() > 1 && n_tokens() > limit_tokens_cur) {
-            if (states.empty()) {
-                break;
-            }
-
-            SRV_WRN(" - cache token limit (%zu, est: %zu) reached, removing oldest entry (size = %.3f MiB)\n",
-                    limit_tokens, limit_tokens_cur, states.front().size() / (1024.0 * 1024.0));
-
-            states.pop_front();
+            evict_one();
         }
     }
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -603,6 +603,9 @@ struct server_prompt {
 
     std::list<common_prompt_checkpoint> checkpoints;
 
+    // second-chance score for cache eviction, 1 = fresh/decayed, higher = more retained
+    uint8_t score = 1;
+
     size_t size() const {
         size_t res = 0;
 


### PR DESCRIPTION
- Pure FIFO eviction always removes the oldest cache entry
- A small side session request evicts a large session's cached KV state immediately, forcing full reprocessing and preventing users on small machines from switching sessions back and forth.

What the fix does:
- Assign score = 1 to new cache entries
- Only on a cache hit (best match) score += 1 (max score=4) -> 4 is the sweet spot
- During checkpoint limit reached, instead of always evicting first out,
  - If front score <= 1, evict it
  - Otherwise, score -= 1 rotate it to the back (second chance), repeat
- If all entries have max score, cap max iter at states.size() * 5 and falls back to evicting the front to prevents infinite loops

With this algorithm, I can switch between sessions without sacrificing compute.

## Additional information

related issue (#23030, #20510)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes - researching for solution