### PR TITLE
Reduce RSS during BF16 GGUF export

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -646,6 +646,32 @@ class ModelBase:
             return gguf.GGMLQuantizationType.Q8_0
         return False
 
+    def _can_write_bf16_raw(self, data_torch: Tensor, data_qtype: gguf.GGMLQuantizationType) -> bool:
+        native_endianess = gguf.GGUFEndian.BIG if sys.byteorder == "big" else gguf.GGUFEndian.LITTLE
+        return (
+            data_qtype == gguf.GGMLQuantizationType.BF16
+            and data_torch.dtype == torch.bfloat16
+            and self.endianess == native_endianess
+        )
+
+    @staticmethod
+    def _bf16_tensor_to_gguf_bytes(data_torch: Tensor) -> np.ndarray:
+        raw_shape = gguf.quant_shape_to_byte_shape(tuple(data_torch.shape), gguf.GGMLQuantizationType.BF16)
+
+        def as_uint8(tensor: Tensor) -> Tensor:
+            return tensor.contiguous().view(torch.uint8).reshape(raw_shape)
+
+        if isinstance(data_torch, LazyTorchTensor):
+            raw_torch = LazyTorchTensor(
+                meta=LazyTorchTensor.meta_with_dtype_and_shape(torch.uint8, raw_shape),
+                args=(data_torch,),
+                func=as_uint8,
+            )
+        else:
+            raw_torch = as_uint8(data_torch)
+
+        return raw_torch.numpy()
+
     # some models need extra generated tensors (like rope_freqs)
     def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
         return ()
@@ -867,10 +893,6 @@ class ModelBase:
 
             old_dtype = data_torch.dtype
 
-            # convert any unsupported data types to float32
-            if data_torch.dtype not in (torch.float16, torch.float32):
-                data_torch = data_torch.to(torch.float32)
-
             # use the first number-like part of the tensor name as the block id
             bid = None
             for part in name.split("."):
@@ -881,9 +903,7 @@ class ModelBase:
             for new_name, data_torch in (self.modify_tensors(data_torch, name, bid)):
                 # TODO: why do we squeeze here?
                 # data = data_torch.squeeze().numpy()
-                data = data_torch.numpy()
-
-                n_dims = len(data.shape)
+                n_dims = len(data_torch.shape)
                 data_qtype: gguf.GGMLQuantizationType | bool = self.tensor_force_quant(name, new_name, bid, n_dims)
 
                 # Most of the codebase that takes in 1D tensors or norms only handles F32 tensors
@@ -961,12 +981,21 @@ class ModelBase:
                     else:
                         raise ValueError(f"Unknown file type: {self.ftype.name}")
 
-                try:
-                    data = gguf.quants.quantize(data, data_qtype)
-                except gguf.QuantError as e:
-                    logger.warning("%s, %s", e, "falling back to F16")
-                    data_qtype = gguf.GGMLQuantizationType.F16
-                    data = gguf.quants.quantize(data, data_qtype)
+                if self._can_write_bf16_raw(data_torch, data_qtype):
+                    data = self._bf16_tensor_to_gguf_bytes(data_torch)
+                else:
+                    # convert any unsupported data types to float32
+                    if data_torch.dtype not in (torch.float16, torch.float32):
+                        data_torch = data_torch.to(torch.float32)
+
+                    data = data_torch.numpy()
+
+                    try:
+                        data = gguf.quants.quantize(data, data_qtype)
+                    except gguf.QuantError as e:
+                        logger.warning("%s, %s", e, "falling back to F16")
+                        data_qtype = gguf.GGMLQuantizationType.F16
+                        data = gguf.quants.quantize(data, data_qtype)
 
                 shape = gguf.quant_shape_from_byte_shape(data.shape, data_qtype) if data.dtype == np.uint8 else data.shape
 

--- a/gguf-py/tests/test_writer_memory.py
+++ b/gguf-py/tests/test_writer_memory.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+if "NO_LOCAL_GGUF" not in os.environ and (Path(__file__).parent.parent.parent / "gguf-py").exists():
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import gguf
+
+
+class TestBf16RawPassthrough(unittest.TestCase):
+    def test_bf16_passthrough_bytes_match_torch_storage(self):
+        if importlib.util.find_spec("torch") is None or importlib.util.find_spec("transformers") is None:
+            self.skipTest("torch and transformers are required for conversion helper tests")
+
+        import torch
+
+        from conversion.base import ModelBase
+
+        tensor = torch.tensor(
+            [[1.0, -2.5, 3.25, 4.5], [0.0, 7.75, -8.5, 9.0]],
+            dtype=torch.float32,
+        ).to(torch.bfloat16)
+
+        expected = tensor.contiguous().view(torch.uint8).reshape(2, 8).numpy()
+        legacy = gguf.quants.quantize(tensor.float().numpy(), gguf.GGMLQuantizationType.BF16)
+        got = ModelBase._bf16_tensor_to_gguf_bytes(tensor)
+
+        self.assertEqual(got.dtype, np.uint8)
+        self.assertEqual(got.shape, expected.shape)
+        np.testing.assert_array_equal(got, expected)
+        np.testing.assert_array_equal(got, legacy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview

In testing I found that tensors were being converted from bf16 to fp32 and back to bf16 during the conversion process. In a local SmolLM2 A/B, the old path used 1.77x the max RSS of the raw BF16 path.

This patch shortcuts this process by keeping the tensors in bf16 throughout the entire process thereby reducing RSS.

## Validation run locally:

I took `HuggingFaceTB/SmolLM2-135M-Instruct` and converted it.  `LLAMA_CONVERT_DISABLE_BF16_RAW` was used to AB test the old and new path, but has been stripped from the PR.

```
/usr/bin/time -l \
  python convert_hf_to_gguf.py \
  --outtype bf16 \
  --split-max-size 256M \
  --outfile /tmp/convert-profile-ab/raw/SmolLM2-135M-BF16.gguf \
  HuggingFaceTB/SmolLM2-135M-Instruct \
  > /tmp/convert-profile-ab/raw/convert.log 2>&1
  ```
  
```
LLAMA_CONVERT_DISABLE_BF16_RAW=1 \
/usr/bin/time -l \
  python convert_hf_to_gguf.py \
  --outtype bf16 \
  --split-max-size 256M \
  --outfile /tmp/convert-profile-ab/no-raw/SmolLM2-135M-BF16.gguf \
  HuggingFaceTB/SmolLM2-135M-Instruct \
  > /tmp/convert-profile-ab/no-raw/convert.log 2>&1
```


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assistance was used to prepare the patch. The submitter reviewed and is responsible for the changes.
