### PR TITLE
gguf: guard GGML_PAD inputs against integer overflow

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -761,6 +761,7 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
     // compute the total size of the data section, taking into account the alignment
     {
         ctx->size = 0;
+        GGML_ASSERT(ctx->alignment > 0 && (ctx->alignment & (ctx->alignment - 1)) == 0 && "alignment must be a power of 2");
         for (size_t i = 0; i < ctx->info.size(); ++i) {
             const gguf_tensor_info & ti = ctx->info[i];
             if (ti.offset != ctx->size) {
@@ -770,7 +771,14 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
                 gguf_free(ctx);
                 return nullptr;
             }
-            size_t padded_size = GGML_PAD(ggml_nbytes(&ti.t), ctx->alignment);
+            const size_t nbytes = ggml_nbytes(&ti.t);
+            if (nbytes > SIZE_MAX - (ctx->alignment - 1)) {
+                GGML_LOG_ERROR("%s: tensor '%s' size %zu too large for alignment padding (alignment %zu)\n",
+                    __func__, ti.t.name, nbytes, ctx->alignment);
+                gguf_free(ctx);
+                return nullptr;
+            }
+            size_t padded_size = GGML_PAD(nbytes, ctx->alignment);
             if (SIZE_MAX - ctx->size < padded_size) {
                 GGML_LOG_ERROR("%s: tensor '%s' size overflow, cannot accumulate size %zu + %zu\n",
                     __func__, ti.t.name, ctx->size, padded_size);


### PR DESCRIPTION
This PR fixes an integer overflow in `GGML_PAD` that bypasses the size overflow guard introduced in GHSA-vgg9-87g3-85w8.

`GGML_PAD(x, n) = ((x) + (n) - 1) & ~((n) - 1)` overflows to 0 when `x = SIZE_MAX - 3` (reachable with an F32 tensor of `ne[0] = SIZE_MAX/4`). The existing guard checks `SIZE_MAX - ctx->size < padded_size` *after* calling `GGML_PAD`, so when `padded_size = 0` the guard trivially passes, `ctx->size` stays 0, and a subsequent tensor causes a small allocation. Tensor A's data pointer then points into that small allocation with `ne[0] = 4.6e18`, producing a heap-buffer-overflow on any element access.

ASan report: `heap-buffer-overflow READ of size 4, 0 bytes after a 32-byte region`.

Fix: check that `nbytes + (alignment - 1)` will not overflow *before* passing to `GGML_PAD`.

Related prior fixes for the same bug class (CWE-190 → CWE-122) in this file:
- GHSA-vgg9-87g3-85w8 (integer overflow in ctx->size accumulation)
- GHSA-96jg-mvhq-q7q7 (integer overflow in nelements × type_size)

This is a bypass of the GHSA-vgg9-87g3-85w8 fix via the GGML_PAD macro itself.

The attached poc_gguf_pad_overflow.py generates trigger_pad.gguf.

On the vulnerable llama.cpp build:

python3 pocs/poc_gguf_pad_overflow.py
LD_LIBRARY_PATH=./build-asan/bin ./build-asan/bin/llama-gguf pocs/trigger_pad.gguf r n

Observed:

gguf_ex_read_0: tensor[0]: name = A, size = 18446744073709551612, offset = 0
gguf_ex_read_0: tensor[1]: name = B, size = 32, offset = 0
gguf_ex_read_1: tensor[0]: name = A, size = 18446744073709551612, offset = 0, type = f32, n_elts = 4611686018427387903
gguf_ex_read_1: tensor[1]: name = B, size = 32, offset = 0, type = f32, n_elts = 8
gguf_ex_read_1: tensor[0]: ... data = 0x...
A data[:10] : 0.000000 1.000000 2.000000 3.000000 4.000000 5.000000 6.000000 7.000000 0.000000 0.000000
gguf_ex_read_1: tensor[1]: ... data = 0x...

That proves the overflow existed: tensor A has ggml_nbytes = SIZE_MAX - 3, GGML_PAD(...) wraps to 0, both tensors end up at offset 0, and llama-gguf reads 10 floats from tensor A even though the backing blob only contains 8 floats / 32 bytes.

The fixed llama-pr build rejects the same GGUF before data is read:

'''
gguf_init_from_reader: tensor 'A' size 18446744073709551612 too large for alignment padding (alignment 32)
gguf_ex_read_0: failed to load '.../trigger_pad.gguf'
'''