### PR TITLE
mtmd: fix double-close of ffmpeg/ffprobe stdin in video helper

### DIFF
--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -643,6 +643,11 @@ struct mtmd_helper_video {
         size_t written = fwrite(input_buf.data(), 1, input_buf.size(), f);
         LOG_DBG("%s: wrote %zu bytes, closing stdin\n", __func__, written);
         fclose(f);
+        // subprocess_stdin() returns sp->stdin_file directly; fclosing our local
+        // copy leaves the struct pointer dangling, so subprocess_destroy() would
+        // fclose() the same FILE again -> heap corruption. Null it so the later
+        // destroy skips stdin.
+        sp->stdin_file = nullptr;
     }
 
     bool probe(float fps_target_arg) {


### PR DESCRIPTION
## Overview

mtmd_helper_video::feed_stdin() closes the FILE returned by subprocess_stdin(), which is sp->stdin_file. The local fclose() leaves sp->stdin_file dangling (still non-NULL), so the subsequent subprocess_destroy() fclose()s the same FILE a second time, corrupting the heap and aborting the process ("corrupted double-linked list" / "corrupted size vs. prev_size").

This reproduces on the server's base64 input_video path (every probe()/start_ffmpeg() feeds the buffer through stdin); the CLI --video <file> path is unaffected because it never spawns the stdin feeder.

Clear sp->stdin_file after fclose() so subprocess_destroy() skips it.

cc @ngxson 

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I was actually trying to consume the new #24269 in LocalAI ( https://github.com/mudler/LocalAI/pull/10216 ) , but faced issues with repetitive video inputs in the server, fix was trivial and tested e2e