### PR TITLE
server : create context checkpoint on slot restore

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2597,6 +2597,16 @@ private:
                     slot->prompt.tokens.clear();
                     slot->prompt.tokens.insert(tokens);
 
+                    // A restored slot has no context checkpoint, so the next
+                    // request with cache_prompt finds no reuse anchor and
+                    // reprocesses the entire restored prefix. Create a
+                    // checkpoint spanning the restored span so the restored
+                    // KV is actually reused.
+                    if (params_base.n_ctx_checkpoints > 0) {
+                        create_checkpoint(*slot, (int64_t) 0, 0,
+                                          (llama_pos) (token_count > 0 ? token_count - 1 : 0));
+                    }
+
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
 


### PR DESCRIPTION
A restored slot had no context checkpoint, so the next request with cache_prompt found no reuse anchor and reprocessed the entire restored prefix (cache_n=0), defeating the purpose of /slots restore. Create a checkpoint spanning the restored span so the restored KV is reused.

Tested on a transformer model (gemma-4-12B, 15924-token prefix): a restore followed by an identical prompt went from prompt_n=15924/15924 (full reprocess) to prompt_n=1/15924 (reused).

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
