### PR TITLE
[RFC] autoparser unable to accommodate non-ASCII reasoning markers, e.g. `◁think▷`

### DIFF
--- a/common/chat-auto-parser-helpers.cpp
+++ b/common/chat-auto-parser-helpers.cpp
@@ -270,6 +270,17 @@ std::vector<segment> segmentize_markers(const std::string & text) {
     std::vector<segment> retval;
     bool in_marker = false;
     char marker_opener = '\0';
+    // For multi-byte UTF-8 openers (e.g. ◁/▷ used by Kimi-VL-Thinking), marker_opener
+    // is '\0' and marker_closer_bytes holds the expected closing byte sequence.
+    std::string marker_closer_bytes;
+
+    // UTF-8 byte sequences for ◁ (U+25C1) and ▷ (U+25B7)
+    static const std::string utf8_triangle_open  = "\xe2\x97\x81"; // ◁
+    static const std::string utf8_triangle_close = "\xe2\x96\xb7"; // ▷
+
+    auto starts_with_bytes = [&](size_t pos, const std::string & bytes) -> bool {
+        return text.compare(pos, bytes.size(), bytes) == 0;
+    };
 
     auto is_marker_opener = [](char c) -> bool { return c == '<' || c == '['; };
     auto is_marker_closer = [](char op, char c) -> bool { return (op == '<' && c == '>') || (op == '[' && c == ']'); };
@@ -284,12 +295,28 @@ std::vector<segment> segmentize_markers(const std::string & text) {
             last_border = cur_pos;
             in_marker = true;
             marker_opener = text[cur_pos];
+        } else if (!in_marker && starts_with_bytes(cur_pos, utf8_triangle_open)) {
+            if (last_border < cur_pos) {
+                retval.push_back(segment(segment_type::TEXT, text.substr(last_border, cur_pos - last_border)));
+            }
+            last_border = cur_pos;
+            in_marker = true;
+            marker_opener = '\0';
+            marker_closer_bytes = utf8_triangle_close;
+            cur_pos += utf8_triangle_open.size() - 1;
         } else if (in_marker && is_marker_closer(marker_opener, text[cur_pos])) {
             // no need to check because last_border will always be smaller
                 retval.push_back(segment(segment_type::MARKER, text.substr(last_border, cur_pos - last_border + 1)));
             last_border = cur_pos + 1;
             in_marker = false;
             marker_opener = '\0';
+        } else if (in_marker && marker_opener == '\0' && starts_with_bytes(cur_pos, marker_closer_bytes)) {
+            size_t end = cur_pos + marker_closer_bytes.size();
+            retval.push_back(segment(segment_type::MARKER, text.substr(last_border, end - last_border)));
+            last_border = end;
+            in_marker = false;
+            marker_closer_bytes.clear();
+            cur_pos = end - 1;
         }
     }
     if (last_border < text.length()) {

--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -1472,7 +1472,9 @@ common_peg_parser common_peg_parser_builder::python_value() {
 common_peg_parser common_peg_parser_builder::marker() {
     auto sharp_bracket_parser = literal("<") + until(">") + literal(">");
     auto square_bracket_parser = literal("[") + until("]") + literal("]");
-    return choice({ sharp_bracket_parser, square_bracket_parser });
+    // UTF-8 triangle brackets ◁ (U+25C1) and ▷ (U+25B7), used by e.g. Kimi-VL-Thinking
+    auto triangle_bracket_parser = literal("\xe2\x97\x81") + until("\xe2\x96\xb7") + literal("\xe2\x96\xb7");
+    return choice({ sharp_bracket_parser, square_bracket_parser, triangle_bracket_parser });
 }
 
 common_peg_parser common_peg_parser_builder::json_member(const std::string & key, const common_peg_parser & p) {


### PR DESCRIPTION
Hi @pwilkin and team!

In follow-up to #18675, let me open an issue after repeatedly failing to find prior discussion.

The attached patch is mostly to demonstrate an issue — it's short enough to tell exactly what is being "fixed". Below I'll describe textually anyway. I'm not convinced it's the best possible approach; sure enough, you'll find a better idea. I'm perfectly fine if the PR gets closed, if anyone more familiar finds a better way.

So, the issue reproduces when running this model: [ggml-org/Kimi-VL-A3B-Thinking-2506-GGUF](https://huggingface.co/ggml-org/Kimi-VL-A3B-Thinking-2506-GGUF),
 * which is a conversion & quantization of [moonshotai/Kimi-VL-A3B-Thinking-2506](https://huggingface.co/moonshotai/Kimi-VL-A3B-Thinking-2506),
 * which is a *"Thinking"* fine-tune of [moonshotai/Kimi-VL-A3B-Instruct](https://huggingface.co/moonshotai/Kimi-VL-A3B-Instruct),
 * which is an instruction-following fine-tune of [moonshotai/Moonlight-16B-A3B](https://huggingface.co/moonshotai/Moonlight-16B-A3B),
 * which is a base model.

The surface-level symptom is, llama.cpp **not parsing the reasoning stream** properly:

<img width="677" height="291" alt="image" src="https://github.com/user-attachments/assets/e43b4c35-de0a-4e9c-846b-d3f918fe5301" />

Do notice the uncommon `◁think▷` marker; the closing one `◁/think▷` follows below in response. The characters are:
 * <kbd>◁</kbd> U+25C1 `WHITE LEFT-POINTING TRIANGLE`
 * <kbd>▷</kbd> U+25B7 `WHITE RIGHT-POINTING TRIANGLE`

These are a property of how the Thinking fine-tune was conducted, I believe. The multi-token sequences `◁think▷`, `◁/think▷` are documented in the models readme's, too.

... *With this patch*, and a correction in chat template jinja, I'm getting `reasoning_mode: TAG_BASED` and proper parses in both llama-cli and llama-server:

<img width="677" height="460" alt="image" src="https://github.com/user-attachments/assets/ba8008d9-cbfe-4dc9-834c-b83ded28155c" />

However again, I'm clear that this is only a rough first cut, a PoC draft that worked; the added logic is too specific and not a good proper fix.

It is necessary, because `segmentize_markers()` cannot handle anything besides `<foo>` and `[bar]`:

https://github.com/ggml-org/llama.cpp/blob/f36e5c348bc8795c34f9a038e58876e7a8423d4d/common/chat-auto-parser-helpers.cpp#L274-L275

(Plus a related change in PEG builder. This patch is made and tested against version `b9747`, but the same code lives in today's master :point_up:)

The real question is:
 * Can the autoparser be generalized to deduce this weirdness, too, from `tokenizer.chat_template` alone?
 * I.e. without requiring code change / nasty hacks like this one.

Hence the RFC tag — Request For Comment.

---------------------------

<details><summary>Fixed & original chat templates</summary>
<h5>Original, distributed with model</h5>

```jinja
{%- for message in messages -%}
  {%- if loop.first and messages[0]['role'] != 'system' -%}
    {{'<|im_system|>system<|im_middle|>You are a helpful assistant<|im_end|>'}}
  {%- endif -%}
  {%- if message['role'] == 'system' -%}{{'<|im_system|>'}}{%- endif -%}
  {%- if message['role'] == 'user' -%}{{'<|im_user|>'}}{%- endif -%}
  {%- if message['role'] == 'assistant' -%}{{'<|im_assistant|>'}}{%- endif -%}
  {{- message['role'] -}}{{'<|im_middle|>'}}

  {%- if message['content'] is string -%}
    {{- message['content'] + '<|im_end|>' -}}
  {%- else -%}
    {%- for content in message['content'] -%}
      {%- if content['type'] == 'image' or 'image' in content or 'image_url' in content -%}
        {{'<|media_start|>image<|media_content|><|media_pad|><|media_end|>'}}
      {%- else -%}
        {{content['text']}}
      {%- endif -%}
    {%- endfor -%}
    {{'<|im_end|>'}}
  {%- endif -%}
{%- endfor -%}
{%- if add_generation_prompt -%}{{'<|im_assistant|>assistant<|im_middle|>'}}{%- endif -%}
```

<h5>Fixed, works as expected together with the PR's patch</h5>

```jinja
{%- for message in messages -%}
  {%- if loop.first and messages[0]['role'] != 'system' -%}
    <|im_system|>system<|im_middle|>You are a helpful AI assistant called Kimi Dolores. You live in the house of Wizard Max. You have a gift of vision, use it wisely.<|im_end|>
  {%- endif -%}
  {%- if message['role'] == 'system' -%} {{'<|im_system|>'}} {%- endif -%}
  {%- if message['role'] == 'user' -%} {{'<|im_user|>'}} {%- endif -%}
  {%- if message['role'] == 'assistant' -%} {{'<|im_assistant|>'}} {%- endif -%}
  {{- message['role'] -}}{{'<|im_middle|>'}}

  {%- if message.get('reasoning_content') -%}
    ◁think▷{{ message['reasoning_content'] }}◁/think▷
  {%- endif -%}

  {%- if message['content'] is string -%}
    {{- message['content'] + '<|im_end|>' -}}
  {%- else -%}
    {%- for content in message['content'] -%}
      {%- if content['type'] == 'image' or 'image' in content or 'image_url' in content -%}
        {{'<|media_start|>image<|media_content|><|media_pad|><|media_end|>'}}
      {%- else -%}
        {{content['text']}}
      {%- endif -%}
    {%- endfor -%}
    {{'<|im_end|>'}}
  {%- endif -%}
{%- endfor -%}
{%- if add_generation_prompt -%}
  {{'<|im_assistant|>assistant<|im_middle|>'}}
{%- endif -%}
```

</details> 

---------------

**AI usage disclosure:** Anthropic Sonnet 4.6 wrote this garbage of patch, with iterated <s>verbal abuse</s> direction provided by the operator (me). But hey, at least it was able to read [the docs][] & follow the source — well done, good codebase. This PR description is 100% pure human writing; best regards.

[the docs]: https://github.com/ggml-org/llama.cpp/blob/master/docs/autoparser.md