### PR TITLE
ggml : make quantization bit-reproducible across compilers and architectures (-ffp-contract=off on ggml-quants.c)

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -208,6 +208,22 @@ add_library(ggml-base
             ggml-quants.h
             gguf.cpp)
 
+# ggml-quants.c contains the reference quantization kernels used when producing
+# quantized model files (ggml_quantize_chunk). The k-quant / i-quant scale
+# search loops in this file are sensitive to floating point contraction (FMA):
+# when the compiler is allowed to contract a*b+c, the selected scales - and
+# therefore the quantized output bits - differ between compilers and
+# architectures. Disabling contraction for this single translation unit makes
+# quantization results bit-identical across compilers and architectures
+# (ref: <link-to-evidence>). Quantization is an offline, one-time operation;
+# the measured cost ranges from none (Apple Silicon/clang) to ~33% slower
+# (x86-64/gcc). Runtime inference kernels (ggml-cpu) are not affected.
+# A '#pragma STDC FP_CONTRACT OFF' in the source is not sufficient:
+# GCC does not implement the pragma and ignores it with a warning.
+if (CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(ggml-quants.c PROPERTIES COMPILE_OPTIONS "-ffp-contract=off")
+endif()
+
 set_target_properties(ggml-base PROPERTIES
     VERSION ${GGML_VERSION}
     SOVERSION ${GGML_VERSION_MAJOR}


### PR DESCRIPTION
<html><head></head><body><h2>Overview</h2><p>This PR makes CPU quantization reproducible across the default GNU/Clang CMake builds by disabling floating-point contraction for <code inline="">ggml/src/ggml-quants.c</code> only. 
The problem is that fused multiply-add changes near tie error comparisons inside the k-quant scale-search loops; which produces different quantized bytes across compilers and architectures despite each platform is locally deterministic. 

The change is narrow and does not modify the quantization algorithm or runtime kernels.</p><h2>Additional information</h2><p>

The og issue was reproduced with the same F16 input, imatrix, quantization tag (<code inline="">b3821</code>), and quant type, where Linux/x86_64-gcc and macOS/arm64-clang differed in 113 of 147 tensors despite only 0.196% of bytes changing. 

My control experiments confirmed that the imatrix was applied identically and while Rosetta and native Apple Silicon still produced different outputs, showing that both architecture and compiler influence the generated bits. The proposed fix: 16-line CMake change that applies <code inline="">-ffp-contract=off</code> only to <code inline="">ggml-quants.c</code> for GNU and Clang. 

Leg | Result
-- | --
b3821 default, ubuntu vs macos | Q4_K_M / Q6_K / IQ4_XS / imatrix-Q4_K_M DIFFER; Q8_0 matches (both models)
b3821 strict (global -ffp-contract=off + no-vectorize), cross-arch | all five quants bit-identical, both models
master (pinned 20a04b2) unpatched default, cross-arch | Q4_K_M / Q6_K / IQ4_XS DIFFER; Q8_0 matches
master + this patch, default flags otherwise, cross-arch | all four quants bit-identical
master, MSVC default (windows-latest) | equals the patched GNU/Clang hashes on all four quants

<p>The key result is that the patch without broader strict floating-point settings produces identical hashes across gcc/Linux, clang/macOS, and MSVC/Windows on current master. 

MSVC already emits the matching output under its default floating-point mode, so this change aligns GNU/Clang with existing MSVC behavior rather than introducing a new result. 

CI runs and supporting data are available in the evidence repository: <a href="https://github.com/theadamdanielsson/gguf-quant-determinism">https://github.com/theadamdanielsson/gguf-quant-determinism</a>.</p>
<p>The executed performance testing on the current master showed no significant burden on the public CI runners, and perplexity measurements remained effectively unchanged relative to the normal quantization error. This PR adresses the default GNU/Clang/AppleClang CMake builds. The toolchain configurations that enable broader fast-math transformations, like <code inline="">-ffp-model=fast</code> or IntelLLVM fast-math defaults, are outside the scope of this change. For mainstream architectures this affects only quantization, though generic fallback inference paths on architectures without SIMD can also execute ref code from the same translation unit.</p><h2>Requirements</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have tested the changes locally and verified the behavior with the available CI evidence.</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> AI was used to automate the experiments and build the CI harness. The analysis and conclusions were written by me.</p></li></ul></body></html>