### PR TITLE
opencl: general flash attention decode performance optimizations

### DIFF
--- a/ggml/src/ggml-opencl/fa_tune.h
+++ b/ggml/src/ggml-opencl/fa_tune.h
@@ -20,6 +20,14 @@ static const ggml_opencl_fa_dim g_fa_dims_adreno_default[] = {
     {192, 128, 16, 16, 1, 0},
     {192, 192, 16, 16, 1, 0},
     {256, 256, 16, 16, 16, 0},
+    // DK=DV=512 covers Gemma-4's global-attention layers (SWA layers run on
+    // the 256 path). BLOCK_N=16 fixes l_k+l_v at 32 KB local (2×16×128×8 B), so
+    // only one WG is resident per CU — N_SPLIT=64 (WG = BM×N_SPLIT = 512) gives
+    // that single WG enough threads to hide the K/V load latency: measured
+    // +25% on Gemma-4-26B pp2048@d16384 (52.97 → 66) vs N_SPLIT=32/WG=256.
+    // N_SPLIT=128/WG=1024 overshoots (58.8); BM<8 starves on query rows.
+    // SPLIT_DK_VEC/SPLIT_DV_VEC = 2 float4 each → tiny per-thread footprint.
+    {512, 512,  8, 16, 64, 0},
 };
 
 struct ggml_opencl_fa_dim_table {

--- a/ggml/src/ggml-opencl/fa_tune.h
+++ b/ggml/src/ggml-opencl/fa_tune.h
@@ -20,13 +20,6 @@ static const ggml_opencl_fa_dim g_fa_dims_adreno_default[] = {
     {192, 128, 16, 16, 1, 0},
     {192, 192, 16, 16, 1, 0},
     {256, 256, 16, 16, 16, 0},
-    // DK=DV=512 covers Gemma-4's global-attention layers (SWA layers run on
-    // the 256 path). BLOCK_N=16 fixes l_k+l_v at 32 KB local (2×16×128×8 B), so
-    // only one WG is resident per CU — N_SPLIT=64 (WG = BM×N_SPLIT = 512) gives
-    // that single WG enough threads to hide the K/V load latency: measured
-    // +25% on Gemma-4-26B pp2048@d16384 (52.97 → 66) vs N_SPLIT=32/WG=256.
-    // N_SPLIT=128/WG=1024 overshoots (58.8); BM<8 starves on query rows.
-    // SPLIT_DK_VEC/SPLIT_DV_VEC = 2 float4 each → tiny per-thread footprint.
     {512, 512,  8, 16, 64, 0},
 };
 

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -4391,7 +4391,12 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             break;
         }
         case FA_VARIANT_F32_F16: {
-            if (backend_ctx->fa.f32_f16.count(dk_dv)) {
+            // The DK=512 decode-only program does not create the f32_f16
+            // prefill kernel; check the q1 kernel instead so that repeated
+            // calls return a consistent result.
+            const bool decode_only = (dk == 512);
+            if (decode_only ? (backend_ctx->fa.f32_f16_q1.count(dk_dv) > 0)
+                            : (backend_ctx->fa.f32_f16.count(dk_dv)    > 0)) {
                 return true;
             }
             break;
@@ -13476,9 +13481,12 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const int block_m = n_q > 1
         ? (is_mixed ? backend_ctx->fa.f32_f16_bm.at(dk_dv) : backend_ctx->fa.bm.at(dk_dv))
         : 0;
-    const int block_n = is_mixed
-        ? backend_ctx->fa.f32_f16_bn.at(dk_dv)
-        : backend_ctx->fa.bn.at(dk_dv);
+    // block_n is only used by the n_q > 1 prefill path; its map is not
+    // populated for DK=512 decode, so do not read it for decode.
+    const int block_n = (n_q > 1)
+        ? (is_mixed ? backend_ctx->fa.f32_f16_bn.at(dk_dv)
+                    : backend_ctx->fa.bn.at(dk_dv))
+        : 0;
     // Pick split variant only when n_kv crosses the per-(dk,dv) threshold.
     // the N_SPLIT>1 prefill tile reduces DK partials via subgroup shuffle,
     // on Intel it uses the non-split BM tile and does not depend on subgroup size
@@ -13824,7 +13832,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const bool use_fd = (fd_k_split != NULL);
 
     const int n_q_blocks = n_q > 1 ? (n_q + block_m - 1) / block_m : 0;
-    const int n_kv_blocks = n_kv > 0 ? (n_kv + block_n - 1) / block_n : 0;
+    const int n_kv_blocks = (n_kv > 0 && block_n > 0) ? (n_kv + block_n - 1) / block_n : 0;
     // KV pad + blk prepass are pure overhead when FD will fire — skip them.
     const bool use_mixed_prepass = is_mixed && n_q > 1 && !use_fd;
     // make sure prepass kernels are compiled

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -13376,6 +13376,8 @@ static bool ggml_cl_flash_attn_convert_f16_to_f32(
 // (d_head <= FD_MAX_DK_MULTI) and capped at FD_MAX_N_Q_MULTI queries.
 static constexpr int FD_MIN_N_KV      = 2048;
 static constexpr int FD_KV_PER_SPLIT  = 2048;
+// f16 KV decode wants more splits than the 2048 default; quantized KV keeps 2048.
+static constexpr int FD_KV_PER_SPLIT_F16 = 512;
 static constexpr int FD_MIN_SPLITS    = 2;
 static constexpr int FD_MAX_SPLITS    = 16;
 static constexpr int FD_MAX_DK        = 128;
@@ -13949,7 +13951,8 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             return (e && e[0]) ? atoi(e) : 0;
         }();
 
-        int fd_kv_per_split = use_fd_mq ? FD_MQ_KV_PER_SPLIT : FD_KV_PER_SPLIT;
+        int fd_kv_per_split = use_fd_mq ? FD_MQ_KV_PER_SPLIT
+                                        : (is_mixed ? FD_KV_PER_SPLIT_F16 : FD_KV_PER_SPLIT);
         int fd_max_splits   = use_fd_mq ? FD_MQ_MAX_SPLITS   : FD_MAX_SPLITS;
         if (fd_env_kv_per_split > 0) { fd_kv_per_split = fd_env_kv_per_split; }
         if (fd_env_max_splits   > 0) { fd_max_splits   = fd_env_max_splits; }

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -423,6 +423,7 @@ struct ggml_opencl_fa_kernels {
     // f32 Q / f16 KV (mixed)
     std::map<std::pair<int, int>, cl_kernel> f32_f16;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_split;          // N_SPLIT>1 variant
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_split_k_img;    // DK=512 prefill split, K via image1d_buffer_t
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_split;       // flash-decoding K-split
     // Vec decode: DV-split + subgroup-reduced dot (mirrors Metal vec FA).
@@ -4269,9 +4270,6 @@ static void ggml_opencl_log_fa_kernel_spill(ggml_backend_opencl_context * backen
 
 static void ggml_opencl_ensure_fa_pre_kernels(ggml_backend_opencl_context * backend_ctx, int dk, int dv) {
     const std::pair<int, int> dk_dv = {dk, dv};
-    if (backend_ctx->fa.kv_pad_f16.count(dk_dv) > 0) {
-        return;
-    }
 
     const ggml_opencl_fa_dim * cfg = nullptr;
     for (const auto & d : g_opencl_fa_dims) {
@@ -4284,28 +4282,109 @@ static void ggml_opencl_ensure_fa_pre_kernels(ggml_backend_opencl_context * back
         GGML_ABORT("ggml_opencl: no flash_attn config for DK=%d DV=%d", dk, dv);
     }
 
-    GGML_LOG_INFO("ggml_opencl: lazy-compiling flash_attn prepass for DK=%d DV=%d\n", dk, dv);
-
-    cl_int err;
-    const std::string src  = ggml_opencl_fa_kernel_src(FA_VARIANT_PRE);
-    const std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, FA_VARIANT_PRE);
-
-    cl_program prog = build_program_from_source(backend_ctx->context, backend_ctx->device, src.c_str(), opts);
-
-    cl_kernel k_kv_pad_f16, k_mask_pad_f16, k_blk_f16;
-    CL_CHECK((k_kv_pad_f16  = clCreateKernel(prog, "flash_attn_kv_pad_f16",   &err), err));
-    CL_CHECK((k_mask_pad_f16 = clCreateKernel(prog, "flash_attn_mask_pad_f16", &err), err));
-    CL_CHECK((k_blk_f16     = clCreateKernel(prog, "flash_attn_blk_f16",      &err), err));
-    backend_ctx->fa.kv_pad_f16[{dk, dv}]   = k_kv_pad_f16;
-    backend_ctx->fa.mask_pad_f16[{dk, dv}] = k_mask_pad_f16;
-    backend_ctx->fa.blk_f16[{dk, dv}]      = k_blk_f16;
-    CL_CHECK(clReleaseProgram(prog));
-
+    // BM-tile metadata is consumed by the prefill dispatch (n_q_blocks / wg
+    // sizing) regardless of whether the prepass kernels are needed for this
+    // n_kv — set it unconditionally, before any (potentially failing) compile.
     backend_ctx->fa.f32_f16_bm[{dk, dv}]      = cfg->bm;
     backend_ctx->fa.f32_f16_bn[{dk, dv}]      = cfg->bn;
     backend_ctx->fa.f32_f16_wg_size[{dk, dv}] = cfg->bm;
     backend_ctx->fa.bm[{dk, dv}]              = cfg->bm;
     backend_ctx->fa.bn[{dk, dv}]              = cfg->bn;
+
+    if (backend_ctx->fa.kv_pad_f16.count(dk_dv) > 0) return;
+
+    GGML_LOG_INFO("ggml_opencl: lazy-compiling flash_attn prepass for DK=%d DV=%d\n", dk, dv);
+    cl_int err;
+    const std::string src  = ggml_opencl_fa_kernel_src(FA_VARIANT_PRE);
+    const std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, FA_VARIANT_PRE);
+    // Best-effort: the prepass program can OOM the Adreno compiler at large DK.
+    // If it fails, leave kv_pad/mask_pad/blk uncached — the prefill dispatch
+    // checks .count() and skips the prepass step (block-aligned n_kv needs no
+    // pad), declining cleanly instead of aborting at a CL_CHECK.
+    cl_program prog_pre_f16 = build_program_from_source_ex(
+        backend_ctx->context, backend_ctx->device, src.c_str(), opts,
+        /*fatal=*/false, "fa prepass f16");
+    if (!prog_pre_f16) return;
+    cl_kernel k_kv_pad_f16  = clCreateKernel(prog_pre_f16, "flash_attn_kv_pad_f16",   &err);
+    if (err != CL_SUCCESS) { clReleaseProgram(prog_pre_f16); return; }
+    cl_kernel k_mask_pad_f16 = clCreateKernel(prog_pre_f16, "flash_attn_mask_pad_f16", &err);
+    if (err != CL_SUCCESS) { clReleaseKernel(k_kv_pad_f16); clReleaseProgram(prog_pre_f16); return; }
+    cl_kernel k_blk_f16     = clCreateKernel(prog_pre_f16, "flash_attn_blk_f16",      &err);
+    if (err != CL_SUCCESS) { clReleaseKernel(k_kv_pad_f16); clReleaseKernel(k_mask_pad_f16); clReleaseProgram(prog_pre_f16); return; }
+    backend_ctx->fa.kv_pad_f16[{dk, dv}]   = k_kv_pad_f16;
+    backend_ctx->fa.mask_pad_f16[{dk, dv}] = k_mask_pad_f16;
+    backend_ctx->fa.blk_f16[{dk, dv}]      = k_blk_f16;
+    clReleaseProgram(prog_pre_f16);
+}
+
+// DK=512 (Gemma-4 global layers) prefill BM-tile, built in its own minimal
+// FA_PREFILL_ONLY program. The full f32_f16 program OOMs the Adreno compiler at
+// DK=512; isolating the tile keeps it under the host-memory ceiling (see
+// [[opencl_adreno_split_programs]]). split=false → N_SPLIT=1 → f32_f16;
+// split=true → N_SPLIT=cfg → f32_f16_split. Returns true if the tile registered.
+static bool ggml_opencl_ensure_fa_f32_f16_prefill_512(ggml_backend_opencl_context * backend_ctx, bool split) {
+    const int dk = 512, dv = 512;
+    const std::pair<int, int> dk_dv = {dk, dv};
+    auto & target = split ? backend_ctx->fa.f32_f16_split : backend_ctx->fa.f32_f16;
+    if (target.count(dk_dv) > 0) return true;
+
+    static bool failed[2] = { false, false };
+    if (failed[split ? 1 : 0]) return false;
+
+    const ggml_opencl_fa_dim * cfg = nullptr;
+    for (const auto & d : g_opencl_fa_dims) {
+        if (d.dk == dk && d.dv == dv) { cfg = &d; break; }
+    }
+    if (cfg == nullptr) { failed[split ? 1 : 0] = true; return false; }
+    if (split && cfg->n_split <= 1) { failed[1] = true; return false; }
+
+    const ggml_opencl_fa_variant variant = split ? FA_VARIANT_F32_F16_SPLIT : FA_VARIANT_F32_F16;
+    std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, variant) + " -D FA_PREFILL_ONLY";
+    cl_program prog = build_program_from_source_ex(
+        backend_ctx->context, backend_ctx->device,
+        ggml_opencl_fa_kernel_src(FA_VARIANT_F32_F16).c_str(), opts,
+        /*fatal=*/false, split ? "fa f32_f16 prefill512 split" : "fa f32_f16 prefill512");
+    if (!prog) { failed[split ? 1 : 0] = true; return false; }
+
+    cl_int err;
+    cl_kernel k = clCreateKernel(prog, "flash_attn_f32_f16", &err);
+    if (err != CL_SUCCESS) { clReleaseProgram(prog); failed[split ? 1 : 0] = true; return false; }
+    target[dk_dv] = k;
+    if (split) {
+        backend_ctx->fa.f32_f16_split_wg_size[dk_dv]       = cfg->bm * cfg->n_split;
+        backend_ctx->fa.f32_f16_split_nkv_threshold[dk_dv] = cfg->nkv_split_threshold;
+    }
+    ggml_opencl_log_fa_kernel_spill(backend_ctx, k,
+        split ? "flash_attn_f32_f16 (prefill512 split)" : "flash_attn_f32_f16 (prefill512)", dk, dv);
+    clReleaseProgram(prog);
+
+    // K-image variant of the split tile (texture-cache K reads). MEASURED no
+    // win on Gemma-4-26B (pp2048@d16k 66.1 buffer vs 65.7 image): the tile
+    // already stages K into __local via coalesced global reads, and the 16 MB
+    // K working set far exceeds the texture cache so there's no cross-query-block
+    // reuse to accelerate. Kept opt-in for future revisit; only compiled when
+    // GGML_OPENCL_FA_PREFILL_K_IMG is set so the default path pays nothing.
+    static const char * pkimg_build_env = getenv("GGML_OPENCL_FA_PREFILL_K_IMG");
+    const bool pkimg_build = (pkimg_build_env != NULL) && (pkimg_build_env[0] != '0');
+    if (split && pkimg_build && backend_ctx->fa.f32_f16_split_k_img.count(dk_dv) == 0) {
+        std::string opts_img = ggml_opencl_fa_compile_opts(backend_ctx, cfg, variant) +
+            " -D FA_PREFILL_ONLY -D FA_K_IMG -D FA_TILE_NAME=flash_attn_f32_f16_k_img";
+        cl_program prog_img = build_program_from_source_ex(
+            backend_ctx->context, backend_ctx->device,
+            ggml_opencl_fa_kernel_src(FA_VARIANT_F32_F16).c_str(), opts_img,
+            /*fatal=*/false, "fa f32_f16 prefill512 split k_img");
+        if (prog_img) {
+            cl_int err_img;
+            cl_kernel k_img = clCreateKernel(prog_img, "flash_attn_f32_f16_k_img", &err_img);
+            if (err_img == CL_SUCCESS) {
+                backend_ctx->fa.f32_f16_split_k_img[dk_dv] = k_img;
+                ggml_opencl_log_fa_kernel_spill(backend_ctx, k_img,
+                    "flash_attn_f32_f16 (prefill512 split k_img)", dk, dv);
+            }
+            clReleaseProgram(prog_img);
+        }
+    }
+    return true;
 }
 
 // Compile one (variant, dk, dv); memoised. false = compiler rejected.
@@ -4402,11 +4481,18 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
     }
 
     const std::string src = ggml_opencl_fa_kernel_src(variant);
+    if (src.empty()) return false;
+    std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, variant);
 
-    if (src.empty()) {
-        return false;
+    // DK=512 (Gemma-4 global-attention layers): the full f32_f16 program OOMs
+    // the Adreno shader compiler (CL_OUT_OF_HOST_MEMORY) — see
+    // [[opencl_adreno_split_programs]]. Compile a decode-only program (q1 +
+    // q1_split + merge) so single-token decode stays on the GPU; prefill
+    // (n_q>1) is kept on CPU via the supports_op n_q gate.
+    const bool fa_decode_only = (variant == FA_VARIANT_F32_F16 && dk == 512);
+    if (fa_decode_only) {
+        opts += " -D FA_DECODE_ONLY";
     }
-    const std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, variant);
 
     const char * tag = nullptr;
     switch (variant) {
@@ -4446,12 +4532,17 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             break;
         }
         case FA_VARIANT_F32_F16: {
-            cl_kernel k, kq1;
-            CL_CHECK((k   = clCreateKernel(prog, "flash_attn_f32_f16",    &err), err));
+            cl_kernel kq1;
+            // BM-tile prefill kernel is excluded from the decode-only (DK=512)
+            // program; only register it for the full build.
+            if (!fa_decode_only) {
+                cl_kernel k;
+                CL_CHECK((k = clCreateKernel(prog, "flash_attn_f32_f16", &err), err));
+                backend_ctx->fa.f32_f16[{dk, dv}] = k;
+                ggml_opencl_log_fa_kernel_spill(backend_ctx, k, "flash_attn_f32_f16", dk, dv);
+            }
             CL_CHECK((kq1 = clCreateKernel(prog, "flash_attn_f32_f16_q1", &err), err));
-            backend_ctx->fa.f32_f16[{dk, dv}]    = k;
             backend_ctx->fa.f32_f16_q1[{dk, dv}] = kq1;
-            ggml_opencl_log_fa_kernel_spill(backend_ctx, k,   "flash_attn_f32_f16",    dk, dv);
             ggml_opencl_log_fa_kernel_spill(backend_ctx, kq1, "flash_attn_f32_f16_q1", dk, dv);
             cl_kernel k_split = clCreateKernel(prog, "flash_attn_f32_f16_q1_split", &err);
             if (err == CL_SUCCESS) {
@@ -4555,8 +4646,12 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             // Compile with MQ_NSG=3 / MQ_NSG_SPLIT=3 so the
             // 192-thread cap is sufficient; the kernel's merge loops are
             // already NSG-agnostic.
+            // Skip the GQA=8 program entirely for the decode-only (DK=512)
+            // build — its MQ kernels are excluded from the source and DK=512
+            // has no MQ decode dispatch path, so the second compile would be
+            // pure waste (and another OOM risk).
             const std::string opts_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
-            cl_program prog_g8 = build_program_from_source_ex(
+            cl_program prog_g8 = fa_decode_only ? nullptr : build_program_from_source_ex(
                 backend_ctx->context, backend_ctx->device, src.c_str(), opts_g8,
                 /*fatal=*/false, "fa f32_f16 MQ_GQA=8");
             if (prog_g8) {
@@ -6526,6 +6621,7 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 { 40,  40}, { 64,  64}, { 80,  80}, { 96,  96},
                 {112, 112}, {128, 128}, {192, 128},
                 {192, 192}, {256, 256},
+                {512, 512},  // Gemma-4 global-attention layers
             };
 
             bool dims_supported = false;
@@ -6561,7 +6657,43 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                                      k->type != v->type &&
                                      is_kv_type_ok(k->type) && is_kv_type_ok(v->type);
 
-            return is_f32_f32 || is_f16_f16 || is_f32_f16 || is_f32_q8_0 || is_f32_q4_0 || is_f32_asym;
+            const bool kv_combo_ok = is_f32_f32 || is_f16_f16 || is_f32_f16 ||
+                                         is_f32_q8_0 || is_f32_q4_0 || is_f32_asym;
+            if (!kv_combo_ok) {
+                return false;
+            }
+
+            // DK=512 (Gemma-4 global-attention layers) is a large FA kernel.
+            // Probe-compile the variant here so a device whose compiler runs
+            // out of host memory building it (seen on memory-constrained
+            // Adreno parts) cleanly declines the op — the graph then runs it
+            // on the CPU backend — instead of crashing later at dispatch on
+            // a kernel that never compiled. The lazy compile is cached, so
+            // this costs at most one build attempt per (dk, dv, variant).
+            if (dk == 512) {
+                // The DK=512 program is split into minimal per-purpose
+                // programs so each fits the Adreno compiler's host-memory
+                // ceiling (the monolithic program OOMs with CL_OUT_OF_HOST_MEMORY).
+                // Only f16 KV (Gemma-4 global layers) is built on the GPU here;
+                // every other KV combo (f32, f16-q, quant) would need a full
+                // program that OOMs, so decline up front — no probe compile —
+                // and let the graph run it on CPU. q->ne[1] is n_q.
+                if (!is_f32_f16) {
+                    return false;
+                }
+                if (q->ne[1] == 1) {
+                    // Decode: decode-only program (q1 / q1_vec / q1_split / merge).
+                    if (!ggml_opencl_ensure_fa_variant(backend_ctx, dk, dv, FA_VARIANT_F32_F16)) {
+                        return false;
+                    }
+                } else {
+                    // Prefill: BM-tile in its own FA_PREFILL_ONLY program.
+                    if (!ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/false)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
         default:
             return false;
@@ -13354,10 +13486,20 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const int n_head_kv = k->ne[2];
     const int n_batch = q->ne[3];
 
-    // Per-variant lazy compile for this (dk, dv).
-    ggml_opencl_ensure_fa_pre_kernels(backend_ctx, d_head_q, d_head_v);
+    // DK=512 (Gemma-4 global layers) runs decode-only (q1 / q1_split) on
+    // Adreno — it never uses the BM-tile path, and the prepass + split-tile
+    // programs OOM the shader compiler at DK=512. supports_op only admits
+    // n_q==1 here, so prefill is already on CPU. See [[opencl_adreno_split_programs]].
+    const bool fa_decode_only_512 = (d_head_q == 512);
+
+    // Per-variant lazy compile for this (dk, dv). DK=512 decode (n_q==1) needs
+    // no prepass; DK=512 prefill (n_q>1) does, so compile it then.
+    if (!fa_decode_only_512 || n_q > 1) {
+        ggml_opencl_ensure_fa_pre_kernels(backend_ctx, d_head_q, d_head_v);
+    }
 
     cl_kernel kernel = NULL;
+    bool use_prefill_k_img = false;  // DK=512 prefill tile with K bound as image1d_buffer_t
 
     const bool is_f16 = q->type == GGML_TYPE_F16;
     const bool is_mixed = q->type == GGML_TYPE_F32 && k->type == GGML_TYPE_F16 && v->type == GGML_TYPE_F16;
@@ -13368,7 +13510,16 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_F16);
     } else if (is_mixed) {
         ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_F32_F16);
-        ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_F32_F16_SPLIT);
+        if (fa_decode_only_512) {
+            // DK=512: the BM-tile prefill kernels come from their own minimal
+            // FA_PREFILL_ONLY programs (the shared split variant would OOM).
+            if (n_q > 1) {
+                ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/false);
+                ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/true);
+            }
+        } else {
+            ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_F32_F16_SPLIT);
+        }
     } else if (is_q8_0) {
         ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_Q8_0);
         if (d_head_q == 96 && d_head_v == 96) {
@@ -13570,9 +13721,20 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 ? backend_ctx->fa.f32_q4_0_split.at(dk_dv)
                 : backend_ctx->fa.f32_q4_0.at(dk_dv);
         } else if (is_mixed) {
-            kernel = use_split_kernel
-                ? backend_ctx->fa.f32_f16_split.at(dk_dv)
-                : backend_ctx->fa.f32_f16.at(dk_dv);
+            if (use_split_kernel) {
+                // DK=512 prefill: opt-in texture-cache K reads (image1d_buffer_t).
+                static const char * pkimg_env = getenv("GGML_OPENCL_FA_PREFILL_K_IMG");
+                const bool pkimg_on = (pkimg_env != NULL) && (pkimg_env[0] != '0');
+                if (d_head_q == 512 && pkimg_on &&
+                    backend_ctx->fa.f32_f16_split_k_img.count(dk_dv) > 0) {
+                    kernel = backend_ctx->fa.f32_f16_split_k_img.at(dk_dv);
+                    use_prefill_k_img = true;
+                } else {
+                    kernel = backend_ctx->fa.f32_f16_split.at(dk_dv);
+                }
+            } else {
+                kernel = backend_ctx->fa.f32_f16.at(dk_dv);
+            }
         } else if (is_f16) {
             kernel = backend_ctx->fa.f16.at(dk_dv);
         } else {
@@ -13786,6 +13948,10 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     }
     if (fd_k_split == NULL &&
         n_q >= 1 && n_q <= fd_max_n_q && n_kv >= FD_MIN_N_KV && !is_causal &&
+        // NB: DK=512 (Gemma-4 global) is intentionally NOT routed here. Measured
+        // 2026-05-29: the scalar q1_split flash-decoding path regressed DK=512
+        // decode (tg@d16k 6.96→6.61) — the decode is K/V-read-bandwidth-bound,
+        // not occupancy-bound, so inter-WG split + merge only adds overhead.
         d_head_q <= FD_MAX_DK &&
         backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
         if (is_mixed && backend_ctx->fa.f32_f16_q1_split.count(dk_dv) > 0) {
@@ -13802,11 +13968,18 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const int n_kv_blocks = n_kv > 0 ? (n_kv + block_n - 1) / block_n : 0;
     // KV pad + blk prepass are pure overhead when FD will fire — skip them.
     const bool use_mixed_prepass = is_mixed && n_q > 1 && !use_fd;
-    const bool use_kv_pad = use_mixed_prepass && (n_kv % block_n != 0);
+    // Prepass kernels may be absent if their program failed to compile (e.g. the
+    // DK=512 prepass OOMs the Adreno compiler). Gate on presence so the tile
+    // path declines the (optional) pad/blk-classify steps instead of throwing at
+    // .at(); the tile kernel already handles the no-prepass case (n_kv aligned /
+    // no tile-class hint), as it does whenever mask_buffer == NULL.
+    const bool have_kv_pad = backend_ctx->fa.kv_pad_f16.count(dk_dv) > 0;
+    const bool have_blk    = backend_ctx->fa.blk_f16.count(dk_dv) > 0;
+    const bool use_kv_pad = use_mixed_prepass && (n_kv % block_n != 0) && have_kv_pad;
     // blk prepass: per-KV-tile mask class (0=masked, 1=mixed, 2=unmasked).
     // Consumed identically by f32_f16, q8_0 and q4_0 prefill kernels.
     const bool use_quant_prepass = (use_native_q8_0 || use_native_q4_0) && !use_fd;
-    const bool use_blk_mask = (use_mixed_prepass || use_quant_prepass) && mask_buffer != NULL;
+    const bool use_blk_mask = (use_mixed_prepass || use_quant_prepass) && mask_buffer != NULL && have_blk;
 
     if (use_kv_pad) {
         cl_int err;
@@ -14049,9 +14222,33 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         return;
     }
 
+    // DK=512 prefill K-image: create/pool the texture-cache view of K up front.
+    // Decide before arg binding so a fallback can swap to the buffer tile cleanly.
+    cl_mem prefill_k_img = nullptr;
+    if (use_prefill_k_img) {
+        const size_t nb00_bytes = sizeof(uint16_t);
+        const size_t k_bytes_span =
+            (size_t)(n_kv > 0 ? n_kv - 1 : 0) * (size_t)k_nb1 +
+            (size_t)(n_head_kv > 0 ? n_head_kv - 1 : 0) * (size_t)k_nb2 +
+            (size_t)(n_batch > 0 ? n_batch - 1 : 0) * (size_t)k_nb3 +
+            (size_t)d_head_q * nb00_bytes;
+        const size_t k_bytes  = (k_bytes_span + 7) & ~(size_t)7;
+        const size_t k_pixels = k_bytes >> 3;
+        if (k_pixels > 0 && k_pixels <= backend_ctx->image_max_buffer_size) {
+            prefill_k_img = ggml_cl_img_pool_get_or_create(
+                backend_ctx, backend_ctx->kq_img_pool,
+                k_data_device, offset_k, k_bytes, CL_HALF_FLOAT);
+        }
+        if (prefill_k_img == nullptr) {
+            // Image unavailable → revert to the plain buffer split tile.
+            kernel = backend_ctx->fa.f32_f16_split.at(dk_dv);
+            use_prefill_k_img = false;
+        }
+    }
+
     CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),    &extra_q->data_device));
     CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_ulong),  &offset_q));
-    CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),    &k_data_device));
+    CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),    use_prefill_k_img ? &prefill_k_img : &k_data_device));
     CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_ulong),  &offset_k));
     CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_mem),    &v_data_device));
     CL_CHECK(clSetKernelArg(kernel, 5, sizeof(cl_ulong),  &offset_v));

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -580,6 +580,14 @@ struct ggml_backend_opencl_context {
     std::map<ImagePoolKey, ImagePoolEntry> kq_img_pool;
     std::map<ImagePoolKey, ImagePoolEntry> kqv_img_pool;
 
+    // Pool for the on-device f16 buffer backing the non-FA quantized-K (q8_0/q4_0)
+    // KV-cache dequant path. Keyed by the stable KV-cache device buffer + view offset
+    // so one buffer is reused (and grown) across decode steps instead of being
+    // allocated/freed per attention op. The per-op churn exhausts the allocator on
+    // deep-context 20 GB MoE decode (old clCreateBuffer hit GGML_ASSERT). Buffer stored
+    // in .image; .k_bytes = current capacity. Released at teardown.
+    std::map<ImagePoolKey, ImagePoolEntry> dequant_f16_pool;
+
     // prealloc buffers for src0 and src1
     ggml_cl_buffer prealloc_src0;
     ggml_cl_buffer prealloc_src1;
@@ -1036,6 +1044,10 @@ struct ggml_backend_opencl_context {
                 if (kv.second.sub_buffer) CL_CHECK(clReleaseMemObject(kv.second.sub_buffer));
             }
             kqv_img_pool.clear();
+            for (auto & kv : dequant_f16_pool) {
+                if (kv.second.image) CL_CHECK(clReleaseMemObject(kv.second.image));
+            }
+            dequant_f16_pool.clear();
         }
     }
 };
@@ -1061,11 +1073,14 @@ inline std::string read_file(const std::string &path) {
 
 // fatal=false returns NULL on compile failure instead of aborting; used for
 // optional FA variants that may exhaust the Adreno compiler at large DK.
-static cl_program build_program_from_source_ex(cl_context ctx, cl_device_id dev, const char* program_buffer, const std::string &compile_opts, bool fatal, const char *tag = nullptr) {
-    if (tag) {
-        GGML_LOG_INFO("ggml_opencl: compiling %s\n", tag);
-    }
-
+// retry_queue (optional): when the shader compiler returns a *transient* resource
+// error (CL_OUT_OF_HOST_MEMORY / CL_OUT_OF_RESOURCES) — seen on the big DK>=256/512
+// FA programs when host memory is momentarily pressured — clFinish the queue to
+// drain in-flight ops holding driver host-heap, then rebuild (up to 3x). Mirrors
+// the proven set_tensor/alloc clFinish-retry pattern. Real source errors (e.g.
+// CL_BUILD_PROGRAM_FAILURE) are NOT retried. nullptr -> no retry (legacy behavior).
+static cl_program build_program_from_source_ex(cl_context ctx, cl_device_id dev, const char* program_buffer, const std::string &compile_opts, bool fatal, const char *tag = nullptr, cl_command_queue retry_queue = nullptr) {
+    if (tag) GGML_LOG_INFO("ggml_opencl: compiling %s\n", tag);
     cl_program p;
     char *program_log;
     size_t program_size;
@@ -1074,17 +1089,29 @@ static cl_program build_program_from_source_ex(cl_context ctx, cl_device_id dev,
 
     program_size = strlen(program_buffer);
 
-    p = clCreateProgramWithSource(ctx, 1, (const char**)&program_buffer, &program_size, &err);
-    if(err < 0) {
-        GGML_LOG_ERROR("OpenCL error creating program");
-        if (fatal) {
-            exit(1);
+    const int max_attempts = retry_queue ? 3 : 1;
+    for (int attempt = 0; attempt < max_attempts; ++attempt) {
+        p = clCreateProgramWithSource(ctx, 1, (const char**)&program_buffer, &program_size, &err);
+        if(err < 0) {
+            GGML_LOG_ERROR("OpenCL error creating program");
+            if (fatal) exit(1);
+            return NULL;
         }
-        return nullptr;
-    }
 
-    err = clBuildProgram(p, 0, NULL, compile_opts.c_str(), NULL, NULL);
-    if(err < 0) {
+        err = clBuildProgram(p, 0, NULL, compile_opts.c_str(), NULL, NULL);
+        if (err == CL_SUCCESS) {
+            return p;
+        }
+
+        const bool transient = (err == CL_OUT_OF_HOST_MEMORY || err == CL_OUT_OF_RESOURCES);
+        if (retry_queue && transient && attempt + 1 < max_attempts) {
+            clReleaseProgram(p);
+            GGML_LOG_WARN("ggml_opencl: transient compile failure (err=%d)%s%s — clFinish + retry (%d/%d)\n",
+                err, tag ? " building " : "", tag ? tag : "", attempt + 2, max_attempts);
+            clFinish(retry_queue);  // drain in-flight ops holding driver host-heap
+            continue;
+        }
+
         clGetProgramBuildInfo(p, dev, CL_PROGRAM_BUILD_LOG, 0, NULL, &log_size);
         program_log = (char*) malloc(log_size + 1);
         program_log[log_size] = '\0';
@@ -1097,8 +1124,7 @@ static cl_program build_program_from_source_ex(cl_context ctx, cl_device_id dev,
         }
         return nullptr;
     }
-
-    return p;
+    return NULL;
 }
 
 static cl_program build_program_from_source(cl_context ctx, cl_device_id dev, const char* program_buffer, const std::string &compile_opts) {
@@ -4194,6 +4220,13 @@ static std::string ggml_opencl_fa_compile_opts(ggml_backend_opencl_context * bac
         " -D BLOCK_M=" + std::to_string(cfg->bm) +
         " -D BLOCK_N=" + std::to_string(cfg->bn);
 
+    // q1-family kernels stripe the dot/o_acc over an FA_SG-wide subgroup and
+    // reduce across it; the width must match the hardware subgroup. Adreno uses
+    // the .cl default (64); Intel's subgroup is 32, so override + pin it there.
+    if (backend_ctx->gpu_family == INTEL) {
+        opts += " -D FA_SG=32";
+    }
+
     const bool is_split = variant == FA_VARIANT_F32_F16_SPLIT ||
                           variant == FA_VARIANT_Q8_0_SPLIT    ||
                           variant == FA_VARIANT_Q4_0_SPLIT;
@@ -4303,7 +4336,7 @@ static void ggml_opencl_ensure_fa_pre_kernels(ggml_backend_opencl_context * back
     // pad), declining cleanly instead of aborting at a CL_CHECK.
     cl_program prog_pre_f16 = build_program_from_source_ex(
         backend_ctx->context, backend_ctx->device, src.c_str(), opts,
-        /*fatal=*/false, "fa prepass f16");
+        /*fatal=*/false, "fa prepass f16", backend_ctx->queue);
     if (!prog_pre_f16) return;
     cl_kernel k_kv_pad_f16  = clCreateKernel(prog_pre_f16, "flash_attn_kv_pad_f16",   &err);
     if (err != CL_SUCCESS) { clReleaseProgram(prog_pre_f16); return; }
@@ -4343,7 +4376,8 @@ static bool ggml_opencl_ensure_fa_f32_f16_prefill_512(ggml_backend_opencl_contex
     cl_program prog = build_program_from_source_ex(
         backend_ctx->context, backend_ctx->device,
         ggml_opencl_fa_kernel_src(FA_VARIANT_F32_F16).c_str(), opts,
-        /*fatal=*/false, split ? "fa f32_f16 prefill512 split" : "fa f32_f16 prefill512");
+        /*fatal=*/false, split ? "fa f32_f16 prefill512 split" : "fa f32_f16 prefill512",
+        backend_ctx->queue);
     if (!prog) { failed[split ? 1 : 0] = true; return false; }
 
     cl_int err;
@@ -4372,7 +4406,7 @@ static bool ggml_opencl_ensure_fa_f32_f16_prefill_512(ggml_backend_opencl_contex
         cl_program prog_img = build_program_from_source_ex(
             backend_ctx->context, backend_ctx->device,
             ggml_opencl_fa_kernel_src(FA_VARIANT_F32_F16).c_str(), opts_img,
-            /*fatal=*/false, "fa f32_f16 prefill512 split k_img");
+            /*fatal=*/false, "fa f32_f16 prefill512 split k_img", backend_ctx->queue);
         if (prog_img) {
             cl_int err_img;
             cl_kernel k_img = clCreateKernel(prog_img, "flash_attn_f32_f16_k_img", &err_img);
@@ -4491,7 +4525,11 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
     // (n_q>1) is kept on CPU via the supports_op n_q gate.
     const bool fa_decode_only = (variant == FA_VARIANT_F32_F16 && dk == 512);
     if (fa_decode_only) {
-        opts += " -D FA_DECODE_ONLY";
+        // FA_DECODE_MINIMAL also drops q1_vec, shrinking the DK=512 program to
+        // q1 + q1_split + merge so the Adreno shader compiler stops OOMing under
+        // host-memory pressure (gemma-4 global layers). q1_vec at DV=512 was the
+        // dominant compile-memory cost and is a fallback-only kernel on X1 anyway.
+        opts += " -D FA_DECODE_ONLY -D FA_DECODE_MINIMAL";
     }
 
     const char * tag = nullptr;
@@ -4507,11 +4545,9 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
         default: break;
     }
     cl_program prog = build_program_from_source_ex(
-        backend_ctx->context, backend_ctx->device, src.c_str(), opts, /*fatal=*/false, tag);
-
-    if (!prog) {
-        return false;
-    }
+        backend_ctx->context, backend_ctx->device, src.c_str(), opts,
+        /*fatal=*/false, tag, backend_ctx->queue);
+    if (!prog) return false;
 
     cl_int err;
     switch (variant) {
@@ -4653,7 +4689,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             const std::string opts_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
             cl_program prog_g8 = fa_decode_only ? nullptr : build_program_from_source_ex(
                 backend_ctx->context, backend_ctx->device, src.c_str(), opts_g8,
-                /*fatal=*/false, "fa f32_f16 MQ_GQA=8");
+                /*fatal=*/false, "fa f32_f16 MQ_GQA=8", backend_ctx->queue);
             if (prog_g8) {
                 const size_t mq_g8_required_wg = 192;  // Q1_WG_SIZE(64) * MQ_NSG_SPLIT(3)
                 cl_kernel k_q1_vec_mq_g8 = clCreateKernel(prog_g8, "flash_attn_f32_f16_q1_vec_mq", &err);
@@ -4774,7 +4810,8 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             const std::string opts_mq_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
             cl_program prog_mq_g8 = build_program_from_source_ex(
                 backend_ctx->context, backend_ctx->device, src.c_str(), opts_mq_g8,
-                /*fatal=*/false, is_q8 ? "fa q8_0 MQ_GQA=8" : "fa q4_0 MQ_GQA=8");
+                /*fatal=*/false, is_q8 ? "fa q8_0 MQ_GQA=8" : "fa q4_0 MQ_GQA=8",
+                backend_ctx->queue);
             if (prog_mq_g8) {
                 const size_t mq_g8_required_wg = 192;
                 cl_kernel k_g8 = clCreateKernel(prog_mq_g8, name_mq_split.c_str(), &err);
@@ -4885,12 +4922,9 @@ static bool ggml_opencl_ensure_fa_quant_split_override(
     const std::string tag = std::string("fa ") + (is_q8_0 ? "q8_0" : "q4_0") +
         " split DK=" + std::to_string(dk);
     cl_program prog = build_program_from_source_ex(
-        backend_ctx->context, backend_ctx->device, src.c_str(), opts, /*fatal=*/false, tag.c_str());
-
-    if (!prog) {
-        return false;
-    }
-
+        backend_ctx->context, backend_ctx->device, src.c_str(), opts,
+        /*fatal=*/false, tag.c_str(), backend_ctx->queue);
+    if (!prog) return false;
     cl_int err;
     cl_kernel k;
     if (is_q8_0) {
@@ -6678,6 +6712,12 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 // every other KV combo (f32, f16-q, quant) would need a full
                 // program that OOMs, so decline up front — no probe compile —
                 // and let the graph run it on CPU. q->ne[1] is n_q.
+                // The DK=512 kernels are sized to just fit the Adreno compiler;
+                // Intel's OpenCL compiler crashes building them, so decline on
+                // Intel up front and run these layers on CPU.
+                if (backend_ctx->gpu_family == INTEL) {
+                    return false;
+                }
                 if (!is_f32_f16) {
                     return false;
                 }
@@ -13559,13 +13599,17 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         ? backend_ctx->fa.f32_f16_bn.at(dk_dv)
         : backend_ctx->fa.bn.at(dk_dv);
     // Pick split variant only when n_kv crosses the per-(dk,dv) threshold.
+    // The N_SPLIT>1 prefill tile reduces DK partials via subgroup shuffle (64-wide
+    // on Adreno); on Intel use the non-split BM tile, which is per-query-row and
+    // subgroup-width-agnostic.
     const bool use_split_kernel = (n_q > 1 && is_mixed &&
+        backend_ctx->gpu_family != INTEL &&
         backend_ctx->fa.f32_f16_split.count(dk_dv) > 0 &&
         n_kv >= backend_ctx->fa.f32_f16_split_nkv_threshold.at(dk_dv));
-    const bool use_split_q8_0 = (use_native_q8_0 &&
+    const bool use_split_q8_0 = (use_native_q8_0 && backend_ctx->gpu_family != INTEL &&
         backend_ctx->fa.f32_q8_0_split.count(dk_dv) > 0 &&
         n_kv >= backend_ctx->fa.f32_q8_0_split_nkv_threshold.at(dk_dv));
-    const bool use_split_q4_0 = (use_native_q4_0 &&
+    const bool use_split_q4_0 = (use_native_q4_0 && backend_ctx->gpu_family != INTEL &&
         backend_ctx->fa.f32_q4_0_split.count(dk_dv) > 0 &&
         n_kv >= backend_ctx->fa.f32_q4_0_split_nkv_threshold.at(dk_dv));
     const int wg_size_fa = (n_q > 1 && is_mixed)
@@ -13741,6 +13785,20 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             kernel = backend_ctx->fa.f32.at(dk_dv);
         }
     }
+
+    // Intel reference path: the vec/MQ/local-tile decode variants are tuned for
+    // a 64-wide Adreno subgroup and miscompute on Intel's narrower (32) subgroup.
+    // Route decode to the basic q1 kernel, which is parameterized on FA_SG and
+    // pins the subgroup width via REQD_FA_SG. The MQ FD-split path is disabled on
+    // Intel below; prefill uses the non-split BM tile (per-lane, sg-agnostic).
+    if (backend_ctx->gpu_family == INTEL && n_q == 1) {
+        use_q1_vec = use_q1_vec_mq = use_local_tile = false;
+        if (is_mixed && backend_ctx->fa.f32_f16_q1.count(dk_dv))      { kernel = backend_ctx->fa.f32_f16_q1.at(dk_dv); }
+        else if (is_f16 && backend_ctx->fa.f16_q1.count(dk_dv))       { kernel = backend_ctx->fa.f16_q1.at(dk_dv); }
+        else if (is_q8_0 && backend_ctx->fa.f32_q8_0_q1.count(dk_dv)) { kernel = backend_ctx->fa.f32_q8_0_q1.at(dk_dv); }
+        else if (is_q4_0 && backend_ctx->fa.f32_q4_0_q1.count(dk_dv)) { kernel = backend_ctx->fa.f32_q4_0_q1.at(dk_dv); }
+        else if (backend_ctx->fa.f32_q1.count(dk_dv))                 { kernel = backend_ctx->fa.f32_q1.at(dk_dv); }
+    }
     GGML_ASSERT(kernel != NULL);
 
     ggml_cl_flash_attn_temp_buffer temp_k;
@@ -13845,6 +13903,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         // q8_0, q4_0, local_*) still require n_q == 1.
         const bool nq1_only        = (n_q == 1);
         if (mq_enabled && mq_kv_ok && nq_in_vec_range && !is_causal &&
+            backend_ctx->gpu_family != INTEL &&  // MQ FD-split is 64-wide-subgroup tuned; Intel uses basic q1
             !use_local_tile &&  // local-tile dispatches its own grid, skip MQ FD-split
             n_kv >= FD_MIN_N_KV &&
             backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
@@ -14315,7 +14374,10 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             // q1_vec is compiled with VEC_NSG=4 → WG = 4 * 64 = 256.
             // q1_vec_mq folds MQ_GQA Q-heads into each WG so the head dim of
             // the grid collapses to n_head_kv (one WG per (kv_head, batch)).
-            const size_t wg_size = use_q1_vec ? 256 : 64;
+            // Basic q1 launches one subgroup-wide WG; the width must match FA_SG
+            // (and REQD_FA_SG) the kernel reduces over -- 64 on Adreno, 32 on Intel.
+            const size_t q1_wg = backend_ctx->gpu_family == INTEL ? 32 : 64;
+            const size_t wg_size = use_q1_vec ? 256 : q1_wg;
             const size_t head_dim_global = use_q1_vec_mq
                 ? (size_t)(n_head_kv * n_batch)
                 : (size_t)(n_head     * n_batch);
@@ -16799,6 +16861,11 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
     cl_ulong src_nb2;
     cl_ulong src_nb3;
 
+    // Stable identity of this KV-cache view for the dequant_f16_pool (survives the
+    // per-step graph rebuild because the underlying cache device buffer persists).
+    uintptr_t pool_key_buf = 0;
+    cl_ulong  pool_key_off = (cl_ulong) tensor->view_offs;
+
     const bool is_soa = tensor->type == GGML_TYPE_Q4_0
         ? ggml_cl_is_q4_0_soa(tensor)
         : ggml_cl_is_q8_0_soa(tensor);
@@ -16817,25 +16884,84 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
         cl_mem aos = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, parent_nbytes, NULL, &err);
         CL_CHECK(err);
 
-        cl_kernel kernel;
-        if (tensor->type == GGML_TYPE_Q8_0) {
+        // Large q4_0/q8_0 WEIGHTS are stored transposed (Adreno trans-weight format,
+        // gated by use_adreno_kernels / enable_adreno_trans_weight at set_tensor). The
+        // plain restore_block kernels assume the un-transposed SoA layout and would
+        // produce scrambled AoS for those weights — pick the trans-aware restore to
+        // match how the weight was actually stored (mirrors get_tensor). Small weights
+        // (and the AoS KV-cache, handled in the else branch above) are not transposed.
+        bool restored = false;
+#ifdef GGML_OPENCL_USE_ADRENO_KERNELS
+        const int p_ne00 = (int) parent->ne[0];
+        const int p_ne01 = (int) parent->ne[1];
+        if (tensor->type == GGML_TYPE_Q8_0 && enable_adreno_trans_weight(backend_ctx, parent)) {
             auto * extra = (ggml_tensor_extra_cl_q8_0 *) soa_src->extra;
-            kernel = backend_ctx->kernel_restore_block_q8_0;
+            pool_key_buf = (uintptr_t) extra->q;
+            cl_kernel kernel = backend_ctx->kernel_restore_block_q8_0_trans;
             CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->q));
             CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->d));
             CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &aos));
-        } else {
+            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_int), &p_ne00));
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_int), &p_ne01));
+            size_t gws[] = { (size_t)(((p_ne01 + 63) / 64) * 64), 1, 1 };
+            size_t lws[] = { 64, 1, 1 };
+            CL_CHECK(clEnqueueNDRangeKernel(backend_ctx->queue, kernel, 3, NULL, gws, lws, 0, NULL, NULL));
+            restored = true;
+        } else if (tensor->type == GGML_TYPE_Q4_0 &&
+                   use_adreno_kernels(backend_ctx, parent) &&
+                   !use_adreno_moe_kernels(backend_ctx, parent)) {
+            // Dense q4_0 weight: stored noshuffle + transposed. Transpose q/d back into
+            // scratch, then reconstruct AoS via the noshuffle restore.
             auto * extra = (ggml_tensor_extra_cl_q4_0 *) soa_src->extra;
-            kernel = backend_ctx->kernel_restore_block_q4_0;
-            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->q));
-            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->d));
-            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &aos));
+            pool_key_buf = (uintptr_t) extra->q;
+            const size_t size_q = (size_t) ggml_nelements(parent) / blck_size * (blck_size / 2);
+            const size_t size_d = (size_t) ggml_nelements(parent) / blck_size * sizeof(ggml_fp16_t);
+            cl_int err2 = CL_SUCCESS;
+            cl_mem buf_tq = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, size_q, NULL, &err2); CL_CHECK(err2);
+            cl_mem buf_td = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, size_d, NULL, &err2); CL_CHECK(err2);
+            transpose_2d_as_16b(backend_ctx, extra->q, buf_tq, size_q, p_ne01, p_ne00 / 4);
+            transpose_2d_as_16b(backend_ctx, extra->d, buf_td, size_d, p_ne01, p_ne00 / 32);
+            cl_uchar mask_0F = 0x0F, mask_F0 = 0xF0;
+            cl_kernel kernel = backend_ctx->kernel_restore_block_q4_0_noshuffle;
+            CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem),   &buf_tq));
+            CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem),   &buf_td));
+            CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem),   &aos));
+            CL_CHECK(clSetKernelArg(kernel, 3, sizeof(cl_uchar), &mask_0F));
+            CL_CHECK(clSetKernelArg(kernel, 4, sizeof(cl_uchar), &mask_F0));
+            const size_t n_blk = parent_nbytes / block_bytes;
+            size_t gws[] = { n_blk, 1, 1 };
+            size_t lws[] = { 1, 1, 1 };
+            CL_CHECK(clEnqueueNDRangeKernel(backend_ctx->queue, kernel, 3, NULL, gws, lws, 0, NULL, NULL));
+            // Retained by the runtime while the restore kernel is queued.
+            CL_CHECK(clReleaseMemObject(buf_tq));
+            CL_CHECK(clReleaseMemObject(buf_td));
+            restored = true;
         }
+#endif // GGML_OPENCL_USE_ADRENO_KERNELS
 
-        const size_t n_blocks = parent_nbytes / block_bytes;
-        size_t gws_rec[] = { n_blocks, 1, 1 };
-        size_t lws_rec[] = { 1, 1, 1 };
-        CL_CHECK(clEnqueueNDRangeKernel(backend_ctx->queue, kernel, 3, NULL, gws_rec, lws_rec, 0, NULL, NULL));
+        if (!restored) {
+            cl_kernel kernel;
+            if (tensor->type == GGML_TYPE_Q8_0) {
+                auto * extra = (ggml_tensor_extra_cl_q8_0 *) soa_src->extra;
+                kernel = backend_ctx->kernel_restore_block_q8_0;
+                CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->q));
+                CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->d));
+                CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &aos));
+                pool_key_buf = (uintptr_t) extra->q;
+            } else {
+                auto * extra = (ggml_tensor_extra_cl_q4_0 *) soa_src->extra;
+                kernel = backend_ctx->kernel_restore_block_q4_0;
+                CL_CHECK(clSetKernelArg(kernel, 0, sizeof(cl_mem), &extra->q));
+                CL_CHECK(clSetKernelArg(kernel, 1, sizeof(cl_mem), &extra->d));
+                CL_CHECK(clSetKernelArg(kernel, 2, sizeof(cl_mem), &aos));
+                pool_key_buf = (uintptr_t) extra->q;
+            }
+
+            const size_t n_blocks = parent_nbytes / block_bytes;
+            size_t gws_rec[] = { n_blocks, 1, 1 };
+            size_t lws_rec[] = { 1, 1, 1 };
+            CL_CHECK(clEnqueueNDRangeKernel(backend_ctx->queue, kernel, 3, NULL, gws_rec, lws_rec, 0, NULL, NULL));
+        }
 
         (void) parent_row_blocks;
         (void) parent_row_bytes;
@@ -16859,6 +16985,8 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
         src_nb1    = tensor->nb[1];
         src_nb2    = tensor->nb[2];
         src_nb3    = tensor->nb[3];
+        pool_key_buf = (uintptr_t) extra->data_device;
+        pool_key_off = (cl_ulong) src_offset;
     }
 
     const cl_int nblk0 = (cl_int) (tensor->ne[0] / ggml_blck_size(tensor->type));
@@ -16868,9 +16996,31 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
 
     const size_t out_bytes = (size_t) ggml_nelements(tensor) * sizeof(ggml_fp16_t);
 
-    cl_int err;
-    cl_mem out = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, out_bytes, NULL, &err);
-    CL_CHECK(err);
+    // Reuse a pooled f16 buffer for this KV-cache view across decode steps instead of
+    // allocating one per attention op — the per-op alloc/free churn exhausts the
+    // allocator on deep-context 20 GB MoE decode. The pool owns the buffer (released at
+    // teardown); the caller must NOT release the returned cl_mem.
+    cl_mem out = nullptr;
+    {
+        auto & pool = backend_ctx->dequant_f16_pool;
+        ggml_backend_opencl_context::ImagePoolKey key{pool_key_buf, (uint64_t) pool_key_off};
+        auto it = pool.find(key);
+        if (it != pool.end() && it->second.k_bytes >= out_bytes && it->second.image) {
+            out = it->second.image;
+        } else {
+            if (it != pool.end()) {
+                if (it->second.image) CL_CHECK(clReleaseMemObject(it->second.image));
+                pool.erase(it);
+            }
+            cl_int err = CL_SUCCESS;
+            out = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, out_bytes, NULL, &err);
+            CL_CHECK(err);
+            ggml_backend_opencl_context::ImagePoolEntry entry;
+            entry.image   = out;
+            entry.k_bytes = out_bytes;
+            pool[key]     = entry;
+        }
+    }
 
     cl_kernel dq_kernel = tensor->type == GGML_TYPE_Q8_0
         ? backend_ctx->kernel_dequant_q8_0_f16_view_aos
@@ -16970,8 +17120,16 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
-    // Non-contig quant src0: on-device dequant to f16 then native f16 MUL_MAT.
-    if ((src0t == GGML_TYPE_Q4_0 || src0t == GGML_TYPE_Q8_0) && !ggml_is_contiguous(src0)) {
+    // Quant KV-cache read (fa=0 attention K/V): on-device dequant to f16 then
+    // native f16 MUL_MAT. Triggered for non-contiguous src0 (the usual head-major
+    // permuted K view when n_head_kv>1) AND for the contiguous case that occurs
+    // when n_head_kv==1 (e.g. Gemma-4 E2B, GQA 8:1) — there the K view is dense so
+    // !ggml_is_contiguous is false, but it still broadcasts over heads
+    // (src1->ne[2] > src0->ne[2]) and must NOT fall into the generic weight GEMV
+    // (which assumes no head broadcast and SIGSEGVs). Head broadcast (r2>1) is a
+    // weight-free signal: model weights never broadcast over ne2.
+    if ((src0t == GGML_TYPE_Q4_0 || src0t == GGML_TYPE_Q8_0) &&
+        (!ggml_is_contiguous(src0) || src1->ne[2] > src0->ne[2])) {
         cl_mem f16_buf = ggml_cl_mul_mat_dequant_quant_to_f16(backend_ctx, src0, nullptr);
 
         ggml_tensor         fake_src0 = *src0;
@@ -16989,9 +17147,8 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
 
         ggml_cl_mul_mat(backend, &fake_src0, src1, dst);
 
-        // Safe to release now: OpenCL retains the memobj while queued
-        // kernels that reference it are still in flight.
-        CL_CHECK(clReleaseMemObject(f16_buf));
+        // f16_buf is owned by backend_ctx->dequant_f16_pool and reused across decode
+        // steps — do NOT release it here (it is freed at backend teardown).
         return;
     }
 

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -443,6 +443,12 @@ struct ggml_opencl_fa_kernels {
     // K-image variant of MQ_G8 vec_mq_split: K bound as image1d_buffer_t
     // (Adreno texture cache, separate BW path from L2). Opt-in, GGML_OPENCL_FA_K_IMG=1.
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_k_img;
+    // K-image variant of MQ_GQA=4 vec_mq_split (default program). Same source as
+    // _g8_k_img but compiled with the default MQ_GQA=4 — targets dense GQA=4
+    // DK=DV=128 (Mistral-7B / Qwen3-8B / Llama-3-8B). Opt-in via
+    // GGML_OPENCL_FA_F16_MQ_DK128=1 (+ GGML_OPENCL_FA_K_IMG=1 for the K-image
+    // path; without K_IMG, the non-image f32_f16_q1_vec_mq_split fires).
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_k_img;
     // Alternative decode FA: 1 WG per (q_idx, q_head) with a __local K/V tile +
     // pure __local tree-reduce. Compiled only at DK=DV=128. Opt-in.
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_tile;
@@ -4489,6 +4495,20 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_split, "flash_attn_f32_f16_q1_vec_mq_split", dk, dv);
                 } else {
                     clReleaseKernel(k_q1_vec_mq_split);
+                }
+            }
+            // K-image variant of MQ_GQA=4 split (default prog). Same source as
+            // the _g8 K-image kernel below, just compiled with the default
+            // MQ_GQA=4 specialization — targets dense GQA=4 DK=DV=128 (Mistral,
+            // Qwen3-8B, Llama-3-8B). Opt-in dispatch.
+            cl_kernel k_q1_vec_mq_split_k_img = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec_mq_split_k_img", &err);
+            if (err == CL_SUCCESS) {
+                if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split_k_img, 256,
+                                                  "flash_attn_f32_f16_q1_vec_mq_split_k_img", dk, dv)) {
+                    backend_ctx->fa.f32_f16_q1_vec_mq_split_k_img[{dk, dv}] = k_q1_vec_mq_split_k_img;
+                    ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_split_k_img, "flash_attn_f32_f16_q1_vec_mq_split_k_img", dk, dv);
+                } else {
+                    clReleaseKernel(k_q1_vec_mq_split_k_img);
                 }
             }
             cl_kernel k_merge = clCreateKernel(prog, "flash_attn_f32_merge", &err);
@@ -13302,6 +13322,10 @@ static constexpr int FD_MAX_SPLITS    = 16;
 static constexpr int FD_MAX_DK        = 128;
 static constexpr int FD_MAX_DK_MULTI  = 64;
 static constexpr int FD_MAX_N_Q_MULTI = 8;
+// MQ FD split-groups have few subgroups (MQ_NSG_SPLIT), so use a smaller
+// kv_per_split to keep the softmax recurrence short; non-MQ keeps FD_KV_PER_SPLIT.
+static constexpr int FD_MQ_KV_PER_SPLIT = 256;
+static constexpr int FD_MQ_MAX_SPLITS   = 128;
 
 static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, const ggml_tensor * k, ggml_tensor * dst) {
     const ggml_tensor * v = dst->src[2];
@@ -13675,12 +13699,40 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 fd_k_split = backend_ctx->fa.f32_f16_q1_local_mq_split.at(dk_dv);
                 use_fd_mq  = true;
                 fd_mq_wg   = 64;  // LMQ_WG
-            // f16 KV — Gemma-3 class (DK=DV=256 GQA=4); n_q==1 only for now
+            // f16 KV — Gemma-3 class (DK=DV=256 GQA=4) and the GQA=4 DK=DV=128
+            // family (Qwen3-4B/8B, Llama-3.x, Mistral-7B). Same MQ_GQA=4 kernel,
+            // already compiled per (dk, dv). Without the DK=128 branch f16 KV
+            // decode on these models falls to the spilling non-MQ split and
+            // pays a GQA-replay on K reads — structurally slower than the q8_0
+            // path on the same model. WG=256 fits at DK=128 (less per-thread
+            // state than DK=256); if the kernel didn't compile or doesn't fit,
+            // `count(dk_dv) > 0` skips dispatch. n_q==1 only for now.
             } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
-                d_head_q == 256 && d_head_v == 256 &&
+                ((d_head_q == 256 && d_head_v == 256) ||
+                 (d_head_q == 128 && d_head_v == 128)) &&
                 backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
                 use_fd_mq  = true;
+            // f16 KV — dense 7-8B class (Mistral-7B / Qwen3-8B / Llama-3-8B),
+            // DK=DV=128 GQA=4. Plain q1_split is 3.5x slower per layer than
+            // FA=0's image-fed l4_x8_gqa_r4_img KQ. MQ closes +60-90% of that
+            // end-to-end at d=8k on X1-85 (Mistral 2.90→5.49, Qwen3-8B 2.37→3.80,
+            // Llama-3-8B 2.56→4.68 t/s). K-image adds ~1-3% per-FA-call further,
+            // opt-in via GGML_OPENCL_FA_K_IMG=1 (mirrors the g8 dispatch).
+            } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
+                d_head_q == 128 && d_head_v == 128 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
+                const bool k_img_on = getenv("GGML_OPENCL_FA_K_IMG") != NULL &&
+                                      getenv("GGML_OPENCL_FA_K_IMG")[0] != '0';
+                if (k_img_on &&
+                    backend_ctx->fa.f32_f16_q1_vec_mq_split_k_img.count(dk_dv) > 0) {
+                    fd_k_split   = backend_ctx->fa.f32_f16_q1_vec_mq_split_k_img.at(dk_dv);
+                    use_fd_mq    = true;
+                    use_fa_k_img = true;
+                } else {
+                    fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
+                    use_fd_mq  = true;
+                }
             // f16 KV — Qwen3-30B-A3B class (DK=DV=128 GQA=8); extended to n_q ∈ [1, N_MAX_VEC_NQ].
             // K-image variant: same MQ_G8 path but K bound via image1d_buffer_t.
             // Opt-in via GGML_OPENCL_FA_K_IMG=1; targets the long-context FA
@@ -13713,11 +13765,16 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 backend_ctx->fa.f32_q8_0_q1_vec_mq_split.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split.at(dk_dv);
                 use_fd_mq  = true;
-            // q4_0 KV — opt-in only. The MQ port for q4_0 regressed on
-            // Qwen3-30B-A3B: q4_0 K is only 4 bits/element, so the K-bandwidth
-            // saving MQ offers doesn't offset the per-head dp4a + LDS overhead
-            // (q8_0 at 8 b/e and f16 at 16 b/e do win). Kernel kept registered;
-            // enable for measurement via GGML_OPENCL_FA_Q4_MQ=1.
+            // q4_0 KV — MQ-split dispatch is split by GQA fan-out:
+            //   GQA=4 (MQ_GQA=4 kernel): default-on. Dense 4/8-class targets
+            //     (Mistral-7B, Qwen3-4B/8B, Llama-3-8B) measure +72-151%
+            //     decode at d=8k/16k vs plain q1_split on Adreno X1-85.
+            //   GQA=8 (g8 / MQ_GQA=8 kernel): opt-in. Regressed on
+            //     Qwen3-30B-A3B (per-FA-call +20% on X1-85): q4_0 K at
+            //     4 b/e gives less K-BW saving than q8/f16 while the
+            //     occupancy drop + per-head dp4a + LDS overhead cost
+            //     more than they save on that shape.
+            //     Enable for measurement via GGML_OPENCL_FA_Q4_MQ=1.
             } else if (nq1_only && is_q4_0) {
                 const char * q4_mq_env = getenv("GGML_OPENCL_FA_Q4_MQ");
                 const bool   q4_mq_on  = (q4_mq_env != NULL) && (q4_mq_env[0] != '0');
@@ -13727,7 +13784,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                     fd_k_split = backend_ctx->fa.f32_q4_0_q1_vec_mq_split_g8.at(dk_dv);
                     use_fd_mq  = true;
                     fd_mq_wg   = 192;
-                } else if (q4_mq_on && gqa_ratio_dispatch == 4 &&
+                } else if (gqa_ratio_dispatch == 4 &&
                     d_head_q == 128 && d_head_v == 128 &&
                     backend_ctx->fa.f32_q4_0_q1_vec_mq_split.count(dk_dv) > 0) {
                     fd_k_split = backend_ctx->fa.f32_q4_0_q1_vec_mq_split.at(dk_dv);
@@ -13854,13 +13911,25 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_head_log2_f);
 
     if (use_fd) {
-        int n_splits = (n_kv + FD_KV_PER_SPLIT - 1) / FD_KV_PER_SPLIT;
-        if (n_splits < FD_MIN_SPLITS) {
-            n_splits = FD_MIN_SPLITS;
-        }
-        if (n_splits > FD_MAX_SPLITS) {
-            n_splits = FD_MAX_SPLITS;
-        }
+        // MQ FD split kernels are latency-bound on a deep per-subgroup
+        // online-softmax recurrence at the prefill-tuned FD_KV_PER_SPLIT;
+        // use a finer decode granularity for them (see FD_MQ_KV_PER_SPLIT).
+        // Env overrides (read once) keep the granularity sweepable.
+        static const int fd_env_kv_per_split = []{
+            const char * e = getenv("GGML_OPENCL_FD_KV_PER_SPLIT");
+            return (e && e[0]) ? atoi(e) : 0;
+        }();
+        static const int fd_env_max_splits = []{
+            const char * e = getenv("GGML_OPENCL_FD_MAX_SPLITS");
+            return (e && e[0]) ? atoi(e) : 0;
+        }();
+        int fd_kv_per_split = use_fd_mq ? FD_MQ_KV_PER_SPLIT : FD_KV_PER_SPLIT;
+        int fd_max_splits   = use_fd_mq ? FD_MQ_MAX_SPLITS   : FD_MAX_SPLITS;
+        if (fd_env_kv_per_split > 0) fd_kv_per_split = fd_env_kv_per_split;
+        if (fd_env_max_splits   > 0) fd_max_splits   = fd_env_max_splits;
+        int n_splits = (n_kv + fd_kv_per_split - 1) / fd_kv_per_split;
+        if (n_splits < FD_MIN_SPLITS) n_splits = FD_MIN_SPLITS;
+        if (n_splits > fd_max_splits) n_splits = fd_max_splits;
         const int kv_per_split = (n_kv + n_splits - 1) / n_splits;
 
         const int fa_partial_floats = 2 + d_head_v;
@@ -13904,10 +13973,16 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                     k_data_device, offset_k, k_bytes, CL_HALF_FLOAT);
             }
             // Fallback: if image creation failed (over max pixels, alloc fail),
-            // re-route through the regular MQ_G8 path. Rare; keeps the run
-            // alive instead of crashing.
+            // re-route through the matching non-image MQ path. Rare; keeps the
+            // run alive instead of crashing. gqa==4 → default MQ kernel,
+            // gqa==8 → MQ_G8 kernel.
             if (k_img == nullptr) {
-                k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.at(dk_dv);
+                if (gqa_ratio_dispatch == 4 &&
+                    backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
+                    k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
+                } else {
+                    k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.at(dk_dv);
+                }
                 use_fa_k_img = false;
                 CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &k_data_device));
                 CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_k));

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -440,6 +440,9 @@ struct ggml_opencl_fa_kernels {
     // a second program compiled with -DMQ_GQA=8 so the Q-row stride matches.
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_g8;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8;
+    // K-image variant of MQ_G8 vec_mq_split: K bound as image1d_buffer_t
+    // (Adreno texture cache, separate BW path from L2). Opt-in, GGML_OPENCL_FA_K_IMG=1.
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_k_img;
     // Alternative decode FA: 1 WG per (q_idx, q_head) with a __local K/V tile +
     // pure __local tree-reduce. Compiled only at DK=DV=128. Opt-in.
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_tile;
@@ -545,6 +548,30 @@ struct ggml_backend_opencl_context {
     ggml_cl_buffer prealloc_quant_trans;
     ggml_cl_buffer prealloc_scales_trans;
     ggml_cl_buffer prealloc_act_trans;
+
+    // Pool of persistent image1d_buffer views over KV-cache layers, keyed by
+    // (parent buffer, offset within parent). Used by the IMG-variant KQ/KQV
+    // dispatch paths to avoid per-call clCreateSubBuffer + clCreateImage +
+    // pending-release-queue churn on long-context decode (which was
+    // catastrophic on Qwen3.6-35B-A3B: 0.99 t/s vs 14.33 t/s on the smaller
+    // 30B model). Entries grow if a later dispatch sees a larger byte-span;
+    // released in free().
+    struct ImagePoolKey {
+        uintptr_t buf;
+        uint64_t  offset;
+        bool operator<(const ImagePoolKey & o) const {
+            if (buf != o.buf) return buf < o.buf;
+            return offset < o.offset;
+        }
+    };
+    struct ImagePoolEntry {
+        cl_mem sub_buffer = nullptr;
+        cl_mem image      = nullptr;
+        size_t k_bytes    = 0;
+        cl_channel_type channel_data_type = CL_FLOAT;
+    };
+    std::map<ImagePoolKey, ImagePoolEntry> kq_img_pool;
+    std::map<ImagePoolKey, ImagePoolEntry> kqv_img_pool;
 
     // prealloc buffers for src0 and src1
     ggml_cl_buffer prealloc_src0;
@@ -672,6 +699,15 @@ struct ggml_backend_opencl_context {
     cl_kernel kernel_mul_mat_f16_f32_l4_dr;
     cl_kernel kernel_mul_mat_f16_f32_l4_dr_ls;
     cl_kernel kernel_mul_mat_f16_f32_l4_dr_lq;
+    cl_kernel kernel_mul_mat_f16_f32_l4_x8 = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_x8_pair = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_x8_gqa4 = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_x8_gqa4_img = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_y8 = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_y8_gqa = nullptr;
+    cl_kernel kernel_mul_mat_f16_f32_l4_y8_gqa_img = nullptr;
     cl_kernel kernel_mul_mat_f16_f32_tiled;
     cl_kernel kernel_adreno_xmem_pack_src_f32;
     cl_kernel kernel_adreno_xmem_prepack_weight_f16;
@@ -982,6 +1018,17 @@ struct ggml_backend_opencl_context {
             write_profiling_info();
             profiling_results.clear();
 #endif
+            // Release pooled image1d_buffer views over KV cache layers.
+            for (auto & kv : kq_img_pool) {
+                if (kv.second.image)      CL_CHECK(clReleaseMemObject(kv.second.image));
+                if (kv.second.sub_buffer) CL_CHECK(clReleaseMemObject(kv.second.sub_buffer));
+            }
+            kq_img_pool.clear();
+            for (auto & kv : kqv_img_pool) {
+                if (kv.second.image)      CL_CHECK(clReleaseMemObject(kv.second.image));
+                if (kv.second.sub_buffer) CL_CHECK(clReleaseMemObject(kv.second.sub_buffer));
+            }
+            kqv_img_pool.clear();
         }
     }
 };
@@ -1942,6 +1989,64 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
             CL_CHECK((backend_ctx->kernel_mul_mat_f16_f32_l4_dr_ls = clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_dr_ls", &err), err));
             CL_CHECK((backend_ctx->kernel_mul_mat_f16_f32_l4_dr_lq = clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_dr_lq", &err), err));
         }
+        // Best-effort: multi-row decode variant (8 K rows / WG, Q cached in __local).
+        cl_int err_x8 = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_x8 =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8", &err_x8);
+        if (err_x8 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8 = nullptr;
+        // Paired K-row variant of _x8: doubles per-wave-cycle memory-issue
+        // parallelism at DK in [128, 256] by using both halves of the 64-lane
+        // warp on adjacent K-rows. Best-effort.
+        cl_int err_x8p = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_pair", &err_x8p);
+        if (err_x8p != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair = nullptr;
+        // GQA-coalesced variant of _x8 for DK=128, r2=4: one WG per K-head,
+        // 64-lane warp partitioned across 4 Q-heads so each K-row is read
+        // once and contributes to 4 outputs. Targets long-context KQ where
+        // the 4× K replay dominates. Best-effort.
+        cl_int err_x8g = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4 =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa4", &err_x8g);
+        if (err_x8g != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4 = nullptr;
+        // image1d_buffer_t (texture-cache) variant of _x8_gqa4. Same kernel
+        // body but K is bound as a read-only image1d_buffer over a sub-buffer
+        // covering the K cache. Host creates the sub-buffer + image per call.
+        // Targets the long-ctx KQ BW gap (effective K-read 7.3 GB/s vs 76
+        // GB/s coalesced peak on Adreno X2). Best-effort.
+        cl_int err_x8gi = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa4_img", &err_x8gi);
+        if (err_x8gi != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img = nullptr;
+        // r2=4 specialization (Llama-3.x / Qwen3-4B/8B / Qwen3.5-4B / etc.).
+        cl_int err_x8gi_r4 = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img", &err_x8gi_r4);
+        if (err_x8gi_r4 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img = nullptr;
+        // DK=256, r2=2 specialization for Gemma-3-4B.
+        cl_int err_r2dk256 = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img", &err_r2dk256);
+        if (err_r2dk256 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img = nullptr;
+        // Streaming-Q multi-output variant for KQV-shaped matmul (ne00 large,
+        // ne01 small). Best-effort.
+        cl_int err_y8 = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_y8 =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_y8", &err_y8);
+        if (err_y8 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_y8 = nullptr;
+        // GQA-coalesced KQV variant: one WG per K-head emits 8 DV-rows × 8
+        // Q-heads = 64 outputs. Reduces V replay by r2=8. Best-effort.
+        cl_int err_y8g = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_y8_gqa", &err_y8g);
+        if (err_y8g != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa = nullptr;
+        // image1d_buffer_t (texture-cache) variant of _y8_gqa. V bound as
+        // read-only image; same generic k_bytes formula handles the V
+        // (transposed n_kv-fast) layout.
+        cl_int err_y8gi = CL_SUCCESS;
+        backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa_img =
+            clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_y8_gqa_img", &err_y8gi);
+        if (err_y8gi != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa_img = nullptr;
         GGML_LOG_CONT(".");
     }
 
@@ -4454,6 +4559,20 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                         ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_split_g8, "flash_attn_f32_f16_q1_vec_mq_split_g8", dk, dv);
                     } else {
                         clReleaseKernel(k_q1_vec_mq_split_g8);
+                    }
+                }
+                // K-image variant: same MQ_GQA=8 specialization but K is
+                // bound as image1d_buffer_t (Adreno texture cache). Only
+                // dispatched when GGML_OPENCL_FA_K_IMG=1. Same source, same
+                // -DMQ_GQA=8 program, just a different __kernel entry.
+                cl_kernel k_q1_vec_mq_split_g8_k_img = clCreateKernel(prog_g8, "flash_attn_f32_f16_q1_vec_mq_split_k_img", &err);
+                if (err == CL_SUCCESS) {
+                    if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split_g8_k_img, mq_g8_required_wg,
+                                                      "flash_attn_f32_f16_q1_vec_mq_split_k_img (g8)", dk, dv)) {
+                        backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_k_img[{dk, dv}] = k_q1_vec_mq_split_g8_k_img;
+                        ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_split_g8_k_img, "flash_attn_f32_f16_q1_vec_mq_split_g8_k_img", dk, dv);
+                    } else {
+                        clReleaseKernel(k_q1_vec_mq_split_g8_k_img);
                     }
                 }
                 // Hybrid local-tile + MQ_GQA=8. WG=64 (1 subgroup); the
@@ -12889,6 +13008,17 @@ static void ggml_cl_flash_attn_read_tensor_host(
     GGML_ASSERT(dst_off == total_bytes);
 }
 
+// Forward decl: used by the FA decode dispatch (K-image variant) below.
+// Definition lives near the other mul_mat IMG paths.
+static cl_mem ggml_cl_img_pool_get_or_create(
+    ggml_backend_opencl_context * backend_ctx,
+    std::map<ggml_backend_opencl_context::ImagePoolKey,
+             ggml_backend_opencl_context::ImagePoolEntry> & pool,
+    cl_mem data_device,
+    cl_ulong offset0,
+    size_t required_bytes,
+    cl_channel_type channel_data_type);
+
 // Rebuild AoS q8_0/q4_0 bytes from a SoA tensor into a temp buffer.
 // Returns false if the tensor is not SoA-quantised (already AoS).
 static bool ggml_cl_flash_attn_reconstruct_aos(
@@ -13501,6 +13631,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     cl_kernel fd_k_split = NULL;
     bool use_fd_mq = false;
     size_t fd_mq_wg = 256;  // MQ_GQA=4 kernel: Q1_WG_SIZE(64) * MQ_NSG_SPLIT(4)
+    bool use_fa_k_img = false;  // K bound as image1d_buffer_t instead of (buf, offset)
     // MQ flash-decoding gate. Bypasses FD_MAX_DK because the MQ split kernel
     // uses NSG subgroups × 64 lanes, so o_acc is DV-split — no spill at DK=DV=256.
     // - gqa_ratio == 4 + DK=DV=256: Gemma-3 family, MQ_GQA=4 kernel.
@@ -13550,7 +13681,19 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
                 use_fd_mq  = true;
-            // f16 KV — Qwen3-30B-A3B class (DK=DV=128 GQA=8); extended to n_q ∈ [1, N_MAX_VEC_NQ]
+            // f16 KV — Qwen3-30B-A3B class (DK=DV=128 GQA=8); extended to n_q ∈ [1, N_MAX_VEC_NQ].
+            // K-image variant: same MQ_G8 path but K bound via image1d_buffer_t.
+            // Opt-in via GGML_OPENCL_FA_K_IMG=1; targets the long-context FA
+            // K-read bandwidth bottleneck.
+            } else if (is_mixed && gqa_ratio_dispatch == 8 &&
+                d_head_q == 128 && d_head_v == 128 &&
+                getenv("GGML_OPENCL_FA_K_IMG") != NULL &&
+                getenv("GGML_OPENCL_FA_K_IMG")[0] != '0' &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_k_img.count(dk_dv) > 0) {
+                fd_k_split   = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_k_img.at(dk_dv);
+                use_fd_mq    = true;
+                fd_mq_wg     = 192;
+                use_fa_k_img = true;
             } else if (is_mixed && gqa_ratio_dispatch == 8 &&
                 d_head_q == 128 && d_head_v == 128 &&
                 backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.count(dk_dv) > 0) {
@@ -13739,8 +13882,43 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         int argi = 0;
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &extra_q->data_device));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_q));
-        CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &k_data_device));
-        CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_k));
+        if (use_fa_k_img) {
+            // K via image1d_buffer_t. Pool keyed on (parent_buffer, offset_k);
+            // image is sub-buffer-backed (origin=offset_k), so the kernel reads
+            // pixels relative to sub-buffer start — no k_offset arg.
+            // Byte-span must cover the FULL strided extent (the K view at FA
+            // decode is often head-major permuted on Adreno, so head/batch
+            // strides can dominate). Round up to 8 B (pixel size = 1 half4).
+            const size_t nb00_bytes  = sizeof(uint16_t);
+            const size_t k_bytes_span =
+                (size_t)(n_kv > 0 ? n_kv - 1 : 0) * (size_t)k_nb1 +
+                (size_t)(n_head_kv > 0 ? n_head_kv - 1 : 0) * (size_t)k_nb2 +
+                (size_t)(n_batch > 0 ? n_batch - 1 : 0) * (size_t)k_nb3 +
+                (size_t)d_head_q * nb00_bytes;
+            const size_t k_bytes  = (k_bytes_span + 7) & ~(size_t)7;
+            const size_t k_pixels = k_bytes >> 3;
+            cl_mem k_img = nullptr;
+            if (k_pixels > 0 && k_pixels <= backend_ctx->image_max_buffer_size) {
+                k_img = ggml_cl_img_pool_get_or_create(
+                    backend_ctx, backend_ctx->kq_img_pool,
+                    k_data_device, offset_k, k_bytes, CL_HALF_FLOAT);
+            }
+            // Fallback: if image creation failed (over max pixels, alloc fail),
+            // re-route through the regular MQ_G8 path. Rare; keeps the run
+            // alive instead of crashing.
+            if (k_img == nullptr) {
+                k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.at(dk_dv);
+                use_fa_k_img = false;
+                CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &k_data_device));
+                CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_k));
+            } else {
+                CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &k_img));
+                // k_offset is baked into the sub-buffer; no separate arg.
+            }
+        } else {
+            CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &k_data_device));
+            CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_k));
+        }
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &v_data_device));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_v));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(float),    &scale));
@@ -16453,6 +16631,68 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
     return out;
 }
 
+// Look up or create a pooled image1d_buffer over a KV-cache view (parent
+// buffer + offset). Reuse across decode steps avoids per-call sub-buffer +
+// image churn that catastrophically slows down 64-layer / 20 GB models. The
+// pool grows the image if a later dispatch sees a larger byte-span; the
+// entry is released only at backend teardown.
+static cl_mem ggml_cl_img_pool_get_or_create(
+    ggml_backend_opencl_context * backend_ctx,
+    std::map<ggml_backend_opencl_context::ImagePoolKey,
+             ggml_backend_opencl_context::ImagePoolEntry> & pool,
+    cl_mem data_device,
+    cl_ulong offset0,
+    size_t required_bytes,
+    cl_channel_type channel_data_type)
+{
+    ggml_backend_opencl_context::ImagePoolKey key{(uintptr_t)data_device, (uint64_t)offset0};
+    auto it = pool.find(key);
+    if (it != pool.end()
+        && it->second.k_bytes >= required_bytes
+        && it->second.channel_data_type == channel_data_type
+        && it->second.image != nullptr) {
+        return it->second.image;
+    }
+
+    // Need to create or recreate. Release any stale entry first.
+    if (it != pool.end()) {
+        if (it->second.image)      CL_CHECK(clReleaseMemObject(it->second.image));
+        if (it->second.sub_buffer) CL_CHECK(clReleaseMemObject(it->second.sub_buffer));
+        pool.erase(it);
+    }
+
+    cl_int status = CL_SUCCESS;
+    cl_buffer_region region = {};
+    region.origin = (size_t)offset0;
+    region.size   = required_bytes;
+    cl_mem sub = clCreateSubBuffer(data_device, 0,
+                                   CL_BUFFER_CREATE_TYPE_REGION, &region, &status);
+    if (status != CL_SUCCESS) {
+        return nullptr;
+    }
+
+    const size_t pixel_size = (channel_data_type == CL_HALF_FLOAT) ? 8 : 16;
+    cl_image_format fmt = {CL_RGBA, channel_data_type};
+    cl_image_desc   desc = {};
+    desc.image_type   = CL_MEM_OBJECT_IMAGE1D_BUFFER;
+    desc.image_width  = required_bytes / pixel_size;
+    desc.buffer       = sub;
+    cl_mem img = clCreateImage(backend_ctx->context, CL_MEM_READ_ONLY,
+                               &fmt, &desc, NULL, &status);
+    if (status != CL_SUCCESS) {
+        CL_CHECK(clReleaseMemObject(sub));
+        return nullptr;
+    }
+
+    ggml_backend_opencl_context::ImagePoolEntry entry;
+    entry.sub_buffer = sub;
+    entry.image      = img;
+    entry.k_bytes    = required_bytes;
+    entry.channel_data_type = channel_data_type;
+    pool[key] = entry;
+    return img;
+}
+
 static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     GGML_ASSERT(src0);
     GGML_ASSERT(src0->extra);
@@ -16559,6 +16799,255 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 ((nb02 * ne02 / 4)/4 <= backend_ctx->image_max_buffer_size)) {
                 ggml_cl_mul_mat_kq_kqv_adreno(backend, src0, src1, dst);
                 return;
+            }
+        }
+
+        // Decode-time GQA-coalesced KQ via image1d_buffer_t (texture cache).
+        // Same shape gate as _x8_gqa4 (DK=128, r2=8, r3=1, ne01%16==0, ne11=1)
+        // plus enough K-cache bytes (must fit image_max_buffer_size in pixels).
+        // Opt-in via GGML_OPENCL_MM_KQ_GQA_IMG=1.
+        // r2=4 variant: GGML_OPENCL_MM_KQ_GQA_R4_IMG=1 enables the r2=4
+        // specialization (Llama-3.x / Qwen3-4B/8B / etc.).
+        // Default ON; set the env var to "0" to disable as a kill-switch.
+        // All test-backend-ops MUL_MAT type_a=f16 cases pass with these gates
+        // enabled. Promoted to default after validation on Qwen3-30B-A3B,
+        // Qwen3.6-35B-A3B, Qwen3-4B, Qwen3-8B, Llama-3-8B.
+        static const char * mm_kq_gqa_img_env = getenv("GGML_OPENCL_MM_KQ_GQA_IMG");
+        static const bool mm_kq_gqa_img_on = (mm_kq_gqa_img_env == nullptr || mm_kq_gqa_img_env[0] != '0');
+        static const char * mm_kq_gqa_r4_img_env = getenv("GGML_OPENCL_MM_KQ_GQA_R4_IMG");
+        static const bool mm_kq_gqa_r4_img_on = (mm_kq_gqa_r4_img_env == nullptr || mm_kq_gqa_r4_img_env[0] != '0');
+        const bool img_r4_gate =
+            mm_kq_gqa_r4_img_on &&
+            backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img != nullptr &&
+            ne11 == 1 && ne01 >= 64 && (ne01 % 16) == 0 && ne00 == 128 &&
+            (ne12 % ne02) == 0 && (ne12 / ne02) == 4 && (ne13 / ne03) == 1;
+        if (mm_kq_gqa_img_on &&
+            backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img != nullptr &&
+            ne11 == 1 && ne01 >= 64 && (ne01 % 16) == 0 && ne00 == 128 &&
+            (ne12 % ne02) == 0 && (ne12 / ne02) == 8 && (ne13 / ne03) == 1) {
+            // K cache byte-span the image must cover. The K view at decode
+            // KQ is often PERMUTED on Adreno (nb01 > nb02 — head-major), so
+            // compute the actual byte-span generically: max byte touched =
+            // (ne01-1)*nb01 + (ne02-1)*nb02 + (ne03-1)*nb03 + ne00*sizeof(half).
+            // Image pixel = 16 bytes (CL_RGBA, CL_FLOAT — mirrors prefill kq).
+            const size_t nb00_bytes = sizeof(uint16_t);
+            const size_t k_bytes_span =
+                (size_t)(ne01 > 0 ? ne01 - 1 : 0) * (size_t)nb01 +
+                (size_t)(ne02 > 0 ? ne02 - 1 : 0) * (size_t)nb02 +
+                (size_t)(ne03 > 0 ? ne03 - 1 : 0) * (size_t)nb03 +
+                (size_t)ne00 * nb00_bytes;
+            // Round up to a multiple of 16 (pixel size) so image_width covers it.
+            const size_t k_bytes = (k_bytes_span + 15) & ~(size_t)15;
+            const size_t k_pixels = k_bytes >> 4;
+            if (k_pixels > 0 && k_pixels <= backend_ctx->image_max_buffer_size) {
+                cl_kernel kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img;
+                // Persistent pool: reuse the same image1d_buffer across decode
+                // steps for the same (parent buffer, offset) view.
+                cl_mem K_img = ggml_cl_img_pool_get_or_create(
+                    backend_ctx, backend_ctx->kq_img_pool,
+                    extra0->data_device, offset0, k_bytes, CL_FLOAT);
+                if (K_img != nullptr) {
+                    cl_uint k_arg = 0;
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &K_img));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extra1->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offset1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extrad->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offsetd));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne00));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb03));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb13));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne0));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r2));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r3));
+
+                    const int nth0_d = 64;
+                    const int64_t n_wg_x = ne01 / 16;
+                    size_t global_work_size[] = {(size_t)n_wg_x * nth0_d, (size_t)1, (size_t)ne02 * ne13};
+                    size_t local_work_size[]  = {(size_t)nth0_d, (size_t)1, 1};
+                    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+                    return;
+                }
+                // Fall through on pool creation failure (rare; image_max etc).
+            }
+        }
+
+        // r2=4 specialization: Llama-3.x / Qwen3-4B/8B / etc.
+        // Uses the same pool (kq_img_pool) as the r2=8 path; different kernel.
+        if (img_r4_gate) {
+            const size_t nb00_bytes = sizeof(uint16_t);
+            const size_t k_bytes_span =
+                (size_t)(ne01 > 0 ? ne01 - 1 : 0) * (size_t)nb01 +
+                (size_t)(ne02 > 0 ? ne02 - 1 : 0) * (size_t)nb02 +
+                (size_t)(ne03 > 0 ? ne03 - 1 : 0) * (size_t)nb03 +
+                (size_t)ne00 * nb00_bytes;
+            const size_t k_bytes = (k_bytes_span + 15) & ~(size_t)15;
+            const size_t k_pixels = k_bytes >> 4;
+            if (k_pixels > 0 && k_pixels <= backend_ctx->image_max_buffer_size) {
+                cl_kernel kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img;
+                cl_mem K_img = ggml_cl_img_pool_get_or_create(
+                    backend_ctx, backend_ctx->kq_img_pool,
+                    extra0->data_device, offset0, k_bytes, CL_FLOAT);
+                if (K_img != nullptr) {
+                    cl_uint k_arg = 0;
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &K_img));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extra1->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offset1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extrad->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offsetd));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne00));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb03));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb13));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne0));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r2));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r3));
+
+                    const int nth0_d = 64;
+                    const int64_t n_wg_x = ne01 / 16;
+                    size_t global_work_size[] = {(size_t)n_wg_x * nth0_d, (size_t)1, (size_t)ne02 * ne13};
+                    size_t local_work_size[]  = {(size_t)nth0_d, (size_t)1, 1};
+                    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+                    return;
+                }
+            }
+        }
+
+        // DK=256, r2=2 specialization (Gemma-3-4B: n_head=8, n_head_kv=4, head_dim=256).
+        // Opt-in via GGML_OPENCL_MM_KQ_GQA_R2_DK256_IMG=1.
+        static const char * mm_kq_r2_dk256_env = getenv("GGML_OPENCL_MM_KQ_GQA_R2_DK256_IMG");
+        static const bool mm_kq_r2_dk256_on = (mm_kq_r2_dk256_env != nullptr && mm_kq_r2_dk256_env[0] != '0');
+        if (mm_kq_r2_dk256_on &&
+            backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img != nullptr &&
+            ne11 == 1 && ne01 >= 64 && (ne01 % 16) == 0 && ne00 == 256 &&
+            (ne12 % ne02) == 0 && (ne12 / ne02) == 2 && (ne13 / ne03) == 1) {
+            const size_t nb00_bytes = sizeof(uint16_t);
+            const size_t k_bytes_span =
+                (size_t)(ne01 > 0 ? ne01 - 1 : 0) * (size_t)nb01 +
+                (size_t)(ne02 > 0 ? ne02 - 1 : 0) * (size_t)nb02 +
+                (size_t)(ne03 > 0 ? ne03 - 1 : 0) * (size_t)nb03 +
+                (size_t)ne00 * nb00_bytes;
+            const size_t k_bytes = (k_bytes_span + 15) & ~(size_t)15;
+            const size_t k_pixels = k_bytes >> 4;
+            if (k_pixels > 0 && k_pixels <= backend_ctx->image_max_buffer_size) {
+                cl_kernel kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img;
+                cl_mem K_img = ggml_cl_img_pool_get_or_create(
+                    backend_ctx, backend_ctx->kq_img_pool,
+                    extra0->data_device, offset0, k_bytes, CL_FLOAT);
+                if (K_img != nullptr) {
+                    cl_uint k_arg = 0;
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &K_img));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extra1->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offset1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extrad->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offsetd));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne00));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb03));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb13));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne0));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r2));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r3));
+
+                    const int nth0_d = 64;
+                    const int64_t n_wg_x = ne01 / 16;
+                    size_t global_work_size[] = {(size_t)n_wg_x * nth0_d, (size_t)1, (size_t)ne02 * ne13};
+                    size_t local_work_size[]  = {(size_t)nth0_d, (size_t)1, 1};
+                    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+                    return;
+                }
+            }
+        }
+
+        // Decode-time GQA-coalesced KQV via image1d_buffer_t (texture cache).
+        // Companion to KQ image dispatch above. Gate matches _y8_gqa:
+        //   src0=V (ne00=n_kv, ne01=DV=128, ne02=n_head_kv), src1=softmax(KQ).
+        //   r2 = ne12/ne02 = 8 for Qwen3-30B-A3B family.
+        // Same generic k_bytes formula handles V's transposed (n_kv-fast) layout.
+        // Opt-in via GGML_OPENCL_MM_KQV_GQA_IMG=1.
+        static const char * mm_kqv_gqa_img_env = getenv("GGML_OPENCL_MM_KQV_GQA_IMG");
+        static const bool mm_kqv_gqa_img_on = (mm_kqv_gqa_img_env != nullptr && mm_kqv_gqa_img_env[0] != '0');
+        if (mm_kqv_gqa_img_on &&
+            backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa_img != nullptr &&
+            ne11 == 1 && ne01 == 128 &&
+            (ne12 % ne02) == 0 && (ne12 / ne02) == 8 && (ne13 / ne03) == 1) {
+            const size_t nb00_bytes = sizeof(uint16_t);
+            const size_t v_bytes_span =
+                (size_t)(ne01 > 0 ? ne01 - 1 : 0) * (size_t)nb01 +
+                (size_t)(ne02 > 0 ? ne02 - 1 : 0) * (size_t)nb02 +
+                (size_t)(ne03 > 0 ? ne03 - 1 : 0) * (size_t)nb03 +
+                (size_t)ne00 * nb00_bytes;
+            // CL_RGBA/CL_HALF_FLOAT: 8-byte pixels (= 1 half4). Same per-iter
+            // access pattern as _y8_gqa, kept register-equivalent.
+            const size_t v_bytes = (v_bytes_span + 7) & ~(size_t)7;
+            const size_t v_pixels = v_bytes >> 3;
+            if (v_pixels > 0 && v_pixels <= backend_ctx->image_max_buffer_size) {
+                cl_kernel kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa_img;
+                cl_mem V_img = ggml_cl_img_pool_get_or_create(
+                    backend_ctx, backend_ctx->kqv_img_pool,
+                    extra0->data_device, offset0, v_bytes, CL_HALF_FLOAT);
+                if (V_img != nullptr) {
+                    cl_uint k_arg = 0;
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &V_img));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extra1->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offset1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_mem),   &extrad->data_device));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &offsetd));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne00));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb01));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb02));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb03));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb10));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb11));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb12));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(cl_ulong), &nb13));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne0));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &ne1));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r2));
+                    CL_CHECK(clSetKernelArg(kernel, k_arg++, sizeof(int),      &r3));
+
+                    const int nth0_d = 64;
+                    const int64_t n_wg_x = ne01 / 8;
+                    size_t global_work_size[] = {(size_t)n_wg_x * nth0_d, (size_t)1, (size_t)ne02 * ne13};
+                    size_t local_work_size[]  = {(size_t)nth0_d, (size_t)1, 1};
+                    backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+                    return;
+                }
             }
         }
     }
@@ -17367,12 +17856,68 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                     kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_dr_ls;
                     nrows  = 1;
                 } else if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
-                    if (ne11 == 1) {
+                    // Multi-output decode variants when Q is a single row:
+                    //   - x8 (Q cached in __local): fast path for KQ where
+                    //     ne00 = DK <= 256 fits the per-WG Q cache.
+                    //   - y8 (streaming Q from global): fallback for KQV
+                    //     where ne00 = n_kv is large (> 256). Adreno L1
+                    //     absorbs the 8× Q-read redundancy across the 8
+                    //     outputs in the WG.
+                    // Biggest win at long context where the KQ/KQV launches
+                    // ~262K WGs each with a single mad.
+                    // Diagnostic: GGML_OPENCL_MM_F16_FORCE_L4=1 bypasses _x8/_y8 multi-output
+                    // variants and forces the original _l4 kernel. Used to bisect Qwen3.6-35B-A3B
+                    // baseline drift between 940c1ef5f and ff90e9a95 (11.13 → 8.38 t/s at d=16k).
+                    static const char * mm_force_l4_env = getenv("GGML_OPENCL_MM_F16_FORCE_L4");
+                    static const bool mm_force_l4_on = (mm_force_l4_env != nullptr && mm_force_l4_env[0] != '0');
+                    const bool can_multi_out = !mm_force_l4_on && ne11 == 1 && ne01 >= 64 && ne01 % 8 == 0;
+                    // Opt-in: GGML_OPENCL_MM_KQ_PAIR=1 swaps _x8 for the
+                    // paired-K-row variant that doubles per-wave-cycle
+                    // memory-issue parallelism at DK in [128, 256]. Held
+                    // behind env var (no long-ctx win on Qwen3-30B-A3B).
+                    static const char * mm_kq_pair_env = getenv("GGML_OPENCL_MM_KQ_PAIR");
+                    static const bool mm_kq_pair_on = (mm_kq_pair_env != nullptr && mm_kq_pair_env[0] != '0');
+                    // Opt-in: GGML_OPENCL_MM_KQ_GQA=1 swaps _x8 for the
+                    // GQA-coalesced variant that reads each K-row once and
+                    // emits gqa_ratio outputs. Specialized for DK=128, r2=8,
+                    // r3=1 (Qwen3-30B-A3B / Qwen3-4B / Qwen3.6-A3B shape).
+                    // +35% tg128 @ d=16k, +30% @ d=8k, +20% @ d=4k on Qwen3-30B-A3B.
+                    static const char * mm_kq_gqa_env = getenv("GGML_OPENCL_MM_KQ_GQA");
+                    static const bool mm_kq_gqa_on = (mm_kq_gqa_env != nullptr && mm_kq_gqa_env[0] != '0');
+                    // Opt-in: GGML_OPENCL_MM_KQV_GQA=1 swaps _y8 for the
+                    // GQA-coalesced KQV variant (DK=128/r2=8/r3=1) that reads
+                    // each V slab once per K-head and emits all r2 Q-heads.
+                    static const char * mm_kqv_gqa_env = getenv("GGML_OPENCL_MM_KQV_GQA");
+                    static const bool mm_kqv_gqa_on = (mm_kqv_gqa_env != nullptr && mm_kqv_gqa_env[0] != '0');
+                    if (can_multi_out && (ne01 % 16) == 0 && ne00 == 128 && r2 == 8 && r3 == 1 && mm_kq_gqa_on &&
+                        backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4 != nullptr) {
+                        kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4;
+                        nrows = 1;
+                    } else if (can_multi_out && ne00 <= 256 && mm_kq_pair_on &&
+                        backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair != nullptr) {
+                        kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair;
+                        nrows = 1;
+                    } else if (can_multi_out && ne00 <= 256 &&
+                        backend_ctx->kernel_mul_mat_f16_f32_l4_x8 != nullptr) {
+                        kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_x8;
+                        nrows = 1;
+                    } else if (can_multi_out && ne01 == 128 && r2 == 8 && r3 == 1 && mm_kqv_gqa_on &&
+                        backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa != nullptr) {
+                        kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa;
+                        nrows = 1;
+                    } else if (can_multi_out &&
+                        backend_ctx->kernel_mul_mat_f16_f32_l4_y8 != nullptr) {
+                        kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_y8;
+                        nrows = 1;
+                    } else if (ne11 == 1) {
+                        // Decode shapes that don't satisfy the x8/y8 row
+                        // constraints (ne01 < 64 or ne01 % 8 != 0) fall back to
+                        // upstream's 4-output _dr kernel.
                         kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_dr;
                         nrows  = 1; // not used by this kernel
                     } else {
                         kernel = backend_ctx->kernel_mul_mat_f16_f32_l4;
-                        nrows  = ne11;
+                        nrows = ne11;
                     }
                 } else {
                     kernel = backend_ctx->kernel_mul_mat_f16_f32;
@@ -18226,6 +18771,32 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         size_t global_work_size[] = {(size_t)(ne01+ndst*nth1-1)/(ndst*nth1)*nth0, (size_t)ne11*nth1, (size_t)ne12*ne13};
         size_t local_work_size[] = {(size_t)nth0, (size_t)nth1, 1};
 
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+    } else if (kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_x8 ||
+               kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair ||
+               kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_y8) {
+        // Multi-output decode variants: each WG processes 8 outputs along
+        // ne01; ne11 == 1. Same grid shape for both x8 (Q cached) and y8
+        // (streaming Q).
+        const int64_t n_wg_x = ne01 / 8;
+        size_t global_work_size[] = {(size_t)n_wg_x*nth0, (size_t)nth1, (size_t)ne12*ne13};
+        size_t local_work_size[]  = {(size_t)nth0, (size_t)nth1, 1};
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+    } else if (kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4) {
+        // GQA-coalesced KQ: one WG per K-head emits N_K_ROWS_GQA=16 K-rows ×
+        // r2 Q-heads. Widens the per-WG latency-hiding window vs the original
+        // N=8 (post-profile: KQ was 70% of decode at d=16k due to memory-stall
+        // serialization on K-row fetches). N=32 regressed 9-11% at long ctx,
+        // likely due to I-cache pressure from the unrolled outer loop.
+        const int64_t n_wg_x = ne01 / 16;
+        size_t global_work_size[] = {(size_t)n_wg_x*nth0, (size_t)nth1, (size_t)ne02*ne13};
+        size_t local_work_size[]  = {(size_t)nth0, (size_t)nth1, 1};
+        backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+    } else if (kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa) {
+        // GQA-coalesced KQV: one WG per K-head emits 8 DV-rows × r2 Q-heads.
+        const int64_t n_wg_x = ne01 / 8;
+        size_t global_work_size[] = {(size_t)n_wg_x*nth0, (size_t)nth1, (size_t)ne02*ne13};
+        size_t local_work_size[]  = {(size_t)nth0, (size_t)nth1, 1};
         backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
     } else {
         if (kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_dr) {

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -426,34 +426,22 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, cl_kernel> f32_f16_split_k_img;    // DK=512 prefill split, K via image1d_buffer_t
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_split;       // flash-decoding K-split
-    // Vec decode: DV-split + subgroup-reduced dot (mirrors Metal vec FA).
-    // Used at large DV (e.g. DK=DV=512) where the standard q1 spills o_acc.
+    // vec decode
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec;
-    // KV-head-coalesced vec decode. One WG handles MQ_GQA Q-heads sharing one
-    // KV-head; K/V loaded once and reused. Compile-locked to MQ_GQA=4 (Gemma-3
-    // family). Falls back to q1_vec / q1 when the gate isn't met.
+    // kv-head-coalesced vec decode
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq;
-    // KV-head-coalesced + flash-decoding split. Pairs MQ coalescing with FD
-    // n_kv-split for occupancy; produces MQ_GQA partial records per WG and
-    // reuses flash_attn_f32_merge for normalization.
+    // kv-head-coalesced + flash-decoding split
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split;
-    // MQ_GQA=8 specializations (Qwen3-30B-A3B / Qwen3-4B class): same source,
-    // a second program compiled with -DMQ_GQA=8 so the Q-row stride matches.
+    // MQ_GQA=8 specializations
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_g8;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8;
-    // K-image variant of MQ_G8 vec_mq_split: K bound as image1d_buffer_t
-    // (Adreno texture cache, separate BW path from L2). Opt-in, GGML_OPENCL_FA_K_IMG=1.
+    // k-image variant of MQ_G8 vec_mq_split
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_k_img;
-    // K-image variant of MQ_GQA=4 vec_mq_split (default program). Same source as
-    // _g8_k_img but compiled with the default MQ_GQA=4 — targets dense GQA=4
-    // DK=DV=128 (Mistral-7B / Qwen3-8B / Llama-3-8B). Opt-in via
-    // GGML_OPENCL_FA_F16_MQ_DK128=1 (+ GGML_OPENCL_FA_K_IMG=1 for the K-image
-    // path; without K_IMG, the non-image f32_f16_q1_vec_mq_split fires).
+    // k-image variant of MQ_GQA=4 vec_mq_split
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_k_img;
-    // Alternative decode FA: 1 WG per (q_idx, q_head) with a __local K/V tile +
-    // pure __local tree-reduce. Compiled only at DK=DV=128. Opt-in.
+    // alternative decode
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_tile;
-    // Hybrid local-tile + MQ + FD-split kernel (DK=DV=128 only). Opt-in.
+    // hybrid local-tile + MQ + FD-split kernel for DK=DV=128 only
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_mq_split;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_mq_split_g8;
     std::map<std::pair<int, int>, int>       f32_f16_bm;
@@ -465,8 +453,7 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1;            // decode
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec;        // DV-split + multi-subgroup decode
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_split;      // flash-decoding pass 1
-    // KV-head-coalesced + flash-decoding split for q8_0 KV; MQ_GQA=4 default,
-    // _g8 second compile for the Qwen3-30B-A3B class (GQA=8).
+    // KV-head-coalesced + flash-decoding split for q8_0 KV
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split;
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8;
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0;               // prefill (baseline)
@@ -478,8 +465,7 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1;
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_vec;        // DV-split + multi-subgroup decode
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_split;
-    // KV-head-coalesced + flash-decoding split for q4_0 KV (dp4a K dot);
-    // MQ_GQA=4 default, _g8 second compile for the Qwen3-30B-A3B class.
+    // kv-head-coalesced + flash-decoding split for q4_0 kv (dp4a K dot)
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_vec_mq_split;
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_vec_mq_split_g8;
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0;
@@ -556,13 +542,10 @@ struct ggml_backend_opencl_context {
     ggml_cl_buffer prealloc_scales_trans;
     ggml_cl_buffer prealloc_act_trans;
 
-    // Pool of persistent image1d_buffer views over KV-cache layers, keyed by
-    // (parent buffer, offset within parent). Used by the IMG-variant KQ/KQV
-    // dispatch paths to avoid per-call clCreateSubBuffer + clCreateImage +
-    // pending-release-queue churn on long-context decode (which was
-    // catastrophic on Qwen3.6-35B-A3B: 0.99 t/s vs 14.33 t/s on the smaller
-    // 30B model). Entries grow if a later dispatch sees a larger byte-span;
-    // released in free().
+    // pool of persistent image1d_buffer views over kv-cache layers, keyed by
+    // (parent buffer, offset within parent)
+    // used by the img-variant KQ/KQV dispatch paths to avoid per-call
+    // clCreateSubBuffer + clCreateImage + pending-release-queue on long-context decode
     struct ImagePoolKey {
         uintptr_t buf;
         uint64_t  offset;
@@ -580,12 +563,7 @@ struct ggml_backend_opencl_context {
     std::map<ImagePoolKey, ImagePoolEntry> kq_img_pool;
     std::map<ImagePoolKey, ImagePoolEntry> kqv_img_pool;
 
-    // Pool for the on-device f16 buffer backing the non-FA quantized-K (q8_0/q4_0)
-    // KV-cache dequant path. Keyed by the stable KV-cache device buffer + view offset
-    // so one buffer is reused (and grown) across decode steps instead of being
-    // allocated/freed per attention op. The per-op churn exhausts the allocator on
-    // deep-context 20 GB MoE decode (old clCreateBuffer hit GGML_ASSERT). Buffer stored
-    // in .image; .k_bytes = current capacity. Released at teardown.
+    // pool for the on-device f16 buffer for kv-cache with non-FA quantized-K (q8_0/q4_0)
     std::map<ImagePoolKey, ImagePoolEntry> dequant_f16_pool;
 
     // prealloc buffers for src0 and src1
@@ -1033,19 +1011,19 @@ struct ggml_backend_opencl_context {
             write_profiling_info();
             profiling_results.clear();
 #endif
-            // Release pooled image1d_buffer views over KV cache layers.
+            // release pooled image1d_buffer views over KV cache layers.
             for (auto & kv : kq_img_pool) {
-                if (kv.second.image)      CL_CHECK(clReleaseMemObject(kv.second.image));
-                if (kv.second.sub_buffer) CL_CHECK(clReleaseMemObject(kv.second.sub_buffer));
+                if (kv.second.image)      { CL_CHECK(clReleaseMemObject(kv.second.image)); }
+                if (kv.second.sub_buffer) { CL_CHECK(clReleaseMemObject(kv.second.sub_buffer)); }
             }
             kq_img_pool.clear();
             for (auto & kv : kqv_img_pool) {
-                if (kv.second.image)      CL_CHECK(clReleaseMemObject(kv.second.image));
-                if (kv.second.sub_buffer) CL_CHECK(clReleaseMemObject(kv.second.sub_buffer));
+                if (kv.second.image)      { CL_CHECK(clReleaseMemObject(kv.second.image)); }
+                if (kv.second.sub_buffer) { CL_CHECK(clReleaseMemObject(kv.second.sub_buffer)); }
             }
             kqv_img_pool.clear();
             for (auto & kv : dequant_f16_pool) {
-                if (kv.second.image) CL_CHECK(clReleaseMemObject(kv.second.image));
+                if (kv.second.image) { CL_CHECK(clReleaseMemObject(kv.second.image)); }
             }
             dequant_f16_pool.clear();
         }
@@ -1073,14 +1051,11 @@ inline std::string read_file(const std::string &path) {
 
 // fatal=false returns NULL on compile failure instead of aborting; used for
 // optional FA variants that may exhaust the Adreno compiler at large DK.
-// retry_queue (optional): when the shader compiler returns a *transient* resource
-// error (CL_OUT_OF_HOST_MEMORY / CL_OUT_OF_RESOURCES) — seen on the big DK>=256/512
-// FA programs when host memory is momentarily pressured — clFinish the queue to
-// drain in-flight ops holding driver host-heap, then rebuild (up to 3x). Mirrors
-// the proven set_tensor/alloc clFinish-retry pattern. Real source errors (e.g.
-// CL_BUILD_PROGRAM_FAILURE) are NOT retried. nullptr -> no retry (legacy behavior).
+// when the compiler returns CL_OUT_OF_HOST_MEMORY/CL_OUT_OF_RESOURCES (seen with DK>=256/512)
+// for FA programs, do clFinish the queue to free up resources, then rebuild (up to 3x)
+// if retry_queue is provided
 static cl_program build_program_from_source_ex(cl_context ctx, cl_device_id dev, const char* program_buffer, const std::string &compile_opts, bool fatal, const char *tag = nullptr, cl_command_queue retry_queue = nullptr) {
-    if (tag) GGML_LOG_INFO("ggml_opencl: compiling %s\n", tag);
+    if (tag) { GGML_LOG_INFO("ggml_opencl: compiling %s\n", tag); }
     cl_program p;
     char *program_log;
     size_t program_size;
@@ -2022,64 +1997,51 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
             CL_CHECK((backend_ctx->kernel_mul_mat_f16_f32_l4_dr_ls = clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_dr_ls", &err), err));
             CL_CHECK((backend_ctx->kernel_mul_mat_f16_f32_l4_dr_lq = clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_dr_lq", &err), err));
         }
-        // Best-effort: multi-row decode variant (8 K rows / WG, Q cached in __local).
+
         cl_int err_x8 = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_x8 =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8", &err_x8);
-        if (err_x8 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8 = nullptr;
-        // Paired K-row variant of _x8: doubles per-wave-cycle memory-issue
-        // parallelism at DK in [128, 256] by using both halves of the 64-lane
-        // warp on adjacent K-rows. Best-effort.
+        if (err_x8 != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_x8 = nullptr; }
+
         cl_int err_x8p = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_pair", &err_x8p);
-        if (err_x8p != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair = nullptr;
-        // GQA-coalesced variant of _x8 for DK=128, r2=4: one WG per K-head,
-        // 64-lane warp partitioned across 4 Q-heads so each K-row is read
-        // once and contributes to 4 outputs. Targets long-context KQ where
-        // the 4× K replay dominates. Best-effort.
+        if (err_x8p != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair = nullptr; }
+
         cl_int err_x8g = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4 =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa4", &err_x8g);
-        if (err_x8g != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4 = nullptr;
-        // image1d_buffer_t (texture-cache) variant of _x8_gqa4. Same kernel
-        // body but K is bound as a read-only image1d_buffer over a sub-buffer
-        // covering the K cache. Host creates the sub-buffer + image per call.
-        // Targets the long-ctx KQ BW gap (effective K-read 7.3 GB/s vs 76
-        // GB/s coalesced peak on Adreno X2). Best-effort.
+        if (err_x8g != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4 = nullptr; }
+
         cl_int err_x8gi = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa4_img", &err_x8gi);
-        if (err_x8gi != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img = nullptr;
-        // r2=4 specialization (Llama-3.x / Qwen3-4B/8B / Qwen3.5-4B / etc.).
+        if (err_x8gi != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img = nullptr; }
+
         cl_int err_x8gi_r4 = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img", &err_x8gi_r4);
-        if (err_x8gi_r4 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img = nullptr;
-        // DK=256, r2=2 specialization for Gemma-3-4B.
+        if (err_x8gi_r4 != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img = nullptr; }
+
         cl_int err_r2dk256 = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img", &err_r2dk256);
-        if (err_r2dk256 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img = nullptr;
-        // Streaming-Q multi-output variant for KQV-shaped matmul (ne00 large,
-        // ne01 small). Best-effort.
+        if (err_r2dk256 != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img = nullptr; }
+
         cl_int err_y8 = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_y8 =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_y8", &err_y8);
-        if (err_y8 != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_y8 = nullptr;
-        // GQA-coalesced KQV variant: one WG per K-head emits 8 DV-rows × 8
-        // Q-heads = 64 outputs. Reduces V replay by r2=8. Best-effort.
+        if (err_y8 != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_y8 = nullptr; }
+
         cl_int err_y8g = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_y8_gqa", &err_y8g);
-        if (err_y8g != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa = nullptr;
-        // image1d_buffer_t (texture-cache) variant of _y8_gqa. V bound as
-        // read-only image; same generic k_bytes formula handles the V
-        // (transposed n_kv-fast) layout.
+        if (err_y8g != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa = nullptr; }
+
         cl_int err_y8gi = CL_SUCCESS;
         backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa_img =
             clCreateKernel(backend_ctx->program_mul_mv_f16_f32_l4, "kernel_mul_mat_f16_f32_l4_y8_gqa_img", &err_y8gi);
-        if (err_y8gi != CL_SUCCESS) backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa_img = nullptr;
+        if (err_y8gi != CL_SUCCESS) { backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa_img = nullptr; }
         GGML_LOG_CONT(".");
     }
 
@@ -4220,9 +4182,6 @@ static std::string ggml_opencl_fa_compile_opts(ggml_backend_opencl_context * bac
         " -D BLOCK_M=" + std::to_string(cfg->bm) +
         " -D BLOCK_N=" + std::to_string(cfg->bn);
 
-    // q1-family kernels stripe the dot/o_acc over an FA_SG-wide subgroup and
-    // reduce across it; the width must match the hardware subgroup. Adreno uses
-    // the .cl default (64); Intel's subgroup is 32, so override + pin it there.
     if (backend_ctx->gpu_family == INTEL) {
         opts += " -D FA_SG=32";
     }
@@ -4241,18 +4200,12 @@ static std::string ggml_opencl_fa_compile_opts(ggml_backend_opencl_context * bac
     return opts;
 }
 
-// Refuse to register a kernel whose required dispatch WG size exceeds either
-// the per-kernel cap (CL_KERNEL_WORK_GROUP_SIZE) or the device cap
-// (CL_DEVICE_MAX_WORK_GROUP_SIZE). On Adreno X2 the per-kernel cap can be
-// well below the device cap (e.g. CL_KERNEL_WORK_GROUP_SIZE = 320 for the
-// q1_vec_mq signature against a device max of 1024) and is enforced at
-// enqueue time — dispatching above it returns CL_INVALID_WORK_GROUP_SIZE.
-// When the check fails, the caller releases the kernel so the existing
-// `kernel_map.count(dk_dv) > 0` dispatch checks fall back gracefully.
+// only register when the kernel's required dispatch workgroup size is within
+// the limit of the device's maximum workgroup size
 static bool ggml_opencl_fa_kernel_fits_wg(ggml_backend_opencl_context * backend_ctx,
                                           cl_kernel kernel, size_t required_wg,
                                           const char * name, int dk, int dv) {
-    if (kernel == NULL) return false;
+    if (kernel == NULL) { return false; }
     const size_t dev_max = backend_ctx->max_workgroup_size;
     if (dev_max < required_wg) {
         GGML_LOG_INFO("ggml_opencl: %s DK=%d DV=%d requires WG %zu > device max %zu; skipping registration (will fall back)\n",
@@ -4317,27 +4270,24 @@ static void ggml_opencl_ensure_fa_pre_kernels(ggml_backend_opencl_context * back
 
     // BM-tile metadata is consumed by the prefill dispatch (n_q_blocks / wg
     // sizing) regardless of whether the prepass kernels are needed for this
-    // n_kv — set it unconditionally, before any (potentially failing) compile.
+    // n_kv — set it unconditionally
     backend_ctx->fa.f32_f16_bm[{dk, dv}]      = cfg->bm;
     backend_ctx->fa.f32_f16_bn[{dk, dv}]      = cfg->bn;
     backend_ctx->fa.f32_f16_wg_size[{dk, dv}] = cfg->bm;
     backend_ctx->fa.bm[{dk, dv}]              = cfg->bm;
     backend_ctx->fa.bn[{dk, dv}]              = cfg->bn;
 
-    if (backend_ctx->fa.kv_pad_f16.count(dk_dv) > 0) return;
+    if (backend_ctx->fa.kv_pad_f16.count(dk_dv) > 0) { return; }
 
     GGML_LOG_INFO("ggml_opencl: lazy-compiling flash_attn prepass for DK=%d DV=%d\n", dk, dv);
     cl_int err;
     const std::string src  = ggml_opencl_fa_kernel_src(FA_VARIANT_PRE);
     const std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, FA_VARIANT_PRE);
-    // Best-effort: the prepass program can OOM the Adreno compiler at large DK.
-    // If it fails, leave kv_pad/mask_pad/blk uncached — the prefill dispatch
-    // checks .count() and skips the prepass step (block-aligned n_kv needs no
-    // pad), declining cleanly instead of aborting at a CL_CHECK.
+    // retry when kernel compile fails
     cl_program prog_pre_f16 = build_program_from_source_ex(
         backend_ctx->context, backend_ctx->device, src.c_str(), opts,
         /*fatal=*/false, "fa prepass f16", backend_ctx->queue);
-    if (!prog_pre_f16) return;
+    if (!prog_pre_f16) { return; }
     cl_kernel k_kv_pad_f16  = clCreateKernel(prog_pre_f16, "flash_attn_kv_pad_f16",   &err);
     if (err != CL_SUCCESS) { clReleaseProgram(prog_pre_f16); return; }
     cl_kernel k_mask_pad_f16 = clCreateKernel(prog_pre_f16, "flash_attn_mask_pad_f16", &err);
@@ -4350,19 +4300,15 @@ static void ggml_opencl_ensure_fa_pre_kernels(ggml_backend_opencl_context * back
     clReleaseProgram(prog_pre_f16);
 }
 
-// DK=512 (Gemma-4 global layers) prefill BM-tile, built in its own minimal
-// FA_PREFILL_ONLY program. The full f32_f16 program OOMs the Adreno compiler at
-// DK=512; isolating the tile keeps it under the host-memory ceiling (see
-// [[opencl_adreno_split_programs]]). split=false → N_SPLIT=1 → f32_f16;
-// split=true → N_SPLIT=cfg → f32_f16_split. Returns true if the tile registered.
+// DK=512 prefill BM-tile
 static bool ggml_opencl_ensure_fa_f32_f16_prefill_512(ggml_backend_opencl_context * backend_ctx, bool split) {
     const int dk = 512, dv = 512;
     const std::pair<int, int> dk_dv = {dk, dv};
     auto & target = split ? backend_ctx->fa.f32_f16_split : backend_ctx->fa.f32_f16;
-    if (target.count(dk_dv) > 0) return true;
+    if (target.count(dk_dv) > 0) { return true; }
 
     static bool failed[2] = { false, false };
-    if (failed[split ? 1 : 0]) return false;
+    if (failed[split ? 1 : 0]) { return false; }
 
     const ggml_opencl_fa_dim * cfg = nullptr;
     for (const auto & d : g_opencl_fa_dims) {
@@ -4392,12 +4338,7 @@ static bool ggml_opencl_ensure_fa_f32_f16_prefill_512(ggml_backend_opencl_contex
         split ? "flash_attn_f32_f16 (prefill512 split)" : "flash_attn_f32_f16 (prefill512)", dk, dv);
     clReleaseProgram(prog);
 
-    // K-image variant of the split tile (texture-cache K reads). MEASURED no
-    // win on Gemma-4-26B (pp2048@d16k 66.1 buffer vs 65.7 image): the tile
-    // already stages K into __local via coalesced global reads, and the 16 MB
-    // K working set far exceeds the texture cache so there's no cross-query-block
-    // reuse to accelerate. Kept opt-in for future revisit; only compiled when
-    // GGML_OPENCL_FA_PREFILL_K_IMG is set so the default path pays nothing.
+    // determine whether to use the K-image variant of the split tile
     static const char * pkimg_build_env = getenv("GGML_OPENCL_FA_PREFILL_K_IMG");
     const bool pkimg_build = (pkimg_build_env != NULL) && (pkimg_build_env[0] != '0');
     if (split && pkimg_build && backend_ctx->fa.f32_f16_split_k_img.count(dk_dv) == 0) {
@@ -4515,20 +4456,12 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
     }
 
     const std::string src = ggml_opencl_fa_kernel_src(variant);
-    if (src.empty()) return false;
+    if (src.empty()) { return false; }
     std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, variant);
 
-    // DK=512 (Gemma-4 global-attention layers): the full f32_f16 program OOMs
-    // the Adreno shader compiler (CL_OUT_OF_HOST_MEMORY) — see
-    // [[opencl_adreno_split_programs]]. Compile a decode-only program (q1 +
-    // q1_split + merge) so single-token decode stays on the GPU; prefill
-    // (n_q>1) is kept on CPU via the supports_op n_q gate.
+    // bypass kernels for DK=512
     const bool fa_decode_only = (variant == FA_VARIANT_F32_F16 && dk == 512);
     if (fa_decode_only) {
-        // FA_DECODE_MINIMAL also drops q1_vec, shrinking the DK=512 program to
-        // q1 + q1_split + merge so the Adreno shader compiler stops OOMing under
-        // host-memory pressure (gemma-4 global layers). q1_vec at DV=512 was the
-        // dominant compile-memory cost and is a fallback-only kernel on X1 anyway.
         opts += " -D FA_DECODE_ONLY -D FA_DECODE_MINIMAL";
     }
 
@@ -4547,7 +4480,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
     cl_program prog = build_program_from_source_ex(
         backend_ctx->context, backend_ctx->device, src.c_str(), opts,
         /*fatal=*/false, tag, backend_ctx->queue);
-    if (!prog) return false;
+    if (!prog) { return false; }
 
     cl_int err;
     switch (variant) {
@@ -4570,7 +4503,6 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
         case FA_VARIANT_F32_F16: {
             cl_kernel kq1;
             // BM-tile prefill kernel is excluded from the decode-only (DK=512)
-            // program; only register it for the full build.
             if (!fa_decode_only) {
                 cl_kernel k;
                 CL_CHECK((k = clCreateKernel(prog, "flash_attn_f32_f16", &err), err));
@@ -4585,10 +4517,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 backend_ctx->fa.f32_f16_q1_split[{dk, dv}] = k_split;
                 ggml_opencl_log_fa_kernel_spill(backend_ctx, k_split, "flash_attn_f32_f16_q1_split", dk, dv);
             }
-            // q1_vec decode kernel (DV-split + subgroup reduce). Compile is
-            // best-effort; if it fails (e.g. driver/extension gap) the standard
-            // q1 path stays the fallback at dispatch. Required WG = 4 × 64 = 256
-            // (VEC_NSG × Q1_WG_SIZE in the kernel).
+            // q1_vec decode kernel (DV-split + subgroup reduce)
             cl_kernel k_q1_vec = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec", &err);
             if (err == CL_SUCCESS) {
                 if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec, 256,
@@ -4599,9 +4528,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     clReleaseKernel(k_q1_vec);
                 }
             }
-            // KV-head-coalesced vec for high-GQA small models (Gemma-3-1B).
-            // Best-effort compile; only used when gqa_ratio == MQ_GQA at dispatch.
-            // Required WG = 4 × 64 = 256 (MQ_NSG × Q1_WG_SIZE).
+            // KV-head-coalesced vec for high-GQA small models
             cl_kernel k_q1_vec_mq = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec_mq", &err);
             if (err == CL_SUCCESS) {
                 if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq, 256,
@@ -4612,8 +4539,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     clReleaseKernel(k_q1_vec_mq);
                 }
             }
-            // KV-head-coalesced + flash-decoding split. Reused merge kernel.
-            // Required WG = 4 × 64 = 256 (MQ_NSG_SPLIT × Q1_WG_SIZE).
+            // KV-head-coalesced + flash-decoding split, reuses merge kernel
             cl_kernel k_q1_vec_mq_split = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec_mq_split", &err);
             if (err == CL_SUCCESS) {
                 if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split, 256,
@@ -4624,10 +4550,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     clReleaseKernel(k_q1_vec_mq_split);
                 }
             }
-            // K-image variant of MQ_GQA=4 split (default prog). Same source as
-            // the _g8 K-image kernel below, just compiled with the default
-            // MQ_GQA=4 specialization — targets dense GQA=4 DK=DV=128 (Mistral,
-            // Qwen3-8B, Llama-3-8B). Opt-in dispatch.
+            // K-image variant of MQ_GQA=4 split
             cl_kernel k_q1_vec_mq_split_k_img = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec_mq_split_k_img", &err);
             if (err == CL_SUCCESS) {
                 if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split_k_img, 256,
@@ -4642,8 +4565,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             if (err == CL_SUCCESS) {
                 backend_ctx->fa.f32_merge[{dk, dv}] = k_merge;
             }
-            // Local-tile decode variant (DK=DV=128 only; LT_WG=128).
-            // Required WG = 128. Best-effort compile.
+            // local-tile decode variant
             if (dk == 128 && dv == 128) {
                 cl_kernel k_lt = clCreateKernel(prog, "flash_attn_f32_f16_q1_local_tile", &err);
                 if (err == CL_SUCCESS) {
@@ -4655,8 +4577,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                         clReleaseKernel(k_lt);
                     }
                 }
-                // Hybrid local-tile + MQ + FD-split. MQ_GQA=4 from default
-                // compile. Required WG = 64 (1 subgroup).
+                // hybrid local-tile + MQ + FD-split
                 cl_kernel k_lmq = clCreateKernel(prog, "flash_attn_f32_f16_q1_local_mq_split", &err);
                 if (err == CL_SUCCESS) {
                     if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_lmq, 64,
@@ -4668,24 +4589,8 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     }
                 }
             }
-            // Second compile of the same source with -DMQ_GQA=8 for the
-            // Qwen3-30B-A3B / Qwen3-4B class (GQA=8). Only the two MQ kernels
-            // are extracted; everything else is identical to the MQ_GQA=4
-            // program above and would just duplicate cache. Compile is
-            // best-effort: if the larger __local Q stage (8 Q rows × DK_VEC)
-            // doesn't fit or the WG cap drops, the dispatch falls back to
-            // the legacy q1_vec path. Mirrors Metal's per-NQPSG template
-            // specialization.
-            // MQ_GQA=8 doubles per-thread state (o_acc[8][1], m_i[8], l_i[8],
-            // slope[8], mask_base[8]) → Adreno's per-kernel WG cap drops from
-            // 256 to 192 due to register pressure (measured on Adreno X2).
-            // Compile with MQ_NSG=3 / MQ_NSG_SPLIT=3 so the
-            // 192-thread cap is sufficient; the kernel's merge loops are
-            // already NSG-agnostic.
-            // Skip the GQA=8 program entirely for the decode-only (DK=512)
-            // build — its MQ kernels are excluded from the source and DK=512
-            // has no MQ decode dispatch path, so the second compile would be
-            // pure waste (and another OOM risk).
+
+            // second compile of the same source with -DMQ_GQA=8
             const std::string opts_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
             cl_program prog_g8 = fa_decode_only ? nullptr : build_program_from_source_ex(
                 backend_ctx->context, backend_ctx->device, src.c_str(), opts_g8,
@@ -4712,10 +4617,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                         clReleaseKernel(k_q1_vec_mq_split_g8);
                     }
                 }
-                // K-image variant: same MQ_GQA=8 specialization but K is
-                // bound as image1d_buffer_t (Adreno texture cache). Only
-                // dispatched when GGML_OPENCL_FA_K_IMG=1. Same source, same
-                // -DMQ_GQA=8 program, just a different __kernel entry.
+                // K-image variant
                 cl_kernel k_q1_vec_mq_split_g8_k_img = clCreateKernel(prog_g8, "flash_attn_f32_f16_q1_vec_mq_split_k_img", &err);
                 if (err == CL_SUCCESS) {
                     if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split_g8_k_img, mq_g8_required_wg,
@@ -4726,8 +4628,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                         clReleaseKernel(k_q1_vec_mq_split_g8_k_img);
                     }
                 }
-                // Hybrid local-tile + MQ_GQA=8. WG=64 (1 subgroup); the
-                // per-kernel WG cap should stay >= 64 even at high reg pressure.
+                // hybrid local-tile + MQ_GQA=8
                 if (dk == 128 && dv == 128) {
                     cl_kernel k_lmq_g8 = clCreateKernel(prog_g8, "flash_attn_f32_f16_q1_local_mq_split", &err);
                     if (err == CL_SUCCESS) {
@@ -4766,8 +4667,8 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 m_q1_split[{dk, dv}] = k_split;
                 ggml_opencl_log_fa_kernel_spill(backend_ctx, k_split, name_q1_split.c_str(), dk, dv);
             }
-            // DV-split decode variant (q1_vec); best-effort compile.
-            // Required WG = 4 × 64 = 256 (VEC_NSG × Q1_WG_SIZE).
+
+            // DV-split decode variant (q1_vec)
             auto & m_q1_vec = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec : backend_ctx->fa.f32_q4_0_q1_vec;
             const std::string name_q1_vec = name_q1 + "_vec";
             cl_kernel k_q1_vec = clCreateKernel(prog, name_q1_vec.c_str(), &err);
@@ -4780,8 +4681,8 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     clReleaseKernel(k_q1_vec);
                 }
             }
-            // KV-head-coalesced + flash-decoding split (MQ_GQA=4 default).
-            // Required WG = 4 × 64 = 256 (MQ_NSG_SPLIT × Q1_WG_SIZE).
+
+            // KV-head-coalesced + flash-decoding split
             auto & m_mq_split = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec_mq_split
                                       : backend_ctx->fa.f32_q4_0_q1_vec_mq_split;
             const std::string name_mq_split = name_q1 + "_vec_mq_split";
@@ -4801,10 +4702,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     backend_ctx->fa.f32_merge[{dk, dv}] = k_merge;
                 }
             }
-            // Second compile with MQ_GQA=8 / MQ_NSG=3 / MQ_NSG_SPLIT=3 for the
-            // Qwen3-30B-A3B / Qwen3-4B class. WG cap at MQ_GQA=8 drops to 192
-            // on Adreno X2 due to register pressure; NSG=3 matches. Best-effort;
-            // falls back to the legacy q1 path at dispatch if missing.
+            // Second compile with MQ_GQA=8, MQ_NSG=3, MQ_NSG_SPLIT=3
             auto & m_mq_split_g8 = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8
                                          : backend_ctx->fa.f32_q4_0_q1_vec_mq_split_g8;
             const std::string opts_mq_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
@@ -4924,7 +4822,7 @@ static bool ggml_opencl_ensure_fa_quant_split_override(
     cl_program prog = build_program_from_source_ex(
         backend_ctx->context, backend_ctx->device, src.c_str(), opts,
         /*fatal=*/false, tag.c_str(), backend_ctx->queue);
-    if (!prog) return false;
+    if (!prog) { return false; }
     cl_int err;
     cl_kernel k;
     if (is_q8_0) {
@@ -6655,7 +6553,7 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 { 40,  40}, { 64,  64}, { 80,  80}, { 96,  96},
                 {112, 112}, {128, 128}, {192, 128},
                 {192, 192}, {256, 256},
-                {512, 512},  // Gemma-4 global-attention layers
+                {512, 512},
             };
 
             bool dims_supported = false;
@@ -6697,24 +6595,7 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                 return false;
             }
 
-            // DK=512 (Gemma-4 global-attention layers) is a large FA kernel.
-            // Probe-compile the variant here so a device whose compiler runs
-            // out of host memory building it (seen on memory-constrained
-            // Adreno parts) cleanly declines the op — the graph then runs it
-            // on the CPU backend — instead of crashing later at dispatch on
-            // a kernel that never compiled. The lazy compile is cached, so
-            // this costs at most one build attempt per (dk, dv, variant).
             if (dk == 512) {
-                // The DK=512 program is split into minimal per-purpose
-                // programs so each fits the Adreno compiler's host-memory
-                // ceiling (the monolithic program OOMs with CL_OUT_OF_HOST_MEMORY).
-                // Only f16 KV (Gemma-4 global layers) is built on the GPU here;
-                // every other KV combo (f32, f16-q, quant) would need a full
-                // program that OOMs, so decline up front — no probe compile —
-                // and let the graph run it on CPU. q->ne[1] is n_q.
-                // The DK=512 kernels are sized to just fit the Adreno compiler;
-                // Intel's OpenCL compiler crashes building them, so decline on
-                // Intel up front and run these layers on CPU.
                 if (backend_ctx->gpu_family == INTEL) {
                     return false;
                 }
@@ -6722,12 +6603,12 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                     return false;
                 }
                 if (q->ne[1] == 1) {
-                    // Decode: decode-only program (q1 / q1_vec / q1_split / merge).
+                    // decode-only program (q1 / q1_vec / q1_split / merge)
                     if (!ggml_opencl_ensure_fa_variant(backend_ctx, dk, dv, FA_VARIANT_F32_F16)) {
                         return false;
                     }
                 } else {
-                    // Prefill: BM-tile in its own FA_PREFILL_ONLY program.
+                    // prefill, BM-tile in its own FA_PREFILL_ONLY program
                     if (!ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/false)) {
                         return false;
                     }
@@ -13200,8 +13081,7 @@ static void ggml_cl_flash_attn_read_tensor_host(
     GGML_ASSERT(dst_off == total_bytes);
 }
 
-// Forward decl: used by the FA decode dispatch (K-image variant) below.
-// Definition lives near the other mul_mat IMG paths.
+// forward decl: used by the FA decode dispatch (K-image variant) below.
 static cl_mem ggml_cl_img_pool_get_or_create(
     ggml_backend_opencl_context * backend_ctx,
     std::map<ggml_backend_opencl_context::ImagePoolKey,
@@ -13527,19 +13407,20 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const int n_batch = q->ne[3];
 
     // DK=512 (Gemma-4 global layers) runs decode-only (q1 / q1_split) on
-    // Adreno — it never uses the BM-tile path, and the prepass + split-tile
-    // programs OOM the shader compiler at DK=512. supports_op only admits
-    // n_q==1 here, so prefill is already on CPU. See [[opencl_adreno_split_programs]].
+    // Adreno - it never uses the BM-tile path, and the prepass + split-tile
+    // programs OOM the compiler at DK=512; supports_op only admits
+    // n_q==1 here and prefill goes to CPU
     const bool fa_decode_only_512 = (d_head_q == 512);
 
-    // Per-variant lazy compile for this (dk, dv). DK=512 decode (n_q==1) needs
-    // no prepass; DK=512 prefill (n_q>1) does, so compile it then.
+    // per-variant lazy compile for this (dk, dv)
+    // DK=512 decode (n_q==1) needs no prepass
+    // DK=512 prefill (n_q>1) does, so compile it only when needed
     if (!fa_decode_only_512 || n_q > 1) {
         ggml_opencl_ensure_fa_pre_kernels(backend_ctx, d_head_q, d_head_v);
     }
 
     cl_kernel kernel = NULL;
-    bool use_prefill_k_img = false;  // DK=512 prefill tile with K bound as image1d_buffer_t
+    bool use_prefill_k_img = false;  //  K is image1d_buffer_t for DK=512 prefill
 
     const bool is_f16 = q->type == GGML_TYPE_F16;
     const bool is_mixed = q->type == GGML_TYPE_F32 && k->type == GGML_TYPE_F16 && v->type == GGML_TYPE_F16;
@@ -13551,8 +13432,8 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     } else if (is_mixed) {
         ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_F32_F16);
         if (fa_decode_only_512) {
-            // DK=512: the BM-tile prefill kernels come from their own minimal
-            // FA_PREFILL_ONLY programs (the shared split variant would OOM).
+            // DK=512: the BM-tile prefill kernels are specifically compiled from
+            // FA_PREFILL_ONLY
             if (n_q > 1) {
                 ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/false);
                 ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/true);
@@ -13599,9 +13480,8 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         ? backend_ctx->fa.f32_f16_bn.at(dk_dv)
         : backend_ctx->fa.bn.at(dk_dv);
     // Pick split variant only when n_kv crosses the per-(dk,dv) threshold.
-    // The N_SPLIT>1 prefill tile reduces DK partials via subgroup shuffle (64-wide
-    // on Adreno); on Intel use the non-split BM tile, which is per-query-row and
-    // subgroup-width-agnostic.
+    // the N_SPLIT>1 prefill tile reduces DK partials via subgroup shuffle,
+    // on Intel it uses the non-split BM tile and does not depend on subgroup size
     const bool use_split_kernel = (n_q > 1 && is_mixed &&
         backend_ctx->gpu_family != INTEL &&
         backend_ctx->fa.f32_f16_split.count(dk_dv) > 0 &&
@@ -13673,10 +13553,8 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     bool use_q1_vec = false;
     bool use_q1_vec_mq = false;
     bool use_local_tile = false;
-    // KV-head-coalesced gate: gqa_ratio == compile-time MQ_GQA (4 → Gemma-3
-    // family). LDS budget restricts to DK=DV=256 for now. At higher DV the
-    // sg_o array (16 KB at DV=256) doubles per DV doubling and would exceed
-    // Adreno 32 KB LDS.
+    // KV-head-coalesced gate: gqa_ratio == compile-time MQ_GQA
+    // restricts to DK=DV=256 for now due to local memory size
     const int gqa_ratio_dispatch = n_head_kv > 0 ? (n_head / n_head_kv) : 0;
     if (n_q == 1) {
         if (use_native_q8_0_q1) {
@@ -13689,14 +13567,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             }
         } else if (use_native_q4_0_q1) {
             // q4_0 vec kernel uses per-lane dp4a (cl_khr_integer_dot_product)
-            // and DV-split across subgroups. The earlier "-10/-11% on
-            // Qwen3.6-A3B MXFP4 / q4_0 KV" caveat was stale: re-measured
-            // 2026-05-23 on X1-85 across four DV=256 targets (gemma-3-4b,
-            // gemma-2-2b, Qwen3.5-9B, Qwen3.6-A3B MXFP4) the vec kernel
-            // wins +25 to +71% end-to-end vs legacy q1; Qwen3.6-A3B at
-            // per-FA-call profile is 3.6× faster (11.0 → 3.04 ms/call).
-            // Default-on for DV>=256. Opt-out via GGML_OPENCL_FA_Q4_VEC=0
-            // for diagnosis if a regression surfaces on an untested shape.
             const char * q4vec_env = getenv("GGML_OPENCL_FA_Q4_VEC");
             const bool   q4vec_off = (q4vec_env != NULL) && (q4vec_env[0] == '0');
             if (!q4vec_off && d_head_v >= 256 &&
@@ -13707,31 +13577,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 kernel = backend_ctx->fa.f32_q4_0_q1.at(dk_dv);
             }
         } else if (is_mixed) {
-            // DV-split decode kernel (mirrors Metal vec FA) wins at large DV
-            // where the standard q1 spills o_acc to DDR. Gate originally at
-            // DV >= 256 (Qwen3.6 / Gemma-4), later lowered to DV >= 128
-            // to cover Qwen3-30B-A3B (DK=DV=128 GQA 8:1). CUDA & Metal pick
-            // the vec-style kernel for DK=128 with multi-Q-per-CTA, so this
-            // is the expected portable shape. Fall back if the kernel
-            // didn't compile (no-extension driver).
-            // NOTE: single-WG MQ (q1_vec_mq) is registered but not dispatched.
-            // At Gemma-3-1B / DK=DV=256 with WG=256 (4 subgroups, the max
-            // viable on Adreno X2 for this kernel), it benches at ~60 t/s
-            // vs legacy q1_vec at ~72 t/s — a regression — so there's no
-            // reason to fire it over legacy at short context. The MQ win
-            // comes from the FD-split path below (q1_vec_mq_split), which
-            // pairs MQ coalescing with n_kv splitting across WGs for
-            // occupancy. Left registered so the source is available for
-            // future experimentation.
-            // Gate the vec path. The default was lowered from DV >= 256 to
-            // DV >= 128 after a 5-model regression sweep (Qwen3-30B-A3B,
-            // Qwen3-8B Q8, Qwen3-4B Q4, Llama-3-8B Q4, Qwen2.5-7B Q4_K_M) showed
-            // no regression and small wins (+0.3 to +3.2% tg128@d=8k fa=1 f16).
-            // GGML_OPENCL_FA_F16_VEC_DK128=0 forces legacy q1 (opt-out for
-            // diagnosis if a regression surfaces on an untested shape).
-            // Opt-in: alternative local-tile decode kernel (DK=DV=128 only).
-            // GGML_OPENCL_FA_LOCAL_TILE=1 routes to flash_attn_f32_f16_q1_local_tile
-            // when registered; suppresses both vec and MQ FD-split paths.
             static const char * lt_env = getenv("GGML_OPENCL_FA_LOCAL_TILE");
             static const bool   lt_on  = (lt_env != NULL) && (lt_env[0] != '0');
             if (lt_on && d_head_q == 128 && d_head_v == 128 &&
@@ -13786,11 +13631,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         }
     }
 
-    // Intel reference path: the vec/MQ/local-tile decode variants are tuned for
-    // a 64-wide Adreno subgroup and miscompute on Intel's narrower (32) subgroup.
-    // Route decode to the basic q1 kernel, which is parameterized on FA_SG and
-    // pins the subgroup width via REQD_FA_SG. The MQ FD-split path is disabled on
-    // Intel below; prefill uses the non-split BM tile (per-lane, sg-agnostic).
+    // Intel goes to the basic q1 kernel
     if (backend_ctx->gpu_family == INTEL && n_q == 1) {
         use_q1_vec = use_q1_vec_mq = use_local_tile = false;
         if (is_mixed && backend_ctx->fa.f32_f16_q1.count(dk_dv))      { kernel = backend_ctx->fa.f32_f16_q1.at(dk_dv); }
@@ -13876,59 +13717,38 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     bool use_fd_mq = false;
     size_t fd_mq_wg = 256;  // MQ_GQA=4 kernel: Q1_WG_SIZE(64) * MQ_NSG_SPLIT(4)
     bool use_fa_k_img = false;  // K bound as image1d_buffer_t instead of (buf, offset)
-    // MQ flash-decoding gate. Bypasses FD_MAX_DK because the MQ split kernel
-    // uses NSG subgroups × 64 lanes, so o_acc is DV-split — no spill at DK=DV=256.
-    // - gqa_ratio == 4 + DK=DV=256: Gemma-3 family, MQ_GQA=4 kernel.
-    // - gqa_ratio == 8 + DK=DV=128: Qwen3-30B-A3B / Qwen3-4B class, MQ_GQA=8
-    //   kernel (compiled alongside via a second program). Mirrors Metal's
-    //   per-NQPSG template dispatch.
+
     {
         const char * mq_env = getenv("GGML_OPENCL_FA_MQ");
         const bool mq_enabled = (mq_env == NULL) ? true : (mq_env[0] != '0');
         const bool mq_kv_ok   = is_mixed || is_q8_0 || is_q4_0;
-        // Opt-in: hybrid local-tile + MQ + FD-split for is_mixed @ DK=DV=128.
+
         const char * lmq_env = getenv("GGML_OPENCL_FA_LOCAL_MQ_SPLIT");
         const bool   lmq_on  = (lmq_env != NULL) && (lmq_env[0] != '0');
-        // Extend the Qwen3-30B-A3B-class (DK=DV=128 GQA=8) f16 MQ_G8 vec path
-        // to handle n_q ∈ [1, N_MAX_VEC_NQ] for speculative-verification
-        // batches. The kernel + grid already support n_q > 1 (gid(2) decodes
-        // split_idx & q_idx); only the n_q==1 gate kept it off for n_q>1.
-        // Default cap = 1 (preserves single-token decode behaviour); override
-        // via GGML_OPENCL_FA_VEC_NQ=N for a higher cap.
+
         static const char * vec_nq_env = getenv("GGML_OPENCL_FA_VEC_NQ");
         static const int N_MAX_VEC_NQ  = (vec_nq_env != NULL && vec_nq_env[0] != '\0')
                                            ? atoi(vec_nq_env) : 1;
+
         const bool nq_in_vec_range = (n_q >= 1) && (n_q <= N_MAX_VEC_NQ);
-        // Only the MQ_G8 path takes n_q > 1; all other MQ paths (DK=DV=256,
-        // q8_0, q4_0, local_*) still require n_q == 1.
         const bool nq1_only        = (n_q == 1);
         if (mq_enabled && mq_kv_ok && nq_in_vec_range && !is_causal &&
-            backend_ctx->gpu_family != INTEL &&  // MQ FD-split is 64-wide-subgroup tuned; Intel uses basic q1
-            !use_local_tile &&  // local-tile dispatches its own grid, skip MQ FD-split
+            backend_ctx->gpu_family != INTEL &&
+            !use_local_tile &&
             n_kv >= FD_MIN_N_KV &&
             backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
-            // Hybrid local-tile + MQ + FD-split — opt-in via env, f16 KV DK=DV=128, n_q==1 only.
             if (nq1_only && lmq_on && is_mixed && d_head_q == 128 && d_head_v == 128 &&
                 gqa_ratio_dispatch == 8 &&
                 backend_ctx->fa.f32_f16_q1_local_mq_split_g8.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_f16_q1_local_mq_split_g8.at(dk_dv);
                 use_fd_mq  = true;
-                fd_mq_wg   = 64;  // LMQ_WG
+                fd_mq_wg   = 64;
             } else if (nq1_only && lmq_on && is_mixed && d_head_q == 128 && d_head_v == 128 &&
                 gqa_ratio_dispatch == 4 &&
                 backend_ctx->fa.f32_f16_q1_local_mq_split.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_f16_q1_local_mq_split.at(dk_dv);
                 use_fd_mq  = true;
-                fd_mq_wg   = 64;  // LMQ_WG
-            // f16 KV — Gemma-3 class (DK=DV=256 GQA=4) and the GQA=4 DK=DV=128
-            // family (Qwen3-4B/8B, Llama-3.x, Mistral-7B). Same MQ_GQA=4 kernel,
-            // already compiled per (dk, dv). Without the DK=128 branch f16 KV
-            // decode on these models falls to the spilling non-MQ split and
-            // pays a GQA-replay on K reads — structurally slower than the q8_0
-            // path on the same model. K-image variant available for DK=DV=128
-            // (opt-in via GGML_OPENCL_FA_K_IMG=1) — adds ~1-3% per-FA-call on
-            // X1-85, dominated by ~15% thermal envelope; not default-on.
-            // n_q==1 only for now.
+                fd_mq_wg   = 64;
             } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
                 ((d_head_q == 256 && d_head_v == 256) ||
                  (d_head_q == 128 && d_head_v == 128)) &&
@@ -13945,10 +13765,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                     fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
                     use_fd_mq  = true;
                 }
-            // f16 KV — Qwen3-30B-A3B class (DK=DV=128 GQA=8); extended to n_q ∈ [1, N_MAX_VEC_NQ].
-            // K-image variant: same MQ_G8 path but K bound via image1d_buffer_t.
-            // Opt-in via GGML_OPENCL_FA_K_IMG=1; targets the long-context FA
-            // K-read bandwidth bottleneck.
             } else if (is_mixed && gqa_ratio_dispatch == 8 &&
                 d_head_q == 128 && d_head_v == 128 &&
                 getenv("GGML_OPENCL_FA_K_IMG") != NULL &&
@@ -13964,29 +13780,17 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.at(dk_dv);
                 use_fd_mq  = true;
                 fd_mq_wg   = 192;
-            // q8_0 KV — DK=DV=128 GQA=8 (Qwen3-30B-A3B q8 KV path); n_q==1 only for now
             } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 8 &&
                 d_head_q == 128 && d_head_v == 128 &&
                 backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8.at(dk_dv);
                 use_fd_mq  = true;
                 fd_mq_wg   = 192;
-            // q8_0 KV — DK=DV=128 GQA=4 (Gemma-3 q8, Llama q8 class); n_q==1 only for now
             } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 4 &&
                 d_head_q == 128 && d_head_v == 128 &&
                 backend_ctx->fa.f32_q8_0_q1_vec_mq_split.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split.at(dk_dv);
                 use_fd_mq  = true;
-            // q4_0 KV — MQ-split dispatch is split by GQA fan-out:
-            //   GQA=4 (MQ_GQA=4 kernel): default-on. Dense 4/8-class targets
-            //     (Mistral-7B, Qwen3-4B/8B, Llama-3-8B) measure +72-151%
-            //     decode at d=8k/16k vs plain q1_split on Adreno X1-85.
-            //   GQA=8 (g8 / MQ_GQA=8 kernel): opt-in. Regressed on
-            //     Qwen3-30B-A3B (per-FA-call +20% on X1-85): q4_0 K at
-            //     4 b/e gives less K-BW saving than q8/f16 while the
-            //     occupancy drop + per-head dp4a + LDS overhead cost
-            //     more than they save on that shape.
-            //     Enable for measurement via GGML_OPENCL_FA_Q4_MQ=1.
             } else if (nq1_only && is_q4_0) {
                 const char * q4_mq_env = getenv("GGML_OPENCL_FA_Q4_MQ");
                 const bool   q4_mq_on  = (q4_mq_env != NULL) && (q4_mq_env[0] != '0');
@@ -14007,10 +13811,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     }
     if (fd_k_split == NULL &&
         n_q >= 1 && n_q <= fd_max_n_q && n_kv >= FD_MIN_N_KV && !is_causal &&
-        // NB: DK=512 (Gemma-4 global) is intentionally NOT routed here. Measured
-        // 2026-05-29: the scalar q1_split flash-decoding path regressed DK=512
-        // decode (tg@d16k 6.96→6.61) — the decode is K/V-read-bandwidth-bound,
-        // not occupancy-bound, so inter-WG split + merge only adds overhead.
         d_head_q <= FD_MAX_DK &&
         backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
         if (is_mixed && backend_ctx->fa.f32_f16_q1_split.count(dk_dv) > 0) {
@@ -14027,11 +13827,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const int n_kv_blocks = n_kv > 0 ? (n_kv + block_n - 1) / block_n : 0;
     // KV pad + blk prepass are pure overhead when FD will fire — skip them.
     const bool use_mixed_prepass = is_mixed && n_q > 1 && !use_fd;
-    // Prepass kernels may be absent if their program failed to compile (e.g. the
-    // DK=512 prepass OOMs the Adreno compiler). Gate on presence so the tile
-    // path declines the (optional) pad/blk-classify steps instead of throwing at
-    // .at(); the tile kernel already handles the no-prepass case (n_kv aligned /
-    // no tile-class hint), as it does whenever mask_buffer == NULL.
+    // make sure prepass kernels are compiled
     const bool have_kv_pad = backend_ctx->fa.kv_pad_f16.count(dk_dv) > 0;
     const bool have_blk    = backend_ctx->fa.blk_f16.count(dk_dv) > 0;
     const bool use_kv_pad = use_mixed_prepass && (n_kv % block_n != 0) && have_kv_pad;
@@ -14134,10 +13930,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_head_log2_f);
 
     if (use_fd) {
-        // MQ FD split kernels are latency-bound on a deep per-subgroup
-        // online-softmax recurrence at the prefill-tuned FD_KV_PER_SPLIT;
-        // use a finer decode granularity for them (see FD_MQ_KV_PER_SPLIT).
-        // Env overrides (read once) keep the granularity sweepable.
         static const int fd_env_kv_per_split = []{
             const char * e = getenv("GGML_OPENCL_FD_KV_PER_SPLIT");
             return (e && e[0]) ? atoi(e) : 0;
@@ -14146,13 +13938,14 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             const char * e = getenv("GGML_OPENCL_FD_MAX_SPLITS");
             return (e && e[0]) ? atoi(e) : 0;
         }();
+
         int fd_kv_per_split = use_fd_mq ? FD_MQ_KV_PER_SPLIT : FD_KV_PER_SPLIT;
         int fd_max_splits   = use_fd_mq ? FD_MQ_MAX_SPLITS   : FD_MAX_SPLITS;
-        if (fd_env_kv_per_split > 0) fd_kv_per_split = fd_env_kv_per_split;
-        if (fd_env_max_splits   > 0) fd_max_splits   = fd_env_max_splits;
+        if (fd_env_kv_per_split > 0) { fd_kv_per_split = fd_env_kv_per_split; }
+        if (fd_env_max_splits   > 0) { fd_max_splits   = fd_env_max_splits; }
         int n_splits = (n_kv + fd_kv_per_split - 1) / fd_kv_per_split;
-        if (n_splits < FD_MIN_SPLITS) n_splits = FD_MIN_SPLITS;
-        if (n_splits > fd_max_splits) n_splits = fd_max_splits;
+        if (n_splits < FD_MIN_SPLITS) { n_splits = FD_MIN_SPLITS; }
+        if (n_splits > fd_max_splits) { n_splits = fd_max_splits; }
         const int kv_per_split = (n_kv + n_splits - 1) / n_splits;
 
         const int fa_partial_floats = 2 + d_head_v;
@@ -14175,12 +13968,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &extra_q->data_device));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_q));
         if (use_fa_k_img) {
-            // K via image1d_buffer_t. Pool keyed on (parent_buffer, offset_k);
-            // image is sub-buffer-backed (origin=offset_k), so the kernel reads
-            // pixels relative to sub-buffer start — no k_offset arg.
-            // Byte-span must cover the FULL strided extent (the K view at FA
-            // decode is often head-major permuted on Adreno, so head/batch
-            // strides can dominate). Round up to 8 B (pixel size = 1 half4).
             const size_t nb00_bytes  = sizeof(uint16_t);
             const size_t k_bytes_span =
                 (size_t)(n_kv > 0 ? n_kv - 1 : 0) * (size_t)k_nb1 +
@@ -14195,10 +13982,8 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                     backend_ctx, backend_ctx->kq_img_pool,
                     k_data_device, offset_k, k_bytes, CL_HALF_FLOAT);
             }
-            // Fallback: if image creation failed (over max pixels, alloc fail),
-            // re-route through the matching non-image MQ path. Rare; keeps the
-            // run alive instead of crashing. gqa==4 → default MQ kernel,
-            // gqa==8 → MQ_G8 kernel.
+
+            // if image creation fails, fallback to buffer based kernels
             if (k_img == nullptr) {
                 if (gqa_ratio_dispatch == 4 &&
                     backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
@@ -14211,7 +13996,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &offset_k));
             } else {
                 CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &k_img));
-                // k_offset is baked into the sub-buffer; no separate arg.
             }
         } else {
             CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &k_data_device));
@@ -14249,9 +14033,9 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &n_splits));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &kv_per_split));
 
-        // MQ split kernel uses MQ_NSG_SPLIT subgroups × 64 lanes and one WG
-        // per (kv_head, batch, split) — collapses the n_head dim to n_head_kv.
-        const size_t fd_wg = use_fd_mq ? fd_mq_wg : 64; // matches Q1_WG_SIZE * NSG (MQ_GQA=4 → 256; MQ_GQA=8 → 192)
+        // MQ split kernel uses MQ_NSG_SPLIT subgroups and one WG per (kv_head, batch, split)
+        // matches Q1_WG_SIZE * NSG (MQ_GQA=4 -> 256; MQ_GQA=8 -> 192)
+        const size_t fd_wg = use_fd_mq ? fd_mq_wg : 64;
         const size_t fd_head_dim = use_fd_mq
             ? (size_t)(n_head_kv * n_batch)
             : (size_t)(n_head     * n_batch);
@@ -14281,8 +14065,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         return;
     }
 
-    // DK=512 prefill K-image: create/pool the texture-cache view of K up front.
-    // Decide before arg binding so a fallback can swap to the buffer tile cleanly.
     cl_mem prefill_k_img = nullptr;
     if (use_prefill_k_img) {
         const size_t nb00_bytes = sizeof(uint16_t);
@@ -14299,7 +14081,6 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 k_data_device, offset_k, k_bytes, CL_HALF_FLOAT);
         }
         if (prefill_k_img == nullptr) {
-            // Image unavailable → revert to the plain buffer split tile.
             kernel = backend_ctx->fa.f32_f16_split.at(dk_dv);
             use_prefill_k_img = false;
         }
@@ -14361,21 +14142,12 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
 
     if (n_q == 1) {
         if (use_local_tile) {
-            // Local-tile decode: 3D grid (LT_WG, n_head, n_batch).
-            // One WG per (q_idx, q_head, batch); LT_WG=128 lanes per WG
-            // co-compute one Q-row's attention via __local tile + tree-reduce.
             const size_t lt_wg = 128;
             size_t local_work_size[]  = { lt_wg, 1, 1 };
             size_t global_work_size[] = { lt_wg, (size_t) n_head, (size_t) n_batch };
             backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
         } else {
-            // q1_vec dispatches with NSG subgroups (WG = NSG*64) to expose the
-            // n_kv loop to multi-subgroup parallelism; everything else uses 64.
-            // q1_vec is compiled with VEC_NSG=4 → WG = 4 * 64 = 256.
-            // q1_vec_mq folds MQ_GQA Q-heads into each WG so the head dim of
-            // the grid collapses to n_head_kv (one WG per (kv_head, batch)).
-            // Basic q1 launches one subgroup-wide WG; the width must match FA_SG
-            // (and REQD_FA_SG) the kernel reduces over -- 64 on Adreno, 32 on Intel.
+            // q1_vec dispatches with NSG subgroups
             const size_t q1_wg = backend_ctx->gpu_family == INTEL ? 32 : 64;
             const size_t wg_size = use_q1_vec ? 256 : q1_wg;
             const size_t head_dim_global = use_q1_vec_mq
@@ -16861,8 +16633,6 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
     cl_ulong src_nb2;
     cl_ulong src_nb3;
 
-    // Stable identity of this KV-cache view for the dequant_f16_pool (survives the
-    // per-step graph rebuild because the underlying cache device buffer persists).
     uintptr_t pool_key_buf = 0;
     cl_ulong  pool_key_off = (cl_ulong) tensor->view_offs;
 
@@ -16884,12 +16654,9 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
         cl_mem aos = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, parent_nbytes, NULL, &err);
         CL_CHECK(err);
 
-        // Large q4_0/q8_0 WEIGHTS are stored transposed (Adreno trans-weight format,
-        // gated by use_adreno_kernels / enable_adreno_trans_weight at set_tensor). The
-        // plain restore_block kernels assume the un-transposed SoA layout and would
-        // produce scrambled AoS for those weights — pick the trans-aware restore to
-        // match how the weight was actually stored (mirrors get_tensor). Small weights
-        // (and the AoS KV-cache, handled in the else branch above) are not transposed.
+        // large q4_0/q8_0 WEIGHTS are stored transposed and small weights
+        // (and the AoS KV-cache, handled in the else branch above) are not.
+        // choose a proper restore kernel based on this.
         bool restored = false;
 #ifdef GGML_OPENCL_USE_ADRENO_KERNELS
         const int p_ne00 = (int) parent->ne[0];
@@ -16910,8 +16677,6 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
         } else if (tensor->type == GGML_TYPE_Q4_0 &&
                    use_adreno_kernels(backend_ctx, parent) &&
                    !use_adreno_moe_kernels(backend_ctx, parent)) {
-            // Dense q4_0 weight: stored noshuffle + transposed. Transpose q/d back into
-            // scratch, then reconstruct AoS via the noshuffle restore.
             auto * extra = (ggml_tensor_extra_cl_q4_0 *) soa_src->extra;
             pool_key_buf = (uintptr_t) extra->q;
             const size_t size_q = (size_t) ggml_nelements(parent) / blck_size * (blck_size / 2);
@@ -16932,7 +16697,7 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
             size_t gws[] = { n_blk, 1, 1 };
             size_t lws[] = { 1, 1, 1 };
             CL_CHECK(clEnqueueNDRangeKernel(backend_ctx->queue, kernel, 3, NULL, gws, lws, 0, NULL, NULL));
-            // Retained by the runtime while the restore kernel is queued.
+
             CL_CHECK(clReleaseMemObject(buf_tq));
             CL_CHECK(clReleaseMemObject(buf_td));
             restored = true;
@@ -16996,10 +16761,8 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
 
     const size_t out_bytes = (size_t) ggml_nelements(tensor) * sizeof(ggml_fp16_t);
 
-    // Reuse a pooled f16 buffer for this KV-cache view across decode steps instead of
-    // allocating one per attention op — the per-op alloc/free churn exhausts the
-    // allocator on deep-context 20 GB MoE decode. The pool owns the buffer (released at
-    // teardown); the caller must NOT release the returned cl_mem.
+    // reuse a pooled f16 buffer for this KV-cache view across decode steps instead of
+    // allocating new one per attention op
     cl_mem out = nullptr;
     {
         auto & pool = backend_ctx->dequant_f16_pool;
@@ -17009,7 +16772,7 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
             out = it->second.image;
         } else {
             if (it != pool.end()) {
-                if (it->second.image) CL_CHECK(clReleaseMemObject(it->second.image));
+                if (it->second.image) { CL_CHECK(clReleaseMemObject(it->second.image)); }
                 pool.erase(it);
             }
             cl_int err = CL_SUCCESS;
@@ -17044,11 +16807,7 @@ static cl_mem ggml_cl_mul_mat_dequant_quant_to_f16(
     return out;
 }
 
-// Look up or create a pooled image1d_buffer over a KV-cache view (parent
-// buffer + offset). Reuse across decode steps avoids per-call sub-buffer +
-// image churn that catastrophically slows down 64-layer / 20 GB models. The
-// pool grows the image if a later dispatch sees a larger byte-span; the
-// entry is released only at backend teardown.
+// look up or create a pooled image1d_buffer over a KV-cache view.
 static cl_mem ggml_cl_img_pool_get_or_create(
     ggml_backend_opencl_context * backend_ctx,
     std::map<ggml_backend_opencl_context::ImagePoolKey,
@@ -17056,8 +16815,8 @@ static cl_mem ggml_cl_img_pool_get_or_create(
     cl_mem data_device,
     cl_ulong offset0,
     size_t required_bytes,
-    cl_channel_type channel_data_type)
-{
+    cl_channel_type channel_data_type
+) {
     ggml_backend_opencl_context::ImagePoolKey key{(uintptr_t)data_device, (uint64_t)offset0};
     auto it = pool.find(key);
     if (it != pool.end()
@@ -17067,10 +16826,10 @@ static cl_mem ggml_cl_img_pool_get_or_create(
         return it->second.image;
     }
 
-    // Need to create or recreate. Release any stale entry first.
+    // need to create or recreate and release any stale entry first.
     if (it != pool.end()) {
-        if (it->second.image)      CL_CHECK(clReleaseMemObject(it->second.image));
-        if (it->second.sub_buffer) CL_CHECK(clReleaseMemObject(it->second.sub_buffer));
+        if (it->second.image)      { CL_CHECK(clReleaseMemObject(it->second.image)); }
+        if (it->second.sub_buffer) {CL_CHECK(clReleaseMemObject(it->second.sub_buffer)); }
         pool.erase(it);
     }
 
@@ -17120,14 +16879,9 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;
 
-    // Quant KV-cache read (fa=0 attention K/V): on-device dequant to f16 then
-    // native f16 MUL_MAT. Triggered for non-contiguous src0 (the usual head-major
-    // permuted K view when n_head_kv>1) AND for the contiguous case that occurs
-    // when n_head_kv==1 (e.g. Gemma-4 E2B, GQA 8:1) — there the K view is dense so
-    // !ggml_is_contiguous is false, but it still broadcasts over heads
-    // (src1->ne[2] > src0->ne[2]) and must NOT fall into the generic weight GEMV
-    // (which assumes no head broadcast and SIGSEGVs). Head broadcast (r2>1) is a
-    // weight-free signal: model weights never broadcast over ne2.
+    // quant kv without FA
+    // used for non-contiguous src0 (the usual head-major permuted K view when n_head_kv>1)
+    // AND for the contiguous case that occurs when n_head_kv==1 (e.g. Gemma-4 E2B)
     if ((src0t == GGML_TYPE_Q4_0 || src0t == GGML_TYPE_Q8_0) &&
         (!ggml_is_contiguous(src0) || src1->ne[2] > src0->ne[2])) {
         cl_mem f16_buf = ggml_cl_mul_mat_dequant_quant_to_f16(backend_ctx, src0, nullptr);
@@ -17146,9 +16900,6 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
         fake_src0.nb[3] = fake_src0.nb[2] * src0->ne[2];
 
         ggml_cl_mul_mat(backend, &fake_src0, src1, dst);
-
-        // f16_buf is owned by backend_ctx->dequant_f16_pool and reused across decode
-        // steps — do NOT release it here (it is freed at backend teardown).
         return;
     }
 
@@ -17222,16 +16973,6 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             }
         }
 
-        // Decode-time GQA-coalesced KQ via image1d_buffer_t (texture cache).
-        // Same shape gate as _x8_gqa4 (DK=128, r2=8, r3=1, ne01%16==0, ne11=1)
-        // plus enough K-cache bytes (must fit image_max_buffer_size in pixels).
-        // Opt-in via GGML_OPENCL_MM_KQ_GQA_IMG=1.
-        // r2=4 variant: GGML_OPENCL_MM_KQ_GQA_R4_IMG=1 enables the r2=4
-        // specialization (Llama-3.x / Qwen3-4B/8B / etc.).
-        // Default ON; set the env var to "0" to disable as a kill-switch.
-        // All test-backend-ops MUL_MAT type_a=f16 cases pass with these gates
-        // enabled. Promoted to default after validation on Qwen3-30B-A3B,
-        // Qwen3.6-35B-A3B, Qwen3-4B, Qwen3-8B, Llama-3-8B.
         static const char * mm_kq_gqa_img_env = getenv("GGML_OPENCL_MM_KQ_GQA_IMG");
         static const bool mm_kq_gqa_img_on = (mm_kq_gqa_img_env == nullptr || mm_kq_gqa_img_env[0] != '0');
         static const char * mm_kq_gqa_r4_img_env = getenv("GGML_OPENCL_MM_KQ_GQA_R4_IMG");
@@ -17245,24 +16986,17 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img != nullptr &&
             ne11 == 1 && ne01 >= 64 && (ne01 % 16) == 0 && ne00 == 128 &&
             (ne12 % ne02) == 0 && (ne12 / ne02) == 8 && (ne13 / ne03) == 1) {
-            // K cache byte-span the image must cover. The K view at decode
-            // KQ is often PERMUTED on Adreno (nb01 > nb02 — head-major), so
-            // compute the actual byte-span generically: max byte touched =
-            // (ne01-1)*nb01 + (ne02-1)*nb02 + (ne03-1)*nb03 + ne00*sizeof(half).
-            // Image pixel = 16 bytes (CL_RGBA, CL_FLOAT — mirrors prefill kq).
             const size_t nb00_bytes = sizeof(uint16_t);
             const size_t k_bytes_span =
                 (size_t)(ne01 > 0 ? ne01 - 1 : 0) * (size_t)nb01 +
                 (size_t)(ne02 > 0 ? ne02 - 1 : 0) * (size_t)nb02 +
                 (size_t)(ne03 > 0 ? ne03 - 1 : 0) * (size_t)nb03 +
                 (size_t)ne00 * nb00_bytes;
-            // Round up to a multiple of 16 (pixel size) so image_width covers it.
+
             const size_t k_bytes = (k_bytes_span + 15) & ~(size_t)15;
             const size_t k_pixels = k_bytes >> 4;
             if (k_pixels > 0 && k_pixels <= backend_ctx->image_max_buffer_size) {
                 cl_kernel kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4_img;
-                // Persistent pool: reuse the same image1d_buffer across decode
-                // steps for the same (parent buffer, offset) view.
                 cl_mem K_img = ggml_cl_img_pool_get_or_create(
                     backend_ctx, backend_ctx->kq_img_pool,
                     extra0->data_device, offset0, k_bytes, CL_FLOAT);
@@ -17298,12 +17032,10 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
                     return;
                 }
-                // Fall through on pool creation failure (rare; image_max etc).
             }
         }
 
-        // r2=4 specialization: Llama-3.x / Qwen3-4B/8B / etc.
-        // Uses the same pool (kq_img_pool) as the r2=8 path; different kernel.
+        // r2=4 specialization
         if (img_r4_gate) {
             const size_t nb00_bytes = sizeof(uint16_t);
             const size_t k_bytes_span =
@@ -17353,8 +17085,7 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             }
         }
 
-        // DK=256, r2=2 specialization (Gemma-3-4B: n_head=8, n_head_kv=4, head_dim=256).
-        // Opt-in via GGML_OPENCL_MM_KQ_GQA_R2_DK256_IMG=1.
+        // DK=256, r2=2 specialization
         static const char * mm_kq_r2_dk256_env = getenv("GGML_OPENCL_MM_KQ_GQA_R2_DK256_IMG");
         static const bool mm_kq_r2_dk256_on = (mm_kq_r2_dk256_env != nullptr && mm_kq_r2_dk256_env[0] != '0');
         if (mm_kq_r2_dk256_on &&
@@ -17409,12 +17140,7 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
             }
         }
 
-        // Decode-time GQA-coalesced KQV via image1d_buffer_t (texture cache).
-        // Companion to KQ image dispatch above. Gate matches _y8_gqa:
-        //   src0=V (ne00=n_kv, ne01=DV=128, ne02=n_head_kv), src1=softmax(KQ).
-        //   r2 = ne12/ne02 = 8 for Qwen3-30B-A3B family.
-        // Same generic k_bytes formula handles V's transposed (n_kv-fast) layout.
-        // Opt-in via GGML_OPENCL_MM_KQV_GQA_IMG=1.
+        // GQA-coalesced KQV for decode using image1d_buffer_t
         static const char * mm_kqv_gqa_img_env = getenv("GGML_OPENCL_MM_KQV_GQA_IMG");
         static const bool mm_kqv_gqa_img_on = (mm_kqv_gqa_img_env != nullptr && mm_kqv_gqa_img_env[0] != '0');
         if (mm_kqv_gqa_img_on &&
@@ -17427,8 +17153,6 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                 (size_t)(ne02 > 0 ? ne02 - 1 : 0) * (size_t)nb02 +
                 (size_t)(ne03 > 0 ? ne03 - 1 : 0) * (size_t)nb03 +
                 (size_t)ne00 * nb00_bytes;
-            // CL_RGBA/CL_HALF_FLOAT: 8-byte pixels (= 1 half4). Same per-iter
-            // access pattern as _y8_gqa, kept register-equivalent.
             const size_t v_bytes = (v_bytes_span + 7) & ~(size_t)7;
             const size_t v_pixels = v_bytes >> 3;
             if (v_pixels > 0 && v_pixels <= backend_ctx->image_max_buffer_size) {
@@ -18276,37 +18000,19 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
                     kernel = backend_ctx->kernel_mul_mat_f16_f32_l4_dr_ls;
                     nrows  = 1;
                 } else if (ne00 >= 128 && ne01 >= 8 && ne00%4 == 0) {
-                    // Multi-output decode variants when Q is a single row:
-                    //   - x8 (Q cached in __local): fast path for KQ where
-                    //     ne00 = DK <= 256 fits the per-WG Q cache.
-                    //   - y8 (streaming Q from global): fallback for KQV
-                    //     where ne00 = n_kv is large (> 256). Adreno L1
-                    //     absorbs the 8× Q-read redundancy across the 8
-                    //     outputs in the WG.
-                    // Biggest win at long context where the KQ/KQV launches
-                    // ~262K WGs each with a single mad.
-                    // Diagnostic: GGML_OPENCL_MM_F16_FORCE_L4=1 bypasses _x8/_y8 multi-output
-                    // variants and forces the original _l4 kernel. Used to bisect Qwen3.6-35B-A3B
-                    // baseline drift between 940c1ef5f and ff90e9a95 (11.13 → 8.38 t/s at d=16k).
+                    // multi-output decode variants when Q is a single row
                     static const char * mm_force_l4_env = getenv("GGML_OPENCL_MM_F16_FORCE_L4");
                     static const bool mm_force_l4_on = (mm_force_l4_env != nullptr && mm_force_l4_env[0] != '0');
                     const bool can_multi_out = !mm_force_l4_on && ne11 == 1 && ne01 >= 64 && ne01 % 8 == 0;
-                    // Opt-in: GGML_OPENCL_MM_KQ_PAIR=1 swaps _x8 for the
                     // paired-K-row variant that doubles per-wave-cycle
-                    // memory-issue parallelism at DK in [128, 256]. Held
-                    // behind env var (no long-ctx win on Qwen3-30B-A3B).
                     static const char * mm_kq_pair_env = getenv("GGML_OPENCL_MM_KQ_PAIR");
                     static const bool mm_kq_pair_on = (mm_kq_pair_env != nullptr && mm_kq_pair_env[0] != '0');
-                    // Opt-in: GGML_OPENCL_MM_KQ_GQA=1 swaps _x8 for the
                     // GQA-coalesced variant that reads each K-row once and
-                    // emits gqa_ratio outputs. Specialized for DK=128, r2=8,
-                    // r3=1 (Qwen3-30B-A3B / Qwen3-4B / Qwen3.6-A3B shape).
-                    // +35% tg128 @ d=16k, +30% @ d=8k, +20% @ d=4k on Qwen3-30B-A3B.
+                    // emits gqa_ratio outputs
                     static const char * mm_kq_gqa_env = getenv("GGML_OPENCL_MM_KQ_GQA");
                     static const bool mm_kq_gqa_on = (mm_kq_gqa_env != nullptr && mm_kq_gqa_env[0] != '0');
-                    // Opt-in: GGML_OPENCL_MM_KQV_GQA=1 swaps _y8 for the
                     // GQA-coalesced KQV variant (DK=128/r2=8/r3=1) that reads
-                    // each V slab once per K-head and emits all r2 Q-heads.
+                    // each V slab once per K-head and emits all r2 Q-heads
                     static const char * mm_kqv_gqa_env = getenv("GGML_OPENCL_MM_KQV_GQA");
                     static const bool mm_kqv_gqa_on = (mm_kqv_gqa_env != nullptr && mm_kqv_gqa_env[0] != '0');
                     if (can_multi_out && (ne01 % 16) == 0 && ne00 == 128 && r2 == 8 && r3 == 1 && mm_kq_gqa_on &&
@@ -19195,25 +18901,19 @@ static void ggml_cl_mul_mat(ggml_backend_t backend, const ggml_tensor * src0, co
     } else if (kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_x8 ||
                kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_x8_pair ||
                kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_y8) {
-        // Multi-output decode variants: each WG processes 8 outputs along
-        // ne01; ne11 == 1. Same grid shape for both x8 (Q cached) and y8
-        // (streaming Q).
+        // multi-output decode variants: each WG processes 8 outputs along ne01, ne11 == 1
         const int64_t n_wg_x = ne01 / 8;
         size_t global_work_size[] = {(size_t)n_wg_x*nth0, (size_t)nth1, (size_t)ne12*ne13};
         size_t local_work_size[]  = {(size_t)nth0, (size_t)nth1, 1};
         backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
     } else if (kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_x8_gqa4) {
-        // GQA-coalesced KQ: one WG per K-head emits N_K_ROWS_GQA=16 K-rows ×
-        // r2 Q-heads. Widens the per-WG latency-hiding window vs the original
-        // N=8 (post-profile: KQ was 70% of decode at d=16k due to memory-stall
-        // serialization on K-row fetches). N=32 regressed 9-11% at long ctx,
-        // likely due to I-cache pressure from the unrolled outer loop.
+        // GQA-coalesced KQ: one WG per K-head emits N_K_ROWS_GQA=16 K-rows * r2 Q-heads
         const int64_t n_wg_x = ne01 / 16;
         size_t global_work_size[] = {(size_t)n_wg_x*nth0, (size_t)nth1, (size_t)ne02*ne13};
         size_t local_work_size[]  = {(size_t)nth0, (size_t)nth1, 1};
         backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
     } else if (kernel == backend_ctx->kernel_mul_mat_f16_f32_l4_y8_gqa) {
-        // GQA-coalesced KQV: one WG per K-head emits 8 DV-rows × r2 Q-heads.
+        // GQA-coalesced KQV: one WG per K-head emits 8 DV-rows * r2 Q-heads
         const int64_t n_wg_x = ne01 / 8;
         size_t global_work_size[] = {(size_t)n_wg_x*nth0, (size_t)nth1, (size_t)ne02*ne13};
         size_t local_work_size[]  = {(size_t)nth0, (size_t)nth1, 1};

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -6608,10 +6608,10 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                     return false;
                 }
                 if (q->ne[1] == 1) {
-                    // decode-only program (q1 / q1_vec / q1_split / merge)
-                    if (!ggml_opencl_ensure_fa_variant(backend_ctx, dk, dv, FA_VARIANT_F32_F16)) {
-                        return false;
-                    }
+                    // DK=512 decode is bandwidth-bound and slower on the GPU
+                    // than on the CPU; decline it here so it runs on the CPU.
+                    // Prefill (n_q > 1) stays on the GPU.
+                    return false;
                 } else {
                     // prefill, BM-tile in its own FA_PREFILL_ONLY program
                     if (!ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/false)) {

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -13493,18 +13493,18 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 kernel = backend_ctx->fa.f32_q8_0_q1.at(dk_dv);
             }
         } else if (use_native_q4_0_q1) {
-            // q4_0 vec kernel now uses per-lane dp4a (cl_khr_integer_dot_product)
-            // — closes most of the gap vs legacy q1 at short ctx (was -45%
-            // pre-dp4a) but still measures -10/-11% behind legacy on the
-            // canonical target (Qwen3.6-A3B MXFP4 / q4_0 KV) at both short
-            // and long context. q8_0 vec wins because q8_0 KV exposes the
-            // o_acc spill more sharply than q4_0; for q4_0 the legacy q1
-            // path's lower per-WG overhead still wins on MoE-bound models.
-            // Keep dispatch on legacy q1 until vec beats it on a real target;
-            // opt-in via GGML_OPENCL_FA_Q4_VEC=1 for measurement.
+            // q4_0 vec kernel uses per-lane dp4a (cl_khr_integer_dot_product)
+            // and DV-split across subgroups. The earlier "-10/-11% on
+            // Qwen3.6-A3B MXFP4 / q4_0 KV" caveat was stale: re-measured
+            // 2026-05-23 on X1-85 across four DV=256 targets (gemma-3-4b,
+            // gemma-2-2b, Qwen3.5-9B, Qwen3.6-A3B MXFP4) the vec kernel
+            // wins +25 to +71% end-to-end vs legacy q1; Qwen3.6-A3B at
+            // per-FA-call profile is 3.6× faster (11.0 → 3.04 ms/call).
+            // Default-on for DV>=256. Opt-out via GGML_OPENCL_FA_Q4_VEC=0
+            // for diagnosis if a regression surfaces on an untested shape.
             const char * q4vec_env = getenv("GGML_OPENCL_FA_Q4_VEC");
-            const bool   q4vec_opt_in = (q4vec_env != NULL) && (q4vec_env[0] != '0');
-            if (q4vec_opt_in && d_head_v >= 256 &&
+            const bool   q4vec_off = (q4vec_env != NULL) && (q4vec_env[0] == '0');
+            if (!q4vec_off && d_head_v >= 256 &&
                 backend_ctx->fa.f32_q4_0_q1_vec.count(dk_dv) > 0) {
                 kernel = backend_ctx->fa.f32_q4_0_q1_vec.at(dk_dv);
                 use_q1_vec = true;
@@ -13704,28 +13704,19 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             // already compiled per (dk, dv). Without the DK=128 branch f16 KV
             // decode on these models falls to the spilling non-MQ split and
             // pays a GQA-replay on K reads — structurally slower than the q8_0
-            // path on the same model. WG=256 fits at DK=128 (less per-thread
-            // state than DK=256); if the kernel didn't compile or doesn't fit,
-            // `count(dk_dv) > 0` skips dispatch. n_q==1 only for now.
+            // path on the same model. K-image variant available for DK=DV=128
+            // (opt-in via GGML_OPENCL_FA_K_IMG=1) — adds ~1-3% per-FA-call on
+            // X1-85, dominated by ~15% thermal envelope; not default-on.
+            // n_q==1 only for now.
             } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
                 ((d_head_q == 256 && d_head_v == 256) ||
                  (d_head_q == 128 && d_head_v == 128)) &&
                 backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
-                fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
-                use_fd_mq  = true;
-            // f16 KV — dense 7-8B class (Mistral-7B / Qwen3-8B / Llama-3-8B),
-            // DK=DV=128 GQA=4. Plain q1_split is 3.5x slower per layer than
-            // FA=0's image-fed l4_x8_gqa_r4_img KQ. MQ closes +60-90% of that
-            // end-to-end at d=8k on X1-85 (Mistral 2.90→5.49, Qwen3-8B 2.37→3.80,
-            // Llama-3-8B 2.56→4.68 t/s). K-image adds ~1-3% per-FA-call further,
-            // opt-in via GGML_OPENCL_FA_K_IMG=1 (mirrors the g8 dispatch).
-            } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
-                d_head_q == 128 && d_head_v == 128 &&
-                backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
-                const bool k_img_on = getenv("GGML_OPENCL_FA_K_IMG") != NULL &&
-                                      getenv("GGML_OPENCL_FA_K_IMG")[0] != '0';
-                if (k_img_on &&
-                    backend_ctx->fa.f32_f16_q1_vec_mq_split_k_img.count(dk_dv) > 0) {
+                const bool k_img_on = d_head_q == 128 && d_head_v == 128 &&
+                                      getenv("GGML_OPENCL_FA_K_IMG") != NULL &&
+                                      getenv("GGML_OPENCL_FA_K_IMG")[0] != '0' &&
+                                      backend_ctx->fa.f32_f16_q1_vec_mq_split_k_img.count(dk_dv) > 0;
+                if (k_img_on) {
                     fd_k_split   = backend_ctx->fa.f32_f16_q1_vec_mq_split_k_img.at(dk_dv);
                     use_fd_mq    = true;
                     use_fa_k_img = true;

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -425,6 +425,27 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, cl_kernel> f32_f16_split;          // N_SPLIT>1 variant
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_split;       // flash-decoding K-split
+    // Vec decode: DV-split + subgroup-reduced dot (mirrors Metal vec FA).
+    // Used at large DV (e.g. DK=DV=512) where the standard q1 spills o_acc.
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec;
+    // KV-head-coalesced vec decode. One WG handles MQ_GQA Q-heads sharing one
+    // KV-head; K/V loaded once and reused. Compile-locked to MQ_GQA=4 (Gemma-3
+    // family). Falls back to q1_vec / q1 when the gate isn't met.
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq;
+    // KV-head-coalesced + flash-decoding split. Pairs MQ coalescing with FD
+    // n_kv-split for occupancy; produces MQ_GQA partial records per WG and
+    // reuses flash_attn_f32_merge for normalization.
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split;
+    // MQ_GQA=8 specializations (Qwen3-30B-A3B / Qwen3-4B class): same source,
+    // a second program compiled with -DMQ_GQA=8 so the Q-row stride matches.
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_g8;
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8;
+    // Alternative decode FA: 1 WG per (q_idx, q_head) with a __local K/V tile +
+    // pure __local tree-reduce. Compiled only at DK=DV=128. Opt-in.
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_tile;
+    // Hybrid local-tile + MQ + FD-split kernel (DK=DV=128 only). Opt-in.
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_mq_split;
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_local_mq_split_g8;
     std::map<std::pair<int, int>, int>       f32_f16_bm;
     std::map<std::pair<int, int>, int>       f32_f16_bn;
     std::map<std::pair<int, int>, int>       f32_f16_wg_size;
@@ -432,7 +453,12 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, int>       f32_f16_split_nkv_threshold;
     // f32 Q / native q8_0 KV
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1;            // decode
+    std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec;        // DV-split + multi-subgroup decode
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_split;      // flash-decoding pass 1
+    // KV-head-coalesced + flash-decoding split for q8_0 KV; MQ_GQA=4 default,
+    // _g8 second compile for the Qwen3-30B-A3B class (GQA=8).
+    std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split;
+    std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8;
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0;               // prefill (baseline)
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_split;         // N_SPLIT>1 variant
     std::map<std::pair<int, int>, int>       f32_q8_0_split_wg_size;        // wg_size = bm*n_split
@@ -440,7 +466,12 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, int>       f32_q8_0_split_bm;             // per-split BLOCK_M
     // f32 Q / native q4_0 KV
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1;
+    std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_vec;        // DV-split + multi-subgroup decode
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_split;
+    // KV-head-coalesced + flash-decoding split for q4_0 KV (dp4a K dot);
+    // MQ_GQA=4 default, _g8 second compile for the Qwen3-30B-A3B class.
+    std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_vec_mq_split;
+    std::map<std::pair<int, int>, cl_kernel> f32_q4_0_q1_vec_mq_split_g8;
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0;
     std::map<std::pair<int, int>, cl_kernel> f32_q4_0_split;
     std::map<std::pair<int, int>, int>       f32_q4_0_split_wg_size;
@@ -4065,6 +4096,41 @@ static std::string ggml_opencl_fa_compile_opts(ggml_backend_opencl_context * bac
     return opts;
 }
 
+// Refuse to register a kernel whose required dispatch WG size exceeds either
+// the per-kernel cap (CL_KERNEL_WORK_GROUP_SIZE) or the device cap
+// (CL_DEVICE_MAX_WORK_GROUP_SIZE). On Adreno X2 the per-kernel cap can be
+// well below the device cap (e.g. CL_KERNEL_WORK_GROUP_SIZE = 320 for the
+// q1_vec_mq signature against a device max of 1024) and is enforced at
+// enqueue time — dispatching above it returns CL_INVALID_WORK_GROUP_SIZE.
+// When the check fails, the caller releases the kernel so the existing
+// `kernel_map.count(dk_dv) > 0` dispatch checks fall back gracefully.
+static bool ggml_opencl_fa_kernel_fits_wg(ggml_backend_opencl_context * backend_ctx,
+                                          cl_kernel kernel, size_t required_wg,
+                                          const char * name, int dk, int dv) {
+    if (kernel == NULL) return false;
+    const size_t dev_max = backend_ctx->max_workgroup_size;
+    if (dev_max < required_wg) {
+        GGML_LOG_INFO("ggml_opencl: %s DK=%d DV=%d requires WG %zu > device max %zu; skipping registration (will fall back)\n",
+                      name, dk, dv, required_wg, dev_max);
+        return false;
+    }
+    size_t kwg = 0;
+    cl_int err = clGetKernelWorkGroupInfo(kernel, backend_ctx->device,
+                                          CL_KERNEL_WORK_GROUP_SIZE,
+                                          sizeof(kwg), &kwg, NULL);
+    if (err != CL_SUCCESS) {
+        GGML_LOG_INFO("ggml_opencl: clGetKernelWorkGroupInfo failed for %s DK=%d DV=%d (err=%d); skipping registration\n",
+                      name, dk, dv, err);
+        return false;
+    }
+    if (kwg < required_wg) {
+        GGML_LOG_INFO("ggml_opencl: %s DK=%d DV=%d per-kernel max %zu < required %zu; skipping registration (will fall back)\n",
+                      name, dk, dv, kwg, required_wg);
+        return false;
+    }
+    return true;
+}
+
 // Log private memory for an FA kernel. Enable via `GGML_OPENCL_FA_LOG_SPILL=1`.
 // On Adreno non-zero private_mem means spilling to global memory due to resource
 // constraint and usually causes performance degradation.
@@ -4281,9 +4347,130 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 backend_ctx->fa.f32_f16_q1_split[{dk, dv}] = k_split;
                 ggml_opencl_log_fa_kernel_spill(backend_ctx, k_split, "flash_attn_f32_f16_q1_split", dk, dv);
             }
+            // q1_vec decode kernel (DV-split + subgroup reduce). Compile is
+            // best-effort; if it fails (e.g. driver/extension gap) the standard
+            // q1 path stays the fallback at dispatch. Required WG = 4 × 64 = 256
+            // (VEC_NSG × Q1_WG_SIZE in the kernel).
+            cl_kernel k_q1_vec = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec", &err);
+            if (err == CL_SUCCESS) {
+                if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec, 256,
+                                                  "flash_attn_f32_f16_q1_vec", dk, dv)) {
+                    backend_ctx->fa.f32_f16_q1_vec[{dk, dv}] = k_q1_vec;
+                    ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec, "flash_attn_f32_f16_q1_vec", dk, dv);
+                } else {
+                    clReleaseKernel(k_q1_vec);
+                }
+            }
+            // KV-head-coalesced vec for high-GQA small models (Gemma-3-1B).
+            // Best-effort compile; only used when gqa_ratio == MQ_GQA at dispatch.
+            // Required WG = 4 × 64 = 256 (MQ_NSG × Q1_WG_SIZE).
+            cl_kernel k_q1_vec_mq = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec_mq", &err);
+            if (err == CL_SUCCESS) {
+                if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq, 256,
+                                                  "flash_attn_f32_f16_q1_vec_mq", dk, dv)) {
+                    backend_ctx->fa.f32_f16_q1_vec_mq[{dk, dv}] = k_q1_vec_mq;
+                    ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq, "flash_attn_f32_f16_q1_vec_mq", dk, dv);
+                } else {
+                    clReleaseKernel(k_q1_vec_mq);
+                }
+            }
+            // KV-head-coalesced + flash-decoding split. Reused merge kernel.
+            // Required WG = 4 × 64 = 256 (MQ_NSG_SPLIT × Q1_WG_SIZE).
+            cl_kernel k_q1_vec_mq_split = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec_mq_split", &err);
+            if (err == CL_SUCCESS) {
+                if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split, 256,
+                                                  "flash_attn_f32_f16_q1_vec_mq_split", dk, dv)) {
+                    backend_ctx->fa.f32_f16_q1_vec_mq_split[{dk, dv}] = k_q1_vec_mq_split;
+                    ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_split, "flash_attn_f32_f16_q1_vec_mq_split", dk, dv);
+                } else {
+                    clReleaseKernel(k_q1_vec_mq_split);
+                }
+            }
             cl_kernel k_merge = clCreateKernel(prog, "flash_attn_f32_merge", &err);
             if (err == CL_SUCCESS) {
                 backend_ctx->fa.f32_merge[{dk, dv}] = k_merge;
+            }
+            // Local-tile decode variant (DK=DV=128 only; LT_WG=128).
+            // Required WG = 128. Best-effort compile.
+            if (dk == 128 && dv == 128) {
+                cl_kernel k_lt = clCreateKernel(prog, "flash_attn_f32_f16_q1_local_tile", &err);
+                if (err == CL_SUCCESS) {
+                    if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_lt, 128,
+                                                      "flash_attn_f32_f16_q1_local_tile", dk, dv)) {
+                        backend_ctx->fa.f32_f16_q1_local_tile[{dk, dv}] = k_lt;
+                        ggml_opencl_log_fa_kernel_spill(backend_ctx, k_lt, "flash_attn_f32_f16_q1_local_tile", dk, dv);
+                    } else {
+                        clReleaseKernel(k_lt);
+                    }
+                }
+                // Hybrid local-tile + MQ + FD-split. MQ_GQA=4 from default
+                // compile. Required WG = 64 (1 subgroup).
+                cl_kernel k_lmq = clCreateKernel(prog, "flash_attn_f32_f16_q1_local_mq_split", &err);
+                if (err == CL_SUCCESS) {
+                    if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_lmq, 64,
+                                                      "flash_attn_f32_f16_q1_local_mq_split", dk, dv)) {
+                        backend_ctx->fa.f32_f16_q1_local_mq_split[{dk, dv}] = k_lmq;
+                        ggml_opencl_log_fa_kernel_spill(backend_ctx, k_lmq, "flash_attn_f32_f16_q1_local_mq_split", dk, dv);
+                    } else {
+                        clReleaseKernel(k_lmq);
+                    }
+                }
+            }
+            // Second compile of the same source with -DMQ_GQA=8 for the
+            // Qwen3-30B-A3B / Qwen3-4B class (GQA=8). Only the two MQ kernels
+            // are extracted; everything else is identical to the MQ_GQA=4
+            // program above and would just duplicate cache. Compile is
+            // best-effort: if the larger __local Q stage (8 Q rows × DK_VEC)
+            // doesn't fit or the WG cap drops, the dispatch falls back to
+            // the legacy q1_vec path. Mirrors Metal's per-NQPSG template
+            // specialization.
+            // MQ_GQA=8 doubles per-thread state (o_acc[8][1], m_i[8], l_i[8],
+            // slope[8], mask_base[8]) → Adreno's per-kernel WG cap drops from
+            // 256 to 192 due to register pressure (measured on Adreno X2).
+            // Compile with MQ_NSG=3 / MQ_NSG_SPLIT=3 so the
+            // 192-thread cap is sufficient; the kernel's merge loops are
+            // already NSG-agnostic.
+            const std::string opts_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
+            cl_program prog_g8 = build_program_from_source_ex(
+                backend_ctx->context, backend_ctx->device, src.c_str(), opts_g8,
+                /*fatal=*/false, "fa f32_f16 MQ_GQA=8");
+            if (prog_g8) {
+                const size_t mq_g8_required_wg = 192;  // Q1_WG_SIZE(64) * MQ_NSG_SPLIT(3)
+                cl_kernel k_q1_vec_mq_g8 = clCreateKernel(prog_g8, "flash_attn_f32_f16_q1_vec_mq", &err);
+                if (err == CL_SUCCESS) {
+                    if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_g8, mq_g8_required_wg,
+                                                      "flash_attn_f32_f16_q1_vec_mq (g8)", dk, dv)) {
+                        backend_ctx->fa.f32_f16_q1_vec_mq_g8[{dk, dv}] = k_q1_vec_mq_g8;
+                        ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_g8, "flash_attn_f32_f16_q1_vec_mq_g8", dk, dv);
+                    } else {
+                        clReleaseKernel(k_q1_vec_mq_g8);
+                    }
+                }
+                cl_kernel k_q1_vec_mq_split_g8 = clCreateKernel(prog_g8, "flash_attn_f32_f16_q1_vec_mq_split", &err);
+                if (err == CL_SUCCESS) {
+                    if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split_g8, mq_g8_required_wg,
+                                                      "flash_attn_f32_f16_q1_vec_mq_split (g8)", dk, dv)) {
+                        backend_ctx->fa.f32_f16_q1_vec_mq_split_g8[{dk, dv}] = k_q1_vec_mq_split_g8;
+                        ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_split_g8, "flash_attn_f32_f16_q1_vec_mq_split_g8", dk, dv);
+                    } else {
+                        clReleaseKernel(k_q1_vec_mq_split_g8);
+                    }
+                }
+                // Hybrid local-tile + MQ_GQA=8. WG=64 (1 subgroup); the
+                // per-kernel WG cap should stay >= 64 even at high reg pressure.
+                if (dk == 128 && dv == 128) {
+                    cl_kernel k_lmq_g8 = clCreateKernel(prog_g8, "flash_attn_f32_f16_q1_local_mq_split", &err);
+                    if (err == CL_SUCCESS) {
+                        if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_lmq_g8, 64,
+                                                          "flash_attn_f32_f16_q1_local_mq_split (g8)", dk, dv)) {
+                            backend_ctx->fa.f32_f16_q1_local_mq_split_g8[{dk, dv}] = k_lmq_g8;
+                            ggml_opencl_log_fa_kernel_spill(backend_ctx, k_lmq_g8, "flash_attn_f32_f16_q1_local_mq_split_g8", dk, dv);
+                        } else {
+                            clReleaseKernel(k_lmq_g8);
+                        }
+                    }
+                }
+                clReleaseProgram(prog_g8);
             }
             break;
         }
@@ -4309,11 +4496,64 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 m_q1_split[{dk, dv}] = k_split;
                 ggml_opencl_log_fa_kernel_spill(backend_ctx, k_split, name_q1_split.c_str(), dk, dv);
             }
+            // DV-split decode variant (q1_vec); best-effort compile.
+            // Required WG = 4 × 64 = 256 (VEC_NSG × Q1_WG_SIZE).
+            auto & m_q1_vec = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec : backend_ctx->fa.f32_q4_0_q1_vec;
+            const std::string name_q1_vec = name_q1 + "_vec";
+            cl_kernel k_q1_vec = clCreateKernel(prog, name_q1_vec.c_str(), &err);
+            if (err == CL_SUCCESS) {
+                if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec, 256,
+                                                  name_q1_vec.c_str(), dk, dv)) {
+                    m_q1_vec[{dk, dv}] = k_q1_vec;
+                    ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec, name_q1_vec.c_str(), dk, dv);
+                } else {
+                    clReleaseKernel(k_q1_vec);
+                }
+            }
+            // KV-head-coalesced + flash-decoding split (MQ_GQA=4 default).
+            // Required WG = 4 × 64 = 256 (MQ_NSG_SPLIT × Q1_WG_SIZE).
+            auto & m_mq_split = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec_mq_split
+                                      : backend_ctx->fa.f32_q4_0_q1_vec_mq_split;
+            const std::string name_mq_split = name_q1 + "_vec_mq_split";
+            cl_kernel k_q1_vec_mq_split = clCreateKernel(prog, name_mq_split.c_str(), &err);
+            if (err == CL_SUCCESS) {
+                if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_q1_vec_mq_split, 256,
+                                                  name_mq_split.c_str(), dk, dv)) {
+                    m_mq_split[{dk, dv}] = k_q1_vec_mq_split;
+                    ggml_opencl_log_fa_kernel_spill(backend_ctx, k_q1_vec_mq_split, name_mq_split.c_str(), dk, dv);
+                } else {
+                    clReleaseKernel(k_q1_vec_mq_split);
+                }
+            }
             if (!backend_ctx->fa.f32_merge.count({dk, dv})) {
                 cl_kernel k_merge = clCreateKernel(prog, "flash_attn_f32_merge", &err);
                 if (err == CL_SUCCESS) {
                     backend_ctx->fa.f32_merge[{dk, dv}] = k_merge;
                 }
+            }
+            // Second compile with MQ_GQA=8 / MQ_NSG=3 / MQ_NSG_SPLIT=3 for the
+            // Qwen3-30B-A3B / Qwen3-4B class. WG cap at MQ_GQA=8 drops to 192
+            // on Adreno X2 due to register pressure; NSG=3 matches. Best-effort;
+            // falls back to the legacy q1 path at dispatch if missing.
+            auto & m_mq_split_g8 = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8
+                                         : backend_ctx->fa.f32_q4_0_q1_vec_mq_split_g8;
+            const std::string opts_mq_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
+            cl_program prog_mq_g8 = build_program_from_source_ex(
+                backend_ctx->context, backend_ctx->device, src.c_str(), opts_mq_g8,
+                /*fatal=*/false, is_q8 ? "fa q8_0 MQ_GQA=8" : "fa q4_0 MQ_GQA=8");
+            if (prog_mq_g8) {
+                const size_t mq_g8_required_wg = 192;
+                cl_kernel k_g8 = clCreateKernel(prog_mq_g8, name_mq_split.c_str(), &err);
+                if (err == CL_SUCCESS) {
+                    if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_g8, mq_g8_required_wg,
+                                                      name_mq_split.c_str(), dk, dv)) {
+                        m_mq_split_g8[{dk, dv}] = k_g8;
+                        ggml_opencl_log_fa_kernel_spill(backend_ctx, k_g8, name_mq_split.c_str(), dk, dv);
+                    } else {
+                        clReleaseKernel(k_g8);
+                    }
+                }
+                clReleaseProgram(prog_mq_g8);
             }
             break;
         }
@@ -13081,13 +13321,86 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     max_bias      = params[1];
     logit_softcap = params[2];
 
+    bool use_q1_vec = false;
+    bool use_q1_vec_mq = false;
+    bool use_local_tile = false;
+    // KV-head-coalesced gate: gqa_ratio == compile-time MQ_GQA (4 → Gemma-3
+    // family). LDS budget restricts to DK=DV=256 for now. At higher DV the
+    // sg_o array (16 KB at DV=256) doubles per DV doubling and would exceed
+    // Adreno 32 KB LDS.
+    const int gqa_ratio_dispatch = n_head_kv > 0 ? (n_head / n_head_kv) : 0;
     if (n_q == 1) {
         if (use_native_q8_0_q1) {
-            kernel = backend_ctx->fa.f32_q8_0_q1.at(dk_dv);
+            if (d_head_v >= 256 &&
+                backend_ctx->fa.f32_q8_0_q1_vec.count(dk_dv) > 0) {
+                kernel = backend_ctx->fa.f32_q8_0_q1_vec.at(dk_dv);
+                use_q1_vec = true;
+            } else {
+                kernel = backend_ctx->fa.f32_q8_0_q1.at(dk_dv);
+            }
         } else if (use_native_q4_0_q1) {
-            kernel = backend_ctx->fa.f32_q4_0_q1.at(dk_dv);
+            // q4_0 vec kernel now uses per-lane dp4a (cl_khr_integer_dot_product)
+            // — closes most of the gap vs legacy q1 at short ctx (was -45%
+            // pre-dp4a) but still measures -10/-11% behind legacy on the
+            // canonical target (Qwen3.6-A3B MXFP4 / q4_0 KV) at both short
+            // and long context. q8_0 vec wins because q8_0 KV exposes the
+            // o_acc spill more sharply than q4_0; for q4_0 the legacy q1
+            // path's lower per-WG overhead still wins on MoE-bound models.
+            // Keep dispatch on legacy q1 until vec beats it on a real target;
+            // opt-in via GGML_OPENCL_FA_Q4_VEC=1 for measurement.
+            const char * q4vec_env = getenv("GGML_OPENCL_FA_Q4_VEC");
+            const bool   q4vec_opt_in = (q4vec_env != NULL) && (q4vec_env[0] != '0');
+            if (q4vec_opt_in && d_head_v >= 256 &&
+                backend_ctx->fa.f32_q4_0_q1_vec.count(dk_dv) > 0) {
+                kernel = backend_ctx->fa.f32_q4_0_q1_vec.at(dk_dv);
+                use_q1_vec = true;
+            } else {
+                kernel = backend_ctx->fa.f32_q4_0_q1.at(dk_dv);
+            }
         } else if (is_mixed) {
-            kernel = backend_ctx->fa.f32_f16_q1.at(dk_dv);
+            // DV-split decode kernel (mirrors Metal vec FA) wins at large DV
+            // where the standard q1 spills o_acc to DDR. Gate originally at
+            // DV >= 256 (Qwen3.6 / Gemma-4), later lowered to DV >= 128
+            // to cover Qwen3-30B-A3B (DK=DV=128 GQA 8:1). CUDA & Metal pick
+            // the vec-style kernel for DK=128 with multi-Q-per-CTA, so this
+            // is the expected portable shape. Fall back if the kernel
+            // didn't compile (no-extension driver).
+            // NOTE: single-WG MQ (q1_vec_mq) is registered but not dispatched.
+            // At Gemma-3-1B / DK=DV=256 with WG=256 (4 subgroups, the max
+            // viable on Adreno X2 for this kernel), it benches at ~60 t/s
+            // vs legacy q1_vec at ~72 t/s — a regression — so there's no
+            // reason to fire it over legacy at short context. The MQ win
+            // comes from the FD-split path below (q1_vec_mq_split), which
+            // pairs MQ coalescing with n_kv splitting across WGs for
+            // occupancy. Left registered so the source is available for
+            // future experimentation.
+            // Gate the vec path. The default was lowered from DV >= 256 to
+            // DV >= 128 after a 5-model regression sweep (Qwen3-30B-A3B,
+            // Qwen3-8B Q8, Qwen3-4B Q4, Llama-3-8B Q4, Qwen2.5-7B Q4_K_M) showed
+            // no regression and small wins (+0.3 to +3.2% tg128@d=8k fa=1 f16).
+            // GGML_OPENCL_FA_F16_VEC_DK128=0 forces legacy q1 (opt-out for
+            // diagnosis if a regression surfaces on an untested shape).
+            // Opt-in: alternative local-tile decode kernel (DK=DV=128 only).
+            // GGML_OPENCL_FA_LOCAL_TILE=1 routes to flash_attn_f32_f16_q1_local_tile
+            // when registered; suppresses both vec and MQ FD-split paths.
+            static const char * lt_env = getenv("GGML_OPENCL_FA_LOCAL_TILE");
+            static const bool   lt_on  = (lt_env != NULL) && (lt_env[0] != '0');
+            if (lt_on && d_head_q == 128 && d_head_v == 128 &&
+                backend_ctx->fa.f32_f16_q1_local_tile.count(dk_dv) > 0) {
+                kernel = backend_ctx->fa.f32_f16_q1_local_tile.at(dk_dv);
+                use_local_tile = true;
+            } else {
+                static const char * f16_vec_dk128_env = getenv("GGML_OPENCL_FA_F16_VEC_DK128");
+                static const bool   f16_vec_dk128_off = (f16_vec_dk128_env != NULL) && (f16_vec_dk128_env[0] == '0');
+                const int dv_gate = f16_vec_dk128_off ? 256 : 128;
+                if (d_head_v >= dv_gate &&
+                    backend_ctx->fa.f32_f16_q1_vec.count(dk_dv) > 0) {
+                    kernel = backend_ctx->fa.f32_f16_q1_vec.at(dk_dv);
+                    use_q1_vec = true;
+                } else {
+                    kernel = backend_ctx->fa.f32_f16_q1.at(dk_dv);
+                }
+            }
         } else if (is_f16) {
             kernel = backend_ctx->fa.f16_q1.at(dk_dv);
         } else {
@@ -13186,7 +13499,102 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     const int is_causal = (mask == NULL && n_q > 1 && n_q == n_kv);
     const int fd_max_n_q = (d_head_q <= FD_MAX_DK_MULTI) ? FD_MAX_N_Q_MULTI : 1;
     cl_kernel fd_k_split = NULL;
-    if (n_q >= 1 && n_q <= fd_max_n_q && n_kv >= FD_MIN_N_KV && !is_causal &&
+    bool use_fd_mq = false;
+    size_t fd_mq_wg = 256;  // MQ_GQA=4 kernel: Q1_WG_SIZE(64) * MQ_NSG_SPLIT(4)
+    // MQ flash-decoding gate. Bypasses FD_MAX_DK because the MQ split kernel
+    // uses NSG subgroups × 64 lanes, so o_acc is DV-split — no spill at DK=DV=256.
+    // - gqa_ratio == 4 + DK=DV=256: Gemma-3 family, MQ_GQA=4 kernel.
+    // - gqa_ratio == 8 + DK=DV=128: Qwen3-30B-A3B / Qwen3-4B class, MQ_GQA=8
+    //   kernel (compiled alongside via a second program). Mirrors Metal's
+    //   per-NQPSG template dispatch.
+    {
+        const char * mq_env = getenv("GGML_OPENCL_FA_MQ");
+        const bool mq_enabled = (mq_env == NULL) ? true : (mq_env[0] != '0');
+        const bool mq_kv_ok   = is_mixed || is_q8_0 || is_q4_0;
+        // Opt-in: hybrid local-tile + MQ + FD-split for is_mixed @ DK=DV=128.
+        const char * lmq_env = getenv("GGML_OPENCL_FA_LOCAL_MQ_SPLIT");
+        const bool   lmq_on  = (lmq_env != NULL) && (lmq_env[0] != '0');
+        // Extend the Qwen3-30B-A3B-class (DK=DV=128 GQA=8) f16 MQ_G8 vec path
+        // to handle n_q ∈ [1, N_MAX_VEC_NQ] for speculative-verification
+        // batches. The kernel + grid already support n_q > 1 (gid(2) decodes
+        // split_idx & q_idx); only the n_q==1 gate kept it off for n_q>1.
+        // Default cap = 1 (preserves single-token decode behaviour); override
+        // via GGML_OPENCL_FA_VEC_NQ=N for a higher cap.
+        static const char * vec_nq_env = getenv("GGML_OPENCL_FA_VEC_NQ");
+        static const int N_MAX_VEC_NQ  = (vec_nq_env != NULL && vec_nq_env[0] != '\0')
+                                           ? atoi(vec_nq_env) : 1;
+        const bool nq_in_vec_range = (n_q >= 1) && (n_q <= N_MAX_VEC_NQ);
+        // Only the MQ_G8 path takes n_q > 1; all other MQ paths (DK=DV=256,
+        // q8_0, q4_0, local_*) still require n_q == 1.
+        const bool nq1_only        = (n_q == 1);
+        if (mq_enabled && mq_kv_ok && nq_in_vec_range && !is_causal &&
+            !use_local_tile &&  // local-tile dispatches its own grid, skip MQ FD-split
+            n_kv >= FD_MIN_N_KV &&
+            backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
+            // Hybrid local-tile + MQ + FD-split — opt-in via env, f16 KV DK=DV=128, n_q==1 only.
+            if (nq1_only && lmq_on && is_mixed && d_head_q == 128 && d_head_v == 128 &&
+                gqa_ratio_dispatch == 8 &&
+                backend_ctx->fa.f32_f16_q1_local_mq_split_g8.count(dk_dv) > 0) {
+                fd_k_split = backend_ctx->fa.f32_f16_q1_local_mq_split_g8.at(dk_dv);
+                use_fd_mq  = true;
+                fd_mq_wg   = 64;  // LMQ_WG
+            } else if (nq1_only && lmq_on && is_mixed && d_head_q == 128 && d_head_v == 128 &&
+                gqa_ratio_dispatch == 4 &&
+                backend_ctx->fa.f32_f16_q1_local_mq_split.count(dk_dv) > 0) {
+                fd_k_split = backend_ctx->fa.f32_f16_q1_local_mq_split.at(dk_dv);
+                use_fd_mq  = true;
+                fd_mq_wg   = 64;  // LMQ_WG
+            // f16 KV — Gemma-3 class (DK=DV=256 GQA=4); n_q==1 only for now
+            } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
+                d_head_q == 256 && d_head_v == 256 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
+                fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
+                use_fd_mq  = true;
+            // f16 KV — Qwen3-30B-A3B class (DK=DV=128 GQA=8); extended to n_q ∈ [1, N_MAX_VEC_NQ]
+            } else if (is_mixed && gqa_ratio_dispatch == 8 &&
+                d_head_q == 128 && d_head_v == 128 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.count(dk_dv) > 0) {
+                fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.at(dk_dv);
+                use_fd_mq  = true;
+                fd_mq_wg   = 192;
+            // q8_0 KV — DK=DV=128 GQA=8 (Qwen3-30B-A3B q8 KV path); n_q==1 only for now
+            } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 8 &&
+                d_head_q == 128 && d_head_v == 128 &&
+                backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8.count(dk_dv) > 0) {
+                fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8.at(dk_dv);
+                use_fd_mq  = true;
+                fd_mq_wg   = 192;
+            // q8_0 KV — DK=DV=128 GQA=4 (Gemma-3 q8, Llama q8 class); n_q==1 only for now
+            } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 4 &&
+                d_head_q == 128 && d_head_v == 128 &&
+                backend_ctx->fa.f32_q8_0_q1_vec_mq_split.count(dk_dv) > 0) {
+                fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split.at(dk_dv);
+                use_fd_mq  = true;
+            // q4_0 KV — opt-in only. The MQ port for q4_0 regressed on
+            // Qwen3-30B-A3B: q4_0 K is only 4 bits/element, so the K-bandwidth
+            // saving MQ offers doesn't offset the per-head dp4a + LDS overhead
+            // (q8_0 at 8 b/e and f16 at 16 b/e do win). Kernel kept registered;
+            // enable for measurement via GGML_OPENCL_FA_Q4_MQ=1.
+            } else if (nq1_only && is_q4_0) {
+                const char * q4_mq_env = getenv("GGML_OPENCL_FA_Q4_MQ");
+                const bool   q4_mq_on  = (q4_mq_env != NULL) && (q4_mq_env[0] != '0');
+                if (q4_mq_on && gqa_ratio_dispatch == 8 &&
+                    d_head_q == 128 && d_head_v == 128 &&
+                    backend_ctx->fa.f32_q4_0_q1_vec_mq_split_g8.count(dk_dv) > 0) {
+                    fd_k_split = backend_ctx->fa.f32_q4_0_q1_vec_mq_split_g8.at(dk_dv);
+                    use_fd_mq  = true;
+                    fd_mq_wg   = 192;
+                } else if (q4_mq_on && gqa_ratio_dispatch == 4 &&
+                    d_head_q == 128 && d_head_v == 128 &&
+                    backend_ctx->fa.f32_q4_0_q1_vec_mq_split.count(dk_dv) > 0) {
+                    fd_k_split = backend_ctx->fa.f32_q4_0_q1_vec_mq_split.at(dk_dv);
+                    use_fd_mq  = true;
+                }
+            }
+        }
+    }
+    if (fd_k_split == NULL &&
+        n_q >= 1 && n_q <= fd_max_n_q && n_kv >= FD_MIN_N_KV && !is_causal &&
         d_head_q <= FD_MAX_DK &&
         backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
         if (is_mixed && backend_ctx->fa.f32_f16_q1_split.count(dk_dv) > 0) {
@@ -13365,10 +13773,15 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &n_splits));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &kv_per_split));
 
-        const size_t fd_wg = 64; // matches Q1_WG_SIZE in the kernel
+        // MQ split kernel uses MQ_NSG_SPLIT subgroups × 64 lanes and one WG
+        // per (kv_head, batch, split) — collapses the n_head dim to n_head_kv.
+        const size_t fd_wg = use_fd_mq ? fd_mq_wg : 64; // matches Q1_WG_SIZE * NSG (MQ_GQA=4 → 256; MQ_GQA=8 → 192)
+        const size_t fd_head_dim = use_fd_mq
+            ? (size_t)(n_head_kv * n_batch)
+            : (size_t)(n_head     * n_batch);
         size_t fd_lws[3] = { fd_wg, 1, 1 };
         // gid(2) packs q_idx * n_splits + split_idx.
-        size_t fd_gws[3] = { fd_wg, (size_t)(n_head * n_batch), (size_t)(n_splits * n_q) };
+        size_t fd_gws[3] = { fd_wg, fd_head_dim, (size_t)(n_splits * n_q) };
         backend_ctx->enqueue_ndrange_kernel(k_split, 3, fd_gws, fd_lws, dst);
 
         cl_kernel k_merge = backend_ctx->fa.f32_merge.at(dk_dv);
@@ -13447,10 +13860,28 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     }
 
     if (n_q == 1) {
-        const size_t wg_size = 64;
-        size_t local_work_size[] = { wg_size, 1 };
-        size_t global_work_size[] = { wg_size, (size_t)(n_head * n_batch) };
-        backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size, local_work_size, dst);
+        if (use_local_tile) {
+            // Local-tile decode: 3D grid (LT_WG, n_head, n_batch).
+            // One WG per (q_idx, q_head, batch); LT_WG=128 lanes per WG
+            // co-compute one Q-row's attention via __local tile + tree-reduce.
+            const size_t lt_wg = 128;
+            size_t local_work_size[]  = { lt_wg, 1, 1 };
+            size_t global_work_size[] = { lt_wg, (size_t) n_head, (size_t) n_batch };
+            backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);
+        } else {
+            // q1_vec dispatches with NSG subgroups (WG = NSG*64) to expose the
+            // n_kv loop to multi-subgroup parallelism; everything else uses 64.
+            // q1_vec is compiled with VEC_NSG=4 → WG = 4 * 64 = 256.
+            // q1_vec_mq folds MQ_GQA Q-heads into each WG so the head dim of
+            // the grid collapses to n_head_kv (one WG per (kv_head, batch)).
+            const size_t wg_size = use_q1_vec ? 256 : 64;
+            const size_t head_dim_global = use_q1_vec_mq
+                ? (size_t)(n_head_kv * n_batch)
+                : (size_t)(n_head     * n_batch);
+            size_t local_work_size[] = { wg_size, 1 };
+            size_t global_work_size[] = { wg_size, head_dim_global };
+            backend_ctx->enqueue_ndrange_kernel(kernel, 2, global_work_size, local_work_size, dst);
+        }
     } else if (use_native_q8_0 || use_native_q4_0) {
         // Native quant prefill. The split variant may override BLOCK_M
         // (e.g. DK=96 quant uses BM=16).

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -1091,7 +1091,7 @@ static cl_program build_program_from_source_ex(cl_context ctx, cl_device_id dev,
         program_log = (char*) malloc(log_size + 1);
         program_log[log_size] = '\0';
         clGetProgramBuildInfo(p, dev, CL_PROGRAM_BUILD_LOG, log_size + 1, program_log, NULL);
-        GGML_LOG_ERROR("ggml_opencl: kernel compile error (err=%d):\n\n%s\n", err, program_log);
+        GGML_LOG_ERROR("ggml_opencl: kernel compile error (err=%d)%s%s:\n\n%s\n", err, tag ? " building " : "", tag ? tag : "", program_log);
         free(program_log);
         clReleaseProgram(p);
         if (fatal) {
@@ -4595,8 +4595,10 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 }
             }
 
-            // second compile of the same source with -DMQ_GQA=8
-            const std::string opts_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
+            // second compile of the same source with -DMQ_GQA=8.
+            // FA_MQ_ONLY keeps only the vec_mq kernels so that the program
+            // compiles within the Adreno compiler's memory budget at DK>=256.
+            const std::string opts_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3 -D FA_MQ_ONLY";
             cl_program prog_g8 = fa_decode_only ? nullptr : build_program_from_source_ex(
                 backend_ctx->context, backend_ctx->device, src.c_str(), opts_g8,
                 /*fatal=*/false, "fa f32_f16 MQ_GQA=8", backend_ctx->queue);

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f16.cl
@@ -10,7 +10,12 @@
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
 #define WG_SIZE (BLOCK_M)
-#define Q1_WG_SIZE 64
+// q1 reduces over a Q1_WG_SIZE-wide WG via work-group barriers; the launch WG
+// must match. Defaults to the Adreno sg (64); host passes -D FA_SG=32 on Intel.
+#ifndef FA_SG
+#define FA_SG 64
+#endif
+#define Q1_WG_SIZE FA_SG
 
 // The kernels are built with -cl-finite-math-only. On some older Adreno GPUs,
 // infinite operand can cause undefined behavior and miscompilation for exp.

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32.cl
@@ -11,7 +11,12 @@
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
 #define WG_SIZE (BLOCK_M)
-#define Q1_WG_SIZE 64
+// q1 reduces over a Q1_WG_SIZE-wide WG via work-group barriers; the launch WG
+// must match. Defaults to the Adreno sg (64); host passes -D FA_SG=32 on Intel.
+#ifndef FA_SG
+#define FA_SG 64
+#endif
+#define Q1_WG_SIZE FA_SG
 
 // The kernels are built with -cl-finite-math-only. On some older Adreno GPUs,
 // infinite operand can cause undefined behavior and miscompilation for exp.
@@ -114,6 +119,15 @@ __kernel void flash_attn_f32(
     __local DATA_TYPE4 l_v[BLOCK_N][DV_VEC];
 
     for (int k_start = 0; k_start < n_kv; k_start += BLOCK_N) {
+#if FA_SG < 64
+        // WAR on l_k/l_v: threads with my_query_row >= n_q skip the compute below
+        // (continue) and would race ahead to reload the tiles while active threads
+        // still read them. A single 64-wide Adreno subgroup (WG == sg) runs lockstep
+        // and hides this; a WG that spans multiple narrower subgroups (Intel sg=32)
+        // corrupts the result. All threads reach this each iteration (no-op on the
+        // first), so it does not diverge with the continue. Compiled out at sg=64.
+        barrier(CLK_LOCAL_MEM_FENCE);
+#endif
         for (int i = tid; i < BLOCK_N * DK_VEC; i += WG_SIZE) {
             const int row = i / DK_VEC;
             const int col = i % DK_VEC;

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -841,7 +841,7 @@ __kernel void flash_attn_f32_f16_q1_vec(
     // Each subgroup independently runs the FA-2 online softmax over its slice
     // of n_kv. Sinks are NOT folded into per-subgroup m_i — they're added once
     // in the cross-subgroup merge to avoid double-counting.
-    ACC_TYPE m_i = -INFINITY;
+    ACC_TYPE m_i = FA_M_INIT;
     ACC_TYPE l_i = 0.0f;
 
     const int kv_per_sg = (n_kv + VEC_NSG - 1) / VEC_NSG;
@@ -1039,7 +1039,7 @@ __kernel void flash_attn_f32_f16_q1_local_tile(
     }
 
     float o_val = 0.0f;
-    float m_i = -INFINITY;
+    float m_i = FA_M_INIT;
     float l_i = 0.0f;
 
     for (int kb = 0; kb < n_kv; kb += LT_KC) {
@@ -1201,7 +1201,7 @@ __kernel void flash_attn_f32_f16_q1_local_mq_split(
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
-                rec[0] = -INFINITY;
+                rec[0] = FA_M_INIT;
                 rec[1] = 0.0f;
             }
         }
@@ -1234,7 +1234,7 @@ __kernel void flash_attn_f32_f16_q1_local_mq_split(
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        m_i[h] = -INFINITY;
+        m_i[h] = FA_M_INIT;
         l_i[h] = 0.0f;
         slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
         #pragma unroll
@@ -1456,7 +1456,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
     ACC_TYPE  l_i[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        m_i[h] = -INFINITY;
+        m_i[h] = FA_M_INIT;
         l_i[h] = 0.0f;
         #pragma unroll
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
@@ -1668,7 +1668,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
-                rec[0] = -INFINITY;
+                rec[0] = FA_M_INIT;
                 rec[1] = 0.0f;
             }
         }
@@ -1719,7 +1719,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     ACC_TYPE  l_i[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        m_i[h] = -INFINITY;
+        m_i[h] = FA_M_INIT;
         l_i[h] = 0.0f;
         #pragma unroll
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
@@ -1923,7 +1923,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
-                rec[0] = -INFINITY;
+                rec[0] = FA_M_INIT;
                 rec[1] = 0.0f;
             }
         }
@@ -1972,7 +1972,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
     ACC_TYPE  l_i[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        m_i[h] = -INFINITY;
+        m_i[h] = FA_M_INIT;
         l_i[h] = 0.0f;
         #pragma unroll
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -90,7 +90,7 @@ inline float get_alibi_slope(
 
 // Adreno compiler crashes when attempting to compile the entire program for DK=512,
 // FA_DECODE_ONLY allows bypass the encoding kernel.
-#ifndef FA_DECODE_ONLY
+#if !defined(FA_DECODE_ONLY) && !defined(FA_MQ_ONLY)
 #ifndef FA_TILE_NAME
 #define FA_TILE_NAME flash_attn_f32_f16
 #endif
@@ -620,6 +620,7 @@ __kernel void FA_TILE_NAME(
 
 // allow bypassing decode kernels to avoid compiler crash for DK=512 on Adreno GPUs
 #ifndef FA_PREFILL_ONLY
+#ifndef FA_MQ_ONLY  // q1 excluded from the MQ-only (g8) program
 REQD_FA_SG
 __kernel void flash_attn_f32_f16_q1(
     const global void * q_void, ulong q_offset,
@@ -776,13 +777,14 @@ __kernel void flash_attn_f32_f16_q1(
     }
 }
 
+#endif  // !FA_MQ_ONLY (q1)
 // decode variant for large DV (e.g. Gemma-4 DK=DV=512 global layers).
 #define VEC_NSG          4
 #define VEC_WG_SIZE      (Q1_WG_SIZE * VEC_NSG)
 #define Q1V_DV_PER_THREAD ((DV_VEC + Q1_WG_SIZE - 1) / Q1_WG_SIZE)
 
 // allow bypassing the kernel to avoid compiler crash for DK=512 on Adreno GPUs
-#ifndef FA_DECODE_MINIMAL
+#if !defined(FA_DECODE_MINIMAL) && !defined(FA_MQ_ONLY)
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_vec(
     const global void * q_void, ulong q_offset,
@@ -976,6 +978,7 @@ __kernel void flash_attn_f32_f16_q1_vec(
 #define LT_KC 32
 #define LT_WG 128
 
+#ifndef FA_MQ_ONLY  // q1_local_tile excluded from the MQ-only (g8) program
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_local_tile(
     const global void * q_void, ulong q_offset,
@@ -1123,6 +1126,7 @@ __kernel void flash_attn_f32_f16_q1_local_tile(
 #define LMQ_KC  32
 #define LMQ_DPL 2   // DK / LMQ_WG at DK=128
 
+#endif  // !FA_MQ_ONLY (q1_local_tile)
 #ifndef MQ_GQA
 #define MQ_GQA 4
 #endif
@@ -1131,6 +1135,7 @@ __kernel void flash_attn_f32_f16_q1_local_tile(
 #define FA_PARTIAL_FLOATS (2 + DV)
 #endif
 
+#ifndef FA_MQ_ONLY  // q1_local_mq_split excluded from the MQ-only (g8) program
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_local_mq_split(
     const global void * q_void, ulong q_offset,
@@ -1329,6 +1334,7 @@ __kernel void flash_attn_f32_f16_q1_local_mq_split(
     }
 }
 
+#endif  // !FA_MQ_ONLY (q1_local_mq_split)
 #ifndef MQ_NSG
 #define MQ_NSG 4
 #endif
@@ -2031,6 +2037,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
 }
 #endif  // !FA_DECODE_ONLY
 
+#ifndef FA_MQ_ONLY  // q1_split + merge excluded from the MQ-only (g8) program
 __kernel void flash_attn_f32_f16_q1_split(
     const global void * q_void, ulong q_offset,
     const global void * k_void, ulong k_offset,
@@ -2261,4 +2268,5 @@ __kernel void flash_attn_f32_merge(
     global O_DATA_TYPE4 * o_row = (global O_DATA_TYPE4 *) ((global char *) o_void + o_offset + o_row_offset);
     o_row[lane] = CONVERT_O_DATA4(o);
 }
+#endif  // !FA_MQ_ONLY (q1_split + merge)
 #endif  // !FA_PREFILL_ONLY (decode kernels)

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -1383,7 +1383,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
     const global char * k_base = (const global char *) k_void + k_offset;
     const global char * v_base = (const global char *) v_void + v_offset;
     global       char * o_base = (global       char *) o_void + o_offset;
-.
+
     __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_WG_SIZE) {
         const int h        = i / DK_VEC;

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -570,6 +570,12 @@ __kernel void flash_attn_f32_f16(
 #endif
 }
 
+// Note: REQD_SUBGROUP_SIZE_64 intentionally omitted. Adding it routes the
+// X2 driver (and X1, per hp-hamoa) to its slower $fallback kernel variant
+// for sibling kernels in the same program — measured -5% on Llama-3.2-3B
+// _q1_vec at d=8192. At WG=Q1_WG_SIZE=64 the Adreno default sg=64, so
+// sub_group_reduce_max/add and sub_group_barrier produce correct WG-wide
+// semantics without the explicit attribute (TBO 2564/2564).
 __kernel void flash_attn_f32_f16_q1(
     const global void * q_void, ulong q_offset,
     const global void * k_void, ulong k_offset,
@@ -630,7 +636,7 @@ __kernel void flash_attn_f32_f16_q1(
     for (int i = tid; i < DK_VEC; i += Q1_WG_SIZE) {
         q_shared[i] = CONVERT_Q_ACC4(q_ptr[i]);
     }
-    barrier(CLK_LOCAL_MEM_FENCE);
+    sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
     float slope = get_alibi_slope(max_bias, head_idx, n_head_log2, m0, m1);
 
@@ -659,15 +665,7 @@ __kernel void flash_attn_f32_f16_q1(
         m_i = max(m_i, score);
     }
 
-    __local ACC_TYPE local_m[Q1_WG_SIZE];
-    local_m[tid] = m_i;
-    barrier(CLK_LOCAL_MEM_FENCE);
-    FA_UNROLL
-    for (int s = Q1_WG_SIZE / 2; s > 0; s >>= 1) {
-        if (tid < s) local_m[tid] = max(local_m[tid], local_m[tid + s]);
-        barrier(CLK_LOCAL_MEM_FENCE);
-    }
-    const ACC_TYPE m_final = local_m[0];
+    const ACC_TYPE m_final = sub_group_reduce_max(m_i);
 
     ACC_TYPE4 o_acc[DV_VEC];
     FA_UNROLL
@@ -700,19 +698,12 @@ __kernel void flash_attn_f32_f16_q1(
         }
     }
 
-    __local ACC_TYPE local_l[Q1_WG_SIZE];
     __local ACC_TYPE4 local_o_comp[Q1_WG_SIZE];
-    local_l[tid] = l_i;
-    barrier(CLK_LOCAL_MEM_FENCE);
-    FA_UNROLL
-    for (int s = Q1_WG_SIZE / 2; s > 0; s >>= 1) {
-        if (tid < s) local_l[tid] += local_l[tid + s];
-        barrier(CLK_LOCAL_MEM_FENCE);
-    }
+    const ACC_TYPE l_red = sub_group_reduce_add(l_i);
 
     const ulong o_row_offset = batch_idx * o_nb3 + head_idx * o_nb1;
     global O_DATA_TYPE4 *o_row = (global O_DATA_TYPE4 *)(o_base + o_row_offset);
-    ACC_TYPE l_final = local_l[0];
+    ACC_TYPE l_final = l_red;
 
     if (sinks_ptr != NULL) {
         l_final += exp(sinks_ptr[head_idx] - m_final);
@@ -722,11 +713,11 @@ __kernel void flash_attn_f32_f16_q1(
         const ACC_TYPE l_inv = 1.0f / l_final;
         for (int i = 0; i < DV_VEC; i++) {
             local_o_comp[tid] = o_acc[i];
-            barrier(CLK_LOCAL_MEM_FENCE);
+            sub_group_barrier(CLK_LOCAL_MEM_FENCE);
             FA_UNROLL
             for (int s = Q1_WG_SIZE / 2; s > 0; s >>= 1) {
                 if (tid < s) local_o_comp[tid] += local_o_comp[tid + s];
-                barrier(CLK_LOCAL_MEM_FENCE);
+                sub_group_barrier(CLK_LOCAL_MEM_FENCE);
             }
             if (tid == 0) {
                 o_row[i] = CONVERT_O_DATA4(local_o_comp[0] * l_inv);
@@ -2180,7 +2171,7 @@ __kernel void flash_attn_f32_f16_q1_split(
     for (int i = tid; i < DK_VEC; i += Q1_WG_SIZE) {
         q_shared[i] = CONVERT_Q_ACC4(q_ptr[i]);
     }
-    barrier(CLK_LOCAL_MEM_FENCE);
+    sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
     const float slope = get_alibi_slope(max_bias, head_idx, n_head_log2, m0, m1);
 
@@ -2205,15 +2196,7 @@ __kernel void flash_attn_f32_f16_q1_split(
         m_i = max(m_i, score);
     }
 
-    __local ACC_TYPE local_m[Q1_WG_SIZE];
-    local_m[tid] = m_i;
-    barrier(CLK_LOCAL_MEM_FENCE);
-    #pragma unroll
-    for (int s = Q1_WG_SIZE / 2; s > 0; s >>= 1) {
-        if (tid < s) local_m[tid] = max(local_m[tid], local_m[tid + s]);
-        barrier(CLK_LOCAL_MEM_FENCE);
-    }
-    const ACC_TYPE m_c = local_m[0];
+    const ACC_TYPE m_c = sub_group_reduce_max(m_i);
 
     // Pass 1b — softmax-weighted V accumulate.
     ACC_TYPE4 o_acc[DV_VEC];
@@ -2247,16 +2230,8 @@ __kernel void flash_attn_f32_f16_q1_split(
         }
     }
 
-    __local ACC_TYPE  local_l[Q1_WG_SIZE];
     __local ACC_TYPE4 local_o[Q1_WG_SIZE];
-    local_l[tid] = l_i;
-    barrier(CLK_LOCAL_MEM_FENCE);
-    #pragma unroll
-    for (int s = Q1_WG_SIZE / 2; s > 0; s >>= 1) {
-        if (tid < s) local_l[tid] += local_l[tid + s];
-        barrier(CLK_LOCAL_MEM_FENCE);
-    }
-    const ACC_TYPE l_c = local_l[0];
+    const ACC_TYPE l_c = sub_group_reduce_add(l_i);
 
     if (tid == 0) {
         rec[0] = (float) m_c;
@@ -2264,11 +2239,11 @@ __kernel void flash_attn_f32_f16_q1_split(
     }
     for (int i = 0; i < DV_VEC; ++i) {
         local_o[tid] = o_acc[i];
-        barrier(CLK_LOCAL_MEM_FENCE);
+        sub_group_barrier(CLK_LOCAL_MEM_FENCE);
         #pragma unroll
         for (int s = Q1_WG_SIZE / 2; s > 0; s >>= 1) {
             if (tid < s) local_o[tid] += local_o[tid + s];
-            barrier(CLK_LOCAL_MEM_FENCE);
+            sub_group_barrier(CLK_LOCAL_MEM_FENCE);
         }
         if (tid == 0) {
             rec_o[i] = local_o[0];

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -13,13 +13,7 @@
 #define REQD_SUBGROUP_SIZE_64
 #endif
 
-// Subgroup width the q1-family kernels stripe the dot/o_acc over and reduce
-// across (sub_group_reduce_*). Defaults to the Adreno default sg (64); the host
-// overrides it with -D FA_SG=<device sg> on non-Adreno GPUs. REQD_FA_SG pins the
-// width on Intel (intel_reqd_sub_group_size), where the WG would otherwise split
-// into multiple narrower subgroups and the reduces would cover only part of it.
-// Left empty on Adreno: the qcom default sg already equals FA_SG=64 there, and
-// the explicit attribute regresses sibling kernels (see the q1_vec note below).
+// subgroup size for q1 kernels
 #ifndef FA_SG
 #define FA_SG 64
 #endif
@@ -50,8 +44,7 @@
 
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
-// Hoisted to file scope so the kept decode kernels (q1_split, merge) still see
-// it when FA_DECODE_ONLY excludes the vec/MQ block that originally defined it.
+
 #ifndef FA_PARTIAL_FLOATS
 #define FA_PARTIAL_FLOATS (2 + DV)
 #endif
@@ -94,10 +87,9 @@ inline float get_alibi_slope(
 
     return pow(base, exph);
 }
-// FA_DECODE_ONLY: built for DK=512 (Gemma-4 global layers) where compiling the
-// full program OOMs the Adreno shader compiler (CL_OUT_OF_HOST_MEMORY). The
-// decode-only build keeps just q1 + q1_split + merge; the heavy BM-tile prefill
-// kernel and all vec/MQ variants are excluded so the program fits the compiler.
+
+// Adreno compiler crashes when attempting to compile the entire program for DK=512,
+// FA_DECODE_ONLY allows bypass the encoding kernel.
 #ifndef FA_DECODE_ONLY
 #ifndef FA_TILE_NAME
 #define FA_TILE_NAME flash_attn_f32_f16
@@ -105,11 +97,6 @@ inline float get_alibi_slope(
 __kernel void FA_TILE_NAME(
     const global void * q_void, ulong q_offset,
 #ifdef FA_K_IMG
-    // K bound as a read-only image1d_buffer_t (CL_RGBA / CL_HALF_FLOAT, 8 B/pixel
-    // = 1 half4) → reads go through the Adreno texture cache, a separate BW lane
-    // that survives the per-query-block K re-reads. k_offset is baked into the
-    // sub-buffer the image views, so the second slot is an unused placeholder
-    // kept only so the host arg layout matches the non-image tile.
     __read_only image1d_buffer_t k_img, ulong k_offset_unused,
 #else
     const global void * k_void, ulong k_offset,
@@ -629,18 +616,9 @@ __kernel void FA_TILE_NAME(
     }
 #endif
 }
+#endif  // !FA_DECODE_ONLY
 
-// Note: REQD_SUBGROUP_SIZE_64 intentionally omitted. Adding it routes the
-// X2 driver (and X1, per hp-hamoa) to its slower $fallback kernel variant
-// for sibling kernels in the same program — measured -5% on Llama-3.2-3B
-// _q1_vec at d=8192. At WG=Q1_WG_SIZE=64 the Adreno default sg=64, so
-// sub_group_reduce_max/add and sub_group_barrier produce correct WG-wide
-// semantics without the explicit attribute (TBO 2564/2564).
-#endif  // !FA_DECODE_ONLY (BM-tile prefill kernel)
-
-// FA_PREFILL_ONLY: the DK=512 prefill program builds ONLY the BM-tile kernel
-// above; every decode kernel below is excluded so the tile compiles in its own
-// minimal program (the full program OOMs the Adreno compiler at DK=512).
+// allow bypassing decode kernels to avoid compiler crash for DK=512 on Adreno GPUs
 #ifndef FA_PREFILL_ONLY
 REQD_FA_SG
 __kernel void flash_attn_f32_f16_q1(
@@ -798,32 +776,12 @@ __kernel void flash_attn_f32_f16_q1(
     }
 }
 
-// Decode variant for large DV (e.g. Gemma-4 DK=DV=512 global layers).
-// Mirrors ggml-metal's kernel_flash_attn_ext_vec design:
-//   - WG = VEC_NSG subgroups × 64 lanes. Each subgroup runs the FA-2 online
-//     softmax loop independently over its slice of n_kv, then a __local merge
-//     combines (m_i, l_i, o_acc) across subgroups. This restores the n_kv
-//     parallelism that a single-subgroup vec port loses.
-//   - DV is split across the subgroup (each thread owns DV_VEC/64 of o_acc);
-//     this kills the o_acc[DV_VEC] private-array spill (~2 KB/thread at DV=512).
-//   - DK is split across the subgroup too; partial dots reduce via
-//     sub_group_reduce_add — no per-iteration barriers in the inner loop.
-//   - Cross-subgroup merge uses __local for sg_m / sg_l / sg_o (~4 KB at
-//     NSG=2, DV=512); one subgroup performs the final norm + write.
-// REQD_SUBGROUP_SIZE_64 ensures the subgroup width matches what the
-// dot/o_acc striding assumes (Adreno X2 miscompiles full-subgroup reduces
-// without the explicit attribute; see ssm_scan notes).
-
+// decode variant for large DV (e.g. Gemma-4 DK=DV=512 global layers).
 #define VEC_NSG          4
 #define VEC_WG_SIZE      (Q1_WG_SIZE * VEC_NSG)
 #define Q1V_DV_PER_THREAD ((DV_VEC + Q1_WG_SIZE - 1) / Q1_WG_SIZE)
 
-// FA_DECODE_MINIMAL: the DK=512 (Gemma-4 global-layer) decode program drops the
-// q1_vec kernel too — its DV=512 vector arrays + REQD_SUBGROUP_SIZE_64 dominate the
-// program's shader-compiler host-memory footprint (the OOM that made DK=512 builds
-// fragile under load), and on Adreno X1 REQD_SUBGROUP_SIZE_64 routes to a slow
-// fallback variant anyway. The minimal program keeps q1 + q1_split + merge, which is
-// correct for decode at any depth; dispatch falls back from q1_vec to q1 cleanly.
+// allow bypassing the kernel to avoid compiler crash for DK=512 on Adreno GPUs
 #ifndef FA_DECODE_MINIMAL
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_vec(
@@ -898,16 +856,15 @@ __kernel void flash_attn_f32_f16_q1_vec(
         sinks_ptr = (const global ACC_TYPE *) ((const global char *) sinks_void + sinks_offset);
     }
 
-    // Per-thread DV slice within its subgroup. For DV=512 / 64-wide subgroup
-    // this is 2 float4 = 32 bytes; for DV=256, 1 float4. Cheap in registers —
-    // replaces the o_acc[DV_VEC] per-thread spill (~2 KB at DV=512).
+    // per-thread DV slice within its subgroup
+    // DV=512 -> 2x float4 = 32 bytes; DV=256 -> 1x float4 - no spill
     ACC_TYPE4 o_acc[Q1V_DV_PER_THREAD];
     #pragma unroll
     for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[i] = (ACC_TYPE4)(0.0f);
 
-    // Each subgroup independently runs the FA-2 online softmax over its slice
-    // of n_kv. Sinks are NOT folded into per-subgroup m_i — they're added once
-    // in the cross-subgroup merge to avoid double-counting.
+    // each subgroup independently runs the FA-2 online softmax over its slice of n_kv.
+    // sinks are not folded into per-subgroup m_i — they're added once in
+    // the cross-subgroup merge to avoid double-counting.
     ACC_TYPE m_i = FA_M_INIT;
     ACC_TYPE l_i = 0.0f;
 
@@ -1009,41 +966,12 @@ __kernel void flash_attn_f32_f16_q1_vec(
     }
 }
 
-#endif  // !FA_DECODE_MINIMAL (q1_vec excluded for the minimal DK=512 decode program)
+#endif  // !FA_DECODE_MINIMAL
 
-#ifndef FA_DECODE_ONLY  // MQ / local-tile decode variants — excluded for the DK=512 decode-only program (minimal program keeps q1 + q1_split + merge)
-// Multi-Query coalesced vec decode (KV-head-coalesced WG dispatch).
-//
-// At high GQA + DK>=256 + small n_head_kv (e.g. Gemma-3-1B: n_head=4,
-// n_head_kv=1, gqa_ratio=4), the standard q1_vec dispatches gqa_ratio WGs
-// per KV head and each WG re-reads the same KV stream from DDR. For a 1B
-// model where attention dominates decode, that 4× K bandwidth overhead is
-// the bottleneck — fa=1 lands at ~40% of fa=0 instead of the ~90% seen on
-// larger models where attention is a smaller fraction of the work.
-//
-// This variant coalesces gqa_ratio Q-heads sharing one KV-head into ONE
-// WG. K and V are read once per cache step and reused across MQ_GQA Q rows,
-// each maintaining its own (m_i, l_i, o_acc) online-softmax state. Output
-// writes MQ_GQA rows from one WG.
-//
-// Differs from Metal's vec FA: Metal does NOT coalesce — it relies on L2
-// reuse across gqa_ratio sibling WGs. Adreno's L2 doesn't amortize the
-// reuse strongly enough on small models, so we coalesce explicitly.
-//
-// Currently compile-locked to MQ_GQA=4 (covers Gemma-3 family); other GQA
-// ratios still fall back to legacy q1 / q1_vec at the dispatch site.
+#ifndef FA_DECODE_ONLY
 
-// ---------------------------------------------------------------------------
-// flash_attn_f32_f16_q1_local_tile — alternative decode FA design:
-// one WG per (q_idx, q_head). Stages K/V into __local tiles of
-// LT_KC rows. Per K-step, all LT_WG=DK lanes co-compute one Q·K dot via a
-// pure __local tree-reduce (no subgroup primitives), broadcast the score,
-// then each lane updates ONE float of its private o_val (D-split, not
-// DV-split). Trades K-bandwidth (no Q-head coalescing, K read by every Q
-// head's WG) for parallelism (n_head WGs in flight instead of n_head_kv).
-// Compiled only at DK=DV=128 and registered at WG=DK=128 (LT_WG match).
-// Dispatch is gated behind GGML_OPENCL_FA_LOCAL_TILE=1.
-// ---------------------------------------------------------------------------
+// flash_attn_f32_f16_q1_local_tile
+// one WG per (q_idx, q_head)
 
 #define LT_KC 32
 #define LT_WG 128
@@ -1189,23 +1117,7 @@ __kernel void flash_attn_f32_f16_q1_local_tile(
     o_row[tid] = o_val * l_inv;
 }
 
-// ---------------------------------------------------------------------------
-// flash_attn_f32_f16_q1_local_mq_split — hybrid local-tile + MQ + FD-split.
-// Combines the 3 levers identified while evaluating local_tile:
-//   1. Q-head coalescing (MQ_GQA Q rows per WG share one KV slice)
-//   2. sub_group_reduce_add for the dot (1 reduce vs tree-reduce's 7 barriers)
-//   3. Flash-decoding split along n_kv (n_splits WGs per kv_head)
-// Plus the __local K/V tile from local_tile (re-use within each tile).
-//
-// WG layout: 1 subgroup of 64 lanes. Each lane owns DK/64 = 2 D-elements at
-// indices (tid*LMQ_DPL .. tid*LMQ_DPL+1). MQ_GQA per-h state lives in
-// private registers (o_acc[MQ_GQA][LMQ_DPL], m_i[MQ_GQA], l_i[MQ_GQA]).
-//
-// Grid: (LMQ_WG, n_head_kv * n_batch, n_splits * n_q). Compiled at DK=DV=128.
-// MQ_GQA=4 default + second compile MQ_GQA=8 alongside the existing MQ split
-// kernels (shared MQ_GQA macro). Writes one partial record per (h, split);
-// flash_attn_f32_merge reused for normalization.
-// ---------------------------------------------------------------------------
+// flash_attn_f32_f16_q1_local_mq_split
 
 #define LMQ_WG  64
 #define LMQ_KC  32
@@ -1396,8 +1308,7 @@ __kernel void flash_attn_f32_f16_q1_local_mq_split(
         barrier(CLK_LOCAL_MEM_FENCE);  // Before next tile load overwrites k/v_tile.
     }
 
-    // Write partial records: one per (h, split). Each lane writes its
-    // LMQ_DPL D-positions of o_acc[h]; merge kernel rescales across splits.
+    // write partial records: one per (h, split)
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
         const int head_idx = head_kv_idx * MQ_GQA + h;
@@ -1418,15 +1329,6 @@ __kernel void flash_attn_f32_f16_q1_local_mq_split(
     }
 }
 
-// MQ collapses one WG per KV-head (vs one per Q-head in legacy q1_vec).
-// Wanted NSG=8 or 16 to compensate for the wavefront-count loss after the
-// head-dim collapse, but Adreno X2's per-kernel CL_KERNEL_WORK_GROUP_SIZE
-// for this signature is 320 — only NSG=4 / WG=256 is reliably dispatchable.
-// At that NSG this kernel benches worse than legacy q1_vec on the target
-// model (Gemma-3-1B tg@d=0 = 60 t/s vs 72 legacy), so it's compiled but
-// not dispatched in the host code. The win came from pairing MQ with the
-// flash-decoding split (q1_vec_mq_split below) — that's the path host
-// dispatch uses at n_kv >= FD_MIN_N_KV.
 #ifndef MQ_NSG
 #define MQ_NSG 4
 #endif
@@ -1475,8 +1377,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
     const global char * k_base = (const global char *) k_void + k_offset;
     const global char * v_base = (const global char *) v_void + v_offset;
     global       char * o_base = (global       char *) o_void + o_offset;
-
-    // Q for all MQ_GQA heads staged in __local once (~4 KB at DK=256).
+.
     __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_WG_SIZE) {
         const int h        = i / DK_VEC;
@@ -1488,16 +1389,14 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    // Per-h ALiBi slope (cheap: 4 floats).
+    // per-h ALiBi slope
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
         slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
     }
 
-    // Per-h mask row pointer. mask_ne2 is usually 1 (broadcast across heads),
-    // in which case all mask_base[h] coincide — but the indexing math handles
-    // both cases.
+    // per-h mask row pointer
     const global char * mask_base[MQ_GQA];
     if (mask_void != NULL) {
         const int mask_batch_idx = batch_idx % mask_ne3;
@@ -1519,8 +1418,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
         sinks_ptr = (const global ACC_TYPE *) ((const global char *) sinks_void + sinks_offset);
     }
 
-    // Per-thread per-h DV slice. At DK=DV=256 / 64-wide sg, Q1V_DV_PER_THREAD=1,
-    // so this is MQ_GQA float4 = 64 bytes per thread.
+    // per-thread per-h DV slice.
     ACC_TYPE4 o_acc[MQ_GQA][Q1V_DV_PER_THREAD];
     ACC_TYPE  m_i[MQ_GQA];
     ACC_TYPE  l_i[MQ_GQA];
@@ -1532,8 +1430,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
     }
 
-    // Each subgroup independently sweeps its slice of n_kv. K and V are
-    // loaded once per cache step and reused MQ_GQA times.
+    // each subgroup independently sweeps its slice of n_kv.
     const int kv_per_sg = (n_kv + MQ_NSG - 1) / MQ_NSG;
     const int kv_start  = sgid * kv_per_sg;
     const int kv_end    = min(n_kv, kv_start + kv_per_sg);
@@ -1595,11 +1492,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
         }
     }
 
-    // Cross-subgroup merge — per-h to keep LDS bounded at NSG=16.
-    //   sg_m, sg_l: [MQ_GQA][MQ_NSG] floats (tiny).
-    //   sg_o: [MQ_NSG][DV_VEC] float4, REUSED across h via barriers.
-    // At MQ_NSG=16, DV=256: sg_o = 16 KB; +4 KB q_shared ≈ 20 KB total LDS.
-    // (Storing all h at once would need 4×16 KB sg_o = 64 KB, exceeding 32 KB.)
+    // cross subgroup merge
     __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG];
     __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG];
     __local ACC_TYPE4 sg_o[MQ_NSG][DV_VEC];
@@ -1614,7 +1507,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
 
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        // Each subgroup publishes its o_acc slice for head h.
+        // each subgroup publishes its o_acc slice for head h.
         {
             int idx = 0;
             for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
@@ -1661,18 +1554,6 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 }
-
-// KV-head-coalesced + flash-decoding split. Pairs the MQ_GQA coalescing
-// (gqa_ratio Q-heads share one KV stream) with flash-decoding (n_splits WGs
-// per (kv_head, batch) along n_kv). One WG = (kv_head, batch, split):
-//   total WGs = n_head_kv * n_batch * n_splits, each WG = MQ_NSG_SPLIT
-//   subgroups × 64 lanes.
-// For Gemma-3-1B at d=16k (n_head_kv=1, n_batch=1, n_splits=8, NSG=8):
-//   8 WGs × 8 sg = 64 wavefronts (vs 16 for the single-WG MQ kernel and
-//   16 for legacy 4 WGs × 4 sg). Restores per-CU occupancy on Adreno X2
-//   while keeping the 4× K-bandwidth saving from MQ coalescing.
-// Output: MQ_GQA partial records per WG, format identical to
-// `flash_attn_f32_f16_q1_split` so the same merge kernel applies.
 
 #ifndef MQ_NSG_SPLIT
 #define MQ_NSG_SPLIT 4
@@ -1729,8 +1610,8 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     const ulong record_stride = (ulong) FA_PARTIAL_FLOATS;
 
     if (kv_start >= kv_end) {
-        // Empty split — write sentinel for each of the MQ_GQA Q-heads so the
-        // merge pass treats this slot as dropped (exp(-INF)=0 contribution).
+        // write sentinel for each of the MQ_GQA Q-heads so the
+        // merge pass treats this slot as dropped
         if (tid == 0) {
             #pragma unroll
             for (int h = 0; h < MQ_GQA; ++h) {
@@ -1749,7 +1630,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     const global char * k_base = (const global char *) k_void + k_offset;
     const global char * v_base = (const global char *) v_void + v_offset;
 
-    // Stage MQ_GQA Q rows in __local once (uniform across WG).
+    // stage MQ_GQA Q rows in __local once (uniform across WG)
     __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE) {
         const int h        = i / DK_VEC;
@@ -1795,7 +1676,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
     }
 
-    // Each subgroup independently sweeps its slice of the split's kv range.
+    // each subgroup independently sweeps its slice of the split's kv range.
     const int kv_len   = kv_end - kv_start;
     const int kv_per_sg = (kv_len + MQ_NSG_SPLIT - 1) / MQ_NSG_SPLIT;
     const int kv_lo    = kv_start + sgid * kv_per_sg;
@@ -1854,8 +1735,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         }
     }
 
-    // Per-h cross-subgroup merge: subgroup 0 folds NSG partials into a single
-    // (m, l, O) record per Q-head, written to the partial buffer.
+    // per-h cross-subgroup merge
     __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG_SPLIT];
     __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG_SPLIT];
     __local ACC_TYPE4 sg_o[MQ_NSG_SPLIT][DV_VEC];
@@ -1881,9 +1761,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         if (sgid == 0) {
             const int head_idx = head_kv_idx * MQ_GQA + h;
 
-            // Fold per-subgroup (m, l) into split-level (m_c, l_c). Note: the
-            // partial record stores RAW O (un-normalized), so the merge kernel
-            // can rescale across splits with exp(m_c - m_final).
+            // fold per-subgroup (m, l) into split-level (m_c, l_c)
             ACC_TYPE m_c = sg_m[h][0];
             #pragma unroll
             for (int s = 1; s < MQ_NSG_SPLIT; ++s) {
@@ -1904,7 +1782,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
                 rec[0] = (float) m_c;
                 rec[1] = (float) l_c;
             }
-            // Each thread writes its DV slice of the merged O.
+            // each thread writes its DV slice of the merged O.
             for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE) {
                 ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
                 #pragma unroll
@@ -1918,27 +1796,6 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 }
-
-// K-image variant of _q1_vec_mq_split.
-//
-// K is bound as a __read_only image1d_buffer_t (CL_RGBA, CL_HALF_FLOAT —
-// 8-byte pixels = 1 half4) over a sub-buffer covering the K cache for
-// this call. Adreno's texture cache is a separate BW path from L2 and
-// dramatically outperforms __global K reads at long context (the
-// _x8_gqa4_img port at the mul_mat layer gave +244% on KQ decode at
-// d=16k). FA's split-path K access pattern (NSG_SPLIT subgroups each
-// stream a contiguous slice of n_kv) is the same shape, so the same
-// texture-cache win should apply.
-//
-// V stays on __global: V's inner loop is long (DV_VEC iters per K
-// position) and arithmetic-intensity hides V latency, so the texture
-// cache adds latency without enough memory-stall to mask (the
-// _y8_gqa_img port at mul_mat regressed -13% for this reason).
-//
-// k_offset is NOT a kernel arg: the sub-buffer is created host-side
-// with CL_BUFFER_CREATE_TYPE_REGION (origin = offset_k), so image
-// addressing is relative to the sub-buffer start. Pixel pitches come
-// from the byte strides via (k_nb >> 3) since each pixel = 8 B.
 
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
@@ -2048,7 +1905,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
     }
 
-    // K pitches in pixel units. Pixel = 1 half4 = 8 B → byte_stride >> 3.
+    // K pitches in pixel units, pixel = 1 half4 = 8 B -> byte_stride >> 3.
     const int pitch_px_row   = (int)(k_nb1 >> 3);
     const int pitch_px_head  = (int)(k_nb2 >> 3);
     const int pitch_px_batch = (int)(k_nb3 >> 3);
@@ -2172,9 +2029,8 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 }
+#endif  // !FA_DECODE_ONLY
 
-
-#endif  // !FA_DECODE_ONLY (vec / MQ / local-tile decode variants)
 __kernel void flash_attn_f32_f16_q1_split(
     const global void * q_void, ulong q_offset,
     const global void * k_void, ulong k_offset,
@@ -2244,7 +2100,7 @@ __kernel void flash_attn_f32_f16_q1_split(
                     (ulong) q_idx * mask_nb1;
     }
 
-    // Share Q via local memory (n_q=1 per split -> uniform across WG).
+    // share Q via local memory (n_q=1 per split -> uniform across WG).
     __local ACC_TYPE4 q_shared[DK_VEC];
     const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
     const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
@@ -2255,7 +2111,7 @@ __kernel void flash_attn_f32_f16_q1_split(
 
     const float slope = get_alibi_slope(max_bias, head_idx, n_head_log2, m0, m1);
 
-    // Pass 1a — split-local max.
+    // pass 1a — split-local max.
     ACC_TYPE m_i = FA_M_INIT;
     for (int k_idx = kv_start + tid; k_idx < kv_end; k_idx += Q1_WG_SIZE) {
         const ulong k_row_offset = batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
@@ -2278,7 +2134,7 @@ __kernel void flash_attn_f32_f16_q1_split(
 
     const ACC_TYPE m_c = sub_group_reduce_max(m_i);
 
-    // Pass 1b — softmax-weighted V accumulate.
+    // pass 1b — softmax-weighted V accumulate.
     ACC_TYPE4 o_acc[DV_VEC];
     #pragma unroll
     for (int i = 0; i < DV_VEC; ++i) o_acc[i] = (ACC_TYPE4)(0.0f);
@@ -2331,7 +2187,8 @@ __kernel void flash_attn_f32_f16_q1_split(
     }
 }
 
-// FD Pass 2: merge per-split partials into final O. Empty splits drop via exp(-INF)=0.
+// FD Pass 2: merge per-split partials into final O
+// empty splits drop via exp(-INF)=0.
 __kernel void flash_attn_f32_merge(
     const global float * partial_void,
     global void * o_void,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -13,6 +13,23 @@
 #define REQD_SUBGROUP_SIZE_64
 #endif
 
+// Subgroup width the q1-family kernels stripe the dot/o_acc over and reduce
+// across (sub_group_reduce_*). Defaults to the Adreno default sg (64); the host
+// overrides it with -D FA_SG=<device sg> on non-Adreno GPUs. REQD_FA_SG pins the
+// width on Intel (intel_reqd_sub_group_size), where the WG would otherwise split
+// into multiple narrower subgroups and the reduces would cover only part of it.
+// Left empty on Adreno: the qcom default sg already equals FA_SG=64 there, and
+// the explicit attribute regresses sibling kernels (see the q1_vec note below).
+#ifndef FA_SG
+#define FA_SG 64
+#endif
+#ifdef cl_intel_required_subgroup_size
+#pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
+#define REQD_FA_SG __attribute__((intel_reqd_sub_group_size(FA_SG)))
+#else
+#define REQD_FA_SG
+#endif
+
 #ifdef cl_khr_subgroup_shuffle
 #pragma OPENCL EXTENSION cl_khr_subgroup_shuffle : enable
 #define HAS_SUBGROUP_SHUFFLE 1
@@ -38,7 +55,7 @@
 #ifndef FA_PARTIAL_FLOATS
 #define FA_PARTIAL_FLOATS (2 + DV)
 #endif
-#define Q1_WG_SIZE 64
+#define Q1_WG_SIZE FA_SG
 
 // The kernels are built with -cl-finite-math-only. On some older Adreno GPUs,
 // infinite operand can cause undefined behavior and miscompilation for exp.
@@ -625,6 +642,7 @@ __kernel void FA_TILE_NAME(
 // above; every decode kernel below is excluded so the tile compiles in its own
 // minimal program (the full program OOMs the Adreno compiler at DK=512).
 #ifndef FA_PREFILL_ONLY
+REQD_FA_SG
 __kernel void flash_attn_f32_f16_q1(
     const global void * q_void, ulong q_offset,
     const global void * k_void, ulong k_offset,
@@ -800,6 +818,13 @@ __kernel void flash_attn_f32_f16_q1(
 #define VEC_WG_SIZE      (Q1_WG_SIZE * VEC_NSG)
 #define Q1V_DV_PER_THREAD ((DV_VEC + Q1_WG_SIZE - 1) / Q1_WG_SIZE)
 
+// FA_DECODE_MINIMAL: the DK=512 (Gemma-4 global-layer) decode program drops the
+// q1_vec kernel too — its DV=512 vector arrays + REQD_SUBGROUP_SIZE_64 dominate the
+// program's shader-compiler host-memory footprint (the OOM that made DK=512 builds
+// fragile under load), and on Adreno X1 REQD_SUBGROUP_SIZE_64 routes to a slow
+// fallback variant anyway. The minimal program keeps q1 + q1_split + merge, which is
+// correct for decode at any depth; dispatch falls back from q1_vec to q1 cleanly.
+#ifndef FA_DECODE_MINIMAL
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_vec(
     const global void * q_void, ulong q_offset,
@@ -984,7 +1009,9 @@ __kernel void flash_attn_f32_f16_q1_vec(
     }
 }
 
-#ifndef FA_DECODE_ONLY  // MQ / local-tile decode variants — excluded for the DK=512 decode-only program (q1 + q1_vec + q1_split + merge kept)
+#endif  // !FA_DECODE_MINIMAL (q1_vec excluded for the minimal DK=512 decode program)
+
+#ifndef FA_DECODE_ONLY  // MQ / local-tile decode variants — excluded for the DK=512 decode-only program (minimal program keeps q1 + q1_split + merge)
 // Multi-Query coalesced vec decode (KV-head-coalesced WG dispatch).
 //
 // At high GQA + DK>=256 + small n_head_kv (e.g. Gemma-3-1B: n_head=4,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -33,6 +33,11 @@
 
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
+// Hoisted to file scope so the kept decode kernels (q1_split, merge) still see
+// it when FA_DECODE_ONLY excludes the vec/MQ block that originally defined it.
+#ifndef FA_PARTIAL_FLOATS
+#define FA_PARTIAL_FLOATS (2 + DV)
+#endif
 #define Q1_WG_SIZE 64
 
 // The kernels are built with -cl-finite-math-only. On some older Adreno GPUs,
@@ -72,9 +77,26 @@ inline float get_alibi_slope(
 
     return pow(base, exph);
 }
-__kernel void flash_attn_f32_f16(
+// FA_DECODE_ONLY: built for DK=512 (Gemma-4 global layers) where compiling the
+// full program OOMs the Adreno shader compiler (CL_OUT_OF_HOST_MEMORY). The
+// decode-only build keeps just q1 + q1_split + merge; the heavy BM-tile prefill
+// kernel and all vec/MQ variants are excluded so the program fits the compiler.
+#ifndef FA_DECODE_ONLY
+#ifndef FA_TILE_NAME
+#define FA_TILE_NAME flash_attn_f32_f16
+#endif
+__kernel void FA_TILE_NAME(
     const global void * q_void, ulong q_offset,
+#ifdef FA_K_IMG
+    // K bound as a read-only image1d_buffer_t (CL_RGBA / CL_HALF_FLOAT, 8 B/pixel
+    // = 1 half4) → reads go through the Adreno texture cache, a separate BW lane
+    // that survives the per-query-block K re-reads. k_offset is baked into the
+    // sub-buffer the image views, so the second slot is an unused placeholder
+    // kept only so the host arg layout matches the non-image tile.
+    __read_only image1d_buffer_t k_img, ulong k_offset_unused,
+#else
     const global void * k_void, ulong k_offset,
+#endif
     const global void * v_void, ulong v_offset,
     global void * o_void, ulong o_offset,
     const float scale,
@@ -134,7 +156,9 @@ __kernel void flash_attn_f32_f16(
     const int mask_batch_idx = mask_void != NULL ? batch_idx % mask_ne3 : 0;
 
     const global char* q_base = (const global char*)q_void + q_offset;
+#ifndef FA_K_IMG
     const global char* k_base = (const global char*)k_void + k_offset;
+#endif
     const global char* v_base = (const global char*)v_void + v_offset;
     global char* o_base = (global char*)o_void + o_offset;
 
@@ -202,7 +226,16 @@ __kernel void flash_attn_f32_f16(
         const ulong k_tile_nb3 = use_kv_pad ? (ulong) n_head_kv * k_tile_nb2 : k_nb3;
         const ulong v_tile_nb2 = use_kv_pad ? (ulong) BLOCK_N * v_nb1 : v_nb2;
         const ulong v_tile_nb3 = use_kv_pad ? (ulong) n_head_kv * v_tile_nb2 : v_nb3;
+#ifdef FA_K_IMG
+        // K via texture cache for the bulk (aligned) tiles; the ragged last
+        // tile (use_kv_pad) still reads the f32-strided pad buffer from global.
+        const global char* k_tile_base = use_kv_pad ? (const global char*) k_pad_void : (const global char*) 0;
+        const int k_pitch_px_row   = (int)(k_nb1 >> 3);
+        const int k_pitch_px_head  = (int)(k_nb2 >> 3);
+        const int k_pitch_px_batch = (int)(k_nb3 >> 3);
+#else
         const global char* k_tile_base = use_kv_pad ? (const global char*) k_pad_void : k_base;
+#endif
         const global char* v_tile_base = use_kv_pad ? (const global char*) v_pad_void : v_base;
 
         for (int i = tid; i < BLOCK_N * DK_VEC; i += WG_SIZE) {
@@ -210,8 +243,18 @@ __kernel void flash_attn_f32_f16(
             const int col = i % DK_VEC;
             const int k_row_idx = k_tile_start + row;
             if (use_kv_pad || k_row_idx < n_kv) {
+#ifdef FA_K_IMG
+                if (use_kv_pad) {
+                    const ulong k_row_offset = batch_idx * k_tile_nb3 + head_kv_idx * k_tile_nb2 + k_row_idx * k_nb1;
+                    l_k[row][col] = ((__global KV_DATA_TYPE4*)(k_tile_base + k_row_offset))[col];
+                } else {
+                    const int k_row_px = batch_idx * k_pitch_px_batch + head_kv_idx * k_pitch_px_head + k_row_idx * k_pitch_px_row;
+                    l_k[row][col] = read_imageh(k_img, k_row_px + col);
+                }
+#else
                 const ulong k_row_offset = batch_idx * k_tile_nb3 + head_kv_idx * k_tile_nb2 + k_row_idx * k_nb1;
                 l_k[row][col] = ((__global KV_DATA_TYPE4*)(k_tile_base + k_row_offset))[col];
+#endif
             } else {
                 l_k[row][col] = (KV_DATA_TYPE4)(0.0h);
             }
@@ -576,6 +619,12 @@ __kernel void flash_attn_f32_f16(
 // _q1_vec at d=8192. At WG=Q1_WG_SIZE=64 the Adreno default sg=64, so
 // sub_group_reduce_max/add and sub_group_barrier produce correct WG-wide
 // semantics without the explicit attribute (TBO 2564/2564).
+#endif  // !FA_DECODE_ONLY (BM-tile prefill kernel)
+
+// FA_PREFILL_ONLY: the DK=512 prefill program builds ONLY the BM-tile kernel
+// above; every decode kernel below is excluded so the tile compiles in its own
+// minimal program (the full program OOMs the Adreno compiler at DK=512).
+#ifndef FA_PREFILL_ONLY
 __kernel void flash_attn_f32_f16_q1(
     const global void * q_void, ulong q_offset,
     const global void * k_void, ulong k_offset,
@@ -616,7 +665,9 @@ __kernel void flash_attn_f32_f16_q1(
     const int head_kv_idx = head_idx / gqa_ratio;
 
     const global char* q_base = (const global char*)q_void + q_offset;
+#ifndef FA_K_IMG
     const global char* k_base = (const global char*)k_void + k_offset;
+#endif
     const global char* v_base = (const global char*)v_void + v_offset;
     global char* o_base = (global char*)o_void + o_offset;
 
@@ -933,6 +984,7 @@ __kernel void flash_attn_f32_f16_q1_vec(
     }
 }
 
+#ifndef FA_DECODE_ONLY  // MQ / local-tile decode variants — excluded for the DK=512 decode-only program (q1 + q1_vec + q1_split + merge kept)
 // Multi-Query coalesced vec decode (KV-head-coalesced WG dispatch).
 //
 // At high GQA + DK>=256 + small n_head_kv (e.g. Gemma-3-1B: n_head=4,
@@ -2095,6 +2147,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
 }
 
 
+#endif  // !FA_DECODE_ONLY (vec / MQ / local-tile decode variants)
 __kernel void flash_attn_f32_f16_q1_split(
     const global void * q_void, ulong q_offset,
     const global void * k_void, ulong k_offset,
@@ -2324,3 +2377,4 @@ __kernel void flash_attn_f32_merge(
     global O_DATA_TYPE4 * o_row = (global O_DATA_TYPE4 *) ((global char *) o_void + o_offset + o_row_offset);
     o_row[lane] = CONVERT_O_DATA4(o);
 }
+#endif  // !FA_PREFILL_ONLY (decode kernels)

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -1,5 +1,18 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
+#ifdef cl_intel_subgroups
+#pragma OPENCL EXTENSION cl_intel_subgroups : enable
+#else
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+#endif
+
+#ifdef cl_qcom_reqd_sub_group_size
+#pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
+#define REQD_SUBGROUP_SIZE_64 __attribute__((qcom_reqd_sub_group_size("half")))
+#else
+#define REQD_SUBGROUP_SIZE_64
+#endif
+
 #ifdef cl_khr_subgroup_shuffle
 #pragma OPENCL EXTENSION cl_khr_subgroup_shuffle : enable
 #define HAS_SUBGROUP_SHUFFLE 1
@@ -725,9 +738,1117 @@ __kernel void flash_attn_f32_f16_q1(
     }
 }
 
-// Flash-decoding split pass. gid(2) = q_idx * n_splits + split_idx.
-// Partial record per split: [m, l, O[DV]]. Merge kernel applies sink + norm.
+// Decode variant for large DV (e.g. Gemma-4 DK=DV=512 global layers).
+// Mirrors ggml-metal's kernel_flash_attn_ext_vec design:
+//   - WG = VEC_NSG subgroups × 64 lanes. Each subgroup runs the FA-2 online
+//     softmax loop independently over its slice of n_kv, then a __local merge
+//     combines (m_i, l_i, o_acc) across subgroups. This restores the n_kv
+//     parallelism that a single-subgroup vec port loses.
+//   - DV is split across the subgroup (each thread owns DV_VEC/64 of o_acc);
+//     this kills the o_acc[DV_VEC] private-array spill (~2 KB/thread at DV=512).
+//   - DK is split across the subgroup too; partial dots reduce via
+//     sub_group_reduce_add — no per-iteration barriers in the inner loop.
+//   - Cross-subgroup merge uses __local for sg_m / sg_l / sg_o (~4 KB at
+//     NSG=2, DV=512); one subgroup performs the final norm + write.
+// REQD_SUBGROUP_SIZE_64 ensures the subgroup width matches what the
+// dot/o_acc striding assumes (Adreno X2 miscompiles full-subgroup reduces
+// without the explicit attribute; see ssm_scan notes).
+
+#define VEC_NSG          4
+#define VEC_WG_SIZE      (Q1_WG_SIZE * VEC_NSG)
+#define Q1V_DV_PER_THREAD ((DV_VEC + Q1_WG_SIZE - 1) / Q1_WG_SIZE)
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_f16_q1_vec(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    global void * o_void, ulong o_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int is_causal,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const ulong o_nb1, const ulong o_nb2, const ulong o_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void* mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    const global void* sinks_void,
+    const ulong sinks_offset
+) {
+    const int tid             = get_local_id(0);
+    const int sgid            = tid / Q1_WG_SIZE;   // subgroup index (0..VEC_NSG-1)
+    const int tid_sg          = tid % Q1_WG_SIZE;   // lane within subgroup
+    const int head_batch_idx  = get_global_id(1);
+
+    const int batch_idx = head_batch_idx / n_head;
+    const int head_idx  = head_batch_idx % n_head;
+
+    const int gqa_ratio   = n_head / n_head_kv;
+    const int head_kv_idx = head_idx / gqa_ratio;
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+    global       char * o_base = (global       char *) o_void + o_offset;
+
+    const global char * mask_base = NULL;
+    if (mask_void != NULL) {
+        const int mask_head_idx  = head_idx  % mask_ne2;
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        mask_base = (const global char *) mask_void + mask_offset +
+                    mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2;
+    }
+
+    // Q is uniform across the WG — stage in __local once. All WG threads load.
+    __local ACC_TYPE4 q_shared[DK_VEC];
+    {
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        for (int i = tid; i < DK_VEC; i += VEC_WG_SIZE) {
+            q_shared[i] = CONVERT_Q_ACC4(q_ptr[i]);
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const float slope = get_alibi_slope(max_bias, head_idx, n_head_log2, m0, m1);
+
+    const global ACC_TYPE * sinks_ptr = NULL;
+    if (sinks_void != NULL) {
+        sinks_ptr = (const global ACC_TYPE *) ((const global char *) sinks_void + sinks_offset);
+    }
+
+    // Per-thread DV slice within its subgroup. For DV=512 / 64-wide subgroup
+    // this is 2 float4 = 32 bytes; for DV=256, 1 float4. Cheap in registers —
+    // replaces the o_acc[DV_VEC] per-thread spill (~2 KB at DV=512).
+    ACC_TYPE4 o_acc[Q1V_DV_PER_THREAD];
+    #pragma unroll
+    for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[i] = (ACC_TYPE4)(0.0f);
+
+    // Each subgroup independently runs the FA-2 online softmax over its slice
+    // of n_kv. Sinks are NOT folded into per-subgroup m_i — they're added once
+    // in the cross-subgroup merge to avoid double-counting.
+    ACC_TYPE m_i = -INFINITY;
+    ACC_TYPE l_i = 0.0f;
+
+    const int kv_per_sg = (n_kv + VEC_NSG - 1) / VEC_NSG;
+    const int kv_start  = sgid * kv_per_sg;
+    const int kv_end    = min(n_kv, kv_start + kv_per_sg);
+
+    for (int k_idx = kv_start; k_idx < kv_end; ++k_idx) {
+        const ulong k_row_off = batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
+        const ulong v_row_off = batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+        const global KV_DATA_TYPE4 * k_ptr = (const global KV_DATA_TYPE4 *) (k_base + k_row_off);
+        const global KV_DATA_TYPE4 * v_ptr = (const global KV_DATA_TYPE4 *) (v_base + v_row_off);
+
+        // Q*K^T: each thread accumulates its DK slice; subgroup-reduce the partial.
+        ACC_TYPE4 dot4 = (ACC_TYPE4)(0.0f);
+        for (int k = tid_sg; k < DK_VEC; k += Q1_WG_SIZE) {
+            dot4 = mad(q_shared[k], CONVERT_KV_ACC4(k_ptr[k]), dot4);
+        }
+        ACC_TYPE dot_partial = dot4.s0 + dot4.s1 + dot4.s2 + dot4.s3;
+        ACC_TYPE score = sub_group_reduce_add(dot_partial) * scale;
+
+        if (mask_base != NULL) {
+            const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base;
+            score += slope * (ACC_TYPE) mask_ptr[k_idx];
+        }
+        if (logit_softcap > 0.0f) {
+            score = logit_softcap * tanh(score / logit_softcap);
+        }
+
+        // FA-2 online update. All threads in the subgroup see the same score,
+        // so m_i and l_i evolve identically across lanes within the subgroup.
+        const ACC_TYPE m_new      = max(m_i, score);
+        const ACC_TYPE scale_prev = native_exp(m_i - m_new);
+        const ACC_TYPE p          = native_exp(score - m_new);
+
+        int idx = 0;
+        for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+            o_acc[idx] = mad(p, CONVERT_KV_ACC4(v_ptr[dv_idx]), o_acc[idx] * scale_prev);
+        }
+        l_i = l_i * scale_prev + p;
+        m_i = m_new;
+    }
+
+    // Cross-subgroup merge via __local. Each subgroup publishes (m_i, l_i)
+    // and its o_acc slice; subgroup 0 then folds them into the final norm
+    // and writes the row.
+    __local ACC_TYPE  sg_m[VEC_NSG];
+    __local ACC_TYPE  sg_l[VEC_NSG];
+    __local ACC_TYPE4 sg_o[VEC_NSG][DV_VEC];
+
+    if (tid_sg == 0) {
+        sg_m[sgid] = m_i;
+        sg_l[sgid] = l_i;
+    }
+    {
+        int idx = 0;
+        for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+            sg_o[sgid][dv_idx] = o_acc[idx];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (sgid == 0) {
+        // m_final = max over all subgroups' m_i, plus the sink (if any).
+        ACC_TYPE m_final = sg_m[0];
+        #pragma unroll
+        for (int s = 1; s < VEC_NSG; ++s) {
+            m_final = max(m_final, sg_m[s]);
+        }
+        if (sinks_ptr != NULL) {
+            m_final = max(m_final, sinks_ptr[head_idx]);
+        }
+
+        ACC_TYPE l_final = 0.0f;
+        #pragma unroll
+        for (int s = 0; s < VEC_NSG; ++s) {
+            l_final += sg_l[s] * native_exp(sg_m[s] - m_final);
+        }
+        if (sinks_ptr != NULL) {
+            l_final += native_exp(sinks_ptr[head_idx] - m_final);
+        }
+        const ACC_TYPE l_inv = (l_final > 0.0f) ? (1.0f / l_final) : 0.0f;
+
+        const ulong o_row_offset = batch_idx * o_nb3 + head_idx * o_nb1;
+        global O_DATA_TYPE4 * o_row = (global O_DATA_TYPE4 *) (o_base + o_row_offset);
+
+        // Each thread in subgroup 0 writes its DV slice, folding all subgroups'
+        // contributions with the rescale factor.
+        int idx = 0;
+        for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+            ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+            #pragma unroll
+            for (int s = 0; s < VEC_NSG; ++s) {
+                const ACC_TYPE alpha = native_exp(sg_m[s] - m_final);
+                o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv_idx], o_merged);
+            }
+            o_row[dv_idx] = CONVERT_O_DATA4(o_merged * l_inv);
+        }
+    }
+}
+
+// Multi-Query coalesced vec decode (KV-head-coalesced WG dispatch).
+//
+// At high GQA + DK>=256 + small n_head_kv (e.g. Gemma-3-1B: n_head=4,
+// n_head_kv=1, gqa_ratio=4), the standard q1_vec dispatches gqa_ratio WGs
+// per KV head and each WG re-reads the same KV stream from DDR. For a 1B
+// model where attention dominates decode, that 4× K bandwidth overhead is
+// the bottleneck — fa=1 lands at ~40% of fa=0 instead of the ~90% seen on
+// larger models where attention is a smaller fraction of the work.
+//
+// This variant coalesces gqa_ratio Q-heads sharing one KV-head into ONE
+// WG. K and V are read once per cache step and reused across MQ_GQA Q rows,
+// each maintaining its own (m_i, l_i, o_acc) online-softmax state. Output
+// writes MQ_GQA rows from one WG.
+//
+// Differs from Metal's vec FA: Metal does NOT coalesce — it relies on L2
+// reuse across gqa_ratio sibling WGs. Adreno's L2 doesn't amortize the
+// reuse strongly enough on small models, so we coalesce explicitly.
+//
+// Currently compile-locked to MQ_GQA=4 (covers Gemma-3 family); other GQA
+// ratios still fall back to legacy q1 / q1_vec at the dispatch site.
+
+// ---------------------------------------------------------------------------
+// flash_attn_f32_f16_q1_local_tile — alternative decode FA design:
+// one WG per (q_idx, q_head). Stages K/V into __local tiles of
+// LT_KC rows. Per K-step, all LT_WG=DK lanes co-compute one Q·K dot via a
+// pure __local tree-reduce (no subgroup primitives), broadcast the score,
+// then each lane updates ONE float of its private o_val (D-split, not
+// DV-split). Trades K-bandwidth (no Q-head coalescing, K read by every Q
+// head's WG) for parallelism (n_head WGs in flight instead of n_head_kv).
+// Compiled only at DK=DV=128 and registered at WG=DK=128 (LT_WG match).
+// Dispatch is gated behind GGML_OPENCL_FA_LOCAL_TILE=1.
+// ---------------------------------------------------------------------------
+
+#define LT_KC 32
+#define LT_WG 128
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_f16_q1_local_tile(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    global void * o_void, ulong o_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int is_causal,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const ulong o_nb1, const ulong o_nb2, const ulong o_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void * mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    const global void * sinks_void,
+    const ulong sinks_offset
+) {
+    const int q_idx     = get_global_id(0) / LT_WG;
+    const int head_idx  = get_global_id(1);
+    const int batch_idx = get_global_id(2);
+    const int tid       = get_local_id(0);
+
+    const int gqa_ratio   = n_head_kv > 0 ? (n_head / n_head_kv) : 1;
+    const int head_kv_idx = head_idx / gqa_ratio;
+
+    const float slope = get_alibi_slope(max_bias, head_idx, n_head_log2, m0, m1);
+
+    __local half  k_tile[LT_KC * DK];   // 32*128*2 = 8 KB at DK=128
+    __local half  v_tile[LT_KC * DV];   // 8 KB
+    __local float red[LT_WG];           // 512 B reduction scratch
+    __local float score_shared;         // broadcast score (each K-step)
+
+    // Each thread owns one float of Q at index `tid` (assumes LT_WG == DK).
+    const global char * q_row_base = (const global char *) q_void + q_offset +
+                                     batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
+    float q_val = ((const global float *) q_row_base)[tid];
+
+    const global char * mask_base = NULL;
+    if (mask_void != NULL) {
+        const int mask_head_idx  = head_idx  % mask_ne2;
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        mask_base = (const global char *) mask_void + mask_offset +
+                    mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2 +
+                    (ulong) q_idx * mask_nb1;
+    }
+
+    float o_val = 0.0f;
+    float m_i = -INFINITY;
+    float l_i = 0.0f;
+
+    for (int kb = 0; kb < n_kv; kb += LT_KC) {
+        const int tile_len = min(LT_KC, n_kv - kb);
+
+        // Stage K and V tiles into __local.
+        for (int i = tid; i < tile_len * DK; i += LT_WG) {
+            const int j = i / DK;
+            const int d = i % DK;
+            const int kv_idx = kb + j;
+            const global char * k_row = (const global char *) k_void + k_offset +
+                                        batch_idx * k_nb3 + head_kv_idx * k_nb2 +
+                                        (ulong) kv_idx * k_nb1;
+            const global char * v_row = (const global char *) v_void + v_offset +
+                                        batch_idx * v_nb3 + head_kv_idx * v_nb2 +
+                                        (ulong) kv_idx * v_nb1;
+            k_tile[j * DK + d] = ((const global half *) k_row)[d];
+            v_tile[j * DV + d] = ((const global half *) v_row)[d];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int j = 0; j < tile_len; ++j) {
+            const int kv_idx = kb + j;
+
+            // Q·K dot via __local tree-reduce.
+            red[tid] = q_val * convert_float(k_tile[j * DK + tid]);
+            barrier(CLK_LOCAL_MEM_FENCE);
+            for (int stride = LT_WG >> 1; stride > 0; stride >>= 1) {
+                if (tid < stride) {
+                    red[tid] += red[tid + stride];
+                }
+                barrier(CLK_LOCAL_MEM_FENCE);
+            }
+
+            if (tid == 0) {
+                float s = red[0] * scale;
+                if (mask_base != NULL) {
+                    const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base;
+                    s += slope * (float) mask_ptr[kv_idx];
+                }
+                if (logit_softcap > 0.0f) {
+                    s = logit_softcap * tanh(s / logit_softcap);
+                }
+                score_shared = s;
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            const float s     = score_shared;
+            const float m_new = fmax(m_i, s);
+            const float alpha = native_exp(m_i - m_new);
+            const float beta  = native_exp(s   - m_new);
+
+            o_val = o_val * alpha + beta * convert_float(v_tile[j * DV + tid]);
+            l_i   = l_i   * alpha + beta;
+            m_i   = m_new;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    // Fold attention sinks into the running (m, l, o), if present.
+    if (sinks_void != NULL) {
+        const global float * sinks_ptr =
+            (const global float *) ((const global char *) sinks_void + sinks_offset);
+        const float m_sink = sinks_ptr[head_idx];
+        const float m_new  = fmax(m_i, m_sink);
+        const float alpha  = native_exp(m_i    - m_new);
+        const float beta   = native_exp(m_sink - m_new);
+        o_val = o_val * alpha;
+        l_i   = l_i * alpha + beta;
+        m_i   = m_new;
+    }
+
+    const float l_inv = (l_i > 0.0f) ? (1.0f / l_i) : 0.0f;
+    global float * o_row = (global float *) ((global char *) o_void + o_offset +
+                                              batch_idx * o_nb3 + head_idx * o_nb1 +
+                                              (ulong) q_idx * o_nb2);
+    o_row[tid] = o_val * l_inv;
+}
+
+// ---------------------------------------------------------------------------
+// flash_attn_f32_f16_q1_local_mq_split — hybrid local-tile + MQ + FD-split.
+// Combines the 3 levers identified while evaluating local_tile:
+//   1. Q-head coalescing (MQ_GQA Q rows per WG share one KV slice)
+//   2. sub_group_reduce_add for the dot (1 reduce vs tree-reduce's 7 barriers)
+//   3. Flash-decoding split along n_kv (n_splits WGs per kv_head)
+// Plus the __local K/V tile from local_tile (re-use within each tile).
+//
+// WG layout: 1 subgroup of 64 lanes. Each lane owns DK/64 = 2 D-elements at
+// indices (tid*LMQ_DPL .. tid*LMQ_DPL+1). MQ_GQA per-h state lives in
+// private registers (o_acc[MQ_GQA][LMQ_DPL], m_i[MQ_GQA], l_i[MQ_GQA]).
+//
+// Grid: (LMQ_WG, n_head_kv * n_batch, n_splits * n_q). Compiled at DK=DV=128.
+// MQ_GQA=4 default + second compile MQ_GQA=8 alongside the existing MQ split
+// kernels (shared MQ_GQA macro). Writes one partial record per (h, split);
+// flash_attn_f32_merge reused for normalization.
+// ---------------------------------------------------------------------------
+
+#define LMQ_WG  64
+#define LMQ_KC  32
+#define LMQ_DPL 2   // DK / LMQ_WG at DK=128
+
+#ifndef MQ_GQA
+#define MQ_GQA 4
+#endif
+
+#ifndef FA_PARTIAL_FLOATS
 #define FA_PARTIAL_FLOATS (2 + DV)
+#endif
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_f16_q1_local_mq_split(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void * mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    global float * partial_void,
+    const int n_splits,
+    const int kv_per_split
+) {
+    const int tid              = get_local_id(0);  // 0..LMQ_WG-1
+    const int kvhead_batch_idx = get_global_id(1);
+    const int split_q_idx      = get_global_id(2);
+    const int split_idx        = split_q_idx % n_splits;
+    const int q_idx            = split_q_idx / n_splits;
+
+    const int batch_idx   = kvhead_batch_idx / n_head_kv;
+    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+
+    const int kv_start = split_idx * kv_per_split;
+    const int kv_end   = min(kv_start + kv_per_split, n_kv);
+
+    const ulong record_stride = (ulong) FA_PARTIAL_FLOATS;
+
+    if (kv_start >= kv_end) {
+        // Empty split — write sentinel for each Q-head so merge treats it as 0.
+        if (tid == 0) {
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                       * n_splits + split_idx);
+                global float * rec = partial_void + rec_idx * record_stride;
+                rec[0] = -INFINITY;
+                rec[1] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+
+    // Stage MQ_GQA Q rows in __local (MQ_GQA × DK floats).
+    __local float q_shared[MQ_GQA * DK];
+    for (int i = tid; i < MQ_GQA * DK; i += LMQ_WG) {
+        const int h        = i / DK;
+        const int d        = i % DK;
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_off = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
+        const global float * q_ptr = (const global float *) (q_base + q_row_off);
+        q_shared[h * DK + d] = q_ptr[d];
+    }
+
+    // K/V tile staging buffers (16 KB combined at DK=DV=128 KC=32).
+    __local half k_tile[LMQ_KC * DK];
+    __local half v_tile[LMQ_KC * DV];
+
+    // Per-h state held in private registers.
+    float o_acc[MQ_GQA][LMQ_DPL];
+    float m_i[MQ_GQA];
+    float l_i[MQ_GQA];
+    float slope[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        m_i[h] = -INFINITY;
+        l_i[h] = 0.0f;
+        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+        #pragma unroll
+        for (int p = 0; p < LMQ_DPL; ++p) o_acc[h][p] = 0.0f;
+    }
+
+    // Per-h mask pointers.
+    const global char * mask_base[MQ_GQA];
+    if (mask_void != NULL) {
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        const global char * mask_base_b = (const global char *) mask_void + mask_offset +
+                                          mask_batch_idx * mask_nb3 +
+                                          (ulong) q_idx * mask_nb1;
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int mask_head_idx = head_idx % mask_ne2;
+            mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
+        }
+    } else {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);  // Ensure Q staged before first dot.
+
+    for (int kb = kv_start; kb < kv_end; kb += LMQ_KC) {
+        const int tile_len = min((int) LMQ_KC, kv_end - kb);
+
+        // Cooperative load K + V tile.
+        for (int i = tid; i < tile_len * DK; i += LMQ_WG) {
+            const int j = i / DK;
+            const int d = i % DK;
+            const int kv_idx = kb + j;
+            const global char * k_row = k_base + batch_idx * k_nb3 + head_kv_idx * k_nb2 + (ulong) kv_idx * k_nb1;
+            const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + (ulong) kv_idx * v_nb1;
+            k_tile[j * DK + d] = ((const global half *) k_row)[d];
+            v_tile[j * DV + d] = ((const global half *) v_row)[d];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        // Process each cache row in the tile.
+        for (int j = 0; j < tile_len; ++j) {
+            const int kv_idx = kb + j;
+
+            // Dot product per h: lane owns LMQ_DPL D-elements at (tid*LMQ_DPL..).
+            float score[MQ_GQA];
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                float contrib = 0.0f;
+                #pragma unroll
+                for (int p = 0; p < LMQ_DPL; ++p) {
+                    const int d = tid * LMQ_DPL + p;
+                    contrib += q_shared[h * DK + d] * (float) k_tile[j * DK + d];
+                }
+                float s = sub_group_reduce_add(contrib) * scale;
+                if (mask_base[h] != NULL) {
+                    const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                    s += slope[h] * (float) mask_ptr[kv_idx];
+                }
+                if (logit_softcap > 0.0f) {
+                    s = logit_softcap * tanh(s / logit_softcap);
+                }
+                score[h] = s;
+            }
+
+            // Online softmax update + V accumulation per h.
+            float p_h[MQ_GQA];
+            float sp_h[MQ_GQA];
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const float m_new = fmax(m_i[h], score[h]);
+                sp_h[h] = native_exp(m_i[h] - m_new);
+                p_h[h]  = native_exp(score[h] - m_new);
+                l_i[h]  = l_i[h] * sp_h[h] + p_h[h];
+                m_i[h]  = m_new;
+            }
+
+            #pragma unroll
+            for (int p = 0; p < LMQ_DPL; ++p) {
+                const int d = tid * LMQ_DPL + p;
+                const float v_val = (float) v_tile[j * DV + d];
+                #pragma unroll
+                for (int h = 0; h < MQ_GQA; ++h) {
+                    o_acc[h][p] = o_acc[h][p] * sp_h[h] + p_h[h] * v_val;
+                }
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);  // Before next tile load overwrites k/v_tile.
+    }
+
+    // Write partial records: one per (h, split). Each lane writes its
+    // LMQ_DPL D-positions of o_acc[h]; merge kernel rescales across splits.
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                               * n_splits + split_idx);
+        global float * rec   = partial_void + rec_idx * record_stride;
+        global float * rec_o = rec + 2;
+
+        if (tid == 0) {
+            rec[0] = m_i[h];
+            rec[1] = l_i[h];
+        }
+        #pragma unroll
+        for (int p = 0; p < LMQ_DPL; ++p) {
+            const int d = tid * LMQ_DPL + p;
+            rec_o[d] = o_acc[h][p];
+        }
+    }
+}
+
+// MQ collapses one WG per KV-head (vs one per Q-head in legacy q1_vec).
+// Wanted NSG=8 or 16 to compensate for the wavefront-count loss after the
+// head-dim collapse, but Adreno X2's per-kernel CL_KERNEL_WORK_GROUP_SIZE
+// for this signature is 320 — only NSG=4 / WG=256 is reliably dispatchable.
+// At that NSG this kernel benches worse than legacy q1_vec on the target
+// model (Gemma-3-1B tg@d=0 = 60 t/s vs 72 legacy), so it's compiled but
+// not dispatched in the host code. The win came from pairing MQ with the
+// flash-decoding split (q1_vec_mq_split below) — that's the path host
+// dispatch uses at n_kv >= FD_MIN_N_KV.
+#ifndef MQ_NSG
+#define MQ_NSG 4
+#endif
+#define MQ_WG_SIZE (Q1_WG_SIZE * MQ_NSG)
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_f16_q1_vec_mq(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    global void * o_void, ulong o_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int is_causal,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const ulong o_nb1, const ulong o_nb2, const ulong o_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void* mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    const global void* sinks_void,
+    const ulong sinks_offset
+) {
+    const int tid              = get_local_id(0);
+    const int sgid             = tid / Q1_WG_SIZE;   // subgroup 0..MQ_NSG-1
+    const int tid_sg           = tid % Q1_WG_SIZE;   // lane 0..63
+    const int kvhead_batch_idx = get_global_id(1);
+
+    const int batch_idx   = kvhead_batch_idx / n_head_kv;
+    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+    global       char * o_base = (global       char *) o_void + o_offset;
+
+    // Q for all MQ_GQA heads staged in __local once (~4 KB at DK=256).
+    __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
+    for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_WG_SIZE) {
+        const int h        = i / DK_VEC;
+        const int k        = i % DK_VEC;
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Per-h ALiBi slope (cheap: 4 floats).
+    float slope[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+    }
+
+    // Per-h mask row pointer. mask_ne2 is usually 1 (broadcast across heads),
+    // in which case all mask_base[h] coincide — but the indexing math handles
+    // both cases.
+    const global char * mask_base[MQ_GQA];
+    if (mask_void != NULL) {
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        const global char * mask_base_b = (const global char *) mask_void + mask_offset +
+                                          mask_batch_idx * mask_nb3;
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int mask_head_idx = head_idx % mask_ne2;
+            mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
+        }
+    } else {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
+    }
+
+    const global ACC_TYPE * sinks_ptr = NULL;
+    if (sinks_void != NULL) {
+        sinks_ptr = (const global ACC_TYPE *) ((const global char *) sinks_void + sinks_offset);
+    }
+
+    // Per-thread per-h DV slice. At DK=DV=256 / 64-wide sg, Q1V_DV_PER_THREAD=1,
+    // so this is MQ_GQA float4 = 64 bytes per thread.
+    ACC_TYPE4 o_acc[MQ_GQA][Q1V_DV_PER_THREAD];
+    ACC_TYPE  m_i[MQ_GQA];
+    ACC_TYPE  l_i[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        m_i[h] = -INFINITY;
+        l_i[h] = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
+    }
+
+    // Each subgroup independently sweeps its slice of n_kv. K and V are
+    // loaded once per cache step and reused MQ_GQA times.
+    const int kv_per_sg = (n_kv + MQ_NSG - 1) / MQ_NSG;
+    const int kv_start  = sgid * kv_per_sg;
+    const int kv_end    = min(n_kv, kv_start + kv_per_sg);
+
+    for (int k_idx = kv_start; k_idx < kv_end; ++k_idx) {
+        const ulong k_row_off = batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
+        const ulong v_row_off = batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+        const global KV_DATA_TYPE4 * k_ptr = (const global KV_DATA_TYPE4 *) (k_base + k_row_off);
+        const global KV_DATA_TYPE4 * v_ptr = (const global KV_DATA_TYPE4 *) (v_base + v_row_off);
+
+        // Q*K^T: load each K stride once, dot against all MQ_GQA Q rows.
+        ACC_TYPE4 dot4[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
+        for (int k = tid_sg; k < DK_VEC; k += Q1_WG_SIZE) {
+            const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_ptr[k]);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                dot4[h] = mad(q_shared[h * DK_VEC + k], k_vec, dot4[h]);
+            }
+        }
+
+        ACC_TYPE score[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE dot_partial = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+            ACC_TYPE s = sub_group_reduce_add(dot_partial) * scale;
+            if (mask_base[h] != NULL) {
+                const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_idx];
+            }
+            if (logit_softcap > 0.0f) {
+                s = logit_softcap * tanh(s / logit_softcap);
+            }
+            score[h] = s;
+        }
+
+        // FA-2 online softmax update — V load amortized across MQ_GQA heads.
+        // p, scale_prev are computed per h; the V vector is loaded once
+        // per dv stride and reused MQ_GQA times.
+        ACC_TYPE p_h[MQ_GQA];
+        ACC_TYPE sp_h[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE m_new = max(m_i[h], score[h]);
+            sp_h[h] = native_exp(m_i[h] - m_new);
+            p_h[h]  = native_exp(score[h] - m_new);
+            l_i[h]  = l_i[h] * sp_h[h] + p_h[h];
+            m_i[h]  = m_new;
+        }
+
+        int idx = 0;
+        for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+            const ACC_TYPE4 v_vec = CONVERT_KV_ACC4(v_ptr[dv_idx]);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                o_acc[h][idx] = mad(p_h[h], v_vec, o_acc[h][idx] * sp_h[h]);
+            }
+        }
+    }
+
+    // Cross-subgroup merge — per-h to keep LDS bounded at NSG=16.
+    //   sg_m, sg_l: [MQ_GQA][MQ_NSG] floats (tiny).
+    //   sg_o: [MQ_NSG][DV_VEC] float4, REUSED across h via barriers.
+    // At MQ_NSG=16, DV=256: sg_o = 16 KB; +4 KB q_shared ≈ 20 KB total LDS.
+    // (Storing all h at once would need 4×16 KB sg_o = 64 KB, exceeding 32 KB.)
+    __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG];
+    __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG];
+    __local ACC_TYPE4 sg_o[MQ_NSG][DV_VEC];
+
+    if (tid_sg == 0) {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            sg_m[h][sgid] = m_i[h];
+            sg_l[h][sgid] = l_i[h];
+        }
+    }
+
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        // Each subgroup publishes its o_acc slice for head h.
+        {
+            int idx = 0;
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+                sg_o[sgid][dv_idx] = o_acc[h][idx];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (sgid == 0) {
+            const int head_idx = head_kv_idx * MQ_GQA + h;
+
+            ACC_TYPE m_final = sg_m[h][0];
+            #pragma unroll
+            for (int s = 1; s < MQ_NSG; ++s) {
+                m_final = max(m_final, sg_m[h][s]);
+            }
+            if (sinks_ptr != NULL) {
+                m_final = max(m_final, sinks_ptr[head_idx]);
+            }
+
+            ACC_TYPE l_final = 0.0f;
+            #pragma unroll
+            for (int s = 0; s < MQ_NSG; ++s) {
+                l_final += sg_l[h][s] * native_exp(sg_m[h][s] - m_final);
+            }
+            if (sinks_ptr != NULL) {
+                l_final += native_exp(sinks_ptr[head_idx] - m_final);
+            }
+            const ACC_TYPE l_inv = (l_final > 0.0f) ? (1.0f / l_final) : 0.0f;
+
+            const ulong o_row_offset = batch_idx * o_nb3 + head_idx * o_nb1;
+            global O_DATA_TYPE4 * o_row = (global O_DATA_TYPE4 *) (o_base + o_row_offset);
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE) {
+                ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+                #pragma unroll
+                for (int s = 0; s < MQ_NSG; ++s) {
+                    const ACC_TYPE alpha = native_exp(sg_m[h][s] - m_final);
+                    o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv_idx], o_merged);
+                }
+                o_row[dv_idx] = CONVERT_O_DATA4(o_merged * l_inv);
+            }
+        }
+        // Barrier guards next h's overwrite of sg_o.
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+}
+
+// KV-head-coalesced + flash-decoding split. Pairs the MQ_GQA coalescing
+// (gqa_ratio Q-heads share one KV stream) with flash-decoding (n_splits WGs
+// per (kv_head, batch) along n_kv). One WG = (kv_head, batch, split):
+//   total WGs = n_head_kv * n_batch * n_splits, each WG = MQ_NSG_SPLIT
+//   subgroups × 64 lanes.
+// For Gemma-3-1B at d=16k (n_head_kv=1, n_batch=1, n_splits=8, NSG=8):
+//   8 WGs × 8 sg = 64 wavefronts (vs 16 for the single-WG MQ kernel and
+//   16 for legacy 4 WGs × 4 sg). Restores per-CU occupancy on Adreno X2
+//   while keeping the 4× K-bandwidth saving from MQ coalescing.
+// Output: MQ_GQA partial records per WG, format identical to
+// `flash_attn_f32_f16_q1_split` so the same merge kernel applies.
+
+#ifndef MQ_NSG_SPLIT
+#define MQ_NSG_SPLIT 4
+#endif
+#define MQ_SPLIT_WG_SIZE (Q1_WG_SIZE * MQ_NSG_SPLIT)
+
+#ifndef FA_PARTIAL_FLOATS
+#define FA_PARTIAL_FLOATS (2 + DV)
+#endif
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_f16_q1_vec_mq_split(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void * mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    global float * partial_void,
+    const int n_splits,
+    const int kv_per_split
+) {
+    const int tid              = get_local_id(0);
+    const int sgid             = tid / Q1_WG_SIZE;
+    const int tid_sg           = tid % Q1_WG_SIZE;
+    const int kvhead_batch_idx = get_global_id(1);
+    const int split_q_idx      = get_global_id(2);
+    const int split_idx        = split_q_idx % n_splits;
+    const int q_idx            = split_q_idx / n_splits;
+
+    const int batch_idx   = kvhead_batch_idx / n_head_kv;
+    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+
+    const int kv_start = split_idx * kv_per_split;
+    const int kv_end   = min(kv_start + kv_per_split, n_kv);
+
+    const ulong record_stride = (ulong) FA_PARTIAL_FLOATS;
+
+    if (kv_start >= kv_end) {
+        // Empty split — write sentinel for each of the MQ_GQA Q-heads so the
+        // merge pass treats this slot as dropped (exp(-INF)=0 contribution).
+        if (tid == 0) {
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                       * n_splits + split_idx);
+                global float * rec = partial_void + rec_idx * record_stride;
+                rec[0] = -INFINITY;
+                rec[1] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+
+    // Stage MQ_GQA Q rows in __local once (uniform across WG).
+    __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
+    for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE) {
+        const int h        = i / DK_VEC;
+        const int k        = i % DK_VEC;
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    float slope[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+    }
+
+    const global char * mask_base[MQ_GQA];
+    if (mask_void != NULL) {
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        const global char * mask_base_b = (const global char *) mask_void + mask_offset +
+                                          mask_batch_idx * mask_nb3 +
+                                          (ulong) q_idx * mask_nb1;
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int mask_head_idx = head_idx % mask_ne2;
+            mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
+        }
+    } else {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
+    }
+
+    ACC_TYPE4 o_acc[MQ_GQA][Q1V_DV_PER_THREAD];
+    ACC_TYPE  m_i[MQ_GQA];
+    ACC_TYPE  l_i[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        m_i[h] = -INFINITY;
+        l_i[h] = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
+    }
+
+    // Each subgroup independently sweeps its slice of the split's kv range.
+    const int kv_len   = kv_end - kv_start;
+    const int kv_per_sg = (kv_len + MQ_NSG_SPLIT - 1) / MQ_NSG_SPLIT;
+    const int kv_lo    = kv_start + sgid * kv_per_sg;
+    const int kv_hi    = min(kv_end, kv_lo + kv_per_sg);
+
+    for (int k_idx = kv_lo; k_idx < kv_hi; ++k_idx) {
+        const ulong k_row_off = batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
+        const ulong v_row_off = batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+        const global KV_DATA_TYPE4 * k_ptr = (const global KV_DATA_TYPE4 *) (k_base + k_row_off);
+        const global KV_DATA_TYPE4 * v_ptr = (const global KV_DATA_TYPE4 *) (v_base + v_row_off);
+
+        ACC_TYPE4 dot4[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
+        for (int k = tid_sg; k < DK_VEC; k += Q1_WG_SIZE) {
+            const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_ptr[k]);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                dot4[h] = mad(q_shared[h * DK_VEC + k], k_vec, dot4[h]);
+            }
+        }
+
+        ACC_TYPE score[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE dot_partial = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+            ACC_TYPE s = sub_group_reduce_add(dot_partial) * scale;
+            if (mask_base[h] != NULL) {
+                const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_idx];
+            }
+            if (logit_softcap > 0.0f) {
+                s = logit_softcap * tanh(s / logit_softcap);
+            }
+            score[h] = s;
+        }
+
+        ACC_TYPE p_h[MQ_GQA];
+        ACC_TYPE sp_h[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE m_new = max(m_i[h], score[h]);
+            sp_h[h] = native_exp(m_i[h] - m_new);
+            p_h[h]  = native_exp(score[h] - m_new);
+            l_i[h]  = l_i[h] * sp_h[h] + p_h[h];
+            m_i[h]  = m_new;
+        }
+
+        int idx = 0;
+        for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+            const ACC_TYPE4 v_vec = CONVERT_KV_ACC4(v_ptr[dv_idx]);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                o_acc[h][idx] = mad(p_h[h], v_vec, o_acc[h][idx] * sp_h[h]);
+            }
+        }
+    }
+
+    // Per-h cross-subgroup merge: subgroup 0 folds NSG partials into a single
+    // (m, l, O) record per Q-head, written to the partial buffer.
+    __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE4 sg_o[MQ_NSG_SPLIT][DV_VEC];
+
+    if (tid_sg == 0) {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            sg_m[h][sgid] = m_i[h];
+            sg_l[h][sgid] = l_i[h];
+        }
+    }
+
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        {
+            int idx = 0;
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+                sg_o[sgid][dv_idx] = o_acc[h][idx];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (sgid == 0) {
+            const int head_idx = head_kv_idx * MQ_GQA + h;
+
+            // Fold per-subgroup (m, l) into split-level (m_c, l_c). Note: the
+            // partial record stores RAW O (un-normalized), so the merge kernel
+            // can rescale across splits with exp(m_c - m_final).
+            ACC_TYPE m_c = sg_m[h][0];
+            #pragma unroll
+            for (int s = 1; s < MQ_NSG_SPLIT; ++s) {
+                m_c = max(m_c, sg_m[h][s]);
+            }
+            ACC_TYPE l_c = 0.0f;
+            #pragma unroll
+            for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                l_c += sg_l[h][s] * native_exp(sg_m[h][s] - m_c);
+            }
+
+            const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                   * n_splits + split_idx);
+            global float  * rec   = partial_void + rec_idx * record_stride;
+            global float4 * rec_o = (global float4 *) (rec + 2);
+
+            if (tid_sg == 0) {
+                rec[0] = (float) m_c;
+                rec[1] = (float) l_c;
+            }
+            // Each thread writes its DV slice of the merged O.
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE) {
+                ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+                #pragma unroll
+                for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                    const ACC_TYPE alpha = native_exp(sg_m[h][s] - m_c);
+                    o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv_idx], o_merged);
+                }
+                rec_o[dv_idx] = o_merged;
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+}
+
 
 __kernel void flash_attn_f32_f16_q1_split(
     const global void * q_void, ulong q_offset,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -1849,6 +1849,260 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     }
 }
 
+// K-image variant of _q1_vec_mq_split.
+//
+// K is bound as a __read_only image1d_buffer_t (CL_RGBA, CL_HALF_FLOAT —
+// 8-byte pixels = 1 half4) over a sub-buffer covering the K cache for
+// this call. Adreno's texture cache is a separate BW path from L2 and
+// dramatically outperforms __global K reads at long context (the
+// _x8_gqa4_img port at the mul_mat layer gave +244% on KQ decode at
+// d=16k). FA's split-path K access pattern (NSG_SPLIT subgroups each
+// stream a contiguous slice of n_kv) is the same shape, so the same
+// texture-cache win should apply.
+//
+// V stays on __global: V's inner loop is long (DV_VEC iters per K
+// position) and arithmetic-intensity hides V latency, so the texture
+// cache adds latency without enough memory-stall to mask (the
+// _y8_gqa_img port at mul_mat regressed -13% for this reason).
+//
+// k_offset is NOT a kernel arg: the sub-buffer is created host-side
+// with CL_BUFFER_CREATE_TYPE_REGION (origin = offset_k), so image
+// addressing is relative to the sub-buffer start. Pixel pitches come
+// from the byte strides via (k_nb >> 3) since each pixel = 8 B.
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
+    const global void * q_void, ulong q_offset,
+    __read_only image1d_buffer_t k_img,
+    const global void * v_void, ulong v_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void * mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    global float * partial_void,
+    const int n_splits,
+    const int kv_per_split
+) {
+    const int tid              = get_local_id(0);
+    const int sgid             = tid / Q1_WG_SIZE;
+    const int tid_sg           = tid % Q1_WG_SIZE;
+    const int kvhead_batch_idx = get_global_id(1);
+    const int split_q_idx      = get_global_id(2);
+    const int split_idx        = split_q_idx % n_splits;
+    const int q_idx            = split_q_idx / n_splits;
+
+    const int batch_idx   = kvhead_batch_idx / n_head_kv;
+    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+
+    const int kv_start = split_idx * kv_per_split;
+    const int kv_end   = min(kv_start + kv_per_split, n_kv);
+
+    const ulong record_stride = (ulong) FA_PARTIAL_FLOATS;
+
+    if (kv_start >= kv_end) {
+        if (tid == 0) {
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                       * n_splits + split_idx);
+                global float * rec = partial_void + rec_idx * record_stride;
+                rec[0] = -INFINITY;
+                rec[1] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+
+    __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
+    for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE) {
+        const int h        = i / DK_VEC;
+        const int k        = i % DK_VEC;
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    float slope[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+    }
+
+    const global char * mask_base[MQ_GQA];
+    if (mask_void != NULL) {
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        const global char * mask_base_b = (const global char *) mask_void + mask_offset +
+                                          mask_batch_idx * mask_nb3 +
+                                          (ulong) q_idx * mask_nb1;
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int mask_head_idx = head_idx % mask_ne2;
+            mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
+        }
+    } else {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
+    }
+
+    ACC_TYPE4 o_acc[MQ_GQA][Q1V_DV_PER_THREAD];
+    ACC_TYPE  m_i[MQ_GQA];
+    ACC_TYPE  l_i[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        m_i[h] = -INFINITY;
+        l_i[h] = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
+    }
+
+    // K pitches in pixel units. Pixel = 1 half4 = 8 B → byte_stride >> 3.
+    const int pitch_px_row   = (int)(k_nb1 >> 3);
+    const int pitch_px_head  = (int)(k_nb2 >> 3);
+    const int pitch_px_batch = (int)(k_nb3 >> 3);
+
+    const int kv_len    = kv_end - kv_start;
+    const int kv_per_sg = (kv_len + MQ_NSG_SPLIT - 1) / MQ_NSG_SPLIT;
+    const int kv_lo     = kv_start + sgid * kv_per_sg;
+    const int kv_hi     = min(kv_end, kv_lo + kv_per_sg);
+
+    for (int k_idx = kv_lo; k_idx < kv_hi; ++k_idx) {
+        const int k_row_px = batch_idx * pitch_px_batch +
+                             head_kv_idx * pitch_px_head +
+                             k_idx * pitch_px_row;
+
+        const ulong v_row_off = batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+        const global KV_DATA_TYPE4 * v_ptr = (const global KV_DATA_TYPE4 *) (v_base + v_row_off);
+
+        ACC_TYPE4 dot4[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
+        for (int k = tid_sg; k < DK_VEC; k += Q1_WG_SIZE) {
+            const half4     k_h4  = read_imageh(k_img, k_row_px + k);
+            const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_h4);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                dot4[h] = mad(q_shared[h * DK_VEC + k], k_vec, dot4[h]);
+            }
+        }
+
+        ACC_TYPE score[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE dot_partial = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+            ACC_TYPE s = sub_group_reduce_add(dot_partial) * scale;
+            if (mask_base[h] != NULL) {
+                const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_idx];
+            }
+            if (logit_softcap > 0.0f) {
+                s = logit_softcap * tanh(s / logit_softcap);
+            }
+            score[h] = s;
+        }
+
+        ACC_TYPE p_h[MQ_GQA];
+        ACC_TYPE sp_h[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE m_new = max(m_i[h], score[h]);
+            sp_h[h] = native_exp(m_i[h] - m_new);
+            p_h[h]  = native_exp(score[h] - m_new);
+            l_i[h]  = l_i[h] * sp_h[h] + p_h[h];
+            m_i[h]  = m_new;
+        }
+
+        int idx = 0;
+        for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+            const ACC_TYPE4 v_vec = CONVERT_KV_ACC4(v_ptr[dv_idx]);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                o_acc[h][idx] = mad(p_h[h], v_vec, o_acc[h][idx] * sp_h[h]);
+            }
+        }
+    }
+
+    __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE4 sg_o[MQ_NSG_SPLIT][DV_VEC];
+
+    if (tid_sg == 0) {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            sg_m[h][sgid] = m_i[h];
+            sg_l[h][sgid] = l_i[h];
+        }
+    }
+
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        {
+            int idx = 0;
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+                sg_o[sgid][dv_idx] = o_acc[h][idx];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (sgid == 0) {
+            const int head_idx = head_kv_idx * MQ_GQA + h;
+
+            ACC_TYPE m_c = sg_m[h][0];
+            #pragma unroll
+            for (int s = 1; s < MQ_NSG_SPLIT; ++s) {
+                m_c = max(m_c, sg_m[h][s]);
+            }
+            ACC_TYPE l_c = 0.0f;
+            #pragma unroll
+            for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                l_c += sg_l[h][s] * native_exp(sg_m[h][s] - m_c);
+            }
+
+            const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                   * n_splits + split_idx);
+            global float  * rec   = partial_void + rec_idx * record_stride;
+            global float4 * rec_o = (global float4 *) (rec + 2);
+
+            if (tid_sg == 0) {
+                rec[0] = (float) m_c;
+                rec[1] = (float) l_c;
+            }
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE) {
+                ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+                #pragma unroll
+                for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                    const ACC_TYPE alpha = native_exp(sg_m[h][s] - m_c);
+                    o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv_idx], o_merged);
+                }
+                rec_o[dv_idx] = o_merged;
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+}
+
 
 __kernel void flash_attn_f32_f16_q1_split(
     const global void * q_void, ulong q_offset,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
@@ -27,7 +27,12 @@
 
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
-#define Q1_WG_SIZE 64
+// q1 reduces over a Q1_WG_SIZE-wide WG via work-group barriers; the launch WG
+// must match. Defaults to the Adreno sg (64); host passes -D FA_SG=32 on Intel.
+#ifndef FA_SG
+#define FA_SG 64
+#endif
+#define Q1_WG_SIZE FA_SG
 
 // The kernels are built with -cl-finite-math-only. On some older Adreno GPUs,
 // infinite operand can cause undefined behavior and miscompilation for exp.

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
@@ -365,6 +365,274 @@ __kernel void flash_attn_f32_q4_0_q1(
     }
 }
 
+// Decode variant for large DV with q4_0 KV — mirrors the f16 vec FA design.
+// See flash_attn_f32_f16.cl for the protocol; the only change here is the
+// per-lane q4_0 dequant on the K/V reads.
+#ifdef cl_intel_subgroups
+#pragma OPENCL EXTENSION cl_intel_subgroups : enable
+#else
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+#endif
+
+#ifdef cl_qcom_reqd_sub_group_size
+#pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
+#define REQD_SUBGROUP_SIZE_64 __attribute__((qcom_reqd_sub_group_size("half")))
+#else
+#define REQD_SUBGROUP_SIZE_64
+#endif
+
+#define VEC_NSG          4
+#define VEC_WG_SIZE      (Q1_WG_SIZE * VEC_NSG)
+#define Q1V_DV_PER_THREAD ((DV_VEC + Q1_WG_SIZE - 1) / Q1_WG_SIZE)
+
+// Dequant one float4 lane (0..7) from a q4_0 block.
+// Lanes 0..3 → low nibbles of qs[0..15], lanes 4..7 → high nibbles.
+inline float4 dequant_q4_0_lane(const global char * block_ptr, int lane) {
+    const float d = vload_half(0, (const global half *)block_ptr);
+    const global uchar * qs = (const global uchar *)(block_ptr + 2);
+    const int g     = lane & 3;
+    const int shift = (lane < 4) ? 0 : 4;
+    return d * (float4)((float)((qs[g*4+0] >> shift) & 0x0F) - 8.0f,
+                        (float)((qs[g*4+1] >> shift) & 0x0F) - 8.0f,
+                        (float)((qs[g*4+2] >> shift) & 0x0F) - 8.0f,
+                        (float)((qs[g*4+3] >> shift) & 0x0F) - 8.0f);
+}
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_q4_0_q1_vec(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    global void * o_void, ulong o_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int is_causal,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const ulong o_nb1, const ulong o_nb2, const ulong o_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void* mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    const global void* sinks_void,
+    const ulong sinks_offset
+) {
+    const int tid             = get_local_id(0);
+    const int sgid            = tid / Q1_WG_SIZE;
+    const int tid_sg          = tid % Q1_WG_SIZE;
+    const int head_batch_idx  = get_global_id(1);
+
+    const int batch_idx = head_batch_idx / n_head;
+    const int head_idx  = head_batch_idx % n_head;
+
+    const int gqa_ratio   = n_head / n_head_kv;
+    const int head_kv_idx = head_idx / gqa_ratio;
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+    global       char * o_base = (global       char *) o_void + o_offset;
+
+    const global char * mask_base = NULL;
+    if (mask_void != NULL) {
+        const int mask_head_idx  = head_idx  % mask_ne2;
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        mask_base = (const global char *) mask_void + mask_offset +
+                    mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2;
+    }
+
+    __local ACC_TYPE4 q_shared[DK_VEC];
+    {
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        for (int i = tid; i < DK_VEC; i += VEC_WG_SIZE) {
+            q_shared[i] = CONVERT_Q_ACC4(q_ptr[i]);
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+#ifdef FA_HAVE_INT_DOT
+    // Quantize Q to int8-packed uints + per-block (qd, q_sum) once per WG
+    // for dp4a dot. One thread per Q block (DK_Q4_BLOCKS threads active);
+    // remaining threads idle this step. At DK=256 this is 8 blocks ~ 320 B
+    // LDS plus the 8-uint packed payload per block.
+    __local uint  q_packed_shared[DK_Q4_BLOCKS * 8];
+    __local float q_d_shared[DK_Q4_BLOCKS];
+    __local int   q_sum_shared[DK_Q4_BLOCKS];
+    if (tid < DK_Q4_BLOCKS) {
+        ACC_TYPE4 q_block[8];
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) q_block[i] = q_shared[tid * 8 + i];
+        uint packed[8];
+        q4_q_block_info info = quant_q_block_int8_packed_q4(q_block, packed);
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) q_packed_shared[tid * 8 + i] = packed[i];
+        q_d_shared[tid]   = info.qd;
+        q_sum_shared[tid] = info.q_sum;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+#endif
+
+    const float slope = get_alibi_slope(max_bias, head_idx, n_head_log2, m0, m1);
+
+    const global ACC_TYPE * sinks_ptr = NULL;
+    if (sinks_void != NULL) {
+        sinks_ptr = (const global ACC_TYPE *) ((const global char *) sinks_void + sinks_offset);
+    }
+
+    ACC_TYPE4 o_acc[Q1V_DV_PER_THREAD];
+    #pragma unroll
+    for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[i] = (ACC_TYPE4)(0.0f);
+
+    ACC_TYPE m_i = -INFINITY;
+    ACC_TYPE l_i = 0.0f;
+
+    const int kv_per_sg = (n_kv + VEC_NSG - 1) / VEC_NSG;
+    const int kv_start  = sgid * kv_per_sg;
+    const int kv_end    = min(n_kv, kv_start + kv_per_sg);
+
+    for (int k_idx = kv_start; k_idx < kv_end; ++k_idx) {
+        const global char * k_row = k_base + batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
+        const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+
+#ifdef FA_HAVE_INT_DOT
+        // Per-lane dp4a path: each lane packs 4 raw q4_0 nibbles (its
+        // quartet of the K block) into a uint, then dot_acc_sat_4x8packed_ss_int
+        // against the matching Q-quartet uint from q_packed_shared. The
+        // (nibble - 8) bias correction is folded in on lane_in_block==0 only,
+        // so the per-block sum reduces correctly across the 8 lanes
+        // contributing to it.
+        ACC_TYPE lane_contrib = 0.0f;
+        for (int qk = tid_sg; qk < DK_VEC; qk += Q1_WG_SIZE) {
+            const int block_idx     = qk / 8;
+            const int lane_in_block = qk % 8;
+            const int g             = lane_in_block & 3;
+            const int shift         = (lane_in_block < 4) ? 0 : 4;
+            const global char *  k_block = k_row + block_idx * Q4_0_BLOCK_SIZE;
+            const float kd = vload_half(0, (const global half *)k_block);
+            const global uchar * k_qs = (const global uchar *)(k_block + 2);
+            const uchar b0 = k_qs[g*4 + 0];
+            const uchar b1 = k_qs[g*4 + 1];
+            const uchar b2 = k_qs[g*4 + 2];
+            const uchar b3 = k_qs[g*4 + 3];
+            const uint k_packed = ((uint)((b0 >> shift) & 0x0F))       |
+                                  ((uint)((b1 >> shift) & 0x0F)) <<  8 |
+                                  ((uint)((b2 >> shift) & 0x0F)) << 16 |
+                                  ((uint)((b3 >> shift) & 0x0F)) << 24;
+            const uint q_packed_lane = q_packed_shared[block_idx * 8 + lane_in_block];
+            const int  raw_dot = dot_acc_sat_4x8packed_ss_int(q_packed_lane, k_packed, 0);
+            const float qd          = q_d_shared[block_idx];
+            const float block_scale = qd * kd;
+            float contrib = (float)raw_dot * block_scale;
+            if (lane_in_block == 0) {
+                // Block bias correction is per-block; attribute it to lane 0
+                // so summing across the 8 lanes recovers
+                // qd*kd*(raw_dot_block - 8*q_sum_block).
+                const int q_sum_b = q_sum_shared[block_idx];
+                contrib -= 8.0f * block_scale * (float)q_sum_b;
+            }
+            lane_contrib += contrib;
+        }
+        ACC_TYPE score = sub_group_reduce_add(lane_contrib) * scale;
+#else
+        ACC_TYPE4 dot4 = (ACC_TYPE4)(0.0f);
+        for (int qk = tid_sg; qk < DK_VEC; qk += Q1_WG_SIZE) {
+            const int block_idx = qk / 8;
+            const int lane      = qk % 8;
+            const float4 k_v = dequant_q4_0_lane(k_row + block_idx * Q4_0_BLOCK_SIZE, lane);
+            dot4 = mad(q_shared[qk], k_v, dot4);
+        }
+        ACC_TYPE dot_partial = dot4.s0 + dot4.s1 + dot4.s2 + dot4.s3;
+        ACC_TYPE score = sub_group_reduce_add(dot_partial) * scale;
+#endif
+
+        if (mask_base != NULL) {
+            const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base;
+            score += slope * (ACC_TYPE) mask_ptr[k_idx];
+        }
+        if (logit_softcap > 0.0f) {
+            score = logit_softcap * tanh(score / logit_softcap);
+        }
+
+        const ACC_TYPE m_new      = max(m_i, score);
+        const ACC_TYPE scale_prev = native_exp(m_i - m_new);
+        const ACC_TYPE p          = native_exp(score - m_new);
+
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            const int block_idx = dv / 8;
+            const int lane      = dv % 8;
+            const float4 v_v = dequant_q4_0_lane(v_row + block_idx * Q4_0_BLOCK_SIZE, lane);
+            o_acc[idx] = mad(p, v_v, o_acc[idx] * scale_prev);
+        }
+        l_i = l_i * scale_prev + p;
+        m_i = m_new;
+    }
+
+    __local ACC_TYPE  sg_m[VEC_NSG];
+    __local ACC_TYPE  sg_l[VEC_NSG];
+    __local ACC_TYPE4 sg_o[VEC_NSG][DV_VEC];
+
+    if (tid_sg == 0) {
+        sg_m[sgid] = m_i;
+        sg_l[sgid] = l_i;
+    }
+    {
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            sg_o[sgid][dv] = o_acc[idx];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (sgid == 0) {
+        ACC_TYPE m_final = sg_m[0];
+        #pragma unroll
+        for (int s = 1; s < VEC_NSG; ++s) {
+            m_final = max(m_final, sg_m[s]);
+        }
+        if (sinks_ptr != NULL) {
+            m_final = max(m_final, sinks_ptr[head_idx]);
+        }
+
+        ACC_TYPE l_final = 0.0f;
+        #pragma unroll
+        for (int s = 0; s < VEC_NSG; ++s) {
+            l_final += sg_l[s] * native_exp(sg_m[s] - m_final);
+        }
+        if (sinks_ptr != NULL) {
+            l_final += native_exp(sinks_ptr[head_idx] - m_final);
+        }
+        const ACC_TYPE l_inv = (l_final > 0.0f) ? (1.0f / l_final) : 0.0f;
+
+        const ulong o_row_offset = batch_idx * o_nb3 + head_idx * o_nb1;
+        global O_DATA_TYPE4 * o_row = (global O_DATA_TYPE4 *) (o_base + o_row_offset);
+
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+            #pragma unroll
+            for (int s = 0; s < VEC_NSG; ++s) {
+                const ACC_TYPE alpha = native_exp(sg_m[s] - m_final);
+                o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv], o_merged);
+            }
+            o_row[dv] = CONVERT_O_DATA4(o_merged * l_inv);
+        }
+    }
+}
+
 // Flash-decoding split pass for q4_0 KV. Merge kernel is type-agnostic and
 // shared with the f16/q8_0 FA kernels.
 #define FA_PARTIAL_FLOATS (2 + DV)
@@ -582,6 +850,344 @@ __kernel void flash_attn_f32_q4_0_q1_split(
 #define SPLIT_DK_Q4_BLOCKS  DK_Q4_BLOCKS_PREFILL
 #define WG_SIZE             BLOCK_M
 #endif
+
+// ---------------------------------------------------------------------------
+// flash_attn_f32_q4_0_q1_vec_mq_split — Multi-Query KV-head-coalesced FA decode
+// with flash-decoding split for q4_0 KV. Structural port of the f16/q8_0 MQ
+// split kernels, with q4_0-specific dp4a K dot (per-lane raw_dot against
+// LDS-staged Q-quantized-int8 + per-block bias correction on lane 0).
+// V dequant stays float (output-side, not on the hot dot).
+//
+// Compile-time params:
+//   MQ_GQA       — Q-heads coalesced per WG (defaults 4; second compile =8
+//                  for Qwen3-30B-A3B / Qwen3-4B GQA=8 class).
+//   MQ_NSG_SPLIT — subgroups per WG (defaults 4; second compile =3 paired
+//                  with MQ_GQA=8 on Adreno X2 where the per-kernel WG cap
+//                  drops to 192 due to register pressure).
+// ---------------------------------------------------------------------------
+
+#ifndef MQ_GQA
+#define MQ_GQA 4
+#endif
+#ifndef MQ_NSG_SPLIT
+#define MQ_NSG_SPLIT 4
+#endif
+#define MQ_SPLIT_WG_SIZE_Q4 (Q1_WG_SIZE * MQ_NSG_SPLIT)
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void * mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    global float * partial_void,
+    const int n_splits,
+    const int kv_per_split
+) {
+    const int tid              = get_local_id(0);
+    const int sgid             = tid / Q1_WG_SIZE;
+    const int tid_sg           = tid % Q1_WG_SIZE;
+    const int kvhead_batch_idx = get_global_id(1);
+    const int split_q_idx      = get_global_id(2);
+    const int split_idx        = split_q_idx % n_splits;
+    const int q_idx            = split_q_idx / n_splits;
+
+    const int batch_idx   = kvhead_batch_idx / n_head_kv;
+    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+
+    const int kv_start = split_idx * kv_per_split;
+    const int kv_end   = min(kv_start + kv_per_split, n_kv);
+
+    const ulong record_stride = (ulong) FA_PARTIAL_FLOATS;
+
+    if (kv_start >= kv_end) {
+        if (tid == 0) {
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                       * n_splits + split_idx);
+                global float * rec = partial_void + rec_idx * record_stride;
+                rec[0] = -INFINITY;
+                rec[1] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+
+    // Stage MQ_GQA Q rows in __local as float4. Used by the FA_HAVE_INT_DOT
+    // path as the source for Q-block quantize, and by the fallback path as
+    // the direct Q vectors for fp dot.
+    __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
+    for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE_Q4) {
+        const int h        = i / DK_VEC;
+        const int k        = i % DK_VEC;
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+#ifdef FA_HAVE_INT_DOT
+    // Per-h, per-block: int8-packed Q + per-block (qd, q_sum). Quantize once
+    // per WG. One thread per (h, block) — MQ_GQA × DK_Q4_BLOCKS active.
+    __local uint  q_packed_shared[MQ_GQA * DK_Q4_BLOCKS * 8];
+    __local float q_d_shared[MQ_GQA * DK_Q4_BLOCKS];
+    __local int   q_sum_shared[MQ_GQA * DK_Q4_BLOCKS];
+    {
+        const int active = MQ_GQA * DK_Q4_BLOCKS;
+        if (tid < active) {
+            const int h        = tid / DK_Q4_BLOCKS;
+            const int block_id = tid % DK_Q4_BLOCKS;
+            ACC_TYPE4 q_block[8];
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) q_block[i] = q_shared[h * DK_VEC + block_id * 8 + i];
+            uint packed[8];
+            q4_q_block_info info = quant_q_block_int8_packed_q4(q_block, packed);
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) q_packed_shared[(h * DK_Q4_BLOCKS + block_id) * 8 + i] = packed[i];
+            q_d_shared[h * DK_Q4_BLOCKS + block_id]   = info.qd;
+            q_sum_shared[h * DK_Q4_BLOCKS + block_id] = info.q_sum;
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+#endif
+
+    float slope[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+    }
+
+    const global char * mask_base[MQ_GQA];
+    if (mask_void != NULL) {
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        const global char * mask_base_b = (const global char *) mask_void + mask_offset +
+                                          mask_batch_idx * mask_nb3 +
+                                          (ulong) q_idx * mask_nb1;
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int mask_head_idx = head_idx % mask_ne2;
+            mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
+        }
+    } else {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
+    }
+
+    ACC_TYPE4 o_acc[MQ_GQA][Q1V_DV_PER_THREAD];
+    ACC_TYPE  m_i[MQ_GQA];
+    ACC_TYPE  l_i[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        m_i[h] = -INFINITY;
+        l_i[h] = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
+    }
+
+    const int kv_len    = kv_end - kv_start;
+    const int kv_per_sg = (kv_len + MQ_NSG_SPLIT - 1) / MQ_NSG_SPLIT;
+    const int kv_lo     = kv_start + sgid * kv_per_sg;
+    const int kv_hi     = min(kv_end, kv_lo + kv_per_sg);
+
+    for (int k_idx = kv_lo; k_idx < kv_hi; ++k_idx) {
+        const global char * k_row = k_base + batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
+        const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+
+#ifdef FA_HAVE_INT_DOT
+        // Per-lane dp4a: each lane handles its quartet of one K block. Each
+        // lane's contribution to each h is dp4a(Q_h_packed, K_packed) scaled
+        // by qd_h * kd. Per-block bias correction (-8*qd_h*kd*q_sum_h) is
+        // attributed to lane_in_block==0 so summing across 8 lanes recovers
+        // qd_h*kd*(raw_dot_block - 8*q_sum_block).
+        ACC_TYPE lane_contrib[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) lane_contrib[h] = 0.0f;
+
+        for (int qk = tid_sg; qk < DK_VEC; qk += Q1_WG_SIZE) {
+            const int block_idx     = qk / 8;
+            const int lane_in_block = qk % 8;
+            const int g             = lane_in_block & 3;
+            const int shift         = (lane_in_block < 4) ? 0 : 4;
+            const global char *  k_block = k_row + block_idx * Q4_0_BLOCK_SIZE;
+            const float kd = vload_half(0, (const global half *)k_block);
+            const global uchar * k_qs = (const global uchar *)(k_block + 2);
+            const uchar b0 = k_qs[g*4 + 0];
+            const uchar b1 = k_qs[g*4 + 1];
+            const uchar b2 = k_qs[g*4 + 2];
+            const uchar b3 = k_qs[g*4 + 3];
+            const uint k_packed = ((uint)((b0 >> shift) & 0x0F))       |
+                                  ((uint)((b1 >> shift) & 0x0F)) <<  8 |
+                                  ((uint)((b2 >> shift) & 0x0F)) << 16 |
+                                  ((uint)((b3 >> shift) & 0x0F)) << 24;
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const uint  q_packed_lane = q_packed_shared[(h * DK_Q4_BLOCKS + block_idx) * 8 + lane_in_block];
+                const int   raw_dot       = dot_acc_sat_4x8packed_ss_int(q_packed_lane, k_packed, 0);
+                const float qd            = q_d_shared[h * DK_Q4_BLOCKS + block_idx];
+                const float block_scale   = qd * kd;
+                float contrib = (float) raw_dot * block_scale;
+                if (lane_in_block == 0) {
+                    const int q_sum_b = q_sum_shared[h * DK_Q4_BLOCKS + block_idx];
+                    contrib -= 8.0f * block_scale * (float) q_sum_b;
+                }
+                lane_contrib[h] += contrib;
+            }
+        }
+
+        ACC_TYPE score[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            ACC_TYPE s = sub_group_reduce_add(lane_contrib[h]) * scale;
+            if (mask_base[h] != NULL) {
+                const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_idx];
+            }
+            if (logit_softcap > 0.0f) {
+                s = logit_softcap * tanh(s / logit_softcap);
+            }
+            score[h] = s;
+        }
+#else
+        // Fallback float-dequant K dot.
+        ACC_TYPE4 dot4[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
+
+        for (int qk = tid_sg; qk < DK_VEC; qk += Q1_WG_SIZE) {
+            const int block_idx = qk / 8;
+            const int lane      = qk % 8;
+            const float4 k_v = dequant_q4_0_lane(k_row + block_idx * Q4_0_BLOCK_SIZE, lane);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                dot4[h] = mad(q_shared[h * DK_VEC + qk], k_v, dot4[h]);
+            }
+        }
+
+        ACC_TYPE score[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE dot_partial = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+            ACC_TYPE s = sub_group_reduce_add(dot_partial) * scale;
+            if (mask_base[h] != NULL) {
+                const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_idx];
+            }
+            if (logit_softcap > 0.0f) {
+                s = logit_softcap * tanh(s / logit_softcap);
+            }
+            score[h] = s;
+        }
+#endif
+
+        ACC_TYPE p_h[MQ_GQA];
+        ACC_TYPE sp_h[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE m_new = max(m_i[h], score[h]);
+            sp_h[h] = native_exp(m_i[h] - m_new);
+            p_h[h]  = native_exp(score[h] - m_new);
+            l_i[h]  = l_i[h] * sp_h[h] + p_h[h];
+            m_i[h]  = m_new;
+        }
+
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            const int block_idx = dv / 8;
+            const int lane      = dv % 8;
+            const float4 v_v = dequant_q4_0_lane(v_row + block_idx * Q4_0_BLOCK_SIZE, lane);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                o_acc[h][idx] = mad(p_h[h], v_v, o_acc[h][idx] * sp_h[h]);
+            }
+        }
+    }
+
+    // Per-h cross-subgroup merge: subgroup 0 folds MQ_NSG_SPLIT partials.
+    __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE4 sg_o[MQ_NSG_SPLIT][DV_VEC];
+
+    if (tid_sg == 0) {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            sg_m[h][sgid] = m_i[h];
+            sg_l[h][sgid] = l_i[h];
+        }
+    }
+
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        {
+            int idx = 0;
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+                sg_o[sgid][dv_idx] = o_acc[h][idx];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (sgid == 0) {
+            const int head_idx = head_kv_idx * MQ_GQA + h;
+
+            ACC_TYPE m_c = sg_m[h][0];
+            #pragma unroll
+            for (int s = 1; s < MQ_NSG_SPLIT; ++s) {
+                m_c = max(m_c, sg_m[h][s]);
+            }
+            ACC_TYPE l_c = 0.0f;
+            #pragma unroll
+            for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                l_c += sg_l[h][s] * native_exp(sg_m[h][s] - m_c);
+            }
+
+            const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                   * n_splits + split_idx);
+            global float  * rec   = partial_void + rec_idx * record_stride;
+            global float4 * rec_o = (global float4 *) (rec + 2);
+
+            if (tid_sg == 0) {
+                rec[0] = (float) m_c;
+                rec[1] = (float) l_c;
+            }
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE) {
+                ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+                #pragma unroll
+                for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                    const ACC_TYPE alpha = native_exp(sg_m[h][s] - m_c);
+                    o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv_idx], o_merged);
+                }
+                rec_o[dv_idx] = o_merged;
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+}
 
 __kernel void flash_attn_f32_q4_0(
     const global void * q_void, ulong q_offset,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
@@ -496,7 +496,7 @@ __kernel void flash_attn_f32_q4_0_q1_vec(
     #pragma unroll
     for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[i] = (ACC_TYPE4)(0.0f);
 
-    ACC_TYPE m_i = -INFINITY;
+    ACC_TYPE m_i = FA_M_INIT;
     ACC_TYPE l_i = 0.0f;
 
     const int kv_per_sg = (n_kv + VEC_NSG - 1) / VEC_NSG;
@@ -927,7 +927,7 @@ __kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
-                rec[0] = -INFINITY;
+                rec[0] = FA_M_INIT;
                 rec[1] = 0.0f;
             }
         }
@@ -1005,7 +1005,7 @@ __kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
     ACC_TYPE  l_i[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        m_i[h] = -INFINITY;
+        m_i[h] = FA_M_INIT;
         l_i[h] = 0.0f;
         #pragma unroll
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q4_0.cl
@@ -27,8 +27,7 @@
 
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
-// q1 reduces over a Q1_WG_SIZE-wide WG via work-group barriers; the launch WG
-// must match. Defaults to the Adreno sg (64); host passes -D FA_SG=32 on Intel.
+
 #ifndef FA_SG
 #define FA_SG 64
 #endif
@@ -370,9 +369,6 @@ __kernel void flash_attn_f32_q4_0_q1(
     }
 }
 
-// Decode variant for large DV with q4_0 KV — mirrors the f16 vec FA design.
-// See flash_attn_f32_f16.cl for the protocol; the only change here is the
-// per-lane q4_0 dequant on the K/V reads.
 #ifdef cl_intel_subgroups
 #pragma OPENCL EXTENSION cl_intel_subgroups : enable
 #else
@@ -469,10 +465,8 @@ __kernel void flash_attn_f32_q4_0_q1_vec(
     barrier(CLK_LOCAL_MEM_FENCE);
 
 #ifdef FA_HAVE_INT_DOT
-    // Quantize Q to int8-packed uints + per-block (qd, q_sum) once per WG
-    // for dp4a dot. One thread per Q block (DK_Q4_BLOCKS threads active);
-    // remaining threads idle this step. At DK=256 this is 8 blocks ~ 320 B
-    // LDS plus the 8-uint packed payload per block.
+    // quantize Q to int8-packed uints + per-block (qd, q_sum) once per WG for dp4a
+    // one thread per Q block, remaining threads idle this step
     __local uint  q_packed_shared[DK_Q4_BLOCKS * 8];
     __local float q_d_shared[DK_Q4_BLOCKS];
     __local int   q_sum_shared[DK_Q4_BLOCKS];
@@ -513,12 +507,8 @@ __kernel void flash_attn_f32_q4_0_q1_vec(
         const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
 
 #ifdef FA_HAVE_INT_DOT
-        // Per-lane dp4a path: each lane packs 4 raw q4_0 nibbles (its
-        // quartet of the K block) into a uint, then dot_acc_sat_4x8packed_ss_int
-        // against the matching Q-quartet uint from q_packed_shared. The
-        // (nibble - 8) bias correction is folded in on lane_in_block==0 only,
-        // so the per-block sum reduces correctly across the 8 lanes
-        // contributing to it.
+        // per-lane dp4a: each lane packs 4 raw q4_0 nibbles into a uint,
+        // then dot_acc_sat_4x8packed_ss_int against the matching uint.
         ACC_TYPE lane_contrib = 0.0f;
         for (int qk = tid_sg; qk < DK_VEC; qk += Q1_WG_SIZE) {
             const int block_idx     = qk / 8;
@@ -542,9 +532,7 @@ __kernel void flash_attn_f32_q4_0_q1_vec(
             const float block_scale = qd * kd;
             float contrib = (float)raw_dot * block_scale;
             if (lane_in_block == 0) {
-                // Block bias correction is per-block; attribute it to lane 0
-                // so summing across the 8 lanes recovers
-                // qd*kd*(raw_dot_block - 8*q_sum_block).
+                // block bias correction is per-block
                 const int q_sum_b = q_sum_shared[block_idx];
                 contrib -= 8.0f * block_scale * (float)q_sum_b;
             }
@@ -856,21 +844,6 @@ __kernel void flash_attn_f32_q4_0_q1_split(
 #define WG_SIZE             BLOCK_M
 #endif
 
-// ---------------------------------------------------------------------------
-// flash_attn_f32_q4_0_q1_vec_mq_split — Multi-Query KV-head-coalesced FA decode
-// with flash-decoding split for q4_0 KV. Structural port of the f16/q8_0 MQ
-// split kernels, with q4_0-specific dp4a K dot (per-lane raw_dot against
-// LDS-staged Q-quantized-int8 + per-block bias correction on lane 0).
-// V dequant stays float (output-side, not on the hot dot).
-//
-// Compile-time params:
-//   MQ_GQA       — Q-heads coalesced per WG (defaults 4; second compile =8
-//                  for Qwen3-30B-A3B / Qwen3-4B GQA=8 class).
-//   MQ_NSG_SPLIT — subgroups per WG (defaults 4; second compile =3 paired
-//                  with MQ_GQA=8 on Adreno X2 where the per-kernel WG cap
-//                  drops to 192 due to register pressure).
-// ---------------------------------------------------------------------------
-
 #ifndef MQ_GQA
 #define MQ_GQA 4
 #endif
@@ -943,9 +916,6 @@ __kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
     const global char * k_base = (const global char *) k_void + k_offset;
     const global char * v_base = (const global char *) v_void + v_offset;
 
-    // Stage MQ_GQA Q rows in __local as float4. Used by the FA_HAVE_INT_DOT
-    // path as the source for Q-block quantize, and by the fallback path as
-    // the direct Q vectors for fp dot.
     __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE_Q4) {
         const int h        = i / DK_VEC;
@@ -958,8 +928,6 @@ __kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
     barrier(CLK_LOCAL_MEM_FENCE);
 
 #ifdef FA_HAVE_INT_DOT
-    // Per-h, per-block: int8-packed Q + per-block (qd, q_sum). Quantize once
-    // per WG. One thread per (h, block) — MQ_GQA × DK_Q4_BLOCKS active.
     __local uint  q_packed_shared[MQ_GQA * DK_Q4_BLOCKS * 8];
     __local float q_d_shared[MQ_GQA * DK_Q4_BLOCKS];
     __local int   q_sum_shared[MQ_GQA * DK_Q4_BLOCKS];
@@ -1026,11 +994,6 @@ __kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
         const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
 
 #ifdef FA_HAVE_INT_DOT
-        // Per-lane dp4a: each lane handles its quartet of one K block. Each
-        // lane's contribution to each h is dp4a(Q_h_packed, K_packed) scaled
-        // by qd_h * kd. Per-block bias correction (-8*qd_h*kd*q_sum_h) is
-        // attributed to lane_in_block==0 so summing across 8 lanes recovers
-        // qd_h*kd*(raw_dot_block - 8*q_sum_block).
         ACC_TYPE lane_contrib[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) lane_contrib[h] = 0.0f;
@@ -1080,7 +1043,7 @@ __kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
             score[h] = s;
         }
 #else
-        // Fallback float-dequant K dot.
+        // fallback float-dequant K dot
         ACC_TYPE4 dot4[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
@@ -1134,7 +1097,7 @@ __kernel void flash_attn_f32_q4_0_q1_vec_mq_split(
         }
     }
 
-    // Per-h cross-subgroup merge: subgroup 0 folds MQ_NSG_SPLIT partials.
+    // per-h cross-subgroup merge
     __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG_SPLIT];
     __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG_SPLIT];
     __local ACC_TYPE4 sg_o[MQ_NSG_SPLIT][DV_VEC];

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -414,7 +414,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec(
     #pragma unroll
     for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[i] = (ACC_TYPE4)(0.0f);
 
-    ACC_TYPE m_i = -INFINITY;
+    ACC_TYPE m_i = FA_M_INIT;
     ACC_TYPE l_i = 0.0f;
 
     const int kv_per_sg = (n_kv + VEC_NSG - 1) / VEC_NSG;
@@ -814,7 +814,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
-                rec[0] = -INFINITY;
+                rec[0] = FA_M_INIT;
                 rec[1] = 0.0f;
             }
         }
@@ -865,7 +865,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
     ACC_TYPE  l_i[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        m_i[h] = -INFINITY;
+        m_i[h] = FA_M_INIT;
         l_i[h] = 0.0f;
         #pragma unroll
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -310,6 +310,206 @@ __kernel void flash_attn_f32_q8_0_q1(
     }
 }
 
+// Decode variant for large DV with q8_0 KV — mirrors the f16 vec FA design.
+// See flash_attn_f32_f16.cl / _q4_0.cl for the protocol; the only change here
+// is the per-lane q8_0 dequant on the K/V reads.
+#ifdef cl_intel_subgroups
+#pragma OPENCL EXTENSION cl_intel_subgroups : enable
+#else
+#pragma OPENCL EXTENSION cl_khr_subgroups : enable
+#endif
+
+#ifdef cl_qcom_reqd_sub_group_size
+#pragma OPENCL EXTENSION cl_qcom_reqd_sub_group_size : enable
+#define REQD_SUBGROUP_SIZE_64 __attribute__((qcom_reqd_sub_group_size("half")))
+#else
+#define REQD_SUBGROUP_SIZE_64
+#endif
+
+#define VEC_NSG          4
+#define VEC_WG_SIZE      (Q1_WG_SIZE * VEC_NSG)
+#define Q1V_DV_PER_THREAD ((DV_VEC + Q1_WG_SIZE - 1) / Q1_WG_SIZE)
+
+// Dequant one float4 lane (0..7) from a q8_0 block.
+// Each q8_0 block holds 32 int8 values; lane L reads bytes [2+L*4 .. 2+L*4+3].
+inline float4 dequant_q8_0_lane(const global char * block_ptr, int lane) {
+    const float d = vload_half(0, (const global half *)block_ptr);
+    const global char * qs = block_ptr + 2 + lane * 4;
+    return d * (float4)((float)qs[0], (float)qs[1], (float)qs[2], (float)qs[3]);
+}
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_q8_0_q1_vec(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    global void * o_void, ulong o_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int is_causal,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const ulong o_nb1, const ulong o_nb2, const ulong o_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void* mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    const global void* sinks_void,
+    const ulong sinks_offset
+) {
+    const int tid             = get_local_id(0);
+    const int sgid            = tid / Q1_WG_SIZE;
+    const int tid_sg          = tid % Q1_WG_SIZE;
+    const int head_batch_idx  = get_global_id(1);
+
+    const int batch_idx = head_batch_idx / n_head;
+    const int head_idx  = head_batch_idx % n_head;
+
+    const int gqa_ratio   = n_head / n_head_kv;
+    const int head_kv_idx = head_idx / gqa_ratio;
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+    global       char * o_base = (global       char *) o_void + o_offset;
+
+    const global char * mask_base = NULL;
+    if (mask_void != NULL) {
+        const int mask_head_idx  = head_idx  % mask_ne2;
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        mask_base = (const global char *) mask_void + mask_offset +
+                    mask_batch_idx * mask_nb3 + mask_head_idx * mask_nb2;
+    }
+
+    __local ACC_TYPE4 q_shared[DK_VEC];
+    {
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        for (int i = tid; i < DK_VEC; i += VEC_WG_SIZE) {
+            q_shared[i] = CONVERT_Q_ACC4(q_ptr[i]);
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const float slope = get_alibi_slope(max_bias, head_idx, n_head_log2, m0, m1);
+
+    const global ACC_TYPE * sinks_ptr = NULL;
+    if (sinks_void != NULL) {
+        sinks_ptr = (const global ACC_TYPE *) ((const global char *) sinks_void + sinks_offset);
+    }
+
+    ACC_TYPE4 o_acc[Q1V_DV_PER_THREAD];
+    #pragma unroll
+    for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[i] = (ACC_TYPE4)(0.0f);
+
+    ACC_TYPE m_i = -INFINITY;
+    ACC_TYPE l_i = 0.0f;
+
+    const int kv_per_sg = (n_kv + VEC_NSG - 1) / VEC_NSG;
+    const int kv_start  = sgid * kv_per_sg;
+    const int kv_end    = min(n_kv, kv_start + kv_per_sg);
+
+    for (int k_idx = kv_start; k_idx < kv_end; ++k_idx) {
+        const global char * k_row = k_base + batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
+        const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+
+        ACC_TYPE4 dot4 = (ACC_TYPE4)(0.0f);
+        for (int qk = tid_sg; qk < DK_VEC; qk += Q1_WG_SIZE) {
+            const int block_idx = qk / 8;
+            const int lane      = qk % 8;
+            const float4 k_v = dequant_q8_0_lane(k_row + block_idx * Q8_0_BLOCK_SIZE, lane);
+            dot4 = mad(q_shared[qk], k_v, dot4);
+        }
+        ACC_TYPE dot_partial = dot4.s0 + dot4.s1 + dot4.s2 + dot4.s3;
+        ACC_TYPE score = sub_group_reduce_add(dot_partial) * scale;
+
+        if (mask_base != NULL) {
+            const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base;
+            score += slope * (ACC_TYPE) mask_ptr[k_idx];
+        }
+        if (logit_softcap > 0.0f) {
+            score = logit_softcap * tanh(score / logit_softcap);
+        }
+
+        const ACC_TYPE m_new      = max(m_i, score);
+        const ACC_TYPE scale_prev = native_exp(m_i - m_new);
+        const ACC_TYPE p          = native_exp(score - m_new);
+
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            const int block_idx = dv / 8;
+            const int lane      = dv % 8;
+            const float4 v_v = dequant_q8_0_lane(v_row + block_idx * Q8_0_BLOCK_SIZE, lane);
+            o_acc[idx] = mad(p, v_v, o_acc[idx] * scale_prev);
+        }
+        l_i = l_i * scale_prev + p;
+        m_i = m_new;
+    }
+
+    __local ACC_TYPE  sg_m[VEC_NSG];
+    __local ACC_TYPE  sg_l[VEC_NSG];
+    __local ACC_TYPE4 sg_o[VEC_NSG][DV_VEC];
+
+    if (tid_sg == 0) {
+        sg_m[sgid] = m_i;
+        sg_l[sgid] = l_i;
+    }
+    {
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            sg_o[sgid][dv] = o_acc[idx];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (sgid == 0) {
+        ACC_TYPE m_final = sg_m[0];
+        #pragma unroll
+        for (int s = 1; s < VEC_NSG; ++s) {
+            m_final = max(m_final, sg_m[s]);
+        }
+        if (sinks_ptr != NULL) {
+            m_final = max(m_final, sinks_ptr[head_idx]);
+        }
+
+        ACC_TYPE l_final = 0.0f;
+        #pragma unroll
+        for (int s = 0; s < VEC_NSG; ++s) {
+            l_final += sg_l[s] * native_exp(sg_m[s] - m_final);
+        }
+        if (sinks_ptr != NULL) {
+            l_final += native_exp(sinks_ptr[head_idx] - m_final);
+        }
+        const ACC_TYPE l_inv = (l_final > 0.0f) ? (1.0f / l_final) : 0.0f;
+
+        const ulong o_row_offset = batch_idx * o_nb3 + head_idx * o_nb1;
+        global O_DATA_TYPE4 * o_row = (global O_DATA_TYPE4 *) (o_base + o_row_offset);
+
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+            #pragma unroll
+            for (int s = 0; s < VEC_NSG; ++s) {
+                const ACC_TYPE alpha = native_exp(sg_m[s] - m_final);
+                o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv], o_merged);
+            }
+            o_row[dv] = CONVERT_O_DATA4(o_merged * l_inv);
+        }
+    }
+}
+
 // Flash-decoding split pass for q8_0 KV. Partial record: [m, l, O[DV]].
 // Merge kernel from flash_attn_f32_f16.cl is type-agnostic and reused.
 #define FA_PARTIAL_FLOATS (2 + DV)
@@ -532,6 +732,267 @@ __kernel void flash_attn_f32_q8_0_q1_split(
 #ifndef FA_V_STRATEGY
 #define FA_V_STRATEGY 0
 #endif
+
+// ---------------------------------------------------------------------------
+// flash_attn_f32_q8_0_q1_vec_mq_split — Multi-Query KV-head-coalesced FA decode
+// with flash-decoding split for q8_0 KV. Structural port of
+// flash_attn_f32_f16_q1_vec_mq_split (in flash_attn_f32_f16.cl); each WG handles
+// MQ_GQA Q-heads sharing one KV-head, so K and V are read once and reused
+// MQ_GQA times. Per-h state (m_i, l_i, o_acc, slope, mask_base) tracked
+// separately.
+//
+// Compile-time params:
+//   MQ_GQA       — Q-heads coalesced per WG (defaults 4; second compile with =8
+//                  for Qwen3-30B-A3B class).
+//   MQ_NSG_SPLIT — subgroups per WG (defaults 4; second compile with =3 paired
+//                  with MQ_GQA=8 on Adreno X2 where the per-kernel WG cap drops
+//                  to 192 due to register pressure).
+//
+// Writes one partial record per (batch, head_idx, q_idx, split_idx) into
+// partial_void; flash_attn_f32_merge (below) normalizes across splits.
+// ---------------------------------------------------------------------------
+
+#ifndef MQ_GQA
+#define MQ_GQA 4
+#endif
+#ifndef MQ_NSG_SPLIT
+#define MQ_NSG_SPLIT 4
+#endif
+#define MQ_SPLIT_WG_SIZE_Q8 (Q1_WG_SIZE * MQ_NSG_SPLIT)
+
+REQD_SUBGROUP_SIZE_64
+__kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
+    const global void * q_void, ulong q_offset,
+    const global void * k_void, ulong k_offset,
+    const global void * v_void, ulong v_offset,
+    const float scale,
+    const int n_q,
+    const int n_kv,
+    const int n_head,
+    const ulong q_nb1, const ulong q_nb2, const ulong q_nb3,
+    const ulong k_nb1, const ulong k_nb2, const ulong k_nb3,
+    const ulong v_nb1, const ulong v_nb2, const ulong v_nb3,
+    const float max_bias,
+    const float m0,
+    const float m1,
+    const int n_head_log2,
+    const float logit_softcap,
+    const int n_head_kv,
+    const global void * mask_void,
+    const ulong mask_offset,
+    const ulong mask_nb1,
+    const ulong mask_nb2,
+    const ulong mask_nb3,
+    const int mask_ne2,
+    const int mask_ne3,
+    global float * partial_void,
+    const int n_splits,
+    const int kv_per_split
+) {
+    const int tid              = get_local_id(0);
+    const int sgid             = tid / Q1_WG_SIZE;
+    const int tid_sg           = tid % Q1_WG_SIZE;
+    const int kvhead_batch_idx = get_global_id(1);
+    const int split_q_idx      = get_global_id(2);
+    const int split_idx        = split_q_idx % n_splits;
+    const int q_idx            = split_q_idx / n_splits;
+
+    const int batch_idx   = kvhead_batch_idx / n_head_kv;
+    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+
+    const int kv_start = split_idx * kv_per_split;
+    const int kv_end   = min(kv_start + kv_per_split, n_kv);
+
+    const ulong record_stride = (ulong) FA_PARTIAL_FLOATS;
+
+    if (kv_start >= kv_end) {
+        // Empty split — write sentinel for each of the MQ_GQA Q-heads.
+        if (tid == 0) {
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                       * n_splits + split_idx);
+                global float * rec = partial_void + rec_idx * record_stride;
+                rec[0] = -INFINITY;
+                rec[1] = 0.0f;
+            }
+        }
+        return;
+    }
+
+    const global char * q_base = (const global char *) q_void + q_offset;
+    const global char * k_base = (const global char *) k_void + k_offset;
+    const global char * v_base = (const global char *) v_void + v_offset;
+
+    // Stage MQ_GQA Q rows in __local as float4 once (uniform across WG).
+    __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
+    for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE_Q8) {
+        const int h        = i / DK_VEC;
+        const int k        = i % DK_VEC;
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    float slope[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+    }
+
+    const global char * mask_base[MQ_GQA];
+    if (mask_void != NULL) {
+        const int mask_batch_idx = batch_idx % mask_ne3;
+        const global char * mask_base_b = (const global char *) mask_void + mask_offset +
+                                          mask_batch_idx * mask_nb3 +
+                                          (ulong) q_idx * mask_nb1;
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int mask_head_idx = head_idx % mask_ne2;
+            mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
+        }
+    } else {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
+    }
+
+    ACC_TYPE4 o_acc[MQ_GQA][Q1V_DV_PER_THREAD];
+    ACC_TYPE  m_i[MQ_GQA];
+    ACC_TYPE  l_i[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        m_i[h] = -INFINITY;
+        l_i[h] = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
+    }
+
+    // Each subgroup sweeps its slice of this split's kv range.
+    const int kv_len    = kv_end - kv_start;
+    const int kv_per_sg = (kv_len + MQ_NSG_SPLIT - 1) / MQ_NSG_SPLIT;
+    const int kv_lo     = kv_start + sgid * kv_per_sg;
+    const int kv_hi     = min(kv_end, kv_lo + kv_per_sg);
+
+    for (int k_idx = kv_lo; k_idx < kv_hi; ++k_idx) {
+        const global char * k_row = k_base + batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
+        const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
+
+        ACC_TYPE4 dot4[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
+
+        for (int qk = tid_sg; qk < DK_VEC; qk += Q1_WG_SIZE) {
+            const int block_idx = qk / 8;
+            const int lane      = qk % 8;
+            const float4 k_v = dequant_q8_0_lane(k_row + block_idx * Q8_0_BLOCK_SIZE, lane);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                dot4[h] = mad(q_shared[h * DK_VEC + qk], k_v, dot4[h]);
+            }
+        }
+
+        ACC_TYPE score[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE dot_partial = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+            ACC_TYPE s = sub_group_reduce_add(dot_partial) * scale;
+            if (mask_base[h] != NULL) {
+                const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_idx];
+            }
+            if (logit_softcap > 0.0f) {
+                s = logit_softcap * tanh(s / logit_softcap);
+            }
+            score[h] = s;
+        }
+
+        ACC_TYPE p_h[MQ_GQA];
+        ACC_TYPE sp_h[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE m_new = max(m_i[h], score[h]);
+            sp_h[h] = native_exp(m_i[h] - m_new);
+            p_h[h]  = native_exp(score[h] - m_new);
+            l_i[h]  = l_i[h] * sp_h[h] + p_h[h];
+            m_i[h]  = m_new;
+        }
+
+        int idx = 0;
+        for (int dv = tid_sg; dv < DV_VEC; dv += Q1_WG_SIZE, ++idx) {
+            const int block_idx = dv / 8;
+            const int lane      = dv % 8;
+            const float4 v_v = dequant_q8_0_lane(v_row + block_idx * Q8_0_BLOCK_SIZE, lane);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                o_acc[h][idx] = mad(p_h[h], v_v, o_acc[h][idx] * sp_h[h]);
+            }
+        }
+    }
+
+    // Per-h cross-subgroup merge: subgroup 0 folds NSG partials into a single
+    // (m, l, O) record per Q-head, written to the partial buffer.
+    __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG_SPLIT];
+    __local ACC_TYPE4 sg_o[MQ_NSG_SPLIT][DV_VEC];
+
+    if (tid_sg == 0) {
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            sg_m[h][sgid] = m_i[h];
+            sg_l[h][sgid] = l_i[h];
+        }
+    }
+
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        {
+            int idx = 0;
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE, ++idx) {
+                sg_o[sgid][dv_idx] = o_acc[h][idx];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (sgid == 0) {
+            const int head_idx = head_kv_idx * MQ_GQA + h;
+
+            ACC_TYPE m_c = sg_m[h][0];
+            #pragma unroll
+            for (int s = 1; s < MQ_NSG_SPLIT; ++s) {
+                m_c = max(m_c, sg_m[h][s]);
+            }
+            ACC_TYPE l_c = 0.0f;
+            #pragma unroll
+            for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                l_c += sg_l[h][s] * native_exp(sg_m[h][s] - m_c);
+            }
+
+            const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
+                                   * n_splits + split_idx);
+            global float  * rec   = partial_void + rec_idx * record_stride;
+            global float4 * rec_o = (global float4 *) (rec + 2);
+
+            if (tid_sg == 0) {
+                rec[0] = (float) m_c;
+                rec[1] = (float) l_c;
+            }
+            for (int dv_idx = tid_sg; dv_idx < DV_VEC; dv_idx += Q1_WG_SIZE) {
+                ACC_TYPE4 o_merged = (ACC_TYPE4)(0.0f);
+                #pragma unroll
+                for (int s = 0; s < MQ_NSG_SPLIT; ++s) {
+                    const ACC_TYPE alpha = native_exp(sg_m[h][s] - m_c);
+                    o_merged = mad((ACC_TYPE4)(alpha), sg_o[s][dv_idx], o_merged);
+                }
+                rec_o[dv_idx] = o_merged;
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+}
 
 __kernel void flash_attn_f32_q8_0(
     const global void * q_void, ulong q_offset,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -24,8 +24,7 @@
 
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
-// q1 reduces over a Q1_WG_SIZE-wide WG via work-group barriers; the launch WG
-// must match. Defaults to the Adreno sg (64); host passes -D FA_SG=32 on Intel.
+
 #ifndef FA_SG
 #define FA_SG 64
 #endif
@@ -315,9 +314,6 @@ __kernel void flash_attn_f32_q8_0_q1(
     }
 }
 
-// Decode variant for large DV with q8_0 KV — mirrors the f16 vec FA design.
-// See flash_attn_f32_f16.cl / _q4_0.cl for the protocol; the only change here
-// is the per-lane q8_0 dequant on the K/V reads.
 #ifdef cl_intel_subgroups
 #pragma OPENCL EXTENSION cl_intel_subgroups : enable
 #else
@@ -335,8 +331,6 @@ __kernel void flash_attn_f32_q8_0_q1(
 #define VEC_WG_SIZE      (Q1_WG_SIZE * VEC_NSG)
 #define Q1V_DV_PER_THREAD ((DV_VEC + Q1_WG_SIZE - 1) / Q1_WG_SIZE)
 
-// Dequant one float4 lane (0..7) from a q8_0 block.
-// Each q8_0 block holds 32 int8 values; lane L reads bytes [2+L*4 .. 2+L*4+3].
 inline float4 dequant_q8_0_lane(const global char * block_ptr, int lane) {
     const float d = vload_half(0, (const global half *)block_ptr);
     const global char * qs = block_ptr + 2 + lane * 4;
@@ -738,25 +732,6 @@ __kernel void flash_attn_f32_q8_0_q1_split(
 #define FA_V_STRATEGY 0
 #endif
 
-// ---------------------------------------------------------------------------
-// flash_attn_f32_q8_0_q1_vec_mq_split — Multi-Query KV-head-coalesced FA decode
-// with flash-decoding split for q8_0 KV. Structural port of
-// flash_attn_f32_f16_q1_vec_mq_split (in flash_attn_f32_f16.cl); each WG handles
-// MQ_GQA Q-heads sharing one KV-head, so K and V are read once and reused
-// MQ_GQA times. Per-h state (m_i, l_i, o_acc, slope, mask_base) tracked
-// separately.
-//
-// Compile-time params:
-//   MQ_GQA       — Q-heads coalesced per WG (defaults 4; second compile with =8
-//                  for Qwen3-30B-A3B class).
-//   MQ_NSG_SPLIT — subgroups per WG (defaults 4; second compile with =3 paired
-//                  with MQ_GQA=8 on Adreno X2 where the per-kernel WG cap drops
-//                  to 192 due to register pressure).
-//
-// Writes one partial record per (batch, head_idx, q_idx, split_idx) into
-// partial_void; flash_attn_f32_merge (below) normalizes across splits.
-// ---------------------------------------------------------------------------
-
 #ifndef MQ_GQA
 #define MQ_GQA 4
 #endif
@@ -830,7 +805,6 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
     const global char * k_base = (const global char *) k_void + k_offset;
     const global char * v_base = (const global char *) v_void + v_offset;
 
-    // Stage MQ_GQA Q rows in __local as float4 once (uniform across WG).
     __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE_Q8) {
         const int h        = i / DK_VEC;
@@ -876,7 +850,6 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
         for (int i = 0; i < Q1V_DV_PER_THREAD; ++i) o_acc[h][i] = (ACC_TYPE4)(0.0f);
     }
 
-    // Each subgroup sweeps its slice of this split's kv range.
     const int kv_len    = kv_end - kv_start;
     const int kv_per_sg = (kv_len + MQ_NSG_SPLIT - 1) / MQ_NSG_SPLIT;
     const int kv_lo     = kv_start + sgid * kv_per_sg;
@@ -938,8 +911,6 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
         }
     }
 
-    // Per-h cross-subgroup merge: subgroup 0 folds NSG partials into a single
-    // (m, l, O) record per Q-head, written to the partial buffer.
     __local ACC_TYPE  sg_m[MQ_GQA][MQ_NSG_SPLIT];
     __local ACC_TYPE  sg_l[MQ_GQA][MQ_NSG_SPLIT];
     __local ACC_TYPE4 sg_o[MQ_NSG_SPLIT][DV_VEC];

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -24,7 +24,12 @@
 
 #define DK_VEC (DK/4)
 #define DV_VEC (DV/4)
-#define Q1_WG_SIZE 64
+// q1 reduces over a Q1_WG_SIZE-wide WG via work-group barriers; the launch WG
+// must match. Defaults to the Adreno sg (64); host passes -D FA_SG=32 on Intel.
+#ifndef FA_SG
+#define FA_SG 64
+#endif
+#define Q1_WG_SIZE FA_SG
 
 // The kernels are built with -cl-finite-math-only. On some older Adreno GPUs,
 // infinite operand can cause undefined behavior and miscompilation for exp.

--- a/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_l4.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_l4.cl
@@ -387,16 +387,6 @@ kernel void kernel_mul_mat_f16_f32_l4_dr_lq(
 }
 #endif // ADRENO_GPU
 
-// Multi-row variant: each workgroup processes N_ROWS_PER_WG K rows instead of
-// 1, amortizing dispatch overhead. The default kernel above launches one WG
-// per (r0, im) which means ~262K workgroups for Qwen3.6 attn KQ at d=16k —
-// 64 threads each doing one mad and a sub_group_reduce. Per-call wall time is
-// ~8× over the K-bandwidth ideal because of wave-dispatch + memory-latency
-// overhead. This variant collapses 8 of those WGs into one and caches Q once
-// per Q-row in __local across the 8 K-row computations.
-//
-// Dispatched when ne11 == 1 (decode: single Q row) and ne01 % N_ROWS == 0,
-// with global x = ne01/N_ROWS * subgroup_size.
 #define N_ROWS_PER_WG 8
 #define N_OUTS_PER_WG 8
 
@@ -442,8 +432,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8(
     const int i12 = im % ne12;
     const int i13 = im / ne12;
 
-    // Single Q row only (decode). Cache Q once in __local for reuse across
-    // the N_ROWS K-row computations.
     const ulong offset_src1 = (i12) * nb12 + (i13) * nb13;
     global float4 * y4 = (global float4 *)(src1 + offset_src1);
 
@@ -478,16 +466,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8(
     }
 }
 
-// Streaming-Q multi-output variant for the KQV-shaped matmul: src0 has small
-// ne01 (e.g. DV=256) but large ne00 (n_kv, up to 16384 at d=16k). The x8
-// kernel can't handle this because its per-WG __local Q cache is sized for
-// ne00 <= 256. This variant streams Q from global (no cache) but still packs
-// N_OUTS_PER_WG = 8 outputs per workgroup. Q is re-read once per output
-// inside the inner loop; Adreno L1 absorbs the 8× redundancy since adjacent
-// outputs in one WG hit the same Q cache lines per iter.
-//
-// Dispatched for the same shape pattern as x8 (ne11 == 1, ne01 divisible by 8)
-// when ne00 > 256, i.e. when the x8 path can't be used.
 #ifdef ADRENO_GPU
 REQD_SUBGROUP_SIZE_64
 #endif
@@ -530,18 +508,13 @@ kernel void kernel_mul_mat_f16_f32_l4_y8(
     const int i12 = im % ne12;
     const int i13 = im / ne12;
 
-    // Q (= src1) base pointer; r1 == 0 since ne11 == 1.
     const ulong offset_src1 = (i12) * nb12 + (i13) * nb13;
     global float4 * y4 = (global float4 *)(src1 + offset_src1);
 
-    // Per-output base pointers (per row of src0). Computed once; inner loop
-    // strides float4 indices across them.
     global half4 * x4_o[N_OUTS_PER_WG];
     #pragma unroll
     for (int o = 0; o < N_OUTS_PER_WG; ++o) {
         const int r0 = r0_base + o;
-        // Pre-cap: if r0 OOB, point to the first row (harmless reads, output
-        // suppressed at write-time). Keeps the inner loop unconditional.
         const int r0c = (r0 < ne01) ? r0 : 0;
         const ulong off = r0c * nb01 + (i12 / r2) * nb02 + (i13 / r3) * nb03;
         x4_o[o] = (global half4 *)(src0 + off);
@@ -571,31 +544,6 @@ kernel void kernel_mul_mat_f16_f32_l4_y8(
     }
 }
 
-// Lane-utilization variant of _x8 for the long-context KQ matmul (Adreno X2).
-//
-// Background: _x8 runs the inner K-loop as
-//   for (i = sgs_lid; i < ne00/4; i += sgs_sz)
-// At DK=128 (Qwen3/Qwen3.6/etc. attention head dim), ne00/4 = 32 but
-// sgs_sz = 64, so the loop runs ONCE with lanes 0..31 active and lanes
-// 32..63 idle. With N_ROWS_PER_WG=8 outer iters, half of every wave-cycle
-// is wasted and the kernel issues only 32 cache-line requests per K-row
-// instead of 64. The depth-sweep on Qwen3-30B-A3B (tg128@d=16k) attributes
-// ~9.5% of the 76 GB/s coalesced-read peak — almost exactly the 50% lane
-// idle × ~20% small-WG ceiling.
-//
-// Fix: pair K-rows across the warp. Lanes 0..31 process row (2p+0), lanes
-// 32..63 process row (2p+1), in parallel. 4 pair iters cover the same 8
-// outputs. Per-pair reduction stays within each 32-lane half via
-// sub_group_shuffle_xor with masks <32 (per opencl_ssm_scan_mamba2:
-// shuffle_xor with mask>=32 silently miscompiles on Adreno X2; we never
-// cross the half-warp boundary).
-//
-// Same total compute (32×8 = 64×4 = 256 lane-mads), same total K bytes per
-// WG, but 2× the per-wave-cycle memory-issue parallelism. Most beneficial
-// for DK in [128, 256] where the per-row inner loop is only 1-2 iters.
-//
-// Dispatch grid identical to _x8: nth0=64, ((ne01/8)*64, 1, ne12*ne13).
-// Opt-in via env var GGML_OPENCL_MM_KQ_PAIR=1 on the host side.
 #define N_OUTS_PAIR  8
 #define N_PAIRS_PAIR (N_OUTS_PAIR / 2)
 
@@ -642,8 +590,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_pair(
     const int i12 = im % ne12;
     const int i13 = im / ne12;
 
-    // Single Q row (decode). Cache Q once in __local for reuse across all
-    // N_OUTS_PAIR K-rows. Both halves of the warp broadcast-read q_loc.
     const ulong offset_src1 = (i12) * nb12 + (i13) * nb13;
     global float4 * y4 = (global float4 *)(src1 + offset_src1);
 
@@ -657,15 +603,12 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_pair(
 
     #pragma unroll
     for (int p = 0; p < N_PAIRS_PAIR; ++p) {
-        // Lower half handles even row, upper half handles odd row.
-        // Dispatch guarantees ne01 % 8 == 0, so r0 is always in range.
         const int r0 = r0_base + 2 * p + half_id;
 
         const ulong offset_src0 = r0 * nb01 + (i12 / r2) * nb02 + (i13 / r3) * nb03;
         global half4 * x4 = (global half4 *)(src0 + offset_src0);
 
         float sumf = 0.0f;
-        // Stride 32 within the 32-lane half. For DK=128 this runs once.
         for (int i = lane_h; i < dk_vec; i += 32) {
             const half4  k4 = x4[i];
             const float4 q  = q_loc[i];
@@ -675,8 +618,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_pair(
                   + convert_float(k4.s3) * q.s3;
         }
 
-        // Reduce within 32-lane half. All 64 lanes execute; the shuffle is
-        // self-contained within each half because masks are <32.
         sumf += sub_group_shuffle_xor(sumf, 16);
         sumf += sub_group_shuffle_xor(sumf, 8);
         sumf += sub_group_shuffle_xor(sumf, 4);
@@ -689,25 +630,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_pair(
     }
 }
 
-// GQA-coalesced KQ variant for the long-context fa=0 path on Adreno X2.
-//
-// Background: at DK=128 the regular _x8 kernel reads each K-row r2 times
-// (once per Q-head sharing the K-head — Qwen3-30B-A3B has r2 = n_head_q /
-// n_head_kv = 8 with n_head_q=32, n_head_kv=4). At d=16k that's 16 MB of
-// unique K read as 128 MB. The L2 path saturates near 56 GB/s, but most of
-// the BW pays for redundant fetches; effective unique-K BW is 9.5% of peak.
-//
-// Fix: one WG per K-head (instead of per Q-head). The 64-lane warp partitions
-// across GQA_RATIO=8 Q-heads (8 lanes each at DK=128 → 32 dk_vec elements /
-// 8 lanes = 4 mads per lane per K-row). Each K-row is read once from global
-// and contributes to GQA_RATIO outputs. Q vectors for the gqa_ratio Q-heads
-// are pre-staged in __local.
-//
-// Specialized for DK=128 and GQA_RATIO=8 (Qwen3-30B-A3B / Qwen3-4B /
-// Qwen3.6-A3B). Other shapes fall through to the regular _x8 path.
-//
-// Dispatch (separate from _x8): nth0=64, ((ne01/8)*64, 1, ne02*ne13).
-// Opt-in via env var GGML_OPENCL_MM_KQ_GQA=1 on the host.
 #define N_K_ROWS_GQA   16
 #define GQA_RATIO_GQA  8
 #define LANES_PER_QH   8    // 64 / GQA_RATIO_GQA
@@ -756,19 +678,14 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa4(
     const int i02 = im_kv % ne02;           // K-head index (also K2 batch)
     const int i03 = im_kv / ne02;           // n13 batch index
 
-    // GQA Q-heads sharing this K-head: i12 ∈ [i02*r2, i02*r2 + r2).
-    // (r2 is the dispatch's guarantee == GQA_RATIO_GQA at this gate.)
     const int q_head_lo = i02 * GQA_RATIO_GQA;
 
-    // Stage all GQA_RATIO Q vectors (one per Q-head sharing the K-head) into
-    // __local. Each Q-head has DK_VEC_GQA = 32 float4 elements; 64 lanes load
-    // 2 per Q-head (32 lanes × 2) using the first 32 lanes per Q-head.
     __local float4 q_loc[GQA_RATIO_GQA * DK_VEC_GQA];   // 4 × 32 = 128 float4
     #pragma unroll
     for (int qh = 0; qh < GQA_RATIO_GQA; ++qh) {
         const int qh_idx = q_head_lo + qh;
         global float4 * y4 = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
-        // Only lanes [0, DK_VEC_GQA) load; broadcast-safe.
+
         if (sgs_lid < DK_VEC_GQA) {
             q_loc[qh * DK_VEC_GQA + sgs_lid] = y4[sgs_lid];
         }
@@ -781,15 +698,10 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa4(
     #pragma unroll
     for (int dr = 0; dr < N_K_ROWS_GQA; ++dr) {
         const int r0 = r0_base + dr;
-        // Dispatch guarantees ne01 % N_K_ROWS_GQA == 0, so r0 < ne01.
 
         const ulong offset_src0 = r0 * nb01 + offset_src0_base;
         global half4 * x4 = (global half4 *)(src0 + offset_src0);
 
-        // Each lane reads 4 K elements covering DK_VEC_GQA = 32 float4 with
-        // LANES_PER_QH = 8 lanes per Q-head partition. The 8 Q-head
-        // partitions in the warp all read the same K-row in parallel (8
-        // duplicated reads per element, served by L1 once cached).
         float sumf = 0.0f;
         #pragma unroll
         for (int t = 0; t < 4; ++t) {
@@ -802,45 +714,17 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa4(
                   + convert_float(k4.s3) * q.s3;
         }
 
-        // Reduce within 8-lane Q-head partition (masks < 8, well within the
-        // safe-shuffle range for Adreno X2's 32-lane cluster bound).
         sumf += sub_group_shuffle_xor(sumf, 4);
         sumf += sub_group_shuffle_xor(sumf, 2);
         sumf += sub_group_shuffle_xor(sumf, 1);
 
         if (lane_q == 0) {
-            // im for this Q-head: linearized (i12=q_head_lo+q_id, i13=i03)
-            // matching the original _x8 dst[im * ne1 * ne0 + r0] indexing.
             const int im_out = i03 * ne12 + (q_head_lo + q_id);
             dst[im_out * ne1 * ne0 + r0] = sumf;
         }
     }
 }
 
-// GQA-coalesced KQV variant for the long-context fa=0 path on Adreno X2.
-//
-// Companion to _x8_gqa4 — applies the same GQA-replay-elimination trick to
-// the second mul_mat per attention block. KQV shape: src0 = V cache
-// [ne00=n_kv, ne01=DV=128, ne02=n_head_kv=4]; src1 = softmax(KQ)
-// [ne10=n_kv, ne11=1, ne12=n_head_q=32]. r2 = ne12/ne02 = 8.
-//
-// Current _y8 dispatches one WG per Q-head × 8 DV-row outputs. It re-reads
-// each V slab r2=8 times across Q-heads. Total V read ≈ 128 MB / call at
-// d=16k for only 16 MB unique V data.
-//
-// _y8_gqa: one WG per K-head × 8 DV-row outputs (dispatch z = ne02 * ne13).
-// Each WG produces N_DV_ROWS_Y8GQA × GQA_RATIO_Y8GQA = 8 × 8 = 64 outputs.
-// V is read once per K-head (per DV-row group); softmax read once per
-// (q_head, dv_group) — total softmax read unchanged, total V read /= r2 = 8.
-//
-// Inner loop: each of 64 lanes processes one K-position chunk (4 elements).
-// Per iter, each lane reads 8 V values (one per DV row, all shared K-head)
-// and 8 softmax values (one per Q-head). Per iter, each lane does 64 mads
-// (8 DV × 8 Q-heads). Accumulator footprint per lane: 64 fp32 = 256 B
-// (significant; watch for register pressure).
-//
-// Dispatch grid: nth0=64, ((ne01/8)*64, 1, ne02*ne13). Opt-in via env var
-// GGML_OPENCL_MM_KQV_GQA=1.
 #define N_DV_ROWS_Y8GQA  8
 #define GQA_RATIO_Y8GQA  8
 
@@ -889,9 +773,6 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa(
     // GQA Q-heads sharing this K-head.
     const int q_head_lo = i02 * GQA_RATIO_Y8GQA;
 
-    // Q (= softmax(KQ)) base pointers per Q-head. Streaming — no caching;
-    // each Q-head's softmax is read once per WG. Across all WGs (ne01/8
-    // DV-groups × ne02 K-heads), total softmax reads = ne01/8 × ne12 × n_kv.
     global float4 * y4_q[GQA_RATIO_Y8GQA];
     #pragma unroll
     for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
@@ -899,7 +780,6 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa(
         y4_q[qh] = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
     }
 
-    // 8 V-row base pointers (per DV output). All 8 share K-head i02.
     global half4 * x4_o[N_DV_ROWS_Y8GQA];
     #pragma unroll
     for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
@@ -909,23 +789,23 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa(
         x4_o[o] = (global half4 *)(src0 + off);
     }
 
-    // 64 accumulators: 8 DV rows × 8 Q-heads.
     float sum[N_DV_ROWS_Y8GQA][GQA_RATIO_Y8GQA] = { {0.0f} };
 
     for (int i = sgs_lid; i < ne00 / 4; i += sgs_sz) {
-        // Load 8 V values (one per DV row), same K-head, K-pos = i.
+        // load 8 V values (one per DV row), same K-head, K-pos = i.
         half4 v[N_DV_ROWS_Y8GQA];
         #pragma unroll
         for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
             v[o] = x4_o[o][i];
         }
-        // Load 8 softmax values (one per Q-head).
+
+        // load 8 softmax values (one per Q-head).
         float4 q[GQA_RATIO_Y8GQA];
         #pragma unroll
         for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
             q[qh] = y4_q[qh][i];
         }
-        // 64 mads.
+
         #pragma unroll
         for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
             const float4 vf = (float4)(convert_float(v[o].s0),
@@ -942,7 +822,6 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa(
         }
     }
 
-    // Reduce each of 64 accumulators across the 64-lane subgroup.
     #pragma unroll
     for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
         const int r0 = r0_base + o;
@@ -957,34 +836,6 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa(
     }
 }
 
-// image1d_buffer_t (texture-cache) variant of _x8_gqa4.
-//
-// Background: profiling _x8_gqa4 N_K_ROWS_GQA=16 on Qwen3-30B-A3B (Adreno X2):
-// KQ stayed at 69% of decode time @ d=16k with effective K-read BW of only
-// ~7.3 GB/s — ~10% of the coalesced __global peak (76 GB/s). The kernel is
-// memory-stall bound on serial K-row fetches; widening the per-WG window
-// via N=16 didn't fix it. The prefill mul_mm_f16_f32_kq uses Adreno's
-// texture-cache (image1d_buffer_t) path for K, which is a separate cache
-// from L2 and historically gives much higher effective BW on Adreno.
-//
-// Identical math to _x8_gqa4. The only change is K is bound as a
-// __read_only image1d_buffer_t over a sub-buffer covering the K cache for
-// this call (offset already baked into the sub-buffer). The pixel format
-// is {CL_RGBA, CL_FLOAT} → 1 pixel = 16 bytes = 1 half8 = 2 half4. Two
-// pixels per K-row per lane (lane_q + t*8 for t∈{0,1}) cover 4 half4 worth
-// of K data, matching _x8_gqa4's per-lane coverage. as_half8(float4) is a
-// bit-cast: bytes preserved end-to-end (the prefill kq path uses the same
-// pattern).
-//
-// Layout note: at decode KQ, the K view on Adreno is permuted (nb01 > nb02 —
-// head-major). The host computes k_bytes generically from
-// (ne01-1)*nb01 + (ne02-1)*nb02 + (ne03-1)*nb03 + ne00*sizeof(half) so the
-// image covers the full byte span regardless of layout. Pitches in this
-// kernel still come from nb01/nb02/nb03 unchanged, so the addressing math
-// is identical to _x8_gqa4.
-//
-// Dispatch (separate from _x8_gqa4): same grid as the regular variant.
-// Opt-in via env var GGML_OPENCL_MM_KQ_GQA_IMG=1 on the host.
 #ifdef ADRENO_GPU
 REQD_SUBGROUP_SIZE_64
 #endif
@@ -1038,14 +889,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa4_img(
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    // Image pixel = 1 float4 = 16 bytes = 8 fp16 (= 2 half4). Pitches in pixel
-    // units. Sub-buffer is bound at offset0 host-side so offset0 is not
-    // threaded through here. Each lane reads 2 pixels per K-row covering 4
-    // half4 worth of K data (same coverage as _x8_gqa4) via a slightly
-    // different access pattern: lane lane_q ∈ [0,8) reads pixels {lane_q,
-    // lane_q+8} (covering half4 positions {2*lane_q, 2*lane_q+1, 2*lane_q+16,
-    // 2*lane_q+17}). Coalesced burst: 8 lanes in the same Q-head partition
-    // read 8 consecutive pixels per iter.
     const int pitch_px_row  = (int)(nb01 >> 4);
     const int pitch_px_head = (int)(nb02 >> 4);
     const int pitch_px_n13  = (int)(nb03 >> 4);
@@ -1086,29 +929,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa4_img(
     }
 }
 
-// image1d_buffer_t (texture-cache) variant of _y8_gqa for KQV decode.
-//
-// Companion to _x8_gqa4_img. Same texture-cache idea applied to V: each
-// per-WG inner-loop iter previously did 8 V-row loads from __global; now
-// they go through the image cache instead.
-//
-// V layout note: at decode KQV, ggml typically TRANSPOSES V vs the K layout
-// so n_kv is the FAST dim and DV is the SLOW dim. So:
-//   - ne00 = n_kv (contracting dim of KQV matmul)
-//   - ne01 = DV  (= 128 for Qwen3 family)
-//   - ne02 = n_head_kv
-//   - nb01 is the DV stride (= n_kv_alloc * 2 bytes typically)
-// The host computes k_bytes generically the same way as for KQ.
-//
-// Image format: CL_RGBA/CL_HALF_FLOAT — 8-byte pixels = 1 half4. Same per-
-// iter access pattern as _y8_gqa (1 half4 per V-row per lane per iter),
-// just via read_imageh instead of __global load. Tried CL_RGBA/CL_FLOAT
-// (16-byte pixels, 2 half4 per pixel) first — same total compute but with
-// 2x per-iter staging which pushed register pressure over a cliff (-16%
-// @ d=16k vs KQV_GQA). The 1:1 half4-per-pixel mapping keeps the kernel
-// register-equivalent to _y8_gqa.
-//
-// Dispatch grid: same as _y8_gqa. Opt-in via env GGML_OPENCL_MM_KQV_GQA_IMG=1.
 #ifdef ADRENO_GPU
 REQD_SUBGROUP_SIZE_64
 #endif
@@ -1150,7 +970,7 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa_img(
 
     const int q_head_lo = i02 * GQA_RATIO_Y8GQA;
 
-    // Q (= softmax(KQ)) base pointers per Q-head. Streaming — no caching.
+    // Q (= softmax(KQ)) base pointers per Q-head
     global float4 * y4_q[GQA_RATIO_Y8GQA];
     #pragma unroll
     for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
@@ -1158,14 +978,13 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa_img(
         y4_q[qh] = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
     }
 
-    // Pixel-space pitches for V image. CL_RGBA/CL_HALF_FLOAT: 1 pixel = 8 bytes = 1 half4.
     const int pitch_px_row  = (int)(nb01 >> 3);
     const int pitch_px_head = (int)(nb02 >> 3);
     const int pitch_px_n13  = (int)(nb03 >> 3);
 
     const int head_px_base = i02 * pitch_px_head + (i03 / r3) * pitch_px_n13;
 
-    // Per-DV-row pixel base.
+    // per-DV-row pixel base
     int row_px_base[N_DV_ROWS_Y8GQA];
     #pragma unroll
     for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
@@ -1174,18 +993,16 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa_img(
         row_px_base[o] = r0c * pitch_px_row + head_px_base;
     }
 
-    // 64 accumulators: 8 DV rows × 8 Q-heads.
     float sum[N_DV_ROWS_Y8GQA][GQA_RATIO_Y8GQA] = { {0.0f} };
 
-    // Same per-iter access pattern as _y8_gqa: 1 half4 per V-row per lane.
     for (int i = sgs_lid; i < ne00 / 4; i += sgs_sz) {
-        // V loads via image: 8 V-row pixels, all at column i in the row.
         half4 v[N_DV_ROWS_Y8GQA];
+
         #pragma unroll
         for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
             v[o] = read_imageh(src0_img, row_px_base[o] + i);
         }
-        // Softmax (global): 8 float4, one per Q-head.
+
         float4 q[GQA_RATIO_Y8GQA];
         #pragma unroll
         for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
@@ -1208,7 +1025,6 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa_img(
         }
     }
 
-    // Reduce each accumulator across the 64-lane subgroup.
     #pragma unroll
     for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
         const int r0 = r0_base + o;
@@ -1223,23 +1039,6 @@ kernel void kernel_mul_mat_f16_f32_l4_y8_gqa_img(
     }
 }
 
-// r2=4 specialization of the GQA-coalesced KQ image kernel.
-//
-// Companion to `_x8_gqa4_img` (r2=8, Qwen3-30B-A3B / Qwen3.6-35B-A3B). This
-// variant fans the 64-lane subgroup across 4 Q-heads (16 lanes per partition)
-// so each lane covers 32/16 = 2 half4 of one K-row per pass. With
-// CL_RGBA/CL_FLOAT image pixels (16 bytes = 1 half8 = 2 half4) this maps to
-// exactly 1 pixel read per lane per K-row — no wasted BW.
-//
-// Targets: Llama-3-8B (n_head=32, n_kv=8 → r2=4), Llama-3.2-1B/3B (same),
-// Qwen3-4B/8B (same). Other shapes fall through.
-//
-// Same dispatch grid as the r2=8 variant: nth0=64, ((ne01/16)*64, 1,
-// ne02*ne13). Opt-in via env var GGML_OPENCL_MM_KQ_GQA_R4_IMG=1 on the host.
-// Shape gate: ne11==1 && ne00==128 && r2==4 && r3==1 && ne01%16==0.
-//
-// Reduction uses sub_group_shuffle_xor with masks 8, 4, 2, 1 — all <32, safe
-// on Adreno X2's silent-miscompile boundary.
 #define N_K_ROWS_GQA_R4   16
 #define GQA_RATIO_R4      4
 #define LANES_PER_QH_R4   16    // = 64 / GQA_RATIO_R4
@@ -1309,8 +1108,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img(
         const int r0 = r0_base + dr;
         const int row_px_base = r0 * pitch_px_row + head_px_base;
 
-        // 1 pixel = 1 half8 = 2 half4. With LANES_PER_QH_R4=16 lanes
-        // and DK_VEC_R4=32 half4/row, lane_q reads pixel `lane_q`.
         const int p = lane_q;
         const half8 k8 = as_half8(read_imagef(src0_img, row_px_base + p));
         const int   i0 = 2 * p;
@@ -1327,7 +1124,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img(
             + convert_float(k8.s6) * qb.s2
             + convert_float(k8.s7) * qb.s3;
 
-        // Reduce within 16-lane Q-head partition.
         sumf += sub_group_shuffle_xor(sumf, 8);
         sumf += sub_group_shuffle_xor(sumf, 4);
         sumf += sub_group_shuffle_xor(sumf, 2);
@@ -1340,13 +1136,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img(
     }
 }
 
-// DK=256, r2=2 specialization for Gemma-3-4B (n_head=8, n_head_kv=4,
-// head_dim=256). 64-lane subgroup partitioned across 2 Q-heads (32 lanes
-// each). DK_VEC=64 half4 per K-row; each lane reads 1 CL_RGBA/CL_FLOAT
-// pixel = 2 half4 — clean 1:1 mapping. Reduction masks {16,8,4,2,1} are
-// all <32 (safe on Adreno X2). Q stage: 2×64=128 float4 = 2 KB local.
-//
-// Opt-in via GGML_OPENCL_MM_KQ_GQA_R2_DK256_IMG=1.
 #define N_K_ROWS_GQA_R2_DK256   16
 #define GQA_RATIO_R2            2
 #define LANES_PER_QH_R2         32    // = 64 / GQA_RATIO_R2
@@ -1394,8 +1183,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img(
 
     const int q_head_lo = i02 * GQA_RATIO_R2;
 
-    // Stage 2 Q-heads × 64 float4 = 128 float4 (2 KB). Each of 64 lanes
-    // loads exactly one float4 per Q-head (DK_VEC_DK256 == subgroup size).
     __local float4 q_loc[GQA_RATIO_R2 * DK_VEC_DK256];
     #pragma unroll
     for (int qh = 0; qh < GQA_RATIO_R2; ++qh) {
@@ -1416,7 +1203,6 @@ kernel void kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img(
         const int r0 = r0_base + dr;
         const int row_px_base = r0 * pitch_px_row + head_px_base;
 
-        // 1 pixel per lane = 2 half4 = 8 fp16. 32 lanes × 2 half4 = 64 half4 covers DK=256.
         const int p = lane_q;
         const half8 k8 = as_half8(read_imagef(src0_img, row_px_base + p));
         const int   i0 = 2 * p;

--- a/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_l4.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_f16_f32_l4.cl
@@ -18,6 +18,14 @@
 #define REQD_SUBGROUP_SIZE_128 __attribute__((qcom_reqd_sub_group_size("full")))
 #endif
 
+#ifdef cl_khr_subgroup_shuffle
+#pragma OPENCL EXTENSION cl_khr_subgroup_shuffle : enable
+#define HAS_SUBGROUP_SHUFFLE 1
+#elif defined(cl_qcom_subgroup_shuffle)
+#pragma OPENCL EXTENSION cl_qcom_subgroup_shuffle : enable
+#define HAS_SUBGROUP_SHUFFLE 1
+#endif
+
 // Assumes row size (ne00) is a multiple of 4
 #ifdef ADRENO_GPU
 REQD_SUBGROUP_SIZE_64
@@ -378,3 +386,1062 @@ kernel void kernel_mul_mat_f16_f32_l4_dr_lq(
     }
 }
 #endif // ADRENO_GPU
+
+// Multi-row variant: each workgroup processes N_ROWS_PER_WG K rows instead of
+// 1, amortizing dispatch overhead. The default kernel above launches one WG
+// per (r0, im) which means ~262K workgroups for Qwen3.6 attn KQ at d=16k —
+// 64 threads each doing one mad and a sub_group_reduce. Per-call wall time is
+// ~8× over the K-bandwidth ideal because of wave-dispatch + memory-latency
+// overhead. This variant collapses 8 of those WGs into one and caches Q once
+// per Q-row in __local across the 8 K-row computations.
+//
+// Dispatched when ne11 == 1 (decode: single Q row) and ne01 % N_ROWS == 0,
+// with global x = ne01/N_ROWS * subgroup_size.
+#define N_ROWS_PER_WG 8
+#define N_OUTS_PER_WG 8
+
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_x8(
+        global char * src0,
+        ulong offset0,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb00,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src0 = (global char *)((global char *)src0 + offset0);
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int sgs_sz  = get_max_sub_group_size();
+
+    const int r0_base = get_group_id(0) * N_ROWS_PER_WG;
+    const int im      = get_group_id(2);
+
+    const int i12 = im % ne12;
+    const int i13 = im / ne12;
+
+    // Single Q row only (decode). Cache Q once in __local for reuse across
+    // the N_ROWS K-row computations.
+    const ulong offset_src1 = (i12) * nb12 + (i13) * nb13;
+    global float4 * y4 = (global float4 *)(src1 + offset_src1);
+
+    __local float4 q_loc[64];   // ne00/4 max for sub_group_size 64
+    if (sgs_lid < ne00 / 4) {
+        q_loc[sgs_lid] = y4[sgs_lid];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    #pragma unroll
+    for (int dr = 0; dr < N_ROWS_PER_WG; ++dr) {
+        const int r0 = r0_base + dr;
+        if (r0 >= ne01) return;
+
+        const ulong offset_src0 = r0 * nb01 + (i12 / r2) * nb02 + (i13 / r3) * nb03;
+        global half4 * x4 = (global half4 *)(src0 + offset_src0);
+
+        float sumf = 0.0f;
+        for (int i = sgs_lid; i < ne00 / 4; i += sgs_sz) {
+            const half4   k4 = x4[i];
+            const float4  q  = q_loc[i];
+            sumf += convert_float(k4.s0) * q.s0
+                  + convert_float(k4.s1) * q.s1
+                  + convert_float(k4.s2) * q.s2
+                  + convert_float(k4.s3) * q.s3;
+        }
+
+        const float all_sum = sub_group_reduce_add(sumf);
+        if (sgs_lid == 0) {
+            dst[im * ne1 * ne0 + r0] = all_sum;  // ne11 == 1, so r1==0
+        }
+    }
+}
+
+// Streaming-Q multi-output variant for the KQV-shaped matmul: src0 has small
+// ne01 (e.g. DV=256) but large ne00 (n_kv, up to 16384 at d=16k). The x8
+// kernel can't handle this because its per-WG __local Q cache is sized for
+// ne00 <= 256. This variant streams Q from global (no cache) but still packs
+// N_OUTS_PER_WG = 8 outputs per workgroup. Q is re-read once per output
+// inside the inner loop; Adreno L1 absorbs the 8× redundancy since adjacent
+// outputs in one WG hit the same Q cache lines per iter.
+//
+// Dispatched for the same shape pattern as x8 (ne11 == 1, ne01 divisible by 8)
+// when ne00 > 256, i.e. when the x8 path can't be used.
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_y8(
+        global char * src0,
+        ulong offset0,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb00,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src0 = (global char *)((global char *)src0 + offset0);
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int sgs_sz  = get_max_sub_group_size();
+
+    const int r0_base = get_group_id(0) * N_OUTS_PER_WG;
+    const int im      = get_group_id(2);
+
+    const int i12 = im % ne12;
+    const int i13 = im / ne12;
+
+    // Q (= src1) base pointer; r1 == 0 since ne11 == 1.
+    const ulong offset_src1 = (i12) * nb12 + (i13) * nb13;
+    global float4 * y4 = (global float4 *)(src1 + offset_src1);
+
+    // Per-output base pointers (per row of src0). Computed once; inner loop
+    // strides float4 indices across them.
+    global half4 * x4_o[N_OUTS_PER_WG];
+    #pragma unroll
+    for (int o = 0; o < N_OUTS_PER_WG; ++o) {
+        const int r0 = r0_base + o;
+        // Pre-cap: if r0 OOB, point to the first row (harmless reads, output
+        // suppressed at write-time). Keeps the inner loop unconditional.
+        const int r0c = (r0 < ne01) ? r0 : 0;
+        const ulong off = r0c * nb01 + (i12 / r2) * nb02 + (i13 / r3) * nb03;
+        x4_o[o] = (global half4 *)(src0 + off);
+    }
+
+    float sum[N_OUTS_PER_WG] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+
+    for (int i = sgs_lid; i < ne00 / 4; i += sgs_sz) {
+        const float4 q4 = y4[i];
+        #pragma unroll
+        for (int o = 0; o < N_OUTS_PER_WG; ++o) {
+            const half4 v4 = x4_o[o][i];
+            sum[o] += convert_float(v4.s0) * q4.s0
+                    + convert_float(v4.s1) * q4.s1
+                    + convert_float(v4.s2) * q4.s2
+                    + convert_float(v4.s3) * q4.s3;
+        }
+    }
+
+    #pragma unroll
+    for (int o = 0; o < N_OUTS_PER_WG; ++o) {
+        const int r0 = r0_base + o;
+        const float s = sub_group_reduce_add(sum[o]);
+        if (sgs_lid == 0 && r0 < ne01) {
+            dst[im * ne1 * ne0 + r0] = s;
+        }
+    }
+}
+
+// Lane-utilization variant of _x8 for the long-context KQ matmul (Adreno X2).
+//
+// Background: _x8 runs the inner K-loop as
+//   for (i = sgs_lid; i < ne00/4; i += sgs_sz)
+// At DK=128 (Qwen3/Qwen3.6/etc. attention head dim), ne00/4 = 32 but
+// sgs_sz = 64, so the loop runs ONCE with lanes 0..31 active and lanes
+// 32..63 idle. With N_ROWS_PER_WG=8 outer iters, half of every wave-cycle
+// is wasted and the kernel issues only 32 cache-line requests per K-row
+// instead of 64. The depth-sweep on Qwen3-30B-A3B (tg128@d=16k) attributes
+// ~9.5% of the 76 GB/s coalesced-read peak — almost exactly the 50% lane
+// idle × ~20% small-WG ceiling.
+//
+// Fix: pair K-rows across the warp. Lanes 0..31 process row (2p+0), lanes
+// 32..63 process row (2p+1), in parallel. 4 pair iters cover the same 8
+// outputs. Per-pair reduction stays within each 32-lane half via
+// sub_group_shuffle_xor with masks <32 (per opencl_ssm_scan_mamba2:
+// shuffle_xor with mask>=32 silently miscompiles on Adreno X2; we never
+// cross the half-warp boundary).
+//
+// Same total compute (32×8 = 64×4 = 256 lane-mads), same total K bytes per
+// WG, but 2× the per-wave-cycle memory-issue parallelism. Most beneficial
+// for DK in [128, 256] where the per-row inner loop is only 1-2 iters.
+//
+// Dispatch grid identical to _x8: nth0=64, ((ne01/8)*64, 1, ne12*ne13).
+// Opt-in via env var GGML_OPENCL_MM_KQ_PAIR=1 on the host side.
+#define N_OUTS_PAIR  8
+#define N_PAIRS_PAIR (N_OUTS_PAIR / 2)
+
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_x8_pair(
+        global char * src0,
+        ulong offset0,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb00,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src0 = (global char *)((global char *)src0 + offset0);
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int half_id = sgs_lid >> 5;     // 0 = lower half, 1 = upper half
+    const int lane_h  = sgs_lid & 31;     // lane 0..31 within half
+
+    const int r0_base = get_group_id(0) * N_OUTS_PAIR;
+    const int im      = get_group_id(2);
+
+    const int i12 = im % ne12;
+    const int i13 = im / ne12;
+
+    // Single Q row (decode). Cache Q once in __local for reuse across all
+    // N_OUTS_PAIR K-rows. Both halves of the warp broadcast-read q_loc.
+    const ulong offset_src1 = (i12) * nb12 + (i13) * nb13;
+    global float4 * y4 = (global float4 *)(src1 + offset_src1);
+
+    __local float4 q_loc[64];   // ne00/4 max for sub_group_size 64
+    if (sgs_lid < ne00 / 4) {
+        q_loc[sgs_lid] = y4[sgs_lid];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int dk_vec = ne00 / 4;
+
+    #pragma unroll
+    for (int p = 0; p < N_PAIRS_PAIR; ++p) {
+        // Lower half handles even row, upper half handles odd row.
+        // Dispatch guarantees ne01 % 8 == 0, so r0 is always in range.
+        const int r0 = r0_base + 2 * p + half_id;
+
+        const ulong offset_src0 = r0 * nb01 + (i12 / r2) * nb02 + (i13 / r3) * nb03;
+        global half4 * x4 = (global half4 *)(src0 + offset_src0);
+
+        float sumf = 0.0f;
+        // Stride 32 within the 32-lane half. For DK=128 this runs once.
+        for (int i = lane_h; i < dk_vec; i += 32) {
+            const half4  k4 = x4[i];
+            const float4 q  = q_loc[i];
+            sumf += convert_float(k4.s0) * q.s0
+                  + convert_float(k4.s1) * q.s1
+                  + convert_float(k4.s2) * q.s2
+                  + convert_float(k4.s3) * q.s3;
+        }
+
+        // Reduce within 32-lane half. All 64 lanes execute; the shuffle is
+        // self-contained within each half because masks are <32.
+        sumf += sub_group_shuffle_xor(sumf, 16);
+        sumf += sub_group_shuffle_xor(sumf, 8);
+        sumf += sub_group_shuffle_xor(sumf, 4);
+        sumf += sub_group_shuffle_xor(sumf, 2);
+        sumf += sub_group_shuffle_xor(sumf, 1);
+
+        if (lane_h == 0) {
+            dst[im * ne1 * ne0 + r0] = sumf;
+        }
+    }
+}
+
+// GQA-coalesced KQ variant for the long-context fa=0 path on Adreno X2.
+//
+// Background: at DK=128 the regular _x8 kernel reads each K-row r2 times
+// (once per Q-head sharing the K-head — Qwen3-30B-A3B has r2 = n_head_q /
+// n_head_kv = 8 with n_head_q=32, n_head_kv=4). At d=16k that's 16 MB of
+// unique K read as 128 MB. The L2 path saturates near 56 GB/s, but most of
+// the BW pays for redundant fetches; effective unique-K BW is 9.5% of peak.
+//
+// Fix: one WG per K-head (instead of per Q-head). The 64-lane warp partitions
+// across GQA_RATIO=8 Q-heads (8 lanes each at DK=128 → 32 dk_vec elements /
+// 8 lanes = 4 mads per lane per K-row). Each K-row is read once from global
+// and contributes to GQA_RATIO outputs. Q vectors for the gqa_ratio Q-heads
+// are pre-staged in __local.
+//
+// Specialized for DK=128 and GQA_RATIO=8 (Qwen3-30B-A3B / Qwen3-4B /
+// Qwen3.6-A3B). Other shapes fall through to the regular _x8 path.
+//
+// Dispatch (separate from _x8): nth0=64, ((ne01/8)*64, 1, ne02*ne13).
+// Opt-in via env var GGML_OPENCL_MM_KQ_GQA=1 on the host.
+#define N_K_ROWS_GQA   16
+#define GQA_RATIO_GQA  8
+#define LANES_PER_QH   8    // 64 / GQA_RATIO_GQA
+#define DK_VEC_GQA     32   // DK / 4 for DK=128
+
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_x8_gqa4(
+        global char * src0,
+        ulong offset0,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb00,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src0 = (global char *)((global char *)src0 + offset0);
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int q_id    = sgs_lid >> 3;       // 0..7: which Q-head (8 per WG)
+    const int lane_q  = sgs_lid & 7;        // 0..7: lane within Q-head partition
+
+    const int r0_base = get_group_id(0) * N_K_ROWS_GQA;
+    const int im_kv   = get_group_id(2);
+
+    const int i02 = im_kv % ne02;           // K-head index (also K2 batch)
+    const int i03 = im_kv / ne02;           // n13 batch index
+
+    // GQA Q-heads sharing this K-head: i12 ∈ [i02*r2, i02*r2 + r2).
+    // (r2 is the dispatch's guarantee == GQA_RATIO_GQA at this gate.)
+    const int q_head_lo = i02 * GQA_RATIO_GQA;
+
+    // Stage all GQA_RATIO Q vectors (one per Q-head sharing the K-head) into
+    // __local. Each Q-head has DK_VEC_GQA = 32 float4 elements; 64 lanes load
+    // 2 per Q-head (32 lanes × 2) using the first 32 lanes per Q-head.
+    __local float4 q_loc[GQA_RATIO_GQA * DK_VEC_GQA];   // 4 × 32 = 128 float4
+    #pragma unroll
+    for (int qh = 0; qh < GQA_RATIO_GQA; ++qh) {
+        const int qh_idx = q_head_lo + qh;
+        global float4 * y4 = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
+        // Only lanes [0, DK_VEC_GQA) load; broadcast-safe.
+        if (sgs_lid < DK_VEC_GQA) {
+            q_loc[qh * DK_VEC_GQA + sgs_lid] = y4[sgs_lid];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // K base offset for this WG. All 8 K-rows × 4 Q-heads share this K-head.
+    const ulong offset_src0_base = (i02) * nb02 + (i03 / r3) * nb03;
+
+    #pragma unroll
+    for (int dr = 0; dr < N_K_ROWS_GQA; ++dr) {
+        const int r0 = r0_base + dr;
+        // Dispatch guarantees ne01 % N_K_ROWS_GQA == 0, so r0 < ne01.
+
+        const ulong offset_src0 = r0 * nb01 + offset_src0_base;
+        global half4 * x4 = (global half4 *)(src0 + offset_src0);
+
+        // Each lane reads 4 K elements covering DK_VEC_GQA = 32 float4 with
+        // LANES_PER_QH = 8 lanes per Q-head partition. The 8 Q-head
+        // partitions in the warp all read the same K-row in parallel (8
+        // duplicated reads per element, served by L1 once cached).
+        float sumf = 0.0f;
+        #pragma unroll
+        for (int t = 0; t < 4; ++t) {
+            const int i = lane_q + t * LANES_PER_QH;   // 8, 16, 24-step
+            const half4  k4 = x4[i];
+            const float4 q  = q_loc[q_id * DK_VEC_GQA + i];
+            sumf += convert_float(k4.s0) * q.s0
+                  + convert_float(k4.s1) * q.s1
+                  + convert_float(k4.s2) * q.s2
+                  + convert_float(k4.s3) * q.s3;
+        }
+
+        // Reduce within 8-lane Q-head partition (masks < 8, well within the
+        // safe-shuffle range for Adreno X2's 32-lane cluster bound).
+        sumf += sub_group_shuffle_xor(sumf, 4);
+        sumf += sub_group_shuffle_xor(sumf, 2);
+        sumf += sub_group_shuffle_xor(sumf, 1);
+
+        if (lane_q == 0) {
+            // im for this Q-head: linearized (i12=q_head_lo+q_id, i13=i03)
+            // matching the original _x8 dst[im * ne1 * ne0 + r0] indexing.
+            const int im_out = i03 * ne12 + (q_head_lo + q_id);
+            dst[im_out * ne1 * ne0 + r0] = sumf;
+        }
+    }
+}
+
+// GQA-coalesced KQV variant for the long-context fa=0 path on Adreno X2.
+//
+// Companion to _x8_gqa4 — applies the same GQA-replay-elimination trick to
+// the second mul_mat per attention block. KQV shape: src0 = V cache
+// [ne00=n_kv, ne01=DV=128, ne02=n_head_kv=4]; src1 = softmax(KQ)
+// [ne10=n_kv, ne11=1, ne12=n_head_q=32]. r2 = ne12/ne02 = 8.
+//
+// Current _y8 dispatches one WG per Q-head × 8 DV-row outputs. It re-reads
+// each V slab r2=8 times across Q-heads. Total V read ≈ 128 MB / call at
+// d=16k for only 16 MB unique V data.
+//
+// _y8_gqa: one WG per K-head × 8 DV-row outputs (dispatch z = ne02 * ne13).
+// Each WG produces N_DV_ROWS_Y8GQA × GQA_RATIO_Y8GQA = 8 × 8 = 64 outputs.
+// V is read once per K-head (per DV-row group); softmax read once per
+// (q_head, dv_group) — total softmax read unchanged, total V read /= r2 = 8.
+//
+// Inner loop: each of 64 lanes processes one K-position chunk (4 elements).
+// Per iter, each lane reads 8 V values (one per DV row, all shared K-head)
+// and 8 softmax values (one per Q-head). Per iter, each lane does 64 mads
+// (8 DV × 8 Q-heads). Accumulator footprint per lane: 64 fp32 = 256 B
+// (significant; watch for register pressure).
+//
+// Dispatch grid: nth0=64, ((ne01/8)*64, 1, ne02*ne13). Opt-in via env var
+// GGML_OPENCL_MM_KQV_GQA=1.
+#define N_DV_ROWS_Y8GQA  8
+#define GQA_RATIO_Y8GQA  8
+
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_y8_gqa(
+        global char * src0,
+        ulong offset0,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb00,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src0 = (global char *)((global char *)src0 + offset0);
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int sgs_sz  = get_max_sub_group_size();
+
+    const int r0_base = get_group_id(0) * N_DV_ROWS_Y8GQA;
+    const int im_kv   = get_group_id(2);
+
+    const int i02 = im_kv % ne02;           // K-head index
+    const int i03 = im_kv / ne02;           // n13 batch index
+
+    // GQA Q-heads sharing this K-head.
+    const int q_head_lo = i02 * GQA_RATIO_Y8GQA;
+
+    // Q (= softmax(KQ)) base pointers per Q-head. Streaming — no caching;
+    // each Q-head's softmax is read once per WG. Across all WGs (ne01/8
+    // DV-groups × ne02 K-heads), total softmax reads = ne01/8 × ne12 × n_kv.
+    global float4 * y4_q[GQA_RATIO_Y8GQA];
+    #pragma unroll
+    for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+        const int qh_idx = q_head_lo + qh;
+        y4_q[qh] = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
+    }
+
+    // 8 V-row base pointers (per DV output). All 8 share K-head i02.
+    global half4 * x4_o[N_DV_ROWS_Y8GQA];
+    #pragma unroll
+    for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+        const int r0 = r0_base + o;
+        const int r0c = (r0 < ne01) ? r0 : 0;
+        const ulong off = r0c * nb01 + (i02) * nb02 + (i03 / r3) * nb03;
+        x4_o[o] = (global half4 *)(src0 + off);
+    }
+
+    // 64 accumulators: 8 DV rows × 8 Q-heads.
+    float sum[N_DV_ROWS_Y8GQA][GQA_RATIO_Y8GQA] = { {0.0f} };
+
+    for (int i = sgs_lid; i < ne00 / 4; i += sgs_sz) {
+        // Load 8 V values (one per DV row), same K-head, K-pos = i.
+        half4 v[N_DV_ROWS_Y8GQA];
+        #pragma unroll
+        for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+            v[o] = x4_o[o][i];
+        }
+        // Load 8 softmax values (one per Q-head).
+        float4 q[GQA_RATIO_Y8GQA];
+        #pragma unroll
+        for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+            q[qh] = y4_q[qh][i];
+        }
+        // 64 mads.
+        #pragma unroll
+        for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+            const float4 vf = (float4)(convert_float(v[o].s0),
+                                       convert_float(v[o].s1),
+                                       convert_float(v[o].s2),
+                                       convert_float(v[o].s3));
+            #pragma unroll
+            for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+                sum[o][qh] += vf.s0 * q[qh].s0
+                            + vf.s1 * q[qh].s1
+                            + vf.s2 * q[qh].s2
+                            + vf.s3 * q[qh].s3;
+            }
+        }
+    }
+
+    // Reduce each of 64 accumulators across the 64-lane subgroup.
+    #pragma unroll
+    for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+        const int r0 = r0_base + o;
+        #pragma unroll
+        for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+            const float s = sub_group_reduce_add(sum[o][qh]);
+            if (sgs_lid == 0 && r0 < ne01) {
+                const int im_out = i03 * ne12 + (q_head_lo + qh);
+                dst[im_out * ne1 * ne0 + r0] = s;
+            }
+        }
+    }
+}
+
+// image1d_buffer_t (texture-cache) variant of _x8_gqa4.
+//
+// Background: profiling _x8_gqa4 N_K_ROWS_GQA=16 on Qwen3-30B-A3B (Adreno X2):
+// KQ stayed at 69% of decode time @ d=16k with effective K-read BW of only
+// ~7.3 GB/s — ~10% of the coalesced __global peak (76 GB/s). The kernel is
+// memory-stall bound on serial K-row fetches; widening the per-WG window
+// via N=16 didn't fix it. The prefill mul_mm_f16_f32_kq uses Adreno's
+// texture-cache (image1d_buffer_t) path for K, which is a separate cache
+// from L2 and historically gives much higher effective BW on Adreno.
+//
+// Identical math to _x8_gqa4. The only change is K is bound as a
+// __read_only image1d_buffer_t over a sub-buffer covering the K cache for
+// this call (offset already baked into the sub-buffer). The pixel format
+// is {CL_RGBA, CL_FLOAT} → 1 pixel = 16 bytes = 1 half8 = 2 half4. Two
+// pixels per K-row per lane (lane_q + t*8 for t∈{0,1}) cover 4 half4 worth
+// of K data, matching _x8_gqa4's per-lane coverage. as_half8(float4) is a
+// bit-cast: bytes preserved end-to-end (the prefill kq path uses the same
+// pattern).
+//
+// Layout note: at decode KQ, the K view on Adreno is permuted (nb01 > nb02 —
+// head-major). The host computes k_bytes generically from
+// (ne01-1)*nb01 + (ne02-1)*nb02 + (ne03-1)*nb03 + ne00*sizeof(half) so the
+// image covers the full byte span regardless of layout. Pitches in this
+// kernel still come from nb01/nb02/nb03 unchanged, so the addressing math
+// is identical to _x8_gqa4.
+//
+// Dispatch (separate from _x8_gqa4): same grid as the regular variant.
+// Opt-in via env var GGML_OPENCL_MM_KQ_GQA_IMG=1 on the host.
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_x8_gqa4_img(
+        __read_only image1d_buffer_t src0_img,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int q_id    = sgs_lid >> 3;       // 0..7: which Q-head (8 per WG)
+    const int lane_q  = sgs_lid & 7;        // 0..7: lane within Q-head partition
+
+    const int r0_base = get_group_id(0) * N_K_ROWS_GQA;
+    const int im_kv   = get_group_id(2);
+
+    const int i02 = im_kv % ne02;
+    const int i03 = im_kv / ne02;
+
+    const int q_head_lo = i02 * GQA_RATIO_GQA;
+
+    __local float4 q_loc[GQA_RATIO_GQA * DK_VEC_GQA];
+    #pragma unroll
+    for (int qh = 0; qh < GQA_RATIO_GQA; ++qh) {
+        const int qh_idx = q_head_lo + qh;
+        global float4 * y4 = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
+        if (sgs_lid < DK_VEC_GQA) {
+            q_loc[qh * DK_VEC_GQA + sgs_lid] = y4[sgs_lid];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Image pixel = 1 float4 = 16 bytes = 8 fp16 (= 2 half4). Pitches in pixel
+    // units. Sub-buffer is bound at offset0 host-side so offset0 is not
+    // threaded through here. Each lane reads 2 pixels per K-row covering 4
+    // half4 worth of K data (same coverage as _x8_gqa4) via a slightly
+    // different access pattern: lane lane_q ∈ [0,8) reads pixels {lane_q,
+    // lane_q+8} (covering half4 positions {2*lane_q, 2*lane_q+1, 2*lane_q+16,
+    // 2*lane_q+17}). Coalesced burst: 8 lanes in the same Q-head partition
+    // read 8 consecutive pixels per iter.
+    const int pitch_px_row  = (int)(nb01 >> 4);
+    const int pitch_px_head = (int)(nb02 >> 4);
+    const int pitch_px_n13  = (int)(nb03 >> 4);
+
+    const int head_px_base = i02 * pitch_px_head + (i03 / r3) * pitch_px_n13;
+
+    #pragma unroll
+    for (int dr = 0; dr < N_K_ROWS_GQA; ++dr) {
+        const int r0 = r0_base + dr;
+        const int row_px_base = r0 * pitch_px_row + head_px_base;
+
+        float sumf = 0.0f;
+        #pragma unroll
+        for (int t = 0; t < 2; ++t) {
+            const int p = lane_q + t * LANES_PER_QH;          // pixel idx in row, 0..15
+            const half8 k8 = as_half8(read_imagef(src0_img, row_px_base + p));
+            const int   i0 = 2 * p;                            // first half4 idx
+            const float4 qa = q_loc[q_id * DK_VEC_GQA + i0    ];
+            const float4 qb = q_loc[q_id * DK_VEC_GQA + i0 + 1];
+            sumf += convert_float(k8.s0) * qa.s0
+                  + convert_float(k8.s1) * qa.s1
+                  + convert_float(k8.s2) * qa.s2
+                  + convert_float(k8.s3) * qa.s3
+                  + convert_float(k8.s4) * qb.s0
+                  + convert_float(k8.s5) * qb.s1
+                  + convert_float(k8.s6) * qb.s2
+                  + convert_float(k8.s7) * qb.s3;
+        }
+
+        sumf += sub_group_shuffle_xor(sumf, 4);
+        sumf += sub_group_shuffle_xor(sumf, 2);
+        sumf += sub_group_shuffle_xor(sumf, 1);
+
+        if (lane_q == 0) {
+            const int im_out = i03 * ne12 + (q_head_lo + q_id);
+            dst[im_out * ne1 * ne0 + r0] = sumf;
+        }
+    }
+}
+
+// image1d_buffer_t (texture-cache) variant of _y8_gqa for KQV decode.
+//
+// Companion to _x8_gqa4_img. Same texture-cache idea applied to V: each
+// per-WG inner-loop iter previously did 8 V-row loads from __global; now
+// they go through the image cache instead.
+//
+// V layout note: at decode KQV, ggml typically TRANSPOSES V vs the K layout
+// so n_kv is the FAST dim and DV is the SLOW dim. So:
+//   - ne00 = n_kv (contracting dim of KQV matmul)
+//   - ne01 = DV  (= 128 for Qwen3 family)
+//   - ne02 = n_head_kv
+//   - nb01 is the DV stride (= n_kv_alloc * 2 bytes typically)
+// The host computes k_bytes generically the same way as for KQ.
+//
+// Image format: CL_RGBA/CL_HALF_FLOAT — 8-byte pixels = 1 half4. Same per-
+// iter access pattern as _y8_gqa (1 half4 per V-row per lane per iter),
+// just via read_imageh instead of __global load. Tried CL_RGBA/CL_FLOAT
+// (16-byte pixels, 2 half4 per pixel) first — same total compute but with
+// 2x per-iter staging which pushed register pressure over a cliff (-16%
+// @ d=16k vs KQV_GQA). The 1:1 half4-per-pixel mapping keeps the kernel
+// register-equivalent to _y8_gqa.
+//
+// Dispatch grid: same as _y8_gqa. Opt-in via env GGML_OPENCL_MM_KQV_GQA_IMG=1.
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_y8_gqa_img(
+        __read_only image1d_buffer_t src0_img,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int sgs_sz  = get_max_sub_group_size();
+
+    const int r0_base = get_group_id(0) * N_DV_ROWS_Y8GQA;
+    const int im_kv   = get_group_id(2);
+
+    const int i02 = im_kv % ne02;
+    const int i03 = im_kv / ne02;
+
+    const int q_head_lo = i02 * GQA_RATIO_Y8GQA;
+
+    // Q (= softmax(KQ)) base pointers per Q-head. Streaming — no caching.
+    global float4 * y4_q[GQA_RATIO_Y8GQA];
+    #pragma unroll
+    for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+        const int qh_idx = q_head_lo + qh;
+        y4_q[qh] = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
+    }
+
+    // Pixel-space pitches for V image. CL_RGBA/CL_HALF_FLOAT: 1 pixel = 8 bytes = 1 half4.
+    const int pitch_px_row  = (int)(nb01 >> 3);
+    const int pitch_px_head = (int)(nb02 >> 3);
+    const int pitch_px_n13  = (int)(nb03 >> 3);
+
+    const int head_px_base = i02 * pitch_px_head + (i03 / r3) * pitch_px_n13;
+
+    // Per-DV-row pixel base.
+    int row_px_base[N_DV_ROWS_Y8GQA];
+    #pragma unroll
+    for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+        const int r0  = r0_base + o;
+        const int r0c = (r0 < ne01) ? r0 : 0;
+        row_px_base[o] = r0c * pitch_px_row + head_px_base;
+    }
+
+    // 64 accumulators: 8 DV rows × 8 Q-heads.
+    float sum[N_DV_ROWS_Y8GQA][GQA_RATIO_Y8GQA] = { {0.0f} };
+
+    // Same per-iter access pattern as _y8_gqa: 1 half4 per V-row per lane.
+    for (int i = sgs_lid; i < ne00 / 4; i += sgs_sz) {
+        // V loads via image: 8 V-row pixels, all at column i in the row.
+        half4 v[N_DV_ROWS_Y8GQA];
+        #pragma unroll
+        for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+            v[o] = read_imageh(src0_img, row_px_base[o] + i);
+        }
+        // Softmax (global): 8 float4, one per Q-head.
+        float4 q[GQA_RATIO_Y8GQA];
+        #pragma unroll
+        for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+            q[qh] = y4_q[qh][i];
+        }
+        // 64 mads.
+        #pragma unroll
+        for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+            const float4 vf = (float4)(convert_float(v[o].s0),
+                                       convert_float(v[o].s1),
+                                       convert_float(v[o].s2),
+                                       convert_float(v[o].s3));
+            #pragma unroll
+            for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+                sum[o][qh] += vf.s0 * q[qh].s0
+                            + vf.s1 * q[qh].s1
+                            + vf.s2 * q[qh].s2
+                            + vf.s3 * q[qh].s3;
+            }
+        }
+    }
+
+    // Reduce each accumulator across the 64-lane subgroup.
+    #pragma unroll
+    for (int o = 0; o < N_DV_ROWS_Y8GQA; ++o) {
+        const int r0 = r0_base + o;
+        #pragma unroll
+        for (int qh = 0; qh < GQA_RATIO_Y8GQA; ++qh) {
+            const float s = sub_group_reduce_add(sum[o][qh]);
+            if (sgs_lid == 0 && r0 < ne01) {
+                const int im_out = i03 * ne12 + (q_head_lo + qh);
+                dst[im_out * ne1 * ne0 + r0] = s;
+            }
+        }
+    }
+}
+
+// r2=4 specialization of the GQA-coalesced KQ image kernel.
+//
+// Companion to `_x8_gqa4_img` (r2=8, Qwen3-30B-A3B / Qwen3.6-35B-A3B). This
+// variant fans the 64-lane subgroup across 4 Q-heads (16 lanes per partition)
+// so each lane covers 32/16 = 2 half4 of one K-row per pass. With
+// CL_RGBA/CL_FLOAT image pixels (16 bytes = 1 half8 = 2 half4) this maps to
+// exactly 1 pixel read per lane per K-row — no wasted BW.
+//
+// Targets: Llama-3-8B (n_head=32, n_kv=8 → r2=4), Llama-3.2-1B/3B (same),
+// Qwen3-4B/8B (same). Other shapes fall through.
+//
+// Same dispatch grid as the r2=8 variant: nth0=64, ((ne01/16)*64, 1,
+// ne02*ne13). Opt-in via env var GGML_OPENCL_MM_KQ_GQA_R4_IMG=1 on the host.
+// Shape gate: ne11==1 && ne00==128 && r2==4 && r3==1 && ne01%16==0.
+//
+// Reduction uses sub_group_shuffle_xor with masks 8, 4, 2, 1 — all <32, safe
+// on Adreno X2's silent-miscompile boundary.
+#define N_K_ROWS_GQA_R4   16
+#define GQA_RATIO_R4      4
+#define LANES_PER_QH_R4   16    // = 64 / GQA_RATIO_R4
+#define DK_VEC_R4         32    // DK / 4 for DK=128
+
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_x8_gqa_r4_img(
+        __read_only image1d_buffer_t src0_img,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int q_id    = sgs_lid >> 4;       // 0..3
+    const int lane_q  = sgs_lid & 15;       // 0..15
+
+    const int r0_base = get_group_id(0) * N_K_ROWS_GQA_R4;
+    const int im_kv   = get_group_id(2);
+
+    const int i02 = im_kv % ne02;
+    const int i03 = im_kv / ne02;
+
+    const int q_head_lo = i02 * GQA_RATIO_R4;
+
+    __local float4 q_loc[GQA_RATIO_R4 * DK_VEC_R4];
+    #pragma unroll
+    for (int qh = 0; qh < GQA_RATIO_R4; ++qh) {
+        const int qh_idx = q_head_lo + qh;
+        global float4 * y4 = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
+        if (sgs_lid < DK_VEC_R4) {
+            q_loc[qh * DK_VEC_R4 + sgs_lid] = y4[sgs_lid];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int pitch_px_row  = (int)(nb01 >> 4);
+    const int pitch_px_head = (int)(nb02 >> 4);
+    const int pitch_px_n13  = (int)(nb03 >> 4);
+
+    const int head_px_base = i02 * pitch_px_head + (i03 / r3) * pitch_px_n13;
+
+    #pragma unroll
+    for (int dr = 0; dr < N_K_ROWS_GQA_R4; ++dr) {
+        const int r0 = r0_base + dr;
+        const int row_px_base = r0 * pitch_px_row + head_px_base;
+
+        // 1 pixel = 1 half8 = 2 half4. With LANES_PER_QH_R4=16 lanes
+        // and DK_VEC_R4=32 half4/row, lane_q reads pixel `lane_q`.
+        const int p = lane_q;
+        const half8 k8 = as_half8(read_imagef(src0_img, row_px_base + p));
+        const int   i0 = 2 * p;
+        const float4 qa = q_loc[q_id * DK_VEC_R4 + i0    ];
+        const float4 qb = q_loc[q_id * DK_VEC_R4 + i0 + 1];
+
+        float sumf =
+              convert_float(k8.s0) * qa.s0
+            + convert_float(k8.s1) * qa.s1
+            + convert_float(k8.s2) * qa.s2
+            + convert_float(k8.s3) * qa.s3
+            + convert_float(k8.s4) * qb.s0
+            + convert_float(k8.s5) * qb.s1
+            + convert_float(k8.s6) * qb.s2
+            + convert_float(k8.s7) * qb.s3;
+
+        // Reduce within 16-lane Q-head partition.
+        sumf += sub_group_shuffle_xor(sumf, 8);
+        sumf += sub_group_shuffle_xor(sumf, 4);
+        sumf += sub_group_shuffle_xor(sumf, 2);
+        sumf += sub_group_shuffle_xor(sumf, 1);
+
+        if (lane_q == 0) {
+            const int im_out = i03 * ne12 + (q_head_lo + q_id);
+            dst[im_out * ne1 * ne0 + r0] = sumf;
+        }
+    }
+}
+
+// DK=256, r2=2 specialization for Gemma-3-4B (n_head=8, n_head_kv=4,
+// head_dim=256). 64-lane subgroup partitioned across 2 Q-heads (32 lanes
+// each). DK_VEC=64 half4 per K-row; each lane reads 1 CL_RGBA/CL_FLOAT
+// pixel = 2 half4 — clean 1:1 mapping. Reduction masks {16,8,4,2,1} are
+// all <32 (safe on Adreno X2). Q stage: 2×64=128 float4 = 2 KB local.
+//
+// Opt-in via GGML_OPENCL_MM_KQ_GQA_R2_DK256_IMG=1.
+#define N_K_ROWS_GQA_R2_DK256   16
+#define GQA_RATIO_R2            2
+#define LANES_PER_QH_R2         32    // = 64 / GQA_RATIO_R2
+#define DK_VEC_DK256            64    // DK / 4 for DK=256
+
+#ifdef ADRENO_GPU
+REQD_SUBGROUP_SIZE_64
+#endif
+kernel void kernel_mul_mat_f16_f32_l4_x8_gqa_r2_dk256_img(
+        __read_only image1d_buffer_t src0_img,
+        global char * src1,
+        ulong offset1,
+        global float * dst,
+        ulong offsetd,
+        int ne00,
+        int ne01,
+        int ne02,
+        ulong nb01,
+        ulong nb02,
+        ulong nb03,
+        int ne10,
+        int ne11,
+        int ne12,
+        ulong nb10,
+        ulong nb11,
+        ulong nb12,
+        ulong nb13,
+        int ne0,
+        int ne1,
+        int r2,
+        int r3
+) {
+    src1 = (global char *)((global char *)src1 + offset1);
+    dst  = (global float*)((global char *)dst  + offsetd);
+
+    const int sgs_lid = get_sub_group_local_id();
+    const int q_id    = sgs_lid >> 5;       // 0..1
+    const int lane_q  = sgs_lid & 31;       // 0..31
+
+    const int r0_base = get_group_id(0) * N_K_ROWS_GQA_R2_DK256;
+    const int im_kv   = get_group_id(2);
+
+    const int i02 = im_kv % ne02;
+    const int i03 = im_kv / ne02;
+
+    const int q_head_lo = i02 * GQA_RATIO_R2;
+
+    // Stage 2 Q-heads × 64 float4 = 128 float4 (2 KB). Each of 64 lanes
+    // loads exactly one float4 per Q-head (DK_VEC_DK256 == subgroup size).
+    __local float4 q_loc[GQA_RATIO_R2 * DK_VEC_DK256];
+    #pragma unroll
+    for (int qh = 0; qh < GQA_RATIO_R2; ++qh) {
+        const int qh_idx = q_head_lo + qh;
+        global float4 * y4 = (global float4 *)(src1 + qh_idx * nb12 + i03 * nb13);
+        q_loc[qh * DK_VEC_DK256 + sgs_lid] = y4[sgs_lid];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int pitch_px_row  = (int)(nb01 >> 4);
+    const int pitch_px_head = (int)(nb02 >> 4);
+    const int pitch_px_n13  = (int)(nb03 >> 4);
+
+    const int head_px_base = i02 * pitch_px_head + (i03 / r3) * pitch_px_n13;
+
+    #pragma unroll
+    for (int dr = 0; dr < N_K_ROWS_GQA_R2_DK256; ++dr) {
+        const int r0 = r0_base + dr;
+        const int row_px_base = r0 * pitch_px_row + head_px_base;
+
+        // 1 pixel per lane = 2 half4 = 8 fp16. 32 lanes × 2 half4 = 64 half4 covers DK=256.
+        const int p = lane_q;
+        const half8 k8 = as_half8(read_imagef(src0_img, row_px_base + p));
+        const int   i0 = 2 * p;
+        const float4 qa = q_loc[q_id * DK_VEC_DK256 + i0    ];
+        const float4 qb = q_loc[q_id * DK_VEC_DK256 + i0 + 1];
+
+        float sumf =
+              convert_float(k8.s0) * qa.s0
+            + convert_float(k8.s1) * qa.s1
+            + convert_float(k8.s2) * qa.s2
+            + convert_float(k8.s3) * qa.s3
+            + convert_float(k8.s4) * qb.s0
+            + convert_float(k8.s5) * qb.s1
+            + convert_float(k8.s6) * qb.s2
+            + convert_float(k8.s7) * qb.s3;
+
+        sumf += sub_group_shuffle_xor(sumf, 16);
+        sumf += sub_group_shuffle_xor(sumf, 8);
+        sumf += sub_group_shuffle_xor(sumf, 4);
+        sumf += sub_group_shuffle_xor(sumf, 2);
+        sumf += sub_group_shuffle_xor(sumf, 1);
+
+        if (lane_q == 0) {
+            const int im_out = i03 * ne12 + (q_head_lo + q_id);
+            dst[im_out * ne1 * ne0 + r0] = sumf;
+        }
+    }
+}

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8441,17 +8441,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 8192, 512, 5120, {128, 1}, {1, 1}));
 #endif
 
-    // q8_0 / q4_0 GDN ssm_out broadcast (Qwen3.5/3.6 hybrids): a contiguous trans-stored
-    // weight applied to a batched activation (src1 ne2 > src0 ne2) is routed through the
-    // dequant-to-f16 path, which must restore the transposed weight correctly. N=1 is the
-    // GEMV path, N>1 the GEMM path.
-    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2560,   1, 4096, {1, 1}, {4, 1}));
-    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2560, 128, 4096, {1, 1}, {4, 1}));
-    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2560, 170, 4096, {1, 1}, {3, 1}));
-    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2560,   1, 4096, {1, 1}, {4, 1}));
-    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2560, 128, 4096, {1, 1}, {4, 1}));
-    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2560, 170, 4096, {1, 1}, {3, 1}));
-
     for (ggml_type type_a : all_types) {
         for (int i = 1; i < 10; ++i) {
             test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8441,6 +8441,17 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 8192, 512, 5120, {128, 1}, {1, 1}));
 #endif
 
+    // q8_0 / q4_0 GDN ssm_out broadcast (Qwen3.5/3.6 hybrids): a contiguous trans-stored
+    // weight applied to a batched activation (src1 ne2 > src0 ne2) is routed through the
+    // dequant-to-f16 path, which must restore the transposed weight correctly. N=1 is the
+    // GEMV path, N>1 the GEMM path.
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2560,   1, 4096, {1, 1}, {4, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2560, 128, 4096, {1, 1}, {4, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2560, 170, 4096, {1, 1}, {3, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2560,   1, 4096, {1, 1}, {4, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2560, 128, 4096, {1, 1}, {4, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2560, 170, 4096, {1, 1}, {3, 1}));
+
     for (ggml_type type_a : all_types) {
         for (int i = 1; i < 10; ++i) {
             test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 16,  i, 256, { 1,  1}, {1, 1}));


### PR DESCRIPTION
## Overview

- This PR has a comprehensive performance optimization on token generation (decode) for Adreno GPUs, i.e., when n_q == 1. In particular, we target token generation performance with the long context window of 8k, 16k and beyond for agentic use cases.  

- Non-Adreno devices keep the original path.

## Additional information

Details of the features in this PR: 

1. Vec decode kernels for f16/q8_0/q4_0 KV (DV-split, subgroup-reduced dots), with a flash-decoding KV split for deep contexts
2. KV-head-coalesced multi-query decode kernels for GQA models (MQ_GQA 4 and 8); 
3. Fix an OOO issue with Adreno compiler by compiling the MQ_GQA=8 kernels in a separate minimal program 
4. Multi-output and GQA-coalesced mul_mat kernels for the KQ/KQV matmuls when flash attention is off, with option of using image1d_buffer_t 
5. DK=DV=512 (gemma-4 global-attention layers): prefill runs on the GPU via split programs; decode is offloading to CPU for now due to CPU's performance edge for this case (effective GPU BW < CPU BW)
6. f16-KV decode split granularity: 512 KV/split (from 2048); For quantized KV keeps 2048
7. A few correctness fixes along these paths: finite running-max init, pooled buffers for the quantized-K dequant path, build retry on transient compiler OOM, trans-weight restore for broadcast quantized mul_mat, etc. 

## Requirements

Fully tested with Adreno X1 and X2 Windows on Snapdragon (WoS) devices. 

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) Yes. 
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, for testing and quick prototyping.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
