### PR TITLE
ui: Fix excessive style recalculation on hover

### DIFF
--- a/tools/ui/src/app.css
+++ b/tools/ui/src/app.css
@@ -148,7 +148,6 @@
 	* {
 		scrollbar-width: thin;
 		scrollbar-color: transparent transparent;
-		transition: scrollbar-color 0.2s ease;
 	}
 
 	*:hover {


### PR DESCRIPTION
## Overview

There's currently a transition for `scrollbar-color` applied to every element on the page with a 0.2s duration, as well as a `:hover` for every element on the page that changes `scrollbar-color`. This is causing excessive style recalculation as well as noticeable lag during certain UI interactions in Chrome. I checked a few browser/OS combos and I'm unsure if this transition is even doing anything from a functional standpoint.

## Additional information

I first noticed this when expanding/collapsing the reasoning block. With a sufficient amount of elements on the page (after several messages, especially with math) the reasoning block was taking around 1s to collapse, during which time the page seemed to be frozen. Removing this transition allows the reasoning blocks to be collapsed instantly.

After digging into this a bit further, I noticed excessive render time just from moving the mouse in and out of the viewport - this scales with the number of elements on the page. Example of this below, comparing before and after this change:

Before:
<img width="1003" height="502" alt="image" src="https://github.com/user-attachments/assets/ed112f37-3e07-41ee-84cd-1579cb3a093c" />
6356 elements invalidated:
<img width="263" height="241" alt="image" src="https://github.com/user-attachments/assets/a2a2ac3a-b9a8-45bf-b010-2f107e12ec33" />

After:
<img width="1007" height="604" alt="image" src="https://github.com/user-attachments/assets/cb7568cc-5f40-4ffd-bfef-8cbbe4eb3e62" />
27 elements invalidated:
<img width="320" height="190" alt="image" src="https://github.com/user-attachments/assets/d275e019-8539-4178-b815-90d30ad2d477" />

As you can see in the after, the number of elements invalidated (6356->27) and time spent rendering (1705ms->554ms) are greatly reduced, but still not 0. There are still a few elements (notably `button.svelte`) that include the `transition-all` class, through which `scrollbar-color` is still animated. I left those as-is because I was unsure which of their properties were intended to be animated.

The excessive time spent here is likely a bug in Chromium. I can repro in Chrome+Edge, but not in Firefox.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
