### PR TITLE
Fix 24486: TP: allows the usage of 4-10 gpus for stepfun and laguna

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -657,6 +657,14 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             return {blck_size_perf};
         }
 
+        if (ud->model->arch == LLM_ARCH_STEP35 || ud->model->arch == LLM_ARCH_LAGUNA) {
+            GGML_ASSERT(segments.size() == 1);
+            const int64_t max_el      = segments[0].first;
+            if (std::regex_match(tensor_name, pattern_attn_gate_weight)) {
+                return {hparams.n_head(il) / hparams.n_head_kv(il)};
+            }
+        }
+
         // everything else
         GGML_ASSERT(segments.size() == 1);
         return {1};

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -676,6 +676,14 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             return {blck_size_perf};
         }
 
+        if (ud->model->arch == LLM_ARCH_STEP35 || ud->model->arch == LLM_ARCH_LAGUNA) {
+            GGML_ASSERT(segments.size() == 1);
+            const int64_t max_el      = segments[0].first;
+            if (std::regex_match(tensor_name, pattern_attn_gate_weight)) {
+                return {hparams.n_head(il) / hparams.n_head_kv(il)};
+            }
+        }
+
         // everything else
         GGML_ASSERT(segments.size() == 1);
         return {1};


### PR DESCRIPTION
## Overview

This fixes https://github.com/ggml-org/llama.cpp/issues/24486 and allows the usage of 4-10 and probably more gpu's. I cannot test with <4 because of too little vram.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes I used llama.cpp and qwen3.5 122b as an advanced grep tool for discovering the codebase all code comes from me (as little as there is). 