### PR TITLE
app : allow --version, --licenses & --help

### DIFF
--- a/app/llama.cpp
+++ b/app/llama.cpp
@@ -50,6 +50,7 @@ struct command {
     std::vector<std::string> aliases;
     bool hidden;
     int (*func)(int, char **);
+    bool flags = false; // allow --name
 };
 
 #ifdef LLAMA_INSTALL_BUILD
@@ -69,9 +70,9 @@ static const command cmds[] = {
     {"fit-params",    "Compute parameters to fit a model in device memory", {},           true,          llama_fit_params   },
     {"quantize",      "Quantize a model",                                   {},           true,          llama_quantize     },
     {"perplexity",    "Compute model perplexity and KL divergence",         {},           true,          llama_perplexity   },
-    {"version",       "Show version",                                       {},           false,         version            },
-    {"licenses",      "Show third-party licenses",                          {"credits"},  false,         licenses           },
-    {"help",          "Show available commands",                            {},           false,         help               },
+    {"version",       "Show version",                                       {},           false,         version,           true },
+    {"licenses",      "Show third-party licenses",                          {"credits"},  false,         licenses,          true },
+    {"help",          "Show available commands",                            {},           false,         help,              true },
 };
 
 #undef UPDATE_HIDDEN
@@ -108,7 +109,10 @@ static int help(int argc, char ** argv) {
     return 0;
 }
 
-static bool matches(const std::string & arg, const command & cmd) {
+static bool matches(std::string arg, const command & cmd) {
+    if (cmd.flags && arg.size() > 2 && arg[0] == '-' && arg[1] == '-') {
+        arg.erase(0, 2);
+    }
     if (arg == cmd.name) {
         return true;
     }


### PR DESCRIPTION
## Overview

Allow `--version`, `--licenses` & `--help` in `llama` binary.

## Additional information

```
$ ./build/bin/llama --help
Usage: ./build/bin/llama <command> [options]

Available commands:
  serve           HTTP API server
  cli             Command-line interactive interface
  download        Download a model
  version         Show version
  licenses        Show third-party licenses
  help            Show available commands

Run './build/bin/llama help all' to show additional commands.
Run './build/bin/llama <command> --help' for command-specific usage.
```

```
$ ./build/bin/llama --serve
error: unknown command '--serve'
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
