### PR TITLE
ggml-cuda : use int64 for norm forward dst offset (match rms_norm_back)

### DIFF
--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -14,7 +14,7 @@ static __global__ void norm_f32(
     const int tid       = threadIdx.x;
 
     x   += sample*stride_sample + channel*stride_channel + row*stride_row;
-    dst += ((sample*nchannels + channel)*nrows + row)*ncols;
+    dst += ((int64_t(sample)*nchannels + channel)*nrows + row)*ncols;
 
     float2 mean_var = make_float2(0.0f, 0.0f);
 
@@ -109,7 +109,7 @@ static __global__ void rms_norm_f32(const float * x,
     static_assert(!do_add || do_multiply, "fusing add is not supported without multiplying");
 
     x   += sample*stride_sample + channel*stride_channel + row*stride_row;
-    dst += ((sample*nchannels + channel)*nrows + row)*ncols;
+    dst += ((int64_t(sample)*nchannels + channel)*nrows + row)*ncols;
 
     if constexpr (do_multiply) {
         const uint32_t mul_row     = fastmodulo(row, mul_nrows_packed);
@@ -254,7 +254,7 @@ static __global__ void l2_norm_f32(
     const int tid       = threadIdx.x;
 
     x   += sample*stride_sample + channel*stride_channel + row*stride_row;
-    dst += ((sample*nchannels + channel)*nrows + row)*ncols;
+    dst += ((int64_t(sample)*nchannels + channel)*nrows + row)*ncols;
 
     float tmp = 0.0f; // partial sum for thread in warp
 


### PR DESCRIPTION
The forward norm kernels (`norm_f32`, `rms_norm_f32`, `l2_norm_f32`) compute the destination offset in 32-bit `int`:

```cpp
dst += ((sample*nchannels + channel)*nrows + row)*ncols;
```

`nrows`/`nchannels` come from `gridDim`, and all factors are `int`, so for a tensor with more than `INT_MAX` elements the product overflows and the kernel writes out of bounds. The matching backward kernel `rms_norm_back_f32` already guards this with `int64_t`:

```cpp
dst  += int64_t(row)*ncols;
```

This promotes the three forward offsets to `int64_t` the same way, by casting the first factor:

```cpp
dst += ((int64_t(sample)*nchannels + channel)*nrows + row)*ncols;
```

The source-pointer arithmetic already uses `int64_t` strides, so only the destination offset needed it. No behavior change for normal sizes; this just makes the forward path consistent with the backward kernel and removes the latent overflow on very large tensors.

AI usage disclosure: AI-assisted finding the overflow (fuzzing the cuda norm ops under compute-sanitizer) and drafting the fix. Reviewed it, own it.
