### PR TITLE
grammar : reject inverted repetition range {m,n} (m>n)

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -461,6 +461,9 @@ const char * llama_grammar_parser::parse_sequence(
     // (though it's technically the same as -1 now)
     auto handle_repetitions = [&](uint64_t min_times, uint64_t max_times) {
         bool no_max = max_times == UINT64_MAX;
+        if (!no_max && max_times < min_times) {
+            throw std::runtime_error("invalid repetition range: max < min");
+        }
         if (last_sym_start == rule.size()) {
             throw std::runtime_error(std::string("expecting preceding item to */+/?/{ at ") + pos);
         }


### PR DESCRIPTION
## Overview

`handle_repetitions` in `llama_grammar_parser::parse_sequence` computes the optional-repetition count as an unsigned subtraction:

```cpp
auto n_opt = no_max ? 1 : max_times - min_times;   // both uint64_t
for (uint64_t i = 0; i < n_opt; i++) { ...; add_rule(...); }
```

For an inverted range like `{2,1}` (min=2, max=1), `max_times - min_times` underflows to ~1.8e19, so the loop appends rules until the process is OOM-killed. The existing `MAX_REPETITION_THRESHOLD` guard does not catch this, because it is computed from `total_rules = max_times` (which is `1` here), not from the underflowed `n_opt`.

Because `grammar` is accepted from untrusted request bodies by `llama-server` (`/completion`, and the `json_schema`→grammar path of `/v1/chat/completions`), this is a remote, unauthenticated DoS.

This PR rejects `max_times < min_times` before expansion; `parse()` already catches `std::runtime_error` and returns a clean parse failure.

## Additional information

Minimal PoC (18 bytes):

```
root ::= "a"{2,1}
```

→ unbounded memory growth (libFuzzer OOM over `llama_grammar_parser::parse`). Found on `master` via libFuzzer + ASan.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — the bug was found via libFuzzer + AddressSanitizer fuzzing of `llama_grammar_parser::parse`; the one-line fix and the PoC were drafted with the help of an AI coding assistant and reviewed/verified by me. I am responsible for all submitted changes.
