### PR TITLE
ggml : fix wrong transpose function for int16 data

### DIFF
--- a/ggml/src/ggml-cpu/spacemit/rvv_kernels.cpp
+++ b/ggml/src/ggml-cpu/spacemit/rvv_kernels.cpp
@@ -639,7 +639,7 @@ static void permute_transpose_impl(const ggml_tensor * src0,
         }
     } else if (n_src_stride == sizeof(int16_t)) {
         for (int64_t bi = ith; bi < batch; bi += nth) {
-            rvv_transposed_s32_mn_to_nm((int8_t *) ((char *) dst->data + bi * batch_stride), n_dst_stride,
+            rvv_transposed_s16_mn_to_nm((int8_t *) ((char *) dst->data + bi * batch_stride), n_dst_stride,
                                         (int8_t *) ((char *) src0->data + bi * batch_stride), m_src_stride, m, n);
         }
     } else {


### PR DESCRIPTION
## Overview

The `sizeof(int16_t)` branch in `permute_transpose_impl` calls `rvv_transposed_s32_mn_to_nm` instead of `rvv_transposed_s16_mn_to_nm`. 


## Additional information

The s32 function uses 32-bit segment load/stores (`vssseg8e32.v`) on 16-bit data, reading 2x bytes per element and producing completely wrong transposition results -- 14 out of 16 positions are corrupted for a 4x4 int16 matrix.

The correct function `rvv_transposed_s16_mn_to_nm` already exists (line 390) and is used in line 1488.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I used AI to help identify this bug and manually confirmed and validated.
