### PR TITLE
Fix Gemma 4 MTP on llama-server (Windows)

### DIFF
--- a/src/models/gemma4-assistant.cpp
+++ b/src/models/gemma4-assistant.cpp
@@ -189,6 +189,7 @@ llama_model_gemma4_assistant::graph::graph(const llama_model & model, const llm_
 
     cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
     cb(cur, "result_norm", -1);
+    res->t_embd = cur;
 
     ggml_tensor * logits = build_lora_mm(model.output, cur);
     cb(logits, "result_output", -1);


### PR DESCRIPTION
## Overview

Minimally fix Gemma 4 MTP models broken on llama-server.exe (Windows)

Fix: https://github.com/ggml-org/llama.cpp/issues/24443

## Additional information

Tested on
- Windows 11
- [unsloth/gemma-4-31B-it-qat-GGUF](https://huggingface.co/unsloth/gemma-4-31B-it-qat-GGUF)
- local build ([unsloth.ai/docs/models/gemma-4/qat#llama.cpp-guide](https://unsloth.ai/docs/models/gemma-4/qat#llama.cpp-guide) adapted for Win11 CMD, yup - old skool)

NB: `E llama_init_from_model: failed to initialize the context: Gemma4Assistant requires ctx_other to be set (this is normal during memory fitting)` is still shown, which can be addressed separately

NB: I considered addressing a related [TODO](https://github.com/ggml-org/llama.cpp/blob/master/src/llama-context.cpp#L90-L98) but this can be addressed separately also

NB: I've not tested other gemma-4 models such as older non-qat ones

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes - to understand code related to the issue and get MTP working locally
