### PR TITLE
server: add system message prefix feature

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3033,6 +3033,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_CHAT_TEMPLATE_KWARGS"));
     add_opt(common_arg(
+        {"--system-message-prefix"}, "STRING",
+        "a jinja-formatted string that will be set as the prefix for the first system message on each request. (if there is no system message on a request, one will be added to the beginning of that request.)",
+        [](common_params & params, const std::string & value) {
+            params.system_message_prefix = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SYSTEM_MESSAGE_PREFIX"));
+    add_opt(common_arg(
         {"-to", "--timeout"}, "N",
         string_format("server read/write timeout in seconds (default: %d)", params.timeout_read),
         [](common_params & params, int value) {

--- a/common/common.h
+++ b/common/common.h
@@ -621,6 +621,7 @@ struct common_params {
     std::string ssl_file_cert = "";                                                                         // NOLINT
 
     std::map<std::string, std::string> default_template_kwargs;
+    std::string system_message_prefix = "";
 
     // UI configs
     bool ui = true;

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "download.h"
+#include "jinja/runtime.h"
 #include "log.h"
 #include "llama.h"
 #include "mtmd.h"
@@ -1076,6 +1077,35 @@ json oaicompat_chat_params_parse(
             throw std::invalid_argument("Cannot use custom grammar constraints with tools.");
         }
         llama_params["parse_tool_calls"] = true;
+    }
+    if (opt.system_message_prefix) {
+        jinja::context ctx(opt.system_message_prefix->source);
+        jinja::runtime runtime(ctx);
+        const jinja::value results = runtime.execute(opt.system_message_prefix->program);
+        std::string system_message_prefix = jinja::runtime::gather_string_parts(results)->as_string().str();
+
+        bool needs_system_message = true;
+        for (auto & message : inputs.messages) {
+            if (message.role == "system") {
+                needs_system_message = false;
+                if (!message.content_parts.empty()) {
+                    message.content_parts.insert(
+                        message.content_parts.begin(),
+                        common_chat_msg_content_part{"text", system_message_prefix}
+                    );
+                } else {
+                    message.content = system_message_prefix + message.content;
+                }
+                break;
+            }
+        }
+
+        if (needs_system_message) {
+            common_chat_msg system_message;
+            system_message.role = "system";
+            system_message.content = system_message_prefix;
+            inputs.messages.insert(inputs.messages.begin(), system_message);
+        }
     }
 
     // merge the template args provided from command line with the args provided in the user request

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -289,12 +289,19 @@ std::vector<server_tokens> tokenize_input_prompts(
 // OAI utils
 //
 
+// used to keep the system_message_prefix string and program together
+struct server_jinja_template {
+    std::string source;
+    jinja::program program;
+};
+
 // global server parameters for chat formatting / parsing
 struct server_chat_params {
     bool use_jinja;
     bool prefill_assistant;
     common_reasoning_format reasoning_format;
     std::map<std::string, std::string> chat_template_kwargs; // mapping key --> json value
+    std::unique_ptr<server_jinja_template> system_message_prefix;
     common_chat_templates_ptr tmpls;
     bool allow_image;
     bool allow_audio;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1,4 +1,5 @@
 #include "server-context.h"
+#include "jinja/parser.h"
 #include "server-chat.h"
 #include "server-common.h"
 #include "server-http.h"
@@ -1324,6 +1325,24 @@ private:
                 return false;
             }
 
+            std::unique_ptr<server_jinja_template> system_message_prefix;
+            try {
+                if (!params_base.system_message_prefix.empty()) {
+                    jinja::lexer lexer;
+                    auto lexer_res = lexer.tokenize(params_base.system_message_prefix);
+
+                    system_message_prefix = std::make_unique<server_jinja_template>(
+                        server_jinja_template {
+                            lexer_res.source,
+                            jinja::parse_from_tokens(lexer_res)
+                        }
+                    );
+                }
+            } catch (const std::exception & e) {
+                SRV_ERR("%s: system_message_prefix template parsing error: %s\n", __func__, e.what());
+                return false;
+            }
+
             // thinking is enabled if:
             // 1. It's not explicitly disabled via --reasoning off
             // 2. The chat template supports it
@@ -1336,6 +1355,7 @@ private:
                 /* prefill_assistant     */ params_base.prefill_assistant,
                 /* reasoning_format      */ params_base.reasoning_format,
                 /* chat_template_kwargs  */ params_base.default_template_kwargs,
+                /* system_message_prefix */ std::move(system_message_prefix),
                 /* tmpls                 */ std::move(chat_templates),
                 /* allow_image           */ mctx ? mtmd_support_vision(mctx) : false,
                 /* allow_audio           */ mctx ? mtmd_support_audio (mctx) : false,

--- a/tools/server/tests/unit/test_template.py
+++ b/tools/server/tests/unit/test_template.py
@@ -81,6 +81,43 @@ def test_date_inside_prompt(template_name: str, format: str, tools: list[dict]):
     assert today_str in prompt, f"Expected today's date ({today_str}) in content ({prompt})"
 
 
+@pytest.mark.parametrize("messages,expected", [
+    (
+        [
+            {"role": "system", "content": "existing"},
+            {"role": "user", "content": "hello"},
+        ],
+        "<|im_start|>system\nPREFIX:existing<|im_end|>",
+    ),
+    (
+        [
+            {"role": "system", "content": [{"type": "text", "text": "existing"}]},
+            {"role": "user", "content": "hello"},
+        ],
+        "<|im_start|>system\nPREFIX:\nexisting<|im_end|>",
+    ),
+    (
+        [
+            {"role": "user", "content": "hello"},
+        ],
+        "<|im_start|>system\nPREFIX:<|im_end|>",
+    ),
+])
+def test_system_message_prefix(messages: list[dict], expected: str):
+    global server
+    server.jinja = True
+    server.chat_template = "chatml"
+    server.system_message_prefix = '{{ "PRE" + "FIX:" }}'
+    server.start()
+
+    res = server.make_request("POST", "/apply-template", data={
+        "messages": messages,
+    })
+
+    assert res.status_code == 200
+    assert expected in res.body["prompt"]
+
+
 @pytest.mark.parametrize("add_generation_prompt", [False, True])
 @pytest.mark.parametrize("template_name,expected_generation_prompt", [
     ("meta-llama-Llama-3.3-70B-Instruct",    "<|start_header_id|>assistant<|end_header_id|>"),

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -100,6 +100,7 @@ class ServerProcess:
     reasoning: Literal['on', 'off', 'auto'] | None = None
     chat_template: str | None = None
     chat_template_file: str | None = None
+    system_message_prefix: str | None = None
     server_path: str | None = None
     mmproj_url: str | None = None
     media_path: str | None = None
@@ -241,6 +242,8 @@ class ServerProcess:
             server_args.extend(["--chat-template", self.chat_template])
         if self.chat_template_file:
             server_args.extend(["--chat-template-file", self.chat_template_file])
+        if self.system_message_prefix:
+            server_args.extend(["--system-message-prefix", self.system_message_prefix])
         if self.mmproj_url:
             server_args.extend(["--mmproj-url", self.mmproj_url])
         if self.media_path:


### PR DESCRIPTION
## Overview

This closes https://github.com/ggml-org/llama.cpp/issues/24246

Essentially, as someone running `llama-server`, there can be information or instructions that are always desirable to put into the system message, as a hardcoded layer above what the client can control. This PR streamlines that process significantly.

This is already possible to do in `llama-server`, it "just" requires a convoluted process of extracting the chat template from a gguf, then painstakingly modifying that chat template by hand to add the desired information into a forced system message. This must be done differently for every single gguf that you intend to serve, since every model these days seems to use its own bespoke chat template. If you only intend to serve one model, this is doable, but for enthusiasts who enjoy testing and using a wide range of models, it becomes burdensome.

If `llama-server` supported this concept directly, then it would work for _all_ models, without clunky chat template modifications.

This PR also avoids the need to modify *every single client/harness* to inject this information, which may not even possible if you don't control the client directly. (For someone offering a hosted API, this would absolutely be the case.)

This PR aims to demonstrate how small (and hopefully inoffensive) the required changes are.

I have deployed the changes to my environment and can confirm that they are working as intended.

## Additional information

My preferred invocation is `--system-message-prefix "{{- \"Today's date: \" + strftime_now(\"%Y-%b-%d (%A)\") + \"\\n\\n\" }}"`, as discussed in the issue linked above, but you could use this for anything, including generic instructions that should be applied to all requests. This feature by itself has *literally nothing* to do with date injection. That is merely the motivating case for myself, and something this feature enables a sysadmin to do.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, to review the code and write test cases. I wrote the code in the first commit, AI wrote the second commit.
