### PR TITLE
[AI policy violation] fix(server): don't clear slot tokens when no better cache entry found

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1332,9 +1332,7 @@ private:
                     ret->prompt_save(*prompt_cache);
                 }
 
-                if (!ret->prompt_load(*prompt_cache, task.tokens)) {
-                    ret->prompt_clear(false);
-                }
+                ret->prompt_load(*prompt_cache, task.tokens);
 
                 prompt_cache->update();
 


### PR DESCRIPTION
## Overview

prompt_load() returns false when no cached entry has strictly better f_keep and sim scores than the slot's current tokens. This is not a failure — the slot's existing tokens are already a valid match for the task. The previous code called prompt_clear(false) on this path, wiping out valid tokens and forcing full prompt reprocessing.

Fix: remove the prompt_clear(false) call. When prompt_load returns false, keep the slot's original tokens which already have high LCP similarity with the task.

## Additional information

This solves excessive reprocessing of the full context. I run multiple pascal gpus which are fairly slow, making the initial processing painful. Before this fix, I constantly found that llama.cpp would reprocess the full context. I've been running this fix for a few days and have found that the server runs much better, rarely needing to process more than 5-10% between calls (using oh-my-pi).

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): yes
- AI usage disclosure: yes, to understand the codebase and evaluate logs to track down the issue and implement a fix. I've been manually testing this heavily over the last couple of days without any issues, only MUCH improved performance.