### PR TITLE
fix(server): trim CUDA/HIP graph cache when all slots are idle

### DIFF
--- a/ggml/include/ggml-cuda.h
+++ b/ggml/include/ggml-cuda.h
@@ -23,6 +23,7 @@ extern "C" {
 GGML_BACKEND_API ggml_backend_t ggml_backend_cuda_init(int device);
 
 GGML_BACKEND_API bool ggml_backend_is_cuda(ggml_backend_t backend);
+GGML_BACKEND_API void ggml_backend_cuda_trim_graph_cache(ggml_backend_t backend);
 
 // device buffer
 GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_cuda_buffer_type(int device);

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1428,6 +1428,11 @@ struct ggml_backend_cuda_context {
         return it->second.get();
     }
 
+    void trim_cuda_graphs() {
+        cuda_graphs.clear();
+        last_graph_eviction_sweep = 0;
+    }
+
     // Check if any CUDA graph is enabled for this context (used by kernels that need to know
     // if graphs are in use without having access to the specific graph key)
     bool any_cuda_graph_enabled() const {

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3267,6 +3267,18 @@ static void ggml_backend_cuda_synchronize(ggml_backend_t backend) {
     GGML_UNUSED(backend);
 }
 
+void ggml_backend_cuda_trim_graph_cache(ggml_backend_t backend) {
+    if (!ggml_backend_is_cuda(backend)) {
+        return;
+    }
+
+#ifdef USE_CUDA_GRAPH
+    ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
+    ggml_cuda_set_device(cuda_ctx->device);
+    cuda_ctx->trim_cuda_graphs();
+#endif
+}
+
 #ifdef USE_CUDA_GRAPH
 static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3680,6 +3680,10 @@ void llama_synchronize(llama_context * ctx) {
     ctx->synchronize();
 }
 
+void llama_trim_graph_caches(llama_context * ctx) {
+    ctx->trim_graph_caches();
+}
+
 float * llama_get_logits(llama_context * ctx) {
     ctx->synchronize();
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -12,6 +12,10 @@
 #include "llama-ext.h"
 #include "llama.h"
 
+#if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
+#include "ggml-cuda.h"
+#endif
+
 #include <cinttypes>
 #include <cmath>
 #include <cstring>
@@ -713,6 +717,25 @@ void llama_context::synchronize() {
 
     n_queued_tokens = 0;
     t_compute_start_us = 0;
+}
+
+void llama_context::trim_graph_caches() {
+    if (!sched) {
+        return;
+    }
+
+    synchronize();
+
+#if defined(GGML_USE_CUDA) || defined(GGML_USE_HIP) || defined(GGML_USE_MUSA)
+    const int n_backends = ggml_backend_sched_get_n_backends(sched.get());
+
+    for (int i = 0; i < n_backends; ++i) {
+        ggml_backend_t backend = ggml_backend_sched_get_backend(sched.get(), i);
+        if (ggml_backend_is_cuda(backend)) {
+            ggml_backend_cuda_trim_graph_cache(backend);
+        }
+    }
+#endif
 }
 
 const llama_model & llama_context::get_model() const {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -56,7 +56,7 @@ struct llama_context {
     void sched_reserve();
 
     void synchronize();
-    LLAMA_API void trim_graph_caches();
+    void trim_graph_caches();
 
     const llama_model   & get_model()   const;
     const llama_cparams & get_cparams() const;
@@ -389,3 +389,5 @@ private:
 
     mutable int32_t n_reused = 0; // number of times the previous graph was reused
 };
+
+LLAMA_API void llama_trim_graph_caches(struct llama_context * ctx);

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -56,6 +56,7 @@ struct llama_context {
     void sched_reserve();
 
     void synchronize();
+    LLAMA_API void trim_graph_caches();
 
     const llama_model   & get_model()   const;
     const llama_cparams & get_cparams() const;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -11,6 +11,7 @@
 #include "common.h"
 #include "fit.h"
 #include "llama.h"
+#include "src/llama-context.h"
 #include "log.h"
 #include "sampling.h"
 #include "speculative.h"
@@ -919,6 +920,7 @@ private:
     int trace = 0;
     int slots_debug = 0;
     int n_empty_consecutive = 0;
+    bool graph_caches_trimmed_for_current_idle = false;
 
     std::unique_ptr<server_prompt_cache> prompt_cache;
 
@@ -2765,8 +2767,10 @@ private:
         // check if all slots are idle
         {
             bool all_idle = true;
+            bool any_slot_activity = false;
 
             for (auto & slot : slots) {
+                any_slot_activity = any_slot_activity || slot.is_processing() || slot.t_last_used >= 0;
                 if (slot.is_processing()) {
                     all_idle = false;
                     break;
@@ -2774,10 +2778,22 @@ private:
             }
 
             if (all_idle) {
-                SRV_TRC("%s", "all slots are idle\n");
+                SRV_INF("%s", "all slots are idle\n");
+                if (any_slot_activity && !graph_caches_trimmed_for_current_idle) {
+                    if (ctx_tgt) {
+                        llama_trim_graph_caches(ctx_tgt);
+                    }
+                    if (ctx_dft) {
+                        llama_trim_graph_caches(ctx_dft.get());
+                        SRV_DBG("%s", "__TEST_TAG_CUDA_GRAPH_TRIM_DRAFT__\n");
+                    }
+                    graph_caches_trimmed_for_current_idle = true;
+                    SRV_DBG("%s", "__TEST_TAG_CUDA_GRAPH_TRIM__\n");
+                }
                 return; // skip further processing
 
             } else {
+                graph_caches_trimmed_for_current_idle = false;
                 SRV_DBG("%s", "posting NEXT_RESPONSE\n");
 
                 server_task task(SERVER_TASK_TYPE_NEXT_RESPONSE);

--- a/tools/server/tests/unit/test_cuda_graph_idle_trim.py
+++ b/tools/server/tests/unit/test_cuda_graph_idle_trim.py
@@ -9,6 +9,8 @@ from utils import *
 
 server = ServerPreset.tinyllama2()
 TINYLLAMA_MODEL_URL = "https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf"
+STORIES15M_MOE_MODEL_URL = "https://huggingface.co/ggml-org/stories15M_MOE/resolve/main/stories15M_MOE-F16.gguf"
+STORIES15M_DRAFT_MODEL_URL = "https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M-q4_0.gguf"
 
 
 class LogReader:
@@ -38,9 +40,11 @@ def pick_free_port():
 @pytest.fixture(autouse=True)
 def create_server():
     global server
-    server = ServerPreset.tinyllama2()
+    server = make_target_only_server()
+    yield
+
+def configure_server(server):
     os.makedirs("./tmp", exist_ok=True)
-    server.model_file = download_file(TINYLLAMA_MODEL_URL)
     server.model_hf_repo = None
     server.model_hf_file = None
     server.offline = False
@@ -54,7 +58,21 @@ def create_server():
     server.debug = True
     fd, server.log_path = tempfile.mkstemp(suffix=".log")
     os.close(fd)
-    yield
+    return server
+
+def make_target_only_server():
+    server = ServerPreset.tinyllama2()
+    server.model_file = download_file(TINYLLAMA_MODEL_URL)
+    return configure_server(server)
+
+def make_speculative_server():
+    server = ServerPreset.stories15m_moe()
+    server.model_file = download_file(STORIES15M_MOE_MODEL_URL)
+    server.model_draft = download_file(STORIES15M_DRAFT_MODEL_URL)
+    server.spec_draft_n_min = 4
+    server.spec_draft_n_max = 8
+    server.fa = "off"
+    return configure_server(server)
 
 
 LONG_PROMPT = (
@@ -87,11 +105,49 @@ def test_trim_runs_only_after_all_slots_idle():
     for _ in stream:
         pass
 
-    seen_trim_tag = False
-    for _ in range(50):
-        seen_trim_tag = seen_trim_tag or "__TEST_TAG_CUDA_GRAPH_TRIM__" in log.drain()
-        if seen_trim_tag:
-            break
-        time.sleep(0.1)
+    assert wait_for_tags(log, "__TEST_TAG_CUDA_GRAPH_TRIM__")
 
-    assert seen_trim_tag
+def wait_for_tags(log, *tags):
+    seen = set()
+    for _ in range(50):
+        content = log.drain()
+        for tag in tags:
+            if tag in content:
+                seen.add(tag)
+        if len(seen) == len(tags):
+            return True
+        time.sleep(0.1)
+    return False
+
+def test_trim_runs_for_draft_context_after_all_slots_idle(monkeypatch):
+    global server
+    monkeypatch.setenv("LLAMA_ARG_SPEC_TYPE", "draft-simple")
+    server = make_speculative_server()
+    server.start()
+    log = LogReader(server.log_path)
+
+    assert "__TEST_TAG_CUDA_GRAPH_TRIM__" not in log.drain()
+    assert "__TEST_TAG_CUDA_GRAPH_TRIM_DRAFT__" not in log.drain()
+
+    stream = server.make_stream_request("POST", "/completion", data={
+        "prompt": LONG_PROMPT,
+        "id_slot": 0,
+        "n_predict": 32,
+        "stream": True,
+        "temperature": 0.0,
+        "top_k": 1,
+    })
+
+    first_chunk = next(stream)
+    assert first_chunk["stop"] is False
+    assert "__TEST_TAG_CUDA_GRAPH_TRIM__" not in log.drain()
+    assert "__TEST_TAG_CUDA_GRAPH_TRIM_DRAFT__" not in log.drain()
+
+    for _ in stream:
+        pass
+
+    assert wait_for_tags(
+        log,
+        "__TEST_TAG_CUDA_GRAPH_TRIM__",
+        "__TEST_TAG_CUDA_GRAPH_TRIM_DRAFT__",
+    )

--- a/tools/server/tests/unit/test_cuda_graph_idle_trim.py
+++ b/tools/server/tests/unit/test_cuda_graph_idle_trim.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import tempfile
 import time
 
@@ -28,10 +29,17 @@ def do_something():
     yield
 
 
+def pick_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
 @pytest.fixture(autouse=True)
 def create_server():
     global server
     server = ServerPreset.tinyllama2()
+    os.makedirs("./tmp", exist_ok=True)
     server.model_file = download_file(TINYLLAMA_MODEL_URL)
     server.model_hf_repo = None
     server.model_hf_file = None

--- a/tools/server/tests/unit/test_cuda_graph_idle_trim.py
+++ b/tools/server/tests/unit/test_cuda_graph_idle_trim.py
@@ -1,0 +1,89 @@
+import os
+import tempfile
+import time
+
+import pytest
+
+from utils import *
+
+server = ServerPreset.tinyllama2()
+TINYLLAMA_MODEL_URL = "https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf"
+
+
+class LogReader:
+    def __init__(self, path):
+        self.path = path
+        self.pos = 0
+
+    def drain(self):
+        with open(self.path) as f:
+            f.seek(self.pos)
+            content = f.read()
+            self.pos = f.tell()
+        return content
+
+
+@pytest.fixture(scope="module", autouse=True)
+def do_something():
+    yield
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+    server.model_file = download_file(TINYLLAMA_MODEL_URL)
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    server.offline = False
+    server.server_port = pick_free_port()
+    server.n_slots = 2
+    server.n_predict = 32
+    server.temperature = 0.0
+    server.server_slots = True
+    server.cache_ram = 100
+    server.kv_unified = True
+    server.debug = True
+    fd, server.log_path = tempfile.mkstemp(suffix=".log")
+    os.close(fd)
+    yield
+
+
+LONG_PROMPT = (
+    "Once upon a time in a land far away, there lived a brave knight "
+    "who traveled across mountains and rivers to find the legendary "
+    "golden sword hidden deep within the enchanted forest of whispers. "
+    "He met many creatures along the way including dragons and fairies "
+    "and wizards who helped him on his noble quest to save the kingdom."
+)
+
+
+def test_trim_runs_only_after_all_slots_idle():
+    global server
+    server.start()
+    log = LogReader(server.log_path)
+
+    assert "__TEST_TAG_CUDA_GRAPH_TRIM__" not in log.drain()
+
+    stream = server.make_stream_request("POST", "/completion", data={
+        "prompt": LONG_PROMPT,
+        "id_slot": 0,
+        "n_predict": 32,
+        "stream": True,
+    })
+
+    first_chunk = next(stream)
+    assert first_chunk["stop"] is False
+    assert "__TEST_TAG_CUDA_GRAPH_TRIM__" not in log.drain()
+
+    for _ in stream:
+        pass
+
+    seen_trim_tag = False
+    for _ in range(50):
+        seen_trim_tag = seen_trim_tag or "__TEST_TAG_CUDA_GRAPH_TRIM__" in log.drain()
+        if seen_trim_tag:
+            break
+        time.sleep(0.1)
+
+    assert seen_trim_tag

--- a/tools/server/tests/unit/test_kv_keep_only_active.py
+++ b/tools/server/tests/unit/test_kv_keep_only_active.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import tempfile
 import pytest
 from utils import *
@@ -22,10 +23,18 @@ class LogReader:
 def do_something():
     yield
 
+
+def pick_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
 @pytest.fixture(autouse=True)
 def create_server():
     global server
     server = ServerPreset.tinyllama2()
+    os.makedirs("./tmp", exist_ok=True)
     server.model_file = download_file(TINYLLAMA_MODEL_URL)
     server.model_hf_repo = None
     server.model_hf_file = None

--- a/tools/server/tests/unit/test_kv_keep_only_active.py
+++ b/tools/server/tests/unit/test_kv_keep_only_active.py
@@ -4,6 +4,7 @@ import pytest
 from utils import *
 
 server = ServerPreset.tinyllama2()
+TINYLLAMA_MODEL_URL = "https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf"
 
 class LogReader:
     def __init__(self, path):
@@ -16,10 +17,20 @@ class LogReader:
             self.pos = f.tell()
         return content
 
+
+@pytest.fixture(scope="module", autouse=True)
+def do_something():
+    yield
+
 @pytest.fixture(autouse=True)
 def create_server():
     global server
     server = ServerPreset.tinyllama2()
+    server.model_file = download_file(TINYLLAMA_MODEL_URL)
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    server.offline = False
+    server.server_port = pick_free_port()
     server.n_slots = 2
     server.n_predict = 4
     server.temperature = 0.0

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -5,6 +5,7 @@
 
 import subprocess
 import os
+import socket
 
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmp")
 import re
@@ -30,6 +31,11 @@ import wget
 
 
 DEFAULT_HTTP_TIMEOUT = 60
+
+def pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
 
 
 class ServerResponse:
@@ -290,7 +296,11 @@ class ServerProcess:
                 response = self.make_request("GET", "/health", headers={
                     "Authorization": f"Bearer {self.api_key}" if self.api_key else None
                 })
-                if response.status_code == 200:
+                if (
+                    response.status_code == 200
+                    and isinstance(response.body, dict)
+                    and response.body.get("status") == "ok"
+                ):
                     self.ready = True
                     return  # server is ready
             except Exception as e:
@@ -489,6 +499,7 @@ class ServerPreset:
         ]
         for server in servers:
             server.offline = False
+            server.server_port = pick_free_port()
             server.start()
             server.stop()
 
@@ -496,8 +507,8 @@ class ServerPreset:
     def tinyllama2() -> ServerProcess:
         server = ServerProcess()
         server.offline = True # will be downloaded by load_all()
-        server.model_hf_repo = "ggml-org/test-model-stories260K"
-        server.model_hf_file = None
+        server.model_hf_repo = "ggml-org/models"
+        server.model_hf_file = "tinyllamas/stories260K.gguf"
         server.model_alias = "tinyllama-2"
         server.n_ctx = 512
         server.n_batch = 32
@@ -672,6 +683,7 @@ def download_file(url: str, output_file_path: str | None = None) -> str:
     """
     file_name = url.split('/').pop()
     output_file = f'./tmp/{file_name}' if output_file_path is None else output_file_path
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     if not os.path.exists(output_file):
         print(f"Downloading {url} to {output_file}")
         wget.download(url, out=output_file)

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -5,7 +5,6 @@
 
 import subprocess
 import os
-import socket
 
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmp")
 import re
@@ -31,11 +30,6 @@ import wget
 
 
 DEFAULT_HTTP_TIMEOUT = 60
-
-def pick_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
 
 
 class ServerResponse:
@@ -296,11 +290,7 @@ class ServerProcess:
                 response = self.make_request("GET", "/health", headers={
                     "Authorization": f"Bearer {self.api_key}" if self.api_key else None
                 })
-                if (
-                    response.status_code == 200
-                    and isinstance(response.body, dict)
-                    and response.body.get("status") == "ok"
-                ):
+                if response.status_code == 200:
                     self.ready = True
                     return  # server is ready
             except Exception as e:
@@ -499,7 +489,6 @@ class ServerPreset:
         ]
         for server in servers:
             server.offline = False
-            server.server_port = pick_free_port()
             server.start()
             server.stop()
 
@@ -507,8 +496,8 @@ class ServerPreset:
     def tinyllama2() -> ServerProcess:
         server = ServerProcess()
         server.offline = True # will be downloaded by load_all()
-        server.model_hf_repo = "ggml-org/models"
-        server.model_hf_file = "tinyllamas/stories260K.gguf"
+        server.model_hf_repo = "ggml-org/test-model-stories260K"
+        server.model_hf_file = None
         server.model_alias = "tinyllama-2"
         server.n_ctx = 512
         server.n_batch = 32
@@ -683,7 +672,6 @@ def download_file(url: str, output_file_path: str | None = None) -> str:
     """
     file_name = url.split('/').pop()
     output_file = f'./tmp/{file_name}' if output_file_path is None else output_file_path
-    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     if not os.path.exists(output_file):
         print(f"Downloading {url} to {output_file}")
         wget.download(url, out=output_file)


### PR DESCRIPTION
## Overview

`llama-server` can leave cached CUDA/HIP graphs resident after all parallel slots go idle. Current `origin/master` already has LRU eviction from `#21611`, but that sweep only runs when the backend re-enters `ggml_backend_cuda_context::cuda_graph(...)`. The remaining issue slice is the fully idle server state: after the final active slot finishes, the server reaches the all-slots-idle fast path and returns without giving the backend graph cache a chance to trim.

This change stays scoped to that idle-only retention path. It adds a narrow CUDA/HIP graph-cache trim helper, routes it through an internal `llama_context` boundary, and invokes it only after the server has confirmed that every slot is idle. The server-side hook now keeps the shared-library boundary on the C side instead of exporting a new private C++ ABI symbol. Active generation, prompt-cache restore behavior, `--cache-idle-slots`, non-unified-KV behavior, and non-CUDA backends stay unchanged.

Closes #25082

## Additional information

Current source anchors:
- `ggml/src/ggml-cuda/common.cuh:1402-1428` stores `cuda_graphs`, tracks `last_graph_eviction_sweep`, and evicts stale graphs only when `ggml_backend_cuda_context::cuda_graph(...)` is entered again.
- `tools/server/server-context.cpp:2762-2775` detects `all slots are idle`, logs the state, and returns.
- `tools/server/server-context.cpp:484-503` marks a slot idle and reaches `update_slots()` through `callback_on_release(id)`.
- `ggml/src/ggml-backend.cpp:1908-1917` and `1937-1945` already provide the synchronize-and-iterate boundary needed to trim backend state per context.

Scope limits:
- keep the merged LRU logic from `#21611`
- do not broaden this into a cache-cap rewrite like draft `#21673`
- do not clear graph caches on every slot release
- do not change prompt-cache, KV-cache, or non-CUDA behavior

Validation scope:
- focused local proof covers the server-side trigger boundary only
- HIP/ROCm RSS reduction is not claimed unless it is actually rerun on a suitable HIP/ROCm host

Local validation that actually ran:
- MSVC CUDA build through `call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64`, `cmake -B build -S . -DGGML_CUDA=ON -G Ninja`, and `ninja -C build llama-server`
- `python -m pytest unit/test_cuda_graph_idle_trim.py -q`, using `LLAMA_SERVER_BIN_PATH` to point the Windows test harness at `build\bin\llama-server.exe`
- `python -m pytest unit/test_kv_keep_only_active.py -q`, using the same binary override

Focused proof coverage:
- target-only negative space: the trim tag stays absent after the first streamed chunk while slot 0 is still active
- target-only idle transition: the trim tag appears only after the server returns to the all-idle branch
- draft-context idle transition: a speculative server with `--model-draft` and `draft-simple` proves the draft-context trim branch executes from the same all-idle gate

Prior work: merged `#21611` added active-use LRU eviction on this surface, and draft `#21673` explores a broader graph-cache memory cap. This target stays limited to the remaining all-slots-idle retention path.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md).
- [x] AI usage disclosure: AI assistance was used to inspect the relevant code paths and prepare this local evidence pack.
- [x] Focused local validation is reported only for commands that actually ran.
- [x] HIP/ROCm RSS reduction is not claimed unless it was validated on a suitable HIP/ROCm host.
