### PR TITLE
readme : add Bodega One to UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 *(to have a project listed here, it should clearly state that it depends on `llama.cpp`)*
 
 - [AI Sublime Text plugin](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) (MIT)
+- [Bodega One](https://bodegaone.ai) (proprietary)
 - [BonzAI App](https://apps.apple.com/us/app/bonzai-your-local-ai-agent/id6752847988) (proprietary)
 - [cztomsik/ava](https://github.com/cztomsik/ava) (MIT)
 - [Dot](https://github.com/alexpinel/Dot) (GPL)


### PR DESCRIPTION
Adds [Bodega One](https://bodegaone.ai) to the UIs list (alphabetical placement, license tag per the section format).

Bodega One is a local-first AI IDE (chat + agentic code modes) for Windows/macOS/Linux that depends on llama.cpp for local inference: it ships a built-in GGUF catalog with one-click llama.cpp setup (hardware-fit checks, quant picker, resumable downloads) and runs models through a bundled llama.cpp server. The dependency is stated on the site and in the app's model-setup flow.

Thanks for the great project!