### PR TITLE
vulkan: use medium matmul tile on Asahi Linux

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -296,6 +296,7 @@ enum vk_device_architecture {
     INTEL_XE2,
     NVIDIA_PRE_TURING,
     NVIDIA_TURING,
+    APPLE_AGX,
 };
 
 static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& device) {
@@ -407,6 +408,11 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
             }
         }
     }
+
+    if (strncmp(props.deviceName.data(), "Apple", 5) == 0) {
+        return vk_device_architecture::APPLE_AGX;
+    }
+
     return vk_device_architecture::OTHER;
 }
 
@@ -6148,6 +6154,17 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->mul_mat_id_m[i] = true;
                 device->mul_mat_id_s[i] = true;
                 break;
+            }
+
+            // Honeykrisp driver for Asahi Linux doesn't report VK_VENDOR_ID_APPLE.
+            // Check for Apple AGX arch and force same configuration as the VK_VENDOR_ID_APPLE case.
+            if (device->architecture == vk_device_architecture::APPLE_AGX) {
+                device->mul_mat_l[i]    = false;
+                device->mul_mat_m[i]    = true;
+                device->mul_mat_s[i]    = false;
+                device->mul_mat_id_l[i] = false;
+                device->mul_mat_id_m[i] = true;
+                device->mul_mat_id_s[i] = false;
             }
 
             device->mul_mat_l_int[i]    = device->mul_mat_l[i];

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -296,7 +296,6 @@ enum vk_device_architecture {
     INTEL_XE2,
     NVIDIA_PRE_TURING,
     NVIDIA_TURING,
-    APPLE_AGX,
 };
 
 static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& device) {
@@ -408,11 +407,6 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
             }
         }
     }
-
-    if (strncmp(props.deviceName.data(), "Apple", 5) == 0) {
-        return vk_device_architecture::APPLE_AGX;
-    }
-
     return vk_device_architecture::OTHER;
 }
 
@@ -6157,11 +6151,11 @@ static vk_device ggml_vk_get_device(size_t idx) {
             }
 
             // Honeykrisp driver for Asahi Linux doesn't report VK_VENDOR_ID_APPLE.
-            // Check for Apple AGX arch and force same configuration as the VK_VENDOR_ID_APPLE case.
-            if (device->architecture == vk_device_architecture::APPLE_AGX) {
-                device->mul_mat_l[i]    = false;
-                device->mul_mat_m[i]    = true;
-                device->mul_mat_s[i]    = false;
+            // Check for Honeykrisp driver and force same configuration as the VK_VENDOR_ID_APPLE case.
+            if (device->driver_id == vk::DriverId::eMesaHoneykrisp) {
+                device->mul_mat_l[i] = false;
+                device->mul_mat_m[i] = true;
+                device->mul_mat_s[i] = false;
                 device->mul_mat_id_l[i] = false;
                 device->mul_mat_id_m[i] = true;
                 device->mul_mat_id_s[i] = false;


### PR DESCRIPTION
## Overview

This PR detects Apple AGX architecture and sets matmul tile size to medium. Currently the Asahi driver in Mesa reports a different vendor ID than VK_VENDOR_ID_APPLE so the 'picking medium tile size for apple' route doesn't trigger and falls back to large. This causes degraded prefill performance.

## Additional information
```
xingjianliu@fedora:~/repos/llama.cpp$ ./build/bin/llama-bench -m ~/repos/llama-2-7b.Q4_0.gguf
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Apple M1 Ultra (G13D C0) (Honeykrisp) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 32768 | int dot: 0 | matrix cores: none
```
Before:
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  -1 |           pp512 |        207.57 ± 0.95 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  -1 |           tg128 |         33.86 ± 0.20 |

After:
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  -1 |           pp512 |        259.00 ± 1.08 |
| llama 7B Q4_0                  |   3.56 GiB |     6.74 B | Vulkan     |  -1 |           tg128 |         34.05 ± 0.12 |

see https://github.com/ggml-org/llama.cpp/issues/10982#issuecomment-4638449490 for the full discussion.


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, Claude code was used in code review and modification suggestions.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
