### PR TITLE
clip : bounds-check image_mean/image_std and grid pinpoints

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1211,7 +1211,7 @@ struct clip_model_loader {
                 std::vector<int> pinpoints;
                 get_arr_int(KEY_IMAGE_GRID_PINPOINTS, pinpoints, false);
                 if (!pinpoints.empty()) {
-                    for (size_t i = 0; i < pinpoints.size(); i += 2) {
+                    for (size_t i = 0; i + 1 < pinpoints.size(); i += 2) {
                         hparams.image_res_candidates.push_back({
                             pinpoints[i],
                             pinpoints[i+1],
@@ -1256,6 +1256,9 @@ struct clip_model_loader {
                 int idx_std  = gguf_find_key(ctx_gguf.get(), KEY_IMAGE_STD);
                 GGML_ASSERT(idx_mean >= 0 && "image_mean not found");
                 GGML_ASSERT(idx_std >= 0  && "image_std not found");
+                if (gguf_get_arr_n(ctx_gguf.get(), idx_mean) < 3 || gguf_get_arr_n(ctx_gguf.get(), idx_std) < 3) {
+                    throw std::runtime_error("image_mean and image_std must each have at least 3 elements");
+                }
                 const float * mean_data = (const float *) gguf_get_arr_data(ctx_gguf.get(), idx_mean);
                 const float * std_data  = (const float *) gguf_get_arr_data(ctx_gguf.get(), idx_std);
                 for (int i = 0; i < 3; ++i) {


### PR DESCRIPTION
## Overview

load_hparams() in clip.cpp reads `clip.vision.image_mean` and `clip.vision.image_std` from the mmproj by casting `gguf_get_arr_data()` to `float*` and copying three elements, without checking that either array actually holds three. a crafted vision mmproj whose `image_mean` is a one or two element array (or a scalar) makes that loop read past the array buffer, a heap out-of-bounds read of model metadata. the grid-pinpoints loop just above has the same shape: it steps `i += 2` and reads `pinpoints[i+1]` without requiring an even count, so an odd-length `image_grid_pinpoints` reads one element past the vector. guard the mean/std read with a length check (the vocab loader already does the same for the scores/token-type arrays via `gguf_get_arr_n`) and stop the pinpoints loop at the last complete pair.

## Additional information

reproduced with a minimal gguf holding a 1-element float `image_mean`: before the change asan reports `heap-buffer-overflow READ of size 4` at the second element; after, the loader rejects the file instead. mmproj/gguf files are an untrusted input boundary (model files are routinely downloaded), and ggml/src/gguf.cpp already hardens the tensor-info path against malformed files in the same spirit.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
