### PR TITLE
model-loader: Split mmap buffers to avoid mapping unneeded data to the GPU

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1363,21 +1363,51 @@ void llama_model_loader::init_mappings(bool prefetch, llama_mlocks * mlock_mmaps
     }
 }
 
-void llama_model_loader::get_mapping_range(size_t * first, size_t * last, void ** addr, int idx, ggml_context * ctx) const {
+std::vector<llama_mapping_range> llama_model_loader::get_mapping_ranges(void ** addr, int idx, ggml_context * ctx) const {
     GGML_ASSERT(!mappings.empty());
     const auto & mapping = mappings.at(idx);
+    std::vector<llama_mapping_range> ranges;
+    std::vector<llama_mapping_range> weight_ranges;
+    // Coalesce nearby ranges if they're closer than this
+    static const size_t coalesce_size = 1024 * 1024;
+    // In case backends prefer their ranges page-aligned
+    // (Might waste a bit on systems with smaller page sizes, but a few kB isn't going to hurt anyone)
+    static const size_t page_mask = 65535;
 
-    *first = mapping->size();
-    *last  = 0;
     *addr = mapping->addr();
     for (ggml_tensor * tensor = ggml_get_first_tensor(ctx); tensor; tensor = ggml_get_next_tensor(ctx, tensor)) {
         const auto * weight = get_weight(ggml_get_name(tensor));
         if (!weight || weight->idx != idx) {
             continue;
         }
-        *first = std::min(*first, weight->offs);
-        *last  = std::max(*last,  weight->offs + ggml_nbytes(tensor));
+        weight_ranges.push_back({ weight->offs, weight->offs + ggml_nbytes(tensor) });
     }
+
+    if (weight_ranges.empty()) {
+        return ranges;
+    }
+
+    // Coalesce ranges by iterating in memory order and merging each with the previous if it can
+    std::sort(weight_ranges.begin(), weight_ranges.end(), [](llama_mapping_range& a, llama_mapping_range& b){ return a.first < b.first; });
+    auto weight     = weight_ranges.begin();
+    auto weight_end = weight_ranges.end();
+    llama_mapping_range range = *weight;
+
+    for (++weight; weight < weight_end; ++weight) {
+        if (range.last + coalesce_size >= weight->first) {
+            range.last = weight->last;
+        } else {
+            size_t first = range.first & ~page_mask;
+            size_t last  = (range.last + page_mask) & ~page_mask;
+            ranges.push_back({ first, last });
+            range = *weight;
+        }
+    }
+
+    size_t first = range.first & ~page_mask;
+    size_t last  = (range.last + page_mask) & ~page_mask;
+    ranges.push_back({ first, std::min(last, mapping->size()) });
+    return ranges;
 }
 
 void llama_model_loader::load_data_for(struct ggml_tensor * cur) const {
@@ -1443,7 +1473,7 @@ bool llama_model_loader::load_all_data(
         }
         // When not using mmaped io use async uploads from pinned memory to GPU memory.
         // First determine if the backend supports the necessary features for async uploads.
-        auto * buf = bufs.count(0) ? bufs.at(0) : nullptr;
+        auto * buf = bufs.count(0) ? bufs.at(0).at(0).buffer : nullptr;
         if (!buf) {
             LLAMA_LOG_DEBUG("%s: no buffer found for async uploads\n", func);
             return nullptr;
@@ -1514,7 +1544,7 @@ bool llama_model_loader::load_all_data(
     if (upload_backend) {
         LLAMA_LOG_DEBUG("%s: using async uploads for device %s, buffer type %s, backend %s\n", __func__,
             ggml_backend_dev_name(ggml_backend_get_device(upload_backend)),
-            ggml_backend_buft_name(ggml_backend_buffer_get_type(bufs.at(0))),
+            ggml_backend_buft_name(ggml_backend_buffer_get_type(bufs.at(0).at(0).buffer)),
             ggml_backend_name(upload_backend));
     }
 
@@ -1537,7 +1567,12 @@ bool llama_model_loader::load_all_data(
             const auto & mapping = mappings.at(weight->idx);
             ggml_backend_buffer_t buf_mmap = nullptr;
             if (bufs.count(weight->idx)) {
-                buf_mmap = bufs.at(weight->idx);
+                const auto & ctx_bufs = bufs.at(weight->idx);
+                auto it = std::lower_bound(ctx_bufs.begin(), ctx_bufs.end(), weight->offs + n_size,
+                                           [](const llama_buf_map_entry & a, size_t b) { return a.range.last < b; });
+                if (it < ctx_bufs.end() && it->range.first <= weight->offs && it->range.last >= weight->offs + n_size) {
+                    buf_mmap = it->buffer;
+                }
             }
             uint8_t * data = (uint8_t *) mapping->addr() + weight->offs;
 

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -14,8 +14,17 @@
 #include <map>
 #include <stdexcept>
 #include <unordered_map>
+#include <vector>
 
-using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
+struct llama_mapping_range {
+    size_t first;
+    size_t last;
+};
+struct llama_buf_map_entry {
+    llama_mapping_range   range;
+    ggml_backend_buffer_t buffer;
+};
+using llama_buf_map = std::unordered_map<uint32_t, std::vector<llama_buf_map_entry>>;
 
 // lists of buffer types used for each layer
 using buft_list_t = std::vector<std::pair<ggml_backend_dev_t, ggml_backend_buffer_type_t>>;
@@ -188,7 +197,7 @@ struct llama_model_loader {
 
     void init_mappings(bool prefetch = true, llama_mlocks * mlock_mmaps = nullptr);
 
-    void get_mapping_range(size_t * first, size_t * last, void ** addr, int idx, ggml_context * ctx) const;
+    std::vector<llama_mapping_range> get_mapping_ranges(void ** addr, int idx, ggml_context * ctx) const;
 
     // for backwards compatibility, does not support ggml-backend
     void load_data_for(struct ggml_tensor * cur) const;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1470,23 +1470,28 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         if (ml.use_mmap && use_mmap_buffer && buffer_from_host_ptr_supported && is_default_buft) {
             GGML_ASSERT(!ml.no_alloc);
             for (uint32_t idx = 0; idx < ml.files.size(); idx++) {
-                // only the mmap region containing the tensors in the model is mapped to the backend buffer
+                // only the mmap regions containing the tensors in the model are mapped to the backend buffer
                 // this is important for metal with apple silicon: if the entire model could be mapped to a metal buffer,
                 //     then we could just use metal for all layers
                 // this allows using partial offloading when the model size exceeds the metal buffer size, but not the RAM size
                 void * addr = nullptr;
-                size_t first, last; // NOLINT
-                ml.get_mapping_range(&first, &last, &addr, idx, ctx);
-                if (first >= last) {
+                const size_t max_size = ggml_get_max_tensor_size(ctx);
+                std::vector<llama_mapping_range> ranges = ml.get_mapping_ranges(&addr, idx, ctx);
+                if (ranges.empty()) {
                     continue;
                 }
-                const size_t max_size = ggml_get_max_tensor_size(ctx);
-                ggml_backend_buffer_t buf = ggml_backend_dev_buffer_from_host_ptr(dev, (char *) addr + first, last - first, max_size);
-                if (buf == nullptr) {
-                    throw std::runtime_error(format("unable to allocate %s buffer", ggml_backend_buft_name(buft)));
+                std::vector<llama_buf_map_entry> & map = buf_map[idx];
+                map.reserve(ranges.size());
+                for (llama_mapping_range range : ranges) {
+                    size_t first = range.first;
+                    size_t size  = range.last - range.first;
+                    ggml_backend_buffer_t buf = ggml_backend_dev_buffer_from_host_ptr(dev, (char *) addr + first, size, max_size);
+                    if (buf == nullptr) {
+                        throw std::runtime_error(format("unable to allocate %s buffer", ggml_backend_buft_name(buft)));
+                    }
+                    bufs.emplace_back(buf);
+                    map.push_back({ range, buf });
                 }
-                bufs.emplace_back(buf);
-                buf_map.emplace(idx, buf);
             }
         } else {
             ggml_backend_buffer_t buf;
@@ -1509,7 +1514,8 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             }
             bufs.emplace_back(buf);
             for (uint32_t idx = 0; idx < ml.files.size(); idx++) {
-                buf_map.emplace(idx, buf);
+                llama_mapping_range range = { 0, SIZE_MAX };
+                buf_map[idx].assign({{ range, buf }});
             }
         }
 


### PR DESCRIPTION
## Overview

Applies the optimization mentioned in the comment at `src/llama-model.cpp:1473` to cmoe as well as partial offloading (previously it would map from the lowest address needed to the highest address needed, which with cmoe ends up being the entire model).  This means that with partially-offloaded non-contiguous weights, files are mapped as one mapping per contiguous set of weights, rather than one large mapping for the whole file.

Also allows models larger than system ram to be used with Apple GPUs (effectively streaming weights from the SSD).  Not currently faster than doing it with the CPU (with `--no-repack`), but working on that...

Running 61GB Qwen3-Coder-Next Q6_K on a 48GB M4 Pro:
|Mode|pp512|tg128|
|-|-|-|
|CPU (--no-repack)|61±11|27±3|
|GPU (-cmoe, before)|OOM|OOM|
|GPU (-cmoe, this PR)|53±8|16±1|
|GPU (-cmoe, this PR + fixes coming soon)|110±21|16±1|

Token generation speed seems to decay slower as contexts get larger compared to the CPU as well.  Plus power usage is lower, since the GPU spends half its time waiting for weights to load (while the CPU had all 10 P cores running most of the time).

## Additional information

Performance of the new split mapping with cmoe (on models that could run before without OOM) was observed to be unaffected on Metal, but should probably be verified on some other APIs to make sure it's not worse there.  (Running with all layers offloaded should result in the same memory mappings as before, so it's mainly cmoe / other partial offloads that should be tested.)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

