### PR TITLE
ggml-cuda : optimize mmvq nwarps for Pascal DP4A

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -63,6 +63,7 @@ static constexpr __host__ __device__ int get_vdr_mmvq(ggml_type type) {
 
 enum mmvq_parameter_table_id {
     MMVQ_PARAMETERS_GENERIC = 0,
+    MMVQ_PARAMETERS_PASCAL_DP4A,
     MMVQ_PARAMETERS_TURING,
     MMVQ_PARAMETERS_GCN,
     MMVQ_PARAMETERS_RDNA2,
@@ -81,6 +82,8 @@ static constexpr __device__ mmvq_parameter_table_id get_device_table_id() {
     return MMVQ_PARAMETERS_GCN;
 #elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_TURING && __CUDA_ARCH__ < GGML_CUDA_CC_AMPERE
     return MMVQ_PARAMETERS_TURING;
+#elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_DP4A && __CUDA_ARCH__ < GGML_CUDA_CC_VOLTA
+    return MMVQ_PARAMETERS_PASCAL_DP4A;
 #else
     return MMVQ_PARAMETERS_GENERIC;
 #endif
@@ -99,8 +102,12 @@ static __host__ mmvq_parameter_table_id get_device_table_id(int cc) {
     if (GGML_CUDA_CC_IS_GCN(cc) || GGML_CUDA_CC_IS_CDNA(cc)) {
         return MMVQ_PARAMETERS_GCN;
     }
-    if (GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_TURING && ggml_cuda_highest_compiled_arch(cc) < GGML_CUDA_CC_AMPERE) {
+    const int arch = ggml_cuda_highest_compiled_arch(cc);
+    if (GGML_CUDA_CC_IS_NVIDIA(cc) && arch >= GGML_CUDA_CC_TURING && arch < GGML_CUDA_CC_AMPERE) {
         return MMVQ_PARAMETERS_TURING;
+    }
+    if (GGML_CUDA_CC_IS_NVIDIA(cc) && arch >= GGML_CUDA_CC_DP4A && arch < GGML_CUDA_CC_VOLTA) {
+        return MMVQ_PARAMETERS_PASCAL_DP4A;
     }
     return MMVQ_PARAMETERS_GENERIC;
 }
@@ -350,7 +357,11 @@ static constexpr __device__ int get_mmvq_mmid_max_batch_for_device() {
 }
 
 static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_dst, mmvq_parameter_table_id table_id) {
-    if (table_id == MMVQ_PARAMETERS_GENERIC) {
+    if (table_id == MMVQ_PARAMETERS_GENERIC || table_id == MMVQ_PARAMETERS_PASCAL_DP4A) {
+        // Pascal cc 6.1/6.2 decode is bandwidth-bound on small SMs: 2 warps beat 4 for single-token.
+        if (table_id == MMVQ_PARAMETERS_PASCAL_DP4A && ncols_dst == 1) {
+            return 2;
+        }
         switch (ncols_dst) {
             case 1:
             case 2:
@@ -456,7 +467,7 @@ static constexpr __host__ __device__ int calc_nwarps(ggml_type type, int ncols_d
 }
 
 static constexpr __host__ __device__ int calc_rows_per_block(int ncols_dst, int table_id, bool small_k = false, int nwarps = 1) {
-    if (table_id == MMVQ_PARAMETERS_GENERIC || table_id == MMVQ_PARAMETERS_GCN || table_id == MMVQ_PARAMETERS_TURING) {
+    if (table_id == MMVQ_PARAMETERS_GENERIC || table_id == MMVQ_PARAMETERS_PASCAL_DP4A || table_id == MMVQ_PARAMETERS_GCN || table_id == MMVQ_PARAMETERS_TURING) {
         switch (ncols_dst) {
             case 1:
                 return small_k ? nwarps : 1;


### PR DESCRIPTION
## Overview

Adds a dedicated MMVQ parameter table for Pascal DP4A GPUs (compute capability 6.1 / 6.2 -GTX 10xx, P40, P4) and tunes the warp count for single-token decode.

Previously these cards fell through to `MMVQ_PARAMETERS_GENERIC`. This PR introduces `MMVQ_PARAMETERS_PASCAL_DP4A`, selected for NVIDIA archs in `[DP4A, VOLTA)` on both the device and host table-id paths, and for `ncols_dst == 1` (single-token decode) uses **2 warps instead of 4**. Pascal decode is memory-bandwidth-bound on these small SMs, so the extra warps add scheduling/occupancy pressure without helping throughput. Batched decode and prefill keep the generic behaviour and are unchanged.

Measured **+2.5% to +5.4%** single-token decode across quants (geomean **+3.07%**) on a GTX 1060 6GB, with no measurable prefill regression.

## Additional information

Benchmarked rigorously, both coverage and depth with a self-contained script that builds `HEAD~1` (baseline) and `HEAD` (this PR) into separate binaries and runs `llama-bench` alternating between them across 6 iterations. Consumer Pascal can't lock clocks (`nvidia-smi -lgc`), so I report the **paired per-iteration delta**, which cancels thermal/boost drift; `t` is the paired t-statistic of the per-iteration Δ%. GTX 1060 6GB (CC 6.1), Llama-3.2-3B-Instruct.

**Decode (tg) -  the mmvq path this PR changes** (`-p 0 -n 128 -ngl 99 -r 10`)

| quant  | baseline t/s | patched t/s | mean Δ  | paired σ% | t     | pairs up |
|--------|--------------|-------------|---------|-----------|-------|----------|
| Q4_0   | 49.41        | 51.68       | +4.59%  | 0.45%     | 25.00 | 6/6      |
| Q4_K_M | 43.49        | 45.85       | +5.44%  | 0.38%     | 34.74 | 6/6      |
| Q5_K_M | 39.92        | 41.22       | +3.24%  | 0.33%     | 23.80 | 6/6      |
| Q8_0   | 32.62        | 33.43       | +2.48%  | 0.53%     | 11.56 | 6/6      |
| Q6_K   | 34.10        | 33.99       | -0.32%  | 0.56%     | -1.41 | 2/6      |

Geomean **+3.07%**. Q6_K is within noise. An earlier independent 10-iteration run reproduced these to within ~0.2% (geomean +3.08%).

**Prefill (pp) -  MMQ path, no-regression control (expected ~0%)** -  two prompt lengths and two `-ub` batch sizes; all rows flat:

| quant  | config      | baseline t/s | patched t/s | mean Δ  | paired σ% | t     | pairs up |
|--------|-------------|--------------|-------------|---------|-----------|-------|----------|
| Q4_0   | pp512       | 950.77       | 950.19      | -0.06%  | 0.52%     | -0.27 | 3/6      |
| Q4_K_M | pp512       | 825.24       | 838.80      | +1.64%  | 4.25%     | 1.03  | 3/6      |
| Q5_K_M | pp512       | 812.26       | 811.70      | -0.07%  | 0.19%     | -0.88 | 2/6      |
| Q8_0   | pp512       | 873.82       | 874.03      | +0.02%  | 0.20%     | 0.30  | 3/6      |
| Q6_K   | pp512       | 770.35       | 770.46      | +0.01%  | 0.23%     | 0.15  | 4/6      |
| Q4_0   | pp512_ub128 | 946.72       | 946.95      | +0.02%  | 0.18%     | 0.34  | 3/6      |
| Q4_K_M | pp512_ub128 | 801.61       | 799.35      | -0.28%  | 0.90%     | -0.94 | 2/6      |
| Q5_K_M | pp512_ub128 | 807.51       | 806.92      | -0.07%  | 0.16%     | -1.09 | 2/6      |
| Q8_0   | pp512_ub128 | 865.61       | 867.55      | +0.22%  | 0.17%     | 3.26  | 5/6      |
| Q6_K   | pp512_ub128 | 765.39       | 765.17      | -0.03%  | 0.08%     | -0.83 | 3/6      |
| Q4_0   | pp2048      | 835.78       | 833.94      | -0.22%  | 0.95%     | -0.56 | 2/6      |
| Q4_K_M | pp2048      | 748.45       | 748.56      | +0.02%  | 0.61%     | 0.07  | 3/6      |
| Q5_K_M | pp2048      | 725.78       | 725.93      | +0.02%  | 0.54%     | 0.10  | 3/6      |
| Q8_0   | pp2048      | 773.93       | 773.75      | -0.02%  | 0.71%     | -0.07 | 3/6      |
| Q6_K   | pp2048      | 692.05       | 692.68      | +0.09%  | 0.56%     | 0.41  | 4/6      |

(The Q4_K_M pp512 `+1.64%` is noise -  σ=4.25%, t=1.03, and the same quant's other prefill configs are flat.)

Benchmark script (builds both commits itself; point `MODELS`/`MODEL_DIR` at your GGUFs and run `./bench-pascal-mmvq.sh`): https://pastebin.com/he3WzqjG

## Requirements
- I have read and agree with the [contributing guidelines.](https://github.com/ggmlorg/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, codex only helped write the benchmarking script, the entire diff itself is handwritten. The source change is my own, from conception to verification and benchmarking methodology.
