### PR TITLE
gguf : reject non-u32 general.alignment

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -607,6 +607,11 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
         GGML_ASSERT(int64_t(ctx->kv.size()) == n_kv);
 
         const int alignment_idx = gguf_find_key(ctx, GGUF_KEY_GENERAL_ALIGNMENT);
+        if (alignment_idx != -1 && gguf_get_kv_type(ctx, alignment_idx) != GGUF_TYPE_UINT32) {
+            GGML_LOG_ERROR("%s: key '%s' must have type u32\n", __func__, GGUF_KEY_GENERAL_ALIGNMENT);
+            gguf_free(ctx);
+            return nullptr;
+        }
         ctx->alignment = alignment_idx == -1 ? GGUF_DEFAULT_ALIGNMENT : gguf_get_val_u32(ctx, alignment_idx);
 
         if (ctx->alignment == 0 || (ctx->alignment & (ctx->alignment - 1)) != 0) {

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -30,6 +30,7 @@ enum handcrafted_file_type {
     // HANDCRAFTED_KV_BAD_VALUE_SIZE          =  30 + offset_has_kv, // removed because it can result in allocations > 1 TB (default sanitizer limit)
     HANDCRAFTED_KV_DUPLICATE_KEY           =  40 + offset_has_kv,
     HANDCRAFTED_KV_BAD_ALIGN               =  50 + offset_has_kv,
+    HANDCRAFTED_KV_BAD_ALIGN_TYPE          =  55 + offset_has_kv,
     HANDCRAFTED_KV_SUCCESS                 = 800 + offset_has_kv,
 
     HANDCRAFTED_TENSORS_BAD_NAME_SIZE      =  10 + offset_has_tensors,
@@ -67,6 +68,7 @@ static std::string handcrafted_file_type_name(const enum handcrafted_file_type h
         case HANDCRAFTED_KV_BAD_TYPE:                return "KV_BAD_TYPE";
         case HANDCRAFTED_KV_DUPLICATE_KEY:           return "KV_DUPLICATE_KEY";
         case HANDCRAFTED_KV_BAD_ALIGN:               return "KV_BAD_ALIGN";
+        case HANDCRAFTED_KV_BAD_ALIGN_TYPE:          return "KV_BAD_ALIGN_TYPE";
         case HANDCRAFTED_KV_SUCCESS:                 return "KV_RANDOM_KV";
 
         case HANDCRAFTED_TENSORS_BAD_NAME_SIZE:      return "TENSORS_BAD_NAME_SIZE";
@@ -255,7 +257,7 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
     }
     {
         uint64_t n_kv = kv_types.size();
-        if (hft == HANDCRAFTED_KV_BAD_ALIGN      ||
+        if (hft == HANDCRAFTED_KV_BAD_ALIGN      || hft == HANDCRAFTED_KV_BAD_ALIGN_TYPE ||
             hft == HANDCRAFTED_TENSORS_BAD_ALIGN || hft == HANDCRAFTED_TENSORS_CUSTOM_ALIGN ||
             hft == HANDCRAFTED_DATA_BAD_ALIGN    || hft == HANDCRAFTED_DATA_CUSTOM_ALIGN) {
 
@@ -340,7 +342,7 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
         helper_write(file, data, hft == HANDCRAFTED_KV_BAD_TYPE ? 1 : gguf_type_size(type));
     }
 
-    if (hft == HANDCRAFTED_KV_BAD_ALIGN      ||
+    if (hft == HANDCRAFTED_KV_BAD_ALIGN      || hft == HANDCRAFTED_KV_BAD_ALIGN_TYPE ||
         hft == HANDCRAFTED_TENSORS_BAD_ALIGN || hft == HANDCRAFTED_TENSORS_CUSTOM_ALIGN ||
         hft == HANDCRAFTED_DATA_BAD_ALIGN    || hft == HANDCRAFTED_DATA_CUSTOM_ALIGN) {
 
@@ -348,10 +350,10 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
         helper_write(file, n);
         helper_write(file, GGUF_KEY_GENERAL_ALIGNMENT, n);
 
-        const int32_t type = gguf_type(GGUF_TYPE_UINT32);
+        const int32_t type = gguf_type(hft == HANDCRAFTED_KV_BAD_ALIGN_TYPE ? GGUF_TYPE_INT32 : GGUF_TYPE_UINT32);
         helper_write(file, type);
 
-        alignment = expect_context_not_null(hft) ? 1 : 13;
+        alignment = (expect_context_not_null(hft) || hft == HANDCRAFTED_KV_BAD_ALIGN_TYPE) ? 1 : 13;
         helper_write(file, alignment);
     }
 
@@ -735,6 +737,7 @@ static std::pair<int, int> test_handcrafted_file(const unsigned int seed) {
         HANDCRAFTED_KV_BAD_TYPE,
         HANDCRAFTED_KV_DUPLICATE_KEY,
         HANDCRAFTED_KV_BAD_ALIGN,
+        HANDCRAFTED_KV_BAD_ALIGN_TYPE,
         HANDCRAFTED_KV_SUCCESS,
 
         HANDCRAFTED_TENSORS_BAD_NAME_SIZE,

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -353,7 +353,7 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
         const int32_t type = gguf_type(hft == HANDCRAFTED_KV_BAD_ALIGN_TYPE ? GGUF_TYPE_INT32 : GGUF_TYPE_UINT32);
         helper_write(file, type);
 
-        alignment = (expect_context_not_null(hft) || hft == HANDCRAFTED_KV_BAD_ALIGN_TYPE) ? 1 : 13;
+        alignment = expect_context_not_null(hft) ? 1 : 13;
         helper_write(file, alignment);
     }
 


### PR DESCRIPTION
## Overview

A GGUF file whose `general.alignment` key is stored with a non-`u32` type (or as an
array) crashes the loader instead of being rejected. `gguf_init_from_reader()` reads it
via `gguf_get_val_u32()`, which asserts the stored type (`ggml/src/gguf.cpp:194`);
`GGML_ASSERT` calls `abort()` in release builds, so a corrupt/crafted model takes down
every `gguf_init_from_*` caller (`llama-cli`, `llama-server`, ...) with SIGABRT.

The u32 requirement is already enforced on the write side (`gguf_check_reserved_keys`),
and the bad-*value* case is already rejected gracefully two lines below — this does the
same for a bad *type*: validate it and `return nullptr`.

Before / after, loading a GGUF with an `int32` `general.alignment`:

    - gguf.cpp:194: GGML_ASSERT(type_to_gguf_type<T>::value == type) failed   (SIGABRT)
    + gguf_init_from_reader: key 'general.alignment' must have type u32       (clean nullptr)

## Additional information

Adds a `HANDCRAFTED_KV_BAD_ALIGN_TYPE` regression case to `tests/test-gguf.cpp`. `ctest -R gguf` passes.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No