### PR TITLE
Add id field to tool call responses API

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -591,10 +591,11 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp() {
 
     for (const common_chat_tool_call & tool_call : oaicompat_msg.tool_calls) {
         output.push_back(json {
+            {"id",        "fc_" + tool_call.id},
             {"type",      "function_call"},
             {"status",    "completed"},
             {"arguments", tool_call.arguments},
-            {"call_id",   "fc_" + tool_call.id},
+            {"call_id",   "call_" + tool_call.id},
             {"name",      tool_call.name},
         });
     }
@@ -690,10 +691,11 @@ json server_task_result_cmpl_final::to_json_oaicompat_resp_stream() {
 
     for (const common_chat_tool_call & tool_call : oaicompat_msg.tool_calls) {
         const json output_item = {
+            {"id",        "fc_" + tool_call.id},
             {"type",      "function_call"},
             {"status",    "completed"},
             {"arguments", tool_call.arguments},
-            {"call_id",   "fc_" + tool_call.id},
+            {"call_id",   "call_" + tool_call.id},
             {"name",      tool_call.name}
         };
         server_sent_events.push_back(json {
@@ -1277,8 +1279,9 @@ json server_task_result_cmpl_partial::to_json_oaicompat_resp() {
                 {"data", json {
                     {"type",  "response.output_item.added"},
                     {"item", json {
+                        {"id",        "fc_" + diff.tool_call_delta.id},
                         {"arguments", ""},
-                        {"call_id",   "fc_" + diff.tool_call_delta.id},
+                        {"call_id",   "call_" + diff.tool_call_delta.id},
                         {"name",      diff.tool_call_delta.name},
                         {"type",      "function_call"},
                         {"status",    "in_progress"},


### PR DESCRIPTION
## Overview

Add the missing `id` field to Responses API `function_call` output items.

The OpenAI Responses API function-calling examples include both an item `id` and a `call_id` on `function_call` output objects. Some clients, such as Rig 0.39, require the item-level `id` field when deserializing `/v1/responses` tool calls.

This change makes llama-server’s `/v1/responses` function-call output more compatible with the documented Responses API shape by emitting:

- `id`: function-call output item id
- `call_id`: tool call correlation id

## Additional information

Tested locally with Qwen3-Coder-Next GGUF through `llama-server /v1/responses`. Before this change, Rig 0.39 failed with `missing field id` when parsing tool calls. After adding the item-level `id`, Rig successfully executed the tool call and returned the final answer.

Reference: OpenAI function calling guide:
https://developers.openai.com/api/docs/guides/function-calling#handling-function-calls

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - ChatGPT was used to help diagnose the compatibility issue and draft this PR description. The code change was manually reviewed and tested.
