### PR TITLE
convert_lora_to_gguf: fix V head reordering for Qwen3.5 LoRA tensors

### DIFF
--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -492,6 +492,54 @@ if __name__ == '__main__':
                     assert tensor.B is not None
                     yield (name, cast(torch.Tensor, LoraTorchTensor(tensor.A, tensor.B)))
 
+            @staticmethod
+            def _reorder_v_heads(
+                tensor: Tensor,
+                dim: int,
+                num_k_heads: int,
+                num_v_per_k: int,
+                head_dim: int,
+            ) -> Tensor:
+                if isinstance(tensor, LoraTorchTensor):
+                    lora_A, lora_B = tensor.get_lora_A_B()
+                    N, V, H = num_k_heads, num_v_per_k, head_dim
+                    total = N * V * H
+
+                    # Linear attention stores V heads grouped by K head:
+                    #   grouped: [G0_v0..v{r-1}, G1_v0..v{r-1}, ...]
+                    #   tiled:   [G0_v0, G1_v0, ..., G0_v1, G1_v1, ...]
+                    # Build the permutation mapping from grouped to tiled order.
+                    # grouped flat index: n*V*H + v*H + h
+                    # tiled flat index:   v*N*H + n*H + h
+                    idx = torch.arange(total)
+                    n_idx = idx // (V * H)
+                    v_idx = (idx % (V * H)) // H
+                    h_idx = idx % H
+                    tiled_idx = v_idx * N * H + n_idx * H + h_idx
+
+                    perm = torch.empty(total, dtype=torch.long)
+                    perm[tiled_idx] = idx  # perm[tiled_pos] = original_position
+
+                    if dim < 0:
+                        dim += len(tensor.shape)
+                    if dim == 0:
+                        # Permute rows of B (output dimension)
+                        lora_B = lora_B.index_select(0, perm.to(device=lora_B.device))
+                    elif dim == 1:
+                        # Permute columns of A (input dimension)
+                        lora_A = lora_A.index_select(-1, perm.to(device=lora_A.device))
+                    else:
+                        raise NotImplementedError(
+                            f"LoRA V head reordering not implemented for dim={dim}"
+                        )
+
+                    return LoraTorchTensor(lora_A, lora_B)
+
+                # For non-LoRA tensors, delegate to the base model implementation.
+                return model_class._reorder_v_heads(
+                    tensor, dim, num_k_heads, num_v_per_k, head_dim,
+                )
+
             def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
                 dest = list(super().modify_tensors(data_torch, name, bid))
                 # some archs may have the same tensor for lm_head and output (tie word embeddings)


### PR DESCRIPTION
When converting Qwen3.5 LoRA adapters to GGUF, `_reorder_v_heads` is called on `LoraTorchTensor` weights (via the `_LinearAttentionVReorderBase` mixin path). The intermediate `reshape()` that splits the V-head dimension changes the last dimension of the tensor, which `LoraTorchTensor.reshape()` does not support and raises `NotImplementedError`.

**The fix**: override `_reorder_v_heads` as a `@staticmethod` in `LoraModel`. For `LoraTorchTensor` inputs, compute the grouped-to-tiled permutation and apply it directly to the appropriate factor matrix:

- **dim=0** (row reorder, e.g. `.in_proj_qkv` V slice, `.in_proj_z`): permute rows of `_lora_B` via `index_select(0, perm)`
- **dim=1** (column reorder, e.g. `.out_proj`): permute columns of `_lora_A` via `index_select(-1, perm)`

This avoids the reshape entirely and is mathematically equivalent to the full `reshape → permute → contiguous → reshape` sequence that the base implementation applies to dense tensors.

For non-LoRA tensors, the method delegates to `model_class._reorder_v_heads` as before.

**Testing**: verified permutation correctness across multiple (N,V,H) configurations; checked that `B @ A_perm` (dim=1) and `B_perm @ A` (dim=0) produce bit-exact results matching the dense path.

Fixes #21125

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>