### PR TITLE
server: add /sleep endpoint to force sleeping state

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -228,14 +228,9 @@ static const char * cu_get_error_str(CUresult err) {
 #endif
 
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-#    define CUDA_SET_SHARED_MEMORY_LIMIT(kernel, nbytes)                                                       \
-        do {                                                                                                   \
-            static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = { false };                         \
-            const int   id                                                = ggml_cuda_get_device();            \
-            if (!shared_memory_limit_raised[id]) {                                                             \
-                CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes)); \
-                shared_memory_limit_raised[id] = true;                                                         \
-            }                                                                                                  \
+#    define CUDA_SET_SHARED_MEMORY_LIMIT(kernel, nbytes) \
+        do {                                               \
+            CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes)); \
         } while (0)
 #else
 #    define CUDA_SET_SHARED_MEMORY_LIMIT(kernel, nbytes) \

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1940,22 +1940,14 @@ void ggml_cuda_flash_attn_ext_mma_f16_case(ggml_backend_cuda_context & ctx, ggml
         fattn_kernel = flash_attn_ext_f16<DKQ, DV, ncols1, ncols2, use_logit_softcap, V_is_K_view>;
 
 #if !defined(GGML_USE_MUSA)
-        static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
-        if (!shared_memory_limit_raised[id]) {
-            CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
-            shared_memory_limit_raised[id] = true;
-        }
+        CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
 #endif // !defined(GGML_USE_MUSA)
     } else {
         constexpr bool use_logit_softcap = true;
         fattn_kernel = flash_attn_ext_f16<DKQ, DV, ncols1, ncols2, use_logit_softcap, V_is_K_view>;
 
 #if !defined(GGML_USE_MUSA)
-        static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
-        if (!shared_memory_limit_raised[id]) {
-            CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
-            shared_memory_limit_raised[id] = true;
-        }
+        CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
 #endif // !defined(GGML_USE_MUSA)
     }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3745,6 +3745,10 @@ void server_context::on_sleeping_changed(std::function<void(bool)> callback) {
     impl->queue_tasks.on_sleeping_state(std::move(callback));
 }
 
+void server_context::request_sleep() {
+    impl->queue_tasks.request_sleep();
+}
+
 // compute the number of tokens before the last user message in the prompt
 static int32_t prompt_get_n_before_user(
         const json & message_spans,
@@ -4825,6 +4829,13 @@ void server_routes::init_routes() {
 
         GGML_ASSERT(dynamic_cast<server_task_result_apply_lora*>(result.get()) != nullptr);
         res->ok(result->to_json());
+        return res;
+    };
+
+    this->post_sleep = [this](const server_http_req &) {
+        auto res = create_response(true);
+        queue_tasks.request_sleep();
+        res->ok({{"success", true}});
         return res;
     };
 }

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -83,6 +83,9 @@ struct server_context {
     // register a callback to be called when sleeping state changes
     // must be set before load_model() is called
     void on_sleeping_changed(std::function<void(bool)> callback);
+
+    // request entering sleeping state immediately
+    void request_sleep();
 };
 
 
@@ -127,6 +130,7 @@ struct server_routes {
     server_http_context::handler_t post_rerank;
     server_http_context::handler_t get_lora_adapters;
     server_http_context::handler_t post_lora_adapters;
+    server_http_context::handler_t post_sleep;
 
     // to be used in router mode
     json get_model_info() const;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -43,6 +43,7 @@ extern char **environ;
 #define DEFAULT_STOP_TIMEOUT 10 // seconds
 
 #define CMD_ROUTER_TO_CHILD_EXIT  "cmd_router_to_child:exit"
+#define CMD_ROUTER_TO_CHILD_SLEEP "cmd_router_to_child:sleep"
 #define CMD_CHILD_TO_ROUTER_READY "cmd_child_to_router:ready" // also sent when waking up from sleep
 #define CMD_CHILD_TO_ROUTER_SLEEP "cmd_child_to_router:sleep"
 #define CMD_CHILD_TO_ROUTER_INFO  "cmd_child_to_router:info:" // followed by json string
@@ -929,6 +930,26 @@ void server_models::unload(const std::string & name) {
     }
 }
 
+void server_models::sleep(const std::string & name) {
+    std::lock_guard<std::mutex> lk(mutex);
+    auto it = mapping.find(name);
+    if (it != mapping.end()) {
+        auto & meta = it->second.meta;
+        if (meta.status == SERVER_MODEL_STATUS_LOADED) {
+            SRV_INF("sleeping model instance name=%s\n", name.c_str());
+            meta.status = SERVER_MODEL_STATUS_SLEEPING;
+            fprintf(it->second.stdin_file, "%s\n", CMD_ROUTER_TO_CHILD_SLEEP);
+            fflush(it->second.stdin_file);
+        } else if (meta.status == SERVER_MODEL_STATUS_SLEEPING) {
+            SRV_WRN("model instance name=%s is already sleeping\n", name.c_str());
+        } else if (meta.status == SERVER_MODEL_STATUS_LOADING) {
+            SRV_WRN("model instance name=%s is still loading, cannot sleep yet\n", name.c_str());
+        } else {
+            SRV_WRN("model instance name=%s is not running\n", name.c_str());
+        }
+    }
+}
+
 void server_models::unload_all() {
     std::vector<std::thread> to_join;
     {
@@ -1063,7 +1084,7 @@ bool server_models::is_child_server() {
     return router_port != nullptr;
 }
 
-std::thread server_models::setup_child_server(const std::function<void(int)> & shutdown_handler, const json & model_info) {
+std::thread server_models::setup_child_server(const std::function<void(int)> & shutdown_handler, const json & model_info, const std::function<void()> & sleep_handler) {
     // send a notification to the router server that a model instance is ready
     common_log_pause(common_log_main());
     fflush(stdout);
@@ -1074,7 +1095,7 @@ std::thread server_models::setup_child_server(const std::function<void(int)> & s
     common_log_resume(common_log_main());
 
     // setup thread for monitoring stdin
-    return std::thread([shutdown_handler]() {
+    return std::thread([shutdown_handler, sleep_handler]() {
         // wait for EOF on stdin
         SRV_INF("%s", "child server monitoring thread started, waiting for EOF on stdin...\n");
         bool eof = false;
@@ -1089,6 +1110,12 @@ std::thread server_models::setup_child_server(const std::function<void(int)> & s
                 SRV_INF("%s", "exit command received, exiting...\n");
                 shutdown_handler(0);
                 break;
+            }
+            if (line.find(CMD_ROUTER_TO_CHILD_SLEEP) != std::string::npos) {
+                SRV_INF("%s", "sleep command received, entering sleep...\n");
+                if (sleep_handler) {
+                    sleep_handler();
+                }
             }
         }
         if (eof) {
@@ -1309,6 +1336,24 @@ void server_models_routes::init_routes() {
             return res;
         }
         models.unload(model->name);
+        res_ok(res, {{"success", true}});
+        return res;
+    };
+
+    this->post_router_models_sleep = [this](const server_http_req & req) {
+        auto res = std::make_unique<server_http_res>();
+        json body = json::parse(req.body);
+        std::string name = json_value(body, "model", std::string());
+        auto model = models.get_meta(name);
+        if (!model.has_value()) {
+            res_err(res, format_error_response("model is not found", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+        if (model->status != SERVER_MODEL_STATUS_LOADED && model->status != SERVER_MODEL_STATUS_SLEEPING) {
+            res_err(res, format_error_response("model is not loaded", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+        models.sleep(model->name);
         res_ok(res, {{"success", true}});
         return res;
     };

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -147,6 +147,9 @@ public:
     void unload(const std::string & name);
     void unload_all();
 
+    // put model into sleep state (thread-safe)
+    void sleep(const std::string & name);
+
     // update the status of a model instance (thread-safe)
     void update_status(const std::string & name, server_model_status status, int exit_code);
     void update_loaded_info(const std::string & name, std::string & raw_info);
@@ -168,7 +171,10 @@ public:
 
     // notify the router server that a model instance is ready
     // return the monitoring thread (to be joined by the caller)
-    static std::thread setup_child_server(const std::function<void(int)> & shutdown_handler, const json & model_info);
+    // shutdown_handler is called with exit code on exit command
+    // model_info is used to notify the router of the model's info
+    // sleep_handler is called on sleep command (optional, may be nullptr)
+    static std::thread setup_child_server(const std::function<void(int)> & shutdown_handler, const json & model_info, const std::function<void()> & sleep_handler = nullptr);
 
     // notify the router server that the sleeping state has changed
     static void notify_router_sleeping_state(bool sleeping);
@@ -206,6 +212,7 @@ struct server_models_routes {
     server_http_context::handler_t get_router_models;
     server_http_context::handler_t post_router_models_load;
     server_http_context::handler_t post_router_models_unload;
+    server_http_context::handler_t post_router_models_sleep;
 };
 
 /**

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -122,6 +122,12 @@ void server_queue::terminate() {
     condition_tasks.notify_all();
 }
 
+void server_queue::request_sleep() {
+    std::unique_lock<std::mutex> lock(mutex_tasks);
+    req_sleep = true;
+    condition_tasks.notify_all();
+}
+
 void server_queue::start_loop(int64_t idle_sleep_ms) {
     running = true;
     time_last_task = ggml_time_ms();
@@ -129,6 +135,9 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
     constexpr auto max_wait_time = std::chrono::seconds(1);
     auto should_sleep = [&]() -> bool {
         // caller must hold mutex_tasks
+        if (req_sleep) {
+            return true;
+        }
         if (idle_sleep_ms < 0) {
             return false;
         }
@@ -189,6 +198,7 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
                 }
                 QUE_INF("%s", "exiting sleeping state\n");
                 req_stop_sleeping = false;
+                req_sleep = false;
                 callback_sleeping_state(false);
                 sleeping = false;
                 time_last_task = ggml_time_ms();

--- a/tools/server/server-queue.h
+++ b/tools/server/server-queue.h
@@ -16,6 +16,7 @@ private:
     bool running  = false;
     bool sleeping = false;
     bool req_stop_sleeping = false;
+    bool req_sleep = false;
     int64_t time_last_task = 0;
 
     // queues
@@ -55,6 +56,9 @@ public:
         std::unique_lock<std::mutex> lock(mutex_tasks);
         return sleeping;
     }
+
+    // request entering sleeping state immediately (bypasses idle timer)
+    void request_sleep();
 
     // end the start_loop routine
     void terminate();

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -176,7 +176,10 @@ int llama_server(int argc, char ** argv) {
 
         ctx_http.post("/models/load",          ex_wrapper(models_routes->post_router_models_load));
         ctx_http.post("/models/unload",        ex_wrapper(models_routes->post_router_models_unload));
+        ctx_http.post("/models/sleep",         ex_wrapper(models_routes->post_router_models_sleep));
     }
+
+    ctx_http.post("/sleep",                    ex_wrapper(routes.post_sleep));
 
     ctx_http.get ("/health",                   ex_wrapper(routes.get_health)); // public endpoint (no API key check)
     ctx_http.get ("/v1/health",                ex_wrapper(routes.get_health)); // public endpoint (no API key check)
@@ -354,7 +357,9 @@ int llama_server(int argc, char ** argv) {
         std::thread monitor_thread;
         if (server_models::is_child_server()) {
             json model_info = routes.get_model_info();
-            monitor_thread = server_models::setup_child_server(shutdown_handler, model_info);
+            monitor_thread = server_models::setup_child_server(shutdown_handler, model_info, [&ctx_server]() {
+                ctx_server.request_sleep();
+            });
         }
 
         // this call blocks the main thread until queue_tasks.terminate() is called


### PR DESCRIPTION
## Overview

POST to /sleep triggers the current server to immediately enter the sleeping state (releasing GPU memory) on demand. In Router mode, POST to /models/sleep {"model": <model>} does the same.

Re-waking works as it already does. Any incoming request automatically wakes the server/instance from sleep.

The current Sleep mechanism is time-based, I wanted a way to programmatically send the model to sleep and release the GPU memory without fully stopping the server or unloading the model.

## Additional information

Posted originally in #24153. As stated, I am using an AI for this. I'm just interested in sharing a useful enhancement, and one I've been testing myself for a few weeks. Please feel free to make any changes needed to this PR to make it acceptable, or as a basis for a rewrite.

A note on the CUDA changes as mentioned in the commit message:

> The cudaFuncSetAttribute call was guarded by a process-lifetime static bool, so after sleep+wake the attribute was skipped since the CUDA context had been destroyed. This caused occupancy to return 0 and trigger GGML_ASSERT(max_blocks_per_sm > 0).
> 
> cudaFuncSetAttribute is idempotent, so the guard is removed entirely.

Without this, sleep, wake -> sleep, wake would result in a assert error on the 2nd wake.

```llama.cpp/ggml/src/ggml-cuda/template-instances/../fattn-common.cuh:1110: GGML_ASSERT(max_blocks_per_sm > 0) failed```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. I am not a C++ dev, and though I've done my best to understand it, I'm leaning heavily on the AI. 