### PR TITLE
server: in SSE mode, send HTTP headers when slot starts

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1734,7 +1734,7 @@ private:
         return true;
     }
 
-    void send_partial_response(server_slot & slot, const completion_token_output & tkn, bool is_progress) {
+    void send_partial_response(server_slot & slot, const completion_token_output & tkn, bool is_progress, bool is_begin = false) {
         auto res = std::make_unique<server_task_result_cmpl_partial>();
 
         res->id    = slot.task->id;
@@ -1746,6 +1746,9 @@ private:
             res->progress.cache     = slot.n_prompt_tokens_cache;
             res->progress.processed = slot.prompt.tokens.size();
             res->progress.time_ms   = (ggml_time_us() - slot.t_start_process_prompt) / 1000;
+        }
+        if (is_begin) {
+            res->is_begin = true;
         } else {
             res->content = tkn.text_to_send;
             res->tokens  = { tkn.tok };
@@ -2828,10 +2831,15 @@ private:
 
                         slot.prompt.tokens.keep_first(n_past);
 
-                        // send initial 0% progress update if needed
                         // this is to signal the client that the request has started processing
-                        if (slot.task->params.stream && slot.task->params.return_progress) {
-                            send_partial_response(slot, {}, true);
+                        if (slot.task->params.stream) {
+                            if (slot.task->params.return_progress) {
+                                // send initial 0% progress update if needed
+                                send_partial_response(slot, {}, true);
+                            } else {
+                                // otherwise, for streaming without progress, signal HTTP to send the headers (i.e. 200 status)
+                                send_partial_response(slot, {}, false, true);
+                            }
                         }
                     }
 
@@ -3745,7 +3753,9 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         // next responses are streamed
         // to be sent immediately
         json first_result_json = first_result->to_json();
-        if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
+        if (first_result_json == nullptr) {
+            res->data = ""; // simply send HTTP headers and status code
+        } else if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
             res->data = format_anthropic_sse(first_result_json);
         } else if (res_type == TASK_RESPONSE_TYPE_OAI_RESP) {
             res->data = format_oai_resp_sse(first_result_json);

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1422,6 +1422,9 @@ void server_task_result_cmpl_partial::update(task_result_state & state) {
 
 json server_task_result_cmpl_partial::to_json() {
     GGML_ASSERT(is_updated && "update() must be called before to_json()");
+    if (is_begin) {
+        return nullptr; // simply signal to HTTP handler to send the headers and status code
+    }
     switch (res_type) {
         case TASK_RESPONSE_TYPE_NONE:
             return to_json_non_oaicompat();

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -419,6 +419,7 @@ struct server_task_result_cmpl_partial : server_task_result {
     bool post_sampling_probs;
     bool is_progress = false;
     bool is_begin = false; // whether to send 200 status to HTTP client (begin of SSE stream)
+                           // ref: https://github.com/ggml-org/llama.cpp/pull/23884
     completion_token_output prob_output;
     result_timings timings;
     result_prompt_progress progress;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -418,6 +418,7 @@ struct server_task_result_cmpl_partial : server_task_result {
 
     bool post_sampling_probs;
     bool is_progress = false;
+    bool is_begin = false; // whether to send 200 status to HTTP client (begin of SSE stream)
     completion_token_output prob_output;
     result_timings timings;
     result_prompt_progress progress;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -47,7 +47,7 @@ enum stop_type {
 };
 
 struct task_params {
-    bool stream          = true;
+    bool stream          = false;
     bool include_usage   = false;
     bool cache_prompt    = true; // remember the prompt to avoid reprocessing all prompt
     bool return_tokens   = false;


### PR DESCRIPTION
## Overview

In stream mode, send HTTP header when the slot starts processing.

This may fix some timeout problems on clients. Ref: https://github.com/earendil-works/pi/issues/5089#issuecomment-4578225112

Test script: https://gist.github.com/ngxson/d46506aab7e4a6b0f0df9f843d721cd6

On master, the header is sent after prompt processing completed (in this case: 0.8s from request sent):

```
[0.800s] STATUS: 200 OK
[0.800s] HEADERS:
[0.800s]   Content-Type: text/event-stream
[0.800s]   Keep-Alive: timeout=5, max=100
[0.800s]   Server: llama.cpp
[0.800s]   Access-Control-Allow-Origin: 
[0.800s]   Transfer-Encoding: chunked
[0.800s] --- streaming chunks ---
[0.800s] CHUNK: {"choices":[{"finish_reason":null,"index":0,"delta":{"role":"assistant","content":null}}],"created":1780083321,"id":"chatcmpl-eeaLzaFFF83iAY9uKZICpcMQsH8N5F3l","model":"unsloth/gemma-4-E4B-it-GGUF:Q4_K_M","system_fingerprint":"b9417-b5f52280f","object":"chat.completion.chunk"}
```

On PR, header is sent as soon as slot starts processing the prompt (0.008s from request sent):

```
[0.008s] STATUS: 200 OK
[0.008s] HEADERS:
[0.008s]   Content-Type: text/event-stream
[0.008s]   Keep-Alive: timeout=5, max=100
[0.008s]   Server: llama.cpp
[0.008s]   Access-Control-Allow-Origin: 
[0.008s]   Transfer-Encoding: chunked
[0.008s] --- streaming chunks ---
[0.799s] CHUNK: {"choices":[{"finish_reason":null,"index":0,"delta":{"role":"assistant","content":null}}],"created":1780083540,"id":"chatcmpl-oJ96sIgDZqP3a4YiY0wwx01FvCTJkGy6","model":"unsloth/gemma-4-E4B-it-GGUF:Q4_K_M","system_fingerprint":"b9419-b9d69e18e","object":"chat.completion.chunk"}
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
