### PR TITLE
ggml-metal: handle buffer allocation failure

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -202,6 +202,9 @@ typedef std::unique_ptr<ggml_backend_metal_buffer_type, ggml_backend_metal_buffe
 static ggml_backend_buffer_t ggml_backend_metal_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size, bool shared) {
     ggml_metal_device_t ctx_dev = (ggml_metal_device_t)buft->device->context;
     ggml_metal_buffer_t res = ggml_metal_buffer_init(ctx_dev, size, shared);
+    if (res == NULL) {
+        return NULL;
+    }
 
     ggml_backend_buffer_i buf_i = ggml_metal_buffer_is_shared(res)
         ? ggml_backend_metal_buffer_shared_i


### PR DESCRIPTION
## Summary

Metal buffer allocation can fail and return `NULL`, for example during a large graph reservation. The shared/private Metal buffer allocation path currently dereferences that result immediately via `ggml_metal_buffer_is_shared(res)`, which turns the allocation failure into a crash.

This change returns `NULL` from the backend allocation callback when `ggml_metal_buffer_init()` fails, matching the existing ggml backend allocation failure contract.

## Changes

- Propagate `ggml_metal_buffer_init()` failure from `ggml_backend_metal_buffer_type_alloc_buffer()`.
- Keep the shared/private buffer interface selection unchanged for successful allocations.

## Testing

- `cmake -B build -DGGML_METAL=ON -DLLAMA_BUILD_TESTS=ON`
- `cmake --build build --target test-backend-ops`

`ctest --test-dir build -R test-backend-ops --output-on-failure` was attempted, but this local macOS environment could not create a Metal command queue (`picking default device: (null)`), so the test aborts before exercising backend ops.
