### PR TITLE
readme : add nika to infrastructure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - [llmaz](https://github.com/InftyAI/llmaz) - ☸️ Easy, advanced inference platform for large language models on Kubernetes.
 - [LLMKube](https://github.com/defilantech/llmkube) - Kubernetes operator for llama.cpp with multi-GPU and Apple Silicon Metal
   support"
+- [Nika](https://github.com/supernovae-st/nika) - workflow engine for AI that drives `llama-server` as a local provider: `.nika.yaml` DAGs statically checked before execution (schema, permits, cost), tamper-evident traces after (AGPL)
 </details>
 
 <details>


### PR DESCRIPTION
## Overview

Adds one line to the **Infrastructure** list (after LLMKube): [Nika](https://github.com/supernovae-st/nika), an open-source (AGPL, Rust) workflow engine that drives `llama-server` as a local provider — same consumer-on-top-of-`llama-server` class as llama-swap in this section.

The claim is verifiable against the shipped binary: `llamacpp` is one of its five local providers (`nika doctor` → `local 5 provider(s) (ollama · lmstudio · llamacpp · localai · vllm)`); workflows address models as `llamacpp/<model>` and run fully offline.

## Additional information

Precedent: llama-swap (#11032) and LLMKube (#20212) were both added to this section by their authors. Disclosure: I am the Nika author (first-party submission).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — this README line and PR text were drafted with an AI agent operating under my direction; I reviewed every word and I am responsible for the submission. No code is touched (data-only README entry).
