### PR TITLE
fix: handle hybrid models where layer 0 has no attention heads

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1126,14 +1126,23 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ROPE_SCALING_ALPHA,       hparams.rope_scaling_alpha, false);
 
     // non-transformer models do not have attention heads
-    if (hparams.n_head() > 0) {
+    // For hybrid models, find the first attention layer to get head dimensions
+    uint32_t first_attn_layer_idx = 0;
+    for (uint32_t i = 0; i < hparams.n_layer; ++i) {
+        if (hparams.n_head_arr[i] > 0) {
+            first_attn_layer_idx = i;
+            break;
+        }
+    }
+
+    if (hparams.n_head(first_attn_layer_idx) > 0) {
         // gpt-neox n_rot = rotary_pct * (n_embd / n_head)
         // gpt-j n_rot = rotary_dim
 
-        hparams.n_embd_head_k_full = hparams.n_embd / hparams.n_head();
+        hparams.n_embd_head_k_full = hparams.n_embd / hparams.n_head(first_attn_layer_idx);
         ml.get_key(LLM_KV_ATTENTION_KEY_LENGTH, hparams.n_embd_head_k_full, false);
 
-        hparams.n_embd_head_v_full = hparams.n_embd / hparams.n_head();
+        hparams.n_embd_head_v_full = hparams.n_embd / hparams.n_head(first_attn_layer_idx);
         ml.get_key(LLM_KV_ATTENTION_VALUE_LENGTH, hparams.n_embd_head_v_full, false);
 
         // sanity check for n_rot (optional)

--- a/src/models/plamo2.cpp
+++ b/src/models/plamo2.cpp
@@ -273,7 +273,7 @@ ggml_tensor * llama_model_plamo2::graph::build_plamo2_mamba_layer(llm_graph_inpu
     GGML_ASSERT(n_seqs != 0);
     GGML_ASSERT(ubatch.equal_seqs());
     GGML_ASSERT(ubatch.n_tokens == n_seq_tokens * n_seqs);
-    GGML_ASSERT(d_inner % n_head == 0);
+    GGML_ASSERT(d_inner % n_heads == 0);
     GGML_ASSERT(n_group == 0);
 
     ggml_tensor * conv_states_all = mctx_cur->get_r_l(il);


### PR DESCRIPTION
## Overview

Fixes issue #24067 
llama.cpp failed to load the model with the following error:
```
error loading model: check_tensor_dims: tensor 'blk.1.attn_qkv.weight' has wrong shape; 
expected 2048, 0, got 2048, 2304, 1, 1
```

## Additional information
Plamo2 is a **hybrid architecture** that alternates between Mamba (SSM) layers and Attention layers:
- Even layers (0, 2, 4, ...): Mamba layers with `n_head = 0`
- Odd layers (1, 3, 5, ...): Attention layers with `n_head = 16`

The code checked `if (hparams.n_head() > 0)` to determine if the model has attention heads. However, `hparams.n_head()` with no argument returns the value for **layer 0**, it returns 0 because the code used layer 0's head count as a proxy for the whole model.

 
This caused the code to:
1.  skip the block that loads the attention head dimensions from GGUF metadata, leaving them at 0.
2. the QKV tensor dimension computed as [n_head * n_embd_head_k + ...] collapsed to 0, so the loader expected

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 
   - Used AI for automated compilation and debugging to check where the config mismatch is happening. It added debug print statement to check the configs loading. Identified at which points the output of loaded config mismatched, suggested a fix to enable and did iterative compilations for the final fix. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
