### PR TITLE
sycl: bound in-flight expert matmuls in mul_mat_id (fix MoE OUT_OF_RESOURCES on Intel iGPU)

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -4393,6 +4393,16 @@ static void ggml_sycl_mul_mat_id(ggml_backend_sycl_context & ctx,
             ggml_sycl_mul_mat(ctx, &src0_row, &src1_row, &dst_row);
         }
 
+        // The OpenCL UR adapter aborts with UR_RESULT_ERROR_OUT_OF_RESOURCES on this MoE op: it
+        // enqueues one matmul per expert (n_as up to hundreds), ggml_sycl_op_mul_mat does no host
+        // wait on a single device, and the node-submit loop never waits between ops, so without a
+        // drain here expert matmuls accumulate across ops until the next mul_mat_id's wait,
+        // exceeding the adapter's in-flight budget. One drain after the loop bounds this to a
+        // single mul_mat_id's experts. Level Zero did not hit this in our testing, so skip it there.
+        if (stream->get_backend() != sycl::backend::ext_oneapi_level_zero) {
+            SYCL_CHECK(CHECK_TRY_ERROR(stream->wait()));
+        }
+
         {
             sycl::range<3> block_dims(1, 1, std::min((unsigned int)ne0, max_work_group_size));
             sycl::range<3> grid_dims(1, 1, n_routed_rows);


### PR DESCRIPTION
## Summary

On the SYCL OpenCL backend (Intel Arc iGPU), running MoE expert tensors on the GPU (`-ngl 99`, no `-ot exps=CPU`) aborts during multi-token prompt processing:

```
opencl backend failed with error: 40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)
ggml-sycl.cpp: SYCL error: CHECK_TRY_ERROR(stream->wait())
```

I hit this on every MoE model I tried with experts on GPU: gemma-4-26b-a4b, qwen3.6-35b-a3b, qwen3-coder-next-80b. This patch makes that configuration run; it is a correctness/availability fix, not a performance optimization.

## Root cause

`ggml_sycl_mul_mat_id` enqueues one matmul per expert (`n_as` up to hundreds). On a single device `ggml_sycl_op_mul_mat` does no host wait, and the node-submit loop never waits between graph ops, so the per-expert matmuls accumulate across ops until the next `mul_mat_id`'s start-of-function wait, exceeding the OpenCL UR adapter's in-flight command/event budget.

It is not a single bad kernel: a 128-expert `mul_mat_id` in isolation (`test-backend-ops`) does not crash; it only manifests across the full model graph. Anything that throttles submission avoids it (`-ub 1`, or even heavy debug logging).

## Fix

Drain the queue once after the expert loop, gated to the non-Level-Zero backend (no-op on Level Zero):

```cpp
if (stream->get_backend() != sycl::backend::ext_oneapi_level_zero) {
    SYCL_CHECK(CHECK_TRY_ERROR(stream->wait()));
}
```

This caps in-flight expert matmuls at a single op's worth. It is numerically inert (it only synchronizes).

## Validation (Intel Arc 140T iGPU, OpenCL UR)

No crash, on configs that previously aborted within seconds:

| model | experts | pp512 | tg |
|---|---|---|---|
| gemma-4-26b-a4b | 128 | 162 tok/s | 14 tok/s |
| qwen3-coder-next-80b | 512 | 138 tok/s | 14 tok/s |

`test-backend-ops -o MUL_MAT_ID` passes. Since the fix only adds a host wait, it cannot change results.

## Repro

```
ONEAPI_DEVICE_SELECTOR=opencl:gpu llama-cli -m gemma-4-26b-a4b-it-Q4_K_M.gguf \
  -ngl 99 -ub 512 -p "<~40-token prompt>" -n 1
# before: UR_RESULT_ERROR_OUT_OF_RESOURCES    after: runs normally
```

---

*Disclosure: I used an AI coding assistant to help with this. The code change is small; the bulk of the work was diagnosis (reproducing the abort, ruling out the work-group / single-kernel theories, and tracing it to async submission pile-up). The investigation and on-hardware validation are mine.*
