### PR TITLE
common : use-after-free when loading LoRA adapter fails

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1249,7 +1249,6 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
         lora.reset(llama_adapter_lora_init(model, la.path.c_str()));
         if (lora == nullptr) {
             COM_ERR("failed to load lora adapter '%s'\n", la.path.c_str());
-            pimpl->model.reset(model);
             return;
         }
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Loading an invalid LoRA adapter causes a use-after-free in llama-server and llama-completion.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

To reproduce:

```
echo "BAD!" > bad.gguf
llama-server -hf ggml-org/models-moved --lora bad.gguf
llama-completion -hf ggml-org/models-moved --lora bad.gguf
```
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
