### PR TITLE
ui: take enabled frontend tools into account

### DIFF
--- a/tools/ui/src/lib/stores/agentic.svelte.ts
+++ b/tools/ui/src/lib/stores/agentic.svelte.ts
@@ -285,6 +285,7 @@ class AgenticStore {
 		const hasTools =
 			mcpStore.hasEnabledServers(perChatOverrides) ||
 			toolsStore.builtinTools.length > 0 ||
+			toolsStore.frontendTools.length > 0 ||
 			toolsStore.customTools.length > 0;
 		return {
 			enabled: hasTools && DEFAULT_AGENTIC_CONFIG.enabled,


### PR DESCRIPTION
## Overview

Currently, the `run_javascript` tool doesn't work unless the server is started with --tools. This is fixed by also checking the frontend tools list in `getConfig`, so that `runAgenticFlow` doesn't return early.

## Additional information

This is a draft because I currently have another open PR (#21923), but it has been stale for very long. I hope that this small improvement can still be added regardless. cc @allozaur and @ServeurpersoCom 

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO