### PR TITLE
Add experimental deterministic `viscosity` sampler

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1819,6 +1819,42 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_sampling());
     add_opt(common_arg(
+        {"--viscosity-alpha"}, "N",
+        string_format("viscosity sampler: viscosity-weighted fallback prior blend strength "
+                      "(valid range 0.0 to 1.0) (default: %.2f)",
+                      (double)params.sampling.viscosity_alpha),
+        [](common_params & params, const std::string & value) {
+            params.sampling.viscosity_alpha = std::stof(value);
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--viscosity-beta"}, "N",
+        string_format("viscosity sampler: accepted-token prior update rate "
+                      "(valid range 0.0 to 1.0) (default: %.2f)",
+                      (double)params.sampling.viscosity_beta),
+        [](common_params & params, const std::string & value) {
+            params.sampling.viscosity_beta = std::stof(value);
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--viscosity-lambda"}, "N",
+        string_format("viscosity sampler: viscosity smoothness weight for damping abrupt prior-blend changes "
+                      "(default: %.2f)",
+                      (double)params.sampling.viscosity_lambda),
+        [](common_params & params, const std::string & value) {
+            params.sampling.viscosity_lambda = std::stof(value);
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--viscosity-prior-floor"}, "N",
+        string_format("viscosity sampler: minimum prior mass assigned to each candidate token "
+                      "(default: %.8f)",
+                      (double)params.sampling.viscosity_prior_floor),
+        [](common_params & params, const std::string & value) {
+            params.sampling.viscosity_prior_floor = std::stof(value);
+        }
+    ).set_sampling());
+    add_opt(common_arg(
         {"--dynatemp-range"}, "N",
         string_format("dynamic temperature range (default: %.2f, 0.0 = disabled)", (double)params.sampling.dynatemp_range),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -114,6 +114,7 @@ enum common_sampler_type {
     COMMON_SAMPLER_TYPE_PENALTIES   = 10,
     COMMON_SAMPLER_TYPE_TOP_N_SIGMA = 11,
     COMMON_SAMPLER_TYPE_ADAPTIVE_P  = 12,
+    COMMON_SAMPLER_TYPE_viscosity      = 13,
 };
 
 // dimensionality reduction methods, used by cvector-generator
@@ -232,6 +233,10 @@ struct common_params_sampling {
     int32_t dry_penalty_last_n = -1;     // how many tokens to scan for repetitions (0 = disable penalty, -1 = context size)
     float   adaptive_target    = -1.0f;  // select tokens near this probability (valid range 0.0 to 1.0; negative = disabled)
     float   adaptive_decay     = 0.90f;  // EMA decay for adaptation; history ≈ 1/(1-decay) tokens (0.0 - 0.99)
+    float   viscosity_alpha       = 0.35f;  // viscosity sampler: blend strength for viscosity-weighted fallback prior
+    float   viscosity_beta        = 0.05f;  // viscosity sampler: accepted-token prior update rate
+    float   viscosity_lambda      = 0.00f;  // viscosity sampler: viscosity smoothness weight for damping abrupt prior-blend changes
+    float   viscosity_prior_floor = 1e-6f;  // viscosity sampler: minimum prior mass for candidate tokens
     int32_t mirostat           = 0;      // 0 = disabled, 1 = mirostat, 2 = mirostat 2.0
     float   top_n_sigma        = -1.00f; // -1.0 = disabled
     float   mirostat_tau       = 5.00f;  // target entropy

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -169,17 +169,19 @@ struct common_sampler {
 };
 
 std::string common_params_sampling::print() const {
-    char result[1024];
+    char result[1536];
 
     snprintf(result, sizeof(result),
             "\trepeat_last_n = %d, repeat_penalty = %.3f, frequency_penalty = %.3f, presence_penalty = %.3f\n"
             "\tdry_multiplier = %.3f, dry_base = %.3f, dry_allowed_length = %d, dry_penalty_last_n = %d\n"
             "\ttop_k = %d, top_p = %.3f, min_p = %.3f, xtc_probability = %.3f, xtc_threshold = %.3f, typical_p = %.3f, top_n_sigma = %.3f, temp = %.3f\n"
-            "\tmirostat = %d, mirostat_lr = %.3f, mirostat_ent = %.3f, adaptive_target = %.3f, adaptive_decay = %.3f",
+            "\tmirostat = %d, mirostat_lr = %.3f, mirostat_ent = %.3f, adaptive_target = %.3f, adaptive_decay = %.3f\n"
+            "\tviscosity_alpha = %.3f, viscosity_beta = %.3f, viscosity_lambda = %.3f, viscosity_prior_floor = %.8f",
             penalty_last_n, penalty_repeat, penalty_freq, penalty_present,
             dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n,
             top_k, top_p, min_p, xtc_probability, xtc_threshold, typ_p, top_n_sigma, temp,
-            mirostat, mirostat_eta, mirostat_tau, adaptive_target, adaptive_decay);
+            mirostat, mirostat_eta, mirostat_tau, adaptive_target, adaptive_decay,
+            viscosity_alpha, viscosity_beta, viscosity_lambda, viscosity_prior_floor);
 
     return std::string(result);
 }
@@ -314,6 +316,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
     if (params.mirostat == 0) {
 
         bool use_adaptive_p = false; // see below
+        bool use_viscosity    = false; // see below
 
         for (const auto & cnstr : params.samplers) {
             switch (cnstr) {
@@ -361,11 +364,23 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
                     // so we know to add the sampler at the very end.
                     use_adaptive_p = true;
                     break;
+                case COMMON_SAMPLER_TYPE_viscosity:
+                    // the `viscosity` sampler selects a single token deterministically, so it must
+                    // terminate the chain in the same way as `adaptive-p`, `dist`, and `mirostat`.
+                    use_viscosity = true;
+                    break;
                 default:
                     GGML_ASSERT(false && "unknown sampler type");
             }
         }
-        if (use_adaptive_p) {
+        if (use_viscosity && use_adaptive_p) {
+            LOG_WRN("%s: both adaptive-p and viscosity were requested; using viscosity as the sampler-chain terminator\n", __func__);
+        }
+
+        if (use_viscosity) {
+            // only if user explicitly included viscosity sampler
+            samplers.push_back(llama_sampler_init_viscosity(params.viscosity_alpha, params.viscosity_beta, params.viscosity_lambda, params.viscosity_prior_floor));
+        } else if (use_adaptive_p) {
             // only if user explicitly included adaptive-p sampler
             samplers.push_back(llama_sampler_init_adaptive_p(params.adaptive_target, params.adaptive_decay, params.seed));
         } else {
@@ -748,6 +763,7 @@ char common_sampler_type_to_chr(enum common_sampler_type cnstr) {
         case COMMON_SAMPLER_TYPE_INFILL:      return 'i';
         case COMMON_SAMPLER_TYPE_PENALTIES:   return 'e';
         case COMMON_SAMPLER_TYPE_ADAPTIVE_P:  return 'a';
+        case COMMON_SAMPLER_TYPE_viscosity:      return 'o';
         default : return '?';
     }
 }
@@ -765,6 +781,7 @@ std::string common_sampler_type_to_str(enum common_sampler_type cnstr) {
         case COMMON_SAMPLER_TYPE_INFILL:      return "infill";
         case COMMON_SAMPLER_TYPE_PENALTIES:   return "penalties";
         case COMMON_SAMPLER_TYPE_ADAPTIVE_P:  return "adaptive_p";
+        case COMMON_SAMPLER_TYPE_viscosity:      return "viscosity";
         default : return "";
     }
 }
@@ -782,6 +799,7 @@ std::vector<common_sampler_type> common_sampler_types_from_names(const std::vect
         { "infill",      COMMON_SAMPLER_TYPE_INFILL },
         { "penalties",   COMMON_SAMPLER_TYPE_PENALTIES },
         { "adaptive_p",  COMMON_SAMPLER_TYPE_ADAPTIVE_P },
+        { "viscosity",      COMMON_SAMPLER_TYPE_viscosity },
     };
 
     // since samplers names are written multiple ways
@@ -798,6 +816,7 @@ std::vector<common_sampler_type> common_sampler_types_from_names(const std::vect
         { "min-p",       COMMON_SAMPLER_TYPE_MIN_P },
         { "temp",        COMMON_SAMPLER_TYPE_TEMPERATURE },
         { "adaptive-p",  COMMON_SAMPLER_TYPE_ADAPTIVE_P },
+        { "entropy-collapse", COMMON_SAMPLER_TYPE_viscosity },
     };
 
     std::vector<common_sampler_type> samplers;
@@ -835,6 +854,7 @@ std::vector<common_sampler_type> common_sampler_types_from_chars(const std::stri
         { common_sampler_type_to_chr(COMMON_SAMPLER_TYPE_INFILL),      COMMON_SAMPLER_TYPE_INFILL },
         { common_sampler_type_to_chr(COMMON_SAMPLER_TYPE_PENALTIES),   COMMON_SAMPLER_TYPE_PENALTIES },
         { common_sampler_type_to_chr(COMMON_SAMPLER_TYPE_ADAPTIVE_P),  COMMON_SAMPLER_TYPE_ADAPTIVE_P },
+        { common_sampler_type_to_chr(COMMON_SAMPLER_TYPE_viscosity),      COMMON_SAMPLER_TYPE_viscosity },
     };
 
     std::vector<common_sampler_type> samplers;

--- a/include/llama.h
+++ b/include/llama.h
@@ -1442,6 +1442,16 @@ extern "C" {
                                float   decay,
                             uint32_t   seed);
 
+    /// @details Experimental deterministic entropy-collapse sampler. Uses the dominant-token-vs-rest
+    /// distribution entropy to derive an viscosity viscosity term, blends the model probabilities with
+    /// a lightweight accepted-token prior, and selects the maximum blended probability.
+    /// This sampler selects a token ID, so it should be last in the sampler chain.
+    LLAMA_API struct llama_sampler * llama_sampler_init_viscosity(
+                               float   alpha,
+                               float   beta,
+                               float   lambda,
+                               float   prior_floor);
+
     LLAMA_API struct llama_sampler * llama_sampler_init_logit_bias(
                              int32_t   n_vocab,
                              int32_t   n_logit_bias,

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -3433,10 +3433,16 @@ struct llama_sampler_viscosity {
 
     float omega_prev;
     float pending_omega;
+    float prior_scale;
     llama_token pending_token_id;
 
     std::vector<float> prior;
 };
+
+static constexpr size_t LLAMA_SAMPLER_VISCOSITY_ACTIVE_MAX  = 64;
+static constexpr size_t LLAMA_SAMPLER_VISCOSITY_ACTIVE_MIN  = 16;
+static constexpr float  LLAMA_SAMPLER_VISCOSITY_PROB_FLOOR  = 1e-4f;
+static constexpr float  LLAMA_SAMPLER_VISCOSITY_SCALE_FLOOR = 1e-12f;
 
 static float llama_sampler_viscosity_clip(float x, float lo, float hi) {
     return std::max(lo, std::min(hi, x));
@@ -3463,6 +3469,10 @@ static void llama_sampler_viscosity_apply(struct llama_sampler * smpl, llama_tok
         return;
     }
 
+    if (cur_p->size > LLAMA_SAMPLER_VISCOSITY_ACTIVE_MAX) {
+        llama_token_data_array_partial_sort_inplace(cur_p, LLAMA_SAMPLER_VISCOSITY_ACTIVE_MAX);
+    }
+
     llama_sampler_softmax_impl(cur_p, false);
 
     size_t i_best_model = 0;
@@ -3474,6 +3484,12 @@ static void llama_sampler_viscosity_apply(struct llama_sampler * smpl, llama_tok
         }
     }
 
+    size_t active_size = cur_p->size;
+    while (active_size > LLAMA_SAMPLER_VISCOSITY_ACTIVE_MIN && cur_p->data[active_size - 1].p < LLAMA_SAMPLER_VISCOSITY_PROB_FLOOR) {
+        active_size--;
+    }
+    cur_p->size = active_size;
+
     const float h = llama_sampler_viscosity_binary_entropy(p_star);
     const float s = 1.0f - fabsf(2.0f*p_star - 1.0f);
     const float omega = llama_sampler_viscosity_clip(0.85f - 0.35f*(h + s), 0.50f, 0.85f);
@@ -3481,7 +3497,7 @@ static void llama_sampler_viscosity_apply(struct llama_sampler * smpl, llama_tok
     double prior_sum = 0.0;
     for (size_t i = 0; i < cur_p->size; ++i) {
         const llama_token id = cur_p->data[i].id;
-        const float prior = id >= 0 && (size_t) id < ctx->prior.size() ? ctx->prior[id] : 0.0f;
+        const float prior = id >= 0 && (size_t) id < ctx->prior.size() ? ctx->prior[id]*ctx->prior_scale : 0.0f;
         prior_sum += std::max(0.0f, prior) + ctx->prior_floor;
     }
 
@@ -3492,7 +3508,7 @@ static void llama_sampler_viscosity_apply(struct llama_sampler * smpl, llama_tok
     float best_q = -INFINITY;
     for (size_t i = 0; i < cur_p->size; ++i) {
         const llama_token id = cur_p->data[i].id;
-        const float prior = id >= 0 && (size_t) id < ctx->prior.size() ? ctx->prior[id] : 0.0f;
+        const float prior = id >= 0 && (size_t) id < ctx->prior.size() ? ctx->prior[id]*ctx->prior_scale : 0.0f;
         const float pi = prior_sum > 0.0 ? (std::max(0.0f, prior) + ctx->prior_floor)/prior_sum : 1.0f/cur_p->size;
         const float q = (1.0f - blend)*cur_p->data[i].p + blend*pi;
 
@@ -3523,11 +3539,18 @@ static void llama_sampler_viscosity_accept(struct llama_sampler * smpl, llama_to
     }
 
     const float beta = llama_sampler_viscosity_clip(ctx->beta, 0.0f, 1.0f);
-    for (float & p : ctx->prior) {
-        p *= 1.0f - beta;
+
+    ctx->prior_scale *= 1.0f - beta;
+    if (ctx->prior_scale < LLAMA_SAMPLER_VISCOSITY_SCALE_FLOOR) {
+        for (float & p : ctx->prior) {
+            p *= ctx->prior_scale;
+        }
+        ctx->prior_scale = 1.0f;
     }
 
-    ctx->prior[token] += beta;
+    if (ctx->prior_scale > 0.0f) {
+        ctx->prior[token] += beta/ctx->prior_scale;
+    }
 
     if (ctx->pending_token_id == token) {
         ctx->omega_prev = ctx->pending_omega;
@@ -3541,6 +3564,7 @@ static void llama_sampler_viscosity_reset(struct llama_sampler * smpl) {
 
     ctx->omega_prev = 0.50f;
     ctx->pending_omega = 0.50f;
+    ctx->prior_scale = 1.0f;
     ctx->pending_token_id = LLAMA_TOKEN_NULL;
     ctx->prior.clear();
 }
@@ -3552,6 +3576,7 @@ static struct llama_sampler * llama_sampler_viscosity_clone(const struct llama_s
 
     result_ctx->omega_prev       = ctx->omega_prev;
     result_ctx->pending_omega    = ctx->pending_omega;
+    result_ctx->prior_scale      = ctx->prior_scale;
     result_ctx->pending_token_id = ctx->pending_token_id;
     result_ctx->prior            = ctx->prior;
 
@@ -3590,6 +3615,7 @@ struct llama_sampler * llama_sampler_init_viscosity(
             /* .prior_floor      = */ std::max(0.0f, prior_floor),
             /* .omega_prev       = */ 0.50f,
             /* .pending_omega    = */ 0.50f,
+            /* .prior_scale      = */ 1.0f,
             /* .pending_token_id = */ LLAMA_TOKEN_NULL,
             /* .prior            = */ {},
         }

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -3423,6 +3423,179 @@ struct llama_sampler * llama_sampler_init_adaptive_p(
     );
 }
 
+// viscosity
+
+struct llama_sampler_viscosity {
+    const float alpha;
+    const float beta;
+    const float lambda;
+    const float prior_floor;
+
+    float omega_prev;
+    float pending_omega;
+    llama_token pending_token_id;
+
+    std::vector<float> prior;
+};
+
+static float llama_sampler_viscosity_clip(float x, float lo, float hi) {
+    return std::max(lo, std::min(hi, x));
+}
+
+static float llama_sampler_viscosity_binary_entropy(float p) {
+    constexpr float eps = 1e-6f;
+
+    p = llama_sampler_viscosity_clip(p, eps, 1.0f - eps);
+
+    return -(p*logf(p) + (1.0f - p)*logf(1.0f - p))/logf(2.0f);
+}
+
+static const char * llama_sampler_viscosity_name(const struct llama_sampler * /*smpl*/) {
+    return "viscosity";
+}
+
+static void llama_sampler_viscosity_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
+    auto * ctx = (llama_sampler_viscosity *) smpl->ctx;
+
+    if (cur_p->size == 0) {
+        cur_p->selected = -1;
+        ctx->pending_token_id = LLAMA_TOKEN_NULL;
+        return;
+    }
+
+    llama_sampler_softmax_impl(cur_p, false);
+
+    size_t i_best_model = 0;
+    float p_star = cur_p->data[0].p;
+    for (size_t i = 1; i < cur_p->size; ++i) {
+        if (cur_p->data[i].p > p_star) {
+            p_star = cur_p->data[i].p;
+            i_best_model = i;
+        }
+    }
+
+    const float h = llama_sampler_viscosity_binary_entropy(p_star);
+    const float s = 1.0f - fabsf(2.0f*p_star - 1.0f);
+    const float omega = llama_sampler_viscosity_clip(0.85f - 0.35f*(h + s), 0.50f, 0.85f);
+
+    double prior_sum = 0.0;
+    for (size_t i = 0; i < cur_p->size; ++i) {
+        const llama_token id = cur_p->data[i].id;
+        const float prior = id >= 0 && (size_t) id < ctx->prior.size() ? ctx->prior[id] : 0.0f;
+        prior_sum += std::max(0.0f, prior) + ctx->prior_floor;
+    }
+
+    const float smooth = 1.0f + ctx->lambda*fabsf(omega - ctx->omega_prev);
+    const float blend = llama_sampler_viscosity_clip(ctx->alpha*omega/smooth, 0.0f, 1.0f);
+
+    size_t i_best = i_best_model;
+    float best_q = -INFINITY;
+    for (size_t i = 0; i < cur_p->size; ++i) {
+        const llama_token id = cur_p->data[i].id;
+        const float prior = id >= 0 && (size_t) id < ctx->prior.size() ? ctx->prior[id] : 0.0f;
+        const float pi = prior_sum > 0.0 ? (std::max(0.0f, prior) + ctx->prior_floor)/prior_sum : 1.0f/cur_p->size;
+        const float q = (1.0f - blend)*cur_p->data[i].p + blend*pi;
+
+        cur_p->data[i].p = q;
+        cur_p->data[i].logit = q > 0.0f ? logf(q) : -INFINITY;
+
+        if (q > best_q) {
+            best_q = q;
+            i_best = i;
+        }
+    }
+
+    cur_p->selected = i_best;
+    ctx->pending_token_id = cur_p->data[i_best].id;
+    ctx->pending_omega = omega;
+}
+
+static void llama_sampler_viscosity_accept(struct llama_sampler * smpl, llama_token token) {
+    auto * ctx = (llama_sampler_viscosity *) smpl->ctx;
+
+    if (token < 0) {
+        ctx->pending_token_id = LLAMA_TOKEN_NULL;
+        return;
+    }
+
+    if ((size_t) token >= ctx->prior.size()) {
+        ctx->prior.resize((size_t) token + 1, 0.0f);
+    }
+
+    const float beta = llama_sampler_viscosity_clip(ctx->beta, 0.0f, 1.0f);
+    for (float & p : ctx->prior) {
+        p *= 1.0f - beta;
+    }
+
+    ctx->prior[token] += beta;
+
+    if (ctx->pending_token_id == token) {
+        ctx->omega_prev = ctx->pending_omega;
+    }
+
+    ctx->pending_token_id = LLAMA_TOKEN_NULL;
+}
+
+static void llama_sampler_viscosity_reset(struct llama_sampler * smpl) {
+    auto * ctx = (llama_sampler_viscosity *) smpl->ctx;
+
+    ctx->omega_prev = 0.50f;
+    ctx->pending_omega = 0.50f;
+    ctx->pending_token_id = LLAMA_TOKEN_NULL;
+    ctx->prior.clear();
+}
+
+static struct llama_sampler * llama_sampler_viscosity_clone(const struct llama_sampler * smpl) {
+    const auto * ctx = (const llama_sampler_viscosity *) smpl->ctx;
+    auto * result = llama_sampler_init_viscosity(ctx->alpha, ctx->beta, ctx->lambda, ctx->prior_floor);
+    auto * result_ctx = (llama_sampler_viscosity *) result->ctx;
+
+    result_ctx->omega_prev       = ctx->omega_prev;
+    result_ctx->pending_omega    = ctx->pending_omega;
+    result_ctx->pending_token_id = ctx->pending_token_id;
+    result_ctx->prior            = ctx->prior;
+
+    return result;
+}
+
+static void llama_sampler_viscosity_free(struct llama_sampler * smpl) {
+    delete (llama_sampler_viscosity *) smpl->ctx;
+}
+
+static struct llama_sampler_i llama_sampler_viscosity_i = {
+    /* .name              = */ llama_sampler_viscosity_name,
+    /* .accept            = */ llama_sampler_viscosity_accept,
+    /* .apply             = */ llama_sampler_viscosity_apply,
+    /* .reset             = */ llama_sampler_viscosity_reset,
+    /* .clone             = */ llama_sampler_viscosity_clone,
+    /* .free              = */ llama_sampler_viscosity_free,
+    /* .backend_init      = */ nullptr,
+    /* .backend_accept    = */ nullptr,
+    /* .backend_apply     = */ nullptr,
+    /* .backend_set_input = */ nullptr,
+};
+
+struct llama_sampler * llama_sampler_init_viscosity(
+    float alpha,
+    float beta,
+    float lambda,
+    float prior_floor
+) {
+    return llama_sampler_init(
+        /* .iface = */ &llama_sampler_viscosity_i,
+        /* .ctx   = */ new llama_sampler_viscosity {
+            /* .alpha            = */ llama_sampler_viscosity_clip(alpha, 0.0f, 1.0f),
+            /* .beta             = */ llama_sampler_viscosity_clip(beta, 0.0f, 1.0f),
+            /* .lambda           = */ std::max(0.0f, lambda),
+            /* .prior_floor      = */ std::max(0.0f, prior_floor),
+            /* .omega_prev       = */ 0.50f,
+            /* .pending_omega    = */ 0.50f,
+            /* .pending_token_id = */ LLAMA_TOKEN_NULL,
+            /* .prior            = */ {},
+        }
+    );
+}
+
 // logit-bias
 
 struct llama_sampler_logit_bias : public llama_sampler_backend {

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -192,6 +192,57 @@ static void test_top_n_sigma(const std::vector<float> & probs, const std::vector
     tester.check();
 }
 
+static llama_token_data_array make_token_data_array(const std::vector<float> & probs, std::vector<llama_token_data> & cur) {
+    cur.clear();
+    cur.reserve(probs.size());
+
+    for (llama_token token_id = 0; token_id < (llama_token) probs.size(); token_id++) {
+        cur.emplace_back(llama_token_data{ token_id, logf(probs[token_id]), 0.0f });
+    }
+
+    return llama_token_data_array { cur.data(), cur.size(), -1, false };
+}
+
+static void test_viscosity() {
+    std::vector<llama_token_data> cur;
+
+    {
+        auto * sampler = llama_sampler_init_viscosity(0.35f, 0.05f, 0.0f, 1e-6f);
+        auto cur_p = make_token_data_array({ 0.10f, 0.20f, 0.70f }, cur);
+
+        llama_sampler_apply(sampler, &cur_p);
+        GGML_ASSERT(cur_p.selected >= 0);
+        GGML_ASSERT(cur_p.data[cur_p.selected].id == 2);
+
+        llama_sampler_free(sampler);
+    }
+
+    {
+        auto * sampler = llama_sampler_init_viscosity(1.0f, 1.0f, 0.0f, 0.0f);
+
+        auto cur_p = make_token_data_array({ 0.34f, 0.33f, 0.33f }, cur);
+        llama_sampler_apply(sampler, &cur_p);
+        GGML_ASSERT(cur_p.selected >= 0);
+        GGML_ASSERT(cur_p.data[cur_p.selected].id == 0);
+
+        llama_sampler_accept(sampler, 2);
+
+        cur_p = make_token_data_array({ 0.34f, 0.33f, 0.33f }, cur);
+        llama_sampler_apply(sampler, &cur_p);
+        GGML_ASSERT(cur_p.selected >= 0);
+        GGML_ASSERT(cur_p.data[cur_p.selected].id == 2);
+
+        llama_sampler_reset(sampler);
+
+        cur_p = make_token_data_array({ 0.34f, 0.33f, 0.33f }, cur);
+        llama_sampler_apply(sampler, &cur_p);
+        GGML_ASSERT(cur_p.selected >= 0);
+        GGML_ASSERT(cur_p.data[cur_p.selected].id == 0);
+
+        llama_sampler_free(sampler);
+    }
+}
+
 static void test_sampler_queue(const size_t n_vocab, const std::string & samplers_sequence, const int top_k, const float top_p, const float min_p
 ) {
     sampler_tester tester(n_vocab);
@@ -363,6 +414,7 @@ int main(void) {
     test_top_n_sigma({0.1f, 0.2f, 0.3f, 0.4f}, {0.571429f, 0.428571f, 0.0f, 0.0f}, 1.00f);
     test_top_n_sigma({0.1f, 0.2f, 0.3f, 0.4f}, {0.1f, 0.2f, 0.3f, 0.4f}, 0.00f); // top_n_sigma == 0 now represents a no-op rather than greedy decoding as of PR#13345
     test_top_n_sigma({0.1f, 0.2f, 0.3f, 0.4f}, {0.4f, 0.3f, 0.2f, 0.1f}, 3.00f);
+    test_viscosity();
 
     test_sampler_queue(10000, "k", 10000, 1.0f, 1.0f);
     test_sampler_queue(10000, "k",     1, 1.0f, 1.0f);

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -125,6 +125,10 @@
 | `--dry-sequence-breaker STRING` | add sequence breaker for DRY sampling, clearing out default breakers ('\n', ':', '"', '*') in the process; use "none" to not use any sequence breakers |
 | `--adaptive-target N` | adaptive-p: select tokens near this probability (valid range 0.0 to 1.0; negative = disabled) (default: -1.00)<br/>[(more info)](https://github.com/ggml-org/llama.cpp/pull/17927) |
 | `--adaptive-decay N` | adaptive-p: decay rate for target adaptation over time. lower values are more reactive, higher values are more stable.<br/>(valid range 0.0 to 0.99) (default: 0.90) |
+| `--viscosity-alpha N` | viscosity sampler: viscosity-weighted fallback prior blend strength (valid range 0.0 to 1.0) (default: 0.35) |
+| `--viscosity-beta N` | viscosity sampler: accepted-token prior update rate (valid range 0.0 to 1.0) (default: 0.05) |
+| `--viscosity-lambda N` | viscosity sampler: viscosity smoothness weight for damping abrupt prior-blend changes (default: 0.00) |
+| `--viscosity-prior-floor N` | viscosity sampler: minimum prior mass assigned to each candidate token (default: 0.00000100) |
 | `--dynatemp-range N` | dynamic temperature range (default: 0.00, 0.0 = disabled) |
 | `--dynatemp-exp N` | dynamic temperature exponent (default: 1.00) |
 | `--mirostat N` | use Mirostat sampling.<br/>Top K, Nucleus and Locally Typical samplers are ignored if used.<br/>(default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0) |

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -142,6 +142,10 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--dry-sequence-breaker STRING` | add sequence breaker for DRY sampling, clearing out default breakers ('\n', ':', '"', '*') in the process; use "none" to not use any sequence breakers |
 | `--adaptive-target N` | adaptive-p: select tokens near this probability (valid range 0.0 to 1.0; negative = disabled) (default: -1.00)<br/>[(more info)](https://github.com/ggml-org/llama.cpp/pull/17927) |
 | `--adaptive-decay N` | adaptive-p: decay rate for target adaptation over time. lower values are more reactive, higher values are more stable.<br/>(valid range 0.0 to 0.99) (default: 0.90) |
+| `--viscosity-alpha N` | viscosity sampler: viscosity-weighted fallback prior blend strength (valid range 0.0 to 1.0) (default: 0.35) |
+| `--viscosity-beta N` | viscosity sampler: accepted-token prior update rate (valid range 0.0 to 1.0) (default: 0.05) |
+| `--viscosity-lambda N` | viscosity sampler: viscosity smoothness weight for damping abrupt prior-blend changes (default: 0.00) |
+| `--viscosity-prior-floor N` | viscosity sampler: minimum prior mass assigned to each candidate token (default: 0.00000100) |
 | `--dynatemp-range N` | dynamic temperature range (default: 0.00, 0.0 = disabled) |
 | `--dynatemp-exp N` | dynamic temperature exponent (default: 1.00) |
 | `--mirostat N` | use Mirostat sampling.<br/>Top K, Nucleus and Locally Typical samplers are ignored if used.<br/>(default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0) |
@@ -495,6 +499,14 @@ These words will not be included in the completion, so make sure to add them to 
 
 `mirostat_eta`: Set the Mirostat learning rate, parameter eta.  Default: `0.1`
 
+`viscosity_alpha`: Set the viscosity sampler viscosity-weighted fallback prior blend strength. Default: `0.35`
+
+`viscosity_beta`: Set the viscosity sampler accepted-token prior update rate. Default: `0.05`
+
+`viscosity_lambda`: Set the viscosity sampler viscosity smoothness weight for damping abrupt prior-blend changes. Default: `0.0`
+
+`viscosity_prior_floor`: Set the viscosity sampler minimum prior mass assigned to each candidate token. Default: `0.000001`
+
 `grammar`: Set grammar for grammar-based sampling.  Default: no grammar
 
 `json_schema`: Set a JSON schema for grammar-based sampling (e.g. `{"items": {"type": "string"}, "minItems": 10, "maxItems": 100}` of a list of strings, or `{}` for any JSON). See [tests](../../tests/test-json-schema-to-grammar.cpp) for supported features.  Default: no JSON schema.
@@ -797,6 +809,10 @@ By default, it is read-only. To make POST request to change global properties, y
       "mirostat": 0,
       "mirostat_tau": 5.0,
       "mirostat_eta": 0.10000000149011612,
+      "viscosity_alpha": 0.3499999940395355,
+      "viscosity_beta": 0.05000000074505806,
+      "viscosity_lambda": 0.0,
+      "viscosity_prior_floor": 9.999999974752427e-7,
       "stop": [],
       "max_tokens": -1,
       "n_keep": 0,
@@ -941,6 +957,10 @@ If query param `?fail_on_no_slot=1` is set, this endpoint will respond with stat
       "mirostat": 0,
       "mirostat_tau": 5.0,
       "mirostat_eta": 0.10000000149011612,
+      "viscosity_alpha": 0.3499999940395355,
+      "viscosity_beta": 0.05000000074505806,
+      "viscosity_lambda": 0.0,
+      "viscosity_prior_floor": 9.999999974752427e-7,
       "max_tokens": -1,
       "n_keep": 0,
       "n_discard": 0,
@@ -1006,6 +1026,10 @@ If query param `?fail_on_no_slot=1` is set, this endpoint will respond with stat
       "mirostat": 0,
       "mirostat_tau": 5.0,
       "mirostat_eta": 0.10000000149011612,
+      "viscosity_alpha": 0.3499999940395355,
+      "viscosity_beta": 0.05000000074505806,
+      "viscosity_lambda": 0.0,
+      "viscosity_prior_floor": 9.999999974752427e-7,
       "max_tokens": -1,
       "n_keep": 0,
       "n_discard": 0,

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -63,6 +63,10 @@ json task_params::to_json(bool only_metrics) const {
             {"mirostat",                  sampling.mirostat},
             {"mirostat_tau",              sampling.mirostat_tau},
             {"mirostat_eta",              sampling.mirostat_eta},
+            {"viscosity_alpha",              sampling.viscosity_alpha},
+            {"viscosity_beta",               sampling.viscosity_beta},
+            {"viscosity_lambda",             sampling.viscosity_lambda},
+            {"viscosity_prior_floor",        sampling.viscosity_prior_floor},
             {"max_tokens",                n_predict},
             {"n_predict",                 n_predict}, // TODO: deduplicate?
             {"n_keep",                    n_keep},
@@ -114,6 +118,10 @@ json task_params::to_json(bool only_metrics) const {
         {"mirostat",                  sampling.mirostat},
         {"mirostat_tau",              sampling.mirostat_tau},
         {"mirostat_eta",              sampling.mirostat_eta},
+        {"viscosity_alpha",              sampling.viscosity_alpha},
+        {"viscosity_beta",               sampling.viscosity_beta},
+        {"viscosity_lambda",             sampling.viscosity_lambda},
+        {"viscosity_prior_floor",        sampling.viscosity_prior_floor},
         {"stop",                      antiprompt},
         {"max_tokens",                n_predict},
         {"n_predict",                 n_predict}, // TODO: deduplicate?
@@ -299,6 +307,10 @@ task_params server_task::params_from_json_cmpl(
     params.sampling.mirostat_eta       = json_value(data, "mirostat_eta",        defaults.sampling.mirostat_eta);
     params.sampling.adaptive_target    = json_value(data, "adaptive_target",     defaults.sampling.adaptive_target);
     params.sampling.adaptive_decay     = json_value(data, "adaptive_decay",      defaults.sampling.adaptive_decay);
+    params.sampling.viscosity_alpha       = json_value(data, "viscosity_alpha",        defaults.sampling.viscosity_alpha);
+    params.sampling.viscosity_beta        = json_value(data, "viscosity_beta",         defaults.sampling.viscosity_beta);
+    params.sampling.viscosity_lambda      = json_value(data, "viscosity_lambda",       defaults.sampling.viscosity_lambda);
+    params.sampling.viscosity_prior_floor = json_value(data, "viscosity_prior_floor",  defaults.sampling.viscosity_prior_floor);
     params.sampling.seed               = json_value(data, "seed",                defaults.sampling.seed);
     params.sampling.n_probs            = json_value(data, "n_probs",             defaults.sampling.n_probs);
     params.sampling.min_keep           = json_value(data, "min_keep",            defaults.sampling.min_keep);

--- a/tools/ui/src/lib/services/chat.service.ts
+++ b/tools/ui/src/lib/services/chat.service.ts
@@ -155,6 +155,10 @@ export class ChatService {
 			dry_base,
 			dry_allowed_length,
 			dry_penalty_last_n,
+			viscosity_alpha,
+			viscosity_beta,
+			viscosity_lambda,
+			viscosity_prior_floor,
 			// Other parameters
 			samplers,
 			backend_sampling,
@@ -289,6 +293,10 @@ export class ChatService {
 		if (dry_base !== undefined) requestBody.dry_base = dry_base;
 		if (dry_allowed_length !== undefined) requestBody.dry_allowed_length = dry_allowed_length;
 		if (dry_penalty_last_n !== undefined) requestBody.dry_penalty_last_n = dry_penalty_last_n;
+		if (viscosity_alpha !== undefined) requestBody.viscosity_alpha = viscosity_alpha;
+		if (viscosity_beta !== undefined) requestBody.viscosity_beta = viscosity_beta;
+		if (viscosity_lambda !== undefined) requestBody.viscosity_lambda = viscosity_lambda;
+		if (viscosity_prior_floor !== undefined) requestBody.viscosity_prior_floor = viscosity_prior_floor;
 
 		if (samplers !== undefined) {
 			requestBody.samplers =

--- a/tools/ui/src/lib/types/api.d.ts
+++ b/tools/ui/src/lib/types/api.d.ts
@@ -155,6 +155,10 @@ export interface ApiLlamaCppServerProps {
 			mirostat: number;
 			mirostat_tau: number;
 			mirostat_eta: number;
+			viscosity_alpha: number;
+			viscosity_beta: number;
+			viscosity_lambda: number;
+			viscosity_prior_floor: number;
 			stop: string[];
 			max_tokens: number;
 			n_keep: number;
@@ -243,6 +247,10 @@ export interface ApiChatCompletionRequest {
 	dry_base?: number;
 	dry_allowed_length?: number;
 	dry_penalty_last_n?: number;
+	viscosity_alpha?: number;
+	viscosity_beta?: number;
+	viscosity_lambda?: number;
+	viscosity_prior_floor?: number;
 	// Sampler configuration
 	samplers?: string[];
 	backend_sampling?: boolean;
@@ -340,6 +348,10 @@ export interface ApiSlotData {
 		mirostat: number;
 		mirostat_tau: number;
 		mirostat_eta: number;
+		viscosity_alpha: number;
+		viscosity_beta: number;
+		viscosity_lambda: number;
+		viscosity_prior_floor: number;
 		max_tokens: number;
 		n_keep: number;
 		n_discard: number;

--- a/tools/ui/src/lib/types/settings.d.ts
+++ b/tools/ui/src/lib/types/settings.d.ts
@@ -96,6 +96,10 @@ export interface SettingsChatServiceOptions {
 	dry_base?: number;
 	dry_allowed_length?: number;
 	dry_penalty_last_n?: number;
+	viscosity_alpha?: number;
+	viscosity_beta?: number;
+	viscosity_lambda?: number;
+	viscosity_prior_floor?: number;
 	// Sampler configuration
 	samplers?: string | string[];
 	backend_sampling?: boolean;


### PR DESCRIPTION
This PR adds an experimental deterministic sampler named `viscosity`.

The sampler derives a simple entropy/balance signal from the current candidate distribution, uses that signal to blend model probability with a lightweight accepted-token prior, and then selects the highest resulting score deterministically. It is intended as an opt-in sampler-chain terminator for users who want a deterministic decoding policy whose behavior does not depend on RNG state.

This does **not** change transformer evaluation, attention, KV cache behavior, model loading, or any ggml backend kernels.

## What Changed

- Added public API:
  - `llama_sampler_init_viscosity(alpha, beta, lambda, prior_floor)`
- Added sampler implementation in `src/llama-sampler.cpp`.
- Added CLI sampling support:
  - `--samplers viscosity`
  - `--viscosity-alpha`
  - `--viscosity-beta`
  - `--viscosity-lambda`
  - `--viscosity-prior-floor`
- Added server request/default serialization for viscosity parameters.
- Added Web UI request/type plumbing for viscosity parameters.
- Added sampler unit coverage in `tests/test-sampling.cpp`.
- Added a hot-path optimization after initial A/B testing:
  - viscosity only evaluates a bounded active candidate set
  - dead tail candidates are pruned by probability floor
  - prior decay is applied lazily through a global scale instead of walking the whole token-id prior vector on every accepted token

## Diff Context

Compared against the original local repo in `llama.cpp_old`, the relevant implementation/API surface is concentrated in:

```text
include/llama.h
src/llama-sampler.cpp
common/common.h
common/sampling.cpp
common/arg.cpp
tests/test-sampling.cpp
tools/cli/README.md
tools/server/README.md
tools/server/server-task.cpp
tools/ui/src/lib/services/chat.service.ts
tools/ui/src/lib/types/api.d.ts
tools/ui/src/lib/types/settings.d.ts
```

Commit-level stats on this branch:

```text
c771e3ce1 feat(sampling): add viscosity sampler parameters and implementation
12 files changed, 364 insertions(+), 4 deletions(-)

0c281ecb4 Optimize viscosity sampler hot path
1 file changed, 31 insertions(+), 5 deletions(-)
```

The current hot-path implementation caps the active route set at 64 candidates, keeps at least 16 candidates, prunes sub-floor probabilities after softmax, and stores prior decay as a lazy `prior_scale`.

## Why

The main goal is deterministic, stateful decoding behavior. Standard stochastic sampler chains are useful and should remain the default. They can also be made reproducible with a fixed seed under stable runtime settings, and this PR does not dispute that. The distinction here is narrower: `viscosity` is not reproducing a random sampling path. It is a deterministic scoring policy:

```text
logits -> viscosity
```

This gives users another deterministic decoding mode to test prompt behavior, compare model changes, and run local workflows where stochastic variety is not desired.

## Algorithm Sketch

For each decode step:

1. Keep a bounded top-logit active set.
2. Softmax the active candidates.
3. Compute the dominant-token probability `p_star`.
4. Compute a binary entropy term and route-balance term.
5. Convert those into a bounded viscosity coefficient: `omega = clip(0.85 - 0.35*(H + S), 0.50, 0.85)`.
6. Blend model probability with a sparse accepted-token prior.
7. Select the maximum blended score deterministically.
8. On accept, update only the accepted token prior and apply decay lazily.

This keeps the sampler zero-dependency and CPU-side.

## A/B Test

I ran a local A/B test against an unmodified original repo folder (`llama.cpp_old`) using the same cached model and prompt.

Model:

```text
bartowski/Qwen2.5-7B-Instruct-GGUF:Q4_K_M
```

Prompt:

```text
Write a concise technical explanation of why token samplers affect sampling overhead but not raw transformer inference speed.
```

Command shape:

```powershell
.\ab-test-qwen.ps1 -Runs 100 -Predict 512 -Seed 42 -NoWarmup
```

Fresh summary log:

```text
C:\Users\alxth\OneDrive\Desktop\llamacpp\logs\ab-qwen-summary-20260606-193247.md
```

### Results

| Target | Runs | Avg total ms | Avg sampling ms | Avg samplers ms | Avg eval ms | Avg word tokens | Avg unique ratio | Determinism |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| fork `viscosity` | 100 | 61416.11 | n/a | n/a | 60503.80 | 473.0 | 0.2960 | PASS, 1 distinct SHA256 |
| old baseline, `--seed 42` | 100 | 55886.56 | n/a | n/a | 55162.54 | 402.0 | 0.4403 | PASS, 1 distinct SHA256 |

Per-run hashes:

```text
fork-viscosity:
  all 100 runs: d2968bf6065f...

old-baseline:
  all 100 runs: 49b73fd5a648...
```

I also checked whether changing CPU thread count from 4 to 6 would change the old baseline completion with the same fixed seed. On this machine, it did not:

```text
old baseline, --threads 4, --seed 42: 3a4a72ea0abd...
old baseline, --threads 6, --seed 42: 3a4a72ea0abd...
```

## Interpretation

The useful result is not that fixed seeds fail. In this local test, the baseline with `--seed 42` was fully reproducible, including across a 4-thread vs. 6-thread check. The useful distinction is that `viscosity` provides a deterministic sampler rule that does not rely on RNG state or seeded stochastic selection.

The performance result should also be interpreted carefully. This sampler does **not** accelerate raw transformer inference. Decode speed is dominated by model evaluation and memory bandwidth, not by sampler arithmetic. In the server-mode 100-run test, server timings reported prompt/eval time but not CLI `samplers time`, so this run should not be used as a sampler microbenchmark.

Earlier CLI smoke testing after the hot-path patch showed the prior full-vector update problem was substantially reduced:

```text
before hot-path patch: 47.04 ms samplers time
after hot-path patch:   5.21 ms samplers time
old baseline:           3.25 ms samplers time
```

So the implementation is no longer walking/decaying the full prior vector every token, but the sampler should still be treated as experimental and benchmarked more broadly before any default behavior is considered.

## Fixed Seed Note

During review discussion, I tested the claim that a fixed seed is enough to reproduce the baseline stochastic sampler. In my local CPU/WSL environment, that claim held:

```text
100 repeated baseline runs with --seed 42: 1 distinct output
baseline --threads 4 vs --threads 6 with --seed 42: identical output
```

This PR should therefore be evaluated as an experimental deterministic decoding mode, not as a replacement for seeded stochastic sampling.

## Testing

Build/test performed locally in WSL:

```bash
cmake --build build --target llama-completion test-sampling -j1
./build/bin/test-sampling
```

Result:

```text
test-sampling: OK
```

Qwen smoke/A-B testing was also run with:

```powershell
.\run-qwen.ps1 -Prompt "Reply with exactly: ready" -Predict 4 -CtxSize 512 -BatchSize 64 -UBatchSize 64 -NoWarmup
.\run-qwen-old.ps1 -Prompt "Reply with exactly: old ready" -Predict 6 -CtxSize 512 -BatchSize 64 -UBatchSize 64 -NoWarmup
.\ab-test-qwen.ps1 -Runs 100 -Predict 512 -Seed 42 -NoWarmup
```

## Review Notes

This PR is intentionally opt-in. The default sampler chain is unchanged unless the user explicitly requests `viscosity`.

Reviewer areas worth extra attention:

- Whether `viscosity` is an acceptable sampler name.
- Whether the public parameters should be kept, renamed, or reduced.
- Whether the active candidate cap should be exposed or left internal.
- Whether this should live as an experimental sampler only.
- Whether server/UI parameter plumbing is desired for an experimental sampler.
- Whether the internal `omega` signal is useful only inside this sampler, or should eventually be exposed as telemetry for future context-management experiments.

## Limitations

- This is not a backend optimization and should not be expected to improve raw tokens/sec.
- Quality evaluation is still preliminary.
- Long-context behavior needs a larger benchmark suite.
- The sampler is deterministic by design, so it trades stochastic diversity for rule-driven reproducibility.
- A fixed seed already reproduced baseline stochastic sampling in my local 100-run test.
- Current local telemetry does not demonstrate a raw inference-speed win or a broad quality win.
