### PR TITLE
model : Gemma4 12B model type detection

### DIFF
--- a/src/models/gemma4.cpp
+++ b/src/models/gemma4.cpp
@@ -23,6 +23,7 @@ void llama_model_gemma4::load_arch_hparams(llama_model_loader & ml) {
         case 30: type = LLM_TYPE_26B_A4B; break;
         case 35: type = LLM_TYPE_E2B; break;
         case 42: type = LLM_TYPE_E4B; break;
+        case 48: type = LLM_TYPE_12B; break;
         case 60: type = LLM_TYPE_31B; break;
         default: type = LLM_TYPE_UNKNOWN;
     }


### PR DESCRIPTION
## Overview

A purely cosmetic change for `llama-bench`, etc. to show Gemma4 12B correctly. Gemma4 12B has 48 layers according to the [model card](https://huggingface.co/google/gemma-4-12B-it#dense-models).

Currently kept as draft, waiting for my other PRs to be reviewed.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
