### PR TITLE
webui: pre-select models in the webui using alias

### DIFF
--- a/tools/ui/src/lib/stores/models.svelte.ts
+++ b/tools/ui/src/lib/stores/models.svelte.ts
@@ -629,7 +629,12 @@ class ModelsStore {
 	}
 
 	findModelByName(modelName: string): ModelOption | null {
-		return this.models.find((model) => model.model === modelName) ?? null;
+		return (
+			this.models.find(
+				(model) =>
+					model.model === modelName || model.id === modelName || model.aliases?.includes(modelName)
+			) ?? null
+		);
 	}
 
 	findModelById(modelId: string): ModelOption | null {


### PR DESCRIPTION
## Overview

You are now able to pre-select models in the webui using a model alias. Before this PR, we only supported `?model=[id]`, where the `[id]` is the model id. Now we are also able to use it like this: `?model=[alias]`.

Solves #24902 

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
