### PR TITLE
ggml: ignore null devices in backend registry

### DIFF
--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -198,6 +198,10 @@ struct ggml_backend_registry {
     }
 
     void register_device(ggml_backend_dev_t device) {
+        if (!device) {
+            return;
+        }
+
         for (auto & dev : devices) {
             if (dev == device) {
                 return;
@@ -274,7 +278,7 @@ struct ggml_backend_registry {
         // remove devices
         devices.erase(
             std::remove_if(devices.begin(), devices.end(),
-                            [reg](ggml_backend_dev_t dev) { return ggml_backend_dev_backend_reg(dev) == reg; }),
+                            [reg](ggml_backend_dev_t dev) { return dev != nullptr && ggml_backend_dev_backend_reg(dev) == reg; }),
             devices.end());
 
         // remove backend
@@ -338,6 +342,9 @@ ggml_backend_dev_t ggml_backend_dev_get(size_t index) {
 ggml_backend_dev_t ggml_backend_dev_by_name(const char * name) {
     for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
         ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (!dev) {
+            continue;
+        }
         if (striequals(ggml_backend_dev_name(dev), name)) {
             return dev;
         }
@@ -348,6 +355,9 @@ ggml_backend_dev_t ggml_backend_dev_by_name(const char * name) {
 ggml_backend_dev_t ggml_backend_dev_by_type(enum ggml_backend_dev_type type) {
     for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
         ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (!dev) {
+            continue;
+        }
         if (ggml_backend_dev_type(dev) == type) {
             return dev;
         }

--- a/ggml/src/ggml-backend-reg.cpp
+++ b/ggml/src/ggml-backend-reg.cpp
@@ -278,7 +278,7 @@ struct ggml_backend_registry {
         // remove devices
         devices.erase(
             std::remove_if(devices.begin(), devices.end(),
-                            [reg](ggml_backend_dev_t dev) { return dev != nullptr && ggml_backend_dev_backend_reg(dev) == reg; }),
+                            [reg](ggml_backend_dev_t dev) { return ggml_backend_dev_backend_reg(dev) == reg; }),
             devices.end());
 
         // remove backend
@@ -342,9 +342,6 @@ ggml_backend_dev_t ggml_backend_dev_get(size_t index) {
 ggml_backend_dev_t ggml_backend_dev_by_name(const char * name) {
     for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
         ggml_backend_dev_t dev = ggml_backend_dev_get(i);
-        if (!dev) {
-            continue;
-        }
         if (striequals(ggml_backend_dev_name(dev), name)) {
             return dev;
         }
@@ -355,9 +352,6 @@ ggml_backend_dev_t ggml_backend_dev_by_name(const char * name) {
 ggml_backend_dev_t ggml_backend_dev_by_type(enum ggml_backend_dev_type type) {
     for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
         ggml_backend_dev_t dev = ggml_backend_dev_get(i);
-        if (!dev) {
-            continue;
-        }
         if (ggml_backend_dev_type(dev) == type) {
             return dev;
         }


### PR DESCRIPTION
Fix a crash path where a backend registration can return a null device.

If a backend partially fails during initialization, the common registry could
store a null device and later crash during device lookup when it assumes every
entry is valid.

This change:
- ignores null devices at registry insertion time
- skips any unexpected null entries during device lookup and unload cleanup
- preserves correct device counting, since a null entry would otherwise increase
  ggml_backend_dev_count() by one and break fallback paths

That keeps optional backend failures from poisoning the shared device list and
breaking CPU/GPU fallback.