### PR TITLE
server : fix router server ignoring parallel setting from --models-preset INI

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -104,10 +104,27 @@ int llama_server(int argc, char ** argv) {
     }
 
     if (params.n_parallel < 0) {
-        SRV_INF("%s", "n_parallel is set to auto, using n_parallel = 4 and kv_unified = true\n");
-
-        params.n_parallel = 4;
-        params.kv_unified = true;
+        if (is_router_server && !params.models_preset.empty()) {
+            // check [*] global section of the models preset for an explicit n_parallel value
+            try {
+                common_preset_context tmp_ctx(LLAMA_EXAMPLE_SERVER);
+                common_preset global;
+                tmp_ctx.load_from_ini(params.models_preset, global);
+                std::string val;
+                if (global.get_option("LLAMA_ARG_N_PARALLEL", val)) {
+                    params.n_parallel = std::stoi(val);
+                }
+            } catch (const std::exception &) {}
+        }
+        if (params.n_parallel < 0) {
+            if (!is_router_server) {
+                SRV_INF("%s", "n_parallel is set to auto, using n_parallel = 4 and kv_unified = true\n");
+                params.n_parallel = 4;
+                params.kv_unified = true;
+            } else {
+                params.n_parallel = 1;
+            }
+        }
     }
 
     // for consistency between server router mode and single-model mode, we set the same model name as alias


### PR DESCRIPTION
Fixes #23135

## Summary

When running `llama-server` in router mode (without `--model`), the router process always initialized with `n_parallel = 4`, even when `parallel = N` was specified in the `[*]` global section of a `--models-preset` INI file.

The issue occurred because the `n_parallel < 0` auto-resolution logic executed unconditionally and did not check whether a preset had already provided an explicit value.

Child model processes were unaffected and correctly inherited `parallel` from the preset. However, the router process logged `n_parallel = 4`, making it appear that the configuration was being ignored.

## Changes

* Read `LLAMA_ARG_N_PARALLEL` from the `[*]` global preset section before applying automatic defaults.
* Respect the preset value when explicitly provided.
* Preserve existing behavior for model-server mode.
* Use `n_parallel = 1` as the router-mode default when no explicit value is configured.

### Result

Router mode:

* Uses the preset value when `parallel` is specified.
* Falls back to `n_parallel = 1` when no value is provided.

Model-server mode:

* Unchanged.
* Continues to default to `n_parallel = 4` and `kv_unified = true`.

## Testing

`preset.ini`

```ini
[*]
parallel = 1

[my-model]
model = /path/to/model.gguf
load-on-startup = true
```

Run:

```bash
llama-server --models-preset preset.ini --models-max 1 --port 8080
```

Before:

* Router logs `n_parallel = 4`.

After:

* Router correctly uses `n_parallel = 1` from the preset.
