### PR TITLE
vulkan: link ggml-cpu when GGML_VULKAN_CHECK_RESULTS / RUN_TESTS are enabled

### DIFF
--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -108,6 +108,9 @@ if (Vulkan_FOUND)
 
     if (GGML_VULKAN_CHECK_RESULTS)
         add_compile_definitions(GGML_VULKAN_CHECK_RESULTS)
+        # the result-checking path computes a CPU reference graph via
+        # ggml_graph_compute_with_ctx(), which is defined in ggml-cpu
+        target_link_libraries(ggml-vulkan PRIVATE ggml-cpu)
     endif()
 
     if (GGML_VULKAN_DEBUG)
@@ -129,6 +132,8 @@ if (Vulkan_FOUND)
 
     if (GGML_VULKAN_RUN_TESTS)
         add_compile_definitions(GGML_VULKAN_RUN_TESTS)
+        # the test path also calls ggml_graph_compute_with_ctx() (ggml-cpu)
+        target_link_libraries(ggml-vulkan PRIVATE ggml-cpu)
     endif()
 
     # Set up toolchain for host compilation whether cross-compiling or not


### PR DESCRIPTION
-DGGML_VULKAN_CHECK_RESULTS=ON and -DGGML_VULKAN_RUN_TESTS=ON failed to link for some reason, and I noticed the debug code in ggml-vulkan.cpp calls ggml_graph_compute_with_ctx from ggml-cpu, but ggml-vulkan only links ggml-base and Vulkan. CI misses it because neither flag is built there i think..? 

Fix: link ggml-cpu under those two options

Tested on Windows/MSVC: fails to link before, builds fine after.

Used Claude to help with the initial writeup, my apologies, and in the future, I will make note to not do that. I appreciate the time anyone spends looking at this. (The fix and testing are mine, not ai slop lol). Again, I SINCERELY apologize for using ai to write it up, and in the future, it will be in my own words.