### PR TITLE
server: set Content-Encoding to gzip for loading.html

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -237,12 +237,32 @@ bool server_http_context::init(const common_params & params) {
         return false;
     };
 
+#if defined(LLAMA_UI_HAS_ASSETS)
+    static auto handle_gzip_header = [](const httplib::Request & req, httplib::Response & res) {
+        if (!llama_ui_use_gzip()) {
+            // no gzip build, skip
+            return true;
+        }
+        if (req.get_header_value("Accept-Encoding").find("gzip") == std::string::npos) {
+            res.status = 415; // unsupported media type
+            res.set_content("Error: gzip is not supported by this browser", "text/plain");
+            return false;
+        } else {
+            res.set_header("Content-Encoding", "gzip");
+        }
+        return true;
+    };
+#endif
+
     auto middleware_server_state = [this](const httplib::Request & req, httplib::Response & res) {
         if (!is_ready.load()) {
 #if defined(LLAMA_UI_HAS_ASSETS)
             if (const auto tmp = string_split<std::string>(req.path, '.');
                 req.path == "/" || (!tmp.empty() && tmp.back() == "html")) {
                 if (const llama_ui_asset * a = llama_ui_find_asset("loading.html")) {
+                    if (!handle_gzip_header(req, res)) {
+                        return false;  // returns error message
+                    }
                     res.status = 503;
                     res.set_content(reinterpret_cast<const char*>(a->data), a->size, "text/html; charset=utf-8");
                     return false;
@@ -321,21 +341,6 @@ bool server_http_context::init(const common_params & params) {
             }
         } else {
 #if defined(LLAMA_UI_HAS_ASSETS)
-            static auto handle_gzip_header = [](const httplib::Request & req, httplib::Response & res) {
-                if (!llama_ui_use_gzip()) {
-                    // no gzip build, skip
-                    return true;
-                }
-                if (req.get_header_value("Accept-Encoding").find("gzip") == std::string::npos) {
-                    res.status = 415; // unsupported media type
-                    res.set_content("Error: gzip is not supported by this browser", "text/plain");
-                    return false;
-                } else {
-                    res.set_header("Content-Encoding", "gzip");
-                }
-                return true;
-            };
-
             auto serve_asset_cached = [](const std::string & name, bool isolation) {
                 return [name, isolation](const httplib::Request & req, httplib::Response & res) {
                     if (!handle_gzip_header(req, res)) {


### PR DESCRIPTION
## Overview

Set Content-Encoding properly for loading.html so that llama-server doesn't display gibberish when the UI is accessed before model loads; fixes #25208 

## Additional information

### Problem & Steps to Reproduce
After e8067a8 added gzip compression, `loading.html` is gzip-compressed but the proper `Content-Encoding` header is not set, causing browsers to interpret the gzipped file as html, displaying gibberish.

To reproduce:

```bash
llama-server -m /path/to/any/model.gguf
wget localhost:8080 -O tmp.html --content-on-error # run before the model finishes loading
file tmp.html
```

Which results in:
```
tmp.html: gzip compressed data, was "loading.html", last modified: ...
```

Alternatively, go to http://localhost:8080 with a browser before model finishes loading to observe the issue.
### Fix
e8067a8 did add `handle_gzip_header()` to add `Content-Encoding: gzip` to the response headers, but it wasn't used in `middleware_server_state()`. I added a simple fix to use `handle_gzip_header()` in `middleware_server_state()` (in the same way as elsewhere). I then had to place `handle_gzip_header()` before `middleware_server_state()`, but did not change its contents.

I have built llama.cpp on Ubuntu after my commit and run llama-server to confirm the fix.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Not used.
