### PR TITLE
Fix WebUI: restore previous system message on Cancel/Escape instead of deleting it

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessage.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessage.svelte
@@ -43,7 +43,7 @@
 		assistantMessages: number;
 		messageTypes: string[];
 	} | null>(null);
-	let editedContent = $derived(message.content);
+	let editedContent = $state(message.content);
 
 	let rawEditContent = $derived.by(() => {
 		if (message.role !== MessageRole.ASSISTANT) return undefined;
@@ -88,7 +88,7 @@
 
 		return parts.join('\n\n\n');
 	});
-	let editedExtras = $derived<DatabaseMessageExtra[]>(message.extra ? [...message.extra] : []);
+	let editedExtras = $state<DatabaseMessageExtra[]>(message.extra ? [...message.extra] : []);
 	let editedUploadedFiles = $state<ChatUploadedFile[]>([]);
 	let isEditing = $state(false);
 	let showDeleteDialog = $state(false);


### PR DESCRIPTION
## Description

Fixes #22819.

When editing the system message in the WebUI, pressing Cancel or Escape would delete the entire message instead of restoring the previous content.

## Root Cause

The bug was caused by `editedContent` and `editedExtras` being declared as Svelte 5 `$derived` runes in `ChatMessage.svelte`. In Svelte 5, `$derived` creates read-only computed values — assignments to them are silently ignored by the runtime.

This meant:
1. When creating a new system message, `handleEdit()` tried to set `editedContent = ''` to clear the placeholder, but it stayed as `SYSTEM_MESSAGE_PLACEHOLDER`
2. When the user typed in the textarea, `setContent(value)` was silently ignored
3. When Save was clicked, `editedContent.trim()` returned the placeholder text instead of the user's input, so the DB write was a no-op
4. On a subsequent edit-cancel, `message.content === SYSTEM_MESSAGE_PLACEHOLDER` evaluated `true`, causing `removeSystemPromptPlaceholder()` to fire and delete the entire message

## Fix

Changed `$derived` to `$state` for both variables, making them properly mutable. Now all assignments throughout the edit lifecycle (start edit, type, save, cancel) take effect as intended.

- `let editedContent = $derived(message.content);` → `let editedContent = $state(message.content);`
- `let editedExtras = $derived<...>(message.extra ? [...message.extra] : []);` → `let editedExtras = $state<...>(message.extra ? [...message.extra] : []);`

## Changes

Single file change in `tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessage.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)