### PR TITLE
json-schema-to-grammar: harden _visit_pattern against malformed regex patterns

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -362,7 +362,12 @@ private:
             auto s = ls.first;
             return is_literal ? "\"" + s + "\"" : s;
         };
-        std::function<literal_or_rule()> transform = [&]() -> literal_or_rule {
+        const int MAX_PATTERN_NESTING = 100;
+        std::function<literal_or_rule(int)> transform = [&](int depth) -> literal_or_rule {
+            if (depth > MAX_PATTERN_NESTING) {
+                _errors.push_back("Pattern nesting too deep");
+                return std::make_pair("", false);
+            }
             size_t start = i;
             std::vector<literal_or_rule> seq;
 
@@ -436,7 +441,7 @@ private:
                             continue;
                         }
                     }
-                    seq.emplace_back("(" + to_rule(transform()) + ")", false);
+                    seq.emplace_back("(" + to_rule(transform(depth + 1)) + ")", false);
                 } else if (c == ')') {
                     i++;
                     if (start > 0 && sub_pattern[start - 1] != '(' && (start < 2 || sub_pattern[start - 2] != '?' || sub_pattern[start - 1] != ':')) {
@@ -465,8 +470,13 @@ private:
                     seq.emplace_back("|", false);
                     i++;
                 } else if (c == '*' || c == '+' || c == '?') {
-                    seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
-                    i++;
+                    if (seq.empty()) {
+                        _errors.push_back("Quantifier with nothing to repeat");
+                        i++;
+                    } else {
+                        seq.back() = std::make_pair(to_rule(seq.back()) + c, false);
+                        i++;
+                    }
                 } else if (c == '{') {
                     std::string curly_brackets = std::string(1, c);
                     i++;
@@ -497,6 +507,10 @@ private:
                         }
                     } catch (const std::invalid_argument & e) {
                         _errors.push_back("Invalid number in curly brackets");
+                        return std::make_pair("", false);
+                    }
+                    if (seq.empty()) {
+                        _errors.push_back("Repetition with nothing to repeat");
                         return std::make_pair("", false);
                     }
                     auto &last = seq.back();
@@ -551,7 +565,7 @@ private:
             }
             return join_seq();
         };
-        return _add_rule(name, "\"\\\"\" (" + to_rule(transform()) + ") \"\\\"\"");
+        return _add_rule(name, "\"\\\"\" (" + to_rule(transform(0)) + ") \"\\\"\"");
     }
 
     /*


### PR DESCRIPTION
Two crashes in `_visit_pattern` (`common/json-schema-to-grammar.cpp`) reachable from an attacker-influenced JSON-schema `pattern` e.g. a `response_format` grammar submitted to the server:

1. **Null dereference / SIGSEGV.** `seq.back()` is called with no `seq.empty()` guard at the `*`/`+`/`?` handler and the `{n,m}` handler. A quantifier with nothing to repeat — for example after an unhandled lookbehind `(?<=x)`, which pushes nothing onto `seq` dereferences an empty vector.
2. **Stack overflow.** `transform()` recurses once per nested `(` with no depth limit, so a deeply-nested pattern overflows the stack.

### Fix
- Guard `seq.empty()` before both `seq.back()` sites; on a malformed pattern, push a parse error to `_errors` (which the existing code at the end of the function turns into a thrown `std::invalid_argument`) instead of dereferencing.
- Cap `transform()` nesting depth (`MAX_PATTERN_NESTING`).

### Validation (built against this commit)
- **Before:** both inputs crash — the empty-`seq` case SIGSEGVs, the deep-nesting case overflows the stack.
- **After:** both are rejected cleanly with `JSON schema conversion failed: Quantifier with nothing to repeat` / `Pattern nesting too deep`; `test-json-schema-to-grammar` passes unchanged.

Fixes #25284
Fixes #25283
