### PR TITLE
Add `help <command>` as alias for `<command> --help`

### DIFF
--- a/app/llama.cpp
+++ b/app/llama.cpp
@@ -118,11 +118,24 @@ static bool matches(const std::string & arg, const command & cmd) {
     return false;
 }
 
+static bool is_cmd(std::string arg) {
+    for (const auto & cmd : cmds) {
+        if (matches(arg, cmd)) {
+            return true;
+        }
+    }
+    return false
+}
+
 int main(int argc, char ** argv) {
     progname = argv[0];
 
-    const std::string arg = argc >= 2 ? argv[1] : "help";
+    const bool help_cmd = argc >= 3 && argv[1] == "help" && is_cmd(argv[2]);
 
+    if (help_cmd) {
+        return main(3, {argv[2], "--help");
+    }
+    
     for (const auto & cmd : cmds) {
         if (matches(arg, cmd)) {
             // keep cmd.name so the router's child processes re-invoke correctly

--- a/app/llama.cpp
+++ b/app/llama.cpp
@@ -124,7 +124,7 @@ static bool is_cmd(std::string arg) {
             return true;
         }
     }
-    return false
+    return false;
 }
 
 int main(int argc, char ** argv) {
@@ -133,7 +133,7 @@ int main(int argc, char ** argv) {
     const bool help_cmd = argc >= 3 && argv[1] == "help" && is_cmd(argv[2]);
 
     if (help_cmd) {
-        return main(3, {argv[2], "--help");
+        return main(3, {argv[2], "--help"});
     }
     
     for (const auto & cmd : cmds) {


### PR DESCRIPTION
## Overview

Allow user to use e.g. `llama help serve" as an alias for `llama serve --help`.

1. Adds a helper to check if help target is a valid command
2. Calls recursively with the alias.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO