### PR TITLE
[BufFix] Fix HunyuanVL XD-RoPE config handling during conversion.

### DIFF
--- a/conversion/hunyuan.py
+++ b/conversion/hunyuan.py
@@ -337,6 +337,12 @@ class HunyuanVLTextModel(HunYuanModel):
 
     def __init__(self, dir_model: Path, *args, **kwargs):
         super().__init__(dir_model, *args, **kwargs)
+        # transformers 5.13.0 encodes HunyuanVL XD-RoPE as dynamic + mrope_section.
+        # Normalize it to avoid the HunYuan dynamic-RoPE context assertion.
+        if self.rope_parameters.get("rope_type") == "dynamic" and "mrope_section" in self.rope_parameters:
+            self.rope_parameters["rope_type"] = "xdrope"
+            self.rope_parameters["type"] = "xdrope"
+            self.rope_parameters["xdrope_section"] = list(self.rope_parameters["mrope_section"])
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()


### PR DESCRIPTION
## Summary

Fix HunyuanVL XD-RoPE config handling during conversion.

`transformers 5.13.0` may encode HunyuanVL XD-RoPE as `dynamic` RoPE with `mrope_section`. This change normalizes it back to `xdrope` before writing GGUF metadata, avoiding the Hunyuan dynamic-RoPE context assertion.

## Changes

- Detect `dynamic` RoPE with `mrope_section` for HunyuanVL
- Normalize it to `xdrope`
- Preserve `mrope_section` as `xdrope_section`

## Testing

Converted HunyuanVL/HunyuanOCR config path without hitting the dynamic-RoPE context assertion.


## Model Weights

- v1.5: https://huggingface.co/tencent/HunyuanOCR
- v1.0: https://huggingface.co/tencent/HunyuanOCR/tree/main/v1.0


<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
