### PR TITLE
server : add token healing support

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -279,6 +279,8 @@ struct common_params_sampling {
     std::string              reasoning_budget_message;         // message injected before end tag when budget exhausted
     bool                     reasoning_control = false;        // create the budget sampler on demand so reasoning can be ended at runtime
 
+    std::string token_healing_prefix;
+
     bool backend_sampling = false;
 
     bool has_logit_bias() const {

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -398,6 +398,12 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         params.backend_sampling = false;
     }
 
+    if (!params.token_healing_prefix.empty() && params.backend_sampling) {
+        LOG_WRN("%s: backend sampling is not compatible with token healing, disabling\n", __func__);
+
+        params.backend_sampling = false;
+    }
+
     auto * result = new common_sampler {
         /* .params  = */ params,
         /* .grmr    = */ grmr,
@@ -441,6 +447,11 @@ static bool grammar_should_apply(struct common_sampler * gsmpl) {
 void common_sampler_accept(struct common_sampler * gsmpl, llama_token token, bool is_generated) {
     if (!gsmpl) {
         return;
+    }
+
+    // Clear token healing prefix on the first accepted generated token
+    if (is_generated) {
+        gsmpl->params.token_healing_prefix.clear();
     }
 
     const auto tm = gsmpl->tm();
@@ -548,6 +559,44 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
     auto & cur_p = gsmpl->cur_p; // initialized by set_logits
 
     gsmpl->set_logits(ctx, idx);
+
+    if (!gsmpl->params.token_healing_prefix.empty()) {
+        const llama_model * model = llama_get_model(ctx);
+        const llama_vocab * vocab = llama_model_get_vocab(model);
+        bool at_least_one_valid = false;
+
+        for (size_t i = 0; i < gsmpl->cur_p.size; ++i) {
+            llama_token token_id = gsmpl->cur_p.data[i].id;
+            if (llama_vocab_is_control(vocab, token_id) || llama_vocab_is_eog(vocab, token_id)) {
+                continue;
+            }
+            std::string piece = common_token_to_piece(vocab, token_id, false);
+            if (piece.size() >= gsmpl->params.token_healing_prefix.size() &&
+                piece.compare(0, gsmpl->params.token_healing_prefix.size(), gsmpl->params.token_healing_prefix) == 0) {
+                at_least_one_valid = true;
+                break;
+            }
+        }
+
+        if (at_least_one_valid) {
+            for (size_t i = 0; i < gsmpl->cur_p.size; ++i) {
+                llama_token token_id = gsmpl->cur_p.data[i].id;
+                if (llama_vocab_is_control(vocab, token_id) || llama_vocab_is_eog(vocab, token_id)) {
+                    gsmpl->cur_p.data[i].logit = -INFINITY;
+                    continue;
+                }
+                std::string piece = common_token_to_piece(vocab, token_id, false);
+                if (piece.size() >= gsmpl->params.token_healing_prefix.size() &&
+                    piece.compare(0, gsmpl->params.token_healing_prefix.size(), gsmpl->params.token_healing_prefix) == 0) {
+                    // keep logit
+                } else {
+                    gsmpl->cur_p.data[i].logit = -INFINITY;
+                }
+            }
+        } else {
+            LOG_WRN("%s: token healing failed: no vocabulary token starts with prefix '%s'\n", __func__, gsmpl->params.token_healing_prefix.c_str());
+        }
+    }
 
     // Check if a backend sampler has already sampled a token in which case we
     // return that token id directly.

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -114,6 +114,9 @@ struct server_slot {
     bool has_new_line   = false;
     bool truncated      = false;
 
+    bool token_healing = false;
+    std::string token_healing_prefix;
+
     stop_type stop;
 
     std::string stopping_word;
@@ -204,6 +207,8 @@ struct server_slot {
         generated_text = "";
         has_new_line   = false;
         truncated      = false;
+        token_healing  = false;
+        token_healing_prefix = "";
         stop           = STOP_TYPE_NONE;
         stopping_word  = "";
         n_sent_text    = 0;
@@ -1424,6 +1429,21 @@ private:
     }
 
     bool launch_slot_with_task(server_slot & slot, server_task && task) {
+        // Token healing
+        slot.token_healing = task.params.token_healing;
+        slot.token_healing_prefix = "";
+        if (slot.token_healing && task.tokens.size() > 0) {
+            llama_token last_token = task.tokens[task.tokens.size() - 1];
+            if (last_token != LLAMA_TOKEN_NULL && !llama_vocab_is_control(vocab, last_token) && !llama_vocab_is_eog(vocab, last_token)) {
+                slot.token_healing_prefix = common_token_to_piece(vocab, last_token, false);
+                task.tokens.keep_first(task.tokens.size() - 1);
+                task.params.sampling.token_healing_prefix = slot.token_healing_prefix;
+                SLT_INF(slot, "token healing activated. prefix: '%s', popped token: %d\n", slot.token_healing_prefix.c_str(), last_token);
+            } else {
+                slot.token_healing = false;
+            }
+        }
+
         // process per-request lora adapters
         if (!task.params.lora.empty()) {
             auto task_loras = construct_lora_list(task.params.lora);
@@ -1511,6 +1531,7 @@ private:
             bool backend_sampling = true;
 
             backend_sampling &= task.params.sampling.backend_sampling;
+            backend_sampling &= !task.params.token_healing;
 
             // TODO: speculative decoding requires multiple samples per batch - not supported yet
             backend_sampling &= !(slot.can_speculate());

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -79,6 +79,7 @@ json task_params::to_json(bool only_metrics) const {
             {"speculative.types",         common_speculative_type_name_str(speculative.types)},
             {"timings_per_token",         timings_per_token},
             {"post_sampling_probs",       post_sampling_probs},
+            {"token_healing",             token_healing},
             {"backend_sampling",          sampling.backend_sampling},
             {"lora",                      lora},
         };
@@ -136,6 +137,7 @@ json task_params::to_json(bool only_metrics) const {
         {"speculative.types",         common_speculative_type_name_str(speculative.types)},
         {"timings_per_token",         timings_per_token},
         {"post_sampling_probs",       post_sampling_probs},
+        {"token_healing",             token_healing},
         {"backend_sampling",          sampling.backend_sampling},
         {"lora",                      lora},
     };
@@ -257,6 +259,7 @@ task_params server_task::params_from_json_cmpl(
     // enabling this will output extra debug information in the HTTP responses from the server
     params.verbose           = params_base.verbosity > 9;
     params.timings_per_token = json_value(data, "timings_per_token", false);
+    params.token_healing     = json_value(data, "token_healing",     false);
 
     params.stream           = json_value(data,       "stream",             false);
     auto stream_opt         = json_value(data,       "stream_options",     json::object());

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -75,6 +75,7 @@ struct task_params {
 
     bool timings_per_token   = false;
     bool post_sampling_probs = false;
+    bool token_healing       = false;
 
     struct common_params_sampling sampling;
     struct common_params_speculative speculative;


### PR DESCRIPTION
### Summary
This PR adds support for **Token Healing** (requested in #5765) to the `llama-server` `/completion` endpoint.

### Details
- **Sampling Constraint**: Added `token_healing_prefix` to `common_params_sampling` and implemented logit constraints in `common_sampler_sample`. If the prefix is set, logits of tokens not matching the prefix are set to `-INFINITY`.
- **Prefill Handling**: Adjusted `common_sampler_accept` to clear the `token_healing_prefix` only when `is_generated` is `true`, preventing it from clearing during the initial prompt prefill.
- **Server API & Integration**:
  - Added `"token_healing": true/false` parameter to `/completion` requests.
  - In `server-context.cpp`, if `token_healing` is requested, we pop the last token from the prompt, convert it back into a string/byte prefix, and store it in sampling parameters.
  - Disabled backend sampling for requests where token healing is active to guarantee logits constraint on CPU.

### Testing & Validation
Tested with `Qwen2.5-0.5B-Instruct-Q4_K_M.gguf`.

#### WITHOUT Token Healing (`token_healing: false`):
- **Prompt**: `"The capital of Fran"`
- **Generated**: `"conia is the town of Garmisch-"`
- **Result**: The model treated `" Fran"` as a complete token and completed the suffix `"conia"`.

#### WITH Token Healing (`token_healing: true`):
- **Prompt**: `"The capital of Fran"`
- **Generated**: `" France is Paris. It is the largest city in"`
- **Result**: Successfully popped `" Fran"`, constrained the first generated token to match prefix `" Fran"`, and successfully predicted `" France"`.

Fixes #5765
