### PR TITLE
nix: add nix-nodejs facilities to build Web UI

### DIFF
--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -150,24 +150,14 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       inherit nodejs;
     };
 
-    buildPhase = ''
-      runHook preBuild
-      npm run build --offline
-      runHook postBuild
-    '';
-
     installPhase = ''
-      runHook preInstall
-      mkdir -p $out
-      cp -r dist/. $out/
-      runHook postInstall
+      LLAMA_UI_OUT_DIR=$out npm run build --offline
     '';
   };
 
   postPatch = lib.optionalString useWebUi ''
-    mkdir -p build/tools/ui
-    cp -r ${finalAttrs.webui} build/tools/ui/dist
-    chmod -R u+w build/tools/ui/dist
+    cp -r ${finalAttrs.webui} tools/ui/dist
+    chmod -R u+w tools/ui/dist
   '';
 
   # With PR#6015 https://github.com/ggml-org/llama.cpp/pull/6015,

--- a/.devops/nix/package.nix
+++ b/.devops/nix/package.nix
@@ -3,6 +3,7 @@
   glibc,
   config,
   stdenv,
+  stdenvNoCC,
   runCommand,
   cmake,
   ninja,
@@ -19,6 +20,8 @@
   openssl,
   shaderc,
   spirv-headers,
+  nodejs,
+  importNpmLock,
   useBlas ?
     builtins.all (x: !x) [
       useCuda
@@ -130,7 +133,41 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     src = lib.cleanSource ../../.;
   };
 
-  postPatch = ''
+  # Builds the webui locally, taking care not to require updating any sha256 hash.
+  webui = stdenvNoCC.mkDerivation {
+    pname = "webui";
+    version = llamaVersion;
+    src = lib.cleanSource ../../tools/ui;
+
+    nativeBuildInputs = [
+      nodejs
+      importNpmLock.linkNodeModulesHook
+    ];
+
+    # no sha256 required when using buildNodeModules
+    npmDeps = importNpmLock.buildNodeModules {
+      npmRoot = ../../tools/ui;
+      inherit nodejs;
+    };
+
+    buildPhase = ''
+      runHook preBuild
+      npm run build --offline
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/. $out/
+      runHook postInstall
+    '';
+  };
+
+  postPatch = lib.optionalString useWebUi ''
+    mkdir -p build/tools/ui
+    cp -r ${finalAttrs.webui} build/tools/ui/dist
+    chmod -R u+w build/tools/ui/dist
   '';
 
   # With PR#6015 https://github.com/ggml-org/llama.cpp/pull/6015,


### PR DESCRIPTION
## Overview

Build the Web UI locally using standard Nix systems for building NodeJS packages.

- Create derivation for the web UI
- npm dependencies are imported via buildNodeModules. Does not require setting any shasum.
- Copy build artifacts to the correct folders.
- Prevents having to download from huggingface.co

Fixes #23067

## Additional information

- I use this PR with my NixOS machines, running the webui as well.
- I have only tested the vulkan build (which should not matter for a nix patch).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, to generate `postPatch`.