### PR TITLE
Add verbose flag to completion requests to return __verbose

### DIFF
--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -503,7 +503,7 @@ task_params eval_llama_cmpl_schema(
     params.antiprompt    = params_base.antiprompt;
 
     // enabling this will output extra debug information in the HTTP responses from the server
-    params.verbose       = params_base.verbosity > 9;
+    params.verbose       = params_base.verbosity > 9 || json_value(data, "verbose", false);
 
     params.chat_parser_params.reasoning_format = params_base.reasoning_format;
 


### PR DESCRIPTION
## Overview

Add a `verbose: true` flag to a completion request to opt-in to receive `__verbose` when the server wasn't started with `--verbose` (both streaming and non-streaming).

## Additional information

This is useful for troubleshooting a single request without blowing up the response size for every request.

Also, this should not be construed to overlap with everything that `--verbose` does, i.e. verbose logging is not included. This only includes `__verbose` on the response.

## Example

request:
```bash
curl http://localhost:8013/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "max_tokens": 10,
    "messages": [
      {"role": "user", "content": "Hello!"}
    ],
    "verbose": true
  }' | jq
```

response:
```json
{
  "choices": [
    ...
  ],
  "__verbose": {
    "index": 0,
    "content": "Here's a thinking process:\n\n1. ",
    ...
  }
}
```

## Questions

- [ ] Is the name ok `verbose`? Could also go with `__verbose` to match the response field.
- I added either-or logic:
  - Either start the server with `--verbose`
    - Or include `"verbose": true`
    - Then you get `__verbose` on the response
  - [ ] Should setting `"verbose": false` result in disabling the `__verbose` field when the server is started with `llama-server --verbose`? I don't foresee a need for this, to one-off disable `__verbose` on a response.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No AI used

Apologies for opening a second PR, I used my master branch on the first one (a few months ago) and somehow closed it and GitHub won't let me reopen it.