### PR TITLE
webui: scope agentic stream writes to owning conversation

### DIFF
--- a/tools/ui/src/lib/stores/chat.svelte.ts
+++ b/tools/ui/src/lib/stores/chat.svelte.ts
@@ -652,6 +652,10 @@ class ChatStore {
 
 		// Mutable state for the current message being streamed
 		let currentMessageId = assistantMessage.id;
+		// tail of this stream's message chain; parent for new tool result/assistant
+		// messages. Not derived from activeMessages, which tracks whichever conversation
+		// the user is currently viewing (and is empty on the new-chat route)
+		let lastMessageId = assistantMessage.id;
 		let streamedContent = '';
 		let streamedReasoningContent = '';
 		let resolvedModel: string | null = null;
@@ -799,8 +803,9 @@ class ChatStore {
 						children: [],
 						extra: extras
 					},
-					currentMessageId
+					lastMessageId
 				);
+				lastMessageId = msg.id;
 				conversationsStore.addMessageToActive(msg, convId);
 				await conversationsStore.updateCurrentNode(msg.id, convId);
 				return msg;
@@ -810,8 +815,6 @@ class ChatStore {
 				streamedContent = '';
 				streamedReasoningContent = '';
 
-				const lastMsg =
-					conversationsStore.activeMessages[conversationsStore.activeMessages.length - 1];
 				const msg = await DatabaseService.createMessageBranch(
 					{
 						convId,
@@ -823,8 +826,9 @@ class ChatStore {
 						children: [],
 						model: resolvedModel
 					},
-					lastMsg.id
+					lastMessageId
 				);
+				lastMessageId = msg.id;
 				conversationsStore.addMessageToActive(msg, convId);
 				currentMessageId = msg.id;
 				return msg;

--- a/tools/ui/src/lib/stores/chat.svelte.ts
+++ b/tools/ui/src/lib/stores/chat.svelte.ts
@@ -780,7 +780,7 @@ class ChatStore {
 				if (timings) uiUpdate.timings = timings;
 				if (resolvedModel) uiUpdate.model = resolvedModel;
 				conversationsStore.updateMessageAtIndex(idx, uiUpdate);
-				await conversationsStore.updateCurrentNode(currentMessageId);
+				await conversationsStore.updateCurrentNode(currentMessageId, convId);
 			},
 			createToolResultMessage: async (
 				toolCallId: string,
@@ -801,8 +801,8 @@ class ChatStore {
 					},
 					currentMessageId
 				);
-				conversationsStore.addMessageToActive(msg);
-				await conversationsStore.updateCurrentNode(msg.id);
+				conversationsStore.addMessageToActive(msg, convId);
+				await conversationsStore.updateCurrentNode(msg.id, convId);
 				return msg;
 			},
 			createAssistantMessage: async () => {
@@ -825,7 +825,7 @@ class ChatStore {
 					},
 					lastMsg.id
 				);
-				conversationsStore.addMessageToActive(msg);
+				conversationsStore.addMessageToActive(msg, convId);
 				currentMessageId = msg.id;
 				return msg;
 			},
@@ -947,7 +947,7 @@ class ChatStore {
 					if (timings) uiUpdate.timings = timings;
 					if (resolvedModel) uiUpdate.model = resolvedModel;
 					conversationsStore.updateMessageAtIndex(idx, uiUpdate);
-					await conversationsStore.updateCurrentNode(currentMessageId);
+					await conversationsStore.updateCurrentNode(currentMessageId, convId);
 					cleanupStreamingState();
 					if (onComplete) await onComplete(content);
 					if (isRouterMode()) modelsStore.fetchRouterModels().catch(console.error);

--- a/tools/ui/src/lib/stores/conversations.svelte.ts
+++ b/tools/ui/src/lib/stores/conversations.svelte.ts
@@ -214,9 +214,17 @@ class ConversationsStore {
 	 */
 
 	/**
-	 * Adds a message to the active messages array
+	 * Adds a message to the active messages array. When `expectedConvId` is provided,
+	 * the push is skipped if the user has navigated away to a different conversation.
+	 * this prevents an in-flight stream (e.g. an agentic loop) from leaking new turns
+	 * into a conversation the user has since switched to. The DB row is still written
+	 * by the caller against the correct conversation, so reopening the original
+	 * conversation will display the message normally.
 	 */
-	addMessageToActive(message: DatabaseMessage): void {
+	addMessageToActive(message: DatabaseMessage, expectedConvId?: string): void {
+		if (expectedConvId !== undefined && expectedConvId !== this.activeConversation?.id) {
+			return;
+		}
 		this.activeMessages.push(message);
 	}
 
@@ -557,11 +565,14 @@ class ConversationsStore {
 	 * Updates the current node of the active conversation
 	 * @param nodeId - The new current node ID
 	 */
-	async updateCurrentNode(nodeId: string): Promise<void> {
-		if (!this.activeConversation) return;
+	async updateCurrentNode(nodeId: string, expectedConvId?: string): Promise<void> {
+		const targetConvId = expectedConvId ?? this.activeConversation?.id;
+		if (!targetConvId) return;
 
-		await DatabaseService.updateCurrentNode(this.activeConversation.id, nodeId);
-		this.activeConversation = { ...this.activeConversation, currNode: nodeId };
+		await DatabaseService.updateCurrentNode(targetConvId, nodeId);
+		if (this.activeConversation?.id === targetConvId) {
+			this.activeConversation = { ...this.activeConversation, currNode: nodeId };
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #24337. When an agentic loop is running in one conversation and the user switches to another one, new tool result and assistant turns from the first conversation start rendering inside the second one until the page is refreshed. The leak is that addMessageToActive and updateCurrentNode in conversationsStore mutate the active in memory state without checking which conversation actually owns the in flight stream.

This adds an optional expectedConvId parameter to both store methods, and the agentic flow callbacks in chatStore now pass the captured convId so writes intended for the original conversation are skipped in memory when the user has switched away. The database writes still happen against the correct conversation so reopening the original chat shows the full transcript as expected.