### PR TITLE
ci : add ubuntu CUDA 13 release binaries (x64/arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,126 @@ jobs:
           path: llama-${{ steps.tag.outputs.name }}-bin-ubuntu-vulkan-${{ matrix.build }}.tar.gz
           name: llama-bin-ubuntu-vulkan-${{ matrix.build }}.tar.gz
 
+  ubuntu-cuda:
+    needs: [check-release, get-version]
+    if: ${{ needs.check-release.outputs.should_release == 'true' }}
+
+    strategy:
+      matrix:
+        include:
+          - build: 'x64'
+            os: ubuntu-24.04
+            cuda_distro: 'ubuntu2404'
+            cuda_repo_arch: 'x86_64'
+          - build: 'arm64'
+            os: ubuntu-24.04-arm
+            cuda_distro: 'ubuntu2404'
+            cuda_repo_arch: 'sbsa'
+
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      actions: write
+
+    env:
+      # Sync with .github/actions/windows-setup-cuda
+      CUDA_VERSION: '13.3'
+      CUDA_VERSION_DASH: '13-3'
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: "tools/ui/package-lock.json"
+
+      - name: Free up disk space
+        uses: ggml-org/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+
+      - name: Install Cuda Toolkit
+        run: |
+          wget https://developer.download.nvidia.com/compute/cuda/repos/${{ matrix.cuda_distro }}/${{ matrix.cuda_repo_arch }}/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update
+          sudo apt-get install -y build-essential cuda-toolkit-${{ env.CUDA_VERSION_DASH }} libssl-dev
+          echo "CUDA_PATH=/usr/local/cuda-${{ env.CUDA_VERSION }}" >> $GITHUB_ENV
+          echo "/usr/local/cuda-${{ env.CUDA_VERSION }}/bin" >> $GITHUB_PATH
+
+      - name: Toolchain workaround (GCC 14)
+        if: ${{ contains(matrix.os, 'ubuntu-24.04') }}
+        run: |
+          sudo apt-get install -y gcc-14 g++-14
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: release-ubuntu-cuda-${{ matrix.build }}-${{ env.CUDA_VERSION }}
+
+      - name: Build
+        id: cmake_build
+        # TODO: Remove GGML_CUDA_CUB_3DOT2 flag once CCCL 3.2 is bundled within CTK and that CTK version is used in this project
+        run: |
+          cmake -B build \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_CUDA=ON \
+            -DGGML_CUDA_CUB_3DOT2=ON \
+            -DLLAMA_FATAL_WARNINGS=ON \
+            -DHF_UI_VERSION=${{ needs.get-version.outputs.ui_version }} \
+            ${{ env.CMAKE_ARGS }}
+          cmake --build build --config Release -j $(nproc)
+
+      - name: ccache-clear
+        uses: ./.github/actions/ccache-clear
+        with:
+          key: release-ubuntu-cuda-${{ matrix.build }}-${{ env.CUDA_VERSION }}
+
+      - name: Determine tag name
+        id: tag
+        uses: ./.github/actions/get-tag-name
+
+      - name: Pack artifacts
+        id: pack_artifacts
+        run: |
+          cp LICENSE ./build/bin/
+          tar -czvf llama-${{ steps.tag.outputs.name }}-bin-ubuntu-cuda-${{ env.CUDA_VERSION }}-${{ matrix.build }}.tar.gz --transform "s,^\.,llama-${{ steps.tag.outputs.name }}," -C ./build/bin .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          path: llama-${{ steps.tag.outputs.name }}-bin-ubuntu-cuda-${{ env.CUDA_VERSION }}-${{ matrix.build }}.tar.gz
+          name: llama-bin-ubuntu-cuda-${{ env.CUDA_VERSION }}-${{ matrix.build }}.tar.gz
+
+      - name: Copy and pack Cuda runtime
+        run: |
+          echo "Cuda install location: ${{ env.CUDA_PATH }}"
+          dst=./build/bin/cudart
+          mkdir -p "$dst"
+          cp -P ${{ env.CUDA_PATH }}/targets/*/lib/libcudart.so* "$dst"/
+          cp -P ${{ env.CUDA_PATH }}/targets/*/lib/libcublas.so* "$dst"/
+          cp -P ${{ env.CUDA_PATH }}/targets/*/lib/libcublasLt.so* "$dst"/
+          tar -czvf cudart-llama-bin-ubuntu-cuda-${{ env.CUDA_VERSION }}-${{ matrix.build }}.tar.gz -C "$dst" .
+
+      - name: Upload Cuda runtime
+        uses: actions/upload-artifact@v6
+        with:
+          path: cudart-llama-bin-ubuntu-cuda-${{ env.CUDA_VERSION }}-${{ matrix.build }}.tar.gz
+          name: cudart-llama-bin-ubuntu-cuda-${{ env.CUDA_VERSION }}-${{ matrix.build }}.tar.gz
+
   android-arm64:
     needs: [check-release, get-version]
     if: ${{ needs.check-release.outputs.should_release == 'true' }}
@@ -1559,6 +1679,7 @@ jobs:
       - ubuntu-22-rocm
       - ubuntu-cpu
       - ubuntu-vulkan
+      - ubuntu-cuda
       - ubuntu-24-openvino
       #- ubuntu-24-sycl
       - android-arm64
@@ -1663,6 +1784,8 @@ jobs:
             - [Ubuntu s390x (CPU)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-s390x.tar.gz)
             - [Ubuntu x64 (Vulkan)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-vulkan-x64.tar.gz)
             - [Ubuntu arm64 (Vulkan)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-vulkan-arm64.tar.gz)
+            - [Ubuntu x64 (CUDA 13)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-cuda-13.3-x64.tar.gz) - [CUDA 13.3 runtime libs](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/cudart-llama-bin-ubuntu-cuda-13.3-x64.tar.gz)
+            - [Ubuntu arm64 (CUDA 13)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-cuda-13.3-arm64.tar.gz) - [CUDA 13.3 runtime libs](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/cudart-llama-bin-ubuntu-cuda-13.3-arm64.tar.gz)
             - [Ubuntu x64 (ROCm 7.2)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-rocm-7.2-x64.tar.gz)
             - [Ubuntu x64 (OpenVINO)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-openvino-${{ needs.ubuntu-24-openvino.outputs.openvino_version }}-x64.tar.gz)
             - [Ubuntu x64 (SYCL FP32)](https://github.com/ggml-org/llama.cpp/releases/download/${{ steps.tag.outputs.name }}/llama-${{ steps.tag.outputs.name }}-bin-ubuntu-sycl-fp32-x64.tar.gz)


### PR DESCRIPTION
## Overview

Currently .devops/cuda.Dockerfile provides a CUDA-enabled Docker image, but there are no native Linux release binaries with CUDA support on the GitHub releases page (only Windows ships prebuilt CUDA binaries).

Add a new "ubuntu-cuda" release job that builds llama.cpp with CUDA 13.3 for both x64 (ubuntu-24.04) and arm64 (ubuntu-24.04-arm, using NVIDIA's linux-sbsa toolkit), installing the toolkit from NVIDIA's official apt network repository.

Mirror the packaging technique already used by the windows-cuda job: ship the built binaries (with the CUDA backend as a DL-loaded plugin) in the main tarball, and separately package the CUDA runtime shared libraries (libcudart, libcublas, libcublasLt) into a "cudart-*" tarball so that users without the full CUDA toolkit installed can still run the CUDA backend by just dropping those libraries alongside the binary.

Wire the new job into the release job's needs list and add the corresponding download links to the generated release notes.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: figuring out github yaml
