### PR TITLE
fix(metal): guard `kernel_concat_bf16` kernel instantiation

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -7557,7 +7557,9 @@ typedef decltype(kernel_concat<float>) kernel_concat_t;
 
 template [[host_name("kernel_concat_f32")]]  kernel kernel_concat_t kernel_concat<float>;
 template [[host_name("kernel_concat_f16")]]  kernel kernel_concat_t kernel_concat<half>;
+#if defined(GGML_METAL_HAS_BF16)
 template [[host_name("kernel_concat_bf16")]] kernel kernel_concat_t kernel_concat<bfloat>;
+#endif
 template [[host_name("kernel_concat_i8")]]   kernel kernel_concat_t kernel_concat<char>;
 template [[host_name("kernel_concat_i16")]]  kernel kernel_concat_t kernel_concat<short>;
 template [[host_name("kernel_concat_i32")]]  kernel kernel_concat_t kernel_concat<int>;


### PR DESCRIPTION
## Overview

cont: #24724 

Guards the inclusion of bf16 kernel concat to avoid `error: use of undeclared identifier 'bfloat'; did you mean 'float'?`

## Additional information

[Failed CI Run](https://github.com/abetlen/llama-cpp-python/actions/runs/27736314067/job/82053814217)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, gpt 5.5 xhigh