### PR TITLE
server : reject mismatched embedding batch sizes

### DIFF
--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -57,3 +57,12 @@ install(TARGETS ${TARGET} RUNTIME)
 
 target_link_libraries(${TARGET} PRIVATE llama-server-impl)
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
+
+if (LLAMA_BUILD_TESTS)
+    add_test(
+        NAME test-server-embedding-batch-mismatch
+        COMMAND ${CMAKE_COMMAND}
+            -DLLAMA_SERVER_BIN=$<TARGET_FILE:llama-server>
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/test-embedding-batch-mismatch.cmake
+    )
+endif()

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -96,11 +96,12 @@ int llama_server(int argc, char ** argv) {
 
     // validate batch size for embeddings
     // embeddings require all tokens to be processed in a single ubatch
+    // see https://github.com/ggml-org/llama.cpp/issues/6263
     // see https://github.com/ggml-org/llama.cpp/issues/12836
-    if (params.embedding && params.n_batch > params.n_ubatch) {
-        SRV_WRN("embeddings enabled with n_batch (%d) > n_ubatch (%d)\n", params.n_batch, params.n_ubatch);
-        SRV_WRN("setting n_batch = n_ubatch = %d to avoid assertion failure\n", params.n_ubatch);
-        params.n_batch = params.n_ubatch;
+    if (params.embedding && params.n_batch != params.n_ubatch) {
+        SRV_ERR("embeddings require n_batch (%d) to equal n_ubatch (%d)\n", params.n_batch, params.n_ubatch);
+        SRV_ERR("%s", "set --batch-size and --ubatch-size to the same value\n");
+        return 1;
     }
 
     if (params.n_parallel < 0) {

--- a/tools/server/tests/test-embedding-batch-mismatch.cmake
+++ b/tools/server/tests/test-embedding-batch-mismatch.cmake
@@ -1,0 +1,20 @@
+execute_process(
+    COMMAND "${LLAMA_SERVER_BIN}" --embedding --batch-size 16 --ubatch-size 8
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+    TIMEOUT 5
+)
+
+if ("${result}" STREQUAL "0")
+    message(FATAL_ERROR "expected llama-server to reject mismatched embedding batch sizes")
+endif()
+
+if (NOT "${result}" MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "llama-server did not exit after detecting mismatched embedding batch sizes: ${result}")
+endif()
+
+set(log "${output}${error}")
+if (NOT log MATCHES "embeddings require n_batch \\(16\\) to equal n_ubatch \\(8\\)")
+    message(FATAL_ERROR "expected embedding batch size error, got:\n${log}")
+endif()


### PR DESCRIPTION
## Overview

this PR fixes #6263.

 `llama-server` now exits with an error when `--embedding` is enabled and `--batch-size` differs from `--ubatch-size`.

the previous behavior silently changed `n_batch`, while this PR makes the invalid configuration explicit.

## Additional information
Related issue: #6263

TODO: a CTest was added for the startup failure case.

Local validation performed:

- `cmake -B build -G Ninja -DLLAMA_BUILD_TESTS=ON -DLLAMA_BUILD_SERVER=ON`
- `cmake --build build --target llama-server -j 8`
- `ctest --test-dir build -R test-server-embedding-batch-mismatch --output-on-failure`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assistance was used during development. I manually reviewed the implementation, test, and local validation results before submitting.
