### PR TITLE
/slots related API fixes

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -898,6 +898,28 @@ Same as the `/v1/embeddings` endpoint.
 ]
 ```
 
+### GET `/metrics`: Prometheus compatible metrics exporter
+
+This endpoint is only accessible if `--metrics` is set.
+
+In *router mode* the query param `?model={model_id}` has to be set. This endpoint will respond with status code 400 `model name is missing from the request` if not set.
+
+#### Available metrics
+
+| Metric | Type | Description |
+| ------ | ---------------------- | ----------- |
+| `llamacpp:prompt_tokens_total` | Counter | Number of prompt tokens processed. |
+| `llamacpp:prompt_seconds_total` | Counter | Prompt process time in seconds. |
+| `llamacpp:prompt_tokens_seconds` | Gauge | Average prompt throughput in tokens/s. |
+| `llamacpp:tokens_predicted_total` | Counter | Number of generation tokens processed. |
+| `llamacpp:tokens_predicted_seconds_total` | Counter | Predict process time in seconds. |
+| `llamacpp:predicted_tokens_seconds` | Gauge | Average generation throughput in tokens/s. |
+| `llamacpp:requests_processing` | Gauge | Number of requests processing. |
+| `llamacpp:requests_deferred` | Gauge | Number of requests deferred. |
+| `llamacpp:n_tokens_max` | Counter | High watermark of the context size observed. |
+| `llamacpp:n_decode_total` | Counter | Total Number of llama_decode() calls. |
+| `llamacpp:n_busy_slots_per_decode` | Gauge | Average number of busy slots per llama_decode() call. |
+
 ### GET `/slots`: Returns the current slots processing state
 
 This endpoint is enabled by default and can be disabled with `--no-slots`. It can be used to query various per-slot metrics, such as speed, processed tokens, sampling parameters, etc.
@@ -1045,28 +1067,6 @@ If query param `?fail_on_no_slot=1` is set, this endpoint will respond with stat
 ```
 
 </details>
-
-### GET `/metrics`: Prometheus compatible metrics exporter
-
-This endpoint is only accessible if `--metrics` is set.
-
-In *router mode* the query param `?model={model_id}` has to be set. This endpoint will respond with status code 400 `model name is missing from the request` if not set.
-
-#### Available metrics
-
-| Metric | Type | Description |
-| ------ | ---------------------- | ----------- |
-| `llamacpp:prompt_tokens_total` | Counter | Number of prompt tokens processed. |
-| `llamacpp:prompt_seconds_total` | Counter | Prompt process time in seconds. |
-| `llamacpp:prompt_tokens_seconds` | Gauge | Average prompt throughput in tokens/s. |
-| `llamacpp:tokens_predicted_total` | Counter | Number of generation tokens processed. |
-| `llamacpp:tokens_predicted_seconds_total` | Counter | Predict process time in seconds. |
-| `llamacpp:predicted_tokens_seconds` | Gauge | Average generation throughput in tokens/s. |
-| `llamacpp:requests_processing` | Gauge | Number of requests processing. |
-| `llamacpp:requests_deferred` | Gauge | Number of requests deferred. |
-| `llamacpp:n_tokens_max` | Counter | High watermark of the context size observed. |
-| `llamacpp:n_decode_total` | Counter | Total Number of llama_decode() calls. |
-| `llamacpp:n_busy_slots_per_decode` | Gauge | Average number of busy slots per llama_decode() call. |
 
 ### POST `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -648,9 +648,13 @@ struct server_slot {
 
         const auto & ptask = task ? task : task_prev;
 
+        // /slots/restore restores tokens, but not task info.
+        if (ptask || !prompt.tokens.empty()) {
+            res["n_prompt_tokens"] = (int32_t) prompt.tokens.size();
+        }
+
         if (ptask) {
             res["id_task"] = ptask->id;
-            res["n_prompt_tokens"]           = (int32_t) prompt.tokens.size();
             res["n_prompt_tokens_processed"] = n_prompt_tokens_processed;
             res["n_prompt_tokens_cache"]     = n_prompt_tokens_cache;
             res["params"] = ptask->params.to_json(only_metrics);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -4500,6 +4500,11 @@ void server_routes::init_routes() {
             return res;
         }
 
+        if (id_slot < 0) {
+            res->error(format_error_response("Invalid slot ID", ERROR_TYPE_INVALID_REQUEST));
+            return res;
+        }
+
         std::string action = req.get_param("action");
 
         if (action == "save") {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2564,12 +2564,14 @@ private:
                     size_t nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), tokens.size(), &token_count);
                     if (nread == 0) {
                         slot->prompt.tokens.clear(); // KV may already been invalidated?
+                        slot->prompt.checkpoints.clear();
                         send_error(task, "Unable to restore slot, no available space in KV cache or invalid slot save file", ERROR_TYPE_INVALID_REQUEST);
                         break;
                     }
                     tokens.resize(token_count);
                     slot->prompt.tokens.clear();
                     slot->prompt.tokens.insert(tokens);
+                    slot->prompt.checkpoints.clear();
 
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1574,8 +1574,13 @@ private:
                 }
             }
 
-            if (ret != nullptr) {
-                const float f_keep = (sim_best*task.tokens.size()) / ret->prompt.tokens.size();
+            // if ret->task_prev is null, /slots/restore was used, and partial information was restored,
+            // we can not proceed here
+            if (ret != nullptr && ret->task_prev != nullptr) {
+                // use last prompt, ignore tokens generated since, so it does not confuse how much to keep
+                const int32_t n_prompt_prev = ret->task_prev->n_tokens();
+
+                const float f_keep = (sim_best*task.tokens.size()) / std::max(1, n_prompt_prev);
 
                 if (task.id_slot == -1) {
                     SLT_INF(*ret, "selected slot by LCP similarity, sim_best = %.3f (> %.3f thold), f_keep = %.3f\n",

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -5095,7 +5095,9 @@ json server_routes::get_model_info() const {
 std::unique_ptr<server_res_generator> server_routes::handle_slots_save(const server_http_req & req, int id_slot) {
     auto res = create_response();
     const json request_data = json::parse(req.body);
-    std::string filename = request_data.at("filename");
+    std::string filename = request_data.contains("filename") && request_data.at("filename").is_string()
+        ? request_data.at("filename").get<std::string>()
+        : "";
     if (!fs_validate_filename(filename)) {
         res->error(format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
         return res;
@@ -5131,7 +5133,9 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_save(const ser
 std::unique_ptr<server_res_generator> server_routes::handle_slots_restore(const server_http_req & req, int id_slot) {
     auto res = create_response();
     const json request_data = json::parse(req.body);
-    std::string filename = request_data.at("filename");
+    std::string filename = request_data.contains("filename") && request_data.at("filename").is_string()
+        ? request_data.at("filename").get<std::string>()
+        : "";
     if (!fs_validate_filename(filename)) {
         res->error(format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
         return res;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -265,6 +265,7 @@ struct server_slot {
         }
 
         prompt.tokens.clear();
+        prompt.checkpoints.clear();
     }
 
     std::vector<common_adapter_lora_info> lora;

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1762,7 +1762,9 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
         }
     }
 
-    if (it_best != states.end()) {
+    const bool found = it_best != states.end();
+
+    if (found) {
         SRV_TRC(" - found better prompt with f_keep = %.3f, sim = %.3f\n", f_keep_best, sim_best);
 
         {
@@ -1804,7 +1806,7 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
         states.erase(it_best);
     }
 
-    return true;
+    return found;
 }
 
 void server_prompt_cache::update() {

--- a/tools/server/tests/unit/test_prompt_cache_checkpoints.py
+++ b/tools/server/tests/unit/test_prompt_cache_checkpoints.py
@@ -1,0 +1,109 @@
+import pytest
+from utils import *
+
+
+@pytest.fixture
+def server():
+    srv = ServerPreset.tinygemma3()
+    # tinygemma3 uses SWA (n_swa > 0), which is required for the server to
+    # ever create context checkpoints in the first place; a plain model like
+    # tinyllama2 supports arbitrary partial KV removal and never checkpoints
+    srv.n_ctx = 1024
+    srv.n_batch = 16
+    srv.n_ubatch = 16
+    srv.n_slots = 1
+    srv.n_predict = 1
+    srv.temperature = 0.0
+    srv.server_slots = True
+    srv.cache_ram = 64
+    srv.n_ctx_checkpoints = 8
+    srv.checkpoint_min_step = 4
+    # Interesting log entries are logged at level 4
+    srv.log_verbosity = 4
+    return srv
+
+
+# long enough that prompt processing spans several batches and at least one
+# context checkpoint gets created near the end
+PROMPT_A = (
+    "The brave knight traveled across the mountains and rivers and forests "
+    "looking for treasure in the old castle ruins near the lake and the "
+    "dragon guarding it fiercely every single day and night"
+)
+
+# shares no meaningful content with PROMPT_A, forcing a genuine prompt-cache miss
+PROMPT_B = (
+    "Quantum electron spin lattice diffraction pattern anomaly detector "
+    "calibration sequence initiated for laboratory experiment number seven"
+)
+
+
+# Trigger full prompt re-processing
+def test_prompt_cache_load_miss_and_hit(server, capfd):
+    server.start()
+
+    # trivial miss: empty cache, slot picks up PROMPT_A
+    res = server.make_request(
+        "POST",
+        "/completion",
+        data={
+            "prompt": PROMPT_A,
+            "cache_prompt": True,
+        },
+    )
+    assert res.status_code == 200
+    out, _ = capfd.readouterr()
+
+    assert "created context checkpoint" in out
+
+    # 2nd miss, this saves PROMPT_A's state into the cache and looks up
+    # PROMPT_B against it
+    res = server.make_request(
+        "POST",
+        "/completion",
+        data={
+            "prompt": PROMPT_B,
+            "cache_prompt": True,
+        },
+    )
+    assert res.status_code == 200
+    out, _ = capfd.readouterr()
+    assert "selected slot by LRU" in out
+    assert "updating prompt cache" in out
+
+    assert "failed to load prompt from cache" in out, (
+        "expected server_prompt_cache::load() to report a miss for the "
+        "unrelated prompt so the slot gets cleared; instead it appears to "
+        "have reported a (bogus) hit:\n" + out
+    )
+
+    assert "erased invalidated context checkpoint" not in out, (
+        "stale checkpoints from the previous conversation leaked into the "
+        "new task and were erased one at a time instead of being cleared "
+        "before processing started:\n" + out
+    )
+    assert "forcing full prompt re-processing" not in out, (
+        "the new task was compared against stale leftover tokens from the "
+        "previous conversation instead of starting from a freshly cleared "
+        "slot:\n" + out
+    )
+
+    # PROMPT_A again, restore succeeds
+    res = server.make_request(
+        "POST",
+        "/completion",
+        data={
+            "prompt": PROMPT_A,
+            "cache_prompt": True,
+        },
+    )
+    assert res.status_code == 200
+    out, _ = capfd.readouterr()
+
+    assert "selected slot by LRU" in out
+    assert "found better prompt" in out, (
+        "expected a genuine prompt-cache hit for the repeated PROMPT_A so "
+        "this test actually exercises the erase-then-compare path in "
+        "server_prompt_cache::load(); instead it looks like a miss:\n" + out
+    )
+    assert "failed to load prompt from cache" not in out

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -4,10 +4,10 @@ from utils import *
 server = ServerPreset.tinyllama2()
 
 @pytest.fixture(autouse=True)
-def create_server():
+def create_server(tmp_path):
     global server
     server = ServerPreset.tinyllama2()
-    server.slot_save_path = "./tmp"
+    server.slot_save_path = str(tmp_path)
     server.temperature = 0.0
 
 

--- a/tools/server/tests/unit/test_slots.py
+++ b/tools/server/tests/unit/test_slots.py
@@ -1,0 +1,656 @@
+import threading
+import time
+from dataclasses import dataclass
+
+import pytest
+from utils import (
+    ServerPreset,
+    ServerResponse,
+    match_regex,
+)
+
+
+@dataclass
+class Prompt:
+    prompt: str
+    content_regex: str
+    prompt_n: int
+    tokens_cached: int
+
+
+PROMPTS = {
+    1: Prompt(
+        prompt="What is the capital of France?",
+        content_regex=r"(allgeme)+",
+        prompt_n=8,
+        tokens_cached=11,
+    ),
+    2: Prompt(
+        prompt="What is the capital of Mexico?",
+        content_regex=r"(osumosum)+",
+        prompt_n=8,
+        tokens_cached=11,
+    ),
+    # shares no tokens with prompts 1/2 (which share "What is the capital of
+    # ...?"), so any KV reused against this prompt that actually belongs to
+    # 1/2 (or vice versa) cannot pass as a coincidental prefix match - it can
+    # only be genuinely valid or genuinely wrong content
+    3: Prompt(
+        prompt="Explain how a rainbow forms.",
+        content_regex=r"(truck)+",
+        prompt_n=7,
+        tokens_cached=10,
+    ),
+}
+
+
+class ServerTest:
+    def __init__(self, tmp_path_) -> None:
+        srv = ServerPreset.tinygemma3()
+        srv.slot_save_path = str(tmp_path_)
+        srv.temperature = 0.0
+        # /slots/save|restore reject any multimodal-capable slot outright, and
+        # tinygemma3 auto-loads its mmproj otherwise
+        srv.no_mmproj = True
+        # "created context checkpoint" is logged at trace level (4); the default
+        # verbosity (3, info) suppresses it
+        srv.log_verbosity = 4
+        # so we can query /slots directly to check a slot's live token count
+        srv.server_slots = True
+
+        self.srv = srv
+        self.tmp_path = tmp_path_
+        self.filenames: set[str] = set()
+        self.filename: str | None = None
+
+    def start(self) -> None:
+        self.srv.start()
+
+    def op_completion(
+        self,
+        prompt_id: int,
+        id_slot: int,
+        prompt_n: None | int = None,
+        tokens_cached: None | int = None,
+    ) -> int:
+        p = PROMPTS[prompt_id]
+        res = self.srv.make_request(
+            "POST",
+            "/completion",
+            data={
+                "prompt": p.prompt,
+                "id_slot": id_slot,
+                "cache_prompt": True,
+            },
+        )
+        assert res.status_code == 200
+        assert match_regex(p.content_regex, res.body["content"])
+        expected_prompt_n = p.prompt_n if prompt_n is None else prompt_n
+        assert res.body["timings"]["prompt_n"] == expected_prompt_n
+
+        expected_tokens_cached = (
+            p.tokens_cached if tokens_cached is None else tokens_cached
+        )
+        assert res.body["tokens_cached"] == expected_tokens_cached
+
+        return expected_tokens_cached
+
+    def start_busy_completions(
+        self, id_slots: list[int], n_predict: int = 200
+    ) -> tuple[list[threading.Thread], dict[int, ServerResponse]]:
+        """Start a long-running completion on each of id_slots in the background and
+        return once they've had a head start, so those slots are genuinely busy by
+        the time the caller does whatever it needs to race against them. Returns the
+        threads (join them when done) and a dict of id_slot -> response, populated
+        once each thread finishes."""
+        results = {}
+        threads = []
+        for id_slot in id_slots:
+
+            def do_completion(id_slot=id_slot):
+                results[id_slot] = self.srv.make_request(
+                    "POST",
+                    "/completion",
+                    data={
+                        "prompt": PROMPTS[1].prompt,
+                        "id_slot": id_slot,
+                        "cache_prompt": True,
+                        "n_predict": n_predict,
+                    },
+                )
+
+            t = threading.Thread(target=do_completion)
+            t.start()
+            threads.append(t)
+        time.sleep(0.2)
+        return threads, results
+
+    def op_slot_save(
+        self, id_slot: int, n_saved: int, filename: str | None = None
+    ) -> bytes:
+        if filename is None:
+            filename = self.filename
+        assert filename is not None
+
+        self.filenames.add(filename)
+        res = self.srv.make_request(
+            "POST",
+            f"/slots/{id_slot}?action=save",
+            data={
+                "filename": filename,
+            },
+        )
+        assert res.status_code == 200
+        assert res.body["n_saved"] == n_saved
+        saved_file = self.tmp_path / filename
+        return saved_file.read_bytes()
+
+    def op_slot_restore(
+        self, id_slot: int, n_restored: int, filename: str | None = None
+    ) -> None:
+        if filename is None:
+            filename = self.filename
+        assert filename is not None
+
+        res = self.srv.make_request(
+            "POST",
+            f"/slots/{id_slot}?action=restore",
+            data={
+                "filename": filename,
+            },
+        )
+        assert res.status_code == 200
+        assert res.body["n_restored"] == n_restored
+
+    def op_slot_erase(self, id_slot: int, n_erased: int) -> None:
+        res = self.srv.make_request("POST", f"/slots/{id_slot}?action=erase")
+        assert res.status_code == 200
+        assert res.body["n_erased"] == n_erased
+
+    def slot_n_prompt_tokens(self, id_slot) -> int:
+        res = self.srv.make_request("GET", "/slots")
+        assert res.status_code == 200
+        slot = next(s for s in res.body if s["id"] == id_slot)
+        print(f"\nSLOT: {slot}\n\n")
+        return slot.get("n_prompt_tokens")
+
+    def assert_filenames(self) -> None:
+        in_tmp = set(f.name for f in self.tmp_path.iterdir())
+        assert in_tmp == self.filenames
+
+
+@pytest.fixture
+def server(tmp_path):
+    return ServerTest(tmp_path)
+
+
+def assert_checkpoints_are_possible(capfd):
+    out, _ = capfd.readouterr()
+    assert "created context checkpoint" in out, (
+        "no context checkpoint was created - this test requires a model "
+        "that actually produces them (e.g. an SWA model like tinygemma3); "
+        "a plain model such as tinyllama2 never creates checkpoints, which "
+        "would make the save/restore checks below meaningless:\n" + out
+    )
+
+
+#
+
+
+def test_slots_get_disabled_without_slots_flag(server):
+    # our test harness always passes --slots or --no-slots explicitly, never
+    # leaving it unset; ServerTest defaults to --slots, so --no-slots
+    # otherwise has zero coverage (the server itself defaults to enabled)
+    server.srv.server_slots = False
+    server.start()
+
+    res = server.srv.make_request("GET", "/slots")
+    assert res.status_code == 501
+    assert res.body["error"]["message"] == (
+        "This server does not support slots endpoint. Start it with `--slots`"
+    )
+
+
+def test_slots_fail_on_no_slot_ignores_value(server):
+    # a "falsy"-looking value like "0" still triggers the rejection, same as
+    # "1" from the README example - only presence is checked, not the value
+    server.start()
+
+    threads, _ = server.start_busy_completions([0, 1])
+
+    res = server.srv.make_request("GET", "/slots?fail_on_no_slot=0")
+    assert res.status_code == 503
+    assert res.body["error"]["message"] == "no slot available"
+
+    # with the param entirely absent, no-idle-slots is not an error at all
+    res = server.srv.make_request("GET", "/slots")
+    assert res.status_code == 200
+
+    for t in threads:
+        t.join()
+
+
+def test_slots_save_restore(server, capfd):
+    server.start()
+    id_slot = 1
+    server.filename = "slot1.bin"
+
+    # prompt_n=8 is the tokenized prompt length; n_saved=11 is the full slot
+    # state (8 prompt + 3 generated tokens, generation stops early on EOS)
+    tokens_cached = server.op_completion(1, id_slot)
+    assert_checkpoints_are_possible(capfd)
+    assert server.slot_n_prompt_tokens(id_slot) == tokens_cached
+    server.op_slot_save(id_slot, tokens_cached)
+
+    # only different part is processed
+    server.op_completion(2, id_slot, 5)
+
+    # n_restored matches n_saved above: the full 11-token slot state
+    server.op_slot_restore(0, tokens_cached)
+
+    # /slots/save|restore only round-trip raw tokens and KV state.
+    server.op_completion(2, 0)
+
+    # same as above - proves slot 1 wasn't corrupted while slot 0 was restored
+    server.op_completion(2, id_slot, 5)
+
+    server.assert_filenames()
+
+
+def test_slots_restore_over_slot_with_own_checkpoints(server, capfd):
+    server.start()
+    server.filename = "restore_over_own_checkpoints.bin"
+
+    # slot 0 builds up its own checkpoints from a conversation (rainbow) that
+    # shares no tokens at all with the France/Mexico prompts used below - so
+    # any KV later reused from these checkpoints cannot coincidentally pass
+    # as valid content for a different prompt the way France/Mexico's shared
+    # "What is the capital of ...?" prefix could
+    server.op_completion(3, 0)
+    assert_checkpoints_are_possible(capfd)
+
+    # slot 1 gets a genuinely unrelated conversation, saved to a file
+    tokens_cached = server.op_completion(1, 1)
+    server.op_slot_save(1, tokens_cached)
+
+    # restore slot 1's file into slot 0, which is neither idle nor erased -
+    # it still holds its own rainbow checkpoints from above. /slots/restore
+    # only ever replaces slot->prompt.tokens (and the underlying KV
+    # sequence); it never touches slot->prompt.checkpoints, so those stale,
+    # content-mismatched checkpoints survive the restore
+    server.op_slot_restore(0, tokens_cached)
+
+    # continuing with the newly-restored France content must still produce a
+    # genuine France completion - if the stale rainbow checkpoints get reused
+    # by position instead of being invalidated, the KV state fed to the model
+    # would belong to a completely unrelated conversation with no shared
+    # tokens to fall back on, and the output must visibly corrupt
+    server.op_completion(1, 0)
+
+    server.assert_filenames()
+
+
+def test_slots_id_wraps_out_of_range(server):
+    server.start()
+    server.filename = "wrap.bin"
+
+    # n_slots=2 (valid ids: 0, 1); get_slot_by_id does `id_slot % slots.size()`,
+    # so an out-of-range id silently wraps instead of erroring - pin this
+    # intentional-but-surprising behavior so it can't change unnoticed
+    tokens_cached = server.op_completion(1, 0)
+
+    # id_slot=2 wraps to slot 0 (2 % 2 == 0), not slot 1 - slot 1 stays idle
+    server.op_slot_save(2, tokens_cached)
+    assert server.slot_n_prompt_tokens(1) is None
+
+    server.op_slot_erase(2, tokens_cached)
+    assert server.slot_n_prompt_tokens(0) == 0
+    assert server.slot_n_prompt_tokens(1) is None
+
+    server.op_slot_restore(2, tokens_cached)
+    assert server.slot_n_prompt_tokens(0) == tokens_cached
+    assert server.slot_n_prompt_tokens(1) is None
+
+    server.assert_filenames()
+
+
+def test_slots_reject_bad_request(server):
+    server.start()
+
+    # pin fs_validate_filename()'s rejection so path traversal via save or
+    # restore can't silently start working again
+    for bad_filename in ["../evil.bin", "sub/evil.bin", "..", ""]:
+        res = server.srv.make_request(
+            "POST", "/slots/0?action=save", data={"filename": bad_filename}
+        )
+        assert res.status_code == 400
+        assert res.body["error"]["message"] == "Invalid filename"
+
+        res = server.srv.make_request(
+            "POST", "/slots/0?action=restore", data={"filename": bad_filename}
+        )
+        assert res.status_code == 400
+        assert res.body["error"]["message"] == "Invalid filename"
+
+    # a non-numeric id_slot must get a clean 400, not crash or wrap like an
+    # out-of-range numeric one does (see test_slots_id_wraps_out_of_range)
+    res = server.srv.make_request(
+        "POST", "/slots/abc?action=save", data={"filename": "x.bin"}
+    )
+    assert res.status_code == 400
+    assert res.body["error"]["message"] == "Invalid slot ID"
+
+    # unlike /completion, -1 has no documented meaning for a specific slot
+    # action - it's rejected instead of silently wrapping via unsigned
+    # overflow, same as any other negative id
+    res = server.srv.make_request(
+        "POST", "/slots/-1?action=save", data={"filename": "x.bin"}
+    )
+    assert res.status_code == 400
+    assert res.body["error"]["message"] == "Invalid slot ID"
+
+    # an action outside save/restore/erase (or a missing one) falls through
+    # to the same clean 400, not a 404 or a silent no-op
+    res = server.srv.make_request(
+        "POST", "/slots/0?action=frobnicate", data={"filename": "x.bin"}
+    )
+    assert res.status_code == 400
+    assert res.body["error"]["message"] == "Invalid action"
+
+    res = server.srv.make_request("POST", "/slots/0", data={"filename": "x.bin"})
+    assert res.status_code == 400
+    assert res.body["error"]["message"] == "Invalid action"
+
+    # a missing filename key, or one with the wrong JSON type (e.g. a
+    # number), must be rejected the same clean way as any other invalid
+    # filename - not treated as an empty/absent key differently, and not
+    # left to throw an uncaught nlohmann::json exception
+    for bad_data in [{}, {"filename": 1}]:
+        res = server.srv.make_request("POST", "/slots/0?action=save", data=bad_data)
+        assert res.status_code == 400
+        assert res.body["error"]["message"] == "Invalid filename"
+
+        # handle_slots_restore has the same filename handling, but is a
+        # separate function - pin it separately in case it ever diverges
+        res = server.srv.make_request("POST", "/slots/0?action=restore", data=bad_data)
+        assert res.status_code == 400
+        assert res.body["error"]["message"] == "Invalid filename"
+
+    server.assert_filenames()
+
+
+def test_slots_post_disabled_without_slot_save_path(server):
+    # ServerTest always sets --slot-save-path, so this rejection otherwise
+    # has zero coverage; it fires before id_slot is even parsed, so it
+    # applies regardless of slot or action
+    server.srv.slot_save_path = None
+    server.start()
+
+    res = server.srv.make_request(
+        "POST", "/slots/0?action=save", data={"filename": "x.bin"}
+    )
+    assert res.status_code == 501
+    assert res.body["error"]["message"] == (
+        "This server does not support slots action. Start it with `--slot-save-path`"
+    )
+
+
+def test_slots_idle_slot_behaviors(server):
+    server.start()
+
+    # erasing a slot that was never touched is a no-op, not an error
+    server.op_slot_erase(1, 0)
+
+    # restoring a file that was never saved is a clean 400, not a crash
+    res = server.srv.make_request(
+        "POST",
+        "/slots/0?action=restore",
+        data={
+            "filename": "this_file_was_never_saved.bin",
+        },
+    )
+    assert res.status_code == 400
+
+    server.filename = "idle.bin"
+    # saving a slot that was never touched is not an error - it just saves
+    # an empty prompt
+    server.op_slot_save(0, 0)
+
+    # saving an idle slot must not fabricate any prompt state for it
+    assert server.slot_n_prompt_tokens(0) is None
+
+    server.assert_filenames()
+
+
+def test_slots_restore_corrupted_file(server):
+    server.start()
+    id_slot = 1
+    server.filename = "corrupted.bin"
+
+    tokens_cached = server.op_completion(1, id_slot)
+    server.op_slot_save(id_slot, tokens_cached)
+
+    # truncate an otherwise-valid save file down to a few bytes - unlike a
+    # nonexistent file, this one exists and opens fine, but
+    # llama_state_seq_load_file() must still reject it as unreadable/invalid
+    # rather than reading past the end of the buffer or restoring garbage
+    saved_file = server.tmp_path / server.filename
+    saved_file.write_bytes(saved_file.read_bytes()[:16])
+
+    res = server.srv.make_request(
+        "POST", "/slots/0?action=restore", data={"filename": server.filename}
+    )
+    assert res.status_code == 400
+    assert res.body["error"]["message"] == (
+        "Unable to restore slot, no available space in KV cache or invalid slot save file"
+    )
+    assert server.slot_n_prompt_tokens(0) is None
+
+    server.assert_filenames()
+
+
+def test_slots_save_overwrite(server):
+    server.start()
+    id_slot = 1
+    server.filename = "overwrite.bin"
+
+    tokens_cached = server.op_completion(1, id_slot)
+    bytes_after_p1 = server.op_slot_save(id_slot, tokens_cached)
+
+    # saving to the same filename again must replace its contents, not
+    # append to it or leave the first save's bytes untouched - n_saved and
+    # n_written alone can't prove this (both prompts tokenize to the same
+    # length), so compare the actual bytes written to disk
+    tokens_cached = server.op_completion(2, id_slot, 5)
+    bytes_after_p2 = server.op_slot_save(id_slot, tokens_cached)
+    assert bytes_after_p1 != bytes_after_p2
+
+    # slot 1 still holds the Mexico tokens, which share a prefix with this
+    # France prompt, so this is a partial cache hit, not a full reprocess
+    tokens_cached = server.op_completion(1, id_slot, 5)
+    bytes_after_p1_again = server.op_slot_save(id_slot, tokens_cached)
+    assert bytes_after_p1 == bytes_after_p1_again
+
+    server.assert_filenames()
+
+
+def test_slots_restore_twice(server):
+    server.start()
+    id_slot = 1
+    server.filename = "slot_restore_twice.bin"
+
+    tokens_cached = server.op_completion(1, id_slot)
+    bytes_after = server.op_slot_save(id_slot, tokens_cached)
+
+    # restoring the same file into the same slot twice in a row must be
+    # idempotent - neither restore should fail or leave the slot corrupted
+    server.op_slot_restore(id_slot, tokens_cached)
+    server.op_slot_restore(id_slot, tokens_cached)
+
+    # saving restored should generate same file
+    bytes_after_again = server.op_slot_save(id_slot, tokens_cached)
+    assert bytes_after == bytes_after_again
+
+    # the slot must still be genuinely usable after the second restore, but
+    # as a full reprocess: /slots/restore now clears prompt.checkpoints
+    # unconditionally (see test_slots_restore_over_slot_with_own_checkpoints),
+    # so even a self-restore of the slot's own file no longer gets a partial
+    # cache hit - there's no cheap way to tell "restoring my own still-valid
+    # checkpoints" apart from "restoring over stale, content-mismatched ones"
+    server.op_completion(1, id_slot)
+
+    server.assert_filenames()
+
+
+def test_slots_save_erase_restore(server):
+    server.start()
+    id_slot = 1
+    server.filename = "slot_save_erase_restore.bin"
+
+    assert server.slot_n_prompt_tokens(id_slot) is None
+
+    tokens_cached = server.op_completion(1, id_slot)
+    assert server.slot_n_prompt_tokens(id_slot) == tokens_cached
+
+    server.op_slot_save(id_slot, tokens_cached)
+    assert server.slot_n_prompt_tokens(id_slot) == tokens_cached
+
+    tokens_cached = server.op_completion(2, id_slot, 5)
+    assert server.slot_n_prompt_tokens(id_slot) == tokens_cached
+
+    # erasing the source slot after saving must not corrupt the file already
+    # written to disk - n_erased reflects what was in the live slot, not the
+    # save file's contents
+    server.op_slot_erase(id_slot, tokens_cached)
+    assert server.slot_n_prompt_tokens(id_slot) == 0
+
+    server.op_slot_erase(id_slot, 0)
+    assert server.slot_n_prompt_tokens(id_slot) == 0
+
+    # save/erase/restore are fully independent of each other: the save file
+    # has no lasting link to slot 1, so erasing slot 1 - even twice - has no
+    # bearing on whether a restore into slot 1 afterward will succeed
+    server.op_slot_restore(id_slot, tokens_cached)
+    assert server.slot_n_prompt_tokens(id_slot) == tokens_cached
+
+    # the previously saved file must still restore correctly into a
+    # different slot even though its source slot has since been erased
+    server.op_slot_restore(0, tokens_cached)
+    assert server.slot_n_prompt_tokens(0) == tokens_cached
+
+    # unlike test_slot_save_restore (where the still-alive slot 1 keeps its
+    # original checkpoint and gets a discount reprocessing the next prompt),
+    # here slot 1 was erased first - that also cleared its checkpoints - so
+    # its own restore is now on equal footing with the freshly restored slot
+    # 0: both must fully reprocess a new prompt, no partial reuse for either
+
+    # no checkpoint survives erase+restore, full reprocess
+    tokens_cached = server.op_completion(2, id_slot)
+    assert server.slot_n_prompt_tokens(id_slot) == tokens_cached
+
+    tokens_cached = server.op_completion(2, 0)
+    # no checkpoint survives restore, full reprocess
+    assert server.slot_n_prompt_tokens(0) == tokens_cached
+
+    server.assert_filenames()
+
+
+def test_slots_erase_after_restore_only(server):
+    server.start()
+    id_slot = 1
+    server.filename = "restore_only.bin"
+
+    tokens_cached = server.op_completion(1, id_slot)
+
+    server.op_slot_save(id_slot, tokens_cached)
+
+    # slot 0 has never processed a task - only ever been restored into
+    server.op_slot_restore(0, tokens_cached)
+    assert server.slot_n_prompt_tokens(0) == tokens_cached
+    server.op_slot_erase(0, tokens_cached)
+
+    # unlike a slot that has processed a real task - which keeps reporting
+    # n_prompt_tokens: 0 explicitly after being erased, see
+    # test_slot_save_erase_restore - a restore-only slot has no task/task_prev
+    # to keep it "known" to /slots once its tokens are cleared: it reverts to
+    # reporting nothing at all, indistinguishable from a slot that was never
+    # touched. This is accepted as a cosmetic quirk rather than a bug: both
+    # states mean the same thing functionally (0 usable tokens, ready for
+    # reuse), and fixing it would need a new persistent flag on server_slot
+    # purely to serve this one introspection difference. Pinned here so any
+    # future change to this behavior is a deliberate, visible decision.
+    assert server.slot_n_prompt_tokens(0) is None
+
+    server.assert_filenames()
+
+
+def test_slots_erase(server, capfd):
+    server.start()
+    id_slot = 1
+
+    tokens_cached = server.op_completion(1, id_slot)
+    assert_checkpoints_are_possible(capfd)
+    server.op_slot_erase(id_slot, tokens_cached)
+
+    # re-run the same prompt, it should process all tokens again
+    server.op_completion(1, id_slot)
+
+
+def test_slots_reject_multimodal_slot(server):
+    # tinygemma3 auto-loads its mmproj unless no_mmproj is set (see ServerTest
+    # above) - flip it back on here to exercise the multimodal rejection
+    server.srv.no_mmproj = False
+    server.start()
+
+    res = server.srv.make_request(
+        "POST", "/slots/0?action=save", data={"filename": "mm.bin"}
+    )
+    assert res.status_code == 501
+    assert "multimodal" in res.body["error"]["message"]
+
+    res = server.srv.make_request(
+        "POST", "/slots/0?action=restore", data={"filename": "mm.bin"}
+    )
+    assert res.status_code == 501
+    assert "multimodal" in res.body["error"]["message"]
+
+    res = server.srv.make_request("POST", "/slots/0?action=erase")
+    assert res.status_code == 501
+    assert "multimodal" in res.body["error"]["message"]
+
+
+def test_slots_defer_while_slot_processing(server, capfd):
+    # exercise the defer-while-busy path directly by racing a save against a
+    # long-running completion on the same slot. The defer log line is
+    # debug-level.
+    server.srv.log_verbosity = 5
+    server.start()
+    id_slot = 1
+    server.filename = "defer.bin"
+
+    hit = False
+    save_res = None
+    comp_body = None
+    for _attempt in range(6):
+        threads, results = server.start_busy_completions([id_slot])
+        save_res = server.srv.make_request(
+            "POST", f"/slots/{id_slot}?action=save", data={"filename": server.filename}
+        )
+        for t in threads:
+            t.join()
+        comp_body = results[id_slot].body
+
+        out, _ = capfd.readouterr()
+        if "requested slot is unavailable, defer task" in out:
+            hit = True
+            break
+
+    assert hit, "never observed the slot-busy defer path across 6 attempts"
+    assert save_res.status_code == 200
+    # the deferred save only ever runs after the completion releases the
+    # slot, so it must reflect the full, final post-generation token count,
+    # not some stale count from before generation started
+    assert save_res.body["n_saved"] == comp_body["tokens_cached"]
+
+    server.filenames.add(server.filename)
+    server.assert_filenames()

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -93,6 +93,7 @@ class ServerProcess:
     models_max: int | None = None
     models_preset: str | None = None
     no_models_autoload: bool | None = None
+    log_verbosity: int | None = None
     lora_files: List[str] | None = None
     enable_ctx_shift: int | None = False
     spec_draft_n_min: int | None = None
@@ -105,10 +106,13 @@ class ServerProcess:
     chat_template_file: str | None = None
     server_path: str | None = None
     mmproj_url: str | None = None
+    no_mmproj: bool = False
     media_path: str | None = None
     sleep_idle_seconds: int | None = None
     cache_ram: int | None = None
     no_cache_idle_slots: bool = False
+    n_ctx_checkpoints: int | None = None
+    checkpoint_min_step: int | None = None
     log_path: str | None = None
     ui_mcp_proxy: bool = False
     backend_sampling: bool = False
@@ -217,6 +221,8 @@ class ServerProcess:
             server_args.extend(["--grp-attn-w", self.n_ga_w])
         if self.debug:
             server_args.append("--verbose")
+        if self.log_verbosity is not None:
+            server_args.extend(["--log-verbosity", self.log_verbosity])
         if self.lora_files:
             for lora_file in self.lora_files:
                 server_args.extend(["--lora", lora_file])
@@ -246,6 +252,8 @@ class ServerProcess:
             server_args.extend(["--chat-template-file", self.chat_template_file])
         if self.mmproj_url:
             server_args.extend(["--mmproj-url", self.mmproj_url])
+        if self.no_mmproj:
+            server_args.append("--no-mmproj")
         if self.media_path:
             server_args.extend(["--media-path", self.media_path])
         if self.sleep_idle_seconds is not None:
@@ -254,6 +262,10 @@ class ServerProcess:
             server_args.extend(["--cache-ram", self.cache_ram])
         if self.no_cache_idle_slots:
             server_args.append("--no-cache-idle-slots")
+        if self.n_ctx_checkpoints is not None:
+            server_args.extend(["--ctx-checkpoints", self.n_ctx_checkpoints])
+        if self.checkpoint_min_step is not None:
+            server_args.extend(["--checkpoint-min-step", self.checkpoint_min_step])
         if self.ui_mcp_proxy:
             server_args.append("--ui-mcp-proxy")
         if self.backend_sampling:


### PR DESCRIPTION
## Overview

Fix `/slots` api related issues, expand testsuite

## Additional information

Essentially `/slots/restore` needs checkpoint cleared not to confuse later compute. After restore there is only partial status information, so some actions needs to be postponed.

Tighten some `/slots` related error cases, require `filename` to be string. And if `id_slot` is used, error if it is < 0 as it makes little sense compared to `/completions` feature with `id_slot=-1`.

Add 2 pytest test suites and fix other.
- to facilitate testing `ServerProcess` needes to have extended capabilities
- Testing of `/slots` needs to be done using checkpoint capable model, here `tinygemma3` and not have multimodal on.
- `test_slots` tests `/slots` API using various ways. I arranged tests so that tests are fatter, but less of them as it takes quite long to start test from fresh and many of the test cases do not require this. It uses miniframework and pytest facilities instead of writing everything step by step as raw, as I wanted to be able to read and write tests more structurally and not bogged down to writing every assert every time just right.
- `test_prompt_cache_checkpoints` tests related situation where slot is reused, prompt cache was updated based on wrong information and that lead to checkpoints leaking / full prompt re-processing, when due to reuse prompt should have been cleared.
- doc style to group `/slots` entries together
- There is `test_slot_save` but I did not understand what it tested as it uses `tinyllama2` that does not do checkpoints. Note that if you do commit by commit test run there is regressions temporary. "server: fix server_prompt_cache::load return value, fixed in next"

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) Yes
- AI usage disclosure: YES

I used AI to help to debug these issues. I used AI to write pytest test suite tests after guidance / work by me to make especially `test_slots` test not very verbose of boilerplate.