### PR TITLE
fix: call n_layer() in model info logging

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1764,7 +1764,7 @@ void llama_model::print_info() const {
                         [](const auto & entry) { return entry >= 0; })) {
             LLAMA_LOG_INFO("%s: deepstack_mapping_arr = %s\n", __func__,
                            print_f([&](uint32_t il) { return hparams.deepstack_mapping_arr[il]; },
-                           hparams.n_layer).c_str());
+                           hparams.n_layer()).c_str());
         }
         // MRoPE (Multi-axis Rotary Position Embedding) sections
         if (const auto & s = hparams.rope_sections; s[0] || s[1] || s[2] || s[3]) {


### PR DESCRIPTION
Fixes a compile error in llama_model::print_info() where hparams.n_layer was referenced as a member instead of called as hparams.n_layer().

Error:

invalid use of non-static member function ‘uint32_t llama_hparams::n_layer() const’

Tested by building:

- llama-server
- llama-cli
- llama-bench

Environment:
- Ubuntu WSL
- CUDA 13.2
- NVIDIA RTX 5090
- CMAKE_CUDA_ARCHITECTURES=120a