### PR TITLE
vulkan: fix 32-bit integer overflow in CEIL_DIV

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -129,7 +129,7 @@ typedef struct VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE {
 #endif
 
 #define ROUNDUP_POW2(M, N) (((M) + (N) - 1) & ~((N) - 1))
-#define CEIL_DIV(M, N) (((M) + (N)-1) / (N))
+#define CEIL_DIV(M, N) (((M) / (N)) + (((M) % (N)) != 0))
 static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
 
 #define VK_VENDOR_ID_AMD 0x1002


### PR DESCRIPTION
## Overview

Fixes #23057.

Mobile Vulkan drivers (Mali, Adreno, CIX) report `maxComputeWorkGroupCount = UINT32_MAX`. `CEIL_DIV`'s numerator `(M + N - 1)` wraps in 32-bit arithmetic and yields 0, so `ggml_vk_matmul` requests 0 descriptor sets for batched matmuls while still dispatching one, tripping `GGML_ASSERT(descriptor_set_idx < descriptor_sets.size())` at model load.

This rewrites the macro with division-based math that has no overflowing intermediate, as suggested by @jeffbolznv in the issue.

Tested on a Mali-G68 (MediaTek Dimensity 900): Gemma 3n E2B Q4_K_M with full Vulkan offload went from a 100% reproducible abort at warmup to generating normally, same throughput as a 64-bit promotion variant.

## Additional information

Full root cause analysis and instrumentation logs are in #23057.

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES, I used an AI assistant to help debug and instrument the descriptor set accounting on my device, which located the overflow (details in #23057). The fix itself is the one-line macro rewrite suggested by @jeffbolznv; I applied it and validated it on my hardware. I can retest on the affected device if follow-up is needed.