### PR TITLE
mtmd: validate GGUF array type and length in clip loader

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1256,6 +1256,17 @@ struct clip_model_loader {
                 int idx_std  = gguf_find_key(ctx_gguf.get(), KEY_IMAGE_STD);
                 GGML_ASSERT(idx_mean >= 0 && "image_mean not found");
                 GGML_ASSERT(idx_std >= 0  && "image_std not found");
+                // Validate element type and length before reading 3 elements, otherwise a
+                // crafted GGUF with a short or wrong-typed image_mean/image_std array causes
+                // an out-of-bounds read past the array buffer.
+                if (gguf_get_arr_type(ctx_gguf.get(), idx_mean) != GGUF_TYPE_FLOAT32 ||
+                    gguf_get_arr_type(ctx_gguf.get(), idx_std)  != GGUF_TYPE_FLOAT32) {
+                    throw std::runtime_error("image_mean and image_std must be FLOAT32 arrays");
+                }
+                if (gguf_get_arr_n(ctx_gguf.get(), idx_mean) < 3 ||
+                    gguf_get_arr_n(ctx_gguf.get(), idx_std)  < 3) {
+                    throw std::runtime_error("image_mean and image_std must have at least 3 elements");
+                }
                 const float * mean_data = (const float *) gguf_get_arr_data(ctx_gguf.get(), idx_mean);
                 const float * std_data  = (const float *) gguf_get_arr_data(ctx_gguf.get(), idx_std);
                 for (int i = 0; i < 3; ++i) {
@@ -3085,6 +3096,11 @@ struct clip_model_loader {
                 throw std::runtime_error("Key not found: " + key);
             }
             return;
+        }
+        // Validate element type before casting the array data to int32_t*, otherwise a
+        // crafted GGUF declaring a narrower element type causes an out-of-bounds read.
+        if (gguf_get_arr_type(ctx_gguf.get(), i) != GGUF_TYPE_INT32) {
+            throw std::runtime_error("expected an INT32 array for key: " + key);
         }
         int n = gguf_get_arr_n(ctx_gguf.get(), i);
         output.resize(n);


### PR DESCRIPTION
### Summary

`clip_model_loader` reads two pieces of array metadata from the GGUF without validating the array's element type or length:

1. `load_hparams` (vision branch) reads `image_mean` / `image_std` as exactly three `float`s, checking only that the keys exist — not that the arrays are `FLOAT32` or have at least 3 elements.
2. `get_arr_int` casts the array data to `int32_t*` and reads `n` elements without checking the array element type is `INT32`.

A malformed mmproj model file can declare these arrays short, or with a narrower element type, causing an out-of-bounds read past the array buffer when the loader reads them. This patch validates element type and minimum length before reading and throws a clear error instead.

### Changes

- `tools/mtmd/clip.cpp` (`load_hparams`): require `image_mean`/`image_std` to be `FLOAT32` arrays with at least 3 elements before reading.
- `tools/mtmd/clip.cpp` (`get_arr_int`): require an `INT32` array before the `int32_t*` cast.

### Testing

- Valid mmproj files are unaffected (converters emit `FLOAT32[3]` and `INT32` arrays).
- Malformed arrays now produce a `std::runtime_error` during load instead of an out-of-bounds read.

### Notes

Found via static review of the GGUF/mmproj load path; reported as a hardening fix with no exploit details.