### PR TITLE
grammar : recognize '|' at start of continuation line

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -438,9 +438,13 @@ const char * llama_grammar_parser::parse_alternates(
         bool                is_nested) {
     llama_grammar_rule rule;
     const char * pos = parse_sequence(src, rule_name, rule, is_nested);
-    while (*pos == '|') {
+    while (true) {
+        const char * next = parse_space(pos, true);
+        if (*next != '|') {
+            break;
+        }
         rule.push_back({LLAMA_GRETYPE_ALT, 0});
-        pos = parse_space(pos + 1, true);
+        pos = parse_space(next + 1, true);
         pos = parse_sequence(pos, rule_name, rule, is_nested);
     }
     rule.push_back({LLAMA_GRETYPE_END, 0});

--- a/tests/test-grammar-parser.cpp
+++ b/tests/test-grammar-parser.cpp
@@ -182,6 +182,19 @@ int main()
     });
 
     verify_parsing(R"""(
+        root  ::= "a"
+                | "b"
+    )""", {
+        {"root", 0},
+    }, {
+        // root (index 0)
+        {LLAMA_GRETYPE_CHAR, 'a'},
+        {LLAMA_GRETYPE_ALT, 0},
+        {LLAMA_GRETYPE_CHAR, 'b'},
+        {LLAMA_GRETYPE_END, 0},
+    });
+
+    verify_parsing(R"""(
         root  ::= a+
         a     ::= "a"
     )""", {


### PR DESCRIPTION
## Overview

A top-level rule whose alternatives are split across lines with a leading `|` failed to parse entirely:

```gbnf
root ::= "foo"
       | "bar"
```

```
parse: error parsing grammar: expecting name at | "bar"
```

The parser didn't skip the newline before checking for `|`, so continuation lines were never recognized. 

Fixes #25156.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

I used AI to assist with the relevant regression testing.