### PR TITLE
arg: Flush log before exiting after usage()

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1071,6 +1071,7 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
             if (ctx_arg.print_usage) {
                 ctx_arg.print_usage(argc, argv);
             }
+            common_log_flush(common_log_main());
             exit(0);
         }
         if (ctx_arg.params.completion) {


### PR DESCRIPTION
## Overview

Under certain conditions, it's possible for messages emitted via LOG() to get lost before exit, apparently because they are emitted by some worker thread, and there is a race. common_params_print_usage() uses printf directly, so its messages are always printed.

Flushing the log before exit seems to resolve this.

## Additional information

Discovered by a reproducible builds host, where the output of eg: `llama-tts -h` always showed the common arguments, but on arm64 sometimes (non-deterministically) left out the tool-specific usage messages:

```c
static void print_usage(int, char ** argv) {
    LOG("\nexample usage:\n");
    LOG("\n    %s -m model.gguf -p \"Hello!\"\n", argv[0]);
    LOG("\n");
}
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, llama.cpp + Qwen3.6-27B

Qwen3.6-27B was used to diagnose the problem.