### PR TITLE
Fix bitwise operation between different enumeration types warning

### DIFF
--- a/tools/mtmd/clip-graph.h
+++ b/tools/mtmd/clip-graph.h
@@ -9,8 +9,6 @@
 #include <vector>
 #include <functional>
 
-#define DEFAULT_INTERPOLATION_MODE (GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS)
-
 struct build_vit_opts {
     ggml_tensor * attn_mask = nullptr;
 };
@@ -57,6 +55,8 @@ struct clip_graph {
     void cb(ggml_tensor * cur0, const char * name, int il) const;
 
     // siglip2 naflex
+    static constexpr auto DEFAULT_INTERPOLATION_MODE = static_cast<uint32_t>(GGML_SCALE_MODE_BILINEAR) | static_cast<uint32_t>(GGML_SCALE_FLAG_ANTIALIAS);
+
     ggml_tensor * resize_position_embeddings(uint32_t interpolation_mode = DEFAULT_INTERPOLATION_MODE);
 
     // build vision transformer (ViT) cgraph


### PR DESCRIPTION
## Overview

warning: bitwise operation between different enumeration types ‘ggml_scale_mode’ and ‘ggml_scale_flag’ is deprecated [-Wdeprecated-enum-enum-conversion]
   12 | #define DEFAULT_INTERPOLATION_MODE (GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS)

Convert macro to constexpr, static cast enum to the target type (uint32_t), put it into the class scope. 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
