### PR TITLE
Webui bugfix for single-model mode usage

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ContextGaugeDetails.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ContextGaugeDetails.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { ChevronDown } from '@lucide/svelte';
+	import { persisted } from '$lib/stores/persisted.svelte';
 	import * as Collapsible from '$lib/components/ui/collapsible';
-	import { STATS_UNITS } from '$lib/constants';
+	import { STATS_UNITS, CONTEXT_GAUGE_DETAILS_OPEN_LOCALSTORAGE_KEY } from '$lib/constants';
 	import ContextGaugeDetailRow from './ContextGaugeDetailRow.svelte';
 
 	interface Props {
@@ -30,7 +31,11 @@
 		transientDetails
 	}: Props = $props();
 
-	let open = $state(false);
+	const detailsOpen = persisted<boolean>(CONTEXT_GAUGE_DETAILS_OPEN_LOCALSTORAGE_KEY, false);
+	let open = $state(detailsOpen.value);
+	$effect(() => {
+		detailsOpen.value = open;
+	});
 
 	const hasCumulative = $derived(cumulativeRead > 0 || cumulativeOutput > 0);
 	const hasCurrent = $derived(currentRead > 0 || currentOutput > 0);

--- a/tools/ui/src/lib/constants/storage.ts
+++ b/tools/ui/src/lib/constants/storage.ts
@@ -16,6 +16,7 @@ export const DB_APP_NAME_DEPRECATED = 'LlamacppWebui';
 
 export const ALWAYS_ALLOWED_TOOLS_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.alwaysAllowedTools`;
 export const CONFIG_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.config`;
+export const CONTEXT_GAUGE_DETAILS_OPEN_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.contextGaugeDetailsOpen`;
 export const DISABLED_TOOLS_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.disabledTools`;
 
 /** Disabled tools keyed by stable selection identity, no migration from the name based key */

--- a/tools/ui/src/lib/hooks/use-context-gauge.svelte.ts
+++ b/tools/ui/src/lib/hooks/use-context-gauge.svelte.ts
@@ -107,7 +107,7 @@ export function useContextGauge(): UseContextGaugeReturn {
 	});
 
 	const isActiveModelLoaded = $derived(
-		activeModelId !== null && modelsStore.isModelLoaded(activeModelId)
+		activeModelId !== null && (!isRouterMode() || modelsStore.isModelLoaded(activeModelId))
 	);
 
 	const isActiveModelLoading = $derived(


### PR DESCRIPTION
## Overview

Webui bugfix for single-model mode usage

## Additional information

In single-model (non-router) mode the server always has its model loaded and the /models/load endpoint does not exist. Current context gauge report the model as unloaded and showed a "Load model" button that will hit /models/load and errored.

See below:

<img width="3839" height="2159" alt="origin" src="https://github.com/user-attachments/assets/eb08d7c3-3d25-4354-a811-5c1e201f6619"/>
&nbsp;
<img width="3839" height="2159" alt="origin_1" src="https://github.com/user-attachments/assets/b928892f-bb74-4ded-812b-a0a2f74b29bb"/>

Cause: isModelLoaded only checks routerModels, which is empty when not in router mode, so isActiveModelLoaded always false there.

Fix: When not in router mode, treat as model loaded so the gauge hide the load prompt.

---

Second commit is to persist the context gauge "Token usage details" open state to browser local storage for better UX experience.
<img width="3839" height="2159" alt="fix" src="https://github.com/user-attachments/assets/02b0403d-9387-4cce-b020-aeed1b048c1b" />

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to help draft and refine the implementation.