### PR TITLE
gguf: add upper bound check for general.alignment (CWE-1284)

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -609,7 +609,7 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
         const int alignment_idx = gguf_find_key(ctx, GGUF_KEY_GENERAL_ALIGNMENT);
         ctx->alignment = alignment_idx == -1 ? GGUF_DEFAULT_ALIGNMENT : gguf_get_val_u32(ctx, alignment_idx);
 
-        if (ctx->alignment == 0 || (ctx->alignment & (ctx->alignment - 1)) != 0) {
+        if (ctx->alignment == 0 || (ctx->alignment & (ctx->alignment - 1)) != 0 || ctx->alignment > 1048576) {
             GGML_LOG_ERROR("%s: alignment %zu is not a power of 2\n", __func__, ctx->alignment);
             gguf_free(ctx);
             return nullptr;


### PR DESCRIPTION
我在看 gguf.cpp 代码时发现，general.alignment 参数现在只做了两项校验：判断是否为 0、是否是 2 的幂，完全没限制最大值。如果外部传入 0x80000000 这种超大对齐值，在 32 位环境里调用 GGML_PAD 宏就会出现整数溢出。

这个漏洞五月份就在 oss-security 安全邮件组里有人提过，但一直没人分配 CVE 编号，也没出修复 PR。实际加载模型根本用不上 2GB 这么夸张的对齐尺寸，直接把对齐值上限限制到 1MB 就足够稳妥，能彻底规避溢出问题。

---
Found while reading gguf.cpp: general.alignment only checks for zero and power-of-2, with no upper bound. Extreme values like 0x80000000 cause GGML_PAD integer overflow on 32-bit platforms. This was mentioned on oss-security in May but never got a CVE or fix. Capping at 1MB is more than enough for any practical model loading - nobody needs 2GB alignment.