### PR TITLE
server : add GET/POST /cvectors for control vector hot-swap

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1163,6 +1163,46 @@ To know the `id` of the adapter, use GET `/lora-adapters`
 ]
 ```
 
+### GET `/cvectors`: Get list of all control vectors
+
+Returns control vectors loaded at startup via `--control-vector` or `--control-vector-scaled`. Returns an empty array if none were loaded.
+
+By default each vector is loaded with scale `1.0`. Vectors omitted from a subsequent POST are set to `0.0`.
+
+**Note:** POST applies the new scale immediately without clearing slot KV caches, matching the behavior of POST `/lora-adapters`.
+
+**Response format**
+
+```json
+[
+    {
+        "id": 0,
+        "path": "my_vector.gguf",
+        "scale": 1.0
+    }
+]
+```
+
+### POST `/cvectors`: Set control vector scales
+
+Updates the strength of loaded control vectors and re-applies them to the model. Vectors not present in the request are set to scale `0.0`.
+
+To find the `id` of a vector, use GET `/cvectors`.
+
+**Request format**
+
+```json
+[
+  {"id": 0, "scale": 0.8}
+]
+```
+
+**Response format**
+
+```json
+{ "success": true }
+```
+
 ## OpenAI-compatible API Endpoints
 
 ### GET `/v1/models`: OpenAI-compatible Model Info API

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -127,6 +127,18 @@ bool lora_should_clear_cache(
         !lora_all_alora(next));
 }
 
+std::map<int, float> parse_cvector_request(const json & data) {
+    std::map<int, float> cvectors;
+
+    for (const auto & entry : data) {
+        int id      = json_value(entry, "id", -1);
+        float scale = json_value(entry, "scale", 0.0f);
+        cvectors[id] = scale;
+    }
+
+    return cvectors;
+}
+
 std::map<int, float> parse_lora_request(const json & data) {
     std::map<int, float> lora;
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -110,6 +110,7 @@ bool lora_should_clear_cache(
         const std::vector<common_adapter_lora_info> & current,
         const std::vector<common_adapter_lora_info> & next);
 
+std::map<int, float> parse_cvector_request(const json & data);
 std::map<int, float> parse_lora_request(const json & data);
 
 bool are_lora_equal(

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2491,6 +2491,52 @@ private:
                     res->id = task.id;
                     queue_results.send(std::move(res));
                 } break;
+            case SERVER_TASK_TYPE_SET_CVEC:
+                {
+                    auto new_cvectors = params_base.control_vectors;
+
+                    bool valid = true;
+                    for (const auto & entry : task.set_cvector) {
+                        if (entry.first < 0 || (size_t) entry.first >= new_cvectors.size()) {
+                            send_error(task, "Invalid control vector ID", ERROR_TYPE_INVALID_REQUEST);
+                            valid = false;
+                            break;
+                        }
+                    }
+                    if (!valid) {
+                        break;
+                    }
+
+                    for (size_t i = 0; i < new_cvectors.size(); ++i) {
+                        const auto it = task.set_cvector.find(i);
+                        new_cvectors[i].strength =
+                                it != task.set_cvector.end() ? it->second : 0.0f;
+                    }
+
+                    const auto cvec = common_control_vector_load(new_cvectors);
+                    if (cvec.n_embd == -1) {
+                        send_error(task, "Failed to load control vectors", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
+
+                    const int err = llama_set_adapter_cvec(
+                            ctx_tgt,
+                            cvec.data.data(),
+                            cvec.data.size(),
+                            cvec.n_embd,
+                            params_base.control_vector_layer_start,
+                            params_base.control_vector_layer_end);
+                    if (err != 0) {
+                        send_error(task, "Failed to apply control vectors");
+                        break;
+                    }
+
+                    params_base.control_vectors = std::move(new_cvectors);
+
+                    auto res = std::make_unique<server_task_result_apply_cvector>();
+                    res->id = task.id;
+                    queue_results.send(std::move(res));
+                } break;
         }
     }
 
@@ -4833,6 +4879,38 @@ void server_routes::init_routes() {
         }
 
         GGML_ASSERT(dynamic_cast<server_task_result_apply_lora*>(result.get()) != nullptr);
+        res->ok(result->to_json());
+        return res;
+    };
+
+    this->post_cvectors = [this](const server_http_req & req) {
+        auto res = create_response();
+        const json body = json::parse(req.body);
+        if (!body.is_array()) {
+            res->error(format_error_response("Request body must be an array", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+
+        auto & rd = res->rd;
+        {
+            server_task task(SERVER_TASK_TYPE_SET_CVEC);
+            task.id = rd.get_new_id();
+            task.set_cvector = parse_cvector_request(body);
+            rd.post_task(std::move(task));
+        }
+
+        auto result = rd.next(req.should_stop);
+        if (!result) {
+            GGML_ASSERT(req.should_stop());
+            return res;
+        }
+
+        if (result->is_error()) {
+            res->error(result->to_json());
+            return res;
+        }
+
+        GGML_ASSERT(dynamic_cast<server_task_result_apply_cvector*>(result.get()) != nullptr);
         res->ok(result->to_json());
         return res;
     };

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2445,6 +2445,13 @@ private:
                     res->n_erased = n_erased;
                     queue_results.send(std::move(res));
                 } break;
+            case SERVER_TASK_TYPE_GET_CVEC:
+                {
+                    auto res = std::make_unique<server_task_result_get_cvector>();
+                    res->id = task.id;
+                    res->cvectors = params_base.control_vectors;
+                    queue_results.send(std::move(res));
+                } break;
             case SERVER_TASK_TYPE_GET_LORA:
                 {
                     // TODO @ngxson : make lora_adapters a dedicated member of server_context
@@ -4737,6 +4744,34 @@ void server_routes::init_routes() {
             top_n);
 
         res->ok(root);
+        return res;
+    };
+
+    this->get_cvectors = [this](const server_http_req & req) {
+        auto res = create_response();
+
+        auto & rd = res->rd;
+        {
+            server_task task(SERVER_TASK_TYPE_GET_CVEC);
+            task.id = rd.get_new_id();
+            rd.post_task(std::move(task));
+        }
+
+        // get the result
+        auto result = rd.next(req.should_stop);
+        if (!result) {
+            // connection was closed
+            GGML_ASSERT(req.should_stop());
+            return res;
+        }
+
+        if (result->is_error()) {
+            res->error(result->to_json());
+            return res;
+        }
+
+        GGML_ASSERT(dynamic_cast<server_task_result_get_cvector*>(result.get()) != nullptr);
+        res->ok(result->to_json());
         return res;
     };
 

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -126,6 +126,7 @@ struct server_routes {
     server_http_context::handler_t post_embeddings_oai;
     server_http_context::handler_t post_rerank;
     server_http_context::handler_t get_cvectors;
+    server_http_context::handler_t post_cvectors;
     server_http_context::handler_t get_lora_adapters;
     server_http_context::handler_t post_lora_adapters;
 

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -125,6 +125,7 @@ struct server_routes {
     server_http_context::handler_t post_embeddings;
     server_http_context::handler_t post_embeddings_oai;
     server_http_context::handler_t post_rerank;
+    server_http_context::handler_t get_cvectors;
     server_http_context::handler_t get_lora_adapters;
     server_http_context::handler_t post_lora_adapters;
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1951,6 +1951,24 @@ json server_task_result_slot_erase::to_json() {
 }
 
 //
+// server_task_result_get_cvector
+//
+
+json server_task_result_get_cvector::to_json() {
+    json result = json::array();
+    for (size_t i = 0; i < cvectors.size(); ++i) {
+        auto & cvec = cvectors[i];
+        json entry = {
+            {"id",            i},
+            {"path",          cvec.fname},
+            {"scale",         cvec.strength},
+        };
+        result.push_back(std::move(entry));
+    }
+    return result;
+}
+
+//
 // server_task_result_get_lora
 //
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1993,6 +1993,14 @@ json server_task_result_get_lora::to_json() {
 }
 
 //
+// server_task_result_apply_cvector
+//
+
+json server_task_result_apply_cvector::to_json() {
+    return json {{ "success", true }};
+}
+
+//
 // server_task_result_apply_lora
 //
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -26,6 +26,7 @@ enum server_task_type {
     SERVER_TASK_TYPE_SLOT_RESTORE,
     SERVER_TASK_TYPE_SLOT_ERASE,
     SERVER_TASK_TYPE_GET_CVEC,
+    SERVER_TASK_TYPE_SET_CVEC,
     SERVER_TASK_TYPE_GET_LORA,
     SERVER_TASK_TYPE_SET_LORA,
 };
@@ -169,6 +170,9 @@ struct server_task {
 
     // used by SERVER_TASK_TYPE_METRICS
     bool metrics_reset_bucket = false;
+
+    // used by SERVER_TASK_TYPE_SET_CVEC
+    std::map<int, float> set_cvector; // mapping control vector ID -> scale
 
     // used by SERVER_TASK_TYPE_SET_LORA
     std::map<int, float> set_lora; // mapping adapter ID -> scale
@@ -584,6 +588,10 @@ struct server_task_result_get_lora : server_task_result {
     };
     std::vector<lora> loras;
 
+    virtual json to_json() override;
+};
+
+struct server_task_result_apply_cvector : server_task_result {
     virtual json to_json() override;
 };
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -25,6 +25,7 @@ enum server_task_type {
     SERVER_TASK_TYPE_SLOT_SAVE,
     SERVER_TASK_TYPE_SLOT_RESTORE,
     SERVER_TASK_TYPE_SLOT_ERASE,
+    SERVER_TASK_TYPE_GET_CVEC,
     SERVER_TASK_TYPE_GET_LORA,
     SERVER_TASK_TYPE_SET_LORA,
 };
@@ -567,6 +568,12 @@ struct server_task_result_control : server_task_result {
         }
         return out;
     }
+};
+
+struct server_task_result_get_cvector : server_task_result {
+    std::vector<common_control_vector_load_info> cvectors;
+
+    virtual json to_json() override;
 };
 
 struct server_task_result_get_lora : server_task_result {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -165,6 +165,7 @@ int llama_server(int argc, char ** argv) {
         routes.post_apply_template         = models_routes->proxy_post;
         routes.post_chat_completions_tok   = models_routes->proxy_post;
         routes.post_responses_tok_oai      = models_routes->proxy_post;
+        routes.get_cvectors                = models_routes->proxy_get;
         routes.get_lora_adapters           = models_routes->proxy_get;
         routes.post_lora_adapters          = models_routes->proxy_post;
         routes.get_slots                   = models_routes->proxy_get;
@@ -213,6 +214,8 @@ int llama_server(int argc, char ** argv) {
     ctx_http.post("/responses/input_tokens",           ex_wrapper(routes.post_responses_tok_oai));
     ctx_http.post("/v1/responses/input_tokens",        ex_wrapper(routes.post_responses_tok_oai));
     ctx_http.post("/v1/messages/count_tokens",         ex_wrapper(routes.post_anthropic_count_tokens)); // anthropic token counting
+    // cvectors hotswap
+    ctx_http.get ("/cvectors",                 ex_wrapper(routes.get_cvectors));
     // LoRA adapters hotswap
     ctx_http.get ("/lora-adapters",            ex_wrapper(routes.get_lora_adapters));
     ctx_http.post("/lora-adapters",            ex_wrapper(routes.post_lora_adapters));

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -166,6 +166,7 @@ int llama_server(int argc, char ** argv) {
         routes.post_chat_completions_tok   = models_routes->proxy_post;
         routes.post_responses_tok_oai      = models_routes->proxy_post;
         routes.get_cvectors                = models_routes->proxy_get;
+        routes.post_cvectors               = models_routes->proxy_post;
         routes.get_lora_adapters           = models_routes->proxy_get;
         routes.post_lora_adapters          = models_routes->proxy_post;
         routes.get_slots                   = models_routes->proxy_get;
@@ -216,6 +217,7 @@ int llama_server(int argc, char ** argv) {
     ctx_http.post("/v1/messages/count_tokens",         ex_wrapper(routes.post_anthropic_count_tokens)); // anthropic token counting
     // cvectors hotswap
     ctx_http.get ("/cvectors",                 ex_wrapper(routes.get_cvectors));
+    ctx_http.post("/cvectors",                 ex_wrapper(routes.post_cvectors));
     // LoRA adapters hotswap
     ctx_http.get ("/lora-adapters",            ex_wrapper(routes.get_lora_adapters));
     ctx_http.post("/lora-adapters",            ex_wrapper(routes.post_lora_adapters));

--- a/tools/server/tests/unit/test_cvector.py
+++ b/tools/server/tests/unit/test_cvector.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+# To run the cvector-file tests, set both env vars to matching paths:
+#   CVECTOR_TEST_MODEL=/path/to/model.gguf
+#   CVECTOR_TEST_FILE=/path/to/control_vector.gguf
+CVECTOR_FILE  = os.environ.get("CVECTOR_TEST_FILE", "")
+CVECTOR_MODEL = os.environ.get("CVECTOR_TEST_MODEL", "")
+HAS_CVEC = bool(CVECTOR_FILE and CVECTOR_MODEL
+                and os.path.exists(CVECTOR_FILE)
+                and os.path.exists(CVECTOR_MODEL))
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+
+
+def test_get_cvectors_empty():
+    global server
+    server.start()
+    res = server.make_request("GET", "/cvectors")
+    assert res.status_code == 200
+    assert res.body == []
+
+
+def test_post_cvectors_invalid_id():
+    global server
+    server.start()
+    res = server.make_request("POST", "/cvectors", data=[{"id": 0, "scale": 1.0}])
+    assert res.status_code == 400
+
+
+def test_post_cvectors_non_array():
+    global server
+    server.start()
+    res = server.make_request("POST", "/cvectors", data={"id": 0, "scale": 1.0})
+    assert res.status_code == 400
+
+
+@pytest.mark.skipif(not HAS_CVEC, reason="set CVECTOR_TEST_FILE and CVECTOR_TEST_MODEL to run")
+def test_get_cvectors_lists_startup():
+    global server
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    server.model_file = CVECTOR_MODEL
+    server.control_vector_files = [CVECTOR_FILE]
+    server.start()
+    res = server.make_request("GET", "/cvectors")
+    assert res.status_code == 200
+    assert isinstance(res.body, list)
+    assert len(res.body) == 1
+    entry = res.body[0]
+    assert entry["id"] == 0
+    assert "path" in entry
+    assert entry["scale"] == pytest.approx(1.0)
+
+
+@pytest.mark.skipif(not HAS_CVEC, reason="set CVECTOR_TEST_FILE and CVECTOR_TEST_MODEL to run")
+def test_post_cvectors_changes_scale():
+    global server
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    server.model_file = CVECTOR_MODEL
+    server.control_vector_files = [CVECTOR_FILE]
+    server.start()
+    res = server.make_request("POST", "/cvectors", data=[{"id": 0, "scale": 0.5}])
+    assert res.status_code == 200
+    assert res.body.get("success") is True
+    res = server.make_request("GET", "/cvectors")
+    assert res.status_code == 200
+    assert res.body[0]["scale"] == pytest.approx(0.5)

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -91,6 +91,7 @@ class ServerProcess:
     models_preset: str | None = None
     no_models_autoload: bool | None = None
     lora_files: List[str] | None = None
+    control_vector_files: List[str] | None = None
     enable_ctx_shift: int | None = False
     spec_draft_n_min: int | None = None
     spec_draft_n_max: int | None = None
@@ -217,6 +218,9 @@ class ServerProcess:
         if self.lora_files:
             for lora_file in self.lora_files:
                 server_args.extend(["--lora", lora_file])
+        if self.control_vector_files:
+            for cv_file in self.control_vector_files:
+                server_args.extend(["--control-vector", cv_file])
         if self.enable_ctx_shift:
             server_args.append("--context-shift")
         if self.api_key:


### PR DESCRIPTION
- **server: add GET /cvectors endpoint to list loaded control vectors**
- **server: add POST /cvectors endpoint to hot-swap control vectors**
- **server : add unit tests for GET/POST /cvectors**
- **server : document GET/POST /cvectors in README**

## Overview

This PR adds server support for managing loaded control vectors through HTTP endpoints.

Specifically, it adds:
1. GET /cvectors to list currently loaded control vectors
2. POST /cvectors to hot-swap control vectors at runtime
3. Unit tests covering the new GET and POST /cvectors endpoints
4. README documentation describing the new API usage

This makes control vectors easier to inspect and update through the server API, similar to existing runtime adapter-management workflows.

## Additional information

Related issue: #10685

Testing:

All relevant server tests pass locally.
Added unit test coverage for both listing loaded control vectors and updating control vectors through the server API.

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) 
- AI usage disclosure:  I used AI assistance to help review the high-level structure of the change. I am responsible for the submitted code, tests, and documentation, and I have reviewed and validated the changes myself.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
