### PR TITLE
loader: increase async upload staging buffer to 4 MiB

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1420,7 +1420,7 @@ bool llama_model_loader::load_all_data(
     std::vector<no_init<uint8_t>> read_buf;
     std::vector<std::future<std::pair<ggml_tensor *, bool>>> validation_result;
 
-    // 4 staging buffers for async uploads, each sized 1MB seems to be a good default for single NVMe drives.
+    // 4 staging buffers for async uploads, each sized 4MB seems to be a good default for single NVMe drives.
     // NVMe raid configurations might require more / larger buffers.
     constexpr size_t n_buffers = 4;
 
@@ -1431,7 +1431,7 @@ bool llama_model_loader::load_all_data(
 
     // Buffer size: balance between memory usage and I/O efficiency
     // 64MB works well for NVMe drives
-    const size_t buffer_size = alignment != 1 ? 64 * 1024 * 1024 + 2 * alignment : 1 * 1024 * 1024;
+    const size_t buffer_size = alignment != 1 ? 64 * 1024 * 1024 + 2 * alignment : 4 * 1024 * 1024;
 
     std::vector<ggml_backend_buffer_t> host_buffers;
     std::vector<ggml_backend_event_t> events;


### PR DESCRIPTION
## Overview

On Windows, the load uses alignment == 1, so the async upload staging buffer is currently 1 MiB.

## Additional information

Benchmarks are WARM READS.



## Requirements



- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Codex assisted with code exploration, benchmarking, and PR preparation. I manually reviewed the change and benchmark results.



## Benchmark

Environment:

- Model: qwen3.6:35b GGUF blob
- Loader payload: 21.45 GiB
- GPU/backend: AMD Radeon RX 7900 XTX, Vulkan
- Command shape: `llama-cli --no-mmap -ngl 999`
- Runs: warm-cache load timing, first 1 MiB warmup excluded

| Chunk | Runs | Avg load | Median | Avg throughput |
| --- | ---: | ---: | ---: | ---: |
| 1 MiB | 5 | 4960.94 ms | 4928.89 ms | 4.32 GiB/s |
| 2 MiB | 5 | 3687.27 ms | 3735.25 ms | 5.82 GiB/s |
| 4 MiB | 5 | 3148.23 ms | 3102.45 ms | 6.81 GiB/s |
| 8 MiB | 5 | 3246.70 ms | 3254.84 ms | 6.61 GiB/s |
| 16 MiB | 5 | 3370.00 ms | 3293.10 ms | 6.37 GiB/s |
| 32 MiB | 2 | 3264.91 ms | 3255.14 ms | 6.57 GiB/s |
| 64 MiB | 2 | 3286.43 ms | 3203.69 ms | 6.53 GiB/s |

## Validation

- `git diff --check`
- Windows Vulkan build:
  - `cmake -S . -B C:\tmp\llama-pr-build -DGGML_VULKAN=ON -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF`
  - `cmake --build C:\tmp\llama-pr-build --config Release --parallel 8 --target llama-bench`
