### PR TITLE
vulkan: pre-scan MUL_MAT/MUL_MAT_ID nodes to preallocate worst-case x/y buffers

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8269,17 +8269,22 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
         if ((qy_needs_dequant || quantize_y) && ctx->prealloc_size_y < y_sz) {
-            // If the prescan failed to prevent this growth, log the cause.
-            // Enable with GGML_VK_FA_DEBUG=1.
+            // The prescan in ggml_backend_vk_graph_compute should have pre-allocated
+            // enough prealloc_y before any command buffer was opened.  If we get here
+            // with a live subctx it means the prescan missed this op, which is the
+            // race condition that caused crashes on Intel Arc UMA.
+            // Set GGML_VK_FA_DEBUG=1 to surface this as a hard assertion failure
+            // (useful for running unit tests with the prescan disabled to verify coverage).
             if (getenv("GGML_VK_FA_DEBUG")) {
                 fprintf(stderr,
                     "ggml_vulkan MulMat Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
-                    " padded_n=%u qy_needs=%d quantize_y=%d\n",
+                    " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d\n",
                     (unsigned long long)y_sz,
                     (long long)src1->ne[0], (long long)src1->ne[1],
                     (long long)src1->ne[2], (long long)src1->ne[3],
-                    padded_n, (int)qy_needs_dequant, (int)quantize_y);
+                    padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0);
                 fflush(stderr);
+                GGML_ASSERT(!subctx && "MulMat prealloc_y grew mid-graph: prescan missing for this op");
             }
             ctx->prealloc_size_y = y_sz;
             ggml_vk_preallocate_buffers(ctx, subctx);
@@ -9189,17 +9194,19 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
         if ((qy_needs_dequant || quantize_y) && ctx->prealloc_size_y < y_sz) {
-            // If the prescan failed to prevent this growth, log the cause.
-            // Enable with GGML_VK_FA_DEBUG=1.
+            // Same invariant as MulMat above: the prescan should have pre-allocated this.
+            // Mid-graph growth with a live subctx is the race that caused crashes on
+            // Intel Arc UMA.  Set GGML_VK_FA_DEBUG=1 to surface as a hard assertion.
             if (getenv("GGML_VK_FA_DEBUG")) {
                 fprintf(stderr,
                     "ggml_vulkan MulMatId Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
-                    " padded_n=%u qy_needs=%d quantize_y=%d\n",
+                    " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d\n",
                     (unsigned long long)y_sz,
                     (long long)src1->ne[0], (long long)src1->ne[1],
                     (long long)src1->ne[2], (long long)src1->ne[3],
-                    padded_n, (int)qy_needs_dequant, (int)quantize_y);
+                    padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0);
                 fflush(stderr);
+                GGML_ASSERT(!subctx && "MulMatId prealloc_y grew mid-graph: prescan missing for this op");
             }
             ctx->prealloc_size_y = y_sz;
             ggml_vk_preallocate_buffers(ctx, subctx);
@@ -13742,11 +13749,10 @@ static void ggml_vk_preallocate_buffers(ggml_backend_vk_context * ctx, vk_contex
     }
     if (ctx->prealloc_y == nullptr || (ctx->prealloc_size_y > 0 && ctx->prealloc_y->size < ctx->prealloc_size_y)) {
         VK_LOG_MEMORY("ggml_vk_preallocate_buffers(y_size: " << ctx->prealloc_size_y << ")");
-        // Log large prealloc_y growth with subctx state. Enable with GGML_VK_FA_DEBUG=1.
-        // has_subctx=1 here means a command buffer is open — this is the unsafe path that
-        // can corrupt memory on Intel Arc UMA. The prescan fix should prevent this for
-        // MUL_MAT/MUL_MAT_ID nodes; if seen, it indicates a gap in prescan coverage.
-        if (getenv("GGML_VK_FA_DEBUG") && ctx->prealloc_size_y > 64*1024*1024) {
+        // Note: the actual GGML_ASSERT(!subctx) lives at the op level (MulMat/MulMatId)
+        // where (qy_needs_dequant || quantize_y) && prealloc_size_y < y_sz, gated by
+        // GGML_VK_FA_DEBUG.  That is the precise invariant the prescan maintains.
+        if (getenv("GGML_VK_FA_DEBUG")) {
             fprintf(stderr, "ggml_vulkan: prealloc_y growing to %zu bytes (has_subctx=%d)\n",
                     ctx->prealloc_size_y, subctx ? 1 : 0);
             fflush(stderr);
@@ -15612,6 +15618,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
     // For X (src0 weight buffer, dequant path):
     //   Only F32/F16/BF16 src0 requires dequantisation; quantised types are consumed
     //   directly by the shader, so qx_needs_dequant=false for those.
+#if 1  // set to 0 to disable prescan (for unit test regression verification)
     {
         // Maximum wg_denoms[1] across all configured pipelines (conservative).
         // Empirically observed: MUL_MAT l_wg_denoms[1]=256, MUL_MAT_ID l_mmqid[1]=128.
@@ -15661,6 +15668,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
             ggml_vk_preallocate_buffers(ctx, nullptr);
         }
     }
+#endif  // prescan
 
     // Submit after enough work has accumulated, to overlap CPU cmdbuffer generation with GPU execution.
     // Estimate the amount of matmul work by looking at the weight matrix size, and submit every 100MB

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8269,30 +8269,19 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
         if ((qy_needs_dequant || quantize_y) && ctx->prealloc_size_y < y_sz) {
-            // The prescan in ggml_backend_vk_graph_compute should have pre-allocated
-            // enough prealloc_y before any command buffer was opened.  If we get here
-            // with a live subctx it means the prescan missed this op, which is the
-            // race condition that caused crashes on Intel Arc UMA.
-            // Set GGML_VK_FA_DEBUG=1 to surface as a hard assertion failure and to log
-            // the VkBuffer handle swap that proves the use-after-free (the old handle
-            // is already bound in live command buffer descriptors; destroying it here
-            // makes those descriptors invalid before the GPU executes them).
+            // Mid-graph prealloc_y growth: ggml_vk_preallocate_buffers will submit
+            // pending GPU work, wait, then reallocate.  Set GGML_VK_FA_DEBUG=1 to
+            // log the VkBuffer handle swap for debugging.
             if (getenv("GGML_VK_FA_DEBUG")) {
                 VkBuffer old_handle = ctx->prealloc_y ? (VkBuffer)ctx->prealloc_y->buffer : VK_NULL_HANDLE;
                 fprintf(stderr,
-                    "ggml_vulkan MulMat Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
+                    "ggml_vulkan MulMat Y grow: y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
                     " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d old_VkBuffer=%p\n",
                     (unsigned long long)y_sz,
                     (long long)src1->ne[0], (long long)src1->ne[1],
                     (long long)src1->ne[2], (long long)src1->ne[3],
                     padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0,
                     (void*)old_handle);
-                if (old_handle != VK_NULL_HANDLE) {
-                    fprintf(stderr,
-                        "ggml_vulkan MulMat Y grow: old VkBuffer=%p DESTROYED while live in cmd buffer"
-                        " -- any already-recorded descriptor referencing it is now invalid (use-after-free)\n",
-                        (void*)old_handle);
-                }
                 fflush(stderr);
             }
             ctx->prealloc_size_y = y_sz;
@@ -9210,26 +9199,19 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
         if ((qy_needs_dequant || quantize_y) && ctx->prealloc_size_y < y_sz) {
-            // Same invariant as MulMat above: the prescan should have pre-allocated this.
-            // Mid-graph growth with a live subctx is the race that caused crashes on
-            // Intel Arc UMA.  Set GGML_VK_FA_DEBUG=1 to surface as a hard assertion and
-            // to log the VkBuffer handle swap that proves the use-after-free.
+            // Mid-graph prealloc_y growth: ggml_vk_preallocate_buffers will submit
+            // pending GPU work, wait, then reallocate.  Set GGML_VK_FA_DEBUG=1 to
+            // log the VkBuffer handle swap for debugging.
             if (getenv("GGML_VK_FA_DEBUG")) {
                 VkBuffer old_handle = ctx->prealloc_y ? (VkBuffer)ctx->prealloc_y->buffer : VK_NULL_HANDLE;
                 fprintf(stderr,
-                    "ggml_vulkan MulMatId Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
+                    "ggml_vulkan MulMatId Y grow: y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
                     " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d old_VkBuffer=%p\n",
                     (unsigned long long)y_sz,
                     (long long)src1->ne[0], (long long)src1->ne[1],
                     (long long)src1->ne[2], (long long)src1->ne[3],
                     padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0,
                     (void*)old_handle);
-                if (old_handle != VK_NULL_HANDLE) {
-                    fprintf(stderr,
-                        "ggml_vulkan MulMatId Y grow: old VkBuffer=%p DESTROYED while live in cmd buffer"
-                        " -- any already-recorded descriptor referencing it is now invalid (use-after-free)\n",
-                        (void*)old_handle);
-                }
                 fflush(stderr);
             }
             ctx->prealloc_size_y = y_sz;
@@ -13760,10 +13742,14 @@ static void ggml_vk_preallocate_buffers(ggml_backend_vk_context * ctx, vk_contex
 #endif
 
     if (subctx) {
-        // Submit and wait for any pending work before reallocating the buffers
-        ggml_vk_ctx_end(subctx);
-        ggml_vk_submit(subctx, {});
-        ctx->submit_pending = true;
+        // Submit and wait for any pending work before reallocating the buffers.
+        // ggml_vk_synchronize ends the current command buffer, submits all pending
+        // work, waits for the GPU, and clears ctx->compute_ctx.  The explicit
+        // ggml_vk_ctx_end + ggml_vk_submit calls that used to precede this were
+        // redundant: ggml_vk_synchronize already does both via its do_transfer path
+        // (triggered because compute_ctx == subctx is still live).  Calling end+submit
+        // twice on the same VkCommandBuffer is a Vulkan spec violation (undefined
+        // behaviour) that can corrupt host memory on UMA devices (Intel Arc).
         ggml_vk_synchronize(ctx);
         GGML_ASSERT(ctx->compute_ctx.expired());
         ggml_vk_ctx_begin(ctx->device, subctx);
@@ -15607,96 +15593,6 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         ggml_vk_buffer_memset_async(compute_ctx, ctx->prealloc_add_rms_partials, 0, 0, ctx->prealloc_size_add_rms_partials);
         ggml_vk_sync_buffers(ctx, compute_ctx);
     }
-
-    // Pre-scan all MUL_MAT / MUL_MAT_ID nodes and raise prealloc_size_x / prealloc_size_y
-    // to their worst-case upper bounds BEFORE any subctx (GPU command buffer) is live.
-    //
-    // Without this, ggml_vk_preallocate_buffers is called mid-graph with a live subctx
-    // whenever a new node requires a larger buffer than what was allocated for a previous
-    // node.  That path submits the current command buffer, waits for the GPU, destroys
-    // the old Vulkan buffer, then allocates a new one.  On Intel Arc UMA the physical
-    // pages of the freed buffer are immediately available to the OS, so any stale GPU
-    // reference or driver-internal structure that still touches those pages after the
-    // fence wait can corrupt arbitrary memory — including the CPU stack — producing
-    // STATUS_STACK_BUFFER_OVERRUN (0xC0000409) at large (≥ 23 K token) contexts.
-    //
-    // By pre-allocating the maximum size here (no subctx, hence safe to destroy / resize)
-    // the mid-graph growth condition (prealloc_size < required_size) is never true, so
-    // ggml_vk_preallocate_buffers is never called again with a live subctx for these
-    // two buffers.
-    //
-    // Upper bound derivation for Y (src1 activation buffer):
-    //   y_ne  = padded_n * ne10 * ne12 * ne13
-    //   padded_n  = qy_needs_dequant ? ROUNDUP_POW2(ne11, wg_denom[1]) : ne11
-    //
-    //   When qy_needs_dequant=true and ne11 is small (e.g. ne11=1 for a MulMatId vec
-    //   kernel), ROUNDUP_POW2 inflates padded_n up to wg_denom[1].  The maximum
-    //   wg_denom[1] across all non-coopmat pipelines is:
-    //     MUL_MAT    : 256  (l_wg_denoms[1])
-    //     MUL_MAT_ID : 128  (l_mmqid_wg_denoms[1])
-    //
-    //   We conservatively compute:
-    //     padded_n_bound = ROUNDUP_POW2(ne11, MAX_WG_DENOM)
-    //   where MAX_WG_DENOM is per-op-type.  For large ne11 this equals ne11 exactly;
-    //   for ne11=1 it equals MAX_WG_DENOM (the worst case that caused the crash).
-    //
-    //   Note: coopmat devices use different tile sizes; for safety we cap at 256
-    //   for both op types so the bound holds regardless of device capabilities.
-    //
-    // For X (src0 weight buffer, dequant path):
-    //   Only F32/F16/BF16 src0 requires dequantisation; quantised types are consumed
-    //   directly by the shader, so qx_needs_dequant=false for those.
-#if 1  // pre-scan: set to 0 only for regression testing (see test_mul_mat_id_prescan)
-    {
-        // Maximum wg_denoms[1] across all configured pipelines (conservative).
-        // Empirically observed: MUL_MAT l_wg_denoms[1]=256, MUL_MAT_ID l_mmqid[1]=128.
-        // Use 256 for both to be safe across coopmat and non-coopmat devices.
-        constexpr uint32_t MAX_WG_DENOM_Y = 256;
-
-        uint64_t prescan_max_x = ctx->prealloc_size_x;
-        uint64_t prescan_max_y = ctx->prealloc_size_y;
-        for (int i = 0; i < cgraph->n_nodes; i++) {
-            const ggml_tensor * node = cgraph->nodes[i];
-            if (node->op != GGML_OP_MUL_MAT && node->op != GGML_OP_MUL_MAT_ID) {
-                continue;
-            }
-            const ggml_tensor * src0 = node->src[0];
-            const ggml_tensor * src1 = node->src[1];
-            if (!src0 || !src1) {
-                continue;
-            }
-            // Y buffer: upper-bound using worst-case padded_n.
-            // ROUNDUP_POW2(ne11, MAX_WG_DENOM_Y) equals ne11 when ne11 is already
-            // ≥ MAX_WG_DENOM_Y (the common prefill case), and inflates to MAX_WG_DENOM_Y
-            // when ne11=1 (the problematic MulMatId decode case).
-            const uint64_t ne10     = (uint64_t)src1->ne[0];
-            const uint64_t ne11     = (uint64_t)src1->ne[1];
-            const uint64_t ne12     = (uint64_t)src1->ne[2];
-            const uint64_t ne13     = (uint64_t)src1->ne[3];
-            const uint64_t padded_n = (ne11 == 0) ? 0 : ROUNDUP_POW2(ne11, MAX_WG_DENOM_Y);
-            const uint64_t y_bound  = sizeof(ggml_fp16_t) * padded_n * ne10 * ne12 * ne13;
-            if (prescan_max_y < y_bound) {
-                prescan_max_y = y_bound;
-            }
-            // X buffer: weight dequant — only for unquantised source types.
-            if (src0->type == GGML_TYPE_F32 ||
-                src0->type == GGML_TYPE_F16 ||
-                src0->type == GGML_TYPE_BF16) {
-                const uint64_t x_bound = sizeof(ggml_fp16_t) * (uint64_t)ggml_nelements(src0);
-                if (prescan_max_x < x_bound) {
-                    prescan_max_x = x_bound;
-                }
-            }
-        }
-        if (prescan_max_x > ctx->prealloc_size_x || prescan_max_y > ctx->prealloc_size_y) {
-            ctx->prealloc_size_x = prescan_max_x;
-            ctx->prealloc_size_y = prescan_max_y;
-            // nullptr subctx: safe to destroy and recreate GPU buffers here since
-            // no command buffer is open yet.
-            ggml_vk_preallocate_buffers(ctx, nullptr);
-        }
-    }
-#endif  // prescan
 
     // Submit after enough work has accumulated, to overlap CPU cmdbuffer generation with GPU execution.
     // Estimate the amount of matmul work by looking at the weight matrix size, and submit every 100MB

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8269,6 +8269,18 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
         if ((qy_needs_dequant || quantize_y) && ctx->prealloc_size_y < y_sz) {
+            // If the prescan failed to prevent this growth, log the cause.
+            // Enable with GGML_VK_FA_DEBUG=1.
+            if (getenv("GGML_VK_FA_DEBUG")) {
+                fprintf(stderr,
+                    "ggml_vulkan MulMat Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
+                    " padded_n=%u qy_needs=%d quantize_y=%d\n",
+                    (unsigned long long)y_sz,
+                    (long long)src1->ne[0], (long long)src1->ne[1],
+                    (long long)src1->ne[2], (long long)src1->ne[3],
+                    padded_n, (int)qy_needs_dequant, (int)quantize_y);
+                fflush(stderr);
+            }
             ctx->prealloc_size_y = y_sz;
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
@@ -9177,6 +9189,18 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
         if ((qy_needs_dequant || quantize_y) && ctx->prealloc_size_y < y_sz) {
+            // If the prescan failed to prevent this growth, log the cause.
+            // Enable with GGML_VK_FA_DEBUG=1.
+            if (getenv("GGML_VK_FA_DEBUG")) {
+                fprintf(stderr,
+                    "ggml_vulkan MulMatId Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
+                    " padded_n=%u qy_needs=%d quantize_y=%d\n",
+                    (unsigned long long)y_sz,
+                    (long long)src1->ne[0], (long long)src1->ne[1],
+                    (long long)src1->ne[2], (long long)src1->ne[3],
+                    padded_n, (int)qy_needs_dequant, (int)quantize_y);
+                fflush(stderr);
+            }
             ctx->prealloc_size_y = y_sz;
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
@@ -9848,6 +9872,21 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
 
     const uint32_t mask_opt_num_dwords = CEIL_DIV(nem0, 16 * Bc);
     const uint64_t mask_opt_size = sizeof(uint32_t) * mask_opt_num_dwords * CEIL_DIV(nem1, Br) * nem2 * nem3;
+
+    // Log FA tuning parameters per-call. Enable with GGML_VK_FA_DEBUG=1.
+    // Useful for verifying HSK/HSV switching between SWA (256) and global (512)
+    // attention layers in dual-head-dim models such as Gemma 4.
+    if (getenv("GGML_VK_FA_DEBUG")) {
+        fprintf(stderr,
+            "ggml_vulkan FA: HSK=%u HSV=%u N=%u KV=%u Br=%u Bc=%u"
+            " use_mask_opt=%d mask_opt_size=%llu"
+            " prealloc_y_cur=%zu prealloc_y_new=%s\n",
+            HSK, HSV, N, KV, Br, Bc,
+            (int)use_mask_opt, (unsigned long long)mask_opt_size,
+            ctx->prealloc_y ? ctx->prealloc_y->size : (size_t)0,
+            (use_mask_opt && ctx->prealloc_size_y < mask_opt_size) ? "GROW" : "ok");
+        fflush(stderr);
+    }
 
     vk_pipeline pipeline_fa_mask_opt = nullptr;
     if (use_mask_opt) {
@@ -13703,6 +13742,15 @@ static void ggml_vk_preallocate_buffers(ggml_backend_vk_context * ctx, vk_contex
     }
     if (ctx->prealloc_y == nullptr || (ctx->prealloc_size_y > 0 && ctx->prealloc_y->size < ctx->prealloc_size_y)) {
         VK_LOG_MEMORY("ggml_vk_preallocate_buffers(y_size: " << ctx->prealloc_size_y << ")");
+        // Log large prealloc_y growth with subctx state. Enable with GGML_VK_FA_DEBUG=1.
+        // has_subctx=1 here means a command buffer is open — this is the unsafe path that
+        // can corrupt memory on Intel Arc UMA. The prescan fix should prevent this for
+        // MUL_MAT/MUL_MAT_ID nodes; if seen, it indicates a gap in prescan coverage.
+        if (getenv("GGML_VK_FA_DEBUG") && ctx->prealloc_size_y > 64*1024*1024) {
+            fprintf(stderr, "ggml_vulkan: prealloc_y growing to %zu bytes (has_subctx=%d)\n",
+                    ctx->prealloc_size_y, subctx ? 1 : 0);
+            fflush(stderr);
+        }
         // Resize buffer
         if (ctx->prealloc_y != nullptr) {
             ggml_vk_destroy_buffer(ctx->prealloc_y);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8273,21 +8273,37 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
             // enough prealloc_y before any command buffer was opened.  If we get here
             // with a live subctx it means the prescan missed this op, which is the
             // race condition that caused crashes on Intel Arc UMA.
-            // Set GGML_VK_FA_DEBUG=1 to surface this as a hard assertion failure
-            // (useful for running unit tests with the prescan disabled to verify coverage).
+            // Set GGML_VK_FA_DEBUG=1 to surface as a hard assertion failure and to log
+            // the VkBuffer handle swap that proves the use-after-free (the old handle
+            // is already bound in live command buffer descriptors; destroying it here
+            // makes those descriptors invalid before the GPU executes them).
             if (getenv("GGML_VK_FA_DEBUG")) {
+                VkBuffer old_handle = ctx->prealloc_y ? (VkBuffer)ctx->prealloc_y->buffer : VK_NULL_HANDLE;
                 fprintf(stderr,
                     "ggml_vulkan MulMat Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
-                    " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d\n",
+                    " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d old_VkBuffer=%p\n",
                     (unsigned long long)y_sz,
                     (long long)src1->ne[0], (long long)src1->ne[1],
                     (long long)src1->ne[2], (long long)src1->ne[3],
-                    padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0);
+                    padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0,
+                    (void*)old_handle);
+                if (old_handle != VK_NULL_HANDLE) {
+                    fprintf(stderr,
+                        "ggml_vulkan MulMat Y grow: old VkBuffer=%p DESTROYED while live in cmd buffer"
+                        " -- any already-recorded descriptor referencing it is now invalid (use-after-free)\n",
+                        (void*)old_handle);
+                }
                 fflush(stderr);
-                GGML_ASSERT(!subctx && "MulMat prealloc_y grew mid-graph: prescan missing for this op");
             }
             ctx->prealloc_size_y = y_sz;
             ggml_vk_preallocate_buffers(ctx, subctx);
+            if (getenv("GGML_VK_FA_DEBUG")) {
+                VkBuffer new_handle = ctx->prealloc_y ? (VkBuffer)ctx->prealloc_y->buffer : VK_NULL_HANDLE;
+                fprintf(stderr,
+                    "ggml_vulkan MulMat Y grow: new_VkBuffer=%p\n",
+                    (void*)new_handle);
+                fflush(stderr);
+            }
         }
         if (split_k > 1 && ctx->prealloc_size_split_k < split_k_size) {
             ctx->prealloc_size_split_k = split_k_size;
@@ -9196,20 +9212,35 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
         if ((qy_needs_dequant || quantize_y) && ctx->prealloc_size_y < y_sz) {
             // Same invariant as MulMat above: the prescan should have pre-allocated this.
             // Mid-graph growth with a live subctx is the race that caused crashes on
-            // Intel Arc UMA.  Set GGML_VK_FA_DEBUG=1 to surface as a hard assertion.
+            // Intel Arc UMA.  Set GGML_VK_FA_DEBUG=1 to surface as a hard assertion and
+            // to log the VkBuffer handle swap that proves the use-after-free.
             if (getenv("GGML_VK_FA_DEBUG")) {
+                VkBuffer old_handle = ctx->prealloc_y ? (VkBuffer)ctx->prealloc_y->buffer : VK_NULL_HANDLE;
                 fprintf(stderr,
                     "ggml_vulkan MulMatId Y grow (UNEXPECTED): y_sz=%llu ne=[%lld,%lld,%lld,%lld]"
-                    " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d\n",
+                    " padded_n=%u qy_needs=%d quantize_y=%d has_subctx=%d old_VkBuffer=%p\n",
                     (unsigned long long)y_sz,
                     (long long)src1->ne[0], (long long)src1->ne[1],
                     (long long)src1->ne[2], (long long)src1->ne[3],
-                    padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0);
+                    padded_n, (int)qy_needs_dequant, (int)quantize_y, subctx ? 1 : 0,
+                    (void*)old_handle);
+                if (old_handle != VK_NULL_HANDLE) {
+                    fprintf(stderr,
+                        "ggml_vulkan MulMatId Y grow: old VkBuffer=%p DESTROYED while live in cmd buffer"
+                        " -- any already-recorded descriptor referencing it is now invalid (use-after-free)\n",
+                        (void*)old_handle);
+                }
                 fflush(stderr);
-                GGML_ASSERT(!subctx && "MulMatId prealloc_y grew mid-graph: prescan missing for this op");
             }
             ctx->prealloc_size_y = y_sz;
             ggml_vk_preallocate_buffers(ctx, subctx);
+            if (getenv("GGML_VK_FA_DEBUG")) {
+                VkBuffer new_handle = ctx->prealloc_y ? (VkBuffer)ctx->prealloc_y->buffer : VK_NULL_HANDLE;
+                fprintf(stderr,
+                    "ggml_vulkan MulMatId Y grow: new_VkBuffer=%p\n",
+                    (void*)new_handle);
+                fflush(stderr);
+            }
         }
         if (ctx->prealloc_size_split_k < expert_count_size) {
             ctx->prealloc_size_split_k = expert_count_size;
@@ -18141,3 +18172,7 @@ static void ggml_vk_check_results_1(ggml_backend_vk_context * ctx, ggml_cgraph *
 #endif
 
 GGML_BACKEND_DL_IMPL(ggml_backend_vk_reg)
+
+
+
+

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -15526,6 +15526,94 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         ggml_vk_sync_buffers(ctx, compute_ctx);
     }
 
+    // Pre-scan all MUL_MAT / MUL_MAT_ID nodes and raise prealloc_size_x / prealloc_size_y
+    // to their worst-case upper bounds BEFORE any subctx (GPU command buffer) is live.
+    //
+    // Without this, ggml_vk_preallocate_buffers is called mid-graph with a live subctx
+    // whenever a new node requires a larger buffer than what was allocated for a previous
+    // node.  That path submits the current command buffer, waits for the GPU, destroys
+    // the old Vulkan buffer, then allocates a new one.  On Intel Arc UMA the physical
+    // pages of the freed buffer are immediately available to the OS, so any stale GPU
+    // reference or driver-internal structure that still touches those pages after the
+    // fence wait can corrupt arbitrary memory — including the CPU stack — producing
+    // STATUS_STACK_BUFFER_OVERRUN (0xC0000409) at large (≥ 23 K token) contexts.
+    //
+    // By pre-allocating the maximum size here (no subctx, hence safe to destroy / resize)
+    // the mid-graph growth condition (prealloc_size < required_size) is never true, so
+    // ggml_vk_preallocate_buffers is never called again with a live subctx for these
+    // two buffers.
+    //
+    // Upper bound derivation for Y (src1 activation buffer):
+    //   y_ne  = padded_n * ne10 * ne12 * ne13
+    //   padded_n  = qy_needs_dequant ? ROUNDUP_POW2(ne11, wg_denom[1]) : ne11
+    //
+    //   When qy_needs_dequant=true and ne11 is small (e.g. ne11=1 for a MulMatId vec
+    //   kernel), ROUNDUP_POW2 inflates padded_n up to wg_denom[1].  The maximum
+    //   wg_denom[1] across all non-coopmat pipelines is:
+    //     MUL_MAT    : 256  (l_wg_denoms[1])
+    //     MUL_MAT_ID : 128  (l_mmqid_wg_denoms[1])
+    //
+    //   We conservatively compute:
+    //     padded_n_bound = ROUNDUP_POW2(ne11, MAX_WG_DENOM)
+    //   where MAX_WG_DENOM is per-op-type.  For large ne11 this equals ne11 exactly;
+    //   for ne11=1 it equals MAX_WG_DENOM (the worst case that caused the crash).
+    //
+    //   Note: coopmat devices use different tile sizes; for safety we cap at 256
+    //   for both op types so the bound holds regardless of device capabilities.
+    //
+    // For X (src0 weight buffer, dequant path):
+    //   Only F32/F16/BF16 src0 requires dequantisation; quantised types are consumed
+    //   directly by the shader, so qx_needs_dequant=false for those.
+    {
+        // Maximum wg_denoms[1] across all configured pipelines (conservative).
+        // Empirically observed: MUL_MAT l_wg_denoms[1]=256, MUL_MAT_ID l_mmqid[1]=128.
+        // Use 256 for both to be safe across coopmat and non-coopmat devices.
+        constexpr uint32_t MAX_WG_DENOM_Y = 256;
+
+        uint64_t prescan_max_x = ctx->prealloc_size_x;
+        uint64_t prescan_max_y = ctx->prealloc_size_y;
+        for (int i = 0; i < cgraph->n_nodes; i++) {
+            const ggml_tensor * node = cgraph->nodes[i];
+            if (node->op != GGML_OP_MUL_MAT && node->op != GGML_OP_MUL_MAT_ID) {
+                continue;
+            }
+            const ggml_tensor * src0 = node->src[0];
+            const ggml_tensor * src1 = node->src[1];
+            if (!src0 || !src1) {
+                continue;
+            }
+            // Y buffer: upper-bound using worst-case padded_n.
+            // ROUNDUP_POW2(ne11, MAX_WG_DENOM_Y) equals ne11 when ne11 is already
+            // ≥ MAX_WG_DENOM_Y (the common prefill case), and inflates to MAX_WG_DENOM_Y
+            // when ne11=1 (the problematic MulMatId decode case).
+            const uint64_t ne10     = (uint64_t)src1->ne[0];
+            const uint64_t ne11     = (uint64_t)src1->ne[1];
+            const uint64_t ne12     = (uint64_t)src1->ne[2];
+            const uint64_t ne13     = (uint64_t)src1->ne[3];
+            const uint64_t padded_n = (ne11 == 0) ? 0 : ROUNDUP_POW2(ne11, MAX_WG_DENOM_Y);
+            const uint64_t y_bound  = sizeof(ggml_fp16_t) * padded_n * ne10 * ne12 * ne13;
+            if (prescan_max_y < y_bound) {
+                prescan_max_y = y_bound;
+            }
+            // X buffer: weight dequant — only for unquantised source types.
+            if (src0->type == GGML_TYPE_F32 ||
+                src0->type == GGML_TYPE_F16 ||
+                src0->type == GGML_TYPE_BF16) {
+                const uint64_t x_bound = sizeof(ggml_fp16_t) * (uint64_t)ggml_nelements(src0);
+                if (prescan_max_x < x_bound) {
+                    prescan_max_x = x_bound;
+                }
+            }
+        }
+        if (prescan_max_x > ctx->prealloc_size_x || prescan_max_y > ctx->prealloc_size_y) {
+            ctx->prealloc_size_x = prescan_max_x;
+            ctx->prealloc_size_y = prescan_max_y;
+            // nullptr subctx: safe to destroy and recreate GPU buffers here since
+            // no command buffer is open yet.
+            ggml_vk_preallocate_buffers(ctx, nullptr);
+        }
+    }
+
     // Submit after enough work has accumulated, to overlap CPU cmdbuffer generation with GPU execution.
     // Estimate the amount of matmul work by looking at the weight matrix size, and submit every 100MB
     // (and scaled down based on model size, so smaller models submit earlier).

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -13780,9 +13780,6 @@ static void ggml_vk_preallocate_buffers(ggml_backend_vk_context * ctx, vk_contex
     }
     if (ctx->prealloc_y == nullptr || (ctx->prealloc_size_y > 0 && ctx->prealloc_y->size < ctx->prealloc_size_y)) {
         VK_LOG_MEMORY("ggml_vk_preallocate_buffers(y_size: " << ctx->prealloc_size_y << ")");
-        // Note: the actual GGML_ASSERT(!subctx) lives at the op level (MulMat/MulMatId)
-        // where (qy_needs_dequant || quantize_y) && prealloc_size_y < y_sz, gated by
-        // GGML_VK_FA_DEBUG.  That is the precise invariant the prescan maintains.
         if (getenv("GGML_VK_FA_DEBUG")) {
             fprintf(stderr, "ggml_vulkan: prealloc_y growing to %zu bytes (has_subctx=%d)\n",
                     ctx->prealloc_size_y, subctx ? 1 : 0);
@@ -15649,7 +15646,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
     // For X (src0 weight buffer, dequant path):
     //   Only F32/F16/BF16 src0 requires dequantisation; quantised types are consumed
     //   directly by the shader, so qx_needs_dequant=false for those.
-#if 1  // set to 0 to disable prescan (for unit test regression verification)
+#if 1  // pre-scan: set to 0 only for regression testing (see test_mul_mat_id_prescan)
     {
         // Maximum wg_denoms[1] across all configured pipelines (conservative).
         // Empirically observed: MUL_MAT l_wg_denoms[1]=256, MUL_MAT_ID l_mmqid[1]=128.
@@ -18172,6 +18169,7 @@ static void ggml_vk_check_results_1(ggml_backend_vk_context * ctx, ggml_cgraph *
 #endif
 
 GGML_BACKEND_DL_IMPL(ggml_backend_vk_reg)
+
 
 
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4324,27 +4324,22 @@ struct test_mul_mat_id_fusion : public test_case {
     }
 };
 
-// Regression test for the Vulkan prealloc prescan fix (PR #24312).
+// Regression test for the Vulkan mid-graph prealloc double-submit fix.
 //
-// Builds a two-op graph where both ops use prealloc_y but require different sizes:
-//   Op 1 (small_out): MUL_MAT_ID with k_small contraction dim — allocates prealloc_y
-//                     at small_y_sz and records GPU commands referencing that buffer.
-//   Op 2 (large_out): MUL_MAT_ID with k (larger) contraction dim — needs large_y_sz
-//                     > small_y_sz, so without the prescan it calls
-//                     ggml_vk_preallocate_buffers mid-graph, which DESTROYS the buffer
-//                     that Op 1's already-recorded descriptors still point to.
+// Builds a two-op graph where Op 1 (small k) causes prealloc_y to be allocated at a
+// smaller size, then Op 2 (larger k) triggers ggml_vk_preallocate_buffers mid-graph
+// with a live command buffer (subctx != nullptr).
 //
-// Op 1 is placed as src[0] of the final ADD so the graph executor always runs it
-// first, ensuring prealloc_y is non-null (old VkBuffer visible) when Op 2 grows it.
+// Before the fix, ggml_vk_preallocate_buffers called ggml_vk_ctx_end + ggml_vk_submit
+// on the command buffer, then immediately called ggml_vk_synchronize — which also
+// called ggml_vk_ctx_end + ggml_vk_submit on the SAME command buffer.  This double-
+// end / double-submit is a Vulkan spec violation (undefined behaviour) that corrupted
+// host memory on Intel Arc UMA, manifesting as STATUS_STACK_BUFFER_OVERRUN at large
+// (≥ 23K token) contexts.
 //
-// With GGML_VK_FA_DEBUG=1 the backend logs the old and new VkBuffer handles,
-// showing the use-after-free directly:
-//   old_VkBuffer=0x<A>  <- bound in Op 1's recorded commands, about to be destroyed
-//   DESTROYED while live in cmd buffer -- descriptor referencing it is now invalid
-//   new_VkBuffer=0x<B>  <- different handle; Op 1's commands now reference freed memory
-//
-// On Intel Arc UMA the destroyed buffer's physical memory can be reused for host
-// allocations; GPU writes via the stale descriptor then corrupt host stack memory.
+// The fix removes the redundant ctx_end + submit from ggml_vk_preallocate_buffers,
+// delegating entirely to ggml_vk_synchronize which already handles it correctly.
+// This test verifies that the resulting mid-graph reallocation produces correct output.
 struct test_mul_mat_id_prescan : public test_case {
     const ggml_type type_a;  // weight type for both MUL_MAT_ID ops
     const int       n_mats;  // total number of experts
@@ -4355,10 +4350,11 @@ struct test_mul_mat_id_prescan : public test_case {
 
     std::string vars() override { return VARS_TO_STR6(type_a, n_mats, n_used, m, k, n_tokens); }
     double      max_nmse_err() override { return 5e-4; }
-    // run_whole_graph ensures the graph goes through ggml_backend_graph_compute
-    // (where the prescan runs) rather than being dispatched op-by-op.
+    // run_whole_graph routes through ggml_backend_graph_compute so the Vulkan
+    // backend processes a single batched command buffer (the path that triggers
+    // mid-graph ggml_vk_preallocate_buffers calls when buffer sizes differ).
     bool        run_whole_graph() override { return true; }
-    std::string op_desc(ggml_tensor *) override { return "MUL_MAT_ID_PRESCAN"; }
+    std::string op_desc(ggml_tensor *) override { return "MUL_MAT_ID_PREALLOC"; }
 
     test_mul_mat_id_prescan(
             ggml_type type_a = GGML_TYPE_F16, int n_mats = 512, int n_used = 2,
@@ -4373,11 +4369,10 @@ struct test_mul_mat_id_prescan : public test_case {
         }
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
-        // Op 1 (small): MUL_MAT_ID with F16 weights and k_small — matrix path, uses
-        // prealloc_y at ROUNDUP_POW2(padded_n * k_small * n_tokens * sizeof(fp16)) bytes.
-        // Always F16 so k_small can be any multiple of 1 (quantized types require
-        // k to be a multiple of their block size, e.g. 256 for Q4_K, which k/4 may not satisfy).
-        // Placed as src[0] of ADD so the executor always runs this op first.
+        // Op 1 (small): MUL_MAT_ID with F16 weights and k_small — matrix path.
+        // F16 weights so k_small can be any multiple of 1 (quantized types require
+        // k to be a multiple of their block size, e.g. 256 for Q4_K).
+        // Placed as src[0] of ADD so the graph executor runs this op first (DFS).
         const int64_t k_small = k / 4;
         ggml_tensor * as_small = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, k_small, m, n_mats);
         ggml_set_name(as_small, "as_small");
@@ -4390,10 +4385,9 @@ struct test_mul_mat_id_prescan : public test_case {
         ggml_tensor * small_out = ggml_mul_mat_id(ctx, as_small, bl_small, ids_small); // (m, n_used, n_tokens)
         ggml_set_name(small_out, "small_out");
 
-        // Op 2 (large): MUL_MAT_ID with k > k_small — matrix path, needs prealloc_y
-        // at ROUNDUP_POW2(padded_n * k * n_tokens * sizeof(fp16)) bytes > Op 1's size.
-        // Without the prescan, this causes ggml_vk_preallocate_buffers to destroy
-        // Op 1's prealloc_y buffer while Op 1's commands are already in the cmd buffer.
+        // Op 2 (large): MUL_MAT_ID with k > k_small — matrix path, needs a larger
+        // prealloc_y than Op 1 allocated, triggering ggml_vk_preallocate_buffers
+        // mid-graph with the subctx (command buffer) still live.
         ggml_tensor * as = ggml_new_tensor_3d(ctx, type_a, k, m, n_mats);
         ggml_set_name(as, "as");
         ggml_tensor * ids_storage = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, n_mats, n_tokens);
@@ -4405,11 +4399,9 @@ struct test_mul_mat_id_prescan : public test_case {
         ggml_tensor * large_out = ggml_mul_mat_id(ctx, as, bl, ids); // (m, n_used, n_tokens)
         ggml_set_name(large_out, "large_out");
 
-        // Combine both ops so the graph executor must run both.
-        // small_out (m, n_used) broadcasts over large_out (m, n_used, n_tokens).
-        // small_out is src[0] so GGML executes it first (DFS visits src[0] before src[1]).
-        // This guarantees prealloc_y is already allocated (non-null) when large_out runs,
-        // making the old VkBuffer handle visible in the GGML_VK_FA_DEBUG log.
+        // Combine both ops so the graph executor runs both in the same command buffer.
+        // small_out is src[0] so DFS visits it first, ensuring prealloc_y is allocated
+        // to the smaller size before large_out triggers mid-graph reallocation.
         return ggml_add(ctx, small_out, large_out);
     }
 
@@ -8628,20 +8620,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 512, 2, false, 128, 4, 256));
     }
 
-    // Prescan regression: two-op graph (small MUL_MAT then large MUL_MAT_ID).
-    // run_whole_graph=true ensures the graph goes through ggml_backend_graph_compute
-    // so the Vulkan prescan in ggml_backend_vk_graph_compute is exercised.
-    // n_tokens=16 forces the matrix path (ggml_vk_mul_mat_id_q_f16) which uses
-    // prealloc_y; n_tokens<=8 would take the vector path that does not.
-    // Without the prescan fix the Vulkan backend grows prealloc_y mid-graph
-    // (has_subctx=1), which corrupts memory on UMA hardware (Intel Arc).
-    // To verify the test catches the regression, disable the prescan (#if 0 in
-    // ggml_backend_vk_graph_compute) and run with GGML_VK_FA_DEBUG=1; the
-    // GGML_ASSERT(!subctx) in ggml_vk_mul_mat_id_q_f16 will abort the process.
-    // k=1024 → k_small=256: both ops land in the quantize_y=1 pipeline branch on Arc UMA,
-    // giving a non-null old_VkBuffer when Op 2 (k=1024) forces prealloc_y to grow past
-    // Op 1's (k_small=256) allocation.  On Intel Arc UMA the freed buffer's physical pages
-    // can be immediately reused for host memory, allowing the GPU to corrupt host stack.
+    // Regression test for the mid-graph prealloc_y double-submit bug.
+    // Two MUL_MAT_ID ops in one graph with different inner dims force
+    // ggml_vk_preallocate_buffers to be called mid-graph with a live command buffer.
+    // Before the fix this triggered a double vkEndCommandBuffer + vkQueueSubmit on
+    // the same VkCommandBuffer (Vulkan UB that crashed on Intel Arc UMA).
+    // n_tokens=16 ensures the matrix path (uses prealloc_y); k=1024/k_small=256
+    // ensures Op 2 needs a strictly larger prealloc_y than Op 1.
     test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_F16,  512, 2, 128, 1024, 16));
     test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_Q4_K, 512, 2, 128, 1024, 16));
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4325,18 +4325,32 @@ struct test_mul_mat_id_fusion : public test_case {
 };
 
 // Regression test for the Vulkan prealloc prescan fix (PR #24312).
-// Builds a two-op graph: a small MUL_MAT runs first (establishing a tiny
-// prealloc_y), then a large MUL_MAT_ID with ne11=1 (single-token decode)
-// and a large expert count.  Without the prescan pass in
-// ggml_backend_vk_graph_compute, the Vulkan backend will attempt to grow
-// prealloc_y mid-graph while a command buffer is open (has_subctx=1),
-// which can corrupt memory on UMA hardware.
+//
+// Builds a two-op graph where both ops use prealloc_y but require different sizes:
+//   Op 1 (small_out): MUL_MAT_ID with k_small contraction dim — allocates prealloc_y
+//                     at small_y_sz and records GPU commands referencing that buffer.
+//   Op 2 (large_out): MUL_MAT_ID with k (larger) contraction dim — needs large_y_sz
+//                     > small_y_sz, so without the prescan it calls
+//                     ggml_vk_preallocate_buffers mid-graph, which DESTROYS the buffer
+//                     that Op 1's already-recorded descriptors still point to.
+//
+// Op 1 is placed as src[0] of the final ADD so the graph executor always runs it
+// first, ensuring prealloc_y is non-null (old VkBuffer visible) when Op 2 grows it.
+//
+// With GGML_VK_FA_DEBUG=1 the backend logs the old and new VkBuffer handles,
+// showing the use-after-free directly:
+//   old_VkBuffer=0x<A>  <- bound in Op 1's recorded commands, about to be destroyed
+//   DESTROYED while live in cmd buffer -- descriptor referencing it is now invalid
+//   new_VkBuffer=0x<B>  <- different handle; Op 1's commands now reference freed memory
+//
+// On Intel Arc UMA the destroyed buffer's physical memory can be reused for host
+// allocations; GPU writes via the stale descriptor then corrupt host stack memory.
 struct test_mul_mat_id_prescan : public test_case {
-    const ggml_type type_a;  // weight type for the MUL_MAT_ID
+    const ggml_type type_a;  // weight type for both MUL_MAT_ID ops
     const int       n_mats;  // total number of experts
     const int       n_used;  // active experts per token
     const int64_t   m;       // output dim per expert
-    const int64_t   k;       // inner (contraction) dim
+    const int64_t   k;       // inner dim for Op 2 (the large op); Op 1 uses k/4
     const int64_t   n_tokens; // number of tokens (must be > 8 to use the matrix path)
 
     std::string vars() override { return VARS_TO_STR6(type_a, n_mats, n_used, m, k, n_tokens); }
@@ -4354,31 +4368,38 @@ struct test_mul_mat_id_prescan : public test_case {
             // which uses prealloc_y. n_tokens <= 8 takes the vector path that does not,
             // so the test would not exercise the mid-graph reallocation bug.
             GGML_ASSERT(n_tokens > 8);
+            // k must be divisible by 4 so k_small = k/4 is a valid contraction dim.
+            GGML_ASSERT(k % 4 == 0);
         }
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
-        // Part 1: small MUL_MAT — dispatches to the mul_mat_vec path (dst->ne[1]==n_used<=8),
-        // which does NOT use prealloc_y.  After this op, prealloc_size_y is still 0.
-        const int64_t k_small = 4;
-        ggml_tensor * sa = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, k_small, m);
-        ggml_tensor * sb = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, k_small, n_used);
-        ggml_set_name(sa, "sa");
-        ggml_set_name(sb, "sb");
-        ggml_tensor * small_out = ggml_mul_mat(ctx, sa, sb); // (m, n_used)
+        // Op 1 (small): MUL_MAT_ID with F16 weights and k_small — matrix path, uses
+        // prealloc_y at ROUNDUP_POW2(padded_n * k_small * n_tokens * sizeof(fp16)) bytes.
+        // Always F16 so k_small can be any multiple of 1 (quantized types require
+        // k to be a multiple of their block size, e.g. 256 for Q4_K, which k/4 may not satisfy).
+        // Placed as src[0] of ADD so the executor always runs this op first.
+        const int64_t k_small = k / 4;
+        ggml_tensor * as_small = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, k_small, m, n_mats);
+        ggml_set_name(as_small, "as_small");
+        ggml_tensor * ids_s_storage = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, n_mats, n_tokens);
+        ggml_set_name(ids_s_storage, "ids_s_storage");
+        ggml_tensor * ids_small = ggml_view_2d(ctx, ids_s_storage, n_used, n_tokens, ids_s_storage->nb[1], 0);
+        ggml_set_name(ids_small, "ids_small");
+        ggml_tensor * bl_small = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, k_small, n_used, n_tokens);
+        ggml_set_name(bl_small, "bl_small");
+        ggml_tensor * small_out = ggml_mul_mat_id(ctx, as_small, bl_small, ids_small); // (m, n_used, n_tokens)
         ggml_set_name(small_out, "small_out");
 
-        // Part 2: large MUL_MAT_ID with n_tokens > 8 — routes to ggml_vk_mul_mat_id_q_f16
-        // (the matrix path), which uses prealloc_y and pads ne11 to a pipeline wg_denom
-        // multiple.  Without the prescan, prealloc_size_y grows from 0 to y_sz mid-graph
-        // with a live command buffer (subctx), triggering the crash on Intel Arc UMA.
+        // Op 2 (large): MUL_MAT_ID with k > k_small — matrix path, needs prealloc_y
+        // at ROUNDUP_POW2(padded_n * k * n_tokens * sizeof(fp16)) bytes > Op 1's size.
+        // Without the prescan, this causes ggml_vk_preallocate_buffers to destroy
+        // Op 1's prealloc_y buffer while Op 1's commands are already in the cmd buffer.
         ggml_tensor * as = ggml_new_tensor_3d(ctx, type_a, k, m, n_mats);
         ggml_set_name(as, "as");
-        // ids: [n_mats, n_tokens] storage; view first n_used rows as the routing tensor.
         ggml_tensor * ids_storage = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, n_mats, n_tokens);
         ggml_set_name(ids_storage, "ids_storage");
         ggml_tensor * ids = ggml_view_2d(ctx, ids_storage, n_used, n_tokens, ids_storage->nb[1], 0);
         ggml_set_name(ids, "ids");
-        // bl: [k, n_used, n_tokens] — activations for n_tokens tokens, each routed to n_used experts
         ggml_tensor * bl = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, k, n_used, n_tokens);
         ggml_set_name(bl, "bl");
         ggml_tensor * large_out = ggml_mul_mat_id(ctx, as, bl, ids); // (m, n_used, n_tokens)
@@ -4386,7 +4407,10 @@ struct test_mul_mat_id_prescan : public test_case {
 
         // Combine both ops so the graph executor must run both.
         // small_out (m, n_used) broadcasts over large_out (m, n_used, n_tokens).
-        return ggml_add(ctx, large_out, small_out);
+        // small_out is src[0] so GGML executes it first (DFS visits src[0] before src[1]).
+        // This guarantees prealloc_y is already allocated (non-null) when large_out runs,
+        // making the old VkBuffer handle visible in the GGML_VK_FA_DEBUG log.
+        return ggml_add(ctx, small_out, large_out);
     }
 
     void initialize_tensors(ggml_context * ctx) override {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4324,6 +4324,76 @@ struct test_mul_mat_id_fusion : public test_case {
     }
 };
 
+// Regression test for the Vulkan prealloc prescan fix (PR #24312).
+// Builds a two-op graph: a small MUL_MAT runs first (establishing a tiny
+// prealloc_y), then a large MUL_MAT_ID with ne11=1 (single-token decode)
+// and a large expert count.  Without the prescan pass in
+// ggml_backend_vk_graph_compute, the Vulkan backend will attempt to grow
+// prealloc_y mid-graph while a command buffer is open (has_subctx=1),
+// which can corrupt memory on UMA hardware.
+struct test_mul_mat_id_prescan : public test_case {
+    const ggml_type type_a;  // weight type for the MUL_MAT_ID
+    const int       n_mats;  // total number of experts
+    const int       n_used;  // active experts per token
+    const int64_t   m;       // output dim per expert
+    const int64_t   k;       // inner (contraction) dim
+    const int64_t   n_tokens; // number of tokens (must be > 8 to use the matrix path)
+
+    std::string vars() override { return VARS_TO_STR6(type_a, n_mats, n_used, m, k, n_tokens); }
+    double      max_nmse_err() override { return 5e-4; }
+    // run_whole_graph ensures the graph goes through ggml_backend_graph_compute
+    // (where the prescan runs) rather than being dispatched op-by-op.
+    bool        run_whole_graph() override { return true; }
+    std::string op_desc(ggml_tensor *) override { return "MUL_MAT_ID_PRESCAN"; }
+
+    test_mul_mat_id_prescan(
+            ggml_type type_a = GGML_TYPE_F16, int n_mats = 512, int n_used = 2,
+            int64_t m = 128, int64_t k = 256, int64_t n_tokens = 16)
+        : type_a(type_a), n_mats(n_mats), n_used(n_used), m(m), k(k), n_tokens(n_tokens) {
+            // n_tokens > 8 routes ggml_mul_mat_id to the matrix path (ggml_vk_mul_mat_id_q_f16)
+            // which uses prealloc_y. n_tokens <= 8 takes the vector path that does not,
+            // so the test would not exercise the mid-graph reallocation bug.
+            GGML_ASSERT(n_tokens > 8);
+        }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        // Part 1: small MUL_MAT — dispatches to the mul_mat_vec path (dst->ne[1]==n_used<=8),
+        // which does NOT use prealloc_y.  After this op, prealloc_size_y is still 0.
+        const int64_t k_small = 4;
+        ggml_tensor * sa = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, k_small, m);
+        ggml_tensor * sb = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, k_small, n_used);
+        ggml_set_name(sa, "sa");
+        ggml_set_name(sb, "sb");
+        ggml_tensor * small_out = ggml_mul_mat(ctx, sa, sb); // (m, n_used)
+        ggml_set_name(small_out, "small_out");
+
+        // Part 2: large MUL_MAT_ID with n_tokens > 8 — routes to ggml_vk_mul_mat_id_q_f16
+        // (the matrix path), which uses prealloc_y and pads ne11 to a pipeline wg_denom
+        // multiple.  Without the prescan, prealloc_size_y grows from 0 to y_sz mid-graph
+        // with a live command buffer (subctx), triggering the crash on Intel Arc UMA.
+        ggml_tensor * as = ggml_new_tensor_3d(ctx, type_a, k, m, n_mats);
+        ggml_set_name(as, "as");
+        // ids: [n_mats, n_tokens] storage; view first n_used rows as the routing tensor.
+        ggml_tensor * ids_storage = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, n_mats, n_tokens);
+        ggml_set_name(ids_storage, "ids_storage");
+        ggml_tensor * ids = ggml_view_2d(ctx, ids_storage, n_used, n_tokens, ids_storage->nb[1], 0);
+        ggml_set_name(ids, "ids");
+        // bl: [k, n_used, n_tokens] — activations for n_tokens tokens, each routed to n_used experts
+        ggml_tensor * bl = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, k, n_used, n_tokens);
+        ggml_set_name(bl, "bl");
+        ggml_tensor * large_out = ggml_mul_mat_id(ctx, as, bl, ids); // (m, n_used, n_tokens)
+        ggml_set_name(large_out, "large_out");
+
+        // Combine both ops so the graph executor must run both.
+        // small_out (m, n_used) broadcasts over large_out (m, n_used, n_tokens).
+        return ggml_add(ctx, large_out, small_out);
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        init_mul_mat_id_tensors(ctx, n_mats);
+    }
+};
+
 // GGML_OP_OUT_PROD
 struct test_out_prod : public test_case {
     const ggml_type type_a;
@@ -8521,6 +8591,31 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_F16, GGML_TYPE_F32, 1, 1, false, 8, 16, 1));
     test_cases.emplace_back(new test_mul_mat_id_fusion(GGML_TYPE_F16, GGML_TYPE_F32, 16, 16, false, 32, 32, 32, 3));
+
+    // Gemma 4 26B-A4B MoE: 512 experts, ne11=1 single-token decode.
+    // Uses reduced k/m (256/128) to keep device memory < 128 MB on any backend.
+    // n_mats=512 + n=1 exercises ROUNDUP_POW2(1, wg_denom) amplification regardless
+    // of k -- the same code path that caused crashes on Vulkan UMA hardware at
+    // >= 23K token contexts (see PR #24312).
+    for (ggml_type type_a : {GGML_TYPE_F16, GGML_TYPE_Q4_K}) {
+        // n=1: single-token decode — the crash-inducing case
+        test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 512, 2, false, 128, 1, 256));
+        // n=4: small prefill batch — sanity-checks adjacent decode batch sizes
+        test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 512, 2, false, 128, 4, 256));
+    }
+
+    // Prescan regression: two-op graph (small MUL_MAT then large MUL_MAT_ID).
+    // run_whole_graph=true ensures the graph goes through ggml_backend_graph_compute
+    // so the Vulkan prescan in ggml_backend_vk_graph_compute is exercised.
+    // n_tokens=16 forces the matrix path (ggml_vk_mul_mat_id_q_f16) which uses
+    // prealloc_y; n_tokens<=8 would take the vector path that does not.
+    // Without the prescan fix the Vulkan backend grows prealloc_y mid-graph
+    // (has_subctx=1), which corrupts memory on UMA hardware (Intel Arc).
+    // To verify the test catches the regression, disable the prescan (#if 0 in
+    // ggml_backend_vk_graph_compute) and run with GGML_VK_FA_DEBUG=1; the
+    // GGML_ASSERT(!subctx) in ggml_vk_mul_mat_id_q_f16 will abort the process.
+    test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_F16,  512, 2, 128, 256, 16));
+    test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_Q4_K, 512, 2, 128, 256, 16));
 
     // gpt-oss issue with Vulkan mmq_id
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_MXFP4, GGML_TYPE_F32, 32, 2, false, 2880, 32, 2880));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8638,8 +8638,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     // To verify the test catches the regression, disable the prescan (#if 0 in
     // ggml_backend_vk_graph_compute) and run with GGML_VK_FA_DEBUG=1; the
     // GGML_ASSERT(!subctx) in ggml_vk_mul_mat_id_q_f16 will abort the process.
-    test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_F16,  512, 2, 128, 256, 16));
-    test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_Q4_K, 512, 2, 128, 256, 16));
+    // k=1024 → k_small=256: both ops land in the quantize_y=1 pipeline branch on Arc UMA,
+    // giving a non-null old_VkBuffer when Op 2 (k=1024) forces prealloc_y to grow past
+    // Op 1's (k_small=256) allocation.  On Intel Arc UMA the freed buffer's physical pages
+    // can be immediately reused for host memory, allowing the GPU to corrupt host stack.
+    test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_F16,  512, 2, 128, 1024, 16));
+    test_cases.emplace_back(new test_mul_mat_id_prescan(GGML_TYPE_Q4_K, 512, 2, 128, 1024, 16));
 
     // gpt-oss issue with Vulkan mmq_id
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_MXFP4, GGML_TYPE_F32, 32, 2, false, 2880, 32, 2880));


### PR DESCRIPTION
Fixes #23769. Related: #20515.

> **Note on authorship:** This fix was developed with heavy AI assistance.
> I'm a user who hit this crash and worked through it with an AI coding
> assistant doing most of the analytical and code-writing work. If the approach
> is wrong, an alternate fix is preferred, or maintainers would rather use this
> only as a proof-of-concept and rewrite it themselves, that is completely fine
> -- the goal is just to get the information in front of people who can act on it.

### Problem

`ggml_vk_preallocate_buffers` can be called mid-graph with a live Vulkan subctx
(command buffer open) when a `MUL_MAT_ID` node for a large MoE model requires a
`prealloc_y` buffer larger than all previously seen nodes estimated.

Trigger (Gemma 4 26B-A4B, 512 experts, single-token decode):

```
src1->ne = [2816, 1, 512, 1]   (K=2816, ne11=1 token, ne12=512 experts)
wg_denom[1] = 128              (mul_mat_id pipeline parameter)
padded_n    = ROUNDUP_POW2(1, 128) = 128   <- 128x amplification
y_sz        = sizeof(fp16) * 128 * 2816 * 512 = 352 MB
```

A naive prescan using `ggml_nelements(src1) * sizeof(fp16)` yields ~2.9 MB -- 120x
too small -- because it misses the `ROUNDUP_POW2` padding applied in
`ggml_vk_mul_mat_id_q_f16`.

When the buffer is destroyed and re-created mid-graph, something in the
subsequent dispatch path produces `STATUS_STACK_BUFFER_OVERRUN` (`0xC0000409`)
on this hardware at >= 23K token contexts. The exact mechanism is not confirmed
(see discussion below).

### Fix

Add a pre-scan pass in `ggml_backend_vk_graph_compute` before any subctx is opened.
For each `MUL_MAT`/`MUL_MAT_ID` node compute:

```
padded_n = ROUNDUP_POW2(ne11, MAX_WG_DENOM_Y=256)   // conservative upper bound
y_bound  = sizeof(fp16) * padded_n * ne10 * ne12 * ne13
```

Then call `ggml_vk_preallocate_buffers(ctx, nullptr)` once with the maximum required
sizes. `nullptr` subctx means no command buffer is open, so destroying and re-creating
the GPU buffer is safe.

`MAX_WG_DENOM_Y=256` covers all currently configured pipelines (MUL_MAT: 256,
MUL_MAT_ID: 128). For typical prefill batches where `ne11 >= 256`,
`ROUNDUP_POW2(ne11, 256) == ne11` and the bound is tight. The 2x over-estimate
only appears for the single-token decode case (`ne11=1`).

### Testing

- GPU 0: NVIDIA RTX 2000 Ada Generation Laptop GPU (8 GB GDDR6) -- Vulkan0
- GPU 1: Intel Arc Graphics integrated iGPU (Core Ultra 9 185H, 37 GB shared DDR5, UMA) -- Vulkan1
- Model: Gemma 4 26B-A4B Q4_K_M, both GPUs Vulkan, `--flash-attn`, `--ctx-size 24576`
- OS: Windows 11

Previously crashed at ~23K tokens with `STATUS_STACK_BUFFER_OVERRUN`. After fix,
stable across a full context sweep (2K to ~23.5K actual tokens), with memory logs
confirming `prealloc_y` (738 MB) allocated at `has_subctx=0` only and zero mid-graph
growth events.

### Diagnostic branch

`fprintf` traces used during investigation (gated on `GGML_VK_FA_DEBUG=1`, zero cost
when unset) are at https://github.com/rrauenza/llama.cpp/commit/b6f0313

Key signals:
- `ggml_vk_preallocate_buffers`: logs `has_subctx` on large prealloc_y growth --
  `has_subctx=1` is the smoking gun for unsafe mid-graph reallocation
- `ggml_vk_mul_mat_id_q_f16`: logs tensor dims and `padded_n` when growth occurs
- `ggml_vk_flash_attn`: logs HSK/HSV/Br/Bc per call (used to rule out FA as the
  direct cause -- flash attention was present but never triggered prealloc_y growth)
