### PR TITLE
ggml : add E4M3 (fp8) CPU quantization type

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -430,7 +430,8 @@ extern "C" {
         GGML_TYPE_NVFP4   = 40, // NVFP4 (4 blocks, E4M3 scale)
         GGML_TYPE_Q1_0    = 41,
         GGML_TYPE_Q2_0    = 42,
-        GGML_TYPE_COUNT   = 43,
+        GGML_TYPE_E4M3    = 43, // E4M3 (fp8)
+        GGML_TYPE_COUNT   = 44,
     };
 
     // precision
@@ -475,6 +476,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_NVFP4   = 26, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q1_0    = 27, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q2_0    = 28, // except 1d tensors
+        GGML_FTYPE_MOSTLY_E4M3    = 29, // except 1d tensors
     };
 
     // available tensor operations:

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -255,6 +255,13 @@ typedef struct {
 } block_q8_0;
 static_assert(sizeof(block_q8_0) == sizeof(ggml_half) + QK8_0, "wrong q8_0 block size/padding");
 
+#define QK_E4M3 32
+typedef struct {
+    ggml_half d;          // delta
+    uint8_t qs[QK_E4M3];  // e4m3 quants
+} block_e4m3;
+static_assert(sizeof(block_e4m3) == sizeof(ggml_half) + QK_E4M3, "wrong e4m3 block size/padding");
+
 #define QK8_1 32
 typedef struct {
     GGML_EXTENSION union {

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -16,6 +16,7 @@
 #define ggml_vec_dot_q8_0_q8_0_generic ggml_vec_dot_q8_0_q8_0
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
+#define ggml_vec_dot_e4m3_q8_0_generic ggml_vec_dot_e4m3_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
@@ -53,6 +54,7 @@
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_mxfp4_4x4_q8_0_generic ggml_gemv_mxfp4_4x4_q8_0
 #define ggml_gemv_mxfp4_8x8_q8_0_generic ggml_gemv_mxfp4_8x8_q8_0
+#define ggml_gemv_e4m3_8x8_q8_0_generic ggml_gemv_e4m3_8x8_q8_0
 #define ggml_gemv_q8_0_4x4_q8_0_generic ggml_gemv_q8_0_4x4_q8_0
 #define ggml_gemv_q8_0_4x8_q8_0_generic ggml_gemv_q8_0_4x8_q8_0
 #define ggml_gemm_q4_0_4x4_q8_0_generic ggml_gemm_q4_0_4x4_q8_0
@@ -69,6 +71,7 @@
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_mxfp4_4x4_q8_0_generic ggml_gemm_mxfp4_4x4_q8_0
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
+#define ggml_gemm_e4m3_8x8_q8_0_generic ggml_gemm_e4m3_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64)
@@ -114,6 +117,7 @@
 // quants.c
 #define quantize_row_q8_K_generic quantize_row_q8_K
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
+#define ggml_vec_dot_e4m3_q8_0_generic ggml_vec_dot_e4m3_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
@@ -138,6 +142,7 @@
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_mxfp4_4x4_q8_0_generic ggml_gemv_mxfp4_4x4_q8_0
 #define ggml_gemv_mxfp4_8x8_q8_0_generic ggml_gemv_mxfp4_8x8_q8_0
+#define ggml_gemv_e4m3_8x8_q8_0_generic ggml_gemv_e4m3_8x8_q8_0
 #define ggml_gemv_q8_0_4x4_q8_0_generic ggml_gemv_q8_0_4x4_q8_0
 #define ggml_gemv_q8_0_4x8_q8_0_generic ggml_gemv_q8_0_4x8_q8_0
 #define ggml_gemm_q4_0_4x4_q8_0_generic ggml_gemm_q4_0_4x4_q8_0
@@ -154,6 +159,7 @@
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_mxfp4_4x4_q8_0_generic ggml_gemm_mxfp4_4x4_q8_0
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
+#define ggml_gemm_e4m3_8x8_q8_0_generic ggml_gemm_e4m3_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__loongarch64)
@@ -164,6 +170,7 @@
 #define ggml_vec_dot_iq1_m_q8_K_generic ggml_vec_dot_iq1_m_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
+#define ggml_vec_dot_e4m3_q8_0_generic ggml_vec_dot_e4m3_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
 // repack.cpp
@@ -185,6 +192,7 @@
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_mxfp4_4x4_q8_0_generic ggml_gemv_mxfp4_4x4_q8_0
 #define ggml_gemv_mxfp4_8x8_q8_0_generic ggml_gemv_mxfp4_8x8_q8_0
+#define ggml_gemv_e4m3_8x8_q8_0_generic ggml_gemv_e4m3_8x8_q8_0
 #define ggml_gemv_q8_0_4x4_q8_0_generic ggml_gemv_q8_0_4x4_q8_0
 #define ggml_gemv_q8_0_4x8_q8_0_generic ggml_gemv_q8_0_4x8_q8_0
 #define ggml_gemm_q4_0_4x4_q8_0_generic ggml_gemm_q4_0_4x4_q8_0
@@ -201,12 +209,14 @@
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_mxfp4_4x4_q8_0_generic ggml_gemm_mxfp4_4x4_q8_0
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
+#define ggml_gemm_e4m3_8x8_q8_0_generic ggml_gemm_e4m3_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__riscv)
 // quants.c
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
+#define ggml_vec_dot_e4m3_q8_0_generic ggml_vec_dot_e4m3_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x1_generic ggml_quantize_mat_q8_0_4x1
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
@@ -226,6 +236,7 @@
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_mxfp4_4x4_q8_0_generic ggml_gemv_mxfp4_4x4_q8_0
 #define ggml_gemv_mxfp4_8x8_q8_0_generic ggml_gemv_mxfp4_8x8_q8_0
+#define ggml_gemv_e4m3_8x8_q8_0_generic ggml_gemv_e4m3_8x8_q8_0
 #define ggml_gemv_q8_0_4x4_q8_0_generic ggml_gemv_q8_0_4x4_q8_0
 #define ggml_gemv_q8_0_4x8_q8_0_generic ggml_gemv_q8_0_4x8_q8_0
 #define ggml_gemm_q4_0_4x4_q8_0_generic ggml_gemm_q4_0_4x4_q8_0
@@ -241,12 +252,14 @@
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_mxfp4_4x4_q8_0_generic ggml_gemm_mxfp4_4x4_q8_0
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
+#define ggml_gemm_e4m3_8x8_q8_0_generic ggml_gemm_e4m3_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__s390x__)
 // quants.c
 #define quantize_row_q8_K_generic quantize_row_q8_K
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
+#define ggml_vec_dot_e4m3_q8_0_generic ggml_vec_dot_e4m3_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
@@ -278,6 +291,7 @@
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_mxfp4_4x4_q8_0_generic ggml_gemv_mxfp4_4x4_q8_0
 #define ggml_gemv_mxfp4_8x8_q8_0_generic ggml_gemv_mxfp4_8x8_q8_0
+#define ggml_gemv_e4m3_8x8_q8_0_generic ggml_gemv_e4m3_8x8_q8_0
 #define ggml_gemv_q8_0_4x4_q8_0_generic ggml_gemv_q8_0_4x4_q8_0
 #define ggml_gemv_q8_0_4x8_q8_0_generic ggml_gemv_q8_0_4x8_q8_0
 #define ggml_gemm_q4_0_4x4_q8_0_generic ggml_gemm_q4_0_4x4_q8_0
@@ -294,6 +308,7 @@
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_mxfp4_4x4_q8_0_generic ggml_gemm_mxfp4_4x4_q8_0
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
+#define ggml_gemm_e4m3_8x8_q8_0_generic ggml_gemm_e4m3_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__wasm__)
@@ -311,6 +326,7 @@
 #define ggml_vec_dot_iq4_xs_q8_K_generic ggml_vec_dot_iq4_xs_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
+#define ggml_vec_dot_e4m3_q8_0_generic ggml_vec_dot_e4m3_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
 // repack.cpp
@@ -332,6 +348,7 @@
 #define ggml_gemv_iq4_nl_8x8_q8_0_generic ggml_gemv_iq4_nl_8x8_q8_0
 #define ggml_gemv_mxfp4_4x4_q8_0_generic ggml_gemv_mxfp4_4x4_q8_0
 #define ggml_gemv_mxfp4_8x8_q8_0_generic ggml_gemv_mxfp4_8x8_q8_0
+#define ggml_gemv_e4m3_8x8_q8_0_generic ggml_gemv_e4m3_8x8_q8_0
 #define ggml_gemv_q8_0_4x4_q8_0_generic ggml_gemv_q8_0_4x4_q8_0
 #define ggml_gemv_q8_0_4x8_q8_0_generic ggml_gemv_q8_0_4x8_q8_0
 #define ggml_gemm_q4_0_4x4_q8_0_generic ggml_gemm_q4_0_4x4_q8_0
@@ -348,6 +365,7 @@
 #define ggml_gemm_iq4_nl_8x8_q8_0_generic ggml_gemm_iq4_nl_8x8_q8_0
 #define ggml_gemm_mxfp4_4x4_q8_0_generic ggml_gemm_mxfp4_4x4_q8_0
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
+#define ggml_gemm_e4m3_8x8_q8_0_generic ggml_gemm_e4m3_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #endif

--- a/ggml/src/ggml-cpu/arch/arm/quants.c
+++ b/ggml/src/ggml-cpu/arch/arm/quants.c
@@ -807,6 +807,59 @@ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
     *s = sumf;
 }
 
+#if defined __ARM_NEON
+static inline float32x4_t e4m3_acc_16(float32x4_t acc, uint8x16_t wb, int8x16_t ab) {
+    const uint16x8_t w16lo = vmovl_u8(vget_low_u8(wb));
+    const uint16x8_t w16hi = vmovl_u8(vget_high_u8(wb));
+    const int16x8_t  a16lo = vmovl_s8(vget_low_s8(ab));
+    const int16x8_t  a16hi = vmovl_s8(vget_high_s8(ab));
+    acc = vmlaq_f32(acc, ggml_e4m3_decode_4_neon(vmovl_u16(vget_low_u16(w16lo))),  vcvtq_f32_s32(vmovl_s16(vget_low_s16(a16lo))));
+    acc = vmlaq_f32(acc, ggml_e4m3_decode_4_neon(vmovl_u16(vget_high_u16(w16lo))), vcvtq_f32_s32(vmovl_s16(vget_high_s16(a16lo))));
+    acc = vmlaq_f32(acc, ggml_e4m3_decode_4_neon(vmovl_u16(vget_low_u16(w16hi))),  vcvtq_f32_s32(vmovl_s16(vget_low_s16(a16hi))));
+    acc = vmlaq_f32(acc, ggml_e4m3_decode_4_neon(vmovl_u16(vget_high_u16(w16hi))), vcvtq_f32_s32(vmovl_s16(vget_high_s16(a16hi))));
+    return acc;
+}
+#endif
+
+void ggml_vec_dot_e4m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_E4M3 == 0);
+    static_assert(QK_E4M3 == QK8_0, "QK_E4M3 and QK8_0 must be the same");
+
+    const block_e4m3 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_E4M3;
+
+    int ib = 0;
+    float sumf = 0;
+
+#if defined __ARM_NEON
+    float32x4_t sumv = vdupq_n_f32(0.0f);
+    for (; ib < nb; ++ib) {
+        float32x4_t acc = vdupq_n_f32(0.0f);
+        acc = e4m3_acc_16(acc, vld1q_u8(x[ib].qs),      vld1q_s8(y[ib].qs));
+        acc = e4m3_acc_16(acc, vld1q_u8(x[ib].qs + 16), vld1q_s8(y[ib].qs + 16));
+        const float d = GGML_CPU_FP16_TO_FP32(x[ib].d) * GGML_CPU_FP16_TO_FP32(y[ib].d);
+        sumv = vmlaq_f32(sumv, acc, vdupq_n_f32(d));
+    }
+    sumf = vaddvq_f32(sumv);
+#endif
+    for (; ib < nb; ++ib) {
+        const float d = GGML_CPU_FP16_TO_FP32(x[ib].d) * GGML_CPU_FP16_TO_FP32(y[ib].d);
+        float si = 0;
+        for (int j = 0; j < QK_E4M3; ++j) {
+            si += GGML_CPU_E4M3_TO_FP32(x[ib].qs[j]) * y[ib].qs[j];
+        }
+        sumf += d * si;
+    }
+    *s = sumf;
+}
+
 void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     assert(nrc == 1);
     UNUSED(nrc);

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -5154,3 +5154,121 @@ void ggml_gemm_q8_0_4x8_q8_0(int                        n,
 #endif  // defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
     ggml_gemm_q8_0_4x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
+
+void ggml_gemv_e4m3_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+#if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert(nr == 1);
+    assert(n % qk == 0);
+    assert(nc % ncols_interleaved == 0);
+    UNUSED(bs);
+    UNUSED(nr);
+
+    const block_q8_0 * a_ptr = (const block_q8_0 *) vy;
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_e4m3x8 * b_ptr = (const block_e4m3x8 *) vx + (x * nb);
+        float32x4_t acc0 = vdupq_n_f32(0.0f);
+        float32x4_t acc1 = vdupq_n_f32(0.0f);
+        for (int l = 0; l < nb; l++) {
+            float dcol[8];
+            for (int j = 0; j < ncols_interleaved; j++) {
+                dcol[j] = GGML_CPU_FP16_TO_FP32(b_ptr[l].d[j]);
+            }
+            float32x4_t part0 = vdupq_n_f32(0.0f);
+            float32x4_t part1 = vdupq_n_f32(0.0f);
+            for (int p = 0; p < qk; p++) {
+                const uint16x8_t q16 = vmovl_u8(vld1_u8(b_ptr[l].qs + p * ncols_interleaved));
+                const float32x4_t w0 = ggml_e4m3_decode_4_neon(vmovl_u16(vget_low_u16(q16)));
+                const float32x4_t w1 = ggml_e4m3_decode_4_neon(vmovl_u16(vget_high_u16(q16)));
+                const float32x4_t av = vdupq_n_f32((float) a_ptr[l].qs[p]);
+                part0 = vmlaq_f32(part0, av, w0);
+                part1 = vmlaq_f32(part1, av, w1);
+            }
+            const float32x4_t ad = vdupq_n_f32(GGML_CPU_FP16_TO_FP32(a_ptr[l].d));
+            acc0 = vmlaq_f32(acc0, vmulq_f32(part0, vld1q_f32(dcol)),     ad);
+            acc1 = vmlaq_f32(acc1, vmulq_f32(part1, vld1q_f32(dcol + 4)), ad);
+        }
+        vst1q_f32(s + x * ncols_interleaved,     acc0);
+        vst1q_f32(s + x * ncols_interleaved + 4, acc1);
+    }
+    return;
+#endif
+    ggml_gemv_e4m3_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+}
+
+void ggml_gemm_e4m3_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+#if ! ((defined(_MSC_VER)) && ! defined(__clang__)) && defined(__aarch64__) && defined(__ARM_NEON)
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert(n % qk == 0);
+    assert(nr % 4 == 0);
+    assert(nc % ncols_interleaved == 0);
+
+    // decode this tile's weights and column scales up front, then reuse them for every row-group
+    thread_local std::vector<float> wdec;  // 8 floats (two float32x4 = 8 columns) per weight position
+    thread_local std::vector<float> dcolv; // 8 floats (two float32x4 = 8 column scales) per block
+    wdec.resize((size_t) nb * qk * 8);
+    dcolv.resize((size_t) nb * 8);
+
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_e4m3x8 * b_ptr = (const block_e4m3x8 *) vx + (x * nb);
+        for (int l = 0; l < nb; l++) {
+            float dcol[8];
+            for (int j = 0; j < ncols_interleaved; j++) {
+                dcol[j] = GGML_CPU_FP16_TO_FP32(b_ptr[l].d[j]);
+            }
+            vst1q_f32(&dcolv[(size_t) l * 8 + 0], vld1q_f32(dcol));
+            vst1q_f32(&dcolv[(size_t) l * 8 + 4], vld1q_f32(dcol + 4));
+            for (int p = 0; p < qk; p++) {
+                const uint16x8_t q16 = vmovl_u8(vld1_u8(b_ptr[l].qs + p * ncols_interleaved));
+                vst1q_f32(&wdec[((size_t) l * qk + p) * 8 + 0], ggml_e4m3_decode_4_neon(vmovl_u16(vget_low_u16(q16))));
+                vst1q_f32(&wdec[((size_t) l * qk + p) * 8 + 4], ggml_e4m3_decode_4_neon(vmovl_u16(vget_high_u16(q16))));
+            }
+        }
+        for (int y = 0; y < nr / 4; y++) {
+            const block_q8_0x4 * a_ptr = (const block_q8_0x4 *) vy + (y * nb);
+            float32x4_t acc0[4];
+            float32x4_t acc1[4];
+            for (int m = 0; m < 4; m++) { acc0[m] = vdupq_n_f32(0.0f); acc1[m] = vdupq_n_f32(0.0f); }
+            for (int l = 0; l < nb; l++) {
+                const float32x4_t dcol0 = vld1q_f32(&dcolv[(size_t) l * 8 + 0]);
+                const float32x4_t dcol1 = vld1q_f32(&dcolv[(size_t) l * 8 + 4]);
+                float32x4_t part0[4];
+                float32x4_t part1[4];
+                for (int m = 0; m < 4; m++) { part0[m] = vdupq_n_f32(0.0f); part1[m] = vdupq_n_f32(0.0f); }
+                const float          * const wl = &wdec[(size_t) l * qk * 8];
+                const int8_t      * const ql = a_ptr[l].qs;
+                for (int p = 0; p < qk; p++) {
+                    const float32x4_t w0 = vld1q_f32(wl + p * 8 + 0);
+                    const float32x4_t w1 = vld1q_f32(wl + p * 8 + 4);
+                    const int8_t * const ar = ql + ((p >> 3) << 5) + (p & 7); // k*32 + i
+                    const float32x4_t a0 = vdupq_n_f32((float) ar[0]);
+                    const float32x4_t a1 = vdupq_n_f32((float) ar[8]);
+                    const float32x4_t a2 = vdupq_n_f32((float) ar[16]);
+                    const float32x4_t a3 = vdupq_n_f32((float) ar[24]);
+                    part0[0] = vmlaq_f32(part0[0], a0, w0); part1[0] = vmlaq_f32(part1[0], a0, w1);
+                    part0[1] = vmlaq_f32(part0[1], a1, w0); part1[1] = vmlaq_f32(part1[1], a1, w1);
+                    part0[2] = vmlaq_f32(part0[2], a2, w0); part1[2] = vmlaq_f32(part1[2], a2, w1);
+                    part0[3] = vmlaq_f32(part0[3], a3, w0); part1[3] = vmlaq_f32(part1[3], a3, w1);
+                }
+                for (int m = 0; m < 4; m++) {
+                    const float32x4_t ad = vdupq_n_f32(GGML_CPU_FP16_TO_FP32(a_ptr[l].d[m]));
+                    acc0[m] = vmlaq_f32(acc0[m], vmulq_f32(part0[m], dcol0), ad);
+                    acc1[m] = vmlaq_f32(acc1[m], vmulq_f32(part1[m], dcol1), ad);
+                }
+            }
+            for (int m = 0; m < 4; m++) {
+                vst1q_f32(s + (y * 4 + m) * bs + x * ncols_interleaved,     acc0[m]);
+                vst1q_f32(s + (y * 4 + m) * bs + x * ncols_interleaved + 4, acc1[m]);
+            }
+        }
+    }
+    return;
+#endif
+    ggml_gemm_e4m3_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+}

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -1139,6 +1139,48 @@ void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
     *s = sumf;
 }
 
+void ggml_vec_dot_e4m3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_E4M3 == 0);
+    static_assert(QK_E4M3 == QK8_0, "QK_E4M3 and QK8_0 must be the same");
+
+    const block_e4m3 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_E4M3;
+
+    int ib = 0;
+    float sumf = 0;
+
+#if defined __AVX2__
+    __m256 accum = _mm256_setzero_ps();
+    for (; ib < nb; ++ib) {
+        __m256 acc = _mm256_setzero_ps();
+        for (int j = 0; j < QK_E4M3; j += 8) {
+            const __m256 w = ggml_e4m3_decode_8_avx2(x[ib].qs + j);
+            const __m256 a = _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(y[ib].qs + j))));
+            acc = _mm256_fmadd_ps(w, a, acc);
+        }
+        const float d = GGML_CPU_FP16_TO_FP32(x[ib].d) * GGML_CPU_FP16_TO_FP32(y[ib].d);
+        accum = _mm256_fmadd_ps(_mm256_set1_ps(d), acc, accum);
+    }
+    sumf = hsum_float_8(accum);
+#endif
+    for (; ib < nb; ++ib) {
+        const float d = GGML_CPU_FP16_TO_FP32(x[ib].d) * GGML_CPU_FP16_TO_FP32(y[ib].d);
+        float si = 0;
+        for (int j = 0; j < QK_E4M3; ++j) {
+            si += GGML_CPU_E4M3_TO_FP32(x[ib].qs[j]) * y[ib].qs[j];
+        }
+        sumf += d * si;
+    }
+    *s = sumf;
+}
+
 void ggml_vec_dot_q5_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     const int qk = QK8_0;
     const int nb = n / qk;

--- a/ggml/src/ggml-cpu/arch/x86/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/x86/repack.cpp
@@ -1710,6 +1710,39 @@ void ggml_gemv_mxfp4_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
     ggml_gemv_mxfp4_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
 
+void ggml_gemv_e4m3_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+#if defined(__AVX2__)
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert(nr == 1);
+    assert(n % qk == 0);
+    assert(nc % ncols_interleaved == 0);
+    UNUSED(bs);
+    UNUSED(nr);
+
+    const block_q8_0 * a_ptr = (const block_q8_0 *) vy;
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_e4m3x8 * b_ptr = (const block_e4m3x8 *) vx + (x * nb);
+        __m256 acc = _mm256_setzero_ps();
+        for (int l = 0; l < nb; l++) {
+            const __m256 dcol = GGML_F32Cx8_LOAD(b_ptr[l].d);
+            __m256 part = _mm256_setzero_ps();
+            for (int p = 0; p < qk; p++) {
+                const __m256 w = ggml_e4m3_decode_8_avx2(b_ptr[l].qs + p * ncols_interleaved);
+                part = _mm256_fmadd_ps(_mm256_set1_ps((float) a_ptr[l].qs[p]), w, part);
+            }
+            acc = _mm256_fmadd_ps(_mm256_mul_ps(part, dcol), _mm256_set1_ps(GGML_CPU_FP16_TO_FP32(a_ptr[l].d)), acc);
+        }
+        _mm256_storeu_ps(s + x * ncols_interleaved, acc);
+    }
+    return;
+#endif
+
+    ggml_gemv_e4m3_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+}
+
 void ggml_gemv_q2_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
     const int qk = QK_K;
     const int nb = n / qk;
@@ -3521,6 +3554,61 @@ void ggml_gemm_mxfp4_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const v
 #endif // defined(__AVX2__) || defined(__AVX512F__)
 
     ggml_gemm_mxfp4_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
+}
+
+void ggml_gemm_e4m3_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+#if defined(__AVX2__)
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert(n % qk == 0);
+    assert(nr % 4 == 0);
+    assert(nc % ncols_interleaved == 0);
+
+    // decode each column-tile's weights once and reuse them across every activation row-group
+    thread_local std::vector<float> wdec;
+    wdec.resize((size_t) nb * qk * 8);
+
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_e4m3x8 * b_ptr = (const block_e4m3x8 *) vx + (x * nb);
+        for (int l = 0; l < nb; l++) {
+            for (int p = 0; p < qk; p++) {
+                _mm256_storeu_ps(&wdec[((size_t) l * qk + p) * 8], ggml_e4m3_decode_8_avx2(b_ptr[l].qs + p * ncols_interleaved));
+            }
+        }
+        for (int y = 0; y < nr / 4; y++) {
+            const block_q8_0x4 * a_ptr = (const block_q8_0x4 *) vy + (y * nb);
+            __m256 acc[4];
+            for (int m = 0; m < 4; m++) acc[m] = _mm256_setzero_ps();
+            for (int l = 0; l < nb; l++) {
+                const __m256 dcol = GGML_F32Cx8_LOAD(b_ptr[l].d);
+                __m256 part[4];
+                for (int m = 0; m < 4; m++) part[m] = _mm256_setzero_ps();
+                const float    * const wl = &wdec[(size_t) l * qk * 8];
+                const int8_t  * const ql = a_ptr[l].qs;
+                for (int p = 0; p < qk; p++) {
+                    const __m256 w = _mm256_loadu_ps(wl + p * 8);
+                    const int8_t * const ar = ql + ((p >> 3) << 5) + (p & 7); // k*32 + i
+                    part[0] = _mm256_fmadd_ps(_mm256_set1_ps((float) ar[0]),  w, part[0]);
+                    part[1] = _mm256_fmadd_ps(_mm256_set1_ps((float) ar[8]),  w, part[1]);
+                    part[2] = _mm256_fmadd_ps(_mm256_set1_ps((float) ar[16]), w, part[2]);
+                    part[3] = _mm256_fmadd_ps(_mm256_set1_ps((float) ar[24]), w, part[3]);
+                }
+                for (int m = 0; m < 4; m++) {
+                    const float ad = GGML_CPU_FP16_TO_FP32(a_ptr[l].d[m]);
+                    acc[m] = _mm256_fmadd_ps(_mm256_mul_ps(part[m], dcol), _mm256_set1_ps(ad), acc[m]);
+                }
+            }
+            for (int m = 0; m < 4; m++) {
+                _mm256_storeu_ps(s + (y * 4 + m) * bs + x * ncols_interleaved, acc[m]);
+            }
+        }
+    }
+    return;
+#endif
+
+    ggml_gemm_e4m3_8x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
 
 void ggml_gemm_q2_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {

--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -329,6 +329,18 @@ static inline int32x4_t ggml_nvfp4_dot8(const int8x8_t q4_lo, const int8x8_t q8_
     return vaddq_s32(sum_lo, sum_hi);
 }
 
+// e4m3 -> f32 (4 lanes)
+static inline float32x4_t ggml_e4m3_decode_4_neon(uint32x4_t b) {
+    const uint32x4_t mag   = vandq_u32(b, vdupq_n_u32(0x7F));
+    const uint32x4_t man   = vandq_u32(b, vdupq_n_u32(0x7));
+    const uint32x4_t nbits = vaddq_u32(vshlq_n_u32(mag, 20), vdupq_n_u32(120u << 23));
+    float32x4_t val = vbslq_f32(vceqq_u32(vandq_u32(b, vdupq_n_u32(0x78)), vdupq_n_u32(0)),
+                                vmulq_f32(vcvtq_f32_u32(man), vdupq_n_f32(1.0f / 512.0f)),
+                                vreinterpretq_f32_u32(nbits));
+    val = vbslq_f32(vceqq_u32(mag, vdupq_n_u32(0x7F)), vdupq_n_f32(NAN), val);
+    return vreinterpretq_f32_u32(vorrq_u32(vreinterpretq_u32_f32(val), vshlq_n_u32(vandq_u32(b, vdupq_n_u32(0x80)), 24)));
+}
+
 #endif // defined(__ARM_NEON)
 
 #ifdef __wasm_simd128__
@@ -343,6 +355,21 @@ static inline int32x4_t ggml_nvfp4_dot8(const int8x8_t q4_lo, const int8x8_t q8_
 #include <intrin.h>
 #elif defined(__SSE__) || defined(__SSE3__) || defined(__SSSE3__) || defined(__AVX__) || defined(__F16C__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__AVX512BF16__)
 #include <immintrin.h>
+#endif
+
+#if defined(__AVX2__)
+static inline __m256 ggml_e4m3_decode_8_avx2(const uint8_t * p) {
+    const __m256i b     = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)p));
+    const __m256i mag   = _mm256_and_si256(b, _mm256_set1_epi32(0x7F));
+    const __m256i man   = _mm256_and_si256(b, _mm256_set1_epi32(0x7));
+    const __m256i nbits = _mm256_add_epi32(_mm256_slli_epi32(mag, 20), _mm256_set1_epi32(120 << 23));
+    __m256 val = _mm256_blendv_ps(_mm256_castsi256_ps(nbits),
+                                  _mm256_mul_ps(_mm256_cvtepi32_ps(man), _mm256_set1_ps(1.0f / 512.0f)),
+                                  _mm256_castsi256_ps(_mm256_cmpeq_epi32(_mm256_and_si256(b, _mm256_set1_epi32(0x78)), _mm256_setzero_si256())));
+    val = _mm256_blendv_ps(val, _mm256_castsi256_ps(_mm256_set1_epi32(0x7FC00000)),
+                           _mm256_castsi256_ps(_mm256_cmpeq_epi32(mag, _mm256_set1_epi32(0x7F))));
+    return _mm256_or_ps(val, _mm256_castsi256_ps(_mm256_slli_epi32(_mm256_and_si256(b, _mm256_set1_epi32(0x80)), 24)));
+}
 #endif
 
 #ifdef __riscv_v_intrinsic

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -82,6 +82,8 @@ float ggml_table_f32_f16[1 << 16];
 // precomputed f32 table for e8m0 half (1 KB) (simd-mappings.h)
 float ggml_table_f32_e8m0_half[1 << 8];
 
+// precomputed f32 table for e4m3 (1 KB) (simd-mappings.h)
+float ggml_table_f32_e4m3[1 << 8];
 // precomputed f32 table for ue4m3 (1 KB) (simd-mappings.h)
 float ggml_table_f32_ue4m3[1 << 8];
 
@@ -292,6 +294,12 @@ static const struct ggml_type_traits_cpu type_traits_cpu[GGML_TYPE_COUNT] = {
     [GGML_TYPE_NVFP4] = {
         .from_float               = quantize_row_nvfp4,
         .vec_dot                  = ggml_vec_dot_nvfp4_q8_0,
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+        .nrows                    = 1,
+    },
+    [GGML_TYPE_E4M3] = {
+        .from_float               = quantize_row_e4m3,
+        .vec_dot                  = ggml_vec_dot_e4m3_q8_0,
         .vec_dot_type             = GGML_TYPE_Q8_0,
         .nrows                    = 1,
     },
@@ -3805,6 +3813,11 @@ void ggml_cpu_init(void) {
             // initialize E8M0 half table (256 entries)
             for (int i = 0; i < (1 << 8); ++i) {
                 ggml_table_f32_e8m0_half[i] = GGML_E8M0_TO_FP32_HALF(i);
+            }
+
+            // initialize E4M3 table (256 entries)
+            for (int i = 0; i < (1 << 8); ++i) {
+                ggml_table_f32_e4m3[i] = ggml_e4m3_to_fp32(i);
             }
 
             // initialize UE4M3 table (256 entries)

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -673,6 +673,7 @@ void ggml_compute_forward_add(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        case GGML_TYPE_E4M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1125,6 +1126,7 @@ void ggml_compute_forward_add1(
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        case GGML_TYPE_E4M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -1256,6 +1258,7 @@ void ggml_compute_forward_acc(
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        case GGML_TYPE_E4M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4465,6 +4468,7 @@ void ggml_compute_forward_out_prod(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        case GGML_TYPE_E4M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4743,6 +4747,7 @@ void ggml_compute_forward_set(
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        case GGML_TYPE_E4M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -4968,6 +4973,7 @@ void ggml_compute_forward_get_rows(
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        case GGML_TYPE_E4M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -5695,6 +5701,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
         case GGML_TYPE_NVFP4:
+        case GGML_TYPE_E4M3:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:

--- a/ggml/src/ggml-cpu/quants.c
+++ b/ggml/src/ggml-cpu/quants.c
@@ -62,6 +62,10 @@ void quantize_row_nvfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, i
     quantize_row_nvfp4_ref(x, y, k);
 }
 
+void quantize_row_e4m3(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k) {
+    quantize_row_e4m3_ref(x, y, k);
+}
+
 //
 // 2-6 bit quantization in super-blocks
 //
@@ -358,6 +362,34 @@ void ggml_vec_dot_nvfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, 
 
             sumf += dy * d * (sumi_lo + sumi_hi);
         }
+    }
+    *s = sumf;
+}
+
+void ggml_vec_dot_e4m3_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_E4M3 == 0);
+    static_assert(QK_E4M3 == QK8_0, "QK_E4M3 and QK8_0 must be the same");
+
+    const block_e4m3 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_E4M3;
+
+    float sumf = 0;
+
+    for (int ib = 0; ib < nb; ++ib) {
+        const float d = GGML_CPU_FP16_TO_FP32(x[ib].d) * GGML_CPU_FP16_TO_FP32(y[ib].d);
+
+        float sumi = 0;
+        for (int j = 0; j < QK_E4M3; ++j) {
+            sumi += GGML_CPU_E4M3_TO_FP32(x[ib].qs[j]) * y[ib].qs[j];
+        }
+        sumf += d * sumi;
     }
     *s = sumf;
 }

--- a/ggml/src/ggml-cpu/quants.h
+++ b/ggml/src/ggml-cpu/quants.h
@@ -23,6 +23,7 @@ void quantize_row_q8_1(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, in
 
 void quantize_row_mxfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_nvfp4(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
+void quantize_row_e4m3 (const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 
 void quantize_row_q2_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
 void quantize_row_q3_K(const float * GGML_RESTRICT x, void * GGML_RESTRICT y, int64_t k);
@@ -48,6 +49,7 @@ void ggml_vec_dot_q8_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
 
 void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_e4m3_q8_0 (int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_q2_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_q3_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
@@ -82,6 +84,7 @@ void ggml_vec_dot_q8_0_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, c
 
 void ggml_vec_dot_mxfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_nvfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_e4m3_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_tq1_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_tq2_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -1271,6 +1271,42 @@ void ggml_gemv_mxfp4_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs,
     }
 }
 
+void ggml_gemv_e4m3_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+    const int blocklen = 8;
+
+    assert(nr == 1);
+    assert(n % qk == 0);
+    assert(nc % ncols_interleaved == 0);
+
+    UNUSED(bs);
+    UNUSED(nr);
+
+    float sumf[8];
+
+    const block_q8_0 * a_ptr = (const block_q8_0 *) vy;
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_e4m3x8 * b_ptr = (const block_e4m3x8 *) vx + (x * nb);
+
+        for (int j = 0; j < ncols_interleaved; j++) sumf[j] = 0.0;
+        for (int l = 0; l < nb; l++) {
+            for (int k = 0; k < (qk / blocklen); k++) {
+                for (int j = 0; j < ncols_interleaved; j++) {
+                    float sumi = 0.0f;
+                    for (int i = 0; i < blocklen; ++i) {
+                        sumi += GGML_CPU_E4M3_TO_FP32(b_ptr[l].qs[(k * blocklen + i) * ncols_interleaved + j]) *
+                                a_ptr[l].qs[k * blocklen + i];
+                    }
+                    sumf[j] += sumi * GGML_CPU_FP16_TO_FP32(b_ptr[l].d[j]) * GGML_CPU_FP16_TO_FP32(a_ptr[l].d);
+                }
+            }
+        }
+        for (int j = 0; j < ncols_interleaved; j++) s[x * ncols_interleaved + j] = sumf[j];
+    }
+}
+
 void ggml_gemv_q8_0_4x4_q8_0_generic(int                        n,
                                      float * GGML_RESTRICT      s,
                                      size_t                     bs,
@@ -2265,6 +2301,47 @@ void ggml_gemm_mxfp4_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs,
                                          (v1 * a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i + qk / 2 * 4]));
                             }
                             sumf[m][j] += sumi * GGML_CPU_E8M0_TO_FP32_HALF(b_ptr[l].e[j]) * GGML_CPU_FP16_TO_FP32(a_ptr[l].d[m]);
+                        }
+                    }
+                }
+            }
+            for (int m = 0; m < 4; m++) {
+                for (int j = 0; j < ncols_interleaved; j++)
+                    s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+            }
+        }
+    }
+}
+
+void ggml_gemm_e4m3_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+    const int blocklen = 8;
+
+    assert(n % qk == 0);
+    assert(nr % 4 == 0);
+    assert(nc % ncols_interleaved == 0);
+
+    float sumf[4][8];
+
+    for (int y = 0; y < nr / 4; y++) {
+        const block_q8_0x4 * a_ptr = (const block_q8_0x4 *) vy + (y * nb);
+        for (int x = 0; x < nc / ncols_interleaved; x++) {
+            const block_e4m3x8 * b_ptr = (const block_e4m3x8 *) vx + (x * nb);
+            for (int m = 0; m < 4; m++) {
+                for (int j = 0; j < ncols_interleaved; j++) sumf[m][j] = 0.0;
+            }
+            for (int l = 0; l < nb; l++) {
+                for (int k = 0; k < (qk / blocklen); k++) {
+                    for (int m = 0; m < 4; m++) {
+                        for (int j = 0; j < ncols_interleaved; j++) {
+                            float sumi = 0.0f;
+                            for (int i = 0; i < blocklen; ++i) {
+                                sumi += GGML_CPU_E4M3_TO_FP32(b_ptr[l].qs[(k * blocklen + i) * ncols_interleaved + j]) *
+                                        a_ptr[l].qs[k * 4 * blocklen + m * blocklen + i];
+                            }
+                            sumf[m][j] += sumi * GGML_CPU_FP16_TO_FP32(b_ptr[l].d[j]) * GGML_CPU_FP16_TO_FP32(a_ptr[l].d[m]);
                         }
                     }
                 }
@@ -3859,6 +3936,57 @@ static int repack_mxfp4_to_mxfp4_8_bl(struct ggml_tensor * t, int interleave_blo
     GGML_UNUSED(data_size);
 }
 
+static block_e4m3x8 make_block_e4m3x8(block_e4m3 * in, unsigned int blck_size_interleave) {
+    block_e4m3x8 out;
+
+    for (int i = 0; i < 8; i++) {
+        out.d[i] = in[i].d;
+    }
+
+    // position-major: 8 consecutive bytes hold the 8 columns at one weight position
+    GGML_ASSERT(blck_size_interleave == 8);
+    for (int p = 0; p < QK_E4M3; p++) {
+        for (int j = 0; j < 8; j++) {
+            out.qs[p * 8 + j] = in[j].qs[p];
+        }
+    }
+
+    return out;
+}
+
+static int repack_e4m3_to_e4m3_8_bl(struct ggml_tensor * t, int interleave_block, const void * GGML_RESTRICT data, size_t data_size) {
+    GGML_ASSERT(t->type == GGML_TYPE_E4M3);
+    GGML_ASSERT(interleave_block == 8);
+
+    const block_e4m3   * src = (const block_e4m3   *)data;
+          block_e4m3x8 * dst = (      block_e4m3x8 *)t->data;
+
+    block_e4m3 dst_tmp[8];
+
+    int nrow = ggml_nrows(t);
+    int nrows_interleaved = 8;
+    int nblocks = t->ne[0] / QK_E4M3;
+
+    GGML_ASSERT(data_size == nrow * nblocks * sizeof(block_e4m3));
+
+    if (t->ne[1] % nrows_interleaved != 0) {
+        return -1;
+    }
+
+    for (int b = 0; b < nrow; b += nrows_interleaved) {
+        for (int64_t x = 0; x < nblocks; x++) {
+            for (int i = 0; i < nrows_interleaved; i++) {
+                dst_tmp[i] = src[x + i * nblocks];
+            }
+            *dst++ = make_block_e4m3x8(dst_tmp, interleave_block);
+        }
+        src += nrows_interleaved * nblocks;
+    }
+    return 0;
+
+    GGML_UNUSED(data_size);
+}
+
 namespace ggml::cpu::repack {
 // repack
 template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS>
@@ -3924,6 +4052,10 @@ template <> int repack<block_mxfp4, 4, 4>(struct ggml_tensor * t, const void * d
 
 template <> int repack<block_mxfp4, 8, 8>(struct ggml_tensor * t, const void * data, size_t data_size) {
     return repack_mxfp4_to_mxfp4_8_bl(t, 8, data, data_size);
+}
+
+template <> int repack<block_e4m3, 8, 8>(struct ggml_tensor * t, const void * data, size_t data_size) {
+    return repack_e4m3_to_e4m3_8_bl(t, 8, data, data_size);
 }
 
 template <> int repack<block_q8_0, 4, 4>(struct ggml_tensor * t, const void * data, size_t data_size) {
@@ -4023,6 +4155,10 @@ template <> void gemv<block_mxfp4, 8, 8, GGML_TYPE_Q8_0>(int n, float * s, size_
     ggml_gemv_mxfp4_8x8_q8_0(n, s, bs, vx, vy, nr, nc);
 }
 
+template <> void gemv<block_e4m3, 8, 8, GGML_TYPE_Q8_0>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemv_e4m3_8x8_q8_0(n, s, bs, vx, vy, nr, nc);
+}
+
 template <> void gemv<block_q8_0, 4, 4, GGML_TYPE_Q8_0>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
     ggml_gemv_q8_0_4x4_q8_0(n, s, bs, vx, vy, nr, nc);
 }
@@ -4118,6 +4254,10 @@ template <> void gemm<block_mxfp4, 4, 4, GGML_TYPE_Q8_0>(int n, float * s, size_
 
 template <> void gemm<block_mxfp4, 8, 8, GGML_TYPE_Q8_0>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
     ggml_gemm_mxfp4_8x8_q8_0(n, s, bs, vx, vy, nr, nc);
+}
+
+template <> void gemm<block_e4m3, 8, 8, GGML_TYPE_Q8_0>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemm_e4m3_8x8_q8_0(n, s, bs, vx, vy, nr, nc);
 }
 
 template <> void gemm<block_q8_0, 4, 4, GGML_TYPE_Q8_0>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
@@ -4554,6 +4694,9 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
     static const ggml::cpu::repack::tensor_traits<block_mxfp4, 4, 4, GGML_TYPE_Q8_0> mxfp4_4x4_q8_0;
     static const ggml::cpu::repack::tensor_traits<block_mxfp4, 8, 8, GGML_TYPE_Q8_0> mxfp4_8x8_q8_0;
 
+    // instance for E4M3
+    static const ggml::cpu::repack::tensor_traits<block_e4m3, 8, 8, GGML_TYPE_Q8_0> e4m3_8x8_q8_0;
+
     // instance for Q8_0
     static const ggml::cpu::repack::tensor_traits<block_q8_0, 4, 4, GGML_TYPE_Q8_0> q8_0_4x4_q8_0;
     static const ggml::cpu::repack::tensor_traits<block_q8_0, 8, 4, GGML_TYPE_Q8_0> q8_0_4x8_q8_0;
@@ -4694,6 +4837,12 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
         if (ggml_cpu_has_neon() && ggml_cpu_has_dotprod()) {
             if (cur->ne[1] % 4 == 0) {
                 return &mxfp4_4x4_q8_0;
+            }
+        }
+    } else if (cur->type == GGML_TYPE_E4M3) {
+        if (ggml_cpu_has_avx2() || ggml_cpu_has_neon()) {
+            if (cur->ne[1] % 8 == 0) {
+                return &e4m3_8x8_q8_0;
             }
         }
     } else if (cur->type == GGML_TYPE_Q8_0) {

--- a/ggml/src/ggml-cpu/repack.h
+++ b/ggml/src/ggml-cpu/repack.h
@@ -133,6 +133,12 @@ struct block_mxfp4x8 {
 };
 static_assert(sizeof(block_mxfp4x8) == 8 + QK_MXFP4 * 4, "wrong mxfp4x8 block size/padding");
 
+struct block_e4m3x8 {
+    ggml_half d[8];            // deltas for 8 e4m3 blocks
+    uint8_t   qs[QK_E4M3 * 8]; // e4m3 quants for 8 blocks
+};
+static_assert(sizeof(block_e4m3x8) == 8 * sizeof(ggml_half) + QK_E4M3 * 8, "wrong e4m3x8 block size/padding");
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -155,6 +161,7 @@ void ggml_gemv_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const 
 void ggml_gemv_iq4_nl_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_mxfp4_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_mxfp4_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemv_e4m3_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q8_0_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q8_0_4x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q4_0_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
@@ -171,6 +178,7 @@ void ggml_gemm_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const 
 void ggml_gemm_iq4_nl_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_mxfp4_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_mxfp4_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemm_e4m3_8x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q8_0_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q8_0_4x8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 #if defined __riscv_zvfh
@@ -207,6 +215,7 @@ void ggml_gemv_iq4_nl_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs
 void ggml_gemv_iq4_nl_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_mxfp4_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_mxfp4_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemv_e4m3_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q8_0_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q8_0_4x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q4_0_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
@@ -223,6 +232,7 @@ void ggml_gemm_iq4_nl_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs
 void ggml_gemm_iq4_nl_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_mxfp4_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_mxfp4_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemm_e4m3_8x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q8_0_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q8_0_4x8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 #if defined __riscv_zvfh

--- a/ggml/src/ggml-cpu/simd-mappings.h
+++ b/ggml/src/ggml-cpu/simd-mappings.h
@@ -131,6 +131,14 @@ extern float ggml_table_f32_ue4m3[1 << 8];
 #define GGML_CPU_E8M0_TO_FP32_HALF(x) GGML_E8M0_TO_FP32_HALF(x)
 #endif
 
+extern float ggml_table_f32_e4m3[1 << 8];
+// Use lookup table for E4M3 on x86 (faster than bit manipulation)
+#if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__)
+#define GGML_CPU_E4M3_TO_FP32(x) ggml_table_f32_e4m3[(uint8_t)(x)]
+#else
+#define GGML_CPU_E4M3_TO_FP32(x) ggml_e4m3_to_fp32(x)
+#endif
+
 // Use lookup table for UE4M3 on x86 and ARM (faster than bit manipulation)
 #if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__ARM_NEON)
 #define GGML_CPU_UE4M3_TO_FP32(x) ggml_table_f32_ue4m3[(uint8_t)(x)]

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -552,6 +552,53 @@ static inline uint8_t ggml_fp32_to_ue4m3(float x) {
     return (uint8_t) ((ue4m3_exp << 3) | ue4m3_man);
 }
 
+// E4M3 (OCP e4m3fn); not merged with ue4m3 above (the unsigned nvfp4-scale codec): the formats differ enough that a shared helper would need flags
+static inline float ggml_e4m3_to_fp32(uint8_t x) {
+    if ((x & 0x7F) == 0x7F) {
+        return NAN;
+    }
+    const float sign = (x & 0x80) ? -1.0f : 1.0f;
+    const int   exp  = (x >> 3) & 0xF;
+    const int   man  = x & 0x7;
+    if (exp == 0) {
+        return sign * ldexpf((float) man, -9);
+    }
+    return sign * ldexpf(1.0f + (float) man / 8.0f, exp - 7);
+}
+
+static inline uint8_t ggml_fp32_to_e4m3(float x) {
+    uint8_t sign = 0;
+    if (x < 0.0f) {
+        sign = 0x80;
+        x = -x;
+    }
+    if (!(x > 0.0f)) {
+        return sign;
+    }
+    if (x > 448.0f) {
+        x = 448.0f;
+    }
+    uint32_t bits;
+    memcpy(&bits, &x, 4);
+    const int fp32_exp = ((bits >> 23) & 0xFF) - 127;
+    const int fp32_man = (bits >> 20) & 0x7;
+    int exp = fp32_exp + 7;
+    if (exp <= 0) {
+        int man = (int) (x * 512.0f + 0.5f); // subnormal: man * 2^-9
+        // x < 2^-6 here, so man <= 8; man == 8 carries into the smallest normal (0x08 = 2^-6)
+        return sign | (uint8_t) man;
+    }
+    int man = fp32_man + ((bits >> 19) & 1);
+    if (man > 7) {
+        man = 0;
+        exp++;
+    }
+    if (exp > 15 || (exp == 15 && man == 7)) {
+        return sign | 0x7E;
+    }
+    return sign | (uint8_t) ((exp << 3) | man);
+}
+
 /**
  * Converts brain16 to float32.
  *

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1271,7 +1271,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_SOLVE_TRI:
         case GGML_OP_MUL_MAT:
         case GGML_OP_MUL_MAT_ID:
-            return has_simdgroup_reduction && op->src[0]->type != GGML_TYPE_NVFP4;
+            return has_simdgroup_reduction && op->src[0]->type != GGML_TYPE_NVFP4 && op->src[0]->type != GGML_TYPE_E4M3;
         case GGML_OP_SET:
         case GGML_OP_CPY:
         case GGML_OP_DUP:
@@ -1331,7 +1331,7 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                 };
             }
         case GGML_OP_GET_ROWS:
-            return op->src[0]->type != GGML_TYPE_NVFP4;
+            return op->src[0]->type != GGML_TYPE_NVFP4 && op->src[0]->type != GGML_TYPE_E4M3;
         case GGML_OP_SET_ROWS:
             {
                 if (op->src[0]->type != GGML_TYPE_F32) {

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -298,6 +298,29 @@ void quantize_row_q8_0_ref(const float * GGML_RESTRICT x, block_q8_0 * GGML_REST
     }
 }
 
+void quantize_row_e4m3_ref(const float * GGML_RESTRICT x, block_e4m3 * GGML_RESTRICT y, int64_t k) {
+    assert(k % QK_E4M3 == 0);
+    const int nb = k / QK_E4M3;
+
+    for (int i = 0; i < nb; i++) {
+        float amax = 0.0f; // absolute max
+
+        for (int j = 0; j < QK_E4M3; j++) {
+            const float v = x[i*QK_E4M3 + j];
+            amax = MAX(amax, fabsf(v));
+        }
+
+        const float d = amax / 448.0f; // 448 = e4m3 max finite
+        const float id = d ? 1.0f/d : 0.0f;
+
+        y[i].d = GGML_FP32_TO_FP16(d);
+
+        for (int j = 0; j < QK_E4M3; ++j) {
+            y[i].qs[j] = ggml_fp32_to_e4m3(x[i*QK_E4M3 + j]*id);
+        }
+    }
+}
+
 // reference implementation for deterministic creation of model files
 void quantize_row_q8_1_ref(const float * GGML_RESTRICT x, block_q8_1 * GGML_RESTRICT y, int64_t k) {
     assert(QK8_1 == 32);
@@ -562,6 +585,22 @@ void dequantize_row_q8_0(const block_q8_0 * GGML_RESTRICT x, float * GGML_RESTRI
 
         for (int j = 0; j < qk; ++j) {
             y[i*qk + j] = x[i].qs[j]*d;
+        }
+    }
+}
+
+void dequantize_row_e4m3(const block_e4m3 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    static const int qk = QK_E4M3;
+
+    assert(k % qk == 0);
+
+    const int nb = k / qk;
+
+    for (int i = 0; i < nb; i++) {
+        const float d = GGML_FP16_TO_FP32(x[i].d);
+
+        for (int j = 0; j < qk; ++j) {
+            y[i*qk + j] = ggml_e4m3_to_fp32(x[i].qs[j])*d;
         }
     }
 }
@@ -2309,6 +2348,12 @@ size_t quantize_nvfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst,
     GGML_UNUSED(quant_weights);
     quantize_row_nvfp4_ref(src, dst, (int64_t)nrow*n_per_row);
     return nrow * ggml_row_size(GGML_TYPE_NVFP4, n_per_row);
+}
+
+size_t quantize_e4m3(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrow, int64_t n_per_row, const float * quant_weights) {
+    GGML_UNUSED(quant_weights);
+    quantize_row_e4m3_ref(src, dst, (int64_t)nrow*n_per_row);
+    return nrow * ggml_row_size(GGML_TYPE_E4M3, n_per_row);
 }
 
 // ====================== Ternary (de)-quantization (BitNet b1.58 and TriLMs)
@@ -5566,6 +5611,10 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
                 // UE4M3 scales are uint8_t — all byte values are valid
                 GGML_UNUSED(data);
                 GGML_UNUSED(nb);
+            } break;
+        case GGML_TYPE_E4M3:
+            {
+                VALIDATE_ROW_DATA_D_F16_IMPL(block_e4m3, data, nb);
             } break;
         case GGML_TYPE_Q2_K:
             {

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -25,6 +25,7 @@ GGML_API void quantize_row_q8_1_ref(const float * GGML_RESTRICT x, block_q8_1 * 
 
 GGML_API void quantize_row_mxfp4_ref(const float * GGML_RESTRICT x, block_mxfp4 * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_nvfp4_ref(const float * GGML_RESTRICT x, block_nvfp4 * GGML_RESTRICT y, int64_t k);
+GGML_API void quantize_row_e4m3_ref (const float * GGML_RESTRICT x, block_e4m3 * GGML_RESTRICT y, int64_t k);
 
 GGML_API void quantize_row_q2_K_ref(const float * GGML_RESTRICT x, block_q2_K * GGML_RESTRICT y, int64_t k);
 GGML_API void quantize_row_q3_K_ref(const float * GGML_RESTRICT x, block_q3_K * GGML_RESTRICT y, int64_t k);
@@ -54,6 +55,7 @@ GGML_API void dequantize_row_q8_0(const block_q8_0 * GGML_RESTRICT x, float * GG
 
 GGML_API void dequantize_row_mxfp4(const block_mxfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_nvfp4(const block_nvfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+GGML_API void dequantize_row_e4m3 (const block_e4m3 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_q2_K(const block_q2_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_q3_K(const block_q3_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
@@ -104,6 +106,7 @@ GGML_API size_t quantize_q8_0(const float * GGML_RESTRICT src, void * GGML_RESTR
 
 GGML_API size_t quantize_mxfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 GGML_API size_t quantize_nvfp4(const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
+GGML_API size_t quantize_e4m3 (const float * GGML_RESTRICT src, void * GGML_RESTRICT dst, int64_t nrows, int64_t n_per_row, const float * imatrix);
 
 GGML_API void iq2xs_init_impl(enum ggml_type type);
 GGML_API void iq2xs_free_impl(enum ggml_type type);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -764,6 +764,14 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .to_float                 = (ggml_to_float_t) dequantize_row_nvfp4,
         .from_float_ref           = (ggml_from_float_t)quantize_row_nvfp4_ref,
     },
+    [GGML_TYPE_E4M3] = {
+        .type_name                = "e4m3",
+        .blck_size                = QK_E4M3,
+        .type_size                = sizeof(block_e4m3),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_e4m3,
+        .from_float_ref           = (ggml_from_float_t) quantize_row_e4m3_ref,
+    },
     [GGML_TYPE_Q2_K] = {
         .type_name                = "q2_K",
         .blck_size                = QK_K,
@@ -1431,6 +1439,7 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_Q8_0:          wtype = GGML_TYPE_Q8_0;  break;
         case GGML_FTYPE_MOSTLY_MXFP4:         wtype = GGML_TYPE_MXFP4; break;
         case GGML_FTYPE_MOSTLY_NVFP4:         wtype = GGML_TYPE_NVFP4; break;
+        case GGML_FTYPE_MOSTLY_E4M3:          wtype = GGML_TYPE_E4M3;  break;
         case GGML_FTYPE_MOSTLY_Q2_K:          wtype = GGML_TYPE_Q2_K;  break;
         case GGML_FTYPE_MOSTLY_Q3_K:          wtype = GGML_TYPE_Q3_K;  break;
         case GGML_FTYPE_MOSTLY_Q4_K:          wtype = GGML_TYPE_Q4_K;  break;
@@ -7761,6 +7770,7 @@ size_t ggml_quantize_chunk(
         case GGML_TYPE_Q8_0:    result = quantize_q8_0   (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_MXFP4:   result = quantize_mxfp4  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_NVFP4:   result = quantize_nvfp4  (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
+        case GGML_TYPE_E4M3:    result = quantize_e4m3   (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q2_K:    result = quantize_q2_K   (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q3_K:    result = quantize_q3_K   (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;
         case GGML_TYPE_Q4_K:    result = quantize_q4_K   (src + start, (char *) dst + start_row * row_size, nrows, n_per_row, imatrix); break;

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -4534,6 +4534,7 @@ class GGMLQuantizationType(IntEnum):
     NVFP4   = 40
     Q1_0    = 41
     Q2_0    = 42
+    E4M3    = 43
 
 
 class ExpertGatingFuncType(IntEnum):
@@ -4590,6 +4591,7 @@ class LlamaFileType(IntEnum):
     MOSTLY_NVFP4         = 39  # except 1d tensors
     MOSTLY_Q1_0          = 40  # except 1d tensors
     MOSTLY_Q2_0          = 41  # except 1d tensors
+    MOSTLY_E4M3          = 42  # except 1d tensors
 
     GUESSED              = 1024  # not specified in the model file
 
@@ -4716,6 +4718,7 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.NVFP4:   (64, 4 + 32),
     GGMLQuantizationType.Q1_0:    (128, 2 + 16),
     GGMLQuantizationType.Q2_0:    (64, 2 + 16),
+    GGMLQuantizationType.E4M3:    (32, 2 + 32),
 }
 
 

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -764,6 +764,58 @@ class NVFP4(__Quant, qtype=GGMLQuantizationType.NVFP4):
         return (d * vals.astype(np.float32)).reshape(n_super, 64)
 
 
+class E4M3(__Quant, qtype=GGMLQuantizationType.E4M3):
+    @staticmethod
+    def fp32_to_e4m3(x: np.ndarray) -> np.ndarray:
+        # matches ggml_fp32_to_e4m3 in ggml-impl.h
+        sign = np.where(x < 0.0, np.uint8(0x80), np.uint8(0))
+        ax = np.minimum(np.abs(x).astype(np.float32), np.float32(448.0))
+        bits = ax.view(np.uint32)
+        fp32_exp = ((bits >> 23) & 0xFF).astype(np.int32) - 127
+        fp32_man = ((bits >> 20) & 0x7).astype(np.int32)
+        exp = fp32_exp + 7
+
+        # sub == 8 rounds up to the smallest normal (0x08)
+        sub = (ax * np.float32(512.0) + np.float32(0.5)).astype(np.int32)
+
+        man = fp32_man + ((bits >> 19) & 1).astype(np.int32)
+        carry = man > 7
+        man = np.where(carry, 0, man)
+        exp_n = np.where(carry, exp + 1, exp)
+        overflow = (exp_n > 15) | ((exp_n == 15) & (man == 7))
+        norm = np.where(overflow, 0x7E, (exp_n << 3) | man)
+
+        mag = np.where(ax > 0.0, np.where(exp <= 0, sub, norm), 0).astype(np.uint8)
+        return mag | sign
+
+    @staticmethod
+    def e4m3_to_fp32(x: np.ndarray) -> np.ndarray:
+        # matches ggml_e4m3_to_fp32 in ggml-impl.h
+        sign = np.where((x & 0x80) != 0, np.float32(-1.0), np.float32(1.0))
+        exp = ((x >> 3) & 0xF).astype(np.int32)
+        man = (x & 0x7).astype(np.float32)
+        val = sign * np.where(exp == 0,
+                              man * np.float32(2.0 ** -9),
+                              (1.0 + man / 8.0) * np.exp2((exp - 7).astype(np.float32)))
+        return np.where((x & 0x7F) == 0x7F, np.float32(np.nan), val.astype(np.float32))
+
+    @classmethod
+    def quantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
+        d = abs(blocks).max(axis=1, keepdims=True) / 448
+        with np.errstate(divide="ignore"):
+            id = np.where(d == 0, 0, 1 / d)
+        qs = cls.fp32_to_e4m3(blocks * id)
+
+        d = d.astype(np.float16).view(np.uint8)
+        return np.concatenate([d, qs], axis=1)
+
+    @classmethod
+    def dequantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
+        d, qs = np.split(blocks, [2], axis=1)
+        d = d.view(np.float16).astype(np.float32)
+        return cls.e4m3_to_fp32(qs) * d
+
+
 class IQ2_XXS(__Quant, qtype=GGMLQuantizationType.IQ2_XXS):
     ksigns: bytes = (
         b"\x00\x81\x82\x03\x84\x05\x06\x87\x88\x09\x0a\x8b\x0c\x8d\x8e\x0f"

--- a/gguf-py/gguf/scripts/gguf_convert_endian.py
+++ b/gguf-py/gguf/scripts/gguf_convert_endian.py
@@ -66,6 +66,7 @@ byteswap_tensors = {
     gguf.GGMLQuantizationType.Q6_K:  byteswap_q6_k,
     gguf.GGMLQuantizationType.MXFP4: byteswap_noop,
     gguf.GGMLQuantizationType.NVFP4: byteswap_noop,
+    gguf.GGMLQuantizationType.E4M3:  byteswap_q8_0,
 }
 
 

--- a/gguf-py/tests/test_quants.py
+++ b/gguf-py/tests/test_quants.py
@@ -69,6 +69,7 @@ class GGMLQuants:
             "tq1_0", "tq2_0",
             "mxfp4",
             "nvfp4",
+            "e4m3",
             "iq2_xxs", "iq2_xs", "iq2_s", "iq3_xxs", "iq3_s", "iq1_s", "iq1_m",
             "iq4_nl", "iq4_xs",
         ):

--- a/include/llama.h
+++ b/include/llama.h
@@ -156,6 +156,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_NVFP4         = 39, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q1_0          = 40, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q2_0          = 41, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_E4M3          = 42, // except 1d tensors
 
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
     };

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -45,6 +45,7 @@ const char * llama_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q8_0:      name = LLAMA_FTYPE_PREFIX "Q8_0"; break;
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: name = LLAMA_FTYPE_PREFIX "MXFP4 MoE"; break;
         case LLAMA_FTYPE_MOSTLY_NVFP4:     name = LLAMA_FTYPE_PREFIX "NVFP4"; break;
+        case LLAMA_FTYPE_MOSTLY_E4M3:      name = LLAMA_FTYPE_PREFIX "E4M3"; break;
         case LLAMA_FTYPE_MOSTLY_Q2_K:      name = LLAMA_FTYPE_PREFIX "Q2_K - Medium"; break;
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:    name = LLAMA_FTYPE_PREFIX "Q2_K - Small"; break;
         case LLAMA_FTYPE_MOSTLY_Q3_K_S:    name = LLAMA_FTYPE_PREFIX "Q3_K - Small"; break;
@@ -767,6 +768,7 @@ llama_model_loader::llama_model_loader(
             case GGML_TYPE_IQ4_XS:  ftype = LLAMA_FTYPE_MOSTLY_IQ4_XS;  break;
             case GGML_TYPE_IQ3_S:   ftype = LLAMA_FTYPE_MOSTLY_IQ3_S;   break;
             case GGML_TYPE_NVFP4:   ftype = LLAMA_FTYPE_MOSTLY_NVFP4;   break;
+            case GGML_TYPE_E4M3:    ftype = LLAMA_FTYPE_MOSTLY_E4M3;    break;
             case GGML_TYPE_Q1_0:    ftype = LLAMA_FTYPE_MOSTLY_Q1_0;    break;
             case GGML_TYPE_Q2_0:    ftype = LLAMA_FTYPE_MOSTLY_Q2_0;    break;
             default:

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -802,6 +802,7 @@ ggml_type llama_ftype_get_default_type(llama_ftype ftype) {
         case LLAMA_FTYPE_ALL_F32:     return GGML_TYPE_F32;
         case LLAMA_FTYPE_MOSTLY_Q1_0: return GGML_TYPE_Q1_0;
         case LLAMA_FTYPE_MOSTLY_Q2_0: return GGML_TYPE_Q2_0;
+        case LLAMA_FTYPE_MOSTLY_E4M3: return GGML_TYPE_E4M3;
 
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return GGML_TYPE_MXFP4;
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7737,6 +7737,7 @@ static const ggml_type all_types[] = {
     GGML_TYPE_Q8_0,
     GGML_TYPE_Q1_0,
     GGML_TYPE_MXFP4, GGML_TYPE_NVFP4,
+    GGML_TYPE_E4M3,
     GGML_TYPE_Q2_K, GGML_TYPE_Q3_K,
     GGML_TYPE_Q4_K, GGML_TYPE_Q5_K,
     GGML_TYPE_Q6_K,

--- a/tests/test-quant-type-selection.cpp
+++ b/tests/test-quant-type-selection.cpp
@@ -57,6 +57,7 @@ static const ftype_name_entry ftype_name_table[] = {
     { "TQ2_0",     LLAMA_FTYPE_MOSTLY_TQ2_0     },
     { "MXFP4_MOE", LLAMA_FTYPE_MOSTLY_MXFP4_MOE },
     { "NVFP4",     LLAMA_FTYPE_MOSTLY_NVFP4     },
+    { "E4M3",      LLAMA_FTYPE_MOSTLY_E4M3      },
 };
 
 static llama_ftype llama_ftype_from_name(const char * name) {

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -67,6 +67,7 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q5_K_M",   LLAMA_FTYPE_MOSTLY_Q5_K_M,   " 5.33G, +0.0569 ppl @ Llama-3-8B",  },
     { "Q6_K",     LLAMA_FTYPE_MOSTLY_Q6_K,     " 6.14G, +0.0217 ppl @ Llama-3-8B",  },
     { "Q8_0",     LLAMA_FTYPE_MOSTLY_Q8_0,     " 7.96G, +0.0026 ppl @ Llama-3-8B",  },
+    { "E4M3",     LLAMA_FTYPE_MOSTLY_E4M3,     " 8.5 bpw fp8 quantization",          },
     { "F16",      LLAMA_FTYPE_MOSTLY_F16,      "14.00G, +0.0020 ppl @ Mistral-7B",  },
     { "BF16",     LLAMA_FTYPE_MOSTLY_BF16,     "14.00G, -0.0050 ppl @ Mistral-7B",  },
     { "F32",      LLAMA_FTYPE_ALL_F32,         "26.00G              @ 7B",          },


### PR DESCRIPTION
## Overview

Add GGML_TYPE_E4M3 (OCP e4m3fn), a CPU fp8 quantization type, so native-fp8 weights load and run as fp8 instead of being dequantized to f16 (double the memory) or approximated as q8_0. Goal is fp8 for CPU and GPU; per the CPU-first rule this is the CPU side, and the GPU backends follow in separate PRs.

Block is q8_0-shaped (fp16 scale + 32 fp8 bytes per block), dotting against q8_0 activations.

## Additional information

What's in here:

- GGML_TYPE_E4M3 type, block struct, e4m3fn conversion + reference quant/dequant
- CPU: scalar, AVX2, NEON vec_dot; repacked 8x8 gemv/gemm for faster prefill
- gguf-py: type constant, numpy quant/dequant, endian convert
- tests: test-backend-ops + test-quantize-fns

Test model (small, runnable): https://huggingface.co/RapidMark/Qwen2.5-1.5B-E4M3-GGUF
This is the exact e4m3 gguf the numbers below were measured on. The f16 baseline and q8_0 comparison are regenerated from the base model (Qwen/Qwen2.5-1.5B-Instruct) with the quantize command in Reproduction.

**Evaluation.** Qwen2.5-1.5B-Instruct, wikitext-2-raw test (full, 584 chunks, n_ctx 512), pure CPU. The similar-size comparison type is Q8_0 (both are one fp16 scale + 32 one-byte elements per block).

Perplexity and KL-divergence vs f16:

| type | size | PPL | vs f16 | Mean KLD | Median KLD | Max KLD | 99% KLD | same-top-token |
|------|-----:|----:|-------:|---------:|-----------:|--------:|--------:|---------------:|
| f16  | 2.88 GiB | 10.134 | -      | -       | -       | -     | -       | -      |
| q8_0 | 1.53 GiB | 10.168 | +0.33% | 0.00200 | 0.00158 | 0.213 | 0.00969 | 97.33% |
| e4m3 | 1.48 GiB | 10.248 | +1.12% | 0.01146 | 0.00937 | 0.846 | 0.05113 | 93.64% |

Pure-CPU throughput (llama-bench, 64 threads):

| type | pp512 (t/s) | tg128 (t/s) |
|------|------------:|------------:|
| f16  | 528.3 | 19.2 |
| q8_0 | 499.3 | 33.1 |
| e4m3 | 253.2 | 34.6 |

e4m3 lands a little behind q8_0 on accuracy, which is expected: q8_0's linear int8 is near-lossless for these weights, and e4m3 spends half its bits on the exponent. On CPU its value is faithful fp8 at half the size of f16, not beating q8_0.

The repacked gemv/gemm is in this PR (not just vec_dot) because it's a 2.5x prefill speedup: on the same model and box, pp512 is 269.8 t/s with the repacked gemm vs 106.4 t/s on the plain vec_dot (tg128 33.1 vs 27.9).

**Reproduction.**

    # f16 baseline from the base model, then the two quants (e4m3 also downloadable from the HF link above)
    llama-quantize qwen2.5-1.5b-f16.gguf qwen2.5-1.5b-q8_0.gguf Q8_0
    llama-quantize qwen2.5-1.5b-f16.gguf qwen2.5-1.5b-e4m3.gguf E4M3

    # perplexity + KL-divergence vs f16
    llama-perplexity -m qwen2.5-1.5b-f16.gguf  -f wiki.test.raw --kl-divergence-base kld-base.dat -t 64
    llama-perplexity -m qwen2.5-1.5b-q8_0.gguf -f wiki.test.raw --kl-divergence --kl-divergence-base kld-base.dat -t 64
    llama-perplexity -m qwen2.5-1.5b-e4m3.gguf -f wiki.test.raw --kl-divergence --kl-divergence-base kld-base.dat -t 64

    # pure-CPU throughput
    llama-bench -m qwen2.5-1.5b-f16.gguf -m qwen2.5-1.5b-q8_0.gguf -m qwen2.5-1.5b-e4m3.gguf -t 64 -p 512 -n 128

**Validation.** test-backend-ops -b CPU passes 16176/16176 (e4m3 MUL_MAT included). Verified on x86 (MSVC and Linux GCC), ARM NEON, and Apple (Metal correctly declines e4m3 and falls back to the CPU path). The gguf-py numpy class is bit-exact against the C library (test_quants.py).

**Environment.**

- CPU: AMD Threadripper 3970X (Zen2), 64 threads
- OS / compiler: Windows 11, MSVC (Release)
- Cross-checked: Linux (GCC), aarch64 (NEON), Apple Silicon (Metal)
- Commit: 136a83339

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used to understand the codebase, run the test suite across the available hardware, provide peer review, and offer suggestions. The design and code are mine and I can explain any line.
