### PR TITLE
server: fix checkpoint handling for hybrid/recurrent models (#24055)

### DIFF
--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -170,7 +170,9 @@ void llama_memory_hybrid::seq_div(llama_seq_id seq_id, llama_pos p0, llama_pos p
 }
 
 llama_pos llama_memory_hybrid::seq_pos_min(llama_seq_id seq_id) const {
-    // the min of the total cache is the max of the two caches' min values
+    // the min of the total cache is the max of the two caches' min values.
+    // the recurrent state is valid only at its latest position, so the combined min must
+    // not report positions that the recurrent state cannot serve
     return std::max(mem_attn->seq_pos_min(seq_id), mem_recr->seq_pos_min(seq_id));
 }
 

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -186,6 +186,10 @@ bool llama_memory_recurrent::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos
                     cell.pos = p0 - 1;
                     return true;
                 }
+                // cannot roll back beyond the available snapshots - the caller has to
+                // restore a checkpoint or reprocess the sequence
+                LLAMA_LOG_DEBUG("%s: cannot roll back recurrent state of seq %d by %d tokens (n_rs_seq = %u)\n",
+                        __func__, (int) seq_id, (int) rollback, n_rs_seq);
                 return false;
             }
             // invalidate tails which will be cleared

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2282,6 +2282,13 @@ private:
         return true;
     }
 
+    // whether the memory state is valid only at its exact final position (hybrid/recurrent),
+    // as opposed to a range of positions (SWA)
+    bool ctx_tgt_state_exact() const {
+        return ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+               ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS;
+    }
+
     // n_tokens_cur: the number of tokens added to the batch for the current slot
     void create_checkpoint(server_slot & slot, const int64_t n_tokens_cur, llama_pos pos_min, llama_pos pos_max) {
         const int id_task = slot.task->id;
@@ -2290,6 +2297,8 @@ private:
         if (!slot.prompt.checkpoints.empty() &&
                 slot.prompt.checkpoints.back().n_tokens == slot.prompt.n_tokens() - n_tokens_cur &&
                 slot.prompt.checkpoints.back().pos_max == pos_max) {
+            // adopt the checkpoint so the min-step eviction below does not erase it
+            slot.prompt.checkpoints.back().id_task = id_task;
             return;
         }
 
@@ -2327,8 +2336,7 @@ private:
         // the state of hybrid/recurrent memory is valid only at its exact final position
         // TODO: for SWA models the saved range can still claim more than it actually covers:
         //       https://github.com/ggml-org/llama.cpp/pull/24411#issuecomment-4677983225
-        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-            ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS) {
+        if (ctx_tgt_state_exact()) {
             pos_min = pos_max;
         }
 
@@ -3296,18 +3304,10 @@ private:
                                     SLT_WRN(slot, "%s\n", st1.str().c_str());
                                 }
 
-                                // with enough per-token snapshots, the recurrent state can be rolled
-                                // back to pos_next directly and no checkpoint is needed
-                                const bool can_rollback =
-                                    ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS &&
-                                    pos_min < pos_min_thold + (llama_pos) llama_n_rs_seq(ctx_tgt);
-
-                                if (pos_min >= pos_min_thold && !can_rollback) {
+                                if (pos_min >= pos_min_thold) {
                                     // whether the checkpoints hold a state that is valid only at its exact
                                     // final position (hybrid/recurrent memory), as opposed to a range (SWA)
-                                    const bool ckpt_exact =
-                                        ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
-                                        ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS;
+                                    const bool ckpt_exact = ctx_tgt_state_exact();
 
                                     // search for a context checkpoint
                                     const auto it = std::find_if(
@@ -3318,8 +3318,10 @@ private:
                                             SLT_TRC(slot, "checking checkpoint with [%d, %d] against %d...\n", cur.pos_min, cur.pos_max, pos_min_thold);
                                             if (ckpt_exact) {
                                                 // usable only if the tokens up to and including its position are
-                                                // a prefix of the new prompt
-                                                return cur.pos_max < pos_min_thold;
+                                                // a prefix of the new prompt, with at least one token left to
+                                                // process [TAG_PROMPT_LOGITS]. the state is self-contained, so
+                                                // the SWA slack in pos_min_thold does not apply
+                                                return cur.pos_max < pos_next - (has_new_tokens ? 0 : 1);
                                             }
                                             // workaround for [TAG_CHECKPOINTS_FIX_POS_MIN]
                                             if (cur.pos_max > pos_next) {
@@ -3355,11 +3357,16 @@ private:
                             {
                                 // erase any checkpoints that cover diverged content - once the new
                                 // tokens are decoded, their staleness would become undetectable
-                                const llama_pos pos_stale = std::min(pos_next_lcp, (llama_pos) slot.task->n_tokens());
+                                const llama_pos pos_stale = std::min(pos_next_lcp, slot.task->tokens.pos_next());
+
+                                // an exact checkpoint at the divergence position irreversibly contains
+                                // the diverged token, while a range (SWA) checkpoint gets that entry
+                                // overwritten when decoding resumes from it
+                                const llama_pos pos_stale_min = ctx_tgt_state_exact() ? pos_stale : pos_stale + 1;
 
                                 for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end();) {
                                     const auto & cur = *it;
-                                    if (cur.pos_max > pos_next || cur.pos_max >= pos_stale) {
+                                    if (cur.pos_max > pos_next || cur.pos_max >= pos_stale_min) {
                                         SLT_INF(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
                                         it = slot.prompt.checkpoints.erase(it);
                                     } else {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2286,6 +2286,13 @@ private:
     void create_checkpoint(server_slot & slot, const int64_t n_tokens_cur, llama_pos pos_min, llama_pos pos_max) {
         const int id_task = slot.task->id;
 
+        // an equivalent checkpoint already exists (e.g. it was just restored)
+        if (!slot.prompt.checkpoints.empty() &&
+                slot.prompt.checkpoints.back().n_tokens == slot.prompt.n_tokens() - n_tokens_cur &&
+                slot.prompt.checkpoints.back().pos_max == pos_max) {
+            return;
+        }
+
         // evict checkpoints within min-step of a previous checkpoint, unless they were
         // created by the current task
         int64_t last = -1;
@@ -2317,8 +2324,14 @@ private:
         cur.id_task = id_task;
 
         // [TAG_CHECKPOINTS_FIX_POS_MIN]
-        // TODO: here we incorrectly deterimne that the saved checkpoint data covers the [pos_min, pos_max] range
-        //       this is not true for SWA models: https://github.com/ggml-org/llama.cpp/pull/24411#issuecomment-4677983225
+        // the state of hybrid/recurrent memory is valid only at its exact final position
+        // TODO: for SWA models the saved range can still claim more than it actually covers:
+        //       https://github.com/ggml-org/llama.cpp/pull/24411#issuecomment-4677983225
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+            ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS) {
+            pos_min = pos_max;
+        }
+
         cur.update_pos(slot.prompt.n_tokens() - n_tokens_cur, pos_min, pos_max);
 
         cur.update_tgt(ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
@@ -2326,7 +2339,7 @@ private:
         // stash the draft's speculative state with the checkpoint
         common_speculative_get_state(spec.get(), slot.id, cur.data_spec);
 
-        SLT_TRC(slot,
+        SLT_INF(slot,
                 "created context checkpoint %d of %d (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
                 (int) slot.prompt.checkpoints.size(), params_base.n_ctx_checkpoints, cur.pos_min,
                 cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024);
@@ -3223,6 +3236,10 @@ private:
 
                             llama_pos pos_next = slot.prompt.tokens.pos_next(n_past);
 
+                            // pos_next can be reduced below by a checkpoint restore - remember the
+                            // divergence point for the checkpoint invalidation
+                            const llama_pos pos_next_lcp = pos_next;
+
                             // ref: https://github.com/ggml-org/llama.cpp/pull/24110
                             const bool has_new_tokens = (n_past < slot.task->n_tokens());
 
@@ -3279,7 +3296,19 @@ private:
                                     SLT_WRN(slot, "%s\n", st1.str().c_str());
                                 }
 
-                                if (pos_min >= pos_min_thold) {
+                                // with enough per-token snapshots, the recurrent state can be rolled
+                                // back to pos_next directly and no checkpoint is needed
+                                const bool can_rollback =
+                                    ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS &&
+                                    pos_min < pos_min_thold + (llama_pos) llama_n_rs_seq(ctx_tgt);
+
+                                if (pos_min >= pos_min_thold && !can_rollback) {
+                                    // whether the checkpoints hold a state that is valid only at its exact
+                                    // final position (hybrid/recurrent memory), as opposed to a range (SWA)
+                                    const bool ckpt_exact =
+                                        ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+                                        ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS;
+
                                     // search for a context checkpoint
                                     const auto it = std::find_if(
                                         slot.prompt.checkpoints.rbegin(),
@@ -3287,6 +3316,11 @@ private:
                                         [&](const auto & cur) {
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             SLT_TRC(slot, "checking checkpoint with [%d, %d] against %d...\n", cur.pos_min, cur.pos_max, pos_min_thold);
+                                            if (ckpt_exact) {
+                                                // usable only if the tokens up to and including its position are
+                                                // a prefix of the new prompt
+                                                return cur.pos_max < pos_min_thold;
+                                            }
                                             // workaround for [TAG_CHECKPOINTS_FIX_POS_MIN]
                                             if (cur.pos_max > pos_next) {
                                                 return false;
@@ -3306,11 +3340,11 @@ private:
 
                                         pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));
                                         n_past   = std::min(slot.prompt.tokens.size_up_to_pos(pos_next), (size_t) it->n_tokens);
-                                        SLT_TRC(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
+                                        SLT_INF(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
                                     }
 
                                     if (do_reset) {
-                                        SLT_TRC(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
+                                        SLT_INF(slot, "forcing full prompt re-processing due to lack of cache data (likely due to SWA or hybrid/recurrent memory, see %s)\n",
                                                 "https://github.com/ggml-org/llama.cpp/pull/13194#issuecomment-2868343055");
                                         pos_next = 0;
                                         n_past = 0;
@@ -3319,11 +3353,14 @@ private:
                             }
 
                             {
-                                // erase any checkpoints with pos_max > pos_next
+                                // erase any checkpoints that cover diverged content - once the new
+                                // tokens are decoded, their staleness would become undetectable
+                                const llama_pos pos_stale = std::min(pos_next_lcp, (llama_pos) slot.task->n_tokens());
+
                                 for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end();) {
                                     const auto & cur = *it;
-                                    if (cur.pos_max > pos_next) {
-                                        SLT_TRC(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
+                                    if (cur.pos_max > pos_next || cur.pos_max >= pos_stale) {
+                                        SLT_INF(slot, "erased invalidated context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_swa = %d, pos_next = %d, size = %.3f MiB)\n", cur.pos_min, cur.pos_max, cur.n_tokens, n_swa, pos_next, (float) cur.size() / 1024 / 1024);
                                         it = slot.prompt.checkpoints.erase(it);
                                     } else {
                                         ++it;


### PR DESCRIPTION
## Overview
this is a reimplementation of #24797

That PR was rejected because it could reuse recurrent state at positions it
was never valid for (trimming checkpoint metadata in place, resetting rs_idx
when a rollback exceeds the available snapshots). This takes the opposite
approach and keeps the invariant intact: recurrent state is only ever
restored at the exact position it was saved at.

- checkpoint metadata records the actual validity at save time
  (`pos_min = pos_max` for hybrid/recurrent) instead of relying on what
  `seq_pos_min` happens to report - resolves `[TAG_CHECKPOINTS_FIX_POS_MIN]`
  for these model types
- a checkpoint is only restored when its exact position lies inside the
  common prefix of the new prompt
- checkpoints covering diverged content are erased instead of trimmed
- no changes to `llama_memory_hybrid` semantics; `seq_rm` still fails
  cleanly on impossible rollbacks (now with a debug log)

On top of that, the cache is made useful for agentic clients, which strip
the reasoning of the previous reply so the next request diverges right at
the end of the previous prompt:

- end-of-prompt checkpoints are exempt from `--checkpoint-min-step`
- eviction drops the checkpoint closest to its neighbor instead of the
  oldest one, so early anchors survive edited/compacted histories
- bounded `n_rs_seq` rollback is tried before the checkpoint search
- checkpoint create/restore/erase log at INFO

## Additional information

Related: #24055

Tested with Qwen3.6-35B-A3B Q4_K_M on Vulkan (RDNA3.5 APU). Resending
identical 22.8k-token request went from a ~96s full prefill to a 4-tok
cache hit. In a 10-turn agentic session normal turns only process the new
content, a mid-history edit correctly falls back to the last valid
checkpoint, and a compacted history restores an early checkpoint instead of
reprocessing everything. Correctness: at temperature 0 a checkpoint-restored
run produces byte-identical output to a fresh full prefill, and two
independent cold runs are byte-identical to each other.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Using Fable for rewriting my (ugly) implementation and creating the test cases based on my example workload. Also used it to translate my german pre written pull request to english and add the test results and more details in.