### PR TITLE
llama-cli: fix crash on wrong server base url

### DIFF
--- a/tools/cli/cli-context.cpp
+++ b/tools/cli/cli-context.cpp
@@ -157,18 +157,12 @@ bool cli_context::init() {
             if (!list_and_ask_models()) {
                 return false;
             }
-        } catch (const std::runtime_error & e) {
-            ui::show_error(e.what());
-            return false;
         } catch (const json::parse_error & e) {
             ui::show_error(e.what());
             ui::show_message("This might be caused by an incorrect server-base endpoint URL");
             return false;
         } catch (const std::exception & e) {
             ui::show_error(e.what());
-            return false;
-        } catch (...) {
-            ui::show_error("unrecognized issue has occurred");
             return false;
         }
 

--- a/tools/cli/cli-context.cpp
+++ b/tools/cli/cli-context.cpp
@@ -153,9 +153,25 @@ bool cli_context::init() {
 
     if (use_external_server) {
         spinner.reset();
-        if (!list_and_ask_models()) {
+        try {
+            if (!list_and_ask_models()) {
+                return false;
+            }
+        } catch (const std::runtime_error & e) {
+            ui::show_error(e.what());
+            return false;
+        } catch (const json::parse_error & e) {
+            ui::show_error(e.what());
+            ui::show_message("This might be caused by an incorrect server-base endpoint URL");
+            return false;
+        } catch (const std::exception & e) {
+            ui::show_error(e.what());
+            return false;
+        } catch (...) {
+            ui::show_error("unrecognized issue has occurred");
             return false;
         }
+
         // restore the spinner for the next step
         spinner.emplace("Waiting for server...");
     }


### PR DESCRIPTION
… by catching exceptions and graceful exit

## Overview
catching exceptions on wrong server base url, avoid crash

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
