### PR TITLE
llama: name fused GDN outputs before callbacks

### DIFF
--- a/src/models/delta-net-base.cpp
+++ b/src/models/delta-net-base.cpp
@@ -401,8 +401,10 @@ std::pair<ggml_tensor *, ggml_tensor *> llm_build_delta_net_base::build_delta_ne
     // K=1: output carries the final state only. state s is 4D [S_v, S_v, H_v, n_seqs].
     ggml_tensor * result = ggml_gated_delta_net(ctx0, q, k, v, g, b, s, /*K=*/1);
     if (n_tokens == 1) {
+        ggml_format_name(result, "%s-%d", LLAMA_TENSOR_NAME_FGDN_AR, il);
         cb(result, LLAMA_TENSOR_NAME_FGDN_AR, il);
     } else {
+        ggml_format_name(result, "%s-%d", LLAMA_TENSOR_NAME_FGDN_CH, il);
         cb(result, LLAMA_TENSOR_NAME_FGDN_CH, il);
     }
 
@@ -566,8 +568,10 @@ ggml_tensor * llm_build_delta_net_base::build_recurrent_attn(
     // state s is 4D [S_v, S_v, H_v, n_seqs]; K snapshot slots are written into the output.
     ggml_tensor * gdn_out = ggml_gated_delta_net(ctx0, q, k, v, g, b, s, K);
     if (n_seq_tokens > 1) {
+        ggml_format_name(gdn_out, "%s-%d", LLAMA_TENSOR_NAME_FGDN_CH, il);
         cb(gdn_out, LLAMA_TENSOR_NAME_FGDN_CH, il);
     } else {
+        ggml_format_name(gdn_out, "%s-%d", LLAMA_TENSOR_NAME_FGDN_AR, il);
         cb(gdn_out, LLAMA_TENSOR_NAME_FGDN_AR, il);
     }
 


### PR DESCRIPTION
## Summary

Name fused GDN result tensors before running the graph callback.

## Context

The FGDN support check looks for graph nodes named with the `__fgdn_ar__-<layer>` / `__fgdn_ch__-<layer>` prefix. With Gemma E2B I saw that check hit a generic name (`node_47`) on the CPU path, which made the support check fail before the fused path could be used.

The callback already gets the same name, but this makes the name explicit on the `ggml_gated_delta_net` result before the callback runs.

## Notes

This did not show a measurable CPU speedup in my local Gemma E2B benchmark, and Vulkan was already enabling the fused path in my setup. The reason for the change is to keep the tensor naming consistent for the support check, not to claim a performance win.

## Testing

```bash
cmake -S . -B /tmp/llama-pr-build \
  -DLLAMA_BUILD_TESTS=OFF \
  -DLLAMA_BUILD_EXAMPLES=OFF \
  -DLLAMA_BUILD_SERVER=OFF \
  -DGGML_VULKAN=OFF \
  -DGGML_CUDA=OFF \
  -DGGML_METAL=OFF
cmake --build /tmp/llama-pr-build --target llama -- -j2
```

I also checked the patch in a local llama-cpp-rs build with Gemma E2B. Fused GDN enabled cleanly there, but I did not observe a meaningful performance change.