### PR TITLE
fix issue 23977

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -246,7 +246,11 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
         info.default_tensor_split[id] = total_vram;
         total_vram += prop.totalGlobalMem;
+#if defined(GGML_USE_HIP)
+        info.devices[id].integrated = prop.integrated;
+#else
         info.devices[id].integrated = false; // Temporarily disabled due to issues with corrupted output (e.g. #15034)
+#endif
         info.devices[id].nsm        = prop.multiProcessorCount;
         info.devices[id].smpb       = prop.sharedMemPerBlock;
         info.devices[id].warp_size  = prop.warpSize;


### PR DESCRIPTION
## Overview
This solution is taken from https://github.com/ggml-org/llama.cpp/issues/23977. Credits to @mapatel-amd for identifying the root cause and proposing the fix.

Test Hard ware env:
```
Strix Halo 128G
```

Test Software env:
```
  Local environment:
  - OS: Ubuntu 24.04.4 LTS, Linux 6.17.0-23-generic, x86_64
  - Hardware: AMD Ryzen AI MAX+ 395 with Radeon 8060S Graphics
  - ROCm device: gfx1151 / Radeon 8060S Graphics
  - Reported ROCm memory: 122880 MiB
  - HIP: 7.12.60610-2bd1678d3d
  - AMD clang: 22.0.0git
  - CMake: 3.28.3
  - Ninja: 1.11.1
  - Base commit: 59917d392
  - Test branch commit: 1bf74b70e
```

Build configuration:
```
  PATH=/opt/rocm/core-7.12/bin:$PATH \
  HIPCXX=/opt/rocm/core-7.12/lib/llvm/bin/clang \
  HIP_PATH=/opt/rocm/core-7.12 \
  cmake -S . -B build-hip-issue23977 -G Ninja \
    -DGGML_HIP=ON \
    -DGPU_TARGETS=gfx1151 \
    -DCMAKE_BUILD_TYPE=Release \
    -DLLAMA_BUILD_TESTS=ON
  cmake --build build-hip-issue23977 --target llama-bench -j 16
  cmake --build build-hip-issue23977 --target test-backend-ops -j 16
```

A/B validation method:

  I used a small local probe, not committed to the repo, to query:
  - ggml_backend_cuda_host_buffer_type()
  - ggml_backend_dev_supports_buft(dev, ROCm_Host)

  The same machine and same HIP build configuration were used before and after the patch.

  A/B result:

  Before:
```
  device=0 name=ROCm0 type=2 host_buft=ROCm_Host supports_host_buft=0
```
  After:
```
  device=0 name=ROCm0 type=2 host_buft=ROCm_Host supports_host_buft=1
```