### PR TITLE
ggml-cpu : fix rms_norm_back wrong output under in-place aliasing

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -4009,13 +4009,7 @@ static void ggml_compute_forward_rms_norm_back_f32(
                 float * dx = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
 
                 // dx[i00] = (dz + x*(-sum_xdz/sum_eps)) * rrms
-                //
-                // GGML_OP_RMS_NORM_BACK is listed in ggml_op_can_inplace, so the
-                // scheduler may alias dst with src0 (dz) or src1 (x). A single
-                // fused read-before-write loop is safe under either aliasing.
-                // A multi-step cpy/scale/acc/scale sequence is NOT safe — if dst
-                // aliases dz, the +=dz step would re-read overwritten memory.
-                // See: https://github.com/ggml-org/ggml/issues/1491
+                // note: https://github.com/ggml-org/ggml/issues/1491
                 const float scale_x = (float) (-sum_xdz) / sum_eps;
                 for (int64_t i00 = 0; i00 < ne00; i00++) {
                     dx[i00] = (dz[i00] + x[i00] * scale_x) * rrms;

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -4008,12 +4008,18 @@ static void ggml_compute_forward_rms_norm_back_f32(
                 // dx := scale(dx, rrms)
                 float * dx = (float *) ((char *) dst->data + i01*nb1 + i02*nb2 + i03*nb3);
 
-                // dx[i00] = (x*(-sum_xdz/sum_eps) + dz) / sqrtf(mean_eps)
-                ggml_vec_cpy_f32  (ne00, dx, x);
-                // ggml_vec_scale_f32(ne00, dx, -mean_xdz/mean_eps);
-                ggml_vec_scale_f32(ne00, dx, (float)(-sum_xdz)/sum_eps);
-                ggml_vec_acc_f32  (ne00, dx, dz);
-                ggml_vec_scale_f32(ne00, dx, rrms);
+                // dx[i00] = (dz + x*(-sum_xdz/sum_eps)) * rrms
+                //
+                // GGML_OP_RMS_NORM_BACK is listed in ggml_op_can_inplace, so the
+                // scheduler may alias dst with src0 (dz) or src1 (x). A single
+                // fused read-before-write loop is safe under either aliasing.
+                // A multi-step cpy/scale/acc/scale sequence is NOT safe — if dst
+                // aliases dz, the +=dz step would re-read overwritten memory.
+                // See: https://github.com/ggml-org/ggml/issues/1491
+                const float scale_x = (float) (-sum_xdz) / sum_eps;
+                for (int64_t i00 = 0; i00 < ne00; i00++) {
+                    dx[i00] = (dz[i00] + x[i00] * scale_x) * rrms;
+                }
             }
         }
     }


### PR DESCRIPTION
## Overview

`ggml_compute_forward_rms_norm_back_f32` could produce wrong results when the destination aliases an input. `GGML_OP_RMS_NORM_BACK` is listed in `ggml_op_can_inplace`, so the scheduler may reuse `src0` (`dz`) or `src1` (`x`)'s buffer for `dx`. The old multi-step `cpy/scale/acc/scale` sequence overwrote that buffer in the `dx := x` step and then re-read it in the `+= dz` step. This replaces it with a single fused read-before-write loop, which is safe under either aliasing.

## Additional information

Requested by @ggerganov in ggml-org/ggml#1519, where I originally reported and fixed this (#1491). Submitting the single ops.cpp change here as asked; no regression test per that thread. Built `ggml-cpu` locally on macOS to confirm it compiles.

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES — assistive port of my own prior fix.
