### PR TITLE
convert : MXFP4 expert passthrough for Gemma4 (vllm_fused_moe)

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1097,6 +1097,57 @@ class ModelBase:
             raise NotImplementedError(f'Architecture {arch!r} not supported!') from None
 
 
+class MXFP4MoEMixin:
+    """Repack transformers/HF MXFP4 expert blocks into native GGUF MXFP4 tensors.
+
+    Shared by GptOssModel and Gemma4Model. ``transform_nibble_layout`` converts the
+    transformers mxfp4 nibble order into ggml's; ``repack_mxfp4`` prepends the E8M0
+    scale to each block and writes the result straight to the gguf_writer as ggml
+    MXFP4 (no dequantization). ``blocks`` is [..., n_block, 16] uint8 and ``scales``
+    is [..., n_block] uint8.
+    """
+
+    def transform_nibble_layout(self, tensor: Tensor) -> Tensor:
+        assert tensor.dtype == torch.uint8
+        assert tensor.shape[-1] == 16
+        # swap nibbles
+        t_lo = tensor & 0x0F
+        t_hi = tensor & 0xF0
+        t_swapped = (t_lo << 4) | (t_hi >> 4)
+        tensor = t_swapped
+        # transform aaaa...bbbb... to abababab...
+        blk_a, blk_b = tensor.chunk(2, dim=-1)
+        # get a_
+        blk_a0 = (blk_a & 0xF0).view(-1, 1)
+        blk_a1 = (blk_a << 4).view(-1, 1)
+        blk_a = torch.stack((blk_a0, blk_a1), dim=2).view(tensor.shape)
+        # get _b
+        blk_b0 = (blk_b >> 4).view(-1, 1)
+        blk_b1 = (blk_b & 0x0F).view(-1, 1)
+        blk_b = torch.stack((blk_b0, blk_b1), dim=2).view(tensor.shape)
+        # swap once more
+        out = blk_a | blk_b
+        out_h = out & 0xF0
+        out_l = out & 0x0F
+        out = (out_h >> 4) | (out_l << 4)
+        return out
+
+    def repack_mxfp4(self, new_name: str, blocks: Tensor, scales: Tensor):
+        assert blocks.dtype == torch.uint8
+        assert scales.dtype == torch.uint8
+        scales = scales.unsqueeze(-1)
+        assert len(blocks.shape) == 4
+        assert len(scales.shape) == 4
+        blocks = self.transform_nibble_layout(blocks)
+        new_data = torch.concat((scales, blocks), dim=-1)
+        new_shape = [new_data.shape[0], new_data.shape[1], new_data.shape[2] * 32]
+        logger.info(f"Repacked {new_name} with shape {new_shape} and quantization MXFP4")
+        # flatten last dim
+        new_data = new_data.view(new_data.shape[0], new_data.shape[1], new_data.shape[2] * new_data.shape[3])
+        new_data = new_data.numpy()
+        self.gguf_writer.add_tensor(new_name, new_data, raw_dtype=gguf.GGMLQuantizationType.MXFP4)
+
+
 class TextModel(ModelBase):
     model_type = ModelType.TEXT
     hf_arch: str

--- a/conversion/gemma.py
+++ b/conversion/gemma.py
@@ -10,7 +10,7 @@ import torch
 if TYPE_CHECKING:
     from torch import Tensor
 
-from .base import MmprojModel, ModelBase, TextModel, gguf, logger
+from .base import LazyTorchTensor, MXFP4MoEMixin, MmprojModel, ModelBase, TextModel, gguf, logger
 
 
 @ModelBase.register("GemmaForCausalLM")
@@ -615,7 +615,7 @@ class Gemma3NModel(Gemma3Model):
 
 
 @ModelBase.register("Gemma4ForConditionalGeneration", "Gemma4ForCausalLM")
-class Gemma4Model(Gemma3Model):
+class Gemma4Model(MXFP4MoEMixin, Gemma3Model):
     model_arch = gguf.MODEL_ARCH.GEMMA4
 
     def norm_shift(self, name: str) -> float:
@@ -739,6 +739,56 @@ class Gemma4Model(Gemma3Model):
                 s = self.model_tensors[w2]
                 self.model_tensors[w2] = lambda s=s, r=r, i=e: s() * r()[i]
         super()._generate_nvfp4_tensors()
+
+    # --- MXFP4 experts (gemma4 "vllm_fused_moe" layout) -------------------
+    # Experts ship as MXFP4 (quant_method="mxfp4", experts only) using the same
+    # per-block byte format as transformers/gpt-oss mxfp4, but with vLLM-fused
+    # tensor names: moe.experts.w13_weight=[gate|up] and moe.experts.w2_weight=down,
+    # each with a sibling _weight_scale. We repack straight to native GGUF MXFP4
+    # rather than dequantizing (the generic dequant_model path has no mxfp4 decoder).
+
+    def dequant_model(self):
+        if self._is_mxfp4:
+            self._generate_mxfp4_tensors()
+            return
+        return super().dequant_model()
+
+    def _generate_mxfp4_tensors(self):
+        # expert intermediate is padded to a kernel-aligned width in the checkpoint;
+        # trim back to expert_feed_forward_length (the value written to the GGUF).
+        n_ff = self.find_hparam(["expert_intermediate_size", "moe_intermediate_size"])
+        assert n_ff % 32 == 0, f"expert ff {n_ff} must be a multiple of the MXFP4 block size (32)"
+
+        tail = "moe.experts.w13_weight.weight"
+        layers = sorted(
+            (k[: -len("w13_weight.weight")], int(re.search(r"\.layers\.(\d+)\.", k).group(1)))
+            for k in self.model_tensors if k.endswith(tail)
+        )
+        for prefix, bid in layers:
+            w13 = LazyTorchTensor.to_eager(self.model_tensors.pop(prefix + "w13_weight.weight")())
+            s13 = LazyTorchTensor.to_eager(self.model_tensors.pop(prefix + "w13_weight_scale.weight")())
+            w2  = LazyTorchTensor.to_eager(self.model_tensors.pop(prefix + "w2_weight.weight")())
+            s2  = LazyTorchTensor.to_eager(self.model_tensors.pop(prefix + "w2_weight_scale.weight")())
+
+            n_expert = w13.shape[0]
+            phys_ff  = w13.shape[1] // 2        # padded per-projection (gate/up) width
+            n_blk_h  = w13.shape[2] // 16       # hidden-dim blocks (n_embd / 32)
+            n_blk_f  = n_ff // 32               # intermediate-dim blocks (after unpad)
+            assert phys_ff >= n_ff, f"layer {bid}: expert ff {phys_ff} < {n_ff}"
+
+            # split fused [gate|up] on the output dim and drop the intermediate padding
+            gate_w, up_w = w13[:, :n_ff, :], w13[:, phys_ff:phys_ff + n_ff, :]
+            gate_s, up_s = s13[:, :n_ff, :], s13[:, phys_ff:phys_ff + n_ff, :]
+            # down: keep all hidden rows, drop padding on the packed intermediate (input) dim
+            n_embd = w2.shape[1]
+            dn_w, dn_s = w2[:, :, :n_ff // 2], s2[:, :, :n_blk_f]
+
+            self.repack_mxfp4(self.format_tensor_name(gguf.MODEL_TENSOR.FFN_GATE_EXP, bid),
+                                      gate_w.reshape(n_expert, n_ff, n_blk_h, 16), gate_s)
+            self.repack_mxfp4(self.format_tensor_name(gguf.MODEL_TENSOR.FFN_UP_EXP, bid),
+                                      up_w.reshape(n_expert, n_ff, n_blk_h, 16), up_s)
+            self.repack_mxfp4(self.format_tensor_name(gguf.MODEL_TENSOR.FFN_DOWN_EXP, bid),
+                                      dn_w.reshape(n_expert, n_embd, n_blk_f, 16), dn_s)
 
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:

--- a/conversion/gpt_oss.py
+++ b/conversion/gpt_oss.py
@@ -7,11 +7,11 @@ import torch
 if TYPE_CHECKING:
     from torch import Tensor
 
-from .base import ModelBase, TextModel, gguf, logger
+from .base import MXFP4MoEMixin, ModelBase, TextModel, gguf, logger
 
 
 @ModelBase.register("GptOssForCausalLM")
-class GptOssModel(TextModel):
+class GptOssModel(MXFP4MoEMixin, TextModel):
     model_arch = gguf.MODEL_ARCH.GPT_OSS
 
     # TODO: remove once MXFP4 is supported more generally
@@ -19,46 +19,6 @@ class GptOssModel(TextModel):
         if self._is_mxfp4:
             return
         return super().dequant_model()
-
-    def transform_nibble_layout(self, tensor):
-        assert tensor.dtype == torch.uint8
-        assert tensor.shape[-1] == 16
-        # swap nibbles
-        t_lo = tensor & 0x0F
-        t_hi = tensor & 0xF0
-        t_swapped = (t_lo << 4) | (t_hi >> 4)
-        tensor = t_swapped
-        # transform aaaa...bbbb... to abababab...
-        blk_a, blk_b = tensor.chunk(2, dim=-1)
-        # get a_
-        blk_a0 = (blk_a & 0xF0).view(-1, 1)
-        blk_a1 = (blk_a << 4).view(-1, 1)
-        blk_a = torch.stack((blk_a0, blk_a1), dim=2).view(tensor.shape)
-        # get _b
-        blk_b0 = (blk_b >> 4).view(-1, 1)
-        blk_b1 = (blk_b & 0x0F).view(-1, 1)
-        blk_b = torch.stack((blk_b0, blk_b1), dim=2).view(tensor.shape)
-        # swap once more
-        out = blk_a | blk_b
-        out_h = out & 0xF0
-        out_l = out & 0x0F
-        out = (out_h >> 4) | (out_l << 4)
-        return out
-
-    def repack_mxfp4(self, new_name: str, blocks: Tensor, scales: Tensor):
-        assert blocks.dtype == torch.uint8
-        assert scales.dtype == torch.uint8
-        scales = scales.unsqueeze(-1)
-        assert len(blocks.shape) == 4
-        assert len(scales.shape) == 4
-        blocks = self.transform_nibble_layout(blocks)
-        new_data = torch.concat((scales, blocks), dim=-1)
-        new_shape = [new_data.shape[0], new_data.shape[1], new_data.shape[2] * 32]
-        logger.info(f"Repacked {new_name} with shape {new_shape} and quantization MXFP4")
-        # flatten last dim
-        new_data = new_data.view(new_data.shape[0], new_data.shape[1], new_data.shape[2] * new_data.shape[3])
-        new_data = new_data.numpy()
-        self.gguf_writer.add_tensor(new_name, new_data, raw_dtype=gguf.GGMLQuantizationType.MXFP4)
 
     def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
         blocks0: Tensor = torch.zeros(1)

--- a/src/llama-hparams.h
+++ b/src/llama-hparams.h
@@ -7,7 +7,7 @@
 
 // bump if necessary
 #define LLAMA_MAX_LAYERS  512
-#define LLAMA_MAX_EXPERTS 512 // Qwen3 Next
+#define LLAMA_MAX_EXPERTS 1024 // gemma-4-120b-a12b (656 experts)
 
 enum llama_expert_gating_func_type {
     LLAMA_EXPERT_GATING_FUNC_TYPE_NONE           = 0,


### PR DESCRIPTION
> **Disclosure:** developed with AI assistance (Claude Code) — see the disclosure comment. I reviewed the diff and verified it end-to-end (converted + ran `gemma-4-120b-a12b-coder` on GPU).

## Summary

Adds native **MXFP4 expert passthrough** for Gemma4 so that `quant_method="mxfp4"` checkpoints convert without a dequant→requant round-trip, and raises the expert cap so 656-expert Gemma4 models load.

Today these checkpoints die in `Gemma4Model` → `base.dequant_model()` with `NotImplementedError: Quant method is not yet supported: 'mxfp4'`. The experts are already 4-bit-native; the right move is to repack them straight to GGUF MXFP4 (as `GptOssModel` does) — not to inflate them to BF16 and quantize back.

## What changed

- **`conversion/base.py`** — new `MXFP4MoEMixin` holding the shared block repack (`transform_nibble_layout` + `repack_mxfp4`), lifted out of `GptOssModel`.
- **`conversion/gpt_oss.py`** — `GptOssModel` now mixes in `MXFP4MoEMixin`; the two methods moved verbatim, no behavior change.
- **`conversion/gemma.py` — `Gemma4Model`** — mixes in `MXFP4MoEMixin`; `dequant_model()` skips the generic dequant when `_is_mxfp4`; `_generate_mxfp4_tensors()` pops the vLLM-fused experts per layer and writes native MXFP4 — `w13_weight` (`[gate‖up]`) → `ffn_gate_exps`+`ffn_up_exps`, `w2_weight` → `ffn_down_exps`, each with its `_weight_scale`. Block format is identical to transformers mxfp4; the work is layout-only (de-concat `w13`, reshape the flattened block dim, trim the kernel-aligned intermediate back to `expert_feed_forward_length` — pad rows are zero).
- **`src/llama-hparams.h`** — `LLAMA_MAX_EXPERTS` 512 → 1024. `gemma-4-120b-a12b` has 656 experts and otherwise aborts in `llama_model_base::load_hparams` (`GGML_ASSERT(n_expert <= LLAMA_MAX_EXPERTS)`).

No C++ graph changes: GEMMA4's `build_moe_ffn` already consumes `ffn_{gate,up,down}_exps` via `mul_mat_id`, which handles MXFP4 on all backends.

## Validation

- **Bit-exact.** Repacked blocks decoded through ggml's MXFP4 path (`kvalues_mxfp4`, `e8m0_to_fp32_half`) match `transformers.integrations.mxfp4.convert_moe_packed_tensors` on real layer-0 experts with `max|Δ| = 0` for gate/up/down — before and after the mixin refactor.
- **End-to-end.** Converted `gemma-4-120b-a12b-coder` → 67 GB GGUF (ftype `MXFP4_MOE`, 90 MXFP4 expert tensors, shapes `ffn_gate_exps=[2816,704,656]`, `ffn_down_exps=[704,2816,656]`), loaded with full GPU offload on Vulkan (RADV gfx1150), generated coherent output (`"Paris"` via chat template; correct factorial code).

## Anticipated questions

**Why does Gemma4 need its own `_generate_mxfp4_tensors` if the repack is shared?**
The byte-level repack *is* shared (`MXFP4MoEMixin.repack_mxfp4`, used by both models). What's Gemma4-specific is the plumbing: the source tensors are vLLM-fused — `w13` is `[gate‖up]` *concatenated* (not gpt-oss's *interleaved* `gate_up_proj`), the block dim is flattened, and the expert intermediate is padded. So de-fusion, reshaping, and unpadding live in `Gemma4Model`; the common part is the mixin.

**Why trim the expert intermediate 768 → 704?**
The checkpoint zero-pads each expert projection to a kernel-aligned width (768). `set_gguf_parameters` writes `expert_feed_forward_length = moe_intermediate_size = 704`, and the C++ side allocates the expert tensors against that. Emitting 768-wide tensors would mismatch the metadata. The pad rows are verified zero, so trimming is lossless.

**Does this affect the existing Gemma4 NVFP4 path?**
No. Everything is gated on `self._is_mxfp4`. `_generate_nvfp4_tensors` and the per-expert NVFP4 layout it handles are untouched.

**Is `LLAMA_MAX_EXPERTS = 1024` safe?**
The macro only gates the load-time assert and sizes `cur_experts[LLAMA_MAX_EXPERTS]` in `llama-graph.cpp` — a stack array of pointers (1024 × 8 B = 8 KB). 1024 is the next power of two above 656.

**Memory cost of the converter change?**
`LazyTorchTensor.to_eager` materializes one layer's experts at a time (~2 GB uint8, transient, freed each iteration) — same order as the gpt-oss path, no full-model BF16 intermediate.

**Is the `vllm_fused_moe` split assumed or verified?**
Verified empirically against this checkpoint (concat boundary located via the zero-padding pattern; block format checked bit-exact), not just inferred from `converter_layout`. Other Gemma4 mxfp4 export layouts, if they appear, would need their own handling — called out below.

## Limitations

- Only the `vllm_fused_moe` MXFP4 export layout is handled (the one Gemma4 mxfp4 checkpoints currently ship).

## Test plan

- [x] `convert_hf_to_gguf.py` on an mxfp4 Gemma4 checkpoint → MXFP4_MOE GGUF
- [x] Bit-exact unit check vs transformers reference dequant (pre- and post-refactor)
- [x] Load + generate on Vulkan with `-ngl 99`
- [ ] CI / a small fixture, if you want one added
