### PR TITLE
fix: ROCm multi-GPU device context loss in ggml_cuda_set_device

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -102,9 +102,8 @@ void ggml_cuda_error(const char * stmt, const char * func, const char * file, in
 // probably because the Windows CUDA libraries forget to make this check before invoking the drivers
 void ggml_cuda_set_device(int device) {
     int current_device;
-    CUDA_CHECK(cudaGetDevice(&current_device));
-
-    if (device == current_device) {
+    cudaError_t err = cudaGetDevice(&current_device);
+    if (err == cudaSuccess && device == current_device) {
         return;
     }
 


### PR DESCRIPTION
## Overview

On multi-GPU ROCm setups, llama-server crashes with `hipErrorIllegalAddress` when restoring a prompt cache checkpoint for hybrid recurrent models Qwen3.6-35B-A3B for example.

## Additional information

Fixes #20176. Related to open PR #21170.
Tested on: 3x AMD RX 9070 XT (gfx1201), ROCm 7.5, Ubuntu 25.04.
ROCM-SMI version: 3.0.0+03a4530
ROCM-SMI-LIB version: 7.5.0

## Requirements

I have read the contributing guidelines

- AI usage disclosure:  Yes, Claude Sonnet 4.6

I myself have no professional background in Coding. 
Please be nice, I tried to read trough the issues page manually and with Claude again and found no fix for it.

I tested the code and on my setup the crash is gone.
Im sorry I read through the contributing guidelines but i am not able to tell you why the fix does the job, i wanted to contribute anyway.