### PR TITLE
llama : meta split state for combined gate+up ffn_up (phi3)

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -550,10 +550,15 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             GGML_ASSERT(tensor->ne[axis] == n_embd + 2*n_embd_gqa);
             return {{n_embd, 1}, {n_embd_gqa, 2}};
         }
-        if ((std::regex_match(tensor_name, pattern_ffn_up_gate_weight) ||
-             std::regex_match(tensor_name, pattern_ffn_up_gate_bias)) &&
-                tensor->ne[axis] == 2*hparams.n_ff(il)) {
-            return {{hparams.n_ff(il), 2}};
+        // phi3 and modern-bert pack gate|up into a dense ffn_up of width 2*n_ff;
+        // ordinary separate ffn_up/ffn_gate stay at n_ff, so this stays a guard
+        // that falls through to the default even split rather than an assert.
+        if (std::regex_match(tensor_name, pattern_ffn_up_gate_weight) ||
+            std::regex_match(tensor_name, pattern_ffn_up_gate_bias)) {
+            const int64_t n_ff = hparams.n_ff(il);
+            if (n_ff != 0 && tensor->ne[axis] == 2*n_ff) {
+                return {{n_ff, 2}};
+            }
         }
         if (std::regex_match(tensor_name, pattern_ffn_gate_up_weight)) {
             const int64_t n_ff_exp = hparams.n_ff_exp;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -550,6 +550,11 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             GGML_ASSERT(tensor->ne[axis] == n_embd + 2*n_embd_gqa);
             return {{n_embd, 1}, {n_embd_gqa, 2}};
         }
+        if ((std::regex_match(tensor_name, pattern_ffn_up_gate_weight) ||
+             std::regex_match(tensor_name, pattern_ffn_up_gate_bias)) &&
+                tensor->ne[axis] == 2*hparams.n_ff(il)) {
+            return {{hparams.n_ff(il), 2}};
+        }
         if (std::regex_match(tensor_name, pattern_ffn_gate_up_weight)) {
             const int64_t n_ff_exp = hparams.n_ff_exp;
             GGML_ASSERT(tensor->ne[axis] == 2*n_ff_exp);


### PR DESCRIPTION
## Overview

phi3 packs the FFN gate and up projections into one `ffn_up` tensor of
width `2*n_ff`. In `llama_meta_device_get_split_state`
(`get_split_segments`) this tensor reaches the default branch, which
divides the concatenated `gate|up` evenly across devices. Each device
then holds a slice that does not line up with its `ffn_down` input, and
the meta backend aborts on
`GGML_ASSERT(split_states_equal(src_ss[0], src_ss[1]))`.

Splitting the tensor into two `n_ff` groups gives every device a
matching gate and up half, the layout the fused `ffn_gate_up` path
already produces. The guard `ne[axis] == 2*n_ff(il)` leaves models with
separate gate and up tensors (each `n_ff`) on the default branch.

## Additional information

Reproduced on clean `master` (`dec5ca557`).

Before:

```text
|  phi3 | Meta | Dense | ggml/src/ggml-backend-meta.cpp:590:
  GGML_ASSERT(split_states_equal(src_ss[0], src_ss[1])) failed
0% tests passed, 1 tests failed out of 1
    25 - test-llama-archs (Subprocess aborted)
```

After:

```text
1/1 Test #25: test-llama-archs ...Passed
100% tests passed, 0 tests failed out of 1
```

This sits in the tensor-parallel / meta-backend line (#22489, #22616,
#23525, #24180).

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES. The five-line split case originates in my
  earlier work; AI assisted with reproducing the phi3 abort, building,
  and running test-llama-archs. I reviewed every line, own the change,
  and can explain it.
