### PR TITLE
ui : fix ui clipping in mobile due to incorrect height setup

### DIFF
--- a/tools/ui/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/tools/ui/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -41,7 +41,7 @@
 	data-slot="sidebar-wrapper"
 	style="--sidebar-width: {sidebar.sidebarWidth}; --sidebar-min-width: {SIDEBAR_MIN_WIDTH}; --sidebar-max-width: {SIDEBAR_MAX_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
 	class={cn(
-		'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
+		'group/sidebar-wrapper flex flex-col min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
 		className
 	)}
 	bind:this={ref}

--- a/tools/ui/src/routes/+layout.svelte
+++ b/tools/ui/src/routes/+layout.svelte
@@ -312,7 +312,7 @@
 	/>
 
 	<Sidebar.Provider bind:open={sidebarOpen}>
-		<div class="flex h-screen w-full">
+		<div class="flex h-full w-full grow">
 			<Sidebar.Root variant="floating" class="h-full"
 				><SidebarNavigation bind:this={chatSidebar} /></Sidebar.Root
 			>


### PR DESCRIPTION
## Overview

UI is clipped when used in mobile when using `h-screen`.

This issue is reproducible in master at c2ba3e47a2038a2c4f51138c1843e374b174e83d (tag: b9628)
reproducible in Android Chrome mobile 148 and on iOS Safari 26 

This fix replaces `h-screen` (100svh) and rely on height: 100% and flex box to properly setup the height for the UI.

### Issue 

UI is either clipped on top or at the bottom. When clipped, it is not possible to scroll to access the button on top or the buttons at the bottom.

Screenshots taken from Android 14 Chrome 148

| clipped top | clipped bottom | clipped bottom keyboard opened
| -- | -- |-- | 
<img width="1440" height="3120" alt="clipped top" src="https://github.com/user-attachments/assets/d257b86e-fd03-4492-8608-76f1fc8441ef" /> | <img width="1440" height="3120" alt="clipped bottom" src="https://github.com/user-attachments/assets/fea2e2bf-e226-4aae-ac6e-625707b0f30d" /> | <img width="1440" height="3120" alt="clipped bottom keyboard opened" src="https://github.com/user-attachments/assets/37f2a30f-9fc3-4d07-9977-31653a129b2b" />



### After fix

Screenshots taken from Android 14 Chrome 148

| default |  keyboard
| -- | -- |
<img width="1440" height="3120" alt="fixed default" src="https://github.com/user-attachments/assets/8b063cd2-c1b0-4886-9f03-6f92995a84f2" /> | <img width="1440" height="3120" alt="fixed keyboard" src="https://github.com/user-attachments/assets/d2a5efbf-d04d-42d0-adc2-f55e3a3b1040" />



## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
