### PR TITLE
build: include conversion package in script wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,10 @@ llama-convert-llama-ggml-to-gguf = "convert_llama_ggml_to_gguf:main"
 llama-ggml-vk-generate-shaders = "ggml_vk_generate_shaders:main"
 
 [tool.poetry]
-packages = [{ include = "*.py", from = "." }]
+packages = [
+    { include = "*.py", from = "." },
+    { include = "conversion", from = "." },
+]
 
 [tool.poetry.dependencies]
 torch = [


### PR DESCRIPTION
Failure mechanism:
The script wheel exposes console entry points such as `llama-convert-hf-to-gguf`, but `[tool.poetry].packages` only includes top-level `*.py` files. Since the recent converter refactor moved shared code into the `conversion/` package, wheel installs built through `poetry-core` omit that package and the entry points fail with `ModuleNotFoundError: No module named 'conversion'`.

Semantic change:
- include the `conversion` package directory in `[tool.poetry].packages`

Preserved invariant:
- no converter logic changes
- no entry point changes
- no dependency changes
- source-tree execution stays the same; only wheel contents are corrected

Testing:
- built the wheel before the change and inspected its contents: `conversion entries: 0`
- rebuilt the wheel after the change and inspected its contents: `conversion entries: 80`
- extracted the rebuilt wheel and successfully imported both `convert_hf_to_gguf` and `convert_lora_to_gguf` from the wheel payload: `imports ok`

Issue:
- fixes #23740
