### PR TITLE
Disable `-ffast-math` on HIP

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -158,5 +158,3 @@ if (GGML_HIP_RCCL)
 endif()
 
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
-
-target_compile_options(ggml-hip PRIVATE "$<$<COMPILE_LANGUAGE:HIP>:-ffast-math;-fno-finite-math-only>")


### PR DESCRIPTION
## Overview

Effectively reverts #23862 and #25373 since #24668 was now added to do effectively the same thing without problems.  `bin/test-backend-ops -o EXPM1` finally passes
```console
  13674/13674 tests passed
  Backend ROCm0: OK
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- [X] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
-  AI usage disclosure: no