### PR TITLE
common: use physical core count for --threads -1 default

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -31,7 +31,6 @@
 #include <regex>
 #include <set>
 #include <string>
-#include <thread> // for hardware_concurrency
 #include <vector>
 
 #ifndef __EMSCRIPTEN__
@@ -1154,7 +1153,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams.n_threads = value;
             if (params.cpuparams.n_threads <= 0) {
-                params.cpuparams.n_threads = std::thread::hardware_concurrency();
+                params.cpuparams.n_threads = common_cpu_get_num_physical_cores();
             }
         }
     ).set_env("LLAMA_ARG_THREADS"));
@@ -1164,7 +1163,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams_batch.n_threads = value;
             if (params.cpuparams_batch.n_threads <= 0) {
-                params.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                params.cpuparams_batch.n_threads = common_cpu_get_num_physical_cores();
             }
         }
     ));
@@ -3405,7 +3404,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.draft.cpuparams.n_threads = value;
             if (params.speculative.draft.cpuparams.n_threads <= 0) {
-                params.speculative.draft.cpuparams.n_threads = std::thread::hardware_concurrency();
+                params.speculative.draft.cpuparams.n_threads = common_cpu_get_num_physical_cores();
             }
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
@@ -3415,7 +3414,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.draft.cpuparams_batch.n_threads = value;
             if (params.speculative.draft.cpuparams_batch.n_threads <= 0) {
-                params.speculative.draft.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                params.speculative.draft.cpuparams_batch.n_threads = common_cpu_get_num_physical_cores();
             }
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));


### PR DESCRIPTION
Replace `std::thread::hardware_concurrency()` with `common_cpu_get_num_physical_cores()` for the `--threads -1` default value calculation.

`std::thread::hardware_concurrency()` returns logical CPU count, which includes hyper-threads, causing `--threads -1` to double-count on HT-enabled systems. `common_cpu_get_num_physical_cores()` already exists in `common/common.cpp` and returns the correct physical core count.

Fixes #19110