### PR TITLE
metal: extend small-batch mat-vec dispatch to 16 rows

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2076,7 +2076,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
            op->src[0]->type == GGML_TYPE_Q8_0 ||
            op->src[0]->type == GGML_TYPE_MXFP4 ||
            op->src[0]->type == GGML_TYPE_IQ4_NL ||
-           false) && (ne11 >= 2 && ne11 <= 8)
+           false) && (ne11 >= 2 && ne11 <= 16)
          ) ||
          (
           (
@@ -2085,7 +2085,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
            op->src[0]->type == GGML_TYPE_Q6_K ||
            op->src[0]->type == GGML_TYPE_Q2_K ||
            op->src[0]->type == GGML_TYPE_Q3_K ||
-           false) && (ne11 >= 4 && ne11 <= 8)
+           false) && (ne11 >= 4 && ne11 <= 16)
          )
         )
        ) {
@@ -2126,6 +2126,19 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
                 r1ptg = 4; break;
             case 5:
                 r1ptg = 5; break;
+            case 9:
+                r1ptg = 3; break;
+            case 10:
+                r1ptg = 5; break;
+            case 11:
+            case 12:
+                r1ptg = 4; break;
+            case 13:
+            case 14:
+            case 15:
+                r1ptg = 5; break;
+            case 16:
+                r1ptg = 4; break;
             default:
                 GGML_ABORT("unsupported ne11");
         };


### PR DESCRIPTION
## What changed

Extends the Metal `mul_mat` small-batch mat-vec dispatch from `ne11 <= 8` to `ne11 <= 16` and adds explicit `r1ptg` choices for `ne11 = 9..16`.

This keeps the existing path and parameters for `ne11 <= 8` unchanged.

## Why

On Apple Metal, batched decode with small row counts can fall off the optimized mat-vec path immediately after width 8. On my local M-series system with Qwen2.5-Coder-0.5B Q4_K_M, this produced a sharp throughput cliff at W=9.

The code already notes that these constants are heuristic and may need tuning across hardware. Extending the guard and adding the missing row-group cases removes the pathological dispatch cliff in this workload.

## Local benchmark

Model: `bartowski/Qwen2.5-Coder-0.5B-Instruct-GGUF:Q4_K_M`

Benchmark shape: `requests=48`, `repeats=3`, `n_predict=128`, `ctx_per_slot=1024`

Aggregate decode throughput, median tok/s:

| W | baseline | patched `ne11 <= 16` |
|---:|---:|---:|
| 1 | 336.88 | 329.45 |
| 8 | 1336.34 | 1074.50 |
| 9 | 777.84 | 1027.72 |
| 10 | 904.93 | 1475.77 |
| 12 | 1033.29 | 1265.69 |
| 14 | 795.91 | 1241.92 |
| 16 | 706.47 | 1350.23 |

Result: the W=8 -> W=9 cliff is removed, with W=9 improving from 777.84 tok/s to 1027.72 tok/s and W=16 improving from 706.47 tok/s to 1350.23 tok/s in this paired benchmark.

## Notes

The single-stream baseline varied between paired runs, so the main claim here is not a universal efficiency gate. The useful signal is that the immediate post-W=8 dispatch cliff disappears and small-batch throughput above 8 becomes usable again on the tested Metal setup.

## Validation

- `git diff --check`
- Local benchmark above on the patched branch
