### PR TITLE
common: fix missing fstream header

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <fstream>
 
 #if defined(_WIN32) && !defined(_WIN32_WINNT)
 #define _WIN32_WINNT 0x0A00


### PR DESCRIPTION
llama.cpp.git/common/common.h:867:6: error: ‘ifstream’ in namespace ‘std’ does not name a type
  867 | std::ifstream fs_open_ifstream(const std::string & fname, std::ios_base::openmode mode);
      |      ^~~~~~~~
llama.cpp.git/common/common.h:17:1: note: ‘std::ifstream’ is defined in header ‘<fstream>’; this is probably fixable by adding ‘#include <fstream>’
   16 | #include <algorithm>
  +++ |+#include <fstream>
   17 |

With the upcoming GCC 17, C++ headers are cleaned up further and include less unnecessary headers. fstream needs to be included here now.