### PR TITLE
perf(hip): enable -funsafe-math-optimizations for the ROCm backend

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -130,6 +130,9 @@ if (GGML_HIP_EXPORT_METRICS)
     set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -Rpass-analysis=kernel-resource-usage --save-temps")
 endif()
 
+# Fast math for HIP, like CUDA's -use_fast_math. Not -ffast-math: that implies -ffinite-math-only, which breaks ggml's INFINITY masking and produces NaNs.
+set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -funsafe-math-optimizations")
+
 if (NOT GGML_CUDA_FA)
     add_compile_definitions(GGML_CUDA_NO_FA)
 endif()


### PR DESCRIPTION
## Overview

The HIP/ROCm backend is denied the fast math CUDA gets, so it runs without that speedup. We added -funsafe-math-optimizations to let AMD use faster math while staying away from NaNs.

## Additional information

Validated on RDNA4 (gfx1201, ROCm 7.0.2): builds clean, test-backend-ops 12508/12508 (including EXPM1), ~+8–15% on FLASH_ATTN.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used AI to write the initial comments, then went back and rewrote them myself.
