### PR TITLE
webui: parse effective-parameter sizes (E2B, E4B) as params

### DIFF
--- a/tools/ui/src/lib/constants/model-id.ts
+++ b/tools/ui/src/lib/constants/model-id.ts
@@ -24,8 +24,10 @@ export const MODEL_CUSTOM_QUANTIZATION_PREFIX_RE = /^UD$/i;
 
 /**
  * Matches a parameter-count segment, e.g. `7B`, `1.5b`, `120M`.
+ * The optional leading `E` covers effective-parameter sizes, e.g. Gemma's
+ * `E2B`/`E4B` (MatFormer models sized by resident params).
  */
-export const MODEL_PARAMS_RE = /^\d+(\.\d+)?[BbMmKkTt]$/;
+export const MODEL_PARAMS_RE = /^[Ee]?\d+(\.\d+)?[BbMmKkTt]$/;
 
 /**
  * Matches an activated-parameter-count segment, e.g. `A10B`, `a2.4b`.

--- a/tools/ui/tests/unit/model-id-parser.test.ts
+++ b/tools/ui/tests/unit/model-id-parser.test.ts
@@ -36,6 +36,11 @@ describe('parseModelId', () => {
 		expect(parseModelId('model-100b:q4_k_m')).toMatchObject({ params: '100B' });
 	});
 
+	it('extracts effective parameters correctly', () => {
+		expect(parseModelId('model-E4B-BF16')).toMatchObject({ params: 'E4B' });
+		expect(parseModelId('model-e2b:q4_k_m')).toMatchObject({ params: 'E2B' });
+	});
+
 	it('extracts activated parameters correctly', () => {
 		expect(parseModelId('model-100B-A10B-BF16')).toMatchObject({ activatedParams: 'A10B' });
 		expect(parseModelId('model-100B-A10B:Q4_K_M')).toMatchObject({ activatedParams: 'A10B' });


### PR DESCRIPTION
Model ids like `ggml-org/gemma-3n-E4B-it-GGUF:Q8_0` currently render in the model selector as an unbroken name (`gemma-3n-E4B-it`), while sibling models with plain sizes (`gemma-4-31B-it`) get a params badge. `MODEL_PARAMS_RE` requires a leading digit, so effective-parameter sizes — Gemma's `E2B`/`E4B`, where `E` denotes effective parameters — fall through to the model name.

Accept an optional leading `E`/`e` in the params segment, analogous to how `MODEL_ACTIVATED_PARAMS_RE` already accepts the `A` prefix (`A3B`). `gemma-3n-E4B-it` now parses as name `gemma-3n`, params `E4B`, tag `it`.