### PR TITLE
lama-bench : fix default thread count evaluated at static init time

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -442,7 +442,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -ub, --ubatch-size <n>                      (default: %s)\n", join(cmd_params_defaults.n_ubatch, ",").c_str());
     printf("  -ctk, --cache-type-k <t>                    (default: %s)\n", join(transform_to_str(cmd_params_defaults.type_k, ggml_type_name), ",").c_str());
     printf("  -ctv, --cache-type-v <t>                    (default: %s)\n", join(transform_to_str(cmd_params_defaults.type_v, ggml_type_name), ",").c_str());
-    printf("  -t, --threads <n>                           (default: %s)\n", join(cmd_params_defaults.n_threads, ",").c_str());
+    printf("  -t, --threads <n>                           (default: auto - determined at runtime via common_cpu_get_num_math())\n");
     printf("  -C, --cpu-mask <hex,hex>                    (default: %s)\n", join(cmd_params_defaults.cpu_mask, ",").c_str());
     printf("  --cpu-strict <0|1>                          (default: %s)\n", join(cmd_params_defaults.cpu_strict, ",").c_str());
     printf("  --poll <0...100>                            (default: %s)\n", join(cmd_params_defaults.poll, ",").c_str());
@@ -1099,7 +1099,12 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
         params.no_host = cmd_params_defaults.no_host;
     }
     if (params.n_threads.empty()) {
-        params.n_threads = cmd_params_defaults.n_threads;
+        // Compute the default thread count at runtime (not at static init time) so that
+        // process CPU affinity set up by NUMA policies (e.g. via numactl) is reflected.
+        // Using cmd_params_defaults.n_threads here would give the wrong count on multi-NUMA
+        // systems because common_cpu_get_num_math() is evaluated during static initialization,
+        // before the process affinity is configured. See: github.com/ggml-org/llama.cpp/issues/17611
+        params.n_threads = { common_cpu_get_num_math() };
     }
     if (params.cpu_mask.empty()) {
         params.cpu_mask = cmd_params_defaults.cpu_mask;


### PR DESCRIPTION

Title: llama-bench : fix default thread count evaluated at static init time

Description: Fixes #17611.

Moves the default thread count evaluation common_cpu_get_num_math() from static initialization time to runtime inside get_cmd_params(). This ensures that on Linux systems with NUMA nodes, any CPU affinity configured after process startup (e.g. via numactl) is read correctly.

Also updated print_usage() to show auto as the default thread count.

Verification: Tested on Apple M4 (macOS).



<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
