### PR TITLE
server: evict LRU resident model on load failure (VRAM pressure)

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -798,6 +798,25 @@ std::vector<server_model_meta> server_models::get_all_meta() {
     return result;
 }
 
+std::string server_models::pick_lru_running_model(const std::string & exclude) const {
+    // Returns the name of the least-recently-used model that is currently
+    // running (loaded/loading/sleeping), excluding the given name. Returns ""
+    // if there is no such model. Used to find a victim to evict when a load
+    // fails, which most often means there is not enough VRAM to coexist.
+    std::string lru_name;
+    int64_t     lru_last_used = ggml_time_ms();
+    for (const auto & m : mapping) {
+        if (m.first == exclude) {
+            continue;
+        }
+        if (m.second.meta.is_running() && m.second.meta.last_used < lru_last_used) {
+            lru_name      = m.first;
+            lru_last_used = m.second.meta.last_used;
+        }
+    }
+    return lru_name;
+}
+
 void server_models::unload_lru() {
     if (base_params.models_max <= 0) {
         return; // no limit
@@ -1261,9 +1280,33 @@ bool server_models::ensure_model_ready(const std::string & name) {
         return false;
     });
 
-    // check final status
+    // If the load failed and there are other models still resident, the most
+    // common cause is VRAM exhaustion from trying to coexist with them. The
+    // router's existing eviction is count-based (unload_lru only fires when the
+    // resident count reaches models_max), so it does not catch the case where a
+    // single large model leaves no room for a second one. Evict the
+    // least-recently-used resident model and retry the load once.
     if (!meta.has_value() || meta->is_failed()) {
-        throw std::runtime_error("model name=" + name + " failed to load");
+        std::string victim = pick_lru_running_model(/* exclude = */ name);
+        if (!victim.empty()) {
+            SRV_WRN("model name=%s failed to load, evicting resident model name=%s to free memory and retrying\n",
+                    name.c_str(), victim.c_str());
+            unload(victim);
+            wait(victim, [](const server_model_meta & m) {
+                return m.status == SERVER_MODEL_STATUS_UNLOADED;
+            });
+            load(name);
+            wait(name, [&meta](const server_model_meta & new_meta) {
+                if (new_meta.status != SERVER_MODEL_STATUS_LOADING) {
+                    meta = new_meta;
+                    return true;
+                }
+                return false;
+            });
+        }
+        if (!meta.has_value() || meta->is_failed()) {
+            throw std::runtime_error("model name=" + name + " failed to load");
+        }
     }
 
     return true;

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -179,6 +179,10 @@ private:
     // unload least recently used models if the limit is reached
     void unload_lru();
 
+    // pick the least-recently-used running model to evict on a failed load
+    // (e.g. due to VRAM pressure), excluding the model we are trying to load
+    std::string pick_lru_running_model(const std::string & exclude) const;
+
     // not thread-safe, caller must hold mutex
     void add_model(server_model_meta && meta);
 


### PR DESCRIPTION
## Summary

In router mode, model eviction is **count-based**: `unload_lru()` only fires when the resident model count reaches `--models-max`. It does not account for VRAM, so a single large resident model can leave no room for a second one. When a request for the second model arrives, the router tries to load it alongside, the child process OOMs, and the request fails with a `500` instead of evicting the resident model.

This is easy to hit in practice: on a 4×48 GB box serving a ~100 GB MoE model and a ~29 GB dense model, the two cannot coexist. With `--models-max 4` (the default-derived value), the router happily keeps the 100 GB model resident and then fails every request for the 29 GB one until a manual restart.

## Change

In `ensure_model_ready()`: when a load fails **and** there is at least one other running model, evict the least-recently-used resident model and retry the load once.

- Adds `pick_lru_running_model(exclude)` — returns the LRU model that is currently running, excluding the model being loaded. Mirrors the selection logic already in `unload_lru()` but without the `models_max` gate and safe to call outside the count-limit path.
- The retry is a single attempt; if it still fails, the original `failed to load` error is thrown as before.
- The victim is waited on until it reaches `UNLOADED` before the retry, so the freed VRAM is actually available.

This makes large-model coexistence work without manual intervention: loading a model that does not fit now auto-evicts the old one, which is the behavior users naturally expect.

## Related

- #24851 — router-mode `/metrics` fan-out (other router-mode server PR by the same author)
- #24850 — expose cache / speculative-decode / resource metrics (other router-mode server PR by the same author)

## Testing

Reproduced the OOM-on-coexistence failure, then verified the retry path:
1. Load the large model (resident, ~100 GB across 4 GPUs).
2. Request the smaller model → child OOMs on first load → router logs `failed to load, evicting resident model name=... to free memory and retrying` → victim unloaded → smaller model loads and serves the request successfully.

No regressions on the normal single-model load path (no resident models ⇒ no victim ⇒ original error behavior preserved).