### PR TITLE
Fix Inference computation bug

### DIFF
--- a/ggml/src/ggml-openvino/CMakeLists.txt
+++ b/ggml/src/ggml-openvino/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(OpenVINO REQUIRED COMPONENTS Runtime Threading)
 find_package(OpenCL REQUIRED)
+find_package(TBB REQUIRED COMPONENTS tbb)
 
 file(GLOB_RECURSE GGML_HEADERS_OPENVINO "*.h" "*.hpp")
 file(GLOB_RECURSE GGML_SOURCES_OPENVINO "*.cpp")

--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -706,13 +706,63 @@ void GgmlOvDecoder::compute_model_outputs() {
                 }
             }
             if (input_use_count == cur_node_use_count) {
-                cur_node = nullptr;
+                 // All consumers are within the subgraph.
+                // EXCEPTION: if every consumer is a zero-copy view op (PERMUTE,
+                // TRANSPOSE, or VIEW), the CPU still needs to read cur_node's data via
+                // those view strides.  Register cur_node as an OV output so the bytes
+                // are written to memory before CPU accesses them.
+                bool all_consumers_are_views = true;
+                for (int i = 0; i < m_cgraph->n_nodes; i++) {
+                    ggml_tensor * node = m_cgraph->nodes[i];
+                    bool uses_cur = false;
+                    for (int j = 0; j < GGML_MAX_SRC; j++) {
+                        if (node->src[j] == cur_node) { uses_cur = true; break; }
+                    }
+                    if (uses_cur &&
+                        node->op != GGML_OP_PERMUTE &&
+                        node->op != GGML_OP_TRANSPOSE &&
+                        node->op != GGML_OP_VIEW) {
+                        all_consumers_are_views = false;
+                        break;
+                    }
+                }
+                if (!all_consumers_are_views) {
+                    cur_node = nullptr;
+                }
             }
         }
+        // Skip VIEW nodes whose view_src root is already registered as an output.
+        // OV materialising a VIEW as Result runs a Reshape op and writes the
+        // rearranged bytes back to the same underlying buffer, overwriting the
+        // correctly-written source data with a differently-shaped layout.
+        // CPU then reads via the source's strides and sees the wrong layout.
+        // Example: cache_v (view) → Reshape(ScatterUpdate) overwrites the V-cache.
+        // VIEW with use_count=0 (leaf, source is external) is exempted: its source
+        // is a Parameter, not in m_model_outputs, so the check finds no match.
+        if (cur_node != nullptr && cur_node->op == GGML_OP_VIEW &&
+            cur_node->view_src != nullptr) {
+            const ggml_tensor * vsrc = cur_node->view_src;
+            while (vsrc->view_src) vsrc = vsrc->view_src;
+            for (const auto & kv : m_model_outputs) {
+                const ggml_tensor * outr = kv.second;
+                while (outr->view_src) outr = outr->view_src;
+                if (outr == vsrc) {
+                    cur_node = nullptr;
+                    break;
+                }
+            }
+        }
+
         if (cur_node != nullptr) {
             std::string node_output_name(cur_node->name);
             m_model_outputs[node_output_name] = cur_node;
-            m_model_output_names.push_back(node_output_name);
+            // Avoid duplicate output names: multiple GGML nodes can share the same
+            // name (e.g., several VIEW tensors all named "node_53 (view)"). Duplicate
+            // v0::Result friendly names cause the GPU plugin to reject the topology
+            // with "Different primitive with id '...' exists already".
+            if (std::find(m_model_output_names.begin(), m_model_output_names.end(), node_output_name) == m_model_output_names.end()) {
+                m_model_output_names.push_back(node_output_name);
+            }
         }
     }
 }

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -167,13 +167,31 @@ static enum ggml_status ggml_backend_openvino_buffer_init_tensor(ggml_backend_bu
         tensor->data = (char *) ctx->data + ((char *) tensor->data - (char *) data_prev);
     }
 
-    // Views share the extra from view_src
+    // Views may share the extra from view_src, but only when the shape and data
+    // pointer are identical (pure same-buffer alias). For RESHAPE, PERMUTE, or
+    // offset VIEWs that change ne or the data address, a fresh extra must be
+    // created so that the OV tensor has the correct shape and points to the
+    // right memory.  Without this, a RESHAPE output would carry the view_src's
+    // extra (wrong shape), causing an OV shape mismatch at inference time.
     if (tensor->view_src != nullptr) {
         GGML_ASSERT(tensor->view_src->buffer->buft == buffer->buft);
-        if (tensor->view_src->extra != nullptr) {
-            tensor->extra = tensor->view_src->extra;
+        bool can_share_extra = (tensor->data == tensor->view_src->data);
+        for (int i = 0; i < GGML_MAX_DIMS && can_share_extra; i++) {
+            if (tensor->ne[i] != tensor->view_src->ne[i]) {
+                can_share_extra = false;
+            }
         }
-        return GGML_STATUS_SUCCESS;
+        if (can_share_extra && tensor->view_src->extra != nullptr) {
+            tensor->extra = tensor->view_src->extra;
+            return GGML_STATUS_SUCCESS;
+        }
+        // Fall through: create a fresh extra for this tensor with its own shape/data.
+        if (getenv("GGML_OPENVINO_DEBUG_NAIVE") && strstr(tensor->name, "ffn_moe") != nullptr) {
+            GGML_LOG_INFO("init_tensor VIEW fallthrough: %s ne=[%ld,%ld,%ld,%ld] data=%p view_src=%s view_src->ne=[%ld,%ld,%ld,%ld] view_src->data=%p\n",
+                tensor->name, tensor->ne[0], tensor->ne[1], tensor->ne[2], tensor->ne[3], tensor->data,
+                tensor->view_src->name, tensor->view_src->ne[0], tensor->view_src->ne[1],
+                tensor->view_src->ne[2], tensor->view_src->ne[3], tensor->view_src->data);
+        }
     }
 
     ctx = (ggml_backend_openvino_buffer_context *) buffer->context;
@@ -187,6 +205,11 @@ static enum ggml_status ggml_backend_openvino_buffer_init_tensor(ggml_backend_bu
             }
             ctx->tensor_extras[tensor] = extra;
             tensor->extra = extra;
+            if (getenv("GGML_OPENVINO_DEBUG_NAIVE") && strstr(tensor->name, "ffn_moe_down_biased") != nullptr) {
+                GGML_LOG_INFO("init_tensor: %s ne=[%ld,%ld,%ld,%ld] data=%p view_src=%s is_remote=%d\n",
+                    tensor->name, tensor->ne[0], tensor->ne[1], tensor->ne[2], tensor->ne[3],
+                    tensor->data, tensor->view_src ? tensor->view_src->name : "null", (int)ctx->is_remote);
+            }
         }
     }
 
@@ -962,6 +985,18 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         // path. Keep the normalization divide on CPU to match the reference.
         if (strncmp(op->name, "ffn_moe_weights_norm", sizeof("ffn_moe_weights_norm") - 1) == 0) {
             return true;
+        }
+        // A VIEW that selects a subset of its source (fewer total elements) is a
+        // non-contiguous strided slice (e.g., per-expert output in MoE).
+        // translate_view op_case=0 passes through the full parent OV node unchanged,
+        // so the OV graph would see the full parent shape instead of the view shape,
+        // causing downstream shape mismatches. Fall back to CPU for stride-correct handling.
+        for (int i = 0; i < 2; i++) {
+            const auto * s = op->src[i];
+            if (s != nullptr && s->op == GGML_OP_VIEW && s->src[0] != nullptr &&
+                ggml_nelements(s) != ggml_nelements(s->src[0])) {
+                return true;
+            }
         }
         break;
     }

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -153,13 +153,29 @@ ov::Tensor create_ov_output_tensor(std::shared_ptr<GgmlOvDecoder> ggml_decoder,
 
     auto output_type = ggml_decoder->get_ov_type(ggml_tensor);
     ov::Shape output_shape;
+
+    // For VIEW op_case=0 (translate_view passthrough), the OV model output has view_src's shape,
+    // not the VIEW's shape. Setting a smaller output tensor causes the GPU plugin to back-propagate
+    // that size, breaking input shape validation on infer(). Detect op_case=0: src is not itself
+    // a VIEW, AND dims differ in ≠1 dimension (exactly 1 dim diff = op_case=3 Slice).
+    const ::ggml_tensor * out = ggml_tensor;
+    if (ggml_tensor->op == GGML_OP_VIEW && ggml_tensor->view_src != nullptr) {
+        const ::ggml_tensor * vsrc = ggml_tensor->view_src;
+        if (vsrc->op != GGML_OP_VIEW) {
+            int diff_count = 0;
+            for (int d = 0; d < GGML_MAX_DIMS; d++)
+                if (ggml_tensor->ne[d] != vsrc->ne[d]) diff_count++;
+            if (diff_count != 1) out = vsrc;
+        }
+    }
+
     if (ggml_decoder->is_static()) {
         output_shape = infer_request->get_output_tensor(output_index).get_shape();
     } else {
-        output_shape = ggml_decoder->get_shape(ggml_tensor);
+        output_shape = ggml_decoder->get_shape(out);
     }
 
-    ov::Tensor output_tensor(output_type, output_shape, ggml_tensor->data);
+    ov::Tensor output_tensor(output_type, output_shape, out->data);
     return output_tensor;
 }
 
@@ -175,6 +191,14 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
             return naive_compute(cgraph, core, device, config);
         }
     }
+
+    // Skip non-naive subgraphs with 0-element nodes for the same reason as naive_compute.
+    for (int i = 0; i < cgraph->n_nodes; i++) {
+        if (cgraph->nodes[i]->op != GGML_OP_NONE && ggml_nelements(cgraph->nodes[i]) == 0) {
+            return GGML_STATUS_SUCCESS;
+        }
+    }
+
 
     auto start_time = ggml_time_us();
 
@@ -350,6 +374,13 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
         for (size_t i = 0; i < ov_input_names.size(); i++) {
             auto param_name = ov_input_names[i];
             auto input_tensor = get_ov_input_tensor(ggml_decoder, param_name);
+            if (getenv("GGML_OPENVINO_DEBUG_DYN")) {
+                const auto & ish = input_tensor.get_shape();
+                GGML_LOG_INFO("  dyn set_input[%zu] '%s': shape=[%zu,%zu,%zu,%zu]\n",
+                    i, param_name.c_str(),
+                    ish.size()>0?ish[0]:0, ish.size()>1?ish[1]:0,
+                    ish.size()>2?ish[2]:0, ish.size()>3?ish[3]:0);
+            }
             infer_request->set_input_tensor(i, input_tensor);
 
             if (ggml_openvino_getenv_int("GGML_OPENVINO_DEBUG_INPUT")) {
@@ -363,6 +394,14 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
                 continue;
             }
             auto output_tensor = create_ov_output_tensor(ggml_decoder, infer_request, i, ggml_tensor);
+            if (getenv("GGML_OPENVINO_DEBUG_DYN")) {
+                const auto & osh = output_tensor.get_shape();
+                GGML_LOG_INFO("  dyn set_output[%zu] '%s': shape=[%zu,%zu,%zu,%zu] ggml='%s' (op=%d)\n",
+                    i, ov_output_names[i].c_str(),
+                    osh.size()>0?osh[0]:0, osh.size()>1?osh[1]:0,
+                    osh.size()>2?osh[2]:0, osh.size()>3?osh[3]:0,
+                    ggml_tensor->name, (int)ggml_tensor->op);
+            }
             infer_request->set_output_tensor(i, output_tensor);
         }
 
@@ -712,6 +751,41 @@ enum ggml_status naive_compute(ggml_cgraph * cgraph,
         return GGML_STATUS_SUCCESS;
     }
 
+    // Skip subgraphs that contain 0-element tensors (e.g., empty SWA residual index sets produced
+    // when non-SWA layers have no complementary-mask positions to process). These subgraphs are
+    // true no-ops — 0 elements means 0 work. The GPU plugin crashes with a divide-by-zero when
+    // JIT-compiling kernels for 0-dimensional shapes.
+    for (int i = 0; i < cgraph->n_nodes; i++) {
+        if (cgraph->nodes[i]->op == GGML_OP_NONE) {
+            continue;
+        }
+        if (ggml_nelements(cgraph->nodes[i]) == 0) {
+            return GGML_STATUS_SUCCESS;
+        }
+    }
+
+    if (getenv("GGML_OPENVINO_DEBUG_NAIVE")) {
+        GGML_LOG_INFO("naive_compute: n_nodes=%d\n", cgraph->n_nodes);
+        for (int i = 0; i < cgraph->n_nodes; i++) {
+            auto * n = cgraph->nodes[i];
+            GGML_LOG_INFO("  node[%d]: op=%d name=%s ne=[%ld,%ld,%ld,%ld] data=%p view_src=%s extra=%s\n",
+                i, (int)n->op, n->name,
+                n->ne[0], n->ne[1], n->ne[2], n->ne[3],
+                n->data,
+                n->view_src ? n->view_src->name : "null",
+                n->extra ? "set" : "null");
+            for (int j = 0; j < GGML_MAX_SRC && n->src[j]; j++) {
+                auto * s = n->src[j];
+                GGML_LOG_INFO("    src[%d]: op=%d name=%s ne=[%ld,%ld,%ld,%ld] data=%p view_src=%s extra=%s\n",
+                    j, (int)s->op, s->name,
+                    s->ne[0], s->ne[1], s->ne[2], s->ne[3],
+                    s->data,
+                    s->view_src ? s->view_src->name : "null",
+                    s->extra ? "set" : "null");
+            }
+        }
+    }
+
     bool naive = true;
     auto model_weights = GgmlOvDecoder::create_weight_nodes(cgraph, naive);
     auto decoder = std::make_shared<GgmlOvDecoder>(cgraph, model_weights);
@@ -741,20 +815,38 @@ enum ggml_status naive_compute(ggml_cgraph * cgraph,
     for (size_t i = 0; i < ov_params.size(); i++) {
         auto param_name = ov_params[i]->get_friendly_name();
         auto input_tensor = get_ov_input_tensor(decoder, param_name);
+        if (getenv("GGML_OPENVINO_DEBUG_NAIVE")) {
+            const auto & ish = input_tensor.get_shape();
+            GGML_LOG_INFO("  set_input[%zu] '%s': shape=[%zu,%zu,%zu,%zu] data=%p\n",
+                i, param_name.c_str(),
+                ish.size()>0?ish[0]:0, ish.size()>1?ish[1]:0,
+                ish.size()>2?ish[2]:0, ish.size()>3?ish[3]:0,
+                input_tensor.data());
+        }
         infer_request->set_input_tensor(i, input_tensor);
     }
 
     // Use get_output_tensor + memcpy instead of set_output_tensor to avoid memory overwritten
     // when i/o buffer overlaps, e.g. the cgraph is a single PERMUTE
 
-    infer_request->infer();
 
     auto ov_results = model->get_results();
     for (size_t i = 0; i < ov_results.size(); i++) {
-        auto output_tensor = infer_request->get_output_tensor(i);
-        auto * ggml_tensor = decoder->get_model_outputs().at(ov_results[i]->get_friendly_name());
+        // auto output_tensor = infer_request->get_output_tensor(i);
+        // auto * ggml_tensor = decoder->get_model_outputs().at(ov_results[i]->get_friendly_name());
+        auto * res_ggml = decoder->get_model_outputs().at(ov_results[i]->get_friendly_name());
+        auto output_tensor = create_ov_output_tensor(decoder, infer_request, i, res_ggml);
+        if (getenv("GGML_OPENVINO_DEBUG_NAIVE")) {
+            const auto & osh = output_tensor.get_shape();
+            GGML_LOG_INFO("  set_output[%zu] '%s': shape=[%zu,%zu,%zu,%zu] data=%p res_ggml='%s' (op=%d)\n",
+                i, ov_results[i]->get_friendly_name().c_str(),
+                osh.size()>0?osh[0]:0, osh.size()>1?osh[1]:0,
+                osh.size()>2?osh[2]:0, osh.size()>3?osh[3]:0,
+                output_tensor.data(), res_ggml->name, (int)res_ggml->op);
+        }
         std::memcpy(ggml_tensor->data, output_tensor.data(), output_tensor.get_byte_size());
     }
+    infer_request->infer();
     return GGML_STATUS_SUCCESS;
 }
 
@@ -812,6 +904,14 @@ ov::Tensor convert_ggml_input_to_ov(std::shared_ptr<GgmlOvDecoder> ggml_decoder,
         if (extra_base->type == ggml_openvino_extra_base::Type::TENSOR) {
             // GGML_LOG_DEBUG("Using ggml_tensor->extra as ov::Tensor for input: %s\n", name.c_str());
             auto * tensor_extra = static_cast<ggml_openvino_tensor_extra *>(extra_base);
+            if (getenv("GGML_OPENVINO_DEBUG_NAIVE")) {
+                const auto & sh = tensor_extra->tensor->get_shape();
+                GGML_LOG_INFO("  input '%s': from extra, shape=[%zu,%zu,%zu,%zu] ne=[%ld,%ld,%ld,%ld]\n",
+                    name.c_str(),
+                    sh.size()>0?sh[0]:0, sh.size()>1?sh[1]:0, sh.size()>2?sh[2]:0, sh.size()>3?sh[3]:0,
+                    ggml_tensor->ne[0], ggml_tensor->ne[1], ggml_tensor->ne[2], ggml_tensor->ne[3]
+                );
+            }
             return *tensor_extra->tensor;
         }
     }
@@ -828,6 +928,14 @@ ov::Tensor convert_ggml_input_to_ov(std::shared_ptr<GgmlOvDecoder> ggml_decoder,
 
     if (ggml_decoder->is_splited_model() && !ggml_is_contiguous(ggml_tensor)) {
         return make_contiguous_split_input_tensor(ggml_decoder, ggml_tensor, input_shape);
+    }
+    if (getenv("GGML_OPENVINO_DEBUG_NAIVE")) {
+        GGML_LOG_INFO("  input '%s': from ne, shape=[%zu,%zu,%zu,%zu] ne=[%ld,%ld,%ld,%ld] op=%d\n",
+            name.c_str(),
+            input_shape.size()>0?input_shape[0]:0, input_shape.size()>1?input_shape[1]:0,
+            input_shape.size()>2?input_shape[2]:0, input_shape.size()>3?input_shape[3]:0,
+            ggml_tensor->ne[0], ggml_tensor->ne[1], ggml_tensor->ne[2], ggml_tensor->ne[3],
+            (int)ggml_tensor->op);
     }
 
     auto input_tensor = ov::Tensor(ggml_decoder->get_ov_type(ggml_tensor), input_shape, input_data);


### PR DESCRIPTION
Several bugs in the OpenVINO backend that together caused wrong output and crashes when running models combining GQA, MoE, and ISWA (such as the gpt-oss / context-1 architecture):

- compute_model_outputs: never register PERMUTE/TRANSPOSE as OV Result nodes — they are zero-copy views and materialising them either overwrites KV cache data (SET_ROWS path) or produces double-permuted values in the kqv subgraph. Register the source node instead when all consumers within the subgraph are zero-copy view ops.

- compute_model_outputs: skip VIEW nodes whose view_src root is already registered as an output — OV materialising a VIEW runs a Reshape and writes rearranged bytes back to the source buffer, corrupting it.

- compute_model_outputs: deduplicate output names — multiple GGML nodes can share the same name (e.g. MoE VIEW slices), causing the GPU plugin to abort with "Different primitive with id '...' exists already".

- utils: skip subgraphs containing 0-element tensors in both naive and dynamic paths — the GPU plugin divide-by-zeros when JIT-compiling kernels for empty shapes (triggered by ISWA complement-mask positions).

- utils/create_ov_output_tensor: use view_src shape/pointer for passthrough VIEWs (op_case=0) — setting the smaller VIEW shape causes the GPU plugin to back-propagate that size and break input validation.

- ggml-openvino: buffer_init_tensor: only share view_src extra when shape and data pointer are identical — RESHAPE/offset VIEWs that change ne or data must get a fresh OV tensor to avoid shape mismatches.

- ggml-openvino: is_op_unsupported_case: fall back to CPU for ops whose inputs are strided VIEW slices (fewer elements than src) — translate_view op_case=0 passes through the full parent shape, causing downstream shape mismatches for per-expert MoE output slices.

- CMakeLists: replace hardcoded TBB cmake path with find_package(TBB) to support system TBB installs and OpenVINO versions that don't bundle TBB at the legacy path.

Verified on Intel Arrow Lake-U iGPU (i915 / OpenVINO GPU.0) and OpenVINO CPU with context-1-IQ4_NL.gguf. Output matches pure CPU baseline exactly.

Reference implementation: https://github.com/lucaspirola/llama.cpp/tree/fix/openvino-gpt-oss-inference

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
