### PR TITLE
openvino: Fix Windows x64 (OpenVINO) release link.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -542,6 +542,7 @@ jobs:
     steps:
       - name: Set OpenVINO version output
         id: openvino_version
+        shell: bash
         run: echo "value=${{ env.OPENVINO_VERSION_MAJOR }}" >> $GITHUB_OUTPUT
 
       - name: Clone


### PR DESCRIPTION
## Overview

Fixes the Windows x64 (OpenVINO) release link.

The `windows-openvino` release job output-writing step is updated to use `shell: bash` to match the ` >> $GITHUB_OUTPUT` syntax. 
This step ran with PowerShell, which requires the $ env:$GITHUB_OUTPUT syntax. As a result, `needs.windows-openvino.outputs.openvino_version` was empty when generating the release notes and produced a broken link like:
`llama-b9682-bin-win-openvino--x64.zip` instead of `llama-b9682-bin-win-openvino-2026.2-x64.zip`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
