### PR TITLE
fix issue #22920 by including unordered_map in tools/server/server-ht…

### DIFF
--- a/tools/server/server-http.h
+++ b/tools/server/server-http.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include <vector>
 #include <cstdint>
+#include <unordered_map>
 
 struct common_params;
 


### PR DESCRIPTION
…tp.h

## Overview
This includes a fix for issue https://github.com/ggml-org/llama.cpp/issues/22920 where a missing include for `unordered_map` in `tools/server/server-http.h` causes a compile-time break in macos 15.xx. The latest main branch now builds on macos 15.7.7.

## Additional information

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO 
