### PR TITLE
server: reject partial media truncation

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -1991,7 +1991,16 @@ mtmd_input_chunks * mtmd_test_create_input_chunks() {
     mtmd_image_tokens_ptr image_tokens(new mtmd_image_tokens);
     image_tokens->nx = 4;
     image_tokens->ny = 4;
-    image_tokens->batch_f32.entries.resize(16);
+    image_tokens->batch_f32.entries.reserve(16);
+    for (int i = 0; i < 16; ++i) {
+        clip_image_f32_ptr image(new clip_image_f32{
+            /* nx          */ 1,
+            /* ny          */ 1,
+            /* buf         */ { 0.0f },
+            /* add_viewsep */ false,
+        });
+        image_tokens->batch_f32.entries.emplace_back(std::move(image));
+    }
     image_tokens->id = "image_1";
     mtmd_input_chunk chunk_image{
         MTMD_INPUT_CHUNK_TYPE_IMAGE,

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -441,7 +441,7 @@ void server_tokens::keep_first(size_t n) {
             // note that the case where we keep a full image at the end is allowed:
             //   tokens[n - 1] == LLAMA_TOKEN_NULL && tokens[n] != LLAMA_TOKEN_NULL
             if (tokens[n - 1] == LLAMA_TOKEN_NULL && tokens[n] == LLAMA_TOKEN_NULL) {
-                find_chunk(n - 1); // will throw an error if the token is not begin-of-chunk
+                find_chunk(n); // will throw an error if the cut is not at a chunk boundary
             }
         }
         // remove all image chunks that are not used anymore

--- a/tools/server/tests/unit/test_vision_api.py
+++ b/tools/server/tests/unit/test_vision_api.py
@@ -28,6 +28,11 @@ def get_img_url(id: str) -> str:
         response = requests.get(IMG_URL_1)
         response.raise_for_status() # Raise an exception for bad status codes
         return base64.b64encode(response.content).decode("utf-8")
+    elif id == "IMG_BASE64_1X1":
+        return (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+            "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        )
     else:
         return id
 
@@ -144,6 +149,32 @@ def test_vision_completion(prompt, image_data, success, re_content):
         assert match_regex(re_content, content)
     else:
         assert res.status_code != 200
+
+
+def test_vision_completion_rejects_partial_media_keep():
+    global server
+    server.n_ctx = 512
+    server.n_slots = 1
+    server.n_predict = 1
+    server.start()
+    payload = {
+        "temperature": 0.0,
+        "top_k": 1,
+        "cache_prompt": True,
+        "n_predict": 1,
+        "prompt": {
+            JSON_PROMPT_STRING_KEY: "alpha beta gamma delta epsilon <__media__>",
+            JSON_MULTIMODAL_KEY: [ get_img_url("IMG_BASE64_1X1") ],
+        },
+    }
+
+    priming_res = server.make_request("POST", "/completion", data=payload)
+    assert priming_res.status_code == 200
+
+    res = server.make_request("POST", "/completion", data=payload)
+    assert res.status_code != 200
+    assert "error" in res.body
+    assert "Chunk not found" in res.body["error"]["message"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- make `server_tokens::keep_first` validate the cut position itself when both sides are media tokens
- reject truncation inside a media chunk instead of keeping the first media token and dropping the rest
- add regression coverage for `server_tokens` using the mtmd test chunks
- make the mtmd test image chunk copy-safe, since `server_tokens` copies media chunks internally

Fixes #24075.

## Tests

- `git diff --check`
- `cmake -S . -B build-codex -G Ninja -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_APP=OFF -DLLAMA_BUILD_UI=OFF -DLLAMA_CURL=OFF -DCMAKE_C_FLAGS="-D_WIN32_WINNT=0x0A00" -DCMAKE_CXX_FLAGS="-D_WIN32_WINNT=0x0A00"`
- `cmake --build build-codex --target test-server-tokens test-mtmd-c-api -j 2`
- `cmake -E env "PATH=C:\mingw64\bin;$env:PATH" ctest --test-dir build-codex -R "test-server-tokens|test-mtmd-c-api" --output-on-failure`
