### PR TITLE
common: update logging to enforce max_capacity and optimize queue resizing

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -11,8 +11,13 @@
 #include <sstream>
 #include <thread>
 #include <vector>
+#include <algorithm>
 
 #if defined(_WIN32)
+#    define WIN32_LEAN_AND_MEAN
+#    ifndef NOMINMAX
+#       define NOMINMAX
+#    endif
 #    include <io.h>
 #    include <windows.h>
 #    define isatty _isatty
@@ -62,16 +67,15 @@ static const char* g_col[] = {
 };
 
 struct common_log_entry {
-    enum ggml_log_level level;
-
-    bool prefix;
-
-    int64_t timestamp;
+    enum ggml_log_level level {GGML_LOG_LEVEL_INFO};
 
     std::vector<char> msg;
 
-    // signals the worker thread to stop
-    bool is_end;
+    int64_t timestamp { 0 };
+    bool is_end       { false }; // signals the worker thread to stop
+    bool prefix       { false };
+
+    common_log_entry(size_t size = 256) : msg(size) { }
 
     void print(FILE * file = nullptr) const {
         FILE * fcur = file;
@@ -122,22 +126,18 @@ struct common_log_entry {
 };
 
 struct common_log {
+    // sane limit to avoid out-of-memory under heavy profiling
+    const size_t max_capacity = 4096;
+
     // default capacity - will be expanded if needed
-    common_log() : common_log(256) {}
-
-    common_log(size_t capacity) {
-        file = nullptr;
-        prefix = false;
+    common_log(size_t capacity = 256) {
+        file       = nullptr;
+        prefix     = false;
         timestamps = false;
-        running = false;
-        t_start = t_us();
+        running    = false;
+        t_start    = t_us();
 
-        // initial message size - will be expanded if longer messages arrive
-        entries.resize(capacity);
-        for (auto & entry : entries) {
-            entry.msg.resize(256);
-        }
-
+        queue.resize(capacity, common_log_entry(256));
         head = 0;
         tail = 0;
 
@@ -152,9 +152,10 @@ struct common_log {
     }
 
 private:
-    std::mutex mtx;
-    std::thread thrd;
-    std::condition_variable cv;
+    std::mutex              mtx;
+    std::thread             thrd;
+    std::condition_variable cv_new;  // new entry
+    std::condition_variable cv_full; // wait on full
 
     FILE * file;
 
@@ -164,24 +165,75 @@ private:
 
     int64_t t_start;
 
-    // ring buffer of entries
-    std::vector<common_log_entry> entries;
+    // queue of entries
+    std::vector<common_log_entry> queue;
     size_t head;
     size_t tail;
 
-    // worker thread copies into this
-    common_log_entry cur;
+    bool print_entry(const common_log_entry & e) const {
+        if (e.is_end) return true;
+
+        e.print();
+        if (file) {
+            e.print(file);
+        }
+        return false;
+    }
+
+    bool flush_queue(const std::vector<common_log_entry> & old_queue, size_t old_head, size_t old_tail) const {
+        bool stop = false;
+        size_t h = old_head;
+        size_t size = old_queue.size();
+        while (h != old_tail && !stop) {
+            stop = print_entry(old_queue[h]);
+            h = (h + 1) % size;
+        }
+        return stop;
+    }
+
+    bool expand_and_flush(std::unique_lock<std::mutex> & lock) {
+        size_t old_head = head;
+        size_t old_tail = tail;
+        size_t old_size = queue.size();
+
+        size_t new_capacity = std::min(old_size * 2, max_capacity);
+        std::vector<common_log_entry> new_queue(new_capacity, common_log_entry(256));
+
+        queue.swap(new_queue);
+        auto & old_queue = new_queue; // alias to make it clear we are flushing the old queue
+        head = 0;
+        tail = 0;
+        cv_full.notify_all(); // wake up blocked producers
+
+        lock.unlock(); // drop the lock during flushing
+
+        bool stop = flush_queue(old_queue, old_head, old_tail);
+
+        lock.lock();
+        return stop;
+    }
 
 public:
+    bool is_full() const {
+        return ((tail + 1) % queue.size()) == head;
+    }
+
+    bool is_empty() const {
+        return head == tail;
+    }
+
     void add(enum ggml_log_level level, const char * fmt, va_list args) {
-        std::lock_guard<std::mutex> lock(mtx);
+        std::unique_lock<std::mutex> lock(mtx);
+
+        // block if the queue is full
+        cv_full.wait(lock, [this]() { return !running || !is_full(); });
 
         if (!running) {
             // discard messages while the worker thread is paused
             return;
         }
 
-        auto & entry = entries[tail];
+        auto & entry = queue[tail];
 
         {
             // cannot use args twice, so make a copy in case we need to expand the buffer
@@ -216,38 +268,16 @@ public:
             va_end(args_copy);
         }
 
-        entry.level = level;
-        entry.prefix = prefix;
+        entry.is_end    = false;
+        entry.level     = level;
+        entry.prefix    = prefix;
         entry.timestamp = 0;
         if (timestamps) {
             entry.timestamp = t_us() - t_start;
         }
-        entry.is_end = false;
 
-        tail = (tail + 1) % entries.size();
-        if (tail == head) {
-            // expand the buffer
-            std::vector<common_log_entry> new_entries(2*entries.size());
-
-            size_t new_tail = 0;
-
-            do {
-                new_entries[new_tail] = std::move(entries[head]);
-
-                head     = (head     + 1) % entries.size();
-                new_tail = (new_tail + 1);
-            } while (head != tail);
-
-            head = 0;
-            tail = new_tail;
-
-            for (size_t i = tail; i < new_entries.size(); i++) {
-                new_entries[i].msg.resize(256);
-            }
-
-            entries = std::move(new_entries);
-        }
-        cv.notify_one();
+        tail = (tail + 1) % queue.size();
+        cv_new.notify_one();
     }
 
     void resume() {
@@ -261,22 +291,26 @@ public:
 
         thrd = std::thread([this]() {
             while (true) {
-                {
-                    std::unique_lock<std::mutex> lock(mtx);
-                    cv.wait(lock, [this]() { return head != tail; });
-                    cur = entries[head];
+                std::unique_lock<std::mutex> lock(mtx);
+                cv_new.wait(lock, [this]() { return !is_empty(); });
 
-                    head = (head + 1) % entries.size();
+                bool stop = false;
+
+                if (is_full() && queue.size() < max_capacity) {
+                    stop = expand_and_flush(lock);
+                } else {
+                    auto & cur = queue[head];
+
+                    lock.unlock(); // drop the lock while printing
+                    stop = print_entry(cur);
+                    lock.lock();
+
+                    head = (head + 1) % queue.size();
+                    cv_full.notify_one();
                 }
 
-                if (cur.is_end) {
+                if (stop) {
                     break;
-                }
-
-                cur.print(); // stdout and stderr
-
-                if (file) {
-                    cur.print(file);
                 }
             }
         });
@@ -293,13 +327,13 @@ public:
             running = false;
 
             // push an entry to signal the worker thread to stop
-            {
-                auto & entry = entries[tail];
-                entry.is_end = true;
+            auto & entry = queue[tail];
+            entry.is_end = true;
+            tail = (tail + 1) % queue.size();
 
-                tail = (tail + 1) % entries.size();
-            }
-            cv.notify_one();
+            // wakeup everyone
+            cv_new.notify_one();
+            cv_full.notify_all();
         }
 
         thrd.join();

--- a/common/log.cpp
+++ b/common/log.cpp
@@ -126,11 +126,8 @@ struct common_log_entry {
 };
 
 struct common_log {
-    // sane limit to avoid out-of-memory under heavy profiling
-    const size_t max_capacity = 4096;
-
-    // default capacity - will be expanded if needed
-    common_log(size_t capacity = 256) {
+    // default capacity
+    common_log(size_t capacity = 512) {
         file       = nullptr;
         prefix     = false;
         timestamps = false;
@@ -180,36 +177,14 @@ private:
         return false;
     }
 
-    bool flush_queue(const std::vector<common_log_entry> & old_queue, size_t old_head, size_t old_tail) const {
+    bool flush_queue(size_t start_head, size_t end_tail, size_t & out_head) const {
         bool stop = false;
-        size_t h = old_head;
-        size_t size = old_queue.size();
-        while (h != old_tail && !stop) {
-            stop = print_entry(old_queue[h]);
-            h = (h + 1) % size;
+        size_t h = start_head;
+        while (h != end_tail && !stop) {
+            stop = print_entry(queue[h]);
+            h = (h + 1) % queue.size();
         }
-        return stop;
-    }
-
-    bool expand_and_flush(std::unique_lock<std::mutex> & lock) {
-        size_t old_head = head;
-        size_t old_tail = tail;
-        size_t old_size = queue.size();
-
-        size_t new_capacity = std::min(old_size * 2, max_capacity);
-        std::vector<common_log_entry> new_queue(new_capacity, common_log_entry(256));
-
-        queue.swap(new_queue);
-        auto & old_queue = new_queue; // alias to make it clear we are flushing the old queue
-        head = 0;
-        tail = 0;
-        cv_full.notify_all(); // wake up blocked producers
-
-        lock.unlock(); // drop the lock during flushing
-
-        bool stop = flush_queue(old_queue, old_head, old_tail);
-
-        lock.lock();
+        out_head = h;
         return stop;
     }
 
@@ -294,20 +269,17 @@ public:
                 std::unique_lock<std::mutex> lock(mtx);
                 cv_new.wait(lock, [this]() { return !is_empty(); });
 
-                bool stop = false;
+                size_t cached_head = head;
+                size_t cached_tail = tail;
 
-                if (is_full() && queue.size() < max_capacity) {
-                    stop = expand_and_flush(lock);
-                } else {
-                    auto & cur = queue[head];
+                lock.unlock(); // drop the lock during flush
 
-                    lock.unlock(); // drop the lock while printing
-                    stop = print_entry(cur);
-                    lock.lock();
+                size_t next_head;
+                bool stop = flush_queue(cached_head, cached_tail, next_head);
 
-                    head = (head + 1) % queue.size();
-                    cv_full.notify_one();
-                }
+                lock.lock();
+                head = next_head;
+                cv_full.notify_all();
 
                 if (stop) {
                     break;


### PR DESCRIPTION
## Overview

I'm working on adding more Op tracing to the hexagon backend and ran into an issue with our current logging implementation. If the logging rate is consistently much higher than the flushing rate then the queue will just keep growing and growing without any bounds eventually resulting in an exception when malloc finally fails.

This PR updates the logger to enforce `max_capacity` limit which is currently set to 4K entries.
I also re-wrote how the queue resizing is done. Now the producer threads are super simple they just block on full queue.
The consumer thread does all the resizing and flushing. Because the queue is only modified by the consumer thread we can get rid of all of the copies (ie for the current entry and when resizing).

## Additional information
@ggerganov  @CISC 
I used a branch in the main repo. Feel free to update directly as needed.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, just for the code review.