### PR TITLE
Add support for HTTP ETags in llama-server

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -323,14 +323,13 @@ bool server_http_context::init(const common_params & params) {
                         res.status = 404;
                         return false;
                     }
+                    res.set_header("ETag", a->etag);
                     // Check If-None-Match for conditional GET (304 Not Modified)
                     if (const std::string & inm = req.get_header_value("If-None-Match");
                         !inm.empty() && inm == a->etag) {
                         res.status = 304;
-                        res.set_header("ETag", a->etag);
                         return false;
                     }
-                    res.set_header("ETag", a->etag);
                     if (with_isolation_headers) {
                         // COEP and COOP headers, required by pyodide (python interpreter)
                         res.set_header("Cross-Origin-Embedder-Policy", "require-corp");

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -317,12 +317,20 @@ bool server_http_context::init(const common_params & params) {
         } else {
 #if defined(LLAMA_UI_HAS_ASSETS)
             auto serve_asset = [](const std::string & name, const char * mime, bool with_isolation_headers) {
-                return [name, mime, with_isolation_headers](const httplib::Request & /*req*/, httplib::Response & res) {
+                return [name, mime, with_isolation_headers](const httplib::Request & req, httplib::Response & res) {
                     const llama_ui_asset * a = llama_ui_find_asset(name.c_str());
                     if (!a) {
                         res.status = 404;
                         return false;
                     }
+                    // Check If-None-Match for conditional GET (304 Not Modified)
+                    if (const std::string & inm = req.get_header_value("If-None-Match");
+                        !inm.empty() && inm == a->etag) {
+                        res.status = 304;
+                        res.set_header("ETag", a->etag);
+                        return false;
+                    }
+                    res.set_header("ETag", a->etag);
                     if (with_isolation_headers) {
                         // COEP and COOP headers, required by pyodide (python interpreter)
                         res.set_header("Cross-Origin-Embedder-Policy", "require-corp");

--- a/tools/ui/CMakeLists.txt
+++ b/tools/ui/CMakeLists.txt
@@ -51,6 +51,7 @@ if(CMAKE_CROSSCOMPILING)
     add_custom_command(
         OUTPUT  "${LLAMA_UI_EMBED_EXE}"
         COMMAND "${HOST_CXX_COMPILER}" -O2 -std=c++17
+                -I"${PROJECT_SOURCE_DIR}/examples/gguf-hash/deps/xxhash"
                 -o "${LLAMA_UI_EMBED_EXE}" "${CMAKE_CURRENT_SOURCE_DIR}/embed.cpp"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/embed.cpp"
         COMMENT "Building llama-ui-embed (host)"
@@ -62,6 +63,7 @@ if(CMAKE_CROSSCOMPILING)
 else()
     add_executable(llama-ui-embed embed.cpp)
     target_compile_features(llama-ui-embed PRIVATE cxx_std_17)
+    target_include_directories(llama-ui-embed PRIVATE ${PROJECT_SOURCE_DIR}/examples/gguf-hash/deps/xxhash)
     set_target_properties(llama-ui-embed PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )

--- a/tools/ui/CMakeLists.txt
+++ b/tools/ui/CMakeLists.txt
@@ -51,7 +51,6 @@ if(CMAKE_CROSSCOMPILING)
     add_custom_command(
         OUTPUT  "${LLAMA_UI_EMBED_EXE}"
         COMMAND "${HOST_CXX_COMPILER}" -O2 -std=c++17
-                -I"${PROJECT_SOURCE_DIR}/examples/gguf-hash/deps/xxhash"
                 -o "${LLAMA_UI_EMBED_EXE}" "${CMAKE_CURRENT_SOURCE_DIR}/embed.cpp"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/embed.cpp"
         COMMENT "Building llama-ui-embed (host)"
@@ -63,7 +62,6 @@ if(CMAKE_CROSSCOMPILING)
 else()
     add_executable(llama-ui-embed embed.cpp)
     target_compile_features(llama-ui-embed PRIVATE cxx_std_17)
-    target_include_directories(llama-ui-embed PRIVATE ${PROJECT_SOURCE_DIR}/examples/gguf-hash/deps/xxhash)
     set_target_properties(llama-ui-embed PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )

--- a/tools/ui/embed.cpp
+++ b/tools/ui/embed.cpp
@@ -10,6 +10,10 @@
 #include <string>
 #include <vector>
 
+// Header-only mode: XXH_INLINE_ALL makes all functions inline
+#define XXH_INLINE_ALL
+#include "xxhash.h"
+
 static bool read_file(const std::string & path, std::vector<unsigned char> & out) {
     std::ifstream f(path, std::ios::binary | std::ios::ate);
     if (!f) {
@@ -95,6 +99,7 @@ int main(int argc, char ** argv) {
         "    const char *          name;\n"
         "    const unsigned char * data;\n"
         "    size_t                size;\n"
+        "    const char *          etag;\n"
         "};\n\n"
         "const llama_ui_asset * llama_ui_find_asset(const char * name);\n";
 
@@ -104,20 +109,25 @@ int main(int argc, char ** argv) {
     if (n_assets > 0) {
         for (int i = 0; i < n_assets; i++) {
             const char * path = argv[3 + i * 2 + 1];
+
             std::vector<unsigned char> bytes;
             if (!read_file(path, bytes)) {
                 return 1;
             }
+            const auto hash = XXH64(bytes.data(), bytes.size(), 0);
+
             cpp += fmt("static const unsigned char asset_%d_data[] = {", i);
             append_bytes_hex(cpp, bytes);
-            cpp += fmt("};\nstatic const size_t        asset_%d_size = %lu;\n\n",
+            cpp += fmt("};\nstatic const size_t        asset_%d_size = %lu;\n",
                        i, static_cast<unsigned long>(bytes.size()));
+            cpp += fmt("static const char        asset_%d_etag[] = \"\\\"0x%016lx\\\"\";\n\n",
+                       i, static_cast<unsigned long>(hash));
         }
 
         cpp += "static const llama_ui_asset g_assets[] = {\n";
         for (int i = 0; i < n_assets; i++) {
-            const char * name = argv[3 + i * 2];
-            cpp += fmt("    { \"%s\", asset_%d_data, asset_%d_size },\n", name, i, i);
+            cpp += fmt("    { \"%s\", asset_%d_data, asset_%d_size, asset_%d_etag },\n",
+                       argv[3 + i * 2], i, i, i);
         }
         cpp += "};\n\n";
 

--- a/tools/ui/embed.cpp
+++ b/tools/ui/embed.cpp
@@ -9,10 +9,19 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
-// Header-only mode: XXH_INLINE_ALL makes all functions inline
-#define XXH_INLINE_ALL
-#include "xxhash.h"
+// Computes FNV-1a hash of the data
+static uint64_t fnv_hash(const uint8_t * data, size_t len) {
+    const uint64_t fnv_prime = 0x100000001b3ULL;
+    uint64_t hash = 0xcbf29ce484222325ULL;
+
+    for (size_t i = 0; i < len; ++i) {
+        hash ^= data[i];
+        hash *= fnv_prime;
+    }
+    return hash;
+}
 
 static bool read_file(const std::string & path, std::vector<unsigned char> & out) {
     std::ifstream f(path, std::ios::binary | std::ios::ate);
@@ -109,15 +118,14 @@ int main(int argc, char ** argv) {
     if (n_assets > 0) {
         for (int i = 0; i < n_assets; i++) {
             const char * path = argv[3 + i * 2 + 1];
-
             std::vector<unsigned char> bytes;
             if (!read_file(path, bytes)) {
                 return 1;
             }
-            const auto hash = XXH64(bytes.data(), bytes.size(), 0);
-
             cpp += fmt("static const unsigned char asset_%d_data[] = {", i);
             append_bytes_hex(cpp, bytes);
+            const auto hash = fnv_hash(bytes.data(), bytes.size());
+
             cpp += fmt("};\nstatic const size_t        asset_%d_size = %lu;\n",
                        i, static_cast<unsigned long>(bytes.size()));
             cpp += fmt("static const char        asset_%d_etag[] = \"\\\"0x%016lx\\\"\";\n\n",


### PR DESCRIPTION
## Overview

The user interface of llama-server is served as embedded static files. For those files the httplib does not generate ETags used for browser caching. This change computes a hash for each statically embedded file to allow caching.

The javascript bundles has a size of around 5MB and it can take a considerable amount of time in low bandwidth environments to download this file each time one opens the llama-server webinterface. Using caching those files have to be downloaded only once.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: yes: I have used an AI coding to understand llama-server and made it generate the required changes. I reworked the changes with AI to be minimal intrusive to avoid AI slop / bloat.
