### PR TITLE
server: check draft context creation error

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -89,7 +89,9 @@ struct server_batch {
     }
 
     ~server_batch() {
-        llama_batch_free(batch);
+        if (batch.token != nullptr) {
+            llama_batch_free(batch);
+        }
     }
 
     void init(int32_t n_tokens_alloc) {
@@ -1215,6 +1217,10 @@ private:
             cparams.ctx_other = ctx_tgt;
 
             ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams));
+            if (ctx_dft == nullptr) {
+                SRV_ERR("%s", "failed to create draft context\n");
+                return false;
+            }
 
             params_base.speculative.draft.ctx_tgt = ctx_tgt;
             params_base.speculative.draft.ctx_dft = ctx_dft.get();


### PR DESCRIPTION
## Overview

We don't  check if context was properly created when loading draft model.  If context does not fit into memory we write an error and continue without enabling speculative decoding. Unless user looks into logs they would be unaware of the situation.
With this change we will stop loading the model if context fails to be created.


I've also fixed trying to free uninitialized memory - introduced by a recent refactor (#24843). 
`free(): invalid pointer` is thrown and process aborted when loading model is canceled before `batch.init()` is called - e.g. if user provide a path to an non-existent model.
I can remove that part if it is planned to be handled in some other way.

Fixes #24758


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  NO 