### PR TITLE
ggml : fix view init skipped after buft max_size split

### DIFF
--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -1123,6 +1123,20 @@ static void free_buffers(ggml_backend_buffer_t ** buffers, const size_t * n_buff
     free(*buffers);
 }
 
+static bool alloc_ctx_tensors_finalize_views(struct ggml_context * ctx) {
+    for (struct ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+        if (t->view_src != NULL && t->buffer == NULL) {
+            enum ggml_status status = ggml_backend_view_init(t);
+            if (status != GGML_STATUS_SUCCESS) {
+                GGML_LOG_ERROR("%s: failed to initialize view tensor %s\n", __func__, t->name);
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 static bool alloc_tensor_range(struct ggml_context * ctx,
         struct ggml_tensor * first, struct ggml_tensor * last,
         ggml_backend_buffer_type_t buft, size_t size,
@@ -1141,23 +1155,13 @@ static bool alloc_tensor_range(struct ggml_context * ctx,
     struct ggml_tallocr tallocr = ggml_tallocr_new(buffer);
 
     for (struct ggml_tensor * t = first; t != last; t = ggml_get_next_tensor(ctx, t)) {
-        enum ggml_status status = GGML_STATUS_SUCCESS;
-        if (t->data == NULL) {
-            if (t->view_src == NULL) {
-                status = ggml_tallocr_alloc(&tallocr, t);
-            } else if (t->buffer == NULL) {
-                status = ggml_backend_view_init(t);
+        if (t->view_src == NULL && t->data == NULL) {
+            enum ggml_status status = ggml_tallocr_alloc(&tallocr, t);
+            if (status != GGML_STATUS_SUCCESS) {
+                GGML_LOG_ERROR("%s: failed to allocate tensor %s\n", __func__, t->name);
+                free_buffers(buffers, n_buffers);
+                return false;
             }
-        } else {
-            if (t->view_src != NULL && t->buffer == NULL) {
-                // view of a pre-allocated tensor
-                status = ggml_backend_view_init(t);
-            }
-        }
-        if (status != GGML_STATUS_SUCCESS) {
-            GGML_LOG_ERROR("%s: failed to initialize tensor %s\n", __func__, t->name);
-            free_buffers(buffers, n_buffers);
-            return false;
         }
     }
 
@@ -1213,6 +1217,11 @@ static ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft_impl(
         GGML_LOG_DEBUG("%s: all tensors in the context are already allocated\n", __func__);
 #endif
         GGML_ASSERT(!buffers);
+        return NULL;
+    }
+
+    if (!alloc_ctx_tensors_finalize_views(ctx)) {
+        free_buffers(&buffers, &n_buffers);
         return NULL;
     }
 

--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -1124,6 +1124,20 @@ static void free_buffers(ggml_backend_buffer_t ** buffers, const size_t * n_buff
     free(*buffers);
 }
 
+static bool alloc_ctx_tensors_finalize_views(struct ggml_context * ctx) {
+    for (struct ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+        if (t->view_src != NULL && t->buffer == NULL) {
+            enum ggml_status status = ggml_backend_view_init(t);
+            if (status != GGML_STATUS_SUCCESS) {
+                GGML_LOG_ERROR("%s: failed to initialize view tensor %s\n", __func__, t->name);
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 static bool alloc_tensor_range(struct ggml_context * ctx,
         struct ggml_tensor * first, struct ggml_tensor * last,
         ggml_backend_buffer_type_t buft, size_t size,
@@ -1142,23 +1156,13 @@ static bool alloc_tensor_range(struct ggml_context * ctx,
     struct ggml_tallocr tallocr = ggml_tallocr_new(buffer);
 
     for (struct ggml_tensor * t = first; t != last; t = ggml_get_next_tensor(ctx, t)) {
-        enum ggml_status status = GGML_STATUS_SUCCESS;
-        if (t->data == NULL) {
-            if (t->view_src == NULL) {
-                status = ggml_tallocr_alloc(&tallocr, t);
-            } else if (t->buffer == NULL) {
-                status = ggml_backend_view_init(t);
+        if (t->view_src == NULL && t->data == NULL) {
+            enum ggml_status status = ggml_tallocr_alloc(&tallocr, t);
+            if (status != GGML_STATUS_SUCCESS) {
+                GGML_LOG_ERROR("%s: failed to allocate tensor %s\n", __func__, t->name);
+                free_buffers(buffers, n_buffers);
+                return false;
             }
-        } else {
-            if (t->view_src != NULL && t->buffer == NULL) {
-                // view of a pre-allocated tensor
-                status = ggml_backend_view_init(t);
-            }
-        }
-        if (status != GGML_STATUS_SUCCESS) {
-            GGML_LOG_ERROR("%s: failed to initialize tensor %s\n", __func__, t->name);
-            free_buffers(buffers, n_buffers);
-            return false;
         }
     }
 
@@ -1214,6 +1218,11 @@ static ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft_impl(
         GGML_LOG_DEBUG("%s: all tensors in the context are already allocated\n", __func__);
 #endif
         GGML_ASSERT(!buffers);
+        return NULL;
+    }
+
+    if (!alloc_ctx_tensors_finalize_views(ctx)) {
+        free_buffers(&buffers, &n_buffers);
         return NULL;
     }
 

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -583,6 +583,31 @@ static void test_reallocation() {
     }
 }
 
+// Parent nbytes > max_size leaves cur_buf_size > max_size. A following view
+// then triggers a split with this_size == 0, so the view-only residual range
+// skips alloc_tensor_range unless views are finalized after all splits.
+static void test_view_init_after_max_size_split() {
+    const size_t max_size = 16;
+    dummy_backend backend = dummy_backend_init(max_size);
+    auto [ctx, graph, ctx_ptr] = make_context();
+    (void) graph;
+
+    ggml_tensor * parent = make_input_with_size(ctx, 24); // 6 x f32, > max_size
+    ggml_tensor * view0  = ggml_view_1d(ctx, parent, 2, 0);
+    ggml_tensor * view1  = ggml_view_1d(ctx, parent, 2, 2 * sizeof(float));
+    assign_names(ctx);
+
+    ggml_backend_buffer_ptr buf(ggml_backend_alloc_ctx_tensors_from_buft(ctx, &backend.buffer_type));
+    GGML_ASSERT(buf);
+
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t; t = ggml_get_next_tensor(ctx, t)) {
+        GGML_ASSERT(t->buffer != nullptr);
+        GGML_ASSERT(t->data != nullptr);
+    }
+    GGML_ASSERT(view0->view_src == parent);
+    GGML_ASSERT(view1->view_src == parent);
+}
+
 static void run(const char * name, void (*f)()) {
     printf("%s ", name);
     fflush(stdout);
@@ -604,5 +629,6 @@ int main() {
     run("test_multiple_buffer_types", test_multiple_buffer_types);
     run("test_buffer_size_zero", test_buffer_size_zero);
     run("test_reallocation", test_reallocation);
+    run("test_view_init_after_max_size_split", test_view_init_after_max_size_split);
     return 0;
 }


### PR DESCRIPTION
When ggml_backend_alloc_ctx_tensors_from_buft splits allocation on buft max_size, a view-only tail at the end of the context could skip the final alloc_tensor_range. Persistent views (e.g. KV k_stream / v_stream) were then left without ggml_backend_view_init.
Allocate only parent tensors in alloc_tensor_range and initialize all views in a final pass over the context after all splits complete.
## Overview
`ggml_backend_alloc_ctx_tensors_from_buft` can split a context across multiple buffers when a tensor would exceed the backend buffer-type `max_size` (for example Vulkan's default 1 GiB). If the remaining tail of the context contains only views, the final `alloc_tensor_range` may be skipped, so those views never get `ggml_backend_view_init`.
Persistent KV stream views (`layer.k_stream` / `v_stream`) then keep `tensor->data == NULL` while `view_src` is allocated. Host state save/restore later calls `ggml_backend_tensor_get` / `set` on those views and hits:
`GGML_ASSERT(tensor->data != NULL && "tensor not allocated")`
This change:
- allocates only parent tensors inside each split range
- initializes all uninitialized views in one final pass over the context
Also adds `test_view_init_after_max_size_split` in `tests/test-alloc.cpp`
to cover the oversized-parent + view-only-tail case.
## Additional information
Fixes #19839
Fixes #23737
Fixes #21762

Related:
- #21576 (state-IO `!tensor->data` guards; complementary discussion)
I reproduced the assert with Qwen3.6-27B (MTP) when a parent KV tensor exceeded buft `max_size` and the context ended with a view-only tail.
Note on #21576: skipping tensors with `!tensor->data` avoids the assert, but can omit real KV still reachable via `view_src` and misalign the serialized state. This PR fixes the missing view init in the allocator instead.
Prior investigation commit (same patch on older master; kept for reference):
https://github.com/Yoshi4470/llama.cpp/commit/99655d5854e63e736a6a93280e01b7e785a59ba5
## Test plan
- [x] `test-alloc` (includes new `test_view_init_after_max_size_split`)
- [x] Vulkan A/B on the Qwen3.6-27B MTP speculative path (same command, 10 runs each):
  - before (`e3546c794`): 0/10 (assert every time)
  - after (this PR): 10/10 (no assert, completed normally)
- [x] Earlier `amdvlk64.dll` crash after the assert site was resolved by an AMD driver update; treated as separate from this allocator fix
- N/A: equivalent-size CPU repro (not practical on this machine)

### Command used for the A/B runs:
- Vulkan / AMDVLK, Windows, AMD Software 26.6.4
- AMD Ryzen AI Max+ 395 with Radeon 8060S (gfx1151)
```
llama-cli.exe -np 8 -c 2097152 --no-mmap -m models/Qwen3.6-27B-UD-Q4_K_XL.gguf \
-ctk q4_0 -ctv q4_0 -ctkd q4_0 -ctvd q4_0 \
--spec-type ngram-mod,draft-mtp --spec-draft-n-max 6 --spec-draft-p-min 0.75 -p "Hello!"
```
## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Cursor assisted with implementing the finalize-views pass and regression test after I identified the root cause in the alloc split path, and with local verification.