### PR TITLE
server: allow missing/null content key in OpenAI Responses API

### DIFF
--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -219,25 +219,27 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
                 item.at("type") == "reasoning") {
                 // #responses_create-input-input_item_list-item-reasoning
 
-                if (!exists_and_is_array(item, "content")) {
-                    throw std::invalid_argument("item['content'] is not an array");
-                }
-                if (item.at("content").empty()) {
-                    throw std::invalid_argument("item['content'] is empty");
-                }
-                if (!exists_and_is_string(item.at("content")[0], "text")) {
-                    throw std::invalid_argument("item['content']['text'] is not a string");
-                }
+                if (item.contains("content") && !item.at("content").is_null()) {
+                    if (!item.at("content").is_array()) {
+                        throw std::invalid_argument("item['content'] is not an array");
+                    }
+                    if (item.at("content").empty()) {
+                        throw std::invalid_argument("item['content'] is empty");
+                    }
+                    if (!exists_and_is_string(item.at("content")[0], "text")) {
+                        throw std::invalid_argument("item['content']['text'] is not a string");
+                    }
 
-                if (merge_prev) {
-                    auto & prev_msg = chatcmpl_messages.back();
-                    prev_msg["reasoning_content"] = item.at("content")[0].at("text");
-                } else {
-                    chatcmpl_messages.push_back(json {
-                        {"role", "assistant"},
-                        {"content", json::array()},
-                        {"reasoning_content", item.at("content")[0].at("text")},
-                    });
+                    if (merge_prev) {
+                        auto & prev_msg = chatcmpl_messages.back();
+                        prev_msg["reasoning_content"] = item.at("content")[0].at("text");
+                    } else {
+                        chatcmpl_messages.push_back(json {
+                            {"role", "assistant"},
+                            {"content", json::array()},
+                            {"reasoning_content", item.at("content")[0].at("text")},
+                        });
+                    }
                 }
             } else {
                 throw std::invalid_argument("Cannot determine type of 'item'");


### PR DESCRIPTION
For the OpenAI Responses API shim, allows the 'content' key of 'reasoning' items to be missing or null.

See explanation in issue #24115.

## Overview

The existing code extracts the `content` of items of type `reasoning` when converting `responses` API requests to the `completions` API format. It therefore requires that any objects in the `items` array of type `reasoning` contain a `content` key and throws if not.

However, the OpenAI spec makes it clear that clients only "may" include content in such a item, not that it's mandatory.

This PR wraps the logic that extracts the `content` in an `if` statement so it is skipped if the `content` key is missing or `null`. In effect, items of type `reasoning` are simply ignored if there is no `content`.

## Additional information

See explanation in issue #24115.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no AI used

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
