### PR TITLE
Fix llama-server router mode removes "UD-" prefix from auto-discovere…

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -516,7 +516,7 @@ struct gguf_split_info {
 
 static gguf_split_info get_gguf_split_info(const std::string & path) {
     static const std::regex re_split("^(.+)-([0-9]{5})-of-([0-9]{5})$", std::regex::icase);
-    static const std::regex re_tag("[-.]([A-Z0-9_]+)$", std::regex::icase);
+    static const std::regex re_tag("[-.]([A-Z]+-[A-Z0-9_]+|[A-Z0-9_]+)$");
     std::smatch m;
 
     std::string prefix = path;


### PR DESCRIPTION
## Overview

Fix an issue in `llama-server` router mode where auto-discovered Unsloth models lose the `UD-` prefix in their generated model IDs.

Previously, a model downloaded with:

```bash
llama-server -hf unsloth/gemma-4-12B-it-qat-GGUF:UD-Q4_K_XL
```

would be auto-discovered in router mode as:

```text
unsloth/gemma-4-12B-it-qat-GGUF:Q4_K_XL
```

instead of the expected:

```text
unsloth/gemma-4-12B-it-qat-GGUF:UD-Q4_K_XL
```

This caused the generated model ID, alias, and `hf-repo` value to differ from the original repository identifier even though the GGUF filename correctly contained the `UD-` prefix.

The fix preserves the full quantization suffix when constructing model identifiers for auto-discovered Hugging Face models, ensuring Unsloth models retain their correct names.

Fixes #24690.

## Additional information

The issue was reproducible with Unsloth GGUF models using quantization variants such as `UD-Q4_K_XL`. Router mode incorrectly stripped the `UD-` portion during model discovery, resulting in mismatched model IDs and launch arguments.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES – OpenCode was used to assist with code development and implementation. ChatGPT was used to help draft the PR description. All code changes, testing, verification, and final submission were reviewed by me.