### PR TITLE
common: Set optimal default thread count for ppc ( linux as well as AIX)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -55,6 +55,10 @@
 #include <pwd.h>
 #endif
 
+#if defined(_AIX)
+#include <sys/systemcfg.h>
+#endif
+
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
@@ -73,7 +77,6 @@ common_time_meas::~common_time_meas() {
 
 int32_t common_cpu_get_num_physical_cores() {
 #if defined(_AIX)
-    #include <sys/systemcfg.h>
     int32_t logical_cpus = _system_configuration.ncpus;
     int32_t smt_threads = _system_configuration.smt_threads;
     if (smt_threads > 0) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -72,7 +72,17 @@ common_time_meas::~common_time_meas() {
 //
 
 int32_t common_cpu_get_num_physical_cores() {
-#ifdef __linux__
+#if defined(_AIX)
+    #include <sys/systemcfg.h>
+    int32_t logical_cpus = _system_configuration.ncpus;
+    int32_t smt_threads = _system_configuration.smt_threads;
+    if (smt_threads > 0) {
+        return static_cast<int32_t>(logical_cpus / smt_threads);
+    }
+    if (logical_cpus > 0) {
+        return static_cast<int32_t>(logical_cpus);
+    }
+#elif defined(__linux__)
     // enumerate the set of thread siblings, num entries is num cores
     std::unordered_set<std::string> siblings;
     for (uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
@@ -202,6 +212,13 @@ int32_t common_cpu_get_num_math() {
             }
         }
     }
+#elif defined(__powerpc64__) || defined(__powerpc__)
+    int32_t smt_factor = 1;
+    int phy_cpus = common_cpu_get_num_physical_cores();
+    int logical_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    if (phy_cpus > 0 && logical_cpus > phy_cpus)
+        smt_factor = logical_cpus / phy_cpus;
+    return phy_cpus * std::min(smt_factor, 2);
 #endif
     return common_cpu_get_num_physical_cores();
 }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -216,8 +216,9 @@ int32_t common_cpu_get_num_math() {
     int32_t smt_factor = 1;
     int phy_cpus = common_cpu_get_num_physical_cores();
     int logical_cpus = sysconf(_SC_NPROCESSORS_ONLN);
-    if (phy_cpus > 0 && logical_cpus > phy_cpus)
+    if (phy_cpus > 0 && logical_cpus > phy_cpus) {
         smt_factor = logical_cpus / phy_cpus;
+    }
     return phy_cpus * std::min(smt_factor, 2);
 #endif
     return common_cpu_get_num_physical_cores();


### PR DESCRIPTION
This patch adds AIX-specific logic to detect the number of physical cores. Currently,  this relies on std::thread::hardware_concurrency(). On AIX systems running with SMT4/SMT8,  this leads to massive degradation in token generation phase due to oversubscription. 

On Power systems, peak throughput. is observed at 2/4 threads per core when supported.  This patch computes the default thread count as  physical_cores * min(smt_factor, 2)

Performance Result:
./build_llama/bin/llama-cli -m /home/shalini/Models/ibm-granite_granite-3.2-8b-instruct-Q4_K_M.gguf -p "Tell me top 3 things about AIX operating system"

**Linux :**
 Power10 Box with 10 physical cores in SMT 8 

Base (default selects 10 threads ) :
[ Prompt: 23.4 t/s | Generation: 14.3 t/s ]
Patch ( default selects  20 threads ):
[ Prompt: 38.6 t/s | Generation: 19.0 t/s ]

 **AIX:**
Power10 Box with 8 physical cores in SMT 8 mode
Base (default selects 32 threads ) :
[ Prompt: 54.8 t/s | Generation: 3.7 t/s ]
Patch ( default selects 16 threads ):
[ Prompt: 49.0 t/s | Generation: 6.3 t/s ]

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
