### PR TITLE
gguf-py: work around gemma4 tokenizer quirk

### DIFF
--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -580,10 +580,21 @@ class LlamaHfVocab(Vocab):
 
         # Allow the tokenizer to default to slow or fast versions.
         # Explicitly set tokenizer to use local paths.
+        # Workaround for a transformers bug (v4.57.x): Gemma 4 tokenizer config has
+        # extra_special_tokens as a list but the code expects a dict.
+        _extra = None
+        _tok_config = base_path / "tokenizer_config.json"
+        if _tok_config.exists():
+            with open(_tok_config, encoding="utf-8") as _f:
+                _cfg = json.load(_f)
+            if isinstance(_cfg.get("extra_special_tokens"), list):
+                _extra = {t: t for t in _cfg["extra_special_tokens"]}
+        _kwargs = {"extra_special_tokens": _extra} if _extra else {}
         self.tokenizer = AutoTokenizer.from_pretrained(
             base_path,
             cache_dir=base_path,
             local_files_only=True,
+            **_kwargs,
         )
         assert self.tokenizer.is_fast  # assume tokenizer.json is used  # ty: ignore[unresolved-attribute]
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

The `extra_special_tokens` in https://huggingface.co/google/gemma-4-31B-it/blob/main/tokenizer_config.json being a list instead of a dict as transformers expects, causing `convert_hf_to_gguf.py` to crash.

This change bypasses that issue by converting the value before passing it to `AutoTokenizer.from_pretrained` as an override.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Without this change, attempting to convert https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.eagle3 runs into the following error: 

```
Traceback (most recent call last):
  File "/home/wim/src/llama.cpp/./convert_hf_to_gguf.py", line 298, in <module>
    main()
    ~~~~^^
  File "/home/wim/src/llama.cpp/./convert_hf_to_gguf.py", line 292, in main
    model_instance.write()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/home/wim/src/llama.cpp/conversion/base.py", line 1024, in write
    self.prepare_metadata(vocab_only=False)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/wim/src/llama.cpp/conversion/base.py", line 1185, in prepare_metadata
    self.set_vocab()
    ~~~~~~~~~~~~~~^^
  File "/home/wim/src/llama.cpp/conversion/llama.py", line 125, in set_vocab
    self._set_vocab_llama_hf()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/wim/src/llama.cpp/conversion/base.py", line 1920, in _set_vocab_llama_hf
    vocab = gguf.LlamaHfVocab(self.dir_model)
  File "/home/wim/src/llama.cpp/gguf-py/gguf/vocab.py", line 583, in __init__
    self.tokenizer = AutoTokenizer.from_pretrained(
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        base_path,
        ^^^^^^^^^^
        cache_dir=base_path,
        ^^^^^^^^^^^^^^^^^^^^
        local_files_only=True,
        ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/wim/src/llama.cpp/.venv/lib/python3.13/site-packages/transformers/models/auto/tokenization_auto.py", line 1156, in from_pretrained
    return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wim/src/llama.cpp/.venv/lib/python3.13/site-packages/transformers/tokenization_utils_base.py", line 2113, in from_pretrained
    return cls._from_pretrained(
           ~~~~~~~~~~~~~~~~~~~~^
        resolved_vocab_files,
        ^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/home/wim/src/llama.cpp/.venv/lib/python3.13/site-packages/transformers/tokenization_utils_base.py", line 2359, in _from_pretrained
    tokenizer = cls(*init_inputs, **init_kwargs)
  File "/home/wim/src/llama.cpp/.venv/lib/python3.13/site-packages/transformers/models/gemma/tokenization_gemma_fast.py", line 100, in __init__
    super().__init__(
    ~~~~~~~~~~~~~~~~^
        vocab_file=vocab_file,
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<8 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/home/wim/src/llama.cpp/.venv/lib/python3.13/site-packages/transformers/tokenization_utils_fast.py", line 178, in __init__
    super().__init__(**kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/wim/src/llama.cpp/.venv/lib/python3.13/site-packages/transformers/tokenization_utils_base.py", line 1472, in __init__
    self._set_model_specific_special_tokens(special_tokens=self.extra_special_tokens)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wim/src/llama.cpp/.venv/lib/python3.13/site-packages/transformers/tokenization_utils_base.py", line 1210, in _set_model_specific_special_tokens
    self.SPECIAL_TOKENS_ATTRIBUTES = self.SPECIAL_TOKENS_ATTRIBUTES + list(special_tokens.keys())
                                                                           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'keys'
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, AI helped me find where to work around the issue with minimal changes

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
