### PR TITLE
server : drop the need for vendor subprocess.h

### DIFF
--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(${TARGET}
     server-http.h
     server-models.cpp
     server-models.h
+    server-process.cpp
+    server-process.h
 )
 set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -305,8 +305,8 @@ static void normalize_anthropic_billing_header(std::string & system_text) {
         return;
     }
 
-    const size_t header_prefix_length = strlen("x-anthropic-billing-header:");
-    const size_t cch_length = 5;
+    constexpr size_t header_prefix_length = sizeof("x-anthropic-billing-header:") - 1;  // null terminator
+    constexpr size_t cch_length = 5;
     const size_t index_cch = system_text.find("cch=", header_prefix_length);
     if (index_cch == std::string::npos) {
         return;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -48,6 +48,10 @@ extern char **environ;
 // ref: https://github.com/ggml-org/llama.cpp/issues/17862
 #define CHILD_ADDR "127.0.0.1"
 
+// short loopback budget for the resumable stream router to child JSON calls (probe, lookup,
+// delete). distinct from params.timeout_read/write which only applies to the generation proxy
+static constexpr int STREAM_LOOKUP_TIMEOUT_MS = 250;
+
 struct server_subproc {
     std::optional<server_process> sproc; // empty while in DOWNLOADING state
     std::atomic<bool> stopped{false}; // set to cancel a download or signal child process exit
@@ -66,8 +70,7 @@ struct server_subproc {
 
     void request_exit() {
         if (sproc.has_value()) {
-            FILE * stdin_file = subprocess_stdin(&sproc.value());
-            if (stdin_file) {
+            if (FILE * stdin_file = sproc->get_stdin()) {
                 fprintf(stdin_file, "%s\n", CMD_ROUTER_TO_CHILD_EXIT);
                 fflush(stdin_file);
             }
@@ -847,8 +850,8 @@ void server_models::load(const std::string & name, const load_options & opts) {
         stop_timeout = inst.meta.stop_timeout,
         child_mode = opts.mode
     ]() {
-        FILE * stdin_file = subprocess_stdin(&child_proc->get());
-        FILE * stdout_file = subprocess_stdout(&child_proc->get()); // combined stdout/stderr
+        FILE * stdin_file = child_proc->sproc->get_stdin();
+        FILE * stdout_file = child_proc->sproc->get_stdout(); // combined stdout/stderr
 
         std::thread log_thread([&]() {
             // read stdout/stderr and forward to main server log
@@ -1240,13 +1243,12 @@ void server_models::handle_child_state(const std::string & name, const std::stri
     switch (state) {
         case SERVER_STATE_DOWNLOADING:
             {
-                std::string result = json_value(payload, "result", std::string());
-                std::string url    = json_value(payload, "url",    std::string());
+                const std::string result = json_value(payload, "result", std::string());
+                const std::string url    = json_value(payload, "url",    std::string());
                 auto request_exit = [&]() {
-                    std::lock_guard<std::mutex> lk(mutex);
-                    auto it = mapping.find(name);
-                    if (it != mapping.end()) {
-                        return it->second.subproc->request_exit();
+                    std::lock_guard lk(mutex);
+                    if (const auto it = mapping.find(name); it != mapping.end()) {
+                        it->second.subproc->request_exit();
                     }
                 };
                 if (result == "download_finished") {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -8,7 +8,6 @@
 #include "download.h"
 
 #include <cpp-httplib/httplib.h> // TODO: remove this once we use HTTP client from download.h
-#include <optional>
 #include <sheredom/subprocess.h>
 
 #include <functional>
@@ -56,13 +55,16 @@ struct server_subproc {
     std::optional<server_process> sproc; // empty while in DOWNLOADING state
     std::atomic<bool> stopped{false}; // set to cancel a download or signal child process exit
 
-    subprocess_s & get() {
-        GGML_ASSERT(sproc.has_value() && "subprocess not initialized");
-        return sproc.value();
+    bool is_alive() const {
+        return sproc.has_value() && sproc->is_alive();
     }
 
-    bool is_alive() {
-        return sproc.has_value() && subprocess_alive(&sproc.value());
+    void terminate() const {
+        if (!sproc.has_value()) {
+            return;
+        }
+
+        sproc->terminate();
     }
 
     void request_exit() {
@@ -75,68 +77,7 @@ struct server_subproc {
         }
         stopped.store(true, std::memory_order_relaxed);
     }
-
-    void terminate() {
-        if (!sproc.has_value()) {
-            return;
-        }
-#if defined(_WIN32)
-        if (sproc->hProcess == NULL) {
-            return;
-        }
-#else
-        if (sproc->child <= 0) {
-            return;
-        }
-#endif
-        subprocess_terminate(&sproc.value());
-    }
 };
-
-// short loopback budget for the resumable stream router to child JSON calls (probe, lookup,
-// delete). distinct from params.timeout_read/write which only applies to the generation proxy
-static constexpr int STREAM_LOOKUP_TIMEOUT_MS = 250;
-
-static std::filesystem::path get_server_exec_path() {
-#if defined(_WIN32)
-    wchar_t buf[32768] = { 0 };  // Large buffer to handle long paths
-    DWORD len = GetModuleFileNameW(nullptr, buf, _countof(buf));
-    if (len == 0 || len >= _countof(buf)) {
-        throw std::runtime_error("GetModuleFileNameW failed or path too long");
-    }
-    return std::filesystem::path(buf);
-#elif defined(__APPLE__) && defined(__MACH__)
-    char small_path[PATH_MAX];
-    uint32_t size = sizeof(small_path);
-
-    if (_NSGetExecutablePath(small_path, &size) == 0) {
-        // resolve any symlinks to get absolute path
-        try {
-            return std::filesystem::canonical(std::filesystem::path(small_path));
-        } catch (...) {
-            return std::filesystem::path(small_path);
-        }
-    } else {
-        // buffer was too small, allocate required size and call again
-        std::vector<char> buf(size);
-        if (_NSGetExecutablePath(buf.data(), &size) == 0) {
-            try {
-                return std::filesystem::canonical(std::filesystem::path(buf.data()));
-            } catch (...) {
-                return std::filesystem::path(buf.data());
-            }
-        }
-        throw std::runtime_error("_NSGetExecutablePath failed after buffer resize");
-    }
-#else
-    char path[FILENAME_MAX];
-    ssize_t count = readlink("/proc/self/exe", path, FILENAME_MAX);
-    if (count <= 0) {
-        throw std::runtime_error("failed to resolve /proc/self/exe");
-    }
-    return std::filesystem::path(std::string(path, count));
-#endif
-}
 
 static void unset_reserved_args(common_preset & preset, bool unset_model_args) {
     preset.unset_option("LLAMA_ARG_SSL_KEY_FILE");
@@ -246,7 +187,7 @@ void server_model_meta::update_caps() {
 
 server_models::server_models(
         const common_params & params,
-        int argc,
+        const int argc,
         char ** argv)
             : ctx_preset(LLAMA_EXAMPLE_SERVER),
               base_params(params),
@@ -319,7 +260,7 @@ void server_models::add_model(server_model_meta && meta) {
 }
 
 void server_models::notify_sse(const std::string & event, const std::string & model_id, const json & data) {
-    std::unique_ptr<server_task_result_router> result = std::make_unique<server_task_result_router>();
+    auto result = std::make_unique<server_task_result_router>();
     result->data = {
         {"model", model_id},
         {"event", event},
@@ -599,7 +540,7 @@ void server_models::load_models() {
             }
 
             inst.meta.exit_code = 0; // clear failed state so the model can be reloaded
-            inst.meta.update_args(ctx_preset, bin_path);
+            inst.meta.update_args(ctx_preset, bin_path.string());
             inst.meta.update_caps();
         }
 
@@ -641,10 +582,8 @@ void server_models::load_models() {
         // collect autoload candidates while still under the lock
         std::vector<std::string> to_autoload;
         for (const auto & name : newly_added) {
-            auto it = mapping.find(name);
-            if (it != mapping.end()) {
-                std::string val;
-                if (it->second.meta.preset.get_option(COMMON_ARG_PRESET_LOAD_ON_STARTUP, val) && common_arg_utils::is_truthy(val)) {
+            if (auto it = mapping.find(name); it != mapping.end()) {
+                if (std::string val; it->second.meta.preset.get_option(COMMON_ARG_PRESET_LOAD_ON_STARTUP, val) && common_arg_utils::is_truthy(val)) {
                     to_autoload.push_back(name);
                 }
             }
@@ -661,37 +600,35 @@ void server_models::load_models() {
 }
 
 void server_models::update_meta(const std::string & name, const server_model_meta & meta) {
-    std::lock_guard<std::mutex> lk(mutex);
-    auto it = mapping.find(name);
-    if (it != mapping.end()) {
+    std::lock_guard lk(mutex);
+    if (const auto it = mapping.find(name); it != mapping.end()) {
         it->second.meta = meta;
     }
     cv.notify_all(); // notify wait_until_loading_finished
 }
 
 bool server_models::has_model(const std::string & name) {
-    std::lock_guard<std::mutex> lk(mutex);
+    std::lock_guard lk(mutex);
     if (mapping.find(name) != mapping.end()) {
         return true;
     }
-    for (const auto & [key, inst] : mapping) {
-        if (inst.meta.aliases.count(name)) {
-            return true;
-        }
-    }
-    return false;
+
+    return std::any_of(
+        mapping.cbegin(),
+        mapping.cend(),
+        [name](const auto & item) { return item.second.meta.aliases.count(name); }
+    );
 }
 
 std::optional<server_model_meta> server_models::get_meta(const std::string & name) {
-    std::unique_lock<std::mutex> lk(mutex);
+    std::unique_lock lk(mutex);
     if (need_reload) {
         lk.unlock();
         load_models();
         lk.lock();
     }
 
-    auto it = mapping.find(name);
-    if (it != mapping.end()) {
+    if (const auto it = mapping.find(name); it != mapping.end()) {
         return it->second.meta;
     }
     for (const auto & [key, inst] : mapping) {
@@ -835,7 +772,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
         unload_lru();
     }
 
-    std::unique_lock<std::mutex> lk(mutex);
+    std::unique_lock lk(mutex);
     // edge case: block until any in-progress reload has finished so we always load
     // against the freshest preset and a consistent mapping state
     cv.wait(lk, [this]() { return !is_reloading; });
@@ -857,7 +794,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
                 count_active++;
             }
         }
-        if (count_active >= (size_t)base_params.models_max) {
+        if (count_active >= static_cast<size_t>(base_params.models_max)) {
             throw std::runtime_error("model limit reached, try again later");
         }
     }
@@ -878,7 +815,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
     {
         SRV_INF("spawning server instance with name=%s on port %d\n", inst.meta.name.c_str(), inst.meta.port);
 
-        inst.meta.update_args(ctx_preset, bin_path); // render args
+        inst.meta.update_args(ctx_preset, bin_path.string()); // render args
 
         std::vector<std::string> child_args = inst.meta.args; // copy
         std::vector<std::string> child_env  = base_env; // copy
@@ -896,15 +833,10 @@ void server_models::load(const std::string & name, const load_options & opts) {
         }
         inst.meta.args = child_args; // save for debugging
 
-        std::vector<char *> argv = to_char_ptr_array(child_args);
-        std::vector<char *> envp = to_char_ptr_array(child_env);
-
         // TODO @ngxson : maybe separate stdout and stderr in the future
         //                so that we can use stdout for commands and stderr for logging
-        int options = subprocess_option_no_window | subprocess_option_combined_stdout_stderr;
         inst.subproc->sproc.emplace();
-        int result = subprocess_create_ex(argv.data(), options, envp.data(), &inst.subproc->get());
-        if (result != 0) {
+        if (inst.subproc->sproc->run(child_args, child_env) != 0) {
             throw std::runtime_error("failed to spawn server instance");
         }
     }
@@ -940,7 +872,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
         });
 
         std::thread stopping_thread([&]() {
-            // thread to monitor explicit stop requests; child crash is signalled via child_proc->stopped
+            // thread to monitor explicit stop requests; child crash is signaled via child_proc->stopped
             auto is_stopping = [this, &name]() {
                 return this->stopping_models.find(name) != this->stopping_models.end();
             };
@@ -994,8 +926,9 @@ void server_models::load(const std::string & name, const load_options & opts) {
 
         // get the exit code
         int exit_code = 0;
-        subprocess_join(&child_proc->get(), &exit_code);
-        subprocess_destroy(&child_proc->get());
+        if (child_proc->sproc.has_value()) {
+            exit_code = child_proc->sproc->join();
+        }
 
         // update status and exit code
         if (child_mode == SERVER_CHILD_MODE_DOWNLOAD) {
@@ -1151,7 +1084,7 @@ bool server_models::remove(const std::string & name) {
     // do everything under one lock acquisition; avoid get_meta() /
     // unload() because they can trigger load_models() which erases
     // transient DOWNLOADING / DOWNLOADED entries as a side-effect
-    std::unique_lock<std::mutex> lk(mutex);
+    std::unique_lock lk(mutex);
 
     auto it = mapping.find(name);
     if (it == mapping.end()) {
@@ -2010,7 +1943,7 @@ struct pipe_t {
         cv.notify_all();
     }
     bool read(T & output, const std::function<bool()> & should_stop) {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk(mutex);
         constexpr auto poll_interval = std::chrono::milliseconds(500);
         while (true) {
             if (!queue.empty()) {
@@ -2064,7 +1997,7 @@ static bool should_strip_proxy_header(const std::string & header_name) {
 
 static std::string generate_multipart_boundary() {
     thread_local std::mt19937 gen(std::random_device{}());
-    static const char chars[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+    static constexpr char chars[] = "0123456789abcdefghijklmnopqrstuvwxyz";
     std::uniform_int_distribution<> dis(0, sizeof(chars) - 2);
     std::string boundary = "----llama-cpp-proxy-";
     for (int i = 0; i < 16; i++) {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1,27 +1,24 @@
-#include "server-common.h"
 #include "server-models.h"
 #include "server-context.h"
 #include "server-stream.h"
 
 #include "build-info.h"
-#include "preset.h"
 #include "download.h"
+#include "preset.h"
+#include "server-common.h"
+#include "server-process.h"
 
-#include <cpp-httplib/httplib.h> // TODO: remove this once we use HTTP client from download.h
-#include <sheredom/subprocess.h>
+#include <cpp-httplib/httplib.h>  // TODO: remove this once we use HTTP client from download.h
 
-#include <functional>
-#include <optional>
 #include <algorithm>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
-#include <cstring>
-#include <cstdlib>
 #include <atomic>
 #include <chrono>
-#include <queue>
+#include <condition_variable>
 #include <filesystem>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <queue>
 #include <random>
 #include <sstream>
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -25,7 +25,6 @@
 #include <filesystem>
 #include <random>
 #include <sstream>
-#include <cstring>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -255,14 +254,8 @@ server_models::server_models(
               base_preset(ctx_preset.load_from_args(argc, argv)) {
     // clean up base preset
     unset_reserved_args(base_preset, true);
-    // set binary path
-    try {
-        bin_path = get_server_exec_path().string();
-    } catch (const std::exception & e) {
-        bin_path = argv[0];
-        LOG_WRN("failed to get server executable path: %s\n", e.what());
-        LOG_WRN("using original argv[0] as fallback: %s\n", argv[0]);
-    }
+
+    bin_path = argv[0]; // TODO: argv[0] is most of the time the path to the executable...
     load_models();
 }
 
@@ -315,7 +308,7 @@ void server_models::add_model(server_model_meta && meta) {
         }
     }
 
-    meta.update_args(ctx_preset, bin_path); // render args
+    meta.update_args(ctx_preset, bin_path.string()); // render args
     meta.update_caps();
     std::string name = meta.name;
     mapping[name] = instance_t{

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -53,27 +53,21 @@ extern char **environ;
 static constexpr int STREAM_LOOKUP_TIMEOUT_MS = 250;
 
 struct server_subproc {
-    std::optional<server_process> sproc; // empty while in DOWNLOADING state
+    server_process sproc; // pid == 0 until spawned
     std::atomic<bool> stopped{false}; // set to cancel a download or signal child process exit
 
     bool is_alive() const {
-        return sproc.has_value() && sproc->is_alive();
+        return sproc.is_alive();
     }
 
     void terminate() const {
-        if (!sproc.has_value()) {
-            return;
-        }
-
-        sproc->terminate();
+        sproc.terminate();
     }
 
     void request_exit() {
-        if (sproc.has_value()) {
-            if (FILE * stdin_file = sproc->get_stdin()) {
-                fprintf(stdin_file, "%s\n", CMD_ROUTER_TO_CHILD_EXIT);
-                fflush(stdin_file);
-            }
+        if (FILE * stdin_file = sproc.get_stdin()) {
+            fprintf(stdin_file, "%s\n", CMD_ROUTER_TO_CHILD_EXIT);
+            fflush(stdin_file);
         }
         stopped.store(true, std::memory_order_relaxed);
     }
@@ -835,8 +829,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
 
         // TODO @ngxson : maybe separate stdout and stderr in the future
         //                so that we can use stdout for commands and stderr for logging
-        inst.subproc->sproc.emplace();
-        if (inst.subproc->sproc->run(child_args, child_env) != 0) {
+        if (inst.subproc->sproc.run(child_args, child_env) != 0) {
             throw std::runtime_error("failed to spawn server instance");
         }
     }
@@ -850,8 +843,8 @@ void server_models::load(const std::string & name, const load_options & opts) {
         stop_timeout = inst.meta.stop_timeout,
         child_mode = opts.mode
     ]() {
-        FILE * stdin_file = child_proc->sproc->get_stdin();
-        FILE * stdout_file = child_proc->sproc->get_stdout(); // combined stdout/stderr
+        FILE * stdin_file = child_proc->sproc.get_stdin();
+        FILE * stdout_file = child_proc->sproc.get_stdout(); // combined stdout/stderr
 
         std::thread log_thread([&]() {
             // read stdout/stderr and forward to main server log
@@ -925,10 +918,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
         }
 
         // get the exit code
-        int exit_code = 0;
-        if (child_proc->sproc.has_value()) {
-            exit_code = child_proc->sproc->join();
-        }
+        int exit_code = child_proc->sproc.join();
 
         // update status and exit code
         if (child_mode == SERVER_CHILD_MODE_DOWNLOAD) {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -53,7 +53,7 @@ extern char **environ;
 #define CHILD_ADDR "127.0.0.1"
 
 struct server_subproc {
-    std::optional<subprocess_s> sproc; // empty while in DOWNLOADING state
+    std::optional<server_process> sproc; // empty while in DOWNLOADING state
     std::atomic<bool> stopped{false}; // set to cancel a download or signal child process exit
 
     subprocess_s & get() {

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -48,7 +48,7 @@ enum server_child_mode {
     SERVER_CHILD_MODE_DOWNLOAD, // download the model and exit
 };
 
-static std::string server_model_status_to_string(server_model_status status) {
+static std::string server_model_status_to_string(const server_model_status status) {
     switch (status) {
         case SERVER_MODEL_STATUS_DOWNLOADING: return "downloading";
         case SERVER_MODEL_STATUS_DOWNLOADED:  return "downloaded";
@@ -60,7 +60,7 @@ static std::string server_model_status_to_string(server_model_status status) {
     }
 }
 
-static std::string server_model_source_to_string(server_model_source source) {
+static std::string server_model_source_to_string(const server_model_source source) {
     switch (source) {
         case SERVER_MODEL_SOURCE_PRESET:     return "preset";
         case SERVER_MODEL_SOURCE_MODELS_DIR: return "models_dir";

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -48,7 +48,7 @@ enum server_child_mode {
     SERVER_CHILD_MODE_DOWNLOAD, // download the model and exit
 };
 
-static std::string server_model_status_to_string(const server_model_status status) {
+static constexpr std::string_view server_model_status_to_string(const server_model_status status) {
     switch (status) {
         case SERVER_MODEL_STATUS_DOWNLOADING: return "downloading";
         case SERVER_MODEL_STATUS_DOWNLOADED:  return "downloaded";
@@ -60,7 +60,7 @@ static std::string server_model_status_to_string(const server_model_status statu
     }
 }
 
-static std::string server_model_source_to_string(const server_model_source source) {
+static constexpr std::string_view server_model_source_to_string(const server_model_source source) {
     switch (source) {
         case SERVER_MODEL_SOURCE_PRESET:     return "preset";
         case SERVER_MODEL_SOURCE_MODELS_DIR: return "models_dir";

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -170,7 +170,7 @@ private:
     common_preset_context ctx_preset;
 
     common_params base_params;
-    std::string bin_path;
+    std::filesystem::path bin_path;
     std::vector<std::string> base_env;
     common_preset base_preset; // base preset from llama-server CLI args
 

--- a/tools/server/server-process.cpp
+++ b/tools/server/server-process.cpp
@@ -86,9 +86,6 @@ static std::wstring escape_cmdline(const std::vector<std::string> & args) {
     return result;
 }
 
-FILE * server_process::get_stdin() const { return fStdin; }
-FILE * server_process::get_stdout() const { return fStdout; }
-
 bool server_process::is_alive() const {
     if (!hHandle) return false;
 
@@ -214,9 +211,6 @@ int server_process::run(const std::vector<std::string> & args, const std::vector
     return 0;
 }
 
-#else
-#endif
-
 server_process::server_process(server_process && o) noexcept
     : hHandle(o.hHandle), fStdin(o.fStdin), fStdout(o.fStdout)
 {
@@ -239,7 +233,152 @@ server_process & server_process::operator=(server_process && o) noexcept {
     return *this;
 }
 
-server_process::~server_process() {
-    terminate();
-    join();
+#else
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <cerrno>
+#include <csignal>
+#include <string>
+#include <vector>
+
+extern char ** environ;
+
+bool server_process::is_alive() const {
+    if (pid <= 0 || joined) return false;
+
+    int wstatus = 0;
+    if (const auto r = waitpid(pid, &wstatus, WNOHANG); r == 0) {
+        return true; // still running
+    }
+    return false;
 }
+
+int server_process::join() {
+    if (pid > 0 && !joined) {
+        int wstatus = 0;
+        if (waitpid(pid, &wstatus, 0) > 0) {
+            status = WIFEXITED(wstatus) ? WEXITSTATUS(wstatus) : -1;
+            joined = true;
+            pid    = 0;
+        }
+    }
+
+    close_stdin();
+    close_stdout();
+
+    return joined ? status : -1;
+}
+
+void server_process::terminate() const {
+    if (pid > 0) {
+        kill(pid, SIGKILL);
+    }
+}
+
+int server_process::run(const std::vector<std::string> & args, const std::vector<std::string> & env) {
+    if (pid > 0) return -1; // already running
+
+    int stdin_pipe[2]  = {-1, -1};
+    int stdout_pipe[2] = {-1, -1};
+
+    if (pipe(stdin_pipe) != 0) return -1;
+    if (pipe(stdout_pipe) != 0) {
+        close(stdin_pipe[0]);
+        close(stdin_pipe[1]);
+        return -1;
+    }
+
+    std::vector<const char *> argv;
+    argv.reserve(args.size() + 1);
+    for (const auto & a : args) argv.push_back(a.c_str());
+    argv.push_back(nullptr);
+
+    std::vector<const char *> envp;
+    if (!env.empty()) {
+        envp.reserve(env.size() + 1);
+        for (const auto & e : env) envp.push_back(e.c_str());
+        envp.push_back(nullptr);
+    }
+
+    const auto child = fork();
+    if (child < 0) {
+        close(stdin_pipe[0]);
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        close(stdout_pipe[1]);
+        return -1;
+    }
+
+    if (child == 0) {
+        // child
+        dup2(stdin_pipe[0],  STDIN_FILENO);
+        dup2(stdout_pipe[1], STDOUT_FILENO);
+        dup2(stdout_pipe[1], STDERR_FILENO);
+
+        close(stdin_pipe[0]);
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        close(stdout_pipe[1]);
+
+        execve(args.empty() ? nullptr : args[0].c_str(),
+               const_cast<char * const *>(argv.data()),
+               envp.empty() ? environ : const_cast<char * const *>(envp.data()));
+        _exit(127);
+    }
+
+    // parent - close child-side ends
+    close(stdin_pipe[0]);
+    close(stdout_pipe[1]);
+
+    fStdin = fdopen(stdin_pipe[1], "w");
+    if (!fStdin) {
+        close(stdin_pipe[1]);
+        close(stdout_pipe[0]);
+        kill(child, SIGKILL);
+        waitpid(child, nullptr, 0);
+        return -1;
+    }
+
+    fStdout = fdopen(stdout_pipe[0], "r");
+    if (!fStdout) {
+        fclose(fStdin);
+        fStdin = nullptr;
+        close(stdout_pipe[0]);
+        kill(child, SIGKILL);
+        waitpid(child, nullptr, 0);
+        return -1;
+    }
+
+    pid    = child;
+    status = 0;
+    joined = false;
+    return 0;
+}
+
+server_process::server_process(server_process && o) noexcept
+    : pid(o.pid), fStdin(o.fStdin), fStdout(o.fStdout)
+{
+    o.pid = -1;
+    o.fStdin  = nullptr;
+    o.fStdout = nullptr;
+}
+
+server_process & server_process::operator=(server_process && o) noexcept {
+    if (this != &o) {
+        terminate();
+        join();
+        pid  = o.pid;
+        fStdin  = o.fStdin;
+        fStdout = o.fStdout;
+        o.pid  = -1;
+        o.fStdin  = nullptr;
+        o.fStdout = nullptr;
+    }
+    return *this;
+}
+
+#endif
+
+

--- a/tools/server/server-process.cpp
+++ b/tools/server/server-process.cpp
@@ -1,0 +1,245 @@
+//
+// Created by Morgan Funtowicz on 6/19/2026.
+//
+#include <server-process.h>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <windows.h>
+#include <locale>
+#include <numeric>
+
+static std::wstring utf8_to_wide(const std::string & s) {
+    if (s.empty()) return {};
+    const int len = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), nullptr, 0);
+    if (len == 0) return {};
+    std::wstring ws(len, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), ws.data(), len);
+    return ws;
+}
+
+static std::wstring build_env_block(const std::vector<std::string> & env) {
+    const size_t total = 1 + std::transform_reduce(
+        env.cbegin(),
+        env.cend(),
+        static_cast<size_t>(0),
+        std::plus<size_t>{},
+        [](const std::string & s) { return s.size() + 1; }
+    );
+
+    std::wstring block;
+    block.reserve(total);
+
+    for (const auto & e : env) {
+        block += utf8_to_wide(e);
+        block += L'\0';
+    }
+    block += L'\0'; // double null terminator
+    return block;
+}
+
+// Build a Windows command-line wstring from argv, escaping as needed.
+static std::wstring escape_cmdline(const std::vector<std::string> & args) {
+    const size_t total = args.size() + std::transform_reduce(
+        args.cbegin(),
+        args.cend(),
+        static_cast<size_t>(0),
+        std::plus<size_t>{},
+        [](const std::string & s) { return s.size() * 2 + 2; }
+    );
+
+    std::wstring result;
+    result.reserve(total);
+
+    for (size_t i = 0; i < args.size(); i++) {
+        if (i > 0) result += L' ';
+
+        const std::wstring arg = utf8_to_wide(args[i]);
+        if (const bool needs_quote = arg.empty() || arg.find_first_of(L" \t\"") != std::wstring::npos; !needs_quote) {
+            result += arg;
+            continue;
+        }
+
+        result += L'"';
+        for (size_t j = 0; j < arg.size(); j++) {
+            unsigned num_backslash = 0;
+            while (j < arg.size() && arg[j] == L'\\') {
+                num_backslash++;
+                j++;
+            }
+            if (j == arg.size()) {
+                result.append(num_backslash * 2, L'\\');
+                break;
+            }
+
+            if (arg[j] == L'"') {
+                result.append(num_backslash * 2 + 1, L'\\');
+                result += L'"';
+            } else {
+                result.append(num_backslash, L'\\');
+                result += arg[j];
+            }
+        }
+        result += L'"';
+    }
+    return result;
+}
+
+FILE * server_process::get_stdin() const { return fStdin; }
+FILE * server_process::get_stdout() const { return fStdout; }
+
+bool server_process::is_alive() const {
+    if (!hHandle) return false;
+
+    DWORD exit_code = 0;
+    if (!GetExitCodeProcess(hHandle, &exit_code)) return false;
+
+    return exit_code == STILL_ACTIVE;
+}
+
+void server_process::terminate() const {
+    if (hHandle) TerminateProcess(hHandle, 0);
+}
+
+int server_process::join() {
+    if (!hHandle) return -1;
+
+    DWORD exit_code = 0;
+
+    WaitForSingleObject(hHandle, INFINITE);
+    GetExitCodeProcess(hHandle, &exit_code);
+    CloseHandle(hHandle);
+    hHandle = nullptr;
+
+    if (fStdin)  { fclose(fStdin);  fStdin  = nullptr; }
+    if (fStdout) { fclose(fStdout); fStdout = nullptr; }
+
+    return static_cast<int>(exit_code);
+}
+
+int server_process::run(const std::vector<std::string> & args, const std::vector<std::string> & env) {
+    if (hHandle) return -1; // already running
+
+    std::wstring wcmdline = escape_cmdline(args);
+
+    // Use argv[0] as the application name if it contains a path separator,
+    // otherwise pass NULL to let CreateProcessW search via PATH.
+    std::wstring wexe;
+    if (!args.empty()) {
+        if (args[0].find('/') != std::string::npos || args[0].find('\\') != std::string::npos) {
+            wexe = utf8_to_wide(args[0]);
+        }
+    }
+
+    // Create pipes for stdin/stdout
+    SECURITY_ATTRIBUTES sa = {sizeof(SECURITY_ATTRIBUTES), nullptr, TRUE};
+
+    HANDLE stdin_read, stdin_write;
+    if (!CreatePipe(&stdin_read, &stdin_write, &sa, 0)) return -1;
+    SetHandleInformation(stdin_write, HANDLE_FLAG_INHERIT, 0);
+
+    HANDLE stdout_read, stdout_write;
+    if (!CreatePipe(&stdout_read, &stdout_write, &sa, 0)) {
+        CloseHandle(stdin_read);
+        CloseHandle(stdin_write);
+        return -1;
+    }
+    SetHandleInformation(stdout_read, HANDLE_FLAG_INHERIT, 0);
+
+    STARTUPINFOW si = {};
+    si.cb = sizeof(si);
+    si.dwFlags   = STARTF_USESTDHANDLES;
+    si.hStdInput  = stdin_read;
+    si.hStdOutput = stdout_write;
+    si.hStdError  = stdout_write;
+
+    PROCESS_INFORMATION pi = {nullptr};
+
+    std::wstring env_block;
+    LPWSTR env_ptr = nullptr;
+    if (!env.empty()) {
+        env_block = build_env_block(env);
+        env_ptr = env_block.data();
+    }
+
+    constexpr DWORD flags = CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT;
+    const auto ok = CreateProcessW(
+        wexe.empty() ? nullptr : wexe.c_str(),
+        wcmdline.data(),
+        nullptr, nullptr,
+        TRUE, // inherit handles
+        flags,
+        env_ptr,
+        nullptr,
+        &si, &pi
+    );
+
+    // Close the child-side handles (inherited by the child)
+    CloseHandle(stdin_read);
+    CloseHandle(stdout_write);
+
+    if (!ok) {
+        CloseHandle(stdin_write);
+        CloseHandle(stdout_read);
+        return -1;
+    }
+
+    // Close the thread handle immediately — we don't need it
+    CloseHandle(pi.hThread);
+
+    // Open C FILEs for the parent-side handles
+    fStdin  = _fdopen(_open_osfhandle(reinterpret_cast<intptr_t>(stdin_write),  _O_WRONLY | _O_TEXT), "w");
+    if (!fStdin) {
+        CloseHandle(stdin_write);
+        CloseHandle(stdout_read);
+        TerminateProcess(pi.hProcess, 1);
+        WaitForSingleObject(pi.hProcess, INFINITE);
+        CloseHandle(pi.hProcess);
+        return -1;
+    }
+
+    fStdout = _fdopen(_open_osfhandle(reinterpret_cast<intptr_t>(stdout_read),  _O_RDONLY | _O_TEXT), "r");
+    if (!fStdout) {
+        fclose(fStdin);
+        fStdin = nullptr;
+        CloseHandle(stdout_read);
+        TerminateProcess(pi.hProcess, 1);
+        WaitForSingleObject(pi.hProcess, INFINITE);
+        CloseHandle(pi.hProcess);
+        return -1;
+    }
+
+    hHandle = pi.hProcess;
+    return 0;
+}
+
+#else
+#endif
+
+server_process::server_process(server_process && o) noexcept
+    : hHandle(o.hHandle), fStdin(o.fStdin), fStdout(o.fStdout)
+{
+    o.hHandle = nullptr;
+    o.fStdin  = nullptr;
+    o.fStdout = nullptr;
+}
+
+server_process & server_process::operator=(server_process && o) noexcept {
+    if (this != &o) {
+        terminate();
+        join();
+        hHandle  = o.hHandle;
+        fStdin  = o.fStdin;
+        fStdout = o.fStdout;
+        o.hHandle  = nullptr;
+        o.fStdin  = nullptr;
+        o.fStdout = nullptr;
+    }
+    return *this;
+}
+
+server_process::~server_process() {
+    terminate();
+    join();
+}

--- a/tools/server/server-process.h
+++ b/tools/server/server-process.h
@@ -1,0 +1,53 @@
+//
+// Created by Morgan Funtowicz on 6/19/2026.
+//
+
+#ifndef LLAMA_CPP_SERVER_PROCESS_H
+#define LLAMA_CPP_SERVER_PROCESS_H
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <sys/types.h>  // pid_t
+#endif
+
+struct server_process {
+    server_process() = default;
+    ~server_process();
+
+    server_process(const server_process &) = delete;
+    server_process & operator=(const server_process &) = delete;
+    server_process(server_process && o) noexcept;
+    server_process & operator=(server_process && o) noexcept;
+
+    [[nodiscard]] FILE * get_stdin() const;
+    [[nodiscard]] FILE * get_stdout() const;
+    [[nodiscard]] bool is_alive() const;
+
+    void terminate() const;
+    int join();
+    int run(const std::vector<std::string> & args, const std::vector<std::string> & env);
+
+private:
+#ifdef _WIN32
+    HANDLE hHandle = nullptr;
+#else
+    pid_t pid    = 0;
+    int   status = 0;
+    bool  joined = false;
+#endif
+
+    FILE * fStdin  = nullptr;
+    FILE * fStdout = nullptr;
+};
+#endif  //LLAMA_CPP_SERVER_PROCESS_H

--- a/tools/server/server-process.h
+++ b/tools/server/server-process.h
@@ -23,21 +23,38 @@
 
 struct server_process {
     server_process() = default;
-    ~server_process();
 
     server_process(const server_process &) = delete;
     server_process & operator=(const server_process &) = delete;
     server_process(server_process && o) noexcept;
     server_process & operator=(server_process && o) noexcept;
 
-    [[nodiscard]] FILE * get_stdin() const;
-    [[nodiscard]] FILE * get_stdout() const;
-    [[nodiscard]] bool is_alive() const;
+    ~server_process() {
+        terminate();
+        join();
+    }
 
+    [[nodiscard]] FILE * get_stdin() const { return fStdin; }
+    [[nodiscard]] FILE * get_stdout() const { return fStdout; }
+
+    void close_stdin() {
+        if (fStdin) {
+            fclose(fStdin);
+        }
+        fStdin = nullptr;
+    }
+
+    void close_stdout() {
+        if (fStdout) {
+            fclose(fStdout);
+        }
+        fStdout = nullptr;
+    }
+
+    [[nodiscard]] bool is_alive() const;
     void terminate() const;
     int join();
     int run(const std::vector<std::string> & args, const std::vector<std::string> & env);
-
 private:
 #ifdef _WIN32
     HANDLE hHandle = nullptr;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -6,7 +6,6 @@
 #include "server-tools.h"
 
 #include "arg.h"
-#include "build-info.h"
 #include "common.h"
 #include "fit.h"
 #include "llama.h"
@@ -15,7 +14,7 @@
 #include <atomic>
 #include <clocale>
 #include <exception>
-#include <signal.h>
+#include <csignal>
 #include <thread> // for std::thread::hardware_concurrency
 
 #if defined(_WIN32)
@@ -423,10 +422,10 @@ int llama_server(int argc, char ** argv) {
     sigaction(SIGINT, &sigint_action, NULL);
     sigaction(SIGTERM, &sigint_action, NULL);
 #elif defined (_WIN32)
-    auto console_ctrl_handler = +[](DWORD ctrl_type) -> BOOL {
-        return (ctrl_type == CTRL_C_EVENT) ? (signal_handler(SIGINT), true) : false;
+    auto console_ctrl_handler = +[](const DWORD ctrl_type) -> BOOL {
+        return ctrl_type == CTRL_C_EVENT ? (signal_handler(SIGINT), true) : false;
     };
-    SetConsoleCtrlHandler(reinterpret_cast<PHANDLER_ROUTINE>(console_ctrl_handler), true);
+    SetConsoleCtrlHandler(console_ctrl_handler, true);
 #endif
 
     if (is_router_server) {


### PR DESCRIPTION
This PR is the first of a potential serie to get rid of third-party dependency to manage subprocess lifecycle.

First to benefit is `llama-server` for which the new, in-tree, implementation provides all the required knobs to replicate what was done through previous vendor dependency.

Notes:
- Added some more c++ features through casting, const, constexpr, etc.
- Removed `std::optional` encapsulating the subprocess as the statement of emptyness is not true anymore