### PR TITLE
cli: refresh sampling defaults after model load

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -396,6 +396,7 @@ int llama_cli(int argc, char ** argv) {
         console::error("\nFailed to load the model\n");
         return 1;
     }
+    ctx_cli.defaults.sampling = params.sampling;
 
     console::spinner::stop();
     console::log("\n");


### PR DESCRIPTION
## Summary

- refresh `ctx_cli.defaults.sampling` after model loading completes
- lets GGUF `general.sampling.*` values applied during `load_model(params)` propagate into `llama-cli` defaults

## Context

Fixes #23847.

`cli_context` is constructed before model loading, so its default sampling snapshot can still contain the CLI/fallback values. `load_model(params)` can update `params.sampling` from the model metadata, but `ctx_cli.defaults` was not refreshed afterward. That leaves `llama-cli` printing and using stale defaults while `llama-completion` reflects the model values correctly.

## Validation

- `git diff --check`
- secret scan on `tools/cli/cli.cpp`
- `cmake --build build --target llama-cli --config Release -j 2`

The build completed on Windows. CMake emitted an existing OpenSSL warning and existing `vendor/sheredom/subprocess.h` conversion warnings.

I also tried `build\\bin\\llama-cli.exe --help`, `-h`, and `--version`, but each invocation hung in this local Windows console environment and had to be terminated. The target still builds and links successfully.
