### PR TITLE
cuda: fix flash attention mask stride overflow

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -664,7 +664,7 @@ constexpr __device__ dequantize_V_t get_dequantize_V() {
 template <int ncols1>
 __launch_bounds__(FATTN_KQ_STRIDE/2, 1)
 static __global__ void flash_attn_mask_to_KV_max(
-        const half2 * __restrict__ mask, int * __restrict__ KV_max, const int ne30, const int s31, const int s33) {
+        const half2 * __restrict__ mask, int * __restrict__ KV_max, const int ne30, const int64_t s31, const int64_t s33) {
     const int ne31     = gridDim.x;
     const int tid      = threadIdx.x;
     const int sequence = blockIdx.y;
@@ -1089,8 +1089,8 @@ void launch_fattn(
     // Only worth the overhead if there is at lease one FATTN_KQ_STRIDE x FATTN_KQ_STRIDE square to be skipped or
     //     multiple sequences of possibly different lengths.
     if (mask && K->ne[1] % FATTN_KQ_STRIDE == 0 && (Q->ne[1] >= 1024 || Q->ne[3] > 1)) {
-        const int s31 = mask->nb[1] / sizeof(half2);
-        const int s33 = mask->nb[3] / sizeof(half2);
+        const int64_t s31 = mask->nb[1] / sizeof(half2);
+        const int64_t s33 = mask->nb[3] / sizeof(half2);
 
         const dim3 blocks_num_KV_max(ntiles_x, Q->ne[3], 1);
         const dim3 block_dim_KV_max(FATTN_KQ_STRIDE/2, 1, 1);


### PR DESCRIPTION
Fixes #24912.

The flash_attn_mask_to_KV_max() helper accepted mask strides s31 and s33 as int values. For large KQ masks, mask->nb[3] / sizeof(half2) can exceed the signed 32-bit range. In the reported 1M-context case, s33 can become 0x80000000, which is negative when stored in an int.

That truncated stride is used in pointer arithmetic:

    mask += sequence*s33 + jt*ncols1*s31;

so the kernel can read from an out-of-bounds mask address.

This change keeps the mask stride values as int64_t from the host-side mask->nb[] calculation through the CUDA helper signature, avoiding truncation for large masks.

Validation: inspected the generated diff and confirmed no remaining int s31/s33 declarations in fattn-common.cuh. I could not run a CUDA build in this environment because nvcc is not installed.