### PR TITLE
opencl: q8_0 GEMM using dot8 + local memory broadcast for Adreno

### DIFF
--- a/ggml/src/ggml-opencl/CMakeLists.txt
+++ b/ggml/src/ggml-opencl/CMakeLists.txt
@@ -156,6 +156,7 @@ set(GGML_OPENCL_KERNELS
     gemm_noshuffle_q6_k_f32
     gemv_noshuffle_q5_k_f32
     gemm_noshuffle_q5_k_f32
+    gemm_dot8_q8_0_f32_lmbcast
     mul
     neg
     norm

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -4226,6 +4226,7 @@ static ggml_backend_opencl_context * ggml_cl_init(ggml_backend_dev_t dev) {
     // determine whether to use dot8 + local memory broadcast GEMM for Q8_0
     backend_ctx->adreno_dot8_lmbcast_q8_0_gemm_enabled = backend_ctx->gpu_family == GPU_FAMILY::ADRENO &&
                                             strstr(ext_buffer, "cl_qcom_dot_product8") != NULL &&
+                                            strstr(ext_buffer, "cl_qcom_local_memory_control") != NULL &&
                                             getenv("GGML_OPENCL_DISABLE_DOT8_GEMM_Q8_0") == nullptr;
 
     // determine whether to use large buffer for Adreno

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -447,6 +447,12 @@ struct ggml_backend_opencl_context {
     bool adreno_xmem_gemm_enabled = false;
 #endif
 
+    // prealloc buffers for dot8 local memory broadcast GEMM
+    ggml_cl_buffer prealloc_dot8_act;
+    ggml_cl_buffer prealloc_dot8_params;
+
+    bool adreno_dot8_lmbcast_q8_0_gemm_enabled = false;
+
     // prealloc buffers for MoE router table preprocess
     bool toggle_reorder = false;
     ggml_cl_buffer prealloc_post_router;
@@ -682,6 +688,9 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_mul_mm_q5_k_f32_l4_lm;
     cl_kernel kernel_mul_mm_q6_k_f32_l4_lm;
     cl_kernel kernel_mul_mm_iq4_nl_f32_l4_lm;
+
+    cl_kernel kernel_gemm_dot8_q8_0_pack_act;
+    cl_kernel kernel_gemm_dot8_q8_0_f32_lmbcast;
 
     std::vector<ProfilingInfo> profiling_info;
     std::vector<ProfilingInfo> profiling_results;
@@ -3699,6 +3708,26 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
         GGML_LOG_CONT(".");
     }
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
+
+    if (backend_ctx->adreno_dot8_lmbcast_q8_0_gemm_enabled) {
+#ifdef GGML_OPENCL_EMBED_KERNELS
+        const std::string kernel_src {
+            #include "gemm_dot8_q8_0_f32_lmbcast.cl.h"
+        };
+#else
+        const std::string kernel_src = read_file("gemm_dot8_q8_0_f32_lmbcast.cl");
+#endif
+        cl_program prog =
+            build_program_from_source(backend_ctx->context, backend_ctx->device, kernel_src.c_str(), compile_opts);
+
+        CL_CHECK((backend_ctx->kernel_gemm_dot8_q8_0_pack_act =
+            clCreateKernel(prog, "kernel_gemm_dot8_q8_0_pack_act", &err), err));
+        CL_CHECK((backend_ctx->kernel_gemm_dot8_q8_0_f32_lmbcast =
+            clCreateKernel(prog, "kernel_gemm_dot8_q8_0_f32_lmbcast", &err), err));
+        CL_CHECK(clReleaseProgram(prog));
+        GGML_LOG_CONT(".");
+    }
+
     GGML_LOG_CONT("\n");
     backend_ctx->kernels_loaded = true;
 }
@@ -3991,6 +4020,10 @@ static void ggml_opencl_print_backend_info(ggml_backend_opencl_device_context * 
     }
 #endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
+    if (backend_ctx->adreno_dot8_lmbcast_q8_0_gemm_enabled) {
+        GGML_LOG_INFO("ggml_opencl: Adreno q8_0 int8-dot GEMM (local-memory broadcast) enabled\n");
+    }
+
     if (backend_ctx->adreno_use_large_buffer) {
         if (!backend_ctx->adreno_has_large_buffer) {
             GGML_LOG_INFO("ggml_opencl: Adreno large buffer requested but not supported by driver, will use regular buffer\n");
@@ -4189,6 +4222,11 @@ static ggml_backend_opencl_context * ggml_cl_init(ggml_backend_dev_t dev) {
     backend_ctx->adreno_xmem_gemm_enabled = getenv("GGML_OPENCL_ADRENO_XMEM_GEMM") != nullptr &&
                                              backend_ctx->gpu_family == GPU_FAMILY::ADRENO;
 #endif
+
+    // determine whether to use dot8 + local memory broadcast GEMM for Q8_0
+    backend_ctx->adreno_dot8_lmbcast_q8_0_gemm_enabled = backend_ctx->gpu_family == GPU_FAMILY::ADRENO &&
+                                            strstr(ext_buffer, "cl_qcom_dot_product8") != NULL &&
+                                            getenv("GGML_OPENCL_DISABLE_DOT8_GEMM_Q8_0") == nullptr;
 
     // determine whether to use large buffer for Adreno
     backend_ctx->adreno_use_large_buffer = getenv("GGML_OPENCL_ADRENO_USE_LARGE_BUFFER") != nullptr &&
@@ -13098,6 +13136,40 @@ static void ggml_cl_mul_mat_q8_0_f32_adreno(ggml_backend_t backend, const ggml_t
         CL_CHECK(clReleaseMemObject(q_img));
         CL_CHECK(clReleaseMemObject(b_img));
         CL_CHECK(clReleaseMemObject(b_sub_buf));
+    } else if (backend_ctx->adreno_dot8_lmbcast_q8_0_gemm_enabled && M % 32 == 0 &&
+               src1->ne[2] == 1 && src1->ne[3] == 1) {
+        const int nblk = K/32;
+
+        backend_ctx->prealloc_dot8_act.allocate(context, (size_t)2*nblk*N*16);
+        backend_ctx->prealloc_dot8_params.allocate(context, (size_t)N*nblk*8);
+
+        kernel = backend_ctx->kernel_gemm_dot8_q8_0_pack_act;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &backend_ctx->prealloc_dot8_act.buffer));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem),   &backend_ctx->prealloc_dot8_params.buffer));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &extra1->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_ulong), &offset1));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(int),      &K));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(int),      &N));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &nblk));
+
+        size_t pack_gws[3] = {(size_t)CEIL_DIV(N*nblk, 64)*64, 1, 1};
+        size_t pack_lws[3] = {64, 1, 1};
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, pack_gws, pack_lws, dst);
+
+        kernel = backend_ctx->kernel_gemm_dot8_q8_0_f32_lmbcast;
+        CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &extra0_q8_0->q));
+        CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem),   &backend_ctx->prealloc_dot8_act.buffer));
+        CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &extra0_q8_0->d));
+        CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_mem),   &backend_ctx->prealloc_dot8_params.buffer));
+        CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem),   &extrad->data_device));
+        CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_ulong), &offsetd));
+        CL_CHECK(clSetKernelArg(kernel, 6, sizeof(int),      &N));
+        CL_CHECK(clSetKernelArg(kernel, 7, sizeof(int),      &M));
+        CL_CHECK(clSetKernelArg(kernel, 8, sizeof(int),      &nblk));
+
+        size_t gws[3] = {(size_t)CEIL_DIV(N, 64)*64, (size_t)(M/32), 1};
+        size_t lws[3] = {64, 1, 1};
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, gws, lws, dst);
     } else {
         cl_mem b_sub_buf = nullptr;
         cl_mem b_sub_buf_trans = nullptr;

--- a/ggml/src/ggml-opencl/kernels/gemm_dot8_q8_0_f32_lmbcast.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_dot8_q8_0_f32_lmbcast.cl
@@ -1,0 +1,216 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#pragma OPENCL EXTENSION cl_qcom_dot_product8 : enable
+#pragma OPENCL EXTENSION cl_qcom_local_memory_control : enable
+
+//------------------------------------------------------------------------------
+// activation quantize+pack: one work-item per (token, 32-K block).
+//------------------------------------------------------------------------------
+kernel void kernel_gemm_dot8_q8_0_pack_act(
+        global uint4 * act,
+        global float2 * params,
+        global const void * src_void,
+        ulong offset,
+        int K,
+        int N,
+        int nblk
+) {
+    const int lin = get_global_id(0);
+    if (lin >= N*nblk) {
+        return;
+    }
+    const int t   = lin / nblk;
+    const int blk = lin % nblk;
+
+    global const float * src = (global const float *)((global const char *)src_void + offset);
+    global const float4 * row = (global const float4 *)(src + (long)t*K + blk*32);
+
+    const float4 v0 = row[0], v1 = row[1], v2 = row[2], v3 = row[3];
+    const float4 v4 = row[4], v5 = row[5], v6 = row[6], v7 = row[7];
+    float4 am = fmax(fmax(fmax(fabs(v0), fabs(v1)), fmax(fabs(v2), fabs(v3))),
+                     fmax(fmax(fabs(v4), fabs(v5)), fmax(fabs(v6), fabs(v7))));
+    const float amax = fmax(fmax(am.x, am.y), fmax(am.z, am.w));
+    const float d_a = amax / 127.0f;
+    const float inv = amax > 0.0f ? 127.0f / amax : 0.0f;
+
+    const int4 q0 = convert_int4_rte(v0*inv), q1 = convert_int4_rte(v1*inv);
+    const int4 q2 = convert_int4_rte(v2*inv), q3 = convert_int4_rte(v3*inv);
+    const int4 q4 = convert_int4_rte(v4*inv), q5 = convert_int4_rte(v5*inv);
+    const int4 q6 = convert_int4_rte(v6*inv), q7 = convert_int4_rte(v7*inv);
+    const int4 s4 = q0+q1+q2+q3+q4+q5+q6+q7;
+    const int sum = s4.x + s4.y + s4.z + s4.w;
+
+    uint4 ta, tb;
+    ta.x = as_uint(convert_char4_sat(q0)); ta.y = as_uint(convert_char4_sat(q1));
+    ta.z = as_uint(convert_char4_sat(q2)); ta.w = as_uint(convert_char4_sat(q3));
+    tb.x = as_uint(convert_char4_sat(q4)); tb.y = as_uint(convert_char4_sat(q5));
+    tb.z = as_uint(convert_char4_sat(q6)); tb.w = as_uint(convert_char4_sat(q7));
+    act[(long)(blk*2 + 0)*N + t] = ta;
+    act[(long)(blk*2 + 1)*N + t] = tb;
+
+    params[(long)blk*N + t] = (float2)(d_a, -128.0f*d_a*(float)sum);
+}
+
+//------------------------------------------------------------------------------
+// Q8_0 GEMM using dot8 + local memory broadcast
+// uses the same memory layout as gemm_noshuffle_q8_0_f32
+//------------------------------------------------------------------------------
+static inline int4 dot8x4(int4 acc, uint4 w, uint s) {
+    acc.x = qcom_dot8_acc(s, w.x, acc.x);
+    acc.y = qcom_dot8_acc(s, w.y, acc.y);
+    acc.z = qcom_dot8_acc(s, w.z, acc.z);
+    acc.w = qcom_dot8_acc(s, w.w, acc.w);
+    return acc;
+}
+
+kernel void kernel_gemm_dot8_q8_0_f32_lmbcast(
+        global const uint4 * q_nosh,
+        global const uint4 * act,
+        global const half * d_trans,
+        global const float2 * params,
+        global void * dst_void,
+        ulong offsetd,
+        int N,
+        int M,
+        int nblk
+) {
+    // One full 32-K block (64 uint4 = two 16-K tiles) gathered per work-group pass.
+    __local uint4 wl[64] __attribute__((qcom_local_memory_control(0)));
+
+    const int lid = get_local_id(0);
+    const int X   = get_group_id(0)*get_local_size(0) + lid;  // token
+    const int Z   = get_group_id(1);                          // 32-channel group
+    const int Xr  = (X < N) ? X : (N - 1);                    // clamped for OOB lanes
+
+    const int Mu = M >> 2;     // M in uint4 (channels/4); M%32==0 so M%4==0
+    const int th = lid >> 5;   // tile half (0/1) within the 32-K block
+    const int qp = (lid >> 3) & 3;
+    const int Mb = lid & 7;
+
+    float4 f0 = 0;
+    float4 f1 = 0;
+    float4 f2 = 0;
+    float4 f3 = 0;
+    float4 f4 = 0;
+    float4 f5 = 0;
+    float4 f6 = 0;
+    float4 f7 = 0;
+
+    int ks = 0;
+    for (int blk = 0; blk < nblk; blk++) {
+        int4 r0 = 0;
+        int4 r1 = 0;
+        int4 r2 = 0;
+        int4 r3 = 0;
+        int4 r4 = 0;
+        int4 r5 = 0;
+        int4 r6 = 0;
+        int4 r7 = 0;
+
+        const uint4 sa = act[(long)(ks + 0)*N + Xr];   // first 16-K tile codes
+        const uint4 sb = act[(long)(ks + 1)*N + Xr];   // second 16-K tile codes
+        ks += 2;
+
+        // cooperative gather from the noshuffle layout
+        const int kq = blk*8 + th*4 + qp;
+        wl[lid] = q_nosh[(long)kq*Mu + Z*8 + Mb] ^ (uint4)0x80808080u;
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // First 16-K tile (wl[0..31]); broadcast-read with subgroup-uniform index.
+        r0 = dot8x4(r0, wl[0], sa.x);
+        r1 = dot8x4(r1, wl[1], sa.x);
+        r2 = dot8x4(r2, wl[2], sa.x);
+        r3 = dot8x4(r3, wl[3], sa.x);
+        r4 = dot8x4(r4, wl[4], sa.x);
+        r5 = dot8x4(r5, wl[5], sa.x);
+        r6 = dot8x4(r6, wl[6], sa.x);
+        r7 = dot8x4(r7, wl[7], sa.x);
+        r0 = dot8x4(r0, wl[8],  sa.y);
+        r1 = dot8x4(r1, wl[9],  sa.y);
+        r2 = dot8x4(r2, wl[10], sa.y);
+        r3 = dot8x4(r3, wl[11], sa.y);
+        r4 = dot8x4(r4, wl[12], sa.y);
+        r5 = dot8x4(r5, wl[13], sa.y);
+        r6 = dot8x4(r6, wl[14], sa.y);
+        r7 = dot8x4(r7, wl[15], sa.y);
+        r0 = dot8x4(r0, wl[16], sa.z);
+        r1 = dot8x4(r1, wl[17], sa.z);
+        r2 = dot8x4(r2, wl[18], sa.z);
+        r3 = dot8x4(r3, wl[19], sa.z);
+        r4 = dot8x4(r4, wl[20], sa.z);
+        r5 = dot8x4(r5, wl[21], sa.z);
+        r6 = dot8x4(r6, wl[22], sa.z);
+        r7 = dot8x4(r7, wl[23], sa.z);
+        r0 = dot8x4(r0, wl[24], sa.w);
+        r1 = dot8x4(r1, wl[25], sa.w);
+        r2 = dot8x4(r2, wl[26], sa.w);
+        r3 = dot8x4(r3, wl[27], sa.w);
+        r4 = dot8x4(r4, wl[28], sa.w);
+        r5 = dot8x4(r5, wl[29], sa.w);
+        r6 = dot8x4(r6, wl[30], sa.w);
+        r7 = dot8x4(r7, wl[31], sa.w);
+
+        // Second 16-K tile (wl[32..63]).
+        r0 = dot8x4(r0, wl[32], sb.x);
+        r1 = dot8x4(r1, wl[33], sb.x);
+        r2 = dot8x4(r2, wl[34], sb.x);
+        r3 = dot8x4(r3, wl[35], sb.x);
+        r4 = dot8x4(r4, wl[36], sb.x);
+        r5 = dot8x4(r5, wl[37], sb.x);
+        r6 = dot8x4(r6, wl[38], sb.x);
+        r7 = dot8x4(r7, wl[39], sb.x);
+        r0 = dot8x4(r0, wl[40], sb.y);
+        r1 = dot8x4(r1, wl[41], sb.y);
+        r2 = dot8x4(r2, wl[42], sb.y);
+        r3 = dot8x4(r3, wl[43], sb.y);
+        r4 = dot8x4(r4, wl[44], sb.y);
+        r5 = dot8x4(r5, wl[45], sb.y);
+        r6 = dot8x4(r6, wl[46], sb.y);
+        r7 = dot8x4(r7, wl[47], sb.y);
+        r0 = dot8x4(r0, wl[48], sb.z);
+        r1 = dot8x4(r1, wl[49], sb.z);
+        r2 = dot8x4(r2, wl[50], sb.z);
+        r3 = dot8x4(r3, wl[51], sb.z);
+        r4 = dot8x4(r4, wl[52], sb.z);
+        r5 = dot8x4(r5, wl[53], sb.z);
+        r6 = dot8x4(r6, wl[54], sb.z);
+        r7 = dot8x4(r7, wl[55], sb.z);
+        r0 = dot8x4(r0, wl[56], sb.w);
+        r1 = dot8x4(r1, wl[57], sb.w);
+        r2 = dot8x4(r2, wl[58], sb.w);
+        r3 = dot8x4(r3, wl[59], sb.w);
+        r4 = dot8x4(r4, wl[60], sb.w);
+        r5 = dot8x4(r5, wl[61], sb.w);
+        r6 = dot8x4(r6, wl[62], sb.w);
+        r7 = dot8x4(r7, wl[63], sb.w);
+
+        // fold: out += d * (d_a*rawdot + (-128*d_a*sum))
+        const float2 ap = params[(long)blk*N + Xr];
+        const float4 c1 = (float4)(ap.x);
+        const float4 c2 = (float4)(ap.y);
+        global const half * dp = d_trans + (long)blk*M + Z*32;
+        float4 t;
+        t = mad(convert_float4(r0), c1, c2); f0 = mad(vload_half4(0, dp), t, f0);
+        t = mad(convert_float4(r1), c1, c2); f1 = mad(vload_half4(1, dp), t, f1);
+        t = mad(convert_float4(r2), c1, c2); f2 = mad(vload_half4(2, dp), t, f2);
+        t = mad(convert_float4(r3), c1, c2); f3 = mad(vload_half4(3, dp), t, f3);
+        t = mad(convert_float4(r4), c1, c2); f4 = mad(vload_half4(4, dp), t, f4);
+        t = mad(convert_float4(r5), c1, c2); f5 = mad(vload_half4(5, dp), t, f5);
+        t = mad(convert_float4(r6), c1, c2); f6 = mad(vload_half4(6, dp), t, f6);
+        t = mad(convert_float4(r7), c1, c2); f7 = mad(vload_half4(7, dp), t, f7);
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (X < N) {
+        global float * dst = (global float *)((global char *)dst_void + offsetd);
+        global float * o = dst + (long)X*M + Z*32;
+        vstore4(f0, 0, o);
+        vstore4(f1, 1, o);
+        vstore4(f2, 2, o);
+        vstore4(f3, 3, o);
+        vstore4(f4, 4, o);
+        vstore4(f5, 5, o);
+        vstore4(f6, 6, o);
+        vstore4(f7, 7, o);
+    }
+}


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This PR adds a new Q8_0 GEMM kernel that utilizes int8 dot product and local memory broadcast for Adreno 8xx. Local memory broadcast exposes a high bandwidth read path to local memory when access is uniform within a subgroup.

Currently, the GEMM kernel consumes the same transposed weight layout. Decoding is not affected.

It is turned on by default and can be disabled by setting env var `GGML_OPENCL_DISABLE_DOT8_GEMM_Q8_0`.

## Additional information

<Details>

### X2-90

**Enabled**

| model                          |       size |     params | backend    | ngl |  fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ---: | --------------: | -------------------: |
| qwen3 4B Q8_0                  |   3.98 GiB |     4.02 B | OpenCL     |  99 |   0 |    0 |           pp512 |        657.70 ± 1.86 |
| qwen3 4B Q8_0                  |   3.98 GiB |     4.02 B | OpenCL     |  99 |   0 |    0 |          pp2048 |        468.62 ± 0.79 |
| qwen3 4B Q8_0                  |   3.98 GiB |     4.02 B | OpenCL     |  99 |   0 |    0 |           tg128 |         23.20 ± 0.04 |

| model                          |       size |     params | backend    | ngl |  fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ---: | --------------: | -------------------: |
| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | OpenCL     |  99 |   0 |    0 |           pp512 |        379.91 ± 1.44 |
| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | OpenCL     |  99 |   0 |    0 |          pp2048 |        306.69 ± 1.90 |
| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | OpenCL     |  99 |   0 |    0 |           tg128 |         13.28 ± 0.02 |

| model                          |       size |     params | backend    | ngl |  fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ---: | --------------: | -------------------: |
| gemma4 E4B Q8_0                |   7.62 GiB |     7.52 B | OpenCL     |  99 |   0 |    0 |           pp512 |        560.74 ± 1.71 |
| gemma4 E4B Q8_0                |   7.62 GiB |     7.52 B | OpenCL     |  99 |   0 |    0 |          pp2048 |        542.33 ± 1.20 |
| gemma4 E4B Q8_0                |   7.62 GiB |     7.52 B | OpenCL     |  99 |   0 |    0 |           tg128 |         19.00 ± 0.24 |

**Disabled**

| model                          |       size |     params | backend    | ngl |  fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ---: | --------------: | -------------------: |
| qwen3 4B Q8_0                  |   3.98 GiB |     4.02 B | OpenCL     |  99 |   0 |    0 |           pp512 |        509.82 ± 1.52 |
| qwen3 4B Q8_0                  |   3.98 GiB |     4.02 B | OpenCL     |  99 |   0 |    0 |          pp2048 |        385.91 ± 1.23 |
| qwen3 4B Q8_0                  |   3.98 GiB |     4.02 B | OpenCL     |  99 |   0 |    0 |           tg128 |         22.99 ± 0.11 |

| model                          |       size |     params | backend    | ngl |  fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ---: | --------------: | -------------------: |
| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | OpenCL     |  99 |   0 |    0 |           pp512 |       296.07 ± 11.13 |
| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | OpenCL     |  99 |   0 |    0 |          pp2048 |       235.36 ± 23.35 |
| qwen3 8B Q8_0                  |   8.11 GiB |     8.19 B | OpenCL     |  99 |   0 |    0 |           tg128 |         13.41 ± 0.08 |

| model                          |       size |     params | backend    | ngl |  fa | mmap |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ---: | --------------: | -------------------: |
| gemma4 E4B Q8_0                |   7.62 GiB |     7.52 B | OpenCL     |  99 |   0 |    0 |           pp512 |        445.00 ± 1.84 |
| gemma4 E4B Q8_0                |   7.62 GiB |     7.52 B | OpenCL     |  99 |   0 |    0 |          pp2048 |        433.56 ± 4.72 |
| gemma4 E4B Q8_0                |   7.62 GiB |     7.52 B | OpenCL     |  99 |   0 |    0 |           tg128 |         18.66 ± 0.37 |

</Details>

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->Yes, used Claude for prototype.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
