### PR TITLE
server : fix samplers parsing in models preset

### DIFF
--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -170,6 +170,9 @@ static std::map<std::string, std::map<std::string, std::string>> parse_ini_from_
         // ws ::= [ \t]*
         auto ws = p.rule("ws", p.chars("[ \t]", 0, -1));
 
+        // ws-required ::= [ \t]+
+        auto ws_required = p.rule("ws-required", p.chars("[ \t]", 1, -1));
+
         // comment ::= [;#] (!newline .)*
         auto comment = p.rule("comment", p.chars("[;#]", 1, 1) + p.zero_or_more(p.negate(newline) + p.any()));
 
@@ -180,7 +183,7 @@ static std::map<std::string, std::map<std::string, std::string>> parse_ini_from_
         auto ident = p.rule("ident", p.chars("[a-zA-Z_]", 1, 1) + p.chars("[a-zA-Z0-9_.-]", 0, -1));
 
         // value ::= (!eol-start .)*
-        auto eol_start = p.rule("eol-start", ws + (p.chars("[;#]", 1, 1) | newline | p.end()));
+        auto eol_start = p.rule("eol-start", (ws_required + p.chars("[;#]", 1, 1)) | (ws + (newline | p.end())));
         auto value = p.rule("value", p.zero_or_more(p.negate(eol_start) + p.any()));
 
         // header-line ::= "[" ws ident ws "]" eol

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,6 +234,7 @@ llama_build_and_test(test-thread-safety.cpp ARGS -m "${MODEL_DEST}" -ngl 99 -p "
 set_tests_properties(test-thread-safety PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 llama_build_and_test(test-arg-parser.cpp)
+llama_build_and_test(test-preset.cpp)
 
 if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   # TODO: repair known memory leaks

--- a/tests/test-preset.cpp
+++ b/tests/test-preset.cpp
@@ -1,0 +1,61 @@
+#include "preset.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+static std::string arg_value(const std::vector<std::string> & args, const std::string & key) {
+    auto it = std::find(args.begin(), args.end(), key);
+    if (it == args.end()) {
+        throw std::runtime_error("missing arg: " + key);
+    }
+    ++it;
+    if (it == args.end()) {
+        throw std::runtime_error("missing value for arg: " + key);
+    }
+    return *it;
+}
+
+static void require_eq(const std::string & actual, const std::string & expected) {
+    if (actual != expected) {
+        throw std::runtime_error("expected '" + expected + "', got '" + actual + "'");
+    }
+}
+
+static void test_ini_semicolon_values() {
+    const auto path = std::filesystem::temp_directory_path() / "llama-test-preset.ini";
+
+    {
+        std::ofstream file(path);
+        file << "; comment line\n"
+             << "[model]\n"
+             << "model = test.gguf\n"
+             << "samplers = top_k;top_p;temperature ; inline comment\n"
+             << "temp = 0.7 ; inline comment\n";
+    }
+
+    common_preset_context ctx(LLAMA_EXAMPLE_SERVER);
+    common_preset global;
+    const common_presets presets = ctx.load_from_ini(path.string(), global);
+    const auto args = presets.at("model").to_args();
+
+    std::filesystem::remove(path);
+
+    require_eq(arg_value(args, "--model"), "test.gguf");
+    require_eq(arg_value(args, "--samplers"), "top_k;top_p;temperature");
+    require_eq(arg_value(args, "--temperature"), "0.7");
+}
+
+int main(void) {
+    try {
+        test_ini_semicolon_values();
+    } catch (std::exception & e) {
+        fprintf(stderr, "test-preset: exception: %s\n", e.what());
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Fixes `#23460`.
- `models-preset` INI parsing treated `;` inside `samplers` as an inline comment marker.
- This truncated values like:
  ```ini
  samplers = top_k;top_p;temperature
  ```
  to just `top_k`.
- The patch preserves semicolon-separated values while still allowing normal comment lines and whitespace-prefixed inline comments.
- Added a focused regression test for preset parsing.



## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used for validation assistance.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
