### PR TITLE
ggml : fix integer overflow in get_alloc_size callback

### DIFF
--- a/ggml/src/ggml-cpu/spacemit/ime.cpp
+++ b/ggml/src/ggml-cpu/spacemit/ime.cpp
@@ -1502,17 +1502,9 @@ static size_t ggml_backend_cpu_riscv64_spacemit_nbytes(ggml_backend_buffer_type_
 
     GGML_UNUSED(buft);
 
-    const auto plain_nbytes = [&]() {
-        size_t total = ggml_type_size(tensor->type);
-        for (int i = 0; i < GGML_MAX_DIMS; ++i) {
-            total += (tensor->ne[i] - 1) * tensor->nb[i];
-        }
-        return total;
-    };
-
     const size_t blck_size = ggml_blck_size(tensor->type);
     if (blck_size == 1) {
-        return plain_nbytes();
+        return ggml_nbytes(tensor);
     }
 
     const size_t row_nbytes = tensor->ne[0] * tensor->nb[0] / blck_size;


### PR DESCRIPTION
## Overview

The plain_nbytes lambda in ggml_backend_cpu_riscv64_spacemit_nbytes() reimplements the same (ne[i]-1)*nb[i] formula as ggml_nbytes(). This is the same integer overflow pattern addressed by GHSA-96jg-mvhq-q7q7 (CVE-2026-33298) in the GGUF loader (#19072), but this copy in the SpaceMIT backend was not covered by that fix.

Since the function is registered as the get_alloc_size callback, it independently controls buffer allocation for SpaceMIT devices. Replace the redundant lambda with a direct call to ggml_nbytes() so there is a single implementation to maintain.

## Additional information

In the current GGUF loading path this redundant code is not independently reachable. However, keeping a second copy of the formula is fragile — any future caller that constructs tensors without going through gguf_init_from_file_impl would hit the unprotected path. Delegating to ggml_nbytes() eliminates that risk.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I used AI to help identify this bug and manually confirmed and validated.
