### PR TITLE
Fix conditional to display 'LLAMA_SPLIT_MODE_TENSOR not implemented for architecture' message

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -308,8 +308,7 @@ llama_model * llama_model_create(llm_arch arch, const llama_model_params & param
 
     if (model != nullptr) {
         model->arch = arch;
-        auto & devices = model->devices;
-        if (!devices.empty() && devices[0].is_meta && !llm_arch_supports_sm_tensor(arch)) {
+        if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && !llm_arch_supports_sm_tensor(arch)) {
             throw std::runtime_error(std::string("LLAMA_SPLIT_MODE_TENSOR not implemented for architecture '") + llm_arch_name(arch) + "'");
         }
     }


### PR DESCRIPTION

## Overview

`-sm tensor` doesn't currently work with DeepSeek Sparse Attention. glm-5.2 uses DSA, but when trying to use `-sm tensor` it tries using it, then blows up with a seemingly irrelevant assert:

0.03.809.143 I srv  llama_server: loading model
0.03.809.197 I srv    load_model: loading model '../models/unsloth/GLM-5.2-GGUF/UD-Q4_K_XL/GLM-5.2-UD-Q4_K_XL-00001-of-00011.gguf'
[...]
llama.cpp/src/llama-model.cpp:411: GGML_ASSERT(!suffix_fallback.empty()) failed
Aborted

There is a check in llama-model.cpp for exactly this situation, but it doesn't work:

```C
        auto & devices = model->devices;
        if (!devices.empty() && devices[0].is_meta && !llm_arch_supports_sm_tensor(arch)) {
             throw std::runtime_error(std::string("LLAMA_SPLIT_MODE_TENSOR not implemented for architecture '") + llm_arch_name(arch) + "'");
         }
```

The problem is that 'devices' has not been populated yet when this gets called, so it's always empty. The early bail out never happens. Fortunately, I don't think we even need to be doing that (at least I couldn't find any case where that mattered), and can simplify it to just:

```C
if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && !llm_arch_supports_sm_tensor(arch)) {
```

This fixes it for me to now bail out way earlier (3 seconds v.s. >90) with a message that actually explains the problem:

```
0.03.566.003 I srv    load_model: loading model '../models/unsloth/GLM-5.2-GGUF/UD-Q4_K_XL/GLM-5.2-UD-Q4_K_XL-00001-of-00011.gguf'
0.03.672.891 E llama_model_load: error loading model: LLAMA_SPLIT_MODE_TENSOR not implemented for architecture 'glm-dsa'
0.03.672.900 E llama_model_load_from_file_impl: failed to load model
```

I've tried this in every combination I have access to GPU/CPU backends and models that should and shouldn't be supported with tensor mode, and it appears to only fix the assert and bail out without wasting a bunch of time trying to load a model that won't work with tensor mode.

Even if DSA gets added to tensor mode, this fix (or something similar) should still happen to prevent further issues.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

