### PR TITLE
docs: fix export-lora --lora-scaled syntax

### DIFF
--- a/tools/export-lora/README.md
+++ b/tools/export-lora/README.md
@@ -6,11 +6,10 @@ Apply LORA adapters to base model and export the resulting model.
 usage: llama-export-lora [options]
 
 options:
-  -m,    --model                  model path from which to load base model (default '')
-         --lora FNAME             path to LoRA adapter  (can be repeated to use multiple adapters)
-         --lora-scaled FNAME S    path to LoRA adapter with user defined scaling S  (can be repeated to use multiple adapters)
-  -t,    --threads N              number of threads to use during computation (default: 4)
-  -o,    --output FNAME           output file (default: 'ggml-lora-merged-f16.gguf')
+  -m,    --model FNAME                  model path from which to load base model
+         --lora FNAME                   path to LoRA adapter (use comma-separated values to load multiple adapters)
+         --lora-scaled FNAME:SCALE,...  path to LoRA adapter with user defined scaling (format: FNAME:SCALE,...)
+  -o,    --output, --output-file FNAME  output file (default: 'ggml-lora-merged-f16.gguf')
 ```
 
 For example:
@@ -22,12 +21,11 @@ For example:
     --lora lora-open-llama-3b-v2-english2tokipona-chat-LATEST.gguf
 ```
 
-Multiple LORA adapters can be applied by passing multiple `--lora FNAME` or `--lora-scaled FNAME S` command line parameters:
+Multiple LORA adapters can be applied by passing comma-separated values to `--lora FNAME` or `--lora-scaled FNAME:SCALE,...`:
 
 ```bash
 ./bin/llama-export-lora \
     -m your_base_model.gguf \
     -o your_merged_model.gguf \
-    --lora-scaled lora_task_A.gguf 0.5 \
-    --lora-scaled lora_task_B.gguf 0.5
+    --lora-scaled lora_task_A.gguf:0.5,lora_task_B.gguf:0.5
 ```


### PR DESCRIPTION
## Overview

While setting up a LoRA workflow, I noticed that `tools/export-lora/README.md` no longer matches the current `llama-export-lora` CLI behavior.

The README documents `--lora-scaled FNAME S`, but the current help output and parser expect `--lora-scaled FNAME:SCALE,...`.

This PR updates the README option description and multi-LoRA example to use the current syntax. No behavior is changed.

## Additional information

This appears to have become stale after #18056 migrated repeated arguments to comma-separated syntax.

## Testing

- Ran `llama-export-lora --help`
- Verified `--lora-scaled foo.gguf 0.5` fails argument parsing with `lora-scaled format: FNAME:SCALE`
- Verified `--lora-scaled foo.gguf:0.5` passes argument parsing and proceeds to model loading

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES 
- I used Codex as an assistive tool to inspect the current CLI help/source and discuss this documentation-only update. I manually reviewed the README diff and understand the submitted change.