### PR TITLE
docs: tuning guidance for draft-mtp speculative decoding

### DIFF
--- a/docs/speculative.md
+++ b/docs/speculative.md
@@ -264,6 +264,39 @@ Specifies a comma-separated list of speculative decoding types to use.
 ./llama-server [...] --spec-type ngram-mod,ngram-map-k4v
 ```
 
+### Tuning `draft-mtp`
+
+`draft-mtp` drafts with the model's own NextN/MTP head, applied autoregressively (the head is
+re-run on its own output hidden state to extend the draft), so acceptance falls off with draft
+depth. Two options dominate throughput:
+
+- `--draft-p-min` (default `0`): the head only proposes a token while its top probability is
+  `>= p_min`. At the default `0`, every draft up to `--spec-draft-n-max` is proposed regardless
+  of confidence, so low-confidence deep drafts are generated and then rejected by the target,
+  wasting a verification pass.
+- `--spec-draft-n-max` (default `3`): maximum draft length. Because MTP is a single head chained
+  autoregressively (rather than `num_nextn_predict_layers` distinct heads), large depths mostly
+  add rejected drafts.
+
+With the defaults, `draft-mtp` can be **slower than no speculation**. Set a confidence gate and a
+small depth:
+
+```bash
+./llama-server -m model-with-mtp.gguf --spec-type draft-mtp \
+    --spec-draft-n-max 2 --draft-p-min 0.6
+```
+
+Measured on StepFun Step-3.x-Flash (`step35`, Q3_K_M) on a single NVIDIA GB10, greedy,
+`-np 1 -c 512 -ub 64`:
+
+| Config | Decode tok/s | Draft acceptance |
+|---|---|---|
+| no speculation | 26.7 | — |
+| `--spec-draft-n-max 3 --draft-p-min 0` (defaults) | 23.5 | 34% |
+| `--spec-draft-n-max 2 --draft-p-min 0` | 29.6 | 54% |
+| `--spec-draft-n-max 2 --draft-p-min 0.6` | **30.5** | **94%** |
+| `--spec-draft-n-max 2 --draft-p-min 0.85` | 29.5 | 97% |
+
 ### `--spec-ngram-*-size-n N`
 
 Sets the size N of the lookup n-gram for n-gram map based speculative decoding.


### PR DESCRIPTION
## Summary

Docs-only change. This adds a short tuning note for `--spec-type draft-mtp` in `docs/speculative.md`.

The point is to document that the default `--spec-draft-n-max 3 --draft-p-min 0` is not always a good setting for MTP self-speculation, because deeper low-confidence drafts can be generated and then rejected by the target model.

## Local benchmark

I measured this locally on my GB10/Spark system with llama.cpp commit `88a3927`.

Setup:

- model: StepFun Step-3.x-Flash (`step35`, Q3_K_M)
- hardware: single NVIDIA GB10
- decoding: greedy
- args: `-np 1 -c 512 -ub 64`

| Config | Decode tok/s | Draft acceptance |
|---|---:|---:|
| no speculation | 26.7 | — |
| `--spec-draft-n-max 3 --draft-p-min 0` | 23.5 | 34% |
| `--spec-draft-n-max 2 --draft-p-min 0` | 29.6 | 54% |
| `--spec-draft-n-max 2 --draft-p-min 0.6` | 30.5 | 94% |
| `--spec-draft-n-max 2 --draft-p-min 0.85` | 29.5 | 97% |

On this setup, `--spec-draft-n-max 2 --draft-p-min 0.6` changed the result from slower-than-baseline to a speedup with high draft acceptance.

## Note

My understanding is that with MTP self-speculation, a single MTP head is chained autoregressively. In this case, deeper drafts can become low-confidence and often fail target verification. The doc change points users at the two knobs that mattered in my test: draft depth and the confidence gate.

AI disclosure: I used Claude Code/Codex only as an assistant for small helper-script checks and note organization. I ran the benchmark myself on my GB10/Spark machine, and I reviewed the numbers, mechanism, and doc change before submitting.

cc @stepfun-ai (`step35` MTP).
