### PR TITLE
server : add --models-preset-only to restrict router to preset models

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3145,6 +3145,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_AUTOLOAD"));
     add_opt(common_arg(
+        {"--models-preset-only"},
+        {"--no-models-preset-only"},
+        string_format("for router server, serve only models from --models-preset, ignoring cached and --models-dir models (default: %s)", params.models_preset_only ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.models_preset_only = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_PRESET_ONLY"));
+    add_opt(common_arg(
         {"--jinja"},
         {"--no-jinja"},
         string_format("whether to use jinja template engine for chat (default: %s)", params.use_jinja ? "enabled" : "disabled"),

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3601,6 +3601,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_AUTOLOAD"));
     add_opt(common_arg(
+        {"--models-preset-only"},
+        {"--no-models-preset-only"},
+        string_format("for router server, serve only models from --models-preset, ignoring cached and --models-dir models (default: %s)", params.models_preset_only ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.models_preset_only = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MODELS_PRESET_ONLY"));
+    add_opt(common_arg(
         {"--jinja"},
         {"--no-jinja"},
         string_format("whether to use jinja template engine for chat (default: %s)", params.use_jinja ? "enabled" : "disabled"),

--- a/common/common.h
+++ b/common/common.h
@@ -645,6 +645,7 @@ struct common_params {
     std::string models_preset = ""; // directory containing model presets for the router server
     int models_max = 4;             // maximum number of models to load simultaneously
     bool models_autoload = true;    // automatically load models when requested via the router server
+    bool models_preset_only = false; // serve only --models-preset entries (skip cache and --models-dir)
 
     bool log_json = false;
 

--- a/common/common.h
+++ b/common/common.h
@@ -668,6 +668,7 @@ struct common_params {
     int models_max = 4;                 // maximum number of models to load simultaneously
     bool models_autoload = true;        // automatically load models when requested via the router server
     std::string models_preset_hf = "";  // show a warning about remote presets on router loaded (if not empty)
+    bool models_preset_only = false;    // serve only --models-preset entries (skip cache and --models-dir)
 
     bool log_json = false;
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -219,6 +219,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--models-preset PATH` | path to INI file containing model presets for the router server (default: disabled)<br/>(env: LLAMA_ARG_MODELS_PRESET) |
 | `--models-max N` | for router server, maximum number of models to load simultaneously (default: 4, 0 = unlimited)<br/>(env: LLAMA_ARG_MODELS_MAX) |
 | `--models-autoload, --no-models-autoload` | for router server, whether to automatically load models (default: enabled)<br/>(env: LLAMA_ARG_MODELS_AUTOLOAD) |
+| `--models-preset-only, --no-models-preset-only` | for router server, serve only models from `--models-preset`, ignoring cached and `--models-dir` models (default: disabled)<br/>(env: LLAMA_ARG_MODELS_PRESET_ONLY) |
 | `--jinja, --no-jinja` | whether to use jinja template engine for chat (default: enabled)<br/>(env: LLAMA_ARG_JINJA) |
 | `--reasoning-format FORMAT` | controls whether thought tags are allowed and/or extracted from the response, and in which format they're returned; one of:<br/>- none: leaves thoughts unparsed in `message.content`<br/>- deepseek: puts thoughts in `message.reasoning_content`<br/>- deepseek-legacy: keeps `<think>` tags in `message.content` while also populating `message.reasoning_content`<br/>(default: auto)<br/>(env: LLAMA_ARG_THINK) |
 | `-rea, --reasoning [on\|off\|auto]` | Use reasoning/thinking in the chat ('on', 'off', or 'auto', default: 'auto' (detect from template))<br/>(env: LLAMA_ARG_REASONING) |
@@ -1576,6 +1577,8 @@ There are 3 possible sources for model files:
 1. Cached models (controlled by the `LLAMA_CACHE` environment variable)
 2. Custom model directory (set via the `--models-dir` argument)
 3. Custom preset (set via the `--models-preset` argument)
+
+To serve only the models declared in `--models-preset` and ignore sources 1 and 2, pass `--models-preset-only`. This is useful when the cache contains many models that should not be exposed by the router.
 
 By default, the router looks for models in the cache. You can add Hugging Face models to the cache with:
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -223,6 +223,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--models-preset PATH` | path to INI file containing model presets for the router server (default: disabled)<br/>(env: LLAMA_ARG_MODELS_PRESET) |
 | `--models-max N` | for router server, maximum number of models to load simultaneously (default: 4, 0 = unlimited)<br/>(env: LLAMA_ARG_MODELS_MAX) |
 | `--models-autoload, --no-models-autoload` | for router server, whether to automatically load models (default: enabled)<br/>(env: LLAMA_ARG_MODELS_AUTOLOAD) |
+| `--models-preset-only, --no-models-preset-only` | for router server, serve only models from `--models-preset`, ignoring cached and `--models-dir` models (default: disabled)<br/>(env: LLAMA_ARG_MODELS_PRESET_ONLY) |
 | `--jinja, --no-jinja` | whether to use jinja template engine for chat (default: enabled)<br/>(env: LLAMA_ARG_JINJA) |
 | `--reasoning-format FORMAT` | controls whether thought tags are allowed and/or extracted from the response, and in which format they're returned; one of:<br/>- none: leaves thoughts unparsed in `message.content`<br/>- deepseek: puts thoughts in `message.reasoning_content`<br/>- deepseek-legacy: keeps `<think>` tags in `message.content` while also populating `message.reasoning_content`<br/>(default: auto)<br/>(env: LLAMA_ARG_THINK) |
 | `-rea, --reasoning [on\|off\|auto]` | Use reasoning/thinking in the chat ('on', 'off', or 'auto', default: 'auto' (detect from template))<br/>(env: LLAMA_ARG_REASONING) |
@@ -1595,6 +1596,8 @@ There are 3 possible sources for model files:
 1. Cached models (controlled by the `LLAMA_CACHE` environment variable)
 2. Custom model directory (set via the `--models-dir` argument)
 3. Custom preset (set via the `--models-preset` argument)
+
+To serve only the models declared in `--models-preset` and ignore sources 1 and 2, pass `--models-preset-only`. This is useful when the cache contains many models that should not be exposed by the router.
 
 By default, the router looks for models in the cache. You can add Hugging Face models to the cache with:
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -100,6 +100,7 @@ static void unset_reserved_args(common_preset & preset, bool unset_model_args) {
     preset.unset_option("LLAMA_ARG_MODELS_MAX");
     preset.unset_option("LLAMA_ARG_MODELS_PRESET");
     preset.unset_option("LLAMA_ARG_MODELS_AUTOLOAD");
+    preset.unset_option("LLAMA_ARG_MODELS_PRESET_ONLY");
     if (unset_model_args) {
         preset.unset_option("LLAMA_ARG_MODEL");
         preset.unset_option("LLAMA_ARG_MMPROJ");
@@ -280,12 +281,23 @@ void server_models::add_model(server_model_meta && meta) {
 
 void server_models::load_models() {
     // Phase 1: load presets from all sources — pure I/O, no lock needed
+    // When --models-preset-only is set, the cache and --models-dir sources are
+    // skipped so the router serves only the models declared in --models-preset.
+    const bool preset_only = base_params.models_preset_only;
+    if (preset_only && base_params.models_preset.empty()) {
+        SRV_WRN("%s", "--models-preset-only is set but --models-preset is empty; no models will be available\n");
+    }
     // 1. cached models
-    common_presets cached_models = ctx_preset.load_from_cache();
-    SRV_INF("Loaded %zu cached model presets\n", cached_models.size());
+    common_presets cached_models;
+    if (preset_only) {
+        SRV_INF("%s", "Skipping cached model presets (--models-preset-only)\n");
+    } else {
+        cached_models = ctx_preset.load_from_cache();
+        SRV_INF("Loaded %zu cached model presets\n", cached_models.size());
+    }
     // 2. local models from --models-dir
     common_presets local_models;
-    if (!base_params.models_dir.empty()) {
+    if (!preset_only && !base_params.models_dir.empty()) {
         local_models = ctx_preset.load_from_models_dir(base_params.models_dir);
         SRV_INF("Loaded %zu local model presets from %s\n", local_models.size(), base_params.models_dir.c_str());
     }

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -305,6 +305,7 @@ static void unset_reserved_args(common_preset & preset, bool unset_model_args) {
     preset.unset_option("LLAMA_ARG_MODELS_MAX");
     preset.unset_option("LLAMA_ARG_MODELS_PRESET");
     preset.unset_option("LLAMA_ARG_MODELS_AUTOLOAD");
+    preset.unset_option("LLAMA_ARG_MODELS_PRESET_ONLY");
     if (unset_model_args) {
         preset.unset_option("LLAMA_ARG_MODEL");
         preset.unset_option("LLAMA_ARG_MMPROJ");
@@ -503,12 +504,23 @@ void server_models::notify_sse(const std::string & event, const std::string & mo
 
 void server_models::load_models() {
     // Phase 1: load presets from all sources - pure I/O, no lock needed
+    // When --models-preset-only is set, the cache and --models-dir sources are
+    // skipped so the router serves only the models declared in --models-preset.
+    const bool preset_only = base_params.models_preset_only;
+    if (preset_only && base_params.models_preset.empty()) {
+        SRV_WRN("%s", "--models-preset-only is set but --models-preset is empty; no models will be available\n");
+    }
     // 1. cached models
-    common_presets cached_models = ctx_preset.load_from_cache();
-    SRV_INF("Loaded %zu cached model presets\n", cached_models.size());
+    common_presets cached_models;
+    if (preset_only) {
+        SRV_INF("%s", "Skipping cached model presets (--models-preset-only)\n");
+    } else {
+        cached_models = ctx_preset.load_from_cache();
+        SRV_INF("Loaded %zu cached model presets\n", cached_models.size());
+    }
     // 2. local models from --models-dir
     common_presets local_models;
-    if (!base_params.models_dir.empty()) {
+    if (!preset_only && !base_params.models_dir.empty()) {
         local_models = ctx_preset.load_from_models_dir(base_params.models_dir);
         SRV_INF("Loaded %zu local model presets from %s\n", local_models.size(), base_params.models_dir.c_str());
     }

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -253,3 +253,32 @@ def test_router_reload_models():
         assert "model-reload-c" in ids, "newly added model should appear"
     finally:
         os.remove(preset_path)
+
+
+def test_router_models_preset_only():
+    """--models-preset-only restricts the router to --models-preset entries,
+    excluding cached models (and --models-dir)."""
+    global server
+
+    preset_path = os.path.join(TMP_DIR, "test_preset_only.ini")
+    with open(preset_path, "w") as f:
+        f.write(
+            "[preset-only-model]\n"
+            "hf-repo = ggml-org/test-model-stories260K\n"
+        )
+
+    server.models_preset = preset_path
+    server.models_preset_only = True
+    server.start()
+
+    try:
+        ids = _get_model_ids(is_reload=False)
+        # Only the preset-declared model is exposed.
+        assert ids == {"preset-only-model"}
+        # Models cached by load_all() (e.g. tinygemma3) are excluded; cached
+        # entries are listed under their "<org>/<repo>:<tag>" id, none of which
+        # should be present.
+        assert "ggml-org/tinygemma3-GGUF:Q8_0" not in ids
+        assert not any("/" in model_id for model_id in ids)
+    finally:
+        os.remove(preset_path)

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -539,3 +539,32 @@ def test_router_delete_model():
     # Model should no longer appear in GET /models
     ids = _get_model_ids(is_reload=False)
     assert MODEL_DOWNLOAD_ID not in ids, f"{MODEL_DOWNLOAD_ID} still present after deletion"
+
+
+def test_router_models_preset_only():
+    """--models-preset-only restricts the router to --models-preset entries,
+    excluding cached models (and --models-dir)."""
+    global server
+
+    preset_path = os.path.join(TMP_DIR, "test_preset_only.ini")
+    with open(preset_path, "w") as f:
+        f.write(
+            "[preset-only-model]\n"
+            "hf-repo = ggml-org/test-model-stories260K\n"
+        )
+
+    server.models_preset = preset_path
+    server.models_preset_only = True
+    server.start()
+
+    try:
+        ids = _get_model_ids(is_reload=False)
+        # Only the preset-declared model is exposed.
+        assert ids == {"preset-only-model"}
+        # Models cached by load_all() (e.g. tinygemma3) are excluded; cached
+        # entries are listed under their "<org>/<repo>:<tag>" id, none of which
+        # should be present.
+        assert "ggml-org/tinygemma3-GGUF:Q8_0" not in ids
+        assert not any("/" in model_id for model_id in ids)
+    finally:
+        os.remove(preset_path)

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -90,6 +90,7 @@ class ServerProcess:
     models_max: int | None = None
     models_preset: str | None = None
     no_models_autoload: bool | None = None
+    models_preset_only: bool | None = None
     lora_files: List[str] | None = None
     enable_ctx_shift: int | None = False
     spec_draft_n_min: int | None = None
@@ -229,6 +230,8 @@ class ServerProcess:
             server_args.append("--no-webui")
         if self.no_models_autoload:
             server_args.append("--no-models-autoload")
+        if self.models_preset_only:
+            server_args.append("--models-preset-only")
         if self.jinja:
             server_args.append("--jinja")
         else:

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -94,6 +94,7 @@ class ServerProcess:
     models_max: int | None = None
     models_preset: str | None = None
     no_models_autoload: bool | None = None
+    models_preset_only: bool | None = None
     lora_files: List[str] | None = None
     enable_ctx_shift: int | None = False
     spec_type: str | None = None
@@ -249,6 +250,8 @@ class ServerProcess:
             server_args.append("--no-ui")
         if self.no_models_autoload:
             server_args.append("--no-models-autoload")
+        if self.models_preset_only:
+            server_args.append("--models-preset-only")
         if self.jinja:
             server_args.append("--jinja")
         else:


### PR DESCRIPTION
## Overview

In router mode the available-model list is built from three sources: the HF cache, --models-dir, and --models-preset. There is no way to restrict it to just the presets, so every cached/downloaded GGUF is exposed and loadable through the router, including models that aren't meant to be served there.

Presets are configured with specific configurations to best work with the machine.  I've curated and generated a preset list specifically to control and maximize how much context is given to each model.  Without this change, the model list is polluted with models and default configurations I don't want used, exploding the model selector drop down in the UI and making it much less usable.

Add --models-preset-only (env LLAMA_ARG_MODELS_PRESET_ONLY, default off): when set, load_models() skips the cache and --models-dir sources, leaving only the models declared in --models-preset. Warn if the flag is set with no --models-preset. Also strip the flag from spawned child presets.

Implements the request in #18609.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used to analyze and generate the initial code, I reviewed and made edits, this is a narrowly targeted change that doesn't have a lot of surface for variations so edits were minimal.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
