### PR TITLE
CUDA: check UMA before cudaMemGetInfo in device_get_memory

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4169,12 +4169,11 @@ static bool ggml_backend_cuda_get_available_uma_memory(long * available_memory_k
 
 static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {
     ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
-    ggml_cuda_set_device(ctx->device);
-    CUDA_CHECK(cudaMemGetInfo(free, total));
-
 // ref: https://github.com/ggml-org/llama.cpp/pull/17368
 #if defined(__linux__)
-    // Check if this is a UMA (Unified Memory Architecture) system
+    // Check if this is a UMA (Unified Memory Architecture) system.
+    // This must happen before cudaMemGetInfo: on some UMA platforms (e.g. GB10) that call
+    // can fail before the UMA path is reached, and it needlessly creates a CUDA context.
     cudaDeviceProp prop;
     CUDA_CHECK(cudaGetDeviceProperties(&prop, ctx->device));
 
@@ -4188,13 +4187,16 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
         long free_swap_kb = 0;
 
         if (ggml_backend_cuda_get_available_uma_memory(&available_memory_kb, &free_swap_kb) && available_memory_kb > 0) {
-            *free = (size_t)available_memory_kb * 1024;
-        } else {
-            GGML_LOG_ERROR("%s: /proc/meminfo reading failed, using cudaMemGetInfo\n", __func__);
+            *total = prop.totalGlobalMem;
+            *free  = (size_t)available_memory_kb * 1024;
+            return;
         }
+        GGML_LOG_ERROR("%s: /proc/meminfo reading failed, using cudaMemGetInfo\n", __func__);
     }
 #endif // defined(__linux__)
 
+    ggml_cuda_set_device(ctx->device);
+    CUDA_CHECK(cudaMemGetInfo(free, total));
 }
 
 static enum ggml_backend_dev_type ggml_backend_cuda_device_get_type(ggml_backend_dev_t dev) {


### PR DESCRIPTION
Fixes #24933.

`ggml_backend_cuda_device_get_memory` calls `cudaMemGetInfo()` unconditionally before the Linux UMA (`/proc/meminfo`) path added in #17368 is reached. On NVIDIA GB10 / DGX Spark this call can fail (`CUDA-capable device(s) is/are busy or unavailable`), so device probing (`llama-bench --list-devices`) aborts before the UMA fallback can run — see the report and diagnosis by @KimYannn in #24933.

This PR reorders the function as the issue suggests:

- Detect UMA first via `cudaGetDeviceProperties()` (`prop.integrated > 0`, or `GGML_CUDA_ENABLE_UNIFIED_MEMORY`).
- On UMA, return `*total = prop.totalGlobalMem` and `*free` from `/proc/meminfo` `MemAvailable`, without calling `cudaMemGetInfo()`.
- If the `/proc/meminfo` read fails, and on discrete GPUs (`prop.integrated == 0`), behavior is unchanged: `cudaMemGetInfo()` as before.

Side benefit: on UMA systems the probe no longer creates a CUDA context at all (`cudaGetDeviceProperties` and `/proc/meminfo` don't need one). `common_init_result`'s `-fit` step calls this probe repeatedly during model load, so this also removes repeated context create/reset churn there.

## Testing

I don't have GB10 hardware; validated on another NVIDIA UMA platform, Jetson Orin Nano Super (`integrated=1`, sm_87, 8 GB unified LPDDR5, aarch64), on this branch (master @ a8cfdbb9 + this patch):

- `prop.totalGlobalMem` matches the `cudaMemGetInfo` total exactly on this device (7619.9 MiB both) — standalone probe.
- `llama-bench --list-devices`: `CUDA0: Orin (7619 MiB, 5821 MiB free)`; free tracks `/proc/meminfo` `MemAvailable`. Probe wall time 0.136 s vs 0.217 s before the change (no context create/reset).
- Full model load + generation (Qwen2.5-1.5B q4_0, `-ngl 99`, `-fit` on): loads and generates correctly.

@KimYannn would you mind testing this on GB10 to confirm it resolves the original failure?

