### PR TITLE
ui: use server modalities in non-router mode

### DIFF
--- a/tools/ui/src/lib/stores/models.svelte.ts
+++ b/tools/ui/src/lib/stores/models.svelte.ts
@@ -131,6 +131,10 @@ class ModelsStore {
 	 */
 
 	getModelModalities(modelId: string): ModelModalities | null {
+		if (!isRouterMode() && serverStore.props?.modalities) {
+			return this.buildModalities(serverStore.props.modalities);
+		}
+
 		const model = this.models.find((m) => m.model === modelId || m.id === modelId);
 		if (model?.modalities) {
 			return model.modalities;


### PR DESCRIPTION
## Overview

Fixes a bug where regenerating a response from a message that had an image attachment would send it without the image attachment. This has been annoying me for months, and finally annoyed me enough to try to figure out what was going on.

The underlying issue is that I'm not using "router mode". I use an external router (llama-swap), which works with more than just llama-server. From what I can tell, this bug likely did not exist in router mode.

In non-router-mode, the model name lookup fails, so the code decides that the model probably isn't multimodal and strips the image attachments. But, when we're not in router mode, we shouldn't _care_ about the name of the model that was used to generate the previous message. It truly does not matter.

For each of these two videos, there are three tests: sending a new message with an image, regenerating the response, and editing the previous message with the attachment and sending it again. Only the second case would fail under the previous code. All three cases pass with the updated code.

Before:

https://github.com/user-attachments/assets/3660b336-6533-44ff-9ee7-47c4b0f1429c

(Test 2 fails: regenerate sends the message without the image attachment.)

After:

https://github.com/user-attachments/assets/5e975e89-ce61-420a-9817-2f053043e3e2

(All 3 tests pass.)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI helped research the issue and wrote a different solution initially, but the solution here is one that I decided on, and AI wrote these lines in the correct place. It is a tiny PR, easily verified by human eyes.
