### PR TITLE
fix(common): tolerate dangling Gemma 4 channel prefix after tool responses

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1392,7 +1392,7 @@ static common_chat_params common_chat_params_init_gemma4(const common_chat_templ
             auto scan_to_toolcall = p.rule("scan-to-toolcall", p.until("<|tool_call>"));
             auto content = p.rule("content", p.content(p.until_one_of({"<|channel>", "<channel|>", "<|tool_call>"})));
             auto message = p.rule("message", thought + content);
-            return start + p.zero_or_more(message) + scan_to_toolcall + tool_call;
+            return start + p.zero_or_more(message) + scan_to_toolcall + tool_call + consume_empty_channels;
         }
 
         // Gemma 4 may emit an extra <|channel>thought\n<channel|> at the end of the content. It may

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -3070,6 +3070,14 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect(message_with_tool_calls("amount", R"({"orig": 1.5e10})"))
             .run();
 
+        // Tool call with trailing <|channel> fragment (#25072)
+        tst.test(
+                "<|tool_call>call:get_time{city:<|\"|>London<|\"|>}<tool_call|><|channel> ")
+            .tools({ get_time_tool })
+            .is_partial(true)
+            .expect(message_with_tool_calls("get_time", R"({"city": "London"})"))
+            .run();
+
         // Edge cases
         tst.test(
                 "<|channel>thought\n<channel|>Hello, world!\nWhat's up?<channel|>")


### PR DESCRIPTION
## Overview

Gemma 4 tool-calling turns can end on a bare `<|channel>` prefix with optional trailing whitespace. On current `master`, that fragment is treated as invalid `peg-gemma4` output, so `llama-server` returns a 500 with:

```text
The model produced output that does not match the expected peg-gemma4 format
```

This change keeps the fix in the shared Gemma 4 parse path. It tolerates only the exact final dangling `<|channel>` prefix with trailing whitespace, preserves any already parsed assistant state, keeps the existing tolerated trailing marker cases, and still rejects malformed non-whitespace tails after parsed prefixes.

Closes #25072

## Additional information

The live issue log shows the final unparsed fragment as:

```text
<|channel> 
```

The non-tool Gemma 4 path already has narrow tolerance for trailing channel-marker noise. The tool-enabled path did not have an equivalent final-parse escape hatch, which is why the shared parser escalated this exact fragment into a 500.

Focused validation for the implemented diff stayed on the parser surfaces:

```bat
test-chat.exe --template google-gemma-4-31B-it.jinja --detailed
ctest --test-dir build-target1-msvc-nofatal -R "^test-chat$" --output-on-failure --timeout 900
ctest --test-dir build-target1-msvc-nofatal -R "^test-chat-peg-parser$" --output-on-failure --timeout 900
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted with local issue triage, patch planning, and test planning.
