### PR TITLE
spec - default MTP draft backend_sampling to off (#23903)

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -305,7 +305,7 @@ struct common_params_speculative_draft {
     float p_split = 0.1f; // speculative decoding split probability
     float p_min   = 0.0f; // minimum speculative decoding probability (greedy)
 
-    bool backend_sampling = true; // offload draft sampling to the backend (default: on)
+    bool backend_sampling = false; // offload draft sampling to the backend (default: off; enabling has substantial per-sequence compute-buffer cost in MTP draft path that can OOM with --parallel N>1)
 
     common_params_model mparams;
 


### PR DESCRIPTION
Fixes #23903.

PR #23287 turned on backend sampling by default for the MTP draft path, but the per-sequence compute buffer overhead is big enough that configs which ran cleanly on b9246 now OOM at --parallel 2 on b9426 and later. Flipping the default back to off restores the working baseline and anyone wanting backend sampling can still opt in with --spec-draft-backend-sampling. I tested locally with a CPU build and a small non-MTP model since the reporter's exact setup needs a Blackwell card, so the MTP path itself still needs someone with that config to confirm the OOM is gone.