### PR TITLE
server: expose prompt cache metrics

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -809,6 +809,8 @@ struct server_metrics {
     uint64_t n_decode_total     = 0;
     uint64_t n_busy_slots_total = 0;
 
+    uint64_t n_prompt_tokens_cache_total = 0;
+
     void init() {
         t_start = ggml_time_us();
     }
@@ -818,6 +820,7 @@ struct server_metrics {
         n_prompt_tokens_processed       += slot.n_prompt_tokens_processed;
         t_prompt_processing             += slot.t_prompt_processing;
         t_prompt_processing_total       += slot.t_prompt_processing;
+        n_prompt_tokens_cache_total     += slot.n_prompt_tokens_cache;
 
         n_tokens_max = std::max(n_tokens_max, (uint64_t) slot.prompt.n_tokens());
     }
@@ -2535,6 +2538,8 @@ private:
 
                     res->n_decode_total          = metrics.n_decode_total;
                     res->n_busy_slots_total      = metrics.n_busy_slots_total;
+
+                    res->n_prompt_tokens_cache_total = metrics.n_prompt_tokens_cache_total;
 
                     if (task.metrics_reset_bucket) {
                         metrics.reset_bucket();
@@ -4430,6 +4435,10 @@ void server_routes::init_routes() {
                     {"name",  "n_tokens_max"},
                     {"help",  "Largest observed n_tokens."},
                     {"value",  res_task->n_tokens_max}
+            }, {
+                    {"name",  "prompt_tokens_cache_total"},
+                    {"help",  "Number of prompt tokens served from cache."},
+                    {"value",  res_task->n_prompt_tokens_cache_total}
             }}},
             {"gauge", {{
                     {"name",  "prompt_tokens_seconds"},
@@ -4451,6 +4460,10 @@ void server_routes::init_routes() {
                     {"name",  "n_busy_slots_per_decode"},
                     {"help",  "Average number of busy slots per llama_decode() call"},
                     {"value",  (float) res_task->n_busy_slots_total / std::max((float) res_task->n_decode_total, 1.f)}
+            },{
+                    {"name",  "prompt_cache_hit_ratio"},
+                    {"help",  "Fraction of prompt tokens served from cache."},
+                    {"value",  (res_task->n_prompt_tokens_cache_total + res_task->n_prompt_tokens_processed_total) ? (double) res_task->n_prompt_tokens_cache_total / (double) (res_task->n_prompt_tokens_cache_total + res_task->n_prompt_tokens_processed_total) : 0.}
             }}}
         };
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -530,6 +530,8 @@ struct server_task_result_metrics : server_task_result {
     uint64_t n_decode_total     = 0;
     uint64_t n_busy_slots_total = 0;
 
+    uint64_t n_prompt_tokens_cache_total = 0;
+
     // while we can also use std::vector<server_slot> this requires copying the slot object which can be quite messy
     // therefore, we use json to temporarily store the slot.to_json() result
     json slots_data = json::array();

--- a/tools/server/tests/unit/test_metrics.py
+++ b/tools/server/tests/unit/test_metrics.py
@@ -1,0 +1,37 @@
+import pytest
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+
+
+def test_prompt_cache_metrics():
+    global server
+    server.server_metrics = True
+    server.n_slots = 1
+    server.start()
+
+    req = {
+        "prompt": "I believe the meaning of life is",
+        "temperature": 0.0,
+        "top_k": 1,
+        "n_predict": 8,
+        "cache_prompt": True,
+    }
+
+    res = server.make_request("POST", "/completion", data=req)
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/completion", data=req)
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] > 0
+
+    res = server.make_request("GET", "/metrics")
+    assert res.status_code == 200
+    assert match_regex(r"llamacpp:prompt_tokens_cache_total\s+[1-9]", res.body)
+    assert "llamacpp:prompt_cache_hit_ratio" in res.body


### PR DESCRIPTION
Adds a small, focused subset of the extended server metrics work from #24850: prompt-cache reuse metrics.

New metrics:

- `llamacpp:prompt_tokens_cache_total`
- `llamacpp:prompt_cache_hit_ratio`

The counter aggregates `slot.n_prompt_tokens_cache` in the existing prompt-eval metrics path, then renders through the current JSON metric-definition block used by `/metrics`.

Tested:

- `cmake --build build-cuda --config Release -j$(nproc) --target llama-server`
- `LLAMA_SERVER_BIN_PATH=$PWD/build-cuda/bin/llama-server N_GPU_LAYERS=0 tools/server/tests/tests.sh unit/test_metrics.py::test_prompt_cache_metrics -q`