### PR TITLE
server: fix checkpoint handling for hybrid memory models

### DIFF
--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -170,8 +170,9 @@ void llama_memory_hybrid::seq_div(llama_seq_id seq_id, llama_pos p0, llama_pos p
 }
 
 llama_pos llama_memory_hybrid::seq_pos_min(llama_seq_id seq_id) const {
-    // the min of the total cache is the max of the two caches' min values
-    return std::max(mem_attn->seq_pos_min(seq_id), mem_recr->seq_pos_min(seq_id));
+    // return only the attention cache's minimum position
+    // recurrent cache has one cell per sequence, so its pos_min == pos_max == current state position
+    return mem_attn->seq_pos_min(seq_id);
 }
 
 llama_pos llama_memory_hybrid::seq_pos_max(llama_seq_id seq_id) const {

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -186,7 +186,9 @@ bool llama_memory_recurrent::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos
                     cell.pos = p0 - 1;
                     return true;
                 }
-                return false;
+                // rollback exceeds snapshot capacity - reset rs_idx to current state
+                // and fall through to normal cell removal below instead of failing
+                set_rs_idx(seq_id, 0);
             }
             // invalidate tails which will be cleared
             if (p0 <= cell.pos && cell.pos < p1) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2909,6 +2909,8 @@ private:
                             // the largest pos_min required for a checkpoint to be useful
                             const auto pos_min_thold = std::max(0, pos_next - n_swa - (has_new_tokens ? 0 : 1));
 
+                            const bool is_hybrid = llama_model_is_hybrid(model_tgt);
+
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
                                 if (pos_min == -1) {
@@ -2968,8 +2970,12 @@ private:
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             LOG_INF("slot %12.*s: id %2d | task %d | Checking checkpoint with [%d, %d] against %d...\n", 12,
                                                 func_name, (slot).id, ((slot).task ? (slot).task->id : -1), cur.pos_min, cur.pos_max, pos_min_thold);
-                                            // workaround for [TAG_CHECKPOINTS_FIX_POS_MIN]
-                                            if (cur.pos_max > pos_next) {
+                                            // for hybrid models, allow checkpoints that extend beyond pos_next (will be trimmed)
+                                            if (!is_hybrid && cur.pos_max > pos_next) {
+                                                return false;
+                                            }
+                                            // checkpoint must have some valid overlap with the new prompt
+                                            if (cur.pos_min >= pos_next) {
                                                 return false;
                                             }
                                             return cur.pos_min < pos_min_thold || cur.pos_min == 0;
@@ -2983,27 +2989,67 @@ private:
                                         it->load_tgt(ctx_tgt,       slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                                         it->load_dft(ctx_dft.get(), slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
 
-                                        pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));
+                                        // for hybrid models, if checkpoint extends beyond pos_next, use pos_next (from LCP)
+                                        // the excess positions will be cleared later; don't let pos_next jump to checkpoint's pos_max
+                                        if (!(is_hybrid && it->pos_max > pos_next)) {
+                                            pos_next = it->pos_max;
+                                        }
                                         n_past   = std::min(slot.prompt.tokens.size_up_to_pos(pos_next), (size_t) it->n_tokens);
                                         SLT_WRN(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
                                     }
 
                                     if (do_reset) {
-                                        SLT_WRN(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
+                                        // Hybrid memory models can have inflated pos_min from stale recurrent state
+                                        // even when valid attention cache prefix exists. If n_past > 0, reuse it.
+                                        if (n_past <= 0) {
+                                            SLT_WRN(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
                                                 "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
-                                        pos_next = 0;
-                                        n_past = 0;
+                                            pos_next = 0;
+                                            n_past = 0;
+                                        }
                                     }
                                 }
-                            }
 
-                            {
-                                // erase any checkpoints with pos_max > pos_next
+                                // For hybrid memory models, clear stale recurrent state beyond the common prefix.
+                                // Run after checkpoint restore/reset so n_past reflects final state.
+                                if (is_hybrid && n_past > 0 && n_past < slot.task->n_tokens()) {
+                                    const auto recr_pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id);
+                                    if (recr_pos_max > (llama_pos) n_past) {
+                                        SLT_WRN(slot, "clearing stale recurrent state beyond n_past = %d (recr_pos_max = %d)\n", n_past, recr_pos_max);
+                                        llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, n_past, -1);
+                                    }
+                                }
+
+                                // trim or erase checkpoints with pos_max > pos_next
+                                // for hybrid models, if the checkpoint has a large valid prefix (pos_min < pos_next),
+                                // trim it instead of erasing
+                                auto seq_rm_both = [&](llama_pos begin, llama_pos end) {
+                                    common_context_seq_rm(ctx_tgt, slot.id, begin, end);
+                                    if (ctx_dft) {
+                                        common_context_seq_rm(ctx_dft.get(), slot.id, begin, end);
+                                    }
+                                };
+
                                 for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end();) {
                                     const auto & cur = *it;
                                     if (cur.pos_max > pos_next) {
-                                        SLT_WRN(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
-                                        it = slot.prompt.checkpoints.erase(it);
+                                        // for hybrid models, keep checkpoints with significant valid prefix
+                                        if (is_hybrid && cur.pos_min < (llama_pos) pos_next) {
+                                            llama_pos overlap = (llama_pos) pos_next - cur.pos_min;
+                                            llama_pos overhang = cur.pos_max - (llama_pos) pos_next;
+                                            SLT_WRN(slot, "Trimming checkpoint [%d,%d]→[%d,%d], valid=%d tokens, discarding %d\n",
+                                                    cur.pos_min, cur.pos_max, cur.pos_min, (llama_pos) pos_next - 1, overlap, overhang);
+                                            // clear the excess KV cache positions that are no longer valid
+                                            seq_rm_both(pos_next, cur.pos_max + 1);
+                                            // update checkpoint metadata to reflect trimmed range
+                                            it->pos_max = pos_next - 1;
+                                            it->n_tokens = pos_next;
+                                            ++it;
+                                        } else {
+                                            SLT_WRN(slot, "Erasing checkpoint [%d,%d] (no valid overlap with pos_next=%d)\n",
+                                                    cur.pos_min, cur.pos_max, (int) pos_next);
+                                            it = slot.prompt.checkpoints.erase(it);
+                                        }
                                     } else {
                                         ++it;
                                     }


### PR DESCRIPTION
## Overview

This PR fixes prompt cache invalidation on hybrid models (such as Qwen3.5/Qwen3.6) where any minor prompt variation (thinking content stripped, injected timestamp, etc.) caused a full prompt re-processing to occur, effectively disabling prompt caching.

Thee server logs would consistently show the following with most agent harness's between turns:
```cpp
    SLT_WRN(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
            "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
```

Related issues: #21831, #23013, #22746, #24714, #24055

## Additional information

Hybrid memory consists of two independent cache subsystems with fundamentally different positional semantics:

- Attention cache: `pos_min` = earliest cached KV position
- Recurrent cache: `pos_min` = current state position (one cell per sequence), so `pos_min == pos_max == current_position` (always the latest)

The previous `seq_pos_min()` implementation took `std::max()` of both caches' min positions, which conflated these semantics. This inflated `pos_min` to the latest position, making it appear as though no prefix was cached and forcing full prompt re-processing on any minor variation.

### Solution

- Return only the attention cache's `pos_min`, matching non-hybrid memory semantics.
- `seq_pos_max` still retains intersection semantics because it bounds valid attention entries by where the recurrent state has advanced.


Additional hardening:

- When speculative decoding partially accepts draft tokens and the rollback distance exceeds `n_rs_seq`, the recurrent cache now falls through to normal cell removal instead of returning `false`. This prevents hybrid `seq_rm` from failing and leaving the attention cache with stale entries. The trade-off is the recurrent state loses precise snapshot restoration, but the KV cache is correctly trimmed. The model re-processes from the last valid checkpoint, producing correct results with slightly higher latency during speculative decoding only.

---

Note that other hybrid types with recurrent memory would likely benefit from the same `seq_pos_min()` change, though I have not explicitly tested those models yet.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: AI was used to investigate and understand how the recurrent memory system works.