### PR TITLE
server: validate fetch target IP and re-check redirects to prevent SSRF

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -443,7 +443,7 @@ static int common_download_file_single_online(const std::string & url,
 
 std::pair<long, std::vector<char>> common_remote_get_content(const std::string          & url,
                                                              const common_remote_params & params) {
-    auto [cli, parts] = common_http_client(url);
+    std::string current_url = url;
 
     httplib::Headers headers;
     for (const auto & h : params.headers) {
@@ -453,26 +453,59 @@ std::pair<long, std::vector<char>> common_remote_get_content(const std::string  
         headers.emplace("User-Agent", "llama-cpp/" + std::string(llama_build_info()));
     }
 
-    if (params.timeout > 0) {
-        cli.set_read_timeout(params.timeout, 0);
-        cli.set_write_timeout(params.timeout, 0);
+    // When ssrf_guard is set, httplib's automatic redirect following is disabled
+    // and each hop is validated here, because httplib re-resolves and follows the
+    // attacker-controlled Location header without re-checking the target IP.
+    const int max_hops = params.ssrf_guard ? 10 : 1;
+
+    for (int hop = 0; hop < max_hops; ++hop) {
+        auto [cli, parts] = common_http_client(current_url);
+
+        if (params.ssrf_guard) {
+            if (!common_host_is_safe(parts.host)) {
+                throw std::runtime_error("error: refusing to fetch non-public address: " + parts.host);
+            }
+            cli.set_follow_location(false); // we follow manually, validating each hop
+        }
+
+        if (params.timeout > 0) {
+            cli.set_read_timeout(params.timeout, 0);
+            cli.set_write_timeout(params.timeout, 0);
+        }
+
+        std::vector<char> buf;
+        auto res = cli.Get(parts.path, headers,
+            [&](const char *data, size_t len) {
+                buf.insert(buf.end(), data, data + len);
+                return params.max_size == 0 ||
+                       buf.size() <= static_cast<size_t>(params.max_size);
+            },
+            nullptr
+        );
+
+        if (!res) {
+            throw std::runtime_error("error: cannot make GET request");
+        }
+
+        // guarded redirect handling: validate the next hop before following it
+        if (params.ssrf_guard && res->status >= 300 && res->status < 400 &&
+            res->has_header("Location")) {
+            std::string loc = res->get_header_value("Location");
+            if (loc.rfind("http://", 0) == 0 || loc.rfind("https://", 0) == 0) {
+                current_url = loc;                          // absolute redirect
+            } else if (!loc.empty() && loc[0] == '/') {
+                current_url = parts.scheme + "://" + parts.host + ":" +
+                              std::to_string(parts.port) + loc; // same host, new path
+            } else {
+                throw std::runtime_error("error: unsupported redirect target");
+            }
+            continue;
+        }
+
+        return { res->status, std::move(buf) };
     }
 
-    std::vector<char> buf;
-    auto res = cli.Get(parts.path, headers,
-        [&](const char *data, size_t len) {
-            buf.insert(buf.end(), data, data + len);
-            return params.max_size == 0 ||
-                   buf.size() <= static_cast<size_t>(params.max_size);
-        },
-        nullptr
-    );
-
-    if (!res) {
-        throw std::runtime_error("error: cannot make GET request");
-    }
-
-    return { res->status, std::move(buf) };
+    throw std::runtime_error("error: too many redirects");
 }
 
 int common_download_file_single(const std::string & url,

--- a/common/download.h
+++ b/common/download.h
@@ -28,6 +28,7 @@ struct common_remote_params {
     common_header_list headers;
     long timeout  = 0;           // in seconds, 0 means no timeout
     long max_size = 0;           // unlimited if 0
+    bool ssrf_guard = false;     // reject private/reserved IPs and re-validate every redirect hop
 };
 
 // get remote file content, returns <http_code, raw_response_body>

--- a/common/http.h
+++ b/common/http.h
@@ -2,6 +2,17 @@
 
 #include <cpp-httplib/httplib.h>
 
+#include <cstdint>
+#include <cstring>
+#ifdef _WIN32
+#  include <ws2tcpip.h>
+#else
+#  include <arpa/inet.h>
+#  include <netdb.h>
+#  include <netinet/in.h>
+#  include <sys/socket.h>
+#endif
+
 struct common_http_url {
     std::string scheme;
     std::string user;
@@ -92,6 +103,46 @@ static std::pair<httplib::Client, common_http_url> common_http_client(const std:
     cli.set_follow_location(true);
 
     return { std::move(cli), std::move(parts) };
+}
+
+// Returns true only if every resolved address for `host` is a public,
+// routable address. Resolving first normalizes decimal/octal/hex IPv4
+// encodings; IPv4-mapped/6to4 IPv6 wrappers are unwrapped and re-checked.
+// Fails closed (returns false) on resolution failure.
+static bool common_host_is_safe(const std::string & host) {
+    auto v4_blocked = [](uint32_t a /*host order*/) {
+        auto in = [&](uint32_t net, int bits){ return (a >> (32-bits)) == (net >> (32-bits)); };
+        return in(0x00000000u,8) || in(0x0A000000u,8)  || in(0x64400000u,10) ||
+               in(0x7F000000u,8) || in(0xA9FE0000u,16) || in(0xAC100000u,12) ||
+               in(0xC0A80000u,16)|| in(0xC6120000u,15) || in(0xE0000000u,4)  ||
+               in(0xF0000000u,4) || (a == 0xFFFFFFFFu);
+    };
+    auto v6_blocked = [&](const uint8_t b[16]) {
+        static const uint8_t loop[16]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+        static const uint8_t any[16]={0};
+        static const uint8_t mapped[12]={0,0,0,0,0,0,0,0,0,0,0xFF,0xFF};
+        if (!memcmp(b,loop,16) || !memcmp(b,any,16)) return true;
+        if ((b[0]&0xFE)==0xFC) return true;                 // fc00::/7
+        if (b[0]==0xFE && (b[1]&0xC0)==0x80) return true;   // fe80::/10
+        if (b[0]==0xFF) return true;                        // ff00::/8
+        if (!memcmp(b,mapped,12))                           // ::ffff:v4
+            return v4_blocked((b[12]<<24)|(b[13]<<16)|(b[14]<<8)|b[15]);
+        if (b[0]==0x20 && b[1]==0x02)                       // 2002:v4::/16
+            return v4_blocked((b[2]<<24)|(b[3]<<16)|(b[4]<<8)|b[5]);
+        return false;
+    };
+    addrinfo hints{}; hints.ai_family = AF_UNSPEC; hints.ai_socktype = SOCK_STREAM;
+    addrinfo * res = nullptr;
+    if (getaddrinfo(host.c_str(), nullptr, &hints, &res) != 0) return false;
+    bool safe = true;
+    for (addrinfo * p = res; p && safe; p = p->ai_next) {
+        if (p->ai_family == AF_INET)
+            safe = !v4_blocked(ntohl(((sockaddr_in*)p->ai_addr)->sin_addr.s_addr));
+        else if (p->ai_family == AF_INET6)
+            safe = !v6_blocked(((sockaddr_in6*)p->ai_addr)->sin6_addr.s6_addr);
+    }
+    freeaddrinfo(res);
+    return safe;
 }
 
 static std::string common_http_show_masked_url(const common_http_url & parts) {

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -846,6 +846,7 @@ static void handle_media(
         common_remote_params params;
         params.max_size = 1024 * 1024 * 10; // 10MB
         params.timeout  = 10; // seconds
+        params.ssrf_guard = true; // reject private/reserved IPs, re-validate redirect hops
         SRV_INF("downloading image from '%s'\n", url.c_str());
         auto res = common_remote_get_content(url, params);
         if (200 <= res.first && res.first < 300) {


### PR DESCRIPTION
## Overview

The multimodal image fetch in handle_media() passes an attacker-supplied image_url to common_remote_get_content() with no validation of the target address. A /v1/chat/completions request can make the server fetch http://127.0.0.1, http://169.254.169.254 (cloud IMDS), or other internal hosts.

## Additional information

Validating only the initial URL is not enough: the fetch client sets set_follow_location(true), and cpp-httplib follows a redirect to the host in the Location header without re-checking it, so a public URL that returns a 302 to an
internal IP bypasses an initial-only check.

This change:
- adds common_host_is_safe() in common/http.h, which resolves the host and rejects loopback / RFC1918 / CGNAT / link-local (169.254/16) / multicast / reserved ranges, including IPv6 and ::ffff:/2002: v4-mapped forms. Resolving first also normalizes decimal/octal/hex IP encodings. Fails closed.

- adds an opt-in ssrf_guard flag to common_remote_params; when set, automatic redirect following is disabled and each hop is re-validated, capped at 10 hops.

- enables ssrf_guard only on the server multimodal fetch path.

Model/manifest downloads (-hf, --model-url, hf-cache) are operator-initiated and keep their existing redirect behavior (flag defaults off), so HF->CDN redirects are unaffected.

## Testing

Built llama-server from this branch with a Qwen2-VL model loaded. The original PoC payload is now rejected before any outbound request is made:

  curl -s http://127.0.0.1:8080/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"http://127.0.0.1:9000/SSRF_PROOF"}}]}]}'
  {"error":{"code":500,"message":"error: refusing to fetch non-public address: 127.0.0.1","type":"server_error"}}

A listener on :9000 receives no request. 169.254.169.254 and RFC1918 targets are rejected the same way.
