### PR TITLE
server: avoid unnecessary checkpoint restore when new tokens are present

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2781,9 +2781,10 @@ private:
                             }
 
                             llama_pos pos_next = slot.prompt.tokens.pos_next(n_past);
+                            const bool has_new_tokens = (n_past < slot.task->n_tokens());
 
                             // the largest pos_min required for a checkpoint to be useful
-                            const auto pos_min_thold = std::max(0, pos_next - n_swa - 1);
+                            const auto pos_min_thold = std::max(0, pos_next - n_swa - (has_new_tokens ? 0 : 1));
 
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2781,6 +2781,8 @@ private:
                             }
 
                             llama_pos pos_next = slot.prompt.tokens.pos_next(n_past);
+
+                            // ref: https://github.com/ggml-org/llama.cpp/pull/24110
                             const bool has_new_tokens = (n_past < slot.task->n_tokens());
 
                             // the largest pos_min required for a checkpoint to be useful


### PR DESCRIPTION
#23280 fixed a crash on hybrid attention models, but might restoring checkpoint rather than reusing current slot even if the input prompt gets full prefix matching and also has new tokens (means there is still tokens to be evaluated).

## Overview
Avoid unnecessary checkpoint restore when the request contains new tokens beyond the cached prefix.

The `pos_min_thold` calculation unconditionally subtracts `1` to guard against the edge case where `n_past == n_tokens()` (no tokens to evaluate for logits). However, when the request has new tokens to process, this `-1` is overly conservative and may trigger a redundant checkpoint restore, involving unnecessary KV state deserialization and GPU memory writes.

This change conditionally applies the `-1` only when `n_past >= task.n_tokens()` (no new tokens), skipping unnecessary checkpoint restoration when there is actual work to do.

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to analyze the checkpoint restore logic.
