### PR TITLE
chat: route LiquidAI LFM2.5 through specialized parser

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1724,10 +1724,23 @@ static common_chat_params common_chat_params_init_lfm2(const common_chat_templat
 //   Tool calls can appear multiple times (parallel tool calls supported)
 static common_chat_params common_chat_params_init_lfm2_5(const common_chat_template &    tmpl,
                                                          const autoparser::generation_params & inputs) {
+
+    auto is_8b_variant = tmpl.source().find("message.thinking") != std::string::npos;
+
+    auto adjusted_messages = inputs.messages;
+    if (is_8b_variant) {
+        // Copy reasoning to the "thinking" field as expected by the LFM2.5 8B A1B template
+        for (auto & msg : adjusted_messages) {
+            if (msg.contains("reasoning_content") && msg.at("reasoning_content").is_string()) {
+                msg["thinking"] = msg.at("reasoning_content");
+            }
+        }
+    }
+
     common_chat_params data;
 
-    data.prompt            = common_chat_template_direct_apply_impl(tmpl, inputs);
-    data.generation_prompt = common_chat_template_generation_prompt_impl(tmpl, inputs);
+    data.prompt            = common_chat_template_direct_apply_impl(tmpl, inputs, /* messages_override= */ adjusted_messages);
+    data.generation_prompt = common_chat_template_generation_prompt_impl(tmpl, inputs, /* messages_override= */ adjusted_messages);
     data.format            = COMMON_CHAT_FORMAT_PEG_NATIVE;
     data.supports_thinking = true;
     data.preserved_tokens  = {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -626,6 +626,22 @@ static bool is_lfm2_template(const std::string & src) {
            src.find("<|tool_list_end|>")   != std::string::npos;
 }
 
+// LFM2.5 format detection: match both static "List of tools: [...]" templates and LiquidAI templates
+// that build the same prefix dynamically via "List of tools: " + (tools | tojson).
+static bool is_lfm2_5_template(const std::string & src) {
+    // LFM2 uses wrapper tokens around the tool list; keep those templates on the LFM2 path.
+    if (src.find("<|tool_list_start|>") != std::string::npos) {
+        return false;
+    }
+
+    if (src.find("List of tools: [") != std::string::npos) {
+        return true;
+    }
+
+    return src.find("List of tools: ") != std::string::npos &&
+           src.find("tools | tojson")  != std::string::npos;
+}
+
 common_chat_prompt_preset common_chat_get_asr_prompt(const common_chat_templates * chat_templates) {
     common_chat_prompt_preset asr_preset;
     asr_preset.system = "";
@@ -2302,8 +2318,7 @@ std::optional<common_chat_params> common_chat_try_specialized_template(
     }
 
     // LFM2.5 format detection: template uses plain "List of tools: [...]" with no special tokens
-    if (src.find("List of tools: [") != std::string::npos &&
-        src.find("<|tool_list_start|>") == std::string::npos) {
+    if (is_lfm2_5_template(src)) {
         LOG_DBG("Using specialized template: LFM2.5\n");
         return common_chat_params_init_lfm2_5(tmpl, params);
     }

--- a/models/templates/LFM2.5-8B-A1B.jinja
+++ b/models/templates/LFM2.5-8B-A1B.jinja
@@ -1,0 +1,105 @@
+{{- bos_token -}}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+
+{%- macro format_arg_value(arg_value) -%}
+    {%- if arg_value is string -%}
+        {{- "'" + arg_value + "'" -}}
+    {%- elif arg_value is mapping -%}
+        {{- arg_value | tojson -}}
+    {%- else -%}
+        {{- arg_value | string -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro parse_content(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- else -%}
+        {%- set _ns = namespace(result="") -%}
+        {%- for item in content -%}
+            {%- if item["type"] == "image" -%}
+                {%- set _ns.result = _ns.result + "<image>" -%}
+            {%- elif item["type"] == "text" -%}
+                {%- set _ns.result = _ns.result + item["text"] -%}
+            {%- else -%}
+                {%- set _ns.result = _ns.result + item | tojson -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {{- _ns.result -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_tool_calls(tool_calls) -%}
+    {%- set tool_calls_ns = namespace(tool_calls=[]) -%}
+    {%- for tool_call in tool_calls -%}
+        {%- set func_name = tool_call["function"]["name"] -%}
+        {%- set func_args = tool_call["function"]["arguments"] -%}
+        {%- set args_ns = namespace(arg_strings=[]) -%}
+        {%- for arg_name, arg_value in func_args.items() -%}
+            {%- set args_ns.arg_strings = args_ns.arg_strings + [arg_name + "=" + format_arg_value(arg_value)] -%}
+        {%- endfor -%}
+        {%- set tool_calls_ns.tool_calls = tool_calls_ns.tool_calls + [func_name + "(" + (args_ns.arg_strings | join(", ")) + ")"] -%}
+    {%- endfor -%}
+    {{- "<|tool_call_start|>[" + (tool_calls_ns.tool_calls | join(", ")) + "]<|tool_call_end|>" -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(system_prompt="", last_user_index=-1) -%}
+{%- if messages[0]["role"] == "system" -%}
+    {%- if messages[0].get("content") -%}
+        {%- set ns.system_prompt = parse_content(messages[0]["content"]) -%}
+    {%- endif -%}
+    {%- set messages = messages[1:] -%}
+{%- endif -%}
+{%- if tools -%}
+    {%- set ns.system_prompt = ns.system_prompt + ("\n\n" if ns.system_prompt else "") + "Today's date: " + strftime_now("%Y-%m-%d") + "\n\nList of tools: " + (tools | tojson) -%}
+{%- endif -%}
+{%- if ns.system_prompt -%}
+    {{- "<|im_start|>system\n" + ns.system_prompt + "<|im_end|>\n" -}}
+{%- endif -%}
+{%- for message in messages -%}
+    {%- if message["role"] == "user" -%}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- for message in messages -%}
+    {{- "<|im_start|>" + message.role + "\n" -}}
+    {%- if message.role == "assistant" -%}
+        {%- generation -%}
+        {%- if message.thinking is defined and (preserve_thinking or loop.index0 > ns.last_user_index) -%}
+            {{- "<think>" + message.thinking + "</think>" -}}
+        {%- endif -%}
+        {%- set _cfm_tag = "CONTINUE_FINAL_MESSAGE_TAG " -%}
+        {%- set _has_cfm = false -%}
+        {%- if message.content is defined -%}
+            {%- set content = parse_content(message.content) -%}
+            {%- if not (preserve_thinking or loop.index0 > ns.last_user_index) -%}
+                {%- if "</think>" in content -%}
+                    {%- set content = content.split("</think>")[-1] | trim -%}
+                {%- endif -%}
+            {%- endif -%}
+            {%- if message.tool_calls is defined and content.endswith(_cfm_tag) -%}
+                {%- set _has_cfm = true -%}
+                {%- set _trunc_len = (content | length) - (_cfm_tag | length) -%}
+                {{- content[:_trunc_len] -}}
+            {%- else -%}
+                {{- content -}}
+            {%- endif -%}
+        {%- endif -%}
+        {%- if message.tool_calls is defined -%}
+            {{- render_tool_calls(message.tool_calls) -}}
+        {%- endif -%}
+        {%- if _has_cfm -%}
+            {{- _cfm_tag -}}
+        {%- endif -%}
+        {{- "<|im_end|>\n" -}}
+        {%- endgeneration -%}
+    {%- else %}
+        {%- if message.get("content") -%}
+            {{- parse_content(message["content"]) -}}
+        {%- endif -%}
+        {{- "<|im_end|>\n" -}}
+    {%- endif %}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "<|im_start|>assistant\n" -}}
+{%- endif -%}

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -4212,6 +4212,24 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .run();
     }
 
+    // LiquidAI LFM2.5 tests - uses plain "List of tools: " + (tools | tojson)
+    {
+        auto tst = peg_tester("models/templates/LFM2.5-8B-A1B.jinja", detailed_debug);
+
+        tst.test("<think>I'm\nthinking</think>Hello, world!\nWhat's up?")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .expect(message_assist_thoughts)
+            .run();
+
+        tst.test("<think>I'm\nthinking</think>[special_function(arg1=1)]")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ special_function_tool })
+            .expect(message_assist_call_thoughts)
+            .run();
+    }
+
     // Reka-Edge tests - uses native JSON format with per-call wrapper
     {
         auto tst = peg_tester("models/templates/Reka-Edge.jinja", detailed_debug);
@@ -5435,6 +5453,13 @@ static void test_template_generation_prompt() {
 
     {
         auto tmpls = read_templates("models/templates/LFM2.5-Instruct.jinja");
+        check(tmpls, basic(),                  "<|im_start|>assistant\n");
+        check(tmpls, continuation_content(),   "<|im_start|>assistant\n<think>I'm thinking</think>Hello, ");
+        check(tmpls, continuation_reasoning(), "<|im_start|>assistant\n<think>I'm");
+    }
+
+    {
+        auto tmpls = read_templates("models/templates/LFM2.5-8B-A1B.jinja");
         check(tmpls, basic(),                  "<|im_start|>assistant\n");
         check(tmpls, continuation_content(),   "<|im_start|>assistant\n<think>I'm thinking</think>Hello, ");
         check(tmpls, continuation_reasoning(), "<|im_start|>assistant\n<think>I'm");


### PR DESCRIPTION
## Overview

  Fixes #23852.

  LiquidAI LFM2.5 responses with `<think>...</think>` were being returned inline in `message.content` instead of being extracted into `message.reasoning_content`.

  Currently there already is a specialized LFM2.5 parser, but LiquidAI's GGUF chat template was not being detected as LFM2.5 because its tool list is built dynamically with Jinja. This change updates LFM2.5 template detection so LiquidAI's template is routed to the existing parser.

## Additional information

  Before this change, the LFM2.5 detector looked for a literal `List of tools: [` substring in the raw template source. The LiquidAI GGUF template can render that prompt text, but its source contains `tools | tojson` instead. Since detection happens before template rendering, the specialized LFM2.5 parser was not selected.

  I added regression coverage using the LFM2.5-8B-A1B template file.

  Tested with:

  ```bash
  ./build-tests/bin/test-chat --template LFM2.5-8B-A1B
  ```

## Requirements
  <!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

  - I have read and agree with the contributing guidelines (https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
  - AI usage disclosure: YES, I used AI to identify the problem and write the fix. I reviewed and tested the code myself.