### PR TITLE
ggml.h: Fix warnings due to enum arithmethic

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2256,6 +2256,18 @@ extern "C" {
         GGML_SCALE_FLAG_ANTIALIAS     = (1 << 9),
     };
 
+#ifdef __cplusplus
+    // Overloads to apply a flag to a mode. Explicitly defined because arithmethic between different enum types are deprecated by C++20 (https://wg21.link/P1120) and disallowed by C++26 (https://wg21.link/P2864).
+
+    inline ggml_scale_mode operator|(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+        return ggml_scale_mode(int(mode) | int(flag));
+    }
+
+    inline ggml_scale_mode operator&(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+        return ggml_scale_mode(int(mode) & int(flag));
+    }
+#endif
+
     // interpolate
     // multiplies ne0 and ne1 by scale factor
     GGML_API struct ggml_tensor * ggml_upscale(

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2259,11 +2259,11 @@ extern "C" {
 #ifdef __cplusplus
     // Overloads to apply a flag to a mode. Explicitly defined because arithmethic between different enum types are deprecated by C++20 (https://wg21.link/P1120) and disallowed by C++26 (https://wg21.link/P2864).
 
-    inline ggml_scale_mode operator|(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+    inline constexpr ggml_scale_mode operator|(const ggml_scale_mode mode, const ggml_scale_flag flag) {
         return ggml_scale_mode(int(mode) | int(flag));
     }
 
-    inline ggml_scale_mode operator&(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+    inline constexpr ggml_scale_mode operator&(const ggml_scale_mode mode, const ggml_scale_flag flag) {
         return ggml_scale_mode(int(mode) & int(flag));
     }
 #endif

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2324,6 +2324,18 @@ extern "C" {
         GGML_SCALE_FLAG_ANTIALIAS     = (1 << 9),
     };
 
+#ifdef __cplusplus
+    // Overloads to apply a flag to a mode. Explicitly defined because arithmethic between different enum types are deprecated by C++20 (https://wg21.link/P1120) and disallowed by C++26 (https://wg21.link/P2864).
+
+    inline ggml_scale_mode operator|(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+        return ggml_scale_mode(int(mode) | int(flag));
+    }
+
+    inline ggml_scale_mode operator&(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+        return ggml_scale_mode(int(mode) & int(flag));
+    }
+#endif
+
     // interpolate
     // multiplies ne0 and ne1 by scale factor
     GGML_API struct ggml_tensor * ggml_upscale(

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2327,11 +2327,11 @@ extern "C" {
 #ifdef __cplusplus
     // Overloads to apply a flag to a mode. Explicitly defined because arithmethic between different enum types are deprecated by C++20 (https://wg21.link/P1120) and disallowed by C++26 (https://wg21.link/P2864).
 
-    inline ggml_scale_mode operator|(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+    inline constexpr ggml_scale_mode operator|(const ggml_scale_mode mode, const ggml_scale_flag flag) {
         return ggml_scale_mode(int(mode) | int(flag));
     }
 
-    inline ggml_scale_mode operator&(const ggml_scale_mode mode, const ggml_scale_flag flag) {
+    inline constexpr ggml_scale_mode operator&(const ggml_scale_mode mode, const ggml_scale_flag flag) {
         return ggml_scale_mode(int(mode) & int(flag));
     }
 #endif

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9357,16 +9357,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     //    test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {i, 2, 1, 3}, rand() % i + 1));
     //}
 
-    for (ggml_scale_mode mode : {GGML_SCALE_MODE_NEAREST, GGML_SCALE_MODE_BILINEAR, GGML_SCALE_MODE_BICUBIC, ggml_scale_mode(GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS)}) {
+    for (ggml_scale_mode mode : {GGML_SCALE_MODE_NEAREST, GGML_SCALE_MODE_BILINEAR, GGML_SCALE_MODE_BICUBIC, GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS}) {
         test_cases.emplace_back(new test_upscale(GGML_TYPE_F32, {512, 512, 3, 2}, 2, mode));
         test_cases.emplace_back(new test_upscale(GGML_TYPE_F32, {512, 512, 3, 2}, 2, mode, true));
         test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {2, 5,  7, 11}, {5, 7, 11, 13}, mode));
         test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {5, 7, 11, 13}, {2, 5,  7, 11}, mode));
     }
     for (ggml_scale_mode mode : {GGML_SCALE_MODE_BILINEAR, GGML_SCALE_MODE_BICUBIC}) {
-        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {2, 5, 7, 11}, {5, 7, 11, 13}, (ggml_scale_mode)(mode | GGML_SCALE_FLAG_ALIGN_CORNERS)));
-        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {1, 4, 3, 2}, {2, 8, 3, 2}, (ggml_scale_mode)(mode | GGML_SCALE_FLAG_ALIGN_CORNERS)));
-        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {4, 1, 3, 2}, {1, 1, 3, 2}, (ggml_scale_mode)(mode | GGML_SCALE_FLAG_ALIGN_CORNERS)));
+        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {2, 5, 7, 11}, {5, 7, 11, 13}, mode | GGML_SCALE_FLAG_ALIGN_CORNERS));
+        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {1, 4, 3, 2}, {2, 8, 3, 2}, mode | GGML_SCALE_FLAG_ALIGN_CORNERS));
+        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {4, 1, 3, 2}, {1, 1, 3, 2}, mode | GGML_SCALE_FLAG_ALIGN_CORNERS));
     }
 
     test_cases.emplace_back(new test_sum());

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10384,16 +10384,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     //    test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {i, 2, 1, 3}, rand() % i + 1));
     //}
 
-    for (ggml_scale_mode mode : {GGML_SCALE_MODE_NEAREST, GGML_SCALE_MODE_BILINEAR, GGML_SCALE_MODE_BICUBIC, ggml_scale_mode(GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS)}) {
+    for (ggml_scale_mode mode : {GGML_SCALE_MODE_NEAREST, GGML_SCALE_MODE_BILINEAR, GGML_SCALE_MODE_BICUBIC, GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS}) {
         test_cases.emplace_back(new test_upscale(GGML_TYPE_F32, {512, 512, 3, 2}, 2, mode));
         test_cases.emplace_back(new test_upscale(GGML_TYPE_F32, {512, 512, 3, 2}, 2, mode, true));
         test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {2, 5,  7, 11}, {5, 7, 11, 13}, mode));
         test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {5, 7, 11, 13}, {2, 5,  7, 11}, mode));
     }
     for (ggml_scale_mode mode : {GGML_SCALE_MODE_BILINEAR, GGML_SCALE_MODE_BICUBIC}) {
-        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {2, 5, 7, 11}, {5, 7, 11, 13}, (ggml_scale_mode)(mode | GGML_SCALE_FLAG_ALIGN_CORNERS)));
-        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {1, 4, 3, 2}, {2, 8, 3, 2}, (ggml_scale_mode)(mode | GGML_SCALE_FLAG_ALIGN_CORNERS)));
-        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {4, 1, 3, 2}, {1, 1, 3, 2}, (ggml_scale_mode)(mode | GGML_SCALE_FLAG_ALIGN_CORNERS)));
+        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {2, 5, 7, 11}, {5, 7, 11, 13}, mode | GGML_SCALE_FLAG_ALIGN_CORNERS));
+        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {1, 4, 3, 2}, {2, 8, 3, 2}, mode | GGML_SCALE_FLAG_ALIGN_CORNERS));
+        test_cases.emplace_back(new test_interpolate(GGML_TYPE_F32, {4, 1, 3, 2}, {1, 1, 3, 2}, mode | GGML_SCALE_FLAG_ALIGN_CORNERS));
     }
 
     test_cases.emplace_back(new test_sum());

--- a/tools/mtmd/clip-graph.h
+++ b/tools/mtmd/clip-graph.h
@@ -9,8 +9,6 @@
 #include <vector>
 #include <functional>
 
-#define DEFAULT_INTERPOLATION_MODE (GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS)
-
 struct build_vit_opts {
     ggml_tensor * attn_mask = nullptr;
     // TODO @ngxson : merge attn_mask and attn_mask_layers into one call
@@ -76,6 +74,8 @@ struct clip_graph {
         GGML_ASSERT(idx < img_batch->entries.size());
         return img_batch->entries[idx];
     }
+
+    static constexpr ggml_scale_mode DEFAULT_INTERPOLATION_MODE = GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS;
 
     // siglip2 naflex
     ggml_tensor * resize_position_embeddings(uint32_t interpolation_mode = DEFAULT_INTERPOLATION_MODE);

--- a/tools/mtmd/clip-graph.h
+++ b/tools/mtmd/clip-graph.h
@@ -9,8 +9,6 @@
 #include <vector>
 #include <functional>
 
-#define DEFAULT_INTERPOLATION_MODE (GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS)
-
 struct build_vit_opts {
     ggml_tensor * attn_mask = nullptr;
     // TODO @ngxson : merge attn_mask and attn_mask_layers into one call
@@ -79,6 +77,8 @@ struct clip_graph {
         GGML_ASSERT(idx < img_batch->entries.size());
         return img_batch->entries[idx];
     }
+
+    static constexpr ggml_scale_mode DEFAULT_INTERPOLATION_MODE = GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS;
 
     // siglip2 naflex
     ggml_tensor * resize_position_embeddings(uint32_t interpolation_mode = DEFAULT_INTERPOLATION_MODE);


### PR DESCRIPTION
## Overview

Arithmethic between different enum types are deprecated by C++20 (https://wg21.link/P1120) and disallowed by C++26
(https://wg21.link/P2864).

Bitwise OR/AND overloads between ggml_scale_mode and ggml_scale_flag are explicitly defined to silence deprecated-enum-enum-conversion warnings.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO