### PR TITLE
mtmd: fix silent prompt truncation on embedded NUL

### DIFF
--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -251,6 +251,7 @@ static int eval_message(mtmd_cli_context & ctx, common_chat_msg & msg) {
 
     mtmd_input_text text;
     text.text          = formatted_chat.c_str();
+    text.text_len      = formatted_chat.size();
     text.add_special   = add_bos;
     text.parse_special = true;
 

--- a/tools/mtmd/mtmd-cli.cpp
+++ b/tools/mtmd/mtmd-cli.cpp
@@ -250,7 +250,7 @@ static int eval_message(mtmd_cli_context & ctx, common_chat_msg & msg) {
     LOG_DBG("formatted_chat.prompt: %s\n", formatted_chat.c_str());
 
     mtmd_input_text text;
-    text.text          = formatted_chat.c_str();
+    text.text          = formatted_chat.data();
     text.text_len      = formatted_chat.size();
     text.add_special   = add_bos;
     text.parse_special = true;

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -839,7 +839,7 @@ struct mtmd_tokenizer {
             size_t n_bitmaps) : ctx(ctx) {
         add_special   = text->add_special;
         parse_special = text->parse_special;
-        input_text    = text->text;
+        input_text.assign(text->text, text->text_len);
         vocab         = ctx->vocab;
 
         std::vector<const mtmd_bitmap *> bitmaps(bmps, bmps + n_bitmaps);

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -809,7 +809,7 @@ void mtmd_free(mtmd_context * ctx) {
 struct mtmd_tokenizer {
     mtmd_context * ctx;
 
-    std::string input_text;
+    std::string input_text; // note: can contain null bytes; do not use c_str()
     bool add_special;
     bool parse_special;
     const llama_vocab * vocab;
@@ -839,8 +839,9 @@ struct mtmd_tokenizer {
             size_t n_bitmaps) : ctx(ctx) {
         add_special   = text->add_special;
         parse_special = text->parse_special;
-        input_text.assign(text->text, text->text_len);
         vocab         = ctx->vocab;
+
+        input_text.assign(text->text, text->text_len);
 
         std::vector<const mtmd_bitmap *> bitmaps(bmps, bmps + n_bitmaps);
         auto parts_str = split_text(input_text, ctx->media_marker);

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -67,7 +67,7 @@ struct mtmd_batch;
 
 struct mtmd_input_text {
     const char * text;
-    size_t text_len; // text byte length, allows embedded NUL bytes
+    size_t text_len;
     bool add_special;
     bool parse_special;
 };

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -67,6 +67,7 @@ struct mtmd_batch;
 
 struct mtmd_input_text {
     const char * text;
+    size_t text_len; // text byte length, allows embedded NUL bytes
     bool add_special;
     bool parse_special;
 };

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -705,7 +705,8 @@ server_tokens process_mtmd_prompt(mtmd_context * mctx, const std::string & promp
     std::vector<server_tokens> inputs;
     // multimodal
     mtmd_input_text inp_txt = {
-        prompt.c_str(),
+        prompt.data(),
+        prompt.size(),
         /* add_special */   true,
         /* parse_special */ true,
     };


### PR DESCRIPTION
## Overview

Low severity on the security side, but it prevents silent/unlogged truncation bugs that can break reliability in agentic use.

### Repro (mmproj loaded)
```
root@pod:/mnt/workspace/git/llama.cpp# ./build/bin/llama-server -m /mnt/inputs/unsloth/gemma-4-E2B-it-GGUF/gemma-4-E2B-it-UD-Q8_K_XL.gguf --mmproj /mnt/inputs/unsloth/gemma-4-E2B-it-GGUF/mmproj-BF16.gguf --jinja -ngl 99 -c 8192 --host 127.0.0.1 --port 7777 -lv 10
...
root@pod:/mnt/workspace/git/llama.cpp# curl -s http://127.0.0.1:7777/v1/chat/completions -H 'Content-Type: application/json' -d '{"stream":false,"max_tokens":64,"messages":[{"role":"user","content":"Reply with exactly the word BANANA and nothing else.\u0000 If you can read this sentence, reply APPLE instead."}]}' | jq -r '.__verbose.prompt'
```

### Before
```
<bos><|turn>system
<|think|>
<turn|>
<|turn>user
Reply with exactly the word BANANA and nothing else.
```

### After
```
<bos><|turn>system
<|think|>
<turn|>
<|turn>user
Reply with exactly the word BANANA and nothing else. If you can read this sentence, reply APPLE instead.<turn|>
<|turn>model
```

## Additional information

Fixes #25543

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
