### PR TITLE
quant : fix quantizing moe with mtp

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -847,7 +847,7 @@ static void init_quantize_state_counters(quantize_state_impl & qs, std::vector<t
             qs.has_tied_embeddings = false;
         }
     }
-    qs.n_ffn_down = qs.n_ffn_gate = qs.n_ffn_up = (int)qs.model.hparams.n_layer();
+    qs.n_ffn_down = qs.n_ffn_gate = qs.n_ffn_up = (int)qs.model.hparams.n_layer_all;
 }
 
 //


### PR DESCRIPTION
## Overview

Fixes #24379
Fixes #24661

## Additional information

Due to the following check and the fact that `n_layer()` instead of `n_layer_all` was being used it was impossible to quantize MoEs with MTP.
https://github.com/ggml-org/llama.cpp/blob/e5c3ac4065e21925c9ff3c06678b0edf4aaf967b/src/llama-quant.cpp#L430-L432

Supersedes #24832

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: арась
- Language disclosure: Komi-Zyrian