### PR TITLE
common/autoparser : accept tagged tool-call arguments in any order

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -405,22 +405,23 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
             }
         }
 
-        // Build required arg sequence in definition order
+        // Build args with fully flexible ordering. Models do not guarantee that
+        // arguments are emitted required-first / in schema order: e.g. Qwen3.x
+        // commonly emits an optional parameter before a required one. The old
+        // grammar (required args first in definition order, optionals after)
+        // could not match such output, which surfaced as a hard
+        // "Failed to parse input at pos N" failure for the whole tool call.
+        // Accept all known parameters in any order (parser leniency).
         common_peg_parser args_seq = p.eps();
-        for (size_t i = 0; i < required_parsers.size(); i++) {
-            if (i > 0) {
-                args_seq = args_seq + p.space();
+        std::vector<common_peg_parser> all_parsers;
+        all_parsers.insert(all_parsers.end(), required_parsers.begin(), required_parsers.end());
+        all_parsers.insert(all_parsers.end(), optional_parsers.begin(), optional_parsers.end());
+        if (!all_parsers.empty()) {
+            common_peg_parser any_arg = p.choice();
+            for (const auto & a : all_parsers) {
+                any_arg |= a;
             }
-            args_seq = args_seq + required_parsers[i];
-        }
-
-        // Build optional args with flexible ordering
-        if (!optional_parsers.empty()) {
-            common_peg_parser any_opt = p.choice();
-            for (const auto & opt : optional_parsers) {
-                any_opt |= opt;
-            }
-            args_seq = args_seq + p.repeat(p.space() + any_opt, 0, -1);
+            args_seq = p.optional(any_arg + p.repeat(p.space() + any_arg, 0, -1));
         }
 
         if (!arguments.start.empty()) {


### PR DESCRIPTION
The tagged tool-call grammar required parameters to appear required-first in schema order, with optionals after. Models that emit an optional parameter before a required one (e.g. Qwen3 grep with path before the required pattern) produced output the grammar could not match, failing the whole call with "Failed to parse input at pos N". Accept all known parameters in any order instead.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
