### PR TITLE
rpc : fix UAF in graph_recompute leading to remote code execution

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -973,6 +973,11 @@ bool rpc_server::free_buffer(const rpc_msg_free_buffer_req & request) {
         GGML_LOG_ERROR("[%s] buffer not found\n", __func__);
         return false;
     }
+    // Discard all cached graphs to avoid use-after-free in graph_recompute,
+    // since their nodes may hold pointers to the buffer being freed.
+    for (auto & sg : stored_graphs) {
+        sg.graph = nullptr;
+    }
     ggml_backend_buffer_free(buffer);
     buffers.erase(buffer);
     return true;
@@ -1375,7 +1380,6 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
         int64_t id;
         memcpy(&id, &nodes[i], sizeof(id));
         graph->nodes[i] = create_node(id, ctx, tensor_ptrs, tensor_map);
-
         // Check if create_node failed for a *non-zero* ID.
         // If id was 0, create_node returning nullptr is expected.
         // If id was non-zero and create_node returned nullptr, it indicates a deserialization error.


### PR DESCRIPTION
The server caches the most recent compute graph per device so that `GRAPH_RECOMPUTE` can re-execute it without resending tensor data. The cached graph nodes hold direct pointers to backend buffers that were live at `graph_compute()` time. If any of those buffers is later released via `FREE_BUFFER`, the next `GRAPH_RECOMPUTE` re-executes the cached graph through the **dangling pointers (use-after-free**).

The bug is reachable by an unauthenticated remote client. The dangling pointers point into chunks an attacker can reshape via subsequent `ALLOC_BUFFER/SET_TENSOR` commands, and the resulting read/write through the cached graph is sufficient to **leak libc addresses** and hijack the buffer `iface vtable` used by `BUFFER_CLEAR`, yielding **remote code execution**.

Track the set of backend buffers each cached graph references, and drop the cached graph in `free_buffer()` when one of its buffers is released. The existing null-check in `graph_recompute()` then rejects the request and the client falls back to `GRAPH_COMPUTE `on the next call.

No protocol or API change.

This was previously reported via private security advisory [GHSA-2phh-px2f-2qmx](https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-2phh-px2f-2qmx) on 2026-04-30. Per maintainer reply on that advisory, the patch is being submitted publicly here.
