### PR TITLE
ggml-cpu: Incorrect A indexing in simd_gemm scalar tail-column path

### DIFF
--- a/ggml/src/ggml-cpu/simd-gemm.h
+++ b/ggml/src/ggml-cpu/simd-gemm.h
@@ -78,7 +78,7 @@ static void simd_gemm(
             for (int64_t i = 0; i < GEMM_RM; i++) {
                 float a = C[i * N + jj];
                 for (int64_t kk = 0; kk < K; kk++) {
-                    a += A[i + kk] * B[kk * N + jj];
+                    a += A[i * K + kk] * B[kk * N + jj];
                 }
                 C[i * N + jj] = a;
             }


### PR DESCRIPTION
## Overview

`simd_gemm()` has an incorrect A-matrix index in the scalar tail-column path for full row blocks.

## Additional information

  This appears to have been introduced by commit `08e6d914b8fef477d2a5aeeb89e08d42709981cf` (`ggml : avoid UB in gemm ukernel (llama/19642)`), which changed the SIMD GEMM ukernel from using global `ii` / `jj` offsets to passing already-offset `A`, `B`, and `C` pointers.

<img width="2846" height="500" alt="image" src="https://github.com/user-attachments/assets/c69acce1-4f90-46ca-b42e-1a9cda4e72d9" />



  Before that commit, the scalar tail-column path used the global row index:

  ```cpp
  a += A[(ii + i) * K + kk] * B[kk * N + jj];

  After the commit, A is advanced after each full row block:

  A += GEMM_RM * K;
  C += GEMM_RM * N;

  So inside the current block, the correct row-major index should be:

  A[i * K + kk]
```
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
