### PR TITLE
ggml-rpc : bound rdma_recv completion length before copy

### DIFF
--- a/ggml/src/ggml-rpc/transport.cpp
+++ b/ggml/src/ggml-rpc/transport.cpp
@@ -447,6 +447,18 @@ bool socket_t::impl::rdma_recv(void * data, size_t size) {
 
         int slot = (int)wc.wr_id;
         size_t got = wc.byte_len;
+        // The completion length is controlled by the remote peer (up to the
+        // posted recv-slot size). A peer that sends more than the logical recv
+        // expects would overflow `dst` here, and `rem -= got` below would
+        // underflow (size_t), turning the loop into an unbounded copy. A
+        // zero-length completion would also make no progress (rem never
+        // decreases) -> spin on repeated 0-byte sends. Reject both and tear the
+        // connection down rather than clamp, so a malformed peer cannot silently
+        // desync the logical message stream.
+        if (got == 0 || got > rem) {
+            GGML_LOG_ERROR("rdma_recv: bad chunk (got=%zu rem=%zu)\n", got, rem);
+            return false;
+        }
         memcpy(dst, c->rx_slot(slot), got);
 
         if (!c->post_rx(slot)) return false;


### PR DESCRIPTION
Found this fuzzing the RPC RDMA transport. `socket_t::impl::rdma_recv` (`ggml/src/ggml-rpc/transport.cpp:450`) copies `wc.byte_len` bytes into the caller's buffer with no check that it fits the requested size, then does `rem -= got` — a `size_t` underflow. The completion length is peer-controlled (up to the posted recv-slot size), so a peer that sends more than the logical recv expects overflows the destination and turns the loop into an unbounded copy; a zero-length completion makes no progress and spins.

Hit it as an ASAN stack-buffer-overflow WRITE on real RoCEv2 hardware with a single oversized post-HELLO SEND. DoS is confirmed (deterministic abort); I have not demonstrated control-transfer, so I'm not claiming RCE — just a peer-reachable out-of-bounds write.

The fix bounds `got` before the copy (kills the OOB write, the `rem -= got` underflow, and a 0-length spin) and drops the connection rather than clamping, so a malformed peer can't silently desync the message stream. Re-confirmed unpatched on master before filing; fix-validated on the same hardware (the oversized SEND now fails closed).

This is the experimental RPC backend, which SECURITY.md places outside the covered threat model — so I'm filing it as a robustness fix, not a security-scope claim. Full PoC + a SoftRoCE repro available on request.

AI usage disclosure: AI-assisted in the RDMA fuzzing that surfaced this and in drafting the fix; I validated the overflow and the fix on real hardware myself and own the change.