### PR TITLE
DeepSeek-V4 Checkpointing Fix

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -967,6 +967,8 @@ bool llm_arch_supports_rs_rollback(const llm_arch & arch) {
     switch (arch) {
         case LLM_ARCH_QWEN35:
         case LLM_ARCH_QWEN35MOE:
+        // DSV4: keep checkpoints enabled.
+        case LLM_ARCH_DEEPSEEK4:
             return true;
         default:
             return false;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -52,6 +52,10 @@ llama_context::llama_context(
     }
 
     cparams.n_rs_seq = params.n_rs_seq;
+    // DSV4: default to its 1-token rollback bound so it is classified RS (keeps checkpoints).
+    if (cparams.n_rs_seq == 0 && model.arch == LLM_ARCH_DEEPSEEK4) {
+        cparams.n_rs_seq = 1;
+    }
     if (cparams.n_rs_seq > 0 && !llm_arch_supports_rs_rollback(model.arch)) {
         LLAMA_LOG_DEBUG("%s: n_rs_seq=%u requested but model arch does not support recurrent partial rollback; clamping to 0\n",
                         __func__, cparams.n_rs_seq);

--- a/src/llama-kv-cache-dsv4.cpp
+++ b/src/llama-kv-cache-dsv4.cpp
@@ -19,7 +19,7 @@ static constexpr uint32_t DSV4_CSA_RATIO = 4;
 static constexpr uint32_t DSV4_HCA_RATIO = 128;
 
 static constexpr uint32_t DSV4_STATE_MAGIC         = 0x34565344; // DSV4
-static constexpr uint32_t DSV4_STATE_VERSION       = 1;
+static constexpr uint32_t DSV4_STATE_VERSION       = 2;   // v2: partial save now includes base + block caches
 static constexpr uint32_t DSV4_STATE_MODE_FULL     = 0;
 static constexpr uint32_t DSV4_STATE_MODE_PARTIAL  = 1;
 static constexpr uint32_t DSV4_K_CACHE_STATE_VER   = 1;
@@ -1163,6 +1163,11 @@ bool llama_kv_cache_dsv4::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1
             return true;
         }
 
+        // Evict the 1-token tail so the last-token re-eval doesn't duplicate it; deeper rollbacks go to a checkpoint.
+        if (seq_id >= 0 && p0 == kv_raw->seq_pos_max(seq_id)) {
+            return kv_raw->seq_rm(seq_id, p0, p1);
+        }
+
         return false;
     }
 
@@ -1248,13 +1253,14 @@ void llama_kv_cache_dsv4::state_write(llama_io_write_i & io, llama_seq_id seq_id
     io.write(&version, sizeof(version));
     io.write(&mode,    sizeof(mode));
 
-    kv_raw->state_write(io, seq_id, flags);
+    // DSV4 base + block caches aren't recomputable from a partial re-decode, so save them even in partial mode.
+    const llama_state_seq_flags raw_flags = flags & ~((llama_state_seq_flags) LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
 
-    if (!partial_only) {
-        dsv4_state_write_k_cache(io, kv_csa.get(), seq_id, flags);
-        dsv4_state_write_k_cache(io, kv_hca.get(), seq_id, flags);
-        dsv4_state_write_k_cache(io, kv_lid.get(), seq_id, flags);
-    }
+    kv_raw->state_write(io, seq_id, raw_flags);
+
+    dsv4_state_write_k_cache(io, kv_csa.get(), seq_id, flags);
+    dsv4_state_write_k_cache(io, kv_hca.get(), seq_id, flags);
+    dsv4_state_write_k_cache(io, kv_lid.get(), seq_id, flags);
 
     csa_state->state_write(io, seq_id, flags);
     hca_state->state_write(io, seq_id, flags);
@@ -1286,13 +1292,14 @@ void llama_kv_cache_dsv4::state_read(llama_io_read_i & io, llama_seq_id seq_id, 
         throw std::runtime_error("DSV4 state flags mismatch");
     }
 
-    kv_raw->state_read(io, seq_id, flags);
+    // Mirror state_write.
+    const llama_state_seq_flags raw_flags = flags & ~((llama_state_seq_flags) LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
 
-    if (!partial_only) {
-        dsv4_state_read_k_cache(io, kv_csa.get(), seq_id, flags);
-        dsv4_state_read_k_cache(io, kv_hca.get(), seq_id, flags);
-        dsv4_state_read_k_cache(io, kv_lid.get(), seq_id, flags);
-    }
+    kv_raw->state_read(io, seq_id, raw_flags);
+
+    dsv4_state_read_k_cache(io, kv_csa.get(), seq_id, flags);
+    dsv4_state_read_k_cache(io, kv_hca.get(), seq_id, flags);
+    dsv4_state_read_k_cache(io, kv_lid.get(), seq_id, flags);
 
     csa_state->state_read(io, seq_id, flags);
     hca_state->state_read(io, seq_id, flags);


### PR DESCRIPTION
PR closed - https://github.com/ggml-org/llama.cpp/pull/25202 was the one which fixed the issue and was merged 20 hours ago - and I was using an older llama.cpp version which caused gibberish

Specifically using `--cache-type-k/v q8_0` before https://github.com/ggml-org/llama.cpp/pull/25202 caused garbage ie `overlayotin kinetic academyléléléléulif` after after the PR "The capital of France is Paris." (correct)

> Fixes DeepSeek-V4 prompt caching - before `--ctx-checkpoints 0` had to be used since prompt caching for DeepSeek-V4-Flash would cause gibberish.
> 
> | llama.cpp | Before PR | After PR |
> | --- | --- | --- |
> | Tool calling (temp 1.0, 3 seeds) | 4/15 | 15/15 |
> 
> Used https://huggingface.co/unsloth/DeepSeek-V4-Flash-GGUF UD-Q8_K_XL, UD-Q4_K_XL for testing and other community quants to verify it wasn't a quant issue!
