### PR TITLE
[server] Return 400 for malformed tool-call arguments instead of 500

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2370,7 +2370,7 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            std::string role = message.contains("role") && message["role"].is_string()
+                            const std::string role = message.contains("role") && message["role"].is_string()
                                 ? message["role"].get<std::string>() : "unknown";
                             throw std::invalid_argument("Failed to parse tool call arguments as JSON in message "
                                 + std::to_string(i) + " (role: " + role + "): " + std::string(e.what()));

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2370,8 +2370,10 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
+                            std::string role = message.contains("role") && message["role"].is_string()
+                                ? message["role"].get<std::string>() : "unknown";
                             throw std::invalid_argument("Failed to parse tool call arguments as JSON in message "
-                                + std::to_string(i) + ": " + std::string(e.what()));
+                                + std::to_string(i) + " (role: " + role + "): " + std::string(e.what()));
                         }
                     }
                 }

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -2360,7 +2360,8 @@ static void convert_tool_responses_gemma4(json & messages) {
 
 static void func_args_not_string(json & messages) {
     GGML_ASSERT(messages.is_array());
-    for (auto & message : messages) {
+    for (size_t i = 0; i < messages.size(); i++) {
+        auto & message = messages[i];
         if (message.contains("tool_calls")) {
             for (auto & tool_call : message["tool_calls"]) {
                 if (tool_call.contains("function") && tool_call["function"].contains("arguments")) {
@@ -2369,7 +2370,8 @@ static void func_args_not_string(json & messages) {
                         try {
                             args = json::parse(args.get<std::string>());
                         } catch (const std::exception & e) {
-                            throw std::runtime_error("Failed to parse tool call arguments as JSON: " + std::string(e.what()));
+                            throw std::invalid_argument("Failed to parse tool call arguments as JSON in message "
+                                + std::to_string(i) + ": " + std::string(e.what()));
                         }
                     }
                 }
@@ -2696,6 +2698,12 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         workaround::map_developer_role_to_system(params.messages);
     }
 
+    if (tmpl.original_caps().supports_object_arguments) {
+        // must run before system_message_not_supported so error messages
+        // reference the correct history entry index
+        workaround::func_args_not_string(params.messages);
+    }
+
     if (!tmpl.original_caps().supports_system_role) {
         workaround::system_message_not_supported(params.messages);
     }
@@ -2705,10 +2713,6 @@ static common_chat_params common_chat_templates_apply_jinja(const struct common_
         // to still be non-null, this puts an empty string everywhere where the
         // content field is null
         workaround::requires_non_null_content(params.messages);
-    }
-
-    if (tmpl.original_caps().supports_object_arguments) {
-        workaround::func_args_not_string(params.messages);
     }
 
     params.extra_context = common_chat_extra_context();

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -675,7 +675,5 @@ def test_malformed_tool_call_args_rejected():
     error = res.body["error"]
     assert error["type"] == "invalid_request_error", \
         f"Expected invalid_request_error, got {error['type']}: {error}"
-    assert any(kw in error["message"].lower() for kw in ["json", "parse", "arguments"]), \
-        f"Expected JSON parse error, got: {error['message']}"
-    assert "role" in error["message"].lower(), \
-        f"Expected 'role' in error message, got: {error['message']}"
+    assert "message 1" in error["message"]
+    assert "role: assistant" in error["message"]

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -643,3 +643,36 @@ def do_test_hello_world(server: ServerProcess, **kwargs):
     code = actual_arguments["code"]
     assert isinstance(code, str), f"Expected code to be a string, got {type(code)}: {json.dumps(code)}"
     assert re.match(r'''print\(("[Hh]ello,? [Ww]orld!?"|'[Hh]ello,? [Ww]orld!?')\)''', re.sub(r'#.*\n?', '', code)), f'Expected hello world, got {code}'
+
+
+def test_malformed_tool_call_args_rejected():
+    """Regression test for issue #25510: malformed tool_calls arguments in
+    prior assistant history must return HTTP 400, not HTTP 500."""
+    global server
+    server.jinja = True
+    server.chat_template_file = '../../../models/templates/meta-llama-Llama-3.3-70B-Instruct.jinja'
+    server.start()
+
+    res = server.make_request("POST", "/v1/chat/completions", data={
+        "max_tokens": 128,
+        "messages": [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "test",
+                        "arguments": "{"
+                    }
+                }
+            ]},
+        ],
+    })
+
+    assert res.status_code == 400, f"Expected HTTP 400, got {res.status_code}: {res.body}"
+    error = res.body["error"]
+    assert error["type"] == "invalid_request_error", \
+        f"Expected invalid_request_error, got {error['type']}: {error}"
+    assert any(kw in error["message"].lower() for kw in ["json", "parse", "arguments"]), \
+        f"Expected JSON parse error, got: {error['message']}"

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -667,6 +667,7 @@ def test_malformed_tool_call_args_rejected():
                     }
                 }
             ]},
+            {"role": "user", "content": "Continue"},
         ],
     })
 
@@ -676,3 +677,5 @@ def test_malformed_tool_call_args_rejected():
         f"Expected invalid_request_error, got {error['type']}: {error}"
     assert any(kw in error["message"].lower() for kw in ["json", "parse", "arguments"]), \
         f"Expected JSON parse error, got: {error['message']}"
+    assert "role" in error["message"].lower(), \
+        f"Expected 'role' in error message, got: {error['message']}"


### PR DESCRIPTION
## Summary
Fixes #25510.

When a client sends malformed tool-call `arguments` in the input history, the server now returns HTTP 400 (invalid_request_error) instead of 500. The error message includes the history entry index and role so clients can identify the problematic message.

## Changes
- `common/chat.cpp`: Change `std::runtime_error` to `std::invalid_argument` in `func_args_not_string()`. The server's `ex_wrapper` maps `std::invalid_argument` to HTTP 400. Move the call before `system_message_not_supported()` so error indices correspond to the original message positions.
- `tools/server/tests/unit/test_tool_call.py`: Add regression test asserting HTTP 400 with `invalid_request_error` type on malformed arguments.

## Notes
- The error message provides diagnostic context (message index and role) but clients should not assume the index maps directly to original HTTP request positions across all templates, as preprocessing may reorder messages.
- This change only affects templates that require parsing tool-call arguments as JSON objects.

## Requirements
- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md).

AI usage disclosure: YES - This PR was written primarily by Claude Code with human supervision. The code change, test, and PR description were generated with AI assistance and manually reviewed.