### PR TITLE
server: add KV cache metrics

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -769,6 +769,15 @@ extern "C" {
     // Check if the memory supports shifting
     LLAMA_API bool llama_memory_can_shift(llama_memory_t mem);
 
+    typedef struct llama_memory_kv_cache_stats {
+        uint64_t used_cells;
+        uint64_t total_cells;
+    } llama_memory_kv_cache_stats;
+
+    // Returns KV cache cell usage.
+    // For models without a KV cache, both values are 0.
+    LLAMA_API llama_memory_kv_cache_stats llama_memory_get_kv_cache_stats(llama_memory_t mem);
+
     //
     // State / sessions
     //

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3796,6 +3796,14 @@ bool llama_memory_can_shift(llama_memory_t mem) {
     return mem->get_can_shift();
 }
 
+llama_memory_kv_cache_stats llama_memory_get_kv_cache_stats(llama_memory_t mem) {
+    if (!mem) {
+        return {};
+    }
+
+    return mem->get_kv_cache_stats();
+}
+
 // llama state API
 
 // deprecated

--- a/src/llama-kv-cache-dsa.cpp
+++ b/src/llama-kv-cache-dsa.cpp
@@ -160,6 +160,10 @@ bool llama_kv_cache_dsa::get_can_shift() const {
            kv_mla->get_size() == kv_lid->get_size();
 }
 
+llama_memory_kv_cache_stats llama_kv_cache_dsa::get_kv_cache_stats() const {
+    return kv_mla->get_kv_cache_stats();
+}
+
 void llama_kv_cache_dsa::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {
     kv_mla->state_write(io, seq_id, flags);
     kv_lid->state_write(io, seq_id, flags);

--- a/src/llama-kv-cache-dsa.h
+++ b/src/llama-kv-cache-dsa.h
@@ -45,6 +45,7 @@ public:
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
+    llama_memory_kv_cache_stats get_kv_cache_stats() const override;
 
     void clear(bool data) override;
 

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -223,6 +223,16 @@ bool llama_kv_cache_iswa::get_can_shift() const {
            kv_base->get_size() == kv_swa->get_size();
 }
 
+llama_memory_kv_cache_stats llama_kv_cache_iswa::get_kv_cache_stats() const {
+    llama_memory_kv_cache_stats stats_base = kv_base->get_kv_cache_stats();
+    llama_memory_kv_cache_stats stats_swa  = kv_swa ->get_kv_cache_stats();
+
+    stats_base.used_cells  += stats_swa.used_cells;
+    stats_base.total_cells += stats_swa.total_cells;
+
+    return stats_base;
+}
+
 void llama_kv_cache_iswa::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {
     if ((flags & LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY) == 0) {
         kv_base->state_write(io, seq_id, flags);

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -44,6 +44,7 @@ public:
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
+    llama_memory_kv_cache_stats get_kv_cache_stats() const override;
 
     void clear(bool data) override;
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1104,6 +1104,17 @@ bool llama_kv_cache::get_can_shift() const {
     return true;
 }
 
+llama_memory_kv_cache_stats llama_kv_cache::get_kv_cache_stats() const {
+    llama_memory_kv_cache_stats stats = {};
+
+    for (const auto & cells : v_cells) {
+        stats.used_cells  += cells.get_used();
+        stats.total_cells += cells.size();
+    }
+
+    return stats;
+}
+
 uint32_t llama_kv_cache::get_size() const {
     const auto & cells = v_cells[seq_to_stream[0]];
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -128,6 +128,7 @@ public:
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
+    llama_memory_kv_cache_stats get_kv_cache_stats() const override;
 
     void clear(bool data) override;
 

--- a/src/llama-memory-hybrid-iswa.cpp
+++ b/src/llama-memory-hybrid-iswa.cpp
@@ -138,6 +138,10 @@ bool llama_memory_hybrid_iswa::get_can_shift() const {
     return mem_attn->get_can_shift();
 }
 
+llama_memory_kv_cache_stats llama_memory_hybrid_iswa::get_kv_cache_stats() const {
+    return mem_attn->get_kv_cache_stats();
+}
+
 void llama_memory_hybrid_iswa::clear(bool data) {
     mem_attn->clear(data);
     mem_recr->clear(data);

--- a/src/llama-memory-hybrid-iswa.h
+++ b/src/llama-memory-hybrid-iswa.h
@@ -57,6 +57,7 @@ public:
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
+    llama_memory_kv_cache_stats get_kv_cache_stats() const override;
 
     void clear(bool data) override;
 

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -133,6 +133,10 @@ bool llama_memory_hybrid::get_can_shift() const {
     return mem_attn->get_can_shift();
 }
 
+llama_memory_kv_cache_stats llama_memory_hybrid::get_kv_cache_stats() const {
+    return mem_attn->get_kv_cache_stats();
+}
+
 void llama_memory_hybrid::clear(bool data) {
     mem_attn->clear(data);
     mem_recr->clear(data);

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -57,6 +57,7 @@ public:
     llama_memory_context_ptr init_update(llama_context * lctx, bool optimize) override;
 
     bool get_can_shift() const override;
+    llama_memory_kv_cache_stats get_kv_cache_stats() const override;
 
     void clear(bool data) override;
 

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -700,6 +700,10 @@ bool llama_memory_recurrent::get_can_shift() const {
     return true;
 }
 
+llama_memory_kv_cache_stats llama_memory_recurrent::get_kv_cache_stats() const {
+    return {};
+}
+
 size_t llama_memory_recurrent::total_size() const {
     size_t size = 0;
     for (const auto & [_, buf] : ctxs_bufs) {

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -60,6 +60,7 @@ public:
     bool find_slot(const llama_ubatch & ubatch);
 
     bool get_can_shift() const override;
+    llama_memory_kv_cache_stats get_kv_cache_stats() const override;
 
     // state write/load
 

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -95,6 +95,7 @@ struct llama_memory_i {
 
     // getters
     virtual bool get_can_shift() const = 0;
+    virtual llama_memory_kv_cache_stats get_kv_cache_stats() const = 0;
 
     //
     // ops

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1067,6 +1067,9 @@ In *router mode* the query param `?model={model_id}` has to be set. This endpoin
 | `llamacpp:n_tokens_max` | Counter | High watermark of the context size observed. |
 | `llamacpp:n_decode_total` | Counter | Total Number of llama_decode() calls. |
 | `llamacpp:n_busy_slots_per_decode` | Gauge | Average number of busy slots per llama_decode() call. |
+| `llamacpp:kv_cache_used_cells` | Gauge | Number of KV cache cells currently in use. |
+| `llamacpp:kv_cache_total_cells` | Gauge | Total number of KV cache cells. |
+| `llamacpp:kv_cache_usage_ratio` | Gauge | Ratio of KV cache cells currently in use. |
 
 ### POST `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2206,6 +2206,10 @@ private:
                     res->n_decode_total          = metrics.n_decode_total;
                     res->n_busy_slots_total      = metrics.n_busy_slots_total;
 
+                    const llama_memory_kv_cache_stats kv_cache_stats = llama_memory_get_kv_cache_stats(llama_get_memory(ctx_tgt));
+                    res->kv_cache_used_cells  = kv_cache_stats.used_cells;
+                    res->kv_cache_total_cells = kv_cache_stats.total_cells;
+
                     if (task.metrics_reset_bucket) {
                         metrics.reset_bucket();
                     }
@@ -4024,6 +4028,18 @@ void server_routes::init_routes() {
                     {"name",  "n_busy_slots_per_decode"},
                     {"help",  "Average number of busy slots per llama_decode() call"},
                     {"value",  (float) res_task->n_busy_slots_total / std::max((float) res_task->n_decode_total, 1.f)}
+            },{
+                    {"name",  "kv_cache_used_cells"},
+                    {"help",  "Number of KV cache cells currently in use."},
+                    {"value",  res_task->kv_cache_used_cells}
+            },{
+                    {"name",  "kv_cache_total_cells"},
+                    {"help",  "Total number of KV cache cells."},
+                    {"value",  res_task->kv_cache_total_cells}
+            },{
+                    {"name",  "kv_cache_usage_ratio"},
+                    {"help",  "Ratio of KV cache cells currently in use."},
+                    {"value",  res_task->kv_cache_total_cells ? (double) res_task->kv_cache_used_cells / res_task->kv_cache_total_cells : 0.}
             }}}
         };
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1906,6 +1906,9 @@ json server_task_result_metrics::to_json() {
         { "n_decode_total",                  n_decode_total },
         { "n_busy_slots_total",              n_busy_slots_total },
 
+        { "kv_cache_used_cells",             kv_cache_used_cells },
+        { "kv_cache_total_cells",            kv_cache_total_cells },
+
         { "slots",                           slots_data },
     };
 }

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -532,6 +532,9 @@ struct server_task_result_metrics : server_task_result {
     uint64_t n_decode_total     = 0;
     uint64_t n_busy_slots_total = 0;
 
+    uint64_t kv_cache_used_cells  = 0;
+    uint64_t kv_cache_total_cells = 0;
+
     // while we can also use std::vector<server_slot> this requires copying the slot object which can be quite messy
     // therefore, we use json to temporarily store the slot.to_json() result
     json slots_data = json::array();

--- a/tools/server/tests/unit/test_basic.py
+++ b/tools/server/tests/unit/test_basic.py
@@ -63,6 +63,24 @@ def test_server_slots():
     assert "params" not in res.body[0]
 
 
+def test_server_metrics_kv_cache():
+    global server
+    server.server_metrics = True
+    server.n_ctx = 512
+    server.n_slots = 2
+    server.start()
+
+    res = server.make_request("GET", "/metrics")
+    assert res.status_code == 200
+    assert "llamacpp:kv_cache_used_cells" in res.body
+    assert "llamacpp:kv_cache_total_cells" in res.body
+    assert "llamacpp:kv_cache_usage_ratio" in res.body
+
+    total_cells = re.search(r"^llamacpp:kv_cache_total_cells (\d+)$", res.body, re.MULTILINE)
+    assert total_cells is not None
+    assert int(total_cells.group(1)) == server.n_ctx
+
+
 def test_load_split_model():
     global server
     server.offline = False


### PR DESCRIPTION
Fixes #23632.

### Problem
The Prometheus `/metrics` endpoint exposes request and throughput metrics, but it does not report KV cache pressure.

### Changes
- add a read-only KV cache cell usage query on llama memory
- report KV cache used cells, total cells, and usage ratio from the server metrics task
- document the new Prometheus gauges
- cover the `/metrics` output in the server basic tests

### Tests
- `.venv/bin/cmake -B build`
- `.venv/bin/cmake --build build --target llama-server -j`
- `PATH="$PWD/.venv/bin:$PATH" LLAMA_CACHE="$PWD/tools/server/tests/tmp" PORT=18080 LLAMA_SERVER_BIN_PATH="$PWD/build/bin/llama-server" ./tools/server/tests/tests.sh unit/test_basic.py::test_server_metrics_kv_cache -q`