### PR TITLE
llama-cli: fix not copying preserved tokens

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -97,11 +97,18 @@ struct cli_context {
                 task.params.chat_parser_params.parser.load(chat_params.parser);
             }
 
+            // Copy the preserved tokens into the sampling params
+            const llama_vocab * vocab = llama_model_get_vocab(
+                llama_get_model(ctx_server.get_llama_context()));
+            for (const auto & token : chat_params.preserved_tokens) {
+                auto ids = common_tokenize(vocab, token, false, true);
+                if (ids.size() == 1) {
+                    task.params.sampling.preserved_tokens.insert(ids[0]);
+                }
+            }
+
             // reasoning budget sampler
             if (!chat_params.thinking_end_tag.empty()) {
-                const llama_vocab * vocab = llama_model_get_vocab(
-                    llama_get_model(ctx_server.get_llama_context()));
-
                 task.params.sampling.reasoning_budget_tokens = defaults.sampling.reasoning_budget_tokens;
                 task.params.sampling.generation_prompt = chat_params.generation_prompt;
 


### PR DESCRIPTION
## Overview

Llama-server will properly read preserved token IDs and copy `chat_params.preserved_tokens` into `task.params.sampling.preserved_tokens`.  However, it appears this was left out of `llama-cli` which does not.
This PR fixes that.

I had just finished a new PR (about to post ) for the new Cohere2 MoE arch and `BLS-Mini-Code-1.0` model, and kept fighting chat template issues repeatedly until I saw it only was happening in `llama-cli` testing, but was not a problem happening when trying via `llama-server`.
So some special tags, for example, `<|END_THINKING|>` were getting detokenized, so the model was never showing output when a response would start, leading to the response not showing.  This only was in `llama-cli`.

Previously:
```
> Hi BLS

[Start thinking]
The user says "Hi BLS". Likely they are greeting. As an AI, we should respond politely. No policy issues. We can ask how can we help.Hello! How can I assist you with today?
```

was really because of: `... how can we help.<|END_THINKING|><|START_TEXT|>Hello! ...`

After this fix:
```
> Hi BLS

[Start thinking]
The user says "Hi BLS". Likely they are greeting. As an AI, we should respond politely. There's no request for content. We can respond with a
[End thinking]

Hello! I'm Command, a Cohere-built language model. How can I assist you with your query today?

[ Prompt: 23.6 t/s | Generation: 195.3 t/s ]
```


## Additional information`
Tested the fix with a few other models previously working and did not see any change in behavior.
test-chat, test-chat-auto-parser, test-chat-template, test-jinja, test-reasoning-budget, test-sampling all pass.

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, used to find the real root cause of the issue and propose a fix.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
