### PR TITLE
mtmd : validate mmproj metadata arrays before consuming

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1176,6 +1176,9 @@ struct clip_model_loader {
                 std::vector<int> pinpoints;
                 get_arr_int(KEY_IMAGE_GRID_PINPOINTS, pinpoints, false);
                 if (!pinpoints.empty()) {
+                    if (pinpoints.size() % 2 != 0) {
+                        throw std::runtime_error(string_format("%s: %s must be an even-length int32 array\n", __func__, KEY_IMAGE_GRID_PINPOINTS));
+                    }
                     for (size_t i = 0; i < pinpoints.size(); i += 2) {
                         hparams.image_res_candidates.push_back({
                             pinpoints[i],
@@ -1221,6 +1224,16 @@ struct clip_model_loader {
                 int idx_std  = gguf_find_key(ctx_gguf.get(), KEY_IMAGE_STD);
                 GGML_ASSERT(idx_mean >= 0 && "image_mean not found");
                 GGML_ASSERT(idx_std >= 0  && "image_std not found");
+                const gguf_type mean_type = gguf_get_arr_type(ctx_gguf.get(), idx_mean);
+                const gguf_type std_type  = gguf_get_arr_type(ctx_gguf.get(), idx_std);
+                const size_t mean_len = gguf_get_arr_n(ctx_gguf.get(), idx_mean);
+                const size_t std_len  = gguf_get_arr_n(ctx_gguf.get(), idx_std);
+                if (mean_type != GGUF_TYPE_FLOAT32 || mean_len != 3) {
+                    throw std::runtime_error(string_format("%s: %s must be a float32 array of length 3, got %s[%zu]\n", __func__, KEY_IMAGE_MEAN, gguf_type_name(mean_type), mean_len));
+                }
+                if (std_type != GGUF_TYPE_FLOAT32 || std_len != 3) {
+                    throw std::runtime_error(string_format("%s: %s must be a float32 array of length 3, got %s[%zu]\n", __func__, KEY_IMAGE_STD, gguf_type_name(std_type), std_len));
+                }
                 const float * mean_data = (const float *) gguf_get_arr_data(ctx_gguf.get(), idx_mean);
                 const float * std_data  = (const float *) gguf_get_arr_data(ctx_gguf.get(), idx_std);
                 for (int i = 0; i < 3; ++i) {
@@ -2919,7 +2932,11 @@ struct clip_model_loader {
             }
             return;
         }
-        int n = gguf_get_arr_n(ctx_gguf.get(), i);
+        const gguf_type arr_type = gguf_get_arr_type(ctx_gguf.get(), i);
+        if (arr_type != GGUF_TYPE_INT32) {
+            throw std::runtime_error(string_format("%s: %s must be an int32 array, got %s\n", __func__, key.c_str(), gguf_type_name(arr_type)));
+        }
+        const int n = gguf_get_arr_n(ctx_gguf.get(), i);
         output.resize(n);
         const int32_t * values = (const int32_t *)gguf_get_arr_data(ctx_gguf.get(), i);
         for (int i = 0; i < n; ++i) {


### PR DESCRIPTION
`clip_model_loader::load_hparams` (`tools/mtmd/clip.cpp`) consumes several mmproj GGUF metadata arrays without validating type or length:

- `image_grid_pinpoints` is walked in pairs (`pinpoints[i]`, `pinpoints[i+1]`) with no even-length check → OOB read on an odd-length array;
- `get_arr_int()` reads array data without checking the array is `INT32`;
- `image_mean` / `image_std` do fixed length-3 reads without checking type or length.

A malformed mmproj model file (odd-length or wrong-type `image_grid_pinpoints`, short or wrong-type `image_mean`/`image_std`) triggers heap-buffer-overflow **reads** in `load_hparams`, before any tensor is loaded. I confirmed all five under ASAN+UBSan on a real build; a well-formed control parses cleanly.

This adds type + length validation before each consume, so malformed metadata fails with a clear loader error instead of an OOB read. Verified before/after on the same ASAN build: the five malformed files go from heap-overflow to clean `rc=1` typed errors; the well-formed control is unchanged (same post-hparams tensor lookup).

These are out-of-bounds reads (crash / potential info-disclosure), reachable from an untrusted mmproj model file via `mtmd_init_from_file`. Distinct from #21402 (a different mmproj invalid-value crash). Filing as loader robustness hardening, consistent with SECURITY.md's stance on untrusted models.

AI usage disclosure: AI-assisted in finding these (fuzzing mmproj metadata) and drafting the validation; I confirmed the OOB reads and the fix under ASAN on real hardware and own the change.