### PR TITLE
TP: round up granularity to 128

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -637,7 +637,6 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
     tensor_config tc = get_tensor_config();
     split_state.axis = tc.axis;
     if (split_state.axis >= 0 && split_state.axis < GGML_MAX_DIMS) {
-        const int64_t ne_full = tensor->ne[split_state.axis];
         const int64_t blck_size = ggml_blck_size(tc.tensor_axis_0->type);
         const float * tensor_split = ud->model->tensor_split();
         std::vector<float> tensor_split_scan;
@@ -654,7 +653,6 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             const int64_t  ne_s = segments[is].first;
             const uint32_t nr_s = segments[is].second;
             const int64_t  g_s  = granularity[is];
-            GGML_ASSERT(ne_full % g_s == 0);
             int64_t low = 0;
             size_t j = 0;
             for (; j < ud->n_devices - 1; j++) {

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -553,10 +553,12 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
     };
 
     auto get_split_granularity = [&](int64_t blck_size, uint32_t il, const std::vector<std::pair<int64_t, uint32_t>> & segments) -> std::vector<int64_t> {
+        // for better performance it may make sense to round up blck_size to a higher power of 2 so that more efficient kernels can be used
         if (hparams.is_recr(il)) {
             // linear attention
-            const int64_t head_dim  = hparams.ssm_d_state;
-            const int64_t granularity_qkv = std::lcm(blck_size, head_dim);
+            const int64_t head_dim        = hparams.ssm_d_state;
+            const int64_t blck_size_perf  = std::lcm(blck_size, 128);
+            const int64_t granularity_qkv = std::lcm(blck_size_perf, head_dim);
             if (std::regex_match(tensor_name, pattern_qkv_weight) || std::regex_match(tensor_name, pattern_attn_gate_weight) ||
                     std::regex_match(tensor_name, pattern_ssm_conv1d) || std::regex_match(tensor_name, pattern_ssm_out_weight)) {
                 return std::vector<int64_t>(segments.size(), granularity_qkv);
@@ -578,17 +580,24 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             // regular attention
             const uint32_t n_gqa    = hparams.n_gqa(il);
             const uint32_t n_embd_q = n_gqa * hparams.n_embd_head_k(il);
-            if (std::regex_match(tensor_name, pattern_attn_sinks)) {
-                GGML_ASSERT(segments.size() == 1);
-                return {std::lcm(n_embd_q, blck_size)/n_embd_q * n_gqa};
+
+            // to handle head sizes like 80, only increase granularity while it doesn't cause underutilization
+            int64_t blck_size_perf = blck_size;
+            while (blck_size_perf < 128 && blck_size_perf*ud->n_devices < n_embd_q) {
+                blck_size_perf *= 2;
             }
 
-            const int64_t granularity_q = std::lcm(n_embd_q, blck_size);
+            if (std::regex_match(tensor_name, pattern_attn_sinks)) {
+                GGML_ASSERT(segments.size() == 1);
+                return {std::lcm(n_embd_q, blck_size_perf)/n_embd_q * n_gqa};
+            }
+
+            const int64_t granularity_q = std::lcm(n_embd_q, blck_size_perf);
             if (std::regex_match(tensor_name, pattern_q_weight) || std::regex_match(tensor_name, pattern_q_bias)) {
                 GGML_ASSERT(segments.size() == 1);
                 // some models have Q gate tensors, for those cases the granularity needs to be doubled:
                 if (ud->model->arch == LLM_ARCH_QWEN3NEXT || ud->model->arch == LLM_ARCH_QWEN35 || ud->model->arch == LLM_ARCH_QWEN35MOE) {
-                    return {std::lcm(2*n_embd_q, blck_size)};
+                    return {std::lcm(2*n_embd_q, blck_size_perf)};
                 }
                 return {granularity_q};
             }
@@ -613,8 +622,9 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         // FFN
         if (std::regex_match(tensor_name, pattern_ffn_up_gate_weight) || std::regex_match(tensor_name, pattern_ffn_up_gate_bias) ||
                 std::regex_match(tensor_name, pattern_ffn_gate_up_weight) || std::regex_match(tensor_name, pattern_ffn_down_weight)) {
+            const int64_t blck_size_perf = std::lcm(blck_size, 128);
             GGML_ASSERT(segments.size() == 1);
-            return {blck_size};
+            return {blck_size_perf};
         }
 
         // everything else


### PR DESCRIPTION
On master for `-sm tensor` the tensors are split to the minimum possible granularity. However, for performance it seems to be preferable to round the granularity up to a larger power of 2, 128 seems to be a good value. This should only make a difference when 

1. the number of GPUs or the tensor dimensions are not a power of 2 and if 
2. FP16/BF16/FP32 or a legacy quant are used.

<details>
<summary>Performance</summary>

| GPU             | Model           |     Microbatch size | Test     |        t/s master |            t/s PR |     Speedup |
| :-------------- | :-------------- | ------------------: | :------- | ----------------: | ----------------: | ----------: |
| 3x NVIDIA A16   | llama 8B F16    |                   1 | pp512    |             30.66 |             34.04 |        1.11 |
| 3x NVIDIA A16   | llama 8B F16    |                   2 | pp512    |             45.91 |             70.78 |        1.54 |
| 3x NVIDIA A16   | llama 8B F16    |                   4 | pp512    |             86.50 |            134.02 |        1.55 |
| 3x NVIDIA A16   | llama 8B F16    |                   8 | pp512    |            154.52 |            244.43 |        1.58 |
| 3x NVIDIA A16   | llama 8B F16    |                  16 | pp512    |            275.71 |            414.48 |        1.50 |
| 3x NVIDIA A16   | llama 8B F16    |                  32 | pp512    |            480.39 |            689.08 |        1.43 |
| 3x NVIDIA A16   | llama 8B F16    |                  64 | pp512    |            731.28 |           1120.62 |        1.53 |
| 3x NVIDIA A16   | llama 8B F16    |                 128 | pp512    |            899.91 |           1262.54 |        1.40 |
| 3x NVIDIA A16   | llama 8B F16    |                 256 | pp512    |           1126.47 |           1414.11 |        1.26 |
| 3x NVIDIA A16   | llama 8B F16    |                 512 | pp512    |           1070.45 |           1507.99 |        1.41 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                   1 | pp512    |             91.29 |             91.18 |        1.00 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                   2 | pp512    |            156.44 |            156.00 |        1.00 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                   4 | pp512    |            206.57 |            206.05 |        1.00 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                   8 | pp512    |            223.84 |            223.31 |        1.00 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                  16 | pp512    |            543.03 |            559.92 |        1.03 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                  32 | pp512    |            865.31 |            885.06 |        1.02 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                  64 | pp512    |           1217.23 |           1215.99 |        1.00 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                 128 | pp512    |           1409.54 |           1426.35 |        1.01 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                 256 | pp512    |           1478.06 |           1494.74 |        1.01 |
| 3x NVIDIA A16   | llama 8B Q4_0   |                 512 | pp512    |           1585.59 |           1615.00 |        1.02 |
| 3x RTX 4090     | llama 8B F16    |                   1 | pp512    |            137.75 |            140.87 |        1.02 |
| 3x RTX 4090     | llama 8B F16    |                   2 | pp512    |            212.39 |            258.29 |        1.22 |
| 3x RTX 4090     | llama 8B F16    |                   4 | pp512    |            379.53 |            470.82 |        1.24 |
| 3x RTX 4090     | llama 8B F16    |                   8 | pp512    |            629.61 |            797.85 |        1.27 |
| 3x RTX 4090     | llama 8B F16    |                  16 | pp512    |           1139.93 |           1261.59 |        1.11 |
| 3x RTX 4090     | llama 8B F16    |                  32 | pp512    |           2206.53 |           2363.42 |        1.07 |
| 3x RTX 4090     | llama 8B F16    |                  64 | pp512    |           3171.78 |           3622.67 |        1.14 |
| 3x RTX 4090     | llama 8B F16    |                 128 | pp512    |           3778.82 |           4616.36 |        1.22 |
| 3x RTX 4090     | llama 8B F16    |                 256 | pp512    |           5021.24 |           5963.07 |        1.19 |
| 3x RTX 4090     | llama 8B F16    |                 512 | pp512    |           6574.54 |           6913.55 |        1.05 |
| 3x RTX 4090     | llama 8B Q4_0   |                   1 | pp512    |            269.30 |            271.25 |        1.01 |
| 3x RTX 4090     | llama 8B Q4_0   |                   2 | pp512    |            459.52 |            483.37 |        1.05 |
| 3x RTX 4090     | llama 8B Q4_0   |                   4 | pp512    |            717.73 |            802.99 |        1.12 |
| 3x RTX 4090     | llama 8B Q4_0   |                   8 | pp512    |            931.62 |           1104.94 |        1.19 |
| 3x RTX 4090     | llama 8B Q4_0   |                  16 | pp512    |           1571.74 |           1674.04 |        1.07 |
| 3x RTX 4090     | llama 8B Q4_0   |                  32 | pp512    |           2760.85 |           2882.11 |        1.04 |
| 3x RTX 4090     | llama 8B Q4_0   |                  64 | pp512    |           3679.10 |           4101.06 |        1.11 |
| 3x RTX 4090     | llama 8B Q4_0   |                 128 | pp512    |           4203.68 |           5111.99 |        1.22 |
| 3x RTX 4090     | llama 8B Q4_0   |                 256 | pp512    |           5317.01 |           6235.11 |        1.17 |
| 3x RTX 4090     | llama 8B Q4_0   |                 512 | pp512    |           7008.85 |           8615.56 |        1.23 |

</details>

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No