### PR TITLE
cuda : fix flash attention crash for `d_head=512` with `gqa_ratio=2` 

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -1316,6 +1316,9 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
 
             launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap>(ctx, dst);
             return;
+        } else {
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap>(ctx, dst);
+            return;
         }
     }
     GGML_ABORT("fatal error");

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -85,7 +85,8 @@ static void ggml_cuda_flash_attn_ext_mma_f16_switch_ncols2(ggml_backend_cuda_con
             ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 1>(ctx, dst);
             return;
         } else {
-            GGML_ABORT("fatal error");
+            ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 4>(ctx, dst);
+            return;
         }
     }
 
@@ -107,7 +108,7 @@ static void ggml_cuda_flash_attn_ext_mma_f16_switch_ncols2(ggml_backend_cuda_con
 
         ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 1>(ctx, dst);
     } else {
-        GGML_ABORT("fatal error");
+        ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 4>(ctx, dst);
     }
 }
 


### PR DESCRIPTION
Close #24400 (confirmed) and #24376 (unconfirmed)

---

## Overview

**Root cause**: Gemma4 MTP draft model has `gqa_ratio=2` but `DKQ=512`, `DV=512`. This combination isn't handled by the dispatcher. In details:

- Bug 1 (tile path, Pascal): PR #20998 added `DKQ=512` but left `DV>256` without a fallback.
- Bug 2 (MMA path, Turing/Ampere): PR #21768 wrapped `ncols2=1/2` in `if constexpr (DKQ <= 256)` assuming `DKQ=512` path would always have `gqa_ratio % 4 == 0`.

This PR adds those handlers with `ncols=4` (for tiling kernel) and `ncols2=4` for MMA kernel, because they're the smallest existing config entry for (DKQ=512, DV=512) in the instantiation table.

## Additional information

### MTP model information
```
$ python3 gguf-py/gguf/scripts/gguf_dump.py ~/models/gemma4/MTP/gemma-4-E4B-it-Q4_0-MTP.gguf | grep -i "head_count\|head_dim\|attention\|key_length"
INFO:gguf-dump:* Loading: /home/hs/models/gemma4/MTP/gemma-4-E4B-it-Q4_0-MTP.gguf
     15: UINT32     |        1 | gemma4-assistant.attention.head_count = 4
     16: UINT32     |        1 | gemma4-assistant.attention.head_count_kv = 2
     19: FLOAT32    |        1 | gemma4-assistant.attention.layer_norm_rms_epsilon = 9.999999974752427e-07
     20: UINT32     |        1 | gemma4-assistant.attention.key_length = 512
     21: UINT32     |        1 | gemma4-assistant.attention.value_length = 512
     23: UINT32     |        1 | gemma4-assistant.attention.sliding_window = 512
     24: UINT32     |        1 | gemma4-assistant.attention.shared_kv_layers = 4
     26: [BOOL]     |        4 | gemma4-assistant.attention.sliding_window_pattern = [True, True, True, False]
     27: UINT32     |        1 | gemma4-assistant.attention.key_length_swa = 256
     28: UINT32     |        1 | gemma4-assistant.attention.value_length_swa = 256
```



## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Use Sonnet 4.6 for brainstorming the possible hypothesis and verify them.