### PR TITLE
vulkan: fix perf logger crash on multi-GPU layer split, label timings by device

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1941,7 +1941,7 @@ static uint64_t ggml_vk_get_node_flops(const ggml_tensor * node) {
 
 class vk_perf_logger {
   public:
-    void print_timings(bool force = false) {
+    void print_timings(const char * device_name = nullptr, bool force = false) {
         if (timings.empty()) {
             return;
         }
@@ -1951,7 +1951,7 @@ class vk_perf_logger {
         }
         print_count = 0;
         uint64_t total_all_op_times = 0;
-        std::cerr << "----------------\nVulkan Timings:" << std::endl;
+        std::cerr << "----------------\nVulkan Timings (" << (device_name ? device_name : "unknown device") << "):" << std::endl;
         for (const auto & t : timings) {
             uint64_t total_op_times = 0;
             for (const auto & time : t.second) {
@@ -15137,7 +15137,7 @@ static void ggml_vk_cleanup(ggml_backend_vk_context * ctx) {
         ctx->transfer_cmd_pool.destroy(ctx->device->device);
     }
     if (vk_perf_logger_enabled) {
-        ctx->perf_logger->print_timings(true);
+        ctx->perf_logger->print_timings(ctx->device->name.c_str(), true);
     }
 }
 
@@ -16281,6 +16281,12 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         std::fill(ctx->query_nodes.begin(), ctx->query_nodes.end(), nullptr);
         std::fill(ctx->query_node_idx.begin(), ctx->query_node_idx.end(), 0);
 
+        // A compute context can be left open by an async cross-device tensor
+        // copy (multi-GPU split). The logger needs the graph in a fresh
+        // command buffer for the timestamp queries, so flush it first.
+        if (!ctx->compute_ctx.expired()) {
+            ggml_vk_synchronize(ctx);
+        }
         GGML_ASSERT(ctx->compute_ctx.expired());
         compute_ctx = ggml_vk_get_compute_ctx(ctx);
         ctx->query_idx = 0;
@@ -16617,7 +16623,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
                 ctx->perf_logger->log_timing(nodes, names, uint64_t((timestamps[i] - timestamps[i-1]) * ctx->device->properties.limits.timestampPeriod));
             }
         }
-        ctx->perf_logger->print_timings();
+        ctx->perf_logger->print_timings(ctx->device->name.c_str());
     }
 
     if (!ctx->device->support_async) {


### PR DESCRIPTION
## Problem

`GGML_VK_PERF_LOGGER=1` aborts on any multi-GPU `--tensor-split` run:

```
ggml/src/ggml-vulkan/ggml-vulkan.cpp:16284: GGML_ASSERT(ctx->compute_ctx.expired()) failed
```

An async cross-device tensor copy (`ggml_vk_cpy_tensor_async`, scheduled between graph splits) can leave a compute context open when the next `graph_compute` for that device begins. The perf-logger entry path asserts that no context exists, because it needs the whole graph in one fresh command buffer for its timestamp queries — so the logger is unusable exactly in the multi-GPU case where per-device timing data is most interesting. Single-GPU profiling is unaffected, which is presumably why this hasn't been hit much.

## Fix

1. In the perf-logger path of `ggml_vk_graph_compute`, if a compute context is still open, flush it via `ggml_vk_synchronize` before starting the timestamped command buffer. Non-logger runs are untouched.
2. While in there: print the device name in each `Vulkan Timings:` block header (`Vulkan Timings (Vulkan0):`), so multi-GPU output can be attributed. With two devices, the interleaved unlabeled blocks were otherwise guesswork.

## Testing

- Hardware: AMD RX 9070 XT (RDNA4, gfx1201) + RX 6700 XT (RDNA2, gfx1031), RADV (Mesa 26.1), Linux.
- Repro: `GGML_VK_PERF_LOGGER=1 ./llama-bench -m <model> -ngl 99 -ts 14/6 -fa 1 -p 512 -n 32`
  - Before: aborts with the assert on the first graph compute after a cross-device copy (100% reproducible).
  - After: full run completes; timing blocks print per device, e.g.
    ```
    Vulkan Timings (Vulkan0):
    MUL_MAT q4_K m=17408 n=256 k=5120: 94 x 1120.11 us = 105291 us (40736.6 GFLOPS/s)
    ...
    Vulkan Timings (Vulkan1):
    MUL_MAT q4_K m=17408 n=256 k=5120: 34 x 2562.3 us = 87118.2 us (17808.1 GFLOPS/s)
    ```
- Single-GPU (`GGML_VK_VISIBLE_DEVICES=0`) perf-logger runs still work; `test-backend-ops -b Vulkan0 -o MUL_MAT` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
