### PR TITLE
common: fix HTTPS handshake on Windows, harden HTTP client

### DIFF
--- a/common/hf-cache.cpp
+++ b/common/hf-cache.cpp
@@ -15,6 +15,10 @@
 #include <string_view>
 #include <stdexcept>
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+#include <openssl/err.h>
+#endif
+
 namespace nl = nlohmann;
 
 #if defined(_WIN32)
@@ -222,7 +226,14 @@ static nl::json api_get(const std::string & url,
 
         throw std::runtime_error("GET failed (" + std::to_string(res->status) + "): " + body);
     } else {
-        throw std::runtime_error("HTTPLIB failed: " + httplib::to_string(res.error()));
+        // surface the backend SSL reason so transport failures are diagnosable instead of opaque
+        char ssl_reason[256] = "n/a";
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+        ERR_error_string_n((unsigned long) res.ssl_backend_error(), ssl_reason, sizeof(ssl_reason));
+#endif
+        throw std::runtime_error(string_format("HTTPLIB failed: %s [ssl_err:%d backend:0x%lx reason:%s]",
+            httplib::to_string(res.error()).c_str(), res.ssl_error(),
+            (unsigned long) res.ssl_backend_error(), ssl_reason));
     }
 }
 

--- a/common/hf-cache.cpp
+++ b/common/hf-cache.cpp
@@ -226,14 +226,16 @@ static nl::json api_get(const std::string & url,
 
         throw std::runtime_error("GET failed (" + std::to_string(res->status) + "): " + body);
     } else {
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
         // surface the backend SSL reason so transport failures are diagnosable instead of opaque
         char ssl_reason[256] = "n/a";
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
         ERR_error_string_n((unsigned long) res.ssl_backend_error(), ssl_reason, sizeof(ssl_reason));
-#endif
         throw std::runtime_error(string_format("HTTPLIB failed: %s [ssl_err:%d backend:0x%lx reason:%s]",
             httplib::to_string(res.error()).c_str(), res.ssl_error(),
             (unsigned long) res.ssl_backend_error(), ssl_reason));
+#else
+        throw std::runtime_error("HTTPLIB failed: " + httplib::to_string(res.error()));
+#endif
     }
 }
 

--- a/common/http.h
+++ b/common/http.h
@@ -91,6 +91,15 @@ static std::pair<httplib::Client, common_http_url> common_http_client(const std:
 
     cli.set_follow_location(true);
 
+    // bound each phase so a stalled handshake or a dead socket fails fast instead of blocking on
+    // the httplib default of 300 seconds
+    constexpr int connection_timeout_sec = 15;
+    constexpr int read_timeout_sec       = 30;
+    constexpr int write_timeout_sec      = 30;
+    cli.set_connection_timeout(connection_timeout_sec, 0);
+    cli.set_read_timeout(read_timeout_sec, 0);
+    cli.set_write_timeout(write_timeout_sec, 0);
+
     return { std::move(cli), std::move(parts) };
 }
 

--- a/vendor/cpp-httplib/CMakeLists.txt
+++ b/vendor/cpp-httplib/CMakeLists.txt
@@ -182,6 +182,13 @@ if(LLAMA_BUILD_BORINGSSL OR LLAMA_BUILD_LIBRESSL)
     endif()
 endif()
 
+# MSVC at /O2 miscompiles the LibreSSL bignum on Windows x64, producing RSA results that vary
+# between runs (ssl_err 0x4FFF086 first or last octet invalid) and break the TLS handshake.
+# Force /Od on the crypto math target until LibreSSL or MSVC ships a fix.
+if(LLAMA_BUILD_LIBRESSL AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(crypto_obj PRIVATE /Od)
+endif()
+
 if (CPPHTTPLIB_OPENSSL_SUPPORT)
     target_compile_definitions(${TARGET} PUBLIC CPPHTTPLIB_OPENSSL_SUPPORT) # used in server.cpp
     if (APPLE AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")


### PR DESCRIPTION
## Overview

The -hf downloader hung or failed on Windows builds using from-source LibreSSL. Root cause: MSVC at /O2 miscompiles LibreSSL's bignum on Windows x64, producing non deterministic RSA verification during the TLS handshake (ssl_err 0x4FFF086, alternating first/last octet invalid). Verified clean on Linux with the same sources. BoringSSL under MSVC was not affected.

### Fix this:
```
PS C:\A> llama serve -hf unsloth/gemma-4-E4B-it-GGUF:BF16 -lv 4
[34m0.00.070.785[0m [32mI [0mcommon_params_handle_remote_preset: looking for remote preset at https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/preset.ini
PS C:\A> ^C
(infinite wait)
```
### Add a timeout and surface the log:
```
PS D:\A\git\llama.cpp\build\bin\Release> .\llama-server.exe -hf unsloth/gemma-4-E4B-it-GGUF:BF16 -lv 4
[34m0.00.020.437[0m [32mI [0mcommon_params_handle_remote_preset: looking for remote preset at https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/preset.ini
[34m0.00.058.244[0m [32mI [0mcommon_download_file_single_online: HEAD failed, status: -1
[34m0.00.058.251[0m [32mI [0mcommon_params_handle_remote_preset: no remote preset found, skipping
[34m0.00.064.753[0m [31mE get_repo_commit: error: HTTPLIB failed: SSL connection failed [ssl_err:4 backend:0x4fff086 reason:error:04FFF086:rsa routines:CRYPTO_internal:last octet invalid]
[0m[34m0.00.064.757[0m [35mW get_repo_files: failed to resolve commit for unsloth/gemma-4-E4B-it-GGUF
[0mfailed to download model from Hugging Face
```

### Then finally, correct the root cause:
```
PS D:\A\git\llama.cpp\build\bin\Release> .\llama-server.exe -hf unsloth/gemma-4-E4B-it-GGUF:Q8_K_XL -lv 4
[34m0.00.020.530[0m [32mI [0mcommon_params_handle_remote_preset: looking for remote preset at https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/preset.ini
[34m0.00.168.244[0m [32mI [0mcommon_download_file_single_online: HEAD failed, status: 404
[34m0.00.168.506[0m [32mI [0mcommon_params_handle_remote_preset: no remote preset found, skipping

Downloading gemma-4-E4B-it-UD-Q8_K_XL.gguf ─────────                  36%[K[1B
```


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
