### PR TITLE
server: real-time reasoning interruption via control endpoint

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -277,6 +277,7 @@ struct common_params_sampling {
     std::vector<llama_token> reasoning_budget_end;             // end tag token sequence
     std::vector<llama_token> reasoning_budget_forced;          // forced sequence (message + end tag)
     std::string              reasoning_budget_message;         // message injected before end tag when budget exhausted
+    bool                     reasoning_control = false;        // create the budget sampler on demand so reasoning can be ended at runtime
 
     bool backend_sampling = false;
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -293,7 +293,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
     }
 
     // reasoning budget sampler (skip when budget is unlimited unless a lazy grammar is active, which needs rbudget for thinking-block suppression)
-    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0)) {
+    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0 || params.reasoning_control)) {
         rbudget = common_reasoning_budget_init(
             vocab,
             params.reasoning_budget_start,

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1244,6 +1244,8 @@ The `response_format` parameter supports both plain JSON output (e.g. `{"type": 
 
 `reasoning_format`: The reasoning format to be parsed. If set to `none`, it will output the raw generated text.
 
+`reasoning_control`: Arms realtime reasoning control for this completion so it can be ended early via `/v1/chat/completions/control`. Defaults to `false`.
+
 `generation_prompt`: The generation prompt that was prefilled in by the template. Prepended to model output before parsing.
 
 `parse_tool_calls`: Whether to parse the generated tool call.
@@ -1349,6 +1351,22 @@ The response also includes a standard `usage` object:
 The server supports parsing and returning reasoning via the `reasoning_content` field, similar to Deepseek API.
 
 Reasoning input (preserve reasoning in history) is also supported by some specific templates. For more details, please refer to [PR#18994](https://github.com/ggml-org/llama.cpp/pull/18994).
+
+### POST `/v1/chat/completions/control`: Control a running chat completion in real time
+
+Acts on an in-flight completion identified by its `id` (the `id` field streamed back by `/v1/chat/completions`). The request is processed in parallel with the SSE stream, so the client sends it while still reading tokens.
+
+*Options:*
+
+`id`: (Required) The chat completion id to act on. A completion that has already finished matches nothing and the call is a no-op.
+
+`action`: (Required) The control action to perform. Currently the only supported value is `reasoning_end`, which forces the end of the current reasoning block so the model moves on to the final answer. Requires `reasoning_control: true` on the original completion request.
+
+`model`: (Required in router mode) The model name, used to route the request to the right instance. Ignored in single model mode.
+
+**Response format**
+
+Returns a JSON object with a boolean `success` field, and an optional `message` field describing the reason when `success` is `false`.
 
 ### POST `/v1/responses`: OpenAI-compatible Responses API
 

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1132,6 +1132,7 @@ json oaicompat_chat_params_parse(
             llama_params["reasoning_budget_start_tag"] = chat_params.thinking_start_tag;
             llama_params["reasoning_budget_end_tag"] = chat_params.thinking_end_tag;
             llama_params["reasoning_budget_message"] = opt.reasoning_budget_message;
+            llama_params["reasoning_control"] = json_value(body, "reasoning_control", false);
         }
     }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1244,6 +1244,23 @@ private:
         return nullptr;
     }
 
+    // resolves the live slot currently serving a given chat completion id. matching the
+    // completion rather than the slot index avoids a TOCTOU: once the completion ends the
+    // slot may be reassigned, and a stale id simply matches nothing
+    server_slot * get_slot_by_cmpl_id(const std::string & cmpl_id) {
+        if (cmpl_id.empty()) {
+            return nullptr;
+        }
+
+        for (server_slot & slot : slots) {
+            if (slot.is_processing() && slot.task && slot.task->params.oaicompat_cmpl_id == cmpl_id) {
+                return &slot;
+            }
+        }
+
+        return nullptr;
+    }
+
     server_slot * get_available_slot(const server_task & task) {
         server_slot * ret = nullptr;
 
@@ -2097,23 +2114,34 @@ private:
                 } break;
             case SERVER_TASK_TYPE_CONTROL:
                 {
-                    server_slot * slot = get_slot_by_id(task.id_slot);
+                    auto res = std::make_unique<server_task_result_control>();
+                    res->id = task.id;
+
+                    // resolve the live completion, a finished one matches nothing (no TOCTOU)
+                    server_slot * slot = get_slot_by_cmpl_id(task.control_cmpl_id);
                     if (slot == nullptr) {
-                        send_error(task, "Invalid slot ID", ERROR_TYPE_INVALID_REQUEST);
+                        res->success = false;
+                        res->message = "no active completion for this id";
+                        queue_results.send(std::move(res));
                         break;
                     }
 
-                    // act on the live slot mid generation, never defer
-                    bool reasoning_active = false;
-                    if (task.control_action == "end_reasoning") {
-                        reasoning_active = common_sampler_reasoning_budget_force(slot->smpl.get());
+                    if (task.control_action == "reasoning_end") {
+                        // the budget sampler only exists when reasoning control was armed
+                        if (!slot->task->params.sampling.reasoning_control) {
+                            res->success = false;
+                            res->message = "reasoning control not enabled for this completion";
+                            queue_results.send(std::move(res));
+                            break;
+                        }
+                        // act on the live slot mid generation, never defer
+                        common_sampler_reasoning_budget_force(slot->smpl.get());
+                        res->success = true;
+                    } else {
+                        res->success = false;
+                        res->message = "unknown control action";
                     }
 
-                    auto res = std::make_unique<server_task_result_control>();
-                    res->id               = task.id;
-                    res->id_slot          = task.id_slot;
-                    res->found            = true;
-                    res->reasoning_active = reasoning_active;
                     queue_results.send(std::move(res));
                 } break;
             case SERVER_TASK_TYPE_NEXT_RESPONSE:
@@ -4272,13 +4300,13 @@ void server_routes::init_routes() {
         auto res = create_response();
         const json body = json::parse(req.body);
 
-        const int id_slot = json_value(body, "id_slot", -1);
-        const std::string action = json_value(body, "action", std::string());
-        if (id_slot < 0) {
-            res->error(format_error_response("missing or invalid id_slot", ERROR_TYPE_INVALID_REQUEST));
+        const std::string cmpl_id = json_value(body, "id", std::string());
+        const std::string action  = json_value(body, "action", std::string());
+        if (cmpl_id.empty()) {
+            res->error(format_error_response("missing completion id", ERROR_TYPE_INVALID_REQUEST));
             return res;
         }
-        if (action != "end_reasoning") {
+        if (action != "reasoning_end") {
             res->error(format_error_response("unknown control action", ERROR_TYPE_INVALID_REQUEST));
             return res;
         }
@@ -4286,9 +4314,9 @@ void server_routes::init_routes() {
         auto & rd = res->rd;
         {
             server_task task(SERVER_TASK_TYPE_CONTROL);
-            task.id             = rd.get_new_id();
-            task.id_slot        = id_slot;
-            task.control_action = action;
+            task.id              = rd.get_new_id();
+            task.control_cmpl_id = cmpl_id;
+            task.control_action  = action;
             rd.post_task(std::move(task));
         }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2095,6 +2095,27 @@ private:
                         }
                     }
                 } break;
+            case SERVER_TASK_TYPE_CONTROL:
+                {
+                    server_slot * slot = get_slot_by_id(task.id_slot);
+                    if (slot == nullptr) {
+                        send_error(task, "Invalid slot ID", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
+
+                    // act on the live slot mid generation, never defer
+                    bool reasoning_active = false;
+                    if (task.control_action == "end_reasoning") {
+                        reasoning_active = common_sampler_reasoning_budget_force(slot->smpl.get());
+                    }
+
+                    auto res = std::make_unique<server_task_result_control>();
+                    res->id               = task.id;
+                    res->id_slot          = task.id_slot;
+                    res->found            = true;
+                    res->reasoning_active = reasoning_active;
+                    queue_results.send(std::move(res));
+                } break;
             case SERVER_TASK_TYPE_NEXT_RESPONSE:
                 {
                     // do nothing
@@ -4245,6 +4266,43 @@ void server_routes::init_routes() {
             body_parsed,
             files,
             TASK_RESPONSE_TYPE_OAI_CHAT);
+    };
+
+    this->post_control = [this](const server_http_req & req) {
+        auto res = create_response();
+        const json body = json::parse(req.body);
+
+        const int id_slot = json_value(body, "id_slot", -1);
+        const std::string action = json_value(body, "action", std::string());
+        if (id_slot < 0) {
+            res->error(format_error_response("missing or invalid id_slot", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+        if (action != "end_reasoning") {
+            res->error(format_error_response("unknown control action", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+
+        auto & rd = res->rd;
+        {
+            server_task task(SERVER_TASK_TYPE_CONTROL);
+            task.id             = rd.get_new_id();
+            task.id_slot        = id_slot;
+            task.control_action = action;
+            rd.post_task(std::move(task));
+        }
+
+        auto result = rd.next(req.should_stop);
+        if (!result) {
+            GGML_ASSERT(req.should_stop());
+            return res;
+        }
+        if (result->is_error()) {
+            res->error(result->to_json());
+            return res;
+        }
+        res->ok(result->to_json());
+        return res;
     };
 
     this->post_responses_oai = [this](const server_http_req & req) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1244,9 +1244,6 @@ private:
         return nullptr;
     }
 
-    // resolves the live slot currently serving a given chat completion id. matching the
-    // completion rather than the slot index avoids a TOCTOU: once the completion ends the
-    // slot may be reassigned, and a stale id simply matches nothing
     server_slot * get_slot_by_cmpl_id(const std::string & cmpl_id) {
         if (cmpl_id.empty()) {
             return nullptr;
@@ -2117,8 +2114,7 @@ private:
                     auto res = std::make_unique<server_task_result_control>();
                     res->id = task.id;
 
-                    // resolve the live completion, a finished one matches nothing (no TOCTOU)
-                    server_slot * slot = get_slot_by_cmpl_id(task.control_cmpl_id);
+                    server_slot * slot = get_slot_by_cmpl_id(task.params.control_cmpl_id);
                     if (slot == nullptr) {
                         res->success = false;
                         res->message = "no active completion for this id";
@@ -2126,7 +2122,7 @@ private:
                         break;
                     }
 
-                    if (task.control_action == "reasoning_end") {
+                    if (task.params.control_action == "reasoning_end") {
                         // the budget sampler only exists when reasoning control was armed
                         if (!slot->task->params.sampling.reasoning_control) {
                             res->success = false;
@@ -4315,8 +4311,8 @@ void server_routes::init_routes() {
         {
             server_task task(SERVER_TASK_TYPE_CONTROL);
             task.id              = rd.get_new_id();
-            task.control_cmpl_id = cmpl_id;
-            task.control_action  = action;
+            task.params.control_cmpl_id = cmpl_id;
+            task.params.control_action  = action;
             rd.post_task(std::move(task));
         }
 

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -110,6 +110,7 @@ struct server_routes {
     server_http_context::handler_t post_completions;
     server_http_context::handler_t post_completions_oai;
     server_http_context::handler_t post_chat_completions;
+    server_http_context::handler_t post_control;
     server_http_context::handler_t post_responses_oai;
     server_http_context::handler_t post_transcriptions_oai;
     server_http_context::handler_t post_anthropic_messages;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -499,6 +499,7 @@ task_params server_task::params_from_json_cmpl(
         const auto end_tag   = json_value(data, "reasoning_budget_end_tag", std::string());
         const auto message   = json_value(data, "reasoning_budget_message", std::string());
         params.sampling.reasoning_budget_tokens = budget;
+        params.sampling.reasoning_control = json_value(data, "reasoning_control", false);
 
         if (!start_tag.empty()) {
             params.sampling.reasoning_budget_start = common_tokenize(vocab, start_tag, false, true);

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -85,6 +85,10 @@ struct task_params {
     std::string        oaicompat_model;
     std::string        oaicompat_cmpl_id;
 
+    // realtime control (SERVER_TASK_TYPE_CONTROL)
+    std::string        control_action;
+    std::string        control_cmpl_id;
+
     // per-request parameters for chat parsing
     common_chat_parser_params chat_parser_params;
 
@@ -135,10 +139,6 @@ struct server_task {
     // used by SERVER_TASK_TYPE_CANCEL
     int id_target = -1;
     int id_slot   = -1;
-
-    // used by SERVER_TASK_TYPE_CONTROL
-    std::string control_action;
-    std::string control_cmpl_id; // targets a live completion, avoids the slot index TOCTOU
 
     // used by parallel sampling (multiple completions from same prompt)
     int id_parent  = -1;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -19,6 +19,7 @@ enum server_task_type {
     SERVER_TASK_TYPE_RERANK,
     SERVER_TASK_TYPE_INFILL,
     SERVER_TASK_TYPE_CANCEL,
+    SERVER_TASK_TYPE_CONTROL,
     SERVER_TASK_TYPE_NEXT_RESPONSE,
     SERVER_TASK_TYPE_METRICS,
     SERVER_TASK_TYPE_SLOT_SAVE,
@@ -134,6 +135,9 @@ struct server_task {
     // used by SERVER_TASK_TYPE_CANCEL
     int id_target = -1;
     int id_slot   = -1;
+
+    // used by SERVER_TASK_TYPE_CONTROL
+    std::string control_action;
 
     // used by parallel sampling (multiple completions from same prompt)
     int id_parent  = -1;
@@ -549,6 +553,19 @@ struct server_task_result_slot_erase : server_task_result {
     size_t n_erased;
 
     virtual json to_json() override;
+};
+
+struct server_task_result_control : server_task_result {
+    bool found            = false; // slot was located
+    bool reasoning_active = false; // a reasoning block was open and got ended
+
+    virtual json to_json() override {
+        return json {
+            { "id_slot",          id_slot },
+            { "found",            found },
+            { "reasoning_active", reasoning_active },
+        };
+    }
 };
 
 struct server_task_result_get_lora : server_task_result {

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -138,6 +138,7 @@ struct server_task {
 
     // used by SERVER_TASK_TYPE_CONTROL
     std::string control_action;
+    std::string control_cmpl_id; // targets a live completion, avoids the slot index TOCTOU
 
     // used by parallel sampling (multiple completions from same prompt)
     int id_parent  = -1;
@@ -556,15 +557,15 @@ struct server_task_result_slot_erase : server_task_result {
 };
 
 struct server_task_result_control : server_task_result {
-    bool found            = false; // slot was located
-    bool reasoning_active = false; // a reasoning block was open and got ended
+    bool        success = false;
+    std::string message; // optional detail when success is false
 
     virtual json to_json() override {
-        return json {
-            { "id_slot",          id_slot },
-            { "found",            found },
-            { "reasoning_active", reasoning_active },
-        };
+        json out = json { { "success", success } };
+        if (!message.empty()) {
+            out["message"] = message;
+        }
+        return out;
     }
 };
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -149,6 +149,7 @@ int llama_server(int argc, char ** argv) {
         routes.post_completions            = models_routes->proxy_post;
         routes.post_completions_oai        = models_routes->proxy_post;
         routes.post_chat_completions       = models_routes->proxy_post;
+        routes.post_control                = models_routes->proxy_post;
         routes.post_responses_oai          = models_routes->proxy_post;
         routes.post_transcriptions_oai     = models_routes->proxy_post;
         routes.post_anthropic_messages     = models_routes->proxy_post;
@@ -185,6 +186,7 @@ int llama_server(int argc, char ** argv) {
     ctx_http.post("/v1/completions",           ex_wrapper(routes.post_completions_oai));
     ctx_http.post("/chat/completions",         ex_wrapper(routes.post_chat_completions));
     ctx_http.post("/v1/chat/completions",      ex_wrapper(routes.post_chat_completions));
+    ctx_http.post("/v1/chat/completions/control", ex_wrapper(routes.post_control));
     ctx_http.post("/v1/responses",             ex_wrapper(routes.post_responses_oai));
     ctx_http.post("/responses",                ex_wrapper(routes.post_responses_oai));
     ctx_http.post("/v1/audio/transcriptions",  ex_wrapper(routes.post_transcriptions_oai));

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
@@ -541,6 +541,7 @@
 				canSend={canSubmit}
 				{disabled}
 				{isLoading}
+				isReasoning={chatStore.isReasoning}
 				{isRecording}
 				{showAddButton}
 				{showModelSelector}

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
@@ -2,7 +2,6 @@
 	import { Square, SkipForward } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { ChatService } from '$lib/services';
-	import { modelsStore } from '$lib/stores/models.svelte';
 	import {
 		ChatFormActionsAdd,
 		ChatFormActionModels,
@@ -88,10 +87,10 @@
 	export function openModelSelector() {
 		selectorModelRef?.open();
 	}
-	// completion id of the streaming assistant message, used to target reasoning control
-	let activeCompletionId = $derived(
-		conversationsStore.activeMessages[conversationsStore.activeMessages.length - 1]?.completionId ??
-			''
+	// the streaming assistant message carries both the completion id and the model that
+	// produced it, targeting reasoning control from the same source keeps them consistent
+	let activeMessage = $derived(
+		conversationsStore.activeMessages[conversationsStore.activeMessages.length - 1]
 	);
 </script>
 
@@ -136,7 +135,8 @@
 		<Button
 			type="button"
 			variant="secondary"
-			onclick={() => ChatService.stopReasoning(activeCompletionId, modelsStore.selectedModelName)}
+			onclick={() =>
+				ChatService.stopReasoning(activeMessage?.completionId ?? '', activeMessage?.model)}
 			class="group h-8 w-8 rounded-full p-0"
 			title="Skip reasoning"
 		>

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
@@ -23,6 +23,7 @@
 		class?: string;
 		disabled?: boolean;
 		isLoading?: boolean;
+		isReasoning?: boolean;
 		isRecording?: boolean;
 		showAddButton?: boolean;
 		showModelSelector?: boolean;
@@ -41,6 +42,7 @@
 		class: className = '',
 		disabled = false,
 		isLoading = false,
+		isReasoning = false,
 		isRecording = false,
 		showAddButton = true,
 		showModelSelector = true,
@@ -125,7 +127,7 @@
 		/>
 	{/if}
 
-	{#if isLoading && !canSubmit}
+	{#if isReasoning}
 		<Button
 			type="button"
 			variant="secondary"

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
@@ -88,6 +88,10 @@
 	export function openModelSelector() {
 		selectorModelRef?.open();
 	}
+	// completion id of the streaming assistant message, used to target reasoning control
+	let activeCmplId = $derived(
+		conversationsStore.activeMessages[conversationsStore.activeMessages.length - 1]?.cmplId ?? ''
+	);
 </script>
 
 <div
@@ -131,7 +135,7 @@
 		<Button
 			type="button"
 			variant="secondary"
-			onclick={() => ChatService.stopReasoning(modelsStore.selectedModelName)}
+			onclick={() => ChatService.stopReasoning(activeCmplId, modelsStore.selectedModelName)}
 			class="group h-8 w-8 rounded-full p-0"
 			title="Skip reasoning"
 		>

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-	import { Square } from '@lucide/svelte';
+	import { Square, SkipForward } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
+	import { ChatService } from '$lib/services';
+	import { modelsStore } from '$lib/stores/models.svelte';
 	import {
 		ChatFormActionsAdd,
 		ChatFormActionModels,
@@ -121,6 +123,20 @@
 			forceForegroundText
 			useGlobalSelection
 		/>
+	{/if}
+
+	{#if isLoading && !canSubmit}
+		<Button
+			type="button"
+			variant="secondary"
+			onclick={() => ChatService.stopReasoning(modelsStore.selectedModelName)}
+			class="group h-8 w-8 rounded-full p-0"
+			title="Skip reasoning"
+		>
+			<span class="sr-only">Skip reasoning</span>
+
+			<SkipForward class="h-4 w-4 stroke-muted-foreground group-hover:stroke-foreground" />
+		</Button>
 	{/if}
 
 	{#if isLoading && !canSubmit}

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
@@ -89,8 +89,9 @@
 		selectorModelRef?.open();
 	}
 	// completion id of the streaming assistant message, used to target reasoning control
-	let activeCmplId = $derived(
-		conversationsStore.activeMessages[conversationsStore.activeMessages.length - 1]?.cmplId ?? ''
+	let activeCompletionId = $derived(
+		conversationsStore.activeMessages[conversationsStore.activeMessages.length - 1]?.completionId ??
+			''
 	);
 </script>
 
@@ -135,7 +136,7 @@
 		<Button
 			type="button"
 			variant="secondary"
-			onclick={() => ChatService.stopReasoning(activeCmplId, modelsStore.selectedModelName)}
+			onclick={() => ChatService.stopReasoning(activeCompletionId, modelsStore.selectedModelName)}
 			class="group h-8 w-8 rounded-full p-0"
 			title="Skip reasoning"
 		>

--- a/tools/ui/src/lib/constants/api-endpoints.ts
+++ b/tools/ui/src/lib/constants/api-endpoints.ts
@@ -4,6 +4,17 @@ export const API_MODELS = {
 	UNLOAD: '/models/unload'
 };
 
+// chat completion routes, the control route drives realtime inference (e.g. end reasoning)
+export const API_CHAT = {
+	COMPLETIONS: './v1/chat/completions',
+	CONTROL: './v1/chat/completions/control'
+};
+
+// slot introspection, requires the --slots flag on the server
+export const API_SLOTS = {
+	LIST: './slots'
+};
+
 export const API_TOOLS = {
 	LIST: '/tools',
 	EXECUTE: '/tools'

--- a/tools/ui/src/lib/constants/control-actions.ts
+++ b/tools/ui/src/lib/constants/control-actions.ts
@@ -1,0 +1,7 @@
+// actions accepted by the realtime inference control endpoint (API_CHAT.CONTROL)
+// kept separate from the endpoint paths since these are protocol level verbs
+export const CONTROL_ACTION = {
+	END_REASONING: 'end_reasoning'
+} as const;
+
+export type ControlAction = (typeof CONTROL_ACTION)[keyof typeof CONTROL_ACTION];

--- a/tools/ui/src/lib/constants/control-actions.ts
+++ b/tools/ui/src/lib/constants/control-actions.ts
@@ -1,7 +1,7 @@
 // actions accepted by the realtime inference control endpoint (API_CHAT.CONTROL)
 // kept separate from the endpoint paths since these are protocol level verbs
 export const CONTROL_ACTION = {
-	END_REASONING: 'end_reasoning'
+	END_REASONING: 'reasoning_end'
 } as const;
 
 export type ControlAction = (typeof CONTROL_ACTION)[keyof typeof CONTROL_ACTION];

--- a/tools/ui/src/lib/constants/index.ts
+++ b/tools/ui/src/lib/constants/index.ts
@@ -15,6 +15,7 @@ export * from './cli-flags';
 export * from './code-blocks';
 export * from './code';
 export * from './context-keys';
+export * from './control-actions';
 export * from './css-classes';
 export * from './floating-ui-constraints';
 export * from './formatters';

--- a/tools/ui/src/lib/services/chat.service.ts
+++ b/tools/ui/src/lib/services/chat.service.ts
@@ -405,11 +405,11 @@ export class ChatService {
 	 * nothing server side. The model is carried so the router forwards to the
 	 * right child, single model ignores it. Returns true on success.
 	 */
-	static async stopReasoning(cmplId: string, model?: string | null): Promise<boolean> {
-		if (!cmplId) return false;
+	static async stopReasoning(completionId: string, model?: string | null): Promise<boolean> {
+		if (!completionId) return false;
 		try {
 			const body: Record<string, unknown> = {
-				id: cmplId,
+				id: completionId,
 				action: CONTROL_ACTION.END_REASONING
 			};
 			if (model) body.model = model;

--- a/tools/ui/src/lib/services/chat.service.ts
+++ b/tools/ui/src/lib/services/chat.service.ts
@@ -406,25 +406,38 @@ export class ChatService {
 	 * right child, single model ignores it. Returns true on success.
 	 */
 	static async stopReasoning(completionId: string, model?: string | null): Promise<boolean> {
-		if (!completionId) return false;
-		try {
-			const body: Record<string, unknown> = {
-				id: completionId,
-				action: CONTROL_ACTION.END_REASONING
-			};
-			if (model) body.model = model;
+		if (!completionId) {
+			console.error(
+				'stopReasoning: no completion id for the active message, cannot target the running completion'
+			);
+			return false;
+		}
 
+		const body: Record<string, unknown> = {
+			id: completionId,
+			action: CONTROL_ACTION.END_REASONING
+		};
+		if (model) body.model = model;
+
+		try {
 			const res = await fetch(API_CHAT.CONTROL, {
 				method: 'POST',
 				headers: getJsonHeaders(),
 				body: JSON.stringify(body)
 			});
-			if (!res.ok) return false;
 
-			const data = await res.json();
-			return data?.success === true;
+			const data = await res.json().catch(() => null);
+			if (!res.ok || data?.success !== true) {
+				console.error('stopReasoning: control request failed', {
+					status: res.status,
+					completionId,
+					response: data
+				});
+				return false;
+			}
+			return true;
 		} catch (error) {
-			console.warn('stopReasoning failed:', error);
+			console.error('stopReasoning: control request threw', { completionId, error });
 			return false;
 		}
 	}

--- a/tools/ui/src/lib/services/chat.service.ts
+++ b/tools/ui/src/lib/services/chat.service.ts
@@ -1,4 +1,4 @@
-import { getJsonHeaders } from '$lib/utils/api-headers';
+import { getAuthHeaders, getJsonHeaders } from '$lib/utils/api-headers';
 import { formatAttachmentText } from '$lib/utils/formatters';
 import { isAbortError } from '$lib/utils/abort';
 import {
@@ -239,6 +239,9 @@ export class ChatService {
 			? ReasoningFormat.NONE
 			: ReasoningFormat.AUTO;
 
+		// arms the budget sampler so reasoning can be ended at runtime via the control endpoint
+		requestBody.reasoning_control = true;
+
 		if (continueFinalMessage) {
 			requestBody.continue_final_message = true;
 			requestBody.add_generation_prompt = false;
@@ -387,6 +390,41 @@ export class ChatService {
 			return slots.every((s) => !s.is_processing);
 		} catch {
 			return true;
+		}
+	}
+
+	/**
+	 * Forces the end of the current reasoning block on the active slot.
+	 * Discovers the processing slot via /slots, carrying the model so it
+	 * works in router mode, then posts the control action. Single model
+	 * resolves the slot locally and ignores the model field.
+	 * Returns true if a reasoning block was active and got ended.
+	 */
+	static async stopReasoning(model?: string | null): Promise<boolean> {
+		try {
+			const slotsUrl = model ? `./slots?model=${encodeURIComponent(model)}` : './slots';
+			const slotsRes = await fetch(slotsUrl, { headers: getAuthHeaders() });
+			if (!slotsRes.ok) return false;
+
+			const slots: { id: number; is_processing: boolean }[] = await slotsRes.json();
+			const active = slots.find((s) => s.is_processing);
+			if (!active) return false;
+
+			const body: Record<string, unknown> = { id_slot: active.id, action: 'end_reasoning' };
+			if (model) body.model = model;
+
+			const res = await fetch('./v1/chat/completions/control', {
+				method: 'POST',
+				headers: getJsonHeaders(),
+				body: JSON.stringify(body)
+			});
+			if (!res.ok) return false;
+
+			const data = await res.json();
+			return data?.reasoning_active === true;
+		} catch (error) {
+			console.warn('stopReasoning failed:', error);
+			return false;
 		}
 	}
 

--- a/tools/ui/src/lib/services/chat.service.ts
+++ b/tools/ui/src/lib/services/chat.service.ts
@@ -6,7 +6,10 @@ import {
 	ATTACHMENT_LABEL_MCP_PROMPT,
 	ATTACHMENT_LABEL_MCP_RESOURCE,
 	LEGACY_AGENTIC_REGEX,
-	SETTINGS_KEYS
+	SETTINGS_KEYS,
+	API_CHAT,
+	API_SLOTS,
+	CONTROL_ACTION
 } from '$lib/constants';
 import {
 	AttachmentType,
@@ -292,7 +295,7 @@ export class ChatService {
 		}
 
 		try {
-			const response = await fetch(`./v1/chat/completions`, {
+			const response = await fetch(API_CHAT.COMPLETIONS, {
 				method: 'POST',
 				headers: getJsonHeaders(),
 				body: JSON.stringify(requestBody),
@@ -382,7 +385,7 @@ export class ChatService {
 	 */
 	static async areAllSlotsIdle(model?: string | null, signal?: AbortSignal): Promise<boolean> {
 		try {
-			const url = model ? `./slots?model=${encodeURIComponent(model)}` : './slots';
+			const url = model ? `${API_SLOTS.LIST}?model=${encodeURIComponent(model)}` : API_SLOTS.LIST;
 			const res = await fetch(url, { signal });
 			if (!res.ok) return true;
 
@@ -402,7 +405,9 @@ export class ChatService {
 	 */
 	static async stopReasoning(model?: string | null): Promise<boolean> {
 		try {
-			const slotsUrl = model ? `./slots?model=${encodeURIComponent(model)}` : './slots';
+			const slotsUrl = model
+				? `${API_SLOTS.LIST}?model=${encodeURIComponent(model)}`
+				: API_SLOTS.LIST;
 			const slotsRes = await fetch(slotsUrl, { headers: getAuthHeaders() });
 			if (!slotsRes.ok) return false;
 
@@ -410,10 +415,13 @@ export class ChatService {
 			const active = slots.find((s) => s.is_processing);
 			if (!active) return false;
 
-			const body: Record<string, unknown> = { id_slot: active.id, action: 'end_reasoning' };
+			const body: Record<string, unknown> = {
+				id_slot: active.id,
+				action: CONTROL_ACTION.END_REASONING
+			};
 			if (model) body.model = model;
 
-			const res = await fetch('./v1/chat/completions/control', {
+			const res = await fetch(API_CHAT.CONTROL, {
 				method: 'POST',
 				headers: getJsonHeaders(),
 				body: JSON.stringify(body)
@@ -495,7 +503,7 @@ export class ChatService {
 		}
 
 		try {
-			await fetch(`./v1/chat/completions`, {
+			await fetch(API_CHAT.COMPLETIONS, {
 				method: 'POST',
 				headers: getJsonHeaders(),
 				body: JSON.stringify(requestBody),

--- a/tools/ui/src/lib/services/chat.service.ts
+++ b/tools/ui/src/lib/services/chat.service.ts
@@ -1,4 +1,4 @@
-import { getAuthHeaders, getJsonHeaders } from '$lib/utils/api-headers';
+import { getJsonHeaders } from '$lib/utils/api-headers';
 import { formatAttachmentText } from '$lib/utils/formatters';
 import { isAbortError } from '$lib/utils/abort';
 import {
@@ -129,6 +129,7 @@ export class ChatService {
 			onReasoningChunk,
 			onToolCallChunk,
 			onModel,
+			onCompletionId,
 			onTimings,
 			// Tools for function calling
 			tools,
@@ -321,6 +322,7 @@ export class ChatService {
 					onReasoningChunk,
 					onToolCallChunk,
 					onModel,
+					onCompletionId,
 					onTimings,
 					conversationId,
 					signal
@@ -397,26 +399,17 @@ export class ChatService {
 	}
 
 	/**
-	 * Forces the end of the current reasoning block on the active slot.
-	 * Discovers the processing slot via /slots, carrying the model so it
-	 * works in router mode, then posts the control action. Single model
-	 * resolves the slot locally and ignores the model field.
-	 * Returns true if a reasoning block was active and got ended.
+	 * Ends the current reasoning block of a running completion, targeted by its
+	 * chat completion id (streamed back as `id`). Matching the completion rather
+	 * than a slot index avoids a TOCTOU: a finished completion simply matches
+	 * nothing server side. The model is carried so the router forwards to the
+	 * right child, single model ignores it. Returns true on success.
 	 */
-	static async stopReasoning(model?: string | null): Promise<boolean> {
+	static async stopReasoning(cmplId: string, model?: string | null): Promise<boolean> {
+		if (!cmplId) return false;
 		try {
-			const slotsUrl = model
-				? `${API_SLOTS.LIST}?model=${encodeURIComponent(model)}`
-				: API_SLOTS.LIST;
-			const slotsRes = await fetch(slotsUrl, { headers: getAuthHeaders() });
-			if (!slotsRes.ok) return false;
-
-			const slots: { id: number; is_processing: boolean }[] = await slotsRes.json();
-			const active = slots.find((s) => s.is_processing);
-			if (!active) return false;
-
 			const body: Record<string, unknown> = {
-				id_slot: active.id,
+				id: cmplId,
 				action: CONTROL_ACTION.END_REASONING
 			};
 			if (model) body.model = model;
@@ -429,7 +422,7 @@ export class ChatService {
 			if (!res.ok) return false;
 
 			const data = await res.json();
-			return data?.reasoning_active === true;
+			return data?.success === true;
 		} catch (error) {
 			console.warn('stopReasoning failed:', error);
 			return false;
@@ -548,6 +541,7 @@ export class ChatService {
 		onReasoningChunk?: (chunk: string) => void,
 		onToolCallChunk?: (chunk: string) => void,
 		onModel?: (model: string) => void,
+		onCompletionId?: (id: string) => void,
 		onTimings?: (timings?: ChatMessageTimings, promptProgress?: ChatMessagePromptProgress) => void,
 		conversationId?: string,
 		abortSignal?: AbortSignal
@@ -565,6 +559,7 @@ export class ChatService {
 		let lastTimings: ChatMessageTimings | undefined;
 		let streamFinished = false;
 		let modelEmitted = false;
+		let idEmitted = false;
 		let toolCallIndexOffset = 0;
 		let hasOpenToolCallBatch = false;
 
@@ -647,6 +642,11 @@ export class ChatService {
 							if (chunkModel && !modelEmitted) {
 								modelEmitted = true;
 								onModel?.(chunkModel);
+							}
+
+							if (parsed.id && !idEmitted) {
+								idEmitted = true;
+								onCompletionId?.(parsed.id);
 							}
 
 							if (promptProgress) {

--- a/tools/ui/src/lib/stores/agentic.svelte.ts
+++ b/tools/ui/src/lib/stores/agentic.svelte.ts
@@ -488,6 +488,7 @@ class AgenticStore {
 			onToolCallsStreaming,
 			onAttachments,
 			onModel,
+			onCompletionId,
 			onAssistantTurnComplete,
 			createToolResultMessage,
 			createAssistantMessage,
@@ -597,6 +598,7 @@ class AgenticStore {
 							}
 						},
 						onModel,
+						onCompletionId,
 						onTimings: (timings?: ChatMessageTimings, progress?: ChatMessagePromptProgress) => {
 							onTimings?.(timings, progress);
 							if (timings) {

--- a/tools/ui/src/lib/stores/chat.svelte.ts
+++ b/tools/ui/src/lib/stores/chat.svelte.ts
@@ -63,7 +63,10 @@ class ChatStore {
 	currentResponse = $state('');
 	errorDialogState = $state<ErrorDialogState | null>(null);
 	isLoading = $state(false);
+	// true while the active conversation streams reasoning content but no visible content yet
+	isReasoning = $state(false);
 	chatLoadingStates = new SvelteMap<string, boolean>();
+	chatReasoningStates = new SvelteMap<string, boolean>();
 	chatStreamingStates = new SvelteMap<string, { response: string; messageId: string }>();
 	private abortControllers = new SvelteMap<string, AbortController>();
 	private preEncodeAbortController: AbortController | null = null;
@@ -94,6 +97,17 @@ class ChatStore {
 		} else {
 			this.chatLoadingStates.delete(convId);
 			if (convId === conversationsStore.activeConversation?.id) this.isLoading = false;
+			this.setChatReasoning(convId, false);
+		}
+	}
+
+	private setChatReasoning(convId: string, reasoning: boolean): void {
+		if (reasoning) {
+			this.chatReasoningStates.set(convId, true);
+			if (convId === conversationsStore.activeConversation?.id) this.isReasoning = true;
+		} else {
+			this.chatReasoningStates.delete(convId);
+			if (convId === conversationsStore.activeConversation?.id) this.isReasoning = false;
 		}
 	}
 	private setChatStreaming(convId: string, response: string, messageId: string): void {
@@ -110,6 +124,7 @@ class ChatStore {
 	}
 	syncLoadingStateForChat(convId: string): void {
 		this.isLoading = this.chatLoadingStates.get(convId) || false;
+		this.isReasoning = this.chatReasoningStates.get(convId) || false;
 		const s = this.chatStreamingStates.get(convId);
 		this.currentResponse = s?.response || '';
 		this.isStreamingActive = s !== undefined;
@@ -263,6 +278,10 @@ class ChatStore {
 
 	isChatLoadingPublic(convId: string): boolean {
 		return this.chatLoadingStates.get(convId) || false;
+	}
+
+	isChatReasoningPublic(convId: string): boolean {
+		return this.chatReasoningStates.get(convId) || false;
 	}
 
 	private isChatLoadingInternal(convId: string): boolean {
@@ -676,6 +695,7 @@ class ChatStore {
 			onChunk: (chunk: string) => {
 				streamedContent += chunk;
 				updateStreamingUI();
+				this.setChatReasoning(convId, false);
 			},
 			onReasoningChunk: (chunk: string) => {
 				streamedReasoningContent += chunk;
@@ -685,6 +705,7 @@ class ChatStore {
 				conversationsStore.updateMessageAtIndex(idx, {
 					reasoningContent: streamedReasoningContent
 				});
+				this.setChatReasoning(convId, true);
 			},
 			onToolCallsStreaming: (toolCalls) => {
 				const idx = conversationsStore.findMessageIndex(currentMessageId);
@@ -1373,6 +1394,7 @@ class ChatStore {
 						appendedContent += chunk;
 						hasReceivedContent = true;
 						updateStreamingContent(originalContent + appendedContent);
+						this.setChatReasoning(msg.convId, false);
 					},
 					onReasoningChunk: (chunk: string) => {
 						appendedReasoning += chunk;
@@ -1382,6 +1404,7 @@ class ChatStore {
 						conversationsStore.updateMessageAtIndex(idx, {
 							reasoningContent: originalReasoning + appendedReasoning
 						});
+						this.setChatReasoning(msg.convId, true);
 					},
 					onTimings: (timings?: ChatMessageTimings, promptProgress?: ChatMessagePromptProgress) => {
 						const tokensPerSecond =
@@ -1924,6 +1947,7 @@ export const isChatLoading = (convId: string) => chatStore.isChatLoadingPublic(c
 export const isChatStreaming = () => chatStore.isStreaming();
 export const isEditing = () => chatStore.isEditing();
 export const isLoading = () => chatStore.isLoading;
+export const isReasoning = () => chatStore.isReasoning;
 export const pendingEditMessageId = () => chatStore.pendingEditMessageId;
 export const chatHasPendingMessage = (convId: string) => chatStore.hasPendingMessage(convId);
 export const chatPendingMessageContent = (convId: string) =>

--- a/tools/ui/src/lib/stores/chat.svelte.ts
+++ b/tools/ui/src/lib/stores/chat.svelte.ts
@@ -674,6 +674,17 @@ class ChatStore {
 			}
 		};
 
+		let cmplIdRecorded = false;
+		const recordCompletionId = (id: string): void => {
+			if (!id || cmplIdRecorded) return;
+			cmplIdRecorded = true;
+			const idx = conversationsStore.findMessageIndex(currentMessageId);
+			conversationsStore.updateMessageAtIndex(idx, { cmplId: id });
+			DatabaseService.updateMessage(currentMessageId, { cmplId: id }).catch(() => {
+				cmplIdRecorded = false;
+			});
+		};
+
 		const updateStreamingUI = () => {
 			this.setChatStreaming(convId, streamedContent, currentMessageId);
 			const idx = conversationsStore.findMessageIndex(currentMessageId);
@@ -723,6 +734,7 @@ class ChatStore {
 				DatabaseService.updateMessage(messageId, { extra: updatedExtras }).catch(console.error);
 			},
 			onModel: (modelName: string) => recordModel(modelName),
+			onCompletionId: (id: string) => recordCompletionId(id),
 			onTurnComplete: (intermediateTimings: ChatMessageTimings) => {
 				// Update the first assistant message with cumulative agentic timings
 				const idx = conversationsStore.findMessageIndex(assistantMessage.id);
@@ -908,6 +920,7 @@ class ChatStore {
 				onChunk: streamCallbacks.onChunk,
 				onReasoningChunk: streamCallbacks.onReasoningChunk,
 				onModel: streamCallbacks.onModel,
+				onCompletionId: streamCallbacks.onCompletionId,
 				onTimings: streamCallbacks.onTimings,
 				onComplete: async (
 					finalContent?: string,

--- a/tools/ui/src/lib/stores/chat.svelte.ts
+++ b/tools/ui/src/lib/stores/chat.svelte.ts
@@ -674,14 +674,14 @@ class ChatStore {
 			}
 		};
 
-		let cmplIdRecorded = false;
+		let completionIdRecorded = false;
 		const recordCompletionId = (id: string): void => {
-			if (!id || cmplIdRecorded) return;
-			cmplIdRecorded = true;
+			if (!id || completionIdRecorded) return;
+			completionIdRecorded = true;
 			const idx = conversationsStore.findMessageIndex(currentMessageId);
-			conversationsStore.updateMessageAtIndex(idx, { cmplId: id });
-			DatabaseService.updateMessage(currentMessageId, { cmplId: id }).catch(() => {
-				cmplIdRecorded = false;
+			conversationsStore.updateMessageAtIndex(idx, { completionId: id });
+			DatabaseService.updateMessage(currentMessageId, { completionId: id }).catch(() => {
+				completionIdRecorded = false;
 			});
 		};
 

--- a/tools/ui/src/lib/types/agentic.d.ts
+++ b/tools/ui/src/lib/types/agentic.d.ts
@@ -93,6 +93,7 @@ export interface AgenticFlowCallbacks {
 	onAttachments?: (messageId: string, extras: DatabaseMessageExtra[]) => void;
 	/** Model name detected from response */
 	onModel?: (model: string) => void;
+	onCompletionId?: (id: string) => void;
 	/** Current assistant turn's streaming is complete - save to DB */
 	onAssistantTurnComplete?: (
 		content: string,

--- a/tools/ui/src/lib/types/api.d.ts
+++ b/tools/ui/src/lib/types/api.d.ts
@@ -271,6 +271,7 @@ export interface ApiChatCompletionToolCall extends ApiChatCompletionToolCallDelt
 }
 
 export interface ApiChatCompletionStreamChunk {
+	id?: string;
 	object?: string;
 	model?: string;
 	choices: Array<{

--- a/tools/ui/src/lib/types/chat.d.ts
+++ b/tools/ui/src/lib/types/chat.d.ts
@@ -97,6 +97,7 @@ export interface ChatStreamCallbacks {
 	onToolCallsStreaming?: (toolCalls: ApiChatCompletionToolCall[]) => void;
 	onAttachments?: (messageId: string, extras: DatabaseMessageExtra[]) => void;
 	onModel?: (model: string) => void;
+	onCompletionId?: (id: string) => void;
 	onTimings?: (timings?: ChatMessageTimings, promptProgress?: ChatMessagePromptProgress) => void;
 	onAssistantTurnComplete?: (
 		content: string,

--- a/tools/ui/src/lib/types/database.d.ts
+++ b/tools/ui/src/lib/types/database.d.ts
@@ -113,7 +113,7 @@ export interface DatabaseMessage {
 	/** Serialized JSON array of tool calls made by assistant messages */
 	toolCalls?: string;
 	/** Chat completion id streamed by the server, used to target realtime control (e.g. end reasoning) */
-	cmplId?: string;
+	completionId?: string;
 	/** Tool call ID for tool result messages (role: 'tool') */
 	toolCallId?: string;
 	children: string[];

--- a/tools/ui/src/lib/types/database.d.ts
+++ b/tools/ui/src/lib/types/database.d.ts
@@ -112,6 +112,8 @@ export interface DatabaseMessage {
 	reasoningContent?: string;
 	/** Serialized JSON array of tool calls made by assistant messages */
 	toolCalls?: string;
+	/** Chat completion id streamed by the server, used to target realtime control (e.g. end reasoning) */
+	cmplId?: string;
 	/** Tool call ID for tool result messages (role: 'tool') */
 	toolCallId?: string;
 	children: string[];

--- a/tools/ui/src/lib/types/settings.d.ts
+++ b/tools/ui/src/lib/types/settings.d.ts
@@ -101,6 +101,7 @@ export interface SettingsChatServiceOptions {
 	onToolCallChunk?: (chunk: string) => void;
 	onAttachments?: (extras: DatabaseMessageExtra[]) => void;
 	onModel?: (model: string) => void;
+	onCompletionId?: (id: string) => void;
 	onTimings?: (timings?: ChatMessageTimings, promptProgress?: ChatMessagePromptProgress) => void;
 	onComplete?: (
 		response: string,


### PR DESCRIPTION
## Overview

Builds on the manual reasoning budget trigger from #23949. Adds a CONTROL task that mirrors the CANCEL path on the live slot and calls common_sampler_reasoning_budget_force to end thinking mid-generation. POST /v1/chat/completions/control with { id_slot, action }, opt-in reasoning_control arms the budget sampler on demand. Router and single model.

Minimal WebUI button as a skeleton for further UI work. cc @allozaur 

## Additional information

### Video

https://github.com/user-attachments/assets/7af5b746-16e4-4529-9f8f-c9bbc3f38add

Closes #23944

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES Opus 4.8 High + MCP container w/GPU

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
