### PR TITLE
common : add missing <fstream> include in common.h

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <fstream>
 
 #if defined(_WIN32) && !defined(_WIN32_WINNT)
 #define _WIN32_WINNT 0x0A00


### PR DESCRIPTION
## Overview
`common/common.h` declares `fs_open_ifstream()` which returns `std::ifstream`, but the header does not `#include <fstream>`. 
The type was previously available only transitively through other includes. 

On stricter toolchains (e.g. GCC trunk on aarch64/Graviton4) that transitive include is not present, so compilation fails with:error: 'ifstream' in namespace 'std' does not name a type

This adds the  `#include <fstream>`, following the include-what-you-use principle.

## Additional information
Fixes #25046

## Requirements
- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — used an AI assistant to help diagnose the root cause (transitive-include breakage) and review the fix. The one-line change and all decisions are my own, and I take responsibility for the submitted change.