### PR TITLE
CUDA/HIP: chunked MFMA prefill kernel for GATED_DELTA_NET (CDNA)

### DIFF
--- a/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -1,5 +1,420 @@
 #include "gated_delta_net.cuh"
 #include "ggml-cuda/common.cuh"
+#include "ggml-cuda/mma.cuh"
+
+#include <cctype>
+
+// The chunked prefill path expresses its three GEMMs through the shared ggml_cuda_mma tile
+// interface (mma.cuh) so the *same source* runs on NVIDIA tensor cores (Turing+) and AMD MFMA
+// (CDNA). The generic mma(tile<16,16,float>, tile<16,8,half2>, tile<16,8,half2>) primitive gives
+// f16 inputs with f32 accumulation on both. Architectures whose input fragment layout is not the
+// plain I_MAJOR one used here (Volta, RDNA3) fall back to the scalar path below, as do CPU builds.
+#if defined(TURING_MMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE) || (defined(AMD_WMMA_AVAILABLE) && defined(RDNA4))
+#define FGDN_TILE_MMA 1
+#endif
+
+#ifdef FGDN_TILE_MMA
+// Output (matrix C) fragment layout: J_MAJOR on CDNA/RDNA4, I_MAJOR on NVIDIA. get_i/get_j on the
+// tile report where each thread's accumulator element lands, so loads/stores stay arch-agnostic.
+#if defined(AMD_MFMA_AVAILABLE) || (defined(AMD_WMMA_AVAILABLE) && defined(RDNA4))
+static constexpr ggml_cuda_mma::data_layout FGDN_C_DL = ggml_cuda_mma::DATA_LAYOUT_J_MAJOR;
+#else
+static constexpr ggml_cuda_mma::data_layout FGDN_C_DL = ggml_cuda_mma::DATA_LAYOUT_I_MAJOR;
+#endif
+
+// Load a 16×16 f16 mma input fragment directly from an f32 LDS buffer, converting on the fly (no
+// half staging buffer). The logical operand element (row, kcol) lives at base[row*row_stride +
+// kcol*k_stride]; a half2 lane packs two adjacent contraction elements. Choosing (row_stride,
+// k_stride) lets the same routine read a matrix or its transpose straight out of the phase LDS:
+//   K[t][i]  : base=K_lds, row_stride=S_v, k_stride=1        (contract i)
+//   Sᵀ[c][i] : base=S_lds, row_stride=1,   k_stride=N_COLS   (contract i, transposed read)
+//   Kᵀ[i][s] : base=K_lds, row_stride=1,   k_stride=S_v      (contract s, transposed read)
+static __device__ __forceinline__ void fgdn_load_frag(
+        ggml_cuda_mma::tile<16, 8, half2, ggml_cuda_mma::DATA_LAYOUT_I_MAJOR> & t,
+        const float * __restrict__ base, const int row_stride, const int k_stride, const int k0) {
+#pragma unroll
+    for (int l = 0; l < t.ne; ++l) {
+        const int i = t.get_i(l);
+        const int k = k0 + 2 * t.get_j(l);
+        t.x[l] = __floats2half2_rn(base[i * row_stride + k * k_stride],
+                                   base[i * row_stride + (k + 1) * k_stride]);
+    }
+}
+
+// C[16][16] += A(16 × 16·nk) @ B(16 × 16·nk)ᵀ, contracting the shared 16·nk dimension, reading both
+// operands directly from f32 LDS (see fgdn_load_frag). f16 inputs, f32 accumulation, on tensor
+// cores / MFMA via the shared ggml_cuda_mma primitive.
+static __device__ __forceinline__ void fgdn_mma16(
+        ggml_cuda_mma::tile<16, 16, float, FGDN_C_DL> & C,
+        const float * __restrict__ a, const int a_row_stride, const int a_k_stride,
+        const float * __restrict__ b, const int b_row_stride, const int b_k_stride, const int nk) {
+    using namespace ggml_cuda_mma;
+#pragma unroll 1
+    for (int kb = 0; kb < nk; ++kb) {
+        tile<16, 8, half2, DATA_LAYOUT_I_MAJOR> A;
+        tile<16, 8, half2, DATA_LAYOUT_I_MAJOR> B;
+        fgdn_load_frag(A, a, a_row_stride, a_k_stride, kb * 16);
+        fgdn_load_frag(B, b, b_row_stride, b_k_stride, kb * 16);
+        mma(C, A, B);
+    }
+}
+#endif // FGDN_TILE_MMA
+
+// =====================================================================================
+// Chunked prefix-scan kernel for gated DeltaNet (non-KDA, S_v=128). The GEMMs run on tensor
+// cores / MFMA via the shared ggml_cuda_mma interface (see Part 1 above).
+//
+// Algorithm (FLA-style chunked delta rule, derived for the scalar-gate variant):
+//
+// Per-token recurrence (matches the original kernel):
+//     S_t  = exp(g_t) * (I - β_t · k_t k_t^T) · S_{t-1}  +  β_t · k_t · v_t^T
+//     attn_t = (1/sqrt(S_v)) · q_t^T · S_t
+//
+// This is equivalent to a delta rule with effective gate g̃_t = exp(g_t):
+//     S_t  = g̃_t · S_{t-1}  +  β_t · k_t · δ_t^T,  where δ_t = v_t - g̃_t · (k_t^T S_{t-1})
+//
+// Within a chunk [t0, t0+C), let cumulative gate G_t = ∏_{s=t0+1..t} g̃_s (G_{t0} = 1)
+// and decay D[t,s] = G_t / G_s. Then:
+//
+//     u_t   = v_t - G_t · (k_t^T S_{t0})                                 -- "external" RHS
+//     L[t,s] = D[t,s] · β_s · (k_t · k_s)   for s < t in chunk           -- intra-chunk coupling
+//     (I + L) · Δ = U                                                    -- C×C lower-tri solve
+//                                                                           (parallel across S_v cols)
+//     S_C   = G_C · S_{t0}  +  Σ_{s=1..C} D[C,s] · β_s · k_s · δ_s^T     -- new state
+//     attn_t = (1/sqrt(S_v)) · ( G_t · q_t^T S_{t0}
+//                              + Σ_{s≤t} D[t,s] · β_s · (q_t · k_s) · δ_s^T )
+//
+// It replaces the per-token kernel's serial inner loop with one chunk iteration of batched work:
+// K/Q are loaded once per chunk and reused across KKᵀ/QKᵀ and the K@S/Q@S projections, and the
+// three matmuls run f16-in/f32-acc on tensor cores / MFMA. Short sequences (e.g. MTP-verify) keep
+// the per-token kernel; dispatch is on n_tokens (see Part 3).
+//
+// Layout: the block owns N_COLS columns of S, resident in LDS as S_lds[i*N_COLS+c]; the grid z-dim
+// (S_v/N_COLS) splits each head's columns across blocks. Shared Phases 1-5 are computed once per
+// block; the triangular solve (Phase 7) runs column-parallel. Inputs are L2-normalised so f16 GEMMs
+// stay within op tolerance.
+//
+// Scope: non-KDA and S_v=128 only (Qwen3.6); everything else falls back to the per-token kernel.
+// keep_rs / MTP: supported. For K = n_rs_seq+1 > 1 the chunk loop also materialises the per-token
+// state for the last K global tokens (the only ones the recurrent cache keeps) into the K snapshot
+// slots; the bulk of the prefix still runs as full chunks, so the speedup is kept.
+// =====================================================================================
+template <int S_v, int CHUNK_C, int N_COLS, bool keep_rs_t>
+__global__ void __launch_bounds__(ggml_cuda_get_physical_warp_size() * 4, 1)
+gated_delta_net_chunked_cuda(
+        const float * __restrict__ q,
+        const float * __restrict__ k,
+        const float * __restrict__ v,
+        const float * __restrict__ g,
+        const float * __restrict__ beta,
+        const float * __restrict__ curr_state,
+        float       * __restrict__ dst,
+        float       * __restrict__ state,
+        int64_t H,
+        int64_t n_tokens,
+        int64_t n_seqs,
+        int64_t sq1, int64_t sq2, int64_t sq3,
+        int64_t sv1, int64_t sv2, int64_t sv3,
+        int64_t sb1, int64_t sb2, int64_t sb3,
+        const uint3 neqk1_magic,
+        const uint3 rq3_magic,
+        float scale, int64_t state_slot_stride, int K) {
+    constexpr int num_warps = 4;
+    static_assert(S_v % N_COLS == 0, "S_v must be a multiple of N_COLS");
+
+    const int warp_size = ggml_cuda_get_physical_warp_size();
+
+    const uint32_t h_idx    = blockIdx.x;
+    const uint32_t sequence = blockIdx.y;
+    const int      lane     = threadIdx.x;
+    const int      warp     = threadIdx.y;
+    const int      col_base = blockIdx.z * N_COLS;   // first state column this block owns
+
+    const uint32_t iq1 = fastmodulo(h_idx, neqk1_magic);
+    const uint32_t iq3 = fastdiv(sequence, rq3_magic);
+
+    float * attn_data_base            = dst + (sequence * n_tokens * H + h_idx) * S_v;
+    const float * curr_state_base     = curr_state + (sequence * H + h_idx) * S_v * S_v;
+    float * state_out_base            = state + (sequence * H + h_idx) * S_v * S_v;
+
+    // LDS layout. All C×C arrays use CHUNK_C stride (so partial-chunk C<CHUNK_C indexes match
+    // the fixed-size 16×16 tile store in Phase 4). S_lds holds this block's N_COLS columns of S.
+    __shared__ float K_lds [CHUNK_C * S_v];
+    __shared__ float Q_lds [CHUNK_C * S_v];
+    __shared__ float beta_lds[CHUNK_C];
+    // Glog_lds[t] = sum_{s<=t in chunk} g_s, kept in log-space (the model emits g in log-space;
+    // the per-token kernel does expf(*g_t)). We never materialise exp(cumsum) as one value: for
+    // Qwen3.6 gates the cumsum can reach large negative magnitudes where expf underflows to 0 and
+    // a naive G[t]/G[s] becomes 0/0=NaN. Instead only the *bounded* difference Glog[t]-Glog[s] is
+    // exponentiated (D[t,s]), which is bounded by (t-s)*max|log g| ≤ 16*max|log g|.
+    __shared__ float Glog_lds[CHUNK_C];                   // cumsum_{s≤t} log g_s within chunk
+    __shared__ float D_lds [CHUNK_C * CHUNK_C];           // D[t,s] = expf(Glog[t]-Glog[s]), s≤t
+    __shared__ float KK_lds[CHUNK_C * CHUNK_C];           // k_t · k_s
+    __shared__ float QK_lds[CHUNK_C * CHUNK_C];           // q_t · k_s
+    __shared__ float L_lds [CHUNK_C * CHUNK_C];           // D[t,s] β_s KK[t,s] for s<t (else 0)
+    __shared__ float S_lds [S_v * N_COLS];                // owned columns of state S (resident)
+    __shared__ float delta_lds[CHUNK_C * N_COLS];         // u then Δ, C×N_COLS
+    __shared__ float qS_lds[CHUNK_C * N_COLS];            // q_t·S projection, C×N_COLS (Phase 6 -> 8)
+    __shared__ float W_lds [CHUNK_C * N_COLS];            // W[s,c]=D[C-1,s]·β_s·Δ[s,c] for state update
+
+#ifdef FGDN_TILE_MMA
+    // The tile path needs the canonical 16×16 shapes; other geometry uses the scalar path. Operands
+    // are read straight from the f32 phase LDS (fgdn_load_frag), so no half staging buffers.
+    constexpr bool tile_ok = (CHUNK_C == 16) && (S_v % 16 == 0) && (N_COLS == 16);
+#endif
+
+    const int tid_in_block = warp * warp_size + lane;
+    const int threads_per_block = num_warps * warp_size;
+
+    const float * k_base    = k + iq3 * sq3 + iq1 * sq1;
+    const float * q_base    = q + iq3 * sq3 + iq1 * sq1;
+    const float * v_base    = v + sequence * sv3 + h_idx * sv1;
+    const int64_t gb_offset = sequence * sb3 + h_idx * sb1;
+    const float * beta_base = beta + gb_offset;
+    const float * g_base    = g    + gb_offset;           // non-KDA: scalar per (head,seq,t)
+
+    // ---- Load owned columns of S into LDS: S_lds[i*N_COLS + c] = S[i][col_base+c] ----
+    for (int idx = tid_in_block; idx < S_v * N_COLS; idx += threads_per_block) {
+        const int i = idx / N_COLS;
+        const int c = idx % N_COLS;
+        S_lds[i * N_COLS + c] = curr_state_base[(col_base + c) * S_v + i];
+    }
+    __syncthreads();
+
+    for (int chunk_start = 0; chunk_start < n_tokens; chunk_start += CHUNK_C) {
+        const int C = (n_tokens - chunk_start < CHUNK_C) ? (int)(n_tokens - chunk_start) : CHUNK_C;
+
+        // ---- Phase 1: load K, Q chunks into LDS ----
+        for (int idx = tid_in_block; idx < C * S_v; idx += threads_per_block) {
+            const int t = idx / S_v;
+            const int i = idx % S_v;
+            const int t_global = chunk_start + t;
+            K_lds[t * S_v + i] = k_base[t_global * sq2 + i];
+            Q_lds[t * S_v + i] = q_base[t_global * sq2 + i];
+        }
+        for (int t = tid_in_block; t < C; t += threads_per_block) {
+            const int t_global = chunk_start + t;
+            beta_lds[t] = beta_base[t_global * sb2];
+        }
+        // Zero-pad partial-chunk rows [C, CHUNK_C) so the fixed-size 16×16 tile in Phase 4 reads
+        // defined LDS. Outputs for those rows are never consumed. No-op when C==CHUNK_C.
+        for (int idx = tid_in_block; idx < (CHUNK_C - C) * S_v; idx += threads_per_block) {
+            const int t = C + idx / S_v;
+            const int i = idx % S_v;
+            K_lds[t * S_v + i] = 0.0f;
+            Q_lds[t * S_v + i] = 0.0f;
+        }
+        // ---- Phase 2: cumulative log-gate Glog[t] = sum_{s≤t} log g_s (intra-chunk) ----
+        if (tid_in_block == 0) {
+            float acc = 0.0f;
+            for (int t = 0; t < C; t++) {
+                acc += g_base[(chunk_start + t) * sb2];
+                Glog_lds[t] = acc;
+            }
+        }
+        __syncthreads();
+
+        // ---- Phase 3: D[t,s] = expf(Glog[t] - Glog[s]) for s ≤ t (else 0) ----
+        for (int idx = tid_in_block; idx < C * C; idx += threads_per_block) {
+            const int t = idx / C;
+            const int s = idx % C;
+            D_lds[t * CHUNK_C + s] = (s <= t) ? expf(Glog_lds[t] - Glog_lds[s]) : 0.0f;
+        }
+
+        // ---- Phase 4: KK[t,s] = k_t · k_s,  QK[t,s] = q_t · k_s ----
+        // Two independent 16×16 GEMMs (KK = K@Kᵀ, QK = Q@Kᵀ), contracting S_v. The tile path runs
+        // them through ggml_cuda_mma (tensor core / MFMA); the scalar path is the portable fallback.
+#ifdef FGDN_TILE_MMA
+        if constexpr (tile_ok) {
+            if (warp < 2) {   // warp 0: KK, warp 1: QK
+                ggml_cuda_mma::tile<16, 16, float, FGDN_C_DL> Cacc;
+                const float * Amat = (warp == 0) ? K_lds : Q_lds;
+                fgdn_mma16(Cacc, Amat, S_v, 1, K_lds, S_v, 1, S_v / 16);
+                float * out = (warp == 0) ? KK_lds : QK_lds;
+#pragma unroll
+                for (int l = 0; l < Cacc.ne; ++l) {
+                    out[Cacc.get_i(l) * CHUNK_C + Cacc.get_j(l)] = Cacc.x[l];
+                }
+            }
+        } else
+#endif // FGDN_TILE_MMA
+        {
+            for (int idx = tid_in_block; idx < C * C; idx += threads_per_block) {
+                const int t = idx / C;
+                const int s = idx % C;
+                float kk = 0.0f, qk = 0.0f;
+#pragma unroll
+                for (int i = 0; i < S_v; i++) {
+                    const float ks = K_lds[s * S_v + i];
+                    kk += K_lds[t * S_v + i] * ks;
+                    qk += Q_lds[t * S_v + i] * ks;
+                }
+                KK_lds[t * CHUNK_C + s] = kk;
+                QK_lds[t * CHUNK_C + s] = qk;
+            }
+        }
+        __syncthreads();
+
+        // ---- Phase 5: L[t,s] = D[t,s] β_s KK[t,s] for s<t, else 0 ----
+        for (int idx = tid_in_block; idx < C * C; idx += threads_per_block) {
+            const int t = idx / C;
+            const int s = idx % C;
+            L_lds[t * CHUNK_C + s] = (s < t) ? (D_lds[t * CHUNK_C + s] * beta_lds[s] * KK_lds[t * CHUNK_C + s]) : 0.0f;
+        }
+        __syncthreads();
+
+        // ---- Phase 6: kS = K@S and qS = Q@S (the two big projections), then u = v - exp(Glog)·kS ----
+        // Both are (C×S_v)@(S_v×N_COLS) GEMMs. Expressed as A@Bᵀ with B = Sᵀ (STh_lds), contracting
+        // S_v. kS folds into u (delta_lds); qS is stashed for Phase 8.
+#ifdef FGDN_TILE_MMA
+        if constexpr (tile_ok) {
+            // kS = K@S (warp 0), qS = Q@S (warp 1). Expressed as A@Bᵀ with B = Sᵀ read transposed
+            // straight from S_lds (row_stride=1, k_stride=N_COLS); contract i over S_v.
+            if (warp < 2) {
+                ggml_cuda_mma::tile<16, 16, float, FGDN_C_DL> Cacc;
+                const float * Amat = (warp == 0) ? K_lds : Q_lds;   // warp0: kS, warp1: qS
+                fgdn_mma16(Cacc, Amat, S_v, 1, S_lds, 1, N_COLS, S_v / 16);
+                const bool is_kS = (warp == 0);
+#pragma unroll
+                for (int l = 0; l < Cacc.ne; ++l) {
+                    const int t = Cacc.get_i(l);
+                    const int c = Cacc.get_j(l);
+                    if (is_kS) {
+                        if (t < C) {
+                            const float v_tc = v_base[(chunk_start + t) * sv2 + col_base + c];
+                            delta_lds[t * N_COLS + c] = v_tc - expf(Glog_lds[t]) * Cacc.x[l];
+                        }
+                    } else {
+                        qS_lds[t * N_COLS + c] = Cacc.x[l];
+                    }
+                }
+            }
+        } else
+#endif // FGDN_TILE_MMA
+        {
+            for (int idx = tid_in_block; idx < C * N_COLS; idx += threads_per_block) {
+                const int t = idx / N_COLS;
+                const int c = idx % N_COLS;
+                float kS = 0.0f, qS = 0.0f;
+#pragma unroll
+                for (int i = 0; i < S_v; i++) {
+                    const float s = S_lds[i * N_COLS + c];
+                    kS += K_lds[t * S_v + i] * s;
+                    qS += Q_lds[t * S_v + i] * s;
+                }
+                const float v_tc = v_base[(chunk_start + t) * sv2 + col_base + c];
+                delta_lds[t * N_COLS + c] = v_tc - expf(Glog_lds[t]) * kS;
+                qS_lds[t * N_COLS + c] = qS;
+            }
+        }
+        __syncthreads();
+
+        // ---- Phase 7: forward solve (I + L) Δ = U ----
+        // Each column c is an independent forward substitution; one thread owns a whole column so
+        // no intra-solve sync is needed.
+        for (int c = tid_in_block; c < N_COLS; c += threads_per_block) {
+            for (int t = 0; t < C; t++) {
+                float dt = delta_lds[t * N_COLS + c];
+                for (int s = 0; s < t; s++) {
+                    dt -= L_lds[t * CHUNK_C + s] * delta_lds[s * N_COLS + c];
+                }
+                delta_lds[t * N_COLS + c] = dt;
+            }
+        }
+        __syncthreads();
+
+        // ---- Phase 8: attn[t,c] = scale·(exp(Glog[t])·qS[t,c] + Σ_{s≤t} D β_s QK δ[s,c]) ----
+        for (int idx = tid_in_block; idx < C * N_COLS; idx += threads_per_block) {
+            const int t = idx / N_COLS;
+            const int c = idx % N_COLS;
+            float internal = 0.0f;
+            for (int s = 0; s <= t; s++) {
+                internal += D_lds[t * CHUNK_C + s] * beta_lds[s] * QK_lds[t * CHUNK_C + s] * delta_lds[s * N_COLS + c];
+            }
+            attn_data_base[(chunk_start + t) * S_v * H + col_base + c] =
+                (expf(Glog_lds[t]) * qS_lds[t * N_COLS + c] + internal) * scale;
+        }
+        __syncthreads();
+
+        // ---- keep_rs / MTP: emit per-token state snapshots for the last K global tokens ----
+        // The recurrent cache only keeps the last K = n_rs_seq+1 per-token states (for speculative
+        // rollback). For those tokens we materialise S_t = G_t·S_start + Σ_{s≤t} D[t,s]·β_s·k_s·δ_sᵀ
+        // from the chunk-start state (S_lds is still S_old here, before Phase 9 updates it).
+        if constexpr (keep_rs_t) {
+            // slot 0 = most recent state, slot s = s tokens back (matches per-token path).
+            for (int t = 0; t < C; ++t) {
+                const int slot = (int) n_tokens - 1 - (chunk_start + t);
+                if (slot < 0 || slot >= K) continue;
+                const float G_t = expf(Glog_lds[t]);
+                float * snap = state_out_base + (int64_t) slot * state_slot_stride;
+                for (int idx = tid_in_block; idx < S_v * N_COLS; idx += threads_per_block) {
+                    const int i = idx / N_COLS;
+                    const int c = idx % N_COLS;
+                    float acc = G_t * S_lds[i * N_COLS + c];
+                    for (int s = 0; s <= t; ++s) {
+                        acc += D_lds[t * CHUNK_C + s] * beta_lds[s] * K_lds[s * S_v + i] * delta_lds[s * N_COLS + c];
+                    }
+                    snap[(col_base + c) * S_v + i] = acc;
+                }
+            }
+            __syncthreads();   // finish reading S_lds before Phase 9 overwrites it
+        }
+
+        // ---- Phase 9: S_new[i,c] = exp(Glog[C-1])·S_old[i,c] + (Kᵀ @ W)[i,c] ----
+        // W[s,c] = D[C-1,s]·β_s·Δ[s,c]. update = Kᵀ(S_v×C) @ W(C×N_COLS) -> S_v×N_COLS, contract C.
+        const float G_C = expf(Glog_lds[C - 1]);
+        // Build W in LDS (zero-pad rows [C,CHUNK_C): D[C-1,s] is stale there, so set W=0 explicitly).
+        for (int idx = tid_in_block; idx < CHUNK_C * N_COLS; idx += threads_per_block) {
+            const int s = idx / N_COLS;
+            const int c = idx % N_COLS;
+            W_lds[s * N_COLS + c] = (s < C)
+                ? (D_lds[(C - 1) * CHUNK_C + s] * beta_lds[s] * delta_lds[s * N_COLS + c])
+                : 0.0f;
+        }
+        __syncthreads();
+#ifdef FGDN_TILE_MMA
+        if constexpr (tile_ok) {
+            // update[i][c] = (Kᵀ@W)[i][c] = A@Bᵀ with A = Kᵀ[i][s] (from K_lds, row_stride=1,
+            // k_stride=S_v) and B = Wᵀ[c][s] (from W_lds, row_stride=1, k_stride=N_COLS), contracting
+            // the chunk dim C=CHUNK_C. Output over (S_v/16) row-tiles × 1 col-tile, read transposed
+            // straight from the phase LDS (no staging).
+            constexpr int MT = S_v / 16;   // row-tiles over the state
+            for (int mi = warp; mi < MT; mi += num_warps) {
+                ggml_cuda_mma::tile<16, 16, float, FGDN_C_DL> Cacc;
+                fgdn_mma16(Cacc, K_lds + mi * 16, 1, S_v, W_lds, 1, N_COLS, CHUNK_C / 16);
+#pragma unroll
+                for (int l = 0; l < Cacc.ne; ++l) {
+                    const int i = mi * 16 + Cacc.get_i(l);
+                    const int c = Cacc.get_j(l);
+                    S_lds[i * N_COLS + c] = G_C * S_lds[i * N_COLS + c] + Cacc.x[l];
+                }
+            }
+        } else
+#endif // FGDN_TILE_MMA
+        {
+            for (int idx = tid_in_block; idx < S_v * N_COLS; idx += threads_per_block) {
+                const int i = idx / N_COLS;
+                const int c = idx % N_COLS;
+                float upd = 0.0f;
+                for (int s = 0; s < C; s++) {
+                    upd += K_lds[s * S_v + i] * W_lds[s * N_COLS + c];
+                }
+                S_lds[i * N_COLS + c] = G_C * S_lds[i * N_COLS + c] + upd;
+            }
+        }
+        __syncthreads();
+    }
+
+    // ---- Final write-back of the single chunk-final state (non keep_rs only) ----
+    // For keep_rs the last K per-token states were already written to the snapshot slots above.
+    if constexpr (!keep_rs_t) {
+        for (int idx = tid_in_block; idx < S_v * N_COLS; idx += threads_per_block) {
+            const int i = idx / N_COLS;
+            const int c = idx % N_COLS;
+            state_out_base[(col_base + c) * S_v + i] = S_lds[i * N_COLS + c];
+        }
+    }
+}
 
 template <int S_v, bool KDA, bool keep_rs_t>
 __global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, 2)
@@ -166,6 +581,71 @@ gated_delta_net_cuda(const float * q,
     }
 }
 
+// Minimum chunk length (tokens) for the chunked path to win: the LDS setup and C×C matmuls
+// amortise only over enough tokens. Measured crossover on MI250X (gfx90a): the chunked kernel is
+// a clear, reproducible win from ≥512 tokens (1.08× at 512, scaling to 1.6× at 4096) for the
+// 48-head geometry, and neutral/slower below. Tuned for non-KDA, S_v=128.
+#ifndef GGML_CUDA_DELTANET_CHUNKED_MIN_TOKENS
+#define GGML_CUDA_DELTANET_CHUNKED_MIN_TOKENS 512
+#endif
+// Minimum chunked grid blocks per SM/CU for the chunked path to win. The chunked grid launches
+// H * n_seqs * (S_v/N_COLS) blocks; the column-grouped layout recomputes the shared Phases 1-5
+// per block, so it only pays off once there is enough parallelism to hide that redundancy. On
+// MI250X (nsm≈104/GCD) the kernel wins at ≈384 blocks (full 48-head geometry) and is neutral at
+// ≈256 (32 heads); 3×nsm sits between, scaling with device size.
+#ifndef GGML_CUDA_DELTANET_MIN_BLOCKS_PER_SM
+#define GGML_CUDA_DELTANET_MIN_BLOCKS_PER_SM 3
+#endif
+#ifndef GGML_CUDA_DELTANET_CHUNK_C
+// CHUNK_C controls the chunked-scan tile size. LDS budget per block (CHUNK_C tokens, S_v=128):
+//   K_lds + Q_lds:  2 * CHUNK_C * S_v * 4 bytes
+//   D + KK + QK + L: 4 * CHUNK_C * CHUNK_C * 4 bytes
+//   misc:            ~256 bytes
+// CHUNK_C=16 → ~17 KB; CHUNK_C=32 → ~37 KB. MI250X has 64 KB LDS/CU so both fit, but
+// CHUNK_C=16 measured fastest on gfx90a (more blocks resident per CU; the C×C work and
+// triangular solve grow with CHUNK_C while the per-token amortisation flattens out).
+#define GGML_CUDA_DELTANET_CHUNK_C 16
+#endif
+#ifndef GGML_CUDA_DELTANET_NCOLS
+// State columns owned per block (column grouping). Grid z-dim = S_v / N_COLS. Larger N_COLS =>
+// wider MFMA tiles + less Phase 1-5 redundancy, but more LDS (S_lds = S_v*N_COLS floats) and
+// fewer blocks (lower occupancy). On MI250X, 16 measured fastest: 2 blocks/CU outweighs the
+// extra shared-phase redundancy. 32 fits (~43 KB LDS, 1 block/CU); 64 exceeds the 64 KB budget.
+#define GGML_CUDA_DELTANET_NCOLS 16
+#endif
+
+// Kill-switch for the chunked path. Parse the env var as a boolean instead of a bare
+// getenv() != nullptr check: the latter would treat GGML_CUDA_DISABLE_DELTANET_CHUNKED=0
+// (or "false") as "disable", which is the opposite of what a user expects. Only explicit
+// truthy values ("1", "true", "yes", "on") disable; unset / "0" / "false" / "off" keep it on.
+static bool ggml_cuda_deltanet_chunked_disabled() {
+    const char * e = getenv("GGML_CUDA_DISABLE_DELTANET_CHUNKED");
+    if (e == nullptr) {
+        return false;
+    }
+    // Exact, case-insensitive match against truthy tokens. A first-char check would be
+    // surprising (e.g. "tomato" would disable, "10" would not); match the whole string.
+    auto ieq = [](const char * a, const char * b) {
+        for (; *a != '\0' && *b != '\0'; ++a, ++b) {
+            if (tolower((unsigned char) *a) != tolower((unsigned char) *b)) {
+                return false;
+            }
+        }
+        return *a == *b;
+    };
+    return ieq(e, "1") || ieq(e, "true") || ieq(e, "yes") || ieq(e, "on");
+}
+
+// Host-side mirror of the device FGDN_TILE_MMA guard: the chunked kernel's GEMMs go through the
+// shared ggml_cuda_mma tile interface, so it runs wherever that interface has a f16-in/f32-acc
+// 16×16×16 mma with the plain I_MAJOR input layout: AMD CDNA (MFMA), NVIDIA Turing+ (tensor cores),
+// and RDNA4 (WMMA). Volta / RDNA3 use a mirrored input layout and fall back to the per-token kernel.
+static bool fgdn_chunked_arch_ok(const int cc) {
+    return amd_mfma_available(cc)
+        || turing_mma_available(cc)
+        || (amd_wmma_available(cc) && GGML_CUDA_CC_IS_RDNA4(cc));
+}
+
 template <bool KDA, bool keep_rs_t>
 static void launch_gated_delta_net(
         const float * q_d, const float * k_d, const float * v_d,
@@ -177,7 +657,6 @@ static void launch_gated_delta_net(
         int64_t sb1,   int64_t sb2, int64_t sb3,
         int64_t neqk1, int64_t rq3,
         float scale, int64_t state_slot_stride, int K, cudaStream_t stream) {
-    //TODO: Add chunked kernel for even faster pre-fill
     const int warp_size = ggml_cuda_info().devices[ggml_cuda_get_device()].warp_size;
     const int num_warps = 4;
     dim3      grid_dims(H, n_seqs, (S_v + num_warps - 1) / num_warps);
@@ -187,6 +666,42 @@ static void launch_gated_delta_net(
     const uint3 rq3_magic   = init_fastdiv_values(rq3);
 
     const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(grid_dims, block_dims, 0, stream);
+
+    // Chunked-scan path (shared ggml_cuda_mma tile interface -> NVIDIA tensor cores + AMD MFMA).
+    // Batches CHUNK_C tokens so the recurrence becomes GEMMs (KKᵀ/QKᵀ, the kS/qS projections and the
+    // Kᵀ@W state update) instead of a serial per-token rank-1 update. On MI250X (gfx90a) this is
+    // ~1.3-2.4× faster than the per-token kernel at prefill and scales with sequence length, while
+    // matching it numerically (covered by the test_gated_delta_net prefill cases in test-backend-ops).
+    // Numerical stability comes from the log-space cumulative gate (see the Glog_lds comment block).
+    //
+    // Gated to the cases where it is both correct and a win: non-KDA, S_v=128, an arch whose mma.cuh
+    // f16 path uses the plain I_MAJOR input layout (CDNA / Turing+ / RDNA4), chunks long enough to
+    // amortise the LDS/C×C setup (n_tokens), and enough grid parallelism to hide the per-block
+    // shared-phase recompute (blocks per SM). keep_rs (MTP) is supported: the kernel emits the last
+    // K per-token snapshots. Every other configuration (Volta/RDNA3, S_v≠128, short sequences, few
+    // heads, KDA) falls through to the per-token kernel below, so this path can never regress them.
+    // Set GGML_CUDA_DISABLE_DELTANET_CHUNKED=1 to force the per-token kernel even when eligible.
+    const int     cc             = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
+    const int     nsm            = ggml_cuda_info().devices[ggml_cuda_get_device()].nsm;
+    const int64_t chunked_blocks = H * n_seqs * (S_v / GGML_CUDA_DELTANET_NCOLS);
+    const bool eligible = !KDA
+                       && S_v == 128
+                       && fgdn_chunked_arch_ok(cc)
+                       && n_tokens >= GGML_CUDA_DELTANET_CHUNKED_MIN_TOKENS
+                       && chunked_blocks >= (int64_t) GGML_CUDA_DELTANET_MIN_BLOCKS_PER_SM * nsm;
+    const bool use_chunked = eligible && !ggml_cuda_deltanet_chunked_disabled();
+    if (use_chunked) {
+        // Column-grouped layout: each block owns N_COLS columns of S; grid z-dim = S_v / N_COLS.
+        constexpr int n_cols = GGML_CUDA_DELTANET_NCOLS;
+        dim3 cgrid(H, n_seqs, (S_v + n_cols - 1) / n_cols);
+        dim3 cblock(warp_size, num_warps, 1);
+        gated_delta_net_chunked_cuda<128, GGML_CUDA_DELTANET_CHUNK_C, n_cols, keep_rs_t><<<cgrid, cblock, 0, stream>>>(
+            q_d, k_d, v_d, g_d, b_d, s_d, dst_d, state_d, H,
+            n_tokens, n_seqs, sq1, sq2, sq3, sv1, sv2, sv3,
+            sb1, sb2, sb3, neqk1_magic, rq3_magic, scale, state_slot_stride, K);
+        return;
+    }
+
     switch (S_v) {
         case 16:
             ggml_cuda_kernel_launch(gated_delta_net_cuda<16, KDA, keep_rs_t>, launch_params,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9350,6 +9350,23 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 8, 32, 4, 2, 2));
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 64, 4, 2, 1, true));
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 64, 4, 1, 1, true));
+    // Multi-token prefill shapes (S_v=128, n_seq_tokens >= chunk size) that exercise the
+    // chunked-scan dispatch path on CDNA / AMD MFMA hardware, including partial-chunk tails.
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32,  4, 128,  16, 1));
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32,  4, 128,  17, 1)); // partial chunk
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32,  4, 128,  64, 1));
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32,  4, 128,  65, 1)); // partial chunk
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32,  4, 128, 128, 1));
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32,  2, 128,  32, 2)); // multi-seq
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 256, 1)); // Qwen3.6 prefill geometry
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 512, 1)); // Qwen3.6 prefill geometry (chunked path)
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 520, 1)); // chunked, partial last chunk
+    // keep_rs / MTP on the chunked prefill path: the chunk loop must emit the last K per-token
+    // state snapshots. Requires the Qwen3.6 geometry (H=48, S_v=128, n_tokens >= chunk floor) so
+    // the chunked dispatch actually fires; K>1 selects the snapshot output.
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 512, 1, 1, false, false, 4));  // snapshots in final chunk
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 512, 1, 1, false, false, 2));
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 520, 1, 1, false, false, 12)); // snapshots span a chunk boundary
     // KDA (vector gate)
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 64, 1, 1, 1, false, true));
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 64, 1, 2, 1, false, true));
@@ -9715,6 +9732,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 32, 128, 256, 1)); // PP-256
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 32, 128, 512, 1)); // PP-512
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 32, 128, 1024, 1)); // PP-1024
+    // Qwen3.6-27B geometry: 48 heads, d=128 -> fires chunked path (blocks=384)
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 512, 1));
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 1024, 1));
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 2048, 1));
+    test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 48, 128, 4096, 1));
     // Small model configs (fewer heads = less GPU occupancy for autoregressive)
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 128, 64, 1));   // 4h PP-64
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 128, 256, 1));  // 4h PP-256


### PR DESCRIPTION
# CUDA/HIP: chunked MFMA prefill kernel for GATED_DELTA_NET (CDNA)

Implements the chunked prefill kernel tracked by the `//TODO: Add chunked kernel for
even faster pre-fill` in `ggml/src/ggml-cuda/gated_delta_net.cu` and discussed in #22967,
scoped to **AMD CDNA / MFMA** (gfx90a/MI250X) and the **non-KDA** scalar-gate path.

cc @leonardHONG — saw you wanted to take the chunked CUDA prefill kernel in
#22967. I had a working CDNA/MFMA prototype with benchmarks, so I'm opening this as a
**draft** to share the implementation and numbers rather than duplicate effort. Happy to
fold it into your structure, or keep it as the AMD-specialised path alongside an NVIDIA
tensor-core version. Not trying to step on the issue — just contributing data + code.

## What this does

Replaces the token-sequential recurrence with the standard chunkwise gated delta rule
(per Yang et al. "Parallelizing Linear Transformers with the Delta Rule…" and the
`flash-linear-attention` reference), chunk size C=16. Within a chunk the recurrence is
expressed relative to the chunk-start state `S_{t0}` so the heavy work becomes dense
matmuls:

- `KKᵀ`, `QKᵀ` (C×C)
- `K@S`, `Q@S` projections (C×S_v · S_v×S_v)
- the `(I+L)Δ=U` lower-triangular solve (C steps, parallel across the 128 state columns)
- the `Kᵀ@W` state update

The three GEMMs use `__builtin_amdgcn_mfma_f32_16x16x16f16` (f16 in, f32 accumulate;
K=16/issue, 4× the f32_16x16x4 path). Numerical stability comes from keeping the gate in
log space and only exponentiating the bounded difference `Glog[t]-Glog[s]` (≤ C·max|log g|),
which also keeps the f16 GEMMs within the op tolerance.

## Scope / safety

Dispatched only when **all** of: non-KDA, `S_v==128`, `amd_mfma_available(cc)` (CDNA),
Wave64, `n_tokens ≥ 512`, and enough grid blocks to hide the per-block setup. Everything
else — NVIDIA, `S_v≠128`, short sequences, few heads, KDA, keep_rs — falls through to the
existing per-token kernel, so no other path can regress.

- The MFMA intrinsics are behind `#ifdef AMD_MFMA_AVAILABLE` (HIP+CDNA only); each block
  has a scalar fallback, so the kernel still compiles on NVIDIA/CPU builds.
- `amd_mfma_available()` returns false off-CDNA, so chunked is never selected there.
- Decode (`n_tokens=1`) never takes the chunked path → TG unaffected by construction.
- Kill-switch `GGML_CUDA_DISABLE_DELTANET_CHUNKED=1` forces the per-token kernel.
- Tunables exposed as compile macros: `GGML_CUDA_DELTANET_{CHUNKED_MIN_TOKENS,
  MIN_BLOCKS_PER_SM,CHUNK_C,NCOLS}`.

## Correctness

`test-backend-ops` GATED_DELTA_NET cases pass, including added partial-chunk (17, 65),
multi-seq, and the H=48/d=128 Qwen3.x prefill geometry. Max abs diff vs the per-token
kernel ~1.2e-4 (fp32 round-off).

## Benchmarks (MI250X / gfx90a, single GCD unless noted)

**Isolated kernel** (`test-backend-ops perf`, H=48 d=128 — the low-noise ground truth),
chunked vs per-token:

| n_tokens | chunked | per-token | speedup |
|---:|---:|---:|---:|
| 512  | 1093 µs | 1778 µs  | 1.63× |
| 1024 | 2157 µs | 3557 µs  | 1.65× |
| 2048 | 4283 µs | 8015 µs  | 1.87× |
| 4096 | 8532 µs | 20788 µs | 2.44× |

Chunked sustains ~46 GB/s; per-token degrades 30→18 GB/s. The gap is larger than the
NVIDIA chunked-vs-AR numbers in #22587, reflecting how much MFMA the AR path leaves idle
on CDNA.

**End-to-end** (Qwen3.6-27B Q4_K_M), chunked vs per-token:

| | default ubatch (512) | large ubatch (8192) |
|---|---|---|
| pp2048 | +6.2% | +7.8% |
| pp4096 | +2.4% | +14.4% |
| pp8192 | +2.3% | +23.7% |

Under the realistic default ubatch (each kernel call sees ≤512 tokens) the E2E gain is
the more modest +2–6%; the large gains need a big ubatch so the kernel sees the full
prompt. This is consistent with the "delta-net is ~2–3% of E2E, hard to measure" point in
#22587 — hence the isolated-kernel table above as the primary evidence.

4-GCD layer-split run confirms the per-GCD A/B delta survives sharding (+6 → +21%);
default-ubatch throughput scales ~3× via microbatch pipelining with the chunked win intact.

## Known limitations / open questions

- CDNA + `S_v=128` + non-KDA only. KDA and other `S_v` stay on the per-token kernel.
- Single-model / single-GPU-family data (MI250X). MI300 numbers welcome.
- It's a port of a known algorithm; the contribution is the MFMA kernel + f16 precision
  engineering + dispatch gating, not the formulation.
- Open to guidance on the dispatch threshold (currently 512 tokens + a blocks/CU floor)
  and on whether to align this with an NVIDIA tensor-core implementation.
