### PR TITLE
server : auto-insert media marker in embedding / multimodal prompts

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -702,10 +702,32 @@ server_tokens process_mtmd_prompt(mtmd_context * mctx, const std::string & promp
         }
     }
     // process prompt
+    std::string prompt_adj;
+
+    const std::string marker = mtmd_get_marker(mctx);
+    const size_t marker_len  = marker.size();
+
+    // count existing media markers in the prompt
+    size_t n_markers = 0;
+    size_t pos = 0;
+    while ((pos = prompt.find(marker, pos)) != std::string::npos) {
+        n_markers++;
+        pos += marker_len;
+    }
+
+    // prepend missing markers so the count matches the number of files
+    // this mirrors the behavior in mtmd-cli.cpp but also handles partial matches
+    if (n_markers < files.size()) {
+        for (size_t i = 0; i < files.size() - n_markers; i++) {
+            prompt_adj += marker;
+        }
+    }
+    prompt_adj += prompt;
+
     std::vector<server_tokens> inputs;
     // multimodal
     mtmd_input_text inp_txt = {
-        prompt.c_str(),
+        prompt_adj.c_str(),
         /* add_special */   true,
         /* parse_special */ true,
     };


### PR DESCRIPTION
The /embedding (and /embeddings, /v1/embeddings) endpoints failed with "number of media markers in text (0) does not match number of bitmaps (1)" when passing multimodal data via the "content" object format.

The server initializes the mtmd context with a randomized media marker (via get_media_marker()), but process_mtmd_prompt() passed the raw prompt string to mtmd_tokenize() without ensuring it contained the required markers. The CLI (mtmd-cli.cpp) already handles this by auto-prepending markers, but the server did not.

Fix: query the actual marker from the mtmd context via mtmd_get_marker() and auto-insert one per file if the prompt lacks them.

## Overview
Fixes #25088 

Essentially calls to the /embedding endpoint were failing because the process_mtmd_prompt function in tools/server/server-common.cpp passes the raw text from a user's prompt without including the placeholder marker from mtmd_default_marker() and one is required for each attatched image. I added a simple check for existence and inserted 1 per image.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
