### PR TITLE
ggml-cpu/repack: fix 3D expert tensor assert for deepseek4 IQ2_XXS models

### DIFF
--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -4279,7 +4279,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
 
         GGML_ASSERT(src1->type == GGML_TYPE_F32);
 
-        GGML_ASSERT(ggml_n_dims(op->src[0]) == 2);
+        GGML_ASSERT(ggml_n_dims(op->src[0]) >= 2);
         // GGML_ASSERT(ggml_n_dims(op->src[1]) == 2);
 
         char *       wdata = static_cast<char *>(params->wdata);

--- a/repack.patch
+++ b/repack.patch
@@ -1,0 +1,11 @@
+--- a/ggml/src/ggml-cpu/repack.cpp
++++ b/ggml/src/ggml-cpu/repack.cpp
+@@ -4279,7 +4279,7 @@
+         GGML_ASSERT(ne03 == 1);
+         GGML_ASSERT(ne13 == 1);
+         GGML_ASSERT(ne3 == 1);
+-        GGML_ASSERT(ggml_n_dims(op->src[0]) == 2);
++        GGML_ASSERT(ggml_n_dims(op->src[0]) >= 2);
+         // GGML_ASSERT(ggml_n_dims(op->src[1]) == 2);
+ 
+         char *       wdata = static_cast<char *>(params->wdata);


### PR DESCRIPTION
Fix: change GGML_ASSERT(n_dims == 2) to >= 2 for MoE expert tensors [4096,2048,256]. Tested on DeepSeek V4 Flash IQ2_XXS (81 GB GGUF).