### PR TITLE
ci: fix vulkan docker images

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -427,6 +427,7 @@ void string_to_spv(std::string name, const std::string& source, const std::map<s
     // Don't write the same dep file from multiple processes
     generate_dep_file = false;
 
+    // Clean up completed futures - don't accumulate virtual memory for completed threads' stacks.
     while (compiles.front().wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
         compiles.pop_front();
     }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -407,7 +407,7 @@ std::map<std::string, std::string> merge_maps(const std::map<std::string, std::s
     return result;
 }
 
-static std::vector<std::future<void>> compiles;
+static std::deque<std::future<void>> compiles;
 void string_to_spv(std::string name, const std::string& source, const std::map<std::string, std::string>& defines, bool fp16 = true, bool coopmat = false, bool coopmat2 = false, bool f16acc = false, const std::string& suffix = "") {
     name = name + (f16acc ? "_f16acc" : "") + (coopmat ? "_cm1" : "") + (coopmat2 ? "_cm2" : (fp16 ? "" : "_fp32")) + suffix;
     std::string out_path = join_paths(output_dir, name + ".spv");
@@ -426,6 +426,10 @@ void string_to_spv(std::string name, const std::string& source, const std::map<s
         string_to_spv_func, name, input_filepath, out_path, defines, coopmat, generate_dep_file, std::move(slot)));
     // Don't write the same dep file from multiple processes
     generate_dep_file = false;
+
+    while (compiles.front().wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+        compiles.pop_front();
+    }
 }
 
 void matmul_shaders(bool fp16, MatMulIdType matmul_id_type, bool coopmat, bool coopmat2, bool f16acc, bool dot2 = false) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -428,7 +428,7 @@ void string_to_spv(std::string name, const std::string& source, const std::map<s
     generate_dep_file = false;
 
     // Clean up completed futures - don't accumulate virtual memory for completed threads' stacks.
-    while (compiles.front().wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+    while (!compiles.empty() && compiles.front().wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
         compiles.pop_front();
     }
 }


### PR DESCRIPTION
## Overview

Starting with `b9438` vulkan docker images produced by CI are broken.  We run out of memory during shaders generation. CI doesn't report an error, but  build artifact are corrupted.
https://github.com/ggml-org/llama.cpp/actions/runs/27397273833/job/80967212036#step:9:2828
```
#14 337.5 Cannot allocate memory
#14 337.5 Error executing command for matmul_id_subgroup_q5_0_f32_aligned: Failed to fork process
```

Fixes #24474 


Container build on fork: https://github.com/Kononnable/llama.cpp/actions/runs/27477825868/job/81220277837#step:9:2810

## Additional information

~Recent additions to `mul_nn.comp` caused RSS memory counters to hit system limits during shaders generation. Building docker images outside of CI worked fine - usually personal computers have more RAM than CI agents.  On CI problems started to happen when RSS was around 21GB.~

In `string_to_spv` we call `std::async` to be able to generate multiple shaders in parallel. We store the futures in `compiles` and never delete them. We never release the resources taken by those futures. 
Creating a future creates a thread which reserves virtual memory for things like the call stack. They don't use a lot of RAM, but each allocates 8MB of virtual memory. We do that thousands of times - it goes into gigabytes of virtual memory. This becomes a problem when we hit limits like `/proc/sys/vm/overcommit_*`.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES,  faster loop during problem debugging