### PR TITLE
server : clamp n_discard to the available context window

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2431,7 +2431,7 @@ private:
                 n_keep = std::min(slot.n_ctx - 4, n_keep);
 
                 const int n_left    = slot.prompt.n_tokens() - n_keep;
-                const int n_discard = slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2);
+                const int n_discard = std::min(slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2), n_left);
 
                 SLT_WRN(slot, "slot context shift, n_keep = %d, n_left = %d, n_discard = %d\n", n_keep, n_left, n_discard);
 


### PR DESCRIPTION
Sending `{"n_discard": 2000000000}` to a server started with `--context-shift` aborts it.

In the context-shift block (`tools/server/server-context.cpp`), `n_discard` comes from the client JSON with only a lower clamp (`std::max(0, params.n_discard)`, added in #22267 for CVE-2026-21869) — no upper bound. It flows into `new_tokens.resize(slot.prompt.tokens.size() - n_discard)`: `size()` is `size_t`, so any `n_discard > size` underflows to a near-`SIZE_MAX` length → `resize()` throws `std::length_error`, which is uncaught → `std::terminate()`. The same unbounded value also overflows `n_keep + n_discard` (`int`) in the `seq_rm`/`seq_add` calls.

Clamp it to the available window, where `n_left` is already known:

```cpp
const int n_discard = std::min(slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2), n_left);
```

After this, `size() - n_discard >= n_keep >= 0` (no underflow) and `n_keep + n_discard <= n_tokens` (no overflow). The internal default (`n_left / 2`) is already `<= n_left`, so normal requests are unchanged. This completes the lower-bound clamp #22267 added for the negative case.

Verified before/after on an aarch64 CPU build at master: `{"n_discard": 2000000000}` with `--context-shift -c 64`, slot context full → `std::length_error` / abort before; after, the shift clamps (`n_discard = 255 = n_left`), the request completes, and the server stays up.

AI usage disclosure: AI-assisted finding the underflow and drafting the one-line fix. Reviewed it, own it, verified the before/after myself.
