### PR TITLE
Backend sampling multi output

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1639,7 +1639,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.n_seq_max         = params.n_parallel;
     cparams.n_rs_seq          = params.speculative.need_n_rs_seq();
     cparams.n_outputs_max     = std::max(params.n_outputs_max, 0);
-    cparams.n_sampling_outputs_per_seq_max = std::max(params.n_sampling_outputs_per_seq_max, 0);
+    cparams.n_outputs_max_per_seq = std::max(params.n_outputs_max_per_seq, 0);
     cparams.n_batch           = params.n_batch;
     cparams.n_ubatch          = params.n_ubatch;
     cparams.n_threads         = params.cpuparams.n_threads;

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1639,6 +1639,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.n_seq_max         = params.n_parallel;
     cparams.n_rs_seq          = params.speculative.need_n_rs_seq();
     cparams.n_outputs_max     = std::max(params.n_outputs_max, 0);
+    cparams.n_sampling_outputs_per_seq_max = std::max(params.n_sampling_outputs_per_seq_max, 0);
     cparams.n_batch           = params.n_batch;
     cparams.n_ubatch          = params.n_ubatch;
     cparams.n_threads         = params.cpuparams.n_threads;

--- a/common/common.h
+++ b/common/common.h
@@ -447,6 +447,7 @@ struct common_params {
     int32_t n_parallel            =     1; // number of parallel sequences to decode
     int32_t n_sequences           =     1; // number of sequences to decode
     int32_t n_outputs_max         =     0; // max outputs in a batch (0 = n_batch)
+    int32_t n_sampling_outputs_per_seq_max = 1; // max outputs per sequence with backend sampling
     int32_t grp_attn_n            =     1; // group-attention factor
     int32_t grp_attn_w            =   512; // group-attention width
     int32_t n_print               =    -1; // print token count every n tokens (-1 = disabled)

--- a/common/common.h
+++ b/common/common.h
@@ -447,7 +447,7 @@ struct common_params {
     int32_t n_parallel            =     1; // number of parallel sequences to decode
     int32_t n_sequences           =     1; // number of sequences to decode
     int32_t n_outputs_max         =     0; // max outputs in a batch (0 = n_batch)
-    int32_t n_sampling_outputs_per_seq_max = 1; // max outputs per sequence with backend sampling
+    int32_t n_outputs_max_per_seq =     1; // max outputs per sequence
     int32_t grp_attn_n            =     1; // group-attention factor
     int32_t grp_attn_w            =   512; // group-attention width
     int32_t n_print               =    -1; // print token count every n tokens (-1 = disabled)

--- a/common/llguidance.cpp
+++ b/common/llguidance.cpp
@@ -115,8 +115,8 @@ static llama_sampler_i llama_sampler_llg_i = {
     /* .backend_init      = */ NULL,
     /* .backend_accept    = */ NULL,
     /* .backend_apply     = */ NULL,
-    /* .backend_reset     = */ NULL,
     /* .backend_set_input = */ NULL,
+    /* .backend_reset     = */ NULL,
 };
 
 static size_t llama_sampler_llg_tokenize_fn(const void * user_data, const uint8_t * bytes, size_t bytes_len,

--- a/common/llguidance.cpp
+++ b/common/llguidance.cpp
@@ -115,6 +115,7 @@ static llama_sampler_i llama_sampler_llg_i = {
     /* .backend_init      = */ NULL,
     /* .backend_accept    = */ NULL,
     /* .backend_apply     = */ NULL,
+    /* .backend_reset     = */ NULL,
     /* .backend_set_input = */ NULL,
 };
 

--- a/common/llguidance.cpp
+++ b/common/llguidance.cpp
@@ -117,6 +117,7 @@ static llama_sampler_i llama_sampler_llg_i = {
     /* .backend_apply     = */ NULL,
     /* .backend_set_input = */ NULL,
     /* .backend_reset     = */ NULL,
+    /* .copy_state        = */ NULL,
 };
 
 static size_t llama_sampler_llg_tokenize_fn(const void * user_data, const uint8_t * bytes, size_t bytes_len,

--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -216,8 +216,8 @@ static struct llama_sampler_i common_reasoning_budget_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 static struct llama_sampler * common_reasoning_budget_clone(const struct llama_sampler * smpl) {

--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -216,6 +216,7 @@ static struct llama_sampler_i common_reasoning_budget_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 

--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -218,6 +218,7 @@ static struct llama_sampler_i common_reasoning_budget_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 static struct llama_sampler * common_reasoning_budget_clone(const struct llama_sampler * smpl) {

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -518,6 +518,26 @@ struct common_sampler * common_sampler_clone(common_sampler * gsmpl) {
     };
 }
 
+void common_sampler_copy(const common_sampler * src, common_sampler * dst) {
+    if (!src || !dst || src == dst) {
+        return;
+    }
+
+    GGML_ASSERT((src->grmr == nullptr) == (dst->grmr == nullptr));
+    GGML_ASSERT((src->rbudget == nullptr) == (dst->rbudget == nullptr));
+
+    llama_sampler_copy(src->grmr,    dst->grmr);
+    llama_sampler_copy(src->rbudget, dst->rbudget);
+    llama_sampler_copy(src->chain,   dst->chain);
+
+    dst->params     = src->params;
+    dst->prev       = src->prev;
+    dst->cur        = src->cur;
+    dst->cur_p      = src->cur_p;
+    dst->cur_p.data = src->cur_p.data ? dst->cur.data() : nullptr; // re-point to dst's buffer
+    dst->t_total_us = src->t_total_us;
+}
+
 void common_perf_print(const struct llama_context * ctx, const struct common_sampler * gsmpl) {
     // TODO: measure grammar performance
 

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -47,6 +47,7 @@ void common_sampler_free(struct common_sampler * gsmpl);
 void                    common_sampler_accept(struct common_sampler * gsmpl, llama_token token, bool is_generated);
 void                    common_sampler_reset (struct common_sampler * gsmpl);
 struct common_sampler * common_sampler_clone (struct common_sampler * gsmpl);
+void                    common_sampler_copy  (const struct common_sampler * src, struct common_sampler * dst);
 
 // arguments can be nullptr to skip printing
 void common_perf_print(const struct llama_context * ctx, const struct common_sampler * gsmpl);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2299,6 +2299,7 @@ common_params common_base_params_to_speculative(const common_params & params) {
     result.cache_type_k  = params_spec.cache_type_k;
     result.cache_type_v  = params_spec.cache_type_v;
     result.n_outputs_max = params.n_parallel;
+    result.n_sampling_outputs_per_seq_max = 1;
 
     return result;
 }
@@ -2384,14 +2385,15 @@ common_speculative_init_result_ptr common_speculative_init_from_params(common_pa
     return std::make_unique<common_speculative_init_result>(params, model_tgt, ctx_tgt);
 }
 
-int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, int32_t n_draft) {
-    const int64_t n_outputs = (int64_t) n_parallel * (1 + (int64_t) std::max(0, n_draft));
-    return std::min<int64_t>(n_batch, n_outputs);
-}
+common_speculative_output_limits common_speculative_get_output_limits(
+        int32_t n_batch, int32_t n_parallel, int32_t n_draft) {
+    const int64_t per_seq = 1 + (int64_t) std::max(0, n_draft);
+    const int64_t total   = (int64_t) n_parallel * per_seq;
 
-int32_t common_speculative_n_outputs_per_seq_max(int32_t n_batch, int32_t n_draft) {
-    const int64_t n_outputs = 1 + (int64_t) std::max(0, n_draft);
-    return std::min<int64_t>(n_batch, n_outputs);
+    return {
+        /* .total   = */ (int32_t) std::min<int64_t>(n_batch, total),
+        /* .per_seq = */ (int32_t) std::min<int64_t>(n_batch, per_seq),
+    };
 }
 
 // initialization of the speculative decoding system

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2382,6 +2382,11 @@ int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, in
     return std::min<int64_t>(n_batch, n_outputs);
 }
 
+int32_t common_speculative_n_outputs_per_seq_max(int32_t n_batch, int32_t n_draft) {
+    const int64_t n_outputs = 1 + (int64_t) std::max(0, n_draft);
+    return std::min<int64_t>(n_batch, n_outputs);
+}
+
 // initialization of the speculative decoding system
 //
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2389,6 +2389,11 @@ int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, in
     return std::min<int64_t>(n_batch, n_outputs);
 }
 
+int32_t common_speculative_n_outputs_per_seq_max(int32_t n_batch, int32_t n_draft) {
+    const int64_t n_outputs = 1 + (int64_t) std::max(0, n_draft);
+    return std::min<int64_t>(n_batch, n_outputs);
+}
+
 // initialization of the speculative decoding system
 //
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2299,7 +2299,7 @@ common_params common_base_params_to_speculative(const common_params & params) {
     result.cache_type_k  = params_spec.cache_type_k;
     result.cache_type_v  = params_spec.cache_type_v;
     result.n_outputs_max = params.n_parallel;
-    result.n_sampling_outputs_per_seq_max = 1;
+    result.n_outputs_max_per_seq = 1;
 
     return result;
 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2292,6 +2292,7 @@ common_params common_base_params_to_speculative(const common_params & params) {
     result.cache_type_k  = params_spec.cache_type_k;
     result.cache_type_v  = params_spec.cache_type_v;
     result.n_outputs_max = params.n_parallel;
+    result.n_sampling_outputs_per_seq_max = 1;
 
     return result;
 }
@@ -2377,14 +2378,15 @@ common_speculative_init_result_ptr common_speculative_init_from_params(common_pa
     return std::make_unique<common_speculative_init_result>(params, model_tgt, ctx_tgt);
 }
 
-int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, int32_t n_draft) {
-    const int64_t n_outputs = (int64_t) n_parallel * (1 + (int64_t) std::max(0, n_draft));
-    return std::min<int64_t>(n_batch, n_outputs);
-}
+common_speculative_output_limits common_speculative_get_output_limits(
+        int32_t n_batch, int32_t n_parallel, int32_t n_draft) {
+    const int64_t per_seq = 1 + (int64_t) std::max(0, n_draft);
+    const int64_t total   = (int64_t) n_parallel * per_seq;
 
-int32_t common_speculative_n_outputs_per_seq_max(int32_t n_batch, int32_t n_draft) {
-    const int64_t n_outputs = 1 + (int64_t) std::max(0, n_draft);
-    return std::min<int64_t>(n_batch, n_outputs);
+    return {
+        /* .total   = */ (int32_t) std::min<int64_t>(n_batch, total),
+        /* .per_seq = */ (int32_t) std::min<int64_t>(n_batch, per_seq),
+    };
 }
 
 // initialization of the speculative decoding system

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2377,6 +2377,11 @@ common_speculative_init_result_ptr common_speculative_init_from_params(common_pa
     return std::make_unique<common_speculative_init_result>(params, model_tgt, ctx_tgt);
 }
 
+int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, int32_t n_draft) {
+    const int64_t n_outputs = (int64_t) n_parallel * (1 + (int64_t) std::max(0, n_draft));
+    return std::min<int64_t>(n_batch, n_outputs);
+}
+
 // initialization of the speculative decoding system
 //
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2292,7 +2292,7 @@ common_params common_base_params_to_speculative(const common_params & params) {
     result.cache_type_k  = params_spec.cache_type_k;
     result.cache_type_v  = params_spec.cache_type_v;
     result.n_outputs_max = params.n_parallel;
-    result.n_sampling_outputs_per_seq_max = 1;
+    result.n_outputs_max_per_seq = 1;
 
     return result;
 }

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2384,6 +2384,11 @@ common_speculative_init_result_ptr common_speculative_init_from_params(common_pa
     return std::make_unique<common_speculative_init_result>(params, model_tgt, ctx_tgt);
 }
 
+int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, int32_t n_draft) {
+    const int64_t n_outputs = (int64_t) n_parallel * (1 + (int64_t) std::max(0, n_draft));
+    return std::min<int64_t>(n_batch, n_outputs);
+}
+
 // initialization of the speculative decoding system
 //
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq) {

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -25,11 +25,14 @@ int32_t common_speculative_n_max(const common_params_speculative * spec);
 
 common_params common_base_params_to_speculative(const common_params & params);
 
-// return the max number of outputs needed for speculative decoding
-int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, int32_t n_draft);
+struct common_speculative_output_limits {
+    int32_t total;
+    int32_t per_seq;
+};
 
-// return the max number of outputs per sequence needed for speculative decoding
-int32_t common_speculative_n_outputs_per_seq_max(int32_t n_batch, int32_t n_draft);
+// return the output limits needed for speculative decoding
+common_speculative_output_limits common_speculative_get_output_limits(
+        int32_t n_batch, int32_t n_parallel, int32_t n_draft);
 
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq);
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -28,6 +28,9 @@ common_params common_base_params_to_speculative(const common_params & params);
 // return the max number of outputs needed for speculative decoding
 int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, int32_t n_draft);
 
+// return the max number of outputs per sequence needed for speculative decoding
+int32_t common_speculative_n_outputs_per_seq_max(int32_t n_batch, int32_t n_draft);
+
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq);
 
 void common_speculative_free(common_speculative * spec);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -25,6 +25,9 @@ int32_t common_speculative_n_max(const common_params_speculative * spec);
 
 common_params common_base_params_to_speculative(const common_params & params);
 
+// return the max number of outputs needed for speculative decoding
+int32_t common_speculative_n_outputs_max(int32_t n_batch, int32_t n_parallel, int32_t n_draft);
+
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq);
 
 void common_speculative_free(common_speculative * spec);

--- a/docs/speculative.md
+++ b/docs/speculative.md
@@ -202,6 +202,12 @@ Example Video:
 
 If a draft model is combined with a draftless decoding the draftless decoding has higher precedence.
 
+### Backend Sampling
+
+Use `--backend-sampling` to run supported target-model samplers on the model backend. Draft-model sampling uses the backend by default and can be controlled with `--spec-draft-backend-sampling` and `--no-spec-draft-backend-sampling`.
+
+Unsupported samplers and device layouts fall back to CPU sampling. Tensor split mode does not support backend sampling. A fixed seed produces repeatable random draws, but stochastic CPU and backend sampling can still select different tokens because floating-point operations can differ between implementations and devices. Use greedy sampling when exact output matching is required.
+
 ### General Speculative Parameters
 
 ```

--- a/examples/lookup/lookup.cpp
+++ b/examples/lookup/lookup.cpp
@@ -30,6 +30,7 @@ int main(int argc, char ** argv){
     const int n_draft = params.speculative.draft.n_max;
 
     params.n_outputs_max = common_speculative_n_outputs_max(params.n_batch, params.n_parallel, n_draft);
+    params.n_sampling_outputs_per_seq_max = common_speculative_n_outputs_per_seq_max(params.n_batch, n_draft);
 
     // init llama.cpp
     llama_backend_init();

--- a/examples/lookup/lookup.cpp
+++ b/examples/lookup/lookup.cpp
@@ -3,9 +3,11 @@
 #include "common.h"
 #include "ngram-cache.h"
 #include "sampling.h"
+#include "speculative.h"
 #include "log.h"
 #include "llama.h"
 
+#include <algorithm>
 #include <clocale>
 #include <cstdint>
 #include <cstdio>
@@ -26,6 +28,8 @@ int main(int argc, char ** argv){
 
     // max. number of additional tokens to draft if match is found
     const int n_draft = params.speculative.draft.n_max;
+
+    params.n_outputs_max = common_speculative_n_outputs_max(params.n_batch, params.n_parallel, n_draft);
 
     // init llama.cpp
     llama_backend_init();

--- a/examples/lookup/lookup.cpp
+++ b/examples/lookup/lookup.cpp
@@ -29,8 +29,9 @@ int main(int argc, char ** argv){
     // max. number of additional tokens to draft if match is found
     const int n_draft = params.speculative.draft.n_max;
 
-    params.n_outputs_max = common_speculative_n_outputs_max(params.n_batch, params.n_parallel, n_draft);
-    params.n_sampling_outputs_per_seq_max = common_speculative_n_outputs_per_seq_max(params.n_batch, n_draft);
+    const auto output_limits = common_speculative_get_output_limits(params.n_batch, params.n_parallel, n_draft);
+    params.n_outputs_max = output_limits.total;
+    params.n_sampling_outputs_per_seq_max = output_limits.per_seq;
 
     // init llama.cpp
     llama_backend_init();

--- a/examples/lookup/lookup.cpp
+++ b/examples/lookup/lookup.cpp
@@ -31,7 +31,7 @@ int main(int argc, char ** argv){
 
     const auto output_limits = common_speculative_get_output_limits(params.n_batch, params.n_parallel, n_draft);
     params.n_outputs_max = output_limits.total;
-    params.n_sampling_outputs_per_seq_max = output_limits.per_seq;
+    params.n_outputs_max_per_seq = output_limits.per_seq;
 
     // init llama.cpp
     llama_backend_init();

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -32,6 +32,8 @@ int main(int argc, char ** argv) {
 
     params.n_outputs_max = common_speculative_n_outputs_max(
             params.n_batch, params.n_parallel, common_speculative_n_max(&params.speculative));
+    params.n_sampling_outputs_per_seq_max = common_speculative_n_outputs_per_seq_max(
+            params.n_batch, common_speculative_n_max(&params.speculative));
 
     // init llama.cpp
     llama_backend_init();
@@ -58,6 +60,9 @@ int main(int argc, char ** argv) {
         const auto & params_spec = params.speculative.draft;
 
         auto params_dft = params;
+
+        params_dft.n_outputs_max = params.n_parallel;
+        params_dft.n_sampling_outputs_per_seq_max = 1;
 
         params_dft.devices      = params_spec.devices;
         params_dft.model        = params_spec.mparams;

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -5,6 +5,7 @@
 #include "log.h"
 #include "llama.h"
 
+#include <algorithm>
 #include <clocale>
 #include <cstdio>
 #include <cstring>
@@ -28,6 +29,9 @@ int main(int argc, char ** argv) {
         LOG_ERR("%s: --n-predict must be >= -1\n", __func__);
         return 1;
     }
+
+    params.n_outputs_max = common_speculative_n_outputs_max(
+            params.n_batch, params.n_parallel, common_speculative_n_max(&params.speculative));
 
     // init llama.cpp
     llama_backend_init();

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -30,10 +30,10 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    params.n_outputs_max = common_speculative_n_outputs_max(
+    const auto output_limits = common_speculative_get_output_limits(
             params.n_batch, params.n_parallel, common_speculative_n_max(&params.speculative));
-    params.n_sampling_outputs_per_seq_max = common_speculative_n_outputs_per_seq_max(
-            params.n_batch, common_speculative_n_max(&params.speculative));
+    params.n_outputs_max = output_limits.total;
+    params.n_sampling_outputs_per_seq_max = output_limits.per_seq;
 
     // init llama.cpp
     llama_backend_init();

--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -33,7 +33,7 @@ int main(int argc, char ** argv) {
     const auto output_limits = common_speculative_get_output_limits(
             params.n_batch, params.n_parallel, common_speculative_n_max(&params.speculative));
     params.n_outputs_max = output_limits.total;
-    params.n_sampling_outputs_per_seq_max = output_limits.per_seq;
+    params.n_outputs_max_per_seq = output_limits.per_seq;
 
     // init llama.cpp
     llama_backend_init();
@@ -62,7 +62,7 @@ int main(int argc, char ** argv) {
         auto params_dft = params;
 
         params_dft.n_outputs_max = params.n_parallel;
-        params_dft.n_sampling_outputs_per_seq_max = 1;
+        params_dft.n_outputs_max_per_seq = 1;
 
         params_dft.devices      = params_spec.devices;
         params_dft.model        = params_spec.mparams;

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -58,10 +58,10 @@ int main(int argc, char ** argv) {
     // max number of parallel drafting sequences (i.e. tree branches)
     const int n_seq_dft = params.n_parallel;
 
-    params.n_outputs_max = common_speculative_n_outputs_max(
+    const auto output_limits = common_speculative_get_output_limits(
             params.n_batch, params.n_parallel, params.speculative.draft.n_max);
-    params.n_sampling_outputs_per_seq_max = common_speculative_n_outputs_per_seq_max(
-            params.n_batch, params.speculative.draft.n_max);
+    params.n_outputs_max = output_limits.total;
+    params.n_sampling_outputs_per_seq_max = output_limits.per_seq;
 
     // probability threshold for splitting a draft branch (only for n_seq_dft > 1)
     const float p_draft_split = params.speculative.draft.p_split;

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -1,6 +1,7 @@
 #include "arg.h"
 #include "common.h"
 #include "sampling.h"
+#include "speculative.h"
 #include "log.h"
 #include "llama.h"
 
@@ -56,6 +57,9 @@ int main(int argc, char ** argv) {
 
     // max number of parallel drafting sequences (i.e. tree branches)
     const int n_seq_dft = params.n_parallel;
+
+    params.n_outputs_max = common_speculative_n_outputs_max(
+            params.n_batch, params.n_parallel, params.speculative.draft.n_max);
 
     // probability threshold for splitting a draft branch (only for n_seq_dft > 1)
     const float p_draft_split = params.speculative.draft.p_split;

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -60,6 +60,8 @@ int main(int argc, char ** argv) {
 
     params.n_outputs_max = common_speculative_n_outputs_max(
             params.n_batch, params.n_parallel, params.speculative.draft.n_max);
+    params.n_sampling_outputs_per_seq_max = common_speculative_n_outputs_per_seq_max(
+            params.n_batch, params.speculative.draft.n_max);
 
     // probability threshold for splitting a draft branch (only for n_seq_dft > 1)
     const float p_draft_split = params.speculative.draft.p_split;
@@ -87,6 +89,8 @@ int main(int argc, char ** argv) {
     params.devices = params.speculative.draft.devices;
     params.model = params.speculative.draft.mparams;
     params.n_gpu_layers = params.speculative.draft.n_gpu_layers;
+    params.n_outputs_max = params.n_parallel;
+    params.n_sampling_outputs_per_seq_max = 1;
     if (params.speculative.draft.cpuparams.n_threads > 0) {
         params.cpuparams.n_threads = params.speculative.draft.cpuparams.n_threads;
     }

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv) {
     const auto output_limits = common_speculative_get_output_limits(
             params.n_batch, params.n_parallel, params.speculative.draft.n_max);
     params.n_outputs_max = output_limits.total;
-    params.n_sampling_outputs_per_seq_max = output_limits.per_seq;
+    params.n_outputs_max_per_seq = output_limits.per_seq;
 
     // probability threshold for splitting a draft branch (only for n_seq_dft > 1)
     const float p_draft_split = params.speculative.draft.p_split;
@@ -90,7 +90,7 @@ int main(int argc, char ** argv) {
     params.model = params.speculative.draft.mparams;
     params.n_gpu_layers = params.speculative.draft.n_gpu_layers;
     params.n_outputs_max = params.n_parallel;
-    params.n_sampling_outputs_per_seq_max = 1;
+    params.n_outputs_max_per_seq = 1;
     if (params.speculative.draft.cpuparams.n_threads > 0) {
         params.cpuparams.n_threads = params.speculative.draft.cpuparams.n_threads;
     }

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -805,11 +805,14 @@ static void ggml_gallocr_alloc_graph_impl(ggml_gallocr_t galloc, struct ggml_cgr
                 if (ggml_impl_is_view(parent)) {
                     struct ggml_tensor * view_src = parent->view_src;
                     struct hash_node * view_src_hn = ggml_gallocr_hash_get(galloc, view_src);
-                    view_src_hn->n_views -= 1;
-                    AT_PRINTF("view_src %s: %d children, %d views\n",
-                        view_src->name, view_src_hn->n_children, view_src_hn->n_views);
-                    if (view_src_hn->n_views == 0 && view_src_hn->n_children == 0 && view_src_hn->allocated) {
-                        ggml_gallocr_free_node(galloc, view_src);
+                    // output views keep their source alive until graph completion
+                    if (!(parent->flags & GGML_TENSOR_FLAG_OUTPUT)) {
+                        view_src_hn->n_views -= 1;
+                        AT_PRINTF("view_src %s: %d children, %d views\n",
+                            view_src->name, view_src_hn->n_children, view_src_hn->n_views);
+                        if (view_src_hn->n_views == 0 && view_src_hn->n_children == 0 && view_src_hn->allocated) {
+                            ggml_gallocr_free_node(galloc, view_src);
+                        }
                     }
                 }
                 else if (p_hn->allocated) {

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -805,14 +805,11 @@ static void ggml_gallocr_alloc_graph_impl(ggml_gallocr_t galloc, struct ggml_cgr
                 if (ggml_impl_is_view(parent)) {
                     struct ggml_tensor * view_src = parent->view_src;
                     struct hash_node * view_src_hn = ggml_gallocr_hash_get(galloc, view_src);
-                    // output views keep their source alive until graph completion
-                    if (!(parent->flags & GGML_TENSOR_FLAG_OUTPUT)) {
-                        view_src_hn->n_views -= 1;
-                        AT_PRINTF("view_src %s: %d children, %d views\n",
-                            view_src->name, view_src_hn->n_children, view_src_hn->n_views);
-                        if (view_src_hn->n_views == 0 && view_src_hn->n_children == 0 && view_src_hn->allocated) {
-                            ggml_gallocr_free_node(galloc, view_src);
-                        }
+                    view_src_hn->n_views -= 1;
+                    AT_PRINTF("view_src %s: %d children, %d views\n",
+                        view_src->name, view_src_hn->n_children, view_src_hn->n_views);
+                    if (view_src_hn->n_views == 0 && view_src_hn->n_children == 0 && view_src_hn->allocated) {
+                        ggml_gallocr_free_node(galloc, view_src);
                     }
                 }
                 else if (p_hn->allocated) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -1274,7 +1274,7 @@ extern "C" {
         // [EXPERIMENTAL]
         // backend sampling interface:
 
-        // return true if the backend supports all ops needed by the sampler and the requested output mode
+        // return true if the backend supports all ops needed by the sampler and can handle up to n_outputs_per_seq_max outputs per sequence
         // note: call once per sampler
         bool (*backend_init)(
                 struct llama_sampler       * smpl,
@@ -1298,7 +1298,7 @@ extern "C" {
         // called before graph execution to set inputs for the current ubatch
         void (*backend_set_input)(struct llama_sampler * smpl);
 
-        // called before rebuilding a sampling graph to clear graph-owned tensor references
+        // called before rebuilding a sampling graph to clear any internal sampler state
         void (*backend_reset)(struct llama_sampler * smpl);
     };
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -1270,9 +1270,12 @@ extern "C" {
         // [EXPERIMENTAL]
         // backend sampling interface:
 
-        // return true if the backend supports all ops needed by the sampler
+        // return true if the backend supports all ops needed by the sampler and the requested output mode
         // note: call once per sampler
-        bool (*backend_init)(struct llama_sampler * smpl, ggml_backend_buffer_type_t buft);
+        bool (*backend_init)(
+                struct llama_sampler       * smpl,
+                ggml_backend_buffer_type_t   buft,
+                bool                         require_multi_output);
 
         // call after .backend_apply()
         void (*backend_accept)(
@@ -1287,6 +1290,9 @@ extern "C" {
                 struct ggml_context       * ctx,
                 struct ggml_cgraph        * gf,
                 struct llama_sampler_data * data);
+
+        // called before rebuilding a sampling graph to clear graph-owned tensor references
+        void (*backend_reset)(struct llama_sampler * smpl);
 
         // called before graph execution to set inputs for the current ubatch
         void (*backend_set_input)(struct llama_sampler * smpl);

--- a/include/llama.h
+++ b/include/llama.h
@@ -1055,6 +1055,8 @@ extern "C" {
     //
 
     // Get the backend sampled token for the ith token.
+    // With multiple outputs, sampler state advances when the token is accepted,
+    // not when it is read through this function.
     // Returns LLAMA_TOKEN_NULL if no token was sampled.
     LLAMA_API llama_token llama_get_sampled_token_ith(struct llama_context * ctx, int32_t i);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -348,15 +348,15 @@ extern "C" {
     // NOTE: changing the default values of parameters marked as [EXPERIMENTAL] may cause crashes or incorrect results in certain configurations
     //       https://github.com/ggml-org/llama.cpp/pull/7544
     struct llama_context_params {
-        uint32_t n_ctx;             // text context, 0 = from model
-        uint32_t n_batch;           // logical maximum batch size that can be submitted to llama_decode
-        uint32_t n_ubatch;          // physical maximum batch size
-        uint32_t n_seq_max;         // max number of sequences (i.e. distinct states for recurrent models)
-        uint32_t n_rs_seq;          // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
-        uint32_t n_outputs_max;     // max outputs in a ubatch (0 = n_batch)
-        uint32_t n_sampling_outputs_per_seq_max; // max outputs per sequence with backend sampling (0 = n_outputs_max)
-        int32_t  n_threads;         // number of threads to use for generation
-        int32_t  n_threads_batch;   // number of threads to use for batch processing
+        uint32_t n_ctx;                 // text context, 0 = from model
+        uint32_t n_batch;               // logical maximum batch size that can be submitted to llama_decode
+        uint32_t n_ubatch;              // physical maximum batch size
+        uint32_t n_seq_max;             // max number of sequences (i.e. distinct states for recurrent models)
+        uint32_t n_rs_seq;              // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
+        uint32_t n_outputs_max;         // max outputs in a ubatch (0 = n_batch)
+        uint32_t n_outputs_max_per_seq; // max outputs per sequence (0 = n_outputs_max)
+        int32_t  n_threads;             // number of threads to use for generation
+        int32_t  n_threads_batch;       // number of threads to use for batch processing
 
         enum llama_context_type      ctx_type;          // set the context type (e.g. MTP)
         enum llama_rope_scaling_type rope_scaling_type; // RoPE scaling type, from `enum llama_rope_scaling_type`
@@ -1274,12 +1274,12 @@ extern "C" {
         // [EXPERIMENTAL]
         // backend sampling interface:
 
-        // return true if the backend supports all ops needed by the sampler and can handle up to n_outputs_per_seq_max outputs per sequence
+        // return true if the backend supports all ops needed by the sampler and can handle up to n_outputs_max_per_seq outputs per sequence
         // note: call once per sampler
         bool (*backend_init)(
                 struct llama_sampler       * smpl,
                 ggml_backend_buffer_type_t   buft,
-                uint32_t                     n_outputs_per_seq_max);
+                uint32_t                     n_outputs_max_per_seq);
 
         // call after .backend_apply()
         void (*backend_accept)(
@@ -1300,6 +1300,10 @@ extern "C" {
 
         // called before rebuilding a sampling graph to clear any internal sampler state
         void (*backend_reset)(struct llama_sampler * smpl);
+
+        // copy mutable state from src into dst while keeping dst's references to the current sampling graph
+        // src and dst must have the same type and configuration
+        void (*copy_state)(const struct llama_sampler * src, struct llama_sampler * dst);
     };
 
     struct llama_sampler {
@@ -1320,6 +1324,9 @@ extern "C" {
     LLAMA_API void                   llama_sampler_apply (      struct llama_sampler * smpl, llama_token_data_array * cur_p);
     LLAMA_API void                   llama_sampler_reset (      struct llama_sampler * smpl);
     LLAMA_API struct llama_sampler * llama_sampler_clone (const struct llama_sampler * smpl);
+    // copy mutable sampler state without changing dst or its sampling graph bindings
+    // src and dst must have the same type and configuration
+    LLAMA_API void                   llama_sampler_copy  (const struct llama_sampler * src, struct llama_sampler * dst);
     // important: do not free if the sampler has been added to a llama_sampler_chain (via llama_sampler_chain_add)
     LLAMA_API void                   llama_sampler_free  (      struct llama_sampler * smpl);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -354,6 +354,7 @@ extern "C" {
         uint32_t n_seq_max;         // max number of sequences (i.e. distinct states for recurrent models)
         uint32_t n_rs_seq;          // number of recurrent-state snapshots per seq for rollback (0 = no rollback) [EXPERIMENTAL]
         uint32_t n_outputs_max;     // max outputs in a ubatch (0 = n_batch)
+        uint32_t n_sampling_outputs_per_seq_max; // max outputs per sequence with backend sampling (0 = n_outputs_max)
         int32_t  n_threads;         // number of threads to use for generation
         int32_t  n_threads_batch;   // number of threads to use for batch processing
 
@@ -1275,7 +1276,7 @@ extern "C" {
         bool (*backend_init)(
                 struct llama_sampler       * smpl,
                 ggml_backend_buffer_type_t   buft,
-                bool                         require_multi_output);
+                uint32_t                     n_outputs_per_seq_max);
 
         // call after .backend_apply()
         void (*backend_accept)(

--- a/include/llama.h
+++ b/include/llama.h
@@ -1057,6 +1057,7 @@ extern "C" {
     // Get the backend sampled token for the ith token.
     // With multiple outputs, sampler state advances when the token is accepted,
     // not when it is read through this function.
+    // When accepting multiple outputs, accept a contiguous prefix in output order.
     // Returns LLAMA_TOKEN_NULL if no token was sampled.
     LLAMA_API llama_token llama_get_sampled_token_ith(struct llama_context * ctx, int32_t i);
 
@@ -1294,11 +1295,11 @@ extern "C" {
                 struct ggml_cgraph        * gf,
                 struct llama_sampler_data * data);
 
-        // called before rebuilding a sampling graph to clear graph-owned tensor references
-        void (*backend_reset)(struct llama_sampler * smpl);
-
         // called before graph execution to set inputs for the current ubatch
         void (*backend_set_input)(struct llama_sampler * smpl);
+
+        // called before rebuilding a sampling graph to clear graph-owned tensor references
+        void (*backend_reset)(struct llama_sampler * smpl);
     };
 
     struct llama_sampler {
@@ -1508,6 +1509,7 @@ extern "C" {
     LLAMA_API uint32_t llama_sampler_get_seed(const struct llama_sampler * smpl);
 
     /// @details Sample and accept a token from the idx-th output of the last evaluation
+    // For multiple outputs from one sampler, call this function in output order without gaps.
     //
     // Shorthand for:
     //    const auto * logits = llama_get_logits_ith(ctx, idx);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1784,6 +1784,11 @@ int llama_context::decode(const llama_batch & batch_inp) {
         return -2;
     };
 
+    // start a new sampling transaction for this logical batch
+    for (const auto & entry : sampling.samplers) {
+        llama_sampler_backend_begin(entry.second);
+    }
+
     int64_t n_outputs_prev = 0;
     int64_t n_tokens_prev  = 0;
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -247,8 +247,8 @@ llama_context::llama_context(
     cparams.n_ubatch = std::min(cparams.n_batch, params.n_ubatch == 0 ? params.n_batch : params.n_ubatch);
 
     cparams.n_outputs_max = params.n_outputs_max == 0 || llama_model_has_encoder(&model) ? cparams.n_batch : params.n_outputs_max;
-    cparams.n_sampling_outputs_per_seq_max = params.n_sampling_outputs_per_seq_max == 0 ?
-            cparams.n_outputs_max : std::min(params.n_sampling_outputs_per_seq_max, cparams.n_outputs_max);
+    cparams.n_outputs_max_per_seq = params.n_outputs_max_per_seq == 0 ?
+            cparams.n_outputs_max : std::min(params.n_outputs_max_per_seq, cparams.n_outputs_max);
 
     // Initialize backend samplers here so they are part of the sampling graph
     // before the reserve passes run later in this function. This avoids a later
@@ -303,19 +303,19 @@ llama_context::llama_context(
         }
     }
 
-    LLAMA_LOG_INFO("%s: n_seq_max     = %u\n",   __func__, cparams.n_seq_max);
-    LLAMA_LOG_INFO("%s: n_ctx         = %u\n",   __func__, cparams.n_ctx);
-    LLAMA_LOG_INFO("%s: n_ctx_seq     = %u\n",   __func__, cparams.n_ctx_seq);
-    LLAMA_LOG_INFO("%s: n_batch       = %u\n",   __func__, cparams.n_batch);
-    LLAMA_LOG_INFO("%s: n_ubatch      = %u\n",   __func__, cparams.n_ubatch);
-    LLAMA_LOG_INFO("%s: causal_attn   = %d\n",   __func__, cparams.causal_attn);
-    LLAMA_LOG_INFO("%s: flash_attn    = %s\n",   __func__, llama_flash_attn_type_name(params.flash_attn_type));
-    LLAMA_LOG_INFO("%s: kv_unified    = %s\n",   __func__, cparams.kv_unified ? "true" : "false");
-    LLAMA_LOG_INFO("%s: freq_base     = %.1f\n", __func__, cparams.rope_freq_base);
-    LLAMA_LOG_INFO("%s: freq_scale    = %g\n",   __func__, cparams.rope_freq_scale);
-    LLAMA_LOG_INFO("%s: n_rs_seq      = %u\n",   __func__, cparams.n_rs_seq);
-    LLAMA_LOG_INFO("%s: n_outputs_max = %u\n",   __func__, cparams.n_outputs_max);
-    LLAMA_LOG_INFO("%s: n_sampling_outputs_per_seq_max = %u\n", __func__, cparams.n_sampling_outputs_per_seq_max);
+    LLAMA_LOG_INFO("%s: n_seq_max             = %u\n",   __func__, cparams.n_seq_max);
+    LLAMA_LOG_INFO("%s: n_ctx                 = %u\n",   __func__, cparams.n_ctx);
+    LLAMA_LOG_INFO("%s: n_ctx_seq             = %u\n",   __func__, cparams.n_ctx_seq);
+    LLAMA_LOG_INFO("%s: n_batch               = %u\n",   __func__, cparams.n_batch);
+    LLAMA_LOG_INFO("%s: n_ubatch              = %u\n",   __func__, cparams.n_ubatch);
+    LLAMA_LOG_INFO("%s: causal_attn           = %d\n",   __func__, cparams.causal_attn);
+    LLAMA_LOG_INFO("%s: flash_attn            = %s\n",   __func__, llama_flash_attn_type_name(params.flash_attn_type));
+    LLAMA_LOG_INFO("%s: kv_unified            = %s\n",   __func__, cparams.kv_unified ? "true" : "false");
+    LLAMA_LOG_INFO("%s: freq_base             = %.1f\n", __func__, cparams.rope_freq_base);
+    LLAMA_LOG_INFO("%s: freq_scale            = %g\n",   __func__, cparams.rope_freq_scale);
+    LLAMA_LOG_INFO("%s: n_rs_seq              = %u\n",   __func__, cparams.n_rs_seq);
+    LLAMA_LOG_INFO("%s: n_outputs_max         = %u\n",   __func__, cparams.n_outputs_max);
+    LLAMA_LOG_INFO("%s: n_outputs_max_per_seq = %u\n",   __func__, cparams.n_outputs_max_per_seq);
 
     if (cparams.n_ctx_seq < hparams.n_ctx_train) {
         LLAMA_LOG_INFO("%s: n_ctx_seq (%u) < n_ctx_train (%u) -- the full capacity of the model will not be utilized\n",
@@ -1235,7 +1235,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
     if (sampler && can_offload) {
         auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
 
-        sampler->iface->backend_init(sampler, buft, cparams.n_sampling_outputs_per_seq_max);
+        sampler->iface->backend_init(sampler, buft, cparams.n_outputs_max_per_seq);
 
         sampling.samplers[seq_id] = sampler;
 
@@ -1681,9 +1681,9 @@ int llama_context::decode(const llama_batch & batch_inp) {
                 seq_output_count[seq_id]++;
                 auto sampler = sampling.samplers.find(seq_id);
                 if (sampler != sampling.samplers.end() &&
-                        seq_output_count[seq_id] > (int32_t) cparams.n_sampling_outputs_per_seq_max) {
+                        seq_output_count[seq_id] > (int32_t) cparams.n_outputs_max_per_seq) {
                     LLAMA_LOG_ERROR("%s: backend sampling supports at most %u outputs per sequence "
-                            "(seq_id %d had %d)\n", __func__, cparams.n_sampling_outputs_per_seq_max,
+                            "(seq_id %d had %d)\n", __func__, cparams.n_outputs_max_per_seq,
                             seq_id, seq_output_count[seq_id]);
                     return -1;
                 }
@@ -2314,14 +2314,14 @@ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
     for (const auto & [seq_id, sampler] : sampling.samplers) {
         const uint32_t n_nodes = llama_sampler_backend_n_nodes(sampler);
         n_sampling_nodes += n_nodes;
-        if (cparams.n_sampling_outputs_per_seq_max > 1) {
+        if (cparams.n_outputs_max_per_seq > 1) {
             n_sampling_nodes_max = std::max(n_sampling_nodes_max, n_nodes);
         }
     }
 
     const uint32_t n_sampling_outputs_max = std::min<uint64_t>(
             std::min(n_tokens, cparams.n_outputs_max),
-            (uint64_t) cparams.n_seq_max * cparams.n_sampling_outputs_per_seq_max);
+            (uint64_t) cparams.n_seq_max * cparams.n_outputs_max_per_seq);
 
     res += n_sampling_nodes;
     if (n_sampling_outputs_max > 1) {
@@ -2384,7 +2384,7 @@ ggml_cgraph * llama_context::graph_reserve(
     }
 
     const uint32_t n_sampling_outputs_per_seq = std::min(
-            ubatch.n_seq_tokens, cparams.n_sampling_outputs_per_seq_max);
+            ubatch.n_seq_tokens, cparams.n_outputs_max_per_seq);
 
     // select sampling rows in round-robin order across sampler sequences
     if (!sampler_seqs.empty()) {
@@ -3496,7 +3496,7 @@ llama_context_params llama_context_default_params() {
         /*.n_seq_max                   =*/ 1,
         /*.n_rs_seq                    =*/ 0,
         /*.n_outputs_max               =*/ 0,
-        /*.n_sampling_outputs_per_seq_max =*/ 1,
+        /*.n_outputs_max_per_seq       =*/ 1,
         /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
         /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
         /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2334,6 +2334,63 @@ llm_graph_result * llama_context::get_gf_res_reserve() const {
     return static_cast<llm_graph_result *>(gf_res_reserve.get());
 }
 
+// pack sampler outputs into as few sequences as possible before using sequences without samplers
+static void ubatch_prepare_reserve(
+              llama_ubatch                            & ubatch,
+              uint32_t                                  n_outputs,
+        const std::map<llama_seq_id, llama_sampler *> & samplers,
+              uint32_t                                  n_outputs_max_per_seq) {
+    const uint32_t n_seqs       = ubatch.n_seqs;
+    const uint32_t n_seq_tokens = ubatch.n_seq_tokens;
+
+    for (uint32_t s = 0; s < n_seqs; ++s) {
+        for (uint32_t t = 0; t < n_seq_tokens; ++t) {
+            const uint32_t i = s * n_seq_tokens + t;
+            ubatch.n_seq_id[i] = 1;
+            ubatch.seq_id[i] = &ubatch.seq_id_unq[s];
+        }
+    }
+
+    // sequences with a sampler that fit in this ubatch
+    std::vector<uint32_t> sampler_seqs;
+    std::vector<bool> has_sampler(n_seqs, false);
+    for (const auto & entry : samplers) {
+        const llama_seq_id seq_id = entry.first;
+        if (seq_id < 0 || (uint32_t) seq_id >= n_seqs) {
+            continue;
+        }
+
+        sampler_seqs.push_back(seq_id);
+        has_sampler[seq_id] = true;
+    }
+
+    uint32_t n_outputs_set = 0;
+
+    const uint32_t n_outputs_per_seq = std::min(n_seq_tokens, n_outputs_max_per_seq);
+    for (uint32_t s : sampler_seqs) {
+        if (n_outputs_set >= n_outputs) {
+            break;
+        }
+
+        for (uint32_t t = 0; t < n_outputs_per_seq && n_outputs_set < n_outputs; ++t) {
+            ubatch.output[s * n_seq_tokens + t] = true;
+            ++n_outputs_set;
+        }
+    }
+
+    // use sequences without samplers for any remaining outputs
+    for (uint32_t t = 0; t < n_seq_tokens && n_outputs_set < n_outputs; ++t) {
+        for (uint32_t s = 0; s < n_seqs && n_outputs_set < n_outputs; ++s) {
+            if (has_sampler[s]) {
+                continue;
+            }
+
+            ubatch.output[s * n_seq_tokens + t] = true;
+            ++n_outputs_set;
+        }
+    }
+}
+
 ggml_cgraph * llama_context::graph_reserve(
         uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only, size_t * sizes) {
     LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
@@ -2358,58 +2415,7 @@ ggml_cgraph * llama_context::graph_reserve(
     llama_batch_allocr balloc(model.hparams.n_pos_per_embd());
     llama_ubatch ubatch = balloc.ubatch_reserve(n_tokens/n_seqs, n_seqs);
 
-    // select sampler outputs first to reserve the largest valid sampling graph
-    std::vector<llama_seq_id> seq_ids(n_seqs);
-    for (uint32_t s = 0; s < n_seqs; ++s) {
-        seq_ids[s] = s;
-        for (uint32_t t = 0; t < ubatch.n_seq_tokens; ++t) {
-            const uint32_t i = s * ubatch.n_seq_tokens + t;
-            ubatch.n_seq_id[i] = 1;
-            ubatch.seq_id[i] = &seq_ids[s];
-        }
-    }
-
-    uint32_t n_outputs_set = 0;
-
-    std::vector<uint32_t> sampler_seqs;
-    std::vector<bool> has_sampler(n_seqs, false);
-    for (const auto & entry : sampling.samplers) {
-        const llama_seq_id seq_id = entry.first;
-        if (seq_id < 0 || (uint32_t) seq_id >= n_seqs) {
-            continue;
-        }
-
-        sampler_seqs.push_back(seq_id);
-        has_sampler[seq_id] = true;
-    }
-
-    const uint32_t n_sampling_outputs_per_seq = std::min(
-            ubatch.n_seq_tokens, cparams.n_outputs_max_per_seq);
-
-    // select sampling rows in round-robin order across sampler sequences
-    if (!sampler_seqs.empty()) {
-        const uint32_t n_sampler_seqs = sampler_seqs.size();
-        n_outputs_set = std::min<uint64_t>(
-                n_outputs, (uint64_t) n_sampler_seqs * n_sampling_outputs_per_seq);
-
-        for (uint32_t i = 0; i < n_outputs_set; ++i) {
-            const uint32_t s = sampler_seqs[i % n_sampler_seqs];
-            const uint32_t t = i / n_sampler_seqs;
-            ubatch.output[s * ubatch.n_seq_tokens + t] = true;
-        }
-    }
-
-    // use sequences without samplers for any remaining outputs
-    for (uint32_t t = 0; t < ubatch.n_seq_tokens && n_outputs_set < n_outputs; ++t) {
-        for (uint32_t s = 0; s < n_seqs && n_outputs_set < n_outputs; ++s) {
-            if (has_sampler[s]) {
-                continue;
-            }
-
-            ubatch.output[s * ubatch.n_seq_tokens + t] = true;
-            ++n_outputs_set;
-        }
-    }
+    ubatch_prepare_reserve(ubatch, n_outputs, sampling.samplers, cparams.n_outputs_max_per_seq);
 
     auto * res = gf_res_reserve.get();
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1674,6 +1674,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
             for (int32_t s = 0; s < ns; ++s) {
                 const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
 
+                if (seq_id < 0 || (uint32_t) seq_id >= n_seq_max) {
+                    continue;
+                }
+
                 seq_output_count[seq_id]++;
                 auto sampler = sampling.samplers.find(seq_id);
                 if (sampler != sampling.samplers.end() &&
@@ -2310,9 +2314,13 @@ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
         }
     }
 
+    const uint32_t n_sampling_outputs_max = std::min<uint64_t>(
+            std::min(n_tokens, cparams.n_outputs_max),
+            (uint64_t) cparams.n_seq_max * cparams.n_sampling_outputs_per_seq_max);
+
     res += n_sampling_nodes;
-    if (cparams.n_outputs_max > 1) {
-        res += (cparams.n_outputs_max - 1) * n_sampling_nodes_max;
+    if (n_sampling_outputs_max > 1) {
+        res += (n_sampling_outputs_max - 1) * n_sampling_nodes_max;
     }
     return res;
 }
@@ -2361,7 +2369,7 @@ ggml_cgraph * llama_context::graph_reserve(
         for (uint32_t s = 0; s < n_seqs && n_outputs_set < n_outputs; ++s) {
             const auto sampler = sampling.samplers.find(s);
             if (t > 0 && (sampler == sampling.samplers.end() ||
-                    cparams.n_sampling_outputs_per_seq_max == 1)) {
+                    t >= cparams.n_sampling_outputs_per_seq_max)) {
                 continue;
             }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -100,7 +100,6 @@ llama_context::llama_context(
     if (cparams.n_seq_max > LLAMA_MAX_SEQ) {
         throw std::runtime_error("n_seq_max must be <= " + std::to_string(LLAMA_MAX_SEQ));
     }
-    cparams.sampler_backend_require_multi_output = params.n_outputs_max > cparams.n_seq_max;
 
     cparams.n_rs_seq = params.n_rs_seq;
     if (cparams.n_rs_seq > 0 && !llm_arch_supports_rs_rollback(model.arch)) {
@@ -158,25 +157,6 @@ llama_context::llama_context(
                 throw std::runtime_error(model.arch_name() + " requires ctx_other to be set (this warning is normal during memory fitting)");
             }
             cparams.ctx_other = params.ctx_other;
-        }
-    }
-
-    // Initialize backend samplers here so they are part of the sampling graph
-    // before the reserve passes run later in this function. This avoids a later
-    // re-reserve when graph nodes change.
-    if (params.samplers != nullptr && params.n_samplers > 0) {
-        for (size_t i = 0; i < params.n_samplers; ++i) {
-            const auto & config = params.samplers[i];
-
-            if (llama_sampler_chain_get(config.sampler, -1) == nullptr) {
-                throw std::runtime_error("the backend samplers must be of type llama_sampler_chain");
-            }
-
-            if (set_sampler(config.seq_id, config.sampler)) {
-                const int n_samplers = llama_sampler_chain_n(config.sampler);
-
-                LLAMA_LOG_INFO("%s: setting backend sampler for seq_id %d (n = %d)\n", __func__, config.seq_id, n_samplers);
-            }
         }
     }
 
@@ -267,6 +247,27 @@ llama_context::llama_context(
     cparams.n_ubatch = std::min(cparams.n_batch, params.n_ubatch == 0 ? params.n_batch : params.n_ubatch);
 
     cparams.n_outputs_max = params.n_outputs_max == 0 || llama_model_has_encoder(&model) ? cparams.n_batch : params.n_outputs_max;
+    cparams.n_sampling_outputs_per_seq_max = params.n_sampling_outputs_per_seq_max == 0 ?
+            cparams.n_outputs_max : std::min(params.n_sampling_outputs_per_seq_max, cparams.n_outputs_max);
+
+    // Initialize backend samplers here so they are part of the sampling graph
+    // before the reserve passes run later in this function. This avoids a later
+    // re-reserve when graph nodes change.
+    if (params.samplers != nullptr && params.n_samplers > 0) {
+        for (size_t i = 0; i < params.n_samplers; ++i) {
+            const auto & config = params.samplers[i];
+
+            if (llama_sampler_chain_get(config.sampler, -1) == nullptr) {
+                throw std::runtime_error("the backend samplers must be of type llama_sampler_chain");
+            }
+
+            if (set_sampler(config.seq_id, config.sampler)) {
+                const int n_samplers = llama_sampler_chain_n(config.sampler);
+
+                LLAMA_LOG_INFO("%s: setting backend sampler for seq_id %d (n = %d)\n", __func__, config.seq_id, n_samplers);
+            }
+        }
+    }
 
     cparams.op_offload = params.op_offload;
     cparams.kv_unified = params.kv_unified;
@@ -314,6 +315,7 @@ llama_context::llama_context(
     LLAMA_LOG_INFO("%s: freq_scale    = %g\n",   __func__, cparams.rope_freq_scale);
     LLAMA_LOG_INFO("%s: n_rs_seq      = %u\n",   __func__, cparams.n_rs_seq);
     LLAMA_LOG_INFO("%s: n_outputs_max = %u\n",   __func__, cparams.n_outputs_max);
+    LLAMA_LOG_INFO("%s: n_sampling_outputs_per_seq_max = %u\n", __func__, cparams.n_sampling_outputs_per_seq_max);
 
     if (cparams.n_ctx_seq < hparams.n_ctx_train) {
         LLAMA_LOG_INFO("%s: n_ctx_seq (%u) < n_ctx_train (%u) -- the full capacity of the model will not be utilized\n",
@@ -1233,7 +1235,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
     if (sampler && can_offload) {
         auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
 
-        sampler->iface->backend_init(sampler, buft, cparams.sampler_backend_require_multi_output);
+        sampler->iface->backend_init(sampler, buft, cparams.n_sampling_outputs_per_seq_max);
 
         sampling.samplers[seq_id] = sampler;
 
@@ -1674,11 +1676,11 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
                 seq_output_count[seq_id]++;
                 auto sampler = sampling.samplers.find(seq_id);
-                if (seq_output_count[seq_id] > 1 &&
-                        sampler != sampling.samplers.end() &&
-                        !cparams.sampler_backend_require_multi_output) {
-                    LLAMA_LOG_ERROR("%s: backend sampling requires at most one output token per sequence (seq_id %d had %d)\n",
-                            __func__, seq_id, seq_output_count[seq_id]);
+                if (sampler != sampling.samplers.end() &&
+                        seq_output_count[seq_id] > (int32_t) cparams.n_sampling_outputs_per_seq_max) {
+                    LLAMA_LOG_ERROR("%s: backend sampling supports at most %u outputs per sequence "
+                            "(seq_id %d had %d)\n", __func__, cparams.n_sampling_outputs_per_seq_max,
+                            seq_id, seq_output_count[seq_id]);
                     return -1;
                 }
             }
@@ -2303,7 +2305,7 @@ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
     for (const auto & [seq_id, sampler] : sampling.samplers) {
         const uint32_t n_nodes = llama_sampler_backend_n_nodes(sampler);
         n_sampling_nodes += n_nodes;
-        if (cparams.sampler_backend_require_multi_output) {
+        if (cparams.n_sampling_outputs_per_seq_max > 1) {
             n_sampling_nodes_max = std::max(n_sampling_nodes_max, n_nodes);
         }
     }
@@ -2359,7 +2361,7 @@ ggml_cgraph * llama_context::graph_reserve(
         for (uint32_t s = 0; s < n_seqs && n_outputs_set < n_outputs; ++s) {
             const auto sampler = sampling.samplers.find(s);
             if (t > 0 && (sampler == sampling.samplers.end() ||
-                    !cparams.sampler_backend_require_multi_output)) {
+                    cparams.n_sampling_outputs_per_seq_max == 1)) {
                 continue;
             }
 
@@ -3453,6 +3455,7 @@ llama_context_params llama_context_default_params() {
         /*.n_seq_max                   =*/ 1,
         /*.n_rs_seq                    =*/ 0,
         /*.n_outputs_max               =*/ 0,
+        /*.n_sampling_outputs_per_seq_max =*/ 1,
         /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
         /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
         /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -10,6 +10,7 @@
 #include "llama-mmap.h"
 #include "llama-model.h"
 #include "llama-ext.h"
+#include "llama-sampler.h"
 #include "llama.h"
 
 #include <cinttypes>
@@ -99,6 +100,7 @@ llama_context::llama_context(
     if (cparams.n_seq_max > LLAMA_MAX_SEQ) {
         throw std::runtime_error("n_seq_max must be <= " + std::to_string(LLAMA_MAX_SEQ));
     }
+    cparams.sampler_backend_require_multi_output = params.n_outputs_max > cparams.n_seq_max;
 
     cparams.n_rs_seq = params.n_rs_seq;
     if (cparams.n_rs_seq > 0 && !llm_arch_supports_rs_rollback(model.arch)) {
@@ -1231,7 +1233,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
     if (sampler && can_offload) {
         auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
 
-        sampler->iface->backend_init(sampler, buft);
+        sampler->iface->backend_init(sampler, buft, cparams.sampler_backend_require_multi_output);
 
         sampling.samplers[seq_id] = sampler;
 
@@ -1576,108 +1578,38 @@ int llama_context::encode(const llama_batch & batch_inp) {
     return 0;
 }
 
-static std::map<llama_seq_id, uint32_t> build_seq_to_output_row(const llama_ubatch & ubatch, uint32_t row_offset) {
-    std::map<llama_seq_id, uint32_t> seq_to_row;
-    // how many output tokens we have seen so far for this ubatch.
-    uint32_t local = 0;
-    for (uint32_t i = 0; i < ubatch.n_tokens; ++i) {
-        // skip tokens that are not output.
-        if (!ubatch.output[i]) {
-            continue;
-        }
-
-        const llama_seq_id seq_id = ubatch.seq_id[i][0];
-        // row_offset is the number of output tokens before this ubatch.
-        seq_to_row[seq_id] = row_offset + local;
-        ++local;
-    }
-    return seq_to_row;
-}
-
-static void copy_tensor_async_ints(
-    const std::map<llama_seq_id, ggml_tensor*> & tensor_map,
-    const buffer_view<llama_token> & sampled,
-    const std::map<llama_seq_id, uint32_t> & seq_to_row,
-    ggml_backend_sched_t sched) {
-    if (!sampled.has_data()) {
-        return;
-    }
-
-    for (const auto & [seq_id, tensor] : tensor_map) {
-        auto it = seq_to_row.find(seq_id);
-        if (it == seq_to_row.end()) {
-            continue;
-        }
-
-        const uint32_t row = it->second;
-        GGML_ASSERT(row < sampled.size);
-
-        GGML_ASSERT(ggml_is_contiguous(tensor) && "sampled tokens tensor must be contiguous for async copy");
-
-        ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(sched, tensor);
-        ggml_backend_tensor_get_async(backend, tensor, sampled.data + row, 0, sizeof(sampled.data[row]));
-    }
-}
-
-static void copy_tensor_async_floats(
-    const std::map<llama_seq_id, ggml_tensor*> & tensor_map,
-    const buffer_view<float> & dst,
+template<typename T>
+static void copy_tensor_async_rows(
+    const std::vector<ggml_tensor *> & tensors,
+    const buffer_view<T> & dst,
     size_t stride,
-    std::vector<uint32_t> & counts,
-    const std::map<llama_seq_id, uint32_t> & seq_to_row,
-    ggml_backend_sched_t sched) {
+    uint32_t row_offset,
+    ggml_backend_sched_t sched,
+    std::vector<uint32_t> * counts = nullptr) {
     if (!dst.has_data()) {
         return;
     }
 
-    for (const auto & [seq_id, tensor] : tensor_map) {
-        auto it = seq_to_row.find(seq_id);
-        if (it == seq_to_row.end()) {
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        auto * tensor = tensors[i];
+        if (tensor == nullptr) {
             continue;
         }
 
-        const uint32_t row = it->second;
-        GGML_ASSERT(row < counts.size());
-
-        GGML_ASSERT(ggml_is_contiguous(tensor) && "logits/probs tensor must be contiguous for async copy");
+        const uint32_t row = row_offset + i;
+        const size_t n_elements = ggml_nelements(tensor);
+        GGML_ASSERT(ggml_is_contiguous(tensor) && "sampling tensor must be contiguous for async copy");
+        GGML_ASSERT(n_elements <= stride);
+        GGML_ASSERT((size_t) row * stride + n_elements <= dst.size);
 
         ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(sched, tensor);
-        float * row_ptr = dst.data + (size_t) row * stride;
+        T * row_ptr = dst.data + (size_t) row * stride;
         ggml_backend_tensor_get_async(backend, tensor, row_ptr, 0, ggml_nbytes(tensor));
 
-        // Update the actual number of logits/probabilities that were written for this row.
-        counts[row] = ggml_nelements(tensor);
-    }
-}
-
-static void copy_tensor_async_candidates(
-    const std::map<llama_seq_id, ggml_tensor*> & tensor_map,
-    const buffer_view<llama_token> & dst,
-    size_t stride,
-    std::vector<uint32_t> & counts,
-    const std::map<llama_seq_id, uint32_t> & seq_to_row,
-    ggml_backend_sched_t sched) {
-    if (!dst.has_data()) {
-        return;
-    }
-
-    for (const auto & [seq_id, tensor] : tensor_map) {
-        auto it = seq_to_row.find(seq_id);
-        if (it == seq_to_row.end()) {
-            continue;
+        if (counts) {
+            GGML_ASSERT(row < counts->size());
+            (*counts)[row] = n_elements;
         }
-
-        const uint32_t row = it->second;
-        GGML_ASSERT(row < counts.size());
-
-        GGML_ASSERT(ggml_is_contiguous(tensor) && "candidates tensor must be contiguous for async copy");
-
-        ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(sched, tensor);
-        llama_token * row_ptr = dst.data + (size_t) row * stride;
-        ggml_backend_tensor_get_async(backend, tensor, row_ptr, 0, ggml_nbytes(tensor));
-
-        // Update the actual number of candidates that were written.
-        counts[row] = ggml_nelements(tensor);
     }
 }
 
@@ -1726,12 +1658,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     const uint32_t n_seq_max = cparams.kv_unified ? LLAMA_MAX_SEQ : cparams.n_seq_max;
 
-    // TODO: avoid this workaround in the future
-    if (has_samplers && batch_inp.logits) {
+    // embedding contexts output every token even when batch.logits is not set
+    if (has_samplers && (output_all || batch_inp.logits)) {
         std::vector<int32_t> seq_output_count(n_seq_max, 0);
 
         for (int32_t i = 0; i < batch_inp.n_tokens; ++i) {
-            if (batch_inp.logits[i] == 0) {
+            if (!output_all && batch_inp.logits[i] == 0) {
                 continue;
             }
 
@@ -1741,7 +1673,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
                 const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
 
                 seq_output_count[seq_id]++;
-                if (seq_output_count[seq_id] > 1) {
+                auto sampler = sampling.samplers.find(seq_id);
+                if (seq_output_count[seq_id] > 1 &&
+                        sampler != sampling.samplers.end() &&
+                        !cparams.sampler_backend_require_multi_output) {
                     LLAMA_LOG_ERROR("%s: backend sampling requires at most one output token per sequence (seq_id %d had %d)\n",
                             __func__, seq_id, seq_output_count[seq_id]);
                     return -1;
@@ -2009,17 +1944,14 @@ int llama_context::decode(const llama_batch & batch_inp) {
             }
         }
 
-        // Copy backend sampling output if this ubatch produced any sampling tensors.
-        if (has_samplers && (!res->t_sampled.empty() || !res->t_sampled_probs.empty() || !res->t_sampled_logits.empty())) {
-            const auto seq_to_output_row = build_seq_to_output_row(ubatch, n_outputs_prev);
+        if (has_samplers) {
             const auto stride = n_vocab;
 
             // async copy the sampling data from the backend to the host
-            copy_tensor_async_ints(res->t_sampled, sampling.sampled, seq_to_output_row, sched.get());
-
-            copy_tensor_async_floats    (res->t_sampled_logits, sampling.logits,     stride, sampling.logits_count,     seq_to_output_row, sched.get());
-            copy_tensor_async_floats    (res->t_sampled_probs,  sampling.probs,      stride, sampling.probs_count,      seq_to_output_row, sched.get());
-            copy_tensor_async_candidates(res->t_candidates,     sampling.candidates, stride, sampling.candidates_count, seq_to_output_row, sched.get());
+            copy_tensor_async_rows(res->t_sampled,        sampling.sampled,    1,      n_outputs_prev, sched.get());
+            copy_tensor_async_rows(res->t_sampled_logits, sampling.logits,     stride, n_outputs_prev, sched.get(), &sampling.logits_count);
+            copy_tensor_async_rows(res->t_sampled_probs,  sampling.probs,      stride, n_outputs_prev, sched.get(), &sampling.probs_count);
+            copy_tensor_async_rows(res->t_candidates,     sampling.candidates, stride, n_outputs_prev, sched.get(), &sampling.candidates_count);
         }
 
         n_outputs_prev += n_outputs;
@@ -2349,6 +2281,7 @@ void llama_context::output_reorder() {
 //
 
 uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
+    uint32_t res;
     if (model.arch == LLM_ARCH_QWEN3NEXT ||
         model.arch == LLM_ARCH_KIMI_LINEAR ||
         model.arch == LLM_ARCH_QWEN35 ||
@@ -2357,11 +2290,27 @@ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
         (model.arch == LLM_ARCH_DFLASH && model.hparams.dsv4_hc_mult > 0) ||
         model.arch == LLM_ARCH_NANBEIGE ||
         model.arch == LLM_ARCH_MINIMAX_M3) {
-        return std::max<uint32_t>(n_tokens * 40, 32u * model.n_tensors());
+        res = std::max<uint32_t>(n_tokens * 40, 32u * model.n_tensors());
+    } else {
+        res = std::max<uint32_t>(1024u, 8u*model.n_tensors());
+        for (const auto & lora : model.loras) {
+            res += lora->get_n_nodes();
+        }
     }
-    uint32_t res = std::max<uint32_t>(1024u, 8u*model.n_tensors());
-    for (const auto & lora : model.loras) {
-        res += lora->get_n_nodes();
+
+    uint32_t n_sampling_nodes = 0;
+    uint32_t n_sampling_nodes_max = 0;
+    for (const auto & [seq_id, sampler] : sampling.samplers) {
+        const uint32_t n_nodes = llama_sampler_backend_n_nodes(sampler);
+        n_sampling_nodes += n_nodes;
+        if (cparams.sampler_backend_require_multi_output) {
+            n_sampling_nodes_max = std::max(n_sampling_nodes_max, n_nodes);
+        }
+    }
+
+    res += n_sampling_nodes;
+    if (cparams.n_outputs_max > 1) {
+        res += (cparams.n_outputs_max - 1) * n_sampling_nodes_max;
     }
     return res;
 }
@@ -2394,13 +2343,29 @@ ggml_cgraph * llama_context::graph_reserve(
     llama_batch_allocr balloc(model.hparams.n_pos_per_embd());
     llama_ubatch ubatch = balloc.ubatch_reserve(n_tokens/n_seqs, n_seqs);
 
-    // set one output token per sequence in order to activate all backend samplers
+    // spread the outputs across all sequences to reserve the largest sampling graph
     std::vector<llama_seq_id> seq_ids(n_seqs);
-    for (uint32_t i = 0; i < n_seqs; ++i) {
-        seq_ids[i] = i;
-        ubatch.n_seq_id[i] = 1;
-        ubatch.seq_id[i] = &seq_ids[i];
-        ubatch.output[i] = true;
+    for (uint32_t s = 0; s < n_seqs; ++s) {
+        seq_ids[s] = s;
+        for (uint32_t t = 0; t < ubatch.n_seq_tokens; ++t) {
+            const uint32_t i = s * ubatch.n_seq_tokens + t;
+            ubatch.n_seq_id[i] = 1;
+            ubatch.seq_id[i] = &seq_ids[s];
+        }
+    }
+
+    uint32_t n_outputs_set = 0;
+    for (uint32_t t = 0; t < ubatch.n_seq_tokens && n_outputs_set < n_outputs; ++t) {
+        for (uint32_t s = 0; s < n_seqs && n_outputs_set < n_outputs; ++s) {
+            const auto sampler = sampling.samplers.find(s);
+            if (t > 0 && (sampler == sampling.samplers.end() ||
+                    !cparams.sampler_backend_require_multi_output)) {
+                continue;
+            }
+
+            ubatch.output[s * ubatch.n_seq_tokens + t] = true;
+            ++n_outputs_set;
+        }
     }
 
     auto * res = gf_res_reserve.get();

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2353,7 +2353,7 @@ ggml_cgraph * llama_context::graph_reserve(
     llama_batch_allocr balloc(model.hparams.n_pos_per_embd());
     llama_ubatch ubatch = balloc.ubatch_reserve(n_tokens/n_seqs, n_seqs);
 
-    // spread the outputs across all sequences to reserve the largest sampling graph
+    // select sampler outputs first to reserve the largest valid sampling graph
     std::vector<llama_seq_id> seq_ids(n_seqs);
     for (uint32_t s = 0; s < n_seqs; ++s) {
         seq_ids[s] = s;
@@ -2365,11 +2365,50 @@ ggml_cgraph * llama_context::graph_reserve(
     }
 
     uint32_t n_outputs_set = 0;
+
+    std::vector<uint32_t> sampler_seqs;
+    std::vector<bool> has_sampler(n_seqs, false);
+    for (const auto & entry : sampling.samplers) {
+        const llama_seq_id seq_id = entry.first;
+        if (seq_id < 0 || (uint32_t) seq_id >= n_seqs) {
+            continue;
+        }
+
+        sampler_seqs.push_back(seq_id);
+        has_sampler[seq_id] = true;
+    }
+
+    const uint32_t n_sampling_outputs_per_seq = std::min(
+            ubatch.n_seq_tokens, cparams.n_sampling_outputs_per_seq_max);
+
+    // activate each configured sampler once
+    if (n_sampling_outputs_per_seq > 0) {
+        for (uint32_t s : sampler_seqs) {
+            if (n_outputs_set >= n_outputs) {
+                break;
+            }
+
+            ubatch.output[s * ubatch.n_seq_tokens] = true;
+            ++n_outputs_set;
+        }
+    }
+
+    // add the remaining valid sampling rows
+    for (uint32_t t = 1; t < n_sampling_outputs_per_seq && n_outputs_set < n_outputs; ++t) {
+        for (uint32_t s : sampler_seqs) {
+            if (n_outputs_set >= n_outputs) {
+                break;
+            }
+
+            ubatch.output[s * ubatch.n_seq_tokens + t] = true;
+            ++n_outputs_set;
+        }
+    }
+
+    // use sequences without samplers for any remaining outputs
     for (uint32_t t = 0; t < ubatch.n_seq_tokens && n_outputs_set < n_outputs; ++t) {
         for (uint32_t s = 0; s < n_seqs && n_outputs_set < n_outputs; ++s) {
-            const auto sampler = sampling.samplers.find(s);
-            if (t > 0 && (sampler == sampling.samplers.end() ||
-                    t >= cparams.n_sampling_outputs_per_seq_max)) {
+            if (has_sampler[s]) {
                 continue;
             }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2386,27 +2386,16 @@ ggml_cgraph * llama_context::graph_reserve(
     const uint32_t n_sampling_outputs_per_seq = std::min(
             ubatch.n_seq_tokens, cparams.n_sampling_outputs_per_seq_max);
 
-    // activate each configured sampler once
-    if (n_sampling_outputs_per_seq > 0) {
-        for (uint32_t s : sampler_seqs) {
-            if (n_outputs_set >= n_outputs) {
-                break;
-            }
+    // select sampling rows in round-robin order across sampler sequences
+    if (!sampler_seqs.empty()) {
+        const uint32_t n_sampler_seqs = sampler_seqs.size();
+        n_outputs_set = std::min<uint64_t>(
+                n_outputs, (uint64_t) n_sampler_seqs * n_sampling_outputs_per_seq);
 
-            ubatch.output[s * ubatch.n_seq_tokens] = true;
-            ++n_outputs_set;
-        }
-    }
-
-    // add the remaining valid sampling rows
-    for (uint32_t t = 1; t < n_sampling_outputs_per_seq && n_outputs_set < n_outputs; ++t) {
-        for (uint32_t s : sampler_seqs) {
-            if (n_outputs_set >= n_outputs) {
-                break;
-            }
-
+        for (uint32_t i = 0; i < n_outputs_set; ++i) {
+            const uint32_t s = sampler_seqs[i % n_sampler_seqs];
+            const uint32_t t = i / n_sampler_seqs;
             ubatch.output[s * ubatch.n_seq_tokens + t] = true;
-            ++n_outputs_set;
         }
     }
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -52,6 +52,7 @@ struct llama_cparams {
     bool op_offload;
     bool kv_unified;
     bool pipeline_parallel;
+    bool sampler_backend_require_multi_output;
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -15,7 +15,7 @@ struct llama_cparams {
     uint32_t n_seq_max;
     uint32_t n_rs_seq;        // number of recurrent-state snapshots per seq for rollback
     uint32_t n_outputs_max;   // max outputs supported by the context
-    uint32_t n_sampling_outputs_per_seq_max;
+    uint32_t n_outputs_max_per_seq;
     int32_t  n_threads;       // number of threads to use for generation
     int32_t  n_threads_batch; // number of threads to use for batch processing
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -15,6 +15,7 @@ struct llama_cparams {
     uint32_t n_seq_max;
     uint32_t n_rs_seq;        // number of recurrent-state snapshots per seq for rollback
     uint32_t n_outputs_max;   // max outputs supported by the context
+    uint32_t n_sampling_outputs_per_seq_max;
     int32_t  n_threads;       // number of threads to use for generation
     int32_t  n_threads_batch; // number of threads to use for batch processing
 
@@ -52,7 +53,6 @@ struct llama_cparams {
     bool op_offload;
     bool kv_unified;
     bool pipeline_parallel;
-    bool sampler_backend_require_multi_output;
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -4,6 +4,7 @@
 #include "llama-model.h"
 #include "llama-batch.h"
 #include "llama-cparams.h"
+#include "llama-sampler.h"
 
 #include "llama-kv-cache.h"
 #include "llama-kv-cache-iswa.h"
@@ -1353,24 +1354,24 @@ void llm_graph_result::set_outputs(const llm_graph_params & params) {
             }
         }
     }
-    for (auto & [seq_id, t] : t_sampled) {
-        if (t != nullptr) {
-            ggml_set_output(t);
+    for (auto * tensor : t_sampled) {
+        if (tensor != nullptr) {
+            ggml_set_output(tensor);
         }
     }
-    for (auto & [seq_id, t] : t_sampled_probs) {
-        if (t != nullptr) {
-            ggml_set_output(t);
+    for (auto * tensor : t_sampled_probs) {
+        if (tensor != nullptr) {
+            ggml_set_output(tensor);
         }
     }
-    for (auto & [seq_id, t] : t_sampled_logits) {
-        if (t != nullptr) {
-            ggml_set_output(t);
+    for (auto * tensor : t_sampled_logits) {
+        if (tensor != nullptr) {
+            ggml_set_output(tensor);
         }
     }
-    for (auto & [seq_id, t] : t_candidates) {
-        if (t != nullptr) {
-            ggml_set_output(t);
+    for (auto * tensor : t_candidates) {
+        if (tensor != nullptr) {
+            ggml_set_output(tensor);
         }
     }
 }
@@ -3649,77 +3650,102 @@ void llm_graph_context::build_sampling() const {
     auto inp_sampling = std::make_unique<llm_graph_input_sampling>(samplers);
     res->add_input(std::move(inp_sampling));
 
-    std::map<llama_seq_id, int32_t> seq_to_logit_row;
-    int32_t logit_row_idx = 0;
-
-    for (uint32_t i = 0; i < ubatch.n_tokens; i++) {
+    std::map<llama_seq_id, std::vector<uint32_t>> sampling_rows;
+    uint32_t n_rows = 0;
+    for (uint32_t i = 0; i < ubatch.n_tokens; ++i) {
         if (ubatch.output[i]) {
-            llama_seq_id seq_id = ubatch.seq_id[i][0];
-            seq_to_logit_row[seq_id] = logit_row_idx;
-            logit_row_idx++;
+            sampling_rows[ubatch.seq_id[i][0]].push_back(n_rows++);
         }
     }
+
+    res->t_sampled.resize(n_rows, nullptr);
+    res->t_sampled_probs.resize(n_rows, nullptr);
+    res->t_sampled_logits.resize(n_rows, nullptr);
+    res->t_candidates.resize(n_rows, nullptr);
 
     // res->t_logits will contain logits for all tokens that want the logits calculated (logits=1 or output=1)
     GGML_ASSERT(res->t_logits != nullptr && "missing t_logits tensor");
 
-    // add a dummy row of logits
-    // this trick makes the graph static, regardless of which samplers are activated
-    // this is important in order to minimize graph reallocations
+    // add a dummy row to keep the single-output graph static regardless of active samplers
+    // multi-output graphs can still vary with the number of output rows
     ggml_tensor * logits_t = ggml_pad(ctx0, res->t_logits, 0, 1, 0, 0);
 
-    for (const auto & [seq_id, sampler] : samplers) {
-        const auto it = seq_to_logit_row.find(seq_id);
-
-        // inactive samplers always work on the first row
-        const auto row_idx = it != seq_to_logit_row.end() ? it->second : 0;
-        const int i_out    = it != seq_to_logit_row.end() ? 1          : 0;
-
-        ggml_tensor * logits_seq = ggml_view_1d(ctx0, logits_t, logits_t->ne[0], row_idx * logits_t->nb[1]);
-        ggml_format_name(logits_seq, "logits_seq_%d", seq_id);
-
-        struct llama_sampler_data data = {
-            /*.logits      =*/ logits_seq,
-            /*.probs       =*/ nullptr,
-            /*.sampled     =*/ nullptr,
-            /*.candidates  =*/ nullptr,
-        };
-
-        assert(sampler->iface->backend_apply);
-        sampler->iface->backend_apply(sampler, ctx0, gf, &data);
-
-        if (data.sampled != nullptr) {
-            res->t_sampled[seq_id] = data.sampled;
-            outs[1] = data.sampled;
-            ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
-        }
-
-        if (data.probs != nullptr) {
-            res->t_sampled_probs[seq_id] = data.probs;
-            outs[1] = data.probs;
-            ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
-        }
-
-        if (data.logits != nullptr) {
-            res->t_sampled_logits[seq_id] = data.logits;
-            outs[1] = data.logits;
-            ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
-        }
-
-        if (data.candidates != nullptr) {
-            res->t_candidates[seq_id] = data.candidates;
-            outs[1] = data.candidates;
-            ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
+    for (const auto & entry : samplers) {
+        if (entry.second->iface->backend_reset) {
+            entry.second->iface->backend_reset(entry.second);
         }
     }
 
-    // TODO: Call llama_sampler_accept_ggml after all samplers have been applied.
+    static const std::vector<uint32_t> dummy_row = { 0 };
+
+    for (const auto & [seq_id, sampler] : samplers) {
+        const auto it = sampling_rows.find(seq_id);
+
+        // inactive samplers always work on the first row
+        const bool active = it != sampling_rows.end();
+        const auto & rows = active ? it->second : dummy_row;
+        const int i_out   = active ? 1          : 0;
+
+        for (uint32_t i = 0; i < rows.size(); ++i) {
+            ggml_tensor * logits_seq = ggml_view_1d(ctx0, logits_t, logits_t->ne[0], rows[i] * logits_t->nb[1]);
+            ggml_format_name(logits_seq, "logits_seq_%d_%u", seq_id, i);
+
+            struct llama_sampler_data data = {
+                /*.logits       =*/ logits_seq,
+                /*.probs        =*/ nullptr,
+                /*.sampled      =*/ nullptr,
+                /*.candidates   =*/ nullptr,
+            };
+
+            assert(sampler->iface->backend_apply);
+            sampler->iface->backend_apply(sampler, ctx0, gf, &data);
+
+            if (data.sampled != nullptr) {
+                if (active) {
+                    res->t_sampled[rows[i]] = data.sampled;
+                }
+                outs[1] = data.sampled;
+                ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
+            }
+
+            if (data.probs != nullptr) {
+                if (active) {
+                    res->t_sampled_probs[rows[i]] = data.probs;
+                }
+                outs[1] = data.probs;
+                ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
+            }
+
+            if (data.logits != nullptr) {
+                if (active) {
+                    res->t_sampled_logits[rows[i]] = data.logits;
+                }
+                outs[1] = data.logits;
+                ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
+            }
+
+            if (data.candidates != nullptr) {
+                if (active) {
+                    res->t_candidates[rows[i]] = data.candidates;
+                }
+                outs[1] = data.candidates;
+                ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
+            }
+        }
+    }
+
+    // TODO: Call backend_accept after all samplers have been applied.
     /*
     for (const auto & [seq_id, sampler] : samplers) {
-        if (auto it = res->t_sampled.find(seq_id); it != res->t_sampled.end()) {
-            ggml_tensor * selected_token = it->second;
-            if (selected_token != nullptr) {
-                llama_sampler_accept_ggml(sampler, ctx0, gf, selected_token);
+        const auto it = sampling_rows.find(seq_id);
+        if (it == sampling_rows.end()) {
+            continue;
+        }
+
+        for (uint32_t row : it->second) {
+            ggml_tensor * selected_token = res->t_sampled[row];
+            if (selected_token != nullptr && sampler->iface->backend_accept) {
+                sampler->iface->backend_accept(sampler, ctx0, gf, selected_token);
             }
         }
     }

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -904,10 +904,10 @@ public:
 
     std::vector<ggml_tensor *> t_layer_inp;
 
-    std::map<llama_seq_id, ggml_tensor *> t_sampled_logits;
-    std::map<llama_seq_id, ggml_tensor *> t_candidates;
-    std::map<llama_seq_id, ggml_tensor *> t_sampled;
-    std::map<llama_seq_id, ggml_tensor *> t_sampled_probs;
+    std::vector<ggml_tensor *> t_sampled;
+    std::vector<ggml_tensor *> t_sampled_probs;
+    std::vector<ggml_tensor *> t_sampled_logits;
+    std::vector<ggml_tensor *> t_candidates;
 
     std::vector<llm_graph_input_ptr> inputs;
     std::vector<llm_graph_fused_node> fused_nodes;

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -603,6 +603,10 @@ static llama_sampler_backend_probe llama_sampler_backend_probe_graph(
         }
     }
 
+    if (sampler->iface->backend_reset) {
+        sampler->iface->backend_reset(sampler);
+    }
+
     return { std::move(ctx_ptr), gf };
 }
 
@@ -1085,6 +1089,8 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     // inputs for the current sampling graph
     std::vector<ggml_tensor *> inp_uniforms;
+
+    bool copy_candidates = false;
 };
 
 static const char * llama_sampler_dist_name(const struct llama_sampler * smpl) {
@@ -1193,7 +1199,8 @@ static bool llama_sampler_dist_backend_init(
         ggml_backend_buffer_type_t   buft,
         uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
+
+    sctx->copy_candidates = n_outputs_per_seq_max > 1;
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1261,9 +1268,11 @@ static void llama_sampler_dist_backend_apply(
         sampled_token = ggml_get_rows(ctx, candidates, idx);
         ggml_set_name(sampled_token, "dist_sampled_token");
 
-        // candidates may be a view whose backing storage can be reused
-        data->candidates = ggml_cont(ctx, data->candidates);
-        ggml_set_name(data->candidates, "dist_candidates_out");
+        if (sctx->copy_candidates) {
+            // candidates may be a view whose backing storage can be reused
+            data->candidates = ggml_cont(ctx, data->candidates);
+            ggml_set_name(data->candidates, "dist_candidates_out");
+        }
     }
 
     data->sampled = sampled_token;

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1245,6 +1245,9 @@ static void llama_sampler_dist_backend_apply(
     struct ggml_tensor * idxf = ggml_sum(ctx, mask);
     ggml_set_name(idxf, "dist_index_f32");
 
+    // Clamp to prevent out-of-bounds access when computing the index.
+    idxf = ggml_clamp(ctx, idxf, 1.0f, mask->ne[0]);
+
     // Use ggml_scale_bias to scale the index value by -1 and then add the size
     // of the mask to that value so we get the correct index ((-1 * idxf) + n).
     struct ggml_tensor * idx = ggml_cast(ctx, ggml_scale_bias(ctx, idxf, -1.0f, mask->ne[0]), GGML_TYPE_I32);

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1121,7 +1121,7 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     std::mt19937 rng;
 
-    // multi-output backend draws are committed as an accepted prefix
+    // use a temporary RNG for multi-output sampling so rejected tokens do not advance rng
     bool backend_transactional;
     std::mt19937 rng_backend;
     size_t n_backend_draws_generated;

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -2950,8 +2950,14 @@ static void llama_sampler_penalties_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_penalties_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_penalties *) smpl->ctx;
+
+    if (n_outputs_per_seq_max > 1) {
+        sctx->init(false);
+        return false;
+    }
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -3112,6 +3118,12 @@ static void llama_sampler_penalties_backend_set_input(struct llama_sampler * smp
     ggml_backend_tensor_set(sctx->inp_counts,    sctx->host_counts.data(),    0, sctx->n_max * sizeof(int32_t));
 }
 
+static void llama_sampler_penalties_backend_reset(struct llama_sampler * smpl) {
+    auto * sctx = (llama_sampler_penalties *) smpl->ctx;
+    sctx->inp_token_ids = nullptr;
+    sctx->inp_counts    = nullptr;
+}
+
 static struct llama_sampler_i llama_sampler_penalties_i = {
     /* .name              = */ llama_sampler_penalties_name,
     /* .accept            = */ llama_sampler_penalties_accept,
@@ -3123,7 +3135,7 @@ static struct llama_sampler_i llama_sampler_penalties_i = {
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_penalties_backend_apply,
     /* .backend_set_input = */ llama_sampler_penalties_backend_set_input,
-    /* .backend_reset     = */ nullptr,
+    /* .backend_reset     = */ llama_sampler_penalties_backend_reset,
 };
 
 struct llama_sampler * llama_sampler_init_penalties(

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -468,10 +468,10 @@ static void llama_sampler_empty_free(struct llama_sampler * smpl) {
 static bool llama_sampler_empty_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     GGML_UNUSED(smpl);
     GGML_UNUSED(buft);
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     return true;
 }
@@ -715,7 +715,7 @@ static void llama_sampler_chain_free(struct llama_sampler * smpl) {
 static bool llama_sampler_chain_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * chain = (llama_sampler_chain *) smpl->ctx;
 
     GGML_ASSERT(chain->is_init == false && "llama_sampler_chain_backend_init() called twice");
@@ -731,9 +731,9 @@ static bool llama_sampler_chain_backend_init(
         // to be able to run a sampler on the backend, it has to:
         // - have the .backend_init() API implemented
         // - return true during .backend_init()
-        // - support the requested output mode
+        // - support the requested per-sequence output limit
         if (res_cur && smpl.ptr->iface->backend_init) {
-            if (!smpl.ptr->iface->backend_init(smpl.ptr, buft, require_multi_output)) {
+            if (!smpl.ptr->iface->backend_init(smpl.ptr, buft, n_outputs_per_seq_max)) {
                 res_cur = false;
             }
         } else {
@@ -1025,9 +1025,9 @@ static void llama_sampler_greedy_apply(struct llama_sampler * /*smpl*/, llama_to
 static bool llama_sampler_greedy_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_greedy *) smpl->ctx;
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1191,9 +1191,9 @@ static void llama_sampler_dist_free(struct llama_sampler * smpl) {
 static bool llama_sampler_dist_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1350,9 +1350,9 @@ static void llama_sampler_top_k_free(struct llama_sampler * smpl) {
 static bool llama_sampler_top_k_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_top_k *) smpl->ctx;
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1499,9 +1499,9 @@ static void llama_sampler_top_p_free(struct llama_sampler * smpl) {
 static bool llama_sampler_top_p_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_top_p *) smpl->ctx;
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1697,9 +1697,9 @@ static void llama_sampler_min_p_free(struct llama_sampler * smpl) {
 static bool llama_sampler_min_p_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_min_p *) smpl->ctx;
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1949,9 +1949,9 @@ static void llama_sampler_backend_temp_sampling(
 static bool llama_sampler_temp_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_temp *) smpl->ctx;
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -2095,9 +2095,9 @@ static void llama_sampler_temp_ext_free(struct llama_sampler * smpl) {
 static bool llama_sampler_temp_ext_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_temp_ext *) smpl->ctx;
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -3865,9 +3865,9 @@ static void llama_sampler_logit_bias_backend_reset(struct llama_sampler * smpl) 
 static bool llama_sampler_logit_bias_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        bool                         require_multi_output) {
+        uint32_t                     n_outputs_per_seq_max) {
     GGML_UNUSED(buft);
-    GGML_UNUSED(require_multi_output);
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     auto * sctx = (llama_sampler_logit_bias *) smpl->ctx;
 

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -869,6 +869,7 @@ llama_token llama_sampler_sample(struct llama_sampler * smpl, struct llama_conte
     // If a backend sampler has already sampled a token, return it.
     if (sampled_token != LLAMA_TOKEN_NULL) {
         LLAMA_LOG_DEBUG("%s: Backend sampler selected token for idx %d. Skipping CPU samplers\n", __func__, idx);
+        llama_sampler_accept(smpl, sampled_token);
         return sampled_token;
     }
 
@@ -1087,6 +1088,12 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     std::mt19937 rng;
 
+    // multi-output backend draws are committed when their tokens are accepted
+    bool backend_transactional;
+    std::mt19937 rng_backend;
+    size_t n_backend_generated;
+    size_t n_backend_accepted;
+
     // inputs for the current sampling graph
     std::vector<ggml_tensor *> inp_uniforms;
 };
@@ -1172,6 +1179,9 @@ static void llama_sampler_dist_reset(struct llama_sampler * smpl) {
     auto * ctx = (llama_sampler_dist *) smpl->ctx;
     ctx->seed_cur = get_rng_seed(ctx->seed);
     ctx->rng.seed(ctx->seed_cur);
+    ctx->rng_backend = ctx->rng;
+    ctx->n_backend_generated = 0;
+    ctx->n_backend_accepted  = 0;
 }
 
 static struct llama_sampler * llama_sampler_dist_clone(const struct llama_sampler * smpl) {
@@ -1182,7 +1192,11 @@ static struct llama_sampler * llama_sampler_dist_clone(const struct llama_sample
     {
         auto * result_ctx = (llama_sampler_dist *) result->ctx;
 
-        result_ctx->rng = ctx->rng;
+        result_ctx->rng                   = ctx->rng;
+        result_ctx->backend_transactional = ctx->backend_transactional;
+        result_ctx->rng_backend           = ctx->rng_backend;
+        result_ctx->n_backend_generated   = ctx->n_backend_generated;
+        result_ctx->n_backend_accepted    = ctx->n_backend_accepted;
     }
 
     return result;
@@ -1197,11 +1211,14 @@ static bool llama_sampler_dist_backend_init(
         ggml_backend_buffer_type_t   buft,
         uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
     sctx->init(res);
+    sctx->backend_transactional = n_outputs_per_seq_max > 1;
+    sctx->rng_backend = sctx->rng;
+    sctx->n_backend_generated = 0;
+    sctx->n_backend_accepted  = 0;
 
     return res;
 }
@@ -1282,10 +1299,17 @@ static void llama_sampler_dist_backend_set_input(struct llama_sampler * smpl) {
     // different sequences).
     std::uniform_real_distribution<double> dist(0.0f, 1.0f);
 
+    auto & rng = sctx->backend_transactional ? sctx->rng_backend : sctx->rng;
+
     for (auto * inp_uniform : sctx->inp_uniforms) {
         GGML_ASSERT(inp_uniform != nullptr);
-        const float rnd = dist(sctx->rng);
+
+        const float rnd = dist(rng);
         ggml_backend_tensor_set(inp_uniform, &rnd, 0, sizeof(float));
+
+        if (sctx->backend_transactional) {
+            ++sctx->n_backend_generated;
+        }
     }
 }
 
@@ -1294,9 +1318,23 @@ static void llama_sampler_dist_backend_reset(struct llama_sampler * smpl) {
     sctx->inp_uniforms.clear();
 }
 
+static void llama_sampler_dist_accept(struct llama_sampler * smpl, llama_token token) {
+    GGML_UNUSED(token);
+
+    auto * sctx = (llama_sampler_dist *) smpl->ctx;
+
+    if (!sctx->backend_transactional || sctx->n_backend_accepted >= sctx->n_backend_generated) {
+        return;
+    }
+
+    std::uniform_real_distribution<double> dist(0.0f, 1.0f);
+    dist(sctx->rng);
+    ++sctx->n_backend_accepted;
+}
+
 static struct llama_sampler_i llama_sampler_dist_i = {
     /* .name              = */ llama_sampler_dist_name,
-    /* .accept            = */ nullptr,
+    /* .accept            = */ llama_sampler_dist_accept,
     /* .apply             = */ llama_sampler_dist_apply,
     /* .reset             = */ llama_sampler_dist_reset,
     /* .clone             = */ llama_sampler_dist_clone,
@@ -1314,12 +1352,37 @@ struct llama_sampler * llama_sampler_init_dist(uint32_t seed) {
         /* .iface = */ &llama_sampler_dist_i,
         /* .ctx   = */ new llama_sampler_dist {
             ("dist"),
-            /* .seed         = */ seed,
-            /* .seed_cur     = */ seed_cur,
-            /* .rng          = */ std::mt19937(seed_cur),
-            /* .inp_uniforms = */ {},
+            /* .seed                  = */ seed,
+            /* .seed_cur              = */ seed_cur,
+            /* .rng                   = */ std::mt19937(seed_cur),
+            /* .backend_transactional = */ false,
+            /* .rng_backend           = */ std::mt19937(seed_cur),
+            /* .n_backend_generated   = */ 0,
+            /* .n_backend_accepted    = */ 0,
+            /* .inp_uniforms          = */ {},
         }
     );
+}
+
+void llama_sampler_backend_begin(llama_sampler * sampler) {
+    GGML_ASSERT(sampler != nullptr);
+
+    if (sampler->iface == &llama_sampler_chain_i) {
+        auto * chain = (llama_sampler_chain *) sampler->ctx;
+        for (auto & entry : chain->samplers) {
+            if (!entry.is_backend) {
+                break;
+            }
+            llama_sampler_backend_begin(entry.ptr);
+        }
+    } else if (sampler->iface == &llama_sampler_dist_i) {
+        auto * ctx = (llama_sampler_dist *) sampler->ctx;
+        if (ctx->backend_transactional) {
+            ctx->rng_backend = ctx->rng;
+            ctx->n_backend_generated = 0;
+            ctx->n_backend_accepted  = 0;
+        }
+    }
 }
 
 // top-k

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -468,10 +468,10 @@ static void llama_sampler_empty_free(struct llama_sampler * smpl) {
 static bool llama_sampler_empty_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     GGML_UNUSED(smpl);
     GGML_UNUSED(buft);
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     return true;
 }
@@ -514,6 +514,7 @@ static struct llama_sampler_i llama_sampler_empty_i = {
     /* .backend_apply     = */ llama_sampler_empty_backend_apply,
     /* .backend_set_input = */ llama_sampler_empty_backend_set_input,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_empty(const char * name) {
@@ -554,6 +555,12 @@ struct llama_sampler_backend {
         this->support = support;
     }
 
+    // copy the state that is not tied to the current sampling graph
+    // samplers that hold only immutable configuration can use this as is
+    void copy_state(const llama_sampler_backend & src) {
+        GGML_UNUSED(src);
+    }
+
 private:
     std::string name;
     std::string name_ext;
@@ -561,6 +568,12 @@ private:
     bool is_init;
     bool support;
 };
+
+// .copy_state for samplers deriving from llama_sampler_backend
+template<typename T>
+static void llama_sampler_backend_copy_state(const struct llama_sampler * src, struct llama_sampler * dst) {
+    ((T *) dst->ctx)->copy_state(*(const T *) src->ctx);
+}
 
 struct llama_sampler_backend_probe {
     ggml_context_ptr ctx;
@@ -720,7 +733,7 @@ static void llama_sampler_chain_free(struct llama_sampler * smpl) {
 static bool llama_sampler_chain_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * chain = (llama_sampler_chain *) smpl->ctx;
 
     GGML_ASSERT(chain->is_init == false && "llama_sampler_chain_backend_init() called twice");
@@ -731,24 +744,24 @@ static bool llama_sampler_chain_backend_init(
     bool backend_prefix = true;
 
     for (auto & smpl : chain->samplers) {
-        bool res_cur = backend_prefix;
+        bool cur_prefix = backend_prefix;
 
         // to be able to run a sampler on the backend, it has to:
         // - have the .backend_init() API implemented
         // - return true during .backend_init()
         // - support the requested per-sequence output limit
-        if (res_cur && smpl.ptr->iface->backend_init) {
-            if (!smpl.ptr->iface->backend_init(smpl.ptr, buft, n_outputs_per_seq_max)) {
-                res_cur = false;
+        if (cur_prefix && smpl.ptr->iface->backend_init) {
+            if (!smpl.ptr->iface->backend_init(smpl.ptr, buft, n_outputs_max_per_seq)) {
+                cur_prefix = false;
             }
         } else {
-            res_cur = false;
+            cur_prefix = false;
         }
 
-        smpl.is_backend = res_cur;
-        backend_prefix = res_cur;
+        smpl.is_backend = cur_prefix;
+        backend_prefix = cur_prefix;
 
-        res = res && res_cur;
+        res = res && cur_prefix;
     }
 
     auto probe = llama_sampler_backend_probe_graph(smpl, 1024*1024, GGML_DEFAULT_GRAPH_SIZE, false);
@@ -822,6 +835,23 @@ static void llama_sampler_chain_backend_reset(struct llama_sampler * smpl) {
     }
 }
 
+static void llama_sampler_chain_copy_state(const struct llama_sampler * src, struct llama_sampler * dst) {
+    const auto * src_chain = (const llama_sampler_chain *) src->ctx;
+    auto * dst_chain = (llama_sampler_chain *) dst->ctx;
+
+    GGML_ASSERT(src_chain->samplers.size() == dst_chain->samplers.size());
+
+    for (size_t i = 0; i < src_chain->samplers.size(); ++i) {
+        llama_sampler_copy(src_chain->samplers[i].ptr, dst_chain->samplers[i].ptr);
+    }
+
+    // note: is_init, n_nodes and is_backend belong to the current sampling graph
+    dst_chain->params      = src_chain->params;
+    dst_chain->cur         = src_chain->cur;
+    dst_chain->t_sample_us = src_chain->t_sample_us;
+    dst_chain->n_sample    = src_chain->n_sample;
+}
+
 static struct llama_sampler_i llama_sampler_chain_i = {
     /* .name              = */ llama_sampler_chain_name,
     /* .accept            = */ llama_sampler_chain_accept,
@@ -834,6 +864,7 @@ static struct llama_sampler_i llama_sampler_chain_i = {
     /* .backend_apply     = */ llama_sampler_chain_backend_apply,
     /* .backend_set_input = */ llama_sampler_chain_backend_set_input,
     /* .backend_reset     = */ llama_sampler_chain_backend_reset,
+    /* .copy_state        = */ llama_sampler_chain_copy_state,
 };
 
 struct llama_sampler * llama_sampler_chain_init(struct llama_sampler_chain_params params) {
@@ -1031,9 +1062,9 @@ static void llama_sampler_greedy_apply(struct llama_sampler * /*smpl*/, llama_to
 static bool llama_sampler_greedy_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_greedy *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1070,6 +1101,7 @@ static struct llama_sampler_i llama_sampler_greedy_i = {
     /* .backend_apply     = */ llama_sampler_greedy_backend_apply,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_greedy>,
 };
 
 struct llama_sampler * llama_sampler_init_greedy() {
@@ -1097,6 +1129,15 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     // inputs for the current sampling graph
     std::vector<ggml_tensor *> inp_uniforms;
+
+    void copy_state(const llama_sampler_dist & src) {
+        // note: inp_uniforms and backend_transactional belong to the current sampling graph
+        seed_cur                  = src.seed_cur;
+        rng                       = src.rng;
+        rng_backend               = src.rng_backend;
+        n_backend_draws_generated = src.n_backend_draws_generated;
+        n_backend_draws_committed = src.n_backend_draws_committed;
+    }
 };
 
 static const char * llama_sampler_dist_name(const struct llama_sampler * smpl) {
@@ -1196,6 +1237,7 @@ static struct llama_sampler * llama_sampler_dist_clone(const struct llama_sample
     {
         auto * result_ctx = (llama_sampler_dist *) result->ctx;
 
+        result_ctx->seed_cur                  = ctx->seed_cur;
         result_ctx->rng                       = ctx->rng;
         result_ctx->backend_transactional     = ctx->backend_transactional;
         result_ctx->rng_backend               = ctx->rng_backend;
@@ -1213,13 +1255,13 @@ static void llama_sampler_dist_free(struct llama_sampler * smpl) {
 static bool llama_sampler_dist_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
     sctx->init(res);
-    sctx->backend_transactional = n_outputs_per_seq_max > 1;
+    sctx->backend_transactional = n_outputs_max_per_seq > 1;
     sctx->rng_backend = sctx->rng;
     sctx->n_backend_draws_generated = 0;
     sctx->n_backend_draws_committed = 0;
@@ -1297,7 +1339,7 @@ static void llama_sampler_dist_backend_set_input(struct llama_sampler * smpl) {
     GGML_ASSERT(!sctx->inp_uniforms.empty());
 
     // We sample in double precision and cast to float to match rnd numbers of
-    // llama_dampler_dist which uses double precision (sampling from
+    // llama_sampler_dist which uses double precision (sampling from
     // std::uniform_real_distribution<double> and
     // std::uniform_real_distribution<float> with same rng will produce
     // different sequences).
@@ -1349,6 +1391,7 @@ static struct llama_sampler_i llama_sampler_dist_i = {
     /* .backend_apply     = */ llama_sampler_dist_backend_apply,
     /* .backend_set_input = */ llama_sampler_dist_backend_set_input,
     /* .backend_reset     = */ llama_sampler_dist_backend_reset,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_dist>,
 };
 
 struct llama_sampler * llama_sampler_init_dist(uint32_t seed) {
@@ -1418,9 +1461,9 @@ static void llama_sampler_top_k_free(struct llama_sampler * smpl) {
 static bool llama_sampler_top_k_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_top_k *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1468,6 +1511,7 @@ static struct llama_sampler_i llama_sampler_top_k_i = {
     /* .backend_apply     = */ llama_sampler_top_k_backend_apply,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_top_k>,
 };
 
 struct llama_sampler * llama_sampler_init_top_k(int32_t k) {
@@ -1567,9 +1611,9 @@ static void llama_sampler_top_p_free(struct llama_sampler * smpl) {
 static bool llama_sampler_top_p_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_top_p *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1667,6 +1711,7 @@ static struct llama_sampler_i llama_sampler_top_p_i = {
     /* .backend_apply     = */ llama_sampler_top_p_backend_apply,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_top_p>,
 };
 
 struct llama_sampler * llama_sampler_init_top_p(float p, size_t min_keep) {
@@ -1765,9 +1810,9 @@ static void llama_sampler_min_p_free(struct llama_sampler * smpl) {
 static bool llama_sampler_min_p_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_min_p *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1829,6 +1874,7 @@ static struct llama_sampler_i llama_sampler_min_p_i = {
     /* .backend_apply     = */ llama_sampler_min_p_backend_apply,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_min_p>,
 };
 
 struct llama_sampler * llama_sampler_init_min_p(float p, size_t min_keep) {
@@ -1940,6 +1986,7 @@ static struct llama_sampler_i llama_sampler_typical_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_typical(float p, size_t min_keep) {
@@ -2017,9 +2064,9 @@ static void llama_sampler_backend_temp_sampling(
 static bool llama_sampler_temp_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_temp *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -2049,6 +2096,7 @@ static struct llama_sampler_i llama_sampler_temp_i = {
     /* .backend_apply     = */ llama_sampler_temp_backend_apply,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_temp>,
 };
 
 struct llama_sampler * llama_sampler_init_temp(float temp) {
@@ -2163,9 +2211,9 @@ static void llama_sampler_temp_ext_free(struct llama_sampler * smpl) {
 static bool llama_sampler_temp_ext_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_temp_ext *) smpl->ctx;
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -2251,6 +2299,7 @@ static struct llama_sampler_i llama_sampler_temp_ext_i = {
     /* .backend_apply     = */ llama_sampler_temp_ext_backend_apply,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_temp_ext>,
 };
 
 struct llama_sampler * llama_sampler_init_temp_ext(float temp, float delta, float exponent) {
@@ -2359,6 +2408,7 @@ static struct llama_sampler_i llama_sampler_xtc_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_xtc(float p, float t, size_t min_keep, uint32_t seed) {
@@ -2447,7 +2497,7 @@ static struct llama_sampler * llama_sampler_mirostat_clone(const struct llama_sa
 
     // copy the state
     {
-        auto * result_ctx = (llama_sampler_mirostat *) smpl->ctx;
+        auto * result_ctx = (llama_sampler_mirostat *) result->ctx;
 
         result_ctx->mu  = ctx->mu;
         result_ctx->rng = ctx->rng;
@@ -2479,6 +2529,7 @@ static struct llama_sampler_i llama_sampler_mirostat_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_mirostat(int32_t n_vocab, uint32_t seed, float tau, float eta, int32_t m) {
@@ -2584,6 +2635,7 @@ static struct llama_sampler_i llama_sampler_mirostat_v2_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_mirostat_v2(uint32_t seed, float tau, float eta) {
@@ -2706,6 +2758,7 @@ static struct llama_sampler_i llama_sampler_grammar_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 static struct llama_sampler * llama_sampler_init_grammar_impl(
@@ -2820,6 +2873,12 @@ struct llama_sampler_penalties : public llama_sampler_backend {
 
     std::vector<int32_t> host_token_ids;
     std::vector<int32_t> host_counts;
+
+    void copy_state(const llama_sampler_penalties & src) {
+        // note: inp_token_ids/inp_counts belong to the current sampling graph
+        prev        = src.prev;
+        token_count = src.token_count;
+    }
 
     static bool is_disabled(
             int32_t penalty_last_n,
@@ -2951,10 +3010,10 @@ static void llama_sampler_penalties_free(struct llama_sampler * smpl) {
 static bool llama_sampler_penalties_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     auto * sctx = (llama_sampler_penalties *) smpl->ctx;
 
-    if (n_outputs_per_seq_max > 1) {
+    if (n_outputs_max_per_seq > 1) {
         sctx->init(false);
         return false;
     }
@@ -3136,6 +3195,7 @@ static struct llama_sampler_i llama_sampler_penalties_i = {
     /* .backend_apply     = */ llama_sampler_penalties_backend_apply,
     /* .backend_set_input = */ llama_sampler_penalties_backend_set_input,
     /* .backend_reset     = */ llama_sampler_penalties_backend_reset,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_penalties>,
 };
 
 struct llama_sampler * llama_sampler_init_penalties(
@@ -3232,6 +3292,7 @@ static struct llama_sampler_i llama_sampler_top_n_sigma_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_top_n_sigma(float n) {
@@ -3570,6 +3631,7 @@ static struct llama_sampler_i llama_sampler_dry_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_dry(const struct llama_vocab * vocab, float dry_multiplier, float dry_base, int32_t dry_allowed_length, int32_t dry_penalty_last_n, const char** seq_breakers, size_t num_breakers) {
@@ -3790,6 +3852,7 @@ static struct llama_sampler_i llama_sampler_adaptive_p_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_adaptive_p(
@@ -3945,9 +4008,9 @@ static void llama_sampler_logit_bias_backend_reset(struct llama_sampler * smpl) 
 static bool llama_sampler_logit_bias_backend_init(
         struct llama_sampler       * smpl,
         ggml_backend_buffer_type_t   buft,
-        uint32_t                     n_outputs_per_seq_max) {
+        uint32_t                     n_outputs_max_per_seq) {
     GGML_UNUSED(buft);
-    GGML_UNUSED(n_outputs_per_seq_max);
+    GGML_UNUSED(n_outputs_max_per_seq);
 
     auto * sctx = (llama_sampler_logit_bias *) smpl->ctx;
 
@@ -3972,6 +4035,7 @@ static struct llama_sampler_i llama_sampler_logit_bias_i = {
     /* .backend_apply     = */ llama_sampler_logit_bias_backend_apply,
     /* .backend_set_input = */ llama_sampler_logit_bias_backend_set_input,
     /* .backend_reset     = */ llama_sampler_logit_bias_backend_reset,
+    /* .copy_state        = */ llama_sampler_backend_copy_state<llama_sampler_logit_bias>,
 };
 
 struct llama_sampler * llama_sampler_init_logit_bias(
@@ -4216,6 +4280,7 @@ static struct llama_sampler_i llama_sampler_infill_i = {
     /* .backend_apply     = */ nullptr,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_infill(const struct llama_vocab * vocab) {
@@ -4227,6 +4292,32 @@ struct llama_sampler * llama_sampler_init_infill(const struct llama_vocab * voca
             /* .buf1  = */ std::vector<char>(512),
         }
     );
+}
+
+void llama_sampler_copy(const struct llama_sampler * src, struct llama_sampler * dst) {
+    if (!src || !dst || src == dst) {
+        return;
+    }
+
+    GGML_ASSERT(src->iface == dst->iface && "llama_sampler_copy: cannot copy between different sampler types");
+
+    if (dst->iface->copy_state) {
+        dst->iface->copy_state(src, dst);
+        return;
+    }
+
+    // build a temporary sampler carrying src's current state
+    llama_sampler * tmp = llama_sampler_clone(src);
+
+    // free dst's old state (frees dst->ctx, including children for a chain)
+    if (dst->iface->free) {
+        dst->iface->free(dst);
+    }
+
+    // transplant tmp's state into dst, then destroy the (now empty) temp shell
+    dst->ctx = tmp->ctx;
+    tmp->ctx = nullptr;
+    delete tmp;
 }
 
 // utils

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -467,9 +467,11 @@ static void llama_sampler_empty_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_empty_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     GGML_UNUSED(smpl);
     GGML_UNUSED(buft);
+    GGML_UNUSED(require_multi_output);
 
     return true;
 }
@@ -510,6 +512,7 @@ static struct llama_sampler_i llama_sampler_empty_i = {
     /* .backend_init      = */ llama_sampler_empty_backend_init,
     /* .backend_accept    = */ llama_sampler_empty_backend_accept,
     /* .backend_apply     = */ llama_sampler_empty_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ llama_sampler_empty_backend_set_input,
 };
 
@@ -559,6 +562,60 @@ private:
     bool support;
 };
 
+struct llama_sampler_backend_probe {
+    ggml_context_ptr ctx;
+    ggml_cgraph * gf;
+};
+
+static llama_sampler_backend_probe llama_sampler_backend_probe_graph(
+        llama_sampler * sampler,
+        int64_t         n_candidates,
+        uint32_t        max_nodes) {
+    ggml_init_params params = {
+        /*.mem_size   =*/ max_nodes * ggml_tensor_overhead() + ggml_graph_overhead_custom(max_nodes, false),
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+
+    ggml_context_ptr ctx_ptr { ggml_init(params) };
+    if (!ctx_ptr) {
+        throw std::runtime_error(format("failed to create ggml context"));
+    }
+
+    auto * ctx = ctx_ptr.get();
+    auto * gf = ggml_new_graph_custom(ctx, max_nodes, false);
+
+    llama_sampler_data data = {
+        /*.logits       =*/ ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n_candidates),
+        /*.probs        =*/ nullptr,
+        /*.sampled      =*/ nullptr,
+        /*.candidates   =*/ ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_candidates),
+    };
+
+    if (sampler->iface->backend_reset) {
+        sampler->iface->backend_reset(sampler);
+    }
+    sampler->iface->backend_apply(sampler, ctx, gf, &data);
+
+    for (auto * output : { data.logits, data.probs, data.sampled, data.candidates }) {
+        if (output) {
+            ggml_build_forward_expand(gf, output);
+        }
+    }
+
+    return { std::move(ctx_ptr), gf };
+}
+
+static uint32_t llama_sampler_backend_probe_n_nodes(const llama_sampler_backend_probe & probe) {
+    uint32_t n_tensors = 0;
+    for (auto * tensor = ggml_get_first_tensor(probe.ctx.get()); tensor;
+            tensor = ggml_get_next_tensor(probe.ctx.get(), tensor)) {
+        ++n_tensors;
+    }
+
+    return std::max<uint32_t>(ggml_graph_n_nodes(probe.gf), n_tensors);
+}
+
 // check if all ggml ops used by the sampler are supported by the backend
 static bool llama_sampler_backend_support(
         llama_sampler              * smpl,
@@ -569,50 +626,10 @@ static bool llama_sampler_backend_support(
         return true;
     }
 
-    ggml_init_params params = {
-        /*.mem_size   =*/ 128*ggml_tensor_overhead() + ggml_graph_overhead(),
-        /*.mem_buffer =*/ NULL,
-        /*.no_alloc   =*/ true,
-    };
+    auto probe = llama_sampler_backend_probe_graph(smpl, 1024*1024, GGML_DEFAULT_GRAPH_SIZE);
 
-    ggml_context_ptr ctx_ptr { ggml_init(params) };
-    if (!ctx_ptr) {
-        throw std::runtime_error(format("failed to create ggml context"));
-    }
-
-    ggml_context * ctx = ctx_ptr.get();
-
-    const int64_t n = 1024*1024;
-
-    llama_sampler_data data = {
-        /*.logits     = */ ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n),
-        /*.probs      = */ nullptr,
-        /*.sampled    = */ nullptr,
-        /*.candidates = */ ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n),
-    };
-
-    ggml_cgraph * gf = ggml_new_graph(ctx);
-
-    smpl->iface->backend_apply(smpl, ctx, gf, &data);
-
-    if (data.logits) {
-        ggml_build_forward_expand(gf, data.logits);
-    }
-
-    if (data.probs) {
-        ggml_build_forward_expand(gf, data.probs);
-    }
-
-    if (data.sampled) {
-        ggml_build_forward_expand(gf, data.sampled);
-    }
-
-    if (data.candidates) {
-        ggml_build_forward_expand(gf, data.candidates);
-    }
-
-    for (int i = 0; i < ggml_graph_n_nodes(gf); i++) {
-        struct ggml_tensor * op = ggml_graph_node(gf, i);
+    for (int i = 0; i < ggml_graph_n_nodes(probe.gf); i++) {
+        struct ggml_tensor * op = ggml_graph_node(probe.gf, i);
 
         if (!ggml_backend_dev_supports_op(device, op)) {
             LLAMA_LOG_WARN("%s: device '%s' does not have support for op %s needed for sampler '%s'\n",
@@ -697,7 +714,8 @@ static void llama_sampler_chain_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_chain_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * chain = (llama_sampler_chain *) smpl->ctx;
 
     GGML_ASSERT(chain->is_init == false && "llama_sampler_chain_backend_init() called twice");
@@ -705,15 +723,17 @@ static bool llama_sampler_chain_backend_init(
     chain->is_init = true;
 
     bool res = true;
+    bool backend_prefix = true;
 
     for (auto & smpl : chain->samplers) {
-        bool res_cur = true;
+        bool res_cur = backend_prefix;
 
         // to be able to run a sampler on the backend, it has to:
         // - have the .backend_init() API implemented
         // - return true during .backend_init()
-        if (smpl.ptr->iface->backend_init) {
-            if (!smpl.ptr->iface->backend_init(smpl.ptr, buft)) {
+        // - support the requested output mode
+        if (res_cur && smpl.ptr->iface->backend_init) {
+            if (!smpl.ptr->iface->backend_init(smpl.ptr, buft, require_multi_output)) {
                 res_cur = false;
             }
         } else {
@@ -721,9 +741,13 @@ static bool llama_sampler_chain_backend_init(
         }
 
         smpl.is_backend = res_cur;
+        backend_prefix = res_cur;
 
         res = res && res_cur;
     }
+
+    auto probe = llama_sampler_backend_probe_graph(smpl, 1024*1024, GGML_DEFAULT_GRAPH_SIZE);
+    chain->n_nodes = llama_sampler_backend_probe_n_nodes(probe);
 
     return res;
 }
@@ -780,6 +804,19 @@ static void llama_sampler_chain_backend_set_input(struct llama_sampler * smpl) {
     }
 }
 
+static void llama_sampler_chain_backend_reset(struct llama_sampler * smpl) {
+    auto * chain = (llama_sampler_chain *) smpl->ctx;
+
+    for (auto & entry : chain->samplers) {
+        if (!entry.is_backend) {
+            break;
+        }
+        if (entry.ptr->iface->backend_reset) {
+            entry.ptr->iface->backend_reset(entry.ptr);
+        }
+    }
+}
+
 static struct llama_sampler_i llama_sampler_chain_i = {
     /* .name              = */ llama_sampler_chain_name,
     /* .accept            = */ llama_sampler_chain_accept,
@@ -790,6 +827,7 @@ static struct llama_sampler_i llama_sampler_chain_i = {
     /* .backend_init      = */ llama_sampler_chain_backend_init,
     /* .backend_accept    = */ llama_sampler_chain_backend_accept,
     /* .backend_apply     = */ llama_sampler_chain_backend_apply,
+    /* .backend_reset     = */ llama_sampler_chain_backend_reset,
     /* .backend_set_input = */ llama_sampler_chain_backend_set_input,
 };
 
@@ -797,14 +835,25 @@ struct llama_sampler * llama_sampler_chain_init(struct llama_sampler_chain_param
     return llama_sampler_init(
         /* .iface = */ &llama_sampler_chain_i,
         /* .ctx   = */ new llama_sampler_chain {
-            /* .params      = */ params,
-            /* .is_init     = */ false,
-            /* .samplers    = */ {},
-            /* .cur         = */ {},
-            /* .t_sample_us = */ 0,
-            /* .n_sample    = */ 0,
+            /* .params               = */ params,
+            /* .is_init              = */ false,
+            /* .n_nodes              = */ 0,
+            /* .samplers             = */ {},
+            /* .cur                  = */ {},
+            /* .t_sample_us          = */ 0,
+            /* .n_sample             = */ 0,
         }
     );
+}
+
+uint32_t llama_sampler_backend_n_nodes(const llama_sampler * sampler) {
+    GGML_ASSERT(sampler != nullptr);
+    GGML_ASSERT(sampler->iface == &llama_sampler_chain_i);
+
+    const auto * chain = (const llama_sampler_chain *) sampler->ctx;
+    GGML_ASSERT(chain->is_init);
+
+    return chain->n_nodes;
 }
 
 llama_token llama_sampler_sample(struct llama_sampler * smpl, struct llama_context * ctx, int32_t idx) {
@@ -975,8 +1024,10 @@ static void llama_sampler_greedy_apply(struct llama_sampler * /*smpl*/, llama_to
 
 static bool llama_sampler_greedy_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * sctx = (llama_sampler_greedy *) smpl->ctx;
+    GGML_UNUSED(require_multi_output);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1011,6 +1062,7 @@ static struct llama_sampler_i llama_sampler_greedy_i = {
     /* .backend_init      = */ llama_sampler_greedy_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_greedy_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -1031,7 +1083,8 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     std::mt19937 rng;
 
-    ggml_tensor * inp_uniform;
+    // inputs for the current sampling graph
+    std::vector<ggml_tensor *> inp_uniforms;
 };
 
 static const char * llama_sampler_dist_name(const struct llama_sampler * smpl) {
@@ -1137,8 +1190,10 @@ static void llama_sampler_dist_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_dist_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
+    GGML_UNUSED(require_multi_output);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1156,9 +1211,10 @@ static void llama_sampler_dist_backend_apply(
 
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
 
-    sctx->inp_uniform = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
-    ggml_set_name (sctx->inp_uniform, "uniform");
-    ggml_set_input(sctx->inp_uniform);
+    ggml_tensor * inp_uniform = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+    ggml_format_name(inp_uniform, "uniform_%zu", sctx->inp_uniforms.size());
+    ggml_set_input(inp_uniform);
+    sctx->inp_uniforms.push_back(inp_uniform);
 
     // flatten
     struct ggml_tensor * logits = ggml_reshape_1d(ctx, data->logits, ggml_nelements(data->logits));
@@ -1174,7 +1230,7 @@ static void llama_sampler_dist_backend_apply(
     // Recall that each entry in cumsum is the cumulative probability up to that
     // index so values stay negative while the cumulative total is below the
     // random value, and become zero/positive once the threshold is crossed.
-    struct ggml_tensor * diff = ggml_sub(ctx, cumsum, sctx->inp_uniform);
+    struct ggml_tensor * diff = ggml_sub(ctx, cumsum, inp_uniform);
     ggml_set_name(diff, "dist_cumsum");
 
     // The ggml_step function produces a tensor where entries are 1 if the
@@ -1201,6 +1257,10 @@ static void llama_sampler_dist_backend_apply(
 
         sampled_token = ggml_get_rows(ctx, candidates, idx);
         ggml_set_name(sampled_token, "dist_sampled_token");
+
+        // candidates may be a view whose backing storage can be reused
+        data->candidates = ggml_cont(ctx, data->candidates);
+        ggml_set_name(data->candidates, "dist_candidates_out");
     }
 
     data->sampled = sampled_token;
@@ -1210,7 +1270,7 @@ static void llama_sampler_dist_backend_apply(
 static void llama_sampler_dist_backend_set_input(struct llama_sampler * smpl) {
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
 
-    GGML_ASSERT(sctx->inp_uniform != nullptr);
+    GGML_ASSERT(!sctx->inp_uniforms.empty());
 
     // We sample in double precision and cast to float to match rnd numbers of
     // llama_dampler_dist which uses double precision (sampling from
@@ -1218,9 +1278,17 @@ static void llama_sampler_dist_backend_set_input(struct llama_sampler * smpl) {
     // std::uniform_real_distribution<float> with same rng will produce
     // different sequences).
     std::uniform_real_distribution<double> dist(0.0f, 1.0f);
-    const float rnd = dist(sctx->rng);
 
-    ggml_backend_tensor_set(sctx->inp_uniform, &rnd, 0, sizeof(float));
+    for (auto * inp_uniform : sctx->inp_uniforms) {
+        GGML_ASSERT(inp_uniform != nullptr);
+        const float rnd = dist(sctx->rng);
+        ggml_backend_tensor_set(inp_uniform, &rnd, 0, sizeof(float));
+    }
+}
+
+static void llama_sampler_dist_backend_reset(struct llama_sampler * smpl) {
+    auto * sctx = (llama_sampler_dist *) smpl->ctx;
+    sctx->inp_uniforms.clear();
 }
 
 static struct llama_sampler_i llama_sampler_dist_i = {
@@ -1233,6 +1301,7 @@ static struct llama_sampler_i llama_sampler_dist_i = {
     /* .backend_init      = */ llama_sampler_dist_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_dist_backend_apply,
+    /* .backend_reset     = */ llama_sampler_dist_backend_reset,
     /* .backend_set_input = */ llama_sampler_dist_backend_set_input,
 };
 
@@ -1242,10 +1311,10 @@ struct llama_sampler * llama_sampler_init_dist(uint32_t seed) {
         /* .iface = */ &llama_sampler_dist_i,
         /* .ctx   = */ new llama_sampler_dist {
             ("dist"),
-            /* .seed        = */ seed,
-            /* .seed_cur    = */ seed_cur,
-            /* .rng         = */ std::mt19937(seed_cur),
-            /* .inp_uniform = */ nullptr,
+            /* .seed         = */ seed,
+            /* .seed_cur     = */ seed_cur,
+            /* .rng          = */ std::mt19937(seed_cur),
+            /* .inp_uniforms = */ {},
         }
     );
 }
@@ -1277,8 +1346,10 @@ static void llama_sampler_top_k_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_top_k_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * sctx = (llama_sampler_top_k *) smpl->ctx;
+    GGML_UNUSED(require_multi_output);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1324,6 +1395,7 @@ static struct llama_sampler_i llama_sampler_top_k_i = {
     /* .backend_init      = */ llama_sampler_top_k_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_top_k_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -1423,8 +1495,10 @@ static void llama_sampler_top_p_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_top_p_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * sctx = (llama_sampler_top_p *) smpl->ctx;
+    GGML_UNUSED(require_multi_output);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1520,6 +1594,7 @@ static struct llama_sampler_i llama_sampler_top_p_i = {
     /* .backend_init      = */ llama_sampler_top_p_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_top_p_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -1618,8 +1693,10 @@ static void llama_sampler_min_p_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_min_p_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * sctx = (llama_sampler_min_p *) smpl->ctx;
+    GGML_UNUSED(require_multi_output);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1679,6 +1756,7 @@ static struct llama_sampler_i llama_sampler_min_p_i = {
     /* .backend_init      = */ llama_sampler_min_p_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_min_p_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -1789,6 +1867,7 @@ static struct llama_sampler_i llama_sampler_typical_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -1866,8 +1945,10 @@ static void llama_sampler_backend_temp_sampling(
 
 static bool llama_sampler_temp_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * sctx = (llama_sampler_temp *) smpl->ctx;
+    GGML_UNUSED(require_multi_output);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1895,6 +1976,7 @@ static struct llama_sampler_i llama_sampler_temp_i = {
     /* .backend_init      = */ llama_sampler_temp_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_temp_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -2009,8 +2091,10 @@ static void llama_sampler_temp_ext_free(struct llama_sampler * smpl) {
 
 static bool llama_sampler_temp_ext_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     auto * sctx = (llama_sampler_temp_ext *) smpl->ctx;
+    GGML_UNUSED(require_multi_output);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -2094,6 +2178,7 @@ static struct llama_sampler_i llama_sampler_temp_ext_i = {
     /* .backend_init      = */ llama_sampler_temp_ext_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_temp_ext_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -2201,6 +2286,7 @@ static struct llama_sampler_i llama_sampler_xtc_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -2320,6 +2406,7 @@ static struct llama_sampler_i llama_sampler_mirostat_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -2424,6 +2511,7 @@ static struct llama_sampler_i llama_sampler_mirostat_v2_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -2545,6 +2633,7 @@ static struct llama_sampler_i llama_sampler_grammar_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -2962,6 +3051,7 @@ static struct llama_sampler_i llama_sampler_penalties_i = {
     /* .backend_init      = */ llama_sampler_penalties_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_penalties_backend_apply,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ llama_sampler_penalties_backend_set_input,
 };
 
@@ -3057,6 +3147,7 @@ static struct llama_sampler_i llama_sampler_top_n_sigma_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -3394,6 +3485,7 @@ static struct llama_sampler_i llama_sampler_dry_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -3613,6 +3705,7 @@ static struct llama_sampler_i llama_sampler_adaptive_p_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
 };
 
@@ -3715,13 +3808,17 @@ static void llama_sampler_logit_bias_backend_apply(
 
     const size_t n = sctx->logit_bias.size();
 
-    sctx->inp_logit_bias = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, n);
-    ggml_set_name(sctx->inp_logit_bias, "logit_bias");
-    ggml_set_input(sctx->inp_logit_bias);
+    if (sctx->inp_logit_bias == nullptr) {
+        GGML_ASSERT(sctx->inp_logit_idxs == nullptr);
 
-    sctx->inp_logit_idxs = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n);
-    ggml_set_name(sctx->inp_logit_idxs, "logit_idxs");
-    ggml_set_input(sctx->inp_logit_idxs);
+        sctx->inp_logit_bias = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, n);
+        ggml_set_name(sctx->inp_logit_bias, "logit_bias");
+        ggml_set_input(sctx->inp_logit_bias);
+
+        sctx->inp_logit_idxs = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n);
+        ggml_set_name(sctx->inp_logit_idxs, "logit_idxs");
+        ggml_set_input(sctx->inp_logit_idxs);
+    }
 
     ggml_tensor * cur = ggml_fill(ctx, data->logits, 0.0f);
 
@@ -3756,10 +3853,18 @@ static void llama_sampler_logit_bias_backend_set_input(struct llama_sampler * sm
     ggml_backend_tensor_set(sctx->inp_logit_idxs, data_logit_idxs.data(), 0, ggml_nbytes(sctx->inp_logit_idxs));
 }
 
+static void llama_sampler_logit_bias_backend_reset(struct llama_sampler * smpl) {
+    auto * sctx = (llama_sampler_logit_bias *) smpl->ctx;
+    sctx->inp_logit_bias = nullptr;
+    sctx->inp_logit_idxs = nullptr;
+}
+
 static bool llama_sampler_logit_bias_backend_init(
         struct llama_sampler       * smpl,
-        ggml_backend_buffer_type_t   buft) {
+        ggml_backend_buffer_type_t   buft,
+        bool                         require_multi_output) {
     GGML_UNUSED(buft);
+    GGML_UNUSED(require_multi_output);
 
     auto * sctx = (llama_sampler_logit_bias *) smpl->ctx;
 
@@ -3782,6 +3887,7 @@ static struct llama_sampler_i llama_sampler_logit_bias_i = {
     /* .backend_init      = */ llama_sampler_logit_bias_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_logit_bias_backend_apply,
+    /* .backend_reset     = */ llama_sampler_logit_bias_backend_reset,
     /* .backend_set_input = */ llama_sampler_logit_bias_backend_set_input,
 };
 
@@ -4022,10 +4128,11 @@ static struct llama_sampler_i llama_sampler_infill_i = {
     /* .reset             = */ nullptr,
     /* .clone             = */ llama_sampler_infill_clone,
     /* .free              = */ llama_sampler_infill_free,
-    /* .backend_apply     = */ nullptr,
-    /* .backend_accept    = */ nullptr,
-    /* .backend_set_input = */ nullptr,
     /* .backend_init      = */ nullptr,
+    /* .backend_accept    = */ nullptr,
+    /* .backend_apply     = */ nullptr,
+    /* .backend_reset     = */ nullptr,
+    /* .backend_set_input = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_infill(const struct llama_vocab * vocab) {

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1114,7 +1114,11 @@ static void llama_sampler_dist_apply(struct llama_sampler * smpl, llama_token_da
 
     cur_p->selected = 0;
 
+    std::uniform_real_distribution<double> dist(0.0f, 1.0f);
+
     if (cur_p->size == 1) {
+        // keep the RNG state aligned with backend sampling, which draws once per output
+        dist(ctx->rng);
         cur_p->data[0].p = 1.0f;
         return;
     }
@@ -1139,7 +1143,6 @@ static void llama_sampler_dist_apply(struct llama_sampler * smpl, llama_token_da
     // sample from the obtained probabilities and normalize the probs in a single pass
     // this is ~3x faster on Mac with full gpt-oss vocab than the version below
     //
-    std::uniform_real_distribution<double> dist(0.0f, 1.0f);
     const double rnd = dist(ctx->rng);
 
           double sum_run = 0.0f;

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -512,8 +512,8 @@ static struct llama_sampler_i llama_sampler_empty_i = {
     /* .backend_init      = */ llama_sampler_empty_backend_init,
     /* .backend_accept    = */ llama_sampler_empty_backend_accept,
     /* .backend_apply     = */ llama_sampler_empty_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ llama_sampler_empty_backend_set_input,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_empty(const char * name) {
@@ -831,8 +831,8 @@ static struct llama_sampler_i llama_sampler_chain_i = {
     /* .backend_init      = */ llama_sampler_chain_backend_init,
     /* .backend_accept    = */ llama_sampler_chain_backend_accept,
     /* .backend_apply     = */ llama_sampler_chain_backend_apply,
-    /* .backend_reset     = */ llama_sampler_chain_backend_reset,
     /* .backend_set_input = */ llama_sampler_chain_backend_set_input,
+    /* .backend_reset     = */ llama_sampler_chain_backend_reset,
 };
 
 struct llama_sampler * llama_sampler_chain_init(struct llama_sampler_chain_params params) {
@@ -1067,8 +1067,8 @@ static struct llama_sampler_i llama_sampler_greedy_i = {
     /* .backend_init      = */ llama_sampler_greedy_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_greedy_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_greedy() {
@@ -1088,11 +1088,11 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     std::mt19937 rng;
 
-    // multi-output backend draws are committed when their tokens are accepted
+    // multi-output backend draws are committed as an accepted prefix
     bool backend_transactional;
     std::mt19937 rng_backend;
-    size_t n_backend_generated;
-    size_t n_backend_accepted;
+    size_t n_backend_draws_generated;
+    size_t n_backend_draws_committed;
 
     // inputs for the current sampling graph
     std::vector<ggml_tensor *> inp_uniforms;
@@ -1183,8 +1183,8 @@ static void llama_sampler_dist_reset(struct llama_sampler * smpl) {
     ctx->seed_cur = get_rng_seed(ctx->seed);
     ctx->rng.seed(ctx->seed_cur);
     ctx->rng_backend = ctx->rng;
-    ctx->n_backend_generated = 0;
-    ctx->n_backend_accepted  = 0;
+    ctx->n_backend_draws_generated = 0;
+    ctx->n_backend_draws_committed = 0;
 }
 
 static struct llama_sampler * llama_sampler_dist_clone(const struct llama_sampler * smpl) {
@@ -1195,11 +1195,11 @@ static struct llama_sampler * llama_sampler_dist_clone(const struct llama_sample
     {
         auto * result_ctx = (llama_sampler_dist *) result->ctx;
 
-        result_ctx->rng                   = ctx->rng;
-        result_ctx->backend_transactional = ctx->backend_transactional;
-        result_ctx->rng_backend           = ctx->rng_backend;
-        result_ctx->n_backend_generated   = ctx->n_backend_generated;
-        result_ctx->n_backend_accepted    = ctx->n_backend_accepted;
+        result_ctx->rng                       = ctx->rng;
+        result_ctx->backend_transactional     = ctx->backend_transactional;
+        result_ctx->rng_backend               = ctx->rng_backend;
+        result_ctx->n_backend_draws_generated = ctx->n_backend_draws_generated;
+        result_ctx->n_backend_draws_committed = ctx->n_backend_draws_committed;
     }
 
     return result;
@@ -1220,8 +1220,8 @@ static bool llama_sampler_dist_backend_init(
     sctx->init(res);
     sctx->backend_transactional = n_outputs_per_seq_max > 1;
     sctx->rng_backend = sctx->rng;
-    sctx->n_backend_generated = 0;
-    sctx->n_backend_accepted  = 0;
+    sctx->n_backend_draws_generated = 0;
+    sctx->n_backend_draws_committed = 0;
 
     return res;
 }
@@ -1311,7 +1311,7 @@ static void llama_sampler_dist_backend_set_input(struct llama_sampler * smpl) {
         ggml_backend_tensor_set(inp_uniform, &rnd, 0, sizeof(float));
 
         if (sctx->backend_transactional) {
-            ++sctx->n_backend_generated;
+            ++sctx->n_backend_draws_generated;
         }
     }
 }
@@ -1326,13 +1326,14 @@ static void llama_sampler_dist_accept(struct llama_sampler * smpl, llama_token t
 
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
 
-    if (!sctx->backend_transactional || sctx->n_backend_accepted >= sctx->n_backend_generated) {
+    if (!sctx->backend_transactional ||
+            sctx->n_backend_draws_committed >= sctx->n_backend_draws_generated) {
         return;
     }
 
     std::uniform_real_distribution<double> dist(0.0f, 1.0f);
     dist(sctx->rng);
-    ++sctx->n_backend_accepted;
+    ++sctx->n_backend_draws_committed;
 }
 
 static struct llama_sampler_i llama_sampler_dist_i = {
@@ -1345,8 +1346,8 @@ static struct llama_sampler_i llama_sampler_dist_i = {
     /* .backend_init      = */ llama_sampler_dist_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_dist_backend_apply,
-    /* .backend_reset     = */ llama_sampler_dist_backend_reset,
     /* .backend_set_input = */ llama_sampler_dist_backend_set_input,
+    /* .backend_reset     = */ llama_sampler_dist_backend_reset,
 };
 
 struct llama_sampler * llama_sampler_init_dist(uint32_t seed) {
@@ -1355,14 +1356,14 @@ struct llama_sampler * llama_sampler_init_dist(uint32_t seed) {
         /* .iface = */ &llama_sampler_dist_i,
         /* .ctx   = */ new llama_sampler_dist {
             ("dist"),
-            /* .seed                  = */ seed,
-            /* .seed_cur              = */ seed_cur,
-            /* .rng                   = */ std::mt19937(seed_cur),
-            /* .backend_transactional = */ false,
-            /* .rng_backend           = */ std::mt19937(seed_cur),
-            /* .n_backend_generated   = */ 0,
-            /* .n_backend_accepted    = */ 0,
-            /* .inp_uniforms          = */ {},
+            /* .seed                      = */ seed,
+            /* .seed_cur                  = */ seed_cur,
+            /* .rng                       = */ std::mt19937(seed_cur),
+            /* .backend_transactional     = */ false,
+            /* .rng_backend               = */ std::mt19937(seed_cur),
+            /* .n_backend_draws_generated = */ 0,
+            /* .n_backend_draws_committed = */ 0,
+            /* .inp_uniforms              = */ {},
         }
     );
 }
@@ -1382,8 +1383,8 @@ void llama_sampler_backend_begin(llama_sampler * sampler) {
         auto * ctx = (llama_sampler_dist *) sampler->ctx;
         if (ctx->backend_transactional) {
             ctx->rng_backend = ctx->rng;
-            ctx->n_backend_generated = 0;
-            ctx->n_backend_accepted  = 0;
+            ctx->n_backend_draws_generated = 0;
+            ctx->n_backend_draws_committed = 0;
         }
     }
 }
@@ -1464,8 +1465,8 @@ static struct llama_sampler_i llama_sampler_top_k_i = {
     /* .backend_init      = */ llama_sampler_top_k_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_top_k_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_top_k(int32_t k) {
@@ -1663,8 +1664,8 @@ static struct llama_sampler_i llama_sampler_top_p_i = {
     /* .backend_init      = */ llama_sampler_top_p_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_top_p_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_top_p(float p, size_t min_keep) {
@@ -1825,8 +1826,8 @@ static struct llama_sampler_i llama_sampler_min_p_i = {
     /* .backend_init      = */ llama_sampler_min_p_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_min_p_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_min_p(float p, size_t min_keep) {
@@ -1936,8 +1937,8 @@ static struct llama_sampler_i llama_sampler_typical_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_typical(float p, size_t min_keep) {
@@ -2045,8 +2046,8 @@ static struct llama_sampler_i llama_sampler_temp_i = {
     /* .backend_init      = */ llama_sampler_temp_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_temp_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_temp(float temp) {
@@ -2247,8 +2248,8 @@ static struct llama_sampler_i llama_sampler_temp_ext_i = {
     /* .backend_init      = */ llama_sampler_temp_ext_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_temp_ext_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_temp_ext(float temp, float delta, float exponent) {
@@ -2355,8 +2356,8 @@ static struct llama_sampler_i llama_sampler_xtc_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_xtc(float p, float t, size_t min_keep, uint32_t seed) {
@@ -2475,8 +2476,8 @@ static struct llama_sampler_i llama_sampler_mirostat_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_mirostat(int32_t n_vocab, uint32_t seed, float tau, float eta, int32_t m) {
@@ -2580,8 +2581,8 @@ static struct llama_sampler_i llama_sampler_mirostat_v2_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_mirostat_v2(uint32_t seed, float tau, float eta) {
@@ -2702,8 +2703,8 @@ static struct llama_sampler_i llama_sampler_grammar_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 static struct llama_sampler * llama_sampler_init_grammar_impl(
@@ -3120,8 +3121,8 @@ static struct llama_sampler_i llama_sampler_penalties_i = {
     /* .backend_init      = */ llama_sampler_penalties_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_penalties_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ llama_sampler_penalties_backend_set_input,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_penalties(
@@ -3216,8 +3217,8 @@ static struct llama_sampler_i llama_sampler_top_n_sigma_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_top_n_sigma(float n) {
@@ -3554,8 +3555,8 @@ static struct llama_sampler_i llama_sampler_dry_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_dry(const struct llama_vocab * vocab, float dry_multiplier, float dry_base, int32_t dry_allowed_length, int32_t dry_penalty_last_n, const char** seq_breakers, size_t num_breakers) {
@@ -3774,8 +3775,8 @@ static struct llama_sampler_i llama_sampler_adaptive_p_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_adaptive_p(
@@ -3956,8 +3957,8 @@ static struct llama_sampler_i llama_sampler_logit_bias_i = {
     /* .backend_init      = */ llama_sampler_logit_bias_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ llama_sampler_logit_bias_backend_apply,
-    /* .backend_reset     = */ llama_sampler_logit_bias_backend_reset,
     /* .backend_set_input = */ llama_sampler_logit_bias_backend_set_input,
+    /* .backend_reset     = */ llama_sampler_logit_bias_backend_reset,
 };
 
 struct llama_sampler * llama_sampler_init_logit_bias(
@@ -4200,8 +4201,8 @@ static struct llama_sampler_i llama_sampler_infill_i = {
     /* .backend_init      = */ nullptr,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ nullptr,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 struct llama_sampler * llama_sampler_init_infill(const struct llama_vocab * vocab) {

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1121,6 +1121,8 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     std::mt19937 rng;
 
+    // TODO: refactor + fix naming
+    //       https://github.com/ggml-org/llama.cpp/pull/25532/changes#r3749906719
     // use a temporary RNG for multi-output sampling so rejected tokens do not advance rng
     bool backend_transactional;
     std::mt19937 rng_backend;

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1089,8 +1089,6 @@ struct llama_sampler_dist : public llama_sampler_backend {
 
     // inputs for the current sampling graph
     std::vector<ggml_tensor *> inp_uniforms;
-
-    bool copy_candidates = false;
 };
 
 static const char * llama_sampler_dist_name(const struct llama_sampler * smpl) {
@@ -1199,8 +1197,7 @@ static bool llama_sampler_dist_backend_init(
         ggml_backend_buffer_type_t   buft,
         uint32_t                     n_outputs_per_seq_max) {
     auto * sctx = (llama_sampler_dist *) smpl->ctx;
-
-    sctx->copy_candidates = n_outputs_per_seq_max > 1;
+    GGML_UNUSED(n_outputs_per_seq_max);
 
     const bool res = llama_sampler_backend_support(smpl, buft);
 
@@ -1267,12 +1264,6 @@ static void llama_sampler_dist_backend_apply(
 
         sampled_token = ggml_get_rows(ctx, candidates, idx);
         ggml_set_name(sampled_token, "dist_sampled_token");
-
-        if (sctx->copy_candidates) {
-            // candidates may be a view whose backing storage can be reused
-            data->candidates = ggml_cont(ctx, data->candidates);
-            ggml_set_name(data->candidates, "dist_candidates_out");
-        }
     }
 
     data->sampled = sampled_token;

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -570,7 +570,8 @@ struct llama_sampler_backend_probe {
 static llama_sampler_backend_probe llama_sampler_backend_probe_graph(
         llama_sampler * sampler,
         int64_t         n_candidates,
-        uint32_t        max_nodes) {
+        uint32_t        max_nodes,
+        bool            with_candidates) {
     ggml_init_params params = {
         /*.mem_size   =*/ max_nodes * ggml_tensor_overhead() + ggml_graph_overhead_custom(max_nodes, false),
         /*.mem_buffer =*/ nullptr,
@@ -589,7 +590,7 @@ static llama_sampler_backend_probe llama_sampler_backend_probe_graph(
         /*.logits       =*/ ggml_new_tensor_1d(ctx, GGML_TYPE_F32, n_candidates),
         /*.probs        =*/ nullptr,
         /*.sampled      =*/ nullptr,
-        /*.candidates   =*/ ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_candidates),
+        /*.candidates   =*/ with_candidates ? ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_candidates) : nullptr,
     };
 
     if (sampler->iface->backend_reset) {
@@ -630,7 +631,7 @@ static bool llama_sampler_backend_support(
         return true;
     }
 
-    auto probe = llama_sampler_backend_probe_graph(smpl, 1024*1024, GGML_DEFAULT_GRAPH_SIZE);
+    auto probe = llama_sampler_backend_probe_graph(smpl, 1024*1024, GGML_DEFAULT_GRAPH_SIZE, true);
 
     for (int i = 0; i < ggml_graph_n_nodes(probe.gf); i++) {
         struct ggml_tensor * op = ggml_graph_node(probe.gf, i);
@@ -750,7 +751,7 @@ static bool llama_sampler_chain_backend_init(
         res = res && res_cur;
     }
 
-    auto probe = llama_sampler_backend_probe_graph(smpl, 1024*1024, GGML_DEFAULT_GRAPH_SIZE);
+    auto probe = llama_sampler_backend_probe_graph(smpl, 1024*1024, GGML_DEFAULT_GRAPH_SIZE, false);
     chain->n_nodes = llama_sampler_backend_probe_n_nodes(probe);
 
     return res;

--- a/src/llama-sampler.h
+++ b/src/llama-sampler.h
@@ -15,6 +15,8 @@ struct llama_sampler_chain {
     // has .backend_init() been called?
     bool is_init = false;
 
+    uint32_t n_nodes = 0;
+
     struct info {
         bool is_backend;
 
@@ -32,6 +34,8 @@ struct llama_sampler_chain {
 
     mutable int32_t n_sample;
 };
+
+uint32_t llama_sampler_backend_n_nodes(const llama_sampler * sampler);
 
 struct llama_sampler * llama_sampler_init_dry_testing(
         float   dry_multiplier,

--- a/src/llama-sampler.h
+++ b/src/llama-sampler.h
@@ -36,6 +36,7 @@ struct llama_sampler_chain {
 };
 
 uint32_t llama_sampler_backend_n_nodes(const llama_sampler * sampler);
+void llama_sampler_backend_begin(llama_sampler * sampler);
 
 struct llama_sampler * llama_sampler_init_dry_testing(
         float   dry_multiplier,

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -388,6 +388,25 @@ static void test_view_inplace() {
     GGML_ASSERT(backend.context->allocated_total() <= 24);
 }
 
+static void test_output_view_lifetime() {
+    dummy_backend backend      = dummy_backend_init(SIZE_MAX);
+    auto [ctx, graph, ctx_ptr] = make_context();
+
+    ggml_tensor * x[5];
+    x[0] = make_input_1d(ctx, 4);
+    x[1] = ggml_scale(ctx, x[0], 2.0f);
+    x[2] = ggml_reshape_2d(ctx, x[1], 2, 2);
+    x[3] = ggml_sum(ctx, x[2]);
+    x[4] = ggml_pad(ctx, x[3], 3, 0, 0, 0);
+    assign_names(ctx);
+
+    ggml_set_output(x[2]);
+    ggml_gallocr_ptr galloc = allocate_graph(graph, x[4], &backend.buffer_type);
+    check_all_allocated(graph);
+    check_max_size(ctx);
+    GGML_ASSERT(!memory_overlap(x[2], x[4]));
+}
+
 static void test_reuse_and_free() {
     dummy_backend backend      = dummy_backend_init(40);
     auto [ctx, graph, ctx_ptr] = make_context();
@@ -597,6 +616,7 @@ int main() {
     run("test_not_enough_chunks", test_not_enough_chunks);
     run("test_fill_leftover_space", test_fill_leftover_space);
     run("test_view_inplace", test_view_inplace);
+    run("test_output_view_lifetime", test_output_view_lifetime);
     run("test_reuse_and_free", test_reuse_and_free);
     run("test_merge_free_block(32)", []() { test_merge_free_block(32); });
     run("test_merge_free_block(SIZE_MAX)", []() { test_merge_free_block(SIZE_MAX); });

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -388,25 +388,6 @@ static void test_view_inplace() {
     GGML_ASSERT(backend.context->allocated_total() <= 24);
 }
 
-static void test_output_view_lifetime() {
-    dummy_backend backend      = dummy_backend_init(SIZE_MAX);
-    auto [ctx, graph, ctx_ptr] = make_context();
-
-    ggml_tensor * x[5];
-    x[0] = make_input_1d(ctx, 4);
-    x[1] = ggml_scale(ctx, x[0], 2.0f);
-    x[2] = ggml_reshape_2d(ctx, x[1], 2, 2);
-    x[3] = ggml_sum(ctx, x[2]);
-    x[4] = ggml_pad(ctx, x[3], 3, 0, 0, 0);
-    assign_names(ctx);
-
-    ggml_set_output(x[2]);
-    ggml_gallocr_ptr galloc = allocate_graph(graph, x[4], &backend.buffer_type);
-    check_all_allocated(graph);
-    check_max_size(ctx);
-    GGML_ASSERT(!memory_overlap(x[2], x[4]));
-}
-
 static void test_reuse_and_free() {
     dummy_backend backend      = dummy_backend_init(40);
     auto [ctx, graph, ctx_ptr] = make_context();
@@ -616,7 +597,6 @@ int main() {
     run("test_not_enough_chunks", test_not_enough_chunks);
     run("test_fill_leftover_space", test_fill_leftover_space);
     run("test_view_inplace", test_view_inplace);
-    run("test_output_view_lifetime", test_output_view_lifetime);
     run("test_reuse_and_free", test_reuse_and_free);
     run("test_merge_free_block(32)", []() { test_merge_free_block(32); });
     run("test_merge_free_block(SIZE_MAX)", []() { test_merge_free_block(SIZE_MAX); });

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -16,19 +16,33 @@
 static void test(void) {
     common_params params;
 
-    assert(common_speculative_n_outputs_max(16, 2, 3) == 8);
-    assert(common_speculative_n_outputs_max(16, 2, -1) == 2);
-    assert(common_speculative_n_outputs_max(4, 2, 3) == 4);
-    assert(common_speculative_n_outputs_max(
+    auto assert_output_limits = [](int32_t n_batch, int32_t n_parallel, int32_t n_draft,
+                                   int32_t total, int32_t per_seq) {
+        const auto limits = common_speculative_get_output_limits(n_batch, n_parallel, n_draft);
+        assert(limits.total == total);
+        assert(limits.per_seq == per_seq);
+    };
+
+    assert_output_limits(16, 2,  3, 8, 4);
+    assert_output_limits(16, 2, -1, 2, 1);
+    assert_output_limits( 4, 2,  3, 4, 4);
+    assert_output_limits( 2, 1,  3, 2, 2);
+    assert_output_limits(
             std::numeric_limits<int32_t>::max(),
             std::numeric_limits<int32_t>::max(),
-            std::numeric_limits<int32_t>::max()) == std::numeric_limits<int32_t>::max());
-    assert(common_speculative_n_outputs_per_seq_max(16, 3) == 4);
-    assert(common_speculative_n_outputs_per_seq_max(16, -1) == 1);
-    assert(common_speculative_n_outputs_per_seq_max(2, 3) == 2);
-    assert(common_speculative_n_outputs_per_seq_max(
             std::numeric_limits<int32_t>::max(),
-            std::numeric_limits<int32_t>::max()) == std::numeric_limits<int32_t>::max());
+            std::numeric_limits<int32_t>::max(),
+            std::numeric_limits<int32_t>::max());
+
+    {
+        common_params base;
+        base.n_parallel = 4;
+        base.n_sampling_outputs_per_seq_max = 8;
+
+        const auto draft = common_base_params_to_speculative(base);
+        assert(draft.n_outputs_max == 4);
+        assert(draft.n_sampling_outputs_per_seq_max == 1);
+    }
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");
     for (int ex = 0; ex < LLAMA_EXAMPLE_COUNT; ex++) {

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -25,7 +25,7 @@ static void test(void) {
 
     assert_output_limits(16, 2,  3, 8, 4);
     assert_output_limits(16, 2, -1, 2, 1);
-    assert_output_limits( 4, 2,  3, 4, 4);
+    assert_output_limits( 6, 2,  3, 6, 4);
     assert_output_limits( 2, 1,  3, 2, 2);
     assert_output_limits(
             std::numeric_limits<int32_t>::max(),

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -37,11 +37,11 @@ static void test(void) {
     {
         common_params base;
         base.n_parallel = 4;
-        base.n_sampling_outputs_per_seq_max = 8;
+        base.n_outputs_max_per_seq = 8;
 
         const auto draft = common_base_params_to_speculative(base);
         assert(draft.n_outputs_max == 4);
-        assert(draft.n_sampling_outputs_per_seq_max == 1);
+        assert(draft.n_outputs_max_per_seq == 1);
     }
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -23,6 +23,12 @@ static void test(void) {
             std::numeric_limits<int32_t>::max(),
             std::numeric_limits<int32_t>::max(),
             std::numeric_limits<int32_t>::max()) == std::numeric_limits<int32_t>::max());
+    assert(common_speculative_n_outputs_per_seq_max(16, 3) == 4);
+    assert(common_speculative_n_outputs_per_seq_max(16, -1) == 1);
+    assert(common_speculative_n_outputs_per_seq_max(2, 3) == 2);
+    assert(common_speculative_n_outputs_per_seq_max(
+            std::numeric_limits<int32_t>::max(),
+            std::numeric_limits<int32_t>::max()) == std::numeric_limits<int32_t>::max());
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");
     for (int ex = 0; ex < LLAMA_EXAMPLE_COUNT; ex++) {

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -2,7 +2,9 @@
 #include "common.h"
 #include "download.h"
 #include "llama.h"
+#include "speculative.h"
 
+#include <limits>
 #include <string>
 #include <vector>
 #include <sstream>
@@ -13,6 +15,14 @@
 
 static void test(void) {
     common_params params;
+
+    assert(common_speculative_n_outputs_max(16, 2, 3) == 8);
+    assert(common_speculative_n_outputs_max(16, 2, -1) == 2);
+    assert(common_speculative_n_outputs_max(4, 2, 3) == 4);
+    assert(common_speculative_n_outputs_max(
+            std::numeric_limits<int32_t>::max(),
+            std::numeric_limits<int32_t>::max(),
+            std::numeric_limits<int32_t>::max()) == std::numeric_limits<int32_t>::max());
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");
     for (int ex = 0; ex < LLAMA_EXAMPLE_COUNT; ex++) {

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -1666,6 +1666,99 @@ static void test_backend_multi_output_greedy(const test_params & params) {
     printf("backend multi-output greedy test PASSED\n");
 }
 
+static void test_backend_multi_sequence_multi_output_dist(const test_params & params) {
+    const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
+    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+    const uint32_t seeds[] = { 88, 1337 };
+    // reduce the chance that swapped random inputs select the same token
+    const float temp = 10.0f;
+
+    llama_sampler_ptr chain_0(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+    llama_sampler_ptr chain_1(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+    llama_sampler_chain_add(chain_0.get(), llama_sampler_init_temp(temp));
+    llama_sampler_chain_add(chain_0.get(), llama_sampler_init_dist(seeds[0]));
+    llama_sampler_chain_add(chain_1.get(), llama_sampler_init_temp(temp));
+    llama_sampler_chain_add(chain_1.get(), llama_sampler_init_dist(seeds[1]));
+    std::vector<llama_sampler_seq_config> configs = {
+        { 0, chain_0.get() },
+        { 1, chain_1.get() },
+    };
+    test_context test_ctx(params, configs, 2, 6, 0, 3);
+
+    std::vector<llama_sampler_seq_config> reference_configs;
+    test_context reference_ctx(params, reference_configs, 2, 6);
+
+    const llama_token seq_tokens[2][3] = {
+        { llama_vocab_bos(vocab), llama_vocab_eos(vocab), llama_vocab_bos(vocab) },
+        { llama_vocab_eos(vocab), llama_vocab_bos(vocab), llama_vocab_eos(vocab) },
+    };
+
+    llama_batch batch = llama_batch_init(6, 0, 1);
+    for (int pos = 0; pos < 3; ++pos) {
+        common_batch_add(batch, seq_tokens[0][pos], pos, { 0 }, true);
+        common_batch_add(batch, seq_tokens[1][pos], pos, { 1 }, true);
+    }
+
+    GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
+    GGML_ASSERT(llama_decode(reference_ctx.ctx.get(), batch) == 0);
+
+    std::mt19937 reference_rngs[] = {
+        std::mt19937(seeds[0]),
+        std::mt19937(seeds[1]),
+    };
+    std::uniform_real_distribution<double> reference_dist(0.0, 1.0);
+    int outputs_per_seq[] = { 0, 0 };
+
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        const llama_seq_id seq_id = batch.seq_id[i][0];
+        GGML_ASSERT(seq_id == 0 || seq_id == 1);
+        outputs_per_seq[seq_id]++;
+
+        const llama_token backend_token = llama_get_sampled_token_ith(test_ctx.ctx.get(), i);
+        const float * sampled_logits = llama_get_sampled_logits_ith(test_ctx.ctx.get(), i);
+        const float * sampled_probs = llama_get_sampled_probs_ith(test_ctx.ctx.get(), i);
+        const uint32_t n_logits = llama_get_sampled_logits_count_ith(test_ctx.ctx.get(), i);
+        const uint32_t n_probs = llama_get_sampled_probs_count_ith(test_ctx.ctx.get(), i);
+        const float * reference_logits = llama_get_logits_ith(reference_ctx.ctx.get(), i);
+
+        GGML_ASSERT(backend_token >= 0 && backend_token < n_vocab);
+        GGML_ASSERT(sampled_logits != nullptr);
+        GGML_ASSERT(sampled_probs != nullptr);
+        GGML_ASSERT(reference_logits != nullptr);
+        GGML_ASSERT(n_logits == (uint32_t) n_vocab);
+        GGML_ASSERT(n_probs == (uint32_t) n_vocab);
+
+        float prob_sum = 0.0f;
+        float cumsum_before = 0.0f;
+        for (llama_token token = 0; token < n_vocab; ++token) {
+            const float expected_logit = reference_logits[token] / temp;
+            const float tolerance = 1e-4f * std::max(1.0f, std::fabs(expected_logit));
+            GGML_ASSERT(std::fabs(sampled_logits[token] - expected_logit) <= tolerance);
+            GGML_ASSERT(std::isfinite(sampled_probs[token]));
+            GGML_ASSERT(sampled_probs[token] >= 0.0f);
+
+            prob_sum += sampled_probs[token];
+            if (token < backend_token) {
+                cumsum_before += sampled_probs[token];
+            }
+        }
+
+        GGML_ASSERT(std::fabs(prob_sum - 1.0f) <= 1e-3f);
+
+        const float rnd = reference_dist(reference_rngs[seq_id]);
+        const float cumsum_sampled = cumsum_before + sampled_probs[backend_token];
+        GGML_ASSERT(rnd >= cumsum_before - 1e-4f);
+        GGML_ASSERT(rnd <= cumsum_sampled + 1e-4f);
+    }
+
+    GGML_ASSERT(outputs_per_seq[0] == 3);
+    GGML_ASSERT(outputs_per_seq[1] == 3);
+
+    llama_batch_free(batch);
+
+    printf("backend multi-sequence multi-output dist test PASSED\n");
+}
+
 static void test_backend_multi_output_sampling_chain(const test_params & params) {
     const llama_seq_id seq_id = 0;
     const int32_t seed = 88;
@@ -1698,12 +1791,15 @@ static void test_backend_multi_output_sampling_chain(const test_params & params)
     std::vector<llama_token_data> reference_data(n_vocab);
     std::mt19937 reference_rng(seed);
     std::uniform_real_distribution<double> reference_dist(0.0, 1.0);
-    int32_t n_reused_after_first_round = -1;
+    const int n_outputs_per_round[] = { 4, 3, 4, 4 };
+    int32_t n_reused_before_repeat = -1;
+    int32_t pos = 0;
 
-    for (int round = 0; round < 2; ++round) {
-        llama_batch batch = llama_batch_init(4, 0, 1);
-        for (int i = 0; i < 4; ++i) {
-            common_batch_add(batch, llama_vocab_bos(vocab), round * 4 + i, { seq_id }, true);
+    for (int round = 0; round < (int) (sizeof(n_outputs_per_round) / sizeof(n_outputs_per_round[0])); ++round) {
+        const int n_outputs = n_outputs_per_round[round];
+        llama_batch batch = llama_batch_init(n_outputs, 0, 1);
+        for (int i = 0; i < n_outputs; ++i) {
+            common_batch_add(batch, llama_vocab_bos(vocab), pos++, { seq_id }, true);
         }
 
         GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
@@ -1795,10 +1891,10 @@ static void test_backend_multi_output_sampling_chain(const test_params & params)
         llama_batch_free(batch);
 
         const int32_t n_reused = llama_perf_context(test_ctx.ctx.get()).n_reused;
-        if (round == 0) {
-            n_reused_after_first_round = n_reused;
-        } else {
-            GGML_ASSERT(n_reused > n_reused_after_first_round);
+        if (round == 2) {
+            n_reused_before_repeat = n_reused;
+        } else if (round == 3) {
+            GGML_ASSERT(n_reused > n_reused_before_repeat);
         }
     }
 
@@ -1884,6 +1980,7 @@ static const backend_test_case BACKEND_TESTS[] = {
     { "set_sampler",     test_backend_set_sampler,             true  },
     { "multi_output_limit",    test_backend_multi_output_limit,      true },
     { "multi_output_greedy",   test_backend_multi_output_greedy,     true },
+    { "multi_sequence_multi_output_dist", test_backend_multi_sequence_multi_output_dist, true },
     { "multi_output_sampling_chain", test_backend_multi_output_sampling_chain, true },
     { "multi_output_cpu",      test_backend_multi_output_cpu_suffix, true },
     { "mixed",           test_backend_mixed_sampling,          true  },

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -87,7 +87,7 @@ struct test_context {
             int32_t n_seq_max = -1,
             uint32_t n_outputs_max = 0,
             uint32_t n_ubatch = 0,
-            uint32_t n_sampling_outputs_per_seq_max = 1) {
+            uint32_t n_outputs_max_per_seq = 1) {
         auto * model = params.model.get();
 
         GGML_ASSERT(model);
@@ -100,7 +100,7 @@ struct test_context {
             cparams.n_ubatch = n_ubatch;
         }
         cparams.n_outputs_max = n_outputs_max;
-        cparams.n_sampling_outputs_per_seq_max = n_sampling_outputs_per_seq_max;
+        cparams.n_outputs_max_per_seq = n_outputs_max_per_seq;
         cparams.samplers = configs.data();
         cparams.n_samplers = configs.size();
         cparams.kv_unified = true;
@@ -276,7 +276,7 @@ struct test_context {
 
 struct test_single_output_backend_sampler {
     bool backend_initialized = false;
-    uint32_t backend_outputs_per_seq_max = 0;
+    uint32_t backend_outputs_max_per_seq = 0;
     int backend_apply_count = 0;
     int apply_count = 0;
 };
@@ -296,10 +296,10 @@ static void test_single_output_backend_sampler_free(llama_sampler * smpl) {
 }
 
 static bool test_single_output_backend_sampler_backend_init(
-        llama_sampler * smpl, ggml_backend_buffer_type_t /*buft*/, uint32_t n_outputs_per_seq_max) {
+        llama_sampler * smpl, ggml_backend_buffer_type_t /*buft*/, uint32_t n_outputs_max_per_seq) {
     auto * ctx = (test_single_output_backend_sampler *) smpl->ctx;
-    ctx->backend_outputs_per_seq_max = n_outputs_per_seq_max;
-    if (n_outputs_per_seq_max > 1) {
+    ctx->backend_outputs_max_per_seq = n_outputs_max_per_seq;
+    if (n_outputs_max_per_seq > 1) {
         return false;
     }
     ctx->backend_initialized = true;
@@ -324,6 +324,7 @@ static llama_sampler_i test_single_output_backend_sampler_i = {
     /* .backend_apply     = */ test_single_output_backend_sampler_backend_apply,
     /* .backend_set_input = */ nullptr,
     /* .backend_reset     = */ nullptr,
+    /* .copy_state        = */ nullptr,
 };
 
 static llama_sampler * test_single_output_backend_sampler_init(
@@ -1771,8 +1772,7 @@ static void test_backend_multi_output_dist_transaction(const test_params & param
     verify_random(0, randoms[2]);
     llama_batch_free(batch);
 
-    GGML_ASSERT(llama_set_sampler(test_ctx.ctx.get(), seq_id, saved.get()));
-    chain = std::move(saved);
+    llama_sampler_copy(saved.get(), chain.get());
 
     batch = decode();
     verify_random(0, randoms[2]);
@@ -1955,7 +1955,7 @@ static void test_backend_multi_output_cpu_suffix(const test_params & params) {
         GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
 
         GGML_ASSERT(sampler_ctx->backend_initialized);
-        GGML_ASSERT(sampler_ctx->backend_outputs_per_seq_max == 1);
+        GGML_ASSERT(sampler_ctx->backend_outputs_max_per_seq == 1);
         GGML_ASSERT(sampler_ctx->backend_apply_count > 0);
         GGML_ASSERT(sampler_ctx->apply_count == 0);
         GGML_ASSERT(llama_get_sampled_token_ith(test_ctx.ctx.get(), 0) != LLAMA_TOKEN_NULL);
@@ -1976,7 +1976,7 @@ static void test_backend_multi_output_cpu_suffix(const test_params & params) {
         GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
 
         GGML_ASSERT(!sampler_ctx->backend_initialized);
-        GGML_ASSERT(sampler_ctx->backend_outputs_per_seq_max == 2);
+        GGML_ASSERT(sampler_ctx->backend_outputs_max_per_seq == 2);
         GGML_ASSERT(sampler_ctx->backend_apply_count == 0);
         for (int i = 0; i < batch.n_tokens; ++i) {
             GGML_ASSERT(llama_get_sampled_token_ith(test_ctx.ctx.get(), i) == LLAMA_TOKEN_NULL);

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -86,7 +86,8 @@ struct test_context {
             std::vector<llama_sampler_seq_config> & configs,
             int32_t n_seq_max = -1,
             uint32_t n_outputs_max = 0,
-            uint32_t n_ubatch = 0) {
+            uint32_t n_ubatch = 0,
+            uint32_t n_sampling_outputs_per_seq_max = 1) {
         auto * model = params.model.get();
 
         GGML_ASSERT(model);
@@ -99,6 +100,7 @@ struct test_context {
             cparams.n_ubatch = n_ubatch;
         }
         cparams.n_outputs_max = n_outputs_max;
+        cparams.n_sampling_outputs_per_seq_max = n_sampling_outputs_per_seq_max;
         cparams.samplers = configs.data();
         cparams.n_samplers = configs.size();
         cparams.kv_unified = true;
@@ -274,7 +276,7 @@ struct test_context {
 
 struct test_single_output_backend_sampler {
     bool backend_initialized = false;
-    bool backend_require_multi_output = false;
+    uint32_t backend_outputs_per_seq_max = 0;
     int backend_apply_count = 0;
     int apply_count = 0;
 };
@@ -294,10 +296,10 @@ static void test_single_output_backend_sampler_free(llama_sampler * smpl) {
 }
 
 static bool test_single_output_backend_sampler_backend_init(
-        llama_sampler * smpl, ggml_backend_buffer_type_t /*buft*/, bool require_multi_output) {
+        llama_sampler * smpl, ggml_backend_buffer_type_t /*buft*/, uint32_t n_outputs_per_seq_max) {
     auto * ctx = (test_single_output_backend_sampler *) smpl->ctx;
-    ctx->backend_require_multi_output = require_multi_output;
-    if (require_multi_output) {
+    ctx->backend_outputs_per_seq_max = n_outputs_per_seq_max;
+    if (n_outputs_per_seq_max > 1) {
         return false;
     }
     ctx->backend_initialized = true;
@@ -1596,26 +1598,27 @@ static void test_backend_cpu_mixed_batch(const test_params & params) {
     printf("backend-cpu mixed batch test PASSED\n");
 }
 
-static void test_backend_multi_output_disabled(const test_params & params) {
+static void test_backend_multi_output_limit(const test_params & params) {
     const llama_seq_id seq_id = 0;
 
     llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
     llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
     std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
-    test_context test_ctx(params, configs, 1, 1);
+    test_context test_ctx(params, configs, 1, 3, 0, 2);
 
-    llama_batch batch = llama_batch_init(2, 0, 1);
-    common_batch_add(batch, llama_vocab_bos(test_ctx.vocab), 0, { seq_id }, true);
-    common_batch_add(batch, llama_vocab_bos(test_ctx.vocab), 1, { seq_id }, true);
+    llama_batch batch = llama_batch_init(3, 0, 1);
+    for (int i = 0; i < 3; ++i) {
+        common_batch_add(batch, llama_vocab_bos(test_ctx.vocab), i, { seq_id }, true);
+    }
 
-    printf(">>> test_backend_multi_output_disabled expected error start:\n");
+    printf(">>> test_backend_multi_output_limit expected error start:\n");
     const int ret = llama_decode(test_ctx.ctx.get(), batch);
-    GGML_ASSERT(ret != 0 && "llama_decode should reject multiple outputs for one sequence");
-    printf("<<< test_backend_multi_output_disabled expected error end.\n");
+    GGML_ASSERT(ret != 0 && "llama_decode should reject outputs above the per-sequence limit");
+    printf("<<< test_backend_multi_output_limit expected error end.\n");
 
     llama_batch_free(batch);
 
-    printf("backend multi-output disabled test PASSED\n");
+    printf("backend multi-output limit test PASSED\n");
 }
 
 // greedy is a stateless terminal selector; verify multi-output backend argmax
@@ -1628,7 +1631,7 @@ static void test_backend_multi_output_greedy(const test_params & params) {
     llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
     llama_sampler_chain_add(chain.get(), llama_sampler_init_greedy());
     std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
-    test_context test_ctx(params, configs, 1, 4);
+    test_context test_ctx(params, configs, 4, 4, 0, 4);
 
     std::vector<llama_sampler_seq_config> reference_configs;
     test_context reference_ctx(params, reference_configs, 1, 4);
@@ -1686,7 +1689,7 @@ static void test_backend_multi_output_sampling_chain(const test_params & params)
     llama_sampler_ptr chain = make_filter_chain();
     llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(seed));
     std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
-    test_context test_ctx(params, configs, 1, 4, 2);
+    test_context test_ctx(params, configs, 1, 4, 2, 4);
 
     std::vector<llama_sampler_seq_config> reference_configs;
     test_context reference_ctx(params, reference_configs, 1, 4, 2);
@@ -1814,14 +1817,14 @@ static void test_backend_multi_output_cpu_suffix(const test_params & params) {
         llama_sampler_chain_add(chain.get(), test_single_output_backend_sampler_init(&sampler_ctx));
         llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
         std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
-        test_context test_ctx(params, configs, 1, 1);
+        test_context test_ctx(params, configs, 1, 1, 0, 4);
 
         llama_batch batch = llama_batch_init(1, 0, 1);
         common_batch_add(batch, llama_vocab_bos(vocab), 0, { seq_id }, true);
         GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
 
         GGML_ASSERT(sampler_ctx->backend_initialized);
-        GGML_ASSERT(!sampler_ctx->backend_require_multi_output);
+        GGML_ASSERT(sampler_ctx->backend_outputs_per_seq_max == 1);
         GGML_ASSERT(sampler_ctx->backend_apply_count > 0);
         GGML_ASSERT(sampler_ctx->apply_count == 0);
         GGML_ASSERT(llama_get_sampled_token_ith(test_ctx.ctx.get(), 0) != LLAMA_TOKEN_NULL);
@@ -1836,7 +1839,7 @@ static void test_backend_multi_output_cpu_suffix(const test_params & params) {
         llama_sampler_chain_add(chain.get(), test_single_output_backend_sampler_init(&sampler_ctx));
         llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
         std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
-        test_context test_ctx(params, configs, 1, 2);
+        test_context test_ctx(params, configs, 1, 2, 0, 0);
 
         llama_batch batch = llama_batch_init(2, 0, 1);
         for (int i = 0; i < 2; ++i) {
@@ -1845,7 +1848,7 @@ static void test_backend_multi_output_cpu_suffix(const test_params & params) {
         GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
 
         GGML_ASSERT(!sampler_ctx->backend_initialized);
-        GGML_ASSERT(sampler_ctx->backend_require_multi_output);
+        GGML_ASSERT(sampler_ctx->backend_outputs_per_seq_max == 2);
         GGML_ASSERT(sampler_ctx->backend_apply_count == 0);
         for (int i = 0; i < batch.n_tokens; ++i) {
             GGML_ASSERT(llama_get_sampled_token_ith(test_ctx.ctx.get(), i) == LLAMA_TOKEN_NULL);
@@ -1879,7 +1882,7 @@ static const backend_test_case BACKEND_TESTS[] = {
     { "dist",            test_backend_dist_sampling,           true  },
     { "dist_and_cpu",    test_backend_dist_sampling_and_cpu,   true  },
     { "set_sampler",     test_backend_set_sampler,             true  },
-    { "multi_output_disabled", test_backend_multi_output_disabled,   true },
+    { "multi_output_limit",    test_backend_multi_output_limit,      true },
     { "multi_output_greedy",   test_backend_multi_output_greedy,     true },
     { "multi_output_sampling_chain", test_backend_multi_output_sampling_chain, true },
     { "multi_output_cpu",      test_backend_multi_output_cpu_suffix, true },

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -1638,18 +1638,18 @@ static void test_backend_multi_sequence_multi_output_dist(const test_params & pa
         { 0, chain_0.get() },
         { 1, chain_1.get() },
     };
-    test_context test_ctx(params, configs, 2, 6, 0, 3);
+    test_context test_ctx(params, configs, 2, 4, 0, 2);
 
     std::vector<llama_sampler_seq_config> reference_configs;
-    test_context reference_ctx(params, reference_configs, 2, 6);
+    test_context reference_ctx(params, reference_configs, 2, 4);
 
-    const llama_token seq_tokens[2][3] = {
-        { llama_vocab_bos(vocab), llama_vocab_eos(vocab), llama_vocab_bos(vocab) },
-        { llama_vocab_eos(vocab), llama_vocab_bos(vocab), llama_vocab_eos(vocab) },
+    const llama_token seq_tokens[2][2] = {
+        { llama_vocab_bos(vocab), llama_vocab_eos(vocab) },
+        { llama_vocab_eos(vocab), llama_vocab_bos(vocab) },
     };
 
-    llama_batch batch = llama_batch_init(6, 0, 1);
-    for (int pos = 0; pos < 3; ++pos) {
+    llama_batch batch = llama_batch_init(4, 0, 1);
+    for (int pos = 0; pos < 2; ++pos) {
         common_batch_add(batch, seq_tokens[0][pos], pos, { 0 }, true);
         common_batch_add(batch, seq_tokens[1][pos], pos, { 1 }, true);
     }
@@ -1662,12 +1662,10 @@ static void test_backend_multi_sequence_multi_output_dist(const test_params & pa
         std::mt19937(seeds[1]),
     };
     std::uniform_real_distribution<double> reference_dist(0.0, 1.0);
-    int outputs_per_seq[] = { 0, 0 };
 
     for (int i = 0; i < batch.n_tokens; ++i) {
         const llama_seq_id seq_id = batch.seq_id[i][0];
         GGML_ASSERT(seq_id == 0 || seq_id == 1);
-        outputs_per_seq[seq_id]++;
 
         llama_sampler * chain = seq_id == 0 ? chain_0.get() : chain_1.get();
         const llama_token backend_token = llama_sampler_sample(chain, test_ctx.ctx.get(), i);
@@ -1707,9 +1705,6 @@ static void test_backend_multi_sequence_multi_output_dist(const test_params & pa
         GGML_ASSERT(rnd <= cumsum_sampled + 1e-4f);
     }
 
-    GGML_ASSERT(outputs_per_seq[0] == 3);
-    GGML_ASSERT(outputs_per_seq[1] == 3);
-
     llama_batch_free(batch);
 
     printf("backend multi-sequence multi-output dist test PASSED\n");
@@ -1747,7 +1742,7 @@ static void test_backend_multi_output_dist_transaction(const test_params & param
 
     std::mt19937 rng(seed);
     std::uniform_real_distribution<double> dist(0.0, 1.0);
-    float randoms[7];
+    float randoms[3];
     for (float & rnd : randoms) {
         rnd = dist(rng);
     }
@@ -1772,25 +1767,15 @@ static void test_backend_multi_output_dist_transaction(const test_params & param
     llama_batch_free(batch);
 
     batch = decode();
-    verify_random(0, randoms[2]);
-    verify_random(1, randoms[3]);
-    verify_random(2, randoms[4]);
-    llama_batch_free(batch);
-
-    batch = decode();
-    verify_random(0, randoms[5]);
-    llama_batch_free(batch);
-
-    batch = decode();
     llama_sampler_ptr saved(llama_sampler_clone(chain.get()));
-    verify_random(0, randoms[6]);
+    verify_random(0, randoms[2]);
     llama_batch_free(batch);
 
     GGML_ASSERT(llama_set_sampler(test_ctx.ctx.get(), seq_id, saved.get()));
     chain = std::move(saved);
 
     batch = decode();
-    verify_random(0, randoms[6]);
+    verify_random(0, randoms[2]);
     llama_batch_free(batch);
 
     printf("backend multi-output dist transaction test PASSED\n");
@@ -1798,142 +1783,152 @@ static void test_backend_multi_output_dist_transaction(const test_params & param
 
 static void test_backend_multi_output_sampling_chain(const test_params & params) {
     const llama_seq_id seq_id = 0;
-    const int32_t seed = 88;
+    const uint32_t seed = 88;
+    const float p = 0.9f;
+    const float temp = 0.8f;
+    const float cdf_epsilon = 1e-4f;
     const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
     const int32_t n_vocab = llama_vocab_n_tokens(vocab);
     const uint32_t k = std::min<uint32_t>(512, n_vocab);
-
     const llama_logit_bias bias = { llama_vocab_bos(vocab), -0.1f };
 
     auto make_filter_chain = [&]() {
         llama_sampler_ptr result(llama_sampler_chain_init(llama_sampler_chain_default_params()));
-        llama_sampler_chain_add(result.get(), llama_sampler_init_logit_bias(
-                n_vocab, 1, &bias));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_logit_bias(n_vocab, 1, &bias));
         llama_sampler_chain_add(result.get(), llama_sampler_init_top_k(k));
-        llama_sampler_chain_add(result.get(), llama_sampler_init_top_p(0.9f, 1));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_top_p(p, 1));
         llama_sampler_chain_add(result.get(), llama_sampler_init_min_p(0.01f, 1));
-        llama_sampler_chain_add(result.get(), llama_sampler_init_temp(0.8f));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_temp(temp));
         return result;
     };
 
     llama_sampler_ptr chain = make_filter_chain();
     llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(seed));
     std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
-    test_context test_ctx(params, configs, 1, 4, 2, 4);
+    test_context test_ctx(params, configs, 1, 2, 2, 2);
 
     std::vector<llama_sampler_seq_config> reference_configs;
-    test_context reference_ctx(params, reference_configs, 1, 4, 2);
-    llama_sampler_ptr reference_filters = make_filter_chain();
+    test_context reference_ctx(params, reference_configs, 1, 2, 2);
 
+    llama_sampler_ptr reference_bias(llama_sampler_init_logit_bias(n_vocab, 1, &bias));
+    llama_sampler_ptr reference_top_k(llama_sampler_init_top_k(k));
+    llama_sampler_ptr reference_top_p(llama_sampler_init_top_p(p, 1));
+    llama_sampler_ptr reference_min_p(llama_sampler_init_min_p(0.01f, 1));
+    llama_sampler_ptr reference_temp(llama_sampler_init_temp(temp));
     std::vector<llama_token_data> reference_data(n_vocab);
-    std::mt19937 reference_rng(seed);
-    std::uniform_real_distribution<double> reference_dist(0.0, 1.0);
-    const int n_outputs_per_round[] = { 4, 3, 4, 4 };
-    int32_t n_reused_before_repeat = -1;
-    int32_t pos = 0;
 
-    for (int round = 0; round < (int) (sizeof(n_outputs_per_round) / sizeof(n_outputs_per_round[0])); ++round) {
-        const int n_outputs = n_outputs_per_round[round];
-        llama_batch batch = llama_batch_init(n_outputs, 0, 1);
-        for (int i = 0; i < n_outputs; ++i) {
-            common_batch_add(batch, llama_vocab_bos(vocab), pos++, { seq_id }, true);
+    auto make_batch = [&](int32_t pos) {
+        llama_batch batch = llama_batch_init(2, 0, 1);
+        for (int i = 0; i < 2; ++i) {
+            common_batch_add(batch, llama_vocab_bos(vocab), pos + i, { seq_id }, true);
+        }
+        return batch;
+    };
+
+    llama_batch batch = make_batch(0);
+    GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
+    GGML_ASSERT(llama_decode(reference_ctx.ctx.get(), batch) == 0);
+
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        const llama_token backend_token = llama_sampler_sample(chain.get(), test_ctx.ctx.get(), i);
+        const float * sampled_logits = llama_get_sampled_logits_ith(test_ctx.ctx.get(), i);
+        const float * sampled_probs = llama_get_sampled_probs_ith(test_ctx.ctx.get(), i);
+        const llama_token * sampled_candidates = llama_get_sampled_candidates_ith(test_ctx.ctx.get(), i);
+        const uint32_t n_logits = llama_get_sampled_logits_count_ith(test_ctx.ctx.get(), i);
+        const uint32_t n_probs = llama_get_sampled_probs_count_ith(test_ctx.ctx.get(), i);
+        const uint32_t n_candidates = llama_get_sampled_candidates_count_ith(test_ctx.ctx.get(), i);
+        const float * reference_logits = llama_get_logits_ith(reference_ctx.ctx.get(), i);
+
+        GGML_ASSERT(backend_token >= 0 && backend_token < n_vocab);
+        GGML_ASSERT(sampled_logits != nullptr);
+        GGML_ASSERT(sampled_probs != nullptr);
+        GGML_ASSERT(sampled_candidates != nullptr);
+        GGML_ASSERT(reference_logits != nullptr);
+        GGML_ASSERT(n_logits == k);
+        GGML_ASSERT(n_probs == n_logits);
+        GGML_ASSERT(n_candidates == n_logits);
+
+        for (llama_token token = 0; token < n_vocab; ++token) {
+            reference_data[token] = { token, reference_logits[token], 0.0f };
         }
 
-        GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
-        GGML_ASSERT(llama_decode(reference_ctx.ctx.get(), batch) == 0);
+        llama_token_data_array reference = {
+            /* .data     = */ reference_data.data(),
+            /* .size     = */ reference_data.size(),
+            /* .selected = */ LLAMA_TOKEN_NULL,
+            /* .sorted   = */ false,
+        };
 
-        for (int i = 0; i < batch.n_tokens; ++i) {
-            const llama_token backend_token = llama_sampler_sample(chain.get(), test_ctx.ctx.get(), i);
-            const float * sampled_logits = llama_get_sampled_logits_ith(test_ctx.ctx.get(), i);
-            const float * sampled_probs = llama_get_sampled_probs_ith(test_ctx.ctx.get(), i);
-            const llama_token * sampled_candidates = llama_get_sampled_candidates_ith(test_ctx.ctx.get(), i);
-            const uint32_t n_logits = llama_get_sampled_logits_count_ith(test_ctx.ctx.get(), i);
-            const uint32_t n_probs = llama_get_sampled_probs_count_ith(test_ctx.ctx.get(), i);
-            const uint32_t n_candidates = llama_get_sampled_candidates_count_ith(test_ctx.ctx.get(), i);
+        llama_sampler_apply(reference_bias.get(), &reference);
+        llama_sampler_apply(reference_top_k.get(), &reference);
+        llama_sampler_apply(reference_top_p.get(), &reference);
+        GGML_ASSERT(reference.size > 0);
 
-            GGML_ASSERT(backend_token >= 0 && backend_token < n_vocab);
-            GGML_ASSERT(sampled_logits != nullptr);
-            GGML_ASSERT(sampled_probs != nullptr);
-            GGML_ASSERT(sampled_candidates != nullptr);
-            GGML_ASSERT(n_logits == k);
-            GGML_ASSERT(n_probs == n_logits);
-            GGML_ASSERT(n_candidates == n_logits);
+        float cdf = 0.0f;
+        for (size_t j = 0; j < reference.size; ++j) {
+            cdf += reference.data[j].p;
+        }
+        const float cdf_before = cdf - reference.data[reference.size - 1].p;
+        const float boundary_distance = std::min(std::fabs(cdf_before - p), std::fabs(cdf - p));
 
-            const float * reference_logits = llama_get_logits_ith(reference_ctx.ctx.get(), i);
-            GGML_ASSERT(reference_logits != nullptr);
+        llama_sampler_apply(reference_min_p.get(), &reference);
+        llama_sampler_apply(reference_temp.get(), &reference);
 
-            for (llama_token token = 0; token < n_vocab; ++token) {
-                reference_data[token] = { token, reference_logits[token], 0.0f };
+        std::unordered_map<llama_token, float> reference_by_id;
+        for (size_t j = 0; j < reference.size; ++j) {
+            reference_by_id.emplace(reference.data[j].id, reference.data[j].logit);
+        }
+        size_t n_backend_only = 0;
+        int32_t sampled_index = -1;
+        float prob_sum = 0.0f;
+
+        for (uint32_t j = 0; j < n_logits; ++j) {
+            GGML_ASSERT(sampled_candidates[j] >= 0 && sampled_candidates[j] < n_vocab);
+            GGML_ASSERT(std::isfinite(sampled_probs[j]));
+            GGML_ASSERT(sampled_probs[j] >= 0.0f);
+            prob_sum += sampled_probs[j];
+
+            if (sampled_candidates[j] == backend_token) {
+                sampled_index = j;
+            }
+            if (!std::isfinite(sampled_logits[j])) {
+                GGML_ASSERT(std::isinf(sampled_logits[j]) && sampled_logits[j] < 0.0f);
+                GGML_ASSERT(sampled_probs[j] == 0.0f);
+                continue;
             }
 
-            llama_token_data_array reference = {
-                /* .data     = */ reference_data.data(),
-                /* .size     = */ reference_data.size(),
-                /* .selected = */ LLAMA_TOKEN_NULL,
-                /* .sorted   = */ false,
-            };
-            llama_sampler_apply(reference_filters.get(), &reference);
-
-            std::vector<bool> reference_matched(reference.size, false);
-            const llama_token_data * reference_begin = reference.data;
-            const llama_token_data * reference_end = reference.data + reference.size;
-            size_t n_matched = 0;
-            int32_t sampled_index = -1;
-            float prob_sum = 0.0f;
-
-            for (uint32_t j = 0; j < n_logits; ++j) {
-                GGML_ASSERT(std::isfinite(sampled_probs[j]));
-                GGML_ASSERT(sampled_probs[j] >= 0.0f);
-                prob_sum += sampled_probs[j];
-
-                if (sampled_candidates[j] == backend_token) {
-                    sampled_index = j;
-                }
-
-                if (!std::isfinite(sampled_logits[j])) {
-                    GGML_ASSERT(std::isinf(sampled_logits[j]) && sampled_logits[j] < 0.0f);
-                    GGML_ASSERT(sampled_probs[j] == 0.0f);
-                    continue;
-                }
-
-                const llama_token_data * match = std::find_if(reference_begin, reference_end,
-                        [&](const llama_token_data & candidate) {
-                            return candidate.id == sampled_candidates[j];
-                        });
-                GGML_ASSERT(match != reference_end);
-
-                const size_t i_reference = match - reference.data;
-                GGML_ASSERT(!reference_matched[i_reference]);
-
-                const float tolerance = 1e-4f * std::max(1.0f, std::fabs(match->logit));
-                GGML_ASSERT(std::fabs(sampled_logits[j] - match->logit) <= tolerance);
-                reference_matched[i_reference] = true;
-                ++n_matched;
+            const auto match = reference_by_id.find(sampled_candidates[j]);
+            if (match == reference_by_id.end()) {
+                ++n_backend_only;
+                continue;
             }
 
-            GGML_ASSERT(n_matched == reference.size);
-            GGML_ASSERT(sampled_index >= 0);
-            GGML_ASSERT(std::fabs(prob_sum - 1.0f) <= 1e-3f);
-
-            const float rnd = reference_dist(reference_rng);
-            float cumsum_before = 0.0f;
-            for (int32_t j = 0; j < sampled_index; ++j) {
-                cumsum_before += sampled_probs[j];
-            }
-            const float cumsum_sampled = cumsum_before + sampled_probs[sampled_index];
-            GGML_ASSERT(rnd >= cumsum_before - 1e-4f);
-            GGML_ASSERT(rnd <= cumsum_sampled + 1e-4f);
+            const float tolerance = 1e-4f * std::max(1.0f, std::fabs(match->second));
+            GGML_ASSERT(std::fabs(sampled_logits[j] - match->second) <= tolerance);
+            reference_by_id.erase(match);
         }
 
-        llama_batch_free(batch);
+        const size_t n_reference_only = reference_by_id.size();
 
-        const int32_t n_reused = llama_perf_context(test_ctx.ctx.get()).n_reused;
-        if (round == 2) {
-            n_reused_before_repeat = n_reused;
-        } else if (round == 3) {
-            GGML_ASSERT(n_reused > n_reused_before_repeat);
+        if (n_backend_only != 0 || n_reference_only != 0) {
+            GGML_ASSERT(n_backend_only <= 1);
+            GGML_ASSERT(n_reference_only <= 1);
+            GGML_ASSERT(boundary_distance <= cdf_epsilon);
         }
+
+        GGML_ASSERT(sampled_index >= 0);
+        GGML_ASSERT(std::isfinite(sampled_logits[sampled_index]));
+        GGML_ASSERT(sampled_probs[sampled_index] > 0.0f);
+        GGML_ASSERT(std::fabs(prob_sum - 1.0f) <= 1e-3f);
     }
+
+    llama_batch_free(batch);
+
+    const int32_t n_reused_before_repeat = llama_perf_context(test_ctx.ctx.get()).n_reused;
+    batch = make_batch(2);
+    GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
+    llama_batch_free(batch);
+    GGML_ASSERT(llama_perf_context(test_ctx.ctx.get()).n_reused > n_reused_before_repeat);
 
     printf("backend multi-output sampling chain test PASSED\n");
 }
@@ -1943,12 +1938,17 @@ static void test_backend_multi_output_cpu_suffix(const test_params & params) {
     const int32_t k = 8;
     const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
 
+    auto make_chain = [&](test_single_output_backend_sampler ** sampler_ctx) {
+        llama_sampler_ptr result(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_top_k(k));
+        llama_sampler_chain_add(result.get(), test_single_output_backend_sampler_init(sampler_ctx));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_dist(88));
+        return result;
+    };
+
     {
         test_single_output_backend_sampler * sampler_ctx = nullptr;
-        llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
-        llama_sampler_chain_add(chain.get(), llama_sampler_init_top_k(k));
-        llama_sampler_chain_add(chain.get(), test_single_output_backend_sampler_init(&sampler_ctx));
-        llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
+        llama_sampler_ptr chain = make_chain(&sampler_ctx);
         std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
         test_context test_ctx(params, configs, 1, 1, 0, 4);
 
@@ -1967,10 +1967,7 @@ static void test_backend_multi_output_cpu_suffix(const test_params & params) {
 
     {
         test_single_output_backend_sampler * sampler_ctx = nullptr;
-        llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
-        llama_sampler_chain_add(chain.get(), llama_sampler_init_top_k(k));
-        llama_sampler_chain_add(chain.get(), test_single_output_backend_sampler_init(&sampler_ctx));
-        llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
+        llama_sampler_ptr chain = make_chain(&sampler_ctx);
         std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
         test_context test_ctx(params, configs, 1, 2, 0, 0);
 

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -1924,11 +1924,9 @@ static void test_backend_multi_output_sampling_chain(const test_params & params)
 
     llama_batch_free(batch);
 
-    const int32_t n_reused_before_repeat = llama_perf_context(test_ctx.ctx.get()).n_reused;
     batch = make_batch(2);
     GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
     llama_batch_free(batch);
-    GGML_ASSERT(llama_perf_context(test_ctx.ctx.get()).n_reused > n_reused_before_repeat);
 
     printf("backend multi-output sampling chain test PASSED\n");
 }

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <functional>
 #include <map>
+#include <random>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -80,7 +81,12 @@ struct test_context {
     std::unordered_map<llama_seq_id, int32_t> seq_positions;
     std::unordered_map<llama_seq_id, int32_t> last_batch_info;
 
-    test_context(const test_params & params, std::vector<llama_sampler_seq_config> & configs, int32_t n_seq_max = -1) {
+    test_context(
+            const test_params & params,
+            std::vector<llama_sampler_seq_config> & configs,
+            int32_t n_seq_max = -1,
+            uint32_t n_outputs_max = 0,
+            uint32_t n_ubatch = 0) {
         auto * model = params.model.get();
 
         GGML_ASSERT(model);
@@ -89,6 +95,10 @@ struct test_context {
         llama_context_params cparams = llama_context_default_params();
         cparams.n_ctx = 512;
         cparams.n_batch = 512;
+        if (n_ubatch > 0) {
+            cparams.n_ubatch = n_ubatch;
+        }
+        cparams.n_outputs_max = n_outputs_max;
         cparams.samplers = configs.data();
         cparams.n_samplers = configs.size();
         cparams.kv_unified = true;
@@ -261,6 +271,65 @@ struct test_context {
         return piece;
     }
 };
+
+struct test_single_output_backend_sampler {
+    bool backend_initialized = false;
+    bool backend_require_multi_output = false;
+    int backend_apply_count = 0;
+    int apply_count = 0;
+};
+
+static const char * test_single_output_backend_sampler_name(const llama_sampler * /*smpl*/) {
+    return "single-output-backend";
+}
+
+static void test_single_output_backend_sampler_apply(
+        llama_sampler * smpl, llama_token_data_array * /*cur_p*/) {
+    auto * ctx = (test_single_output_backend_sampler *) smpl->ctx;
+    ctx->apply_count++;
+}
+
+static void test_single_output_backend_sampler_free(llama_sampler * smpl) {
+    delete (test_single_output_backend_sampler *) smpl->ctx;
+}
+
+static bool test_single_output_backend_sampler_backend_init(
+        llama_sampler * smpl, ggml_backend_buffer_type_t /*buft*/, bool require_multi_output) {
+    auto * ctx = (test_single_output_backend_sampler *) smpl->ctx;
+    ctx->backend_require_multi_output = require_multi_output;
+    if (require_multi_output) {
+        return false;
+    }
+    ctx->backend_initialized = true;
+    return true;
+}
+
+static void test_single_output_backend_sampler_backend_apply(
+        llama_sampler * smpl, ggml_context * /*ctx*/, ggml_cgraph * /*gf*/, llama_sampler_data * /*data*/) {
+    auto * ctx = (test_single_output_backend_sampler *) smpl->ctx;
+    ctx->backend_apply_count++;
+}
+
+static llama_sampler_i test_single_output_backend_sampler_i = {
+    /* .name              = */ test_single_output_backend_sampler_name,
+    /* .accept            = */ nullptr,
+    /* .apply             = */ test_single_output_backend_sampler_apply,
+    /* .reset             = */ nullptr,
+    /* .clone             = */ nullptr,
+    /* .free              = */ test_single_output_backend_sampler_free,
+    /* .backend_init      = */ test_single_output_backend_sampler_backend_init,
+    /* .backend_accept    = */ nullptr,
+    /* .backend_apply     = */ test_single_output_backend_sampler_backend_apply,
+    /* .backend_reset     = */ nullptr,
+    /* .backend_set_input = */ nullptr,
+};
+
+static llama_sampler * test_single_output_backend_sampler_init(
+        test_single_output_backend_sampler ** sampler_ctx) {
+    auto * ctx = new test_single_output_backend_sampler;
+    *sampler_ctx = ctx;
+    return llama_sampler_init(&test_single_output_backend_sampler_i, ctx);
+}
 
 static void test_backend_greedy_sampling(const test_params & params) {
     const int seq_id = 0;
@@ -1527,43 +1596,270 @@ static void test_backend_cpu_mixed_batch(const test_params & params) {
     printf("backend-cpu mixed batch test PASSED\n");
 }
 
-static void test_backend_max_outputs(const test_params & params) {
-    const int seq_id = 0;
-    const int32_t seed = 88;
+static void test_backend_multi_output_disabled(const test_params & params) {
+    const llama_seq_id seq_id = 0;
 
-    llama_sampler_chain_params backend_chain_params = llama_sampler_chain_default_params();
-    llama_sampler_ptr backend_sampler_chain(llama_sampler_chain_init(backend_chain_params));
-    llama_sampler_chain_add(backend_sampler_chain.get(), llama_sampler_init_dist(seed));
-    std::vector<llama_sampler_seq_config> backend_sampler_configs = {{ seq_id, backend_sampler_chain.get() }};
+    llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+    llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
+    std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
+    test_context test_ctx(params, configs, 1, 1);
 
-    test_context test_ctx(params, backend_sampler_configs);
+    llama_batch batch = llama_batch_init(2, 0, 1);
+    common_batch_add(batch, llama_vocab_bos(test_ctx.vocab), 0, { seq_id }, true);
+    common_batch_add(batch, llama_vocab_bos(test_ctx.vocab), 1, { seq_id }, true);
 
-    llama_batch batch = llama_batch_init(512, 0, 1);
-    std::string prompt = "Hello";
-
-    std::vector<llama_token> tokens;
-    tokens.push_back(llama_vocab_bos(test_ctx.vocab));
-
-    std::vector<llama_token> prompt_tokens(32);
-    int n_tokens = llama_tokenize(test_ctx.vocab, prompt.c_str(), prompt.length(),
-                                   prompt_tokens.data(), prompt_tokens.size(),
-                                   false, false);
-    for (int i = 0; i < n_tokens; i++) {
-        tokens.push_back(prompt_tokens[i]);
-    }
-
-    for (size_t i = 0; i < tokens.size(); i++) {
-        // set all tokens as output to trigger error
-        common_batch_add(batch, tokens[i], i, { seq_id }, true);
-    }
-
-    printf(">>> test_max_outputs expected error start:\n");
+    printf(">>> test_backend_multi_output_disabled expected error start:\n");
     const int ret = llama_decode(test_ctx.ctx.get(), batch);
-    GGML_ASSERT(ret != 0 && "llama_decode should not succeed multiple outputs per sequence");
-    printf("<<< test_max_outputs expected error end.\n");
+    GGML_ASSERT(ret != 0 && "llama_decode should reject multiple outputs for one sequence");
+    printf("<<< test_backend_multi_output_disabled expected error end.\n");
+
     llama_batch_free(batch);
 
-    printf("backend max outputs test PASSED\n");
+    printf("backend multi-output disabled test PASSED\n");
+}
+
+// greedy is a stateless terminal selector; verify multi-output backend argmax
+// matches the per-row argmax of the reference logits.
+static void test_backend_multi_output_greedy(const test_params & params) {
+    const llama_seq_id seq_id = 0;
+    const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
+    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+
+    llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+    llama_sampler_chain_add(chain.get(), llama_sampler_init_greedy());
+    std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
+    test_context test_ctx(params, configs, 1, 4);
+
+    std::vector<llama_sampler_seq_config> reference_configs;
+    test_context reference_ctx(params, reference_configs, 1, 4);
+
+    llama_batch batch = llama_batch_init(4, 0, 1);
+    for (int i = 0; i < 4; ++i) {
+        common_batch_add(batch, llama_vocab_bos(vocab), i, { seq_id }, true);
+    }
+
+    GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0 &&
+            "multi-output backend greedy sampling should succeed");
+    GGML_ASSERT(llama_decode(reference_ctx.ctx.get(), batch) == 0);
+
+    for (int i = 0; i < batch.n_tokens; ++i) {
+        const llama_token backend_token = llama_get_sampled_token_ith(test_ctx.ctx.get(), i);
+        GGML_ASSERT(backend_token >= 0 && backend_token < n_vocab);
+
+        const float * logits = llama_get_logits_ith(reference_ctx.ctx.get(), i);
+        GGML_ASSERT(logits != nullptr);
+        llama_token argmax = 0;
+        for (llama_token t = 1; t < n_vocab; ++t) {
+            if (logits[t] > logits[argmax]) {
+                argmax = t;
+            }
+        }
+        printf("row %d: backend greedy=%d argmax=%d\n", i, backend_token, argmax);
+        GGML_ASSERT(backend_token == argmax);
+    }
+
+    llama_batch_free(batch);
+
+    printf("backend multi-output greedy test PASSED\n");
+}
+
+static void test_backend_multi_output_sampling_chain(const test_params & params) {
+    const llama_seq_id seq_id = 0;
+    const int32_t seed = 88;
+    const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
+    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+    const uint32_t k = std::min<uint32_t>(2048, n_vocab);
+
+    const llama_logit_bias bias = { llama_vocab_bos(vocab), -0.1f };
+
+    auto make_filter_chain = [&]() {
+        llama_sampler_ptr result(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_logit_bias(
+                n_vocab, 1, &bias));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_top_k(k));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_top_p(0.9f, 1));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_min_p(0.01f, 1));
+        llama_sampler_chain_add(result.get(), llama_sampler_init_temp(0.8f));
+        return result;
+    };
+
+    llama_sampler_ptr chain = make_filter_chain();
+    llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(seed));
+    std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
+    test_context test_ctx(params, configs, 1, 4, 2);
+
+    std::vector<llama_sampler_seq_config> reference_configs;
+    test_context reference_ctx(params, reference_configs, 1, 4, 2);
+    llama_sampler_ptr reference_filters = make_filter_chain();
+
+    std::vector<llama_token_data> reference_data(n_vocab);
+    std::mt19937 reference_rng(seed);
+    std::uniform_real_distribution<double> reference_dist(0.0, 1.0);
+    int32_t n_reused_after_first_round = -1;
+
+    for (int round = 0; round < 2; ++round) {
+        llama_batch batch = llama_batch_init(4, 0, 1);
+        for (int i = 0; i < 4; ++i) {
+            common_batch_add(batch, llama_vocab_bos(vocab), round * 4 + i, { seq_id }, true);
+        }
+
+        GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
+        GGML_ASSERT(llama_decode(reference_ctx.ctx.get(), batch) == 0);
+
+        for (int i = 0; i < batch.n_tokens; ++i) {
+            const llama_token backend_token = llama_get_sampled_token_ith(test_ctx.ctx.get(), i);
+            const float * sampled_logits = llama_get_sampled_logits_ith(test_ctx.ctx.get(), i);
+            const float * sampled_probs = llama_get_sampled_probs_ith(test_ctx.ctx.get(), i);
+            const llama_token * sampled_candidates = llama_get_sampled_candidates_ith(test_ctx.ctx.get(), i);
+            const uint32_t n_logits = llama_get_sampled_logits_count_ith(test_ctx.ctx.get(), i);
+            const uint32_t n_probs = llama_get_sampled_probs_count_ith(test_ctx.ctx.get(), i);
+            const uint32_t n_candidates = llama_get_sampled_candidates_count_ith(test_ctx.ctx.get(), i);
+
+            GGML_ASSERT(backend_token >= 0 && backend_token < n_vocab);
+            GGML_ASSERT(sampled_logits != nullptr);
+            GGML_ASSERT(sampled_probs != nullptr);
+            GGML_ASSERT(sampled_candidates != nullptr);
+            GGML_ASSERT(n_logits == k);
+            GGML_ASSERT(n_probs == n_logits);
+            GGML_ASSERT(n_candidates == n_logits);
+
+            const float * reference_logits = llama_get_logits_ith(reference_ctx.ctx.get(), i);
+            GGML_ASSERT(reference_logits != nullptr);
+
+            for (llama_token token = 0; token < n_vocab; ++token) {
+                reference_data[token] = { token, reference_logits[token], 0.0f };
+            }
+
+            llama_token_data_array reference = {
+                /* .data     = */ reference_data.data(),
+                /* .size     = */ reference_data.size(),
+                /* .selected = */ LLAMA_TOKEN_NULL,
+                /* .sorted   = */ false,
+            };
+            llama_sampler_apply(reference_filters.get(), &reference);
+
+            std::vector<bool> reference_matched(reference.size, false);
+            const llama_token_data * reference_begin = reference.data;
+            const llama_token_data * reference_end = reference.data + reference.size;
+            size_t n_matched = 0;
+            int32_t sampled_index = -1;
+            float prob_sum = 0.0f;
+
+            for (uint32_t j = 0; j < n_logits; ++j) {
+                GGML_ASSERT(std::isfinite(sampled_probs[j]));
+                GGML_ASSERT(sampled_probs[j] >= 0.0f);
+                prob_sum += sampled_probs[j];
+
+                if (sampled_candidates[j] == backend_token) {
+                    sampled_index = j;
+                }
+
+                if (!std::isfinite(sampled_logits[j])) {
+                    GGML_ASSERT(std::isinf(sampled_logits[j]) && sampled_logits[j] < 0.0f);
+                    GGML_ASSERT(sampled_probs[j] == 0.0f);
+                    continue;
+                }
+
+                const llama_token_data * match = std::find_if(reference_begin, reference_end,
+                        [&](const llama_token_data & candidate) {
+                            return candidate.id == sampled_candidates[j];
+                        });
+                GGML_ASSERT(match != reference_end);
+
+                const size_t i_reference = match - reference.data;
+                GGML_ASSERT(!reference_matched[i_reference]);
+
+                const float tolerance = 1e-4f * std::max(1.0f, std::fabs(match->logit));
+                GGML_ASSERT(std::fabs(sampled_logits[j] - match->logit) <= tolerance);
+                reference_matched[i_reference] = true;
+                ++n_matched;
+            }
+
+            GGML_ASSERT(n_matched == reference.size);
+            GGML_ASSERT(sampled_index >= 0);
+            GGML_ASSERT(std::fabs(prob_sum - 1.0f) <= 1e-3f);
+
+            const float rnd = reference_dist(reference_rng);
+            float cumsum_before = 0.0f;
+            for (int32_t j = 0; j < sampled_index; ++j) {
+                cumsum_before += sampled_probs[j];
+            }
+            const float cumsum_sampled = cumsum_before + sampled_probs[sampled_index];
+            GGML_ASSERT(rnd >= cumsum_before - 1e-4f);
+            GGML_ASSERT(rnd <= cumsum_sampled + 1e-4f);
+        }
+
+        llama_batch_free(batch);
+
+        const int32_t n_reused = llama_perf_context(test_ctx.ctx.get()).n_reused;
+        if (round == 0) {
+            n_reused_after_first_round = n_reused;
+        } else {
+            GGML_ASSERT(n_reused > n_reused_after_first_round);
+        }
+    }
+
+    printf("backend multi-output sampling chain test PASSED\n");
+}
+
+static void test_backend_multi_output_cpu_suffix(const test_params & params) {
+    const llama_seq_id seq_id = 0;
+    const int32_t k = 8;
+    const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
+
+    {
+        test_single_output_backend_sampler * sampler_ctx = nullptr;
+        llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+        llama_sampler_chain_add(chain.get(), llama_sampler_init_top_k(k));
+        llama_sampler_chain_add(chain.get(), test_single_output_backend_sampler_init(&sampler_ctx));
+        llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
+        std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
+        test_context test_ctx(params, configs, 1, 1);
+
+        llama_batch batch = llama_batch_init(1, 0, 1);
+        common_batch_add(batch, llama_vocab_bos(vocab), 0, { seq_id }, true);
+        GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
+
+        GGML_ASSERT(sampler_ctx->backend_initialized);
+        GGML_ASSERT(!sampler_ctx->backend_require_multi_output);
+        GGML_ASSERT(sampler_ctx->backend_apply_count > 0);
+        GGML_ASSERT(sampler_ctx->apply_count == 0);
+        GGML_ASSERT(llama_get_sampled_token_ith(test_ctx.ctx.get(), 0) != LLAMA_TOKEN_NULL);
+
+        llama_batch_free(batch);
+    }
+
+    {
+        test_single_output_backend_sampler * sampler_ctx = nullptr;
+        llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+        llama_sampler_chain_add(chain.get(), llama_sampler_init_top_k(k));
+        llama_sampler_chain_add(chain.get(), test_single_output_backend_sampler_init(&sampler_ctx));
+        llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(88));
+        std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
+        test_context test_ctx(params, configs, 1, 2);
+
+        llama_batch batch = llama_batch_init(2, 0, 1);
+        for (int i = 0; i < 2; ++i) {
+            common_batch_add(batch, llama_vocab_bos(vocab), i, { seq_id }, true);
+        }
+        GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
+
+        GGML_ASSERT(!sampler_ctx->backend_initialized);
+        GGML_ASSERT(sampler_ctx->backend_require_multi_output);
+        GGML_ASSERT(sampler_ctx->backend_apply_count == 0);
+        for (int i = 0; i < batch.n_tokens; ++i) {
+            GGML_ASSERT(llama_get_sampled_token_ith(test_ctx.ctx.get(), i) == LLAMA_TOKEN_NULL);
+            GGML_ASSERT(llama_get_sampled_logits_count_ith(test_ctx.ctx.get(), i) == (uint32_t) k);
+            GGML_ASSERT(llama_get_sampled_candidates_count_ith(test_ctx.ctx.get(), i) == (uint32_t) k);
+            const llama_token token = llama_sampler_sample(chain.get(), test_ctx.ctx.get(), i);
+            GGML_ASSERT(token >= 0 && token < llama_vocab_n_tokens(vocab));
+        }
+        GGML_ASSERT(sampler_ctx->apply_count == batch.n_tokens);
+
+        llama_batch_free(batch);
+    }
+
+    printf("backend multi-output CPU suffix test PASSED\n");
 }
 
 struct backend_test_case {
@@ -1583,7 +1879,10 @@ static const backend_test_case BACKEND_TESTS[] = {
     { "dist",            test_backend_dist_sampling,           true  },
     { "dist_and_cpu",    test_backend_dist_sampling_and_cpu,   true  },
     { "set_sampler",     test_backend_set_sampler,             true  },
-    { "max_outputs",     test_backend_max_outputs,             true  },
+    { "multi_output_disabled", test_backend_multi_output_disabled,   true },
+    { "multi_output_greedy",   test_backend_multi_output_greedy,     true },
+    { "multi_output_sampling_chain", test_backend_multi_output_sampling_chain, true },
+    { "multi_output_cpu",      test_backend_multi_output_cpu_suffix, true },
     { "mixed",           test_backend_mixed_sampling,          true  },
     { "min_p",           test_backend_min_p_sampling,          true  },
     { "cpu_mixed",       test_backend_cpu_mixed_batch,         true  },

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -1621,51 +1621,6 @@ static void test_backend_multi_output_limit(const test_params & params) {
     printf("backend multi-output limit test PASSED\n");
 }
 
-// greedy is a stateless terminal selector; verify multi-output backend argmax
-// matches the per-row argmax of the reference logits.
-static void test_backend_multi_output_greedy(const test_params & params) {
-    const llama_seq_id seq_id = 0;
-    const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
-    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
-
-    llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
-    llama_sampler_chain_add(chain.get(), llama_sampler_init_greedy());
-    std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
-    test_context test_ctx(params, configs, 4, 4, 0, 4);
-
-    std::vector<llama_sampler_seq_config> reference_configs;
-    test_context reference_ctx(params, reference_configs, 1, 4);
-
-    llama_batch batch = llama_batch_init(4, 0, 1);
-    for (int i = 0; i < 4; ++i) {
-        common_batch_add(batch, llama_vocab_bos(vocab), i, { seq_id }, true);
-    }
-
-    GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0 &&
-            "multi-output backend greedy sampling should succeed");
-    GGML_ASSERT(llama_decode(reference_ctx.ctx.get(), batch) == 0);
-
-    for (int i = 0; i < batch.n_tokens; ++i) {
-        const llama_token backend_token = llama_get_sampled_token_ith(test_ctx.ctx.get(), i);
-        GGML_ASSERT(backend_token >= 0 && backend_token < n_vocab);
-
-        const float * logits = llama_get_logits_ith(reference_ctx.ctx.get(), i);
-        GGML_ASSERT(logits != nullptr);
-        llama_token argmax = 0;
-        for (llama_token t = 1; t < n_vocab; ++t) {
-            if (logits[t] > logits[argmax]) {
-                argmax = t;
-            }
-        }
-        printf("row %d: backend greedy=%d argmax=%d\n", i, backend_token, argmax);
-        GGML_ASSERT(backend_token == argmax);
-    }
-
-    llama_batch_free(batch);
-
-    printf("backend multi-output greedy test PASSED\n");
-}
-
 static void test_backend_multi_sequence_multi_output_dist(const test_params & params) {
     const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
     const int32_t n_vocab = llama_vocab_n_tokens(vocab);
@@ -1714,7 +1669,8 @@ static void test_backend_multi_sequence_multi_output_dist(const test_params & pa
         GGML_ASSERT(seq_id == 0 || seq_id == 1);
         outputs_per_seq[seq_id]++;
 
-        const llama_token backend_token = llama_get_sampled_token_ith(test_ctx.ctx.get(), i);
+        llama_sampler * chain = seq_id == 0 ? chain_0.get() : chain_1.get();
+        const llama_token backend_token = llama_sampler_sample(chain, test_ctx.ctx.get(), i);
         const float * sampled_logits = llama_get_sampled_logits_ith(test_ctx.ctx.get(), i);
         const float * sampled_probs = llama_get_sampled_probs_ith(test_ctx.ctx.get(), i);
         const uint32_t n_logits = llama_get_sampled_logits_count_ith(test_ctx.ctx.get(), i);
@@ -1757,6 +1713,87 @@ static void test_backend_multi_sequence_multi_output_dist(const test_params & pa
     llama_batch_free(batch);
 
     printf("backend multi-sequence multi-output dist test PASSED\n");
+}
+
+static void test_backend_multi_output_dist_transaction(const test_params & params) {
+    const llama_seq_id seq_id = 0;
+    const uint32_t seed = 95;
+    const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
+
+    llama_sampler_ptr chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+    llama_sampler_chain_add(chain.get(), llama_sampler_init_temp(10.0f));
+    llama_sampler_chain_add(chain.get(), llama_sampler_init_dist(seed));
+    std::vector<llama_sampler_seq_config> configs = {{ seq_id, chain.get() }};
+    test_context test_ctx(params, configs, 1, 3, 2, 3);
+
+    auto verify_random = [&](int32_t row, float rnd, bool accept = true) {
+        const llama_token token = accept ?
+            llama_sampler_sample(chain.get(), test_ctx.ctx.get(), row) :
+            llama_get_sampled_token_ith(test_ctx.ctx.get(), row);
+        const float * probs = llama_get_sampled_probs_ith(test_ctx.ctx.get(), row);
+
+        GGML_ASSERT(token >= 0 && token < llama_vocab_n_tokens(vocab));
+        GGML_ASSERT(probs != nullptr);
+
+        float cumsum_before = 0.0f;
+        for (llama_token i = 0; i < token; ++i) {
+            cumsum_before += probs[i];
+        }
+
+        const float cumsum_sampled = cumsum_before + probs[token];
+        GGML_ASSERT(rnd >= cumsum_before - 1e-4f);
+        GGML_ASSERT(rnd <= cumsum_sampled + 1e-4f);
+    };
+
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    float randoms[7];
+    for (float & rnd : randoms) {
+        rnd = dist(rng);
+    }
+
+    int32_t pos = 0;
+    auto decode = [&]() {
+        llama_batch batch = llama_batch_init(3, 0, 1);
+        for (int32_t i = 0; i < 3; ++i) {
+            common_batch_add(batch, llama_vocab_bos(vocab), pos++, { seq_id }, true);
+        }
+        GGML_ASSERT(llama_decode(test_ctx.ctx.get(), batch) == 0);
+        return batch;
+    };
+
+    llama_batch batch = decode();
+    verify_random(0, randoms[0], false);
+    llama_batch_free(batch);
+
+    batch = decode();
+    verify_random(0, randoms[0]);
+    verify_random(1, randoms[1]);
+    llama_batch_free(batch);
+
+    batch = decode();
+    verify_random(0, randoms[2]);
+    verify_random(1, randoms[3]);
+    verify_random(2, randoms[4]);
+    llama_batch_free(batch);
+
+    batch = decode();
+    verify_random(0, randoms[5]);
+    llama_batch_free(batch);
+
+    batch = decode();
+    llama_sampler_ptr saved(llama_sampler_clone(chain.get()));
+    verify_random(0, randoms[6]);
+    llama_batch_free(batch);
+
+    GGML_ASSERT(llama_set_sampler(test_ctx.ctx.get(), seq_id, saved.get()));
+    chain = std::move(saved);
+
+    batch = decode();
+    verify_random(0, randoms[6]);
+    llama_batch_free(batch);
+
+    printf("backend multi-output dist transaction test PASSED\n");
 }
 
 static void test_backend_multi_output_sampling_chain(const test_params & params) {
@@ -1806,7 +1843,7 @@ static void test_backend_multi_output_sampling_chain(const test_params & params)
         GGML_ASSERT(llama_decode(reference_ctx.ctx.get(), batch) == 0);
 
         for (int i = 0; i < batch.n_tokens; ++i) {
-            const llama_token backend_token = llama_get_sampled_token_ith(test_ctx.ctx.get(), i);
+            const llama_token backend_token = llama_sampler_sample(chain.get(), test_ctx.ctx.get(), i);
             const float * sampled_logits = llama_get_sampled_logits_ith(test_ctx.ctx.get(), i);
             const float * sampled_probs = llama_get_sampled_probs_ith(test_ctx.ctx.get(), i);
             const llama_token * sampled_candidates = llama_get_sampled_candidates_ith(test_ctx.ctx.get(), i);
@@ -1979,8 +2016,8 @@ static const backend_test_case BACKEND_TESTS[] = {
     { "dist_and_cpu",    test_backend_dist_sampling_and_cpu,   true  },
     { "set_sampler",     test_backend_set_sampler,             true  },
     { "multi_output_limit",    test_backend_multi_output_limit,      true },
-    { "multi_output_greedy",   test_backend_multi_output_greedy,     true },
     { "multi_sequence_multi_output_dist", test_backend_multi_sequence_multi_output_dist, true },
+    { "multi_output_dist_transaction", test_backend_multi_output_dist_transaction, true },
     { "multi_output_sampling_chain", test_backend_multi_output_sampling_chain, true },
     { "multi_output_cpu",      test_backend_multi_output_cpu_suffix, true },
     { "mixed",           test_backend_mixed_sampling,          true  },

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -322,8 +322,8 @@ static llama_sampler_i test_single_output_backend_sampler_i = {
     /* .backend_init      = */ test_single_output_backend_sampler_backend_init,
     /* .backend_accept    = */ nullptr,
     /* .backend_apply     = */ test_single_output_backend_sampler_backend_apply,
-    /* .backend_reset     = */ nullptr,
     /* .backend_set_input = */ nullptr,
+    /* .backend_reset     = */ nullptr,
 };
 
 static llama_sampler * test_single_output_backend_sampler_init(

--- a/tests/test-backend-sampler.cpp
+++ b/tests/test-backend-sampler.cpp
@@ -732,7 +732,7 @@ static void test_backend_multi_sequence_sampling(const test_params & params) {
 }
 
 static void test_backend_dist_sampling(const test_params & params) {
-    const int seq_id = 189;
+    const int seq_id = 0;
     const int32_t seed = 88;
 
     struct llama_sampler_chain_params backend_chain_params = llama_sampler_chain_default_params();
@@ -1801,7 +1801,7 @@ static void test_backend_multi_output_sampling_chain(const test_params & params)
     const int32_t seed = 88;
     const llama_vocab * vocab = llama_model_get_vocab(params.model.get());
     const int32_t n_vocab = llama_vocab_n_tokens(vocab);
-    const uint32_t k = std::min<uint32_t>(2048, n_vocab);
+    const uint32_t k = std::min<uint32_t>(512, n_vocab);
 
     const llama_logit_bias bias = { llama_vocab_bos(vocab), -0.1f };
 

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -61,6 +61,31 @@ private:
     std::vector<llama_token_data> cur;
 };
 
+static llama_token sample_dist(llama_sampler * sampler, const std::vector<float> & logits) {
+    std::vector<llama_token_data> cur;
+    for (llama_token token_id = 0; token_id < (llama_token) logits.size(); ++token_id) {
+        cur.push_back({ token_id, logits[token_id], 0.0f });
+    }
+
+    llama_token_data_array cur_p = { cur.data(), cur.size(), -1, false };
+    llama_sampler_apply(sampler, &cur_p);
+    GGML_ASSERT(cur_p.selected >= 0);
+    return cur_p.data[cur_p.selected].id;
+}
+
+static void test_dist_singleton_rng() {
+    llama_sampler * singleton = llama_sampler_init_dist(4242);
+    llama_sampler * control   = llama_sampler_init_dist(4242);
+
+    sample_dist(singleton, { 0.0f });
+    sample_dist(control,   { 0.0f, 0.0f });
+
+    GGML_ASSERT(sample_dist(singleton, { 0.0f, 0.0f }) == sample_dist(control, { 0.0f, 0.0f }));
+
+    llama_sampler_free(singleton);
+    llama_sampler_free(control);
+}
+
 static void test_temp(const std::vector<float> & probs, const std::vector<float> & probs_expected, float temp) {
     sampler_tester tester(probs, probs_expected);
 
@@ -307,6 +332,8 @@ static void test_perf() {
 
 int main(void) {
     ggml_time_init();
+
+    test_dist_singleton_rng();
 
     test_temp({0.1f, 0.2f, 0.3f, 0.4f}, {0.1f, 0.2f, 0.3f, 0.4f}, 1.0f);
     test_temp({0.1f, 0.2f, 0.3f, 0.4f}, {0.0f, 0.0f, 0.0f, 1.0f}, 0.0f);

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -70,6 +70,7 @@ static llama_token sample_dist(llama_sampler * sampler, const std::vector<float>
     llama_token_data_array cur_p = { cur.data(), cur.size(), -1, false };
     llama_sampler_apply(sampler, &cur_p);
     GGML_ASSERT(cur_p.selected >= 0);
+    GGML_ASSERT((size_t) cur_p.selected < cur_p.size);
     return cur_p.data[cur_p.selected].id;
 }
 
@@ -80,7 +81,10 @@ static void test_dist_singleton_rng() {
     sample_dist(singleton, { 0.0f });
     sample_dist(control,   { 0.0f, 0.0f });
 
-    GGML_ASSERT(sample_dist(singleton, { 0.0f, 0.0f }) == sample_dist(control, { 0.0f, 0.0f }));
+    const std::vector<float> logits(256, 0.0f);
+    for (int i = 0; i < 4; ++i) {
+        GGML_ASSERT(sample_dist(singleton, logits) == sample_dist(control, logits));
+    }
 
     llama_sampler_free(singleton);
     llama_sampler_free(control);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -222,6 +222,7 @@ struct server_slot {
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
     bool spec_is_replay = false;
+    common_sampler_ptr spec_smpl_save;
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
     //       see https://github.com/ggml-org/llama.cpp/pull/18283#issuecomment-3710175837
@@ -359,6 +360,7 @@ struct server_slot {
             spec_draft.clear();
             spec_i_batch.clear();
             spec_ckpt.clear();
+            spec_smpl_save.reset();
         }
         generated_tokens.clear();
         generated_token_probs.clear();
@@ -3108,6 +3110,11 @@ private:
 
         // update the batch with the sampled/drafted tokens
         iterate(generating, [&](server_slot & slot) {
+            GGML_ASSERT(!slot.spec_smpl_save);
+            if (!slot.spec_draft.empty()) {
+                // backend sampling advances the sampler during llama_decode()
+                slot.spec_smpl_save.reset(common_sampler_clone(slot.smpl.get()));
+            }
             slot.handle_last_sampled_token(batch);
         });
 
@@ -3886,8 +3893,8 @@ private:
 
             // verify and try to accept the draft
             {
-                // save the sampler sampler state in case we need to restore it
-                common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
+                GGML_ASSERT(slot.spec_smpl_save);
+                common_sampler_ptr smpl_save = std::move(slot.spec_smpl_save);
 
                 GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
                 auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -51,6 +51,18 @@ static uint32_t server_n_outputs_max(const common_params & params) {
     return std::max<int32_t>(1, n_outputs);
 }
 
+static uint32_t server_n_sampling_outputs_per_seq_max(const common_params & params) {
+    if (params.embedding ||
+            (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED && params.pooling_type != LLAMA_POOLING_TYPE_NONE)) {
+        return 1;
+    }
+
+    const int32_t n_outputs = common_speculative_n_outputs_per_seq_max(
+            params.n_batch, common_speculative_n_max(&params.speculative));
+
+    return std::max<int32_t>(1, n_outputs);
+}
+
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
 enum slot_state {
     SLOT_STATE_IDLE,
@@ -1063,6 +1075,7 @@ private:
 
         params_base = params;
         params_base.n_outputs_max = server_n_outputs_max(params_base);
+        params_base.n_sampling_outputs_per_seq_max = server_n_sampling_outputs_per_seq_max(params_base);
 
         const bool has_mmproj = !params.mmproj.path.empty();
         const bool has_draft = params.speculative.has_dft();
@@ -1143,6 +1156,7 @@ private:
                 bool measure_model_bytes = has_draft;
 
                 common_params params_dft = common_base_params_to_speculative(params_base);
+                params_dft.n_sampling_outputs_per_seq_max = 1;
 
                 auto mparams_dft = common_model_params_to_llama(params_dft);
                 auto cparams_dft = common_context_params_to_llama(params_dft);
@@ -1231,6 +1245,7 @@ private:
                 // progress callback
                 params_dft.load_progress_callback           = load_progress_callback;
                 params_dft.load_progress_callback_user_data = &load_progress_spec;
+                params_dft.n_sampling_outputs_per_seq_max = 1;
 
                 spec_init = common_speculative_init_from_params(params_dft, model_tgt, ctx_tgt);
                 model_dft = spec_init->model();

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3882,7 +3882,8 @@ private:
 
         // speculative decoding - main model sample and accept
         iterate(slots, [&](server_slot & slot) {
-            if (slot.state != SLOT_STATE_GENERATING || !slot.can_speculate() || slot.spec_draft.empty()) {
+            if (slot.state != SLOT_STATE_GENERATING || !slot.can_speculate() ||
+                    slot.spec_draft.empty() || slot.spec_i_batch.empty()) {
                 return;
             }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -39,28 +39,18 @@ using json = nlohmann::ordered_json;
 
 constexpr int HTTP_POLLING_SECONDS = 1;
 
-static uint32_t server_n_outputs_max(const common_params & params) {
+static common_speculative_output_limits server_output_limits(const common_params & params) {
     if (params.embedding ||
             (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED && params.pooling_type != LLAMA_POOLING_TYPE_NONE)) {
-        return params.n_batch;
+        return { params.n_batch, 1 };
     }
 
-    const int32_t n_outputs = common_speculative_n_outputs_max(
+    auto result = common_speculative_get_output_limits(
             params.n_batch, params.n_parallel, common_speculative_n_max(&params.speculative));
 
-    return std::max<int32_t>(1, n_outputs);
-}
-
-static uint32_t server_n_sampling_outputs_per_seq_max(const common_params & params) {
-    if (params.embedding ||
-            (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED && params.pooling_type != LLAMA_POOLING_TYPE_NONE)) {
-        return 1;
-    }
-
-    const int32_t n_outputs = common_speculative_n_outputs_per_seq_max(
-            params.n_batch, common_speculative_n_max(&params.speculative));
-
-    return std::max<int32_t>(1, n_outputs);
+    result.total   = std::max<int32_t>(1, result.total);
+    result.per_seq = std::max<int32_t>(1, result.per_seq);
+    return result;
 }
 
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
@@ -1074,8 +1064,9 @@ private:
         const bool is_resume = sleeping;
 
         params_base = params;
-        params_base.n_outputs_max = server_n_outputs_max(params_base);
-        params_base.n_sampling_outputs_per_seq_max = server_n_sampling_outputs_per_seq_max(params_base);
+        const auto output_limits = server_output_limits(params_base);
+        params_base.n_outputs_max = output_limits.total;
+        params_base.n_sampling_outputs_per_seq_max = output_limits.per_seq;
 
         const bool has_mmproj = !params.mmproj.path.empty();
         const bool has_draft = params.speculative.has_dft();
@@ -1156,7 +1147,6 @@ private:
                 bool measure_model_bytes = has_draft;
 
                 common_params params_dft = common_base_params_to_speculative(params_base);
-                params_dft.n_sampling_outputs_per_seq_max = 1;
 
                 auto mparams_dft = common_model_params_to_llama(params_dft);
                 auto cparams_dft = common_context_params_to_llama(params_dft);
@@ -1245,7 +1235,6 @@ private:
                 // progress callback
                 params_dft.load_progress_callback           = load_progress_callback;
                 params_dft.load_progress_callback_user_data = &load_progress_spec;
-                params_dft.n_sampling_outputs_per_seq_max = 1;
 
                 spec_init = common_speculative_init_from_params(params_dft, model_tgt, ctx_tgt);
                 model_dft = spec_init->model();

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -222,7 +222,6 @@ struct server_slot {
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
     bool spec_is_replay = false;
-    common_sampler_ptr spec_smpl_save;
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
     //       see https://github.com/ggml-org/llama.cpp/pull/18283#issuecomment-3710175837
@@ -360,7 +359,6 @@ struct server_slot {
             spec_draft.clear();
             spec_i_batch.clear();
             spec_ckpt.clear();
-            spec_smpl_save.reset();
         }
         generated_tokens.clear();
         generated_token_probs.clear();
@@ -3110,11 +3108,6 @@ private:
 
         // update the batch with the sampled/drafted tokens
         iterate(generating, [&](server_slot & slot) {
-            GGML_ASSERT(!slot.spec_smpl_save);
-            if (!slot.spec_draft.empty()) {
-                // backend sampling advances the sampler during llama_decode()
-                slot.spec_smpl_save.reset(common_sampler_clone(slot.smpl.get()));
-            }
             slot.handle_last_sampled_token(batch);
         });
 
@@ -3894,8 +3887,7 @@ private:
 
             // verify and try to accept the draft
             {
-                GGML_ASSERT(slot.spec_smpl_save);
-                common_sampler_ptr smpl_save = std::move(slot.spec_smpl_save);
+                common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
 
                 GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
                 auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
@@ -3933,16 +3925,12 @@ private:
                         slot.mem.seq_rm(slot.id, ckpt.pos_max + 1, -1);
 
                         slot.prompt.tokens.keep_first(ckpt.n_tokens);
-                        const bool restore_backend_sampler = slot.backend_sampling;
-                        if (restore_backend_sampler) {
-                            llama_set_sampler(slot.ctx_tgt, slot.id, nullptr);
+                        if (slot.backend_sampling) {
+                            slot.backend_sampling = llama_set_sampler(
+                                slot.ctx_tgt, slot.id, common_sampler_get(smpl_save.get()));
                         }
 
                         slot.smpl = std::move(smpl_save);
-                        if (restore_backend_sampler) {
-                            slot.backend_sampling = llama_set_sampler(
-                                slot.ctx_tgt, slot.id, common_sampler_get(slot.smpl.get()));
-                        }
 
                         return;
                     }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -40,18 +40,15 @@ using json = nlohmann::ordered_json;
 constexpr int HTTP_POLLING_SECONDS = 1;
 
 static uint32_t server_n_outputs_max(const common_params & params) {
-    const uint32_t n_batch  = params.n_batch;
-
     if (params.embedding ||
             (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED && params.pooling_type != LLAMA_POOLING_TYPE_NONE)) {
-        return n_batch;
+        return params.n_batch;
     }
 
-    const uint32_t n_outputs_per_seq = 1 + common_speculative_n_max(&params.speculative);
+    const int32_t n_outputs = common_speculative_n_outputs_max(
+            params.n_batch, params.n_parallel, common_speculative_n_max(&params.speculative));
 
-    const uint64_t n_outputs = (uint64_t) params.n_parallel * n_outputs_per_seq;
-
-    return std::max<uint32_t>(1, std::min<uint64_t>(n_batch, n_outputs));
+    return std::max<int32_t>(1, n_outputs);
 }
 
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
@@ -303,6 +300,7 @@ struct server_slot {
     json json_schema;
 
     common_sampler_ptr smpl;
+    bool backend_sampling = false;
 
     llama_token sampled; // in speculative mode, this is the last accepted token
 
@@ -364,6 +362,7 @@ struct server_slot {
         task.reset();
 
         llama_set_sampler(ctx_tgt, id, nullptr);
+        backend_sampling = false;
 
         // clear alora start
         alora_invocation_start = -1;
@@ -1832,21 +1831,17 @@ private:
 
             const bool need_pre_sample_logits = task.params.sampling.n_probs > 0 && !task.params.post_sampling_probs;
 
-            bool backend_sampling = true;
-
-            backend_sampling &= task.params.sampling.backend_sampling;
-
-            // TODO: speculative decoding requires multiple samples per batch - not supported yet
-            backend_sampling &= !(slot.can_speculate());
+            bool use_backend_sampling = task.params.sampling.backend_sampling;
 
             // TODO: getting pre sampling logits is not yet supported with backend sampling
-            backend_sampling &= !need_pre_sample_logits;
+            use_backend_sampling &= !need_pre_sample_logits;
 
             // TODO: tmp until backend sampling is fully implemented
-            if (backend_sampling) {
-                llama_set_sampler(ctx_tgt, slot.id, common_sampler_get(slot.smpl.get()));
+            if (use_backend_sampling) {
+                slot.backend_sampling = llama_set_sampler(ctx_tgt, slot.id, common_sampler_get(slot.smpl.get()));
             } else {
                 llama_set_sampler(ctx_tgt, slot.id, nullptr);
+                slot.backend_sampling = false;
             }
 
             SLT_TRC(slot, "sampler chain: %s\n", common_sampler_print(slot.smpl.get()).c_str());
@@ -3915,7 +3910,16 @@ private:
                         slot.mem.seq_rm(slot.id, ckpt.pos_max + 1, -1);
 
                         slot.prompt.tokens.keep_first(ckpt.n_tokens);
+                        const bool restore_backend_sampler = slot.backend_sampling;
+                        if (restore_backend_sampler) {
+                            llama_set_sampler(slot.ctx_tgt, slot.id, nullptr);
+                        }
+
                         slot.smpl = std::move(smpl_save);
+                        if (restore_backend_sampler) {
+                            slot.backend_sampling = llama_set_sampler(
+                                slot.ctx_tgt, slot.id, common_sampler_get(slot.smpl.get()));
+                        }
 
                         return;
                     }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -302,7 +302,6 @@ struct server_slot {
     json json_schema;
 
     common_sampler_ptr smpl;
-    bool backend_sampling = false;
 
     llama_token sampled; // in speculative mode, this is the last accepted token
 
@@ -364,7 +363,6 @@ struct server_slot {
         task.reset();
 
         llama_set_sampler(ctx_tgt, id, nullptr);
-        backend_sampling = false;
 
         // clear alora start
         alora_invocation_start = -1;
@@ -1066,7 +1064,7 @@ private:
         params_base = params;
         const auto output_limits = server_output_limits(params_base);
         params_base.n_outputs_max = output_limits.total;
-        params_base.n_sampling_outputs_per_seq_max = output_limits.per_seq;
+        params_base.n_outputs_max_per_seq = output_limits.per_seq;
 
         const bool has_mmproj = !params.mmproj.path.empty();
         const bool has_draft = params.speculative.has_dft();
@@ -1842,10 +1840,9 @@ private:
 
             // TODO: tmp until backend sampling is fully implemented
             if (use_backend_sampling) {
-                slot.backend_sampling = llama_set_sampler(ctx_tgt, slot.id, common_sampler_get(slot.smpl.get()));
+                llama_set_sampler(ctx_tgt, slot.id, common_sampler_get(slot.smpl.get()));
             } else {
                 llama_set_sampler(ctx_tgt, slot.id, nullptr);
-                slot.backend_sampling = false;
             }
 
             SLT_TRC(slot, "sampler chain: %s\n", common_sampler_print(slot.smpl.get()).c_str());
@@ -3914,12 +3911,7 @@ private:
                         slot.mem.seq_rm(slot.id, ckpt.pos_max + 1, -1);
 
                         slot.prompt.tokens.keep_first(ckpt.n_tokens);
-                        if (slot.backend_sampling) {
-                            slot.backend_sampling = llama_set_sampler(
-                                slot.ctx_tgt, slot.id, common_sampler_get(smpl_save.get()));
-                        }
-
-                        slot.smpl = std::move(smpl_save);
+                        common_sampler_copy(smpl_save.get(), slot.smpl.get());
 
                         return;
                     }

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -40,7 +40,6 @@ def test_with_and_without_draft():
     server.start()
     res = server.make_request("POST", "/completion", data=request)
     assert res.status_code == 200
-    content_no_draft = res.body["content"]
     tokens_no_draft = res.body["tokens"]
     server.stop()
 
@@ -51,10 +50,8 @@ def test_with_and_without_draft():
     res = server.make_request("POST", "/completion", data=request)
     assert res.status_code == 200
     assert res.body["timings"]["draft_n"] > 0
-    content_draft = res.body["content"]
     tokens_draft = res.body["tokens"]
 
-    assert content_no_draft == content_draft
     assert tokens_no_draft == tokens_draft
 
 

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -25,34 +25,37 @@ def fixture_create_server():
 
 def test_with_and_without_draft():
     global server
-    server.model_draft = None  # disable draft model
-    server.spec_type = None
-    server.start()
-    res = server.make_request("POST", "/completion", data={
+    request = {
         "prompt": "I believe the meaning of life is",
         "temperature": 0.0,
         "top_k": 1,
+        "seed": 4242,
         "n_predict": 16,
-    })
+        "return_tokens": True,
+    }
+
+    server.model_draft = None  # disable draft model
+    server.spec_type = None
+    server.backend_sampling = True
+    server.start()
+    res = server.make_request("POST", "/completion", data=request)
     assert res.status_code == 200
     content_no_draft = res.body["content"]
+    tokens_no_draft = res.body["tokens"]
     server.stop()
 
     # create new server with draft model
     create_server()
     server.backend_sampling = True
     server.start()
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "I believe the meaning of life is",
-        "temperature": 0.0,
-        "top_k": 1,
-        "n_predict": 16,
-    })
+    res = server.make_request("POST", "/completion", data=request)
     assert res.status_code == 200
     assert res.body["timings"]["draft_n"] > 0
     content_draft = res.body["content"]
+    tokens_draft = res.body["tokens"]
 
     assert content_no_draft == content_draft
+    assert tokens_no_draft == tokens_draft
 
 
 def test_different_draft_min_draft_max():

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -40,6 +40,7 @@ def test_with_and_without_draft():
 
     # create new server with draft model
     create_server()
+    server.backend_sampling = True
     server.start()
     res = server.make_request("POST", "/completion", data={
         "prompt": "I believe the meaning of life is",

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -27,8 +27,8 @@ def test_with_and_without_draft():
     global server
     request = {
         "prompt": "I believe the meaning of life is",
-        "temperature": 0.0,
-        "top_k": 1,
+        "temperature": 0.8,
+        "top_k": 40,
         "seed": 4242,
         "n_predict": 16,
         "return_tokens": True,


### PR DESCRIPTION
## Overview

This PR extends backend sampling from one output per sequence to multiple outputs, enabling backend sampling during speculative decoding.
* Add `n_sampling_outputs_per_seq_max` to context parameters, separating the total output budget from the per-sequence backend-sampling limit.
* Build one backend-sampling graph row per output rather than per sequence. 
* Extend graph reservation and node budgeting for replicated sampler graphs. 
* Add graph probing for both backend operation support and sampler node counting.
* Add a `backend_reset` hook to clear graph-owned tensor references before graph reconstruction.
* Make distribution sampling deterministic between CPU and backend paths - use a temporary RNG for multi-output sampling so rejected tokens do not advance rng
* Clamp the distribution mask sum before converting it into a sampled index, preventing an out-of-range access. (Copied from https://github.com/ggml-org/llama.cpp/pull/19833)

## Additional information

Performance: I see a perf improvement of ~8% on RTX 5090 with the Qwen-3.6-35B Q4_K_M model. Acceptance ratio with both backend and CPU sampling is exactly same.

CPU sampling: `llama-server -m Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --spec-type draft-mtp --seed 42`
```
python3 mtp-bench.py
  code_python        pred= 192 draft= 168 acc= 135 rate=0.804 tok/s=379.5
  code_cpp           pred= 192 draft= 190 acc= 127 rate=0.668 tok/s=343.1
  explain_concept    pred= 192 draft= 210 acc= 119 rate=0.567 tok/s=308.9
  summarize          pred= 192 draft= 169 acc= 134 rate=0.793 tok/s=380.3
  qa_factual         pred= 192 draft= 170 acc= 134 rate=0.788 tok/s=382.0
  translation        pred= 192 draft= 176 acc= 132 rate=0.750 tok/s=370.2
  creative_short     pred= 192 draft= 207 acc= 120 rate=0.580 tok/s=315.8
  stepwise_math      pred= 192 draft= 160 acc= 137 rate=0.856 tok/s=401.1
  long_code_review   pred= 192 draft= 168 acc= 134 rate=0.798 tok/s=379.2
```

Backend sampling: `llama-server -m Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --spec-type draft-mtp --seed 42 -bs`

```
python3 mtp-bench.py
  code_python        pred= 192 draft= 168 acc= 135 rate=0.804 tok/s=411.4
  code_cpp           pred= 192 draft= 190 acc= 127 rate=0.668 tok/s=369.2
  explain_concept    pred= 192 draft= 210 acc= 119 rate=0.567 tok/s=330.2
  summarize          pred= 192 draft= 169 acc= 134 rate=0.793 tok/s=412.3
  qa_factual         pred= 192 draft= 170 acc= 134 rate=0.788 tok/s=414.4
  translation        pred= 192 draft= 176 acc= 132 rate=0.750 tok/s=400.4
  creative_short     pred= 192 draft= 207 acc= 120 rate=0.580 tok/s=337.8
  stepwise_math      pred= 192 draft= 160 acc= 137 rate=0.856 tok/s=437.1
  long_code_review   pred= 192 draft= 168 acc= 134 rate=0.798 tok/s=410.2
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, paired with Codex. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
