### PR TITLE
mtmd: add NVIDIA LocateAnything-3B vision support

### DIFF
--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -270,6 +270,7 @@ MMPROJ_MODEL_MAP: dict[str, str] = {
     "Lfm2AudioForConditionalGeneration": "lfm2",
     "Lfm2VlForConditionalGeneration": "lfm2",
     "LightOnOCRForConditionalGeneration": "lighton_ocr",
+    "LocateAnythingForConditionalGeneration": "locateanything",
     "Llama4ForConditionalGeneration": "llama4",
     "LlavaForConditionalGeneration": "llava",
     "MERaLiON2ForConditionalGeneration": "ultravox",

--- a/conversion/locateanything.py
+++ b/conversion/locateanything.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable, TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+from .base import MmprojModel, ModelBase, gguf
+
+
+@ModelBase.register("LocateAnythingForConditionalGeneration")
+class LocateAnythingModel(MmprojModel):
+    """NVIDIA LocateAnything-3B vision tower + connector.
+
+    The encoder is MoonViT-SO-400M, identical to the one Kimi-K2.5 uses, so we reuse the existing
+    MoonViT tensor mapping (rename the ``vision_model.`` prefix to ``vision_tower.``) and the
+    interleaved->split Q/K permute. The connector is the "Eagle MLP"
+    (LayerNorm(4608) -> Linear -> GELU -> Linear); it maps onto the shared ``mm_projector`` names.
+
+    The text tower is plain Qwen2.5-3B and is converted separately by Qwen2Model, which auto-routes
+    via ``text_config.architectures = ["Qwen2ForCausalLM"]`` (no extra code here).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert self.hparams_vision is not None, "LocateAnything requires vision_config in model config"
+
+        self.patch_size = self.hparams_vision.get("patch_size", 14)
+        self.merge_kernel_size = tuple(self.hparams_vision.get("merge_kernel_size", [2, 2]))
+
+        # vision_config has no image_size; derive one from the learned pos-emb grid for the base class.
+        pos_emb_h = self.hparams_vision.get("init_pos_emb_height", 64)
+        self.hparams_vision["image_size"] = pos_emb_h * self.patch_size
+
+    def set_gguf_parameters(self):
+        super().set_gguf_parameters()
+        assert self.hparams_vision is not None
+
+        self.gguf_writer.add_clip_projector_type(gguf.VisionProjectorType.LOCATEANYTHING)
+
+        # native learned position-embedding grid (interpolated at runtime for other resolutions)
+        self.gguf_writer.add_uint32("vision.pos_emb_height", self.hparams_vision.get("init_pos_emb_height", 64))
+        self.gguf_writer.add_uint32("vision.pos_emb_width", self.hparams_vision.get("init_pos_emb_width", 64))
+
+        self.gguf_writer.add_vision_use_gelu(True)
+        self.gguf_writer.add_vision_attention_layernorm_eps(self.hparams_vision.get("layer_norm_eps", 1e-5))
+        self.gguf_writer.add_vision_projector_scale_factor(self.merge_kernel_size[0])
+
+        # The HF processor caps images at in_token_limit *patches* (pre-merge) and never upscales.
+        # Translate to a pixel budget for the dynamic-size preprocessor; set the minimum to a single
+        # merged token so small images are not upscaled.
+        in_token_limit = self.preprocessor_config.get("in_token_limit", 25600)
+        pixels_per_patch = self.patch_size ** 2
+        merge_pixels = (self.patch_size * self.merge_kernel_size[0]) * (self.patch_size * self.merge_kernel_size[1])
+        self.gguf_writer.add_vision_min_pixels(merge_pixels)
+        self.gguf_writer.add_vision_max_pixels(in_token_limit * pixels_per_patch)
+
+    @staticmethod
+    def permute(weights: Tensor, n_head: int) -> Tensor:
+        # interleaved -> split RoPE layout, matching Kimi-K2.5 (lets build_rope_2d run in split mode)
+        out_dim, in_dim = weights.shape
+        head_dim = out_dim // n_head
+        w = weights.reshape(n_head, head_dim // 4, 2, 2, in_dim)
+        w = w.permute(0, 2, 1, 3, 4)
+        return w.reshape(out_dim, in_dim)
+
+    @classmethod
+    def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
+        name, gen = item
+
+        if not (name.startswith("vision_model") or name.startswith("mlp1")):
+            return None
+
+        return super().filter_tensors(item)
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        assert self.hparams_vision is not None
+        n_head = self.hparams_vision.get("num_attention_heads", 16)
+
+        # Eagle-MLP connector -> shared mm_projector names (mlp1.2 is GELU, no weights):
+        #   mlp1.0 (LayerNorm) -> mm_projector.pre_norm
+        #   mlp1.1 (Linear)    -> mm_projector.proj.linear_1
+        #   mlp1.3 (Linear)    -> mm_projector.proj.linear_2
+        if name.startswith("mlp1."):
+            name = (name
+                    .replace("mlp1.0.", "mm_projector.pre_norm.")
+                    .replace("mlp1.1.", "mm_projector.proj.linear_1.")
+                    .replace("mlp1.3.", "mm_projector.proj.linear_2."))
+            yield from super().modify_tensors(data_torch, name, bid)
+            return
+
+        # vision encoder: rename to the shared MoonViT prefix
+        if name.startswith("vision_model."):
+            name = name.replace("vision_model.", "vision_tower.", 1)
+
+        # keep the fused wqkv (maps to V_ENC_ATTN_QKV), but permute Q/K interleaved->split
+        if "wqkv" in name:
+            out_dim = data_torch.shape[0]
+            qkv_dim = out_dim // 3
+            head_dim = qkv_dim // n_head
+
+            if "weight" in name:
+                wq, wk, wv = data_torch[:qkv_dim, :], data_torch[qkv_dim:2 * qkv_dim, :], data_torch[2 * qkv_dim:, :]
+                wq = self.permute(wq, n_head)
+                wk = self.permute(wk, n_head)
+                data_torch = torch.cat([wq, wk, wv], dim=0)
+            elif "bias" in name:
+                bq, bk, bv = data_torch[:qkv_dim], data_torch[qkv_dim:2 * qkv_dim], data_torch[2 * qkv_dim:]
+                bq = bq.reshape(n_head, head_dim // 4, 2, 2).permute(0, 2, 1, 3).reshape(-1)
+                bk = bk.reshape(n_head, head_dim // 4, 2, 2).permute(0, 2, 1, 3).reshape(-1)
+                data_torch = torch.cat([bq, bk, bv], dim=0)
+
+        yield from super().modify_tensors(data_torch, name, bid)

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -4554,6 +4554,7 @@ class VisionProjectorType:
     GRANITE_SPEECH = "granite_speech"  # audio
     MIMOVL         = "mimovl"
     GRANITE4_VISION = "granite4_vision"
+    LOCATEANYTHING = "locateanything"
 
 
 # Items here are (block size, type size)

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(mtmd
             models/internvl.cpp
             models/kimivl.cpp
             models/kimik25.cpp
+            models/locateanything.cpp
             models/nemotron-v2-vl.cpp
             models/llama4.cpp
             models/llava.cpp

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -363,6 +363,7 @@ enum projector_type {
     PROJECTOR_TYPE_GRANITE_SPEECH,
     PROJECTOR_TYPE_MIMOVL,
     PROJECTOR_TYPE_GRANITE4_VISION,
+    PROJECTOR_TYPE_LOCATEANYTHING,
     PROJECTOR_TYPE_UNKNOWN,
 };
 
@@ -417,6 +418,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_GRANITE_SPEECH, "granite_speech"},
     { PROJECTOR_TYPE_MIMOVL,     "mimovl"},
     { PROJECTOR_TYPE_GRANITE4_VISION, "granite4_vision"},
+    { PROJECTOR_TYPE_LOCATEANYTHING, "locateanything"},
 };
 
 static projector_type clip_projector_type_from_string(const std::string & str) {

--- a/tools/mtmd/clip-model.h
+++ b/tools/mtmd/clip-model.h
@@ -64,6 +64,7 @@ struct clip_hparams {
     int32_t image_max_pixels = -1;
     resize_algo image_resize_algo = RESIZE_ALGO_BICUBIC;
     pad_style image_resize_pad = PAD_CEIL; // padding style when resizing
+    bool image_resize_round_up = false; // align the dynamic target size up (ceil) instead of to nearest
     std::array<uint8_t, 3> image_pad_color = {0, 0, 0};
 
     // (preprocessor) for llava-uhd style models

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1411,9 +1411,11 @@ struct clip_model_loader {
                 case PROJECTOR_TYPE_LOCATEANYTHING:
                     {
                         // MoonViT encoder shared with Kimi-K2.5, but the HF processor resizes with
-                        // Pillow bicubic and stretches to a multiple of patch*merge (no letterbox).
+                        // Pillow bicubic and stretches to a multiple of patch*merge (no letterbox),
+                        // rounding the target size UP (ceil) rather than to the nearest multiple.
                         hparams.image_resize_algo = RESIZE_ALGO_BICUBIC_PILLOW;
                         hparams.image_resize_pad  = PAD_NONE;
+                        hparams.image_resize_round_up = true;
                         hparams.rope_theta = 10000.0f;
                         get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -960,6 +960,10 @@ static std::unique_ptr<clip_graph> clip_get_graph_builder(clip_ctx * ctx, const 
             {
                 builder = std::make_unique<clip_graph_kimik25>(ctx, img);
             } break;
+        case PROJECTOR_TYPE_LOCATEANYTHING:
+            {
+                builder = std::make_unique<clip_graph_locateanything>(ctx, img);
+            } break;
         case PROJECTOR_TYPE_COGVLM:
             {
                 builder = std::make_unique<clip_graph_cogvlm>(ctx, img);
@@ -1403,6 +1407,27 @@ struct clip_model_loader {
                         } else {
                             hparams.set_limit_image_tokens(2, 4096);
                         }
+                    } break;
+                case PROJECTOR_TYPE_LOCATEANYTHING:
+                    {
+                        // MoonViT encoder shared with Kimi-K2.5, but the HF processor resizes with
+                        // Pillow bicubic and stretches to a multiple of patch*merge (no letterbox).
+                        hparams.image_resize_algo = RESIZE_ALGO_BICUBIC_PILLOW;
+                        hparams.image_resize_pad  = PAD_NONE;
+                        hparams.rope_theta = 10000.0f;
+                        get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
+
+                        int min_pixels = 0, max_pixels = 0;
+                        get_u32(KEY_IMAGE_MIN_PIXELS, min_pixels, false);
+                        get_u32(KEY_IMAGE_MAX_PIXELS, max_pixels, false);
+                        if (min_pixels > 0 && max_pixels > 0) {
+                            hparams.image_min_pixels = min_pixels;
+                            hparams.image_max_pixels = max_pixels;
+                        } else {
+                            // fallback: in_token_limit 25600 patches -> 25600 * 14^2 pixels
+                            hparams.set_limit_image_tokens(4, 25600);
+                        }
+                        hparams.set_warmup_n_tokens(32*32); // avoid OOM on warmup
                     } break;
                 case PROJECTOR_TYPE_GEMMA3:
                     {
@@ -2276,6 +2301,7 @@ struct clip_model_loader {
             case PROJECTOR_TYPE_KIMIVL:
             case PROJECTOR_TYPE_PADDLEOCR:
             case PROJECTOR_TYPE_KIMIK25:
+            case PROJECTOR_TYPE_LOCATEANYTHING:
                 {
                     model.mm_input_norm_w = get_tensor(TN_MM_INP_NORM);
                     model.mm_input_norm_b = get_tensor(TN_MM_INP_NORM_B);
@@ -3352,6 +3378,7 @@ int clip_n_output_tokens(const struct clip_ctx * ctx, struct clip_image_f32 * im
         case PROJECTOR_TYPE_LFM2:
         case PROJECTOR_TYPE_KIMIVL:
         case PROJECTOR_TYPE_KIMIK25:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
             {
                 // dynamic size
                 int out_patch_size = params.patch_size * ctx->model.hparams.n_merge;
@@ -4012,6 +4039,7 @@ bool clip_image_batch_encode(clip_ctx * ctx, const int n_threads, const clip_ima
         case PROJECTOR_TYPE_PIXTRAL:
         case PROJECTOR_TYPE_KIMIVL:
         case PROJECTOR_TYPE_KIMIK25:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
         case PROJECTOR_TYPE_LIGHTONOCR:
             {
                 // set the 2D positions
@@ -4560,6 +4588,7 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
         case PROJECTOR_TYPE_KIMIVL:
         case PROJECTOR_TYPE_PADDLEOCR:
         case PROJECTOR_TYPE_KIMIK25:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
         case PROJECTOR_TYPE_YASA2:
             return ctx->model.mm_2_w->ne[1];
         case PROJECTOR_TYPE_HUNYUANVL:

--- a/tools/mtmd/models/locateanything.cpp
+++ b/tools/mtmd/models/locateanything.cpp
@@ -1,0 +1,70 @@
+#include "models.h"
+
+// LocateAnything-3B vision graph.
+//
+// The encoder is MoonViT-SO-400M, identical to the one Kimi-K2.5 uses, so we inherit
+// clip_graph_kimik25 and reuse its 3D position-embedding resize and the interleaved->split
+// RoPE convention (Q/K are permuted at conversion time, so build_rope_2d runs in split mode).
+//
+// The connector is the "Eagle MLP": LayerNorm(4608) -> Linear(4608, 2048) -> GELU -> Linear(2048, 2048).
+// Unlike Kimi-K2.5 (whose projection norm is applied per 1152-dim sub-token before the 2x2 merge),
+// the LayerNorm here normalises the full merged 4608-dim feature, so the build() below drops the
+// sub-token view trick and normalises the merged axis directly.
+ggml_cgraph * clip_graph_locateanything::build() {
+    ggml_tensor * pos_h = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_patches);
+    ggml_set_name(pos_h, "pos_h");
+    ggml_set_input(pos_h);
+
+    ggml_tensor * pos_w = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_patches);
+    ggml_set_name(pos_w, "pos_w");
+    ggml_set_input(pos_w);
+
+    ggml_tensor * learned_pos_embd = resize_position_embeddings_3d(GGML_SCALE_MODE_BICUBIC);
+
+    // MoonViT uses interleaved 2D RoPE natively; Q/K are permuted to split format during
+    // conversion, so build_rope_2d is called in split mode (interleave = false).
+    auto add_pos = [&](ggml_tensor * cur, const clip_layer &) {
+        cur = build_rope_2d(ctx0, cur, pos_w, pos_h, hparams.rope_theta, false);
+        return cur;
+    };
+
+    ggml_tensor * inp = build_inp();
+
+    // add the learned position embedding before the encoder (mirrors clip_graph_kimik25::build)
+    inp = ggml_add(ctx0, inp, learned_pos_embd);
+
+    ggml_tensor * cur = build_vit(
+                            inp, n_patches,
+                            NORM_TYPE_NORMAL,
+                            hparams.ffn_op,
+                            nullptr,
+                            add_pos);
+
+    cb(cur, "vit_out", -1);
+
+    {
+        // 2x2 patch merge -> [4608, n_merged_patches]
+        const int scale_factor = model.hparams.n_merge;
+        cur = build_patch_merge_permute(cur, scale_factor);
+
+        // Eagle-MLP projection norm: LayerNorm over the merged 4608 axis (no per-sub-token view).
+        cur = ggml_norm(ctx0, cur, hparams.eps);
+        cur = ggml_mul(ctx0, cur, model.mm_input_norm_w);
+        cur = ggml_add(ctx0, cur, model.mm_input_norm_b);
+        cb(cur, "proj_inp_normed", -1);
+
+        // projection mlp: Linear -> GELU -> Linear
+        cur = build_ffn(cur,
+            model.mm_1_w, model.mm_1_b,
+            nullptr, nullptr,
+            model.mm_2_w, model.mm_2_b,
+            FFN_GELU,
+            -1);
+
+        cb(cur, "proj_out", -1);
+    }
+
+    ggml_build_forward_expand(gf, cur);
+
+    return gf;
+}

--- a/tools/mtmd/models/models.h
+++ b/tools/mtmd/models/models.h
@@ -209,6 +209,15 @@ struct clip_graph_kimik25 : clip_graph {
     ggml_tensor * resize_position_embeddings_3d(uint32_t interpolation_mode);
 };
 
+// LocateAnything-3B: MoonViT-SO-400M encoder (shared with Kimi-K2.5) + an "Eagle MLP" connector.
+// The only divergence from Kimi-K2.5 is the projection LayerNorm, which normalises the merged
+// 4608-dim feature directly instead of the pre-merge 1152-dim sub-tokens, so we reuse the
+// 3D pos-emb resize but override build().
+struct clip_graph_locateanything : clip_graph_kimik25 {
+    clip_graph_locateanything(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph_kimik25(ctx, img) {}
+    ggml_cgraph * build() override;
+};
+
 struct clip_graph_exaone4_5 : clip_graph {
     clip_graph_exaone4_5(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
     ggml_cgraph * build() override;

--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -142,7 +142,7 @@ struct img_tool {
     // calculate the size of the **resized** image, while preserving the aspect ratio
     // the calculated size will have min_pixels <= W*H <= max_pixels
     // this is referred as "smart_resize" in transformers code
-    static clip_image_size calc_size_preserved_ratio(const clip_image_size & inp_size, const int align_size, const int min_pixels, const int max_pixels) {
+    static clip_image_size calc_size_preserved_ratio(const clip_image_size & inp_size, const int align_size, const int min_pixels, const int max_pixels, bool round_up = false) {
         GGML_ASSERT(align_size > 0);
         const int width  = inp_size.width;
         const int height = inp_size.height;
@@ -151,9 +151,9 @@ struct img_tool {
         auto ceil_by_factor  = [f = align_size](float x) { return static_cast<int>(std::ceil(x / static_cast<float>(f))) * f; };
         auto floor_by_factor = [f = align_size](float x) { return static_cast<int>(std::floor(x / static_cast<float>(f))) * f; };
 
-        // always align up first
-        int h_bar = std::max(align_size, round_by_factor(height));
-        int w_bar = std::max(align_size, round_by_factor(width));
+        // initial alignment: most models round to nearest; some (e.g. LocateAnything) ceil
+        int h_bar = std::max(align_size, round_up ? ceil_by_factor(height) : round_by_factor(height));
+        int w_bar = std::max(align_size, round_up ? ceil_by_factor(width)  : round_by_factor(width));
 
         if (h_bar * w_bar > max_pixels) {
             const auto beta = std::sqrt(static_cast<float>(height * width) / max_pixels);
@@ -898,7 +898,8 @@ bool mtmd_image_preprocessor_dyn_size::preprocess(const clip_image_u8 & img, cli
         original_size,
         hparams.patch_size * cur_merge,
         hparams.image_min_pixels,
-        hparams.image_max_pixels);
+        hparams.image_max_pixels,
+        hparams.image_resize_round_up);
     img_tool::resize(img, resized_image, target_size,
                         hparams.image_resize_algo,
                         hparams.image_resize_pad,

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -554,6 +554,13 @@ struct mtmd_context {
                     img_end = "<|media_end|>";
                     image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
                 } break;
+            case PROJECTOR_TYPE_LOCATEANYTHING:
+                {
+                    // InternVL-style markers: <img> ... <IMG_CONTEXT> * n ... </img>
+                    img_beg = "<img>";
+                    img_end = "</img>";
+                    image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
+                } break;
             case PROJECTOR_TYPE_LIGHTONOCR:
                 {
                     // <|im_start|> ... (image embeddings) ... <|im_end|>


### PR DESCRIPTION
This adds support for [NVIDIA LocateAnything-3B](https://huggingface.co/nvidia/LocateAnything-3B),
a visual grounding / detection VLM.

This PR covers the model itself (autoregressive decode). Its Parallel Box Decoding ("fast mode")
will come in a follow-up PR.

## What it reuses

- Vision encoder: MoonViT-SO-400M, same as Kimi-K2.5. `clip_graph_locateanything` subclasses
  `clip_graph_kimik25` and only overrides `build()`.
- Connector: an "Eagle MLP" (`LayerNorm(4608) → Linear → GELU → Linear`) on the shared
  `mm_projector` tensors. The LayerNorm runs over the merged 4608-dim feature (the one diff from Kimi-K2.5).
- Text: plain Qwen2.5-3B via the existing `Qwen2Model`. No `src/` changes.

## What's new

- `PROJECTOR_TYPE_LOCATEANYTHING` and its graph.
- Converter `conversion/locateanything.py`: renames `vision_model.` to `vision_tower.`, maps the
  Eagle MLP to `mm_projector.*`, permutes the fused `wqkv` to split Q/K, writes the pixel budget
  from `in_token_limit`.
- `image_resize_round_up` hparam (off by default, set only here): the HF processor rounds the
  resize up to a multiple of `patch*merge`, but `calc_size_preserved_ratio` rounds to nearest,
  which squished images and caused repeated-box loops.

## Converting and running

```bash
python convert_hf_to_gguf.py /path/to/LocateAnything-3B --outtype bf16            # text (qwen2)
python convert_hf_to_gguf.py /path/to/LocateAnything-3B --mmproj --outtype bf16   # mmproj

llama-mtmd-cli -m la-text-bf16.gguf --mmproj la-mmproj-bf16.gguf \
  --image image.jpg --chat-template chatml \
  -p "<image 1><__media__>Locate all the instances that matches the following description: dog."
```

Output is `<box><x1><y1><x2><y2></box>`, or `<box><x><y></box>` for a point, or `<box>None</box>`
for no match. Coordinates are control tokens `<0>..<1000>`; convert to pixels with
`px = coord / 1000 * image_dim`.

## HF Model Hub
Pre-converted GGUFs (LM + mmproj, bf16 / q8_0 / Q4_K_M): https://huggingface.co/sabafallah/LocateAnything-3B-GGUF

## Testing

I compared the output against the HF reference (CPU sdpa, bf16, greedy) on a few images covering
detection, no-match, point, and natural-image detection. The boxes match token-for-token, apart
from a couple of coordinate tokens off by 1-2px on small boxes, which is bf16 backend noise.

## License

The weights use NVIDIA's non-commercial license. The code here is MIT like the rest of llama.cpp.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used AI assistance for code review, debugging, implementation checks, and testing. I have reviewed the submitted changes and take responsibility for the full contents of this PR.
