### PR TITLE
fix: step35 MTP does not allocate KV cache for all layers

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2112,6 +2112,15 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                         filter = [n_main](int32_t il) { return (uint32_t)il >= n_main; };
                     }
 
+                    if (arch == LLM_ARCH_STEP35 && hparams.nextn_predict_layers > 0) {
+                        const uint32_t n_main = hparams.n_layer - hparams.nextn_predict_layers;
+                        if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP) {
+                            filter = [n_main](int32_t il) { return (uint32_t)il >= n_main; };
+                        } else {
+                            filter = [n_main](int32_t il) { return (uint32_t)il <  n_main; };
+                        }
+                    }
+
                     if (hparams.swa_type != LLAMA_SWA_TYPE_NONE) {
                         GGML_ASSERT(hparams.is_swa_any());
 


### PR DESCRIPTION
## Overview

While testing the Step3.5 mtp feature from #23274 (cc @pwilkin ), the memory watermark felt high. Turns out draft context allocates a KV cache for all layers, even though it only runs the NextN block(s).

STEP35 isn't a hybrid arch, so it misses the per-context KV layer filter that Qwen3.5 already has. This just adds the same filter for STEP35: the MTP context keeps only the NextN blocks (`il >= n_main`), the main context keeps the trunk (`il < n_main`). 

**Before**:
  ```
  5051:0.03.567.532 I srv    load_model: loading draft model '/xxx/Step3.7-flash-mtp-Q8_0.gguf'
  llama_kv_cache: size = 1644.00 MiB (35072 cells, 12 layers, 1/1 seqs), K (f16): 822.00 MiB, V (f16): 822.00 MiB
  llama_kv_cache: size =  216.00 MiB ( 1536 cells, 36 layers, 1/1 seqs), K (f16): 108.00 MiB, V (f16): 108.00 MiB
  ```

  **After** :
  ```
  5050:0.03.544.909 I srv    load_model: loading draft model '/xxx/Step3.7-flash-mtp-Q8_0.gguf'
  llama_kv_cache: size =    0.00 MiB (35072 cells,  0 layers, 1/1 seqs), K (f16):   0.00 MiB, V (f16):   0.00 MiB
  llama_kv_cache: size =   18.00 MiB ( 1536 cells,  3 layers, 1/1 seqs), K (f16):   9.00 MiB, V (f16):   9.00 MiB
  ```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
