### PR TITLE
mtmd: fix gemma 4 projector pre_norm

### DIFF
--- a/tools/mtmd/models/gemma4v.cpp
+++ b/tools/mtmd/models/gemma4v.cpp
@@ -124,12 +124,12 @@ ggml_cgraph * clip_graph_gemma4v::build() {
     }
 
     // Gemma4MultimodalEmbedder
-    cur = build_mm(model.mm_input_proj_w, cur);
-    cb(cur, "projected", -1);
-
-    // embedding_post_projection_norm
-    cur = ggml_rms_norm(ctx0, cur, hparams.eps);
-    cb(cur, "projected_normed", -1);
+    {
+        // embedding_pre_projection_norm
+        cur = ggml_rms_norm(ctx0, cur, hparams.eps);
+        cur = build_mm(model.mm_input_proj_w, cur);
+        cb(cur, "projected", -1);
+    }
 
     ggml_build_forward_expand(gf, cur);
     return gf;


### PR DESCRIPTION
## Overview

The early pre-release version of gemma 4 uses post norm for multimodal projector, but it was later swapped to pre-norm and I did not notice about that.

This should fix some vision-related problems with gemma 4.

Ref python code: https://github.com/huggingface/transformers/blob/1656d90b774d94c30af24113e60e926fc2f39072/src/transformers/models/gemma4/modeling_gemma4.py#L2068-L2092

Test:

<img width="309" height="313" alt="image" src="https://github.com/user-attachments/assets/e34cf566-d7fa-4b0d-a462-ffba4bec8b7f" />

<img width="586" height="685" alt="image" src="https://github.com/user-attachments/assets/d3cd7779-0fce-4d0e-8397-bbd61422a0c7" />

<img width="1013" height="800" alt="image" src="https://github.com/user-attachments/assets/c88d5d54-0450-40db-a496-03768d0ad08a" />


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
