### PR TITLE
ggml-cuda: use argsort for small multi-row top-k

### DIFF
--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -36,7 +36,9 @@ static void top_k_cub(ggml_cuda_pool & pool,
                          ncols, k, env));
 }
 
-#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+#endif  // CUB_TOP_K_AVAILABLE
+
+#ifdef GGML_CUDA_USE_CUB
 
 static int next_power_of_2(int x) {
     int n = 1;
@@ -46,7 +48,7 @@ static int next_power_of_2(int x) {
     return n;
 }
 
-#endif                            // CUB_TOP_K_AVAILABLE
+#endif  // GGML_CUDA_USE_CUB
 
 void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0   = dst->src[0];
@@ -66,11 +68,16 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 #ifdef CUB_TOP_K_AVAILABLE
     // TODO: Switch to `DeviceSegmentedTopK` for multi-row TopK once implemented
     // https://github.com/NVIDIA/cccl/issues/6391
-    // TODO: investigate if there exists a point where parallelized argsort is faster than sequential top-k
-    for (int i = 0; i < nrows; i++) {
-        top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+    const bool use_argsort = nrows > 1 && ncols <= 4096;
+    if (!use_argsort) {
+        for (int i = 0; i < nrows; i++) {
+            top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+        }
+        return;
     }
-#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+#endif  // CUB_TOP_K_AVAILABLE
+
+#if defined(GGML_CUDA_USE_CUB)
     // Fall back to argsort + copy
     const int    ncols_pad      = next_power_of_2(ncols);
     const size_t shared_mem     = ncols_pad * sizeof(int);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9949,11 +9949,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_argsort(GGML_TYPE_F32, {200000, 16, 1, 1}));
 
     test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {2, 1, 1, 1}, 1));
-    for (auto k : {1, 10, 40, 400}) {
-        for (auto nrows : {1, 2, 4, 8, 16}) {
-            for (auto cols : {k, 1000, 4096, 8192, 16384, 32768, 65000, 200000}) {
-                test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {cols, nrows, 1, 1}, k));
-            }
+    for (int nrows : {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096}) {
+        for (int ncols : {4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65000, 200000}) {
+            const int k = std::max(1, std::min(nrows, ncols) / 2);
+            test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {ncols, nrows, 1, 1}, k));
         }
     }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9950,8 +9950,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
 
     test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {2, 1, 1, 1}, 1));
     for (auto k : {1, 10, 40, 400}) {
-        for (auto nrows : {1, 16}) {
-            for (auto cols : {k, 1000, 65000, 200000}) {
+        for (auto nrows : {1, 2, 4, 8, 16}) {
+            for (auto cols : {k, 1000, 4096, 8192, 16384, 32768, 65000, 200000}) {
                 test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {cols, nrows, 1, 1}, k));
             }
         }


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Update ggml/src/ggml-cuda/top-k.cu to now use a heuristic when CUB DeviceTopK is available:

```cpp
const bool use_argsort = nrows > 1 && ncols <= 4096;
```
CUB DeviceTopK is currently invoked once per row. Benchmarking showed that, for small column counts and multiple rows, this per-row overhead can make it slower than the existing argsort implementation. For nrows = {2, 4, 8, 16}, argsort seems to outperform DeviceTopK at ncols = 4096. However, DeviceTopK generally was better from ncols=8192 and onwards, especially for larger columns counts. The 4096 threshold is therefore used as a simple conservative number that improves the consistently faster cases without attempting to model every shape-specific crossover.

Benchmarked with: 
```sh
./<cuda-build-dir>/bin/test-backend-ops perf -b CUDA0 -o TOP_K --output sql
```

| nrows | ncols | k | DeviceTopK (us) | argsort (us) | Faster |
|------:|------:|--:|----------------:|-------------:|:--------|
| 2 | 4096  | 1   | 29.68 | 23.61 | argsort |
| 2 | 4096  | 10  | 29.72 | 23.66 | argsort |
| 2 | 4096  | 40  | 30.15 | 23.58 | argsort |
| 2 | 4096  | 400 | 30.98 | 23.54 | argsort |
| 2 | 8192  | 1   | 29.38 | 86.10 | DeviceTopK |
| 2 | 8192  | 10  | 29.57 | 86.24 | DeviceTopK |
| 2 | 8192  | 40  | 30.00 | 86.13 | DeviceTopK |
| 2 | 8192  | 400 | 30.53 | 86.15 | DeviceTopK |
| 4 | 4096  | 1   | 59.57 | 23.94 | argsort |
| 4 | 4096  | 10  | 59.79 | 23.96 | argsort |
| 4 | 4096  | 40  | 60.91 | 23.94 | argsort |
| 4 | 4096  | 400 | 61.98 | 23.93 | argsort |
| 4 | 8192  | 1   | 58.40 | 86.53 | DeviceTopK |
| 4 | 8192  | 10  | 58.53 | 86.51 | DeviceTopK |
| 4 | 8192  | 40  | 59.60 | 86.52 | DeviceTopK |
| 4 | 8192  | 400 | 61.12 | 86.52 | DeviceTopK |
| 8 | 4096  | 1   | 118.66 | 27.58 | argsort |
| 8 | 4096  | 10  | 119.15 | 27.58 | argsort |
| 8 | 4096  | 40  | 120.95 | 27.61 | argsort |
| 8 | 4096  | 400 | 124.01 | 27.60 | argsort |
| 8 | 8192  | 1   | 116.72 | 110.03 | argsort |
| 8 | 8192  | 10  | 117.55 | 110.00 | argsort |
| 8 | 8192  | 40  | 119.02 | 113.43 | argsort |
| 8 | 8192  | 400 | 121.94 | 110.30 | argsort |
| 8 | 16384 | 1   | 119.73 | 208.46 | DeviceTopK |
| 8 | 16384 | 10  | 119.73 | 208.64 | DeviceTopK |
| 8 | 16384 | 40  | 121.10 | 209.37 | DeviceTopK |
| 8 | 16384 | 400 | 124.99 | 208.42 | DeviceTopK |
| 16 | 4096 | 1   | 236.58 | 55.42 | argsort |
| 16 | 4096 | 10  | 240.12 | 51.30 | argsort |
| 16 | 4096 | 40  | 243.25 | 56.02 | argsort |
| 16 | 4096 | 400 | 248.50 | 56.39 | argsort |
| 16 | 8192 | 1   | 233.77 | 238.75 | DeviceTopK |
| 16 | 8192 | 10  | 234.94 | 240.50 | DeviceTopK |
| 16 | 8192 | 40  | 238.52 | 241.60 | DeviceTopK |
| 16 | 8192 | 400 | 244.21 | 246.25 | DeviceTopK |
| 16 | 16384 | 1   | 241.49 | 421.60 | DeviceTopK |
| 16 | 16384 | 10  | 241.96 | 420.80 | DeviceTopK |
| 16 | 16384 | 40  | 245.02 | 425.54 | DeviceTopK |
| 16 | 16384 | 400 | 251.97 | 425.87 | DeviceTopK |

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes<!-- mention: YES / NO - if yes, describe how AI was used -->
  - AI assisted with the investigation of the fix.
  - I reviewed and understood every changed line and personally reran all validation listed above.
  - I understand that I am fully responsible for all changes submitted in this PR. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
