### PR TITLE
server : reset fit_params_target to baseline on model (re)load

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -890,6 +890,11 @@ private:
 
     common_params params_base;
 
+    // Pristine per-device fit-params target captured on the FIRST load, so
+    // resuming from sleep does not re-add mmproj/draft sizes cumulatively (#24475).
+    std::vector<size_t> fit_params_target_base;
+    bool fit_params_target_base_set = false;
+
     // note: keep these alive - they determine the lifetime of the model, context, etc.
     common_init_result_ptr llama_init;
 
@@ -1008,6 +1013,14 @@ private:
 
         params_base = params;
         params_base.n_outputs_max = server_n_outputs_max(params_base);
+
+        // #24475: restore fit-params target to first-load baseline before mmproj/draft sizes add below
+        if (!fit_params_target_base_set) {
+            fit_params_target_base     = params_base.fit_params_target;
+            fit_params_target_base_set = true;
+        } else {
+            params_base.fit_params_target = fit_params_target_base;
+        }
 
         const bool has_mmproj = !params.mmproj.path.empty();
         const bool has_draft = params.speculative.has_dft();


### PR DESCRIPTION
## Overview

`llama-server` with `--mmproj` (and/or a draft/MTP model) inflates its free-memory
target every time it resumes from sleep. With `--sleep-idle-seconds`, each wake adds
the mmproj/draft size again, so `fit_params_target` grows without bound.

Root cause: `handle_sleeping_state(false)` re-calls `load_model(params_base)`, and
`load_model()` adds the mmproj size (`fit_params_target[i] += size`) and the draft/MTP
size (`fit_params_target[i] += bytes`) to `params_base.fit_params_target`. That target
is never reset to its first-load baseline, so the additions compound across wakes.

Fix: snapshot the per-device `fit_params_target` on the first load and restore it before
the mmproj/draft sizes are added, so the first load and every resume accumulate from the
same clean baseline.

Fixes #24475.

## Additional information

The same `+=` pattern applies to the draft/MTP branch, so this also covers the draft case
the reporter suspected.

Validation (host-side server logic, hardware-independent):
- Builds cleanly (`cmake --build ... --target llama-server`, recompiles `server-context.cpp`).
- A faithful harness of the `load_model` target lifecycle reproduces the bug and the fix:
  with the reporter's ~1290 MiB mmproj + a 500 MiB draft, the stock target grows
  2814 -> 4604 -> 6394 -> 8184 MiB across three wakes, while the patched target stays at
  2814 MiB on every wake.

I currently have two other open PRs (#24237 HIP runtime, #24450 Vulkan build tooling); this one
touches a different area (`server`). Happy to serialize and wait if you'd prefer I keep fewer open at once.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — AI was used in an assistive capacity only (locating the
  relevant code paths and drafting wording). I authored and reviewed the change, understand
  it fully, and can explain every line; the root-cause analysis and validation are mine. No
  AI-written code was submitted without manual review.
