### PR TITLE
fix: load qwen35 Ollama GGUF exports

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -398,6 +398,7 @@ namespace GGUFMeta {
 
     template bool llama_model_loader::get_arr<std::vector<std::string>>(enum llm_kv kid, std::vector<std::string> & result, bool required);
     template bool llama_model_loader::get_arr<std::array<int32_t, 512>>(enum llm_kv kid, std::array<int32_t, 512> & result, bool required);
+    template bool llama_model_loader::get_arr<std::array<int32_t, 4>>(enum llm_kv kid, std::array<int32_t, 4> & result, bool required);
     template bool llama_model_loader::get_arr<std::vector<int32_t>>(enum llm_kv kid, std::vector<int32_t> & result, bool required);
     template bool llama_model_loader::get_arr<std::array<uint32_t, LLAMA_MAX_LAYERS>>(enum llm_kv kid, std::array<uint32_t, LLAMA_MAX_LAYERS> & result, bool required);
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1486,7 +1486,9 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             }
         }
     }
-    ml.done_getting_tensors();
+    // Ollama-exported qwen35/qwen35moe GGUFs bundle vision (v.*) and MTP (mtp.*)
+    // sibling tensors the text model does not use
+    ml.done_getting_tensors(arch == LLM_ARCH_QWEN35 || arch == LLM_ARCH_QWEN35MOE);
 
     // Tied NVFP4 output is valid when no separate LM-head scale tensors are present.
     // If sidecar scales exist, the output weight must be an actual output tensor.

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -3,7 +3,10 @@
 
 void llama_model_qwen35::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
-    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
+    // some GGUFs (e.g. Ollama exports) store 3 rope sections instead of 4;
+    // accept either length and leave trailing sections zeroed
+    hparams.rope_sections.fill(0);
+    ml.get_arr(LLM_KV_ROPE_DIMENSION_SECTIONS, hparams.rope_sections, true);
 
     // Load linear attention (gated delta net) parameters
     ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);
@@ -68,7 +71,9 @@ void llama_model_qwen35::load_arch_tensors(llama_model_loader & ml) {
 
         if (!hparams.is_recr(il)) {
             // Attention layers
-            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, flags);
+            // use per-layer GQA dims: some GGUFs (e.g. Ollama exports) store
+            // head_count_kv as a per-layer array with 0 on linear-attention layers
+            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, hparams.n_embd_k_gqa(il), hparams.n_embd_v_gqa(il), flags);
             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", il), { n_embd_head_k * n_head, n_embd }, flags);
 
             // Q/K normalization for attention layers
@@ -80,7 +85,11 @@ void llama_model_qwen35::load_arch_tensors(llama_model_loader & ml) {
             layer.wqkv           = create_tensor(tn(LLM_TENSOR_ATTN_QKV,       "weight", il), { n_embd, key_dim * 2 + value_dim }, TENSOR_NOT_REQUIRED);
             layer.wqkv_gate      = create_tensor(tn(LLM_TENSOR_ATTN_GATE,      "weight", il), { n_embd, value_dim }, TENSOR_NOT_REQUIRED);
             layer.ssm_conv1d     = create_tensor(tn(LLM_TENSOR_SSM_CONV1D,     "weight", il), { hparams.ssm_d_conv, conv_dim }, flags);
-            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   il), { hparams.ssm_dt_rank }, flags);
+            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   il), { hparams.ssm_dt_rank }, flags | TENSOR_NOT_REQUIRED);
+            if (!layer.ssm_dt) {
+                // some GGUFs (e.g. Ollama exports) store this without the .bias suffix
+                layer.ssm_dt     = create_tensor(tn(LLM_TENSOR_SSM_DT,                   il), { hparams.ssm_dt_rank }, flags);
+            }
             layer.ssm_a          = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,             il), { hparams.ssm_dt_rank }, flags);
             layer.ssm_beta       = create_tensor(tn(LLM_TENSOR_SSM_BETA,       "weight", il), { n_embd, n_v_heads }, flags);
             layer.ssm_alpha      = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,      "weight", il), { n_embd, n_v_heads }, flags);
@@ -285,6 +294,9 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn(
     cb(Vcur, "Vcur", il);
 
     // Apply K normalization
+    // per-layer KV head count: some GGUFs (e.g. Ollama exports) store
+    // head_count_kv as a per-layer array with 0 on linear-attention layers
+    const int64_t n_head_kv = hparams.n_head_kv(il);
     Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
     Kcur = build_norm(Kcur, model.layers[il].attn_k_norm, nullptr, LLM_NORM_RMS, il);
     cb(Kcur, "Kcur_normed", il);
@@ -575,6 +587,7 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     gate = ggml_cont_2d(ctx0, gate, n_embd_head * n_head, n_tokens);
     cb(gate, "mtp_gate", il);
 
+    const int64_t n_head_kv = hparams.n_head_kv(il);
     ggml_tensor * Kcur = build_lora_mm(layer.wk, cur, layer.wk_s);
     Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
     Kcur = build_norm(Kcur, layer.attn_k_norm, nullptr, LLM_NORM_RMS, il);

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -6,7 +6,10 @@ void llama_model_qwen35moe::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_shexp, false);
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
 
-    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
+    // some GGUFs (e.g. Ollama exports) store 3 rope sections instead of 4;
+    // accept either length and leave trailing sections zeroed
+    hparams.rope_sections.fill(0);
+    ml.get_arr(LLM_KV_ROPE_DIMENSION_SECTIONS, hparams.rope_sections, true);
 
     // Load linear attention (gated delta net) parameters
     ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);
@@ -74,7 +77,9 @@ void llama_model_qwen35moe::load_arch_tensors(llama_model_loader & ml) {
 
         if (!hparams.is_recr(il)) {
             // Attention layers
-            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, n_embd_k_gqa, n_embd_v_gqa, flags);
+            // use per-layer GQA dims: some GGUFs (e.g. Ollama exports) store
+            // head_count_kv as a per-layer array with 0 on linear-attention layers
+            create_tensor_qkv(layer, il, n_embd, n_embd_head_k * n_head * 2, hparams.n_embd_k_gqa(il), hparams.n_embd_v_gqa(il), flags);
             layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", il), { n_embd_head_k * n_head, n_embd }, flags);
 
             // Q/K normalization for attention layers
@@ -86,7 +91,11 @@ void llama_model_qwen35moe::load_arch_tensors(llama_model_loader & ml) {
             layer.wqkv           = create_tensor(tn(LLM_TENSOR_ATTN_QKV,       "weight", il), { n_embd, key_dim * 2 + value_dim }, TENSOR_NOT_REQUIRED);
             layer.wqkv_gate      = create_tensor(tn(LLM_TENSOR_ATTN_GATE,      "weight", il), { n_embd, value_dim }, TENSOR_NOT_REQUIRED);
             layer.ssm_conv1d     = create_tensor(tn(LLM_TENSOR_SSM_CONV1D,     "weight", il), { hparams.ssm_d_conv, conv_dim }, flags);
-            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   il), { hparams.ssm_dt_rank }, flags);
+            layer.ssm_dt         = create_tensor(tn(LLM_TENSOR_SSM_DT,         "bias",   il), { hparams.ssm_dt_rank }, flags | TENSOR_NOT_REQUIRED);
+            if (!layer.ssm_dt) {
+                // some GGUFs (e.g. Ollama exports) store this without the .bias suffix
+                layer.ssm_dt     = create_tensor(tn(LLM_TENSOR_SSM_DT,                   il), { hparams.ssm_dt_rank }, flags);
+            }
             layer.ssm_a          = create_tensor(tn(LLM_TENSOR_SSM_A_NOSCAN,             il), { hparams.ssm_dt_rank }, flags);
             layer.ssm_beta       = create_tensor(tn(LLM_TENSOR_SSM_BETA,       "weight", il), { n_embd, n_v_heads }, flags);
             layer.ssm_alpha      = create_tensor(tn(LLM_TENSOR_SSM_ALPHA,      "weight", il), { n_embd, n_v_heads }, flags);
@@ -309,6 +318,9 @@ ggml_tensor * llama_model_qwen35moe::graph::build_layer_attn(
     cb(Vcur, "Vcur", il);
 
     // Apply K normalization
+    // per-layer KV head count: some GGUFs (e.g. Ollama exports) store
+    // head_count_kv as a per-layer array with 0 on linear-attention layers
+    const int64_t n_head_kv = hparams.n_head_kv(il);
     Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
     Kcur = build_norm(Kcur, model.layers[il].attn_k_norm, nullptr, LLM_NORM_RMS, il);
     cb(Kcur, "Kcur_normed", il);
@@ -639,6 +651,7 @@ llama_model_qwen35moe::graph_mtp::graph_mtp(const llama_model & model, const llm
     gate = ggml_cont_2d(ctx0, gate, n_embd_head * n_head, n_tokens);
     cb(gate, "mtp_gate", il);
 
+    const int64_t n_head_kv = hparams.n_head_kv(il);
     ggml_tensor * Kcur = build_lora_mm(layer.wk, cur, layer.wk_s);
     Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
     Kcur = build_norm(Kcur, layer.attn_k_norm, nullptr, LLM_NORM_RMS, il);


### PR DESCRIPTION
## Summary

This PR makes the qwen35 and qwen35moe loaders accept GGUF exports that are currently produced by Ollama for Qwen3.5/Qwen3.6 models.

It fixes four load/runtime mismatches seen with exact Ollama blobs:

- `rope.dimension_sections` may contain 3 entries instead of 4; the trailing section remains zeroed
- recurrent `ssm_dt` tensors may be stored without the `.bias` suffix
- text-only loading should tolerate bundled sibling tensors such as vision (`v.*`) and MTP (`mtp.*`) tensors
- attention graph construction should use per-layer KV-head dimensions for qwen35/qwen35moe

## Repro

Using llama.cpp `2da668617`, these exact Ollama blobs fail before this patch:

```bash
llama-cli -m /Users/saurav-air/.ollama/models/blobs/sha256-83c54730a5fea8a0958598c01617c1419c431e93b33bacf980b49a420c798926 \
  -p 'Say hello.' -n 1 -c 2048 -ngl 999 --temp 0 --no-display-prompt --simple-io
```

Error:

```text
key qwen35.rope.dimension_sections has wrong array length; expected 4, got 3
```

And:

```bash
llama-cli -m /Users/saurav-air/.ollama/models/blobs/sha256-93c83617a40560a61cda911ee327efdb5b5fbd39caa8b777a4ec565c0af1af3d \
  -p 'Say hello.' -n 1 -c 2048 -ngl 999 --temp 0 --no-display-prompt --simple-io
```

Error:

```text
key qwen35moe.rope.dimension_sections has wrong array length; expected 4, got 3
```

## Test plan

Built on macOS / Apple Silicon with Metal:

```bash
cmake --build build --target llama-completion llama-bench -j
```

Smoke-tested both exact Ollama blobs with `llama-completion`.

Benchmarked both exact blobs with:

```bash
llama-bench -m <exact-ollama-blob> -p 115 -n 128 -r 3 -ngl 999 -o md
```

Results on 128GB M3 Max:

| Model | Prompt t/s | Gen t/s |
|---|---:|---:|
| Qwen3.6 27B Q4_K_M exact Ollama blob | 181.55 ± 0.22 | 17.60 ± 1.07 |
| Qwen3.5 122B-A10B Q4_K_M exact Ollama blob | 217.86 ± 1.54 | 35.07 ± 0.21 |

## Notes / limitations

This is intentionally scoped to qwen35/qwen35moe. The partial-load behavior is used so text generation can ignore bundled sibling tensors such as vision and MTP tensors.

I opened this as a draft because I would appreciate maintainer guidance on whether the partial tensor-load behavior should be gated more narrowly than architecture-level qwen35/qwen35moe.
