### PR TITLE
ggml-cpu: use UE4M3 LUT in ARM NVFP4 dot product

### DIFF
--- a/ggml/src/ggml-cpu/arch/arm/quants.c
+++ b/ggml/src/ggml-cpu/arch/arm/quants.c
@@ -812,10 +812,10 @@ void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
         const float dy0 = GGML_CPU_FP16_TO_FP32(y[2*ib].d);
         const float dy1 = GGML_CPU_FP16_TO_FP32(y[2*ib+1].d);
         const float32x4_t nvsc = {
-            ggml_ue4m3_to_fp32(x[ib].d[0]),
-            ggml_ue4m3_to_fp32(x[ib].d[1]),
-            ggml_ue4m3_to_fp32(x[ib].d[2]),
-            ggml_ue4m3_to_fp32(x[ib].d[3])
+            GGML_CPU_UE4M3_TO_FP32(x[ib].d[0]),
+            GGML_CPU_UE4M3_TO_FP32(x[ib].d[1]),
+            GGML_CPU_UE4M3_TO_FP32(x[ib].d[2]),
+            GGML_CPU_UE4M3_TO_FP32(x[ib].d[3])
         };
         const float32x4_t scales = vmulq_f32(nvsc, (float32x4_t){dy0, dy0, dy1, dy1});
 

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -131,8 +131,8 @@ extern float ggml_table_f32_ue4m3[1 << 8];
 #define GGML_CPU_E8M0_TO_FP32_HALF(x) GGML_E8M0_TO_FP32_HALF(x)
 #endif
 
-// Use lookup table for UE4M3 on x86 (faster than bit manipulation)
-#if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__)
+// Use lookup table for UE4M3 on x86 and ARM (faster than bit manipulation)
+#if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__ARM_NEON)
 #define GGML_CPU_UE4M3_TO_FP32(x) ggml_table_f32_ue4m3[(uint8_t)(x)]
 #else
 #define GGML_CPU_UE4M3_TO_FP32(x) ggml_ue4m3_to_fp32(x)


### PR DESCRIPTION
## Overview

This PR extends the UE4M3 lookup table optimization introduced in #23961 to the ARM implementation of the NVFP4 dot product.

The ARM implementation now uses the existing `GGML_CPU_UE4M3_TO_FP32` lookup table for UE4M3 scale decoding. This aligns the ARM implementation with the x86 implementation while reusing the shared lookup table infrastructure.

## Additional Information

**Test machine:**

- **CPU:** AWS Graviton2 (Neoverse-N1)
- **Cores/Threads:** 4/4
- **Architecture:** aarch64
- **OS:** Ubuntu 26.04 LTS (GNU/Linux 7.0.0-1006-aws)
- **Relevant CPU flags:** `fp asimd aes pmull sha1 sha2 crc32 atomics fphp asimdhp asimdrdm asimddp`

## llama-bench

### Baseline (master)

Command:

```sh
./build-master/bin/llama-bench -m models/Qwen3.5-4B-NVFP4.gguf -p 512 -n 0 -r 5
```

| model | size | params | backend | threads | test | t/s |
| --- | ---: | ---: | --- | ---: | ---: | ---: |
| qwen35 4B NVFP4 | 3.28 GiB | 4.33 B | CPU | 4 | pp512 | **1.89 ± 0.00** |

### This PR

Command:

```sh
./build-lut/bin/llama-bench -m models/Qwen3.5-4B-NVFP4.gguf -p 512 -n 0 -r 5
```

| model | size | params | backend | threads | test | t/s |
| --- | ---: | ---: | --- | ---: | ---: | ---: |
| qwen35 4B NVFP4 | 3.28 GiB | 4.33 B | CPU | 4 | pp512 | **9.97 ± 0.07** |

## Functional Verification

Command:

```sh
./build-lut/bin/test-quantize-fns -v
```

```text
Testing nvfp4
nvfp4 absolute quantization error:    ok (0.002337)
nvfp4 reference implementation error: ok (0.000000)
nvfp4 dot product error:              ok (0.019774)
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO, I wrote the optimization part myself.