### PR TITLE
tests: export-graph-ops: exit gracefully when called w/o arguments

### DIFF
--- a/tests/test-export-graph-ops.cpp
+++ b/tests/test-export-graph-ops.cpp
@@ -152,6 +152,10 @@ int main(int argc, char ** argv) {
         init_result = common_init_from_params(params);
 
         ctx = init_result->context();
+        if (!ctx) {
+            LOG_ERR("failed to initialize params\n");
+            return 1;
+        }
     } else {
 #ifdef LLAMA_HF_FETCH
         auto [hf_repo, hf_quant] = common_download_split_repo_tag(params.model.hf_repo);


### PR DESCRIPTION
## Overview

Fixes a segfault when `test-export-graph-ops` is called without any arguments.

```shell
$ build/bin/test-export-graph-ops
Segmentation fault         build/bin/test-export-graph-ops
```

## Additional information

The segfault also races with the logging output, sometimes the cause (missing parameter) is not logged. Discovered after the initial report.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO