### PR TITLE
server: expose model resource metrics

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2536,6 +2536,12 @@ private:
                     res->n_decode_total          = metrics.n_decode_total;
                     res->n_busy_slots_total      = metrics.n_busy_slots_total;
 
+                    if (model_tgt != nullptr) {
+                        res->model_size_bytes = llama_model_size(model_tgt);
+                        res->model_n_params   = llama_model_n_params(model_tgt);
+                    }
+                    res->n_ctx_total = (uint64_t) n_ctx;
+
                     if (task.metrics_reset_bucket) {
                         metrics.reset_bucket();
                     }
@@ -4451,6 +4457,18 @@ void server_routes::init_routes() {
                     {"name",  "n_busy_slots_per_decode"},
                     {"help",  "Average number of busy slots per llama_decode() call"},
                     {"value",  (float) res_task->n_busy_slots_total / std::max((float) res_task->n_decode_total, 1.f)}
+            },{
+                    {"name",  "model_size_bytes"},
+                    {"help",  "Model weights size in bytes."},
+                    {"value",  res_task->model_size_bytes}
+            },{
+                    {"name",  "model_n_params"},
+                    {"help",  "Number of model parameters."},
+                    {"value",  res_task->model_n_params}
+            },{
+                    {"name",  "n_ctx"},
+                    {"help",  "Total context size across all slots."},
+                    {"value",  res_task->n_ctx_total}
             }}}
         };
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -530,6 +530,10 @@ struct server_task_result_metrics : server_task_result {
     uint64_t n_decode_total     = 0;
     uint64_t n_busy_slots_total = 0;
 
+    uint64_t model_size_bytes = 0;
+    uint64_t model_n_params   = 0;
+    uint64_t n_ctx_total      = 0;
+
     // while we can also use std::vector<server_slot> this requires copying the slot object which can be quite messy
     // therefore, we use json to temporarily store the slot.to_json() result
     json slots_data = json::array();

--- a/tools/server/tests/unit/test_metrics.py
+++ b/tools/server/tests/unit/test_metrics.py
@@ -1,0 +1,22 @@
+import pytest
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+
+
+def test_model_resource_metrics():
+    global server
+    server.server_metrics = True
+    server.start()
+
+    res = server.make_request("GET", "/metrics")
+    assert res.status_code == 200
+    assert match_regex(r"llamacpp:model_size_bytes\s+[1-9]", res.body)
+    assert match_regex(r"llamacpp:model_n_params\s+[1-9]", res.body)
+    assert match_regex(r"llamacpp:n_ctx\s+[1-9]", res.body)


### PR DESCRIPTION
Adds a small, focused subset of the extended server metrics work from #24850: unambiguous model resource gauges.

New metrics:

- `llamacpp:model_size_bytes`
- `llamacpp:model_n_params`
- `llamacpp:n_ctx`

These values come from the loaded model/context and are rendered through the current `/metrics` JSON metric-definition block.

This intentionally does not add the old `kv_cache_bytes` metric: the public `llama_state_get_size()` API reports serialized state size, not KV-cache allocation bytes, so a KV/cache memory metric should wait for a dedicated public memory accounting API.

Tested:

- `cmake --build build-cuda --config Release -j$(nproc) --target llama-server`
- `LLAMA_SERVER_BIN_PATH=$PWD/build-cuda/bin/llama-server N_GPU_LAYERS=0 tools/server/tests/tests.sh unit/test_metrics.py::test_model_resource_metrics -q`