### PR TITLE
server: tests: consolidate with pytest conventions

### DIFF
--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -109,4 +109,4 @@ jobs:
         run: |
           cd tools/server/tests
           export ${{ matrix.extra_args }}
-          SLOW_TESTS=1 pytest -v -x
+          pytest -v -x

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           cd tools/server/tests
           export ${{ matrix.extra_args }}
-          SLOW_TESTS=1 pytest -v -x
+          pytest -v -x
 
   server-windows:
     runs-on: windows-2022
@@ -177,5 +177,4 @@ jobs:
         if: ${{ (github.event.schedule || github.event.inputs.slow_tests == 'true') && matrix.build_type == 'Release' }}
         run: |
           cd tools/server/tests
-          $env:SLOW_TESTS = "1"
           pytest -v -x

--- a/tools/server/tests/README.md
+++ b/tools/server/tests/README.md
@@ -28,10 +28,10 @@ It's possible to override some scenario steps values with environment variables:
 | variable                 | description                                                                                    |
 |--------------------------|------------------------------------------------------------------------------------------------|
 | `PORT`                   | `context.server_port` to set the listening port of the server during scenario, default: `8080` |
-| `LLAMA_SERVER_BIN_PATH`  | to change the server binary path, default: `../../../build/bin/llama-server`                         |
+| `LLAMA_SERVER_BIN_PATH`  | to change the server binary path, default: `<repo_root>/build/bin/llama-server`                         |
 | `DEBUG`                  | to enable steps and server verbose mode `--verbose`                                       |
 | `N_GPU_LAYERS`           | number of model layers to offload to VRAM `-ngl --n-gpu-layers`                                |
-| `LLAMA_CACHE`            | by default server tests re-download models to the `tmp` subfolder. Set this to your cache (e.g. `$HOME/Library/Caches/llama.cpp` on Mac or `$HOME/.cache/llama.cpp` on Unix) to avoid this |
+| `LLAMA_CACHE`            | by default server tests re-download models to the `<repo_root>/tools/server/tests/tmp` subfolder. Set this to your cache (e.g. `$HOME/Library/Caches/llama.cpp` on Mac or `$HOME/.cache/llama.cpp` on Unix) to avoid this |
 
 To run slow tests (will download many models, make sure to set `LLAMA_CACHE` if needed):
 

--- a/tools/server/tests/conftest.py
+++ b/tools/server/tests/conftest.py
@@ -19,3 +19,14 @@ def stop_server_after_each_test():
 def do_something():
     # this will be run once per test session, before any tests
     ServerPreset.load_all()
+
+
+@pytest.fixture
+def server_factory():
+    """Factory: returns a fresh, configured (but not started) ServerProcess."""
+    def _build(preset="tinyllama2", **overrides):
+        s = getattr(ServerPreset, preset)()
+        for k, v in overrides.items():
+            setattr(s, k, v)
+        return s
+    return _build

--- a/tools/server/tests/conftest.py
+++ b/tools/server/tests/conftest.py
@@ -15,15 +15,12 @@ def stop_server_after_each_test():
         server.stop()
 
 
-@pytest.fixture(scope="module", autouse=True)
-def do_something():
-    # this will be run once per test session, before any tests
-    ServerPreset.load_all()
-
-
-@pytest.fixture
+@pytest.fixture(scope="session")
 def server_factory():
     """Factory: returns a fresh, configured (but not started) ServerProcess."""
+    # Pre-caches all preset models once per test session, before any tests using the fixture
+    ServerPreset.load_all()
+
     def _build(preset="tinyllama2", **overrides):
         s = getattr(ServerPreset, preset)()
         for k, v in overrides.items():

--- a/tools/server/tests/unit/test_basic.py
+++ b/tools/server/tests/unit/test_basic.py
@@ -2,24 +2,19 @@ import pytest
 import requests
 from utils import *
 
-server = ServerPreset.tinyllama2()
+
+@pytest.fixture
+def server(server_factory):
+    return server_factory("tinyllama2")
 
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-
-
-def test_server_start_simple():
-    global server
+def test_server_start_simple(server):
     server.start()
     res = server.make_request("GET", "/health")
     assert res.status_code == 200
 
 
-def test_server_props():
-    global server
+def test_server_props(server):
     server.start()
     res = server.make_request("GET", "/props")
     assert res.status_code == 200
@@ -31,8 +26,7 @@ def test_server_props():
     assert default_val["params"]["seed"] == server.seed
 
 
-def test_server_models():
-    global server
+def test_server_models(server):
     server.start()
     res = server.make_request("GET", "/models")
     assert res.status_code == 200
@@ -40,9 +34,7 @@ def test_server_models():
     assert res.body["data"][0]["id"] == server.model_alias
 
 
-def test_server_slots():
-    global server
-
+def test_server_slots(server):
     # without slots endpoint enabled, this should return error
     server.server_slots = False
     server.start()
@@ -63,8 +55,7 @@ def test_server_slots():
     assert "params" not in res.body[0]
 
 
-def test_load_split_model():
-    global server
+def test_load_split_model(server):
     server.offline = False
     server.model_hf_repo = "ggml-org/models"
     server.model_hf_file = "tinyllamas/split/stories15M-q8_0-00001-of-00003.gguf"
@@ -79,8 +70,7 @@ def test_load_split_model():
     assert match_regex("(little|girl)+", res.body["content"])
 
 
-def test_no_webui():
-    global server
+def test_no_webui(server):
     # default: webui enabled
     server.start()
     url = f"http://{server.server_host}:{server.server_port}"
@@ -96,8 +86,7 @@ def test_no_webui():
     assert res.status_code == 404
 
 
-def test_server_model_aliases_and_tags():
-    global server
+def test_server_model_aliases_and_tags(server):
     server.model_alias = "tinyllama-2,fim,code"
     server.model_tags = "chat,fim,small"
     server.start()

--- a/tools/server/tests/unit/test_chat_completion.py
+++ b/tools/server/tests/unit/test_chat_completion.py
@@ -163,7 +163,7 @@ def test_chat_template():
 def test_chat_template_assistant_prefill(prefill, re_prefill):
     global server
     server.jinja = True
-    server.chat_template_file = "../../../models/templates/meta-llama-Llama-3.1-8B-Instruct.jinja"
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/meta-llama-Llama-3.1-8B-Instruct.jinja'
     server.debug = True  # to get the "__verbose" object in the response
     server.start()
     res = server.make_request("POST", "/chat/completions", data={
@@ -184,7 +184,7 @@ def test_chat_template_continue_final_message_vllm_compat():
     Both must produce the same prompt."""
     global server
     server.jinja = True
-    server.chat_template_file = "../../../models/templates/meta-llama-Llama-3.1-8B-Instruct.jinja"
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/meta-llama-Llama-3.1-8B-Instruct.jinja'
     server.debug = True
     server.start()
     res = server.make_request("POST", "/chat/completions", data={

--- a/tools/server/tests/unit/test_chat_completion.py
+++ b/tools/server/tests/unit/test_chat_completion.py
@@ -2,14 +2,10 @@ import pytest
 from openai import OpenAI
 from utils import *
 
-server: ServerProcess
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-
-
+@pytest.fixture
+def server(server_factory):
+    return server_factory('tinyllama2')
 @pytest.mark.parametrize(
     "model,system_prompt,user_prompt,max_tokens,re_content,n_prompt,n_predicted,finish_reason,jinja,chat_template",
     [
@@ -25,8 +21,7 @@ def create_server():
         (None, "Book", [{"type": "text", "text": "What is"}, {"type": "text", "text": "the best book"}], 8, "Whillicter", 79, 8, "length", True, None),
     ]
 )
-def test_chat_completion(model, system_prompt, user_prompt, max_tokens, re_content, n_prompt, n_predicted, finish_reason, jinja, chat_template):
-    global server
+def test_chat_completion(server, model, system_prompt, user_prompt, max_tokens, re_content, n_prompt, n_predicted, finish_reason, jinja, chat_template):
     server.jinja = jinja
     server.chat_template = chat_template
     server.start()
@@ -51,8 +46,7 @@ def test_chat_completion(model, system_prompt, user_prompt, max_tokens, re_conte
     assert choice["finish_reason"] == finish_reason
 
 
-def test_chat_completion_cached_tokens():
-    global server
+def test_chat_completion_cached_tokens(server):
     server.n_slots = 1
     server.start()
     seq = [
@@ -79,8 +73,7 @@ def test_chat_completion_cached_tokens():
         ("You are a coding assistant.", "Write the fibonacci function in c++.", 128, "(Aside|she|felter|alonger)+", 104, 128, "length"),
     ]
 )
-def test_chat_completion_stream(system_prompt, user_prompt, max_tokens, re_content, n_prompt, n_predicted, finish_reason):
-    global server
+def test_chat_completion_stream(server, system_prompt, user_prompt, max_tokens, re_content, n_prompt, n_predicted, finish_reason):
     server.model_alias = "llama-test-model"
     server.start()
     res = server.make_stream_request("POST", "/chat/completions", data={
@@ -119,8 +112,7 @@ def test_chat_completion_stream(system_prompt, user_prompt, max_tokens, re_conte
             assert data["usage"]["completion_tokens"] == n_predicted
 
 
-def test_chat_completion_with_openai_library():
-    global server
+def test_chat_completion_with_openai_library(server):
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
     res = client.chat.completions.create(
@@ -139,8 +131,7 @@ def test_chat_completion_with_openai_library():
     assert match_regex("(Suddenly)+", res.choices[0].message.content)
 
 
-def test_chat_template():
-    global server
+def test_chat_template(server):
     server.chat_template = "llama3"
     server.debug = True  # to get the "__verbose" object in the response
     server.start()
@@ -160,8 +151,7 @@ def test_chat_template():
     ("Whill", "Whill"),
     ([{"type": "text", "text": "Wh"}, {"type": "text", "text": "ill"}], "Wh\n\nill"),
 ])
-def test_chat_template_assistant_prefill(prefill, re_prefill):
-    global server
+def test_chat_template_assistant_prefill(server, prefill, re_prefill):
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/meta-llama-Llama-3.1-8B-Instruct.jinja'
     server.debug = True  # to get the "__verbose" object in the response
@@ -179,10 +169,9 @@ def test_chat_template_assistant_prefill(prefill, re_prefill):
     assert res.body["__verbose"]["prompt"].endswith(f"<|start_header_id|>user<|end_header_id|>\n\nWhat is the best book<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n{re_prefill}")
 
 
-def test_chat_template_continue_final_message_vllm_compat():
+def test_chat_template_continue_final_message_vllm_compat(server):
     """continue_final_message is the vLLM/transformers explicit alias for the prefill_assistant heuristic.
     Both must produce the same prompt."""
-    global server
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/meta-llama-Llama-3.1-8B-Instruct.jinja'
     server.debug = True
@@ -202,9 +191,8 @@ def test_chat_template_continue_final_message_vllm_compat():
     assert res.body["__verbose"]["prompt"].endswith("<|start_header_id|>user<|end_header_id|>\n\nWhat is the best book<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nWhill")
 
 
-def test_chat_template_continue_final_message_mutual_exclusion():
+def test_chat_template_continue_final_message_mutual_exclusion(server):
     """add_generation_prompt and continue_final_message both set to true must be rejected"""
-    global server
     server.chat_template = "llama3"
     server.start()
     res = server.make_request("POST", "/chat/completions", data={
@@ -219,8 +207,7 @@ def test_chat_template_continue_final_message_mutual_exclusion():
     assert res.status_code == 400
 
 
-def test_apply_chat_template():
-    global server
+def test_apply_chat_template(server):
     server.chat_template = "command-r"
     server.start()
     res = server.make_request("POST", "/apply-template", data={
@@ -245,8 +232,7 @@ def test_apply_chat_template():
     ({"type": "json_object", "schema": {"type": 123}}, 0, None),
     ({"type": "json_object", "schema": {"type": "hiccup"}}, 0, None),
 ])
-def test_completion_with_response_format(response_format: dict, n_predicted: int, re_content: str | None):
-    global server
+def test_completion_with_response_format(server, response_format: dict, n_predicted: int, re_content: str | None):
     server.start()
     res = server.make_request("POST", "/chat/completions", data={
         "max_tokens": n_predicted,
@@ -269,8 +255,7 @@ def test_completion_with_response_format(response_format: dict, n_predicted: int
     (False, {"const": "42"}, 6, "\"42\""),
     (True, {"const": "42"}, 6, "\"42\""),
 ])
-def test_completion_with_json_schema(jinja: bool, json_schema: dict, n_predicted: int, re_content: str):
-    global server
+def test_completion_with_json_schema(server, jinja: bool, json_schema: dict, n_predicted: int, re_content: str):
     server.jinja = jinja
     server.debug = True
     server.start()
@@ -291,8 +276,7 @@ def test_completion_with_json_schema(jinja: bool, json_schema: dict, n_predicted
     (False, 'root ::= "a"{5,5}', 6, "a{5,5}"),
     (True, 'root ::= "a"{5,5}', 6, "a{5,5}"),
 ])
-def test_completion_with_grammar(jinja: bool, grammar: str, n_predicted: int, re_content: str):
-    global server
+def test_completion_with_grammar(server, jinja: bool, grammar: str, n_predicted: int, re_content: str):
     server.jinja = jinja
     server.start()
     res = server.make_request("POST", "/chat/completions", data={
@@ -318,8 +302,7 @@ def test_completion_with_grammar(jinja: bool, grammar: str, n_predicted: int, re
     [{"role": "system", "content": "test"}, {}],
     [{"role": "user", "content": "test"}, {"role": "assistant", "content": "test"}, {"role": "assistant", "content": "test"}],
 ])
-def test_invalid_chat_completion_req(messages):
-    global server
+def test_invalid_chat_completion_req(server, messages):
     server.start()
     res = server.make_request("POST", "/chat/completions", data={
         "messages": messages,
@@ -328,8 +311,7 @@ def test_invalid_chat_completion_req(messages):
     assert "error" in res.body
 
 
-def test_chat_completion_with_timings_per_token():
-    global server
+def test_chat_completion_with_timings_per_token(server):
     server.start()
     res = server.make_stream_request("POST", "/chat/completions", data={
         "max_tokens": 10,
@@ -358,8 +340,7 @@ def test_chat_completion_with_timings_per_token():
     assert stats_received
 
 
-def test_logprobs():
-    global server
+def test_logprobs(server):
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
     res = client.chat.completions.create(
@@ -385,8 +366,7 @@ def test_logprobs():
     assert aggregated_text == output_text
 
 
-def test_logprobs_stream():
-    global server
+def test_logprobs_stream(server):
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
     res = client.chat.completions.create(
@@ -426,8 +406,7 @@ def test_logprobs_stream():
     assert aggregated_text == output_text
 
 
-def test_logit_bias():
-    global server
+def test_logit_bias(server):
     server.start()
 
     exclude = ["i", "I", "the", "The", "to", "a", "an", "be", "is", "was", "but", "But", "and", "And", "so", "So", "you", "You", "he", "He", "she", "She", "we", "We", "they", "They", "it", "It", "his", "His", "her", "Her", "book", "Book"]
@@ -454,8 +433,7 @@ def test_logit_bias():
     assert output_text
     assert all(output_text.find(" " + tok + " ") == -1 for tok in exclude)
 
-def test_context_size_exceeded():
-    global server
+def test_context_size_exceeded(server):
     server.start()
     res = server.make_request("POST", "/chat/completions", data={
         "messages": [
@@ -472,8 +450,7 @@ def test_context_size_exceeded():
     assert res.body["error"]["n_ctx"] == server.n_ctx // server.n_slots
 
 
-def test_context_size_exceeded_stream():
-    global server
+def test_context_size_exceeded_stream(server):
     server.start()
     try:
         for _ in server.make_stream_request("POST", "/chat/completions", data={
@@ -501,8 +478,7 @@ def test_context_size_exceeded_stream():
         (64, 2, True),
     ]
 )
-def test_return_progress(n_batch, batch_count, reuse_cache):
-    global server
+def test_return_progress(server, n_batch, batch_count, reuse_cache):
     server.n_batch = n_batch
     server.n_ctx = 256
     server.n_slots = 1
@@ -551,8 +527,7 @@ def test_return_progress(n_batch, batch_count, reuse_cache):
     assert total_batch_count == batch_count
 
 
-def test_chat_completions_multiple_choices():
-    global server
+def test_chat_completions_multiple_choices(server):
     server.start()
     # make sure cache can be reused across multiple choices and multiple requests
     # ref: https://github.com/ggml-org/llama.cpp/pull/18663

--- a/tools/server/tests/unit/test_compat_anthropic.py
+++ b/tools/server/tests/unit/test_compat_anthropic.py
@@ -5,9 +5,6 @@ import requests
 
 from utils import *
 
-server: ServerProcess
-
-
 def get_test_image_base64() -> str:
     """Get a test image in base64 format"""
     # Use the same test image as test_vision_api.py
@@ -15,22 +12,20 @@ def get_test_image_base64() -> str:
     response = requests.get(IMG_URL)
     response.raise_for_status()
     return base64.b64encode(response.content).decode("utf-8")
-
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.model_alias = "tinyllama-2-anthropic"
-    server.server_port = 8082
-    server.n_slots = 1
-    server.n_ctx = 8192
-    server.n_batch = 2048
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.model_alias = "tinyllama-2-anthropic"
+    s.server_port = 8082
+    s.n_slots = 1
+    s.n_ctx = 8192
+    s.n_batch = 2048
+    return s
 
 
 @pytest.fixture
 def vision_server():
     """Separate fixture for vision tests that require multimodal support"""
-    global server
     server = ServerPreset.tinygemma3()
     server.offline = False  # Allow downloading the model
     server.model_alias = "tinygemma3-anthropic"
@@ -41,7 +36,7 @@ def vision_server():
 
 # Basic message tests
 
-def test_anthropic_messages_basic():
+def test_anthropic_messages_basic(server):
     """Test basic Anthropic messages endpoint"""
     server.start()
 
@@ -74,7 +69,7 @@ def test_anthropic_messages_basic():
     assert "timings" not in res.body, "Anthropic API should not include timings field"
 
 
-def test_anthropic_messages_with_system():
+def test_anthropic_messages_with_system(server):
     """Test messages with system prompt"""
     server.start()
 
@@ -92,7 +87,7 @@ def test_anthropic_messages_with_system():
     assert len(res.body["content"]) > 0
 
 
-def test_anthropic_messages_multipart_content():
+def test_anthropic_messages_multipart_content(server):
     """Test messages with multipart content blocks"""
     server.start()
 
@@ -114,7 +109,7 @@ def test_anthropic_messages_multipart_content():
     assert res.body["type"] == "message"
 
 
-def test_anthropic_messages_conversation():
+def test_anthropic_messages_conversation(server):
     """Test multi-turn conversation"""
     server.start()
 
@@ -134,7 +129,7 @@ def test_anthropic_messages_conversation():
 
 # Streaming tests
 
-def test_anthropic_messages_streaming():
+def test_anthropic_messages_streaming(server):
     """Test streaming messages"""
     server.start()
 
@@ -208,7 +203,7 @@ def test_anthropic_messages_streaming():
 
 # Token counting tests
 
-def test_anthropic_count_tokens():
+def test_anthropic_count_tokens(server):
     """Test token counting endpoint"""
     server.start()
 
@@ -227,7 +222,7 @@ def test_anthropic_count_tokens():
     assert "output_tokens" not in res.body
 
 
-def test_anthropic_count_tokens_with_system():
+def test_anthropic_count_tokens_with_system(server):
     """Test token counting with system prompt"""
     server.start()
 
@@ -243,7 +238,7 @@ def test_anthropic_count_tokens_with_system():
     assert res.body["input_tokens"] > 0
 
 
-def test_anthropic_count_tokens_no_max_tokens():
+def test_anthropic_count_tokens_no_max_tokens(server):
     """Test that count_tokens doesn't require max_tokens"""
     server.start()
 
@@ -261,7 +256,7 @@ def test_anthropic_count_tokens_no_max_tokens():
 
 # Tool use tests
 
-def test_anthropic_tool_use_basic():
+def test_anthropic_tool_use_basic(server):
     """Test basic tool use"""
     server.jinja = True
     server.start()
@@ -308,7 +303,7 @@ def test_anthropic_tool_use_basic():
         assert isinstance(tool_block["input"], dict)
 
 
-def test_anthropic_tool_result():
+def test_anthropic_tool_result(server):
     """Test sending tool results back
 
     This test verifies that tool_result blocks are properly converted to
@@ -356,7 +351,7 @@ def test_anthropic_tool_result():
     assert res.body["content"][0]["type"] == "text"
 
 
-def test_anthropic_tool_result_with_text():
+def test_anthropic_tool_result_with_text(server):
     """Test tool result mixed with text content
 
     This tests the edge case where a user message contains both text and
@@ -402,7 +397,7 @@ def test_anthropic_tool_result_with_text():
     assert len(res.body["content"]) > 0
 
 
-def test_anthropic_tool_result_error():
+def test_anthropic_tool_result_error(server):
     """Test tool result with error flag"""
     server.jinja = True
     server.start()
@@ -441,7 +436,7 @@ def test_anthropic_tool_result_error():
     assert res.body["type"] == "message"
 
 
-def test_anthropic_tool_streaming():
+def test_anthropic_tool_streaming(server):
     """Test streaming with tool use"""
     server.jinja = True
     server.start()
@@ -496,7 +491,7 @@ def test_anthropic_tool_streaming():
 
 # Vision/multimodal tests
 
-def test_anthropic_vision_format_accepted():
+def test_anthropic_vision_format_accepted(server):
     """Test that Anthropic vision format is accepted (format validation only)"""
     server.start()
 
@@ -533,9 +528,8 @@ def test_anthropic_vision_format_accepted():
     assert "image input is not supported" in res.body.get("error", {}).get("message", "").lower()
 
 
-def test_anthropic_vision_base64_with_multimodal_model(vision_server):
+def test_anthropic_vision_base64_with_multimodal_model(server, vision_server):
     """Test vision with base64 image using Anthropic format with multimodal model"""
-    global server
     server = vision_server
     server.start()
 
@@ -576,7 +570,7 @@ def test_anthropic_vision_base64_with_multimodal_model(vision_server):
 
 # Parameter tests
 
-def test_anthropic_stop_sequences():
+def test_anthropic_stop_sequences(server):
     """Test stop_sequences parameter"""
     server.start()
 
@@ -593,7 +587,7 @@ def test_anthropic_stop_sequences():
     assert res.body["type"] == "message"
 
 
-def test_anthropic_temperature():
+def test_anthropic_temperature(server):
     """Test temperature parameter"""
     server.start()
 
@@ -610,7 +604,7 @@ def test_anthropic_temperature():
     assert res.body["type"] == "message"
 
 
-def test_anthropic_top_p():
+def test_anthropic_top_p(server):
     """Test top_p parameter"""
     server.start()
 
@@ -627,7 +621,7 @@ def test_anthropic_top_p():
     assert res.body["type"] == "message"
 
 
-def test_anthropic_top_k():
+def test_anthropic_top_k(server):
     """Test top_k parameter (llama.cpp specific)"""
     server.start()
 
@@ -646,7 +640,7 @@ def test_anthropic_top_k():
 
 # Error handling tests
 
-def test_anthropic_missing_messages():
+def test_anthropic_missing_messages(server):
     """Test error when messages are missing"""
     server.start()
 
@@ -660,7 +654,7 @@ def test_anthropic_missing_messages():
     assert res.status_code >= 400
 
 
-def test_anthropic_empty_messages():
+def test_anthropic_empty_messages(server):
     """Test permissive handling of empty messages array"""
     server.start()
 
@@ -678,7 +672,7 @@ def test_anthropic_empty_messages():
 
 # Content block index tests
 
-def test_anthropic_streaming_content_block_indices():
+def test_anthropic_streaming_content_block_indices(server):
     """Test that content block indices are correct in streaming"""
     server.jinja = True
     server.start()
@@ -725,7 +719,7 @@ def test_anthropic_streaming_content_block_indices():
 
 # Extended features tests
 
-def test_anthropic_thinking():
+def test_anthropic_thinking(server):
     """Test extended thinking parameter"""
     server.jinja = True
     server.start()
@@ -746,7 +740,7 @@ def test_anthropic_thinking():
     assert res.body["type"] == "message"
 
 
-def test_anthropic_metadata():
+def test_anthropic_metadata(server):
     """Test metadata parameter"""
     server.start()
 
@@ -767,7 +761,7 @@ def test_anthropic_metadata():
 
 # Compatibility tests
 
-def test_anthropic_vs_openai_different_response_format():
+def test_anthropic_vs_openai_different_response_format(server):
     """Verify Anthropic format is different from OpenAI format"""
     server.start()
 
@@ -814,9 +808,8 @@ def test_anthropic_vs_openai_different_response_format():
 # The next two tests cover the input path (conversation history):
 # Client sends thinking blocks -> convert_anthropic_to_oai -> reasoning_content -> template
 
-def test_anthropic_thinking_history_in_count_tokens():
+def test_anthropic_thinking_history_in_count_tokens(server):
     """Test that interleaved thinking blocks in conversation history are not dropped during conversion."""
-    global server
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/Qwen-Qwen3-0.6B.jinja'
     server.start()
@@ -883,9 +876,8 @@ def test_anthropic_thinking_history_in_count_tokens():
         f"Expected more tokens with thinking ({res_with.body['input_tokens']}) than without ({res_without.body['input_tokens']})"
 
 
-def test_anthropic_thinking_history_in_template():
+def test_anthropic_thinking_history_in_template(server):
     """Test that reasoning_content from converted interleaved thinking blocks renders in the prompt."""
-    global server
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/Qwen-Qwen3-0.6B.jinja'
     server.start()
@@ -946,9 +938,8 @@ def test_anthropic_thinking_history_in_template():
 
 @pytest.mark.slow
 @pytest.mark.parametrize("stream", [False, True])
-def test_anthropic_thinking_with_reasoning_model(stream):
+def test_anthropic_thinking_with_reasoning_model(server, stream):
     """Test that thinking content blocks are properly returned for reasoning models"""
-    global server
     server = ServerProcess()
     server.model_hf_repo = "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF"
     server.model_hf_file = "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf"

--- a/tools/server/tests/unit/test_compat_anthropic.py
+++ b/tools/server/tests/unit/test_compat_anthropic.py
@@ -818,7 +818,7 @@ def test_anthropic_thinking_history_in_count_tokens():
     """Test that interleaved thinking blocks in conversation history are not dropped during conversion."""
     global server
     server.jinja = True
-    server.chat_template_file = '../../../models/templates/Qwen-Qwen3-0.6B.jinja'
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/Qwen-Qwen3-0.6B.jinja'
     server.start()
 
     tool = {
@@ -887,7 +887,7 @@ def test_anthropic_thinking_history_in_template():
     """Test that reasoning_content from converted interleaved thinking blocks renders in the prompt."""
     global server
     server.jinja = True
-    server.chat_template_file = '../../../models/templates/Qwen-Qwen3-0.6B.jinja'
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/Qwen-Qwen3-0.6B.jinja'
     server.start()
 
     reasoning_1 = "I should check the project structure first."

--- a/tools/server/tests/unit/test_compat_gcp.py
+++ b/tools/server/tests/unit/test_compat_gcp.py
@@ -1,18 +1,15 @@
 import pytest
 from utils import *
 
-server: ServerProcess
+
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.gcp_compat = True
+    return s
 
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.gcp_compat = True
-
-
-def test_gcp_predict_camel_case():
-    global server
+def test_gcp_predict_camel_case(server):
     server.start()
     res = server.make_request("POST", "/predict", data={
         "instances": [
@@ -35,8 +32,7 @@ def test_gcp_predict_camel_case():
     assert len(prediction["choices"][0]["message"]["content"]) > 0
 
 
-def test_gcp_predict_multiple_instances():
-    global server
+def test_gcp_predict_multiple_instances(server):
     server.n_slots = 2
     server.start()
     res = server.make_request("POST", "/predict", data={

--- a/tools/server/tests/unit/test_compat_oai_responses.py
+++ b/tools/server/tests/unit/test_compat_oai_responses.py
@@ -2,15 +2,13 @@ import pytest
 from openai import OpenAI
 from utils import *
 
-server: ServerProcess
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
+@pytest.fixture
+def server(server_factory):
+    return server_factory("tinyllama2")
 
-def test_responses_with_openai_library():
-    global server
+
+def test_responses_with_openai_library(server):
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
     res = client.responses.create(
@@ -27,8 +25,8 @@ def test_responses_with_openai_library():
     assert res.output[0].id.startswith("msg_")
     assert match_regex("(Suddenly)+", res.output_text)
 
-def test_responses_stream_with_openai_library():
-    global server
+
+def test_responses_stream_with_openai_library(server):
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
     stream = client.responses.create(

--- a/tools/server/tests/unit/test_completion.py
+++ b/tools/server/tests/unit/test_completion.py
@@ -6,22 +6,16 @@ import random
 from openai import OpenAI
 from utils import *
 
-server = ServerPreset.tinyllama2()
-
 JSON_MULTIMODAL_KEY = "multimodal_data"
 JSON_PROMPT_STRING_KEY = "prompt_string"
-
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-
+@pytest.fixture
+def server(server_factory):
+    return server_factory('tinyllama2')
 @pytest.mark.parametrize("prompt,n_predict,re_content,n_prompt,n_predicted,truncated,return_tokens", [
     ("I believe the meaning of life is", 8, "(going|bed)+", 18, 8, False, False),
     ("Write a joke about AI from a very long prompt which will not be truncated", 64, "(princesses|everyone|kids|Anna|forest)+", 46, 64, False, True),
 ])
-def test_completion(prompt: str, n_predict: int, re_content: str, n_prompt: int, n_predicted: int, truncated: bool, return_tokens: bool):
-    global server
+def test_completion(server, prompt: str, n_predict: int, re_content: str, n_prompt: int, n_predicted: int, truncated: bool, return_tokens: bool):
     server.start()
     res = server.make_request("POST", "/completion", data={
         "n_predict": n_predict,
@@ -45,8 +39,7 @@ def test_completion(prompt: str, n_predict: int, re_content: str, n_prompt: int,
     ("I believe the meaning of life is", 8, "(going|bed)+", 18, 8, False),
     ("Write a joke about AI from a very long prompt which will not be truncated", 64, "(princesses|everyone|kids|Anna|forest)+", 46, 64, False),
 ])
-def test_completion_stream(prompt: str, n_predict: int, re_content: str, n_prompt: int, n_predicted: int, truncated: bool):
-    global server
+def test_completion_stream(server, prompt: str, n_predict: int, re_content: str, n_prompt: int, n_predicted: int, truncated: bool):
     server.start()
     res = server.make_stream_request("POST", "/completion", data={
         "n_predict": n_predict,
@@ -73,8 +66,7 @@ def test_completion_stream(prompt: str, n_predict: int, re_content: str, n_promp
             content += data["content"]
 
 
-def test_completion_stream_vs_non_stream():
-    global server
+def test_completion_stream_vs_non_stream(server):
     server.start()
     res_stream = server.make_stream_request("POST", "/completion", data={
         "n_predict": 8,
@@ -91,8 +83,7 @@ def test_completion_stream_vs_non_stream():
     assert content_stream == res_non_stream.body["content"]
 
 
-def test_completion_with_openai_library():
-    global server
+def test_completion_with_openai_library(server):
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
     res = client.completions.create(
@@ -106,8 +97,7 @@ def test_completion_with_openai_library():
     assert match_regex("(going|bed)+", res.choices[0].text)
 
 
-def test_completion_stream_with_openai_library():
-    global server
+def test_completion_stream_with_openai_library(server):
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
     res = client.completions.create(
@@ -127,8 +117,7 @@ def test_completion_stream_with_openai_library():
 
 # Test case from https://github.com/ggml-org/llama.cpp/issues/13780
 @pytest.mark.slow
-def test_completion_stream_with_openai_library_stops():
-    global server
+def test_completion_stream_with_openai_library_stops(server):
     server.model_hf_repo = "bartowski/Phi-3.5-mini-instruct-GGUF:Q4_K_M"
     server.model_hf_file = None
     server.start()
@@ -150,8 +139,7 @@ def test_completion_stream_with_openai_library_stops():
 
 
 @pytest.mark.parametrize("n_slots", [1, 2])
-def test_consistent_result_same_seed(n_slots: int):
-    global server
+def test_consistent_result_same_seed(server, n_slots: int):
     server.n_slots = n_slots
     server.start()
     last_res = None
@@ -168,8 +156,7 @@ def test_consistent_result_same_seed(n_slots: int):
 
 
 @pytest.mark.parametrize("n_slots", [1, 2])
-def test_different_result_different_seed(n_slots: int):
-    global server
+def test_different_result_different_seed(server, n_slots: int):
     server.n_slots = n_slots
     server.start()
     last_res = None
@@ -188,8 +175,7 @@ def test_different_result_different_seed(n_slots: int):
 # @pytest.mark.parametrize("temperature", [0.0, 1.0])
 @pytest.mark.parametrize("n_batch", [16, 32])
 @pytest.mark.parametrize("temperature", [0.0])
-def test_consistent_result_different_batch_size(n_batch: int, temperature: float):
-    global server
+def test_consistent_result_different_batch_size(server, n_batch: int, temperature: float):
     server.n_batch = n_batch
     server.start()
     last_res = None
@@ -206,8 +192,7 @@ def test_consistent_result_different_batch_size(n_batch: int, temperature: float
 
 
 @pytest.mark.skip(reason="This test fails on linux, need to be fixed")
-def test_cache_vs_nocache_prompt():
-    global server
+def test_cache_vs_nocache_prompt(server):
     server.start()
     res_cache = server.make_request("POST", "/completion", data={
         "prompt": "I believe the meaning of life is",
@@ -224,8 +209,7 @@ def test_cache_vs_nocache_prompt():
     assert res_cache.body["content"] == res_no_cache.body["content"]
 
 
-def test_nocache_long_input_prompt():
-    global server
+def test_nocache_long_input_prompt(server):
     server.start()
     res = server.make_request("POST", "/completion", data={
         "prompt": "I believe the meaning of life is"*32,
@@ -235,8 +219,7 @@ def test_nocache_long_input_prompt():
     })
     assert res.status_code == 400
 
-def test_json_prompt_no_mtmd():
-    global server
+def test_json_prompt_no_mtmd(server):
     server.start()
     res = server.make_request("POST", "/completion", data={
         "prompt": { JSON_PROMPT_STRING_KEY: "I believe the meaning of life is" },
@@ -246,8 +229,7 @@ def test_json_prompt_no_mtmd():
     })
     assert res.status_code == 200
 
-def test_json_prompt_mtm_error_when_not_supported():
-    global server
+def test_json_prompt_mtm_error_when_not_supported(server):
     server.start()
     res = server.make_request("POST", "/completion", data={
         "prompt": { JSON_PROMPT_STRING_KEY: "I believe the meaning of life is <__media__>", JSON_MULTIMODAL_KEY: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" },
@@ -258,8 +240,7 @@ def test_json_prompt_mtm_error_when_not_supported():
     # MTMD is disabled on this model, so this should fail.
     assert res.status_code != 200
 
-def test_completion_with_tokens_input():
-    global server
+def test_completion_with_tokens_input(server):
     server.temperature = 0.0
     server.start()
     prompt_str = "I believe the meaning of life is"
@@ -324,8 +305,7 @@ def test_completion_with_tokens_input():
     (4, 2), # some slots must be idle
     (4, 6),
 ])
-def test_completion_parallel_slots(n_slots: int, n_requests: int):
-    global server
+def test_completion_parallel_slots(server, n_slots: int, n_requests: int):
     server.n_slots = n_slots
     server.temperature = 0.0
     server.start()
@@ -379,8 +359,7 @@ def test_completion_parallel_slots(n_slots: int, n_requests: int):
         (256, 4, [90, 90, 40, 75], [True,  True,  True,  True]),
     ],
 )
-def test_completion_unified(n_ctx, n_slots, n_predict_vals, expected_success):
-    global server
+def test_completion_unified(server, n_ctx, n_slots, n_predict_vals, expected_success):
     server.n_slots = n_slots
     server.kv_unified = True
     server.n_ctx = n_ctx
@@ -408,10 +387,8 @@ def test_completion_unified(n_ctx, n_slots, n_predict_vals, expected_success):
         ("I believe the meaning of life is", 32, ["content", "generation_settings/n_predict", "prompt"]),
     ],
 )
-def test_completion_response_fields(
-    prompt: str, n_predict: int, response_fields: list[str]
+def test_completion_response_fields(server, prompt: str, n_predict: int, response_fields: list[str]
 ):
-    global server
     server.start()
     res = server.make_request(
         "POST",
@@ -435,8 +412,7 @@ def test_completion_response_fields(
         assert "generation_settings" in res.body
 
 
-def test_n_probs():
-    global server
+def test_n_probs(server):
     server.start()
     res = server.make_request("POST", "/completion", data={
         "prompt": "I believe the meaning of life is",
@@ -460,8 +436,7 @@ def test_n_probs():
             assert "bytes" in prob and type(prob["bytes"]) == list
 
 
-def test_n_probs_stream():
-    global server
+def test_n_probs_stream(server):
     server.start()
     res = server.make_stream_request("POST", "/completion", data={
         "prompt": "I believe the meaning of life is",
@@ -487,8 +462,7 @@ def test_n_probs_stream():
                     assert "bytes" in prob and type(prob["bytes"]) == list
 
 
-def test_n_probs_post_sampling():
-    global server
+def test_n_probs_post_sampling(server):
     server.start()
     res = server.make_request("POST", "/completion", data={
         "prompt": "Today was the day. Today I would finally become a",
@@ -524,9 +498,8 @@ def test_n_probs_post_sampling():
             # if the ones we did get already sum to 1.0.
             assert sum(p["prob"] for p in tok["top_probs"]) == pytest.approx(1.0)
 
-def test_n_probs_post_backend_sampling():
+def test_n_probs_post_backend_sampling(server):
     """Verify that the same probabilities are returned with and without backend sampling."""
-    global server
     server.backend_sampling = True
     server.start()
 
@@ -569,8 +542,7 @@ def test_n_probs_post_backend_sampling():
             verify_token(aa, bb)
 
 @pytest.mark.parametrize("tokenize,openai_style", [(False, False), (False, True), (True, False), (True, True)])
-def test_logit_bias(tokenize, openai_style):
-    global server
+def test_logit_bias(server, tokenize, openai_style):
     server.start()
 
     exclude = ["i", "I", "the", "The", "to", "a", "an", "be", "is", "was", "but", "But", "and", "And", "so", "So", "you", "You", "he", "He", "she", "She", "we", "We", "they", "They", "it", "It", "his", "His", "her", "Her", "book", "Book"]
@@ -601,8 +573,7 @@ def test_logit_bias(tokenize, openai_style):
     assert all(output_text.find(" " + tok + " ") == -1 for tok in exclude)
 
 
-def test_cancel_request():
-    global server
+def test_cancel_request(server):
     server.n_ctx = 4096
     server.n_predict = -1
     server.n_slots = 1
@@ -624,8 +595,7 @@ def test_cancel_request():
 # this test exercises the host-memory prompt cache
 # ref: https://github.com/ggml-org/llama.cpp/pull/16391
 # ref: https://github.com/ggml-org/llama.cpp/pull/17078
-def test_completion_prompt_cache():
-    global server
+def test_completion_prompt_cache(server):
     server.n_slots = 2
     server.kv_unified = True
     server.start()

--- a/tools/server/tests/unit/test_completion.py
+++ b/tools/server/tests/unit/test_completion.py
@@ -135,7 +135,7 @@ def test_completion_stream_with_openai_library_stops(server):
         if choice.finish_reason is None:
             assert choice.text is not None
             output_text += choice.text
-    assert match_regex("Sure, here's one for[\\s\\S]*", output_text), f'Unexpected output: {output_text}'
+    assert match_regex("Sure[,!] here's one for[\\s\\S]*", output_text), f'Unexpected output: {output_text}'
 
 
 @pytest.mark.parametrize("n_slots", [1, 2])

--- a/tools/server/tests/unit/test_ctx_shift.py
+++ b/tools/server/tests/unit/test_ctx_shift.py
@@ -1,9 +1,6 @@
 import pytest
 from utils import *
 
-server = ServerPreset.tinyllama2()
-
-
 SHORT_TEXT = """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -16,21 +13,19 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 """.strip()
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.n_ctx = 512
+    s.n_slots = 2
+    s.n_predict = 128
+    return s
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.n_ctx = 512
-    server.n_slots = 2
-    server.n_predict = 128
 
-
-def test_ctx_shift_enabled():
+def test_ctx_shift_enabled(server):
     # the prompt is 226 tokens
     # the slot context is 512/2 = 256 tokens
     # 96 tokens are generated thanks to shifting the context when it gets full
-    global server
     server.enable_ctx_shift = True
     server.start()
     res = server.make_request("POST", "/completion", data={
@@ -47,8 +42,7 @@ def test_ctx_shift_enabled():
     (64, 64, False),
     (-1, 248, True), # 8 tokens prompt + 248 tokens generated = 256 tokens total
 ])
-def test_ctx_shift_disabled_short_prompt(n_predict: int, n_token_output: int, truncated: bool):
-    global server
+def test_ctx_shift_disabled_short_prompt(server, n_predict: int, n_token_output: int, truncated: bool):
     server.n_predict = -1
     server.start()
     res = server.make_request("POST", "/completion", data={
@@ -60,8 +54,7 @@ def test_ctx_shift_disabled_short_prompt(n_predict: int, n_token_output: int, tr
     assert res.body["truncated"] == truncated
 
 
-def test_ctx_shift_disabled_long_prompt():
-    global server
+def test_ctx_shift_disabled_long_prompt(server):
     server.start()
     res = server.make_request("POST", "/completion", data={
         "n_predict": 64,
@@ -71,8 +64,7 @@ def test_ctx_shift_disabled_long_prompt():
     assert "error" in res.body
     assert "exceeds the available context size" in res.body["error"]["message"]
 
-def test_ctx_shift_disabled_stream():
-    global server
+def test_ctx_shift_disabled_stream(server):
     server.start()
     res = server.make_stream_request("POST", "/v1/completions", data={
         "n_predict": 256,

--- a/tools/server/tests/unit/test_embedding.py
+++ b/tools/server/tests/unit/test_embedding.py
@@ -4,18 +4,12 @@ import pytest
 from openai import OpenAI
 from utils import *
 
-server = ServerPreset.bert_bge_small()
-
 EPSILON = 1e-3
+@pytest.fixture
+def server(server_factory):
+    return server_factory('bert_bge_small')
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.bert_bge_small()
-
-
-def test_embedding_single():
-    global server
+def test_embedding_single(server):
     server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
@@ -30,8 +24,7 @@ def test_embedding_single():
     assert abs(sum([x ** 2 for x in res.body['data'][0]['embedding']]) - 1) < EPSILON
 
 
-def test_embedding_multiple():
-    global server
+def test_embedding_multiple(server):
     server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
@@ -49,7 +42,7 @@ def test_embedding_multiple():
         assert len(d['embedding']) > 1
 
 
-def test_embedding_multiple_with_fa():
+def test_embedding_multiple_with_fa(server):
     server = ServerPreset.bert_bge_small_with_fa()
     server.pooling = 'last'
     server.start()
@@ -85,8 +78,7 @@ def test_embedding_multiple_with_fa():
         ([[12, 34, 56], [12, "string", 34, 56]], True),
     ]
 )
-def test_embedding_mixed_input(input, is_multi_prompt: bool):
-    global server
+def test_embedding_mixed_input(server, input, is_multi_prompt: bool):
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={"input": input})
     assert res.status_code == 200
@@ -101,8 +93,7 @@ def test_embedding_mixed_input(input, is_multi_prompt: bool):
         assert len(data[0]['embedding']) > 1
 
 
-def test_embedding_pooling_mean():
-    global server
+def test_embedding_pooling_mean(server):
     server.pooling = 'mean'
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
@@ -117,8 +108,7 @@ def test_embedding_pooling_mean():
     assert abs(sum([x ** 2 for x in res.body['data'][0]['embedding']]) - 1) < EPSILON
 
 
-def test_embedding_pooling_mean_multiple():
-    global server
+def test_embedding_pooling_mean_multiple(server):
     server.pooling = 'mean'
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
@@ -135,8 +125,7 @@ def test_embedding_pooling_mean_multiple():
         assert len(d['embedding']) > 1
 
 
-def test_embedding_pooling_none():
-    global server
+def test_embedding_pooling_none(server):
     server.pooling = 'none'
     server.start()
     res = server.make_request("POST", "/embeddings", data={
@@ -151,8 +140,7 @@ def test_embedding_pooling_none():
         assert abs(sum([x ** 2 for x in x]) - 1) > EPSILON
 
 
-def test_embedding_pooling_none_oai():
-    global server
+def test_embedding_pooling_none_oai(server):
     server.pooling = 'none'
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
@@ -164,8 +152,7 @@ def test_embedding_pooling_none_oai():
     assert "error" in res.body
 
 
-def test_embedding_openai_library_single():
-    global server
+def test_embedding_openai_library_single(server):
     server.pooling = 'last'
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
@@ -174,8 +161,7 @@ def test_embedding_openai_library_single():
     assert len(res.data[0].embedding) > 1
 
 
-def test_embedding_openai_library_multiple():
-    global server
+def test_embedding_openai_library_multiple(server):
     server.pooling = 'last'
     server.start()
     client = OpenAI(api_key="dummy", base_url=f"http://{server.server_host}:{server.server_port}/v1")
@@ -190,8 +176,7 @@ def test_embedding_openai_library_multiple():
         assert len(d.embedding) > 1
 
 
-def test_embedding_error_prompt_too_long():
-    global server
+def test_embedding_error_prompt_too_long(server):
     server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
@@ -201,7 +186,7 @@ def test_embedding_error_prompt_too_long():
     assert "too large" in res.body["error"]["message"]
 
 
-def test_same_prompt_give_same_result():
+def test_same_prompt_give_same_result(server):
     server.pooling = 'last'
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
@@ -229,8 +214,7 @@ def test_same_prompt_give_same_result():
         ("This is a test", 6),
     ]
 )
-def test_embedding_usage_single(content, n_tokens):
-    global server
+def test_embedding_usage_single(server, content, n_tokens):
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={"input": content})
     assert res.status_code == 200
@@ -238,8 +222,7 @@ def test_embedding_usage_single(content, n_tokens):
     assert res.body['usage']['prompt_tokens'] == n_tokens
 
 
-def test_embedding_usage_multiple():
-    global server
+def test_embedding_usage_multiple(server):
     server.start()
     res = server.make_request("POST", "/v1/embeddings", data={
         "input": [
@@ -252,7 +235,7 @@ def test_embedding_usage_multiple():
     assert res.body['usage']['prompt_tokens'] == 2 * 9
 
 
-def test_embedding_openai_library_base64():
+def test_embedding_openai_library_base64(server):
     server.start()
     test_input = "Test base64 embedding output"
 

--- a/tools/server/tests/unit/test_ignore_eos.py
+++ b/tools/server/tests/unit/test_ignore_eos.py
@@ -1,18 +1,14 @@
 import pytest
 from utils import *
 
-server = ServerPreset.tinyllama2()
+
+@pytest.fixture
+def server(server_factory):
+    return server_factory("tinyllama2")
 
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-
-
-def test_ignore_eos_populates_logit_bias():
+def test_ignore_eos_populates_logit_bias(server):
     """ignore_eos=true must add EOG logit biases to generation_settings."""
-    global server
     server.start()
     res = server.make_request("POST", "/completion", data={
         "n_predict": 8,
@@ -28,9 +24,8 @@ def test_ignore_eos_populates_logit_bias():
         assert entry["bias"] is None  # null in JSON represents -inf
 
 
-def test_ignore_eos_false_no_logit_bias():
+def test_ignore_eos_false_no_logit_bias(server):
     """ignore_eos=false (default) must NOT add EOG logit biases."""
-    global server
     server.start()
     res = server.make_request("POST", "/completion", data={
         "n_predict": 8,

--- a/tools/server/tests/unit/test_infill.py
+++ b/tools/server/tests/unit/test_infill.py
@@ -1,16 +1,11 @@
 import pytest
 from utils import *
 
-server = ServerPreset.tinyllama_infill()
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama_infill()
-
-
-def test_infill_without_input_extra():
-    global server
+@pytest.fixture
+def server(server_factory):
+    return server_factory('tinyllama_infill')
+def test_infill_without_input_extra(server):
     server.start()
     res = server.make_request("POST", "/infill", data={
         "input_prefix": "#include <cstdio>\n#include \"llama.h\"\n\nint main() {\n",
@@ -21,8 +16,7 @@ def test_infill_without_input_extra():
     assert match_regex("(Ann|small|shiny|Daddy|Jimmy)+", res.body["content"])
 
 
-def test_infill_with_input_extra():
-    global server
+def test_infill_with_input_extra(server):
     server.start()
     res = server.make_request("POST", "/infill", data={
         "input_extra": [{
@@ -44,8 +38,7 @@ def test_infill_with_input_extra():
     {"filename": 123, "text": "abc"},
     {"filename": 123, "text": 456},
 ])
-def test_invalid_input_extra_req(input_extra):
-    global server
+def test_invalid_input_extra_req(server, input_extra):
     server.start()
     res = server.make_request("POST", "/infill", data={
         "input_extra": [input_extra],
@@ -58,8 +51,7 @@ def test_invalid_input_extra_req(input_extra):
 
 
 @pytest.mark.slow
-def test_with_qwen_model():
-    global server
+def test_with_qwen_model(server):
     server.model_file = None
     server.model_hf_repo = "ggml-org/Qwen2.5-Coder-1.5B-IQ3_XXS-GGUF"
     server.model_hf_file = "qwen2.5-coder-1.5b-iq3_xxs-imat.gguf"

--- a/tools/server/tests/unit/test_infill.py
+++ b/tools/server/tests/unit/test_infill.py
@@ -57,7 +57,7 @@ def test_invalid_input_extra_req(input_extra):
     assert "error" in res.body
 
 
-@pytest.mark.skipif(not is_slow_test_allowed(), reason="skipping slow test")
+@pytest.mark.slow
 def test_with_qwen_model():
     global server
     server.model_file = None

--- a/tools/server/tests/unit/test_kv_keep_only_active.py
+++ b/tools/server/tests/unit/test_kv_keep_only_active.py
@@ -3,8 +3,6 @@ import tempfile
 import pytest
 from utils import *
 
-server = ServerPreset.tinyllama2()
-
 class LogReader:
     def __init__(self, path):
         self.path = path
@@ -15,21 +13,19 @@ class LogReader:
             content = f.read()
             self.pos = f.tell()
         return content
-
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.n_slots = 2
-    server.n_predict = 4
-    server.temperature = 0.0
-    server.server_slots = True
-    server.cache_ram = 100
-    server.kv_unified = True
-    server.debug = True
-    fd, server.log_path = tempfile.mkstemp(suffix='.log')
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.n_slots = 2
+    s.n_predict = 4
+    s.temperature = 0.0
+    s.server_slots = True
+    s.cache_ram = 100
+    s.kv_unified = True
+    s.debug = True
+    fd, s.log_path = tempfile.mkstemp(suffix='.log')
     os.close(fd)
-    yield
+    return s
 
 
 LONG_PROMPT = (
@@ -42,8 +38,7 @@ LONG_PROMPT = (
 
 
 # idle slot cleared on launch should restore from cache-ram
-def test_clear_and_restore():
-    global server
+def test_clear_and_restore(server):
     server.start()
     log = LogReader(server.log_path)
 
@@ -89,8 +84,7 @@ def test_clear_and_restore():
     assert "__TEST_TAG_CACHE_IDLE_SLOT__" not in log.drain()
 
 
-def test_disabled_with_flag():
-    global server
+def test_disabled_with_flag(server):
     server.no_cache_idle_slots = True
     server.start()
     log = LogReader(server.log_path)

--- a/tools/server/tests/unit/test_lora.py
+++ b/tools/server/tests/unit/test_lora.py
@@ -1,15 +1,12 @@
 import pytest
 from utils import *
 
-server = ServerPreset.stories15m_moe()
-
 LORA_FILE_URL = "https://huggingface.co/ggml-org/stories15M_MOE/resolve/main/moe_shakespeare15M.gguf"
-
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.stories15m_moe()
-    server.lora_files = [download_file(LORA_FILE_URL)]
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('stories15m_moe')
+    s.lora_files = [download_file(LORA_FILE_URL)]
+    return s
 
 
 @pytest.mark.parametrize("scale,re_content", [
@@ -18,8 +15,7 @@ def create_server():
     # with lora, the model should behave like a Shakespearean text generator
     (1.0, "(eye|love|glass|sun)+"),
 ])
-def test_lora(scale: float, re_content: str):
-    global server
+def test_lora(server, scale: float, re_content: str):
     server.start()
     res_lora_control = server.make_request("POST", "/lora-adapters", data=[
         {"id": 0, "scale": scale}
@@ -32,8 +28,7 @@ def test_lora(scale: float, re_content: str):
     assert match_regex(re_content, res.body["content"])
 
 
-def test_lora_per_request():
-    global server
+def test_lora_per_request(server):
     server.n_slots = 4
     server.start()
 

--- a/tools/server/tests/unit/test_lora.py
+++ b/tools/server/tests/unit/test_lora.py
@@ -66,7 +66,7 @@ def test_lora_per_request():
         assert match_regex(re_test, res.body["content"])
 
 
-@pytest.mark.skipif(not is_slow_test_allowed(), reason="skipping slow test")
+@pytest.mark.slow
 def test_with_big_model():
     server = ServerProcess()
     server.model_hf_repo = "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF"

--- a/tools/server/tests/unit/test_proxy.py
+++ b/tools/server/tests/unit/test_proxy.py
@@ -1,17 +1,13 @@
 import pytest
 from utils import *
 
-server = ServerPreset.tinyllama2()
+
+@pytest.fixture
+def server(server_factory):
+    return server_factory("tinyllama2")
 
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-
-
-def test_mcp_no_proxy():
-    global server
+def test_mcp_no_proxy(server):
     server.webui_mcp_proxy = False
     server.start()
 
@@ -19,8 +15,7 @@ def test_mcp_no_proxy():
     assert res.status_code == 404
 
 
-def test_mcp_proxy():
-    global server
+def test_mcp_proxy(server):
     server.webui_mcp_proxy = True
     server.start()
 
@@ -30,8 +25,7 @@ def test_mcp_proxy():
     assert "Example Domain" in res.text
 
 
-def test_mcp_proxy_custom_port():
-    global server
+def test_mcp_proxy_custom_port(server):
     server.webui_mcp_proxy = True
     server.start()
 

--- a/tools/server/tests/unit/test_rerank.py
+++ b/tools/server/tests/unit/test_rerank.py
@@ -1,15 +1,10 @@
 import pytest
 from utils import *
 
-server = ServerPreset.jina_reranker_tiny()
 
-
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.jina_reranker_tiny()
-
-
+@pytest.fixture
+def server(server_factory):
+    return server_factory('jina_reranker_tiny')
 TEST_DOCUMENTS = [
     "A machine is a physical system that uses power to apply forces and control movement to perform an action. The term is commonly applied to artificial devices, such as those employing engines or motors, but also to natural biological macromolecules, such as molecular machines.",
     "Learning is the process of acquiring new understanding, knowledge, behaviors, skills, values, attitudes, and preferences. The ability to learn is possessed by humans, non-human animals, and some machines; there is also evidence for some kind of learning in certain plants.",
@@ -18,8 +13,7 @@ TEST_DOCUMENTS = [
 ]
 
 
-def test_rerank():
-    global server
+def test_rerank(server):
     server.start()
     res = server.make_request("POST", "/rerank", data={
         "query": "Machine learning is",
@@ -41,8 +35,7 @@ def test_rerank():
     assert least_relevant["index"] == 3
 
 
-def test_rerank_tei_format():
-    global server
+def test_rerank_tei_format(server):
     server.start()
     res = server.make_request("POST", "/rerank", data={
         "query": "Machine learning is",
@@ -70,8 +63,7 @@ def test_rerank_tei_format():
     123,
     [1, 2, 3],
 ])
-def test_invalid_rerank_req(documents):
-    global server
+def test_invalid_rerank_req(server, documents):
     server.start()
     res = server.make_request("POST", "/rerank", data={
         "query": "Machine learning is",
@@ -88,8 +80,7 @@ def test_invalid_rerank_req(documents):
         ("Which city?", "Machine learning is ", "Paris, capitale de la", 26),
     ]
 )
-def test_rerank_usage(query, doc1, doc2, n_tokens):
-    global server
+def test_rerank_usage(server, query, doc1, doc2, n_tokens):
     server.start()
 
     res = server.make_request("POST", "/rerank", data={
@@ -110,8 +101,7 @@ def test_rerank_usage(query, doc1, doc2, n_tokens):
     (4, 4),
     (99, len(TEST_DOCUMENTS)),    # higher than available docs
 ])
-def test_rerank_top_n(top_n, expected_len):
-    global server
+def test_rerank_top_n(server, top_n, expected_len):
     server.start()
     data = {
         "query": "Machine learning is",
@@ -131,8 +121,7 @@ def test_rerank_top_n(top_n, expected_len):
     (4, 4),
     (99, len(TEST_DOCUMENTS)),    # higher than available docs
 ])
-def test_rerank_tei_top_n(top_n, expected_len):
-    global server
+def test_rerank_tei_top_n(server, top_n, expected_len):
     server.start()
     data = {
         "query": "Machine learning is",

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -1,16 +1,13 @@
 import pytest
 from utils import *
 
-server: ServerProcess
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.router()
+@pytest.fixture
+def server(server_factory):
+    return server_factory('router')
 
 
-def test_router_props():
-    global server
+def test_router_props(server):
     server.models_max = 2
     server.no_models_autoload = True
     server.start()
@@ -29,8 +26,7 @@ def test_router_props():
         ("non-existent/model", False),
     ]
 )
-def test_router_chat_completion_stream(model: str, success: bool):
-    global server
+def test_router_chat_completion_stream(server, model: str, success: bool):
     server.start()
     content = ""
     ex: ServerError | None = None
@@ -62,13 +58,13 @@ def test_router_chat_completion_stream(model: str, success: bool):
         assert content == ""
 
 
-def _get_model_ids(is_reload: bool) -> set[str]:
+def _get_model_ids(server, is_reload: bool) -> set[str]:
     res = server.make_request("GET", "/models" + ("?reload=1" if is_reload else ""))
     assert res.status_code == 200
     return {item["id"] for item in res.body.get("data", [])}
 
 
-def _get_model_status(model_id: str) -> str:
+def _get_model_status(server, model_id: str) -> str:
     res = server.make_request("GET", "/models")
     assert res.status_code == 200
     for item in res.body.get("data", []):
@@ -77,11 +73,11 @@ def _get_model_status(model_id: str) -> str:
     raise AssertionError(f"Model {model_id} not found in /models response")
 
 
-def _wait_for_model_status(model_id: str, desired: set[str], timeout: int = 60) -> str:
+def _wait_for_model_status(server, model_id: str, desired: set[str], timeout: int = 60) -> str:
     deadline = time.time() + timeout
     last_status = None
     while time.time() < deadline:
-        last_status = _get_model_status(model_id)
+        last_status = _get_model_status(server, model_id)
         if last_status in desired:
             return last_status
         time.sleep(1)
@@ -91,7 +87,7 @@ def _wait_for_model_status(model_id: str, desired: set[str], timeout: int = 60) 
 
 
 def _load_model_and_wait(
-    model_id: str, timeout: int = 60, headers: dict | None = None
+    server, model_id: str, timeout: int = 60, headers: dict | None = None
 ) -> None:
     load_res = server.make_request(
         "POST", "/models/load", data={"model": model_id}, headers=headers
@@ -99,24 +95,22 @@ def _load_model_and_wait(
     assert load_res.status_code == 200
     assert isinstance(load_res.body, dict)
     assert load_res.body.get("success") is True
-    _wait_for_model_status(model_id, {"loaded"}, timeout=timeout)
+    _wait_for_model_status(server, model_id, {"loaded"}, timeout=timeout)
 
 
-def test_router_unload_model():
-    global server
+def test_router_unload_model(server):
     server.start()
     model_id = "ggml-org/tinygemma3-GGUF:Q8_0"
 
-    _load_model_and_wait(model_id)
+    _load_model_and_wait(server, model_id)
 
     unload_res = server.make_request("POST", "/models/unload", data={"model": model_id})
     assert unload_res.status_code == 200
     assert unload_res.body.get("success") is True
-    _wait_for_model_status(model_id, {"unloaded"})
+    _wait_for_model_status(server, model_id, {"unloaded"})
 
 
-def test_router_models_max_evicts_lru():
-    global server
+def test_router_models_max_evicts_lru(server):
     server.models_max = 2
     server.start()
 
@@ -129,23 +123,22 @@ def test_router_models_max_evicts_lru():
     # Load only the first 2 models to fill the cache
     first, second, third = candidate_models[:3]
 
-    _load_model_and_wait(first, timeout=120)
-    _load_model_and_wait(second, timeout=120)
+    _load_model_and_wait(server, first, timeout=120)
+    _load_model_and_wait(server, second, timeout=120)
 
     # Verify both models are loaded
-    assert _get_model_status(first) == "loaded"
-    assert _get_model_status(second) == "loaded"
+    assert _get_model_status(server, first) == "loaded"
+    assert _get_model_status(server, second) == "loaded"
 
     # Load the third model - this should trigger LRU eviction of the first model
-    _load_model_and_wait(third, timeout=120)
+    _load_model_and_wait(server, third, timeout=120)
 
     # Verify eviction: third is loaded, first was evicted
-    assert _get_model_status(third) == "loaded"
-    assert _get_model_status(first) == "unloaded"
+    assert _get_model_status(server, third) == "loaded"
+    assert _get_model_status(server, first) == "unloaded"
 
 
-def test_router_no_models_autoload():
-    global server
+def test_router_no_models_autoload(server):
     server.no_models_autoload = True
     server.start()
     model_id = "ggml-org/tinygemma3-GGUF:Q8_0"
@@ -162,7 +155,7 @@ def test_router_no_models_autoload():
     assert res.status_code == 400
     assert "error" in res.body
 
-    _load_model_and_wait(model_id)
+    _load_model_and_wait(server, model_id)
 
     success_res = server.make_request(
         "POST",
@@ -177,8 +170,7 @@ def test_router_no_models_autoload():
     assert "error" not in success_res.body
 
 
-def test_router_api_key_required():
-    global server
+def test_router_api_key_required(server):
     server.api_key = "sk-router-secret"
     server.start()
 
@@ -197,7 +189,7 @@ def test_router_api_key_required():
     assert res.status_code == 401
     assert res.body.get("error", {}).get("type") == "authentication_error"
 
-    _load_model_and_wait(model_id, headers=auth_headers)
+    _load_model_and_wait(server, model_id, headers=auth_headers)
 
     authed = server.make_request(
         "POST",
@@ -213,10 +205,8 @@ def test_router_api_key_required():
     assert "error" not in authed.body
 
 
-def test_router_reload_models():
+def test_router_reload_models(server):
     """POST /models/reload re-reads the INI preset and updates the model list."""
-    global server
-
     preset_path = os.path.join(TESTS_TMP_DIR, "test_reload.ini")
 
     # Initial preset: two models
@@ -232,7 +222,7 @@ def test_router_reload_models():
     server.models_preset = preset_path
     server.start()
 
-    ids = _get_model_ids(is_reload=False)
+    ids = _get_model_ids(server, is_reload=False)
     assert "model-reload-a" in ids
     assert "model-reload-b" in ids
 
@@ -247,7 +237,7 @@ def test_router_reload_models():
         )
 
     try:
-        ids = _get_model_ids(is_reload=True)
+        ids = _get_model_ids(server, is_reload=True)
         assert "model-reload-a" not in ids, "removed model should no longer appear"
         assert "model-reload-b" in ids, "unchanged model should still appear"
         assert "model-reload-c" in ids, "newly added model should appear"

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -217,7 +217,7 @@ def test_router_reload_models():
     """POST /models/reload re-reads the INI preset and updates the model list."""
     global server
 
-    preset_path = os.path.join(TMP_DIR, "test_reload.ini")
+    preset_path = os.path.join(TESTS_TMP_DIR, "test_reload.ini")
 
     # Initial preset: two models
     with open(preset_path, "w") as f:

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -2,29 +2,24 @@ import pytest
 from openai import OpenAI
 from utils import *
 
-server = ServerPreset.tinyllama2()
-
 TEST_API_KEY = "sk-this-is-the-secret-key"
-
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.api_key = TEST_API_KEY
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.api_key = TEST_API_KEY
+    return s
 
 
 @pytest.mark.parametrize("endpoint", ["/health", "/models"])
-def test_access_public_endpoint(endpoint: str):
-    global server
+def test_access_public_endpoint(server, endpoint: str):
     server.start()
     res = server.make_request("GET", endpoint)
     assert res.status_code == 200
     assert "error" not in res.body
 
 
-def test_access_static_assets_without_api_key():
+def test_access_static_assets_without_api_key(server):
     """Static web UI assets should not require API key authentication (issue #21229)"""
-    global server
     server.start()
     for path in ["/", "/bundle.js", "/bundle.css"]:
         res = server.make_request("GET", path)
@@ -32,8 +27,7 @@ def test_access_static_assets_without_api_key():
 
 
 @pytest.mark.parametrize("api_key", [None, "invalid-key"])
-def test_incorrect_api_key(api_key: str):
-    global server
+def test_incorrect_api_key(server, api_key: str):
     server.start()
     res = server.make_request("POST", "/completions", data={
         "prompt": "I believe the meaning of life is",
@@ -45,8 +39,7 @@ def test_incorrect_api_key(api_key: str):
     assert res.body["error"]["type"] == "authentication_error"
 
 
-def test_correct_api_key():
-    global server
+def test_correct_api_key(server):
     server.start()
     res = server.make_request("POST", "/completions", data={
         "prompt": "I believe the meaning of life is",
@@ -58,8 +51,7 @@ def test_correct_api_key():
     assert "content" in res.body
 
 
-def test_correct_api_key_anthropic_header():
-    global server
+def test_correct_api_key_anthropic_header(server):
     server.start()
     res = server.make_request("POST", "/completions", data={
         "prompt": "I believe the meaning of life is",
@@ -71,8 +63,7 @@ def test_correct_api_key_anthropic_header():
     assert "content" in res.body
 
 
-def test_openai_library_correct_api_key():
-    global server
+def test_openai_library_correct_api_key(server):
     server.start()
     client = OpenAI(api_key=TEST_API_KEY, base_url=f"http://{server.server_host}:{server.server_port}")
     res = client.chat.completions.create(
@@ -92,8 +83,7 @@ def test_openai_library_correct_api_key():
     ("web.mydomain.fr", "Access-Control-Allow-Methods", "GET, POST"),
     ("web.mydomain.fr", "Access-Control-Allow-Headers", "*"),
 ])
-def test_cors_options(origin: str, cors_header: str, cors_header_value: str):
-    global server
+def test_cors_options(server, origin: str, cors_header: str, cors_header_value: str):
     server.start()
     res = server.make_request("OPTIONS", "/completions", headers={
         "Origin": origin,
@@ -115,7 +105,7 @@ def test_cors_options(origin: str, cors_header: str, cors_header_value: str):
         (f"{LLAMA_CPP_ROOT}/tools", "file://../mtmd/test-1.jpeg", False), # no directory traversal
     ]
 )
-def test_local_media_file(media_path, image_url, success,):
+def test_local_media_file(server, media_path, image_url, success,):
     server = ServerPreset.tinygemma3()
     server.media_path = media_path
     server.start()

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -109,10 +109,10 @@ def test_cors_options(origin: str, cors_header: str, cors_header_value: str):
     "media_path, image_url, success",
     [
         (None,             "file://mtmd/test-1.jpeg",    False), # disabled media path, should fail
-        ("../../../tools", "file://mtmd/test-1.jpeg",    True),
-        ("../../../tools", "file:////mtmd//test-1.jpeg", True),  # should be the same file as above
-        ("../../../tools", "file://mtmd/notfound.jpeg",  False), # non-existent file
-        ("../../../tools", "file://../mtmd/test-1.jpeg", False), # no directory traversal
+        (f"{LLAMA_CPP_ROOT}/tools", "file://mtmd/test-1.jpeg",    True),
+        (f"{LLAMA_CPP_ROOT}/tools", "file:////mtmd//test-1.jpeg", True),  # should be the same file as above
+        (f"{LLAMA_CPP_ROOT}/tools", "file://mtmd/notfound.jpeg",  False), # non-existent file
+        (f"{LLAMA_CPP_ROOT}/tools", "file://../mtmd/test-1.jpeg", False), # no directory traversal
     ]
 )
 def test_local_media_file(media_path, image_url, success,):

--- a/tools/server/tests/unit/test_sleep.py
+++ b/tools/server/tests/unit/test_sleep.py
@@ -2,17 +2,13 @@ import pytest
 import time
 from utils import *
 
-server = ServerPreset.tinyllama2()
+
+@pytest.fixture
+def server(server_factory):
+    return server_factory("tinyllama2")
 
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-
-
-def test_server_sleep():
-    global server
+def test_server_sleep(server):
     server.sleep_idle_seconds = 1
     server.start()
 

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -1,18 +1,16 @@
 import pytest
 from utils import *
 
-server = ServerPreset.tinyllama2()
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.slot_save_path = TESTS_TMP_DIR
-    server.temperature = 0.0
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.slot_save_path = TESTS_TMP_DIR
+    s.temperature = 0.0
+    return s
 
 
-def test_slot_save_restore():
-    global server
+def test_slot_save_restore(server):
     server.start()
 
     # First prompt in slot 1 should be fully processed
@@ -70,8 +68,7 @@ def test_slot_save_restore():
     assert res.body["timings"]["prompt_n"] == 1
 
 
-def test_slot_erase():
-    global server
+def test_slot_erase(server):
     server.start()
 
     res = server.make_request("POST", "/completion", data={

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -7,7 +7,7 @@ server = ServerPreset.tinyllama2()
 def create_server():
     global server
     server = ServerPreset.tinyllama2()
-    server.slot_save_path = "./tmp"
+    server.slot_save_path = TESTS_TMP_DIR
     server.temperature = 0.0
 
 

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -3,27 +3,25 @@ from utils import *
 
 # We use a F16 MOE gguf as main model, and q4_0 as draft model
 
-server = ServerPreset.stories15m_moe()
-
 MODEL_DRAFT_FILE_URL = "https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M-q4_0.gguf"
 
-def create_server():
-    global server
-    server = ServerPreset.stories15m_moe()
+
+def _build_server(server_factory):
+    s = server_factory("stories15m_moe")
     # set default values
-    server.model_draft = download_file(MODEL_DRAFT_FILE_URL)
-    server.draft_min = 4
-    server.draft_max = 8
-    server.fa = "off"
+    s.model_draft = download_file(MODEL_DRAFT_FILE_URL)
+    s.draft_min = 4
+    s.draft_max = 8
+    s.fa = "off"
+    return s
 
 
-@pytest.fixture(autouse=True)
-def fixture_create_server():
-    return create_server()
+@pytest.fixture
+def server(server_factory):
+    return _build_server(server_factory)
 
 
-def test_with_and_without_draft():
-    global server
+def test_with_and_without_draft(server, server_factory):
     server.model_draft = None  # disable draft model
     server.start()
     res = server.make_request("POST", "/completion", data={
@@ -37,7 +35,7 @@ def test_with_and_without_draft():
     server.stop()
 
     # create new server with draft model
-    create_server()
+    server = _build_server(server_factory)
     server.start()
     res = server.make_request("POST", "/completion", data={
         "prompt": "I believe the meaning of life is",
@@ -51,8 +49,7 @@ def test_with_and_without_draft():
     assert content_no_draft == content_draft
 
 
-def test_different_draft_min_draft_max():
-    global server
+def test_different_draft_min_draft_max(server):
     test_values = [
         (1, 2),
         (1, 4),
@@ -78,8 +75,7 @@ def test_different_draft_min_draft_max():
         last_content = res.body["content"]
 
 
-def test_slot_ctx_not_exceeded():
-    global server
+def test_slot_ctx_not_exceeded(server):
     server.n_ctx = 256
     server.start()
     res = server.make_request("POST", "/completion", data={
@@ -92,8 +88,7 @@ def test_slot_ctx_not_exceeded():
     assert len(res.body["content"]) > 0
 
 
-def test_with_ctx_shift():
-    global server
+def test_with_ctx_shift(server):
     server.n_ctx = 256
     server.enable_ctx_shift = True
     server.start()
@@ -114,8 +109,7 @@ def test_with_ctx_shift():
     (1, 2),
     (2, 2),
 ])
-def test_multi_requests_parallel(n_slots: int, n_requests: int):
-    global server
+def test_multi_requests_parallel(server, n_slots: int, n_requests: int):
     server.n_slots = n_slots
     server.start()
     tasks = []

--- a/tools/server/tests/unit/test_template.py
+++ b/tools/server/tests/unit/test_template.py
@@ -42,7 +42,7 @@ def test_reasoning(template_name: str, reasoning: Literal['on', 'off', 'auto'] |
     global server
     server.jinja = True
     server.reasoning = reasoning
-    server.chat_template_file = f'../../../models/templates/{template_name}.jinja'
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
     server.start()
 
     res = server.make_request("POST", "/apply-template", data={
@@ -65,7 +65,7 @@ def test_reasoning(template_name: str, reasoning: Literal['on', 'off', 'auto'] |
 def test_date_inside_prompt(template_name: str, format: str, tools: list[dict]):
     global server
     server.jinja = True
-    server.chat_template_file = f'../../../models/templates/{template_name}.jinja'
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
     server.start()
 
     res = server.make_request("POST", "/apply-template", data={
@@ -88,7 +88,7 @@ def test_date_inside_prompt(template_name: str, format: str, tools: list[dict]):
 def test_add_generation_prompt(template_name: str, expected_generation_prompt: str, add_generation_prompt: bool):
     global server
     server.jinja = True
-    server.chat_template_file = f'../../../models/templates/{template_name}.jinja'
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
     server.start()
 
     res = server.make_request("POST", "/apply-template", data={

--- a/tools/server/tests/unit/test_template.py
+++ b/tools/server/tests/unit/test_template.py
@@ -13,14 +13,13 @@ import datetime
 from utils import *
 from typing import Literal
 
-server: ServerProcess
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.model_alias = "tinyllama-2"
-    server.n_slots = 1
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.model_alias = "tinyllama-2"
+    s.n_slots = 1
+    return s
 
 
 @pytest.mark.parametrize("tools", [None, [], [TEST_TOOL]])
@@ -38,8 +37,7 @@ def create_server():
     ("CohereForAI-c4ai-command-r7b-12-2024-tool_use","auto", "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"),
     ("CohereForAI-c4ai-command-r7b-12-2024-tool_use", "off", "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|><|START_THINKING|><|END_THINKING|>"),
 ])
-def test_reasoning(template_name: str, reasoning: Literal['on', 'off', 'auto'] | None, expected_end: str, tools: list[dict]):
-    global server
+def test_reasoning(server, template_name: str, reasoning: Literal['on', 'off', 'auto'] | None, expected_end: str, tools: list[dict]):
     server.jinja = True
     server.reasoning = reasoning
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
@@ -62,8 +60,7 @@ def test_reasoning(template_name: str, reasoning: Literal['on', 'off', 'auto'] |
     ("meta-llama-Llama-3.3-70B-Instruct",    "%d %b %Y"),
     ("fireworks-ai-llama-3-firefunction-v2", "%b %d %Y"),
 ])
-def test_date_inside_prompt(template_name: str, format: str, tools: list[dict]):
-    global server
+def test_date_inside_prompt(server, template_name: str, format: str, tools: list[dict]):
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
     server.start()
@@ -85,8 +82,7 @@ def test_date_inside_prompt(template_name: str, format: str, tools: list[dict]):
 @pytest.mark.parametrize("template_name,expected_generation_prompt", [
     ("meta-llama-Llama-3.3-70B-Instruct",    "<|start_header_id|>assistant<|end_header_id|>"),
 ])
-def test_add_generation_prompt(template_name: str, expected_generation_prompt: str, add_generation_prompt: bool):
-    global server
+def test_add_generation_prompt(server, template_name: str, expected_generation_prompt: str, add_generation_prompt: bool):
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
     server.start()

--- a/tools/server/tests/unit/test_tokenize.py
+++ b/tools/server/tests/unit/test_tokenize.py
@@ -1,17 +1,13 @@
 import pytest
 from utils import *
 
-server = ServerPreset.tinyllama2()
+
+@pytest.fixture
+def server(server_factory):
+    return server_factory("tinyllama2")
 
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-
-
-def test_tokenize_detokenize():
-    global server
+def test_tokenize_detokenize(server):
     server.start()
     # tokenize
     content = "What is the capital of France ?"
@@ -28,8 +24,7 @@ def test_tokenize_detokenize():
     assert res_detok.body["content"].strip() == content
 
 
-def test_tokenize_with_bos():
-    global server
+def test_tokenize_with_bos(server):
     server.start()
     # tokenize
     content = "What is the capital of France ?"
@@ -42,8 +37,7 @@ def test_tokenize_with_bos():
     assert res_tok.body["tokens"][0] == bosId
 
 
-def test_tokenize_with_pieces():
-    global server
+def test_tokenize_with_pieces(server):
     server.start()
     # tokenize
     content = "This is a test string with unicode 媽 and emoji 🤗"

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -11,20 +11,17 @@ from utils import *
 from enum import Enum
 from typing import TypedDict
 
-server: ServerProcess
-
 TIMEOUT_START_SLOW = 15 * 60 # this is needed for real model tests
 TIMEOUT_HTTP_REQUEST = 60
-
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
-    server = ServerPreset.tinyllama2()
-    server.model_alias = "tinyllama-2-tool-call"
-    server.server_port = 8081
-    server.n_slots = 1
-    server.n_ctx = 8192
-    server.n_batch = 2048
+@pytest.fixture
+def server(server_factory):
+    s = server_factory('tinyllama2')
+    s.model_alias = "tinyllama-2-tool-call"
+    s.server_port = 8081
+    s.n_slots = 1
+    s.n_ctx = 8192
+    s.n_batch = 2048
+    return s
 
 class CompletionMode(Enum):
     NORMAL = "normal"
@@ -246,8 +243,7 @@ def do_test_completion_with_required_tool_tiny(server: ServerProcess, tool: dict
     (TEST_TOOL,    "success",  "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M", None),
     (PYTHON_TOOL,  "code",     "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M", None),
 ])
-def test_completion_with_required_tool_real_model(tool: dict, argument_key: str | None, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
-    global server
+def test_completion_with_required_tool_real_model(server, tool: dict, argument_key: str | None, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
     n_predict = 512
     server.jinja = True
     server.n_ctx = 8192
@@ -310,8 +306,7 @@ def do_test_completion_without_tool_call(server: ServerProcess, n_predict: int, 
     ("meta-llama-Llama-3.3-70B-Instruct",         128, [TEST_TOOL],   None),
     ("meta-llama-Llama-3.3-70B-Instruct",         128, [PYTHON_TOOL], 'none'),
 ])
-def test_completion_without_tool_call_fast(template_name: str, n_predict: int, tools: list[dict], tool_choice: str | None, stream: CompletionMode):
-    global server
+def test_completion_without_tool_call_fast(server, template_name: str, n_predict: int, tools: list[dict], tool_choice: str | None, stream: CompletionMode):
     server.n_predict = n_predict
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
@@ -332,8 +327,7 @@ def test_completion_without_tool_call_fast(template_name: str, n_predict: int, t
     ("meta-llama-Llama-3.2-3B-Instruct",              256, [TEST_TOOL],   None),
     ("meta-llama-Llama-3.2-3B-Instruct",              256, [PYTHON_TOOL], 'none'),
 ])
-def test_completion_without_tool_call_slow(template_name: str, n_predict: int, tools: list[dict], tool_choice: str | None, stream: CompletionMode):
-    global server
+def test_completion_without_tool_call_slow(server, template_name: str, n_predict: int, tools: list[dict], tool_choice: str | None, stream: CompletionMode):
     server.n_predict = n_predict
     server.jinja = True
     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
@@ -383,8 +377,7 @@ def test_completion_without_tool_call_slow(template_name: str, n_predict: int, t
 
     # ("bartowski/Llama-3.2-1B-Instruct-GGUF:Q4_K_M", ("meta-llama/Llama-3.2-3B-Instruct", None)),
 ])
-def test_weather(hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
-    global server
+def test_weather(server, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
     n_predict = 512
     server.jinja = True
     server.n_ctx = 8192
@@ -443,8 +436,7 @@ def do_test_weather(server: ServerProcess, **kwargs):
     # (None,                                           128,  "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:Q4_K_M",  None),
     # ("[\\s\\S]*?\\*\\*\\s*0.5($|\\*\\*)",            8192, "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M", None),
 ])
-def test_calc_result(result_override: str | None, n_predict: int, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
-    global server
+def test_calc_result(server, result_override: str | None, n_predict: int, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
     server.jinja = True
     server.n_ctx = 8192 * 2
     server.n_predict = n_predict
@@ -530,8 +522,7 @@ def do_test_calc_result(server: ServerProcess, result_override: str | None, n_pr
     # (1024, 'none',      CompletionMode.NORMAL,   None, "^(<think>\\s*)?I need[\\s\\S]*?</think>\\s*To find[\\s\\S]*",                 "bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF:Q4_K_M", None),
     # (128,  'deepseek',  None, "^Okay, let me figure out the sum of 102 and 7[\\s\\S]*",                      "bartowski/Qwen_QwQ-32B-GGUF:Q4_K_M",                None),
 ])
-def test_thoughts(n_predict: int, reasoning_format: Literal['deepseek', 'none'] | None, expect_content: str | None, expect_reasoning_content: str | None, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
-    global server
+def test_thoughts(server, n_predict: int, reasoning_format: Literal['deepseek', 'none'] | None, expect_content: str | None, expect_reasoning_content: str | None, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
     server.reasoning_format = reasoning_format
     server.jinja = True
     server.n_ctx = 8192 * 2
@@ -603,8 +594,7 @@ def test_thoughts(n_predict: int, reasoning_format: Literal['deepseek', 'none'] 
     ("bartowski/gemma-2-2b-it-GGUF:Q4_K_M",              None),
     ("bartowski/gemma-2-2b-it-GGUF:Q4_K_M",              "chatml"),
 ])
-def test_hello_world(hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
-    global server
+def test_hello_world(server, hf_repo: str, template_override: str | Tuple[str, str | None] | None, stream: CompletionMode):
     n_predict = 512 # High because of DeepSeek R1
     server.jinja = True
     server.n_ctx = 8192

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -144,7 +144,7 @@ def do_test_completion_with_required_tool_tiny(server: ServerProcess, tool: dict
 #     # server = ServerPreset.stories15m_moe()
 #     server.jinja = True
 #     server.n_predict = n_predict
-#     server.chat_template_file = f'../../../models/templates/{template_name}.jinja'
+#     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
 #     server.start()
 #     do_test_completion_with_required_tool_tiny(server, tool, argument_key, n_predict, stream=stream == CompletionMode.STREAMED, temperature=0.0, top_k=1, top_p=1.0)
 
@@ -187,7 +187,7 @@ def do_test_completion_with_required_tool_tiny(server: ServerProcess, tool: dict
 #     # server = ServerPreset.stories15m_moe()
 #     server.jinja = True
 #     server.n_predict = n_predict
-#     server.chat_template_file = f'../../../models/templates/{template_name}.jinja'
+#     server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
 #     server.start(timeout_seconds=TIMEOUT_START_SLOW)
 #     do_test_completion_with_required_tool_tiny(server, tool, argument_key, n_predict, stream=stream == CompletionMode.STREAMED)
 
@@ -256,7 +256,7 @@ def test_completion_with_required_tool_real_model(tool: dict, argument_key: str 
     server.model_hf_file = None
     if isinstance(template_override, tuple):
         (template_hf_repo, template_variant) = template_override
-        server.chat_template_file = f"../../../models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
+        server.chat_template_file = f"{LLAMA_CPP_ROOT}/models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
         assert os.path.exists(server.chat_template_file), f"Template file {server.chat_template_file} does not exist. Run `python scripts/get_chat_template.py {template_hf_repo} {template_variant} > {server.chat_template_file}` to download the template."
     elif isinstance(template_override, str):
         server.chat_template = template_override
@@ -314,7 +314,7 @@ def test_completion_without_tool_call_fast(template_name: str, n_predict: int, t
     global server
     server.n_predict = n_predict
     server.jinja = True
-    server.chat_template_file = f'../../../models/templates/{template_name}.jinja'
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
     server.start()
     do_test_completion_without_tool_call(server, n_predict, tools, tool_choice, stream=stream == CompletionMode.STREAMED)
 
@@ -336,7 +336,7 @@ def test_completion_without_tool_call_slow(template_name: str, n_predict: int, t
     global server
     server.n_predict = n_predict
     server.jinja = True
-    server.chat_template_file = f'../../../models/templates/{template_name}.jinja'
+    server.chat_template_file = f'{LLAMA_CPP_ROOT}/models/templates/{template_name}.jinja'
     server.start(timeout_seconds=TIMEOUT_START_SLOW)
     do_test_completion_without_tool_call(server, n_predict, tools, tool_choice, stream=stream == CompletionMode.STREAMED)
 
@@ -393,7 +393,7 @@ def test_weather(hf_repo: str, template_override: str | Tuple[str, str | None] |
     server.model_hf_file = None
     if isinstance(template_override, tuple):
         (template_hf_repo, template_variant) = template_override
-        server.chat_template_file = f"../../../models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
+        server.chat_template_file = f"{LLAMA_CPP_ROOT}/models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
         assert os.path.exists(server.chat_template_file), f"Template file {server.chat_template_file} does not exist. Run `python scripts/get_chat_template.py {template_hf_repo} {template_variant} > {server.chat_template_file}` to download the template."
     elif isinstance(template_override, str):
         server.chat_template = template_override
@@ -452,7 +452,7 @@ def test_calc_result(result_override: str | None, n_predict: int, hf_repo: str, 
     server.model_hf_file = None
     if isinstance(template_override, tuple):
         (template_hf_repo, template_variant) = template_override
-        server.chat_template_file = f"../../../models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
+        server.chat_template_file = f"{LLAMA_CPP_ROOT}/models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
         assert os.path.exists(server.chat_template_file), f"Template file {server.chat_template_file} does not exist. Run `python scripts/get_chat_template.py {template_hf_repo} {template_variant} > {server.chat_template_file}` to download the template."
     elif isinstance(template_override, str):
         server.chat_template = template_override
@@ -540,7 +540,7 @@ def test_thoughts(n_predict: int, reasoning_format: Literal['deepseek', 'none'] 
     server.model_hf_file = None
     if isinstance(template_override, tuple):
         (template_hf_repo, template_variant) = template_override
-        server.chat_template_file = f"../../../models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
+        server.chat_template_file = f"{LLAMA_CPP_ROOT}/models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
         assert os.path.exists(server.chat_template_file), f"Template file {server.chat_template_file} does not exist. Run `python scripts/get_chat_template.py {template_hf_repo} {template_variant} > {server.chat_template_file}` to download the template."
     elif isinstance(template_override, str):
         server.chat_template = template_override
@@ -613,7 +613,7 @@ def test_hello_world(hf_repo: str, template_override: str | Tuple[str, str | Non
     server.model_hf_file = None
     if isinstance(template_override, tuple):
         (template_hf_repo, template_variant) = template_override
-        server.chat_template_file = f"../../../models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
+        server.chat_template_file = f"{LLAMA_CPP_ROOT}/models/templates/{template_hf_repo.replace('/', '-') + ('-' + template_variant if template_variant else '')}.jinja"
         assert os.path.exists(server.chat_template_file), f"Template file {server.chat_template_file} does not exist. Run `python scripts/get_chat_template.py {template_hf_repo} {template_variant} > {server.chat_template_file}` to download the template."
     elif isinstance(template_override, str):
         server.chat_template = template_override

--- a/tools/server/tests/unit/test_vision_api.py
+++ b/tools/server/tests/unit/test_vision_api.py
@@ -3,8 +3,6 @@ from utils import *
 import base64
 import requests
 
-server: ServerProcess
-
 def get_img_url(id: str) -> str:
     IMG_URL_0 = "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/test/11_truck.png"
     IMG_URL_1 = "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/test/91_cat.png"
@@ -34,14 +32,12 @@ def get_img_url(id: str) -> str:
 JSON_MULTIMODAL_KEY = "multimodal_data"
 JSON_PROMPT_STRING_KEY = "prompt_string"
 
-@pytest.fixture(autouse=True)
-def create_server():
-    global server
+@pytest.fixture
+def server(server_factory):
     os.environ['LLAMA_MEDIA_MARKER'] = '<__media__>'
-    server = ServerPreset.tinygemma3()
+    return server_factory('tinygemma3')
 
-def test_models_supports_multimodal_capability():
-    global server
+def test_models_supports_multimodal_capability(server):
     server.start()
     res = server.make_request("GET", "/models", data={})
     assert res.status_code == 200
@@ -50,8 +46,7 @@ def test_models_supports_multimodal_capability():
     assert "completion" in model_info["capabilities"]
     assert "multimodal" in model_info["capabilities"]
 
-def test_v1_models_supports_multimodal_capability():
-    global server
+def test_v1_models_supports_multimodal_capability(server):
     server.start()
     res = server.make_request("GET", "/v1/models", data={})
     assert res.status_code == 200
@@ -74,8 +69,7 @@ def test_v1_models_supports_multimodal_capability():
         # TODO @ngxson : test with multiple images, no images and with audio
     ]
 )
-def test_vision_chat_completion(prompt, image_url, success, re_content):
-    global server
+def test_vision_chat_completion(server, prompt, image_url, success, re_content):
     server.start()
     res = server.make_request("POST", "/chat/completions", data={
         "temperature": 0.0,
@@ -108,8 +102,7 @@ def test_vision_chat_completion(prompt, image_url, success, re_content):
         ("What is this:\n",             "",                     False, None), # empty string
     ]
 )
-def test_vision_completion(prompt, image_data, success, re_content):
-    global server
+def test_vision_completion(server, prompt, image_data, success, re_content):
     server.start()
     res = server.make_request("POST", "/completions", data={
         "temperature": 0.0,
@@ -137,8 +130,7 @@ def test_vision_completion(prompt, image_data, success, re_content):
         ("What is this:\n",             "base64",               False), # non-image data
     ]
 )
-def test_vision_embeddings(prompt, image_data, success):
-    global server
+def test_vision_embeddings(server, prompt, image_data, success):
     server.server_embeddings = True
     server.n_batch = 512
     server.start()

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -6,7 +6,6 @@
 import subprocess
 import os
 
-TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmp")
 import re
 import json
 from json import JSONDecodeError
@@ -14,6 +13,7 @@ import sys
 import requests
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -30,6 +30,10 @@ import wget
 
 
 DEFAULT_HTTP_TIMEOUT = 60
+LLAMA_CPP_ROOT = Path(__file__).resolve().parents[3]
+
+
+TESTS_TMP_DIR = str(LLAMA_CPP_ROOT / "tools/server/tests/tmp")
 
 
 class ServerResponse:
@@ -126,7 +130,7 @@ class ServerProcess:
     def start(self, timeout_seconds: int = DEFAULT_HTTP_TIMEOUT) -> None:
         env = {**os.environ}
         if "LLAMA_CACHE" not in os.environ:
-            env["LLAMA_CACHE"] = "tmp"
+            env["LLAMA_CACHE"] = TESTS_TMP_DIR
         if self.external_server:
             print(f"[external_server]: Assuming external server running on {self.server_host}:{self.server_port}")
             return
@@ -135,9 +139,9 @@ class ServerProcess:
         elif "LLAMA_SERVER_BIN_PATH" in os.environ:
             server_path = os.environ["LLAMA_SERVER_BIN_PATH"]
         elif os.name == "nt":
-            server_path = "../../../build/bin/Release/llama-server.exe"
+            server_path = str(LLAMA_CPP_ROOT / "build/bin/Release/llama-server.exe")
         else:
-            server_path = "../../../build/bin/llama-server"
+            server_path = str(LLAMA_CPP_ROOT / "build/bin/llama-server")
         server_args = [
             "--host",
             self.server_host,
@@ -668,7 +672,7 @@ def download_file(url: str, output_file_path: str | None = None) -> str:
     Returns the local path of the downloaded file.
     """
     file_name = url.split('/').pop()
-    output_file = f'./tmp/{file_name}' if output_file_path is None else output_file_path
+    output_file = f'{TESTS_TMP_DIR}/{file_name}' if output_file_path is None else output_file_path
     if not os.path.exists(output_file):
         print(f"Downloading {url} to {output_file}")
         wget.download(url, out=output_file)

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -680,7 +680,3 @@ def download_file(url: str, output_file_path: str | None = None) -> str:
     else:
         print(f"File already exists at {output_file}")
     return output_file
-
-
-def is_slow_test_allowed():
-    return os.environ.get("SLOW_TESTS") == "1" or os.environ.get("SLOW_TESTS") == "ON"


### PR DESCRIPTION
## Overview

This modifies the server tests to:
- allow tests to be run from the top directory,
- homogenize slow test filtering (`slow` `pytest` marker versus explicit `SLOW_TESTS` environment variable),
- cleanup `pytest` fixtures previously migrated from `behave`.

The first change is mostly to improve the developer experience (I like to run everything from the top dir).
The second change is for consistency: make sure all slow/non slow tests can be selected unambiguously with a single pytest idiom.
The third change is mainly an alignment on pytest fixture conventions, but it also prepares a future pull-request where I plan to include the slow tests model fetch directly in a pytest fixture, instead of relying on an external script.

Finally, I also extended a matching pattern to fix a flaky test.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. I asked a code agent to go through the tests and CI workflows to identify the relevant patterns. I also asked it to replicate changes I had made to test_basic.py.