### PR TITLE
vulkan: add allreduce function with cross-device CPU proxy and fix Tensor Parallel crash [EXPERIMENTAL]

### DIFF
--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -83,6 +83,9 @@ extern "C" {
     GGML_API ggml_backend_buffer_t ggml_backend_multi_buffer_alloc_buffer(ggml_backend_buffer_t * buffers, size_t n_buffers);
     GGML_API bool                  ggml_backend_buffer_is_multi_buffer(ggml_backend_buffer_t buffer);
     GGML_API void                  ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage);
+    // resolve the physical sub-buffer whose memory range contains addr (NULL if none); sub-buffers have a
+    // usable context/get_base, the multi-buffer wrapper does not, so backends need this to find the real buffer
+    GGML_API ggml_backend_buffer_t ggml_backend_multi_buffer_get_buffer(ggml_backend_buffer_t buffer, const void * addr);
 
     //
     // Backend (meta)

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1193,8 +1193,6 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
         }
         if (t_ij->view_src != nullptr) {
             t_ij->data = (char *) t_ij->view_src->data + t_ij->view_offs;
-            // A view aliases its source's storage and must reference the source's buffer:
-            // simple_buf (bufs[j]) may be a multi-buffer the backend cannot resolve here.
             if (t_ij->view_src->buffer != nullptr) {
                 t_ij->buffer = t_ij->view_src->buffer;
             }

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1196,9 +1196,20 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
             if (t_ij->view_src->buffer != nullptr) {
                 t_ij->buffer = t_ij->view_src->buffer;
             }
-        } else if (simple_buf != nullptr) {
+        } else if (simple_buf != nullptr && !ggml_backend_buffer_is_multi_buffer(simple_buf)) {
+            // single contiguous buffer: mirror the offset. A multi-buffer has no usable base, so leave the
+            // tensor for the gallocr to place (alloc_ctx_tensors assigns each tensor a real sub-buffer).
             t_ij->data = (char *) ggml_backend_buffer_get_base(simple_buf)
                 + size_t(tensor->data) - size_t(ggml_backend_buffer_get_base(tensor->buffer));
+        }
+        // Backends require the physical buffer, not the multi-buffer wrapper (its context is unusable).
+        // Resolve it from the tensor's data address -- works for any tensor, not just views.
+        if (t_ij->buffer != nullptr && t_ij->data != nullptr
+                && ggml_backend_buffer_is_multi_buffer(t_ij->buffer)) {
+            ggml_backend_buffer_t sub = ggml_backend_multi_buffer_get_buffer(t_ij->buffer, t_ij->data);
+            if (sub != nullptr) {
+                t_ij->buffer = sub;
+            }
         }
         t_ij->extra = tensor->extra;
         for (int i = 0; i < GGML_MAX_SRC; i++) {

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1193,6 +1193,11 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
         }
         if (t_ij->view_src != nullptr) {
             t_ij->data = (char *) t_ij->view_src->data + t_ij->view_offs;
+            // A view aliases its source's storage and must reference the source's buffer:
+            // simple_buf (bufs[j]) may be a multi-buffer the backend cannot resolve here.
+            if (t_ij->view_src->buffer != nullptr) {
+                t_ij->buffer = t_ij->view_src->buffer;
+            }
         } else if (simple_buf != nullptr) {
             t_ij->data = (char *) ggml_backend_buffer_get_base(simple_buf)
                 + size_t(tensor->data) - size_t(ggml_backend_buffer_get_base(tensor->buffer));

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -725,6 +725,20 @@ bool ggml_backend_buffer_is_multi_buffer(ggml_backend_buffer_t buffer) {
     return buffer->iface.free_buffer == ggml_backend_multi_buffer_free_buffer;
 }
 
+ggml_backend_buffer_t ggml_backend_multi_buffer_get_buffer(ggml_backend_buffer_t buffer, const void * addr) {
+    GGML_ASSERT(ggml_backend_buffer_is_multi_buffer(buffer));
+    ggml_backend_multi_buffer_context * ctx = (ggml_backend_multi_buffer_context *) buffer->context;
+    for (size_t i = 0; i < ctx->n_buffers; i++) {
+        ggml_backend_buffer_t sub = ctx->buffers[i];
+        const char * base = (const char *) ggml_backend_buffer_get_base(sub);
+        const size_t size = ggml_backend_buffer_get_size(sub);
+        if ((const char *) addr >= base && (const char *) addr < base + size) {
+            return sub;
+        }
+    }
+    return NULL;
+}
+
 void ggml_backend_multi_buffer_set_usage(ggml_backend_buffer_t buffer, enum ggml_backend_buffer_usage usage) {
     GGML_ASSERT(buffer);
     GGML_ASSERT(ggml_backend_buffer_is_multi_buffer(buffer));

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -18371,8 +18371,8 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
 // Ring AllReduce: reduce-scatter then all-gather around a ring, O(n) host traffic vs the pipeline's O(n^2).
 // The output is split into n chunks; each of 2*(n-1) steps a device sends one chunk to its next neighbor's
 // host buffer and pulls the matching chunk from its prev neighbor (accumulating in reduce-scatter, copying
-// in all-gather). tensors[i] is the in-place working buffer. fp32 + native-import only for now (the proof
-// of the algorithm); F16 staging and the proxy bridge are follow-ups. GGML_VK_COMM_RING selects this path.
+// in all-gather). tensors[i] is the in-place working buffer. Supports native peer-import and the CPU-proxy
+// bridge (for RADV/cross-vendor); fp32 staging only for now (F16 is a follow-up). GGML_VK_COMM_RING selects it.
 static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * comm,
                                                 ggml_tensor ** tensors, size_t nbytes) {
     const size_t   n    = comm->backends.size();
@@ -18384,7 +18384,7 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
     const uint64_t round    = comm->ring_round++;
     const size_t   slot_off = (size_t) (round & 1) * 2 * comm->cap; // round-slot holds this round's 2(n-1) chunks
 
-    std::vector<uint64_t> compute_val(n), reduce_val(n), prev_reduce(n), up_base(n);
+    std::vector<uint64_t> compute_val(n), reduce_val(n), prev_reduce(n), up_base(n), pxy_base(n);
     for (size_t i = 0; i < n; i++) {
         prev_reduce[i] = comm->last_reduce[i];
         compute_val[i] = comm->vkctx[i]->comm_prog_val;
@@ -18393,6 +18393,10 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
         comm->last_reduce[i]          = reduce_val[i];
         up_base[i]      = comm->up_val[i];
         comm->up_val[i] += nsteps;
+        if (comm->proxy) {
+            pxy_base[i]       = comm->pxy_val[i];
+            comm->pxy_val[i] += nsteps + 1; // nsteps recv bridges + 1 cross-round WAR bridge
+        }
         uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(comm->prog[i]);
         if (done >= comm->pool_max_val[i]) { ggml_vk_command_pool_cleanup(comm->device[i], comm->cmd_pool[i]); }
         comm->pool_max_val[i] = reduce_val[i];
@@ -18428,7 +18432,15 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
             if (t == 0) {
                 tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
                 if (round >= 2) { // WAR: next device finished reading our send buffer in the round that reused this slot
-                    tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][nextd], prev_reduce[nextd] });
+                    if (comm->proxy) {
+                        const uint64_t pv = pxy_base[i] + 1;
+                        tctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                        std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                        comm->bridge_q[i].push_back({ comm->device[nextd]->device, comm->prog[nextd], prev_reduce[nextd],
+                                                      comm->device[i]->device, comm->pxy[i], pv });
+                    } else {
+                        tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][nextd], prev_reduce[nextd] });
+                    }
                 }
             } else {
                 tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t }); // prev recv updated c_send
@@ -18440,7 +18452,15 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
             tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
 
             ggml_vk_ctx_begin(comm->device[i], cctx);
-            cctx->s->wait_semaphores.push_back({ comm->peer_up[i][prevd], up_base[prevd] + t + 1 });
+            if (comm->proxy) {
+                const uint64_t pv = pxy_base[i] + 2 + t;
+                cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                comm->bridge_q[i].push_back({ comm->device[prevd]->device, comm->up[prevd], up_base[prevd] + t + 1,
+                                              comm->device[i]->device, comm->pxy[i], pv });
+            } else {
+                cctx->s->wait_semaphores.push_back({ comm->peer_up[i][prevd], up_base[prevd] + t + 1 });
+            }
             if (recv_sz) {
                 ggml_vk_buffer_copy_async(cctx, tbc->dev_buffer, 0, comm->host_buf[prevd][i], hoff, recv_sz);
                 ggml_vk_sync_buffers(comm->vkctx[i], cctx);
@@ -18497,7 +18517,7 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
             all_compute = all_compute && (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE);
         }
         if (all_compute) {
-            if (comm->ring && !comm->proxy) { // ring is native-import + fp32 only for now
+            if (comm->ring) { // ring supports native-import and CPU-proxy; fp32 staging only for now
                 return ggml_backend_vk_comm_allreduce_ring(comm, tensors, nbytes);
             }
             return ggml_backend_vk_comm_allreduce_pipeline(comm, tensors, nbytes);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -679,8 +679,6 @@ struct vk_device_struct {
     uint64_t min_imported_host_pointer_alignment;
     bool external_memory_host {};
     bool external_semaphore {};
-    bool external_memory_fd {};
-    bool external_memory_dma_buf {};
     bool fp16;
     bool bf16;
     bool pipeline_robustness;
@@ -5745,10 +5743,6 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->external_memory_host = true;
             } else if (strcmp("VK_KHR_external_semaphore_fd", properties.extensionName) == 0) {
                 device->external_semaphore = true;
-            } else if (strcmp("VK_KHR_external_memory_fd", properties.extensionName) == 0) {
-                device->external_memory_fd = true;
-            } else if (strcmp("VK_EXT_external_memory_dma_buf", properties.extensionName) == 0) {
-                device->external_memory_dma_buf = true;
 #if defined(VK_EXT_shader_64bit_indexing)
             } else if (strcmp("VK_EXT_shader_64bit_indexing", properties.extensionName) == 0) {
                 device->shader_64b_indexing = true;
@@ -6079,13 +6073,6 @@ static vk_device ggml_vk_get_device(size_t idx) {
         if (device->external_semaphore) {
             device_extensions.push_back("VK_KHR_external_semaphore");
             device_extensions.push_back("VK_KHR_external_semaphore_fd");
-        }
-        if (device->external_memory_fd) {
-            device_extensions.push_back("VK_KHR_external_memory");
-            device_extensions.push_back("VK_KHR_external_memory_fd");
-        }
-        if (device->external_memory_dma_buf) {
-            device_extensions.push_back("VK_EXT_external_memory_dma_buf");
         }
 
 #if defined(VK_EXT_shader_64bit_indexing)
@@ -17861,10 +17848,6 @@ struct ggml_backend_vk_comm_context {
     std::vector<uint64_t>                   pool_max_val;
     PFN_vkGetSemaphoreFdKHR                 pGetSemFd  = nullptr;
     PFN_vkImportSemaphoreFdKHR              pImportSemFd = nullptr;
-    bool                                    d2d = false;
-    PFN_vkGetMemoryFdKHR                    pGetMemFd      = nullptr;
-    PFN_vkGetMemoryFdPropertiesKHR         pGetMemFdProps = nullptr;
-    std::vector<vk_buffer>                  d2d_own;
     std::vector<void*>                      host_ptr;
     std::vector<std::vector<vk_buffer>>     host_buf;
     std::vector<ggml_backend_buffer_t>      tmp_buffer;
@@ -17949,96 +17932,6 @@ static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm
     return dst;
 }
 
-static vk_buffer ggml_vk_comm_create_exportable(vk_device & device, size_t size) {
-    vk_buffer buf = std::make_shared<vk_buffer_struct>();
-    buf->size   = size;
-    buf->device = device;
-    buf->ptr    = nullptr;
-    vk::ExternalMemoryBufferCreateInfo ext_bci{ vk::ExternalMemoryHandleTypeFlagBits::eDmaBufEXT };
-    vk::BufferCreateInfo bci{ {}, size,
-        vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst, vk::SharingMode::eExclusive };
-    bci.pNext = &ext_bci;
-    buf->buffer = device->device.createBuffer(bci);
-    vk::MemoryRequirements             mem_req   = device->device.getBufferMemoryRequirements(buf->buffer);
-    vk::PhysicalDeviceMemoryProperties mem_props = device->physical_device.getMemoryProperties();
-    uint32_t mtype = UINT32_MAX;
-    for (uint32_t t = 0; t < mem_props.memoryTypeCount; t++) {
-        if (!(mem_req.memoryTypeBits & (1u << t))) { continue; }
-        if (mem_props.memoryTypes[t].propertyFlags & vk::MemoryPropertyFlagBits::eDeviceLocal) { mtype = t; break; }
-    }
-    if (mtype == UINT32_MAX) { GGML_LOG_WARN("ggml_vulkan: D2D export: no device-local memory type\n"); return {}; }
-    vk::ExportMemoryAllocateInfo emai{ vk::ExternalMemoryHandleTypeFlagBits::eDmaBufEXT };
-    vk::MemoryAllocateInfo       mai{ mem_req.size, mtype };
-    mai.pNext = &emai;
-    try {
-        buf->device_memory = device->device.allocateMemory(mai);
-    } catch (const vk::SystemError & e) {
-        GGML_LOG_WARN("ggml_vulkan: D2D export: allocateMemory(exportable) failed: %s\n", e.what());
-        return {};
-    }
-    buf->memory_property_flags = mem_props.memoryTypes[mtype].propertyFlags;
-    device->device.bindBufferMemory(buf->buffer, buf->device_memory, 0);
-    return buf;
-}
-
-static vk_buffer ggml_vk_comm_import_buffer(ggml_backend_vk_comm_context * comm, vk_device & dst_dev,
-                                            vk_device & src_dev, vk_buffer & src_buf, size_t size) {
-    int fd = -1;
-    VkMemoryGetFdInfoKHR gfi{};
-    gfi.sType      = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
-    gfi.memory     = (VkDeviceMemory) src_buf->device_memory;
-    gfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
-    if (comm->pGetMemFd((VkDevice) src_dev->device, &gfi, &fd) != VK_SUCCESS || fd < 0) {
-        GGML_LOG_WARN("ggml_vulkan: D2D import: vkGetMemoryFdKHR failed (fd=%d)\n", fd);
-        return {};
-    }
-
-    vk_buffer buf = std::make_shared<vk_buffer_struct>();
-    buf->size   = size;
-    buf->device = dst_dev;
-    buf->ptr    = nullptr;
-    vk::ExternalMemoryBufferCreateInfo ext_bci{ vk::ExternalMemoryHandleTypeFlagBits::eDmaBufEXT };
-    vk::BufferCreateInfo bci{ {}, size,
-        vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst, vk::SharingMode::eExclusive };
-    bci.pNext = &ext_bci;
-    buf->buffer = dst_dev->device.createBuffer(bci);
-    vk::MemoryRequirements mem_req = dst_dev->device.getBufferMemoryRequirements(buf->buffer);
-
-    VkMemoryFdPropertiesKHR fdProps{};
-    fdProps.sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR;
-    comm->pGetMemFdProps((VkDevice) dst_dev->device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT, fd, &fdProps);
-
-    vk::PhysicalDeviceMemoryProperties mem_props = dst_dev->physical_device.getMemoryProperties();
-    uint32_t mtype = UINT32_MAX;
-    for (uint32_t t = 0; t < mem_props.memoryTypeCount; t++) {
-        if (!(mem_req.memoryTypeBits  & (1u << t))) { continue; }
-        if (!(fdProps.memoryTypeBits  & (1u << t))) { continue; }
-        mtype = t;
-        if (mem_props.memoryTypes[t].propertyFlags & vk::MemoryPropertyFlagBits::eDeviceLocal) { break; }
-    }
-    if (mtype == UINT32_MAX) {
-        GGML_LOG_WARN("ggml_vulkan: D2D import: no compatible memory type (fdBits=0x%x reqBits=0x%x)\n",
-                      fdProps.memoryTypeBits, mem_req.memoryTypeBits);
-        return {};
-    }
-
-    VkImportMemoryFdInfoKHR imfi{};
-    imfi.sType      = VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR;
-    imfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
-    imfi.fd         = fd;
-    vk::MemoryAllocateInfo mai{ mem_req.size, mtype };
-    mai.pNext = &imfi;
-    try {
-        buf->device_memory = dst_dev->device.allocateMemory(mai);
-    } catch (const vk::SystemError & e) {
-        GGML_LOG_WARN("ggml_vulkan: D2D import: allocateMemory(import) failed: %s\n", e.what());
-        return {};
-    }
-    buf->memory_property_flags = mem_props.memoryTypes[mtype].propertyFlags;
-    dst_dev->device.bindBufferMemory(buf->buffer, buf->device_memory, 0);
-    return buf;
-}
-
 static bool ggml_vk_comm_opaque_fd_supported(ggml_backend_vk_comm_context * comm) {
     const size_t n = comm->device.size();
     uint8_t driver_uuid[VK_UUID_SIZE];
@@ -18087,9 +17980,7 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->host_buf[k].resize(n_backends);
     }
     comm->use_f16 = (getenv("GGML_VK_COMM_FP32") == nullptr);
-    comm->ring    = (getenv("GGML_VK_COMM_RING") != nullptr);
-    comm->d2d     = (getenv("GGML_VK_COMM_D2D") != nullptr);
-    comm->d2d_own.resize(n_backends, nullptr);
+    comm->ring    = (getenv("GGML_VK_COMM_PIPELINE") == nullptr);
     comm->up16_buffer.resize(n_backends, nullptr);
     comm->dn16_buffer.resize(n_backends, nullptr);
     comm->up16_tensor.resize(n_backends, nullptr);
@@ -18102,18 +17993,6 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->pGetSemFd    = (PFN_vkGetSemaphoreFdKHR)    comm->device[0]->device.getProcAddr("vkGetSemaphoreFdKHR");
         comm->pImportSemFd = (PFN_vkImportSemaphoreFdKHR) comm->device[0]->device.getProcAddr("vkImportSemaphoreFdKHR");
         comm->fast = comm->pGetSemFd && comm->pImportSemFd;
-    }
-    if (comm->fast && comm->d2d) {
-        bool dmabuf = true;
-        for (size_t i = 0; i < n_backends; i++) {
-            dmabuf = dmabuf && comm->device[i]->external_memory_fd && comm->device[i]->external_memory_dma_buf;
-        }
-        comm->pGetMemFd      = (PFN_vkGetMemoryFdKHR)           comm->device[0]->device.getProcAddr("vkGetMemoryFdKHR");
-        comm->pGetMemFdProps = (PFN_vkGetMemoryFdPropertiesKHR) comm->device[0]->device.getProcAddr("vkGetMemoryFdPropertiesKHR");
-        comm->d2d = dmabuf && comm->pGetMemFd && comm->pGetMemFdProps;
-        if (!comm->d2d) {
-            GGML_LOG_INFO("ggml_vulkan: comm D2D requested but VK_EXT_external_memory_dma_buf unavailable; using host staging\n");
-        }
     }
     if (comm->fast) {
         comm->prog.resize(n_backends);
@@ -18271,7 +18150,6 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         for (size_t i = 0; i < n; i++) {
             comm->host_buf[k][i].reset();
         }
-        comm->d2d_own[k].reset();
         ggml_vk_comm_aligned_free(comm->host_ptr[k]);
         comm->host_ptr[k] = nullptr;
     }
@@ -18291,46 +18169,15 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
     }
 
     const size_t slotcap = (comm->ring ? 4 : 2) * newcap;
-    if (comm->d2d) {
-        bool ok = true;
-        for (size_t k = 0; k < n && ok; k++) {
-            comm->d2d_own[k] = ggml_vk_comm_create_exportable(comm->device[k], slotcap);
-            if (!comm->d2d_own[k]) { ok = false; break; }
-            comm->host_buf[k][k] = comm->d2d_own[k];
-            for (size_t i = 0; i < n; i++) {
-                if (i == k) {
-                    continue;
-                }
-                comm->host_buf[k][i] = ggml_vk_comm_import_buffer(comm, comm->device[i], comm->device[k],
-                                                                  comm->d2d_own[k], slotcap);
-                if (!comm->host_buf[k][i]) { ok = false; break; }
-            }
+    for (size_t k = 0; k < n; k++) {
+        comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
+        if (!comm->host_ptr[k]) {
+            return false;
         }
-        if (ok) {
-            GGML_LOG_INFO("ggml_vulkan: comm D2D peer buffers active (%zu devices, %zu KiB/slot over PCIe P2P)\n",
-                          n, slotcap / 1024);
-        } else {
-            for (size_t k = 0; k < n; k++) {
-                for (size_t i = 0; i < n; i++) {
-                    comm->host_buf[k][i].reset();
-                }
-                comm->d2d_own[k].reset();
-            }
-            comm->d2d = false;
-            GGML_LOG_WARN("ggml_vulkan: comm D2D peer import unsupported here; falling back to host staging\n");
-        }
-    }
-    if (!comm->d2d) {
-        for (size_t k = 0; k < n; k++) {
-            comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
-            if (!comm->host_ptr[k]) {
+        for (size_t i = 0; i < n; i++) {
+            comm->host_buf[k][i] = ggml_vk_buffer_from_host_ptr(comm->device[i], comm->host_ptr[k], slotcap);
+            if (!comm->host_buf[k][i]) {
                 return false;
-            }
-            for (size_t i = 0; i < n; i++) {
-                comm->host_buf[k][i] = ggml_vk_buffer_from_host_ptr(comm->device[i], comm->host_ptr[k], slotcap);
-                if (!comm->host_buf[k][i]) {
-                    return false;
-                }
             }
         }
     }
@@ -18717,11 +18564,6 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
 static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor ** tensors) {
     ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
     const size_t n = comm->backends.size();
-
-    static const bool off = getenv("GGML_VK_COMM_OFF") != nullptr;
-    if (off) {
-        return false;
-    }
 
     if (!comm->fast || tensors[0]->type != GGML_TYPE_F32) {
         return false;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17906,6 +17906,13 @@ static vk::Semaphore ggml_vk_create_export_timeline(vk_device & device) {
     return device->device.createSemaphore(sci);
 }
 
+static vk::Semaphore ggml_vk_create_plain_timeline(vk_device & device) {
+    vk::SemaphoreTypeCreateInfo stci{ vk::SemaphoreType::eTimeline, 0 };
+    vk::SemaphoreCreateInfo sci{};
+    sci.pNext = &stci;
+    return device->device.createSemaphore(sci);
+}
+
 static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm, vk_device & dst_dev,
                                              vk_device & src_dev, vk::Semaphore src_sem) {
     int fd = -1;
@@ -18002,8 +18009,6 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->xfer_pool_max_val.assign(n_backends, 0);
         comm->ring_ok = true;
         for (size_t i = 0; i < n_backends; i++) {
-            comm->prog[i] = ggml_vk_create_export_timeline(comm->device[i]);
-            comm->up[i]   = ggml_vk_create_export_timeline(comm->device[i]);
             comm->cmd_pool[i].init(comm->device[i], &comm->device[i]->compute_queue);
             comm->cmd_pool_xfer[i].init(comm->device[i], &comm->device[i]->transfer_queue);
             if (comm->device[i]->single_queue ||
@@ -18011,10 +18016,20 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
                 comm->ring_ok = false;
             }
         }
+        // Decide proxy vs native cross-device sync before creating the progress timelines: the proxy path only
+        // signals/reads them locally, so it must not request exportable handles. Some devices (e.g. llvmpipe, or
+        // RADV on older Mesa) cannot create exportable timeline semaphores at all, which would otherwise abort
+        // init here instead of falling back to the proxy.
         comm->proxy = getenv("GGML_VK_COMM_PROXY") != nullptr;
         if (!comm->proxy && !ggml_vk_comm_opaque_fd_supported(comm)) {
             comm->proxy = true;
             GGML_LOG_INFO("ggml_vulkan: cross-device OPAQUE_FD timeline import unsupported; using portable CPU-proxy sync\n");
+        }
+        for (size_t i = 0; i < n_backends; i++) {
+            comm->prog[i] = comm->proxy ? ggml_vk_create_plain_timeline(comm->device[i])
+                                        : ggml_vk_create_export_timeline(comm->device[i]);
+            comm->up[i]   = comm->proxy ? ggml_vk_create_plain_timeline(comm->device[i])
+                                        : ggml_vk_create_export_timeline(comm->device[i]);
         }
         if (!comm->proxy) {
             try {
@@ -18135,11 +18150,28 @@ static void ggml_backend_vk_comm_free(void * comm_ctx) {
 }
 
 static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, size_t nbytes) {
-    if (nbytes <= comm->cap) {
+    // Reuse the current buffers when they fit and are not grossly oversized. We deliberately SHRINK when the
+    // request is much smaller than the current cap (e.g. the prefill->decode transition): the imported external
+    // host buffers are made visible across devices on every timeline-semaphore signal, so an oversized `cap`
+    // left over from a large prefill stalls every small (decode) all-reduce in proportion to its size.
+    constexpr size_t shrink_slack = 4;
+    if (nbytes <= comm->cap && comm->cap <= nbytes * shrink_slack) {
         return true;
     }
     const size_t n      = comm->backends.size();
     const size_t newcap = (nbytes + comm->align - 1) & ~(comm->align - 1);
+
+    // Buffers may still be referenced by the previous (async) all-reduce; wait for it before freeing them.
+    for (size_t i = 0; i < n; i++) {
+        if (comm->last_reduce[i] == 0) {
+            continue;
+        }
+        vk::SemaphoreWaitInfo wi;
+        wi.semaphoreCount = 1;
+        wi.pSemaphores    = &comm->prog[i];
+        wi.pValues        = &comm->last_reduce[i];
+        (void) comm->device[i]->device.waitSemaphores(wi, UINT64_MAX);
+    }
 
     for (size_t k = 0; k < n; k++) {
         for (size_t i = 0; i < n; i++) {
@@ -18349,6 +18381,179 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
     return true;
 }
 
+// Recursive halving/doubling all-reduce for a power-of-two device count. Bandwidth-optimal like the ring but
+// uses 2*log2(n) cross-device steps instead of 2*(n-1), so its latency scales far better for n>=4. The per-device
+// step schedule (peer, send/recv ranges, reduce-vs-copy) is built exactly as in the reference simulation
+// scratchpad/tree_sim.py; the GPU plumbing (F16 host staging, F32 accumulate, timeline-semaphore / CPU-proxy
+// sync) mirrors ggml_backend_vk_comm_allreduce_ring. Opt-in via GGML_VK_COMM_TREE; the ring stays the default.
+// NOTE: only n=2 (and n=2 with forced proxy) is runnable on a 2-GPU box; the multi-step path is exercised by the
+// reference simulation and the n=2 plumbing test, not directly at n>=4.
+static bool ggml_backend_vk_comm_allreduce_tree(ggml_backend_vk_comm_context * comm, ggml_tensor ** tensors) {
+    const size_t  n   = comm->backends.size();
+    const size_t  esz = ggml_type_size(GGML_TYPE_F32);
+    const size_t  xsz = sizeof(uint16_t);
+    const int64_t nel = ggml_nelements(tensors[0]);
+
+    int logn = 0;
+    while (((size_t) 1 << (logn + 1)) <= n) { logn++; }   // n is a power of two (checked by caller)
+    const uint64_t nsteps = 2u * (uint64_t) logn;
+    const uint64_t nprog  = 2u * nsteps;                  // two compute signals (prep-send, reduce) per step
+
+    // Per-step host stride: the largest single send is ceil(nel/2) F16 elements. A distinct offset per step keeps
+    // a step's staged data alive until the peer has read it. Double-buffered by round like the ring.
+    const size_t   stride   = (size_t) ((nel + 1) / 2) * xsz;
+    const uint64_t round    = comm->ring_round++;
+    const size_t   slot_off = (size_t) (round & 1) * 2 * comm->cap;
+
+    // Build each device's schedule, mirroring tree_sim.py (validated for n=2..8).
+    struct step_t { size_t peer; int64_t soff, slen, roff, rlen; bool add; };
+    std::vector<std::vector<step_t>> sched(n);
+    std::vector<std::vector<size_t>> reuse_peers(n);   // distinct peers that read host[i] (for cross-call reuse wait)
+    {
+        std::vector<int64_t> coff(n, 0), clen(n, nel);
+        for (size_t dist = n / 2; dist >= 1; dist /= 2) {              // reduce-scatter (recursive halving)
+            for (size_t i = 0; i < n; i++) {
+                const size_t  p    = i ^ dist;
+                const int64_t off  = coff[i], len = clen[i];
+                const int64_t half = len / 2;
+                step_t st; st.peer = p; st.add = true;
+                if (i < p) { st.soff = off + half; st.slen = len - half; st.roff = off;        st.rlen = half;        coff[i] = off;        clen[i] = half; }
+                else       { st.soff = off;        st.slen = half;       st.roff = off + half; st.rlen = len - half; coff[i] = off + half; clen[i] = len - half; }
+                sched[i].push_back(st);
+            }
+        }
+        for (size_t dist = 1; dist < n; dist *= 2) {                   // all-gather (recursive doubling)
+            std::vector<int64_t> noff(n), nlen(n);
+            for (size_t i = 0; i < n; i++) {
+                const size_t p = i ^ dist;
+                step_t st; st.peer = p; st.add = false;
+                st.soff = coff[i]; st.slen = clen[i];
+                st.roff = coff[p]; st.rlen = clen[p];
+                sched[i].push_back(st);
+                noff[i] = std::min(coff[i], coff[p]);
+                nlen[i] = std::max(coff[i] + clen[i], coff[p] + clen[p]) - noff[i];
+            }
+            coff = noff; clen = nlen;
+        }
+        for (size_t i = 0; i < n; i++) {
+            for (const auto & st : sched[i]) {
+                if (std::find(reuse_peers[i].begin(), reuse_peers[i].end(), st.peer) == reuse_peers[i].end()) {
+                    reuse_peers[i].push_back(st.peer);
+                }
+            }
+        }
+    }
+
+    std::vector<uint64_t> compute_val(n), reduce_val(n), prev_reduce(n), up_base(n), pxy_base(n);
+    for (size_t i = 0; i < n; i++) {
+        prev_reduce[i] = comm->last_reduce[i];
+        compute_val[i] = comm->vkctx[i]->comm_prog_val;
+        reduce_val[i]  = compute_val[i] + nprog;
+        comm->vkctx[i]->comm_prog_val = reduce_val[i];
+        comm->last_reduce[i]          = reduce_val[i];
+        up_base[i]      = comm->up_val[i];
+        comm->up_val[i] += nsteps;
+        if (comm->proxy) {
+            pxy_base[i]       = comm->pxy_val[i];
+            comm->pxy_val[i] += nsteps + (uint64_t) reuse_peers[i].size();
+        }
+        uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(comm->prog[i]);
+        if (done >= comm->pool_max_val[i]) { ggml_vk_command_pool_cleanup(comm->device[i], comm->cmd_pool[i]); }
+        comm->pool_max_val[i] = reduce_val[i];
+        uint64_t xdone = comm->device[i]->device.getSemaphoreCounterValue(comm->up[i]);
+        if (xdone >= comm->xfer_pool_max_val[i]) { ggml_vk_command_pool_cleanup(comm->device[i], comm->cmd_pool_xfer[i]); }
+        comm->xfer_pool_max_val[i] = up_base[i] + nsteps;
+    }
+
+    auto set_view = [](ggml_tensor * tt, ggml_backend_buffer_t buf, char * data, int64_t ne0, size_t es) {
+        tt->ne[0] = ne0; tt->ne[1] = tt->ne[2] = tt->ne[3] = 1;
+        tt->nb[0] = es;  tt->nb[1] = tt->nb[2] = tt->nb[3] = (size_t) ne0 * es;
+        tt->buffer = buf; tt->data = data; tt->view_offs = 0;
+    };
+
+    for (size_t i = 0; i < n; i++) {
+        ggml_backend_vk_buffer_context * ubc = (ggml_backend_vk_buffer_context *) comm->up16_buffer[i]->context;
+        ggml_backend_vk_buffer_context * dbc = (ggml_backend_vk_buffer_context *) comm->dn16_buffer[i]->context;
+        ggml_tensor * up16t = comm->up16_tensor[i];
+        ggml_tensor * dn16t = comm->dn16_tensor[i];
+        ggml_tensor * rview = comm->ring_view[i];
+        char *        ubase = (char *) ggml_backend_buffer_get_base(comm->up16_buffer[i]);
+        char *        dbase = (char *) ggml_backend_buffer_get_base(comm->dn16_buffer[i]);
+        char *        tbase = (char *) tensors[i]->data;
+
+        vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
+        vk_context tctx = ggml_vk_create_temporary_context(comm->cmd_pool_xfer[i]);
+
+        for (uint64_t t = 0; t < nsteps; t++) {
+            const step_t & st  = sched[i][t];
+            const size_t   peer = st.peer;
+            const size_t   hoff = slot_off + (size_t) t * stride;
+
+            // compute-A: copy this step's send range to the F16 staging buffer.
+            ggml_vk_ctx_begin(comm->device[i], cctx);
+            cctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + 2 * t });
+            if (st.slen) {
+                set_view(rview, tensors[i]->buffer,  tbase + (size_t) st.soff * esz, st.slen, esz);
+                set_view(up16t, comm->up16_buffer[i], ubase,                          st.slen, xsz);
+                ggml_vk_cpy(comm->vkctx[i], cctx, rview, up16t);
+            }
+            ggml_vk_ctx_end(cctx);
+            cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + 2 * t + 1 });
+
+            // transfer: stage F16 send to this device's host buffer at the step offset.
+            ggml_vk_ctx_begin(comm->device[i], tctx);
+            tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + 2 * t + 1 });
+            if (t == 0 && round >= 2) {
+                // The round-1-ago call wrote/read the same host slot; ensure those peer reads are done before reuse.
+                for (size_t pi = 0; pi < reuse_peers[i].size(); pi++) {
+                    const size_t rp = reuse_peers[i][pi];
+                    if (comm->proxy) {
+                        const uint64_t pv = pxy_base[i] + 1 + pi;
+                        tctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                        std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                        comm->bridge_q[i].push_back({ comm->device[rp]->device, comm->prog[rp], prev_reduce[rp],
+                                                      comm->device[i]->device, comm->pxy[i], pv });
+                    } else {
+                        tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][rp], prev_reduce[rp] });
+                    }
+                }
+            }
+            if (st.slen) {
+                ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], hoff, ubc->dev_buffer, 0, (size_t) st.slen * xsz);
+            }
+            ggml_vk_ctx_end(tctx);
+            tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
+
+            // compute-B: wait our own + the peer's transfer, read the peer's staged data, reduce/copy it in.
+            ggml_vk_ctx_begin(comm->device[i], cctx);
+            cctx->s->wait_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
+            if (comm->proxy) {
+                const uint64_t pv = pxy_base[i] + (uint64_t) reuse_peers[i].size() + 1 + t;
+                cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                comm->bridge_q[i].push_back({ comm->device[peer]->device, comm->up[peer], up_base[peer] + t + 1,
+                                              comm->device[i]->device, comm->pxy[i], pv });
+            } else {
+                cctx->s->wait_semaphores.push_back({ comm->peer_up[i][peer], up_base[peer] + t + 1 });
+            }
+            if (st.rlen) {
+                ggml_vk_buffer_copy_async(cctx, dbc->dev_buffer, 0, comm->host_buf[peer][i], hoff, (size_t) st.rlen * xsz);
+                ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+                set_view(dn16t, comm->dn16_buffer[i], dbase,                           st.rlen, xsz);
+                set_view(rview, tensors[i]->buffer,   tbase + (size_t) st.roff * esz,  st.rlen, esz);
+                if (st.add) { ggml_vk_add(comm->vkctx[i], cctx, rview, dn16t, rview); }
+                else        { ggml_vk_cpy(comm->vkctx[i], cctx, dn16t, rview); }
+                ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+            }
+            ggml_vk_ctx_end(cctx);
+            cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + 2 * t + 2 });
+        }
+        ggml_vk_submit(tctx, {});
+        ggml_vk_submit(cctx, {});
+    }
+    return true;
+}
+
 static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor ** tensors) {
     ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
     const size_t n = comm->backends.size();
@@ -18377,6 +18582,12 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
             all_compute = all_compute && (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE);
         }
         if (all_compute) {
+            // Opt-in recursive halving/doubling for power-of-two device counts (fewer cross-device steps than the
+            // ring at n>=4); the ring remains the default and handles non-power-of-two counts.
+            static const bool use_tree = getenv("GGML_VK_COMM_TREE") != nullptr;
+            if (use_tree && (n & (n - 1)) == 0) {
+                return ggml_backend_vk_comm_allreduce_tree(comm, tensors);
+            }
             return ggml_backend_vk_comm_allreduce_ring(comm, tensors);
         }
     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17853,17 +17853,14 @@ struct ggml_backend_vk_comm_context {
     std::vector<ggml_backend_buffer_t>      tmp_buffer;
     std::vector<ggml_tensor*>               tmp_tensor;
     ggml_context *                          tctx = nullptr;
-    bool                                    pipeline_ok = false;
+    bool                                    ring_ok = false;
     std::vector<vk::Semaphore>              up;
     std::vector<std::vector<vk::Semaphore>> peer_up;
     std::vector<uint64_t>                   up_val;
     std::vector<vk_command_pool>            cmd_pool_xfer;
     std::vector<uint64_t>                   xfer_pool_max_val;
-    uint64_t                                pipe_round = 0;
-    bool                                    ring = false;
     uint64_t                                ring_round = 0;
     std::vector<ggml_tensor*>               ring_view;
-    bool                                    use_f16 = false;
     std::vector<ggml_backend_buffer_t>      up16_buffer;
     std::vector<ggml_backend_buffer_t>      dn16_buffer;
     std::vector<ggml_tensor*>               up16_tensor;
@@ -17979,8 +17976,6 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     for (size_t k = 0; k < n_backends; k++) {
         comm->host_buf[k].resize(n_backends);
     }
-    comm->use_f16 = (getenv("GGML_VK_COMM_FP32") == nullptr);
-    comm->ring    = (getenv("GGML_VK_COMM_PIPELINE") == nullptr);
     comm->up16_buffer.resize(n_backends, nullptr);
     comm->dn16_buffer.resize(n_backends, nullptr);
     comm->up16_tensor.resize(n_backends, nullptr);
@@ -18005,7 +18000,7 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->up_val.assign(n_backends, 0);
         comm->cmd_pool_xfer.resize(n_backends);
         comm->xfer_pool_max_val.assign(n_backends, 0);
-        comm->pipeline_ok = true;
+        comm->ring_ok = true;
         for (size_t i = 0; i < n_backends; i++) {
             comm->prog[i] = ggml_vk_create_export_timeline(comm->device[i]);
             comm->up[i]   = ggml_vk_create_export_timeline(comm->device[i]);
@@ -18013,7 +18008,7 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
             comm->cmd_pool_xfer[i].init(comm->device[i], &comm->device[i]->transfer_queue);
             if (comm->device[i]->single_queue ||
                 comm->device[i]->transfer_queue.queue == comm->device[i]->compute_queue.queue) {
-                comm->pipeline_ok = false;
+                comm->ring_ok = false;
             }
         }
         comm->proxy = getenv("GGML_VK_COMM_PROXY") != nullptr;
@@ -18168,7 +18163,7 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         }
     }
 
-    const size_t slotcap = (comm->ring ? 4 : 2) * newcap;
+    const size_t slotcap = 4 * newcap;
     for (size_t k = 0; k < n; k++) {
         comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
         if (!comm->host_ptr[k]) {
@@ -18215,159 +18210,15 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
     return true;
 }
 
-static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context * comm,
-                                                    ggml_tensor ** tensors, size_t nbytes) {
-    const size_t n = comm->backends.size();
-
-    constexpr size_t chunk_target = 4u << 20;
-    constexpr int    kmax         = 4;
-    const bool   f16    = comm->use_f16;
-    const size_t xbytes = f16 ? (nbytes / 2) : nbytes;
-    int K = (int) ((xbytes + chunk_target - 1) / chunk_target);
-    K = std::max(2, std::min(K, kmax));
-    size_t chunk = (xbytes + K - 1) / K;
-    chunk = (chunk + 15) & ~((size_t) 15);
-    K = (int) ((xbytes + chunk - 1) / chunk);
-
-    const int    slot     = (int) (comm->pipe_round & 1);
-    const size_t slot_off = (size_t) slot * comm->cap;
-    comm->pipe_round++;
-
-    std::vector<uint64_t> compute_val(n), cast_val(n), reduce_val(n), up_base(n), pxy_base(n);
-    for (size_t i = 0; i < n; i++) {
-        compute_val[i] = comm->vkctx[i]->comm_prog_val;
-        cast_val[i]    = compute_val[i] + 1;
-        reduce_val[i]  = compute_val[i] + (f16 ? 2 : 1);
-        comm->vkctx[i]->comm_prog_val = reduce_val[i];
-        comm->last_reduce[i]          = reduce_val[i];
-        up_base[i]                    = comm->up_val[i];
-        comm->up_val[i]              += (uint64_t) K;
-        if (comm->proxy) {
-            pxy_base[i]               = comm->pxy_val[i];
-            comm->pxy_val[i]         += (uint64_t) (n - 1) * K;
-        }
-    }
-
-    auto recycle = [&](size_t i, vk_command_pool & pool, vk::Semaphore sem, uint64_t & pool_max, uint64_t target) {
-        uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(sem);
-        if (done < pool_max && pool.buffers_in_use() >= 256) {
-            vk::SemaphoreWaitInfo wi;
-            wi.semaphoreCount = 1;
-            wi.pSemaphores    = &sem;
-            wi.pValues        = &pool_max;
-            (void) comm->device[i]->device.waitSemaphores(wi, UINT64_MAX);
-            done = pool_max;
-        }
-        if (done >= pool_max) {
-            ggml_vk_command_pool_cleanup(comm->device[i], pool);
-        }
-        pool_max = target;
-    };
-    for (size_t i = 0; i < n; i++) {
-        recycle(i, comm->cmd_pool[i],      comm->prog[i], comm->pool_max_val[i],      reduce_val[i]);
-        recycle(i, comm->cmd_pool_xfer[i], comm->up[i],   comm->xfer_pool_max_val[i], up_base[i] + (uint64_t) K);
-    }
-
-    for (size_t i = 0; i < n; i++) {
-        ggml_backend_vk_buffer_context * bc   = (ggml_backend_vk_buffer_context *) tensors[i]->buffer->context;
-        ggml_backend_vk_buffer_context * tbc  = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
-        ggml_backend_vk_buffer_context * upbc = (ggml_backend_vk_buffer_context *) comm->up16_buffer[i]->context;
-        ggml_backend_vk_buffer_context * dnbc = (ggml_backend_vk_buffer_context *) comm->dn16_buffer[i]->context;
-        const size_t src_off = vk_tensor_offset(tensors[i]) + tensors[i]->view_offs;
-
-        if (f16) {
-            for (ggml_tensor * t : { comm->up16_tensor[i], comm->dn16_tensor[i] }) {
-                for (int d = 0; d < GGML_MAX_DIMS; d++) { t->ne[d] = tensors[i]->ne[d]; }
-                t->nb[0] = ggml_type_size(GGML_TYPE_F16);
-                for (int d = 1; d < GGML_MAX_DIMS; d++) { t->nb[d] = t->nb[d - 1] * t->ne[d - 1]; }
-            }
-        }
-
-        vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
-
-        if (f16) {
-            ggml_vk_ctx_begin(comm->device[i], cctx);
-            cctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
-            cctx->s->wait_semaphores.push_back({ comm->up[i],   up_base[i] });
-            ggml_vk_cpy(comm->vkctx[i], cctx, tensors[i], comm->up16_tensor[i]);
-            ggml_vk_ctx_end(cctx);
-            cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], cast_val[i] });
-        }
-
-        const uint64_t up_ready    = f16 ? cast_val[i] : compute_val[i];
-        vk_buffer &    up_src       = f16 ? upbc->dev_buffer : bc->dev_buffer;
-        const size_t   up_src_off   = f16 ? 0 : src_off;
-        vk_context tctx = ggml_vk_create_temporary_context(comm->cmd_pool_xfer[i]);
-        for (int cI = 0; cI < K; cI++) {
-            const size_t off = (size_t) cI * chunk;
-            const size_t sz  = std::min(chunk, xbytes - off);
-            ggml_vk_ctx_begin(comm->device[i], tctx);
-            if (cI == 0) {
-                tctx->s->wait_semaphores.push_back({ comm->prog[i], up_ready });
-            }
-            ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], slot_off + off, up_src, up_src_off + off, sz);
-            ggml_vk_ctx_end(tctx);
-            tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + (uint64_t) cI + 1 });
-        }
-        ggml_vk_submit(tctx, {});
-
-        ggml_tensor * tmp = comm->tmp_tensor[i];
-        for (int d = 0; d < GGML_MAX_DIMS; d++) {
-            tmp->ne[d] = tensors[i]->ne[d];
-        }
-        tmp->nb[0] = ggml_type_size(GGML_TYPE_F32);
-        for (int d = 1; d < GGML_MAX_DIMS; d++) {
-            tmp->nb[d] = tmp->nb[d - 1] * tmp->ne[d - 1];
-        }
-        vk_buffer &    dn_dst      = f16 ? dnbc->dev_buffer : tbc->dev_buffer;
-        ggml_tensor *  add_src1    = f16 ? comm->dn16_tensor[i] : tmp;
-        for (size_t k = 0; k < n; k++) {
-            if (k == i) {
-                continue;
-            }
-            const size_t p = (k < i) ? k : k - 1;
-            for (int cI = 0; cI < K; cI++) {
-                const size_t off = (size_t) cI * chunk;
-                const size_t sz  = std::min(chunk, xbytes - off);
-                ggml_vk_ctx_begin(comm->device[i], cctx);
-                if (comm->proxy) {
-                    const uint64_t pv = pxy_base[i] + (uint64_t) p * K + (uint64_t) cI + 1;
-                    cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
-                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
-                    comm->bridge_q[i].push_back({ comm->device[k]->device, comm->up[k], up_base[k] + (uint64_t) cI + 1,
-                                                  comm->device[i]->device, comm->pxy[i], pv });
-                } else {
-                    cctx->s->wait_semaphores.push_back({ comm->peer_up[i][k], up_base[k] + (uint64_t) cI + 1 });
-                }
-                ggml_vk_buffer_copy_async(cctx, dn_dst, off, comm->host_buf[k][i], slot_off + off, sz);
-                ggml_vk_ctx_end(cctx);
-            }
-            ggml_vk_ctx_begin(comm->device[i], cctx);
-            if (!f16) {
-                cctx->s->wait_semaphores.push_back({ comm->up[i], up_base[i] + (uint64_t) K });
-            }
-            ggml_vk_sync_buffers(comm->vkctx[i], cctx);
-            ggml_vk_add(comm->vkctx[i], cctx, tensors[i], add_src1, tensors[i]);
-            ggml_vk_sync_buffers(comm->vkctx[i], cctx);
-            ggml_vk_ctx_end(cctx);
-        }
-        cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], reduce_val[i] });
-        ggml_vk_submit(cctx, {});
-    }
-    return true;
-}
-
 static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * comm,
-                                                ggml_tensor ** tensors, size_t nbytes) {
+                                                ggml_tensor ** tensors) {
     const size_t   n    = comm->backends.size();
-    const bool     f16  = comm->use_f16;
     const size_t   esz  = ggml_type_size(GGML_TYPE_F32);
-    const size_t   xsz  = f16 ? sizeof(uint16_t) : esz;
+    const size_t   xsz  = sizeof(uint16_t);
     const int64_t  nel  = ggml_nelements(tensors[0]);
     const int64_t  cels = (nel + (int64_t) n - 1) / (int64_t) n;
-    const size_t   xcsz = (size_t) cels * xsz;
     const uint64_t nsteps = 2 * (uint64_t) (n - 1);
-    const uint64_t nprog  = nsteps + (f16 ? 1 : 0);
+    const uint64_t nprog  = nsteps + 1;
 
     const uint64_t round    = comm->ring_round++;
     const size_t   slot_off = (size_t) (round & 1) * 2 * comm->cap;
@@ -18412,7 +18263,7 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
             tt->buffer = buf; tt->data = data; tt->view_offs = 0;
         };
 
-        if (f16) {
+        {
             ggml_backend_vk_buffer_context * ubc = (ggml_backend_vk_buffer_context *) comm->up16_buffer[i]->context;
             ggml_backend_vk_buffer_context * dbc = (ggml_backend_vk_buffer_context *) comm->dn16_buffer[i]->context;
             ggml_tensor * up16t = comm->up16_tensor[i];
@@ -18491,69 +18342,6 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
                 ggml_vk_ctx_end(cctx);
                 cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 2 });
             }
-        } else {
-            ggml_backend_vk_buffer_context * bc  = (ggml_backend_vk_buffer_context *) tensors[i]->buffer->context;
-            ggml_backend_vk_buffer_context * tbc = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
-            const size_t  base_off = vk_tensor_offset(tensors[i]) + tensors[i]->view_offs;
-            ggml_tensor * rtmp     = comm->tmp_tensor[i];
-            char *        tmpbase  = (char *) ggml_backend_buffer_get_base(comm->tmp_buffer[i]);
-
-            for (uint64_t t = 0; t < nsteps; t++) {
-                const bool     rs = (t < (uint64_t) (n - 1));
-                const size_t   s  = (size_t) (rs ? t : t - (n - 1));
-                const size_t   c_send = rs ? (i + n - s) % n : (i + n + 1 - s) % n;
-                const size_t   c_recv = rs ? (i + n - s - 1) % n : (i + n - s) % n;
-                const size_t   send_off = c_send * xcsz, recv_off = c_recv * xcsz;
-                const size_t   send_sz = send_off >= nbytes ? 0 : std::min(xcsz, nbytes - send_off);
-                const size_t   recv_sz = recv_off >= nbytes ? 0 : std::min(xcsz, nbytes - recv_off);
-                const size_t   hoff = slot_off + (size_t) t * xcsz;
-
-                ggml_vk_ctx_begin(comm->device[i], tctx);
-                if (t == 0) {
-                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
-                    if (round >= 2) {
-                        if (comm->proxy) {
-                            const uint64_t pv = pxy_base[i] + 1;
-                            tctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
-                            std::lock_guard<std::mutex> lk(comm->bridge_mtx);
-                            comm->bridge_q[i].push_back({ comm->device[nextd]->device, comm->prog[nextd], prev_reduce[nextd],
-                                                          comm->device[i]->device, comm->pxy[i], pv });
-                        } else {
-                            tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][nextd], prev_reduce[nextd] });
-                        }
-                    }
-                } else {
-                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t });
-                }
-                if (send_sz) {
-                    ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], hoff, bc->dev_buffer, base_off + send_off, send_sz);
-                }
-                ggml_vk_ctx_end(tctx);
-                tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
-
-                ggml_vk_ctx_begin(comm->device[i], cctx);
-                if (comm->proxy) {
-                    const uint64_t pv = pxy_base[i] + 2 + t;
-                    cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
-                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
-                    comm->bridge_q[i].push_back({ comm->device[prevd]->device, comm->up[prevd], up_base[prevd] + t + 1,
-                                                  comm->device[i]->device, comm->pxy[i], pv });
-                } else {
-                    cctx->s->wait_semaphores.push_back({ comm->peer_up[i][prevd], up_base[prevd] + t + 1 });
-                }
-                if (recv_sz) {
-                    ggml_vk_buffer_copy_async(cctx, tbc->dev_buffer, 0, comm->host_buf[prevd][i], hoff, recv_sz);
-                    ggml_vk_sync_buffers(comm->vkctx[i], cctx);
-                    const int64_t rc = (int64_t) (recv_sz / esz);
-                    set_view(rtmp, comm->tmp_buffer[i], tmpbase,                                 rc, esz);
-                    set_view(rview, tensors[i]->buffer, tbase + recv_off,                        rc, esz);
-                    if (rs) { ggml_vk_add(comm->vkctx[i], cctx, rview, rtmp, rview); }
-                    else    { ggml_vk_cpy(comm->vkctx[i], cctx, rtmp, rview); }
-                    ggml_vk_sync_buffers(comm->vkctx[i], cctx);
-                }
-                ggml_vk_ctx_end(cctx);
-                cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 1 });
-            }
         }
         ggml_vk_submit(tctx, {});
         ggml_vk_submit(cctx, {});
@@ -18582,17 +18370,14 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         return false;
     }
 
-    constexpr size_t pipeline_min = 2u << 20;
-    if (comm->pipeline_ok && n >= 2 && nbytes >= pipeline_min) {
+    constexpr size_t ring_min = 2u << 20;
+    if (comm->ring_ok && n >= 2 && nbytes >= ring_min) {
         bool all_compute = true;
         for (size_t i = 0; i < n; i++) {
             all_compute = all_compute && (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE);
         }
         if (all_compute) {
-            if (comm->ring) {
-                return ggml_backend_vk_comm_allreduce_ring(comm, tensors, nbytes);
-            }
-            return ggml_backend_vk_comm_allreduce_pipeline(comm, tensors, nbytes);
+            return ggml_backend_vk_comm_allreduce_ring(comm, tensors);
         }
     }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -676,6 +676,7 @@ struct vk_device_struct {
     uint64_t suballocation_block_size;
     uint64_t min_imported_host_pointer_alignment;
     bool external_memory_host {};
+    bool external_semaphore {};
     bool fp16;
     bool bf16;
     bool pipeline_robustness;
@@ -2077,6 +2078,13 @@ struct ggml_backend_vk_context {
     std::string name;
 
     vk_device device;
+
+    // Tensor-parallel collective (comm) chains the cross-device AllReduce into this device's
+    // compute queue via a monotonic timeline semaphore, so per-layer reductions are ordered on
+    // the GPU instead of by CPU barriers. Set up by ggml_backend_vk_comm_init while TP is active.
+    bool         comm_active = false;
+    vk::Semaphore comm_prog_sem = VK_NULL_HANDLE;
+    uint64_t     comm_prog_val  = 0;
 
     size_t semaphore_idx, event_idx;
     ggml_vk_garbage_collector gc;
@@ -5734,6 +5742,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->memory_priority = true;
             } else if (strcmp("VK_EXT_external_memory_host", properties.extensionName) == 0) {
                 device->external_memory_host = true;
+            } else if (strcmp("VK_KHR_external_semaphore_fd", properties.extensionName) == 0) {
+                device->external_semaphore = true;
 #if defined(VK_EXT_shader_64bit_indexing)
             } else if (strcmp("VK_EXT_shader_64bit_indexing", properties.extensionName) == 0) {
                 device->shader_64b_indexing = true;
@@ -6060,6 +6070,10 @@ static vk_device ggml_vk_get_device(size_t idx) {
 
         if (device->external_memory_host) {
             device_extensions.push_back("VK_EXT_external_memory_host");
+        }
+        if (device->external_semaphore) {
+            device_extensions.push_back("VK_KHR_external_semaphore");
+            device_extensions.push_back("VK_KHR_external_semaphore_fd");
         }
 
 #if defined(VK_EXT_shader_64bit_indexing)
@@ -14877,6 +14891,13 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
     if (submit || last_node) {
         ggml_vk_ctx_end(compute_ctx);
 
+        // Tensor parallel: signal this subgraph's completion on the device progress timeline so
+        // the cross-device AllReduce can chain after it on the GPU (see ggml_backend_vk_comm_*).
+        if (last_node && ctx->comm_active && !compute_ctx->seqs.empty()) {
+            ctx->comm_prog_val++;
+            compute_ctx->seqs.back().back().signal_semaphores.push_back({ ctx->comm_prog_sem, ctx->comm_prog_val });
+        }
+
         // TODO probably it'd be better to pass a exit_node flag to ggml_vk_compute_forward
         if (last_node) {
             compute_ctx->exit_tensor_idx = node_idx_begin;
@@ -15472,9 +15493,17 @@ static bool ggml_backend_vk_cpy_tensor_async(ggml_backend_t backend_src, ggml_ba
     if (ggml_backend_buffer_is_vk(src->buffer)) {
         ggml_backend_vk_buffer_context * src_buf_ctx = (ggml_backend_vk_buffer_context *)src->buffer->context;
 
-        // Async copy only works within the same device
+        // Different devices have no peer-to-peer path, so stage through host memory.
+        // Flush the source backend so its data is ready, then run the blocking staged
+        // copy here and return true. This skips the scheduler's extra full synchronize
+        // of the destination backend (ggml_vk_buffer_copy already blocks until the write
+        // to the destination lands).
         if (src_buf_ctx->dev_buffer->device != dst_buf->device) {
-            return false;
+            ggml_backend_synchronize(backend_src);
+            ggml_vk_buffer_copy(dst_buf, vk_tensor_offset(dst) + dst->view_offs,
+                                src_buf_ctx->dev_buffer, vk_tensor_offset(src) + src->view_offs,
+                                ggml_nbytes(src));
+            return true;
         }
 
         vk_context compute_ctx = ggml_vk_get_compute_ctx(ctx);
@@ -16185,6 +16214,13 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         // initialize partial sums to zero.
         ggml_vk_buffer_memset_async(compute_ctx, ctx->prealloc_add_rms_partials, 0, 0, ctx->prealloc_size_add_rms_partials);
         ggml_vk_sync_buffers(ctx, compute_ctx);
+    }
+
+    // Tensor parallel: make this subgraph's compute wait on the previous layer's reduction, ordered
+    // on the GPU via the device progress timeline instead of a CPU barrier.
+    if (ctx->comm_active) {
+        compute_ctx = ggml_vk_get_compute_ctx(ctx);
+        compute_ctx->s->wait_semaphores.push_back({ ctx->comm_prog_sem, ctx->comm_prog_val });
     }
 
     // Submit after enough work has accumulated, to overlap CPU cmdbuffer generation with GPU execution.
@@ -17803,11 +17839,641 @@ static ggml_backend_dev_t ggml_backend_vk_reg_get_device(ggml_backend_reg_t reg,
     return devices[device];
 }
 
+// ---------------------------------------------------------------------------
+// Cross-device collective (AllReduce) for tensor parallelism (SPLIT_MODE_TENSOR).
+// The meta backend discovers these via get_proc_address and prefers them over its
+// generic host-staged butterfly fallback.
+// ---------------------------------------------------------------------------
+struct ggml_backend_vk_comm_context {
+    std::vector<ggml_backend_t>             backends;
+    std::vector<ggml_backend_vk_context*>   vkctx;
+    std::vector<vk_device>                  device;
+    size_t                                  align = 4096;
+    size_t                                  cap   = 0;
+    bool                                    fast  = false;
+    // Per device: an exportable monotonic timeline ("progress") semaphore. graph_compute and the
+    // gather/reduce steps wait the previous value and signal the next, so the per-layer AllReduce is
+    // ordered entirely on the GPU. prog[i] is also published in vkctx[i]->comm_prog_sem.
+    std::vector<vk::Semaphore>              prog;          // prog[i] lives on device i
+    std::vector<std::vector<vk::Semaphore>> peer_prog;     // peer_prog[i][j] = device i's import of prog[j]
+    std::vector<uint64_t>                   last_reduce;   // last reduce value signalled, per device
+    // Dedicated command pool per device; its buffers are recycled (not leaked into the shared queue
+    // pool) once the GPU has caught up, tracked by the highest reduce value recorded into it.
+    std::vector<vk_command_pool>            cmd_pool;
+    std::vector<uint64_t>                   pool_max_val;
+    PFN_vkGetSemaphoreFdKHR                 pGetSemFd  = nullptr;
+    PFN_vkImportSemaphoreFdKHR              pImportSemFd = nullptr;
+    // host_ptr[k]: shared CPU staging holding device k's gathered slice, imported on every device.
+    std::vector<void*>                      host_ptr;
+    std::vector<std::vector<vk_buffer>>     host_buf;      // host_buf[k][i] = device i's import of host_ptr[k]
+    std::vector<ggml_backend_buffer_t>      tmp_buffer;    // device-local scratch per device (peer data for the add)
+    std::vector<ggml_tensor*>               tmp_tensor;
+    ggml_context *                          tctx = nullptr;
+    // Chunked full-duplex pipeline (large tensors only): split each slice into chunks, stream the
+    // uploads (this device's slice -> host) on the dedicated TRANSFER queue while the COMPUTE queue
+    // pulls the peer's already-uploaded chunks back. Upload and download then run concurrently over
+    // the full-duplex PCIe link (~T instead of ~2T). up[i] is an exportable per-chunk progress
+    // timeline so the peer's download can wait on individual chunks; cmd_pool_xfer[i] feeds the
+    // transfer queue. pipeline_ok requires a transfer queue distinct from the compute queue.
+    bool                                    pipeline_ok = false;
+    std::vector<vk::Semaphore>              up;            // up[i]: exportable upload-progress timeline on device i
+    std::vector<std::vector<vk::Semaphore>> peer_up;       // peer_up[i][j] = device i's import of up[j]
+    std::vector<uint64_t>                   up_val;        // running upload-chunk counter, per device
+    std::vector<vk_command_pool>            cmd_pool_xfer; // dedicated transfer-queue pool per device
+    std::vector<uint64_t>                   xfer_pool_max_val;
+    uint64_t                                pipe_round = 0; // pipeline allreduce counter; its parity picks the host slot
+    // F16 staging (the lever NCCL uses -- bf16_RING_LL): cast each fp32 partial to F16 on-device before
+    // the host transfer, so only half the bytes cross the bandwidth-bound PCIe link. up16 holds the cast
+    // partial (upload source); dn16 receives the peer's F16 slice (then added straight into the fp32
+    // result via the mixed-type add pipeline). Pipeline path only; the single-shot/TG path stays fp32.
+    bool                                    use_f16 = false;
+    std::vector<ggml_backend_buffer_t>      up16_buffer;
+    std::vector<ggml_backend_buffer_t>      dn16_buffer;
+    std::vector<ggml_tensor*>               up16_tensor;
+    std::vector<ggml_tensor*>               dn16_tensor;
+};
+
+static vk::Semaphore ggml_vk_create_export_timeline(vk_device & device) {
+    vk::ExportSemaphoreCreateInfo esci{ vk::ExternalSemaphoreHandleTypeFlagBits::eOpaqueFd };
+    vk::SemaphoreTypeCreateInfo   stci{ vk::SemaphoreType::eTimeline, 0 };
+    stci.pNext = &esci;
+    vk::SemaphoreCreateInfo sci{};
+    sci.pNext = &stci;
+    return device->device.createSemaphore(sci);
+}
+
+// Export src_sem from src_dev via OPAQUE_FD and import it as a fresh timeline on dst_dev, so dst_dev's
+// queues can wait on src_dev's progress. A new fd is taken per import (the fd is consumed by import).
+static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm, vk_device & dst_dev,
+                                             vk_device & src_dev, vk::Semaphore src_sem) {
+    int fd = -1;
+    VkSemaphoreGetFdInfoKHR gi{};
+    gi.sType      = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
+    gi.semaphore  = src_sem;
+    gi.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+    comm->pGetSemFd((VkDevice) src_dev->device, &gi, &fd);
+
+    vk::SemaphoreTypeCreateInfo stci{ vk::SemaphoreType::eTimeline, 0 };
+    vk::SemaphoreCreateInfo sci{};
+    sci.pNext = &stci;
+    vk::Semaphore dst = dst_dev->device.createSemaphore(sci);
+
+    VkImportSemaphoreFdInfoKHR isi{};
+    isi.sType      = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+    isi.semaphore  = dst;
+    isi.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+    isi.fd         = fd;
+    comm->pImportSemFd((VkDevice) dst_dev->device, &isi);
+    return dst;
+}
+
+static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_backends) {
+    ggml_backend_vk_comm_context * comm = new ggml_backend_vk_comm_context;
+    comm->backends.assign(backends, backends + n_backends);
+    comm->vkctx.resize(n_backends);
+    comm->device.resize(n_backends);
+    bool ok = (n_backends == 2);
+    for (size_t i = 0; i < n_backends; i++) {
+        comm->vkctx[i]  = (ggml_backend_vk_context *) backends[i]->context;
+        comm->device[i] = comm->vkctx[i]->device;
+        ok = ok && comm->device[i]->external_memory_host && comm->device[i]->external_semaphore;
+        comm->align = std::max(comm->align, (size_t) comm->device[i]->min_imported_host_pointer_alignment);
+    }
+    // The GPU-pipelined path stages through host memory shared (imported) across all devices, reduces
+    // on the GPU, and chains everything via exported timeline semaphores so there are no CPU barriers.
+    // It needs VK_EXT_external_memory_host + VK_KHR_external_semaphore_fd on every device.
+    comm->fast = ok;
+    comm->host_ptr.resize(n_backends, nullptr);
+    comm->host_buf.resize(n_backends);
+    comm->tmp_buffer.resize(n_backends, nullptr);
+    comm->tmp_tensor.resize(n_backends, nullptr);
+    for (size_t k = 0; k < n_backends; k++) {
+        comm->host_buf[k].resize(n_backends);
+    }
+    // F16 staging halves the host transfer (default on; GGML_VK_COMM_FP32 forces the old fp32 path).
+    comm->use_f16 = (getenv("GGML_VK_COMM_FP32") == nullptr);
+    comm->up16_buffer.resize(n_backends, nullptr);
+    comm->dn16_buffer.resize(n_backends, nullptr);
+    comm->up16_tensor.resize(n_backends, nullptr);
+    comm->dn16_tensor.resize(n_backends, nullptr);
+    const ggml_init_params ip = { ggml_tensor_overhead() * (n_backends + 8), nullptr, true };
+    comm->tctx = ggml_init(ip);
+
+    if (comm->fast) {
+        comm->pGetSemFd    = (PFN_vkGetSemaphoreFdKHR)    comm->device[0]->device.getProcAddr("vkGetSemaphoreFdKHR");
+        comm->pImportSemFd = (PFN_vkImportSemaphoreFdKHR) comm->device[0]->device.getProcAddr("vkImportSemaphoreFdKHR");
+        comm->fast = comm->pGetSemFd && comm->pImportSemFd;
+    }
+    if (comm->fast) {
+        comm->prog.resize(n_backends);
+        comm->peer_prog.assign(n_backends, std::vector<vk::Semaphore>(n_backends));
+        comm->last_reduce.assign(n_backends, 0);
+        comm->cmd_pool.resize(n_backends);
+        comm->pool_max_val.assign(n_backends, 0);
+        comm->up.resize(n_backends);
+        comm->peer_up.assign(n_backends, std::vector<vk::Semaphore>(n_backends));
+        comm->up_val.assign(n_backends, 0);
+        comm->cmd_pool_xfer.resize(n_backends);
+        comm->xfer_pool_max_val.assign(n_backends, 0);
+        // The full-duplex pipeline needs a transfer queue distinct from the compute queue (so uploads
+        // and downloads run on independent engines). NVIDIA exposes a dedicated transfer family; if a
+        // device has only one queue, fall back to the single-shot path for large tensors too.
+        comm->pipeline_ok = true;
+        for (size_t i = 0; i < n_backends; i++) {
+            comm->prog[i] = ggml_vk_create_export_timeline(comm->device[i]);
+            comm->up[i]   = ggml_vk_create_export_timeline(comm->device[i]);
+            comm->cmd_pool[i].init(comm->device[i], &comm->device[i]->compute_queue);
+            comm->cmd_pool_xfer[i].init(comm->device[i], &comm->device[i]->transfer_queue);
+            if (comm->device[i]->single_queue ||
+                comm->device[i]->transfer_queue.queue == comm->device[i]->compute_queue.queue) {
+                comm->pipeline_ok = false;
+            }
+        }
+        // import each device's progress + upload timelines into every peer (fresh OPAQUE_FD per import)
+        for (size_t j = 0; j < n_backends; j++) {
+            for (size_t i = 0; i < n_backends; i++) {
+                if (i == j) { continue; }
+                comm->peer_prog[i][j] = ggml_vk_import_timeline(comm, comm->device[i], comm->device[j], comm->prog[j]);
+                comm->peer_up[i][j]   = ggml_vk_import_timeline(comm, comm->device[i], comm->device[j], comm->up[j]);
+            }
+        }
+        for (size_t i = 0; i < n_backends; i++) {
+            comm->vkctx[i]->comm_prog_sem = comm->prog[i];
+            comm->vkctx[i]->comm_prog_val = 0;
+            comm->vkctx[i]->comm_active   = true;
+        }
+    }
+    return comm;
+}
+
+static void ggml_backend_vk_comm_free(void * comm_ctx) {
+    ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
+    for (size_t i = 0; i < comm->vkctx.size(); i++) {
+        ggml_backend_synchronize(comm->backends[i]);
+        comm->vkctx[i]->comm_active   = false;
+        comm->vkctx[i]->comm_prog_sem = VK_NULL_HANDLE;
+    }
+    for (size_t i = 0; i < comm->prog.size(); i++) {
+        if (comm->prog[i]) {
+            comm->device[i]->device.destroySemaphore(comm->prog[i]);
+        }
+        if (i < comm->up.size() && comm->up[i]) {
+            comm->device[i]->device.destroySemaphore(comm->up[i]);
+        }
+        for (size_t j = 0; j < comm->peer_prog[i].size(); j++) {
+            if (comm->peer_prog[i][j]) {
+                comm->device[i]->device.destroySemaphore(comm->peer_prog[i][j]);
+            }
+            if (i < comm->peer_up.size() && j < comm->peer_up[i].size() && comm->peer_up[i][j]) {
+                comm->device[i]->device.destroySemaphore(comm->peer_up[i][j]);
+            }
+        }
+    }
+    for (size_t i = 0; i < comm->cmd_pool.size(); i++) {
+        comm->cmd_pool[i].destroy(comm->device[i]->device);
+    }
+    for (size_t i = 0; i < comm->cmd_pool_xfer.size(); i++) {
+        comm->cmd_pool_xfer[i].destroy(comm->device[i]->device);
+    }
+    for (auto & row : comm->host_buf) {
+        for (auto & b : row) {
+            b.reset();
+        }
+    }
+    for (void * p : comm->host_ptr) {
+        std::free(p);
+    }
+    for (ggml_backend_buffer_t b : comm->tmp_buffer) {
+        if (b) {
+            ggml_backend_buffer_free(b);
+        }
+    }
+    for (ggml_backend_buffer_t b : comm->up16_buffer) {
+        if (b) {
+            ggml_backend_buffer_free(b);
+        }
+    }
+    for (ggml_backend_buffer_t b : comm->dn16_buffer) {
+        if (b) {
+            ggml_backend_buffer_free(b);
+        }
+    }
+    if (comm->tctx) {
+        ggml_free(comm->tctx);
+    }
+    delete comm;
+}
+
+// (re)allocate the shared host staging and device scratch to hold nbytes per slice.
+static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, size_t nbytes) {
+    if (nbytes <= comm->cap) {
+        return true;
+    }
+    const size_t n      = comm->backends.size();
+    const size_t newcap = (nbytes + comm->align - 1) & ~(comm->align - 1);
+
+    for (size_t k = 0; k < n; k++) {
+        for (size_t i = 0; i < n; i++) {
+            comm->host_buf[k][i].reset();
+        }
+        std::free(comm->host_ptr[k]);
+        comm->host_ptr[k] = nullptr;
+    }
+    for (size_t i = 0; i < n; i++) {
+        if (comm->tmp_buffer[i]) {
+            ggml_backend_buffer_free(comm->tmp_buffer[i]);
+            comm->tmp_buffer[i] = nullptr;
+        }
+        if (comm->up16_buffer[i]) {
+            ggml_backend_buffer_free(comm->up16_buffer[i]);
+            comm->up16_buffer[i] = nullptr;
+        }
+        if (comm->dn16_buffer[i]) {
+            ggml_backend_buffer_free(comm->dn16_buffer[i]);
+            comm->dn16_buffer[i] = nullptr;
+        }
+    }
+
+    // Two slots per host buffer: the chunked pipeline ping-pongs between them by round parity so an
+    // upload never has to wait for the peer to finish reading the previous round's buffer (the
+    // single-shot path always uses slot 0). cap stays the per-slot size; the allocation is 2x.
+    const size_t slotcap = 2 * newcap;
+    // One host buffer per device, allocated on the host and imported into every device via
+    // VK_EXT_external_memory_host (which page-locks it for DMA). host_buf[k][i] = device i's import of
+    // host_ptr[k], holding device k's slice. (Driver-allocated shared memory via OPAQUE_FD was tried and
+    // gives no extra bandwidth here -- the import already gets full PCIe rate -- and can't cross mixed GPUs.)
+    for (size_t k = 0; k < n; k++) {
+        comm->host_ptr[k] = std::aligned_alloc(comm->align, slotcap);
+        if (!comm->host_ptr[k]) {
+            return false;
+        }
+        for (size_t i = 0; i < n; i++) {
+            comm->host_buf[k][i] = ggml_vk_buffer_from_host_ptr(comm->device[i], comm->host_ptr[k], slotcap);
+            if (!comm->host_buf[k][i]) {
+                return false;
+            }
+        }
+    }
+    for (size_t i = 0; i < n; i++) {
+        ggml_backend_buffer_type_t bt = ggml_backend_get_default_buffer_type(comm->backends[i]);
+        comm->tmp_buffer[i] = ggml_backend_buft_alloc_buffer(bt, newcap);
+        if (!comm->tmp_buffer[i]) {
+            return false;
+        }
+        if (!comm->tmp_tensor[i]) {
+            comm->tmp_tensor[i] = ggml_new_tensor_1d(comm->tctx, GGML_TYPE_F32, 1);
+        }
+        comm->tmp_tensor[i]->buffer = comm->tmp_buffer[i];
+        comm->tmp_tensor[i]->data   = ggml_backend_buffer_get_base(comm->tmp_buffer[i]);
+        // F16 device buffers for the cast partial (upload src) and the peer's F16 slice (download dst).
+        // newcap (fp32 cap) holds the F16 data (half the bytes) with room to spare.
+        comm->up16_buffer[i] = ggml_backend_buft_alloc_buffer(bt, newcap);
+        comm->dn16_buffer[i] = ggml_backend_buft_alloc_buffer(bt, newcap);
+        if (!comm->up16_buffer[i] || !comm->dn16_buffer[i]) {
+            return false;
+        }
+        if (!comm->up16_tensor[i]) {
+            comm->up16_tensor[i] = ggml_new_tensor_1d(comm->tctx, GGML_TYPE_F16, 1);
+        }
+        if (!comm->dn16_tensor[i]) {
+            comm->dn16_tensor[i] = ggml_new_tensor_1d(comm->tctx, GGML_TYPE_F16, 1);
+        }
+        comm->up16_tensor[i]->buffer = comm->up16_buffer[i];
+        comm->up16_tensor[i]->data   = ggml_backend_buffer_get_base(comm->up16_buffer[i]);
+        comm->dn16_tensor[i]->buffer = comm->dn16_buffer[i];
+        comm->dn16_tensor[i]->data   = ggml_backend_buffer_get_base(comm->dn16_buffer[i]);
+    }
+    comm->cap = newcap;
+    return true;
+}
+
+// Large-tensor AllReduce via a full-duplex chunked pipeline. Each device's slice is split into K
+// chunks. The dedicated TRANSFER queue streams this device's slice out to shared host memory chunk by
+// chunk (signalling up[i] after each), while the COMPUTE queue pulls each peer chunk back the moment
+// the peer has uploaded it (waiting peer_up) and finally adds the peer slices in. Because uploads and
+// downloads run on independent queues/engines, the two directions of the full-duplex PCIe link overlap,
+// so the reduction costs ~T (one slice transfer) instead of the single-shot path's ~2T (upload then
+// download). All tensors are assumed to carry a real partial (GGML_TENSOR_FLAG_COMPUTE); the caller
+// gates on that. Validated for n==2 (the only configuration the comm enables).
+static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context * comm,
+                                                    ggml_tensor ** tensors, size_t nbytes) {
+    const size_t n = comm->backends.size();
+
+    // Chunking: aim for ~chunk_target bytes per chunk, with at least 2 chunks (one split is enough to
+    // overlap the two PCIe directions) and capped at kmax. Each extra chunk adds a submission and a
+    // cross-device semaphore wait whose latency outweighs the finer overlap, so over-splitting hurts --
+    // measured sweet spot is K=2..4. Align the chunk to 16B (F32 element-aligned).
+    constexpr size_t chunk_target = 4u << 20;
+    constexpr int    kmax         = 4;
+    // F16 staging: cast the fp32 partial to F16 on-device, transfer only half the bytes (the lever NCCL
+    // uses), then add the peer's F16 slice straight into the fp32 result. xbytes is what actually crosses
+    // the PCIe link; chunking is sized off it.
+    const bool   f16    = comm->use_f16;
+    const size_t xbytes = f16 ? (nbytes / 2) : nbytes;
+    int K = (int) ((xbytes + chunk_target - 1) / chunk_target);
+    K = std::max(2, std::min(K, kmax));
+    size_t chunk = (xbytes + K - 1) / K;
+    chunk = (chunk + 15) & ~((size_t) 15);
+    K = (int) ((xbytes + chunk - 1) / chunk); // alignment may drop the count of non-empty chunks
+
+    // Double-buffer the shared host staging: ping-pong between two slots by round parity so an upload
+    // never has to wait for the peer to finish reading last round's buffer. The slot's previous user was
+    // two rounds ago, which is already ordered before this round's compute (transitively via the per-round
+    // reduce->compute->upload chain), so no explicit reuse guard is needed.
+    const int    slot     = (int) (comm->pipe_round & 1);
+    const size_t slot_off = (size_t) slot * comm->cap;
+    comm->pipe_round++;
+
+    // Reserve timeline values up front for every device (so each knows its peers' per-chunk upload
+    // values): prog[i] advances by 1 fp32 (compute -> reduce), or 2 in F16 (compute -> cast -> reduce);
+    // up[i] advances by K (one per uploaded chunk).
+    std::vector<uint64_t> compute_val(n), cast_val(n), reduce_val(n), up_base(n);
+    for (size_t i = 0; i < n; i++) {
+        compute_val[i] = comm->vkctx[i]->comm_prog_val;
+        cast_val[i]    = compute_val[i] + 1;                  // F16: cast done (unused in fp32)
+        reduce_val[i]  = compute_val[i] + (f16 ? 2 : 1);
+        comm->vkctx[i]->comm_prog_val = reduce_val[i];
+        comm->last_reduce[i]          = reduce_val[i];
+        up_base[i]                    = comm->up_val[i];
+        comm->up_val[i]              += (uint64_t) K;
+    }
+
+    // Recycle both command pools once their queue caught up (non-blocking timeline query), with a
+    // bounded drain if a long prefill lets a pool grow too large (mirrors the single-shot policy).
+    auto recycle = [&](size_t i, vk_command_pool & pool, vk::Semaphore sem, uint64_t & pool_max, uint64_t target) {
+        uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(sem);
+        if (done < pool_max && pool.buffers_in_use() >= 256) {
+            vk::SemaphoreWaitInfo wi;
+            wi.semaphoreCount = 1;
+            wi.pSemaphores    = &sem;
+            wi.pValues        = &pool_max;
+            (void) comm->device[i]->device.waitSemaphores(wi, UINT64_MAX);
+            done = pool_max;
+        }
+        if (done >= pool_max) {
+            ggml_vk_command_pool_cleanup(comm->device[i], pool);
+        }
+        pool_max = target;
+    };
+    for (size_t i = 0; i < n; i++) {
+        recycle(i, comm->cmd_pool[i],      comm->prog[i], comm->pool_max_val[i],      reduce_val[i]);
+        recycle(i, comm->cmd_pool_xfer[i], comm->up[i],   comm->xfer_pool_max_val[i], up_base[i] + (uint64_t) K);
+    }
+
+    for (size_t i = 0; i < n; i++) {
+        ggml_backend_vk_buffer_context * bc   = (ggml_backend_vk_buffer_context *) tensors[i]->buffer->context;
+        ggml_backend_vk_buffer_context * tbc  = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
+        ggml_backend_vk_buffer_context * upbc = (ggml_backend_vk_buffer_context *) comm->up16_buffer[i]->context;
+        ggml_backend_vk_buffer_context * dnbc = (ggml_backend_vk_buffer_context *) comm->dn16_buffer[i]->context;
+        const size_t src_off = vk_tensor_offset(tensors[i]) + tensors[i]->view_offs;
+
+        // the F16 scratch tensors mirror tensors[i]'s shape (same element count, 2-byte elements)
+        if (f16) {
+            for (ggml_tensor * t : { comm->up16_tensor[i], comm->dn16_tensor[i] }) {
+                for (int d = 0; d < GGML_MAX_DIMS; d++) { t->ne[d] = tensors[i]->ne[d]; }
+                t->nb[0] = ggml_type_size(GGML_TYPE_F16);
+                for (int d = 1; d < GGML_MAX_DIMS; d++) { t->nb[d] = t->nb[d - 1] * t->ne[d - 1]; }
+            }
+        }
+
+        vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
+
+        // ---- (F16) cast this device's fp32 partial -> up16 (F16) on the compute queue ----
+        if (f16) {
+            ggml_vk_ctx_begin(comm->device[i], cctx);
+            cctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] }); // own compute done (reads tensors[i])
+            cctx->s->wait_semaphores.push_back({ comm->up[i],   up_base[i] });      // prev round's uploads done (WAR on up16)
+            ggml_vk_cpy(comm->vkctx[i], cctx, tensors[i], comm->up16_tensor[i]);
+            ggml_vk_ctx_end(cctx);
+            cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], cast_val[i] });
+        }
+
+        // ---- transfer queue: stream this device's slice out, one chunk per submission. Source is the
+        //      F16 cast (up16) or, in fp32 mode, tensors[i] directly. ----
+        const uint64_t up_ready    = f16 ? cast_val[i] : compute_val[i];
+        vk_buffer &    up_src       = f16 ? upbc->dev_buffer : bc->dev_buffer;
+        const size_t   up_src_off   = f16 ? 0 : src_off;
+        vk_context tctx = ggml_vk_create_temporary_context(comm->cmd_pool_xfer[i]);
+        for (int cI = 0; cI < K; cI++) {
+            const size_t off = (size_t) cI * chunk;
+            const size_t sz  = std::min(chunk, xbytes - off);
+            ggml_vk_ctx_begin(comm->device[i], tctx);
+            if (cI == 0) {
+                // gate on this device's slice being ready (cast in F16, or compute in fp32; cross-queue).
+                // Double-buffering makes a peer-reuse guard unnecessary (see slot logic above).
+                tctx->s->wait_semaphores.push_back({ comm->prog[i], up_ready });
+            }
+            ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], slot_off + off, up_src, up_src_off + off, sz);
+            ggml_vk_ctx_end(tctx);
+            tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + (uint64_t) cI + 1 });
+        }
+        ggml_vk_submit(tctx, {});
+
+        // ---- compute queue: pull each peer chunk back as it lands, then add the peer slice into the
+        //      fp32 result (mixed F32 += F16 add in F16 mode, F32 += F32 in fp32 mode). ----
+        ggml_tensor * tmp = comm->tmp_tensor[i];
+        for (int d = 0; d < GGML_MAX_DIMS; d++) {
+            tmp->ne[d] = tensors[i]->ne[d];
+        }
+        tmp->nb[0] = ggml_type_size(GGML_TYPE_F32);
+        for (int d = 1; d < GGML_MAX_DIMS; d++) {
+            tmp->nb[d] = tmp->nb[d - 1] * tmp->ne[d - 1];
+        }
+        vk_buffer &    dn_dst      = f16 ? dnbc->dev_buffer : tbc->dev_buffer;
+        ggml_tensor *  add_src1    = f16 ? comm->dn16_tensor[i] : tmp;
+        for (size_t k = 0; k < n; k++) {
+            if (k == i) {
+                continue;
+            }
+            // one download submission per chunk, each waiting only on that peer's matching upload chunk,
+            // so a chunk's download begins as soon as the peer produced it -- this is what overlaps the
+            // upload and download directions.
+            for (int cI = 0; cI < K; cI++) {
+                const size_t off = (size_t) cI * chunk;
+                const size_t sz  = std::min(chunk, xbytes - off);
+                ggml_vk_ctx_begin(comm->device[i], cctx);
+                cctx->s->wait_semaphores.push_back({ comm->peer_up[i][k], up_base[k] + (uint64_t) cI + 1 });
+                ggml_vk_buffer_copy_async(cctx, dn_dst, off, comm->host_buf[k][i], slot_off + off, sz);
+                ggml_vk_ctx_end(cctx);
+            }
+            // add this peer's now-complete slice into the running sum. The leading barrier covers the
+            // download copies above (same queue, submission order). In fp32 mode the uploads read
+            // tensors[i], so wait on them first (WAR: the add overwrites tensors[i]); in F16 mode the
+            // uploads read up16, and the cast's read of tensors[i] is already ordered before the add's
+            // write by the barrier, so no up-wait is needed.
+            ggml_vk_ctx_begin(comm->device[i], cctx);
+            if (!f16) {
+                cctx->s->wait_semaphores.push_back({ comm->up[i], up_base[i] + (uint64_t) K });
+            }
+            ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+            ggml_vk_add(comm->vkctx[i], cctx, tensors[i], add_src1, tensors[i]);
+            ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+            ggml_vk_ctx_end(cctx);
+        }
+        cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], reduce_val[i] });
+        ggml_vk_submit(cctx, {});
+    }
+    return true;
+}
+
+static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor ** tensors) {
+    ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
+    const size_t n = comm->backends.size();
+
+    // Escape hatch: GGML_VK_COMM_OFF disables this custom AllReduce and lets the meta backend fall back
+    // to its CPU-barriered butterfly (slower, but a safe valve if the comm ever misbehaves).
+    static const bool off = getenv("GGML_VK_COMM_OFF") != nullptr;
+    if (off) {
+        return false;
+    }
+
+    if (!comm->fast || tensors[0]->type != GGML_TYPE_F32) {
+        return false; // -> meta backend butterfly fallback
+    }
+    const int64_t ne = ggml_nelements(tensors[0]);
+    if (ne == 0) {
+        return true;
+    }
+    const size_t nbytes = ggml_nbytes(tensors[0]);
+    for (size_t i = 0; i < n; i++) {
+        if (tensors[i]->type != GGML_TYPE_F32 || ggml_nelements(tensors[i]) != ne || !ggml_is_contiguous(tensors[i])) {
+            return false;
+        }
+    }
+    if (!ggml_backend_vk_comm_ensure(comm, nbytes)) {
+        return false;
+    }
+
+    // Large tensors (prefill activations) go through the full-duplex chunked pipeline, which overlaps
+    // the upload and download directions for ~2x. Small tensors (decode, one token) stay on the
+    // single-shot path below, where the fixed per-call overhead dominates and chunking would only add
+    // submissions. Gated on every slice carrying a real partial (the pipeline always uploads real data).
+    constexpr size_t pipeline_min = 2u << 20;
+    if (comm->pipeline_ok && n == 2 && nbytes >= pipeline_min) {
+        bool all_compute = true;
+        for (size_t i = 0; i < n; i++) {
+            all_compute = all_compute && (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE);
+        }
+        if (all_compute) {
+            return ggml_backend_vk_comm_allreduce_pipeline(comm, tensors, nbytes);
+        }
+    }
+
+    // Everything below is enqueued on the GPU and ordered via the per-device progress timeline; no
+    // CPU barrier is taken, so the next layer's compute can be submitted while this reduction runs.
+    //
+    // Gather: copy each device's slice into its shared host buffer. Ordered after this device's
+    // compute (prog[i] >= compute value, signalled by graph_compute) and after every peer finished
+    // reading this buffer last round (so the single host buffer is safe to overwrite). Signals the
+    // gather value on prog[i].
+
+    // Reserve the timeline values up front: each device advances by 2 (gather, then reduce).
+    std::vector<uint64_t> compute_val(n), gather_val(n), reduce_val(n), prev_reduce(n);
+    for (size_t i = 0; i < n; i++) {
+        prev_reduce[i] = comm->last_reduce[i];
+        compute_val[i] = comm->vkctx[i]->comm_prog_val;
+        gather_val[i]  = compute_val[i] + 1;
+        reduce_val[i]  = compute_val[i] + 2;
+        comm->vkctx[i]->comm_prog_val = reduce_val[i];
+        comm->last_reduce[i]          = reduce_val[i];
+        // Recycle the dedicated command pool once the GPU has finished everything recorded into it
+        // (non-blocking timeline query). During decode this happens every token; during a long
+        // prefill the GPU stays behind, so also cap the live command buffers and drain (bounded
+        // wait) when the pool grows too large -- otherwise it grows unbounded and command-buffer
+        // lookup goes quadratic.
+        uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(comm->prog[i]);
+        if (done < comm->pool_max_val[i] && comm->cmd_pool[i].buffers_in_use() >= 256) {
+            vk::SemaphoreWaitInfo wi;
+            wi.semaphoreCount = 1;
+            wi.pSemaphores    = &comm->prog[i];
+            wi.pValues        = &comm->pool_max_val[i];
+            (void) comm->device[i]->device.waitSemaphores(wi, UINT64_MAX);
+            done = comm->pool_max_val[i];
+        }
+        if (done >= comm->pool_max_val[i]) {
+            ggml_vk_command_pool_cleanup(comm->device[i], comm->cmd_pool[i]);
+        }
+        comm->pool_max_val[i] = reduce_val[i];
+    }
+
+    // For each device, record the gather and reduce as two batches in one command context and issue
+    // them with a single vkQueueSubmit (the global queue mutex makes each submit the dominant cost).
+    for (size_t i = 0; i < n; i++) {
+        ggml_tensor * tmp = comm->tmp_tensor[i];
+        for (int d = 0; d < GGML_MAX_DIMS; d++) {
+            tmp->ne[d] = tensors[i]->ne[d];
+        }
+        tmp->nb[0] = ggml_type_size(GGML_TYPE_F32);
+        for (int d = 1; d < GGML_MAX_DIMS; d++) {
+            tmp->nb[d] = tmp->nb[d - 1] * tmp->ne[d - 1];
+        }
+        ggml_backend_vk_buffer_context * tbc = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
+        vk_context c = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
+
+        // gather batch: wait this device's compute and the peers' previous reduce (so the shared host
+        // buffer is safe to overwrite); copy this slice to host; signal the gather value.
+        ggml_vk_ctx_begin(comm->device[i], c);
+        c->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
+        for (size_t k = 0; k < n; k++) {
+            if (k != i) {
+                c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], prev_reduce[k] });
+            }
+        }
+        if (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE) {
+            ggml_backend_vk_buffer_context * bc = (ggml_backend_vk_buffer_context *) tensors[i]->buffer->context;
+            ggml_vk_buffer_copy_async(c, comm->host_buf[i][i], 0, bc->dev_buffer,
+                                      vk_tensor_offset(tensors[i]) + tensors[i]->view_offs, nbytes);
+        } else {
+            ggml_vk_buffer_memset_async(c, comm->host_buf[i][i], 0, 0, nbytes);
+        }
+        ggml_vk_ctx_end(c);
+        c->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], gather_val[i] });
+
+        // reduce batch: wait this device's gather (so it has finished reading this slice) and the
+        // peers' gather (cross-device); add each peer slice in; signal the reduce value.
+        ggml_vk_ctx_begin(comm->device[i], c);
+        c->s->wait_semaphores.push_back({ comm->prog[i], gather_val[i] });
+        for (size_t k = 0; k < n; k++) {
+            if (k != i) {
+                c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], gather_val[k] });
+            }
+        }
+        for (size_t k = 0; k < n; k++) {
+            if (k == i) {
+                continue;
+            }
+            ggml_vk_buffer_copy_async(c, tbc->dev_buffer, 0, comm->host_buf[k][i], 0, nbytes);
+            ggml_vk_sync_buffers(comm->vkctx[i], c);
+            ggml_vk_add(comm->vkctx[i], c, tensors[i], tmp, tensors[i]);
+            ggml_vk_sync_buffers(comm->vkctx[i], c);
+        }
+        ggml_vk_ctx_end(c);
+        c->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], reduce_val[i] });
+
+        ggml_vk_submit(c, {});
+    }
+    return true;
+}
+
+static void * ggml_backend_vk_reg_get_proc_address(ggml_backend_reg_t reg, const char * name) {
+    UNUSED(reg);
+    if (strcmp(name, "ggml_backend_comm_init") == 0) {
+        return (void *) ggml_backend_vk_comm_init;
+    }
+    if (strcmp(name, "ggml_backend_comm_free") == 0) {
+        return (void *) ggml_backend_vk_comm_free;
+    }
+    if (strcmp(name, "ggml_backend_comm_allreduce_tensor") == 0) {
+        return (void *) ggml_backend_vk_comm_allreduce_tensor;
+    }
+    return nullptr;
+}
+
 static const struct ggml_backend_reg_i ggml_backend_vk_reg_i = {
     /* .get_name         = */ ggml_backend_vk_reg_get_name,
     /* .get_device_count = */ ggml_backend_vk_reg_get_device_count,
     /* .get_device       = */ ggml_backend_vk_reg_get_device,
-    /* .get_proc_address = */ NULL,
+    /* .get_proc_address = */ ggml_backend_vk_reg_get_proc_address,
 };
 
 ggml_backend_reg_t ggml_backend_vk_reg() {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2081,9 +2081,6 @@ struct ggml_backend_vk_context {
 
     vk_device device;
 
-    // Tensor-parallel collective (comm) chains the cross-device AllReduce into this device's
-    // compute queue via a monotonic timeline semaphore, so per-layer reductions are ordered on
-    // the GPU instead of by CPU barriers. Set up by ggml_backend_vk_comm_init while TP is active.
     bool         comm_active = false;
     vk::Semaphore comm_prog_sem = VK_NULL_HANDLE;
     uint64_t     comm_prog_val  = 0;
@@ -14893,8 +14890,6 @@ static bool ggml_vk_build_graph(ggml_backend_vk_context * ctx, ggml_cgraph * cgr
     if (submit || last_node) {
         ggml_vk_ctx_end(compute_ctx);
 
-        // Tensor parallel: signal this subgraph's completion on the device progress timeline so
-        // the cross-device AllReduce can chain after it on the GPU (see ggml_backend_vk_comm_*).
         if (last_node && ctx->comm_active && !compute_ctx->seqs.empty()) {
             ctx->comm_prog_val++;
             compute_ctx->seqs.back().back().signal_semaphores.push_back({ ctx->comm_prog_sem, ctx->comm_prog_val });
@@ -16218,8 +16213,6 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         ggml_vk_sync_buffers(ctx, compute_ctx);
     }
 
-    // Tensor parallel: make this subgraph's compute wait on the previous layer's reduction, ordered
-    // on the GPU via the device progress timeline instead of a CPU barrier.
     if (ctx->comm_active) {
         compute_ctx = ggml_vk_get_compute_ctx(ctx);
         compute_ctx->s->wait_semaphores.push_back({ ctx->comm_prog_sem, ctx->comm_prog_val });
@@ -17853,52 +17846,40 @@ struct ggml_backend_vk_comm_context {
     size_t                                  align = 4096;
     size_t                                  cap   = 0;
     bool                                    fast  = false;
-    // Exportable per-device "progress" timeline; the AllReduce steps wait+signal it, ordering the whole
-    // reduction on the GPU (no CPU barriers). Also published in vkctx[i]->comm_prog_sem.
-    std::vector<vk::Semaphore>              prog;          // prog[i] lives on device i
-    std::vector<std::vector<vk::Semaphore>> peer_prog;     // peer_prog[i][j] = device i's import of prog[j]
-    std::vector<uint64_t>                   last_reduce;   // last reduce value signalled, per device
-    std::vector<vk_command_pool>            cmd_pool;      // per-device pool, recycled once the GPU catches up
+    std::vector<vk::Semaphore>              prog;
+    std::vector<std::vector<vk::Semaphore>> peer_prog;
+    std::vector<uint64_t>                   last_reduce;
+    std::vector<vk_command_pool>            cmd_pool;
     std::vector<uint64_t>                   pool_max_val;
     PFN_vkGetSemaphoreFdKHR                 pGetSemFd  = nullptr;
     PFN_vkImportSemaphoreFdKHR              pImportSemFd = nullptr;
-    // host_ptr[k]: shared CPU staging holding device k's gathered slice, imported on every device.
     std::vector<void*>                      host_ptr;
-    std::vector<std::vector<vk_buffer>>     host_buf;      // host_buf[k][i] = device i's import of host_ptr[k]
-    std::vector<ggml_backend_buffer_t>      tmp_buffer;    // device-local scratch per device (peer data for the add)
+    std::vector<std::vector<vk_buffer>>     host_buf;
+    std::vector<ggml_backend_buffer_t>      tmp_buffer;
     std::vector<ggml_tensor*>               tmp_tensor;
     ggml_context *                          tctx = nullptr;
-    // Chunked full-duplex pipeline (large tensors): upload this device's slice on the TRANSFER queue
-    // while the COMPUTE queue pulls peer chunks back, overlapping both PCIe directions (~T not ~2T).
     bool                                    pipeline_ok = false;
-    std::vector<vk::Semaphore>              up;            // up[i]: exportable upload-progress timeline on device i
-    std::vector<std::vector<vk::Semaphore>> peer_up;       // peer_up[i][j] = device i's import of up[j]
-    std::vector<uint64_t>                   up_val;        // running upload-chunk counter, per device
-    std::vector<vk_command_pool>            cmd_pool_xfer; // dedicated transfer-queue pool per device
+    std::vector<vk::Semaphore>              up;
+    std::vector<std::vector<vk::Semaphore>> peer_up;
+    std::vector<uint64_t>                   up_val;
+    std::vector<vk_command_pool>            cmd_pool_xfer;
     std::vector<uint64_t>                   xfer_pool_max_val;
-    uint64_t                                pipe_round = 0; // pipeline allreduce counter; its parity picks the host slot
-    // F16 staging: cast each fp32 partial to F16 before the host transfer, so only half the bytes cross
-    // the bandwidth-bound link. up16 = cast partial (upload src); dn16 = peer's F16 slice. Pipeline only.
+    uint64_t                                pipe_round = 0;
     bool                                    use_f16 = false;
     std::vector<ggml_backend_buffer_t>      up16_buffer;
     std::vector<ggml_backend_buffer_t>      dn16_buffer;
     std::vector<ggml_tensor*>               up16_tensor;
     std::vector<ggml_tensor*>               dn16_tensor;
-    // CPU-proxy cross-device sync: portable fallback when importing a peer's OPAQUE_FD timeline is
-    // unavailable (cross-vendor) or forced via GGML_VK_COMM_PROXY. A helper thread host-signals a local
-    // pxy[] timeline that the consumer's download is parked on, standing in for the imported peer timeline.
     bool                                    proxy = false;
-    std::vector<vk::Semaphore>              pxy;       // pxy[i]: local (non-exported) proxy timeline on device i
-    std::vector<uint64_t>                   pxy_val;   // running proxy-signal counter, per device
+    std::vector<vk::Semaphore>              pxy;
+    std::vector<uint64_t>                   pxy_val;
     struct bridge_task { vk::Device wdev; vk::Semaphore wsem; uint64_t wval; vk::Device sdev; vk::Semaphore ssem; uint64_t sval; };
-    std::vector<std::deque<bridge_task>>    bridge_q;  // one FIFO of pending bridges per consumer device
+    std::vector<std::deque<bridge_task>>    bridge_q;
     std::mutex                              bridge_mtx;
     std::thread                             proxy_thread;
     std::atomic<bool>                       proxy_stop{false};
 };
 
-// Proxy thread: when a queued bridge's peer timeline (wsem) reaches wval, host-signal this device's pxy[]
-// to sval and the parked download wakes. FIFO per consumer keeps pxy[] monotonic; spin-then-yield.
 static void ggml_vk_comm_proxy_loop(ggml_backend_vk_comm_context * comm) {
     while (!comm->proxy_stop.load(std::memory_order_relaxed)) {
         bool progress = false;
@@ -17909,7 +17890,7 @@ static void ggml_vk_comm_proxy_loop(ggml_backend_vk_comm_context * comm) {
                     std::lock_guard<std::mutex> lk(comm->bridge_mtx);
                     if (comm->bridge_q[q].empty()) { break; }
                     t = comm->bridge_q[q].front();
-                    if (t.wdev.getSemaphoreCounterValue(t.wsem) < t.wval) { break; } // head not ready
+                    if (t.wdev.getSemaphoreCounterValue(t.wsem) < t.wval) { break; }
                     comm->bridge_q[q].pop_front();
                 }
                 vk::SemaphoreSignalInfo si{ t.ssem, t.sval };
@@ -17930,8 +17911,6 @@ static vk::Semaphore ggml_vk_create_export_timeline(vk_device & device) {
     return device->device.createSemaphore(sci);
 }
 
-// Export src_sem from src_dev via OPAQUE_FD and import it as a fresh timeline on dst_dev, so dst_dev's
-// queues can wait on src_dev's progress. A new fd is taken per import (the fd is consumed by import).
 static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm, vk_device & dst_dev,
                                              vk_device & src_dev, vk::Semaphore src_sem) {
     int fd = -1;
@@ -17955,9 +17934,6 @@ static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm
     return dst;
 }
 
-// Whether cross-device OPAQUE_FD timeline import is officially supported: the handle must be exportable
-// and importable on every device, sharing one driverUUID (OPAQUE_FD payloads are driver-private). Gate on
-// the driver, not the device -- NVIDIA imports cross-device within one driver despite differing deviceUUIDs.
 static bool ggml_vk_comm_opaque_fd_supported(ggml_backend_vk_comm_context * comm) {
     const size_t n = comm->device.size();
     uint8_t driver_uuid[VK_UUID_SIZE];
@@ -17990,15 +17966,13 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     comm->backends.assign(backends, backends + n_backends);
     comm->vkctx.resize(n_backends);
     comm->device.resize(n_backends);
-    bool ok = (n_backends == 2);
+    bool ok = (n_backends >= 2);
     for (size_t i = 0; i < n_backends; i++) {
         comm->vkctx[i]  = (ggml_backend_vk_context *) backends[i]->context;
         comm->device[i] = comm->vkctx[i]->device;
         ok = ok && comm->device[i]->external_memory_host && comm->device[i]->external_semaphore;
         comm->align = std::max(comm->align, (size_t) comm->device[i]->min_imported_host_pointer_alignment);
     }
-    // The fast path stages through host-imported shared memory and orders on the GPU via exported
-    // timelines; it needs VK_EXT_external_memory_host + VK_KHR_external_semaphore_fd on every device.
     comm->fast = ok;
     comm->host_ptr.resize(n_backends, nullptr);
     comm->host_buf.resize(n_backends);
@@ -18007,13 +17981,12 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     for (size_t k = 0; k < n_backends; k++) {
         comm->host_buf[k].resize(n_backends);
     }
-    // F16 staging halves the host transfer (default on; GGML_VK_COMM_FP32 forces the old fp32 path).
     comm->use_f16 = (getenv("GGML_VK_COMM_FP32") == nullptr);
     comm->up16_buffer.resize(n_backends, nullptr);
     comm->dn16_buffer.resize(n_backends, nullptr);
     comm->up16_tensor.resize(n_backends, nullptr);
     comm->dn16_tensor.resize(n_backends, nullptr);
-    const ggml_init_params ip = { ggml_tensor_overhead() * (n_backends + 8), nullptr, true };
+    const ggml_init_params ip = { ggml_tensor_overhead() * (3 * n_backends + 8), nullptr, true };
     comm->tctx = ggml_init(ip);
 
     if (comm->fast) {
@@ -18032,8 +18005,6 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->up_val.assign(n_backends, 0);
         comm->cmd_pool_xfer.resize(n_backends);
         comm->xfer_pool_max_val.assign(n_backends, 0);
-        // The full-duplex pipeline needs a transfer queue distinct from compute; without one, large
-        // tensors take the single-shot path too.
         comm->pipeline_ok = true;
         for (size_t i = 0; i < n_backends; i++) {
             comm->prog[i] = ggml_vk_create_export_timeline(comm->device[i]);
@@ -18045,8 +18016,6 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
                 comm->pipeline_ok = false;
             }
         }
-        // Cross-device ordering: import each peer's OPAQUE_FD timelines so the GPU waits on them directly
-        // (fastest, but driver-private). GGML_VK_COMM_PROXY or an unsupported config picks the CPU-proxy.
         comm->proxy = getenv("GGML_VK_COMM_PROXY") != nullptr;
         if (!comm->proxy && !ggml_vk_comm_opaque_fd_supported(comm)) {
             comm->proxy = true;
@@ -18062,7 +18031,7 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
                     }
                 }
             } catch (const vk::SystemError &) {
-                comm->proxy = true; // import threw despite the gate -> fall back to the proxy
+                comm->proxy = true;
                 GGML_LOG_INFO("ggml_vulkan: comm OPAQUE_FD timeline import failed; using portable CPU-proxy sync\n");
             }
         }
@@ -18109,7 +18078,7 @@ static void ggml_vk_comm_aligned_free(void * ptr) {
 static void ggml_backend_vk_comm_free(void * comm_ctx) {
     ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
     for (size_t i = 0; i < comm->vkctx.size(); i++) {
-        ggml_backend_synchronize(comm->backends[i]); // proxy (if any) is still alive here so parked downloads drain
+        ggml_backend_synchronize(comm->backends[i]);
         comm->vkctx[i]->comm_active   = false;
         comm->vkctx[i]->comm_prog_sem = VK_NULL_HANDLE;
     }
@@ -18173,7 +18142,6 @@ static void ggml_backend_vk_comm_free(void * comm_ctx) {
     delete comm;
 }
 
-// (re)allocate the shared host staging and device scratch to hold nbytes per slice.
 static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, size_t nbytes) {
     if (nbytes <= comm->cap) {
         return true;
@@ -18203,12 +18171,7 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         }
     }
 
-    // Two slots per host buffer: the pipeline ping-pongs by round parity so an upload never waits on the
-    // peer reading last round's buffer (single-shot always uses slot 0). cap is per-slot; allocation is 2x.
     const size_t slotcap = 2 * newcap;
-    // One host buffer per device, imported into every device via VK_EXT_external_memory_host (page-locked
-    // for DMA). host_buf[k][i] = device i's import of host_ptr[k]. (Driver-allocated OPAQUE_FD shared
-    // memory gave no extra bandwidth here and can't cross mixed GPUs.)
     for (size_t k = 0; k < n; k++) {
         comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
         if (!comm->host_ptr[k]) {
@@ -18232,7 +18195,6 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         }
         comm->tmp_tensor[i]->buffer = comm->tmp_buffer[i];
         comm->tmp_tensor[i]->data   = ggml_backend_buffer_get_base(comm->tmp_buffer[i]);
-        // F16 scratch: up16 = cast partial (upload src), dn16 = peer's F16 slice (download dst).
         comm->up16_buffer[i] = ggml_backend_buft_alloc_buffer(bt, newcap);
         comm->dn16_buffer[i] = ggml_backend_buft_alloc_buffer(bt, newcap);
         if (!comm->up16_buffer[i] || !comm->dn16_buffer[i]) {
@@ -18253,50 +18215,39 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
     return true;
 }
 
-// Large-tensor AllReduce via a full-duplex chunked pipeline: the TRANSFER queue streams this device's
-// slice out chunk by chunk while the COMPUTE queue pulls each peer chunk back as it lands and adds it in.
-// The two PCIe directions overlap, so the reduction costs ~T instead of ~2T. n==2 only.
 static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context * comm,
                                                     ggml_tensor ** tensors, size_t nbytes) {
     const size_t n = comm->backends.size();
 
-    // Aim for ~chunk_target per chunk, min 2 (enough to overlap both directions), capped at kmax: each
-    // extra chunk adds a submission + cross-device wait that outweighs the finer overlap (sweet spot 2..4).
     constexpr size_t chunk_target = 4u << 20;
     constexpr int    kmax         = 4;
-    // F16: only half the bytes cross PCIe, so size chunking off xbytes (what actually crosses the link).
     const bool   f16    = comm->use_f16;
     const size_t xbytes = f16 ? (nbytes / 2) : nbytes;
     int K = (int) ((xbytes + chunk_target - 1) / chunk_target);
     K = std::max(2, std::min(K, kmax));
     size_t chunk = (xbytes + K - 1) / K;
     chunk = (chunk + 15) & ~((size_t) 15);
-    K = (int) ((xbytes + chunk - 1) / chunk); // alignment may drop the count of non-empty chunks
+    K = (int) ((xbytes + chunk - 1) / chunk);
 
-    // Ping-pong the host slot by round parity: this slot's previous user was two rounds ago and is already
-    // ordered before this round's compute, so no explicit reuse guard is needed.
     const int    slot     = (int) (comm->pipe_round & 1);
     const size_t slot_off = (size_t) slot * comm->cap;
     comm->pipe_round++;
 
-    // Reserve timeline values up front so each device knows its peers' per-chunk upload values. prog
-    // advances 1 (fp32) or 2 (F16: compute->cast->reduce); up advances K (one per chunk).
     std::vector<uint64_t> compute_val(n), cast_val(n), reduce_val(n), up_base(n), pxy_base(n);
     for (size_t i = 0; i < n; i++) {
         compute_val[i] = comm->vkctx[i]->comm_prog_val;
-        cast_val[i]    = compute_val[i] + 1;                  // F16: cast done (unused in fp32)
+        cast_val[i]    = compute_val[i] + 1;
         reduce_val[i]  = compute_val[i] + (f16 ? 2 : 1);
         comm->vkctx[i]->comm_prog_val = reduce_val[i];
         comm->last_reduce[i]          = reduce_val[i];
         up_base[i]                    = comm->up_val[i];
         comm->up_val[i]              += (uint64_t) K;
-        if (comm->proxy) {                                   // proxy mode: device i's downloads park on pxy[i]
+        if (comm->proxy) {
             pxy_base[i]               = comm->pxy_val[i];
-            comm->pxy_val[i]         += (uint64_t) K;
+            comm->pxy_val[i]         += (uint64_t) (n - 1) * K;
         }
     }
 
-    // Recycle each pool once its queue caught up (non-blocking), with a bounded drain if a pool grew too large.
     auto recycle = [&](size_t i, vk_command_pool & pool, vk::Semaphore sem, uint64_t & pool_max, uint64_t target) {
         uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(sem);
         if (done < pool_max && pool.buffers_in_use() >= 256) {
@@ -18324,7 +18275,6 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
         ggml_backend_vk_buffer_context * dnbc = (ggml_backend_vk_buffer_context *) comm->dn16_buffer[i]->context;
         const size_t src_off = vk_tensor_offset(tensors[i]) + tensors[i]->view_offs;
 
-        // the F16 scratch tensors mirror tensors[i]'s shape (same element count, 2-byte elements)
         if (f16) {
             for (ggml_tensor * t : { comm->up16_tensor[i], comm->dn16_tensor[i] }) {
                 for (int d = 0; d < GGML_MAX_DIMS; d++) { t->ne[d] = tensors[i]->ne[d]; }
@@ -18335,17 +18285,15 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
 
         vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
 
-        // ---- (F16) cast this device's fp32 partial -> up16 (F16) on the compute queue ----
         if (f16) {
             ggml_vk_ctx_begin(comm->device[i], cctx);
-            cctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] }); // own compute done (reads tensors[i])
-            cctx->s->wait_semaphores.push_back({ comm->up[i],   up_base[i] });      // prev round's uploads done (WAR on up16)
+            cctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
+            cctx->s->wait_semaphores.push_back({ comm->up[i],   up_base[i] });
             ggml_vk_cpy(comm->vkctx[i], cctx, tensors[i], comm->up16_tensor[i]);
             ggml_vk_ctx_end(cctx);
             cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], cast_val[i] });
         }
 
-        // ---- transfer queue: stream this device's slice out, one chunk per submission (F16 cast or fp32 src) ----
         const uint64_t up_ready    = f16 ? cast_val[i] : compute_val[i];
         vk_buffer &    up_src       = f16 ? upbc->dev_buffer : bc->dev_buffer;
         const size_t   up_src_off   = f16 ? 0 : src_off;
@@ -18355,7 +18303,6 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
             const size_t sz  = std::min(chunk, xbytes - off);
             ggml_vk_ctx_begin(comm->device[i], tctx);
             if (cI == 0) {
-                // gate on this device's slice being ready; double-buffering removes any peer-reuse guard.
                 tctx->s->wait_semaphores.push_back({ comm->prog[i], up_ready });
             }
             ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], slot_off + off, up_src, up_src_off + off, sz);
@@ -18364,7 +18311,6 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
         }
         ggml_vk_submit(tctx, {});
 
-        // ---- compute queue: pull each peer chunk back as it lands, then add it into the fp32 result ----
         ggml_tensor * tmp = comm->tmp_tensor[i];
         for (int d = 0; d < GGML_MAX_DIMS; d++) {
             tmp->ne[d] = tensors[i]->ne[d];
@@ -18379,27 +18325,23 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
             if (k == i) {
                 continue;
             }
-            // one download per chunk, waiting only on that peer's matching upload chunk -- this is what
-            // overlaps the upload and download directions.
+            const size_t p = (k < i) ? k : k - 1;
             for (int cI = 0; cI < K; cI++) {
                 const size_t off = (size_t) cI * chunk;
                 const size_t sz  = std::min(chunk, xbytes - off);
                 ggml_vk_ctx_begin(comm->device[i], cctx);
                 if (comm->proxy) {
-                    // park on the local proxy timeline; the proxy thread signals it once peer k's upload
-                    // of this chunk lands (bridge queued below).
-                    cctx->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + (uint64_t) cI + 1 });
+                    const uint64_t pv = pxy_base[i] + (uint64_t) p * K + (uint64_t) cI + 1;
+                    cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
                     std::lock_guard<std::mutex> lk(comm->bridge_mtx);
                     comm->bridge_q[i].push_back({ comm->device[k]->device, comm->up[k], up_base[k] + (uint64_t) cI + 1,
-                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + (uint64_t) cI + 1 });
+                                                  comm->device[i]->device, comm->pxy[i], pv });
                 } else {
                     cctx->s->wait_semaphores.push_back({ comm->peer_up[i][k], up_base[k] + (uint64_t) cI + 1 });
                 }
                 ggml_vk_buffer_copy_async(cctx, dn_dst, off, comm->host_buf[k][i], slot_off + off, sz);
                 ggml_vk_ctx_end(cctx);
             }
-            // add this peer's slice into the running sum (barrier covers the downloads above). fp32 mode's
-            // uploads read tensors[i], so wait on them first (WAR); F16 uploads read up16, already ordered.
             ggml_vk_ctx_begin(comm->device[i], cctx);
             if (!f16) {
                 cctx->s->wait_semaphores.push_back({ comm->up[i], up_base[i] + (uint64_t) K });
@@ -18419,15 +18361,13 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
     ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
     const size_t n = comm->backends.size();
 
-    // Escape hatch: GGML_VK_COMM_OFF disables this custom AllReduce and lets the meta backend fall back
-    // to its CPU-barriered butterfly (slower, but a safe valve if the comm ever misbehaves).
     static const bool off = getenv("GGML_VK_COMM_OFF") != nullptr;
     if (off) {
         return false;
     }
 
     if (!comm->fast || tensors[0]->type != GGML_TYPE_F32) {
-        return false; // -> meta backend butterfly fallback
+        return false;
     }
     const int64_t ne = ggml_nelements(tensors[0]);
     if (ne == 0) {
@@ -18443,10 +18383,8 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         return false;
     }
 
-    // Large tensors (prefill) use the full-duplex pipeline (~2x); small tensors (decode) take the
-    // single-shot path below, where fixed per-call overhead dominates. Pipeline needs real partials.
     constexpr size_t pipeline_min = 2u << 20;
-    if (comm->pipeline_ok && n == 2 && nbytes >= pipeline_min) {
+    if (comm->pipeline_ok && n >= 2 && nbytes >= pipeline_min) {
         bool all_compute = true;
         for (size_t i = 0; i < n; i++) {
             all_compute = all_compute && (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE);
@@ -18456,11 +18394,6 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         }
     }
 
-    // Single-shot path: gather each slice to host, then reduce, as two batches per device, all ordered on
-    // the GPU progress timeline (no CPU barrier -- the next layer can be submitted while this runs).
-    //
-    // Reserve timeline values: each device advances by 2 (gather, reduce). Proxy mode also reserves 2 pxy
-    // values: +1 bridges the gather's peer-reuse guard, +2 the reduce's wait on the peer's gather.
     std::vector<uint64_t> compute_val(n), gather_val(n), reduce_val(n), prev_reduce(n), pxy_base(n);
     for (size_t i = 0; i < n; i++) {
         prev_reduce[i] = comm->last_reduce[i];
@@ -18471,10 +18404,8 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         comm->last_reduce[i]          = reduce_val[i];
         if (comm->proxy) {
             pxy_base[i]       = comm->pxy_val[i];
-            comm->pxy_val[i] += 2;
+            comm->pxy_val[i] += 2 * (uint64_t) (n - 1);
         }
-        // Recycle the pool once the GPU caught up (non-blocking); during a long prefill the GPU lags, so
-        // cap live buffers and drain when too large, else command-buffer lookup goes quadratic.
         uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(comm->prog[i]);
         if (done < comm->pool_max_val[i] && comm->cmd_pool[i].buffers_in_use() >= 256) {
             vk::SemaphoreWaitInfo wi;
@@ -18490,7 +18421,6 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         comm->pool_max_val[i] = reduce_val[i];
     }
 
-    // Record gather + reduce as two batches in one submit (the queue mutex makes each submit the dominant cost).
     for (size_t i = 0; i < n; i++) {
         ggml_tensor * tmp = comm->tmp_tensor[i];
         for (int d = 0; d < GGML_MAX_DIMS; d++) {
@@ -18503,16 +18433,18 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         ggml_backend_vk_buffer_context * tbc = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
         vk_context c = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
 
-        // gather: wait own compute + peers' previous reduce (host buffer safe to overwrite), copy slice to host.
         ggml_vk_ctx_begin(comm->device[i], c);
         c->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
+        if (comm->proxy) {
+            c->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + (uint64_t) (n - 1) });
+        }
         for (size_t k = 0; k < n; k++) {
             if (k != i) {
+                const size_t p = (k < i) ? k : k - 1;
                 if (comm->proxy) {
-                    c->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + 1 });
                     std::lock_guard<std::mutex> lk(comm->bridge_mtx);
                     comm->bridge_q[i].push_back({ comm->device[k]->device, comm->prog[k], prev_reduce[k],
-                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + 1 });
+                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + p + 1 });
                 } else {
                     c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], prev_reduce[k] });
                 }
@@ -18528,16 +18460,18 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         ggml_vk_ctx_end(c);
         c->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], gather_val[i] });
 
-        // reduce: wait own gather + peers' gather (cross-device), add each peer slice in.
         ggml_vk_ctx_begin(comm->device[i], c);
         c->s->wait_semaphores.push_back({ comm->prog[i], gather_val[i] });
+        if (comm->proxy) {
+            c->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + 2 * (uint64_t) (n - 1) });
+        }
         for (size_t k = 0; k < n; k++) {
             if (k != i) {
+                const size_t p = (k < i) ? k : k - 1;
                 if (comm->proxy) {
-                    c->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + 2 });
                     std::lock_guard<std::mutex> lk(comm->bridge_mtx);
                     comm->bridge_q[i].push_back({ comm->device[k]->device, comm->prog[k], gather_val[k],
-                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + 2 });
+                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + (uint64_t) (n - 1) + p + 1 });
                 } else {
                     c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], gather_val[k] });
                 }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -679,6 +679,8 @@ struct vk_device_struct {
     uint64_t min_imported_host_pointer_alignment;
     bool external_memory_host {};
     bool external_semaphore {};
+    bool external_memory_fd {};      // VK_KHR_external_memory_fd: fd-based memory export/import
+    bool external_memory_dma_buf {}; // VK_EXT_external_memory_dma_buf: cross-device DMA_BUF handle for D2D peer P2P
     bool fp16;
     bool bf16;
     bool pipeline_robustness;
@@ -5743,6 +5745,10 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->external_memory_host = true;
             } else if (strcmp("VK_KHR_external_semaphore_fd", properties.extensionName) == 0) {
                 device->external_semaphore = true;
+            } else if (strcmp("VK_KHR_external_memory_fd", properties.extensionName) == 0) {
+                device->external_memory_fd = true;
+            } else if (strcmp("VK_EXT_external_memory_dma_buf", properties.extensionName) == 0) {
+                device->external_memory_dma_buf = true;
 #if defined(VK_EXT_shader_64bit_indexing)
             } else if (strcmp("VK_EXT_shader_64bit_indexing", properties.extensionName) == 0) {
                 device->shader_64b_indexing = true;
@@ -6073,6 +6079,13 @@ static vk_device ggml_vk_get_device(size_t idx) {
         if (device->external_semaphore) {
             device_extensions.push_back("VK_KHR_external_semaphore");
             device_extensions.push_back("VK_KHR_external_semaphore_fd");
+        }
+        if (device->external_memory_fd) {
+            device_extensions.push_back("VK_KHR_external_memory");
+            device_extensions.push_back("VK_KHR_external_memory_fd");
+        }
+        if (device->external_memory_dma_buf) {
+            device_extensions.push_back("VK_EXT_external_memory_dma_buf");
         }
 
 #if defined(VK_EXT_shader_64bit_indexing)
@@ -17853,6 +17866,10 @@ struct ggml_backend_vk_comm_context {
     std::vector<uint64_t>                   pool_max_val;
     PFN_vkGetSemaphoreFdKHR                 pGetSemFd  = nullptr;
     PFN_vkImportSemaphoreFdKHR              pImportSemFd = nullptr;
+    bool                                    d2d = false; // GGML_VK_COMM_D2D: peer device buffers over PCIe P2P, not host staging
+    PFN_vkGetMemoryFdKHR                    pGetMemFd      = nullptr;
+    PFN_vkGetMemoryFdPropertiesKHR         pGetMemFdProps = nullptr;
+    std::vector<vk_buffer>                  d2d_own; // d2d_own[k] = device k's exportable buffer (== host_buf[k][k])
     std::vector<void*>                      host_ptr;
     std::vector<std::vector<vk_buffer>>     host_buf;
     std::vector<ggml_backend_buffer_t>      tmp_buffer;
@@ -17939,6 +17956,100 @@ static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm
     return dst;
 }
 
+// D2D: a device-local buffer whose memory is exportable via OPAQUE_FD, so a peer GPU can import and read
+// it directly over PCIe P2P -- replacing the host-memory staging on P2P-capable topologies.
+static vk_buffer ggml_vk_comm_create_exportable(vk_device & device, size_t size) {
+    vk_buffer buf = std::make_shared<vk_buffer_struct>();
+    buf->size   = size;
+    buf->device = device;
+    buf->ptr    = nullptr;
+    vk::ExternalMemoryBufferCreateInfo ext_bci{ vk::ExternalMemoryHandleTypeFlagBits::eDmaBufEXT };
+    vk::BufferCreateInfo bci{ {}, size,
+        vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst, vk::SharingMode::eExclusive };
+    bci.pNext = &ext_bci;
+    buf->buffer = device->device.createBuffer(bci);
+    vk::MemoryRequirements             mem_req   = device->device.getBufferMemoryRequirements(buf->buffer);
+    vk::PhysicalDeviceMemoryProperties mem_props = device->physical_device.getMemoryProperties();
+    uint32_t mtype = UINT32_MAX;
+    for (uint32_t t = 0; t < mem_props.memoryTypeCount; t++) {
+        if (!(mem_req.memoryTypeBits & (1u << t))) { continue; }
+        if (mem_props.memoryTypes[t].propertyFlags & vk::MemoryPropertyFlagBits::eDeviceLocal) { mtype = t; break; }
+    }
+    if (mtype == UINT32_MAX) { GGML_LOG_WARN("ggml_vulkan: D2D export: no device-local memory type\n"); return {}; }
+    vk::ExportMemoryAllocateInfo emai{ vk::ExternalMemoryHandleTypeFlagBits::eDmaBufEXT };
+    vk::MemoryAllocateInfo       mai{ mem_req.size, mtype };
+    mai.pNext = &emai;
+    try {
+        buf->device_memory = device->device.allocateMemory(mai);
+    } catch (const vk::SystemError & e) {
+        GGML_LOG_WARN("ggml_vulkan: D2D export: allocateMemory(exportable) failed: %s\n", e.what());
+        return {};
+    }
+    buf->memory_property_flags = mem_props.memoryTypes[mtype].propertyFlags;
+    device->device.bindBufferMemory(buf->buffer, buf->device_memory, 0);
+    return buf;
+}
+
+// D2D: import a peer device's exported buffer memory (OPAQUE_FD) as a local buffer handle on dst_dev.
+// Copies recorded on dst_dev that read this buffer fetch from src_dev's VRAM over PCIe P2P.
+static vk_buffer ggml_vk_comm_import_buffer(ggml_backend_vk_comm_context * comm, vk_device & dst_dev,
+                                            vk_device & src_dev, vk_buffer & src_buf, size_t size) {
+    int fd = -1;
+    VkMemoryGetFdInfoKHR gfi{};
+    gfi.sType      = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+    gfi.memory     = (VkDeviceMemory) src_buf->device_memory;
+    gfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+    if (comm->pGetMemFd((VkDevice) src_dev->device, &gfi, &fd) != VK_SUCCESS || fd < 0) {
+        GGML_LOG_WARN("ggml_vulkan: D2D import: vkGetMemoryFdKHR failed (fd=%d)\n", fd);
+        return {};
+    }
+
+    vk_buffer buf = std::make_shared<vk_buffer_struct>();
+    buf->size   = size;
+    buf->device = dst_dev;
+    buf->ptr    = nullptr;
+    vk::ExternalMemoryBufferCreateInfo ext_bci{ vk::ExternalMemoryHandleTypeFlagBits::eDmaBufEXT };
+    vk::BufferCreateInfo bci{ {}, size,
+        vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst, vk::SharingMode::eExclusive };
+    bci.pNext = &ext_bci;
+    buf->buffer = dst_dev->device.createBuffer(bci);
+    vk::MemoryRequirements mem_req = dst_dev->device.getBufferMemoryRequirements(buf->buffer);
+
+    VkMemoryFdPropertiesKHR fdProps{};
+    fdProps.sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR;
+    comm->pGetMemFdProps((VkDevice) dst_dev->device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT, fd, &fdProps);
+
+    vk::PhysicalDeviceMemoryProperties mem_props = dst_dev->physical_device.getMemoryProperties();
+    uint32_t mtype = UINT32_MAX;
+    for (uint32_t t = 0; t < mem_props.memoryTypeCount; t++) {
+        if (!(mem_req.memoryTypeBits  & (1u << t))) { continue; }
+        if (!(fdProps.memoryTypeBits  & (1u << t))) { continue; }
+        mtype = t;
+        if (mem_props.memoryTypes[t].propertyFlags & vk::MemoryPropertyFlagBits::eDeviceLocal) { break; }
+    }
+    if (mtype == UINT32_MAX) {
+        GGML_LOG_WARN("ggml_vulkan: D2D import: no compatible memory type (fdBits=0x%x reqBits=0x%x)\n",
+                      fdProps.memoryTypeBits, mem_req.memoryTypeBits);
+        return {};
+    }
+
+    VkImportMemoryFdInfoKHR imfi{};
+    imfi.sType      = VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR;
+    imfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+    imfi.fd         = fd;
+    vk::MemoryAllocateInfo mai{ mem_req.size, mtype };
+    mai.pNext = &imfi;
+    try {
+        buf->device_memory = dst_dev->device.allocateMemory(mai);
+    } catch (const vk::SystemError & e) {
+        GGML_LOG_WARN("ggml_vulkan: D2D import: allocateMemory(import) failed: %s\n", e.what());
+        return {};
+    }
+    buf->memory_property_flags = mem_props.memoryTypes[mtype].propertyFlags;
+    dst_dev->device.bindBufferMemory(buf->buffer, buf->device_memory, 0);
+    return buf;
+}
+
 static bool ggml_vk_comm_opaque_fd_supported(ggml_backend_vk_comm_context * comm) {
     const size_t n = comm->device.size();
     uint8_t driver_uuid[VK_UUID_SIZE];
@@ -17988,6 +18099,8 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     }
     comm->use_f16 = (getenv("GGML_VK_COMM_FP32") == nullptr);
     comm->ring    = (getenv("GGML_VK_COMM_RING") != nullptr);
+    comm->d2d     = (getenv("GGML_VK_COMM_D2D") != nullptr);
+    comm->d2d_own.resize(n_backends, nullptr);
     comm->up16_buffer.resize(n_backends, nullptr);
     comm->dn16_buffer.resize(n_backends, nullptr);
     comm->up16_tensor.resize(n_backends, nullptr);
@@ -18000,6 +18113,18 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->pGetSemFd    = (PFN_vkGetSemaphoreFdKHR)    comm->device[0]->device.getProcAddr("vkGetSemaphoreFdKHR");
         comm->pImportSemFd = (PFN_vkImportSemaphoreFdKHR) comm->device[0]->device.getProcAddr("vkImportSemaphoreFdKHR");
         comm->fast = comm->pGetSemFd && comm->pImportSemFd;
+    }
+    if (comm->fast && comm->d2d) {
+        bool dmabuf = true;
+        for (size_t i = 0; i < n_backends; i++) {
+            dmabuf = dmabuf && comm->device[i]->external_memory_fd && comm->device[i]->external_memory_dma_buf;
+        }
+        comm->pGetMemFd      = (PFN_vkGetMemoryFdKHR)           comm->device[0]->device.getProcAddr("vkGetMemoryFdKHR");
+        comm->pGetMemFdProps = (PFN_vkGetMemoryFdPropertiesKHR) comm->device[0]->device.getProcAddr("vkGetMemoryFdPropertiesKHR");
+        comm->d2d = dmabuf && comm->pGetMemFd && comm->pGetMemFdProps;
+        if (!comm->d2d) {
+            GGML_LOG_INFO("ggml_vulkan: comm D2D requested but VK_EXT_external_memory_dma_buf unavailable; using host staging\n");
+        }
     }
     if (comm->fast) {
         comm->prog.resize(n_backends);
@@ -18160,6 +18285,7 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         for (size_t i = 0; i < n; i++) {
             comm->host_buf[k][i].reset();
         }
+        comm->d2d_own[k].reset();
         ggml_vk_comm_aligned_free(comm->host_ptr[k]);
         comm->host_ptr[k] = nullptr;
     }
@@ -18180,15 +18306,50 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
 
     // ring mode needs 2*(n-1) per-step chunks per round (~2x the tensor), double-buffered by round -> 4x.
     const size_t slotcap = (comm->ring ? 4 : 2) * newcap;
-    for (size_t k = 0; k < n; k++) {
-        comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
-        if (!comm->host_ptr[k]) {
-            return false;
+    if (comm->d2d) {
+        // D2D: device k's partials live in an exportable device buffer; peers import it and read over PCIe P2P.
+        bool ok = true;
+        for (size_t k = 0; k < n && ok; k++) {
+            comm->d2d_own[k] = ggml_vk_comm_create_exportable(comm->device[k], slotcap);
+            if (!comm->d2d_own[k]) { ok = false; break; }
+            comm->host_buf[k][k] = comm->d2d_own[k];
+            for (size_t i = 0; i < n; i++) {
+                if (i == k) {
+                    continue;
+                }
+                comm->host_buf[k][i] = ggml_vk_comm_import_buffer(comm, comm->device[i], comm->device[k],
+                                                                  comm->d2d_own[k], slotcap);
+                if (!comm->host_buf[k][i]) { ok = false; break; }
+            }
         }
-        for (size_t i = 0; i < n; i++) {
-            comm->host_buf[k][i] = ggml_vk_buffer_from_host_ptr(comm->device[i], comm->host_ptr[k], slotcap);
-            if (!comm->host_buf[k][i]) {
+        if (ok) {
+            GGML_LOG_INFO("ggml_vulkan: comm D2D peer buffers active (%zu devices, %zu KiB/slot over PCIe P2P)\n",
+                          n, slotcap / 1024);
+        } else {
+            // Peer import unsupported on this driver/topology (e.g. NVIDIA rejects cross-device fd import):
+            // drop the partial D2D buffers, disable D2D, and fall through to host staging -- NOT the slow
+            // meta-backend butterfly. One-time: comm->d2d stays false so later ensure() growths skip D2D.
+            for (size_t k = 0; k < n; k++) {
+                for (size_t i = 0; i < n; i++) {
+                    comm->host_buf[k][i].reset();
+                }
+                comm->d2d_own[k].reset();
+            }
+            comm->d2d = false;
+            GGML_LOG_WARN("ggml_vulkan: comm D2D peer import unsupported here; falling back to host staging\n");
+        }
+    }
+    if (!comm->d2d) {
+        for (size_t k = 0; k < n; k++) {
+            comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
+            if (!comm->host_ptr[k]) {
                 return false;
+            }
+            for (size_t i = 0; i < n; i++) {
+                comm->host_buf[k][i] = ggml_vk_buffer_from_host_ptr(comm->device[i], comm->host_ptr[k], slotcap);
+                if (!comm->host_buf[k][i]) {
+                    return false;
+                }
             }
         }
     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17865,6 +17865,11 @@ struct ggml_backend_vk_comm_context {
     std::vector<vk_command_pool>            cmd_pool_xfer;
     std::vector<uint64_t>                   xfer_pool_max_val;
     uint64_t                                pipe_round = 0;
+    // Ring AllReduce (reduce-scatter + all-gather), O(n) host traffic vs the all-to-all pipeline's O(n^2).
+    // GGML_VK_COMM_RING selects it for large tensors. ring_view[i] is a chunk-sized view of tensors[i].
+    bool                                    ring = false;
+    uint64_t                                ring_round = 0;
+    std::vector<ggml_tensor*>               ring_view;
     bool                                    use_f16 = false;
     std::vector<ggml_backend_buffer_t>      up16_buffer;
     std::vector<ggml_backend_buffer_t>      dn16_buffer;
@@ -17982,11 +17987,13 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->host_buf[k].resize(n_backends);
     }
     comm->use_f16 = (getenv("GGML_VK_COMM_FP32") == nullptr);
+    comm->ring    = (getenv("GGML_VK_COMM_RING") != nullptr);
     comm->up16_buffer.resize(n_backends, nullptr);
     comm->dn16_buffer.resize(n_backends, nullptr);
     comm->up16_tensor.resize(n_backends, nullptr);
     comm->dn16_tensor.resize(n_backends, nullptr);
-    const ggml_init_params ip = { ggml_tensor_overhead() * (3 * n_backends + 8), nullptr, true };
+    comm->ring_view.resize(n_backends, nullptr);
+    const ggml_init_params ip = { ggml_tensor_overhead() * (4 * n_backends + 8), nullptr, true };
     comm->tctx = ggml_init(ip);
 
     if (comm->fast) {
@@ -18171,7 +18178,8 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         }
     }
 
-    const size_t slotcap = 2 * newcap;
+    // ring mode needs 2*(n-1) per-step chunks per round (~2x the tensor), double-buffered by round -> 4x.
+    const size_t slotcap = (comm->ring ? 4 : 2) * newcap;
     for (size_t k = 0; k < n; k++) {
         comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
         if (!comm->host_ptr[k]) {
@@ -18210,6 +18218,9 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         comm->up16_tensor[i]->data   = ggml_backend_buffer_get_base(comm->up16_buffer[i]);
         comm->dn16_tensor[i]->buffer = comm->dn16_buffer[i];
         comm->dn16_tensor[i]->data   = ggml_backend_buffer_get_base(comm->dn16_buffer[i]);
+        if (!comm->ring_view[i]) {
+            comm->ring_view[i] = ggml_new_tensor_1d(comm->tctx, GGML_TYPE_F32, 1); // view into tensors[i], set per use
+        }
     }
     comm->cap = newcap;
     return true;
@@ -18357,6 +18368,102 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
     return true;
 }
 
+// Ring AllReduce: reduce-scatter then all-gather around a ring, O(n) host traffic vs the pipeline's O(n^2).
+// The output is split into n chunks; each of 2*(n-1) steps a device sends one chunk to its next neighbor's
+// host buffer and pulls the matching chunk from its prev neighbor (accumulating in reduce-scatter, copying
+// in all-gather). tensors[i] is the in-place working buffer. fp32 + native-import only for now (the proof
+// of the algorithm); F16 staging and the proxy bridge are follow-ups. GGML_VK_COMM_RING selects this path.
+static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * comm,
+                                                ggml_tensor ** tensors, size_t nbytes) {
+    const size_t   n    = comm->backends.size();
+    const size_t   esz  = ggml_type_size(GGML_TYPE_F32);
+    const int64_t  cels = (ggml_nelements(tensors[0]) + (int64_t) n - 1) / (int64_t) n;
+    const size_t   csz  = (size_t) cels * esz;          // bytes per chunk (last chunk may be shorter)
+    const uint64_t nsteps = 2 * (uint64_t) (n - 1);
+
+    const uint64_t round    = comm->ring_round++;
+    const size_t   slot_off = (size_t) (round & 1) * 2 * comm->cap; // round-slot holds this round's 2(n-1) chunks
+
+    std::vector<uint64_t> compute_val(n), reduce_val(n), prev_reduce(n), up_base(n);
+    for (size_t i = 0; i < n; i++) {
+        prev_reduce[i] = comm->last_reduce[i];
+        compute_val[i] = comm->vkctx[i]->comm_prog_val;
+        reduce_val[i]  = compute_val[i] + nsteps;
+        comm->vkctx[i]->comm_prog_val = reduce_val[i];
+        comm->last_reduce[i]          = reduce_val[i];
+        up_base[i]      = comm->up_val[i];
+        comm->up_val[i] += nsteps;
+        uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(comm->prog[i]);
+        if (done >= comm->pool_max_val[i]) { ggml_vk_command_pool_cleanup(comm->device[i], comm->cmd_pool[i]); }
+        comm->pool_max_val[i] = reduce_val[i];
+        uint64_t xdone = comm->device[i]->device.getSemaphoreCounterValue(comm->up[i]);
+        if (xdone >= comm->xfer_pool_max_val[i]) { ggml_vk_command_pool_cleanup(comm->device[i], comm->cmd_pool_xfer[i]); }
+        comm->xfer_pool_max_val[i] = up_base[i] + nsteps;
+    }
+
+    for (size_t i = 0; i < n; i++) {
+        const size_t nextd = (i + 1) % n;
+        const size_t prevd = (i + n - 1) % n;
+        ggml_backend_vk_buffer_context * bc  = (ggml_backend_vk_buffer_context *) tensors[i]->buffer->context;
+        ggml_backend_vk_buffer_context * tbc = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
+        const size_t  base_off = vk_tensor_offset(tensors[i]) + tensors[i]->view_offs;
+        ggml_tensor * rtmp     = comm->tmp_tensor[i];
+        ggml_tensor * rview    = comm->ring_view[i];
+        char *        tmpbase  = (char *) ggml_backend_buffer_get_base(comm->tmp_buffer[i]);
+
+        vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);      // compute queue: recv + reduce
+        vk_context tctx = ggml_vk_create_temporary_context(comm->cmd_pool_xfer[i]); // transfer queue: send
+
+        for (uint64_t t = 0; t < nsteps; t++) {
+            const bool     rs = (t < (uint64_t) (n - 1));
+            const size_t   s  = (size_t) (rs ? t : t - (n - 1));
+            const size_t   c_send = rs ? (i + n - s) % n : (i + n + 1 - s) % n;
+            const size_t   c_recv = rs ? (i + n - s - 1) % n : (i + n - s) % n;
+            const size_t   send_off = c_send * csz, recv_off = c_recv * csz;
+            const size_t   send_sz = send_off >= nbytes ? 0 : std::min(csz, nbytes - send_off);
+            const size_t   recv_sz = recv_off >= nbytes ? 0 : std::min(csz, nbytes - recv_off);
+            const size_t   hoff = slot_off + (size_t) t * csz;
+
+            ggml_vk_ctx_begin(comm->device[i], tctx);
+            if (t == 0) {
+                tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
+                if (round >= 2) { // WAR: next device finished reading our send buffer in the round that reused this slot
+                    tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][nextd], prev_reduce[nextd] });
+                }
+            } else {
+                tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t }); // prev recv updated c_send
+            }
+            if (send_sz) {
+                ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], hoff, bc->dev_buffer, base_off + send_off, send_sz);
+            }
+            ggml_vk_ctx_end(tctx);
+            tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
+
+            ggml_vk_ctx_begin(comm->device[i], cctx);
+            cctx->s->wait_semaphores.push_back({ comm->peer_up[i][prevd], up_base[prevd] + t + 1 });
+            if (recv_sz) {
+                ggml_vk_buffer_copy_async(cctx, tbc->dev_buffer, 0, comm->host_buf[prevd][i], hoff, recv_sz);
+                ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+                const int64_t rc = (int64_t) (recv_sz / esz);
+                for (ggml_tensor * tt : { rtmp, rview }) {
+                    tt->ne[0] = rc; tt->ne[1] = tt->ne[2] = tt->ne[3] = 1;
+                    tt->nb[0] = esz; tt->nb[1] = tt->nb[2] = tt->nb[3] = (size_t) rc * esz;
+                }
+                rtmp->buffer  = comm->tmp_buffer[i]; rtmp->data  = tmpbase;
+                rview->buffer = tensors[i]->buffer;  rview->data = (char *) tensors[i]->data + recv_off; rview->view_offs = 0;
+                if (rs) { ggml_vk_add(comm->vkctx[i], cctx, rview, rtmp, rview); }
+                else    { ggml_vk_cpy(comm->vkctx[i], cctx, rtmp, rview); }
+                ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+            }
+            ggml_vk_ctx_end(cctx);
+            cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 1 });
+        }
+        ggml_vk_submit(tctx, {});
+        ggml_vk_submit(cctx, {});
+    }
+    return true;
+}
+
 static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor ** tensors) {
     ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
     const size_t n = comm->backends.size();
@@ -18390,6 +18497,9 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
             all_compute = all_compute && (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE);
         }
         if (all_compute) {
+            if (comm->ring && !comm->proxy) { // ring is native-import + fp32 only for now
+                return ggml_backend_vk_comm_allreduce_ring(comm, tensors, nbytes);
+            }
             return ggml_backend_vk_comm_allreduce_pipeline(comm, tensors, nbytes);
         }
     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -72,6 +72,7 @@ typedef struct VkPhysicalDeviceCooperativeMatrixDecodeVectorFeaturesNV {
 #if defined(_MSC_VER)
 # define NOMINMAX 1
 # include <windows.h>
+# include <malloc.h> // _aligned_malloc / _aligned_free
 # define YIELD() YieldProcessor()
 #elif defined(__clang__) || defined(__GNUC__)
 # if defined(__x86_64__) ||defined(__i386__)
@@ -18086,6 +18087,25 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     return comm;
 }
 
+// std::aligned_alloc is not available with MSVC/MinGW; use the Win32 equivalents there.
+// The alignment is a runtime value (VK_EXT_external_memory_host minImportedHostPointerAlignment),
+// so the fixed-alignment ggml_aligned_malloc cannot be used here.
+static void * ggml_vk_comm_aligned_alloc(size_t alignment, size_t size) {
+#if defined(_MSC_VER) || defined(__MINGW32__)
+    return _aligned_malloc(size, alignment);
+#else
+    return std::aligned_alloc(alignment, size);
+#endif
+}
+
+static void ggml_vk_comm_aligned_free(void * ptr) {
+#if defined(_MSC_VER) || defined(__MINGW32__)
+    _aligned_free(ptr);
+#else
+    std::free(ptr);
+#endif
+}
+
 static void ggml_backend_vk_comm_free(void * comm_ctx) {
     ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
     for (size_t i = 0; i < comm->vkctx.size(); i++) {
@@ -18130,7 +18150,7 @@ static void ggml_backend_vk_comm_free(void * comm_ctx) {
         }
     }
     for (void * p : comm->host_ptr) {
-        std::free(p);
+        ggml_vk_comm_aligned_free(p);
     }
     for (ggml_backend_buffer_t b : comm->tmp_buffer) {
         if (b) {
@@ -18165,7 +18185,7 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         for (size_t i = 0; i < n; i++) {
             comm->host_buf[k][i].reset();
         }
-        std::free(comm->host_ptr[k]);
+        ggml_vk_comm_aligned_free(comm->host_ptr[k]);
         comm->host_ptr[k] = nullptr;
     }
     for (size_t i = 0; i < n; i++) {
@@ -18190,7 +18210,7 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
     // for DMA). host_buf[k][i] = device i's import of host_ptr[k]. (Driver-allocated OPAQUE_FD shared
     // memory gave no extra bandwidth here and can't cross mixed GPUs.)
     for (size_t k = 0; k < n; k++) {
-        comm->host_ptr[k] = std::aligned_alloc(comm->align, slotcap);
+        comm->host_ptr[k] = ggml_vk_comm_aligned_alloc(comm->align, slotcap);
         if (!comm->host_ptr[k]) {
             return false;
         }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -679,8 +679,8 @@ struct vk_device_struct {
     uint64_t min_imported_host_pointer_alignment;
     bool external_memory_host {};
     bool external_semaphore {};
-    bool external_memory_fd {};      // VK_KHR_external_memory_fd: fd-based memory export/import
-    bool external_memory_dma_buf {}; // VK_EXT_external_memory_dma_buf: cross-device DMA_BUF handle for D2D peer P2P
+    bool external_memory_fd {};
+    bool external_memory_dma_buf {};
     bool fp16;
     bool bf16;
     bool pipeline_robustness;
@@ -17847,11 +17847,6 @@ static ggml_backend_dev_t ggml_backend_vk_reg_get_device(ggml_backend_reg_t reg,
     return devices[device];
 }
 
-// ---------------------------------------------------------------------------
-// Cross-device collective (AllReduce) for tensor parallelism (SPLIT_MODE_TENSOR).
-// The meta backend discovers these via get_proc_address and prefers them over its
-// generic host-staged butterfly fallback.
-// ---------------------------------------------------------------------------
 struct ggml_backend_vk_comm_context {
     std::vector<ggml_backend_t>             backends;
     std::vector<ggml_backend_vk_context*>   vkctx;
@@ -17866,10 +17861,10 @@ struct ggml_backend_vk_comm_context {
     std::vector<uint64_t>                   pool_max_val;
     PFN_vkGetSemaphoreFdKHR                 pGetSemFd  = nullptr;
     PFN_vkImportSemaphoreFdKHR              pImportSemFd = nullptr;
-    bool                                    d2d = false; // GGML_VK_COMM_D2D: peer device buffers over PCIe P2P, not host staging
+    bool                                    d2d = false;
     PFN_vkGetMemoryFdKHR                    pGetMemFd      = nullptr;
     PFN_vkGetMemoryFdPropertiesKHR         pGetMemFdProps = nullptr;
-    std::vector<vk_buffer>                  d2d_own; // d2d_own[k] = device k's exportable buffer (== host_buf[k][k])
+    std::vector<vk_buffer>                  d2d_own;
     std::vector<void*>                      host_ptr;
     std::vector<std::vector<vk_buffer>>     host_buf;
     std::vector<ggml_backend_buffer_t>      tmp_buffer;
@@ -17882,8 +17877,6 @@ struct ggml_backend_vk_comm_context {
     std::vector<vk_command_pool>            cmd_pool_xfer;
     std::vector<uint64_t>                   xfer_pool_max_val;
     uint64_t                                pipe_round = 0;
-    // Ring AllReduce (reduce-scatter + all-gather), O(n) host traffic vs the all-to-all pipeline's O(n^2).
-    // GGML_VK_COMM_RING selects it for large tensors. ring_view[i] is a chunk-sized view of tensors[i].
     bool                                    ring = false;
     uint64_t                                ring_round = 0;
     std::vector<ggml_tensor*>               ring_view;
@@ -17956,8 +17949,6 @@ static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm
     return dst;
 }
 
-// D2D: a device-local buffer whose memory is exportable via OPAQUE_FD, so a peer GPU can import and read
-// it directly over PCIe P2P -- replacing the host-memory staging on P2P-capable topologies.
 static vk_buffer ggml_vk_comm_create_exportable(vk_device & device, size_t size) {
     vk_buffer buf = std::make_shared<vk_buffer_struct>();
     buf->size   = size;
@@ -17990,8 +17981,6 @@ static vk_buffer ggml_vk_comm_create_exportable(vk_device & device, size_t size)
     return buf;
 }
 
-// D2D: import a peer device's exported buffer memory (OPAQUE_FD) as a local buffer handle on dst_dev.
-// Copies recorded on dst_dev that read this buffer fetch from src_dev's VRAM over PCIe P2P.
 static vk_buffer ggml_vk_comm_import_buffer(ggml_backend_vk_comm_context * comm, vk_device & dst_dev,
                                             vk_device & src_dev, vk_buffer & src_buf, size_t size) {
     int fd = -1;
@@ -18188,9 +18177,6 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
     return comm;
 }
 
-// std::aligned_alloc is not available with MSVC/MinGW; use the Win32 equivalents there.
-// The alignment is a runtime value (VK_EXT_external_memory_host minImportedHostPointerAlignment),
-// so the fixed-alignment ggml_aligned_malloc cannot be used here.
 static void * ggml_vk_comm_aligned_alloc(size_t alignment, size_t size) {
 #if defined(_MSC_VER) || defined(__MINGW32__)
     return _aligned_malloc(size, alignment);
@@ -18304,10 +18290,8 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         }
     }
 
-    // ring mode needs 2*(n-1) per-step chunks per round (~2x the tensor), double-buffered by round -> 4x.
     const size_t slotcap = (comm->ring ? 4 : 2) * newcap;
     if (comm->d2d) {
-        // D2D: device k's partials live in an exportable device buffer; peers import it and read over PCIe P2P.
         bool ok = true;
         for (size_t k = 0; k < n && ok; k++) {
             comm->d2d_own[k] = ggml_vk_comm_create_exportable(comm->device[k], slotcap);
@@ -18326,9 +18310,6 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
             GGML_LOG_INFO("ggml_vulkan: comm D2D peer buffers active (%zu devices, %zu KiB/slot over PCIe P2P)\n",
                           n, slotcap / 1024);
         } else {
-            // Peer import unsupported on this driver/topology (e.g. NVIDIA rejects cross-device fd import):
-            // drop the partial D2D buffers, disable D2D, and fall through to host staging -- NOT the slow
-            // meta-backend butterfly. One-time: comm->d2d stays false so later ensure() growths skip D2D.
             for (size_t k = 0; k < n; k++) {
                 for (size_t i = 0; i < n; i++) {
                     comm->host_buf[k][i].reset();
@@ -18380,7 +18361,7 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         comm->dn16_tensor[i]->buffer = comm->dn16_buffer[i];
         comm->dn16_tensor[i]->data   = ggml_backend_buffer_get_base(comm->dn16_buffer[i]);
         if (!comm->ring_view[i]) {
-            comm->ring_view[i] = ggml_new_tensor_1d(comm->tctx, GGML_TYPE_F32, 1); // view into tensors[i], set per use
+            comm->ring_view[i] = ggml_new_tensor_1d(comm->tctx, GGML_TYPE_F32, 1);
         }
     }
     comm->cap = newcap;
@@ -18529,25 +18510,20 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
     return true;
 }
 
-// Ring AllReduce: reduce-scatter then all-gather around a ring, O(n) host traffic vs the pipeline's O(n^2).
-// The output is split into n chunks; each of 2*(n-1) steps a device sends one chunk to its next neighbor's
-// host buffer and pulls the matching chunk from its prev neighbor (accumulating in reduce-scatter, copying
-// in all-gather). tensors[i] is the in-place working buffer. Supports native peer-import and the CPU-proxy
-// bridge (for RADV/cross-vendor); fp32 staging only for now (F16 is a follow-up). GGML_VK_COMM_RING selects it.
 static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * comm,
                                                 ggml_tensor ** tensors, size_t nbytes) {
     const size_t   n    = comm->backends.size();
-    const bool     f16  = comm->use_f16;                          // F16 staging: cast each chunk before transport
-    const size_t   esz  = ggml_type_size(GGML_TYPE_F32);          // tensors[i] (the accumulator) is fp32
-    const size_t   xsz  = f16 ? sizeof(uint16_t) : esz;           // transported element size
+    const bool     f16  = comm->use_f16;
+    const size_t   esz  = ggml_type_size(GGML_TYPE_F32);
+    const size_t   xsz  = f16 ? sizeof(uint16_t) : esz;
     const int64_t  nel  = ggml_nelements(tensors[0]);
-    const int64_t  cels = (nel + (int64_t) n - 1) / (int64_t) n;  // elements per chunk (last chunk may be shorter)
-    const size_t   xcsz = (size_t) cels * xsz;                    // transported bytes per chunk
+    const int64_t  cels = (nel + (int64_t) n - 1) / (int64_t) n;
+    const size_t   xcsz = (size_t) cels * xsz;
     const uint64_t nsteps = 2 * (uint64_t) (n - 1);
-    const uint64_t nprog  = nsteps + (f16 ? 1 : 0);               // f16 adds one pre-cast prog step
+    const uint64_t nprog  = nsteps + (f16 ? 1 : 0);
 
     const uint64_t round    = comm->ring_round++;
-    const size_t   slot_off = (size_t) (round & 1) * 2 * comm->cap; // round-slot holds this round's 2(n-1) chunks
+    const size_t   slot_off = (size_t) (round & 1) * 2 * comm->cap;
 
     std::vector<uint64_t> compute_val(n), reduce_val(n), prev_reduce(n), up_base(n), pxy_base(n);
     for (size_t i = 0; i < n; i++) {
@@ -18560,7 +18536,7 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
         comm->up_val[i] += nsteps;
         if (comm->proxy) {
             pxy_base[i]       = comm->pxy_val[i];
-            comm->pxy_val[i] += nsteps + 1; // nsteps recv bridges + 1 cross-round WAR bridge
+            comm->pxy_val[i] += nsteps + 1;
         }
         uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(comm->prog[i]);
         if (done >= comm->pool_max_val[i]) { ggml_vk_command_pool_cleanup(comm->device[i], comm->cmd_pool[i]); }
@@ -18576,8 +18552,8 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
         ggml_tensor * rview = comm->ring_view[i];
         char *        tbase = (char *) tensors[i]->data;
 
-        vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);      // compute queue: recv + reduce
-        vk_context tctx = ggml_vk_create_temporary_context(comm->cmd_pool_xfer[i]); // transfer queue: send
+        vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
+        vk_context tctx = ggml_vk_create_temporary_context(comm->cmd_pool_xfer[i]);
 
         auto chunk_cels = [&](size_t c) -> int64_t {
             const int64_t off = (int64_t) c * cels;
@@ -18590,8 +18566,6 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
         };
 
         if (f16) {
-            // fp32 accumulator (tensors[i]) + F16 transport: each reduced chunk is cast to F16 (folded into the
-            // recv step, so just one extra pre-cast prog value). Per-step up16 slots avoid a send-buffer WAR.
             ggml_backend_vk_buffer_context * ubc = (ggml_backend_vk_buffer_context *) comm->up16_buffer[i]->context;
             ggml_backend_vk_buffer_context * dbc = (ggml_backend_vk_buffer_context *) comm->dn16_buffer[i]->context;
             ggml_tensor * up16t = comm->up16_tensor[i];
@@ -18599,10 +18573,10 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
             char *        ubase = (char *) ggml_backend_buffer_get_base(comm->up16_buffer[i]);
             char *        dbase = (char *) ggml_backend_buffer_get_base(comm->dn16_buffer[i]);
 
-            const int64_t cels0 = chunk_cels(i); // chunk i is the first send (t==0)
+            const int64_t cels0 = chunk_cels(i);
             ggml_vk_ctx_begin(comm->device[i], cctx);
             cctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
-            cctx->s->wait_semaphores.push_back({ comm->up[i],   up_base[i] }); // up16 free of the previous round's sends
+            cctx->s->wait_semaphores.push_back({ comm->up[i],   up_base[i] });
             if (cels0) {
                 set_view(rview, tensors[i]->buffer,  tbase + (size_t) i * cels * esz, cels0, esz);
                 set_view(up16t, comm->up16_buffer[i], ubase,                          cels0, xsz);
@@ -18617,7 +18591,7 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
                 const size_t  c_send = rs ? (i + n - s) % n : (i + n + 1 - s) % n;
                 const size_t  c_recv = rs ? (i + n - s - 1) % n : (i + n - s) % n;
                 const int64_t scels = chunk_cels(c_send), rcels = chunk_cels(c_recv);
-                const size_t  uoff = (size_t) t * (size_t) cels * xsz; // per-step up16 slot
+                const size_t  uoff = (size_t) t * (size_t) cels * xsz;
                 const size_t  hoff = slot_off + uoff;
 
                 ggml_vk_ctx_begin(comm->device[i], tctx);
@@ -18635,7 +18609,7 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
                         }
                     }
                 } else {
-                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 1 }); // cast for c_send done
+                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 1 });
                 }
                 if (scels) {
                     ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], hoff, ubc->dev_buffer, uoff, (size_t) scels * xsz);
@@ -18658,10 +18632,10 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
                     ggml_vk_sync_buffers(comm->vkctx[i], cctx);
                     set_view(dn16t, comm->dn16_buffer[i], dbase,                                 rcels, xsz);
                     set_view(rview, tensors[i]->buffer,   tbase + (size_t) c_recv * cels * esz,  rcels, esz);
-                    if (rs) { ggml_vk_add(comm->vkctx[i], cctx, rview, dn16t, rview); } // fp32 += F16
-                    else    { ggml_vk_cpy(comm->vkctx[i], cctx, dn16t, rview); }        // F16 -> fp32
+                    if (rs) { ggml_vk_add(comm->vkctx[i], cctx, rview, dn16t, rview); }
+                    else    { ggml_vk_cpy(comm->vkctx[i], cctx, dn16t, rview); }
                     ggml_vk_sync_buffers(comm->vkctx[i], cctx);
-                    if (t + 1 < nsteps) { // cast the just-reduced chunk (== next step's send) to F16
+                    if (t + 1 < nsteps) {
                         set_view(up16t, comm->up16_buffer[i], ubase + (size_t) (t + 1) * cels * xsz, rcels, xsz);
                         ggml_vk_cpy(comm->vkctx[i], cctx, rview, up16t);
                         ggml_vk_sync_buffers(comm->vkctx[i], cctx);
@@ -18773,7 +18747,7 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
             all_compute = all_compute && (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE);
         }
         if (all_compute) {
-            if (comm->ring) { // ring supports native-import and CPU-proxy; fp32 staging only for now
+            if (comm->ring) {
                 return ggml_backend_vk_comm_allreduce_ring(comm, tensors, nbytes);
             }
             return ggml_backend_vk_comm_allreduce_pipeline(comm, tensors, nbytes);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -18537,10 +18537,14 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
 static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * comm,
                                                 ggml_tensor ** tensors, size_t nbytes) {
     const size_t   n    = comm->backends.size();
-    const size_t   esz  = ggml_type_size(GGML_TYPE_F32);
-    const int64_t  cels = (ggml_nelements(tensors[0]) + (int64_t) n - 1) / (int64_t) n;
-    const size_t   csz  = (size_t) cels * esz;          // bytes per chunk (last chunk may be shorter)
+    const bool     f16  = comm->use_f16;                          // F16 staging: cast each chunk before transport
+    const size_t   esz  = ggml_type_size(GGML_TYPE_F32);          // tensors[i] (the accumulator) is fp32
+    const size_t   xsz  = f16 ? sizeof(uint16_t) : esz;           // transported element size
+    const int64_t  nel  = ggml_nelements(tensors[0]);
+    const int64_t  cels = (nel + (int64_t) n - 1) / (int64_t) n;  // elements per chunk (last chunk may be shorter)
+    const size_t   xcsz = (size_t) cels * xsz;                    // transported bytes per chunk
     const uint64_t nsteps = 2 * (uint64_t) (n - 1);
+    const uint64_t nprog  = nsteps + (f16 ? 1 : 0);               // f16 adds one pre-cast prog step
 
     const uint64_t round    = comm->ring_round++;
     const size_t   slot_off = (size_t) (round & 1) * 2 * comm->cap; // round-slot holds this round's 2(n-1) chunks
@@ -18549,7 +18553,7 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
     for (size_t i = 0; i < n; i++) {
         prev_reduce[i] = comm->last_reduce[i];
         compute_val[i] = comm->vkctx[i]->comm_prog_val;
-        reduce_val[i]  = compute_val[i] + nsteps;
+        reduce_val[i]  = compute_val[i] + nprog;
         comm->vkctx[i]->comm_prog_val = reduce_val[i];
         comm->last_reduce[i]          = reduce_val[i];
         up_base[i]      = comm->up_val[i];
@@ -18569,75 +18573,166 @@ static bool ggml_backend_vk_comm_allreduce_ring(ggml_backend_vk_comm_context * c
     for (size_t i = 0; i < n; i++) {
         const size_t nextd = (i + 1) % n;
         const size_t prevd = (i + n - 1) % n;
-        ggml_backend_vk_buffer_context * bc  = (ggml_backend_vk_buffer_context *) tensors[i]->buffer->context;
-        ggml_backend_vk_buffer_context * tbc = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
-        const size_t  base_off = vk_tensor_offset(tensors[i]) + tensors[i]->view_offs;
-        ggml_tensor * rtmp     = comm->tmp_tensor[i];
-        ggml_tensor * rview    = comm->ring_view[i];
-        char *        tmpbase  = (char *) ggml_backend_buffer_get_base(comm->tmp_buffer[i]);
+        ggml_tensor * rview = comm->ring_view[i];
+        char *        tbase = (char *) tensors[i]->data;
 
         vk_context cctx = ggml_vk_create_temporary_context(comm->cmd_pool[i]);      // compute queue: recv + reduce
         vk_context tctx = ggml_vk_create_temporary_context(comm->cmd_pool_xfer[i]); // transfer queue: send
 
-        for (uint64_t t = 0; t < nsteps; t++) {
-            const bool     rs = (t < (uint64_t) (n - 1));
-            const size_t   s  = (size_t) (rs ? t : t - (n - 1));
-            const size_t   c_send = rs ? (i + n - s) % n : (i + n + 1 - s) % n;
-            const size_t   c_recv = rs ? (i + n - s - 1) % n : (i + n - s) % n;
-            const size_t   send_off = c_send * csz, recv_off = c_recv * csz;
-            const size_t   send_sz = send_off >= nbytes ? 0 : std::min(csz, nbytes - send_off);
-            const size_t   recv_sz = recv_off >= nbytes ? 0 : std::min(csz, nbytes - recv_off);
-            const size_t   hoff = slot_off + (size_t) t * csz;
+        auto chunk_cels = [&](size_t c) -> int64_t {
+            const int64_t off = (int64_t) c * cels;
+            return off >= nel ? 0 : std::min(cels, nel - off);
+        };
+        auto set_view = [](ggml_tensor * tt, ggml_backend_buffer_t buf, char * data, int64_t ne0, size_t es) {
+            tt->ne[0] = ne0; tt->ne[1] = tt->ne[2] = tt->ne[3] = 1;
+            tt->nb[0] = es;  tt->nb[1] = tt->nb[2] = tt->nb[3] = (size_t) ne0 * es;
+            tt->buffer = buf; tt->data = data; tt->view_offs = 0;
+        };
 
-            ggml_vk_ctx_begin(comm->device[i], tctx);
-            if (t == 0) {
-                tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
-                if (round >= 2) { // WAR: next device finished reading our send buffer in the round that reused this slot
-                    if (comm->proxy) {
-                        const uint64_t pv = pxy_base[i] + 1;
-                        tctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
-                        std::lock_guard<std::mutex> lk(comm->bridge_mtx);
-                        comm->bridge_q[i].push_back({ comm->device[nextd]->device, comm->prog[nextd], prev_reduce[nextd],
-                                                      comm->device[i]->device, comm->pxy[i], pv });
-                    } else {
-                        tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][nextd], prev_reduce[nextd] });
-                    }
-                }
-            } else {
-                tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t }); // prev recv updated c_send
-            }
-            if (send_sz) {
-                ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], hoff, bc->dev_buffer, base_off + send_off, send_sz);
-            }
-            ggml_vk_ctx_end(tctx);
-            tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
+        if (f16) {
+            // fp32 accumulator (tensors[i]) + F16 transport: each reduced chunk is cast to F16 (folded into the
+            // recv step, so just one extra pre-cast prog value). Per-step up16 slots avoid a send-buffer WAR.
+            ggml_backend_vk_buffer_context * ubc = (ggml_backend_vk_buffer_context *) comm->up16_buffer[i]->context;
+            ggml_backend_vk_buffer_context * dbc = (ggml_backend_vk_buffer_context *) comm->dn16_buffer[i]->context;
+            ggml_tensor * up16t = comm->up16_tensor[i];
+            ggml_tensor * dn16t = comm->dn16_tensor[i];
+            char *        ubase = (char *) ggml_backend_buffer_get_base(comm->up16_buffer[i]);
+            char *        dbase = (char *) ggml_backend_buffer_get_base(comm->dn16_buffer[i]);
 
+            const int64_t cels0 = chunk_cels(i); // chunk i is the first send (t==0)
             ggml_vk_ctx_begin(comm->device[i], cctx);
-            if (comm->proxy) {
-                const uint64_t pv = pxy_base[i] + 2 + t;
-                cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
-                std::lock_guard<std::mutex> lk(comm->bridge_mtx);
-                comm->bridge_q[i].push_back({ comm->device[prevd]->device, comm->up[prevd], up_base[prevd] + t + 1,
-                                              comm->device[i]->device, comm->pxy[i], pv });
-            } else {
-                cctx->s->wait_semaphores.push_back({ comm->peer_up[i][prevd], up_base[prevd] + t + 1 });
-            }
-            if (recv_sz) {
-                ggml_vk_buffer_copy_async(cctx, tbc->dev_buffer, 0, comm->host_buf[prevd][i], hoff, recv_sz);
-                ggml_vk_sync_buffers(comm->vkctx[i], cctx);
-                const int64_t rc = (int64_t) (recv_sz / esz);
-                for (ggml_tensor * tt : { rtmp, rview }) {
-                    tt->ne[0] = rc; tt->ne[1] = tt->ne[2] = tt->ne[3] = 1;
-                    tt->nb[0] = esz; tt->nb[1] = tt->nb[2] = tt->nb[3] = (size_t) rc * esz;
-                }
-                rtmp->buffer  = comm->tmp_buffer[i]; rtmp->data  = tmpbase;
-                rview->buffer = tensors[i]->buffer;  rview->data = (char *) tensors[i]->data + recv_off; rview->view_offs = 0;
-                if (rs) { ggml_vk_add(comm->vkctx[i], cctx, rview, rtmp, rview); }
-                else    { ggml_vk_cpy(comm->vkctx[i], cctx, rtmp, rview); }
-                ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+            cctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
+            cctx->s->wait_semaphores.push_back({ comm->up[i],   up_base[i] }); // up16 free of the previous round's sends
+            if (cels0) {
+                set_view(rview, tensors[i]->buffer,  tbase + (size_t) i * cels * esz, cels0, esz);
+                set_view(up16t, comm->up16_buffer[i], ubase,                          cels0, xsz);
+                ggml_vk_cpy(comm->vkctx[i], cctx, rview, up16t);
             }
             ggml_vk_ctx_end(cctx);
-            cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 1 });
+            cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + 1 });
+
+            for (uint64_t t = 0; t < nsteps; t++) {
+                const bool    rs = (t < (uint64_t) (n - 1));
+                const size_t  s  = (size_t) (rs ? t : t - (n - 1));
+                const size_t  c_send = rs ? (i + n - s) % n : (i + n + 1 - s) % n;
+                const size_t  c_recv = rs ? (i + n - s - 1) % n : (i + n - s) % n;
+                const int64_t scels = chunk_cels(c_send), rcels = chunk_cels(c_recv);
+                const size_t  uoff = (size_t) t * (size_t) cels * xsz; // per-step up16 slot
+                const size_t  hoff = slot_off + uoff;
+
+                ggml_vk_ctx_begin(comm->device[i], tctx);
+                if (t == 0) {
+                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + 1 });
+                    if (round >= 2) {
+                        if (comm->proxy) {
+                            const uint64_t pv = pxy_base[i] + 1;
+                            tctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                            std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                            comm->bridge_q[i].push_back({ comm->device[nextd]->device, comm->prog[nextd], prev_reduce[nextd],
+                                                          comm->device[i]->device, comm->pxy[i], pv });
+                        } else {
+                            tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][nextd], prev_reduce[nextd] });
+                        }
+                    }
+                } else {
+                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 1 }); // cast for c_send done
+                }
+                if (scels) {
+                    ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], hoff, ubc->dev_buffer, uoff, (size_t) scels * xsz);
+                }
+                ggml_vk_ctx_end(tctx);
+                tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
+
+                ggml_vk_ctx_begin(comm->device[i], cctx);
+                if (comm->proxy) {
+                    const uint64_t pv = pxy_base[i] + 2 + t;
+                    cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                    comm->bridge_q[i].push_back({ comm->device[prevd]->device, comm->up[prevd], up_base[prevd] + t + 1,
+                                                  comm->device[i]->device, comm->pxy[i], pv });
+                } else {
+                    cctx->s->wait_semaphores.push_back({ comm->peer_up[i][prevd], up_base[prevd] + t + 1 });
+                }
+                if (rcels) {
+                    ggml_vk_buffer_copy_async(cctx, dbc->dev_buffer, 0, comm->host_buf[prevd][i], hoff, (size_t) rcels * xsz);
+                    ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+                    set_view(dn16t, comm->dn16_buffer[i], dbase,                                 rcels, xsz);
+                    set_view(rview, tensors[i]->buffer,   tbase + (size_t) c_recv * cels * esz,  rcels, esz);
+                    if (rs) { ggml_vk_add(comm->vkctx[i], cctx, rview, dn16t, rview); } // fp32 += F16
+                    else    { ggml_vk_cpy(comm->vkctx[i], cctx, dn16t, rview); }        // F16 -> fp32
+                    ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+                    if (t + 1 < nsteps) { // cast the just-reduced chunk (== next step's send) to F16
+                        set_view(up16t, comm->up16_buffer[i], ubase + (size_t) (t + 1) * cels * xsz, rcels, xsz);
+                        ggml_vk_cpy(comm->vkctx[i], cctx, rview, up16t);
+                        ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+                    }
+                }
+                ggml_vk_ctx_end(cctx);
+                cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 2 });
+            }
+        } else {
+            ggml_backend_vk_buffer_context * bc  = (ggml_backend_vk_buffer_context *) tensors[i]->buffer->context;
+            ggml_backend_vk_buffer_context * tbc = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
+            const size_t  base_off = vk_tensor_offset(tensors[i]) + tensors[i]->view_offs;
+            ggml_tensor * rtmp     = comm->tmp_tensor[i];
+            char *        tmpbase  = (char *) ggml_backend_buffer_get_base(comm->tmp_buffer[i]);
+
+            for (uint64_t t = 0; t < nsteps; t++) {
+                const bool     rs = (t < (uint64_t) (n - 1));
+                const size_t   s  = (size_t) (rs ? t : t - (n - 1));
+                const size_t   c_send = rs ? (i + n - s) % n : (i + n + 1 - s) % n;
+                const size_t   c_recv = rs ? (i + n - s - 1) % n : (i + n - s) % n;
+                const size_t   send_off = c_send * xcsz, recv_off = c_recv * xcsz;
+                const size_t   send_sz = send_off >= nbytes ? 0 : std::min(xcsz, nbytes - send_off);
+                const size_t   recv_sz = recv_off >= nbytes ? 0 : std::min(xcsz, nbytes - recv_off);
+                const size_t   hoff = slot_off + (size_t) t * xcsz;
+
+                ggml_vk_ctx_begin(comm->device[i], tctx);
+                if (t == 0) {
+                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
+                    if (round >= 2) {
+                        if (comm->proxy) {
+                            const uint64_t pv = pxy_base[i] + 1;
+                            tctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                            std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                            comm->bridge_q[i].push_back({ comm->device[nextd]->device, comm->prog[nextd], prev_reduce[nextd],
+                                                          comm->device[i]->device, comm->pxy[i], pv });
+                        } else {
+                            tctx->s->wait_semaphores.push_back({ comm->peer_prog[i][nextd], prev_reduce[nextd] });
+                        }
+                    }
+                } else {
+                    tctx->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] + t });
+                }
+                if (send_sz) {
+                    ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], hoff, bc->dev_buffer, base_off + send_off, send_sz);
+                }
+                ggml_vk_ctx_end(tctx);
+                tctx->seqs.back().back().signal_semaphores.push_back({ comm->up[i], up_base[i] + t + 1 });
+
+                ggml_vk_ctx_begin(comm->device[i], cctx);
+                if (comm->proxy) {
+                    const uint64_t pv = pxy_base[i] + 2 + t;
+                    cctx->s->wait_semaphores.push_back({ comm->pxy[i], pv });
+                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                    comm->bridge_q[i].push_back({ comm->device[prevd]->device, comm->up[prevd], up_base[prevd] + t + 1,
+                                                  comm->device[i]->device, comm->pxy[i], pv });
+                } else {
+                    cctx->s->wait_semaphores.push_back({ comm->peer_up[i][prevd], up_base[prevd] + t + 1 });
+                }
+                if (recv_sz) {
+                    ggml_vk_buffer_copy_async(cctx, tbc->dev_buffer, 0, comm->host_buf[prevd][i], hoff, recv_sz);
+                    ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+                    const int64_t rc = (int64_t) (recv_sz / esz);
+                    set_view(rtmp, comm->tmp_buffer[i], tmpbase,                                 rc, esz);
+                    set_view(rview, tensors[i]->buffer, tbase + recv_off,                        rc, esz);
+                    if (rs) { ggml_vk_add(comm->vkctx[i], cctx, rview, rtmp, rview); }
+                    else    { ggml_vk_cpy(comm->vkctx[i], cctx, rtmp, rview); }
+                    ggml_vk_sync_buffers(comm->vkctx[i], cctx);
+                }
+                ggml_vk_ctx_end(cctx);
+                cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], compute_val[i] + t + 1 });
+            }
         }
         ggml_vk_submit(tctx, {});
         ggml_vk_submit(cctx, {});

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -67,6 +67,7 @@ typedef struct VkPhysicalDeviceCooperativeMatrixDecodeVectorFeaturesNV {
 #include <future>
 #include <condition_variable>
 #include <thread>
+#include <atomic>
 
 #if defined(_MSC_VER)
 # define NOMINMAX 1
@@ -17851,15 +17852,12 @@ struct ggml_backend_vk_comm_context {
     size_t                                  align = 4096;
     size_t                                  cap   = 0;
     bool                                    fast  = false;
-    // Per device: an exportable monotonic timeline ("progress") semaphore. graph_compute and the
-    // gather/reduce steps wait the previous value and signal the next, so the per-layer AllReduce is
-    // ordered entirely on the GPU. prog[i] is also published in vkctx[i]->comm_prog_sem.
+    // Exportable per-device "progress" timeline; the AllReduce steps wait+signal it, ordering the whole
+    // reduction on the GPU (no CPU barriers). Also published in vkctx[i]->comm_prog_sem.
     std::vector<vk::Semaphore>              prog;          // prog[i] lives on device i
     std::vector<std::vector<vk::Semaphore>> peer_prog;     // peer_prog[i][j] = device i's import of prog[j]
     std::vector<uint64_t>                   last_reduce;   // last reduce value signalled, per device
-    // Dedicated command pool per device; its buffers are recycled (not leaked into the shared queue
-    // pool) once the GPU has caught up, tracked by the highest reduce value recorded into it.
-    std::vector<vk_command_pool>            cmd_pool;
+    std::vector<vk_command_pool>            cmd_pool;      // per-device pool, recycled once the GPU catches up
     std::vector<uint64_t>                   pool_max_val;
     PFN_vkGetSemaphoreFdKHR                 pGetSemFd  = nullptr;
     PFN_vkImportSemaphoreFdKHR              pImportSemFd = nullptr;
@@ -17869,12 +17867,8 @@ struct ggml_backend_vk_comm_context {
     std::vector<ggml_backend_buffer_t>      tmp_buffer;    // device-local scratch per device (peer data for the add)
     std::vector<ggml_tensor*>               tmp_tensor;
     ggml_context *                          tctx = nullptr;
-    // Chunked full-duplex pipeline (large tensors only): split each slice into chunks, stream the
-    // uploads (this device's slice -> host) on the dedicated TRANSFER queue while the COMPUTE queue
-    // pulls the peer's already-uploaded chunks back. Upload and download then run concurrently over
-    // the full-duplex PCIe link (~T instead of ~2T). up[i] is an exportable per-chunk progress
-    // timeline so the peer's download can wait on individual chunks; cmd_pool_xfer[i] feeds the
-    // transfer queue. pipeline_ok requires a transfer queue distinct from the compute queue.
+    // Chunked full-duplex pipeline (large tensors): upload this device's slice on the TRANSFER queue
+    // while the COMPUTE queue pulls peer chunks back, overlapping both PCIe directions (~T not ~2T).
     bool                                    pipeline_ok = false;
     std::vector<vk::Semaphore>              up;            // up[i]: exportable upload-progress timeline on device i
     std::vector<std::vector<vk::Semaphore>> peer_up;       // peer_up[i][j] = device i's import of up[j]
@@ -17882,16 +17876,49 @@ struct ggml_backend_vk_comm_context {
     std::vector<vk_command_pool>            cmd_pool_xfer; // dedicated transfer-queue pool per device
     std::vector<uint64_t>                   xfer_pool_max_val;
     uint64_t                                pipe_round = 0; // pipeline allreduce counter; its parity picks the host slot
-    // F16 staging (the lever NCCL uses -- bf16_RING_LL): cast each fp32 partial to F16 on-device before
-    // the host transfer, so only half the bytes cross the bandwidth-bound PCIe link. up16 holds the cast
-    // partial (upload source); dn16 receives the peer's F16 slice (then added straight into the fp32
-    // result via the mixed-type add pipeline). Pipeline path only; the single-shot/TG path stays fp32.
+    // F16 staging: cast each fp32 partial to F16 before the host transfer, so only half the bytes cross
+    // the bandwidth-bound link. up16 = cast partial (upload src); dn16 = peer's F16 slice. Pipeline only.
     bool                                    use_f16 = false;
     std::vector<ggml_backend_buffer_t>      up16_buffer;
     std::vector<ggml_backend_buffer_t>      dn16_buffer;
     std::vector<ggml_tensor*>               up16_tensor;
     std::vector<ggml_tensor*>               dn16_tensor;
+    // CPU-proxy cross-device sync: portable fallback when importing a peer's OPAQUE_FD timeline is
+    // unavailable (cross-vendor) or forced via GGML_VK_COMM_PROXY. A helper thread host-signals a local
+    // pxy[] timeline that the consumer's download is parked on, standing in for the imported peer timeline.
+    bool                                    proxy = false;
+    std::vector<vk::Semaphore>              pxy;       // pxy[i]: local (non-exported) proxy timeline on device i
+    std::vector<uint64_t>                   pxy_val;   // running proxy-signal counter, per device
+    struct bridge_task { vk::Device wdev; vk::Semaphore wsem; uint64_t wval; vk::Device sdev; vk::Semaphore ssem; uint64_t sval; };
+    std::vector<std::deque<bridge_task>>    bridge_q;  // one FIFO of pending bridges per consumer device
+    std::mutex                              bridge_mtx;
+    std::thread                             proxy_thread;
+    std::atomic<bool>                       proxy_stop{false};
 };
+
+// Proxy thread: when a queued bridge's peer timeline (wsem) reaches wval, host-signal this device's pxy[]
+// to sval and the parked download wakes. FIFO per consumer keeps pxy[] monotonic; spin-then-yield.
+static void ggml_vk_comm_proxy_loop(ggml_backend_vk_comm_context * comm) {
+    while (!comm->proxy_stop.load(std::memory_order_relaxed)) {
+        bool progress = false;
+        for (size_t q = 0; q < comm->bridge_q.size(); q++) {
+            for (;;) {
+                ggml_backend_vk_comm_context::bridge_task t;
+                {
+                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                    if (comm->bridge_q[q].empty()) { break; }
+                    t = comm->bridge_q[q].front();
+                    if (t.wdev.getSemaphoreCounterValue(t.wsem) < t.wval) { break; } // head not ready
+                    comm->bridge_q[q].pop_front();
+                }
+                vk::SemaphoreSignalInfo si{ t.ssem, t.sval };
+                t.sdev.signalSemaphore(si);
+                progress = true;
+            }
+        }
+        if (!progress) { std::this_thread::yield(); }
+    }
+}
 
 static vk::Semaphore ggml_vk_create_export_timeline(vk_device & device) {
     vk::ExportSemaphoreCreateInfo esci{ vk::ExternalSemaphoreHandleTypeFlagBits::eOpaqueFd };
@@ -17927,6 +17954,36 @@ static vk::Semaphore ggml_vk_import_timeline(ggml_backend_vk_comm_context * comm
     return dst;
 }
 
+// Whether cross-device OPAQUE_FD timeline import is officially supported: the handle must be exportable
+// and importable on every device, sharing one driverUUID (OPAQUE_FD payloads are driver-private). Gate on
+// the driver, not the device -- NVIDIA imports cross-device within one driver despite differing deviceUUIDs.
+static bool ggml_vk_comm_opaque_fd_supported(ggml_backend_vk_comm_context * comm) {
+    const size_t n = comm->device.size();
+    uint8_t driver_uuid[VK_UUID_SIZE];
+    for (size_t i = 0; i < n; i++) {
+        vk::PhysicalDeviceIDProperties id;
+        vk::PhysicalDeviceProperties2  p2;
+        p2.pNext = &id;
+        comm->device[i]->physical_device.getProperties2(&p2);
+        if (i == 0) {
+            memcpy(driver_uuid, id.driverUUID.data(), VK_UUID_SIZE);
+        } else if (memcmp(driver_uuid, id.driverUUID.data(), VK_UUID_SIZE) != 0) {
+            return false;
+        }
+
+        vk::SemaphoreTypeCreateInfo               stci{ vk::SemaphoreType::eTimeline, 0 };
+        vk::PhysicalDeviceExternalSemaphoreInfo   esi{ vk::ExternalSemaphoreHandleTypeFlagBits::eOpaqueFd };
+        esi.pNext = &stci;
+        vk::ExternalSemaphoreProperties esp = comm->device[i]->physical_device.getExternalSemaphoreProperties(esi);
+        const vk::ExternalSemaphoreFeatureFlags need =
+            vk::ExternalSemaphoreFeatureFlagBits::eExportable | vk::ExternalSemaphoreFeatureFlagBits::eImportable;
+        if ((esp.externalSemaphoreFeatures & need) != need) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_backends) {
     ggml_backend_vk_comm_context * comm = new ggml_backend_vk_comm_context;
     comm->backends.assign(backends, backends + n_backends);
@@ -17939,9 +17996,8 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         ok = ok && comm->device[i]->external_memory_host && comm->device[i]->external_semaphore;
         comm->align = std::max(comm->align, (size_t) comm->device[i]->min_imported_host_pointer_alignment);
     }
-    // The GPU-pipelined path stages through host memory shared (imported) across all devices, reduces
-    // on the GPU, and chains everything via exported timeline semaphores so there are no CPU barriers.
-    // It needs VK_EXT_external_memory_host + VK_KHR_external_semaphore_fd on every device.
+    // The fast path stages through host-imported shared memory and orders on the GPU via exported
+    // timelines; it needs VK_EXT_external_memory_host + VK_KHR_external_semaphore_fd on every device.
     comm->fast = ok;
     comm->host_ptr.resize(n_backends, nullptr);
     comm->host_buf.resize(n_backends);
@@ -17975,9 +18031,8 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
         comm->up_val.assign(n_backends, 0);
         comm->cmd_pool_xfer.resize(n_backends);
         comm->xfer_pool_max_val.assign(n_backends, 0);
-        // The full-duplex pipeline needs a transfer queue distinct from the compute queue (so uploads
-        // and downloads run on independent engines). NVIDIA exposes a dedicated transfer family; if a
-        // device has only one queue, fall back to the single-shot path for large tensors too.
+        // The full-duplex pipeline needs a transfer queue distinct from compute; without one, large
+        // tensors take the single-shot path too.
         comm->pipeline_ok = true;
         for (size_t i = 0; i < n_backends; i++) {
             comm->prog[i] = ggml_vk_create_export_timeline(comm->device[i]);
@@ -17989,13 +18044,38 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
                 comm->pipeline_ok = false;
             }
         }
-        // import each device's progress + upload timelines into every peer (fresh OPAQUE_FD per import)
-        for (size_t j = 0; j < n_backends; j++) {
-            for (size_t i = 0; i < n_backends; i++) {
-                if (i == j) { continue; }
-                comm->peer_prog[i][j] = ggml_vk_import_timeline(comm, comm->device[i], comm->device[j], comm->prog[j]);
-                comm->peer_up[i][j]   = ggml_vk_import_timeline(comm, comm->device[i], comm->device[j], comm->up[j]);
+        // Cross-device ordering: import each peer's OPAQUE_FD timelines so the GPU waits on them directly
+        // (fastest, but driver-private). GGML_VK_COMM_PROXY or an unsupported config picks the CPU-proxy.
+        comm->proxy = getenv("GGML_VK_COMM_PROXY") != nullptr;
+        if (!comm->proxy && !ggml_vk_comm_opaque_fd_supported(comm)) {
+            comm->proxy = true;
+            GGML_LOG_INFO("ggml_vulkan: cross-device OPAQUE_FD timeline import unsupported; using portable CPU-proxy sync\n");
+        }
+        if (!comm->proxy) {
+            try {
+                for (size_t j = 0; j < n_backends; j++) {
+                    for (size_t i = 0; i < n_backends; i++) {
+                        if (i == j) { continue; }
+                        comm->peer_prog[i][j] = ggml_vk_import_timeline(comm, comm->device[i], comm->device[j], comm->prog[j]);
+                        comm->peer_up[i][j]   = ggml_vk_import_timeline(comm, comm->device[i], comm->device[j], comm->up[j]);
+                    }
+                }
+            } catch (const vk::SystemError &) {
+                comm->proxy = true; // import threw despite the gate -> fall back to the proxy
+                GGML_LOG_INFO("ggml_vulkan: comm OPAQUE_FD timeline import failed; using portable CPU-proxy sync\n");
             }
+        }
+        if (comm->proxy) {
+            comm->pxy.resize(n_backends);
+            comm->pxy_val.assign(n_backends, 0);
+            comm->bridge_q.resize(n_backends);
+            for (size_t i = 0; i < n_backends; i++) {
+                vk::SemaphoreTypeCreateInfo stci{ vk::SemaphoreType::eTimeline, 0 };
+                vk::SemaphoreCreateInfo sci{};
+                sci.pNext = &stci;
+                comm->pxy[i] = comm->device[i]->device.createSemaphore(sci);
+            }
+            comm->proxy_thread = std::thread(ggml_vk_comm_proxy_loop, comm);
         }
         for (size_t i = 0; i < n_backends; i++) {
             comm->vkctx[i]->comm_prog_sem = comm->prog[i];
@@ -18009,9 +18089,18 @@ static void * ggml_backend_vk_comm_init(ggml_backend_t * backends, size_t n_back
 static void ggml_backend_vk_comm_free(void * comm_ctx) {
     ggml_backend_vk_comm_context * comm = static_cast<ggml_backend_vk_comm_context *>(comm_ctx);
     for (size_t i = 0; i < comm->vkctx.size(); i++) {
-        ggml_backend_synchronize(comm->backends[i]);
+        ggml_backend_synchronize(comm->backends[i]); // proxy (if any) is still alive here so parked downloads drain
         comm->vkctx[i]->comm_active   = false;
         comm->vkctx[i]->comm_prog_sem = VK_NULL_HANDLE;
+    }
+    if (comm->proxy_thread.joinable()) {
+        comm->proxy_stop.store(true, std::memory_order_relaxed);
+        comm->proxy_thread.join();
+    }
+    for (size_t i = 0; i < comm->pxy.size(); i++) {
+        if (comm->pxy[i]) {
+            comm->device[i]->device.destroySemaphore(comm->pxy[i]);
+        }
     }
     for (size_t i = 0; i < comm->prog.size(); i++) {
         if (comm->prog[i]) {
@@ -18094,14 +18183,12 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         }
     }
 
-    // Two slots per host buffer: the chunked pipeline ping-pongs between them by round parity so an
-    // upload never has to wait for the peer to finish reading the previous round's buffer (the
-    // single-shot path always uses slot 0). cap stays the per-slot size; the allocation is 2x.
+    // Two slots per host buffer: the pipeline ping-pongs by round parity so an upload never waits on the
+    // peer reading last round's buffer (single-shot always uses slot 0). cap is per-slot; allocation is 2x.
     const size_t slotcap = 2 * newcap;
-    // One host buffer per device, allocated on the host and imported into every device via
-    // VK_EXT_external_memory_host (which page-locks it for DMA). host_buf[k][i] = device i's import of
-    // host_ptr[k], holding device k's slice. (Driver-allocated shared memory via OPAQUE_FD was tried and
-    // gives no extra bandwidth here -- the import already gets full PCIe rate -- and can't cross mixed GPUs.)
+    // One host buffer per device, imported into every device via VK_EXT_external_memory_host (page-locked
+    // for DMA). host_buf[k][i] = device i's import of host_ptr[k]. (Driver-allocated OPAQUE_FD shared
+    // memory gave no extra bandwidth here and can't cross mixed GPUs.)
     for (size_t k = 0; k < n; k++) {
         comm->host_ptr[k] = std::aligned_alloc(comm->align, slotcap);
         if (!comm->host_ptr[k]) {
@@ -18125,8 +18212,7 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
         }
         comm->tmp_tensor[i]->buffer = comm->tmp_buffer[i];
         comm->tmp_tensor[i]->data   = ggml_backend_buffer_get_base(comm->tmp_buffer[i]);
-        // F16 device buffers for the cast partial (upload src) and the peer's F16 slice (download dst).
-        // newcap (fp32 cap) holds the F16 data (half the bytes) with room to spare.
+        // F16 scratch: up16 = cast partial (upload src), dn16 = peer's F16 slice (download dst).
         comm->up16_buffer[i] = ggml_backend_buft_alloc_buffer(bt, newcap);
         comm->dn16_buffer[i] = ggml_backend_buft_alloc_buffer(bt, newcap);
         if (!comm->up16_buffer[i] || !comm->dn16_buffer[i]) {
@@ -18147,27 +18233,18 @@ static bool ggml_backend_vk_comm_ensure(ggml_backend_vk_comm_context * comm, siz
     return true;
 }
 
-// Large-tensor AllReduce via a full-duplex chunked pipeline. Each device's slice is split into K
-// chunks. The dedicated TRANSFER queue streams this device's slice out to shared host memory chunk by
-// chunk (signalling up[i] after each), while the COMPUTE queue pulls each peer chunk back the moment
-// the peer has uploaded it (waiting peer_up) and finally adds the peer slices in. Because uploads and
-// downloads run on independent queues/engines, the two directions of the full-duplex PCIe link overlap,
-// so the reduction costs ~T (one slice transfer) instead of the single-shot path's ~2T (upload then
-// download). All tensors are assumed to carry a real partial (GGML_TENSOR_FLAG_COMPUTE); the caller
-// gates on that. Validated for n==2 (the only configuration the comm enables).
+// Large-tensor AllReduce via a full-duplex chunked pipeline: the TRANSFER queue streams this device's
+// slice out chunk by chunk while the COMPUTE queue pulls each peer chunk back as it lands and adds it in.
+// The two PCIe directions overlap, so the reduction costs ~T instead of ~2T. n==2 only.
 static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context * comm,
                                                     ggml_tensor ** tensors, size_t nbytes) {
     const size_t n = comm->backends.size();
 
-    // Chunking: aim for ~chunk_target bytes per chunk, with at least 2 chunks (one split is enough to
-    // overlap the two PCIe directions) and capped at kmax. Each extra chunk adds a submission and a
-    // cross-device semaphore wait whose latency outweighs the finer overlap, so over-splitting hurts --
-    // measured sweet spot is K=2..4. Align the chunk to 16B (F32 element-aligned).
+    // Aim for ~chunk_target per chunk, min 2 (enough to overlap both directions), capped at kmax: each
+    // extra chunk adds a submission + cross-device wait that outweighs the finer overlap (sweet spot 2..4).
     constexpr size_t chunk_target = 4u << 20;
     constexpr int    kmax         = 4;
-    // F16 staging: cast the fp32 partial to F16 on-device, transfer only half the bytes (the lever NCCL
-    // uses), then add the peer's F16 slice straight into the fp32 result. xbytes is what actually crosses
-    // the PCIe link; chunking is sized off it.
+    // F16: only half the bytes cross PCIe, so size chunking off xbytes (what actually crosses the link).
     const bool   f16    = comm->use_f16;
     const size_t xbytes = f16 ? (nbytes / 2) : nbytes;
     int K = (int) ((xbytes + chunk_target - 1) / chunk_target);
@@ -18176,18 +18253,15 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
     chunk = (chunk + 15) & ~((size_t) 15);
     K = (int) ((xbytes + chunk - 1) / chunk); // alignment may drop the count of non-empty chunks
 
-    // Double-buffer the shared host staging: ping-pong between two slots by round parity so an upload
-    // never has to wait for the peer to finish reading last round's buffer. The slot's previous user was
-    // two rounds ago, which is already ordered before this round's compute (transitively via the per-round
-    // reduce->compute->upload chain), so no explicit reuse guard is needed.
+    // Ping-pong the host slot by round parity: this slot's previous user was two rounds ago and is already
+    // ordered before this round's compute, so no explicit reuse guard is needed.
     const int    slot     = (int) (comm->pipe_round & 1);
     const size_t slot_off = (size_t) slot * comm->cap;
     comm->pipe_round++;
 
-    // Reserve timeline values up front for every device (so each knows its peers' per-chunk upload
-    // values): prog[i] advances by 1 fp32 (compute -> reduce), or 2 in F16 (compute -> cast -> reduce);
-    // up[i] advances by K (one per uploaded chunk).
-    std::vector<uint64_t> compute_val(n), cast_val(n), reduce_val(n), up_base(n);
+    // Reserve timeline values up front so each device knows its peers' per-chunk upload values. prog
+    // advances 1 (fp32) or 2 (F16: compute->cast->reduce); up advances K (one per chunk).
+    std::vector<uint64_t> compute_val(n), cast_val(n), reduce_val(n), up_base(n), pxy_base(n);
     for (size_t i = 0; i < n; i++) {
         compute_val[i] = comm->vkctx[i]->comm_prog_val;
         cast_val[i]    = compute_val[i] + 1;                  // F16: cast done (unused in fp32)
@@ -18196,10 +18270,13 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
         comm->last_reduce[i]          = reduce_val[i];
         up_base[i]                    = comm->up_val[i];
         comm->up_val[i]              += (uint64_t) K;
+        if (comm->proxy) {                                   // proxy mode: device i's downloads park on pxy[i]
+            pxy_base[i]               = comm->pxy_val[i];
+            comm->pxy_val[i]         += (uint64_t) K;
+        }
     }
 
-    // Recycle both command pools once their queue caught up (non-blocking timeline query), with a
-    // bounded drain if a long prefill lets a pool grow too large (mirrors the single-shot policy).
+    // Recycle each pool once its queue caught up (non-blocking), with a bounded drain if a pool grew too large.
     auto recycle = [&](size_t i, vk_command_pool & pool, vk::Semaphore sem, uint64_t & pool_max, uint64_t target) {
         uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(sem);
         if (done < pool_max && pool.buffers_in_use() >= 256) {
@@ -18248,8 +18325,7 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
             cctx->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], cast_val[i] });
         }
 
-        // ---- transfer queue: stream this device's slice out, one chunk per submission. Source is the
-        //      F16 cast (up16) or, in fp32 mode, tensors[i] directly. ----
+        // ---- transfer queue: stream this device's slice out, one chunk per submission (F16 cast or fp32 src) ----
         const uint64_t up_ready    = f16 ? cast_val[i] : compute_val[i];
         vk_buffer &    up_src       = f16 ? upbc->dev_buffer : bc->dev_buffer;
         const size_t   up_src_off   = f16 ? 0 : src_off;
@@ -18259,8 +18335,7 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
             const size_t sz  = std::min(chunk, xbytes - off);
             ggml_vk_ctx_begin(comm->device[i], tctx);
             if (cI == 0) {
-                // gate on this device's slice being ready (cast in F16, or compute in fp32; cross-queue).
-                // Double-buffering makes a peer-reuse guard unnecessary (see slot logic above).
+                // gate on this device's slice being ready; double-buffering removes any peer-reuse guard.
                 tctx->s->wait_semaphores.push_back({ comm->prog[i], up_ready });
             }
             ggml_vk_buffer_copy_async(tctx, comm->host_buf[i][i], slot_off + off, up_src, up_src_off + off, sz);
@@ -18269,8 +18344,7 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
         }
         ggml_vk_submit(tctx, {});
 
-        // ---- compute queue: pull each peer chunk back as it lands, then add the peer slice into the
-        //      fp32 result (mixed F32 += F16 add in F16 mode, F32 += F32 in fp32 mode). ----
+        // ---- compute queue: pull each peer chunk back as it lands, then add it into the fp32 result ----
         ggml_tensor * tmp = comm->tmp_tensor[i];
         for (int d = 0; d < GGML_MAX_DIMS; d++) {
             tmp->ne[d] = tensors[i]->ne[d];
@@ -18285,22 +18359,27 @@ static bool ggml_backend_vk_comm_allreduce_pipeline(ggml_backend_vk_comm_context
             if (k == i) {
                 continue;
             }
-            // one download submission per chunk, each waiting only on that peer's matching upload chunk,
-            // so a chunk's download begins as soon as the peer produced it -- this is what overlaps the
-            // upload and download directions.
+            // one download per chunk, waiting only on that peer's matching upload chunk -- this is what
+            // overlaps the upload and download directions.
             for (int cI = 0; cI < K; cI++) {
                 const size_t off = (size_t) cI * chunk;
                 const size_t sz  = std::min(chunk, xbytes - off);
                 ggml_vk_ctx_begin(comm->device[i], cctx);
-                cctx->s->wait_semaphores.push_back({ comm->peer_up[i][k], up_base[k] + (uint64_t) cI + 1 });
+                if (comm->proxy) {
+                    // park on the local proxy timeline; the proxy thread signals it once peer k's upload
+                    // of this chunk lands (bridge queued below).
+                    cctx->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + (uint64_t) cI + 1 });
+                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                    comm->bridge_q[i].push_back({ comm->device[k]->device, comm->up[k], up_base[k] + (uint64_t) cI + 1,
+                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + (uint64_t) cI + 1 });
+                } else {
+                    cctx->s->wait_semaphores.push_back({ comm->peer_up[i][k], up_base[k] + (uint64_t) cI + 1 });
+                }
                 ggml_vk_buffer_copy_async(cctx, dn_dst, off, comm->host_buf[k][i], slot_off + off, sz);
                 ggml_vk_ctx_end(cctx);
             }
-            // add this peer's now-complete slice into the running sum. The leading barrier covers the
-            // download copies above (same queue, submission order). In fp32 mode the uploads read
-            // tensors[i], so wait on them first (WAR: the add overwrites tensors[i]); in F16 mode the
-            // uploads read up16, and the cast's read of tensors[i] is already ordered before the add's
-            // write by the barrier, so no up-wait is needed.
+            // add this peer's slice into the running sum (barrier covers the downloads above). fp32 mode's
+            // uploads read tensors[i], so wait on them first (WAR); F16 uploads read up16, already ordered.
             ggml_vk_ctx_begin(comm->device[i], cctx);
             if (!f16) {
                 cctx->s->wait_semaphores.push_back({ comm->up[i], up_base[i] + (uint64_t) K });
@@ -18344,10 +18423,8 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         return false;
     }
 
-    // Large tensors (prefill activations) go through the full-duplex chunked pipeline, which overlaps
-    // the upload and download directions for ~2x. Small tensors (decode, one token) stay on the
-    // single-shot path below, where the fixed per-call overhead dominates and chunking would only add
-    // submissions. Gated on every slice carrying a real partial (the pipeline always uploads real data).
+    // Large tensors (prefill) use the full-duplex pipeline (~2x); small tensors (decode) take the
+    // single-shot path below, where fixed per-call overhead dominates. Pipeline needs real partials.
     constexpr size_t pipeline_min = 2u << 20;
     if (comm->pipeline_ok && n == 2 && nbytes >= pipeline_min) {
         bool all_compute = true;
@@ -18359,16 +18436,12 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         }
     }
 
-    // Everything below is enqueued on the GPU and ordered via the per-device progress timeline; no
-    // CPU barrier is taken, so the next layer's compute can be submitted while this reduction runs.
+    // Single-shot path: gather each slice to host, then reduce, as two batches per device, all ordered on
+    // the GPU progress timeline (no CPU barrier -- the next layer can be submitted while this runs).
     //
-    // Gather: copy each device's slice into its shared host buffer. Ordered after this device's
-    // compute (prog[i] >= compute value, signalled by graph_compute) and after every peer finished
-    // reading this buffer last round (so the single host buffer is safe to overwrite). Signals the
-    // gather value on prog[i].
-
-    // Reserve the timeline values up front: each device advances by 2 (gather, then reduce).
-    std::vector<uint64_t> compute_val(n), gather_val(n), reduce_val(n), prev_reduce(n);
+    // Reserve timeline values: each device advances by 2 (gather, reduce). Proxy mode also reserves 2 pxy
+    // values: +1 bridges the gather's peer-reuse guard, +2 the reduce's wait on the peer's gather.
+    std::vector<uint64_t> compute_val(n), gather_val(n), reduce_val(n), prev_reduce(n), pxy_base(n);
     for (size_t i = 0; i < n; i++) {
         prev_reduce[i] = comm->last_reduce[i];
         compute_val[i] = comm->vkctx[i]->comm_prog_val;
@@ -18376,11 +18449,12 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         reduce_val[i]  = compute_val[i] + 2;
         comm->vkctx[i]->comm_prog_val = reduce_val[i];
         comm->last_reduce[i]          = reduce_val[i];
-        // Recycle the dedicated command pool once the GPU has finished everything recorded into it
-        // (non-blocking timeline query). During decode this happens every token; during a long
-        // prefill the GPU stays behind, so also cap the live command buffers and drain (bounded
-        // wait) when the pool grows too large -- otherwise it grows unbounded and command-buffer
-        // lookup goes quadratic.
+        if (comm->proxy) {
+            pxy_base[i]       = comm->pxy_val[i];
+            comm->pxy_val[i] += 2;
+        }
+        // Recycle the pool once the GPU caught up (non-blocking); during a long prefill the GPU lags, so
+        // cap live buffers and drain when too large, else command-buffer lookup goes quadratic.
         uint64_t done = comm->device[i]->device.getSemaphoreCounterValue(comm->prog[i]);
         if (done < comm->pool_max_val[i] && comm->cmd_pool[i].buffers_in_use() >= 256) {
             vk::SemaphoreWaitInfo wi;
@@ -18396,8 +18470,7 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         comm->pool_max_val[i] = reduce_val[i];
     }
 
-    // For each device, record the gather and reduce as two batches in one command context and issue
-    // them with a single vkQueueSubmit (the global queue mutex makes each submit the dominant cost).
+    // Record gather + reduce as two batches in one submit (the queue mutex makes each submit the dominant cost).
     for (size_t i = 0; i < n; i++) {
         ggml_tensor * tmp = comm->tmp_tensor[i];
         for (int d = 0; d < GGML_MAX_DIMS; d++) {
@@ -18410,13 +18483,19 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         ggml_backend_vk_buffer_context * tbc = (ggml_backend_vk_buffer_context *) comm->tmp_buffer[i]->context;
         vk_context c = ggml_vk_create_temporary_context(comm->cmd_pool[i]);
 
-        // gather batch: wait this device's compute and the peers' previous reduce (so the shared host
-        // buffer is safe to overwrite); copy this slice to host; signal the gather value.
+        // gather: wait own compute + peers' previous reduce (host buffer safe to overwrite), copy slice to host.
         ggml_vk_ctx_begin(comm->device[i], c);
         c->s->wait_semaphores.push_back({ comm->prog[i], compute_val[i] });
         for (size_t k = 0; k < n; k++) {
             if (k != i) {
-                c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], prev_reduce[k] });
+                if (comm->proxy) {
+                    c->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + 1 });
+                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                    comm->bridge_q[i].push_back({ comm->device[k]->device, comm->prog[k], prev_reduce[k],
+                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + 1 });
+                } else {
+                    c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], prev_reduce[k] });
+                }
             }
         }
         if (tensors[i]->flags & GGML_TENSOR_FLAG_COMPUTE) {
@@ -18429,13 +18508,19 @@ static bool ggml_backend_vk_comm_allreduce_tensor(void * comm_ctx, ggml_tensor *
         ggml_vk_ctx_end(c);
         c->seqs.back().back().signal_semaphores.push_back({ comm->prog[i], gather_val[i] });
 
-        // reduce batch: wait this device's gather (so it has finished reading this slice) and the
-        // peers' gather (cross-device); add each peer slice in; signal the reduce value.
+        // reduce: wait own gather + peers' gather (cross-device), add each peer slice in.
         ggml_vk_ctx_begin(comm->device[i], c);
         c->s->wait_semaphores.push_back({ comm->prog[i], gather_val[i] });
         for (size_t k = 0; k < n; k++) {
             if (k != i) {
-                c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], gather_val[k] });
+                if (comm->proxy) {
+                    c->s->wait_semaphores.push_back({ comm->pxy[i], pxy_base[i] + 2 });
+                    std::lock_guard<std::mutex> lk(comm->bridge_mtx);
+                    comm->bridge_q[i].push_back({ comm->device[k]->device, comm->prog[k], gather_val[k],
+                                                  comm->device[i]->device, comm->pxy[i], pxy_base[i] + 2 });
+                } else {
+                    c->s->wait_semaphores.push_back({ comm->peer_prog[i][k], gather_val[k] });
+                }
             }
         }
         for (size_t k = 0; k < n; k++) {


### PR DESCRIPTION
## Overview

I've heard from @0cc4m that Vulkan maintainers really like large, LLM assisted PRs, so here's one that should make them happy 😁 

This fixes crashes in the pipeline and introduces a Vulkan F16 AllReduce.

## Additional information

Benchmark results on my box - would love someone with non-NVidia hardware to test this:

# Vulkan tensor-parallel benchmark v2 (rebased+cleaned build) — RTX 3080 + RTX 5060 Ti

pp512 / tg128 (tok/s). `llama-bench -fa 1`, default ubatch. 19 LLMs, 2-16GB. Each split-mode in its own run.
Cases: Vk-layer / CUDA-layer / Vk-tensor crashfix (butterfly, `GGML_VK_COMM_OFF`) / **Vk-tensor F16 (this work)** / CUDA-tensor (NCCL).

## Depth 0

| model | Vk-layer | CUDA-layer | Vk-tns crashfix | **Vk-tns F16** | CUDA-tensor |
|---|---|---|---|---|---|
| Apriel-1.6-15b | 1843/44 | 2152/52 | 400/33 | 1262/55 | 1258/68 |
| Bielik-11B | 2483/33 | 2695/39 | 461/30 | 1567/47 | 1524/55 |
| Devstral-24B | 610/23 | 700/27 | -/- | -/- | -/- |
| Falcon-H1R-7B | 2528/44 | 2946/52 | -/- | -/- | -/- |
| GLM-4.6V-Flash | 2143/39 | 3559/48 | -/- | -/- | -/- |
| LFM2-8B-A1B | 5062/259 | 9023/317 | -/- | -/- | -/- |
| Llama-3.2-3B | 4444/104 | 9173/123 | 1378/62 | 4047/115 | 3919/142 |
| Ministral-3-14B | 1776/32 | 2025/38 | 460/30 | 1378/42 | 1373/49 |
| North-Mini-Code | 2253/107 | 3380/142 | -/- | -/- | -/- |
| Qwen3-4B-2507 | 3911/127 | 6312/144 | 1232/51 | 3231/77 | 3375/146 |
| Qwen3.5-27B | 397/20 | 522/26 | 283/21 | 413/29 | -/- |
| Qwen3.5-35B-A3B | 1916/82 | 2708/101 | 1061/37 | 2290/68 | -/- |
| Qwen3.5-9B | 2943/42 | 3323/51 | 706/44 | 2205/61 | 2180/73 |
| Qwen3.6-27B-smol | 527/21 | 595/26 | -/- | -/- | -/- |
| gemma-3-12b | 2131/26 | 2372/31 | -/- | -/- | -/- |
| gemma-4-E2B | 5313/62 | 6122/82 | -/- | -/- | -/- |
| gemma-4-E4B | 2700/67 | 4363/88 | 928/40 | 2392/70 | 2536/94 |
| gpt-oss-20b | 837/102 | 5374/149 | 1337/66 | 3335/120 | 3878/178 |
| granite-4.0-h-tiny | 5210/147 | 5908/171 | -/- | -/- | -/- |

## Depth 4096

| model | Vk-layer | CUDA-layer | Vk-tns crashfix | **Vk-tns F16** | CUDA-tensor |
|---|---|---|---|---|---|
| Apriel-1.6-15b | 1625/39 | 1924/48 | 388/33 | 1190/50 | 1191/64 |
| Bielik-11B | 2103/30 | 2330/37 | 432/30 | 1448/44 | 1428/51 |
| Devstral-24B | 980/21 | 1210/27 | -/- | -/- | -/- |
| Falcon-H1R-7B | 2350/40 | 2758/51 | -/- | -/- | -/- |
| GLM-4.6V-Flash | 2302/38 | 3081/46 | -/- | -/- | -/- |
| LFM2-8B-A1B | 6962/224 | 8538/311 | -/- | -/- | -/- |
| Llama-3.2-3B | 6060/85 | 7033/109 | 1106/58 | 3654/97 | 3570/132 |
| Ministral-3-14B | 1597/30 | 1847/36 | 437/29 | 1315/40 | 1312/47 |
| North-Mini-Code | 2250/82 | 2431/120 | -/- | -/- | -/- |
| Qwen3-4B-2507 | 3995/91 | 5006/122 | 935/49 | 2863/90 | 3036/135 |
| Qwen3.5-27B | 759/23 | 975/26 | 271/21 | 688/30 | -/- |
| Qwen3.5-35B-A3B | 2298/76 | 2608/99 | 915/37 | 2160/65 | -/- |
| Qwen3.5-9B | 2850/40 | 3255/51 | 693/42 | 2119/59 | 2111/72 |
| Qwen3.6-27B-smol | 729/20 | 981/26 | -/- | -/- | -/- |
| gemma-3-12b | 2040/24 | 2317/30 | -/- | -/- | -/- |
| gemma-4-E2B | 3824/54 | 5574/81 | -/- | -/- | -/- |
| gemma-4-E4B | 2790/55 | 4056/85 | 795/38 | 2229/66 | 2425/92 |
| gpt-oss-20b | 2754/101 | 5057/142 | 1259/61 | 3173/107 | 3632/172 |
| granite-4.0-h-tiny | 5173/138 | 5999/172 | -/- | -/- | -/- |

## Depth 40000

| model | Vk-layer | CUDA-layer | Vk-tns crashfix | **Vk-tns F16** | CUDA-tensor |
|---|---|---|---|---|---|
| Apriel-1.6-15b | 703/23 | 703/26 | 285/25 | -/- | -/- |
| Bielik-11B | 591/19 | 730/22 | -/- | -/- | -/- |
| Devstral-24B | 356/16 | -/- | -/- | -/- | -/- |
| Falcon-H1R-7B | 790/31 | 1636/43 | -/- | -/- | -/- |
| GLM-4.6V-Flash | 948/33 | 1307/41 | -/- | -/- | -/- |
| LFM2-8B-A1B | 3044/124 | 5475/236 | -/- | -/- | -/- |
| Llama-3.2-3B | 1691/44 | 1500/57 | 738/47 | 1661/67 | 2087/80 |
| Ministral-3-14B | 724/20 | 770/24 | -/- | -/- | -/- |
| North-Mini-Code | 1227/70 | 1981/97 | -/- | -/- | -/- |
| Qwen3-4B-2507 | 1085/42 | 1146/47 | 680/37 | 1215/56 | 1723/69 |
| Qwen3.5-27B | 567/19 | 733/24 | -/- | -/- | -/- |
| Qwen3.5-35B-A3B | 1365/62 | 1964/86 | -/- | -/- | -/- |
| Qwen3.5-9B | 1752/36 | 2460/45 | 631/39 | 1765/53 | 1794/65 |
| Qwen3.6-27B-smol | 531/18 | 746/23 | -/- | -/- | -/- |
| gemma-3-12b | 1382/20 | 1663/26 | -/- | -/- | -/- |
| gemma-4-E2B | 1742/53 | 3114/74 | -/- | -/- | -/- |
| gemma-4-E4B | 1472/50 | 2605/72 | 744/37 | 1386/60 | 1952/81 |
| gpt-oss-20b | 2081/72 | 2317/112 | 1092/60 | 2281/90 | 2625/143 |
| granite-4.0-h-tiny | 3896/113 | 5026/152 | -/- | -/- | -/- |

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, Opus under my direction