### PR TITLE
HIP: use hipBLAS for dense prefill on gfx900, keep MMQ for MoE

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -368,5 +368,15 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         return true;
     }
 
+    // gfx900 (Vega 10) lacks native dp4a; emulated MMQ loses to dequant + hipBLAS
+    // for dense Q4/K-quant prefill, but stays faster for Q8_0 and for all MoE
+    // matrices, where the hipBLAS path is much slower.
+    if (GGML_CUDA_CC_IS_GCN(cc) && cc < GGML_CUDA_CC_VEGA20) {
+        if (n_experts > 0 || type == GGML_TYPE_Q8_0) {
+            return true;
+        }
+        return ne11 < 32;
+    }
+
     return (!GGML_CUDA_CC_IS_CDNA(cc)) || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;
 }

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -368,14 +368,11 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         return true;
     }
 
-    // gfx900 (Vega 10) lacks native dp4a; emulated MMQ loses to dequant + hipBLAS
-    // for dense Q4/K-quant prefill, but stays faster for Q8_0 and for all MoE
-    // matrices, where the hipBLAS path is much slower.
+    // gfx900 (Vega 10) lacks native dp4a, so MMQ is emulated and loses to
+    // dequant + hipBLAS for dense matrices; keep MMQ only for MoE, where the
+    // hipBLAS path is much slower.
     if (cc == GGML_CUDA_CC_VEGA) {
-        if (n_experts > 0 || type == GGML_TYPE_Q8_0) {
-            return true;
-        }
-        return ne11 < 32;
+        return n_experts > 0;
     }
 
     return (!GGML_CUDA_CC_IS_CDNA(cc)) || ne11 < MMQ_DP4A_MAX_BATCH_SIZE;

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -371,7 +371,7 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
     // gfx900 (Vega 10) lacks native dp4a; emulated MMQ loses to dequant + hipBLAS
     // for dense Q4/K-quant prefill, but stays faster for Q8_0 and for all MoE
     // matrices, where the hipBLAS path is much slower.
-    if (GGML_CUDA_CC_IS_GCN(cc) && cc < GGML_CUDA_CC_VEGA20) {
+    if (cc == GGML_CUDA_CC_VEGA) {
         if (n_experts > 0 || type == GGML_TYPE_Q8_0) {
             return true;
         }

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -368,8 +368,8 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         return true;
     }
 
-    // gfx900 (Vega 10) lacks native dp4a, so MMQ is emulated and loses to
-    // dequant + hipBLAS for dense matrices; keep MMQ only for MoE, where the
+    // gfx900 (Vega 10) lacks native dp4a, loses to dequant + hipBLAS
+    // for dense matrices; keep MMQ only for MoE, where the
     // hipBLAS path is much slower.
     if (cc == GGML_CUDA_CC_VEGA) {
         return n_experts > 0;


### PR DESCRIPTION
## Overview

`gfx900` (Vega 10) has no native `dp4a`. The current code forces MMQ for all GCN. This routes dense `matmuls` to `dequant` + `hipBLAS` on gfx900 while keeping MMQ for MoE, where `hipBLAS` is much slower.

Overall Performance Gains:

 - `Qwen3.5 4B`: +36.1%
 - `Qwen3.6 27B`: +18.9%
 - `Gemma4 12B`: +65.1%
 - `Overall average`: ~40%

## Additional information
Before (Qwen3.5 4B):
```
nerd-dell@nerd-dell:~/llama.cpp$ ./build/bin/llama-bench -m ~/gguf_store/qwen3.5-4B/Qwen_Qwen3.5-4B-Q8_0.gguf -ngl 999 -sm tensor
 -p 16,32,64,128,256,512,1024,2048 -n 128
ggml_cuda_init: found 4 ROCm devices (Total VRAM: 32704 MiB):
  Device 0: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 1: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 2: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 3: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
| model                          |       size |     params | backend    | ngl |     sm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --------------: | -------------------: |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |            pp16 |       181.59 ± 73.88 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |            pp32 |       232.12 ± 69.22 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |            pp64 |       254.99 ± 19.22 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           pp128 |        384.78 ± 4.11 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           pp256 |        420.97 ± 1.74 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           pp512 |        474.99 ± 0.68 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |          pp1024 |        458.11 ± 0.97 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |          pp2048 |        448.79 ± 1.31 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           tg128 |         35.84 ± 1.60 |

build: 717920bf9 (9623)
```

After (Qwen3.5 4B):
```
nerd-dell@nerd-dell:~/llama.cpp$ ./build/bin/llama-bench -m ~/gguf_store/qwen3.5-4B/Qwen_Qwen3.5-4B-Q8_0.gguf -ngl 999 -sm tensor -p 16,32,64,128,256,512,1024,2048 -n 128
ggml_cuda_init: found 4 ROCm devices (Total VRAM: 32704 MiB):
  Device 0: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 1: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 2: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 3: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
| model                          |       size |     params | backend    | ngl |     sm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --------------: | -------------------: |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |            pp16 |       181.04 ± 73.63 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |            pp32 |      303.10 ± 114.31 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |            pp64 |      434.39 ± 126.31 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           pp128 |       516.05 ± 68.64 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           pp256 |        605.60 ± 7.74 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           pp512 |        657.86 ± 4.46 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |          pp1024 |        623.32 ± 2.13 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |          pp2048 |        607.57 ± 0.68 |
| qwen35 4B Q8_0                 |   4.29 GiB |     4.33 B | ROCm       | 999 | tensor |           tg128 |         35.81 ± 1.77 |

build: 717920bf9 (9623)
```

Before (Qwen3.6 27B):
```
nerd-dell@nerd-dell:~/llama.cpp$ ./build/bin/llama-bench -m ~/gguf_store/Qwen3.6-27B-Q4_1.gguf -ngl 999 -sm tensor -p 16,32,64,128,
256,512,1024,2048 -n 128
ggml_cuda_init: found 4 ROCm devices (Total VRAM: 32704 MiB):
  Device 0: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 1: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 2: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 3: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
| model                          |       size |     params | backend    | ngl |     sm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --------------: | -------------------: |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |            pp16 |        50.45 ± 15.02 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |            pp32 |         70.16 ± 9.65 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |            pp64 |         83.38 ± 0.74 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           pp128 |        101.40 ± 0.35 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           pp256 |        116.66 ± 0.29 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           pp512 |        121.73 ± 0.27 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |          pp1024 |        119.38 ± 0.22 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |          pp2048 |        118.03 ± 0.73 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           tg128 |         19.05 ± 0.98 |

build: 597b6672e (9621)
```

After (Qwen 3.6 27B):
```
nerd-dell@nerd-dell:~/llama.cpp$ ./build/bin/llama-bench -m ~/gguf_store/Qwen3.6-27B-Q4_1.gguf -ngl 999 -sm tensor -p 16,32,64,128,256,512,1024,2048 -n 128
ggml_cuda_init: found 4 ROCm devices (Total VRAM: 32704 MiB):
  Device 0: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 1: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 2: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 3: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
| model                          |       size |     params | backend    | ngl |     sm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --------------: | -------------------: |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |            pp16 |        53.54 ± 16.04 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |            pp32 |        81.12 ± 17.83 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |            pp64 |        109.17 ± 6.03 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           pp128 |        126.48 ± 1.99 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           pp256 |        140.36 ± 0.17 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           pp512 |        144.66 ± 0.07 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |          pp1024 |        140.14 ± 0.42 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |          pp2048 |        138.09 ± 0.77 |
| qwen35 27B Q4_1                |  16.33 GiB |    27.32 B | ROCm       | 999 | tensor |           tg128 |         19.15 ± 0.93 |

build: 717920bf9 (9623)
```

Before (Gemma4 12B):
```
nerd-dell@nerd-dell:~/llama.cpp$ ./build/bin/llama-bench -m ~/gguf_store/gemma-4-12b-it-Q8_0.gguf -ngl 999 -sm layer -p 16,32,64,128,256,512,1024,2048 -n 128
ggml_cuda_init: found 4 ROCm devices (Total VRAM: 32704 MiB):
  Device 0: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 1: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 2: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 3: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |            pp16 |         56.55 ± 0.56 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |            pp32 |         66.28 ± 0.22 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |            pp64 |         60.04 ± 0.07 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           pp128 |         68.76 ± 0.03 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           pp256 |         80.16 ± 0.07 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           pp512 |         78.86 ± 0.07 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |          pp1024 |        107.79 ± 0.13 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |          pp2048 |        118.01 ± 0.37 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           tg128 |         17.58 ± 0.04 |

build: f05cf4676 (9625)
```

After (Gemma-4 12B)
```
nerd-dell@nerd-dell:~/llama.cpp$ ./build/bin/llama-bench -m ~/gguf_store/gemma-4-12b-it-Q8_0.gguf -ngl 999 -sm layer -p 16,32,
64,128,256,512,1024,2048 -n 128
ggml_cuda_init: found 4 ROCm devices (Total VRAM: 32704 MiB):
  Device 0: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 1: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 2: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
  Device 3: AMD Radeon Graphics, gfx900:xnack- (0x900), VMM: no, Wave Size: 64, VRAM: 8176 MiB
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |            pp16 |         56.90 ± 0.53 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |            pp32 |         66.42 ± 2.63 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |            pp64 |        104.60 ± 0.45 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           pp128 |        149.50 ± 0.29 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           pp256 |        171.98 ± 0.39 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           pp512 |        148.20 ± 0.79 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |          pp1024 |        182.33 ± 0.52 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |          pp2048 |        185.39 ± 0.39 |
| gemma4 ?B Q8_0                 |  11.78 GiB |    11.91 B | ROCm       | 999 |           tg128 |         17.97 ± 0.04 |

build: 717920bf9 (9623)
```
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 

    - Yes, I used Opus 4.8 with the Copilot CLI harness for initial investigation to see what I could do about the lack of `dp4a`.  This led me to adding this -`DGGML_CUDA_FORCE_CUBLAS=ON` to my build and running tests to see how speeds compared, which is then when I noticed dense models in particular were consistently speeding up, but not MoE.  Used that as a springboard for adding this conditional block, then did manual work to ensure it wasn't being too assuming (like how it assumed Q8_0 would regress, I doubted that and validated by hand).
