### PR TITLE
fix(cuda): sanitize invalid Blackwell smpbo values

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -288,6 +288,11 @@ static ggml_cuda_device_info ggml_cuda_init() {
                       (size_t)(prop.totalGlobalMem / (1024 * 1024)));
 #else
         info.devices[id].smpbo = prop.sharedMemPerBlockOptin;
+        if (info.devices[id].smpbo == 0 || info.devices[id].smpbo > 1024*1024) {
+            GGML_LOG_WARN("%s: device %d reported invalid sharedMemPerBlockOptin=%zu, falling back to sharedMemPerBlock=%zu\n",
+                    __func__, id, info.devices[id].smpbo, (size_t) prop.sharedMemPerBlock);
+            info.devices[id].smpbo = prop.sharedMemPerBlock;
+        }
         info.devices[id].cc = 100*prop.major + 10*prop.minor;
         GGML_LOG_INFO("  Device %d: %s, compute capability %d.%d, VMM: %s, VRAM: %zu MiB\n",
                       id, prop.name, prop.major, prop.minor, device_vmm ? "yes" : "no",


### PR DESCRIPTION
Fixes #23385.

Failure mechanism:
- early Blackwell launch drivers can report broken `cudaDeviceProp.sharedMemPerBlockOptin` values such as `0` or `0x100000001`
- `ggml_cuda_init()` stored that value directly in `info.devices[id].smpbo`
- multiple CUDA paths consume `smpbo` as a hard shared-memory ceiling, not just softmax
- `mmq.cuh` uses it to prune valid MMQ tile shapes, which can leave `mmq_x_best = 0` and abort on Blackwell
- `mmid.cu` and `softmax.cu` also use the same cached limit when setting dynamic shared memory attributes

Semantic change:
- sanitize `sharedMemPerBlockOptin` once during CUDA device-info initialization
- if the reported value is `0` or implausibly large (`> 1 MiB`), log a warning and fall back to `sharedMemPerBlock`
- keep the workaround centralized so every `smpbo` consumer gets the same sane value

Why here instead of another per-kernel workaround:
- PR #22338 already demonstrated the same Blackwell driver bug on a softmax path
- issue #23385 shows the remaining MMQ failure comes from the same cached device property
- fixing the cached property is the narrowest place that covers MMQ, MMID, and SOFT_MAX together

Validation:
- source-path verification:
  - `ggml/src/ggml-cuda/ggml-cuda.cu` initializes `info.devices[id].smpbo`
  - `ggml/src/ggml-cuda/mmq.cuh` gates MMQ tile selection on `smpbo`
  - `ggml/src/ggml-cuda/mmid.cu` and `ggml/src/ggml-cuda/softmax.cu` also consume `smpbo`
- local Windows configure passed with `-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=120`
- targeted build did not finish within the local command timeout window, so runtime reproduction is still pending on the patched tree