### PR TITLE
Fix Qwen 3.6 MoE (qwen35moe) model compatibility: MRoPE, hybrid GQA, SSM tensor fixes

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1420,7 +1420,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             }
         }
     }
-    ml.done_getting_tensors();
+    ml.done_getting_tensors(arch == LLM_ARCH_QWEN35MOE);
 
     GGML_ASSERT(!(output && tok_embd &&
             strcmp(output->name, tok_embd->name) == 0 &&

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -89,7 +89,8 @@ void llama_model_qwen35moe::load_arch_tensors(llama_model_loader & ml) {
 
         if (!hparams.is_recurrent(il)) {
             // Attention layers
-            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, flags);
+            // Use per-layer GQA because the LLAMA_LOAD_LOCALS macro captures n_embd_k_gqa at il=0 (recurrent layer, 0 KV heads)
+            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, hparams.n_embd_k_gqa(il), hparams.n_embd_v_gqa(il), flags);
             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", il), { n_embd_head_k * n_head, n_embd }, flags);
 
             // Q/K normalization for attention layers
@@ -131,7 +132,7 @@ void llama_model_qwen35moe::load_arch_tensors(llama_model_loader & ml) {
         layer.attn_norm      = create_tensor(tn(LLM_TENSOR_ATTN_NORM,      "weight", il), { n_embd }, 0);
         layer.attn_post_norm = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM, "weight", il), { n_embd }, 0);
 
-        create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, 0);
+        create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, hparams.n_embd_k_gqa(il), hparams.n_embd_v_gqa(il), 0);
         layer.wo          = create_tensor(tn(LLM_TENSOR_ATTN_OUT,    "weight", il), { n_embd_head_k * n_head, n_embd }, 0);
         layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", il), { n_embd_head_k }, 0);
         layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", il), { n_embd_head_k }, 0);

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -6,7 +6,19 @@ void llama_model_qwen35moe::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_shexp, false);
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
 
-    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
+    // Qwen 3.6 MoE uses 3 MRoPE sections (Q/K/V); pad to 4 for compatibility
+    {
+        std::fill(hparams.rope_sections.begin(), hparams.rope_sections.end(), 0);
+        const std::string key = ml.llm_kv(LLM_KV_ROPE_DIMENSION_SECTIONS);
+        const int kid = gguf_find_key(ml.metadata, key.c_str());
+        if (kid >= 0 && gguf_get_kv_type(ml.metadata, kid) == GGUF_TYPE_ARRAY) {
+            const size_t n = gguf_get_arr_n(ml.metadata, kid);
+            const int32_t * data = (const int32_t *) gguf_get_arr_data(ml.metadata, kid);
+            for (size_t i = 0; i < n && i < hparams.rope_sections.size(); i++) {
+                hparams.rope_sections[i] = data[i];
+            }
+        }
+    }
 
     // Load linear attention (gated delta net) parameters
     ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -323,8 +323,9 @@ ggml_tensor * llama_model_qwen35moe::graph::build_layer_attn(
     ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_s);
     cb(Vcur, "Vcur", il);
 
-    // Apply K normalization
-    Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+    // Apply K normalization — use per-layer n_head_kv (hybrid architecture: recurrent layers have 0 KV heads, attention layers have N)
+    const auto n_head_kv_il = hparams.n_head_kv(il);
+    Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv_il, n_tokens);
     Kcur = build_norm(Kcur, model.layers[il].attn_k_norm, nullptr, LLM_NORM_RMS, il);
     cb(Kcur, "Kcur_normed", il);
 
@@ -335,7 +336,7 @@ ggml_tensor * llama_model_qwen35moe::graph::build_layer_attn(
     gate = ggml_cont_2d(ctx0, gate, n_embd_head * n_head, n_tokens);
     cb(gate, "gate_reshaped", il);
 
-    Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
+    Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv_il, n_tokens);
 
     // Apply IMRoPE
     Qcur = ggml_rope_multi(
@@ -642,13 +643,14 @@ llama_model_qwen35moe::graph_mtp::graph_mtp(const llama_model & model, const llm
     gate = ggml_cont_2d(ctx0, gate, n_embd_head * n_head, n_tokens);
     cb(gate, "mtp_gate", il);
 
+    const auto n_head_kv_mtp = hparams.n_head_kv(il);
     ggml_tensor * Kcur = build_lora_mm(layer.wk, cur, layer.wk_s);
-    Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
+    Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv_mtp, n_tokens);
     Kcur = build_norm(Kcur, layer.attn_k_norm, nullptr, LLM_NORM_RMS, il);
     cb(Kcur, "mtp_Kcur_normed", il);
 
     ggml_tensor * Vcur = build_lora_mm(layer.wv, cur, layer.wv_s);
-    Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
+    Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv_mtp, n_tokens);
     cb(Vcur, "mtp_Vcur", il);
 
     Qcur = ggml_rope_multi(ctx0, Qcur, inp_pos, nullptr,

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -101,7 +101,7 @@ void llama_model_qwen35moe::load_arch_tensors(llama_model_loader & ml) {
             layer.wqkv           = create_tensor(tn(LLM_TENSOR_ATTN_QKV,       "weight", il), { n_embd, key_dim * 2 + value_dim }, TENSOR_NOT_REQUIRED);
             layer.wqkv_gate      = create_tensor(tn(LLM_TENSOR_ATTN_GATE,      "weight", il), { n_embd, value_dim }, TENSOR_NOT_REQUIRED);
             layer.ssm_conv1d     = create_tensor(tn(LLM_TENSOR_SSM_CONV1D,     "weight", il), { hparams.ssm_d_conv, conv_dim }, flags);
-            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   il), { hparams.ssm_dt_rank }, flags);
+            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,                   il), { hparams.ssm_dt_rank }, flags);
             layer.ssm_a          = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,             il), { hparams.ssm_dt_rank }, flags);
             layer.ssm_beta       = create_tensor(tn(LLM_TENSOR_SSM_BETA,       "weight", il), { n_embd, n_v_heads }, flags);
             layer.ssm_alpha      = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,      "weight", il), { n_embd, n_v_heads }, flags);


### PR DESCRIPTION
## Summary

This PR fixes 5 issues preventing the Qwen 3.6 MoE (qwen35moe) model from loading and running in llama.cpp. The Qwen 3.6 MoE GGUF format (based on ByteDance Seed-OSS-36B) uses a hybrid recurrent/attention architecture with several differences from the original Qwen3Next model code:

### Changes

**1. MRoPE rope section handling** (`qwen35moe.cpp`)
The GGUF stores `rope.dimension_sections` as a 3-element array `[11, 11, 10]` (Q/K/V sections for Multimodal RoPE) instead of the expected 4. Read the raw GGUF array and pad to 4 elements.

**2. SSM dt tensor naming** (`qwen35moe.cpp`)
The GGUF stores `blk.X.ssm_dt` as a plain tensor, not a bias tensor. Changed `tn(SSM_DT, "bias", il)` to `tn(SSM_DT, il)`.

**3. Per-layer GQA values** (`qwen35moe.cpp`)
The `LLAMA_LOAD_LOCALS` macro computes `n_embd_k_gqa = hparams.n_embd_k_gqa()` which defaults to layer 0 (a recurrent layer with 0 KV heads). Attention layers (every 4th) have `n_head_kv=2`. Fixed both `create_tensor_qkv` call sites to use `hparams.n_embd_k_gqa(il)`.

**4. Per-layer n_head_kv in graph** (`qwen35moe.cpp`)
`llm_graph_context` initializes `n_head_kv = hparams.n_head_kv()` = 0 (layer 0). The `build_layer_attn` and MTP graph functions used this 0 value for `ggml_reshape_3d`, causing an abort. Replaced with `hparams.n_head_kv(il)`.

**5. Partial tensor loading** (`llama-model.cpp`)
The GGUF bundles vision encoder tensors (`v.*` prefix) and MTP head tensors (`mtp.*`) alongside the text decoder. Text-only inference loads ~733 of 1194 tensors. Enabled `partial=true` for this architecture.

### Testing

- Build: passes with CUDA (sm_75) and CPU backends
- Model: loads and runs `qwen3.6:35b-a3b` GGUF (Q4_K_M, 35B MoE)
- Verified with both llama-cli and llama-server
- Performance: ~13-28 t/s generation on RTX 2080 Super + 48GB RAM with expert offloading