### PR TITLE
common : resolve non-positive --threads to the number of math cores

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -32,7 +32,6 @@
 #include <regex>
 #include <set>
 #include <string>
-#include <thread> // for hardware_concurrency
 #include <vector>
 
 #ifndef __EMSCRIPTEN__
@@ -1274,22 +1273,17 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI, LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP}));
     add_opt(common_arg(
         {"-t", "--threads"}, "N",
-        string_format("number of CPU threads to use during generation (default: %d)", params.cpuparams.n_threads),
+        string_format("number of CPU threads to use during generation (default: %d, -1 = number of math cores)", params.cpuparams.n_threads),
         [](common_params & params, int value) {
-            params.cpuparams.n_threads = value;
-            if (params.cpuparams.n_threads <= 0) {
-                params.cpuparams.n_threads = std::thread::hardware_concurrency();
-            }
+            // <= 0: resolved in postprocess_cpu_params (ref: https://github.com/ggml-org/llama.cpp/issues/19110)
+            params.cpuparams.n_threads = value > 0 ? value : -1;
         }
     ).set_env("LLAMA_ARG_THREADS"));
     add_opt(common_arg(
         {"-tb", "--threads-batch"}, "N",
         "number of threads to use during batch and prompt processing (default: same as --threads)",
         [](common_params & params, int value) {
-            params.cpuparams_batch.n_threads = value;
-            if (params.cpuparams_batch.n_threads <= 0) {
-                params.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
-            }
+            params.cpuparams_batch.n_threads = value > 0 ? value : -1;
         }
     ));
     add_opt(common_arg(
@@ -3535,20 +3529,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--spec-draft-threads", "-td", "--threads-draft"}, "N",
         "number of threads to use during generation (default: same as --threads)",
         [](common_params & params, int value) {
-            params.speculative.draft.cpuparams.n_threads = value;
-            if (params.speculative.draft.cpuparams.n_threads <= 0) {
-                params.speculative.draft.cpuparams.n_threads = std::thread::hardware_concurrency();
-            }
+            params.speculative.draft.cpuparams.n_threads = value > 0 ? value : -1;
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
         {"--spec-draft-threads-batch", "-tbd", "--threads-batch-draft"}, "N",
         "number of threads to use during batch and prompt processing (default: same as --threads-draft)",
         [](common_params & params, int value) {
-            params.speculative.draft.cpuparams_batch.n_threads = value;
-            if (params.speculative.draft.cpuparams_batch.n_threads <= 0) {
-                params.speculative.draft.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
-            }
+            params.speculative.draft.cpuparams_batch.n_threads = value > 0 ? value : -1;
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -117,6 +117,26 @@ static void test(void) {
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.cpuparams.n_threads == 1234);
 
+    // non-positive thread counts resolve to the number of math CPUs
+    // ref: https://github.com/ggml-org/llama.cpp/issues/19110
+    argv = {"binary_name", "-t", "-1"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
+    assert(params.cpuparams.n_threads == common_cpu_get_num_math());
+
+    argv = {"binary_name", "-t", "0"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
+    assert(params.cpuparams.n_threads == common_cpu_get_num_math());
+
+    // non-positive -tb/-td inherit the CPU params of -t
+    argv = {"binary_name", "-t", "2", "-tb", "-1"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
+    assert(params.cpuparams.n_threads == 2);
+    assert(params.cpuparams_batch.n_threads == 2);
+
+    argv = {"binary_name", "-t", "3", "-td", "-1"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+    assert(params.speculative.draft.cpuparams.n_threads == 3);
+
     argv = {"binary_name", "--verbose"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.verbosity > 1);

--- a/tools/completion/README.md
+++ b/tools/completion/README.md
@@ -97,7 +97,7 @@ llama-completion.exe -m models\gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
 | `--version` | show version and build info |
 | `-cl, --cache-list` | show list of models in cache |
 | `--completion-bash` | print source-able bash completion script for llama.cpp |
-| `-t, --threads N` | number of CPU threads to use during generation (default: -1)<br/>(env: LLAMA_ARG_THREADS) |
+| `-t, --threads N` | number of CPU threads to use during generation (default: -1, -1 = number of math cores)<br/>(env: LLAMA_ARG_THREADS) |
 | `-tb, --threads-batch N` | number of threads to use during batch and prompt processing (default: same as --threads) |
 | `-C, --cpu-mask M` | CPU affinity mask: arbitrarily long hex. Complements cpu-range (default: "") |
 | `-Cr, --cpu-range lo-hi` | range of CPUs for affinity. Complements --cpu-mask |

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -35,7 +35,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--version` | show version and build info |
 | `-cl, --cache-list` | show list of models in cache |
 | `--completion-bash` | print source-able bash completion script for llama.cpp |
-| `-t, --threads N` | number of CPU threads to use during generation (default: -1)<br/>(env: LLAMA_ARG_THREADS) |
+| `-t, --threads N` | number of CPU threads to use during generation (default: -1, -1 = number of math cores)<br/>(env: LLAMA_ARG_THREADS) |
 | `-tb, --threads-batch N` | number of threads to use during batch and prompt processing (default: same as --threads) |
 | `-C, --cpu-mask M` | CPU affinity mask: arbitrarily long hex. Complements cpu-range (default: "") |
 | `-Cr, --cpu-range lo-hi` | range of CPUs for affinity. Complements --cpu-mask |


### PR DESCRIPTION
Fixes #19110

## Overview

Explicit `-t`/`-tb`/`-td`/`-tbd` values `<= 0` are eagerly resolved to `std::thread::hardware_concurrency()` (all logical CPUs) inside the arg handlers, bypassing the `postprocess_cpu_params()` sentinel logic that the flag-omitted default uses (`common_cpu_get_num_math()` — physical cores, excluding SMT siblings and efficiency cores). So `--threads -1` silently oversubscribes SMT/E-cores and degrades token generation, while omitting `-t` entirely gives the good default. #19110 reports tg dropping from ~9 t/s to ~2.5 t/s from adding `--threads -1`.

This change stores `-1` for any non-positive value and lets `postprocess_cpu_params()` resolve it — the same path as the default. The four handlers are changed consistently; the now-unused `#include <thread>` is removed; the `-t` help text documents the sentinel and the generated README tables are updated.

Resolved thread counts on M1 (4 P-cores + 4 E-cores, `hardware_concurrency() == 8`, math cores = 4), verified with `llama-completion` master vs branch:

| invocation | before | after |
|---|---|---|
| (no `-t`) | 4 | 4 (unchanged) |
| `-t -1` | 8 | 4 |
| `-t 0` | 8 | 4 |
| `LLAMA_ARG_THREADS=-1` | 8 | 4 |
| `-t 2 -tb -1` | t=2, tb=8 | t=2, tb=2 |
| `-t 4` | 4 | 4 (unchanged) |

Perf impact of the two counts `-t -1` resolves to (llama-bench, CPU backend via `-ngl 0`, Llama-3.2-1B-Instruct Q4_K_M, 5 reps, cold chip; iMac M1 8 GB, macOS 25.5):

| threads | pp512 t/s | tg128 t/s |
|---|---|---|
| 4 (after) | 227.08 ± 11.66 | 54.68 ± 1.13 |
| 8 (before) | 210.22 ± 8.01 | 24.71 ± 3.06 |

tg advantage of 4 threads was consistent across 3 runs at different thermal states (2.2x cold to 5.6x throttled, with 8-thread variance growing under load); pp512 was equal within noise. This machine shows the E-core variant of the problem; the SMT double-count variant is the one measured in #19110.

Behavior changes to be aware of (beyond the headline fix):
- `-t 0` previously meant all logical CPUs, now auto (math cores). Not documented anywhere as "all cores"; no in-repo script/doc/test uses `-t 0`.
- Explicit non-positive `-tb`/`-td`/`-tbd` now inherit the full CPU config of their role model (count, mask, priority, poll — `postprocess_cpu_params()` struct copy), identical to omitting the flag, per the documented "default: same as --threads". Previously they got the hardware_concurrency count while keeping their own mask/priority. The same struct copy already happens on master whenever the flag is omitted.

## Additional information

- The eager `hardware_concurrency()` resolution predates the `arg.cpp` split (it was moved verbatim in #9388); no reachable history documents it as an intentional choice.
- New `test-arg-parser` cases pin the resolution (`-t -1`/`-t 0` == `common_cpu_get_num_math()`, `-tb -1`/`-td -1` inherit); they fail on master on SMT/hybrid machines and pass with this change.
- `llama-bench` has its own arg parser and is unaffected by this change.

## Requirements

- [ ] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — this change was developed with AI assistance (Claude); the author reviewed the diff, and the behavior matrix and benchmarks were measured on the author's hardware.
