### PR TITLE
Removes PDL enrollment of launch_fattn kernels to fix bug on DGX Spark

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -1153,8 +1153,8 @@ void launch_fattn(
 
     GGML_ASSERT(block_dim.x % warp_size == 0);
 
-    const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(blocks_num, block_dim, nbytes_shared, main_stream);
-    ggml_cuda_kernel_launch(fattn_kernel, launch_params,
+        // disabled PDL enrollment for now due to a compiler bug.
+        fattn_kernel<<<blocks_num, block_dim, nbytes_shared, main_stream>>>(
         (const char *) Q->data,
         K_data,
         V_data,


### PR DESCRIPTION
## Overview
On DGX Spark, we saw spurious test failures when running `test-backend-ops -o FLASH_ATTN_EXT` with PDL enabled.
We identified an internal bug which caused a race condition in a kernel launched with `launch_fattn()`.
For now, moving these kernels out of PDL enrollment fixes this bug in my testing. 

## Performance Impact 
Negative perf impact is limited, I saw around ~0.2% perf loss on both DGX Spark and RTX Pro 6000 for the models gpt-oss20B and qwen35moe 35B.A3B Q4_K.
<!-- Describe what this PR does and why. Be concise but complete -->

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for debugging. Every line of code proposed here was manually checked and tested before commit.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
@ORippler @ggerganov let me know if this fixes the bug on your setups.