### PR TITLE
chat: harden peg-native tool call parsing

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -103,6 +103,10 @@ common_chat_params peg_generator::generate_parser(const common_chat_template &  
             data.grammar_triggers = {
                 { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, trigger_marker }
             };
+            if (autoparser.tools.format.mode == tool_format::JSON_NATIVE) {
+                // some models emit the openai wrapper, trigger on it as well
+                data.grammar_triggers.push_back({ COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "{\"type\": \"function\"," });
+            }
         }
     }
 

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -103,8 +103,8 @@ common_chat_params peg_generator::generate_parser(const common_chat_template &  
             data.grammar_triggers = {
                 { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, trigger_marker }
             };
-            if (autoparser.tools.format.mode == tool_format::JSON_NATIVE) {
-                // Some models emit the OpenAI wrapper, trigger on it as well
+            if (autoparser.tools.format.openai_wrapper_trigger) {
+                // model emits the OpenAI function wrapper, trigger on it
                 data.grammar_triggers.push_back({ COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "{\"type\": \"function\"," });
             }
         }

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -104,7 +104,7 @@ common_chat_params peg_generator::generate_parser(const common_chat_template &  
                 { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, trigger_marker }
             };
             if (autoparser.tools.format.mode == tool_format::JSON_NATIVE) {
-                // some models emit the openai wrapper, trigger on it as well
+                // Some models emit the OpenAI wrapper, trigger on it as well
                 data.grammar_triggers.push_back({ COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "{\"type\": \"function\"," });
             }
         }

--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -228,13 +228,13 @@ common_peg_parser analyze_tools::build_tool_parser_json_native(parser_build_cont
         auto single_tool_parser = p.standard_json_tools(
             format.per_call_start, format.per_call_end, inputs.tools, inputs.parallel_tool_calls,
             inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED, name_field, args_field, format.tools_array_wrapped,
-            format.fun_name_is_key, format.id_field, format.gen_id_field, format.parameter_order);
+            format.fun_name_is_key, format.id_field, format.gen_id_field, format.parameter_order, format.openai_wrapper_trigger);
         tools_parser = p.trigger_rule("tool-calls", p.one_or_more(single_tool_parser + p.space()));
     } else {
         tools_parser = p.standard_json_tools(
             format.section_start, format.section_end, inputs.tools, inputs.parallel_tool_calls,
             inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED, name_field, args_field, format.tools_array_wrapped,
-            format.fun_name_is_key, format.id_field, format.gen_id_field, format.parameter_order);
+            format.fun_name_is_key, format.id_field, format.gen_id_field, format.parameter_order, format.openai_wrapper_trigger);
     }
 
     // Handle content wrappers if present

--- a/common/chat-auto-parser.h
+++ b/common/chat-auto-parser.h
@@ -181,6 +181,7 @@ struct tool_format_analysis {
 
     bool fun_name_is_key = false;       // In JSON format function name is JSON key, i.e. { "<funname>": { ... arguments ... } }
     bool tools_array_wrapped = false;   // Tool calls wrapped in JSON array [...]
+    bool openai_wrapper_trigger = false;  // model emits the OpenAI function wrapper, trigger on it
 
     std::string              function_field = "function";
     std::string              name_field     = "name";

--- a/common/chat-diff-analyzer.cpp
+++ b/common/chat-diff-analyzer.cpp
@@ -165,6 +165,14 @@ static std::vector<std::function<void(const common_chat_template & tmpl, autopar
               LOG_DBG(ANSI_ORANGE "[Patch: Apriel 1.6]\n" ANSI_RESET);
           }
       },
+      // template uses the JSON {name, parameters} tool instruction, emits the OpenAI function wrapper
+      [](const common_chat_template & tmpl, autoparser & analysis) -> void {
+          if (tmpl.src.find("Respond in the format {\"name\": function name") != std::string::npos &&
+              tmpl.src.find("Do not use variables.") != std::string::npos) {
+              analysis.tools.format.openai_wrapper_trigger = true;
+              LOG_DBG(ANSI_ORANGE "[Patch: JSON name/parameters tool instruction]\n" ANSI_RESET);
+          }
+      },
 
     });
 

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -807,7 +807,7 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
                 return idx_a < idx_b;
             });
 
-        // accept an optional leading "type": "function" field
+        // Accept an optional leading "type": "function" field
         auto type_field = optional(literal("\"type\"") + space() + literal(":") + space() +
                                    literal("\"function\"") + space() + literal(",") + space());
         auto ordered_body = tool_open(literal("{")) + space() + type_field;

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -807,10 +807,7 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
                 return idx_a < idx_b;
             });
 
-        // accept an optional leading "type": "function" field
-        auto type_field = optional(literal("\"type\"") + space() + literal(":") + space() +
-                                   literal("\"function\"") + space() + literal(",") + space());
-        auto ordered_body = tool_open(literal("{")) + space() + type_field;
+        auto ordered_body = tool_open(literal("{")) + space();
         for (size_t i = 0; i < parser_pairs.size(); i++) {
             ordered_body = ordered_body + parser_pairs[i].first;
             if (i < parser_pairs.size() - 1) {

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -745,7 +745,8 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
     const std::string &              effective_args_key,
     const std::string &              call_id_key,
     const std::string &              gen_call_id_key,
-    const std::vector<std::string> & parameters_order) {
+    const std::vector<std::string> & parameters_order,
+    bool                             accept_openai_wrapper) {
 
     auto tool_choices    = choice();
     auto name_key_parser = literal("\"" + effective_name_key + "\"");
@@ -807,9 +808,12 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
                 return idx_a < idx_b;
             });
 
-        // Accept an optional leading "type": "function" field
-        auto type_field = optional(literal("\"type\"") + space() + literal(":") + space() +
-                                   literal("\"function\"") + space() + literal(",") + space());
+        // accept an optional leading "type": "function" field when the model emits the OpenAI wrapper
+        common_peg_parser type_field = eps();
+        if (accept_openai_wrapper) {
+            type_field = optional(literal("\"type\"") + space() + literal(":") + space() +
+                                  literal("\"function\"") + space() + literal(",") + space());
+        }
         auto ordered_body = tool_open(literal("{")) + space() + type_field;
         for (size_t i = 0; i < parser_pairs.size(); i++) {
             ordered_body = ordered_body + parser_pairs[i].first;
@@ -873,7 +877,8 @@ common_peg_parser common_chat_peg_builder::standard_json_tools(
                                                        bool                             function_is_key,
                                                        const std::string &              call_id_key,
                                                        const std::string &              gen_call_id_key,
-                                                       const std::vector<std::string> & parameters_order) {
+                                                       const std::vector<std::string> & parameters_order,
+                                                       bool                             accept_openai_wrapper) {
     if (!tools.is_array() || tools.empty()) {
         return eps();
     }
@@ -891,7 +896,7 @@ common_peg_parser common_chat_peg_builder::standard_json_tools(
         if (!name_spec.first.empty() || !args_spec.first.empty()) {
             tool_choices = build_json_tools_nested_keys(tools, effective_name_key, effective_args_key, call_id_key, gen_call_id_key);
         } else {
-            tool_choices = build_json_tools_flat_keys(tools, effective_name_key, effective_args_key, call_id_key, gen_call_id_key, parameters_order);
+            tool_choices = build_json_tools_flat_keys(tools, effective_name_key, effective_args_key, call_id_key, gen_call_id_key, parameters_order, accept_openai_wrapper);
         }
     }
 

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -807,7 +807,10 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
                 return idx_a < idx_b;
             });
 
-        auto ordered_body = tool_open(literal("{")) + space();
+        // accept an optional leading "type": "function" field
+        auto type_field = optional(literal("\"type\"") + space() + literal(":") + space() +
+                                   literal("\"function\"") + space() + literal(",") + space());
+        auto ordered_body = tool_open(literal("{")) + space() + type_field;
         for (size_t i = 0; i < parser_pairs.size(); i++) {
             ordered_body = ordered_body + parser_pairs[i].first;
             if (i < parser_pairs.size() - 1) {

--- a/common/chat-peg-parser.h
+++ b/common/chat-peg-parser.h
@@ -120,7 +120,8 @@ class common_chat_peg_builder : public common_peg_parser_builder {
                                           bool                             function_is_key = false,
                                           const std::string &              call_id_key = "",
                                           const std::string &              gen_call_id_key = "",
-                                          const std::vector<std::string> & parameters_order = {});
+                                          const std::vector<std::string> & parameters_order = {},
+                                          bool                             accept_openai_wrapper = false);
 
     // Legacy-compatible helper for building XML/tagged style tool calls
     // Used by tests and manual parsers
@@ -157,7 +158,8 @@ class common_chat_peg_builder : public common_peg_parser_builder {
                                                  const std::string &              effective_args_key,
                                                  const std::string &              call_id_key,
                                                  const std::string &              gen_call_id_key,
-                                                 const std::vector<std::string> & parameters_order);
+                                                 const std::vector<std::string> & parameters_order,
+                                                 bool                             accept_openai_wrapper);
 };
 
 inline common_peg_arena build_chat_peg_parser(

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2164,8 +2164,7 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            // keep the raw arguments string when it is not valid json
-                            LOG_WRN("%s: tool call arguments are not valid json, keeping raw string: %s\n", __func__, e.what());
+                            throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
                         }
                     }
                 }
@@ -2521,16 +2520,11 @@ common_chat_msg common_chat_peg_parse(const common_peg_arena &          src_pars
             }
             return msg;
         }
-        if (!is_partial) {
-            // on a final parse failure log the fragment and raise a clean error
-            LOG_WRN("%s: unparsed %s output: %s\n", __func__, common_chat_format_name(params.format),
-                    effective_input.substr(result.end).c_str());
-            throw std::runtime_error(std::string("the model produced output that does not match the expected ") +
-                                     common_chat_format_name(params.format) + " format");
-        }
-        common_chat_msg msg;
-        msg.role = "assistant";
-        return msg;
+        // log the unparsed fragment and raise a clean error
+        LOG_WRN("%s: unparsed %s output: %s\n", __func__, common_chat_format_name(params.format),
+                effective_input.substr(result.end).c_str());
+        throw std::runtime_error(std::string("the model produced output that does not match the expected ") +
+                                 common_chat_format_name(params.format) + " format");
     }
 
     common_chat_msg msg;

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2164,7 +2164,8 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
+                            // keep the raw arguments string when it is not valid json
+                            LOG_WRN("%s: tool call arguments are not valid json, keeping raw string: %s\n", __func__, e.what());
                         }
                     }
                 }
@@ -2520,8 +2521,16 @@ common_chat_msg common_chat_peg_parse(const common_peg_arena &          src_pars
             }
             return msg;
         }
-        throw std::runtime_error(std::string("Failed to parse input at pos ") + std::to_string(result.end) + ": " +
-                                 effective_input.substr(result.end));
+        if (!is_partial) {
+            // on a final parse failure log the fragment and raise a clean error
+            LOG_WRN("%s: unparsed %s output: %s\n", __func__, common_chat_format_name(params.format),
+                    effective_input.substr(result.end).c_str());
+            throw std::runtime_error(std::string("the model produced output that does not match the expected ") +
+                                     common_chat_format_name(params.format) + " format");
+        }
+        common_chat_msg msg;
+        msg.role = "assistant";
+        return msg;
     }
 
     common_chat_msg msg;

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2520,10 +2520,9 @@ common_chat_msg common_chat_peg_parse(const common_peg_arena &          src_pars
             }
             return msg;
         }
-        // log the unparsed fragment and raise a clean error
         LOG_WRN("%s: unparsed %s output: %s\n", __func__, common_chat_format_name(params.format),
                 effective_input.substr(result.end).c_str());
-        throw std::runtime_error(std::string("the model produced output that does not match the expected ") +
+        throw std::runtime_error(std::string("The model produced output that does not match the expected ") +
                                  common_chat_format_name(params.format) + " format");
     }
 


### PR DESCRIPTION
## Overview

While working we hit a silent bug on llama 3.3 dense: the assistant turn came back empty, no error shown. It only happened with tools enabled. The model emits a tool call in a variant format that the peg-native parser rejects, which blew up the whole turn. I landed a debug log first to confirm exactly what the model was emitting, then the actual fix: accept the "type": "function" variant, and fail soft on parse errors instead of tearing down the turn.

## Additional information

A bug was discovered while working on this PR https://github.com/ggml-org/llama.cpp/pull/23226 that allows the system to see when an error occurs; otherwise, it's silent (empty assistant turn). This PR adds the missing error if the PEG fails.

<img width="579" height="279" alt="604615515-bd9a70de-baf7-44bb-99c4-9701cd714d17" src="https://github.com/user-attachments/assets/f09ec7f8-eab5-402b-a503-3b19133747bb" />

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
