### PR TITLE
Improve tagged tool parsing with reasoning

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -8,6 +8,8 @@
 #include "nlohmann/json.hpp"
 #include "peg-parser.h"
 
+#include <algorithm>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 
@@ -405,22 +407,42 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
             }
         }
 
-        // Build required arg sequence in definition order
-        common_peg_parser args_seq = p.eps();
-        for (size_t i = 0; i < required_parsers.size(); i++) {
-            if (i > 0) {
-                args_seq = args_seq + p.space();
-            }
-            args_seq = args_seq + required_parsers[i];
-        }
-
-        // Build optional args with flexible ordering
+        common_peg_parser optional_args = p.eps();
         if (!optional_parsers.empty()) {
             common_peg_parser any_opt = p.choice();
             for (const auto & opt : optional_parsers) {
                 any_opt |= opt;
             }
-            args_seq = args_seq + p.repeat(p.space() + any_opt, 0, -1);
+            optional_args = p.repeat(any_opt + p.space(), 0, -1);
+        }
+
+        // Build required args in any order. Tagged arguments carry their
+        // parameter name in-band, so the model should not have to emit required
+        // arguments in schema/property order.
+        common_peg_parser args_seq = p.eps();
+        constexpr size_t max_required_permutations = 6;
+        if (required_parsers.empty()) {
+            args_seq = optional_args;
+        } else if (required_parsers.size() <= max_required_permutations) {
+            std::vector<size_t> order(required_parsers.size());
+            std::iota(order.begin(), order.end(), 0);
+
+            common_peg_parser required_orders = p.choice();
+            do {
+                common_peg_parser seq = optional_args;
+                for (size_t idx : order) {
+                    seq = seq + required_parsers[idx] + p.space() + optional_args;
+                }
+                required_orders |= seq;
+            } while (std::next_permutation(order.begin(), order.end()));
+
+            args_seq = required_orders;
+        } else {
+            // Avoid factorial grammar growth for unusually large schemas.
+            args_seq = optional_args;
+            for (const auto & required : required_parsers) {
+                args_seq = args_seq + required + p.space() + optional_args;
+            }
         }
 
         if (!arguments.start.empty()) {

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -454,13 +454,24 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
     auto require_tools = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED;
 
     common_peg_parser tool_calls = p.eps();
+    common_peg_parser tool_call_item = p.eps();
 
     if (!format.per_call_start.empty()) {
         auto wrapped_call = format.per_call_start + p.space() + tool_choice + p.space() + format.per_call_end;
+        if (format.section_start.empty()) {
+            // Lazy grammars are activated from the first tool-call marker in the
+            // generated suffix. The trigger grammar must validate the tool call,
+            // but it should not require the tool call to be the last segment in
+            // the completion. Tagged tool calls can appear inside reasoning
+            // blocks, followed by </think>, content, or more segments that the
+            // full parser will handle afterwards.
+            p.trigger_rule("tool-call", wrapped_call + p.rest());
+        }
+        tool_call_item = wrapped_call + p.space();
         if (inputs.parallel_tool_calls) {
-            tool_calls = p.trigger_rule("tool-call", wrapped_call + p.zero_or_more(p.space() + wrapped_call) + p.space());
+            tool_calls = wrapped_call + p.zero_or_more(p.space() + wrapped_call) + p.space();
         } else {
-            tool_calls = p.trigger_rule("tool-call", wrapped_call + p.space());
+            tool_calls = wrapped_call + p.space();
         }
         if (!format.section_start.empty()) {
             tool_calls = p.trigger_rule("tool-calls",
@@ -486,6 +497,55 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
 
     std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
     auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
+
+    // Treat tag-based reasoning markers as mode switches rather than containers that
+    // hide tools. Text inside the reasoning markers is emitted as reasoning_content,
+    // text outside is emitted as content, and valid tool calls can appear in either
+    // mode. This path applies to tagged-argument tool formats, such as:
+    //
+    //   <tool_call>
+    //   <function=name>
+    //   <parameter=arg>value</parameter>
+    //   </function>
+    //   </tool_call>
+    //
+    // Use a specific tool boundary that includes the function-name prefix when
+    // possible, so prose such as "I might call <tool_call> later" remains text.
+    if (ctx.extracting_reasoning && ctx.reasoning &&
+        !trim_whitespace(ctx.reasoning->start).empty() &&
+        !trim_whitespace(ctx.reasoning->end).empty() &&
+        format.section_start.empty() &&
+        !trim_whitespace(format.per_call_start).empty() &&
+        !trim_whitespace(format.per_call_end).empty()) {
+        const std::string think_start = trim_whitespace(ctx.reasoning->start);
+        const std::string think_end   = trim_whitespace(ctx.reasoning->end);
+        const std::string tool_start  = trim_whitespace(format.per_call_start) +
+            (function.name_prefix.empty() ? "" : "\n" + function.name_prefix);
+
+        auto in_think_boundary = p.choice({
+            p.literal(tool_start),
+            p.literal(think_end),
+        });
+        auto root_boundary = p.choice({
+            p.literal(think_start),
+            p.literal(think_end),
+            p.literal(tool_start),
+        });
+
+        auto reasoning_chunk = p.reasoning(
+            p.negate(in_think_boundary) + p.any() + p.until_one_of({ tool_start, think_end }));
+        auto content_chunk = p.content(
+            p.negate(root_boundary) + p.any() + p.until_one_of({ think_start, think_end, tool_start }));
+
+        auto stale_think_end = p.literal(think_end) + p.space();
+        auto think_block =
+            p.literal(think_start) + p.space() +
+            p.zero_or_more(p.choice({ tool_call_item, reasoning_chunk })) +
+            p.optional(stale_think_end);
+
+        return p.zero_or_more(p.choice({ think_block, tool_call_item, stale_think_end, content_chunk })) + p.end();
+    }
+
     return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
 }
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -495,6 +495,32 @@ static common_chat_tool write_tool{
         "required": ["file", "content"]
     })",
 };
+static common_chat_tool edit_snake_tool{
+    /* .name = */ "edit",
+    /* .description = */ "edit a file",
+    /* .parameters = */ R"({
+        "type": "object",
+        "properties": {
+            "file": {
+                "type": "string",
+                "description": "File path."
+            },
+            "new_string": {
+                "type": "string",
+                "description": "Replacement text."
+            },
+            "old_string": {
+                "type": "string",
+                "description": "Exact text to replace."
+            },
+            "replace_all": {
+                "type": "boolean",
+                "description": "Replace every occurrence."
+            }
+        },
+        "required": ["file", "old_string", "new_string"]
+    })",
+};
 
 static common_chat_tool html_tool{
     /* .name = */ "html",
@@ -1923,6 +1949,47 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
         })
             .expect_tool_calls({
                 { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
+            })
+            .run();
+
+        tst.test(
+               "<tool_call>\n"
+               "<function=edit>\n"
+               "<parameter=file>\n"
+               "/workspace/jsonlfilter/test_parse.go\n"
+               "</parameter>\n"
+               "<parameter=old_string>\n"
+               "package main\n"
+               "\n"
+               "import \"testing\"\n"
+               "\n"
+               "func TestDebug(t *testing.T) {\n"
+               "\tline := `{name:Jette,status:sleepy}`\n"
+               "\tt.Logf(\"Status: %q\\n\", result[\"status\"])\n"
+               "}\n"
+               "</parameter>\n"
+               "<parameter=new_string>\n"
+               "package main\n"
+               "\n"
+               "import (\n"
+               "\t\"strings\"\n"
+               "\t\"testing\"\n"
+               ")\n"
+               "\n"
+               "func TestDebug(t *testing.T) {\n"
+               "\tline := `{name:Jette,status:sleepy}`\n"
+               "\tt.Logf(\"Status: %q\\n\", result[\"status\"])\n"
+               "}\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .enable_thinking(false)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({
+                edit_snake_tool
+        })
+            .expect_tool_calls({
+                { "edit", R"({"file":"/workspace/jsonlfilter/test_parse.go","old_string":"package main\n\nimport \"testing\"\n\nfunc TestDebug(t *testing.T) {\n\tline := `{name:Jette,status:sleepy}`\n\tt.Logf(\"Status: %q\\n\", result[\"status\"])\n}","new_string":"package main\n\nimport (\n\t\"strings\"\n\t\"testing\"\n)\n\nfunc TestDebug(t *testing.T) {\n\tline := `{name:Jette,status:sleepy}`\n\tt.Logf(\"Status: %q\\n\", result[\"status\"])\n}"})", {} },
             })
             .run();
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -477,6 +477,24 @@ static common_chat_tool python_tool{
         "required": ["code"]
     })",
 };
+static common_chat_tool write_tool{
+    /* .name = */ "write",
+    /* .description = */ "write a file",
+    /* .parameters = */ R"({
+        "type": "object",
+        "properties": {
+            "file": {
+                "type": "string",
+                "description": "File path."
+            },
+            "content": {
+                "type": "string",
+                "description": "Full replacement file content."
+            }
+        },
+        "required": ["file", "content"]
+    })",
+};
 
 static common_chat_tool html_tool{
     /* .name = */ "html",
@@ -1919,7 +1937,8 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_content(R"({"amount": 123.45, "date": "2025-12-03"})")
             .run();
 
-        // tool call segment in reasoning
+        // Qwen3.5 can emit tool calls inside <think>. Treat <think> as a
+        // reasoning/content mode switch, not as a container that hides tools.
         tst.test(
                "Let's call a tool: <tool_call>\n"
                "<function=python>\n"
@@ -1946,19 +1965,42 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({
                 python_tool
         })
-            .expect_reasoning(
-                "Let's call a tool: <tool_call>\n"
-                "<function=python>\n"
-                "<parameter=code>\n"
-                "def hello():\n"
-                "    print(\"Not the real call!\")\n"
-                "\n"
-                "hello()\n"
-                "</parameter>\n"
-                "</function>\n"
-                "</tool_call>")
+            .expect_reasoning("Let's call a tool:")
             .expect_tool_calls({
+                { "python", "{\"code\": \"def hello():\\n    print(\\\"Not the real call!\\\")\\n\\nhello()\"}", {} },
                 { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need to write a debug file.\n"
+               "<tool_call>\n"
+               "<function=write>\n"
+               "<parameter=file>\n"
+               "/workspace/jsonlfilter/debug_test.go\n"
+               "</parameter>\n"
+               "<parameter=content>\n"
+               "package main\n"
+               "\n"
+               "func main() {\n"
+               "    line := `{name:Jette,status:sleepy}`\n"
+               "    fmt.Printf(\"Status: %q\\n\", result[\"status\"])\n"
+               "}\n"
+               "\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "</think>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({
+                write_tool
+        })
+            .expect_reasoning("Need to write a debug file.")
+            .expect_content("Done.")
+            .expect_tool_calls({
+                { "write", R"({"file":"/workspace/jsonlfilter/debug_test.go","content":"package main\n\nfunc main() {\n    line := `{name:Jette,status:sleepy}`\n    fmt.Printf(\"Status: %q\\n\", result[\"status\"])\n}\n"})", {} },
             })
             .run();
 
@@ -2417,7 +2459,8 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_content(R"({"amount": 123.45, "date": "2025-12-03"})")
             .run();
 
-        // tool call segment in reasoning
+        // Qwen3.5 can emit tool calls inside <think>. Treat <think> as a
+        // reasoning/content mode switch, not as a container that hides tools.
         tst.test(
                "Let's call a tool: <tool_call>\n"
                "<function=python>\n"
@@ -2445,17 +2488,9 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({
                 python_tool
         })
-            .expect_reasoning("Let's call a tool: <tool_call>\n"
-               "<function=python>\n"
-               "<parameter=code>\n"
-               "def hello():\n"
-               "    print(\"Not the real call!\")\n"
-               "\n"
-               "hello()\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n")
+            .expect_reasoning("Let's call a tool:")
             .expect_tool_calls({
+                { "python", "{\"code\": \"def hello():\\n    print(\\\"Not the real call!\\\")\\n\\nhello()\"}", {} },
                 { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
             })
             .run();


### PR DESCRIPTION
## Overview

This PR fixes two tagged-tool parsing issues found while testing Qwen3.5 with reasoning enabled and XML-style tool calls.

### Commit 1: Fix tagged tool calls inside reasoning

The current llama.cpp parser splits content parsing and reasoning parsing into separate paths. This means a `<tool_call>` emitted inside a `<think>...</think>` block can be consumed as `reasoning_content` instead of being parsed as a tool call.

This commit combines those paths for the `TAG_WITH_TAGGED` parser. Reasoning tags now act as text-mode switches:

- text inside reasoning tags is emitted as `reasoning_content`
- text outside reasoning tags is emitted as normal `content`
- tagged tool calls are parsed as `tool_calls` in either mode

The lazy tagged-tool grammar was also adjusted so a triggered `<tool_call>...</tool_call>` does not have to be the final suffix of the completion. This allows the full parser to handle following segments such as `</think>` or later content.

### Commit 2: Accept required tagged tool args in any order

Tagged parameters include their names in-band, for example `<parameter=old_string>`. Requiring these parameters to appear in schema/property iteration order is stricter than necessary and caused valid Qwen-style tool calls to fail parsing.

This commit keeps the existing grammar-based parser structure, but generates permutations for required tagged arguments so they can be accepted in any order. Optional arguments can still appear flexibly around them.

This is intended as a narrow, low-impact fix. A more scalable long-term design would be to parse tagged parameters as an unordered list, collect them by name, reject duplicates, check required parameters after parsing, and emit normalized arguments. That would avoid permutation growth, but would require a larger parser/mapper refactor.

To avoid pathological grammar growth, this commit caps the permutation path at six required parameters. Schemas with more than six required parameters keep the previous fixed-order behavior.

This fixes Qwen-style outputs such as:

```xml
<think>
Reasoning...

<tool_call>
<function=edit>
<parameter=file>...</parameter>
<parameter=old_string>...</parameter>
<parameter=new_string>...</parameter>
</function>
</tool_call>
</think>
```

## Additional information

This was tested downstream with ctgbot and Qwen3.5 9B using reasoning enabled and XML-style tool calls.

A patched CUDA image used for downstream validation is available here:

```text
ghcr.io/bartdeboer/llama-cpp:server-cuda-ctgbot-patches-a03afef
```
Digest:

```text
sha256:a952fea7e739130000e9bca0f4f886a76ba0bb95a932fe23d56b929ef8f1255e
```
Tested locally with:

```text
./build/bin/test-chat --suppress-debug
```

Related issues:

- Fixes #20837
- Fixes #22684
- Related to #20260
- Related to #22398

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assistance was used for investigation and prototyping. I have a software engineering background, but I am not primarily a C++/llama.cpp contributor. I designed the code shape together with Codex, reviewed the changes, tested them locally, and am responsible for the submitted code.