### PR TITLE
convert: Add Qwen3.6 MoE switch_mlp tensor mapping for GGUF conversion

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -83,7 +83,57 @@ class Qwen2MoeModel(TextModel):
 
     _experts: list[dict[str, Tensor]] | None = None
 
+    _switch_mlp_buf: dict[int, dict[str, Tensor]] | None = None
+
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # handle Qwen3.6 MoE switch_mlp tensors
+        # switch_mlp is Qwen3.6's name for the merged expert block.
+        # These are already 3D tensors [n_experts, dim, dim] but with
+        # separate gate_proj and up_proj that need fusing into gate_up_proj.
+        if "mlp.switch_mlp." in name:
+            # Strip language_model. prefix if present
+            clean_name = name.replace("language_model.", "")
+
+            if "switch_mlp.down_proj" in clean_name:
+                # down_proj can be yielded directly as experts.down_proj
+                mapped = clean_name.replace("switch_mlp.", "experts.")
+                if not mapped.endswith(".weight"):
+                    mapped += ".weight"
+                yield from super().modify_tensors(data_torch, mapped, bid)
+                return
+
+            if "switch_mlp.gate_proj" in clean_name or "switch_mlp.up_proj" in clean_name:
+                # Collect gate_proj and up_proj, fuse when both available
+                assert bid is not None
+                if self._switch_mlp_buf is None:
+                    self._switch_mlp_buf = {}
+                if bid not in self._switch_mlp_buf:
+                    self._switch_mlp_buf[bid] = {}
+                self._switch_mlp_buf[bid][clean_name] = data_torch
+
+                # Check if we have both gate and up for this block
+                gate_key = None
+                up_key = None
+                for k in self._switch_mlp_buf[bid]:
+                    if "gate_proj" in k:
+                        gate_key = k
+                    if "up_proj" in k:
+                        up_key = k
+
+                if gate_key and up_key:
+                    gate = self._switch_mlp_buf[bid].pop(gate_key)
+                    up = self._switch_mlp_buf[bid].pop(up_key)
+                    # Fuse: concat along intermediate_size dim (dim=1 for 3D)
+                    cat_dim = 1 if gate.ndim == 3 else 0
+                    fused = torch.cat([gate, up], dim=cat_dim)
+                    fused_name = f"model.layers.{bid}.mlp.experts.gate_up_proj.weight"
+                    yield from super().modify_tensors(fused, fused_name, bid)
+                return
+
+        # Strip language_model. prefix for other tensors too
+        if name.startswith("language_model."):
+            name = name.replace("language_model.", "")
+
         # handle aggregated expert tensors
         # GGUF stores dimensions reversed from PyTorch, so:
         # PyTorch (A,B,C) -> GGUF writes [C,B,A] -> GGML reads ne={C,B,A}


### PR DESCRIPTION
## Problem

Converting Qwen3.6 MoE models (`qwen3_5_moe` / `Qwen3_5MoeForConditionalGeneration`) to GGUF fails:

```
ValueError: Can not map tensor 'model.layers.0.mlp.switch_mlp.down_proj.weight'
```

This affects all Qwen3.6-35B-A3B variants and any fine-tuned derivatives.

## Root Cause

Qwen3.6 MoE uses `switch_mlp` for its expert block instead of the `experts.{xid}` pattern that the converter expects. Additionally:

1. Expert tensors are stored as merged 3D tensors (`[n_experts, dim, dim]`) under `switch_mlp.{proj}` rather than individual per-expert 2D tensors
2. `gate_proj` and `up_proj` are separate tensors that need fusing into `gate_up_proj`
3. Models fused via `mlx_lm.fuse` have a `language_model.` prefix from the `ConditionalGeneration` wrapper

## Changes

`conversion/qwen.py`:

- **`switch_mlp.down_proj` handling:** Renamed to `experts.down_proj` and yielded directly (already a valid merged 3D tensor)
- **`switch_mlp.gate_proj` + `up_proj` fusion:** Collected per-block in a buffer, fused via `torch.cat(dim=1)` when both are available, yielded as `experts.gate_up_proj` — which the existing handler then splits correctly for GGUF output
- **`language_model.` prefix stripping:** Handles the `ConditionalGeneration` wrapper prefix that appears in MLX-fused models

## Testing

Tested end-to-end:
```bash
python convert_hf_to_gguf.py /path/to/qwen3.6-fused --outfile model-f16.gguf --outtype f16
./build/bin/llama-quantize model-f16.gguf model-Q4_K_M.gguf Q4_K_M
# Both complete successfully, model loads in llama-server and Ollama
```

## Applies To

- `Qwen3_5MoeForConditionalGeneration` architecture
- Qwen3.6-35B-A3B (all variants)
- Fine-tuned and fused derivatives (via mlx_lm, PEFT, etc.)
- Models with `model_type: qwen3_5_moe`

---

*Discovered and implemented by Gabriel Garcia / RavenX LLC*