### PR TITLE
vulkan: disable async transfer queue on amdvlk (mitigate MoE partial-offload crash)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6555,6 +6555,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
         const bool prefers_transfer_queue =
             device->vendor_id == VK_VENDOR_ID_AMD &&
             device->architecture != AMD_GCN &&
+            device->driver_id != vk::DriverId::eAmdProprietary &&
+            device->driver_id != vk::DriverId::eAmdOpenSource &&
             !device->uma &&
             !allow_graphics_queue;
 


### PR DESCRIPTION
## Overview

Disables the async transfer queue on the **amdvlk** driver family to mitigate an intermittent long-context crash with MoE + partial offload (#25195). Under partial offload, streamed MoE expert-weight re-uploads race across submits on the async transfer queue (`prefers_transfer_queue`, added in #19976 for AMD partial-offload perf) — amdvlk corrupts on the race, RADV tolerates it. Disabling the queue drives the validated sync-validation racing-write count to 0.

```diff
 const bool prefers_transfer_queue =
     device->vendor_id == VK_VENDOR_ID_AMD &&
     device->architecture != AMD_GCN &&
+    device->driver_id != vk::DriverId::eAmdProprietary &&
+    device->driver_id != vk::DriverId::eAmdOpenSource &&
     !device->uma &&
     !allow_graphics_queue;
```

This is a **mitigation, not the root fix** — the race is latent (tolerated on RADV); a proper submit-level synchronization fix is the Vulkan backend maintainer's domain. Perf on amdvlk is within noise (near-free); RADV keeps the async queue and is unaffected. Full diagnosis in #25195.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — AI tooling assisted the investigation and drafting this description. The one-line driver-ID guard I authored/reviewed and validated on real hardware; I take responsibility for the submission.
