### PR TITLE
server : add --sleep-mode <keep-alive/terminate> to optionally exit process on idle

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3383,6 +3383,21 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--sleep-mode"}, "MODE",
+        "action taken when --sleep-idle-seconds is reached: 'keep-alive' (default, free the model but keep the "
+        "process alive for fast wakeup) or 'terminate' (exit the process to free all resources; requires a "
+        "supervisor such as the router or systemd to respawn on the next request)",
+        [](common_params & params, const std::string & value) {
+            if (value == "keep-alive") {
+                params.sleep_mode = COMMON_SLEEP_MODE_KEEP_ALIVE;
+            } else if (value == "terminate") {
+                params.sleep_mode = COMMON_SLEEP_MODE_TERMINATE;
+            } else {
+                throw std::invalid_argument("invalid value: must be 'keep-alive' or 'terminate'");
+            }
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--simple-io"},
         "use basic IO for better compatibility in subprocesses and limited consoles",
         [](common_params & params) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3385,8 +3385,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     add_opt(common_arg(
         {"--sleep-mode"}, "MODE",
         "action taken when --sleep-idle-seconds is reached: 'keep-alive' (default, free the model but keep the "
-        "process alive for fast wakeup) or 'terminate' (exit the process to free all resources; requires a "
-        "supervisor such as the router or systemd to respawn on the next request)",
+        "process alive for fast wakeup) or 'terminate' (exit the process to free all resources)"
         [](common_params & params, const std::string & value) {
             if (value == "keep-alive") {
                 params.sleep_mode = COMMON_SLEEP_MODE_KEEP_ALIVE;

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3385,7 +3385,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     add_opt(common_arg(
         {"--sleep-mode"}, "MODE",
         "action taken when --sleep-idle-seconds is reached: 'keep-alive' (default, free the model but keep the "
-        "process alive for fast wakeup) or 'terminate' (exit the process to free all resources)"
+        "process alive for fast wakeup) or 'terminate' (exit the process to free all resources)",
         [](common_params & params, const std::string & value) {
             if (value == "keep-alive") {
                 params.sleep_mode = COMMON_SLEEP_MODE_KEEP_ALIVE;

--- a/common/common.h
+++ b/common/common.h
@@ -428,7 +428,7 @@ enum common_reasoning_format {
 
 enum common_sleep_mode {
     COMMON_SLEEP_MODE_KEEP_ALIVE, // free the model but keep the process alive (fast wakeup)
-    COMMON_SLEEP_MODE_TERMINATE,  // exit the process on idle (frees all resources; requires a supervisor to respawn)
+    COMMON_SLEEP_MODE_TERMINATE,  // exit the process on idle
 };
 
 

--- a/common/common.h
+++ b/common/common.h
@@ -426,6 +426,11 @@ enum common_reasoning_format {
     // see: https://github.com/ggml-org/llama.cpp/pull/15408
 };
 
+enum common_sleep_mode {
+    COMMON_SLEEP_MODE_KEEP_ALIVE, // free the model but keep the process alive (fast wakeup)
+    COMMON_SLEEP_MODE_TERMINATE,  // exit the process on idle (frees all resources; requires a supervisor to respawn)
+};
+
 
 struct lr_opt {
     float    lr0          = 1e-5; // learning rate at first epoch
@@ -635,6 +640,7 @@ struct common_params {
     int enable_reasoning = -1; // -1 = auto, 0 = disable, 1 = enable
     bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
     int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
+    common_sleep_mode sleep_mode = COMMON_SLEEP_MODE_KEEP_ALIVE; // what to do when the idle timeout is reached
 
     std::vector<std::string> api_keys;
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -228,6 +228,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-sps, --slot-prompt-similarity SIMILARITY` | how much the prompt of a request must match the prompt of a slot in order to use that slot (default: 0.10, 0.0 = disabled) |
 | `--lora-init-without-apply` | load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: disabled) |
 | `--sleep-idle-seconds SECONDS` | number of seconds of idleness after which the server will sleep (default: -1; -1 = disabled) |
+| `--sleep-mode MODE` | action when the idle timeout is reached: `keep-alive` (default, free the model but keep the process alive for fast wakeup) or `terminate` (exit the process to free all resources; requires a supervisor such as the router or systemd to respawn) |
 | `--log-prompts-dir PATH` | Log prompts to directory (only used for debugging, default: disabled) |
 | `--spec-draft-hf, -hfd, -hfrd, --hf-repo-draft <user>/<model>[:quant]` | Same as --hf-repo, but for the draft model (default: unused)<br/>(env: LLAMA_ARG_SPEC_DRAFT_HF_REPO) |
 | `--spec-draft-threads, -td, --threads-draft N` | number of threads to use during generation (default: same as --threads) |
@@ -1989,6 +1990,8 @@ Example of an error:
 The server supports an automatic sleep mode that activates after a specified period of inactivity (no incoming tasks). This feature, introduced in [PR #18228](https://github.com/ggml-org/llama.cpp/pull/18228), can be enabled using the `--sleep-idle-seconds` command-line argument. It works seamlessly in both single-model and multi-model configurations.
 
 When the server enters sleep mode, the model and its associated memory (including the KV cache) are unloaded from RAM to conserve resources. Any new incoming task will automatically trigger the model to reload.
+
+By default (`--sleep-mode keep-alive`) the process stays alive so wakeup only needs to reload the model. Note that a live process still holds a per-process GPU device context (loaded kernels and runtime buffers), so a small amount of VRAM remains reserved while sleeping. To release *all* resources, use `--sleep-mode terminate`: on idle the process exits, and a supervisor respawns it on the next request. In router mode (`--models-preset`) the router already respawns terminated instances on demand; for a standalone server you must provide your own supervisor (e.g. systemd socket activation). `terminate` trades a slower wakeup (full process + backend startup) for zero idle VRAM.
 
 The sleeping status can be retrieved from the `GET /props` endpoint (or `/props?model=(model_name)` in router mode).
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -228,7 +228,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-sps, --slot-prompt-similarity SIMILARITY` | how much the prompt of a request must match the prompt of a slot in order to use that slot (default: 0.10, 0.0 = disabled) |
 | `--lora-init-without-apply` | load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: disabled) |
 | `--sleep-idle-seconds SECONDS` | number of seconds of idleness after which the server will sleep (default: -1; -1 = disabled) |
-| `--sleep-mode MODE` | action when the idle timeout is reached: `keep-alive` (default, free the model but keep the process alive for fast wakeup) or `terminate` (exit the process to free all resources; requires a supervisor such as the router or systemd to respawn) |
+| `--sleep-mode MODE` | action when the idle timeout is reached: `keep-alive` (default, free the model but keep the process alive for fast wakeup) or `terminate` (exit the process to free all resources) |
 | `--log-prompts-dir PATH` | Log prompts to directory (only used for debugging, default: disabled) |
 | `--spec-draft-hf, -hfd, -hfrd, --hf-repo-draft <user>/<model>[:quant]` | Same as --hf-repo, but for the draft model (default: unused)<br/>(env: LLAMA_ARG_SPEC_DRAFT_HF_REPO) |
 | `--spec-draft-threads, -td, --threads-draft N` | number of threads to use during generation (default: same as --threads) |
@@ -1991,7 +1991,7 @@ The server supports an automatic sleep mode that activates after a specified per
 
 When the server enters sleep mode, the model and its associated memory (including the KV cache) are unloaded from RAM to conserve resources. Any new incoming task will automatically trigger the model to reload.
 
-By default (`--sleep-mode keep-alive`) the process stays alive so wakeup only needs to reload the model. Note that a live process still holds a per-process GPU device context (loaded kernels and runtime buffers), so a small amount of VRAM remains reserved while sleeping. To release *all* resources, use `--sleep-mode terminate`: on idle the process exits, and a supervisor respawns it on the next request. In router mode (`--models-preset`) the router already respawns terminated instances on demand; for a standalone server you must provide your own supervisor (e.g. systemd socket activation). `terminate` trades a slower wakeup (full process + backend startup) for zero idle VRAM.
+By default (`--sleep-mode keep-alive`) the process stays alive so wakeup only needs to reload the model. Note that a live process still holds a per-process GPU device context (loaded kernels and runtime buffers), so a small amount of VRAM remains reserved while sleeping. To release *all* resources, use `--sleep-mode terminate`: on idle the process exits, and a supervisor respawns it on the next request, `terminate` trades a slower wakeup (full process + backend startup) for zero idle VRAM.
 
 The sleeping status can be retrieved from the `GET /props` endpoint (or `/props?model=(model_name)` in router mode).
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -956,12 +956,10 @@ private:
         GGML_ASSERT(sleeping != new_state);
         if (new_state) {
             if (params_base.sleep_mode == COMMON_SLEEP_MODE_TERMINATE) {
-                SRV_INF("%s", "idle timeout reached, terminating process (--sleep-mode terminate)\n");
+                SRV_INF("%s", "idle timeout reached, terminating process \n");
                 destroy();
                 fflush(stdout);
                 fflush(stderr);
-                // exit immediately: process death returns all resources (incl. GPU memory) to the OS;
-                // a supervisor (router or systemd) is expected to respawn on the next request
                 std::_Exit(0);
             }
             SRV_INF("%s", "server is entering sleeping state\n");

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdlib>
 #include <cinttypes>
 #include <exception>
 #include <memory>
@@ -954,6 +955,15 @@ private:
     void handle_sleeping_state(bool new_state) {
         GGML_ASSERT(sleeping != new_state);
         if (new_state) {
+            if (params_base.sleep_mode == COMMON_SLEEP_MODE_TERMINATE) {
+                SRV_INF("%s", "idle timeout reached, terminating process (--sleep-mode terminate)\n");
+                destroy();
+                fflush(stdout);
+                fflush(stderr);
+                // exit immediately: process death returns all resources (incl. GPU memory) to the OS;
+                // a supervisor (router or systemd) is expected to respawn on the next request
+                std::_Exit(0);
+            }
             SRV_INF("%s", "server is entering sleeping state\n");
             destroy();
         } else {


### PR DESCRIPTION
## Overview

Adds a `llama-server` argument for determining what to do to a child process when they hit the `sleep` state.  I've noticed on two of my rigs (`gfx900` and `gfx906`) that when the child process goes into a `sleep` state, the idle power draw and clocks stay relatively high due to the child process still claiming resources on the GPUs.  This results, at least for me, with a decent amount of wasted electricity and higher idle thermals that is super wasteful (my `gfx900` cards are idling 10C higher in the normal `sleep` mode vs truly idle)

Argument added is `--sleep-mode`, options are

- `keep-alive` - Logic as it stands today, child frees resources but is still alive
- `terminate` - New option, on entering `sleep` the child process is terminated

Depending on the system there's probably not too much penalty on just using `keep-alive`, I can imagine consumer GPUs idle just fine, but on these old data center cards the trade-off of letting `llama-server` spawn a new child 100% beats the large power draw and thermal drift.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yep
- AI usage disclosure: Yes, I used Opus 4.8 w/ the Copilot CLI harness to do some initial investigation, as I noticed on my rigs that I was having unreasonably high idle temps when using `sleep-idle-seconds`, up in the 55C range, when I was expecting more in the 37C area, where they typically idle.  That started my investigation, which led to me better understanding how the `sleep` logic works for children processes.  Springboarding off of this, I made the `llama-server` arg by hand, then used copilot to check it, and add a little bit of documentation.  Then, went through by hand and refined said documentation.
