### PR TITLE
CUDA: allow small_k mmvq for IQ3 types when K is too small to occupy the block

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -887,7 +887,11 @@ static void mul_mat_vec_q_switch_ncols_dst(
         const bool is_nvidia_pascal_older = GGML_CUDA_CC_IS_NVIDIA(cc) && cc < GGML_CUDA_CC_VOLTA;
 
         if (is_nvidia_turing_plus) {
-            if (ncols_dst == 1 &&
+            // The LUT-heavy IQ3 vec_dot regresses with small_k at regular K sizes, but when K is
+            // small enough that most of the thread block would sit idle (e.g. the 512-wide expert
+            // FFNs of Qwen3.6-35B-A3B, where blocks_per_row_x is 2) small_k is still a clear win:
+            // -29% for iq3_xxs and -10% for iq3_s at m=2048, n=1, k=512 on RTX 4060 Ti.
+            if (ncols_dst == 1 && blocks_per_row_x >= nwarps * blocks_per_iter_1warp / 2 &&
                     std::find(iq_slow_turing.begin(), iq_slow_turing.end(), type) != iq_slow_turing.end()) {
                 use = false;
             }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9643,6 +9643,17 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     }
 
 
+    // qwen3.6-35b-a3b (256 experts, top-8, tiny expert FFN: exercises small-k mmvq)
+    for (int bs : {1, 4, 8, 512}) {
+        for (ggml_type type_a : {GGML_TYPE_Q4_K, GGML_TYPE_IQ2_S, GGML_TYPE_IQ3_S, GGML_TYPE_IQ3_XXS}) {
+            for (ggml_type type_b : {GGML_TYPE_F32}) {
+                test_cases.emplace_back(new test_mul_mat_id(type_a, type_b, 256, 8, false, 512, bs, 2048));
+                test_cases.emplace_back(new test_mul_mat_id(type_a, type_b, 256, 8, false, 2048, bs, 512));
+                test_cases.emplace_back(new test_mul_mat_id_fusion(type_a, type_b, 256, 8, false, 512, bs, 2048, 1));
+            }
+        }
+    }
+
     // gpt-oss-20b
     for (int bs : {1, 4, 8, 512}) {
         for (ggml_type type_a : {GGML_TYPE_MXFP4}) {


### PR DESCRIPTION
The `iq_slow_turing` exception in `should_use_small_k()` disables the small_k path for IQ3_XXS and IQ3_S wholesale on NVIDIA Turing+. That is the right call at regular K sizes, where the LUT-heavy IQ3 vec_dot regresses with small_k. But at very small K, most of the thread block sits idle on the regular path (the `kbx` loop covers only `blocks_per_row_x` slots), and small_k wins despite the LUT pressure.

This matters for MoE models with narrow expert FFNs. Qwen3.6-35B-A3B (256 experts, top-8, expert FFN width 512) hits it on every decode step: its IQ3-quantized expert down projections run `m=2048, n=1, k=512`, i.e. `blocks_per_row_x = 2` against a 4-warp block.

This PR keeps the exception but only applies it when K is large enough for the regular path to occupy at least half of the block's K-block slots. It also adds Qwen3.6-35B-A3B expert-shaped cases to the `test-backend-ops` perf suite, which previously had no coverage for small-K `MUL_MAT_ID`.

### Performance

`test-backend-ops perf -o MUL_MAT_ID`, RTX 4060 Ti (Ada, CC 8.9), `n_mats=256, n_used=8, n=1`:

| type | m | k | master | PR | delta |
|---|---|---|---|---|---|
| iq3_xxs | 2048 | 512 | 34.08 us | 24.17 us | **-29.1%** |
| iq3_s | 2048 | 512 | 33.79 us | 30.50 us | **-9.7%** |
| iq3_xxs | 512 | 2048 | 12.50 us | 12.42 us | ~0 |
| iq3_s | 512 | 2048 | 13.01 us | 13.08 us | ~0 |
| iq2_s (control, not in exception list) | both | both | unchanged | unchanged | ~0 |
| q4_K (control, not in exception list) | both | both | unchanged | unchanged | ~0 |

End to end: Qwen3.6-35B-A3B UD-IQ3_XXS fully offloaded on the same GPU goes from 84.14 to 85.19 tg64 t/s (+1.2%), with the remaining IQ3 decode time bound by the vec_dot itself rather than occupancy.

Verified engagement via nsys (`--cuda-graph-trace=node`): the IQ3_S expert matvecs move from `mul_mat_vec_q<..., small_k=false>` to `small_k=true` after the change.

### Correctness

- `test-backend-ops test -o MUL_MAT -b CUDA0`: 1136 OK, 0 FAIL
- `test-backend-ops test -o MUL_MAT_ID -b CUDA0`: 792 OK, 0 FAIL
