### PR TITLE
server: cancel generation when client disconnects

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -204,6 +204,9 @@ struct server_slot {
 
     std::function<void(int /* id_slot */)> callback_on_release;
 
+    // cancellation flag: set by cancel task, checked in update_slots()
+    std::shared_ptr<std::atomic<bool>> should_stop = std::make_shared<std::atomic<bool>>(false);
+
     // Speculative decoding stats
     int32_t n_draft_total = 0;      // Total draft tokens generated
     int32_t n_draft_accepted = 0;   // Draft tokens actually accepted
@@ -2232,6 +2235,7 @@ private:
                     // release slot linked with the task id
                     for (auto & slot : slots) {
                         if (slot.task && slot.task->id == task.id_target) {
+                            slot.should_stop->store(true);
                             slot.release();
                             break;
                         }
@@ -2591,6 +2595,13 @@ private:
             if (!slot_batched) {
                 slot_batched = &slot;
             } else if (!slot_batched->can_batch_with(slot)) {
+                continue;
+            }
+
+            if (slot.should_stop->load()) {
+                SLT_WRN(slot, "%s", "cancellation requested, releasing slot\n");
+                send_error(slot, "request cancelled by client");
+                slot.release();
                 continue;
             }
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1492,17 +1492,21 @@ server_http_proxy::server_http_proxy(
     cli->set_write_timeout(timeout_read, 0); // reversed for cli (client) vs srv (server)
     cli->set_read_timeout(timeout_write, 0);
     this->status = 500; // to be overwritten upon response
-    this->cleanup = [pipe]() {
+    this->cleanup = [pipe, cli]() {
+        cli->stop(); // abort in-flight child request
         pipe->close_read();
         pipe->close_write();
     };
 
     // wire up the receive end of the pipe
-    this->next = [pipe, should_stop](std::string & out) -> bool {
+    this->next = [pipe, cli, should_stop](std::string & out) -> bool {
         msg_t msg;
         bool has_next = pipe->read(msg, should_stop);
         if (!msg.data.empty()) {
             out = std::move(msg.data);
+        }
+        if (!has_next && should_stop()) {
+            cli->stop(); // abort child request on disconnect
         }
         return has_next; // false if EOF or pipe broken
     };


### PR DESCRIPTION
## Overview
### When an HTTP client disconnects mid-generation (e.g. Ctrl+C), the server now frees the slot immediately instead of letting it run to EOS.

Fix (two parts):

1. Direct server (server-context.cpp): Add an atomic cancellation flag to server_slot. The CANCEL task handler sets it, and update_slots() checks it before each slot's generating batch — catching the edge case where the cancel arrives while update_slots() is mid-flight.

2. Router proxy (server-models.cpp): When the proxy's pipe reader detects client disconnect via should_stop(), call cli->stop() on the httplib::Client to abort the in-flight HTTP request to the child server. The child's httplib then sees the broken connection, is_connection_closed becomes true, and the child's own generation cancel path kicks in.

## Additional information

- Fixes https://github.com/ggml-org/llama.cpp/issues/24496
- ~Full CI still passes~ CI results are identical between `main` and my local post-change code
- Tested via opencode API session in API mode with Qwen 3.5 9B,server running on a local M4 mac mini, client on my workstation PC. Started a prompt and monitored via SSH, hitting double escape once started. 

Before: processing and progress logs continued.
After: client cancellation propagates through the proxy, immediately freeing the task slot

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES: used to confirm the scaffolding/boilerplate for the proxy, and provide insight on the suggested solution in the linked issue 24496. Once relevant files were confirmed, I wrote the initial contract scheme for the cancellation, and had the AI review it. It added comments (which I deem relevant) and some logging which I think gives a little value, while recommending a `shared_ptr` implementation rather than a naked atomic

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
