### PR TITLE
hexagon: allow dflash lm-head offload experiment

### DIFF
--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -75,6 +75,9 @@ int main(int argc, char ** argv) {
         }
 
         auto cparams = common_context_params_to_llama(params_dft);
+        cparams.n_rs_seq  = 0;
+        cparams.ctx_other = ctx_tgt;
+
         ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams));
 
         params.speculative.draft.ctx_tgt = ctx_tgt;
@@ -129,9 +132,24 @@ int main(int argc, char ** argv) {
     // target model sampling context
     common_sampler_ptr smpl(common_sampler_init(model_tgt, params.sampling));
 
+    // init the speculator before prompt eval so implementations can configure the target context
+    const auto & params_spec = params.speculative;
+
+    struct common_speculative * spec = common_speculative_init(params.speculative, 1);
+
     // eval the prompt
-    llama_decode(ctx_tgt,       llama_batch_get_one(inp.data(), inp.size() - 1));
-    llama_decode(ctx_dft.get(), llama_batch_get_one(inp.data(), inp.size() - 1));
+    llama_batch batch_prompt = llama_batch_init(llama_n_batch(ctx_tgt), 0, 1);
+    for (size_t i = 0; i + 1 < inp.size(); ++i) {
+        common_batch_add(batch_prompt, inp[i], i, { seq_id }, false);
+    }
+    llama_decode(ctx_tgt, batch_prompt);
+    if (!common_speculative_process(spec, batch_prompt)) {
+        LOG_ERR("%s: failed to process speculative prompt batch\n", __func__);
+        llama_batch_free(batch_prompt);
+        common_speculative_free(spec);
+        return 1;
+    }
+    llama_batch_free(batch_prompt);
 
     // note: keep the last token separate!
     llama_token id_last = inp.back();
@@ -141,11 +159,6 @@ int main(int argc, char ** argv) {
     prompt_tgt.reserve(llama_n_ctx(ctx_tgt));
 
     int n_past = inp.size() - 1;
-
-    // init the speculator
-    const auto & params_spec = params.speculative;
-
-    struct common_speculative * spec = common_speculative_init(params.speculative, 1);
 
     common_speculative_begin(spec, seq_id, prompt_tgt);
 
@@ -227,10 +240,9 @@ int main(int argc, char ** argv) {
             llama_decode(ctx_tgt, batch_tgt);
         }
 
-        // evaluate the same batch with the draft model
-        {
-            // TODO: extend to support MTP, Eagle, etc. See server code for reference
-            llama_decode(ctx_dft.get(), batch_tgt);
+        if (!common_speculative_process(spec, batch_tgt)) {
+            LOG_ERR("%s: failed to process speculative batch\n", __func__);
+            break;
         }
 
         // only save the sampler sampler state if we use checkpoints

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -61,6 +61,7 @@ static int    opt_etm     = 0;
 static int    opt_verbose = 0;
 static int    opt_profile = 0; // profiling mode (0-disabled, 1-basic, 2-pmu)
 static int    opt_hostbuf = 1; // hostbuf ON by default
+static int    opt_lm_head = 0; // allow large output projection matmuls
 
 static int    opt_mm_select = 3; // 3 = HMX -> Tiled -> Flat -> CPU, 2 = Tiled -> Flat -> CPU, 1 = Flat -> CPU
 static int    opt_fa_select = 2; // 2 = HMX -> HVX -> CPU, 1 = HVX -> CPU, 0 = CPU (unsupported)
@@ -2794,7 +2795,7 @@ static bool ggml_hexagon_supported_mul_mat(const struct ggml_hexagon_session * s
             }
 
             // hardcoded limit to refuse the lm-head for now
-            if (src0->ne[1] > 32768) {
+            if (!opt_lm_head && src0->ne[1] > 32768) {
                 return false;
             }
 
@@ -4278,6 +4279,7 @@ static void ggml_hexagon_init(ggml_backend_reg * reg) {
     const char * str_vmem     = getenv("GGML_HEXAGON_VMEM");
     const char * str_mbuf     = getenv("GGML_HEXAGON_MBUF");
     const char * str_optrace  = getenv("GGML_HEXAGON_OPTRACE");
+    const char * str_lm_head  = getenv("GGML_HEXAGON_LM_HEAD");
 
     // Init Arch first since it affects other defaults
     if (!str_arch) {
@@ -4307,6 +4309,7 @@ static void ggml_hexagon_init(ggml_backend_reg * reg) {
     opt_opbatch   = str_opbatch  ? strtoul(str_opbatch, NULL, 0)          : opt_opbatch;
     opt_opqueue   = str_opqueue  ? strtoul(str_opqueue, NULL, 0)          : opt_opqueue;
     opt_optrace   = str_optrace  ? strtoul(str_optrace, NULL, 0)          : (opt_opbatch * 128);
+    opt_lm_head   = str_lm_head  ? atoi(str_lm_head)                      : opt_lm_head;
     opt_oppoll    = str_oppoll   ? strtoul(str_oppoll,  NULL, 0)          : opt_oppoll;
     opt_opfusion  = str_opfusion ? atoi(str_opfusion)                     : opt_opfusion;
     opt_profile   = str_profile  ? atoi(str_profile)                      : 0;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -958,11 +958,11 @@ void llm_graph_input_mem_hybrid::set_input(const llama_ubatch * ubatch) {
 
     mctx->get_attn()->set_input_kq_mask(inp_attn->self_kq_mask, ubatch, cparams.causal_attn);
 
-    if (inp_attn->self_k_rot) {
+    if (inp_attn->self_k_rot && inp_attn->self_k_rot->buffer) {
         mctx->get_attn()->set_input_k_rot(inp_attn->self_k_rot);
     }
 
-    if (inp_attn->self_v_rot) {
+    if (inp_attn->self_v_rot && inp_attn->self_v_rot->buffer) {
         mctx->get_attn()->set_input_v_rot(inp_attn->self_v_rot);
     }
 
@@ -1068,19 +1068,19 @@ void llm_graph_input_mem_hybrid_iswa::set_input(const llama_ubatch * ubatch) {
         attn_ctx->get_swa()->set_input_kq_mask(inp_attn->self_kq_mask_swa, ubatch, cparams.causal_attn);
     }
 
-    if (inp_attn->self_k_rot) {
+    if (inp_attn->self_k_rot && inp_attn->self_k_rot->buffer) {
         attn_ctx->get_base()->set_input_k_rot(inp_attn->self_k_rot);
     }
 
-    if (inp_attn->self_v_rot) {
+    if (inp_attn->self_v_rot && inp_attn->self_v_rot->buffer) {
         attn_ctx->get_base()->set_input_v_rot(inp_attn->self_v_rot);
     }
 
-    if (inp_attn->self_k_rot_swa) {
+    if (inp_attn->self_k_rot_swa && inp_attn->self_k_rot_swa->buffer) {
         attn_ctx->get_swa()->set_input_k_rot(inp_attn->self_k_rot_swa);
     }
 
-    if (inp_attn->self_v_rot_swa) {
+    if (inp_attn->self_v_rot_swa && inp_attn->self_v_rot_swa->buffer) {
         attn_ctx->get_swa()->set_input_v_rot(inp_attn->self_v_rot_swa);
     }
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -3,6 +3,8 @@
 #include "llama-kv-cache.h"
 #include "llama-kv-cache-iswa.h"
 
+#include <cstring>
+
 void llama_model_dflash::load_arch_hparams(llama_model_loader & ml) {
 
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
@@ -266,6 +268,9 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
         const auto * model_other = llama_get_model(cparams.ctx_other);
         GGML_ASSERT(model_other->output != nullptr && "DFlash decoder requires the target model's output projection");
         output = model_other->output;
+        if (model_other->tok_embd != nullptr && std::strcmp(output->name, model_other->tok_embd->name) == 0) {
+            output = model_other->tok_embd;
+        }
     }
 
     cur = build_lora_mm(output, cur);


### PR DESCRIPTION
## Overview

This PR fixes several Hexagon issues that prevented DFlash from working correctly and improves speculative decoding support on Hexagon.

- guard optional rotary inputs that may exist without a backend buffer in hybrid/iSWA graphs
- add opt-in HTP lm-head placement for large quantized models used by DFlash verification
- make `llama-speculative-simple` use the common speculative path, matching server behavior for DFlash/EAGLE/MTP-style drafts
- handle tied embedding/lm-head fallback when DFlash shares target tensors through `ctx_other`

## Additional information

Tested on an SM8750 Android device with Qwen3.5-4B Q8_0 / Q4_0 target GGUFs and a Qwen3.5-4B DFlash F16 draft GGUF.

`GGML_HEXAGON_LM_HEAD=1` is kept opt-in to preserve existing behavior until large lm-head kernels are validated across more Hexagon deployments. When embeddings are tied, the output tensor may point to an HTP-only repacked buffer while `tok_embd` still refers to the original CPU-accessible tensor. Use `tok_embd` for the tied fallback to avoid building CPU draft graphs with HTP-only buffers.

<details>
<summary>Build and run commands</summary>

Build:

```bash
cmake -S . -B build-android-hexagon \
  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
  -DANDROID_ABI=arm64-v8a \
  -DANDROID_PLATFORM=android-34 \
  -DCMAKE_BUILD_TYPE=Release \
  -DGGML_CPU_ARM_ARCH=armv8.7-a+fp16+dotprod+i8mm \
  -DGGML_HEXAGON=ON \
  -DHEXAGON_SDK_ROOT=$HEXAGON_SDK_ROOT \
  -DHEXAGON_TOOLS_ROOT=$HEXAGON_TOOLS_ROOT \
  -DPREBUILT_LIB_DIR=android_aarch64 \
  -DLLAMA_BUILD_SERVER=ON \
  -DLLAMA_BUILD_EXAMPLES=ON

cmake --build build-android-hexagon \
  --target llama-cli llama-bench llama-speculative-simple htp-v79 -j 16
```

Target-only run:

`HEXAGON_LIB_DIR` is the directory containing the Hexagon shared libraries.

```bash
LD_LIBRARY_PATH=$HEXAGON_LIB_DIR ADSP_LIBRARY_PATH=$HEXAGON_LIB_DIR \
./bin/llama-cli \
  -m models/Qwen3.5-4B-Q8_0.gguf \
  -dev HTP0 -ngl 99 \
  -c 4096 -b 2048 -ub 1024 \
  -t 6 --threads-batch 6 \
  -C 0xfc --cpu-strict 1 --poll 100 \
  --temp 0 -cnv -st --jinja \
  --no-display-prompt --show-timings \
  -p "$PROMPT" -n 128
```

DFlash run:

```bash
GGML_HEXAGON_LM_HEAD=1 \
LD_LIBRARY_PATH=$HEXAGON_LIB_DIR ADSP_LIBRARY_PATH=$HEXAGON_LIB_DIR \
./bin/llama-speculative-simple \
  -m models/Qwen3.5-4B-Q8_0.gguf \
  -md models/Qwen3.5-4B-DFlash-F16.gguf \
  --spec-type draft-dflash --spec-draft-n-max N \
  -dev HTP0 -ngl 99 -devd HTP0 -ngld 99 \
  -c 4096 -b 2048 -ub 1024 \
  -t 6 -tb 6 -td 6 -tbd 6 \
  -C 0xfc --cpu-strict 1 \
  --temp 0 \
  -p "$PROMPT" -n 128
```

Decode results use 128 generated tokens and temperature 0. Target-only rows use `llama-cli`. DFlash rows use `llama-speculative-simple` to report drafted and accepted tokens. `n_max` was swept from 1 upward for each prompt and backend.

</details>

The same runtime settings were used across runs except for `n_max` and target/draft backend placement. Across the tested prompts, DFlash benefits from running the draft model on HTP when acceptance is reasonable. Peak speedups reach 2.51x over target-only decoding. For HTP targets, enabling the lm-head on HTP improved Q8_0 DFlash decode from 15.0 to 17.1 tok/s in the tested `n_max=9` configuration.

Summary:

| Prompt | Target | Target/Draft | Best n_max | Target-only tok/s | DFlash tok/s | Accept rate | Mean accept len | Speedup |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| quicksort | Q4_0 | HTP0/HTP0 | 11 | 10.6 | 16.535 | 67.045% | 8.375 | 1.56x |
| quicksort | Q8_0 | HTP0/HTP0 | 9 | 8.4 | 21.095 | 78.704% | 8.083 | 2.51x |
| Pythagorean | Q4_0 | CPU/HTP0 | 3 | 16.7 | 21.855 | 72.358% | 3.171 | 1.31x |
| Pythagorean | Q8_0 | HTP0/HTP0 | 3 | 8.4 | 15.753 | 76.923% | 3.308 | 1.88x |
| DC trip | Q4_0 | HTP0/CPU | 1 | 10.4 | 9.798 | 66.667% | 1.667 | 0.94x |
| DC trip | Q8_0 | HTP0/HTP0 | 2 | 8.4 | 9.750 | 43.478% | 1.870 | 1.16x |

Q8_0 `n_max=9` lm-head placement with HTP0 target and HTP0 draft:

| lm-head placement | Env | Decode tok/s |
| --- | --- | ---: |
| CPU fallback | unset | 15.0 |
| HTP0 | `GGML_HEXAGON_LM_HEAD=1` | 17.1 |

<details>
<summary>Full n_max sweep and per-prompt results</summary>

### Prompt: `Write a quicksort algorithm in Python. Write code only.`

Best results:

| Target | Run | Target backend | Draft backend | Best n_max | Decode tok/s | Draft / accepted | Accept rate | Mean accept len | Speedup |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Q4_0 | target-only | CPU | n/a | n/a | 16.8 | n/a | n/a | n/a | 1.00x |
| Q4_0 | target-only | HTP0 | n/a | n/a | 10.6 | n/a | n/a | n/a | 1.00x |
| Q4_0 | DFlash | CPU | CPU | 3 | 22.113 | 108 / 96 | 88.889% | 3.667 | 1.32x |
| Q4_0 | DFlash | CPU | HTP0 | 3 | 26.259 | 108 / 96 | 88.889% | 3.667 | 1.56x |
| Q4_0 | DFlash | HTP0 | CPU | 7 | 16.333 | 147 / 115 | 78.231% | 6.476 | 1.54x |
| Q4_0 | DFlash | HTP0 | HTP0 | 11 | 16.535 | 176 / 118 | 67.045% | 8.375 | 1.56x |
| Q8_0 | target-only | CPU | n/a | n/a | 11.4 | n/a | n/a | n/a | 1.00x |
| Q8_0 | target-only | HTP0 | n/a | n/a | 8.4 | n/a | n/a | n/a | 1.00x |
| Q8_0 | DFlash | CPU | CPU | 3 | 19.860 | 78 / 71 | 91.026% | 3.731 | 1.74x |
| Q8_0 | DFlash | CPU | HTP0 | 3 | 23.713 | 78 / 71 | 91.026% | 3.731 | 2.08x |
| Q8_0 | DFlash | HTP0 | CPU | 9 | 17.133 | 108 / 85 | 78.704% | 8.083 | 2.04x |
| Q8_0 | DFlash | HTP0 | HTP0 | 9 | 21.095 | 108 / 85 | 78.704% | 8.083 | 2.51x |

n_max sweep decode tok/s:

| Target | Target/Draft | n=1 | n=2 | n=3 | n=4 | n=5 | n=6 | n=7 | n=8 | n=9 | n=10 | n=11 | n=12 | n=13 | n=14 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Q4_0 | CPU/CPU | 12.686 | 12.068 | 22.113 | 18.153 | 18.092 | 16.159 | | | | | | | | |
| Q4_0 | CPU/HTP0 | 12.449 | 12.659 | 26.259 | 18.408 | 17.528 | 16.262 | | | | | | | | |
| Q4_0 | HTP0/CPU | 11.624 | 12.037 | 15.148 | 14.128 | 14.906 | 13.519 | 16.333 | 14.725 | 15.462 | 13.944 | 15.722 | 13.813 | 13.082 | 11.300 |
| Q4_0 | HTP0/HTP0 | 9.827 | 10.832 | 14.912 | 13.049 | 12.719 | 13.103 | 15.585 | 11.547 | 14.568 | 14.339 | 16.535 | 15.192 | 14.402 | 13.485 |
| Q8_0 | CPU/CPU | 9.444 | 10.611 | 19.860 | 17.146 | 15.374 | 15.231 | | | | | | | | |
| Q8_0 | CPU/HTP0 | 10.868 | 11.981 | 23.713 | 19.156 | 16.794 | 16.650 | | | | | | | | |
| Q8_0 | HTP0/CPU | 10.191 | 12.564 | 14.437 | 13.462 | 13.790 | 14.631 | 14.854 | 15.197 | 17.133 | 15.600 | | | | |
| Q8_0 | HTP0/HTP0 | 11.557 | 15.133 | 17.585 | 14.949 | 15.835 | 17.735 | 17.485 | 18.137 | 21.095 | 20.564 | 19.351 | 18.572 | | |

### Prompt: `Explain the Pythagorean theorem`

Best results:

| Target | Run | Target backend | Draft backend | Best n_max | Decode tok/s | Draft / accepted | Accept rate | Mean accept len | Speedup |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Q4_0 | target-only | CPU | n/a | n/a | 16.7 | n/a | n/a | n/a | 1.00x |
| Q4_0 | target-only | HTP0 | n/a | n/a | 10.5 | n/a | n/a | n/a | 1.00x |
| Q4_0 | DFlash | CPU | CPU | 3 | 16.312 | 129 / 86 | 66.667% | 3.000 | 0.98x |
| Q4_0 | DFlash | CPU | HTP0 | 3 | 21.855 | 123 / 89 | 72.358% | 3.171 | 1.31x |
| Q4_0 | DFlash | HTP0 | CPU | 3 | 11.336 | 132 / 87 | 65.909% | 2.977 | 1.08x |
| Q4_0 | DFlash | HTP0 | HTP0 | 3 | 13.431 | 120 / 90 | 75.000% | 3.250 | 1.28x |
| Q8_0 | target-only | CPU | n/a | n/a | 11.3 | n/a | n/a | n/a | 1.00x |
| Q8_0 | target-only | HTP0 | n/a | n/a | 8.4 | n/a | n/a | n/a | 1.00x |
| Q8_0 | DFlash | CPU | CPU | 3 | 17.193 | 123 / 91 | 73.984% | 3.220 | 1.52x |
| Q8_0 | DFlash | CPU | HTP0 | 3 | 20.913 | 123 / 91 | 73.984% | 3.220 | 1.85x |
| Q8_0 | DFlash | HTP0 | CPU | 3 | 12.805 | 117 / 90 | 76.923% | 3.308 | 1.52x |
| Q8_0 | DFlash | HTP0 | HTP0 | 3 | 15.753 | 117 / 90 | 76.923% | 3.308 | 1.88x |

n_max sweep decode tok/s:

| Target | Target/Draft | n=1 | n=2 | n=3 | n=4 | n=5 | n=6 | n=7 | n=8 | n=9 | n=10 | n=11 | n=12 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Q4_0 | CPU/CPU | 11.304 | 10.628 | 16.312 | 12.122 | 11.433 | 8.807 | | | | | | |
| Q4_0 | CPU/HTP0 | 11.667 | 11.083 | 21.855 | 14.348 | 13.026 | 11.942 | | | | | | |
| Q4_0 | HTP0/CPU | 10.816 | 9.876 | 11.336 | 9.737 | 9.583 | 8.115 | | | | | | |
| Q4_0 | HTP0/HTP0 | 9.290 | 9.392 | 13.431 | 10.251 | 10.056 | 9.500 | | | | | | |
| Q8_0 | CPU/CPU | 9.922 | 10.082 | 17.193 | 14.179 | 11.956 | 9.428 | | | | | | |
| Q8_0 | CPU/HTP0 | 10.037 | 9.838 | 20.913 | 14.106 | 11.958 | 10.766 | | | | | | |
| Q8_0 | HTP0/CPU | 9.790 | 11.425 | 12.805 | 11.031 | 10.683 | 10.238 | | | | | | |
| Q8_0 | HTP0/HTP0 | 11.016 | 13.458 | 15.753 | 12.342 | 12.112 | 12.204 | 11.630 | 10.895 | 11.428 | 11.153 | 10.972 | 10.384 |

### Prompt: `Plan a 1 day trip to DC`

Best results:

| Target | Run | Target backend | Draft backend | Best n_max | Decode tok/s | Draft / accepted | Accept rate | Mean accept len | Speedup |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Q4_0 | target-only | CPU | n/a | n/a | 16.8 | n/a | n/a | n/a | 1.00x |
| Q4_0 | target-only | HTP0 | n/a | n/a | 10.4 | n/a | n/a | n/a | 1.00x |
| Q4_0 | DFlash | CPU | CPU | 3 | 11.232 | 192 / 65 | 33.854% | 2.016 | 0.67x |
| Q4_0 | DFlash | CPU | HTP0 | 3 | 14.999 | 183 / 69 | 37.705% | 2.131 | 0.89x |
| Q4_0 | DFlash | HTP0 | CPU | 1 | 9.798 | 78 / 52 | 66.667% | 1.667 | 0.94x |
| Q4_0 | DFlash | HTP0 | HTP0 | 3 | 9.270 | 171 / 73 | 42.690% | 2.281 | 0.89x |
| Q8_0 | target-only | CPU | n/a | n/a | 11.4 | n/a | n/a | n/a | 1.00x |
| Q8_0 | target-only | HTP0 | n/a | n/a | 8.4 | n/a | n/a | n/a | 1.00x |
| Q8_0 | DFlash | CPU | CPU | 3 | 10.592 | 195 / 64 | 32.821% | 1.985 | 0.93x |
| Q8_0 | DFlash | CPU | HTP0 | 3 | 12.835 | 195 / 64 | 32.821% | 1.985 | 1.13x |
| Q8_0 | DFlash | HTP0 | CPU | 2 | 8.231 | 138 / 60 | 43.478% | 1.870 | 0.98x |
| Q8_0 | DFlash | HTP0 | HTP0 | 2 | 9.750 | 138 / 60 | 43.478% | 1.870 | 1.16x |

n_max sweep decode tok/s:

| Target | Target/Draft | n=1 | n=2 | n=3 | n=4 | n=5 | n=6 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Q4_0 | CPU/CPU | 9.487 | 8.102 | 11.232 | 7.330 | 6.658 | 5.370 |
| Q4_0 | CPU/HTP0 | 9.528 | 8.177 | 14.999 | 9.344 | 7.881 | 6.680 |
| Q4_0 | HTP0/CPU | 9.798 | 7.661 | 8.253 | 6.211 | 5.972 | 5.105 |
| Q4_0 | HTP0/HTP0 | 8.701 | 7.398 | 9.270 | 6.783 | 6.230 | 5.432 |
| Q8_0 | CPU/CPU | 8.428 | 7.222 | 10.592 | 7.899 | 6.538 | 5.216 |
| Q8_0 | CPU/HTP0 | 8.176 | 7.206 | 12.835 | 8.309 | 6.640 | 5.636 |
| Q8_0 | HTP0/CPU | 7.466 | 8.231 | 7.220 | 6.296 | 5.909 | |
| Q8_0 | HTP0/HTP0 | 8.658 | 9.750 | 8.544 | 7.040 | 6.707 | |

</details>

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI assisted with summarizing benchmark results.
