### PR TITLE
model: add support for Hy3 (HYV3ForCausalLM)

### DIFF
--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -106,6 +106,7 @@ TEXT_MODEL_MAP: dict[str, str] = {
     "HunYuanDenseV1ForCausalLM": "hunyuan",
     "HunYuanMoEV1ForCausalLM": "hunyuan",
     "HunYuanVLForConditionalGeneration": "hunyuan",
+    "HYV3ForCausalLM": "hunyuan",
     "IQuestCoderForCausalLM": "llama",
     "InternLM2ForCausalLM": "internlm",
     "InternLM3ForCausalLM": "internlm",

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -437,6 +437,19 @@ class ModelBase:
                         tensors_to_remove.append(name)
                         if self._fp8_as_q8:
                             self._fp8_dequantized.add(weight_name)
+                    # per-tensor static FP8 (e.g. AngelSlim: Hy3-FP8): scalar weight_scale multiplier
+                    if name.endswith(".weight_scale"):
+                        weight_name = name.removesuffix("_scale")
+                        w = self.model_tensors[weight_name]
+                        s = self.model_tensors[name]
+                        # scalar scale: never block-expanded, even if the quant config
+                        # declares weight_block_size for its block-wise tensors
+                        self.model_tensors[weight_name] = lambda w=w, s=s: dequant_simple(w(), s(), None)
+                        tensors_to_remove.append(name)
+                        if self._fp8_as_q8:
+                            self._fp8_dequantized.add(weight_name)
+                    if name.endswith(".input_scale"):  # static activation scale, unused
+                        tensors_to_remove.append(name)
                     if name.endswith(".activation_scale"):  # unused
                         tensors_to_remove.append(name)
                     if name.endswith("_activation_scale"):  # Mistral-Small-4-119B-2602, unused
@@ -1248,6 +1261,9 @@ class TextModel(ModelBase):
                 pass
             elif rope_type.lower() == "llama3":
                 # Handled in generate_extra_tensors
+                pass
+            elif rope_type == "default":
+                # standard rope_parameters value for plain RoPE without scaling
                 pass
             else:
                 logger.warning(f"Unknown RoPE type: {rope_type}")

--- a/conversion/hunyuan.py
+++ b/conversion/hunyuan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 from pathlib import Path
 from typing import Callable, Iterable, TYPE_CHECKING
@@ -286,6 +287,112 @@ class HunYuanModel(TextModel):
                 return
 
         yield from super().modify_tensors(data_torch, name, bid)
+
+
+@ModelBase.register("HYV3ForCausalLM")
+class HYV3Model(TextModel):
+    model_arch = gguf.MODEL_ARCH.HY_V3
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # block_count includes the NextN/MTP prediction layer
+        self.block_count = self.hparams["num_hidden_layers"] + self.hparams.get("num_nextn_predict_layers", 0)
+        self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
+
+    def set_vocab(self):
+        tokens, toktypes, tokpre = self.get_vocab_base()
+        self.gguf_writer.add_tokenizer_model("gpt2")
+        self.gguf_writer.add_tokenizer_pre(tokpre)
+        self.gguf_writer.add_token_list(tokens)
+        self.gguf_writer.add_token_types(toktypes)
+        special_vocab = gguf.SpecialVocab(self.dir_model, load_merges=True)
+        # The stock chat template builds special-token names with '<...{}...>'.format(HYTK)
+        # where HYTK is a literal constant; jinja engines without str.format() (e.g. minja
+        # in llama.cpp) fail to parse it. Resolve those calls statically before embedding.
+        if isinstance(special_vocab.chat_template, str) and ".format(HYTK)" in special_vocab.chat_template:
+            hytk = re.search(r"set\s+HYTK\s*=\s*(['\"])(.*?)\1", special_vocab.chat_template)
+            if hytk is not None:
+                special_vocab.chat_template = re.sub(
+                    r"(['\"])([^'\"]*)\{\}([^'\"]*)\1\.format\(HYTK\)",
+                    lambda m: f"{m.group(1)}{m.group(2)}{hytk.group(2)}{m.group(3)}{m.group(1)}",
+                    special_vocab.chat_template,
+                )
+            if ".format(HYTK)" in special_vocab.chat_template:
+                logger.warning("chat template still contains .format(HYTK) calls after static resolution; "
+                               "the embedded template will not parse with jinja engines lacking str.format()")
+        special_vocab.add_to_gguf(self.gguf_writer)
+        # EOS stays <|hy_eos|> (eos_token_id, ends assistant turns per the chat template);
+        # eod_token_id marks document boundaries and is registered as an additional stop.
+        if (eod_token_id := self.hparams.get("eod_token_id")) is not None:
+            self.gguf_writer.add_eot_token_id(eod_token_id)
+
+    def set_gguf_parameters(self):
+        super().set_gguf_parameters()
+        hparams = self.hparams
+
+        # Full rotation RoPE (no partial_rotary_factor)
+        if (head_dim := hparams.get("head_dim")) is None:
+            head_dim = hparams["hidden_size"] // hparams["num_attention_heads"]
+        self.gguf_writer.add_rope_dimension_count(head_dim)
+
+        # both keys are read as required by the C++ loader: fail here rather than at load time
+        self.gguf_writer.add_expert_feed_forward_length(hparams["moe_intermediate_size"])
+        self.gguf_writer.add_expert_shared_count(hparams["num_shared_experts"])
+
+        # Leading dense block count: prefer first_k_dense_replace, fall back to mlp_layer_types
+        if (first_k_dense := hparams.get("first_k_dense_replace")) is not None:
+            self.gguf_writer.add_leading_dense_block_count(first_k_dense)
+        elif (mlp_layer_types := hparams.get("mlp_layer_types")) is not None:
+            dense_count = next((i for i, t in enumerate(mlp_layer_types) if t != "dense"), len(mlp_layer_types))
+            self.gguf_writer.add_leading_dense_block_count(dense_count)
+
+        # Router: sigmoid gating, normalised weights, scaling factor 2.826
+        self.gguf_writer.add_expert_gating_func(gguf.ExpertGatingFuncType.SIGMOID)
+        if (router_scale := hparams.get("router_scaling_factor")) is not None:
+            self.gguf_writer.add_expert_weights_scale(router_scale)
+        if (route_norm := hparams.get("route_norm")) is not None:
+            self.gguf_writer.add_expert_weights_norm(route_norm)
+
+        # NextN/MTP prediction layers
+        if (num_nextn := hparams.get("num_nextn_predict_layers")) is not None:
+            self.gguf_writer.add_nextn_predict_layers(num_nextn)
+
+    _experts: list[dict[str, Tensor]] | None = None
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # lm_head is untied (tie_word_embeddings=false), no need to skip it
+        # Accumulate and stack per-expert tensors into a single 3D tensor per layer
+        if "mlp.experts" in name:
+            n_experts = self.find_hparam(["num_local_experts", "num_experts"])
+            assert bid is not None
+
+            if self._experts is None:
+                self._experts = [{} for _ in range(self.block_count)]
+
+            self._experts[bid][name] = data_torch
+
+            if len(self._experts[bid]) >= n_experts * 3:
+                for w_name in ["down_proj", "gate_proj", "up_proj"]:
+                    datas: list[Tensor] = []
+                    for xid in range(n_experts):
+                        ename = f"model.layers.{bid}.mlp.experts.{xid}.{w_name}.weight"
+                        datas.append(self._experts[bid][ename])
+                        del self._experts[bid][ename]
+                    data_torch = torch.stack(datas, dim=0)
+                    merged_name = f"model.layers.{bid}.mlp.experts.{w_name}.weight"
+                    yield from super().modify_tensors(data_torch, merged_name, bid)
+                return
+            else:
+                return
+
+        yield from super().modify_tensors(data_torch, name, bid)
+
+    def prepare_tensors(self):
+        super().prepare_tensors()
+        if self._experts is not None:
+            experts = [k for d in self._experts for k in d.keys()]
+            if len(experts) > 0:
+                raise ValueError(f"Unprocessed experts: {experts}")
 
 
 @ModelBase.register("HunYuanVLForConditionalGeneration")

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -539,6 +539,7 @@ class MODEL_ARCH(IntEnum):
     KIMI_LINEAR      = auto()
     TALKIE           = auto()
     MELLUM           = auto()
+    HY_V3            = auto()
 
 
 class VISION_PROJECTOR_TYPE(IntEnum):
@@ -1120,6 +1121,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
     MODEL_ARCH.KIMI_LINEAR:      "kimi-linear",
     MODEL_ARCH.TALKIE:           "talkie",
     MODEL_ARCH.MELLUM:           "mellum",
+    MODEL_ARCH.HY_V3:            "hy-v3",
 }
 
 VISION_PROJECTOR_TYPE_NAMES: dict[VISION_PROJECTOR_TYPE, str] = {
@@ -4399,6 +4401,35 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_GATE_EXP,
         MODEL_TENSOR.FFN_DOWN_EXP,
         MODEL_TENSOR.FFN_UP_EXP,
+    ],
+    MODEL_ARCH.HY_V3: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT_NORM,
+        MODEL_TENSOR.OUTPUT,
+        MODEL_TENSOR.ATTN_NORM,
+        MODEL_TENSOR.FFN_NORM,
+        MODEL_TENSOR.ATTN_Q,
+        MODEL_TENSOR.ATTN_K,
+        MODEL_TENSOR.ATTN_V,
+        MODEL_TENSOR.ATTN_OUT,
+        MODEL_TENSOR.ATTN_Q_NORM,
+        MODEL_TENSOR.ATTN_K_NORM,
+        MODEL_TENSOR.FFN_GATE,
+        MODEL_TENSOR.FFN_DOWN,
+        MODEL_TENSOR.FFN_UP,
+        MODEL_TENSOR.FFN_GATE_INP,
+        MODEL_TENSOR.FFN_GATE_EXP,
+        MODEL_TENSOR.FFN_DOWN_EXP,
+        MODEL_TENSOR.FFN_UP_EXP,
+        MODEL_TENSOR.FFN_GATE_SHEXP,
+        MODEL_TENSOR.FFN_DOWN_SHEXP,
+        MODEL_TENSOR.FFN_UP_SHEXP,
+        MODEL_TENSOR.FFN_EXP_PROBS_B,
+        # NextN/MTP tensors - preserved but unused at inference
+        MODEL_TENSOR.NEXTN_EH_PROJ,
+        MODEL_TENSOR.NEXTN_ENORM,
+        MODEL_TENSOR.NEXTN_HNORM,
+        MODEL_TENSOR.NEXTN_SHARED_HEAD_NORM,
     ],
     # TODO
 }

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -2415,6 +2415,13 @@ class TensorNameMap:
 
     # architecture-specific block mappings
     arch_block_mappings_cfg: dict[MODEL_ARCH, dict[MODEL_TENSOR, tuple[str, ...]]] = {
+        # hy-v3 reuses final_layernorm for the NextN shared head norm; keep the
+        # mapping arch-scoped because bailingmoe2 maps the same source name to FFN_NORM
+        MODEL_ARCH.HY_V3: {
+            MODEL_TENSOR.NEXTN_SHARED_HEAD_NORM: (
+                "model.layers.{bid}.final_layernorm",
+            ),
+        },
         MODEL_ARCH.ARCTIC: {
             MODEL_TENSOR.FFN_NORM: (
                 "model.layers.{bid}.residual_layernorm",
@@ -2437,7 +2444,9 @@ class TensorNameMap:
             for key in keys:
                 self.mapping[key] = (tensor, tensor_name)
         if arch in self.arch_block_mappings_cfg:
-            self.block_mappings_cfg.update(self.arch_block_mappings_cfg[arch])
+            # merge into an instance-level copy: updating the class-level dict in place
+            # would leak arch-specific mappings into maps built later in the same process
+            self.block_mappings_cfg = {**self.block_mappings_cfg, **self.arch_block_mappings_cfg[arch]}
         for bid in range(n_blocks):
             for tensor, keys in self.block_mappings_cfg.items():
                 if tensor not in MODEL_TENSORS[arch]:

--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -81,6 +81,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
     { LLM_ARCH_CHATGLM,          "chatglm"          },
     { LLM_ARCH_GLM4,             "glm4"             },
     { LLM_ARCH_GLM4_MOE,         "glm4moe"          },
+    { LLM_ARCH_HY_V3,            "hy-v3"            },
     { LLM_ARCH_GLM_DSA,          "glm-dsa"          },
     { LLM_ARCH_BITNET,           "bitnet"           },
     { LLM_ARCH_T5,               "t5"               },

--- a/src/llama-arch.h
+++ b/src/llama-arch.h
@@ -86,6 +86,7 @@ enum llm_arch {
     LLM_ARCH_CHATGLM,
     LLM_ARCH_GLM4,
     LLM_ARCH_GLM4_MOE,
+    LLM_ARCH_HY_V3,
     LLM_ARCH_GLM_DSA,
     LLM_ARCH_BITNET,
     LLM_ARCH_T5,

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -194,6 +194,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
             return new llama_model_glm4(params);
         case LLM_ARCH_GLM4_MOE:
             return new llama_model_glm4_moe(params);
+        case LLM_ARCH_HY_V3:
+            return new llama_model_hy_v3(params);
         case LLM_ARCH_BITNET:
             return new llama_model_bitnet(params);
         case LLM_ARCH_T5:
@@ -804,6 +806,7 @@ const char * llm_type_name(llm_type type) {
         case LLM_TYPE_196B_A11B:     return "196B.A11B";
         case LLM_TYPE_230B_A10B:     return "230B.A10B";
         case LLM_TYPE_235B_A22B:     return "235B.A22B";
+        case LLM_TYPE_295B_A21B:     return "295B.A21B";
         case LLM_TYPE_300B_A47B:     return "300B.A47B";
         case LLM_TYPE_310B_A15B:     return "310B.A15B";
         case LLM_TYPE_355B_A32B:     return "355B.A32B";
@@ -2555,6 +2558,9 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
             return model->hparams.use_mrope() ? LLAMA_ROPE_TYPE_MROPE : LLAMA_ROPE_TYPE_NORM;
         case LLM_ARCH_GLM4_MOE:
             return model->hparams.use_mrope() ? LLAMA_ROPE_TYPE_MROPE : LLAMA_ROPE_TYPE_NEOX;
+
+        case LLM_ARCH_HY_V3:
+            return LLAMA_ROPE_TYPE_NEOX;
 
         case LLM_ARCH_HUNYUAN_VL:
             return model->hparams.use_mrope() ? LLAMA_ROPE_TYPE_MROPE : LLAMA_ROPE_TYPE_NEOX;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -135,6 +135,7 @@ enum llm_type {
     LLM_TYPE_196B_A11B, // Step3.5-Flash
     LLM_TYPE_230B_A10B, // Minimax M2
     LLM_TYPE_235B_A22B,
+    LLM_TYPE_295B_A21B, // Hy3
     LLM_TYPE_300B_A47B, // Ernie MoE big
     LLM_TYPE_310B_A15B, // /MiMo-V2-Flash
     LLM_TYPE_355B_A32B, // GLM-4.5

--- a/src/models/hy-v3.cpp
+++ b/src/models/hy-v3.cpp
@@ -1,0 +1,273 @@
+#include "models.h"
+
+// Hy3 (tencent/Hy3, model_type hy_v3): hybrid MoE with GQA, per-head QK-norm,
+// NEOX RoPE, sigmoid-gated routing with exp_probs_b bias, 1 shared expert per MoE layer,
+// and 1 inert NextN/MTP layer appended after the 80 real layers.
+//
+// Architecture reference: src/transformers/models/hy_v3/modeling_hy_v3.py
+// Forward pass per layer:
+//   h = x + Attn(RMSNorm(x))         -- input_layernorm
+//   h = h + FFN(RMSNorm(h))          -- post_attention_layernorm
+// Attention: GQA, per-head RMSNorm on Q and K (mandatory), then NEOX RoPE.
+// FFN layer 0: dense SiLU gate-up-down (intermediate=13312).
+// FFN layers 1+: MoE sigmoid router with exp_probs_b correction, top-8 of 192,
+//   norm_w=true, scale_w=true (2.826), plus 1 shared expert added plain (no fp32 cast).
+
+void llama_model_hy_v3::load_arch_hparams(llama_model_loader & ml) {
+    ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
+
+    // MoE parameters
+    ml.get_key(LLM_KV_EXPERT_COUNT,              hparams.n_expert);
+    ml.get_key(LLM_KV_EXPERT_USED_COUNT,         hparams.n_expert_used);
+    ml.get_key(LLM_KV_EXPERT_SHARED_COUNT,       hparams.n_expert_shared);
+    ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH, hparams.n_ff_exp);
+    ml.get_key(LLM_KV_LEADING_DENSE_BLOCK_COUNT, hparams.n_layer_dense_lead, false);
+    ml.get_key(LLM_KV_EXPERT_WEIGHTS_SCALE,      hparams.expert_weights_scale, false);
+    ml.get_key(LLM_KV_EXPERT_WEIGHTS_NORM,       hparams.expert_weights_norm, false);
+    ml.get_key(LLM_KV_EXPERT_GATING_FUNC,        hparams.expert_gating_func, false);
+
+    // Hy3 always uses sigmoid gating
+    if (hparams.expert_gating_func == LLAMA_EXPERT_GATING_FUNC_TYPE_NONE) {
+        hparams.expert_gating_func = LLAMA_EXPERT_GATING_FUNC_TYPE_SIGMOID;
+    }
+
+    // NextN/MTP parameters
+    ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
+    GGML_ASSERT(hparams.n_layer_nextn < hparams.n_layer_all && "n_layer_nextn must be < n_layer_all");
+
+    // n_layer() = n_layer_all - n_layer_nextn = 80 for the real model
+    switch (hparams.n_layer()) {
+        case 80: type = LLM_TYPE_295B_A21B; break;
+        default: type = LLM_TYPE_UNKNOWN;
+    }
+}
+
+void llama_model_hy_v3::load_arch_tensors(llama_model_loader &) {
+    LLAMA_LOAD_LOCALS;
+    const int64_t n_expert_shared = hparams.n_expert_shared;
+
+    GGML_ASSERT(hparams.n_expert > 0      && "n_expert must be > 0 for HY_V3 MoE layers");
+    GGML_ASSERT(hparams.n_expert_used > 0 && "n_expert_used must be > 0 for HY_V3 MoE layers");
+
+    tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, 0);
+
+    output_norm = create_tensor(tn(LLM_TENSOR_OUTPUT_NORM, "weight"), { n_embd }, 0);
+    output      = create_tensor(tn(LLM_TENSOR_OUTPUT,      "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
+    if (output == NULL) {
+        output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, TENSOR_DUPLICATED);
+    }
+
+    // Load ALL layers including the NextN layer so the total tensor count is satisfied.
+    // Tensors for i >= n_layer are tagged TENSOR_SKIP so they are stored but never
+    // referenced in the forward graph.
+    for (int i = 0; i < n_layer_all; ++i) {
+        int flags = 0;
+        if (i >= n_layer) {
+            // NextN tensors are never referenced in the forward graph, so also
+            // tolerate GGUFs where the NextN block has been pruned
+            flags |= TENSOR_SKIP | TENSOR_NOT_REQUIRED;
+        }
+
+        auto & layer = layers[i];
+
+        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM,  "weight", i), { n_embd }, flags);
+
+        create_tensor_qkv(layer, i, n_embd,
+                          n_embd_head_k * n_head, n_embd_k_gqa, n_embd_v_gqa, flags);
+        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i),
+                                 { n_embd_head_k * n_head, n_embd }, flags);
+
+        // Per-head QK norms - mandatory for Hy3
+        layer.attn_q_norm = create_tensor(
+            tn(LLM_TENSOR_ATTN_Q_NORM, "weight", i), { n_embd_head_k }, flags);
+        layer.attn_k_norm = create_tensor(
+            tn(LLM_TENSOR_ATTN_K_NORM, "weight", i), { n_embd_head_k }, flags);
+
+        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), { n_embd }, flags);
+
+        const bool use_moe = (static_cast<uint32_t>(i) >= hparams.n_layer_dense_lead);
+
+        if (use_moe) {
+            layer.ffn_gate_inp =
+                create_tensor(tn(LLM_TENSOR_FFN_GATE_INP, "weight", i), { n_embd, n_expert }, flags);
+            layer.ffn_exp_probs_b =
+                create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, i), { n_expert }, flags);
+
+            const int64_t n_ff_exp = hparams.n_ff_exp;
+
+            create_tensor_gate_up_exps(layer, i, n_embd, n_ff_exp, n_expert, flags);
+            layer.ffn_down_exps = create_tensor(
+                tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), { n_ff_exp, n_embd, n_expert }, flags);
+
+            // Shared expert (num_shared_experts=1, intermediate=n_ff_exp)
+            if (n_expert_shared > 0) {
+                const int64_t n_ff_shexp = n_ff_exp * n_expert_shared;
+                layer.ffn_gate_shexp = create_tensor(
+                    tn(LLM_TENSOR_FFN_GATE_SHEXP, "weight", i), { n_embd, n_ff_shexp }, flags);
+                layer.ffn_down_shexp = create_tensor(
+                    tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), { n_ff_shexp, n_embd }, flags);
+                layer.ffn_up_shexp   = create_tensor(
+                    tn(LLM_TENSOR_FFN_UP_SHEXP,   "weight", i), { n_embd, n_ff_shexp }, flags);
+            }
+        } else {
+            // Dense layer 0
+            layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), { n_embd, n_ff }, flags);
+            layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), { n_ff, n_embd }, flags);
+            layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), { n_embd, n_ff }, flags);
+        }
+
+        // NextN-specific tensors (layer index >= n_layer)
+        // final_layernorm maps to NEXTN_SHARED_HEAD_NORM per SPEC.
+        if (i >= n_layer) {
+            layer.nextn.eh_proj = create_tensor(
+                tn(LLM_TENSOR_NEXTN_EH_PROJ, "weight", i), { 2 * n_embd, n_embd }, flags);
+            layer.nextn.enorm   = create_tensor(
+                tn(LLM_TENSOR_NEXTN_ENORM, "weight", i), { n_embd }, flags);
+            layer.nextn.hnorm   = create_tensor(
+                tn(LLM_TENSOR_NEXTN_HNORM, "weight", i), { n_embd }, flags);
+            layer.nextn.shared_head_norm = create_tensor(
+                tn(LLM_TENSOR_NEXTN_SHARED_HEAD_NORM, "weight", i), { n_embd }, flags);
+        }
+    }
+}
+
+std::unique_ptr<llm_graph_context> llama_model_hy_v3::build_arch_graph(const llm_graph_params & params) const {
+    return std::make_unique<graph>(*this, params);
+}
+
+llama_model_hy_v3::graph::graph(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+    const int64_t n_embd_head = hparams.n_embd_head_v();
+
+    GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
+    GGML_ASSERT(n_embd_head == n_rot);
+
+    ggml_tensor * cur;
+    ggml_tensor * inpL;
+
+    inpL = build_inp_embd(model.tok_embd);
+
+    ggml_tensor * inp_pos = build_inp_pos();
+
+    auto * inp_attn = build_attn_inp_kv();
+
+    ggml_tensor * inp_out_ids = build_inp_out_ids();
+
+    // Forward pass over real layers only; NextN layer tensors are loaded but
+    // never processed - the loop bound n_layer = n_layer_all - n_layer_nextn.
+    for (int il = 0; il < n_layer; ++il) {
+        ggml_tensor * inpSA = inpL;
+
+        // Pre-attention norm (input_layernorm)
+        cur = build_norm(inpL,
+                model.layers[il].attn_norm, NULL,
+                LLM_NORM_RMS, il);
+        cb(cur, "attn_norm", il);
+
+        // Self-attention with per-head QK-norm then NEOX RoPE
+        {
+            auto [Qcur, Kcur, Vcur] = build_qkv(model.layers[il], cur,
+                    n_embd_head, n_head, n_head_kv, il);
+
+            // Per-head RMSNorm on Q, then RoPE
+            Qcur = build_norm(Qcur, model.layers[il].attn_q_norm, NULL, LLM_NORM_RMS, il);
+            cb(Qcur, "Qcur_normed", il);
+
+            Qcur = ggml_rope_ext(ctx0, Qcur, inp_pos, nullptr,
+                    n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow);
+
+            // Per-head RMSNorm on K, then RoPE
+            Kcur = build_norm(Kcur, model.layers[il].attn_k_norm, NULL, LLM_NORM_RMS, il);
+            cb(Kcur, "Kcur_normed", il);
+
+            Kcur = ggml_rope_ext(ctx0, Kcur, inp_pos, nullptr,
+                    n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow);
+
+            cb(Qcur, "Qcur", il);
+            cb(Kcur, "Kcur", il);
+            cb(Vcur, "Vcur", il);
+
+            cur = build_attn(inp_attn,
+                    model.layers[il].wo, NULL, model.layers[il].wo_s,
+                    Qcur, Kcur, Vcur, nullptr, nullptr, nullptr,
+                    1.0f / sqrtf(float(n_embd_head)), il);
+        }
+
+        if (il == n_layer - 1 && inp_out_ids) {
+            cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
+            inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
+        }
+
+        ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
+        cb(ffn_inp, "ffn_inp", il);
+
+        // Pre-FFN norm (post_attention_layernorm)
+        cur = build_norm(ffn_inp,
+                model.layers[il].ffn_norm, NULL,
+                LLM_NORM_RMS, il);
+        cb(cur, "ffn_norm", il);
+
+        // FFN: dense for layer 0, MoE+shared for layers 1+
+        if (static_cast<uint32_t>(il) < hparams.n_layer_dense_lead) {
+            // Dense SiLU FFN
+            cur = build_ffn(cur,
+                    model.layers[il].ffn_up,   NULL, NULL,
+                    model.layers[il].ffn_gate, NULL, NULL,
+                    model.layers[il].ffn_down, NULL, NULL,
+                    NULL,
+                    LLM_FFN_SILU, LLM_FFN_PAR, il);
+            cb(cur, "ffn_out", il);
+        } else {
+            // Routed MoE: sigmoid gating, exp_probs_b selection bias,
+            // norm_w=true, scale_w=true, scale=2.826
+            ggml_tensor * routed_out = build_moe_ffn(cur,
+                    model.layers[il].ffn_gate_inp,
+                    model.layers[il].ffn_up_exps,
+                    model.layers[il].ffn_gate_exps,
+                    model.layers[il].ffn_down_exps,
+                    model.layers[il].ffn_exp_probs_b,
+                    n_expert, n_expert_used,
+                    LLM_FFN_SILU, hparams.expert_weights_norm,
+                    hparams.expert_weights_scale,
+                    (llama_expert_gating_func_type) hparams.expert_gating_func,
+                    il,
+                    nullptr,
+                    model.layers[il].ffn_gate_up_exps);
+            cb(routed_out, "ffn_moe_out", il);
+
+            // Shared expert - plain add (enable_moe_fp32_combine=false in hy3-config)
+            ggml_tensor * shared_out = build_ffn(cur,
+                    model.layers[il].ffn_up_shexp,   NULL, NULL,
+                    model.layers[il].ffn_gate_shexp, NULL, NULL,
+                    model.layers[il].ffn_down_shexp, NULL, NULL,
+                    NULL,
+                    LLM_FFN_SILU, LLM_FFN_PAR, il);
+            cb(shared_out, "ffn_shexp_out", il);
+
+            cur = ggml_add(ctx0, routed_out, shared_out);
+            cb(cur, "ffn_out", il);
+        }
+
+        cur = ggml_add(ctx0, cur, ffn_inp);
+
+        cur = build_cvec(cur, il);
+        cb(cur, "l_out", il);
+
+        inpL = cur;
+    }
+    cur = inpL;
+
+    cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
+
+    cb(cur, "result_norm", -1);
+    res->t_embd = cur;
+
+    // lm_head (untied; tie_word_embeddings=false)
+    cur = build_lora_mm(model.output, cur, model.output_s);
+
+    cb(cur, "result_output", -1);
+    res->t_logits = cur;
+
+    ggml_build_forward_expand(gf, cur);
+}

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -1302,6 +1302,19 @@ struct llama_model_glm4_moe : public llama_model_base {
 };
 
 
+struct llama_model_hy_v3 : public llama_model_base {
+    llama_model_hy_v3(const struct llama_model_params & params) : llama_model_base(params) {}
+    void load_arch_hparams(llama_model_loader & ml) override;
+    void load_arch_tensors(llama_model_loader & ml) override;
+
+    struct graph : public llm_graph_context {
+        graph(const llama_model & model, const llm_graph_params & params);
+    };
+
+    std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
+};
+
+
 struct llama_model_bitnet : public llama_model_base {
     llama_model_bitnet(const struct llama_model_params & params) : llama_model_base(params) {}
     void load_arch_hparams(llama_model_loader & ml) override;


### PR DESCRIPTION

Closes #22477

Adds support for [tencent/Hy3](https://huggingface.co/tencent/Hy3) (Apache 2.0), a 295B-A21B MoE model (`model_type: hy_v3`, `HYV3ForCausalLM`).

## Architecture

80 transformer layers + 1 NextN/MTP prediction layer, 192 routed experts (top-8) + 1 shared expert, GQA 64Q/8KV with head dim 128.

- **Routing**: sigmoid gating with `exp_probs_b` selection bias (DeepSeek-V3 recipe), normalized weights, scale 2.826 (`router_scaling_factor` from config)
- **Attention**: per-head RMSNorm on Q and K applied **before** NEOX RoPE (Qwen3-style)
- **FFN**: layer 0 dense (SiLU, intermediate 13312), layers 1-79 MoE (expert intermediate 1536) + shared expert added plain (no fp32 combine)
- **NextN/MTP**: 1 prediction layer (GLM-4.5-style tensor names: `eh_proj`/`enorm`/`hnorm`/`shared_head_norm`); tensors are converted and stored but skipped in the forward graph (`TENSOR_SKIP | TENSOR_NOT_REQUIRED`, same approach as glm4-moe) so they remain available for future MTP/speculative work. GGUFs with a pruned NextN block also load fine.
- Untied embeddings, vocab 120832, `eos` 120025 / `eod` 120026 (registered as EOT)

The graph implementation reuses the existing helpers (`build_moe_ffn` with `gate_up_exps` support, `create_tensor_gate_up_exps`, `create_tensor_qkv`).

## Conversion notes

- Supports the official FP8 checkpoint ([tencent/Hy3-FP8](https://huggingface.co/tencent/Hy3-FP8), AngelSlim per-tensor static FP8): scalar `.weight_scale` dequantization added to the generic fp8 path in `conversion/base.py`.
- The stock chat template builds special-token names with `'<...{}...>'.format(HYTK)`, which jinja engines without Python `str.format()` (minja included) cannot parse. The converter statically resolves those calls before embedding the template, so the resulting GGUFs work out of the box with `--jinja`.
- `model.layers.{bid}.final_layernorm` maps to `NEXTN_SHARED_HEAD_NORM` via an **arch-scoped** block mapping (bailingmoe2 maps the same source name to a different tensor). The arch-scoped merge was also made instance-level to avoid mutating the class-level mapping dict shared across `TensorNameMap` instances.

## Verification

**Logit parity vs `transformers`** (f32 GGUF from [yujiepan/hy3-tiny-random](https://huggingface.co/yujiepan/hy3-tiny-random), greedy, 4 prompts — English prose, code, French, chat with special tokens):

| prompt | avg KL | max KL | top-1 agreement |
|---|---|---|---|
| english_prose | 0.00000 | 0.00000 | 1.00 |
| code_snippet | 0.00000 | 0.00000 | 1.00 |
| french_text | 0.00000 | 0.00000 | 1.00 |
| chat_special | 0.00000 | 0.00000 | 1.00 |

Tokenization matches `AutoTokenizer` exactly on all test strings; `eos`/`eot` ids verified.

**Real model**: converted the full FP8 checkpoint to Q8_0 (317.6 GB) and verified sane greedy generation and imatrix perplexity (wiki-style calibration text, PPL ~5.3 at 512-token chunks over 60+ chunks).

**Quantization**: `llama-quantize` with `--tensor-type` overrides and imatrix works as expected (IQ3_XXS expert / q5_K attention mix); quantized GGUFs and the imatrix file will be published on Hugging Face referencing this PR.

## Notes for reviewers

- `rope_parameters.rope_type: "default"` (plain RoPE, no scaling) previously logged `Unknown RoPE type`; a no-op case was added to the shared rope handling.
- The NextN layer's expert tensors add ~8 GB to a Q8_0 GGUF; they are kept intentionally (MTP-capable runtimes / future speculative decoding), matching what glm4-moe conversions do. Quantizers that strip them produce GGUFs that still load.
