### PR TITLE
fix(convert): avoid eager KeyError when hparams lacks top-level architectures

### DIFF
--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -397,7 +397,7 @@ if __name__ == '__main__':
 
     with torch.inference_mode():
         try:
-            model_arch = hparams.get("text_config", {}).get("architectures", hparams["architectures"])[0]
+            model_arch = (hparams.get("text_config", {}).get("architectures") or hparams["architectures"])[0]
             logger.info("Using model architecture: %s", model_arch)
             model_class = get_model_class(model_arch)
         except NotImplementedError:


### PR DESCRIPTION
## Description

`convert_lora_to_gguf.py` throws a `KeyError` when loading a base model whose `hparams` dict stores `architectures` only inside `text_config` (e.g. Gemma 4).

## Root Cause

```python
# Before: hparams["architectures"] is evaluated eagerly as default arg
model_arch = hparams.get("text_config", {}).get("architectures", hparams["architectures"])[0]
```

Python evaluates `hparams["architectures"]` immediately as the default argument to `.get()`, even when the first `.get()` succeeds. If the top-level key is missing, this raises `KeyError`.

## Fix

```python
# After: short-circuit or defers the fallback
model_arch = (hparams.get("text_config", {}).get("architectures") or hparams["architectures"])[0]
```

Uses `or` short-circuit evaluation so `hparams["architectures"]` is only evaluated when the first lookup returns `None` or an empty list.

## Related

Closes #24613