### PR TITLE
ui: Improve performance when streaming

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessages.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessages.svelte
@@ -169,6 +169,20 @@
 		});
 	});
 
+	let siblingInfoByMessageId = $derived.by(() => {
+		const nodeMap = new Map(
+			allConversationMessages.map((msg) => [msg.id, msg] as const)
+		);
+		const siblingMap = new Map<string, ChatMessageSiblingInfo>();
+		for (const msg of allConversationMessages) {
+			const info = getMessageSiblings(nodeMap, msg.id);
+			if (info) {
+				siblingMap.set(msg.id, info);
+			}
+		}
+		return siblingMap;
+	});
+
 	let displayMessages = $derived.by(() => {
 		if (!messages.length) {
 			return [];
@@ -223,18 +237,18 @@
 				}
 			}
 
-			const siblingInfo = getMessageSiblings(allConversationMessages, msg.id);
+			const siblingInfo = siblingInfoByMessageId.get(msg.id) ?? {
+				message: msg,
+				siblingIds: [msg.id],
+				currentIndex: 0,
+				totalSiblings: 1
+			};
 
 			result.push({
 				message: msg,
 				toolMessages,
 				isLastAssistantMessage: false,
-				siblingInfo: siblingInfo || {
-					message: msg,
-					siblingIds: [msg.id],
-					currentIndex: 0,
-					totalSiblings: 1
-				}
+				siblingInfo
 			});
 		}
 

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessages.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessages.svelte
@@ -20,9 +20,9 @@
 		agenticInjectSteeringMessage
 	} from '$lib/stores/agentic.svelte';
 	import {
+		buildSiblingInfoMap,
 		copyToClipboard,
 		formatMessageForClipboard,
-		getMessageSiblings,
 		hasAgenticContent
 	} from '$lib/utils';
 
@@ -169,19 +169,7 @@
 		});
 	});
 
-	let siblingInfoByMessageId = $derived.by(() => {
-		const nodeMap = new Map(
-			allConversationMessages.map((msg) => [msg.id, msg] as const)
-		);
-		const siblingMap = new Map<string, ChatMessageSiblingInfo>();
-		for (const msg of allConversationMessages) {
-			const info = getMessageSiblings(nodeMap, msg.id);
-			if (info) {
-				siblingMap.set(msg.id, info);
-			}
-		}
-		return siblingMap;
-	});
+	let siblingInfoByMessageId = $derived(buildSiblingInfoMap(allConversationMessages));
 
 	let displayMessages = $derived.by(() => {
 		if (!messages.length) {

--- a/tools/ui/src/lib/utils/branching.ts
+++ b/tools/ui/src/lib/utils/branching.ts
@@ -121,10 +121,7 @@ function findLeafNodeInMap(
  * @param messageId - Starting message ID to find leaf for
  * @returns The leaf node ID, or the original messageId if no children
  */
-export function findLeafNode(
-	messages: readonly DatabaseMessage[],
-	messageId: string
-): string {
+export function findLeafNode(messages: readonly DatabaseMessage[], messageId: string): string {
 	const nodeMap = new Map(messages.map((msg) => [msg.id, msg] as const));
 	return findLeafNodeInMap(nodeMap, messageId);
 }
@@ -224,4 +221,25 @@ export function getMessageSiblings(
 		currentIndex,
 		totalSiblings: siblingIds.length
 	};
+}
+
+/**
+ * Builds sibling information for every message in a conversation.
+ * A single node map is shared across all lookups for O(1) access.
+ *
+ * @param messages - All messages in the conversation
+ * @returns Map of message ID to its sibling information
+ */
+export function buildSiblingInfoMap(
+	messages: readonly DatabaseMessage[]
+): Map<string, ChatMessageSiblingInfo> {
+	const nodeMap = new Map(messages.map((msg) => [msg.id, msg] as const));
+	const siblingMap = new Map<string, ChatMessageSiblingInfo>();
+	for (const msg of messages) {
+		const info = getMessageSiblings(nodeMap, msg.id);
+		if (info) {
+			siblingMap.set(msg.id, info);
+		}
+	}
+	return siblingMap;
 }

--- a/tools/ui/src/lib/utils/branching.ts
+++ b/tools/ui/src/lib/utils/branching.ts
@@ -92,18 +92,14 @@ export function filterByLeafNodeId(
  * Finds the leaf node (message with no children) for a given message branch.
  * Traverses down the tree following the last child until reaching a leaf.
  *
- * @param messages - All messages in the conversation
+ * @param nodeMap - Map of messages keyed by ID
  * @param messageId - Starting message ID to find leaf for
  * @returns The leaf node ID, or the original messageId if no children
  */
-export function findLeafNode(messages: readonly DatabaseMessage[], messageId: string): string {
-	const nodeMap = new Map<string, DatabaseMessage>();
-
-	// Build node map for quick lookups
-	for (const msg of messages) {
-		nodeMap.set(msg.id, msg);
-	}
-
+function findLeafNodeInMap(
+	nodeMap: ReadonlyMap<string, DatabaseMessage>,
+	messageId: string
+): string {
 	let currentNode: DatabaseMessage | undefined = nodeMap.get(messageId);
 	while (currentNode && currentNode.children.length > 0) {
 		// Follow the last child (most recent branch)
@@ -112,6 +108,25 @@ export function findLeafNode(messages: readonly DatabaseMessage[], messageId: st
 	}
 
 	return currentNode?.id ?? messageId;
+}
+
+/**
+ * Convenience wrapper around {@link findLeafNodeInMap} for callers that only have
+ * a flat message array.
+ *
+ * Finds the leaf node (message with no children) for a given message branch.
+ * Traverses down the tree following the last child until reaching a leaf.
+ *
+ * @param messages - All messages in the conversation
+ * @param messageId - Starting message ID to find leaf for
+ * @returns The leaf node ID, or the original messageId if no children
+ */
+export function findLeafNode(
+	messages: readonly DatabaseMessage[],
+	messageId: string
+): string {
+	const nodeMap = new Map(messages.map((msg) => [msg.id, msg] as const));
+	return findLeafNodeInMap(nodeMap, messageId);
 }
 
 /**
@@ -156,21 +171,14 @@ export function findDescendantMessages(
  * Gets sibling information for a message, including all sibling IDs and current position.
  * Siblings are messages that share the same parent.
  *
- * @param messages - All messages in the conversation
+ * @param nodeMap - Map of messages keyed by ID
  * @param messageId - The message to get sibling info for
  * @returns Sibling information including leaf node IDs for navigation
  */
 export function getMessageSiblings(
-	messages: readonly DatabaseMessage[],
+	nodeMap: ReadonlyMap<string, DatabaseMessage>,
 	messageId: string
 ): ChatMessageSiblingInfo | null {
-	const nodeMap = new Map<string, DatabaseMessage>();
-
-	// Build node map for quick lookups
-	for (const msg of messages) {
-		nodeMap.set(msg.id, msg);
-	}
-
 	const message = nodeMap.get(messageId);
 	if (!message) {
 		return null;
@@ -203,7 +211,9 @@ export function getMessageSiblings(
 
 	// Convert sibling message IDs to their corresponding leaf node IDs
 	// This allows navigation between different conversation branches
-	const siblingLeafIds = siblingIds.map((siblingId: string) => findLeafNode(messages, siblingId));
+	const siblingLeafIds = siblingIds.map((siblingId: string) =>
+		findLeafNodeInMap(nodeMap, siblingId)
+	);
 
 	// Find current message's position among siblings
 	const currentIndex = siblingIds.indexOf(messageId);
@@ -214,88 +224,4 @@ export function getMessageSiblings(
 		currentIndex,
 		totalSiblings: siblingIds.length
 	};
-}
-
-/**
- * Creates a display-ready list of messages with sibling information for UI rendering.
- * This is the main function used by chat components to render conversation branches.
- *
- * @param messages - All messages in the conversation
- * @param leafNodeId - Current leaf node being viewed
- * @returns Array of messages with sibling navigation info
- */
-export function getMessageDisplayList(
-	messages: readonly DatabaseMessage[],
-	leafNodeId: string
-): ChatMessageSiblingInfo[] {
-	// Get the current conversation path
-	const currentPath = filterByLeafNodeId(messages, leafNodeId, true);
-	const result: ChatMessageSiblingInfo[] = [];
-
-	// Add sibling info for each message in the current path
-	for (const message of currentPath) {
-		if (message.type === 'root') {
-			continue; // Skip root messages in display
-		}
-
-		const siblingInfo = getMessageSiblings(messages, message.id);
-		if (siblingInfo) {
-			result.push(siblingInfo);
-		}
-	}
-
-	return result;
-}
-
-/**
- * Checks if a message has multiple siblings (indicating branching at that point).
- *
- * @param messages - All messages in the conversation
- * @param messageId - The message to check
- * @returns True if the message has siblings
- */
-export function hasMessageSiblings(
-	messages: readonly DatabaseMessage[],
-	messageId: string
-): boolean {
-	const siblingInfo = getMessageSiblings(messages, messageId);
-	return siblingInfo ? siblingInfo.totalSiblings > 1 : false;
-}
-
-/**
- * Gets the next sibling message ID for navigation.
- *
- * @param messages - All messages in the conversation
- * @param messageId - Current message ID
- * @returns Next sibling's leaf node ID, or null if at the end
- */
-export function getNextSibling(
-	messages: readonly DatabaseMessage[],
-	messageId: string
-): string | null {
-	const siblingInfo = getMessageSiblings(messages, messageId);
-	if (!siblingInfo || siblingInfo.currentIndex >= siblingInfo.totalSiblings - 1) {
-		return null;
-	}
-
-	return siblingInfo.siblingIds[siblingInfo.currentIndex + 1];
-}
-
-/**
- * Gets the previous sibling message ID for navigation.
- *
- * @param messages - All messages in the conversation
- * @param messageId - Current message ID
- * @returns Previous sibling's leaf node ID, or null if at the beginning
- */
-export function getPreviousSibling(
-	messages: readonly DatabaseMessage[],
-	messageId: string
-): string | null {
-	const siblingInfo = getMessageSiblings(messages, messageId);
-	if (!siblingInfo || siblingInfo.currentIndex <= 0) {
-		return null;
-	}
-
-	return siblingInfo.siblingIds[siblingInfo.currentIndex - 1];
 }

--- a/tools/ui/src/lib/utils/index.ts
+++ b/tools/ui/src/lib/utils/index.ts
@@ -25,11 +25,7 @@ export {
 	findMessageById,
 	findLeafNode,
 	findDescendantMessages,
-	getMessageSiblings,
-	getMessageDisplayList,
-	hasMessageSiblings,
-	getNextSibling,
-	getPreviousSibling
+	getMessageSiblings
 } from './branching';
 
 // Code

--- a/tools/ui/src/lib/utils/index.ts
+++ b/tools/ui/src/lib/utils/index.ts
@@ -25,7 +25,8 @@ export {
 	findMessageById,
 	findLeafNode,
 	findDescendantMessages,
-	getMessageSiblings
+	getMessageSiblings,
+	buildSiblingInfoMap
 } from './branching';
 
 // Code


### PR DESCRIPTION
## Overview

Currently:
- For each stream event:
  - For each `filteredMessage`:
    - Build `nodeMap` of all messages
     - For each sibling
       - Build `nodeMap` of all messages again

So if you have a lot of messages (or siblings), plenty of CPU was being burned recalculating all the sibling info in high frequency + heavily nested loops.

Post-fix:
- On certain structural changes (edit, regenerate, delete, etc):
  - Build `nodeMap` of all messages
  - Build the map of siblings for all messages
- For each stream event:
  - For each `filteredMessage`:
    - Read from the map of siblings

I also opted to clean up some dead code rather than update it for these changes.

## Additional information

Before:
<img width="1394" height="737" alt="image" src="https://github.com/user-attachments/assets/77f65940-68d7-4394-aa44-693a442bfc4b" />

Total scripting time: 9235 ms

After:
<img width="1381" height="680" alt="image" src="https://github.com/user-attachments/assets/9797845f-0cf6-4606-9bfe-504dfb08bd0a" />

Total scripting time: 3056 ms (3x reduction)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, pi with Qwen3.6-27B