### PR TITLE
server-context: chain the caller-provided load_progress_callback instead of discarding it

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -970,11 +970,17 @@ private:
         std::string stage;
         std::vector<std::string> stages;
         int64_t t_last_load_progress_ms = 0;
+        llama_progress_callback orig_cb = nullptr;
+        void *                  orig_ud = nullptr;
         load_progress_data(server_context_impl * ctx, const std::string & stage) : ctx(ctx), stage(stage) {}
     };
     static bool load_progress_callback(float progress, void * user_data) {
         auto * d = static_cast<load_progress_data *>(user_data);
         GGML_ASSERT(d);
+        // chain the caller-provided callback unthrottled
+        if (d->orig_cb && !d->orig_cb(progress, d->orig_ud)) {
+            return false;
+        }
         // always emit the first and final sample; throttle the rest to one per 200ms
         {
             auto & t_last = d->t_last_load_progress_ms;
@@ -1008,6 +1014,13 @@ private:
 
         params_base = params;
         params_base.n_outputs_max = server_n_outputs_max(params_base);
+
+        load_progress_text.orig_cb   = params.load_progress_callback;
+        load_progress_text.orig_ud   = params.load_progress_callback_user_data;
+        load_progress_mmproj.orig_cb = params.load_progress_callback;
+        load_progress_mmproj.orig_ud = params.load_progress_callback_user_data;
+        load_progress_spec.orig_cb   = params.load_progress_callback;
+        load_progress_spec.orig_ud   = params.load_progress_callback_user_data;
 
         const bool has_mmproj = !params.mmproj.path.empty();
         const bool has_draft = params.speculative.has_dft();


### PR DESCRIPTION
## Overview

In order to update *llama-cli* model-loading capability (for instance, swapping models with a `/model` slash-command), model-loading should be able to be gracefully cancelled without exiting the application.

At the moment, server_context_impl::load_model() unconditionally overwrites params.load_progress_callback/_user_data with its own static load_progress_callback (pointed at its internal load_progress_data) before calling common_init_from_params():

```
params_base.load_progress_callback           = load_progress_callback;
params_base.load_progress_callback_user_data = &load_progress_text;
```

As a result, any embedder that links server-context and sets common_params.load_progress_callback to observe or cancel a model load has it silently dropped — the model loader only ever calls the engine's own callback. During llama_model_load the progress callback's false return is the only cancellation hook (the llama_context abort callback does not exist until after the load), so this effectively makes an in-progress load uncancellable for engine embedders, and llama-cli today sets no load callback at all.

This change captures the caller's {callback, user_data} at the top of load_model() and invokes it from the
engine's static callback, before the engine's own throttled state reporting:

```
if (d->orig_cb && !d->orig_cb(progress, d->orig_ud)) {
    return false;   // caller aborted the load
}
```

Compatibility

Strictly additive. When no caller callback is supplied (orig_cb == nullptr) behavior is identical to today;
existing callback_state / SERVER_STATE_LOADING reporting is unchanged.

Notes
  • The caller's callback is invoked per load stage (text / mmproj / spec), since each stage runs its own
    load_progress_data. A cancellation predicate is unaffected; a progress reporter should expect one 0→1 sweep
    per stage.
  • It is called before the engine's 200 ms callback_state throttle, so a cancel is not delayed up to 200 ms.
    The loader does not call it in a hot loop, so this is cheap.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, Claude helped me with analysis. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
