### PR TITLE
convert: add --temp-dir option for custom temp file location

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -114,7 +114,7 @@ class ModelBase:
     no_mtp: bool = False
 
     def __init__(self, dir_model: Path, ftype: gguf.LlamaFileType, fname_out: Path, *, is_big_endian: bool = False,
-                 use_temp_file: bool = False, eager: bool = False,
+                 use_temp_file: bool = False, temp_dir: str | None = None, eager: bool = False,
                  metadata_override: Path | None = None, model_name: str | None = None,
                  split_max_tensors: int = 0, split_max_size: int = 0, dry_run: bool = False,
                  small_first_shard: bool = False, hparams: dict[str, Any] | None = None, remote_hf_model_id: str | None = None,
@@ -137,6 +137,7 @@ class ModelBase:
         self.is_big_endian = is_big_endian
         self.endianess = gguf.GGUFEndian.BIG if is_big_endian else gguf.GGUFEndian.LITTLE
         self.use_temp_file = use_temp_file
+        self.temp_dir = temp_dir
         self.lazy = not eager or (remote_hf_model_id is not None)
         self.dry_run = dry_run
         self.remote_hf_model_id = remote_hf_model_id
@@ -176,6 +177,7 @@ class ModelBase:
 
         # Configure GGUF Writer
         self.gguf_writer = gguf.GGUFWriter(path=None, arch=gguf.MODEL_ARCH_NAMES[self.model_arch], endianess=self.endianess, use_temp_file=self.use_temp_file,
+                                           temp_dir=self.temp_dir,
                                            split_max_tensors=split_max_tensors, split_max_size=split_max_size, dry_run=dry_run, small_first_shard=small_first_shard)
 
         # Mistral specific

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -74,6 +74,10 @@ def parse_args() -> argparse.Namespace:
         help="use the tempfile library while processing (helpful when running out of memory, process killed)",
     )
     parser.add_argument(
+        "--temp-dir", type=str, default=None,
+        help="directory to store temporary files when using --use-temp-file (default: system temp directory)",
+    )
+    parser.add_argument(
         "--no-lazy", action="store_true",
         help="use more RAM by computing all outputs before writing (use in case lazy evaluation is broken)",
     )
@@ -216,6 +220,13 @@ def main() -> None:
         logger.error("Error: Cannot use temp file when splitting")
         sys.exit(1)
 
+    if args.temp_dir is not None:
+        if not args.use_temp_file:
+            logger.warning("Warning: --temp-dir is ignored without --use-temp-file")
+        elif not os.path.isdir(args.temp_dir):
+            logger.error(f"Error: Temp directory does not exist: {args.temp_dir}")
+            sys.exit(1)
+
     if args.outfile is not None:
         fname_out = args.outfile
     elif hf_repo_id:
@@ -271,6 +282,7 @@ def main() -> None:
 
         model_instance = model_class(dir_model, output_type, fname_out,
                                      is_big_endian=args.bigendian, use_temp_file=args.use_temp_file,
+                                     temp_dir=args.temp_dir,
                                      eager=args.no_lazy,
                                      metadata_override=args.metadata, model_name=args.model_name,
                                      split_max_tensors=args.split_max_tensors,

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -85,7 +85,8 @@ class GGUFWriter:
 
     def __init__(
         self, path: os.PathLike[str] | str | None, arch: str, use_temp_file: bool = False, endianess: GGUFEndian = GGUFEndian.LITTLE,
-        split_max_tensors: int = 0, split_max_size: int = 0, dry_run: bool = False, small_first_shard: bool = False
+        split_max_tensors: int = 0, split_max_size: int = 0, dry_run: bool = False, small_first_shard: bool = False,
+        temp_dir: str | None = None,
     ):
         self.fout = None
         self.path = Path(path) if path else None
@@ -93,6 +94,7 @@ class GGUFWriter:
         self.endianess = endianess
         self.data_alignment = GGUF_DEFAULT_ALIGNMENT
         self.use_temp_file = use_temp_file
+        self.temp_dir = temp_dir
         self.temp_file = None
         self.tensors = [{}]
         self.kv_data = [{}]
@@ -384,7 +386,7 @@ class GGUFWriter:
             # Don't byteswap inplace since lazy copies cannot handle it
             tensor = tensor.byteswap(inplace=False)
         if self.use_temp_file and self.temp_file is None:
-            fp = tempfile.SpooledTemporaryFile(mode="w+b", max_size=256 * 1024 * 1024)
+            fp = tempfile.SpooledTemporaryFile(mode="w+b", max_size=256 * 1024 * 1024, dir=self.temp_dir)
             fp.seek(0)
             self.temp_file = fp
 


### PR DESCRIPTION
Adds a --temp-dir CLI argument to convert_hf_to_gguf.py that allows users to specify a custom directory for temporary files when using --use-temp-file.

This is useful when the system default temp directory is on a partition with limited disk space.

The change threads the temp_dir parameter through:
- convert_hf_to_gguf.py (CLI argument + validation)
- conversion/base.py (ModelBase constructor)
- gguf-py/gguf/gguf_writer.py (GGUFWriter + SpooledTemporaryFile)

Closes #17770

## Overview

When running `convert_hf_to_gguf.py --use-temp-file`, temporary files are always written to the system's default temp directory (e.g., `C:\Users\...\AppData\Local\Temp` on Windows or `/tmp` on Linux). Users whose temp partition has limited disk space — common when converting large models — cannot redirect these files to a different drive or partition.

This PR adds a `--temp-dir` argument that lets users point temp file creation to any directory:

`python convert_hf_to_gguf.py model_dir --use-temp-file --temp-dir /mnt/bigdisk/tmp`

Validation is included:
- A warning is shown if `--temp-dir` is used without `--use-temp-file`
- An error is shown if the specified directory does not exist

## Additional information

This PR addresses the feature request exactly as specified in the issue description. The changes are confined to the Python conversion scripts and do not impact the C/C++ core.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
- - AI usage disclosure: YES — AI was used to assist with identifying the issue, understanding the codebase, and generating the fix. All changes have been reviewed and understood by the submitter.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
