### PR TITLE
vulkan: add fast path for contiguous buffer transfers

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7387,8 +7387,12 @@ static void ggml_vk_buffer_write_2d(vk_buffer& dst, size_t offset, const void * 
     if(dst->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible) {
         GGML_ASSERT(dst->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
 
-        for (size_t i = 0; i < height; i++) {
-            memcpy((uint8_t *)dst->ptr + offset + i * dpitch, (const uint8_t *) src + i * spitch, width);
+        if (width == spitch && width == dpitch) {
+            memcpy((uint8_t *)dst->ptr + offset, src, width * height);
+        } else {
+            for (size_t i = 0; i < height; i++) {
+                memcpy((uint8_t *)dst->ptr + offset + i * dpitch, (const uint8_t *) src + i * spitch, width);
+            }
         }
     } else {
         std::lock_guard<std::recursive_mutex> guard(dst->device->mutex);
@@ -7507,8 +7511,12 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
     if(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostVisible && src->device->uma) {
         GGML_ASSERT(src->memory_property_flags & vk::MemoryPropertyFlagBits::eHostCoherent);
 
-        for (size_t i = 0; i < height; i++) {
-            memcpy((uint8_t *) dst + i * dpitch, (const uint8_t *) src->ptr + offset + i * spitch, width);
+        if (width == spitch && width == dpitch) {
+            memcpy(dst, (const uint8_t *) src->ptr + offset, width * height);
+        } else {
+            for (size_t i = 0; i < height; i++) {
+                memcpy((uint8_t *) dst + i * dpitch, (const uint8_t *) src->ptr + offset + i * spitch, width);
+            }
         }
     } else {
         std::lock_guard<std::recursive_mutex> guard(src->device->mutex);


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
When a 2D buffer read or write is actually contiguous in memory, the code now uses one bulk memcpy instead of copying row-by-row.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

The standalone benchmark shows that the contiguous write is around 2.5 times faster than non-contiguous write.

```bash
❯ ./benchmark_uma 
Benchmarking Isolated 2D UMA Transfer Optimization Path
Dimensions: 8192x4096 float32 (Matrix Size: 128 MB)
Symmetry Broken: Host is packed, Device is padded for Non-Contiguous run.
--------------------------------------------------------------------------------
Contiguous (Optimized Fast-Path)    Write: 0.002925 s/op,  Read: 0.000000 s/op
Non-Contiguous (Row-by-Row)         Write: 0.007888 s/op,  Read: 0.007925 s/op
--------------------------------------------------------------------------------
```

This is the output can include the fast path count:

```bash
❯ llama-bench -m ~/model/Hy-MT2-1.8B-UD-Q4_K_XL.gguf -p 512 -ngl 99 -fa 1
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = AMD Radeon 880M Graphics (RADV STRIX1) (radv) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 64 | shared memory: 65536 | int dot: 1 | matrix cores: KHR_coopmat
| model                          |       size |     params | backend    | ngl | fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -: | --------------: | -------------------: |
| hunyuan-dense 1.8B Q4_K - Medium |   1.08 GiB |     1.79 B | Vulkan     |  99 |  1 |           pp512 |       1483.90 ± 3.47 |
| hunyuan-dense 1.8B Q4_K - Medium |   1.08 GiB |     1.79 B | Vulkan     |  99 |  1 |           tg128 |         62.47 ± 0.14 |
Fast path write activated 3589 times

build: 19e92c33e (9049)
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, for finding this<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
