### PR TITLE
ggml-cuda : optimize conv_transpose_1d indexing

### DIFF
--- a/ggml/src/ggml-cuda/conv-transpose-1d.cu
+++ b/ggml/src/ggml-cuda/conv-transpose-1d.cu
@@ -11,30 +11,32 @@ static  __global__ void conv_transpose_1d_kernel(
         return;
     }
 
-    int out_index = global_index / dst_ne0;
+    int out_t = global_index % dst_ne0;
+    int out_ch = (global_index / dst_ne0) % dst_ne1;
+    int plane = global_index / (dst_ne0 * dst_ne1);
 
     float accumulator = 0;
 
     for (int c = 0; c < src0_ne2; c++) {
-        int idx = global_index % dst_ne0;
+        int kernel_offset = src0_ne0 * (out_ch + src0_ne1 * c);
+        int input_offset = src1_ne0 * (c + src1_ne1 * plane);
 
-        int kernel_offset = (src0_ne0 * src0_ne1 * c) + (out_index * src0_ne0);
-        int input_offset = src1_ne0 * c;
-
-        for (int i = 0; i < src1_ne0; i++) {
-            if (!(idx >= i*s0 && idx < i*s0 + src0_ne0)) {
+        for (int k = 0; k < src0_ne0; k++) {
+            int input_numer = out_t + p0 - k*d0;
+            if (input_numer < 0 || input_numer % s0 != 0) {
                 continue;
             }
-            int weight_idx = idx - i*s0;
 
-            float kernel_weight = src0[kernel_offset + weight_idx];
-            float input_value =  src1[input_offset+i];
+            int input_t = input_numer / s0;
+            if (input_t >= src1_ne0) {
+                continue;
+            }
 
-            accumulator += kernel_weight * input_value;
+            accumulator += src0[kernel_offset + k] * src1[input_offset + input_t];
         }
     }
     dst[global_index] = accumulator;
-    GGML_UNUSED_VARS(p0, d0, src0_ne3, src1_ne3, dst_ne3, src1_ne1, dst_ne1, src1_ne2, dst_ne2);
+    GGML_UNUSED_VARS(src0_ne3, src1_ne2, src1_ne3, dst_ne2, dst_ne3);
 }
 
 static void conv_transpose_1d_f32_f32_cuda(


### PR DESCRIPTION
## Overview

this PR is there to change the CUDA conv_transpose_1d kernel to avoid scanning every input timestep for each output element. i encountered this issue while utilizing this kernel for LTX 2.3 on a GB10.

## Additional information

old behavior:
the old kernel checks each input position and then filters out positions that do not contribute. the updated kernel iterates over kernel taps, computes the possible contributing input timestep directly, validates it, and accumulates only valid contributors.

new behavior:

```text
before: input_channels * input_time
after:  input_channels * kernel_width
```

### Nsys tests

these measurements were taken on GB10 / DGX Spark.

```text
GPU:  NVIDIA GB10
CUDA: 13.0
arch: sm_121
```

the A/B profile used the same LTX-like `conv_transpose_1d` shape and the same launch count for the old and updated kernels.

```text
shape_output = 3093 x 256
shape_input  = 1546 x 256
kernel_width = 3
stride       = 2
iters        = 3
```

Nsight Systems CUDA kernel summary:

```text
old kernel:
  total      = 1.338 s
  instances  = 4
  avg        = 334.55 ms

direct-index kernel:
  total      = 0.0117 s
  instances  = 4
  avg        = 2.93 ms

nsys avg speedup = 114.03x
correctness max_abs = 1.49e-07
```

CUDA event timing from the same A/B harness:

```text
old kernel avg     = 337.84 ms
direct kernel avg  = 2.91 ms
speedup            = 115.92x
```

impact this had for denoising, based on a 2s 720p audio included video.

```text
audio VAE decode: 13.99 s -> 1.61 s
full wall time:   109.41 s -> 96.10 s
```
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) - yes
- AI usage disclosure: AI was used for the nsys benchmarking and execution. code and results of the benchmarks were validated by me. every line is properly understood within the file and in context to the repository.
