### PR TITLE
Use env var to disable tensor split rotation

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -373,6 +373,8 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         size_t   rotation; // when assigning tensor slices, rotate how the rounding is done for more even allocation
     };
 
+    const bool use_rotation = !ud->tensor_split_rot_disable;
+
     auto get_tensor_config_impl = [&](
                 const ggml_backend_meta_split_axis axis, const std::string & suffix = "", const std::string & suffix_fallback = "") -> tensor_config {
         // the layers in a tensor can be inhomogeneous, if the pattern is cleanly divided by the number of GPUs there can be aliasing effects,
@@ -395,16 +397,16 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             GGML_ASSERT(length_prefix != std::string::npos);
             prefix = tensor_name.substr(0, length_prefix + 1);
             il = std::stoull(tensor_name.substr(4, length_prefix));
-            rotation = get_il_eff(il) % ud->n_devices;
+            rotation = use_rotation ? get_il_eff(il) % ud->n_devices : 0;
         } else if (tensor_name.substr(0, 6) == "cache_") {
             const size_t layer_index_start = tensor_name.find("_l", 6);
             GGML_ASSERT(layer_index_start != std::string::npos);
             il = std::stoull(tensor_name.substr(layer_index_start + 2));
             prefix = "blk." + std::to_string(il) + ".";
-            rotation = get_il_eff(il) % ud->n_devices;
+            rotation = use_rotation ? get_il_eff(il) % ud->n_devices : 0;
         } else {
             il = 0;
-            rotation = hparams.n_layer() % ud->n_devices;
+            rotation = use_rotation ? hparams.n_layer() % ud->n_devices : 0;
         }
         const ggml_tensor * tensor_axis_0 = suffix.empty() ? tensor : ud->model->get_tensor((prefix + suffix).c_str());
         if (tensor_axis_0 == nullptr) {

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -515,6 +515,7 @@ struct llama_device {
 struct llama_meta_device_get_split_state_userdata {
     size_t                     n_devices;
     const struct llama_model * model;
+    bool                       tensor_split_rot_disable = false;
 };
 
 struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const struct ggml_tensor * tensor, void * userdata);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -121,6 +121,14 @@ int64_t llama_time_us(void) {
     return ggml_time_us();
 }
 
+static void llama_apply_tensor_split_rot_disable(llama_meta_device_get_split_state_userdata & ud) {
+    const char * rot_disable = getenv("LLAMA_TENSOR_SPLIT_ROT_DISABLE");
+    if (rot_disable && atoi(rot_disable)) {
+        LLAMA_LOG_WARN("%s: tensor-split rotation force disabled (LLAMA_TENSOR_SPLIT_ROT_DISABLE)\n", __func__);
+        ud.tensor_split_rot_disable = true;
+    }
+}
+
 // returns true on success
 static bool llama_prepare_model_devices(const llama_model_params & params, llama_model * model) {
     // create list of devices to use with this model
@@ -140,13 +148,7 @@ static bool llama_prepare_model_devices(const llama_model_params & params, llama
             }
             model->get_split_state_ud.n_devices = n_devs;
             model->get_split_state_ud.model = model;
-            {
-                const char * rot_disable = getenv("LLAMA_TENSOR_SPLIT_ROT_DISABLE");
-                if (rot_disable && atoi(rot_disable)) {
-                    LLAMA_LOG_WARN("%s: tensor-split rotation force disabled (LLAMA_TENSOR_SPLIT_ROT_DISABLE)\n", __func__);
-                    model->get_split_state_ud.tensor_split_rot_disable = true;
-                }
-            }
+            llama_apply_tensor_split_rot_disable(model->get_split_state_ud);
             model->devices.push_back({
                 true, ggml_backend_meta_device(
                 params.devices, n_devs, llama_meta_device_get_split_state, &model->get_split_state_ud)
@@ -188,13 +190,7 @@ static bool llama_prepare_model_devices(const llama_model_params & params, llama
             GGML_ASSERT(!devs.empty());
             model->get_split_state_ud.n_devices = devs.size();
             model->get_split_state_ud.model     = model;
-            {
-                const char * rot_disable = getenv("LLAMA_TENSOR_SPLIT_ROT_DISABLE");
-                if (rot_disable && atoi(rot_disable)) {
-                    LLAMA_LOG_WARN("%s: tensor-split rotation force disabled (LLAMA_TENSOR_SPLIT_ROT_DISABLE)\n", __func__);
-                    model->get_split_state_ud.tensor_split_rot_disable = true;
-                }
-            }
+            llama_apply_tensor_split_rot_disable(model->get_split_state_ud);
             gpus.push_back({
                 true, ggml_backend_meta_device(
                 devs.data(), devs.size(), llama_meta_device_get_split_state, &model->get_split_state_ud)

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -140,6 +140,13 @@ static bool llama_prepare_model_devices(const llama_model_params & params, llama
             }
             model->get_split_state_ud.n_devices = n_devs;
             model->get_split_state_ud.model = model;
+            {
+                const char * rot_disable = getenv("LLAMA_TENSOR_SPLIT_ROT_DISABLE");
+                if (rot_disable && atoi(rot_disable)) {
+                    LLAMA_LOG_WARN("%s: tensor-split rotation force disabled (LLAMA_TENSOR_SPLIT_ROT_DISABLE)\n", __func__);
+                    model->get_split_state_ud.tensor_split_rot_disable = true;
+                }
+            }
             model->devices.push_back({
                 true, ggml_backend_meta_device(
                 params.devices, n_devs, llama_meta_device_get_split_state, &model->get_split_state_ud)
@@ -181,6 +188,13 @@ static bool llama_prepare_model_devices(const llama_model_params & params, llama
             GGML_ASSERT(!devs.empty());
             model->get_split_state_ud.n_devices = devs.size();
             model->get_split_state_ud.model     = model;
+            {
+                const char * rot_disable = getenv("LLAMA_TENSOR_SPLIT_ROT_DISABLE");
+                if (rot_disable && atoi(rot_disable)) {
+                    LLAMA_LOG_WARN("%s: tensor-split rotation force disabled (LLAMA_TENSOR_SPLIT_ROT_DISABLE)\n", __func__);
+                    model->get_split_state_ud.tensor_split_rot_disable = true;
+                }
+            }
             gpus.push_back({
                 true, ggml_backend_meta_device(
                 devs.data(), devs.size(), llama_meta_device_get_split_state, &model->get_split_state_ud)


### PR DESCRIPTION
## Overview

Adds a temporary environment variable, **LLAMA_TENSOR_SPLIT_ROT_DISABLE=1**, to allow the user to optionally disable tensor split rotation

## Additional information

When using gemma-4-31B with MTP on systems with a non-power-of-two number of GPUs, the draft MTP will fail to split evenly causing an assertion:

<details><summary>gemma4 w/MTP crash dump on 3 GPUs</summary>
<p>

```
Environment: HIP_VISIBLE_DEVICES=0,1,2 RCCL_P2P_DISABLE=1 NCCL_P2P_DISABLE=1 RCCL_BUFFSIZE=16777216

Starting: /llm/runtimes/rocm/llama-server --model /llm/models/Gemma4/31B/gemma-4-31B-it-Q6_K_XL.gguf --alias Gemma4-31B-Q8_K_XL --prio 2 --fit false --no-mmap --top-k 64 --port 8034 --threads 4 --mlock --parallel 1 --top-p 0.95 --min-p 0.02 --host 0.0.0.0 --cpu-strict 1 --cpu-range 1-4 --predict 60000 --threads-http 4 --cache-ram 10240 --ctx-size 180000 --flash-attn auto --batch-size 1024 --ubatch-size 1024 --temperature 1.0 --n-gpu-layers all --cache-type-k q8_0 --cache-type-v q8_0 --ctx-checkpoints 48 --repeat-penalty 1.05 --presence-penalty 0.0 --reasoning-budget 30000 --split-mode tensor --tensor-split 17,20,14 --device ROCm0,ROCm1,ROCm2 --main-gpu 0 --mmproj /llm/models/Gemma4/31B/mmproj-F16.gguf --spec-type draft-mtp --spec-draft-n-max 3 --spec-draft-p-min 0.01 --spec-draft-device ROCm0,ROCm1,ROCm2 --spec-draft-model /llm/models/Gemma4/31B/gemma-4-31B-it-Q8_0-MTP.gguf

0.00.018.207 I log_info: verbosity = 3 (adjust with the `-lv N` CLI arg)
0.00.018.208 I device_info:
0.00.018.218 I   - ROCm0   : AMD Radeon AI PRO R9700 (32624 MiB, 32548 MiB free)
0.00.018.220 I   - ROCm1   : AMD Radeon AI PRO R9700 (32624 MiB, 32548 MiB free)
0.00.018.221 I   - ROCm2   : AMD Radeon AI PRO R9700 (32624 MiB, 32548 MiB free)
0.00.018.223 I   - CPU     : AMD Ryzen 7 9800X3D 8-Core Processor (190836 MiB, 190836 MiB free)
0.00.018.248 I system_info: n_threads = 4 (n_threads_batch = 4) / 8 | ROCm : NO_VMM = 1 | NO_PEER_COPY = 1 | PEER_MAX_BATCH_SIZE = 128 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX_VNNI = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | AVX512_VBMI = 1 | AVX512_VNNI = 1 | AVX512_BF16 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 | 
0.00.018.260 I srv          init: running without SSL
0.00.018.284 I srv          init: using 4 threads for HTTP server
0.00.018.426 I srv         start: binding port with default address family
0.00.019.569 I srv  llama_server: loading model
0.00.019.571 I srv    load_model: loading model '/llm/models/Gemma4/31B/gemma-4-31B-it-Q6_K_XL.gguf'
0.00.234.338 W load: control-looking token:    212 '</s>' was not control-type; this is probably a bug in the model. its type will be overridden
0.00.234.507 W load: control-looking token:     50 '<|tool_response>' was not control-type; this is probably a bug in the model. its type will be overridden
0.00.236.827 W load: control-looking token:      1 '<eos>' was not control-type; this is probably a bug in the model. its type will be overridden
0.00.243.286 W load: special_eog_ids contains '<|tool_response>', removing '</s>' token from EOG list
0.04.842.250 W llama_context: n_ctx_seq (180224) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
0.06.394.259 I common_init_from_params: warming up the model with an empty run - please wait ... (--no-warmup to disable)
0.06.561.995 I srv    load_model: loading draft model '/llm/models/Gemma4/31B/gemma-4-31B-it-Q8_0-MTP.gguf'
0.06.763.242 W load: control-looking token:    212 '</s>' was not control-type; this is probably a bug in the model. its type will be overridden
0.06.763.402 W load: control-looking token:     50 '<|tool_response>' was not control-type; this is probably a bug in the model. its type will be overridden
0.06.771.848 W load: special_eog_ids contains '<|tool_response>', removing '</s>' token from EOG list
0.06.966.163 W llama_context: n_ctx_seq (180224) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
0.07.136.234 W llama_kv_cache: layer   3: sharing with layer 59. k = 0x2000000000000000, v = 0x2000000000000000
0.07.136.310 W llama_kv_cache: layer   0: sharing with layer 58. k = 0x2000000000000000, v = 0x2000000000000000
0.07.136.311 W llama_kv_cache: layer   1: sharing with layer 58. k = 0x2000000000000000, v = 0x2000000000000000
0.07.136.311 W llama_kv_cache: layer   2: sharing with layer 58. k = 0x2000000000000000, v = 0x2000000000000000
0.07.296.746 I srv    load_model: loaded multimodal model, '/llm/models/Gemma4/31B/mmproj-F16.gguf'
0.07.296.757 I srv    load_model: initializing slots, n_slots = 1
0.07.382.261 I common_speculative_impl_draft_mtp: adding speculative implementation 'draft-mtp'
0.07.382.264 I common_speculative_impl_draft_mtp: - n_max=3, n_min=0, p_min=0.01, n_embd=5376, backend_sampling=1
0.07.382.267 I common_speculative_impl_draft_mtp: - gpu_layers=-1, cache_k=f16, cache_v=f16, ctx_tgt=yes, ctx_dft=yes, devices=[ROCm0, ROCm1, ROCm2]
0.07.382.316 W set_sampler: backend sampling not supported with SPLIT_MODE_TENSOR; using CPU
0.07.382.317 W common_speculative_impl_draft_mtp: backend offload failed for seq_id=0; using CPU sampler
/home/stew675/llama.rocm/ggml/src/ggml-backend-meta.cpp:1043: GGML_ASSERT(split_state.ne[j]*split_state.nr[0] * tensor->src[i]->ne[src_ss[i].axis] == sum * tensor->ne[split_state.axis]) failed
[New LWP 17308]
[New LWP 17307]
[New LWP 17306]
[New LWP 17305]
[New LWP 17304]
[New LWP 17303]
[New LWP 17302]
[New LWP 17301]
[New LWP 17300]
[New LWP 17295]
[New LWP 17294]
[New LWP 17293]
[New LWP 17292]
[New LWP 17291]
[New LWP 17290]
[New LWP 17289]
[New LWP 17288]
[New LWP 17287]
[New LWP 17286]
[New LWP 17277]
[New LWP 17276]
[New LWP 17275]
[New LWP 17274]
[New LWP 17273]
[New LWP 17272]
[New LWP 17270]
[New LWP 17269]

This GDB supports auto-downloading debuginfo from the following URLs:
  <ima:enforcing>
  <https://debuginfod.fedoraproject.org/>
  <ima:ignore>
Enable debuginfod for this session? (y or [n]) [answered N; input not from terminal]
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
0x00007f8701e82412 in __syscall_cancel_arch () from /lib64/libc.so.6
#0  0x00007f8701e82412 in __syscall_cancel_arch () from /lib64/libc.so.6
#1  0x00007f8701e7662c in __internal_syscall_cancel () from /lib64/libc.so.6
#2  0x00007f8701e76674 in __syscall_cancel () from /lib64/libc.so.6
#3  0x00007f8701ee624f in wait4 () from /lib64/libc.so.6
#4  0x00007f870b33ce76 in ggml_print_backtrace () from /home/stew675/llama.rocm/build/bin/libggml-base.so.0
#5  0x00007f870b33c489 in ggml_abort () from /home/stew675/llama.rocm/build/bin/libggml-base.so.0
#6  0x00007f870b366fcf in ggml_backend_meta_get_split_state(ggml_backend_meta_simple_tensor_container&, ggml_tensor const*, bool) () from /home/stew675/llama.rocm/build/bin/libggml-base.so.0
#7  0x00007f870b36d60d in ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_meta_simple_tensor_container&, ggml_tensor*) () from /home/stew675/llama.rocm/build/bin/libggml-base.so.0
#8  0x00007f870b36b979 in ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer*, ggml_tensor*) () from /home/stew675/llama.rocm/build/bin/libggml-base.so.0
#9  0x00007f870b35616c in ggml_gallocr_alloc_graph () from /home/stew675/llama.rocm/build/bin/libggml-base.so.0
#10 0x00007f870b35d154 in ggml_backend_sched_alloc_graph () from /home/stew675/llama.rocm/build/bin/libggml-base.so.0
#11 0x00007f870aa28ddc in llama_context::process_ubatch(llama_ubatch const&, llm_graph_type, llama_memory_context_i*, ggml_status&) () from /home/stew675/llama.rocm/build/bin/libllama.so.0
#12 0x00007f870aa2a634 in llama_context::decode(llama_batch const&) () from /home/stew675/llama.rocm/build/bin/libllama.so.0
#13 0x00007f870aa2f8ab in llama_decode () from /home/stew675/llama.rocm/build/bin/libllama.so.0
#14 0x00007f870af5c79b in common_context_can_seq_rm(llama_context*) () from /home/stew675/llama.rocm/build/bin/libllama-common.so.0
#15 0x00007f870b4e69bc in server_context_impl::load_model(common_params&) () from /home/stew675/llama.rocm/build/bin/libllama-server-impl.so
#16 0x00007f870b4143ea in llama_server(int, char**) () from /home/stew675/llama.rocm/build/bin/libllama-server-impl.so
#17 0x00007f8701e0a681 in __libc_start_call_main () from /lib64/libc.so.6
#18 0x00007f8701e0a798 in __libc_start_main_impl () from /lib64/libc.so.6
#19 0x00000000004003a5 in _start ()
[Inferior 1 (process 17267) detached]
Aborted                    (core dumped) start-llama

```

</p>
</details> 

## Related Bugs / PRs

https://github.com/ggml-org/llama.cpp/issues/24486  <- Directly related
https://github.com/ggml-org/llama.cpp/pull/22950  <- Somewhat related
https://github.com/ggml-org/llama.cpp/pull/21808 <- Looks like it attempted to partially fix but still fails this scenario
https://github.com/ggml-org/llama.cpp/issues/21765 <- Linked by above

## Fix approach

This is not a fix for the issue, but is rather a temporary measure via an easy to remove again environment variable that allows the user to situationally disable tensor split rotation.

If this PR is rejected, I completely understand as it is not a true fix, but I at least wanted to raise it as an issue with a temporary solution for anyone else who is affected may use until such time as one of the people who understands this area better than I do can fix it properly.

## Result

For my particular scenario it fixes the crashing, although the weights are seen to be imbalanced somewhat, which can be addressed by manually tuning --split-tensor ratios.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- I have performed a summary search of open issues and bugs and linked what I found, but there may be more
- AI usage disclosure:  **YES**  - AI was used to assist in identifying the root cause
