### PR TITLE
vocab : reject invalid tokenizer metadata

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -25,6 +25,16 @@
 // helpers
 //
 
+static void check_add_special_token(
+        const bool add_token,
+        const llama_token id,
+        const char * add_key,
+        const char * id_key) {
+    if (add_token && id == LLAMA_TOKEN_NULL) {
+        throw std::runtime_error(format("%s is true, but %s is not set", add_key, id_key));
+    }
+}
+
 struct naive_trie {
     naive_trie() : has_value(false), value(0) {
     }
@@ -2411,7 +2421,13 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             word = "[EMPTY_" + std::to_string(i) + "]";
         }
 
-        token_to_id[word] = i;
+        const auto token_to_id_res = token_to_id.emplace(word, i);
+        if (!token_to_id_res.second) {
+            throw std::runtime_error(format(
+                "duplicate token in vocabulary: '%s' has ids %d and %u",
+                word.c_str(), token_to_id_res.first->second, i));
+        }
+
         max_token_len = std::max(max_token_len, (int) word.size());
 
         auto & token_data = id_to_token[i];
@@ -2540,6 +2556,13 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
 
                 LLAMA_LOG_WARN("%s: override '%s' to 'true' for Gemma4\n", __func__, kv(LLM_KV_TOKENIZER_ADD_BOS).c_str());
             }
+
+            check_add_special_token(add_bos, special_bos_id,
+                    kv(LLM_KV_TOKENIZER_ADD_BOS).c_str(), kv(LLM_KV_TOKENIZER_BOS_ID).c_str());
+            check_add_special_token(add_eos, special_eos_id,
+                    kv(LLM_KV_TOKENIZER_ADD_EOS).c_str(), kv(LLM_KV_TOKENIZER_EOS_ID).c_str());
+            check_add_special_token(add_sep, special_sep_id,
+                    kv(LLM_KV_TOKENIZER_ADD_SEP).c_str(), kv(LLM_KV_TOKENIZER_SEP_ID).c_str());
         }
 
         // BertNormalizer options

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,6 +144,8 @@ if (NOT WIN32)
     )
 endif()
 
+llama_build_and_test(test-tokenizer-invalid-metadata.cpp)
+
 if (LLAMA_LLGUIDANCE)
     llama_build_and_test(test-grammar-llguidance.cpp ARGS ${PROJECT_SOURCE_DIR}/models/ggml-vocab-llama-bpe.gguf)
 endif ()

--- a/tests/test-tokenizer-invalid-metadata.cpp
+++ b/tests/test-tokenizer-invalid-metadata.cpp
@@ -1,0 +1,129 @@
+#include "ggml.h"
+#include "ggml-cpp.h"
+#include "gguf.h"
+#include "llama.h"
+#include "llama-cpp.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+static bool silent_progress_callback(float /* progress */, void * /* user_data */) {
+    return true;
+}
+
+static void set_base_vocab_metadata(
+        struct gguf_context * ctx,
+        std::vector<const char *> tokens,
+        const char * tokenizer_model = "t5") {
+    gguf_set_val_str(ctx, "general.architecture", "mpt");
+    gguf_set_val_str(ctx, "tokenizer.ggml.model", tokenizer_model);
+    gguf_set_arr_str(ctx, "tokenizer.ggml.tokens", tokens.data(), tokens.size());
+}
+
+static llama_model_ptr load_vocab_from_gguf(const struct gguf_context * ctx) {
+    FILE * file = tmpfile();
+    GGML_ASSERT(file);
+
+    if (!gguf_write_to_file_ptr(ctx, file, true)) {
+        fclose(file);
+        throw std::runtime_error("failed to write GGUF metadata");
+    }
+    rewind(file);
+
+    llama_model_params params = llama_model_default_params();
+    params.vocab_only = true;
+    params.use_mmap   = false;
+    params.no_alloc   = true;
+    params.progress_callback = silent_progress_callback;
+
+    llama_model_ptr model(llama_model_load_from_file_ptr(file, params));
+    fclose(file);
+    return model;
+}
+
+static bool load_vocab_succeeds(const struct gguf_context * ctx) {
+    return load_vocab_from_gguf(ctx) != nullptr;
+}
+
+static bool tokenize_succeeds(llama_model * model, const std::string & text) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+
+    int32_t n_tokens = llama_tokenize(vocab, text.data(), (int32_t) text.size(), nullptr, 0, true, true);
+    if (n_tokens < 0) {
+        n_tokens = -n_tokens;
+    }
+
+    std::vector<llama_token> tokens(n_tokens);
+    return llama_tokenize(vocab, text.data(), (int32_t) text.size(), tokens.data(), (int32_t) tokens.size(), true, true) >= 0;
+}
+
+static void test_duplicate_token_string_fails_load() {
+    gguf_context_ptr ctx(gguf_init_empty());
+    set_base_vocab_metadata(ctx.get(), { "x", "x" });
+
+    GGML_ASSERT(!load_vocab_succeeds(ctx.get()));
+}
+
+static void test_add_bos_without_bos_id_fails_load() {
+    gguf_context_ptr ctx(gguf_init_empty());
+    set_base_vocab_metadata(ctx.get(), { "<pad>", "</s>", "<unk>", "a" });
+    gguf_set_val_bool(ctx.get(), "tokenizer.ggml.add_bos_token", true);
+
+    GGML_ASSERT(!load_vocab_succeeds(ctx.get()));
+}
+
+static void test_add_eos_without_eos_id_fails_load() {
+    gguf_context_ptr ctx(gguf_init_empty());
+    set_base_vocab_metadata(ctx.get(), { "[PAD]", "[CLS]", "[SEP]", "[UNK]", "a" }, "bert");
+    gguf_set_val_u32(ctx.get(), "tokenizer.ggml.bos_token_id", 1);
+    gguf_set_val_u32(ctx.get(), "tokenizer.ggml.sep_token_id", 2);
+    gguf_set_val_u32(ctx.get(), "tokenizer.ggml.unk_token_id", 3);
+    gguf_set_val_bool(ctx.get(), "tokenizer.ggml.add_eos_token", true);
+
+    GGML_ASSERT(!load_vocab_succeeds(ctx.get()));
+}
+
+static void test_add_sep_without_sep_id_fails_load() {
+    gguf_context_ptr ctx(gguf_init_empty());
+    set_base_vocab_metadata(ctx.get(), { "<pad>", "</s>", "<unk>", "a" });
+    gguf_set_val_bool(ctx.get(), "tokenizer.ggml.add_sep_token", true);
+
+    GGML_ASSERT(!load_vocab_succeeds(ctx.get()));
+}
+
+static void test_add_bos_with_bos_id_loads_and_tokenizes() {
+    gguf_context_ptr ctx(gguf_init_empty());
+    set_base_vocab_metadata(ctx.get(), { "<pad>", "</s>", "<unk>", "<s>", "a" });
+    gguf_set_val_bool(ctx.get(), "tokenizer.ggml.add_bos_token", true);
+    gguf_set_val_u32(ctx.get(), "tokenizer.ggml.bos_token_id", 3);
+
+    llama_model_ptr model = load_vocab_from_gguf(ctx.get());
+    GGML_ASSERT(model);
+    GGML_ASSERT(tokenize_succeeds(model.get(), "a"));
+}
+
+int main() {
+    llama_log_set([](ggml_log_level, const char *, void *) {}, nullptr);
+
+    FILE * file = tmpfile();
+#ifdef _WIN32
+    if (!file) {
+        fprintf(stderr, "failed to create tmpfile(), needs elevated privileges on Windows");
+        fprintf(stderr, "skipping tests");
+        return 0;
+    }
+#else
+    GGML_ASSERT(file);
+#endif
+    fclose(file);
+
+    test_duplicate_token_string_fails_load();
+    test_add_bos_without_bos_id_fails_load();
+    test_add_eos_without_eos_id_fails_load();
+    test_add_sep_without_sep_id_fails_load();
+    test_add_bos_with_bos_id_loads_and_tokenizes();
+
+    return 0;
+}


### PR DESCRIPTION
## Overview

Fixes #24885.

Reject malformed tokenizer metadata during vocab load. 

This covers duplicate token strings and `add_bos_token`, `add_eos_token`, or `add_sep_token`

## Additional information

Tested against original `duplicate-token-string.gguf` and `ugm-missing-bos.gguf` with ASan/UBSan

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Parts of the code are AI generated. ChatGPT was used to generate the test cases and review the code I wrote. I can explain/justify any design choices in my code. I understand this repo has a strict AI policy though, so if these contributions are unwelcome, I totally understand.