### PR TITLE
mtmd : fix DeepSeek-OCR-2 multi-tile processing (#24880)

### DIFF
--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -1186,7 +1186,7 @@ mtmd_image_preproc_out mtmd_image_preprocessor_deepseekocr::preprocess(const cli
 
         clip_image_u8 refined;
         img_tool::resize(img, refined, { tile_size * grid_w, tile_size * grid_h }, RESIZE_ALGO_BICUBIC_PILLOW,
-                         PAD_NONE);
+                         PAD_NEAREST, hparams.image_pad_color);
 
         for (int row = 0; row < grid_h; row++) {
             if (fuse_row) {

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -616,9 +616,10 @@ struct mtmd_context {
             case PROJECTOR_TYPE_DEEPSEEKOCR:
             case PROJECTOR_TYPE_DEEPSEEKOCR2:
                 {
+                    tok_ov_img_start = {lookup_token("<image>")};
                     img_end = "\n"; // prevent empty batch on llama-server
                     image_preproc = std::make_unique<mtmd_image_preprocessor_deepseekocr>(ctx_v);
-                    ov_img_first = false;
+                    ov_img_first = true; // MUST be true for DeepSeek-VL-2 to output [global, sep, tiles...]
                 } break;
             case PROJECTOR_TYPE_HUNYUANVL:
                 {


### PR DESCRIPTION
Resolves #24880 (in collaboration with previous fixes)

- Enforce `ov_img_first = true` to place global tile before local tiles
- Change global tile resize from `PAD_NONE` to `PAD_NEAREST` to preserve aspect ratio
- Prepend missing `<image>` token (`tok_ov_img_start`) required for model vision grounding

## Overview

- **Fixes DeepSeek-VL-2 / DeepSeek-OCR-2 multi-tile image processing hallucination loops.**

Currently, providing high-resolution non-square images to DeepSeek-OCR-2 causes the model to output endless repetitive garbage (e.g., `D3D3D3...`). This PR fixes three issues in `mtmd` that were breaking the visual tokenization:
1. DeepSeek strictly requires the global overview to be placed *before* the high-resolution local tiles (`[global_view] + [view_separator] + [local_views]`). Setting `ov_img_first = true` enforces this sequence.
2. The global overview was being aggressively stretched into a square because `PAD_NONE` was used. Switching to `PAD_NEAREST` preserves the spatial aspect ratio, which is critical for the model's structural grounding.
3. The visual embeddings were being emitted without the `<image>` anchor token, breaking the grounding projection. Explicitly declaring `tok_ov_img_start` fixes this.

## Additional information

This has been tested locally on `deepseek-ocr-2-q8_0.gguf` using various large rectangular multi-tile diagrams and text pages to be recognized. With these changes, the model correctly extracts structural layout tokens (like `table[[...]]` and `image[[...]]`) and transcribes text perfectly instead of falling into a hallucination loop.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. An AI coding assistant helped diagnose the token sequence inversion and aspect ratio distortion bugs via local testing, and assisted in drafting the C++ patch.
