### PR TITLE
opencl: ragged-tile MoE prefill FP16 GEMM optimization (skip padded expert tiles)

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -19345,6 +19345,14 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
                     global_size[2] = static_cast<size_t>(max_post_router_tile);
@@ -19577,6 +19585,14 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
                     global_size[2] = static_cast<size_t>(max_post_router_tile);
@@ -19758,6 +19774,14 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
+
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -19941,6 +19965,14 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
+
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20198,12 +20230,20 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    // Ragged tile-skip: skip empty 8-column dot-groups for sparse expert tiles
+                    // whose trailing token-slots are all padding (byte-identical). Default on;
+                    // opt out with GGML_OPENCL_MOE_RAGGED_FP16=0.
                     static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
+
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20389,6 +20429,14 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
                     global_size[2] = static_cast<size_t>(max_post_router_tile);
@@ -20569,6 +20617,14 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
+
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20758,6 +20814,14 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
                     const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
+
+                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
+                    // 16 = half (legacy), 32 = disabled. Override with
+                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
+                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
+                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -517,6 +517,10 @@ struct ggml_backend_opencl_context {
     bool has_qcom_subgroup_shuffle = false;  // specifically cl_qcom_subgroup_shuffle
     bool disable_fusion;
 
+    // ragged moe, use int to directly pass to kernel
+    cl_uint  adreno_use_moe_ragged;
+    cl_uint  adreno_moe_ragged_skip_gran;
+
     bool adreno_has_large_buffer;
     bool adreno_use_large_buffer;
     bool adreno_use_bin_kernels;
@@ -5341,6 +5345,15 @@ static ggml_backend_opencl_context * ggml_cl_init(ggml_backend_dev_t dev) {
     // determine whether to use large buffer for Adreno
     backend_ctx->adreno_use_large_buffer = getenv("GGML_OPENCL_ADRENO_USE_LARGE_BUFFER") != nullptr &&
                                            backend_ctx->gpu_family == GPU_FAMILY::ADRENO;
+
+    // ragged moe, unspecified or non-zero means enabled, set to 0 to disable
+    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+    backend_ctx->adreno_use_moe_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+
+    // ragged moe, tile-skip granularity (columns per skip-group): 8 = quarter (default),
+    // 16 = half (legacy), 32 = disabled. Override with GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}
+    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
+    backend_ctx->adreno_moe_ragged_skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
 
 #ifdef GGML_OPENCL_USE_ADRENO_BIN_KERNELS
     // try loading adreno binary kernels if enabled
@@ -19338,20 +19351,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -19578,20 +19579,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -19768,20 +19757,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -19959,20 +19936,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),       &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),       &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20230,20 +20195,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip empty 8-column dot-groups for sparse expert tiles
-                    // whose trailing token-slots are all padding (byte-identical). Default on;
-                    // opt out with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20422,20 +20375,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20611,20 +20552,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20808,20 +20737,8 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
-                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
-                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
-                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
-                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
-                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
-
-                    // Tile-skip granularity (columns per skip-group): 8 = quarter (default),
-                    // 16 = half (legacy), 32 = disabled. Override with
-                    // GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}.
-                    static const char * ragged_gran_env = getenv("GGML_OPENCL_MOE_RAGGED_GRAN");
-                    int skip_gran = (ragged_gran_env != NULL) ? atoi(ragged_gran_env) : 8;
-                    if (skip_gran != 8 && skip_gran != 16 && skip_gran != 32) { skip_gran = 8; }
-                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &skip_gran));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_use_moe_ragged));
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_uint),   &backend_ctx->adreno_moe_ragged_skip_gran));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -19338,6 +19338,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -19564,6 +19570,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -19740,6 +19752,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -19917,6 +19935,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20174,6 +20198,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20352,6 +20382,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20527,6 +20563,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);
@@ -20710,6 +20752,12 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(cl_mem),    &(backend_ctx->prealloc_total_tiles.buffer)));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne00));
                     CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &ne01));
+                    // Ragged tile-skip: skip the second dot-half for sparse expert tiles whose
+                    // upper 16 token-slots are all padding (byte-identical). Default on; opt out
+                    // with GGML_OPENCL_MOE_RAGGED_FP16=0.
+                    static const char * ragged_fp16_env = getenv("GGML_OPENCL_MOE_RAGGED_FP16");
+                    const int is_ragged = (ragged_fp16_env == NULL) ? 1 : (atoi(ragged_fp16_env) != 0);
+                    CL_CHECK(clSetKernelArg(kernel, arg_idx++, sizeof(int),       &is_ragged));
 
                     // set thread grid
                     global_size[1] = static_cast<size_t>((ne01 + 63) / 64);

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
@@ -157,7 +157,8 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -165,6 +166,17 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -218,7 +230,7 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -245,7 +257,7 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
@@ -132,6 +132,46 @@ static inline half8 mxfp4_to_fp16_packed8(ushort2 fp4x8) {
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 static inline half e8m0_to_fp16(uchar x) {
     ushort bits;
@@ -158,7 +198,8 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -171,13 +212,24 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
     // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
     // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
     // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -228,9 +280,11 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -256,8 +310,10 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_0_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_0_f32_ns.cl
@@ -109,7 +109,8 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -117,6 +118,17 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -169,7 +181,7 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -195,7 +207,7 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_0_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_0_f32_ns.cl
@@ -98,6 +98,46 @@
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 __attribute__((qcom_wave_pair_mode(1))) // 1=force single 2=force pair
 kernel void kernel_gemm_moe_q4_0_f32_ns(
@@ -110,7 +150,8 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -123,13 +164,24 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
     // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
     // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
     // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -179,9 +231,11 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -206,8 +260,10 @@ kernel void kernel_gemm_moe_q4_0_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_1_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_1_f32_ns.cl
@@ -110,7 +110,8 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -118,6 +119,17 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -171,7 +183,7 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -197,7 +209,7 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_1_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_1_f32_ns.cl
@@ -98,6 +98,46 @@
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 __attribute__((qcom_wave_pair_mode(1))) // 1=force single 2=force pair
 kernel void kernel_gemm_moe_q4_1_f32_ns(
@@ -111,7 +151,8 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -124,13 +165,24 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
     // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
     // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
     // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -181,9 +233,11 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -208,8 +262,10 @@ kernel void kernel_gemm_moe_q4_1_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
@@ -114,6 +114,46 @@ inline void get_scale_min_k4(
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 __attribute__((qcom_wave_pair_mode(1)))
 kernel void kernel_gemm_moe_q4_k_f32_ns(
@@ -128,7 +168,8 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -138,16 +179,24 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
         return;
     }
 
-    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
-    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
-    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -211,9 +260,11 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Second half (next 16 elements, same sub-block scale)
         uint half_step = step + TILESIZE_K;
@@ -233,8 +284,10 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q4_k_f32_ns.cl
@@ -127,7 +127,8 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -135,6 +136,17 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -201,7 +213,7 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
 
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Second half (next 16 elements, same sub-block scale)
         uint half_step = step + TILESIZE_K;
@@ -222,7 +234,7 @@ kernel void kernel_gemm_moe_q4_k_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_0_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_0_f32_ns.cl
@@ -110,7 +110,8 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -118,6 +119,17 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -173,7 +185,7 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -199,7 +211,7 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_0_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_0_f32_ns.cl
@@ -98,6 +98,46 @@
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 __attribute__((qcom_wave_pair_mode(1))) // 1=force single 2=force pair
 kernel void kernel_gemm_moe_q5_0_f32_ns(
@@ -111,7 +151,8 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -124,13 +165,24 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
     // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
     // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
     // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -183,9 +235,11 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -210,8 +264,10 @@ kernel void kernel_gemm_moe_q5_0_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_1_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_1_f32_ns.cl
@@ -111,7 +111,8 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -119,6 +120,17 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -175,7 +187,7 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -201,7 +213,7 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_1_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_1_f32_ns.cl
@@ -98,6 +98,46 @@
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 __attribute__((qcom_wave_pair_mode(1))) // 1=force single 2=force pair
 kernel void kernel_gemm_moe_q5_1_f32_ns(
@@ -112,7 +152,8 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -125,13 +166,24 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
     // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
     // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
     // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -185,9 +237,11 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 8 elements reduction for better precision
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Repeat for second sub-block
         uint half_step = step + TILESIZE_K;
@@ -212,8 +266,10 @@ kernel void kernel_gemm_moe_q5_1_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         // 32 16x16 fp16 dot product with 3-levels reduction for better precision
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_k_f32_ns.cl
@@ -114,6 +114,46 @@ inline void get_scale_min_k4(
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 __attribute__((qcom_wave_pair_mode(1)))
 kernel void kernel_gemm_moe_q5_k_f32_ns(
@@ -129,7 +169,8 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -142,13 +183,24 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
     // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
     // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
     // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -216,9 +268,11 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Second half
         uint half_step = step + TILESIZE_K;
@@ -238,8 +292,10 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q5_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q5_k_f32_ns.cl
@@ -128,7 +128,8 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -136,6 +137,17 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -206,7 +218,7 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
 
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Second half
         uint half_step = step + TILESIZE_K;
@@ -227,7 +239,7 @@ kernel void kernel_gemm_moe_q5_k_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q6_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q6_k_f32_ns.cl
@@ -111,7 +111,8 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
         __write_only image1d_buffer_t dst,
         __global     int *            total_tiles,
         uint ne00,
-        uint ne01
+        uint ne01,
+        uint is_ragged
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -119,6 +120,17 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
     // Boundary check
     if (block_id_n >= total_tiles[0]) {
         return;
+    }
+
+    // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
+    // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
+    // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
+    bool skip_hi = false;
+    if (is_ragged) {
+        skip_hi = true;
+        for (int _t = 16; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+        }
     }
 
     __private half16 reg_a;
@@ -185,7 +197,7 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
 
         half16 acc;
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
 
         // Second half
         uint half_step = step + TILESIZE_K;
@@ -206,7 +218,7 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
         dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16);
+        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_q6_k_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_q6_k_f32_ns.cl
@@ -98,6 +98,46 @@
     c_reg.lo += convert_float8(acc.lo); \
     c_reg.hi += convert_float8(acc.hi); \
 
+// Quarter-tile variant: computes 8 output columns (one skip-group) into a float8
+// accumulator. Same reduction order / flush cadence as dotx16_reduce8, so the
+// non-skipped path is byte-identical; it just lets the caller skip empty
+// 8-column groups at finer granularity. Uses a private half8 `acc8`.
+#define dotx8_reduce4(a_reg, b_lm, c_reg, lm_offset) \
+    acc8.s0 = dot(a_reg.s0123, b_lm[lm_offset + 0]); \
+    acc8.s1 = dot(a_reg.s0123, b_lm[lm_offset + 1]); \
+    acc8.s2 = dot(a_reg.s0123, b_lm[lm_offset + 2]); \
+    acc8.s3 = dot(a_reg.s0123, b_lm[lm_offset + 3]); \
+    acc8.s4 = dot(a_reg.s0123, b_lm[lm_offset + 4]); \
+    acc8.s5 = dot(a_reg.s0123, b_lm[lm_offset + 5]); \
+    acc8.s6 = dot(a_reg.s0123, b_lm[lm_offset + 6]); \
+    acc8.s7 = dot(a_reg.s0123, b_lm[lm_offset + 7]); \
+    acc8.s0 += dot(a_reg.s4567, b_lm[lm_offset + 32]); \
+    acc8.s1 += dot(a_reg.s4567, b_lm[lm_offset + 33]); \
+    acc8.s2 += dot(a_reg.s4567, b_lm[lm_offset + 34]); \
+    acc8.s3 += dot(a_reg.s4567, b_lm[lm_offset + 35]); \
+    acc8.s4 += dot(a_reg.s4567, b_lm[lm_offset + 36]); \
+    acc8.s5 += dot(a_reg.s4567, b_lm[lm_offset + 37]); \
+    acc8.s6 += dot(a_reg.s4567, b_lm[lm_offset + 38]); \
+    acc8.s7 += dot(a_reg.s4567, b_lm[lm_offset + 39]); \
+    c_reg += convert_float8(acc8); \
+    acc8.s0 = dot(a_reg.s89ab, b_lm[lm_offset + 64]); \
+    acc8.s1 = dot(a_reg.s89ab, b_lm[lm_offset + 65]); \
+    acc8.s2 = dot(a_reg.s89ab, b_lm[lm_offset + 66]); \
+    acc8.s3 = dot(a_reg.s89ab, b_lm[lm_offset + 67]); \
+    acc8.s4 = dot(a_reg.s89ab, b_lm[lm_offset + 68]); \
+    acc8.s5 = dot(a_reg.s89ab, b_lm[lm_offset + 69]); \
+    acc8.s6 = dot(a_reg.s89ab, b_lm[lm_offset + 70]); \
+    acc8.s7 = dot(a_reg.s89ab, b_lm[lm_offset + 71]); \
+    acc8.s0 += dot(a_reg.scdef, b_lm[lm_offset + 96]); \
+    acc8.s1 += dot(a_reg.scdef, b_lm[lm_offset + 97]); \
+    acc8.s2 += dot(a_reg.scdef, b_lm[lm_offset + 98]); \
+    acc8.s3 += dot(a_reg.scdef, b_lm[lm_offset + 99]); \
+    acc8.s4 += dot(a_reg.scdef, b_lm[lm_offset + 100]); \
+    acc8.s5 += dot(a_reg.scdef, b_lm[lm_offset + 101]); \
+    acc8.s6 += dot(a_reg.scdef, b_lm[lm_offset + 102]); \
+    acc8.s7 += dot(a_reg.scdef, b_lm[lm_offset + 103]); \
+    c_reg += convert_float8(acc8); \
+
 
 __attribute__((qcom_wave_pair_mode(1)))
 kernel void kernel_gemm_moe_q6_k_f32_ns(
@@ -112,7 +152,8 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
         __global     int *            total_tiles,
         uint ne00,
         uint ne01,
-        uint is_ragged
+        uint is_ragged,
+        uint skip_gran
 ) {
     uint block_id_m = get_global_id(1); // m_tile
     uint block_id_n = get_global_id(2); // n_tile
@@ -125,13 +166,24 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
     // Ragged tile-skip: when is_ragged and the upper 16 token-slots of this tile are all
     // padding (router 0xFFFFFFFF), skip the second (reg_c.hi) dotx16_reduce8 half -> ~half
     // the GEMM dot for sparse tiles. Numerically identical (the skipped lanes are padding).
-    bool skip_hi = false;
-    if (is_ragged) {
-        skip_hi = true;
-        for (int _t = 16; _t < TILESIZE_N; ++_t) {
-            if (src2[block_id_n * TILESIZE_N + _t] != 0xFFFFFFFFu) { skip_hi = false; break; }
+    // Ragged tile-skip: tokens are packed contiguously per expert (moe_scatter fills
+    // lanes 0..V-1, moe_fill pre-pads the rest), so router padding (0xFFFFFFFF) is always
+    // trailing. Find the valid-token count V and round it UP to the skip granularity
+    // skip_gran (columns per skip-group: 8 = quarter, 16 = half/legacy, 32 = disabled).
+    // A 8-column group g is all-padding iff its first column (8*g) >= n_active, so its
+    // dotx8_reduce4 is skipped. Numerically identical (skipped lanes are padding).
+    uint n_active = TILESIZE_N;
+    if (is_ragged && skip_gran < TILESIZE_N) {
+        uint n_valid = TILESIZE_N;
+        for (uint _t = 0; _t < TILESIZE_N; ++_t) {
+            if (src2[block_id_n * TILESIZE_N + _t] == 0xFFFFFFFFu) { n_valid = _t; break; }
         }
+        n_active = min((uint)TILESIZE_N, ((n_valid + skip_gran - 1) / skip_gran) * skip_gran);
     }
+    // Group 0 (cols 0-7) always runs; groups 1-3 skip when fully padding.
+    bool skip_g1 = (8u  >= n_active);
+    bool skip_g2 = (16u >= n_active);
+    bool skip_g3 = (24u >= n_active);
 
     __private half16 reg_a;
     __private float32 reg_c = (float32)(0);
@@ -195,9 +247,11 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
-        half16 acc;
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        half8 acc8;
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
 
         // Second half
         uint half_step = step + TILESIZE_K;
@@ -217,8 +271,10 @@ kernel void kernel_gemm_moe_q6_k_f32_ns(
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
-        dotx16_reduce8(reg_a, shared_b, reg_c.lo, 0);
-        if (!skip_hi) { dotx16_reduce8(reg_a, shared_b, reg_c.hi, 16); }
+        dotx8_reduce4(reg_a, shared_b, reg_c.lo.lo, 0);
+        if (!skip_g1) { dotx8_reduce4(reg_a, shared_b, reg_c.lo.hi, 8); }
+        if (!skip_g2) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.lo, 16); }
+        if (!skip_g3) { dotx8_reduce4(reg_a, shared_b, reg_c.hi.hi, 24); }
     }
 
     if ((get_global_id(0) + block_id_m * TILESIZE_M) >= ne01) {


### PR DESCRIPTION
## Overview

1. The MoE prefill GEMM groups tokens into 32-wide per-expert tiles; at low tokens-per-expert most tiles are mostly padding and the computation is not needed and hurt performance. 
2. This PR is to skip the fully-padding skip-groups and pad in the quarter granularity, dotx8_reduce4, across all eight *_f32_ns MoE GEMMs (q4_0/q4_1/q5_0/q5_1/q4_k/q5_k/q6_k/mxfp4) to save unnecessary computations. 
3. Default on and opt out with GGML_OPENCL_MOE_RAGGED_FP16=0. 
4. Granularity can be set via GGML_OPENCL_MOE_RAGGED_GRAN={8,16,32}
5. Numerically identical. 
6. Only for prefill: token generation untouched. 

## Additional information

Gains on X2 GPU: Qwen3-30B-A3B Q4_K_M pp128 +24% / pp512 +10%; Q4_0 pp128 +26%; gpt-oss-20b MXFP4 pp128 +20%

## Requirements

Tested with Adreno GPUs on Windows on Snapdragon (WoS) X1 and X2 devices. 

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, for testing and prototyping. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
