### PR TITLE
quantize: wire NVFP4 ftype (experts NVFP4, other tensors Q8_0)

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -444,7 +444,7 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
             const int64_t nx = tensor->ne[0];
             const int64_t qk_k = ggml_blck_size(new_type);
 
-            if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE) {
+            if (ftype == LLAMA_FTYPE_MOSTLY_MXFP4_MOE || ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
                 new_type = GGML_TYPE_Q8_0;
             }
             else if (arch == LLM_ARCH_FALCON || nx % qk_k != 0) {
@@ -464,6 +464,14 @@ static ggml_type llama_tensor_get_type_impl(quantize_state_impl & qs, ggml_type 
         // other tensors -> Q8_0
         if (tensor->ne[2] > 1) {
             new_type = GGML_TYPE_MXFP4;
+        } else {
+            new_type = GGML_TYPE_Q8_0;
+        }
+    } else if (ftype == LLAMA_FTYPE_MOSTLY_NVFP4) {
+        // MoE   tensors -> NVFP4
+        // other tensors -> Q8_0
+        if (tensor->ne[2] > 1) {
+            new_type = GGML_TYPE_NVFP4;
         } else {
             new_type = GGML_TYPE_Q8_0;
         }
@@ -804,6 +812,7 @@ ggml_type llama_ftype_get_default_type(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q2_0: return GGML_TYPE_Q2_0;
 
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return GGML_TYPE_MXFP4;
+        case LLAMA_FTYPE_MOSTLY_NVFP4:     return GGML_TYPE_NVFP4;
 
         // K-quants
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -37,6 +37,7 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q4_0",     LLAMA_FTYPE_MOSTLY_Q4_0,     " 4.34G, +0.4685 ppl @ Llama-3-8B",  },
     { "Q4_1",     LLAMA_FTYPE_MOSTLY_Q4_1,     " 4.78G, +0.4511 ppl @ Llama-3-8B",  },
     { "MXFP4_MOE",LLAMA_FTYPE_MOSTLY_MXFP4_MOE," MXFP4 MoE",  },
+    { "NVFP4",    LLAMA_FTYPE_MOSTLY_NVFP4,  " NVFP4 MoE (experts NVFP4, rest Q8_0)", },
     { "Q5_0",     LLAMA_FTYPE_MOSTLY_Q5_0,     " 5.21G, +0.1316 ppl @ Llama-3-8B",  },
     { "Q5_1",     LLAMA_FTYPE_MOSTLY_Q5_1,     " 5.65G, +0.1062 ppl @ Llama-3-8B",  },
     { "IQ2_XXS",  LLAMA_FTYPE_MOSTLY_IQ2_XXS,  " 2.06 bpw quantization",            },


### PR DESCRIPTION
## Overview

The NVFP4 GGML type has CPU/CUDA/Vulkan kernels and `LLAMA_FTYPE_MOSTLY_NVFP4` exists, but the ftype was not reachable from `llama-quantize` — no mapping in the quantization logic and no CLI entry. This wires it up, mirroring the MXFP4_MOE convention: expert tensors (`ne[2] > 1`) → NVFP4, everything else → Q8_0.

## Additional information

Validated by quantizing Nemotron-3-Puzzle-75B-A9B (75B MoE) from a Q8_0 master with imatrix, on Strix Halo (Radeon 8060S):

| quant | size | PPL (wikitext-2 test, 24 chunks) | decode t/s (ROCm, tg128) |
|---|---|---|---|
| Q8_0 master | 77.7 GiB | 5.325 | — |
| Q4_K_M | 48.1 GiB | 5.404 | 19.9 |
| **NVFP4** | **45.0 GiB** | **5.383** | **16.6** |

NVFP4 lands between Q4_K_M and IQ4_XS-based mixes on both size and PPL — a useful native option now that the kernels exist, and the natural target for checkpoints shipped in NVFP4.

Used by the Nemotron-3-Puzzle support PR: https://github.com/ggml-org/llama.cpp/pull/25444

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — AI-assisted, as in #25444. I reviewed the diff and validated the result end-to-end on my hardware. Full responsibility is mine.
