### PR TITLE
server: remove is_last_user_message bypass of checkpoint_min_step

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3443,7 +3443,6 @@ private:
                     }
 
                     const auto & spans = slot.task->params.message_spans;
-                    const auto last_user_pos = spans.last_user_message_pos();
 
                     // add prompt tokens for processing in the current batch
                     while (slot.prompt.n_tokens() < slot.task->n_tokens() && batch.size() < n_batch) {
@@ -3507,7 +3506,6 @@ private:
                     const bool near_prompt_end = slot.task->n_tokens() < slot.prompt.n_tokens() + n_ubatch;
 
                     const bool is_user_start = spans.is_user_start(n_tokens_start);
-                    const bool is_last_user_message = n_tokens_start == last_user_pos;
 
                     // entire prompt has been processed
                     if (slot.prompt.n_tokens() == slot.task->n_tokens()) {
@@ -3542,8 +3540,8 @@ private:
                     // do not checkpoint after mtmd chunks
                     do_checkpoint = do_checkpoint && !has_mtmd;
 
-                    // no need to create checkpoints that are too close together, unless it's the last user message
-                    do_checkpoint = do_checkpoint && (slot.prompt.checkpoints.empty() || is_last_user_message || n_tokens_start > slot.prompt.checkpoints.back().n_tokens + params_base.checkpoint_min_step);
+                    // no need to create checkpoints that are too close together
+                    do_checkpoint = do_checkpoint && (slot.prompt.checkpoints.empty() || n_tokens_start > slot.prompt.checkpoints.back().n_tokens + params_base.checkpoint_min_step);
                     SLT_DBG(slot, "main/do_checkpoint = %s, pos_min = %d, pos_max = %d\n", do_checkpoint ? "yes" : "no", pos_min, pos_max);
 
                     // note: we create the checkpoint before calling llama_decode(), so the current batch is not


### PR DESCRIPTION
## Problem

In agent workflows with `--ctx-checkpoints`, checkpoints are created at ~1K token spacing instead of respecting `checkpoint_min_step` (8K default), causing catastrophic cache invalidation.

### Root Cause

`server-context.cpp:3546` has an OR clause that bypasses `checkpoint_min_step` for "last user message" boundaries:

```cpp
do_checkpoint = do_checkpoint && (
    slot.prompt.checkpoints.empty() ||
    is_last_user_message ||  // ← bypasses min_step entirely
    n_tokens_start > slot.prompt.checkpoints.back().n_tokens + params_base.checkpoint_min_step);
```

In an agent workflow, every completion request is a new "last user message". This means the bypass fires on every turn, creating checkpoints at ~1K spacing regardless of the configured minimum.

### Impact

With 8 checkpoints and ~1K spacing in a 138K context:
- Checkpoint window covers ~9K tokens (**3.8%** of context)
- When a request jumps outside that window (common in multi-step agent tasks), all 8 checkpoints are invalidated at once
- Forces full prompt reprocess: 40K tokens reprocessed in 18 seconds

**Observed checkpoint gaps** (all below 8K `checkpoint_min_step`):
```
74822 → 76021: 1,199 tokens
76021 → 77253: 1,232 tokens
77253 → 78262: 1,009 tokens
78262 → 78751:   489 tokens
78751 → 79155:   404 tokens
```

## Fix

Remove the `is_last_user_message` bypass so `checkpoint_min_step` always applies. User message boundaries still get checkpoints — just not when they're closer than the minimum spacing.

## Testing

- Compiles cleanly with CUDA on x86_64 (no warnings)
- 6-line diff, 2 insertions, 4 deletions