### PR TITLE
ggml : add aarch64 HWCAP fallbacks and fix fp16 variant detection

### DIFF
--- a/ggml/src/ggml-cpu/arch/arm/cpu-feats.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/cpu-feats.cpp
@@ -8,6 +8,22 @@
 #include <sys/sysctl.h>
 #endif
 
+#if !defined(HWCAP_FPHP)
+#define HWCAP_FPHP (1 << 9)
+#endif
+
+#if !defined(HWCAP_ASIMDHP)
+#define HWCAP_ASIMDHP (1 << 10)
+#endif
+
+#if !defined(HWCAP_ASIMDDP)
+#define HWCAP_ASIMDDP (1 << 20)
+#endif
+
+#if !defined(HWCAP_SVE)
+#define HWCAP_SVE (1 << 22)
+#endif
+
 #if !defined(HWCAP2_SVE2)
 #define HWCAP2_SVE2 (1 << 1)
 #endif

--- a/ggml/src/ggml-cpu/arch/arm/cpu-feats.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/cpu-feats.cpp
@@ -39,7 +39,7 @@
 struct aarch64_features {
     // has_neon not needed, aarch64 has NEON guaranteed
     bool has_dotprod     = false;
-    bool has_fp16_va     = false;
+    bool has_fp16        = false;
     bool has_sve         = false;
     bool has_sve2        = false;
     bool has_i8mm        = false;
@@ -52,7 +52,7 @@ struct aarch64_features {
         uint32_t hwcap2 = getauxval(AT_HWCAP2);
 
         has_dotprod = !!(hwcap & HWCAP_ASIMDDP);
-        has_fp16_va = !!(hwcap & HWCAP_FPHP);
+        has_fp16    = !!(hwcap & HWCAP_FPHP) && !!(hwcap & HWCAP_ASIMDHP);
         has_sve     = !!(hwcap & HWCAP_SVE);
         has_sve2    = !!(hwcap2 & HWCAP2_SVE2);
         has_i8mm    = !!(hwcap2 & HWCAP2_I8MM);
@@ -91,7 +91,7 @@ static int ggml_backend_cpu_aarch64_score() {
     score += 1<<1;
 #endif
 #ifdef GGML_USE_FP16_VECTOR_ARITHMETIC
-    if (!af.has_fp16_va) { return 0; }
+    if (!af.has_fp16) { return 0; }
     score += 1<<2;
 #endif
 #ifdef GGML_USE_SVE


### PR DESCRIPTION
## Overview

Add more HWCAP macro fallback defines such that compilation targeting glibc 2.17 on linux aarch64 works. Also in the `aarch64_features` struct rename `has_fp16_va` to `has_fp16` and make it also check for `HWCAP_ASIMDHP` instead of only `HWCAP_FPHP` because the arch tag `+fp16` implies both those HWCAPs.

## Additional information

Despite glibc 2.17 being very old (that version was released in 2012) it's still kinda relevant in some environments and for example the conda ecosystem still uses glibc 2.17 as a target baseline by default, see https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-glibc-versions and since my goal is to bring the dynamic loading of CPU backends to the conda packages of llama.cpp I'd like to make this compile in the default conda build environment which uses glibc 2.17

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. I was trying to make https://github.com/conda-forge/llama.cpp-feedstock compile with `GGML_BACKEND_DL` and `GGML_CPU_ALL_VARIANTS` and used AI to help me find the root cause for why it doesn't compile and suggest a way to fix it. I also asked it to provide sources so I could read up on this topic because I'm not very deep into low-level topics like this but I wanted to ensure that I completely understand the problem and how to fix it.