### PR TITLE
[SYCL] Update compute runtime version to 26.x in docker

### DIFF
--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -57,6 +57,16 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.url=$IMAGE_URL \
       org.opencontainers.image.source=$IMAGE_SOURCE
 
+#Following versions are for multiple GPUs, since 26.x has known issue:
+#   https://github.com/ggml-org/llama.cpp/issues/21747,
+#   https://github.com/intel/compute-runtime/issues/921.
+#ARG IGC_VERSION=v2.20.5
+#ARG IGC_VERSION_FULL=2_2.20.5+19972
+#ARG COMPUTE_RUNTIME_VERSION=25.40.35563.10
+#ARG COMPUTE_RUNTIME_VERSION_FULL=25.40.35563.10-0
+#ARG IGDGMM_VERSION=22.8.2
+
+
 ARG IGC_VERSION=v2.34.4
 ARG IGC_VERSION_FULL=2_2.34.4+21428
 ARG COMPUTE_RUNTIME_VERSION=26.18.38308.1

--- a/.devops/intel.Dockerfile
+++ b/.devops/intel.Dockerfile
@@ -57,11 +57,11 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.url=$IMAGE_URL \
       org.opencontainers.image.source=$IMAGE_SOURCE
 
-ARG IGC_VERSION=v2.20.5
-ARG IGC_VERSION_FULL=2_2.20.5+19972
-ARG COMPUTE_RUNTIME_VERSION=25.40.35563.10
-ARG COMPUTE_RUNTIME_VERSION_FULL=25.40.35563.10-0
-ARG IGDGMM_VERSION=22.8.2
+ARG IGC_VERSION=v2.34.4
+ARG IGC_VERSION_FULL=2_2.34.4+21428
+ARG COMPUTE_RUNTIME_VERSION=26.18.38308.1
+ARG COMPUTE_RUNTIME_VERSION_FULL=26.18.38308.1-0
+ARG IGDGMM_VERSION=22.10.0
 RUN mkdir /tmp/neo/ && cd /tmp/neo/ \
   && wget https://github.com/intel/intel-graphics-compiler/releases/download/$IGC_VERSION/intel-igc-core-${IGC_VERSION_FULL}_amd64.deb \
   && wget https://github.com/intel/intel-graphics-compiler/releases/download/$IGC_VERSION/intel-igc-opencl-${IGC_VERSION_FULL}_amd64.deb \


### PR DESCRIPTION
Fix issue: https://github.com/ggml-org/llama.cpp/issues/23160, https://github.com/ggml-org/llama.cpp/issues/23533

Use the 26.x compute runtime to improve the performance of Intel GPU.
Keep the old version (25.x) as comments: it can fix the known issue of multiple GPU error:
     https://github.com/ggml-org/llama.cpp/issues/21747
    https://github.com/intel/compute-runtime/issues/921

Tested locally and docker CI: https://github.com/arthw/llama.cpp/actions/runs/26876395054/job/79264816286