### PR TITLE
convert : fix conversion for Mistral-Medium-3.5-128B

### DIFF
--- a/conversion/mistral.py
+++ b/conversion/mistral.py
@@ -105,8 +105,9 @@ class MistralModel(LlamaModel):
             gguf_writer.add_rope_scaling_yarn_log_mul(mscale_all_dim)
             gguf_writer.add_rope_scaling_orig_ctx_len(yarn_params["original_max_position_embeddings"])
 
-        if "llama_4_scaling" in hparams:
-            gguf_writer.add_attn_temperature_scale(hparams["llama_4_scaling"]["beta"])
+        llama_4_scaling = hparams.get("llama_4_scaling")
+        if llama_4_scaling is not None:
+            gguf_writer.add_attn_temperature_scale(llama_4_scaling["beta"])
 
 
 class MistralMoeModel(DeepseekV2Model):

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -238,7 +238,7 @@ def main() -> None:
             assert hparams.get("vision_encoder") is not None, "This model does not support multimodal"
             from conversion.pixtral import PixtralModel
             model_class = PixtralModel
-        elif "moe" in hparams:
+        elif hparams.get("moe") is not None:
             from conversion.mistral import MistralMoeModel
             model_class = MistralMoeModel
         else:


### PR DESCRIPTION
Mistral explicitly sets `moe` and `llama_4_scaling` to `null` in [params.json](https://huggingface.co/mistralai/Mistral-Medium-3.5-128B/blob/main/params.json), breaking `key in dict` checks during conversion. Replace with `dict.get(key) is not None` where this matters.

Fixes `convert-hf-to-gguf.py --mistral-format Mistral-Medium-3.5-128B`.

One open question from my side: In `MistralModel::__init__()` there's another `"llama_4_scaling" not in self.hparams` check. I'm guessing this one shouldn't be relaxed?

```py
# for compatibility, we use LLAMA arch for older models
# TODO: remove this once everyone migrates to newer version of llama.cpp
if "llama_4_scaling" not in self.hparams:
    self.model_arch = gguf.MODEL_ARCH.LLAMA
    self.gguf_writer.arch = gguf.MODEL_ARCH_NAMES[self.model_arch]
    self.gguf_writer.add_architecture()
    self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
```

## Additional information
```log
INFO:hf-to-gguf:Loading model: Mistral-Medium-3.5-128B
INFO:hf-to-gguf:gguf: indexing model part 'consolidated-00001-of-00003.safetensors'
INFO:hf-to-gguf:gguf: indexing model part 'consolidated-00002-of-00003.safetensors'
INFO:hf-to-gguf:gguf: indexing model part 'consolidated-00003-of-00003.safetensors'
INFO:hf-to-gguf:heuristics detected bfloat16 tensor dtype, setting --outtype bf16
INFO:gguf.gguf_writer:gguf: This GGUF file is for Little Endian only
INFO:hf-to-gguf:Using MistralMoeModel
Traceback (most recent call last):
  File ".../llama.cpp/.venv/bin/llama-convert-hf-to-gguf", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File ".../llama.cpp/convert_hf_to_gguf.py", line 263, in main
    model_instance = model_class(dir_model, output_type, fname_out,
                                 is_big_endian=args.bigendian, use_temp_file=args.use_temp_file,
    ...<8 lines>...
                                 fp8_as_q8=args.fp8_as_q8,
                                 )
  File ".../llama.cpp/conversion/mistral.py", line 162, in __init__
    if key in moe:
       ^^^^^^^^^^
TypeError: argument of type 'NoneType' is not a container or iterable
```

```log
...
INFO:hf-to-gguf:Set meta model
INFO:hf-to-gguf:Set model parameters
INFO:hf-to-gguf:gguf: context length = 262144
INFO:hf-to-gguf:gguf: embedding length = 12288
INFO:hf-to-gguf:gguf: feed forward length = 28672
INFO:hf-to-gguf:gguf: head count = 96
INFO:hf-to-gguf:gguf: key-value head count = 8
INFO:hf-to-gguf:gguf: rope theta = 1000000.0
INFO:hf-to-gguf:gguf: rms norm epsilon = 1e-05
INFO:hf-to-gguf:gguf: file type = 32
Traceback (most recent call last):
  File ".../llama.cpp/.venv/bin/llama-convert-hf-to-gguf", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File ".../llama.cpp/convert_hf_to_gguf.py", line 282, in main
    model_instance.write()
    ~~~~~~~~~~~~~~~~~~~~^^
  File ".../llama.cpp/conversion/base.py", line 1021, in write
    self.prepare_metadata(vocab_only=False)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File ".../llama.cpp/conversion/base.py", line 1157, in prepare_metadata
    super().prepare_metadata(vocab_only=vocab_only)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File ".../llama.cpp/conversion/base.py", line 1011, in prepare_metadata
    self.set_gguf_parameters()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File ".../llama.cpp/conversion/mistral.py", line 94, in set_gguf_parameters
    MistralModel.set_mistral_config(self.gguf_writer, self.hparams)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../llama.cpp/conversion/mistral.py", line 109, in set_mistral_config
    gguf_writer.add_attn_temperature_scale(hparams["llama_4_scaling"]["beta"])
                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. I let Gemma 4 31B loose with the error messages, and trimmed the patch set down afterwards.
