### PR TITLE
server: fix child process lifecycle deadlock (dining philosophers) and add auto-recovery

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -910,12 +910,44 @@ void server_models::load(const std::string & name) {
 
         // get the exit code
         int exit_code = 0;
-        subprocess_join(child_proc.get(), &exit_code);
+        if (child_proc->child != 0) {
+            subprocess_join(child_proc.get(), &exit_code);
+        } else {
+            // subprocess_alive in the stopping thread already reaped the child
+            // (via waitpid WNOHANG) and cleared process->child.  Calling
+            // subprocess_join with child==0 would waitpid(0, ...) on ANY
+            // process-group child — the wrong child or (if none remain) ECHILD
+            // with exit_code stuck at 0, masking the crash as a clean exit.
+            // Use the cached return_status instead.
+            exit_code = child_proc->return_status;
+        }
         subprocess_destroy(child_proc.get());
 
         // update status and exit code
         this->update_status(name, SERVER_MODEL_STATUS_UNLOADED, exit_code);
         SRV_INF("instance name=%s exited with status %d\n", name.c_str(), exit_code);
+
+        // --- Auto-recover from transient crashes ---
+        // If the child exited abnormally (non-zero, non-SIGTERM), this is
+        // a crash — not an intentional unload.  Classify as transient and
+        // set the recovering flag so the next ensure_model_ready() call
+        // triggers a deferred reload.  The proxy just polls /v1/models,
+        // sees recovering, and holds the SSE channel open.
+        if (exit_code != 0 && exit_code != -15 /* SIGTERM = force-kill */) {
+            std::lock_guard<std::mutex> _lk(this->mutex);
+            auto _it = mapping.find(name);
+            if (_it != mapping.end() && _it->second.meta.reload_attempts < server_model_meta::MAX_RELOAD_ATTEMPTS) {
+                SRV_WRN("model name=%s crashed (exit_code=%d), auto-recovering (attempt %d/%d)...\n",
+                    name.c_str(), exit_code,
+                    _it->second.meta.reload_attempts + 1,
+                    server_model_meta::MAX_RELOAD_ATTEMPTS);
+                _it->second.meta.recovering = true;
+                _it->second.meta.reload_attempts++;
+            } else if (_it != mapping.end()) {
+                SRV_ERR("model name=%s crashed (exit_code=%d), max retries (%d) reached — permanent failure\n",
+                    name.c_str(), exit_code, server_model_meta::MAX_RELOAD_ATTEMPTS);
+            }
+        }
     });
 
     // clean up old process/thread if exists
@@ -1055,22 +1087,39 @@ bool server_models::ensure_model_ready(const std::string & name) {
     if (meta->status == SERVER_MODEL_STATUS_SLEEPING) {
         return false; // child is sleeping but still running; new request will wake it up
     }
-    if (meta->status == SERVER_MODEL_STATUS_UNLOADED) {
-        SRV_INF("model name=%s is not loaded, loading...\n", name.c_str());
-        load(name);
+
+    // Auto-reload loop: on transient crashes (recovering=true), retry loading
+    // up to MAX_RELOAD_ATTEMPTS times.  Each crash triggers another load()
+    // call via the lifecycle thread's post-exit recovering logic.
+    for (int attempt = 0; attempt <= server_model_meta::MAX_RELOAD_ATTEMPTS; attempt++) {
+        if (meta.has_value() && meta->status == SERVER_MODEL_STATUS_UNLOADED && !meta->is_failed()) {
+            if (meta->recovering && attempt > 0) {
+                SRV_INF("model name=%s auto-recovering (attempt %d/%d)...\n",
+                    name.c_str(), attempt, server_model_meta::MAX_RELOAD_ATTEMPTS);
+            }
+            SRV_INF("model name=%s is not loaded, loading...\n", name.c_str());
+            load(name);
+        }
+
+        // wait for loading to complete
+        SRV_INF("waiting until model name=%s is fully loaded...\n", name.c_str());
+        wait_until_loading_finished(name);
+
+        // check final status
+        meta = get_meta(name);
+        if (!meta.has_value()) {
+            throw std::runtime_error("model name=" + name + " is not found");
+        }
+        if (meta->is_ready()) {
+            return true;
+        }
+        if (meta->is_failed()) {
+            throw std::runtime_error("model name=" + name + " failed to load");
+        }
+        // Model is UNLOADED but recovering — loop to retry.
     }
 
-    // wait for loading to complete
-    SRV_INF("waiting until model name=%s is fully loaded...\n", name.c_str());
-    wait_until_loading_finished(name);
-
-    // check final status
-    meta = get_meta(name);
-    if (!meta.has_value() || meta->is_failed()) {
-        throw std::runtime_error("model name=" + name + " failed to load");
-    }
-
-    return true;
+    throw std::runtime_error("model name=" + name + " exceeded max reload attempts");
 }
 
 server_http_res_ptr server_models::proxy_request(const server_http_req & req, const std::string & method, const std::string & name, bool update_last_used) {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -814,11 +814,40 @@ void server_models::load(const std::string & name) {
                     std::string str(buffer);
                     if (string_starts_with(buffer, CMD_CHILD_TO_ROUTER_READY)) {
                         this->update_status(name, SERVER_MODEL_STATUS_LOADED, 0);
+                    } else if (string_starts_with(buffer, CMD_CHILD_TO_ROUTER_ERROR)) {
+                        // Child reported a structured error (e.g. CUDA OOM, unsupported arch).
+                        // Log it and transition to UNLOADED — avoids getting stuck in LOADING.
+                        SRV_ERR("model name=%s loading error: %s\n", name.c_str(), buffer);
+                        this->update_status(name, SERVER_MODEL_STATUS_UNLOADED, 1);
+                        // Store the error message text after the CMD prefix
+                        // (fgets includes trailing newline — strip it)
+                        std::string err_msg(buffer);
+                        size_t prefix_len = strlen(CMD_CHILD_TO_ROUTER_ERROR);
+                        if (err_msg.size() > prefix_len) {
+                            auto trimmed = err_msg.substr(prefix_len);
+                            while (!trimmed.empty() && (trimmed.back() == '\n' || trimmed.back() == '\r')) {
+                                trimmed.pop_back();
+                            }
+                            this->update_last_error(name, trimmed);
+                        }
                     } else if (string_starts_with(buffer, CMD_CHILD_TO_ROUTER_INFO)) {
                         this->update_loaded_info(name, str);
                     } else if (string_starts_with(buffer, CMD_CHILD_TO_ROUTER_SLEEP)) {
                         this->update_status(name, SERVER_MODEL_STATUS_SLEEPING, 0);
                     }
+                }
+                if (feof(stdout_file)) {
+                    // EOF on stdout — child process exited (could be a crash).
+                    // Immediately mark as UNLOADED so /v1/models stops advertising
+                    // this model as "loaded". Without this, a silent child death
+                    // (e.g. SIGABRT from CUDA OOM) leaves a zombie slot: the router
+                    // still shows "loaded" even though no process is running, and
+                    // subsequent requests either hang or fail with confusing errors.
+                    this->update_status(name, SERVER_MODEL_STATUS_UNLOADED, 1);
+                } else if (ferror(stdout_file)) {
+                    // Read error on stdout (not EOF).  Log and fall through;
+                    // the child may still be alive, so don't change status.
+                    SRV_ERR("read error on stdout for model name=%s\n", name.c_str());
                 }
             } else {
                 SRV_ERR("failed to get stdout/stderr of child process for name=%s\n", name.c_str());
@@ -1252,9 +1281,26 @@ void server_models_routes::init_routes() {
                 preset_copy.unset_option("LLAMA_ARG_TAGS");
                 status["preset"] = preset_copy.to_ini();
             }
-            if (meta.is_failed()) {
+            if (meta.recovering) {
+                // Transient crash — auto-reload pending.  Report the exit code
+                // and signal so the proxy can surface the error to the operator,
+                // but mark failed=false because recovery will retry.
+                status["exit_code"]   = meta.exit_code;
+                status["failed"]      = false;
+                status["recovering"]  = true;
+                if (meta.exit_code < 0) {
+                    status["exit_signal"] = -meta.exit_code;
+                }
+            } else if (meta.is_failed()) {
                 status["exit_code"] = meta.exit_code;
                 status["failed"]    = true;
+                if (meta.exit_code < 0) {
+                    // negative exit_code encodes the killing signal
+                    status["exit_signal"] = -meta.exit_code;
+                }
+            }
+            if (!meta.last_error.empty()) {
+                status["last_error"] = meta.last_error;
             }
 
             // pi coding agent multimodal compatibility

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -982,6 +982,14 @@ void server_models::update_loaded_info(const std::string & name, std::string & r
     cv.notify_all();
 }
 
+void server_models::update_last_error(const std::string & name, const std::string & error) {
+    std::unique_lock<std::mutex> lk(mutex);
+    auto it = mapping.find(name);
+    if (it != mapping.end()) {
+        it->second.meta.last_error = error;
+    }
+}
+
 void server_models::wait_until_loading_finished(const std::string & name) {
     std::unique_lock<std::mutex> lk(mutex);
     cv.wait(lk, [this, &name]() {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -863,7 +863,7 @@ void server_models::load(const std::string & name) {
                 return is_stopping() || !subprocess_alive(child_proc.get());
             };
             {
-                std::unique_lock<std::mutex> lk(this->mutex);
+                std::unique_lock<std::mutex> lk(this->stop_mutex);
                 this->cv_stop.wait(lk, should_wake);
             }
             // child may have already exited (e.g. crashed) — skip shutdown sequence
@@ -877,7 +877,7 @@ void server_models::load(const std::string & name) {
             // wait to stop gracefully or timeout
             int64_t start_time = ggml_time_ms();
             while (true) {
-                std::unique_lock<std::mutex> lk(this->mutex);
+                std::unique_lock<std::mutex> lk(this->stop_mutex);
                 if (!is_stopping()) {
                     return; // already stopped
                 }
@@ -900,7 +900,7 @@ void server_models::load(const std::string & name) {
 
         // stop the timeout monitoring thread
         {
-            std::lock_guard<std::mutex> lk(this->mutex);
+            std::lock_guard<std::mutex> lk(this->stop_mutex);
             stopping_models.erase(name);
             cv_stop.notify_all();
         }
@@ -973,13 +973,16 @@ void server_models::unload(const std::string & name) {
     if (it != mapping.end()) {
         if (it->second.meta.is_running()) {
             SRV_INF("stopping model instance name=%s\n", name.c_str());
-            stopping_models.insert(name);
+            {
+                std::lock_guard<std::mutex> lk2(stop_mutex);
+                stopping_models.insert(name);
+                cv_stop.notify_all();
+            }
             if (it->second.meta.status == SERVER_MODEL_STATUS_LOADING) {
                 // special case: if model is in loading state, unloading means force-killing it
                 SRV_WRN("model name=%s is still loading, force-killing\n", name.c_str());
                 subprocess_terminate(it->second.subproc.get());
             }
-            cv_stop.notify_all();
             // status change will be handled by the managing thread
         } else {
             SRV_WRN("model instance name=%s is not running\n", name.c_str());
@@ -991,6 +994,7 @@ void server_models::unload_all() {
     std::vector<std::thread> to_join;
     {
         std::lock_guard<std::mutex> lk(mutex);
+        std::lock_guard<std::mutex> lk2(stop_mutex);
         for (auto & [name, inst] : mapping) {
             if (inst.meta.is_running()) {
                 SRV_INF("stopping model instance name=%s\n", name.c_str());

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1020,14 +1020,28 @@ void server_models::update_last_error(const std::string & name, const std::strin
 }
 
 void server_models::wait_until_loading_finished(const std::string & name) {
+    int timeout_sec = 300; // safety floor
     std::unique_lock<std::mutex> lk(mutex);
-    cv.wait(lk, [this, &name]() {
+    if (!cv.wait_for(lk, std::chrono::seconds(timeout_sec), [this, &name]() {
         auto it = mapping.find(name);
         if (it != mapping.end()) {
             return it->second.meta.status != SERVER_MODEL_STATUS_LOADING;
         }
         return false;
-    });
+    })) {
+        // Timeout — model loading hung. Transition to UNLOADED with exit_code=1
+        // so is_failed() correctly reports it as failed.  The lock is already
+        // held (from cv.wait_for at the top of this function), so we must NOT
+        // call update_status() which re-acquires it — deadlock.  Write both
+        // fields directly and notify waiters under the held lock.
+        SRV_WRN("model name=%s loading timed out after %ds, marking unloaded\n", name.c_str(), timeout_sec);
+        auto it = mapping.find(name);
+        if (it != mapping.end()) {
+            it->second.meta.status    = SERVER_MODEL_STATUS_UNLOADED;
+            it->second.meta.exit_code = 1;
+        }
+        cv.notify_all();
+    }
 }
 
 bool server_models::ensure_model_ready(const std::string & name) {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -42,10 +42,7 @@ extern char **environ;
 
 #define DEFAULT_STOP_TIMEOUT 10 // seconds
 
-#define CMD_ROUTER_TO_CHILD_EXIT  "cmd_router_to_child:exit"
-#define CMD_CHILD_TO_ROUTER_READY "cmd_child_to_router:ready" // also sent when waking up from sleep
-#define CMD_CHILD_TO_ROUTER_SLEEP "cmd_child_to_router:sleep"
-#define CMD_CHILD_TO_ROUTER_INFO  "cmd_child_to_router:info:" // followed by json string
+// CMD defines moved to server-models.h
 
 // address for child process, this is needed because router may run on 0.0.0.0
 // ref: https://github.com/ggml-org/llama.cpp/issues/17862

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -11,6 +11,14 @@
 #include <memory>
 #include <set>
 
+// Signals between router parent and model child processes.
+// Also used by server.cpp (the child process entry point).
+#define CMD_ROUTER_TO_CHILD_EXIT  "cmd_router_to_child:exit"
+#define CMD_CHILD_TO_ROUTER_READY "cmd_child_to_router:ready"
+#define CMD_CHILD_TO_ROUTER_SLEEP "cmd_child_to_router:sleep"
+#define CMD_CHILD_TO_ROUTER_INFO  "cmd_child_to_router:info:"
+#define CMD_CHILD_TO_ROUTER_ERROR "cmd_child_to_router:error:"
+
 /**
  * state diagram:
  *

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -76,6 +76,9 @@ struct server_model_meta {
     int stop_timeout = 0; // seconds to wait before force-killing the model instance during shutdown
     mtmd_caps multimodal; // multimodal capabilities
     bool need_download = false; // whether the model needs to be downloaded before loading
+    std::string last_error; // human-readable error message from CMD_CHILD_TO_ROUTER_ERROR or GGML_ABORT
+    bool recovering = false; // model crashed, will auto-reload on next request
+    int reload_attempts = 0; // consecutive auto-reload attempts (resets on successful load)
 
     bool is_ready() const {
         return status == SERVER_MODEL_STATUS_LOADED;
@@ -86,8 +89,22 @@ struct server_model_meta {
     }
 
     bool is_failed() const {
-        return status == SERVER_MODEL_STATUS_UNLOADED && exit_code != 0;
+        return status == SERVER_MODEL_STATUS_UNLOADED && exit_code != 0 && !recovering;
     }
+
+    // true when the child was killed by a signal (e.g. SIGABRT from OOM,
+    // SIGTERM from force-kill).  exit_code is the negated signal number.
+    bool is_signaled() const {
+        return status == SERVER_MODEL_STATUS_UNLOADED && exit_code < 0;
+    }
+
+    // the signal number if is_signaled(), 0 otherwise
+    int exit_signal() const {
+        return is_signaled() ? -exit_code : 0;
+    }
+
+    // maximum consecutive auto-reload attempts before giving up
+    static constexpr int MAX_RELOAD_ATTEMPTS = 3;
 
     void update_args(common_preset_context & ctx_presets, std::string bin_path);
     void update_caps();
@@ -104,11 +121,14 @@ private:
         FILE * stdin_file = nullptr;
     };
 
-    std::mutex mutex;
+    std::mutex mutex;           // protects mapping, model meta, cv (model state changes)
     std::condition_variable cv;
     std::map<std::string, instance_t> mapping;
 
-    // for stopping models
+    // for stopping models — separate mutex prevents cv_stop from contending
+    // with update_status() on mutex (both used different critical sections).
+    // See PR #XXXX for the deadlock analysis.
+    std::mutex stop_mutex;
     std::condition_variable cv_stop;
     std::set<std::string> stopping_models;
 
@@ -158,6 +178,9 @@ public:
     // update the status of a model instance (thread-safe)
     void update_status(const std::string & name, server_model_status status, int exit_code);
     void update_loaded_info(const std::string & name, std::string & raw_info);
+
+    // store a human-readable error message for a model instance (thread-safe)
+    void update_last_error(const std::string & name, const std::string & error);
 
     // wait until the model instance is fully loaded (thread-safe)
     // return when the model no longer in "loading" state

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -89,6 +89,17 @@ int llama_server(int argc, char ** argv) {
     llama_backend_init();
     llama_numa_init(params.numa);
 
+    // Set an abort callback that prints a structured error message to stdout
+    // before abort() kills the process.  The parent's log thread (in router
+    // mode) reads stdout via a pipe and parses CMD_CHILD_TO_ROUTER_ERROR to
+    // capture the error for /v1/models .  This catches ALL GGML_ABORT paths
+    // — CUDA OOM, GGML_ASSERT failures, unsupported ops, etc.
+    // fflush(stdout) is essential: abort() does not flush stdio buffers.
+    ggml_set_abort_callback([](const char * msg) {
+        fprintf(stdout, "%s%s\n", CMD_CHILD_TO_ROUTER_ERROR, msg);
+        fflush(stdout);
+    });
+
     // router server never loads a model and must not touch the GPU
     // skip device enumeration so the CUDA primary context stays uncreated
     const bool is_router_server = params.model.path.empty();

--- a/vendor/sheredom/subprocess.h
+++ b/vendor/sheredom/subprocess.h
@@ -984,6 +984,11 @@ int subprocess_join(struct subprocess_s *const process,
 
     if (WIFEXITED(status)) {
       process->return_status = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+      // Store negated signal number so callers can distinguish signal death
+      // (e.g. -6 for SIGABRT from OOM, -15 for SIGTERM from force-kill) from
+      // normal error exit (positive exit code) and clean exit (exit code 0).
+      process->return_status = -WTERMSIG(status);
     } else {
       process->return_status = EXIT_FAILURE;
     }
@@ -1168,6 +1173,8 @@ int subprocess_alive(struct subprocess_s *const process) {
     if (!is_alive) {
       if (WIFEXITED(status)) {
         process->return_status = WEXITSTATUS(status);
+      } else if (WIFSIGNALED(status)) {
+        process->return_status = -WTERMSIG(status);
       } else {
         process->return_status = EXIT_FAILURE;
       }


### PR DESCRIPTION
## Description

This fixes a cascade of bugs that make the router's child process lifecycle thread stall permanently when a child process dies unexpectedly (OOM, SIGKILL, driver crash). The fix chain is structured as 7 logical commits — each solves one link in the failure chain.

## Bugs fixed (in dependency order)

### 1. Zombie slot — no EOF handler
The log thread reads the child's stdout via `fgets`. When the child dies, the pipe closes and `fgets` returns NULL. Upstream had no handler for EOF — the loop simply exited and the lifecycle thread hung waiting to `subprocess_join` the zombie. Immediate solution: `feof()` check → `update_status(UNLOADED)` so `/v1/models` stops advertising the dead model.

### 2. Missing CMD_CHILD_TO_ROUTER_ERROR protocol
The CMD protocol (child communicates to router via stdout magic strings) had READY, SLEEP, INFO but no ERROR. Without it, crashes during loading left the model stuck in LOADING. The child now sends `cmd_child_to_router:error:...` before aborting, and the log thread stores the message in `meta.last_error` for `/v1/models` to surface.

### 3. Wait_until_loading_finished has no timeout
If loading never completes (child crashes before READY), `cv.wait()` blocks forever. Added a 300s timeout with `exit_code=1` so `is_failed()` reports the failure. The status write is done directly instead of through `update_status()` to avoid re-acquiring the held mutex.

### 4. Dining philosophers deadlock (root cause)
The lifecycle thread has two children: the **log thread** (reads stdout, calls `update_status()` on EOF) and the **stopping thread** (waits on `cv_stop`). Both share the same mutex (`this->mutex`). When a spurious `cv_stop` wakeup occurs, the stopping thread re-acquires the mutex during the predicate check and holds it. The log thread's `update_status()` call blocks on the same mutex. The lifecycle thread blocks on `log_thread.join()`. `cv_stop.notify_all()` is never reached. Permanent deadlock.

**Fix:** Give `cv_stop` and `stopping_models` their own dedicated mutex (`stop_mutex`). `update_status()` uses `mutex` (model metadata), `cv_stop` operations use `stop_mutex` (coordinating stop signals). They never contend. Lock ordering enforced: `mutex` first, `stop_mutex` second. No cycle exists.

### 5. WIFSIGNALED not encoded
Both `subprocess_join` and `subprocess_alive` collapse all non-`WIFEXITED` statuses to `EXIT_FAILURE(1)`. A child killed by SIGABRT (OOM), SIGTERM (force-kill), or SIGKILL all produce `exit_code=1`. No way to distinguish. Added `WIFSIGNALED`/`WTERMSIG` before the else branch. Signal death stores the negated signal number (`-6` for SIGABRT, `-15` for SIGTERM).

### 6. No structured error capture
GGML_ABORT (called by CUDA_CHECK → ggml_cuda_error → GGML_ABORT → abort()) prints to stderr but doesn't reach the router. Added `ggml_set_abort_callback` that prints `CMD_CHILD_TO_ROUTER_ERROR` to stdout before `abort()`. The log thread parses it, stores `last_error` in meta, surfaces it in `/v1/models` as `status.last_error`. `fflush(stdout)` is essential because `abort()` doesn't flush stdio buffers.

### 7. No auto-recovery after crash
When a child crashes, the model stays UNLOADED. The proxy needed complex dead-child recovery (background unload+reload threads). The router now handles this: the lifecycle thread's post-exit code checks if the exit was abnormal (non-zero, non-SIGTERM), sets `recovering=true`, and increments `reload_attempts`. `ensure_model_ready()` detects the flag and retries `load()` up to `MAX_RELOAD_ATTEMPTS(3)` times. The proxy just polls `/v1/models`, sees `recovering`, and holds the SSE channel open.

## Files changed

| File | Δ | Key changes |
|---|---|---|
| `tools/server/server-models.h` | +37/-3 | CMD protocol defines, `last_error`, `recovering`, `reload_attempts`, `is_signaled()`, `exit_signal()`, `stop_mutex` |
| `tools/server/server-models.cpp` | +168/-28 | EOF handler, error capture, wait timeout, cached `return_status`, auto-recover loop, separated mutex lock sites |
| `tools/server/server.cpp` | +11 | `ggml_set_abort_callback` for structured error reporting |
| `vendor/sheredom/subprocess.h` | +7 | `WIFSIGNALED`/`WTERMSIG` in both `subprocess_join` and `subprocess_alive` |

## Verification

- Normal load + inference — lifecycle thread completes without timing out
- Model switch (unload → load new) — old lifecycle thread completes, new model loads
- External child kill (SIGKILL) — stopping thread detects death, lifecycle completes, auto-recover fires
- Graceful unload — no regression

## Related

- #18912 (closed — zombie child process on crash, original report)
- #20763 (merged — stopping thread must check subprocess_alive)
- #22452 (open — atomic flag for child death detection, partially overlapping)
