### PR TITLE
CUDA: batch out_prod broadcast (dps2>1) path with cublasSgemmBatched

### DIFF
--- a/ggml/src/ggml-cuda/out-prod.cu
+++ b/ggml/src/ggml-cuda/out-prod.cu
@@ -2,6 +2,28 @@
 
 #include <cstdint>
 
+static __global__ void k_compute_out_prod_ptrs(
+        const float * src0_d, const float * src1_d, float * dst_d,
+        const float ** ptrs_a, const float ** ptrs_b, float ** ptrs_c,
+        const int64_t ne2, const int64_t ne3,
+        const int64_t dps2, const int64_t dps3,
+        const size_t s02, const size_t s03,
+        const size_t s12, const size_t s13,
+        const size_t s2,  const size_t s3) {
+    const int64_t i2 = blockIdx.x*blockDim.x + threadIdx.x;
+    const int64_t i3 = blockIdx.y*blockDim.y + threadIdx.y;
+
+    if (i2 >= ne2 || i3 >= ne3) {
+        return;
+    }
+
+    const int64_t idx = i3*ne2 + i2;
+
+    ptrs_a[idx] = src0_d + (i3/dps3)*s03 + (i2/dps2)*s02;
+    ptrs_b[idx] = src1_d +  i3      *s13 +  i2      *s12;
+    ptrs_c[idx] = dst_d  +  i3      *s3  +  i2      *s2;
+}
+
 void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0 = dst->src[0];
     const ggml_tensor * src1 = dst->src[1];
@@ -67,18 +89,39 @@ void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
                         &beta,  dst_d  +  i3     *s3,  ldc, s2,
                         batch_count));
         }
+    } else if (ne2 > 1 || ne3 > 1) {
+        // dps2 > 1 (src0 broadcast along dim 2 with non-uniform stride) or multiple GEMMs
+        // along dim 3: compute per-GEMM pointers on the device and use a single batched GEMM.
+        GGML_ASSERT(ne3 > 0);
+        GGML_ASSERT(ne2 <= (int64_t) std::numeric_limits<int>::max() / ne3);
+        const int batch_count = (int) (ne2 * ne3);
+
+        ggml_cuda_pool_alloc<const float *> ptrs_a(ctx.pool(), batch_count);
+        ggml_cuda_pool_alloc<const float *> ptrs_b(ctx.pool(), batch_count);
+        ggml_cuda_pool_alloc<      float *> ptrs_c(ctx.pool(), batch_count);
+
+        const dim3 block_dims(16, 16);
+        const dim3 grid_dims((ne2 + block_dims.x - 1)/block_dims.x, (ne3 + block_dims.y - 1)/block_dims.y);
+        k_compute_out_prod_ptrs<<<grid_dims, block_dims, 0, stream>>>(
+            src0_d, src1_d, dst_d,
+            ptrs_a.get(), ptrs_b.get(), ptrs_c.get(),
+            ne2, ne3, dps2, dps3, s02, s03, s12, s13, s2, s3);
+        CUDA_CHECK(cudaGetLastError());
+
+        CUBLAS_CHECK(
+            cublasSgemmBatched(handle, CUBLAS_OP_N, src1_cublas_op,
+                    ne0, ne1, ne01,
+                    &alpha, ptrs_a.get(), lda,
+                            ptrs_b.get(), ldb,
+                    &beta,  ptrs_c.get(), ldc,
+                    batch_count));
     } else {
-        // Fallback: ne2 == 1 (no batching benefit) or dps2 > 1 (src0 broadcast along dim 2
-        // with non-uniform stride; would need cublasSgemmBatched with pointer arrays).
-        for (int64_t i3 = 0; i3 < ne3; ++i3) {
-            for (int64_t i2 = 0; i2 < ne2; ++i2) {
-                CUBLAS_CHECK(
-                    cublasSgemm(handle, CUBLAS_OP_N, src1_cublas_op,
-                            ne0, ne1, ne01,
-                            &alpha, src0_d + (i3/dps3)*s03 + (i2/dps2)*s02, lda,
-                                    src1_d +  i3      *s13 +  i2      *s12, ldb,
-                            &beta,  dst_d  +  i3      *s3  +  i2      *s2,  ldc));
-            }
-        }
+        // ne2 == 1 && ne3 == 1: single GEMM
+        CUBLAS_CHECK(
+            cublasSgemm(handle, CUBLAS_OP_N, src1_cublas_op,
+                    ne0, ne1, ne01,
+                    &alpha, src0_d, lda,
+                            src1_d, ldb,
+                    &beta,  dst_d,  ldc));
     }
 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8643,6 +8643,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                                   256, 16, 16, {ne2, 1}, {1, 1}));
     }
 
+    // nr2 sweep to cover the cublasSgemmBatched pointer-array path (dps2 > 1)
+    for (int64_t nr2 : {8, 16, 32}) {
+        test_cases.emplace_back(new test_out_prod(GGML_TYPE_F32, GGML_TYPE_F32,
+                                                  256, 16, 16, {1, 1}, {nr2, 1}));
+    }
+
     // add_id
     for (ggml_type type_a : {GGML_TYPE_F32}) {
         for (ggml_type type_b : {GGML_TYPE_F32}) {


### PR DESCRIPTION
## Overview



Follow-up to #22651.



That PR batched the `out_prod` inner loop with `cublasSgemmStridedBatched` for the uniform-stride case (`dps2 == 1`). The remaining broadcast fallback (`dps2 > 1`, where `src0` is broadcast along dim 2) still used a nested loop of per-slice `cublasSgemm` calls, with a comment noting that this case would need `cublasSgemmBatched` with pointer arrays.



This PR implements that fallback. A small device kernel builds the per-GEMM A/B/C pointer arrays, handling `src0` broadcast through `(i2 / dps2)` and `(i3 / dps3)`, and the fallback issues one `cublasSgemmBatched` call instead of `ne2 * ne3` separate `cublasSgemm` calls.






## Additional information



Correctness:



* `test-backend-ops test -o OUT_PROD`: 71/71 passed (NMSE vs CPU, existing `5e-4` threshold), covering `dps2 > 1`, `dps3 > 1`, and combined `dps2 > 1 && dps3 > 1`

* `compute-sanitizer --tool memcheck`: 0 errors







Benchmarks on RTX 5090 (Blackwell, SM120), F32.



Batch scaling, `m=256, n=16, k=16`, `nr=[ne2,1]`, so `dps2 = ne2`:



| ne2 |  master | this PR | speedup |
| --: | ------: | ------: | ------: |
|   2 | 11.2 us |  3.1 us |    3.6x |
|   8 |  150 us |  3.1 us |     48x |
|  32 |  262 us |  3.3 us |     79x |
| 128 | 1042 us |  5.2 us |    200x |
| 256 | 2161 us |  7.7 us |    282x |



The win holds down to `ne2 = 2`, so no batch-count threshold is needed.



GEMM-size sweep, fixed `ne2 = 32`: the relative win shrinks as GEMMs become compute-bound, but never regresses.



| shape (m x n x k)  | master | this PR | speedup |
| ------------------ | -----: | ------: | ------: |
| 256 x 16 x 16      | 263 us |  3.3 us |     79x |
| 512 x 512 x 512    | 677 us |  106 us |    6.4x |
| 1024 x 1024 x 1024 | 877 us |  649 us |   1.35x |



Dim-3 and combined broadcast use the same path:



| case                            |    master | this PR | speedup |
| ------------------------------- | --------: | ------: | ------: |
| `ne2=1`, `dps3>1`, `nr=[1,8]`   |  148.5 us | 3.03 us |     49x |
| `ne2=1`, `dps3>1`, `nr=[1,32]`  |  283.4 us | 3.24 us |     87x |
| `ne2=1`, `dps3>1`, `nr=[1,128]` | 1180.4 us | 5.44 us |    217x |
| `dps2>1 && dps3>1`, `nr=[8,8]`  |  521.3 us | 3.53 us |    148x |




## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
