### PR TITLE
fix: symbol collision for `ggml_vec_dot_q4_1_q8_1` when building for wasm

### DIFF
--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -293,7 +293,6 @@
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__wasm__)
 // quants.c
-#define ggml_vec_dot_q4_1_q8_1_generic ggml_vec_dot_q4_1_q8_1
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
 #define ggml_vec_dot_tq2_0_q8_K_generic ggml_vec_dot_tq2_0_q8_K
 #define ggml_vec_dot_iq2_xxs_q8_K_generic ggml_vec_dot_iq2_xxs_q8_K


### PR DESCRIPTION
## Overview

cont #22209

`ggml_vec_dot_q4_1_q8_1_generic` is renamed here for wasm builds even though `ggml_vec_dot_q4_1_q8_1` was recently implemented in `wasm/quants.c`, this breaks builds with `CMAKE_SYSTEM_PROCESSOR=wasm`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO