### PR TITLE
Optimizing SVE and NEON Support for PaddleOCR VL on ARM Architecture

### DIFF
--- a/ggml/src/ggml-cpu/simd-gemm.h
+++ b/ggml/src/ggml-cpu/simd-gemm.h
@@ -109,6 +109,109 @@ static void simd_gemm(
         C += N;
     }
 }
+#elif defined(GGML_SIMD) && defined(__ARM_FEATURE_SVE) && defined(__ARM_FEATURE_FMA)
+
+static constexpr int GEMM_RM = 4;
+
+template <int RM>
+static inline void sve_simd_gemm_ukernel(
+    float       * GGML_RESTRICT C,
+    const float * GGML_RESTRICT A,
+    const float * GGML_RESTRICT B,
+    int K, int N, int KN, svbool_t pg_rem)
+{
+    svfloat32_t acc0, acc1, acc2, acc3;
+    if constexpr (RM > 0) acc0 = svld1_f32(pg_rem, C + 0 * N);
+    if constexpr (RM > 1) acc1 = svld1_f32(pg_rem, C + 1 * N);
+    if constexpr (RM > 2) acc2 = svld1_f32(pg_rem, C + 2 * N);
+    if constexpr (RM > 3) acc3 = svld1_f32(pg_rem, C + 3 * N);
+
+    for (int kk = 0; kk < K; kk++) {
+        svfloat32_t Bv = svld1_f32(pg_rem, B + kk * N);
+        if constexpr (RM > 0) {
+            svfloat32_t p = svdup_n_f32(A[0 * K + kk]);
+            acc0 = svmad_f32_m(pg_rem, Bv, p, acc0);
+        }
+        if constexpr (RM > 1) {
+            svfloat32_t p = svdup_n_f32(A[1 * K + kk]);
+            acc1 = svmad_f32_m(pg_rem, Bv, p, acc1);
+        }
+        if constexpr (RM > 2) {
+            svfloat32_t p = svdup_n_f32(A[2 * K + kk]);
+            acc2 = svmad_f32_m(pg_rem, Bv, p, acc2);
+        }
+        if constexpr (RM > 3) {
+            svfloat32_t p = svdup_n_f32(A[3 * K + kk]);
+            acc3 = svmad_f32_m(pg_rem, Bv, p, acc3);
+        }
+    }
+
+    if constexpr (RM > 0) svst1_f32(pg_rem, C + 0 * N, acc0);
+    if constexpr (RM > 1) svst1_f32(pg_rem, C + 1 * N, acc1);
+    if constexpr (RM > 2) svst1_f32(pg_rem, C + 2 * N, acc2);
+    if constexpr (RM > 3) svst1_f32(pg_rem, C + 3 * N, acc3);
+}
+
+template <int RM>
+static inline void sve_simd_gemm_dispatch_tail(
+    float       * GGML_RESTRICT C,
+    const float * GGML_RESTRICT A,
+    const float * GGML_RESTRICT B,
+    int K, int N, int KN, int remaining_rows, svbool_t pg_rem)
+{
+    if constexpr (RM > 0) {
+        if (remaining_rows == RM) {
+            sve_simd_gemm_ukernel<RM>(C, A, B, K, N, KN, pg_rem);
+        } else {
+            sve_simd_gemm_dispatch_tail<RM - 1>(C, A, B, K, N, KN, remaining_rows, pg_rem);
+        }
+    }
+}
+
+static void simd_gemm(
+    float       * GGML_RESTRICT C,
+    const float * GGML_RESTRICT A,
+    const float * GGML_RESTRICT B,
+    int M, int K, int N)
+{
+    static bool warned = false;
+    if (!warned) {
+        // fprintf(stderr, "DEBUG: Using SVE optimized simd_gemm path (M=%d, K=%d, N=%d)\n", M, K, N);
+        warned = true;
+    }
+    const int KN = svcntw();
+    svbool_t pg = svptrue_b32();
+
+    int64_t ii = 0;
+    for (; ii + GEMM_RM <= M; ii += GEMM_RM) {
+        int64_t jj = 0;
+        for (; jj + KN <= N; jj += KN) {
+            sve_simd_gemm_ukernel<GEMM_RM>(C + jj, A, B + jj, K, N, KN, pg);
+        }
+        if (jj < N) {
+            int rem_n = N - (int)jj;
+            svbool_t pg_rem = svwhilelt_b32(0, rem_n);
+            sve_simd_gemm_ukernel<GEMM_RM>(C + jj, A, B + jj, K, N, KN, pg_rem);
+        }
+
+        A += GEMM_RM * K;
+        C += GEMM_RM * N;
+    }
+
+    int remaining_rows = M - (int)ii;
+    if (remaining_rows > 0) {
+        int64_t jj = 0;
+        for (; jj + KN <= N; jj += KN) {
+            sve_simd_gemm_dispatch_tail<GEMM_RM - 1>(C + jj, A, B + jj, K, N, KN, remaining_rows, pg);
+        }
+        if (jj < N) {
+            int rem_n = N - (int)jj;
+            svbool_t pg_rem = svwhilelt_b32(0, rem_n);
+            sve_simd_gemm_dispatch_tail<GEMM_RM - 1>(C + jj, A, B + jj, K, N, KN, remaining_rows, pg_rem);
+        }
+    }
+}
+
 #elif defined(GGML_SIMD) && defined(__riscv_v_intrinsic)
 // RM accumulators + 1 B vector = RM + 1 <= 8  =>  RM <= 7
 // Microkernel: C[RM x vl] += A[RM x K] * B[K x N]

--- a/ggml/src/ggml-cpu/vec.h
+++ b/ggml/src/ggml-cpu/vec.h
@@ -1540,11 +1540,24 @@ inline static void ggml_vec_sum_bf16_ggf(const int n, float * s, const ggml_bf16
 
 inline static void ggml_vec_max_f32(const int n, float * s, const float * x) {
 #ifndef GGML_USE_ACCELERATE
+#if defined(__ARM_NEON)
+    int i = 0;
+    float32x4_t max_vec = vdupq_n_f32(-INFINITY);
+    for (; i + 3 < n; i += 4) {
+        max_vec = vmaxq_f32(max_vec, vld1q_f32(x + i));
+    }
+    float max_val = vmaxvq_f32(max_vec);
+    for (; i < n; i++) {
+        max_val = MAX(max_val, x[i]);
+    }
+    *s = max_val;
+#else
     float max = -INFINITY;
     for (int i = 0; i < n; ++i) {
         max = MAX(max, x[i]);
     }
     *s = max;
+#endif
 #else
     vDSP_maxv(x, 1, s, n);
 #endif

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -10,6 +10,13 @@
 // FIXME: required here for quantization functions
 #include "ggml-quants.h"
 
+#ifdef __ARM_FEATURE_SVE
+#include <arm_sve.h>
+#endif
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+#endif
+
 #ifdef GGML_USE_CPU_HBM
 #include <hbwmalloc.h>
 #endif
@@ -466,9 +473,32 @@ ggml_bf16_t ggml_fp32_to_bf16(float x) {
 }
 
 void ggml_fp16_to_fp32_row(const ggml_fp16_t * x, float * y, int64_t n) {
+#if defined(__ARM_FEATURE_SVE)
+    int64_t i = 0;
+    for (; i + svcntw() <= n; i += svcntw()) {
+        svbool_t pg = svwhilelt_b16_s32(i, n);
+        svfloat32_t val = svcvt_f32_f16_x(pg, svld1_f16(pg, (const __fp16 *)x + i));
+        svst1_f32(pg, y + i, val);
+    }
+    for (; i < n; i++) {
+        y[i] = GGML_FP16_TO_FP32(x[i]);
+    }
+#elif defined(__ARM_NEON)
+    int64_t i = 0;
+    for (; i + 7 < n; i += 8) {
+        float32x4_t val0 = vcvt_f32_f16(vld1_f16((const __fp16 *)x + i + 0));
+        float32x4_t val1 = vcvt_f32_f16(vld1_f16((const __fp16 *)x + i + 4));
+        vst1q_f32(y + i + 0, val0);
+        vst1q_f32(y + i + 4, val1);
+    }
+    for (; i < n; i++) {
+        y[i] = GGML_FP16_TO_FP32(x[i]);
+    }
+#else
     for (int64_t i = 0; i < n; i++) {
         y[i] = GGML_FP16_TO_FP32(x[i]);
     }
+#endif
 }
 
 void ggml_fp32_to_fp16_row(const float * x, ggml_fp16_t * y, int64_t n) {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -4190,13 +4190,17 @@ bool clip_image_batch_encode(clip_ctx * ctx, const int n_threads, const clip_ima
             GGML_ABORT("Unknown projector type");
     }
 
-    // ggml_backend_cpu_set_n_threads(ctx->backend_cpu, n_threads);
-    ggml_backend_dev_t dev = ggml_backend_get_device(ctx->backend_cpu);
-    ggml_backend_reg_t reg = dev ? ggml_backend_dev_backend_reg(dev) : nullptr;
-    if (reg) {
-        auto ggml_backend_set_n_threads_fn = (ggml_backend_set_n_threads_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_set_n_threads");
-        if (ggml_backend_set_n_threads_fn) {
-            ggml_backend_set_n_threads_fn(ctx->backend_cpu, n_threads);
+    ggml_backend_t backends[] = { ctx->backend, ctx->backend_cpu };
+    for (auto b : backends) {
+        if (!b) continue;
+        ggml_backend_cpu_set_n_threads(b, n_threads);
+        ggml_backend_dev_t dev = ggml_backend_get_device(b);
+        ggml_backend_reg_t reg = dev ? ggml_backend_dev_backend_reg(dev) : nullptr;
+        if (reg) {
+            auto ggml_backend_set_n_threads_fn = (ggml_backend_set_n_threads_t) ggml_backend_reg_get_proc_address(reg, "ggml_backend_set_n_threads");
+            if (ggml_backend_set_n_threads_fn) {
+                ggml_backend_set_n_threads_fn(b, n_threads);
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

This PR optimizes the Matrix Multiplication (MatMul) performance on ARM architecture by improving/rewriting the SVE and NEON instruction paths. 

Key changes include:
- Optimized clip path of PaddleOCRVL  using ARM SVE/NEON assembly/intrinsics.

## Test Results
Images Size: 823*1165
Models: PaddleOCR-VL-1.5-Q4_0.gguf, PaddleOCR-VL-1.5-mmproj-q8_0.gguf
Environment: Radxa Orion O6 (Arm V9)
Run Time(s) before Optimization:
```text
# Total Time
3min
# Some profiling logs
  [op profiling] Kcur_pos-0 (permuted) (copy)       :      1.245 ms
  [op profiling] Vcur-0 (permuted) (copy)           :      1.537 ms
  [op profiling] node_35                            :   5122.599 ms
  [op profiling] node_37                            :     44.011 ms
  [op profiling] attn_out-0                         :      0.693 ms
  [op profiling] ffn_inp-0                          :      1.423 ms
```
Run Time(s) after Optimization
```text
# Total Time
1min
# Some profiling logs
  [op profiling] Kcur_pos-0 (permuted) (copy)       :      1.358 ms
  [op profiling] Vcur-0 (permuted) (copy)           :      3.856 ms
  [op profiling] node_36                            :   1085.529 ms
  [op profiling] node_38                            :     54.999 ms
  [op profiling] ffn_inp-0                          :      1.304 ms
```

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES