### PR TITLE
server: add "X-Accel-Buffering": "no" header to streaming endpoints

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -492,6 +492,8 @@ using server_http_req_ptr = std::unique_ptr<server_http_req>;
 static void process_handler_response(server_http_req_ptr && request, server_http_res_ptr & response, httplib::Response & res) {
     if (response->is_stream()) {
         res.status = response->status;
+        // Tell Nginx to not buffer any streamed response
+        response->headers["X-Accel-Buffering"] = "no";
         set_headers(res, response->headers);
         const std::string content_type = response->content_type;
         // convert to shared_ptr as both chunked_content_provider() and on_complete() need to use it


### PR DESCRIPTION
## Overview

This header tells Nginx (as a reverse proxy with SSL) to NOT buffer responses. 
Only streaming endpoints are affected. The header does nothing if Nginx is not involved.
Without it, Nginx will break streaming with certain applications (notably the Pi coding harness).
[Nginx docs for reference](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for codebase exploration