### PR TITLE
cuda: VMM-backed allocator for weight buffers (opt-in via GGML_CUDA_VMM_BUFFERS)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -580,6 +580,91 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
     }
 };
+
+// ----------------------------------------------------------------------------
+// VMM-backed allocator for long-lived buffers (weight tensors).
+//
+// Unlike ggml_cuda_pool_vmm above, which is a LIFO scratch pool for transient
+// compute allocations, this helper allocates an isolated VA region + single
+// physical handle per buffer. Each buffer's lifetime is independent and freed
+// in arbitrary order (model unload).
+//
+// Motivation: on L4T 36.4.7 the CVE-2025-33177 NvMap patch rejects large
+// single-shot cudaMalloc requests. Empirically (driver-API probe at
+// `cuMemCreate`+`cuMemMap` on Jetson Orin Nano Super 8GB, see
+// distributed-torch/runs/vmm_spike_20260513T162324Z/), the VMM API bypasses
+// the cap up to the physical memory ceiling. This helper lets weight buffers
+// take the same path.
+//
+// Beyond Jetson, the VMM path is also useful on long-running desktop servers
+// where the legacy cudaMalloc allocator fragments — analogous to PyTorch's
+// PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True.
+struct ggml_cuda_vmm_buffer {
+    int device = -1;
+    CUdeviceptr addr = 0;          // mapped VA base (also returned as void* to ggml-backend)
+    size_t mapped_size = 0;        // bytes mapped / accessible (granularity-aligned)
+    CUmemGenericAllocationHandle handle = 0;
+    bool valid = false;
+};
+
+// Allocate `size` bytes of VMM-backed device memory on `device`.
+// On success, fills *out with handle/addr/mapped_size and returns CUDA_SUCCESS.
+// On failure, leaves *out invalid (valid=false) and returns the CUresult so
+// the caller can fall back to cudaMalloc with diagnostic info.
+static CUresult ggml_cuda_vmm_alloc_buffer(ggml_cuda_vmm_buffer * out, size_t size, int device) {
+    out->device = device;
+    out->valid = false;
+
+    CUmemAllocationProp prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = device;
+
+    const size_t granularity = ggml_cuda_info().devices[device].vmm_granularity;
+    if (granularity == 0) {
+        return CUDA_ERROR_NOT_SUPPORTED;
+    }
+    const size_t aligned = ((size + granularity - 1) / granularity) * granularity;
+
+    CUresult r = cuMemCreate(&out->handle, aligned, &prop, 0);
+    if (r != CUDA_SUCCESS) return r;
+
+    r = cuMemAddressReserve(&out->addr, aligned, 0, 0, 0);
+    if (r != CUDA_SUCCESS) {
+        (void)cuMemRelease(out->handle);
+        return r;
+    }
+
+    r = cuMemMap(out->addr, aligned, 0, out->handle, 0);
+    if (r != CUDA_SUCCESS) {
+        (void)cuMemAddressFree(out->addr, aligned);
+        (void)cuMemRelease(out->handle);
+        return r;
+    }
+
+    CUmemAccessDesc adesc = {};
+    adesc.location = prop.location;
+    adesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    r = cuMemSetAccess(out->addr, aligned, &adesc, 1);
+    if (r != CUDA_SUCCESS) {
+        (void)cuMemUnmap(out->addr, aligned);
+        (void)cuMemAddressFree(out->addr, aligned);
+        (void)cuMemRelease(out->handle);
+        return r;
+    }
+
+    out->mapped_size = aligned;
+    out->valid = true;
+    return CUDA_SUCCESS;
+}
+
+static void ggml_cuda_vmm_free_buffer(ggml_cuda_vmm_buffer * b) {
+    if (!b->valid) return;
+    CU_CHECK(cuMemUnmap(b->addr, b->mapped_size));
+    CU_CHECK(cuMemAddressFree(b->addr, b->mapped_size));
+    CU_CHECK(cuMemRelease(b->handle));
+    b->valid = false;
+}
 #endif // defined(GGML_USE_VMM)
 
 std::unique_ptr<ggml_cuda_pool> ggml_backend_cuda_context::new_pool_for_device(int                  device,
@@ -625,6 +710,11 @@ struct ggml_backend_cuda_buffer_context {
     int device;
     void * dev_ptr = nullptr;
     std::string name;
+#if defined(GGML_USE_VMM)
+    // When valid, this buffer was allocated via the VMM API (cuMemCreate/cuMemMap)
+    // rather than cudaMalloc. Destructor dispatches on vmm.valid.
+    ggml_cuda_vmm_buffer vmm{};
+#endif
 
     ggml_backend_cuda_buffer_context(int device, void * dev_ptr) :
         device(device), dev_ptr(dev_ptr),
@@ -632,6 +722,12 @@ struct ggml_backend_cuda_buffer_context {
     }
 
     ~ggml_backend_cuda_buffer_context() {
+#if defined(GGML_USE_VMM)
+        if (vmm.valid) {
+            ggml_cuda_vmm_free_buffer(&vmm);
+            return;
+        }
+#endif
         CUDA_CHECK(cudaFree(dev_ptr));
     }
 };
@@ -776,19 +872,59 @@ static bool ggml_backend_buft_is_cuda(ggml_backend_buffer_type_t buft) {
 
 static ggml_backend_buffer_t ggml_backend_cuda_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
     ggml_backend_cuda_buffer_type_context * buft_ctx = (ggml_backend_cuda_buffer_type_context *)buft->context;
+    const int device = buft_ctx->device;
 
-    ggml_cuda_set_device(buft_ctx->device);
+    ggml_cuda_set_device(device);
+
+#if defined(GGML_USE_VMM)
+    // GGML_CUDA_VMM_BUFFERS=1 routes weight-buffer allocations through the CUDA
+    // VMM API (cuMemCreate / cuMemAddressReserve / cuMemMap / cuMemSetAccess),
+    // analogous to PyTorch's PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True.
+    // Two benefits, both empirically validated:
+    //   (1) on L4T 36.4.7 Jetson, bypasses the CVE-2025-33177 NvMap allocation-
+    //       tracking cap that rejects large single-shot cudaMalloc requests
+    //       (see discussion #16706). cuMemCreate uses a different kernel path
+    //       not gated by the patch.
+    //   (2) the larger benefit: large weight buffers going through VMM leaves
+    //       cudaMalloc's NvMap budget free for the smaller compute / KV-cache
+    //       buffers that still need it (which is critical on memory-tight
+    //       Jetson with hostile page-cache pressure). Recommended companion
+    //       flags: `--no-mmap` to keep GGUF off the page cache during load,
+    //       and `echo 3 > /proc/sys/vm/drop_caches` before launch.
+    // Default off; explicit opt-in until soak-tested. Falls back to cudaMalloc
+    // on VMM failure (preserves graceful degradation on older CUDA drivers /
+    // unsupported topologies).
+    if (getenv("GGML_CUDA_VMM_BUFFERS") != nullptr && ggml_cuda_info().devices[device].vmm) {
+        ggml_cuda_vmm_buffer v;
+        const CUresult vr = ggml_cuda_vmm_alloc_buffer(&v, size, device);
+        if (vr == CUDA_SUCCESS) {
+            static bool announced = false;
+            if (!announced) {
+                announced = true;
+                GGML_LOG_INFO("%s: GGML_CUDA_VMM_BUFFERS=1 — weight-buffer allocations using cuMemCreate (first %.2f MiB succeeded on device %d)\n",
+                              __func__, size / 1024.0 / 1024.0, device);
+            }
+            ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(device, (void *)v.addr);
+            ctx->vmm = v;
+            return ggml_backend_buffer_init(buft, ggml_backend_cuda_buffer_interface, ctx, size);
+        }
+        const char * es = nullptr;
+        cuGetErrorString(vr, &es);
+        GGML_LOG_WARN("%s: VMM alloc of %.2f MiB on device %d failed (%s); falling back to cudaMalloc\n",
+                      __func__, size / 1024.0 / 1024.0, device, es ? es : "(no string)");
+    }
+#endif
 
     void * dev_ptr;
-    cudaError_t err = ggml_cuda_device_malloc(&dev_ptr, size, buft_ctx->device);
+    cudaError_t err = ggml_cuda_device_malloc(&dev_ptr, size, device);
     if (err != cudaSuccess) {
         // clear the error
         (void)cudaGetLastError();
-        GGML_LOG_ERROR("%s: allocating %.2f MiB on device %d: cudaMalloc failed: %s\n", __func__, size / 1024.0 / 1024.0, buft_ctx->device, cudaGetErrorString(err));
+        GGML_LOG_ERROR("%s: allocating %.2f MiB on device %d: cudaMalloc failed: %s\n", __func__, size / 1024.0 / 1024.0, device, cudaGetErrorString(err));
         return nullptr;
     }
 
-    ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(buft_ctx->device, dev_ptr);
+    ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(device, dev_ptr);
 
     return ggml_backend_buffer_init(buft, ggml_backend_cuda_buffer_interface, ctx, size);
 }


### PR DESCRIPTION
## Summary

Adds an opt-in allocation path for weight buffers that uses the CUDA Virtual Memory Management API (`cuMemCreate` / `cuMemAddressReserve` / `cuMemMap` / `cuMemSetAccess`) instead of `cudaMalloc`. Enabled via `GGML_CUDA_VMM_BUFFERS=1`. Default off until soak-tested. The mechanism is the same one PyTorch's `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` already exploits.

Single-file change: `ggml/src/ggml-cuda/ggml-cuda.cu` (~140 insertions, 4 deletions). The VMM primitives are already in-tree for the scratch pool (`ggml_cuda_pool_vmm`, since 2024); this PR adds a per-buffer variant with arbitrary-order free, then routes `ggml_backend_cuda_buffer_type_alloc_buffer` through it when the env var is set and the device reports `vmm: yes`.

## Motivation: discussion #16706 and CVE-2025-33177

[Discussion #16706](https://github.com/ggml-org/llama.cpp/discussions/16706) and many downstream reports describe gemma-3n loads failing on Jetson L4T 36.4.7+ with:

```
NvMapMemAllocInternalTagged: 1075072515 error 12
NvMapMemHandleAlloc: error 0
cudaMalloc failed: out of memory
```

The L4T 36.4.7 release shipped a security fix for **CVE-2025-33177** (NvMap "improper tracking of memory allocations could allow a local attacker to cause memory overallocation", CWE-400 Uncontrolled Resource Consumption). NVIDIA staff confirmed on the [developer forum](https://forums.developer.nvidia.com/t/intermittent-nvmapmemalloc-error-12-and-cuda-allocator-crash-during-pytorch-inference-on-jetson-orin-nano/349752): *"The security fix adds a mechanism to prevent allocation from going into the OOM path. This led to some limitations in allocable memory."* The check rejects `cudaMalloc` requests once cumulative NvMap-tracked pressure approaches a safety budget, even when actual free physical memory is well above the request size.

`cuMemCreate` uses a different kernel allocation path not gated by the patch. PyTorch already exploits this via expandable_segments; this PR brings the same bypass to llama.cpp.

## Empirical evidence

### 1. Driver-API VMM bypass (isolated probe)

Standalone CUDA driver-API probe on Jetson Orin Nano Super 8 GB, L4T 36.4.7, fresh process, fresh page cache:

| API                          | 256 → 5632 MiB sweep |
|------------------------------|----------------------|
| `cudaMalloc`                 | 5120 MiB pass, **5376 MiB fail** with `NvMapMemAllocInternalTagged` |
| `cuMemCreate` + `cuMemMap`   | **22/22 pass**, zero NvMap errors in stderr |

The VMM path doesn't trigger the patched code at the sizes that matter for real model loads.

### 2. End-to-end Gemma-3n-E2B-it Q4_K_XL (the #16706 case)

Same hardware, same `--no-mmap` flag, same `-ngl 99`, page caches dropped before each run. Only difference: `GGML_CUDA_VMM_BUFFERS=1`.

| run | env var | result |
|---|---|---|
| baseline | none | **SIGSEGV** after `cudaMalloc failed` on the 520 MiB compute buffer |
| patched | `GGML_CUDA_VMM_BUFFERS=1` | **loads + generates coherent output** at 22.3 tok/s |

### 3. TinyLlama byte-identity smoke

Same deterministic args (seed 42, temp 0), with vs without `GGML_CUDA_VMM_BUFFERS=1`. Generated text is **byte-identical**; the only `diff` is the throughput line (run-to-run jitter). Memory accounting shifts by ~30 MiB (VMM granularity / VA bookkeeping), as expected.

### 4. Cross-framework evidence: PyTorch FSDP also hits the cap

Worth noting for upstream context — this isn't a llama.cpp-specific issue. The same kernel-side NvMap cap fires on PyTorch workloads with similar allocation patterns. We captured an FSDP1 + bnb-NF4 + LoRA training run (TinyLlama 1.1B at WS=4) failing on the same Jetson Orin Nano Super 8 GB / L4T 36.4.7 host during the first FSDP all-gather, with the byte-identical PyTorch caching-allocator failure mode:

```
RuntimeError: NVML_SUCCESS == r INTERNAL ASSERT FAILED at CUDACachingAllocator.cpp:995
```

Memory state at failure: 988 MB allocated peak, 1024 MB reserved, 388 MB free, 3.2 GiB page-cached. The all-gather request was ~188 MB at bf16, far below any byte-count cap — but page-cache pressure had compressed the dynamic cap below that size.

PyTorch users can mitigate with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` (routes torch's caching allocator through the same CUDA VMM API this PR uses). The cross-framework pattern is *"don't use cudaMalloc for large or pressured allocations on post-CVE-2025-33177 Tegra"* — and this PR brings the same mitigation to llama.cpp.

**End-to-end mitigation validated on the same hardware** (2026-05-13 PM): the same WS=4 FSDP+bnb-NF4 training workload that crashed without the env var ran cleanly with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` set across all 4 ranks — 30 SGD steps end-to-end, loss descended, zero allocator retries, zero OOMs across 7 memory snapshots including on the 36.4.7 host. PyTorch's VMM-API path works decisively for real workloads, not just synthetic probes; this PR brings the equivalent path to llama.cpp.

## Mechanism (the part that surprised us)

The patch isn't just "use VMM for weight buffers because cudaMalloc fails for them." Reading the debug traces revealed a more nuanced picture:

In the failing baseline run, the four allocations are 1533.76 + 256 + 32 + 520 MiB. The first three each succeed under `cudaMalloc` individually. By the time the fourth (520 MiB) arrives, **1821 MiB has already gone through cudaMalloc** — and NvMap's safety budget refuses it.

Under the patched run, the same first three allocations succeed under `cuMemCreate`. When the fourth 520 MiB allocation arrives, `cuMemCreate` *also* fails (it hits a cumulative limit). But the WARN-and-fall-back path then issues a `cudaMalloc(520 MiB)` and **it succeeds**, because the cudaMalloc-tracked counter is near zero — by routing the earlier large requests through VMM, the patched run kept cudaMalloc's running total clean.

**Important refinement** (per follow-up controlled cumulative tests): cuMemCreate and cudaMalloc fail at the *same* cumulative threshold (~3.84 GiB on Orin Nano Super 8 GB). The two APIs do not have independent unlimited budgets. The mechanism the patch exploits is:

- **Per-allocation cap is API-specific.** `cuMemCreate` accepts ~5.5 GiB single-shot allocations that `cudaMalloc` rejects at ~5.4 GiB. The CVE-2025-33177 patch sits in the `cudaMalloc` → NvMap entry, not in the VMM API entry.
- **Cumulative cap is API-shared (or identically thresholded).** Once cumulative committed memory reaches ~3.84 GiB, neither API accepts further allocations regardless of size.
- **Strategic routing matters.** By routing the large weight buffers through `cuMemCreate`, the patch keeps cudaMalloc's running counter near zero — so when smaller compute / KV-cache buffers arrive later that legitimately need cudaMalloc (or where VMM has hit its cumulative limit), cudaMalloc has headroom to satisfy them as isolated requests.

The net effect is the same as the dual-budget story, but the mechanism is sharper: it's not "two budgets we can both fill," it's "API-specific per-allocation thresholds against a shared cumulative ceiling, where routing strategy determines which API has headroom at the moment of each request."

## Design notes

- **Per-buffer model**: each `ggml_backend_cuda_buffer_context` owns its own VA reservation + single physical handle, freed in arbitrary order on model unload. The existing `ggml_cuda_pool_vmm` is LIFO-only by design (scratch); weight buffers need arbitrary-order free.
- **Fallback preserved**: `cuMemCreate` failure logs a `GGML_LOG_WARN` and falls through to the existing `ggml_cuda_device_malloc`. Old CUDA drivers and topologies without VMM support are unaffected.
- **Single contiguous VA per buffer**: `get_base()`, `set_tensor`, `get_tensor`, `clear`, and all downstream kernels read/write off a single base pointer + offsets. The single contiguous `cuMemAddressReserve` region preserves that contract — no kernel changes needed.
- **One-shot success INFO log**: emits once per process under `-v` so operators can confirm the path engaged.
- **Default off**: opt-in via env var until soak-tested across the matrix.

## Companion operator notes for Jetson L4T 36.4.7

This PR fixes the patch-side issue; two operator-side things also matter:

1. **`--no-mmap`** — keeps the GGUF off the kernel page cache during load. Page cache fills competing memory and shrinks the NvMap safety budget further.
2. **Drop page caches before launch**: `sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'`. On a development host that's been running other workloads, page cache pressure alone can defeat both VMM and cudaMalloc paths.

These are runtime hygiene, not code concerns — but worth surfacing in the release notes / discussion reply.

## Compatibility & risk

- **Default off**: existing users see no behavior change.
- **HIP/ROCm**: the existing `ggml_cuda_pool_vmm` compiles under HIP with vendor workarounds. This PR uses the same primitives. The patch is gated by `#if defined(GGML_USE_VMM)` and only activates when the env var is set; HIP impact is the same as the existing pool. If HIP-VMM has known issues, the env var simply won't be set on those builds.
- **Multi-GPU**: `cuMemSetAccess` is called per-device for the local device only. Multi-GPU peer-access TBD as a follow-up if needed.
- **Future JetPack patches**: NVIDIA may eventually extend the CVE-2025-33177 patch to also gate `cuMemCreate`. If/when that happens, this code path can fall back to `cudaMalloc` cleanly via the existing WARN-and-fall-through.

## Test plan

- [x] L4T 36.4.7 / Jetson Orin Nano Super 8 GB / sm_87: TinyLlama Q4_K_M byte-identity (text output and memory accounting deltas as expected)
- [x] L4T 36.4.7: gemma-3n-E2B-it Q4_K_XL end-to-end with `--no-mmap` (baseline SIGSEGV; patched loads + generates)
- [x] Driver-API isolated probe (cuMemCreate at 256–5632 MiB)
- [ ] Desktop CUDA regression (consumer GPU + data-center GPU)
- [ ] HIP/ROCm regression
- [ ] Soak test (long-running server with many model swaps)
- [ ] Multi-GPU smoke
- [ ] Wikitext perplexity on TinyLlama Q4_K_M (byte-identity at the eval level)

The unchecked items are for reviewers / CI to run on hardware I don't have access to.

## References

- Discussion: https://github.com/ggml-org/llama.cpp/discussions/16706
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-33177
- NVIDIA Security Bulletin: https://nvidia.custhelp.com/app/answers/detail/a_id/5716
- NVIDIA developer forum: https://forums.developer.nvidia.com/t/intermittent-nvmapmemalloc-error-12-and-cuda-allocator-crash-during-pytorch-inference-on-jetson-orin-nano/349752
- PyTorch expandable_segments precedent: https://github.com/pytorch/pytorch/blob/main/c10/cuda/CUDACachingAllocator.cpp (search "expandable_segments")