### PR TITLE
feat(ggml-cpu): add VLEN1024 Q4_K/Q5_K 64x1 CPU_REPACK path

### DIFF
--- a/ggml/src/ggml-cpu/arch/riscv/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/riscv/repack.cpp
@@ -389,6 +389,222 @@ void ggml_gemv_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
     }
 }
 
+void ggml_gemv_q4_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK_K;
+    const int nb = n / qk;
+    const int ncols_interleaved = 64;
+    const int blocklen = 1;
+    const size_t vl = __riscv_vsetvl_e32m2(ncols_interleaved);
+    const size_t vl4 = vl * 4;
+
+    assert (n % qk == 0);
+    assert (nc % ncols_interleaved == 0);
+    assert (vl == 64);
+
+    UNUSED(s);
+    UNUSED(bs);
+    UNUSED(vx);
+    UNUSED(vy);
+    UNUSED(nr);
+    UNUSED(nc);
+    UNUSED(nb);
+    UNUSED(blocklen);
+
+    const block_q8_K * a_ptr = (const block_q8_K *) vy;
+
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_q4_Kx64 * b_ptr = (const block_q4_Kx64 *) vx + (x * nb);
+
+        vfloat32m2_t sumf = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+
+        for (int l = 0; l < nb; l++) {
+            vint32m2_t sumi = __riscv_vmv_v_x_i32m2(0, vl);
+
+            const vfloat32m2_t dmins_d = __riscv_vfmul_vf_f32m2(
+                __riscv_vfwcvt_f_f_v_f32m2(__riscv_vle16_v_f16m1((const _Float16 *) b_ptr[l].dmin, vl), vl), a_ptr[l].d, vl);
+
+            for (int j = 0; j < QK_K / 128; j++) {
+                vuint8m2_t scales_mins_lo = __riscv_vle8_v_u8m2(&b_ptr[l].scales[j * 4 * ncols_interleaved], vl4);
+                vuint8m2_t scales_lo = __riscv_vand_vx_u8m2(scales_mins_lo, 0x0F, vl4);
+                vuint8m2_t mins_lo = __riscv_vsrl_vx_u8m2(scales_mins_lo, 4, vl4);
+
+                vuint8m2_t scales_mins_hi = __riscv_vle8_v_u8m2(&b_ptr[l].scales[8 * ncols_interleaved], vl4);
+                vuint8m2_t scales_hi;
+                vuint8m2_t mins_hi;
+                if (!j) {
+                    scales_hi = __riscv_vsll_vx_u8m2(__riscv_vand_vx_u8m2(scales_mins_hi, 0x03, vl4), 4, vl4);
+                    mins_hi = __riscv_vsll_vx_u8m2(__riscv_vand_vx_u8m2(scales_mins_hi, 0x0C, vl4), 2, vl4);
+                } else {
+                    scales_hi = __riscv_vand_vx_u8m2(scales_mins_hi, 0x30, vl4);
+                    mins_hi = __riscv_vsrl_vx_u8m2(__riscv_vand_vx_u8m2(scales_mins_hi, 0xC0, vl4), 2, vl4);
+                }
+                vuint16m4_t scales = __riscv_vzext_vf2_u16m4(__riscv_vor_vv_u8m2(scales_hi, scales_lo, vl4), vl4);
+                vint16m4_t mins = __riscv_vreinterpret_v_u16m4_i16m4(
+                    __riscv_vzext_vf2_u16m4(__riscv_vor_vv_u8m2(mins_hi, mins_lo, vl4), vl4));
+
+                vint32m2_t bsums = __riscv_vmv_v_x_i32m2(0, vl);
+                bsums = __riscv_vwmacc_vx_i32m2(bsums, a_ptr[l].bsums[j * 8] + a_ptr[l].bsums[j * 8 + 1],
+                                                __riscv_vget_v_i16m4_i16m1(mins, 0), vl);
+                bsums = __riscv_vwmacc_vx_i32m2(bsums, a_ptr[l].bsums[j * 8 + 2] + a_ptr[l].bsums[j * 8 + 3],
+                                                __riscv_vget_v_i16m4_i16m1(mins, 1), vl);
+                bsums = __riscv_vwmacc_vx_i32m2(bsums, a_ptr[l].bsums[j * 8 + 4] + a_ptr[l].bsums[j * 8 + 5],
+                                                __riscv_vget_v_i16m4_i16m1(mins, 2), vl);
+                bsums = __riscv_vwmacc_vx_i32m2(bsums, a_ptr[l].bsums[j * 8 + 6] + a_ptr[l].bsums[j * 8 + 7],
+                                                __riscv_vget_v_i16m4_i16m1(mins, 3), vl);
+
+                sumf = __riscv_vfsub_vv_f32m2(sumf, __riscv_vfmul_vv_f32m2(dmins_d, __riscv_vfcvt_f_x_v_f32m2(bsums, vl), vl), vl);
+
+                for (int k = 0; k < 2; k++) {
+                    vint16m1_t sumi_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                    vint16m1_t sumi_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+
+                    for (int i = k * 16; i < k * 16 + QK4_0 / 2; i++) {
+                        const vuint8mf2_t b_0_packed = __riscv_vle8_v_u8mf2(
+                            &b_ptr[l].qs[j * 64 * ncols_interleaved + i * ncols_interleaved], vl);
+                        const vint8mf2_t b_s_0 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vand_vx_u8mf2(b_0_packed, 0xF, vl));
+                        const vint8mf2_t b_s_1 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vsrl_vx_u8mf2(b_0_packed, 4, vl));
+
+                        sumi_s_0 = __riscv_vwmacc_vx_i16m1(sumi_s_0, a_ptr[l].qs[j * 128 + i], b_s_0, vl);
+                        sumi_s_1 = __riscv_vwmacc_vx_i16m1(sumi_s_1, a_ptr[l].qs[j * 128 + 32 + i], b_s_1, vl);
+                    }
+
+                    sumi = __riscv_vwmacc_vv_i32m2(sumi,
+                        __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 0)),
+                        sumi_s_0, vl);
+                    sumi = __riscv_vwmacc_vv_i32m2(sumi,
+                        __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 1)),
+                        sumi_s_1, vl);
+                }
+
+                for (int k = 0; k < 2; k++) {
+                    vint16m1_t sumi_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                    vint16m1_t sumi_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+
+                    for (int i = k * 16; i < k * 16 + QK4_0 / 2; i++) {
+                        const vuint8mf2_t b_0_packed = __riscv_vle8_v_u8mf2(
+                            &b_ptr[l].qs[j * 64 * ncols_interleaved + 32 * ncols_interleaved + i * ncols_interleaved], vl);
+                        const vint8mf2_t b_s_0 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vand_vx_u8mf2(b_0_packed, 0xF, vl));
+                        const vint8mf2_t b_s_1 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vsrl_vx_u8mf2(b_0_packed, 4, vl));
+
+                        sumi_s_0 = __riscv_vwmacc_vx_i16m1(sumi_s_0, a_ptr[l].qs[j * 128 + 64 + i], b_s_0, vl);
+                        sumi_s_1 = __riscv_vwmacc_vx_i16m1(sumi_s_1, a_ptr[l].qs[j * 128 + 96 + i], b_s_1, vl);
+                    }
+
+                    sumi = __riscv_vwmacc_vv_i32m2(sumi,
+                        __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 2)),
+                        sumi_s_0, vl);
+                    sumi = __riscv_vwmacc_vv_i32m2(sumi,
+                        __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 3)),
+                        sumi_s_1, vl);
+                }
+            }
+
+            const vfloat32m2_t b_d = __riscv_vfwcvt_f_f_v_f32m2(__riscv_vle16_v_f16m1((const _Float16 *) &b_ptr[l].d[0], vl), vl);
+            const vfloat32m2_t d_0 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d, vl);
+
+            sumf = __riscv_vfmacc_vv_f32m2(sumf, __riscv_vfcvt_f_x_v_f32m2(sumi, vl), d_0, vl);
+        }
+
+        __riscv_vse32_v_f32m2(s + x * ncols_interleaved, sumf, vl);
+    }
+}
+
+static inline vint16m1_t ggml_rvv_k_scale_64(const uint8_t * GGML_RESTRICT scales, int idx, size_t vl) {
+    constexpr int ncols = 64;
+    const int hi_idx = idx & 3;
+
+    const vuint8mf2_t vlo_raw = __riscv_vle8_v_u8mf2(scales + idx * ncols, vl);
+    const vuint8mf2_t vlo = __riscv_vand_vx_u8mf2(vlo_raw, 0x0f, vl);
+    const vuint8mf2_t vhi_raw = __riscv_vle8_v_u8mf2(scales + 8 * ncols + hi_idx * ncols, vl);
+    const vuint8mf2_t vhi = idx < 4 ?
+        __riscv_vsll_vx_u8mf2(__riscv_vand_vx_u8mf2(vhi_raw, 0x03, vl), 4, vl) :
+        __riscv_vand_vx_u8mf2(vhi_raw, 0x30, vl);
+
+    return __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2_u16m1(__riscv_vor_vv_u8mf2(vlo, vhi, vl), vl));
+}
+
+static inline vint16m1_t ggml_rvv_k_min_64(const uint8_t * GGML_RESTRICT scales, int idx, size_t vl) {
+    constexpr int ncols = 64;
+    const int hi_idx = idx & 3;
+
+    const vuint8mf2_t vlo_raw = __riscv_vle8_v_u8mf2(scales + idx * ncols, vl);
+    const vuint8mf2_t vlo = __riscv_vsrl_vx_u8mf2(vlo_raw, 4, vl);
+    const vuint8mf2_t vhi_raw = __riscv_vle8_v_u8mf2(scales + 8 * ncols + hi_idx * ncols, vl);
+    const vuint8mf2_t vhi = idx < 4 ?
+        __riscv_vsll_vx_u8mf2(__riscv_vand_vx_u8mf2(vhi_raw, 0x0c, vl), 2, vl) :
+        __riscv_vsrl_vx_u8mf2(__riscv_vand_vx_u8mf2(vhi_raw, 0xc0, vl), 2, vl);
+
+    return __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2_u16m1(__riscv_vor_vv_u8mf2(vlo, vhi, vl), vl));
+}
+
+static inline vint16m1_t ggml_rvv_q5_K_weight_64(const uint8_t * GGML_RESTRICT qs,
+                                                 const uint8_t * GGML_RESTRICT qh,
+                                                 int group,
+                                                 int idx,
+                                                 bool high,
+                                                 size_t vl) {
+    constexpr int ncols = 64;
+    const vuint8mf2_t vpacked = __riscv_vle8_v_u8mf2(qs + (group * 32 + idx) * ncols, vl);
+    const vuint8mf2_t vlo = high ? __riscv_vsrl_vx_u8mf2(vpacked, 4, vl) : __riscv_vand_vx_u8mf2(vpacked, 0x0f, vl);
+    const vuint8mf2_t vqh = __riscv_vle8_v_u8mf2(qh + idx * ncols, vl);
+    const vuint8mf2_t vh = __riscv_vand_vx_u8mf2(__riscv_vsrl_vx_u8mf2(vqh, group * 2 + (high ? 1 : 0), vl), 0x01, vl);
+    const vuint8mf2_t vq = __riscv_vor_vv_u8mf2(vlo, __riscv_vsll_vx_u8mf2(vh, 4, vl), vl);
+
+    return __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2_u16m1(vq, vl));
+}
+
+void ggml_gemv_q5_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    assert(n % QK_K == 0);
+    assert(nr == 1);
+    assert(nc % 64 == 0);
+
+    UNUSED(bs);
+    UNUSED(nr);
+
+    const int nb = n / QK_K;
+    const size_t vl = __riscv_vsetvl_e32m2(64);
+    assert(vl == 64);
+
+    const block_q8_K * a_ptr = (const block_q8_K *) vy;
+    for (int x = 0; x < nc / 64; x++) {
+        const block_q5_Kx64 * b_ptr = (const block_q5_Kx64 *) vx + (x * nb);
+        vfloat32m2_t sumf = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+
+        for (int l = 0; l < nb; l++) {
+            vint32m2_t sumi = __riscv_vmv_v_x_i32m2(0, vl);
+
+            for (int group = 0; group < 4; group++) {
+                const vint16m1_t vscale_0 = ggml_rvv_k_scale_64(b_ptr[l].scales, group * 2 + 0, vl);
+                const vint16m1_t vscale_1 = ggml_rvv_k_scale_64(b_ptr[l].scales, group * 2 + 1, vl);
+
+                for (int i = 0; i < 32; i++) {
+                    const vint16m1_t vw_0 = __riscv_vmul_vv_i16m1(
+                        ggml_rvv_q5_K_weight_64(b_ptr[l].qs, b_ptr[l].qh, group, i, false, vl), vscale_0, vl);
+                    const vint16m1_t vw_1 = __riscv_vmul_vv_i16m1(
+                        ggml_rvv_q5_K_weight_64(b_ptr[l].qs, b_ptr[l].qh, group, i, true, vl), vscale_1, vl);
+                    sumi = __riscv_vwmacc_vx_i32m2(sumi, (int16_t) a_ptr[l].qs[group * 64 + i], vw_0, vl);
+                    sumi = __riscv_vwmacc_vx_i32m2(sumi, (int16_t) a_ptr[l].qs[group * 64 + 32 + i], vw_1, vl);
+                }
+            }
+
+            const vfloat32m2_t vd = __riscv_vfmul_vf_f32m2(
+                __riscv_vfwcvt_f_f_v_f32m2(__riscv_vle16_v_f16m1((const _Float16 *) b_ptr[l].d, vl), vl), a_ptr[l].d, vl);
+            sumf = __riscv_vfmacc_vv_f32m2(sumf, __riscv_vfcvt_f_x_v_f32m2(sumi, vl), vd, vl);
+
+            const vfloat32m2_t vdmin = __riscv_vfmul_vf_f32m2(
+                __riscv_vfwcvt_f_f_v_f32m2(__riscv_vle16_v_f16m1((const _Float16 *) b_ptr[l].dmin, vl), vl), a_ptr[l].d, vl);
+            for (int sb = 0; sb < 8; sb++) {
+                const vint16m1_t vmin = ggml_rvv_k_min_64(b_ptr[l].scales, sb, vl);
+                const int bsum = a_ptr[l].bsums[sb * 2] + a_ptr[l].bsums[sb * 2 + 1];
+                const vint32m2_t vcorr = __riscv_vwmul_vx_i32m2(vmin, bsum, vl);
+                sumf = __riscv_vfsub_vv_f32m2(sumf, __riscv_vfmul_vv_f32m2(__riscv_vfcvt_f_x_v_f32m2(vcorr, vl), vdmin, vl), vl);
+            }
+        }
+
+        __riscv_vse32_v_f32m2(s + x * 64, sumf, vl);
+    }
+}
+
 void ggml_gemv_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
     const int qk = QK8_0;
     const int nb = n / qk;
@@ -1245,6 +1461,299 @@ void ggml_gemm_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const v
             __riscv_vse32_v_f32m2(s + (y * 4 + 1) * bs + x * 16, sumf_1, 16);
             __riscv_vse32_v_f32m2(s + (y * 4 + 2) * bs + x * 16, sumf_2, 16);
             __riscv_vse32_v_f32m2(s + (y * 4 + 3) * bs + x * 16, sumf_3, 16);
+        }
+    }
+}
+
+void ggml_gemm_q4_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK_K;
+    const int nb = n / qk;
+    const int ncols_interleaved = 64;
+    const int blocklen = 1;
+    const size_t vl = __riscv_vsetvl_e32m2(ncols_interleaved);
+    const size_t vl4 = vl * 4;
+
+    assert (n % qk == 0);
+    assert (nr % 4 == 0);
+    assert (nc % ncols_interleaved == 0);
+    assert (vl == 64);
+
+    UNUSED(s);
+    UNUSED(bs);
+    UNUSED(vx);
+    UNUSED(vy);
+    UNUSED(nr);
+    UNUSED(nc);
+    UNUSED(nb);
+    UNUSED(blocklen);
+
+    for (int y = 0; y < nr / 4; y++) {
+        const block_q8_Kx4 * a_ptr = (const block_q8_Kx4 *) vy + (y * nb);
+        for (int x = 0; x < nc / ncols_interleaved; x++) {
+            const block_q4_Kx64 * b_ptr = (const block_q4_Kx64 *) vx + (x * nb);
+
+            vfloat32m2_t sumf_0 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+            vfloat32m2_t sumf_1 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+            vfloat32m2_t sumf_2 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+            vfloat32m2_t sumf_3 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+
+            for (int l = 0; l < nb; l++) {
+                vint32m2_t sumi_0 = __riscv_vmv_v_x_i32m2(0, vl);
+                vint32m2_t sumi_1 = __riscv_vmv_v_x_i32m2(0, vl);
+                vint32m2_t sumi_2 = __riscv_vmv_v_x_i32m2(0, vl);
+                vint32m2_t sumi_3 = __riscv_vmv_v_x_i32m2(0, vl);
+
+                const vfloat32m2_t dmins = __riscv_vfwcvt_f_f_v_f32m2(
+                    __riscv_vle16_v_f16m1((const _Float16 *) b_ptr[l].dmin, vl), vl);
+
+                for (int j = 0; j < QK_K / 128; j++) {
+                    vuint8m2_t scales_mins_lo = __riscv_vle8_v_u8m2(&b_ptr[l].scales[j * 4 * ncols_interleaved], vl4);
+                    vuint8m2_t scales_lo = __riscv_vand_vx_u8m2(scales_mins_lo, 0x0F, vl4);
+                    vuint8m2_t mins_lo = __riscv_vsrl_vx_u8m2(scales_mins_lo, 4, vl4);
+
+                    vuint8m2_t scales_mins_hi = __riscv_vle8_v_u8m2(&b_ptr[l].scales[8 * ncols_interleaved], vl4);
+                    vuint8m2_t scales_hi;
+                    vuint8m2_t mins_hi;
+                    if (!j) {
+                        scales_hi = __riscv_vsll_vx_u8m2(__riscv_vand_vx_u8m2(scales_mins_hi, 0x03, vl4), 4, vl4);
+                        mins_hi = __riscv_vsll_vx_u8m2(__riscv_vand_vx_u8m2(scales_mins_hi, 0x0C, vl4), 2, vl4);
+                    } else {
+                        scales_hi = __riscv_vand_vx_u8m2(scales_mins_hi, 0x30, vl4);
+                        mins_hi = __riscv_vsrl_vx_u8m2(__riscv_vand_vx_u8m2(scales_mins_hi, 0xC0, vl4), 2, vl4);
+                    }
+                    vuint16m4_t scales = __riscv_vzext_vf2_u16m4(__riscv_vor_vv_u8m2(scales_hi, scales_lo, vl4), vl4);
+                    vint16m4_t mins = __riscv_vreinterpret_v_u16m4_i16m4(
+                        __riscv_vzext_vf2_u16m4(__riscv_vor_vv_u8m2(mins_hi, mins_lo, vl4), vl4));
+
+                    vint32m2_t bsums_0 = __riscv_vmv_v_x_i32m2(0, vl);
+                    vint32m2_t bsums_1 = __riscv_vmv_v_x_i32m2(0, vl);
+                    vint32m2_t bsums_2 = __riscv_vmv_v_x_i32m2(0, vl);
+                    vint32m2_t bsums_3 = __riscv_vmv_v_x_i32m2(0, vl);
+
+                    const vint16m1_t vmins_0 = __riscv_vget_v_i16m4_i16m1(mins, 0);
+                    const vint16m1_t vmins_1 = __riscv_vget_v_i16m4_i16m1(mins, 1);
+                    const vint16m1_t vmins_2 = __riscv_vget_v_i16m4_i16m1(mins, 2);
+                    const vint16m1_t vmins_3 = __riscv_vget_v_i16m4_i16m1(mins, 3);
+
+                    const int base_0 = j * 32;
+                    bsums_0 = __riscv_vwmacc_vx_i32m2(bsums_0, a_ptr[l].bsums[base_0 + 0] + a_ptr[l].bsums[base_0 + 4], vmins_0, vl);
+                    bsums_1 = __riscv_vwmacc_vx_i32m2(bsums_1, a_ptr[l].bsums[base_0 + 1] + a_ptr[l].bsums[base_0 + 5], vmins_0, vl);
+                    bsums_2 = __riscv_vwmacc_vx_i32m2(bsums_2, a_ptr[l].bsums[base_0 + 2] + a_ptr[l].bsums[base_0 + 6], vmins_0, vl);
+                    bsums_3 = __riscv_vwmacc_vx_i32m2(bsums_3, a_ptr[l].bsums[base_0 + 3] + a_ptr[l].bsums[base_0 + 7], vmins_0, vl);
+
+                    const int base_1 = j * 32 + 8;
+                    bsums_0 = __riscv_vwmacc_vx_i32m2(bsums_0, a_ptr[l].bsums[base_1 + 0] + a_ptr[l].bsums[base_1 + 4], vmins_1, vl);
+                    bsums_1 = __riscv_vwmacc_vx_i32m2(bsums_1, a_ptr[l].bsums[base_1 + 1] + a_ptr[l].bsums[base_1 + 5], vmins_1, vl);
+                    bsums_2 = __riscv_vwmacc_vx_i32m2(bsums_2, a_ptr[l].bsums[base_1 + 2] + a_ptr[l].bsums[base_1 + 6], vmins_1, vl);
+                    bsums_3 = __riscv_vwmacc_vx_i32m2(bsums_3, a_ptr[l].bsums[base_1 + 3] + a_ptr[l].bsums[base_1 + 7], vmins_1, vl);
+
+                    const int base_2 = j * 32 + 16;
+                    bsums_0 = __riscv_vwmacc_vx_i32m2(bsums_0, a_ptr[l].bsums[base_2 + 0] + a_ptr[l].bsums[base_2 + 4], vmins_2, vl);
+                    bsums_1 = __riscv_vwmacc_vx_i32m2(bsums_1, a_ptr[l].bsums[base_2 + 1] + a_ptr[l].bsums[base_2 + 5], vmins_2, vl);
+                    bsums_2 = __riscv_vwmacc_vx_i32m2(bsums_2, a_ptr[l].bsums[base_2 + 2] + a_ptr[l].bsums[base_2 + 6], vmins_2, vl);
+                    bsums_3 = __riscv_vwmacc_vx_i32m2(bsums_3, a_ptr[l].bsums[base_2 + 3] + a_ptr[l].bsums[base_2 + 7], vmins_2, vl);
+
+                    const int base_3 = j * 32 + 24;
+                    bsums_0 = __riscv_vwmacc_vx_i32m2(bsums_0, a_ptr[l].bsums[base_3 + 0] + a_ptr[l].bsums[base_3 + 4], vmins_3, vl);
+                    bsums_1 = __riscv_vwmacc_vx_i32m2(bsums_1, a_ptr[l].bsums[base_3 + 1] + a_ptr[l].bsums[base_3 + 5], vmins_3, vl);
+                    bsums_2 = __riscv_vwmacc_vx_i32m2(bsums_2, a_ptr[l].bsums[base_3 + 2] + a_ptr[l].bsums[base_3 + 6], vmins_3, vl);
+                    bsums_3 = __riscv_vwmacc_vx_i32m2(bsums_3, a_ptr[l].bsums[base_3 + 3] + a_ptr[l].bsums[base_3 + 7], vmins_3, vl);
+
+                    const vfloat32m2_t dmins_d_0 = __riscv_vfmul_vf_f32m2(dmins, a_ptr[l].d[0], vl);
+                    const vfloat32m2_t dmins_d_1 = __riscv_vfmul_vf_f32m2(dmins, a_ptr[l].d[1], vl);
+                    const vfloat32m2_t dmins_d_2 = __riscv_vfmul_vf_f32m2(dmins, a_ptr[l].d[2], vl);
+                    const vfloat32m2_t dmins_d_3 = __riscv_vfmul_vf_f32m2(dmins, a_ptr[l].d[3], vl);
+
+                    sumf_0 = __riscv_vfsub_vv_f32m2(sumf_0, __riscv_vfmul_vv_f32m2(dmins_d_0, __riscv_vfcvt_f_x_v_f32m2(bsums_0, vl), vl), vl);
+                    sumf_1 = __riscv_vfsub_vv_f32m2(sumf_1, __riscv_vfmul_vv_f32m2(dmins_d_1, __riscv_vfcvt_f_x_v_f32m2(bsums_1, vl), vl), vl);
+                    sumf_2 = __riscv_vfsub_vv_f32m2(sumf_2, __riscv_vfmul_vv_f32m2(dmins_d_2, __riscv_vfcvt_f_x_v_f32m2(bsums_2, vl), vl), vl);
+                    sumf_3 = __riscv_vfsub_vv_f32m2(sumf_3, __riscv_vfmul_vv_f32m2(dmins_d_3, __riscv_vfcvt_f_x_v_f32m2(bsums_3, vl), vl), vl);
+
+                    for (int k = 0; k < 2; k++) {
+                        vint16m1_t sumi_0_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_1_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_2_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_3_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_0_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_1_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_2_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_3_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+
+                        for (int i = k * 16; i < k * 16 + QK4_0 / 2; i++) {
+                            const vuint8mf2_t b_0_packed = __riscv_vle8_v_u8mf2(
+                                &b_ptr[l].qs[j * 64 * ncols_interleaved + i * ncols_interleaved], vl);
+                            const vint8mf2_t b_s_0 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vand_vx_u8mf2(b_0_packed, 0xF, vl));
+                            const vint8mf2_t b_s_1 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vsrl_vx_u8mf2(b_0_packed, 4, vl));
+
+                            sumi_0_s_0 = __riscv_vwmacc_vx_i16m1(sumi_0_s_0, a_ptr[l].qs[j * 512 + i * 4], b_s_0, vl);
+                            sumi_1_s_0 = __riscv_vwmacc_vx_i16m1(sumi_1_s_0, a_ptr[l].qs[j * 512 + i * 4 + 1], b_s_0, vl);
+                            sumi_2_s_0 = __riscv_vwmacc_vx_i16m1(sumi_2_s_0, a_ptr[l].qs[j * 512 + i * 4 + 2], b_s_0, vl);
+                            sumi_3_s_0 = __riscv_vwmacc_vx_i16m1(sumi_3_s_0, a_ptr[l].qs[j * 512 + i * 4 + 3], b_s_0, vl);
+
+                            sumi_0_s_1 = __riscv_vwmacc_vx_i16m1(sumi_0_s_1, a_ptr[l].qs[j * 512 + 128 + i * 4], b_s_1, vl);
+                            sumi_1_s_1 = __riscv_vwmacc_vx_i16m1(sumi_1_s_1, a_ptr[l].qs[j * 512 + 128 + i * 4 + 1], b_s_1, vl);
+                            sumi_2_s_1 = __riscv_vwmacc_vx_i16m1(sumi_2_s_1, a_ptr[l].qs[j * 512 + 128 + i * 4 + 2], b_s_1, vl);
+                            sumi_3_s_1 = __riscv_vwmacc_vx_i16m1(sumi_3_s_1, a_ptr[l].qs[j * 512 + 128 + i * 4 + 3], b_s_1, vl);
+                        }
+
+                        const vint16m1_t vscale_0 = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 0));
+                        const vint16m1_t vscale_1 = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 1));
+                        sumi_0 = __riscv_vwmacc_vv_i32m2(sumi_0, vscale_0, sumi_0_s_0, vl);
+                        sumi_0 = __riscv_vwmacc_vv_i32m2(sumi_0, vscale_1, sumi_0_s_1, vl);
+                        sumi_1 = __riscv_vwmacc_vv_i32m2(sumi_1, vscale_0, sumi_1_s_0, vl);
+                        sumi_1 = __riscv_vwmacc_vv_i32m2(sumi_1, vscale_1, sumi_1_s_1, vl);
+                        sumi_2 = __riscv_vwmacc_vv_i32m2(sumi_2, vscale_0, sumi_2_s_0, vl);
+                        sumi_2 = __riscv_vwmacc_vv_i32m2(sumi_2, vscale_1, sumi_2_s_1, vl);
+                        sumi_3 = __riscv_vwmacc_vv_i32m2(sumi_3, vscale_0, sumi_3_s_0, vl);
+                        sumi_3 = __riscv_vwmacc_vv_i32m2(sumi_3, vscale_1, sumi_3_s_1, vl);
+                    }
+
+                    for (int k = 0; k < 2; k++) {
+                        vint16m1_t sumi_0_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_1_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_2_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_3_s_0 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_0_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_1_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_2_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+                        vint16m1_t sumi_3_s_1 = __riscv_vmv_v_x_i16m1(0.0f, vl);
+
+                        for (int i = k * 16; i < k * 16 + QK4_0 / 2; i++) {
+                            const vuint8mf2_t b_0_packed = __riscv_vle8_v_u8mf2(
+                                &b_ptr[l].qs[j * 64 * ncols_interleaved + 32 * ncols_interleaved + i * ncols_interleaved], vl);
+                            const vint8mf2_t b_s_0 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vand_vx_u8mf2(b_0_packed, 0xF, vl));
+                            const vint8mf2_t b_s_1 = __riscv_vreinterpret_v_u8mf2_i8mf2(__riscv_vsrl_vx_u8mf2(b_0_packed, 4, vl));
+
+                            sumi_0_s_0 = __riscv_vwmacc_vx_i16m1(sumi_0_s_0, a_ptr[l].qs[j * 512 + 256 + i * 4], b_s_0, vl);
+                            sumi_1_s_0 = __riscv_vwmacc_vx_i16m1(sumi_1_s_0, a_ptr[l].qs[j * 512 + 256 + i * 4 + 1], b_s_0, vl);
+                            sumi_2_s_0 = __riscv_vwmacc_vx_i16m1(sumi_2_s_0, a_ptr[l].qs[j * 512 + 256 + i * 4 + 2], b_s_0, vl);
+                            sumi_3_s_0 = __riscv_vwmacc_vx_i16m1(sumi_3_s_0, a_ptr[l].qs[j * 512 + 256 + i * 4 + 3], b_s_0, vl);
+
+                            sumi_0_s_1 = __riscv_vwmacc_vx_i16m1(sumi_0_s_1, a_ptr[l].qs[j * 512 + 384 + i * 4], b_s_1, vl);
+                            sumi_1_s_1 = __riscv_vwmacc_vx_i16m1(sumi_1_s_1, a_ptr[l].qs[j * 512 + 384 + i * 4 + 1], b_s_1, vl);
+                            sumi_2_s_1 = __riscv_vwmacc_vx_i16m1(sumi_2_s_1, a_ptr[l].qs[j * 512 + 384 + i * 4 + 2], b_s_1, vl);
+                            sumi_3_s_1 = __riscv_vwmacc_vx_i16m1(sumi_3_s_1, a_ptr[l].qs[j * 512 + 384 + i * 4 + 3], b_s_1, vl);
+                        }
+
+                        const vint16m1_t vscale_2 = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 2));
+                        const vint16m1_t vscale_3 = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vget_v_u16m4_u16m1(scales, 3));
+                        sumi_0 = __riscv_vwmacc_vv_i32m2(sumi_0, vscale_2, sumi_0_s_0, vl);
+                        sumi_0 = __riscv_vwmacc_vv_i32m2(sumi_0, vscale_3, sumi_0_s_1, vl);
+                        sumi_1 = __riscv_vwmacc_vv_i32m2(sumi_1, vscale_2, sumi_1_s_0, vl);
+                        sumi_1 = __riscv_vwmacc_vv_i32m2(sumi_1, vscale_3, sumi_1_s_1, vl);
+                        sumi_2 = __riscv_vwmacc_vv_i32m2(sumi_2, vscale_2, sumi_2_s_0, vl);
+                        sumi_2 = __riscv_vwmacc_vv_i32m2(sumi_2, vscale_3, sumi_2_s_1, vl);
+                        sumi_3 = __riscv_vwmacc_vv_i32m2(sumi_3, vscale_2, sumi_3_s_0, vl);
+                        sumi_3 = __riscv_vwmacc_vv_i32m2(sumi_3, vscale_3, sumi_3_s_1, vl);
+                    }
+                }
+
+                const vfloat32m2_t b_d = __riscv_vfwcvt_f_f_v_f32m2(__riscv_vle16_v_f16m1((const _Float16 *) b_ptr[l].d, vl), vl);
+                const vfloat32m2_t d_0 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[0], vl);
+                const vfloat32m2_t d_1 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[1], vl);
+                const vfloat32m2_t d_2 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[2], vl);
+                const vfloat32m2_t d_3 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[3], vl);
+
+                sumf_0 = __riscv_vfmacc_vv_f32m2(sumf_0, __riscv_vfcvt_f_x_v_f32m2(sumi_0, vl), d_0, vl);
+                sumf_1 = __riscv_vfmacc_vv_f32m2(sumf_1, __riscv_vfcvt_f_x_v_f32m2(sumi_1, vl), d_1, vl);
+                sumf_2 = __riscv_vfmacc_vv_f32m2(sumf_2, __riscv_vfcvt_f_x_v_f32m2(sumi_2, vl), d_2, vl);
+                sumf_3 = __riscv_vfmacc_vv_f32m2(sumf_3, __riscv_vfcvt_f_x_v_f32m2(sumi_3, vl), d_3, vl);
+            }
+
+            __riscv_vse32_v_f32m2(s + (y * 4 + 0) * bs + x * ncols_interleaved, sumf_0, vl);
+            __riscv_vse32_v_f32m2(s + (y * 4 + 1) * bs + x * ncols_interleaved, sumf_1, vl);
+            __riscv_vse32_v_f32m2(s + (y * 4 + 2) * bs + x * ncols_interleaved, sumf_2, vl);
+            __riscv_vse32_v_f32m2(s + (y * 4 + 3) * bs + x * ncols_interleaved, sumf_3, vl);
+        }
+    }
+}
+
+void ggml_gemm_q5_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    assert(n % QK_K == 0);
+    assert(nr % 4 == 0);
+    assert(nc % 64 == 0);
+
+    const int nb = n / QK_K;
+    const size_t vl = __riscv_vsetvl_e32m2(64);
+    assert(vl == 64);
+
+    for (int row_tile = 0; row_tile < nr; row_tile += 4) {
+        const block_q8_Kx4 * a_ptr = (const block_q8_Kx4 *) vy + (row_tile / 4) * nb;
+        for (int col_tile = 0; col_tile < nc; col_tile += 64) {
+            const block_q5_Kx64 * b_ptr = (const block_q5_Kx64 *) vx + (col_tile / 64) * nb;
+
+            vfloat32m2_t sumf_0 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+            vfloat32m2_t sumf_1 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+            vfloat32m2_t sumf_2 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+            vfloat32m2_t sumf_3 = __riscv_vfmv_v_f_f32m2(0.0f, vl);
+
+            for (int l = 0; l < nb; l++) {
+                vint32m2_t sumi_0 = __riscv_vmv_v_x_i32m2(0, vl);
+                vint32m2_t sumi_1 = __riscv_vmv_v_x_i32m2(0, vl);
+                vint32m2_t sumi_2 = __riscv_vmv_v_x_i32m2(0, vl);
+                vint32m2_t sumi_3 = __riscv_vmv_v_x_i32m2(0, vl);
+
+                for (int group = 0; group < 4; group++) {
+                    const vint16m1_t vscale_0 = ggml_rvv_k_scale_64(b_ptr[l].scales, group * 2 + 0, vl);
+                    const vint16m1_t vscale_1 = ggml_rvv_k_scale_64(b_ptr[l].scales, group * 2 + 1, vl);
+
+                    for (int i = 0; i < 32; i++) {
+                        const vint16m1_t vw_0 = __riscv_vmul_vv_i16m1(
+                            ggml_rvv_q5_K_weight_64(b_ptr[l].qs, b_ptr[l].qh, group, i, false, vl), vscale_0, vl);
+                        const vint16m1_t vw_1 = __riscv_vmul_vv_i16m1(
+                            ggml_rvv_q5_K_weight_64(b_ptr[l].qs, b_ptr[l].qh, group, i, true, vl), vscale_1, vl);
+                        const int q8_base = group * 256 + i * 4;
+
+                        sumi_0 = __riscv_vwmacc_vx_i32m2(sumi_0, (int16_t) a_ptr[l].qs[q8_base + 0], vw_0, vl);
+                        sumi_1 = __riscv_vwmacc_vx_i32m2(sumi_1, (int16_t) a_ptr[l].qs[q8_base + 1], vw_0, vl);
+                        sumi_2 = __riscv_vwmacc_vx_i32m2(sumi_2, (int16_t) a_ptr[l].qs[q8_base + 2], vw_0, vl);
+                        sumi_3 = __riscv_vwmacc_vx_i32m2(sumi_3, (int16_t) a_ptr[l].qs[q8_base + 3], vw_0, vl);
+
+                        sumi_0 = __riscv_vwmacc_vx_i32m2(sumi_0, (int16_t) a_ptr[l].qs[q8_base + 128 + 0], vw_1, vl);
+                        sumi_1 = __riscv_vwmacc_vx_i32m2(sumi_1, (int16_t) a_ptr[l].qs[q8_base + 128 + 1], vw_1, vl);
+                        sumi_2 = __riscv_vwmacc_vx_i32m2(sumi_2, (int16_t) a_ptr[l].qs[q8_base + 128 + 2], vw_1, vl);
+                        sumi_3 = __riscv_vwmacc_vx_i32m2(sumi_3, (int16_t) a_ptr[l].qs[q8_base + 128 + 3], vw_1, vl);
+                    }
+                }
+
+                const vfloat32m2_t b_d = __riscv_vfwcvt_f_f_v_f32m2(
+                    __riscv_vle16_v_f16m1((const _Float16 *) b_ptr[l].d, vl), vl);
+                const vfloat32m2_t d_0 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[0], vl);
+                const vfloat32m2_t d_1 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[1], vl);
+                const vfloat32m2_t d_2 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[2], vl);
+                const vfloat32m2_t d_3 = __riscv_vfmul_vf_f32m2(b_d, a_ptr[l].d[3], vl);
+
+                sumf_0 = __riscv_vfmacc_vv_f32m2(sumf_0, __riscv_vfcvt_f_x_v_f32m2(sumi_0, vl), d_0, vl);
+                sumf_1 = __riscv_vfmacc_vv_f32m2(sumf_1, __riscv_vfcvt_f_x_v_f32m2(sumi_1, vl), d_1, vl);
+                sumf_2 = __riscv_vfmacc_vv_f32m2(sumf_2, __riscv_vfcvt_f_x_v_f32m2(sumi_2, vl), d_2, vl);
+                sumf_3 = __riscv_vfmacc_vv_f32m2(sumf_3, __riscv_vfcvt_f_x_v_f32m2(sumi_3, vl), d_3, vl);
+
+                const vfloat32m2_t b_dmin = __riscv_vfwcvt_f_f_v_f32m2(
+                    __riscv_vle16_v_f16m1((const _Float16 *) b_ptr[l].dmin, vl), vl);
+                const vfloat32m2_t dmin_0 = __riscv_vfmul_vf_f32m2(b_dmin, a_ptr[l].d[0], vl);
+                const vfloat32m2_t dmin_1 = __riscv_vfmul_vf_f32m2(b_dmin, a_ptr[l].d[1], vl);
+                const vfloat32m2_t dmin_2 = __riscv_vfmul_vf_f32m2(b_dmin, a_ptr[l].d[2], vl);
+                const vfloat32m2_t dmin_3 = __riscv_vfmul_vf_f32m2(b_dmin, a_ptr[l].d[3], vl);
+
+                for (int sb = 0; sb < 8; sb++) {
+                    const vint16m1_t vmin = ggml_rvv_k_min_64(b_ptr[l].scales, sb, vl);
+                    const int base = sb * 8;
+                    const vint32m2_t vcorr_0 = __riscv_vwmul_vx_i32m2(vmin, a_ptr[l].bsums[base + 0] + a_ptr[l].bsums[base + 4], vl);
+                    const vint32m2_t vcorr_1 = __riscv_vwmul_vx_i32m2(vmin, a_ptr[l].bsums[base + 1] + a_ptr[l].bsums[base + 5], vl);
+                    const vint32m2_t vcorr_2 = __riscv_vwmul_vx_i32m2(vmin, a_ptr[l].bsums[base + 2] + a_ptr[l].bsums[base + 6], vl);
+                    const vint32m2_t vcorr_3 = __riscv_vwmul_vx_i32m2(vmin, a_ptr[l].bsums[base + 3] + a_ptr[l].bsums[base + 7], vl);
+
+                    sumf_0 = __riscv_vfsub_vv_f32m2(sumf_0, __riscv_vfmul_vv_f32m2(__riscv_vfcvt_f_x_v_f32m2(vcorr_0, vl), dmin_0, vl), vl);
+                    sumf_1 = __riscv_vfsub_vv_f32m2(sumf_1, __riscv_vfmul_vv_f32m2(__riscv_vfcvt_f_x_v_f32m2(vcorr_1, vl), dmin_1, vl), vl);
+                    sumf_2 = __riscv_vfsub_vv_f32m2(sumf_2, __riscv_vfmul_vv_f32m2(__riscv_vfcvt_f_x_v_f32m2(vcorr_2, vl), dmin_2, vl), vl);
+                    sumf_3 = __riscv_vfsub_vv_f32m2(sumf_3, __riscv_vfmul_vv_f32m2(__riscv_vfcvt_f_x_v_f32m2(vcorr_3, vl), dmin_3, vl), vl);
+                }
+            }
+
+            __riscv_vse32_v_f32m2(s + (row_tile + 0) * bs + col_tile, sumf_0, vl);
+            __riscv_vse32_v_f32m2(s + (row_tile + 1) * bs + col_tile, sumf_1, vl);
+            __riscv_vse32_v_f32m2(s + (row_tile + 2) * bs + col_tile, sumf_2, vl);
+            __riscv_vse32_v_f32m2(s + (row_tile + 3) * bs + col_tile, sumf_3, vl);
         }
     }
 }

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -24,6 +24,42 @@
 
 #define UNUSED GGML_UNUSED
 
+static bool ggml_repack_rvv_vlen1024_type(const struct ggml_tensor * cur, ggml_type type) {
+#if defined __riscv_zvfh
+    if (!cur || cur->type != type || !ggml_cpu_has_riscv_v()) {
+        return false;
+    }
+
+    return __riscv_vlenb() * 8 == 1024;
+#else
+    GGML_UNUSED(cur);
+    GGML_UNUSED(type);
+    return false;
+#endif
+}
+
+static int ggml_repack_q4_K_vlen1024_cols(const struct ggml_tensor * cur) {
+    if (!ggml_repack_rvv_vlen1024_type(cur, GGML_TYPE_Q4_K)) {
+        return 0;
+    }
+    if (cur->ne[1] % 64 == 0) {
+        return 64;
+    }
+
+    return 0;
+}
+
+static int ggml_repack_q5_K_vlen1024_cols(const struct ggml_tensor * cur) {
+    if (!ggml_repack_rvv_vlen1024_type(cur, GGML_TYPE_Q5_K)) {
+        return 0;
+    }
+    if (cur->ne[1] % 64 == 0) {
+        return 64;
+    }
+
+    return 0;
+}
+
 static inline int nearest_int(float fval) {
     assert(fabsf(fval) <= 4194303.f);
     float val = fval + 12582912.f;
@@ -2962,6 +2998,49 @@ static block_q4_Kx16 make_block_q4_Kx16(block_q4_K * in, unsigned int blck_size_
     return out;
 }
 
+static block_q4_Kx64 make_block_q4_Kx64(block_q4_K * in, unsigned int blck_size_interleave) {
+    block_q4_Kx64 out;
+    constexpr int N_COLS = 64;
+
+    GGML_ASSERT(blck_size_interleave == 1);
+
+    for (int i = 0; i < N_COLS; i++) {
+        out.d[i] = in[i].GGML_COMMON_AGGR_U.GGML_COMMON_AGGR_S.d;
+        out.dmin[i] = in[i].GGML_COMMON_AGGR_U.GGML_COMMON_AGGR_S.dmin;
+    }
+
+    for (int i = 0; i < QK_K / 2 * N_COLS; ++i) {
+        int src_id = i % N_COLS;
+        int src_offset = i / N_COLS;
+
+        out.qs[i] = in[src_id].qs[src_offset];
+    }
+
+    uint8_t s[8 * N_COLS], m[8 * N_COLS];
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < N_COLS; j++) {
+            s[i * N_COLS + j] = in[j].scales[i] & 63;
+            m[i * N_COLS + j] = in[j].scales[i + 4] & 63;
+        }
+    }
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < N_COLS; j++) {
+            s[4 * N_COLS + i * N_COLS + j] = ((in[j].scales[i] & 192) >> 2) | (in[j].scales[i + 8] & 15);
+            m[4 * N_COLS + i * N_COLS + j] = ((in[j].scales[i + 4] & 192) >> 2) | ((in[j].scales[i + 8] & 240) >> 4);
+        }
+    }
+
+    for (int i = 0; i < 8 * N_COLS; i++) {
+        out.scales[i] = (s[i] & 15) | ((m[i] & 15) << 4);
+    }
+    for (int i = 0; i < 4 * N_COLS; i++) {
+        out.scales[8 * N_COLS + i] =
+            ((s[i] & 48) >> 4) | ((m[i] & 48) >> 2) | (s[4 * N_COLS + i] & 48) | ((m[4 * N_COLS + i] & 48) << 2);
+    }
+
+    return out;
+}
+
 static block_q2_Kx8 make_block_q2_Kx8(block_q2_K * in, unsigned int blck_size_interleave) {
     block_q2_Kx8 out;
 
@@ -3084,6 +3163,54 @@ static block_q5_Kx8 make_block_q5_Kx8(block_q5_K * in, unsigned int blck_size_in
         out.scales[i * 12 + 57] = (s[5] & 15) + ((m[5] & 15) << 4);
         out.scales[i * 12 + 58] = (s[6] & 15) + ((m[6] & 15) << 4);
         out.scales[i * 12 + 59] = (s[7] & 15) + ((m[7] & 15) << 4);
+    }
+
+    return out;
+}
+
+static block_q5_Kx64 make_block_q5_Kx64(const block_q5_K * in, unsigned int blck_size_interleave) {
+    block_q5_Kx64 out;
+    constexpr int N_COLS = 64;
+
+    GGML_ASSERT(blck_size_interleave == 1);
+
+    for (int i = 0; i < N_COLS; i++) {
+        out.d[i] = in[i].GGML_COMMON_AGGR_U.GGML_COMMON_AGGR_S.d;
+        out.dmin[i] = in[i].GGML_COMMON_AGGR_U.GGML_COMMON_AGGR_S.dmin;
+    }
+
+    for (int i = 0; i < QK_K / 2 * N_COLS; ++i) {
+        const int src_id = i % N_COLS;
+        const int src_offset = i / N_COLS;
+        out.qs[i] = in[src_id].qs[src_offset];
+    }
+
+    for (int i = 0; i < QK_K / 8 * N_COLS; ++i) {
+        const int src_id = i % N_COLS;
+        const int src_offset = i / N_COLS;
+        out.qh[i] = in[src_id].qh[src_offset];
+    }
+
+    uint8_t s[8 * N_COLS], m[8 * N_COLS];
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < N_COLS; j++) {
+            s[i * N_COLS + j] = in[j].scales[i] & 63;
+            m[i * N_COLS + j] = in[j].scales[i + 4] & 63;
+        }
+    }
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < N_COLS; j++) {
+            s[4 * N_COLS + i * N_COLS + j] = ((in[j].scales[i] & 192) >> 2) | (in[j].scales[i + 8] & 15);
+            m[4 * N_COLS + i * N_COLS + j] = ((in[j].scales[i + 4] & 192) >> 2) | ((in[j].scales[i + 8] & 240) >> 4);
+        }
+    }
+
+    for (int i = 0; i < 8 * N_COLS; i++) {
+        out.scales[i] = (s[i] & 15) | ((m[i] & 15) << 4);
+    }
+    for (int i = 0; i < 4 * N_COLS; i++) {
+        out.scales[8 * N_COLS + i] =
+            ((s[i] & 48) >> 4) | ((m[i] & 48) >> 2) | (s[4 * N_COLS + i] & 48) | ((m[4 * N_COLS + i] & 48) << 2);
     }
 
     return out;
@@ -3289,6 +3416,34 @@ static int repack_q4_K_to_q4_K_16_bl(struct ggml_tensor * t, int interleave_bloc
     GGML_UNUSED(data_size);
 }
 
+static int repack_q4_K_to_q4_K_64_bl(struct ggml_tensor * t, int interleave_block, const void * GGML_RESTRICT data, size_t data_size) {
+    GGML_ASSERT(t->type == GGML_TYPE_Q4_K);
+    constexpr int nrows_interleaved = 64;
+
+    block_q4_Kx64 * dst = (block_q4_Kx64*)t->data;
+    const block_q4_K * src = (const block_q4_K*) data;
+    block_q4_K dst_tmp[nrows_interleaved];
+    int nrow = ggml_nrows(t);
+    int nblocks = t->ne[0] / QK_K;
+
+    GGML_ASSERT(data_size == nrow * nblocks * sizeof(block_q4_K));
+
+    if (t->ne[1] % nrows_interleaved != 0 || t->ne[0] % QK_K != 0) {
+        return -1;
+    }
+
+    for (int b = 0; b < nrow; b += nrows_interleaved) {
+        for (int64_t x = 0; x < nblocks; x++) {
+            for (int i  = 0; i < nrows_interleaved; i++ ) {
+                dst_tmp[i] = src[x + i * nblocks];
+            }
+            *dst++ = make_block_q4_Kx64(dst_tmp, interleave_block);
+        }
+        src += nrows_interleaved * nblocks;
+    }
+    return 0;
+}
+
 static int repack_q2_K_to_q2_K_8_bl(struct ggml_tensor * t, int interleave_block, const void * GGML_RESTRICT data, size_t data_size) {
     GGML_ASSERT(t->type == GGML_TYPE_Q2_K);
     GGML_ASSERT(interleave_block == 8);
@@ -3411,6 +3566,34 @@ static int repack_q5_K_to_q5_K_8_bl(struct ggml_tensor *       t,
                 dst_tmp[i] = src[x + i * nblocks];
             }
             *dst++ = make_block_q5_Kx8(dst_tmp, interleave_block);
+        }
+        src += nrows_interleaved * nblocks;
+    }
+    return 0;
+}
+
+static int repack_q5_K_to_q5_K_64_bl(struct ggml_tensor * t, int interleave_block, const void * GGML_RESTRICT data, size_t data_size) {
+    GGML_ASSERT(t->type == GGML_TYPE_Q5_K);
+    constexpr int nrows_interleaved = 64;
+
+    block_q5_Kx64 * dst = (block_q5_Kx64 *) t->data;
+    const block_q5_K * src = (const block_q5_K *) data;
+    block_q5_K dst_tmp[nrows_interleaved];
+    int nrow = ggml_nrows(t);
+    int nblocks = t->ne[0] / QK_K;
+
+    GGML_ASSERT(data_size == nrow * nblocks * sizeof(block_q5_K));
+
+    if (t->ne[1] % nrows_interleaved != 0 || t->ne[0] % QK_K != 0) {
+        return -1;
+    }
+
+    for (int b = 0; b < nrow; b += nrows_interleaved) {
+        for (int64_t x = 0; x < nblocks; x++) {
+            for (int i = 0; i < nrows_interleaved; i++) {
+                dst_tmp[i] = src[x + i * nblocks];
+            }
+            *dst++ = make_block_q5_Kx64(dst_tmp, interleave_block);
         }
         src += nrows_interleaved * nblocks;
     }
@@ -3943,6 +4126,14 @@ template <> int repack<block_q4_K, 1, 16>(struct ggml_tensor * t, const void * d
     return repack_q4_K_to_q4_K_16_bl(t, 1, data, data_size);
 }
 
+template <> int repack<block_q4_K, 1, 64>(struct ggml_tensor * t, const void * data, size_t data_size) {
+    return repack_q4_K_to_q4_K_64_bl(t, 1, data, data_size);
+}
+
+template <> int repack<block_q5_K, 1, 64>(struct ggml_tensor * t, const void * data, size_t data_size) {
+    return repack_q5_K_to_q5_K_64_bl(t, 1, data, data_size);
+}
+
 template <> int repack<block_iq4_nl, 1, 16>(struct ggml_tensor * t, const void * data, size_t data_size) {
     return repack_iq4_nl_to_iq4_nl_16_bl(t, 1, data, data_size);
 }
@@ -4038,6 +4229,14 @@ template <> void gemv<block_q4_0, 1, 16, GGML_TYPE_Q8_0>(int n, float * s, size_
 
 template <> void gemv<block_q4_K, 1, 16, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
     ggml_gemv_q4_K_16x1_q8_K(n, s, bs, vx, vy, nr, nc);
+}
+
+template <> void gemv<block_q4_K, 1, 64, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemv_q4_K_64x1_q8_K(n, s, bs, vx, vy, nr, nc);
+}
+
+template <> void gemv<block_q5_K, 1, 64, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemv_q5_K_64x1_q8_K(n, s, bs, vx, vy, nr, nc);
 }
 
 template <> void gemv<block_iq4_nl, 1, 16, GGML_TYPE_Q8_0>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
@@ -4137,6 +4336,14 @@ template <> void gemm<block_q4_K, 1, 16, GGML_TYPE_Q8_K>(int n, float * s, size_
     ggml_gemm_q4_K_16x1_q8_K(n, s, bs, vx, vy, nr, nc);
 }
 
+template <> void gemm<block_q4_K, 1, 64, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemm_q4_K_64x1_q8_K(n, s, bs, vx, vy, nr, nc);
+}
+
+template <> void gemm<block_q5_K, 1, 64, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemm_q5_K_64x1_q8_K(n, s, bs, vx, vy, nr, nc);
+}
+
 template <> void gemm<block_iq4_nl, 1, 16, GGML_TYPE_Q8_0>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
     ggml_gemm_iq4_nl_16x1_q8_0(n, s, bs, vx, vy, nr, nc);
 }
@@ -4156,7 +4363,6 @@ class tensor_traits_base : public ggml::cpu::tensor_traits {
 };
 
 template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PARAM_TYPE> class tensor_traits : public tensor_traits_base {
-
     bool work_size(int /* n_threads */, const struct ggml_tensor * op, size_t & size) override {
         // not realy a GGML_TYPE_Q8_0 but same size.
         switch (op->op) {
@@ -4565,6 +4771,8 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
 #if defined __riscv_zvfh
     static const ggml::cpu::repack::tensor_traits<block_q4_0, 1, 16, GGML_TYPE_Q8_0> q4_0_16x1_q8_0;
     static const ggml::cpu::repack::tensor_traits<block_q4_K, 1, 16, GGML_TYPE_Q8_K> q4_K_16x1_q8_K;
+    static const ggml::cpu::repack::tensor_traits<block_q4_K, 1, 64, GGML_TYPE_Q8_K> q4_K_64x1_q8_K;
+    static const ggml::cpu::repack::tensor_traits<block_q5_K, 1, 64, GGML_TYPE_Q8_K> q5_K_64x1_q8_K;
     static const ggml::cpu::repack::tensor_traits<block_iq4_nl, 1, 16, GGML_TYPE_Q8_0> iq4_nl_16x1_q8_0;
     static const ggml::cpu::repack::tensor_traits<block_q8_0, 1, 16, GGML_TYPE_Q8_0> q8_0_16x1_q8_0;
     static const ggml::cpu::repack::tensor_traits<block_q2_K, 1, 16, GGML_TYPE_Q8_K> q2_K_16x1_q8_K;
@@ -4615,11 +4823,14 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
         }
         if (ggml_cpu_has_riscv_v()) {
             #if defined __riscv_zvfh
+            switch (ggml_repack_q4_K_vlen1024_cols(cur)) {
+                case 64: { return &q4_K_64x1_q8_K; }
+                default: { break; }
+            }
             switch (__riscv_vlenb() * 8) {
                 case 128:  { break; } // TODO
                 case 256:  { if (cur->ne[1] % 16 == 0) { return &q4_K_16x1_q8_K; } break; }
                 case 512:  { break; } // TODO
-                case 1024: { break; } // TODO
                 default:   { return nullptr; }
             }
             #endif
@@ -4642,6 +4853,14 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
             #endif
         }
     } else if (cur->type == GGML_TYPE_Q5_K) {
+        if (ggml_cpu_has_riscv_v()) {
+            #if defined __riscv_zvfh
+            switch (ggml_repack_q5_K_vlen1024_cols(cur)) {
+                case 64: { return &q5_K_64x1_q8_K; }
+                default: { break; }
+            }
+            #endif
+        }
         if (ggml_cpu_has_neon() && ggml_cpu_has_matmul_int8()) {
             if (cur->ne[1] % 8 == 0) {
                 return &q5_K_8x8_q8_K;

--- a/ggml/src/ggml-cpu/repack.h
+++ b/ggml/src/ggml-cpu/repack.h
@@ -56,6 +56,15 @@ struct block_q4_Kx16 {
 };
 
 static_assert(sizeof(block_q4_Kx16) == sizeof(ggml_half) * 32 + K_SCALE_SIZE * 16 + QK_K * 8, "wrong q4_K block size/padding");
+
+struct block_q4_Kx64 {
+    ggml_half d[64];
+    ggml_half dmin[64];
+    uint8_t scales[K_SCALE_SIZE * 64];
+    uint8_t qs[QK_K / 2 * 64];
+};
+
+static_assert(sizeof(block_q4_Kx64) == sizeof(block_q4_K) * 64, "wrong q4_Kx64 block size/padding");
 struct block_q2_Kx8 {
     ggml_half d[8];      // super-block scale for quantized scales
     ggml_half dmin[8];   // super-block scale for quantized mins
@@ -82,6 +91,16 @@ struct block_q5_Kx8 {
 
 static_assert(sizeof(block_q5_Kx8) == sizeof(ggml_half) * 16 + K_SCALE_SIZE * 8 + QK_K * 5,
               "wrong q5_K block size/padding");
+
+struct block_q5_Kx64 {
+    ggml_half d[64];
+    ggml_half dmin[64];
+    uint8_t   scales[K_SCALE_SIZE * 64];
+    uint8_t   qh[QK_K / 8 * 64];
+    uint8_t   qs[QK_K / 2 * 64];
+};
+
+static_assert(sizeof(block_q5_Kx64) == sizeof(block_q5_K) * 64, "wrong q5_Kx64 block size/padding");
 
 struct block_q6_Kx8 {
     ggml_half d[8];
@@ -178,11 +197,15 @@ void ggml_quantize_mat_q8_0_4x1(const float * GGML_RESTRICT x, void * GGML_RESTR
 void ggml_quantize_mat_q8_K_4x1(const float * GGML_RESTRICT x, void * GGML_RESTRICT vy, int64_t k);
 void ggml_gemv_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemv_q4_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemv_q5_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q2_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q4_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q4_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemm_q4_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemm_q5_K_64x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_iq4_nl_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q8_0_16x1_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q2_K_16x1_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);


### PR DESCRIPTION
## Overview

Adds a Q4_K/Q5_K repack layout and VLEN1024 dispatch path. It takes effect only when a register width of VLEN=1024 bit is detected and the tensor's row count is divisible by 64; tensors that do not meet the shape requirements fall back to their original paths. All RVV intrinsics are located in riscv/repack.cpp. Tested on a SpacemiT K3 A100 core (VLEN=1024 bit) without enabling the SpacemiT-specific backend. Perplexity/accuracy regression results and speedups are shown below:
 kernel-original vs kernel-after
| type | n | avg speedup | nmse |
|------|---|------------:|-----:|
| q4_K | 1 | ~37.8x | 1.06e-14 |
| q4_K | 4 | ~17.4x | 1.49e-14 |
| q5_K | 1 | ~23.7x | 3.64e-14 |
| q5_K | 4 | ~30.4x | 6.93e-14 |

Specific test model：Model: tinyllama-1.1b-chat-v0.3.Q3_K_M, CPU, 8 threads, b/ub=128, ngl=0, fa=on, mmap=0: 
llama-bench：build-original vs build-after

| build | pp128 (t/s) | tg64 (t/s) |
|-------|------------:|-----------:|
| original | 4.73 ± 0.20 | 3.84 ± 0.00 |
| a100 | 12.04 ± 0.01 | 9.04 ± 0.04 |
| speedup | ~2.55x | ~2.35x |

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

`RVV_VLEN = 128` in system_info is expected: it prints raw `__riscv_vlenb()` in bytes, while dispatch compares in bits (`__riscv_vlenb() * 8`). 128 bytes = 1024 bits, so `VLEN == 1024` holds on the A100 core.
`REPACK=1` only indicates compile-time support and stays `1` even when `--no-repack` disables it at runtime.The repack path is verified to actually run (not just compiled in): perplexity is ~47.2 s/pass with repack vs ~111.6 s/pass with `--no-repack`.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->

YES - I used Codex to help write a standalone microbenchmark harness for Q4_K/Q5_K performance and correctness and to review my code and suggest improvements.