### PR TITLE
llama : error clearly when a non-causal model is used for generation

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -194,6 +194,14 @@ llama_context::llama_context(
         cparams.causal_attn = params.attention_type == LLAMA_ATTENTION_TYPE_CAUSAL;
     }
 
+    // Non-causal models (e.g. embedding/classification encoders such as BERT) cannot generate text.
+    // A generation request (bounded n_outputs_max) would otherwise trip GGML_ASSERT in output_reserve();
+    // fail early with a clear message instead of aborting.
+    if (!cparams.causal_attn && !llama_model_has_encoder(&model) && params.n_outputs_max != 0) {
+        throw std::runtime_error("this model is non-causal (e.g. an embedding/classification model) "
+            "and cannot be used for text generation; use the embedding API (e.g. llama-embedding) instead");
+    }
+
     cparams.flash_attn = params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED;
     cparams.auto_fa    = params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1166,6 +1166,11 @@ private:
             return false;
         }
 
+        if (ctx_tgt == nullptr) {
+            SRV_ERR("failed to create context with model, '%s'\n", params_base.model.path.c_str());
+            return false;
+        }
+
         vocab = llama_model_get_vocab(model_tgt);
 
         n_ctx = llama_n_ctx(ctx_tgt);


### PR DESCRIPTION
## Overview

Loading an embedding/classification model (e.g. BERT/DistilRoBERTa) into a generation tool like `llama-cli` currently aborts with `GGML_ASSERT(n_outputs_max <= cparams.n_outputs_max)` in `output_reserve()` (#24967). Non-causal models emit one output row per token, while a generation request uses a bounded `n_outputs_max` (`llama-cli` uses `1`), so the cap is exceeded.

Rather than raising the cap (which only lets `llama-cli` proceed into `the current context does not allow logits computation. skipping`), this PR **fails early** during `llama_context` construction with a clear, actionable message:

> this model is non-causal (e.g. an embedding/classification model) and cannot be used for text generation; use the embedding API (e.g. llama-embedding) instead

It also adds a missing null-context check in the shared server/CLI load path (`server_context_impl::load_model`), which previously dereferenced the null context via `llama_n_ctx()` and segfaulted right after the clean error.

## Additional info

These classifier models are fully usable in llama.cpp via the embedding/rank path — they just aren't generative. For example `llama-embedding --pooling rank` returns the per-label scores correctly:

```
$ llama-embedding -m emotion-distilroberta.gguf --pooling rank --embd-normalize -1 -p "I am furious and angry"
rerank score 0:   5.84 [anger]   ...  -2.00 [joy]
$ ...                                                  -p "I feel wonderful joy and happiness"
rerank score 0:   6.12 [joy]     ...  -1.27 [anger]
```

Tested on RDNA4 (gfx1201, Vulkan):
- `llama-cli` on a DistilRoBERTa emotion classifier -> now exits cleanly (rc=1) with the message above, instead of aborting (rc=134) / segfaulting (rc=139).
- `llama-embedding --pooling rank` on the same model -> unchanged, correct per-label scores.
- A causal model (Gemma) via `llama-cli` -> unchanged, generates normally.

## Requirements

- [x] I have read and followed the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI assistance: **yes** — an AI coding assistant helped investigate the root cause, draft the change, and run the reproduction/regression tests on real hardware; all changes were reviewed and verified by me.

Fixes #24967
