### PR TITLE
docs: fix bench port help text

### DIFF
--- a/tools/server/bench/bench.py
+++ b/tools/server/bench/bench.py
@@ -28,7 +28,7 @@ def main(args_in: list[str] | None = None) -> None:
     parser.add_argument("--branch", type=str, help="Branch name", default="detached")
     parser.add_argument("--commit", type=str, help="Commit name", default="dirty")
     parser.add_argument("--host", type=str, help="Server listen host", default="0.0.0.0")
-    parser.add_argument("--port", type=int, help="Server listen host", default="8080")
+    parser.add_argument("--port", type=int, help="Server listen port", default="8080")
     parser.add_argument("--model-path-prefix", type=str, help="Prefix where to store the model files", default="models")
     parser.add_argument("--n-prompts", type=int,
                         help="SERVER_BENCH_N_PROMPTS: total prompts to randomly select in the benchmark", required=True)


### PR DESCRIPTION
## Overview

In tools/server/bench/bench.py the help text for both --host and --port were the same ("server listen host"), this updates the --port message to be "server listen port"

To confirm the changes I tested with python tools/server/bench/bench.py --help
and the --host and --port help texts were updated.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

