### PR TITLE
server: also free backend on sleep

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -64,6 +64,16 @@ enum slot_state {
     SLOT_STATE_GENERATING,
 };
 
+struct server_backend {
+    server_backend(const common_params & params) {
+        llama_backend_init();
+        llama_numa_init(params.numa);
+    }
+    ~server_backend() {
+        llama_backend_free();
+    }
+};
+
 struct server_slot; // forward declaration
 
 struct server_batch {
@@ -937,6 +947,9 @@ private:
 
     int64_t t_last_load_progress_ms = 0;
 
+    // optional so that it's only initialized in non-router mode
+    std::optional<server_backend> backend;
+
     void destroy() {
         spec.reset();
         ctx_dft.reset();
@@ -949,6 +962,8 @@ private:
 
         mtmd_free(mctx);
         mctx = nullptr;
+
+        backend.reset();
     }
 
     void handle_sleeping_state(bool new_state) {
@@ -1003,6 +1018,8 @@ private:
         load_progress_data load_progress_text  (this, "text_model");
         load_progress_data load_progress_mmproj(this, "mmproj_model");
         load_progress_data load_progress_spec  (this, "spec_model");
+
+        backend.emplace(params_base);
 
         const bool is_resume = sleeping;
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -91,9 +91,6 @@ int llama_server(int argc, char ** argv) {
         return 1;
     }
 
-    llama_backend_init();
-    llama_numa_init(params.numa);
-
     common_models_handler models_handler;
     try {
         models_handler = common_models_handler_init(params, LLAMA_EXAMPLE_SERVER);
@@ -348,7 +345,6 @@ int llama_server(int argc, char ** argv) {
                 models_routes->stopping.store(true); // maybe redundant, but just to be safe
                 models_routes->models.unload_all();
             }
-            llama_backend_free();
         };
 
         if (!ctx_http.start()) {
@@ -374,7 +370,6 @@ int llama_server(int argc, char ** argv) {
             g_stream_sessions.stop_gc();
             ctx_http.stop();
             ctx_server.terminate();
-            llama_backend_free();
         };
 
         // start the HTTP server before loading the model to be able to serve /health requests


### PR DESCRIPTION
## Overview

Call `llama_backend_free()` on sleep

As a side effect of this change, `llama_backend_init()` is not longer called on router mode (which is expected)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
