### PR TITLE
HIP: Tune RDNA4 MMQ tiles for Q6_K / Q2_K (gfx1201) 

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -126,7 +126,7 @@ void ggml_cuda_mul_mat_q(
 
     if (!ids) {
         const size_t nbytes_src1_q8_1 = ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1 +
-            get_mmq_x_max_host(cc)*sizeof(block_q8_1_mmq);
+            get_mmq_x_max_host(cc, (ggml_type) src0->type)*sizeof(block_q8_1_mmq);
         ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), nbytes_src1_q8_1);
 
         {
@@ -184,7 +184,7 @@ void ggml_cuda_mul_mat_q(
     }
 
     const size_t nbytes_src1_q8_1 = ne12*n_expert_used*ne10_padded * sizeof(block_q8_1)/QK8_1 +
-        get_mmq_x_max_host(cc)*sizeof(block_q8_1_mmq);
+        get_mmq_x_max_host(cc, (ggml_type) src0->type)*sizeof(block_q8_1_mmq);
     ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), nbytes_src1_q8_1);
 
     const int64_t ne11_flat = ne12*n_expert_used;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -106,10 +106,14 @@ struct tile_x_sizes {
     int sc;
 };
 
-static int get_mmq_x_max_host(const int cc) {
-    // B_best mmq_x=64.
+// RDNA4 per-type geometry: the 64/64/4 tile + A6 + UNROLL8 is optimal only for
+// HBM-bound Q6_K (low arithmetic intensity, dequant-heavy). Compute-bound types
+// (Q4_K/Q4_0/Q5_0/Q8_0, high AI) regress with nwarps=4/mmq_y=64 and need the
+// stock 128/128/8 geometry. Gate the RDNA4-special values on type==Q6_K; all
+// other types fall through to the stock (per-arch) values.
+static int get_mmq_x_max_host(const int cc, const ggml_type type) {
     if (GGML_CUDA_CC_IS_RDNA4(cc)) {
-        return 64;
+        return type == GGML_TYPE_Q6_K ? 64 : 128;
     }
     return (turing_mma_available(cc) || amd_wmma_available(cc)) ? 128 :
         GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA ?
@@ -120,9 +124,10 @@ static int get_mmq_x_max_host(const int cc) {
 #endif // GGML_CUDA_FORCE_MMQ
 }
 
+template <ggml_type type>
 static constexpr __device__ int get_mmq_x_max_device() {
 #if defined(RDNA4)
-    return 64;
+    return type == GGML_TYPE_Q6_K ? 64 : 128;
 #elif defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 128;
 #else // defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -145,11 +150,14 @@ static constexpr __device__ int get_mmq_x_max_device() {
 #endif // defined(RDNA4) / MMA / WMMA
 }
 
-static int get_mmq_y_host(const int cc) {
-    // RDNA4: nwarps=4 → mmq_y=64 (WMMA writeback: nwarps * 16 == mmq_y).
-    // Combined with MMQ_UNROLL=1 this lands mmq_x=64 under the 128 VGPR budget.
+static int get_mmq_y_host(const int cc, const ggml_type type) {
+    // RDNA4: Q6_K uses nwarps=4 → mmq_y=64 (WMMA writeback: nwarps*16==mmq_y);
+    // compute-bound types keep stock 128/128/8. RDNA1 is 64/4 (no WMMA path).
     if (GGML_CUDA_CC_IS_AMD(cc)) {
-        return (GGML_CUDA_CC_IS_RDNA1(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) ? 64 : 128;
+        if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+            return type == GGML_TYPE_Q6_K ? 64 : 128;
+        }
+        return GGML_CUDA_CC_IS_RDNA1(cc) ? 64 : 128;
     }
     return (GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA) ? 128 : 64;
 }
@@ -163,13 +171,16 @@ if (type == GGML_TYPE_NVFP4 || type == GGML_TYPE_MXFP4) {
     return MMQ_ITER_K;
 }
 
+template <ggml_type type>
 static constexpr __device__ int get_mmq_y_device() {
 #if defined(GGML_USE_HIP)
-#if defined(RDNA1) || defined(RDNA4)
+#if defined(RDNA4)
+    return type == GGML_TYPE_Q6_K ? 64 : 128;
+#elif defined(RDNA1)
     return 64;
 #else
     return 128;
-#endif // defined(RDNA1) || defined(RDNA4)
+#endif // defined(RDNA4) / RDNA1 / other AMD
 #else
 #if __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
     return 128;
@@ -320,21 +331,22 @@ static constexpr __device__ int mmq_get_granularity_device(const int /*mmq_x*/) 
 #endif // AMD_MFMA_AVAILABLE
 
 #if defined(GGML_USE_HIP)
-static int mmq_get_nwarps_host(const int cc, const int warp_size) {
+static int mmq_get_nwarps_host(const int cc, const int warp_size, const ggml_type type) {
     if (GGML_CUDA_CC_IS_RDNA4(cc)) {
-        return 4;
+        return type == GGML_TYPE_Q6_K ? 4 : 8;
     }
     return amd_mfma_available(cc) ? 8 : 256/warp_size;
 }
 #else
-static int mmq_get_nwarps_host(const int /*cc*/, const int warp_size) {
+static int mmq_get_nwarps_host(const int /*cc*/, const int warp_size, const ggml_type /*type*/) {
     return 256/warp_size;
 }
 #endif // (GGML_USE_HIP)
 
+template <ggml_type type>
 static constexpr __device__ int mmq_get_nwarps_device() {
 #if defined(RDNA4)
-    return 4;
+    return type == GGML_TYPE_Q6_K ? 4 : 8;
 #elif defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 8;
 #else
@@ -346,7 +358,16 @@ static constexpr __device__ int mmq_get_nwarps_device() {
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q1_0(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -427,7 +448,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q4_0(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -489,7 +519,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q4_0_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q4_0, mmq_y);
@@ -538,7 +577,16 @@ static __device__ __forceinline__ void vec_dot_q4_0_q8_1_dp4a(
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q4_1(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -600,7 +648,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q4_1_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q4_1, mmq_y);
@@ -649,7 +706,16 @@ static __device__ __forceinline__ void vec_dot_q4_1_q8_1_dp4a(
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q5_0(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -727,7 +793,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q5_1(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -803,7 +878,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q8_0(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -865,7 +949,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_mxfp4(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -934,7 +1027,16 @@ static __device__ __forceinline__ void load_tiles_mxfp4_fp4(const char * __restr
                                                             const int kbx0,
                                                             const int i_max,
                                                             const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     int *      x_qs = (int *) x_tile;
@@ -979,7 +1081,16 @@ static __device__ __forceinline__ void load_tiles_nvfp4_nvfp4(const char * __res
                                                             const int kbx0,
                                                             const int i_max,
                                                             const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
     constexpr int iter_k = get_iter_k(GGML_TYPE_NVFP4);
     constexpr int threads_per_row = iter_k / QK_NVFP4; // each thread processes 1 block
@@ -1101,7 +1212,16 @@ static __device__ __forceinline__ void load_tiles_nvfp4(const char * __restrict_
                                                         const int kb0,
                                                         const int i_max,
                                                         const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -1156,7 +1276,16 @@ static __device__ __forceinline__ void load_tiles_nvfp4(const char * __restrict_
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q8_0_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q8_0, mmq_y);
@@ -1327,7 +1456,16 @@ static __device__ __forceinline__ void vec_dot_q8_0_q8_1_mma(
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q8_1_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q5_1, mmq_y);
@@ -1489,7 +1627,16 @@ static __device__ __forceinline__ void vec_dot_q8_1_q8_1_mma(
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q8_0_16_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = MMQ_DP4A_TXS_Q8_0_16;
@@ -1657,7 +1804,12 @@ static __device__ __forceinline__ void vec_dot_q8_0_16_q8_1_mma(
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q2_K(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     int   * x_qs = (int   *)  x_tile;
@@ -1716,7 +1868,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q2_K_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q2_K, mmq_y);
@@ -1976,7 +2137,16 @@ static __device__ __forceinline__ void vec_dot_q2_K_q8_1_mma(
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q3_K(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -2078,7 +2248,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q3_K_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q3_K, mmq_y);
@@ -2122,7 +2301,16 @@ static __device__ __forceinline__ int unpack_scales_q45_K(const int * scales, co
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q4_K(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -2232,7 +2420,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q4_K_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q4_K, mmq_y);
@@ -2266,7 +2463,16 @@ static __device__ __forceinline__ void vec_dot_q4_K_q8_1_dp4a(
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q5_K(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -2389,7 +2595,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q5_K_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q5_K, mmq_y);
@@ -2424,7 +2639,16 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_dp4a(
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q6_K_ex(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride,
     const bool use_pf, const int ql_pf, const int qh_pf) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -2564,7 +2788,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 template <int mmq_x, int mmq_y>
 static __device__ __forceinline__ void vec_dot_q6_K_q8_1_dp4a(
     const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr tile_x_sizes txs = mmq_get_dp4a_tile_x_sizes(GGML_TYPE_Q6_K, mmq_y);
@@ -2809,7 +3042,16 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq4_nl(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -2874,7 +3116,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq2_xxs(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -2936,7 +3187,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq2_xs(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -2999,7 +3259,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq2_s(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -3065,7 +3334,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq3_xxs(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -3127,7 +3405,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq3_s(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -3194,7 +3481,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq1_s(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -3254,7 +3550,16 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
 template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_iq4_xs(
     const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -3321,7 +3626,16 @@ template<int mmq_x, int mmq_y, bool need_check>
 static __device__ __forceinline__ void mmq_write_back_dp4a(
         const float * __restrict__ sum, const int32_t * __restrict__ ids_dst, float * __restrict__ dst,
         const int stride, const int i_max, const int j_max) {
-    constexpr int nwarps = mmq_get_nwarps_device();
+    // MMA path: mmq_y == nwarps*16 (WMMA/MFMA writeback granularity), so derive
+    // nwarps from the mmq_y template param — this lets per-type geometry dispatch
+    // (Q6_K=64/4 vs compute-bound=128/8) flow through without threading `type`
+    // into every load_tiles/vec_dot. dp4a path keeps the stock wave-based count.
+    constexpr int nwarps =
+#if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+        mmq_y / 16;
+#else
+        256 / ggml_cuda_get_physical_warp_size();
+#endif
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
 #pragma unroll
@@ -3351,7 +3665,7 @@ static __device__ __forceinline__ void mmq_write_back_mma(
         const int stride, const int i_max, const int j_max) {
 
     constexpr int granularity = mmq_get_granularity_device(mmq_x);
-    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int nwarps = mmq_get_nwarps_device<type>();
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     constexpr int tileC_IJ = mmq_get_granularity_device(0);
@@ -3585,9 +3899,9 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
         const int tile_x_max_i, const int tile_y_max_j, const int kb0_start, const int kb0_stop) {
 
     constexpr int              warp_size  = ggml_cuda_get_physical_warp_size();
-    constexpr int              nwarps     = mmq_get_nwarps_device();
+    constexpr int              nwarps     = mmq_get_nwarps_device<type>();
     constexpr int              qk         = ggml_cuda_type_traits<type>::qk;
-    constexpr int              mmq_y      = get_mmq_y_device();
+    constexpr int              mmq_y      = get_mmq_y_device<type>();
     constexpr load_tiles_mmq_t load_tiles = mmq_type_traits<mmq_x, mmq_y, need_check, type>::load_tiles;
 
     extern __shared__ int data_mul_mat_q[];
@@ -3620,83 +3934,88 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 #if defined(RDNA4)
         // RDNA4: prefetch the second Y half (y1) into registers before load_tiles, then
         // copy it back into LDS for the second vec_dot. Avoids a second HBM read of y1
-        // on the memory-bound path and lets the y0 load overlap with load_tiles.
-        constexpr int n_y_ld = (mmq_x * MMQ_TILE_Y_K + nwarps * warp_size - 1) / (nwarps * warp_size);
-        int y1_reg[n_y_ld];
-        {
-            const int * by1 = y + ncols_y * ((kb0 * qk / ne_block) * sz + sz);
+        // and lets the y0 load overlap with load_tiles. Gated on type != Q4_K: the
+        // y1_reg[] register pressure at mmq_x=128 pushes Q4_K's scale-heavy dequant over
+        // an occupancy cliff, so Q4_K keeps the stock second-HBM-read path. The N13
+        // next-kb0 pointer prefetch inside is Q6_K-only (uses block_q6_K).
+        if constexpr (type != GGML_TYPE_Q4_K) {
+            constexpr int n_y_ld = (mmq_x * MMQ_TILE_Y_K + nwarps * warp_size - 1) / (nwarps * warp_size);
+            int y1_reg[n_y_ld];
+            {
+                const int * by1 = y + ncols_y * ((kb0 * qk / ne_block) * sz + sz);
+#pragma unroll
+                for (int i = 0; i < n_y_ld; ++i) {
+                    const int l = i * nwarps * warp_size + threadIdx.y * warp_size + threadIdx.x;
+                    y1_reg[i] = by1[l];
+                }
+            }
+            load_tiles(x, tile_x, offset_x + kb0, tile_x_max_i, stride_row_x);
+            {
+                const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
+#pragma unroll
+                for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                    int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                    tile_y[l] = by0[l];
+                }
+            }
+            __syncthreads();
+            vec_dot(tile_x, tile_y, sum, 0);
+            __syncthreads(); // Required: first vec_dot reads tile_y (LDS); the next loop
+                             // overwrites tile_y from y1_reg. Without this barrier cross-warp
+                             // races corrupt the second dot product.
 #pragma unroll
             for (int i = 0; i < n_y_ld; ++i) {
                 const int l = i * nwarps * warp_size + threadIdx.y * warp_size + threadIdx.x;
-                y1_reg[i] = by1[l];
+                tile_y[l] = y1_reg[i];
             }
-        }
-#endif
-        load_tiles(x, tile_x, offset_x + kb0, tile_x_max_i, stride_row_x);
-#if defined(RDNA4)
-        {
-            const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
-#pragma unroll
-            for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
-                int l = l0 + threadIdx.y*warp_size + threadIdx.x;
-                tile_y[l] = by0[l];
+            __syncthreads();
+            vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+            __syncthreads();
+            // N13: prefetch next kb0 block pointer only (1 reg). Q6_K-only (uses block_q6_K).
+            if constexpr (type == GGML_TYPE_Q6_K) {
+                const int kb0_next = kb0 + blocks_per_iter;
+                if (kb0_next < kb0_stop) {
+                    const int tid = threadIdx.y * warp_size + threadIdx.x;
+                    const block_q6_K * bxi_n = (const block_q6_K *) x + offset_x + kb0_next + (tid % mmq_y) * stride_row_x;
+                    asm volatile("" :: "v"(bxi_n));
+                }
             }
-        }
-        __syncthreads();
-        vec_dot(tile_x, tile_y, sum, 0);
-        __syncthreads(); // Required: first vec_dot reads tile_y (LDS); the next loop
-                         // overwrites tile_y from y1_reg. Without this barrier cross-warp
-                         // races corrupt the second dot product.
-#pragma unroll
-        for (int i = 0; i < n_y_ld; ++i) {
-            const int l = i * nwarps * warp_size + threadIdx.y * warp_size + threadIdx.x;
-            tile_y[l] = y1_reg[i];
-        }
-        __syncthreads();
-        vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
-        __syncthreads();
-        // N13: prefetch next kb0 block pointer only (1 reg).
-        if constexpr (type == GGML_TYPE_Q6_K) {
-            const int kb0_next = kb0 + blocks_per_iter;
-            if (kb0_next < kb0_stop) {
-                const int tid = threadIdx.y * warp_size + threadIdx.x;
-                const block_q6_K * bxi_n = (const block_q6_K *) x + offset_x + kb0_next + (tid % mmq_y) * stride_row_x;
-                asm volatile("" :: "v"(bxi_n));
-            }
-        }
-#else
-        {
-            const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
-#pragma unroll
-            for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
-                int l = l0 + threadIdx.y*warp_size + threadIdx.x;
-
-                tile_y[l] = by0[l];
-            }
-        }
-
-        __syncthreads();
-
-        vec_dot(tile_x, tile_y, sum, 0);
-
-        __syncthreads();
-
-        {
-            const int * by0 = y + ncols_y * ((kb0 * qk / ne_block) * sz + sz);
-#pragma unroll
-            for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
-                int l = l0 + threadIdx.y*warp_size + threadIdx.x;
-
-                tile_y[l] = by0[l];
-            }
-        }
-
-        __syncthreads();
-
-        vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
-
-        __syncthreads();
+        } else
 #endif // defined(RDNA4)
+        {
+            load_tiles(x, tile_x, offset_x + kb0, tile_x_max_i, stride_row_x);
+            {
+                const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
+#pragma unroll
+                for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                    int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+
+                    tile_y[l] = by0[l];
+                }
+            }
+
+            __syncthreads();
+
+            vec_dot(tile_x, tile_y, sum, 0);
+
+            __syncthreads();
+
+            {
+                const int * by0 = y + ncols_y * ((kb0 * qk / ne_block) * sz + sz);
+#pragma unroll
+                for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                    int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+
+                    tile_y[l] = by0[l];
+                }
+            }
+
+            __syncthreads();
+
+            vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+
+            __syncthreads();
+        }
     }
 
     if (fixup) {
@@ -3712,15 +4031,15 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 template <ggml_type type, int mmq_x, bool need_check>
 #if defined(GGML_USE_HIP)
 #if defined(RDNA4)
-    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 2)
+    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device<type>(), 2)
 #elif defined(RDNA3) || defined(RDNA2) || defined(CDNA) || defined(GCN)
-    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 2)
+    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device<type>(), 2)
 #endif // RDNA4 / other AMD
 #else
 #if __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
-    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 1)
+    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device<type>(), 1)
 #else
-    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 2)
+    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device<type>(), 2)
 #endif // __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
 #endif // defined(GGML_USE_HIP)
 static __global__ void mul_mat_q(
@@ -3732,16 +4051,16 @@ static __global__ void mul_mat_q(
         const uint3 ntx) {
 
     // Skip unused template specializations for faster compilation:
-    if (mmq_x > get_mmq_x_max_device() || mmq_x % mmq_get_granularity_device(mmq_x) != 0) {
+    if (mmq_x > get_mmq_x_max_device<type>() || mmq_x % mmq_get_granularity_device(mmq_x) != 0) {
         NO_DEVICE_CODE;
         return;
     }
 
-    constexpr int nwarps = mmq_get_nwarps_device();
+    constexpr int nwarps = mmq_get_nwarps_device<type>();
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     constexpr int qk    = ggml_cuda_type_traits<type>::qk;
-    constexpr int mmq_y = get_mmq_y_device();
+    constexpr int mmq_y = get_mmq_y_device<type>();
 
     const uint32_t nty = (nrows_x + mmq_y - 1) / mmq_y; // Number of tiles y
 
@@ -3967,18 +4286,18 @@ static __global__ void mul_mat_q(
 }
 
 template <ggml_type type, int mmq_x, bool need_check>
-__launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device()/2, 1)
+__launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device<type>()/2, 1)
 static __global__ void mul_mat_q_stream_k_fixup(
         const int32_t * __restrict__ ids_dst, const int32_t * __restrict__ expert_bounds, float * __restrict__ dst,
         float * __restrict__ tmp_last_tile, const uint3 blocks_per_ne00, const int nrows_x, const int ncols_dst,
         const int stride_col_dst, const uint3 nchannels_y, const int stride_channel_dst, const uint3 nsamples_y,
         const int stride_sample_dst, const uint3 ntx) {
-    constexpr int mmq_y           = get_mmq_y_device();
+    constexpr int mmq_y           = get_mmq_y_device<type>();
     constexpr int qk              = ggml_cuda_type_traits<type>::qk;
     constexpr int ITER_K          = get_iter_k(type);
     constexpr int blocks_per_iter = ITER_K / qk;
 
-    constexpr int nwarps = mmq_get_nwarps_device()/2;
+    constexpr int nwarps = mmq_get_nwarps_device<type>()/2;
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
     float sum[mmq_x / nwarps] = {0.0f};
@@ -4129,8 +4448,8 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     const int cc = ggml_cuda_info().devices[id].cc;
     const int nsm = ggml_cuda_info().devices[id].nsm;
     const int warp_size = ggml_cuda_info().devices[id].warp_size;
-    const int nwarps = mmq_get_nwarps_host(cc, warp_size);
-    const int mmq_y = get_mmq_y_host(cc);
+    const int nwarps = mmq_get_nwarps_host(cc, warp_size, type);
+    const int mmq_y = get_mmq_y_host(cc, type);
 
     const dim3 block_dims(warp_size, nwarps, 1);
 
@@ -4242,10 +4561,10 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
     const int    cc     = ggml_cuda_info().devices[id].cc;
     const size_t smpbo  = ggml_cuda_info().devices[id].smpbo;
     const int warp_size = ggml_cuda_info().devices[id].warp_size;
-    const int nwarps    = mmq_get_nwarps_host(cc, warp_size);
+    const int nwarps    = mmq_get_nwarps_host(cc, warp_size, type);
 
-    const int mmq_x_max = get_mmq_x_max_host(cc);
-    const int mmq_y = get_mmq_y_host(cc);
+    const int mmq_x_max = get_mmq_x_max_host(cc, type);
+    const int mmq_y = get_mmq_y_host(cc, type);
 
     int mmq_x_best  = 0;
     int ntiles_x_best = INT_MAX;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -111,9 +111,16 @@ struct tile_x_sizes {
 // (Q4_K/Q4_0/Q5_0/Q8_0, high AI) regress with nwarps=4/mmq_y=64 and need the
 // stock 128/128/8 geometry. Gate the RDNA4-special values on type==Q6_K; all
 // other types fall through to the stock (per-arch) values.
+// Q2_K: mmq_x_max is capped at 64 (vs stock 128). Stock mmq_x=128 leaves Q2_K at
+// ~2 TFLOPS (dequant-bound, low arithmetic intensity); mmq_x=64 gives 3x more blocks
+// and smaller per-block work, lifting Q2_K prefill to ~6.5 TFLOPS (+200% vs stock).
+// Q2_K is also excluded from A6 (see mul_mat_q_process_tile): at both mmq_x=128 and
+// mmq_x=64 the y1_reg[] register pressure adds net overhead for Q2_K, so the +200%
+// gain comes entirely from the tile-size change, not A6. mmq_y/nwarps stay at stock
+// 128/8 (only the N-tile cap changes).
 static int get_mmq_x_max_host(const int cc, const ggml_type type) {
     if (GGML_CUDA_CC_IS_RDNA4(cc)) {
-        return type == GGML_TYPE_Q6_K ? 64 : 128;
+        return (type == GGML_TYPE_Q6_K || type == GGML_TYPE_Q2_K) ? 64 : 128;
     }
     return (turing_mma_available(cc) || amd_wmma_available(cc)) ? 128 :
         GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA ?
@@ -127,7 +134,7 @@ static int get_mmq_x_max_host(const int cc, const ggml_type type) {
 template <ggml_type type>
 static constexpr __device__ int get_mmq_x_max_device() {
 #if defined(RDNA4)
-    return type == GGML_TYPE_Q6_K ? 64 : 128;
+    return (type == GGML_TYPE_Q6_K || type == GGML_TYPE_Q2_K) ? 64 : 128;
 #elif defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 128;
 #else // defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
@@ -3934,11 +3941,15 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 #if defined(RDNA4)
         // RDNA4: prefetch the second Y half (y1) into registers before load_tiles, then
         // copy it back into LDS for the second vec_dot. Avoids a second HBM read of y1
-        // and lets the y0 load overlap with load_tiles. Gated on type != Q4_K: the
-        // y1_reg[] register pressure at mmq_x=128 pushes Q4_K's scale-heavy dequant over
-        // an occupancy cliff, so Q4_K keeps the stock second-HBM-read path. The N13
-        // next-kb0 pointer prefetch inside is Q6_K-only (uses block_q6_K).
-        if constexpr (type != GGML_TYPE_Q4_K) {
+        // and lets the y0 load overlap with load_tiles. Gated on type != Q4_K && type != Q3_K
+        // && type != Q2_K: the y1_reg[] register pressure at mmq_x=128 pushes scale-heavy
+        // K-quants (Q4_K with scales+mins, Q3_K with 6-bit scales) over an occupancy cliff,
+        // so they keep the stock second-HBM-read path. Q2_K also stays on the stock path:
+        // at mmq_x=64 (capped for Q2_K to fix the N=128 occupancy cliff) A6's y1_reg[] still
+        // adds net overhead, so the +200% Q2_K prefill gain comes entirely from mmq_x=64,
+        // not A6. Compute-bound block types (Q4_0/Q5_0/Q8_0) and Q5_K do benefit from A6
+        // (+1..6%). The N13 next-kb0 pointer prefetch inside is Q6_K-only (uses block_q6_K).
+        if constexpr (type != GGML_TYPE_Q4_K && type != GGML_TYPE_Q3_K && type != GGML_TYPE_Q2_K) {
             constexpr int n_y_ld = (mmq_x * MMQ_TILE_Y_K + nwarps * warp_size - 1) / (nwarps * warp_size);
             int y1_reg[n_y_ld];
             {

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -107,6 +107,10 @@ struct tile_x_sizes {
 };
 
 static int get_mmq_x_max_host(const int cc) {
+    // B_best mmq_x=64.
+    if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+        return 64;
+    }
     return (turing_mma_available(cc) || amd_wmma_available(cc)) ? 128 :
         GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA ?
 #ifdef GGML_CUDA_FORCE_MMQ
@@ -117,7 +121,9 @@ static int get_mmq_x_max_host(const int cc) {
 }
 
 static constexpr __device__ int get_mmq_x_max_device() {
-#if defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#if defined(RDNA4)
+    return 64;
+#elif defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 128;
 #else // defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 
@@ -136,12 +142,16 @@ static constexpr __device__ int get_mmq_x_max_device() {
 #endif // __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
 
 #endif // defined(GGML_USE_HIP)
-#endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#endif // defined(RDNA4) / MMA / WMMA
 }
 
 static int get_mmq_y_host(const int cc) {
-    return GGML_CUDA_CC_IS_AMD(cc) ? (GGML_CUDA_CC_IS_RDNA1(cc) ? 64 : 128) :
-        ((GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA) ? 128 : 64);
+    // RDNA4: nwarps=4 → mmq_y=64 (WMMA writeback: nwarps * 16 == mmq_y).
+    // Combined with MMQ_UNROLL=1 this lands mmq_x=64 under the 128 VGPR budget.
+    if (GGML_CUDA_CC_IS_AMD(cc)) {
+        return (GGML_CUDA_CC_IS_RDNA1(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) ? 64 : 128;
+    }
+    return (GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA) ? 128 : 64;
 }
 
 static constexpr __device__ int get_iter_k([[maybe_unused]] const ggml_type type) {
@@ -155,11 +165,11 @@ if (type == GGML_TYPE_NVFP4 || type == GGML_TYPE_MXFP4) {
 
 static constexpr __device__ int get_mmq_y_device() {
 #if defined(GGML_USE_HIP)
-#if defined(RDNA1)
+#if defined(RDNA1) || defined(RDNA4)
     return 64;
 #else
     return 128;
-#endif // defined RDNA1
+#endif // defined(RDNA1) || defined(RDNA4)
 #else
 #if __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
     return 128;
@@ -177,6 +187,15 @@ static constexpr __device__ int get_mmq_y_device() {
 // The final tile size in K direction is padded to avoid shared memory bank conflicts,
 // in terms of 32 bit elements that means K % 2 == 1 for dp4a or K % 8 == 4 for mma.
 #define MMQ_TILE_NE_K 32
+
+// RDNA4: unroll the dequant/load-tiles loops by 8 (vs the stock default). At
+// mmq_x=64 this is the largest win from the D-series (+~1.2 TFLOPS, ATT wait
+// 33.8%->24.3%) and stays 1-wave at 160 VGPR. Other arches keep the stock pragma.
+#if defined(RDNA4)
+#define MMQ_UNROLL _Pragma("unroll 8")
+#else
+#define MMQ_UNROLL _Pragma("unroll")
+#endif
 
 #define MMQ_DP4A_TXS_Q4_0    tile_x_sizes{mmq_y*MMQ_TILE_NE_K   + mmq_y, mmq_y*MMQ_TILE_NE_K/QI4_0   + mmq_y/QI4_0,     0}
 #define MMQ_DP4A_TXS_Q4_1    tile_x_sizes{mmq_y*MMQ_TILE_NE_K   + mmq_y, mmq_y*MMQ_TILE_NE_K/QI4_1   + mmq_y/QI4_1,     0}
@@ -223,6 +242,12 @@ static constexpr __host__ __device__ tile_x_sizes mmq_get_dp4a_tile_x_sizes(ggml
 #define MMQ_MMA_TILE_X_K_Q2_K  (2*MMQ_TILE_NE_K + MMQ_TILE_NE_K                           + 4)
 #define MMQ_MMA_TILE_X_K_Q3_K  (2*MMQ_TILE_NE_K + MMQ_TILE_NE_K/2                         + 4)
 #define MMQ_MMA_TILE_X_K_Q6_K  (2*MMQ_TILE_NE_K + MMQ_TILE_NE_K/QI6_K   + MMQ_TILE_NE_K/8 + 7)
+
+// RDNA4 Q6_K: store packed 6-bit-in-byte values in LDS and expand to signed int8
+// in vec_dot after ldmatrix. Fewer LDS bytes for the qs tile, same register count.
+#ifndef MMQ_Q6_PACKED_P04
+#define MMQ_Q6_PACKED_P04 1
+#endif
 
 static_assert(MMQ_MMA_TILE_X_K_Q8_0 % 8 == 4, "Wrong padding.");
 static_assert(MMQ_MMA_TILE_X_K_Q8_1 % 8 == 4, "Wrong padding.");
@@ -296,6 +321,9 @@ static constexpr __device__ int mmq_get_granularity_device(const int /*mmq_x*/) 
 
 #if defined(GGML_USE_HIP)
 static int mmq_get_nwarps_host(const int cc, const int warp_size) {
+    if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+        return 4;
+    }
     return amd_mfma_available(cc) ? 8 : 256/warp_size;
 }
 #else
@@ -305,11 +333,13 @@ static int mmq_get_nwarps_host(const int /*cc*/, const int warp_size) {
 #endif // (GGML_USE_HIP)
 
 static constexpr __device__ int mmq_get_nwarps_device() {
-#if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#if defined(RDNA4)
+    return 4;
+#elif defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 8;
 #else
     return 256/ggml_cuda_get_physical_warp_size();
-#endif // AMD_MFMA_AVAILABLE
+#endif // RDNA4 / MFMA / WMMA
 }
 
 // ------------------------------------------------------------
@@ -2391,8 +2421,9 @@ static __device__ __forceinline__ void vec_dot_q5_K_q8_1_dp4a(
     }
 }
 
-template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q6_K(
-    const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
+template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q6_K_ex(
+    const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride,
+    const bool use_pf, const int ql_pf, const int qh_pf) {
     constexpr int nwarps = mmq_get_nwarps_device();
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
 
@@ -2410,9 +2441,44 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     constexpr int threads_per_row = MMQ_ITER_K / (4 * QR6_K);
     constexpr int nrows = warp_size / threads_per_row;
     const int txi = warp_size > threads_per_row ? threadIdx.x % threads_per_row : threadIdx.x;
+    // Hoist txi-only address knobs out of the i-loop.
+    const int kq0 = 2*txi - txi % (QI6_K/2) + 0;
+    const int kq1 = 2*txi - txi % (QI6_K/2) + QI6_K/2;
+    const int qh_idx = (QI6_K/4) * (txi / (QI6_K/2)) + txi % (QI6_K/4);
+    const int qh_shift = (txi & 0x08) >> 2;
+    constexpr int step_i = nrows * nwarps;
 
-#pragma unroll
-    for (int i0 = 0; i0 < mmq_y; i0 += nrows*nwarps) {
+#if defined(RDNA4) && (defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE))
+    // RDNA4 hot path (need_check=false): stride the qs/ql/qh pointers by step_i
+    // instead of recomputing i*TILE each iteration, and optionally consume a
+    // prefetched first-row ql/qh pair (use_pf) to overlap the first dequant with loads.
+    if constexpr (!need_check) {
+        const int i_lane = (nrows == 1) ? threadIdx.y : (threadIdx.y*nrows + threadIdx.x/threads_per_row);
+        int * row = x_qs + i_lane * MMQ_MMA_TILE_X_K_Q6_K;
+        const block_q6_K * bxi = (const block_q6_K *) x + kbx0 + i_lane * stride;
+MMQ_UNROLL
+        for (int i0 = 0; i0 < mmq_y; i0 += step_i) {
+            const int ql = (use_pf && i0 == 0) ? ql_pf : get_int_b4(bxi->ql, txi);
+            const int qh = (use_pf && i0 == 0) ? qh_pf : get_int_b4(bxi->qh, qh_idx);
+            const int ql0 = (ql >> 0) & 0x0F0F0F0F;
+            const int ql1 = (ql >> 4) & 0x0F0F0F0F;
+            const int qh0 = ((qh >> qh_shift) << 4) & 0x30303030;
+            const int qh1 =  (qh >> qh_shift)       & 0x30303030;
+#if MMQ_Q6_PACKED_P04
+            row[kq0] = ql0 | qh0;
+            row[kq1] = ql1 | qh1;
+#else
+            row[kq0] = __vsubss4(ql0 | qh0, 0x20202020);
+            row[kq1] = __vsubss4(ql1 | qh1, 0x20202020);
+#endif
+            row += step_i * MMQ_MMA_TILE_X_K_Q6_K;
+            bxi += step_i * stride;
+        }
+    } else
+#endif // RDNA4 + MMA
+    {
+MMQ_UNROLL
+    for (int i0 = 0; i0 < mmq_y; i0 += step_i) {
         int i = i0 + (nrows == 1 ? threadIdx.y : threadIdx.y*nrows + threadIdx.x/threads_per_row);
 
         if (need_check) {
@@ -2421,27 +2487,36 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
 
         const block_q6_K * bxi = (const block_q6_K *) x + kbx0 + i*stride;
 
+#if defined(RDNA4)
+        const int ql = get_int_b4(bxi->ql, txi);
+        const int qh = get_int_b4(bxi->qh, qh_idx);
+#else
         const int ql = get_int_b2(bxi->ql, txi);
+        const int qh = get_int_b2(bxi->qh, qh_idx);
+#endif // defined(RDNA4)
         const int ql0 = (ql >> 0) & 0x0F0F0F0F;
         const int ql1 = (ql >> 4) & 0x0F0F0F0F;
 
-        const int qh = get_int_b2(bxi->qh, (QI6_K/4) * (txi / (QI6_K/2)) + txi % (QI6_K/4));
-        const int qh0 = ((qh >> ((txi & 0x08) >> 2)) << 4) & 0x30303030;
-        const int qh1 =  (qh >> ((txi & 0x08) >> 2))       & 0x30303030;
-
-        const int kq0 = 2*txi - txi % (QI6_K/2) + 0;
-        const int kq1 = 2*txi - txi % (QI6_K/2) + QI6_K/2;
+        const int qh0 = ((qh >> qh_shift) << 4) & 0x30303030;
+        const int qh1 =  (qh >> qh_shift)       & 0x30303030;
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
-        x_qs[i*MMQ_MMA_TILE_X_K_Q6_K + kq0] = __vsubss4(ql0 | qh0, 0x20202020);
-        x_qs[i*MMQ_MMA_TILE_X_K_Q6_K + kq1] = __vsubss4(ql1 | qh1, 0x20202020);
+        int * row = x_qs + i * MMQ_MMA_TILE_X_K_Q6_K;
+#if defined(RDNA4) && MMQ_Q6_PACKED_P04
+        row[kq0] = ql0 | qh0;
+        row[kq1] = ql1 | qh1;
+#else
+        row[kq0] = __vsubss4(ql0 | qh0, 0x20202020);
+        row[kq1] = __vsubss4(ql1 | qh1, 0x20202020);
+#endif
 #else
         x_qs[i*(2*MMQ_TILE_NE_K + 1) + kq0] = __vsubss4(ql0 | qh0, 0x20202020);
         x_qs[i*(2*MMQ_TILE_NE_K + 1) + kq1] = __vsubss4(ql1 | qh1, 0x20202020);
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     }
+    } // need_check / non-RDNA4
 
-#pragma unroll
+MMQ_UNROLL
     for (int i0 = 0; i0 < mmq_y; i0 += nwarps*warp_size) {
         int i = (i0 + threadIdx.y*warp_size + threadIdx.x) % mmq_y;
 
@@ -2459,7 +2534,7 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
     }
 
     constexpr int rows_per_warp = warp_size / 4;
-#pragma unroll
+MMQ_UNROLL
     for (int i0 = 0; i0 < mmq_y; i0 += nwarps*rows_per_warp) {
         int i = (i0 + threadIdx.y*rows_per_warp + threadIdx.x/(MMQ_TILE_NE_K/8)) % mmq_y;
 
@@ -2470,11 +2545,20 @@ template <int mmq_y, bool need_check> static __device__ __forceinline__ void loa
         const block_q6_K * bxi = (const block_q6_K *) x + kbx0 + i*stride + (threadIdx.x % (MMQ_TILE_NE_K/8)) / 4;
 
 #if defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#if defined(RDNA4)
+        x_sc[i*MMQ_MMA_TILE_X_K_Q6_K + threadIdx.x%4] = get_int_b4(bxi->scales, threadIdx.x % (MMQ_TILE_NE_K/8));
+#else
         x_sc[i*MMQ_MMA_TILE_X_K_Q6_K + threadIdx.x%4] = get_int_b2(bxi->scales, threadIdx.x % (MMQ_TILE_NE_K/8));
+#endif // defined(RDNA4)
 #else
         x_sc[i*(MMQ_TILE_NE_K/8) + i/8 + threadIdx.x%(MMQ_TILE_NE_K/8)] = get_int_b2(bxi->scales, threadIdx.x%(QI6_K/8));
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     }
+}
+
+template <int mmq_y, bool need_check> static __device__ __forceinline__ void load_tiles_q6_K(
+    const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
+    load_tiles_q6_K_ex<mmq_y, need_check>(x, x_tile, kbx0, i_max, stride, false, 0, 0);
 }
 
 template <int mmq_x, int mmq_y>
@@ -2535,13 +2619,27 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
 
     const int i0 = (threadIdx.y / ntx) * rows_per_warp;
 
-    for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += 4) {
+    // RDNA4 small-N decode: unroll the k01 loop by 2 for small mmq_x (<=16) so the
+    // compiler overlaps adjacent K-tile A-ldmatrix loads with the mma of the previous
+    // tile, halving the LDS-load stall (ATT ds_read wait 6.5%->3.1%, WMMA 1.5->1.9%).
+    // Large mmq_x keeps the default unroll: unroll 2 raises VGPR pressure (88->136,
+    // waves 2->1) and regresses large-N prefill. Dispatch is constexpr, so each
+    // instantiation compiles to exactly one of the two loop forms.
+    auto k01_body = [&](const int k01) {
         const int k0 = k00 + k01;
 
         tile_A A[ntx];
 #pragma unroll
         for (int n = 0; n < ntx; ++n) {
             load_ldmatrix(A[n], x_qs + (i0 + n*tile_A::I)*MMQ_MMA_TILE_X_K_Q6_K + k0, MMQ_MMA_TILE_X_K_Q6_K);
+#if defined(RDNA4) && MMQ_Q6_PACKED_P04
+            // RDNA4: expand packed 6-bit-in-byte to signed int8 in registers after
+            // ldmatrix, before the iu8 mma.
+#pragma unroll
+            for (int l = 0; l < tile_A::ne; ++l) {
+                A[n].x[l] = __vsubss4(A[n].x[l], 0x20202020);
+            }
+#endif
         }
 
 #pragma unroll
@@ -2552,19 +2650,55 @@ static __device__ __forceinline__ void vec_dot_q6_K_q8_1_mma(
             const int j = j0 + tile_C::get_j(0);
             const float dB = y_df[j*MMQ_TILE_Y_K + k01/QI8_1];
 
+            // RDNA4 Q6_K epilogue: dispatch on mmq_x to keep decode bit-exact without
+            // regressing prefill. fmaf's fused rounding (1 rounding vs mul+add's 2)
+            // produces a ~5e-5 vs-upstream residual that accumulates over layers and
+            // drops speculative-decoding accept (91%->88%); only separate mul+add is
+            // bit-exact, but it is ~32% slower on the prefill hot loop. Small mmq_x
+            // (<=16, the decode/verify path taken by MTP N<=16) uses the stock mul+add
+            // order (bit-identical to upstream, accept preserved); large mmq_x (prefill)
+            // keeps the hoisted-sd fmaf (fast, residual harmless for prefill). The
+            // dispatch is constexpr so each instantiation compiles to one path.
+            if constexpr (mmq_x <= 16) {
 #pragma unroll
-            for (int n = 0; n < ntx; ++n) {
-                tile_C C;
-                mma(C, A[n], B);
-
+                for (int n = 0; n < ntx; ++n) {
+                    tile_C C;
+                    mma(C, A[n], B);
 #pragma unroll
-                for (int l = 0; l < tile_C::ne; ++l) {
-                    const int i = i0 + n*tile_C::I + tile_C::get_i(l);
-                    const int8_t * sc = (const int8_t *) (x_sc + i*MMQ_MMA_TILE_X_K_Q6_K + k00/16);
-                    sum[(j0/tile_C::J + n)*tile_C::ne + l] += C.x[l] * sc[k01/4] * x_df[i*MMQ_MMA_TILE_X_K_Q6_K] * dB;
+                    for (int l = 0; l < tile_C::ne; ++l) {
+                        const int i = i0 + n*tile_C::I + tile_C::get_i(l);
+                        const int8_t * sc = (const int8_t *) (x_sc + i*MMQ_MMA_TILE_X_K_Q6_K + k00/16);
+                        sum[(j0/tile_C::J + n)*tile_C::ne + l] += C.x[l] * sc[k01/4] * x_df[i*MMQ_MMA_TILE_X_K_Q6_K] * dB;
+                    }
+                }
+            } else {
+                float sd_all[ntx][tile_C::ne];
+#pragma unroll
+                for (int n = 0; n < ntx; ++n) {
+#pragma unroll
+                    for (int l = 0; l < tile_C::ne; ++l) {
+                        const int i = i0 + n*tile_C::I + tile_C::get_i(l);
+                        const int8_t * sc = (const int8_t *) (x_sc + i*MMQ_MMA_TILE_X_K_Q6_K + k00/16);
+                        sd_all[n][l] = (float)sc[k01/4] * x_df[i*MMQ_MMA_TILE_X_K_Q6_K];
+                    }
+                }
+#pragma unroll
+                for (int n = 0; n < ntx; ++n) {
+                    tile_C C;
+                    mma(C, A[n], B);
+#pragma unroll
+                    for (int l = 0; l < tile_C::ne; ++l) {
+                        sum[(j0/tile_C::J + n)*tile_C::ne + l] = fmaf(C.x[l] * sd_all[n][l], dB, sum[(j0/tile_C::J + n)*tile_C::ne + l]);
+                    }
                 }
             }
         }
+    };
+    if constexpr (mmq_x <= 16) {
+#pragma unroll 2
+        for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += 4) k01_body(k01);
+    } else {
+        for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += 4) k01_body(k01);
     }
 #elif defined(TURING_MMA_AVAILABLE)
 
@@ -3483,7 +3617,54 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
     constexpr int sz = sizeof(block_q8_1_mmq) / sizeof(int);
 
     for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
+#if defined(RDNA4)
+        // RDNA4: prefetch the second Y half (y1) into registers before load_tiles, then
+        // copy it back into LDS for the second vec_dot. Avoids a second HBM read of y1
+        // on the memory-bound path and lets the y0 load overlap with load_tiles.
+        constexpr int n_y_ld = (mmq_x * MMQ_TILE_Y_K + nwarps * warp_size - 1) / (nwarps * warp_size);
+        int y1_reg[n_y_ld];
+        {
+            const int * by1 = y + ncols_y * ((kb0 * qk / ne_block) * sz + sz);
+#pragma unroll
+            for (int i = 0; i < n_y_ld; ++i) {
+                const int l = i * nwarps * warp_size + threadIdx.y * warp_size + threadIdx.x;
+                y1_reg[i] = by1[l];
+            }
+        }
+#endif
         load_tiles(x, tile_x, offset_x + kb0, tile_x_max_i, stride_row_x);
+#if defined(RDNA4)
+        {
+            const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
+#pragma unroll
+            for (int l0 = 0; l0 < mmq_x * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
+                int l = l0 + threadIdx.y*warp_size + threadIdx.x;
+                tile_y[l] = by0[l];
+            }
+        }
+        __syncthreads();
+        vec_dot(tile_x, tile_y, sum, 0);
+        __syncthreads(); // Required: first vec_dot reads tile_y (LDS); the next loop
+                         // overwrites tile_y from y1_reg. Without this barrier cross-warp
+                         // races corrupt the second dot product.
+#pragma unroll
+        for (int i = 0; i < n_y_ld; ++i) {
+            const int l = i * nwarps * warp_size + threadIdx.y * warp_size + threadIdx.x;
+            tile_y[l] = y1_reg[i];
+        }
+        __syncthreads();
+        vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
+        __syncthreads();
+        // N13: prefetch next kb0 block pointer only (1 reg).
+        if constexpr (type == GGML_TYPE_Q6_K) {
+            const int kb0_next = kb0 + blocks_per_iter;
+            if (kb0_next < kb0_stop) {
+                const int tid = threadIdx.y * warp_size + threadIdx.x;
+                const block_q6_K * bxi_n = (const block_q6_K *) x + offset_x + kb0_next + (tid % mmq_y) * stride_row_x;
+                asm volatile("" :: "v"(bxi_n));
+            }
+        }
+#else
         {
             const int * by0 = y + ncols_y * (kb0 * qk / ne_block) * sz;
 #pragma unroll
@@ -3515,6 +3696,7 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
         vec_dot(tile_x, tile_y, sum, MMQ_TILE_NE_K);
 
         __syncthreads();
+#endif // defined(RDNA4)
     }
 
     if (fixup) {
@@ -3529,9 +3711,11 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
 template <ggml_type type, int mmq_x, bool need_check>
 #if defined(GGML_USE_HIP)
-#if defined(RDNA4) || defined(RDNA3) || defined(RDNA2) || defined(CDNA) || defined(GCN)
+#if defined(RDNA4)
     __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 2)
-#endif // defined(RDNA4) || defined(RDNA3) || defined(RDNA2) || defined(CDNA) || defined(GCN)
+#elif defined(RDNA3) || defined(RDNA2) || defined(CDNA) || defined(GCN)
+    __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 2)
+#endif // RDNA4 / other AMD
 #else
 #if __CUDA_ARCH__ >= GGML_CUDA_CC_VOLTA
     __launch_bounds__(ggml_cuda_get_physical_warp_size()*mmq_get_nwarps_device(), 1)
@@ -4075,7 +4259,8 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
 
         const int ntiles_x = (args.ncols_max + mmq_x - 1) / mmq_x;
 
-        if (ntiles_x < ntiles_x_best) {
+        // Prefer fewer tiles; on a tie prefer larger mmq_x (higher arithmetic intensity).
+        if (ntiles_x < ntiles_x_best || (ntiles_x == ntiles_x_best && mmq_x > mmq_x_best)) {
             mmq_x_best = mmq_x;
             ntiles_x_best = ntiles_x;
         }


### PR DESCRIPTION
## Overview
This PR aims to tune mul_mat_q on RDNA4 (gfx1201). Changes are gated with #if defined(RDNA4). Non-RDNA4 builds match upstream. Benchmarked on Radeon AI PRO R9700 / ROCm 7.2.4; shapes from Qwen3.6-27B FFN.

### Main Results
#### mmq-bench prefill ( ffn_gate 17408x5120, same-GPU0 A/B)
type | stock n512(TFLOPS) | this-version n512(TFLOPS) | delta | stock n2048(TFLOPS) | this-version n2048 (TFLOPS)| delta
-- | -- | -- | -- | -- | -- | --|
Q6_K | 32.64 | 46.75 | +43.3% | 33.04 | 46.64 | +41.2%
Q4_K | 76.32 | 76.50 | +0.2% | 76.15 | 76.37 | +0.3%
Q4_0 | 76.75 | 77.89 | +1.5% | 76.59 | 77.93 | +1.7%
Q5_K | 66.80 | 71.43 | +6.9% | 66.79 | 71.23 | +6.6%
Q5_0 | 73.57 | 76.25 | +3.6% | 73.25 | 76.04 | +3.8%
Q8_0 | 80.07 | 80.68 | +0.8% | 81.01 | 81.29 | +0.3%
Q2_K | 1.93 | 6.50 | +237% | 2.07 | 6.51 | +214%
Q3_K | 58.10 | 58.19 | +0.2% | 58.12 | 58.74 | +1.1%

#### 27B Q6_K prefill (Qwen3.6-27B-UD-Q6_K_XL)
test | stock t/s | this version t/s | delta
-- | -- | -- | --
pp512 | 705.83 | 888.79 | +25.9%
pp2048 | 694.68 | 872.70 | +25.6%
pp8192 | 641.65 | 792.90 | +23.6%
tg128 | 21.50 | 21.50 | +0.0%

#### 27B Q2_K prefill (Qwen3.6-27B-UD-Q2_K_XL)
| test | stock t/s | this version  t/s | delta |
|------|----------:|--------:|------:|
| pp512 | 87.21 | 263.99 | **+202.7%** |
| pp2048 | 87.10 | 262.42 | **+201.3%** |
| pp8192 | 86.64 | 254.39 | **+193.6%** |
| tg128 | 30.80 | 30.80 | +0.0% |

#### llama-bench 7B Q6_K (Qwen2.5-7B-Instruct-Q6_K)
test | stock t/s | this version t/s | delta
-- | -- | -- | --
pp512 | 2279.14 | 3289.76 | +44.3%
pp2048 | 2302.51 | 3297.88 | +43.2%
pp8192 | 2145.20 | 3000.91 | +39.9%
tg128 | 85.19 | 85.59 | +0.5%

#### Decode
##### E2E MTP accept(Qwen3.6-27B-UD-Q6_K_XL)
n-max | metric | stock (e3546c794) | this version (fe2df7f34) | delta
-- | -- | -- | -- | --
N2 | accept | 86% (60/70) | 86% (60/70) | identical
N2 | t/s | 42.64 ± 0.09 | 42.40 ± 0.08 | -0.6%
N3 | accept | 77% (66/86) | 77% (66/86) | identical
N3 | t/s | 44.88 ± 0.07 | 44.55 ± 0.07 | -0.7%

##### Q2_K/Q3_K decode regression fix
Q2_K/Q3_K decode (N=14/32/128): no regression vs stock. Q2_K N=128 was -70% with intermediate build, fixed to -0.2% in final commit.

#### Perplexity Test
llama-perplexity 7B (wiki.test.raw): stock 7.9666, opt 7.9675 (+0.011%, limit 0.5%)
#### Test-backend-ops
test-backend-ops MUL_MAT: 1134/1134 passed (ROCm0 backend)

## Additional information
### Precision (vs stock golden, --check-ref)
| type | N=14 | N=128 | N=512 | N=2048 |
|------|------|-------|-------|--------|
| Q2_K | bit-exact | bit-exact | near 6.9e-5 | near 6.9e-5 |
| Q3_K | bit-exact | bit-exact | bit-exact | bit-exact |
| Q4_K | bit-exact | bit-exact | bit-exact | bit-exact |
| Q4_0 | bit-exact | bit-exact | bit-exact | bit-exact |
| Q5_K | bit-exact | bit-exact | bit-exact | bit-exact |
| Q5_0 | bit-exact | bit-exact | bit-exact | bit-exact |
| Q6_K | bit-exact | near 3.1e-5 | near 3.8e-5 | near 3.8e-5 |
| Q8_0 | bit-exact | bit-exact | bit-exact | bit-exact |

Summary: **27/32 BIT-EXACT**, **5/32 NEAR** (cos=1.0, argmax=1.0, abs&lt;1e-4). No FAIL.  
NEAR causes: Q6_K N&gt;=128 = fmaf epilogue; Q2_K N&gt;=512 = mmq_x=64 vs stock 128 reduction order.  

### Final mmq.cuh state (what's gated on type, RDNA4 only)
| Lever | Q6_K | Q2_K | Q3_K | Q4_K | Q4_0 | Q5_K | Q5_0 | Q8_0 | other |
|-------|------|------|------|------|------|------|------|------|-------|
| mmq_x_max | 64 | 64 | 128 | 128 | 128 | 128 | 128 | 128 | 128 |
| mmq_y | 64 | 128 | 128 | 128 | 128 | 128 | 128 | 128 | 128 |
| nwarps | 4 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 |
| A6 y1-prefetch | yes | no | no | no | yes | yes | yes | yes | yes |
| MMQ_UNROLL=8 | yes | no | no | no | no | no | no | no | no |
| N13 next-kb0 pf | yes | no | no | no | no | no | no | no | no |

### Levers to optimize this kernel (what changed)
#### Commit 1 (ff4c006e9): Q6_K tuning
- mmq_x_max=64, mmq_y=64, nwarps=4, MMQ_UNROLL=8 (stock WMMA 128/128/8/default)
- load_tiles_q6_K hot path: pointer-stride qs walk, packed 6-bit-in-byte LDS staging
- Y-pipe: prefetch second Y half into registers before load_tiles (A6 y1-prefetch)
- Next-kb block-pointer prefetch (Q6_K-only)
- Small-N decode: unroll k01 loop by 2 for mmq_x<=16
- Q6_K epilogue dispatch on mmq_x: small=stock mul+add (bit-exact), large=fmaf (fast)
#### Commit 2 (9f07b0d46): per-type geometry dispatch
- Gate RDNA4 64/64/4 geometry on type==Q6_K; all others keep stock 128/128/8
- A6 y1-prefetch gated on type != Q4_K (register pressure hurts Q4_K)
#### Commit 3 (fe2df7f34): Q3_K + Q2_K fix
- A6 gate tightened: type != Q4_K && type != Q3_K && type != Q2_K
  - Q3_K: scale-heavy K-quant, A6 register pressure regressed prefill -4.6% -> now +0.2%
  - Q2_K: A6 adds net overhead at both mmq_x=128 and 64, excluded
- Q2_K mmq_x_max: 128 -> 64 on RDNA4
  - Stock 128 was suboptimal for 2-bit dequant-bound kernel (only ~2 TFLOPS)
  - mmq_x=64 gives 3x more blocks, smaller per-block work -> ~6.5 TFLOPS (+237%)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES,  used agent with kernel optimization skills guided , all changes reviewed and understood by the contributor. Commit messages marked with Assisted-by: Cursor.