### PR TITLE
vulkan: fix UMA performance by preferring cached host memory and handling non…

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3008,13 +3008,13 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
             if (memory_type_indices.empty()) {
                 continue;
             }
-            buf->memory_property_flags = req_flags;
 
             bool done = false;
 
             for (auto mtype_it = memory_type_indices.begin(); mtype_it != memory_type_indices.end(); mtype_it++) {
                 try {
                     buf->device_memory = device->device.allocateMemory({ mem_req.size, *mtype_it, &mem_flags_info });
+                    buf->memory_property_flags = mem_props.memoryTypes[*mtype_it].propertyFlags;
                     done = true;
                     break;
                 } catch (const vk::SystemError& e) {
@@ -3081,6 +3081,7 @@ static vk_buffer ggml_vk_create_buffer_device(vk_device& device, size_t size) {
                                                        vk::MemoryPropertyFlagBits::eDeviceLocal});
         } else if (device->uma) {
             // Prefer cached host memory over device-local for UMA to avoid WC read penalties
+            // If unavailable, fall back to device-local memory.
             buf = ggml_vk_create_buffer(device, size, {vk::MemoryPropertyFlagBits::eDeviceLocal | vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostCached,
                                                        vk::MemoryPropertyFlagBits::eDeviceLocal,
                                                        vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent});

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2948,8 +2948,6 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
 
     vk::PhysicalDeviceMemoryProperties mem_props = device->physical_device.getMemoryProperties();
 
-    uint32_t selected_memory_type_idx = UINT32_MAX;
-
     const vk::MemoryPriorityAllocateInfoEXT mem_priority_info { 1.0f };
 
     vk::MemoryAllocateFlagsInfo mem_flags_info { mem_flags };
@@ -2992,7 +2990,6 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
             return {};
         }
 
-        selected_memory_type_idx = memory_type_idx;
         buf->memory_property_flags = mem_props.memoryTypes[memory_type_idx].propertyFlags;
         try {
             vk::ImportMemoryHostPointerInfoEXT import_info;
@@ -3018,7 +3015,6 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
                 try {
                     buf->device_memory = device->device.allocateMemory({ mem_req.size, *mtype_it, &mem_flags_info });
                     buf->memory_property_flags = mem_props.memoryTypes[*mtype_it].propertyFlags;
-                    selected_memory_type_idx = *mtype_it;
                     done = true;
                     break;
                 } catch (const vk::SystemError& e) {
@@ -3059,14 +3055,6 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
     if (device->buffer_device_address) {
         const vk::BufferDeviceAddressInfo addressInfo(buf->buffer);
         buf->bda_addr = device->device.getBufferAddress(addressInfo);
-    }
-
-    if (selected_memory_type_idx != UINT32_MAX) {
-        GGML_LOG_DEBUG("ggml_vulkan: Allocated buffer of size %zu using memory type %u flags %s (import=%d)\n",
-                size,
-                (unsigned) selected_memory_type_idx,
-                to_string(buf->memory_property_flags).c_str(),
-                import_ptr ? 1 : 0);
     }
 
     device->memory_logger->log_allocation(buf, size);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7701,8 +7701,12 @@ static void ggml_vk_buffer_write_2d(vk_buffer& dst, size_t offset, const void * 
     VK_LOG_DEBUG("ggml_vk_buffer_write_2d(" << width << ", " << height << ")");
     // Buffer is already mapped
     if (ggml_vk_buffer_host_write_direct(dst)) {
-        for (size_t i = 0; i < height; i++) {
-            memcpy((uint8_t *)dst->ptr + offset + i * dpitch, (const uint8_t *) src + i * spitch, width);
+        if (width == spitch && width == dpitch) {
+            memcpy((uint8_t *)dst->ptr + offset, src, width * height);
+        } else {
+            for (size_t i = 0; i < height; i++) {
+                memcpy((uint8_t *)dst->ptr + offset + i * dpitch, (const uint8_t *) src + i * spitch, width);
+            }
         }
         if (!(dst->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent)) {
             uint64_t atom_size = dst->device->properties.limits.nonCoherentAtomSize;
@@ -7867,8 +7871,13 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
             range.size = aligned_size;
             src->device->device.invalidateMappedMemoryRanges({range});
         }
-        for (size_t i = 0; i < height; i++) {
-            memcpy((uint8_t *) dst + i * dpitch, (const uint8_t *) src->ptr + offset + i * spitch, width);
+
+        if (width == spitch && width == dpitch) {
+            memcpy(dst, (const uint8_t *) src->ptr + offset, width * height);
+        } else {
+            for (size_t i = 0; i < height; i++) {
+                memcpy((uint8_t *) dst + i * dpitch, (const uint8_t *) src->ptr + offset + i * spitch, width);
+            }
         }
     } else {
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7840,8 +7840,6 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     // through PCIe is sufficient fast reading back data from PCIe is slower than going through
     // the HW device to host copy path.
     if (ggml_vk_buffer_host_read_direct(src)) {
-        GGML_ASSERT(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
-
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
         vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
         ggml_vk_ctx_begin(src->device, subctx);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2948,6 +2948,8 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
 
     vk::PhysicalDeviceMemoryProperties mem_props = device->physical_device.getMemoryProperties();
 
+    uint32_t selected_memory_type_idx = UINT32_MAX;
+
     const vk::MemoryPriorityAllocateInfoEXT mem_priority_info { 1.0f };
 
     vk::MemoryAllocateFlagsInfo mem_flags_info { mem_flags };
@@ -2990,6 +2992,7 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
             return {};
         }
 
+        selected_memory_type_idx = memory_type_idx;
         buf->memory_property_flags = mem_props.memoryTypes[memory_type_idx].propertyFlags;
         try {
             vk::ImportMemoryHostPointerInfoEXT import_info;
@@ -3015,6 +3018,7 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
                 try {
                     buf->device_memory = device->device.allocateMemory({ mem_req.size, *mtype_it, &mem_flags_info });
                     buf->memory_property_flags = mem_props.memoryTypes[*mtype_it].propertyFlags;
+                    selected_memory_type_idx = *mtype_it;
                     done = true;
                     break;
                 } catch (const vk::SystemError& e) {
@@ -3026,7 +3030,6 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
                     }
                 }
             }
-
             if (done) {
                 break;
             }
@@ -3058,6 +3061,14 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
         buf->bda_addr = device->device.getBufferAddress(addressInfo);
     }
 
+    if (selected_memory_type_idx != UINT32_MAX) {
+        GGML_LOG_DEBUG("ggml_vulkan: Allocated buffer of size %zu using memory type %u flags %s (import=%d)\n",
+                size,
+                (unsigned) selected_memory_type_idx,
+                to_string(buf->memory_property_flags).c_str(),
+                import_ptr ? 1 : 0);
+    }
+
     device->memory_logger->log_allocation(buf, size);
 
     return buf;
@@ -3080,9 +3091,8 @@ static vk_buffer ggml_vk_create_buffer_device(vk_device& device, size_t size) {
             buf = ggml_vk_create_buffer(device, size, {vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent,
                                                        vk::MemoryPropertyFlagBits::eDeviceLocal});
         } else if (device->uma) {
-            // On UMA, prefer host-visible memory so direct tensor borrowing works.
-            // If unavailable, fall back to device-local memory.
-            buf = ggml_vk_create_buffer(device, size, {vk::MemoryPropertyFlagBits::eDeviceLocal | vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent,
+            // Prefer cached host memory over device-local for UMA to avoid WC read penalties
+            buf = ggml_vk_create_buffer(device, size, {vk::MemoryPropertyFlagBits::eDeviceLocal | vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostCached,
                                                        vk::MemoryPropertyFlagBits::eDeviceLocal,
                                                        vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent});
         } else if (device->disable_host_visible_vidmem) {
@@ -7677,18 +7687,46 @@ static bool ggml_vk_buffer_write_async(vk_context subctx, vk_buffer& dst, size_t
     return ggml_vk_buffer_write_2d_async(subctx, dst, offset, src, size, size, size, 1, sync_staging);
 }
 
+static bool ggml_vk_buffer_host_write_direct(const vk_buffer & buf) {
+    if (!(buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible)) {
+        return false;
+    }
+    if (buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent) {
+        return true;
+    }
+    return buf->device->uma && (buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCached);
+}
+
+static bool ggml_vk_buffer_host_read_direct(const vk_buffer & buf) {
+    if (!(buf->device->uma && (buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible))) {
+        return false;
+    }
+    if (buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent) {
+        return true;
+    }
+    return static_cast<bool>(buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCached);
+}
+
 static void ggml_vk_buffer_write_2d(vk_buffer& dst, size_t offset, const void * src, size_t spitch, size_t dpitch, size_t width, size_t height) {
     VK_LOG_DEBUG("ggml_vk_buffer_write_2d(" << width << ", " << height << ")");
     // Buffer is already mapped
-    if(dst->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible) {
-        GGML_ASSERT(dst->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
-
-        if (width == spitch && width == dpitch) {
-            memcpy((uint8_t *)dst->ptr + offset, src, width * height);
-        } else {
-            for (size_t i = 0; i < height; i++) {
-                memcpy((uint8_t *)dst->ptr + offset + i * dpitch, (const uint8_t *) src + i * spitch, width);
+    if (ggml_vk_buffer_host_write_direct(dst)) {
+        for (size_t i = 0; i < height; i++) {
+            memcpy((uint8_t *)dst->ptr + offset + i * dpitch, (const uint8_t *) src + i * spitch, width);
+        }
+        if (!(dst->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent)) {
+            uint64_t atom_size = dst->device->properties.limits.nonCoherentAtomSize;
+            uint64_t aligned_offset = offset & ~(atom_size - 1);
+            uint64_t end_offset = (offset + (uint64_t)dpitch * height + atom_size - 1) & ~(atom_size - 1);
+            uint64_t aligned_size = end_offset - aligned_offset;
+            if (aligned_offset + aligned_size > dst->size) {
+                aligned_size = VK_WHOLE_SIZE;
             }
+            vk::MappedMemoryRange range;
+            range.memory = dst->device_memory;
+            range.offset = aligned_offset;
+            range.size = aligned_size;
+            dst->device->device.flushMappedMemoryRanges({range});
         }
     } else {
         std::lock_guard<std::recursive_mutex> guard(dst->device->mutex);
@@ -7804,32 +7842,23 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     // If the device is not an UMA device the memory is host-accessible through rebar. While writing
     // through PCIe is sufficient fast reading back data from PCIe is slower than going through
     // the HW device to host copy path.
-    if(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible && src->device->uma) {
-        GGML_ASSERT(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
-
-        std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
-        vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
-        ggml_vk_ctx_begin(src->device, subctx);
-        subctx->s->buffer->buf.pipelineBarrier(
-            vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,
-            vk::PipelineStageFlagBits::eHost,
-            {},
-            { { vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferWrite,
-                vk::AccessFlagBits::eHostRead } },
-            {}, {});
-        ggml_vk_ctx_end(subctx);
-        ggml_vk_submit(subctx, src->device->fence);
-        VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX),
-                 "vk_buffer_read_2d uma waitForFences");
-        src->device->device.resetFences({ src->device->fence });
-        ggml_vk_queue_command_pools_cleanup(src->device);
-
-        if (width == spitch && width == dpitch) {
-            memcpy(dst, (const uint8_t *) src->ptr + offset, width * height);
-        } else {
-            for (size_t i = 0; i < height; i++) {
-                memcpy((uint8_t *) dst + i * dpitch, (const uint8_t *) src->ptr + offset + i * spitch, width);
+    if (ggml_vk_buffer_host_read_direct(src)) {
+        if (!(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent)) {
+            uint64_t atom_size = src->device->properties.limits.nonCoherentAtomSize;
+            uint64_t aligned_offset = offset & ~(atom_size - 1);
+            uint64_t end_offset = (offset + (uint64_t)spitch * height + atom_size - 1) & ~(atom_size - 1);
+            uint64_t aligned_size = end_offset - aligned_offset;
+            if (aligned_offset + aligned_size > src->size) {
+                aligned_size = VK_WHOLE_SIZE;
             }
+            vk::MappedMemoryRange range;
+            range.memory = src->device_memory;
+            range.offset = aligned_offset;
+            range.size = aligned_size;
+            src->device->device.invalidateMappedMemoryRanges({range});
+        }
+        for (size_t i = 0; i < height; i++) {
+            memcpy((uint8_t *) dst + i * dpitch, (const uint8_t *) src->ptr + offset + i * spitch, width);
         }
     } else {
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7688,6 +7688,9 @@ static bool ggml_vk_buffer_host_write_direct(const vk_buffer & buf) {
 }
 
 static bool ggml_vk_buffer_host_read_direct(const vk_buffer & buf) {
+    // Returns true if the buffer can be read directly from the host.
+    // This does NOT imply coherency - for non-coherent memory (e.g. eHostCached),
+    // the caller must handle synchronization (pipeline barrier + invalidateMappedMemoryRanges).
     if (!(buf->device->uma && (buf->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible))) {
         return false;
     }
@@ -7837,27 +7840,27 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     // through PCIe is sufficient fast reading back data from PCIe is slower than going through
     // the HW device to host copy path.
     if (ggml_vk_buffer_host_read_direct(src)) {
-        if (!(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent)) {
-            // Synchronize: ensure GPU writes are visible to the host
-            {
-                std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
-                vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
-                ggml_vk_ctx_begin(src->device, subctx);
-                subctx->s->buffer->buf.pipelineBarrier(
-                    vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,
-                    vk::PipelineStageFlagBits::eHost,
-                    {},
-                    { { vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferWrite,
-                        vk::AccessFlagBits::eHostRead } },
-                    {}, {});
-                ggml_vk_ctx_end(subctx);
-                ggml_vk_submit(subctx, src->device->fence);
-                VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX),
-                         "vk_buffer_read_2d uma waitForFences");
-                src->device->device.resetFences({ src->device->fence });
-                ggml_vk_queue_command_pools_cleanup(src->device);
-            }
+        // Synchronize: ensure GPU writes are visible to the host
+        {
+            std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
+            vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
+            ggml_vk_ctx_begin(src->device, subctx);
+            subctx->s->buffer->buf.pipelineBarrier(
+                vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,
+                vk::PipelineStageFlagBits::eHost,
+                {},
+                { { vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferWrite,
+                    vk::AccessFlagBits::eHostRead } },
+                {}, {});
+            ggml_vk_ctx_end(subctx);
+            ggml_vk_submit(subctx, src->device->fence);
+            VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX),
+                     "vk_buffer_read_2d uma waitForFences");
+            src->device->device.resetFences({ src->device->fence });
+            ggml_vk_queue_command_pools_cleanup(src->device);
+        }
 
+        if (!(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent)) {
             uint64_t atom_size = src->device->properties.limits.nonCoherentAtomSize;
             uint64_t aligned_offset = offset & ~(atom_size - 1);
             uint64_t end_offset = (offset + (uint64_t)spitch * height + atom_size - 1) & ~(atom_size - 1);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7834,6 +7834,26 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     // the HW device to host copy path.
     if (ggml_vk_buffer_host_read_direct(src)) {
         if (!(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent)) {
+            // Synchronize: ensure GPU writes are visible to the host
+            {
+                std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
+                vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
+                ggml_vk_ctx_begin(src->device, subctx);
+                subctx->s->buffer->buf.pipelineBarrier(
+                    vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,
+                    vk::PipelineStageFlagBits::eHost,
+                    {},
+                    { { vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferWrite,
+                        vk::AccessFlagBits::eHostRead } },
+                    {}, {});
+                ggml_vk_ctx_end(subctx);
+                ggml_vk_submit(subctx, src->device->fence);
+                VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX),
+                         "vk_buffer_read_2d uma waitForFences");
+                src->device->device.resetFences({ src->device->fence });
+                ggml_vk_queue_command_pools_cleanup(src->device);
+            }
+
             uint64_t atom_size = src->device->properties.limits.nonCoherentAtomSize;
             uint64_t aligned_offset = offset & ~(atom_size - 1);
             uint64_t end_offset = (offset + (uint64_t)spitch * height + atom_size - 1) & ~(atom_size - 1);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3008,13 +3008,13 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
             if (memory_type_indices.empty()) {
                 continue;
             }
+            buf->memory_property_flags = req_flags;
 
             bool done = false;
 
             for (auto mtype_it = memory_type_indices.begin(); mtype_it != memory_type_indices.end(); mtype_it++) {
                 try {
                     buf->device_memory = device->device.allocateMemory({ mem_req.size, *mtype_it, &mem_flags_info });
-                    buf->memory_property_flags = mem_props.memoryTypes[*mtype_it].propertyFlags;
                     done = true;
                     break;
                 } catch (const vk::SystemError& e) {
@@ -3026,6 +3026,7 @@ static vk_buffer ggml_vk_create_buffer(vk_device& device, size_t size, const std
                     }
                 }
             }
+
             if (done) {
                 break;
             }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7840,25 +7840,24 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     // through PCIe is sufficient fast reading back data from PCIe is slower than going through
     // the HW device to host copy path.
     if (ggml_vk_buffer_host_read_direct(src)) {
-        // Synchronize: ensure GPU writes are visible to the host
-        {
-            std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
-            vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
-            ggml_vk_ctx_begin(src->device, subctx);
-            subctx->s->buffer->buf.pipelineBarrier(
-                vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,
-                vk::PipelineStageFlagBits::eHost,
-                {},
-                { { vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferWrite,
-                    vk::AccessFlagBits::eHostRead } },
-                {}, {});
-            ggml_vk_ctx_end(subctx);
-            ggml_vk_submit(subctx, src->device->fence);
-            VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX),
-                     "vk_buffer_read_2d uma waitForFences");
-            src->device->device.resetFences({ src->device->fence });
-            ggml_vk_queue_command_pools_cleanup(src->device);
-        }
+        GGML_ASSERT(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
+
+        std::lock_guard<std::recursive_mutex> guard(src->device->mutex);
+        vk_context subctx = ggml_vk_create_temporary_context(src->device->compute_queue.cmd_pool);
+        ggml_vk_ctx_begin(src->device, subctx);
+        subctx->s->buffer->buf.pipelineBarrier(
+            vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eHost,
+            {},
+            { { vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferWrite,
+                vk::AccessFlagBits::eHostRead } },
+            {}, {});
+        ggml_vk_ctx_end(subctx);
+        ggml_vk_submit(subctx, src->device->fence);
+        VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX),
+                 "vk_buffer_read_2d uma waitForFences");
+        src->device->device.resetFences({ src->device->fence });
+        ggml_vk_queue_command_pools_cleanup(src->device);
 
         if (!(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent)) {
             uint64_t atom_size = src->device->properties.limits.nonCoherentAtomSize;


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
The original code was potentially allocating write-combining (WC) memory for device buffers, which is fast to write but painfully slow to read back.

In addition, in ggml_vk_create_buffer, memory_property_flags was being set to the requested flags rather than what was actually allocated. This PR sets memory_property_flags from what the driver actually gave.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
I use this [benchmark script](https://gist.github.com/winstonma/a9e6f0f4a7587c950ff8a789cfa04904) to test `ggml_backend_tensor_set` and `ggml_backend_tensor_get` on my AMD UMA device.

## Before the patch

```
❯ cmake --build build --target test-vulkan-uma-perf && ./build/bin/test-vulkan-uma-perf
[  0%] Built target cpp-httplib
[  3%] Built target ggml-base
[  3%] Performing build step for 'vulkan-shaders-gen'
[100%] Built target vulkan-shaders-gen
[  3%] Performing install step for 'vulkan-shaders-gen'
-- Up-to-date: /home/winston/Code/llama.cpp/build/Release/./vulkan-shaders-gen
[  4%] Completed 'vulkan-shaders-gen'
[  4%] Built target vulkan-shaders-gen
[ 63%] Built target ggml-vulkan
[ 65%] Built target ggml-cpu
[ 65%] Built target ggml
[ 93%] Built target llama
[ 93%] Built target llama-common-base
[100%] Built target llama-common
[100%] Built target test-vulkan-uma-perf
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon 880M Graphics (RADV STRIX1) (radv) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 64 | shared memory: 65536 | int dot: 1 | matrix cores: KHR_coopmat

Vulkan UMA Transfer Performance Matrix
=============================================
Size (B)       Set BW (GB/s)  Get BW (GB/s)  
---------------------------------------------
2048           0.03           0.05           
4096           0.09           0.10           
8192           0.19           0.20           
16384          0.40           0.41           
32768          0.70           0.79           
65536          1.60           1.54           
131072         3.08           2.32           
262144         4.17           3.27           
524288         3.93           4.62           
1048576        7.13           8.35           
2097152        9.01           9.07           
4194304        10.67          12.03          
8388608        12.39          12.79          
16777216       13.22          13.34          
33554432       12.55          13.69          
67108864       13.44          13.83          
134217728      13.63          14.17          
268435456      14.34          14.44          
536870912      14.52          14.97          
1073741824     14.52          14.97          
=============================================
```

## Patch is applied:

```
❯ cmake --build build --target test-vulkan-uma-perf && ./build/bin/test-vulkan-uma-perf
[  0%] Built target cpp-httplib
[  3%] Built target ggml-base
[  3%] Performing build step for 'vulkan-shaders-gen'
[100%] Built target vulkan-shaders-gen
[  3%] Performing install step for 'vulkan-shaders-gen'
-- Up-to-date: /home/winston/Code/llama.cpp/build/Release/./vulkan-shaders-gen
[  4%] Completed 'vulkan-shaders-gen'
[  4%] Built target vulkan-shaders-gen
[ 62%] Built target ggml-vulkan
[ 64%] Built target ggml-cpu
[ 64%] Built target ggml
[ 92%] Built target llama
[ 93%] Built target llama-common-base
[100%] Built target llama-common
[100%] Built target test-vulkan-uma-perf
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon 880M Graphics (RADV STRIX1) (radv) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 64 | shared memory: 65536 | int dot: 1 | matrix cores: KHR_coopmat
ggml_vulkan: Allocated buffer of size 2048 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 4096 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 8192 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 16384 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 32768 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 65536 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 131072 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 262144 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 524288 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 1048576 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 2097152 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 4194304 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 8388608 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 16777216 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 33554432 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 67108864 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 134217728 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 268435456 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 536870912 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)
ggml_vulkan: Allocated buffer of size 1073741824 using memory type 5 flags { HostVisible | HostCoherent | HostCached } (import=0)

Vulkan UMA Transfer Performance Matrix
=============================================
Size (B)       Set BW (GB/s)  Get BW (GB/s)  
---------------------------------------------
2048           9.29           25.45          
4096           37.47          64.55          
8192           29.36          89.59          
16384          36.84          108.79         
32768          42.76          47.14          
65536          38.88          44.74          
131072         41.56          45.46          
262144         44.48          48.03          
524288         36.47          40.33          
1048576        28.50          30.79          
2097152        25.10          28.33          
4194304        31.85          35.26          
8388608        22.62          30.74          
16777216       21.06          24.17          
33554432       21.99          23.16          
67108864       20.90          21.50          
134217728      22.71          22.23          
268435456      21.92          22.23          
536870912      22.21          21.94          
1073741824     22.21          22.09          
=============================================
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, for finding/implementing and create benchmark test<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
