### PR TITLE
webui: add a context compaction action to the Web UI context gauge.

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatForm.svelte
@@ -62,6 +62,8 @@
 		onStop?: () => void;
 		onSubmit?: () => void;
 		onSystemPromptClick?: (draft: { message: string; files: ChatUploadedFile[] }) => void;
+		onCompactContext?: () => void;
+		onModelCheck?: () => boolean;
 		onUploadedFileRemove?: (fileId: string) => void;
 		onUploadedFilesChange?: (files: ChatUploadedFile[]) => void;
 		onValueChange?: (value: string) => void;
@@ -82,6 +84,8 @@
 		onFilesAdd,
 		onStop,
 		onSubmit,
+		onCompactContext,
+		onModelCheck,
 		onSystemPromptClick,
 		onUploadedFileRemove,
 		onUploadedFilesChange,
@@ -550,6 +554,8 @@
 				onFileUpload={handleFileUpload}
 				onMicClick={handleMicClick}
 				{onStop}
+				{onCompactContext}
+				{onModelCheck}
 				onSystemPromptClick={() => onSystemPromptClick?.({ message: value, files: uploadedFiles })}
 				onMcpPromptClick={showMcpPromptButton ? () => (isPromptPickerOpen = true) : undefined}
 				onMcpResourcesClick={() => (isResourceDialogOpen = true)}

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormActions/ChatFormActions.svelte
@@ -40,6 +40,8 @@
 		onSystemPromptClick?: () => void;
 		onMcpPromptClick?: () => void;
 		onMcpResourcesClick?: () => void;
+		onCompactContext?: () => void;
+		onModelCheck?: () => boolean;
 	}
 
 	let {
@@ -58,7 +60,9 @@
 		onStop,
 		onSystemPromptClick,
 		onMcpPromptClick,
-		onMcpResourcesClick
+		onMcpResourcesClick,
+		onCompactContext,
+		onModelCheck
 	}: Props = $props();
 
 	let currentConfig = $derived(config());
@@ -80,6 +84,7 @@
 	let hasVisionModality = $state(false);
 	let hasModelSelected = $state(false);
 	let isSelectedModelInCache = $state(true);
+	let isCompactingContext = $state(false);
 	let submitTooltip = $state('');
 
 	let hasAudioAttachments = $derived(
@@ -129,6 +134,35 @@
 		const liveOutputTokens = processingState.outputTokensUsed ?? 0;
 		return livePromptTokens > 0 || liveOutputTokens > 0;
 	});
+
+	let canCompactContext = $derived(
+		!!onCompactContext &&
+			!disabled &&
+			!isLoading &&
+			!isCompactingContext &&
+			conversationsStore.activeMessages.length > 0 &&
+			(!showModelSelector || hasModelSelected)
+	);
+
+	let compactTooltip = $derived.by(() => {
+		if (isCompactingContext) return 'Compacting context...';
+		if (showModelSelector && !hasModelSelected) return 'Select a model to compact context';
+		if (conversationsStore.activeMessages.length === 0) return 'No context to compact';
+		if (isLoading) return 'Wait for the current response to finish';
+		if (disabled) return 'Compact context unavailable';
+		return 'Compact context';
+	});
+
+	async function handleCompactContextClick() {
+		if (isCompactingContext || !canCompactContext) return;
+		if (onModelCheck?.() === false) return;
+		isCompactingContext = true;
+		try {
+			await Promise.resolve(onCompactContext?.());
+		} finally {
+			isCompactingContext = false;
+		}
+	}
 </script>
 
 <div
@@ -155,7 +189,12 @@
 
 	<div class="flex items-center gap-1.5">
 		{#if hasProcessedTokens}
-			<ChatFormContextGauge />
+			<ChatFormContextGauge
+				onCompactContext={onCompactContext ? handleCompactContextClick : undefined}
+				compactDisabled={!canCompactContext}
+				compactLoading={isCompactingContext}
+				{compactTooltip}
+			/>
 		{/if}
 
 		{#if showModelSelector}

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ChatFormContextGauge.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ChatFormContextGauge.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
+	import { Loader2 } from '@lucide/svelte';
 	import * as HoverCard from '$lib/components/ui/hover-card';
+	import { Button } from '$lib/components/ui/button';
 	import { activeConversation, activeMessages } from '$lib/stores/conversations.svelte';
 	import { chatStore, isChatStreaming, isLoading } from '$lib/stores/chat.svelte';
 	import { formatParameters } from '$lib/utils/formatters';
@@ -9,6 +11,20 @@
 	import ContextGaugeDetails from './ContextGaugeDetails.svelte';
 	import ContextGaugeLoadModel from './ContextGaugeLoadModel.svelte';
 	import { colorLevelBgClass, colorLevelTextClass } from './context-gauge';
+
+	interface Props {
+		onCompactContext?: () => void;
+		compactDisabled?: boolean;
+		compactLoading?: boolean;
+		compactTooltip?: string;
+	}
+
+	let {
+		onCompactContext,
+		compactDisabled = false,
+		compactLoading = false,
+		compactTooltip = 'Compact context'
+	}: Props = $props();
 
 	const gauge = useContextGauge();
 
@@ -40,6 +56,7 @@
 			gauge.contextTotal > 0 &&
 			(gauge.activeModelId !== null || gauge.isActiveModelLoaded)
 	);
+	const showLoadModelAction = $derived(gauge.activeModelId !== null && !gauge.isActiveModelLoaded);
 </script>
 
 <HoverCard.Root>
@@ -61,7 +78,7 @@
 				</span>
 			</div>
 
-			{#if gauge.activeModelId !== null && !gauge.isActiveModelLoaded}
+			{#if showLoadModelAction}
 				<ContextGaugeLoadModel
 					modelId={gauge.activeModelId}
 					isLoading={gauge.isActiveModelLoading}
@@ -87,6 +104,26 @@
 				</div>
 			{:else}
 				<div class="text-xs text-muted-foreground">No context info available</div>
+			{/if}
+
+			{#if onCompactContext && !showLoadModelAction}
+				<div class="border-t border-border/50 pt-2">
+					<Button
+						size="sm"
+						variant="secondary"
+						class="self-start"
+						disabled={compactDisabled || compactLoading}
+						title={compactTooltip}
+						onclick={onCompactContext}
+					>
+						{#if compactLoading}
+							<Loader2 class="h-3.5 w-3.5 animate-spin" />
+							Compacting...
+						{:else}
+							Compact context
+						{/if}
+					</Button>
+				</div>
 			{/if}
 
 			{#if gauge.hasAnyUsage}

--- a/tools/ui/src/lib/components/app/chat/ChatScreen/ChatScreen.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatScreen/ChatScreen.svelte
@@ -183,6 +183,15 @@
 		await chatStore.addSystemPrompt();
 	}
 
+	async function handleCompactContext() {
+		const success = await chatStore.compactContext();
+		if (success) {
+			import('svelte-sonner').then(({ toast }) => {
+				toast.success('Context compacted');
+			});
+		}
+	}
+
 	$effect(() => {
 		const shouldDisableAutoScroll =
 			config().disableAutoScroll || (isMobile.current && isCurrentConversationLoading);
@@ -296,6 +305,7 @@
 				onSend={handleSendMessage}
 				onStop={() => chatStore.stopGeneration()}
 				onSystemPromptAdd={handleSystemPromptAdd}
+				onCompactContext={handleCompactContext}
 				bind:uploadedFiles={fileUpload.uploadedFiles}
 			/>
 		</div>

--- a/tools/ui/src/lib/components/app/chat/ChatScreen/ChatScreenForm.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatScreen/ChatScreenForm.svelte
@@ -16,6 +16,8 @@
 		onSend?: (message: string, files?: ChatUploadedFile[]) => Promise<boolean>;
 		onStop?: () => void;
 		onSystemPromptAdd?: (draft: { message: string; files: ChatUploadedFile[] }) => void;
+		onCompactContext?: () => void;
+		onModelCheck?: () => boolean;
 		uploadedFiles?: ChatUploadedFile[];
 	}
 
@@ -29,6 +31,8 @@
 		onSend,
 		onStop,
 		onSystemPromptAdd,
+		onCompactContext,
+		onModelCheck,
 		uploadedFiles = $bindable([])
 	}: Props = $props();
 
@@ -147,6 +151,8 @@
 		{onStop}
 		onSubmit={handleSubmit}
 		onSystemPromptClick={handleSystemPromptClick}
+		{onCompactContext}
+		onModelCheck={() => chatFormRef?.checkModelSelected() ?? true}
 		onUploadedFileRemove={handleUploadedFileRemove}
 	/>
 </div>

--- a/tools/ui/src/lib/stores/chat.svelte.ts
+++ b/tools/ui/src/lib/stores/chat.svelte.ts
@@ -2431,6 +2431,116 @@ class ChatStore {
 			}
 		}
 	}
+
+	async compactContext(): Promise<boolean> {
+		const activeConv = conversationsStore.activeConversation;
+		if (!activeConv || conversationsStore.activeMessages.length === 0) return false;
+		if (this.isChatLoadingInternal(activeConv.id)) return false;
+
+		this.setChatLoading(activeConv.id, true);
+		this.clearChatStreaming(activeConv.id);
+
+		try {
+			const promptMessages = conversationsStore.activeMessages;
+			const allMessages = await conversationsStore.getConversationMessages(activeConv.id);
+			const rootMessage = allMessages.find((m) => m.type === 'root' && m.parent === null);
+
+			const compactPrompt = `You are compacting a conversation into durable context for future turns.
+
+Write a concise Markdown context note that preserves only information needed to continue the conversation accurately.
+
+Preserve:
+- the user's goals and current intent
+- current state, progress, and decisions made
+- facts, constraints, preferences, assumptions, and open questions
+- important entities: files, paths, commands, errors, URLs, APIs, model names, tools, repositories, settings, versions, dates
+- TODOs and next steps
+- any prior summary or durable memory that is still relevant
+
+Omit:
+- greetings, small talk, repeated discussion, dead ends
+- transient debugging steps unless they explain the current state
+- reasoning that did not affect decisions
+- obsolete information superseded later in the conversation
+
+Requirements:
+- Use Markdown.
+- Be specific and factual.
+- Keep exact names, paths, commands, errors, and numeric values when they matter.
+- Do not invent or infer missing facts.
+- Prefer compact bullets over prose.
+- Organize by topic when helpful.
+- If the conversation is short, keep this very short.
+- If the conversation is long, include enough detail for another assistant to continue without reading the original history.
+
+Output only the compacted context note.`;
+
+			const compactMessage: ApiChatMessageData = {
+				role: MessageRole.USER,
+				content: compactPrompt
+			};
+
+			const conversationModel = this.getConversationModel(promptMessages);
+			const effectiveModel = isRouterMode() ? selectedModelName() || conversationModel : undefined;
+
+			let compactedContent = '';
+
+			await ChatService.sendMessage(
+				[...promptMessages, compactMessage],
+				{
+					...this.getApiOptions(),
+					model: effectiveModel,
+					stream: true,
+					custom: { chat_template_kwargs: { enable_thinking: false } },
+					onChunk: (chunk: string) => {
+						compactedContent += chunk;
+					}
+				},
+				activeConv.id
+			);
+
+			if (!compactedContent.trim()) {
+				this.setChatLoading(activeConv.id, false);
+				return false;
+			}
+
+			const compactedTrimmed = compactedContent.trim();
+			const messageIdsToDelete = conversationsStore.activeMessages
+				.filter((m) => m.id !== rootMessage?.id)
+				.map((m) => m.id);
+
+			for (const messageId of messageIdsToDelete) {
+				await DatabaseService.deleteMessage(messageId);
+			}
+
+			const rootId = rootMessage?.id ?? (await DatabaseService.createRootMessage(activeConv.id));
+
+			const newSystemMessage = await DatabaseService.createSystemMessage(
+				activeConv.id,
+				compactedTrimmed,
+				rootId
+			);
+
+			await DatabaseService.updateConversation(activeConv.id, {
+				currNode: newSystemMessage.id
+			});
+
+			conversationsStore.activeMessages = [newSystemMessage];
+			conversationsStore.activeConversation = {
+				...conversationsStore.activeConversation,
+				currNode: newSystemMessage.id,
+				lastModified: Date.now()
+			};
+
+			conversationsStore.updateConversationTimestamp();
+			this.setChatLoading(activeConv.id, false);
+			return true;
+		} catch (error) {
+			console.error('Failed to compact context:', error);
+			if (activeConv) this.setChatLoading(activeConv.id, false);
+			return false;
+		}
+	}
 }
 
 export const chatStore = new ChatStore();


### PR DESCRIPTION
## Overview

Adds a context compaction action to the Web UI context gauge.

The new action lets users replace the current active conversation path with a compact Markdown context note generated by the selected model. This is useful when a conversation has grown large but the user wants to preserve the important state, decisions, constraints, preferences, and next steps for future turns.

The action is integrated into the existing `ChatFormContextGauge` hover card so context usage and context management live in the same UI surface.

Main behavior:
- Adds a `Compact context` action to the context gauge popover.
- Hides the compact action while the gauge is showing the `Load model` action.
- Shows a `Compacting...` loading state while compaction is running.
- Uses the active model to generate a durable Markdown context note.
- Replaces the current active message path with the compacted note as a system message.
- Keeps model selection validation consistent with normal chat submission.
- Disables thinking for the compaction request via `chat_template_kwargs.enable_thinking = false`.

## Additional information

The compaction prompt is intentionally general-purpose. It asks the model to preserve only information needed to continue the conversation accurately, including goals, current state, decisions, constraints, preferences, open questions, important files/commands/errors/API names, and next steps.

The feature does not change the existing context gauge token accounting. It only adds an action to compact the current conversation context.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to help draft and refine the implementation and PR description.
