### PR TITLE
ggml-cpu: detect AVX-VNNI in MSVC native builds

### DIFF
--- a/ggml/src/ggml-cpu/cmake/FindSIMD.cmake
+++ b/ggml/src/ggml-cpu/cmake/FindSIMD.cmake
@@ -40,6 +40,18 @@ set(AVX2_CODE "
     }
 ")
 
+set(AVX_VNNI_CODE "
+    #include <immintrin.h>
+    int main()
+    {
+        __m256i acc = _mm256_setzero_si256();
+        const __m256i a = _mm256_set1_epi8(1);
+        const __m256i b = _mm256_set1_epi8(2);
+        acc = _mm256_dpbusd_avx_epi32(acc, a, b);
+        return _mm256_extract_epi32(acc, 0) == 8 ? 0 : 1;
+    }
+")
+
 set(FMA_CODE "
     #include <immintrin.h>
     int main()
@@ -90,6 +102,13 @@ if ((NOT ${AVX2_FOUND}) OR (NOT ${FMA_FOUND}))
     set(GGML_AVX2 OFF)
 else()
     set(GGML_AVX2 ON)
+endif()
+
+check_sse("AVX_VNNI" " ;/arch:AVX2")
+if ((NOT ${AVX_VNNI_FOUND}) OR (NOT ${AVX2_FOUND}))
+    set(GGML_AVX_VNNI OFF)
+else()
+    set(GGML_AVX_VNNI ON)
 endif()
 
 check_sse("AVX512" " ;/arch:AVX512")


### PR DESCRIPTION
FindSIMD.cmake (used for instruction-set detection when building with MSVC and GGML_NATIVE) only probes AVX, AVX2, FMA and AVX512, so MSVC builds never define __AVXVNNI__ and always fall back to the maddubs/madd/add int8 dot-product sequence even on CPUs that support vpdpbusd (Intel Alder Lake and newer).

Add a compile-and-run probe for AVX-VNNI, mirroring the existing checks, and enable GGML_AVX_VNNI when it succeeds.

Measured on i5-13420H (Raptor Lake), Qwen2.5-0.5B-Instruct Q4_0, 8 threads: pp512 570 -> 753 t/s (+32%), tg128 unchanged. Perplexity is bit-identical; test-quantize-fns passes.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
