### PR TITLE
server : fix reasoning budget WebUI precedence over model.ini

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1126,9 +1126,9 @@ json oaicompat_chat_params_parse(
 
     // Reasoning budget: pass parameters through to sampling layer
     {
-        int reasoning_budget = opt.reasoning_budget;
-        if (reasoning_budget == -1 && body.contains("thinking_budget_tokens")) {
-            reasoning_budget = json_value(body, "thinking_budget_tokens", -1);
+        int reasoning_budget = json_value(body, "thinking_budget_tokens", -1);
+        if (reasoning_budget == -1) {
+            reasoning_budget = opt.reasoning_budget;
         }
 
         if (!chat_params.thinking_end_tag.empty()) {


### PR DESCRIPTION
## Overview

cont #23434 

When `reasoning-budget` is set in `model.ini`, the per-request `thinking_budget_tokens` from the WebUI is ignored because the model.ini value takes unconditional precedence.

Swap the precedence so the WebUI per-request value is checked first, with the model.ini value serving as a fallback default.

## Additional information

One-line fix in `oaicompat_chat_params_parse()` — the `json_value(body, "thinking_budget_tokens", -1)` call is now made first, and `opt.reasoning_budget` is used only when the body value is `-1` (unset).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.6-27B
