### PR TITLE
cuda: bump context generation on device reset to re-apply kernel attributes and fix a crash during model reload

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <memory>
 #include <mutex>
+#include <atomic>
 
 #if defined(GGML_USE_HIP)
 #define GGML_COMMON_DECL_HIP
@@ -230,11 +231,12 @@ static const char * cu_get_error_str(CUresult err) {
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 #    define CUDA_SET_SHARED_MEMORY_LIMIT(kernel, nbytes)                                                       \
         do {                                                                                                   \
-            static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = { false };                         \
-            const int   id                                                = ggml_cuda_get_device();            \
-            if (!shared_memory_limit_raised[id]) {                                                             \
+            static int ctx_gen_last_raised[GGML_CUDA_MAX_DEVICES] = { -1 };                                   \
+            const int id                     = ggml_cuda_get_device();                                          \
+            const int current_gen            = ggml_cuda_ctx_generation(id);                                   \
+            if (ctx_gen_last_raised[id] != current_gen) {                                                       \
                 CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes)); \
-                shared_memory_limit_raised[id] = true;                                                         \
+                ctx_gen_last_raised[id] = current_gen;                                                          \
             }                                                                                                  \
         } while (0)
 #else
@@ -1139,6 +1141,12 @@ const ggml_cuda_device_info & ggml_cuda_info();
 
 void ggml_cuda_set_device(int device);
 int ggml_cuda_get_device();
+
+// Returns the current CUDA context generation for the given device.
+// This counter is incremented whenever cudaDeviceReset is called, allowing
+// CUDA function attribute caches (e.g. shared memory limit guards) to detect
+// context changes and re-apply their attributes.
+int ggml_cuda_ctx_generation(int device);
 
 struct ggml_cuda_pool {
     virtual ~ggml_cuda_pool() = default;

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1940,10 +1940,11 @@ void ggml_cuda_flash_attn_ext_mma_f16_case(ggml_backend_cuda_context & ctx, ggml
         fattn_kernel = flash_attn_ext_f16<DKQ, DV, ncols1, ncols2, use_logit_softcap, V_is_K_view>;
 
 #if !defined(GGML_USE_MUSA)
-        static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
-        if (!shared_memory_limit_raised[id]) {
+        static int ctx_gen_last_raised[GGML_CUDA_MAX_DEVICES] = {-1};
+        const int current_gen = ggml_cuda_ctx_generation(id);
+        if (ctx_gen_last_raised[id] != current_gen) {
             CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
-            shared_memory_limit_raised[id] = true;
+            ctx_gen_last_raised[id] = current_gen;
         }
 #endif // !defined(GGML_USE_MUSA)
     } else {
@@ -1951,10 +1952,11 @@ void ggml_cuda_flash_attn_ext_mma_f16_case(ggml_backend_cuda_context & ctx, ggml
         fattn_kernel = flash_attn_ext_f16<DKQ, DV, ncols1, ncols2, use_logit_softcap, V_is_K_view>;
 
 #if !defined(GGML_USE_MUSA)
-        static bool shared_memory_limit_raised[GGML_CUDA_MAX_DEVICES] = {false};
-        if (!shared_memory_limit_raised[id]) {
+        static int ctx_gen_last_raised[GGML_CUDA_MAX_DEVICES] = {-1};
+        const int current_gen = ggml_cuda_ctx_generation(id);
+        if (ctx_gen_last_raised[id] != current_gen) {
             CUDA_CHECK(cudaFuncSetAttribute(reinterpret_cast<fattn_kernel_ptr_t>(fattn_kernel), cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
-            shared_memory_limit_raised[id] = true;
+            ctx_gen_last_raised[id] = current_gen;
         }
 #endif // !defined(GGML_USE_MUSA)
     }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -354,6 +354,23 @@ const ggml_cuda_device_info & ggml_cuda_info() {
     return info;
 }
 
+// Per-device generation counter that increments on each cudaDeviceReset call.
+// Used by CUDA function attribute caches (e.g. shared memory limits) to detect
+// CUDA context changes and re-apply the attributes in the new context.
+static std::atomic<int> device_ctx_gen[GGML_CUDA_MAX_DEVICES] = {};
+
+// Wrapper around cudaDeviceReset that bumps the context generation counter
+// before resetting, so static attribute caches know to re-apply their settings.
+// All callers that need cudaDeviceReset should use this function.
+static void ggml_cuda_device_reset(int device) {
+    device_ctx_gen[device]++;
+    CUDA_CHECK(cudaDeviceReset());
+}
+
+int ggml_cuda_ctx_generation(int device) {
+    return device_ctx_gen[device].load();
+}
+
 // #define DEBUG_CUDA_MALLOC
 
 // buffer pool for cuda (legacy)
@@ -5038,8 +5055,10 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
     // If no backends or buffers are active, the cudaMemGetInfo call above lazily created a CUDA
     // context that permanently consumes VRAM. Reset the device to free it.
+    // Use ggml_cuda_device_reset() so the context generation counter is bumped, allowing
+    // CUDA function attribute caches (e.g. shared memory limits) to detect the context change.
     if (ctx->active_count == 0) {
-        CUDA_CHECK(cudaDeviceReset());
+        ggml_cuda_device_reset(ctx->device);
     }
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 }


### PR DESCRIPTION
#23935 reset device context created by `cudaMemGetInfo` but did not reset the kernel static guards

## Overview
Fix a crash in the CUDA flash attention kernel (`GGML_ASSERT(max_blocks_per_sm > 0) failed`) that occurs after a `cudaDeviceReset` destroys the CUDA context. The root cause is that static boolean guards (e.g. `shared_memory_limit_raised`) prevent CUDA function attributes such as `cudaFuncAttributeMaxDynamicSharedMemorySize` from being re-applied in the newly created context after the reset.

This can happen in the llama-server router mode when a model wakes from sleep: during reload, `common_fit_params` queries GPU memory via `ggml_backend_cuda_device_get_memory()`, which calls `cudaDeviceReset()` when no buffers are active. This destroys the existing CUDA context, but the static attribute guards remain `true` and skip re-setting the attributes for the new context.

The fix introduces a per-device context generation counter that is bumped on every `cudaDeviceReset`. Static attribute caches now compare the current generation instead of a boolean, so they correctly re-apply their settings when the context has changed.

### Changes
- **`ggml-cuda.cu`**: Add `device_ctx_gen[]` generation array, `ggml_cuda_device_reset()` wrapper (increments gen + calls `cudaDeviceReset`), and `ggml_cuda_ctx_generation()` accessor. Replace direct `cudaDeviceReset` call in `ggml_backend_cuda_device_get_memory()` with the wrapper.
- **`common.cuh`**: Add `ggml_cuda_ctx_generation()` declaration. Update `CUDA_SET_SHARED_MEMORY_LIMIT` macro to use generation-based check instead of a static bool.
- **`fattn-mma-f16.cuh`**: Update two inline shared memory limit guards to use generation-based check.

## Additional information
### what I see in log
```
[54387] 1.57.145.136 I srv  update_slots: all slots are idle
[54387] 121.57.649.356 I que    start_loop: entering sleeping state
[54387] cmd_child_to_router:sleep
[54387] 121.57.649.738 I srv  handle_sleep: server is entering sleeping state
[54387] 183.17.201.220 I que    start_loop: exiting sleeping state
[54387] cmd_child_to_router:ready
[54387] 183.17.201.555 I srv  handle_sleep: server is exiting sleeping state
[54387] 183.17.201.582 I srv    load_model: loading model '/home/sunyongyue/M36D.gguf'
[54387] 183.18.301.119 I srv    load_model: [spec] estimated memory usage of MTP context is 1869.48 MiB
[54387] 183.18.301.186 I common_init_result: fitting params to device memory ...
[54387] 183.18.301.194 I common_init_result: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)
[54387] 183.19.333.556 W common_fit_params: failed to fit params to free device memory: n_gpu_layers already set by user to 999, abort
[54387] 183.28.440.975 W llama_context: n_ctx_seq (229376) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
[54387] 183.28.698.620 I common_init_from_params: warming up the model with an empty run - please wait ... (--no-warmup to disable)
[54387] 183.28.777.741 I srv    load_model: creating MTP draft context against the target model '/home/sunyongyue/M36D.gguf'
[54387] 183.28.777.781 W llama_context: n_ctx_seq (229376) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
[54387] 183.29.023.837 I srv    load_model: initializing slots, n_slots = 3
[54387] 183.29.109.661 I common_context_can_seq_rm: the context supports bounded partial sequence removal
[54387] 183.29.139.427 I common_speculative_impl_draft_mtp: adding speculative implementation 'draft-mtp'
[54387] 183.29.139.441 I common_speculative_impl_draft_mtp: - n_max=3, n_min=0, p_min=0.00, n_embd=5120, backend_sampling=1
[54387] 183.29.139.443 I common_speculative_impl_draft_mtp: - gpu_layers=-1, cache_k=q8_0, cache_v=q4_0, ctx_tgt=yes, ctx_dft=yes, devices=[default]
[54387] 183.29.438.306 I srv    load_model: speculative decoding context initialized
[54387] 183.29.438.318 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 229376
[54387] 183.29.438.339 I slot   load_model: id  1 | task -1 | new slot, n_ctx = 229376
[54387] 183.29.438.341 I slot   load_model: id  2 | task -1 | new slot, n_ctx = 229376
[54387] 183.29.438.404 I srv    load_model: prompt cache is enabled, size limit: 8192 MiB
[54387] 183.29.438.412 I srv    load_model: use `--cache-ram 0` to disable the prompt cache
[54387] 183.29.457.231 I srv    load_model: for more info see https://github.com/ggml-org/llama.cpp/pull/16391
[54387] 183.29.457.241 I srv    load_model: context checkpoints enabled, max = 4, min spacing = 4096
[54387] 183.29.457.573 I srv  update_slots: all slots are idle
[54387] 183.29.482.908 I srv  params_from_: Chat format: peg-native
[54387] 183.29.485.005 I slot get_availabl: id  2 | task -1 | selected slot by LRU, t_last = -1
[54387] 183.29.485.014 I srv  get_availabl: updating prompt cache
[54387] 183.29.485.028 I srv          load:  - looking for better prompt, base f_keep = -1.000, sim = 0.000
[54387] 183.29.485.033 I srv        update:  - cache state: 0 prompts, 0.000 MiB (limits: 8192.000 MiB, 229376 tokens, 8589934592 est)
[54387] 183.29.485.034 I srv  get_availabl: prompt cache update took 0.02 ms
[54387] 183.29.485.129 I slot launch_slot_: id  2 | task 760 | processing task, is_child = 0
[54387] 183.29.517.747 I srv  params_from_: Chat format: peg-native
[54387] /home/sunyongyue/wkspace/llama.cpp/ggml/src/ggml-cuda/template-instances/../fattn-common.cuh:1110: GGML_ASSERT(max_blocks_per_sm > 0) failed
[54387] gdb: /home/linuxbrew/.linuxbrew/lib/libncursesw.so.6: no version information available (required by gdb)
[54387] gdb: /home/linuxbrew/.linuxbrew/lib/libncursesw.so.6: no version information available (required by gdb)
[54387] gdb: /home/linuxbrew/.linuxbrew/lib/libncursesw.so.6: no version information available (required by gdb)
[54387] [New LWP 1906452]
[54387] [New LWP 1906454]
[54387] [New LWP 1906455]
[54387] [New LWP 1906456]
[54387] [New LWP 1906457]
[54387] [New LWP 1906458]
[54387] [New LWP 1906459]
[54387] [New LWP 1906460]
[54387] [New LWP 1906461]
[54387] [New LWP 1906484]
[54387] [New LWP 1932387]
[54387] [New LWP 1932404]
[54387] [Thread debugging using libthread_db enabled]
[54387] Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[54387] 0x00007f4981d99b57 in __GI___wait4 (pid=1932414, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
[54387] 30	../sysdeps/unix/sysv/linux/wait4.c: No such file or directory.
[54387] #0  0x00007f4981d99b57 in __GI___wait4 (pid=1932414, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
[54387] 30	in ../sysdeps/unix/sysv/linux/wait4.c
[54387] #1  0x00007f498138f44b in ggml_print_backtrace () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libggml-base.so.0
[54387] #2  0x00007f498138f59e in ggml_abort () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libggml-base.so.0
[54387] #3  0x00007f497e561bd7 in void launch_fattn<256, 32, 2>(ggml_backend_cuda_context&, ggml_tensor*, void (*)(char const*, char const*, char const*, char const*, char const*, int const*, float*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int, int, int, int, int, int, int, int, int, long, int, int, long, int, int, int, int, int, long), int, unsigned long, int, bool, bool, bool, int) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libggml-cuda.so.0
[54387] #4  0x00007f497e561ef3 in void ggml_cuda_flash_attn_ext_mma_f16_case<256, 256, 32, 2>(ggml_backend_cuda_context&, ggml_tensor*) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libggml-cuda.so.0
[54387] #5  0x00007f497e1b562d in ggml_backend_cuda_graph_compute(ggml_backend*, ggml_cgraph*) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libggml-cuda.so.0
[54387] #6  0x00007f49813ab687 in ggml_backend_sched_graph_compute_async () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libggml-base.so.0
[54387] #7  0x00007f4981515e51 in llama_context::graph_compute(ggml_cgraph*, bool) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libllama.so.0
[54387] #8  0x00007f4981518454 in llama_context::process_ubatch(llama_ubatch const&, llm_graph_type, llama_memory_context_i*, ggml_status&) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libllama.so.0
[54387] #9  0x00007f498151f8c2 in llama_context::decode(llama_batch const&) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libllama.so.0
[54387] #10 0x00007f498152108b in llama_decode () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libllama.so.0
[54387] #11 0x00007f498225d6f0 in server_context_impl::update_slots() () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libllama-server-impl.so
[54387] #12 0x00007f49822e7a61 in server_queue::start_loop(long) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libllama-server-impl.so
[54387] #13 0x00007f49821bfaa3 in llama_server(int, char**) () from /home/sunyongyue/wkspace/llama.cpp/build/bin/libllama-server-impl.so
[54387] #14 0x00007f4981ced24a in __libc_start_call_main (main=main@entry=0x5610bdf91180 <main>, argc=argc@entry=59, argv=argv@entry=0x7ffd597024a8) at ../sysdeps/nptl/libc_start_call_main.h:58
[54387] 58	../sysdeps/nptl/libc_start_call_main.h: No such file or directory.
[54387] #15 0x00007f4981ced305 in __libc_start_main_impl (main=0x5610bdf91180 <main>, argc=59, argv=0x7ffd597024a8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffd59702498) at ../csu/libc-start.c:360
[54387] 360	../csu/libc-start.c: No such file or directory.
[54387] #16 0x00005610bdf911b1 in _start ()
[54387] [Inferior 1 (process 1906446) detached]
```

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES