### PR TITLE
minja : cap range() materialization in chat-template render

### DIFF
--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -402,10 +402,29 @@ const func_builtins & global_builtins() {
                 step = arg2->as_int();
             }
 
-            auto out = mk_val<value_array>();
             if (step == 0) {
                 throw raised_exception("range() step argument must not be zero");
             }
+
+            constexpr uint64_t RANGE_RENDER_LIMIT = 1000000;
+            uint64_t range_size = 0;
+            if (step > 0) {
+                if (start < stop) {
+                    const uint64_t span = static_cast<uint64_t>(stop) - static_cast<uint64_t>(start) - 1;
+                    range_size = span / static_cast<uint64_t>(step) + 1;
+                }
+            } else if (start > stop) {
+                const uint64_t span = static_cast<uint64_t>(start) - static_cast<uint64_t>(stop) - 1;
+                range_size = span / static_cast<uint64_t>(-step) + 1;
+            }
+
+            if (range_size > RANGE_RENDER_LIMIT) {
+                throw raised_exception(
+                    "range() size " + std::to_string(range_size) +
+                    " exceeds render limit " + std::to_string(RANGE_RENDER_LIMIT));
+            }
+
+            auto out = mk_val<value_array>();
             if (step > 0) {
                 for (int64_t i = start; i < stop; i += step) {
                     out->push_back(mk_val<value_int>(i));


### PR DESCRIPTION
minja's `range()` (`common/jinja/value.cpp`) materializes the full iterable into an array before the loop runs, with no size check. A model's `chat_template` containing `{% for i in range(1000000000) %}` makes template rendering try to build a billion-element array — on `llama-cli` the process hangs until it's killed.

This caps `range()` at 1M elements: compute the count first with overflow-safe arithmetic, and throw a clean `range() size N exceeds render limit` before allocating. Real chat templates use `range()` proportional to the conversation (the shipped `models/templates/` all use `range(messages|length...)`-scale), so the cap sits orders of magnitude above legitimate use — no behavior change for normal templates.

Verified on a real GGUF: a `range(10**9)` template went from watchdog-killed (rc 137, never reaching a template error) to a deterministic `range() size 1000000000 exceeds render limit 1000000` error; shipped `range()`-using templates render unchanged. On `llama-server` the capped error fails closed (clean model-load error); on `llama-cli` it currently surfaces via the same uncaught-template-error path as #24093.

Framing this as reliability hardening on the chat-template render path (adjacent to #24093), not a security report — SECURITY.md excludes DoS and recommends sandboxing untrusted models. It's intentionally narrow: caps `range()` materialization only; it does not bound arbitrary `for` loops over large arrays or deep recursion (a general render budget could be a follow-up). The 1M cap is bikesheddable — happy to lower it (e.g. 100k) if preferred.

AI usage disclosure: AI-assisted in finding this (fuzzing chat-template rendering) and drafting the cap; I validated the before/after on real hardware and own the change.