### PR TITLE
mmvq Optim:  add MMVQ_PARAMETERS_TURING(mmvq_parameter_table_id) for …

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -99,7 +99,7 @@ static __host__ mmvq_parameter_table_id get_device_table_id(int cc) {
     if (GGML_CUDA_CC_IS_GCN(cc) || GGML_CUDA_CC_IS_CDNA(cc)) {
         return MMVQ_PARAMETERS_GCN;
     }
-    if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_TURING && cc < GGML_CUDA_CC_AMPERE) {
+    if (GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_TURING && ggml_cuda_highest_compiled_arch(cc) < GGML_CUDA_CC_AMPERE) {
         return MMVQ_PARAMETERS_TURING;
     }
     return MMVQ_PARAMETERS_GENERIC;

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -63,6 +63,7 @@ static constexpr __host__ __device__ int get_vdr_mmvq(ggml_type type) {
 
 enum mmvq_parameter_table_id {
     MMVQ_PARAMETERS_GENERIC = 0,
+    MMVQ_PARAMETERS_TURING,
     MMVQ_PARAMETERS_GCN,
     MMVQ_PARAMETERS_RDNA2,
     MMVQ_PARAMETERS_RDNA3_0,
@@ -78,6 +79,8 @@ static constexpr __device__ mmvq_parameter_table_id get_device_table_id() {
     return MMVQ_PARAMETERS_RDNA2;
 #elif defined(GCN) || defined(CDNA)
     return MMVQ_PARAMETERS_GCN;
+#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_TURING && __CUDA_ARCH__ < GGML_CUDA_CC_AMPERE
+    return MMVQ_PARAMETERS_TURING;
 #else
     return MMVQ_PARAMETERS_GENERIC;
 #endif
@@ -95,6 +98,9 @@ static __host__ mmvq_parameter_table_id get_device_table_id(int cc) {
     }
     if (GGML_CUDA_CC_IS_GCN(cc) || GGML_CUDA_CC_IS_CDNA(cc)) {
         return MMVQ_PARAMETERS_GCN;
+    }
+    if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_TURING && cc < GGML_CUDA_CC_AMPERE) {
+        return MMVQ_PARAMETERS_TURING;
     }
     return MMVQ_PARAMETERS_GENERIC;
 }
@@ -370,11 +376,38 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
         }
         return 1;
     }
+    if (table_id == MMVQ_PARAMETERS_TURING) {
+        if (ncols_dst == 1) {
+            switch (type) {
+                case GGML_TYPE_Q2_K:
+                case GGML_TYPE_Q3_K:
+                case GGML_TYPE_Q4_K:
+                case GGML_TYPE_Q5_K:
+                case GGML_TYPE_Q6_K:
+                    return 2;
+                default:
+                    return 4;
+            }
+        }
+        switch (ncols_dst) {
+            case 2:
+            case 3:
+            case 4:
+                return 4;
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+                return 2;
+            default:
+                return 1;
+        }
+    }
     return 1;
 }
 
 static constexpr __host__ __device__ int calc_rows_per_block(int ncols_dst, int table_id, bool small_k = false, int nwarps = 1) {
-    if (table_id == MMVQ_PARAMETERS_GENERIC || table_id == MMVQ_PARAMETERS_GCN) {
+    if (table_id == MMVQ_PARAMETERS_GENERIC || table_id == MMVQ_PARAMETERS_GCN || table_id == MMVQ_PARAMETERS_TURING) {
         switch (ncols_dst) {
             case 1:
                 return small_k ? nwarps : 1;


### PR DESCRIPTION
adds MMVQ_PARAMETERS_TURING for SM75

## Overview
While profiling Qwen3-0.6B Q4_K_M on a GTX 1660 (SM75) with
`ncu --set launch_stats`, I noticed that `mmvq<12,1,1,1>` uses
89 registers/thread — far above the 64-register threshold — causing
SM occupancy to drop from 1698 to 668 (−61%):

| Kernel | block | reg/thread | Occupancy |
|--------|-------|-----------|-----------|
| `mmvq<12,1,1,1>` (Q4_K, has_fusion, small_k) | 128 | **89** | **668** |
| `mmvq<12,1,0,1>` (Q4_K, no fusion, small_k)  | 128 | 64 | 1698 |
| `mmvq<2,1,1,1>`  (Q4_0, control)              | 128 | 64 | 1656 |

Adjusting the `nwarps`（4->2） parameter resolved this issue. warp_occ also shows a slight increase.

### what I do

I adds MMVQ_PARAMETERS_TURING for SM75, tuning nwarps from 4 to 2 for K-quant types (Q2_K–Q6_K). Following optimization, the inference throughput (tg) for Qwen3-4B Q4_K_M increased by 6.2%, while that of Qwen3-0.6B Q5_K_M rose by 8.3%.   
#### related PR: https://github.com/ggml-org/llama.cpp/pull/23349

## Benchmark and ncu profiling data

Hardware: NVIDIA GeForce GTX 1660 (SM75), 6 GiB VRAM, CUDA 12.8
Models: Qwen3-0.6B, Qwen3-4B (ggml-org/Qwen3-GGUF)
Params: pp=512, n=128, ngl=99, r=5
| computer | value |
|------|----|
| GPU | NVIDIA GeForce GTX 1660 (SM75, Turing) |
| VRAM | 6 GiB |
| CUDA | 12.8 |
| ncu | Nsight Compute 2025.1.0 |
| baseline commit | `ef93e98d` (MMVQ_PARAMETERS_GENERIC, nwarps=4) |
| optimized commit | `e0173129` (MMVQ_PARAMETERS_TURING, nwarps=2) |
|  cpu | CPU: Intel Core i7-8700 @ 3.20GH |
|  mem | 32 GiB |

### Token Generation (tg128)
Qwen3-4B_Q5_K_M is too big for 6 GiB VRAM,so I do not test it.

| model | quant | size | before (t/s) | after (t/s) | delta |
|-------|-------|------|--------------|-------------|-------|
| Qwen3-4B   | Q4_K_M | 2.32 GiB | 51.81 ± 0.01 | **55.05 ± 0.03** | **+6.2%** |
| Qwen3-4B   | Q5_K_M | 2.69 GiB | 47.63 ± 0.01 | **49.18 ± 0.02** | **+3.3%** |
| Qwen3-4B   | Q4_0   | 2.20 GiB | 55.38 ± 0.01 | 55.69 ± 0.01 | ~0% (control) |
| Qwen3-4B   | Q8_0   | 3.98 GiB | 35.51 ± 0.00 | 35.51 ± 0.00 | ~0% (control) |
| Qwen3-0.6B | Q4_K_M | 373 MiB  | 223.36 ± 3.02 | **225.31 ± 0.15** | +0.9% |
| Qwen3-0.6B | Q5_K_M | 418 MiB  | 195.37 ± 0.24 | **211.63 ± 0.31** | **+8.3%** |
| Qwen3-0.6B | Q6_K   | 467 MiB  | 189.86 ± 0.07 | **195.11 ± 0.30** | **+2.8%** |
| Qwen3-0.6B | Q4_0   | 358 MiB  | 226.76 ± 0.80 | 227.61 ± 0.42 | ~0% (control) |

### Prompt Processing (pp512) — unaffected 
 pp unaffected by my pr

| model | quant | before (t/s) | after (t/s) | delta |
|-------|-------|--------------|-------------|-------|
| Qwen3-4B   | Q4_K_M | 242.39 ± 0.02 | 240.57 ± 0.16 | ~0% |
| Qwen3-4B   | Q5_K_M | 242.28 ± 0.55 | 242.03 ± 0.02 | ~0% |
| Qwen3-0.6B | Q5_K_M | 1397.39 ± 0.56 | 1397.85 ± 0.94 | ~0% |
| Qwen3-0.6B | Q6_K   | 1396.93 ± 3.53 | 1397.44 ± 2.87 | ~0% |


### ncu Profiling — Qwen3-0.6B Q4_K_M

Before (nwarps=4):

| Kernel | block | reg/thread | Occupancy |
|--------|-------|-----------|-----------|
| `mmvq<12,1,0,0>` | 128 | 36 | 1698 |
| `mmvq<12,1,0,1>` | 128 | 64 | 1698 |
| `mmvq<12,1,1,0>` | 128 | 50 | 1698 |
| `mmvq<12,1,1,1>` | 128 | **89** | **668** |

After (nwarps=2):

| Kernel | block | reg/thread | Occupancy |
|--------|-------|-----------|-----------|
| `mmvq<12,1,0,0>` | 64 | 41 | 1698 |
| `mmvq<12,1,1,0>` | 64 | 50 | 1698 |
| `mmvq<14,1,0,0>` | 64 | 44 | 1698 |
| `mmvq<14,1,1,0>` | 64 | 45 | 1698 |

`mmvq<12,1,1,1>` (reg=89, Occupancy=668) **completely eliminated**.
All kernels restored to full occupancy (1698).

### ncu Profiling — Qwen3-4B Q4_K_M
`ncu --set launch_stats --export ... llama-bench -m Qwen3-4B-Q4_K_M.gguf -p 1 -n 4 -ngl 99 -r 1 --no-warmup`
#### before
| Kernel | block | reg | smem_bytes | smem_ld_wf | smem_st_wf | warp_occ% |
|--------|-------|-----|-----------|-----------|-----------|----------|
| `mmvq<12,1,0,0>` | 128 | 36 | 384 | 12288 | 12288 | 83.25 |
| `mmvq<14,1,0,0>` | 128 | 42 | 384 | 3072 | 3072 | 87.71 |
| `mmvq<12,1,1,0>` | 128 | 50 | 768 | 7680 | 7680 | 87.79 |
| `mmvq<14,1,1,0>` | 128 | 43 | 768 | 7680 | 7680 | 94.09 |
#### after
| Kernel | block | reg | smem_bytes | smem_ld_wf | smem_st_wf | warp_occ% |
|--------|-------|-----|-----------|-----------|-----------|----------|
| `mmvq<12,1,0,0>` | 64 | 41 | 128 | 4096 | 4096 | 89.48 |
| `mmvq<14,1,0,0>` | 64 | 44 | 128 | 1024 | 1024 | 89.42 |
| `mmvq<12,1,1,0>` | 64 | 50 | 256 | 2560 | 2560 | 90.77 |
| `mmvq<14,1,1,0>` | 64 | 45 | 256 | 2560 | 2560 | 94.24 |
#### contrast

 
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES，I used AI tools to familiarize myself with potentially problematic code in the early stages, and later help me to wiriting bash scripts to assist in testing. I manually performed comprehensive tests on the qwen 0.6B and 4B models using the Q4_K_M through Q6_K_M quantization schemes, and also conducted full-scale NCU profiling both before and after optimization. 
 Code changes were manually written and verified by myself one line by oneline.

