### PR TITLE
cuda, cpu : fix GQA head mapping in GDN kernel

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -10688,8 +10688,8 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
 
     const float * state_in_base = (const float *)src_state->data;
 
-  //const int64_t rq1 = nev1 / neq1;
-  //const int64_t rk1 = nev1 / nek1;
+    const int64_t rq1 = nev1 / neq1;
+    const int64_t rk1 = nev1 / nek1;
     const int64_t rq3 = nev3 / neq3;
     const int64_t rk3 = nev3 / nek3;
 
@@ -10699,8 +10699,8 @@ static void ggml_compute_forward_gated_delta_net_one_chunk(
         const int64_t iv1 = ir % H; // head_index
         const int64_t iv3 = ir / H; // sequence
 
-        const int64_t iq1 = iv1 % neq1;
-        const int64_t ik1 = iv1 % nek1;
+        const int64_t iq1 = iv1 / rq1;
+        const int64_t ik1 = iv1 / rk1;
 
         const int64_t iq3 = iv3 / rq3;
         const int64_t ik3 = iv3 / rk3;

--- a/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -34,7 +34,7 @@ gated_delta_net_cuda(const float * q,
     const int      lane     = threadIdx.x;
     const int      col      = blockIdx.z * blockDim.y + threadIdx.y;
 
-    const uint32_t iq1 = fastmodulo(h_idx, neqk1_magic);
+    const uint32_t iq1 = fastdiv(h_idx, neqk1_magic);
     const uint32_t iq3 = fastdiv(sequence, rq3_magic);
 
     float *       attn_data        = dst;
@@ -245,7 +245,7 @@ static void ggml_cuda_op_gated_delta_net_impl(
     const bool kda = (src_g->ne[0] == S_v);
 
     GGML_ASSERT(neq1 == nek1);
-    const int64_t neqk1 = neq1;
+    const int64_t neqk1 = nev1 / neq1;
 
     const int64_t rq3 = nev3 / neq3;
 


### PR DESCRIPTION
## Overview

Fixes GQA head index computation in both CUDA and CPU backends. With v_repeat > 1, the kernel used modulo instead of division to map value heads to query/key heads, causing wrong Q/K data to be read.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted in implementing and testing the fix under my review and direction.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
