### PR TITLE
fix(tps): correct off-by-one in decode token count for generation TPS

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -80,7 +80,7 @@ struct server_slot {
     // generation props
     int32_t n_ctx       = 0;  // context size per slot
     int32_t n_keep      = 0;
-    int32_t n_decoded   = 0;
+    int32_t n_decoded   = -1;
     int32_t n_remaining = -1;
     int32_t i_batch     = -1;
 
@@ -2994,7 +2994,7 @@ private:
                         // extract the logits only for the last token
                         batch.logits[batch.n_tokens - 1] = true;
 
-                        slot.n_decoded = 0;
+                        slot.n_decoded = -1;
                         slot.i_batch   = batch.n_tokens - 1;
 
                         slot.init_sampler();
@@ -3299,7 +3299,7 @@ private:
 
                 slot.n_decoded += 1;
 
-                if (slot.n_decoded == 1) {
+                if (slot.n_decoded == 0) {
                     slot.t_start_generation = t_current;
                     slot.t_prompt_processing = (slot.t_start_generation - slot.t_start_process_prompt) / 1e3;
                     metrics.on_prompt_eval(slot);


### PR DESCRIPTION
## Overview

Generation TPS was computed using an extra decode token in the token count, while the decode time measurement did not include this extra step. This caused an inflated TPS value due to mismatched token/time accounting.

This change fixes the off-by-one issue in decode token counting to ensure consistent alignment between decode tokens and decode duration.

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes (used for commit message drafting and wording)
<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
