### PR TITLE
Placed MMA gateway over WMMA gateway

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -500,6 +500,12 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         return BEST_FATTN_KERNEL_MMA_F16;
     }
 
+    // AMD WMMA is always faster than the tile kernel if the full tile width of 16 can be utilized.
+    // MMA path is always faster than WMMA path when headsize allows for it.
+    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 128) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
+        return BEST_FATTN_KERNEL_MMA_F16;
+    }
+
     // Use the WMMA kernel if possible:
     if (ggml_cuda_should_use_wmma_fattn(cc) && K->ne[1] % FATTN_KQ_STRIDE == 0 && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[0] != 192 && Q->ne[0] != 512 && Q->ne[0] != 576) {
         if (can_use_vector_kernel && Q->ne[1] <= 2) {
@@ -519,11 +525,6 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         if ((Q->ne[0] <= 256 && Q->ne[1] * gqa_ratio_eff > 64)) {
             return BEST_FATTN_KERNEL_MMA_F16;
         }
-    }
-
-    // AMD WMMA is always faster than the tile kernel if the full tile width of 16 can be utilized.
-    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 128) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
-        return BEST_FATTN_KERNEL_MMA_F16;
     }
 
     // If there are no tensor cores available, use the generic tile kernel:


### PR DESCRIPTION
## Overview
<!-- Describe what this PR does and why. Be concise but complete -->
When the build parameter `GGML_HIP_ROCWMMA_FATTN=ON` is added, it forces all fast attention kernel pathways to `BEST_FATTN_KERNEL_WMMA_F16` given a large enough batch size, and applicable head sizes (else we fall back to `VEC` or `TILE`). However, the `BEST_FATTN_KERNEL_MMA_F16` path is faster for models with head sizes <=128 as seen in the two benchmark tests performed on RDNA3 and RDNA4 below.

This patch fixes two things in one.
1. By checking if the `MMA` path is applicable and trying it out before `WMMA`, performance for models with head sizes <= 128 improves.
2. Allows `GGML_HIP_ROCWMMA_FATTN` to follow its definition in [CMakeLists.txt](https://github.com/ggml-org/llama.cpp/blob/049326a00025d00b08cc188ed716b681e984a3f8/ggml/CMakeLists.txt#L219) more tightly.

## Additional information
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
Benchmarking using two `llama-bench` run lines
```
./llama-bench -m <model> -ngl 99 -pg 512,128 -fa 1
./llama-bench -m <model> -p 4096,8192 -n 128 -b 2048,4096 -ngl 99 -fa 1
```
Using the following build line for both before and after patch.
```cmake -B build -G Ninja \
  -DGGML_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx1201 \
  -DCMAKE_PREFIX_PATH="$DEVEL" -DCMAKE_HIP_COMPILER="$DEVEL/lib/llvm/bin/amdclang++" \
  -DLLAMA_CURL=OFF -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=OFF \
  -DGGML_HIP_ROCWMMA_FATTN=ON
```
Tables below show % difference in tok/s from pre-patch to post-patch.
### RDNA4 Benchmark
<img width="1005" height="270" alt="image" src="https://github.com/user-attachments/assets/30f0d27e-3879-4ff0-b358-4e331c1ec67e" />

### GGML_HIP_ROCWMMA_FATTN Definition
In [CMakeLists.txt](https://github.com/ggml-org/llama.cpp/blob/049326a00025d00b08cc188ed716b681e984a3f8/ggml/CMakeLists.txt#L219) it mentions 
```
option(GGML_HIP_ROCWMMA_FATTN               "ggml: enable rocWMMA for FlashAttention"         OFF)
```
This build parameter should just enable rocWMMA, not force rocWMMA. Before this patch, if the above build parameter is turned on, it forces the fattn kernel path to `WMMA` given a large enough batch size. However, with this patch, the compiler choses either `WMMA` or `MMA` path depending on which is fast for the given model. If the build parameter is off, this patch will not have an effect.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
