### PR TITLE
CUDA: only support F32/F16 for GGML_OP_REPEAT

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5337,8 +5337,9 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             } break;
         case GGML_OP_REPEAT:
             {
+                // the CUDA REPEAT path only implements F32/F16; other types assert at runtime
                 ggml_type src0_type = op->src[0]->type;
-                return src0_type != GGML_TYPE_I32 && src0_type != GGML_TYPE_I16;
+                return src0_type == GGML_TYPE_F32 || src0_type == GGML_TYPE_F16;
             } break;
         case GGML_OP_REPEAT_BACK:
                 return op->type == GGML_TYPE_F32 && (op->src[0]->ne[2]*op->src[0]->ne[3]) <= (1 << 15);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8086,6 +8086,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 1, 1, 2}));
         test_cases.emplace_back(new test_repeat(GGML_TYPE_I32, {10, 5, 4, ne3}, {2, 1, 1, 1}));
         test_cases.emplace_back(new test_repeat(GGML_TYPE_I16, {10, 5, 4, ne3}, {1, 1, 1, 2}));
+        test_cases.emplace_back(new test_repeat(GGML_TYPE_BF16, {10, 5, 4, ne3}, {2, 1, 1, 1}));
     }
 
     for (bool view : {false, true}) {


### PR DESCRIPTION


## Overview

 `ggml_backend_cuda_device_supports_op` reported `GGML_OP_REPEAT` as supported  for every type except `I32`/`I16` (a blacklist). The CUDA path only implements `F32` and `F16`: other types (`BF16`, k-quants, ...) hit a `GGML_ASSERT` / `GGML_ABORT` in `ggml_cuda_op_bin_bcast` (`binbcast.cu`) at runtime instead of falling back to the CPU backend. `supports_op` should not advertise dtypes whose CUDA execution path asserts.

  Switch the check to a whitelist of the types the kernel actually implements  (`F32`/`F16`). Unsupported types now fall back to CPU; `I32`/`I16` behaviour is unchanged.




## Additional information

RTX 5090 (sm120a):

  ```
  CUDA_VISIBLE_DEVICES=0 test-backend-ops -b CUDA0 -o REPEAT
  ```

  10/10 `REPEAT` tests pass; the added `BF16` case is correctly reported as `not supported [CUDA0]` 


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
