### PR TITLE
CUDA: don't route RDNA3.5 flash attention to the rocWMMA kernel

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -822,9 +822,9 @@ static __global__ void flash_attn_tile(
     // Skip unused kernel variants for faster compilation:
 
     if (
-#ifdef GGML_USE_WMMA_FATTN
+#if defined(GGML_USE_WMMA_FATTN) && !defined(RDNA3_5)
             (ncols2 != 1 && DV != 40 && DV != 72 && DV != 512) ||
-#endif // GGML_USE_WMMA_FATTN
+#endif // defined(GGML_USE_WMMA_FATTN) && !defined(RDNA3_5)
             (use_logit_softcap && !(DV == 128 || DV == 256 || DV == 512))
     ) {
         GGML_UNUSED_VARS(Q, K, V, mask, sinks, KV_max, dst, dst_meta, scale,

--- a/ggml/src/ggml-cuda/fattn-wmma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-wmma-f16.cuh
@@ -28,7 +28,7 @@ static bool ggml_cuda_should_use_wmma_fattn(const int cc) {
     return false;
 #else
     if ((GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) == GGML_CUDA_CC_VOLTA) ||
-        GGML_CUDA_CC_IS_RDNA3(cc) || GGML_CUDA_CC_IS_MTHREADS(cc)) {
+        GGML_CUDA_CC_IS_RDNA3_0(cc) || GGML_CUDA_CC_IS_MTHREADS(cc)) {
         return true;
     } else if (GGML_CUDA_CC_IS_CDNA(cc)){
 #if defined(GGML_HIP_ROCWMMA_FATTN) && (ROCWMMA_VERSION_MAJOR < 2 || ROCWMMA_VERSION_MINOR > 0 || ROCWMMA_VERSION_PATCH > 0)


### PR DESCRIPTION
## Overview

On RDNA3.5 (gfx1150 / gfx1151, e.g. Strix Halo APUs), building with `GGML_HIP_ROCWMMA_FATTN=ON` regresses flash-attention **prefill** — scaling with context length, up to ~**-42%** at `pp8192` for a DV=256 MoE model — while `-fa 0` and token generation are unaffected (#24437).

The regression is a **kernel-selection** issue, not a math bug. `ggml_cuda_should_use_wmma_fattn()` enables the rocWMMA FA kernel for the entire `GGML_CUDA_CC_IS_RDNA3()` family, which lumps RDNA3.5 APUs together with RDNA3.0 discrete GPUs. The rocWMMA FA kernel that benefits the discrete parts is slower than the tile / native-mma path on RDNA3.5.

This PR narrows the runtime gate to `GGML_CUDA_CC_IS_RDNA3_0()`:
- **RDNA3.0** discrete GPUs (RX 7000) keep using the rocWMMA kernel **unchanged**.
- **RDNA3.5** falls back to the tile / native-mma path.

A second, coupled change is required: in a rocWMMA build (`GGML_USE_WMMA_FATTN`), `fattn-tile.cuh` compile-time-stubs the tile `DV=256, ncols2 != 1` variants to `NO_DEVICE_CODE` (it assumes WMMA covers them). So the runtime gate change **alone** aborts at runtime (`HSA_STATUS_ERROR_EXCEPTION`) on RDNA3.5. The second hunk makes that compile-time skip arch-aware (`!defined(RDNA3_5)`) so the tile variant is emitted.

## Additional information

**Scope / blast radius** — the change only affects RDNA3.5. `RDNA3.0`, `CDNA`, `NVIDIA` and `MTHREADS` selection is unchanged (the runtime gate keeps `RDNA3.0` on rocWMMA, and the compile-time `!defined(RDNA3_5)` guard only alters the RDNA3.5 device pass).

**On-device A/B (gfx1151, Strix Halo)** — single-variable toggle of this patch, captured with `rocprofv3 --kernel-trace` (the kernel-trace path works on gfx1151 even though PMC counters do not):

| arm | dispatched FA kernel | per-op | `pp8192 -fa 1` |
|-----|----------------------|-------:|---------------:|
| before (rocWMMA on) | `flash_attn_ext_f16<256,16,4,64>` | 5522 us | 569 t/s |
| after (this PR) | `flash_attn_tile<256,256,4,8>` | 642 us | **985 t/s** |

The FA kernel is **8.6x faster** and prefill recovers to the `-fa 0` baseline, `rc=0` (no `NO_DEVICE_CODE` crash). Model: Qwen3 35B-A3B Q8_0, full offload. The deeper reason the rocWMMA FA kernel is slower here is discussed in #24437 (the WMMA *fragment* API does a per-op register<->LDS round-trip to obtain a defined layout); this PR does not try to optimize that kernel — it routes RDNA3.5 onto the tile / native-mma path the selector already prefers elsewhere.

**Validation status (honest):**
- Reproduced and verified **on gfx1151 only**. gfx1150 is the same RDNA3.5 family and is expected to behave the same, but I have **not** tested it.
- Shapes exercised: DV=256 (-> tile) and head_dim <= 128 (-> native mma). This routes RDNA3.5 off rocWMMA for FA generally; I have not benchmarked every shape.
- Opening as a **draft** for maintainer feedback on the approach (narrowing the gate vs. a different mechanism for emitting the tile variant) before marking it ready.

Addresses #24437.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — AI tooling assisted the investigation (kernel-trace profiling and A/B analysis) and helped draft this description and the commit message. I reproduced and verified the change on real gfx1151 hardware, and I understand and can explain every line of the diff.
