### PR TITLE
sycl: fix check_graph_compatibility() to allow graphs for MoE decode (CONCAT dim!=3, MUL_MAT_ID fused path)

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -5185,7 +5185,13 @@ static bool check_graph_compatibility(ggml_cgraph * cgraph) {
             case GGML_OP_MUL_MAT_ID:
                 // The non-fused path (ne12 > 1) blocks on host; the fused single-token decode
                 // path (ne12 == 1, FP32 src1) runs entirely on GPU - allow that case.
-                if (!g_ggml_sycl_use_async_mem_op ||
+                // opt_for_reorder_id() uses sycl_reorder_temp_buffer (USM malloc/free), which
+                // requires async USM allocation to be graph-capturable. When the reorder
+                // optimization is disabled (GGML_SYCL_DISABLE_OPT=1 / g_ggml_sycl_disable_optimize),
+                // no reorder runs and async USM is not needed for this path.
+                // Note: GGML_SYCL_DISABLE_OPT is being renamed to GGML_SYCL_ENABLE_OPT in a
+                // pending PR; update this check when that rename lands.
+                if ((!g_ggml_sycl_use_async_mem_op && !g_ggml_sycl_disable_optimize) ||
                         cgraph->nodes[i]->src[1]->ne[2] != 1 ||
                         cgraph->nodes[i]->src[1]->type != GGML_TYPE_F32) {
                     GGML_LOG_INFO("%s: disabling SYCL graphs due to unsupported node type %s\n", __func__,

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -5170,18 +5170,29 @@ static bool check_graph_compatibility(ggml_cgraph * cgraph) {
         switch (node_op) {
             default:
                 break;
-            case GGML_OP_CONCAT:
-                // ggml_sycl_op_concat() does a blocking host wait after memcpy operations,
-                // but wait() can't be called on the events returned by a queue recording
-                // to a graph.
-                [[fallthrough]];
+            case GGML_OP_CONCAT: {
+                // dim==3 contiguous concat uses blocking memcpy; other dims use async GPU kernels.
+                const int32_t dim = ((const int32_t *) cgraph->nodes[i]->op_params)[0];
+                const ggml_tensor * src0 = cgraph->nodes[i]->src[0];
+                const ggml_tensor * src1 = cgraph->nodes[i]->src[1];
+                if (dim == 3 && ggml_is_contiguous(src0) && ggml_is_contiguous(src1)) {
+                    GGML_LOG_INFO("%s: disabling SYCL graphs due to unsupported node type %s\n", __func__,
+                                  ggml_op_name(node_op));
+                    return false;
+                }
+                break;
+            }
             case GGML_OP_MUL_MAT_ID:
-                // ggml_sycl_mul_mat_id() does a blocking host wait on the sycl queue after
-                // submitting a memcpy operation, but wait() can't be called on a queue that
-                // is recording to a graph.
-                GGML_LOG_INFO("%s: disabling SYCL graphs due to unsupported node type %s\n", __func__,
-                              ggml_op_name(node_op));
-                return false;
+                // The non-fused path (ne12 > 1) blocks on host; the fused single-token decode
+                // path (ne12 == 1, FP32 src1) runs entirely on GPU - allow that case.
+                if (!g_ggml_sycl_use_async_mem_op ||
+                        cgraph->nodes[i]->src[1]->ne[2] != 1 ||
+                        cgraph->nodes[i]->src[1]->type != GGML_TYPE_F32) {
+                    GGML_LOG_INFO("%s: disabling SYCL graphs due to unsupported node type %s\n", __func__,
+                                  ggml_op_name(node_op));
+                    return false;
+                }
+                break;
             case GGML_OP_MUL_MAT:
                 // We cannot use graphs with ggml_sycl_mul_mat() when SYCL async memory allocation extensions are not available,
                 // as SYCL malloc / free and host wait calls are not supported when recording to a graph which are all present


### PR DESCRIPTION
## Summary

`check_graph_compatibility()` was unconditionally rejecting `GGML_OP_CONCAT` and `GGML_OP_MUL_MAT_ID`, blocking SYCL command graph capture for any model with MoE routing or SSM-style concatenation — even when those ops are fully async.

### GGML_OP_CONCAT

Only the `dim==3` contiguous path does `stream->memcpy(...).wait()`. All other dims use async GPU kernels (`concat_T_sycl`) and are graph-compatible. Models such as qwen3.6-35B use `dim=0` for SSM conv state concatenation.

### GGML_OP_MUL_MAT_ID

The non-fused prefill path (`ne12 > 1`) copies expert IDs to host with `stream->wait()` — correctly rejected. The fused single-token decode path in `ggml_sycl_mul_mat_id_mmvq_fused()` (`ne12==1`, FP32 src1) runs `ggml_sycl_mul_mat_vec_q_id()` entirely on GPU with no host wait — graph-compatible.

**Pool address stability**: `ggml_sycl_pool_vmm` uses a fixed base address with LIFO linear allocation. `src1_q8_alloc` in the fused path always gets `pool_addr+0`, so addresses are stable across graph replays when `g_ggml_sycl_use_async_mem_op` is set.

## Test plan

- [x] Intel Arc Pro B70 (Xe2/Battlemage), qwen3.6-35B-A3B Q4_K_M, `GGML_SYCL_DISABLE_GRAPH=0`, `GGML_SYCL_DISABLE_OPT=1`
- [x] Graph capture succeeded (no "disabling SYCL graphs" log messages)
- [x] Decode output correct on small test requests
- [x] 3678-token sustained decode ran cleanly (207s)
- [x] Prefill unaffected — falls back gracefully for `ne12>1`

Related: #24810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
