### PR TITLE
server : fix SSL env vars leaking to router child processes

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -108,6 +108,29 @@ static void unset_reserved_args(common_preset & preset, bool unset_model_args) {
     }
 }
 
+static void unset_reserved_env(std::vector<std::string> & env) {
+    auto unset_env = [&env](const char * key) {
+        const std::string prefix = std::string(key) + "=";
+        env.erase(
+            std::remove_if(env.begin(), env.end(), [&prefix](const std::string & item) {
+                return item.rfind(prefix, 0) == 0;
+            }),
+            env.end());
+    };
+
+    unset_env("LLAMA_ARG_SSL_KEY_FILE");
+    unset_env("LLAMA_ARG_SSL_CERT_FILE");
+    unset_env("LLAMA_API_KEY");
+    unset_env("LLAMA_ARG_MODELS_DIR");
+    unset_env("LLAMA_ARG_MODELS_MAX");
+    unset_env("LLAMA_ARG_MODELS_PRESET");
+    unset_env("LLAMA_ARG_MODELS_AUTOLOAD");
+    unset_env("LLAMA_ARG_MODEL");
+    unset_env("LLAMA_ARG_MMPROJ");
+    unset_env("LLAMA_ARG_ALIAS");
+    unset_env("LLAMA_ARG_HF_REPO");
+}
+
 #ifdef _WIN32
 static std::string wide_to_utf8(const wchar_t * ws) {
     if (!ws || !*ws) {
@@ -778,6 +801,7 @@ void server_models::load(const std::string & name) {
 
         std::vector<std::string> child_args = inst.meta.args; // copy
         std::vector<std::string> child_env  = base_env; // copy
+        unset_reserved_env(child_env);
         child_env.push_back("LLAMA_SERVER_ROUTER_PORT=" + std::to_string(base_params.port));
 
         SRV_INF("%s", "spawning server instance with args:\n");

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -213,6 +213,71 @@ def test_router_api_key_required():
     assert "error" not in authed.body
 
 
+def test_router_ssl_env_does_not_leak_to_child(monkeypatch, tmp_path):
+    global server
+
+    key_file = tmp_path / "key.pem"
+    cert_file = tmp_path / "cert.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-keyout",
+            str(key_file),
+            "-out",
+            str(cert_file),
+            "-days",
+            "1",
+            "-subj",
+            "/CN=localhost",
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    monkeypatch.setenv("LLAMA_ARG_SSL_KEY_FILE", str(key_file))
+    monkeypatch.setenv("LLAMA_ARG_SSL_CERT_FILE", str(cert_file))
+    monkeypatch.setenv("LLAMA_ARG_MODELS_DIR", str(tmp_path))
+    monkeypatch.setenv("LLAMA_ARG_MODELS_AUTOLOAD", "enabled")
+    monkeypatch.setenv("LLAMA_ARG_MODELS_MAX", "1")
+
+    source_model = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "..",
+        "tmp",
+        "models--ggml-org--models",
+        "blobs",
+        "270cba1bd5109f42d03350f60406024560464db173c0e387d91f0426d3bd256d",
+    )
+    model_path = tmp_path / "stories260K.gguf"
+    subprocess.run(["cp", source_model, str(model_path)], check=True)
+
+    server.server_ssl = True
+    server.verify_ssl = False
+    server.models_dir = str(tmp_path)
+    server.server_port = 2224
+    server.start()
+
+    res = server.make_request(
+        "POST",
+        "/v1/chat/completions",
+        data={
+            "model": "stories260K",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 4,
+        },
+    )
+
+    assert res.status_code == 200
+    assert "error" not in res.body
+
+
 def test_router_reload_models():
     """POST /models/reload re-reads the INI preset and updates the model list."""
     global server

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -49,6 +49,7 @@ class ServerProcess:
     debug: bool = False
     server_port: int = 8080
     server_host: str = "127.0.0.1"
+    server_ssl: bool = False
     model_hf_repo: str | None = "ggml-org/models"
     model_hf_file: str | None = "tinyllamas/stories260K.gguf"
     model_alias: str = "tinyllama-2"
@@ -110,6 +111,7 @@ class ServerProcess:
     webui_mcp_proxy: bool = False
     backend_sampling: bool = False
     gcp_compat: bool = False
+    verify_ssl: bool = True
 
     # session variables
     process: subprocess.Popen | None = None
@@ -332,16 +334,17 @@ class ServerProcess:
         headers: dict | None = None,
         timeout: float | None = None,
     ) -> ServerResponse:
-        url = f"http://{self.server_host}:{self.server_port}{path}"
+        scheme = "https" if self.server_ssl else "http"
+        url = f"{scheme}://{self.server_host}:{self.server_port}{path}"
         parse_body = False
         if method == "GET":
-            response = requests.get(url, headers=headers, timeout=timeout)
+            response = requests.get(url, headers=headers, timeout=timeout, verify=self.verify_ssl)
             parse_body = True
         elif method == "POST":
-            response = requests.post(url, headers=headers, json=data, timeout=timeout)
+            response = requests.post(url, headers=headers, json=data, timeout=timeout, verify=self.verify_ssl)
             parse_body = True
         elif method == "OPTIONS":
-            response = requests.options(url, headers=headers, timeout=timeout)
+            response = requests.options(url, headers=headers, timeout=timeout, verify=self.verify_ssl)
         else:
             raise ValueError(f"Unimplemented method: {method}")
         result = ServerResponse()
@@ -364,9 +367,10 @@ class ServerProcess:
         data: dict | None = None,
         headers: dict | None = None,
     ) -> Iterator[dict]:
-        url = f"http://{self.server_host}:{self.server_port}{path}"
+        scheme = "https" if self.server_ssl else "http"
+        url = f"{scheme}://{self.server_host}:{self.server_port}{path}"
         if method == "POST":
-            response = requests.post(url, headers=headers, json=data, stream=True)
+            response = requests.post(url, headers=headers, json=data, stream=True, verify=self.verify_ssl)
         else:
             raise ValueError(f"Unimplemented method: {method}")
         if response.status_code != 200:


### PR DESCRIPTION
Fixes #24388

When running llama.cpp in router mode with SSL configured via environment variables (LLAMA_ARG_SSL_KEY_FILE, LLAMA_ARG_SSL_CERT_FILE), child server processes would incorrectly inherit these settings and start HTTPS listeners. This caused the router's HTTP client to fail with "Failed to read connection".

## Overview

Add `unset_reserved_env()` function to filter router-only environment variables before spawning child server processes. Child instances should inherit the base environment but must never inherit SSL configuration intended for the parent router.

Additionally enhance the test harness to support HTTPS testing and add a focused regression test that reproduces the exact failure scenario.

## Changes

- `tools/server/server-models.cpp`: Add `unset_reserved_env()` to remove SSL and router-specific env vars before child spawn
- `tools/server/tests/utils.py`: Add `server_ssl` and `verify_ssl` flags to ServerProcess; update HTTP methods to support HTTPS
- `tools/server/tests/unit/test_router.py`: Add `test_router_ssl_env_does_not_leak_to_child()` regression test

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)