### PR TITLE
server: fix non-bound n_discard value (ctx shifting)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2554,9 +2554,7 @@ private:
                 const int n_left    = slot.prompt.n_tokens() - n_keep;
                 int       n_discard = slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2);
 
-                // n_discard is only hard-limited to INT32_MAX via server-schema, so clamp to n_left - 1
-                // keep at least one token after n_keep so the tail removal below stays a bounded partial rollback (recurrent/hybrid memories abort when the rollback exceeds n_rs_seq)
-                // and so the resize() does not wrap to a huge size_t
+                // ref: https://github.com/ggml-org/llama.cpp/pull/24786
                 n_discard = std::clamp(n_discard, 0, std::max(0, n_left - 1));
 
                 SLT_WRN(slot, "slot context shift, n_keep = %d, n_left = %d, n_discard = %d\n", n_keep, n_left, n_discard);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2552,7 +2552,12 @@ private:
                 n_keep = std::min(slot.n_ctx - 4, n_keep);
 
                 const int n_left    = slot.prompt.n_tokens() - n_keep;
-                const int n_discard = slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2);
+                int       n_discard = slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2);
+
+                // n_discard is only hard-limited to INT32_MAX via server-schema, so clamp to n_left - 1
+                // keep at least one token after n_keep so the tail removal below stays a bounded partial rollback (recurrent/hybrid memories abort when the rollback exceeds n_rs_seq)
+                // and so the resize() does not wrap to a huge size_t
+                n_discard = std::clamp(n_discard, 0, std::max(0, n_left - 1));
 
                 SLT_WRN(slot, "slot context shift, n_keep = %d, n_left = %d, n_discard = %d\n", n_keep, n_left, n_discard);
 


### PR DESCRIPTION
## Overview

Hard-limit `n_discard` to `n_left - 1`

<details>

<summary>Detailed report</summary>

# Context Shift `n_discard` Overflow -> Server Crash

**Severity**: High (unauthenticated remote DoS) | **Component**: llama-server context shift
**Status**: fixed locally (not yet committed)

## Problem

With `--context-shift` on, a `/completion` request with huge `n_discard` (e.g. `INT32_MAX`,
which passes schema validation, only hard-limited to `[0, INT32_MAX]` at [server-schema.cpp:51-52](tools/server/server-schema.cpp#L51-L52))
crashes the server. The context-shift code uses `n_discard` unchecked.

### Two crash paths (report 0009 only documented #1)

1. **`std::length_error`** at [server-context.cpp:2577](tools/server/server-context.cpp#L2577):
   `new_tokens.resize(size() - n_discard)` is `size_t` arithmetic -> `8191 - 2147483647`
   wraps to ~`1.8e19` -> uncaught `std::length_error` -> abort.

2. **`GGML_ABORT`** at [common.cpp:1492](common/common.cpp#L1492) (only with the report's
   proposed clamp in place): clamping to exactly `n_left` removes the *entire* tail. For
   recurrent/hybrid memories the partial-tail rollback is rejected
   ([llama-memory-recurrent.cpp:182-190](src/llama-memory-recurrent.cpp#L182-L190)),
   `llama_memory_seq_rm` returns false, `common_context_seq_rm` calls `GGML_ABORT`.
   Reproduced: `failed to remove sequence 0 with p0=1, p1=8191` -> death.

`n_discard < n_left` (e.g. 4000, 7000) does NOT crash - failure is specific to the
`n_discard == n_left` boundary.

## Fix

Clamp to `n_left - 1` (keep >=1 token after `n_keep`) - closes both paths. The report's
patch (clamp to `n_left`) also had a compile error (`n_discard` was `const`) and left
crash #2 open. At [server-context.cpp:2554-2561](tools/server/server-context.cpp#L2554-L2561):

```cpp
const int n_left    = slot.prompt.n_tokens() - n_keep;
int       n_discard = slot.task->params.n_discard ? slot.task->params.n_discard : (n_left / 2);

// n_discard is only hard-limited to INT32_MAX, so clamp to n_left - 1.
// keep at least one token after n_keep so the tail removal below stays a bounded
// partial rollback (recurrent/hybrid memories abort when the rollback exceeds n_rs_seq)
// and so the resize() does not wrap to a huge size_t
n_discard = std::clamp(n_discard, 0, std::max(0, n_left - 1));
```

## PoC

Needs a model with `n_ctx_train >= 8192` (small story models train at 256, reject the
prompt before context shift triggers). `--fit off` prevents auto-shrinking the slot ctx.

```bash
./build/bin/llama-server -m model-Q4_K_M.gguf \
    --context-shift --port 9909 -c 8192 -np 1 --temp 0 --fit off

python3 -c "
import json, urllib.request
data = json.dumps({
    'prompt':     'The quick brown fox jumps over the lazy dog ' * 550,  # ~7701 tok, fits n_ctx=8192
    'n_predict':  9000,
    'n_discard':  2147483647,
    'n_keep':     0,
    'temperature': 0,
    'ignore_eos': True,   # force generation to the ctx boundary so the shift fires
    'stream':     False
}).encode()
req = urllib.request.Request('http://localhost:9909/completion', data=data,
                             headers={'Content-Type': 'application/json'})
print(urllib.request.urlopen(req, timeout=300).status)
"
```

### Expected

- **Before fix**: server aborts. Log: `n_discard = 8190` then `failed to remove sequence
  0 with p0=1, p1=8191` (or `std::length_error: vector` on the un-clamped path). Client:
  `RemoteDisconnected`.
- **After fix**: HTTP 200, 9000 tokens generated, server alive. Log: `n_discard = 8189`
  (clamped to `n_left - 1`).

### Verified (fixed build)

| Case | Result |
|------|--------|
| `n_discard=INT32_MAX`, ignore_eos, prompt fills ctx | HTTP 200, alive (was: crash) |
| `n_discard=INT32_MAX`, prompt exceeds ctx | clean HTTP 400 `exceed_context_size` |
| default `n_discard=0` (half = 4095) | HTTP 200, alive (normal preserved) |
| `n_discard=7000` (< n_left=8190) | HTTP 200, used 7000 as-is, alive |

</details>

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: bug found by dsv4-pro and validated by glm-5.2, via pi-agent <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
