### PR TITLE
metal : wind down leftover residency sets at teardown instead of aborting

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -618,13 +618,35 @@ void ggml_metal_rsets_free(ggml_metal_rsets_t rsets) {
         return;
     }
 
-    // note: if you hit this assert, most likely you haven't deallocated all Metal resources before exiting
-    GGML_ASSERT([rsets->data count] == 0);
-
+    // Stop the keep-alive heartbeat before touching the collection, so the drain below
+    // cannot race the background thread's residency requests.
     atomic_store_explicit(&rsets->d_stop, true, memory_order_relaxed);
 
     dispatch_group_wait(rsets->d_group, DISPATCH_TIME_FOREVER);
     dispatch_release(rsets->d_group);
+
+    // The device is torn down from a C++ static destructor at process exit. If the host did
+    // not free every Metal buffer first, that buffer's residency set is still registered
+    // here, so the array is non-empty. The original code did GGML_ASSERT([rsets->data count]
+    // == 0), which calls abort() and crashes the app on every quit on macOS 15+. The device
+    // does not own the buffers and cannot free them from its destructor, so instead of
+    // aborting, defensively wind down residency on any leftover sets (mirroring
+    // ggml_metal_buffer_rset_free, minus -release, since each set is still owned by its
+    // not-yet-freed buffer) before releasing the collection. The backing buffers are
+    // reclaimed by the OS as the process exits. No behavior change when all buffers were
+    // freed (the array is empty).
+#if defined(GGML_METAL_HAS_RESIDENCY_SETS)
+    if (@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, *)) {
+        if ([rsets->data count] != 0) {
+            GGML_LOG_DEBUG("%s: %ld residency set(s) still registered at teardown; winding down\n",
+                           __func__, (long) [rsets->data count]);
+            for (id rset in rsets->data) {
+                [rset endResidency];
+                [rset removeAllAllocations];
+            }
+        }
+    }
+#endif
 
     [rsets->data release];
     [rsets->lock release];


### PR DESCRIPTION
## What

On macOS 15+ (Apple Silicon), `ggml_metal_rsets_free()` does `GGML_ASSERT([rsets->data count] == 0)`, which calls `abort()` when the Metal device is torn down while residency sets are still registered. The device is freed from a C++ static destructor at process exit (`ggml_metal_device_get`'s function-local `static` vector), so **any app embedding the Metal backend that exits without freeing every Metal buffer first crashes on every quit.**

## Why it happens

A residency set is added in `ggml_metal_buffer_init_*` and removed from the collection in exactly one place — `ggml_metal_buffer_free()`. An application that lets the OS reclaim its model/weights on exit (a common, historically fine pattern) never calls `ggml_backend_buffer_free` for those buffers, so the collection is non-empty when the device's static destructor runs `ggml_metal_rsets_free()`, and the assert fires.

The device does not own those buffers and cannot free them from its destructor, so the assert can't be made to legitimately hold from within `ggml_metal_rsets_free()`.

## Fix

Make teardown defensive instead of aborting:

1. stop the keep-alive heartbeat (existing `d_stop` + `dispatch_group_wait`),
2. wind down residency on any leftover sets — `endResidency` + `removeAllAllocations`, mirroring `ggml_metal_buffer_rset_free()` but **without** `-release` (each set is still owned by its not-yet-freed buffer, so releasing here would over-release),
3. then release the collection as before.

The backing buffers are reclaimed by the OS as the process exits. **No behavior change when all buffers were freed** — the array is empty and the loop is a no-op. Guarded by the existing `GGML_METAL_HAS_RESIDENCY_SETS` + `@available(macOS 15.0, …)`.

## Notes

- The assert was added in #17766 ("metal : add residency sets keep-alive heartbeat"). It's a teardown sanity check, not a correctness/security guard: nothing reads `rsets->data` after this point, so leftover entries cause no UB — only the abort.
- Same fix submitted to whisper.cpp (which syncs this file from here): ggml-org/whisper.cpp#3870.
- Repro: drive the Metal backend on macOS 15+ Apple Silicon and quit the process without explicitly freeing the backend buffers → abort on quit. Surfaced in a real macOS app (live dictation).

Happy to adjust — feedback welcome.
