### PR TITLE
ggml-cuda: tune MMQ tile size for RDNA3.5 (gfx1151)

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -107,6 +107,7 @@ struct tile_x_sizes {
 };
 
 static int get_mmq_x_max_host(const int cc) {
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) { return 64; }
     return (turing_mma_available(cc) || amd_wmma_available(cc)) ? 128 :
         GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA ?
 #ifdef GGML_CUDA_FORCE_MMQ
@@ -117,7 +118,9 @@ static int get_mmq_x_max_host(const int cc) {
 }
 
 static constexpr __device__ int get_mmq_x_max_device() {
-#if defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#if defined(RDNA3_5)
+    return 64;
+#elif defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 128;
 #else // defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 
@@ -140,7 +143,7 @@ static constexpr __device__ int get_mmq_x_max_device() {
 }
 
 static int get_mmq_y_host(const int cc) {
-    return GGML_CUDA_CC_IS_AMD(cc) ? (GGML_CUDA_CC_IS_RDNA1(cc) ? 64 : 128) :
+    return GGML_CUDA_CC_IS_AMD(cc) ? ((GGML_CUDA_CC_IS_RDNA1(cc) || GGML_CUDA_CC_IS_RDNA3_5(cc)) ? 64 : 128) :
         ((GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA) ? 128 : 64);
 }
 
@@ -155,11 +158,11 @@ if (type == GGML_TYPE_NVFP4 || type == GGML_TYPE_MXFP4) {
 
 static constexpr __device__ int get_mmq_y_device() {
 #if defined(GGML_USE_HIP)
-#if defined(RDNA1)
+#if defined(RDNA1) || defined(RDNA3_5)
     return 64;
 #else
     return 128;
-#endif // defined RDNA1
+#endif // defined RDNA1 || defined RDNA3_5
 #else
 #if __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
     return 128;
@@ -296,7 +299,9 @@ static constexpr __device__ int mmq_get_granularity_device(const int /*mmq_x*/) 
 
 #if defined(GGML_USE_HIP)
 static int mmq_get_nwarps_host(const int cc, const int warp_size) {
-    return amd_mfma_available(cc) ? 8 : 256/warp_size;
+    if (amd_mfma_available(cc)) { return 8; }
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) { return 4; }
+    return 256/warp_size;
 }
 #else
 static int mmq_get_nwarps_host(const int /*cc*/, const int warp_size) {
@@ -305,8 +310,14 @@ static int mmq_get_nwarps_host(const int /*cc*/, const int warp_size) {
 #endif // (GGML_USE_HIP)
 
 static constexpr __device__ int mmq_get_nwarps_device() {
-#if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#if defined(AMD_MFMA_AVAILABLE)
     return 8;
+#elif defined(AMD_WMMA_AVAILABLE)
+#if defined(RDNA3_5)
+    return 4;
+#else
+    return 8;
+#endif // defined(RDNA3_5)
 #else
     return 256/ggml_cuda_get_physical_warp_size();
 #endif // AMD_MFMA_AVAILABLE


### PR DESCRIPTION
## Overview

Strix halo (gfx1151, RDNA3.5) has the same MMQ tile counts as RDNA3.0 (mmq_x=128, mmq_y=128, nwarps=8), but these sizes cause significant VGPR register pressure on gfx1151. This leads to register spilling and a important prompt processing degradations.

Reducing to mmq_x=64, mmq_y=64, nwarps=4 improves the register pressure. This is very similar to PR #8085, applied to RDNA1 (gfx803), which uses mmq_y=64 for the same reason.

### Benchmarks

Tested on gfx1151 (Radeon 8060S, 40 CU, ROCm 7.0), Q4_K_M, 3 runs each:

**Qwen3.5-122B-A10B (MoE):**

| Test | Before   | After    | Delta  |
|-------------|----------|----------|--------|
| pp128       | 144 t/s  | 234 t/s  | +62%   |
| pp512       | 303 t/s  | 375 t/s  | +24%   |
| pp2048      | 317 t/s  | 401 t/s  | +26%   |
| pp4096      | 299 t/s  | 393 t/s  | +31%   |
| pp8192      | 285 t/s  | 357 t/s  | +25%   |
| pp16384     | 250 t/s  | 305 t/s  | +22%   |

**Dense models:**
- Mistral-7B: neutral (within measurable variance)
- Qwen3.5-27B: no effect

Both FA modes (fa=0 and fa=1) were tested with consistent gains across both.

---

## Additional Information

- This was started after reading [#21284](https://github.com/ggml-org/llama.cpp/issues/21284), which spotlights VGPR spilling as a root cause of gfx1151 prefill underperformance and proposes similar tile values (mmq_x=48). This PR uses mmq_x=64 since it is a power-of-two alignment and benchmarks seem to confirm it resolves the issue.
- The gain show most on MoE models because expert dispatch creates many tiny independent tiles, causing hard register spilling here. For dense models that are already memory-bandwidth-bound on the iGPU, tile size has less impact.
- RDNA3.0 (gfx1100/1101) is intentionally left unchanged.

---

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- **AI usage disclosure:** No
