### PR TITLE
fix: correct overallocation when fitting speculative context without specified n_ctx

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1243,6 +1243,7 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
             params.tensor_split,
             params.tensor_buft_overrides.data(),
             params.fit_params_target.data(),
+            params.fit_params_overhead_per_ctx.data(),
             params.fit_params_min_ctx,
             params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
     }
@@ -1332,6 +1333,9 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
         COM_ERR("failed to create context with model '%s'\n", params.model.path.c_str());
         return;
     }
+
+    // persist resolved context size back to params
+    params.n_ctx = llama_n_ctx(lctx);
 
     pimpl->context.reset(lctx);
 }

--- a/common/common.h
+++ b/common/common.h
@@ -478,6 +478,8 @@ struct common_params {
 
     // margin per device in bytes for fitting parameters to free memory:
     std::vector<size_t> fit_params_target = std::vector<size_t>(llama_max_devices(), 1024 * 1024*1024);
+    // bytes-per-ctx overhead per device for fitting parameters to free memory:
+    std::vector<size_t> fit_params_overhead_per_ctx = std::vector<size_t>(llama_max_devices(), 0);
 
     enum llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER; // how to split the model across GPUs
     enum llama_load_mode  load_mode  = LLAMA_LOAD_MODE_MMAP; // how to load the model

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -175,7 +175,8 @@ common_device_memory_data_vec common_get_device_memory_data(
 static void common_params_fit_impl(
         const char * path_model, struct llama_model_params * mparams, struct llama_context_params * cparams,
         float * tensor_split, struct llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins_s, uint32_t n_ctx_min, enum ggml_log_level log_level) {
+        const size_t * margins_base_s, const size_t * margins_per_ctx_s, uint32_t n_ctx_min, 
+        enum ggml_log_level log_level) {
     if (mparams->split_mode == LLAMA_SPLIT_MODE_TENSOR) {
         throw common_params_fit_exception("llama_params_fit is not implemented for SPLIT_MODE_TENSOR, abort");
     }
@@ -194,13 +195,23 @@ static void common_params_fit_impl(
     const dmds_t dmds_full = common_get_device_memory_data_impl(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
     const size_t nd = devs.size(); // number of devices
 
-    std::vector<int64_t> margins; // this function uses int64_t rather than size_t for memory sizes to more conveniently handle deficits
-    margins.reserve(nd);
+    std::vector<int64_t> margins_base; // this function uses int64_t rather than size_t for memory sizes to more conveniently handle deficits
+    margins_base.reserve(nd);
     if (nd == 0) {
-        margins.push_back(margins_s[0]);
+        margins_base.push_back(margins_base_s[0]);
     } else {
         for (size_t id = 0; id < nd; id++) {
-            margins.push_back(margins_s[id]);
+            margins_base.push_back(margins_base_s[id]);
+        }
+    }
+
+    std::vector<int64_t> margins_per_ctx;
+    margins_per_ctx.reserve(nd);
+    if (nd == 0) {
+        margins_per_ctx.push_back(margins_per_ctx_s ? margins_per_ctx_s[0] : 0);
+    } else {
+        for (size_t id = 0; id < nd; id++) {
+            margins_per_ctx.push_back(margins_per_ctx_s ? margins_per_ctx_s[id] : 0);
         }
     }
 
@@ -228,15 +239,18 @@ static void common_params_fit_impl(
     std::vector<int64_t> projected_free_per_device;
     projected_free_per_device.reserve(nd);
 
+    // n_ctx used by initial measurement
+    const uint32_t n_ctx_initial = cparams->n_ctx == 0 ? hp_nct : cparams->n_ctx;
+
     if (nd == 0) {
-        sum_projected_used = dmds_full.back().mb.total();
+        sum_projected_used = dmds_full.back().mb.total() + margins_per_ctx.back() * n_ctx_initial;
         sum_free           = dmds_full.back().total;
         sum_projected_free = sum_free - sum_projected_used;
         LOG_TRC("%s: projected to use %" PRId64 " MiB of host memory vs. %" PRId64 " MiB of total host memory\n",
             __func__, sum_projected_used/MiB, sum_free/MiB);
-        if (sum_projected_free >= margins[0]) {
+        if (sum_projected_free >= margins_base[0]) {
             LOG_TRC("%s: will leave %" PRId64 " >= %" PRId64 " MiB of system memory, no changes needed\n",
-                __func__, sum_projected_free/MiB, margins[0]/MiB);
+                __func__, sum_projected_free/MiB, margins_base[0]/MiB);
             return;
         }
     } else {
@@ -246,7 +260,7 @@ static void common_params_fit_impl(
         for (size_t id = 0; id < nd; id++) {
             const llama_device_memory_data & dmd = dmds_full[id];
 
-            const int64_t projected_used = dmd.mb.total();
+            const int64_t projected_used = dmd.mb.total() + margins_per_ctx[id] * n_ctx_initial;
             const int64_t projected_free = dmd.free - projected_used;
             projected_free_per_device.push_back(projected_free);
 
@@ -257,22 +271,22 @@ static void common_params_fit_impl(
 
             if (nd > 1) {
                 LOG_TRC("%s:   - %s: %6" PRId64 " total, %6" PRId64 " used, %6" PRId64 " free vs. target of %6" PRId64 "\n",
-                    __func__, dev_names[id].c_str(), dmd.total/MiB, projected_used/MiB, projected_free/MiB, margins[id]/MiB);
+                    __func__, dev_names[id].c_str(), dmd.total/MiB, projected_used/MiB, projected_free/MiB, margins_base[id]/MiB);
             }
         }
         assert(sum_free >= 0 && sum_projected_used >= 0);
         LOG_TRC("%s: projected to use %" PRId64 " MiB of device memory vs. %" PRId64 " MiB of free device memory\n",
             __func__, sum_projected_used/MiB, sum_free/MiB);
         if (nd == 1) {
-            if (projected_free_per_device[0] >= margins[0]) {
+            if (projected_free_per_device[0] >= margins_base[0]) {
                 LOG_TRC("%s: will leave %" PRId64 " >= %" PRId64 " MiB of free device memory, no changes needed\n",
-                    __func__, projected_free_per_device[0]/MiB, margins[0]/MiB);
+                    __func__, projected_free_per_device[0]/MiB, margins_base[0]/MiB);
                 return;
             }
         } else {
             bool changes_needed = false;
             for (size_t id = 0; id < nd; id++) {
-                if (projected_free_per_device[id] < margins[id]) {
+                if (projected_free_per_device[id] < margins_base[id]) {
                     changes_needed = true;
                     break;
                 }
@@ -289,16 +303,16 @@ static void common_params_fit_impl(
     {
         int64_t global_surplus = sum_projected_free;
         if (nd == 0) {
-            global_surplus -= margins[0];
+            global_surplus -= margins_base[0];
         } else {
             for (size_t id = 0; id < nd; id++) {
-                global_surplus -= margins[id];
+                global_surplus -= margins_base[id];
             }
         }
         if (global_surplus < 0) {
             if (nd <= 1) {
                 LOG_TRC("%s: cannot meet free memory target of %" PRId64 " MiB, need to reduce device memory by %" PRId64 " MiB\n",
-                    __func__, margins[0]/MiB, -global_surplus/MiB);
+                    __func__, margins_base[0]/MiB, -global_surplus/MiB);
             } else {
                 LOG_TRC(
                     "%s: cannot meet free memory targets on all devices, need to use %" PRId64 " MiB less in total\n",
@@ -308,10 +322,10 @@ static void common_params_fit_impl(
                 if (hp_nct > n_ctx_min) {
                     int64_t sum_used_target = sum_free;
                     if (nd == 0) {
-                        sum_used_target -= margins[0];
+                        sum_used_target -= margins_base[0];
                     } else {
                         for (size_t id = 0; id < nd; id++) {
-                            sum_used_target -= margins[id];
+                            sum_used_target -= margins_base[id];
                         }
                     }
                     if (nd > 1) {
@@ -328,10 +342,12 @@ static void common_params_fit_impl(
                     cparams->n_ctx = n_ctx_min;
                     const dmds_t dmds_min_ctx = common_get_device_memory_data_impl(path_model, mparams, cparams, devs, hp_ngl, hp_nct, hp_nex, log_level);
                     if (nd == 0) {
-                        sum_projected_used_min_ctx = dmds_min_ctx.back().mb.total();
+                        sum_projected_used_min_ctx = dmds_min_ctx.back().mb.total() 
+                            + margins_per_ctx.back() * n_ctx_min;
                     } else {
                         for (size_t id = 0; id < nd; id++) {
-                            sum_projected_used_min_ctx += dmds_min_ctx[id].mb.total();
+                            sum_projected_used_min_ctx += dmds_min_ctx[id].mb.total()
+                                + margins_per_ctx[id] * n_ctx_min;
                         }
                     }
                     if (sum_used_target > sum_projected_used_min_ctx) {
@@ -537,7 +553,7 @@ static void common_params_fit_impl(
 
         for (size_t id = 0; id < nd; id++) {
             global_surplus_cpu_moe += dmds_cpu_moe[id].free;
-            global_surplus_cpu_moe -= int64_t(dmds_cpu_moe[id].mb.total()) + margins[id];
+            global_surplus_cpu_moe -= int64_t(dmds_cpu_moe[id].mb.total()) + margins_base[id];
         }
 
         if (global_surplus_cpu_moe > 0) {
@@ -556,7 +572,7 @@ static void common_params_fit_impl(
     std::vector<int64_t> targets; // maximum acceptable memory use per device
     targets.reserve(nd);
     for (size_t id = 0; id < nd; id++) {
-        targets.push_back(dmds_full[id].free - margins[id]);
+        targets.push_back(dmds_full[id].free - margins_base[id] - margins_per_ctx[id] * cparams->n_ctx);
         LOG_TRC("%s: id=%zu, target=%" PRId64 " MiB\n", __func__, id, targets[id]/MiB);
     }
 
@@ -791,13 +807,14 @@ enum common_params_fit_status common_fit_params(
         llama_context_params * cparams,
         float * tensor_split,
         llama_model_tensor_buft_override * tensor_buft_overrides,
-        size_t * margins,
+        size_t * margins_base,
+        size_t * margins_per_ctx,
         uint32_t n_ctx_min,
         ggml_log_level log_level) {
     const int64_t t0_us = llama_time_us();
     common_params_fit_status status = COMMON_PARAMS_FIT_STATUS_SUCCESS;
     try {
-        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins, n_ctx_min, log_level);
+        common_params_fit_impl(path_model, mparams, cparams, tensor_split, tensor_buft_overrides, margins_base, margins_per_ctx, n_ctx_min, log_level);
         LOG_TRC("%s: successfully fit params to free device memory\n", __func__);
     } catch (const common_params_fit_exception & e) {
         LOG_WRN("%s: failed to fit params to free device memory: %s\n", __func__, e.what());

--- a/common/fit.h
+++ b/common/fit.h
@@ -20,11 +20,12 @@ common_params_fit_status common_fit_params(
                          const char * path_model,
                  llama_model_params * mparams,
                llama_context_params * cparams,
-                              float * tensor_split,          // writable buffer for tensor split, needs at least llama_max_devices elements
-   llama_model_tensor_buft_override * tensor_buft_overrides, // writable buffer for overrides, needs at least llama_max_tensor_buft_overrides elements
-                             size_t * margins,               // margins of memory to leave per device in bytes
-                           uint32_t   n_ctx_min,             // minimum context size to set when trying to reduce memory use
-                     ggml_log_level   log_level);            // minimum log level to print during fitting, lower levels go to debug log
+                              float * tensor_split,                // writable buffer for tensor split, needs at least llama_max_devices elements
+   llama_model_tensor_buft_override * tensor_buft_overrides,       // writable buffer for overrides, needs at least llama_max_tensor_buft_overrides elements
+                             size_t * margins_base,                // margins of memory to leave per device in bytes
+                             size_t * margins_per_ctx,             // margins of memory to leave per-device in bytes per ctx
+                           uint32_t   n_ctx_min,                   // minimum context size to set when trying to reduce memory use
+                     ggml_log_level   log_level);                  // minimum log level to print during fitting, lower levels go to debug log 
 
 // print estimated memory to stdout
 void common_fit_print(

--- a/tools/fit-params/fit-params.cpp
+++ b/tools/fit-params/fit-params.cpp
@@ -32,7 +32,8 @@ int llama_fit_params(int argc, char ** argv) {
 
     if (!params.fit_params_print) {
         const common_params_fit_status status = common_fit_params(params.model.path.c_str(), &mparams, &cparams,
-                params.tensor_split, params.tensor_buft_overrides.data(), params.fit_params_target.data(), params.fit_params_min_ctx,
+                params.tensor_split, params.tensor_buft_overrides.data(), params.fit_params_target.data(), 
+                params.fit_params_overhead_per_ctx.data(), params.fit_params_min_ctx,
                 params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
         if (status != COMMON_PARAMS_FIT_STATUS_SUCCESS) {
             LOG_ERR("%s: failed to fit CLI arguments to free memory, exiting...\n", __func__);

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2282,7 +2282,8 @@ int llama_bench(int argc, char ** argv) {
             mparams.tensor_buft_overrides = fit_overrides.data();
             cparams.n_ctx                 = 0;
 
-            std::vector<size_t> margins(llama_max_devices(), inst.fit_target * 1024 * 1024);
+            std::vector<size_t> margins_base(llama_max_devices(), inst.fit_target * 1024 * 1024);
+            std::vector<size_t> margins_per_ctx(llama_max_devices(), 0);
 
             uint32_t n_ctx_needed = inst.n_prompt + inst.n_gen + inst.n_depth;
             cparams.n_ctx = std::max(cparams.n_ctx, n_ctx_needed);
@@ -2290,7 +2291,8 @@ int llama_bench(int argc, char ** argv) {
             common_fit_params(inst.model.c_str(), &mparams, &cparams,
                 fit_tensor_split.data(),
                 fit_overrides.data(),
-                margins.data(),
+                margins_base.data(),
+                margins_per_ctx.data(),
                 inst.fit_min_ctx,
                 params.verbose ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
        }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1146,7 +1146,8 @@ private:
                         devs, hp_ngl, hp_nct, hp_nex, GGML_LOG_LEVEL_ERROR);
 
                     GGML_ASSERT(!params_base.fit_params_target.empty());
-                    size_t total = 0;
+                    GGML_ASSERT(!params_base.fit_params_overhead_per_ctx.empty());
+                    size_t total_fixed = 0;
 
                     std::vector<ggml_backend_dev_t> tgt_devices = params.devices;
 
@@ -1156,21 +1157,29 @@ private:
                         }
                     }
 
+                    const uint32_t n_ctx_spec = cparams_dft.n_ctx == 0 ? hp_nct : cparams_dft.n_ctx;
+                    GGML_ASSERT(n_ctx_spec != 0);
+
+                    // calculate spec footprint as a fixed portion and a ctx-dependent portion
                     for (size_t j = 0; j < devs.size(); ++j) {
-                        const size_t bytes = (measure_model_bytes ? dmd[j].model : 0) + dmd[j].context + dmd[j].compute;
-                        total += bytes;
+                        const size_t fixed   = (measure_model_bytes ? dmd[j].model : 0) + dmd[j].compute;
+                        const size_t per_ctx = dmd[j].context / n_ctx_spec;
+                        total_fixed += fixed;
                         for (size_t i = 0; i < tgt_devices.size(); i++) {
                             if (tgt_devices[i] == devs[j]) {
-                                SRV_DBG("[spec] adding %.2f MiB to fit_params_target for device %s\n",
-                                        bytes / (1024.0 * 1024.0), ggml_backend_dev_name(devs[j]));
-                                params_base.fit_params_target[i] += bytes;
+                                SRV_DBG("[spec] adding %.2f MiB (fixed) + %.2f MiB/ctx to fit_params for device %s\n",
+                                        fixed   / (1024.0 * 1024.0),
+                                        per_ctx / (1024.0 * 1024.0),
+                                        ggml_backend_dev_name(devs[j]));
+                                params_base.fit_params_target[i]           += fixed;
+                                params_base.fit_params_overhead_per_ctx[i] += per_ctx;
                                 break;
                             }
                         }
                     }
-                    SRV_TRC("[spec] estimated memory usage of %s is %.2f MiB\n",
+                    SRV_TRC("[spec] estimated fixed memory usage of %s is %.2f MiB\n",
                             has_draft ? "draft model" : "MTP context",
-                            total / (1024.0 * 1024.0));
+                            total_fixed / (1024.0 * 1024.0));
                 } catch (const std::exception & e) {
                     SRV_WRN("[spec] failed to measure %s memory: %s\n",
                             has_draft ? "draft model" : "MTP context", e.what());

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1160,10 +1160,21 @@ private:
                     const uint32_t n_ctx_spec = cparams_dft.n_ctx == 0 ? hp_nct : cparams_dft.n_ctx;
                     GGML_ASSERT(n_ctx_spec != 0);
 
-                    // calculate spec footprint as a fixed portion and a ctx-dependent portion
+                    const bool fa_on = cparams_dft.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED;
+
+                    // estimate the per_ctx portion of the compute buffer according the attention input mask
+                    // built for each layer, which has dimensions n_ctx * n_ubatch.
+                    const size_t mask_per_ctx = cparams_dft.n_ubatch * (fa_on ? 2 : 4);
+                    const size_t mask_at_spec = mask_per_ctx * n_ctx_spec;
+
                     for (size_t j = 0; j < devs.size(); ++j) {
-                        const size_t fixed   = (measure_model_bytes ? dmd[j].model : 0) + dmd[j].compute;
-                        const size_t per_ctx = dmd[j].context / n_ctx_spec;
+                        const size_t compute_fixed = dmd[j].compute > mask_at_spec
+                            ? dmd[j].compute - mask_at_spec
+                            : 0;
+
+                        // calculate spec footprint as a fixed portion and a ctx-dependent portion
+                        const size_t fixed   = (measure_model_bytes ? dmd[j].model : 0) + compute_fixed;
+                        const size_t per_ctx = (dmd[j].context / n_ctx_spec) + mask_per_ctx;
                         total_fixed += fixed;
                         for (size_t i = 0; i < tgt_devices.size(); i++) {
                             if (tgt_devices[i] == devs[j]) {


### PR DESCRIPTION
## Overview

When running with `--fit-params` enabled and without specifying a `--ctx-size`, `load_model` overestimates the memory footprint of any draft/mtp context. It uses `n_ctx_train` to estimate speculative context size, rather than the actual context size. This is due to the fact that `n_ctx` is not determined until after the main model fit is run.

As a result, speculative contexts take up more VRAM than they should. On my 32 GB machine, I found that `--fit-params` was overestimating qwen3.6's MTP context by ~500 MiB.

Fixes #25408 

## Additional information

In this PR:
- a helper method now splits speculative context fit into two parts: a fixed component, and a per-ctx component
- the main model fit now uses the per-ctx overhead when calculating n_ctx
- n_ctx is now persisted after main model fit and used to init speculative context

**Results** I ran the same command on both master and this branch:

`llama-server -m Qwen3.6-27B-UD-Q4_K_XL --fit-target 512 --n-gpu-layers 999 -b 4096 -ub 1024 -np 1 --spec-type draft-mtp --spec-draft-n-max 2`

* On master: fit gives `n_ctx: 184320`
* On my branch: fit gives `n_ctx: 190464`

Server log outputs from both runs show that the speculative model is now initialized with the correct context, whereas on master it's initialized with n_ctx_train:

```ini
# MASTER
I common_speculative_init_result: creating MTP draft context against the target model '/home/fox/kitsu/models/qwen3.6-dense-mtp/Qwen3.6-27B-UD-Q4_K_XL.gguf'
I llama_context: constructing llama_context
I llama_context: n_seq_max     = 1
I llama_context: n_ctx         = 262144
I llama_context: n_ctx_seq     = 262144
I llama_context: n_batch       = 4096
I llama_context: n_ubatch      = 1024
I llama_context: causal_attn   = 1
I llama_context: flash_attn    = enabled
I llama_context: kv_unified    = false
I llama_context: freq_base     = 10000000.0
I llama_context: freq_scale    = 1
I llama_context: n_rs_seq      = 0
I llama_context: n_outputs_max = 1
I llama_context:  CUDA_Host  output buffer size =     0.95 MiB
I llama_kv_cache:      CUDA0 KV buffer size =  1024.00 MiB
I llama_kv_cache: size = 1024.00 MiB (262144 cells,   1 layers,  1/1 seqs), K (f16):  512.00 MiB, V (f16):  512.00 MiB
I llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
I llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
I sched_reserve: reserving ...
I resolve_fused_ops: resolving fused Gated Delta Net support:
I resolve_fused_ops: fused Gated Delta Net (autoregressive) enabled
I resolve_fused_ops: fused Gated Delta Net (chunked) enabled
I sched_reserve:      CUDA0 compute buffer size =   648.03 MiB
I sched_reserve:  CUDA_Host compute buffer size =   552.04 MiB
I sched_reserve: graph nodes  = 50
I sched_reserve: graph splits = 2
I sched_reserve: reserve took 119.12 ms, sched copies = 1
```

```ini
# FIX
I common_speculative_init_result: creating MTP draft context against the target model '/home/fox/kitsu/models/qwen3.6-dense-mtp/Qwen3.6-27B-UD-Q4_K_XL.gguf'
I llama_context: constructing llama_context
I llama_context: n_seq_max     = 1
I llama_context: n_ctx         = 190464
I llama_context: n_ctx_seq     = 190464
I llama_context: n_batch       = 4096
I llama_context: n_ubatch      = 1024
I llama_context: causal_attn   = 1
I llama_context: flash_attn    = enabled
I llama_context: kv_unified    = false
I llama_context: freq_base     = 10000000.0
I llama_context: freq_scale    = 1
I llama_context: n_rs_seq      = 0
I llama_context: n_outputs_max = 1
I llama_context: n_ctx_seq (190464) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
I llama_context:  CUDA_Host  output buffer size =     0.95 MiB
I llama_kv_cache:      CUDA0 KV buffer size =   744.00 MiB
I llama_kv_cache: size =  744.00 MiB (190464 cells,   1 layers,  1/1 seqs), K (f16):  372.00 MiB, V (f16):  372.00 MiB
I llama_kv_cache: attn_rot_k = 0, n_embd_head_k_all = 256
I llama_kv_cache: attn_rot_v = 0, n_embd_head_k_all = 256
I sched_reserve: reserving ...
I resolve_fused_ops: resolving fused Gated Delta Net support:
I resolve_fused_ops: fused Gated Delta Net (autoregressive) enabled
I resolve_fused_ops: fused Gated Delta Net (chunked) enabled
I sched_reserve:      CUDA0 compute buffer size =   508.03 MiB
I sched_reserve:  CUDA_Host compute buffer size =   412.04 MiB
I sched_reserve: graph nodes  = 50
I sched_reserve: graph splits = 2
I sched_reserve: reserve took 80.78 ms, sched copies = 1
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): yes
- AI usage disclosure: yes, I used GLM 5.2 for a first pass at these changes. The fix ended up being more complex than I anticipated, so I reviewed and reimplemented it all myself.