### PR TITLE
chat: include full unparsed prompt in debug message on parse error

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2678,8 +2678,8 @@ common_chat_msg common_chat_peg_parse(const common_peg_arena &          src_pars
             }
             return msg;
         }
-        throw std::runtime_error(std::string("Failed to parse input at pos ") + std::to_string(result.end) + ": " +
-                                 effective_input.substr(result.end));
+        LOG_DBG("Failure during parsing following input at position %lu: \n\n=== START ===\n%s\n=== END ===\n", result.end, effective_input.c_str());
+        throw std::runtime_error(std::string("Failed to parse input at pos ") + std::to_string(result.end) + ": " + effective_input.substr(result.end));
     }
 
     common_chat_msg msg;


### PR DESCRIPTION
As in topic.

## Overview

Minimal change to enable dumping full unparsed prompt.

## Additional information

Need for debugging parser errors.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No