### PR TITLE
common/chat: detect parallel tool call support from template caps

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2539,7 +2539,7 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         params.json_schema = json::parse(inputs.json_schema);
     }
 
-    params.parallel_tool_calls = inputs.parallel_tool_calls;
+    params.parallel_tool_calls = inputs.parallel_tool_calls || caps.supports_parallel_tool_calls;
 
     if (params.tools.is_array()) {
         if (params.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE && !params.grammar.empty()) {


### PR DESCRIPTION
Use jinja::caps to detect if the template supports parallel tool calling and if so enable in the autoparser.

## Overview

The full details are in the issue I reported #24181, but the summary is that parallel tool calling was not detected for Step 3.x Flash and disabled by the autoparser. This caused the LLM to produce thinking/call patterns that were different than what it was trained on and eventually resulted in self correction loops (which sometimes caused infinite looping).

Even though I noticed this on Step 3.x, this could also affect other models.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, I used deepseek v4 to help investigate the issue. I simplified the patch produced by it