### PR TITLE
server/common: Fix `response_format: json_schema` & prefill parsing bug

### DIFF
--- a/common/json_schema_prefill_support.hpp
+++ b/common/json_schema_prefill_support.hpp
@@ -1,0 +1,83 @@
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <optional>
+
+/**
+ * 解析 GBNF 语法并根据 root 规则的结构修复 input 字符串。
+ *
+ * 逻辑：
+ * 1. 从 thought 规则中提取结束常量（如 "<channel|>"）。
+ * 2. 从 root 规则中分析 (thought | )? 与 response-format-schema 之间的常量或 space 规则。
+ * 3. 在 input 中定位结束符，并插入缺失的内容。
+ */
+void fix_thought_json_transition(const std::string& gbnf_grammar, std::string& input) {
+    std::string_view gbnf(gbnf_grammar);
+
+    // --- 1. 提取 thought 规则的结束标志位 ---
+    // 找到 thought ::= ... 并取最后一个引号内的字符串
+    size_t thought_def = gbnf.find("thought ::= ");
+    if (thought_def == std::string_view::npos) return;
+
+    size_t thought_eol = gbnf.find('\n', thought_def);
+    std::string_view thought_line = gbnf.substr(thought_def, thought_eol - thought_def);
+
+    size_t last_quote_end = thought_line.rfind('"');
+    if (last_quote_end == std::string_view::npos) return;
+    size_t last_quote_start = thought_line.rfind('"', last_quote_end - 1);
+    if (last_quote_start == std::string_view::npos) return;
+
+    std::string thought_end_tag{thought_line.substr(last_quote_start + 1, last_quote_end - last_quote_start - 1)};
+
+    // --- 2. 分析 root 规则中间件 ---
+    size_t root_def = gbnf.find("root ::= ");
+    if (root_def == std::string_view::npos) return;
+
+    size_t root_eol = gbnf.find('\n', root_def);
+    std::string_view root_line = gbnf.substr(root_def, root_eol - root_def);
+
+    // 寻找 (thought | )? 之后，response-format-schema 之前的内容
+    std::string_view anchor = "(thought | )?";
+    size_t anchor_pos = root_line.find(anchor);
+    if (anchor_pos == std::string_view::npos) return;
+
+    size_t schema_pos = root_line.find("response-format-schema");
+    if (schema_pos == std::string_view::npos) return;
+
+    std::string_view middle_part = root_line.substr(anchor_pos + anchor.length(), schema_pos - (anchor_pos + anchor.length()));
+
+    // 解析中间件中的常量字符串和 space 变量
+    std::string to_insert;
+    size_t cursor = 0;
+    while (cursor < middle_part.length()) {
+        if (middle_part[cursor] == '"') {
+            size_t next_q = middle_part.find('"', cursor + 1);
+            if (next_q != std::string_view::npos) {
+                to_insert += middle_part.substr(cursor + 1, next_q - cursor - 1);
+                cursor = next_q + 1;
+            } else break;
+        } else if (middle_part.compare(cursor, 5, "space") == 0) {
+            to_insert += "\n"; // 将 GBNF 的 space 规则默认解析为一个换行符，因为 ```json 更适合它
+            cursor += 5;
+        } else {
+            cursor++;
+        }
+    }
+
+    // --- 3. 修改 input 字符串 ---
+    size_t idx = input.find(thought_end_tag);
+    if (idx == std::string::npos) return;
+
+    size_t insert_pos = idx + thought_end_tag.length();
+
+    // 检查是否已经存在该内容，避免重复插入
+    if (insert_pos < input.length() && !to_insert.empty()) {
+        // 如果 input 对应位置还没这段内容，则插入
+        if (input.compare(insert_pos, to_insert.length(), to_insert) != 0) {
+            input.insert(insert_pos, to_insert);
+        }
+    } else if (insert_pos == input.length()) {
+        input.insert(insert_pos, to_insert);
+    }
+}

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -6,6 +6,7 @@
 #include "reasoning-budget.h"
 
 #include "ggml.h"
+#include "json_schema_prefill_support.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -198,6 +199,31 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
     std::vector<llama_sampler *> samplers;
 
     const std::string & grammar_str = common_grammar_value(params.grammar);
+
+
+
+    // Compute prefill tokens from the generation prompt
+    std::vector<llama_token> prefill_tokens;
+    auto generation_prompt = params.generation_prompt;
+    if (!generation_prompt.empty()) {
+        fix_thought_json_transition(grammar_str, generation_prompt);
+        params.generation_prompt = generation_prompt;
+
+        GGML_ASSERT(vocab != nullptr);
+        auto tokens = common_tokenize(vocab, generation_prompt, false, true);
+        for (size_t i = 0; i < tokens.size(); i++) {
+            std::string piece = common_token_to_piece(vocab, tokens[i], true);
+            if (i == 0 && std::isspace(piece[0]) && !std::isspace(generation_prompt[0])) {
+                // Some tokenizers will add a space before the first special token, need to exclude
+                continue;
+            }
+            LOG_DBG("%s: prefill token: %d = %s\n", __func__, tokens[i], piece.c_str());
+            prefill_tokens.push_back(tokens[i]);
+        }
+    }
+
+
+
     if (grammar_str.compare(0, 11, "%llguidance") == 0) {
 #ifdef LLAMA_USE_LLGUIDANCE
         grmr = llama_sampler_init_llg(vocab, "lark", grammar_str.c_str());
@@ -263,22 +289,6 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         throw std::runtime_error("failed to parse grammar");
     }
 
-    // Compute prefill tokens from the generation prompt
-    std::vector<llama_token> prefill_tokens;
-    if (!params.generation_prompt.empty()) {
-        GGML_ASSERT(vocab != nullptr);
-        auto tokens = common_tokenize(vocab, params.generation_prompt, false, true);
-        for (size_t i = 0; i < tokens.size(); i++) {
-            std::string piece = common_token_to_piece(vocab, tokens[i], true);
-            if (i == 0 && std::isspace(piece[0]) && !std::isspace(params.generation_prompt[0])) {
-                // Some tokenizers will add a space before the first special token, need to exclude
-                continue;
-            }
-            LOG_DBG("%s: prefill token: %d = %s\n", __func__, tokens[i], piece.c_str());
-            prefill_tokens.push_back(tokens[i]);
-        }
-    }
-
     // Feed generation prompt tokens to the grammar sampler so it advances past
     // tokens the template already placed in the prompt.
     // Only applies to output-format and tool-call grammars; user-supplied grammars must not be prefilled.
@@ -290,7 +300,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
             }
         } catch (std::exception &e) {
             LOG_ERR("%s: error initializing grammar sampler for grammar:\n%s\n\nGeneration prompt:\n'%s'\n", __func__,
-                common_grammar_value(params.grammar).c_str(), params.generation_prompt.c_str());
+                common_grammar_value(params.grammar).c_str(), generation_prompt.c_str());
             throw e;
         }
     }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1813,6 +1813,7 @@ private:
                 send_error(task, err_msg, ERROR_TYPE_INVALID_REQUEST);
                 return false;
             }
+            task.params.chat_parser_params->generation_prompt = task.params.sampling.generation_prompt;
 
             const bool need_pre_sample_logits = task.params.sampling.n_probs > 0 && !task.params.post_sampling_probs;
 

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -291,43 +291,43 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
     add((new field_json("chat_format"))
         ->set_desc("Chat format used internally by the server")
         ->set_handler([&](field_eval_context & ctx, const json & data) {
-            ctx.params.chat_parser_params.format = static_cast<common_chat_format>(data.at("chat_format").get<int>());
-            SRV_TRC("chat format: %s\n", common_chat_format_name(ctx.params.chat_parser_params.format));
+            ctx.params.chat_parser_params->format = static_cast<common_chat_format>(data.at("chat_format").get<int>());
+            SRV_TRC("chat format: %s\n", common_chat_format_name(ctx.params.chat_parser_params->format));
         }));
 
     add((new field_str("reasoning_format"))
         ->set_desc("Reasoning format for chain-of-thought models")
         ->set_handler([&](field_eval_context & ctx, const json & data) {
             auto reasoning_format = common_reasoning_format_from_name(data.at("reasoning_format").get<std::string>());
-            ctx.params.chat_parser_params.reasoning_format = reasoning_format;
-            ctx.params.chat_parser_params.reasoning_in_content = ctx.params.stream && (reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY);
+            ctx.params.chat_parser_params->reasoning_format = reasoning_format;
+            ctx.params.chat_parser_params->reasoning_in_content = ctx.params.stream && (reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY);
         }));
 
     add((new field_str("generation_prompt"))
         ->set_desc("Generation prompt appended to the chat template output")
         ->set_handler([&](field_eval_context & ctx, const json & data) {
             std::string s = data.at("generation_prompt").get<std::string>();
-            ctx.params.chat_parser_params.generation_prompt = s;
+            ctx.params.chat_parser_params->generation_prompt = s;
             ctx.params.sampling.generation_prompt = s;
         }));
 
-    add((new field_bool("parse_tool_calls", params.chat_parser_params.parse_tool_calls))
+    add((new field_bool("parse_tool_calls", params.chat_parser_params->parse_tool_calls))
         ->set_desc("Whether to parse tool calls from the generated output"));
 
     add((new field_str("chat_parser"))
         ->set_desc("Chat parser configuration string")
         ->set_handler([&](field_eval_context & ctx, const json & data) {
-            ctx.params.chat_parser_params.parser.load(data.at("chat_parser").get<std::string>());
+            ctx.params.chat_parser_params->parser.load(data.at("chat_parser").get<std::string>());
         }));
 
     add((new field_json("continue_final_message"))
         ->set_desc("Whether to continue the final message of the chat template")
         ->set_handler([&](field_eval_context & ctx, const json & data) {
             auto continuation = common_chat_continuation_parse(data.at("continue_final_message"));
-            ctx.params.chat_parser_params.is_continuation = continuation != COMMON_CHAT_CONTINUATION_NONE;
+            ctx.params.chat_parser_params->is_continuation = continuation != COMMON_CHAT_CONTINUATION_NONE;
         }));
 
-    add((new field_bool("echo", params.chat_parser_params.echo))
+    add((new field_bool("echo", params.chat_parser_params->echo))
         ->set_desc("Whether to echo the input tokens in the output"));
 
     //
@@ -533,7 +533,7 @@ task_params eval_llama_cmpl_schema(
     // enabling this will output extra debug information in the HTTP responses from the server
     params.verbose       = params_base.verbosity > 9;
 
-    params.chat_parser_params.reasoning_format = params_base.reasoning_format;
+    params.chat_parser_params->reasoning_format = params_base.reasoning_format;
 
     // create context and schema
     field_eval_context ctx(params);
@@ -559,8 +559,8 @@ task_params eval_llama_cmpl_schema(
         }
 
         // if "reasoning_format" is not provided, its handler will not be called, we will need to handle it here
-        auto reasoning_format = params.chat_parser_params.reasoning_format;
-        params.chat_parser_params.reasoning_in_content = params.stream && (reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY);
+        auto reasoning_format = params.chat_parser_params->reasoning_format;
+        params.chat_parser_params->reasoning_in_content = params.stream && (reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY);
     }
 
     // debugging

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -73,10 +73,10 @@ json task_params::to_json(bool only_metrics) const {
             {"stream",                    stream},
             {"n_probs",                   sampling.n_probs},
             {"min_keep",                  sampling.min_keep},
-            {"chat_format",               common_chat_format_name(chat_parser_params.format)},
-            {"reasoning_format",          common_reasoning_format_name(chat_parser_params.reasoning_format)},
-            {"reasoning_in_content",      chat_parser_params.reasoning_in_content},
-            {"generation_prompt",         chat_parser_params.generation_prompt},
+            {"chat_format",               common_chat_format_name(chat_parser_params->format)},
+            {"reasoning_format",          common_reasoning_format_name(chat_parser_params->reasoning_format)},
+            {"reasoning_in_content",      chat_parser_params->reasoning_in_content},
+            {"generation_prompt",         chat_parser_params->generation_prompt},
             {"samplers",                  samplers},
             {"speculative.types",         common_speculative_type_name_str(speculative.types)},
             {"timings_per_token",         timings_per_token},
@@ -132,10 +132,10 @@ json task_params::to_json(bool only_metrics) const {
         {"grammar_lazy",              sampling.grammar_lazy},
         {"grammar_triggers",          grammar_triggers},
         {"preserved_tokens",          sampling.preserved_tokens},
-        {"chat_format",               common_chat_format_name(chat_parser_params.format)},
-        {"reasoning_format",          common_reasoning_format_name(chat_parser_params.reasoning_format)},
-        {"reasoning_in_content",      chat_parser_params.reasoning_in_content},
-        {"generation_prompt",         chat_parser_params.generation_prompt},
+        {"chat_format",               common_chat_format_name(chat_parser_params->format)},
+        {"reasoning_format",          common_reasoning_format_name(chat_parser_params->reasoning_format)},
+        {"reasoning_in_content",      chat_parser_params->reasoning_in_content},
+        {"generation_prompt",         chat_parser_params->generation_prompt},
         {"samplers",                  samplers},
         {"speculative.types",         common_speculative_type_name_str(speculative.types)},
         {"timings_per_token",         timings_per_token},
@@ -148,14 +148,14 @@ json task_params::to_json(bool only_metrics) const {
 //
 // task_result_state
 //
-task_result_state::task_result_state(const common_chat_parser_params & chat_parser_params)
-    : chat_parser_params(chat_parser_params)
+task_result_state::task_result_state(std::shared_ptr<common_chat_parser_params> chat_parser_params)
+    : chat_parser_params(std::move(chat_parser_params))
     , oai_resp_id("resp_" + random_string())
     , oai_resp_reasoning_id("rs_" + random_string())
     , oai_resp_message_id("msg_" + random_string()) {
-    if (chat_parser_params.is_continuation && !chat_parser_params.echo) {
+    if (this->chat_parser_params->is_continuation && !this->chat_parser_params->echo) {
         // initialize chat_msg to avoid emitting a delta containing the assistant prefill
-        chat_msg = common_chat_parse("", true, chat_parser_params);
+        chat_msg = common_chat_parse("", true, *this->chat_parser_params);
     }
 }
 
@@ -170,7 +170,7 @@ common_chat_msg task_result_state::update_chat_msg(
     auto new_msg = common_chat_parse(
         generated_text,
         is_partial,
-        chat_parser_params);
+        *chat_parser_params);
     if (!new_msg.empty()) {
         new_msg.set_tool_call_ids(generated_tool_call_ids, gen_tool_call_id);
         chat_msg = new_msg;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -89,7 +89,9 @@ struct task_params {
     std::string        control_cmpl_id;
 
     // per-request parameters for chat parsing
-    common_chat_parser_params chat_parser_params;
+    std::shared_ptr<common_chat_parser_params> chat_parser_params;
+
+    task_params() : chat_parser_params(std::make_shared<common_chat_parser_params>()) {}
 
     // message spans for checkpointing
     common_chat_msg_spans message_spans;
@@ -105,7 +107,7 @@ struct task_params {
 struct task_result_state {
     // tracking diffs for partial tool calls
     std::vector<common_chat_msg_diff> diffs;
-    common_chat_parser_params chat_parser_params;
+    std::shared_ptr<common_chat_parser_params> chat_parser_params;
     common_chat_msg chat_msg;
     std::string generated_text; // append new chunks of generated text here
     std::vector<std::string> generated_tool_call_ids;
@@ -123,7 +125,7 @@ struct task_result_state {
     const std::string oai_resp_message_id;
     std::string oai_resp_fc_id; // function call ID for current args delta
 
-    task_result_state(const common_chat_parser_params & chat_parser_params);
+    task_result_state(std::shared_ptr<common_chat_parser_params> p);
 
     // parse partial tool calls and update the internal state
     common_chat_msg update_chat_msg(


### PR DESCRIPTION

## Overview

The problem happens when you prefill json schema on Gemma4 (maybe other model),

bnf = `
...
root ::= start (thought | )? "```json" space response-format-schema space "```"
...
`
generation_prompt = `<|turn>model
<|channel>thought
<channel|>{"name":`

It could not parse because 3-backtick + json is missing

Fixes #23990

Automatically insert const string in BNF grammar `thought` to `response-format-schema`
Also changed struct `server_task` and `task_result_state` to share `chat_parser_params`

generation_prompt_fixed = `<|turn>model
<|channel>thought
<channel|>```json
{"name":`

## Additional information

This is a draft because
- share `chat_parser_params` might cause concurrent bugs, and 
- `common/json_schema_prefill_support.hpp` mostly written by AI, this BNF string parser is very naive.

But **IT RUNS** now, if you (viewer, not contributor or owner) need this, cherry-pick it!


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES


<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
