### PR TITLE
llama : disable graph reuse when contexts share memory under SPLIT_MODE_TENSOR

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -223,6 +223,15 @@ llama_context::llama_context(
         }
     }
 
+    // With SPLIT_MODE_TENSOR both contexts share meta-backend buffers;
+    // a reused graph holds dangling per-device refs after the peer rebuilds.
+    if (cparams.ctx_other != nullptr &&
+        (model.split_mode() == LLAMA_SPLIT_MODE_TENSOR ||
+         cparams.ctx_other->get_model().split_mode() == LLAMA_SPLIT_MODE_TENSOR)) {
+        graph_reuse_disable = true;
+        cparams.ctx_other->graph_reuse_disable = true;
+    }
+
     // ref: https://github.com/ggml-org/llama.cpp/pull/17046#discussion_r2503085732
     cparams.n_ctx = GGML_PAD(cparams.n_ctx, 256);
 


### PR DESCRIPTION
Fixes crash when running with Gemma MTP and Tensor. Originally found while playing with [beelama](https://github.com/Anbeeld/beellama.cpp), discovered it also affected mainline, and found others with the issue. 

Two contexts sharing memory under SPLIT_MODE_TENSOR (e.g. Gemma4 MTP or EAGLE3 draft + target) both create views into the same meta-backend buffers. Reusing a stale graph after the peer has rebuilt leaves dangling per-device tensor references, causing fattn.cu:579 crashes.

Fix: disable graph reuse for both contexts when either uses tensor split and they share memory. Backend-agnostic, applies to Gemma4 MTP and EAGLE3. 

Confirmed on 2x 7900 XTX (ROCm/HIP/RCCL) with 3 sequential same-slot requests.
Also confirmed on NVIDIA by testers in #24314.

Fixes #24324, #24314, #24440  

- [x] I have read and agree with the contributing guidelines
- [x] AI usage disclosure: AI assistance used for codebase exploration, hypothesis testing, and verification. I understand the patch as written. 