### PR TITLE
chat: honor explicit deepseek reasoning format

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -121,12 +121,23 @@ common_peg_arena autoparser::build_parser(const generation_params & inputs, cons
         parser_build_context ctx(p, inputs);
         bool                 extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
 
-        ctx.extracting_reasoning = extract_reasoning && reasoning.mode != reasoning_mode::NONE;
+        const bool explicit_deepseek_reasoning = inputs.reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK ||
+                                                 inputs.reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY;
+
+        analyze_reasoning default_reasoning;
+        if (explicit_deepseek_reasoning && inputs.enable_thinking && reasoning.mode == reasoning_mode::NONE) {
+            default_reasoning.mode  = reasoning_mode::TAG_BASED;
+            default_reasoning.start = "<think>";
+            default_reasoning.end   = "</think>";
+        }
+        const auto & effective_reasoning = default_reasoning.mode == reasoning_mode::NONE ? reasoning : default_reasoning;
+
+        ctx.extracting_reasoning = extract_reasoning && effective_reasoning.mode != reasoning_mode::NONE;
         ctx.content              = &content;
-        ctx.reasoning            = &reasoning;
+        ctx.reasoning            = &effective_reasoning;
 
         // Build reasoning parser
-        ctx.reasoning_parser = reasoning.build_parser(ctx);
+        ctx.reasoning_parser = effective_reasoning.build_parser(ctx);
 
         auto parser = p.eps();
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -2600,6 +2600,60 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
     }
 
     {
+        // Qwen2.5-style templates do not expose reasoning markers, but some
+        // fine-tunes emit DeepSeek-style <think> tags. AUTO should not guess.
+        auto tst = peg_tester("models/templates/Qwen-Qwen2.5-7B-Instruct.jinja");
+
+        tst.test(R"(<think>
+I'm thinking
+</think>
+
+Hello, world!)")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .expect_content(R"(<think>
+I'm thinking
+</think>
+
+Hello, world!)")
+            .run();
+
+        tst.test(R"(<think>
+I'm thinking
+</think>
+
+Hello, world!)")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
+            .expect(simple_assist_msg("Hello, world!", "I'm thinking"))
+            .run();
+
+        tst.test(R"(<think>
+I'm thinking
+</think>
+
+Hello, world!)")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY)
+            .expect(simple_assist_msg("Hello, world!", "I'm thinking"))
+            .run();
+
+        tst.test(R"(<think>
+I'm thinking
+</think>
+
+Hello, world!)")
+            .enable_thinking(false)
+            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
+            .expect_content(R"(<think>
+I'm thinking
+</think>
+
+Hello, world!)")
+            .run();
+    }
+
+    {
         // NVIDIA Nemotron-3 Nano
         auto tst = peg_tester("models/templates/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.jinja", detailed_debug);
 


### PR DESCRIPTION
## Overview

Honor explicit DeepSeek-style reasoning parsing for templates that do not expose reasoning markers.

Some Qwen-style reasoning fine-tunes emit standard `<think>...</think>` blocks, but their chat templates look like ordinary Qwen instruct templates and do not advertise reasoning markers. `auto` should remain conservative in that case, but an explicit `--reasoning-format deepseek` or `--reasoning-format deepseek-legacy` should still enable the standard tag parser.

This keeps `auto` from guessing while making explicit parser selection work for this class of models.

## Additional information

Related to #25292.

This is not intended as a full out-of-box fix for VibeThinker. The canonical OOB fix should come from the model/GGUF chat template exposing reasoning markers directly.

This PR only makes explicit parser selection work for standard `<think>...</think>` output when users opt into it with `--reasoning-format deepseek` or `deepseek-legacy`.

Validation:

```sh
cmake --build build --target test-chat -j"$(nproc)"
./build/bin/test-chat
```

Result: `[chat] All tests passed!`

End-to-end check with a real VibeThinker GGUF:

```sh
cmake --build build --target llama-server -j"$(nproc)"
./build/bin/llama-server \
  -m /tmp/llama-models/vibethinker/vibethinker-3b-q4_k_m.gguf \
  --host 127.0.0.1 --port 18092 -c 1024 -ngl 0 \
  --reasoning-format deepseek --reasoning on
```

A non-streaming `/v1/chat/completions` request returned `message.reasoning_content` and `message.content == "4"`; the content field did not contain `<think>` tags. A control request with `reasoning_format: "none"` kept `<think>` in `message.content`, confirming the separation comes from the explicit reasoning parser.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assistance was used for code navigation, test drafting, and wording. The contributor reviewed the change, validation result, and is responsible for all submitted content.
