### PR TITLE
examples: add minimal FFI demo for llama.cpp shared library

### DIFF
--- a/examples/jsllama/README.md
+++ b/examples/jsllama/README.md
@@ -1,0 +1,288 @@
+# jsllama
+
+A lightweight Bun.js FFI binding for llama.cpp, enabling direct inference calls to shared libraries (.so) for running large language models in JavaScript.
+
+## Features
+
+- Load GGUF format large language models
+- Streaming text generation (generator and callback styles)
+- Model unloading and resource cleanup
+- Supports CPU and GPU (Vulkan) inference
+- Temperature sampling and repetition penalty to avoid duplicate output
+- Zero native compilation needed at runtime — pre-compiled shared libraries
+
+## Prerequisites
+
+- [Bun.js](https://bun.sh/) >= 1.0
+- llama.cpp compiled shared library files (included in `bin/` directory)
+
+## Installation
+
+```bash
+cd jsllama
+bun install
+```
+
+## Compilation (Optional)
+
+If you need to recompile the C wrapper library, use the following command:
+
+```bash
+cd <PROJECT_DIR>
+g++ -shared -fPIC -o bin/libjsllama.so jsllama.cpp \
+  -I<LLAMA_CPP_INCLUDE_DIR> \
+  -I<GGML_INCLUDE_DIR> \
+  -L./bin -lllama \
+  -Wl,-rpath,'$ORIGIN'
+```
+
+Replace the placeholders:
+- `<PROJECT_DIR>` — Path to the jsllama project directory
+- `<LLAMA_CPP_INCLUDE_DIR>` — Path to llama.cpp `include/` directory
+- `<GGML_INCLUDE_DIR>` — Path to ggml `include/` directory
+
+## Usage
+
+### Basic Usage
+
+```javascript
+import { Llama } from "./index.js";
+
+const llama = new Llama({
+  nCtx: 2048,
+  nBatch: 512,
+  nThreads: 4,
+  nGpuLayers: -1,
+});
+
+llama.loadModel("/path/to/model.gguf");
+
+for (const token of llama.generate("Hello, introduce yourself", { maxTokens: 100 })) {
+  process.stdout.write(token);
+}
+
+llama.unloadModel();
+Llama.free();
+```
+
+### Streaming Output (with Callback)
+
+```javascript
+await llama.generateStream("Tell me a short joke: ", (token) => {
+  process.stdout.write(token);
+}, { maxTokens: 50 });
+```
+
+### Configuration Options
+
+```javascript
+const llama = new Llama({
+  nCtx: 2048,
+  nBatch: 512,
+  nThreads: 4,
+  nGpuLayers: -1,
+});
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| nCtx | number | 2048 | Context length for text processing |
+| nBatch | number | 2048 | Batch size for processing |
+| nThreads | number | 4 | Number of threads during generation |
+| nGpuLayers | number | -1 | Layers to offload to GPU (-1 = all) |
+
+### Generation Options
+
+```javascript
+llama.generate(prompt, {
+  maxTokens: 256,
+});
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| maxTokens | number | 256 | Maximum number of tokens to generate |
+
+## Running Examples
+
+```bash
+bun example.js /path/to/your/model.gguf
+```
+
+## Running Tests
+
+```bash
+bun test.js
+```
+
+## Project Structure
+
+```
+jsllama/
+├── bin/
+│   ├── libjsllama.so      # C wrapper library
+│   ├── libllama.so*       # llama.cpp core library
+│   ├── libggml*.so*       # ggml base library
+│   └── libllama-common.so* # llama.cpp common library
+├── jsllama.cpp            # C wrapper source code
+├── dll.js                 # FFI binding layer
+├── index.js               # High-level JavaScript API
+├── example.js             # Usage example
+├── test.js                # Test script
+└── package.json
+```
+
+## Architecture
+
+1. **jsllama.cpp** — C wrapper layer that simplifies the complex llama.cpp API
+   - Encapsulates `llama_batch` structure with automatic `n_tokens` setup
+   - Configures temperature sampler and repetition penalty to avoid duplicate output
+2. **dll.js** — Bun.js FFI bindings that define C function signatures
+3. **index.js** — High-level JavaScript class providing an easy-to-use API
+   - `generate()` — Generator style, iterate with `for...of`
+   - `generateStream()` — Callback style, async streaming output
+
+---
+
+# jsllama
+
+基于 Bun.js FFI 的 llama.cpp 封装库，支持直接调用 .so 文件进行模型推理。
+
+## 功能
+
+- 加载 GGUF 格式的大语言模型
+- 流式文本生成输出（支持生成器和回调两种方式）
+- 模型卸载与资源释放
+- 支持 CPU 和 GPU (Vulkan) 推理
+- 温度采样和重复惩罚，避免生成重复内容
+
+## 前置要求
+
+- [Bun.js](https://bun.sh/) >= 1.0
+- llama.cpp 编译的共享库文件（已包含在 `bin/` 目录中）
+
+## 安装
+
+```bash
+cd jsllama
+bun install
+```
+
+## 编译（可选）
+
+如需重新编译 C 封装库，请使用以下命令：
+
+```bash
+cd <项目目录>
+g++ -shared -fPIC -o bin/libjsllama.so jsllama.cpp \
+  -I<LLAMA_CPP_INCLUDE_DIR> \
+  -I<GGML_INCLUDE_DIR> \
+  -L./bin -lllama \
+  -Wl,-rpath,'$ORIGIN'
+```
+
+占位符说明：
+- `<项目目录>` — jsllama 项目目录路径
+- `<LLAMA_CPP_INCLUDE_DIR>` — llama.cpp 的 `include/` 目录路径
+- `<GGML_INCLUDE_DIR>` — ggml 的 `include/` 目录路径
+
+## 使用方法
+
+### 基本用法
+
+```javascript
+import { Llama } from "./index.js";
+
+const llama = new Llama({
+  nCtx: 2048,
+  nBatch: 512,
+  nThreads: 4,
+  nGpuLayers: -1,
+});
+
+llama.loadModel("/path/to/model.gguf");
+
+for (const token of llama.generate("你好，请介绍一下自己", { maxTokens: 100 })) {
+  process.stdout.write(token);
+}
+
+llama.unloadModel();
+Llama.free();
+```
+
+### 流式输出（带回调）
+
+```javascript
+await llama.generateStream("讲一个简短的笑话：", (token) => {
+  process.stdout.write(token);
+}, { maxTokens: 50 });
+```
+
+### 配置选项
+
+```javascript
+const llama = new Llama({
+  nCtx: 2048,
+  nBatch: 512,
+  nThreads: 4,
+  nGpuLayers: -1,
+});
+```
+
+| 选项 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| nCtx | number | 2048 | 文本上下文长度 |
+| nBatch | number | 2048 | 批处理大小 |
+| nThreads | number | 4 | 生成时使用的线程数 |
+| nGpuLayers | number | -1 | 卸载到 GPU 的层数（-1 表示全部） |
+
+### 生成选项
+
+```javascript
+llama.generate(prompt, {
+  maxTokens: 256,
+});
+```
+
+| 选项 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| maxTokens | number | 256 | 最大生成 token 数 |
+
+## 运行示例
+
+```bash
+bun example.js /path/to/your/model.gguf
+```
+
+## 运行测试
+
+```bash
+bun test.js
+```
+
+## 项目结构
+
+```
+jsllama/
+├── bin/
+│   ├── libjsllama.so      # C 封装库
+│   ├── libllama.so*       # llama.cpp 核心库
+│   ├── libggml*.so*       # ggml 基础库
+│   └── libllama-common.so* # llama.cpp 公共库
+├── jsllama.cpp            # C 封装源码
+├── dll.js                 # FFI 绑定层
+├── index.js               # 高级 JavaScript API
+├── example.js             # 使用示例
+├── test.js                # 测试脚本
+└── package.json
+```
+
+## 架构说明
+
+1. **jsllama.cpp** — C 封装层，简化 llama.cpp 的复杂 API
+   - 封装 `llama_batch` 结构体，自动设置 `n_tokens`
+   - 配置温度采样器和重复惩罚，避免重复输出
+2. **dll.js** — Bun.js FFI 绑定，定义 C 函数签名
+3. **index.js** — 高级 JavaScript 类，提供易用的 API
+   - `generate()` — 生成器方式，使用 `for...of` 遍历
+   - `generateStream()` — 回调方式，异步流式输出

--- a/examples/jsllama/dll.js
+++ b/examples/jsllama/dll.js
@@ -1,0 +1,168 @@
+import { dlopen, ptr, toBuffer } from "bun:ffi";
+
+const libPath = import.meta.dirname + "/bin/libjsllama.so";
+
+const libs = dlopen(libPath, {
+  jsllama_backend_init: {
+    args: [],
+    returns: "void",
+  },
+  jsllama_backend_free: {
+    args: [],
+    returns: "void",
+  },
+  jsllama_load_model: {
+    args: ["cstring", "i32", "i32", "i32", "i32"],
+    returns: "ptr",
+  },
+  jsllama_free_model: {
+    args: ["ptr"],
+    returns: "void",
+  },
+  jsllama_tokenize: {
+    args: ["ptr", "cstring", "i32", "ptr", "i32", "i32", "i32"],
+    returns: "i32",
+  },
+  jsllama_decode: {
+    args: ["ptr", "buffer", "i32", "i32"],
+    returns: "i32",
+  },
+  jsllama_decode_single: {
+    args: ["ptr", "i32", "i32"],
+    returns: "i32",
+  },
+  jsllama_sample: {
+    args: ["ptr"],
+    returns: "i32",
+  },
+  jsllama_is_eog: {
+    args: ["ptr", "i32"],
+    returns: "i32",
+  },
+  jsllama_token_to_piece: {
+    args: ["ptr", "i32", "ptr", "i32"],
+    returns: "i32",
+  },
+  jsllama_kv_cache_clear: {
+    args: ["ptr"],
+    returns: "void",
+  },
+  jsllama_get_vocab_size: {
+    args: ["ptr"],
+    returns: "i32",
+  },
+  jsllama_get_logits: {
+    args: ["ptr", "i32"],
+    returns: "ptr",
+  },
+});
+
+export const jsllama = libs.symbols;
+
+export function initBackend() {
+  jsllama.jsllama_backend_init();
+}
+
+export function freeBackend() {
+  jsllama.jsllama_backend_free();
+}
+
+export function loadModel(path, nCtx, nBatch, nThreads, nGpuLayers) {
+  return jsllama.jsllama_load_model(path, nCtx, nBatch, nThreads, nGpuLayers);
+}
+
+export function freeModel(handle) {
+  jsllama.jsllama_free_model(handle);
+}
+
+export function tokenize(handle, text, addSpecial, parseSpecial) {
+  const maxTokens = text.length + 256;
+  const tokens = new Int32Array(maxTokens);
+  const tokensPtr = ptr(tokens);
+  const textBuf = new TextEncoder().encode(text);
+  
+  const result = jsllama.jsllama_tokenize(
+    handle,
+    textBuf,
+    textBuf.length,
+    tokensPtr,
+    maxTokens,
+    addSpecial ? 1 : 0,
+    parseSpecial ? 1 : 0
+  );
+  
+  if (result < 0) {
+    const needed = -result;
+    const newTokens = new Int32Array(needed);
+    const newTokensPtr = ptr(newTokens);
+    const result2 = jsllama.jsllama_tokenize(
+      handle,
+      textBuf,
+      textBuf.length,
+      newTokensPtr,
+      needed,
+      addSpecial ? 1 : 0,
+      parseSpecial ? 1 : 0
+    );
+    if (result2 < 0) {
+      throw new Error("Tokenization failed");
+    }
+    const finalTokens = new Int32Array(result2);
+    finalTokens.set(newTokens.slice(0, result2));
+    return finalTokens;
+  }
+  
+  const finalTokens = new Int32Array(result);
+  finalTokens.set(tokens.slice(0, result));
+  return finalTokens;
+}
+
+export function decode(handle, tokens, nPast) {
+  return jsllama.jsllama_decode(handle, tokens, tokens.length, nPast);
+}
+
+export function decodeSingle(handle, token, nPast) {
+  return jsllama.jsllama_decode_single(handle, token, nPast);
+}
+
+export function sample(handle) {
+  return jsllama.jsllama_sample(handle);
+}
+
+export function isEogToken(handle, token) {
+  return jsllama.jsllama_is_eog(handle, token) !== 0;
+}
+
+export function tokenToPiece(handle, token) {
+  const buf = new Int8Array(32);
+  const bufPtr = ptr(buf);
+  const result = jsllama.jsllama_token_to_piece(handle, token, bufPtr, 32);
+  
+  if (result < 0) {
+    const needed = -result;
+    const newBuf = new Int8Array(needed);
+    const newBufPtr = ptr(newBuf);
+    const result2 = jsllama.jsllama_token_to_piece(handle, token, newBufPtr, needed);
+    if (result2 < 0) {
+      return "";
+    }
+    return new TextDecoder().decode(newBuf.slice(0, result2));
+  }
+  
+  return new TextDecoder().decode(buf.slice(0, result));
+}
+
+export function kvCacheClear(handle) {
+  jsllama.jsllama_kv_cache_clear(handle);
+}
+
+export function getVocabSize(handle) {
+  return jsllama.jsllama_get_vocab_size(handle);
+}
+
+export function getLogits(handle, idx) {
+  const logitsPtr = jsllama.jsllama_get_logits(handle, idx);
+  const vocabSize = getVocabSize(handle);
+  const logitsBuf = toBuffer(logitsPtr, vocabSize * 4);
+  return new Float32Array(logitsBuf);
+}

--- a/examples/jsllama/example.js
+++ b/examples/jsllama/example.js
@@ -1,0 +1,44 @@
+import { Llama } from "./index.js";
+
+const modelPath = process.argv[2];
+
+if (!modelPath) {
+  console.log("Usage: bun example.js <path-to-model>");
+  console.log("Example: bun example.js /path/to/llama-2-7b-chat.Q4_K_M.gguf");
+  process.exit(1);
+}
+
+const llama = new Llama({
+  nCtx: 2048,
+  nBatch: 512,
+  nThreads: 4,
+  nGpuLayers: 100,
+  logLevel: "silent"
+});
+
+console.log("Loading model...");
+llama.loadModel(modelPath);
+console.log("Model loaded successfully!");
+
+const prompt = "你好";
+console.log(`\nPrompt: ${prompt}`);
+console.log("\nResponse:");
+
+let fullResponse = "";
+
+for (const token of llama.generate(prompt, { maxTokens: 100 })) {
+  process.stdout.write(token);
+  fullResponse += token;
+}
+
+console.log("\n\n---\nStreaming response with callback:");
+
+await llama.generateStream("你好，请简单介绍一下你自己：", (token) => {
+  process.stdout.write(token);
+}, { maxTokens: 50 });
+
+console.log("\n\nUnloading model...");
+llama.unloadModel();
+console.log("Model unloaded!");
+
+Llama.free();

--- a/examples/jsllama/index.js
+++ b/examples/jsllama/index.js
@@ -1,0 +1,121 @@
+import { initBackend, freeBackend, loadModel, freeModel, tokenize, decode, decodeSingle, sample, isEogToken, tokenToPiece, kvCacheClear, getVocabSize, getLogits } from "./dll.js";
+
+export class Llama {
+  #handle = null;
+  #initialized = false;
+  #nCtx = 2048;
+  #nBatch = 2048;
+  #nThreads = 4;
+  #nGpuLayers = -1;
+  static #staticInitialized = false;
+
+  static init() {
+    if (!this.#staticInitialized) {
+      initBackend();
+      this.#staticInitialized = true;
+    }
+  }
+
+  static free() {
+    if (this.#staticInitialized) {
+      freeBackend();
+      this.#staticInitialized = false;
+    }
+  }
+
+  constructor(options = {}) {
+    this.#nCtx = options.nCtx || 2048;
+    this.#nBatch = options.nBatch || 2048;
+    this.#nThreads = options.nThreads || 4;
+    this.#nGpuLayers = options.nGpuLayers ?? -1;
+  }
+
+  loadModel(modelPath) {
+    Llama.init();
+
+    this.#handle = loadModel(new TextEncoder().encode(modelPath), this.#nCtx, this.#nBatch, this.#nThreads, this.#nGpuLayers);
+    
+    if (!this.#handle || this.#handle === 0n) {
+      throw new Error(`Failed to load model: ${modelPath}`);
+    }
+
+    this.#initialized = true;
+    return true;
+  }
+
+  unloadModel() {
+    if (this.#handle) {
+      freeModel(this.#handle);
+      this.#handle = null;
+    }
+    this.#initialized = false;
+  }
+
+  *generate(prompt, options = {}) {
+    if (!this.#initialized) {
+      throw new Error("Model not loaded");
+    }
+
+    const maxTokens = options.maxTokens || 256;
+
+    kvCacheClear(this.#handle);
+
+    const tokens = tokenize(this.#handle, prompt, true, true);
+    
+    let nPast = 0;
+    let nConsumed = 0;
+    let generated = 0;
+
+    try {
+      while (generated < maxTokens) {
+        if (nConsumed < tokens.length) {
+          const nTake = Math.min(this.#nBatch, tokens.length - nConsumed);
+          const promptTokens = new Int32Array(nTake);
+          for (let i = 0; i < nTake; i++) {
+            promptTokens[i] = tokens[nConsumed + i];
+          }
+          
+          const ret = decode(this.#handle, promptTokens, nPast);
+          if (ret !== 0) {
+            throw new Error(`Decode failed with code ${ret}`);
+          }
+          
+          nPast += nTake;
+          nConsumed += nTake;
+        } else {
+          const nextToken = sample(this.#handle);
+          
+          if (isEogToken(this.#handle, nextToken)) {
+            break;
+          }
+          
+          const piece = tokenToPiece(this.#handle, nextToken);
+          generated++;
+          yield piece;
+          
+          const ret = decodeSingle(this.#handle, nextToken, nPast);
+          if (ret !== 0) {
+            throw new Error(`Decode failed with code ${ret}`);
+          }
+          
+          nPast++;
+        }
+      }
+    } catch (error) {
+      console.error("Generation error:", error);
+    }
+  }
+
+  async generateStream(prompt, callback, options = {}) {
+    for (const token of this.generate(prompt, options)) {
+      callback(token);
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+
+  get isLoaded() {
+    return this.#initialized;
+  }
+}
+
+export default Llama;

--- a/examples/jsllama/jsllama.cpp
+++ b/examples/jsllama/jsllama.cpp
@@ -1,0 +1,169 @@
+
+#include <llama.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#define JSLLAMA_API __attribute__ ((visibility ("default")))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    void* model;
+    void* ctx;
+    void* vocab;
+    void* sampler;
+    int32_t n_ctx;
+    int32_t n_batch;
+    int32_t n_threads;
+    int32_t n_gpu_layers;
+} jsllama_handle;
+
+JSLLAMA_API void jsllama_backend_init(void) {
+    llama_backend_init();
+}
+
+JSLLAMA_API void jsllama_backend_free(void) {
+    llama_backend_free();
+}
+
+JSLLAMA_API jsllama_handle* jsllama_load_model(const char* path, int32_t n_ctx, int32_t n_batch, int32_t n_threads, int32_t n_gpu_layers) {
+    jsllama_handle* handle = (jsllama_handle*)calloc(1, sizeof(jsllama_handle));
+    if (!handle) return NULL;
+
+    struct llama_model_params model_params = llama_model_default_params();
+    model_params.n_gpu_layers = n_gpu_layers;
+
+    handle->model = llama_model_load_from_file(path, model_params);
+    if (!handle->model) {
+        free(handle);
+        return NULL;
+    }
+
+    handle->vocab = (void*)llama_model_get_vocab((const struct llama_model*)handle->model);
+
+    struct llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx = n_ctx;
+    ctx_params.n_batch = n_batch;
+    ctx_params.n_ubatch = n_batch < 512 ? n_batch : 512;
+    ctx_params.n_threads = n_threads;
+    ctx_params.n_threads_batch = n_threads;
+
+    handle->ctx = llama_init_from_model((struct llama_model*)handle->model, ctx_params);
+    if (!handle->ctx) {
+        llama_model_free((struct llama_model*)handle->model);
+        free(handle);
+        return NULL;
+    }
+
+    handle->n_ctx = n_ctx;
+    handle->n_batch = n_batch;
+    handle->n_threads = n_threads;
+    handle->n_gpu_layers = n_gpu_layers;
+
+    struct llama_sampler_chain_params sampler_params = llama_sampler_chain_default_params();
+    handle->sampler = (void*)llama_sampler_chain_init(sampler_params);
+    
+    llama_sampler_chain_add((struct llama_sampler*)handle->sampler, llama_sampler_init_temp(0.8f));
+    llama_sampler_chain_add((struct llama_sampler*)handle->sampler, llama_sampler_init_penalties(64, 1.25f, 0.1f, 0.0f));
+    llama_sampler_chain_add((struct llama_sampler*)handle->sampler, llama_sampler_init_greedy());
+
+    return handle;
+}
+
+JSLLAMA_API void jsllama_free_model(jsllama_handle* handle) {
+    if (!handle) return;
+    
+    if (handle->sampler) {
+        llama_sampler_free((struct llama_sampler*)handle->sampler);
+    }
+    if (handle->ctx) {
+        llama_free((struct llama_context*)handle->ctx);
+    }
+    if (handle->model) {
+        llama_model_free((struct llama_model*)handle->model);
+    }
+    free(handle);
+}
+
+JSLLAMA_API int32_t jsllama_tokenize(jsllama_handle* handle, const char* text, int32_t text_len, int32_t* tokens, int32_t max_tokens, int add_special, int parse_special) {
+    return llama_tokenize(
+        (const struct llama_vocab*)handle->vocab,
+        text, text_len,
+        tokens, max_tokens,
+        add_special, parse_special
+    );
+}
+
+JSLLAMA_API int32_t jsllama_decode(jsllama_handle* handle, const int32_t* tokens, int32_t n_tokens, int32_t n_past) {
+    if (n_tokens <= 0) {
+        return -1;
+    }
+    struct llama_batch batch = llama_batch_init(n_tokens, 0, 1);
+    
+    batch.n_tokens = n_tokens;
+    
+    for (int32_t i = 0; i < n_tokens; i++) {
+        batch.token[i] = tokens[i];
+        batch.pos[i] = n_past + i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = (i == n_tokens - 1) ? 1 : 0;
+    }
+    
+    int32_t ret = llama_decode((struct llama_context*)handle->ctx, batch);
+    llama_batch_free(batch);
+    
+    return ret;
+}
+
+JSLLAMA_API int32_t jsllama_decode_single(jsllama_handle* handle, int32_t token, int32_t n_past) {
+    struct llama_batch batch = llama_batch_init(1, 0, 1);
+    
+    batch.n_tokens = 1;
+    batch.token[0] = token;
+    batch.pos[0] = n_past;
+    batch.n_seq_id[0] = 1;
+    batch.seq_id[0][0] = 0;
+    batch.logits[0] = 1;
+    
+    int32_t ret = llama_decode((struct llama_context*)handle->ctx, batch);
+    llama_batch_free(batch);
+    
+    return ret;
+}
+
+JSLLAMA_API int32_t jsllama_sample(jsllama_handle* handle) {
+    return llama_sampler_sample((struct llama_sampler*)handle->sampler, (struct llama_context*)handle->ctx, -1);
+}
+
+JSLLAMA_API int jsllama_is_eog(jsllama_handle* handle, int32_t token) {
+    return llama_vocab_is_eog((const struct llama_vocab*)handle->vocab, token);
+}
+
+JSLLAMA_API int32_t jsllama_token_to_piece(jsllama_handle* handle, int32_t token, char* buf, int32_t buf_len) {
+    return llama_token_to_piece(
+        (const struct llama_vocab*)handle->vocab,
+        token,
+        buf, buf_len,
+        0, false
+    );
+}
+
+JSLLAMA_API void jsllama_kv_cache_clear(jsllama_handle* handle) {
+    llama_memory_clear(llama_get_memory((struct llama_context*)handle->ctx), true);
+}
+
+JSLLAMA_API int32_t jsllama_get_vocab_size(jsllama_handle* handle) {
+    return llama_vocab_n_tokens((const struct llama_vocab*)handle->vocab);
+}
+
+JSLLAMA_API float* jsllama_get_logits(jsllama_handle* handle, int32_t idx) {
+    return llama_get_logits_ith((struct llama_context*)handle->ctx, idx);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/jsllama/package.json
+++ b/examples/jsllama/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "jsllama",
+  "version": "1.0.0",
+  "description": "Bun.js FFI wrapper for llama.cpp",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "example": "bun example.js"
+  },
+  "keywords": ["llama", "ffi", "bun"],
+  "license": "MIT"
+}


### PR DESCRIPTION
## Overview

A lightweight Bun.js FFI binding for llama.cpp that enables direct inference calls to shared libraries (.so) for running large language models in JavaScript. This project provides a minimal, efficient alternative to existing bindings like node-llama-cpp, with support for GGUF model loading, streaming text generation, and GPU offloading.

## Additional information

Existing llama.cpp bindings (node-llama-cpp, python-llama-cpp) lag behind in keeping up with llama.cpp version updates. This project aims to provide a more lightweight and direct approach to calling llama.cpp through Bun.js FFI.

## Requirements

- I have read and agree with the `https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md`
- AI usage disclosure: YES - AI was used to help refine the README.md file, translate Chinese to English, collect and organize reference materials (such as FFI usage patterns), and assist with the implementation of example.js