### PR TITLE
server: handle DELETE on /cors-proxy for MCP streamable-http

### DIFF
--- a/tools/server/server-cors-proxy.h
+++ b/tools/server/server-cors-proxy.h
@@ -81,3 +81,17 @@ static server_http_context::handler_t proxy_handler_post = [](const server_http_
 static server_http_context::handler_t proxy_handler_get = [](const server_http_req & req) -> server_http_res_ptr {
     return proxy_request(req, "GET");
 };
+
+static server_http_context::handler_t proxy_handler_delete = [](const server_http_req &) -> server_http_res_ptr {
+    // MCP streamable-http clients send DELETE to terminate a session. Some hosted
+    // upstreams (e.g. Exa) reject DELETE, which makes the UI health check fail and
+    // disables the server for conversations. Session teardown is pure cleanup, so
+    // answer 200 directly instead of forwarding.
+    auto res = std::make_unique<server_http_res>();
+    res->status = 200;
+    res->headers["Access-Control-Allow-Origin"] = "*";
+    res->headers["Access-Control-Allow-Headers"] = "*";
+    res->headers["Access-Control-Allow-Methods"] = "GET,POST,DELETE,OPTIONS";
+    res->headers["Access-Control-Expose-Headers"] = "*";
+    return res;
+};

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -291,9 +291,11 @@ int llama_server(int argc, char ** argv) {
         SRV_WRN("%s", "-----------------\n");
         ctx_http.get ("/cors-proxy",      ex_wrapper(proxy_handler_get));
         ctx_http.post("/cors-proxy",      ex_wrapper(proxy_handler_post));
+        ctx_http.del ("/cors-proxy",      ex_wrapper(proxy_handler_delete));
     } else {
         ctx_http.get ("/cors-proxy",      ex_wrapper(res_403));
         ctx_http.post("/cors-proxy",      ex_wrapper(res_403));
+        ctx_http.del ("/cors-proxy",      ex_wrapper(res_403));
     }
 
     // EXPERIMENTAL built-in tools


### PR DESCRIPTION
## Summary

The built-in CORS proxy (`--ui-mcp-proxy`) only registers `GET` and `POST` handlers for `/cors-proxy`. The MCP streamable-http transport terminates a session by sending a `DELETE` request, which has no matching route and falls through to the 403 handler. As a result the Web UI health-check fails for hosted MCP servers that follow the streamable-http spec (e.g. Exa), and the server is disabled for every conversation:

> Protocol error after initialize: Failed to terminate session

This registers a `DELETE` route on `/cors-proxy` that responds `200` directly, since session teardown is pure cleanup and the upstream response is irrelevant to the client.

## Background

- `tools/server/server.cpp` previously registered only `get`/`post` for `/cors-proxy`.
- `tools/server/server-cors-proxy.h` had no `DELETE` handler.
- Reproduces with any hosted streamable-http MCP server that the browser reaches via the proxy (Exa's `https://mcp.exa.ai/mcp` is the reported case).

## Changes

- `tools/server/server-cors-proxy.h`: add `proxy_handler_delete` returning a permissive `200` with the same CORS headers as the other handlers (`GET,POST,DELETE,OPTIONS`).
- `tools/server/server.cpp`: register `ctx_http.del("/cors-proxy", proxy_handler_delete)` and the matching `res_403` fallback when the proxy is disabled.

## Testing

- Built `llama-server` with `--ui-mcp-proxy`, configured the Exa MCP server in the Web UI.
- Before: health-check logged `405` from Exa, server marked unhealthy, tools invisible.
- After: health-check completes, server stays healthy, `web_search_exa` tool is available and callable.

cc @ngxson @allozaur (server/ui maintainers per recent MCP proxy PRs #24500, #24970)
