### PR TITLE
server : opt-in automatic disk prompt/KV cache (--slot-save-auto) (2/2)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -675,6 +675,15 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         ));
     }
 
+    // the auto disk prompt/KV cache needs a directory to live in; fail fast & loud rather than
+    // silently doing nothing if --slot-save-auto is set without --slot-save-path.
+    if (params.slot_save_auto && params.slot_save_path.empty()) {
+        throw std::invalid_argument("--slot-save-auto requires --slot-save-path to be set");
+    }
+    if (params.slot_save_auto && params.slot_save_block <= 0) {
+        throw std::invalid_argument("--slot-save-block must be > 0");
+    }
+
     return true;
 }
 
@@ -3112,6 +3121,21 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.slot_save_max_bytes = (int64_t) value * 1024 * 1024;
         }
     ).set_env("LLAMA_ARG_SLOT_SAVE_MAX_MB").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--slot-save-auto"},
+        "automatically restore/save prompt KV to/from --slot-save-path across requests and restarts (transparent disk prompt cache); requires --slot-save-path (default: disabled)",
+        [](common_params & params) {
+            params.slot_save_auto = true;
+        }
+    ).set_env("LLAMA_ARG_SLOT_SAVE_AUTO").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--slot-save-block"}, "N",
+        string_format("token-ID hash block size for the auto disk cache index; reuse granularity "
+                      "is one block (default: %d)", params.slot_save_block),
+        [](common_params & params, int value) {
+            params.slot_save_block = value;
+        }
+    ).set_env("LLAMA_ARG_SLOT_SAVE_BLOCK").set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
         {"--media-path"}, "PATH",
         "directory for loading local media files; files can be accessed via file:// URLs using relative paths (default: disabled)",

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3093,6 +3093,26 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--slot-save-max-count"}, "N",
+        string_format("max number of slot-save snapshots kept in --slot-save-path (treated as a dedicated dir); oldest are evicted (default: %d, 0 = unlimited)", params.slot_save_max_count),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("--slot-save-max-count must be >= 0 (0 = unlimited)");
+            }
+            params.slot_save_max_count = value;
+        }
+    ).set_env("LLAMA_ARG_SLOT_SAVE_MAX_COUNT").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--slot-save-max-mb"}, "N",
+        string_format("max total size (MiB) of the --slot-save-path store; oldest snapshots are evicted (default: %d, 0 = unlimited)", (int) (params.slot_save_max_bytes / (1024 * 1024))),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("--slot-save-max-mb must be >= 0 (0 = unlimited)");
+            }
+            params.slot_save_max_bytes = (int64_t) value * 1024 * 1024;
+        }
+    ).set_env("LLAMA_ARG_SLOT_SAVE_MAX_MB").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--media-path"}, "PATH",
         "directory for loading local media files; files can be accessed via file:// URLs using relative paths (default: disabled)",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -649,6 +649,11 @@ struct common_params {
     // evicted together as one unit). Defaults are finite & sane; 0 means "unlimited" (only if set).
     int32_t slot_save_max_count = 64;                                // max snapshots in slot_save_path (0 = unlimited)
     int64_t slot_save_max_bytes = (int64_t) 32 * 1024 * 1024 * 1024; // 32 GiB cap (0 = unlimited)
+    // --- auto disk prompt/KV cache (opt-in, default OFF; see tools/server "auto disk cache") ---
+    // master switch for the transparent cross-process prompt/KV cache. Requires slot_save_path.
+    // When false the whole feature is inert: no startup dir scan, no index, no per-request hashing.
+    bool    slot_save_auto  = false;  // master switch; requires slot_save_path to be set
+    int32_t slot_save_block = 256;    // token-ID hash block size (vLLM-APC / SGLang-radix style)
     std::string media_path; // path to directory for loading media files
 
     float slot_prompt_similarity = 0.1f;

--- a/common/common.h
+++ b/common/common.h
@@ -645,6 +645,10 @@ struct common_params {
     bool log_json = false;
 
     std::string slot_save_path;
+    // bounded slot-save store (LRU eviction by mtime; a state file + its .logits sidecar are
+    // evicted together as one unit). Defaults are finite & sane; 0 means "unlimited" (only if set).
+    int32_t slot_save_max_count = 64;                                // max snapshots in slot_save_path (0 = unlimited)
+    int64_t slot_save_max_bytes = (int64_t) 32 * 1024 * 1024 * 1024; // 32 GiB cap (0 = unlimited)
     std::string media_path; // path to directory for loading media files
 
     float slot_prompt_similarity = 0.1f;

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -618,6 +618,90 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
     return id;
 }
 
+// Rebuild the candidate set from a raw full-vocab logits buffer, mirroring
+// common_sampler::set_logits()'s full-logits branch (the else-branch above). Used by
+// common_sampler_sample_from_logits() to sample from persisted logits instead of a llama_context.
+// Callers must pre-validate logits != nullptr && n_vocab > 0 (the only caller does so via asserts).
+static void common_sampler_set_logits_raw(struct common_sampler * gsmpl, const float * logits, int n_vocab) {
+    auto & cur = gsmpl->cur;
+
+    cur.resize(n_vocab);
+    for (llama_token token_id = 0; token_id < n_vocab; token_id++) {
+        cur[token_id] = llama_token_data{token_id, logits[token_id], 0.0f};
+    }
+
+    gsmpl->cur_p = { cur.data(), cur.size(), -1, false };
+}
+
+llama_token common_sampler_sample_from_logits(struct common_sampler * gsmpl, const float * logits, int n_vocab, bool grammar_first) {
+    // This mirrors common_sampler_sample()'s CPU full-logits apply sequence exactly (reasoning
+    // budget -> [grammar] -> chain, plus grammar rejection-resampling), with set_logits(ctx,idx)
+    // replaced by common_sampler_set_logits_raw(). It intentionally omits two things that are
+    // inapplicable to replayed logits: llama_synchronize() (the logits are caller-provided, not
+    // pending in any llama_context) and the backend-sampler short-circuit (a replayed distribution
+    // never carries a backend-sampled token, and backend sampling is incompatible with
+    // grammar/reasoning-budget anyway — see common_sampler_sample).
+    GGML_ASSERT(logits != nullptr);
+    GGML_ASSERT(n_vocab > 0);
+
+    const auto tm = gsmpl->tm();
+
+    llama_token id = LLAMA_TOKEN_NULL;
+
+    auto & grmr    = gsmpl->grmr;
+    auto & rbudget = gsmpl->rbudget;
+    auto & chain   = gsmpl->chain;
+    auto & cur_p   = gsmpl->cur_p; // initialized by common_sampler_set_logits_raw
+
+    common_sampler_set_logits_raw(gsmpl, logits, n_vocab);
+
+    // apply reasoning budget first
+    llama_sampler_apply(rbudget, &cur_p);
+
+    if (grammar_first && grammar_should_apply(gsmpl)) {
+        llama_sampler_apply(grmr, &cur_p);
+    }
+
+    llama_sampler_apply(chain, &cur_p);
+
+    id = cur_p.data[cur_p.selected].id;
+
+    if (grammar_first || !grammar_should_apply(gsmpl)) {
+        return id;
+    }
+
+    // check if the sampled token fits the grammar (grammar-based rejection sampling)
+    {
+        llama_token_data       single_token_data       = { id, 1.0f, 0.0f };
+        llama_token_data_array single_token_data_array = { &single_token_data, 1, -1, false };
+
+        llama_sampler_apply(grmr, &single_token_data_array);
+
+        const bool is_valid = single_token_data_array.data[0].logit != -INFINITY;
+        if (is_valid) {
+            return id;
+        }
+    }
+
+    // resampling:
+    // if the token is not valid, sample again, but first apply the grammar sampler and then the sampling chain
+    common_sampler_set_logits_raw(gsmpl, logits, n_vocab);
+
+    llama_sampler_apply(rbudget,  &cur_p);
+
+    if (grammar_should_apply(gsmpl)) {
+        llama_sampler_apply(grmr,  &cur_p);
+    }
+
+    llama_sampler_apply(chain, &cur_p);
+
+    GGML_ASSERT(cur_p.selected != -1 && "no selected token during sampling - check your sampling configuration");
+
+    id = cur_p.data[cur_p.selected].id;
+
+    return id;
+}
+
 std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sampler * gsmpl, struct llama_context * ctx, const std::vector<int> & idxs, const llama_tokens & draft, bool grammar_first) {
     GGML_ASSERT(idxs.size() == draft.size() + 1 && "idxs.size() must be draft.size() + 1");
 

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -64,6 +64,21 @@ struct llama_sampler * common_sampler_get(const struct common_sampler * gsmpl);
 //
 llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_context * ctx, int idx, bool grammar_first = false);
 
+// Sample a token directly from a caller-provided full-vocab logits buffer instead of reading them
+// from a llama_context. Mirrors common_sampler_sample()'s full-logits path exactly (reasoning
+// budget -> [grammar] -> chain, plus grammar rejection-resampling), so the selected token is
+// identical to what would have been produced had `logits` come from llama_get_logits_ith(ctx, idx).
+// `logits` must point to at least `n_vocab` floats in vocab-id order; the caller is responsible for
+// verifying n_vocab matches the live model. Does NOT call common_sampler_accept() (the caller
+// accepts separately, as with common_sampler_sample). Leaves cur_p populated for
+// common_sampler_get_candidates().
+// NOTE: the selected token also depends on the sampler's accumulated state (penalty/grammar/
+// reasoning-budget history and RNG position), exactly like common_sampler_sample(). The caller must
+// have advanced `gsmpl` to the intended decode step (e.g. by replaying the same accepted-token
+// history, as common_sampler_reset()+init does over a restored prompt) for the result to match a
+// live sample at that step; the helper is NOT stateless given only `logits`.
+llama_token common_sampler_sample_from_logits(struct common_sampler * gsmpl, const float * logits, int n_vocab, bool grammar_first = false);
+
 // generalized version of common_sampler_sample
 //
 // will cross-reference the sampled tokens with a batch of draft tokens and accept those that match

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -196,6 +196,10 @@ public:
 
     llama_tokens get_text_tokens() const;
 
+    // per-request media signal (has_mtmd is server-wide and wrong here): true if this
+    // prompt contains ANY media chunk (image/audio); a text-only prompt has an empty media map.
+    bool has_media() const { return !map_idx_to_media.empty(); }
+
     // for compatibility with speculative decoding
     void set_token(llama_pos pos, llama_token id);
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -17,14 +17,30 @@
 #include "mtmd-helper.h"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <cinttypes>
 #include <exception>
 #include <fstream>
-#include <memory>
 #include <filesystem>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
+
+#ifndef _WIN32
+#include <unistd.h> // getpid() for per-writer-unique temp filenames (cross-process atomicity)
+#else
+#include <process.h> // _getpid()
+#define getpid _getpid
+#endif
 
 // fix problem with std::min and std::max
 #if defined(_WIN32)
@@ -54,7 +70,7 @@ enum server_state {
     SERVER_STATE_READY,          // Server is ready and model is loaded
 };
 
-// --- KV restore-reuse: logits sidecar (Feature A) -------------------------------
+// --- KV restore-reuse: logits sidecar -------------------------------------------
 // When a slot's full state is saved to disk (SLOT_SAVE) for a recurrent/hybrid (FULL) model,
 // we additionally persist the last decoded token's full-vocab logits in a small sidecar file
 // (<state>.logits). On SLOT_RESTORE of an exact-prompt "regenerate" request, those logits let
@@ -67,6 +83,21 @@ static constexpr uint32_t SLOT_LOGITS_VERSION = 1u;
 
 static std::string slot_logits_sidecar_path(const std::string & state_filepath) {
     return state_filepath + ".logits";
+}
+
+// Best-effort "touch": bump the mtime of an auto-cache snapshot's 3-file unit (state + .logits +
+// .meta) to now, so a snapshot that is REUSED (read/restored) but never rewritten is treated as
+// recently-used by the mtime LRU. Without this, the LRU is least-recently-WRITTEN, which would
+// evict a hot base snapshot that N forked requests keep restoring from (it never gets rewritten).
+// Never throws and never errors out the caller: every failure is swallowed via error_code (the
+// file may have been concurrently evicted by another process; that is harmless here). This only
+// runs on a successful restore, off the generation hot path.
+static void auto_touch_unit(const std::string & state_filepath) {
+    const auto now = std::filesystem::file_time_type::clock::now();
+    std::error_code ec;
+    std::filesystem::last_write_time(state_filepath, now, ec);
+    std::filesystem::last_write_time(slot_logits_sidecar_path(state_filepath), now, ec);
+    std::filesystem::last_write_time(state_filepath + ".meta", now, ec);
 }
 
 // Best-effort write of the logits sidecar. Returns the number of bytes written (0 on failure or
@@ -165,12 +196,14 @@ static bool slot_logits_read(const std::string & state_filepath,
     return true;
 }
 
-// --- KV restore-reuse: bounded slot-save store (Feature C) ----------------------
-// One slot-save snapshot = a state file plus its optional <name>.logits sidecar; the two are
-// always evicted together as a single unit, keyed by the state file's mtime (LRU).
+// --- KV restore-reuse: bounded slot-save store ----------------------------------
+// One slot-save snapshot = a state file plus its optional <name>.logits sidecar and (for auto-cache
+// snapshots) its <name>.meta sidecar; all are always evicted together as a single unit, keyed by
+// the state file's mtime (LRU).
 struct slot_save_unit {
     std::string state_path;
-    std::string sidecar_path; // "" if none
+    std::string sidecar_path; // "<state>.logits", "" if none
+    std::string meta_path;    // "<state>.meta",   "" if none (auto disk cache)
     uintmax_t   bytes = 0;
     std::filesystem::file_time_type mtime;
 };
@@ -232,10 +265,21 @@ static void slot_save_enforce_limits(const std::string & dir,
                 present.count(p.substr(0, p.size() - 7))) {
                 continue;
             }
+            // a "<X>.meta" file is the auto disk cache's tokens+fingerprint sidecar; treat it
+            // exactly like ".logits" — accounted with its state file below, reaped if orphaned.
+            if (p.size() >= 5 && p.compare(p.size() - 5, 5, ".meta") == 0 &&
+                present.count(p.substr(0, p.size() - 5))) {
+                continue;
+            }
             // reap an ORPHANED sidecar (its state file was evicted/lost): otherwise these silently
             // accumulate (we never count them) and eat real on-disk space forever.
             if (p.size() >= 7 && p.compare(p.size() - 7, 7, ".logits") == 0 &&
                 !present.count(p.substr(0, p.size() - 7))) {
+                std::filesystem::remove(p, fec);
+                continue;
+            }
+            if (p.size() >= 5 && p.compare(p.size() - 5, 5, ".meta") == 0 &&
+                !present.count(p.substr(0, p.size() - 5))) {
                 std::filesystem::remove(p, fec);
                 continue;
             }
@@ -252,6 +296,14 @@ static void slot_save_enforce_limits(const std::string & dir,
                 if (!fec) {
                     u.sidecar_path = side;
                     u.bytes += sb;
+                }
+            }
+            const std::string meta = p + ".meta";
+            if (present.count(meta)) {
+                const auto mb = std::filesystem::file_size(meta, fec);
+                if (!fec) {
+                    u.meta_path = meta;
+                    u.bytes += mb;
                 }
             }
             u.mtime = std::filesystem::last_write_time(p, fec);
@@ -276,6 +328,9 @@ static void slot_save_enforce_limits(const std::string & dir,
                 std::filesystem::remove(u.state_path, ec);
                 if (!u.sidecar_path.empty()) {
                     std::filesystem::remove(u.sidecar_path, ec);
+                }
+                if (!u.meta_path.empty()) {
+                    std::filesystem::remove(u.meta_path, ec);
                 }
                 break;
             }
@@ -306,6 +361,9 @@ static void slot_save_enforce_limits(const std::string & dir,
         if (!u.sidecar_path.empty()) {
             std::filesystem::remove(u.sidecar_path, ec);
         }
+        if (!u.meta_path.empty()) {
+            std::filesystem::remove(u.meta_path, ec);
+        }
         total -= std::min(total, (uintmax_t) u.bytes);
         count = (count > 0) ? count - 1 : 0;
         idx++;
@@ -326,6 +384,305 @@ static void slot_save_enforce_limits(const std::string & dir,
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// --- Auto disk prompt/KV cache (opt-in: --slot-save-auto) ---
+//
+// Persists per-slot KV snapshots to disk (state file + '.meta' [tokens + fingerprint]
+// + '.logits' sidecar) and indexes them by a chained hash over token IDs, so a cold
+// process can reuse a warm process's KV with no client/router involvement.
+//
+// Design invariants (all must hold; comments below reference them by number):
+//   1. Off by default: every hook's FIRST statement is auto_cache_enabled(); when
+//      false there is no scan, index, hashing, or allocation — behavior is unchanged.
+//   2. Never restore on hash alone: the snapshot's token-ID array must byte-compare
+//      equal to the request prefix before any restore (collision-safe).
+//   3. Model identity: each snapshot carries a fingerprint (model/vocab/ctx/rope/
+//      KV-type/FULL-vs-attention/LoRA); a mismatch refuses the restore.
+//   4. Fallback totality: any failure (corrupt file, fp/vocab mismatch, IO error,
+//      no match) falls back to a normal prefill — never crash, never wrong output.
+//   5. Hot-path purity: the multi-GB save runs only on slot release/reassign, never
+//      during generation; restore happens once before prefill.
+//
+// Concurrency: all slot work runs on the single server-loop thread, so the index is
+// single-threaded and the mutex below is uncontended today; it becomes load-bearing
+// only if the save I/O is later moved to a worker thread (do not make save async
+// without keeping the mutex honest). Independent of legacy --prompt-cache and the
+// in-memory prefix-reuse path; auto-restore fires only when in-memory reuse is poor.
+// ---------------------------------------------------------------------------
+
+static constexpr uint32_t SLOT_META_MAGIC   = 0x544D4B4Cu; // "LKMT" (llama kv meta), LE
+static constexpr uint32_t SLOT_META_VERSION = 1u;
+
+// Model/quant/context fingerprint that MUST match for a restore to be sound. All
+// fields are stable inference-affecting identity captured once at model load and
+// compared by exact equality (pure-CPU int compares). See invariant 3. The blob
+// produced by llama_state_seq_save_file is only safe to load into a context with
+// identical KV geometry — a Q4_0-KV blob loaded into an F16 ctx, or a different
+// rope/yarn scale (positions are baked into the saved state), silently corrupts —
+// so cache_type_k/v and rope_scale are NOT optional.
+struct model_fp {
+    uint64_t fp_model      = 0; // hash of llama_model_desc + size + n_params (+ n_embd/n_layer)
+    uint32_t fp_n_vocab    = 0;
+    uint32_t fp_n_ctx_train= 0;
+    uint32_t fp_n_embd     = 0;
+    uint32_t fp_n_layer    = 0;
+    uint32_t fp_rope_type  = 0;
+    uint32_t fp_cache_k    = 0; // ggml_type of K cache (enum int)
+    uint32_t fp_cache_v    = 0; // ggml_type of V cache (enum int)
+    uint32_t fp_n_ctx      = 0; // effective per-seq n_ctx
+    uint32_t fp_kv_full    = 0; // 1 if COMMON_CONTEXT_SEQ_RM_TYPE_FULL else 0
+    uint32_t fp_block      = 0; // slot_save_block this snapshot was hashed with
+    uint64_t fp_rope_scale = 0; // bit-pattern of effective rope_freq_scale (position-critical)
+    // rope_freq_base and ALL YaRN params also bake positions into the saved KV state exactly as
+    // rope_freq_scale does — a same-model run differing only in --rope-freq-base or any --yarn-*
+    // flag would otherwise pass the fingerprint and silently restore positionally-corrupt state.
+    // All are bit-cast (float->u32) into identity; yarn_orig_ctx is an int. "0/negative = use
+    // model-trained value" is normalized in auto_compute_fingerprint so equal effective configs match.
+    uint64_t fp_rope_base       = 0; // bit-pattern of effective rope_freq_base
+    uint32_t fp_yarn_ext        = 0; // bit-pattern of yarn_ext_factor
+    uint32_t fp_yarn_attn       = 0; // bit-pattern of yarn_attn_factor
+    uint32_t fp_yarn_beta_fast  = 0; // bit-pattern of yarn_beta_fast
+    uint32_t fp_yarn_beta_slow  = 0; // bit-pattern of yarn_beta_slow
+    uint32_t fp_yarn_orig_ctx   = 0; // yarn_orig_ctx (int)
+    uint64_t fp_lora       = 0; // hash of active LoRA-set ids+scales (0 if none)
+    // refuse cross-shape restores: 1 if the server was launched with --mmproj (mctx != nullptr),
+    // else 0. The auto-cache only ever persists text-only prefixes, but mmproj-aware rope (M-RoPE)
+    // and projector wiring CAN alter the text KV layout, so we conservatively REFUSE to cross-load
+    // a text-only-server snapshot into an mmproj server (or vice-versa) — they get disjoint stores.
+    // Removing this bit later would require proving the text KV layout is identical across the two
+    // deployment shapes.
+    uint32_t fp_mmproj_loaded   = 0;
+
+    // exact field-by-field equality (C++17: no defaulted operator==). Any difference REFUSES the
+    // restore (invariant 3). Note: fp_block is intentionally part of identity — a snapshot hashed
+    // with a different block size cannot be longest-prefix-matched against the current index.
+    bool operator==(const model_fp & o) const {
+        return fp_model == o.fp_model && fp_n_vocab == o.fp_n_vocab &&
+               fp_n_ctx_train == o.fp_n_ctx_train && fp_n_embd == o.fp_n_embd &&
+               fp_n_layer == o.fp_n_layer && fp_rope_type == o.fp_rope_type &&
+               fp_cache_k == o.fp_cache_k && fp_cache_v == o.fp_cache_v &&
+               fp_n_ctx == o.fp_n_ctx && fp_kv_full == o.fp_kv_full &&
+               fp_block == o.fp_block && fp_rope_scale == o.fp_rope_scale &&
+               fp_rope_base == o.fp_rope_base && fp_yarn_ext == o.fp_yarn_ext &&
+               fp_yarn_attn == o.fp_yarn_attn && fp_yarn_beta_fast == o.fp_yarn_beta_fast &&
+               fp_yarn_beta_slow == o.fp_yarn_beta_slow && fp_yarn_orig_ctx == o.fp_yarn_orig_ctx &&
+               fp_lora == o.fp_lora && fp_mmproj_loaded == o.fp_mmproj_loaded;
+    }
+};
+
+// 64-bit chained block hash over token IDs. Each token folds via FNV-1a then a
+// splitmix avalanche; block k's output seeds block k+1, so the hash at every block
+// boundary commits to the ENTIRE prefix [0, (k+1)*B). Collision resistance is only
+// a candidate-narrowing accelerator: we NEVER trust it alone (invariant 2) — the
+// caller byte-verifies tokens before any restore. Block boundaries are the only
+// resumable prefix lengths (vLLM-APC / SGLang-radix granularity).
+static inline uint64_t auto_hash_mix(uint64_t h, int32_t tok) {
+    h ^= (uint64_t) (uint32_t) tok;
+    h *= 0x100000001b3ULL;                                  // FNV-1a 64-bit prime
+    h ^= h >> 29; h *= 0xbf58476d1ce4e5b9ULL; h ^= h >> 32; // splitmix64 finalize
+    return h;
+}
+
+// Returns, for each block boundary b in [1 .. n/B], the cumulative chain hash
+// committing to tokens[0 .. b*B). out[k] = hash of prefix length (k+1)*B. The
+// chain is salted with `salt` (the model fingerprint hash) so two different models
+// can never produce the same boundary hash for identical tokens. A trailing
+// partial block is NOT a boundary (only whole-block prefixes are index keys).
+static std::vector<uint64_t> auto_block_hashes(const llama_tokens & toks, int B, uint64_t salt) {
+    std::vector<uint64_t> out;
+    if (B <= 0) {
+        return out;
+    }
+    out.reserve(toks.size() / (size_t) B);
+    uint64_t h = 0xcbf29ce484222325ULL ^ salt; // FNV offset basis, fingerprint-salted
+    for (size_t i = 0; i < toks.size(); ++i) {
+        h = auto_hash_mix(h, toks[i]);
+        if ((i + 1) % (size_t) B == 0) {
+            out.push_back(h);
+        }
+    }
+    return out;
+}
+
+// One in-memory index entry: the longest snapshot that reaches a given block
+// boundary. Mirrors slot_save_unit's mtime LRU semantics for reconciliation.
+struct auto_cache_entry {
+    std::string state_path; // full state file path (sidecars derived via *_path helpers)
+    uint32_t    n_tokens = 0;
+    model_fp    fp;         // snapshot's fingerprint (must equal the live one to be used)
+};
+
+// boundary-hash -> best (longest) entry covering that prefix length. Touched only
+// from the single server-loop thread in v1 (mtx documented above). `scanned`
+// guards the one-time startup scan; `dir_mtime`/`last_refresh` drive the cheap
+// cross-process refresh (see auto_index_refresh): a peer process that writes a new
+// snapshot bumps the slot-save directory's mtime, which the next lookup notices and
+// re-scans — so a freshly-created cache becomes visible to OTHER processes without a
+// restart (no inotify/no background thread; one stat per gated check).
+struct auto_cache_index {
+    std::mutex mtx;
+    std::unordered_map<uint64_t, auto_cache_entry> by_boundary;
+    std::unordered_set<std::string> indexed_files;    // state paths already scanned (incremental refresh)
+    bool scanned = false;
+    std::filesystem::file_time_type dir_mtime{};      // dir mtime as of the last scan
+    std::chrono::steady_clock::time_point last_refresh{}; // throttle: skip stat storms in a burst
+};
+
+// Cross-process refresh throttle: at most one dir-mtime stat per this interval on the hot lookup
+// path (a forced refresh on a lookup miss bypasses it). Sub-second so a peer's new snapshot is
+// visible within ~1 prefill of being written — effectively immediate from the user's view.
+static constexpr int AUTO_REFRESH_MIN_MS = 1000;
+
+// Sidecar path twins for an auto snapshot's state file. `.logits` is the committed
+// (byte-identical) regenerate sidecar; `.meta` is the NEW tokens+fingerprint
+// sidecar this feature adds so the startup scan / pre-restore verify reads only a
+// tiny file, never the multi-GB state.
+static std::string slot_meta_sidecar_path(const std::string & state_filepath) {
+    return state_filepath + ".meta";
+}
+
+// Best-effort atomic write of the .meta sidecar (LE, temp+rename — the exact idiom
+// of slot_logits_write). Layout: magic/version, fingerprint fields, tok_count,
+// chain_hash, then int32 tokens[tok_count]. Returns true on success. Never throws.
+static bool slot_meta_write(const std::string & state_filepath,
+                            const model_fp & fp,
+                            const llama_tokens & toks,
+                            uint64_t chain_hash) {
+    const std::string sidecar = slot_meta_sidecar_path(state_filepath);
+    const std::string tmp     = sidecar + ".tmp";
+
+    std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+    if (!f) {
+        return false;
+    }
+    auto put_u32 = [&](uint32_t v) {
+        const unsigned char b[4] = {
+            (unsigned char)( v        & 0xFF),
+            (unsigned char)((v >> 8)  & 0xFF),
+            (unsigned char)((v >> 16) & 0xFF),
+            (unsigned char)((v >> 24) & 0xFF),
+        };
+        f.write((const char *) b, 4);
+    };
+    auto put_u64 = [&](uint64_t v) {
+        put_u32((uint32_t)(v & 0xFFFFFFFFu));
+        put_u32((uint32_t)(v >> 32));
+    };
+    put_u32(SLOT_META_MAGIC);
+    put_u32(SLOT_META_VERSION);
+    put_u64(fp.fp_model);
+    put_u32(fp.fp_n_vocab);
+    put_u32(fp.fp_n_ctx_train);
+    put_u32(fp.fp_n_embd);
+    put_u32(fp.fp_n_layer);
+    put_u32(fp.fp_rope_type);
+    put_u32(fp.fp_cache_k);
+    put_u32(fp.fp_cache_v);
+    put_u32(fp.fp_n_ctx);
+    put_u32(fp.fp_kv_full);
+    put_u32(fp.fp_block);
+    put_u64(fp.fp_rope_scale);
+    // rope_freq_base + YaRN fingerprint fields
+    put_u64(fp.fp_rope_base);
+    put_u32(fp.fp_yarn_ext);
+    put_u32(fp.fp_yarn_attn);
+    put_u32(fp.fp_yarn_beta_fast);
+    put_u32(fp.fp_yarn_beta_slow);
+    put_u32(fp.fp_yarn_orig_ctx);
+    put_u64(fp.fp_lora);
+    // mmproj deployment-shape bit — refuses cross-shape restores.
+    put_u32(fp.fp_mmproj_loaded);
+    put_u32((uint32_t) toks.size());
+    put_u64(chain_hash);
+    // token IDs as raw LE int32 (llama_token == int32_t; llama.cpp's on-disk
+    // contract is native-LE, matching slot_logits_write's float payload).
+    f.write((const char *) toks.data(), (std::streamsize) toks.size() * sizeof(int32_t));
+    f.flush();
+    if (!f.good()) {
+        f.close();
+        std::error_code ec;
+        std::filesystem::remove(tmp, ec);
+        return false;
+    }
+    f.close();
+    std::error_code ec;
+    std::filesystem::rename(tmp, sidecar, ec); // atomic replace
+    if (ec) {
+        std::filesystem::remove(tmp, ec);
+        return false;
+    }
+    return true;
+}
+
+// Read a .meta sidecar. Returns true and fills `fp_out` + `toks_out` iff a valid
+// sidecar exists. Any short read / bad magic / version mismatch => false with
+// outputs cleared (invariant 4). Never throws. Note: `chain_hash` is recorded for
+// debuggability but the authority for reuse is always the byte-compared tokens.
+static bool slot_meta_read(const std::string & state_filepath,
+                           model_fp & fp_out,
+                           llama_tokens & toks_out) {
+    fp_out = model_fp{};
+    toks_out.clear();
+    const std::string sidecar = slot_meta_sidecar_path(state_filepath);
+    std::ifstream f(sidecar, std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    auto get_u32 = [&](uint32_t & v) -> bool {
+        unsigned char b[4];
+        f.read((char *) b, 4);
+        if (f.gcount() != 4) {
+            return false;
+        }
+        v = (uint32_t) b[0] | ((uint32_t) b[1] << 8) | ((uint32_t) b[2] << 16) | ((uint32_t) b[3] << 24);
+        return true;
+    };
+    auto get_u64 = [&](uint64_t & v) -> bool {
+        uint32_t lo = 0, hi = 0;
+        if (!get_u32(lo) || !get_u32(hi)) {
+            return false;
+        }
+        v = (uint64_t) lo | ((uint64_t) hi << 32);
+        return true;
+    };
+    uint32_t magic = 0, version = 0;
+    if (!get_u32(magic) || !get_u32(version)) {
+        return false;
+    }
+    if (magic != SLOT_META_MAGIC || version != SLOT_META_VERSION) {
+        return false;
+    }
+    model_fp fp;
+    uint32_t tok_count = 0;
+    uint64_t chain_hash = 0;
+    if (!get_u64(fp.fp_model)         || !get_u32(fp.fp_n_vocab)       || !get_u32(fp.fp_n_ctx_train) ||
+        !get_u32(fp.fp_n_embd)        || !get_u32(fp.fp_n_layer)       || !get_u32(fp.fp_rope_type)   ||
+        !get_u32(fp.fp_cache_k)       || !get_u32(fp.fp_cache_v)       || !get_u32(fp.fp_n_ctx)       ||
+        !get_u32(fp.fp_kv_full)       || !get_u32(fp.fp_block)         || !get_u64(fp.fp_rope_scale)  ||
+        // rope_freq_base + YaRN — must be read in the same order slot_meta_write emits.
+        !get_u64(fp.fp_rope_base)     || !get_u32(fp.fp_yarn_ext)      || !get_u32(fp.fp_yarn_attn)   ||
+        !get_u32(fp.fp_yarn_beta_fast)|| !get_u32(fp.fp_yarn_beta_slow)|| !get_u32(fp.fp_yarn_orig_ctx)||
+        // mmproj deployment-shape bit — read in the same order slot_meta_write emits.
+        !get_u64(fp.fp_lora)          || !get_u32(fp.fp_mmproj_loaded) ||
+        !get_u32(tok_count)           || !get_u64(chain_hash)) {
+        return false;
+    }
+    (void) chain_hash;
+    // sanity-bound the count so a corrupt header cannot make us allocate gigabytes.
+    if (tok_count > (1u << 28)) {
+        return false;
+    }
+    toks_out.resize(tok_count);
+    const std::streamsize want = (std::streamsize) tok_count * (std::streamsize) sizeof(int32_t);
+    f.read((char *) toks_out.data(), want);
+    if (f.gcount() != want) {
+        toks_out.clear();
+        return false;
+    }
+    fp_out = fp;
+    return true;
 }
 
 struct server_slot {
@@ -1006,6 +1363,19 @@ private:
 
     bool sleeping = false;
 
+    // --- auto disk prompt/KV cache (opt-in: --slot-save-auto) ---
+    // Default-constructed: empty and untouched when the feature is OFF (invariant 1).
+    // `cur_fp` is the live model fingerprint, computed once at load (only when enabled).
+    auto_cache_index auto_idx;
+    model_fp         cur_fp;
+
+    // The ONE gate for the entire auto disk cache. When false, NO hook below does
+    // any work (no scan, no hash, no alloc). This is invariant 1 — the first
+    // statement of every auto_* hook is `if (!auto_cache_enabled()) return;`.
+    bool auto_cache_enabled() const {
+        return params_base.slot_save_auto && !params_base.slot_save_path.empty();
+    }
+
     void destroy() {
         spec.reset();
         ctx_dft.reset();
@@ -1026,11 +1396,541 @@ private:
         if (slot.prompt.n_tokens() == 0) {
             return;
         }
+        // Auto-save (write path, invariant 5): persist this slot's KV to disk BEFORE the
+        // in-memory cache drops it. This runs at task-launch time for idle slots (off the
+        // launching task's generation hot path), reusing the exact SLOT_SAVE machinery.
+        // Gate the CALL SITE so the entire call frame is elided when OFF (this is the dominant
+        // idle-slot-flush path under cache_idle_slots=true). The callee keeps its own
+        // first-statement gate as defense-in-depth.
+        if (auto_cache_enabled()) {
+            auto_save_slot_if_useful(slot);
+        }
         SLT_INF(slot, "%s", "saving idle slot to prompt cache\n");
         SLT_DBG(slot, "%s", "__TEST_TAG_CACHE_IDLE_SLOT__\n");
         slot.prompt_save(*prompt_cache);
         slot.prompt_clear(false);
         prompt_cache->update();
+    }
+
+    // ----- auto disk cache: fingerprint, index, restore, save (all gated by auto_cache_enabled()) -----
+
+    // hash of the active LoRA set (ids/scales) for the fingerprint; 0 when no adapter is active.
+    static uint64_t auto_lora_hash(const std::vector<common_adapter_lora_info> & lora) {
+        uint64_t h = 0xcbf29ce484222325ULL;
+        bool any = false;
+        for (const auto & a : lora) {
+            if (a.scale == 0.0f) {
+                continue; // disabled adapter does not affect inference identity
+            }
+            any = true;
+            for (char c : a.path) {
+                h ^= (uint64_t) (unsigned char) c; h *= 0x100000001b3ULL;
+            }
+            uint32_t sc; std::memcpy(&sc, &a.scale, sizeof(sc));
+            h = auto_hash_mix(h, (int32_t) sc);
+        }
+        return any ? h : 0;
+    }
+
+    // Compute the live model fingerprint once at load (invariant 3). Pure-CPU; only called from
+    // an auto_cache_enabled() branch so it costs nothing when OFF.
+    // See README "Automatic disk prompt cache" for which flags invalidate the cache.
+    model_fp auto_compute_fingerprint() const {
+        model_fp fp;
+        // model identity string (arch + params + quant), hardened with size/n_params/n_embd/n_layer.
+        char desc[256] = {0};
+        llama_model_desc(model_tgt, desc, sizeof(desc));
+        uint64_t h = 0xcbf29ce484222325ULL;
+        for (const char * p = desc; *p; ++p) {
+            h ^= (uint64_t) (unsigned char) *p; h *= 0x100000001b3ULL;
+        }
+        const uint64_t sz = llama_model_size(model_tgt);
+        const uint64_t np = llama_model_n_params(model_tgt);
+        h = auto_hash_mix(h, (int32_t) (sz & 0xFFFFFFFFu)); h = auto_hash_mix(h, (int32_t) (sz >> 32));
+        h = auto_hash_mix(h, (int32_t) (np & 0xFFFFFFFFu)); h = auto_hash_mix(h, (int32_t) (np >> 32));
+
+        fp.fp_model       = h;
+        fp.fp_n_vocab     = (uint32_t) llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+        fp.fp_n_ctx_train = (uint32_t) llama_model_n_ctx_train(model_tgt);
+        fp.fp_n_embd      = (uint32_t) llama_model_n_embd(model_tgt);
+        fp.fp_n_layer     = (uint32_t) llama_model_n_layer(model_tgt);
+        fp.fp_rope_type   = (uint32_t) llama_model_rope_type(model_tgt);
+        // K/V cache type has no live-ctx getter — capture from the server's own params (the value
+        // used to construct ctx_tgt). Blob-layout-critical: a Q4_0-KV blob into an F16 ctx corrupts.
+        fp.fp_cache_k     = (uint32_t) params_base.cache_type_k;
+        fp.fp_cache_v     = (uint32_t) params_base.cache_type_v;
+        fp.fp_n_ctx       = (uint32_t) llama_n_ctx_seq(ctx_tgt);
+        fp.fp_kv_full     = (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) ? 1u : 0u;
+        fp.fp_block       = (uint32_t) params_base.slot_save_block;
+        // effective rope scale (positions are baked into the saved state). rope_freq_scale==0 means
+        // "use the model's trained value", so fall back to that for a stable comparison.
+        float rs = params_base.rope_freq_scale != 0.0f
+                       ? params_base.rope_freq_scale
+                       : llama_model_rope_freq_scale_train(model_tgt);
+        uint32_t rsb; std::memcpy(&rsb, &rs, sizeof(rsb));
+        fp.fp_rope_scale  = (uint64_t) rsb;
+        // rope_freq_base + the five YaRN params also bake positions into the saved
+        // KV, so they MUST be part of identity. There is no public getter for the model's trained
+        // rope base, so we normalize "use-model-default" to a single canonical 0 sentinel: when the
+        // operator left the knob at its default (rope_freq_base==0; YaRN floats<0, i.e. -1.0 "auto";
+        // yarn_orig_ctx<=0), we store 0. Two runs that both rely on the model default thus match;
+        // any explicit override (or two different overrides) yields a different fp and refuses
+        // (conservative — a needless miss is safe, a wrong restore is not). yarn_orig_ctx is an int.
+        auto bitcast_f = [](float v) -> uint32_t { uint32_t u; std::memcpy(&u, &v, sizeof(u)); return u; };
+        auto norm_yarn = [&](float v) -> uint32_t { return v < 0.0f ? 0u : bitcast_f(v); }; // <0 == model default
+        const float rb = params_base.rope_freq_base > 0.0f ? params_base.rope_freq_base : 0.0f; // 0 == model default
+        uint32_t rbb; std::memcpy(&rbb, &rb, sizeof(rbb));
+        fp.fp_rope_base      = (uint64_t) rbb;
+        fp.fp_yarn_ext       = norm_yarn(params_base.yarn_ext_factor);
+        fp.fp_yarn_attn      = norm_yarn(params_base.yarn_attn_factor);
+        fp.fp_yarn_beta_fast = norm_yarn(params_base.yarn_beta_fast);
+        fp.fp_yarn_beta_slow = norm_yarn(params_base.yarn_beta_slow);
+        fp.fp_yarn_orig_ctx  = params_base.yarn_orig_ctx > 0 ? (uint32_t) params_base.yarn_orig_ctx : 0u;
+        // LoRA: fingerprint the global adapter set so a snapshot under adapter A never restores
+        // under B. (Per-request adapter overrides additionally gate at the restore hook.)
+        fp.fp_lora        = auto_lora_hash(params_base.lora_adapters);
+        // deployment-shape bit (invariant 3): text-only server vs --mmproj server get
+        // disjoint stores (mmproj-aware rope/projector wiring can change the text KV layout).
+        fp.fp_mmproj_loaded = (mctx != nullptr) ? 1u : 0u;
+        return fp;
+    }
+
+    // Auto-snapshot filename: model-fp prefix lets the startup scan reject foreign-model files by
+    // name before opening anything; chain-hash + token-count make it deterministic across processes
+    // (a same-prefix save from another process yields the same name -> atomic-rename-idempotent).
+    std::string auto_state_filename(uint64_t chain_hash, size_t n_tokens) const {
+        char buf[96]; // "auto-" + 16 hex fp + "-" + 16 hex hash + "-" + up to 20-digit count + ".bin" < 96
+        snprintf(buf, sizeof(buf), "auto-%016" PRIx64 "-%016" PRIx64 "-%zu.bin",
+                 cur_fp.fp_model, chain_hash, n_tokens);
+        return params_base.slot_save_path + std::string(buf);
+    }
+
+    // Insert/keep-longer: an entry replaces an existing boundary only if it covers a longer prefix.
+    void auto_index_insert_locked(uint64_t boundary, const auto_cache_entry & e) {
+        auto it = auto_idx.by_boundary.find(boundary);
+        if (it == auto_idx.by_boundary.end() || it->second.n_tokens < e.n_tokens) {
+            auto_idx.by_boundary[boundary] = e;
+        }
+    }
+
+    // Scan the slot-save dir and (re)build index entries from .meta sidecars: header-only reads
+    // (never the multi-GB state). Each bad/foreign file is skipped individually (invariant 4);
+    // foreign-model files are left on disk (a sibling model may own them). Idempotent: re-running it
+    // only ever keep-longer-inserts the same/new entries (auto_index_insert_locked), so it is safe to
+    // call repeatedly for the cross-process refresh. Records the dir mtime so a refresh can cheaply
+    // tell whether anything changed. CALLER MUST HOLD auto_idx.mtx.
+    void auto_index_scan_locked() {
+        std::error_code mec;
+        const auto dmt = std::filesystem::last_write_time(params_base.slot_save_path, mec);
+        if (!mec) {
+            auto_idx.dir_mtime = dmt; // snapshot the dir mtime we are scanning at
+        }
+        std::error_code ec;
+        for (std::filesystem::directory_iterator it(params_base.slot_save_path, ec), end;
+             !ec && it != end; it.increment(ec)) {
+            std::error_code fec;
+            if (!it->is_regular_file(fec) || fec) {
+                continue;
+            }
+            const std::string p = it->path().string();
+            // only our own state files: basename "auto-*.bin" (sidecars and temps skipped). Requiring
+            // the "auto-" basename prefix rejects foreign/manual .bin files BY NAME before we open any
+            // sidecar — the stated scan optimization.
+            const std::string base = it->path().filename().string();
+            if (base.rfind("auto-", 0) != 0) {
+                continue; // not one of ours
+            }
+            if (p.size() < 4 || p.compare(p.size() - 4, 4, ".bin") != 0) {
+                continue;
+            }
+            // already indexed by a prior scan? cheap skip so a refresh only opens NEW files.
+            if (auto_idx.indexed_files.count(p)) {
+                continue;
+            }
+            model_fp fp;
+            llama_tokens toks;
+            if (!slot_meta_read(p, fp, toks)) {
+                continue; // no/short/corrupt meta -> not indexable (invariant 4)
+            }
+            if (!(fp == cur_fp)) {
+                continue; // foreign model / requant / different ctx geometry (invariant 3)
+            }
+            const auto bhs = auto_block_hashes(toks, params_base.slot_save_block, cur_fp.fp_model);
+            auto_cache_entry e{ p, (uint32_t) toks.size(), fp };
+            for (uint64_t bh : bhs) {
+                auto_index_insert_locked(bh, e);
+            }
+            auto_idx.indexed_files.insert(p);
+        }
+    }
+
+    // One-time startup scan: builds the initial index. Invariant 1: only ever called from an
+    // auto_cache_enabled() branch.
+    void auto_index_scan() {
+        std::lock_guard<std::mutex> lk(auto_idx.mtx);
+        if (auto_idx.scanned) {
+            return;
+        }
+        auto_idx.scanned = true;
+        auto_idx.last_refresh = std::chrono::steady_clock::now();
+        auto_index_scan_locked();
+    }
+
+    // Cross-process refresh: make snapshots that OTHER processes created visible here WITHOUT a
+    // restart. Cheap by design: throttled to at most once per AUTO_REFRESH_MIN_MS, and even then it
+    // only does one stat of the dir mtime — a full re-scan happens ONLY when the dir actually changed
+    // (a peer create/rename/delete bumps the dir mtime) or when `force` is set (a lookup miss, where
+    // we are about to pay a cold prefill anyway so the scan is free in comparison). On a change we
+    // also drop entries whose files a peer evicted. CALLER MUST HOLD auto_idx.mtx.
+    void auto_index_refresh_locked(bool force) {
+        const auto now = std::chrono::steady_clock::now();
+        if (!force &&
+            now - auto_idx.last_refresh < std::chrono::milliseconds(AUTO_REFRESH_MIN_MS)) {
+            return; // throttled: avoid a stat storm during a burst of lookups
+        }
+        auto_idx.last_refresh = now;
+        std::error_code ec;
+        const auto dmt = std::filesystem::last_write_time(params_base.slot_save_path, ec);
+        if (!ec && dmt == auto_idx.dir_mtime && !force) {
+            return; // nothing changed on disk since the last scan
+        }
+        // a peer changed the dir (or forced): re-scan for NEW files, then reconcile deletions.
+        auto_index_scan_locked();
+        auto_index_drop_missing_locked();
+    }
+
+    // Longest-prefix lookup over the request tokens. Returns the candidate whose boundary hash is
+    // the DEEPEST match with a fingerprint equal to the live one. Verification (byte-compare of the
+    // candidate's persisted tokens) is mandatory and done by the caller (invariant 2). O(#blocks).
+    std::optional<auto_cache_entry> auto_index_lookup(const llama_tokens & req) {
+        if (!auto_cache_enabled()) {
+            return std::nullopt; // off by default
+        }
+        const auto bhs = auto_block_hashes(req, params_base.slot_save_block, cur_fp.fp_model);
+        std::lock_guard<std::mutex> lk(auto_idx.mtx);
+        // Cross-process visibility: cheaply pick up snapshots a peer process created since our last
+        // scan (throttled dir-mtime check). Then search; on a MISS, force a re-scan and search again
+        // — the force is justified because a miss means we are about to cold-prefill, so the scan
+        // cost is negligible against it, and a peer's snapshot written <1s ago (within the throttle
+        // window) is still found on this first request rather than only the next one.
+        auto_index_refresh_locked(/*force=*/false);
+        for (int attempt = 0; attempt < 2; ++attempt) {
+            for (size_t k = bhs.size(); k-- > 0; ) { // longest boundary first
+                auto it = auto_idx.by_boundary.find(bhs[k]);
+                if (it == auto_idx.by_boundary.end()) {
+                    continue;
+                }
+                if (!(it->second.fp == cur_fp)) {
+                    continue; // invariant 3
+                }
+                return it->second;
+            }
+            if (attempt == 0) {
+                auto_index_refresh_locked(/*force=*/true); // miss -> rescan once before giving up
+            }
+        }
+        return std::nullopt;
+    }
+
+    // After an LRU eviction (which deletes files silently — ours OR a peer process's), drop index
+    // boundaries pointing at files that no longer exist, and forget them in indexed_files so a future
+    // re-create can be re-indexed. Cheap stat per unique path; keeps index <-> disk consistent (invariant 4).
+    // A lookup that races an eviction and finds a now-deleted file simply fails the load -> prefill.
+    // CALLER MUST HOLD auto_idx.mtx.
+    void auto_index_drop_missing_locked() {
+        std::unordered_set<std::string> gone;
+        for (auto it = auto_idx.by_boundary.begin(); it != auto_idx.by_boundary.end(); ) {
+            std::error_code ec;
+            if (!std::filesystem::exists(it->second.state_path, ec) || ec) {
+                gone.insert(it->second.state_path);
+                it = auto_idx.by_boundary.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        for (const auto & p : gone) {
+            auto_idx.indexed_files.erase(p);
+        }
+    }
+
+    void auto_index_drop_missing() {
+        std::lock_guard<std::mutex> lk(auto_idx.mtx);
+        auto_index_drop_missing_locked();
+    }
+
+    // Restore a disk snapshot INTO `slot`, mirroring the SLOT_RESTORE handler body. Returns true on
+    // success (slot.prompt.tokens / n_past-equivalent + just_restored + restored_logits are set as
+    // for a manual restore). On ANY failure (load <=0, capacity exceeded) the slot seq is left
+    // cleared and false is returned so the caller falls through to a normal prefill (invariant 4).
+    bool do_slot_restore(server_slot & slot, const std::string & filepath,
+                         size_t * out_token_count = nullptr, size_t * out_nread = nullptr) {
+        llama_tokens tokens;
+        tokens.resize(slot.n_ctx);
+        size_t token_count = 0;
+        const size_t nread = llama_state_seq_load_file(
+            ctx_tgt, filepath.c_str(), slot.id, tokens.data(), tokens.size(), &token_count);
+        if (out_nread)       { *out_nread = nread; }
+        if (out_token_count) { *out_token_count = token_count; }
+        if (nread == 0) {
+            slot.prompt.tokens.clear(); // KV may already have been invalidated by the partial load
+            return false;
+        }
+        tokens.resize(token_count);
+        slot.prompt.tokens.clear();
+        slot.prompt.tokens.insert(tokens);
+        slot.just_restored = true;
+
+        // Reconstruct a context checkpoint at the restored position so hybrid/recurrent (and SWA)
+        // models — which cannot partially rewind — can reuse this state for the suffix; other
+        // models do not need it.
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+            const auto ckpt_pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
+            const auto ckpt_pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id);
+            if (ckpt_pos_min >= 0) {
+                slot.prompt.checkpoints.clear();
+                create_checkpoint(slot, 0, ckpt_pos_min, ckpt_pos_max);
+            }
+        }
+
+        // The restored state's running distribution is unknown; invalidate any stale capture so a
+        // later SLOT_SAVE cannot persist a mismatched sidecar.
+        slot.logits_last.clear();
+        slot.logits_last_n_tokens = -1;
+
+        // Load the regenerate logits sidecar (FULL only) so an exact-prompt regenerate can emit the
+        // first token without re-decoding into the restored recurrent state.
+        slot.restored_logits.clear();
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+            const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+            if (slot_logits_read(filepath, nv, (uint32_t) token_count, slot.restored_logits)) {
+                SLT_INF(slot, "loaded logits sidecar (%d vocab, %zu tokens) — regenerate fast-path armed\n", nv, token_count);
+            }
+        }
+        return true;
+    }
+
+    // AUTO-RESTORE wrapper: byte-verify the candidate's persisted tokens against the request prefix
+    // (invariant 2), confirm the fingerprint (invariant 3), then restore. Returns the verified prefix length
+    // actually restored, or 0 if nothing was restored (caller keeps the in-memory prefill path).
+    // `req` is the full request token-ID array; `n_keep_mem` is the in-memory match to beat.
+    int auto_restore_into_slot(server_slot & slot, const auto_cache_entry & cand,
+                               const llama_tokens & req, int n_keep_mem) {
+        // read the small .meta sidecar (tokens + fp) — never opens the multi-GB state file (invariant 5).
+        model_fp disk_fp;
+        llama_tokens disk_toks;
+        if (!slot_meta_read(cand.state_path, disk_fp, disk_toks)) {
+            return 0; // invariant 4
+        }
+        if (!(disk_fp == cur_fp)) {
+            return 0; // invariant 3
+        }
+        // byte-verify: longest common prefix of the persisted tokens and the request (invariant 2).
+        const size_t lim = std::min(disk_toks.size(), req.size());
+        size_t v = 0;
+        while (v < lim && disk_toks[v] == req[v]) {
+            ++v;
+        }
+        // Only WHOLE-block prefixes are valid reuse lengths (hash boundaries).
+        const int B = params_base.slot_save_block;
+        int n_keep_disk;
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+            // a FULL/recurrent/hybrid/SWA state cannot be PARTIALLY rewound —
+            // do_slot_restore loads the ENTIRE L-token snapshot, and a later keep_first(n_past<L)
+            // would issue a PARTIAL common_context_seq_rm that GGML_ABORTs the server (a FULL model's
+            // llama_memory_seq_rm refuses a partial range). So we ONLY auto-restore a FULL snapshot
+            // when the request diverges at or beyond the snapshot end (v == disk_toks.size(), i.e.
+            // the whole snapshot is a verified prefix of the request). If the request diverges INSIDE
+            // the snapshot, refuse and fall back to normal prefill — never restore a FULL snapshot we
+            // would have to partially unwind. (No block-boundary clamp for FULL: only the exact whole
+            // snapshot is a legal restore length here.)
+            if (v != disk_toks.size()) {
+                return 0;
+            }
+            n_keep_disk = (int) disk_toks.size();
+        } else {
+            // Attention (PART) models support per-token partial seq_rm, so a mid-snapshot divergence
+            // is fine: claim the verified prefix clamped down to the last whole block boundary <= v.
+            // An exact full-snapshot match keeps the whole snapshot length.
+            if (v == disk_toks.size()) {
+                n_keep_disk = (int) disk_toks.size();
+            } else {
+                n_keep_disk = (int) (v - (v % (size_t) B));
+            }
+        }
+        if (n_keep_disk <= 0) {
+            return 0;
+        }
+        // MARGIN gate (invariant 5): only pay a multi-GB load if disk strictly beats the
+        // in-memory match by at least one block — never thrash a reload to save a few tokens.
+        if (n_keep_disk < n_keep_mem + B) {
+            return 0;
+        }
+        // Clear the slot's resident KV before loading the snapshot (mirror the restore-continue safe
+        // fallback): seq removal + token/checkpoint clear so the restore writes into an empty seq.
+        llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, -1, -1);
+        slot.prompt.tokens.clear();
+        slot.prompt.checkpoints.clear();
+
+        if (!do_slot_restore(slot, cand.state_path)) {
+            // restore failed -> slot seq already cleared by do_slot_restore; caller reprefills (invariant 4).
+            return 0;
+        }
+        // do_slot_restore loaded the snapshot. For FULL models n_keep_disk == snapshot length (gated
+        // above), so the existing regenerate / suffix-reuse path takes over with no partial
+        // rewind. For attention models the request may diverge inside the snapshot; keep_first(n_past)
+        // + a PARTIAL seq_rm then reprefills the divergent tail (supported for PART). The verified
+        // prefix is what we claim as reused.
+        // Bump the snapshot's mtime so the LRU treats a reused-but-not-rewritten base snapshot as
+        // recently-used (true LRU, not least-recently-written) — critical for the fan-out case where
+        // many requests restore one hot base prefix. Best-effort; never errors the restore (invariant 4).
+        auto_touch_unit(cand.state_path);
+        SLT_INF(slot, "auto-restore: reused %d tokens from disk (in-memory match was %d), file=%s\n",
+                n_keep_disk, n_keep_mem, cand.state_path.c_str());
+        return n_keep_disk;
+    }
+
+    // AUTO-SAVE: persist a slot's KV before it is discarded, keyed by its token-prefix block hash.
+    // Skips redundant writes (an equal-or-longer snapshot already covers this prefix), writes the
+    // state + .logits + .meta as a 3-file unit (atomically, .meta LAST so a torn write is never
+    // indexed), enforces the bounded LRU, then reconciles the index. Invariant 1: first statement
+    // is the gate; invariant 5: only called on slot release/reassign, never during generation.
+    void auto_save_slot_if_useful(server_slot & slot) {
+        if (!auto_cache_enabled()) {
+            return; // off by default
+        }
+        // exclusions reuse the existing guards. NOTE: an idle slot has already been reset(), so
+        // `slot.task` is null here — the just-finished task survives as `slot.task_prev`. Use it for
+        // the generative check (COMPLETION/INFILL only). Gate on the PER-REQUEST `has_media()` (not
+        // the server-wide has_mtmd/mctx) so an --mmproj server still persists its text-only turns;
+        // a turn carrying an image (has_media()==true) is skipped — exactly correct, since token-ids
+        // alone cannot identify image content.
+        const auto & wtask = slot.task ? slot.task : slot.task_prev;
+        if (!wtask || !wtask->need_sampling() || slot.prompt.tokens.has_media()) {
+            return;
+        }
+        // The fingerprint captures the GLOBAL LoRA set; refuse to persist a snapshot taken under a
+        // per-request adapter override that differs from it (invariant 3). (Conservative: a future version
+        // could fold the slot's adapters into the snapshot fingerprint instead.)
+        if (!are_lora_equal(slot.lora, params_base.lora_adapters)) {
+            return;
+        }
+        // get_text_tokens() (not get_tokens()): media-safe accessor that never trips the
+        // get_tokens() GGML_ASSERT(!has_mtmd) under mmproj. For this no-media prompt (has_media()
+        // false, guarded above) it equals the full token-id prefix, so the persisted token stream
+        // and the block-hash key are byte-identical to what a text-only server would write.
+        const llama_tokens toks = slot.prompt.tokens.get_text_tokens();
+        if ((int) toks.size() < params_base.slot_save_block) {
+            return; // < 1 block: not worth a multi-GB write
+        }
+        const auto bhs = auto_block_hashes(toks, params_base.slot_save_block, cur_fp.fp_model);
+        if (bhs.empty()) {
+            return;
+        }
+        const uint64_t full_hash = bhs.back(); // commits the whole whole-block prefix
+        {
+            std::lock_guard<std::mutex> lk(auto_idx.mtx);
+            auto it = auto_idx.by_boundary.find(full_hash);
+            if (it != auto_idx.by_boundary.end() && it->second.n_tokens >= toks.size()) {
+                return; // an equal-or-longer snapshot for this exact prefix already exists
+            }
+        }
+
+        const std::string fname = auto_state_filename(full_hash, toks.size());
+        // cross-process atomicity: the temp path MUST be unique per writer. The final
+        // name (fname) is deterministic (fp + chain hash + tok count), so two processes sharing one
+        // --slot-save-path would otherwise both stream a multi-GB state into the SAME "<fname>.tmp"
+        // and interleave -> a corrupt temp gets renamed over a good final file. We disambiguate the
+        // temp with pid + a per-process monotonic counter, so each writer owns its own complete temp
+        // and the deterministic-name rename is the ONLY shared, atomic step (idempotent: identical
+        // content). The sidecar temps derive from this same unique base so they are unique too.
+        // (nonce is atomic so it stays correct if save I/O is later threaded.)
+        static std::atomic<uint64_t> s_tmp_nonce{0};
+        const uint64_t nonce = s_tmp_nonce.fetch_add(1, std::memory_order_relaxed);
+        const std::string tmp = fname + "." + std::to_string((long) getpid()) + "." +
+                                std::to_string(nonce) + ".tmp";
+
+        // 1) write the state to a per-writer-unique temp path (atomic via rename below). NOTE:
+        //    llama_state_seq_save_file writes in place, so we write to the unique temp then rename — a
+        //    crash mid-write never leaves a corrupt state file the index would trust.
+        const size_t nwrite = llama_state_seq_save_file(ctx_tgt, tmp.c_str(), slot.id,
+                                                        toks.data(), toks.size());
+        if (nwrite == 0) {
+            std::error_code ec; std::filesystem::remove(tmp, ec);
+            return; // invariant 4: disk full / IO error -> generation unaffected
+        }
+        // 2) regenerate logits sidecar on the temp path (FULL only, and only when the captured
+        //    distribution provably belongs to this exact state — the same stamp check SLOT_SAVE uses).
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL &&
+            slot.logits_last_n_tokens == (int32_t) toks.size() && !slot.logits_last.empty()) {
+            const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+            slot_logits_write(tmp, slot.logits_last, nv, (uint32_t) toks.size());
+        }
+        // 3) meta sidecar on the temp path (tokens + fingerprint). Written but renamed LAST.
+        if (!slot_meta_write(tmp, cur_fp, toks, full_hash)) {
+            std::error_code ec;
+            std::filesystem::remove(tmp, ec);
+            std::filesystem::remove(slot_logits_sidecar_path(tmp), ec);
+            std::filesystem::remove(slot_meta_sidecar_path(tmp), ec);
+            return; // invariant 4
+        }
+        // 4) atomic publish: rename state first, then sidecars to their final names. .meta is the
+        //    last to appear, so the startup scan (which keys on .meta) never sees a half-written unit.
+        std::error_code ec;
+        std::filesystem::rename(tmp, fname, ec);
+        if (ec) {
+            std::filesystem::remove(tmp, ec);
+            std::filesystem::remove(slot_logits_sidecar_path(tmp), ec);
+            std::filesystem::remove(slot_meta_sidecar_path(tmp), ec);
+            return; // invariant 4
+        }
+        std::filesystem::rename(slot_logits_sidecar_path(tmp), slot_logits_sidecar_path(fname), ec);
+        ec.clear();
+        std::filesystem::rename(slot_meta_sidecar_path(tmp), slot_meta_sidecar_path(fname), ec);
+        // the .meta is the scan key — a unit whose .meta never landed must NOT be
+        // published. If the meta rename failed, the .bin is already in place but unindexable, so we
+        // unlink the orphan .bin (and any leftover temps) and DO NOT insert into the in-memory index.
+        // Leaving the .bin would waste disk and a restart scan would skip it anyway (no .meta).
+        if (ec) {
+            std::error_code rec;
+            std::filesystem::remove(fname, rec);
+            std::filesystem::remove(slot_logits_sidecar_path(fname), rec);
+            std::filesystem::remove(slot_logits_sidecar_path(tmp), rec);
+            std::filesystem::remove(slot_meta_sidecar_path(tmp), rec);
+            return; // invariant 4: don't index a unit whose .meta (the scan key) never published
+        }
+
+        SLT_INF(slot, "auto-save: persisted %zu tokens to %s\n", toks.size(), fname.c_str());
+
+        // index insert (every boundary -> this snapshot), then bounded-LRU + reconcile.
+        {
+            std::lock_guard<std::mutex> lk(auto_idx.mtx);
+            auto_cache_entry e{ fname, (uint32_t) toks.size(), cur_fp };
+            for (uint64_t bh : bhs) {
+                auto_index_insert_locked(bh, e);
+            }
+            auto_idx.indexed_files.insert(fname); // remember our own write so a refresh won't re-open it
+        }
+        if (params_base.slot_save_max_count > 0 || params_base.slot_save_max_bytes > 0) {
+            bool oversized = false;
+            slot_save_enforce_limits(params_base.slot_save_path,
+                                     params_base.slot_save_max_count,
+                                     params_base.slot_save_max_bytes,
+                                     fname, oversized);
+        }
+        // Reconcile index with what the LRU kept (ours or a peer's) AND adopt the post-write dir
+        // mtime as our scan baseline — both under ONE lock. Re-baselining here means OUR OWN
+        // save+evict does not make the next lookup think a PEER changed the dir (which would force a
+        // redundant full re-scan); a real peer write afterwards bumps the mtime again -> still
+        // detected. CALLER holds no lock here.
+        {
+            std::lock_guard<std::mutex> lk(auto_idx.mtx);
+            auto_index_drop_missing_locked();
+            std::error_code mec;
+            const auto dmt = std::filesystem::last_write_time(params_base.slot_save_path, mec);
+            if (!mec) {
+                auto_idx.dir_mtime = dmt;
+            }
+        }
     }
 
     void handle_sleeping_state(bool new_state) {
@@ -1433,6 +2333,16 @@ private:
         // propagate new defaults back to caller
         params = params_base;
 
+        // AUTO disk prompt/KV cache (invariant 1): compute the model fingerprint and build the
+        // longest-prefix index ONCE, header-only — but ONLY when the feature is enabled. When OFF
+        // this is a single boolean test and nothing else (no fingerprint, no scan, no allocation).
+        if (auto_cache_enabled()) {
+            cur_fp = auto_compute_fingerprint();
+            auto_index_scan();
+            SRV_INF("auto disk prompt cache enabled: indexed %zu prefix boundaries from %s (block=%d)\n",
+                    auto_idx.by_boundary.size(), params_base.slot_save_path.c_str(), params_base.slot_save_block);
+        }
+
         if (!is_resume) {
             return init();
         }
@@ -1618,6 +2528,17 @@ private:
 
         if (ret) {
             const auto & tokens = ret->prompt.tokens;
+
+            // Second auto-save site for when cache_idle_slots is OFF (the idle-flush path that calls
+            // slot_save_and_clear -> auto_save never runs). Here get_available_slot just picked `ret`
+            // for a new task and `update_cache` signals its prior KV is about to be discarded, so we
+            // persist it before the prompt_save/prompt_load below overwrites it. Mutually exclusive
+            // with the primary site via !cache_idle_slots, so no double-save. Reads `update_cache`
+            // BEFORE the `&& prompt_cache` narrowing so disk save works without --cache-ram. The
+            // callee carries all correctness gates; `ret` is idle so this never stalls generation.
+            if (auto_cache_enabled() && !params_base.cache_idle_slots && update_cache) {
+                auto_save_slot_if_useful(*ret);
+            }
 
             update_cache = update_cache && prompt_cache;
 
@@ -2484,7 +3405,7 @@ private:
                     const llama_tokens & tokens = slot->prompt.tokens.get_tokens();
                     const size_t nwrite = llama_state_seq_save_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
 
-                    // Feature A: persist this slot's last-token logits as a sidecar (FULL/recurrent
+                    // persist this slot's last-token logits as a sidecar (FULL/recurrent
                     // only). Best-effort — a missing/failed sidecar simply disables the regenerate
                     // fast-path for this snapshot. NOT folded into res->n_bytes (that contract stays
                     // "state-file bytes only").
@@ -2510,7 +3431,7 @@ private:
                         }
                     }
 
-                    // Feature C: enforce the bounded slot-save store (LRU by mtime). If this single
+                    // enforce the bounded slot-save store (LRU by mtime). If this single
                     // snapshot exceeds the byte cap, reject the save instead of evicting everything.
                     if (nwrite > 0 &&
                         (params_base.slot_save_max_count > 0 || params_base.slot_save_max_bytes > 0)) {
@@ -2561,52 +3482,14 @@ private:
                     std::string filename = task.slot_action.filename;
                     std::string filepath = task.slot_action.filepath;
 
-                    llama_tokens tokens;
-                    tokens.resize(slot->n_ctx);
+                    // Shared restore body (also used by the transparent auto-restore path): loads the
+                    // state file into seq slot->id, sets just_restored + restored_logits, rebuilds the
+                    // FULL-model checkpoint. On a load failure the slot seq is cleared and we error.
                     size_t token_count = 0;
-                    size_t nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), tokens.size(), &token_count);
-                    if (nread == 0) {
-                        slot->prompt.tokens.clear(); // KV may already been invalidated?
+                    size_t nread = 0;
+                    if (!do_slot_restore(*slot, filepath, &token_count, &nread)) {
                         send_error(task, "Unable to restore slot, no available space in KV cache or invalid slot save file", ERROR_TYPE_INVALID_REQUEST);
                         break;
-                    }
-                    tokens.resize(token_count);
-                    slot->prompt.tokens.clear();
-                    slot->prompt.tokens.insert(tokens);
-                    slot->just_restored = true;
-
-                    // Reconstruct a context checkpoint at the restored position so the prompt-cache
-                    // reuse path can reuse this state on the next matching request. Hybrid/recurrent
-                    // (and SWA) models cannot partially rewind their memory, so without a checkpoint
-                    // the matcher forces a full re-prefill; other models do not need it.
-                    if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
-                        const auto ckpt_pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot->id);
-                        const auto ckpt_pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot->id);
-                        if (ckpt_pos_min >= 0) {
-                            slot->prompt.checkpoints.clear();
-                            create_checkpoint(*slot, 0, ckpt_pos_min, ckpt_pos_max);
-                        }
-                    }
-
-                    // The restored state's freshly-sampled "running" distribution is unknown: the
-                    // logits in `logits_last` (if any) belong to a PRIOR generation on this slot
-                    // object, NOT to the restored state. Invalidate them so a subsequent SLOT_SAVE
-                    // (e.g. a restore -> re-checkpoint with no intervening decode) cannot persist a
-                    // stale, mismatched sidecar. (Belt-and-suspenders: the SLOT_SAVE stamp check
-                    // already blocks this, since the stamp no longer equals the restored length.)
-                    slot->logits_last.clear();
-                    slot->logits_last_n_tokens = -1;
-
-                    // Feature A/B: load the logits sidecar (if any) so an exact-prompt regenerate
-                    // can emit the first token without re-decoding into the restored recurrent state.
-                    // The token-count check binds the sidecar to exactly this restored state.
-                    // On any failure restored_logits stays empty and Feature B falls back safely.
-                    slot->restored_logits.clear();
-                    if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
-                        const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
-                        if (slot_logits_read(filepath, nv, (uint32_t) token_count, slot->restored_logits)) {
-                            SLT_INF(*slot, "loaded logits sidecar (%d vocab, %zu tokens) — regenerate fast-path armed\n", nv, token_count);
-                        }
                     }
 
                     const int64_t t_end = ggml_time_us();
@@ -3028,6 +3911,44 @@ private:
                                 // reuse any previously computed tokens that are common with the new prompt
                                 n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
 
+                                // ===== AUTO-RESTORE: cold/cross-process KV reuse from disk (opt-in) ==========
+                                // If the in-memory match (n_past) is POOR and the disk index holds a snapshot
+                                // whose persisted tokens are a verified, fingerprint-matching, longer prefix of
+                                // this request, restore it INTO the slot and RECOMPUTE n_past so all downstream
+                                // machinery runs unchanged — agnostic to HOW the tokens arrived. Gated on the
+                                // PER-REQUEST has_media() (not the server-wide has_mtmd) so an --mmproj server
+                                // still caches its text-only turns: a no-media prompt has no NULL placeholders,
+                                // so get_text_tokens() equals the full token-id prefix and does not trip the
+                                // get_tokens() GGML_ASSERT(!has_mtmd); a turn carrying an image (and every turn
+                                // after it) is skipped. auto_restore_into_slot byte-verifies tokens + fingerprint
+                                // and falls back to a normal prefill on any mismatch/failure (invariants 2/3/4).
+                                // media-prefix caching intentionally unsupported: token-ids cannot identify image content.
+                                if (auto_cache_enabled()
+                                        && slot.task->need_sampling()        // generative only (not embed/rerank)
+                                        && !slot.prompt.tokens.has_media()   // no media in THIS request
+                                        && slot.alora_invocation_start <= 0      // aLoRA caching bound (mirror below)
+                                        && are_lora_equal(slot.lora, params_base.lora_adapters)) { // fp captures global LoRA (invariant 3)
+                                    // get_text_tokens() (not get_tokens()): media-safe accessor that never asserts
+                                    // under has_mtmd and, for this no-media prompt, equals the full token-id prefix.
+                                    const llama_tokens req = input_tokens.get_text_tokens();
+                                    if (auto cand = auto_index_lookup(req)) {
+                                        // auto_restore_into_slot may CLEAR the slot
+                                        // (KV seq + prompt.tokens) and then have do_slot_restore FAIL
+                                        // (corrupt/short .bin, KV-capacity exceeded, racing LRU eviction
+                                        // deleting the file mid-read). In that case the slot tokens are now
+                                        // empty. We therefore RECOMPUTE n_past UNCONDITIONALLY after any
+                                        // attempt — not only on success — so a cleared-but-failed restore
+                                        // falls back to n_past=0 (clean cold prefill) instead of carrying a
+                                        // stale n_keep_mem>0 into keep_first() on an empty token vector
+                                        // (which would GGML_ASSERT/abort). The recompute is harmless on the
+                                        // early-return-before-clear paths (margin/fp/verify rejects): those
+                                        // leave prompt.tokens untouched, so the LCP is identical to before.
+                                        auto_restore_into_slot(slot, *cand, req, (int) n_past);
+                                        n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
+                                    }
+                                }
+                                // ===== end AUTO-RESTORE =====================================================
+
                                 // if there is an alora invoked, don't cache after the invocation start
                                 if (slot.alora_invocation_start > 0) {
                                     SLT_DBG(slot, "only caching to alora invocation start (n_past = %d, alora_invocation_start = %d)\n", n_past, slot.alora_invocation_start);
@@ -3108,7 +4029,7 @@ private:
                             // the largest pos_min required for a checkpoint to be useful
                             const auto pos_min_thold = std::max(0, pos_next - n_swa - 1);
 
-                            // ===== Feature B: restore-continue (regenerate fast-path) ====================
+                            // ===== restore-continue (regenerate fast-path) ==============================
                             // A just-restored FULL/recurrent slot receiving the EXACT restored tokens (no
                             // suffix) cannot rewind its memory: the normal path would re-decode into the
                             // already-occupied sequence and crash (the pure-recurrent gate at the relaxed
@@ -3229,7 +4150,7 @@ private:
                                 pos_next = 0; // mirror the do_reset path; keep the stale full-length value from leaking into the checkpoint-erase loop below
                                 // fall through to the normal guard below with an empty sequence (safe)
                             }
-                            // ===== end Feature B ========================================================
+                            // ===== end restore-continue =================================================
 
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
@@ -3812,7 +4733,7 @@ private:
 
                 llama_token id = common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, tok_idx);
 
-                // Feature A: capture this slot's last-token full-vocab logits for a possible disk
+                // capture this slot's last-token full-vocab logits for a possible disk
                 // save. Cost: one ~n_vocab*4-byte copy per decoded token, incurred ONLY on
                 // FULL/recurrent models AND only when slot saving is enabled (--slot-save-path set);
                 // attention models and servers without slot-save pay nothing at all. The copy is

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -20,8 +20,10 @@
 #include <cstddef>
 #include <cinttypes>
 #include <exception>
+#include <fstream>
 #include <memory>
 #include <filesystem>
+#include <set>
 #include <utility>
 
 // fix problem with std::min and std::max
@@ -51,6 +53,280 @@ enum server_state {
     SERVER_STATE_LOADING_MODEL,  // Server is starting up, model not fully loaded yet
     SERVER_STATE_READY,          // Server is ready and model is loaded
 };
+
+// --- KV restore-reuse: logits sidecar (Feature A) -------------------------------
+// When a slot's full state is saved to disk (SLOT_SAVE) for a recurrent/hybrid (FULL) model,
+// we additionally persist the last decoded token's full-vocab logits in a small sidecar file
+// (<state>.logits). On SLOT_RESTORE of an exact-prompt "regenerate" request, those logits let
+// the server emit the first token WITHOUT re-decoding into the (un-rewindable) restored
+// recurrent state — which would otherwise crash. The sidecar is independent of libllama's
+// state-file format (so that format is left untouched) and is purely best-effort: any
+// missing/corrupt/vocab-mismatched sidecar degrades gracefully to the existing behavior.
+static constexpr uint32_t SLOT_LOGITS_MAGIC   = 0x474C4B4Cu; // "LKLG" (llama kv logits), LE
+static constexpr uint32_t SLOT_LOGITS_VERSION = 1u;
+
+static std::string slot_logits_sidecar_path(const std::string & state_filepath) {
+    return state_filepath + ".logits";
+}
+
+// Best-effort write of the logits sidecar. Returns the number of bytes written (0 on failure or
+// when there is nothing valid to write). Never throws. The file is written to a temp path and
+// atomically renamed so a partial/interrupted write can never leave a corrupt sidecar in place.
+// Fields are serialized byte-by-byte little-endian (not a raw struct fwrite) for portability;
+// the float payload is documented LE-only, matching llama.cpp's native-LE state-file contract.
+static size_t slot_logits_write(const std::string & state_filepath,
+                                const std::vector<float> & logits,
+                                int32_t n_vocab,
+                                uint32_t n_tokens) {
+    if (logits.empty() || (int32_t) logits.size() != n_vocab || n_vocab <= 0) {
+        return 0;
+    }
+    const std::string sidecar = slot_logits_sidecar_path(state_filepath);
+    const std::string tmp     = sidecar + ".tmp";
+
+    std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+    if (!f) {
+        return 0;
+    }
+    auto put_u32 = [&](uint32_t v) {
+        const unsigned char b[4] = {
+            (unsigned char)( v        & 0xFF),
+            (unsigned char)((v >> 8)  & 0xFF),
+            (unsigned char)((v >> 16) & 0xFF),
+            (unsigned char)((v >> 24) & 0xFF),
+        };
+        f.write((const char *) b, 4);
+    };
+    put_u32(SLOT_LOGITS_MAGIC);
+    put_u32(SLOT_LOGITS_VERSION);
+    put_u32((uint32_t) n_vocab);
+    put_u32(n_tokens);
+    f.write((const char *) logits.data(), (std::streamsize) logits.size() * sizeof(float));
+    f.flush();
+    if (!f.good()) {
+        f.close();
+        std::error_code ec;
+        std::filesystem::remove(tmp, ec);
+        return 0;
+    }
+    f.close();
+    std::error_code ec;
+    std::filesystem::rename(tmp, sidecar, ec); // atomic replace
+    if (ec) {
+        std::filesystem::remove(tmp, ec);
+        return 0;
+    }
+    return 16 + logits.size() * sizeof(float);
+}
+
+// Read a logits sidecar. Returns true and fills `out` (size n_vocab) iff a valid sidecar exists
+// whose vocab matches `expect_n_vocab` AND whose recorded token count matches `expect_n_tokens`
+// (the count of the state just restored). The token-count check is AUTHORITATIVE: it binds the
+// sidecar to the exact state it was saved against, so a sidecar that was somehow written for a
+// different state length can never be reused. Any mismatch / short read / missing file => false
+// with `out` cleared, so the caller falls back to existing behavior. Never throws.
+static bool slot_logits_read(const std::string & state_filepath,
+                             int32_t expect_n_vocab,
+                             uint32_t expect_n_tokens,
+                             std::vector<float> & out) {
+    out.clear();
+    if (expect_n_vocab <= 0) {
+        return false;
+    }
+    const std::string sidecar = slot_logits_sidecar_path(state_filepath);
+    std::ifstream f(sidecar, std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    auto get_u32 = [&](uint32_t & v) -> bool {
+        unsigned char b[4];
+        f.read((char *) b, 4);
+        if (f.gcount() != 4) {
+            return false;
+        }
+        v = (uint32_t) b[0] | ((uint32_t) b[1] << 8) | ((uint32_t) b[2] << 16) | ((uint32_t) b[3] << 24);
+        return true;
+    };
+    uint32_t magic = 0, version = 0, n_vocab = 0, n_tokens = 0;
+    if (!get_u32(magic) || !get_u32(version) || !get_u32(n_vocab) || !get_u32(n_tokens)) {
+        return false;
+    }
+    if (magic != SLOT_LOGITS_MAGIC || version != SLOT_LOGITS_VERSION ||
+        (int32_t) n_vocab != expect_n_vocab || n_tokens != expect_n_tokens) {
+        return false;
+    }
+    out.resize(n_vocab);
+    const std::streamsize want = (std::streamsize) n_vocab * (std::streamsize) sizeof(float);
+    f.read((char *) out.data(), want);
+    if (f.gcount() != want) {
+        out.clear();
+        return false;
+    }
+    return true;
+}
+
+// --- KV restore-reuse: bounded slot-save store (Feature C) ----------------------
+// One slot-save snapshot = a state file plus its optional <name>.logits sidecar; the two are
+// always evicted together as a single unit, keyed by the state file's mtime (LRU).
+struct slot_save_unit {
+    std::string state_path;
+    std::string sidecar_path; // "" if none
+    uintmax_t   bytes = 0;
+    std::filesystem::file_time_type mtime;
+};
+
+// Enforce --slot-save-max-count / --slot-save-max-bytes over `dir` using LRU-by-mtime eviction.
+// `just_written` is the state path that was just saved: it is never evicted, but if it ALONE
+// exceeds the byte cap it is deleted (with its sidecar) and `oversized` is set so the caller can
+// reject the save rather than evict everything else. Operates strictly within `dir`; uses only
+// the error_code std::filesystem overloads so it never throws across the server loop.
+//
+// IMPORTANT: when a cap is set, --slot-save-path is treated as a server-owned store — any regular
+// file in it (other than recognized "<X>.logits" sidecars and "*.tmp" temporaries) is an eviction
+// candidate. Point --slot-save-max-count/-mb at a DEDICATED directory; do not mix unrelated files
+// into the slot-save directory. (With no caps set — the default unless explicitly enabled — nothing
+// is ever deleted and the directory is left exactly as before.)
+// `just_written` is the exact filepath string the server built as `slot_save_path + filename`;
+// directory_iterator(dir) over that same `slot_save_path` yields identically-spelled path strings
+// on POSIX (the production target), so raw string equality correctly identifies the just-saved
+// unit. (Not used on Windows in practice; if ever needed there, switch to filename comparison.)
+static void slot_save_enforce_limits(const std::string & dir,
+                                     int32_t max_count, int64_t max_bytes,
+                                     const std::string & just_written,
+                                     bool & oversized) {
+    oversized = false;
+    if (max_count <= 0 && max_bytes <= 0) {
+        return; // both unlimited
+    }
+
+    std::error_code ec;
+    std::vector<slot_save_unit> units;
+    uintmax_t this_unit_bytes = 0;
+
+    // First pass: enumerate every regular file once and record the full set of paths so we can
+    // tell a real sidecar (sibling of a state file we wrote) from a state file a client happened
+    // to name "foo.logits". We must NOT blindly skip every "*.logits" — fs_validate_filename
+    // allows that suffix, so a state file literally named "foo.logits" would otherwise escape both
+    // caps entirely. Only "<X>.logits" where "<X>" also exists is treated as a sidecar.
+    std::vector<std::string> all_files;
+    {
+        std::set<std::string> present;
+        for (std::filesystem::directory_iterator it(dir, ec), end; !ec && it != end; it.increment(ec)) {
+            std::error_code fec;
+            if (!it->is_regular_file(fec) || fec) {
+                continue;
+            }
+            all_files.push_back(it->path().string());
+            present.insert(all_files.back());
+        }
+
+        for (const std::string & p : all_files) {
+            std::error_code fec;
+            // in-flight temp files are never counted or evicted (a concurrent save owns them)
+            if (p.size() >= 4 && p.compare(p.size() - 4, 4, ".tmp") == 0) {
+                continue;
+            }
+            // a "<X>.logits" file is a sidecar ONLY when its state file "<X>" is also present;
+            // accounted together with that state file below, so skip it here.
+            if (p.size() >= 7 && p.compare(p.size() - 7, 7, ".logits") == 0 &&
+                present.count(p.substr(0, p.size() - 7))) {
+                continue;
+            }
+            // reap an ORPHANED sidecar (its state file was evicted/lost): otherwise these silently
+            // accumulate (we never count them) and eat real on-disk space forever.
+            if (p.size() >= 7 && p.compare(p.size() - 7, 7, ".logits") == 0 &&
+                !present.count(p.substr(0, p.size() - 7))) {
+                std::filesystem::remove(p, fec);
+                continue;
+            }
+
+            slot_save_unit u;
+            u.state_path = p;
+            u.bytes = std::filesystem::file_size(p, fec);
+            if (fec) {
+                continue;
+            }
+            const std::string side = p + ".logits";
+            if (present.count(side)) {
+                const auto sb = std::filesystem::file_size(side, fec);
+                if (!fec) {
+                    u.sidecar_path = side;
+                    u.bytes += sb;
+                }
+            }
+            u.mtime = std::filesystem::last_write_time(p, fec);
+            if (fec) {
+                continue;
+            }
+
+            if (p == just_written) {
+                this_unit_bytes = u.bytes;
+            }
+            units.push_back(std::move(u));
+        }
+    }
+
+    // a single snapshot larger than the byte cap is rejected: delete only the just-written unit,
+    // do NOT cascade-evict every other (valid) snapshot to make room for something that can't fit.
+    // NOTE: intentionally a no-op when max_bytes == 0 (byte cap disabled); in count-only mode an
+    // individual snapshot's size is never bounded — only --slot-save-max-mb bounds per-snapshot size.
+    if (max_bytes > 0 && this_unit_bytes > (uintmax_t) max_bytes) {
+        for (const auto & u : units) {
+            if (u.state_path == just_written) {
+                std::filesystem::remove(u.state_path, ec);
+                if (!u.sidecar_path.empty()) {
+                    std::filesystem::remove(u.sidecar_path, ec);
+                }
+                break;
+            }
+        }
+        oversized = true;
+        return;
+    }
+
+    std::sort(units.begin(), units.end(),
+              [](const slot_save_unit & a, const slot_save_unit & b) { return a.mtime < b.mtime; }); // oldest first
+
+    size_t    count = units.size();
+    uintmax_t total = 0;
+    for (const auto & u : units) {
+        total += u.bytes;
+    }
+    size_t idx = 0;
+
+    auto evict_oldest = [&]() -> bool {
+        while (idx < units.size() && units[idx].state_path == just_written) {
+            idx++; // never evict the snapshot we just wrote
+        }
+        if (idx >= units.size()) {
+            return false;
+        }
+        const auto & u = units[idx];
+        std::filesystem::remove(u.state_path, ec);
+        if (!u.sidecar_path.empty()) {
+            std::filesystem::remove(u.sidecar_path, ec);
+        }
+        total -= std::min(total, (uintmax_t) u.bytes);
+        count = (count > 0) ? count - 1 : 0;
+        idx++;
+        return true;
+    };
+
+    if (max_count > 0) {
+        while (count > (size_t) max_count) {
+            if (!evict_oldest()) {
+                break;
+            }
+        }
+    }
+    if (max_bytes > 0) {
+        while (total > (uintmax_t) max_bytes) {
+            if (!evict_oldest()) {
+                break;
+            }
+        }
+    }
+}
 
 struct server_slot {
     int id;
@@ -99,6 +375,21 @@ struct server_slot {
     bool has_new_line   = false;
     bool truncated      = false;
     bool just_restored  = false; // set on disk slot-restore; one-shot, gates restored-slot KV reuse
+
+    // --- KV restore-reuse (logits sidecar) ---
+    // Full-vocab logits of this slot's most recently sampled token, captured at sample time
+    // (only populated for FULL/recurrent models when --slot-save-path is set). Serialized to the
+    // <state>.logits sidecar on SLOT_SAVE so a later exact-prompt "regenerate" can emit the first
+    // token WITHOUT re-decoding into the (un-rewindable) restored recurrent state.
+    std::vector<float> logits_last;     // size n_vocab when valid, else empty
+    // Token count of the prompt-state that `logits_last` corresponds to (i.e. the slot's KV/token
+    // length at the moment of capture). Used to BIND the captured distribution to a specific state:
+    // a sidecar is only written when this equals the saved snapshot's token_count, so a stale
+    // distribution (e.g. left over from a prior task, or skipped on a spec-decode step) can never
+    // be serialized against a mismatched state. -1 = no valid capture.
+    int32_t logits_last_n_tokens = -1;
+    // Logits loaded from a sidecar at SLOT_RESTORE, consumed once by the restore-continue path.
+    std::vector<float> restored_logits; // size n_vocab when a valid sidecar was loaded, else empty
 
     stop_type stop;
 
@@ -214,6 +505,12 @@ struct server_slot {
 
         // clear alora start
         alora_invocation_start = -1;
+
+        // one-shot; never carry restored sidecar logits into a non-restore request.
+        // NOTE: logits_last is deliberately NOT cleared here — it is the slot's running
+        // "last sampled distribution" and must survive into the idle state so a subsequent
+        // SLOT_SAVE can serialize it.
+        restored_logits.clear();
     }
 
     void init_sampler() const {
@@ -383,8 +680,12 @@ struct server_slot {
 
         timings.prompt_n            = n_prompt_tokens_processed;
         timings.prompt_ms           = t_prompt_processing;
-        timings.prompt_per_token_ms = t_prompt_processing / n_prompt_tokens_processed;
-        timings.prompt_per_second   = 1e3 / t_prompt_processing * n_prompt_tokens_processed;
+        // Guard against n_prompt_tokens_processed == 0 (e.g. the restore-continue regenerate
+        // fast-path, where the entire prompt is reused and zero tokens are re-processed). Without
+        // this, the divisions emit inf/NaN which then serialize as invalid JSON in the response's
+        // "timings" object.
+        timings.prompt_per_token_ms = n_prompt_tokens_processed > 0 ? t_prompt_processing / n_prompt_tokens_processed : 0.0;
+        timings.prompt_per_second   = n_prompt_tokens_processed > 0 ? 1e3 / t_prompt_processing * n_prompt_tokens_processed : 0.0;
 
         timings.predicted_n            = n_decoded;
         timings.predicted_ms           = t_token_generation;
@@ -1392,6 +1693,13 @@ private:
     }
 
     bool launch_slot_with_task(server_slot & slot, server_task && task) {
+        // A new task is being assigned to this slot: its prompt may differ from whatever produced
+        // the slot's current `logits_last` (even at the same token count). Invalidate the capture so
+        // a SLOT_SAVE issued on the new prompt can never serialize a stale, mismatched distribution.
+        // The stamp is re-established only by a real decode of the new prompt (the capture point).
+        slot.logits_last.clear();
+        slot.logits_last_n_tokens = -1;
+
         // process per-request lora adapters
         if (!task.params.lora.empty()) {
             auto task_loras = construct_lora_list(task.params.lora);
@@ -2176,6 +2484,49 @@ private:
                     const llama_tokens & tokens = slot->prompt.tokens.get_tokens();
                     const size_t nwrite = llama_state_seq_save_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
 
+                    // Feature A: persist this slot's last-token logits as a sidecar (FULL/recurrent
+                    // only). Best-effort — a missing/failed sidecar simply disables the regenerate
+                    // fast-path for this snapshot. NOT folded into res->n_bytes (that contract stays
+                    // "state-file bytes only").
+                    //
+                    // CRITICAL consistency guard: only write the sidecar when the captured logits
+                    // provably belong to the EXACT state being saved, i.e. logits_last_n_tokens ==
+                    // token_count. This blocks every stale-logits path (restore-then-save with no
+                    // intervening decode; a spec-decode step that skipped the capture; a distribution
+                    // left over from a prior task on this slot object) from persisting a sidecar that
+                    // does not match the saved state — which would otherwise emit a wrong first token
+                    // on a later regenerate with nothing to catch it.
+                    if (nwrite > 0 && ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+                        if (slot->logits_last_n_tokens == (int32_t) token_count && !slot->logits_last.empty()) {
+                            const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                            const size_t nwrite_logits =
+                                slot_logits_write(filepath, slot->logits_last, nv, (uint32_t) token_count);
+                            if (nwrite_logits == 0) {
+                                SLT_WRN(*slot, "%s", "failed to write logits sidecar; regenerate fast-path disabled for this snapshot\n");
+                            }
+                        } else {
+                            SLT_DBG(*slot, "no matching captured logits for this state (stamp=%d, token_count=%zu); sidecar omitted\n",
+                                    slot->logits_last_n_tokens, token_count);
+                        }
+                    }
+
+                    // Feature C: enforce the bounded slot-save store (LRU by mtime). If this single
+                    // snapshot exceeds the byte cap, reject the save instead of evicting everything.
+                    if (nwrite > 0 &&
+                        (params_base.slot_save_max_count > 0 || params_base.slot_save_max_bytes > 0)) {
+                        bool oversized = false;
+                        slot_save_enforce_limits(params_base.slot_save_path,
+                                                 params_base.slot_save_max_count,
+                                                 params_base.slot_save_max_bytes,
+                                                 filepath, oversized);
+                        if (oversized) {
+                            send_error(task,
+                                       "slot snapshot exceeds --slot-save-max-mb; save rejected",
+                                       ERROR_TYPE_INVALID_REQUEST);
+                            break;
+                        }
+                    }
+
                     const int64_t t_end = ggml_time_us();
                     const double t_save_ms = (t_end - t_start) / 1000.0;
 
@@ -2234,6 +2585,27 @@ private:
                         if (ckpt_pos_min >= 0) {
                             slot->prompt.checkpoints.clear();
                             create_checkpoint(*slot, 0, ckpt_pos_min, ckpt_pos_max);
+                        }
+                    }
+
+                    // The restored state's freshly-sampled "running" distribution is unknown: the
+                    // logits in `logits_last` (if any) belong to a PRIOR generation on this slot
+                    // object, NOT to the restored state. Invalidate them so a subsequent SLOT_SAVE
+                    // (e.g. a restore -> re-checkpoint with no intervening decode) cannot persist a
+                    // stale, mismatched sidecar. (Belt-and-suspenders: the SLOT_SAVE stamp check
+                    // already blocks this, since the stamp no longer equals the restored length.)
+                    slot->logits_last.clear();
+                    slot->logits_last_n_tokens = -1;
+
+                    // Feature A/B: load the logits sidecar (if any) so an exact-prompt regenerate
+                    // can emit the first token without re-decoding into the restored recurrent state.
+                    // The token-count check binds the sidecar to exactly this restored state.
+                    // On any failure restored_logits stays empty and Feature B falls back safely.
+                    slot->restored_logits.clear();
+                    if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+                        const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                        if (slot_logits_read(filepath, nv, (uint32_t) token_count, slot->restored_logits)) {
+                            SLT_INF(*slot, "loaded logits sidecar (%d vocab, %zu tokens) — regenerate fast-path armed\n", nv, token_count);
                         }
                     }
 
@@ -2735,6 +3107,129 @@ private:
 
                             // the largest pos_min required for a checkpoint to be useful
                             const auto pos_min_thold = std::max(0, pos_next - n_swa - 1);
+
+                            // ===== Feature B: restore-continue (regenerate fast-path) ====================
+                            // A just-restored FULL/recurrent slot receiving the EXACT restored tokens (no
+                            // suffix) cannot rewind its memory: the normal path would re-decode into the
+                            // already-occupied sequence and crash (the pure-recurrent gate at the relaxed
+                            // checkpoint predicate below is FALSE for this case, so just_restored would never
+                            // be consumed and [TAG_PROMPT_LOGITS] would decrement n_past and re-decode into
+                            // the occupied sequence). Detect that case here, BEFORE the n_past>0 guard, and:
+                            //   - if we have the saved next-token logits: emit the first token with NO decode,
+                            //     keeping the full restored state, then continue normal autoregression;
+                            //   - otherwise: fall back to a SAFE clear-then-reprefill (never crash).
+                            // Gated so it is unreachable for non-recurrent models, with-suffix requests,
+                            // non-generative slots, and multimodal (already excluded by check_no_mtmd at
+                            // save/restore). With-suffix restore reuse is left entirely to the unchanged
+                            // relaxed-predicate path below.
+                            // NOTE: cache_prompt==false sets n_past=0 above, so this gate (which
+                            // requires n_past == task->n_tokens()) is naturally not entered for a
+                            // no-cache request; that case safely takes the normal full-clear +
+                            // reprefill path (common_context_seq_rm at [p0,-1) empties the restored
+                            // sequence first), so regenerate degrades to a cold reprefill, never a crash.
+                            // No `n_past < n_ctx` clause: the fast path emits with NO decode so it
+                            // needs no free context slot; a full-n_ctx no-suffix restore is handled
+                            // here rather than falling through to a zero-token-added crash window.
+                            if (slot.just_restored &&
+                                ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL &&
+                                slot.task->need_sampling() &&
+                                slot.alora_invocation_start <= 0 &&
+                                n_past == slot.task->n_tokens() &&
+                                n_past == (int) slot.prompt.n_tokens()) {
+
+                                slot.just_restored = false; // one-shot consume (this path owns it)
+
+                                if (!slot.restored_logits.empty()) {
+                                    // --- fast path: emit first token from saved logits, no decode ---
+                                    slot.n_prompt_tokens_cache     = n_past; // entire prompt "reused"
+                                    slot.n_prompt_tokens_processed = 0;      // prompt_n = 0 => observable reuse signal
+
+                                    // prime the sampler over the full restored prompt (penalties/grammar
+                                    // history), exactly as the normal DONE_PROMPT transition (init_sampler) would.
+                                    slot.n_decoded = 0;
+                                    slot.init_sampler();
+
+                                    slot.state   = SLOT_STATE_GENERATING;
+                                    slot.i_batch = -1;
+
+                                    // rebuild the (cold, unsaved) draft context for the restored prompt,
+                                    // mirroring the normal prompt-done transition.
+                                    if (slot.can_speculate()) {
+                                        common_speculative_begin(spec.get(), slot.id, slot.prompt.tokens.get_text_tokens());
+                                    }
+
+                                    const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                                    const llama_token id = common_sampler_sample_from_logits(
+                                            slot.smpl.get(), slot.restored_logits.data(), nv, /*grammar_first=*/false);
+                                    slot.restored_logits.clear(); // consumed
+
+                                    common_sampler_accept(slot.smpl.get(), id, true);
+
+                                    // mirror the generation accounting from the normal sample path
+                                    const int64_t t_current = ggml_time_us();
+                                    slot.n_decoded += 1;
+                                    slot.t_start_generation  = t_current;
+                                    slot.t_prompt_processing = (slot.t_start_generation - slot.t_start_process_prompt) / 1e3;
+                                    metrics.on_prompt_eval(slot);
+                                    slot.t_token_generation  = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;
+
+                                    if (slot.task->params.stream) {
+                                        // mirror the normal prompt-start streaming signal exactly so a
+                                        // return_progress client still gets its initial 0% progress event
+                                        if (slot.task->params.return_progress) {
+                                            send_partial_response(slot, {}, true);
+                                        } else {
+                                            // signal HTTP to send the headers (200 status)
+                                            send_partial_response(slot, {}, false, true);
+                                        }
+                                    }
+
+                                    completion_token_output result;
+                                    result.tok  = id;
+                                    // inline of the accept_special_token lambda (defined later in this method,
+                                    // out of scope here): keep special tokens iff the server allows specials
+                                    // or the request explicitly preserves this token.
+                                    const bool keep_special =
+                                        params_base.special ||
+                                        slot.task->params.sampling.preserved_tokens.find(result.tok) !=
+                                            slot.task->params.sampling.preserved_tokens.end();
+                                    result.text_to_send = common_token_to_piece(slot.ctx_tgt, result.tok, keep_special);
+                                    result.prob         = 1.0f;
+
+                                    // First-token logprobs (n_probs>0): the post-sampling variant reads the
+                                    // candidate set (cur_p), which common_sampler_sample_from_logits leaves
+                                    // populated — so we can serve it exactly as the normal path does. The
+                                    // pre-sampling variant reads raw ctx logits at a decode index we bypass
+                                    // here; idx=-1 is passed but populate_token_probs() only uses idx in that
+                                    // branch, so we restrict the call to post_sampling to stay correct.
+                                    if (slot.task->params.sampling.n_probs > 0 && slot.task->params.post_sampling_probs) {
+                                        populate_token_probs(slot, result, /*post_sampling=*/true, params_base.special, /*idx=*/-1);
+                                    }
+
+                                    if (!process_token(result, slot)) {
+                                        slot.print_timings();
+                                        send_final_response(slot);
+                                        metrics.on_prediction(slot);
+                                        slot.release();
+                                    }
+
+                                    SLT_INF(slot, "%s", "restore-continue: emitted first token from saved logits (prompt_n=0)\n");
+                                    continue; // skip ALL prompt-batch building for this slot this iteration
+                                }
+
+                                // --- safe fallback: no valid sidecar -> clear restored seq, then reprefill ---
+                                // FULL models support full-sequence removal; clearing first guarantees the
+                                // subsequent reprefill writes into an EMPTY sequence instead of re-decoding
+                                // into the already-occupied restored state (which is the crash being fixed).
+                                SLT_WRN(slot, "%s", "restore-continue: no saved logits; clearing restored state and re-prefilling\n");
+                                llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, -1, -1);
+                                slot.prompt.tokens.clear();
+                                slot.prompt.checkpoints.clear();
+                                n_past   = 0;
+                                pos_next = 0; // mirror the do_reset path; keep the stale full-length value from leaking into the checkpoint-erase loop below
+                                // fall through to the normal guard below with an empty sequence (safe)
+                            }
+                            // ===== end Feature B ========================================================
 
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
@@ -3316,6 +3811,32 @@ private:
                 const int tok_idx = slot.i_batch - i;
 
                 llama_token id = common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, tok_idx);
+
+                // Feature A: capture this slot's last-token full-vocab logits for a possible disk
+                // save. Cost: one ~n_vocab*4-byte copy per decoded token, incurred ONLY on
+                // FULL/recurrent models AND only when slot saving is enabled (--slot-save-path set);
+                // attention models and servers without slot-save pay nothing at all. The copy is
+                // unavoidable for correctness: ctx logits are overwritten by the next slot's decode,
+                // so a lazy read at SLOT_SAVE would be wrong under --parallel>1. Captured per-slot
+                // from this slot's own tok_idx so it is correct for any N/interleave (never read
+                // from the shared ctx at save time). common_sampler_sample already synchronized the
+                // context above, so llama_get_logits_ith is valid here.
+                if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL && !params_base.slot_save_path.empty()) {
+                    const float * lg = llama_get_logits_ith(slot.ctx_tgt, tok_idx);
+                    if (lg) {
+                        const int nv = llama_vocab_n_tokens(llama_model_get_vocab(model_tgt));
+                        slot.logits_last.assign(lg, lg + nv);
+                        // Stamp the capture with the token count of the state it corresponds to.
+                        // At this point process_token() has NOT yet appended the just-sampled token,
+                        // so prompt.tokens.size() is exactly the length whose final token produced
+                        // these logits — i.e. it matches the token_count a SLOT_SAVE would record.
+                        slot.logits_last_n_tokens = (int32_t) slot.prompt.tokens.size();
+                    } else {
+                        // capture failed -> invalidate so a later save never serializes stale logits
+                        slot.logits_last.clear();
+                        slot.logits_last_n_tokens = -1;
+                    }
+                }
 
                 slot.i_batch = -1;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -98,6 +98,7 @@ struct server_slot {
     bool has_next_token = true;
     bool has_new_line   = false;
     bool truncated      = false;
+    bool just_restored  = false; // set on disk slot-restore; one-shot, gates restored-slot KV reuse
 
     stop_type stop;
 
@@ -2221,6 +2222,20 @@ private:
                     tokens.resize(token_count);
                     slot->prompt.tokens.clear();
                     slot->prompt.tokens.insert(tokens);
+                    slot->just_restored = true;
+
+                    // Reconstruct a context checkpoint at the restored position so the prompt-cache
+                    // reuse path can reuse this state on the next matching request. Hybrid/recurrent
+                    // (and SWA) models cannot partially rewind their memory, so without a checkpoint
+                    // the matcher forces a full re-prefill; other models do not need it.
+                    if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL) {
+                        const auto ckpt_pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot->id);
+                        const auto ckpt_pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot->id);
+                        if (ckpt_pos_min >= 0) {
+                            slot->prompt.checkpoints.clear();
+                            create_checkpoint(*slot, 0, ckpt_pos_min, ckpt_pos_max);
+                        }
+                    }
 
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
@@ -2773,6 +2788,10 @@ private:
 
                                 if (pos_min >= pos_min_thold) {
                                     // search for a context checkpoint
+                                    // reuse a tail checkpoint (e.g. restored from disk) when genuinely-new tokens follow,
+                                    // which supply the required logits so the >=1-token guarantee still holds
+                                    const bool slot_was_restored = slot.just_restored; slot.just_restored = false;
+                                    const bool has_new_suffix = (size_t) slot.task->n_tokens() > (size_t) n_past;
                                     const auto it = std::find_if(
                                         slot.prompt.checkpoints.rbegin(),
                                         slot.prompt.checkpoints.rend(),
@@ -2780,7 +2799,7 @@ private:
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             LOG_INF("slot %12.*s: id %2d | task %d | Checking checkpoint with [%d, %d] against %d...\n", 12,
                                                 func_name, (slot).id, ((slot).task ? (slot).task->id : -1), cur.pos_min, cur.pos_max, pos_min_thold);
-                                            return cur.pos_min < pos_min_thold || cur.pos_min == 0;
+                                            return cur.pos_min == 0 || cur.pos_min < pos_min_thold || (slot_was_restored && has_new_suffix && cur.pos_min == pos_min_thold);
                                         }
                                     );
 


### PR DESCRIPTION
## Overview

Today, disk slot save/restore is a manual primitive — a client has to call `/slots save|restore` itself. A plain `/v1/chat/completions` client (OpenWebUI, qwen-code, etc.) gets no cross-request or cross-process KV reuse from disk, so a cold server re-prefills a large prompt from scratch every time (#17107, #18244). And when `--mmproj` is loaded, save/restore is blocked even for text-only turns (#21133).

This PR adds an **opt-in, default-off** transparent disk prompt cache: with `--slot-save-auto`, plain chat-completions clients get cross-request and cross-process KV reuse with no `/slots` calls and no client changes.

- **Block-hash index** over token IDs (vLLM-APC / SGLang-radix style), built by a header-only scan of the slot-save dir.
- **Auto-restore** the longest snapshot that is a **byte-verified token prefix** of the request (never on hash alone), gated by an exact model fingerprint (arch/vocab/ctx/rope/kv-type/recurrence/adapters); any mismatch or error falls back to normal prefill. The restored prefix feeds the reuse/regenerate path from the prerequisite PR.
- **Auto-save** on eviction (off the hot path), deduped, bounded by the existing LRU.
- **Cross-process** visibility without restart (throttled dir-mtime check picks up peers' snapshots) — so a multi-instance pool shares one prefill.
- **Multimodal:** caches the text-only turns of an mmproj session up to the first image  (per-request has-media gate, token IDs can't identify image content) — fixes #21133.  If there is enough appetite we could support images in a future PR.

New flags: `--slot-save-auto` (requires `--slot-save-path`), `--slot-save-block` (default 256). The entire feature is fronted by one `auto_cache_enabled()` check: when off, no scan/index/hashing/allocation and behavior is bit-identical to without the patch.

## Additional information

Stacked on #<PR1> (`kv-restore-reuse`) — please review/merge that first; until then this PR's diff includes those commits too.

Correctness invariants: never restore on a hash match alone (byte-verify the persisted tokens); refuse cross-model/quant/rope/kv-type/adapter snapshots via fingerprint; every failure falls back to normal prefill. Recurrent/hybrid snapshots include generated tokens, so reuse requires the request to *extend* the snapshot (the normal multi-turn pattern).

Tested on Qwen3.6-27B (recurrent) + Llama-3.2-1B (attention): off = byte-identical; cold process B restores a 1140-token snapshot written by process A and prefills only the 18 new tokens (`prompt_n=18/1158`), coherent output, no restart; LRU bounds + multimodal text-turn gating. README options rows should be regenerated with `llama-gen-docs` at merge; branch based on an older `master`, will rebase on request.

Note: This is part 2, part 1 implements the disk caching on it's own: #24003

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — design, implementation, and tests were developed with substantial AI assistance, then validated by me on real recurrent + attention models. I have reviewed the changes and take responsibility for them.
