### PR TITLE
common : validate dataset size before computing datapoint count

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1914,7 +1914,15 @@ common_control_vector_data common_control_vector_load(const std::vector<common_c
 
 ggml_opt_dataset_t common_opt_dataset_init(struct llama_context * ctx, const std::vector<llama_token> & tokens, int64_t stride) {
     const int64_t ne_datapoint = llama_n_ctx(ctx);
-    const int64_t ndata        = (tokens.size() - ne_datapoint - 1) / stride;
+
+    if ((int64_t) tokens.size() < ne_datapoint + 1) {
+        LOG_ERR("%s: dataset contains %zu tokens but requires at least %lld tokens for a context size of %lld. "
+                "Provide more training data or reduce the context size (-c).\n",
+                __func__, tokens.size(), (long long)(ne_datapoint + 1), (long long)ne_datapoint);
+        exit(1);
+    }
+
+    const int64_t ndata = ((int64_t) tokens.size() - ne_datapoint - 1) / stride;
     ggml_opt_dataset_t result = ggml_opt_dataset_init(
         GGML_TYPE_I32, GGML_TYPE_I32, ne_datapoint, ne_datapoint, ndata, /*ndata_shard =*/ 1);
 


### PR DESCRIPTION
## Overview

This PR  Fixes a crash where fine-tuning with a dataset too small for the requested context size caused an integer underflow, producing an "impossible" allocation request (a value near UINT64_MAX) instead of a clear error.].

The change was made to improve [performance/compatibility/functionality] by [short explanation of what you changed].

## Additional information

Testing performed:

* Built successfully with the existing build system.
* Verified the changes with relevant tests.

Additional notes:

* All submitted changes have been reviewed and verified by me.

## Requirements

* I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
AI usage disclosure: YES - This PR was developed with AI assistance. AI generated portions of the implementation and helped with debugging. I reviewed the changes, validated the behavior, reproduced the original issue, and verified the final result.