### PR TITLE
llama : fix DeepSeek-V4 quantized K-cache garbage (disable Hadamard rotation for the arch) + regression tests

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -339,7 +339,9 @@ llama_kv_cache::llama_kv_cache(
             hparams.n_embd_head_k() % 64 == 0;
 
         // always create Hadamard rotation tensors for DeepSeek lightning indexers
-        if ((model.arch == LLM_ARCH_DEEPSEEK32 || model.arch == LLM_ARCH_DEEPSEEK4) &&
+        // (LLAMA_ATTN_ROT_DISABLE overrides this too, for diagnosing the quantized-K corruption)
+        if (!attn_rot_disable &&
+                (model.arch == LLM_ARCH_DEEPSEEK32 || model.arch == LLM_ARCH_DEEPSEEK4) &&
                 hparams.n_embd_head_k_full == hparams.indexer_head_size) {
             attn_rot_k = true;
         }
@@ -349,6 +351,21 @@ llama_kv_cache::llama_kv_cache(
             n_embd_head_v_all > 0 &&
             ggml_is_quantized(type_v) &&
             hparams.n_embd_head_v() % 64 == 0;
+
+        // DeepSeek-V4: the Hadamard incoherence rotation is not correctly integrated with this
+        // model's attention. Enabling it (which only happens for a quantized K/V cache) allocates
+        // self_k_rot, which forces every layer off the designed sparse CSA/HCA/lightning-indexer
+        // paths (they require self_k_rot==nullptr) onto build_raw_attention, whose rotation handling
+        // is broken (plain ggml_mul_mat instead of the block-wise ggml_mul_mat_aux, and no
+        // un-rotation of the MLA V-is-K-view output before the v_mla up-projection). The result is
+        // confident gibberish on ALL backends (verified CPU + CUDA/Volta). Until the sparse paths
+        // learn to apply/undo the rotation, disable it here so quantized K/V flows through the
+        // correct attention with plain (near-lossless) q8_0. f16 caches never enabled rotation, so
+        // they are unaffected. See exec-logs/2026-07-07-ds4kernel-fable-execlog.md.
+        if (model.arch == LLM_ARCH_DEEPSEEK4) {
+            attn_rot_k = false;
+            attn_rot_v = false;
+        }
     }
 
     LLAMA_LOG_INFO("%s: attn_rot_k = %d, n_embd_head_k_all = %d\n", __func__, attn_rot_k, n_embd_head_k_all);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7772,6 +7772,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_F32, GGML_TYPE_I64, { 1, 8, 1, 3 }, { 1, 1 }, 2, false));
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_F32, GGML_TYPE_I32, { 1, 8, 1, 3 }, { 1, 1 }, 2, false));
     test_cases.emplace_back(new test_set_rows(GGML_TYPE_Q8_0, GGML_TYPE_I32, { 256, 5, 1, 3 }, { 1, 1, }, 1, false));
+    // DeepSeek-V4-Flash MLA K-cache write: 576-wide (512 latent + 64 RoPE) q8_0 row, indexed rows.
+    // Isolates the CUDA quantize-on-write (k_set_rows_quant) for the exact MLA head width.
+    test_cases.emplace_back(new test_set_rows(GGML_TYPE_Q8_0, GGML_TYPE_I64, { 576, 5, 1, 1 }, { 1, 1, }, 3, false));
+    test_cases.emplace_back(new test_set_rows(GGML_TYPE_Q8_0, GGML_TYPE_I32, { 576, 5, 1, 1 }, { 1, 1, }, 3, false));
     for (ggml_type type : all_types) {
         for (int b : {1, 7}) {
             for (bool v : {false, true}) {
@@ -9169,6 +9173,17 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 128, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q4_0));
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 128, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q4_0, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(72, 72, 4, {1, 1}, 96, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0));
+    // DeepSeek MLA 576/512 with a quantized (q8_0) K-cache. V is a sub-view of K (V_is_K_view),
+    // so this exercises the exact Volta sm_70 path that serves garbage in DeepSeek-V4-Flash.
+    // nb=1 -> generation (tile/vec kernel); nb=32 -> prefill (mma-f16 kernel). f16 controls above.
+    for (int nb : { 1, 32 }) {
+        for (int nr2 : { 8, 16 }) {
+            test_cases.emplace_back(new test_flash_attn_ext(
+                        576, 512, 1, {nr2, 1}, 512, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0));
+            test_cases.emplace_back(new test_flash_attn_ext(
+                        576, 512, 1, {nr2, 1}, 512, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+        }
+    }
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 96, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F32));
     test_cases.emplace_back(new test_flash_attn_ext(128, 128, 4, {1, 1}, 256, 1, false, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0));
     test_cases.emplace_back(new test_flash_attn_ext(128, 128, 4, {1, 1}, 96, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q1_0, GGML_TYPE_Q1_0));


### PR DESCRIPTION
Fixes #25382.

A quantized K-cache enables the Hadamard incoherence rotation; a non-null `self_k_rot` diverts every DeepSeek-V4 layer off its sparse CSA/HCA/lightning-indexer attention (which asserts the rotation is absent) into `build_raw_attention`, which applies the rotation with a plain `ggml_mul_mat` (not the block-reshaping `ggml_mul_mat_aux`) and never un-rotates the MLA V-is-a-view-of-K output. Result: confident gibberish on every backend (CPU and CUDA verified identical) behind a healthy server.

This PR takes fix option (a) from the issue — the minimal, arch-scoped change: do not enable the KV rotation for `LLM_ARCH_DEEPSEEK4`, so a quantized K flows through the model's designed sparse attention as plain q8_0. f16 behavior is untouched (rotation was never active there).

- Commit 1: `test-backend-ops` cases at the exact MLA geometry (hsk=576/hsv=512, V as a sub-view of K, quantized cache types) — these pass in isolation before and after, demonstrating the kernels were never the problem.
- Commit 2: the fix.

Verification on our rig (8× V100 + CPU): full K/V ∈ {q8_0,f16}² live matrix coherent at temp 0 after the fix (q8-K cells were garbage before); no change to any f16 cell. CPU-only build + the new SET_ROWS cases pass on this branch.

We also have the deeper fix working — making the sparse paths rotation-aware and re-enabling the rotation (options b+c, branch `ds4-rotation-aware` on this fork; measured ~6.8% decode cost, and directionally better long-context retrieval with q8-K than rotation-off) — happy to follow up with that PR if maintainers prefer the rotation kept functional for this arch.

Full research record: https://github.com/ProprietaryLegal/deepseek-v4-flash-v100