### PR TITLE
kv-cache : fix SWA state save/load round-trip past n_swa

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1998,7 +1998,8 @@ void llama_kv_cache::state_write(llama_io_write_i & io, llama_seq_id seq_id, lla
             add_cell = add_cell && (seq_id == -1 || cells.seq_has(i, seq_id));
 
             // check the cell is not SWA-masked
-            if (add_cell && seq_id != -1) {
+            // never SWA-mask a per-seq dump: exact reload needs the full resident ring, not just the last n_swa cells
+            if (add_cell && seq_id != -1 && swa_type == LLAMA_SWA_TYPE_NONE) {
                 const bool is_masked = llama_hparams::is_masked_swa(n_swa, swa_type, cells.pos_get(i), cells.seq_pos_max(seq_id));
 
                 add_cell = !is_masked;
@@ -2260,15 +2261,31 @@ bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32
             ubatch.seq_id[i]   = &dest_seq_id;
         }
 
-        sinfo = find_slot(ubatch, false);
-        if (sinfo.empty()) {
-            LLAMA_LOG_ERROR("%s: failed to find %d available cells in kv cache\n", __func__,  cell_count);
-            return false;
-        }
+        // SWA sub-cache is a rolling ring buffer: place each cell at pos%size and set the ring head, not find_slot
+        if (swa_type != LLAMA_SWA_TYPE_NONE) {
+            const uint32_t size = cells.size();
+            sinfo.s0 = strm; sinfo.s1 = strm;
+            sinfo.resize(1);
+            sinfo.strm[0] = strm;
+            sinfo.idxs[0].resize(cell_count);
+            llama_pos max_pos = -1;
+            for (uint32_t i = 0; i < cell_count; ++i) {
+                sinfo.idxs[0][i] = (uint32_t) (ubatch.pos[i] % (llama_pos) size);
+                if (ubatch.pos[i] > max_pos) max_pos = ubatch.pos[i];
+            }
+            apply_ubatch(sinfo, ubatch);
+            v_heads[strm] = (uint32_t) ((max_pos + 1) % (llama_pos) size);
+        } else {
+            sinfo = find_slot(ubatch, false);
+            if (sinfo.empty()) {
+                LLAMA_LOG_ERROR("%s: failed to find %d available cells in kv cache\n", __func__,  cell_count);
+                return false;
+            }
 
-        // TODO: we cannot yet restore llama_kv_cell_ext as the apply_ubatch() does not support it yet
-        //       see: https://github.com/ggml-org/llama.cpp/pull/16825#issuecomment-3460868350
-        apply_ubatch(sinfo, ubatch);
+            // TODO: we cannot yet restore llama_kv_cell_ext as the apply_ubatch() does not support it yet
+            //       see: https://github.com/ggml-org/llama.cpp/pull/16825#issuecomment-3460868350
+            apply_ubatch(sinfo, ubatch);
+        }
 
         LLAMA_LOG_DEBUG("%s: cell_count = %d, dest_seq_id = %d\n", __func__, cell_count, dest_seq_id);
 
@@ -2290,6 +2307,18 @@ bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32
 
         clear(true);
 
+        // SWA sub-cache is a rolling ring buffer: restore each cell at pos%size with head=(max+1)%size, not contiguous slot i / head 0
+        const bool     is_swa = swa_type != LLAMA_SWA_TYPE_NONE;
+        const uint32_t size   = cells.size();
+
+        sinfo.s0 = strm;
+        sinfo.s1 = strm;
+        sinfo.resize(1);
+        sinfo.strm[0] = strm;
+        sinfo.idxs[0].resize(cell_count);
+
+        llama_pos max_pos = -1;
+
         for (uint32_t i = 0; i < cell_count; ++i) {
             llama_pos pos;
             uint32_t  n_seq_id;
@@ -2297,12 +2326,14 @@ bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32
             io.read(&pos,      sizeof(pos));
             io.read(&n_seq_id, sizeof(n_seq_id));
 
-            cells.pos_set(i, pos);
+            const uint32_t slot = is_swa ? (uint32_t) (pos % (llama_pos) size) : i;
+
+            cells.pos_set(slot, pos);
 
             if (hparams.n_pos_per_embd() > 1) {
                 llama_kv_cell_ext ext;
                 io.read(&ext, sizeof(ext));
-                cells.ext_set(i, ext);
+                cells.ext_set(slot, ext);
             }
 
             for (uint32_t j = 0; j < n_seq_id; ++j) {
@@ -2314,21 +2345,15 @@ bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32
                     return false;
                 }
 
-                cells.seq_add(i, seq_id);
+                cells.seq_add(slot, seq_id);
             }
+
+            sinfo.idxs[0][i] = slot;
+
+            if (pos > max_pos) max_pos = pos;
         }
 
-        // Create contiguous slot_info for whole cache restore
-        sinfo.s0 = strm;
-        sinfo.s1 = strm;
-        sinfo.resize(1);
-        sinfo.strm[0] = strm;
-        sinfo.idxs[0].resize(cell_count);
-        for (uint32_t i = 0; i < cell_count; ++i) {
-            sinfo.idxs[0][i] = i;
-        }
-
-        head = 0;
+        head = is_swa ? (uint32_t) ((max_pos + 1) % (llama_pos) size) : 0;
     }
 
     return true;


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
The SWA sub-cache is a rolling ring buffer (cell = pos % size, head = (max_pos+1) % size), but state save/load did not preserve that geometry, so saving a sequence longer than `n_swa` and reloading it produced a different continuation. Also the full swa kvcache layer is needed instead of only `n_swa` slide to give identical results. 

Three fixes in `llama-kv-cache.cpp`:
  - `state_write` (per-seq): stop SWA-masking the dump; ship the full resident ring.
  - `state_read_meta` (per-seq): place SWA cells at pos%size and set the ring head.
  - `state_read_meta` (whole-cache): same ring placement instead of contiguous slots. Base (full-attention) placement is unchanged. 
  
Fixes `test-save-load-state` on SWA models (e.g. gpt-oss, `n_swa=128`) for prompts longer than `n_swa` (#25295 ).

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
The fixes maybe temporary as it discard the find_slot part.

Abalation study: I name the fixes above as F1, F2, F3 and see how it affects the `test-save-load-state`:

F1 only: n_prompt=200/1000 both fail
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 200  -ub 512 -n 16
0.00.513.725 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.513.731 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.513.880 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.113 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.515.041 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.046.262 I main: no prompt provided, generating 200 (n_batch) random tokens
0.01.046.274 I main: the input prompt is 200 tokens
0.01.510.374 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 200

=== Test 1: baseline ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 

=== Test 2: state load ===
27005 106520 30284 92745 121748 1260 2936 93868 1495 499 27 91 180870 105909 62 7866 0.02.175.194 E 
test_state_load: error: generation differs from expected
```
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 1000  -ub 512 -n 16
0.00.517.136 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.143 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.283 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.498 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.518.384 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.052.593 I main: no prompt provided, generating 1000 (n_batch) random tokens
0.01.052.617 I main: the input prompt is 1000 tokens
0.02.239.506 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 1000

=== Test 1: baseline ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 

=== Test 2: state load ===
31166 114348 35187 84033 108381 2293 3748 113923 2337 256 220 7959 7959 81409 720 258 0.02.919.907 E 
test_state_load: error: generation differs from expected
```

F2 only: n_prompt=200/1000 both fail
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 200  -ub 512 -n 16
0.00.516.107 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.112 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.259 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.478 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.365 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.049.414 I main: no prompt provided, generating 200 (n_batch) random tokens
0.01.049.427 I main: the input prompt is 200 tokens
0.01.512.457 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 200

=== Test 1: baseline ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 

=== Test 2: state load ===
27005 106520 30284 92745 121748 1260 2936 93868 1495 499 27 91 180870 105909 62 7866 0.02.176.811 E 
test_state_load: error: generation differs from expected
```
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 1000  -ub 512 -n 16
0.00.516.845 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.848 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.998 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.225 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.518.120 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.049.874 I main: no prompt provided, generating 1000 (n_batch) random tokens
0.01.049.899 I main: the input prompt is 1000 tokens
0.02.238.540 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 1000

=== Test 1: baseline ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 

=== Test 2: state load ===
31166 114348 35187 84033 108381 2293 3748 113923 2337 256 220 7959 7959 81409 720 258 0.02.926.470 E 
test_state_load: error: generation differs from expected
```

F3 only: n_prompt=200/1000 both fail
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 200  -ub 512 -n 16
0.00.514.813 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.817 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.959 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.515.175 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.057 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.047.289 I main: no prompt provided, generating 200 (n_batch) random tokens
0.01.047.300 I main: the input prompt is 200 tokens
0.01.514.009 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 200

=== Test 1: baseline ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 

=== Test 2: state load ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 
PASS

=== Test 3: seq copy (host) ===
27005 106523 48296 91536 105860 493 1436 100810 865 378 27 91 180870 105909 62 7920 0.02.678.597 E 
test_seq_cp_host: error: generation differs from expected
```
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 1000  -ub 512 -n 16
0.00.517.961 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.966 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.518.113 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.518.339 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.519.263 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.051.031 I main: no prompt provided, generating 1000 (n_batch) random tokens
0.01.051.057 I main: the input prompt is 1000 tokens
0.02.244.613 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 1000

=== Test 1: baseline ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 

=== Test 2: state load ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 
PASS

=== Test 3: seq copy (host) ===
31166 114346 54395 88522 135417 3100 1163 116350 108 2103 27 91 180870 105909 62 7920 0.03.434.185 E 
test_seq_cp_host: error: generation differs from expected
```

F1+F2: n_prompt=200/1000 both fail
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 200  -ub 512 -n 16
0.00.514.383 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.389 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.530 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.745 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.515.646 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.047.393 I main: no prompt provided, generating 200 (n_batch) random tokens
0.01.047.407 I main: the input prompt is 200 tokens
0.01.509.181 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 200

=== Test 1: baseline ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 

=== Test 2: state load ===
27005 106520 30284 92745 121748 1260 2936 93868 1495 499 27 91 180870 105909 62 7866 0.02.177.621 E 
test_state_load: error: generation differs from expected
```
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 1000  -ub 512 -n 16
0.00.513.961 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.513.967 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.113 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.335 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.515.221 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.047.845 I main: no prompt provided, generating 1000 (n_batch) random tokens
0.01.047.865 I main: the input prompt is 1000 tokens
0.02.237.172 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 1000

=== Test 1: baseline ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 

=== Test 2: state load ===
31166 114348 35187 84033 108381 2293 3748 113923 2337 256 220 7959 7959 81409 720 258 0.02.922.821 E 
test_state_load: error: generation differs from expected
```

F1+F3: n_prompt=200 passes but n_prompt=1000 fails
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 200  -ub 512 -n 16
0.00.516.210 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.215 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.360 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.579 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.479 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.049.906 I main: no prompt provided, generating 200 (n_batch) random tokens
0.01.049.915 I main: the input prompt is 200 tokens
0.01.513.436 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 200

=== Test 1: baseline ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 

=== Test 2: state load ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 
PASS

=== Test 3: seq copy (host) ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 
PASS

=== Test 4: seq copy (device) ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 
PASS

All tests passed.
```
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 1000  -ub 512 -n 16
0.00.513.011 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.513.015 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.513.158 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.513.371 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.514.246 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.044.832 I main: no prompt provided, generating 1000 (n_batch) random tokens
0.01.044.852 I main: the input prompt is 1000 tokens
0.02.234.401 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 1000

=== Test 1: baseline ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 

=== Test 2: state load ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 
PASS

=== Test 3: seq copy (host) ===
31166 114347 41285 97008 135791 2988 2271 106559 2161 609 7 15354 4653 104077 716 286 0.03.424.888 E 
test_seq_cp_host: error: generation differs from expected
```

F1+F2+F3: n_prompt=200/1000 both pass
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 200  -ub 512 -n 16
0.00.516.571 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.577 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.730 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.516.954 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.859 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.050.477 I main: no prompt provided, generating 200 (n_batch) random tokens
0.01.050.488 I main: the input prompt is 200 tokens
0.01.514.586 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 200

=== Test 1: baseline ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 

=== Test 2: state load ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 
PASS

=== Test 3: seq copy (host) ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 
PASS

=== Test 4: seq copy (device) ===
27005 106523 48296 91535 116729 2390 2088 104127 2207 357 21 20246 11091 84681 579 327 
PASS

All tests passed.
```
```console
$ test-save-load-state -m gpt-oss-20b-mxfp4.gguf -ngl 99 -b 1000  -ub 512 -n 16
0.00.517.263 W load: setting token '<|message|>' (200008) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.270 W load: setting token '<|constrain|>' (200003) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.417 W load: setting token '<|channel|>' (200005) attribute to USER_DEFINED (16), old attributes: 8
0.00.517.636 W load: setting token '<|start|>' (200006) attribute to USER_DEFINED (16), old attributes: 8
0.00.518.514 W load: special_eog_ids contains both '<|return|>' and '<|call|>', or '<|calls|>' and '<|flush|>' tokens, removing '<|end|>' token from EOG list
0.01.050.362 I main: no prompt provided, generating 1000 (n_batch) random tokens
0.01.050.387 I main: the input prompt is 1000 tokens
0.02.239.415 I cmn  common_promp: saved session before last token to dump_state.bin, n_new = 1000

=== Test 1: baseline ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 

=== Test 2: state load ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 
PASS

=== Test 3: seq copy (host) ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 
PASS

=== Test 4: seq copy (device) ===
31166 114347 41285 97013 133944 3242 2661 104629 2057 786 32 14799 8928 69796 787 62 
PASS

All tests passed.
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
Yes. I used it to identify what different between baseline and save-load-state, fixes recommendation.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
