### PR TITLE
vulkan: Intel Xe flash attention, GEMM optimizations(Xe-LPG Plus/Xe2/Xe3) [MEGA PR]

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2321,6 +2321,25 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ));
     add_opt(common_arg(
+        {"-cw"}, "MODE",
+        "load-time compressed-weight cache (Q4_0) for quick MoE path. "
+        "MODE in {auto, on, off}. Default: auto. auto enables on Intel Xe2+, off elsewhere. Pass 'on' to force enable, or 'off' to force disable. "
+        "When active, mmap is disabled automatically. "
+        "PPL will drop ~4% once feature is enabled, but tg perf get boost ~30%. "
+        "GSM8K N=200, -cw on: 194/200 = 97.00% for Qwen3.6-35B-A3B-UD-Q4_K_M.",
+        [](common_params & params, const std::string & value) {
+            if (value == "on" || value == "1" || value == "true") {
+                params.cw = 1;
+            } else if (value == "off" || value == "0" || value == "false") {
+                params.cw = 0;
+            } else if (value == "auto" || value == "-1") {
+                params.cw = -1;
+            } else {
+                throw std::invalid_argument("invalid -cw value: '" + value + "' (expected auto|on|off)");
+            }
+        }
+    ).set_env("LLAMA_ARG_CW"));
+    add_opt(common_arg(
         {"-ot", "--override-tensor"}, "<tensor name pattern>=<buffer type>,...",
         "override tensor buffer type", [](common_params & params, const std::string & value) {
             parse_tensor_buffer_overrides(value, params.tensor_buft_overrides);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1547,6 +1547,8 @@ struct llama_model_params common_model_params_to_llama(common_params & params) {
         mparams.tensor_buft_overrides = params.tensor_buft_overrides.data();
     }
 
+    mparams.cw = params.cw;  // tri-state: -1 auto, 0 off, 1 on. Loader resolves auto by scanning tensors for downgrade candidates and disables mmap when active.
+
     mparams.progress_callback           = params.load_progress_callback;
     mparams.progress_callback_user_data = params.load_progress_callback_user_data;
     mparams.no_alloc                    = params.no_alloc;

--- a/common/common.h
+++ b/common/common.h
@@ -500,6 +500,7 @@ struct common_params {
     std::vector<std::string> antiprompt; // strings upon which more user input is prompted (a.k.a. reverse prompts)
     std::vector<llama_model_kv_override> kv_overrides;
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
+    int8_t cw = -1;       // 0 = off, 1 = on, -1 = auto (default): on for Intel Xe2+, off elsewhere
 
     bool lora_init_without_apply = false; // only load lora to memory, but do not apply it to ctx (user can manually apply lora later using llama_adapter_lora_apply)
     std::vector<common_adapter_lora_info> lora_adapters; // lora adapter path with user defined scale

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -198,6 +198,10 @@ static void ggml_vk_destroy_pipeline(vk::Device& device, vk_pipeline& pipeline);
 struct vk_matmul_pipeline_struct {
     vk_pipeline l, m, s;
     vk_pipeline a_l, a_m, a_s;
+    // Intel-only alternative l/a_l (BM=128 tile). Selected at dispatch by
+    // ggml_vk_guess_matmul_pipeline under some condition. Null for non-Intel
+    // and for pipeline categories that don't build the alt.
+    vk_pipeline l_alt, a_l_alt;
     // Returns true when all unaligned pipelines are null.
     // We only check for unaligned variants since one of the unaligned pipelines must exist
     // while aligned pipelines are optional
@@ -762,6 +766,7 @@ struct vk_device_struct {
     vk_matmul_pipeline2 pipeline_matmul_id_f16_f32;
 
     vk_matmul_pipeline2 pipeline_dequant_mul_mat_mat_id[GGML_TYPE_COUNT];
+    vk_matmul_pipeline2 pipeline_dequant_mul_mat_mat_id_f16b[GGML_TYPE_COUNT]; // f16 B-type variant (coopmat1 only)
     vk_matmul_pipeline2 pipeline_dequant_mul_mat_mat_id_q8_1[GGML_TYPE_COUNT];
 
     vk_pipeline pipeline_matmul_split_k_reduce;
@@ -771,6 +776,8 @@ struct vk_device_struct {
     vk_pipeline pipeline_dequant_mul_mat_vec_f32_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT][mul_mat_vec_max_cols];
     vk_pipeline pipeline_dequant_mul_mat_vec_f16_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT][mul_mat_vec_max_cols];
     vk_pipeline pipeline_dequant_mul_mat_vec_id_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT];
+    // Q4_K f32_f32 alt with NUM_ROWS=4 register-tile on M; selected when ne00<=1024.
+    vk_pipeline pipeline_dequant_mul_mat_vec_q4_k_4rows_f32_f32[DMMV_WG_SIZE_COUNT][mul_mat_vec_max_cols];
 
     vk_pipeline pipeline_dequant_mul_mat_vec_q8_1_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT][mul_mat_vec_max_cols];
     vk_pipeline pipeline_dequant_mul_mat_vec_id_q8_1_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT];
@@ -3772,6 +3779,13 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         m_warptile_mmqid_int_k = { 128,                      64,  64, 32, mul_mat_subgroup_size_16,     32, 1, 2, 2, 1, mul_mat_subgroup_size_16 };
         s_warptile_mmqid_int_k = { mul_mat_subgroup_size_32, 32,  32, 32, s_warptile_wm,                32, 1, 2, 1, 1, mul_mat_subgroup_size_16 };
 
+        l_mmq_wg_denoms = l_wg_denoms = { 128, 128, 1 };
+        m_mmq_wg_denoms = m_wg_denoms = { 64, 64, 1 };
+        s_mmq_wg_denoms = s_wg_denoms = { 32, 32, 1 };
+        l_align                       = 128;
+        m_align                       = 64;
+        s_align                       = 32;
+
         // chip specific tuning
         if ((device->architecture == AMD_GCN) && (device->driver_id != vk::DriverId::eAmdProprietary)) {
             m_warptile_mmq = m_warptile_mmq_int = { 256, 64, 64, 32, 16, 16, 2, 2, 2, 1, 16 };
@@ -3782,17 +3796,18 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             l_warptile_mmq = l_warptile_mmq_int = { 256, 128, 128, 32, subgroup_size_8, 64, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq_int_k = { 256, 128, 128, 32, subgroup_size_16, 64, 1, 4, 2, 1, subgroup_size_16 };
         } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support) {
-            // Xe2/Xe3 with coopmat enabled - warptile performance tuning
+            // Xe1/Xe2/Xe3 with coopmat enabled - warptile performance tuning
             l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
-            l_warptile_mmq = { 512, 128, 128, 32, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
+            if (device->architecture == INTEL_PRE_XE2) {
+                l_warptile_mmq  = { 512, 256, 128, 32, 32, 32, 2, 8, 8, 16, 16 };
+                l_mmq_wg_denoms = { 256, 128, 1 };
+                l_align         = 32;  //set as BK
+            } else {
+                l_warptile_mmq  = { 512, 128, 256, 32, 32, 32, 2, 8, 16, 16, 16 };
+                l_mmq_wg_denoms = { 128, 256, 1 };
+                l_align         = 32;  //set as BK
+            }
         }
-
-        l_mmq_wg_denoms = l_wg_denoms = {128, 128, 1 };
-        m_mmq_wg_denoms = m_wg_denoms = { 64,  64, 1 };
-        s_mmq_wg_denoms = s_wg_denoms = { 32,  32, 1 };
-        l_align = 128;
-        m_align =  64;
-        s_align =  32;
 
         for (uint32_t i = 0; i < GGML_TYPE_COUNT; ++i) {
             ggml_type t = (ggml_type)i;
@@ -4155,20 +4170,46 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
 #endif  // defined(VK_NV_cooperative_matrix2) && defined(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
 #if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
     if (device->coopmat_support) {
+        // set_warp_tile: save current tile state and apply override.
+        // restore_warp_tile: revert to the previously saved state.
+        // The two lambdas share saved state; callers must not nest two active overrides simultaneously.
+        std::vector<uint32_t>   saved_wt;
+        std::array<uint32_t, 3> saved_wgd{};
+        uint32_t                saved_al = 0;
+
+        auto set_warp_tile = [&](std::vector<uint32_t>   wt,
+                                  std::array<uint32_t, 3> wgd,
+                                  uint32_t al) {
+            saved_wt  = l_warptile_mmq;
+            saved_wgd = l_mmq_wg_denoms;
+            saved_al  = l_align;
+            l_warptile_mmq  = std::move(wt);
+            l_mmq_wg_denoms = wgd;
+            l_align         = al;
+        };
+
+        auto restore_warp_tile = [&]() {
+            l_warptile_mmq  = std::move(saved_wt);
+            l_mmq_wg_denoms = saved_wgd;
+            l_align         = saved_al;
+        };
+
         // Create 6 variants, {s,m,l}x{unaligned,aligned}
+        // required_subgroup_size is derived from the WARP element (last) of the warptile,
+        // so it is always consistent with the tile and no separate tracking variable is needed.
 #define CREATE_MM(TYPE, PIPELINE_NAME, NAMELC, F16ACC, WG_DENOMS, WARPTILE, PUSHCONST, PARAMCOUNT, ID) \
         if (device->mul_mat ## ID ## _l[TYPE]) \
-            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->l, #NAMELC #F16ACC "_l", NAMELC ## F16ACC ## _cm1_len, NAMELC ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), l_ ## WG_DENOMS, l_ ## WARPTILE, 1, false, true);   \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->l, #NAMELC #F16ACC "_l", NAMELC ## F16ACC ## _cm1_len, NAMELC ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), l_ ## WG_DENOMS, l_ ## WARPTILE, 1, false, true, (l_ ## WARPTILE).back());   \
         if (device->mul_mat ## ID ## _m[TYPE]) \
-            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->m, #NAMELC #F16ACC "_m", NAMELC ## F16ACC ## _cm1_len, NAMELC ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), m_ ## WG_DENOMS, m_ ## WARPTILE, 1, false, true);   \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->m, #NAMELC #F16ACC "_m", NAMELC ## F16ACC ## _cm1_len, NAMELC ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), m_ ## WG_DENOMS, m_ ## WARPTILE, 1, false, true, (m_ ## WARPTILE).back());   \
         if (device->mul_mat ## ID ## _s[TYPE]) \
-            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->s, #NAMELC #F16ACC "_s", NAMELC ## F16ACC ## _cm1_len, NAMELC ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), s_ ## WG_DENOMS, s_ ## WARPTILE, 1, false, true);   \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->s, #NAMELC #F16ACC "_s", NAMELC ## F16ACC ## _cm1_len, NAMELC ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), s_ ## WG_DENOMS, s_ ## WARPTILE, 1, false, true, (s_ ## WARPTILE).back());   \
         if (device->mul_mat ## ID ## _l[TYPE]) \
-            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->a_l, #NAMELC #F16ACC "_aligned_l", NAMELC ## _aligned ## F16ACC ## _cm1_len, NAMELC ## _aligned ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), l_ ## WG_DENOMS, l_ ## WARPTILE, l_align, false, true);   \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->a_l, #NAMELC #F16ACC "_aligned_l", NAMELC ## _aligned ## F16ACC ## _cm1_len, NAMELC ## _aligned ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), l_ ## WG_DENOMS, l_ ## WARPTILE, l_align, false, true, (l_ ## WARPTILE).back());   \
         if (device->mul_mat ## ID ## _m[TYPE]) \
-            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->a_m, #NAMELC #F16ACC "_aligned_m", NAMELC ## _aligned ## F16ACC ## _cm1_len, NAMELC ## _aligned ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), m_ ## WG_DENOMS, m_ ## WARPTILE, m_align, false, true);   \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->a_m, #NAMELC #F16ACC "_aligned_m", NAMELC ## _aligned ## F16ACC ## _cm1_len, NAMELC ## _aligned ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), m_ ## WG_DENOMS, m_ ## WARPTILE, m_align, false, true, (m_ ## WARPTILE).back());   \
         if (device->mul_mat ## ID ## _s[TYPE]) \
-            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->a_s, #NAMELC #F16ACC "_aligned_s", NAMELC ## _aligned ## F16ACC ## _cm1_len, NAMELC ## _aligned ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), s_ ## WG_DENOMS, s_ ## WARPTILE, s_align, false, true);   \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->a_s, #NAMELC #F16ACC "_aligned_s", NAMELC ## _aligned ## F16ACC ## _cm1_len, NAMELC ## _aligned ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), s_ ## WG_DENOMS, s_ ## WARPTILE, s_align, false, true, (s_ ## WARPTILE).back());   \
 
         // Create 2 variants, {f16,f32} accumulator
 #define CREATE_MM2(TYPE, PIPELINE_NAME, NAMELC, WG_DENOMS, WARPTILE, PUSHCONST, PARAMCOUNT, ID) \
@@ -4177,6 +4218,22 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         } \
         if (device->coopmat_acc_f32_support) { \
             CREATE_MM(TYPE, PIPELINE_NAME . f32acc, NAMELC, , WG_DENOMS, WARPTILE, PUSHCONST, PARAMCOUNT, ID) \
+        } \
+
+        // build the alt l/a_l pipelines into the ->l_alt / ->a_l_alt slots.
+        // Same shader SPV as ->l/->a_l, but compiled with a different warp tile via the saved l_warptile_mmq.
+#define CREATE_MM_ALT(TYPE, PIPELINE_NAME, NAMELC, F16ACC, WG_DENOMS, WARPTILE, PUSHCONST, PARAMCOUNT, ID) \
+        if (device->mul_mat ## ID ## _l[TYPE]) \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->l_alt,   #NAMELC #F16ACC "_l_alt",         NAMELC ##            F16ACC ## _cm1_len, NAMELC ##            F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), l_ ## WG_DENOMS, l_ ## WARPTILE, 1,       false, true, (l_ ## WARPTILE).back());   \
+        if (device->mul_mat ## ID ## _l[TYPE]) \
+            ggml_vk_create_pipeline(device, device-> PIPELINE_NAME ->a_l_alt, #NAMELC #F16ACC "_aligned_l_alt", NAMELC ## _aligned ## F16ACC ## _cm1_len, NAMELC ## _aligned ## F16ACC ## _cm1_data, "main", PARAMCOUNT, sizeof(PUSHCONST), l_ ## WG_DENOMS, l_ ## WARPTILE, l_align, false, true, (l_ ## WARPTILE).back());
+
+#define CREATE_MM2_ALT(TYPE, PIPELINE_NAME, NAMELC, WG_DENOMS, WARPTILE, PUSHCONST, PARAMCOUNT, ID) \
+        if (device->coopmat_acc_f16_support) { \
+            CREATE_MM_ALT(TYPE, PIPELINE_NAME . f16acc, NAMELC, _f16acc, WG_DENOMS, WARPTILE, PUSHCONST, PARAMCOUNT, ID) \
+        } \
+        if (device->coopmat_acc_f32_support) { \
+            CREATE_MM_ALT(TYPE, PIPELINE_NAME . f32acc, NAMELC, , WG_DENOMS, WARPTILE, PUSHCONST, PARAMCOUNT, ID) \
         } \
 
         CREATE_MM(GGML_TYPE_F32, pipeline_matmul_f32, matmul_f32_f32, , wg_denoms, warptile, vk_mat_mat_push_constants, 3, );
@@ -4239,6 +4296,81 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             CREATE_MM(GGML_TYPE_NVFP4,   pipeline_dequant_mul_mat_mat[GGML_TYPE_NVFP4].f32acc,   matmul_nvfp4_f32,   , mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
         }
 
+        // f16 B-type dense GEMM pipelines for coopmat1 (used when y_non_contig auto-converts f32→f16)
+        CREATE_MM2(GGML_TYPE_Q1_0, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q1_0], matmul_q1_0_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_Q4_0, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q4_0], matmul_q4_0_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_Q4_1, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q4_1], matmul_q4_1_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_Q5_0, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q5_0], matmul_q5_0_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_Q5_1, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q5_1], matmul_q5_1_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        // Xe3 LPG: q8_0 uses BM=BN=128 BK=64 tile; restore brings back the 128x256 xe2 base used by K-quants/IQ*.
+        if (device->architecture == INTEL_XE2 && device->coopmat_support && device->shader_core_count == 12) set_warp_tile({256, 128, 128, 64, 32, 32, 2, 8, 16, 16, 16}, {128, 128, 1}, 64);
+        CREATE_MM2(GGML_TYPE_Q8_0, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q8_0], matmul_q8_0_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        if (device->architecture == INTEL_XE2 && device->coopmat_support && device->shader_core_count == 12) restore_warp_tile();
+        CREATE_MM2(GGML_TYPE_Q2_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q2_K], matmul_q2_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_Q3_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q3_K], matmul_q3_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_Q5_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q5_K], matmul_q5_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        // Xe1: Q4_K/Q6_K use sgs=32 with a 128x128 tile; IQ* reverts to the xe1 standard tile.
+        if (device->architecture == INTEL_PRE_XE2) set_warp_tile({512, 128, 128, 32, 32, 32, 2, 8, 8, 16, 32}, {128, 128, 1}, l_align);
+        CREATE_MM2(GGML_TYPE_Q4_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q4_K], matmul_q4_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_Q6_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q6_K], matmul_q6_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        if (device->architecture == INTEL_PRE_XE2) restore_warp_tile();
+        CREATE_MM2(GGML_TYPE_IQ1_S,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ1_S],   matmul_iq1_s_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ1_M,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ1_M],   matmul_iq1_m_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ2_XXS, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ2_XXS], matmul_iq2_xxs_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ2_XS,  pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ2_XS],  matmul_iq2_xs_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ2_S,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ2_S],   matmul_iq2_s_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ3_XXS, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ3_XXS], matmul_iq3_xxs_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ3_S],   matmul_iq3_s_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ4_XS],  matmul_iq4_xs_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ4_NL],  matmul_iq4_nl_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_MXFP4],   matmul_mxfp4_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+        CREATE_MM2(GGML_TYPE_NVFP4,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_NVFP4],   matmul_nvfp4_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+
+        // build the ALT l/a_l pipelines into ->l_alt / ->a_l_alt for f16-B-type
+        // dense quant matmul (pipeline_dequant_mul_mat_mat_f16[*]). The dispatch in
+        // ggml_vk_guess_matmul_pipeline picks these when n<256 && m<4096.
+        // Uses the BM=128/WM=16 warp tile.
+        if (device->vendor_id == VK_VENDOR_ID_INTEL) {
+            // Intel XE2 coopmat shape: TM=8, TN=16, TK=16 (tm_m/tn_m/tk_m are out of scope here)
+            set_warp_tile({ 512, 128, 128, 32, 16, 32, 2, 8, 16, 16, 16 }, { 128, 128, 1 }, 32);
+
+            CREATE_MM2_ALT(GGML_TYPE_Q4_0, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q4_0], matmul_q4_0_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q4_1, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q4_1], matmul_q4_1_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q5_0, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q5_0], matmul_q5_0_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q5_1, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q5_1], matmul_q5_1_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q8_0, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q8_0], matmul_q8_0_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q2_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q2_K], matmul_q2_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q3_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q3_K], matmul_q3_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q4_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q4_K], matmul_q4_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q5_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q5_K], matmul_q5_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_Q6_K, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_Q6_K], matmul_q6_k_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ1_S,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ1_S],   matmul_iq1_s_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ1_M,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ1_M],   matmul_iq1_m_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ2_XXS, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ2_XXS], matmul_iq2_xxs_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ2_XS,  pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ2_XS],  matmul_iq2_xs_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ2_S,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ2_S],   matmul_iq2_s_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ3_XXS, pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ3_XXS], matmul_iq3_xxs_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ3_S],   matmul_iq3_s_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ4_XS],  matmul_iq4_xs_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_IQ4_NL],  matmul_iq4_nl_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+            CREATE_MM2_ALT(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_f16[GGML_TYPE_MXFP4],   matmul_mxfp4_f16,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_push_constants, 3, );
+
+            restore_warp_tile();
+        }
+
+        // Intel matmul_id warptile tuning
+        if (device->vendor_id == VK_VENDOR_ID_INTEL) {
+            if (device->architecture == INTEL_PRE_XE2) {
+                l_warptile_mmq  = { 512, 128, 128, 32, 32, 32, 2, 8, 8, 16, 32 };
+                l_mmq_wg_denoms = { 128, 128, 1 };
+            }
+            else if (device->architecture == INTEL_XE2) {
+                l_warptile_mmq  = { 512, 128, 128, 32, 32, 32, 2, 8, 16, 16, 32 };
+                l_mmq_wg_denoms = { 128, 128, 1 };
+            }
+            l_align = 32;  //set as BK
+        }
+
         GGML_ASSERT(device->subgroup_ballot);
 
         CREATE_MM(GGML_TYPE_F32, pipeline_matmul_id_f32, matmul_id_subgroup_f32_f32, , wg_denoms, warptile, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
@@ -4270,10 +4402,16 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         CREATE_MM2(GGML_TYPE_IQ3_S,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ3_S],   matmul_id_subgroup_iq3_s_f32,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
         CREATE_MM2(GGML_TYPE_IQ4_XS,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_XS],  matmul_id_subgroup_iq4_xs_f32,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
         CREATE_MM2(GGML_TYPE_IQ4_NL,  pipeline_dequant_mul_mat_mat_id[GGML_TYPE_IQ4_NL],  matmul_id_subgroup_iq4_nl_f32,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
-        CREATE_MM2(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_MXFP4],   matmul_id_subgroup_mxfp4_f32,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
+        CREATE_MM2(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_MXFP4],      matmul_id_subgroup_mxfp4_f32, mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
+        CREATE_MM2(GGML_TYPE_MXFP4,   pipeline_dequant_mul_mat_mat_id_f16b[GGML_TYPE_MXFP4], matmul_id_subgroup_mxfp4_f16, mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
+        CREATE_MM2(GGML_TYPE_Q4_K,    pipeline_dequant_mul_mat_mat_id_f16b[GGML_TYPE_Q4_K],  matmul_id_subgroup_q4_k_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
+        CREATE_MM2(GGML_TYPE_Q5_K,    pipeline_dequant_mul_mat_mat_id_f16b[GGML_TYPE_Q5_K],  matmul_id_subgroup_q5_k_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
+        CREATE_MM2(GGML_TYPE_Q5_1,    pipeline_dequant_mul_mat_mat_id_f16b[GGML_TYPE_Q5_1],  matmul_id_subgroup_q5_1_f16,  mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
         CREATE_MM2(GGML_TYPE_NVFP4,   pipeline_dequant_mul_mat_mat_id[GGML_TYPE_NVFP4],   matmul_id_subgroup_nvfp4_f32,   mmq_wg_denoms, warptile_mmq, vk_mat_mat_id_push_constants, mul_mat_id_param_count, _id);
 #undef CREATE_MM2
 #undef CREATE_MM
+#undef CREATE_MM2_ALT
+#undef CREATE_MM_ALT
     } else
 #endif  // defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
     if (device->fp16) {
@@ -4675,6 +4813,8 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_Q2_K][i], "mul_mat_vec_q2_k_f32_f32", arr_dmmv_q2_k_f32_f32_len[reduc16], arr_dmmv_q2_k_f32_f32_data[reduc16], "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_kq, 1, 1}, {wg_size_subgroup16, rm_kq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_Q3_K][i], "mul_mat_vec_q3_k_f32_f32", arr_dmmv_q3_k_f32_f32_len[reduc16], arr_dmmv_q3_k_f32_f32_data[reduc16], "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_kq, 1, 1}, {wg_size_subgroup16, rm_kq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_Q4_K][i], "mul_mat_vec_q4_k_f32_f32", arr_dmmv_q4_k_f32_f32_len[reduc16], arr_dmmv_q4_k_f32_f32_data[reduc16], "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_kq, 1, 1}, {wg_size_subgroup16, rm_kq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
+            // Q4_K f32_f32 alt: NUM_ROWS=4 register-tile on M. Selected at dispatch when k<=1024.
+            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_q4_k_4rows_f32_f32[w][i], "mul_mat_vec_q4_k_4rows_f32_f32", arr_dmmv_q4_k_f32_f32_len[reduc16], arr_dmmv_q4_k_f32_f32_data[reduc16], "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {4, 1, 1}, {wg_size_subgroup16, 4, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_Q5_K][i], "mul_mat_vec_q5_k_f32_f32", arr_dmmv_q5_k_f32_f32_len[reduc16], arr_dmmv_q5_k_f32_f32_data[reduc16], "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_kq, 1, 1}, {wg_size_subgroup16, rm_kq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_Q6_K][i], "mul_mat_vec_q6_k_f32_f32", arr_dmmv_q6_k_f32_f32_len[reduc16], arr_dmmv_q6_k_f32_f32_data[reduc16], "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_kq, 1, 1}, {wg_size_subgroup16, rm_kq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_IQ1_S][i],   "mul_mat_vec_iq1_s_f32_f32",   arr_dmmv_iq1_s_f32_f32_len[reduc16],   arr_dmmv_iq1_s_f32_f32_data[reduc16],   "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
@@ -6990,7 +7130,7 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_pipeline(ggml_backend_vk_conte
         return pipelines;
     }
 
-    if (src1_type != GGML_TYPE_F32 && !ctx->device->coopmat2) {
+    if (src1_type != GGML_TYPE_F32 && src1_type != GGML_TYPE_F16 && !ctx->device->coopmat2) {
         return nullptr;
     }
 
@@ -7027,6 +7167,9 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_pipeline(ggml_backend_vk_conte
         return prec == GGML_PREC_DEFAULT ? ctx->device->pipeline_dequant_mul_mat_mat_f16[src0_type].f16acc : ctx->device->pipeline_dequant_mul_mat_mat_f16[src0_type].f32acc;
     }
     if (ctx->device->coopmat_support) {
+        if (src1_type == GGML_TYPE_F16) {
+            return (ctx->device->fp16 && ctx->device->coopmat_acc_f16_support && prec == GGML_PREC_DEFAULT) ? ctx->device->pipeline_dequant_mul_mat_mat_f16[src0_type].f16acc : ctx->device->pipeline_dequant_mul_mat_mat_f16[src0_type].f32acc;
+        }
         return (ctx->device->fp16 && ctx->device->coopmat_acc_f16_support && prec == GGML_PREC_DEFAULT) ? ctx->device->pipeline_dequant_mul_mat_mat[src0_type].f16acc : ctx->device->pipeline_dequant_mul_mat_mat[src0_type].f32acc;
     }
     return (ctx->device->fp16 && prec == GGML_PREC_DEFAULT) ? ctx->device->pipeline_dequant_mul_mat_mat[src0_type].f16acc : ctx->device->pipeline_dequant_mul_mat_mat[src0_type].f32acc;
@@ -7113,6 +7256,14 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec(ggml_backend_vk_context * 
         return ctx->device->pipeline_dequant_mul_mat_vec_q8_1_f32[dmmv_wg][a_type][num_cols-1];
     }
 
+    // Q4_K f32_f32 with small K wins from NUM_ROWS=4 register-tiling on M (Qwen3-0.6B shapes).
+    if (a_type == GGML_TYPE_Q4_K && b_type == GGML_TYPE_F32 && k <= 1024) {
+        vk_pipeline alt = ctx->device->pipeline_dequant_mul_mat_vec_q4_k_4rows_f32_f32[dmmv_wg][num_cols-1];
+        if (alt) {
+            return alt;
+        }
+    }
+
     return b_type == GGML_TYPE_F32 ? ctx->device->pipeline_dequant_mul_mat_vec_f32_f32[dmmv_wg][a_type][num_cols-1] : ctx->device->pipeline_dequant_mul_mat_vec_f16_f32[dmmv_wg][a_type][num_cols-1];
 }
 
@@ -7151,19 +7302,16 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_id_pipeline(ggml_backend_vk_co
         return pipelines;
     }
 
-    GGML_ASSERT(src1_type == GGML_TYPE_F32 || (ctx->device->coopmat2 && src1_type == GGML_TYPE_F16));
+    GGML_ASSERT(src1_type == GGML_TYPE_F32 || src1_type == GGML_TYPE_F16);
 
     switch (src0_type) {
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q4_1:
         case GGML_TYPE_Q5_0:
-        case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
-        case GGML_TYPE_Q4_K:
-        case GGML_TYPE_Q5_K:
         case GGML_TYPE_Q6_K:
         case GGML_TYPE_IQ1_S:
         case GGML_TYPE_IQ1_M:
@@ -7174,7 +7322,27 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_id_pipeline(ggml_backend_vk_co
         case GGML_TYPE_IQ3_S:
         case GGML_TYPE_IQ4_XS:
         case GGML_TYPE_IQ4_NL:
+            if (src1_type == GGML_TYPE_F16 && !ctx->device->coopmat2) {
+                return nullptr; // no f16 B pipeline for these types on coopmat1
+            }
+            break;
+        case GGML_TYPE_Q4_K:
+        case GGML_TYPE_Q5_K:
+        case GGML_TYPE_Q5_1:
         case GGML_TYPE_MXFP4:
+            if (src1_type == GGML_TYPE_F16 && !ctx->device->coopmat2) {
+                // Use the dedicated f16 B pipeline
+                vk_matmul_pipeline2& mmp_f16b = ctx->device->pipeline_dequant_mul_mat_mat_id_f16b[src0_type];
+                bool prefer_fp16acc = ctx->device->fp16;
+                bool support_fp16acc = !mmp_f16b.f16acc->is_empty();
+                bool support_fp32acc = !mmp_f16b.f32acc->is_empty();
+                if (support_fp16acc && (prefer_fp16acc || !support_fp32acc)) {
+                    return mmp_f16b.f16acc;
+                } else if (support_fp32acc) {
+                    return mmp_f16b.f32acc;
+                }
+                return nullptr;
+            }
         case GGML_TYPE_NVFP4:
             break;
         default:
@@ -8029,6 +8197,16 @@ static vk_pipeline ggml_vk_guess_matmul_pipeline(ggml_backend_vk_context * ctx, 
     if ((mm_m && (m <= 64 || n <= 64)) || !mm_l) {
         return aligned ? mmp->a_m : mmp->m;
     }
+
+    // Intel-only: use the alt l-tile (BM=128, WM=16, WG=512) for small-N / small-M shapes.
+    // The alt pipeline was pre-built at device init and lives in mmp->l_alt / mmp->a_l_alt;
+    // non-Intel and pipelines without an alt fall through to the regular l path.
+    if (ctx->device->vendor_id == VK_VENDOR_ID_INTEL &&
+        n < 256 && m < 4096 &&
+        (aligned ? mmp->a_l_alt : mmp->l_alt) != nullptr) {
+        return aligned ? mmp->a_l_alt : mmp->l_alt;
+    }
+
     return aligned ? mmp->a_l : mmp->l;
 }
 
@@ -8428,6 +8606,11 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
     const bool x_non_contig = (ctx->device->coopmat2 && src0->type == GGML_TYPE_F32) ||
                               !ggml_vk_dim01_contiguous(src0);
     const bool y_non_contig = (ctx->device->coopmat2 && src1->type == GGML_TYPE_F32) ||
+                              // Intel coopmat1: force f32->f16 conversion so the f16-B-type pipeline is used.
+                              // non-Intel coopmat1 devices will have no impact.
+                              (ctx->device->coopmat_support && !ctx->device->coopmat2 &&
+                               ctx->device->vendor_id == VK_VENDOR_ID_INTEL &&
+                               ggml_is_quantized(src0->type) && src1->type == GGML_TYPE_F32) ||
                               (src0->type == GGML_TYPE_BF16 && src1->type != GGML_TYPE_BF16) ||
                               !ggml_vk_dim01_contiguous(src1);
 
@@ -8704,15 +8887,21 @@ static bool ggml_vk_should_use_mmvq(const vk_device& device, uint32_t m, uint32_
             }
         }
 
-        if (device->driver_id == vk::DriverId::eIntelProprietaryWindows) {
-            // Intel Windows proprietary driver MMVQ performance for !Q2/Q3/Q6 is worse than fp16,
-            // see https://github.com/ggml-org/llama.cpp/issues/17628 and
-            // https://github.com/ggml-org/llama.cpp/pull/23056
+        if (k < 2048) {
             return false;
         }
 
-        if (k < 2048) {
-            return false;
+        if (device->driver_id == vk::DriverId::eIntelProprietaryWindows) {
+            // Intel Windows proprietary driver tuning
+            switch (src0_type) {
+            case GGML_TYPE_MXFP4:
+            case GGML_TYPE_Q4_K:
+            case GGML_TYPE_Q5_K:
+            case GGML_TYPE_Q8_0:  // MMVQ tg-slower than float path on Xe3 (n>1 pp returns true earlier)
+                return false;
+            default:
+                return true;
+            }
         }
 
         switch (src0_type) {
@@ -8765,6 +8954,11 @@ static void ggml_vk_mul_mat_vec_q_f16(ggml_backend_vk_context * ctx, vk_context&
     GGML_ASSERT(ne11 == 1 || ne12 * ne13 == 1);
     bool batch_n = ne11 > 1;
 
+    // For large batch_n (N > max_cols), dispatch one workgroup per column with NUM_COLS=1
+    // instead of processing all columns in a single workgroup
+    const bool large_batch_n = batch_n && ne11 > mul_mat_vec_max_cols;
+    const uint32_t effective_num_cols = large_batch_n ? 1 : static_cast<uint32_t>(ne11);
+
     const bool x_non_contig = !ggml_vk_dim01_contiguous(src0);
     const bool y_non_contig = !ggml_vk_dim01_contiguous(src1);
 
@@ -8783,12 +8977,12 @@ static void ggml_vk_mul_mat_vec_q_f16(ggml_backend_vk_context * ctx, vk_context&
     }
 
     // Check for mmq first
-    vk_pipeline dmmv = quantize_y ? ggml_vk_get_dequantize_mul_mat_vec(ctx, src0->type, GGML_TYPE_Q8_1, ne11, ne20, ne00) : nullptr;
+    vk_pipeline dmmv = quantize_y ? ggml_vk_get_dequantize_mul_mat_vec(ctx, src0->type, GGML_TYPE_Q8_1, effective_num_cols, ne20, ne00) : nullptr;
     vk_pipeline to_q8_1 = nullptr;
 
     if (dmmv == nullptr) {
         // Fall back to f16 dequant mul mat
-        dmmv = ggml_vk_get_dequantize_mul_mat_vec(ctx, src0->type, src1->type, ne11, ne20, ne00);
+        dmmv = ggml_vk_get_dequantize_mul_mat_vec(ctx, src0->type, src1->type, effective_num_cols, ne20, ne00);
         quantize_y = false;
     }
 
@@ -8941,12 +9135,15 @@ static void ggml_vk_mul_mat_vec_q_f16(ggml_backend_vk_context * ctx, vk_context&
         fusion_flags |= MAT_VEC_FUSION_FLAGS_BIAS1;
     }
 
-    ggml_pipeline_request_descriptor_sets(ctx, dmmv, CEIL_DIV(ne12 * ne13, ctx->device->properties.limits.maxComputeWorkGroupCount[1]));
+    // For large_batch_n, dispatch ne11 workgroups in Y (one per column) instead of ne12*ne13
+    const uint32_t total_y = large_batch_n ? static_cast<uint32_t>(ne11) : static_cast<uint32_t>(ne12 * ne13);
+
+    ggml_pipeline_request_descriptor_sets(ctx, dmmv, CEIL_DIV(total_y, ctx->device->properties.limits.maxComputeWorkGroupCount[1]));
 
     uint32_t base_work_group_y = 0;
-    while (base_work_group_y < ne12 * ne13) {
+    while (base_work_group_y < total_y) {
 
-        uint32_t groups_y = std::min((uint32_t)(ne12 * ne13) - base_work_group_y, ctx->device->properties.limits.maxComputeWorkGroupCount[1]);
+        uint32_t groups_y = std::min(total_y - base_work_group_y, ctx->device->properties.limits.maxComputeWorkGroupCount[1]);
         const vk_mat_vec_push_constants pc = {
             (uint32_t)ne00, (uint32_t)ne10, (uint32_t)ne10, (uint32_t)ne01,
             stride_batch_x, stride_batch_y, stride_batch_d,
@@ -9276,8 +9473,10 @@ static void ggml_vk_mul_mat(ggml_backend_vk_context * ctx, vk_context& subctx, c
                src1->ne[2] <= ctx->device->properties.limits.maxComputeWorkGroupCount[2]) {
         ggml_vk_mul_mat_vec_nc_f16_f32(ctx, subctx, cgraph, node_idx);
     // mul_mat_vec supports batching ne12*ne13 when ne11==1, or treating ne11 as the batch size (up to four)
-    // when ne12 and ne13 are one.
-    } else if ((dst->ne[1] == 1 || (dst->ne[1] <= mul_mat_vec_max_cols && src1->ne[2] * src1->ne[3] == 1)) &&
+    // when ne12 and ne13 are one. For small M (<=4) with large N, dispatch one workgroup per column.
+    } else if ((dst->ne[1] == 1 ||
+                (dst->ne[1] <= mul_mat_vec_max_cols && src1->ne[2] * src1->ne[3] == 1) ||
+                (dst->ne[0] <= 4 && src1->ne[2] * src1->ne[3] == 1)) &&
                (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || src0->type == GGML_TYPE_BF16 || ggml_is_quantized(src0->type))) {
         ggml_vk_mul_mat_vec_q_f16(ctx, subctx, cgraph, node_idx);
     } else {
@@ -9365,6 +9564,10 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
 #endif
     const bool y_non_contig = y_decode_vector_staging ||
                               (ctx->device->coopmat2 && src1->type == GGML_TYPE_F32) ||
+                              // Intel coopmat1: force f32->f16 conversion so the f16-B-type pipeline is used.
+                              (ctx->device->coopmat_support && !ctx->device->coopmat2 &&
+                               ctx->device->vendor_id == VK_VENDOR_ID_INTEL &&
+                               (src0->type == GGML_TYPE_MXFP4 || src0->type == GGML_TYPE_Q4_K || src0->type == GGML_TYPE_Q5_K || src0->type == GGML_TYPE_Q5_1) && src1->type == GGML_TYPE_F32) ||
                               (src0->type == GGML_TYPE_BF16 && src1->type != GGML_TYPE_BF16) ||
                               !ggml_vk_dim01_contiguous(src1);
 
@@ -9880,7 +10083,8 @@ static void ggml_vk_mul_mat_id(ggml_backend_vk_context * ctx, vk_context& subctx
     ggml_tensor * src1 = dst->src[1];
     ggml_tensor * src2 = dst->src[2];
     VK_LOG_DEBUG("ggml_vk_mul_mat_id(" << src0 << ", " << src1 << ", " << src2 << ", " << dst << ")");
-    if (ggml_vk_use_mul_mat_vec_id(cgraph, node_idx)) {
+    // vec path only supports f32/Q8_1 B; fall through to matrix path for f16 B
+    if (ggml_vk_use_mul_mat_vec_id(cgraph, node_idx) && src1->type != GGML_TYPE_F16) {
         ggml_vk_mul_mat_vec_id_q_f16(ctx, subctx, cgraph, node_idx);
     } else {
         ggml_vk_mul_mat_id_q_f16(ctx, subctx, src0, src1, src2, dst);
@@ -10098,7 +10302,6 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                                                                    mask != nullptr, use_mask_opt, logit_softcap != 0, k->type, v->type);
 
     vk_pipeline pipeline = nullptr;
-
     {
         std::lock_guard<std::mutex> guard(ctx->device->compile_mutex);
         auto &pipelines = ctx->device->pipeline_flash_attn_f32_f16;
@@ -10356,10 +10559,10 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                                     pc, { dispatch_x, workgroups_y, workgroups_z });
 
         ggml_vk_sync_buffers(ctx, subctx);
-        const vk_op_flash_attn_split_k_reduce_push_constants pc2 = { HSV, (uint32_t)ne1, (uint32_t)ne2, (uint32_t)ne3, split_k, (sinks != nullptr) };
+        const vk_op_flash_attn_split_k_reduce_push_constants pc2 = { HSV, static_cast<uint32_t>(ne1), static_cast<uint32_t>(ne2), static_cast<uint32_t>(ne3), split_k, (sinks != nullptr) };
         ggml_vk_dispatch_pipeline(ctx, subctx, ctx->device->pipeline_flash_attn_split_k_reduce,
                                     {split_k_buf, sinks_buf, dst_buf},
-                                    pc2, { (uint32_t)ne1, HSV, (uint32_t)(ne2 * ne3) });
+                                    pc2, { static_cast<uint32_t>(ne1), HSV, static_cast<uint32_t>(ne2 * ne3) });
         ctx->prealloc_split_k_need_sync = true;
     } else if (xe_fa_opt) {
         auto power_of_2 = [&](uint32_t in) {
@@ -16264,13 +16467,11 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
 
             bool need_disable = false;
 
-            // topk_moe often overwrites the source, but for a given row all the src values are
-            // loaded before anything is stored. If there's only one row, this is safe, so treat
-            // this as a special case.
-            bool is_topk_moe_single_row = ctx->fused_topk_moe_mode != TOPK_MOE_COUNT &&
-                                          ggml_nrows(cgraph->nodes[i]->src[0]) == 1;
+            // Note: topk_moe handles src/dst overlap internally for all batch sizes,
+            // so skip the overlap check entirely for topk_moe fusions.
+            bool is_topk_moe = ctx->fused_topk_moe_mode != TOPK_MOE_COUNT;
 
-            if (!is_topk_moe_single_row) {
+            if (!is_topk_moe) {
                 for (int j = 0; j < 2; ++j) {
                     ggml_tensor *dst = output_nodes[j];
                     if (!dst) {
@@ -16777,6 +16978,12 @@ void ggml_backend_vk_get_device_description(int device, char * description, size
     GGML_ASSERT(device < (int) vk_instance.device_indices.size());
     int dev_idx = vk_instance.device_indices[device];
     ggml_vk_get_device_description(dev_idx, description, description_size);
+}
+
+static bool ggml_backend_vk_is_intel_xe2(int device) {
+    GGML_ASSERT(device < (int) vk_instance.device_indices.size());
+    int dev_idx = vk_instance.device_indices[device];
+    return ggml_vk_get_device(dev_idx)->architecture == INTEL_XE2;
 }
 
 void ggml_backend_vk_get_device_memory(int device, size_t * free, size_t * total) {
@@ -17676,11 +17883,20 @@ static ggml_backend_dev_t ggml_backend_vk_reg_get_device(ggml_backend_reg_t reg,
     return devices[device];
 }
 
+static void * ggml_backend_vk_reg_get_proc_address(ggml_backend_reg_t reg, const char * name) {
+    if (std::strcmp(name, "ggml_backend_vk_is_intel_xe2") == 0) {
+        return (void *) ggml_backend_vk_is_intel_xe2;
+    }
+    return nullptr;
+
+    GGML_UNUSED(reg);
+}
+
 static const struct ggml_backend_reg_i ggml_backend_vk_reg_i = {
     /* .get_name         = */ ggml_backend_vk_reg_get_name,
     /* .get_device_count = */ ggml_backend_vk_reg_get_device_count,
     /* .get_device       = */ ggml_backend_vk_reg_get_device,
-    /* .get_proc_address = */ NULL,
+    /* .get_proc_address = */ ggml_backend_vk_reg_get_proc_address,
 };
 
 ggml_backend_reg_t ggml_backend_vk_reg() {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -308,6 +308,7 @@ enum vk_device_architecture {
     AMD_RDNA1,
     AMD_RDNA2,
     AMD_RDNA3,
+    INTEL_PRE_XE2,
     INTEL_XE2,
     NVIDIA_PRE_TURING,
     NVIDIA_TURING,
@@ -389,6 +390,7 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
             // https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2025-0/intel-xe-gpu-architecture.html
             return vk_device_architecture::INTEL_XE2;
         }
+        else if (subgroup_size_control_props.minSubgroupSize == 8) return vk_device_architecture::INTEL_PRE_XE2;
     } else if (props.vendorID == VK_VENDOR_ID_NVIDIA) {
         const std::vector<vk::ExtensionProperties> ext_props = device.enumerateDeviceExtensionProperties();
 
@@ -3742,7 +3744,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             l_warptile = { 256, 128, 128, 16, subgroup_size_8, 64, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq = l_warptile_mmq_int = { 256, 128, 128, 32, subgroup_size_8, 64, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq_int_k = { 256, 128, 128, 32, subgroup_size_16, 64, 1, 4, 2, 1, subgroup_size_16 };
-        } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support && device->architecture == INTEL_XE2) {
+        } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support) {
             // Xe2/Xe3 with coopmat enabled - warptile performance tuning
             l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq = { 512, 128, 128, 32, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
@@ -5618,6 +5620,16 @@ static vk_device ggml_vk_get_device(size_t idx) {
             device->external_memory_host = false;
         }
 
+        if (device->vendor_id == VK_VENDOR_ID_INTEL) {
+            // Override driver-reported maxStorageBufferRange to 2 GiB.
+            // Some Intel drivers report a smaller value than hardware actually supports,
+            // causing large tensors to be CPU-offloaded unnecessarily.
+            // TODO: remove once driver fixes the issue.
+            if (device->properties.limits.maxStorageBufferRange < 2u * 1024u * 1024u * 1024u) {
+                device->properties.limits.maxStorageBufferRange = 2u * 1024u * 1024u * 1024u;
+            }
+        }
+
         // Implementing the async backend interfaces seems broken on older Intel HW,
         // see https://github.com/ggml-org/llama.cpp/issues/17302.
         device->support_async = (device->vendor_id != VK_VENDOR_ID_INTEL ||
@@ -6174,7 +6186,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 // Current Windows driver does not expose BF16 support.
                 // We only want to use l_warptile if coopmat is available and is Xe2+
                 const bool xe2_with_coopmat = device->coopmat_support && device->architecture == INTEL_XE2;
-                const bool use_l_warptile = (i == GGML_TYPE_BF16) ? (device->coopmat_bf16_support && xe2_with_coopmat) : xe2_with_coopmat;
+                const bool use_l_warptile = (i == GGML_TYPE_BF16) ? (device->coopmat_bf16_support && xe2_with_coopmat) :
+                                                                    device->coopmat_support;
                 device->mul_mat_l[i] = use_l_warptile;
                 device->mul_mat_id_l[i] = use_l_warptile;
                 device->mul_mat_m[i] = true;
@@ -17413,9 +17426,9 @@ static bool ggml_vk_device_is_supported(const vk::PhysicalDevice & vkdev) {
 static bool ggml_vk_khr_cooperative_matrix_support(const vk::PhysicalDeviceProperties& props, const vk::PhysicalDeviceDriverProperties& driver_props, vk_device_architecture arch) {
     switch (props.vendorID) {
     case VK_VENDOR_ID_INTEL:
-        // Only allowing Xe2 GPU at the moment since Xe2 GPU can gain significant performance boost,
-        // while some older hardware (ex. Arc A770) has performance regressions
-        return arch == vk_device_architecture::INTEL_XE2;
+        // Only allowing Xe2/Xe3 GPU and integrated Xe GPUs at the moment since older hardware (ex. Arc A770) has performance regressions.
+        return (arch == vk_device_architecture::INTEL_XE2) || 
+            (arch == vk_device_architecture::INTEL_PRE_XE2 && props.deviceType == vk::PhysicalDeviceType::eIntegratedGpu);
     case VK_VENDOR_ID_AMD:
         if (driver_props.driverID == vk::DriverId::eAmdProprietary || driver_props.driverID == vk::DriverId::eAmdOpenSource) {
             // Workaround for AMD proprietary driver reporting support on all GPUs
@@ -17463,6 +17476,8 @@ static uint32_t ggml_vk_intel_shader_core_count(const vk::PhysicalDevice& vkdev)
     case 0xE20B:  // B580
     case 0xE211:  // Pro B60
         return 20;
+    case 0xB080:  // PTL Xe3 LPG 2x6 (12 subslices)
+        return 12;
     default:
         return 0;
     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -930,6 +930,11 @@ struct vk_device_struct {
     std::map<std::pair<uint32_t, uint32_t>, vk_pipeline> pipeline_fa_mask_opt;
 
     vk_pipeline pipeline_flash_attn_split_k_reduce;
+
+    std::map<std::pair<uint32_t, uint32_t>, vk_pipeline> pipeline_xe_fa_prefill_single_phase;
+    std::map<std::pair<uint32_t, uint32_t>, std::pair<vk_pipeline, vk_pipeline>> pipeline_xe_fa_prefill_dual_phases;
+    std::map<std::pair<uint32_t, uint32_t>, std::pair<vk_pipeline, vk_pipeline>> pipeline_xe_fa_decode_dual_phases;
+
     vk_pipeline pipeline_count_experts;
 
     // [2] is for whether to take n_experts from spec constant (0) or push constant (1)
@@ -1172,6 +1177,38 @@ struct vk_flash_attn_push_constants {
     uint32_t k_num;
 };
 static_assert(sizeof(vk_flash_attn_push_constants) <= 128, "sizeof(vk_flash_attn_push_constants) must be <= 128");
+
+struct vk_fa_xe_opt_push_constants {
+    uint32_t kv_seq_len;
+    uint32_t activation_length;
+    uint32_t q_head;
+    uint32_t kv_head;
+    uint32_t qk_ratio;
+    uint32_t qk_sub_groups;
+    uint32_t flag;
+    uint32_t kv_stride;
+    uint32_t batch_stride_q;
+    uint32_t batch_stride_k;
+    uint32_t batch_stride_v;
+    uint32_t batch_stride_m;
+    uint32_t batch_stride_o;
+    float softmax_scale;
+};
+
+struct vk_fa_xe_opt_prefill_split_push_constants {
+    uint32_t q_head;
+    uint32_t kv_head;
+    uint32_t qk_ratio;
+    uint32_t start_head_q;
+    uint32_t start_head_kv;
+    uint32_t activation_length;
+    uint32_t start_activation;
+    uint32_t kv_seq_len;
+    uint32_t kv_head_per_split;
+    uint32_t flag;
+    uint32_t kv_stride;
+    float softmax_scale;
+};
 
 struct vk_op_push_constants {
     uint32_t KX;
@@ -1980,8 +2017,8 @@ struct ggml_backend_vk_context {
 
     size_t semaphore_idx, event_idx;
     ggml_vk_garbage_collector gc;
-    size_t prealloc_size_x, prealloc_size_y, prealloc_size_split_k, prealloc_size_add_rms_partials, prealloc_size_add_rms_partials_offset;
-    vk_buffer prealloc_x, prealloc_y, prealloc_split_k, prealloc_add_rms_partials, sync_staging;
+    size_t prealloc_size_x, prealloc_size_y, prealloc_size_split_k, prealloc_size_add_rms_partials, prealloc_size_add_rms_partials_offset, prealloc_fattn_temp_size;
+    vk_buffer prealloc_x, prealloc_y, prealloc_split_k, prealloc_add_rms_partials, sync_staging, prealloc_fattn_temp;
     vk::Fence fence, almost_ready_fence;
     bool submit_pending {};
     bool almost_ready_fence_pending {};
@@ -4843,6 +4880,78 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     ggml_vk_create_pipeline(device, device->pipeline_matmul_split_k_reduce, "split_k_reduce", split_k_reduce_len, split_k_reduce_data, "main", 2, 2 * sizeof(uint32_t), {256 * 4, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_flash_attn_split_k_reduce, "fa_split_k_reduce", fa_split_k_reduce_len, fa_split_k_reduce_data, "main", 3, sizeof(vk_op_flash_attn_split_k_reduce_push_constants), {1, device->subgroup_size, 1}, {device->subgroup_size}, 1, true);
 
+    if (device->vendor_id == VK_VENDOR_ID_INTEL && (device->architecture == INTEL_XE2 || (device->architecture == INTEL_PRE_XE2 && device->coopmat_support && device->uma))) {
+        uint32_t xe_native_sub_group_size = 16;
+        uint32_t xe_fa_hdim64_dp = 32;
+        auto power_of_2 = [&](uint32_t in) {
+            GGML_ASSERT(in != 0);
+            uint32_t ret = 0;
+            uint32_t temp = in - 1;
+            while ((temp & 0x1) != 0) {
+                temp = temp >> 1;
+                ret++;
+            }
+            return ret;
+        };
+
+        if (device->architecture == INTEL_PRE_XE2) {
+            xe_native_sub_group_size = 8;
+            xe_fa_hdim64_dp = 16;
+        }
+
+        for (auto& it : device->pipeline_xe_fa_prefill_single_phase) {
+            auto HdQk = it.first;
+            auto& pipeline = it.second;
+            uint32_t head_dim = HdQk.first;
+            uint32_t gqa_ratio = HdQk.second;
+            uint32_t gqa_ratio_power2 = (int32_t)(1 << power_of_2(gqa_ratio));
+            uint32_t qk_groups = gqa_ratio / gqa_ratio_power2;
+            switch (head_dim) {
+            case 64:
+                ggml_vk_create_pipeline(device, pipeline, "xe_fa_opt_prefill", fa_hdim_64_cm1_len, fa_hdim_64_cm1_data, "main", 6, sizeof(vk_fa_xe_opt_push_constants), { 256 / gqa_ratio_power2, 1, 1 }, { 256, power_of_2(gqa_ratio), xe_fa_hdim64_dp, xe_native_sub_group_size }, 1, false, true, xe_native_sub_group_size);
+                break;
+            case 96:
+                ggml_vk_create_pipeline(device, pipeline, "xe_fa_opt_prefill", fa_hdim_96_cm1_len, fa_hdim_96_cm1_data, "main", 6, sizeof(vk_fa_xe_opt_push_constants), { 256 / gqa_ratio_power2, 1, 1 }, { 256, power_of_2(gqa_ratio), 16, xe_native_sub_group_size }, 1, false, true, xe_native_sub_group_size);
+                break;
+            case 128:
+                ggml_vk_create_pipeline(device, pipeline, "xe_fa_opt_prefill", fa_hdim_128_cm1_len, fa_hdim_128_cm1_data, "main", 6, sizeof(vk_fa_xe_opt_push_constants), { 128 / gqa_ratio_power2, 1, 1 }, { 256, power_of_2(gqa_ratio), 16, xe_native_sub_group_size }, 1, false, true, xe_native_sub_group_size);
+                break;
+            default:
+                pipeline = nullptr;
+                break;
+            }
+        }
+
+        for (auto& it : device->pipeline_xe_fa_prefill_dual_phases) {
+            auto HdQk = it.first;
+            auto& pipelines = it.second;
+            uint32_t head_dim = HdQk.first;
+            uint32_t gqa_ratio = HdQk.second;
+            uint32_t gqa_ratio_power2 = (int32_t)(1 << power_of_2(gqa_ratio));
+            uint32_t qk_groups = gqa_ratio / gqa_ratio_power2;
+            switch (head_dim) {
+            case 256:
+            case 512:
+                ggml_vk_create_pipeline(device, pipelines.first, "xe_fa_opt_prefill_ph1", fa_prefill_ph1_cm1_len, fa_prefill_ph1_cm1_data, "main", 6, sizeof(vk_fa_xe_opt_prefill_split_push_constants), { 256 / gqa_ratio_power2, 1, 64 }, { 256, power_of_2(gqa_ratio), 64, head_dim, xe_native_sub_group_size }, 1, false, true, xe_native_sub_group_size);
+                ggml_vk_create_pipeline(device, pipelines.second, "xe_fa_opt_prefill_ph2", fa_prefill_ph2_cm1_len, fa_prefill_ph2_cm1_data, "main", 6, sizeof(vk_fa_xe_opt_prefill_split_push_constants), { 256 / gqa_ratio_power2, 64, 1 }, { 256, power_of_2(gqa_ratio), 6, head_dim, xe_native_sub_group_size }, 1, false, true, xe_native_sub_group_size);
+                break;
+            default:
+                pipelines.first = nullptr;
+                pipelines.second = nullptr;
+                break;
+            }
+        }
+
+        for (auto& it : device->pipeline_xe_fa_decode_dual_phases) {
+            auto HdQk = it.first;
+            auto& pipelines = it.second;
+            uint32_t head_dim = HdQk.first;
+            uint32_t gqa_ratio = HdQk.second;
+            ggml_vk_create_pipeline(device, pipelines.first, "xe_fa_opt_decode_ph1", fa_decode_ph1_cm1_len, fa_decode_ph1_cm1_data, "main", 5, sizeof(vk_fa_xe_opt_push_constants), { 1, 64, 1 }, { 128, gqa_ratio, head_dim, 16 }, 1, false, true, 16);
+            ggml_vk_create_pipeline(device, pipelines.second, "xe_fa_opt_decode_ph2", fa_decode_ph2_cm1_len, fa_decode_ph2_cm1_data, "main", 5, sizeof(vk_fa_xe_opt_push_constants), { 16, 1, 1 }, { 128, gqa_ratio, head_dim, xe_native_sub_group_size }, 1, false, true, xe_native_sub_group_size);
+        }
+    }
+
     for (auto &it : device->pipeline_fa_mask_opt) {
         auto BrBc = it.first;
         ggml_vk_create_pipeline(device, it.second, "fa_mask_opt", fa_mask_opt_len, fa_mask_opt_data, "main", 2, sizeof(vk_op_flash_attn_mask_opt_push_constants), {1, 1, 1}, {128, 128 / device->subgroup_size, BrBc.first, BrBc.second}, 1, true, true, device->subgroup_size);
@@ -6779,6 +6888,7 @@ static void ggml_vk_init(ggml_backend_vk_context * ctx, size_t idx) {
     ctx->prealloc_size_x = 0;
     ctx->prealloc_size_y = 0;
     ctx->prealloc_size_split_k = 0;
+    ctx->prealloc_fattn_temp_size = 0;
     // Fixed size of 1KB, for deterministic behavior
     ctx->prealloc_size_add_rms_partials = 1024;
 
@@ -10000,6 +10110,100 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
         }
     }
 
+    bool xe_fa_opt = false;
+    bool fa_copy_qstate = false;
+    bool xe_fa_supported_platform =
+        (ctx->device.get()->architecture == INTEL_XE2 && ctx->device.get()->properties.deviceID != 0xFD80 && ctx->device.get()->properties.deviceID != 0xFD81) ||
+        (ctx->device.get()->architecture == INTEL_PRE_XE2 && ctx->device.get()->coopmat_support && ctx->device.get()->uma);
+    uint32_t max_supported_gqa_ratio = 8;
+    std::set<uint32_t> supported_head_dim = { 64, 96, 128, 256, 512 };
+    bool xe_fa_supported_usage = supported_head_dim.find(neq0) != supported_head_dim.end() && qk_ratio <= max_supported_gqa_ratio && q->nb[1] > q->nb[2] && mask != nullptr;
+    bool xe_fa_supported_dtype = q->type == GGML_TYPE_F32 && k->type == GGML_TYPE_F16 && v->type == GGML_TYPE_F16 && (mask != nullptr && mask->type == GGML_TYPE_F16);
+    std::pair<vk_pipeline, vk_pipeline> xe_fa_pipeline_dual_phases;
+    xe_fa_pipeline_dual_phases.first = xe_fa_pipeline_dual_phases.second = nullptr;
+
+    xe_fa_opt = xe_fa_supported_platform && xe_fa_supported_usage && xe_fa_supported_dtype;
+    size_t size_p = 0;
+    size_t size_group_max = 0;
+    size_t size_global_max = 0;
+    size_t m_p = 4096;
+    if (xe_fa_opt){
+        std::lock_guard<std::recursive_mutex> guard(ctx->device->mutex);
+        int64_t batches = neq3;
+        uint64_t x_ne = ggml_nelements(q);
+        const size_t hdim_reserved_p_decode = 32 * 1024;
+        const size_t hdim_growth_p = 4 * 1024;
+        const size_t reduce_group_log2 = 6;
+        const size_t reduce_group = 64;
+        size_t hdim_reserve_p = (size_t)nek1;
+        hdim_reserve_p = (hdim_reserve_p + reduce_group - 1) / reduce_group * reduce_group;
+        size_t hdim_group_max = hdim_reserve_p >> reduce_group_log2;
+        size_p = m_p * hdim_reserve_p * sizeof(uint16_t);
+        size_group_max = m_p * hdim_group_max * sizeof(float);
+        size_global_max = m_p * sizeof(float);
+        size_t tmp_size = (size_t)(hdim_reserved_p_decode * 17 / 16 * neq2 * batches * sizeof(float));
+        if (neq1 == 1) {
+            auto& pipelines = ctx->device->pipeline_xe_fa_decode_dual_phases;
+            auto it = pipelines.find({ (uint32_t)neq0, qk_ratio });
+            if (it != pipelines.end()) {
+                xe_fa_pipeline_dual_phases = it->second;
+            }
+            else {
+                pipelines[{(uint32_t)neq0, qk_ratio}] = xe_fa_pipeline_dual_phases = std::make_pair(std::make_shared<vk_pipeline_struct>(), std::make_shared<vk_pipeline_struct>());
+            }
+            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
+            assert(xe_fa_pipeline_dual_phases.first);
+            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.second, 1);
+            assert(xe_fa_pipeline_dual_phases.second);
+        }
+        else {
+            if (neq0 > 128) {
+                auto& pipelines = ctx->device->pipeline_xe_fa_prefill_dual_phases;
+                auto it = pipelines.find({ (uint32_t)neq0, qk_ratio });
+                if (it != pipelines.end()) {
+                    xe_fa_pipeline_dual_phases = it->second;
+                }
+                else {
+                    pipelines[{(uint32_t)neq0, qk_ratio}] = xe_fa_pipeline_dual_phases = std::make_pair(std::make_shared<vk_pipeline_struct>(), std::make_shared<vk_pipeline_struct>());
+                }
+                ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
+                assert(xe_fa_pipeline_dual_phases.first);
+                ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.second, 1);
+                assert(xe_fa_pipeline_dual_phases.second);
+                fa_copy_qstate = true;
+            }
+            else {
+                auto& pipelines = ctx->device->pipeline_xe_fa_prefill_single_phase;
+                auto it = pipelines.find({ (uint32_t)neq0, qk_ratio });
+                if (it != pipelines.end()) {
+                    xe_fa_pipeline_dual_phases.first = it->second;
+                }
+                else {
+                    pipelines[{(uint32_t)neq0, qk_ratio}] = xe_fa_pipeline_dual_phases.first = std::make_shared<vk_pipeline_struct>();
+                }
+                ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
+                assert(xe_fa_pipeline_dual_phases.first);
+            }
+        }
+
+        if (neq1 == 1) { // decode temp buffer
+            tmp_size = std::max(tmp_size, (uint64_t)((nek1 + hdim_growth_p - 1) / hdim_growth_p * hdim_growth_p) * 17 / 16 * neq2 * batches * sizeof(float));
+        }
+
+        if (xe_fa_pipeline_dual_phases.second != nullptr && neq1 > 1) {
+            size_t prefill_temp_size = size_p + size_group_max + size_global_max;
+            if (fa_copy_qstate == true) {
+                prefill_temp_size = prefill_temp_size + x_ne * sizeof(ggml_fp16_t);
+            }
+            tmp_size = std::max(tmp_size, prefill_temp_size);
+        }
+
+        if (ctx->prealloc_fattn_temp_size < tmp_size) {
+            ctx->prealloc_fattn_temp_size = tmp_size;
+            ggml_vk_preallocate_buffers(ctx, subctx);
+        }
+    }
+
     assert(pipeline);
     // Compile early to initialize wg_denoms.
     ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
@@ -10027,6 +10231,11 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
         if (total_wgs_no_split < shader_core_count * 2) {
             split_k = shader_core_count * 2 / total_wgs_no_split;
         }
+    }
+
+    if (xe_fa_opt == true) {
+        split_k = 1;
+        use_mask_opt = false;
     }
 
     if (split_k > 1) {
@@ -10152,6 +10361,132 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                                     {split_k_buf, sinks_buf, dst_buf},
                                     pc2, { (uint32_t)ne1, HSV, (uint32_t)(ne2 * ne3) });
         ctx->prealloc_split_k_need_sync = true;
+    } else if (xe_fa_opt) {
+        auto power_of_2 = [&](uint32_t in) {
+            GGML_ASSERT(in != 0);
+            uint32_t ret = 0;
+            uint32_t temp = in - 1;
+            while ((temp & 0x1) != 0) {
+                temp = temp >> 1;
+                ret++;
+            }
+            return ret;
+        };
+        auto to_fp16_vk_0 = ggml_vk_get_to_fp16(ctx, q->type);
+        uint64_t x_ne = ggml_nelements(q);
+        int64_t batches = neq3;
+        vk_subbuffer q_temp_buf = fa_copy_qstate ? ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, 0) : q_buf;
+        vk_fa_xe_opt_push_constants fattn_consts;
+        int32_t gqa_ratio_pow2 = (int32_t)(1 << power_of_2(qk_ratio));
+        int32_t qk_groups = qk_ratio / gqa_ratio_pow2;
+        uint32_t activation_per_split = 512;
+        uint32_t kv_head_per_split = (m_p / activation_per_split) / gqa_ratio_pow2;
+        fattn_consts.activation_length = neq1;
+        fattn_consts.kv_head = nek2;
+        fattn_consts.kv_seq_len = nek1;
+        fattn_consts.q_head = neq2;
+        fattn_consts.softmax_scale = scale;
+        fattn_consts.flag = (sinks != nullptr) ? 1 : 0;
+        fattn_consts.qk_ratio = qk_ratio;
+        fattn_consts.qk_sub_groups = qk_groups;
+        fattn_consts.kv_stride = k_stride;
+        fattn_consts.batch_stride_q = nbq3 / ggml_type_size(q->type);
+        fattn_consts.batch_stride_k = nbk3 / ggml_type_size(k->type);
+        fattn_consts.batch_stride_v = nbv3 / ggml_type_size(v->type);
+        fattn_consts.batch_stride_m = mask ? (mask->nb[3] / ggml_type_size(mask->type)) : 0;
+        fattn_consts.batch_stride_o = nb3 / ggml_type_size(dst->type);
+
+        vk_fa_xe_opt_prefill_split_push_constants fattn_consts_dual_prefill;
+        fattn_consts_dual_prefill.kv_head = nek2;
+        fattn_consts_dual_prefill.kv_seq_len = nek1;
+        fattn_consts_dual_prefill.q_head = neq2;
+        fattn_consts_dual_prefill.softmax_scale = scale;
+        fattn_consts_dual_prefill.flag = (sinks != nullptr) ? 1 : 0;
+        fattn_consts_dual_prefill.start_head_q = 0;
+        fattn_consts_dual_prefill.kv_head_per_split = kv_head_per_split;
+        fattn_consts_dual_prefill.kv_stride = k_stride;
+        fattn_consts_dual_prefill.qk_ratio = qk_ratio;
+        if (fa_copy_qstate) {
+            const std::vector<uint32_t> pc_cpy_fp16 =
+            { (uint32_t)q->ne[0], (uint32_t)q->ne[1], (uint32_t)q->ne[2], (uint32_t)q->ne[3], (uint32_t)(ggml_nelements(q)) };
+
+            ggml_vk_sync_buffers(ctx, subctx);
+            ggml_pipeline_request_descriptor_sets(ctx, to_fp16_vk_0, 1);
+            ggml_vk_dispatch_pipeline(ctx, subctx, to_fp16_vk_0, { q_buf, q_temp_buf }, pc_cpy_fp16, { (uint32_t)(x_ne), 1, 1 });
+        }
+
+        if (neq1 == 1) {
+            size_t size_decode_p = neq3 * neq2 * nek1 * sizeof(float);
+            vk_subbuffer p_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, 0);
+            vk_subbuffer max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, size_decode_p);
+            ggml_vk_sync_buffers(ctx, subctx);
+            ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.first,
+                { q_temp_buf, k_buf, mask_buf, p_temp_buf, max_temp_buf },
+                fattn_consts, { (uint32_t)nek2, (uint32_t)nek1, (uint32_t)batches });
+            ggml_vk_sync_buffers(ctx, subctx);
+            ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.second,
+                { p_temp_buf, v_buf, max_temp_buf, sinks_buf, dst_buf },
+                fattn_consts, { (uint32_t)neq0, (uint32_t)nek2, (uint32_t)batches });
+        }
+        else if (xe_fa_pipeline_dual_phases.second != nullptr && neq1 > 1) { // 2 phase prefill
+            size_t temp_offset = 0;
+            if (fa_copy_qstate) { temp_offset += x_ne * sizeof(uint16_t); }
+            vk_subbuffer p_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, temp_offset);
+            temp_offset += size_p;
+            vk_subbuffer group_max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, temp_offset);
+            temp_offset += size_group_max;
+            vk_subbuffer global_max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, temp_offset);
+            temp_offset += size_global_max;
+            uint32_t q_len = neq1;
+            int32_t gqa_ratio = (int32_t)(1 << power_of_2(qk_ratio));
+            int32_t q_loop = (q_len + activation_per_split - 1) / activation_per_split;
+            int32_t p_loop = qk_ratio / gqa_ratio;
+            int32_t v_loop = (nek2 + kv_head_per_split - 1) / kv_head_per_split;
+            vk_subbuffer q_batch_buf = q_temp_buf;
+            vk_subbuffer k_batch_buf = k_buf;
+            vk_subbuffer v_batch_buf = v_buf;
+            vk_subbuffer m_batch_buf = mask_buf;
+            vk_subbuffer o_batch_buf = dst_buf;
+            uint32_t q_temp_batch_div = ggml_type_size(q->type) / ggml_type_size(GGML_TYPE_F16);
+            for (int64_t bl = 0; bl < batches; bl++) {
+                for (int32_t ql = 0; ql < q_loop; ql++) {
+                    uint32_t p_len_process = ql == q_loop - 1 ? q_len - ql * activation_per_split : activation_per_split;
+                    fattn_consts_dual_prefill.activation_length = p_len_process;
+                    fattn_consts_dual_prefill.start_activation = ql * activation_per_split;
+                    for (int32_t pl = 0; pl < p_loop; pl++) {
+                        fattn_consts_dual_prefill.start_head_q = pl * gqa_ratio;
+                        for (int32_t vl = 0; vl < v_loop; vl++) {
+                            fattn_consts_dual_prefill.start_head_kv = vl * kv_head_per_split;
+                            uint32_t v_head_process = vl == v_loop - 1 ? nek2 - vl * kv_head_per_split : kv_head_per_split;
+                            ggml_vk_sync_buffers(ctx, subctx);
+                            ggml_vk_buffer_memset_async(subctx, global_max_temp_buf.buffer, global_max_temp_buf.offset, 0xFEFFFFFF, size_global_max);
+
+                            ggml_vk_sync_buffers(ctx, subctx);
+                            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
+                            ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.first,
+                                { q_batch_buf, k_batch_buf, m_batch_buf, p_temp_buf, group_max_temp_buf, global_max_temp_buf },
+                                fattn_consts_dual_prefill, { (uint32_t)p_len_process, (uint32_t)v_head_process, (uint32_t)nek1 });
+
+                            ggml_vk_sync_buffers(ctx, subctx);
+                            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.second, 1);
+                            ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.second,
+                                { p_temp_buf, v_batch_buf, group_max_temp_buf, sinks_buf, o_batch_buf, global_max_temp_buf },
+                                fattn_consts_dual_prefill, { (uint32_t)p_len_process, (uint32_t)(v_head_process * neq0), 1 });
+                        }
+                    }
+                }
+                q_batch_buf.offset += nbq3 / q_temp_batch_div;
+                k_batch_buf.offset += nbk3;
+                v_batch_buf.offset += nbv3;
+                m_batch_buf.offset += mask ? (mask->nb[3]) : 0;
+                o_batch_buf.offset += nb3;
+            }
+        }
+        else {
+            ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.first,
+                { q_temp_buf, k_buf, v_buf, mask_buf, sinks_buf, dst_buf },
+                fattn_consts, { (uint32_t)neq1, (uint32_t)(qk_groups * nek2), (uint32_t)batches });
+        }
     } else {
         if (gqa_ratio > 1) {
             // When using gqa, we want one actual workgroup per batch, so cancel out wg_denoms
@@ -13931,6 +14266,14 @@ static void ggml_vk_preallocate_buffers(ggml_backend_vk_context * ctx, vk_contex
         }
         ctx->prealloc_add_rms_partials = ggml_vk_create_buffer_device(ctx->device, ctx->prealloc_size_add_rms_partials);
     }
+    if (ctx->prealloc_fattn_temp == nullptr || (ctx->prealloc_fattn_temp_size > 0 && ctx->prealloc_fattn_temp->size < ctx->prealloc_fattn_temp_size)) {
+        VK_LOG_MEMORY("ggml_vk_preallocate_buffers(prealloc_fattn_temp_size: " << ctx->prealloc_fattn_temp_size << ")");
+        // Resize buffer
+        if (ctx->prealloc_fattn_temp != nullptr) {
+            ggml_vk_destroy_buffer(ctx->prealloc_fattn_temp);
+        }
+        ctx->prealloc_fattn_temp = ggml_vk_create_buffer_device(ctx->device, ctx->prealloc_fattn_temp_size);
+    }
 }
 
 static void ggml_vk_compute_forward(ggml_backend_vk_context* ctx, ggml_cgraph * cgraph, ggml_tensor* tensor, int tensor_idx, bool almost_ready);
@@ -14542,6 +14885,7 @@ static void ggml_vk_cleanup(ggml_backend_vk_context * ctx) {
     ggml_vk_destroy_buffer(ctx->prealloc_y);
     ggml_vk_destroy_buffer(ctx->prealloc_split_k);
     ggml_vk_destroy_buffer(ctx->prealloc_add_rms_partials);
+    ggml_vk_destroy_buffer(ctx->prealloc_fattn_temp);
     ggml_vk_destroy_buffer(ctx->sync_staging);
 
     ctx->prealloc_y_last_pipeline_used = nullptr;
@@ -14551,6 +14895,7 @@ static void ggml_vk_cleanup(ggml_backend_vk_context * ctx) {
     ctx->prealloc_size_x = 0;
     ctx->prealloc_size_y = 0;
     ctx->prealloc_size_split_k = 0;
+    ctx->prealloc_fattn_temp_size = 0;
 
     for (auto& event : ctx->gc.events) {
         ctx->device->device.destroyEvent(event);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2024,8 +2024,8 @@ struct ggml_backend_vk_context {
 
     size_t semaphore_idx, event_idx;
     ggml_vk_garbage_collector gc;
-    size_t prealloc_size_x, prealloc_size_y, prealloc_size_split_k, prealloc_size_add_rms_partials, prealloc_size_add_rms_partials_offset, prealloc_fattn_temp_size;
-    vk_buffer prealloc_x, prealloc_y, prealloc_split_k, prealloc_add_rms_partials, sync_staging, prealloc_fattn_temp;
+    size_t prealloc_size_x, prealloc_size_y, prealloc_size_split_k, prealloc_size_add_rms_partials, prealloc_size_add_rms_partials_offset;
+    vk_buffer prealloc_x, prealloc_y, prealloc_split_k, prealloc_add_rms_partials, sync_staging;
     vk::Fence fence, almost_ready_fence;
     bool submit_pending {};
     bool almost_ready_fence_pending {};
@@ -7028,7 +7028,6 @@ static void ggml_vk_init(ggml_backend_vk_context * ctx, size_t idx) {
     ctx->prealloc_size_x = 0;
     ctx->prealloc_size_y = 0;
     ctx->prealloc_size_split_k = 0;
-    ctx->prealloc_fattn_temp_size = 0;
     // Fixed size of 1KB, for deterministic behavior
     ctx->prealloc_size_add_rms_partials = 1024;
 
@@ -10331,7 +10330,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
     size_t size_global_max = 0;
     size_t m_p = 4096;
     if (xe_fa_opt){
-        std::lock_guard<std::recursive_mutex> guard(ctx->device->mutex);
+        std::lock_guard<std::mutex> guard(ctx->device->compile_mutex);
         int64_t batches = neq3;
         uint64_t x_ne = ggml_nelements(q);
         const size_t hdim_reserved_p_decode = 32 * 1024;
@@ -10354,10 +10353,6 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
             else {
                 pipelines[{(uint32_t)neq0, qk_ratio}] = xe_fa_pipeline_dual_phases = std::make_pair(std::make_shared<vk_pipeline_struct>(), std::make_shared<vk_pipeline_struct>());
             }
-            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
-            assert(xe_fa_pipeline_dual_phases.first);
-            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.second, 1);
-            assert(xe_fa_pipeline_dual_phases.second);
         }
         else {
             if (neq0 > 128) {
@@ -10369,10 +10364,6 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                 else {
                     pipelines[{(uint32_t)neq0, qk_ratio}] = xe_fa_pipeline_dual_phases = std::make_pair(std::make_shared<vk_pipeline_struct>(), std::make_shared<vk_pipeline_struct>());
                 }
-                ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
-                assert(xe_fa_pipeline_dual_phases.first);
-                ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.second, 1);
-                assert(xe_fa_pipeline_dual_phases.second);
                 fa_copy_qstate = true;
             }
             else {
@@ -10384,8 +10375,6 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                 else {
                     pipelines[{(uint32_t)neq0, qk_ratio}] = xe_fa_pipeline_dual_phases.first = std::make_shared<vk_pipeline_struct>();
                 }
-                ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
-                assert(xe_fa_pipeline_dual_phases.first);
             }
         }
 
@@ -10401,9 +10390,12 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
             tmp_size = std::max(tmp_size, prefill_temp_size);
         }
 
-        if (ctx->prealloc_fattn_temp_size < tmp_size) {
-            ctx->prealloc_fattn_temp_size = tmp_size;
+        if (ctx->prealloc_size_y < tmp_size) {
+            ctx->prealloc_size_y = tmp_size;
             ggml_vk_preallocate_buffers(ctx, subctx);
+        }
+        if (ctx->prealloc_y_need_sync) {
+            ggml_vk_sync_buffers(ctx, subctx);
         }
     }
 
@@ -10578,7 +10570,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
         auto to_fp16_vk_0 = ggml_vk_get_to_fp16(ctx, q->type);
         uint64_t x_ne = ggml_nelements(q);
         int64_t batches = neq3;
-        vk_subbuffer q_temp_buf = fa_copy_qstate ? ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, 0) : q_buf;
+        vk_subbuffer q_temp_buf = fa_copy_qstate ? ggml_vk_subbuffer(ctx, ctx->prealloc_y, 0) : q_buf;
         vk_fa_xe_opt_push_constants fattn_consts;
         int32_t gqa_ratio_pow2 = (int32_t)(1 << power_of_2(qk_ratio));
         int32_t qk_groups = qk_ratio / gqa_ratio_pow2;
@@ -10616,29 +10608,33 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
             ggml_vk_sync_buffers(ctx, subctx);
             ggml_pipeline_request_descriptor_sets(ctx, to_fp16_vk_0, 1);
             ggml_vk_dispatch_pipeline(ctx, subctx, to_fp16_vk_0, { q_buf, q_temp_buf }, pc_cpy_fp16, { (uint32_t)(x_ne), 1, 1 });
+            ctx->prealloc_y_need_sync = true;
         }
 
         if (neq1 == 1) {
             size_t size_decode_p = neq3 * neq2 * nek1 * sizeof(float);
-            vk_subbuffer p_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, 0);
-            vk_subbuffer max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, size_decode_p);
+            vk_subbuffer p_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_y, 0);
+            vk_subbuffer max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_y, size_decode_p);
             ggml_vk_sync_buffers(ctx, subctx);
+            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
             ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.first,
                 { q_temp_buf, k_buf, mask_buf, p_temp_buf, max_temp_buf },
                 fattn_consts, { (uint32_t)nek2, (uint32_t)nek1, (uint32_t)batches });
             ggml_vk_sync_buffers(ctx, subctx);
+            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.second, 1);
             ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.second,
                 { p_temp_buf, v_buf, max_temp_buf, sinks_buf, dst_buf },
                 fattn_consts, { (uint32_t)neq0, (uint32_t)nek2, (uint32_t)batches });
+            ctx->prealloc_y_need_sync = true;
         }
         else if (xe_fa_pipeline_dual_phases.second != nullptr && neq1 > 1) { // 2 phase prefill
             size_t temp_offset = 0;
             if (fa_copy_qstate) { temp_offset += x_ne * sizeof(uint16_t); }
-            vk_subbuffer p_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, temp_offset);
+            vk_subbuffer p_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_y, temp_offset);
             temp_offset += size_p;
-            vk_subbuffer group_max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, temp_offset);
+            vk_subbuffer group_max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_y, temp_offset);
             temp_offset += size_group_max;
-            vk_subbuffer global_max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_fattn_temp, temp_offset);
+            vk_subbuffer global_max_temp_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_y, temp_offset);
             temp_offset += size_global_max;
             uint32_t q_len = neq1;
             int32_t gqa_ratio = (int32_t)(1 << power_of_2(qk_ratio));
@@ -10684,8 +10680,10 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
                 m_batch_buf.offset += mask ? (mask->nb[3]) : 0;
                 o_batch_buf.offset += nb3;
             }
+            ctx->prealloc_y_need_sync = true;
         }
         else {
+            ggml_pipeline_request_descriptor_sets(ctx, xe_fa_pipeline_dual_phases.first, 1);
             ggml_vk_dispatch_pipeline(ctx, subctx, xe_fa_pipeline_dual_phases.first,
                 { q_temp_buf, k_buf, v_buf, mask_buf, sinks_buf, dst_buf },
                 fattn_consts, { (uint32_t)neq1, (uint32_t)(qk_groups * nek2), (uint32_t)batches });
@@ -14469,14 +14467,6 @@ static void ggml_vk_preallocate_buffers(ggml_backend_vk_context * ctx, vk_contex
         }
         ctx->prealloc_add_rms_partials = ggml_vk_create_buffer_device(ctx->device, ctx->prealloc_size_add_rms_partials);
     }
-    if (ctx->prealloc_fattn_temp == nullptr || (ctx->prealloc_fattn_temp_size > 0 && ctx->prealloc_fattn_temp->size < ctx->prealloc_fattn_temp_size)) {
-        VK_LOG_MEMORY("ggml_vk_preallocate_buffers(prealloc_fattn_temp_size: " << ctx->prealloc_fattn_temp_size << ")");
-        // Resize buffer
-        if (ctx->prealloc_fattn_temp != nullptr) {
-            ggml_vk_destroy_buffer(ctx->prealloc_fattn_temp);
-        }
-        ctx->prealloc_fattn_temp = ggml_vk_create_buffer_device(ctx->device, ctx->prealloc_fattn_temp_size);
-    }
 }
 
 static void ggml_vk_compute_forward(ggml_backend_vk_context* ctx, ggml_cgraph * cgraph, ggml_tensor* tensor, int tensor_idx, bool almost_ready);
@@ -15088,7 +15078,6 @@ static void ggml_vk_cleanup(ggml_backend_vk_context * ctx) {
     ggml_vk_destroy_buffer(ctx->prealloc_y);
     ggml_vk_destroy_buffer(ctx->prealloc_split_k);
     ggml_vk_destroy_buffer(ctx->prealloc_add_rms_partials);
-    ggml_vk_destroy_buffer(ctx->prealloc_fattn_temp);
     ggml_vk_destroy_buffer(ctx->sync_staging);
 
     ctx->prealloc_y_last_pipeline_used = nullptr;
@@ -15098,7 +15087,6 @@ static void ggml_vk_cleanup(ggml_backend_vk_context * ctx) {
     ctx->prealloc_size_x = 0;
     ctx->prealloc_size_y = 0;
     ctx->prealloc_size_split_k = 0;
-    ctx->prealloc_fattn_temp_size = 0;
 
     for (auto& event : ctx->gc.events) {
         ctx->device->device.destroyEvent(event);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_decode_phase_1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_decode_phase_1.comp
@@ -1,0 +1,167 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer Q {float qState[];};
+layout (binding = 0) readonly buffer Q_VEC2 {f16vec2 qStateVec2[];};
+layout (binding = 1) readonly buffer K {float16_t kState[];};
+layout (binding = 1) readonly buffer K_MAT2X4 {f16mat2x4 kStateMat[];};
+layout (binding = 2) buffer MASK {f16vec2 mState[];};
+layout (binding = 2) buffer MASK_F16 {float16_t mState_f16[];};
+layout (binding = 3) buffer P_FP32 {float matP_f32[];};
+layout (binding = 4) buffer OUT_MAX {float out_max_f32[];};
+
+layout (push_constant) uniform parameter
+{
+  uint kvSeqLen;
+  uint activationLength;
+  uint qHead;
+  uint kvHead;
+  uint qkRatio;
+  uint qkSubGroups;
+  uint flag;
+  uint kvStride;
+  uint batchStrideQ;
+  uint batchStrideK;
+  uint batchStrideV;
+  uint batchStrideM;
+  uint batchStrideO;
+  float softMaxScale;
+} p;
+
+layout (constant_id = 0) const uint GROUPSIZE = 32;
+layout (constant_id = 1) const uint GQA_RATIO = 8;
+layout (constant_id = 2) const uint HEAD_DIM = 128;
+layout (constant_id = 3) const uint WARPSIZE = 16;
+
+#define MAX_HEADS 8
+
+#define MAT_P_COUNT (DP / WARPSIZE)
+#define MATP_REDUCE (GROUPSIZE / 2)
+#define SUBGROUP_COUNT (GROUPSIZE / WARPSIZE)
+#define SUBGROUP_DIVISION (SUBGROUP_COUNT / GQA_RATIO)
+
+#define K_COUNT (WARPSIZE / 8)
+#define O_COUNT ((GQA_RATIO + SUBGROUP_COUNT - 1) / SUBGROUP_COUNT)
+
+shared float slm_pool_pv[GQA_RATIO * GROUPSIZE];
+shared float slm_pool_max_temp[GQA_RATIO];
+
+void main() {
+  const uint lane = gl_SubgroupInvocationID;
+  const uint h = gl_WorkGroupID.x;
+  const uint v = gl_WorkGroupID.y;
+  const uint d = gl_WorkGroupID.z;
+  const uint localLinearId = gl_SubgroupID;
+  const uint hhq = localLinearId & 0x1;
+  const uint vvq = localLinearId >> 1;
+  const uint qDim = p.qHead * HEAD_DIM;
+  const uint oDim = qDim;
+  const uint kvDim = p.kvStride;
+  const uint maskDim = p.kvSeqLen;
+  const uint offsetBaseQ = (d * p.batchStrideQ + h * HEAD_DIM * GQA_RATIO + hhq * WARPSIZE + lane);
+  const uint offsetBaseK = (d * p.batchStrideK + (v * MATP_REDUCE + vvq * WARPSIZE) * kvDim + lane * kvDim + h * HEAD_DIM + hhq * K_COUNT * 8) / 8;
+  const uint offsetOut = d * p.qHead * p.kvSeqLen + v * MATP_REDUCE + h * GQA_RATIO * p.kvSeqLen + localLinearId * O_COUNT * p.kvSeqLen + lane;
+  const uint offsetMax = d * p.qHead * p.kvSeqLen / MATP_REDUCE + v + h * GQA_RATIO * p.kvSeqLen / MATP_REDUCE + localLinearId * O_COUNT * p.kvSeqLen / MATP_REDUCE;
+  const uint offsetSlmPv = (localLinearId * WARPSIZE + lane);
+  const uint offsetSlmLoadPv = (localLinearId * O_COUNT * GROUPSIZE + lane);
+  const uint offsetBaseM = d * p.batchStrideM + v * MATP_REDUCE + lane;
+  const float16_t fp16SoftmaxScale = float16_t(p.softMaxScale);
+  f16mat2x4 matK[K_COUNT];
+  float matQ[GQA_RATIO];
+  float fp32P[GQA_RATIO];
+  float fp32TempO[GROUPSIZE / WARPSIZE];
+  float fp32O[O_COUNT][MATP_REDUCE / WARPSIZE];
+  float maxOut[O_COUNT];
+  float16_t mask[MATP_REDUCE / WARPSIZE];
+
+  [[unroll]] for (uint i = 0; i < GQA_RATIO; i++) {
+    fp32P[i] = 0.0f;
+  }
+
+  [[unroll]] for (uint i = 0; i < MATP_REDUCE / WARPSIZE; i++) {
+    mask[i] = mState_f16[i * WARPSIZE + offsetBaseM];
+  }
+
+  const uint loopCount = HEAD_DIM / WARPSIZE / 2;
+  [[unroll]] for (uint loop = 0; loop < loopCount; loop++) {
+    [[unroll]] for (uint kd = 0; kd < K_COUNT; kd++) {
+      matK[kd] = kStateMat[offsetBaseK + loop * 2 * K_COUNT + kd];
+    }
+
+    [[unroll]] for (uint qd = 0; qd < GQA_RATIO; qd++) {
+      matQ[qd] = qState[offsetBaseQ + loop * 2 * WARPSIZE + qd * HEAD_DIM];
+    }
+
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+        fp32P[nn] = fma(float(matK[kk][0].x), subgroupBroadcast(matQ[nn], 8 * kk + 0), fp32P[nn]);
+        fp32P[nn] = fma(float(matK[kk][0].y), subgroupBroadcast(matQ[nn], 8 * kk + 1), fp32P[nn]);
+        fp32P[nn] = fma(float(matK[kk][0].z), subgroupBroadcast(matQ[nn], 8 * kk + 2), fp32P[nn]);
+        fp32P[nn] = fma(float(matK[kk][0].w), subgroupBroadcast(matQ[nn], 8 * kk + 3), fp32P[nn]);
+        fp32P[nn] = fma(float(matK[kk][1].x), subgroupBroadcast(matQ[nn], 8 * kk + 4), fp32P[nn]);
+        fp32P[nn] = fma(float(matK[kk][1].y), subgroupBroadcast(matQ[nn], 8 * kk + 5), fp32P[nn]);
+        fp32P[nn] = fma(float(matK[kk][1].z), subgroupBroadcast(matQ[nn], 8 * kk + 6), fp32P[nn]);
+        fp32P[nn] = fma(float(matK[kk][1].w), subgroupBroadcast(matQ[nn], 8 * kk + 7), fp32P[nn]);
+      }
+    }
+  }
+
+  [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+    fp32P[nn] = fp32P[nn] * p.softMaxScale;
+  }
+
+  [[unroll]] for (uint pd = 0; pd < GQA_RATIO; pd++) {
+    slm_pool_pv[offsetSlmPv + pd * GROUPSIZE] = fp32P[pd];
+  }
+
+  barrier();
+
+  if (O_COUNT * localLinearId < GQA_RATIO) {
+    float maskFp32[MATP_REDUCE / WARPSIZE];
+    [[unroll]] for (uint i = 0; i < MATP_REDUCE / WARPSIZE; i++) {
+      maskFp32[i] = float(mask[i]);
+    }
+    [[unroll]] for (uint oc = 0; oc < O_COUNT; oc++) {
+      [[unroll]] for (uint os = 0; os < GROUPSIZE / WARPSIZE; os++) {
+        fp32TempO[os] = slm_pool_pv[offsetSlmLoadPv + os * WARPSIZE + oc * GROUPSIZE];
+      }
+
+      [[unroll]] for (uint os = 0; os < MATP_REDUCE / WARPSIZE; os++) {
+        fp32O[oc][os] = fp32TempO[2 * os] + fp32TempO[2 * os + 1];
+      }
+
+      [[unroll]] for (uint os = 0; os < MATP_REDUCE / WARPSIZE; os++) {
+        fp32O[oc][os] = fp32O[oc][os] + maskFp32[os];
+      }
+
+      float maxTemp = fp32O[oc][0];
+      [[unroll]] for (uint os = 1; os < MATP_REDUCE / WARPSIZE; os++) {
+        maxTemp = max(maxTemp, fp32O[oc][os]);
+      }
+      maxOut[oc] = subgroupMax(maxTemp);
+      [[unroll]] for (uint os = 0; os < MATP_REDUCE / WARPSIZE; os++) {
+        fp32O[oc][os] = exp(fp32O[oc][os] - maxOut[oc]);
+        fp32O[oc][os] = maskFp32[os] < -1e38 ? 0.0f : fp32O[oc][os];
+      }
+    }
+
+    [[unroll]] for (uint oc = 0; oc < O_COUNT; oc++) {
+      [[unroll]] for (uint os = 0; os < MATP_REDUCE / WARPSIZE; os++) {
+        matP_f32[offsetOut + oc * p.kvSeqLen + os * WARPSIZE] = fp32O[oc][os];
+      }
+      if (lane == 0) {
+        out_max_f32[offsetMax + oc * p.kvSeqLen / MATP_REDUCE] = maxOut[oc];
+      }
+    }
+  }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_decode_phase_1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_decode_phase_1.comp
@@ -76,6 +76,7 @@ void main() {
   const uint offsetSlmLoadPv = (localLinearId * O_COUNT * GROUPSIZE + lane);
   const uint offsetBaseM = d * p.batchStrideM + v * MATP_REDUCE + lane;
   const float16_t fp16SoftmaxScale = float16_t(p.softMaxScale);
+  const float fp32Min = uintBitsToFloat(0xFEFFFFFF);
   f16mat2x4 matK[K_COUNT];
   float matQ[GQA_RATIO];
   float fp32P[GQA_RATIO];
@@ -144,14 +145,13 @@ void main() {
         fp32O[oc][os] = fp32O[oc][os] + maskFp32[os];
       }
 
-      float maxTemp = fp32O[oc][0];
-      [[unroll]] for (uint os = 1; os < MATP_REDUCE / WARPSIZE; os++) {
+      float maxTemp = fp32Min;
+      [[unroll]] for (uint os = 0; os < MATP_REDUCE / WARPSIZE; os++) {
         maxTemp = max(maxTemp, fp32O[oc][os]);
       }
       maxOut[oc] = subgroupMax(maxTemp);
       [[unroll]] for (uint os = 0; os < MATP_REDUCE / WARPSIZE; os++) {
         fp32O[oc][os] = exp(fp32O[oc][os] - maxOut[oc]);
-        fp32O[oc][os] = maskFp32[os] < -1e38 ? 0.0f : fp32O[oc][os];
       }
     }
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_decode_phase_2.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_decode_phase_2.comp
@@ -1,0 +1,251 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer P {float pState[];};
+layout (binding = 1) readonly buffer V {float16_t vState[];};
+layout (binding = 1) readonly buffer V_MAT2X4 {f16mat2x4 vStateMat[];};
+layout (binding = 2) buffer MAX_FP32 {float max_f32[];};
+layout (binding = 3) buffer SINK_FP32 {float sink_f32[];};
+layout (binding = 4) buffer OUT_FP32 {float out_f32[];};
+
+layout (push_constant) uniform parameter
+{
+  uint kvSeqLen;
+  uint activationLength;
+  uint qHead;
+  uint kvHead;
+  uint qkRatio;
+  uint qkSubGroups;
+  uint flag;
+  uint kvStride;
+  uint batchStrideQ;
+  uint batchStrideK;
+  uint batchStrideV;
+  uint batchStrideM;
+  uint batchStrideO;
+  float softMaxScale;
+} p;
+
+layout (constant_id = 0) const uint GROUPSIZE = 32;
+layout (constant_id = 1) const uint GQA_RATIO = 8;
+layout (constant_id = 2) const uint HEAD_DIM = 128;
+layout (constant_id = 3) const uint WARPSIZE = 16;
+
+#define MATP_REDUCE 64
+
+#define MAT_P_COUNT (DP / WARPSIZE)
+#define SUBGROUP_COUNT (GROUPSIZE / WARPSIZE)
+#define SLM_SIZE_HIS_MAX (((GQA_RATIO + WARPSIZE - 1) / WARPSIZE) * WARPSIZE)
+#define V_GROUPS 2
+#define P_GROUPS (SUBGROUP_COUNT / V_GROUPS)
+#define O_COUNT ((GQA_RATIO * 8 + WARPSIZE - 1) / WARPSIZE)
+#define SLM_O_SIZE (O_COUNT * WARPSIZE * SUBGROUP_COUNT)
+
+shared float slm_pool_o[SLM_O_SIZE];
+shared float slm_pool_softmax[SUBGROUP_COUNT * GQA_RATIO];
+shared float slm_pool_historic_max[SLM_SIZE_HIS_MAX];
+
+void main() {
+  const uint lane = gl_SubgroupInvocationID;
+  const uint h = gl_WorkGroupID.x;
+  const uint v = gl_WorkGroupID.y;
+  const uint d = gl_WorkGroupID.z;
+  const uint localLinearId = gl_SubgroupID;
+  const uint hhv = localLinearId % V_GROUPS;
+  const uint vvv = localLinearId / V_GROUPS;
+  const uint maxDim = p.kvSeqLen / MATP_REDUCE;
+  const uint kvDim = p.kvStride;
+  const uint maskDim = p.kvSeqLen;
+  const uint offsetBaseP = (d * p.qHead * p.kvSeqLen + v * GQA_RATIO * p.kvSeqLen + vvv * WARPSIZE + lane);
+  const uint offsetBaseMax = (d * p.qHead * maxDim + v * GQA_RATIO * maxDim);
+  const uint offsetBaseV = (d * p.batchStrideV + v * HEAD_DIM + lane * kvDim + h * V_GROUPS * 8 + vvv * WARPSIZE * kvDim + hhv * 8) / 8;
+  const uint offsetOut = d * p.batchStrideO + v * GQA_RATIO * HEAD_DIM + h * V_GROUPS * 8 + localLinearId * 8;
+  const float fp32Min = uintBitsToFloat(0xFEFFFFFF);
+  uint offsetV = offsetBaseV;
+  uint offsetMax = offsetBaseMax;
+
+  f16mat2x4 matV;
+  float matP[GQA_RATIO];
+  float fp32O[GQA_RATIO * 8];
+  float historicMax[GQA_RATIO];
+  float softmaxSum[GQA_RATIO];
+  float fp32SinkCoeff = fp32Min;
+
+  [[unroll]] for (uint i = 0; i < GQA_RATIO; i++) {
+    softmaxSum[i] = 0;
+    historicMax[i] = fp32Min;
+  }
+
+  [[unroll]] for (uint i = 0; i < 8 * GQA_RATIO; i++) {
+    fp32O[i] = 0.0f;
+  }
+
+  if (0x1 == (p.flag & 0x1)) {
+    if (lane < GQA_RATIO) {
+      fp32SinkCoeff = sink_f32[v * GQA_RATIO + lane];
+    }
+  }
+
+  const uint loopCount = p.kvSeqLen / P_GROUPS / WARPSIZE;
+
+  for (uint loop = 0; loop < loopCount; loop++) {
+    float currMax[GQA_RATIO];
+    float loopMax[GQA_RATIO];
+    float compensationO[GQA_RATIO];
+    float compensationP[GQA_RATIO];
+
+    matV = vStateMat[offsetV];
+
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      currMax[nn] = max_f32[offsetMax + nn * maxDim];
+    }
+
+    [[unroll]] for (uint pn = 0; pn < GQA_RATIO; pn++) {
+      matP[pn] = pState[offsetBaseP + loop * P_GROUPS * WARPSIZE + pn * p.kvSeqLen];
+    }
+
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      loopMax[nn] = max(currMax[nn], historicMax[nn]);
+    }
+
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      compensationO[nn] = exp(historicMax[nn] - loopMax[nn]);
+    }
+
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      compensationP[nn] = exp(currMax[nn] - loopMax[nn]);
+    }
+
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      matP[nn] = matP[nn] * compensationP[nn];
+      softmaxSum[nn] = softmaxSum[nn] * compensationO[nn] + matP[nn];
+      fp32O[8 * nn + 0] = fp32O[8 * nn + 0] * compensationO[nn];
+      fp32O[8 * nn + 1] = fp32O[8 * nn + 1] * compensationO[nn];
+      fp32O[8 * nn + 2] = fp32O[8 * nn + 2] * compensationO[nn];
+      fp32O[8 * nn + 3] = fp32O[8 * nn + 3] * compensationO[nn];
+      fp32O[8 * nn + 4] = fp32O[8 * nn + 4] * compensationO[nn];
+      fp32O[8 * nn + 5] = fp32O[8 * nn + 5] * compensationO[nn];
+      fp32O[8 * nn + 6] = fp32O[8 * nn + 6] * compensationO[nn];
+      fp32O[8 * nn + 7] = fp32O[8 * nn + 7] * compensationO[nn];
+    }
+
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      fp32O[nn * 8 + 0] = fma(float(matV[0].x), matP[nn], fp32O[nn * 8 + 0]);
+      fp32O[nn * 8 + 1] = fma(float(matV[0].y), matP[nn], fp32O[nn * 8 + 1]);
+      fp32O[nn * 8 + 2] = fma(float(matV[0].z), matP[nn], fp32O[nn * 8 + 2]);
+      fp32O[nn * 8 + 3] = fma(float(matV[0].w), matP[nn], fp32O[nn * 8 + 3]);
+      fp32O[nn * 8 + 4] = fma(float(matV[1].x), matP[nn], fp32O[nn * 8 + 4]);
+      fp32O[nn * 8 + 5] = fma(float(matV[1].y), matP[nn], fp32O[nn * 8 + 5]);
+      fp32O[nn * 8 + 6] = fma(float(matV[1].z), matP[nn], fp32O[nn * 8 + 6]);
+      fp32O[nn * 8 + 7] = fma(float(matV[1].w), matP[nn], fp32O[nn * 8 + 7]);
+    }
+
+    offsetV += WARPSIZE * P_GROUPS * kvDim / 8;
+    offsetMax += 1;
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      historicMax[nn] = loopMax[nn];
+    }
+  }
+
+
+  [[unroll]] for (uint nn = 0; nn < 8 * GQA_RATIO; nn++) {
+    float sumTemp = subgroupAdd(fp32O[nn]);
+    if (lane == 0) {
+      slm_pool_o[nn * P_GROUPS + hhv * 8 * GQA_RATIO * P_GROUPS + vvv] = sumTemp;
+    }
+  }
+
+  if (hhv == 0) {
+    [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+      float sumTemp = subgroupAdd(softmaxSum[nn]);
+      if (lane == 0) {
+        slm_pool_softmax[nn * P_GROUPS + vvv] = sumTemp;
+      }
+    }
+
+    if (0x1 == (p.flag & 0x1)) {
+      if (vvv == 0) {
+        [[unroll]] for (uint nn = 0; nn < GQA_RATIO; nn++) {
+          if (lane == 0) {
+            slm_pool_historic_max[nn] = historicMax[nn];
+          }
+        }
+      }
+    }
+  }
+
+
+  barrier();
+  float softmaxMul;
+  if (localLinearId < V_GROUPS) {
+    float fp32SlmTempO[O_COUNT][P_GROUPS];
+    float fp32SlmTempSoftmax[P_GROUPS];
+    const uint slmOffsetLoad = localLinearId * 8 * GQA_RATIO * P_GROUPS + lane * P_GROUPS;
+    [[unroll]] for (uint oc = 0; oc < O_COUNT; oc++) {
+      [[unroll]] for (uint split = 0; split < P_GROUPS; split++) {
+        fp32SlmTempO[oc][split] = slm_pool_o[slmOffsetLoad + oc * WARPSIZE * P_GROUPS + split];
+      }
+    }
+
+    [[unroll]] for (uint oc = 0; oc < P_GROUPS; oc++) {
+      if (lane < GQA_RATIO) {
+        fp32SlmTempSoftmax[oc] = slm_pool_softmax[lane * P_GROUPS + oc];
+      } else {
+        fp32SlmTempSoftmax[oc] = 0;
+      }
+    }
+
+    softmaxMul = fp32SlmTempSoftmax[0] + fp32SlmTempSoftmax[1];
+    [[unroll]] for (uint oc = 2; oc < P_GROUPS; oc++) {
+      softmaxMul = softmaxMul + fp32SlmTempSoftmax[oc];
+    }
+
+    if (0x1 == (p.flag & 0x1)) {
+      float historicMaxTemp = fp32Min;
+      if (lane < GQA_RATIO) {
+        historicMaxTemp = slm_pool_historic_max[lane];
+      }
+      float sinkCompensation = historicMaxTemp - fp32SinkCoeff;
+      sinkCompensation = exp(sinkCompensation);
+      float softmaxSumTemp = softmaxMul * sinkCompensation;
+      softmaxMul = softmaxMul + 1.0f / sinkCompensation;
+      softmaxMul = 1.0f / softmaxMul;
+      sinkCompensation = sinkCompensation / (1.0f + softmaxSumTemp);
+      softmaxMul = historicMaxTemp < fp32SinkCoeff ? sinkCompensation : softmaxMul;
+    } else {
+      softmaxMul = 1.0f / softmaxMul;
+    }
+
+    [[unroll]] for (uint oc = 0; oc < O_COUNT; oc++) {
+      fp32O[oc] = fp32SlmTempO[oc][0] + fp32SlmTempO[oc][1];
+      [[unroll]] for (uint split = 2; split < P_GROUPS; split++) {
+        fp32O[oc] = fp32O[oc] + fp32SlmTempO[oc][split];
+      }
+    }
+
+    [[unroll]] for (uint oc = 0; oc < O_COUNT; oc++) {
+      const uint tempHead = (oc * WARPSIZE + lane) / 8;
+      if (oc * WARPSIZE + lane < 8 * GQA_RATIO) {
+        fp32O[oc] = fp32O[oc] * subgroupBroadcast(softmaxMul, tempHead);
+      }
+    }
+
+    [[unroll]] for (uint oc = 0; oc < O_COUNT; oc++) {
+      const uint tempHead = (oc * WARPSIZE + lane) / 8;
+      const uint tempChannel = (oc * WARPSIZE + lane) % 8;
+      if (oc * WARPSIZE + lane < 8 * GQA_RATIO) {
+        out_f32[offsetOut + tempHead * HEAD_DIM + tempChannel] = fp32O[oc];
+      }
+    }
+  }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_hdim128.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_hdim128.comp
@@ -1,0 +1,363 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_EXT_shared_memory_block : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer Q {float16_t qState[];};
+layout (binding = 0) readonly buffer Q_VEC2 {f16vec2 qStateVec2[];};
+layout (binding = 0) readonly buffer Q_F32_VEC8 {mat2x4 qStateF32[];};
+layout (binding = 1) readonly buffer K {float16_t kState[];};
+layout (binding = 1) readonly buffer K_VEC4 {f16vec4 kStateVec4[];};
+layout (binding = 2) readonly buffer V {float16_t vState[];};
+layout (binding = 2) readonly buffer V_VEC4 {f16vec4 vStateVec4[];};
+layout (binding = 3) buffer MASK {float16_t mState[];};
+layout (binding = 4) buffer SINK {float sinkCoeff[];};
+layout (binding = 5) buffer OUT {vec4 attnOut[];};
+layout (binding = 5) buffer OUT_FP16 {f16vec4 out_f16[];};
+
+layout (push_constant) uniform parameter
+{
+  uint kvSeqLen;
+  uint activationLength;
+  uint qHead;
+  uint kvHead;
+  uint qkRatio;
+  uint qkSubGroups;
+  uint flag;
+  uint kvStride;
+  uint batchStrideQ;
+  uint batchStrideK;
+  uint batchStrideV;
+  uint batchStrideM;
+  uint batchStrideO;
+  float softMaxScale;
+} p;
+
+layout (constant_id = 0) const uint GROUPSIZE = 256;
+layout (constant_id = 1) const uint GQA_RATIO_LOG2 = 3;
+layout (constant_id = 2) const uint DP = 32;
+layout (constant_id = 3) const uint TN = 16;
+
+#define HEAD_DIM 128
+#define QK_WARP_REDUCE 2
+#define WARPSIZE TN
+#define WARP_DIM (HEAD_DIM / QK_WARP_REDUCE)
+#define GQA_MASK (QK_WARP_REDUCE * (1 << GQA_RATIO_LOG2) - 1)
+#define GQA_RATIO (1 << GQA_RATIO_LOG2)
+
+#define SLM_POOL_SIZE_P (TN * DP * GROUPSIZE / WARPSIZE)
+#define OUTPUT_PER_WORKGROUP (GROUPSIZE / GQA_RATIO / QK_WARP_REDUCE)
+
+#define SLM_POOL_SIZE_Q (4 * 16 * TN * GROUPSIZE / WARPSIZE / 2)
+#define SLM_POOL_SIZE_K (DP * HEAD_DIM / 2)
+#define SLM_POOL_SIZE_V (DP * HEAD_DIM)
+#define SLM_POOL_SIZE_M (OUTPUT_PER_WORKGROUP * DP)
+#define SLM_POOL_SIZE_REDUCE (OUTPUT_PER_WORKGROUP * GQA_RATIO)
+#define SLM_POOL_SIZE_TOTAL_F32 (SLM_POOL_SIZE_P + SLM_POOL_SIZE_K + SLM_POOL_SIZE_M + SLM_POOL_SIZE_V + SLM_POOL_SIZE_REDUCE * 3)
+#define SLM_POOL_SIZE_TOTAL_F16_VEC2 (SLM_POOL_SIZE_Q)
+
+#define SLM_OFFSET_BASE_Q 0
+#define SLM_OFFSET_BASE_P 0
+#define SLM_OFFSET_BASE_K (SLM_OFFSET_BASE_P + SLM_POOL_SIZE_P)
+#define SLM_OFFSET_BASE_M (SLM_OFFSET_BASE_K + SLM_POOL_SIZE_K)
+#define SLM_OFFSET_BASE_V (SLM_OFFSET_BASE_M + SLM_POOL_SIZE_M)
+#define SLM_OFFSET_BASE_HISTORIC_MAX (SLM_OFFSET_BASE_V + SLM_POOL_SIZE_V)
+#define SLM_OFFSET_BASE_SOFTMAX_COMPENSATION (SLM_OFFSET_BASE_HISTORIC_MAX + SLM_POOL_SIZE_REDUCE)
+#define SLM_OFFSET_BASE_SOFTMAX_SUM (SLM_OFFSET_BASE_SOFTMAX_COMPENSATION + SLM_POOL_SIZE_REDUCE)
+
+#define K_COUNT (((SLM_POOL_SIZE_K * 2) / GROUPSIZE) / 4)
+#define V_COUNT (((SLM_POOL_SIZE_V) / GROUPSIZE) / 4)
+#define M_COUNT (SLM_POOL_SIZE_M / GROUPSIZE)
+#define MAT_P_COUNT (DP / 8)
+
+#define SUBGROUP_COUNT (GROUPSIZE / WARPSIZE)
+#define K_OUTER (GROUPSIZE / DP)
+#define V_OUTER (GROUPSIZE / DP)
+
+#define K_INNER (16 / K_COUNT / 4)
+
+shared slm_pool_block {
+  float slm_pool_f32[SLM_POOL_SIZE_TOTAL_F32];
+} slm_pool_float;
+
+shared slm_pool_alias_block {
+  f16vec2 slm_pool_f16[SLM_POOL_SIZE_TOTAL_F16_VEC2];
+} slm_pool_f16vec2;
+
+void main() {
+  const uint lane = gl_SubgroupInvocationID;
+  const uint h = gl_WorkGroupID.x;
+  const uint mix_group = gl_WorkGroupID.y;
+  const uint bs =  gl_WorkGroupID.z;
+  const uint d = mix_group % p.qkSubGroups;
+  const uint v = mix_group / p.qkSubGroups;
+  const uint localLinearId = gl_SubgroupID;
+  const uint hhq = localLinearId & GQA_MASK;
+  const uint vvq = localLinearId >> (GQA_RATIO_LOG2 + 1);
+  const uint hhhq = hhq % QK_WARP_REDUCE;
+  const uint hhvq = hhq / QK_WARP_REDUCE;
+  const uint hhk = localLinearId % K_OUTER;
+  const uint vvk = localLinearId / K_OUTER;
+  const uint hhhk = hhk % K_INNER;
+  const uint vvvk = hhk / K_INNER;
+  const uint hhp = localLinearId % QK_WARP_REDUCE;
+  const uint vvp = localLinearId / QK_WARP_REDUCE;
+  const uint hhv = localLinearId % K_OUTER;
+  const uint vvv = localLinearId / K_OUTER;
+
+  const uint qDim = p.qHead * HEAD_DIM;
+  const uint oDim = qDim;
+  const uint kvDim = p.kvStride;
+  const uint maskDim = p.kvSeqLen;
+  uint offsetBaseK = (bs * p.batchStrideK + vvk * TN * kvDim + hhk * K_COUNT * 4 + lane * kvDim + v * HEAD_DIM) / 4;
+  uint offsetBaseV = (bs * p.batchStrideV + vvv * TN * kvDim + hhv * V_COUNT * 4 + lane * kvDim + v * HEAD_DIM) / 4;
+  uint offsetBaseMask = (h * OUTPUT_PER_WORKGROUP + vvq * TN + lane);
+  offsetBaseMask = min(offsetBaseMask, p.activationLength - 1);
+  offsetBaseMask = (offsetBaseMask * maskDim + bs * p.batchStrideM + hhq * M_COUNT);
+  const uint offsetSlmQ = (localLinearId * TN * WARP_DIM + lane * WARP_DIM) / 2 + SLM_OFFSET_BASE_Q;
+  const uint offsetSlmK = (vvvk * 16 * DP + vvk * TN * 16 + lane * 16 + hhhk * K_COUNT * 4) / 2 + SLM_OFFSET_BASE_K;
+  const uint offsetSlmV = (vvv * TN * HEAD_DIM + hhv * V_COUNT * 4 + lane * HEAD_DIM) + SLM_OFFSET_BASE_V;
+  const uint offsetSlmM = (vvq * TN * DP + hhq * M_COUNT + lane * DP) + SLM_OFFSET_BASE_M;
+  const uint offsetSlmReduce = (vvp * TN + lane);
+  const uint offsetLoadSlmP = (vvp * TN * DP * QK_WARP_REDUCE + lane * DP * QK_WARP_REDUCE) + SLM_OFFSET_BASE_P;
+  const uint offsetSlmP = (vvp * TN * DP * QK_WARP_REDUCE + lane * DP) + SLM_OFFSET_BASE_P;
+  const uint offsetSlmLoadV = (lane * HEAD_DIM + hhhq * WARP_DIM) + SLM_OFFSET_BASE_V;
+  const uint offsetSlmLoadMaskP = (vvq * TN * DP + lane * DP) + SLM_OFFSET_BASE_M;
+
+  const uint offsetOut =  (bs * p.batchStrideO + h * OUTPUT_PER_WORKGROUP * oDim + (v * p.qkRatio + d * GQA_RATIO + hhvq) * HEAD_DIM + hhhq * WARP_DIM + vvq * TN * qDim + lane * oDim) / 4;
+  uint offsetBaseQ = h * OUTPUT_PER_WORKGROUP + vvq * TN + lane;
+  offsetBaseQ = min(offsetBaseQ, p.activationLength - 1);
+  offsetBaseQ = (offsetBaseQ * qDim + bs * p.batchStrideQ + (v * p.qkRatio + d * GQA_RATIO + hhvq) * HEAD_DIM + hhhq * WARP_DIM) / 8;
+
+  const float16_t fp16SoftmaxScale = float16_t(p.softMaxScale);
+  const float fp32Min = uintBitsToFloat(0xFEFFFFFF);
+  const uint kvBoundary = (bs * p.batchStrideK + (p.kvSeqLen - 1) * kvDim + (v + 1) * HEAD_DIM) / 4 - 1;
+  const float fp32SinkCoeff = sinkCoeff[v * p.qkRatio + d * GQA_RATIO + hhvq];
+
+  [[unroll]] for (uint i = 0; i < WARP_DIM / 8; i++) {
+    mat2x4 f32TempMat = qStateF32[offsetBaseQ + i];
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 0] = f16vec2(f32TempMat[0].xy);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 1] = f16vec2(f32TempMat[0].zw);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 2] = f16vec2(f32TempMat[1].xy);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 3] = f16vec2(f32TempMat[1].zw);
+  }
+
+  float fp32Out[WARP_DIM];
+
+  [[unroll]] for (uint i = 0; i < WARP_DIM; i++) {
+    fp32Out[i] = 0;
+  }
+
+  barrier();
+
+  coopmat<float16_t, gl_ScopeSubgroup, 16, TN, gl_MatrixUseB> matQ[4];
+  const uint coopMatBaseQ = localLinearId * TN * WARP_DIM / 2 + SLM_OFFSET_BASE_Q;
+  [[unroll]] for (uint i = 0; i < 4; i++) {
+    coopMatLoad(
+      matQ[i],
+      slm_pool_f16vec2.slm_pool_f16,
+      coopMatBaseQ + 8 * i,
+      WARP_DIM / 2,
+      gl_CooperativeMatrixLayoutColumnMajor);
+  }
+
+  barrier();
+
+  const uint loopCount = (p.kvSeqLen) / DP;
+  float historicMax = fp32Min;
+  float softmaxSum = 0;
+  for (uint loop = 0; loop < loopCount; loop++) {
+    f16vec4 f16KState[K_COUNT];
+    {
+      coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator> sums[MAT_P_COUNT];
+      coopmat<float16_t, gl_ScopeSubgroup, 8, 16, gl_MatrixUseA> matK[MAT_P_COUNT];
+
+      float16_t f16MaskState[M_COUNT];
+
+      [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+        f16KState[kk] = kStateVec4[offsetBaseK + kk];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+        f16MaskState[kk] = mState[offsetBaseMask + kk];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+        slm_pool_f16vec2.slm_pool_f16[offsetSlmK + 2 * kk] = f16KState[kk].xy * fp16SoftmaxScale;
+        slm_pool_f16vec2.slm_pool_f16[offsetSlmK + 2 * kk + 1] = f16KState[kk].zw * fp16SoftmaxScale;
+      }
+
+      [[unroll]] for (uint i = 0; i < MAT_P_COUNT; i++) {
+        sums[i] = coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator>(0.0f);
+      }
+
+      barrier();
+      [[unroll]] for (uint dd = 0; dd < 4; dd++) {
+        [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+          coopMatLoad(
+            matK[cc],
+            slm_pool_f16vec2.slm_pool_f16,
+            SLM_OFFSET_BASE_K + hhhq * DP * WARP_DIM / 2 + DP * 8 * dd + 8 * 8 * cc,
+            16 / 2,
+            gl_CooperativeMatrixLayoutRowMajor);
+        }
+
+        [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+          sums[cc] = coopMatMulAdd(matK[cc], matQ[dd], sums[cc]);
+        }
+      }
+
+      {
+        [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+          slm_pool_float.slm_pool_f32[offsetSlmM + kk] = float(f16MaskState[kk]);
+        }
+      }
+
+      [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+        coopMatStore(sums[cc], slm_pool_float.slm_pool_f32, SLM_OFFSET_BASE_P + 8 * cc + hhp * DP + vvp * TN * DP * QK_WARP_REDUCE, DP * QK_WARP_REDUCE, gl_CooperativeMatrixLayoutColumnMajor);
+      }
+    }
+
+    barrier();
+    [[unroll]] for (uint kk = 0; kk < V_COUNT; kk++) {
+      f16KState[kk] = vStateVec4[offsetBaseV + kk];
+    }
+
+    // p reduce sum and softmax
+    if (hhp == 0) {
+      float fp32M[DP];
+      float matP[DP * QK_WARP_REDUCE];
+      float localMax = historicMax;
+      float softmaxCompensation;
+
+      [[unroll]] for (uint cc = 0; cc < DP * QK_WARP_REDUCE; cc++) {
+        matP[cc] = slm_pool_float.slm_pool_f32[offsetLoadSlmP + cc];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < DP; kk++) {
+        fp32M[kk] = slm_pool_float.slm_pool_f32[offsetSlmLoadMaskP + kk];
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = matP[cc] + matP[cc + DP];
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = matP[cc] + fp32M[cc];
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        localMax = max(localMax, matP[cc]);
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = matP[cc] - localMax;
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = exp(matP[cc]);
+      }
+
+      softmaxCompensation = exp(historicMax - localMax);
+
+      softmaxSum = softmaxSum * softmaxCompensation;
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        softmaxSum += matP[cc];
+      }
+
+      historicMax = localMax;
+      slm_pool_float.slm_pool_f32[SLM_OFFSET_BASE_HISTORIC_MAX + offsetSlmReduce] = historicMax;
+      slm_pool_float.slm_pool_f32[SLM_OFFSET_BASE_SOFTMAX_COMPENSATION + offsetSlmReduce] = softmaxCompensation;
+      slm_pool_float.slm_pool_f32[SLM_OFFSET_BASE_SOFTMAX_SUM + offsetSlmReduce] = softmaxSum;
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        slm_pool_float.slm_pool_f32[offsetSlmP + cc] = matP[cc];
+      }
+    }
+
+    // gemm pv
+    {
+      float fp32V[32];
+      float matP[DP];
+
+      [[unroll]] for (uint cc = 0; cc < V_COUNT; cc++) {
+        fp32V[4 * cc + 0] = float(f16KState[cc].x);
+        fp32V[4 * cc + 1] = float(f16KState[cc].y);
+        fp32V[4 * cc + 2] = float(f16KState[cc].z);
+        fp32V[4 * cc + 3] = float(f16KState[cc].w);
+      }
+
+      [[unroll]] for (uint cc = 0; cc < V_COUNT * 4; cc++) {
+        slm_pool_float.slm_pool_f32[offsetSlmV + cc] = fp32V[cc];
+      }
+
+      barrier();
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = slm_pool_float.slm_pool_f32[offsetSlmP + cc];
+      }
+
+      float softmaxCompensation = slm_pool_float.slm_pool_f32[SLM_OFFSET_BASE_SOFTMAX_COMPENSATION + offsetSlmReduce];
+      [[unroll]] for (uint cc = 0; cc < WARP_DIM; cc++) {
+        fp32Out[cc] = fp32Out[cc] * softmaxCompensation;
+      }
+
+      [[unroll]] for (uint pk = 0; pk < DP / TN; pk++) {
+        [[unroll]] for (uint hc = 0; hc < WARP_DIM / 32; hc++) {
+          [[unroll]] for (uint kk = 0; kk < 32; kk++) {
+            fp32V[kk] = slm_pool_float.slm_pool_f32[offsetSlmLoadV + kk + 32 * hc + TN * HEAD_DIM * pk];
+          }
+
+          [[unroll]] for (uint kk = 0; kk < TN; kk++) {
+            [[unroll]] for (uint cc = 0; cc < 32; cc++) {
+              fp32Out[cc + 32 * hc] = fma(matP[kk + TN * pk], subgroupBroadcast(fp32V[cc], kk), fp32Out[cc + 32 * hc]);
+            }
+          }
+        }
+      }
+    }
+
+    offsetBaseK = offsetBaseK + DP * kvDim / 4;
+    offsetBaseK = min(offsetBaseK, kvBoundary);
+    offsetBaseV = offsetBaseV + DP * kvDim / 4;
+    offsetBaseV = min(offsetBaseV, kvBoundary);
+    offsetBaseMask += DP;
+  }
+
+  float softmaxMul;
+  softmaxSum = slm_pool_float.slm_pool_f32[SLM_OFFSET_BASE_SOFTMAX_SUM + offsetSlmReduce];
+
+  if (0x1 == (p.flag & 0x1)) {
+    historicMax = slm_pool_float.slm_pool_f32[SLM_OFFSET_BASE_HISTORIC_MAX + offsetSlmReduce];
+    float sinkCompensation = historicMax - fp32SinkCoeff;
+    sinkCompensation = exp(sinkCompensation);
+    float softmaxSumTemp = softmaxSum * sinkCompensation;
+    softmaxSum = softmaxSum + 1.0f / sinkCompensation;
+    softmaxSum = 1.0f / softmaxSum;
+    sinkCompensation = sinkCompensation / (1.0f + softmaxSumTemp);
+    softmaxMul = historicMax < fp32SinkCoeff ? sinkCompensation : softmaxSum;
+  }
+  else {
+    softmaxMul = 1.0f / softmaxSum;
+  }
+
+  [[unroll]] for (uint cc = 0; cc < WARP_DIM; cc++) {
+    fp32Out[cc] = fp32Out[cc] * softmaxMul;
+  }
+
+  uint offsetCoord = h * OUTPUT_PER_WORKGROUP + vvq * TN + lane;
+  [[unroll]] for (uint cc = 0; cc < WARP_DIM / 4; cc++) {
+    if (offsetCoord < p.activationLength) {
+      attnOut[offsetOut + cc] = vec4(fp32Out[4 * cc], fp32Out[4 * cc + 1], fp32Out[4 * cc + 2], fp32Out[4 * cc + 3]);
+    }
+  }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_hdim64.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_hdim64.comp
@@ -1,0 +1,331 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_EXT_shared_memory_block : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer Q {float16_t qState[];};
+layout (binding = 0) readonly buffer Q_VEC2 {f16vec2 qStateVec2[];};
+layout (binding = 0) readonly buffer Q_F32_VEC8 {mat2x4 qStateF32[];};
+layout (binding = 1) readonly buffer K {float16_t kState[];};
+layout (binding = 1) readonly buffer K_VEC4 {f16vec4 kStateVec4[];};
+layout (binding = 2) readonly buffer V {float16_t vState[];};
+layout (binding = 2) readonly buffer V_VEC4 {f16vec4 vStateVec4[];};
+layout (binding = 3) buffer MASK {f16vec2 mState[];};
+layout (binding = 4) buffer SINK {float sinkCoeff[];};
+layout (binding = 5) buffer OUT {vec4 attnOut[];};
+layout (binding = 5) buffer OUT_FP16 {f16vec4 out_f16[];};
+
+layout (push_constant) uniform parameter
+{
+  uint kvSeqLen;
+  uint activationLength;
+  uint qHead;
+  uint kvHead;
+  uint qkRatio;
+  uint qkSubGroups;
+  uint flag;
+  uint kvStride;
+  uint batchStrideQ;
+  uint batchStrideK;
+  uint batchStrideV;
+  uint batchStrideM;
+  uint batchStrideO;
+  float softMaxScale;
+} p;
+
+layout (constant_id = 0) const uint GROUPSIZE = 256;
+layout (constant_id = 1) const uint GQA_RATIO_LOG2 = 3;
+layout (constant_id = 2) const uint DP = 32;
+layout (constant_id = 3) const uint TN = 16;
+
+#define HEAD_DIM 64
+#define WARPSIZE TN
+#define GQA_MASK ((1 << GQA_RATIO_LOG2) - 1)
+#define GQA_RATIO (1 << GQA_RATIO_LOG2)
+
+#define SLM_POOL_SIZE_P (TN * DP * GROUPSIZE / WARPSIZE)
+#define OUTPUT_PER_WORKGROUP (GROUPSIZE / GQA_RATIO)
+
+#define SLM_POOL_SIZE_Q (4 * 16 * TN * GROUPSIZE / WARPSIZE / 2)
+#define SLM_POOL_SIZE_K (DP * HEAD_DIM / 2)
+#define SLM_POOL_SIZE_V (DP * HEAD_DIM)
+#define SLM_POOL_SIZE_M (OUTPUT_PER_WORKGROUP * DP)
+#define SLM_POOL_SIZE_TOTAL_F32 (SLM_POOL_SIZE_P + SLM_POOL_SIZE_K + SLM_POOL_SIZE_M + SLM_POOL_SIZE_V)
+#define SLM_POOL_SIZE_TOTAL_F16_VEC2 (SLM_POOL_SIZE_Q)
+
+#define SLM_OFFSET_BASE_Q 0
+#define SLM_OFFSET_BASE_P 0
+#define SLM_OFFSET_BASE_K (SLM_OFFSET_BASE_P + SLM_POOL_SIZE_P)
+#define SLM_OFFSET_BASE_M (SLM_OFFSET_BASE_K + SLM_POOL_SIZE_K)
+#define SLM_OFFSET_BASE_V (SLM_OFFSET_BASE_M + SLM_POOL_SIZE_M)
+
+#define K_COUNT (((DP * HEAD_DIM) / GROUPSIZE) / 4)
+#define V_COUNT (((DP * HEAD_DIM) / GROUPSIZE) / 4)
+#define M_COUNT (((DP * OUTPUT_PER_WORKGROUP) / GROUPSIZE) / 2)
+#define MAT_P_COUNT (DP / 8)
+
+#define SUBGROUP_COUNT (GROUPSIZE / WARPSIZE)
+#define K_OUTER (GROUPSIZE / DP)
+#define V_OUTER (GROUPSIZE / DP)
+
+#define K_INNER (16 / K_COUNT / 4)
+
+shared slm_pool_block {
+  float slm_pool_f32[SLM_POOL_SIZE_TOTAL_F32];
+} slm_pool_float;
+
+shared slm_pool_alias_block {
+  f16vec2 slm_pool_f16[SLM_POOL_SIZE_TOTAL_F16_VEC2];
+} slm_pool_f16vec2;
+
+void main() {
+  const uint lane = gl_SubgroupInvocationID;
+  const uint h = gl_WorkGroupID.x;
+  const uint mix_group = gl_WorkGroupID.y;
+  const uint bs =  gl_WorkGroupID.z;
+  const uint d = mix_group % p.qkSubGroups;
+  const uint v = mix_group / p.qkSubGroups;
+  const uint localLinearId = gl_SubgroupID;
+  const uint hhq = localLinearId & GQA_MASK;
+  const uint vvq = localLinearId >> GQA_RATIO_LOG2;
+  const uint hhk = localLinearId % K_OUTER;
+  const uint vvk = localLinearId / K_OUTER;
+  const uint hhhk = hhk % K_INNER;
+  const uint vvvk = hhk / K_INNER;
+
+  const uint hhv = localLinearId % K_OUTER;
+  const uint vvv = localLinearId / K_OUTER;
+
+  const uint qDim = p.qHead * HEAD_DIM;
+  const uint oDim = qDim;
+  const uint kvDim = p.kvStride;
+  const uint maskDim = p.kvSeqLen;
+  uint offsetBaseK = (bs * p.batchStrideK + vvk * TN * kvDim + hhk * K_COUNT * 4 + lane * kvDim + v * HEAD_DIM) / 4;
+  uint offsetBaseV = (bs * p.batchStrideV + vvv * TN * kvDim + hhv * V_COUNT * 4 + lane * kvDim + v * HEAD_DIM) / 4;
+  uint offsetBaseMask = (h * OUTPUT_PER_WORKGROUP + vvq * TN + lane);
+  offsetBaseMask = min(offsetBaseMask, p.activationLength - 1);
+  offsetBaseMask = (offsetBaseMask * maskDim + bs * p.batchStrideM + hhq * M_COUNT * 2) / 2;
+  const uint offsetSlmQ = (localLinearId * TN * HEAD_DIM + lane * HEAD_DIM) / 2 + SLM_OFFSET_BASE_Q;
+  const uint offsetSlmK = (vvvk * 16 * DP + vvk * TN * 16 + lane * 16 + hhhk * K_COUNT * 4) / 2 + SLM_OFFSET_BASE_K;
+  const uint offsetSlmV = (vvv * TN * HEAD_DIM + hhv * V_COUNT * 4 + lane * HEAD_DIM + SLM_OFFSET_BASE_V);
+  const uint offsetSlmM = (vvq * TN * DP + hhq * M_COUNT * 2 + lane * DP + SLM_OFFSET_BASE_M);
+  const uint offsetLoadSlmP = (SLM_OFFSET_BASE_P + localLinearId * TN * DP + lane * DP);
+  const uint offsetSlmLoadV = (lane * HEAD_DIM + SLM_OFFSET_BASE_V);
+  const uint offsetSlmLoadMaskP = (vvq * TN * DP + lane * DP + SLM_OFFSET_BASE_M);
+  const uint offsetOut =  (bs * p.batchStrideO + h * OUTPUT_PER_WORKGROUP * oDim + (v * p.qkRatio + d * GQA_RATIO + hhq) * HEAD_DIM + vvq * TN * oDim + lane * oDim) / 4;
+  uint offsetBaseQ = h * OUTPUT_PER_WORKGROUP + vvq * TN + lane;
+  offsetBaseQ = min(offsetBaseQ, p.activationLength - 1);
+  offsetBaseQ = (offsetBaseQ * qDim + bs * p.batchStrideQ + (v * p.qkRatio + d * GQA_RATIO + hhq) * HEAD_DIM) / 8;
+  const float16_t fp16SoftmaxScale = float16_t(p.softMaxScale);
+  const float fp32Min = uintBitsToFloat(0xFEFFFFFF);
+  const uint kvBoundary = (bs * p.batchStrideK + (p.kvSeqLen - 1) * kvDim + (v + 1) * HEAD_DIM) / 4 - 1;
+  const float fp32SinkCoeff = sinkCoeff[v * p.qkRatio + d * GQA_RATIO + hhq];
+
+  [[unroll]] for (uint i = 0; i < HEAD_DIM / 8; i++) {
+    mat2x4 f32TempMat = qStateF32[offsetBaseQ + i];
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 0] = f16vec2(f32TempMat[0].xy);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 1] = f16vec2(f32TempMat[0].zw);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 2] = f16vec2(f32TempMat[1].xy);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 3] = f16vec2(f32TempMat[1].zw);
+  }
+
+  float fp32Out[HEAD_DIM];
+  [[unroll]] for (uint i = 0; i < HEAD_DIM; i++) {
+    fp32Out[i] = 0;
+  }
+
+  barrier();
+
+  coopmat<float16_t, gl_ScopeSubgroup, 16, TN, gl_MatrixUseB> matQ[4];
+  const uint coopMatBaseQ = localLinearId * TN * HEAD_DIM / 2 + SLM_OFFSET_BASE_Q;
+  [[unroll]] for (uint i = 0; i < 4; i++) {
+    coopMatLoad(
+      matQ[i],
+      slm_pool_f16vec2.slm_pool_f16,
+      coopMatBaseQ + 8 * i,
+      HEAD_DIM / 2,
+      gl_CooperativeMatrixLayoutColumnMajor);
+  }
+
+  barrier();
+
+  const uint loopCount = (p.kvSeqLen) / DP;
+  float historicMax = fp32Min;
+  float softmaxSum = 0;
+  for (uint loop = 0; loop < loopCount; loop++) {
+
+    {
+      coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator> sums[MAT_P_COUNT];
+      coopmat<float16_t, gl_ScopeSubgroup, 8, 16, gl_MatrixUseA> matK[MAT_P_COUNT];
+      f16vec4 f16KState[K_COUNT];
+
+      f16vec2 f16MaskState[M_COUNT];
+
+      [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+        f16KState[kk] = kStateVec4[offsetBaseK + kk];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+        f16MaskState[kk] = mState[offsetBaseMask + kk];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+        slm_pool_f16vec2.slm_pool_f16[offsetSlmK + 2 * kk] = f16KState[kk].xy * fp16SoftmaxScale;
+        slm_pool_f16vec2.slm_pool_f16[offsetSlmK + 2 * kk + 1] = f16KState[kk].zw * fp16SoftmaxScale;
+      }
+
+      [[unroll]] for (uint i = 0; i < MAT_P_COUNT; i++) {
+        sums[i] = coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator>(0.0f);
+      }
+
+      barrier();
+      [[unroll]] for (uint dd = 0; dd < 4; dd++) {
+        [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+          coopMatLoad(
+            matK[cc],
+            slm_pool_f16vec2.slm_pool_f16,
+            SLM_OFFSET_BASE_K + DP * 8 * dd + 8 * 8 * cc,
+            16 / 2,
+            gl_CooperativeMatrixLayoutRowMajor);
+        }
+
+        [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+          sums[cc] = coopMatMulAdd(matK[cc], matQ[dd], sums[cc]);
+        }
+      }
+
+      {
+        vec2 tempMaskF32[M_COUNT];
+        [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+          tempMaskF32[kk] = vec2(f16MaskState[kk]);
+        }
+
+        [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+          slm_pool_float.slm_pool_f32[offsetSlmM + 2 * kk + 0] = tempMaskF32[kk].x;
+          slm_pool_float.slm_pool_f32[offsetSlmM + 2 * kk + 1] = tempMaskF32[kk].y;
+        }
+      }
+
+      [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+        coopMatStore(sums[cc], slm_pool_float.slm_pool_f32, SLM_OFFSET_BASE_P + 8 * cc + localLinearId * TN * DP, DP, gl_CooperativeMatrixLayoutColumnMajor);
+      }
+    }
+
+    barrier();
+    {
+      f16vec4 f16VState[V_COUNT];
+      float fp32V[32];
+      [[unroll]] for (uint kk = 0; kk < V_COUNT; kk++) {
+        f16VState[kk] = vStateVec4[offsetBaseV + kk];
+      }
+
+      float matP[DP];
+      float localMax = historicMax;
+      float softmaxCompensation;
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = slm_pool_float.slm_pool_f32[offsetLoadSlmP + cc];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < DP; kk++) {
+        fp32V[kk] = slm_pool_float.slm_pool_f32[offsetSlmLoadMaskP + kk];
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = matP[cc] + fp32V[cc];
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        localMax = max(localMax, matP[cc]);
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = matP[cc] - localMax;
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = exp(matP[cc]);
+      }
+
+      {
+        [[unroll]] for (uint cc = 0; cc < V_COUNT; cc++) {
+          fp32V[4 * cc + 0] = float(f16VState[cc].x);
+          fp32V[4 * cc + 1] = float(f16VState[cc].y);
+          fp32V[4 * cc + 2] = float(f16VState[cc].z);
+          fp32V[4 * cc + 3] = float(f16VState[cc].w);
+        }
+
+        [[unroll]] for (uint cc = 0; cc < V_COUNT * 4; cc++) {
+          slm_pool_float.slm_pool_f32[offsetSlmV + cc] = fp32V[cc];
+        }
+      }
+
+      softmaxCompensation = exp(historicMax - localMax);
+      [[unroll]] for (uint cc = 0; cc < HEAD_DIM; cc++) {
+        fp32Out[cc] = fp32Out[cc] * softmaxCompensation;
+      }
+
+      softmaxSum = softmaxSum * softmaxCompensation;
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        softmaxSum += matP[cc];
+      }
+
+      historicMax = localMax;
+      barrier();
+
+      [[unroll]] for (uint pk = 0; pk < DP / TN; pk++) {
+        [[unroll]] for (uint hc = 0; hc < HEAD_DIM / 32; hc++) {
+          [[unroll]] for (uint kk = 0; kk < 32; kk++) {
+            fp32V[kk] = slm_pool_float.slm_pool_f32[offsetSlmLoadV + kk + 32 * hc + TN * HEAD_DIM * pk];
+          }
+
+          [[unroll]] for (uint kk = 0; kk < TN; kk++) {
+            [[unroll]] for (uint cc = 0; cc < 32; cc++) {
+              fp32Out[cc + 32 * hc] = fma(matP[kk + TN * pk], subgroupBroadcast(fp32V[cc], kk), fp32Out[cc + 32 * hc]);
+            }
+          }
+        }
+      }
+    }
+
+    offsetBaseK = offsetBaseK + DP * kvDim / 4;
+    offsetBaseK = min(offsetBaseK, kvBoundary);
+    offsetBaseV = offsetBaseV + DP * kvDim / 4;
+    offsetBaseV = min(offsetBaseV, kvBoundary);
+    offsetBaseMask += DP / 2;
+  }
+
+  float softmaxMul;
+  if (0x1 == (p.flag & 0x1)) {
+    float sinkCompensation = historicMax - fp32SinkCoeff;
+    sinkCompensation = exp(sinkCompensation);
+    float softmaxSumTemp = softmaxSum * sinkCompensation;
+    softmaxSum = softmaxSum + 1.0f / sinkCompensation;
+    softmaxSum = 1.0f / softmaxSum;
+    sinkCompensation = sinkCompensation / (1.0f + softmaxSumTemp);
+    softmaxMul = historicMax < fp32SinkCoeff ? sinkCompensation : softmaxSum;
+  } else {
+    softmaxMul = 1.0f / softmaxSum;
+  }
+
+  [[unroll]] for (uint cc = 0; cc < HEAD_DIM; cc++) {
+    fp32Out[cc] = fp32Out[cc] * softmaxMul;
+  }
+
+  uint offsetCoord = h * OUTPUT_PER_WORKGROUP + vvq * TN + lane;
+
+  [[unroll]] for (uint cc = 0; cc < HEAD_DIM / 4; cc++) {
+    if (offsetCoord < p.activationLength) {
+      attnOut[offsetOut + cc] = vec4(fp32Out[4 * cc], fp32Out[4 * cc + 1], fp32Out[4 * cc + 2], fp32Out[4 * cc + 3]);
+    }
+  }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_hdim96.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_hdim96.comp
@@ -1,0 +1,348 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_EXT_shared_memory_block : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer Q {float16_t qState[];};
+layout (binding = 0) readonly buffer Q_VEC2 {f16vec2 qStateVec2[];};
+layout (binding = 0) readonly buffer Q_F32_VEC8 {mat2x4 qStateF32[];};
+layout (binding = 1) readonly buffer K {float16_t kState[];};
+layout (binding = 1) readonly buffer K_VEC4 {f16vec4 kStateVec4[];};
+layout (binding = 1) readonly buffer K_VEC2 {f16vec2 kStateVec2[];};
+layout (binding = 2) readonly buffer V {float16_t vState[];};
+layout (binding = 2) readonly buffer V_VEC2 {f16vec2 vStateVec2[];};
+layout (binding = 3) buffer MASK {f16vec2 mState[];};
+layout (binding = 4) buffer SINK {float sinkCoeff[];};
+layout (binding = 5) buffer OUT {vec4 attnOut[];};
+layout (binding = 5) buffer OUT_FP16 {f16vec4 out_f16[];};
+
+layout (push_constant) uniform parameter
+{
+  uint kvSeqLen;
+  uint activationLength;
+  uint qHead;
+  uint kvHead;
+  uint qkRatio;
+  uint qkSubGroups;
+  uint flag;
+  uint kvStride;
+  uint batchStrideQ;
+  uint batchStrideK;
+  uint batchStrideV;
+  uint batchStrideM;
+  uint batchStrideO;
+  float softMaxScale;
+} p;
+
+layout (constant_id = 0) const uint GROUPSIZE = 256;
+layout (constant_id = 1) const uint GQA_RATIO_LOG2 = 3;
+layout (constant_id = 2) const uint DP = 32;
+layout (constant_id = 3) const uint TN = 16;
+
+#define HEAD_DIM 96
+#define HEAD_DIM_MAJOR 64
+#define HEAD_DIM_MINOR (HEAD_DIM - HEAD_DIM_MAJOR)
+
+#define TK 16
+#define MAT_Q_COUNT (HEAD_DIM / TK)
+#define WARPSIZE TN
+#define GQA_MASK ((1 << GQA_RATIO_LOG2) - 1)
+#define GQA_RATIO (1 << GQA_RATIO_LOG2)
+
+#define SLM_POOL_SIZE_P (TN * DP * GROUPSIZE / WARPSIZE)
+#define OUTPUT_PER_WORKGROUP (GROUPSIZE / GQA_RATIO)
+
+#define SLM_POOL_SIZE_Q (MAT_Q_COUNT * TK * TN * GROUPSIZE / WARPSIZE / 2)
+#define SLM_POOL_SIZE_K (DP * HEAD_DIM / 2)
+#define SLM_POOL_SIZE_V (DP * HEAD_DIM)
+#define SLM_POOL_SIZE_M (OUTPUT_PER_WORKGROUP * DP)
+#define SLM_POOL_SIZE_TOTAL_F32 (SLM_POOL_SIZE_P + SLM_POOL_SIZE_K + SLM_POOL_SIZE_M + SLM_POOL_SIZE_V)
+#define SLM_POOL_SIZE_TOTAL_F16_VEC2 (SLM_POOL_SIZE_Q)
+
+#define SLM_OFFSET_BASE_Q 0
+#define SLM_OFFSET_BASE_P 0
+#define SLM_OFFSET_BASE_K (SLM_OFFSET_BASE_P + SLM_POOL_SIZE_P)
+#define SLM_OFFSET_BASE_M (SLM_OFFSET_BASE_K + SLM_POOL_SIZE_K)
+#define SLM_OFFSET_BASE_V (SLM_OFFSET_BASE_M + SLM_POOL_SIZE_M)
+
+#define K_MAJOR_COUNT_VEC4 (((DP * HEAD_DIM_MAJOR) / GROUPSIZE) / 4)
+#define K_MINOR_COUNT_VEC2 (((DP * HEAD_DIM_MINOR) / GROUPSIZE) / 2)
+#define V_COUNT (((DP * HEAD_DIM) / GROUPSIZE) / 2)
+#define M_COUNT (((DP * OUTPUT_PER_WORKGROUP) / GROUPSIZE) / 2)
+#define MAT_P_COUNT (DP / 8)
+
+#define SUBGROUP_COUNT (GROUPSIZE / WARPSIZE)
+#define K_OUTER (GROUPSIZE / DP)
+#define V_OUTER (GROUPSIZE / DP)
+
+#define K_MAJOR_INNER (TK / K_MAJOR_COUNT_VEC4 / 4)
+#define K_MINOR_INNER (TK / K_MINOR_COUNT_VEC2 / 2)
+
+shared slm_pool_block {
+  float slm_pool_f32[SLM_POOL_SIZE_TOTAL_F32];
+} slm_pool_float;
+
+shared slm_pool_alias_block {
+  f16vec2 slm_pool_f16[SLM_POOL_SIZE_TOTAL_F16_VEC2];
+} slm_pool_f16vec2;
+
+void main() {
+  const uint lane = gl_SubgroupInvocationID;
+  const uint h = gl_WorkGroupID.x;
+  const uint mix_group = gl_WorkGroupID.y;
+  const uint bs =  gl_WorkGroupID.z;
+  const uint d = mix_group % p.qkSubGroups;
+  const uint v = mix_group / p.qkSubGroups;
+  const uint localLinearId = gl_SubgroupID;
+  const uint hhq = localLinearId & GQA_MASK;
+  const uint vvq = localLinearId >> GQA_RATIO_LOG2;
+  const uint hhk = localLinearId % K_OUTER;
+  const uint vvk = localLinearId / K_OUTER;
+  const uint hhhkMajor = hhk % K_MAJOR_INNER;
+  const uint vvvkMajor = hhk / K_MAJOR_INNER;
+  const uint hhhkMinor = hhk % K_MINOR_INNER;
+  const uint vvvkMinor = hhk / K_MINOR_INNER;
+
+  const uint hhv = localLinearId % K_OUTER;
+  const uint vvv = localLinearId / K_OUTER;
+
+  const uint qDim = p.qHead * HEAD_DIM;
+  const uint oDim = qDim;
+  const uint kvDim = p.kvStride;
+  const uint maskDim = p.kvSeqLen;
+  const uint offsetBaseKMajor = (bs * p.batchStrideK + hhk * K_MAJOR_COUNT_VEC4 * 4 + v * HEAD_DIM) / 4;
+  const uint offsetBaseKMinor = (bs * p.batchStrideK + hhk * K_MINOR_COUNT_VEC2 * 2 + v * HEAD_DIM + HEAD_DIM_MAJOR) / 2;
+  const uint offsetBaseV = (bs * p.batchStrideV + hhv * V_COUNT * 2 + v * HEAD_DIM) / 2;
+
+  uint offsetBaseMask = (h * OUTPUT_PER_WORKGROUP + vvq * TN + lane);
+  offsetBaseMask = min(offsetBaseMask, p.activationLength - 1);
+  offsetBaseMask = (offsetBaseMask * maskDim + bs * p.batchStrideM + hhq * M_COUNT * 2) / 2;
+  const uint offsetSlmQ = (localLinearId * TN * HEAD_DIM + lane * HEAD_DIM) / 2 + SLM_OFFSET_BASE_Q;
+  const uint offsetSlmKMajor = (vvvkMajor * TK * DP + vvk * TN * TK + lane * TK + hhhkMajor * K_MAJOR_COUNT_VEC4 * 4) / 2 + SLM_OFFSET_BASE_K;
+  const uint offsetSlmKMinor = (vvvkMinor * TK * DP + vvk * TN * TK + lane * TK + hhhkMinor * K_MINOR_COUNT_VEC2 * 2 + HEAD_DIM_MAJOR * DP) / 2 + SLM_OFFSET_BASE_K;
+  const uint offsetSlmV = (vvv * TN * HEAD_DIM + hhv * V_COUNT * 2 + lane * HEAD_DIM + SLM_OFFSET_BASE_V);
+  const uint offsetSlmM = (vvq * TN * DP + hhq * M_COUNT * 2 + lane * DP + SLM_OFFSET_BASE_M);
+  const uint offsetLoadSlmP = (SLM_OFFSET_BASE_P + localLinearId * TN * DP + lane * DP);
+  const uint offsetSlmLoadV = (lane * HEAD_DIM + SLM_OFFSET_BASE_V);
+  const uint offsetSlmLoadMaskP = (vvq * TN * DP + lane * DP + SLM_OFFSET_BASE_M);
+  const uint offsetOut =  (bs * p.batchStrideO + h * OUTPUT_PER_WORKGROUP * oDim + (v * p.qkRatio + d * GQA_RATIO + hhq) * HEAD_DIM + vvq * TN * oDim + lane * oDim) / 4;
+  uint offsetBaseQ = h * OUTPUT_PER_WORKGROUP + vvq * TN + lane;
+  offsetBaseQ = min(offsetBaseQ, p.activationLength - 1);
+  offsetBaseQ = (offsetBaseQ * qDim + bs * p.batchStrideQ + (v * p.qkRatio + d * GQA_RATIO + hhq) * HEAD_DIM) / 8;
+  const float16_t fp16SoftmaxScale = float16_t(p.softMaxScale);
+  const float fp32Min = uintBitsToFloat(0xFEFFFFFF);
+  const float fp32SinkCoeff = sinkCoeff[v * p.qkRatio + d * GQA_RATIO + hhq];
+
+  [[unroll]] for (uint i = 0; i < HEAD_DIM / 8; i++) {
+    mat2x4 f32TempMat = qStateF32[offsetBaseQ + i];
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 0] = f16vec2(f32TempMat[0].xy);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 1] = f16vec2(f32TempMat[0].zw);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 2] = f16vec2(f32TempMat[1].xy);
+    slm_pool_f16vec2.slm_pool_f16[offsetSlmQ + i * 4 + 3] = f16vec2(f32TempMat[1].zw);
+  }
+
+  float fp32Out[HEAD_DIM];
+  [[unroll]] for (uint i = 0; i < HEAD_DIM; i++) {
+    fp32Out[i] = 0;
+  }
+
+  barrier();
+
+  coopmat<float16_t, gl_ScopeSubgroup, TK, TN, gl_MatrixUseB> matQ[MAT_Q_COUNT];
+  const uint coopMatBaseQ = localLinearId * TN * HEAD_DIM / 2 + SLM_OFFSET_BASE_Q;
+  [[unroll]] for (uint i = 0; i < MAT_Q_COUNT; i++) {
+    coopMatLoad(
+      matQ[i],
+      slm_pool_f16vec2.slm_pool_f16,
+      coopMatBaseQ + 8 * i,
+      HEAD_DIM / 2,
+      gl_CooperativeMatrixLayoutColumnMajor);
+  }
+
+  barrier();
+
+  const uint loopCount = (p.kvSeqLen) / DP;
+  float historicMax = fp32Min;
+  float softmaxSum = 0;
+  for (uint loop = 0; loop < loopCount; loop++) {
+    uint kvCoord = vvk * TN + lane + loop * DP;
+    kvCoord = min(kvCoord, p.kvSeqLen - 1);
+    kvCoord = kvCoord * kvDim;
+    {
+      coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator> sums[MAT_P_COUNT];
+      coopmat<float16_t, gl_ScopeSubgroup, 8, TK, gl_MatrixUseA> matK[MAT_P_COUNT];
+      f16vec4 f16KStateMajor[K_MAJOR_COUNT_VEC4];
+      f16vec2 f16KStateMinor[K_MINOR_COUNT_VEC2];
+
+      f16vec2 f16MaskState[M_COUNT];
+
+      [[unroll]] for (uint kk = 0; kk < K_MAJOR_COUNT_VEC4; kk++) {
+        f16KStateMajor[kk] = kStateVec4[offsetBaseKMajor + kvCoord / 4 + kk];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < K_MINOR_COUNT_VEC2; kk++) {
+        f16KStateMinor[kk] = kStateVec2[offsetBaseKMinor + kvCoord / 2+ kk];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+        f16MaskState[kk] = mState[offsetBaseMask + kk];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < K_MAJOR_COUNT_VEC4; kk++) {
+        slm_pool_f16vec2.slm_pool_f16[offsetSlmKMajor + 2 * kk] = f16KStateMajor[kk].xy * fp16SoftmaxScale;
+        slm_pool_f16vec2.slm_pool_f16[offsetSlmKMajor + 2 * kk + 1] = f16KStateMajor[kk].zw * fp16SoftmaxScale;
+      }
+
+      [[unroll]] for (uint kk = 0; kk < K_MINOR_COUNT_VEC2; kk++) {
+        slm_pool_f16vec2.slm_pool_f16[offsetSlmKMinor + kk] = f16KStateMinor[kk].xy * fp16SoftmaxScale;
+      }
+
+      [[unroll]] for (uint i = 0; i < MAT_P_COUNT; i++) {
+        sums[i] = coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator>(0.0f);
+      }
+
+      barrier();
+      [[unroll]] for (uint dd = 0; dd < MAT_Q_COUNT; dd++) {
+        [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+          coopMatLoad(
+            matK[cc],
+            slm_pool_f16vec2.slm_pool_f16,
+            SLM_OFFSET_BASE_K + DP * 8 * dd + 8 * 8 * cc,
+            TK / 2,
+            gl_CooperativeMatrixLayoutRowMajor);
+        }
+
+        [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+          sums[cc] = coopMatMulAdd(matK[cc], matQ[dd], sums[cc]);
+        }
+      }
+
+      {
+        vec2 tempMaskF32[M_COUNT];
+        [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+          tempMaskF32[kk] = vec2(f16MaskState[kk]);
+        }
+
+        [[unroll]] for (uint kk = 0; kk < M_COUNT; kk++) {
+          slm_pool_float.slm_pool_f32[offsetSlmM + 2 * kk + 0] = tempMaskF32[kk].x;
+          slm_pool_float.slm_pool_f32[offsetSlmM + 2 * kk + 1] = tempMaskF32[kk].y;
+        }
+      }
+
+      [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+        coopMatStore(sums[cc], slm_pool_float.slm_pool_f32, SLM_OFFSET_BASE_P + 8 * cc + localLinearId * TN * DP, DP, gl_CooperativeMatrixLayoutColumnMajor);
+      }
+    }
+
+    barrier();
+    {
+      f16vec2 f16VState[V_COUNT];
+      float fp32V[32];
+      [[unroll]] for (uint kk = 0; kk < V_COUNT; kk++) {
+        f16VState[kk] = vStateVec2[offsetBaseV + kvCoord / 2 + kk];
+      }
+
+      float matP[DP];
+      float localMax = historicMax;
+      float softmaxCompensation;
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = slm_pool_float.slm_pool_f32[offsetLoadSlmP + cc];
+      }
+
+      [[unroll]] for (uint kk = 0; kk < DP; kk++) {
+        fp32V[kk] = slm_pool_float.slm_pool_f32[offsetSlmLoadMaskP + kk];
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = matP[cc] + fp32V[cc];
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        localMax = max(localMax, matP[cc]);
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = matP[cc] - localMax;
+      }
+
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        matP[cc] = exp(matP[cc]);
+      }
+
+      {
+        [[unroll]] for (uint cc = 0; cc < V_COUNT; cc++) {
+          fp32V[2 * cc + 0] = float(f16VState[cc].x);
+          fp32V[2 * cc + 1] = float(f16VState[cc].y);
+        }
+
+        [[unroll]] for (uint cc = 0; cc < V_COUNT * 2; cc++) {
+          slm_pool_float.slm_pool_f32[offsetSlmV + cc] = fp32V[cc];
+        }
+      }
+
+      softmaxCompensation = exp(historicMax - localMax);
+      [[unroll]] for (uint cc = 0; cc < HEAD_DIM; cc++) {
+        fp32Out[cc] = fp32Out[cc] * softmaxCompensation;
+      }
+
+      softmaxSum = softmaxSum * softmaxCompensation;
+      [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+        softmaxSum += matP[cc];
+      }
+
+      historicMax = localMax;
+      barrier();
+
+      [[unroll]] for (uint pk = 0; pk < DP / TN; pk++) {
+        [[unroll]] for (uint hc = 0; hc < HEAD_DIM / 32; hc++) {
+          [[unroll]] for (uint kk = 0; kk < 32; kk++) {
+            fp32V[kk] = slm_pool_float.slm_pool_f32[offsetSlmLoadV + kk + 32 * hc + TN * HEAD_DIM * pk];
+          }
+
+          [[unroll]] for (uint kk = 0; kk < TN; kk++) {
+            [[unroll]] for (uint cc = 0; cc < 32; cc++) {
+              fp32Out[cc + 32 * hc] = fma(matP[kk + TN * pk], subgroupBroadcast(fp32V[cc], kk), fp32Out[cc + 32 * hc]);
+            }
+          }
+        }
+      }
+    }
+
+    offsetBaseMask += DP / 2;
+  }
+
+  float softmaxMul;
+  if (0x1 == (p.flag & 0x1)) {
+    float sinkCompensation = historicMax - fp32SinkCoeff;
+    sinkCompensation = exp(sinkCompensation);
+    float softmaxSumTemp = softmaxSum * sinkCompensation;
+    softmaxSum = softmaxSum + 1.0f / sinkCompensation;
+    softmaxSum = 1.0f / softmaxSum;
+    sinkCompensation = sinkCompensation / (1.0f + softmaxSumTemp);
+    softmaxMul = historicMax < fp32SinkCoeff ? sinkCompensation : softmaxSum;
+  } else {
+    softmaxMul = 1.0f / softmaxSum;
+  }
+
+  [[unroll]] for (uint cc = 0; cc < HEAD_DIM; cc++) {
+    fp32Out[cc] = fp32Out[cc] * softmaxMul;
+  }
+
+  uint offsetCoord = h * OUTPUT_PER_WORKGROUP + vvq * TN + lane;
+
+  [[unroll]] for (uint cc = 0; cc < HEAD_DIM / 4; cc++) {
+    if (offsetCoord < p.activationLength) {
+      attnOut[offsetOut + cc] = vec4(fp32Out[4 * cc], fp32Out[4 * cc + 1], fp32Out[4 * cc + 2], fp32Out[4 * cc + 3]);
+    }
+  }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_prefill_phase_1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_prefill_phase_1.comp
@@ -1,0 +1,239 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_subgroup_extended_types_int16 : require
+#extension GL_EXT_shader_atomic_float : require
+#extension GL_EXT_shader_atomic_float2 : require
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_KHR_shader_subgroup_vote : enable
+#extension GL_EXT_shared_memory_block : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer Q {float16_t qState[];};
+layout (binding = 0) readonly buffer Q_VEC2 {f16vec2 qStateVec2[];};
+layout (binding = 1) readonly buffer K {float16_t kState[];};
+layout (binding = 1) readonly buffer K_VEC4 {f16vec4 kStateVec4[];};
+layout (binding = 2) buffer MASK {f16vec4 mState[];};
+layout (binding = 2) buffer MASK_UINT16 {u16vec4 mState_u16[];};
+layout (binding = 3) buffer OUT_P_FP16 {f16vec4 out_f16[];};
+layout (binding = 3) buffer OUT_P_VEC4 {vec4 out_f32_vec4[];};
+layout (binding = 3) buffer OUT_P_FP32 {float out_f32[];};
+
+layout (binding = 4) buffer OUT_MAX_FP32 {float out_max_f32[];};
+layout (binding = 5) buffer GLOBAL_MAX_FP32 {float global_max_f32[];};
+
+layout (push_constant) uniform parameter
+{
+  uint qHead;
+  uint kvHead;
+  uint qkRatio;
+  uint startHeadQ;
+  uint startHeadKv;
+  uint activationLength;
+  uint startActivation;
+  uint kvSeqLen;
+  uint kvHeadPerSplit;
+  uint flag;
+  uint kvStride;
+  float softMaxScale;
+} p;
+
+layout (constant_id = 0) const uint GROUPSIZE = 256;
+layout (constant_id = 1) const uint GQA_RATIO_LOG2 = 3;
+layout (constant_id = 2) const uint DP = 64;
+layout (constant_id = 3) const uint HEAD_DIM = 256;
+layout (constant_id = 4) const uint TN = 16;
+
+#define WARPSIZE TN
+#define GQA_MASK ((1 << GQA_RATIO_LOG2) - 1)
+#define GQA_RATIO (1 << GQA_RATIO_LOG2)
+#define LOOP_K 32
+
+#define SLM_POOL_SIZE_P (TN * DP * GROUPSIZE / WARPSIZE)
+#define OUTPUT_PER_WORKGROUP (TN * GROUPSIZE / WARPSIZE / GQA_RATIO)
+
+#define SLM_POOL_SIZE_K (LOOP_K * DP / 2)
+#define SLM_POOL_SIZE_M (OUTPUT_PER_WORKGROUP * DP)
+
+#define K_COUNT (((SLM_POOL_SIZE_K * 2) / GROUPSIZE) / 4)
+#define M_COUNT (SLM_POOL_SIZE_M / GROUPSIZE)
+#define MAT_P_COUNT (DP / 8)
+
+#define SUBGROUP_COUNT (GROUPSIZE / WARPSIZE)
+#define K_OUTER (LOOP_K / K_COUNT / 4)
+#define K_INNER (16 / K_COUNT / 4)
+
+shared slm_pool_block {
+  float slm_pool_qp[SLM_POOL_SIZE_P];
+} slm_pool;
+
+shared slm_pool_alias_block {
+  f16vec2 slm_pool_k[SLM_POOL_SIZE_K * 2];
+} slm_pool_alias;
+
+void main() {
+  const uint lane = gl_SubgroupInvocationID;
+  const uint h = gl_WorkGroupID.x;
+  const uint v = gl_WorkGroupID.y;
+  const uint d = gl_WorkGroupID.z;
+  const uint localLinearId = gl_SubgroupID;
+  const uint hhq = localLinearId & GQA_MASK;
+  const uint vvq = localLinearId >> (GQA_RATIO_LOG2);
+  const uint hhk = localLinearId % K_OUTER;
+  const uint vvk = localLinearId / K_OUTER;
+  const uint hhhk = hhk % K_INNER;
+  const uint vvvk = hhk / K_INNER;
+  const uint headIdxV = v + p.startHeadKv;
+  const uint headIdxQ = headIdxV * p.qkRatio + p.startHeadQ + hhq;
+  const uint qDim = p.qHead * HEAD_DIM;
+  const uint maxDim = (p.kvSeqLen + DP - 1) / DP;
+  const uint oDim = maxDim * DP;
+  const uint kvDim = p.kvStride;
+  const uint maskDim = p.kvSeqLen;
+  const uint groupAlignedActivationLength = (p.activationLength + OUTPUT_PER_WORKGROUP - 1) / OUTPUT_PER_WORKGROUP * OUTPUT_PER_WORKGROUP;
+  uint offsetBaseK = (d * DP + vvk * TN + lane);
+  offsetBaseK = min(offsetBaseK, p.kvSeqLen - 1);
+  offsetBaseK = (offsetBaseK * kvDim + hhk * K_COUNT * 4 + headIdxV * HEAD_DIM) / 4;
+  uint offsetBaseMask = (h * OUTPUT_PER_WORKGROUP + /* vvq * TN + */ lane);
+  offsetBaseMask = min(offsetBaseMask, p.activationLength - 1);
+  offsetBaseMask = (p.startActivation + offsetBaseMask * maskDim + d * DP /* + hhq * M_COUNT */) / 4;
+  const uint offsetSlmK = (vvvk * 16 * DP + vvk * TN * 16 + lane * 16 + hhhk * K_COUNT * 4) / 2;
+  const uint offsetSlmM = (vvq * TN * DP + hhq * M_COUNT + lane * DP);
+  const uint offsetLoadSlmP = (localLinearId * TN * DP + lane * DP);
+  uint offsetLoadMask = (h * OUTPUT_PER_WORKGROUP + vvq * TN + lane);
+  offsetLoadMask = min(offsetLoadMask, p.activationLength - 1);
+  offsetLoadMask = ((p.startActivation + offsetLoadMask) * maskDim + d * DP) / 4;
+  const uint offsetMax =  ((v * GQA_RATIO * groupAlignedActivationLength + h * OUTPUT_PER_WORKGROUP * GQA_RATIO + localLinearId * WARPSIZE + lane) * maxDim + d);
+  const uint offsetOut =  ((v * GQA_RATIO * groupAlignedActivationLength + h * OUTPUT_PER_WORKGROUP * GQA_RATIO + localLinearId * WARPSIZE + lane) * oDim + d * DP) / 4;
+  const uint offsetGlobalMax = (v * GQA_RATIO * groupAlignedActivationLength + h * OUTPUT_PER_WORKGROUP * GQA_RATIO + localLinearId * WARPSIZE + lane);
+  const float16_t fp16SoftmaxScale = float16_t(p.softMaxScale);
+  const float fp32Min = uintBitsToFloat(0xFEFFFFFF);
+  const uint kvBoundary = ((p.kvSeqLen - 1) * kvDim + (v + 1) * HEAD_DIM) / 4 - 1;
+  uint coopMatBaseQ = ((p.startActivation + h * OUTPUT_PER_WORKGROUP) * qDim + headIdxQ * HEAD_DIM + vvq * TN * qDim) / 2;
+
+  f16vec4 f16KState[K_COUNT];
+  coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator> sums[MAT_P_COUNT];
+
+  [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+    f16KState[kk] = kStateVec4[offsetBaseK + kk];
+  }
+
+  [[unroll]] for (uint i = 0; i < MAT_P_COUNT; i++) {
+    sums[i] = coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator>(0.0f);
+  }
+
+  [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+    slm_pool_alias.slm_pool_k[offsetSlmK + 2 * kk] = f16KState[kk].xy * fp16SoftmaxScale;
+    slm_pool_alias.slm_pool_k[offsetSlmK + 2 * kk + 1] = f16KState[kk].zw * fp16SoftmaxScale;
+  }
+
+  offsetBaseK = offsetBaseK + LOOP_K / 4;
+  const uint loopCount = HEAD_DIM / LOOP_K;
+
+  [[unroll]] for (uint loop = 0; loop < loopCount; loop++) {
+    const uint slmPingPongLoad = (loop & 0x1) * SLM_POOL_SIZE_K;
+    const uint slmPingPongStore = ((loop + 1) & 0x1) * SLM_POOL_SIZE_K;
+
+    coopmat<float16_t, gl_ScopeSubgroup, 8, 16, gl_MatrixUseA> matK[MAT_P_COUNT];
+    if (loop + 1 < loopCount) {
+      [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+        f16KState[kk] = kStateVec4[offsetBaseK + kk];
+      }
+    }
+
+    barrier();
+
+    [[unroll]] for (uint dd = 0; dd < 2; dd++) {
+      coopmat<float16_t, gl_ScopeSubgroup, 16, TN, gl_MatrixUseB> matQ;
+      coopMatLoad(
+        matQ,
+        qStateVec2,
+        coopMatBaseQ + 8 * dd,
+        qDim / 2,
+        gl_CooperativeMatrixLayoutColumnMajor);
+
+      [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+        coopMatLoad(
+          matK[cc],
+          slm_pool_alias.slm_pool_k,
+          slmPingPongLoad + MAT_P_COUNT * 8 * 8 * dd + 8 * 8 * cc,
+          16 / 2,
+          gl_CooperativeMatrixLayoutRowMajor);
+      }
+
+      [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+        sums[cc] = coopMatMulAdd(matK[cc], matQ, sums[cc]);
+      }
+    }
+
+    if (loop + 1 < loopCount) {
+      [[unroll]] for (uint kk = 0; kk < K_COUNT; kk++) {
+        slm_pool_alias.slm_pool_k[slmPingPongStore + offsetSlmK + 2 * kk] = f16KState[kk].xy * fp16SoftmaxScale;
+        slm_pool_alias.slm_pool_k[slmPingPongStore + offsetSlmK + 2 * kk + 1] = f16KState[kk].zw * fp16SoftmaxScale;
+      }
+    }
+
+    offsetBaseK = offsetBaseK + LOOP_K / 4;
+    coopMatBaseQ = coopMatBaseQ + LOOP_K / 2;
+  }
+
+  barrier();
+  [[unroll]] for (uint cc = 0; cc < MAT_P_COUNT; cc++) {
+    coopMatStore(sums[cc], slm_pool.slm_pool_qp, 8 * cc + localLinearId * TN * DP, DP, gl_CooperativeMatrixLayoutColumnMajor);
+  }
+
+  barrier();
+
+  // p reduce sum and softmax
+  {
+    float matP[DP];
+    float localMax = fp32Min;
+    uint offsetCoord = h * OUTPUT_PER_WORKGROUP + vvq * TN + lane;
+
+    [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+      matP[cc] = slm_pool.slm_pool_qp[offsetLoadSlmP + cc];
+    }
+
+    [[unroll]] for (uint cc = 0; cc < DP / 4; cc++) {
+      f16vec4 f16MaskTemp;
+      f16MaskTemp = mState[offsetLoadMask + cc];
+      matP[4 * cc + 0] = matP[4 * cc + 0] + float(f16MaskTemp.x);
+      matP[4 * cc + 1] = matP[4 * cc + 1] + float(f16MaskTemp.y);
+      matP[4 * cc + 2] = matP[4 * cc + 2] + float(f16MaskTemp.z);
+      matP[4 * cc + 3] = matP[4 * cc + 3] + float(f16MaskTemp.w);
+    }
+
+    [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+      localMax = max(localMax, matP[cc]);
+    }
+
+    if (offsetCoord < p.activationLength) {
+      atomicMax(global_max_f32[offsetGlobalMax], localMax); 
+    }
+
+    [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+      matP[cc] = matP[cc] - localMax;
+    }
+
+    [[unroll]] for (uint cc = 0; cc < DP; cc++) {
+      matP[cc] = exp(matP[cc]);
+    }
+
+    [[unroll]] for (uint cc = 0; cc < DP / 4; cc++) {
+      if (offsetCoord < p.activationLength) {
+        out_f16[offsetOut + cc] = f16vec4(matP[4 * cc], matP[4 * cc + 1], matP[4 * cc + 2], matP[4 * cc + 3]);
+      }
+    }
+
+    if (offsetCoord < p.activationLength) {
+      out_max_f32[offsetMax] = localMax;
+    }
+  }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_prefill_phase_2.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_prefill_phase_2.comp
@@ -1,0 +1,287 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+#extension GL_EXT_shader_subgroup_extended_types_int16 : require
+#extension GL_EXT_shader_atomic_float : require
+#extension GL_EXT_shader_atomic_float2 : require
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
+#extension GL_KHR_shader_subgroup_vote : enable
+#extension GL_EXT_shared_memory_block : enable
+
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer P_VEC2 {f16vec2 pStateVec2[];};
+layout (binding = 0) readonly buffer P_MAT2X4 {f16mat2x4 pStateMat2x4[];};
+layout (binding = 1) readonly buffer V {float16_t vState[];};
+layout (binding = 1) readonly buffer V_VEC4 {f16vec4 vStateVec4[];};
+layout (binding = 2) buffer GROUP_MAX_P {float groupMax[];};
+layout (binding = 3) buffer SINK {float sinkState[];};
+layout (binding = 4) buffer OUT_P_VEC4 {vec4 out_f32_vec4[];};
+layout (binding = 4) buffer OUT_P_VEC2 {f16vec2 out_f16_vec2[];};
+layout (binding = 5) buffer GLOBAL_MAX_FP32 {float global_max_f32[];};
+
+layout (push_constant) uniform parameter
+{
+  uint qHead;
+  uint kvHead;
+  uint qkRatio;
+  uint startHeadQ;
+  uint startHeadKv;
+  uint activationLength;
+  uint startActivation;
+  uint kvSeqLen;
+  uint kvHeadPerSplit;
+  uint flag;
+  uint kvStride;
+  float softMaxScale;
+} p;
+
+layout (constant_id = 0) const uint GROUPSIZE = 256;
+layout (constant_id = 1) const uint GQA_RATIO_LOG2 = 3;
+layout (constant_id = 2) const uint DP_LOG2 = 6;
+layout (constant_id = 3) const uint HEAD_DIM = 256;
+layout (constant_id = 4) const uint TN = 16;
+
+#define DP (1 << DP_LOG2)
+#define WARPSIZE TN
+#define WARP_DIM 64
+#define V_GROUPS_PER_HEAD (HEAD_DIM / WARP_DIM)
+#define K_PER_LOOP_LOG2 5
+#define K_PER_LOOP (1 << K_PER_LOOP_LOG2)
+#define MAT_P_COUNT (K_PER_LOOP / 16)
+#define MAT_O_COUNT (WARP_DIM / 8)
+
+#define GQA_MASK ((1 << GQA_RATIO_LOG2) - 1)
+#define GQA_RATIO (1 << GQA_RATIO_LOG2)
+#define SUBGROUP_COUNT (GROUPSIZE / WARPSIZE)
+
+#define SLM_POOL_SIZE_P ((TN * K_PER_LOOP * SUBGROUP_COUNT))
+#define SLM_POOL_SIZE_O (TN * WARP_DIM * SUBGROUP_COUNT)
+#define OUTPUT_PER_WORKGROUP (TN * SUBGROUP_COUNT / GQA_RATIO)
+#define SLM_POOL_SIZE_V (K_PER_LOOP * WARP_DIM)
+#define SLM_OFFSET_P 0
+#define SLM_OFFSET_V SLM_POOL_SIZE_P * 2
+
+#define V_COUNT (((SLM_POOL_SIZE_V) / GROUPSIZE) / 4)
+#define V_INNER (WARP_DIM / V_COUNT / 4)
+
+#define SLM_V_GROUP_DIV (16 / WARPSIZE)
+
+shared slm_pool_block {
+  float slm_pool_o[SLM_POOL_SIZE_O];
+} slm_pool;
+
+shared slm_pool_alias_block {
+  float16_t slm_pool_pv[SLM_POOL_SIZE_P * 2 + SLM_POOL_SIZE_V * 2];
+} slm_pool_alias;
+
+void main() {
+  const uint lane = gl_SubgroupInvocationID;
+  const uint h = gl_WorkGroupID.x;
+  const uint v = gl_WorkGroupID.y;
+  const uint localLinearId = gl_SubgroupID;
+  const uint hhp = localLinearId & GQA_MASK;
+  const uint vvp = localLinearId >> (GQA_RATIO_LOG2);
+  const uint hhv = localLinearId % V_INNER;
+  const uint vvv = localLinearId / V_INNER;
+  const uint slmChannelV = vvv % SLM_V_GROUP_DIV;
+  const uint slmGroupV = vvv / SLM_V_GROUP_DIV;
+  const uint channelV = (v % V_GROUPS_PER_HEAD);
+  const uint headIdxPv = (v / V_GROUPS_PER_HEAD);
+  const uint headIdxV = headIdxPv + p.startHeadKv;
+  const uint headIdxO = headIdxV * p.qkRatio + p.startHeadQ + hhp;
+  const uint maxDim = (p.kvSeqLen + DP - 1) / DP;
+  const uint pDim = maxDim * DP;
+  const uint kvDim = p.kvStride;
+  const uint oDim = p.qHead * HEAD_DIM;
+  const uint groupAlignedActivationLength = (p.activationLength + OUTPUT_PER_WORKGROUP - 1) / OUTPUT_PER_WORKGROUP * OUTPUT_PER_WORKGROUP;
+  uint offsetBaseV = (vvv * TN + lane);
+  offsetBaseV = min(offsetBaseV, p.kvSeqLen - 1);
+  offsetBaseV = (offsetBaseV * kvDim + hhv * V_COUNT * 4 + headIdxV * HEAD_DIM + channelV * WARP_DIM) / 4;
+  uint offsetBaseP = (headIdxPv * groupAlignedActivationLength * GQA_RATIO + h * OUTPUT_PER_WORKGROUP * GQA_RATIO + localLinearId * WARPSIZE + lane);
+  offsetBaseP = offsetBaseP * pDim / 2;
+  const uint offsetBaseGroupMax = (headIdxPv * groupAlignedActivationLength * GQA_RATIO + h * OUTPUT_PER_WORKGROUP * GQA_RATIO + localLinearId * WARPSIZE + lane) * maxDim;
+  const uint offsetBaseGlobalMax = (headIdxPv * groupAlignedActivationLength * GQA_RATIO + h * OUTPUT_PER_WORKGROUP * GQA_RATIO + localLinearId * WARPSIZE + lane);
+  const uint offsetSlmV = (SLM_OFFSET_V + hhv * 16 * V_COUNT * 4 + slmGroupV * 16 * WARP_DIM + slmChannelV * WARPSIZE + lane);
+  const uint offsetSlmP = (SLM_OFFSET_P + localLinearId * TN * K_PER_LOOP + lane * K_PER_LOOP);
+  const uint offsetSlmO = (localLinearId * TN * WARP_DIM + lane * WARP_DIM);
+  uint offsetOut = h * OUTPUT_PER_WORKGROUP + vvp * TN + lane;
+  offsetOut = min(offsetOut, p.activationLength - 1);
+  offsetOut = ((offsetOut + p.startActivation) * oDim + headIdxO * HEAD_DIM + channelV * WARP_DIM) / 4;
+  const float fp32Min = uintBitsToFloat(0xFEFFFFFF);
+  const uint kvBoundary = ((p.kvSeqLen - 1) * kvDim + (v + 1) * HEAD_DIM) / 4 - 1;
+  const uint coopMatBaseP = localLinearId * TN * K_PER_LOOP;
+  float fp32GlobalMax = global_max_f32[offsetBaseGlobalMax];
+  const float fp32SinkCoeff = sinkState[headIdxO];
+  f16vec4 f16VState[V_COUNT];
+  coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator> sums[MAT_O_COUNT];
+
+  [[unroll]] for (uint kk = 0; kk < V_COUNT; kk++) {
+    f16VState[kk] = vStateVec4[offsetBaseV + kk];
+  }
+
+  [[unroll]] for (uint i = 0; i < MAT_O_COUNT; i++) {
+    sums[i] = coopmat<float, gl_ScopeSubgroup, 8, TN, gl_MatrixUseAccumulator>(0.0f);
+  }
+
+  [[unroll]] for (uint kk = 0; kk < V_COUNT; kk++) {
+    slm_pool_alias.slm_pool_pv[offsetSlmV + 64 * kk + 16 * 0] = f16VState[kk].x;
+    slm_pool_alias.slm_pool_pv[offsetSlmV + 64 * kk + 16 * 1] = f16VState[kk].y;
+    slm_pool_alias.slm_pool_pv[offsetSlmV + 64 * kk + 16 * 2] = f16VState[kk].z;
+    slm_pool_alias.slm_pool_pv[offsetSlmV + 64 * kk + 16 * 3] = f16VState[kk].w;
+  }
+
+  const uint loopCount = (p.kvSeqLen + K_PER_LOOP - 1) / K_PER_LOOP;
+  float fp32LoopMax;
+  float fp32SoftMaxSum = 0.0f;
+  fp32LoopMax = groupMax[offsetBaseGroupMax];
+  {
+    float fp32Compensation = exp(fp32LoopMax - fp32GlobalMax);
+    [[unroll]] for (uint kk = 0; kk < K_PER_LOOP / 8; kk++) {
+      f16mat2x4 fp16TempP = pStateMat2x4[offsetBaseP / 4 + kk];
+      mat2x4 fp32TempP = mat2x4(fp16TempP);
+      fp32TempP = fp32TempP * fp32Compensation;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].x;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].y;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].z;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].w;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].x;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].y;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].z;
+      fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].w;
+      fp16TempP = f16mat2x4(fp32TempP);
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 0] = fp16TempP[0].x;
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 1] = fp16TempP[0].y;
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 2] = fp16TempP[0].z;
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 3] = fp16TempP[0].w;
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 4] = fp16TempP[1].x;
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 5] = fp16TempP[1].y;
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 6] = fp16TempP[1].z;
+      slm_pool_alias.slm_pool_pv[offsetSlmP + 8 * kk + 7] = fp16TempP[1].w;
+    }
+  }
+
+  barrier();
+
+  offsetBaseP = offsetBaseP + K_PER_LOOP / 2;
+  offsetBaseV = offsetBaseV + K_PER_LOOP * kvDim / 4;
+
+  for (uint loop = 0; loop < loopCount; loop++) {
+    const uint slmPingPongLoad = (loop & 0x1);
+    const uint slmPingPongStore = ((loop + 1) & 0x1);
+
+    if (loop + 1 < loopCount) {
+      const uint offsetGroupMax = offsetBaseGroupMax + (((loop + 1) * K_PER_LOOP) >> DP_LOG2);
+      fp32LoopMax = groupMax[offsetGroupMax];
+      [[unroll]] for (uint kk = 0; kk < V_COUNT; kk++) {
+        f16VState[kk] = vStateVec4[offsetBaseV + kk];
+      }
+    }
+
+    barrier();
+
+    [[unroll]] for (uint dd = 0; dd < K_PER_LOOP / 16; dd++) {
+      coopmat<float16_t, gl_ScopeSubgroup, 8, 16, gl_MatrixUseA> matV[MAT_O_COUNT];
+      coopmat<float16_t, gl_ScopeSubgroup, 16, TN, gl_MatrixUseB> matP;
+      coopMatLoad(
+        matP,
+        slm_pool_alias.slm_pool_pv,
+        slmPingPongLoad * SLM_POOL_SIZE_P + coopMatBaseP + 16 * dd,
+        K_PER_LOOP,
+        gl_CooperativeMatrixLayoutColumnMajor);
+
+      [[unroll]] for (uint cc = 0; cc < MAT_O_COUNT; cc++) {
+        coopMatLoad(
+          matV[cc],
+          slm_pool_alias.slm_pool_pv,
+          slmPingPongLoad * SLM_POOL_SIZE_V + SLM_OFFSET_V + MAT_O_COUNT * 8 * 16 * dd + 8 * 16 * cc,
+          16,
+          gl_CooperativeMatrixLayoutRowMajor);
+      }
+
+      [[unroll]] for (uint cc = 0; cc < MAT_O_COUNT; cc++) {
+        sums[cc] = coopMatMulAdd(matV[cc], matP, sums[cc]);
+      }
+    }
+
+    if (loop + 1 < loopCount) {
+      float fp32Compensation = exp(fp32LoopMax - fp32GlobalMax);
+      [[unroll]] for (uint kk = 0; kk < V_COUNT; kk++) {
+        slm_pool_alias.slm_pool_pv[offsetSlmV + slmPingPongStore * SLM_POOL_SIZE_V + 64 * kk + 16 * 0] = f16VState[kk].x;
+        slm_pool_alias.slm_pool_pv[offsetSlmV + slmPingPongStore * SLM_POOL_SIZE_V + 64 * kk + 16 * 1] = f16VState[kk].y;
+        slm_pool_alias.slm_pool_pv[offsetSlmV + slmPingPongStore * SLM_POOL_SIZE_V + 64 * kk + 16 * 2] = f16VState[kk].z;
+        slm_pool_alias.slm_pool_pv[offsetSlmV + slmPingPongStore * SLM_POOL_SIZE_V + 64 * kk + 16 * 3] = f16VState[kk].w;
+      }
+
+      [[unroll]] for (uint kk = 0; kk < K_PER_LOOP / 8; kk++) {
+        f16mat2x4 fp16TempP = pStateMat2x4[offsetBaseP / 4 + kk];
+        mat2x4 fp32TempP = mat2x4(fp16TempP);
+        fp32TempP = fp32TempP * fp32Compensation;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].x;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].y;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].z;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[0].w;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].x;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].y;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].z;
+        fp32SoftMaxSum = fp32SoftMaxSum + fp32TempP[1].w;
+        fp16TempP = f16mat2x4(fp32TempP);
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 0] = fp16TempP[0].x;
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 1] = fp16TempP[0].y;
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 2] = fp16TempP[0].z;
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 3] = fp16TempP[0].w;
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 4] = fp16TempP[1].x;
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 5] = fp16TempP[1].y;
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 6] = fp16TempP[1].z;
+        slm_pool_alias.slm_pool_pv[offsetSlmP + slmPingPongStore * SLM_POOL_SIZE_P + 8 * kk + 7] = fp16TempP[1].w;
+      }
+    }
+
+    offsetBaseV = offsetBaseV + K_PER_LOOP * kvDim / 4;
+    offsetBaseP = offsetBaseP + K_PER_LOOP / 2;
+  }
+
+  barrier();
+  [[unroll]] for (uint cc = 0; cc < MAT_O_COUNT; cc++) {
+    coopMatStore(sums[cc], slm_pool.slm_pool_o, 8 * cc + localLinearId * TN * WARP_DIM, WARP_DIM, gl_CooperativeMatrixLayoutColumnMajor);
+  }
+
+  barrier();
+
+  // output rescale
+  {
+    float matO[WARP_DIM];
+    float fp32SoftMaxMul;
+    if (0x1 == (p.flag & 0x1)) {
+      float sinkCompensation = fp32GlobalMax - fp32SinkCoeff;
+      sinkCompensation = exp(sinkCompensation);
+      float softmaxSumTemp = fp32SoftMaxSum * sinkCompensation;
+      fp32SoftMaxSum = fp32SoftMaxSum + 1.0f / sinkCompensation;
+      fp32SoftMaxSum = 1.0f / fp32SoftMaxSum;
+      sinkCompensation = sinkCompensation / (1.0f + softmaxSumTemp);
+      fp32SoftMaxMul = fp32GlobalMax < fp32SinkCoeff ? sinkCompensation : fp32SoftMaxSum;
+    } else {
+      fp32SoftMaxMul = 1.0f / fp32SoftMaxSum;
+    }
+
+    [[unroll]] for (uint cc = 0; cc < WARP_DIM; cc++) {
+      matO[cc] = slm_pool.slm_pool_o[offsetSlmO + cc];
+    }
+
+    [[unroll]] for (uint cc = 0; cc < WARP_DIM; cc++) {
+      matO[cc] = matO[cc] * fp32SoftMaxMul;
+    }
+    uint offsetCoord = h * OUTPUT_PER_WORKGROUP + vvp * TN + lane;
+    [[unroll]] for (uint cc = 0; cc < WARP_DIM / 4; cc++) {
+      if (offsetCoord < p.activationLength) {
+        out_f32_vec4[offsetOut + cc] = vec4(matO[4 * cc], matO[4 * cc + 1], matO[4 * cc + 2], matO[4 * cc + 3]);
+      }
+    }
+  }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm.comp
@@ -120,7 +120,9 @@ layout (constant_id = 3) const uint BK = 16;  // Assumed to be 32 if working wit
 #define BK_STEP 2
 #endif
 
-#ifdef COOPMAT
+#if defined(COOPMAT) && defined(LOAD_A_OPT)
+#define SHMEM_STRIDE (BK / 2)
+#elif defined(COOPMAT)
 #define SHMEM_STRIDE (BK / 2 + 4)
 #else
 #define SHMEM_STRIDE (BK / 2 + 1)
@@ -227,6 +229,10 @@ void main() {
 
     // Workgroup has no work
     if (ic * BN >= _ne1) return;
+
+    uint required_work_items = (_ne1 - ic * BN) * BK / LOAD_VEC_B;
+    uint required_warp_c = (_ne1 - ic * BN + WN - 1) / WN ;
+
 #endif
 
 #ifdef MUL_MAT_ID
@@ -251,8 +257,8 @@ void main() {
 #endif
 
 #ifdef COOPMAT
-    coopmat<FLOAT_TYPE, gl_ScopeSubgroup, TM, TK, gl_MatrixUseA> cache_a;
-    coopmat<FLOAT_TYPE, gl_ScopeSubgroup, TK, TN, gl_MatrixUseB> cache_b;
+    coopmat<FLOAT_TYPE, gl_ScopeSubgroup, TM, TK, gl_MatrixUseA> cache_a[cms_per_row];
+    coopmat<FLOAT_TYPE, gl_ScopeSubgroup, TK, TN, gl_MatrixUseB> cache_b[cms_per_col];
     coopmat<ACC_TYPE, gl_ScopeSubgroup, TM, TN, gl_MatrixUseAccumulator> sums[cms_per_row * cms_per_col];
 
     [[unroll]] for (uint i = 0; i < cms_per_row * cms_per_col; i++) {
@@ -277,6 +283,9 @@ void main() {
         [[unroll]] for (uint l = 0; l < BM; l += loadstride_a) {
             load_a_to_shmem(pos_a, loadr_a, loadc_a + l, ir * BM + loadc_a + l, block, end_k);
         }
+        #ifdef MUL_MAT_ID
+        if (gl_LocalInvocationID.x < required_work_items) {
+        #endif
         [[unroll]] for (uint l = 0; l < BN; l += loadstride_b) {
 #if !defined(MUL_MAT_ID)
             load_b_to_shmem(pos_b, loadr_b, loadc_b + l, ic * BN + loadc_b + l, block, end_k);
@@ -284,6 +293,9 @@ void main() {
             load_b_to_shmem(pos_b, loadr_b, loadc_b + l, ic, _ne1, block, end_k);
 #endif
         }
+        #ifdef MUL_MAT_ID
+        }
+        #endif
 
         barrier();
 
@@ -291,18 +303,32 @@ void main() {
         pos_b += BK / LOAD_VEC_B;
 
 #ifdef COOPMAT
+#ifdef MUL_MAT_ID
+        if (warp_c < required_warp_c) {
+#endif
         [[unroll]] for (uint i = 0; i < BK; i += TK) {
             [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
                 // Load from shared into cache
-                coopMatLoad(cache_a, buf_a, (warp_r * WM + cm_row * TM) * SHMEM_STRIDE + i / 2, SHMEM_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+#ifndef LOAD_A_OPT
+                coopMatLoad(cache_a[cm_row], buf_a, (warp_r * WM + cm_row * TM) * SHMEM_STRIDE + i / 2, SHMEM_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+#else
+                coopMatLoad(cache_a[cm_row], buf_a, (warp_r * WM + cm_row * TM) * TK / 2 + i * BM / 2, TK / 2, gl_CooperativeMatrixLayoutRowMajor);
+#endif
+            }
 
-                [[unroll]] for (uint cm_col = 0; cm_col < cms_per_col; cm_col++) {
-                    coopMatLoad(cache_b, buf_b, (warp_c * WN + cm_col * TN) * SHMEM_STRIDE + i / 2, SHMEM_STRIDE, gl_CooperativeMatrixLayoutColumnMajor);
+            [[unroll]] for (uint cm_col = 0; cm_col < cms_per_col; cm_col++) {
+                coopMatLoad(cache_b[cm_col], buf_b, (warp_c * WN + cm_col * TN) * SHMEM_STRIDE + i / 2, SHMEM_STRIDE, gl_CooperativeMatrixLayoutColumnMajor);
+            }
 
-                    sums[cm_col * cms_per_row + cm_row] = coopMatMulAdd(cache_a, cache_b, sums[cm_col * cms_per_row + cm_row]);
+            [[unroll]] for (uint cm_col = 0; cm_col < cms_per_col; cm_col++) {
+                [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
+                    sums[cm_col * cms_per_row + cm_row] = coopMatMulAdd(cache_a[cm_row], cache_b[cm_col], sums[cm_col * cms_per_row + cm_row]);
                 }
             }
         }
+#ifdef MUL_MAT_ID
+        }
+#endif
 #else
         [[unroll]] for (uint i = 0; i < BK / BK_STEP; i++) {
             // Load from shared into cache

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_funcs.glsl
@@ -2,7 +2,13 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
 #if defined(DATA_A_F32) || defined(DATA_A_F16)
 #if LOAD_VEC_A == 8
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+#else
+            const uint buf_idx_outer = (row * LOAD_VEC_A) / TK;
+            const uint buf_idx_inner = (row * LOAD_VEC_A) % TK;
+            const uint buf_idx = buf_idx_outer * BM * TK / 2 + col * TK / 2 + buf_idx_inner / 2;
+#endif
             FLOAT_TYPEV8 aa = FLOAT_TYPEV8(data_a[idx]);
             buf_a[buf_idx    ] = aa[0].xy;
             buf_a[buf_idx + 1] = aa[0].zw;
@@ -10,13 +16,25 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
             buf_a[buf_idx + 3] = aa[1].zw;
 #elif LOAD_VEC_A == 4
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+#else
+            const uint buf_idx_outer = (row * LOAD_VEC_A) / TK;
+            const uint buf_idx_inner = (row * LOAD_VEC_A) % TK;
+            const uint buf_idx = buf_idx_outer * BM * TK / 2 + col * TK / 2 + buf_idx_inner / 2;
+#endif
             FLOAT_TYPEV4 aa = FLOAT_TYPEV4(data_a[idx]);
             buf_a[buf_idx    ] = aa.xy;
             buf_a[buf_idx + 1] = aa.zw;
 #else // LOAD_VEC_BATCH_A == 2
             const uint idx = pos_a + col * p.stride_a + row * 2;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row;
+#else
+            const uint buf_idx_outer = (row) / (TK / 2);
+            const uint buf_idx_inner = (row) % (TK / 2);
+            const uint buf_idx = buf_idx_outer * BM * TK / 2 + col * TK / 2 + buf_idx_inner;
+#endif
             if (idx_m < p.M && block + row * 2 + 1 < end_k) {
                 buf_a[buf_idx] = FLOAT_TYPEV2(data_a[idx],
                                               data_a[idx + 1]);
@@ -79,7 +97,13 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
             buf_a[buf_idx + 9 ] = FLOAT_TYPEV2(v1.zw);
 #elif defined(DATA_A_Q5_0)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
-            const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 4;
+#ifndef LOAD_A_OPT
+            const uint buf_idx = col * SHMEM_STRIDE + row;
+#else
+            const uint buf_idx_outer = row / (TK);
+            const uint buf_idx_0 = buf_idx_outer * BM * TK + col * TK / 2 + row;
+            const uint buf_idx_1 = buf_idx_outer * BM * TK + BM * TK / 2 + col * TK / 2 + row;
+#endif
 
             const uint ib = idx / 8;
             const uint iqs = idx & 0x07;
@@ -91,12 +115,24 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
 
             const uint vui = uint(data_a_packed16[ib].qs[iqs]);
             const vec4 v = (vec4((vui & 0xF) | qh0.x, ((vui >> 4) & 0xF) | qh0.y, ((vui >> 8) & 0xF) | qh1.x, (vui >> 12) | qh1.y) - 16.0f) * d;
-
+#ifndef LOAD_A_OPT
             buf_a[buf_idx    ] = FLOAT_TYPEV2(v.xz);
             buf_a[buf_idx + 8] = FLOAT_TYPEV2(v.yw);
+#else
+            buf_a[buf_idx_0] = FLOAT_TYPEV2(v.xz);
+            buf_a[buf_idx_1] = FLOAT_TYPEV2(v.yw);
+#endif
 #elif defined(DATA_A_Q5_1)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 4;
+#else
+            // Follow Q5_0 LOAD_A_OPT pattern, adapted for LOAD_VEC_A=8 (2 VEC2 per half)
+            const uint eff_row = row * LOAD_VEC_A / 4;  // 2 VEC2 positions per load
+            const uint buf_idx_outer = eff_row / TK;
+            const uint buf_idx_0 = buf_idx_outer * BM * TK + col * TK / 2 + eff_row;
+            const uint buf_idx_1 = buf_idx_outer * BM * TK + BM * TK / 2 + col * TK / 2 + eff_row;
+#endif
 
             const uint ib = idx / 4;
             const uint iqs = idx & 0x03;
@@ -112,13 +148,26 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
             const vec4 v0 = vec4((vui & 0xF) | qh0.x, ((vui >> 4) & 0xF) | qh0.y, ((vui >> 8) & 0xF) | qh1.x, ((vui >> 12) & 0xF) | qh1.y) * dm.x + dm.y;
             const vec4 v1 = vec4(((vui >> 16) & 0xF) | qh2.x, ((vui >> 20) & 0xF) | qh2.y, ((vui >> 24) & 0xF) | qh3.x, ((vui >> 28) & 0xF) | qh3.y) * dm.x + dm.y;
 
+#ifndef LOAD_A_OPT
             buf_a[buf_idx    ] = FLOAT_TYPEV2(v0.xz);
             buf_a[buf_idx + 1] = FLOAT_TYPEV2(v1.xz);
             buf_a[buf_idx + 8] = FLOAT_TYPEV2(v0.yw);
             buf_a[buf_idx + 9] = FLOAT_TYPEV2(v1.yw);
+#else
+            buf_a[buf_idx_0    ] = FLOAT_TYPEV2(v0.xz);
+            buf_a[buf_idx_0 + 1] = FLOAT_TYPEV2(v1.xz);
+            buf_a[buf_idx_1    ] = FLOAT_TYPEV2(v0.yw);
+            buf_a[buf_idx_1 + 1] = FLOAT_TYPEV2(v1.yw);
+#endif
 #elif defined(DATA_A_Q8_0)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+#else
+            const uint buf_idx_outer = (row * LOAD_VEC_A) / TK;
+            const uint buf_idx_inner = (row * LOAD_VEC_A) % TK;
+            const uint buf_idx = buf_idx_outer * BM * TK / 2 + col * TK / 2 + buf_idx_inner / 2;
+#endif
 
             const uint ib = idx / 8;
             const uint iqs = idx & 0x07;
@@ -189,43 +238,70 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
                                           dl * (qs.y - hm.y));
 #elif defined(DATA_A_Q4_K)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+#else
+            const uint buf_idx_outer = (row * LOAD_VEC_A) / TK;
+            const uint buf_idx_inner = (row * LOAD_VEC_A) % TK;
+            const uint buf_idx = buf_idx_outer * BM * TK / 2 + col * TK / 2 + buf_idx_inner / 2;
+#endif
 
-            const uint ib = idx / 64;                  // 4 values per idx
-            const uint iqs = (idx % 64) * 2;           // 0,2,4..126
+            const uint ib  = idx / 64;                    // 4 values per idx
+            const uint iqs = (idx % 64) * 2;              // 0,2,4..126
 
-            const uint n = iqs / 32;                   // 0,1,2,3
-            const uint b = (iqs % 32) / 16;            // 0,1
-            const uint is = 2 * n + b;                 // 0..7
-            const uint qsi = n * 32 + (iqs % 16) * 2;  // 0,2,4..126
+            const uint n   = iqs / 32;                    // 0,1,2,3
+            const uint b   = (iqs % 32) / 16;             // 0,1
+            const uint is  = 2u * n + b;                  // 0..7
+            const uint j   = is & 3u;                     // low 2 bits: 0..3
+            const int  jsh = int(j * 8u);                 // byte bit-offset: 0,8,16,24
+            const uint qsi = n * 32u + (iqs % 16u) * 2u; // 0,2,4..126
 
-            const vec2 loadd = vec2(data_a[ib].dm);
+            const vec2 loadd = vec2(data_a_packed32[ib].dm);
 
-            const uvec3 scales = uvec3(data_a_packed32[ib].scales[0],
-                                       data_a_packed32[ib].scales[1],
-                                       data_a_packed32[ib].scales[2]);
-            const uint scalesoffs = (is & 3) * 8;
+            // Q4_K scales: 12 bytes packed as 3 uint32 words.
+            // Decode 6-bit sc and mbyte via bitfieldExtract — avoids 4 scattered byte reads and
+            // 10 runtime ternaries. The condition (is < 4u) is warp-uniform (stride_a/LOAD_VEC_A
+            // is a multiple of 64), so this branch compiles to a uniform predicate with no divergence.
+            //   sw0 = scales[0..3], sw1 = scales[4..7], sw2 = scales[8..11]
+            //   is<4: sc   = sw0[j] bits[0:5];   mbyte = sw1[j] bits[0:5]
+            //   is≥4: sc   = sw2[j] bits[0:3] | sw0[j] bits[6:7]<<4
+            //         mbyte = sw2[j] bits[4:7] | sw1[j] bits[6:7]<<4
+            const uint sw0 = data_a_packed32[ib].scales[0];
+            const uint sw1 = data_a_packed32[ib].scales[1];
+            const uint sw2 = data_a_packed32[ib].scales[2];
 
-            const uint scidx0 = (is < 4) ? 0 : 2;
-            const uint scidxshift0 = scalesoffs;
-            const uint scidxshift1 = (is < 4) ? scalesoffs : scalesoffs + 2;
-            const uint mbidx0 = (is < 4) ? 1 : 2;
-            const uint mbidxshift0 = (is < 4) ? scalesoffs : scalesoffs + 4;
-            const uint mbidxshift1 = (is < 4) ? scalesoffs : scalesoffs + 2;
+            uint sc, mbyte;
+            if (is < 4u) {
+                sc    = bitfieldExtract(sw0, jsh,     6);
+                mbyte = bitfieldExtract(sw1, jsh,     6);
+            } else {
+                sc    = bitfieldExtract(sw2, jsh,     4) | (bitfieldExtract(sw0, jsh + 6, 2) << 4u);
+                mbyte = bitfieldExtract(sw2, jsh + 4, 4) | (bitfieldExtract(sw1, jsh + 6, 2) << 4u);
+            }
 
-            const uint8_t sc    = uint8_t(((scales[scidx0] >> scidxshift0) & 0xF) | ((scales[0] >> scidxshift1) & 0x30));
-            const uint8_t mbyte = uint8_t(((scales[mbidx0] >> mbidxshift0) & 0xF) | ((scales[1] >> mbidxshift1) & 0x30));
+            const float d = loadd.x * float(sc);
+            const float m = -loadd.y * float(mbyte);
 
-            const float d = loadd.x * sc;
-            const float m = -loadd.y * mbyte;
-
-            const vec4 q = vec4(unpack8((data_a_packed32[ib].qs[qsi / 4] >> (b * 4)) & 0x0F0F0F0F));
+            // Nibble decode: 4× bitfieldExtract avoids byte-register scatter/gather chain
+            // (shr + and 0x0F0F0F0F + 4×mov:b + 4×mov:ub→uw + 4×itof → 4×bfe + 4×itof)
+            const uint qs_word = data_a_packed32[ib].qs[qsi / 4];
+            const int base = int(b * 4u);  // 0 or 4, per-lane
+            const vec4 q = vec4(float(bitfieldExtract(qs_word, base,      4)),
+                                float(bitfieldExtract(qs_word, base + 8,  4)),
+                                float(bitfieldExtract(qs_word, base + 16, 4)),
+                                float(bitfieldExtract(qs_word, base + 24, 4)));
 
             buf_a[buf_idx    ] = FLOAT_TYPEV2(fma(d, q.x, m), fma(d, q.y, m));
             buf_a[buf_idx + 1] = FLOAT_TYPEV2(fma(d, q.z, m), fma(d, q.w, m));
 #elif defined(DATA_A_Q5_K)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+#else
+            const uint buf_idx_outer = (row * LOAD_VEC_A) / TK;
+            const uint buf_idx_inner = (row * LOAD_VEC_A) % TK;
+            const uint buf_idx = buf_idx_outer * BM * TK / 2 + col * TK / 2 + buf_idx_inner / 2;
+#endif
 
             const uint ib = idx / 64;                  // 4 values per idx
             const uint iqs = (idx % 64) * 2;           // 0,2,4..126
@@ -236,25 +312,26 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
             const uint qsi = n * 32 + (iqs % 16) * 2;  // 0,2,4..126
             const uint qhi = (iqs % 16) * 2;           // 0,2,4..30
 
-            const vec2 loadd = vec2(data_a[ib].dm);
+            // OPT: bitfieldExtract scale decode (same layout as Q4_K, avoids 10 ternaries + 4 byte reads)
+            const vec2 loadd = vec2(data_a_packed32[ib].dm);
 
-            const uvec3 scales = uvec3(data_a_packed32[ib].scales[0],
-                                       data_a_packed32[ib].scales[1],
-                                       data_a_packed32[ib].scales[2]);
-            const uint scalesoffs = (is & 3) * 8;
+            const uint j   = is & 3u;
+            const int  jsh = int(j * 8u);
+            const uint sw0 = data_a_packed32[ib].scales[0];
+            const uint sw1 = data_a_packed32[ib].scales[1];
+            const uint sw2 = data_a_packed32[ib].scales[2];
 
-            const uint scidx0 = (is < 4) ? 0 : 2;
-            const uint scidxshift0 = scalesoffs;
-            const uint scidxshift1 = (is < 4) ? scalesoffs : scalesoffs + 2;
-            const uint mbidx0 = (is < 4) ? 1 : 2;
-            const uint mbidxshift0 = (is < 4) ? scalesoffs : scalesoffs + 4;
-            const uint mbidxshift1 = (is < 4) ? scalesoffs : scalesoffs + 2;
+            uint sc, mbyte;
+            if (is < 4u) {
+                sc    = bitfieldExtract(sw0, jsh,     6);
+                mbyte = bitfieldExtract(sw1, jsh,     6);
+            } else {
+                sc    = bitfieldExtract(sw2, jsh,     4) | (bitfieldExtract(sw0, jsh + 6, 2) << 4u);
+                mbyte = bitfieldExtract(sw2, jsh + 4, 4) | (bitfieldExtract(sw1, jsh + 6, 2) << 4u);
+            }
 
-            const uint8_t sc    = uint8_t(((scales[scidx0] >> scidxshift0) & 0xF) | ((scales[0] >> scidxshift1) & 0x30));
-            const uint8_t mbyte = uint8_t(((scales[mbidx0] >> mbidxshift0) & 0xF) | ((scales[1] >> mbidxshift1) & 0x30));
-
-            const float d = loadd.x * sc;
-            const float m = -loadd.y * mbyte;
+            const float d = loadd.x * float(sc);
+            const float m = -loadd.y * float(mbyte);
 
             const uint qs = (data_a_packed32[ib].qs[qsi / 4] >> (b * 4)) & 0x0F0F0F0F;
             const uint qh = ((data_a_packed32[ib].qh[qhi / 4] >> (iqs / 16)) & 0x01010101) << 4;
@@ -264,7 +341,13 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
             buf_a[buf_idx + 1] = FLOAT_TYPEV2(fma(d, q.z, m), fma(d, q.w, m));
 #elif defined(DATA_A_Q6_K)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 2;
+#else
+            const uint buf_idx_outer = (row * LOAD_VEC_A) / TK;
+            const uint buf_idx_inner = (row * LOAD_VEC_A) % TK;
+            const uint buf_idx = buf_idx_outer * BM * TK / 2 + col * TK / 2 + buf_idx_inner / 2;
+#endif
 
             const uint ib = idx / 128;                  // 2 values per idx
             const uint iqs = idx % 128;                 // 0..127
@@ -490,7 +573,13 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
                                                   kvalues_iq4nl[vui >> 12]);
 #elif defined(DATA_A_MXFP4)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
+#ifndef LOAD_A_OPT
             const uint buf_idx = col * SHMEM_STRIDE + row * LOAD_VEC_A / 4;
+#else
+            const uint buf_idx_outer = row / (TK);
+            const uint buf_idx_0 = buf_idx_outer * BM * TK + col * TK / 2 + row;
+            const uint buf_idx_1 = buf_idx_outer * BM * TK + BM * TK / 2 + col * TK / 2 + row;
+#endif
 
             const uint ib = idx / 8;
             const uint iqs = (idx & 0x07) * 2;
@@ -498,11 +587,25 @@ void load_a_to_shmem(const uint pos_a, const uint row, const uint col, const uin
             const float d = e8m0_to_fp32(data_a[ib].e) * 0.5;
             const uint vui = uint(data_a[ib].qs[iqs]);
             const uint vui2 = uint(data_a[ib].qs[iqs+1]);
-
-            buf_a[buf_idx    ] = FLOAT_TYPEV2(kvalues_mxfp4[vui  & 0xF] * d,
-                                              kvalues_mxfp4[vui2 & 0xF] * d);
-            buf_a[buf_idx + 8] = FLOAT_TYPEV2(kvalues_mxfp4[vui  >>  4] * d,
-                                              kvalues_mxfp4[vui2 >>  4] * d);
+            // ---------------------------------------------------------------------------
+            // MXFP4 magnitude table: nibble bits[2:0] → {0,1,2,3,4,6,8,12} packed as
+            // 4-bit fields in a uint32 (nibble 0 in bits [3:0], nibble 7 in bits [31:28]).
+            // Decode: mag = bitfieldExtract(MXFP4_LUT, int((nibble & 7u) << 2), 4)
+            //         val = float(mag) * ((nibble >= 8u) ? -d : d)
+            // ---------------------------------------------------------------------------
+            const uint MXFP4_LUT = 0xC8643210u;
+#define MXFP4_VAL(nibble, scale) (float(bitfieldExtract(MXFP4_LUT, int(((nibble) & 7u) << 2), 4)) * (((nibble) >= 8u) ? -(scale) : (scale)))
+#ifndef LOAD_A_OPT
+            buf_a[buf_idx    ] = FLOAT_TYPEV2(MXFP4_VAL(vui  & 0xF, d),
+                                             MXFP4_VAL(vui2 & 0xF, d));
+            buf_a[buf_idx + 8] = FLOAT_TYPEV2(MXFP4_VAL(vui  >> 4,  d),
+                                             MXFP4_VAL(vui2 >> 4,  d));
+#else
+            buf_a[buf_idx_0] = FLOAT_TYPEV2(MXFP4_VAL(vui  & 0xF, d),
+                                            MXFP4_VAL(vui2 & 0xF, d));
+            buf_a[buf_idx_1] = FLOAT_TYPEV2(MXFP4_VAL(vui  >> 4,  d),
+                                            MXFP4_VAL(vui2 >> 4,  d));
+#endif
 #elif defined(DATA_A_NVFP4)
             const uint idx = pos_a + col * p.stride_a / LOAD_VEC_A + row;
             // lo and hi nibbles are 8 elements apart, which doesn't quite line up with

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -833,6 +833,14 @@ void process_shaders() {
 
     string_to_spv("fa_mask_opt", "flash_attn_mask_opt.comp", {});
 
+    string_to_spv("fa_hdim_64", "flash_attn_hdim64.comp", {}, true, true, false, false);
+    string_to_spv("fa_hdim_96", "flash_attn_hdim96.comp", {}, true, true, false, false);
+    string_to_spv("fa_hdim_128", "flash_attn_hdim128.comp", {}, true, true, false, false);
+    string_to_spv("fa_decode_ph1", "flash_attn_decode_phase_1.comp", {}, true, true, false, false);
+    string_to_spv("fa_decode_ph2", "flash_attn_decode_phase_2.comp", {}, true, true, false, false);
+    string_to_spv("fa_prefill_ph1", "flash_attn_prefill_phase_1.comp", {}, true, true, false, false);
+    string_to_spv("fa_prefill_ph2", "flash_attn_prefill_phase_2.comp", {}, true, true, false, false);
+
     string_to_spv("quantize_q8_1", "quantize_q8_1.comp", {});
     string_to_spv("quantize_q8_1_subgroup", "quantize_q8_1.comp", {{"USE_SUBGROUPS", "1"}});
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -70,6 +70,92 @@ const std::vector<std::string> type_names = {
     "bf16",
 };
 
+const std::vector<std::string> load_a_opt_kernels = {
+    "matmul_id_subgroup_mxfp4_f32_cm1",
+    "matmul_f16_cm1",
+    "matmul_f16_f32_cm1",
+    "matmul_f32_f32_cm1",
+    "matmul_q4_k_f32_cm1",
+    "matmul_q6_k_f32_cm1",
+    "matmul_q5_0_f32_cm1",
+    "matmul_q8_0_f32_cm1",
+    "matmul_id_subgroup_mxfp4_f32_aligned_cm1",
+    "matmul_f16_aligned_cm1",
+    "matmul_f16_f32_aligned_cm1",
+    "matmul_f32_f32_aligned_cm1",
+    "matmul_q4_k_f32_aligned_cm1",
+    "matmul_q6_k_f32_aligned_cm1",
+    "matmul_q5_0_f32_aligned_cm1",
+    "matmul_q8_0_f32_aligned_cm1",
+    // f16acc variants (Step 6.2)
+    "matmul_q4_k_f32_f16acc_cm1",
+    "matmul_q6_k_f32_f16acc_cm1",
+    "matmul_q5_0_f32_f16acc_cm1",
+    "matmul_q8_0_f32_f16acc_cm1",
+    "matmul_id_subgroup_mxfp4_f32_f16acc_cm1",
+    "matmul_q4_k_f32_aligned_f16acc_cm1",
+    "matmul_q6_k_f32_aligned_f16acc_cm1",
+    "matmul_q5_0_f32_aligned_f16acc_cm1",
+    "matmul_q8_0_f32_aligned_f16acc_cm1",
+    "matmul_id_subgroup_mxfp4_f32_aligned_f16acc_cm1",
+    // f16 B-type MXFP4 variants (Step 6.2/6.3)
+    "matmul_id_subgroup_mxfp4_f16_cm1",
+    "matmul_id_subgroup_mxfp4_f16_aligned_cm1",
+    "matmul_id_subgroup_mxfp4_f16_f16acc_cm1",
+    "matmul_id_subgroup_mxfp4_f16_aligned_f16acc_cm1",
+    // Q4_K / Q5_K MUL_MAT_ID subgroup variants
+    "matmul_id_subgroup_q4_k_f32_cm1",
+    "matmul_id_subgroup_q4_k_f32_aligned_cm1",
+    "matmul_id_subgroup_q4_k_f32_f16acc_cm1",
+    "matmul_id_subgroup_q4_k_f32_aligned_f16acc_cm1",
+    "matmul_id_subgroup_q4_k_f16_cm1",
+    "matmul_id_subgroup_q4_k_f16_aligned_cm1",
+    "matmul_id_subgroup_q4_k_f16_f16acc_cm1",
+    "matmul_id_subgroup_q4_k_f16_aligned_f16acc_cm1",
+    "matmul_id_subgroup_q5_k_f32_cm1",
+    "matmul_id_subgroup_q5_k_f32_aligned_cm1",
+    "matmul_id_subgroup_q5_k_f32_f16acc_cm1",
+    "matmul_id_subgroup_q5_k_f32_aligned_f16acc_cm1",
+    "matmul_id_subgroup_q5_k_f16_cm1",
+    "matmul_id_subgroup_q5_k_f16_aligned_cm1",
+    "matmul_id_subgroup_q5_k_f16_f16acc_cm1",
+    "matmul_id_subgroup_q5_k_f16_aligned_f16acc_cm1",
+    // Q5_1 dense GEMM and MUL_MAT_ID variants
+    "matmul_q5_1_f32_cm1",
+    "matmul_q5_1_f32_aligned_cm1",
+    "matmul_q5_1_f32_f16acc_cm1",
+    "matmul_q5_1_f32_aligned_f16acc_cm1",
+    "matmul_q5_1_f16_cm1",
+    "matmul_q5_1_f16_aligned_cm1",
+    "matmul_q5_1_f16_f16acc_cm1",
+    "matmul_q5_1_f16_aligned_f16acc_cm1",
+    "matmul_id_subgroup_q5_1_f32_cm1",
+    "matmul_id_subgroup_q5_1_f32_aligned_cm1",
+    "matmul_id_subgroup_q5_1_f32_f16acc_cm1",
+    "matmul_id_subgroup_q5_1_f32_aligned_f16acc_cm1",
+    "matmul_id_subgroup_q5_1_f16_cm1",
+    "matmul_id_subgroup_q5_1_f16_aligned_cm1",
+    "matmul_id_subgroup_q5_1_f16_f16acc_cm1",
+    "matmul_id_subgroup_q5_1_f16_aligned_f16acc_cm1",
+    // f16 B-type dense GEMM variants (Step 6.3)
+    "matmul_q5_0_f16_cm1",
+    "matmul_q5_0_f16_aligned_cm1",
+    "matmul_q5_0_f16_f16acc_cm1",
+    "matmul_q5_0_f16_aligned_f16acc_cm1",
+    "matmul_q8_0_f16_cm1",
+    "matmul_q8_0_f16_aligned_cm1",
+    "matmul_q8_0_f16_f16acc_cm1",
+    "matmul_q8_0_f16_aligned_f16acc_cm1",
+    "matmul_q4_k_f16_cm1",
+    "matmul_q4_k_f16_aligned_cm1",
+    "matmul_q4_k_f16_f16acc_cm1",
+    "matmul_q4_k_f16_aligned_f16acc_cm1",
+    "matmul_q6_k_f16_cm1",
+    "matmul_q6_k_f16_aligned_cm1",
+    "matmul_q6_k_f16_f16acc_cm1",
+    "matmul_q6_k_f16_aligned_f16acc_cm1",
+};
+
 enum MatMulIdType {
     NONE,
     DEFAULT,
@@ -104,6 +190,13 @@ void execute_command(std::vector<std::string>& command, std::string& stdout_str,
     std::string cmd;
     for (const auto& part : command) {
         cmd += part + " ";
+    }
+
+    for (int32_t ii = 0; ii < load_a_opt_kernels.size(); ii++) {
+        if (cmd.find(load_a_opt_kernels.at(ii)) != std::string::npos) {
+            cmd.append(" -DLOAD_A_OPT");
+            std::cout << cmd << std::endl;
+        }
     }
 
     if (!CreateProcessA(NULL, cmd.data(), NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -324,6 +324,7 @@ extern "C" {
         bool use_extra_bufts; // use extra buffer types (used for weight repacking)
         bool no_host;         // bypass host buffer allowing extra buffers to be used
         bool no_alloc;        // only load metadata and simulate memory allocations
+        int8_t cw;            // load-time compressed weight cache (Q4_0) for matching tensors. 0 = off, 1 = on (default), -1 = auto (on iff model has any matching downgrade candidate). Forces no-mmap when active.
     };
 
     struct llama_sampler_seq_config {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1,6 +1,7 @@
 #include "llama-context.h"
 
 #include "ggml.h"
+#include "ggml-backend.h"
 #include "llama-arch.h"
 #include "llama-graph.h"
 #include "llama-impl.h"
@@ -195,6 +196,24 @@ llama_context::llama_context(
     cparams.n_ubatch = std::min(cparams.n_batch, params.n_ubatch == 0 ? params.n_batch : params.n_ubatch);
 
     cparams.n_outputs_max = params.n_outputs_max == 0 ? cparams.n_batch : params.n_outputs_max;
+
+    // For MoE models with flash attention on Intel Xe2, raise n_ubatch to 2048.
+    if (cparams.flash_attn && hparams.n_expert > 1 && cparams.n_ubatch < 2048) {
+        auto * vk_reg = ggml_backend_reg_by_name("Vulkan");
+        if (vk_reg) {
+            using is_intel_xe2_fn_t = bool (*)(int);
+            auto is_intel_xe2_fn = (is_intel_xe2_fn_t) ggml_backend_reg_get_proc_address(vk_reg, "ggml_backend_vk_is_intel_xe2");
+            if (is_intel_xe2_fn) {
+                int n = (int) ggml_backend_reg_dev_count(vk_reg);
+                for (int i = 0; i < n; i++) {
+                    if (is_intel_xe2_fn(i)) {
+                        cparams.n_ubatch = std::min(cparams.n_batch, 2048u);
+                        break;
+                    }
+                }
+            }
+        }
+    }
 
     cparams.op_offload = params.op_offload;
     cparams.kv_unified = params.kv_unified;

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -11,11 +11,46 @@
 #include <cstdint>
 #include <cstring>
 #include <future>
+#include <mutex>
 #include <regex>
+#include <thread>
 
 static const size_t kiB = 1024;
 static const size_t MiB = 1024*kiB;
 static const size_t GiB = 1024*MiB;
+
+// Load-time cw pattern table.
+namespace {
+    struct cw_pat {
+        const char * pat;
+        ggml_type    type;
+        ggml_type    fallback;
+    };
+    const cw_pat cw_patterns[] = {
+        {"attn_q.weight",          GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"attn_k.weight",          GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"attn_v.weight",          GGML_TYPE_Q8_0, GGML_TYPE_COUNT},
+        {"attn_output.weight",     GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"attn_qkv.weight",        GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"attn_gate.weight",       GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"ssm_out.weight",         GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"ffn_gate.weight",        GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"ffn_up.weight",          GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"ffn_down.weight",        GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"ffn_gate_shexp.weight",  GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"ffn_up_shexp.weight",    GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"ffn_down_shexp.weight",  GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"output.weight",          GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+        {"token_embd.weight",      GGML_TYPE_Q4_0, GGML_TYPE_COUNT},
+    };
+    constexpr size_t cw_npatterns = sizeof(cw_patterns) / sizeof(cw_patterns[0]);
+
+    // Bits per weight for a quantized type: ggml_type_size is bytes per block,
+    // ggml_blck_size is elements per block; multiply by 8 to convert to bits.
+    inline double cw_bpw(ggml_type t) {
+        return 8.0 * (double) ggml_type_size(t) / (double) ggml_blck_size(t);
+    }
+}
 
 const char * llama_file_version_name(llama_fver version) {
     switch (version) {
@@ -520,7 +555,8 @@ llama_model_loader::llama_model_loader(
         bool check_tensors,
         bool no_alloc,
         const llama_model_kv_override * param_overrides_p,
-        const llama_model_tensor_buft_override * param_tensor_buft_overrides_p)
+        const llama_model_tensor_buft_override * param_tensor_buft_overrides_p,
+        int8_t param_cw)
         : metadata(meta), set_tensor_data(set_tensor_data), set_tensor_data_ud(set_tensor_data_ud) {
     int trace = 0;
     if (getenv("LLAMA_TRACE")) {
@@ -534,6 +570,7 @@ llama_model_loader::llama_model_loader(
     }
 
     tensor_buft_overrides = param_tensor_buft_overrides_p;
+    // cw_enabled is resolved later, once arch_name is known (see end of ctor).
 
     if (!fname.empty()) {
         // Load the main GGUF
@@ -811,6 +848,68 @@ llama_model_loader::llama_model_loader(
     if (!llama_mmap::SUPPORTED) {
         LLAMA_LOG_WARN("%s: mmap is not supported on this platform\n", __func__);
         use_mmap = false;
+    }
+
+    {
+        // Per-layer enable gate.
+        auto parse_blk = [](const std::string & n) -> int {
+            if (n.compare(0, 4, "blk.") != 0) return -1;
+            size_t end = n.find('.', 4);
+            if (end == std::string::npos) return -1;
+            int idx = 0;
+            for (size_t i = 4; i < end; ++i) {
+                if (n[i] < '0' || n[i] > '9') return -1;
+                idx = idx * 10 + (n[i] - '0');
+            }
+            return idx;
+        };
+        {
+            struct qkv_types { ggml_type q = GGML_TYPE_COUNT, k = GGML_TYPE_COUNT, v = GGML_TYPE_COUNT, qkv = GGML_TYPE_COUNT, ffnup = GGML_TYPE_COUNT, ffngateup = GGML_TYPE_COUNT; };
+            std::unordered_map<int, qkv_types> per_layer;
+            for (const auto & kv : weights_map) {
+                const std::string & name = kv.first;
+                int li = parse_blk(name);
+                if (li < 0) continue;
+                if      (name.find(".attn_qkv.weight")       != std::string::npos) per_layer[li].qkv      = kv.second.tensor->type;
+                else if (name.find(".attn_q.weight")         != std::string::npos) per_layer[li].q        = kv.second.tensor->type;
+                else if (name.find(".attn_k.weight")         != std::string::npos) per_layer[li].k        = kv.second.tensor->type;
+                else if (name.find(".attn_v.weight")         != std::string::npos) per_layer[li].v        = kv.second.tensor->type;
+                else if (name.find(".ffn_up_exps.weight")    != std::string::npos) per_layer[li].ffnup    = kv.second.tensor->type;
+                else if (name.find(".ffn_gate_up_exps.weight") != std::string::npos) per_layer[li].ffngateup = kv.second.tensor->type;
+            }
+            for (const auto & p : per_layer) {
+                const qkv_types & w = p.second;
+                const bool fused_ok  = (w.qkv == GGML_TYPE_Q8_0);
+                const bool split_ok  = (w.q == GGML_TYPE_Q8_0 && w.k == GGML_TYPE_Q8_0 && w.v == GGML_TYPE_Q8_0);
+                const bool ffn_ok    = (w.ffnup    != GGML_TYPE_COUNT && cw_bpw(w.ffnup)    < 5) ||
+                                       (w.ffngateup != GGML_TYPE_COUNT && cw_bpw(w.ffngateup) < 5);
+                if ((fused_ok || split_ok) && ffn_ok) {
+                    cw_layer_enabled.insert(p.first);
+                }
+            }
+        }
+
+        if (param_cw == 0) {
+            cw_enabled = false;
+        } else if (param_cw == 1) {
+            cw_enabled = true;
+        } else {
+            cw_enabled = false;
+        }
+        // Gate the entire feature on the per-layer check. If no layer qualifies,
+        // cw has nothing to downgrade — keep mmap on and short-circuit.
+        if (cw_enabled && cw_layer_enabled.empty()) {
+            LLAMA_LOG_INFO("%s: cw: no eligible layer found; cw disabled.\n", __func__);
+            cw_enabled = false;
+        }
+        if (cw_enabled && use_mmap) {
+            LLAMA_LOG_INFO("%s: cw active; disabling mmap so the load-time transform can run.\n", __func__);
+            use_mmap = false;
+        }
+        if (cw_enabled) {
+            LLAMA_LOG_INFO("%s: cw: %zu blk.* layers eligible.\n",
+                __func__, cw_layer_enabled.size());
+        }
     }
 
     this->use_mmap = use_mmap;
@@ -1276,6 +1375,53 @@ struct ggml_tensor * llama_model_loader::create_tensor(
     struct ggml_tensor * tensor = ggml_dup_tensor(ctx, cur);
     ggml_set_name(tensor, ggml_get_name(cur));
 
+    if (cw_enabled && ggml_is_quantized(tensor->type) && tensor->type != GGML_TYPE_Q4_0) {
+        const double cur_bpw = cw_bpw(tensor->type);
+        const char * name    = ggml_get_name(tensor);
+        bool layer_allowed;
+        if (strncmp(name, "blk.", 4) == 0) {
+            int li = 0;
+            for (const char * c = name + 4; *c && *c != '.'; ++c) {
+                if (*c < '0' || *c > '9') { li = -1; break; }
+                li = li * 10 + (*c - '0');
+            }
+            layer_allowed = (li >= 0 && cw_layer_enabled.count(li) > 0);
+        } else {
+            layer_allowed = !cw_layer_enabled.empty();
+        }
+        for (size_t i = 0; layer_allowed && i < cw_npatterns; ++i) {
+            const cw_pat & p = cw_patterns[i];
+            if (!strstr(name, p.pat)) continue;
+            if (cur_bpw <= 4.0) break;  // bits/weight gate: keep <=4 bpw types unchanged
+            ggml_type target = p.type;
+            if (cur_bpw <= cw_bpw(target)) break;  // not a downgrade
+            ggml_type new_type = target;
+            int       blck     = ggml_blck_size(new_type);
+            if (tensor->ne[0] % blck != 0) {
+                if (p.fallback != GGML_TYPE_COUNT &&
+                    tensor->ne[0] % ggml_blck_size(p.fallback) == 0 &&
+                    cur_bpw > cw_bpw(p.fallback)) {
+                    new_type = p.fallback;
+                    blck     = ggml_blck_size(new_type);
+                } else {
+                    LLAMA_LOG_WARN("%s: cw skipped for %s: ne[0]=%lld not divisible by %s block %d\n",
+                        __func__, name, (long long) tensor->ne[0],
+                        ggml_type_name(target), ggml_blck_size(target));
+                    break;
+                }
+            }
+            const ggml_type orig_type = tensor->type;
+            tensor->type  = new_type;
+            tensor->nb[0] = ggml_type_size(new_type);
+            tensor->nb[1] = tensor->nb[0] * (tensor->ne[0] / blck);
+            for (int d = 2; d < GGML_MAX_DIMS; d++) {
+                tensor->nb[d] = tensor->nb[d-1] * tensor->ne[d-1];
+            }
+            cw_src_type[name] = orig_type;
+            break;
+        }
+    }
+
     if (duplicated) {
         size_data += ggml_nbytes(cur);
     } else {
@@ -1419,7 +1565,23 @@ bool llama_model_loader::load_all_data(
     GGML_ASSERT(size_data != 0 && "call init_mappings() first");
 
     std::vector<no_init<uint8_t>> read_buf;
+    std::vector<no_init<uint8_t>> cw_dst_buf;     // staging for cw-encoded output bytes
+    std::vector<no_init<float>>   cw_f32_buf;     // staging for dequantized F32 values
     std::vector<std::future<std::pair<ggml_tensor *, bool>>> validation_result;
+
+    // Worker count for load-time cw. Override with LLAMA_CW_THREADS.
+    int cw_nthread = 0;
+    if (!cw_src_type.empty()) {
+        if (const char * env = getenv("LLAMA_CW_THREADS")) {
+            cw_nthread = atoi(env);
+        }
+        if (cw_nthread <= 0) {
+            cw_nthread = (int) std::thread::hardware_concurrency();
+        }
+        if (cw_nthread <= 0) {
+            cw_nthread = 4;
+        }
+    }
 
     // 4 staging buffers for async uploads, each sized 1MB seems to be a good default for single NVMe drives.
     // NVMe raid configurations might require more / larger buffers.
@@ -1534,6 +1696,79 @@ bool llama_model_loader::load_all_data(
 
         size_t n_size = ggml_nbytes(cur);
 
+        // Detect load-time cw: cur->type is the (possibly rewritten) target type;
+        // the on-disk source type is recovered from cw_src_type.
+        auto cw_it = cw_src_type.find(ggml_get_name(cur));
+        const bool is_cw = cw_it != cw_src_type.end();
+        const ggml_type orig_type = is_cw ? cw_it->second : cur->type;
+        const size_t disk_n_size = is_cw
+            ? ggml_row_size(orig_type, cur->ne[0]) * (ggml_nelements(cur) / cur->ne[0])
+            : n_size;
+
+        // Lambda: dequant `src` (orig_type) -> F32 -> cw to cur->type, then upload.
+        // Both phases are parallelized across cw_nthread workers.
+        auto cw_and_set = [&](const uint8_t * src) {
+            const int64_t nelements = ggml_nelements(cur);
+            const int64_t n_per_row = cur->ne[0];
+            const int64_t nrows     = nelements / n_per_row;
+            const ggml_type_traits * qt = ggml_get_type_traits(orig_type);
+            GGML_ASSERT(qt && qt->to_float);
+
+            cw_f32_buf.resize(nelements);
+            float * f32_ptr = reinterpret_cast<float *>(cw_f32_buf.data());
+            cw_dst_buf.resize(n_size);
+            void * dst_ptr = reinterpret_cast<void *>(cw_dst_buf.data());
+
+            const int nth = std::max(1, cw_nthread);
+
+            // Phase 1: parallel dequant. Split source blocks across workers.
+            // qt->to_float can run on any element count that is a multiple of the
+            // source block size; we honour that by chunking in whole blocks.
+            const int64_t src_blck   = ggml_blck_size(orig_type);
+            const size_t  src_blck_b = ggml_type_size(orig_type);
+            GGML_ASSERT(nelements % src_blck == 0);
+            const int64_t total_blocks = nelements / src_blck;
+
+            auto dequant_worker = [&](int tid) {
+                const int64_t per      = total_blocks / nth;
+                const int64_t leftover = total_blocks - per * nth;
+                const int64_t start_blk = tid * per + std::min<int64_t>(tid, leftover);
+                const int64_t my_blocks = per + (tid < leftover ? 1 : 0);
+                if (my_blocks == 0) return;
+                const int64_t my_elems = my_blocks * src_blck;
+                qt->to_float(src + start_blk * src_blck_b,
+                             f32_ptr + start_blk * src_blck,
+                             my_elems);
+            };
+
+            std::vector<std::thread> workers;
+            workers.reserve(nth - 1);
+            for (int t = 1; t < nth; t++) workers.emplace_back(dequant_worker, t);
+            dequant_worker(0);
+            for (auto & w : workers) w.join();
+            workers.clear();
+
+            // Phase 2: parallel cw. Split rows across workers.
+            // ggml_quantize_chunk uses its `start` arg (in elements) to compute
+            // both the source f32 offset and the dst byte offset, so we pass
+            // the unmodified base pointers.
+            auto quant_worker = [&](int tid) {
+                const int64_t per      = nrows / nth;
+                const int64_t leftover = nrows - per * nth;
+                const int64_t first_row = tid * per + std::min<int64_t>(tid, leftover);
+                const int64_t my_rows   = per + (tid < leftover ? 1 : 0);
+                if (my_rows == 0) return;
+                ggml_quantize_chunk(cur->type, f32_ptr, dst_ptr,
+                    first_row * n_per_row, my_rows, n_per_row, nullptr);
+            };
+
+            for (int t = 1; t < nth; t++) workers.emplace_back(quant_worker, t);
+            quant_worker(0);
+            for (auto & w : workers) w.join();
+
+            ggml_backend_tensor_set(cur, dst_ptr, 0, n_size);
+        };
+
         if (use_mmap) {
             const auto & mapping = mappings.at(weight->idx);
             ggml_backend_buffer_t buf_mmap = nullptr;
@@ -1542,7 +1777,7 @@ bool llama_model_loader::load_all_data(
             }
             uint8_t * data = (uint8_t *) mapping->addr() + weight->offs;
 
-            if (check_tensors) {
+            if (check_tensors && !is_cw) {
                 validation_result.emplace_back(std::async(std::launch::async, [cur, data, n_size] {
                     return std::make_pair(cur, ggml_validate_row_data(cur->type, data, n_size));
                 }));
@@ -1550,6 +1785,11 @@ bool llama_model_loader::load_all_data(
 
             GGML_ASSERT(buf_mmap || cur->data); // either we have a buffer to allocate the tensor in, or it is already allocated
             if (buf_mmap && cur->data == nullptr) {
+                if (is_cw) {
+                    throw std::runtime_error(format(
+                        "tensor '%s' selected for load-time cw but allocated to mmap zero-copy buffer; rerun with --no-mmap",
+                        ggml_get_name(cur)));
+                }
                 ggml_backend_tensor_alloc(buf_mmap, cur, data);
                 if (lmlocks) {
                     const auto & lmlock = lmlocks->at(weight->idx);
@@ -1559,6 +1799,8 @@ bool llama_model_loader::load_all_data(
                 auto & mmap_used = mmaps_used[weight->idx];
                 mmap_used.first  = std::min(mmap_used.first,  weight->offs);
                 mmap_used.second = std::max(mmap_used.second, weight->offs + n_size);
+            } else if (is_cw) {
+                cw_and_set(data);
             } else {
                 ggml_backend_tensor_set(cur, data, 0, n_size);
             }
@@ -1566,16 +1808,23 @@ bool llama_model_loader::load_all_data(
             const auto & file = files.at(weight->idx);
 
             if (ggml_backend_buffer_is_host(cur->buffer)) {
-                file->seek(weight->offs, SEEK_SET);
-                file->read_raw(cur->data, n_size);
-                if (check_tensors) {
-                    validation_result.emplace_back(std::async(std::launch::async, [cur, n_size] {
-                        return std::make_pair(cur, ggml_validate_row_data(cur->type, cur->data, n_size));
-                    }));
+                if (is_cw) {
+                    read_buf.resize(disk_n_size);
+                    file->seek(weight->offs, SEEK_SET);
+                    file->read_raw(read_buf.data(), disk_n_size);
+                    cw_and_set((const uint8_t *) read_buf.data());
+                } else {
+                    file->seek(weight->offs, SEEK_SET);
+                    file->read_raw(cur->data, n_size);
+                    if (check_tensors) {
+                        validation_result.emplace_back(std::async(std::launch::async, [cur, n_size] {
+                            return std::make_pair(cur, ggml_validate_row_data(cur->type, cur->data, n_size));
+                        }));
+                    }
                 }
             } else {
                 // If upload_backend is valid load the tensor in chunks to pinned memory and upload the buffers asynchronously to the GPU.
-                if (upload_backend) {
+                if (upload_backend && !is_cw) {
                     size_t offset = weight->offs;
                     alignment = file->read_alignment();
                     size_t aligned_offset = offset & ~(alignment - 1);
@@ -1627,6 +1876,11 @@ bool llama_model_loader::load_all_data(
                         ++buffer_idx;
                         buffer_idx %= n_buffers;
                     }
+                } else if (is_cw) {
+                    read_buf.resize(disk_n_size);
+                    file->seek(weight->offs, SEEK_SET);
+                    file->read_raw(read_buf.data(), disk_n_size);
+                    cw_and_set((const uint8_t *) read_buf.data());
                 } else {
                     read_buf.resize(n_size);
                     file->seek(weight->offs, SEEK_SET);

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <stdexcept>
 #include <unordered_map>
+#include <unordered_set>
 
 using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
 
@@ -89,6 +90,10 @@ struct llama_model_loader {
     std::map<std::string, llama_tensor_weight, weight_name_comparer> weights_map;
     std::unordered_map<std::string, llama_model_kv_override> kv_overrides;
     const llama_model_tensor_buft_override * tensor_buft_overrides;
+    bool cw_enabled = false;
+
+    std::unordered_map<std::string, ggml_type> cw_src_type;
+    std::unordered_set<int> cw_layer_enabled;
 
     gguf_context_ptr metadata_ptr;
     struct gguf_context * metadata; // either metadata_ptr.get() or externally set
@@ -131,7 +136,8 @@ struct llama_model_loader {
         bool check_tensors,
         bool no_alloc,
         const llama_model_kv_override * param_overrides_p,
-        const llama_model_tensor_buft_override * param_tensor_buft_overrides_p);
+        const llama_model_tensor_buft_override * param_tensor_buft_overrides_p,
+        int8_t param_cw = 1);
 
     template<typename T>
     typename std::enable_if<std::is_integral<T>::value, bool>::type

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2267,6 +2267,7 @@ llama_model_params llama_model_default_params() {
         /*.use_extra_bufts             =*/ true,
         /*.no_host                     =*/ false,
         /*.no_alloc                    =*/ false,
+        /*.cw                     =*/ -1,  // auto by default: on for Intel Xe2+, off elsewhere
     };
 
     return result;

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -286,13 +286,23 @@ static void llama_tensor_dequantize_impl(
 //
 
 static bool tensor_allows_quantization(const llama_model_quantize_params * params, llm_arch arch, const ggml_tensor * tensor) {
-    // trivial checks first -- no string ops needed
-    if (params->only_copy)       return false;
-
     // quantize only 2D and 3D tensors (experts)
     if (ggml_n_dims(tensor) < 2) return false;
 
     const std::string name = ggml_get_name(tensor);
+
+    // With only_copy (ftype COPY), quantize only tensors matching an explicit
+    // --tensor-type override pattern; everything else is copied as-is.
+    if (params->only_copy) {
+        if (params->tt_overrides) {
+            for (const auto * p = params->tt_overrides; p->pattern != nullptr; p++) {
+                if (name.find(p->pattern) != std::string::npos) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     // This used to be a regex, but <regex> has an extreme cost to compile times.
     bool quantize = name.rfind("weight") == name.size() - 6; // ends with 'weight'?
@@ -671,31 +681,33 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, const llama_mod
 
     ggml_type new_type = default_type;
 
-    // get more optimal quantization type based on the tensor shape, layer, etc.
-    if (!params->pure && ggml_is_quantized(default_type)) {
-        // if the user provided tensor types - use those
-        bool manual = false;
-        if (!qs.tensor_type_patterns.empty()) {
-            const std::string tensor_name(tensor->name);
-            for (const auto & [pattern, qtype] : qs.tensor_type_patterns) {
-                if (std::regex_search(tensor_name, pattern)) {
-                    if (qtype != new_type) {
-                        LLAMA_LOG_WARN("%s: %-36s - applying manual override: %s -> %s\n",
-                                       __func__, tensor_name.c_str(), ggml_type_name(new_type), ggml_type_name(qtype));
-                        new_type = qtype;
-                    }
+    // User-provided --tensor-type overrides take precedence. Apply them regardless
+    // of the default_type (needed for ftype=COPY, where default_type is F32 but the
+    // user still wants specific tensors requantized).
+    bool manual = false;
+    if (!params->pure && !qs.tensor_type_patterns.empty()) {
+        const std::string tensor_name(tensor->name);
+        for (const auto & [pattern, qtype] : qs.tensor_type_patterns) {
+            if (std::regex_search(tensor_name, pattern)) {
+                if (qtype != new_type) {
+                    LLAMA_LOG_WARN("%s: %-36s - applying manual override: %s -> %s\n",
+                                   __func__, tensor_name.c_str(), ggml_type_name(new_type), ggml_type_name(qtype));
+                    new_type = qtype;
                     manual = true;
                     break;
                 }
             }
         }
+    }
 
-        // if not manual - use the standard logic for choosing the quantization type based on the selected mixture
-        if (!manual) {
-            new_type = llama_tensor_get_type_impl(qs, new_type, tensor, params->ftype, tm.category);
-        }
+    // get more optimal quantization type based on the tensor shape, layer, etc.
+    if (!manual && !params->pure && ggml_is_quantized(default_type)) {
+        // standard logic for choosing the quantization type based on the selected mixture
+        new_type = llama_tensor_get_type_impl(qs, new_type, tensor, params->ftype, tm.category);
+    }
 
-        // incompatible tensor shapes are handled here - fallback to a compatible type
+    // incompatible tensor shapes are handled here - fallback to a compatible type
+    if (ggml_is_quantized(new_type)) {
         new_type = tensor_type_fallback(qs, tensor, new_type);
     }
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -279,8 +279,29 @@ static bool llama_prepare_model_devices(const llama_model_params & params, llama
 static std::pair<int, llama_model *> llama_model_load(struct gguf_context * metadata, llama_model_set_tensor_data_t set_tensor_data, void * set_tensor_data_ud,
         const std::string & fname, std::vector<std::string> & splits, FILE * file, llama_model_params & params) {
     try {
+        // Resolve cw auto-mode: enable on Intel Xe2 (let loader check for matching candidates), off elsewhere.
+        if (params.cw == -1) {
+            bool is_intel_xe2 = false;
+            auto * vk_reg = ggml_backend_reg_by_name("Vulkan");
+            if (vk_reg) {
+                using is_intel_xe2_fn_t = bool (*)(int);
+                auto is_intel_xe2_fn = (is_intel_xe2_fn_t) ggml_backend_reg_get_proc_address(vk_reg, "ggml_backend_vk_is_intel_xe2");
+                if (is_intel_xe2_fn) {
+                    int n = (int) ggml_backend_reg_dev_count(vk_reg);
+                    for (int i = 0; i < n; i++) {
+                        if (is_intel_xe2_fn(i)) { is_intel_xe2 = true; break; }
+                    }
+                }
+            }
+            if (is_intel_xe2) {
+                params.cw = 1;
+            } else {
+                params.cw = 0;
+            }
+        }
+
         llama_model_loader ml(metadata, set_tensor_data, set_tensor_data_ud, fname, splits, file, params.use_mmap, params.use_direct_io,
-            params.check_tensors, params.no_alloc, params.kv_overrides, params.tensor_buft_overrides);
+            params.check_tensors, params.no_alloc, params.kv_overrides, params.tensor_buft_overrides, params.cw);
 
         ml.print_info();
         std::unique_ptr<llama_model> model_ptr(llama_model_create(ml, params));

--- a/src/models/gemma4.cpp
+++ b/src/models/gemma4.cpp
@@ -312,9 +312,9 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
             cb(cur_moe, "ffn_norm_2", il);
 
             // custom MoE logits calculation (router operates on attn_out, not cur)
-            ggml_tensor * tmp = ggml_rms_norm(ctx0, attn_out, hparams.f_norm_rms_eps);
+            // fuse rms_norm + mul(ffn_gate_inp_s) into one RMS_NORM_MUL dispatch; keep constant scale separate
+            ggml_tensor * tmp = build_norm(attn_out, model.layers[il].ffn_gate_inp_s, nullptr, LLM_NORM_RMS, il);
             tmp = ggml_scale(ctx0, tmp, 1.0f / sqrtf((float) n_embd));
-            tmp = ggml_mul(ctx0, tmp, model.layers[il].ffn_gate_inp_s);
             ggml_tensor * logits = build_lora_mm(model.layers[il].ffn_gate_inp, tmp); // [n_expert, n_tokens]
             cb(logits, "ffn_moe_logits", il);
 

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -349,6 +349,7 @@ struct cmd_params {
     std::vector<bool>                embeddings;
     std::vector<bool>                no_op_offload;
     std::vector<bool>                no_host;
+    int8_t                           cw;  // -1 auto, 0 off, 1 on
     std::vector<size_t>              fit_params_target;
     std::vector<uint32_t>            fit_params_min_ctx;
     ggml_numa_strategy               numa;
@@ -393,6 +394,7 @@ static const cmd_params cmd_params_defaults = {
     /* embeddings           */ { false },
     /* no_op_offload        */ { false },
     /* no_host              */ { false },
+    /* cw                   */ -1,    // auto by default: on for Intel Xe2+, off elsewhere
     /* fit_params_target    */ { 0 },
     /* fit_params_min_ctx   */ { 0 },
     /* numa                 */ GGML_NUMA_STRATEGY_DISABLED,
@@ -464,6 +466,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("                                              (default: disabled)\n");
     printf("  -nopo, --no-op-offload <0|1>                (default: 0)\n");
     printf("  --no-host <0|1>                             (default: %s)\n", join(cmd_params_defaults.no_host, ",").c_str());
+    printf("  -cw <auto|on|off>                           load-time compressed-weight cache (Q4_0) for matching tensors. (default: off; auto enables on Intel Xe2+, off elsewhere)\n");
     printf("\n");
     printf(
         "Multiple values can be given for each parameter by separating them with ','\n"
@@ -516,11 +519,11 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     params.delay                = cmd_params_defaults.delay;
     params.progress             = cmd_params_defaults.progress;
     params.no_warmup            = cmd_params_defaults.no_warmup;
+    params.cw                   = cmd_params_defaults.cw;
 
     if (const char * env = getenv("HF_TOKEN")) {
         params.hf_token = env;
     }
-
     for (int i = 1; i < argc; i++) {
         arg = argv[i];
         if (arg.compare(0, arg_prefix.size(), arg_prefix) == 0) {
@@ -852,6 +855,24 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 }
                 auto p = string_split<bool>(argv[i], split_delim);
                 params.no_host.insert(params.no_host.end(), p.begin(), p.end());
+            } else if (arg == "-cw") {
+                i++;
+                if (i >= argc) {
+                    invalid_param = true;
+                    break;
+                }
+                std::string v = argv[i];
+                if (v == "on" || v == "1" || v == "true") {
+                    params.cw = 1;
+                } else if (v == "off" || v == "0" || v == "false") {
+                    params.cw = 0;
+                } else if (v == "auto" || v == "-1") {
+                    params.cw = -1;
+                } else {
+                    fprintf(stderr, "error: invalid -cw value: '%s' (expected auto|on|off)\n", v.c_str());
+                    invalid_param = true;
+                    break;
+                }
             } else if (arg == "-ts" || arg == "--tensor-split") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1169,6 +1190,7 @@ struct cmd_params_instance {
     bool               embeddings;
     bool               no_op_offload;
     bool               no_host;
+    int8_t             cw;
     size_t             fit_target;
     uint32_t           fit_min_ctx;
 
@@ -1185,6 +1207,7 @@ struct cmd_params_instance {
         mparams.use_mmap      = use_mmap;
         mparams.use_direct_io = use_direct_io;
         mparams.no_host       = no_host;
+        mparams.cw            = cw;  // tri-state; loader resolves auto by scanning tensors for downgrade candidates and disables mmap when active
 
         if (n_cpu_moe <= 0) {
             if (tensor_buft_overrides.empty()) {
@@ -1232,6 +1255,7 @@ struct cmd_params_instance {
                use_mmap == other.use_mmap && use_direct_io == other.use_direct_io &&
                devices == other.devices &&
                no_host == other.no_host &&
+               cw == other.cw &&
                vec_tensor_buft_override_equal(tensor_buft_overrides, other.tensor_buft_overrides);
     }
 
@@ -1315,6 +1339,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .embeddings   = */ embd,
                 /* .no_op_offload= */ nopo,
                 /* .no_host      = */ noh,
+                /* .cw           = */ params.cw,
                 /* .fit_target   = */ fpt,
                 /* .fit_min_ctx  = */ fpc,
             };
@@ -1352,6 +1377,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .embeddings   = */ embd,
                 /* .no_op_offload= */ nopo,
                 /* .no_host      = */ noh,
+                /* .cw           = */ params.cw,
                 /* .fit_target   = */ fpt,
                 /* .fit_min_ctx  = */ fpc,
             };
@@ -1389,6 +1415,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .embeddings   = */ embd,
                 /* .no_op_offload= */ nopo,
                 /* .no_host      = */ noh,
+                /* .cw           = */ params.cw,
                 /* .fit_target   = */ fpt,
                 /* .fit_min_ctx  = */ fpc,
             };
@@ -1431,6 +1458,7 @@ struct test {
     bool                     embeddings;
     bool                     no_op_offload;
     bool                     no_host;
+    int8_t                   cw;
     size_t                   fit_target;
     uint32_t                 fit_min_ctx;
     int                      n_prompt;
@@ -1471,6 +1499,7 @@ struct test {
         embeddings     = inst.embeddings;
         no_op_offload  = inst.no_op_offload;
         no_host        = inst.no_host;
+        cw             = inst.cw;
         fit_target     = inst.fit_target;
         fit_min_ctx    = inst.fit_min_ctx;
         n_prompt       = inst.n_prompt;
@@ -1530,7 +1559,7 @@ struct test {
             "type_k",         "type_v",         "n_gpu_layers",  "n_cpu_moe",      "split_mode",
             "main_gpu",       "no_kv_offload",  "flash_attn",    "devices",        "tensor_split",
             "tensor_buft_overrides",            "use_mmap",      "use_direct_io",  "embeddings",
-            "no_op_offload",  "no_host",        "fit_target",     "fit_min_ctx",
+            "no_op_offload",  "no_host",        "cw",       "fit_target",     "fit_min_ctx",
             "n_prompt",       "n_gen",          "n_depth",
             "test_time",      "avg_ns",         "stddev_ns",     "avg_ts",         "stddev_ts"
         };
@@ -1625,6 +1654,7 @@ struct test {
                                             std::to_string(embeddings),
                                             std::to_string(no_op_offload),
                                             std::to_string(no_host),
+                                            (cw == 1 ? "on" : (cw == 0 ? "off" : "auto")),
                                             std::to_string(fit_target),
                                             std::to_string(fit_min_ctx),
                                             std::to_string(n_prompt),
@@ -1821,6 +1851,9 @@ struct markdown_printer : public printer {
         if (field == "no_host") {
             return 4;
         }
+        if (field == "cw") {
+            return -4;  // STRING: left-aligned, fits "auto"
+        }
 
         int width = std::max((int) field.length(), 10);
 
@@ -1860,6 +1893,9 @@ struct markdown_printer : public printer {
         }
         if (field == "no_host") {
             return "noh";
+        }
+        if (field == "cw") {
+            return "rq";
         }
         if (field == "devices") {
             return "dev";
@@ -1953,6 +1989,9 @@ struct markdown_printer : public printer {
         }
         if (params.no_host.size() > 1 || params.no_host != cmd_params_defaults.no_host) {
             fields.emplace_back("no_host");
+        }
+        if (params.cw != cmd_params_defaults.cw) {
+            fields.emplace_back("cw");
         }
         if (params.fit_params_target.size() > 1 || params.fit_params_target != cmd_params_defaults.fit_params_target) {
             fields.emplace_back("fit_target");


### PR DESCRIPTION
## Overview

**Co-authors:** @jxia4intel, @sliu39

> **Draft / Evaluation only — not for merge.** This mega PR exists solely to show the full feature set in one place and will remain as a draft. Please refer to the individual PRs below for review and merging.

**Target platforms:** Xe-LPG Plus (Arrow Lake-H iGPU), Xe2, Xe3

> | PR | Series | Description | Target |
> |----|--------|-------------|--------|
> | https://github.com/ggml-org/llama.cpp/pull/24404 | 1/3 | Xe-LPG Plus coopmat1 enable + INTEL_PRE_XE2 enum | Xe-LPG Plus |
> | https://github.com/ggml-org/llama.cpp/pull/24406 | 2/3 | Intel Xe FA optimization kernels | Xe-LPG Plus, Xe2, Xe3 |
> | https://github.com/ggml-org/llama.cpp/pull/24407 | 3/3 | GEMM/Group GEMM optimizations | Xe-LPG Plus, Xe2, Xe3 |
>
> **Dependency graph:**
> ```
> #24404 (ARLH) ← #24406 (FA)
>            ← #24407 (GEMM+CW)
> ```
> PR6 and PR7 are independent of each other; both build on PR5.

### Flash Attention (Intel Xe)

- New Vulkan shaders: single-phase prefill (`flash_attn_hdim64/96/128`) and two-phase split prefill/decode variants
- Pipelines keyed by `(head_dim, gqa_ratio)` for runtime dispatch across various GQA ratios without combinatorial pipeline proliferation
- Supports non-power-of-two GQA ratios via subgroup splitting (`qk_groups`)
- Intel Xe1 (integrated GPU, UMA, cooperative matrix) and Xe2 paths with separate warptile tuning
- Two-phase decode splits softmax reduction across subgroups; shared QK state copy (`fa_copy_qstate`) between prefill phases

### GEMM kernel optimizations (Intel Xe)

- `LOAD_A_OPT` path: SLM-based A-matrix layout optimization for coopmat1
- MXFP4, Q4_K, Q5_K dequant via `bitfieldExtract` optimization
- Alt pipeline (`l_alt`/`a_l_alt`, BM=128 warptile) for runtime selection when problem dimensions are small
- f32→f16 activation conversion for Intel coopmat GEMM, scoped to Intel devices only
- `vulkan-shaders-gen.cpp`: registers all new pipeline variants

### MoE optimizations (Intel Xe)

- `mul_mm.comp` shader optimization for `MUL_MAT_ID`: reduces unnecessary memory loads and matrix core operations for MoE models
- Separate warptile tuning for MoE expert GEMM
- Gemma4 MoE router: fuse `rms_norm + mul` into a single `RMS_NORM_MUL` kernel dispatch for the expert gate input calculation

### Performance (Windows OS)
ARLH
<img width="2400" height="1262" alt="ARLH_prefill" src="https://github.com/user-attachments/assets/e0c3a81f-40df-4803-be3d-210ffd6c176b" />

<img width="2399" height="1293" alt="ARLH_decode" src="https://github.com/user-attachments/assets/b1792d49-18be-41c4-9d8a-c356c5ea72af" />

LNL
<img width="2560" height="1379" alt="LNL_prefill" src="https://github.com/user-attachments/assets/965e3dd7-8d57-4345-ab05-dc443239546c" />

<img width="2560" height="1379" alt="LNL_prefill" src="https://github.com/user-attachments/assets/42998fea-ca9e-443e-aef9-75c05be18c87" />

B70 Arc Pro
<img width="2828" height="1945" alt="B70_prefill" src="https://github.com/user-attachments/assets/316320ce-1f3d-403b-ac26-1f1f880e31a9" />
<img width="2797" height="1763" alt="B70_decode" src="https://github.com/user-attachments/assets/ee4d885f-fda6-4569-855d-3e97a6290bdd" />

PTL
<img width="2755" height="1425" alt="PTL_prefill" src="https://github.com/user-attachments/assets/ef40b32f-f111-4b8e-9e64-e2c9366898a1" />
<img width="2614" height="1387" alt="PTLdecode" src="https://github.com/user-attachments/assets/137463cb-0e6c-47ac-bea1-998120df425f" />

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used claude code, then lots of manual review/tweaking.