### PR TITLE
llama: copy tensor_split at model load instead of retaining caller pointer, resolving segfault

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1655,6 +1655,14 @@ const float * llama_model::tensor_split() const {
     return params.tensor_split;
 }
 
+void llama_model::own_tensor_split(size_t n) {
+    if (params.tensor_split == nullptr || n == 0) {
+        return;
+    }
+    tensor_split_owned.assign(params.tensor_split, params.tensor_split + n);
+    params.tensor_split = tensor_split_owned.data();
+}
+
 uint32_t llama_model::n_gpu_layers() const {
     // note: plus 1 for the "output" layer
     return params.n_gpu_layers >= 0 ? params.n_gpu_layers : hparams.n_layer_all + 1;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -513,8 +513,8 @@ struct llama_device {
 };
 
 struct llama_meta_device_get_split_state_userdata {
-    size_t                     n_devices;
-    const struct llama_model * model;
+    size_t                     n_devices = 0;
+    const struct llama_model * model     = nullptr;
 };
 
 struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const struct ggml_tensor * tensor, void * userdata);
@@ -616,6 +616,8 @@ struct llama_model {
     size_t n_devices() const;
     const float * tensor_split() const;
 
+    void own_tensor_split(size_t n);
+
     uint32_t n_gpu_layers() const;
     llama_split_mode split_mode() const;
 
@@ -656,6 +658,8 @@ struct llama_model {
 
 protected:
     llama_model_params params;
+
+    std::vector<float> tensor_split_owned;
 
     struct impl;
     std::unique_ptr<impl> pimpl;

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -290,6 +290,8 @@ static std::pair<int, llama_model *> llama_model_load(struct gguf_context * meta
             return {-1, nullptr};
         }
 
+        model_ptr->own_tensor_split(std::max(model_ptr->devices.size(), model_ptr->get_split_state_ud.n_devices));
+
         auto * model = dynamic_cast<llama_model_base *>(model_ptr.get());
         if (model == nullptr) {
             GGML_ABORT("fatal error: model does not implement llama_model_base");


### PR DESCRIPTION
## Overview

Ran across this problem with an MTP draft model under -sm tensor on 2 GPUs: tensor_split read back as [514516.25, 0.0], assigning the draft layer's entire KV cache to device 0 while Q remained head-split 12/12, which the FLASH_ATTN_EXT split consistency check in ggml-backend-meta.cpp then correctly rejects on line 1042 (the GGML_ASSERT).

Basically figured out that llama_model keeps the raw llama_model_params.tensor_split pointer for its entire lifetime, but the caller owns that storage and it is not guaranteed to outlive the model. llama-server creates draft models from a temporary copy of its parameters (`common_params params_dft = params_base` is a local in load_model), so the draft model's tensor_split pointer dangles once that scope exits.

Far as I can tell, the bug stays hidden in a fair number of configs because the pointer gets consumed eagerly during load (layer placement) while still valid. The single lazy consumer is the meta backend split-state callback (llama_meta_device_get_split_state), which runs at graph-allocation time under "-sm tensor" (which IS marked experimental, after all). The main model allocates its graphs during the load-time warm up while the pointer is still valid; a draft model has no warm up, so its first split-state computation happens at the first request that needs a new graph, reading freed memory.

May be the root cause of some of the anecdotally noted segfault type issues that seem to be intermittent and/or unreproducible when running with "-sm tensor" and draft-mtp. Failures are dependent on the build given what happens to be in memory, so reproducing it was "fun". Frankly, it's a pretty small change to fix something that's only recently been exposed because of an experimental feature, so it doesn't surprise me it leaked through. That said, once you see the problem, it's pretty hard to unsee, and this seemed like the most minimal way to fix it reliably.

## Reproduction:

Note this isn't consistently reproducible, it didn't fire for me until I happened to upgrade various system libraries and compiled against the same commit that worked fine previously.

In any case, Qwen3.6-27B + MTP draft (--spec-type draft-mtp), -sm tensor, 2x RTX 3090. Req 1 completes, req 2 aborts during draft decode. Instrumentation showed tensor_split reading back as [514516.25, 0.0] in that case, which assigns the draft layer's entire KV cache to device 0 while Q remains head-split 12/12, the FLASH_ATTN_EXT split consistency assert then rejects the graph (as it should, ggml-backend-meta.cpp line 1042). Because the dangling read depends on heap/stack reuse, symptoms are going to change between builds and toolchains (crash on request 2, crash mid-generation, silently degenerate splits).

## Testing:

I tested it before and after making the change. Crash on every second request before, 1438 consecutive requests plus a full speculative-decoding benchmark clean after, with correct per-device KV splits. Main-model behavior is unaffected (splits were always done while the pointer was valid).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Sort of? The code wasn't generated by AI, but I ran my fixes through an LLM to triple-check my work and make sure I wasn't impacting anything else I was unaware of. I also used one originally to quickly map the backtrace to the codebase with context (I have a local set of patches I always assume are the root cause, so wanted to make sure those weren't the culprit). Code changes were made by me, research, troubleshooting and isolation of the issue was also performed by me as well, AI was used as a cross-check once the code was done, and as an initial guide to ease mapping the backtrace to the code path.