### PR TITLE
mtmd: dsocr-tiles fixes

### DIFF
--- a/tools/mtmd/models/deepseekocr.cpp
+++ b/tools/mtmd/models/deepseekocr.cpp
@@ -320,9 +320,7 @@ ggml_cgraph * clip_graph_deepseekocr::build() {
         // add CLS token per batch item
         // inp: [n_embd, clip_n_patches, n_batch]
         // class_embedding: [n_embd] -> [n_embd, 1, n_batch]
-        ggml_tensor * cls_embd = ggml_reshape_3d(ctx0, model.class_embedding, n_embd, 1, 1);
-        ggml_tensor * cls_target = ggml_new_tensor_3d(ctx0, model.class_embedding->type, n_embd, 1, n_batch);
-        cls_embd = ggml_repeat(ctx0, cls_embd, cls_target);
+        ggml_tensor * cls_embd = ggml_repeat_4d(ctx0, model.class_embedding, n_embd, 1, n_batch, 1);
         inp = ggml_concat(ctx0, cls_embd, inp, 1);
 
         // for selecting learned pos embd, used by ViT

--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -1204,7 +1204,6 @@ mtmd_image_preproc_out mtmd_image_preprocessor_deepseekocr::preprocess(const cli
                     }
                 }
                 output.append(hparams, row_img, true);
-                grid_w = 1; // reset grid_w to 1 since we fused the row
             } else {
                 for (int col = 0; col < grid_w; col++) {
                     clip_image_u8 tile;
@@ -1212,6 +1211,9 @@ mtmd_image_preproc_out mtmd_image_preprocessor_deepseekocr::preprocess(const cli
                     output.append(hparams, tile, true);
                 }
             }
+        }
+        if (fuse_row) {
+            grid_w = 1; // each fused row is one image; a single output column
         }
     }
 

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -1170,12 +1170,6 @@ struct mtmd_tokenizer {
                     cur.entries.emplace_back(std::move(ov_chunk));
                     add_text(ctx->tok_ov_img_end);
                 }
-
-                if (!ctx->img_end.empty()) {
-                    // add image end token (currently only used by deepseekocr)
-                    add_text(ctx->img_end, true);
-                }
-
             } else {
 
                 if (preproc_out.entries.size() == 0) {


### PR DESCRIPTION
- ds-ocr img-preproc fuse_row tile-drop fix for multi rows and columns images
- mtmd drop the duplicate redundant img_end
- deepseekocr graph simplify CLS broadcast cleanup

AI usage disclosure: YES - I used AI assistance for code review, debugging, implementation checks, and testing. I have reviewed the submitted changes and take responsibility for the full contents of this PR.
