### PR TITLE
test(server): homogeneize slow tests eviction

### DIFF
--- a/.github/workflows/server-sanitize.yml
+++ b/.github/workflows/server-sanitize.yml
@@ -109,4 +109,4 @@ jobs:
         run: |
           cd tools/server/tests
           export ${{ matrix.extra_args }}
-          SLOW_TESTS=1 pytest -v -x
+          pytest -v -x

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -111,7 +111,7 @@ jobs:
         if: ${{ github.event.schedule || github.event.inputs.slow_tests == 'true' }}
         run: |
           cd tools/server/tests
-          SLOW_TESTS=1 pytest -v -x
+          pytest -v -x
 
       - name: Tests (Backend sampling)
         id: server_integration_tests_backend_sampling
@@ -177,5 +177,4 @@ jobs:
         if: ${{ github.event.schedule || github.event.inputs.slow_tests == 'true' }}
         run: |
           cd tools/server/tests
-          $env:SLOW_TESTS = "1"
           pytest -v -x

--- a/tools/server/tests/unit/test_infill.py
+++ b/tools/server/tests/unit/test_infill.py
@@ -57,7 +57,7 @@ def test_invalid_input_extra_req(input_extra):
     assert "error" in res.body
 
 
-@pytest.mark.skipif(not is_slow_test_allowed(), reason="skipping slow test")
+@pytest.mark.slow
 def test_with_qwen_model():
     global server
     server.model_file = None

--- a/tools/server/tests/unit/test_lora.py
+++ b/tools/server/tests/unit/test_lora.py
@@ -66,7 +66,7 @@ def test_lora_per_request():
         assert match_regex(re_test, res.body["content"])
 
 
-@pytest.mark.skipif(not is_slow_test_allowed(), reason="skipping slow test")
+@pytest.mark.slow
 def test_with_big_model():
     server = ServerProcess()
     server.model_hf_repo = "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF"

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -676,7 +676,3 @@ def download_file(url: str, output_file_path: str | None = None) -> str:
     else:
         print(f"File already exists at {output_file}")
     return output_file
-
-
-def is_slow_test_allowed():
-    return os.environ.get("SLOW_TESTS") == "1" or os.environ.get("SLOW_TESTS") == "ON"


### PR DESCRIPTION
The most recent server tests are excluded by passing "-m not slow" on the pytest command line, but some older tests used the legacy SLOW_TESTS = 1 opt-in mechanism. This aligns all tests.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
