### PR TITLE
qwen2 : use no-cache attention path for training graphs

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3250,6 +3250,19 @@ void llama_context::opt_init(struct llama_model * model, struct llama_opt_params
     GGML_ASSERT(model->hparams.n_ctx_train % n_batch  == 0);
     GGML_ASSERT(n_batch                    % n_ubatch == 0);
 
+    // The graph buffer normally reserved by sched_reserve() is sized by graph_max_nodes(),
+    // which assumes the compact, fused inference graph shape (one Flash Attention node and
+    // one KV-cache-write node per layer). Training builds a larger, unfused, no-cache forward
+    // graph (see LLM_GRAPH_TYPE_TRAIN), and ggml_opt_alloc() then appends a full set of
+    // backward-pass nodes into that same buffer. Re-reserve it here, now that we know for
+    // certain training is starting, with enough headroom for both. The factor below is a
+    // heuristic (not a measured worst case) covering the unfused attention op count plus
+    // backward-pass node growth; if training graphs grow further this may need revisiting.
+    {
+        const size_t max_nodes_train = 8 * this->graph_max_nodes(n_batch);
+        gf_res_prev.reset(new llm_graph_result(max_nodes_train));
+    }
+
     ggml_opt_params opt_params = ggml_opt_default_params(sched.get(), GGML_OPT_LOSS_TYPE_CROSS_ENTROPY);
     opt_params.opt_period      = n_batch / n_ubatch;
     opt_params.get_opt_pars    = lopt_params.get_opt_pars;
@@ -3349,7 +3362,10 @@ void llama_context::opt_epoch_iter(
 
             auto * res = gf_res_prev.get();
 
-            const auto gparams = graph_params(res, ubatch, mctx.get(), ctx_type_to_graph_type(cparams.ctx_type));
+            // Use LLM_GRAPH_TYPE_TRAIN so architectures build a graph without KV-cache writes,
+            // which ggml's backward-pass builder cannot differentiate through. This is currently
+            // the only call site that produces LLM_GRAPH_TYPE_TRAIN.
+            const auto gparams = graph_params(res, ubatch, mctx.get(), LLM_GRAPH_TYPE_TRAIN);
 
             res->reset();
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3419,6 +3419,19 @@ void llama_context::opt_init(struct llama_model * model, struct llama_opt_params
         sched_reserve();
     }
 
+    // The graph buffer normally reserved by sched_reserve() is sized by graph_max_nodes(),
+    // which assumes the compact, fused inference graph shape (one Flash Attention node and
+    // one KV-cache-write node per layer). Training builds a larger, unfused, no-cache forward
+    // graph (see LLM_GRAPH_TYPE_TRAIN), and ggml_opt_alloc() then appends a full set of
+    // backward-pass nodes into that same buffer. Re-reserve it here, now that we know for
+    // certain training is starting, with enough headroom for both. The factor below is a
+    // heuristic (not a measured worst case) covering the unfused attention op count plus
+    // backward-pass node growth; if training graphs grow further this may need revisiting.
+    {
+        const size_t max_nodes_train = 8ULL * this->graph_max_nodes(n_batch);
+        gf_res_prev.reset(new llm_graph_result(max_nodes_train));
+    }
+
     ggml_opt_params opt_params = ggml_opt_default_params(sched.get(), GGML_OPT_LOSS_TYPE_CROSS_ENTROPY);
     opt_params.opt_period      = n_batch / n_ubatch;
     opt_params.get_opt_pars    = lopt_params.get_opt_pars;
@@ -3518,7 +3531,10 @@ void llama_context::opt_epoch_iter(
 
             auto * res = gf_res_prev.get();
 
-            const auto gparams = graph_params(res, ubatch, mctx.get(), ctx_type_to_graph_type(cparams.ctx_type));
+            // Use LLM_GRAPH_TYPE_TRAIN so architectures build a graph without KV-cache writes,
+            // which ggml's backward-pass builder cannot differentiate through. This is currently
+            // the only call site that produces LLM_GRAPH_TYPE_TRAIN.
+            const auto gparams = graph_params(res, ubatch, mctx.get(), LLM_GRAPH_TYPE_TRAIN);
 
             res->reset();
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -34,6 +34,7 @@ enum llm_graph_type {
     LLM_GRAPH_TYPE_ENCODER,
     LLM_GRAPH_TYPE_DECODER,
     LLM_GRAPH_TYPE_DECODER_MTP,
+    LLM_GRAPH_TYPE_TRAIN, // graph built for backward-pass (gradient) computation; architectures must avoid KV-cache writes for this type, since they are not supported by ggml's autodiff
 };
 
 enum llm_ffn_op_type : int {

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -39,6 +39,7 @@ enum llm_graph_type {
     LLM_GRAPH_TYPE_ENCODER,
     LLM_GRAPH_TYPE_DECODER,
     LLM_GRAPH_TYPE_DECODER_MTP,
+    LLM_GRAPH_TYPE_TRAIN, // graph built for backward-pass (gradient) computation; architectures must avoid KV-cache writes for this type, since they are not supported by ggml's autodiff
 };
 
 enum llm_fused_op {

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -442,6 +442,10 @@ struct llama_model_qwen2 : public llama_model_base {
     void load_arch_hparams(llama_model_loader & ml) override;
     void load_arch_tensors(llama_model_loader & ml) override;
 
+    // Inference builds a graph<false> against the persistent KV cache. Training builds
+    // graph<true>, which avoids KV-cache writes since they are not supported by ggml's
+    // backward-pass builder. See qwen2.cpp for the shared implementation.
+    template <bool is_training>
     struct graph : public llm_graph_context {
         graph(const llama_model & model, const llm_graph_params & params);
     };

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -484,6 +484,10 @@ struct llama_model_qwen2 : public llama_model_base {
     void load_arch_hparams(llama_model_loader & ml) override;
     void load_arch_tensors(llama_model_loader & ml) override;
 
+    // Inference builds a graph<false> against the persistent KV cache. Training builds
+    // graph<true>, which avoids KV-cache writes since they are not supported by ggml's
+    // backward-pass builder. See qwen2.cpp for the shared implementation.
+    template <bool is_training>
     struct graph : public llm_graph_context {
         graph(const llama_model & model, const llm_graph_params & params);
     };

--- a/src/models/qwen2.cpp
+++ b/src/models/qwen2.cpp
@@ -47,10 +47,21 @@ void llama_model_qwen2::load_arch_tensors(llama_model_loader &) {
 }
 
 std::unique_ptr<llm_graph_context> llama_model_qwen2::build_arch_graph(const llm_graph_params & params) const {
-    return std::make_unique<graph>(*this, params);
+    // Training graphs use a different topology than inference graphs: they must avoid
+    // KV-cache writes, which are not supported by ggml's backward-pass (autodiff) builder.
+    if (params.gtype == LLM_GRAPH_TYPE_TRAIN) {
+        return std::make_unique<graph<true>>(*this, params);
+    }
+    return std::make_unique<graph<false>>(*this, params);
 }
 
-llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+// graph<false> (inference): builds attention against the persistent KV cache.
+// graph<true>  (training):  builds attention with no cache, since a KV-cache write node
+//                            cannot be differentiated by ggml's backward-pass builder.
+// The two topologies share this single definition; `if constexpr` selects the differing
+// parts at compile time with no runtime branch and no duplicated model-graph code.
+template <bool is_training>
+llama_model_qwen2::graph<is_training>::graph(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
     const int64_t n_embd_head = hparams.n_embd_head_v();
 
     GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
@@ -64,7 +75,14 @@ llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_param
     // inp_pos - contains the positions
     ggml_tensor * inp_pos = build_inp_pos();
 
-    auto * inp_attn = build_attn_inp_kv();
+    llm_graph_input_attn_kv       * inp_attn_kv = nullptr;
+    llm_graph_input_attn_no_cache * inp_attn_nc = nullptr;
+
+    if constexpr (is_training) {
+        inp_attn_nc = build_attn_inp_no_cache();
+    } else {
+        inp_attn_kv = build_attn_inp_kv();
+    }
 
     ggml_tensor * inp_out_ids = build_inp_out_ids();
 
@@ -99,9 +117,15 @@ llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_param
             cb(Kcur, "Kcur", il);
             cb(Vcur, "Vcur", il);
 
-            cur = build_attn(inp_attn,
-                    model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
-                    Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
+            if constexpr (is_training) {
+                cur = build_attn(inp_attn_nc,
+                        model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
+                        Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
+            } else {
+                cur = build_attn(inp_attn_kv,
+                        model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
+                        Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
+            }
         }
         if (il == n_layer - 1 && inp_out_ids) {
             cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
@@ -152,3 +176,8 @@ llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_param
 
     ggml_build_forward_expand(gf, cur);
 }
+
+// Explicit instantiation: both graph topologies are needed at link time since
+// build_arch_graph() selects between them at runtime via params.gtype.
+template struct llama_model_qwen2::graph<false>;
+template struct llama_model_qwen2::graph<true>;


### PR DESCRIPTION
## Overview

This PR fixes llama-finetune training crashes caused by the inference graph path incorrectly using the persistent KV cache during training.

`llama_opt_epoch()` was building its training graph through the same path used for normal inference. For causal decoder models such as Qwen2, this path writes K/V values into the persistent KV cache using `ggml_set_rows()`. While this is required for inference, the resulting graph node cannot be handled by ggml's backward graph builder, causing an assertion failure during backward graph construction.

This change adds a dedicated training graph type (`LLM_GRAPH_TYPE_TRAIN`) and routes training through the existing differentiable no-cache attention path. The Qwen2 model graph was templated so inference and training share the same implementation while selecting the appropriate attention path at compile time.

Additionally, training graph memory reservation was updated to account for the larger unfused forward graph and the additional backward graph nodes generated during optimization.

## Additional information

Testing performed:

* Tested with `Qwen2.5-14B-Instruct`.
* Verified training previously crashed during backward graph construction.
* Verified training now completes multiple full epochs with converging training and validation loss.

Notes:

* Flash Attention must be disabled during training (`-fa off`) because ggml currently does not have a Flash Attention backward implementation. This is an existing limitation and is not addressed by this patch.

## Requirements

* I have read and agree to the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - This PR was developed with AI assistance. AI generated portions of the implementation and helped with debugging. I reviewed the changes, validated the behavior, reproduced the original issue, and verified the final result.