### PR TITLE
requirements : Update transformers back to 5.5.1

### DIFF
--- a/requirements/requirements-convert_legacy_llama.txt
+++ b/requirements/requirements-convert_legacy_llama.txt
@@ -1,7 +1,7 @@
 numpy~=1.26.4
 sentencepiece>=0.1.98,<0.3.0
 
-transformers==4.57.6
+transformers==5.5.1
 
 gguf>=0.1.0
 protobuf>=4.21.0,<5.0.0


### PR DESCRIPTION
## Overview

This resolves an issue when converting Gemma 4's MTP safetensors to GGUF.

## Additional information

The version of transformers was reverted in https://github.com/ggml-org/llama.cpp/pull/23966 , apparently to resolve a separate issue, and notes that it was pending https://github.com/huggingface/transformers/pull/45887 (which has since been merged).

transformers was previously updated to 5.5.1 in https://github.com/ggml-org/llama.cpp/pull/21617 for the same reason as this PR.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Used to find the dependency issue.
