### PR TITLE
server: fix cache_prompt inconsistency (checkpoints not cleared between requests)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -213,6 +213,10 @@ struct server_slot {
 
         // clear alora start
         alora_invocation_start = -1;
+
+        // clear context checkpoints from the previous run
+        // they are re-created during prompt processing if needed
+        prompt.checkpoints.clear();
     }
 
     void init_sampler() const {
@@ -2797,10 +2801,14 @@ private:
                                     }
 
                                     if (do_reset) {
-                                        SLT_WRN(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
-                                                "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
-                                        pos_next = 0;
-                                        n_past = 0;
+                                        if (pos_min >= 0) {
+                                            SLT_WRN(slot, "no checkpoints available, but KV cache has valid data - skipping checkpoint restoration for n_past = %d\n", n_past);
+                                        } else {
+                                            SLT_WRN(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
+                                                    "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
+                                            pos_next = 0;
+                                            n_past = 0;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes #19034

## Bug
When `cache_prompt=True`, two identical requests could produce different completions. The divergence appeared on the second `cache_prompt=True` request. Setting `batch_size=1` eliminated the divergence.

## Root cause
Context checkpoints (`slot.prompt.checkpoints`) created during prompt processing of one request survived in the slot and were erroneously restored on the next request, corrupting the KV cache prefix reuse.

After the first request completed, `server_slot::release()` → `reset()` cleared metadata but **not** `prompt.checkpoints`. When the next identical request arrived with `cache_prompt=True`:

1. `get_available_slot()` found the idle slot with valid KV cache prefix
2. In `update_slots()`, the checkpoint restoration code found stale checkpoints from run 1
3. It restored the KV cache to an intermediate state from run 1 and adjusted `n_past`
4. This corrupted the cached prefix, producing different logits

With `batch_size=1`, checkpoints were never created during prompt processing (the 256-token `checkpoint_min_step` prevented it), which is why single-token batches were unaffected.

## Fix (two changes)

**1. Clear `prompt.checkpoints` in `server_slot::reset()`:**
Checkpoints are internal to a single prompt processing run. They should not survive across requests. They are safely re-created during the next run if needed.

**2. Skip force-reset when KV cache has valid data:**
In the checkpoint restoration path, when `do_reset` is true but the KV cache has valid data (`pos_min >= 0`), do not force `n_past = 0`. The cache prefix from the previous run is intact and does not need full reprocessing. The old code unconditionally set `n_past = 0` when it could not find checkpoints, which defeated cache reuse entirely.