### PR TITLE
Qwen35 think tool mode switch

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -458,11 +458,20 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
 
     if (!format.per_call_start.empty()) {
         auto wrapped_call = format.per_call_start + p.space() + tool_choice + p.space() + format.per_call_end;
-        tool_call_item = p.trigger_rule("tool-call", wrapped_call + p.space());
+        if (format.section_start.empty()) {
+            // Lazy grammars are activated from the first tool-call marker in the
+            // generated suffix. The trigger grammar must validate the tool call,
+            // but it should not require the tool call to be the last segment in
+            // the completion. Tagged tool calls can appear inside reasoning
+            // blocks, followed by </think>, content, or more segments that the
+            // full parser will handle afterwards.
+            p.trigger_rule("tool-call", wrapped_call + p.rest());
+        }
+        tool_call_item = wrapped_call + p.space();
         if (inputs.parallel_tool_calls) {
-            tool_calls = p.trigger_rule("tool-call", wrapped_call + p.zero_or_more(p.space() + wrapped_call) + p.space());
+            tool_calls = wrapped_call + p.zero_or_more(p.space() + wrapped_call) + p.space();
         } else {
-            tool_calls = p.trigger_rule("tool-call", wrapped_call + p.space());
+            tool_calls = wrapped_call + p.space();
         }
         if (!format.section_start.empty()) {
             tool_calls = p.trigger_rule("tool-calls",

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -489,23 +489,29 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
     std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
     auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
 
-    // Qwen3.5 XML tools are frequently emitted inside <think>...</think> blocks.  Treat
-    // <think> as a mode switch: text inside it is reasoning, text outside it is content,
-    // and valid tool calls can appear in either mode.  This is intentionally limited to
-    // the XML tagged-argument format used by Qwen (<tool_call><function=...><parameter=...>)
-    // to avoid changing semantics for other templates that may mention tool markers in
-    // reasoning text.
+    // Treat tag-based reasoning markers as mode switches rather than containers that
+    // hide tools. Text inside the reasoning markers is emitted as reasoning_content,
+    // text outside is emitted as content, and valid tool calls can appear in either
+    // mode. This path applies to tagged-argument tool formats, such as:
+    //
+    //   <tool_call>
+    //   <function=name>
+    //   <parameter=arg>value</parameter>
+    //   </function>
+    //   </tool_call>
+    //
+    // Use a specific tool boundary that includes the function-name prefix when
+    // possible, so prose such as "I might call <tool_call> later" remains text.
     if (ctx.extracting_reasoning && ctx.reasoning &&
-        trim_whitespace(ctx.reasoning->start) == "<think>" &&
-        trim_whitespace(ctx.reasoning->end) == "</think>" &&
+        !trim_whitespace(ctx.reasoning->start).empty() &&
+        !trim_whitespace(ctx.reasoning->end).empty() &&
         format.section_start.empty() &&
-        trim_whitespace(format.per_call_start) == "<tool_call>" &&
-        trim_whitespace(format.per_call_end) == "</tool_call>") {
+        !trim_whitespace(format.per_call_start).empty() &&
+        !trim_whitespace(format.per_call_end).empty()) {
         const std::string think_start = trim_whitespace(ctx.reasoning->start);
         const std::string think_end   = trim_whitespace(ctx.reasoning->end);
-        // Use the more specific Qwen XML tool prefix as the text boundary so that
-        // prose such as "I might call <tool_call> later" remains reasoning text.
-        const std::string tool_start  = trim_whitespace(format.per_call_start) + "\n" + function.name_prefix;
+        const std::string tool_start  = trim_whitespace(format.per_call_start) +
+            (function.name_prefix.empty() ? "" : "\n" + function.name_prefix);
 
         auto in_think_boundary = p.choice({
             p.literal(tool_start),

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -454,9 +454,11 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
     auto require_tools = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED;
 
     common_peg_parser tool_calls = p.eps();
+    common_peg_parser tool_call_item = p.eps();
 
     if (!format.per_call_start.empty()) {
         auto wrapped_call = format.per_call_start + p.space() + tool_choice + p.space() + format.per_call_end;
+        tool_call_item = p.trigger_rule("tool-call", wrapped_call + p.space());
         if (inputs.parallel_tool_calls) {
             tool_calls = p.trigger_rule("tool-call", wrapped_call + p.zero_or_more(p.space() + wrapped_call) + p.space());
         } else {
@@ -486,6 +488,49 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
 
     std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
     auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
+
+    // Qwen3.5 XML tools are frequently emitted inside <think>...</think> blocks.  Treat
+    // <think> as a mode switch: text inside it is reasoning, text outside it is content,
+    // and valid tool calls can appear in either mode.  This is intentionally limited to
+    // the XML tagged-argument format used by Qwen (<tool_call><function=...><parameter=...>)
+    // to avoid changing semantics for other templates that may mention tool markers in
+    // reasoning text.
+    if (ctx.extracting_reasoning && ctx.reasoning &&
+        trim_whitespace(ctx.reasoning->start) == "<think>" &&
+        trim_whitespace(ctx.reasoning->end) == "</think>" &&
+        format.section_start.empty() &&
+        trim_whitespace(format.per_call_start) == "<tool_call>" &&
+        trim_whitespace(format.per_call_end) == "</tool_call>") {
+        const std::string think_start = trim_whitespace(ctx.reasoning->start);
+        const std::string think_end   = trim_whitespace(ctx.reasoning->end);
+        // Use the more specific Qwen XML tool prefix as the text boundary so that
+        // prose such as "I might call <tool_call> later" remains reasoning text.
+        const std::string tool_start  = trim_whitespace(format.per_call_start) + "\n" + function.name_prefix;
+
+        auto in_think_boundary = p.choice({
+            p.literal(tool_start),
+            p.literal(think_end),
+        });
+        auto root_boundary = p.choice({
+            p.literal(think_start),
+            p.literal(think_end),
+            p.literal(tool_start),
+        });
+
+        auto reasoning_chunk = p.reasoning(
+            p.negate(in_think_boundary) + p.any() + p.until_one_of({ tool_start, think_end }));
+        auto content_chunk = p.content(
+            p.negate(root_boundary) + p.any() + p.until_one_of({ think_start, think_end, tool_start }));
+
+        auto stale_think_end = p.literal(think_end) + p.space();
+        auto think_block =
+            p.literal(think_start) + p.space() +
+            p.zero_or_more(p.choice({ tool_call_item, reasoning_chunk })) +
+            p.optional(stale_think_end);
+
+        return p.zero_or_more(p.choice({ think_block, tool_call_item, stale_think_end, content_chunk })) + p.end();
+    }
+
     return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
 }
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -477,6 +477,24 @@ static common_chat_tool python_tool{
         "required": ["code"]
     })",
 };
+static common_chat_tool write_tool{
+    /* .name = */ "write",
+    /* .description = */ "write a file",
+    /* .parameters = */ R"({
+        "type": "object",
+        "properties": {
+            "file": {
+                "type": "string",
+                "description": "File path."
+            },
+            "content": {
+                "type": "string",
+                "description": "Full replacement file content."
+            }
+        },
+        "required": ["file", "content"]
+    })",
+};
 
 static common_chat_tool html_tool{
     /* .name = */ "html",
@@ -1951,6 +1969,38 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_tool_calls({
                 { "python", "{\"code\": \"def hello():\\n    print(\\\"Not the real call!\\\")\\n\\nhello()\"}", {} },
                 { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need to write a debug file.\n"
+               "<tool_call>\n"
+               "<function=write>\n"
+               "<parameter=file>\n"
+               "/workspace/jsonlfilter/debug_test.go\n"
+               "</parameter>\n"
+               "<parameter=content>\n"
+               "package main\n"
+               "\n"
+               "func main() {\n"
+               "    line := `{name:Jette,status:sleepy}`\n"
+               "    fmt.Printf(\"Status: %q\\n\", result[\"status\"])\n"
+               "}\n"
+               "\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "</think>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({
+                write_tool
+        })
+            .expect_reasoning("Need to write a debug file.")
+            .expect_content("Done.")
+            .expect_tool_calls({
+                { "write", R"({"file":"/workspace/jsonlfilter/debug_test.go","content":"package main\n\nfunc main() {\n    line := `{name:Jette,status:sleepy}`\n    fmt.Printf(\"Status: %q\\n\", result[\"status\"])\n}\n"})", {} },
             })
             .run();
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1919,7 +1919,8 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_content(R"({"amount": 123.45, "date": "2025-12-03"})")
             .run();
 
-        // tool call segment in reasoning
+        // Qwen3.5 can emit tool calls inside <think>. Treat <think> as a
+        // reasoning/content mode switch, not as a container that hides tools.
         tst.test(
                "Let's call a tool: <tool_call>\n"
                "<function=python>\n"
@@ -1946,18 +1947,9 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({
                 python_tool
         })
-            .expect_reasoning(
-                "Let's call a tool: <tool_call>\n"
-                "<function=python>\n"
-                "<parameter=code>\n"
-                "def hello():\n"
-                "    print(\"Not the real call!\")\n"
-                "\n"
-                "hello()\n"
-                "</parameter>\n"
-                "</function>\n"
-                "</tool_call>")
+            .expect_reasoning("Let's call a tool:")
             .expect_tool_calls({
+                { "python", "{\"code\": \"def hello():\\n    print(\\\"Not the real call!\\\")\\n\\nhello()\"}", {} },
                 { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
             })
             .run();
@@ -2417,7 +2409,8 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_content(R"({"amount": 123.45, "date": "2025-12-03"})")
             .run();
 
-        // tool call segment in reasoning
+        // Qwen3.5 can emit tool calls inside <think>. Treat <think> as a
+        // reasoning/content mode switch, not as a container that hides tools.
         tst.test(
                "Let's call a tool: <tool_call>\n"
                "<function=python>\n"
@@ -2445,17 +2438,9 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({
                 python_tool
         })
-            .expect_reasoning("Let's call a tool: <tool_call>\n"
-               "<function=python>\n"
-               "<parameter=code>\n"
-               "def hello():\n"
-               "    print(\"Not the real call!\")\n"
-               "\n"
-               "hello()\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n")
+            .expect_reasoning("Let's call a tool:")
             .expect_tool_calls({
+                { "python", "{\"code\": \"def hello():\\n    print(\\\"Not the real call!\\\")\\n\\nhello()\"}", {} },
                 { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
             })
             .run();


### PR DESCRIPTION
## Overview

This changes the chat auto-parser behavior for tagged tool-call formats when reasoning tags are enabled.

Previously, `<think>...</think>` was parsed as a reasoning container before tool parsing. If a model emitted a valid tagged tool call inside a reasoning block, the entire tool call was treated as `reasoning_content` instead of being parsed as a tool call.

Some Qwen-style models are designed to emit XML-style tool calls inside `<think>` blocks, for example:

```
<think>
Reasoning... 

<tool_call>...</tool_call>
</think>

<tool_call>...</tool_call>
Final answer... 
```

This PR treats reasoning tags as mode switches instead of containers that hide tool calls:

- text inside reasoning tags is emitted as `reasoning_content`
- text outside reasoning tags is emitted as normal `content`
- valid tagged tool calls are parsed as `tool_calls` in either mode

The change currently applies to tagged-argument tool formats and avoids treating casual prose containing `<tool_call>` as a tool call by using a more specific boundary when available.

Tests were updated to cover tool calls inside reasoning blocks.

## Additional information

This was motivated by Qwen3.5-style output where tool calls may appear inside `<think>` blocks.

Tested with:

`./build/bin/test-chat`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assistance was used during investigation/prototyping. I have a background in software engineering, but I'm not experienced with C++. I designed the code shape together with Codex.