### PR TITLE
server : prevent LRU eviction of models still loading

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -751,6 +751,9 @@ void server_models::unload_lru() {
         for (const auto & m : mapping) {
             if (m.second.meta.is_running()) {
                 count_active++;
+                if (m.second.meta.status == SERVER_MODEL_STATUS_LOADING) {
+                    continue;
+                }
                 if (m.second.meta.last_used < lru_last_used) {
                     lru_model_name = m.first;
                     lru_last_used = m.second.meta.last_used;


### PR DESCRIPTION
## Overview

In router mode with `models_max`, `unload_lru()` could select a model in `LOADING` state as the LRU victim. Because the child's stdin monitoring thread starts only after model loading completes, the exit command sits unread in the buffer and the `stop_timeout` expires before the child ever receives it, causing a force-kill.

LOADING models still count toward capacity to prevent resource exhaustion from concurrent loads, but are excluded from eviction.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.6-27B