### PR TITLE
metal : optimize Mamba-2 SSM scan decode

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -544,7 +544,11 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
 
     const int nsg = (ne00 + 31)/32;
 
-    snprintf(base, 256, "kernel_ssm_scan_%s", ggml_type_name(op->src[0]->type));
+    const bool use_group_kernel = op->src[3]->ne[0] == 1 && op->src[1]->ne[2] == 1 &&
+        (ne00 == 128 || ne00 == 256);
+
+    snprintf(base, 256, "kernel_ssm_scan%s_%s",
+            use_group_kernel ? "_group" : "", ggml_type_name(op->src[0]->type));
     snprintf(name, 256, "%s_nsg=%d", base, nsg);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
@@ -552,12 +556,14 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
         res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
     }
 
-    // Shared memory layout:
-    // - sgptg * NW floats for partial sums (nsg * 32)
-    // - sgptg floats for shared_x_dt (nsg)
-    // - sgptg floats for shared_dA (nsg)
-    // Total: nsg * (32 + 2) floats
-    res.smem = (32 + 2)*sizeof(float)*nsg;
+    if (!use_group_kernel) {
+        // Shared memory layout:
+        // - sgptg * NW floats for partial sums (nsg * 32)
+        // - sgptg floats for shared_x_dt (nsg)
+        // - sgptg floats for shared_dA (nsg)
+        // Total: nsg * (32 + 2) floats
+        res.smem = (32 + 2)*sizeof(float)*nsg;
+    }
 
     return res;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1553,7 +1553,15 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
 
-    ggml_metal_encoder_dispatch_threadgroups(enc, d_inner, n_head, n_seqs, d_state, 1, 1);
+    const bool use_group_kernel = src3->ne[0] == 1 && n_seq_tokens == 1 &&
+        (d_state == 128 || d_state == 256);
+    if (use_group_kernel) {
+        const int64_t nsg = d_state / 32;
+        ggml_metal_encoder_dispatch_threadgroups(
+                enc, (d_inner * n_head + nsg - 1) / nsg, n_seqs, 1, d_state, 1, 1);
+    } else {
+        ggml_metal_encoder_dispatch_threadgroups(enc, d_inner, n_head, n_seqs, d_state, 1, 1);
+    }
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2392,6 +2392,89 @@ kernel void kernel_ssm_scan_f32(
     s_buff[i] = s;
 }
 
+kernel void kernel_ssm_scan_group_f32(
+        constant ggml_metal_kargs_ssm_scan & args,
+        device const void * src0,
+        device const void * src1,
+        device const void * src2,
+        device const void * src3,
+        device const void * src4,
+        device const void * src5,
+        device const void * src6,
+        device      float * dst,
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort  sgptg[[simdgroups_per_threadgroup]]) {
+    constexpr short NW = N_SIMDWIDTH;
+
+    const int32_t nc = args.d_state;
+    const int32_t nr = args.d_inner;
+    const int32_t nh = args.n_head;
+    const int32_t ng = args.n_group;
+    const int32_t nt = args.n_seq_tokens;
+
+    const int32_t row = tgpig.x * sgptg + sgitg;
+    if (row >= nr * nh) {
+        return;
+    }
+
+    const int32_t i1 = row % nr;
+    const int32_t ir = row / nr;
+    const int32_t i3 = tgpig.y;
+    const int32_t g  = ir / (nh / ng);
+
+    device const int32_t * ids = (device const int32_t *) src6;
+
+    device const float * s0 = (device const float *) ((device const char *) src0
+            + ir * args.nb02 + ids[i3] * args.nb03 + i1 * args.nb01);
+    device       float * s  = (device       float *) ((device       char *) dst + args.s_off
+            + ir * args.nb02 + i3 * args.nb03 + i1 * args.nb01);
+
+    device const float * x  = (device const float *) ((device const char *) src1
+            + i1 * args.nb10 + ir * args.nb11 + i3 * args.nb13);
+    device const float * dt = (device const float *) ((device const char *) src2
+            + ir * args.nb20 + i3 * args.nb22);
+    device const float * A  = (device const float *) ((device const char *) src3
+            + ir * args.nb31);
+    device const float * B  = (device const float *) ((device const char *) src4
+            + g * args.nb41 + i3 * args.nb43);
+    device const float * C  = (device const float *) ((device const char *) src5
+            + g * args.nb51 + i3 * args.nb53);
+
+    device float * y = dst + i1 + ir * nr + i3 * nt * nh * nr;
+
+    float state[8];
+    const int32_t c_factor = nc / NW;
+
+    for (int32_t j = 0; j < c_factor; ++j) {
+        state[j] = s0[j * NW + tiisg];
+    }
+
+    for (int32_t i = 0; i < nt; ++i) {
+        const float dt0  = dt[i * args.ns21];
+        const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
+        const float dA   = exp(dtsp * A[0]);
+        const float x_dt = x[i * args.ns12] * dtsp;
+
+        float sumf = 0.0f;
+        for (int32_t j = 0; j < c_factor; ++j) {
+            const int32_t state_idx = j * NW + tiisg;
+            state[j] = state[j] * dA + B[i * args.ns42 + state_idx] * x_dt;
+            sumf += state[j] * C[i * args.ns52 + state_idx];
+        }
+
+        sumf = simd_sum(sumf);
+        if (tiisg == 0) {
+            y[i * nh * nr] = sumf;
+        }
+    }
+
+    for (int32_t j = 0; j < c_factor; ++j) {
+        s[j * NW + tiisg] = state[j];
+    }
+}
+
 kernel void kernel_rwkv_wkv6_f32(
     device const float * k,
     device const float * v,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8507,6 +8507,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 16, 1, 1024, 1, 32, 4)); // Mamba-1
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 32, 4)); // Mamba-2
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 256, 64,  8, 2, 32, 4)); // Falcon-H1
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2,  1, 4)); // Mamba-2 generate
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 256, 64,  8, 2,  1, 4)); // Falcon-H1 generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 128, 4, 4, 16, 2, true)); // x/B/C overlap
 
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));


### PR DESCRIPTION
Overview
This PR introduces a specialized Metal kernel, kernel_ssm_scan_group_f32, to optimize the SSM (State Space Model) scan operation specifically during token generation. By targeting configurations with a sequence length of 1 and state dimensions of 128 or 256, this change provides significant performance improvements for Mamba-2 and Falcon-H1 models. The implementation includes updated pipeline compilation and dispatch logic to support this path, as well as new test cases to ensure correctness.

Additional information
Performance Impact: Optimized execution path for common SSM generation workloads.

Files Modified:

ggml/src/ggml-metal/ggml-metal-device.cpp: Added pipeline registration for the grouped kernel.

ggml/src/ggml-metal/ggml-metal-ops.cpp: Updated dispatch logic to use the grouped kernel for supported dimensions.

ggml/src/ggml-metal/ggml-metal.metal: Implemented the high-performance grouped kernel.

tests/test-backend-ops.cpp: Added verification tests for Mamba-2 and Falcon-H1.

Reviewer Note: A minor consolidation of shared memory logic in ggml-metal-device.cpp is recommended to remove redundant assignments.

Requirements
I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

AI usage disclosure: YES. This PR description and code structural recommendations were drafted with the assistance of an AI.

Note to project maintainers: As an AI agent, I acknowledge that the user is responsible for reviewing, testing, and ultimately submitting these changes. Please refer to AGENTS.md and CONTRIBUTING.md for project policies regarding AI-generated content.