### PR TITLE
vocab : validate tokenizer metadata before typed reads

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -77,6 +77,23 @@ struct llm_tokenizer {
     virtual ~llm_tokenizer() = default;
 };
 
+static void check_gguf_array_type(
+        const struct gguf_context * ctx,
+        const int                   key_idx,
+        const char *                key,
+        const enum gguf_type        type_expected) {
+    if (gguf_get_kv_type(ctx, key_idx) != GGUF_TYPE_ARRAY) {
+        throw std::runtime_error(format("%s is not an array", key));
+    }
+
+    const enum gguf_type type = gguf_get_arr_type(ctx, key_idx);
+    if (type != type_expected) {
+        throw std::runtime_error(format(
+            "%s has invalid array type: expected %s, got %s",
+            key, gguf_type_name(type_expected), gguf_type_name(type)));
+    }
+}
+
 struct llm_symbol {
     using index = int;
     index prev;
@@ -881,13 +898,18 @@ private:
 struct llm_tokenizer_ugm : llm_tokenizer {
     llm_tokenizer_ugm(const llama_vocab & vocab, const std::vector<char> & precompiled_charsmap) {
         if (precompiled_charsmap.size() > 0) {
+            if (precompiled_charsmap.size() < sizeof(uint32_t)) {
+                throw std::runtime_error("Index out of array bounds in precompiled charsmap!");
+            }
+
             size_t charsmap_offset = 0;
 
             // First four bytes of precompiled_charsmap contains length of binary
             // blob containing XOR-compressed compact double array (XCDA) entries
-            uint32_t xcda_blob_size = *(const uint32_t *) &precompiled_charsmap[0];
+            uint32_t xcda_blob_size;
+            memcpy(&xcda_blob_size, precompiled_charsmap.data(), sizeof(xcda_blob_size));
             charsmap_offset += sizeof(xcda_blob_size);
-            if (xcda_blob_size + charsmap_offset >= precompiled_charsmap.size()) {
+            if (xcda_blob_size >= precompiled_charsmap.size() - charsmap_offset) {
                 throw std::runtime_error("Index out of array bounds in precompiled charsmap!");
             }
 
@@ -2012,21 +2034,39 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
 
             const int precompiled_charsmap_keyidx = gguf_find_key(ctx, kv(LLM_KV_TOKENIZER_PRECOMPILED_CHARSMAP).c_str());
             if (precompiled_charsmap_keyidx != -1) {
+                if (gguf_get_kv_type(ctx, precompiled_charsmap_keyidx) != GGUF_TYPE_ARRAY) {
+                    throw std::runtime_error(format(
+                        "%s is not an array",
+                        kv(LLM_KV_TOKENIZER_PRECOMPILED_CHARSMAP).c_str()));
+                }
+
                 const gguf_type pc_type = gguf_get_arr_type(ctx, precompiled_charsmap_keyidx);
-                GGML_ASSERT(pc_type == GGUF_TYPE_INT8 || pc_type == GGUF_TYPE_UINT8);
+                if (pc_type != GGUF_TYPE_INT8 && pc_type != GGUF_TYPE_UINT8) {
+                    throw std::runtime_error(format(
+                        "%s has invalid array type: expected i8 or u8, got %s",
+                        kv(LLM_KV_TOKENIZER_PRECOMPILED_CHARSMAP).c_str(), gguf_type_name(pc_type)));
+                }
 
                 const size_t n_precompiled_charsmap = gguf_get_arr_n(ctx, precompiled_charsmap_keyidx);
-                const char * pc = (const char *) gguf_get_arr_data(ctx, precompiled_charsmap_keyidx);
-                precompiled_charsmap.assign(pc, pc + n_precompiled_charsmap);
+                precompiled_charsmap.clear();
+                if (n_precompiled_charsmap > 0) {
+                    const char * pc = (const char *) gguf_get_arr_data(ctx, precompiled_charsmap_keyidx);
+                    precompiled_charsmap.assign(pc, pc + n_precompiled_charsmap);
+                    if (precompiled_charsmap.size() < sizeof(uint32_t)) {
+                        throw std::runtime_error("Index out of array bounds in precompiled charsmap!");
+                    }
+                }
 #if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
                 // correct endianness of data in precompiled_charsmap binary blob
-                uint32_t * xcda_blob_size = (uint32_t *) &precompiled_charsmap[0];
-                *xcda_blob_size = __builtin_bswap32(*xcda_blob_size);
-                assert(*xcda_blob_size + sizeof(uint32_t) < n_precompiled_charsmap);
-                size_t xcda_array_size = *xcda_blob_size / sizeof(uint32_t);
-                uint32_t * xcda_array = (uint32_t *) &precompiled_charsmap[sizeof(uint32_t)];
-                for (size_t i = 0; i < xcda_array_size; ++i) {
-                    xcda_array[i] = __builtin_bswap32(xcda_array[i]);
+                if (!precompiled_charsmap.empty()) {
+                    uint32_t * xcda_blob_size = (uint32_t *) &precompiled_charsmap[0];
+                    *xcda_blob_size = __builtin_bswap32(*xcda_blob_size);
+                    assert(*xcda_blob_size + sizeof(uint32_t) < n_precompiled_charsmap);
+                    size_t xcda_array_size = *xcda_blob_size / sizeof(uint32_t);
+                    uint32_t * xcda_array = (uint32_t *) &precompiled_charsmap[sizeof(uint32_t)];
+                    for (size_t i = 0; i < xcda_array_size; ++i) {
+                        xcda_array[i] = __builtin_bswap32(xcda_array[i]);
+                    }
                 }
 #endif
             }
@@ -2385,6 +2425,8 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
     const float * scores = nullptr;
     const int score_idx = gguf_find_key(ctx, kv(LLM_KV_TOKENIZER_SCORES).c_str());
     if (score_idx != -1) {
+        check_gguf_array_type(
+                ctx, score_idx, kv(LLM_KV_TOKENIZER_SCORES).c_str(), GGUF_TYPE_FLOAT32);
         const uint32_t n_scores = gguf_get_arr_n(ctx, score_idx);
         if (n_scores < n_tokens) {
             throw std::runtime_error("Index out of array bounds for scores (" + std::to_string(n_scores) + " < " + std::to_string(n_tokens) + ")\n");
@@ -2392,14 +2434,16 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
         scores = (const float * ) gguf_get_arr_data(ctx, score_idx);
     }
 
-    const int * toktypes = nullptr;
+    const int32_t * toktypes = nullptr;
     const int toktype_idx = gguf_find_key(ctx, kv(LLM_KV_TOKENIZER_TOKEN_TYPE).c_str());
     if (toktype_idx != -1) {
+        check_gguf_array_type(
+                ctx, toktype_idx, kv(LLM_KV_TOKENIZER_TOKEN_TYPE).c_str(), GGUF_TYPE_INT32);
         const uint32_t n_toktypes = gguf_get_arr_n(ctx, toktype_idx);
         if (n_toktypes < n_tokens) {
             throw std::runtime_error("Index out of array bounds for toktypes (" + std::to_string(n_toktypes) + " < " + std::to_string(n_tokens) + ")\n");
         }
-        toktypes = (const int * ) gguf_get_arr_data(ctx, toktype_idx);
+        toktypes = (const int32_t * ) gguf_get_arr_data(ctx, toktype_idx);
     }
 
     id_to_token.resize(n_tokens);
@@ -2551,7 +2595,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
         {
             const int suppress_idx = gguf_find_key(ctx, kv(LLM_KV_TOKENIZER_SUPPRESS_TOKENS).c_str());
             if (suppress_idx != -1) {
-                const int n = gguf_get_arr_n(ctx, suppress_idx);
+                check_gguf_array_type(
+                        ctx, suppress_idx, kv(LLM_KV_TOKENIZER_SUPPRESS_TOKENS).c_str(), GGUF_TYPE_INT32);
+                const size_t n = gguf_get_arr_n(ctx, suppress_idx);
                 const int32_t * data = (const int32_t *) gguf_get_arr_data(ctx, suppress_idx);
                 suppress_tokens.assign(data, data + n);
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -213,6 +213,7 @@ llama_build_and_test(
     peg-parser/tests.h
 )
 llama_build_and_test(test-regex-partial.cpp)
+llama_build_and_test(test-tokenizer-metadata-validation.cpp)
 
 if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "s390x")
     set(MODEL_NAME "tinyllamas/stories15M-q4_0.gguf")

--- a/tests/test-tokenizer-metadata-validation.cpp
+++ b/tests/test-tokenizer-metadata-validation.cpp
@@ -1,0 +1,162 @@
+#include "gguf.h"
+#include "llama.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+static void add_base_vocab_metadata(struct gguf_context * ctx) {
+    gguf_set_val_str(ctx, "general.architecture", "mpt");
+    gguf_set_val_str(ctx, "tokenizer.ggml.model", "t5");
+
+    const char * tokens[] = {
+        "<pad>", "</s>", "<unk>", "a", "b", "c", "d", "e",
+    };
+    gguf_set_arr_str(ctx, "tokenizer.ggml.tokens", tokens, sizeof(tokens) / sizeof(tokens[0]));
+}
+
+static bool load_vocab_from_ctx(const struct gguf_context * ctx) {
+    FILE * file = tmpfile();
+    if (!file) {
+        fprintf(stderr, "failed to create temporary file\n");
+        return false;
+    }
+
+    if (!gguf_write_to_file_ptr(ctx, file, false)) {
+        fprintf(stderr, "failed to write GGUF test file\n");
+        fclose(file);
+        return false;
+    }
+
+    fflush(file);
+    rewind(file);
+
+    llama_model_params params = llama_model_default_params();
+    params.vocab_only = true;
+    params.use_mmap  = false;
+    params.no_alloc  = true;
+
+    llama_model * model = llama_model_load_from_file_ptr(file, params);
+    fclose(file);
+
+    if (model) {
+        llama_model_free(model);
+        return true;
+    }
+
+    return false;
+}
+
+static bool expect_load_result(const char * name, const struct gguf_context * ctx, const bool expected) {
+    const bool actual = load_vocab_from_ctx(ctx);
+    if (actual != expected) {
+        fprintf(stderr, "%s: expected load %s, got %s\n",
+                name, expected ? "success" : "failure", actual ? "success" : "failure");
+        return false;
+    }
+    return true;
+}
+
+static gguf_context * make_base_ctx() {
+    gguf_context * ctx = gguf_init_empty();
+    add_base_vocab_metadata(ctx);
+    return ctx;
+}
+
+int main() {
+    llama_log_set([](ggml_log_level, const char *, void *) {}, nullptr);
+    llama_backend_init();
+
+    std::vector<gguf_context *> ctxs;
+    bool ok = true;
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        ok = expect_load_result("valid minimal vocab", ctx, true) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        const uint8_t scores[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+        gguf_set_arr_data(ctx, "tokenizer.ggml.scores", GGUF_TYPE_UINT8, scores, sizeof(scores));
+        ok = expect_load_result("uint8 scores", ctx, false) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        const float scores[] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+        gguf_set_arr_data(
+                ctx, "tokenizer.ggml.scores",
+                GGUF_TYPE_FLOAT32, scores, sizeof(scores) / sizeof(scores[0]));
+        ok = expect_load_result("float32 scores", ctx, true) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        const uint8_t token_types[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+        gguf_set_arr_data(
+                ctx, "tokenizer.ggml.token_type",
+                GGUF_TYPE_UINT8, token_types, sizeof(token_types));
+        ok = expect_load_result("uint8 token types", ctx, false) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        const int32_t token_types[] = { 1, 1, 1, 1, 1, 1, 1, 1 };
+        gguf_set_arr_data(
+                ctx, "tokenizer.ggml.token_type",
+                GGUF_TYPE_INT32, token_types, sizeof(token_types) / sizeof(token_types[0]));
+        ok = expect_load_result("int32 token types", ctx, true) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        const uint8_t suppress_tokens[] = { 0 };
+        gguf_set_arr_data(
+                ctx, "tokenizer.ggml.suppress_tokens",
+                GGUF_TYPE_UINT8, suppress_tokens, sizeof(suppress_tokens));
+        ok = expect_load_result("uint8 suppress tokens", ctx, false) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        const int32_t suppress_tokens[] = { 0 };
+        gguf_set_arr_data(
+                ctx, "tokenizer.ggml.suppress_tokens",
+                GGUF_TYPE_INT32, suppress_tokens, sizeof(suppress_tokens) / sizeof(suppress_tokens[0]));
+        ok = expect_load_result("int32 suppress tokens", ctx, true) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        gguf_set_arr_data(
+                ctx, "tokenizer.ggml.precompiled_charsmap",
+                GGUF_TYPE_UINT8, nullptr, 0);
+        ok = expect_load_result("empty precompiled charsmap", ctx, true) && ok;
+    }
+
+    {
+        gguf_context * ctx = make_base_ctx();
+        ctxs.push_back(ctx);
+        const uint8_t precompiled_charsmap[] = { 0 };
+        gguf_set_arr_data(
+                ctx, "tokenizer.ggml.precompiled_charsmap",
+                GGUF_TYPE_UINT8, precompiled_charsmap, sizeof(precompiled_charsmap));
+        ok = expect_load_result("short precompiled charsmap", ctx, false) && ok;
+    }
+
+    for (gguf_context * ctx : ctxs) {
+        gguf_free(ctx);
+    }
+
+    llama_backend_free();
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Overview

Fixes #24888.

This PR is a fix to reject malformed tokenizer metadata during vocab loading before GGUF array data is read. This validates the expected array element types for tokenizer scores, token types, suppress tokens, and UGM precompiled charsmap data. It rejects charsmap blobs that are too short or non empty.

## Additional information

Tested with the original minimized repro GGUFs from #24888 under ASan/UBSan

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Parts of the code are AI generated. ChatGPT was used to generate the test cases and review the code I wrote. I can explain/justify any design choices in my code. I understand this repo has a strict AI policy though, so if these contributions are unwelcome, I totally understand.