### PR TITLE
server: expose speculative decoding metrics

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -809,6 +809,10 @@ struct server_metrics {
     uint64_t n_decode_total     = 0;
     uint64_t n_busy_slots_total = 0;
 
+    uint64_t n_draft_tokens_total    = 0;
+    uint64_t n_draft_tokens_accepted = 0;
+    uint64_t n_draft_verify_steps    = 0;
+
     void init() {
         t_start = ggml_time_us();
     }
@@ -827,6 +831,12 @@ struct server_metrics {
         n_tokens_predicted         += slot.n_decoded;
         t_tokens_generation        += slot.t_token_generation;
         t_tokens_generation_total  += slot.t_token_generation;
+    }
+
+    void on_draft_stats(const server_slot & slot) {
+        n_draft_tokens_total    += (uint64_t) slot.n_draft_total;
+        n_draft_tokens_accepted += (uint64_t) slot.n_draft_accepted;
+        n_draft_verify_steps    += (uint64_t) slot.n_draft_verif_steps;
     }
 
     void on_decoded(const std::vector<server_slot> & slots) {
@@ -2184,6 +2194,8 @@ private:
 
         res->generation_params = slot.task->params; // copy the parameters
 
+        metrics.on_draft_stats(slot);
+
         queue_results.send(std::move(res));
     }
 
@@ -2535,6 +2547,10 @@ private:
 
                     res->n_decode_total          = metrics.n_decode_total;
                     res->n_busy_slots_total      = metrics.n_busy_slots_total;
+
+                    res->n_draft_tokens_total    = metrics.n_draft_tokens_total;
+                    res->n_draft_tokens_accepted = metrics.n_draft_tokens_accepted;
+                    res->n_draft_verify_steps    = metrics.n_draft_verify_steps;
 
                     if (task.metrics_reset_bucket) {
                         metrics.reset_bucket();
@@ -4430,6 +4446,18 @@ void server_routes::init_routes() {
                     {"name",  "n_tokens_max"},
                     {"help",  "Largest observed n_tokens."},
                     {"value",  res_task->n_tokens_max}
+            }, {
+                    {"name",  "draft_tokens_total"},
+                    {"help",  "Speculative decoding: number of draft tokens proposed."},
+                    {"value",  res_task->n_draft_tokens_total}
+            }, {
+                    {"name",  "draft_tokens_accepted_total"},
+                    {"help",  "Speculative decoding: number of draft tokens accepted by the target model."},
+                    {"value",  res_task->n_draft_tokens_accepted}
+            }, {
+                    {"name",  "draft_verify_steps_total"},
+                    {"help",  "Speculative decoding: number of draft verification steps."},
+                    {"value",  res_task->n_draft_verify_steps}
             }}},
             {"gauge", {{
                     {"name",  "prompt_tokens_seconds"},
@@ -4451,6 +4479,14 @@ void server_routes::init_routes() {
                     {"name",  "n_busy_slots_per_decode"},
                     {"help",  "Average number of busy slots per llama_decode() call"},
                     {"value",  (float) res_task->n_busy_slots_total / std::max((float) res_task->n_decode_total, 1.f)}
+            },{
+                    {"name",  "draft_acceptance_rate"},
+                    {"help",  "Speculative decoding: accepted / proposed draft tokens."},
+                    {"value",  res_task->n_draft_tokens_total ? (double) res_task->n_draft_tokens_accepted / (double) res_task->n_draft_tokens_total : 0.}
+            },{
+                    {"name",  "draft_mean_accept_len"},
+                    {"help",  "Speculative decoding: mean accepted sequence length per verification step, including the sampled token."},
+                    {"value",  res_task->n_draft_verify_steps ? 1.0 + (double) res_task->n_draft_tokens_accepted / (double) res_task->n_draft_verify_steps : 0.}
             }}}
         };
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -530,6 +530,10 @@ struct server_task_result_metrics : server_task_result {
     uint64_t n_decode_total     = 0;
     uint64_t n_busy_slots_total = 0;
 
+    uint64_t n_draft_tokens_total    = 0;
+    uint64_t n_draft_tokens_accepted = 0;
+    uint64_t n_draft_verify_steps    = 0;
+
     // while we can also use std::vector<server_slot> this requires copying the slot object which can be quite messy
     // therefore, we use json to temporarily store the slot.to_json() result
     json slots_data = json::array();

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -51,6 +51,30 @@ def test_with_and_without_draft():
     assert content_no_draft == content_draft
 
 
+def test_metrics():
+    global server
+    server.server_metrics = True
+    server.spec_type = "draft-simple"
+    server.spec_draft_n_min = 1
+    server.spec_draft_n_max = 4
+    server.start()
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "I believe the meaning of life is",
+        "temperature": 0.0,
+        "top_k": 1,
+        "n_predict": 16,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("GET", "/metrics")
+    assert res.status_code == 200
+    assert match_regex(r"llamacpp:draft_tokens_total\s+[1-9]", res.body)
+    assert match_regex(r"llamacpp:draft_tokens_accepted_total\s+\d+", res.body)
+    assert match_regex(r"llamacpp:draft_verify_steps_total\s+[1-9]", res.body)
+    assert "llamacpp:draft_acceptance_rate" in res.body
+    assert "llamacpp:draft_mean_accept_len" in res.body
+
+
 def test_different_draft_min_draft_max():
     global server
     test_values = [

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -94,6 +94,7 @@ class ServerProcess:
     enable_ctx_shift: int | None = False
     spec_draft_n_min: int | None = None
     spec_draft_n_max: int | None = None
+    spec_type: str | None = None
     no_ui: bool | None = None
     jinja: bool | None = None
     reasoning_format: Literal['deepseek', 'none', 'nothink'] | None = None
@@ -225,6 +226,8 @@ class ServerProcess:
             server_args.extend(["--spec-draft-n-max", self.spec_draft_n_max])
         if self.spec_draft_n_min:
             server_args.extend(["--spec-draft-n-min", self.spec_draft_n_min])
+        if self.spec_type:
+            server_args.extend(["--spec-type", self.spec_type])
         if self.no_ui:
             server_args.append("--no-ui")
         if self.no_models_autoload:


### PR DESCRIPTION
Adds a small, focused subset of the extended server metrics work from #24850: Prometheus metrics for speculative decoding activity.

New metrics:

- `llamacpp:draft_tokens_total`
- `llamacpp:draft_tokens_accepted_total`
- `llamacpp:draft_verify_steps_total`
- `llamacpp:draft_acceptance_rate`
- `llamacpp:draft_mean_accept_len`

The implementation follows the current upstream `/metrics` path: aggregate slot draft counters once when the final completion response is emitted, copy them into `server_task_result_metrics`, and render through the existing JSON metric-definition block.

Tested:

- `cmake --build build-cuda --config Release -j$(nproc) --target llama-server`
- `LLAMA_SERVER_BIN_PATH=$PWD/build-cuda/bin/llama-server N_GPU_LAYERS=0 tools/server/tests/tests.sh unit/test_speculative.py::test_metrics -q`