### PR TITLE
arg: Skip mmproj download when user supplied mmproj

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -444,7 +444,7 @@ bool common_params_handle_models(common_params & params, llama_example curr_ex) 
     opts.offline         = params.offline;
     opts.skip_download   = params.skip_download;
     opts.download_mtp    = spec_type_draft_mtp;
-    opts.download_mmproj = !params.no_mmproj;
+    opts.download_mmproj = !params.no_mmproj && params.mmproj.path.empty() && params.mmproj.url.empty();
 
     // sub-models (draft, mmproj, vocoder) are explicitly specified by the user,
     // so we should not auto-discover mtp/mmproj siblings for them


### PR DESCRIPTION
## Overview

Current behaviour:

When `-hf` is present and user supplied an mmproj with `--mmproj` or `--mmproj-url`, the download of mmproj from Hugging Face still happens.

Behaviour after this PR:

No mmproj download from Hugging Face happens, when mmproj is already specified by the user.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) :heavy_check_mark: 
- AI usage disclosure: no AI used.
