### PR TITLE
common : default GPU_MAX_HW_QUEUES=1 on HIP to fix idle GPU load

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstdarg>
 #include <cstring>
+#include <cstdlib>
 #include <ctime>
 #include <filesystem>
 #include <fstream>
@@ -371,6 +372,16 @@ void common_init() {
     common_log_set_timestamps(common_log_main(), true);
 
     llama_log_set(common_log_default_callback, NULL);
+
+#if defined(GGML_USE_HIP)
+    // Work around a ROCm/amdgpu MES multi-queue issue where an idle server
+    // can sit at ~100% GFX utilization and max clocks (#3929, #21430, #23965).
+    // Default GPU_MAX_HW_QUEUES to 1 on HIP builds when the user has not set it;
+    // an explicit value is always respected.
+    if (!std::getenv("GPU_MAX_HW_QUEUES")) {
+        setenv("GPU_MAX_HW_QUEUES", "1", 0);
+    }
+#endif
 }
 
 void common_params_print_info(const common_params & params, bool print_devices) {


### PR DESCRIPTION
## Overview

On HIP/ROCm, `llama-server` with `--mmproj` can leave the GPU pinned at high utilization and
maximum core clock while all slots are idle. This is a known ROCm/amdgpu MES multi-queue behavior
(see #3929, #21430) and is reported for the mmproj idle case in #23965. Limiting the number of HW
queues to 1 avoids the idle busy-loop.

In `common_init()`, for **HIP builds only**, default `GPU_MAX_HW_QUEUES` to `1` when the user has
not already set it. An explicitly-set value is always respected; non-HIP builds are untouched:

```c
#if defined(GGML_USE_HIP)
    if (!std::getenv("GPU_MAX_HW_QUEUES")) {
        setenv("GPU_MAX_HW_QUEUES", "1", 0);
    }
#endif
```

Fixes #23965.

## Additional information

Validated on real AMD ROCm hardware:
- Hardware: Radeon RX 9070 (gfx1201, RDNA4) · ROCm 7.2.1
- Before: with `--mmproj`, an idle server holds the core clock at ~3.2 GHz.
- After: with the default in place, an idle server settles to its low idle clock for the large
  majority of samples (a single transient boost spike is normal).

Note on the approach: this sets an environment default rather than changing mmproj logic. If
maintainers prefer documenting `GPU_MAX_HW_QUEUES=1` for ROCm consumer GPUs instead of a code
default, I'm glad to switch to a docs-only change.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — AI was used in an assistive capacity only (locating the relevant
  code paths and drafting wording). I authored and reviewed the change, understand it fully, and can
  explain every line; the fix and the on-hardware validation are mine. No AI-written code was
  submitted without manual review.
