### PR TITLE
llama: limit max outputs of `llama_context`

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1562,8 +1562,8 @@ struct llama_context_params common_context_params_to_llama(const common_params &
 
     cparams.n_ctx             = params.n_ctx;
     cparams.n_seq_max         = params.n_parallel;
-    cparams.n_rs_seq          = params.speculative.need_n_rs_seq();
-    cparams.n_outputs_per_seq = std::max(params.n_outputs_per_seq, 0);
+    cparams.n_rs_seq      = params.speculative.need_n_rs_seq();
+    cparams.n_outputs_max = std::max(params.n_outputs_max, 0);
     cparams.n_batch           = params.n_batch;
     cparams.n_ubatch          = params.n_ubatch;
     cparams.n_threads         = params.cpuparams.n_threads;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1562,8 +1562,8 @@ struct llama_context_params common_context_params_to_llama(const common_params &
 
     cparams.n_ctx             = params.n_ctx;
     cparams.n_seq_max         = params.n_parallel;
-    cparams.n_rs_seq      = params.speculative.need_n_rs_seq();
-    cparams.n_outputs_max = std::max(params.n_outputs_max, 0);
+    cparams.n_rs_seq          = params.speculative.need_n_rs_seq();
+    cparams.n_outputs_max     = std::max(params.n_outputs_max, 0);
     cparams.n_batch           = params.n_batch;
     cparams.n_ubatch          = params.n_ubatch;
     cparams.n_threads         = params.cpuparams.n_threads;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1563,6 +1563,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.n_ctx             = params.n_ctx;
     cparams.n_seq_max         = params.n_parallel;
     cparams.n_rs_seq          = params.speculative.need_n_rs_seq();
+    cparams.n_outputs_per_seq = std::max(params.n_outputs_per_seq, 0);
     cparams.n_batch           = params.n_batch;
     cparams.n_ubatch          = params.n_ubatch;
     cparams.n_threads         = params.cpuparams.n_threads;

--- a/common/common.h
+++ b/common/common.h
@@ -431,7 +431,7 @@ struct common_params {
     int32_t n_chunks              =    -1; // max number of chunks to process (-1 = unlimited)
     int32_t n_parallel            =     1; // number of parallel sequences to decode
     int32_t n_sequences           =     1; // number of sequences to decode
-    int32_t n_outputs_max         =     0; // max outputs in a ubatch (0 = n_batch)
+    int32_t n_outputs_max         =     0; // max outputs in a batch (0 = n_batch)
     int32_t grp_attn_n            =     1; // group-attention factor
     int32_t grp_attn_w            =   512; // group-attention width
     int32_t n_print               =    -1; // print token count every n tokens (-1 = disabled)

--- a/common/common.h
+++ b/common/common.h
@@ -431,7 +431,7 @@ struct common_params {
     int32_t n_chunks              =    -1; // max number of chunks to process (-1 = unlimited)
     int32_t n_parallel            =     1; // number of parallel sequences to decode
     int32_t n_sequences           =     1; // number of sequences to decode
-    int32_t n_outputs_per_seq     =     0; // max outputs per sequence in a ubatch (0 = no limit)
+    int32_t n_outputs_max         =     0; // max outputs in a ubatch (0 = n_batch)
     int32_t grp_attn_n            =     1; // group-attention factor
     int32_t grp_attn_w            =   512; // group-attention width
     int32_t n_print               =    -1; // print token count every n tokens (-1 = disabled)

--- a/common/common.h
+++ b/common/common.h
@@ -431,6 +431,7 @@ struct common_params {
     int32_t n_chunks              =    -1; // max number of chunks to process (-1 = unlimited)
     int32_t n_parallel            =     1; // number of parallel sequences to decode
     int32_t n_sequences           =     1; // number of sequences to decode
+    int32_t n_outputs_per_seq     =     0; // max outputs per sequence in a ubatch (0 = no limit)
     int32_t grp_attn_n            =     1; // group-attention factor
     int32_t grp_attn_w            =   512; // group-attention width
     int32_t n_print               =    -1; // print token count every n tokens (-1 = disabled)

--- a/include/llama.h
+++ b/include/llama.h
@@ -339,6 +339,7 @@ extern "C" {
         uint32_t n_ubatch;          // physical maximum batch size
         uint32_t n_seq_max;         // max number of sequences (i.e. distinct states for recurrent models)
         uint32_t n_rs_seq;          // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
+        uint32_t n_outputs_per_seq; // max outputs per sequence in a ubatch (0 = no limit)
         int32_t  n_threads;         // number of threads to use for generation
         int32_t  n_threads_batch;   // number of threads to use for batch processing
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -339,7 +339,7 @@ extern "C" {
         uint32_t n_ubatch;          // physical maximum batch size
         uint32_t n_seq_max;         // max number of sequences (i.e. distinct states for recurrent models)
         uint32_t n_rs_seq;          // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
-        uint32_t n_outputs_per_seq; // max outputs per sequence in a ubatch (0 = no limit)
+        uint32_t n_outputs_max;     // max outputs in a ubatch (0 = n_batch)
         int32_t  n_threads;         // number of threads to use for generation
         int32_t  n_threads_batch;   // number of threads to use for batch processing
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -30,6 +30,24 @@ static llm_graph_type ctx_type_to_graph_type(llama_context_type ctx_type) {
     throw std::runtime_error("Unsupported ctx type");
 }
 
+static uint32_t graph_n_outputs_pp(const llama_cparams & cparams, uint32_t n_tokens, uint32_t n_seqs) {
+    GGML_ASSERT(n_tokens >= 1);
+    GGML_ASSERT(n_seqs   >= 1);
+
+    const bool reserve_all_outputs =
+        cparams.embeddings ||
+        cparams.pooling_type != LLAMA_POOLING_TYPE_NONE ||
+        cparams.n_outputs_per_seq == 0;
+
+    if (reserve_all_outputs) {
+        return n_tokens;
+    }
+
+    const uint64_t n_outputs = (uint64_t) n_seqs * cparams.n_outputs_per_seq;
+
+    return std::max<uint32_t>(1, std::min<uint64_t>(n_tokens, n_outputs));
+}
+
 llama_context::llama_context(
         const llama_model & model,
               llama_context_params params) :
@@ -50,6 +68,8 @@ llama_context::llama_context(
     if (cparams.n_seq_max > LLAMA_MAX_SEQ) {
         throw std::runtime_error("n_seq_max must be <= " + std::to_string(LLAMA_MAX_SEQ));
     }
+
+    cparams.n_outputs_per_seq = params.n_outputs_per_seq;
 
     cparams.n_rs_seq = params.n_rs_seq;
     if (cparams.n_rs_seq > 0 && !llm_arch_supports_rs_rollback(model.arch)) {
@@ -577,8 +597,7 @@ void llama_context::sched_reserve() {
     int n_splits_tg = -1;
     int n_nodes_tg  = -1;
 
-    const bool     reserve_all_outputs = cparams.embeddings || cparams.pooling_type != LLAMA_POOLING_TYPE_NONE;
-    const uint32_t n_outputs_pp        = reserve_all_outputs ? n_tokens : n_seqs;
+    const uint32_t n_outputs_pp = graph_n_outputs_pp(cparams, n_tokens, n_seqs);
 
     // reserve pp (prompt processing) graph first so that buffers are only allocated once
     {
@@ -777,8 +796,7 @@ bool llama_context::memory_update(bool optimize) {
         const uint32_t n_seqs = cparams.n_seq_max;
         const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
 
-        const bool     reserve_all_outputs = cparams.embeddings || cparams.pooling_type != LLAMA_POOLING_TYPE_NONE;
-        const uint32_t n_outputs_pp        = reserve_all_outputs ? n_tokens : n_seqs;
+        const uint32_t n_outputs_pp = graph_n_outputs_pp(cparams, n_tokens, n_seqs);
 
         auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
         if (!gf) {
@@ -2230,9 +2248,13 @@ ggml_cgraph * llama_context::graph_reserve(
     LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
     GGML_ASSERT(n_outputs >= 1);
 
+    const bool reserve_all_outputs = n_outputs >= n_tokens;
+
     if (n_tokens % n_seqs != 0) {
         n_tokens = ((n_tokens + (n_seqs - 1)) / n_seqs) * n_seqs; // round to next multiple of n_seqs
-        n_outputs = std::max(n_outputs, n_tokens);
+        if (reserve_all_outputs) {
+            n_outputs = std::max(n_outputs, n_tokens);
+        }
 
         LLAMA_LOG_DEBUG("%s: making n_tokens a multiple of n_seqs - n_tokens = %u, n_seqs = %u, n_outputs = %u\n", __func__, n_tokens, n_seqs, n_outputs);
     }
@@ -3343,6 +3365,7 @@ llama_context_params llama_context_default_params() {
         /*.n_ubatch                    =*/ 512,
         /*.n_seq_max                   =*/ 1,
         /*.n_rs_seq                    =*/ 0,
+        /*.n_outputs_per_seq           =*/ 0,
         /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
         /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
         /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -778,9 +778,9 @@ bool llama_context::memory_update(bool optimize) {
         const uint32_t n_seqs = cparams.n_seq_max;
         const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
 
-        const uint32_t n_outputs_pp = std::min(n_tokens, cparams.n_outputs_max);
+        const uint32_t n_outputs_max = std::min(n_tokens, cparams.n_outputs_max);
 
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_max, mctx.get());
         if (!gf) {
             LLAMA_LOG_ERROR("%s: failed to reserve graph after the memory update\n", __func__);
         }
@@ -1786,8 +1786,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
             // needs to happen before the graph is built
             n_outputs = n_outputs_new;
-
-            GGML_ASSERT(n_outputs <= cparams.n_outputs_max);
         }
 
         ggml_status status;
@@ -2148,6 +2146,8 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
 
     this->n_outputs = 0;
 
+    GGML_ASSERT(n_outputs_max <= cparams.n_outputs_max);
+
     return n_outputs_max;
 }
 
@@ -2232,14 +2232,8 @@ ggml_cgraph * llama_context::graph_reserve(
     LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
     GGML_ASSERT(n_outputs >= 1);
 
-    const bool reserve_all_outputs = n_outputs >= n_tokens;
-
     if (n_tokens % n_seqs != 0) {
         n_tokens = ((n_tokens + (n_seqs - 1)) / n_seqs) * n_seqs; // round to next multiple of n_seqs
-        if (reserve_all_outputs) {
-            n_outputs = std::max(n_outputs, n_tokens);
-        }
-
         LLAMA_LOG_DEBUG("%s: making n_tokens a multiple of n_seqs - n_tokens = %u, n_seqs = %u, n_outputs = %u\n", __func__, n_tokens, n_seqs, n_outputs);
     }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -531,7 +531,7 @@ void llama_context::sched_reserve() {
             // note: n_outputs must match n_tokens for embedding models with mean/rank pooling,
             // because build_pooling creates inp_mean with shape [n_tokens, n_seqs] and multiplies
             // it with t_embd which is reduced to [n_outputs, ...] via out_ids. if n_outputs != n_tokens,
-            // the ggml_mul_mat assertion fails. this matches the pp reservation below (line ~553).
+            // the ggml_mul_mat assertion fails.
             const uint32_t n_tokens_ch = 16*n_seqs;
             auto * gf = graph_reserve(n_tokens_ch, n_seqs, n_tokens_ch, mctx.get(), true);
             if (!gf) {
@@ -577,16 +577,19 @@ void llama_context::sched_reserve() {
     int n_splits_tg = -1;
     int n_nodes_tg  = -1;
 
+    const bool     reserve_all_outputs = cparams.embeddings || cparams.pooling_type != LLAMA_POOLING_TYPE_NONE;
+    const uint32_t n_outputs_pp        = reserve_all_outputs ? n_tokens : n_seqs;
+
     // reserve pp (prompt processing) graph first so that buffers are only allocated once
     {
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get(),
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get(),
                 model.hparams.no_alloc, model.hparams.no_alloc ? backend_buf_exp_size.data() : nullptr);
         if (!gf) {
             if (cparams.pipeline_parallel) {
                 LLAMA_LOG_WARN("%s: compute buffer allocation failed, retrying without pipeline parallelism\n", __func__);
                 cparams.pipeline_parallel = false;
                 sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, false, cparams.op_offload));
-                gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get());
+                gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
             }
             if (!gf) {
                 throw std::runtime_error("failed to allocate compute pp buffers");
@@ -614,7 +617,7 @@ void llama_context::sched_reserve() {
         //
         // auto * gf = graph_reserve(n_tokens, 1, n_tokens, mctx.get());
         //
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get(), model.hparams.no_alloc);
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get(), model.hparams.no_alloc);
         if (!gf) {
             throw std::runtime_error("failed to allocate compute pp buffers");
         }
@@ -774,7 +777,10 @@ bool llama_context::memory_update(bool optimize) {
         const uint32_t n_seqs = cparams.n_seq_max;
         const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
 
-        auto * gf = graph_reserve(n_tokens, n_seqs, n_tokens, mctx.get());
+        const bool     reserve_all_outputs = cparams.embeddings || cparams.pooling_type != LLAMA_POOLING_TYPE_NONE;
+        const uint32_t n_outputs_pp        = reserve_all_outputs ? n_tokens : n_seqs;
+
+        auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
         if (!gf) {
             LLAMA_LOG_ERROR("%s: failed to reserve graph after the memory update\n", __func__);
         }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -30,24 +30,6 @@ static llm_graph_type ctx_type_to_graph_type(llama_context_type ctx_type) {
     throw std::runtime_error("Unsupported ctx type");
 }
 
-static uint32_t graph_n_outputs_pp(const llama_cparams & cparams, uint32_t n_tokens, uint32_t n_seqs) {
-    GGML_ASSERT(n_tokens >= 1);
-    GGML_ASSERT(n_seqs   >= 1);
-
-    const bool reserve_all_outputs =
-        cparams.embeddings ||
-        cparams.pooling_type != LLAMA_POOLING_TYPE_NONE ||
-        cparams.n_outputs_per_seq == 0;
-
-    if (reserve_all_outputs) {
-        return n_tokens;
-    }
-
-    const uint64_t n_outputs = (uint64_t) n_seqs * cparams.n_outputs_per_seq;
-
-    return std::max<uint32_t>(1, std::min<uint64_t>(n_tokens, n_outputs));
-}
-
 llama_context::llama_context(
         const llama_model & model,
               llama_context_params params) :
@@ -68,8 +50,6 @@ llama_context::llama_context(
     if (cparams.n_seq_max > LLAMA_MAX_SEQ) {
         throw std::runtime_error("n_seq_max must be <= " + std::to_string(LLAMA_MAX_SEQ));
     }
-
-    cparams.n_outputs_per_seq = params.n_outputs_per_seq;
 
     cparams.n_rs_seq = params.n_rs_seq;
     if (cparams.n_rs_seq > 0 && !llm_arch_supports_rs_rollback(model.arch)) {
@@ -201,6 +181,8 @@ llama_context::llama_context(
     cparams.n_batch = cparams.causal_attn ? std::min(cparams.n_ctx, params.n_batch) : params.n_batch;
 
     cparams.n_ubatch = std::min(cparams.n_batch, params.n_ubatch == 0 ? params.n_batch : params.n_ubatch);
+
+    cparams.n_outputs_max = params.n_outputs_max == 0 ? cparams.n_batch : params.n_outputs_max;
 
     cparams.op_offload = params.op_offload;
     cparams.kv_unified = params.kv_unified;
@@ -597,7 +579,7 @@ void llama_context::sched_reserve() {
     int n_splits_tg = -1;
     int n_nodes_tg  = -1;
 
-    const uint32_t n_outputs_pp = graph_n_outputs_pp(cparams, n_tokens, n_seqs);
+    const uint32_t n_outputs_pp = std::min(n_tokens, cparams.n_outputs_max);
 
     // reserve pp (prompt processing) graph first so that buffers are only allocated once
     {
@@ -796,7 +778,7 @@ bool llama_context::memory_update(bool optimize) {
         const uint32_t n_seqs = cparams.n_seq_max;
         const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
 
-        const uint32_t n_outputs_pp = graph_n_outputs_pp(cparams, n_tokens, n_seqs);
+        const uint32_t n_outputs_pp = std::min(n_tokens, cparams.n_outputs_max);
 
         auto * gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
         if (!gf) {
@@ -1804,6 +1786,8 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
             // needs to happen before the graph is built
             n_outputs = n_outputs_new;
+
+            GGML_ASSERT(n_outputs <= cparams.n_outputs_max);
         }
 
         ggml_status status;
@@ -3365,7 +3349,7 @@ llama_context_params llama_context_default_params() {
         /*.n_ubatch                    =*/ 512,
         /*.n_seq_max                   =*/ 1,
         /*.n_rs_seq                    =*/ 0,
-        /*.n_outputs_per_seq           =*/ 0,
+        /*.n_outputs_max               =*/ 0,
         /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
         /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
         /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -12,9 +12,10 @@ struct llama_cparams {
     uint32_t n_batch;
     uint32_t n_ubatch;
     uint32_t n_seq_max;
-    uint32_t n_rs_seq;        // number of recurrent-state snapshots per seq for rollback
-    int32_t  n_threads;       // number of threads to use for generation
-    int32_t  n_threads_batch; // number of threads to use for batch processing
+    uint32_t n_rs_seq;          // number of recurrent-state snapshots per seq for rollback
+    uint32_t n_outputs_per_seq; // max outputs per sequence in a ubatch (0 = no limit)
+    int32_t  n_threads;         // number of threads to use for generation
+    int32_t  n_threads_batch;   // number of threads to use for batch processing
 
     float rope_freq_base;
     float rope_freq_scale;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -13,7 +13,7 @@ struct llama_cparams {
     uint32_t n_ubatch;
     uint32_t n_seq_max;
     uint32_t n_rs_seq;        // number of recurrent-state snapshots per seq for rollback
-    uint32_t n_outputs_max;   // max outputs in a ubatch
+    uint32_t n_outputs_max;   // max outputs supported by the context
     int32_t  n_threads;       // number of threads to use for generation
     int32_t  n_threads_batch; // number of threads to use for batch processing
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -12,10 +12,10 @@ struct llama_cparams {
     uint32_t n_batch;
     uint32_t n_ubatch;
     uint32_t n_seq_max;
-    uint32_t n_rs_seq;          // number of recurrent-state snapshots per seq for rollback
-    uint32_t n_outputs_per_seq; // max outputs per sequence in a ubatch (0 = no limit)
-    int32_t  n_threads;         // number of threads to use for generation
-    int32_t  n_threads_batch;   // number of threads to use for batch processing
+    uint32_t n_rs_seq;        // number of recurrent-state snapshots per seq for rollback
+    uint32_t n_outputs_max;   // max outputs in a ubatch
+    int32_t  n_threads;       // number of threads to use for generation
+    int32_t  n_threads_batch; // number of threads to use for batch processing
 
     float rope_freq_base;
     float rope_freq_scale;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -39,11 +39,10 @@ constexpr int HTTP_POLLING_SECONDS = 1;
 
 static uint32_t server_n_outputs_max(const common_params & params) {
     const uint32_t n_batch  = params.n_batch;
-    const uint32_t n_ubatch = std::min(n_batch, params.n_ubatch == 0 ? n_batch : params.n_ubatch);
 
     if (params.embedding ||
             (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED && params.pooling_type != LLAMA_POOLING_TYPE_NONE)) {
-        return n_ubatch;
+        return n_batch;
     }
 
     uint32_t n_outputs_per_seq = 1;
@@ -78,7 +77,7 @@ static uint32_t server_n_outputs_max(const common_params & params) {
 
     const uint64_t n_outputs = (uint64_t) params.n_parallel * n_outputs_per_seq;
 
-    return std::max<uint32_t>(1, std::min<uint64_t>(n_ubatch, n_outputs));
+    return std::max<uint32_t>(1, std::min<uint64_t>(n_batch, n_outputs));
 }
 
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -37,30 +37,38 @@ using json = nlohmann::ordered_json;
 
 constexpr int HTTP_POLLING_SECONDS = 1;
 
-static uint32_t server_n_outputs_per_seq(const common_params_speculative & speculative) {
-    uint32_t n_outputs = 1;
+static uint32_t server_n_outputs_max(const common_params & params) {
+    const uint32_t n_batch  = params.n_batch;
+    const uint32_t n_ubatch = std::min(n_batch, params.n_ubatch == 0 ? n_batch : params.n_ubatch);
 
-    for (const auto type : speculative.types) {
+    if (params.embedding ||
+            (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED && params.pooling_type != LLAMA_POOLING_TYPE_NONE)) {
+        return n_ubatch;
+    }
+
+    uint32_t n_outputs_per_seq = 1;
+
+    for (const auto type : params.speculative.types) {
         switch (type) {
             case COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE:
             case COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3:
             case COMMON_SPECULATIVE_TYPE_DRAFT_MTP:
-                n_outputs = std::max<uint32_t>(n_outputs, 1 + std::max(0, speculative.draft.n_max));
+                n_outputs_per_seq = std::max<uint32_t>(n_outputs_per_seq, 1 + std::max(0, params.speculative.draft.n_max));
                 break;
             case COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE:
-                n_outputs = std::max<uint32_t>(n_outputs, 1 + speculative.ngram_simple.size_m);
+                n_outputs_per_seq = std::max<uint32_t>(n_outputs_per_seq, 1 + params.speculative.ngram_simple.size_m);
                 break;
             case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K:
-                n_outputs = std::max<uint32_t>(n_outputs, 1 + speculative.ngram_map_k.size_m);
+                n_outputs_per_seq = std::max<uint32_t>(n_outputs_per_seq, 1 + params.speculative.ngram_map_k.size_m);
                 break;
             case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V:
-                n_outputs = std::max<uint32_t>(n_outputs, 1 + speculative.ngram_map_k4v.size_m);
+                n_outputs_per_seq = std::max<uint32_t>(n_outputs_per_seq, 1 + params.speculative.ngram_map_k4v.size_m);
                 break;
             case COMMON_SPECULATIVE_TYPE_NGRAM_MOD:
-                n_outputs = std::max<uint32_t>(n_outputs, 1 + std::max(0, speculative.ngram_mod.n_max));
+                n_outputs_per_seq = std::max<uint32_t>(n_outputs_per_seq, 1 + std::max(0, params.speculative.ngram_mod.n_max));
                 break;
             case COMMON_SPECULATIVE_TYPE_NGRAM_CACHE:
-                n_outputs = std::max<uint32_t>(n_outputs, 1 + 8);
+                n_outputs_per_seq = std::max<uint32_t>(n_outputs_per_seq, 1 + 8);
                 break;
             case COMMON_SPECULATIVE_TYPE_NONE:
             case COMMON_SPECULATIVE_TYPE_COUNT:
@@ -68,7 +76,9 @@ static uint32_t server_n_outputs_per_seq(const common_params_speculative & specu
         }
     }
 
-    return n_outputs;
+    const uint64_t n_outputs = (uint64_t) params.n_parallel * n_outputs_per_seq;
+
+    return std::max<uint32_t>(1, std::min<uint64_t>(n_ubatch, n_outputs));
 }
 
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
@@ -787,7 +797,7 @@ private:
         SRV_INF("loading model '%s'\n", params.model.path.c_str());
 
         params_base = params;
-        params_base.n_outputs_per_seq = server_n_outputs_per_seq(params_base.speculative);
+        params_base.n_outputs_max = server_n_outputs_max(params_base);
 
         std::string & mmproj_path = params_base.mmproj.path;
         bool has_mmproj = !mmproj_path.empty();
@@ -854,7 +864,7 @@ private:
                 }
 
                 if (!has_draft) {
-                    params_dft.n_outputs_per_seq = 1;
+                    params_dft.n_outputs_max = params_base.n_parallel;
                 }
 
                 auto mparams_dft = common_model_params_to_llama(params_dft);
@@ -980,11 +990,11 @@ private:
                     params_base.model.path.c_str());
 
             auto cparams_mtp = common_context_params_to_llama(params_base);
-            cparams_mtp.ctx_type          = LLAMA_CONTEXT_TYPE_MTP;
-            cparams_mtp.type_k            = params_base.speculative.draft.cache_type_k;
-            cparams_mtp.type_v            = params_base.speculative.draft.cache_type_v;
-            cparams_mtp.n_rs_seq          = 0;
-            cparams_mtp.n_outputs_per_seq = 1;
+            cparams_mtp.ctx_type      = LLAMA_CONTEXT_TYPE_MTP;
+            cparams_mtp.type_k        = params_base.speculative.draft.cache_type_k;
+            cparams_mtp.type_v        = params_base.speculative.draft.cache_type_v;
+            cparams_mtp.n_rs_seq      = 0;
+            cparams_mtp.n_outputs_max = params_base.n_parallel;
 
             ctx_dft.reset(llama_init_from_model(model_tgt, cparams_mtp));
             if (ctx_dft == nullptr) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -37,6 +37,40 @@ using json = nlohmann::ordered_json;
 
 constexpr int HTTP_POLLING_SECONDS = 1;
 
+static uint32_t server_n_outputs_per_seq(const common_params_speculative & speculative) {
+    uint32_t n_outputs = 1;
+
+    for (const auto type : speculative.types) {
+        switch (type) {
+            case COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE:
+            case COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3:
+            case COMMON_SPECULATIVE_TYPE_DRAFT_MTP:
+                n_outputs = std::max<uint32_t>(n_outputs, 1 + std::max(0, speculative.draft.n_max));
+                break;
+            case COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE:
+                n_outputs = std::max<uint32_t>(n_outputs, 1 + speculative.ngram_simple.size_m);
+                break;
+            case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K:
+                n_outputs = std::max<uint32_t>(n_outputs, 1 + speculative.ngram_map_k.size_m);
+                break;
+            case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V:
+                n_outputs = std::max<uint32_t>(n_outputs, 1 + speculative.ngram_map_k4v.size_m);
+                break;
+            case COMMON_SPECULATIVE_TYPE_NGRAM_MOD:
+                n_outputs = std::max<uint32_t>(n_outputs, 1 + std::max(0, speculative.ngram_mod.n_max));
+                break;
+            case COMMON_SPECULATIVE_TYPE_NGRAM_CACHE:
+                n_outputs = std::max<uint32_t>(n_outputs, 1 + 8);
+                break;
+            case COMMON_SPECULATIVE_TYPE_NONE:
+            case COMMON_SPECULATIVE_TYPE_COUNT:
+                break;
+        }
+    }
+
+    return n_outputs;
+}
+
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
 enum slot_state {
     SLOT_STATE_IDLE,
@@ -753,6 +787,7 @@ private:
         SRV_INF("loading model '%s'\n", params.model.path.c_str());
 
         params_base = params;
+        params_base.n_outputs_per_seq = server_n_outputs_per_seq(params_base.speculative);
 
         std::string & mmproj_path = params_base.mmproj.path;
         bool has_mmproj = !mmproj_path.empty();
@@ -816,6 +851,10 @@ private:
                 } else {
                     // MTP draft context lives on the target model, only context+compute are new
                     measure_model_bytes = false;
+                }
+
+                if (!has_draft) {
+                    params_dft.n_outputs_per_seq = 1;
                 }
 
                 auto mparams_dft = common_model_params_to_llama(params_dft);
@@ -941,10 +980,11 @@ private:
                     params_base.model.path.c_str());
 
             auto cparams_mtp = common_context_params_to_llama(params_base);
-            cparams_mtp.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
-            cparams_mtp.type_k   = params_base.speculative.draft.cache_type_k;
-            cparams_mtp.type_v   = params_base.speculative.draft.cache_type_v;
-            cparams_mtp.n_rs_seq = 0;
+            cparams_mtp.ctx_type          = LLAMA_CONTEXT_TYPE_MTP;
+            cparams_mtp.type_k            = params_base.speculative.draft.cache_type_k;
+            cparams_mtp.type_v            = params_base.speculative.draft.cache_type_v;
+            cparams_mtp.n_rs_seq          = 0;
+            cparams_mtp.n_outputs_per_seq = 1;
 
             ctx_dft.reset(llama_init_from_model(model_tgt, cparams_mtp));
             if (ctx_dft == nullptr) {


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

continue #23764, this PR only reserves logits space for `n_seqs` when possible. With `-ub 2048` and MTP, this saves another 1.2GB of VRAM for me. I've tested `llama-perplexity` also and it seems to work fine. ~But maybe there is a better API, putting up as a draft for now~ According to me an API in llama-context is a good solution for this, by default it will reserve all tokens but specifically in server-context we can set it to 1 whenever possible.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for review and testing across various configs <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
