### PR TITLE
Add missing include

### DIFF
--- a/common/ngram-mod.cpp
+++ b/common/ngram-mod.cpp
@@ -1,5 +1,7 @@
 #include "ngram-mod.h"
 
+#include <algorithm>
+
 //
 // common_ngram_mod
 //


### PR DESCRIPTION
## Overview

Add a missing include to keep clang-tidy happy. The cpp file in question uses `std::fill` which technically requires `#include <algorithm>`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

