### PR TITLE
llama : fix long/short rope factor selection by sequence length

### DIFF
--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -9,6 +9,16 @@
 #include <algorithm>
 #include <sstream>
 
+int32_t llama_ubatch::pos_max() const {
+    int32_t res = 0;
+    if (pos) {
+        for (uint32_t i = 0; i < n_tokens; ++i) {
+            res = std::max(res, (int32_t) pos[i]);
+        }
+    }
+    return res;
+}
+
 llama_batch_allocr::llama_batch_allocr(uint32_t n_pos_per_embd) : n_pos_per_embd(n_pos_per_embd) {
     const char * LLAMA_BATCH_DEBUG = getenv("LLAMA_BATCH_DEBUG");
     debug = LLAMA_BATCH_DEBUG ? atoi(LLAMA_BATCH_DEBUG) : 0;

--- a/src/llama-batch.h
+++ b/src/llama-batch.h
@@ -27,6 +27,9 @@ struct llama_ubatch {
         return n_pos >= 3;
     }
 
+    // largest token position in the ubatch (max over all sequences)
+    int32_t pos_max() const;
+
     uint32_t b_equal_seqs; // note: this is a boolean, but we use an int32_t for alignment
                            //       otherwise address sanitizer complains
     // TODO: whole_seqs for embeddings?

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1818,6 +1818,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
     do {
         const auto & ubatch = mctx->get_ubatch();
 
+        const int32_t pos_max = ubatch.pos_max();
+        if (model.layers[0].rope_freqs == nullptr && model.layers[0].rope_long != nullptr &&
+            pos_max >= (int32_t) model.hparams.n_ctx_orig_yarn) {
+            LLAMA_LOG_WARN("%s: LongRoPE: sequence length (%d) reached n_ctx_orig_yarn (%u), switching to long rope factors, which may give approximate output\n", __func__, pos_max + 1, model.hparams.n_ctx_orig_yarn);
+        }
+
         // count the outputs in this ubatch
         {
             int32_t n_outputs_new = 0;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2400,6 +2400,7 @@ llm_graph_params llama_context::graph_params(
         /*.hparams     =*/ model.hparams,
         /*.cparams     =*/ cparams,
         /*.ubatch      =*/ ubatch,
+        /*.pos_max     =*/ ubatch.pos_max(),
         /*.gtype       =*/ gtype,
         /*.sched       =*/ sched.get(),
         /*.backend_cpu =*/ backend_cpu,

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1054,6 +1054,7 @@ llm_graph_context::llm_graph_context(const llm_graph_params & params) :
     n_tokens         (ubatch.n_tokens),
     n_outputs        (params.n_outputs),
     n_ctx_orig       (cparams.n_ctx_orig_yarn),
+    pos_max          (params.pos_max),
     pooling_type     (cparams.pooling_type),
     rope_type        (hparams.rope_type),
     sched            (params.sched),

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -593,6 +593,8 @@ struct llm_graph_params {
 
     llama_ubatch ubatch; // note: intentionally make a copy
 
+    int32_t pos_max;
+
     llm_graph_type gtype;
 
     ggml_backend_sched_t sched;
@@ -657,6 +659,11 @@ struct llm_graph_params {
         }
 
         if (!can_reuse_ubatch) {
+            return false;
+        }
+
+        if ((pos_max       >= (int32_t) hparams.n_ctx_orig_yarn) !=
+            (other.pos_max >= (int32_t) hparams.n_ctx_orig_yarn)) {
             return false;
         }
 
@@ -812,6 +819,8 @@ struct llm_graph_context {
     const int64_t n_tokens;
     const int64_t n_outputs;
     const int32_t n_ctx_orig; // yarn
+
+    const int32_t pos_max;
 
     const enum llama_pooling_type pooling_type;
     const enum llama_rope_type    rope_type;

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1918,6 +1918,13 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
 
     const auto & cparams = lctx->get_cparams();
 
+    int32_t pos_max = 0;
+    for (uint32_t s = 0; s < n_stream; ++s) {
+        for (llama_seq_id seq_id = 0; seq_id < LLAMA_MAX_SEQ; ++seq_id) {
+            pos_max = std::max(pos_max, (int32_t) v_cells[s].seq_pos_max(seq_id));
+        }
+    }
+
     for (const auto & layer : layers) {
         const uint32_t il = layer.il;
 
@@ -1931,7 +1938,7 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
         const float freq_base_l  = model.get_rope_freq_base (cparams, il);
         const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
 
-        ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+        ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
         ggml_tensor * k =
             ggml_view_3d(ctx, layer.k,

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1985,15 +1985,15 @@ float llama_model::get_rope_freq_scale(const llama_cparams & cparams, int il) co
     return hparams.is_swa(il) ? hparams.rope_freq_scale_train_swa : cparams.rope_freq_scale;
 }
 
-ggml_tensor * llama_model::get_rope_factors(const llama_cparams & cparams, int il) const {
-    const uint32_t n_ctx_seq = cparams.n_ctx_seq;
+ggml_tensor * llama_model::get_rope_factors(const llama_cparams & cparams, int32_t pos_max, int il) const {
+    GGML_UNUSED(cparams);
 
-    // choose long/short freq factors based on the context size
     if (layers[il].rope_freqs != nullptr) {
         return layers[il].rope_freqs;
     }
 
-    if (n_ctx_seq > hparams.n_ctx_orig_yarn) {
+    // long factors once positions reach the original training length
+    if (pos_max >= (int32_t) hparams.n_ctx_orig_yarn) {
         return layers[il].rope_long;
     }
 

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -638,7 +638,7 @@ struct llama_model {
     float get_rope_freq_base (const llama_cparams & cparams, int il) const;
     float get_rope_freq_scale(const llama_cparams & cparams, int il) const;
 
-    ggml_tensor * get_rope_factors(const llama_cparams & cparams, int il) const;
+    ggml_tensor * get_rope_factors(const llama_cparams & cparams, int32_t pos_max, int il) const;
 
     llama_memory_i * create_memory(const llama_memory_params & params, const llama_cparams & cparams) const;
 

--- a/src/models/apertus.cpp
+++ b/src/models/apertus.cpp
@@ -84,7 +84,7 @@ llama_model_apertus::graph::graph(const llama_model & model, const llm_graph_par
 
         // self-attention
         {
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/arcee.cpp
+++ b/src/models/arcee.cpp
@@ -77,7 +77,7 @@ llama_model_arcee::graph::graph(const llama_model & model, const llm_graph_param
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/bailingmoe.cpp
+++ b/src/models/bailingmoe.cpp
@@ -84,7 +84,7 @@ llama_model_bailingmoe::graph::graph(const llama_model & model, const llm_graph_
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/cohere2.cpp
+++ b/src/models/cohere2.cpp
@@ -82,7 +82,7 @@ llama_model_cohere2::graph::graph(const llama_model & model, const llm_graph_par
         // self-attention
         {
             // rope freq factors for 128k context
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/cohere2moe.cpp
+++ b/src/models/cohere2moe.cpp
@@ -186,7 +186,7 @@ llama_model_cohere2moe::graph::graph(const llama_model & model, const llm_graph_
                     n_embd_head, n_head, n_head_kv, il);
 
             if (is_swa || force_rope) {
-                ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+                ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
                 Qcur = ggml_rope_ext(
                         ctx0, Qcur, inp_pos, rope_factors,
@@ -360,7 +360,7 @@ llama_model_cohere2moe::graph_mtp::graph_mtp(const llama_model & model, const ll
     ggml_tensor * ffn_inp = cur;
 
     auto [Qcur, Kcur, Vcur] = build_qkv(layer, cur, n_embd_head, n_head, n_head_kv, il);
-    ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+    ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
     Qcur = ggml_rope_ext(
             ctx0, Qcur, inp_pos, rope_factors,
             n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,

--- a/src/models/deci.cpp
+++ b/src/models/deci.cpp
@@ -119,7 +119,7 @@ llama_model_deci::graph::graph(const llama_model & model, const llm_graph_params
         } else if (n_head > 0) {
             // self-attention
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/deepseek.cpp
+++ b/src/models/deepseek.cpp
@@ -103,7 +103,7 @@ llama_model_deepseek::graph::graph(const llama_model & model, const llm_graph_pa
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/eagle3.cpp
+++ b/src/models/eagle3.cpp
@@ -232,7 +232,7 @@ llama_model_eagle3::graph<false>::graph(const llama_model & model, const llm_gra
         Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
 
         // rope freq factors, returns nullptr if not available
-        ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+        ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
         // RoPE
         Qcur = ggml_rope_ext(

--- a/src/models/exaone-moe.cpp
+++ b/src/models/exaone-moe.cpp
@@ -141,7 +141,7 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
 
         // self-attention
         {
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/exaone.cpp
+++ b/src/models/exaone.cpp
@@ -72,7 +72,7 @@ llama_model_exaone::graph::graph(const llama_model & model, const llm_graph_para
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/exaone4.cpp
+++ b/src/models/exaone4.cpp
@@ -119,7 +119,7 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
 
         // self-attention
         {
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,
                     n_embd_head, n_head, n_head_kv, il);

--- a/src/models/granite-hybrid.cpp
+++ b/src/models/granite-hybrid.cpp
@@ -208,7 +208,7 @@ ggml_tensor * llama_model_granite_hybrid::graph::build_attention_layer(ggml_tens
 
     const bool use_rope = hparams.rope_finetuned;
     if (use_rope) {
-        ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+        ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
         Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, rope_factors, n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
                              ext_factor, attn_factor, beta_fast, beta_slow);
 

--- a/src/models/granite.cpp
+++ b/src/models/granite.cpp
@@ -205,7 +205,7 @@ ggml_tensor * llama_model_granite::graph::build_attention_layer(
 
     const bool use_rope = hparams.rope_finetuned;
     if (use_rope) {
-        ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+        ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
         Qcur = ggml_rope_ext(
                 ctx0, Qcur, inp_pos, rope_factors,
                 n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,

--- a/src/models/hunyuan-moe.cpp
+++ b/src/models/hunyuan-moe.cpp
@@ -85,7 +85,7 @@ llama_model_hunyuan_moe::graph::graph(const llama_model & model, const llm_graph
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/hunyuan-vl.cpp
+++ b/src/models/hunyuan-vl.cpp
@@ -93,7 +93,7 @@ llama_model_hunyuan_vl::graph::graph(const llama_model & model, const llm_graph_
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -137,7 +137,7 @@ llama_model_llama::graph<embed>::graph(const llama_model & model, const llm_grap
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/llama4.cpp
+++ b/src/models/llama4.cpp
@@ -154,7 +154,7 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/minicpm3.cpp
+++ b/src/models/minicpm3.cpp
@@ -91,7 +91,7 @@ llama_model_minicpm3::graph::graph(const llama_model & model, const llm_graph_pa
     for (int il = 0; il < n_layer; ++il) {
         ggml_tensor * inpSA = inpL;
 
-        ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+        ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
         // norm
         cur = build_norm(inpL,

--- a/src/models/mistral3.cpp
+++ b/src/models/mistral3.cpp
@@ -128,7 +128,7 @@ llama_model_mistral3::graph::graph(const llama_model & model, const llm_graph_pa
         // self-attention
         {
             // rope freq factors for llama3; may return nullptr for llama2 and other models
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             // compute Q and K and RoPE them
             auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,

--- a/src/models/phi3.cpp
+++ b/src/models/phi3.cpp
@@ -94,7 +94,7 @@ llama_model_phi3::graph<iswa>::graph(const llama_model & model, const llm_graph_
         // self-attention
         {
             // rope freq factors for 128k context
-            ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = model.get_rope_factors(cparams, pos_max, il);
 
             ggml_tensor* attn_norm_output = build_norm(inpL,
                     model.layers[il].attn_norm,

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -245,7 +245,7 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
 
             // RoPE (partial rotary factors per layer)
             const bool is_swa = hparams.is_swa(il);
-            ggml_tensor * rope_factors = is_swa ? nullptr : model.get_rope_factors(cparams, il);
+            ggml_tensor * rope_factors = is_swa ? nullptr : model.get_rope_factors(cparams, pos_max, il);
             const int64_t n_rot_l = hparams.n_rot(il);
             Qcur = ggml_rope_ext(
                 ctx0, Qcur, inp_pos, rope_factors,
@@ -450,7 +450,7 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     }
 
     const bool    is_swa       = hparams.is_swa(il);
-    ggml_tensor * rope_factors = is_swa ? nullptr : model.get_rope_factors(cparams, il);
+    ggml_tensor * rope_factors = is_swa ? nullptr : model.get_rope_factors(cparams, pos_max, il);
     const int64_t n_rot_l      = hparams.n_rot(il);
 
     Qcur = ggml_rope_ext(


### PR DESCRIPTION
For LongRoPE models (Phi-3 / Phi-4 family), `get_rope_factors()` previously selected the long/short RoPE factors based on `cparams.n_ctx_seq`.

`n_ctx_seq` is the allocated context size, fixed at context creation and unrelated to the actual sequence length, so it is not a sound basis for choosing the factors — the selection should depend on the current sequence length.

This PR selects the factors based on the largest token position actually reached instead.

**Known remaining issues (left out to avoid a larger PR; I'm happy to extend this PR if needed)**

1. **No per-request factor selection.** A ubatch may mix short and long sequences, but the whole ubatch is selected with a single maximum position.
2. **History is not corrected when the context grows past the boundary.** Once a sequence grows beyond `original_max_position_embeddings`, keys already written to the KV-cache with the short factors are not re-rotated.

Fixes #24823