### PR TITLE
[fattn-tune] Add Blackwell MMA config

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -87,6 +87,15 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
     return fattn_mma_config(32, 1, 0, 0, 0, 0, 0, false);
 }
 
+static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_config_sm120(const int DKQ, const int DV, const int ncols) {
+    // SM120: only D128/ncols=8 (nstages 2->1) showed a reliable speedup in randomized
+    // measurement. The full head_dim {64,80,96,128} x ncols {8,16,32,64} grid was tested;
+    // the other 15 cells were inconclusive -> Ampere.
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(128, 128, 8, 128, 2, 128, 64, 64, 64, 1, true);
+
+    return ggml_cuda_fattn_mma_get_config_ampere(DKQ, DV, ncols);
+}
+
 static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_config_turing(const int DKQ, const int DV, const int ncols) {
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256,  8, 128, 2,  64, 128, 128, 128, 2, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 16, 128, 2,  64, 128, 128, 128, 2, true);
@@ -229,6 +238,9 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
 }
 
 static __host__ fattn_mma_config ggml_cuda_fattn_mma_get_config(const int DKQ, const int DV, const int ncols, const int cc) {
+    if (cc == GGML_CUDA_CC_BLACKWELL && ggml_cuda_highest_compiled_arch(cc) == GGML_CUDA_CC_BLACKWELL) {
+        return ggml_cuda_fattn_mma_get_config_sm120(DKQ, DV, ncols);
+    }
     if (ampere_mma_available(cc)) {
         return ggml_cuda_fattn_mma_get_config_ampere(DKQ, DV, ncols);
     }
@@ -246,7 +258,9 @@ static __host__ fattn_mma_config ggml_cuda_fattn_mma_get_config(const int DKQ, c
 }
 
 static constexpr __device__ fattn_mma_config ggml_cuda_fattn_mma_get_config(const int DKQ, const int DV, const int ncols) {
-#if defined(AMPERE_MMA_AVAILABLE)
+#if defined(BLACKWELL_MMA_AVAILABLE) && __CUDA_ARCH__ == GGML_CUDA_CC_BLACKWELL
+    return ggml_cuda_fattn_mma_get_config_sm120(DKQ, DV, ncols);
+#elif defined(AMPERE_MMA_AVAILABLE)
     return ggml_cuda_fattn_mma_get_config_ampere(DKQ, DV, ncols);
 #elif defined(TURING_MMA_AVAILABLE)
     return ggml_cuda_fattn_mma_get_config_turing(DKQ, DV, ncols);


### PR DESCRIPTION
# SM120 Flash Attention Configuration Re-test Results

This time I did not lock the maximum frequency. Instead I used the default dynamic frequency and fixed KV depth at 32768. I re-searched and tested all 16 configuration cells of `head_dim=64/80/96/128 × ncols=8/16/32/64`. Only SM120's D128/ncols=8 produced a stable positive gain, so in the end only this one entry is kept:

```cpp
GGML_CUDA_FATTN_MMA_CONFIG_CASE(128, 128, 8, 128, 2, 128, 64, 64, 64, 1, true);
```

1. The operator-level independent confirmation result for this configuration is about **+0.94%**. The median change in the real-model `llama-bench` run is **+0.377%**.

| Test level | Experiment parameters | Median change | bootstrap 95% CI | Conclusion |
| --- | --- | ---: | --- | --- |
| `FLASH_ATTN_EXT` operator, 6-config independent confirmation measurement | D128/ncols=8, GQA4, F16 KV, 32K depth, 10 randomized AB/BA blocks | **+0.940%** | **[+0.923%, +0.960%]** | Reproduces the operator-level gain |
| `llama-bench` model guardrail | Qwen2.5-3B-Instruct Q4_K_M, `-p 8 -n 0 -d 32768`, 10 randomized AB/BA blocks | **+0.377%** | **[-0.745%, +1.731%]** | No statistically significant regression observed, but cannot prove end-to-end speedup |

## Testing, screening and validation process
## Detailed experiment parameters, results and commands

The common experiment environment and formal measurement parameters are as follows:

| Item | Parameters |
| --- | --- |
| GPU | NVIDIA GeForce RTX 5060 Ti, CC 12.0 (SM120) |
| Driver / CUDA | 596.49 / 13.0.88 |
| Build | CUDA Release, architecture 120 |
| GPU frequency | Default dynamic frequency, not locked; telemetry ~2565–2850 MHz |
| baseline / candidate | Same source code, compiled into two separate binaries |
| Formal measurement | 10 randomized paired blocks, 5 AB and 5 BA |
| Primary metric | Paired speedup median + bootstrap 95% CI |

### Operator-level testing

The main performance test runs the `FLASH_ATTN_EXT` operator directly, without loading a full model:

```bash
GGML_FATTN_TUNE_SYNTHETIC=1 \
./bin/test-backend-ops perf -b CUDA0 -o FLASH_ATTN_EXT \
-p 'hsk=128,hsv=128,nh=8,nr23=\[4,1\],kv=32768,nb=2,.*prec=f32,type_K=f16,type_V=f16'
```

Each formal run uses 10 randomized paired blocks, 5 run as `AB` and the other 5 as `BA`. `A` is the baseline, `B` is the candidate.

The speedup for each pair is computed as:

```text
speedup = (baseline_us / candidate_us - 1) × 100%
```

Finally I take the median of the 10 paired speedups to reduce the effect of individual outliers, and compute the 95% confidence interval with bootstrap.

The 10 raw paired results for D128/ncols=8 in this independent confirmation run are:

| block | order | baseline (µs) | candidate (µs) | speedup |
| ---: | :---: | ---: | ---: | ---: |
| 1 | AB | 324.79 | 321.83 | +0.920% |
| 2 | BA | 325.03 | 321.94 | +0.960% |
| 3 | BA | 325.79 | 322.81 | +0.923% |
| 4 | AB | 325.07 | 322.06 | +0.935% |
| 5 | BA | 325.88 | 322.83 | +0.945% |
| 6 | AB | 325.78 | 322.68 | +0.961% |
| 7 | AB | 325.70 | 322.65 | +0.945% |
| 8 | BA | 325.43 | 322.33 | +0.962% |
| 9 | BA | 325.25 | 322.52 | +0.846% |
| 10 | AB | 325.34 | 322.33 | +0.934% |

The median of these 10 paired speedups is **+0.940%**, and the bootstrap 95% CI is **[+0.923%, +0.960%]**.

### `llama-bench`

After the operator test confirmed a stable small gain on the target kernel, I ran a layer of regression guardrail with a real model. The test model is Qwen2.5-3B-Instruct Q4_K_M.

```bash
./bin/llama-bench -m /models/Qwen2.5-3B-Instruct-Q4_K_M.gguf \
  -p 8 -n 0 -d 32768 -b 512 -ub 512 -ctk f16 -ctv f16 \
  -ngl 99 -fa on -r 3 -o jsonl
```

32K prefill.

The model test also ran 10 randomized AB/BA paired blocks, in the order:

```text
AB, BA, BA, AB, BA, AB, AB, BA, AB, BA
```

The 10 paired speedups are:

```text
[-0.121, -1.169, +2.015, +0.339, +1.731,
 -1.882, +1.930, +0.416, -0.745, +0.778]
```

The median change is **+0.377%**, and the bootstrap 95% CI is **[-0.745%, +1.731%]**.

### Correctness and execution-path confirmation

In addition to the performance tests, I also ran these checks:

- 16/16 exact 32K tiled-F32 correctness cases passed;
- `compute-sanitizer memcheck` found no memory errors;
- Nsight Compute confirmed that both baseline and candidate hit `flash_attn_ext_f16<128,128,2,4,...>`, which shows the test actually reached the kernel modified in this change;
- The SM120 scoped patch passed the CUDA Release 120a build.









## Motivation:
ggml_cuda_fattn_mma_get_config doesn't have a dedicated parameter table for Blackwell; Blackwell uses Ampere's parameters.
This comit add architecture-specific `GGML_CUDA_FATTN_MMA_CONFIG_CASE` entries for the Blackwell GPU, replace the default Ampere parameters, and tune for each (DKQ, DV, ncols) combination.
## Changes

- Added the `ggml_cuda_fattn_mma_get_config_blackwell()` function with 16 CONFIG_CASE entries
- Covers head_dim = 64, 80, 96, 128, ncols = 8, 16, 32, 64

## test
  llama-bench -p 512 -n 0 -fa 1
Tested the pp (prefill) stage
### Test Environment

| Item | Configuration |
|------|--------------|
| CPU | Intel Core i7-14700K |
| RAM | 16 GB |
| OS | Win11 + Ubuntu 24.04.3 LTS (WSL2) |
| GPU | NVIDIA GeForce RTX 5060 Ti - 16GB (Blackwell, GB206) |
| VRAM | 16 GB (16311 MiB) |
| CUDA | 13.0.88 |
| Driver | 596.49 |
| Persistence Mode | On (`nvidia-smi -pm 1`) |
| SM Clock | 3090 MHz (max, locked during testing) |
GPU clock locked(SM 3090 MHz, Mem 14001 MHz), 3 warmup runs, ran the benchmark 10 times and took the average:

### model 
| head_dim | model | result |
|----------|------|------|
| 128 | Qwen2.5-7B-Instruct-Q4_K_M.gguf | ✅ IDENTICAL |
| 96 | CodeLlama-7B-Instruct-Q4_K_M.gguf | ✅ IDENTICAL |
| 80 | phi-2.Q4_K_M.gguf | ✅ IDENTICAL |
| 64 | qwen2.5-0.5b-instruct-q4_k_m.gguf | ✅ IDENTICAL |
### baseline
commitid: 0b7154066e8544ed88d92ae2132cc1e055cf6304

### test results
####  3 warmup runs, ran the benchmark 10 times and took the average
Because of the following 7 items (64/32, 80/16, 80/32, 80/64, 96/16, 96/32, 96/64), my tuning didn't improve much, less than 0.1%, so I just went with the Ampere configuration. That’s why the experiment list isn’t included either.

| head_dim | ncols | Baseline (t/s) | Optimized (t/s) | Δ% |
|----------|-------|---------------|----------------|-----|
| 64 | 8 | 7803.1 | 7931.5 | **1.65%** |
| 64 | 16 | 7890.7 | 7908.2 | 0.22% |
| 64 | 32 | Use Ampere config | — | — |
| 64 | 64 | 7849.2 | 7939.1 | **1.14%** |
| 80 | 8 | 3666.7 | 3681.1 | 0.39% |
| 80 | 16 | Use Ampere config | — | — |
| 80 | 32 | Use Ampere config | — | — |
| 80 | 64 | Use Ampere config | — | — |
| 96 | 8 | 1818.8 | 1820.6 | 0.10% |
| 96 | 16 | Use Ampere config | — | — |
| 96 | 32 | Use Ampere config | — | — |
| 96 | 64 | Use Ampere config | — | — |
| 128 | 8 | 1829.0 | 1833.3 | **0.23%** |
| 128 | 16 | 1825.0 | 1828.4 | **0.19%** |
| 128 | 32 | 1822.0 | 1827.5 | 0.30% |
| 128 | 64 | 1820.7 | 1825.7 | **0.27%** |


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <YES>: Used to help understand code and design experiments
