### PR TITLE
common: centralise datetime formatting

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -30,15 +30,6 @@
 
 using json = nlohmann::ordered_json;
 
-static std::string format_time(const std::chrono::system_clock::time_point & now, const std::string & format) {
-    auto               time       = std::chrono::system_clock::to_time_t(now);
-    auto               local_time = *std::localtime(&time);
-    std::ostringstream ss;
-    ss << std::put_time(&local_time, format.c_str());
-    auto res = ss.str();
-    return res;
-}
-
 static json safe_args_parse(const std::string & to_parse) {
     std::string stripped = to_parse;
     if (to_parse.at(0) == '"' && to_parse.at(to_parse.length() - 1) == '"') {
@@ -2256,8 +2247,8 @@ static void func_args_not_string(json & messages) {
 static json common_chat_extra_context() {
     json ctx = json::object();
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
-    std::string datetime_str = format_time(now, "%b %d %Y");
-    std::string date_str = format_time(now, "%d %b %Y");
+    std::string datetime_str = common_time_format("%b %d %Y", now);
+    std::string date_str = common_time_format("%d %b %Y", now);
     ctx["datetime"] = datetime_str;
     ctx["date_string"] = date_str;
     return ctx;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -14,7 +14,6 @@
 #include <cinttypes>
 #include <climits>
 #include <cmath>
-#include <chrono>
 #include <cstdarg>
 #include <cstring>
 #include <ctime>
@@ -470,16 +469,14 @@ std::string string_get_sortable_timestamp() {
     using clock = std::chrono::system_clock;
 
     const clock::time_point current_time = clock::now();
-    const time_t as_time_t = clock::to_time_t(current_time);
-    char timestamp_no_ns[100];
-    std::strftime(timestamp_no_ns, 100, "%Y_%m_%d-%H_%M_%S", std::localtime(&as_time_t));
+    std::string timestamp_no_ns = common_time_format("%Y_%m_%d-%H_%M_%S", current_time);
 
     const int64_t ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         current_time.time_since_epoch() % 1000000000).count();
     char timestamp_ns[11];
     snprintf(timestamp_ns, 11, "%09" PRId64, ns);
 
-    return std::string(timestamp_no_ns) + "." + std::string(timestamp_ns);
+    return timestamp_no_ns + "." + std::string(timestamp_ns);
 }
 
 void string_replace_all(std::string & s, const std::string & search, const std::string & replace) {
@@ -792,6 +789,23 @@ static inline bool glob_match(const char * pattern, const char * str) {
 
 bool glob_match(const std::string & pattern, const std::string & str) {
     return glob_match(pattern.c_str(), str.c_str());
+}
+
+//
+// Time utils
+//
+
+std::string common_time_format(const char * fmt, const std::chrono::system_clock::time_point & tp) {
+    auto timestamp = std::chrono::system_clock::to_time_t(tp);
+    struct tm local_time;
+#ifdef _WIN32
+    localtime_s(&local_time, &timestamp);
+#else
+    localtime_r(&timestamp, &local_time);
+#endif
+    std::ostringstream ss;
+    ss << std::put_time(&local_time, fmt);
+    return ss ? ss.str() : "";
 }
 
 //

--- a/common/common.h
+++ b/common/common.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <chrono>
 
 #if defined(_WIN32) && !defined(_WIN32_WINNT)
 #define _WIN32_WINNT 0x0A00
@@ -825,6 +826,13 @@ std::string string_from(const struct llama_context * ctx, const std::vector<llam
 std::string string_from(const struct llama_context * ctx, const struct llama_batch & batch);
 
 bool glob_match(const std::string & pattern, const std::string & str);
+
+//
+// Time utils
+//
+
+// Formats a time string in the local timezone. Returns "" on failure.
+std::string common_time_format(const char * fmt, const std::chrono::system_clock::time_point & tp);
 
 //
 // Filesystem utils

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -4,6 +4,7 @@
 #include "value.h"
 
 #include <cassert>
+#include <chrono>
 #include <ctime>
 #include <memory>
 #include <sstream>
@@ -49,7 +50,7 @@ void enable_debug(bool enable);
 
 struct context {
     std::shared_ptr<std::string> src; // for debugging; use shared_ptr to avoid copying on scope creation
-    std::time_t current_time; // for functions that need current time
+    std::chrono::system_clock::time_point current_time; // for functions that need current time
 
     bool is_get_stats = false; // whether to collect stats
 
@@ -63,7 +64,7 @@ struct context {
         env->insert("False", mk_val<value_bool>(false));
         env->insert("none",  mk_val<value_none>());
         env->insert("None",  mk_val<value_none>());
-        current_time = std::time(nullptr);
+        current_time = std::chrono::system_clock::now();
     }
     ~context() = default;
 

--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -1,3 +1,4 @@
+#include "common.h"
 #include "runtime.h"
 #include "unicode.h"
 #include "value.h"
@@ -372,12 +373,11 @@ const func_builtins & global_builtins() {
             std::string format = args.get_pos(0)->as_string().str();
             // get current time
             // TODO: make sure this is the same behavior as Python's strftime
-            char buf[100];
-            if (std::strftime(buf, sizeof(buf), format.c_str(), std::localtime(&args.ctx.current_time))) {
-                return mk_val<value_string>(std::string(buf));
-            } else {
+            std::string result = common_time_format(format.c_str(), args.ctx.current_time);
+            if (result.empty()) {
                 throw raised_exception("strftime_now: failed to format time");
             }
+            return mk_val<value_string>(result);
         }},
         {"range", [](const func_args & args) -> value {
             args.ensure_count(1, 3);

--- a/examples/parallel/parallel.cpp
+++ b/examples/parallel/parallel.cpp
@@ -132,13 +132,11 @@ struct client {
 };
 
 static void print_date_time() {
-    std::time_t current_time = std::time(nullptr);
-    std::tm* local_time = std::localtime(&current_time);
-    char buffer[80];
-    strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", local_time);
+    auto current_time = std::chrono::system_clock::now();
+    std::string time_text = common_time_format("%Y-%m-%d %H:%M:%S", current_time);
 
     LOG_INF("\n");
-    LOG_INF("\033[35mrun parameters as of %s\033[0m\n", buffer);
+    LOG_INF("\033[35mrun parameters as of %s\033[0m\n", time_text.c_str());
     LOG_INF("\n");
 }
 

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -717,9 +717,7 @@ struct server_tool_get_datetime : server_tool {
 
     json invoke(json) override {
         auto now = std::chrono::system_clock::now();
-        auto time = std::chrono::system_clock::to_time_t(now);
-
-        return {{"result", std::ctime(&time)}};
+        return {{"result", common_time_format("%c", now)}};
     }
 };
 


### PR DESCRIPTION
## Overview

A new time_format function has been defined in common.h/.cpp to format C++ chrono time points.

This new function replaces multiple different string formatting mechanism scattered through the code, many using threading-unsafe functions such as localtime or ctime according to POSIX.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no
