### PR TITLE
server: skip broken --fit memory probe for integrated MTP

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -849,11 +849,35 @@ private:
                 }
                 cparams_dft.n_rs_seq = 0;
 
+                bool skip_measure = false;
+
+                // Integrated MTP shares the target model; the no-alloc probe context cannot be
+                // constructed without llama_set_mtp_source(), so memory_breakdown() aborts.
+                // See https://github.com/ggml-org/llama.cpp/issues/24117
+                if (spec_mtp && !has_draft) {
+                    skip_measure = true;
+                    SRV_WRN("[spec] skipping --fit memory measurement for integrated MTP model '%s'\n",
+                            params_dft.model.path.c_str());
+                } else if (spec_mtp && has_draft) {
+                    struct gguf_init_params meta_params = {
+                        /* .no_alloc = */ true,
+                        /* .ctx      = */ nullptr,
+                    };
+                    gguf_context_ptr meta(gguf_init_from_file(params_dft.model.path.c_str(), meta_params));
+                    const int arch_key = gguf_find_key(meta.get(), "general.architecture");
+                    if (arch_key >= 0 &&
+                            std::string(gguf_get_val_str(meta.get(), arch_key)) == "gemma4-assistant") {
+                        skip_measure = true;
+                        SRV_WRN("[spec] skipping --fit memory measurement for Gemma 4 assistant draft model '%s'\n",
+                                params_dft.model.path.c_str());
+                    }
+                }
+
                 std::vector<ggml_backend_dev_t> devs;
                 uint32_t hp_ngl = 0;
                 uint32_t hp_nct = 0;
                 uint32_t hp_nex = 0;
-                try {
+                if (!skip_measure) try {
                     auto dmd = common_get_device_memory_data(
                         params_dft.model.path.c_str(), &mparams_dft, &cparams_dft,
                         devs, hp_ngl, hp_nct, hp_nex, GGML_LOG_LEVEL_ERROR);


### PR DESCRIPTION
## Summary

Fixes #24117.

When `--fit on` is used with `--spec-type draft-mtp` and no separate `--model-draft`, llama-server probes MTP context memory before the target model is loaded. `common_get_device_memory_data()` creates a no-alloc probe context and calls `llama_get_memory_breakdown()`, which reaches `llama_context::memory_breakdown()` and aborts with `GGML_ASSERT(sched) failed` because the MTP draft context is not valid without `llama_set_mtp_source()`.

This affects integrated MTP models such as Qwen3.6 `*.mtp.gguf` on all backends (Vulkan, ROCm, CUDA).

This PR skips the broken pre-load `--fit` memory measurement for:
- integrated MTP models (`draft-mtp` without a separate draft model)
- Gemma 4 assistant draft models, which also require a wired target context

The real model load path is unaffected; MTP works once the target + draft contexts are created normally.

## Test plan

- [x] Reproduced crash on upstream master: `llama-server --model Qwen3.6-35B-A3B-UD-IQ3_XXS_mtp.gguf --spec-type draft-mtp --fit on` → `GGML_ASSERT(sched) failed`
- [x] Verified fix loads successfully with `--fit on --spec-type draft-mtp` (Vulkan/RADV, 96k ctx)
- [x] Verified MTP speculative decoding works after load (`draft_n` / `draft_n_accepted` in completion response)
- [ ] CI


Made with [Cursor](https://cursor.com)