### PR TITLE
Improvement: code quality, docs, and build-system fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...3.28) # for add_link_options and implicit target directories.
+cmake_minimum_required(VERSION 3.14...3.30) # for add_link_options and implicit target directories.
 project("llama.cpp" C CXX)
 include(CheckIncludeFileCXX)
 
@@ -12,7 +12,7 @@ if (NOT XCODE AND NOT MSVC AND NOT CMAKE_BUILD_TYPE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-message("CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+message(STATUS "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 
 # Add path to modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Docker](https://github.com/ggml-org/llama.cpp/actions/workflows/docker.yml/badge.svg)](https://github.com/ggml-org/llama.cpp/actions/workflows/docker.yml)
 [![Winget](https://github.com/ggml-org/llama.cpp/actions/workflows/winget.yml/badge.svg)](https://github.com/ggml-org/llama.cpp/actions/workflows/winget.yml)
 
-[Manifesto](https://github.com/ggml-org/llama.cpp/discussions/205) / [ggml](https://github.com/ggml-org/ggml) / [ops](https://github.com/ggml-org/llama.cpp/blob/master/docs/ops.md)
+[Manifesto](https://github.com/ggml-org/llama.cpp/discussions/205) / [ggml](https://github.com/ggml-org/ggml) / [ops](docs/ops.md)
 
 LLM inference in C/C++
 
@@ -295,7 +295,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 | [OpenCL](docs/backend/OPENCL.md) | Adreno GPU |
 | [IBM zDNN](docs/backend/zDNN.md) | IBM Z & LinuxONE |
 | [WebGPU](docs/build.md#webgpu) | All |
-| [RPC](https://github.com/ggml-org/llama.cpp/tree/master/tools/rpc) | All |
+| [RPC](tools/rpc) | All |
 | [Hexagon [In Progress]](docs/backend/snapdragon/README.md) | Snapdragon |
 | [VirtGPU](docs/backend/VirtGPU.md) | VirtGPU APIR |
 
@@ -467,7 +467,10 @@ To learn more about model quantization, [read this documentation](tools/quantize
     <summary>Measure KL divergence</summary>
 
     ```bash
-    # TODO
+    # Measure KL divergence between two runs (e.g. different backends or configs)
+    llama-perplexity -m model.gguf -f prompts/wiki.test -ngl 99 2>&1 | tee run1.log
+    llama-perplexity -m model.gguf -f prompts/wiki.test -ngl 99 --different-flag 2>&1 | tee run2.log
+    python3 scripts/compare-logprobs.py --a run1.log --b run2.log
     ```
 
     </details>

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -27,7 +27,8 @@ function(llama_add_compile_flags)
             add_compile_options("$<$<COMPILE_LANGUAGE:C>:${C_FLAGS};${GF_C_FLAGS}>"
                                 "$<$<COMPILE_LANGUAGE:CXX>:${CXX_FLAGS};${GF_CXX_FLAGS}>")
         else()
-            # todo : msvc
+            # msvc warnings
+            add_compile_options(/W4 /wd4005 /wd4244 /wd4267 /wd4305 /wd4456 /wd4457 /wd4458 /wd4459 /wd4566 /wd4702 /wd4996 /wd5054)
             set(C_FLAGS   "" PARENT_SCOPE)
             set(CXX_FLAGS "" PARENT_SCOPE)
         endif()

--- a/convert_hf_to_gguf_update.py
+++ b/convert_hf_to_gguf_update.py
@@ -15,11 +15,11 @@ from hashlib import sha256
 from enum import IntEnum, auto
 from transformers import AutoTokenizer
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("convert_hf_to_gguf_update")
 sess = requests.Session()
 
-convert_py_pth = pathlib.Path("conversion/base.py")
+convert_py_pth = pathlib.Path(__file__).resolve().parent / "conversion" / "base.py"
 convert_py = convert_py_pth.read_text(encoding="utf-8")
 hf_token_pth = pathlib.Path.home() / ".cache" / "huggingface" / "token"
 hf_token = hf_token_pth.read_text(encoding="utf-8").strip() if hf_token_pth.exists() else None

--- a/examples/model-conversion/scripts/utils/check-nmse.py
+++ b/examples/model-conversion/scripts/utils/check-nmse.py
@@ -41,7 +41,7 @@ def load_logits(file_path):
                         value = float(line.strip())
                     data.append(value)
             return np.array(data, dtype=np.float32)
-        except:
+        except (ValueError, IOError, OSError):
             return np.loadtxt(file_path, dtype=np.float32)
 
 def interpret_nmse(nmse):

--- a/ggml/src/ggml-openvino/CMakeLists.txt
+++ b/ggml/src/ggml-openvino/CMakeLists.txt
@@ -3,8 +3,8 @@ find_package(OpenCL REQUIRED)
 
 include("${OpenVINO_DIR}/../3rdparty/tbb/lib/cmake/TBB/TBBConfig.cmake")
 
-file(GLOB_RECURSE GGML_HEADERS_OPENVINO "*.h" "*.hpp")
-file(GLOB_RECURSE GGML_SOURCES_OPENVINO "*.cpp")
+file(GLOB_RECURSE GGML_HEADERS_OPENVINO CONFIGURE_DEPENDS "*.h" "*.hpp")
+file(GLOB_RECURSE GGML_SOURCES_OPENVINO CONFIGURE_DEPENDS "*.cpp")
 
 ggml_add_backend_library(ggml-openvino
     ${GGML_SOURCES_OPENVINO}

--- a/scripts/compare-logprobs.py
+++ b/scripts/compare-logprobs.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import argparse
 import requests
 import json

--- a/scripts/gen-unicode-data.py
+++ b/scripts/gen-unicode-data.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from __future__ import annotations
 
 import array

--- a/scripts/server-test-model.py
+++ b/scripts/server-test-model.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import argparse
 import json
 import requests

--- a/tools/mtmd/legacy-models/convert_image_encoder_to_gguf.py
+++ b/tools/mtmd/legacy-models/convert_image_encoder_to_gguf.py
@@ -354,7 +354,7 @@ if has_llava_projector:
     else:
         model.vision_model.encoder.layers = model.vision_model.encoder.layers[:max(feature_layers)]
 
-    projector = torch.load(args.llava_projector)
+    projector = torch.load(args.llava_projector, weights_only=True)
     for name, data in projector.items():
         name = get_tensor_name(name)
         # pw and dw conv ndim==4

--- a/tools/mtmd/legacy-models/glmedge-convert-image-encoder-to-gguf.py
+++ b/tools/mtmd/legacy-models/glmedge-convert-image-encoder-to-gguf.py
@@ -150,7 +150,7 @@ if args.use_f32:
 
 vision_config = SiglipVisionConfig(**v_hparams)
 model = SiglipVisionModel(vision_config)
-model.load_state_dict(torch.load(os.path.join(dir_model, "glm.clip")))
+model.load_state_dict(torch.load(os.path.join(dir_model, "glm.clip"), weights_only=True))
 
 fname_middle = None
 has_text_encoder = False
@@ -221,7 +221,7 @@ fout.add_bool("clip.use_gelu", True)
 
 if has_glm_projector:
     # model.vision_model.encoder.layers.pop(-1)  # pyright: ignore[reportAttributeAccessIssue]
-    projector = torch.load(args.llava_projector)
+    projector = torch.load(args.llava_projector, weights_only=True)
     for name, data in projector.items():
         name = get_tensor_name(name)
         # pw and dw conv ndim==4

--- a/tools/mtmd/legacy-models/llava_surgery.py
+++ b/tools/mtmd/legacy-models/llava_surgery.py
@@ -10,7 +10,7 @@ args = ap.parse_args()
 
 # find the model part that includes the the multimodal projector weights
 path = sorted(glob.glob(f"{args.model}/pytorch_model*.bin"))[-1]
-checkpoint = torch.load(path)
+checkpoint = torch.load(path, weights_only=True)
 
 # get a list of mm tensor names
 mm_tensors = [k for k, v in checkpoint.items() if k.startswith("model.mm_projector")]

--- a/tools/mtmd/legacy-models/llava_surgery_v2.py
+++ b/tools/mtmd/legacy-models/llava_surgery_v2.py
@@ -22,7 +22,7 @@ def load_model(file_path):
                 print(f"{key} : {tensors[key].shape}")
         return tensors, 'safetensor'
     else:
-        return torch.load(file_path, map_location=torch.device('cpu')), 'pytorch'
+        return torch.load(file_path, map_location=torch.device('cpu'), weights_only=True), 'pytorch'
 
 
 # Unified saving function

--- a/tools/mtmd/legacy-models/minicpmv-convert-image-encoder-to-gguf.py
+++ b/tools/mtmd/legacy-models/minicpmv-convert-image-encoder-to-gguf.py
@@ -650,7 +650,7 @@ processor = None
 #     model.attn_pool = torch.nn.Identity()
 
 # model.blocks = model.blocks[:-1]
-model.load_state_dict(torch.load(os.path.join(dir_model, "minicpmv.clip")))
+model.load_state_dict(torch.load(os.path.join(dir_model, "minicpmv.clip"), weights_only=True))
 
 fname_middle = None
 has_text_encoder = True
@@ -800,7 +800,7 @@ def _replace_name_resampler(s, v):
     return {s: v}
 
 if has_minicpmv_projector:
-    projector = torch.load(args.minicpmv_projector)
+    projector = torch.load(args.minicpmv_projector, weights_only=True)
     new_state_dict = {}
     for k, v in projector.items():
         kvs = _replace_name_resampler(k, v)

--- a/tools/tts/convert_pt_to_hf.py
+++ b/tools/tts/convert_pt_to_hf.py
@@ -23,7 +23,7 @@ path_dst = os.path.dirname(model_path)
 
 print(f"Loading model from {model_path}")
 
-model = torch.load(model_path, map_location='cpu')
+model = torch.load(model_path, map_location='cpu', weights_only=True)
 
 #print(model)
 


### PR DESCRIPTION
## Summary

Multiple improvements across the llama.cpp codebase:

### Documentation
- Fix hardcoded `master` branch URLs in README.md (ops table, RPC reference)
- Fill in the empty `TODO` placeholder for the KL divergence measurement example

### Build System
- Bump CMake version upper bound from 3.28 to 3.30 (avoids deprecation warnings on newer CMake)
- Add `STATUS` prefix to CMAKE_BUILD_TYPE message for quieter output
- Add MSVC `/W4` warning flags in common.cmake (was previously just a `todo` comment)
- Add `CONFIGURE_DEPENDS` to OpenVINO source globs so newly added source files trigger reconfigure

### Python / Security
- Add `weights_only=True` to **all** `torch.load()` calls in legacy model conversion scripts (mitigates arbitrary code execution via malicious pickle payloads)
- Add `#!/usr/bin/env python3` shebangs to Python scripts missing them (`gen-unicode-data`, `compare-logprobs`, `server-test-model`)
- Narrow bare `except:` to concrete exception types in `check-nmse.py`
- Lower log noise in `convert_hf_to_gguf_update` (INFO instead of DEBUG) and resolve the conversion-script path relative to script location (not cwd)