### PR TITLE
gguf: reject empty KV keys with a clear error

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -557,6 +557,10 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
                 GGML_LOG_ERROR("%s: encountered bad_alloc error while reading key %" PRIi64 "\n", __func__, i);
                 ok = false;
             }
+            if (ok && key.empty()) {
+                GGML_LOG_ERROR("%s: empty key for KV pair at index %" PRIi64 "\n", __func__, i);
+                ok = false;
+            }
             for (size_t j = 0; ok && j < ctx->kv.size(); ++j) {
                 if (key == ctx->kv[j].key) {
                     GGML_LOG_ERROR("%s: duplicate key '%s' for tensors %zu and %" PRIi64 " \n", __func__, key.c_str(), j, i);

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -29,6 +29,7 @@ enum handcrafted_file_type {
     HANDCRAFTED_KV_BAD_TYPE                =  20 + offset_has_kv,
     // HANDCRAFTED_KV_BAD_VALUE_SIZE          =  30 + offset_has_kv, // removed because it can result in allocations > 1 TB (default sanitizer limit)
     HANDCRAFTED_KV_DUPLICATE_KEY           =  40 + offset_has_kv,
+    HANDCRAFTED_KV_BAD_KEY_SIZE_ZERO       =  60 + offset_has_kv,
     HANDCRAFTED_KV_BAD_ALIGN               =  50 + offset_has_kv,
     HANDCRAFTED_KV_SUCCESS                 = 800 + offset_has_kv,
 
@@ -66,6 +67,7 @@ static std::string handcrafted_file_type_name(const enum handcrafted_file_type h
         case HANDCRAFTED_KV_BAD_KEY_SIZE:            return "KV_BAD_KEY_SIZE";
         case HANDCRAFTED_KV_BAD_TYPE:                return "KV_BAD_TYPE";
         case HANDCRAFTED_KV_DUPLICATE_KEY:           return "KV_DUPLICATE_KEY";
+        case HANDCRAFTED_KV_BAD_KEY_SIZE_ZERO:       return "KV_BAD_KEY_SIZE_ZERO";
         case HANDCRAFTED_KV_BAD_ALIGN:               return "KV_BAD_ALIGN";
         case HANDCRAFTED_KV_SUCCESS:                 return "KV_RANDOM_KV";
 
@@ -257,6 +259,7 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
         uint64_t n_kv = kv_types.size();
         if (hft == HANDCRAFTED_KV_BAD_ALIGN      ||
             hft == HANDCRAFTED_TENSORS_BAD_ALIGN || hft == HANDCRAFTED_TENSORS_CUSTOM_ALIGN ||
+            hft == HANDCRAFTED_KV_BAD_KEY_SIZE_ZERO ||
             hft == HANDCRAFTED_DATA_BAD_ALIGN    || hft == HANDCRAFTED_DATA_CUSTOM_ALIGN) {
 
             n_kv += 1;
@@ -289,6 +292,10 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
         if (hft == HANDCRAFTED_KV_BAD_KEY_SIZE) {
             const uint64_t n = -1;
             helper_write(file, n);
+        } else if (hft == HANDCRAFTED_KV_BAD_KEY_SIZE_ZERO) {
+            const uint64_t n = 0;
+            helper_write(file, n);
+            // no key bytes follow because length is 0
         } else {
             const uint64_t n = key.length();
             helper_write(file, n);
@@ -734,6 +741,7 @@ static std::pair<int, int> test_handcrafted_file(const unsigned int seed) {
         HANDCRAFTED_KV_BAD_KEY_SIZE,
         HANDCRAFTED_KV_BAD_TYPE,
         HANDCRAFTED_KV_DUPLICATE_KEY,
+        HANDCRAFTED_KV_BAD_KEY_SIZE_ZERO,
         HANDCRAFTED_KV_BAD_ALIGN,
         HANDCRAFTED_KV_SUCCESS,
 


### PR DESCRIPTION
gguf: reject empty KV keys with a clear error

While fuzzing the GGUF parser I found that a file with a zero-length
key in its KV section causes `gguf_init_from_reader()` to abort the
process via `GGML_ASSERT(!key.empty())`. The assertion lives in the
`gguf_kv` constructor and is reached through all 12 type-dispatch
paths in `gguf_init_from_reader()`.

Repro (45-byte file, all 12 value types trigger):

```bash
$ python3 poc_empty_key.py poc.gguf
$ llama-cli -m poc.gguf
Aborted (core dumped)            # pre-fix
```

The fix is one extra check after `gr.read(key)` in
`ggml/src/gguf.cpp`. Same loop, same `ok` flag, same `gguf_free(ctx)`
cleanup path that the other errors in this function use. So malformed
files are reported via `GGML_LOG_ERROR` and `gguf_init_from_file()`
returns `nullptr` instead of crashing.

Tested:
- `poc.gguf` from `poc_empty_key.py` now prints a clean error and
  returns nullptr (no SIGABRT)
- a normal GGUF still loads fine
- the other error branches in this function are untouched

A new test case `HANDCRAFTED_KV_BAD_KEY_SIZE_ZERO` joins the existing
`BAD_KEY_SIZE` (length = -1) in `tests/test-gguf.cpp`. It exercises
the same path through `get_handcrafted_file` -> `gguf_init_from_file_ptr`
-> `expect_context_not_null` and asserts the loader returns `nullptr`.

Files changed:
- `ggml/src/gguf.cpp`     -- 3 lines, empty-key check in the KV loop
- `tests/test-gguf.cpp`   -- enum, name, generator, hft list
- `poc_empty_key.py`      -- standalone reproducer (no deps)

This is covered by `ggml/**` in SECURITY.md.
