### PR TITLE
spec: support spec-draft-p-min in DFlash

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -968,7 +968,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         for (auto & s : smpls) {
             common_params_sampling sparams;
             sparams.no_perf  = false;
-            sparams.top_k    = 1;
+            sparams.top_k    = 10;
             sparams.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
             s.reset(common_sampler_init(model_dft, sparams));
         }
@@ -1172,6 +1172,10 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
                 }
 
                 const llama_token id = cur_p->data[0].id;
+
+                if (cur_p->data[0].p < params.p_min) {
+                    break;
+                }
 
                 common_sampler_accept(smpl, id, true);
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -955,10 +955,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u\n", __func__, block_size, mask_token_id, target_layer_ids_n);
 
         // DFlash input is [id_last, <mask> * (block_size-1)], so it can draft at most block_size-1 tokens per step
-        if (this->params.n_max > block_size - 1) {
-            LOG_WRN("%s: requested draft size %d exceeds the trained DFlash block size %d -- clamping to %d draft tokens per step\n",
-                    __func__, this->params.n_max, block_size - 1, block_size - 1);
-            this->params.n_max = block_size - 1;
+        if (this->params.n_max > block_size - 1 || this->params.n_min > block_size - 1) {
+            LOG_WRN("%s: requested draft size (n_max=%d, n_min=%d) exceeds the trained DFlash block size %d -- clamping to %d\n",
+                    __func__, this->params.n_max, this->params.n_min, block_size, block_size - 1);
+            this->params.n_max = std::min(this->params.n_max, block_size - 1);
+            this->params.n_min = std::min(this->params.n_min, block_size - 1);
         }
 
         batch        = llama_batch_init(llama_n_batch(ctx_dft), 0,          n_seq);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1181,6 +1181,10 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
                 result.push_back(id);
             }
+
+            if (result.size() < (size_t) params.n_min) {
+                result.clear();
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

Allow user to set `--spec-draft-p-min` in DFlash. 

I thought DFlash is a diffusion-based draft model rather than an autoregressive one, so I initially assumed that `spec-draft-p-min` wasn't very important because truncating the draft doesn't reduce the draft generation time. 
However, it can still be useful for reducing the target model's verification time by truncating the draft token once a token's confidence falls below the threshold specified by `--spec-draft-p-min`. 

Therefore, in some use cases, tuning this parameter can improve overall performance.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
