### PR TITLE
Support Step3.5/3.7 flash mtp3

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -825,7 +825,16 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
     int32_t n_embd = 0;
 
-    bool is_mem_shared = false;
+    // One MTP draft driver, three modes (flags set once in the ctor):
+    //   is_mem_shared : gemma4-assistant — the draft shares the target's KV and
+    //                   runs every nextn layer in a single graph; the catch-up
+    //                   decode is skipped and all draft tokens reuse one position.
+    //   chain_heads   : step35 — n_mtp_layers independently-trained heads run one
+    //                   per step (mtp_layer_offset = k), each on its own KV.
+    //   neither       : single-block AR (qwen3.5/3.6) — one trained MTP head.
+    int32_t n_mtp_layers  = 1;
+    bool    is_mem_shared = false;   // gemma4
+    bool    chain_heads   = false;   // derived in the ctor: n_mtp_layers > 1 && !is_mem_shared
 
     // Per-sequence cross-batch carryover: pair (h_p, x_{p+1}) at MTP pos p+1.
     // The last h-row of one process() call needs the first token of the NEXT
@@ -856,6 +865,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         n_embd = llama_model_n_embd_out(llama_get_model(ctx_dft));
         GGML_ASSERT(n_embd == llama_model_n_embd(llama_get_model(ctx_tgt)) &&
                 "MTP input row width must match the target h_nextn width");
+        n_mtp_layers = std::max(1, (int) llama_model_n_nextn_layer(llama_get_model(ctx_dft)));
+        // note: chain_heads / n_max clamp are derived below, once is_mem_shared is known.
 
         LOG_INF("%s: adding speculative implementation 'draft-mtp'\n", __func__);
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f, n_embd=%d, backend_sampling=%d\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min, n_embd, (int) this->params.backend_sampling);
@@ -902,6 +913,14 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         llama_set_embeddings_nextn(ctx_dft, true, /*masked*/ true);
 
         is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
+        chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
+
+        // step35-style chaining uses each trained head exactly once per draft
+        // round, so the draft length is capped at the number of heads. Mem-shared
+        // archs (gemma4) run every head in one graph, so this clamp does not apply.
+        if (chain_heads) {
+            this->params.n_max = std::min(this->params.n_max, n_mtp_layers);
+        }
 
         pending_h.assign(n_seq, std::vector<float>(n_embd, 0.0f));
 
@@ -988,8 +1007,12 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         // if kv is shared with target (e.g Gemma4), then we can skip this catch-up decode
         if (!is_mem_shared) {
+            // Build the teacher-forcing batch ONCE — it is identical for every head:
+            // tokens at their real positions, tgt nextn-embd right-shifted by one,
+            // pending_h planted at each seq's first slot. llama_decode only reads the
+            // batch, so the same buffer is replayed per head; only the layer offset
+            // and the per-head KV reset differ.
             common_batch_clear(batch);
-
             for (int k = 0; k < n_tokens; ++k) {
                 common_batch_add(batch, batch_in.token[k], batch_in.pos[k], { batch_in.seq_id[k][0] }, 0);
             }
@@ -1003,23 +1026,43 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 const float * h_tgt = llama_get_embeddings_nextn(ctx_tgt);
                 std::memcpy(batch.embd + (size_t) 1 * n_embd, h_tgt, row_bytes * (n_tokens-1));
             }
-
-            // fill the pending embeddings from a previous run
-            auto set_h = [&](int idx, const float * h_row) {
-                std::memcpy(batch.embd + (size_t) idx * n_embd, h_row, row_bytes);
-            };
-
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (i_batch_beg[seq_id] < 0) {
-                    continue;
-                }
-
-                set_h(i_batch_beg[seq_id], pending_h[seq_id].data());
+                if (i_batch_beg[seq_id] < 0) continue;
+                std::memcpy(batch.embd + (size_t) i_batch_beg[seq_id] * n_embd,
+                            pending_h[seq_id].data(), row_bytes);
             }
 
-            const int32_t rc = llama_decode(ctx_dft, batch);
-            if (rc != 0) {
-                LOG_ERR("%s: llama_decode(ctx_dft) failed rc=%d (pos=%d)\n", __func__, (int) rc, (int) batch_in.pos[0]);
+            auto * mem_dft = llama_get_memory(ctx_dft);
+
+            bool ok = true;
+            for (int head = 0; head < n_mtp_layers; ++head) {
+                // chain_heads == false keeps the legacy single-decode path byte-for-byte
+                // (no seq_rm, no offset switch). When chaining, reset each sequence's
+                // own batch region first so this head re-decodes the whole batch into
+                // a clean, position-aligned slot set (find_slot is deterministic given
+                // identical v_cells). Lower bound = this batch's first pos for the seq
+                // (prompt-multi-ubatch safe).
+                if (chain_heads) {
+                    for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                        if (i_batch_beg[seq_id] < 0) continue;
+                        llama_memory_seq_rm(mem_dft, seq_id, batch_in.pos[i_batch_beg[seq_id]], -1);
+                    }
+                    llama_set_mtp_layer_offset(ctx_dft, head);
+                }
+
+                const int32_t rc = llama_decode(ctx_dft, batch);
+                if (rc != 0) {
+                    LOG_ERR("%s: llama_decode(ctx_dft) head=%d failed rc=%d (pos=%d)\n",
+                            __func__, head, (int) rc, (int) batch_in.pos[0]);
+                    ok = false;
+                    break;
+                }
+            }
+
+            if (chain_heads) {
+                llama_set_mtp_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
+            }
+            if (!ok) {
                 return false;
             }
         }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -825,13 +825,10 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
     int32_t n_embd = 0;
 
-    // One MTP draft driver, three modes (flags set once in the ctor):
-    //   is_mem_shared : gemma4-assistant — the draft shares the target's KV and
-    //                   runs every nextn layer in a single graph; the catch-up
-    //                   decode is skipped and all draft tokens reuse one position.
-    //   chain_heads   : step35 — n_mtp_layers independently-trained heads run one
-    //                   per step (mtp_layer_offset = k), each on its own KV.
-    //   neither       : single-block AR (qwen35 / qwen35moe) — one trained MTP head.
+    // One MTP draft driver, three modes (set once in the ctor):
+    //   is_mem_shared (gemma4): shares the target KV, runs all heads in one graph.
+    //   chain_heads (step35): n_mtp_layers trained heads, one per draft step.
+    //   neither (qwen35 / qwen35moe): a single trained MTP head.
     int32_t n_mtp_layers  = 1;
     bool    is_mem_shared = false;   // gemma4
     bool    chain_heads   = false;   // derived in the ctor: n_mtp_layers > 1 && !is_mem_shared
@@ -849,8 +846,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     std::vector<std::vector<float>> verify_h;
     std::vector<int32_t> verify_h_rows;
 
-    // Per-seq draft length from the single-head draft() path. Currently write-only
-    // (accept() rolls back via verify_h_rows); kept pending a follow-up cleanup.
+    // Per-seq draft length from the last draft() call, used in accept() to
+    // roll back ctx_dft's recurrent state past the AR draft's redundant
+    // pre-advancement before process() mirrored the verify batch.
     std::vector<uint16_t> last_n_drafted;
 
     common_speculative_impl_draft_mtp(const common_params_speculative & params, uint32_t n_seq)
@@ -865,7 +863,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         GGML_ASSERT(n_embd == llama_model_n_embd(llama_get_model(ctx_tgt)) &&
                 "MTP input row width must match the target h_nextn width");
         n_mtp_layers = std::max(1, (int) llama_model_n_layer_nextn(llama_get_model(ctx_dft)));
-        // note: chain_heads / n_max clamp are derived below, once is_mem_shared is known.
 
         LOG_INF("%s: adding speculative implementation 'draft-mtp'\n", __func__);
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f, n_embd=%d, backend_sampling=%d\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min, n_embd, (int) this->params.backend_sampling);
@@ -1006,12 +1003,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         // if kv is shared with target (e.g Gemma4), then we can skip this catch-up decode
         if (!is_mem_shared) {
-            // Build the teacher-forcing batch ONCE — it is identical for every head:
-            // tokens at their real positions, tgt nextn-embd right-shifted by one,
-            // pending_h planted at each seq's first slot. llama_decode only reads the
-            // batch, so the same buffer is replayed per head; only the layer offset
-            // and the per-head KV reset differ.
             common_batch_clear(batch);
+
             for (int k = 0; k < n_tokens; ++k) {
                 common_batch_add(batch, batch_in.token[k], batch_in.pos[k], { batch_in.seq_id[k][0] }, 0);
             }
@@ -1025,12 +1018,18 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 const float * h_tgt = llama_get_embeddings_nextn(ctx_tgt);
                 std::memcpy(batch.embd + (size_t) 1 * n_embd, h_tgt, row_bytes * (n_tokens-1));
             }
+
+            // fill the pending embeddings from a previous run
+            auto set_h = [&](int idx, const float * h_row) {
+                std::memcpy(batch.embd + (size_t) idx * n_embd, h_row, row_bytes);
+            };
+
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
                 if (i_batch_beg[seq_id] < 0) {
                     continue;
                 }
-                std::memcpy(batch.embd + (size_t) i_batch_beg[seq_id] * n_embd,
-                            pending_h[seq_id].data(), row_bytes);
+
+                set_h(i_batch_beg[seq_id], pending_h[seq_id].data());
             }
 
             auto * mem_dft = llama_get_memory(ctx_dft);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1042,7 +1042,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                         }
                         llama_memory_seq_rm(mem_dft, seq_id, batch_in.pos[i_batch_beg[seq_id]], -1);
                     }
-                    llama_set_mtp_layer_offset(ctx_dft, head);
+                    llama_set_nextn_layer_offset(ctx_dft, head);
                 }
 
                 const int32_t rc = llama_decode(ctx_dft, batch);
@@ -1055,7 +1055,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             }
 
             if (chain_heads) {
-                llama_set_mtp_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
+                llama_set_nextn_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
             }
             if (!ok) {
                 return false;
@@ -1133,7 +1133,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                         llama_memory_seq_rm(mem_dft, seq_id, dparams[seq_id].n_past, -1);
                     }
                 }
-                llama_set_mtp_layer_offset(ctx_dft, i);
+                llama_set_nextn_layer_offset(ctx_dft, i);
             }
 
             int ret = llama_decode(ctx_dft, batch);
@@ -1216,7 +1216,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         }
 
         if (chain_heads) {
-            llama_set_mtp_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
+            llama_set_nextn_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
         }
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1091,6 +1091,11 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     void draft(common_speculative_draft_params_vec & dparams) override {
         auto & ctx_dft = params.ctx_dft;
 
+        if (chain_heads) {
+            draft_multi_head(dparams);
+            return;
+        }
+
         common_batch_clear(batch);
 
         // keep track of which sequences are still drafting
@@ -1208,6 +1213,114 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             }
 
             last_n_drafted[seq_id] = (uint16_t) dp.result->size();
+        }
+    }
+
+    // Multi-head MTP draft: chain heads 0..n_mtp_layers-1. Step s runs head s on
+    // the accumulated prefix [id_last, draft_1, .., draft_s] and samples draft_{s+1}.
+    // Each slot's embd is the hidden produced by the PREVIOUS head for that token
+    // (slot 0 is always pending_h = trunk h). Per-step seq_rm keeps each head's KV
+    // on a clean, position-aligned slot set.
+    void draft_multi_head(common_speculative_draft_params_vec & dparams) {
+        auto * ctx_dft = params.ctx_dft;
+        auto * mem_dft = llama_get_memory(ctx_dft);
+        const size_t row_bytes = (size_t) n_embd * sizeof(float);
+
+        // Per-seq accumulated draft state. Positions are implicit: slot k always
+        // sits at round_start + k (the prefix is contiguous from id_last), so we
+        // don't store a parallel positions vector.
+        struct seq_state {
+            bool active = false;
+            llama_pos round_start = 0;                 // pos of id_last (slot 0)
+            std::vector<llama_token> toks;             // [id_last, draft_1, ...]
+            std::vector<std::vector<float>> slot_h;    // embd per slot (toks[k] <-> slot_h[k])
+        };
+        std::vector<seq_state> st(n_seq);
+
+        int n_drafting = 0;
+        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+            auto & dp = dparams[seq_id];
+            if (!dp.drafting) continue;
+            common_sampler_reset(smpls[seq_id].get());
+            st[seq_id].active      = true;
+            st[seq_id].round_start = dp.n_past;
+            st[seq_id].toks.push_back(dp.id_last);
+            st[seq_id].slot_h.push_back(pending_h[seq_id]); // slot 0 = trunk pending_h
+            n_drafting++;
+        }
+        if (n_drafting == 0) return;
+
+        const int n_steps = n_mtp_layers; // one head per step, capped at head count
+
+        for (int step = 0; step < n_steps && n_drafting > 0; ++step) {
+            // 1) per-seq KV reset for this head + select the head's layer.
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (!st[seq_id].active) continue;
+                llama_memory_seq_rm(mem_dft, seq_id, st[seq_id].round_start, -1);
+            }
+            llama_set_mtp_layer_offset(ctx_dft, step);
+
+            // 2) build accumulated batch; logits only on each seq's last slot.
+            common_batch_clear(batch);
+            std::vector<int> last_i_batch(n_seq, -1);
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (!st[seq_id].active) continue;
+                auto & s = st[seq_id];
+                const int len = (int) s.toks.size();
+                for (int k = 0; k < len; ++k) {
+                    const bool is_last = (k == len - 1);
+                    common_batch_add(batch, s.toks[k], s.round_start + k, { seq_id }, is_last);
+                    std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd,
+                                s.slot_h[k].data(), row_bytes);
+                    if (is_last) last_i_batch[seq_id] = batch.n_tokens - 1;
+                }
+            }
+
+            const int rc = llama_decode(ctx_dft, batch);
+            if (rc != 0) {
+                LOG_WRN("%s: multi-head draft decode step=%d rc=%d\n", __func__, step, rc);
+                break;
+            }
+
+            // 3) sample next draft token per active seq; extend prefix + slot_h.
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (!st[seq_id].active) continue;
+                auto & s  = st[seq_id];
+                auto & dp = dparams[seq_id];
+                const int ib = last_i_batch[seq_id];
+
+                auto * smpl = smpls[seq_id].get();
+                common_sampler_sample(smpl, ctx_dft, ib, true);
+                const float * h_row = llama_get_embeddings_nextn_ith(ctx_dft, ib);
+                const auto  * cur_p = common_sampler_get_candidates(smpl, true);
+                const llama_token id = cur_p->data[0].id;
+
+                if (cur_p->data[0].p < params.p_min) {
+                    s.active = false; n_drafting--; continue;
+                }
+
+                common_sampler_accept(smpl, id, true);
+                dp.result->push_back(id);
+
+                if ((int) dp.result->size() >= params.n_max) {
+                    s.active = false; n_drafting--; continue;
+                }
+
+                // next slot's token + its embd (= this head's output at last slot).
+                // Its position is implicit: round_start + toks.size().
+                s.toks.push_back(id);
+                s.slot_h.emplace_back(h_row, h_row + n_embd);
+            }
+        }
+
+        llama_set_mtp_layer_offset(ctx_dft, 0); // restore default
+
+        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+            auto & dp = dparams[seq_id];
+            if (!dp.drafting) continue;
+            if (dp.result->size() < (size_t) params.n_min) {
+                dp.result->clear();
+            }
         }
     }
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -831,7 +831,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     //                   decode is skipped and all draft tokens reuse one position.
     //   chain_heads   : step35 — n_mtp_layers independently-trained heads run one
     //                   per step (mtp_layer_offset = k), each on its own KV.
-    //   neither       : single-block AR (qwen3.5/3.6) — one trained MTP head.
+    //   neither       : single-block AR (qwen35 / qwen35moe) — one trained MTP head.
     int32_t n_mtp_layers  = 1;
     bool    is_mem_shared = false;   // gemma4
     bool    chain_heads   = false;   // derived in the ctor: n_mtp_layers > 1 && !is_mem_shared
@@ -849,9 +849,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     std::vector<std::vector<float>> verify_h;
     std::vector<int32_t> verify_h_rows;
 
-    // Per-seq draft length from the last draft() call, used in accept() to
-    // roll back ctx_dft's recurrent state past the AR draft's redundant
-    // pre-advancement before process() mirrored the verify batch.
+    // Per-seq draft length from the single-head draft() path. Currently write-only
+    // (accept() rolls back via verify_h_rows); kept pending a follow-up cleanup.
     std::vector<uint16_t> last_n_drafted;
 
     common_speculative_impl_draft_mtp(const common_params_speculative & params, uint32_t n_seq)
@@ -865,7 +864,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         n_embd = llama_model_n_embd_out(llama_get_model(ctx_dft));
         GGML_ASSERT(n_embd == llama_model_n_embd(llama_get_model(ctx_tgt)) &&
                 "MTP input row width must match the target h_nextn width");
-        n_mtp_layers = std::max(1, (int) llama_model_n_nextn_layer(llama_get_model(ctx_dft)));
+        n_mtp_layers = std::max(1, (int) llama_model_n_layer_nextn(llama_get_model(ctx_dft)));
         // note: chain_heads / n_max clamp are derived below, once is_mem_shared is known.
 
         LOG_INF("%s: adding speculative implementation 'draft-mtp'\n", __func__);
@@ -1027,7 +1026,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 std::memcpy(batch.embd + (size_t) 1 * n_embd, h_tgt, row_bytes * (n_tokens-1));
             }
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (i_batch_beg[seq_id] < 0) continue;
+                if (i_batch_beg[seq_id] < 0) {
+                    continue;
+                }
                 std::memcpy(batch.embd + (size_t) i_batch_beg[seq_id] * n_embd,
                             pending_h[seq_id].data(), row_bytes);
             }
@@ -1036,15 +1037,17 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
             bool ok = true;
             for (int head = 0; head < n_mtp_layers; ++head) {
-                // chain_heads == false keeps the legacy single-decode path byte-for-byte
-                // (no seq_rm, no offset switch). When chaining, reset each sequence's
-                // own batch region first so this head re-decodes the whole batch into
-                // a clean, position-aligned slot set (find_slot is deterministic given
-                // identical v_cells). Lower bound = this batch's first pos for the seq
-                // (prompt-multi-ubatch safe).
+                // chain_heads == false (n_mtp_layers == 1) runs the loop once and
+                // skips seq_rm / offset — same observable decode as single-block.
+                // When chaining, reset each seq's batch region first so this head
+                // re-decodes into a clean, position-aligned slot set (find_slot
+                // stays deterministic). Lower bound = this batch's first pos for the
+                // seq (prompt-multi-ubatch safe).
                 if (chain_heads) {
                     for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                        if (i_batch_beg[seq_id] < 0) continue;
+                        if (i_batch_beg[seq_id] < 0) {
+                            continue;
+                        }
                         llama_memory_seq_rm(mem_dft, seq_id, batch_in.pos[i_batch_beg[seq_id]], -1);
                     }
                     llama_set_mtp_layer_offset(ctx_dft, head);
@@ -1240,7 +1243,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         int n_drafting = 0;
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
-            if (!dp.drafting) continue;
+            if (!dp.drafting) {
+                continue;
+            }
             common_sampler_reset(smpls[seq_id].get());
             st[seq_id].active      = true;
             st[seq_id].round_start = dp.n_past;
@@ -1248,14 +1253,18 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             st[seq_id].slot_h.push_back(pending_h[seq_id]); // slot 0 = trunk pending_h
             n_drafting++;
         }
-        if (n_drafting == 0) return;
+        if (n_drafting == 0) {
+            return;
+        }
 
         const int n_steps = n_mtp_layers; // one head per step, capped at head count
 
         for (int step = 0; step < n_steps && n_drafting > 0; ++step) {
             // 1) per-seq KV reset for this head + select the head's layer.
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (!st[seq_id].active) continue;
+                if (!st[seq_id].active) {
+                    continue;
+                }
                 llama_memory_seq_rm(mem_dft, seq_id, st[seq_id].round_start, -1);
             }
             llama_set_mtp_layer_offset(ctx_dft, step);
@@ -1264,7 +1273,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             common_batch_clear(batch);
             std::vector<int> last_i_batch(n_seq, -1);
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (!st[seq_id].active) continue;
+                if (!st[seq_id].active) {
+                    continue;
+                }
                 auto & s = st[seq_id];
                 const int len = (int) s.toks.size();
                 for (int k = 0; k < len; ++k) {
@@ -1284,7 +1295,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
             // 3) sample next draft token per active seq; extend prefix + slot_h.
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (!st[seq_id].active) continue;
+                if (!st[seq_id].active) {
+                    continue;
+                }
                 auto & s  = st[seq_id];
                 auto & dp = dparams[seq_id];
                 const int ib = last_i_batch[seq_id];
@@ -1296,14 +1309,18 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 const llama_token id = cur_p->data[0].id;
 
                 if (cur_p->data[0].p < params.p_min) {
-                    s.active = false; n_drafting--; continue;
+                    s.active = false;
+                    n_drafting--;
+                    continue;
                 }
 
                 common_sampler_accept(smpl, id, true);
                 dp.result->push_back(id);
 
                 if ((int) dp.result->size() >= params.n_max) {
-                    s.active = false; n_drafting--; continue;
+                    s.active = false;
+                    n_drafting--;
+                    continue;
                 }
 
                 // next slot's token + its embd (= this head's output at last slot).
@@ -1317,7 +1334,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
-            if (!dp.drafting) continue;
+            if (!dp.drafting) {
+                continue;
+            }
             if (dp.result->size() < (size_t) params.n_min) {
                 dp.result->clear();
             }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -846,6 +846,9 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     std::vector<std::vector<float>> verify_h;
     std::vector<int32_t> verify_h_rows;
 
+    std::vector<int>                i_last;
+    std::vector<std::vector<float>> chain_h;
+
     common_speculative_impl_draft_mtp(const common_params_speculative & params, uint32_t n_seq)
         : common_speculative_impl(COMMON_SPECULATIVE_TYPE_DRAFT_MTP, n_seq)
         , params(params.draft)
@@ -908,10 +911,16 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         if (chain_heads) {
             this->params.n_max = std::min(this->params.n_max, n_mtp_layers);
+            
+            chain_h.assign(n_seq, {});
+            for (auto & c : chain_h) {
+                c.reserve((size_t) (this->params.n_max + 1) * n_embd);
+            }
         }
 
         pending_h.assign(n_seq, std::vector<float>(n_embd, 0.0f));
 
+        i_last.assign(n_seq, -1);
         i_batch_beg.assign(n_seq, -1);
         i_batch_end.assign(n_seq, -1);
 
@@ -1027,6 +1036,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             bool ok = true;
             for (int head = 0; head < n_mtp_layers; ++head) {
                 if (chain_heads) {
+                    // ref: https://github.com/ggml-org/llama.cpp/pull/24340/changes#r3413498544
                     for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
                         if (i_batch_beg[seq_id] < 0) {
                             continue;
@@ -1085,13 +1095,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
 
-        std::vector<int> i_last(n_seq, -1);
-
-        std::vector<std::vector<float>> chain_h;
-        if (chain_heads) {
-            chain_h.resize(n_seq);
-        }
-
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
 
@@ -1116,9 +1119,12 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         int i = 0;
 
         while (n_drafting > 0) {
-            // chained heads: every trained head keeps its own KV, so reset each
-            // sequence's draft region and select head `i` before re-decoding the
-            // rebuilt prefix (head 0 sees just id_last).
+            // each step decodes under a different head, i.e. a different decoder layer, and
+            // KV is per layer. process() filled this layer's KV only for positions < n_past
+            // (prompt + accepted prefix) — nothing in the draft region yet. so reset the
+            // draft region (the seq_rm lower bound is n_past, leaving the prompt KV intact)
+            // and select head i so it rebuilds its own layer's KV there; decoding just the
+            // latest token would leave its attention reading cells only another head wrote.
             if (chain_heads) {
                 auto * mem_dft = llama_get_memory(ctx_dft);
                 for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
@@ -1837,7 +1843,7 @@ common_speculative * common_speculative_init(common_params_speculative & params,
 
         bool has_draft_simple = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE));
         bool has_draft_eagle3 = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3)) && params.draft.ctx_dft != nullptr;
-        bool has_mtp = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DRAFT_MTP)) && params.draft.ctx_dft != nullptr;
+        bool has_draft_mtp    = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DRAFT_MTP))    && params.draft.ctx_dft != nullptr;
 
 
 
@@ -1875,7 +1881,7 @@ common_speculative * common_speculative_init(common_params_speculative & params,
         if (has_draft_eagle3) {
             configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3, params));
         }
-        if (has_mtp) {
+        if (has_draft_mtp) {
             configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DRAFT_MTP, params));
         }
     }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1083,10 +1083,14 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         int n_drafting = 0;
         std::vector<bool> drafting(n_seq);
 
-        const float * h_row = nullptr;
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
 
         std::vector<int> i_last(n_seq, -1);
+
+        std::vector<std::vector<float>> chain_h;
+        if (chain_heads) {
+            chain_h.resize(n_seq);
+        }
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
@@ -1100,19 +1104,21 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             common_sampler_reset(smpls[seq_id].get());
 
             common_batch_add(batch, dp.id_last, dp.n_past, { seq_id }, true);
-
-            h_row = pending_h[seq_id].data();
-            std::memcpy(batch.embd + n_embd*(batch.n_tokens - 1), h_row, row_bytes);
+            std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, pending_h[seq_id].data(), row_bytes);
 
             i_last[seq_id] = batch.n_tokens - 1;
+
+            if (chain_heads) {
+                chain_h[seq_id].assign(pending_h[seq_id].begin(), pending_h[seq_id].end());
+            }
         }
 
         int i = 0;
 
         while (n_drafting > 0) {
-            // chained heads: every trained head keeps its own KV, so reset
-            // each sequence's draft region and select head `i` before re-decoding the
-            // accumulated prefix.
+            // chained heads: every trained head keeps its own KV, so reset each
+            // sequence's draft region and select head `i` before re-decoding the
+            // rebuilt prefix (head 0 sees just id_last).
             if (chain_heads) {
                 auto * mem_dft = llama_get_memory(ctx_dft);
                 for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
@@ -1129,11 +1135,10 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 break;
             }
 
-            // the growing-KV paths rebuild the batch with only the new tokens (the KV
-            // already holds the prefix); chained heads keep accumulating into it
-            if (!chain_heads) {
-                common_batch_clear(batch);
-            }
+            // rebuild the batch for the next step: the growing-KV paths re-add only the
+            // new token (the KV already holds the prefix), while chained heads re-add the
+            // whole prefix at the next head. dropped sequences are simply not re-added.
+            common_batch_clear(batch);
 
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
                 if (!drafting[seq_id]) {
@@ -1143,7 +1148,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 auto * smpl = smpls[seq_id].get();
 
                 common_sampler_sample(smpl, ctx_dft, i_last[seq_id], true);
-                h_row = llama_get_embeddings_nextn_ith(ctx_dft, i_last[seq_id]);
+                const float * h_row = llama_get_embeddings_nextn_ith(ctx_dft, i_last[seq_id]);
 
                 const auto * cur_p = common_sampler_get_candidates(smpl, true);
 
@@ -1178,17 +1183,24 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 }
 
                 if (chain_heads) {
-                    batch.logits[i_last[seq_id]] = false;
-                }
+                    chain_h[seq_id].insert(chain_h[seq_id].end(), h_row, h_row + n_embd);
 
-                if (is_mem_shared) {
+                    const int n_rows = (int) result.size() + 1; // id_last + tokens drafted so far
+                    for (int t = 0; t < n_rows; ++t) {
+                        const llama_token tok = (t == 0) ? dp.id_last : result[t - 1];
+                        common_batch_add(batch, tok, dp.n_past + t, { seq_id }, t == n_rows - 1);
+                        std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd,
+                                    chain_h[seq_id].data() + (size_t) t * n_embd, row_bytes);
+                    }
+                } else if (is_mem_shared) {
                     // note: with shared memory (e.g. Gemma4 assistants) we use the same position for all draft tokens
                     // ref: https://github.com/huggingface/transformers/blob/effde20942e3f82a1b97449f60b3a48c5ff96145/docs/source/en/model_doc/gemma4_assistant.md?plain=1#L36-L37
                     common_batch_add(batch, id, dp.n_past, { seq_id }, true);
+                    std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, h_row, row_bytes);
                 } else {
                     common_batch_add(batch, id, dp.n_past + i + 1, { seq_id }, true);
+                    std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, h_row, row_bytes);
                 }
-                std::memcpy(batch.embd + n_embd*(batch.n_tokens - 1), h_row, row_bytes);
 
                 i_last[seq_id] = batch.n_tokens - 1;
             }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -846,11 +846,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     std::vector<std::vector<float>> verify_h;
     std::vector<int32_t> verify_h_rows;
 
-    // Per-seq draft length from the last draft() call, used in accept() to
-    // roll back ctx_dft's recurrent state past the AR draft's redundant
-    // pre-advancement before process() mirrored the verify batch.
-    std::vector<uint16_t> last_n_drafted;
-
     common_speculative_impl_draft_mtp(const common_params_speculative & params, uint32_t n_seq)
         : common_speculative_impl(COMMON_SPECULATIVE_TYPE_DRAFT_MTP, n_seq)
         , params(params.draft)
@@ -925,8 +920,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         verify_h.assign(n_seq, {});
         verify_h_rows.assign(n_seq, 0);
-
-        last_n_drafted.assign(n_seq, 0);
     }
 
     ~common_speculative_impl_draft_mtp() override {
@@ -1093,11 +1086,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     void draft(common_speculative_draft_params_vec & dparams) override {
         auto & ctx_dft = params.ctx_dft;
 
-        if (chain_heads) {
-            draft_multi_head(dparams);
-            return;
-        }
-
         common_batch_clear(batch);
 
         // keep track of which sequences are still drafting
@@ -1106,6 +1094,11 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         const float * h_row = nullptr;
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
+
+        // chained heads accumulate the prefix into the batch across draft
+        // steps instead of rebuilding it, so each sequence samples from its last
+        // appended slot; i_last tracks that slot.
+        std::vector<int> i_last(n_seq, -1);
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
@@ -1122,20 +1115,38 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
             h_row = pending_h[seq_id].data();
             std::memcpy(batch.embd + n_embd*(batch.n_tokens - 1), h_row, row_bytes);
-        }
 
-        int ret = llama_decode(ctx_dft, batch);
-        if (ret != 0) {
-            LOG_WRN("%s: llama_decode returned %d\n", __func__, ret);
-            return;
+            i_last[seq_id] = batch.n_tokens - 1;
         }
 
         int i = 0;
 
         while (n_drafting > 0) {
-            int i_batch = 0;
+            // chained heads: every trained head keeps its own KV, so reset
+            // each sequence's draft region and select head `i` before re-decoding the
+            // accumulated prefix (head 0 sees just id_last). the single-head (qwen)
+            // and mem-shared (gemma4) paths leave their growing KV untouched.
+            if (chain_heads) {
+                auto * mem_dft = llama_get_memory(ctx_dft);
+                for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                    if (drafting[seq_id]) {
+                        llama_memory_seq_rm(mem_dft, seq_id, dparams[seq_id].n_past, -1);
+                    }
+                }
+                llama_set_mtp_layer_offset(ctx_dft, i);
+            }
 
-            common_batch_clear(batch);
+            int ret = llama_decode(ctx_dft, batch);
+            if (ret != 0) {
+                LOG_WRN("%s: llama_decode[%d] returned %d\n", __func__, i, ret);
+                break;
+            }
+
+            // the growing-KV paths rebuild the batch with only the new tokens (the KV
+            // already holds the prefix); chained heads keep accumulating into it
+            if (!chain_heads) {
+                common_batch_clear(batch);
+            }
 
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
                 if (!drafting[seq_id]) {
@@ -1144,9 +1155,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 auto * smpl = smpls[seq_id].get();
 
-                common_sampler_sample(smpl, ctx_dft, i_batch, true);
-                h_row = llama_get_embeddings_nextn_ith(ctx_dft, i_batch);
-                ++i_batch;
+                common_sampler_sample(smpl, ctx_dft, i_last[seq_id], true);
+                h_row = llama_get_embeddings_nextn_ith(ctx_dft, i_last[seq_id]);
 
                 const auto * cur_p = common_sampler_get_candidates(smpl, true);
 
@@ -1180,6 +1190,12 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                     continue;
                 }
 
+                // chained heads: only the newly appended slot keeps its logits, so the
+                // slot we just sampled stops producing an output on the next head
+                if (chain_heads) {
+                    batch.logits[i_last[seq_id]] = false;
+                }
+
                 if (is_mem_shared) {
                     // note: with shared memory (e.g. Gemma4 assistants) we use the same position for all draft tokens
                     // ref: https://github.com/huggingface/transformers/blob/effde20942e3f82a1b97449f60b3a48c5ff96145/docs/source/en/model_doc/gemma4_assistant.md?plain=1#L36-L37
@@ -1188,154 +1204,27 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                     common_batch_add(batch, id, dp.n_past + i + 1, { seq_id }, true);
                 }
                 std::memcpy(batch.embd + n_embd*(batch.n_tokens - 1), h_row, row_bytes);
+
+                i_last[seq_id] = batch.n_tokens - 1;
             }
 
             if (batch.n_tokens == 0) {
                 break;
             }
 
-            // evaluate the drafted tokens on the draft model
-            ret = llama_decode(ctx_dft, batch);
-            if (ret != 0) {
-                LOG_WRN("%s: llama_decode[%d] returned %d\n", __func__, i, ret);
-                break;
-            }
-
             ++i;
         }
 
+        if (chain_heads) {
+            llama_set_mtp_layer_offset(ctx_dft, 0); // restore default for non-draft decodes
+        }
+
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
             if (!dp.drafting) {
                 continue;
             }
 
-            if (dp.result->size() < (size_t) params.n_min) {
-                dp.result->clear();
-            }
-
-            last_n_drafted[seq_id] = (uint16_t) dp.result->size();
-        }
-    }
-
-    // Multi-head MTP draft: chain heads 0..n_mtp_layers-1. Step s runs head s on
-    // the accumulated prefix [id_last, draft_1, .., draft_s] and samples draft_{s+1}.
-    // Each slot's embd is the hidden produced by the PREVIOUS head for that token
-    // (slot 0 is always pending_h = trunk h). Per-step seq_rm keeps each head's KV
-    // on a clean, position-aligned slot set.
-    void draft_multi_head(common_speculative_draft_params_vec & dparams) {
-        auto * ctx_dft = params.ctx_dft;
-        auto * mem_dft = llama_get_memory(ctx_dft);
-        const size_t row_bytes = (size_t) n_embd * sizeof(float);
-
-        // Per-seq accumulated draft state. Positions are implicit: slot k always
-        // sits at round_start + k (the prefix is contiguous from id_last), so we
-        // don't store a parallel positions vector.
-        struct seq_state {
-            bool active = false;
-            llama_pos round_start = 0;                 // pos of id_last (slot 0)
-            std::vector<llama_token> toks;             // [id_last, draft_1, ...]
-            std::vector<std::vector<float>> slot_h;    // embd per slot (toks[k] <-> slot_h[k])
-        };
-        std::vector<seq_state> st(n_seq);
-
-        int n_drafting = 0;
-        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-            auto & dp = dparams[seq_id];
-            if (!dp.drafting) {
-                continue;
-            }
-            common_sampler_reset(smpls[seq_id].get());
-            st[seq_id].active      = true;
-            st[seq_id].round_start = dp.n_past;
-            st[seq_id].toks.push_back(dp.id_last);
-            st[seq_id].slot_h.push_back(pending_h[seq_id]); // slot 0 = trunk pending_h
-            n_drafting++;
-        }
-        if (n_drafting == 0) {
-            return;
-        }
-
-        const int n_steps = n_mtp_layers; // one head per step, capped at head count
-
-        for (int step = 0; step < n_steps && n_drafting > 0; ++step) {
-            // 1) per-seq KV reset for this head + select the head's layer.
-            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (!st[seq_id].active) {
-                    continue;
-                }
-                llama_memory_seq_rm(mem_dft, seq_id, st[seq_id].round_start, -1);
-            }
-            llama_set_mtp_layer_offset(ctx_dft, step);
-
-            // 2) build accumulated batch; logits only on each seq's last slot.
-            common_batch_clear(batch);
-            std::vector<int> last_i_batch(n_seq, -1);
-            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (!st[seq_id].active) {
-                    continue;
-                }
-                auto & s = st[seq_id];
-                const int len = (int) s.toks.size();
-                for (int k = 0; k < len; ++k) {
-                    const bool is_last = (k == len - 1);
-                    common_batch_add(batch, s.toks[k], s.round_start + k, { seq_id }, is_last);
-                    std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd,
-                                s.slot_h[k].data(), row_bytes);
-                    if (is_last) last_i_batch[seq_id] = batch.n_tokens - 1;
-                }
-            }
-
-            const int rc = llama_decode(ctx_dft, batch);
-            if (rc != 0) {
-                LOG_WRN("%s: multi-head draft decode step=%d rc=%d\n", __func__, step, rc);
-                break;
-            }
-
-            // 3) sample next draft token per active seq; extend prefix + slot_h.
-            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-                if (!st[seq_id].active) {
-                    continue;
-                }
-                auto & s  = st[seq_id];
-                auto & dp = dparams[seq_id];
-                const int ib = last_i_batch[seq_id];
-
-                auto * smpl = smpls[seq_id].get();
-                common_sampler_sample(smpl, ctx_dft, ib, true);
-                const float * h_row = llama_get_embeddings_nextn_ith(ctx_dft, ib);
-                const auto  * cur_p = common_sampler_get_candidates(smpl, true);
-                const llama_token id = cur_p->data[0].id;
-
-                if (cur_p->data[0].p < params.p_min) {
-                    s.active = false;
-                    n_drafting--;
-                    continue;
-                }
-
-                common_sampler_accept(smpl, id, true);
-                dp.result->push_back(id);
-
-                if ((int) dp.result->size() >= params.n_max) {
-                    s.active = false;
-                    n_drafting--;
-                    continue;
-                }
-
-                // next slot's token + its embd (= this head's output at last slot).
-                // Its position is implicit: round_start + toks.size().
-                s.toks.push_back(id);
-                s.slot_h.emplace_back(h_row, h_row + n_embd);
-            }
-        }
-
-        llama_set_mtp_layer_offset(ctx_dft, 0); // restore default
-
-        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
-            auto & dp = dparams[seq_id];
-            if (!dp.drafting) {
-                continue;
-            }
             if (dp.result->size() < (size_t) params.n_min) {
                 dp.result->clear();
             }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -907,8 +907,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
 
         // step35-style chaining uses each trained head exactly once per draft
-        // round, so the draft length is capped at the number of heads. Mem-shared
-        // archs (gemma4) run every head in one graph, so this clamp does not apply.
+        // round, so the draft length is capped at the number of heads
         if (chain_heads) {
             this->params.n_max = std::min(this->params.n_max, n_mtp_layers);
         }
@@ -1029,12 +1028,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
             bool ok = true;
             for (int head = 0; head < n_mtp_layers; ++head) {
-                // chain_heads == false (n_mtp_layers == 1) runs the loop once and
-                // skips seq_rm / offset — same observable decode as single-block.
-                // When chaining, reset each seq's batch region first so this head
-                // re-decodes into a clean, position-aligned slot set (find_slot
-                // stays deterministic). Lower bound = this batch's first pos for the
-                // seq (prompt-multi-ubatch safe).
                 if (chain_heads) {
                     for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
                         if (i_batch_beg[seq_id] < 0) {
@@ -1095,9 +1088,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         const float * h_row = nullptr;
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
 
-        // chained heads accumulate the prefix into the batch across draft
-        // steps instead of rebuilding it, so each sequence samples from its last
-        // appended slot; i_last tracks that slot.
         std::vector<int> i_last(n_seq, -1);
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
@@ -1124,8 +1114,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         while (n_drafting > 0) {
             // chained heads: every trained head keeps its own KV, so reset
             // each sequence's draft region and select head `i` before re-decoding the
-            // accumulated prefix (head 0 sees just id_last). the single-head (qwen)
-            // and mem-shared (gemma4) paths leave their growing KV untouched.
+            // accumulated prefix.
             if (chain_heads) {
                 auto * mem_dft = llama_get_memory(ctx_dft);
                 for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -906,8 +906,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
         chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
 
-        // step35-style chaining uses each trained head exactly once per draft
-        // round, so the draft length is capped at the number of heads
         if (chain_heads) {
             this->params.n_max = std::min(this->params.n_max, n_mtp_layers);
         }
@@ -1179,8 +1177,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                     continue;
                 }
 
-                // chained heads: only the newly appended slot keeps its logits, so the
-                // slot we just sampled stops producing an output on the next head
                 if (chain_heads) {
                     batch.logits[i_last[seq_id]] = false;
                 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1189,6 +1189,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 }
 
                 if (chain_heads) {
+                    // ref: https://github.com/ggml-org/llama.cpp/pull/24340#discussion_r3448031546
                     chain_h[seq_id].insert(chain_h[seq_id].end(), h_row, h_row + n_embd);
 
                     const int n_rows = (int) result.size() + 1; // id_last + tokens drafted so far

--- a/include/llama.h
+++ b/include/llama.h
@@ -558,16 +558,15 @@ extern "C" {
     LLAMA_API const struct llama_vocab * llama_model_get_vocab(const struct llama_model * model);
     LLAMA_API enum llama_rope_type       llama_model_rope_type(const struct llama_model * model);
 
-    LLAMA_API int32_t llama_model_n_ctx_train(const struct llama_model * model);
-    LLAMA_API int32_t llama_model_n_embd     (const struct llama_model * model);
-    LLAMA_API int32_t llama_model_n_embd_inp (const struct llama_model * model);
-    LLAMA_API int32_t llama_model_n_embd_out (const struct llama_model * model);
-    LLAMA_API int32_t llama_model_n_layer    (const struct llama_model * model);
-    // Number of appended NextN/MTP prediction blocks (0 if the model has none)
+    LLAMA_API int32_t llama_model_n_ctx_train  (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_embd       (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_embd_inp   (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_embd_out   (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_layer      (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_layer_nextn(const struct llama_model * model);
-    LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
-    LLAMA_API int32_t llama_model_n_head_kv  (const struct llama_model * model);
-    LLAMA_API int32_t llama_model_n_swa      (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_head       (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_head_kv    (const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_swa        (const struct llama_model * model);
 
     // Get the model's RoPE frequency scaling factor
     LLAMA_API float llama_model_rope_freq_scale_train(const struct llama_model * model);

--- a/include/llama.h
+++ b/include/llama.h
@@ -564,7 +564,7 @@ extern "C" {
     LLAMA_API int32_t llama_model_n_embd_out (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_layer    (const struct llama_model * model);
     // Number of appended NextN/MTP prediction blocks (0 if the model has none)
-    LLAMA_API int32_t llama_model_n_nextn_layer(const struct llama_model * model);
+    LLAMA_API int32_t llama_model_n_layer_nextn(const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head_kv  (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_swa      (const struct llama_model * model);

--- a/include/llama.h
+++ b/include/llama.h
@@ -563,6 +563,8 @@ extern "C" {
     LLAMA_API int32_t llama_model_n_embd_inp (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_embd_out (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_layer    (const struct llama_model * model);
+    // Number of appended NextN/MTP prediction blocks (0 if the model has none)
+    LLAMA_API int32_t llama_model_n_nextn_layer(const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head     (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_head_kv  (const struct llama_model * model);
     LLAMA_API int32_t llama_model_n_swa      (const struct llama_model * model);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1156,8 +1156,8 @@ void llama_context::set_embeddings_layer_inp(uint32_t lid, bool enable) {
     sched_need_reserve = true;
 }
 
-void llama_context::set_mtp_layer_offset(int32_t offset) {
-    cparams.mtp_layer_offset = offset;
+void llama_context::set_nextn_layer_offset(int32_t offset) {
+    cparams.nextn_layer_offset = offset;
 }
 
 void llama_context::set_causal_attn(bool value) {
@@ -3703,8 +3703,8 @@ void llama_set_embeddings_layer_inp(llama_context * ctx, uint32_t lid, bool valu
     ctx->set_embeddings_layer_inp(lid, value);
 }
 
-void llama_set_mtp_layer_offset(llama_context * ctx, int32_t offset) {
-    ctx->set_mtp_layer_offset(offset);
+void llama_set_nextn_layer_offset(llama_context * ctx, int32_t offset) {
+    ctx->set_nextn_layer_offset(offset);
 }
 
 llama_memory_t llama_get_memory(const struct llama_context * ctx) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1156,6 +1156,10 @@ void llama_context::set_embeddings_layer_inp(uint32_t lid, bool enable) {
     sched_need_reserve = true;
 }
 
+void llama_context::set_mtp_layer_offset(int32_t offset) {
+    cparams.mtp_layer_offset = offset;
+}
+
 void llama_context::set_causal_attn(bool value) {
     LLAMA_LOG_DEBUG("%s: value = %d\n", __func__, value);
 
@@ -3697,6 +3701,10 @@ void llama_set_embeddings_nextn(llama_context * ctx, bool value, bool masked) {
 
 void llama_set_embeddings_layer_inp(llama_context * ctx, uint32_t lid, bool value) {
     ctx->set_embeddings_layer_inp(lid, value);
+}
+
+void llama_set_mtp_layer_offset(llama_context * ctx, int32_t offset) {
+    ctx->set_mtp_layer_offset(offset);
 }
 
 llama_memory_t llama_get_memory(const struct llama_context * ctx) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -115,7 +115,7 @@ struct llama_context {
     void set_embeddings (bool value);
     void set_embeddings_nextn(bool value, bool masked);
     void set_embeddings_layer_inp(uint32_t lid, bool enable);
-    void set_mtp_layer_offset(int32_t offset);
+    void set_nextn_layer_offset(int32_t offset);
     void set_causal_attn(bool value);
     void set_warmup(bool value);
 

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -115,6 +115,7 @@ struct llama_context {
     void set_embeddings (bool value);
     void set_embeddings_nextn(bool value, bool masked);
     void set_embeddings_layer_inp(uint32_t lid, bool enable);
+    void set_mtp_layer_offset(int32_t offset);
     void set_causal_attn(bool value);
     void set_warmup(bool value);
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -18,6 +18,11 @@ struct llama_cparams {
     int32_t  n_threads;       // number of threads to use for generation
     int32_t  n_threads_batch; // number of threads to use for batch processing
 
+    // MTP (multi-token prediction): which appended NextN/MTP block the
+    // DECODER_MTP graph runs, as an offset past the trunk (il = n_layer() + offset).
+    // 0 selects the first MTP head; the speculative driver bumps it per draft step.
+    int32_t  mtp_layer_offset = 0;
+
     float rope_freq_base;
     float rope_freq_scale;
 
@@ -33,11 +38,6 @@ struct llama_cparams {
     bool embeddings_nextn;        // also extract the hidden state before the final output norm
     bool embeddings_nextn_masked; // extract for only rows where batch.logits != 0
     bool causal_attn;
-
-    // MTP (multi-token prediction): which appended NextN/MTP block the
-    // DECODER_MTP graph runs, as an offset past the trunk (il = n_layer() + offset).
-    // 0 selects the first MTP head; the speculative driver bumps it per draft step.
-    int32_t mtp_layer_offset = 0;
     bool offload_kqv;
     bool flash_attn;
     bool auto_fa;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -33,6 +33,11 @@ struct llama_cparams {
     bool embeddings_nextn;        // also extract the hidden state before the final output norm
     bool embeddings_nextn_masked; // extract for only rows where batch.logits != 0
     bool causal_attn;
+
+    // MTP (multi-token prediction): which appended NextN/MTP block the
+    // DECODER_MTP graph runs, as an offset past the trunk (il = n_layer() + offset).
+    // 0 selects the first MTP head; the speculative driver bumps it per draft step.
+    int32_t mtp_layer_offset = 0;
     bool offload_kqv;
     bool flash_attn;
     bool auto_fa;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -18,10 +18,7 @@ struct llama_cparams {
     int32_t  n_threads;       // number of threads to use for generation
     int32_t  n_threads_batch; // number of threads to use for batch processing
 
-    // MTP (multi-token prediction): which appended NextN/MTP block the
-    // DECODER_MTP graph runs, as an offset past the trunk (il = n_layer() + offset).
-    // 0 selects the first MTP head; the speculative driver bumps it per draft step.
-    int32_t  mtp_layer_offset = 0;
+    int32_t  nextn_layer_offset = 0;
 
     float rope_freq_base;
     float rope_freq_scale;

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -95,6 +95,11 @@ LLAMA_API llama_memory_breakdown llama_get_memory_breakdown(const struct llama_c
 // If masked == false, output the embeddings for all tokens in the batch regardless of batch.logits
 LLAMA_API void llama_set_embeddings_nextn(struct llama_context * ctx, bool value, bool masked);
 
+// Select which appended NextN/MTP block the DECODER_MTP graph runs (offset past
+// the trunk: il = n_layer() + offset). Used by the speculative MTP driver to
+// chain multiple trained MTP heads. Default 0 (first head).
+LLAMA_API void llama_set_mtp_layer_offset(struct llama_context * ctx, int32_t offset);
+
 // mirrors:
 // LLAMA_API float * llama_get_embeddings(struct llama_context * ctx);
 LLAMA_API float * llama_get_embeddings_nextn(struct llama_context * ctx);

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -95,10 +95,10 @@ LLAMA_API llama_memory_breakdown llama_get_memory_breakdown(const struct llama_c
 // If masked == false, output the embeddings for all tokens in the batch regardless of batch.logits
 LLAMA_API void llama_set_embeddings_nextn(struct llama_context * ctx, bool value, bool masked);
 
-// Select which appended NextN/MTP block the DECODER_MTP graph runs (offset past
-// the trunk: il = n_layer() + offset). Used by the speculative MTP driver to
-// chain multiple trained MTP heads. Default 0 (first head).
-LLAMA_API void llama_set_mtp_layer_offset(struct llama_context * ctx, int32_t offset);
+// Select which appended NextN block the DECODER_MTP graph runs (offset past
+// the trunk: il = n_layer() + offset). Used by the speculative NextN driver to
+// chain multiple trained NextN heads. Default 0 (first head).
+LLAMA_API void llama_set_nextn_layer_offset(struct llama_context * ctx, int32_t offset);
 
 // mirrors:
 // LLAMA_API float * llama_get_embeddings(struct llama_context * ctx);

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -682,11 +682,15 @@ struct llm_graph_params {
             }
         }
 
+        // TODO: https://github.com/ggml-org/llama.cpp/pull/24340#discussion_r3448035248
+        if (cparams.nextn_layer_offset != other.cparams.nextn_layer_offset) {
+            return false;
+        }
+
         return
             cparams.embeddings              == other.cparams.embeddings              &&
             cparams.embeddings_nextn        == other.cparams.embeddings_nextn        &&
             cparams.embeddings_nextn_masked == other.cparams.embeddings_nextn_masked &&
-            cparams.nextn_layer_offset      == other.cparams.nextn_layer_offset      &&
             cparams.causal_attn             == other.cparams.causal_attn             &&
             arch  == other.arch  &&
             gtype == other.gtype &&

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -686,7 +686,7 @@ struct llm_graph_params {
             cparams.embeddings              == other.cparams.embeddings              &&
             cparams.embeddings_nextn        == other.cparams.embeddings_nextn        &&
             cparams.embeddings_nextn_masked == other.cparams.embeddings_nextn_masked &&
-            cparams.mtp_layer_offset        == other.cparams.mtp_layer_offset        &&
+            cparams.nextn_layer_offset      == other.cparams.nextn_layer_offset      &&
             cparams.causal_attn             == other.cparams.causal_attn             &&
             arch  == other.arch  &&
             gtype == other.gtype &&

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -683,8 +683,11 @@ struct llm_graph_params {
         }
 
         return
-            cparams.embeddings  == other.cparams.embeddings  &&
-            cparams.causal_attn == other.cparams.causal_attn &&
+            cparams.embeddings              == other.cparams.embeddings              &&
+            cparams.embeddings_nextn        == other.cparams.embeddings_nextn        &&
+            cparams.embeddings_nextn_masked == other.cparams.embeddings_nextn_masked &&
+            cparams.mtp_layer_offset        == other.cparams.mtp_layer_offset        &&
+            cparams.causal_attn             == other.cparams.causal_attn             &&
             arch  == other.arch  &&
             gtype == other.gtype &&
             cvec  == other.cvec  &&

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2312,6 +2312,10 @@ int32_t llama_model_n_layer(const llama_model * model) {
     return model->hparams.n_layer();
 }
 
+int32_t llama_model_n_nextn_layer(const llama_model * model) {
+    return model->hparams.n_layer_nextn;
+}
+
 int32_t llama_model_n_head(const llama_model * model) {
     return model->hparams.n_head();
 }

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2312,7 +2312,7 @@ int32_t llama_model_n_layer(const llama_model * model) {
     return model->hparams.n_layer();
 }
 
-int32_t llama_model_n_nextn_layer(const llama_model * model) {
+int32_t llama_model_n_layer_nextn(const llama_model * model) {
     return model->hparams.n_layer_nextn;
 }
 

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -536,9 +536,6 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     // n_outputs rows of t_h_nextn, so the output slots must come first. Without it
     // a multi-head draft (step >= 1, output slot != row 0) extracts the wrong row.
     // Identity when n_outputs == n_tokens, so the single-head path is unchanged.
-    // The MTP graph is always run masked; assert it so this stays valid.
-    GGML_ASSERT(cparams.embeddings_nextn_masked &&
-                "STEP35 MTP graph requires masked nextn extraction");
     ggml_tensor * inp_out_ids = build_inp_out_ids();
     cur = ggml_get_rows(ctx0, cur, inp_out_ids);
 

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -532,6 +532,13 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     cur = ggml_add(ctx0, cur, ffn_inp);
     cb(cur, "mtp_post_ffn", il);
 
+    // Gather t_h_nextn/t_logits to the n_outputs rows, like the trunk graph: the
+    // context and backend sampling assume an inp_out_ids gather. Without it a draft
+    // batch whose output slot isn't row 0 (multi-head chain, step>=1) reads the wrong
+    // row. Identity gather when n_outputs==n_tokens, so the single-head path is unchanged.
+    ggml_tensor * inp_out_ids = build_inp_out_ids();
+    cur = ggml_get_rows(ctx0, cur, inp_out_ids);
+
     // Pre-norm hidden state: used by the AR draft loop to seed the next MTP step.
     cb(cur, "h_nextn", -1);
     res->t_h_nextn = cur;

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -112,7 +112,7 @@ void llama_model_step35::load_arch_tensors(llama_model_loader & ml) {
         layer.ffn_down_shexp = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), {hparams.n_ff_shexp, n_embd}, TENSOR_NOT_REQUIRED);
     };
 
-    auto load_block_mtp = [&](int i, bool is_first_mtp) {
+    auto load_block_mtp = [&](int i) {
         auto & layer = layers[i];
 
         const uint32_t n_head_l      = hparams.n_head(i);
@@ -121,15 +121,12 @@ void llama_model_step35::load_arch_tensors(llama_model_loader & ml) {
 
         // The MTP block is a full Step3p5 decoder layer (mtp_block) plus the
         // NextN-specific wiring (enorm/hnorm/eh_proj + optional shared head).
-        // `mtp_flags` becomes NOT_REQUIRED when the GGUF is trunk-only.
-        //
-        // Only the FIRST MTP block (i == n_main) is required for the
-        // single-block MTP runtime; trailing MTP blocks are always tolerated
-        // as missing so pruned GGUFs (block 0 only) load cleanly. Override
-        // mtp_flags to NOT_REQUIRED for those.
-        const int eff_mtp_flags = is_first_mtp ? mtp_flags : (mtp_flags | TENSOR_NOT_REQUIRED);
+        // Multi-block MTP: every declared MTP block is required (the draft chain
+        // runs all n_layer_nextn heads), so each block uses the captured
+        // `mtp_flags` directly — already NOT_REQUIRED for a trunk-only GGUF,
+        // which keeps that path correct.
 
-        layer.attn_norm   = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, eff_mtp_flags);
+        layer.attn_norm   = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, mtp_flags);
         layer.attn_q_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), {n_embd_head_k}, TENSOR_NOT_REQUIRED);
         layer.attn_k_norm = create_tensor(tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), {n_embd_head_k}, TENSOR_NOT_REQUIRED);
 
@@ -140,12 +137,12 @@ void llama_model_step35::load_arch_tensors(llama_model_loader & ml) {
             layer.rope_freqs = create_tensor(tn(LLM_TENSOR_ROPE_FREQS, "weight", i), {n_rot_max/2}, TENSOR_NOT_REQUIRED | TENSOR_DUPLICATED);
         }
 
-        create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head_l, n_embd_k_gqa, n_embd_v_gqa, eff_mtp_flags);
-        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_v * n_head_l, n_embd}, eff_mtp_flags);
+        create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head_l, n_embd_k_gqa, n_embd_v_gqa, mtp_flags);
+        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_embd_head_v * n_head_l, n_embd}, mtp_flags);
 
         layer.wqkv_gate = create_tensor(tn(LLM_TENSOR_ATTN_GATE, "weight", i), {n_embd, n_head_l}, TENSOR_NOT_REQUIRED);
 
-        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, eff_mtp_flags);
+        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, mtp_flags);
 
         // dense MLP (leading dense blocks) — present if the MTP block isn't MoE
         layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, TENSOR_NOT_REQUIRED);
@@ -165,9 +162,9 @@ void llama_model_step35::load_arch_tensors(llama_model_loader & ml) {
         layer.ffn_down_shexp = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), {hparams.n_ff_shexp, n_embd}, TENSOR_NOT_REQUIRED);
 
         // NextN-specific tensors that define the MTP block.
-        layer.nextn.eh_proj          = create_tensor(tn(LLM_TENSOR_NEXTN_EH_PROJ,          "weight", i), { 2 * n_embd, n_embd }, eff_mtp_flags);
-        layer.nextn.enorm            = create_tensor(tn(LLM_TENSOR_NEXTN_ENORM,            "weight", i), { n_embd },              eff_mtp_flags);
-        layer.nextn.hnorm            = create_tensor(tn(LLM_TENSOR_NEXTN_HNORM,            "weight", i), { n_embd },              eff_mtp_flags);
+        layer.nextn.eh_proj          = create_tensor(tn(LLM_TENSOR_NEXTN_EH_PROJ,          "weight", i), { 2 * n_embd, n_embd }, mtp_flags);
+        layer.nextn.enorm            = create_tensor(tn(LLM_TENSOR_NEXTN_ENORM,            "weight", i), { n_embd },              mtp_flags);
+        layer.nextn.hnorm            = create_tensor(tn(LLM_TENSOR_NEXTN_HNORM,            "weight", i), { n_embd },              mtp_flags);
         layer.nextn.embed_tokens     = create_tensor(tn(LLM_TENSOR_NEXTN_EMBED_TOKENS,     "weight", i), { n_embd, n_vocab },     TENSOR_NOT_REQUIRED);
         layer.nextn.shared_head_head = create_tensor(tn(LLM_TENSOR_NEXTN_SHARED_HEAD_HEAD, "weight", i), { n_embd, n_vocab },     TENSOR_NOT_REQUIRED);
         layer.nextn.shared_head_norm = create_tensor(tn(LLM_TENSOR_NEXTN_SHARED_HEAD_NORM, "weight", i), { n_embd },              TENSOR_NOT_REQUIRED);
@@ -176,13 +173,11 @@ void llama_model_step35::load_arch_tensors(llama_model_loader & ml) {
     for (int i = 0; i < n_layer; ++i) {
         load_block_trunk(i, trunk_flags);
     }
-    // Only the first MTP block (i == n_main) is required at runtime — the
-    // single-block-MTP graph in build_arch_graph always uses that one.
-    // Trailing MTP blocks are loaded if present (so an un-pruned GGUF with
-    // all MTP layers still works) but tolerated when absent via the pruning
-    // path. See scripts/prune_step35_extra_mtp.py for the pruner.
+    // All n_layer_nextn MTP blocks are required — the multi-block draft chain
+    // runs every head (head k at offset k). The GGUF declares the count via
+    // step35.nextn_predict_layers.
     for (int i = n_layer; i < n_layer_all; ++i) {
-        load_block_mtp(i, /*is_first_mtp=*/ i == n_layer);
+        load_block_mtp(i);
     }
 }
 
@@ -372,13 +367,14 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     : llm_graph_context(params) {
     GGML_ASSERT(hparams.n_layer_nextn > 0 && "STEP35 MTP requires n_layer_nextn > 0");
 
-    // Single-block MTP only: always run the first trained MTP block (Qwen
-    // MTP / vLLM single-MTP-layer style). Multi-block round-robin proved to
-    // be a much deeper refactor than this PR justifies; the trailing MTP
-    // blocks are loaded with TENSOR_NOT_REQUIRED so pruned GGUFs (with just
-    // block 0) also work — see load_arch_tensors below and
-    // scripts/prune_step35_extra_mtp.py.
-    const int il = hparams.n_layer();
+    // Multi-block MTP: the DECODER_MTP graph runs the MTP head selected by
+    // cparams.mtp_layer_offset (0 = first trained head). The speculative driver
+    // bumps the offset per draft step to chain heads 45->46->47. offset 0 keeps
+    // single-block behavior identical to before.
+    const int il = hparams.n_layer() + cparams.mtp_layer_offset;
+    GGML_ASSERT(cparams.mtp_layer_offset >= 0 &&
+                cparams.mtp_layer_offset < (int) hparams.n_layer_nextn &&
+                "mtp_layer_offset out of range [0, n_layer_nextn)");
     const auto & layer = model.layers[il];
 
     GGML_ASSERT(layer.nextn.eh_proj && "MTP block missing nextn.eh_proj");

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -368,13 +368,13 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     GGML_ASSERT(hparams.n_layer_nextn > 0 && "STEP35 MTP requires n_layer_nextn > 0");
 
     // Multi-block MTP: the DECODER_MTP graph runs the MTP head selected by
-    // cparams.mtp_layer_offset (0 = first trained head). The speculative driver
+    // cparams.nextn_layer_offset (0 = first trained head). The speculative driver
     // bumps the offset per draft step to chain heads 45->46->47. offset 0 keeps
     // single-block behavior identical to before.
-    const int il = hparams.n_layer() + cparams.mtp_layer_offset;
-    GGML_ASSERT(cparams.mtp_layer_offset >= 0 &&
-                cparams.mtp_layer_offset < (int) hparams.n_layer_nextn &&
-                "mtp_layer_offset out of range [0, n_layer_nextn)");
+    const int il = hparams.n_layer() + cparams.nextn_layer_offset;
+    GGML_ASSERT(cparams.nextn_layer_offset >= 0 &&
+                cparams.nextn_layer_offset < (int) hparams.n_layer_nextn &&
+                "nextn_layer_offset out of range [0, n_layer_nextn)");
     const auto & layer = model.layers[il];
 
     GGML_ASSERT(layer.nextn.eh_proj && "MTP block missing nextn.eh_proj");

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -532,10 +532,13 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     cur = ggml_add(ctx0, cur, ffn_inp);
     cb(cur, "mtp_post_ffn", il);
 
-    // Gather t_h_nextn/t_logits to the n_outputs rows, like the trunk graph: the
-    // context and backend sampling assume an inp_out_ids gather. Without it a draft
-    // batch whose output slot isn't row 0 (multi-head chain, step>=1) reads the wrong
-    // row. Identity gather when n_outputs==n_tokens, so the single-head path is unchanged.
+    // Gather to the n_outputs rows: masked nextn extraction copies the first
+    // n_outputs rows of t_h_nextn, so the output slots must come first. Without it
+    // a multi-head draft (step >= 1, output slot != row 0) extracts the wrong row.
+    // Identity when n_outputs == n_tokens, so the single-head path is unchanged.
+    // The MTP graph is always run masked; assert it so this stays valid.
+    GGML_ASSERT(cparams.embeddings_nextn_masked &&
+                "STEP35 MTP graph requires masked nextn extraction");
     ggml_tensor * inp_out_ids = build_inp_out_ids();
     cur = ggml_get_rows(ctx0, cur, inp_out_ids);
 

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -532,10 +532,6 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     cur = ggml_add(ctx0, cur, ffn_inp);
     cb(cur, "mtp_post_ffn", il);
 
-    // Gather to the n_outputs rows: masked nextn extraction copies the first
-    // n_outputs rows of t_h_nextn, so the output slots must come first. Without it
-    // a multi-head draft (step >= 1, output slot != row 0) extracts the wrong row.
-    // Identity when n_outputs == n_tokens, so the single-head path is unchanged.
     ggml_tensor * inp_out_ids = build_inp_out_ids();
     cur = ggml_get_rows(ctx0, cur, inp_out_ids);
 


### PR DESCRIPTION
## Overview
follow-up to [#23274](https://github.com/ggml-org/llama.cpp/pull/23274).(cc @pwilkin )

<details>
<summary>📜 Full data-flow trace — couldn't think of a good way to draw this, so I wrote it all down instead. It's long, but every byte is load-bearing.</summary>

Notation:
- `token@pos` / `h(pos)` — positions are explicit (0-indexed)
- `h_tgt(p)` — target NextN hidden at p (before the output norm)
- `h45(p)` / `h46(p)` — head 45/46 output hidden, chained between heads while drafting
- `pending_h = h_tgt(pos of id_last − 1)` — always the trunk h, regardless of chaining

Example: a 4-token prompt at positions 0–3.

```
Time ─────────────────────────────────────────────────────────────────────▶

═══ Round 0: prompt bootstrap ══════════════════════════════════════════════
  prompt: [t0@0, t1@1, t2@2, t3@3]   (need_embd → all logits=true)

  ② target decode → verify_h = [h_tgt(0), h_tgt(1), h_tgt(2), h_tgt(3)]

  ③ process (mirror once per head, all logits=0, h_tgt shifted right by 1):
       for head in {45, 46, 47}:
         seq_rm(ctx_dft, seq, ≥ this ubatch's first pos)   // = 0 here; reset before each head
         token = [t0@0, t1@1,    t2@2,    t3@3]
         embd  = [0,    h_tgt(0), h_tgt(1), h_tgt(2)]   ← row 0 = pending_h = 0 (sentinel)
         → write KV_head@0..3 (teacher-forced, logits=0)
                              h_tgt(3) pushed out → pending_h default = h_tgt(3)
       (no draft → accept not called → pending_h stays = h_tgt(3))

  sample logits at pos 3 → T_first@4
       slot.sampled = T_first@4 ;  pending_h = h_tgt(3)
       invariant: id_last=T_first@4, pending_h=h_tgt(3)=h_tgt(4-1)  ✓

═══ Round 1: generation (id_last=T_first@4, pending_h=h_tgt(3)) ═════════════
  ⑥ draft (accumulated batch; switch head each step, 1 decode/step, batch grows):
       round_start = pos of id_last = 4; seq_rm(≥4) before switching to each head

       set_mtp_layer_offset(ctx_dft, 0)   // head 45
       step0 [h45]  seq_rm(≥4); batch=[T_first@4],            embd=[h_tgt(3)]
                    → decode → write KV45@4; sample draft1@5; output h45(4)

       set_mtp_layer_offset(ctx_dft, 1)   // head 46
       step1 [h46]  seq_rm(≥4); batch=[T_first@4, draft1@5],  embd=[h_tgt(3), h45(4)]
                    → decode → write KV46@4,5; sample draft2@6; output h46(5)

       set_mtp_layer_offset(ctx_dft, 2)   // head 47
       step2 [h47]  seq_rm(≥4); batch=[T_first@4, draft1@5, draft2@6],
                    embd=[h_tgt(3), h45(4), h46(5)]
                    → decode → write KV47@4,5,6; sample draft3@7
                    (draft length capped at n_mtp_layers = 3)

       spec_draft = [draft1, draft2, draft3]

  ── post-draft seq_rm (server, cross-round cleanup; unchanged) ──
       ckpt.pos_max = 3 (ctx_tgt only covers prompt @0..3 here; T_first not decoded yet)
       seq_rm(ctx_dft, slot.id, ≥4)  → every head's KV trimmed back to @0..3

  ① target batch (4 tokens, all logits=true):
       token = [T_first@4, draft1@5, draft2@6, draft3@7]

  ② target decode → verify_h = [h_tgt(4), h_tgt(5), h_tgt(6), h_tgt(7)] + logits[0..3]

  ③ process (once per head, logits=0; embd = h_tgt right-shift, NOT inter-head h):
       for head in {45, 46, 47}:
         seq_rm(ctx_dft, seq, ≥4)   // reset before each head; all heads rewrite from @4
         token = [T_first@4, draft1@5, draft2@6, draft3@7]
         embd  = [h_tgt(3),  h_tgt(4), h_tgt(5), h_tgt(6)]
                  ↑ pending_h           h_tgt(7) pushed out → pending_h default
         → rewrite KV_head@4..7 (teacher-forced, logits=0)

  ④ verify (sample from ctx_tgt logits, identical to the single-block path):
       logits[0] → real tok@5 == draft1  ✓
       logits[1] → real tok@6 == draft2  ✓
       logits[2] → real tok@7 != draft3  ✗ → resample T_new@7
       accepted = [draft1, draft2, T_new] ;  n_accepted = 2

  ⑤ accept (identical to the single-block path):
       pending_h    = verify_h[n_accepted] = verify_h[2] = h_tgt(6)
       slot.sampled = accepted.back()      = T_new (pos 7)
       invariant: id_last=T_new@7, pending_h=h_tgt(6)=h_tgt(7-1)  ✓

═══ Round 2: generation (id_last=T_new@7, pending_h=h_tgt(6)) ═══════════════
  ⑥ step0 [h45]  seq_rm(≥7); batch=[T_new@7],                  embd=[h_tgt(6)]
                 → write KV45@7; draft1'@8, h45(7)
     step1 [h46]  seq_rm(≥7); batch=[T_new@7, draft1'@8],       embd=[h_tgt(6), h45(7)]
                 → write KV46@7,8; draft2'@9, h46(8)
     step2 [h47]  seq_rm(≥7); batch=[T_new@7, draft1'@8, draft2'@9],
                 embd=[h_tgt(6), h45(7), h46(8)]
                 → write KV47@7,8,9; draft3'@10
     ── post-draft seq_rm(≥8); ① target batch; ② target decode; ③ process ×3
        (process resets seq_rm(≥7) per head, then rewrites @7..10)
```

</details>

**Core strategy** 
Each MTP head is its own decoder layer with its own KV, and the driver runs one head per `llama_decode`. A `seq_rm` before each head clears the range it re-decodes, so it reuses the same slots (`find_slot` is deterministic) instead of stacking duplicate positions; `find_slot` / `apply_ubatch` are untouched. The two phases differ only in what feeds the heads:

| phase | embd fed to each head | purpose |
|---|---|---|
| **`process()`** | trunk `h_tgt`, right-shifted by one (**not** the inter-head hidden) | re-anchor each head's committed-prefix KV to the target's real hidden → next round starts target-aligned |
| **`draft()`** | the previous head's output, chained (slot 0 = trunk `pending_h`) | generate the draft tokens; each head rebuilds its own layer's KV on the growing prefix |

Only the trunk `h_tgt` crosses rounds, so `pending_h` / `verify_h` stay single-layer.

**MTP Block Selection Strategy** 
- `cparams.mtp_layer_offset` (`src/llama-cparams.h`) — picks which appended MTP block the `DECODER_MTP` graph runs: `il = n_layer() + offset`. Default 0.
- `graph_mtp` selects the head by offset (`il = n_layer() + cparams.mtp_layer_offset`, was a hardcoded `n_layer()`).
- `graph_mtp` now gathers its output rows via `build_inp_out_ids()`, like the trunk graph. **The fix that makes chaining work:** from step 1 on, the output is the last batch row, not row 0, so without it heads 46/47 read the wrong row. Identity gather when `n_outputs == n_tokens`, so the single-head path is unchanged.
- Loader now requires all `n_layer_nextn` MTP blocks.
- `n_max` is clamped to the head count when chaining (each head used once).

### Results
```
./llama-server \
    -m Step-3.7-IQ4_XS.gguf \
    --spec-type draft-mtp \
    --spec-draft-model Step3.7-flash-mtp-Q8_0.gguf \
    -ngl all \
    --spec-draft-ngl all \
    -c 35000 \
    -np 1 \
    -b 2048 \
    -ub 1024 \
    --temp 0 \
    --spec-draft-n-max {n} \
    --spec-draft-p-min 0.0 \
    --host 127.0.0.1 \
    --port 8080
```

The command is identical on both machines; only `--spec-draft-n-max` and the build change. **Before** = single-block MTP on master (one head, looped when n-max > 1); **after** = the three-layer chain.

#### DGX Spark GB10

**Before (single-block MTP, master)**

`--spec-draft-n-max 2`
```
  code_python        pred= 192 draft= 164 acc= 108 rate=0.658 tok/s=30.8
  code_cpp           pred= 192 draft= 172 acc= 104 rate=0.605 tok/s=30.5
  explain_concept    pred= 192 draft= 171 acc= 105 rate=0.614 tok/s=30.8
  summarize          pred= 192 draft= 160 acc= 110 rate=0.688 tok/s=33.2
  qa_factual         pred= 192 draft= 146 acc= 117 rate=0.801 tok/s=36.6
  translation        pred= 192 draft= 173 acc= 104 rate=0.601 tok/s=30.8
  creative_short     pred= 192 draft= 189 acc=  95 rate=0.503 tok/s=28.1
  stepwise_math      pred= 192 draft= 156 acc= 113 rate=0.724 tok/s=34.6
  long_code_review   pred= 192 draft= 161 acc= 110 rate=0.683 tok/s=31.7

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1728,
  "total_draft": 1492,
  "total_draft_accepted": 966,
  "aggregate_accept_rate": 0.6475,
  "wall_s_total": 60.19
}
```

`--spec-draft-n-max 3`
```
  code_python        pred= 192 draft= 233 acc= 112 rate=0.481 tok/s=28.8
  code_cpp           pred= 192 draft= 243 acc= 109 rate=0.449 tok/s=27.7
  explain_concept    pred= 192 draft= 252 acc= 106 rate=0.421 tok/s=26.3
  summarize          pred= 192 draft= 233 acc= 112 rate=0.481 tok/s=27.7
  qa_factual         pred= 192 draft= 196 acc= 125 rate=0.638 tok/s=30.5
  translation        pred= 192 draft= 242 acc= 109 rate=0.450 tok/s=25.7
  creative_short     pred= 192 draft= 271 acc=  99 rate=0.365 tok/s=24.9
  stepwise_math      pred= 192 draft= 226 acc= 115 rate=0.509 tok/s=30.0
  long_code_review   pred= 192 draft= 235 acc= 112 rate=0.477 tok/s=27.3

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1728,
  "total_draft": 2131,
  "total_draft_accepted": 999,
  "aggregate_accept_rate": 0.4688,
  "wall_s_total": 70.1
}
```

**After (three-layer MTP, this PR)**

`--spec-draft-n-max 2`
```
  code_python        pred= 192 draft= 154 acc= 113 rate=0.734 tok/s=33.9
  code_cpp           pred= 192 draft= 156 acc= 112 rate=0.718 tok/s=32.6
  explain_concept    pred= 192 draft= 153 acc= 114 rate=0.745 tok/s=34.9
  summarize          pred= 192 draft= 150 acc= 115 rate=0.767 tok/s=35.5
  qa_factual         pred= 192 draft= 146 acc= 117 rate=0.801 tok/s=36.9
  translation        pred= 192 draft= 164 acc= 108 rate=0.658 tok/s=29.8
  creative_short     pred= 192 draft= 171 acc= 104 rate=0.608 tok/s=30.0
  stepwise_math      pred= 192 draft= 139 acc= 121 rate=0.871 tok/s=39.4
  long_code_review   pred= 192 draft= 143 acc= 118 rate=0.825 tok/s=36.2

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1728,
  "total_draft": 1376,
  "total_draft_accepted": 1022,
  "aggregate_accept_rate": 0.7427,
  "wall_s_total": 56.95
}
```

`--spec-draft-n-max 3`
```
  code_python        pred= 192 draft= 188 acc= 128 rate=0.681 tok/s=35.1
  code_cpp           pred= 192 draft= 213 acc= 119 rate=0.559 tok/s=31.4
  explain_concept    pred= 192 draft= 208 acc= 121 rate=0.582 tok/s=32.2
  summarize          pred= 192 draft= 203 acc= 122 rate=0.601 tok/s=33.0
  qa_factual         pred= 192 draft= 181 acc= 130 rate=0.718 tok/s=38.0
  translation        pred= 192 draft= 198 acc= 124 rate=0.626 tok/s=34.7
  creative_short     pred= 192 draft= 244 acc= 108 rate=0.443 tok/s=27.4
  stepwise_math      pred= 192 draft= 170 acc= 134 rate=0.788 tok/s=40.6
  long_code_review   pred= 192 draft= 199 acc= 124 rate=0.623 tok/s=33.1

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1728,
  "total_draft": 1804,
  "total_draft_accepted": 1110,
  "aggregate_accept_rate": 0.6153,
  "wall_s_total": 56.57
}
```

#### Mac Studio M4 Max

**Before (single-block MTP, master)**

`--spec-draft-n-max 2`
```
  code_python        pred= 192 draft= 162 acc= 110 rate=0.679 tok/s=42.6
  code_cpp           pred= 192 draft= 179 acc= 101 rate=0.564 tok/s=38.4
  explain_concept    pred= 192 draft= 171 acc= 105 rate=0.614 tok/s=40.2
  summarize          pred= 192 draft= 162 acc= 110 rate=0.679 tok/s=42.5
  qa_factual         pred= 161 draft= 122 acc= 101 rate=0.828 tok/s=47.4
  translation        pred= 192 draft= 171 acc= 104 rate=0.608 tok/s=40.0
  creative_short     pred= 192 draft= 188 acc=  97 rate=0.516 tok/s=36.7
  stepwise_math      pred= 192 draft= 155 acc= 113 rate=0.729 tok/s=44.3
  long_code_review   pred= 192 draft= 165 acc= 108 rate=0.654 tok/s=41.1

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1697,
  "total_draft": 1475,
  "total_draft_accepted": 949,
  "aggregate_accept_rate": 0.6434,
  "wall_s_total": 46.38
}
```

`--spec-draft-n-max 3`
```
  code_python        pred= 192 draft= 233 acc= 113 rate=0.485 tok/s=33.7
  code_cpp           pred= 192 draft= 259 acc= 104 rate=0.402 tok/s=30.4
  explain_concept    pred= 192 draft= 249 acc= 107 rate=0.430 tok/s=31.7
  summarize          pred= 192 draft= 226 acc= 115 rate=0.509 tok/s=34.7
  qa_factual         pred= 161 draft= 165 acc= 105 rate=0.636 tok/s=39.9
  translation        pred= 192 draft= 244 acc= 109 rate=0.447 tok/s=32.3
  creative_short     pred= 192 draft= 278 acc=  98 rate=0.352 tok/s=28.4
  stepwise_math      pred= 192 draft= 220 acc= 117 rate=0.532 tok/s=35.8
  long_code_review   pred= 192 draft= 232 acc= 113 rate=0.487 tok/s=33.0

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1697,
  "total_draft": 2106,
  "total_draft_accepted": 981,
  "aggregate_accept_rate": 0.4658,
  "wall_s_total": 56.7
}
```

**After (three-layer MTP, this PR)**

`--spec-draft-n-max 2`
```
  code_python        pred= 192 draft= 150 acc= 116 rate=0.773 tok/s=45.3
  code_cpp           pred= 192 draft= 165 acc= 108 rate=0.654 tok/s=41.2
  explain_concept    pred= 192 draft= 155 acc= 113 rate=0.729 tok/s=43.8
  summarize          pred= 192 draft= 150 acc= 116 rate=0.773 tok/s=45.0
  qa_factual         pred= 161 draft= 114 acc= 104 rate=0.912 tok/s=49.7
  translation        pred= 192 draft= 153 acc= 113 rate=0.739 tok/s=43.8
  creative_short     pred= 192 draft= 172 acc= 104 rate=0.605 tok/s=39.1
  stepwise_math      pred= 192 draft= 144 acc= 119 rate=0.826 tok/s=46.8
  long_code_review   pred= 192 draft= 153 acc= 114 rate=0.745 tok/s=43.2

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1697,
  "total_draft": 1356,
  "total_draft_accepted": 1007,
  "aggregate_accept_rate": 0.7426,
  "wall_s_total": 43.83
}
```

`--spec-draft-n-max 3`
```
  code_python        pred= 192 draft= 188 acc= 128 rate=0.681 tok/s=40.8
  code_cpp           pred= 192 draft= 205 acc= 122 rate=0.595 tok/s=37.2
  explain_concept    pred= 192 draft= 207 acc= 121 rate=0.585 tok/s=36.8
  summarize          pred= 192 draft= 194 acc= 126 rate=0.649 tok/s=39.4
  qa_factual         pred= 161 draft= 141 acc= 114 rate=0.808 tok/s=45.6
  translation        pred= 192 draft= 199 acc= 124 rate=0.623 tok/s=38.3
  creative_short     pred= 192 draft= 242 acc= 109 rate=0.450 tok/s=31.5
  stepwise_math      pred= 192 draft= 170 acc= 134 rate=0.788 tok/s=44.9
  long_code_review   pred= 192 draft= 208 acc= 121 rate=0.582 tok/s=36.1

Aggregate: {
  "n_requests": 9,
  "total_predicted": 1697,
  "total_draft": 1754,
  "total_draft_accepted": 1099,
  "aggregate_accept_rate": 0.6266,
  "wall_s_total": 49.38
}
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: CC for code and test, but the core data flow was designed by human <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
