### PR TITLE
common : make --threads -1 resolve to physical cores (#19110)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -32,7 +32,6 @@
 #include <regex>
 #include <set>
 #include <string>
-#include <thread> // for hardware_concurrency
 #include <vector>
 
 #ifndef __EMSCRIPTEN__
@@ -1278,7 +1277,10 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams.n_threads = value;
             if (params.cpuparams.n_threads <= 0) {
-                params.cpuparams.n_threads = std::thread::hardware_concurrency();
+                // leave unresolved so postprocess_cpu_params() picks the physical core
+                // count, matching the default when the flag is not set (avoids
+                // over-counting logical cores via std::thread::hardware_concurrency())
+                params.cpuparams.n_threads = -1;
             }
         }
     ).set_env("LLAMA_ARG_THREADS"));
@@ -1288,7 +1290,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.cpuparams_batch.n_threads = value;
             if (params.cpuparams_batch.n_threads <= 0) {
-                params.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                // leave unresolved so postprocess_cpu_params() inherits from --threads
+                params.cpuparams_batch.n_threads = -1;
             }
         }
     ));
@@ -3537,7 +3540,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.draft.cpuparams.n_threads = value;
             if (params.speculative.draft.cpuparams.n_threads <= 0) {
-                params.speculative.draft.cpuparams.n_threads = std::thread::hardware_concurrency();
+                // leave unresolved so postprocess_cpu_params() inherits from --threads
+                params.speculative.draft.cpuparams.n_threads = -1;
             }
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
@@ -3547,7 +3551,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, int value) {
             params.speculative.draft.cpuparams_batch.n_threads = value;
             if (params.speculative.draft.cpuparams_batch.n_threads <= 0) {
-                params.speculative.draft.cpuparams_batch.n_threads = std::thread::hardware_concurrency();
+                // leave unresolved so postprocess_cpu_params() inherits from --threads-draft
+                params.speculative.draft.cpuparams_batch.n_threads = -1;
             }
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));


### PR DESCRIPTION
Fixes #19110.

### Problem

Passing `--threads -1` (or `0`, or any value `<= 0`) resolves the thread count via `std::thread::hardware_concurrency()`, which returns the number of *logical* processors. On SMT / hyper-threaded CPUs this over-subscribes the math threads and can noticeably reduce throughput.

Meanwhile, *omitting* `--threads` leaves `n_threads = -1`, which is later resolved by `postprocess_cpu_params()` via `common_cpu_get_num_math()` — i.e. the *physical* / math core count. So explicitly requesting "auto" (`-t -1`) produced a *worse* value than simply not passing the flag.

Example on an 8-core / 16-thread CPU:
- omitting `--threads` → 8 threads (physical)
- `--threads -1` (before this PR) → 16 threads (logical, over-subscribed)

### Fix

Set `n_threads = -1` on `<= 0` in the `--threads`, `--threads-batch`, `--threads-draft` and `--threads-batch-draft` handlers, so the value flows through the existing `postprocess_cpu_params()` resolution instead of being hard-set to `hardware_concurrency()`.

This makes `-t -1` identical to leaving the flag unset, and (importantly) lets the batch/draft variants keep their documented "default: same as --threads" inheritance via the `role_model` path — which a direct `common_cpu_get_num_math()` call in each handler would have broken.

The now-unused `<thread>` include is removed.

Note: on Intel hybrid (P/E-core) CPUs, `common_cpu_get_num_math()` counts performance cores specifically rather than a raw physical count, which is the intended "math cores" behavior and still strictly better than logical-core over-subscription.

### Testing

- Builds clean (`llama-common`, MSVC / VS2019, x64 Release).
- Verified the resolution path: `-t -1` → `postprocess_cpu_params()` → `common_cpu_get_num_math()`, with `-tb`/`-tbd -1` inheriting from their parent params.
