### PR TITLE
vulkan: Walsh-Hadamard fast path segfaults on AMD iGPU (Radeon 780M) — same pattern as Intel Arc

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5076,7 +5076,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
 
     ggml_vk_create_pipeline(device, device->pipeline_sum_rows_f32, "sum_rows_f32", sum_rows_f32_len, sum_rows_f32_data, "main", 2, sizeof(vk_op_sum_rows_push_constants), {1, 1, 1}, { device->subgroup_size }, 1);
     // Intel Arc B390 was observed segfaulting with this shader.
-    if (device->subgroup_basic && device->subgroup_shuffle && device->vendor_id != VK_VENDOR_ID_INTEL) {
+    if (device->subgroup_basic && device->subgroup_shuffle && device->vendor_id != VK_VENDOR_ID_INTEL && !device->uma) {
         int idx = 0;
         for (uint32_t n : {64, 128, 256, 512}) {
             if (device->subgroup_size <= n) {


### PR DESCRIPTION
## Overview

I have installed version b8757, but versions are b9500+ getting crushed with Vulkan inference. Cpu inference is working.

Tested on AMD Ryzen 7 7840HS (Radeon 780M), Qwen3.5-9B-Q4_K_M, Windows 11.

I (sincerely to say, deepseek) found that problem caused by #23687 and crash fixed for intel gpu in https://github.com/ggml-org/llama.cpp/commit/4d8cc0c

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: deepseek found that problem, when llama-server crashed and suggest that fix.
