### PR TITLE
perplexity : Printing PPL when stride is used (#25335) [no release]

### DIFF
--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -348,6 +348,7 @@ static results_perplexity perplexity_v2(llama_context * ctx, const common_params
 
     int count = 0;
     double nll = 0.0;
+    double nll2 = 0.0;
 
     const int n_seq = std::max(1, n_batch / n_ctx);
     LOG_INF("%s: computing over %d chunks, n_ctx=%d, batch_size=%d, n_seq=%d\n", __func__, n_chunk, n_ctx, n_batch, n_seq);
@@ -426,7 +427,9 @@ static results_perplexity perplexity_v2(llama_context * ctx, const common_params
             logit_history[start + j + 1] = tok_logits[tokens[start + j + 1]];
             prob_history[start + j + 1]  = prob;
 
-            nll += -std::log(prob);
+            const double log_p = -std::log(prob);
+            nll += log_p;
+            nll2 += log_p * log_p;
             ++count;
         }
         // perplexity is e^(average negative log-likelihood)
@@ -438,7 +441,18 @@ static results_perplexity perplexity_v2(llama_context * ctx, const common_params
     }
     LOG("\n");
 
-    return {tokens, std::exp(nll / count), logit_history, prob_history};
+    double final_nll = nll / count;
+    double final_nll2 = nll2 / count;
+    const double ppl = exp(final_nll);
+    final_nll2 -= final_nll * final_nll;
+    if (final_nll2 > 0) {
+        final_nll2 = std::sqrt(final_nll2 / (count - 1));
+        LOG_INF("Final estimate: PPL = %.4lf +/- %.5lf\n", ppl, final_nll2 * ppl);
+    } else {
+        LOG_ERR("Unexpected negative standard deviation of log(prob)\n");
+    }
+
+    return {tokens, ppl, logit_history, prob_history};
 }
 
 static results_perplexity perplexity(llama_context * ctx, const common_params & params, const int32_t n_ctx) {


### PR DESCRIPTION
## Overview

Does calculate and print the estimated perplexity the same way as if no stride option would be used. Addressing issue #25335

## Additional information

Example that now even with `stride` prints the final estimate:
```
llama-perplexity -c 16384 --ppl-stride 4096 -b 2048 -ub 2048 --no-warmup -ngl all -f "data/css-none.txt" -hf unsloth/gemma-4-31B-it-qat-GGUF:UD-Q4_K_XL
0.00.966.251 I Will perform strided perplexity calculation -> adjusting context size from 16384 to 18432
0.00.966.306 I common_init_result: fitting params to device memory ...
0.00.966.307 I common_init_result: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)
0.03.918.212 W load: override 'tokenizer.ggml.add_bos_token' to 'true' for Gemma4
0.03.982.940 W load: control-looking token:    212 '</s>' was not control-type; this is probably a bug in the model. its type will be overridden
0.03.983.520 W load: control-looking token:     50 '<|tool_response>' was not control-type; this is probably a bug in the model. its type will be overridden
0.04.012.195 W load: special_eog_ids contains '<|tool_response>', removing '</s>' token from EOG list
0.24.433.777 W llama_context: n_ctx_seq (18432) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
0.24.584.506 I
0.24.584.601 I system_info: n_threads = 6 (n_threads_batch = 6) / 6 | CUDA : ARCHS = 1200 | FORCE_MMQ = 1 | USE_GRAPHS = 1 | PEER_MAX_BATCH_SIZE = 128 | FA_ALL_QUANTS = 1 | BLACKWELL_NATIVE_FP4 = 1 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | OPENMP = 1 | REPACK = 1 |
0.24.584.607 I perplexity_v2: tokenizing the input ..
0.24.628.429 I perplexity_v2: have 43190 tokens. Calculation chunk = 18432
0.24.628.432 I perplexity_v2: computing over 7 chunks, n_ctx=18432, batch_size=2048, n_seq=1
0.59.222.729 I perplexity_v2: 34.59 seconds per pass - ETA 4.03 minutes
[1]5.4264,[2]4.2845,[3]4.0225,[4]4.1034,[5]4.7461,[6]4.3093,[7]4.1548,
5.10.081.545 I Final estimate: PPL = 4.1548 +/- 0.07346
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
