### PR TITLE
test-llama-archs: disable DS 3.2 [no release]

### DIFF
--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -407,7 +407,7 @@ static bool arch_supported(const llm_arch arch) {
     if (arch == LLM_ARCH_PLM) {
         return false; // TODO tensor shapes
     }
-    if (arch == LLM_ARCH_DEEPSEEK2OCR) {
+    if (arch == LLM_ARCH_DEEPSEEK2OCR || arch == LLM_ARCH_DEEPSEEK32) {
         return false;
     }
 


### PR DESCRIPTION
After https://github.com/ggml-org/llama.cpp/pull/23346 the CI is failing on master with `/home/johannesg/Projects/llama.cpp/ggml/src/ggml-cpu/binary-ops.cpp:135: binary_op: unsupported types: dst: f32, src0: f32, src1: f16`. This PR disables the tests for the corresponding arch for now.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
