### PR TITLE
 llama : suppress misleading Gemma4Assistant error during memory fitting

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -106,7 +106,7 @@ llama_context::llama_context(
     if (model.arch == LLM_ARCH_EAGLE3) {
         if (model.tok_embd == nullptr || model.output == nullptr) {
             if (params.ctx_other == nullptr) {
-                throw std::runtime_error("EAGLE3 requires ctx_other to be set (this warning is normal during memory fitting)");
+                throw llama_exception("EAGLE3 requires ctx_other to be set (this warning is normal during memory fitting)");
             }
             cparams.ctx_other = params.ctx_other;
         }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -22,6 +22,10 @@
 // llama_context
 //
 
+class llama_exception : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 static llm_graph_type ctx_type_to_graph_type(llama_context_type ctx_type) {
     switch (ctx_type) {
         case LLAMA_CONTEXT_TYPE_DEFAULT: return LLM_GRAPH_TYPE_DEFAULT;
@@ -93,8 +97,7 @@ llama_context::llama_context(
     // TODO: more generic
     if (model.arch == LLM_ARCH_GEMMA4_ASSISTANT) {
         if (params.ctx_other == nullptr) {
-            // TODO: change from runtime_error to llama_exception to avoid printing error message
-            throw std::runtime_error("Gemma4Assistant requires ctx_other to be set (this warning is normal during memory fitting)");
+            throw llama_exception("Gemma4Assistant requires ctx_other to be set (this warning is normal during memory fitting)");
         }
 
         cparams.ctx_other = params.ctx_other;
@@ -3560,6 +3563,8 @@ llama_context * llama_init_from_model(
     try {
         auto * ctx = new llama_context(*model, params);
         return ctx;
+    } catch (const llama_exception & err) {
+        LLAMA_LOG_WARN("%s: failed to initialize the context: %s\n", __func__, err.what());
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: failed to initialize the context: %s\n", __func__, err.what());
     }


### PR DESCRIPTION
## Overview

Thank you @am17an for [Gemma4 MTP](https://github.com/ggml-org/llama.cpp/pull/23398) support ^ it introduced

https://github.com/ggml-org/llama.cpp/blob/4988f6e866057afd130c1515ecef0c9bab9a15f8/src/llama-context.cpp#L93-L101

which sent me down the wrong track earlier (my fault)
- https://github.com/ggml-org/llama.cpp/pull/24480

and was noted in couple follow-ups
- https://github.com/ggml-org/llama.cpp/pull/24282#issuecomment-4644388723
- https://github.com/ggml-org/llama.cpp/pull/24267#issuecomment-4643402989

and couple issues
- https://github.com/ggml-org/llama.cpp/issues/24343 🐧
- https://github.com/ggml-org/llama.cpp/issues/24350 (Windows)

so i addressed the 2nd TODO only (for minimality)

if this looks as intended, happy to address the 1st TODO post-merge
(RE both LLM_ARCH_GEMMA4_ASSISTANT and LLM_ARCH_EAGLE3)

 Fix: https://github.com/ggml-org/llama.cpp/issues/24343
 Fix: https://github.com/ggml-org/llama.cpp/issues/24350

## Additional information

I've tested on
- Windows 11
- [unsloth/gemma-4-31B-it-qat-GGUF](https://huggingface.co/unsloth/gemma-4-31B-it-qat-GGUF)
- local build ([unsloth.ai/docs/models/gemma-4/qat#llama.cpp-guide](https://unsloth.ai/docs/models/gemma-4/qat#llama.cpp-guide) adapted for Win11 CMD, yup - old skool)

Before

<img width="1933" height="1346" alt="image" src="https://github.com/user-attachments/assets/4232b94c-cd59-4ae0-8da7-0ead9ee0d496" />

After

<img width="1930" height="1328" alt="image" src="https://github.com/user-attachments/assets/a07d790d-c636-4871-888a-df0c3340c8c6" />

NB: i noted https://github.com/shedrachokonofua/aether/commit/b0d4bcab3e21f62d9fb4a8cd8f94c2ca452e017a but idk what it's doing and the mentioned https://github.com/ggml-org/llama.cpp/issues/24376 is unrelated

P.S: i've not touched C++ in a while

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
