### PR TITLE
jinja : implement call statement

### DIFF
--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -686,7 +686,11 @@ value set_statement::execute_impl(context & ctx) {
     return mk_val<value_undefined>();
 }
 
-static inline void bind_parameters(const std::string & name, const statements & this_args, const func_args & args, const size_t expected_count, const size_t input_count, context & ctx) {
+static inline void bind_parameters(const std::string & name, const statements & this_args, const func_args & args, context & ctx) {
+    const size_t expected_count = this_args.size();
+    const size_t input_count = args.count();
+
+    JJ_DEBUG("Invoking '%s' with %zu input arguments (expected %zu)", name.c_str(), input_count, expected_count);
     for (size_t i = 0; i < expected_count; ++i) {
         if (i < input_count) {
             if (is_stmt<identifier>(this_args[i])) {
@@ -735,13 +739,9 @@ value macro_statement::execute_impl(context & ctx) {
     std::string name = cast_stmt<identifier>(this->name)->val;
 
     const func_handler func = [this, name](const func_args & args) -> value {
-        size_t expected_count = this->args.size();
-        size_t input_count = args.count();
-
-        JJ_DEBUG("Invoking macro '%s' with %zu input arguments (expected %zu)", name.c_str(), input_count, expected_count);
         context macro_ctx(args.ctx); // new scope for macro execution
 
-        bind_parameters(name, this->args, args, expected_count, input_count, macro_ctx);
+        bind_parameters(name, this->args, args, macro_ctx);
 
         // execute macro body
         JJ_DEBUG("Executing macro '%s' body with %zu statements", name.c_str(), this->body.size());
@@ -770,13 +770,9 @@ value call_statement::execute_impl(context & ctx) {
     context caller_ctx(ctx); // new scope for caller execution
 
     const func_handler func = [this, &caller_ctx](const func_args & args) -> value {
-        size_t expected_count = this->caller_args.size();
-        size_t input_count = args.count();
-
-        JJ_DEBUG("Caller function invoked with %zu input arguments (expected %zu)", input_count, expected_count);
         context block_ctx(caller_ctx); // new scope for block execution
 
-        bind_parameters("caller", this->caller_args, args, expected_count, input_count, block_ctx);
+        bind_parameters("caller", this->caller_args, args, block_ctx);
 
         JJ_DEBUG("Executing call body with %zu statements", this->body.size());
         auto res = exec_statements(this->body, block_ctx);

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -686,59 +686,62 @@ value set_statement::execute_impl(context & ctx) {
     return mk_val<value_undefined>();
 }
 
+static const auto bind_parameters = [](const std::string & name, const statements & this_args, const func_args & args, const size_t expected_count, const size_t input_count, context & ctx) {
+    for (size_t i = 0; i < expected_count; ++i) {
+        if (i < input_count) {
+            if (is_stmt<identifier>(this_args[i])) {
+                // normal parameter
+                std::string param_name = cast_stmt<identifier>(this_args[i])->val;
+                value param_value = args.get_kwarg_or_pos(param_name, i);
+                JJ_DEBUG("  Binding parameter '%s' to argument of type %s", param_name.c_str(), param_value->type().c_str());
+                ctx.set_val(param_name, param_value);
+            } else if (is_stmt<keyword_argument_expression>(this_args[i])) {
+                // default argument used as normal parameter
+                auto kwarg = cast_stmt<keyword_argument_expression>(this_args[i]);
+                if (!is_stmt<identifier>(kwarg->key)) {
+                    throw std::runtime_error("Keyword argument key must be an identifier in '" + name + "'");
+                }
+                std::string param_name = cast_stmt<identifier>(kwarg->key)->val;
+                value param_value = args.get_kwarg_or_pos(param_name, i);
+                JJ_DEBUG("  Binding parameter '%s' to argument of type %s", param_name.c_str(), param_value->type().c_str());
+                ctx.set_val(param_name, param_value);
+            } else {
+                throw std::runtime_error("Invalid parameter type in '" + name + "'");
+            }
+        } else {
+            auto & default_arg = this_args[i];
+            if (is_stmt<keyword_argument_expression>(default_arg)) {
+                auto kwarg = cast_stmt<keyword_argument_expression>(default_arg);
+                if (!is_stmt<identifier>(kwarg->key)) {
+                    throw std::runtime_error("Keyword argument key must be an identifier in '" + name + "'");
+                }
+                std::string param_name = cast_stmt<identifier>(kwarg->key)->val;
+                JJ_DEBUG("  Binding parameter '%s' to default argument of type %s", param_name.c_str(), kwarg->val->type().c_str());
+                ctx.set_val(param_name, kwarg->val->execute(args.ctx));
+            } else {
+                throw std::runtime_error("Not enough arguments provided to '" + name + "'");
+            }
+            //std::string param_name = cast_stmt<identifier>(default_args[i])->val;
+            //JJ_DEBUG("  Binding parameter '%s' to default", param_name.c_str());
+            //ctx.var[param_name] = default_args[i]->execute(ctx);
+        }
+    }
+};
+
 value macro_statement::execute_impl(context & ctx) {
     if (!is_stmt<identifier>(this->name)) {
         throw std::runtime_error("Macro name must be an identifier");
     }
     std::string name = cast_stmt<identifier>(this->name)->val;
 
-    const func_handler func = [this, name, &ctx](const func_args & args) -> value {
+    const func_handler func = [this, name](const func_args & args) -> value {
         size_t expected_count = this->args.size();
         size_t input_count = args.count();
 
         JJ_DEBUG("Invoking macro '%s' with %zu input arguments (expected %zu)", name.c_str(), input_count, expected_count);
-        context macro_ctx(ctx); // new scope for macro execution
+        context macro_ctx(args.ctx); // new scope for macro execution
 
-        // bind parameters
-        for (size_t i = 0; i < expected_count; ++i) {
-            if (i < input_count) {
-                if (is_stmt<identifier>(this->args[i])) {
-                    // normal parameter
-                    std::string param_name = cast_stmt<identifier>(this->args[i])->val;
-                    value param_value = args.get_kwarg_or_pos(param_name, i);
-                    JJ_DEBUG("  Binding parameter '%s' to argument of type %s", param_name.c_str(), param_value->type().c_str());
-                    macro_ctx.set_val(param_name, param_value);
-                } else if (is_stmt<keyword_argument_expression>(this->args[i])) {
-                    // default argument used as normal parameter
-                    auto kwarg = cast_stmt<keyword_argument_expression>(this->args[i]);
-                    if (!is_stmt<identifier>(kwarg->key)) {
-                        throw std::runtime_error("Keyword argument key must be an identifier in macro '" + name + "'");
-                    }
-                    std::string param_name = cast_stmt<identifier>(kwarg->key)->val;
-                    value param_value = args.get_kwarg_or_pos(param_name, i);
-                    JJ_DEBUG("  Binding parameter '%s' to argument of type %s", param_name.c_str(), param_value->type().c_str());
-                    macro_ctx.set_val(param_name, param_value);
-                } else {
-                    throw std::runtime_error("Invalid parameter type in macro '" + name + "'");
-                }
-            } else {
-                auto & default_arg = this->args[i];
-                if (is_stmt<keyword_argument_expression>(default_arg)) {
-                    auto kwarg = cast_stmt<keyword_argument_expression>(default_arg);
-                    if (!is_stmt<identifier>(kwarg->key)) {
-                        throw std::runtime_error("Keyword argument key must be an identifier in macro '" + name + "'");
-                    }
-                    std::string param_name = cast_stmt<identifier>(kwarg->key)->val;
-                    JJ_DEBUG("  Binding parameter '%s' to default argument of type %s", param_name.c_str(), kwarg->val->type().c_str());
-                    macro_ctx.set_val(param_name, kwarg->val->execute(ctx));
-                } else {
-                    throw std::runtime_error("Not enough arguments provided to macro '" + name + "'");
-                }
-                //std::string param_name = cast_stmt<identifier>(default_args[i])->val;
-                //JJ_DEBUG("  Binding parameter '%s' to default", param_name.c_str());
-                //macro_ctx.var[param_name] = default_args[i]->execute(ctx);
-            }
-        }
+        bind_parameters(name, this->args, args, expected_count, input_count, macro_ctx);
 
         // execute macro body
         JJ_DEBUG("Executing macro '%s' body with %zu statements", name.c_str(), this->body.size());
@@ -750,6 +753,50 @@ value macro_statement::execute_impl(context & ctx) {
     JJ_DEBUG("Defining macro '%s' with %zu parameters", name.c_str(), args.size());
     ctx.set_val(name, mk_val<value_func>(name, func));
     return mk_val<value_undefined>();
+}
+
+value call_statement::execute_impl(context & ctx) {
+    auto call_expr = cast_stmt<call_expression>(this->call);
+    if (!call_expr) {
+        throw std::runtime_error("Call statement requires a valid call expression");
+    }
+
+    value callee_val = call_expr->callee->execute(ctx);
+    if (!is_val<value_func>(callee_val)) {
+        throw std::runtime_error("Callee expression is not a function: got " + callee_val->type());
+    }
+    auto * callee_func = cast_val<value_func>(callee_val);
+
+    context caller_ctx(ctx); // new scope for caller execution
+
+    const func_handler func = [this, &caller_ctx](const func_args & args) -> value {
+        size_t expected_count = this->caller_args.size();
+        size_t input_count = args.count();
+
+        JJ_DEBUG("Caller function invoked with %zu input arguments (expected %zu)", input_count, expected_count);
+        context block_ctx(caller_ctx); // new scope for block execution
+
+        bind_parameters("caller", this->caller_args, args, expected_count, input_count, block_ctx);
+
+        JJ_DEBUG("Executing call body with %zu statements", this->body.size());
+        auto res = exec_statements(this->body, block_ctx);
+        JJ_DEBUG("Call body execution complete, result: %s", res->val_str.str().c_str());
+        return res;
+    };
+
+    context call_ctx(ctx);
+    call_ctx.set_val("caller", mk_val<value_func>("caller", func));
+
+    func_args args(call_ctx);
+
+    for (const auto & arg_expr : call_expr->args) {
+        auto arg_val = arg_expr->execute(ctx);
+        JJ_DEBUG("  Argument type: %s", arg_val->type().c_str());
+        args.push_back(arg_val);
+    }
+
+    JJ_DEBUG("Calling macro '%s' with %zu arguments", callee_func->name.c_str(), args.count());
+    return callee_func->invoke(args);
 }
 
 value member_expression::execute_impl(context & ctx) {
@@ -890,7 +937,7 @@ value call_expression::execute_impl(context & ctx) {
     // execute callee
     value callee_val = callee->execute(ctx);
     if (!is_val<value_func>(callee_val)) {
-        throw std::runtime_error("Callee is not a function: got " + callee_val->type());
+        throw std::runtime_error("Callee expression is not a function: got " + callee_val->type());
     }
     auto * callee_func = cast_val<value_func>(callee_val);
     JJ_DEBUG("Calling function '%s' with %zu arguments", callee_func->name.c_str(), args.count());

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -763,7 +763,7 @@ value call_statement::execute_impl(context & ctx) {
 
     value callee_val = call_expr->callee->execute(ctx);
     if (!is_val<value_func>(callee_val)) {
-        throw std::runtime_error("Callee expression is not a function: got " + callee_val->type());
+        throw std::runtime_error("Callee is not a function: got " + callee_val->type());
     }
     auto * callee_func = cast_val<value_func>(callee_val);
 
@@ -937,7 +937,7 @@ value call_expression::execute_impl(context & ctx) {
     // execute callee
     value callee_val = callee->execute(ctx);
     if (!is_val<value_func>(callee_val)) {
-        throw std::runtime_error("Callee expression is not a function: got " + callee_val->type());
+        throw std::runtime_error("Callee is not a function: got " + callee_val->type());
     }
     auto * callee_func = cast_val<value_func>(callee_val);
     JJ_DEBUG("Calling function '%s' with %zu arguments", callee_func->name.c_str(), args.count());

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -686,7 +686,7 @@ value set_statement::execute_impl(context & ctx) {
     return mk_val<value_undefined>();
 }
 
-static const auto bind_parameters = [](const std::string & name, const statements & this_args, const func_args & args, const size_t expected_count, const size_t input_count, context & ctx) {
+static inline void bind_parameters(const std::string & name, const statements & this_args, const func_args & args, const size_t expected_count, const size_t input_count, context & ctx) {
     for (size_t i = 0; i < expected_count; ++i) {
         if (i < input_count) {
             if (is_stmt<identifier>(this_args[i])) {
@@ -726,7 +726,7 @@ static const auto bind_parameters = [](const std::string & name, const statement
             //ctx.var[param_name] = default_args[i]->execute(ctx);
         }
     }
-};
+}
 
 value macro_statement::execute_impl(context & ctx) {
     if (!is_stmt<identifier>(this->name)) {

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -769,7 +769,7 @@ value call_statement::execute_impl(context & ctx) {
 
     context caller_ctx(ctx); // new scope for caller execution
 
-    const func_handler func = [this, &caller_ctx](const func_args & args) -> value {
+    const func_handler func = [this, caller_ctx = std::move(caller_ctx)](const func_args & args) -> value {
         context block_ctx(caller_ctx); // new scope for block execution
 
         bind_parameters("caller", this->caller_args, args, block_ctx);

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -552,6 +552,7 @@ struct call_statement : public statement {
         for (const auto & arg : this->caller_args) chk_type<expression>(arg);
     }
     std::string type() const override { return "CallStatement"; }
+    value execute_impl(context & ctx) override;
 };
 
 struct ternary_expression : public expression {

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -995,6 +995,32 @@ static void test_macros(testing & t) {
         json::object(),
         "Hello, John Smith,Hi, Jane Doe"
     );
+
+    test_template(t, "macro with caller",
+        "\
+{%- macro nest_dict(o, i, ff='') %}\n\
+  {{- caller(ff) }}\n\
+  {%- for k, v in o|items %}\n\
+    {{- i + k + ': ' }}\n\
+    {%- if v is mapping %}\n\
+      {{- '{' }}\n\
+      {% call(f) nest_dict(v, i + '    ') %}\n\
+        {{- 'fail' if ff is undefined }}\n\
+      {%- endcall %}\n\
+      {{- i + '}' }}\n\
+    {% else %}\n\
+      {{- v|string }}\n\
+    {% endif %}\n\
+  {%- endfor %}\n\
+{%- endmacro %}\n\
+{%- call(f) nest_dict({'root1': 1, 'root2': {'nest1': 1, 'nest2': {'nest3': 2}}}, '    ', 'Dict') %}\n\
+  {{- 'fail' if ff is defined }}\n\
+  {{- f + ' {' }}\n\
+{% endcall %}\n\
+{{- '}' }}",
+        json::object(),
+        "Dict {\n    root1: 1\n    root2: {\n        nest1: 1\n        nest2: {\n            nest3: 2\n        }\n    }\n}"
+    );
 }
 
 static void test_namespace(testing & t) {


### PR DESCRIPTION
## Overview

Implement `call` statement.

## Additional information

Adds support for (with and without `call`/`caller` parameters):
```jinja
{% macro func() %}
  {{ caller() }}
{% endmacro %}
{% call func() %}
Hello World!
{% endcall %}
```

Currently only used by [MiniCPM4-MCP](https://huggingface.co/openbmb/MiniCPM4-MCP) AFAIK, however this model also need parser support to work. cc/ @pwilkin @aldehir if you want a challenge. :)

Also fixes a minor context inheritance issue with macros (which was necessary for `caller()` to work) where macros would inherit from definition context instead of calling context.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, `Qwen 3.6 27B` was used for drafting