### PR TITLE
llama : skip K/V rotation input when its buffer is unallocated

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -494,11 +494,11 @@ void llm_graph_input_attn_kv::set_input(const llama_ubatch * ubatch) {
         mctx->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
     }
 
-    if (self_k_rot) {
+    if (self_k_rot && self_k_rot->buffer) {
         mctx->set_input_k_rot(self_k_rot);
     }
 
-    if (self_v_rot) {
+    if (self_v_rot && self_v_rot->buffer) {
         mctx->set_input_v_rot(self_v_rot);
     }
 }
@@ -592,19 +592,19 @@ void llm_graph_input_attn_kv_iswa::set_input(const llama_ubatch * ubatch) {
         mctx->get_swa()->set_input_kq_mask(self_kq_mask_swa, ubatch, cparams.causal_attn);
     }
 
-    if (self_k_rot) {
+    if (self_k_rot && self_k_rot->buffer) {
         mctx->get_base()->set_input_k_rot(self_k_rot);
     }
 
-    if (self_v_rot) {
+    if (self_v_rot && self_v_rot->buffer) {
         mctx->get_base()->set_input_v_rot(self_v_rot);
     }
 
-    if (self_k_rot_swa) {
+    if (self_k_rot_swa && self_k_rot_swa->buffer) {
         mctx->get_swa()->set_input_k_rot(self_k_rot_swa);
     }
 
-    if (self_v_rot_swa) {
+    if (self_v_rot_swa && self_v_rot_swa->buffer) {
         mctx->get_swa()->set_input_v_rot(self_v_rot_swa);
     }
 }


### PR DESCRIPTION
## Overview

`llm_graph_input_attn_kv::set_input` and `llm_graph_input_attn_kv_iswa::set_input` currently call `set_input_k_rot` / `set_input_v_rot` whenever the rotation tensor pointer is non-null (#25191). That tensor's `buffer` can be unallocated (`NULL`) when a graph only *stores* K/V without attending -- for example DFlash speculative decoding's KV-injection pass. `set_input_k_rot` immediately calls `ggml_backend_buffer_is_host(dst->buffer)`, which aborts with `GGML_ASSERT(buffer)`:

```
ggml-backend.cpp:194: GGML_ASSERT(buffer) failed
  ggml_backend_buffer_is_host ()
  llama_kv_cache::set_input_k_rot(ggml_tensor*) const
  llm_graph_input_attn_kv_iswa::set_input(llama_ubatch const*)
  common_speculative_impl_draft_dflash::process(llama_batch const&)
```

The adjacent `kq_mask` inputs in these same two functions already guard exactly this case -- their comment notes "the mask is left unallocated when the graph only stores K/V without attending (e.g. DFlash's KV-injection pass)" -- with an `&& ->buffer` check. The `k_rot`/`v_rot` inputs, added later, were missing that guard. This PR adds the same guard to the four `k_rot`/`v_rot` inputs. When the buffer is unallocated there is no data to upload, so skipping the upload is correct.

## Additional information

Reproduced on RDNA4 (gfx1201, Vulkan) with a DFlash draft whose head dim is a multiple of 64 (so `attn_rot_k`/`attn_rot_v` are enabled) and `--cache-type-k q8_0 --cache-type-k-draft q8_0`:

- before: `llama-server ... --spec-type draft-dflash` aborts (rc=134) on the first draft decode with the assert above.
- after: the same command runs to completion, speculative decoding stays active, no assert.
- a regular causal model (no DFlash) is unaffected -- the guard is a no-op when the buffer is allocated.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: an AI coding assistant helped investigate and reproduce this on real hardware; I authored and reviewed the change and this description, and I can explain and take responsibility for every line.

Fixes #25191
