### PR TITLE
model : glm-dsa load DSA indexer tensors as optional

### DIFF
--- a/src/models/glm-dsa.cpp
+++ b/src/models/glm-dsa.cpp
@@ -101,11 +101,11 @@ void llama_model_glm_dsa::load_arch_tensors(llama_model_loader &) {
         layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, flags);
 
         // DSA indexer
-        layer.indexer_k_norm   = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "weight", i), {hparams.indexer_head_size}, flags);
-        layer.indexer_k_norm_b = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "bias",   i), {hparams.indexer_head_size}, flags);
-        layer.indexer_proj     = create_tensor(tn(LLM_TENSOR_INDEXER_PROJ,     "weight", i), {n_embd, hparams.indexer_n_head}, flags);
-        layer.indexer_attn_k   = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_K,   "weight", i), {n_embd, hparams.indexer_head_size}, flags);
-        layer.indexer_attn_q_b = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_Q_B, "weight", i), {q_lora_rank, hparams.indexer_n_head * hparams.indexer_head_size}, flags);
+        layer.indexer_k_norm   = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "weight", i), {hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
+        layer.indexer_k_norm_b = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "bias",   i), {hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
+        layer.indexer_proj     = create_tensor(tn(LLM_TENSOR_INDEXER_PROJ,     "weight", i), {n_embd, hparams.indexer_n_head}, flags | TENSOR_NOT_REQUIRED);
+        layer.indexer_attn_k   = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_K,   "weight", i), {n_embd, hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
+        layer.indexer_attn_q_b = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_Q_B, "weight", i), {q_lora_rank, hparams.indexer_n_head * hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
         if (i < (int) hparams.n_layer_dense_lead) {
             layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, flags);
             layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, flags);


### PR DESCRIPTION
## Overview

Loading any **GLM-5.2** GGUF (`GlmMoeDsaForCausalLM` / `GLM_DSA`) fails with `missing tensor 'blk.3.indexer.k_norm.weight'`. GLM-5.2 ships the DSA lightning indexer on only a subset of layers, but `llama_model_glm_dsa::load_arch_tensors` created the five `indexer_*` tensors on every layer as required.

`GLM_DSA` uses `llama_model_deepseek2::graph` (plain MLA) and never references the indexer tensors (the DSA indexer runtime isn't implemented yet), so they are loaded-but-unused. Marking them `TENSOR_NOT_REQUIRED` lets layers without an indexer load as `nullptr`; the model runs as full MLA attention. DeepSeek-V3.2 (uniform indexer on every layer) is unaffected.

## Additional information

Complements the conversion support in #19460. Verified by loading and generating from a GLM-5.2 GGUF on Metal (previously failed at load).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES.** Full disclosure: this change was developed with an AI agent (Claude Code) under my direction — it diagnosed the missing-tensor failure, wrote the five-line `TENSOR_NOT_REQUIRED` change, and drafted this description; verified by building and running a GLM-5.2 GGUF. Given the project's policy on predominantly-AI-generated PRs, I leave it to the maintainers whether this qualifies as acceptable assistive use or should be reworked/declined.