### PR TITLE
mtmd : fix output-buffer size for multi-image batches without temporal merge

### DIFF
--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -97,8 +97,16 @@ struct mtmd_image_tokens {
             return (nx + 1) * ny + 2;
         }
         // [QWEN_VIDEO] this logic is quite ugly, it's mostly to make qwen-vl temporal merge work, can be improved in the future
-        if (batch_f32.entries.size() == 1 || n_temporal_merge == 1) {
+        if (batch_f32.entries.size() == 1) {
             return nx * ny;
+        }
+        if (n_temporal_merge == 1) {
+            // multiple image entries (e.g. tiles, or several images batched together)
+            // without temporal merge: the encoder outputs nx*ny tokens per entry, so the
+            // total number of output tokens scales with the number of entries. Returning
+            // nx*ny here under-sizes the embedding output buffer in mtmd_encode_impl() and
+            // trips "clip.cpp: Output buffer size mismatch" (seen with Gemma-4 vision).
+            return nx * ny * (uint32_t) batch_f32.entries.size();
         }
         uint32_t nz = batch_f32.entries.size();
         // TODO: simplify this by repeating the last frame until it fits the temporal merge


### PR DESCRIPTION
## Summary

`mtmd_image_tokens::n_tokens()` under-counts the output tokens for a **multi-image batch**
when the model does not use temporal merge, so `clip_image_batch_encode()` aborts with
`Output buffer size mismatch`.

## Repro

Send a chat request with **two images** to a model whose image entries get batched into a
single `clip_image_batch_encode` call and that has `n_temporal_merge == 1` (e.g. **Gemma-4**
vision):

```
clip.cpp: Output buffer size mismatch
clip_image_batch_encode: output buffer has 322560 elements but expected 645120
GGML_ABORT
```

(`322560 = 1*126*2560`, `645120 = 2*126*2560` — the buffer was sized for one image while the
encoder produced two; `embeddings->ne[2] == entries.size() == 2`.)

## Root cause

`mtmd_encode_impl()` sizes the output buffer as `n_embd_out * image_tokens->n_tokens()`.
`n_tokens()` returns `nx*ny` (a single entry) whenever `n_temporal_merge == 1`, ignoring
`batch_f32.entries.size()`, but `clip_image_batch_encode()` produces
`entries.size() * nx * ny` tokens.

## Fix

Multiply by the entry count when there is no temporal merge. The single-entry path and the
temporal-merge branch (entries divided by the merge factor) are unchanged.

## Testing

Built on Intel Arc (SYCL). Before: every 2-image Gemma-4 request aborts. After: 2-image
requests encode all entries and return normally; single-image paths (e.g. Qwen3-VL) unchanged.
