### PR TITLE
convert : reorder V heads for LoraTorchTensor

### DIFF
--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -498,6 +498,33 @@ if __name__ == '__main__':
                     assert tensor.B is not None
                     yield (name, cast(torch.Tensor, LoraTorchTensor(tensor.A, tensor.B)))
 
+            @staticmethod
+            def _reorder_v_heads(tensor: Tensor, dim: int, num_k_heads: int, num_v_per_k: int, head_dim: int) -> Tensor:
+                if not isinstance(tensor, LoraTorchTensor):
+                    return model_class._reorder_v_heads(tensor, dim, num_k_heads, num_v_per_k, head_dim)  # ty: ignore[unresolved-attribute]
+
+                # LoraTorchTensor cannot reshape the row size, so apply the same
+                # reordering to a single LoRA factor instead. W = B @ A, so
+                # reordering output rows reorders B and reordering input columns
+                # reorders A. Reuse the base implementation to build the index.
+                shape = tensor.shape
+                if dim < 0:
+                    dim += len(shape)
+                lora_a, lora_b = tensor.get_lora_A_B()
+                if dim == len(shape) - 1:
+                    perm = model_class._reorder_v_heads(  # ty: ignore[unresolved-attribute]
+                        torch.arange(shape[dim], dtype=torch.long).unsqueeze(0),
+                        1, num_k_heads, num_v_per_k, head_dim,
+                    ).squeeze(0)
+                    lora_a = lora_a.index_select(-1, perm)
+                else:
+                    perm = model_class._reorder_v_heads(  # ty: ignore[unresolved-attribute]
+                        torch.arange(shape[dim], dtype=torch.long).unsqueeze(-1),
+                        0, num_k_heads, num_v_per_k, head_dim,
+                    ).squeeze(-1)
+                    lora_b = lora_b.index_select(dim, perm)
+                return cast(torch.Tensor, LoraTorchTensor(lora_a, lora_b))
+
             def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
                 dest = list(super().modify_tensors(data_torch, name, bid))
                 # some archs may have the same tensor for lm_head and output (tie word embeddings)


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Converting a Qwen3.5 LoRA adapter fails: `_reorder_v_heads` reshapes V into
`[num_k_heads, num_v_per_k, head_dim]`, which a `LoraTorchTensor` (`W = B @ A`) can't do without
reshaping its row size, so the `out_proj` reorder raises `NotImplementedError`.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Fixes #21125.

This overrides `_reorder_v_heads` on `LoraModel`: plain tensors use the base method, and a
`LoraTorchTensor` gets the reorder applied to a single factor (`B` rows for output, `A`'s last
axis for input). The index comes from running the base method on an `arange`, like the nvfp4
`out_proj` reorder already does. The new path's `B @ A` matches the dense reorder for
`dim=0/1/-1`; I haven't run a full Qwen3.5-9B conversion (no GPU/base model).

conv1d / A_log / dt_bias still lack `LoraTorchTensor` support, but the issue's adapter doesn't
touch them.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used to review the change. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
