### PR TITLE
vulkan: disable FA mask_opt on GCN to improve performance

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10311,7 +10311,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
 
     // Only use mask opt when the mask is fairly large. This hasn't been tuned extensively.
     bool use_mask_opt = mask && nem1 >= 32 && nem0 * nem1 > 32768 && nem0 >= tuning_params.block_cols * 16
-                        && ctx->device->architecture != vk_device_architecture::AMD_GCN;
+                        && (ctx->device->architecture != vk_device_architecture::AMD_GCN || HSK > 256 || HSV > 256);
     vk_fa_pipeline_state fa_pipeline_state = get_fa_pipeline_state(ctx->device, tuning_params, HSK, HSV, aligned, f32acc,
                                                                    mask != nullptr, use_mask_opt, logit_softcap != 0, k->type, v->type);
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10310,7 +10310,8 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
     }
 
     // Only use mask opt when the mask is fairly large. This hasn't been tuned extensively.
-    bool use_mask_opt = mask && nem1 >= 32 && nem0 * nem1 > 32768 && nem0 >= tuning_params.block_cols * 16;
+    bool use_mask_opt = mask && nem1 >= 32 && nem0 * nem1 > 32768 && nem0 >= tuning_params.block_cols * 16
+                        && ctx->device->architecture != vk_device_architecture::AMD_GCN;
     vk_fa_pipeline_state fa_pipeline_state = get_fa_pipeline_state(ctx->device, tuning_params, HSK, HSV, aligned, f32acc,
                                                                    mask != nullptr, use_mask_opt, logit_softcap != 0, k->type, v->type);
 


### PR DESCRIPTION
## Overview

I accidentally noticed this while testing some other changes. It's not a universal improvement, but mostly seems to be positive on GCN. I don't really know why it slows it down so much, or if there's a good way to predict where it helps and where it doesn't. Maybe it helps on DeepSeek (GLM4.7 Flash) because of the large head sizes? Let me know if you have ideas @jeffbolznv.

AMD Radeon Pro VII on Linux RADV:

| model                           | size      | params  | ngl | fa | mmap | test          | t/s (before)  | t/s (after)   | diff   |
|---------------------------------|-----------|---------|-----|----|------|---------------|---------------|---------------|--------|
| llama 8B Q4_0                   | 4.33 GiB  | 8.03 B  | -1  | 1  | 0    | pp512         | 845.80 ± 1.20 | 855.26 ± 0.66 | +1.1%  |
| llama 8B Q4_0                   | 4.33 GiB  | 8.03 B  | -1  | 1  | 0    | pp512 @ d4096 | 455.09 ± 4.63 | 559.51 ± 0.31 | +22.9% |
| llama 8B Q4_0                   | 4.33 GiB  | 8.03 B  | -1  | 1  | 0    | pp512 @ d8192 | 274.00 ± 2.80 | 386.68 ± 0.59 | +41.1% |
| deepseek2 30B.A3B Q3_K - Small  | 12.37 GiB | 29.94 B | -1  | 1  | 0    | pp512         | 784.35 ± 4.41 | 782.86 ± 4.07 | -0.2%  |
| deepseek2 30B.A3B Q3_K - Small  | 12.37 GiB | 29.94 B | -1  | 1  | 0    | pp512 @ d4096 | 436.08 ± 1.83 | 382.73 ± 1.09 | -12.2% |
| deepseek2 30B.A3B Q3_K - Small  | 12.37 GiB | 29.94 B | -1  | 1  | 0    | pp512 @ d8192 | 284.13 ± 0.58 | 240.42 ± 0.41 | -15.4% |
| qwen35moe 35B.A3B Q2_K - Medium | 11.74 GiB | 34.66 B | -1  | 1  | 0    | pp512         | 722.12 ± 6.36 | 719.99 ± 4.29 | -0.3%  |
| qwen35moe 35B.A3B Q2_K - Medium | 11.74 GiB | 34.66 B | -1  | 1  | 0    | pp512 @ d4096 | 649.81 ± 3.34 | 656.49 ± 3.78 | +1.0%  |
| qwen35moe 35B.A3B Q2_K - Medium | 11.74 GiB | 34.66 B | -1  | 1  | 0    | pp512 @ d8192 | 592.58 ± 4.44 | 604.61 ± 3.73 | +2.0%  |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES