### PR TITLE
ggml-hip: enable -ffast-math for HIP builds

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -155,3 +155,5 @@ if (GGML_HIP_RCCL)
 endif()
 
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
+
+target_compile_options(ggml-hip PRIVATE "$<$<COMPILE_LANGUAGE:HIP>:-ffast-math>")


### PR DESCRIPTION
## Overview

This add `-ffast-math` to HIP builds, mirroring the `-use_fast_math` flag already applied to CUDA builds in `ggml-cuda/CMakeLists.txt`.

The flag was previously missing from HIP because it had no effect in older toolchains. It was changed by ROCm/LLVM: https://reviews.llvm.org/D154790

I tried disuccing this in #23339, @IMbackK confirmed the historical reason and @am17an suggested adding the flag rather than using `__expf` directly.


To prove the changes I ran some benchmarks.
---

## Benchmarks

Benchmarked on gfx1151 (RDNA3.5/Strix Halo, 40 CUs) against latest master (2f6c815). These two models cover both the FA paths.

**Qwen3.5-27B Q4_K_M** — head_dim=256 (TILE path), FA=1, prompt t/s:

| pp    | upstream | + fast-math | delta |
|-------|----------|-------------|-------|
| 512   | 307      | 321         | +4.6% |
| 2048  | 302      | 323         | +7.0% |
| 4096  | 300      | 312         | +4.0% |
| 8192  | 288      | 307         | +6.6% |
| 16384 | 263      | 280         | +6.5% |
| 32768 | 233      | 246         | +5.6% |

**Qwen3-0.6B BF16** — head_dim=64 (MMA path), FA=1, prompt t/s:

| pp    | upstream | + fast-math | delta |
|-------|----------|-------------|-------|
| 512   | 9325     | 9642        | +3.4% |
| 2048  | 8609     | 8892        | +3.3% |
| 4096  | 7485     | 7661        | +2.4% |
| 8192  | 5770     | 5846        | +1.3% |
| 16384 | 3581     | 3636        | +1.5% |
| 32768 | 2037     | 2049        | +0.6% |

FA=0 results were essentially the same across both builds.

---

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO