### PR TITLE
server: add -pp parameter to force enable/disable pipeline parallelism

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1390,6 +1390,22 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                            }
                        }).set_env("LLAMA_ARG_FLASH_ATTN"));
     add_opt(common_arg(
+        {"-pp", "--pipeline-parallelism"}, "[on|off|auto]",
+        "set pipeline parallelism ('on', 'off', or 'auto', default: 'auto')",
+        [](common_params & params, const std::string & value) {
+            if (is_truthy(value)) {
+                params.pp = LLAMA_PIPELINE_PARALLELISM_ENABLED;
+            } else if (is_falsey(value)) {
+                params.pp = LLAMA_PIPELINE_PARALLELISM_DISABLED;
+            } else if (is_autoy(value)) {
+                params.pp = LLAMA_PIPELINE_PARALLELISM_AUTO;
+            } else {
+                throw std::runtime_error(
+                    string_format("error: unknown value for --pipeline-parallelism: '%s'\n", value.c_str()));
+            }
+        }
+    ).set_env("LLAMA_ARG_PIPELINE_PARALLELISM"));
+    add_opt(common_arg(
         {"-p", "--prompt"}, "PROMPT",
         "prompt to start generation with; for system message, use -sys",
         [](common_params & params, const std::string & value) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1585,6 +1585,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.op_offload        = !params.no_op_offload;
     cparams.swa_full          = params.swa_full;
     cparams.kv_unified        = params.kv_unified;
+    cparams.pp = params.pp;
 
     cparams.type_k = params.cache_type_k;
     cparams.type_v = params.cache_type_v;

--- a/common/common.h
+++ b/common/common.h
@@ -458,6 +458,7 @@ struct common_params {
     std::vector<size_t> fit_params_target = std::vector<size_t>(llama_max_devices(), 1024 * 1024*1024);
 
     enum llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER; // how to split the model across GPUs
+    enum llama_pipeline_parallelism pp = LLAMA_PIPELINE_PARALLELISM_AUTO; // force enable or disable pipeline parallelism
 
     common_cpu_params cpuparams;
     common_cpu_params cpuparams_batch;

--- a/include/llama.h
+++ b/include/llama.h
@@ -203,6 +203,12 @@ extern "C" {
         LLAMA_CONTEXT_TYPE_MTP     = 1,
     };
 
+    enum llama_pipeline_parallelism {
+        LLAMA_PIPELINE_PARALLELISM_AUTO     = -1,
+        LLAMA_PIPELINE_PARALLELISM_DISABLED = 0,
+        LLAMA_PIPELINE_PARALLELISM_ENABLED  = 1,
+    };
+
     // TODO: simplify (https://github.com/ggml-org/llama.cpp/pull/9294#pullrequestreview-2286561979)
     typedef struct llama_token_data {
         llama_token id; // token id
@@ -348,6 +354,7 @@ extern "C" {
         enum llama_pooling_type      pooling_type;      // whether to pool (sum) embedding results by sequence id
         enum llama_attention_type    attention_type;    // attention type to use for embeddings
         enum llama_flash_attn_type   flash_attn_type;   // when to enable Flash Attention
+        enum llama_pipeline_parallelism pp;             // force enable/disable pipeline parallelism
 
         // ref: https://github.com/ggml-org/llama.cpp/pull/2054
         float    rope_freq_base;   // RoPE base frequency, 0 = from model

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -189,6 +189,7 @@ llama_context::llama_context(
 
     // initialized later
     cparams.pipeline_parallel = false;
+    cparams.pp = params.pp;
 
     {
         const char * LLAMA_GRAPH_REUSE_DISABLE = getenv("LLAMA_GRAPH_REUSE_DISABLE");
@@ -230,6 +231,7 @@ llama_context::llama_context(
     LLAMA_LOG_INFO("%s: freq_scale    = %g\n",   __func__, cparams.rope_freq_scale);
     LLAMA_LOG_INFO("%s: n_rs_seq      = %u\n",   __func__, cparams.n_rs_seq);
     LLAMA_LOG_INFO("%s: n_outputs_max = %u\n",   __func__, cparams.n_outputs_max);
+    LLAMA_LOG_INFO("%s: pp            = %u\n",   __func__, cparams.pp);
 
     if (cparams.n_ctx_seq < hparams.n_ctx_train) {
         LLAMA_LOG_WARN("%s: n_ctx_seq (%u) < n_ctx_train (%u) -- the full capacity of the model will not be utilized\n",
@@ -365,10 +367,16 @@ llama_context::llama_context(
             }
         }
 
+        if (cparams.pp == LLAMA_PIPELINE_PARALLELISM_DISABLED) {
+            pipeline_parallel = false;
+        }
+
         cparams.pipeline_parallel = pipeline_parallel;
 
         if (cparams.pipeline_parallel) {
             LLAMA_LOG_INFO("%s: pipeline parallelism enabled\n", __func__);
+        } else {
+            LLAMA_LOG_INFO("%s: pipeline parallelism disabled\n", __func__);
         }
 
         sched_reserve();
@@ -588,6 +596,9 @@ void llama_context::sched_reserve() {
                 model.hparams.no_alloc, model.hparams.no_alloc ? backend_buf_exp_size.data() : nullptr);
         if (!gf) {
             if (cparams.pipeline_parallel) {
+                if (cparams.pp == LLAMA_PIPELINE_PARALLELISM_ENABLED) {
+                    throw std::runtime_error("compute buffer allocation with pipeline parallelism failed");
+                }
                 LLAMA_LOG_WARN("%s: compute buffer allocation failed, retrying without pipeline parallelism\n", __func__);
                 cparams.pipeline_parallel = false;
                 sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, false, cparams.op_offload));
@@ -3352,6 +3363,7 @@ llama_context_params llama_context_default_params() {
         /*.pooling_type                =*/ LLAMA_POOLING_TYPE_UNSPECIFIED,
         /*.attention_type              =*/ LLAMA_ATTENTION_TYPE_UNSPECIFIED,
         /*.flash_attn_type             =*/ LLAMA_FLASH_ATTN_TYPE_AUTO,
+        /*.pp                          =*/ LLAMA_PIPELINE_PARALLELISM_AUTO,
         /*.rope_freq_base              =*/ 0.0f,
         /*.rope_freq_scale             =*/ 0.0f,
         /*.yarn_ext_factor             =*/ -1.0f,

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -377,6 +377,9 @@ llama_context::llama_context(
             LLAMA_LOG_INFO("%s: pipeline parallelism enabled\n", __func__);
         } else {
             LLAMA_LOG_INFO("%s: pipeline parallelism disabled\n", __func__);
+            if (cparams.pp == LLAMA_PIPELINE_PARALLELISM_ENABLED) {
+                throw std::runtime_error("pipeline parallelism enabled by user but unsupported in this configuration");
+            }
         }
 
         sched_reserve();

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -46,6 +46,7 @@ struct llama_cparams {
 
     enum llama_context_type ctx_type;
     enum llama_pooling_type pooling_type;
+    enum llama_pipeline_parallelism pp;
 
     ggml_backend_sched_eval_callback cb_eval;
     void * cb_eval_user_data;


### PR DESCRIPTION
## Overview

Add a `-pp` option that forces enabling/disabling pipeline parallelism.

Currently, pipeline parallelism is enabled automatically provided the requirements are met, and disabled automatically if there is not enough memory for it to allocate. This is not desirable in some situations:

- Case 1: I want to enable pipeline parallelism, and to be certain that it is enabled. If it can't allocate memory and gets disabled, I want it to fail rather than switch to a low-performance mode with only a warning in the logs.
- Case 2: Pipeline parallelism does not work for me. But it still grabs its memory, and quite a significant amount of it, for doing nothing. I want to disable it, even though I do have enough memory, because I need that memory as "headroom" for operating at a long context (which will fail when you reach that much context unless you have enough headroom).

Of course, the default mode is "auto", which keeps the current behavior.

Related to #24026 - pipeline parallelism still does not work for me, but at least now I have a way to disable it.

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

I've tested this and I'm using this myself, but I'm not very confident about my understanding of the codebase and code style. If I missed something, feel free to modify the PR, or implement it in a different way.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I've used AI to help me navigate the code base, find the relevant parts, explain the code to me, do code review and make sure I have not missed anything (I'm pretty sure I've missed something anyway, so a human review is still necessary). It also provided examples of what I might want to do, but those were pretty clueless, so I've used existing options as a reference instead. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
