### PR TITLE
docs : fix typos in CUDA-FEDORA.md and grammars/README.md

### DIFF
--- a/docs/backend/CUDA-FEDORA.md
+++ b/docs/backend/CUDA-FEDORA.md
@@ -270,7 +270,7 @@ You have successfully set up CUDA on Fedora within a toolbox environment using t
 
 ---
 
-**Disclaimer:** Manually installing and modifying system packages can lead to instability of the container. The above steps are provided as a guideline and may need adjustments based on your specific system configuration. Always back up important data before making significant system changes, especially as your home folder is writable and shared with he toolbox.
+**Disclaimer:** Manually installing and modifying system packages can lead to instability of the container. The above steps are provided as a guideline and may need adjustments based on your specific system configuration. Always back up important data before making significant system changes, especially as your home folder is writable and shared with the toolbox.
 
 **Acknowledgments:** Special thanks to the Fedora community and NVIDIA documentation for providing resources that assisted in creating this guide.
 

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -233,7 +233,7 @@ And a non-exhaustive list of other unsupported features that are unlikely to be 
 > [!WARNING]
 > The JSON schemas spec states `object`s accept [additional properties](https://json-schema.org/understanding-json-schema/reference/object#additionalproperties) by default.
 > Since this is slow and seems prone to hallucinations, we default to no additional properties.
-> You can set `"additionalProperties": true` in the the schema of any object to explicitly allow additional properties.
+> You can set `"additionalProperties": true` in the schema of any object to explicitly allow additional properties.
 
 If you're using [Pydantic](https://pydantic.dev/) to generate schemas, you can enable additional properties with the `extra` config on each model class:
 


### PR DESCRIPTION
Fix two documentation typos:
     - docs/backend/CUDA-FEDORA.md line 273: "shared with he toolbox" → "shared with the toolbox"
     - grammars/README.md line 236: "in the the schema" → "in the schema"