### PR TITLE
common, server : preserve HF file for cached models

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -916,7 +916,7 @@ std::vector<common_cached_model_info> common_list_cached_models() {
             continue;
         }
         if (seen.insert(f.repo_id + ":" + split.tag).second) {
-            result.push_back({f.repo_id, split.tag});
+            result.push_back({f.repo_id, split.tag, f.path});
         }
     }
 

--- a/common/download.h
+++ b/common/download.h
@@ -45,6 +45,7 @@ std::pair<std::string, std::string> common_download_split_repo_tag(const std::st
 struct common_cached_model_info {
     std::string repo;
     std::string tag;
+    std::string hf_file;
     std::string to_string() const {
         return repo + ":" + tag;
     }

--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -348,7 +348,10 @@ common_presets common_preset_context::load_from_cache() const {
     for (const auto & model : cached_models) {
         common_preset preset;
         preset.name = model.to_string();
-        preset.set_option(*this, "LLAMA_ARG_HF_REPO", model.to_string());
+        preset.set_option(*this, "LLAMA_ARG_HF_REPO", model.repo);
+        if (!model.hf_file.empty()) {
+            preset.set_option(*this, "LLAMA_ARG_HF_FILE", model.hf_file);
+        }
         out[preset.name] = preset;
     }
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -152,6 +152,7 @@ static void unset_reserved_args(common_preset & preset, bool unset_model_args) {
         preset.unset_option("LLAMA_ARG_MMPROJ");
         preset.unset_option("LLAMA_ARG_ALIAS");
         preset.unset_option("LLAMA_ARG_HF_REPO");
+        preset.unset_option("LLAMA_ARG_HF_FILE");
     }
 }
 
@@ -225,7 +226,7 @@ void server_model_meta::update_caps() {
             "LLAMA_ARG_MMPROJ",
             "LLAMA_ARG_MMPROJ_URL",
             "LLAMA_ARG_HF_REPO",
-            "LLAMA_ARG_HF_REPO_FILE",
+            "LLAMA_ARG_HF_FILE",
         });
         params.offline = true;
         common_models_handler handler = common_models_handler_init(params, LLAMA_EXAMPLE_SERVER);


### PR DESCRIPTION
## Overview

Today I downloaded a model from: https://huggingface.co/mudler/Step-3.5-Flash-APEX-GGUF, which contains the following files:

```
Step-3.7-Flash-APEX-Balanced.gguf
Step-3.7-Flash-APEX-Compact.gguf
Step-3.7-Flash-APEX-I-Balanced.gguf
Step-3.7-Flash-APEX-I-Compact.gguf <-- I downloaded this one to my huggingface cache
Step-3.7-Flash-APEX-I-Mini.gguf
Step-3.7-Flash-APEX-I-Quality.gguf
Step-3.7-Flash-APEX-Quality.gguf
```

Using `llama serve` discovers the model with the following identifier: `mudler/Step-3.7-Flash-APEX-GGUF:COMPACT`. The issue is that the tag `:COMPACT` is a ambiguous and llama will (silently) start downloading `Step-3.7-Flash-APEX-Compact.gguf` from huggingface when you start using the model.

The fix is to pass the GGUF filename using `LLAMA_ARG_HF_FILE` so we avoid the ambiguity.

## Additional information

I think there is a larger discussion to be had about the way the tag is determined, because a better tag name here would arguably be `I-COMPACT`. Unsloth's `UD-xxx` quants have a similar issue: https://https://huggingface.co/unsloth/Step-3.7-Flash-GGUF. This is not something I would feel comfortable submitting a PR for though.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, pi:gpt-5.5 was used to triage and fix the issue. I reviewed the code thoroughly by hand and fully understand the changes.

Duncan