### PR TITLE
ggml-alloc : check realloc result in alloc_tensor_range

### DIFF
--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -1135,7 +1135,14 @@ static bool alloc_tensor_range(struct ggml_context * ctx,
         return false;
     }
 
-    *buffers = realloc(*buffers, sizeof(ggml_backend_buffer_t) * (*n_buffers + 1));
+    ggml_backend_buffer_t * new_buffers = realloc(*buffers, sizeof(ggml_backend_buffer_t) * (*n_buffers + 1));
+    if (new_buffers == NULL) {
+        GGML_LOG_ERROR("%s: failed to reallocate buffer array\n", __func__);
+        ggml_backend_buffer_free(buffer);
+        free_buffers(buffers, n_buffers);
+        return false;
+    }
+    *buffers = new_buffers;
     (*buffers)[(*n_buffers)++] = buffer;
 
     struct ggml_tallocr tallocr = ggml_tallocr_new(buffer);


### PR DESCRIPTION
Fixes #24557.

In `alloc_tensor_range` the realloc result is written straight back to `*buffers` and used on the next line with no NULL check, so if realloc fails it leaks the old array and then writes through a NULL pointer. The other realloc calls in ggml-backend.cpp assert the result; this one doesn't.

This keeps the result in a temp and, on failure, frees the new buffer and the existing array and returns false. That's the same error path the function already takes when the buffer allocation itself fails.

Builds clean with `cc -fsyntax-only` here. I didn't run the full build matrix.

Disclosure: I used an AI tool to help find this bug and write the patch. It's an 8-line change and I've gone through it.