### PR TITLE
model : register t_layer_inp for qwen3next

### DIFF
--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -121,6 +121,7 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
     ggml_tensor * inp_out_ids = build_inp_out_ids();
 
     for (int il = 0; il < n_layer; ++il) {
+        res->t_layer_inp[il] = inpL;
         ggml_tensor * inpSA = inpL;
 
         cur = build_norm(inpL, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, il);

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -122,6 +122,7 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
 
     for (int il = 0; il < n_layer; ++il) {
         res->t_layer_inp[il] = inpL;
+
         ggml_tensor * inpSA = inpL;
 
         cur = build_norm(inpL, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, il);


### PR DESCRIPTION
## Overview

This fixes speculative decoding support for `qwen3next`.

`qwen3next` graphs did not set `res->t_layer_inp[il]`, so drafters that extract target hidden states, such as DFlash and EAGLE3, abort at runtime:

```text
llama-graph.cpp:1244: GGML_ASSERT(t_layer_inp[il] != nullptr && "layer input tensor is null") failed
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, for description
