### PR TITLE
server: fix router proxy failing when --timeout 0 is used

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -2177,9 +2177,12 @@ server_http_proxy::server_http_proxy(
 
     // setup Client
     cli->set_follow_location(true);
-    cli->set_connection_timeout(timeout_read, 0); // use --timeout value instead of hardcoded 5 s
-    cli->set_write_timeout(timeout_read, 0); // reversed for cli (client) vs srv (server)
-    cli->set_read_timeout(timeout_write, 0);
+    // httplib treats timeout of 0 as "immediate timeout", not "no timeout"
+    // when user passes --timeout 0, treat it as no timeout by using a large value
+    constexpr int32_t no_timeout_s = 3600;
+    cli->set_connection_timeout(timeout_read == 0 ? no_timeout_s : timeout_read, 0);
+    cli->set_write_timeout(timeout_read == 0 ? no_timeout_s : timeout_read, 0);
+    cli->set_read_timeout(timeout_write == 0 ? no_timeout_s : timeout_write, 0);
     this->status = 500; // to be overwritten upon response
     this->cleanup = [pipe]() {
         pipe->close_read();


### PR DESCRIPTION
## Description

When using `--models-preset` in router mode with `--timeout 0`, all requests fail with `proxy error: Failed to read connection` (HTTP 500), even though the child server processes and completes the request successfully.

## Root Cause

httplib treats a timeout value of 0 as "immediate timeout", not "no timeout". When the user passes `--timeout 0` (the documented way to disable timeouts), the router proxy sets `set_connection_timeout(0, 0)`, `set_write_timeout(0, 0)`, and `set_read_timeout(0, 0)`, causing the httplib client to fail immediately on every request.

The `Error::Read` occurs <1ms after the proxy starts, confirming this is a timeout issue rather than a connection problem.

## Fix

Map timeout values of 0 to 3600 seconds before passing to httplib, treating 0 as "no timeout" rather than "immediate timeout".

## Reproduction

```bash
llama-server --host 0.0.0.0 --port 8080 --models-preset models.ini --timeout 0
curl http://127.0.0.1:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "any-model", "messages": [{"role": "user", "content": "hi"}]}'
# Returns: proxy error: Failed to read connection
```

## Verification

Tested with the fix applied - router mode now works correctly with `--timeout 0`.

Closes #25396