### PR TITLE
common : retry HTTP requests over IPv4 when IPv6 connect fails

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -227,48 +227,51 @@ static bool common_pull_file(httplib::Client & cli,
     const char * func = __func__; // avoid __func__ inside a lambda
     size_t progress_step = 0;
 
-    auto res = cli.Get(resolve_path, headers,
-        [&](const httplib::Response &response) {
-            if (p.downloaded > 0 && response.status != 206) {
-                LOG_WRN("%s: server did not respond with 206 Partial Content for a resume request. Status: %d\n", func, response.status);
-                return false;
-            }
-            if (p.downloaded == 0 && response.status != 200) {
-                LOG_WRN("%s: download received non-successful status code: %d\n", func, response.status);
-                return false;
-            }
-            if (p.total == 0 && response.has_header("Content-Length")) {
-                try {
-                    size_t content_length = std::stoull(response.get_header_value("Content-Length"));
-                    p.total = p.downloaded + content_length;
-                } catch (const std::exception &e) {
-                    LOG_WRN("%s: invalid Content-Length header: %s\n", func, e.what());
+    auto res = common_http_request_with_ipv4_fallback(cli, [&] {
+        return cli.Get(
+            resolve_path, headers,
+            [&](const httplib::Response & response) {
+                if (p.downloaded > 0 && response.status != 206) {
+                    LOG_WRN("%s: server did not respond with 206 Partial Content for a resume request. Status: %d\n",
+                            func, response.status);
+                    return false;
                 }
-            }
-            return true;
-        },
-        [&](const char *data, size_t len) {
-            ofs.write(data, len);
-            if (!ofs) {
-                LOG_ERR("%s: error writing to file: %s\n", func, path_tmp.c_str());
-                return false;
-            }
-            p.downloaded += len;
-            progress_step += len;
-
-            if (progress_step >= p.total / 1000 || p.downloaded == p.total) {
-                if (callback) {
-                    callback->on_update(p);
-                    if (callback->is_cancelled()) {
-                        return false;
+                if (p.downloaded == 0 && response.status != 200) {
+                    LOG_WRN("%s: download received non-successful status code: %d\n", func, response.status);
+                    return false;
+                }
+                if (p.total == 0 && response.has_header("Content-Length")) {
+                    try {
+                        size_t content_length = std::stoull(response.get_header_value("Content-Length"));
+                        p.total               = p.downloaded + content_length;
+                    } catch (const std::exception & e) {
+                        LOG_WRN("%s: invalid Content-Length header: %s\n", func, e.what());
                     }
                 }
-                progress_step = 0;
-            }
-            return true;
-        },
-        nullptr
-    );
+                return true;
+            },
+            [&](const char * data, size_t len) {
+                ofs.write(data, len);
+                if (!ofs) {
+                    LOG_ERR("%s: error writing to file: %s\n", func, path_tmp.c_str());
+                    return false;
+                }
+                p.downloaded += len;
+                progress_step += len;
+
+                if (progress_step >= p.total / 1000 || p.downloaded == p.total) {
+                    if (callback) {
+                        callback->on_update(p);
+                        if (callback->is_cancelled()) {
+                            return false;
+                        }
+                    }
+                    progress_step = 0;
+                }
+                return true;
+            },
+            nullptr);
+    });
 
     if (!res) {
         LOG_ERR("%s: download failed: %s (status: %d)\n",
@@ -322,7 +325,7 @@ static int common_download_file_single_online(const std::string & url,
         LOG_DBG("%s: no previous model file found %s\n", __func__, path.c_str());
     }
 
-    auto head = cli.Head(parts.path);
+    auto head = common_http_request_with_ipv4_fallback(cli, [&] { return cli.Head(parts.path); });
     if (!head || head->status < 200 || head->status >= 300) {
         LOG_TRC("%s: HEAD failed, status: %d\n", __func__, head ? head->status : -1);
         if (file_exists) {
@@ -459,14 +462,16 @@ std::pair<long, std::vector<char>> common_remote_get_content(const std::string  
     }
 
     std::vector<char> buf;
-    auto res = cli.Get(parts.path, headers,
-        [&](const char *data, size_t len) {
-            buf.insert(buf.end(), data, data + len);
-            return params.max_size == 0 ||
-                   buf.size() <= static_cast<size_t>(params.max_size);
-        },
-        nullptr
-    );
+    auto res = common_http_request_with_ipv4_fallback(cli, [&] {
+        buf.clear();  // drop anything buffered by a failed first attempt
+        return cli.Get(
+            parts.path, headers,
+            [&](const char * data, size_t len) {
+                buf.insert(buf.end(), data, data + len);
+                return params.max_size == 0 || buf.size() <= static_cast<size_t>(params.max_size);
+            },
+            nullptr);
+    });
 
     if (!res) {
         throw std::runtime_error("error: cannot make GET request");

--- a/common/hf-cache.cpp
+++ b/common/hf-cache.cpp
@@ -210,7 +210,7 @@ static nl::json api_get(const std::string & url,
         LOG_WRN("%s: invalid token, authentication disabled\n", __func__);
     }
 
-    if (auto res = cli.Get(parts.path, headers)) {
+    if (auto res = common_http_request_with_ipv4_fallback(cli, [&] { return cli.Get(parts.path, headers); })) {
         auto body = res->body;
 
         if (res->status == 200) {

--- a/common/http.h
+++ b/common/http.h
@@ -91,7 +91,19 @@ static std::pair<httplib::Client, common_http_url> common_http_client(const std:
 
     cli.set_follow_location(true);
 
+    cli.set_connection_timeout(5, 0);  // fail fast on a dead IPv6 route instead of hanging
+
     return { std::move(cli), std::move(parts) };
+}
+
+// cpp-httplib tries addresses serially and never falls back from IPv6 to IPv4, so do it ourselves
+template <typename Fn> static auto common_http_request_with_ipv4_fallback(httplib::Client & cli, Fn && fn) -> decltype(fn()) {
+    auto res = fn();
+    if (!res && (res.error() == httplib::Error::ConnectionTimeout || res.error() == httplib::Error::Connection)) {
+        cli.set_address_family(AF_INET);
+        res = fn();
+    }
+    return res;
 }
 
 static std::string common_http_show_masked_url(const common_http_url & parts) {


### PR DESCRIPTION
## Overview

On a host (e.g. HF) that has an IPv6 (AAAA) DNS record but no working IPv6 route, `llama-server -hf ` hangs at the first HTTP request. With -v it stalls:

```
tonyz@tonyz-sff-lin ~/s/llama.cpp (master)> ./build/bin/llama-server -hf xxx -c 0 -v
0.00.083.740 I common_params_handle_remote_preset: looking for remote preset at https://huggingface.co/xxx/resolve/main/preset.ini
0.00.084.861 D common_download_file_single_online: no previous model file found xxx
```

Upon investigation, hang is in `cli.Head()`. huggingface.co has multiple addresses and cpp-httplib tries them sequentially with IPv6 first, and it never falls back to the working IPv4 address. The default connection timeout at 300s, the request blocks for ~5 minutes before failing.

This PR bounds the connect timeout and adds an IPv4 fallback, so dual-stack hosts with broken IPv6 connectivity work again - 

```
tonyz@tonyz-sff-lin ~/s/llama.cpp (master)> ./build/bin/llama-server -hf xxx -c 0 -v --no-mmap
0.00.092.428 I common_params_handle_remote_preset: looking for remote preset at https://huggingface.co/xxx/resolve/main/preset.ini
0.00.093.583 D common_download_file_single_online: no previous model file found xxx
0.05.295.020 I common_download_file_single_online: HEAD failed, status: 404
0.05.296.016 I common_params_handle_remote_preset: no remote preset found, skipping
0.15.671.972 D common_download_file_single_online: using cached file: /home/tonyz/.cache/huggingface/hub/xxx.gguf
0.15.672.141 D common_download_file_single_online: using cached file: /home/tonyz/.cache/huggingface/hub/xxxx.gguf
0.15.672.533 I common_params_print_info: build 9439 (55f5dd2cf) with GNU 13.3.0 for Linux x86_64
```

### Notes

- Chose cpp template for easier adaption of different httplib methods/signatures
- Timeouts: I picked 5 seconds connect timeout without a specific reason (libcurl [defaults to 300ms](https://github.com/icing/curl/blob/master/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md), happy to use the same setup if needed), and it only bounds connection setup, not transfers, so it's safe.

## Additional information

In #18828 we removed libcurl and in previous changes replaced libcurl with cpp-httplib - this caused a regression as libcurl supports rfc6555 - this is not supported in cpp-httplib, thus this issue.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, assisted with root-causing hang `llama-server` start.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
