### PR TITLE
cuda : add opt-in VMM-backed allocator for weight buffers
  (GGML_CUDA_VMM_BUFFERS)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -581,6 +581,74 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
         GGML_ASSERT(ptr == (void *) ((char *)(pool_addr) + pool_used));
     }
 };
+
+// VMM-backed allocator for weight buffers (per-buffer lifetime, arbitrary-order free)
+struct ggml_cuda_vmm_buffer {
+    int device = -1;
+    CUdeviceptr addr = 0;          // mapped VA base (also returned as void * to ggml-backend)
+    size_t mapped_size = 0;        // bytes mapped / accessible (granularity-aligned)
+    CUmemGenericAllocationHandle handle = 0;
+    bool valid = false;
+};
+
+// Allocate `size` bytes of VMM-backed device memory on `device`.
+// On success, fills *out with handle/addr/mapped_size and returns CUDA_SUCCESS.
+// On failure, leaves *out invalid (valid=false) and returns the CUresult so
+// the caller can fall back to cudaMalloc with diagnostic info.
+static CUresult ggml_cuda_vmm_alloc_buffer(ggml_cuda_vmm_buffer * out, size_t size, int device) {
+    out->device = device;
+    out->valid = false;
+
+    CUmemAllocationProp prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = device;
+
+    const size_t granularity = ggml_cuda_info().devices[device].vmm_granularity;
+    if (granularity == 0) {
+        return CUDA_ERROR_NOT_SUPPORTED;
+    }
+    const size_t aligned = ((size + granularity - 1) / granularity) * granularity;
+
+    CUresult r = cuMemCreate(&out->handle, aligned, &prop, 0);
+    if (r != CUDA_SUCCESS) return r;
+
+    r = cuMemAddressReserve(&out->addr, aligned, 0, 0, 0);
+    if (r != CUDA_SUCCESS) {
+        (void)cuMemRelease(out->handle);
+        return r;
+    }
+
+    r = cuMemMap(out->addr, aligned, 0, out->handle, 0);
+    if (r != CUDA_SUCCESS) {
+        (void)cuMemAddressFree(out->addr, aligned);
+        (void)cuMemRelease(out->handle);
+        return r;
+    }
+
+    CUmemAccessDesc adesc = {};
+    adesc.location = prop.location;
+    adesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    r = cuMemSetAccess(out->addr, aligned, &adesc, 1);
+    if (r != CUDA_SUCCESS) {
+        (void)cuMemUnmap(out->addr, aligned);
+        (void)cuMemAddressFree(out->addr, aligned);
+        (void)cuMemRelease(out->handle);
+        return r;
+    }
+
+    out->mapped_size = aligned;
+    out->valid = true;
+    return CUDA_SUCCESS;
+}
+
+static void ggml_cuda_vmm_free_buffer(ggml_cuda_vmm_buffer * b) {
+    if (!b->valid) return;
+    CU_CHECK(cuMemUnmap(b->addr, b->mapped_size));
+    CU_CHECK(cuMemAddressFree(b->addr, b->mapped_size));
+    CU_CHECK(cuMemRelease(b->handle));
+    b->valid = false;
+}
 #endif // defined(GGML_USE_VMM)
 
 std::unique_ptr<ggml_cuda_pool> ggml_backend_cuda_context::new_pool_for_device(int                  device,
@@ -626,6 +694,11 @@ struct ggml_backend_cuda_buffer_context {
     int device;
     void * dev_ptr = nullptr;
     std::string name;
+#if defined(GGML_USE_VMM)
+    // When valid, this buffer was allocated via the VMM API (cuMemCreate/cuMemMap)
+    // rather than cudaMalloc. Destructor dispatches on vmm.valid.
+    ggml_cuda_vmm_buffer vmm{};
+#endif
 
     ggml_backend_cuda_buffer_context(int device, void * dev_ptr) :
         device(device), dev_ptr(dev_ptr),
@@ -633,6 +706,12 @@ struct ggml_backend_cuda_buffer_context {
     }
 
     ~ggml_backend_cuda_buffer_context() {
+#if defined(GGML_USE_VMM)
+        if (vmm.valid) {
+            ggml_cuda_vmm_free_buffer(&vmm);
+            return;
+        }
+#endif
         CUDA_CHECK(cudaFree(dev_ptr));
     }
 };
@@ -777,19 +856,43 @@ static bool ggml_backend_buft_is_cuda(ggml_backend_buffer_type_t buft) {
 
 static ggml_backend_buffer_t ggml_backend_cuda_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
     ggml_backend_cuda_buffer_type_context * buft_ctx = (ggml_backend_cuda_buffer_type_context *)buft->context;
+    const int device = buft_ctx->device;
 
-    ggml_cuda_set_device(buft_ctx->device);
+    ggml_cuda_set_device(device);
+
+#if defined(GGML_USE_VMM)
+    // opt-in VMM path: bypasses CVE-2025-33177 NvMap cap on Jetson L4T 36.4.7+
+    if (getenv("GGML_CUDA_VMM_BUFFERS") != nullptr && ggml_cuda_info().devices[device].vmm) {
+        ggml_cuda_vmm_buffer v;
+        const CUresult vr = ggml_cuda_vmm_alloc_buffer(&v, size, device);
+        if (vr == CUDA_SUCCESS) {
+            static bool announced = false;
+            if (!announced) {
+                announced = true;
+                GGML_LOG_INFO("%s: GGML_CUDA_VMM_BUFFERS=1 — weight-buffer allocations using cuMemCreate (first %.2f MiB succeeded on device %d)\n",
+                              __func__, size / 1024.0 / 1024.0, device);
+            }
+            ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(device, (void *)v.addr);
+            ctx->vmm = v;
+            return ggml_backend_buffer_init(buft, ggml_backend_cuda_buffer_interface, ctx, size);
+        }
+        const char * es = nullptr;
+        cuGetErrorString(vr, &es);
+        GGML_LOG_WARN("%s: VMM alloc of %.2f MiB on device %d failed (%s); falling back to cudaMalloc\n",
+                      __func__, size / 1024.0 / 1024.0, device, es ? es : "(no string)");
+    }
+#endif
 
     void * dev_ptr;
-    cudaError_t err = ggml_cuda_device_malloc(&dev_ptr, size, buft_ctx->device);
+    cudaError_t err = ggml_cuda_device_malloc(&dev_ptr, size, device);
     if (err != cudaSuccess) {
         // clear the error
         (void)cudaGetLastError();
-        GGML_LOG_ERROR("%s: allocating %.2f MiB on device %d: cudaMalloc failed: %s\n", __func__, size / 1024.0 / 1024.0, buft_ctx->device, cudaGetErrorString(err));
+        GGML_LOG_ERROR("%s: allocating %.2f MiB on device %d: cudaMalloc failed: %s\n", __func__, size / 1024.0 / 1024.0, device, cudaGetErrorString(err));
         return nullptr;
     }
 
-    ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(buft_ctx->device, dev_ptr);
+    ggml_backend_cuda_buffer_context * ctx = new ggml_backend_cuda_buffer_context(device, dev_ptr);
 
     return ggml_backend_buffer_init(buft, ggml_backend_cuda_buffer_interface, ctx, size);
 }


### PR DESCRIPTION
Hi there,

Sorry about [the premature PR creation](https://github.com/ggml-org/llama.cpp/pull/23732), I gave bad instructions to an agent and accidentally opened this as a result. My agent, my fault. Thanks for your understanding.

This is my first contribution, so (extra) thanks in advance for your patience. I designed the approach, identified the integration point, and directed Claude Code to implement it. The domain knowledge (CVE characterization, VMM bypass discovery, allocation-path analysis) is mine from hands-on work; the C++ implementation mechanics were generated by AI following existing patterns under my close supervision. I've reviewed and re-reviewed every line and can explain and maintain the code independently.

## Summary

Opt-in allocation path for weight buffers using the CUDA VMM API (`cuMemCreate` / `cuMemMap`) instead of `cudaMalloc`. Enabled via `GGML_CUDA_VMM_BUFFERS=1`, default off.

Single-file change to `ggml/src/ggml-cuda/ggml-cuda.cu` (~105 insertions, 4 deletions). Reuses the same VMM primitives the existing scratch pool (`ggml_cuda_pool_vmm`) already uses, wrapped per-buffer with arbitrary-order free for weight-buffer lifetimes.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI was used for code generation. I designed the approach, reviewed every line multiple times, and can explain and maintain the code independently.

## Motivation

Discussion #16706 and downstream reports describe model loads failing on Jetson L4T 36.4.7+ after the CVE-2025-33177 NvMap security patch. The patch rejects `cudaMalloc` requests once cumulative NvMap-tracked pressure hits a safety budget, even when free physical memory is available. `cuMemCreate` enters the kernel through a different path not gated by this patch — PyTorch already exploits this via `expandable_segments:True`.

## What the patch does

The mechanism isn't just "use VMM because cudaMalloc fails." In the failing baseline, four weight allocations (1534 + 256 + 32 + 520 MiB) each go through `cudaMalloc`. By the fourth, 1821 MiB of NvMap budget is consumed and the request is rejected.

With the patch, the first three go through `cuMemCreate`. When the fourth also fails under VMM (shared cumulative cap at ~3.84 GiB), the fallback `cudaMalloc(520 MiB)` succeeds — because the cudaMalloc counter is near zero. Strategic routing keeps headroom where it's needed.

## Empirical evidence

All on Jetson Orin Nano Super 8 GB, L4T 36.4.7, sm_87:

| Test | Result |
|---|---|
| Driver-API probe: `cuMemCreate` 256–5632 MiB sweep | 22/22 pass (vs cudaMalloc failing at 5376 MiB) |
| gemma-3n-E2B-it Q4_K_XL end-to-end | Baseline SIGSEGV → patched loads + generates at 22.3 tok/s |
| TinyLlama byte-identity (seed 42, temp 0) | Output byte-identical with/without env var |
| PyTorch FSDP cross-validation | Same NvMap cap mitigated by `expandable_segments:True` on same hardware |

## Design

- Per-buffer VMM: each `ggml_backend_cuda_buffer_context` owns its own VA + physical handle, freed in arbitrary order (unlike the LIFO scratch pool)
- Graceful fallback: VMM failure logs WARN, falls through to `cudaMalloc`
- Single contiguous VA per buffer: downstream kernels see the same pointer contract, no kernel changes needed
- One-shot INFO log on first successful VMM allocation under `-v`

## Compatibility

- Default off — zero behavior change for existing users
- Gated by `#if defined(GGML_USE_VMM)` + env var + `device.vmm` runtime check
- HIP/ROCm: same primitives as existing pool; env var simply won't be set on unsupported builds
- If NVIDIA later gates `cuMemCreate` too, the fallback path handles it cleanly

## Operator notes for L4T 36.4.7

- Use `--no-mmap` to keep GGUF off the page cache during load
- Drop page caches before launch on long-running dev hosts: `echo 3 > /proc/sys/vm/drop_caches`

## Test plan

- [x] TinyLlama Q4_K_M byte-identity on L4T 36.4.7 / sm_87
- [x] gemma-3n-E2B-it Q4_K_XL end-to-end (baseline SIGSEGV; patched loads + generates)
- [x] Driver-API isolated probe (256–5632 MiB)
- [x] CPU-only CI: 45/45 passed
- [x] CUDA CI on Jetson sm_87: 41/42 passed (1 pre-existing `test-thread-safety` ptrace issue)
- [ ] Desktop CUDA regression (consumer + data-center GPU)
- [ ] HIP/ROCm regression
- [ ] Soak test (long-running server, many model swaps)

Unchecked items need hardware I don't have. I maintain a 4-node Jetson Orin Nano Super 8 GB cluster (L4T 36.4.4 and 36.4.7) and am happy to run additional tests, address feedback, and maintain this code long-term.

## References

- Discussion: https://github.com/ggml-org/llama.cpp/discussions/16706
- CVE-2025-33177: https://nvd.nist.gov/vuln/detail/CVE-2025-33177
- NVIDIA forum: https://forums.developer.nvidia.com/t/intermittent-nvmapmemalloc-error-12-and-cuda-allocator-crash-during-pytorch-inference-on-jetson-orin-nano/349752
