### PR TITLE
ggml-cuda : restore prop.integrated on HIP builds

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -246,7 +246,11 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
         info.default_tensor_split[id] = total_vram;
         total_vram += prop.totalGlobalMem;
+#if defined(GGML_USE_HIP)
+        info.devices[id].integrated = prop.integrated;
+#else
         info.devices[id].integrated = false; // Temporarily disabled due to issues with corrupted output (e.g. #15034)
+#endif
         info.devices[id].nsm        = prop.multiProcessorCount;
         info.devices[id].smpb       = prop.sharedMemPerBlock;
         info.devices[id].warp_size  = prop.warpSize;


### PR DESCRIPTION

PR #16308 sets `info.devices[id].integrated = false` unconditionally for every
CUDA/HIP device — a workaround for corrupted output on Jetson Orin (#15034). On
HIP/ROCm this discards the device's real `hipDeviceProp_t.integrated` flag.

With the cached `integrated` field forced to `false`, `supports_buft()` refuses
CUDA host buffers on AMD APU/UMA parts, even though `get_type()` already reads
`prop.integrated` directly (#23007). The two paths therefore disagree, breaking
host-buffer use on integrated GPUs under ROCm.

This guards the workaround to non-HIP (CUDA) builds and restores
`prop.integrated` for HIP, so the Jetson workaround stays in place for CUDA while
AMD APUs report their true integrated status:

```c
#if defined(GGML_USE_HIP)
        info.devices[id].integrated = prop.integrated;
#else
        info.devices[id].integrated = false; // Temporarily disabled ... (#15034)
#endif
```

Validated on an AMD Ryzen AI MAX+ 395 (gfx1151 APU, ROCm 7.2.1): the HIP device
now reports `integrated=1` and the cached `info.devices[id].integrated` matches
`prop.integrated`. Discrete AMD GPUs report `integrated=0` and are unaffected.

Fixes #23977

---

*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*
