### PR TITLE
ggml: imatrix-aware NVFP4 quantization (scale search) + wire NVFP4 ftype

### DIFF
--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -343,69 +343,29 @@ void quantize_row_mxfp4_ref(const float * GGML_RESTRICT x, block_mxfp4 * GGML_RE
     }
 }
 
-void quantize_row_nvfp4_ref(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y, int64_t k) {
-    static const int qk = QK_NVFP4;
-    static const int qk_sub = QK_NVFP4_SUB;
-    static const int n_sub = QK_NVFP4 / QK_NVFP4_SUB;
-
-    assert(k % qk == 0);
-
-    const int nb = k / qk;
-
-    for (int i = 0; i < nb; i++) {
-        for (int s = 0; s < n_sub; s++) {
-            const float * xb = x + i*qk + s*qk_sub;
-
-            float amax = 0.0f;
-            for (int j = 0; j < qk_sub; j++) {
-                if (amax < fabsf(xb[j])) {
-                    amax = fabsf(xb[j]);
-                }
-            }
-
-            // UE4M3 scale: amax / 6.0 maps the max E2M1 value (6.0) to amax
-            const uint8_t ue = ggml_fp32_to_ue4m3(amax / 6.0f);
-            y[i].d[s] = ue;
-            const float d = ggml_ue4m3_to_fp32(ue);
-
-            for (int j = 0; j < qk_sub/2; ++j) {
-                const uint8_t x0 = best_index_mxfp4(xb[0        + j], d);
-                const uint8_t x1 = best_index_mxfp4(xb[qk_sub/2 + j], d);
-
-                y[i].qs[s*(qk_sub/2) + j] = x0 | (x1 << 4);
-            }
-        }
-    }
-}
-
-// Importance-aware NVFP4: instead of fixing the per-sub-block scale at amax/6, search a
-// small window of UE4M3 scale codes around it and keep the one minimizing the (optionally
-// importance-weighted) reconstruction error of the sub-block. With quant_weights == NULL this
-// reduces to an unweighted scale search (still better than amax/6); with an imatrix it spends
-// precision on the columns whose activations matter. Output format is unchanged, so the result
-// runs on stock NVFP4 kernels.
+// Core NVFP4 encoder, shared by the reference path and the importance-aware path.
 //
-// Window width: the optimal UE4M3 code sits a few codes around amax/6, skewed positive (the
-// non-uniform E2M1 codes {..6,8,12} make scaling UP to clamp an outlier and fit the bulk often
-// optimal). +/-12 is comfortably wide. Narrowing to +/-8 measurably regresses search-only PPL on
-// real weights (Qwen3.5-9B wiki: 8.240 -> 8.287) even though a synthetic-weight proxy showed
-// saturation -- real weight tails are heavier than the proxy, so keep the margin.
-// An iterative coordinate-descent solve (make_qkx-style) was prototyped and is WORSE here: it
-// gets stuck in local minima that the dense brute-force window avoids. A fixed window is both
-// better and simpler than an iterative solver for NVFP4's discrete non-uniform codes.
-#define NVFP4_SCALE_SEARCH 12  // +/- codes around amax/6 (brute force; iterative solve is worse)
-
-static void quantize_row_nvfp4_impl(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y,
-                                    int64_t k, const float * GGML_RESTRICT quant_weights) {
+// Each 16-element sub-block gets a UE4M3 scale. The baseline scale amax/6 maps the max
+// |x| to the top E2M1 magnitude (6). With `search > 0` we also try UE4M3 codes in
+// [base-search, base+search] and keep the one minimizing the (optionally importance-
+// weighted) reconstruction error; the winning E2M1 nibbles are cached during the search so
+// the final packing reuses them instead of recomputing. The output is ordinary NVFP4, so
+// the result runs unmodified on stock NVFP4 kernels.
+//
+//   search == 0, quant_weights == NULL  -> identical to the legacy amax/6 reference.
+//   search  > 0, quant_weights == NULL  -> unweighted scale search (better than amax/6).
+//   search  > 0, quant_weights != NULL  -> importance-weighted scale search (imatrix).
+//
+// quant_weights, when present, is one value per input column (length k, shared across rows
+// by the caller) and is indexed by column only.
+static void quantize_row_nvfp4_core(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y,
+                                    int64_t k, const float * GGML_RESTRICT quant_weights, int search) {
     static const int qk = QK_NVFP4;
     static const int qk_sub = QK_NVFP4_SUB;
     static const int n_sub = QK_NVFP4 / QK_NVFP4_SUB;
 
     assert(k % qk == 0);
     const int nb = k / qk;
-
-    // NVFP4_NO_SEARCH=1 forces the legacy amax/6 scale (search window 0) for A/B testing.
-    const int search = getenv("NVFP4_NO_SEARCH") ? 0 : NVFP4_SCALE_SEARCH;
 
     for (int i = 0; i < nb; i++) {
         for (int s = 0; s < n_sub; s++) {
@@ -426,11 +386,12 @@ static void quantize_row_nvfp4_impl(const float * GGML_RESTRICT x, block_nvfp4 *
                 continue;
             }
 
+            // amax / 6.0 maps the max E2M1 value (6.0) to amax
             const uint8_t base = ggml_fp32_to_ue4m3(amax / 6.0f);
 
-            // search UE4M3 scale codes in [base-search, base+search], pick min (weighted) error
             uint8_t best_code = base;
             float   best_cost = INFINITY;
+            uint8_t best_idx[QK_NVFP4_SUB];
             const int lo = (int) base - search;
             const int hi = (int) base + search;
             for (int c = lo; c <= hi; ++c) {
@@ -441,29 +402,51 @@ static void quantize_row_nvfp4_impl(const float * GGML_RESTRICT x, block_nvfp4 *
                 if (d <= 0.0f) {
                     continue;
                 }
-                float cost = 0.0f;
+                float   cost = 0.0f;
+                uint8_t idx[QK_NVFP4_SUB];
                 for (int j = 0; j < qk_sub; ++j) {
-                    const int idx = best_index_mxfp4(xb[j], d);
-                    const float r = kvalues_mxfp4[idx] * d - xb[j];
+                    idx[j] = best_index_mxfp4(xb[j], d);
+                    const float r = kvalues_mxfp4[idx[j]] * d - xb[j];
                     const float w = wb ? wb[j] : 1.0f;
                     cost += w * r * r;
                 }
                 if (cost < best_cost) {
                     best_cost = cost;
                     best_code = (uint8_t) c;
+                    memcpy(best_idx, idx, sizeof(best_idx));
                 }
             }
 
+            // best_cost stays INFINITY only when no code in the window was valid, i.e.
+            // base == 0 (sub-normal underflow of amax/6); encode that as a zero block,
+            // matching the legacy reference.
+            if (best_cost == INFINITY) {
+                y[i].d[s] = 0;
+                for (int j = 0; j < qk_sub/2; ++j) {
+                    y[i].qs[s*(qk_sub/2) + j] = 0;
+                }
+                continue;
+            }
+
             y[i].d[s] = best_code;
-            const float d = ggml_ue4m3_to_fp32(best_code);
             for (int j = 0; j < qk_sub/2; ++j) {
-                const uint8_t x0 = best_index_mxfp4(xb[0        + j], d);
-                const uint8_t x1 = best_index_mxfp4(xb[qk_sub/2 + j], d);
-                y[i].qs[s*(qk_sub/2) + j] = x0 | (x1 << 4);
+                y[i].qs[s*(qk_sub/2) + j] = best_idx[j] | (best_idx[qk_sub/2 + j] << 4);
             }
         }
     }
 }
+
+void quantize_row_nvfp4_ref(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y, int64_t k) {
+    quantize_row_nvfp4_core(x, y, k, NULL, 0);
+}
+
+// Scale-search half-window for the importance-aware path. The optimal UE4M3 code sits a few
+// codes around amax/6, skewed positive (the non-uniform E2M1 codes {..6,8,12} make scaling UP
+// to clamp an outlier and fit the bulk often optimal). +/-12 is comfortably wide; narrowing to
+// +/-8 measurably regresses real-weight PPL, so keep the margin. A brute-force window beats an
+// iterative coordinate-descent solve here, which gets stuck in local minima created by the
+// non-uniform code spacing.
+#define NVFP4_SCALE_SEARCH 12
 
 void dequantize_row_q1_0(const block_q1_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
     static const int qk = QK1_0;
@@ -2325,8 +2308,8 @@ size_t quantize_nvfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
     char * qrow = (char *) dst;
     for (int64_t row = 0; row < nrow; ++row) {
         // quant_weights (imatrix) is one value per input column, length n_per_row, shared
-        // across all rows of this tensor — indexed by column only, NOT offset per row.
-        quantize_row_nvfp4_impl(src + row * n_per_row, (block_nvfp4 *) qrow, n_per_row, quant_weights);
+        // across all rows of this tensor -- indexed by column only, NOT offset per row.
+        quantize_row_nvfp4_core(src + row * n_per_row, (block_nvfp4 *) qrow, n_per_row, quant_weights, NVFP4_SCALE_SEARCH);
         qrow += row_size;
     }
     return nrow * row_size;

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -384,7 +384,16 @@ void quantize_row_nvfp4_ref(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RE
 // reduces to an unweighted scale search (still better than amax/6); with an imatrix it spends
 // precision on the columns whose activations matter. Output format is unchanged, so the result
 // runs on stock NVFP4 kernels.
-#define NVFP4_SCALE_SEARCH 12  // +/- codes searched around the amax/6 starting scale
+//
+// Window width: the optimal UE4M3 code sits a few codes around amax/6, skewed positive (the
+// non-uniform E2M1 codes {..6,8,12} make scaling UP to clamp an outlier and fit the bulk often
+// optimal). +/-12 is comfortably wide. Narrowing to +/-8 measurably regresses search-only PPL on
+// real weights (Qwen3.5-9B wiki: 8.240 -> 8.287) even though a synthetic-weight proxy showed
+// saturation -- real weight tails are heavier than the proxy, so keep the margin.
+// An iterative coordinate-descent solve (make_qkx-style) was prototyped and is WORSE here: it
+// gets stuck in local minima that the dense brute-force window avoids. A fixed window is both
+// better and simpler than an iterative solver for NVFP4's discrete non-uniform codes.
+#define NVFP4_SCALE_SEARCH 12  // +/- codes around amax/6 (brute force; iterative solve is worse)
 
 static void quantize_row_nvfp4_impl(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y,
                                     int64_t k, const float * GGML_RESTRICT quant_weights) {

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -343,21 +343,9 @@ void quantize_row_mxfp4_ref(const float * GGML_RESTRICT x, block_mxfp4 * GGML_RE
     }
 }
 
-// Core NVFP4 encoder, shared by the reference path and the importance-aware path.
-//
-// Each 16-element sub-block gets a UE4M3 scale. The baseline scale amax/6 maps the max
-// |x| to the top E2M1 magnitude (6). With `search > 0` we also try UE4M3 codes in
-// [base-search, base+search] and keep the one minimizing the (optionally importance-
-// weighted) reconstruction error; the winning E2M1 nibbles are cached during the search so
-// the final packing reuses them instead of recomputing. The output is ordinary NVFP4, so
-// the result runs unmodified on stock NVFP4 kernels.
-//
-//   search == 0, quant_weights == NULL  -> identical to the legacy amax/6 reference.
-//   search  > 0, quant_weights == NULL  -> unweighted scale search (better than amax/6).
-//   search  > 0, quant_weights != NULL  -> importance-weighted scale search (imatrix).
-//
-// quant_weights, when present, is one value per input column (length k, shared across rows
-// by the caller) and is indexed by column only.
+// search > 0 tries UE4M3 scale codes in [base-search, base+search] and keeps the one with the
+// lowest (optionally quant_weights-weighted) error. search == 0 && !quant_weights matches the
+// legacy amax/6 reference. quant_weights is per-column (length k), indexed by column only.
 static void quantize_row_nvfp4_core(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y,
                                     int64_t k, const float * GGML_RESTRICT quant_weights, int search) {
     static const int qk = QK_NVFP4;
@@ -378,20 +366,13 @@ static void quantize_row_nvfp4_core(const float * GGML_RESTRICT x, block_nvfp4 *
                     amax = fabsf(xb[j]);
                 }
             }
-            if (amax == 0.0f) {
-                y[i].d[s] = 0;
-                for (int j = 0; j < qk_sub/2; ++j) {
-                    y[i].qs[s*(qk_sub/2) + j] = 0;
-                }
-                continue;
-            }
 
             // amax / 6.0 maps the max E2M1 value (6.0) to amax
             const uint8_t base = ggml_fp32_to_ue4m3(amax / 6.0f);
 
-            uint8_t best_code = base;
+            uint8_t best_code = 0;
             float   best_cost = INFINITY;
-            uint8_t best_idx[QK_NVFP4_SUB];
+            uint8_t best_idx[QK_NVFP4_SUB] = { 0 };
             const int lo = (int) base - search;
             const int hi = (int) base + search;
             for (int c = lo; c <= hi; ++c) {
@@ -417,17 +398,8 @@ static void quantize_row_nvfp4_core(const float * GGML_RESTRICT x, block_nvfp4 *
                 }
             }
 
-            // best_cost stays INFINITY only when no code in the window was valid, i.e.
-            // base == 0 (sub-normal underflow of amax/6); encode that as a zero block,
-            // matching the legacy reference.
-            if (best_cost == INFINITY) {
-                y[i].d[s] = 0;
-                for (int j = 0; j < qk_sub/2; ++j) {
-                    y[i].qs[s*(qk_sub/2) + j] = 0;
-                }
-                continue;
-            }
-
+            // no valid code (base == 0 from a sub-normal amax/6) leaves the zero-initialized
+            // best_code / best_idx, encoding a zero block as the reference does
             y[i].d[s] = best_code;
             for (int j = 0; j < qk_sub/2; ++j) {
                 y[i].qs[s*(qk_sub/2) + j] = best_idx[j] | (best_idx[qk_sub/2 + j] << 4);
@@ -440,12 +412,7 @@ void quantize_row_nvfp4_ref(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RE
     quantize_row_nvfp4_core(x, y, k, NULL, 0);
 }
 
-// Scale-search half-window for the importance-aware path. The optimal UE4M3 code sits a few
-// codes around amax/6, skewed positive (the non-uniform E2M1 codes {..6,8,12} make scaling UP
-// to clamp an outlier and fit the bulk often optimal). +/-12 is comfortably wide; narrowing to
-// +/-8 measurably regresses real-weight PPL, so keep the margin. A brute-force window beats an
-// iterative coordinate-descent solve here, which gets stuck in local minima created by the
-// non-uniform code spacing.
+// half-window of UE4M3 scale codes searched around the amax/6 baseline
 #define NVFP4_SCALE_SEARCH 12
 
 void dequantize_row_q1_0(const block_q1_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
@@ -2307,9 +2274,9 @@ size_t quantize_nvfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
     const size_t row_size = ggml_row_size(GGML_TYPE_NVFP4, n_per_row);
     char * qrow = (char *) dst;
     for (int64_t row = 0; row < nrow; ++row) {
-        // quant_weights (imatrix) is one value per input column, length n_per_row, shared
-        // across all rows of this tensor -- indexed by column only, NOT offset per row.
-        quantize_row_nvfp4_core(src + row * n_per_row, (block_nvfp4 *) qrow, n_per_row, quant_weights, NVFP4_SCALE_SEARCH);
+        // quant_weights is shared across rows (one value per column), so it is not advanced
+        quantize_row_nvfp4_core(src, (block_nvfp4 *) qrow, n_per_row, quant_weights, NVFP4_SCALE_SEARCH);
+        src  += n_per_row;
         qrow += row_size;
     }
     return nrow * row_size;

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -378,6 +378,84 @@ void quantize_row_nvfp4_ref(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RE
     }
 }
 
+// Importance-aware NVFP4: instead of fixing the per-sub-block scale at amax/6, search a
+// small window of UE4M3 scale codes around it and keep the one minimizing the (optionally
+// importance-weighted) reconstruction error of the sub-block. With quant_weights == NULL this
+// reduces to an unweighted scale search (still better than amax/6); with an imatrix it spends
+// precision on the columns whose activations matter. Output format is unchanged, so the result
+// runs on stock NVFP4 kernels.
+#define NVFP4_SCALE_SEARCH 12  // +/- codes searched around the amax/6 starting scale
+
+static void quantize_row_nvfp4_impl(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y,
+                                    int64_t k, const float * GGML_RESTRICT quant_weights) {
+    static const int qk = QK_NVFP4;
+    static const int qk_sub = QK_NVFP4_SUB;
+    static const int n_sub = QK_NVFP4 / QK_NVFP4_SUB;
+
+    assert(k % qk == 0);
+    const int nb = k / qk;
+
+    // NVFP4_NO_SEARCH=1 forces the legacy amax/6 scale (search window 0) for A/B testing.
+    const int search = getenv("NVFP4_NO_SEARCH") ? 0 : NVFP4_SCALE_SEARCH;
+
+    for (int i = 0; i < nb; i++) {
+        for (int s = 0; s < n_sub; s++) {
+            const float * xb = x + i*qk + s*qk_sub;
+            const float * wb = quant_weights ? quant_weights + i*qk + s*qk_sub : NULL;
+
+            float amax = 0.0f;
+            for (int j = 0; j < qk_sub; j++) {
+                if (amax < fabsf(xb[j])) {
+                    amax = fabsf(xb[j]);
+                }
+            }
+            if (amax == 0.0f) {
+                y[i].d[s] = 0;
+                for (int j = 0; j < qk_sub/2; ++j) {
+                    y[i].qs[s*(qk_sub/2) + j] = 0;
+                }
+                continue;
+            }
+
+            const uint8_t base = ggml_fp32_to_ue4m3(amax / 6.0f);
+
+            // search UE4M3 scale codes in [base-search, base+search], pick min (weighted) error
+            uint8_t best_code = base;
+            float   best_cost = INFINITY;
+            const int lo = (int) base - search;
+            const int hi = (int) base + search;
+            for (int c = lo; c <= hi; ++c) {
+                if (c < 1 || c > 0x7E) {
+                    continue;
+                }
+                const float d = ggml_ue4m3_to_fp32((uint8_t) c);
+                if (d <= 0.0f) {
+                    continue;
+                }
+                float cost = 0.0f;
+                for (int j = 0; j < qk_sub; ++j) {
+                    const int idx = best_index_mxfp4(xb[j], d);
+                    const float r = kvalues_mxfp4[idx] * d - xb[j];
+                    const float w = wb ? wb[j] : 1.0f;
+                    cost += w * r * r;
+                }
+                if (cost < best_cost) {
+                    best_cost = cost;
+                    best_code = (uint8_t) c;
+                }
+            }
+
+            y[i].d[s] = best_code;
+            const float d = ggml_ue4m3_to_fp32(best_code);
+            for (int j = 0; j < qk_sub/2; ++j) {
+                const uint8_t x0 = best_index_mxfp4(xb[0        + j], d);
+                const uint8_t x1 = best_index_mxfp4(xb[qk_sub/2 + j], d);
+                y[i].qs[s*(qk_sub/2) + j] = x0 | (x1 << 4);
+            }
+        }
+    }
+}
+
 void dequantize_row_q1_0(const block_q1_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
     static const int qk = QK1_0;
 
@@ -2234,9 +2312,15 @@ size_t quantize_mxfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
 }
 
 size_t quantize_nvfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrow, int64_t n_per_row, const float * quant_weights) {
-    GGML_UNUSED(quant_weights);
-    quantize_row_nvfp4_ref(src, dst, (int64_t)nrow*n_per_row);
-    return nrow * ggml_row_size(GGML_TYPE_NVFP4, n_per_row);
+    const size_t row_size = ggml_row_size(GGML_TYPE_NVFP4, n_per_row);
+    char * qrow = (char *) dst;
+    for (int64_t row = 0; row < nrow; ++row) {
+        // quant_weights (imatrix) is one value per input column, length n_per_row, shared
+        // across all rows of this tensor — indexed by column only, NOT offset per row.
+        quantize_row_nvfp4_impl(src + row * n_per_row, (block_nvfp4 *) qrow, n_per_row, quant_weights);
+        qrow += row_size;
+    }
+    return nrow * row_size;
 }
 
 // ====================== Ternary (de)-quantization (BitNet b1.58 and TriLMs)

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -468,8 +468,7 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
             new_type = GGML_TYPE_Q8_0;
         }
     } else if (ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
-        // 2D weight tensors -> NVFP4. Shapes whose ne[0] is not a multiple of the NVFP4 block
-        // size fall back to Q8_0 in tensor_type_fallback(); 1D / tiny tensors are skipped earlier.
+        // weight tensors -> NVFP4 (ne[0] % block != 0 falls back to Q8_0 in tensor_type_fallback)
         new_type = GGML_TYPE_NVFP4;
     } else if (category == tensor_category::TOKEN_EMBD) {
         if (qs.params->token_embedding_type < GGML_TYPE_COUNT) {

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -387,6 +387,7 @@ static ggml_type tensor_type_fallback(quantize_state_impl & qs, const ggml_tenso
             case GGML_TYPE_Q4_K:    return_type = GGML_TYPE_Q5_0;   break;
             case GGML_TYPE_Q5_K:    return_type = GGML_TYPE_Q5_1;   break;
             case GGML_TYPE_Q6_K:    return_type = GGML_TYPE_Q8_0;   break;
+            case GGML_TYPE_NVFP4:   return_type = GGML_TYPE_Q8_0;   break;
             default:
                 throw std::runtime_error(format("no tensor type fallback is defined for type %s",
                                                 ggml_type_name(target_type)));
@@ -467,8 +468,8 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
             new_type = GGML_TYPE_Q8_0;
         }
     } else if (ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
-        // 2D weight tensors -> NVFP4 (the block-size guard falls back odd shapes to Q8_0);
-        // 1D / tiny tensors -> Q8_0
+        // 2D weight tensors -> NVFP4. Shapes whose ne[0] is not a multiple of the NVFP4 block
+        // size fall back to Q8_0 in tensor_type_fallback(); 1D / tiny tensors are skipped earlier.
         new_type = GGML_TYPE_NVFP4;
     } else if (category == tensor_category::TOKEN_EMBD) {
         if (qs.params->token_embedding_type < GGML_TYPE_COUNT) {

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -443,7 +443,7 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
             const int64_t nx = tensor->ne[0];
             const int64_t qk_k = ggml_blck_size(new_type);
 
-            if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE) {
+            if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE || ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
                 new_type = GGML_TYPE_Q8_0;
             }
             else if (arch == LLM_ARCH_FALCON || nx % qk_k != 0) {
@@ -466,6 +466,10 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
         } else {
             new_type = GGML_TYPE_Q8_0;
         }
+    } else if (ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
+        // 2D weight tensors -> NVFP4 (the block-size guard falls back odd shapes to Q8_0);
+        // 1D / tiny tensors -> Q8_0
+        new_type = GGML_TYPE_NVFP4;
     } else if (category == tensor_category::TOKEN_EMBD) {
         if (qs.params->token_embedding_type < GGML_TYPE_COUNT) {
             new_type = qs.params->token_embedding_type;
@@ -802,6 +806,7 @@ ggml_type llama_ftype_get_default_type(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q1_0: return GGML_TYPE_Q1_0;
 
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return GGML_TYPE_MXFP4;
+        case LLAMA_FTYPE_MOSTLY_NVFP4:     return GGML_TYPE_NVFP4;
 
         // K-quants
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -36,6 +36,7 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q4_0",     LLAMA_FTYPE_MOSTLY_Q4_0,     " 4.34G, +0.4685 ppl @ Llama-3-8B",  },
     { "Q4_1",     LLAMA_FTYPE_MOSTLY_Q4_1,     " 4.78G, +0.4511 ppl @ Llama-3-8B",  },
     { "MXFP4_MOE",LLAMA_FTYPE_MOSTLY_MXFP4_MOE," MXFP4 MoE",  },
+    { "NVFP4",    LLAMA_FTYPE_MOSTLY_NVFP4,    " NVFP4 4-bit (imatrix-aware)",  },
     { "Q5_0",     LLAMA_FTYPE_MOSTLY_Q5_0,     " 5.21G, +0.1316 ppl @ Llama-3-8B",  },
     { "Q5_1",     LLAMA_FTYPE_MOSTLY_Q5_1,     " 5.65G, +0.1062 ppl @ Llama-3-8B",  },
     { "IQ2_XXS",  LLAMA_FTYPE_MOSTLY_IQ2_XXS,  " 2.06 bpw quantization",            },


### PR DESCRIPTION
## Overview

In short, this PR improves NVFP4 quantization quality by replacing the fixed `amax/6`
per-sub-block scale with a small scale search that minimizes (optionally imatrix-weighted)
reconstruction error, and it wires up the `NVFP4` ftype so `llama-quantize` can actually
produce NVFP4 GGUFs.

Today `quantize_nvfp4` does `GGML_UNUSED(quant_weights)` and quantizes each 16-element
sub-block with a fixed scale `amax/6`. The imatrix is ignored, and `LLAMA_FTYPE_MOSTLY_NVFP4`
is defined but unreferenced - there is no CLI type, no ftype->ggml_type mapping, and no
per-tensor selection - so NVFP4 GGUFs can only come from external/convert tools, not from
`llama-quantize`.

This change:

- adds `quantize_row_nvfp4_core(x, y, k, quant_weights, search)`; the existing
  `quantize_row_nvfp4_ref` becomes `core(..., NULL, 0)`, so there is one encoder, not two.
- for each sub-block, searches UE4M3 scale codes in `[base-search, base+search]` around the
  `amax/6` baseline and keeps the code with the lowest reconstruction error; with an imatrix
  the error is importance-weighted per input column. The winning E2M1 nibbles are cached
  during the search and reused for packing.
- wires `LLAMA_FTYPE_MOSTLY_NVFP4`: CLI type in `quantize.cpp`, `ftype->GGML_TYPE_NVFP4`
  mapping, per-tensor selection (2D weights -> NVFP4, output/embed/1D -> Q8_0), and a
  `tensor_type_fallback` case (`ne[0] % 64 != 0` -> Q8_0) so odd-shaped tensors do not abort
  the run.

The output is ordinary NVFP4, so the result runs unmodified on the existing NVFP4 kernels.
With `search > 0` and no imatrix the scale search alone already improves quality; an imatrix
adds further on top.

Results below are on Qwen3.5-9B, Gemma-4-26B-A4B, and Qwen3.6-27B (+ MTP), the last being
my own daily-driver model and including MTP speculative-decoding acceptance.

## Benchmark Setup

- Base: `upstream/master` at `c818263f2`
- Patch commit: `c73069749`
- Hardware: NVIDIA GeForce RTX 5090 Laptop GPU, 24463 MiB VRAM
- Driver: 595.71.05
- Build: CUDA 13.1, `build/bin/{llama-quantize,llama-imatrix,llama-perplexity}`
- Quantization: source f16 GGUF -> `llama-quantize ... NVFP4`
- imatrix: `llama-imatrix` over a calibration corpus, 40 chunks
- Perplexity: `llama-perplexity -f wiki.test.raw --chunks <N>`
- Three arms compared:
  - `RTN`: legacy `amax/6` scale (search window 0, no imatrix) - baseline
  - `scale-search`: scale search, no imatrix
  - `scale-search + imatrix`: scale search using the imatrix

## Results

Lower perplexity is better. All three GGUFs for a given model are identical in size (the
change is in scale selection only, not the format).

### Qwen3.5-9B (wikitext-2 test, 60 chunks, imatrix on wiki.train)

| arm | PPL | vs RTN |
| --- | ---: | ---: |
| RTN (amax/6) | 8.497 +/- 0.180 | - |
| scale-search | 8.247 +/- 0.172 | -2.9% |
| scale-search + imatrix | 7.984 +/- 0.165 | -6.0% |

### Gemma-4-26B-A4B (60 chunks, imatrix built on a code corpus)

Cross-domain check: the imatrix was built on code yet improves both eval corpora.

| corpus | RTN | scale-search | scale-search + imatrix |
| --- | ---: | ---: | ---: |
| wikitext-2 | 5.888 +/- 0.109 | 5.827 (-1.0%) | 5.675 +/- 0.103 (-3.6%) |
| code | 1.933 +/- 0.024 | 1.909 (-1.2%) | 1.885 +/- 0.023 (-2.5%) |

### Qwen3.6-27B + MTP (hybrid SSM/attn, daily-driver model; 40 chunks, imatrix on code)

| corpus | RTN | scale-search | scale-search + imatrix |
| --- | ---: | ---: | ---: |
| wikitext-2 | 6.123 +/- 0.149 | 6.128 (+0.1%) | 6.167 (+0.7%) |
| code | 1.950 +/- 0.031 | 1.925 (-1.3%) | 1.903 +/- 0.030 (-2.4%) |

Here the imatrix was built on code and the wikitext numbers are off-domain: scale-search is
roughly flat on wikitext and helps on code, while the code-built imatrix improves the code
eval (-2.4%) but slightly regresses wikitext (+0.7%). So scale-search is domain-neutral and
safe on its own; the imatrix benefit is largest when the calibration domain matches the
target workload. (Unlike Gemma above, where a code imatrix happened to also help wikitext,
this hybrid model does not generalize the code imatrix to wikitext.)

MTP acceptance, same draft model in both arms (so the comparison isolates the requantized
trunk), code/reasoning prompts, greedy decoding:

| arm | draft_n | accepted | accept_rate |
| --- | ---: | ---: | ---: |
| RTN (amax/6) | 525 | 343 | 65.3% |
| scale-search + imatrix | 642 | 489 | 76.2% |

On the matching (code) domain the better-quantized trunk raises MTP acceptance by ~11 points,
which directly reduces speculative verification passes.

## Notes on the scale search

- Window width `NVFP4_SCALE_SEARCH = 12`. The optimal code sits within a few codes of
  `amax/6`, reoriented positive (the non-uniform E2M1 codes `{..6,8,12}` mean scaling up to clamp
  an outlier and fit the bulk is often optimal). Narrowing to +/-8 measurably regressed
  9B search-only PPL (8.240 -> 8.287), so the margin is kept.
- An iterative coordinate-descent solve (make_qkx-style: assign nibbles -> weighted-LSQ scale
  -> snap to UE4M3 -> repeat) was prototyped and performed worse than the brute-force window;
The non-uniform code spacing creates local boundaries that the dense window steps over.

## Validation

- `git diff --check`
- `cmake --build build --target llama-quantize llama-perplexity test-quant-type-selection -j 8`
- Verified the refactor is byte-identical to the pre-refactor implementation for both the
  scale-search and scale-search+imatrix outputs (so the measured PPL is unchanged by the
  cleanup).
- A/B baseline: a local build with the search window set to 0 reproduces the legacy `amax/6`
  reference exactly (this is what the `RTN` arm above was quantized with).
- `test-quant-type-selection`: the pre-existing MXFP4_MOE/IQ snapshot diffs are present on
  `master` without this change; NVFP4 sections are unaffected.

-----------------------
AI usage disclosure: YES - Claude opus 4.8 xhigh was used to write this code. It assisted with code writing, local code review, benchmarking, cleanup, and preparing the MD-styled parts of this PR, like the tables.

While an LLM wrote the code, I did the design, the research, and the codebase reading, I directed, reviewed and steered during development, designed the benchmarks, reviewed the code more than once and instructed changes, and I'm doing the final signing on this code and PR.
I own this code, and I'm responsible for the output of the tools I use.

