### PR TITLE
ggml-zendnn : fix DL backend loading for Ollama

### DIFF
--- a/ggml/src/ggml-zendnn/CMakeLists.txt
+++ b/ggml/src/ggml-zendnn/CMakeLists.txt
@@ -89,3 +89,17 @@ target_link_libraries(ggml-zendnn PRIVATE m pthread)
 if (GGML_OPENMP)
     target_link_libraries(ggml-zendnn PRIVATE OpenMP::OpenMP_CXX)
 endif()
+
+if (ZENDNN_SHARED_LIB AND CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set_target_properties(ggml-zendnn PROPERTIES
+        BUILD_WITH_INSTALL_RPATH ON
+        INSTALL_RPATH "$ORIGIN")
+
+    add_custom_command(TARGET ggml-zendnn POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${ZENDNN_ROOT}/zendnnl/lib/libzendnnl.so
+            $<TARGET_FILE_DIR:ggml-zendnn>/libzendnnl.so)
+
+    install(FILES ${ZENDNN_ROOT}/zendnnl/lib/libzendnnl.so
+        TYPE LIB)
+endif()


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Required by Ollama. The ggml-zendnn backend fails to load when deployed outside the build tree. This fix makes it relocatable.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
