### PR TITLE
model : reject n_layer > LLAMA_MAX_LAYERS (fix OOB write in set_swa_pattern)

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1068,6 +1068,15 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ATTENTION_CAUSAL,        hparams.causal_attn,     false);
     ml.get_key(LLM_KV_POOLING_TYPE,            hparams.pooling_type,    false);
     ml.get_key(LLM_KV_BLOCK_COUNT,             hparams.n_layer_all);
+
+    // n_layer_all drives writes into fixed-size per-layer arrays (std::array<..., LLAMA_MAX_LAYERS>,
+    // e.g. is_swa_impl in set_swa_pattern). Reject a model that declares more layers than those
+    // arrays hold, otherwise an out-of-range block_count causes an out-of-bounds write during load.
+    if (hparams.n_layer_all > LLAMA_MAX_LAYERS) {
+        throw std::runtime_error(format("invalid n_layer = %u (exceeds LLAMA_MAX_LAYERS = %d)",
+            hparams.n_layer_all, LLAMA_MAX_LAYERS));
+    }
+
     ml.get_key(LLM_KV_EXPERT_COUNT,            hparams.n_expert,        false);
     ml.get_key(LLM_KV_EXPERT_USED_COUNT,       hparams.n_expert_used,   false);
     ml.get_key(LLM_KV_EXPERT_GROUP_COUNT,      hparams.n_expert_groups, false);


### PR DESCRIPTION
### Summary

`n_layer_all` (from GGUF `block_count`) is never bounded against `LLAMA_MAX_LAYERS` (512), but drives writes into fixed-size `std::array<..., LLAMA_MAX_LAYERS>` per-layer arrays. On a full load of a sliding-window-attention arch (gemma2/gemma3/gemma-embedding/olmo2/cohere2/exaone4/…), `llama_hparams::set_swa_pattern` writes `is_swa_impl[il]` for `il < n_layer()`, so `block_count > 512` causes an out-of-bounds heap write during model load.

### Root cause

`src/llama-model.cpp` reads block_count with no ceiling; `is_swa_impl` is a fixed `std::array<uint32_t, LLAMA_MAX_LAYERS>`; `set_swa_pattern` loops over `n_layer()` (== `n_layer_all`) and writes into it:

```cpp
for (uint32_t il = 0; il < n_layer(); ++il) {
    is_swa_impl[il] = ...;   // OOB write when n_layer_all > 512
}
```

The generic `get_key_or_arr(FEED_FORWARD_LENGTH / HEAD_COUNT, …, n_layer())` calls throw on `n > 512` only when those keys are *present*; omitting them lets an out-of-range `n_layer` reach `set_swa_pattern`. (The bug requires a full load, not `vocab_only`, since `set_swa_pattern` lives in the arch subclass.)

### Reproduce

```python
# poc.py — needs the repo's gguf-py
import gguf, numpy as np
w = gguf.GGUFWriter("swa_oob_poc.gguf", "gemma2")
w.add_block_count(100000)   # >> LLAMA_MAX_LAYERS (512)
w.add_context_length(64); w.add_embedding_length(16); w.add_layer_norm_rms_eps(1e-5)
w.add_tokenizer_model("llama"); w.add_token_list(["a","b","c","d"])
w.add_token_scores([0.0]*4); w.add_token_types([1]*4)
w.add_bos_token_id(1); w.add_eos_token_id(2)
w.write_header_to_file(); w.write_kv_data_to_file(); w.write_tensors_to_file(); w.close()
```

```
cmake -B build -DLLAMA_SANITIZE_ADDRESS=ON && cmake --build build -j --target llama-cli
python3 poc.py
./build/bin/llama-cli -m swa_oob_poc.gguf -p x -n 1
# => AddressSanitizer: heap-buffer-overflow  WRITE of size 4  in llama_hparams::set_swa_pattern
```

### Fix

Reject `n_layer_all > LLAMA_MAX_LAYERS` right after reading block_count — one check covers every fixed-`LLAMA_MAX_LAYERS`-array write. With the patch the PoC model is cleanly rejected; `block_count <= 512` models are unaffected.

### Impact

Out-of-bounds heap write on load of an untrusted GGUF (SWA arch). Write length is attacker-controlled via `block_count`; large → crash (DoS), moderate (513…) → corrupts adjacent `llama_hparams` state. In-process threat model (Ollama / llama-cpp-python / LM Studio). Scope `src/**`.
