### PR TITLE
vocab : bounds-check precompiled charsmap before header read

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -881,6 +881,9 @@ private:
 struct llm_tokenizer_ugm : llm_tokenizer {
     llm_tokenizer_ugm(const llama_vocab & vocab, const std::vector<char> & precompiled_charsmap) {
         if (precompiled_charsmap.size() > 0) {
+            if (precompiled_charsmap.size() < sizeof(uint32_t)) {
+                throw std::runtime_error("Index out of array bounds in precompiled charsmap!");
+            }
             size_t charsmap_offset = 0;
 
             // First four bytes of precompiled_charsmap contains length of binary
@@ -2020,13 +2023,15 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                 precompiled_charsmap.assign(pc, pc + n_precompiled_charsmap);
 #if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
                 // correct endianness of data in precompiled_charsmap binary blob
-                uint32_t * xcda_blob_size = (uint32_t *) &precompiled_charsmap[0];
-                *xcda_blob_size = __builtin_bswap32(*xcda_blob_size);
-                assert(*xcda_blob_size + sizeof(uint32_t) < n_precompiled_charsmap);
-                size_t xcda_array_size = *xcda_blob_size / sizeof(uint32_t);
-                uint32_t * xcda_array = (uint32_t *) &precompiled_charsmap[sizeof(uint32_t)];
-                for (size_t i = 0; i < xcda_array_size; ++i) {
-                    xcda_array[i] = __builtin_bswap32(xcda_array[i]);
+                if (n_precompiled_charsmap >= sizeof(uint32_t)) {
+                    uint32_t * xcda_blob_size = (uint32_t *) &precompiled_charsmap[0];
+                    *xcda_blob_size = __builtin_bswap32(*xcda_blob_size);
+                    assert(*xcda_blob_size + sizeof(uint32_t) < n_precompiled_charsmap);
+                    size_t xcda_array_size = *xcda_blob_size / sizeof(uint32_t);
+                    uint32_t * xcda_array = (uint32_t *) &precompiled_charsmap[sizeof(uint32_t)];
+                    for (size_t i = 0; i < xcda_array_size; ++i) {
+                        xcda_array[i] = __builtin_bswap32(xcda_array[i]);
+                    }
                 }
 #endif
             }


### PR DESCRIPTION
## Overview

the ugm tokenizer reads a 4-byte xcda blob size out of `tokenizer.ggml.precompiled_charsmap` with `*(const uint32_t *) &precompiled_charsmap[0]` after only checking `size() > 0`, so a gguf whose precompiled_charsmap array carries 1-3 bytes reads up to three bytes past the heap allocation while loading the model. the length is taken straight from `gguf_get_arr_n` in `llama_vocab::impl::load`, so it is fully controlled by the model file. require at least `sizeof(uint32_t)` bytes before touching the header, reusing the existing out-of-bounds error. the big-endian byteswap block in `load()` dereferences the same 4-byte header without a length check, so it gets the same guard.

## Additional information

reachable at load time via `init_tokenizer` for unigram/t5-style vocabs. asan on the extracted read reports a heap-buffer-overflow read of size 4 on a 2-byte buffer; with the guard a short charsmap is rejected instead. falls under the "untrusted models" class in SECURITY.md.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
