### PR TITLE
ui: adjust currentMessageId so tool call results don't get orphaned

### DIFF
--- a/tools/ui/src/lib/stores/chat.svelte.ts
+++ b/tools/ui/src/lib/stores/chat.svelte.ts
@@ -803,6 +803,7 @@ class ChatStore {
 				);
 				conversationsStore.addMessageToActive(msg);
 				await conversationsStore.updateCurrentNode(msg.id);
+				currentMessageId = msg.id;
 				return msg;
 			},
 			createAssistantMessage: async () => {


### PR DESCRIPTION
## Overview

The message database uses a directed graph where each message has exactly one parent. To build a chat completion request, this graph is traversed from a leaf node up to the root.

During agentic use, a model may generate a response with multiple `tool_calls`. For each `tool_calls`, there needs to be a `"role": "tool"` message with the corresponding id in all subsequent sequences. This implies the correct directed graph should look like

 * User: roll two dice at once, such that both tool calls are generated in one turn.
    * Assistant: Sure! `tool_calls=[one, two]`
        * Tool[one]: 1d4 = 3
           * Tool[two]: 1d4 = 4

However, because `currentMessageId` wasn't being updated during `createToolMessageResult`, the graph instead looked like this

 * User: roll two dice at once, such that both tool calls are generated in one turn.
    * Assistant: Sure! `tool_calls=[one, two]`
        * Tool[one]: 1d4 = 3 // This is now orphaned and won't be included in `messages`
        * Tool[two]: 1d4 = 4
           * User: how many lights do you see?

`llama-server` doesn't really notice this problem, but e.g. the Deepseek API will kick back errors and this basically bricks the context.

There might be a better way to handle this (e.g. changing `filterByLeafNodeId` or something) but mirroring the `createAssistantMessage` branch and just adjusting the `currentMessageId` seemed reasonable to me, and fixes the bug on my computer, so. It's kind of a trivial change and I realize I'm breaking the "don't make PRs without a corresponding issue" rule but eh, sorry.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for emotional support.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
