### PR TITLE
server: fix router args not being forwarded to child instances

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -351,6 +351,12 @@ void server_models::load_models() {
         source_map[name] = SERVER_MODEL_SOURCE_PRESET;
     }
 
+    // overlay router's own CLI args on top of every model preset so that
+    // e.g. `llama-server --temp 0` is honoured by all child processes
+    for (auto & [name, preset] : final_presets) {
+        preset.merge(base_preset);
+    }
+
     auto get_source = [&](const std::string & name) {
         return source_map.count(name) ? source_map.at(name) : SERVER_MODEL_SOURCE_PRESET;
     };


### PR DESCRIPTION
## Overview

Fix https://github.com/ggml-org/llama.cpp/issues/24735

Test:

```
llama-server --temp 0
```

`/models` API should correctly return the added arg:

<img width="458" height="168" alt="image" src="https://github.com/user-attachments/assets/5257a1d4-91de-41c3-9b15-55aee0af8c3b" />


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
