### PR TITLE
cuda: sanitize invalid Blackwell sharedMemPerBlockOptin

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -289,6 +289,11 @@ static ggml_cuda_device_info ggml_cuda_init() {
                       (size_t)(prop.totalGlobalMem / (1024 * 1024)));
 #else
         info.devices[id].smpbo = prop.sharedMemPerBlockOptin;
+        if (info.devices[id].smpbo == 0 || info.devices[id].smpbo > prop.sharedMemPerMultiprocessor) {
+            GGML_LOG_WARN("%s: device %d reported invalid sharedMemPerBlockOptin=%zu, falling back to sharedMemPerBlock=%zu\n",
+                    __func__, id, info.devices[id].smpbo, (size_t) prop.sharedMemPerBlock);
+            info.devices[id].smpbo = prop.sharedMemPerBlock;
+        }
         info.devices[id].cc = 100*prop.major + 10*prop.minor;
         GGML_LOG_INFO("  Device %d: %s, compute capability %d.%d, VMM: %s, VRAM: %zu MiB\n",
                       id, prop.name, prop.major, prop.minor, device_vmm ? "yes" : "no",


### PR DESCRIPTION
Some Blackwell CUDA driver/device combinations can report an invalid `sharedMemPerBlockOptin` value. Sanitize that value during CUDA device initialization and fall back to `sharedMemPerBlock` when the opt-in value is zero or larger than `sharedMemPerMultiprocessor`.

Validation:
- RTX 5090
- SM120 CUDA build passed
- `test-backend-ops CUDA0 MUL_MAT` passed 1134/1134