### PR TITLE
fix(ggml-alloc): C/C++ ABI crash - bool return from ggml_backend_buft_is_meta corrupted in C callers with GCC -O3

### DIFF
--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -88,9 +88,9 @@ extern "C" {
     // Backend (meta)
     //
 
-    GGML_API bool ggml_backend_is_meta       (ggml_backend_t backend);
-    GGML_API bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf);
-    GGML_API bool ggml_backend_buft_is_meta  (ggml_backend_buffer_type_t buft);
+    GGML_API int ggml_backend_is_meta       (ggml_backend_t backend);
+    GGML_API int ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf);
+    GGML_API int ggml_backend_buft_is_meta  (ggml_backend_buffer_type_t buft);
 
     GGML_API size_t         ggml_backend_meta_n_backends    (ggml_backend_t meta_backend);
     GGML_API ggml_backend_t ggml_backend_meta_simple_backend(ggml_backend_t meta_backend, size_t index);

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -337,8 +337,8 @@ static const struct ggml_backend_buffer_type_i ggml_backend_meta_buffer_type_ifa
     /* .is_host          = */ ggml_backend_meta_buffer_type_is_host,
 };
 
-bool ggml_backend_buft_is_meta(ggml_backend_buffer_type_t buft) {
-    return buft != nullptr && buft->iface.get_name == ggml_backend_meta_buffer_type_iface.get_name;
+int ggml_backend_buft_is_meta(ggml_backend_buffer_type_t buft) {
+    return (buft != nullptr && buft->iface.get_name == ggml_backend_meta_buffer_type_iface.get_name) ? 1 : 0;
 }
 
 static ggml_backend_buffer_type_t ggml_backend_meta_device_get_buffer_type(ggml_backend_dev_t dev) {
@@ -1488,8 +1488,8 @@ static const ggml_backend_buffer_i ggml_backend_meta_buffer_iface = {
     /* .reset           = */ ggml_backend_meta_buffer_reset,
 };
 
-bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf) {
-    return buf != nullptr && buf->iface.free_buffer == ggml_backend_meta_buffer_iface.free_buffer;
+int ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf) {
+    return (buf != nullptr && buf->iface.free_buffer == ggml_backend_meta_buffer_iface.free_buffer) ? 1 : 0;
 }
 
 static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
@@ -2235,8 +2235,8 @@ static const ggml_backend_i ggml_backend_meta_i = {
     /* .graph_optimize          = */ nullptr,
 };
 
-bool ggml_backend_is_meta(ggml_backend_t backend) {
-    return backend != nullptr && backend->iface.get_name == ggml_backend_meta_i.get_name;
+int ggml_backend_is_meta(ggml_backend_t backend) {
+    return (backend != nullptr && backend->iface.get_name == ggml_backend_meta_i.get_name) ? 1 : 0;
 }
 
 static ggml_backend_t ggml_backend_meta_device_init_backend(ggml_backend_dev_t dev, const char * params) {


### PR DESCRIPTION
## Problem

`ggml_backend_alloc_ctx_tensors_from_buft` in `ggml-alloc.c` (C) calls
`ggml_backend_buft_is_meta` (defined in `ggml-backend-meta.cpp`, C++, returns `bool`).

On x86-64 with GCC -O3, a `bool`-returning C++ function uses `sete al` which only sets
the low 8 bits (AL). The upper 3 bytes of EAX are left with garbage from prior instructions.
When the C caller evaluates the return value, GCC may generate `test eax, eax` (32-bit)
rather than `test al, al` (8-bit). A function that logically returns false (AL = 0x00)
can appear truthy because EAX holds garbage — confirmed value: `0xDCA88D00`.

**Crash observed:**
```
GGML_ASSERT(ggml_backend_buft_is_meta(meta_buft)) -- ggml-backend-meta.cpp:271
```

`ggml_backend_alloc_ctx_tensors_from_buft` (C file) incorrectly took the meta branch
for a plain Vulkan_Host buffer. Inside the C++ meta code the same function evaluated
correctly as false → assert fired.

Reproduced on: Windows, GCC MinGW-w64, -O3, Intel Iris Xe (Vulkan iGPU).
Triggered when `token_embd.weight` falls back to CPU — Vulkan_Host buffer hits this
allocation path.

## Fix

Change the three `is_meta` predicates to return `int` instead of `bool`.
`int` is 4 bytes — the callee fills full EAX with 0 or 1 (C++ `bool`→`int`
conversion zero-extends). C callers always read a clean value regardless of how
the compiler generates the branch.

All call sites use the result in a boolean context (`if`, `!=`, `GGML_ASSERT`),
so `0`/`1` int values are drop-in replacements for `false`/`true` bool values.

## Files changed

- `ggml/src/ggml-backend-impl.h` — declarations: `bool` → `int`
- `ggml/src/ggml-backend-meta.cpp` — definitions: `bool` → `int`, explicit `? 1 : 0`
