### PR TITLE
ui : fix llama-ui-embed crash when no asset dir is given

### DIFF
--- a/tools/ui/embed.cpp
+++ b/tools/ui/embed.cpp
@@ -1,7 +1,7 @@
 // llama-ui-embed: generate ui.cpp / ui.h that embed UI assets as C arrays.
 //
 // Usage:
-//   llama-ui-embed <out_cpp> <out_h> <asset_dir>
+//   llama-ui-embed <out_cpp> <out_h> [<asset_dir>]
 //
 // Recursively embeds every regular file under <asset_dir>.
 // Asset names are relative paths from <asset_dir> (e.g. "_app/immutable/bundle.HASH.js").
@@ -147,9 +147,9 @@ int main(int argc, char ** argv) {
 
     const std::string out_cpp   = argv[1];
     const std::string out_h     = argv[2];
-    const std::string asset_dir = argv[3];
+    const std::string asset_dir = (argc >= 4) ? argv[3] : std::string();
 
-    const bool        use_gzip = std::filesystem::exists(asset_dir + "/_gzip");
+    const bool        use_gzip = !asset_dir.empty() && std::filesystem::exists(asset_dir + "/_gzip");
     const std::string in_dir   = use_gzip ? (asset_dir + "/_gzip") : asset_dir;
 
     std::vector<asset_entry> assets;


### PR DESCRIPTION
## Overview

When no asset directory is passed in, the `llama-ui` library should still compile with zero assets. This fixes a regression that crashed when no asset directory was given, which may happen when none of the UI build methods succeed.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
