### PR TITLE
cmake: skip cvector-generator and export-lora when CPU backend is disabled

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -33,8 +33,8 @@ else()
     if (GGML_RPC)
         add_subdirectory(rpc)
     endif()
-    if (NOT GGML_BACKEND_DL)
-        # these examples use the backends directly and cannot be built with dynamic loading
+    if (NOT GGML_BACKEND_DL AND GGML_CPU)
+        # these tools use backends directly (no dynamic loading) and depend on CPU backend symbols
         add_subdirectory(cvector-generator)
         add_subdirectory(export-lora)
     endif()


### PR DESCRIPTION
## Overview

 Both `cvector-generator` and `export-lora` link against CPU backend symbols (`ggml_backend_cpu_init`,
 `ggml_get_f32_nd`, etc.) unconditionally. When building with `-DGGML_CPU=OFF`, these tools fail to
 link, causing `cmake --install` to error on a missing binary:

```
CMake Error at build/tools/cvector-generator/cmake_install.cmake:52 (file):
  file INSTALL cannot find
  "<repo-path>/llama.cpp/build/bin/llama-cvector-generator": No such
  file or directory.
Call Stack (most recent call first):
  build/tools/cmake_install.cmake:122 (include)
  build/cmake_install.cmake:67 (include)
```

Both tools are guarded by `NOT GGML_BACKEND_DL` but not by `GGML_CPU`. Added the missing check.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted in identifying the issue and proposing the fix