### PR TITLE
CUDA: Small optimizations to MMVQ

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -549,8 +549,8 @@ static __global__ void mul_mat_vec_q(
 
     [[maybe_unused]] float x_biases[ncols_dst]    = { 0.0f };
     [[maybe_unused]] float gate_biases[ncols_dst] = { 0.0f };
-    [[maybe_unused]] float x_scales;
-    [[maybe_unused]] float gate_scales;
+    [[maybe_unused]] float x_scales = 1.0f;
+    [[maybe_unused]] float gate_scales = 1.0f;
     if constexpr (has_fusion) {
         // 1. Hide latency by prefetching bias, gates and scales here
         // 2. load only on threads that won't die after partial sum calculation
@@ -655,47 +655,38 @@ static __global__ void mul_mat_vec_q(
                     tmp_gate[j][i] = warp_reduce_sum<warp_size>(tmp_gate[j][i]);
                 }
             }
-        }
 
-        if (threadIdx.x < rows_per_cuda_block && (rows_per_cuda_block == 1 || uint32_t(row0 + threadIdx.x) < stride_col_dst)) {
-            float result = tmp[j][threadIdx.x];
-            if constexpr (has_fusion) {
-                if constexpr (type == GGML_TYPE_NVFP4) {
-                    if (use_scale) {
+            if (threadIdx.x == i && (rows_per_cuda_block == 1 || uint32_t(row0 + i) < stride_col_dst)) {
+                float result = tmp[j][i];
+                if constexpr (has_fusion) {
+                    if constexpr (type == GGML_TYPE_NVFP4) {
                         result *= x_scales;
                     }
-                }
-                if (use_bias) {
                     result += x_biases[j];
-                }
-                if (use_gate) {
-                    float gate_value = tmp_gate[j][threadIdx.x];
-                    if constexpr (type == GGML_TYPE_NVFP4) {
-                        if (use_gate_scale) {
+                    if (use_gate) {
+                        float gate_value = tmp_gate[j][i];
+                        if constexpr (type == GGML_TYPE_NVFP4) {
                             gate_value *= gate_scales;
                         }
-                    }
-                    if (use_gate_bias) {
                         gate_value += gate_biases[j];
-                    }
-                    switch (active_glu) {
-                        case GGML_GLU_OP_SWIGLU:
-                            result *= ggml_cuda_op_silu_single(gate_value);
-                            break;
-                        case GGML_GLU_OP_GEGLU:
-                            result *= ggml_cuda_op_gelu_single(gate_value);
-                            break;
-                        case GGML_GLU_OP_SWIGLU_OAI: {
-                            result = ggml_cuda_op_swiglu_oai_single(gate_value, result);
-                            break;
+                        switch (active_glu) {
+                            case GGML_GLU_OP_SWIGLU:
+                                result *= ggml_cuda_op_silu_single(gate_value);
+                                break;
+                            case GGML_GLU_OP_GEGLU:
+                                result *= ggml_cuda_op_gelu_single(gate_value);
+                                break;
+                            case GGML_GLU_OP_SWIGLU_OAI:
+                                result = ggml_cuda_op_swiglu_oai_single(gate_value, result);
+                                break;
+                            default:
+                                result = result * gate_value;
+                                break;
                         }
-                        default:
-                            result = result * gate_value;
-                            break;
                     }
                 }
+                dst[j*stride_col_dst + i] = result;
             }
-            dst[j*stride_col_dst + threadIdx.x] = result;
         }
     }
 


### PR DESCRIPTION
## Overview

2 Optimizations to MMVQ:
1. Only index `tmp` by compile times -> Avoid relying on compiler to optimize local memory away (which fails for ncols_dst > 1).
2. Always multiply/add for NVFP4 -> Cheaper than issuing control flow statements/adding more predicates to that loop

## Additional information

<details>
<summary> performance </summary>

B6000

| Model                    |   ub size | Test   |   t/s master |   t/s this branch |   Speedup |
|:-------------------------|------------------:|:-------|-------------:|-------------------------------:|----------:|
| gemma4 26B.A4B NVFP4     |                 1 | pp128  |       173.28 |                         176.30 |      1.02 |
| gemma4 26B.A4B NVFP4     |                 4 | pp128  |       533.80 |                         533.47 |      1.00 |
| gemma4 26B.A4B NVFP4     |                 8 | pp128  |       921.54 |                         923.00 |      1.00 |
| gemma4 26B.A4B Q4_K_M    |                 1 | pp128  |       217.78 |                         217.58 |      1.00 |
| gemma4 26B.A4B Q4_K_M    |                 4 | pp128  |       641.70 |                         669.99 |      1.04 |
| gemma4 26B.A4B Q4_K_M    |                 8 | pp128  |       971.05 |                        1023.59 |      1.05 |
| qwen35 27B NVFP4         |                 1 | pp128  |        67.01 |                          66.72 |      1.00 |
| qwen35 27B NVFP4         |                 4 | pp128  |       190.60 |                         202.49 |      1.06 |
| qwen35 27B NVFP4         |                 8 | pp128  |       294.20 |                         316.16 |      1.07 |
| qwen35 27B Q4_K_M        |                 1 | pp128  |        69.96 |                          69.50 |      0.99 |
| qwen35 27B Q4_K_M        |                 4 | pp128  |       166.17 |                         183.54 |      1.10 |
| qwen35 27B Q4_K_M        |                 8 | pp128  |       196.29 |                         231.13 |      1.18 |
| qwen35moe 35B.A3B NVFP4  |                 1 | pp128  |       240.95 |                         245.13 |      1.02 |
| qwen35moe 35B.A3B NVFP4  |                 4 | pp128  |       557.78 |                         569.68 |      1.02 |
| qwen35moe 35B.A3B NVFP4  |                 8 | pp128  |       883.06 |                         934.68 |      1.06 |
| qwen35moe 35B.A3B Q4_K_M |                 1 | pp128  |       255.48 |                         255.83 |      1.00 |
| qwen35moe 35B.A3B Q4_K_M |                 4 | pp128  |       562.35 |                         598.20 |      1.06 |
| qwen35moe 35B.A3B Q4_K_M |                 8 | pp128  |       887.64 |                         951.10 |      1.07 |

DGX Spark

| Model                    |   Microbatch size | Test   |   t/s master.   |   t/s this branch |   Speedup |
|:-------------------------|------------------:|:-------|----------------:|-------------------------------:|----------:|
| gemma4 26B.A4B NVFP4     |                 1 | pp128  |           38.29 |                          38.76 |      1.01 |
| gemma4 26B.A4B NVFP4     |                 4 | pp128  |          128.37 |                         127.71 |      0.99 |
| gemma4 26B.A4B NVFP4     |                 8 | pp128  |          218.04 |                         216.13 |      0.99 |
| gemma4 26B.A4B Q4_K_M    |                 1 | pp128  |           57.47 |                          57.63 |      1.00 |
| gemma4 26B.A4B Q4_K_M    |                 4 | pp128  |          158.02 |                         158.49 |      1.00 |
| gemma4 26B.A4B Q4_K_M    |                 8 | pp128  |          234.44 |                         237.67 |      1.01 |
| qwen35moe 35B.A3B NVFP4  |                 1 | pp128  |           76.96 |                          76.60 |      1.00 |
| qwen35moe 35B.A3B NVFP4  |                 4 | pp128  |          205.28 |                         206.60 |      1.01 |
| qwen35moe 35B.A3B NVFP4  |                 8 | pp128  |          310.70 |                         329.57 |      1.06 |
| qwen35moe 35B.A3B Q4_K_M |                 1 | pp128  |           69.41 |                          69.89 |      1.01 |
| qwen35moe 35B.A3B Q4_K_M |                 4 | pp128  |          184.23 |                         183.95 |      1.00 |
| qwen35moe 35B.A3B Q4_K_M |                 8 | pp128  |          274.83 |                         287.38 |      1.05 |


</details>
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - paired with codex on this

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
