### PR TITLE
server : do not parse when flushing http headers

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1393,6 +1393,9 @@ json server_task_result_cmpl_final::to_json_anthropic_stream() {
 //
 void server_task_result_cmpl_partial::update(task_result_state & state) {
     is_updated = true;
+    if (is_begin) {
+        return; // begin marker only flushes headers, skip parsing
+    }
     state.update_chat_msg(content, true, oaicompat_msg_diffs);
 
     // Copy current state for use in to_json_*() (reflects state BEFORE this chunk)


### PR DESCRIPTION
## Overview

When flushing http headers, the parse function is called and silently strips content we want to retain that is part of the generation prompt. This PR suppressing that initial parse so that content is kept. The most common usage is when `reasoning_format = none` and we want to retain the initial `<think>` tag that is part of the generation prompt. However, this can surface as well when continuing a message and `echo = true` .

ref: https://github.com/ggml-org/llama.cpp/issues/23320#issuecomment-4589689379

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
