### PR TITLE
ggml : fix SUM for non-contiguous tensors

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -1292,7 +1292,6 @@ static void ggml_compute_forward_sum_f32(
     }
 
     assert(ggml_is_scalar(dst));
-    assert(src0->nb[0] == sizeof(float));
 
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
     GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
@@ -1303,10 +1302,16 @@ static void ggml_compute_forward_sum_f32(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
-                ggml_vec_sum_f32_ggf(ne00,
-                        &row_sum,
-                        (float *) ((char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03));
-                sum += row_sum;
+                const char * row = (const char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03;
+                if (nb00 == sizeof(float)) {
+                    ggml_vec_sum_f32_ggf(ne00, &row_sum, (const float *) row);
+                    sum += row_sum;
+                } else {
+                    // src rows are not contiguous, e.g. permuted views
+                    for (int64_t i00 = 0; i00 < ne00; i00++) {
+                        sum += *(const float *) (row + i00*nb00);
+                    }
+                }
             }
         }
     }
@@ -1325,8 +1330,6 @@ static void ggml_compute_forward_sum_f16(
 
     assert(ggml_is_scalar(dst));
 
-    assert(src0->nb[0] == sizeof(ggml_fp16_t));
-
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
     GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
 
@@ -1336,10 +1339,16 @@ static void ggml_compute_forward_sum_f16(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
-                ggml_vec_sum_f16_ggf(ne00,
-                    &row_sum,
-                    (ggml_fp16_t *) ((char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
-                sum += row_sum;
+                const char * row = (const char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03;
+                if (nb00 == sizeof(ggml_fp16_t)) {
+                    ggml_vec_sum_f16_ggf(ne00, &row_sum, (const ggml_fp16_t *) row);
+                    sum += row_sum;
+                } else {
+                    // src rows are not contiguous, e.g. permuted views
+                    for (int64_t i00 = 0; i00 < ne00; i00++) {
+                        sum += GGML_CPU_FP16_TO_FP32(*(const ggml_fp16_t *) (row + i00 * nb00));
+                    }
+                }
             }
         }
     }
@@ -1358,8 +1367,6 @@ static void ggml_compute_forward_sum_bf16(
 
     assert(ggml_is_scalar(dst));
 
-    assert(src0->nb[0] == sizeof(ggml_bf16_t));
-
     GGML_TENSOR_LOCALS(int64_t, ne0, src0, ne)
     GGML_TENSOR_LOCALS(size_t,  nb0, src0, nb)
 
@@ -1369,10 +1376,16 @@ static void ggml_compute_forward_sum_bf16(
     for (int64_t i03 = 0; i03 < ne03; i03++) {
         for (int64_t i02 = 0; i02 < ne02; i02++) {
             for (int64_t i01 = 0; i01 < ne01; i01++) {
-                ggml_vec_sum_bf16_ggf(ne00,
-                    &row_sum,
-                    (ggml_bf16_t *) ((char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03));
-                sum += row_sum;
+                const char * row = (const char *) src0->data + i01 * nb01 + i02 * nb02 + i03 * nb03;
+                if (nb00 == sizeof(ggml_bf16_t)) {
+                    ggml_vec_sum_bf16_ggf(ne00, &row_sum, (const ggml_bf16_t *) row);
+                    sum += row_sum;
+                } else {
+                    // src rows are not contiguous, e.g. permuted views
+                    for (int64_t i00 = 0; i00 < ne00; i00++) {
+                        sum += GGML_BF16_TO_FP32(*(const ggml_bf16_t *) (row + i00 * nb00));
+                    }
+                }
             }
         }
     }

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -1308,8 +1308,8 @@ static void ggml_compute_forward_sum_f32(
                     sum += row_sum;
                 } else {
                     // src rows are not contiguous, e.g. permuted views
-                    for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        sum += *(const float *) (row + i00*nb00);
+                    for (const char * p = row; p < row + ne00*nb00; p += nb00) {
+                        sum += *(const float *) p;
                     }
                 }
             }
@@ -1345,8 +1345,8 @@ static void ggml_compute_forward_sum_f16(
                     sum += row_sum;
                 } else {
                     // src rows are not contiguous, e.g. permuted views
-                    for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        sum += GGML_CPU_FP16_TO_FP32(*(const ggml_fp16_t *) (row + i00 * nb00));
+                    for (const char * p = row; p < row + ne00*nb00; p += nb00) {
+                        sum += GGML_CPU_FP16_TO_FP32(*(const ggml_fp16_t *) p);
                     }
                 }
             }
@@ -1382,8 +1382,8 @@ static void ggml_compute_forward_sum_bf16(
                     sum += row_sum;
                 } else {
                     // src rows are not contiguous, e.g. permuted views
-                    for (int64_t i00 = 0; i00 < ne00; i00++) {
-                        sum += GGML_BF16_TO_FP32(*(const ggml_bf16_t *) (row + i00 * nb00));
+                    for (const char * p = row; p < row + ne00*nb00; p += nb00) {
+                        sum += GGML_BF16_TO_FP32(*(const ggml_bf16_t *) p);
                     }
                 }
             }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4928,7 +4928,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             //return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]);
             return ggml_is_contiguous(op->src[0]) && ggml_is_contiguous(op->src[1]);
         case GGML_OP_SUM:
-            return ggml_is_contiguous_rows(op->src[0]);
+            return op->src[0]->type == GGML_TYPE_F32 && ggml_is_contiguously_allocated(op->src[0]);
         case GGML_OP_TOP_K:
         case GGML_OP_ARGSORT:
 #ifndef GGML_CUDA_USE_CUB

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5243,7 +5243,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             //return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]);
             return ggml_is_contiguous(op->src[0]) && ggml_is_contiguous(op->src[1]);
         case GGML_OP_SUM:
-            return ggml_is_contiguous_rows(op->src[0]);
+            return op->src[0]->type == GGML_TYPE_F32 && ggml_is_contiguously_allocated(op->src[0]);
         case GGML_OP_TOP_K:
         case GGML_OP_ARGSORT:
 #ifndef GGML_CUDA_USE_CUB

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9165,6 +9165,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 1024, 1, 1 }));
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 256, 1, 1 }));
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 256, 1, 1 }, { 1, 0, 2, 3 })); // sum dst not-contiguous
+    test_cases.emplace_back(new test_sum(GGML_TYPE_F16, { 33, 256, 1, 1 }, { 1, 0, 2, 3 }));
+    test_cases.emplace_back(new test_sum(GGML_TYPE_BF16, { 33, 256, 1, 1 }, { 1, 0, 2, 3 }));
     test_cases.emplace_back(new test_sum_rows());
     test_cases.emplace_back(new test_sum_rows(GGML_TYPE_F32, { 11, 5, 6, 3 }, true, false));
     test_cases.emplace_back(new test_sum_rows(GGML_TYPE_F32, { 11, 5, 6, 3 }, false, true));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9681,6 +9681,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 1024, 1, 1 }));
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 256, 1, 1 }));
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 256, 1, 1 }, { 1, 0, 2, 3 })); // sum dst not-contiguous
+    test_cases.emplace_back(new test_sum(GGML_TYPE_F16, { 33, 256, 1, 1 }, { 1, 0, 2, 3 }));
+    test_cases.emplace_back(new test_sum(GGML_TYPE_BF16, { 33, 256, 1, 1 }, { 1, 0, 2, 3 }));
     test_cases.emplace_back(new test_sum_rows());
     test_cases.emplace_back(new test_sum_rows(GGML_TYPE_F32, { 11, 5, 6, 3 }, true, false));
     test_cases.emplace_back(new test_sum_rows(GGML_TYPE_F32, { 11, 5, 6, 3 }, false, true));


### PR DESCRIPTION
## Overview

Fixes #25568.

This PR fixes incorrect results and backend failures for `SUM` on non-contiguous tensors across the CPU implementation, CUDA capability checks, and backend tests.

The CPU implementations of `ggml_compute_forward_sum_f32`, `_f16`, and `_bf16` previously assumed `nb[0] == type_size`, causing silently incorrect results for permuted views in release builds. The existing fast path is preserved, while a stride-aware path is now used for non-contiguous inputs.

CUDA `supports_op` previously accepted layouts and types that the kernel would reject with an assertion. Its checks now match the kernel requirements: `GGML_TYPE_F32` and `ggml_is_contiguously_allocated`.

As a result, permuted dense inputs now execute correctly on CUDA, while unsupported strided or non-F32 inputs correctly fall back instead of aborting.

The existing permuted `SUM` case now executes and passes, with additional permuted F16 and BF16 test cases added.

## Additional information

Validation results:

```text
test-backend-ops test -o SUM -b CUDA0 : 8/8 passed (the previously-skipped permuted case now executes and passes)
test-backend-ops test -b CUDA0        : 12989/12989 passed
test-backend-ops grad -o SUM -b CUDA0 : 16929/16929 passed
ground truth (33x256 permuted view, double-precision reference = 101277.000):
  CPU   : 101277.000 (was 100608.750 before the fix)
  CUDA0 : 101277.000 (was not supported before the fix)
Environment: Windows 11, RTX 5070 (sm_120), CUDA 13.3, MSVC 19.50
```

Contiguous F16 and BF16 cases were not added because Metal and SYCL currently lack matching type checks in `supports_op`, despite their implementations only supporting F32. Addressing those backend-specific capability checks is outside the scope of this PR.

The CPU path for `nb[0] == type_size` remains unchanged, with the full `12989/12989` backend test run showing no regressions.

The full analysis, minimal reproductions, and backend capability-check comparison are available in #25568.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
  - AI assisted with the investigation, reproduction programs, and initial implementation of the fix.
  - I reviewed and understood every changed line and personally reran all validation listed above.
  - I understand that I am fully responsible for all changes submitted in this PR.
