### PR TITLE
common-log: Supports displaying the location of the printed log, including the filename and line number.

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -393,7 +393,10 @@ void common_log_free(struct common_log * log) {
     delete log;
 }
 
-void common_log_add(struct common_log * log, enum ggml_log_level level, const char * fmt, ...) {
+void common_log_add(struct common_log * log, enum ggml_log_level level, const char* prefix, const char * fmt, ...) {
+    std::string str_prefix = prefix;
+    const std::string str = str_prefix + fmt;
+    fmt = str.data();
     va_list args;
     va_start(args, fmt);
     log->add(level, fmt, args);
@@ -448,6 +451,6 @@ static int common_get_verbosity(enum ggml_log_level level) {
 void common_log_default_callback(enum ggml_log_level level, const char * text, void * /*user_data*/) {
     auto verbosity = common_get_verbosity(level);
     if (verbosity <= common_log_verbosity_thold) {
-        common_log_add(common_log_main(), level, "%s", text);
+        common_log_add(common_log_main(), level, "[] ", "%s", text);
     }
 }

--- a/common/log.h
+++ b/common/log.h
@@ -59,8 +59,8 @@ void                common_log_pause (struct common_log * log); // pause  the wo
 void                common_log_resume(struct common_log * log); // resume the worker thread, not thread-safe
 void                common_log_free  (struct common_log * log);
 
-LOG_ATTRIBUTE_FORMAT(3, 4)
-void common_log_add(struct common_log * log, enum ggml_log_level level, const char * fmt, ...);
+LOG_ATTRIBUTE_FORMAT(4, 5)
+void common_log_add(struct common_log * log, enum ggml_log_level level, const char* prefix, const char * fmt, ...);
 
 // defaults: file = NULL, colors = false, prefix = false, timestamps = false
 //
@@ -104,7 +104,9 @@ void common_log_flush         (struct common_log * log);                    // f
 #define LOG_TMPL(level, verbosity, ...) \
     do { \
         if ((verbosity) <= common_log_get_verbosity_thold()) { \
-            common_log_add(common_log_main(), (level), __VA_ARGS__); \
+            char prefix[256]; \
+            snprintf(prefix, sizeof prefix, "[%s:%d] ", __FILE__, __LINE__); \
+            common_log_add(common_log_main(), (level), prefix, __VA_ARGS__); \
         } \
     } while (0)
 


### PR DESCRIPTION
* Additional print code location: [file:line] when LOG* macro function.

* Additional print same format: [] when common_log_default_callback function.

## Overview

1. Function Description

Add a location to the LOG printout, including the filename and corresponding line number, for easier reading and code troubleshooting.

If a LOG* related macro function is called, this information will be printed additionally.

For the common_log_default_callback function, to ensure it has the same formatting, [] will be printed additionally.


2. Testing Methods

Only linux x86 test


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
