### PR TITLE
arg: try fixing test-args-parser randomly fails

### DIFF
--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -17,10 +17,10 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # paths: [
-    #   '.github/workflows/build-openvino.yml',
-    #   'ggml/src/ggml-openvino/**'
-    # ]
+    paths: [
+      '.github/workflows/build-openvino.yml',
+      'ggml/src/ggml-openvino/**'
+    ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -17,10 +17,10 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-openvino.yml',
-      'ggml/src/ggml-openvino/**'
-    ]
+    # paths: [
+    #   '.github/workflows/build-openvino.yml',
+    #   'ggml/src/ggml-openvino/**'
+    # ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2861,7 +2861,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.server_tools = parse_csv_row(value);
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_TOOLS"));
-        add_opt(common_arg(
+    add_opt(common_arg(
         {"-ag", "--agent"},
         {"-no-ag", "--no-agent"},
         "whether to enable CORS proxy and all built-in tools - do not enable in untrusted environments (default: disabled)",

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -924,7 +924,7 @@ static utf8_argv make_utf8_argv() {
 #endif
 
 bool common_params_parse(int argc, char ** argv, common_params & params, llama_example ex, void(*print_usage)(int, char **)) {
-#ifdef _WIN32
+#ifdef 0 //_WIN32
     auto utf8 = make_utf8_argv();
     if (!utf8.ptrs.empty()) {
         argc = static_cast<int>(utf8.buf.size());

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -924,7 +924,7 @@ static utf8_argv make_utf8_argv() {
 #endif
 
 bool common_params_parse(int argc, char ** argv, common_params & params, llama_example ex, void(*print_usage)(int, char **)) {
-#ifdef 0 //_WIN32
+#if 0 //#ifdef _WIN32
     auto utf8 = make_utf8_argv();
     if (!utf8.ptrs.empty()) {
         argc = static_cast<int>(utf8.buf.size());

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -924,10 +924,10 @@ static utf8_argv make_utf8_argv() {
 #endif
 
 bool common_params_parse(int argc, char ** argv, common_params & params, llama_example ex, void(*print_usage)(int, char **)) {
-#if 0 //#ifdef _WIN32
+#ifdef _WIN32
     auto utf8 = make_utf8_argv();
-    if (!utf8.ptrs.empty()) {
-        argc = static_cast<int>(utf8.buf.size());
+    // repair argv only when it matches the process command line
+    if (static_cast<int>(utf8.buf.size()) == argc) {
         argv = utf8.ptrs.data();
     }
 #endif

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -10,7 +10,7 @@
 #undef NDEBUG
 #include <cassert>
 
-int main(void) {
+int test(void) {
     common_params params;
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");
@@ -211,4 +211,14 @@ int main(void) {
     }
 
     printf("test-arg-parser: all tests OK\n\n");
+}
+
+int main(void) {
+    try {
+        test();
+    } catch (std::exception & e) {
+        fprintf(stderr, "test-arg-parser: exception: %s\n", e.what());
+        return 1;
+    }
+    return 0;
 }

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -75,7 +75,7 @@ int main(void) {
     }
 
     std::vector<char *> char_args;
-    auto list_str_to_char = [&char_args](std::vector<std::string> & argv) -> std::vector<char *> {
+    auto list_str_to_char = [&char_args](std::vector<std::string> & argv) -> std::vector<char *> & {
         char_args.clear();
         for (auto & arg : argv) {
             char_args.push_back(const_cast<char *>(arg.data()));

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -10,7 +10,7 @@
 #undef NDEBUG
 #include <cassert>
 
-int test(void) {
+static void test(void) {
     common_params params;
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");
@@ -74,14 +74,12 @@ int test(void) {
         }
     }
 
-    std::vector<char *> char_args;
-    auto list_str_to_char = [&char_args](std::vector<std::string> & argv) -> std::vector<char *> & {
-        char_args.clear();
+    auto list_str_to_char = [](std::vector<std::string> & argv) -> std::vector<char *> {
+        std::vector<char *> res;
         for (auto & arg : argv) {
-            char_args.push_back(const_cast<char *>(arg.data()));
+            res.push_back(const_cast<char *>(arg.data()));
         }
-        char_args.push_back(nullptr);
-        return char_args;
+        return res;
     };
 
     std::vector<std::string> argv;

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -74,12 +74,14 @@ int main(void) {
         }
     }
 
-    auto list_str_to_char = [](std::vector<std::string> & argv) -> std::vector<char *> {
-        std::vector<char *> res;
+    std::vector<char *> char_args;
+    auto list_str_to_char = [&char_args](std::vector<std::string> & argv) -> std::vector<char *> {
+        char_args.clear();
         for (auto & arg : argv) {
-            res.push_back(const_cast<char *>(arg.data()));
+            char_args.push_back(const_cast<char *>(arg.data()));
         }
-        return res;
+        char_args.push_back(nullptr);
+        return char_args;
     };
 
     std::vector<std::string> argv;


### PR DESCRIPTION
## Overview

no idea why `openvino-windows-2022` workflow randomly fails: https://github.com/ggml-org/llama.cpp/actions/runs/27849196743/job/82424736785

the reported error is quite unexpected:

<img width="997" height="397" alt="image" src="https://github.com/user-attachments/assets/d576867c-e22a-4324-a59d-ae09e74f2daf" />

for the first 2 test cases, it should show:

```
error while handling argument "-m": expected value for argument

usage:
-m,    --model FNAME                    model path to load
                                        (env: LLAMA_ARG_MODEL)


to show complete usage, run with -h
error while handling argument "-ngl": stoi: no conversion

usage:
-ngl,  --gpu-layers, --n-gpu-layers N   max. number of layers to store in VRAM, either an exact number,
                                        'auto', or 'all' (default: auto)
                                        (env: LLAMA_ARG_N_GPU_LAYERS)
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
