### PR TITLE
graph: nocache attn: avoid null mask buffer access

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1,5 +1,6 @@
 #include "llama-graph.h"
 
+#include "ggml.h"
 #include "llama-impl.h"
 #include "llama-model.h"
 #include "llama-batch.h"
@@ -463,16 +464,22 @@ void llm_graph_input_attn_no_cache::set_input(const llama_ubatch * ubatch) {
         }
     };
 
-    GGML_ASSERT(self_kq_mask);
-    GGML_ASSERT(ggml_backend_buffer_is_host(self_kq_mask->buffer));
-    if (self_kq_mask->type == GGML_TYPE_F16) {
-        fill_mask((ggml_fp16_t *) self_kq_mask->data, ggml_nelements(self_kq_mask), 0, LLAMA_SWA_TYPE_NONE);
-    } else {
-        fill_mask((float       *) self_kq_mask->data, ggml_nelements(self_kq_mask), 0, LLAMA_SWA_TYPE_NONE);
+    GGML_ASSERT(swa_mix != LLM_SWA_MIX_UNSET);
+
+    if (swa_mix != LLM_SWA_MIX_ALL) {
+        GGML_ASSERT(self_kq_mask);
+        GGML_ASSERT(self_kq_mask->buffer);
+        GGML_ASSERT(ggml_backend_buffer_is_host(self_kq_mask->buffer));
+        if (self_kq_mask->type == GGML_TYPE_F16) {
+            fill_mask((ggml_fp16_t *) self_kq_mask->data, ggml_nelements(self_kq_mask), 0, LLAMA_SWA_TYPE_NONE);
+        } else {
+            fill_mask((float       *) self_kq_mask->data, ggml_nelements(self_kq_mask), 0, LLAMA_SWA_TYPE_NONE);
+        }
     }
 
-    if (hparams.swa_type != LLAMA_SWA_TYPE_NONE) {
+    if (swa_mix != LLM_SWA_MIX_NONE) {
         GGML_ASSERT(self_kq_mask_swa);
+        GGML_ASSERT(self_kq_mask_swa->buffer);
         GGML_ASSERT(ggml_backend_buffer_is_host(self_kq_mask_swa->buffer));
         if (self_kq_mask_swa->type == GGML_TYPE_F16) {
             fill_mask((ggml_fp16_t *) self_kq_mask_swa->data, ggml_nelements(self_kq_mask_swa), hparams.n_swa, hparams.swa_type);
@@ -2210,6 +2217,16 @@ ggml_tensor * llm_graph_context::build_attn(
     ggml_build_forward_expand(gf, v_cur);
 
     const bool is_swa = hparams.is_swa(il);
+    switch (inp->swa_mix) {
+    case LLM_SWA_MIX_UNSET:
+        inp->swa_mix = is_swa ? LLM_SWA_MIX_ALL : LLM_SWA_MIX_NONE; break;
+    case LLM_SWA_MIX_NONE:
+        inp->swa_mix = is_swa ? LLM_SWA_MIX_SOME : LLM_SWA_MIX_NONE; break;
+    case LLM_SWA_MIX_ALL:
+        inp->swa_mix = is_swa ? LLM_SWA_MIX_ALL : LLM_SWA_MIX_SOME; break;
+    case LLM_SWA_MIX_SOME:
+        break;
+    }
 
     const auto & kq_mask = is_swa ? inp->get_kq_mask_swa() : inp->get_kq_mask();
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -59,6 +59,13 @@ enum llm_norm_type {
     LLM_NORM_GROUP,
 };
 
+enum llm_swa_mix {
+    LLM_SWA_MIX_UNSET = 0,
+    LLM_SWA_MIX_NONE  = 1,
+    LLM_SWA_MIX_SOME  = 2,
+    LLM_SWA_MIX_ALL   = 3,
+};
+
 // TODO: tmp - need something better to pass the data from the encoder to the decoder
 struct llama_cross {
     // the output embeddings from the encoder as a ggml tensor
@@ -297,6 +304,9 @@ public:
     ggml_tensor * self_kq_mask_cnv     = nullptr; //         [n_tokens, n_batch/n_stream, 1, n_stream]
     ggml_tensor * self_kq_mask_swa     = nullptr; // F32/F16 [n_tokens, n_batch/n_stream, 1, n_stream]
     ggml_tensor * self_kq_mask_swa_cnv = nullptr; //         [n_tokens, n_batch/n_stream, 1, n_stream]
+
+    // Record the usage of SWA across layers in this particular graph
+    llm_swa_mix swa_mix = LLM_SWA_MIX_UNSET;
 
     const llama_hparams hparams;
     const llama_cparams cparams;


### PR DESCRIPTION
## Overview

When there is a model with only SWA layers then the scheduler never
allocates the kq_mask buffer. Meanwhile llm_graph_input_attn_no_cache::set_input()
fills the non-SWA mask unconditionally triggering an assertion failure.

This change tracks when SWA and non-SWA layers are used in a graph and
fills only the mask(s) that are used. In theory nextn layers can be on
a separate graph so we can not simply check hparam's layers for SWA.

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

This is similar to #23131. Presently there are no SWA only no-kv-cache models
so this bug can't be triggered. However I am working on adding the OpenAI Privacy 
Filter model archicture which does token classification using only SWA.

I didn't simply check that the buffer is allocated because if there is another bug
that causes the buffer alloation to be missed then it kicks the bucket down the road.
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, I vibe coded the original fix and then threw that away and wrote this, using Claude for review and codebase searches.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
