### PR TITLE
server : hint preserve_thinking when supported by chat template

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -367,8 +367,6 @@ bool common_chat_templates_support_enable_thinking(const common_chat_templates *
     return params.supports_thinking;
 }
 
-// Check if the template source contains the preserve_thinking kwarg.
-// This is useful for printing a hint to the user to enable it.
 bool common_chat_templates_support_preserve_thinking(const common_chat_templates * chat_templates) {
     std::string src = common_chat_templates_source(chat_templates);
     return src.find("preserve_thinking") != std::string::npos;

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -367,6 +367,13 @@ bool common_chat_templates_support_enable_thinking(const common_chat_templates *
     return params.supports_thinking;
 }
 
+// Check if the template source contains the preserve_thinking kwarg.
+// This is useful for printing a hint to the user to enable it.
+bool common_chat_templates_support_preserve_thinking(const common_chat_templates * chat_templates) {
+    std::string src = common_chat_templates_source(chat_templates);
+    return src.find("preserve_thinking") != std::string::npos;
+}
+
 std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const json & messages) {
     std::vector<common_chat_msg> msgs;
 

--- a/common/chat.h
+++ b/common/chat.h
@@ -347,6 +347,7 @@ common_reasoning_format common_reasoning_format_from_name(const std::string & fo
 common_chat_tool_choice common_chat_tool_choice_parse_oaicompat(const std::string & tool_choice);
 
 bool common_chat_templates_support_enable_thinking(const common_chat_templates * chat_templates);
+bool common_chat_templates_support_preserve_thinking(const common_chat_templates * chat_templates);
 
 // Parses a JSON array of messages in OpenAI's chat completion API format.
 std::vector<common_chat_msg> common_chat_msgs_parse_oaicompat(const nlohmann::ordered_json & messages);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1524,7 +1524,7 @@ private:
             if (params_base.use_jinja && common_chat_templates_support_preserve_thinking(chat_templates.get())) {
                 auto it = params_base.default_template_kwargs.find("preserve_thinking");
                 if (it == params_base.default_template_kwargs.end()) {
-                    SRV_WRN("%s\n", "chat template supports 'preserve_thinking' - consider using --chat-template-kwargs \"{\\\"preserve_thinking\\\": true}\"");
+                    SRV_WRN("%s\n", "chat template supports 'preserve_thinking' - consider using --chat-template-kwargs \"{\\\"preserve_thinking\\\": true}\" (ref: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking)");
                 }
             }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1520,6 +1520,14 @@ private:
             const bool enable_thinking = params_base.enable_reasoning != 0 && template_supports_thinking;
             SRV_TRC("%s: chat template, thinking = %d\n", __func__, enable_thinking);
 
+            // hint: suggest preserve_thinking if the template supports it but user hasn't set it
+            if (params_base.use_jinja && common_chat_templates_support_preserve_thinking(chat_templates.get())) {
+                auto it = params_base.default_template_kwargs.find("preserve_thinking");
+                if (it == params_base.default_template_kwargs.end()) {
+                    SRV_WRN("%s\n", "chat template supports 'preserve_thinking' - consider using --chat-template-kwargs \"{\\\"preserve_thinking\\\": true}\"");
+                }
+            }
+
             // IMPORTANT: chat_params is reused across sleeping / resuming states,
             //            never store llama_context/llama_model pointers in chat_params,
             //            as they may be invalidated after sleeping


### PR DESCRIPTION
## Overview

ref https://github.com/ggml-org/llama.cpp/pull/24093#issuecomment-4818424793

Print a hint to enable `preserve_thinking` kwarg when the chat template supports it.

```bash
# llama serve -hf unsloth/Qwen3.6-27B-MTP-GGUF:Q4_K_M
0.00.571.359 I cmn  common_param: common_params_print_info: verbosity = 3 (adjust with the `-lv N` CLI arg)
0.00.573.173 I srv    load_model: loading model 'unsloth/Qwen3.6-27B-MTP-GGUF:Q4_K_M'
0.08.345.590 I srv    load_model: initializing, n_slots = 4, n_ctx_slot = 131072, kv_unified = 'true'
0.08.378.594 W srv          init: chat template supports 'preserve_thinking' - consider using --chat-template-kwargs "{\"preserve_thinking\": true}" (ref: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking)
0.08.378.603 I srv  llama_server: model loaded
0.08.378.607 I srv  llama_server: listening on http://0.0.0.0:8013
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.6-27B
