### PR TITLE
fix(hexagon): use padded stride for ssm-conv weights

### DIFF
--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -183,24 +183,25 @@ static inline void hvx_transpose_32x32_f32(HVX_Vector m[32]) {
 // transposed into VTCM.
 //
 // VTCM layouts (per thread):
-//   src1_T : {d_inner_per_thread, d_conv}   — staged once per launch (small).
-//   src0_T : {d_inner_tile,     ncs}        — staged per d_inner-tile.
+//   src1_T : {d_inner_stride, d_conv}       - staged once per launch (small).
+//   src0_T : {d_inner_tile,     ncs}        - staged per d_inner-tile.
 //
 // d_inner_tile is chosen so that per-thread VTCM stays under the budget.
 // Each thread iterates ceil(d_inner_per_thread d_inner_tile) tiles serially.
 #define HTP_SSM_CONV_VTCM_BUDGET (1u << 20) // 1 MiB per thread
 
-// Scalar transpose: src1 {d_conv, d_inner} (DDR) -> {d_inner_per_thread, d_conv} (VTCM)
+// Scalar transpose: src1 {d_conv, d_inner} (DDR) -> {d_inner_stride, d_conv} (VTCM)
 static inline void transpose_src1(const float * src1_data,
                                   uint32_t      src1_stride_inner,
                                   uint32_t      i1_off,
                                   uint32_t      d_inner_per_thread,
+                                  uint32_t      d_inner_stride,
                                   uint32_t      d_conv,
                                   float *       src1_T) {
     for (uint32_t i = 0; i < d_inner_per_thread; ++i) {
         const float * src_row = src1_data + (i1_off + i) * src1_stride_inner;
         for (uint32_t j = 0; j < d_conv; ++j) {
-            src1_T[j * d_inner_per_thread + i] = src_row[j];
+            src1_T[j * d_inner_stride + i] = src_row[j];
         }
     }
 }
@@ -280,6 +281,7 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
     }
 
     const uint32_t d_inner_per_thread = ir1 - ir0;
+    const uint32_t d_inner_stride     = scctx->nrows_per_thread;
     const uint32_t d_inner_tile       = scctx->d_inner_tile;
 
     const float * src0_data = (const float *) src0->data;
@@ -290,8 +292,8 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
     float * src0_T = (float *)(octx->src0_spad.data + ith * octx->src0_spad.size_per_thread);
     float * src1_T = (float *)(octx->src1_spad.data + ith * octx->src1_spad.size_per_thread);
 
-    // Stage src1 weights once into VTCM in {d_inner_per_thread, d_conv} layout.
-    transpose_src1(src1_data, src1_stride_inner, ir0, d_inner_per_thread, d_conv, src1_T);
+    // Stage src1 weights once into VTCM in {d_inner_stride, d_conv} layout.
+    transpose_src1(src1_data, src1_stride_inner, ir0, d_inner_per_thread, d_inner_stride, d_conv, src1_T);
 
     const uint32_t C_TILE = VLEN_FP32;
 
@@ -314,7 +316,7 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
                     HVX_Vector acc = hvx_vec_splat_f32(0.0f);
                     for (uint32_t j = 0; j < d_conv; ++j) {
                         HVX_Vector x = *(const HVX_Vector *) (src0_T + (t + j) * d_inner_tile + cb);
-                        HVX_Vector w = *(const HVX_Vector *) (src1_T + j * d_inner_per_thread + tile_off + cb);
+                        HVX_Vector w = *(const HVX_Vector *) (src1_T + j * d_inner_stride + tile_off + cb);
                         acc          = Q6_Vqf32_vadd_Vqf32Vqf32(acc, Q6_Vqf32_vmpy_VsfVsf(x, w));
                     }
                     HVX_Vector res = Q6_Vsf_equals_Vqf32(acc);
@@ -362,8 +364,7 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
             use_hvx = 1;
         }
 
-        scctx.nrows_per_thread  = (d_inner + n_threads - 1) / n_threads;
-        scctx.nrows_per_thread += (scctx.nrows_per_thread & 1);
+        scctx.nrows_per_thread = hex_round_up((d_inner + n_threads - 1) / n_threads, VLEN_FP32);
 
         const uint32_t d_inner_per_thread = scctx.nrows_per_thread;
         const uint32_t ncs                = src0->ne[0];


### PR DESCRIPTION
## Overview

Qwen3.5-0.8B Q4_0 and Qwen3.5-2B Q4_0 already produced coherent output on HTP0, but Qwen3.5-4B Q4_0 could degrade into corrupted text on the same backend even though it uses the same model family structure. That made the issue look shape- or partition-dependent rather than a general Qwen3.5 HTP failure.

The difference comes from how the SSM_CONV HVX path partitions `d_inner` across threads. For 0.8B and 2B with the tested thread configuration, the per-thread row partitions were aligned to the HVX vector width, so the existing staged weight layout happened to be safe. For 4B, the partition was not always `VLEN_FP32` aligned, which exposed a stride mismatch in `src1_T`: the buffer was sized with the padded per-thread row count, but `transpose_src1` and the HVX weight loads used the unpadded row count as the stride.

This change makes the padded stride explicit for `src1_T` and aligns the per-thread row count to `VLEN_FP32`, so the staged VTCM weight layout matches the HVX vector access pattern.

## Additional information

- Base commit: 18ef86ecec723361362a332a79b4d913fd724d40
- Fix commit: 0d0ff6e710757b1fc33d66673d9f5d48fac9673e
- Container image: ghcr.io/snapdragon-toolchain/arm64-android:v0.7
- Tested on SM8750 / Hexagon v79

The smoke prompt asked the model to start with `CATALOG_AAR_OK` and write a concise engineering note about Android on-device LLM inference with a Maven AAR, local model catalog, verified downloads, and deterministic benchmarking.

| Model | Quant | Setting | Output excerpt |
|---|---|---|---|
| Qwen3.5-4B | Q4_0 | before fix, default HTP path | `in,le era,,, or,(),,ly,,0/ ... ger,ger,,%ase,/0.IIkest: j ver,%8 and,D 4 student,un,` |
| Qwen3.5-4B | Q4_0 | after fix, default HTP path | `<think> Thinking Process: 1. **Analyze the Request:** * **Constraint:** Start the answer with CATALOG_AAR_OK. * **Content:** Write a concise engineering note about Android on-device LLM inference.` |

- Run Command Reference

```sh
export LD_LIBRARY_PATH=$PWD/lib
export ADSP_LIBRARY_PATH=$PWD/lib

./bin/llama-bench \
  -m /data/local/tmp/Qwen3.5-4B-Q4_0.app.gguf \
  -dev HTP0 -ngl 99 -fa on \
  -p 1024 -n 128 -r 1 -b 1024 -ub 1024 \
  --poll 1000 -t 6 -C 0xfc --cpu-strict 1 \
  -o jsonl -oe jsonl
```

The completion smoke used the same runtime environment, model, device, offload, batch, thread, and CPU affinity settings, with deterministic sampling (`temperature = 0`, `top_k = 1`, `top_p = 1`, `seed = 42`).

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
- AI is only used for investigation assistance. Manual review is fully performed.