### PR TITLE
docs: fix llama2c help text quote

### DIFF
--- a/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
+++ b/examples/convert-llama2c-to-ggml/convert-llama2c-to-ggml.cpp
@@ -808,7 +808,7 @@ static void print_usage(int /*argc*/, char ** argv, const struct train_params * 
     fprintf(stderr, "  -h, --help                       show this help message and exit\n");
     fprintf(stderr, "  --copy-vocab-from-model FNAME    path of gguf llama model or llama2.c vocabulary from which to copy vocab (default '%s')\n", params->fn_vocab_model);
     fprintf(stderr, "  --llama2c-model FNAME            [REQUIRED] model path from which to load Karpathy's llama2.c model\n");
-    fprintf(stderr, "  --llama2c-output-model FNAME     model path to save the converted llama2.c model (default %s')\n", params->fn_llama2c_output_model);
+    fprintf(stderr, "  --llama2c-output-model FNAME     model path to save the converted llama2.c model (default '%s')\n", params->fn_llama2c_output_model);
     fprintf(stderr, "\n");
 }
 


### PR DESCRIPTION
## Overview

In the help text for '--llama2c-output-model', before there was no opening quote around the default value (default %s'), I just added the opening quote (default '%s')

## Requirements


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO