### PR TITLE
Speed up ggml_gemv_q4_K_8x8_q8_K

### DIFF
--- a/ggml/src/ggml-cpu/arch/x86/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/x86/repack.cpp
@@ -1512,6 +1512,7 @@ void ggml_gemv_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
 
             // Pointers to RHS blocks
             const block_q4_Kx8 * b_ptr = b_ptr_start + (x * b_nb);
+            const block_q4_Kx8 * next_b_ptr = b_ptr_start + ((x+1) * b_nb);
 
             // Master FP accumulators
             __m256 acc_row = _mm256_setzero_ps();
@@ -1536,6 +1537,22 @@ void ggml_gemv_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
 
                 // Processes two sub blocks from each Q4_K in each iteration
                 for (int sb = 0; sb < QK_K / 64; sb++) {
+
+                    // Prefetching of the next blocks
+                    if(b + 1 < nb) {
+                        _mm_prefetch(b_ptr[b+1].qs + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(b_ptr[b+1].qs + 64 + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(b_ptr[b+1].qs + 128 + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(b_ptr[b+1].qs + 192 + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(b_ptr[b+1].scales + 24 * sb, _MM_HINT_T0);
+                    }
+                    else if(x + 1 < nc / 8) {
+                        _mm_prefetch(next_b_ptr[0].qs + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(next_b_ptr[0].qs + 64 + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(next_b_ptr[0].qs + 128 + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(next_b_ptr[0].qs + 192 + sb * 256, _MM_HINT_T0);
+                        _mm_prefetch(next_b_ptr[0].scales + 24 * sb, _MM_HINT_T0);
+                    }
 
                     // Load the eight block_q4_K for two sub blocks quantized values interleaved with each other in chunks of eight - B0,B1 ....B6,B7
                     const __m256i rhs_raw_vec_0123_0 = _mm256_loadu_si256((const __m256i * )(b_ptr[b].qs + sb * 256));


### PR DESCRIPTION
## Overview

Hello. On my machine (i5-9600KF CPU with 2x3200 DDR4 channels reaching up to ~42 GB/s and having a 16 cycle CAS latency), the computation of all Q4_K models I tested (from 3B to 27B models) is pretty memory-bound. That being said, the memory is not fully saturated partially because of memory latency (mainly the DRAM). This PR helps x86 CPU to saturate the memory bandwidth even more thanks to **prefetching** instructions. For example on Ministral 3B (Q4_K_S), the speed up is about 5-6% on my machine for the first test, and about 13% for the second one. This speed up is roughly the same on bigger models.

## Additional information

Here is a benchmark:

```
     # Master branch

$ ./bin/llama-bench -m /mnt/397758A91B369501/lmstudio/models/unsloth/Ministral-3-3B-Instruct-2512-GGUF/Ministral-3-3B-Instruct-2512-Q4_K_S.gguf
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| mistral3 3B Q4_K - Small       |   1.90 GiB |     3.43 B | CPU        |       6 |           pp512 |         80.95 ± 0.72 |
| mistral3 3B Q4_K - Small       |   1.90 GiB |     3.43 B | CPU        |       6 |           tg128 |         16.22 ± 0.08 |

--------------------

     # This PR

$ ./bin/llama-bench -m /mnt/397758A91B369501/lmstudio/models/unsloth/Ministral-3-3B-Instruct-2512-GGUF/Ministral-3-3B-Instruct-2512-Q4_K_S.gguf
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| mistral3 3B Q4_K - Small       |   1.90 GiB |     3.43 B | CPU        |       6 |           pp512 |         85.26 ± 1.35 |
| mistral3 3B Q4_K - Small       |   1.90 GiB |     3.43 B | CPU        |       6 |           tg128 |         18.32 ± 0.19 |
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
