### PR TITLE
vocab : validate special-token ids against vocab size (fix OOB read in llama_vocab::impl::load)

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -2520,14 +2520,23 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             int32_t & id = std::get<1>(it);
 
             uint32_t new_id;
-            if (!ml.get_key(std::get<0>(it), new_id, false)) {
-                continue;
+            if (ml.get_key(std::get<0>(it), new_id, false)) {
+                if (new_id >= id_to_token.size()) {
+                    LLAMA_LOG_WARN("%s: bad special token: '%s' = %u, using default id %d\n",
+                        __func__, key.c_str(), new_id, id);
+                } else {
+                    id = new_id;
+                }
             }
-            if (new_id >= id_to_token.size()) {
-                LLAMA_LOG_WARN("%s: bad special token: '%s' = %u, using default id %d\n",
-                    __func__, key.c_str(), new_id, id);
-            } else {
-                id = new_id;
+
+            // The default id (used when the key is absent, or when an explicit id is out of range)
+            // is otherwise never validated against the vocab size. An out-of-range default reaches
+            // id_to_token[id] below (e.g. the special_eog_ids loop) as an out-of-bounds access.
+            // Disable the special token if its resolved id is out of range.
+            if (id != LLAMA_TOKEN_NULL && (size_t) id >= id_to_token.size()) {
+                LLAMA_LOG_WARN("%s: special token '%s' id %d is out of vocab range (size %zu), disabling\n",
+                    __func__, key.c_str(), id, id_to_token.size());
+                id = LLAMA_TOKEN_NULL;
             }
         }
 


### PR DESCRIPTION
### Summary

A default special-token id can be used as an out-of-bounds index into `id_to_token` during vocab load, causing a heap-buffer-overflow read.

This is the `load()`-path sibling of **GHSA-g4cc-763q-h9h6**, whose fix ([`c33fe8b8`](https://github.com/ggml-org/llama.cpp/commit/c33fe8b8), #14145) hardened only `print_info()` (switching to `.at()`). The identical unchecked primitive remains in `llama_vocab::impl::load()`.

### Root cause

Each special token gets a per-tokenizer **default** id (e.g. `special_eos_id = 2` for `llama`/SPM, `11` for `gpt2`). The clamp loop in `llama_vocab::impl::load()` only bounds-checks an id when its KV key is **present**:

```cpp
if (!ml.get_key(std::get<0>(it), new_id, false)) {
    continue;                 // key absent -> default id never checked
}
if (new_id >= id_to_token.size()) { /* keep default (also unchecked) */ }
```

`id_to_token` is sized to `n_tokens = gguf_get_arr_n(tokenizer.ggml.tokens)`, which the file controls. If the file declares a tiny vocab and omits the `*_id` key, the default id (e.g. 2) is never re-validated. It then flows into `special_eog_ids` and is dereferenced with a raw `operator[]` in the "printing all EOG tokens" loop:

```cpp
for (auto tid : special_eog_ids) {
    auto & text = id_to_token[tid].text;   // OOB read when tid >= id_to_token.size()
    ... text.c_str() ...
}
```

### Reproduce

A GGUF with a 2-token `llama` vocab and no `tokenizer.ggml.eos_token_id` key:

```python
# poc.py — needs the repo's gguf-py
import gguf, numpy as np
w = gguf.GGUFWriter("oob_read_poc.gguf", "llama")
w.add_context_length(64); w.add_embedding_length(16); w.add_block_count(1)
w.add_feed_forward_length(32); w.add_head_count(2); w.add_head_count_kv(2)
w.add_layer_norm_rms_eps(1e-5)
w.add_tokenizer_model("llama")            # default special_eos_id == 2
w.add_token_list(["a", "b"])              # id_to_token.size() == 2
w.add_token_scores([0.0, 0.0]); w.add_token_types([1, 1])
# tokenizer.ggml.eos_token_id intentionally OMITTED
w.add_tensor("token_embd.weight", np.zeros((16, 2), dtype=np.float32))
w.write_header_to_file(); w.write_kv_data_to_file(); w.write_tensors_to_file(); w.close()
```

```
cmake -B build -DLLAMA_SANITIZE_ADDRESS=ON && cmake --build build -j --target llama-cli
python3 poc.py
./build/bin/llama-cli -m oob_read_poc.gguf -p x -n 1
# => AddressSanitizer: heap-buffer-overflow  READ of size 8  in llama_vocab::impl::load
```

### Fix

After resolving each special-token id (default or explicit), validate it against `id_to_token.size()` and disable it (`LLAMA_TOKEN_NULL`) if out of range. Valid models are unaffected. With this change the PoC model loads cleanly.

### Impact

Out-of-bounds heap read during model load → crash (DoS) when loading an untrusted GGUF; the OOB `std::string` deref can additionally read adjacent heap. Covered scope (`src/**`). Severity comparable to the sibling GHSA-g4cc (Medium).
