### PR TITLE
feat: add --threads-all option to llama-bench

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -450,6 +450,7 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -ctk, --cache-type-k <t>                    (default: %s)\n", join(transform_to_str(cmd_params_defaults.type_k, ggml_type_name), ",").c_str());
     printf("  -ctv, --cache-type-v <t>                    (default: %s)\n", join(transform_to_str(cmd_params_defaults.type_v, ggml_type_name), ",").c_str());
     printf("  -t, --threads <n>                           (default: %s)\n", join(cmd_params_defaults.n_threads, ",").c_str());
+    printf("  -ta, --threads-all                          use all logical cores (including SMT)\n");
     printf("  -C, --cpu-mask <hex,hex>                    (default: %s)\n", join(cmd_params_defaults.cpu_mask, ",").c_str());
     printf("  --cpu-strict <0|1>                          (default: %s)\n", join(cmd_params_defaults.cpu_strict, ",").c_str());
     printf("  --poll <0...100>                            (default: %s)\n", join(cmd_params_defaults.poll, ",").c_str());
@@ -693,6 +694,8 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 }
                 auto p = parse_int_range(argv[i]);
                 params.n_threads.insert(params.n_threads.end(), p.begin(), p.end());
+            } else if (arg == "-ta" || arg == "--threads-all") {
+                params.n_threads.push_back(std::thread::hardware_concurrency());
             } else if (arg == "-C" || arg == "--cpu-mask") {
                 if (++i >= argc) {
                     invalid_param = true;


### PR DESCRIPTION
## Summary
Add a new command-line option `-ta` / `--threads-all` to `llama-bench` that uses all logical cores (including SMT/hyperthreading) instead of only physical cores.

## Problem
As discussed in issue #17611, llama-bench currently uses `cpu_get_num_math()` which returns the number of physical cores. On systems with SMT/hyperthreading enabled (e.g., dual CPU with 36 cores / 72 threads), this results in only 50% CPU utilization being reported by default.

While using physical cores is generally optimal for llama.cpp workloads, users who want to benchmark their system's full capabilities need to manually specify thread count with `-t 72`.

## Solution
Add a convenient `-ta` / `--threads-all` flag that automatically uses `std::thread::hardware_concurrency()` to get all logical cores.

### Usage
```bash
# Use all logical cores (including SMT)
./llama-bench -ta
./llama-bench --threads-all