### PR TITLE
Docs: Adds AI Badgr as an optional hosted GPU launch path for running a `llama.cpp` server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 <details>
 <summary>Infrastructure</summary>
 
+- [AI Badgr](https://aibadgr.com/gpu/launch?template=llama-cpp) - Launch llama.cpp Server on routed GPU capacity with an OpenAI-compatible endpoint
 - [Paddler](https://github.com/intentee/paddler) - Open-source LLMOps platform for hosting and scaling AI in your own infrastructure
 - [GPUStack](https://github.com/gpustack/gpustack) - Manage GPU clusters for running LLMs
 - [llama_cpp_canister](https://github.com/onicai/llama_cpp_canister) - llama.cpp as a smart contract on the Internet Computer, using WebAssembly


### PR DESCRIPTION
## Overview

Adds AI Badgr as an optional hosted GPU launch path for running a `llama.cpp` server.

This documents the prefilled AI Badgr `llama-cpp` template and the equivalent CLI flow:

```bash
badgr serve template llama-cpp --max-cost 3
```

It gives users another way to run a GPU-backed `llama.cpp` server with a cost cap and a hosted endpoint, without changing the existing local build or server instructions.

## Additional information

AI Badgr template page:

https://aibadgr.com/gpu/launch?template=llama-cpp

This is a docs-only change. It does not modify `llama.cpp` source code or build behavior.

## Requirements

* I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES — ChatGPT/Copilot was used to help draft the documentation wording. I reviewed and edited the final submitted changes.