### PR TITLE
common: reject ctx-size 1

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1276,6 +1276,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"-c", "--ctx-size"}, "N",
         string_format("size of the prompt context (default: %d, 0 = loaded from model)", params.n_ctx),
         [](common_params & params, int value) {
+            if (value == 1) {
+                throw std::invalid_argument("ctx-size must be 0 or at least 2");
+            }
             params.n_ctx = value;
             if (value == 0) {
                 // disable context reduction in llama_params_fit if the user explicitly requests the full context size:

--- a/tools/server/tests/unit/test_basic.py
+++ b/tools/server/tests/unit/test_basic.py
@@ -18,6 +18,17 @@ def test_server_start_simple():
     assert res.status_code == 200
 
 
+def test_server_rejects_ctx_size_one(tmp_path):
+    global server
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    server.models_dir = str(tmp_path)
+    server.no_models_autoload = True
+    server.n_ctx = 1
+    with pytest.raises(RuntimeError, match="Server process died"):
+        server.start(timeout_seconds=3)
+
+
 def test_server_props():
     global server
     server.start()


### PR DESCRIPTION
Fixes #24098.

`--ctx-size 1` currently passes argument parsing, then the server can get as far as model loading and warmup before hitting an internal `GGML_ASSERT`. A one-token context is not useful for the server, and the failure mode is much harder to understand than a front-door argument error.

This rejects `--ctx-size 1` in the shared argument parser while preserving the existing meanings of `0` (load from model) and `>= 2`.

## To verify

- `cmake -S . -B build-codex -G Ninja -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=OFF -DGGML_CUDA=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_UI=OFF -DCMAKE_C_FLAGS="-D_WIN32_WINNT=0x0A00" -DCMAKE_CXX_FLAGS="-D_WIN32_WINNT=0x0A00"`
- `cmake --build build-codex --target llama-server --parallel 4`
- `llama-server.exe --ctx-size 1 --models-dir build-codex/empty-models --no-models-autoload --host 127.0.0.1 --port 29333`
  - exits with code 1 and prints `ctx-size must be 0 or at least 2`
- `python -m py_compile tools/server/tests/unit/test_basic.py tools/server/tests/utils.py`

I also tried the targeted pytest case locally, but this Windows CPU build has HTTPS support disabled, and the test suite's module fixture downloads the tiny HF model before reaching the selected test. The direct binary check above covers the changed parser path without loading a model.
