### PR TITLE
ci(self-hosted) : fix missing Linux label on cpu-x64-high-perf runner

### DIFF
--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -298,7 +298,7 @@ jobs:
           GG_BUILD_OPENVINO=1 GGML_OPENVINO_DEVICE=GPU GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ~/results/llama.cpp ~/mnt/llama.cpp
 
   cpu-x64-high-perf:
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Clone


### PR DESCRIPTION
## Overview

The \`cpu-x64-high-perf\` job in \`build-self-hosted.yml\` was missing the \`Linux\` label in its \`runs-on\` specification, causing the runner to not be discovered. Added \`Linux\` to match the pattern used by all other self-hosted Linux jobs.

## Additional information

Fixes: https://github.com/ggml-org/llama.cpp/pull/23927#discussion_r3332213086

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. llama.cpp + pi + Qwen3.6-27B