### PR TITLE
server: fix checkpoint invalidation after tool requests in multi-turn conversation

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1535,7 +1535,7 @@ done:
 static void common_context_seq_rm(llama_context * ctx, llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
     auto * mem = llama_get_memory(ctx);
     if (!llama_memory_seq_rm(mem, seq_id, p0, p1)) {
-        GGML_ABORT("%s", string_format("failed to remove sequence %d with p0=%d, p1=%d\n", seq_id, p0, p1).c_str());
+        COM_WRN("failed to remove sequence %d with p0=%d, p1=%d\n", seq_id, p0, p1);
     }
 }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1625,7 +1625,7 @@ done:
 static void common_context_seq_rm(llama_context * ctx, llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
     auto * mem = llama_get_memory(ctx);
     if (!llama_memory_seq_rm(mem, seq_id, p0, p1)) {
-        GGML_ABORT("%s", string_format("failed to remove sequence %d with p0=%d, p1=%d\n", seq_id, p0, p1).c_str());
+        COM_WRN("failed to remove sequence %d with p0=%d, p1=%d\n", seq_id, p0, p1);
     }
 }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -534,6 +534,24 @@ struct server_slot {
                 prompt_clear();
             }
 
+            // erase generation-phase checkpoints (pos > prompt) to free slots for next request's input-phase checkpoints
+            if (!task->is_child()) {
+                auto prompt_end = task->n_tokens();
+                int erased = 0;
+                for (auto it = prompt.checkpoints.begin(); it != prompt.checkpoints.end();) {
+                    if (it->pos_min > prompt_end) {
+                        SLT_DBG(*this, "release: erasing generation checkpoint (pos_min=%d > prompt_end=%d)\n", it->pos_min, prompt_end);
+                        it = prompt.checkpoints.erase(it);
+                        erased++;
+                    } else {
+                        ++it;
+                    }
+                }
+                if (erased > 0) {
+                    SLT_INF(*this, "release: erased %d generation checkpoints (prompt_end=%d)\n", erased, prompt_end);
+                }
+            }
+
             reset();
 
             callback_on_release(id);
@@ -3039,8 +3057,12 @@ private:
                     ckpt.load_dft(ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                 }
 
-                if (!llama_memory_seq_rm(llama_get_memory(ctx_dft), slot.id, ckpt.pos_max + 1, -1)) {
-                    GGML_ABORT("failed to remove sequence %d\n", slot.id);
+                {
+                    const llama_pos p0_ckpt = ckpt.pos_max + 1;
+                    auto * mem_dft = llama_get_memory(ctx_dft);
+                    if (!llama_memory_seq_rm(mem_dft, slot.id, p0_ckpt, -1)) {
+                        SLT_WRN(slot, "ckpt seq_rm [%d, end) failed, skipping\n", p0_ckpt);
+                    }
                 }
             }
 
@@ -3140,6 +3162,7 @@ private:
 
                         // keep track how many tokens we can reuse from the previous state
                         int n_past = 0;
+                        int n_past_common = 0;
 
                         // empty prompt passed -> release the slot and send empty response
                         if (input_tokens.empty()) {
@@ -3195,6 +3218,7 @@ private:
                             if (slot.task->params.cache_prompt) {
                                 // reuse any previously computed tokens that are common with the new prompt
                                 n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
+                                n_past_common = n_past;
 
                                 // if there is an alora invoked, don't cache after the invocation start
                                 if (slot.alora_invocation_start > 0) {
@@ -3351,7 +3375,8 @@ private:
 
                                         pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));
                                         n_past   = std::min(slot.prompt.tokens.size_up_to_pos(pos_next), (size_t) it->n_tokens);
-                                        SLT_TRC(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
+                                        n_past_common = std::min(n_past_common, (int) it->n_tokens);
+                                        SLT_WRN(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
                                     }
 
                                     if (do_reset) {
@@ -3359,6 +3384,7 @@ private:
                                                 "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
                                         pos_next = 0;
                                         n_past = 0;
+                                        n_past_common = 0;
                                     }
                                 }
                             }
@@ -3367,8 +3393,8 @@ private:
                                 // erase any checkpoints with pos_max > pos_next
                                 for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end();) {
                                     const auto & cur = *it;
-                                    if (cur.pos_max > pos_next) {
-                                        SLT_TRC(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
+                                    if (cur.pos_max > (int)slot.task->n_tokens()) {
+                                        SLT_WRN(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
                                         it = slot.prompt.checkpoints.erase(it);
                                     } else {
                                         ++it;
@@ -3387,7 +3413,7 @@ private:
                         slot.n_prompt_tokens_cache = n_past;
                         slot.n_prompt_tokens_processed = 0;
 
-                        slot.prompt.tokens.keep_first(n_past);
+                        slot.prompt.tokens.keep_first(std::max((size_t)n_past_common, (size_t)n_past));
 
                         // this is to signal the client that the request has started processing
                         if (slot.task->params.stream) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -512,6 +512,24 @@ struct server_slot {
 
             callback_on_reset(*this);
 
+            // erase generation-phase checkpoints (pos > prompt) to free slots for next request's input-phase checkpoints
+            if (!task->is_child()) {
+                auto prompt_end = task->n_tokens();
+                int erased = 0;
+                for (auto it = prompt.checkpoints.begin(); it != prompt.checkpoints.end();) {
+                    if (it->pos_min > prompt_end) {
+                        SLT_DBG(*this, "release: erasing generation checkpoint (pos_min=%d > prompt_end=%d)\n", it->pos_min, prompt_end);
+                        it = prompt.checkpoints.erase(it);
+                        erased++;
+                    } else {
+                        ++it;
+                    }
+                }
+                if (erased > 0) {
+                    SLT_INF(*this, "release: erased %d generation checkpoints (prompt_end=%d)\n", erased, prompt_end);
+                }
+            }
+
             reset();
 
             callback_on_release(id);
@@ -2946,8 +2964,12 @@ private:
                     ckpt.load_dft(ctx_dft, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
                 }
 
-                if (!llama_memory_seq_rm(llama_get_memory(ctx_dft), slot.id, ckpt.pos_max + 1, -1)) {
-                    GGML_ABORT("failed to remove sequence %d\n", slot.id);
+                {
+                    const llama_pos p0_ckpt = ckpt.pos_max + 1;
+                    auto * mem_dft = llama_get_memory(ctx_dft);
+                    if (!llama_memory_seq_rm(mem_dft, slot.id, p0_ckpt, -1)) {
+                        SLT_WRN(slot, "ckpt seq_rm [%d, end) failed, skipping\n", p0_ckpt);
+                    }
                 }
             }
 
@@ -3046,6 +3068,7 @@ private:
 
                         // keep track how many tokens we can reuse from the previous state
                         int n_past = 0;
+                        int n_past_common = 0;
 
                         // empty prompt passed -> release the slot and send empty response
                         if (input_tokens.empty()) {
@@ -3101,6 +3124,7 @@ private:
                             if (slot.task->params.cache_prompt) {
                                 // reuse any previously computed tokens that are common with the new prompt
                                 n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
+                                n_past_common = n_past;
 
                                 // if there is an alora invoked, don't cache after the invocation start
                                 if (slot.alora_invocation_start > 0) {
@@ -3257,7 +3281,8 @@ private:
 
                                         pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));
                                         n_past   = std::min(slot.prompt.tokens.size_up_to_pos(pos_next), (size_t) it->n_tokens);
-                                        SLT_TRC(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
+                                        n_past_common = std::min(n_past_common, (int) it->n_tokens);
+                                        SLT_WRN(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
                                     }
 
                                     if (do_reset) {
@@ -3265,6 +3290,7 @@ private:
                                                 "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
                                         pos_next = 0;
                                         n_past = 0;
+                                        n_past_common = 0;
                                     }
                                 }
                             }
@@ -3273,8 +3299,8 @@ private:
                                 // erase any checkpoints with pos_max > pos_next
                                 for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end();) {
                                     const auto & cur = *it;
-                                    if (cur.pos_max > pos_next) {
-                                        SLT_TRC(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
+                                    if (cur.pos_max > (int)slot.task->n_tokens()) {
+                                        SLT_WRN(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
                                         it = slot.prompt.checkpoints.erase(it);
                                     } else {
                                         ++it;
@@ -3295,7 +3321,7 @@ private:
 
                         metrics.add_prompt_cached(n_past);
 
-                        slot.prompt.tokens.keep_first(n_past);
+                        slot.prompt.tokens.keep_first(std::max((size_t)n_past_common, (size_t)n_past));
 
                         // this is to signal the client that the request has started processing
                         if (slot.task->params.stream) {


### PR DESCRIPTION
Fixes #24890

Overview
--------
Checkpoint selection in the server chooses suboptimal checkpoints when
n_past from get_common_prefix() (true token matching) is overwritten by
checkpoint restoration's smaller value. The incorrect n_past cascades to
pos_next, causing subsequent erasure of valid checkpoints. Additionally,
generation-phase checkpoints fill the slot limit, evicting input-phase
checkpoints needed for subsequent requests. Finally, sequence removal
failures crash the process via GGML_ABORT.

Changes (6 items, 2 files: common/common.cpp + tools/server/server-context.cpp)
-------------------------------------------------------------------------------

1. Save get_common_prefix result as n_past_common before checkpoint
   restoration overwrites n_past.

2. keep_first(max(n_past_common, n_past)) so token history is never
   shrunk by an older checkpoint value. Clamp n_past_common to
   checkpoint.n_tokens after restoration and zero it on do_reset.

3. Change erasure condition from cur.pos_max > pos_next to
   cur.pos_max > slot.task->n_tokens() to use the physical prompt
   length, not a checkpoint-corrupted pos_next.

4. Replace common_context_seq_rm's hard GGML_ABORT with a warning in
   common.cpp (covers all call sites), and use a direct
   llama_memory_seq_rm call with SLT_WRN on failure in the checkpoint
   restore path. Sequence removal failures no longer crash the process.

5. Erase generation-phase checkpoints on slot release (pos >
   prompt_end) to free the slot limit for input-phase checkpoints.

6. Type-safe log format specifiers and promote checkpoint restore /
   erasure logs to SLT_WRN for visibility.

Verification
------------
Qwen 3.6 27B, 140+ messages through proxy pool. Before: 6-17 checkpoints
erased per request, prompt_eval 10000+ tokens, M-RoPE batch init failures.
After: 0 erasure when checkpoint covers common prefix, prompt_eval
proportional to real content delta (500-3000 tokens), no M-RoPE errors.

Requirements
------------
- [x] I have read and agree with the contributing guidelines
- AI usage disclosure: YES - AI assisted with code analysis and root
  cause investigation. All code changes manually reviewed.