### PR TITLE
[UT] enhance UT to show all real unsupported backends

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1338,19 +1338,37 @@ struct test_case {
         }
 
         // check if the backends support the ops
-        bool supported = true;
+        bool supported1 = true;
+        bool supported2 = true;
         for (ggml_backend_t backend : {backend1, backend2}) {
             for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
                 if (!ggml_backend_supports_op(backend, t)) {
-                    supported = false;
+                    if (backend == backend1) {
+                        supported1 = false;
+                    } else {
+                        supported2 = false;
+                    }
                     break;
                 }
             }
         }
 
-        if (!supported) {
+        if (!supported1 || !supported2) {
             // Create test result for unsupported operation
-            test_result result(ggml_backend_name(backend1), current_op_name, vars(), "test",
+            std::string unsupported_backend = "";
+            if(!supported1 && supported2) {
+                unsupported_backend = ggml_backend_name(backend1);
+            }
+
+            if(supported1 && !supported2) {
+                unsupported_backend = ggml_backend_name(backend2);
+            }
+
+            if(!supported1 && !supported2) {
+                unsupported_backend = std::string(ggml_backend_name(backend1)) + ", " + std::string(ggml_backend_name(backend2));
+            }
+
+            test_result result(unsupported_backend.c_str(), current_op_name, vars(), "test",
                              false, false, "not supported");
 
             print_test_result_locked(output_printer, result);
@@ -1472,7 +1490,7 @@ struct test_case {
         // Create test result
         bool        test_passed = ud.ok && cmp_ok;
         std::string error_msg   = test_passed ? "" : (!cmp_ok ? "compare failed" : "test failed");
-        test_result result(ggml_backend_name(backend1), current_op_name, vars(), "test", supported, test_passed,
+        test_result result(ggml_backend_name(backend1), current_op_name, vars(), "test", supported1, test_passed,
                            error_msg);
 
         print_test_result_locked(output_printer, result);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1338,37 +1338,23 @@ struct test_case {
         }
 
         // check if the backends support the ops
-        bool supported1 = true;
-        bool supported2 = true;
+        bool supported = true;
+        std::string unsupported_str;
         for (ggml_backend_t backend : {backend1, backend2}) {
             for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
                 if (!ggml_backend_supports_op(backend, t)) {
-                    if (backend == backend1) {
-                        supported1 = false;
+                    supported = false;
+                    if (unsupported_str.empty()) {
+                        unsupported_str = std::string(ggml_backend_name(backend));
                     } else {
-                        supported2 = false;
+                        unsupported_str += ", " + std::string(ggml_backend_name(backend));
                     }
-                    break;
                 }
             }
         }
 
-        if (!supported1 || !supported2) {
-            // Create test result for unsupported operation
-            std::string unsupported_backend = "";
-            if(!supported1 && supported2) {
-                unsupported_backend = ggml_backend_name(backend1);
-            }
-
-            if(supported1 && !supported2) {
-                unsupported_backend = ggml_backend_name(backend2);
-            }
-
-            if(!supported1 && !supported2) {
-                unsupported_backend = std::string(ggml_backend_name(backend1)) + ", " + std::string(ggml_backend_name(backend2));
-            }
-
-            test_result result(unsupported_backend.c_str(), current_op_name, vars(), "test",
+        if (!supported) {
+            test_result result(unsupported_str, current_op_name, vars(), "test",
                              false, false, "not supported");
 
             print_test_result_locked(output_printer, result);
@@ -1490,7 +1476,7 @@ struct test_case {
         // Create test result
         bool        test_passed = ud.ok && cmp_ok;
         std::string error_msg   = test_passed ? "" : (!cmp_ok ? "compare failed" : "test failed");
-        test_result result(ggml_backend_name(backend1), current_op_name, vars(), "test", supported1, test_passed,
+        test_result result(ggml_backend_name(backend1), current_op_name, vars(), "test", supported, test_passed,
                            error_msg);
 
         print_test_result_locked(output_printer, result);


### PR DESCRIPTION
UT case show unsupported backend in log.
But if it's not supported by CPU, the UT still show the target backend (like SYCL) not to support it, instead of showing CPU don't support it.
It provides wrong info.

This PT enhance it to show all real unsupported backends.
Like show both SYCL0 and CPU `[SYCL0, CPU]` as below:

```
 CPY(type_src=f32,type_dst=iq3_s,ne_src=[256,4,4,4],permute_src=[0,0,0,0],permute_dst=[0,0,0,0],_src_transpose=0): not supported [SYCL0, CPU] 
 CPY(type_src=f32,type_dst=iq3_s,ne_src=[256,2,3,4],permute_src=[0,2,1,3],permute_dst=[0,0,0,0],_src_transpose=0): not supported [SYCL0, CPU] 
 CPY(type_src=f32,type_dst=iq4_xs,ne_src=[256,4,4,4],permute_src=[0,0,0,0],permute_dst=[0,0,0,0],_src_transpose=0): not supported [SYCL0] 
 CPY(type_src=f32,type_dst=iq4_xs,ne_src=[256,2,3,4],permute_src=[0,2,1,3],permute_dst=[0,0,0,0],_src_transpose=0): not supported [SYCL0] 

```