### PR TITLE
Ensure unique node names and add org_src to track the org tensor for OpenVINO backend 

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -695,7 +695,9 @@ extern "C" {
 
         void * extra; // extra things e.g. for ggml-cuda.cu
 
-        char padding[8];
+        char padding[16];
+        // add a struct ggml_tensor * named org_src, initialized to NULL, for keeping track of original source tensors in case of in-place operations
+        struct ggml_tensor * org_src;
     };
 
     static const size_t GGML_TENSOR_SIZE = sizeof(struct ggml_tensor);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1242,28 +1242,6 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
         GGML_ASSERT(*cur_backend_id != -1);
     }
 
-    // OpenVINO currently uses ggml tensor names as graph indices. Some models (e.g. gpt-oss and
-    // llama4) can contain duplicate ggml tensor names, so we append node ids here to keep names
-    // unique. This is a temporary workaround and will be further optimized away in the future.
-    {
-        bool has_openvino_backend = false;
-        for (int i = 0; i < sched->n_backends; i++) {
-            if (strcmp(ggml_backend_name(sched->backends[i]), "OPENVINO") == 0) {
-                has_openvino_backend = true;
-                break;
-            }
-        }
-
-        if (has_openvino_backend) {
-            for (int i = 0; i < graph->n_nodes; i++) {
-                struct ggml_tensor * node = graph->nodes[i];
-                char                 new_name[128];
-                snprintf(new_name, sizeof(new_name), "%s#%d", node->name, i);
-                ggml_format_name(node, "%s", new_name);
-            }
-        }
-    }
-
     // pass 5: split graph, find tensors that need to be copied
     {
         int i_split = 0;

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1242,6 +1242,28 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
         GGML_ASSERT(*cur_backend_id != -1);
     }
 
+    // OpenVINO currently uses ggml tensor names as graph indices. Some models (e.g. gpt-oss and
+    // llama4) can contain duplicate ggml tensor names, so we append node ids here to keep names
+    // unique. This is a temporary workaround and will be further optimized away in the future.
+    {
+        bool has_openvino_backend = false;
+        for (int i = 0; i < sched->n_backends; i++) {
+            if (strcmp(ggml_backend_name(sched->backends[i]), "OPENVINO") == 0) {
+                has_openvino_backend = true;
+                break;
+            }
+        }
+
+        if (has_openvino_backend) {
+            for (int i = 0; i < graph->n_nodes; i++) {
+                struct ggml_tensor * node = graph->nodes[i];
+                char                 new_name[128];
+                snprintf(new_name, sizeof(new_name), "%s#%d", node->name, i);
+                ggml_format_name(node, "%s", new_name);
+            }
+        }
+    }
+
     // pass 5: split graph, find tensors that need to be copied
     {
         int i_split = 0;
@@ -1360,6 +1382,7 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
                                 ggml_set_input(tensor_copy);
                                 ggml_set_output(tensor_copy); // prevent ggml-alloc from overwriting the tensor
                             }
+                            tensor_copy->org_src = src;
                             tensor_id_copy(src_id, cur_backend_id, c) = tensor_copy;
                             SET_CAUSE(tensor_copy, "4.cpy");
                         }

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1781,6 +1781,7 @@ static struct ggml_tensor * ggml_new_tensor_impl(
         /*.name         =*/ { 0 },
         /*.extra        =*/ NULL,
         /*.padding      =*/ { 0 },
+        /*.org_src       =*/ NULL,
     };
 
     // TODO: this should not be needed as long as we don't rely on aligned SIMD loads

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -512,12 +512,17 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const gg
     size_t max_device_label_length = 4;
     {
         std::vector<ggml_backend_dev_t> devices_meta;
+        bool has_openvino = false;
         {
             const size_t device_count = ggml_backend_dev_count();
             for (size_t i = 0; i < device_count; i++) {
                 ggml_backend_dev_t dev = ggml_backend_dev_get(i);
                 dev_configs.emplace_back(std::vector<ggml_backend_dev_t>{dev}, ggml_backend_dev_description(dev), LLAMA_SPLIT_MODE_LAYER);
                 max_device_label_length = std::max(max_device_label_length, dev_configs.back().label.length());
+
+                if (strncmp(ggml_backend_dev_name(dev), "OPENVINO", 8) == 0) {
+                    has_openvino = true;
+                }
 
                 // cpu-based devices cannot be used in tensor split mode
                 if (ggml_backend_dev_buffer_type(dev) != ggml_backend_cpu_buffer_type()) {
@@ -526,7 +531,9 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const gg
             }
         }
 
-        dev_configs.emplace_back(devices_meta, "Meta", LLAMA_SPLIT_MODE_TENSOR);
+        if (!has_openvino) {
+            dev_configs.emplace_back(devices_meta, "Meta", LLAMA_SPLIT_MODE_TENSOR);
+        }
     }
 
     size_t max_arch_name_length = 0;


### PR DESCRIPTION
**Add org_src in ggml_tensor to keep the org src for OpenVINO fallback**

* Added a new `org_src` pointer to the `ggml_tensor` struct to keep track of original source tensors, especially useful when creating tensor copies during backend graph splitting, the `org_src` pointer is set to the source tensor. Only get this org src info, OpenVINO backend can retrieve and compute the dynamic dim, which is important for OV model creating. 

**Ensure unique tensor names for OpenVINO backend**

* Ensure unique tensor names in graphs targeting OpenVINO by appending node IDs to tensor names, addressing issues with models (such as gpt-oss) that have duplicate tensor names (`ggml/src/ggml-backend.cpp`). This is because the OpenVINO backend used the tensor name as index.

**Testing without META**

* Updated the backend device configuration logic in the test suite to only add the "Meta" device configuration if OpenVINO is not present.

