### PR TITLE
ci : build-msys job slimming [no ci]

### DIFF
--- a/.github/workflows/build-msys.yml
+++ b/.github/workflows/build-msys.yml
@@ -27,8 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sys: UCRT64,  env: ucrt-x86_64,  build: Release }
-          - { sys: CLANG64, env: clang-x86_64, build: Release }
+          - { sys: UCRT64,  env: ucrt-x86_64,  compiler: gcc,   build: Release }
+          - { sys: CLANG64, env: clang-x86_64, compiler: clang, build: Release }
 
     steps:
       - name: Clone
@@ -48,9 +48,7 @@ jobs:
           update: true
           msystem: ${{matrix.sys}}
           install: >-
-            base-devel
-            git
-            mingw-w64-${{matrix.env}}-toolchain
+            mingw-w64-${{matrix.env}}-${{matrix.compiler}}
             mingw-w64-${{matrix.env}}-cmake
             mingw-w64-${{matrix.env}}-openblas
 


### PR DESCRIPTION
## Overview

This PR attempts to slim down the dependencies for build-msys jobs making the same changes that we applied in whisper.cpp to reduce the size of the github actions cache, and should also improve the run time due to fewer dependencies that need to be installed.
## Additional information

I realize this is a scheduled job but I think it would still make sense to apply these changes.

I ran this on my [fork](https://github.com/danbev/llama.cpp/actions/runs/26996861523/job/79668313408) and it passed. The github [cache](https://github.com/danbev/llama.cpp/actions/caches?query=sort%3Aaccessed-desc) for this job are the following:
```
msys2-pkgs-upd:true-conf:c3b1d407-files:faa0dba24e8d2f387eaee8e3f624e2b2b6b806a5c47086e16c5f9d2c55e6e667
200 MB 
msys2-pkgs-upd:true-conf:f43c365f-files:c6629634f6d038bbc3fd3c1c9273a1c8e61ffdec95b6d71cd5a20d6f06dfccba
140 MB
```

Refs: https://github.com/ggml-org/whisper.cpp/pull/3858

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
