### PR TITLE
server: handle If-None-Match weak ETags

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -325,7 +325,7 @@ bool server_http_context::init(const common_params & params) {
                     res.set_header("ETag", a->etag);
                     // Check If-None-Match for conditional GET (304 Not Modified)
                     if (const std::string & inm = req.get_header_value("If-None-Match");
-                        !inm.empty() && inm == a->etag) {
+                        !inm.empty() && (inm == a->etag || inm == std::string("W/") + a->etag)) {
                         res.status = 304;
                         return false;
                     }


### PR DESCRIPTION
## Overview

See #23849 for details. In short, current logic of comparing ETags in `If-None-Match` HTTP header does not consider "weak" ETags (prepended with `W/`) to be the same as "strong" ones, while HTTP specs requires this. This causes reverse proxies which compress HTTP responses (and "weakens" the ETag in the process) to break browser cache validation.

This PR provides a "quick" fix, which assumes llama-server never generate weak ETags by itself. While HTTP specs requires handling more cases (e.g. `*` wildcard, or multiple ETags), I don't think they are worth to implement here.

Fixes #23849.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

