### PR TITLE
gguf : add tensor shape accessor

### DIFF
--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -129,6 +129,8 @@ extern "C" {
     GGML_API int64_t        gguf_find_tensor      (const struct gguf_context * ctx, const char * name); // returns -1 if the tensor is not found
     GGML_API size_t         gguf_get_tensor_offset(const struct gguf_context * ctx, int64_t tensor_id);
     GGML_API const char *   gguf_get_tensor_name  (const struct gguf_context * ctx, int64_t tensor_id);
+    GGML_API uint32_t       gguf_get_tensor_n_dims(const struct gguf_context * ctx, int64_t tensor_id); // trailing dims of size 1 are not counted (see ggml_n_dims)
+    GGML_API int64_t        gguf_get_tensor_dim   (const struct gguf_context * ctx, int64_t tensor_id, int dim); // returns ne[dim], which is 1 for dim >= n_dims; requires dim < GGML_MAX_DIMS
     GGML_API enum ggml_type gguf_get_tensor_type  (const struct gguf_context * ctx, int64_t tensor_id);
     GGML_API size_t         gguf_get_tensor_size  (const struct gguf_context * ctx, int64_t tensor_id);
 

--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -125,14 +125,14 @@ extern "C" {
     // get ith C string from array with given key_id
     GGML_API const char * gguf_get_arr_str (const struct gguf_context * ctx, int64_t key_id, size_t i);
 
-    GGML_API int64_t        gguf_get_n_tensors    (const struct gguf_context * ctx);
-    GGML_API int64_t        gguf_find_tensor      (const struct gguf_context * ctx, const char * name); // returns -1 if the tensor is not found
-    GGML_API size_t         gguf_get_tensor_offset(const struct gguf_context * ctx, int64_t tensor_id);
-    GGML_API const char *   gguf_get_tensor_name  (const struct gguf_context * ctx, int64_t tensor_id);
-    GGML_API uint32_t       gguf_get_tensor_n_dims(const struct gguf_context * ctx, int64_t tensor_id); // trailing dims of size 1 are not counted (see ggml_n_dims)
-    GGML_API int64_t        gguf_get_tensor_dim   (const struct gguf_context * ctx, int64_t tensor_id, int dim); // returns ne[dim], which is 1 for dim >= n_dims; requires dim < GGML_MAX_DIMS
-    GGML_API enum ggml_type gguf_get_tensor_type  (const struct gguf_context * ctx, int64_t tensor_id);
-    GGML_API size_t         gguf_get_tensor_size  (const struct gguf_context * ctx, int64_t tensor_id);
+    GGML_API int64_t         gguf_get_n_tensors    (const struct gguf_context * ctx);
+    GGML_API int64_t         gguf_find_tensor      (const struct gguf_context * ctx, const char * name); // returns -1 if the tensor is not found
+    GGML_API size_t          gguf_get_tensor_offset(const struct gguf_context * ctx, int64_t tensor_id);
+    GGML_API const char *    gguf_get_tensor_name  (const struct gguf_context * ctx, int64_t tensor_id);
+    GGML_API uint32_t        gguf_get_tensor_n_dims(const struct gguf_context * ctx, int64_t tensor_id); // trailing dims of size 1 are not counted (see ggml_n_dims)
+    GGML_API const int64_t * gguf_get_tensor_ne    (const struct gguf_context * ctx, int64_t tensor_id); // returns ne, an array of GGML_MAX_DIMS elements; ne[dim] is 1 for dim >= n_dims
+    GGML_API enum ggml_type  gguf_get_tensor_type  (const struct gguf_context * ctx, int64_t tensor_id);
+    GGML_API size_t          gguf_get_tensor_size  (const struct gguf_context * ctx, int64_t tensor_id);
 
     // removes key if it exists, returns id that the key had prior to removal (-1 if it didn't exist)
     GGML_API int64_t gguf_remove_key(struct gguf_context * ctx, const char * key);

--- a/ggml/include/gguf.h
+++ b/ggml/include/gguf.h
@@ -129,7 +129,6 @@ extern "C" {
     GGML_API int64_t         gguf_find_tensor      (const struct gguf_context * ctx, const char * name); // returns -1 if the tensor is not found
     GGML_API size_t          gguf_get_tensor_offset(const struct gguf_context * ctx, int64_t tensor_id);
     GGML_API const char *    gguf_get_tensor_name  (const struct gguf_context * ctx, int64_t tensor_id);
-    GGML_API uint32_t        gguf_get_tensor_n_dims(const struct gguf_context * ctx, int64_t tensor_id); // trailing dims of size 1 are not counted (see ggml_n_dims)
     GGML_API const int64_t * gguf_get_tensor_ne    (const struct gguf_context * ctx, int64_t tensor_id); // returns ne, an array of GGML_MAX_DIMS elements; ne[dim] is 1 for dim >= n_dims
     GGML_API enum ggml_type  gguf_get_tensor_type  (const struct gguf_context * ctx, int64_t tensor_id);
     GGML_API size_t          gguf_get_tensor_size  (const struct gguf_context * ctx, int64_t tensor_id);

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -1187,10 +1187,9 @@ uint32_t gguf_get_tensor_n_dims(const struct gguf_context * ctx, int64_t tensor_
     return (uint32_t) ggml_n_dims(&ctx->info[tensor_id].t);
 }
 
-int64_t gguf_get_tensor_dim(const struct gguf_context * ctx, int64_t tensor_id, int dim) {
+const int64_t * gguf_get_tensor_ne(const struct gguf_context * ctx, int64_t tensor_id) {
     GGML_ASSERT(tensor_id >= 0 && tensor_id < gguf_get_n_tensors(ctx));
-    GGML_ASSERT(dim >= 0 && dim < GGML_MAX_DIMS);
-    return ctx->info[tensor_id].t.ne[dim];
+    return ctx->info[tensor_id].t.ne;
 }
 
 enum ggml_type gguf_get_tensor_type(const struct gguf_context * ctx, int64_t tensor_id) {

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -1182,6 +1182,17 @@ const char * gguf_get_tensor_name(const struct gguf_context * ctx, int64_t tenso
     return ctx->info[tensor_id].t.name;
 }
 
+uint32_t gguf_get_tensor_n_dims(const struct gguf_context * ctx, int64_t tensor_id) {
+    GGML_ASSERT(tensor_id >= 0 && tensor_id < gguf_get_n_tensors(ctx));
+    return (uint32_t) ggml_n_dims(&ctx->info[tensor_id].t);
+}
+
+int64_t gguf_get_tensor_dim(const struct gguf_context * ctx, int64_t tensor_id, int dim) {
+    GGML_ASSERT(tensor_id >= 0 && tensor_id < gguf_get_n_tensors(ctx));
+    GGML_ASSERT(dim >= 0 && dim < GGML_MAX_DIMS);
+    return ctx->info[tensor_id].t.ne[dim];
+}
+
 enum ggml_type gguf_get_tensor_type(const struct gguf_context * ctx, int64_t tensor_id) {
     GGML_ASSERT(tensor_id >= 0 && tensor_id < gguf_get_n_tensors(ctx));
     return ctx->info[tensor_id].t.type;

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -1182,11 +1182,6 @@ const char * gguf_get_tensor_name(const struct gguf_context * ctx, int64_t tenso
     return ctx->info[tensor_id].t.name;
 }
 
-uint32_t gguf_get_tensor_n_dims(const struct gguf_context * ctx, int64_t tensor_id) {
-    GGML_ASSERT(tensor_id >= 0 && tensor_id < gguf_get_n_tensors(ctx));
-    return (uint32_t) ggml_n_dims(&ctx->info[tensor_id].t);
-}
-
 const int64_t * gguf_get_tensor_ne(const struct gguf_context * ctx, int64_t tensor_id) {
     GGML_ASSERT(tensor_id >= 0 && tensor_id < gguf_get_n_tensors(ctx));
     return ctx->info[tensor_id].t.ne;

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -659,16 +659,6 @@ static bool handcrafted_check_tensors(const gguf_context * gguf_ctx, const unsig
                 ok = false;
             }
 
-            uint32_t n_dims = 1;
-            for (int j = GGML_MAX_DIMS - 1; j >= 1; --j) {
-                if (shape[j] != 1) {
-                    n_dims = j + 1;
-                    break;
-                }
-            }
-            if (gguf_get_tensor_n_dims(gguf_ctx, id) != n_dims) {
-                ok = false;
-            }
             const int64_t * ne = gguf_get_tensor_ne(gguf_ctx, id);
             for (int j = 0; j < GGML_MAX_DIMS; ++j) {
                 if (ne[j] != shape[j]) {

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -669,8 +669,9 @@ static bool handcrafted_check_tensors(const gguf_context * gguf_ctx, const unsig
             if (gguf_get_tensor_n_dims(gguf_ctx, id) != n_dims) {
                 ok = false;
             }
+            const int64_t * ne = gguf_get_tensor_ne(gguf_ctx, id);
             for (int j = 0; j < GGML_MAX_DIMS; ++j) {
-                if (gguf_get_tensor_dim(gguf_ctx, id, j) != shape[j]) {
+                if (ne[j] != shape[j]) {
                     ok = false;
                 }
             }

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -658,6 +658,22 @@ static bool handcrafted_check_tensors(const gguf_context * gguf_ctx, const unsig
             if (gguf_get_tensor_type(gguf_ctx, id) != type) {
                 ok = false;
             }
+
+            uint32_t n_dims = 1;
+            for (int j = GGML_MAX_DIMS - 1; j >= 1; --j) {
+                if (shape[j] != 1) {
+                    n_dims = j + 1;
+                    break;
+                }
+            }
+            if (gguf_get_tensor_n_dims(gguf_ctx, id) != n_dims) {
+                ok = false;
+            }
+            for (int j = 0; j < GGML_MAX_DIMS; ++j) {
+                if (gguf_get_tensor_dim(gguf_ctx, id, j) != shape[j]) {
+                    ok = false;
+                }
+            }
         } else {
             ok = false;
             continue;


### PR DESCRIPTION
## Overview

This adds a small GGUF accessor for tensor shapes:

- `gguf_get_tensor_ne()` — returns the shape as `const int64_t *` (an array of `GGML_MAX_DIMS` elements)

The GGUF API already exposes tensor name, type, offset and byte size. This makes the tensor rank and dimensions available through the public API as well, so tools can inspect GGUF metadata without parsing tensor headers themselves or relying on internal structures.

I also extended `tests/test-gguf.cpp` to check this accessor against the existing handcrafted tensor metadata cases.


Tested:

```bash
cmake --build build --target test-gguf -j 8
ctest --test-dir build -R '^test-gguf$' --output-on-failure
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, claude fable 5 for review
