### PR TITLE
build : use umbrella Headers directory for XCFramework module map

### DIFF
--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -130,14 +130,7 @@ setup_framework_structure() {
     # Create module map (common for all platforms)
     cat > ${module_path}module.modulemap << EOF
 framework module llama {
-    header "llama.h"
-    header "ggml.h"
-    header "ggml-alloc.h"
-    header "ggml-backend.h"
-    header "ggml-metal.h"
-    header "ggml-cpu.h"
-    header "ggml-blas.h"
-    header "gguf.h"
+    umbrella "Headers"
 
     link "c++"
     link framework "Accelerate"


### PR DESCRIPTION
## Overview

The XCFramework generated by `build-xcframework.sh` creates a module map that manually lists public headers.

That list can fall out of sync with the framework's `Headers` directory. The module map is currently missing `ggml-opt.h`, which is present in the framework headers. This can cause downstream Apple builds to fail with:

```text
Include of non-modular header inside framework module 'llama'
```

Use the framework's `Headers` directory itself as the module map umbrella instead of maintaining a manual header list. This makes all public headers under the generated framework's `Headers` directory part of the `llama` module.

## Additional information

The generated `llama.xcframework` contains a `llama.framework` bundle. Inside that framework, the public headers are copied into `llama.framework/Headers`, and `llama.framework/Modules/module.modulemap` tells Clang which of those headers belong to the importable `llama` module.

This issue shows up when a downstream Apple build imports the generated framework as a module. In that case, Clang expects headers included by `llama.h` to also be declared by the framework's module map. Since `ggml-opt.h` is present in `llama.framework/Headers` but missing from `module.modulemap`, the import can fail as a non-modular include.

Projects that build llama.cpp directly from source, or consume the headers without importing the generated framework module, may not hit this error.

Verification:

- Built the XCFramework before this change and consumed it from a downstream iOS build.
- The build failed because `llama.h` includes `ggml-opt.h`, but `ggml-opt.h` was not listed in the generated module map.
- Rebuilt the XCFramework after this change.
- The same build succeeded.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes - I wrote and reviewed the code change. AI was used to analyze before/after build logs and review commit/PR wording.
