### PR TITLE
server : reuse disk-restored KV for recurrent/hybrid models (regenerate + bounded slot-save store) (1/2)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3093,6 +3093,26 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--slot-save-max-count"}, "N",
+        string_format("max number of slot-save snapshots kept in --slot-save-path (treated as a dedicated dir); oldest are evicted (default: %d, 0 = unlimited)", params.slot_save_max_count),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("--slot-save-max-count must be >= 0 (0 = unlimited)");
+            }
+            params.slot_save_max_count = value;
+        }
+    ).set_env("LLAMA_ARG_SLOT_SAVE_MAX_COUNT").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--slot-save-max-mb"}, "N",
+        string_format("max total size (MiB) of the --slot-save-path store; oldest snapshots are evicted (default: %d, 0 = unlimited)", (int) (params.slot_save_max_bytes / (1024 * 1024))),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("--slot-save-max-mb must be >= 0 (0 = unlimited)");
+            }
+            params.slot_save_max_bytes = (int64_t) value * 1024 * 1024;
+        }
+    ).set_env("LLAMA_ARG_SLOT_SAVE_MAX_MB").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--media-path"}, "PATH",
         "directory for loading local media files; files can be accessed via file:// URLs using relative paths (default: disabled)",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -645,6 +645,10 @@ struct common_params {
     bool log_json = false;
 
     std::string slot_save_path;
+    // bounded slot-save store (LRU eviction by mtime; a state file + its .logits sidecar are
+    // evicted together as one unit). Defaults are finite & sane; 0 means "unlimited" (only if set).
+    int32_t slot_save_max_count = 64;                                // max snapshots in slot_save_path (0 = unlimited)
+    int64_t slot_save_max_bytes = (int64_t) 32 * 1024 * 1024 * 1024; // 32 GiB cap (0 = unlimited)
     std::string media_path; // path to directory for loading media files
 
     float slot_prompt_similarity = 0.1f;

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -618,6 +618,90 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
     return id;
 }
 
+// Rebuild the candidate set from a raw full-vocab logits buffer, mirroring
+// common_sampler::set_logits()'s full-logits branch (the else-branch above). Used by
+// common_sampler_sample_from_logits() to sample from persisted logits instead of a llama_context.
+// Callers must pre-validate logits != nullptr && n_vocab > 0 (the only caller does so via asserts).
+static void common_sampler_set_logits_raw(struct common_sampler * gsmpl, const float * logits, int n_vocab) {
+    auto & cur = gsmpl->cur;
+
+    cur.resize(n_vocab);
+    for (llama_token token_id = 0; token_id < n_vocab; token_id++) {
+        cur[token_id] = llama_token_data{token_id, logits[token_id], 0.0f};
+    }
+
+    gsmpl->cur_p = { cur.data(), cur.size(), -1, false };
+}
+
+llama_token common_sampler_sample_from_logits(struct common_sampler * gsmpl, const float * logits, int n_vocab, bool grammar_first) {
+    // This mirrors common_sampler_sample()'s CPU full-logits apply sequence exactly (reasoning
+    // budget -> [grammar] -> chain, plus grammar rejection-resampling), with set_logits(ctx,idx)
+    // replaced by common_sampler_set_logits_raw(). It intentionally omits two things that are
+    // inapplicable to replayed logits: llama_synchronize() (the logits are caller-provided, not
+    // pending in any llama_context) and the backend-sampler short-circuit (a replayed distribution
+    // never carries a backend-sampled token, and backend sampling is incompatible with
+    // grammar/reasoning-budget anyway — see common_sampler_sample).
+    GGML_ASSERT(logits != nullptr);
+    GGML_ASSERT(n_vocab > 0);
+
+    const auto tm = gsmpl->tm();
+
+    llama_token id = LLAMA_TOKEN_NULL;
+
+    auto & grmr    = gsmpl->grmr;
+    auto & rbudget = gsmpl->rbudget;
+    auto & chain   = gsmpl->chain;
+    auto & cur_p   = gsmpl->cur_p; // initialized by common_sampler_set_logits_raw
+
+    common_sampler_set_logits_raw(gsmpl, logits, n_vocab);
+
+    // apply reasoning budget first
+    llama_sampler_apply(rbudget, &cur_p);
+
+    if (grammar_first && grammar_should_apply(gsmpl)) {
+        llama_sampler_apply(grmr, &cur_p);
+    }
+
+    llama_sampler_apply(chain, &cur_p);
+
+    id = cur_p.data[cur_p.selected].id;
+
+    if (grammar_first || !grammar_should_apply(gsmpl)) {
+        return id;
+    }
+
+    // check if the sampled token fits the grammar (grammar-based rejection sampling)
+    {
+        llama_token_data       single_token_data       = { id, 1.0f, 0.0f };
+        llama_token_data_array single_token_data_array = { &single_token_data, 1, -1, false };
+
+        llama_sampler_apply(grmr, &single_token_data_array);
+
+        const bool is_valid = single_token_data_array.data[0].logit != -INFINITY;
+        if (is_valid) {
+            return id;
+        }
+    }
+
+    // resampling:
+    // if the token is not valid, sample again, but first apply the grammar sampler and then the sampling chain
+    common_sampler_set_logits_raw(gsmpl, logits, n_vocab);
+
+    llama_sampler_apply(rbudget,  &cur_p);
+
+    if (grammar_should_apply(gsmpl)) {
+        llama_sampler_apply(grmr,  &cur_p);
+    }
+
+    llama_sampler_apply(chain, &cur_p);
+
+    GGML_ASSERT(cur_p.selected != -1 && "no selected token during sampling - check your sampling configuration");
+
+    id = cur_p.data[cur_p.selected].id;
+
+    return id;
+}
+
 std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sampler * gsmpl, struct llama_context * ctx, const std::vector<int> & idxs, const llama_tokens & draft, bool grammar_first) {
     GGML_ASSERT(idxs.size() == draft.size() + 1 && "idxs.size() must be draft.size() + 1");
 

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -64,6 +64,21 @@ struct llama_sampler * common_sampler_get(const struct common_sampler * gsmpl);
 //
 llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first = false);
 
+// Sample a token directly from a caller-provided full-vocab logits buffer instead of reading them
+// from a llama_context. Mirrors common_sampler_sample()'s full-logits path exactly (reasoning
+// budget -> [grammar] -> chain, plus grammar rejection-resampling), so the selected token is
+// identical to what would have been produced had `logits` come from llama_get_logits_ith(ctx, idx).
+// `logits` must point to at least `n_vocab` floats in vocab-id order; the caller is responsible for
+// verifying n_vocab matches the live model. Does NOT call common_sampler_accept() (the caller
+// accepts separately, as with common_sampler_sample). Leaves cur_p populated for
+// common_sampler_get_candidates().
+// NOTE: the selected token also depends on the sampler's accumulated state (penalty/grammar/
+// reasoning-budget history and RNG position), exactly like common_sampler_sample(). The caller must
+// have advanced `gsmpl` to the intended decode step (e.g. by replaying the same accepted-token
+// history, as common_sampler_reset()+init does over a restored prompt) for the result to match a
+// live sample at that step; the helper is NOT stateless given only `logits`.
+llama_token common_sampler_sample_from_logits(struct common_sampler * gsmpl, const float * logits, int n_vocab, bool grammar_first = false);
+
 // generalized version of common_sampler_sample
 //
 // will cross-reference the sampled tokens with a batch of draft tokens and accept those that match

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -20,8 +20,10 @@
 #include <cstddef>
 #include <cinttypes>
 #include <exception>
+#include <fstream>
 #include <memory>
 #include <filesystem>
+#include <set>
 #include <utility>
 
 // fix problem with std::min and std::max
@@ -51,6 +53,280 @@ enum server_state {
     SERVER_STATE_LOADING_MODEL,  // Server is starting up, model not fully loaded yet
     SERVER_STATE_READY,          // Server is ready and model is loaded
 };
+
+// --- KV restore-reuse: logits sidecar (Feature A) -------------------------------
+// When a slot's full state is saved to disk (SLOT_SAVE) for a recurrent/hybrid (FULL) model,
+// we additionally persist the last decoded token's full-vocab logits in a small sidecar file
+// (<state>.logits). On SLOT_RESTORE of an exact-prompt "regenerate" request, those logits let
+// the server emit the first token WITHOUT re-decoding into the (un-rewindable) restored
+// recurrent state — which would otherwise crash. The sidecar is independent of libllama's
+// state-file format (so that format is left untouched) and is purely best-effort: any
+// missing/corrupt/vocab-mismatched sidecar degrades gracefully to the existing behavior.
+static constexpr uint32_t SLOT_LOGITS_MAGIC   = 0x474C4B4Cu; // "LKLG" (llama kv logits), LE
+static constexpr uint32_t SLOT_LOGITS_VERSION = 1u;
+
+static std::string slot_logits_sidecar_path(const std::string & state_filepath) {
+    return state_filepath + ".logits";
+}
+
+// Best-effort write of the logits sidecar. Returns the number of bytes written (0 on failure or
+// when there is nothing valid to write). Never throws. The file is written to a temp path and
+// atomically renamed so a partial/interrupted write can never leave a corrupt sidecar in place.
+// Fields are serialized byte-by-byte little-endian (not a raw struct fwrite) for portability;
+// the float payload is documented LE-only, matching llama.cpp's native-LE state-file contract.
+static size_t slot_logits_write(const std::string & state_filepath,
+                                const std::vector<float> & logits,
+                                int32_t n_vocab,
+                                uint32_t n_tokens) {
+    if (logits.empty() || (int32_t) logits.size() != n_vocab || n_vocab <= 0) {
+        return 0;
+    }
+    const std::string sidecar = slot_logits_sidecar_path(state_filepath);
+    const std::string tmp     = sidecar + ".tmp";
+
+    std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+    if (!f) {
+        return 0;
+    }
+    auto put_u32 = [&](uint32_t v) {
+        const unsigned char b[4] = {
+            (unsigned char)( v        & 0xFF),
+            (unsigned char)((v >> 8)  & 0xFF),
+            (unsigned char)((v >> 16) & 0xFF),
+            (unsigned char)((v >> 24) & 0xFF),
+        };
+        f.write((const char *) b, 4);
+    };
+    put_u32(SLOT_LOGITS_MAGIC);
+    put_u32(SLOT_LOGITS_VERSION);
+    put_u32((uint32_t) n_vocab);
+    put_u32(n_tokens);
+    f.write((const char *) logits.data(), (std::streamsize) logits.size() * sizeof(float));
+    f.flush();
+    if (!f.good()) {
+        f.close();
+        std::error_code ec;
+        std::filesystem::remove(tmp, ec);
+        return 0;
+    }
+    f.close();
+    std::error_code ec;
+    std::filesystem::rename(tmp, sidecar, ec); // atomic replace
+    if (ec) {
+        std::filesystem::remove(tmp, ec);
+        return 0;
+    }
+    return 16 + logits.size() * sizeof(float);
+}
+
+// Read a logits sidecar. Returns true and fills `out` (size n_vocab) iff a valid sidecar exists
+// whose vocab matches `expect_n_vocab` AND whose recorded token count matches `expect_n_tokens`
+// (the count of the state just restored). The token-count check is AUTHORITATIVE: it binds the
+// sidecar to the exact state it was saved against, so a sidecar that was somehow written for a
+// different state length can never be reused. Any mismatch / short read / missing file => false
+// with `out` cleared, so the caller falls back to existing behavior. Never throws.
+static bool slot_logits_read(const std::string & state_filepath,
+                             int32_t expect_n_vocab,
+                             uint32_t expect_n_tokens,
+                             std::vector<float> & out) {
+    out.clear();
+    if (expect_n_vocab <= 0) {
+        return false;
+    }
+    const std::string sidecar = slot_logits_sidecar_path(state_filepath);
+    std::ifstream f(sidecar, std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    auto get_u32 = [&](uint32_t & v) -> bool {
+        unsigned char b[4];
+        f.read((char *) b, 4);
+        if (f.gcount() != 4) {
+            return false;
+        }
+        v = (uint32_t) b[0] | ((uint32_t) b[1] << 8) | ((uint32_t) b[2] << 16) | ((uint32_t) b[3] << 24);
+        return true;
+    };
+    uint32_t magic = 0, version = 0, n_vocab = 0, n_tokens = 0;
+    if (!get_u32(magic) || !get_u32(version) || !get_u32(n_vocab) || !get_u32(n_tokens)) {
+        return false;
+    }
+    if (magic != SLOT_LOGITS_MAGIC || version != SLOT_LOGITS_VERSION ||
+        (int32_t) n_vocab != expect_n_vocab || n_tokens != expect_n_tokens) {
+        return false;
+    }
+    out.resize(n_vocab);
+    const std::streamsize want = (std::streamsize) n_vocab * (std::streamsize) sizeof(float);
+    f.read((char *) out.data(), want);
+    if (f.gcount() != want) {
+        out.clear();
+        return false;
+    }
+    return true;
+}
+
+// --- KV restore-reuse: bounded slot-save store (Feature C) ----------------------
+// One slot-save snapshot = a state file plus its optional <name>.logits sidecar; the two are
+// always evicted together as a single unit, keyed by the state file's mtime (LRU).
+struct slot_save_unit {
+    std::string state_path;
+    std::string sidecar_path; // "" if none
+    uintmax_t   bytes = 0;
+    std::filesystem::file_time_type mtime;
+};
+
+// Enforce --slot-save-max-count / --slot-save-max-bytes over `dir` using LRU-by-mtime eviction.
+// `just_written` is the state path that was just saved: it is never evicted, but if it ALONE
+// exceeds the byte cap it is deleted (with its sidecar) and `oversized` is set so the caller can
+// reject the save rather than evict everything else. Operates strictly within `dir`; uses only
+// the error_code std::filesystem overloads so it never throws across the server loop.
+//
+// IMPORTANT: when a cap is set, --slot-save-path is treated as a server-owned store — any regular
+// file in it (other than recognized "<X>.logits" sidecars and "*.tmp" temporaries) is an eviction
+// candidate. Point --slot-save-max-count/-mb at a DEDICATED directory; do not mix unrelated files
+// into the slot-save directory. (With no caps set — the default unless explicitly enabled — nothing
+// is ever deleted and the directory is left exactly as before.)
+// `just_written` is the exact filepath string the server built as `slot_save_path + filename`;
+// directory_iterator(dir) over that same `slot_save_path` yields identically-spelled path strings
+// on POSIX (the production target), so raw string equality correctly identifies the just-saved
+// unit. (Not used on Windows in practice; if ever needed there, switch to filename comparison.)
+static void slot_save_enforce_limits(const std::string & dir,
+                                     int32_t max_count, int64_t max_bytes,
+                                     const std::string & just_written,
+                                     bool & oversized) {
+    oversized = false;
+    if (max_count <= 0 && max_bytes <= 0) {
+        return; // both unlimited
+    }
+
+    std::error_code ec;
+    std::vector<slot_save_unit> units;
+    uintmax_t this_unit_bytes = 0;
+
+    // First pass: enumerate every regular file once and record the full set of paths so we can
+    // tell a real sidecar (sibling of a state file we wrote) from a state file a client happened
+    // to name "foo.logits". We must NOT blindly skip every "*.logits" — fs_validate_filename
+    // allows that suffix, so a state file literally named "foo.logits" would otherwise escape both
+    // caps entirely. Only "<X>.logits" where "<X>" also exists is treated as a sidecar.
+    std::vector<std::string> all_files;
+    {
+        std::set<std::string> present;
+        for (std::filesystem::directory_iterator it(dir, ec), end; !ec && it != end; it.increment(ec)) {
+            std::error_code fec;
+            if (!it->is_regular_file(fec) || fec) {
+                continue;
+            }
+            all_files.push_back(it->path().string());
+            present.insert(all_files.back());
+        }
+
+        for (const std::string & p : all_files) {
+            std::error_code fec;
+            // in-flight temp files are never counted or evicted (a concurrent save owns them)
+            if (p.size() >= 4 && p.compare(p.size() - 4, 4, ".tmp") == 0) {
+                continue;
+            }
+            // a "<X>.logits" file is a sidecar ONLY when its state file "<X>" is also present;
+            // accounted together with that state file below, so skip it here.
+            if (p.size() >= 7 && p.compare(p.size() - 7, 7, ".logits") == 0 &&
+                present.count(p.substr(0, p.size() - 7))) {
+                continue;
+            }
+            // reap an ORPHANED sidecar (its state file was evicted/lost): otherwise these silently
+            // accumulate (we never count them) and eat real on-disk space forever.
+            if (p.size() >= 7 && p.compare(p.size() - 7, 7, ".logits") == 0 &&
+                !present.count(p.substr(0, p.size() - 7))) {
+                std::filesystem::remove(p, fec);
+                continue;
+            }
+
+            slot_save_unit u;
+            u.state_path = p;
+            u.bytes = std::filesystem::file_size(p, fec);
+            if (fec) {
+                continue;
+            }
+            const std::string side = p + ".logits";
+            if (present.count(side)) {
+                const auto sb = std::filesystem::file_size(side, fec);
+                if (!fec) {
+                    u.sidecar_path = side;
+                    u.bytes += sb;
+                }
+            }
+            u.mtime = std::filesystem::last_write_time(p, fec);
+            if (fec) {
+                continue;
+            }
+
+            if (p == just_written) {
+                this_unit_bytes = u.bytes;
+            }
+            units.push_back(std::move(u));
+        }
+    }
+
+    // a single snapshot larger than the byte cap is rejected: delete only the just-written unit,
+    // do NOT cascade-evict every other (valid) snapshot to make room for something that can't fit.
+    // NOTE: intentionally a no-op when max_bytes == 0 (byte cap disabled); in count-only mode an
+    // individual snapshot's size is never bounded — only --slot-save-max-mb bounds per-snapshot size.
+    if (max_bytes > 0 && this_unit_bytes > (uintmax_t) max_bytes) {
+        for (const auto & u : units) {
+            if (u.state_path == just_written) {
+                std::filesystem::remove(u.state_path, ec);
+                if (!u.sidecar_path.empty()) {
+                    std::filesystem::remove(u.sidecar_path, ec);
+                }
+                break;
+            }
+        }
+        oversized = true;
+        return;
+    }
+
+    std::sort(units.begin(), units.end(),
+              [](const slot_save_unit & a, const slot_save_unit & b) { return a.mtime < b.mtime; }); // oldest first
+
+    size_t    count = units.size();
+    uintmax_t total = 0;
+    for (const auto & u : units) {
+        total += u.bytes;
+    }
+    size_t idx = 0;
+
+    auto evict_oldest = [&]() -> bool {
+        while (idx < units.size() && units[idx].state_path == just_written) {
+            idx++; // never evict the snapshot we just wrote
+        }
+        if (idx >= units.size()) {
+            return false;
+        }
+        const auto & u = units[idx];
+        std::filesystem::remove(u.state_path, ec);
+        if (!u.sidecar_path.empty()) {
+            std::filesystem::remove(u.sidecar_path, ec);
+        }
+        total -= std::min(total, (uintmax_t) u.bytes);
+        count = (count > 0) ? count - 1 : 0;
+        idx++;
+        return true;
+    };
+
+    if (max_count > 0) {
+        while (count > (size_t) max_count) {
+            if (!evict_oldest()) {
+                break;
+            }
+        }
+    }
+    if (max_bytes > 0) {
+        while (total > (uintmax_t) max_bytes) {
+            if (!evict_oldest()) {
+                break;
+            }
+        }
+    }
+}
 
 struct server_slot {
     int id;
@@ -99,6 +375,21 @@ struct server_slot {
     bool has_new_line   = false;
     bool truncated      = false;
     bool just_restored  = false; // set on disk slot-restore; one-shot, gates restored-slot KV reuse
+
+    // --- KV restore-reuse (logits sidecar) ---
+    // Full-vocab logits of this slot's most recently sampled token, captured at sample time
+    // (only populated for FULL/recurrent models when --slot-save-path is set). Serialized to the
+    // <state>.logits sidecar on SLOT_SAVE so a later exact-prompt "regenerate" can emit the first
+    // token WITHOUT re-decoding into the (un-rewindable) restored recurrent state.
+    std::vector<float> logits_last;     // size n_vocab when valid, else empty
+    // Token count of the prompt-state that `logits_last` corresponds to (i.e. the slot's KV/token
+    // length at the moment of capture). Used to BIND the captured distribution to a specific state:
+    // a sidecar is only written when this equals the saved snapshot's token_count, so a stale
+    // distribution (e.g. left over from a prior task, or skipped on a spec-decode step) can never
+    // be serialized against a mismatched state. -1 = no valid capture.
+    int32_t logits_last_n_tokens = -1;
+    // Logits loaded from a sidecar at SLOT_RESTORE, consumed once by the restore-continue path.
+    std::vector<float> restored_logits; // size n_vocab when a valid sidecar was loaded, else empty
 
     stop_type stop;
 
@@ -214,6 +505,12 @@ struct server_slot {
 
         // clear alora start
         alora_invocation_start = -1;
+
+        // one-shot; never carry restored sidecar logits into a non-restore request.
+        // NOTE: logits_last is deliberately NOT cleared here — it is the slot's running
+        // "last sampled distribution" and must survive into the idle state so a subsequent
+        // SLOT_SAVE can serialize it.
+        restored_logits.clear();
     }
 
     void init_sampler() const {
@@ -383,8 +680,12 @@ struct server_slot {
 
         timings.prompt_n            = n_prompt_tokens_processed;
         timings.prompt_ms           = t_prompt_processing;
-        timings.prompt_per_token_ms = t_prompt_processing / n_prompt_tokens_processed;
-        timings.prompt_per_second   = 1e3 / t_prompt_processing * n_prompt_tokens_processed;
+        // Guard against n_prompt_tokens_processed == 0 (e.g. the restore-continue regenerate
+        // fast-path, where the entire prompt is reused and zero tokens are re-processed). Without
+        // this, the divisions emit inf/NaN which then serialize as invalid JSON in the response's
+        // "timings" object.
+        timings.prompt_per_token_ms = n_prompt_tokens_processed > 0 ? t_prompt_processing / n_prompt_tokens_processed : 0.0;
+        timings.prompt_per_second   = n_prompt_tokens_processed > 0 ? 1e3 / t_prompt_processing * n_prompt_tokens_processed : 0.0;
 
         timings.predicted_n            = n_decoded;
         timings.predicted_ms           = t_token_generation;
@@ -1392,6 +1693,13 @@ private:
     }
 
     bool launch_slot_with_task(server_slot & slot, server_task && task) {
+        // A new task is being assigned to this slot: its prompt may differ from whatever produced
+        // the slot's current `logits_last` (even at the same token count). Invalidate the capture so
+        // a SLOT_SAVE issued on the new prompt can never serialize a stale, mismatched distribution.
+        // The stamp is re-established only by a real decode of the new prompt (the capture point).
+        slot.logits_last.clear();
+        slot.logits_last_n_tokens = -1;
+
         // process per-request lora adapters
         if (!task.params.lora.empty()) {
             auto task_loras = construct_lora_list(task.params.lora);
@@ -2176,6 +2484,49 @@ private:
                     const llama_tokens & tokens = slot->prompt.tokens.get_tokens();
                     const size_t nwrite = llama_state_seq_save_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
 
+                    // Feature A: persist this slot's last-token logits as a sidecar (FULL/recurrent
+                    // only). Best-effort — a missing/failed sidecar simply disables the regenerate
+                    // fast-path for this snapshot. NOT folded into res->n_bytes (that contract stays
+                    // "state-file bytes only").
+                    //
+                    // CRITICAL consistency guard: only write the sidecar when the captured logits
+                    // provably belong to the EXACT state being saved, i.e. logits_last_n_tokens ==
+                    // token_count. This blocks every stale-logits path (restore-then-save with no
+                    // intervening decode; a spec-decode step that skipped the capture; a distribution
+                    // left over from a prior task on this slot object) from persisting a sidecar that
+                    // does not match the saved state — which would otherwise emit a wrong first token
+                    // on a later regenerate with nothing to catch it.
+                    if (nwrite > 0 && ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+                        if (slot->logits_last_n_tokens == (int32_t) token_count && !slot->logits_last.empty()) {
+                            const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                            const size_t nwrite_logits =
+                                slot_logits_write(filepath, slot->logits_last, nv, (uint32_t) token_count);
+                            if (nwrite_logits == 0) {
+                                SLT_WRN(*slot, "%s", "failed to write logits sidecar; regenerate fast-path disabled for this snapshot\n");
+                            }
+                        } else {
+                            SLT_DBG(*slot, "no matching captured logits for this state (stamp=%d, token_count=%zu); sidecar omitted\n",
+                                    slot->logits_last_n_tokens, token_count);
+                        }
+                    }
+
+                    // Feature C: enforce the bounded slot-save store (LRU by mtime). If this single
+                    // snapshot exceeds the byte cap, reject the save instead of evicting everything.
+                    if (nwrite > 0 &&
+                        (params_base.slot_save_max_count > 0 || params_base.slot_save_max_bytes > 0)) {
+                        bool oversized = false;
+                        slot_save_enforce_limits(params_base.slot_save_path,
+                                                 params_base.slot_save_max_count,
+                                                 params_base.slot_save_max_bytes,
+                                                 filepath, oversized);
+                        if (oversized) {
+                            send_error(task,
+                                       "slot snapshot exceeds --slot-save-max-mb; save rejected",
+                                       ERROR_TYPE_INVALID_REQUEST);
+                            break;
+                        }
+                    }
+
                     const int64_t t_end = ggml_time_us();
                     const double t_save_ms = (t_end - t_start) / 1000.0;
 
@@ -2234,6 +2585,27 @@ private:
                         if (ckpt_pos_min >= 0) {
                             slot->prompt.checkpoints.clear();
                             create_checkpoint(*slot, 0, ckpt_pos_min, ckpt_pos_max);
+                        }
+                    }
+
+                    // The restored state's freshly-sampled "running" distribution is unknown: the
+                    // logits in `logits_last` (if any) belong to a PRIOR generation on this slot
+                    // object, NOT to the restored state. Invalidate them so a subsequent SLOT_SAVE
+                    // (e.g. a restore -> re-checkpoint with no intervening decode) cannot persist a
+                    // stale, mismatched sidecar. (Belt-and-suspenders: the SLOT_SAVE stamp check
+                    // already blocks this, since the stamp no longer equals the restored length.)
+                    slot->logits_last.clear();
+                    slot->logits_last_n_tokens = -1;
+
+                    // Feature A/B: load the logits sidecar (if any) so an exact-prompt regenerate
+                    // can emit the first token without re-decoding into the restored recurrent state.
+                    // The token-count check binds the sidecar to exactly this restored state.
+                    // On any failure restored_logits stays empty and Feature B falls back safely.
+                    slot->restored_logits.clear();
+                    if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+                        const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                        if (slot_logits_read(filepath, nv, (uint32_t) token_count, slot->restored_logits)) {
+                            SLT_INF(*slot, "loaded logits sidecar (%d vocab, %zu tokens) — regenerate fast-path armed\n", nv, token_count);
                         }
                     }
 
@@ -2735,6 +3107,129 @@ private:
 
                             // the largest pos_min required for a checkpoint to be useful
                             const auto pos_min_thold = std::max(0, pos_next - n_swa - 1);
+
+                            // ===== Feature B: restore-continue (regenerate fast-path) ====================
+                            // A just-restored FULL/recurrent slot receiving the EXACT restored tokens (no
+                            // suffix) cannot rewind its memory: the normal path would re-decode into the
+                            // already-occupied sequence and crash (the pure-recurrent gate at the relaxed
+                            // checkpoint predicate below is FALSE for this case, so just_restored would never
+                            // be consumed and [TAG_PROMPT_LOGITS] would decrement n_past and re-decode into
+                            // the occupied sequence). Detect that case here, BEFORE the n_past>0 guard, and:
+                            //   - if we have the saved next-token logits: emit the first token with NO decode,
+                            //     keeping the full restored state, then continue normal autoregression;
+                            //   - otherwise: fall back to a SAFE clear-then-reprefill (never crash).
+                            // Gated so it is unreachable for non-recurrent models, with-suffix requests,
+                            // non-generative slots, and multimodal (already excluded by check_no_mtmd at
+                            // save/restore). With-suffix restore reuse is left entirely to the unchanged
+                            // relaxed-predicate path below.
+                            // NOTE: cache_prompt==false sets n_past=0 above, so this gate (which
+                            // requires n_past == task->n_tokens()) is naturally not entered for a
+                            // no-cache request; that case safely takes the normal full-clear +
+                            // reprefill path (common_context_seq_rm at [p0,-1) empties the restored
+                            // sequence first), so regenerate degrades to a cold reprefill, never a crash.
+                            // No `n_past < n_ctx` clause: the fast path emits with NO decode so it
+                            // needs no free context slot; a full-n_ctx no-suffix restore is handled
+                            // here rather than falling through to a zero-token-added crash window.
+                            if (slot.just_restored &&
+                                ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL &&
+                                slot.task->need_sampling() &&
+                                slot.alora_invocation_start <= 0 &&
+                                n_past == slot.task->n_tokens() &&
+                                n_past == (int) slot.prompt.n_tokens()) {
+
+                                slot.just_restored = false; // one-shot consume (this path owns it)
+
+                                if (!slot.restored_logits.empty()) {
+                                    // --- fast path: emit first token from saved logits, no decode ---
+                                    slot.n_prompt_tokens_cache     = n_past; // entire prompt "reused"
+                                    slot.n_prompt_tokens_processed = 0;      // prompt_n = 0 => observable reuse signal
+
+                                    // prime the sampler over the full restored prompt (penalties/grammar
+                                    // history), exactly as the normal DONE_PROMPT transition (init_sampler) would.
+                                    slot.n_decoded = 0;
+                                    slot.init_sampler();
+
+                                    slot.state   = SLOT_STATE_GENERATING;
+                                    slot.i_batch = -1;
+
+                                    // rebuild the (cold, unsaved) draft context for the restored prompt,
+                                    // mirroring the normal prompt-done transition.
+                                    if (slot.can_speculate()) {
+                                        common_speculative_begin(spec.get(), slot.id, slot.prompt.tokens.get_text_tokens());
+                                    }
+
+                                    const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                                    const llama_token id = common_sampler_sample_from_logits(
+                                            slot.smpl.get(), slot.restored_logits.data(), nv, /*grammar_first=*/false);
+                                    slot.restored_logits.clear(); // consumed
+
+                                    common_sampler_accept(slot.smpl.get(), id, true);
+
+                                    // mirror the generation accounting from the normal sample path
+                                    const int64_t t_current = ggml_time_us();
+                                    slot.n_decoded += 1;
+                                    slot.t_start_generation  = t_current;
+                                    slot.t_prompt_processing = (slot.t_start_generation - slot.t_start_process_prompt) / 1e3;
+                                    metrics.on_prompt_eval(slot);
+                                    slot.t_token_generation  = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;
+
+                                    if (slot.task->params.stream) {
+                                        // mirror the normal prompt-start streaming signal exactly so a
+                                        // return_progress client still gets its initial 0% progress event
+                                        if (slot.task->params.return_progress) {
+                                            send_partial_response(slot, {}, true);
+                                        } else {
+                                            // signal HTTP to send the headers (200 status)
+                                            send_partial_response(slot, {}, false, true);
+                                        }
+                                    }
+
+                                    completion_token_output result;
+                                    result.tok  = id;
+                                    // inline of the accept_special_token lambda (defined later in this method,
+                                    // out of scope here): keep special tokens iff the server allows specials
+                                    // or the request explicitly preserves this token.
+                                    const bool keep_special =
+                                        params_base.special ||
+                                        slot.task->params.sampling.preserved_tokens.find(result.tok) !=
+                                            slot.task->params.sampling.preserved_tokens.end();
+                                    result.text_to_send = common_token_to_piece(slot.ctx_tgt, result.tok, keep_special);
+                                    result.prob         = 1.0f;
+
+                                    // First-token logprobs (n_probs>0): the post-sampling variant reads the
+                                    // candidate set (cur_p), which common_sampler_sample_from_logits leaves
+                                    // populated — so we can serve it exactly as the normal path does. The
+                                    // pre-sampling variant reads raw ctx logits at a decode index we bypass
+                                    // here; idx=-1 is passed but populate_token_probs() only uses idx in that
+                                    // branch, so we restrict the call to post_sampling to stay correct.
+                                    if (slot.task->params.sampling.n_probs > 0 && slot.task->params.post_sampling_probs) {
+                                        populate_token_probs(slot, result, /*post_sampling=*/true, params_base.special, /*idx=*/-1);
+                                    }
+
+                                    if (!process_token(result, slot)) {
+                                        slot.print_timings();
+                                        send_final_response(slot);
+                                        metrics.on_prediction(slot);
+                                        slot.release();
+                                    }
+
+                                    SLT_INF(slot, "%s", "restore-continue: emitted first token from saved logits (prompt_n=0)\n");
+                                    continue; // skip ALL prompt-batch building for this slot this iteration
+                                }
+
+                                // --- safe fallback: no valid sidecar -> clear restored seq, then reprefill ---
+                                // FULL models support full-sequence removal; clearing first guarantees the
+                                // subsequent reprefill writes into an EMPTY sequence instead of re-decoding
+                                // into the already-occupied restored state (which is the crash being fixed).
+                                SLT_WRN(slot, "%s", "restore-continue: no saved logits; clearing restored state and re-prefilling\n");
+                                llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, -1, -1);
+                                slot.prompt.tokens.clear();
+                                slot.prompt.checkpoints.clear();
+                                n_past   = 0;
+                                pos_next = 0; // mirror the do_reset path; keep the stale full-length value from leaking into the checkpoint-erase loop below
+                                // fall through to the normal guard below with an empty sequence (safe)
+                            }
+                            // ===== end Feature B ========================================================
 
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
@@ -3316,6 +3811,32 @@ private:
                 const int tok_idx = slot.i_batch - i;
 
                 llama_token id = common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, tok_idx);
+
+                // Feature A: capture this slot's last-token full-vocab logits for a possible disk
+                // save. Cost: one ~n_vocab*4-byte copy per decoded token, incurred ONLY on
+                // FULL/recurrent models AND only when slot saving is enabled (--slot-save-path set);
+                // attention models and servers without slot-save pay nothing at all. The copy is
+                // unavoidable for correctness: ctx logits are overwritten by the next slot's decode,
+                // so a lazy read at SLOT_SAVE would be wrong under --parallel>1. Captured per-slot
+                // from this slot's own tok_idx so it is correct for any N/interleave (never read
+                // from the shared ctx at save time). common_sampler_sample already synchronized the
+                // context above, so llama_get_logits_ith is valid here.
+                if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL && !params_base.slot_save_path.empty()) {
+                    const float * lg = llama_get_logits_ith(slot.ctx_tgt, tok_idx);
+                    if (lg) {
+                        const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                        slot.logits_last.assign(lg, lg + nv);
+                        // Stamp the capture with the token count of the state it corresponds to.
+                        // At this point process_token() has NOT yet appended the just-sampled token,
+                        // so prompt.tokens.size() is exactly the length whose final token produced
+                        // these logits — i.e. it matches the token_count a SLOT_SAVE would record.
+                        slot.logits_last_n_tokens = (int32_t) slot.prompt.tokens.size();
+                    } else {
+                        // capture failed -> invalidate so a later save never serializes stale logits
+                        slot.logits_last.clear();
+                        slot.logits_last_n_tokens = -1;
+                    }
+                }
 
                 slot.i_batch = -1;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -98,6 +98,7 @@ struct server_slot {
     bool has_next_token = true;
     bool has_new_line   = false;
     bool truncated      = false;
+    bool just_restored  = false; // set on disk slot-restore; one-shot, gates restored-slot KV reuse
 
     stop_type stop;
 
@@ -2221,6 +2222,20 @@ private:
                     tokens.resize(token_count);
                     slot->prompt.tokens.clear();
                     slot->prompt.tokens.insert(tokens);
+                    slot->just_restored = true;
+
+                    // Reconstruct a context checkpoint at the restored position so the prompt-cache
+                    // reuse path can reuse this state on the next matching request. Hybrid/recurrent
+                    // (and SWA) models cannot partially rewind their memory, so without a checkpoint
+                    // the matcher forces a full re-prefill; other models do not need it.
+                    if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+                        const auto ckpt_pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot->id);
+                        const auto ckpt_pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot->id);
+                        if (ckpt_pos_min >= 0) {
+                            slot->prompt.checkpoints.clear();
+                            create_checkpoint(*slot, 0, ckpt_pos_min, ckpt_pos_max);
+                        }
+                    }
 
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
@@ -2773,6 +2788,10 @@ private:
 
                                 if (pos_min >= pos_min_thold) {
                                     // search for a context checkpoint
+                                    // reuse a tail checkpoint (e.g. restored from disk) when genuinely-new tokens follow,
+                                    // which supply the required logits so the >=1-token guarantee still holds
+                                    const bool slot_was_restored = slot.just_restored; slot.just_restored = false;
+                                    const bool has_new_suffix = (size_t) slot.task->n_tokens() > (size_t) n_past;
                                     const auto it = std::find_if(
                                         slot.prompt.checkpoints.rbegin(),
                                         slot.prompt.checkpoints.rend(),
@@ -2780,7 +2799,7 @@ private:
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             LOG_INF("slot %12.*s: id %2d | task %d | Checking checkpoint with [%d, %d] against %d...\n", 12,
                                                 func_name, (slot).id, ((slot).task ? (slot).task->id : -1), cur.pos_min, cur.pos_max, pos_min_thold);
-                                            return cur.pos_min < pos_min_thold || cur.pos_min == 0;
+                                            return cur.pos_min == 0 || cur.pos_min < pos_min_thold || (slot_was_restored && has_new_suffix && cur.pos_min == pos_min_thold);
                                         }
                                     );
 


### PR DESCRIPTION
## Overview

For recurrent/hybrid (FULL seq-rm) models, disk slot save/restore currently doesn't deliver KV reuse, and the exact-prompt "regenerate" case **crashes the server** (`GGML_ABORT`): after a `/slots restore`, continuing re-processes the whole prompt, and re-sending the saved prompt with no new suffix re-decodes into the un-rewindable recurrent state. This makes save/restore unusable for the growing class of recurrent/hybrid models (Mamba, Falcon-H, Jamba, Qwen3-Next, etc.). See #21831 and discussion #19264.

This PR makes disk save/restore actually reuse the restored KV for these models, and adds a bound on the slot-save directory.  This is absolutely necessary when running a GPU cluster with deep-context taking 10-30min to regenerate across instances.

- **Reuse after restore:** reconstruct a context checkpoint at the restored tail (gated by a one-shot `just_restored` flag) so a continuation request reuses the restored state and prefills only the new suffix. In-process serving is byte-identical.
- **Regenerate (no new suffix):** persist the saved state's final next-token logits to a small `<state>.logits` sidecar; on an exact-prompt restore, emit the first token from those logits (new `common_sampler_sample_from_logits`) instead of re-decoding into the occupied sequence (`prompt_n=0`). Safe clear+reprefill fallback when no sidecar exists — this also fixes the crash.
- **Bounded store:** `--slot-save-max-count` (default 64) / `--slot-save-max-mb` (default 32768); LRU-by-mtime, state+sidecar evicted as a unit, single-oversized save rejected.

All new behavior is gated on `COMMON_CONTEXT_SEQ_RM_TYPE_FULL` + a no-suffix/`need_sampling`/no-aLoRA predicate, so attention models, existing with-suffix reuse, multimodal, embeddings, and normal generation are unaffected. Only 2 existing lines change (a `get_timings` divide-by-zero guard); everything else is additive. No public API change (`common_sampler_sample_from_logits` is additive); the state-file format is untouched (the sidecar is a new optional self-validating file).

## Additional information

Addresses #21831 (recurrent/hybrid forces full re-processing) and implements the whole-state-at-a-position checkpointing proposed in #19264. Building block for on-disk reuse of large prompts (#17107, #18244).

Tested on Qwen3.6-27B (recurrent/hybrid, Q5_K_M) + Llama-3.2-1B (attention control): with-suffix reuse after a cold-process restore (1140-token snapshot, only the suffix prefilled), regenerate `prompt_n=0` + coherent + no crash, sidecar-missing fallback, attention model byte-identical, and the LRU bounds. Branch is based on an older `master`; will rebase on request.

Note: This is part 1, part 2 implements multi-instance automatic disk caching: #24004

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — the implementation and tests were developed with substantial AI assistance (design, code, and review), then validated by me on real recurrent + attention models. I have reviewed the changes and take responsibility for them.
