### PR TITLE
server: run sampling in a threadpool 

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1169,6 +1169,16 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ));
     add_opt(common_arg(
+        {"--threads-sampling"}, "N",
+        "number of threads to use during sampling (default: same as --threads)",
+        [](common_params & params, int value) {
+            params.sampling_n_threads = value;
+            if (params.sampling_n_threads <= 0) {
+                params.sampling_n_threads = std::thread::hardware_concurrency();
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-C", "--cpu-mask"}, "M",
         "CPU affinity mask: arbitrarily long hex. Complements cpu-range (default: \"\")",
         [](common_params & params, const std::string & mask) {

--- a/common/common.h
+++ b/common/common.h
@@ -471,6 +471,8 @@ struct common_params {
     common_cpu_params cpuparams;
     common_cpu_params cpuparams_batch;
 
+    int sampling_n_threads = -1; // number of threads for sampling, used by server
+
     ggml_backend_sched_eval_callback cb_eval = nullptr;
     void * cb_eval_user_data                 = nullptr;
 

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1598,32 +1598,36 @@ server_threadpool::~server_threadpool() {
 }
 
 void server_threadpool::init(int n) {
-    for (int i = 0; i < n; i++) {
-        threads.emplace_back([this]() {
-            while (true) {
-                std::function<void()> task;
-                {
-                    std::unique_lock<std::mutex> lock(mtx);
-                    cv.wait(lock, [this]() { return stop || !tasks.empty(); });
-                    if (stop && tasks.empty()) return;
-                    task = std::move(tasks.front());
-                    tasks.pop();
-                }
-                task();
-                {
-                    std::lock_guard<std::mutex> lock(mtx);
-                    pending--;
-                }
-                cv_done.notify_one();
-            }
-        });
+    // the caller (main thread) participates as a worker, so spawn n-1 threads
+    const int n_workers = std::max(1, n) - 1;
+    for (int i = 0; i < n_workers; i++) {
+        threads.emplace_back([this]() { run_worker(); });
+    }
+}
+
+void server_threadpool::run_worker() {
+    while (true) {
+        std::function<void()> task;
+        {
+            std::unique_lock<std::mutex> lock(mtx);
+            cv.wait(lock, [this]() { return stop || !tasks.empty(); });
+            if (stop && tasks.empty()) return;
+            task = std::move(tasks.front());
+            tasks.pop();
+        }
+        task();
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            pending--;
+        }
+        cv_done.notify_all();
     }
 }
 
 void server_threadpool::enqueue(std::function<void()> fn) {
     {
         std::lock_guard<std::mutex> lock(mtx);
-        GGML_ASSERT(!stop && !threads.empty());
+        GGML_ASSERT(!stop);
         tasks.push(std::move(fn));
         pending++;
     }
@@ -1631,6 +1635,30 @@ void server_threadpool::enqueue(std::function<void()> fn) {
 }
 
 void server_threadpool::wait_all() {
-    std::unique_lock<std::mutex> lock(mtx);
-    cv_done.wait(lock, [this]() { return pending == 0; });
+    // the calling thread helps drain the queue until no tasks remain pending
+    while (true) {
+        std::function<void()> task;
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            if (pending == 0) {
+                return;
+            }
+            if (!tasks.empty()) {
+                task = std::move(tasks.front());
+                tasks.pop();
+            }
+        }
+        if (task) {
+            task();
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                pending--;
+            }
+            cv_done.notify_all();
+        } else {
+            // no task available right now, but some are still pending (being run by workers)
+            std::unique_lock<std::mutex> lock(mtx);
+            cv_done.wait(lock, [this]() { return pending == 0 || !tasks.empty(); });
+        }
+    }
 }

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1583,3 +1583,54 @@ server_tokens format_prompt_rerank(
 
     return result;
 }
+
+//
+// threadpool
+//
+
+server_threadpool::~server_threadpool() {
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        stop = true;
+    }
+    cv.notify_all();
+    for (auto & t : threads) t.join();
+}
+
+void server_threadpool::init(int n) {
+    for (int i = 0; i < n; i++) {
+        threads.emplace_back([this]() {
+            while (true) {
+                std::function<void()> task;
+                {
+                    std::unique_lock<std::mutex> lock(mtx);
+                    cv.wait(lock, [this]() { return stop || !tasks.empty(); });
+                    if (stop && tasks.empty()) return;
+                    task = std::move(tasks.front());
+                    tasks.pop();
+                }
+                task();
+                {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    pending--;
+                }
+                cv_done.notify_one();
+            }
+        });
+    }
+}
+
+void server_threadpool::enqueue(std::function<void()> fn) {
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        GGML_ASSERT(!stop && !threads.empty());
+        tasks.push(std::move(fn));
+        pending++;
+    }
+    cv.notify_one();
+}
+
+void server_threadpool::wait_all() {
+    std::unique_lock<std::mutex> lock(mtx);
+    cv_done.wait(lock, [this]() { return pending == 0; });
+}

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -12,6 +12,11 @@
 #include <string>
 #include <vector>
 #include <cinttypes>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <functional>
 
 using json = nlohmann::ordered_json;
 
@@ -370,3 +375,35 @@ server_tokens format_prompt_rerank(
         mtmd_context * mctx,
         const std::string & query,
         const std::string & doc);
+
+//
+// threadpool utils
+// to be used for multi-threaded sampling
+//
+
+struct server_threadpool {
+    std::vector<std::thread> threads;
+    std::queue<std::function<void()>> tasks;
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::condition_variable cv_done;
+    int pending = 0;
+    bool stop = false;
+
+    ~server_threadpool();
+    void init(int n);
+
+    template<typename T>
+    void run_all(std::vector<T> & tasks, std::function<void(T&)> handler) {
+        for (auto & item : tasks) {
+            enqueue([&handler, &item]() {
+                handler(item);
+            });
+        }
+        wait_all();
+    }
+
+private:
+    void enqueue(std::function<void()> fn);
+    void wait_all();
+};

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -381,6 +381,8 @@ server_tokens format_prompt_rerank(
 // to be used for multi-threaded sampling
 //
 
+// the main thread participates as one of the pool's workers, so init(n)
+// only spawns n-1 background threads (the caller is the nth)
 struct server_threadpool {
     std::vector<std::thread> threads;
     std::queue<std::function<void()>> tasks;
@@ -400,10 +402,12 @@ struct server_threadpool {
                 handler(item);
             });
         }
+        // the calling thread runs tasks too, until all are done
         wait_all();
     }
 
 private:
     void enqueue(std::function<void()> fn);
     void wait_all();
+    void run_worker();
 };

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1460,7 +1460,15 @@ private:
 
         metrics.init();
 
-        threadpool.init(params_base.cpuparams.n_threads);
+        // initialize threadpool
+        {
+            int threadpool_size = params_base.sampling_n_threads;
+            if (threadpool_size <= 0) {
+                threadpool_size = params_base.cpuparams.n_threads;
+            }
+            SRV_DBG("%s: initializing threadpool, size = %d\n", __func__, threadpool_size);
+            threadpool.init(threadpool_size);
+        }
 
         if (params_base.cache_idle_slots) {
             if (params_base.cache_ram_mib == 0) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3705,7 +3705,6 @@ private:
     }
 
     struct sampling_task {
-        bool skip = true;
         server_slot * slot = nullptr;
         int32_t tok_idx = 0;
         llama_token sampled_id = LLAMA_TOKEN_NULL; // result
@@ -3734,6 +3733,7 @@ private:
 
         std::vector<sampling_task> smpl_tasks;
         smpl_tasks.resize(slots.size());
+        bool need_sampling = false;
 
         iterate(slots, [&](server_slot & slot) {
             auto & smpl_task = smpl_tasks[slot.id];
@@ -3784,22 +3784,30 @@ private:
 
             // otherwise, we must sample the next token
             // also shift batch idx according to the current sub-batch
-            smpl_task.skip    = false;
+            smpl_task.slot    = &slot;
             smpl_task.tok_idx = slot.i_batch - off;
+            need_sampling     = true;
         });
 
         // run multiple sampling tasks in parallel
         GGML_ASSERT(smpl_tasks.size() == slots.size());
-        threadpool.run_all<sampling_task>(smpl_tasks, [](sampling_task & task) {
-            if (!task.skip) {
-                LOG_INF("sampling for slot %d, tok_idx = %d\n", task.slot->id, task.tok_idx);
-                task.sampled_id = common_sampler_sample(task.slot->smpl.get(),
-                                        task.slot->ctx_tgt, task.tok_idx);
-            }
-        });
+        if (need_sampling) {
+            llama_synchronize(ctx_tgt);
+            threadpool.run_all<sampling_task>(smpl_tasks, [](sampling_task & task) {
+                if (task.slot) {
+                    task.sampled_id = common_sampler_sample(task.slot->smpl.get(),
+                                            task.slot->ctx_tgt, task.tok_idx);
+                }
+            });
+        }
 
         iterate(slots, [&](server_slot & slot) {
             auto & smpl_task = smpl_tasks[slot.id];
+
+            if (!smpl_task.slot) {
+                return;
+            }
+
             auto tok_idx = smpl_task.tok_idx;
             auto id = smpl_task.sampled_id;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -866,6 +866,9 @@ public:
     // note: chat_params must not be refreshed upon existing sleeping state
     server_chat_params chat_params;
 
+    // threadpool for parallel sampling
+    server_threadpool threadpool;
+
     server_state_callback_t callback_state = [](server_state, json) -> void {};
 
     server_context_impl() {
@@ -1456,6 +1459,8 @@ private:
         });
 
         metrics.init();
+
+        threadpool.init(params_base.cpuparams.n_threads);
 
         if (params_base.cache_idle_slots) {
             if (params_base.cache_ram_mib == 0) {
@@ -3699,6 +3704,12 @@ private:
         return true;
     }
 
+    struct sampling_task {
+        server_slot * slot;
+        int32_t tok_idx;
+        llama_token sampled_id; // result
+    };
+
     void post_decode(int32_t n_batch_tokens, int32_t off, llama_batch & batch_view) {
         // for checking if a given batch index is inside batch_view
         auto is_inside_view = [&](int32_t idx) {
@@ -3719,6 +3730,9 @@ private:
             return params_base.special ||
                 slot.task->params.sampling.preserved_tokens.find(token) != slot.task->params.sampling.preserved_tokens.end();
         };
+
+        std::vector<sampling_task> smpl_tasks;
+        smpl_tasks.reserve(slots.size());
 
         iterate(slots, [&](server_slot & slot) {
             // optionally send prompt processing progress
@@ -3767,6 +3781,17 @@ private:
 
             // shifted according to the current sub-batch
             const int tok_idx = slot.i_batch - off;
+            smpl_tasks.push_back({&slot, tok_idx, LLAMA_TOKEN_NULL});
+        });
+
+        // run multiple sampling tasks in parallel
+        threadpool.run_all<sampling_task>(smpl_tasks, [](sampling_task & task) {
+            task.sampled_id = common_sampler_sample(task.slot->smpl.get(), task.slot->ctx_tgt, task.tok_idx);
+        });
+
+        iterate(slots, [&](server_slot & slot) {
+            auto & smpl_task = smpl_tasks[slot.id];
+            auto tok_idx = smpl_task.tok_idx;
 
             llama_token id;
             {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3705,9 +3705,10 @@ private:
     }
 
     struct sampling_task {
-        server_slot * slot;
-        int32_t tok_idx;
-        llama_token sampled_id; // result
+        bool skip = true;
+        server_slot * slot = nullptr;
+        int32_t tok_idx = 0;
+        llama_token sampled_id = LLAMA_TOKEN_NULL; // result
     };
 
     void post_decode(int32_t n_batch_tokens, int32_t off, llama_batch & batch_view) {
@@ -3732,9 +3733,11 @@ private:
         };
 
         std::vector<sampling_task> smpl_tasks;
-        smpl_tasks.reserve(slots.size());
+        smpl_tasks.resize(slots.size());
 
         iterate(slots, [&](server_slot & slot) {
+            auto & smpl_task = smpl_tasks[slot.id];
+
             // optionally send prompt processing progress
             if (slot.state == SLOT_STATE_PROCESSING_PROMPT || slot.state == SLOT_STATE_DONE_PROMPT) {
                 if (slot.task->params.stream && slot.task->params.return_progress) {
@@ -3779,25 +3782,26 @@ private:
                 return; // sample using speculative decoding
             }
 
-            // shifted according to the current sub-batch
-            const int tok_idx = slot.i_batch - off;
-            smpl_tasks.push_back({&slot, tok_idx, LLAMA_TOKEN_NULL});
+            // otherwise, we must sample the next token
+            // also shift batch idx according to the current sub-batch
+            smpl_task.skip    = false;
+            smpl_task.tok_idx = slot.i_batch - off;
         });
 
         // run multiple sampling tasks in parallel
+        GGML_ASSERT(smpl_tasks.size() == slots.size());
         threadpool.run_all<sampling_task>(smpl_tasks, [](sampling_task & task) {
-            task.sampled_id = common_sampler_sample(task.slot->smpl.get(), task.slot->ctx_tgt, task.tok_idx);
+            if (!task.skip) {
+                LOG_INF("sampling for slot %d, tok_idx = %d\n", task.slot->id, task.tok_idx);
+                task.sampled_id = common_sampler_sample(task.slot->smpl.get(),
+                                        task.slot->ctx_tgt, task.tok_idx);
+            }
         });
 
         iterate(slots, [&](server_slot & slot) {
             auto & smpl_task = smpl_tasks[slot.id];
             auto tok_idx = smpl_task.tok_idx;
-
-            llama_token id;
-            {
-                scoped_timer timer(t_sampl, n_sampl);
-                id = common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, tok_idx);
-            }
+            auto id = smpl_task.sampled_id;
 
             slot.i_batch = -1;
 


### PR DESCRIPTION
## Overview

Ref discussion: https://github.com/ggml-org/llama.cpp/pull/24843

- Add `server_threadpool` that spawn n-1 threads (plus one main thread)
- Add `--threads-sampling` argument to select the number of threads

Benchmark: RTX 5060 Ti + 12th Gen Intel(R) Core(TM) i7-12700KF

10 concurrent requests --> around ~5% speed improvement

```
Baseline:

0.24.072.468 I slot print_timing: id 25 | task 4 | n_decoded =    481, tg =  25.27 t/s, tg_3s =  25.04 t/s
0.24.072.839 I slot print_timing: id 26 | task 5 | n_decoded =    481, tg =  25.27 t/s, tg_3s =  25.04 t/s
0.24.073.215 I slot print_timing: id 27 | task 3 | n_decoded =    481, tg =  25.28 t/s, tg_3s =  25.04 t/s
0.24.073.574 I slot print_timing: id 28 | task 2 | n_decoded =    481, tg =  25.28 t/s, tg_3s =  25.04 t/s

PR:

0.24.029.817 I slot print_timing: id 25 | task 5 | n_decoded =    502, tg =  26.75 t/s, tg_3s =  26.52 t/s
0.24.029.818 I slot print_timing: id 26 | task 4 | n_decoded =    502, tg =  26.75 t/s, tg_3s =  26.52 t/s
0.24.029.820 I slot print_timing: id 27 | task 3 | n_decoded =    502, tg =  26.75 t/s, tg_3s =  26.52 t/s
0.24.029.821 I slot print_timing: id 28 | task 1 | n_decoded =    502, tg =  26.75 t/s, tg_3s =  26.52 t/s
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
