### PR TITLE
server : add last-5-seconds generation speed display

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -197,6 +197,10 @@ struct server_slot {
     int64_t t_start_process_prompt;
     int64_t t_start_generation;
 
+    int64_t t_tg_window_start = 0;
+    int32_t n_tg_window_start = 0;
+    double  tg_second_last    = 0.0; // token generation speed over the last completed window
+
     double t_prompt_processing = 0.0; // ms
     double t_token_generation = 0.0;  // ms
 
@@ -226,6 +230,9 @@ struct server_slot {
         }
         generated_tokens.clear();
         generated_token_probs.clear();
+        t_tg_window_start = 0;
+        n_tg_window_start = 0;
+        tg_second_last    = 0.0;
         json_schema = json();
 
         // clear speculative decoding stats
@@ -463,6 +470,19 @@ struct server_slot {
 
         const int64_t t_now = ggml_time_us();
 
+        // window over which the recent (last) token generation speed is computed
+        const int64_t tg_window_us = 5*1000*1000;
+
+        if (t_tg_window_start == 0) {
+            t_tg_window_start = t_now;
+            n_tg_window_start = n_decoded;
+        } else if (t_now - t_tg_window_start >= tg_window_us) {
+            // once the window elapses, compute speed and reset
+            tg_second_last    = 1e6 / (t_now - t_tg_window_start) * (n_decoded - n_tg_window_start);
+            t_tg_window_start = t_now;
+            n_tg_window_start = n_decoded;
+        }
+
         if (t_now - t_print_last < 3*1000*1000) {
             return;
         }
@@ -471,7 +491,8 @@ struct server_slot {
 
         const double n_gen_second = 1e3 / t_token_generation * n_decoded;
 
-        SLT_INF(*this, "n_decoded = %6d, tg = %6.2f t/s\n", n_decoded, n_gen_second);
+        SLT_INF(*this, "n_decoded = %6d, tg = %6.2f t/s, tg(last %ds) = %6.2f t/s\n",
+                n_decoded, n_gen_second, (int) (tg_window_us / (1000*1000)), tg_second_last);
     }
 
     void print_timings_pp() const {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -193,13 +193,10 @@ struct server_slot {
     // stats
     size_t n_sent_text = 0; // number of sent text character
 
-    int64_t t_print_last = 0;
     int64_t t_start_process_prompt;
     int64_t t_start_generation;
-
-    int64_t t_tg_window_start = 0;
-    int32_t n_tg_window_start = 0;
-    double  tg_second_last    = 0.0; // token generation speed over the last completed window
+    int64_t t_print_last = 0;
+    int32_t n_decoded_last = 0;
 
     double t_prompt_processing = 0.0; // ms
     double t_token_generation = 0.0;  // ms
@@ -230,9 +227,6 @@ struct server_slot {
         }
         generated_tokens.clear();
         generated_token_probs.clear();
-        t_tg_window_start = 0;
-        n_tg_window_start = 0;
-        tg_second_last    = 0.0;
         json_schema = json();
 
         // clear speculative decoding stats
@@ -470,29 +464,17 @@ struct server_slot {
 
         const int64_t t_now = ggml_time_us();
 
-        // window over which the recent (last) token generation speed is computed
-        const int64_t tg_window_us = 5*1000*1000;
-
-        if (t_tg_window_start == 0) {
-            t_tg_window_start = t_now;
-            n_tg_window_start = n_decoded;
-        } else if (t_now - t_tg_window_start >= tg_window_us) {
-            // once the window elapses, compute speed and reset
-            tg_second_last    = 1e6 / (t_now - t_tg_window_start) * (n_decoded - n_tg_window_start);
-            t_tg_window_start = t_now;
-            n_tg_window_start = n_decoded;
-        }
-
         if (t_now - t_print_last < 3*1000*1000) {
             return;
         }
 
+        const double n_gen_second     = 1e3 / (t_token_generation)   * (n_decoded);
+        const double n_gen_second_win = 1e6 / (t_now - t_print_last) * (n_decoded - n_decoded_last);
+
         t_print_last = t_now;
+        n_decoded_last = n_decoded;
 
-        const double n_gen_second = 1e3 / t_token_generation * n_decoded;
-
-        SLT_INF(*this, "n_decoded = %6d, tg = %6.2f t/s, tg(last %ds) = %6.2f t/s\n",
-                n_decoded, n_gen_second, (int) (tg_window_us / (1000*1000)), tg_second_last);
+        SLT_INF(*this, "n_decoded = %6d, tg = %6.2f t/s, tg_3s = %6.2f t/s\n", n_decoded, n_gen_second, n_gen_second_win);
     }
 
     void print_timings_pp() const {
@@ -2958,8 +2940,8 @@ private:
                         }
                     }
 
-                    const int64_t t_current = ggml_time_us();
-                    slot.t_prompt_processing = (t_current - slot.t_start_process_prompt) / 1e3;
+                    const int64_t t_now = ggml_time_us();
+                    slot.t_prompt_processing = (t_now - slot.t_start_process_prompt) / 1e3;
                     slot.print_timings_pp();
 
                     // truncate any tokens that are beyond n_past for this slot
@@ -3412,17 +3394,19 @@ private:
                 common_sampler_accept(slot.smpl.get(), id, true);
 
                 // here we have synchronized the llama_context (due to the sampling above), so we can do time measurement
-                const int64_t t_current = ggml_time_us();
+                const int64_t t_now = ggml_time_us();
 
                 slot.n_decoded += 1;
 
                 if (slot.n_decoded == 1) {
-                    slot.t_start_generation = t_current;
+                    slot.t_start_generation = t_now;
+                    slot.t_print_last = t_now;
+                    slot.n_decoded_last = 0;
                     slot.t_prompt_processing = (slot.t_start_generation - slot.t_start_process_prompt) / 1e3;
                     metrics.on_prompt_eval(slot);
                 }
 
-                slot.t_token_generation = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;
+                slot.t_token_generation = std::max<int64_t>(1, t_now - slot.t_start_generation) / 1e3;
 
                 completion_token_output result;
                 result.tok          = id;
@@ -3516,11 +3500,11 @@ private:
                     slot.spec_draft = std::move(accepted);
                 }
 
-                const int64_t t_current = ggml_time_us();
+                const int64_t t_now = ggml_time_us();
 
                 const auto ids = std::move(slot.spec_draft);
 
-                slot.t_token_generation = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;
+                slot.t_token_generation = std::max<int64_t>(1, t_now - slot.t_start_generation) / 1e3;
 
                 // update how many tokens out of those tested were accepted
                 slot.n_draft_accepted += ids.size() - 1;


### PR DESCRIPTION
## Overview

This PR adds a `tg(last 5s)` display to the server token generation speed log.

I noticed `tg` is computed as an average over the entire computation, which, for instance on my Macbook, doesn't really tell the full story (other than that yes, speed decreases as the context grows longer).

Example:

```
6.33.268.728  I slot print_timing: id  0 | task 0 | n_decoded =    100, tg =  12.24 t/s, tg(last 5s) =   0.00 t/s
[...]
7.55.294.463  I slot print_timing: id  0 | task 0 | n_decoded =   1005, tg =  11.14 t/s, tg(last 5s) =  10.77 t/s
[...]
11.19.803.987 I slot print_timing: id  0 | task 0 | n_decoded =   2888, tg =   9.80 t/s, tg(last 5s) =   6.98 t/s
[...]
12.49.318.567 I slot print_timing: id  0 | task 0 | n_decoded =   3415, tg =   8.89 t/s, tg(last 5s) =   5.49 t/s
12.52.326.484 I slot print_timing: id  0 | task 0 | n_decoded =   3430, tg =   8.86 t/s, tg(last 5s) =   5.22 t/s
12.55.413.214 I slot print_timing: id  0 | task 0 | n_decoded =   3446, tg =   8.83 t/s, tg(last 5s) =   5.10 t/s
12.58.511.666 I slot print_timing: id  0 | task 0 | n_decoded =   3463, tg =   8.80 t/s, tg(last 5s) =   5.47 t/s
[...]
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES: assisted by Claude Code (Opus 4.8).