### PR TITLE
server: expose n_prompt_tokens_target in /slots endpoint

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -510,6 +510,7 @@ struct server_slot {
             res["n_prompt_tokens"]           = (int32_t) prompt.tokens.size();
             res["n_prompt_tokens_processed"] = n_prompt_tokens_processed;
             res["n_prompt_tokens_cache"]     = n_prompt_tokens_cache;
+            res["n_prompt_tokens_target"]    = ptask->n_tokens();
             res["params"] = ptask->params.to_json(only_metrics);
             res["next_token"] = {
                 {


### PR DESCRIPTION
## Overview

The GET /slots endpoint currently exposes `n_prompt_tokens_processed` but not the **final** token count of the task's prompt.  I needed this to monitor the progress of long-prompt processing in my own tooling and noticed the field wasn't available. This PR adds `n_prompt_tokens_target` to the slot JSON so clients can compute:

 ```
 progress = n_prompt_tokens_processed / n_prompt_tokens_target
 ```
 
This aligns with the terminal's own progress reporting in `print_timings_pp(),` e.g.:

 ```
slot print_timing: id  0 | task 3854 | prompt processing, n_tokens =  32768, progress = 0.25, t =  2.00 s / 16384.00 tokens per second
 ```
I chose the name `n_prompt_tokens_target` over `n_prompt_token_total` to avoid ambiguity.
 
 
<details>
<summary>Example /slots response</summary>

```json
   {
     "id": 1,
     "n_ctx": 165376,
     "speculative": true,
     "is_processing": true,
     "id_task": 42,
     "n_prompt_tokens": 3072,
     "n_prompt_tokens_processed": 3072,
     "n_prompt_tokens_cache": 0,
     "n_prompt_tokens_target": 34228,
     "params": { /* ... */ },
     "next_token": [ /* ... */ ]
   }
```
Progress: 3072 / 34228 = 0.09 (9%)
</details>
 
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, Reviewed with Pi (qwen3.6-27b)

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
