### PR TITLE
Improve utilization (and tg t/s) by reducing K_QUANTS_PER_ITERATION to 1 on DMMV path

### DIFF
--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -680,14 +680,14 @@ static void dequantize_mul_mat_vec_q4_k(const void *__restrict__ vx,
             q16[2] = q2[0] & 0x0f0f;
             q16[3] = q2[0] & 0xf0f0;
 
-            float4 s = {0.f, 0.f, 0.f, 0.f};
+            sycl::float4 s = {0.f, 0.f, 0.f, 0.f};
             float smin = 0;
             for (int l = 0; l < 2; ++l) {
-                s.x += y1[l] * q4[l+0]; s.y += y1[l+32] * q4[l+2];
-                s.z += y2[l] * q4[l+4]; s.w += y2[l+32] * q4[l+6];
+                s.x() += y1[l] * q4[l+0]; s.y() += y1[l+32] * q4[l+2];
+                s.z() += y2[l] * q4[l+4]; s.w() += y2[l+32] * q4[l+6];
                 smin += y1[l] * sc[2] + y1[l+32] * sc[3] + y2[l] * sc[6] + y2[l+32] * sc[7];
             }
-            tmp += dall * (s.x * sc[0] + s.y * sc[1] * 1.f/16.f + s.z * sc[4] + s.w * sc[5] * 1.f/16.f) - dmin * smin;
+            tmp += dall * (s.x() * sc[0] + s.y() * sc[1] * 1.f/16.f + s.z() * sc[4] + s.w() * sc[5] * 1.f/16.f) - dmin * smin;
 #endif
         }
 
@@ -835,14 +835,14 @@ static void dequantize_mul_mat_vec_q4_k_reorder(const void *__restrict__ vx,
             q16[2] = q2[0] & 0x0f0f;
             q16[3] = q2[0] & 0xf0f0;
 
-            float4 s = {0.f, 0.f, 0.f, 0.f};
+            sycl::float4 s = {0.f, 0.f, 0.f, 0.f};
             float smin = 0;
             for (int l = 0; l < 2; ++l) {
-                s.x += y1[l] * q4[l+0]; s.y += y1[l+32] * q4[l+2];
-                s.z += y2[l] * q4[l+4]; s.w += y2[l+32] * q4[l+6];
+                s.x() += y1[l] * q4[l+0]; s.y() += y1[l+32] * q4[l+2];
+                s.z() += y2[l] * q4[l+4]; s.w() += y2[l+32] * q4[l+6];
                 smin += y1[l] * sc[2] + y1[l+32] * sc[3] + y2[l] * sc[6] + y2[l+32] * sc[7];
             }
-            tmp += dall * (s.x * sc[0] + s.y * sc[1] * 1.f/16.f + s.z * sc[4] + s.w * sc[5] * 1.f/16.f) - dmin * smin;
+            tmp += dall * (s.x() * sc[0] + s.y() * sc[1] * 1.f/16.f + s.z() * sc[4] + s.w() * sc[5] * 1.f/16.f) - dmin * smin;
 #endif
         }
 

--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -1126,7 +1126,7 @@ static void dequantize_mul_mat_vec_q5_k_reorder(const void *__restrict__ vx,
 
     // sum up partial sums and write back result
 #pragma unroll
-    for (int mask = QK_WARP_SIZE / 2; mask > 0; mask >>= 1) {
+    for (int mask = WARP_SIZE / 2; mask > 0; mask >>= 1) {
         tmp +=
             dpct::permute_sub_group_by_xor(item_ct1.get_sub_group(), tmp, mask);
     }
@@ -1762,10 +1762,13 @@ static void dequantize_mul_mat_vec_q5_K_sycl_reorder(const void *vx, const float
                                                      const int nrows,
                                                      dpct::queue_ptr stream) {
     GGML_ASSERT(ncols % QK_K == 0);
-    const sycl::range<3> block_dims(1, 1, QK_WARP_SIZE);
+    const int ny = 2 / K_QUANTS_PER_ITERATION;
+    const int block_num_y = (nrows + ny - 1) / ny;
+    const sycl::range<3> block_nums(1, 1, block_num_y);
+    const sycl::range<3> block_dims(1, ny, WARP_SIZE);
     stream->parallel_for(
-        sycl::nd_range<3>(sycl::range<3>(1, 1, nrows) * block_dims, block_dims),
-        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(QK_WARP_SIZE)]] {
+        sycl::nd_range<3>(block_nums * block_dims, block_dims),
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(WARP_SIZE)]] {
             dequantize_mul_mat_vec_q5_k_reorder(vx, y, dst, ncols, nrows, item_ct1);
         });
 }

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -3527,6 +3527,10 @@ inline bool ggml_sycl_supports_reorder_dmmv(enum ggml_type type) {
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_Q3_K:
+        case GGML_TYPE_Q4_K:
+        case GGML_TYPE_Q5_K:
+        case GGML_TYPE_Q6_K:
             return true;
         default:
             return false;

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -521,7 +521,9 @@ ggml_backend_sycl_buffer_init_tensor(ggml_backend_buffer_t buffer,
         switch (tensor->type) {
             case GGML_TYPE_Q4_0:
             case GGML_TYPE_Q8_0:
+            case GGML_TYPE_Q3_K:
             case GGML_TYPE_Q4_K:
+            case GGML_TYPE_Q5_K:
             case GGML_TYPE_Q6_K:{
                 ggml_tensor_extra_gpu * extra = new ggml_tensor_extra_gpu{};
                 tensor->extra                 = extra;

--- a/ggml/src/ggml-sycl/presets.hpp
+++ b/ggml/src/ggml-sycl/presets.hpp
@@ -62,7 +62,7 @@
 #endif
 
 #ifndef K_QUANTS_PER_ITERATION
-#define K_QUANTS_PER_ITERATION 2
+#define K_QUANTS_PER_ITERATION 1
 #else
 static_assert(K_QUANTS_PER_ITERATION == 1 || K_QUANTS_PER_ITERATION == 2, "K_QUANTS_PER_ITERATION must be 1 or 2");
 #endif


### PR DESCRIPTION
## Overview

The DMMV path recently changed the warp size from 32 to 16.  When combined with the reordered layout and reducing K_QUANTS_PER_ITERATION to 1 the work group size is increased from 16 to 32, resulting in reduced stalls and better utilization.

This gives a significant performance boost to tg t/s, up to 1.53x for Q4_K.

## Additional information

Smoke tests on B70 comparing baseline (master branch @ 3fc4e105279105106b08a133a4e3e483116e621f), KQPI=1 with the AOS layout, and finally with SOA layout.

```
export GGML_SYCL_PRIORITIZE_DMMV=1
for model in Qwen3.5-27B-Q2 Gemma-4-26B-Q3 Qwen3.5-27B-Q4 Qwen3.5-27B-Q5 Qwen3.5-27B-Q6; do ./build/bin/llama-bench -p 64 -n 16 -r 1 -ngl 999 -dev SYCL0 -m /models/${model}.gguf; done
```

| model                          |            test |         baseline t/s |           KQPI=1 t/s | KQPI=1 reordered t/s |  |
| ------------------------------ | --------------: | -------------------: | -------------------: | -------------------: | ----: |
| gemma4 26B.A4B Q3_K - Medium   |            pp64 |        294.82 ± 0.00 |        292.14 ± 0.00 |        298.22 ± 0.00 | 1.023 |
| gemma4 26B.A4B Q3_K - Medium   |            tg16 |         42.09 ± 0.00 |         37.99 ± 0.00 |         40.90 ± 0.00 | 0.972 |
| qwen35 27B Q4_K - Medium       |            pp64 |        188.58 ± 0.00 |        186.15 ± 0.00 |        189.23 ± 0.00 | 1.003 |
| qwen35 27B Q4_K - Medium       |            tg16 |         13.27 ± 0.00 |         12.89 ± 0.00 |         20.41 ± 0.00 | 1.538 |
| qwen35 27B Q5_K - Medium       |            pp64 |        231.61 ± 0.00 |        227.71 ± 0.00 |        231.78 ± 0.00 | 1.001 |
| qwen35 27B Q5_K - Medium       |            tg16 |         12.16 ± 0.00 |          8.68 ± 0.00 |         22.53 ± 0.00 | 1.853 |
| qwen35 27B Q6_K                |            pp64 |        216.41 ± 0.00 |        213.56 ± 0.00 |        218.05 ± 0.00 | 1.008 |
| qwen35 27B Q6_K                |            tg16 |         10.97 ± 0.00 |          5.42 ± 0.00 |         14.84 ± 0.00 | 1.353 |

More benchmarks with different models.

```
for model in Qwen3.5-9B-Q4 Qwen3.5-9B-Q8 Gemma-4-31B-Q6; do ./build/bin/llama-bench -p 128 -n 32 -ngl 999 -m /models/${model}.gguf; done
```

| model                          |            test |         baseline t/s |           KQPI=1 t/s | KQPI=1 reordered t/s |  |
| ------------------------------ | --------------: | -------------------: | -------------------: | -------------------: | ----: |
| qwen35 9B Q4_K - Medium        |           pp128 |      1110.94 ± 12.29 |       1076.49 ± 9.31 |       1118.67 ± 8.56 | 1.007 |
| qwen35 9B Q4_K - Medium        |            tg32 |         41.14 ± 0.17 |         36.73 ± 0.18 |         60.57 ± 1.19 | 1.472 |
| qwen35 9B Q8_0                 |           pp128 |      1234.18 ± 14.57 |      1234.70 ± 15.98 |      1233.31 ± 17.19 | 0.999 |
| qwen35 9B Q8_0                 |            tg32 |         38.76 ± 0.04 |         38.76 ± 0.04 |         38.76 ± 0.04 | 1.000 |
| gemma4 31B Q6_K                |           pp128 |        331.03 ± 2.62 |        325.97 ± 1.89 |        332.20 ± 1.60 | 1.004 |
| gemma4 31B Q6_K                |            tg32 |          9.26 ± 0.02 |          4.42 ± 0.00 |         12.82 ± 0.07 | 1.384 |


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, to navigate code