### PR TITLE
CI: test-backend-ops -j8

### DIFF
--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -93,5 +93,4 @@ jobs:
           export GGML_VK_DISABLE_F16=1
           export GGML_VK_DISABLE_COOPMAT=1
           # This is using llvmpipe and runs slower than other backends
-          # test-backend-ops is too slow on llvmpipe, skip it
-          ctest -L main -E test-backend-ops --verbose --timeout 900
+          ctest -L main --verbose --timeout 1800

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -683,7 +683,7 @@ function gg_run_test_backend_ops_cpu {
 
     set -e
 
-    (time ./bin/test-backend-ops -b CPU ) 2>&1 | tee -a $OUT/${ci}-test-backend-ops-cpu.log
+    (time ./bin/test-backend-ops -j 8 -b CPU ) 2>&1 | tee -a $OUT/${ci}-test-backend-ops-cpu.log
 
     set +e
 }

--- a/scripts/snapdragon/qdc/tests/linux/run_linux.sh
+++ b/scripts/snapdragon/qdc/tests/linux/run_linux.sh
@@ -193,9 +193,9 @@ run_backend_ops_case() {
       pattern="type_a=${dtype}"
       ;;
   esac
-  echo "=== [backend-ops:$dtype] test-backend-ops -b HTP0 -o MUL_MAT ==="
+  echo "=== [backend-ops:$dtype] test-backend-ops -j 8 -b HTP0 -o MUL_MAT ==="
   timeout 600 env GGML_HEXAGON_NDEV=1 GGML_HEXAGON_HOSTBUF=0 ./bin/test-backend-ops \
-      -b HTP0 -o MUL_MAT -p "$pattern" \
+      -j 8 -b HTP0 -o MUL_MAT -p "$pattern" \
       > "$log" 2>&1
   local rc=$?
   note_timeout_if_triggered "$rc" 600 "$log"

--- a/scripts/snapdragon/qdc/tests/run_backend_ops_posix.py
+++ b/scripts/snapdragon/qdc/tests/run_backend_ops_posix.py
@@ -35,7 +35,7 @@ def test_backend_ops_htp0(type_a):
     result = run_script(
         "run-tool.sh",
         extra_env={"HB": "0"},
-        extra_args=["test-backend-ops", "-b", "HTP0", "-o", "MUL_MAT", "-p", quoted_pattern],
+        extra_args=["test-backend-ops", "-j", "8", "-b", "HTP0", "-o", "MUL_MAT", "-p", quoted_pattern],
     )
     write_qdc_log(f"backend_ops_{type_a}.log", result.stdout or "")
     assert result.returncode == 0, (

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,7 +241,7 @@ if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   llama_build_and_test(test-opt.cpp)
 endif()
 llama_build_and_test(test-gguf.cpp)
-llama_build_and_test(test-backend-ops.cpp)
+llama_build_and_test(test-backend-ops.cpp ARGS -j 8)
 
 llama_build_and_test(test-model-load-cancel.cpp LABEL "model")
 llama_build_and_test(test-autorelease.cpp       LABEL "model")


### PR DESCRIPTION
## Overview

Try enabling `test-backend-ops -j 8` in CI. Let's see what happens.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, written by codex.
