### PR TITLE
server: support causal-LM rerankers via logit-margin scoring

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -588,6 +588,11 @@ extern "C" {
     // Undefined behavior for non-classifier models
     LLAMA_API uint32_t llama_model_n_cls_out(const struct llama_model * model);
 
+    // Returns true if the model has a classification head (cls or cls_out tensor).
+    // Models without a classification head cannot produce meaningful scores through
+    // pooling-based reranking and need an alternative scoring method.
+    LLAMA_API bool llama_model_has_cls_head(const struct llama_model * model);
+
     // Returns label of classifier output by index (<n_cls_out). Returns nullptr if no label provided
     LLAMA_API const char * llama_model_cls_label(const struct llama_model * model, uint32_t i);
 

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2453,6 +2453,10 @@ uint32_t llama_model_n_cls_out(const struct llama_model * model) {
     return model->hparams.n_cls_out;
 }
 
+bool llama_model_has_cls_head(const struct llama_model * model) {
+    return model->cls != nullptr || model->cls_out != nullptr;
+}
+
 const char * llama_model_cls_label(const struct llama_model * model, uint32_t i) {
     if (i < model->classifier_labels.size()) {
         return model->classifier_labels[i].c_str();

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -37,6 +37,53 @@
 
 using json = nlohmann::ordered_json;
 
+// causal-LM reranking helpers
+
+// Official Qwen3-Reranker judge prompt: fallback when GGUF has no "rerank" template.
+static const char * DEFAULT_CAUSAL_RERANK_TEMPLATE =
+    "<|im_start|>system\n"
+    "Judge whether the Document meets the requirements based on the Query and the Instruct provided. "
+    "Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n"
+    "<|im_start|>user\n"
+    "<Instruct>: Given a web search query, retrieve relevant passages that answer the query\n"
+    "<Query>: {query}\n"
+    "<Document>: {document}<|im_end|>\n"
+    "<|im_start|>assistant\n"
+    "<think>\n\n</think>\n\n";
+
+// Use the model's GGUF "rerank" template if present, otherwise the built-in default.
+static std::string format_causal_rerank_prompt(
+        const struct llama_model * model,
+        const std::string & query,
+        const std::string & document) {
+    const char * tmpl = llama_model_chat_template(model, "rerank");
+    if (tmpl == nullptr) {
+        tmpl = DEFAULT_CAUSAL_RERANK_TEMPLATE;
+    }
+    std::string prompt = tmpl;
+    string_replace_all(prompt, "{query}",    query);
+    string_replace_all(prompt, "{document}", document);
+    return prompt;
+}
+
+// sigmoid(margin / 5) where margin = ln(P(yes)) - ln(P(no)).
+// Calibration factor from ZeroEntropy's Qwen3-Reranker.
+static float score_yes_no_logit_margin(const std::vector<completion_token_output::prob_info> & token_probs) {
+    double p_yes = 0.0, p_no = 0.0;
+    for (const auto & entry : token_probs) {
+        std::string token_text = entry.txt;
+        while (!token_text.empty() && (token_text.front() == ' ' || token_text.front() == '\t')) token_text.erase(token_text.begin());
+        while (!token_text.empty() && (token_text.back()  == ' ' || token_text.back()  == '\t')) token_text.pop_back();
+        for (auto & c : token_text) c = (char)std::tolower((unsigned char)c);
+        if (token_text == "yes") p_yes += entry.prob;
+        else if (token_text == "no") p_no += entry.prob;
+    }
+    constexpr double prob_floor = 1e-9;
+    constexpr double calibration = 5.0;
+    double margin = std::log(std::max(p_yes, prob_floor)) - std::log(std::max(p_no, prob_floor));
+    return (float)(1.0 / (1.0 + std::exp(-margin / calibration)));
+}
+
 constexpr int HTTP_POLLING_SECONDS = 1;
 
 static uint32_t server_n_outputs_max(const common_params & params) {
@@ -4947,39 +4994,83 @@ void server_routes::init_routes() {
 
         int top_n = json_value(body, "top_n", (int)documents.size());
 
-        // create and queue the task
-        json responses = json::array();
+        const bool is_causal_reranker = !llama_model_has_cls_head(ctx_server.model_tgt);
+
+        // Create and queue tasks: causal-LM and pooling paths differ only here
         auto & rd = res->rd;
         {
             std::vector<server_task> tasks;
             tasks.reserve(documents.size());
-            for (size_t i = 0; i < documents.size(); i++) {
-                auto tmp = format_prompt_rerank(ctx_server.model_tgt, ctx_server.vocab, ctx_server.mctx, query, documents[i]);
-                server_task task = server_task(SERVER_TASK_TYPE_RERANK);
-                task.id     = rd.get_new_id();
-                task.tokens = std::move(tmp);
-                tasks.push_back(std::move(task));
+
+            if (is_causal_reranker) {
+                const bool has_rerank_template = llama_model_chat_template(ctx_server.model_tgt, "rerank") != nullptr;
+                SRV_INF("causal-LM reranker detected (no classification head), using logit-margin scoring for %zu documents\n", documents.size());
+                if (!has_rerank_template) {
+                    SRV_WRN("%s", "model has no 'rerank' chat template in GGUF metadata, using built-in default (Qwen3-Reranker format)\n");
+                }
+
+                for (size_t i = 0; i < documents.size(); i++) {
+                    std::string prompt_str = format_causal_rerank_prompt(
+                        ctx_server.model_tgt, query.get<std::string>(), documents[i]);
+                    auto prompt_tokens = tokenize_input_prompts(ctx_server.vocab, ctx_server.mctx, json(prompt_str), false, true);
+
+                    server_task task = server_task(SERVER_TASK_TYPE_COMPLETION);
+                    task.id     = rd.get_new_id();
+                    task.index  = i;
+                    task.tokens = std::move(prompt_tokens[0]);
+                    task.params.n_predict            = 1;
+                    task.params.sampling.temp         = 0;
+                    task.params.sampling.n_probs      = 10;
+                    task.params.post_sampling_probs   = false;
+                    task.params.stream                = false;
+                    tasks.push_back(std::move(task));
+                }
+            } else {
+                for (size_t i = 0; i < documents.size(); i++) {
+                    auto rerank_tokens = format_prompt_rerank(ctx_server.model_tgt, ctx_server.vocab, ctx_server.mctx, query, documents[i]);
+                    server_task task = server_task(SERVER_TASK_TYPE_RERANK);
+                    task.id     = rd.get_new_id();
+                    task.tokens = std::move(rerank_tokens);
+                    tasks.push_back(std::move(task));
+                }
             }
+
             rd.post_tasks(std::move(tasks));
         }
 
-        // wait for the results
+        // Wait and collect results
         auto all_results = rd.wait_for_all(req.should_stop);
 
-        // collect results
         if (all_results.is_terminated) {
-            return res; // connection is closed
+            return res;
         } else if (all_results.error) {
             res->error(all_results.error->to_json());
             return res;
-        } else {
-            for (auto & res : all_results.results) {
-                GGML_ASSERT(dynamic_cast<server_task_result_rerank*>(res.get()) != nullptr);
-                responses.push_back(res->to_json());
+        }
+
+        json responses = json::array();
+        for (auto & result : all_results.results) {
+            if (is_causal_reranker) {
+                auto * completion = dynamic_cast<server_task_result_cmpl_final*>(result.get());
+                if (!completion) {
+                    continue;
+                }
+                float score = 0.0f;
+                if (!completion->probs_output.empty()) {
+                    score = score_yes_no_logit_margin(completion->probs_output[0].probs);
+                }
+                auto rerank_result = std::make_unique<server_task_result_rerank>();
+                rerank_result->id       = completion->id;
+                rerank_result->index    = completion->index;
+                rerank_result->n_tokens = completion->n_prompt_tokens;
+                rerank_result->score    = score;
+                responses.push_back(rerank_result->to_json());
+            } else {
+                GGML_ASSERT(dynamic_cast<server_task_result_rerank*>(result.get()) != nullptr);
+                responses.push_back(result->to_json());
             }
         }
 
-        // write JSON response
         json root = format_response_rerank(
             body,
             meta->model_name,

--- a/tools/server/tests/unit/test_rerank_causal.py
+++ b/tools/server/tests/unit/test_rerank_causal.py
@@ -1,0 +1,156 @@
+import pytest
+from utils import *
+
+TEST_DOCUMENTS = [
+    "Machine learning is a field of study in artificial intelligence concerned with the development and study of statistical algorithms that can learn from data and generalize to unseen data, and thus perform tasks without explicit instructions.",
+    "A machine is a physical system that uses power to apply forces and control movement to perform an action. The term is commonly applied to artificial devices, such as those employing engines or motors, but also to natural biological macromolecules, such as molecular machines.",
+    "Learning is the process of acquiring new understanding, knowledge, behaviors, skills, values, attitudes, and preferences. The ability to learn is possessed by humans, non-human animals, and some machines; there is also evidence for some kind of learning in certain plants.",
+    "Paris, capitale de la France, est une grande ville europeenne et un centre mondial de l'art, de la mode, de la gastronomie et de la culture.",
+]
+
+
+# These tests verify that the /v1/rerank endpoint correctly detects causal-LM
+# reranker models (those without a classification head) and routes them through
+# logit-margin scoring instead of the pooling path.
+#
+# To run locally with a causal-LM reranker GGUF:
+#   LLAMA_SERVER_BIN_PATH=./build/bin/llama-server \
+#   LLAMA_MODEL_PATH=path/to/causal-reranker.gguf \
+#   python -m pytest tools/server/tests/unit/test_rerank_causal.py -v
+
+
+def create_causal_reranker_server():
+    srv = ServerProcess()
+    srv.server_reranking = True
+    model_path = os.environ.get("LLAMA_MODEL_PATH", "")
+    if model_path:
+        srv.model_hf_repo = None
+        srv.model_hf_file = None
+        srv.model_file = model_path
+    else:
+        pytest.skip("LLAMA_MODEL_PATH not set (need a causal-LM reranker GGUF)")
+    return srv
+
+
+@pytest.mark.skipif(
+    not os.environ.get("LLAMA_MODEL_PATH"),
+    reason="Requires LLAMA_MODEL_PATH pointing to a causal-LM reranker GGUF",
+)
+class TestCausalRerank:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.server = create_causal_reranker_server()
+
+    def test_causal_rerank_scores_discriminate(self):
+        """Causal-LM reranker must produce discriminating scores, not near-zero garbage."""
+        self.server.start()
+        res = self.server.make_request(
+            "POST",
+            "/v1/rerank",
+            data={
+                "query": "Machine learning is",
+                "documents": TEST_DOCUMENTS,
+            },
+        )
+        assert res.status_code == 200
+        results = res.body["results"]
+        assert len(results) == len(TEST_DOCUMENTS)
+
+        scores = {r["index"]: r["relevance_score"] for r in results}
+
+        # Doc 0 (machine learning) must score highest
+        assert scores[0] > scores[1], "relevant doc should outscore related doc"
+        assert scores[0] > scores[3], (
+            "relevant doc should outscore foreign-language doc"
+        )
+
+        # Scores must be in [0, 1] (calibrated sigmoid output)
+        for idx, score in scores.items():
+            assert 0.0 <= score <= 1.0, f"doc {idx} score {score} out of [0,1] range"
+
+        # Scores must not be near-zero garbage (the pre-fix failure mode)
+        assert scores[0] > 0.5, (
+            f"relevant doc score {scores[0]} too low (pre-fix garbage?)"
+        )
+
+        # Spread between best and worst must be meaningful
+        spread = scores[0] - min(scores.values())
+        assert spread > 0.1, f"score spread {spread} too small for discrimination"
+
+    def test_causal_rerank_top_n(self):
+        """top_n parameter must limit results for causal-LM rerankers."""
+        self.server.start()
+        res = self.server.make_request(
+            "POST",
+            "/v1/rerank",
+            data={
+                "query": "Machine learning is",
+                "documents": TEST_DOCUMENTS,
+                "top_n": 2,
+            },
+        )
+        assert res.status_code == 200
+        assert len(res.body["results"]) == 2
+
+    def test_causal_rerank_tei_format(self):
+        """TEI format (texts instead of documents) must work for causal-LM rerankers."""
+        self.server.start()
+        res = self.server.make_request(
+            "POST",
+            "/v1/rerank",
+            data={
+                "query": "Machine learning is",
+                "texts": TEST_DOCUMENTS,
+            },
+        )
+        assert res.status_code == 200
+        assert len(res.body) == len(TEST_DOCUMENTS)
+
+        scores = {r["index"]: r["score"] for r in res.body}
+        assert scores[0] > scores[3], (
+            "relevant doc should outscore foreign-language doc (TEI format)"
+        )
+
+    def test_causal_rerank_single_document(self):
+        """Single-document rerank must work without errors."""
+        self.server.start()
+        res = self.server.make_request(
+            "POST",
+            "/v1/rerank",
+            data={
+                "query": "Machine learning is",
+                "documents": [TEST_DOCUMENTS[0]],
+            },
+        )
+        assert res.status_code == 200
+        assert len(res.body["results"]) == 1
+        assert 0.0 <= res.body["results"][0]["relevance_score"] <= 1.0
+
+
+# Verify the existing pooling-based reranker still works unchanged
+class TestPoolingRerankUnchanged:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.server = ServerPreset.jina_reranker_tiny()
+
+    def test_pooling_rerank_still_works(self):
+        """BERT-style rerankers must still use the pooling path and produce correct results."""
+        self.server.start()
+        res = self.server.make_request(
+            "POST",
+            "/rerank",
+            data={
+                "query": "Machine learning is",
+                "documents": [
+                    "A machine is a physical system that uses power to apply forces.",
+                    "Machine learning is a field of study in artificial intelligence.",
+                    "Paris is the capital of France.",
+                ],
+            },
+        )
+        assert res.status_code == 200
+        results = res.body["results"]
+        assert len(results) == 3
+
+        scores = {r["index"]: r["relevance_score"] for r in results}
+        assert scores[1] > scores[2], "ML doc should outscore Paris doc"


### PR DESCRIPTION
## Overview

Fixes #25447

The `/v1/rerank` endpoint silently returns near-zero scores (~1e-20) for causal-LM rerankers like zerank-2 and Qwen3-Reranker. These models have no classification head, their `lm_head` is tied to token embeddings therefore the pooling path extracts raw hidden states instead of classification scores.

This PR adds a completion-based scoring path for such models. When `llama_model_has_cls_head()` returns false, the endpoint generates one token per document using a judge prompt and computes relevance from the yes/no logit margin. Existing BERT-style rerankers (jina, bge) are unaffected, they have `cls`/`cls_out` tensors and continue using the pooling path.

Changes:

- **`include/llama.h` / `src/llama-model.cpp`**: add `llama_model_has_cls_head()` to check for `cls` or `cls_out` tensors
- **`tools/server/server-context.cpp`**: detect causal-LM rerankers and route through completion-based logit-margin scoring. Uses the model's GGUF "rerank" chat template when available, falls back to a built-in Qwen3-Reranker judge prompt
- **`tools/server/tests/unit/test_rerank_causal.py`**:  test cases for causal-LM reranking + pooling path regression test

Tested with zerank-2 Q6_K (before: 1e-20 garbage, after: 0.984/0.016 matching `/v1/completions`) and jina-reranker-v1-tiny-en F16 (pooling path unchanged, correct scores).


## Reproduction & results

**Before (pooling path returns garbage for causal-LM reranker):**

```bash
llama-server -m zerank-2.Q6_K.gguf --reranking --port 18080

curl -s -X POST http://localhost:18080/v1/rerank \
  -H "Content-Type: application/json" \
  -d '{"query":"Machine learning is","documents":["Machine learning is a field of study in artificial intelligence.","Paris is the capital of France."]}'

{
  "results": [
    { "index": 0, "relevance_score": 1.22e-20 },
    { "index": 1, "relevance_score": 2.45e-23 }
  ]
}

After (logit-margin scoring, same model, same endpoint):

{
  "results": [
    { "index": 0, "relevance_score": 0.9844 },
    { "index": 1, "relevance_score": 0.0156 }
  ]
}

jina-reranker-v1-tiny-en (BERT-style, pooling path unchanged):

{
  "results": [
    { "index": 0, "relevance_score": 0.1004 },
    { "index": 1, "relevance_score": -0.0026 }
  ]
}
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used for research assistance. Code manually reviewed and tested on both model types.
