### PR TITLE
OpenCL: fix sub_group_shuffle_xor compatibility for Qualcomm Adreno GPUs

### DIFF
--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -8,6 +8,18 @@
 #define HAS_SUBGROUP_SHUFFLE 1
 #endif
 
+#ifdef cl_qcom_subgroup_shuffle
+#pragma OPENCL EXTENSION cl_qcom_subgroup_shuffle : enable
+
+#undef sub_group_shuffle_xor
+#define sub_group_shuffle_xor(val, mask) \
+    qcom_sub_group_shuffle_xor( \
+        (val), \
+        (mask), \
+        CLK_SUB_GROUP_SHUFFLE_WIDTH_WAVE_SIZE_QCOM, \
+        0.0f)
+#endif
+
 #define ACC_TYPE float
 #define ACC_TYPE4 float4
 #define Q_DATA_TYPE4 float4

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
@@ -12,6 +12,18 @@
 #define HAS_SUBGROUP_SHUFFLE 1
 #endif
 
+#ifdef cl_qcom_subgroup_shuffle
+#pragma OPENCL EXTENSION cl_qcom_subgroup_shuffle : enable
+
+#undef sub_group_shuffle_xor
+#define sub_group_shuffle_xor(val, mask) \
+    qcom_sub_group_shuffle_xor( \
+        (val), \
+        (mask), \
+        CLK_SUB_GROUP_SHUFFLE_WIDTH_WAVE_SIZE_QCOM, \
+        0.0f)
+#endif
+
 // Flash attention: Q=f32, K=q4_0, V=q4_0.
 // Block = half d + uchar qs[16]; qs[j] low/high nibble -> elem j / j+16.
 // Dequant: val[i] = d * (nibble_i - 8). dp4a path runs on raw 0..15 nibbles

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -12,6 +12,18 @@
 #define HAS_SUBGROUP_SHUFFLE 1
 #endif
 
+#ifdef cl_qcom_subgroup_shuffle
+#pragma OPENCL EXTENSION cl_qcom_subgroup_shuffle : enable
+
+#undef sub_group_shuffle_xor
+#define sub_group_shuffle_xor(val, mask) \
+    qcom_sub_group_shuffle_xor( \
+        (val), \
+        (mask), \
+        CLK_SUB_GROUP_SHUFFLE_WIDTH_WAVE_SIZE_QCOM, \
+        0.0f)
+#endif
+
 // Flash attention: Q=f32, K=q8_0, V=q8_0.
 
 #define ACC_TYPE float


### PR DESCRIPTION
This PR fixes OpenCL kernel compilation failures on Qualcomm Adreno GPUs
when using Flash Attention kernels.

### Issue
On Adreno OpenCL implementations, `sub_group_shuffle_xor()` is not
provided under `cl_khr_subgroup_shuffle`, even though subgroup support is
advertised.

Compilation fails with:

implicit declaration of function 'sub_group_shuffle_xor'

### Root cause
Qualcomm OpenCL exposes subgroup shuffle functionality via
`cl_qcom_subgroup_shuffle` extension and `qcom_sub_group_shuffle_xor`,
instead of the standard Khronos `sub_group_shuffle_xor` builtin.

### Fix
Add a compatibility macro for Qualcomm devices:

```c
#ifdef cl_qcom_subgroup_shuffle
#pragma OPENCL EXTENSION cl_qcom_subgroup_shuffle : enable

#undef sub_group_shuffle_xor
#define sub_group_shuffle_xor(val, mask) \
    qcom_sub_group_shuffle_xor( \
        (val), \
        (mask), \
        CLK_SUB_GROUP_SHUFFLE_WIDTH_WAVE_SIZE_QCOM, \
        0.0f)
#endif
```

### Affected files
- `flash_attn_f32_f16.cl`
- `flash_attn_f32_q4_0.cl`
- `flash_attn_f32_q8_0.cl`

### Tested on
- Snapdragon Adreno 740 (Android OpenCL 3.0 Qualcomm driver)

### Notes
This aligns Flash Attention kernels with existing Adreno-specific implementations already present in other kernels (e.g. mul_mv_f16_f32_l4.cl).