### PR TITLE
docs: link function calling guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ To learn more about model quantization, [read this documentation](tools/quantize
 - [cli](tools/cli/README.md)
 - [completion](tools/completion/README.md)
 - [server](tools/server/README.md)
+- [function calling](docs/function-calling.md)
 - [GBNF grammars](grammars/README.md)
 
 #### Development documentation


### PR DESCRIPTION
## Summary
- add the existing function calling guide to the README documentation index
- make `docs/function-calling.md` easier to discover

Closes #13523

## Validation
- `test -f docs/function-calling.md`
- `git diff --check HEAD~1 HEAD`
