### PR TITLE
vocab : adopt leading TemplateProcessing special token as BOS

### DIFF
--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -246,6 +246,11 @@ class SpecialVocab:
                             if special_first := tmpl_single[0].get('SpecialToken', {}).get('id'):
                                 if not tokenizer_config:
                                     special_bos = special_first
+                                elif special_first not in (special_bos, special_cls):
+                                    if not special_bos:
+                                        tokenizer_config['bos_token'] = special_bos = special_first
+                                    if not special_cls:
+                                        tokenizer_config['cls_token'] = special_cls = special_first
                                 self.add_special_token['bos'] = True if special_first in (special_bos, special_cls) else False
                                 if special_first not in (special_bos, special_cls):
                                     logger.warning(f'Unknown leading special token {special_first!r} in TemplateProcessing<single>')


### PR DESCRIPTION
While testing something else, I noticed that `bert-base-uncased`, a basic model, was unexpectedly missing its `BOS`/`EOS` tokens.

**The cause:** the leading `[CLS]` in the `TemplateProcessing` template isn't named in its [`tokenizer_config.json`](https://huggingface.co/google-bert/bert-base-uncased/blob/main/tokenizer_config.json), so `add_bos` is left `false` and the `[CLS]`/`[SEP]` wrapping is dropped.

---
Tests (`bert-base-uncased`):

| Input | `transformers` | master | this PR |
|---|---|---|---|
| `hello world` | `[101, 7592, 2088, 102]` | `[7592, 2088]` | `[101, 7592, 2088, 102]` |
| `café` | `[101, 7668, 102]` | `[7668]` | `[101, 7668, 102]` |
| `Berlin` | `[101, 4068, 102]` | `[4068]` | `[101, 4068, 102]` |