### PR TITLE
llama: drop redundant f16 cast for DSA mla/lid masks

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -2656,14 +2656,14 @@ llm_graph_input_attn_k_dsa * llm_graph_context::build_attn_inp_k_dsa() const {
         inp->self_k_idxs_mla = mctx_cur->get_mla()->build_input_k_idxs(ctx0, ubatch);
 
         inp->self_kq_mask_mla = build_attn_inp_kq_mask(ctx0, mctx_cur->get_mla(), ubatch, cparams);
-        inp->self_kq_mask_mla_cnv = cparams.flash_attn ? ggml_cast(ctx0, inp->self_kq_mask_mla, GGML_TYPE_F16) : inp->self_kq_mask_mla;
+        inp->self_kq_mask_mla_cnv = inp->self_kq_mask_mla;
     }
 
     {
         inp->self_k_idxs_lid = mctx_cur->get_lid()->build_input_k_idxs(ctx0, ubatch);
 
         inp->self_kq_mask_lid = build_attn_inp_kq_mask(ctx0, mctx_cur->get_lid(), ubatch, cparams);
-        inp->self_kq_mask_lid_cnv = cparams.flash_attn ? ggml_cast(ctx0, inp->self_kq_mask_lid, GGML_TYPE_F16) : inp->self_kq_mask_lid;
+        inp->self_kq_mask_lid_cnv = inp->self_kq_mask_lid;
 
         inp->self_k_rot_lid = mctx_cur->get_lid()->build_input_k_rot(ctx0);
     }


### PR DESCRIPTION
## Overview
Follow-up to #23764. That PR reserved the KQ mask directly in f16 under flash attention and dropped the redundant `ggml_cast(..., F16)` for the regular, SWA, cross and no-cache paths. The two DSA mask paths in `build_attn_inp_k_dsa` (`self_kq_mask_mla`, `self_kq_mask_lid`; used by `deepseek32` / `glm-dsa`) were missed — they still `ggml_cast` an already-f16 mask to f16, allocating a duplicate mask buffer plus a copy op. This assigns the mask directly, matching the sibling paths. `set_input_kq_mask` already fills f16 masks, so no other change is needed.

## Additional information
I don't have hardware to run a glm-dsa / DeepSeek-V3.2 model locally, so I haven't measured the saving end-to-end. The change is a direct analogue of the already-merged regular-path change in #23764 and builds cleanly.

## Requirements
- I have read and agree with the contributing guidelines
- AI usage disclosure: YES — used the Claude CLI.
