### PR TITLE
readme : add Lynkr to Infrastructure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - [GPUStack](https://github.com/gpustack/gpustack) - Manage GPU clusters for running LLMs
 - [llama_cpp_canister](https://github.com/onicai/llama_cpp_canister) - llama.cpp as a smart contract on the Internet Computer, using WebAssembly
 - [llama-swap](https://github.com/mostlygeek/llama-swap) - transparent proxy that adds automatic model switching with llama-server
+- [Lynkr](https://github.com/Fast-Editor/Lynkr) - self-hosted gateway that routes AI coding tools (Claude Code, Cursor, Codex CLI) to llama.cpp by request complexity, with tool-output compression and semantic caching
 - [Kalavai](https://github.com/kalavai-net/kalavai-client) - Crowdsource end to end LLM deployment at any scale
 - [llmaz](https://github.com/InftyAI/llmaz) - ☸️ Easy, advanced inference platform for large language models on Kubernetes.
 - [LLMKube](https://github.com/defilantech/llmkube) - Kubernetes operator for llama.cpp with multi-GPU and Apple Silicon Metal


### PR DESCRIPTION
## Overview

Adds Lynkr to the Infrastructure list in the README's ecosystem section, next to llama-swap, following the existing one-line entry format.

Lynkr is an Apache-2.0 self-hosted LLM gateway that uses llama.cpp (`llama-server`) as a first-class routing tier: it scores requests from AI coding tools (Claude Code, Cursor, Codex CLI, Cline, Continue) by complexity and routes simple/medium requests to local llama.cpp models, escalating only complex ones to configured cloud providers. It also compresses JSON tool outputs and adds semantic caching in front of local inference.

Repo: https://github.com/Fast-Editor/Lynkr

## Additional information

Single-line README change; no code affected. Similar in spirit to the existing llama-swap and Paddler entries.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — this PR (the one-line README entry and this description) was prepared with an AI assistant (Claude Code) at the direction of the Lynkr maintainer, who reviewed the change. The referenced project itself is the maintainer's work.
