### PR TITLE
server: exclude compute buffer from fit margin for draft/MTP models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -848,10 +848,12 @@ private:
                     }
 
                     for (size_t j = 0; j < devs.size(); ++j) {
+                        // Note: compute buffer is excluded because it is shared
+                        // with the main model via ggml_backend_sched and will be
+                        // accounted for during the main model's fit measurement.
                         const size_t bytes =
                             (measure_model_bytes ? dmd[j].mb.model : 0) +
-                            dmd[j].mb.context +
-                            dmd[j].mb.compute;
+                            dmd[j].mb.context;
                         total += bytes;
                         for (size_t i = 0; i < tgt_devices.size(); i++) {
                             if (tgt_devices[i] == devs[j]) {


### PR DESCRIPTION


Fixes #23772






| Version | `fit_params_target` addition | Log output |
|---------|------------------------------|------------|
| **b9305 (buggy)** | **509 MiB** (8 context + 501 compute) | `[spec] adding 509.00 MiB to fit_params_target` |
| **b9305-fix** | **8 MiB** (8 context only) | `[spec] adding 8.00 MiB to fit_params_target` |

The buggy version over-reserves VRAM by **501 MiB**, forcing the fit algorithm to make more conservative offloading decisions.

## Benchmark Results

### Test Environment
- **GPU**: NVIDIA RTX 3090 Ti (24 GB)
- **CPU**: Intel i7-14700KF
- **Model**: `unsloth/Qwen3.6-35B-A3B-MTP-GGUF` (UD-Q4_K_M, 21.1 GB)
- **Params**: `--fit on --fit-target 5120 --spec-type draft-mtp --spec-draft-n-max 2 --ctx-size 4096 --flash-attn on`

### 3-Way Comparison (b9297 baseline vs b9305 buggy vs b9305 fix)

> `--fit-target 5120` simulates constrained VRAM to trigger fit adjustments (the reporter uses 2× RTX 3060 12GB where VRAM pressure is much higher).

| Version | spec reservation | GPU layers | PP (t/s) | TG (t/s) |
|---------|-----------------|-----------|---------|---------|
| b9297 (pre-regression baseline) | N/A | 42/42 | **270.6** | **128.5** |
| b9305 (with PR #23485 bug) | 509 MiB | 42/42 | 260.5 | 124.6 |
| **b9305 + this fix** | **8 MiB** | 42/42 | **268.5** | **127.3** |

### Performance Analysis

| Comparison | PP change | TG change |
|------------|----------|----------|
| Regression (b9305 vs b9297) | **-3.7%** | **-3.1%** |
| Fix improvement (fix vs b9305) | **+3.1%** | **+2.2%** |
| Fix vs baseline (fix vs b9297) | **-0.8%** | **-1.0%** |




<details>
<summary>Full server logs (buggy vs fix)</summary>

**b9305 buggy:**
```
[spec] adding 509.00 MiB to fit_params_target for device CUDA0
[spec] estimated memory usage of MTP context is 509.00 MiB
common_params_fit_impl: cannot meet free memory target of 5120 MiB, need to reduce device memory by 4472 MiB
```

**b9305 fix:**
```
[spec] adding 8.00 MiB to fit_params_target for device CUDA0
[spec] estimated memory usage of MTP context is 8.00 MiB
common_params_fit_impl: cannot meet free memory target of 5128 MiB, need to reduce device memory by 4480 MiB
```

</details>

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I used Claude to assist with writing the benchmark scripts for cross-version testing.<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
