### PR TITLE
Add specialized tagged thinking tool parser

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1102,6 +1102,153 @@ static common_chat_params common_chat_params_init_ministral_3(const common_chat_
     return data;
 }
 
+static common_chat_params common_chat_params_init_tagged_thinking_tools(const common_chat_template & tmpl,
+                                                                const autoparser::generation_params & inputs) {
+    common_chat_params data;
+
+    const bool has_tools         = inputs.tools.is_array() && !inputs.tools.empty();
+    const bool extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+
+    data.supports_thinking      = true;
+    data.thinking_start_tag     = "<think>";
+    data.thinking_end_tag       = "</think>";
+    data.prompt                 = common_chat_template_direct_apply(tmpl, inputs);
+    data.generation_prompt      = common_chat_template_generation_prompt(tmpl, inputs);
+    data.format                 = COMMON_CHAT_FORMAT_PEG_NATIVE;
+    data.strict_eof_on_complete = true;
+    data.preserved_tokens       = {
+        "<think>",
+        "</think>",
+        "<tool_call>",
+        "</tool_call>",
+    };
+
+    if (!has_tools || inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_NONE) {
+        return data;
+    }
+
+    auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {
+        auto generation_prompt = p.literal(data.generation_prompt);
+        auto tool_choices = p.choice();
+
+        foreach_function(inputs.tools, [&](const json & tool) {
+            const auto & function = tool.at("function");
+            const auto   name     = function.at("name").get<std::string>();
+
+            auto arg_choices = p.choice();
+            foreach_parameter(function, [&](const std::string & prop_name, const json & prop_schema, bool) {
+                const bool is_string = prop_schema.value("type", "") == "string";
+
+                auto value_until = [&](const std::string & marker) {
+                    return is_string ?
+                        p.tool_arg_string_value(p.until(marker)) :
+                        p.tool_arg_value(p.until(marker));
+                };
+
+                auto arg_open = p.tool_arg_open(
+                    p.literal("<parameter=") + p.tool_arg_name(p.literal(prop_name)) + p.literal(">"));
+
+                auto arg = p.tool_arg(arg_open + p.choice({
+                    p.literal("\n") + value_until("\n</parameter>") + p.tool_arg_close(p.literal("\n</parameter>")),
+                    value_until("</parameter>") + p.tool_arg_close(p.literal("</parameter>")),
+                }));
+                arg_choices |= p.rule("tool-" + name + "-arg-" + prop_name, arg);
+            });
+
+            auto args = p.tool_args(p.zero_or_more(arg_choices + p.space()));
+            auto func = p.tool(
+                p.tool_open(p.literal("<function=") + p.tool_name(p.literal(name)) + p.literal(">")) +
+                p.space() + args + p.space() +
+                p.tool_close(p.literal("</function>")));
+
+            tool_choices |= p.rule("tool-" + name, func);
+        });
+
+        auto tool_call =
+            p.literal("<tool_call>") + p.space() + tool_choices + p.space() + p.literal("</tool_call>");
+
+        const int max_calls = inputs.parallel_tool_calls ? -1 : 1;
+        auto tool_calls     = p.repeat(tool_call + p.space(), 1, max_calls);
+
+        p.rule("tool-tail", [&]() {
+            auto content_until_boundary = p.content(p.until_one_of({"<tool_call>", "</think>"}));
+            return p.choice({
+                p.literal("</think>") + p.space() + p.content(p.rest()),
+                content_until_boundary + p.choice({
+                    p.ref("tool-call"),
+                    p.literal("</think>") + p.space() + p.content(p.rest()),
+                    p.content(p.rest()),
+                }),
+            });
+        });
+        auto tool_suffix = p.trigger_rule("tool-call", tool_calls + p.ref("tool-tail"));
+
+        auto outside = p.choice({
+            p.content(p.until("<tool_call>")) + tool_suffix,
+            p.content(p.rest()),
+        });
+
+        if (!extract_reasoning || !inputs.enable_thinking) {
+            return generation_prompt + outside;
+        }
+
+        // Classify the emitted completion rather than the generation prompt. Some
+        // templates prefill "<think>\n", but Qwen-style models may omit the
+        // matching close tag for tool-call and final-answer turns. In practice:
+        //   - emitted </think> closes reasoning;
+        //   - emitted <tool_call> makes any preceding text reasoning;
+        //   - no emitted reasoning/tool tags means final assistant content.
+        auto reasoning_before_boundary =
+            p.reasoning(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"})) +
+            p.optional(p.literal("\n"));
+
+        auto reasoning_until_tool =
+            p.peek(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"}) + p.literal("\n<tool_call>")) +
+            reasoning_before_boundary +
+            tool_suffix;
+
+        auto reasoning_until_close =
+            p.peek(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"}) + p.choice({
+                p.literal("</think>"),
+                p.literal("\n</think>"),
+            })) +
+            reasoning_before_boundary +
+            p.literal("</think>") + p.space() + outside;
+
+        auto reasoning_then_boundary = p.choice({
+            tool_suffix,
+            reasoning_until_tool,
+            reasoning_until_close,
+            p.content(p.rest()),
+        });
+
+        auto generated_reasoning = p.literal("<think>") + p.space() + reasoning_then_boundary;
+
+        return generation_prompt + p.choice({
+            generated_reasoning,
+            reasoning_then_boundary,
+        });
+    });
+
+    data.parser       = parser.save();
+    data.grammar_lazy = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_AUTO;
+    data.grammar      = build_grammar([&](const common_grammar_builder & builder) {
+        foreach_function(inputs.tools, [&](const json & tool) {
+            const auto & function = tool.at("function");
+            auto         schema   = function.at("parameters");
+            builder.resolve_refs(schema);
+        });
+        parser.build_grammar(builder, data.grammar_lazy);
+    });
+    if (data.grammar_lazy) {
+        data.grammar_triggers = {
+            { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<tool_call>" },
+        };
+    }
+
+    return data;
+}
+
 static common_chat_params common_chat_params_init_gpt_oss(const common_chat_template &    tmpl,
                                                           const autoparser::generation_params & inputs) {
     common_chat_params data;
@@ -2398,6 +2545,20 @@ std::optional<common_chat_params> common_chat_try_specialized_template(
         return common_chat_params_init_ministral_3(tmpl, params);
     }
 
+    // Tagged thinking/tool protocol: reasoning uses <think>...</think> and tools use
+    // <tool_call><function=name><parameter=arg>...</parameter></function></tool_call>.
+    if (params.tools.is_array() && !params.tools.empty() &&
+        params.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE &&
+        src.find("<think>") != std::string::npos &&
+        src.find("</think>") != std::string::npos &&
+        src.find("<tool_call>") != std::string::npos &&
+        src.find("</tool_call>") != std::string::npos &&
+        src.find("<function=") != std::string::npos &&
+        src.find("<parameter=") != std::string::npos) {
+        LOG_DBG("Using specialized template: tagged thinking tools\n");
+        return common_chat_params_init_tagged_thinking_tools(tmpl, params);
+    }
+
     // GPT-OSS - has unique channel-based structure that needs dedicated handler
     if (src.find("<|channel|>") != std::string::npos) {
         LOG_DBG("Using specialized template: GPT-OSS\n");
@@ -2706,6 +2867,15 @@ common_chat_msg common_chat_peg_parse(const common_peg_arena &          src_pars
 
     common_peg_parse_context ctx(effective_input, flags);
     auto result = parser.parse(ctx);
+
+    // Streaming parses are lenient so an unterminated prefix can still produce deltas.
+    // Some complete parses intentionally use EOF as a boundary; retry those strictly
+    // when requested so "until"/"rest" parsers can commit at the actual end.
+    if (!is_partial && params.strict_eof_on_complete && result.need_more_input()) {
+        flags = common_peg_parse_flags(flags & ~COMMON_PEG_PARSE_FLAG_LENIENT);
+        ctx = common_peg_parse_context(effective_input, flags);
+        result = parser.parse(ctx);
+    }
 
     if (result.fail()) {
         // During partial parsing, return partial results if any AST nodes were captured

--- a/common/chat.h
+++ b/common/chat.h
@@ -279,6 +279,9 @@ struct common_chat_params {
     std::vector<std::string>            preserved_tokens;
     std::vector<std::string>            additional_stops;
     std::string                         parser;
+    // If a complete parse reports NEED_MORE in lenient streaming mode, retry without
+    // leniency so EOF can be used as a real boundary by parsers that opt in.
+    bool                                strict_eof_on_complete = false;
     common_chat_msg_delimiters          message_delimiters;
 };
 
@@ -294,11 +297,13 @@ struct common_chat_parser_params {
     bool                    is_continuation      = false;
     bool                    echo                 = false;  // Include assistant prefilled msg in output
     bool                    debug                = false;  // Enable debug output for PEG parser
+    bool                    strict_eof_on_complete = false;
     common_peg_arena        parser               = {};
     common_chat_parser_params() = default;
     common_chat_parser_params(const common_chat_params & chat_params) {
-        format  = chat_params.format;
-        generation_prompt = chat_params.generation_prompt;
+        format                 = chat_params.format;
+        generation_prompt      = chat_params.generation_prompt;
+        strict_eof_on_complete = chat_params.strict_eof_on_complete;
     }
 };
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1375,6 +1375,11 @@ class peg_tester {
         template_path_(template_path),
         detailed_debug_(detailed_debug) {}
 
+    explicit peg_tester(common_chat_templates_ptr tmpls, const std::string & template_path, const bool detailed_debug = false) :
+        tmpls_(std::move(tmpls)),
+        template_path_(template_path),
+        detailed_debug_(detailed_debug) {}
+
     const std::string & template_path() const { return template_path_; }
 
     peg_test_builder test(const std::string & input);
@@ -2171,7 +2176,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             })
             .run();
 
-
         // test code that starts with indent
         tst.test(
                "<tool_call>\n"
@@ -2188,6 +2192,100 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
         })
             .expect_tool_calls({
                 { "python", "{\"code\": \"    print(\\\"Hello, world!\\\")\"}", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need to inspect the current directory.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "</think>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ run_in_terminal_tool })
+            .expect_reasoning("Need to inspect the current directory.")
+            .expect_content("Done.")
+            .expect_tool_calls({
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need to inspect the current directory.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ run_in_terminal_tool })
+            .expect_reasoning("Need to inspect the current directory.")
+            .expect_content("Done.")
+            .expect_tool_calls({
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
+            })
+            .run();
+
+        tst.test(
+               "<tool_call>\n"
+               "<function=edit>\n"
+               "<parameter=newString>\n"
+               "new text\n"
+               "</parameter>\n"
+               "<parameter=oldString>\n"
+               "old text\n"
+               "</parameter>\n"
+               "<parameter=filename>\n"
+               "foo.cpp\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .enable_thinking(false)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ edit_tool })
+            .expect_tool_calls({
+                { "edit", R"({"newString": "new text", "oldString": "old text", "filename": "foo.cpp"})", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need the directory.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "Need the files.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "ls\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "</think>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .parallel_tool_calls(true)
+            .tools({ run_in_terminal_tool })
+            .expect_reasoning("Need the directory.")
+            .expect_content("Need the files.\nDone.")
+            .expect_tool_calls({
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
+                { "run_in_terminal", R"({"command": "ls"})", {} },
             })
             .run();
 
@@ -2281,7 +2379,7 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({
                 special_function_tool
         })
-            .expect_reasoning("<think>\n\n")
+            .expect_reasoning("")
             .expect_tool_calls({ { "special_function", "{\"arg1\": 1}", "" } })
             .run();
 
@@ -2396,6 +2494,13 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_content("Final answer without tools.")
             .run();
 
+        tst.test("Final answer without thinking.")
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .enable_thinking(true)
+            .tools({ run_in_terminal_tool })
+            .expect_content("Final answer without thinking.")
+            .run();
+
         // Continuation tests
         tst.test("world!\nWhat's up?")
             .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
@@ -2500,6 +2605,93 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
                 .expect_tool_calls({
                     { "run_in_terminal", R"({"command": "pwd"})", {} },
                 })
+                .run();
+        }
+
+        {
+            auto src = read_file("models/templates/Qwen3.5-4B.jinja");
+            string_replace_all(src,
+                "{%- if add_generation_prompt %}\n"
+                "    {{- '<|im_start|>assistant\\n' }}\n"
+                "    {%- if enable_thinking is defined and enable_thinking is false %}\n"
+                "        {{- '<think>\\n\\n</think>\\n\\n' }}\n"
+                "    {%- else %}\n"
+                "        {{- '<think>\\n' }}\n"
+                "    {%- endif %}\n"
+                "{%- endif %}",
+                "{%- if add_generation_prompt %}\n"
+                "    {{- '<|im_start|>assistant\\n' }}\n"
+                "{%- endif %}");
+
+            auto no_prefill = peg_tester(
+                common_chat_templates_ptr(common_chat_templates_init(/* model= */ nullptr, src)),
+                "models/templates/Qwen3.5-4B-no-prefill-think.jinja",
+                detailed_debug);
+
+            no_prefill.test(
+                   "<think>\n"
+                   "I need to run a terminal command.\n"
+                   "</think>\n\n"
+                   "<tool_call>\n"
+                   "<function=run_in_terminal>\n"
+                   "<parameter=command>\n"
+                   "pwd\n"
+                   "</parameter>\n"
+                   "</function>\n"
+                   "</tool_call>")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_reasoning("I need to run a terminal command.")
+                .expect_tool_calls({
+                    { "run_in_terminal", R"({"command": "pwd"})", {} },
+                })
+                .run();
+
+            no_prefill.test(
+                   "<think>\n"
+                   "I need to run a terminal command.\n"
+                   "<tool_call>\n"
+                   "<function=run_in_terminal>\n"
+                   "<parameter=command>\n"
+                   "pwd\n"
+                   "</parameter>\n"
+                   "</function>\n"
+                   "</tool_call>\n"
+                   "Done.")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_reasoning("I need to run a terminal command.")
+                .expect_content("Done.")
+                .expect_tool_calls({
+                    { "run_in_terminal", R"({"command": "pwd"})", {} },
+                })
+                .run();
+
+            no_prefill.test(
+                   "I need to run a terminal command.\n"
+                   "<tool_call>\n"
+                   "<function=run_in_terminal>\n"
+                   "<parameter=command>\n"
+                   "pwd\n"
+                   "</parameter>\n"
+                   "</function>\n"
+                   "</tool_call>")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_reasoning("I need to run a terminal command.")
+                .expect_tool_calls({
+                    { "run_in_terminal", R"({"command": "pwd"})", {} },
+                })
+                .run();
+
+            no_prefill.test("Final answer without thinking.")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_content("Final answer without thinking.")
                 .run();
         }
     }


### PR DESCRIPTION
## Overview

This PR adds a specialized parser for tagged thinking/tool-call outputs.

It was motivated by testing Qwen3.5-9B with reasoning enabled and XML-style tool calls in an agent/tool-loop setup.

Two parser issues showed up:

1. A valid `<tool_call>` emitted while the parser was inside a `<think>...</think>` reasoning block was surfaced as `reasoning_content` instead of being parsed as a tool call.
2. Tagged function parameters such as `<parameter=old_string>` were required to appear in schema/property iteration order, even though the parameter name is already carried in-band by the tag.

## Observed Qwen behavior

Qwen3.5 appears to use three practical response modes:

1. Pure reasoning messages

```xml
<think>
reasoning...
</think>
```
2. Tool-call messages, which may include reasoning before the tool call

```xml
reasoning before tool call...
<tool_call>
<function=...>
<parameter=...>...</parameter>
</function>
</tool_call>
```
3. Final-answer messages

```text
Final answer...
```
The important detail is that Qwen does not always emit a complete `<think>...</think>` block for every response mode.

For pure reasoning messages, Qwen reliably emits/uses reasoning tags and closes with `</think>`.

For tool-call messages, Qwen may emit reasoning-like text before `<tool_call>`, but it may not emit a matching `</think>` before the tool call.

For final-answer messages, Qwen may emit plain assistant content without closing a template-prefilled `<think>` block.

The standard Qwen Jinja template helps by prefilling assistant generation with:

```text
<think>
```
That works well for pure reasoning messages, because Qwen then emits:

```xml
reasoning...
</think>
```
However, for tool-call and final-answer messages, Qwen may effectively ignore that prefilled reasoning state. Some downstream template variants, such as no-prefill template fixes, remove this `<think>` prefill entirely.

So the parser should not rely only on whether the Jinja template prefilled `<think>`. It needs to classify the emitted completion itself.

## Parser behavior added by this PR

This PR adds a specialized parser for the tagged thinking/tool-call protocol family used by Qwen-style templates:

```xml
<think>...</think>
<tool_call>
<function=name>
<parameter=arg>...</parameter>
</function>
</tool_call>
```
The parser kicks in when this tag family is detected in the template.

It classifies emitted output as follows:

- `</think>` marks preceding text as `reasoning_content`.
- `<tool_call>` marks preceding text as `reasoning_content`, even if no explicit `<think>` tag was emitted in the completion.
- `<tool_call>...</tool_call>` is parsed as a tool call.
- Text after a parsed tool call is parsed as assistant content.
- If no reasoning/tool tags are emitted, the output is parsed as final assistant content.

This makes the parser robust to both default Qwen templates that prefill `<think>` and no-prefill template variants.

## Tagged parameter handling

For tagged tool calls, function argument names are already present in-band:

```xml
<parameter=old_string>...</parameter>
<parameter=new_string>...</parameter>
```
This PR parses tagged parameters by their emitted names rather than requiring schema/property iteration order.

It also allows string parameters to contain raw multiline content/code until the closing `</parameter>` tag.

This fixes Qwen-style tool calls such as edit/write calls where multiline code appears inside a string parameter.

## Additional information

This was tested downstream with Qwen3.5-9B using reasoning enabled and XML-style tool calls.

A patched CUDA image used for downstream validation is available here:

```text
ghcr.io/bartdeboer/llama-cpp:server-cuda-tagged-thinking-tools-168643697
```
Digest:

```text
sha256:0b43e14146cb715ff8fa6960083ac9c18aae065eed197f87bc88d3c96f7e0240
```
Validated locally with:

```bash
./build/bin/test-chat --suppress-debug --template Qwen3.5
./build/bin/test-chat --suppress-debug
```
Related issues / prior art:

- Related to #23773
- Fixes #20837
- Fixes #22684
- Related to #20260
- Related to #22398
- Related to vLLM's Qwen3 reasoning parser behavior, where `<tool_call>` can act as a reasoning boundary.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assistance was used for investigation and prototyping. I have a software engineering background, but I am not primarily a C++/llama.cpp contributor. I reviewed the changes, tested them locally and downstream, and am responsible for the submitted code.