### PR TITLE
loader: map sparse mmap tensor ranges

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1450,7 +1450,7 @@ bool llama_model_loader::load_all_data(
         }
         // When not using mmaped io use async uploads from pinned memory to GPU memory.
         // First determine if the backend supports the necessary features for async uploads.
-        auto * buf = bufs.count(0) ? bufs.at(0) : nullptr;
+        auto * buf = llama_buf_map_first(bufs);
         if (!buf) {
             LLAMA_LOG_DEBUG("%s: no buffer found for async uploads\n", func);
             return nullptr;
@@ -1521,7 +1521,7 @@ bool llama_model_loader::load_all_data(
     if (upload_backend) {
         LLAMA_LOG_DEBUG("%s: using async uploads for device %s, buffer type %s, backend %s\n", __func__,
             ggml_backend_dev_name(ggml_backend_get_device(upload_backend)),
-            ggml_backend_buft_name(ggml_backend_buffer_get_type(bufs.at(0))),
+            ggml_backend_buft_name(ggml_backend_buffer_get_type(llama_buf_map_first(bufs))),
             ggml_backend_name(upload_backend));
     }
 
@@ -1542,11 +1542,8 @@ bool llama_model_loader::load_all_data(
 
         if (use_mmap) {
             const auto & mapping = mappings.at(weight->idx);
-            ggml_backend_buffer_t buf_mmap = nullptr;
-            if (bufs.count(weight->idx)) {
-                buf_mmap = bufs.at(weight->idx);
-            }
             uint8_t * data = (uint8_t *) mapping->addr() + weight->offs;
+            ggml_backend_buffer_t buf_mmap = llama_buf_map_find(bufs, weight->idx, weight->offs, n_size);
 
             if (check_tensors) {
                 validation_result.emplace_back(std::async(std::launch::async, [cur, data, n_size] {

--- a/src/llama-model-loader.h
+++ b/src/llama-model-loader.h
@@ -11,11 +11,41 @@
 
 #include <cstddef>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <stdexcept>
 #include <unordered_map>
+#include <vector>
 
-using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
+struct llama_buf_range {
+    uint32_t idx;
+    size_t first;
+    size_t last;
+    ggml_backend_buffer_t buf;
+};
+
+using llama_buf_map = std::vector<llama_buf_range>;
+
+static inline void llama_buf_map_add(llama_buf_map & bufs, uint32_t idx, ggml_backend_buffer_t buf, size_t first = 0, size_t last = std::numeric_limits<size_t>::max()) {
+    bufs.push_back({ idx, first, last, buf });
+}
+
+static inline ggml_backend_buffer_t llama_buf_map_first(const llama_buf_map & bufs) {
+    return bufs.empty() ? nullptr : bufs.front().buf;
+}
+
+static inline ggml_backend_buffer_t llama_buf_map_find(const llama_buf_map & bufs, uint32_t idx, size_t offs, size_t size) {
+    if (offs + size < offs) {
+        return nullptr;
+    }
+    const size_t end = offs + size;
+    for (const llama_buf_range & range : bufs) {
+        if (range.idx == idx && offs >= range.first && end <= range.last) {
+            return range.buf;
+        }
+    }
+    return nullptr;
+}
 
 // lists of buffer types used for each layer
 using buft_list_t = std::vector<std::pair<ggml_backend_dev_t, ggml_backend_buffer_type_t>>;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1532,24 +1532,57 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         std::vector<ggml_backend_buffer_ptr> bufs;
         if (ml.use_mmap && use_mmap_buffer && buffer_from_host_ptr_supported && is_default_buft) {
             GGML_ASSERT(!ml.no_alloc);
+            struct mmap_span {
+                size_t first;
+                size_t last;
+            };
+            constexpr size_t mmap_coalesce_gap = 64ull * 1024ull * 1024ull;
             for (uint32_t idx = 0; idx < ml.files.size(); idx++) {
-                // only the mmap region containing the tensors in the model is mapped to the backend buffer
-                // this is important for metal with apple silicon: if the entire model could be mapped to a metal buffer,
-                //     then we could just use metal for all layers
-                // this allows using partial offloading when the model size exceeds the metal buffer size, but not the RAM size
                 void * addr = nullptr;
                 size_t first, last; // NOLINT
                 ml.get_mapping_range(&first, &last, &addr, idx, ctx);
                 if (first >= last) {
                     continue;
                 }
-                const size_t max_size = ggml_get_max_tensor_size(ctx);
-                ggml_backend_buffer_t buf = ggml_backend_dev_buffer_from_host_ptr(dev, (char *) addr + first, last - first, max_size);
-                if (buf == nullptr) {
-                    throw std::runtime_error(format("unable to allocate %s buffer", ggml_backend_buft_name(buft)));
+
+                std::vector<mmap_span> spans;
+                for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+                    const auto * weight = ml.get_weight(ggml_get_name(t));
+                    if (!weight || weight->idx != idx) {
+                        continue;
+                    }
+                    spans.push_back({ weight->offs, weight->offs + ggml_nbytes(t) });
                 }
-                bufs.emplace_back(buf);
-                buf_map.emplace(idx, buf);
+                std::sort(spans.begin(), spans.end(), [](const mmap_span & a, const mmap_span & b) {
+                    return a.first < b.first;
+                });
+
+                std::vector<mmap_span> ranges;
+                for (const mmap_span & span : spans) {
+                    if (ranges.empty() || span.first > ranges.back().last + mmap_coalesce_gap) {
+                        ranges.push_back(span);
+                    } else {
+                        ranges.back().last = std::max(ranges.back().last, span.last);
+                    }
+                }
+
+                const size_t max_size = ggml_get_max_tensor_size(ctx);
+                if (ranges.size() > 1) {
+                    LLAMA_LOG_INFO("%s: mapping %zu sparse mmap ranges for %s file %u instead of one %.2f GiB span\n",
+                            __func__, ranges.size(), ggml_backend_buft_name(buft), idx, (last - first) / 1024.0 / 1024.0 / 1024.0);
+                }
+                for (const mmap_span & range : ranges) {
+                    ggml_backend_buffer_t buf = ggml_backend_dev_buffer_from_host_ptr(dev, (char *) addr + range.first, range.last - range.first, max_size);
+                    if (buf == nullptr) {
+                        throw std::runtime_error(format("unable to allocate %s buffer", ggml_backend_buft_name(buft)));
+                    }
+                    bufs.emplace_back(buf);
+                    llama_buf_map_add(buf_map, idx, buf, range.first, range.last);
+                    LLAMA_LOG_INFO("%s: mapped %s mmap range file %u offset %.2f GiB size %.2f MiB\n",
+                            __func__, ggml_backend_buft_name(buft), idx,
+                            range.first / 1024.0 / 1024.0 / 1024.0,
+                            (range.last - range.first) / 1024.0 / 1024.0);
+                }
             }
         } else {
             ggml_backend_buffer_t buf;
@@ -1572,7 +1605,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             }
             bufs.emplace_back(buf);
             for (uint32_t idx = 0; idx < ml.files.size(); idx++) {
-                buf_map.emplace(idx, buf);
+                llama_buf_map_add(buf_map, idx, buf);
             }
         }
 


### PR DESCRIPTION
## Summary

This changes mmap-backed backend buffer creation so tensor buffer overrides can map multiple sparse file ranges instead of one large span per file.

On Apple Silicon/Metal, a model may have only a subset of tensors assigned to a backend buffer while large skipped tensors remain between them in the GGUF file. Mapping the full `[first, last)` span can make Metal attempt to create a buffer that covers unused gaps, which can fail or waste addressable GPU buffer space.

## Changes

- Replace the single `idx -> buffer` loader map with range-aware entries.
- Coalesce tensor spans only across small gaps (`64 MiB`) and create one backend mmap buffer per coalesced range.
- Resolve each tensor load through `(file idx, offset, size)` so tensors land in the correct sparse range buffer.
- Keep non-mmap allocation behavior using one catch-all range per file.

## Validation

- Built locally on macOS/arm64 with Metal enabled:
  - `cmake --build build --target llama-cli -j 8`

This patch was originally extracted from a local Apple Silicon MoE/offload experiment where sparse mmap avoided Metal OOM when large routed expert tensors were overridden away from the default backend.