### PR TITLE
ggml: improve RVV q8_0 GEMM accumulation

### DIFF
--- a/ggml/src/ggml-cpu/arch/riscv/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/riscv/repack.cpp
@@ -1375,12 +1375,12 @@ void ggml_gemm_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
                 for (int i = 0; i < QK8_0; i++) {
                     // Load `b_ptr`.
                     const vint8mf2_t b_0 = __riscv_vle8_v_i8mf2((const int8_t *)&b_ptr[l].qs[i * 16], 16);
-                    // const vint16m1_t b_0_16 = __riscv_vwcvt_x_x_v_i16m1(b_0, 16);
+                    const vint16m1_t b_0_16 = __riscv_vwcvt_x_x_v_i16m1(b_0, 16);
 
-                    sumi_0 = __riscv_vwadd_wv_i32m2(sumi_0, __riscv_vwmul_vx_i16m1(b_0, a_ptr[l].qs[i * 4 + 0], 16), 16);
-                    sumi_1 = __riscv_vwadd_wv_i32m2(sumi_1, __riscv_vwmul_vx_i16m1(b_0, a_ptr[l].qs[i * 4 + 1], 16), 16);
-                    sumi_2 = __riscv_vwadd_wv_i32m2(sumi_2, __riscv_vwmul_vx_i16m1(b_0, a_ptr[l].qs[i * 4 + 2], 16), 16);
-                    sumi_3 = __riscv_vwadd_wv_i32m2(sumi_3, __riscv_vwmul_vx_i16m1(b_0, a_ptr[l].qs[i * 4 + 3], 16), 16);
+                    sumi_0 = __riscv_vwmacc_vx_i32m2(sumi_0, a_ptr[l].qs[i * 4 + 0], b_0_16, 16);
+                    sumi_1 = __riscv_vwmacc_vx_i32m2(sumi_1, a_ptr[l].qs[i * 4 + 1], b_0_16, 16);
+                    sumi_2 = __riscv_vwmacc_vx_i32m2(sumi_2, a_ptr[l].qs[i * 4 + 2], b_0_16, 16);
+                    sumi_3 = __riscv_vwmacc_vx_i32m2(sumi_3, a_ptr[l].qs[i * 4 + 3], b_0_16, 16);
                 }
 
                 const vfloat16m1_t b_d = __riscv_vle16_v_f16m1((const _Float16 *)b_ptr[l].d, 16);


### PR DESCRIPTION
## Overview

Improve the RVV q8_0 16x1 GEMM kernel by replacing the inner-loop `vwmul + vwadd` accumulation sequence with `vwmacc`.

This keeps the same arithmetic result, `sum += a * b`, while emitting a shorter widening multiply-accumulate sequence for the q8_0 GEMM prefill path.

## Additional information

Tested on Spacemit K3 with Qwen2.5-1.5B Q8_0, 8 threads.

| test | baseline | patched |
|---|---:|---:|
| pp128 | 35.11 ± 0.34 t/s | 63.64 ± 0.02 t/s |
| pp512 | 34.87 ± 0.05 t/s | 62.29 ± 0.42 t/s |
| pp1024 | 34.19 ± 0.04 t/s | 60.37 ± 0.39 t/s |
| tg128 | 10.46 ± 0.08 t/s | 10.47 ± 0.05 t/s |

Correctness was checked with a standalone RVV harness comparing the old kernel, the new kernel, and a scalar reference. All tested cases passed with exact output matches.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. I implemented the code change, Codex helped run the tests, and I reviewed the results.