### PR TITLE
common,server : fix custom preset dedup against cached models

### DIFF
--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <sstream>
 #include <filesystem>
-#include <regex>
 
 static std::string rm_leading_dashes(const std::string & str) {
     size_t pos = 0;
@@ -15,23 +14,6 @@ static std::string rm_leading_dashes(const std::string & str) {
         ++pos;
     }
     return str.substr(pos);
-}
-
-static std::string canonical_tag(const std::string & tag) {
-    static const std::regex re_tag("[-.]([A-Z0-9_]+)$", std::regex::icase);
-    std::smatch m;
-    if (std::regex_search(tag, m, re_tag)) {
-        std::string canon = m[1].str();
-        for (char & c : canon) {
-            c = (char) std::toupper((unsigned char) c);
-        }
-        return canon;
-    }
-    std::string upper = tag;
-    for (char & c : upper) {
-        c = (char) std::toupper((unsigned char) c);
-    }
-    return upper;
 }
 
 std::vector<std::string> common_preset::to_args(const std::string & bin_path) const {
@@ -288,18 +270,7 @@ common_presets common_preset_context::load_from_ini(const std::string & path, co
 
     for (auto section : ini_data) {
         common_preset preset;
-        std::string section_name = section.first.empty() ? std::string(COMMON_PRESET_DEFAULT_NAME) : section.first;
-        if (section_name != "*" && section_name != COMMON_PRESET_DEFAULT_NAME) {
-            auto colon_idx = section_name.rfind(':');
-            if (colon_idx != std::string::npos) {
-                std::string tag       = section_name.substr(colon_idx + 1);
-                std::string canon_tag = canonical_tag(tag);
-                if (canon_tag != tag) {
-                    section_name = section_name.substr(0, colon_idx + 1) + canon_tag;
-                }
-            }
-        }
-        preset.name = section_name;
+        preset.name = section.first.empty() ? std::string(COMMON_PRESET_DEFAULT_NAME) : section.first;
         LOG_DBG("loading preset: %s\n", preset.name.c_str());
         for (const auto & [key, value] : section.second) {
             if (key == "version") {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -339,6 +339,24 @@ void server_models::notify_sse(const std::string & event, const std::string & mo
     sse.broadcast(std::move(result));
 }
 
+// Match a preset section to a cached model that the cache may store without a
+// convenience prefix on the quant tag. Quant tags use '_' and never '-', so the
+// token after the last '-' is tried as the base; if it names a cached model,
+// return it so the preset merges in instead of duplicating it, else return "".
+static std::string cached_base_name(const std::string & name, const common_presets & cached_models) {
+    auto colon = name.rfind(':');
+    if (colon == std::string::npos) {
+        return {};
+    }
+    const std::string tag = name.substr(colon + 1);
+    auto dash = tag.find_last_of('-');
+    if (dash == std::string::npos) {
+        return {}; // no prefix to strip; exact-name match is handled by the caller
+    }
+    std::string base = name.substr(0, colon + 1) + tag.substr(dash + 1);
+    return cached_models.find(base) != cached_models.end() ? base : std::string{};
+}
+
 void server_models::load_models() {
     // Phase 1: load presets from all sources - pure I/O, no lock needed
     // 1. cached models
@@ -374,13 +392,26 @@ void server_models::load_models() {
         final_presets[name] = preset;
         source_map[name] = SERVER_MODEL_SOURCE_MODELS_DIR;
     }
+    // custom_names tracks which final entries came (at least partly) from a
+    // custom preset, for the '*' marker in log_available_models
+    std::unordered_set<std::string> custom_names;
     for (const auto & [name, custom] : custom_presets) {
-        if (final_presets.find(name) != final_presets.end()) {
-            final_presets[name].merge(custom);
+        // exact-name match, or match after dropping a quant-tag prefix the
+        // cache already stripped (see cached_base_name)
+        std::string base = cached_base_name(name, cached_models);
+        auto it = final_presets.find(name);
+        if (it == final_presets.end() && !base.empty()) {
+            it = final_presets.find(base);
+        }
+        if (it != final_presets.end()) {
+            it->second.merge(custom);
+            source_map[it->first] = SERVER_MODEL_SOURCE_PRESET;
+            custom_names.insert(it->first);
         } else {
             final_presets[name] = custom;
+            source_map[name] = SERVER_MODEL_SOURCE_PRESET;
+            custom_names.insert(name);
         }
-        source_map[name] = SERVER_MODEL_SOURCE_PRESET;
     }
 
     // overlay router's own CLI args on top of every model preset so that
@@ -394,8 +425,6 @@ void server_models::load_models() {
     };
 
     // Helpers that read `mapping` - must be called while holding the lock.
-    std::unordered_set<std::string> custom_names;
-    for (const auto & [name, preset] : custom_presets) custom_names.insert(name);
     auto join_set = [](const std::set<std::string> & s) {
         std::string result;
         for (const auto & v : s) {


### PR DESCRIPTION

## Overview

Revert the canonical_tag() case-folding in preset.cpp that collapsed distinct alias presets (e.g. Q4_K_XL-thinking and Q8_0-thinking into THINKING) and broke downstream tools keying by name.

Instead, add cached_base_name() in server-models.cpp so a custom preset section whose quant tag carries a convenience prefix merges into the cached entry the cache stores without that prefix. Presets whose tag suffix is not a cached quant keep their own name as a separate alias row.

Also track custom_names during the merge so the '*' marker lands on the actual mapping key rather than the unmerged custom name.

## Additional information

This is another solution that is #25226.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
