### PR TITLE
ui: fix ETag truncation with MSVC compiler

### DIFF
--- a/tools/ui/embed.cpp
+++ b/tools/ui/embed.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cinttypes>
 #include <cstdint>
 
 // Computes FNV-1a hash of the data
@@ -126,10 +127,10 @@ int main(int argc, char ** argv) {
             append_bytes_hex(cpp, bytes);
             const auto hash = fnv_hash(bytes.data(), bytes.size());
 
-            cpp += fmt("};\nstatic const size_t        asset_%d_size = %lu;\n",
-                       i, static_cast<unsigned long>(bytes.size()));
-            cpp += fmt("static const char        asset_%d_etag[] = \"\\\"0x%016lx\\\"\";\n\n",
-                       i, static_cast<unsigned long>(hash));
+            cpp += fmt("};\nstatic const size_t        asset_%d_size = %zu;\n",
+                       i, bytes.size());
+            cpp += fmt("static const char        asset_%d_etag[] = \"\\\"0x%016" PRIx64 "\\\"\";\n\n",
+                       i, hash);
         }
 
         cpp += "static const llama_ui_asset g_assets[] = {\n";


### PR DESCRIPTION
## Overview

In the process of generating ETags for embedded web UI files, the `uint64_t` file hash is casted into a `unsigned long` value before being converted into a 64-bit hexadecimal string. MSVC compiler uses 32 bit `long` values, and thus will truncate the hash value. This don't really affect anything (aside for some ridiculous hypothetical load-balancing setup with servers running different OSes), but hey, why do a type cast when you can use the full value just like on Linux?

For consistency, type cast on the `size_t` value above is also removed. I don't really believe we will have 4GB+ of static files, though.

## Additional information

Tested on Windows 11 with Visual Studio 2026.

Current master:

```console
C:\Users\EZForever>curl -I http://127.0.0.1:9070/bundle.js
HTTP/1.1 200 OK
Server: llama.cpp
Access-Control-Allow-Origin:
ETag: "0x000000002639b40d"
Content-Type: application/javascript; charset=utf-8
Content-Length: 5285413
Accept-Ranges: bytes
Keep-Alive: timeout=5, max=100
```

This PR:

```console
C:\Users\EZForever>curl -I http://127.0.0.1:9070/bundle.js
HTTP/1.1 200 OK
Server: llama.cpp
Access-Control-Allow-Origin:
ETag: "0xf0f916632639b40d"
Content-Type: application/javascript; charset=utf-8
Content-Length: 5285413
Accept-Ranges: bytes
Keep-Alive: timeout=5, max=100
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

