### PR TITLE
CUDA: XOR swizzle flash attn  K,V smem fp16 tiles

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -2,6 +2,7 @@
 #include "cp-async.cuh"
 #include "mma.cuh"
 #include "fattn-common.cuh"
+#include "fattn-swizzle.cuh"
 
 using namespace ggml_cuda_mma;
 
@@ -66,7 +67,7 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(192, 128, 32, 128, 2,  32,  96,  64,  64, 2, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(192, 128, 64, 128, 2,  32,  96,  64,  64, 2, true);
 
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256,  8,  64, 4,  64, 128, 128, 128, 2, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256,  8, 128, 2,  64, 128, 128, 128, 2, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 16,  64, 4,  32, 128, 128, 128, 2, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 32, 128, 2,  32, 128, 128, 128, 2, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 128, 2,  32, 128, 128, 128, 2, true);
@@ -397,7 +398,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                 for (int k0 = k0_start; k0 < k0_stop; k0 += stride_k) {
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
-                    cp_async_cg_16<preload>(tile_KV_32 + i*(stride_tile*sizeof(half2)) + k*16, KV + i*stride_KV + k*h2_per_chunk);
+                    const int smem_offs_b = ggml_cuda_fattn_swz_bytes_rc<stride_tile>(i, k*h2_per_chunk);
+                    cp_async_cg_16<preload>(tile_KV_32 + smem_offs_b, KV + i*stride_KV + k*h2_per_chunk);
                 }
             }
         };
@@ -432,7 +434,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                 for (int k0 = k0_start; k0 < k0_stop; k0 += stride_k) {
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
-                    ggml_cuda_memcpy_1<16>(tile_KV + i*stride_tile + k*4,
+                    ggml_cuda_memcpy_1<16>((char*)tile_KV + ggml_cuda_fattn_swz_bytes_rc<stride_tile>(i, k*h2_per_chunk),
                         !oob_check || i < i_sup ? KV + i*stride_KV + k*h2_per_chunk : zero);
                 }
             }
@@ -568,9 +570,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
     constexpr bool Q_in_reg        = ggml_cuda_fattn_mma_get_Q_in_reg (DKQ, DV, ncols);
     constexpr int  nstages         = ggml_cuda_fattn_mma_get_nstages  (DKQ, DV, ncols1, ncols2);
 
-    constexpr int stride_tile_K = nbatch_K2 + 4;
-
-    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : nbatch_V2 + 4;
+    // swizzle the tile stride for K and V based on the batch size.
+    constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
+    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
 
     const int k_VKQ_0 = kb0 * nbatch_fa;
 #if defined(TURING_MMA_AVAILABLE)
@@ -623,7 +625,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #pragma unroll
                 for (int k_KQ_0 = k0_start; k_KQ_0 < k0_stop; k_KQ_0 += T_A_KQ::J) {
                     T_A_KQ K_A;
-                    load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K>(
+                        K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[k_KQ_0/T_A_KQ::J]);
                     } else {
@@ -649,7 +652,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                     const int i_KQ_0 = i_KQ_00 + (threadIdx.y % np)*T_A_KQ::I;
 
                     T_A_KQ K_A;
-                    load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K>(
+                        K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
 
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[0]);
@@ -978,7 +982,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::J;
 
                 T_A_VKQ A; // Transposed in SRAM but not in registers, gets transposed on load.
-                load_ldmatrix_trans(A, tile_V_i + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
+                const int v_lin = (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
+                ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<T_A_VKQ, stride_tile_V>(
+                    A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
                 if constexpr (T_B_KQ::I == 8) {
                     mma(VKQ_C[i_VKQ_0/T_A_VKQ::I], A, B[k00/(np*T_A_VKQ::J)]);
                 } else {
@@ -1004,7 +1010,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::I;
 
                 T_A_VKQ A; // Transposed in both SRAM and registers, load normally.
-                load_ldmatrix(A, tile_V_i + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
+                const int v_lin = (int)(tile_V_i - tile_V) + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
+                ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_VKQ, stride_tile_V>(
+                    A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
                 mma(VKQ_C[i_VKQ_0/i0_stride], B[k00/(np*T_A_VKQ::I)], A);
             }
         }
@@ -1168,9 +1176,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
     static_assert(nwarps * (cols_per_warp/ncols2) % ncols1 == 0, "bad nwarps");
 
     constexpr int stride_tile_Q = DKQ/2     + 4;
-    constexpr int stride_tile_K = nbatch_K2 + 4;
-
-    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : nbatch_V2 + 4;
+    // swizzle the tile stride for K and V based on the batch size.
+    constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
+    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
     constexpr int stride_tile_KV_max = stride_tile_K > stride_tile_V ? stride_tile_K : stride_tile_V;
 
     extern __shared__ half2 tile_Q[];
@@ -1914,8 +1922,11 @@ void ggml_cuda_flash_attn_ext_mma_f16_case(ggml_backend_cuda_context & ctx, ggml
 
     constexpr bool V_is_K_view = DKQ == 576; // Guaranteed by the kernel selection logic in fattn.cu
 
-    const size_t nbytes_shared_KV_1stage = nbatch_fa            * std::max(nbatch_K2 + 4,  nbatch_V2 + 4) * sizeof(half2);
-    const size_t nbytes_shared_KV_2stage = nbatch_fa            *         (nbatch_K2 + 4 + nbatch_V2 + 4) * sizeof(half2);
+    // KV tile strides must match flash_attn_ext_f16_iter / _process_tile.
+    const int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2, cc);
+    const int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2, cc);
+    const size_t nbytes_shared_KV_1stage = nbatch_fa            * std::max(stride_tile_K,  stride_tile_V) * sizeof(half2);
+    const size_t nbytes_shared_KV_2stage = nbatch_fa            *         (stride_tile_K + stride_tile_V) * sizeof(half2);
     const size_t nbytes_shared_Q         = ncols                * (DKQ/2 + 4)                             * sizeof(half2);
     const size_t nbytes_shared_mask      = ncols1               * (nbatch_fa/2 + 4)                       * sizeof(half2);
     const size_t nbytes_shared_combine   = nwarps*cols_per_warp * (nbatch_combine + 4)                    * sizeof(half2);

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -398,8 +398,13 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                 for (int k0 = k0_start; k0 < k0_stop; k0 += stride_k) {
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
-                    const int smem_offs_b = ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk);
-                    cp_async_cg_16<preload>(tile_KV_32 + smem_offs_b, KV + i*stride_KV + k*h2_per_chunk);
+                    if constexpr (swz) {
+                        const int smem_offs_b = ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk);
+                        cp_async_cg_16<preload>(tile_KV_32 + smem_offs_b, KV + i*stride_KV + k*h2_per_chunk);
+                    } else {
+                        cp_async_cg_16<preload>(
+                            tile_KV_32 + i*(stride_tile*sizeof(half2)) + k*16, KV + i*stride_KV + k*h2_per_chunk);
+                    }
                 }
             }
         };
@@ -434,8 +439,15 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                 for (int k0 = k0_start; k0 < k0_stop; k0 += stride_k) {
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
-                    ggml_cuda_memcpy_1<16>((char*)tile_KV + ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk),
-                        !oob_check || i < i_sup ? KV + i*stride_KV + k*h2_per_chunk : zero);
+                    if constexpr (swz) {
+                        ggml_cuda_memcpy_1<16>(
+                            (char *) tile_KV + ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk),
+                            !oob_check || i < i_sup ? KV + i*stride_KV + k*h2_per_chunk : zero);
+                    } else {
+                        ggml_cuda_memcpy_1<16>(
+                            tile_KV + i*stride_tile + k*4,
+                            !oob_check || i < i_sup ? KV + i*stride_KV + k*h2_per_chunk : zero);
+                    }
                 }
             }
         };
@@ -984,9 +996,14 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::J;
 
                 T_A_VKQ A; // Transposed in SRAM but not in registers, gets transposed on load.
-                const int v_lin = (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<T_A_VKQ, stride_tile_V, swz_V>(
-                    A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
+                if constexpr (swz_V) {
+                    const int v_lin = (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<T_A_VKQ, stride_tile_V, swz_V>(
+                        A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
+                } else {
+                    load_ldmatrix_trans(
+                        A, tile_V_i + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
+                }
                 if constexpr (T_B_KQ::I == 8) {
                     mma(VKQ_C[i_VKQ_0/T_A_VKQ::I], A, B[k00/(np*T_A_VKQ::J)]);
                 } else {
@@ -1012,9 +1029,13 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::I;
 
                 T_A_VKQ A; // Transposed in both SRAM and registers, load normally.
-                const int v_lin = (int)(tile_V_i - tile_V) + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_VKQ, stride_tile_V, swz_V>(
-                    A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
+                if constexpr (swz_V) {
+                    const int v_lin = (int)(tile_V_i - tile_V) + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_VKQ, stride_tile_V, swz_V>(
+                        A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
+                } else {
+                    load_ldmatrix(A, tile_V_i + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
+                }
                 mma(VKQ_C[i_VKQ_0/i0_stride], B[k00/(np*T_A_VKQ::I)], A);
             }
         }

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -399,11 +399,10 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
                     if constexpr (swz) {
-                        const int smem_offs_b = ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk);
+                        const int smem_offs_b = ggml_cuda_fattn_smem_swizzle::bytes_rc<stride_tile>(i, k*h2_per_chunk);
                         cp_async_cg_16<preload>(tile_KV_32 + smem_offs_b, KV + i*stride_KV + k*h2_per_chunk);
                     } else {
-                        cp_async_cg_16<preload>(
-                            tile_KV_32 + i*(stride_tile*sizeof(half2)) + k*16, KV + i*stride_KV + k*h2_per_chunk);
+                        cp_async_cg_16<preload>(tile_KV_32 + i*(stride_tile*sizeof(half2)) + k*16, KV + i*stride_KV + k*h2_per_chunk);
                     }
                 }
             }
@@ -440,12 +439,10 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
                     if constexpr (swz) {
-                        ggml_cuda_memcpy_1<16>(
-                            (char *) tile_KV + ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk),
+                        ggml_cuda_memcpy_1<16>((char *) tile_KV + ggml_cuda_fattn_smem_swizzle::bytes_rc<stride_tile>(i, k*h2_per_chunk),
                             !oob_check || i < i_sup ? KV + i*stride_KV + k*h2_per_chunk : zero);
                     } else {
-                        ggml_cuda_memcpy_1<16>(
-                            tile_KV + i*stride_tile + k*4,
+                        ggml_cuda_memcpy_1<16>(tile_KV + i*stride_tile + k*4,
                             !oob_check || i < i_sup ? KV + i*stride_KV + k*h2_per_chunk : zero);
                     }
                 }
@@ -583,10 +580,10 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
     constexpr int  nstages         = ggml_cuda_fattn_mma_get_nstages  (DKQ, DV, ncols1, ncols2);
 
     // swizzle the tile stride for K and V based on the batch size.
-    constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
-    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
-    constexpr bool swz_K = ggml_cuda_fattn_swz_enabled(nbatch_K2);
-    constexpr bool swz_V = V_is_K_view ? swz_K : ggml_cuda_fattn_swz_enabled(nbatch_V2);
+    constexpr int stride_tile_K = ggml_cuda_fattn_smem_swizzle::tile_stride(nbatch_K2);
+    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_smem_swizzle::tile_stride(nbatch_V2);
+    constexpr bool swz_K = ggml_cuda_fattn_smem_swizzle::enabled(nbatch_K2);
+    constexpr bool swz_V = V_is_K_view ? swz_K : ggml_cuda_fattn_smem_swizzle::enabled(nbatch_V2);
 
     const int k_VKQ_0 = kb0 * nbatch_fa;
 #if defined(TURING_MMA_AVAILABLE)
@@ -639,8 +636,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #pragma unroll
                 for (int k_KQ_0 = k0_start; k_KQ_0 < k0_stop; k_KQ_0 += T_A_KQ::J) {
                     T_A_KQ K_A;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K, swz_K>(
-                        K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
+                    if constexpr (swz_K) {
+                        ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
+                    } else {
+                        load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
+                    }
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[k_KQ_0/T_A_KQ::J]);
                     } else {
@@ -666,8 +666,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                     const int i_KQ_0 = i_KQ_00 + (threadIdx.y % np)*T_A_KQ::I;
 
                     T_A_KQ K_A;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K, swz_K>(
-                        K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
+                    if constexpr (swz_K) {
+                        ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
+                    } else {
+                        load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
+                    }
 
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[0]);
@@ -998,11 +1001,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 T_A_VKQ A; // Transposed in SRAM but not in registers, gets transposed on load.
                 if constexpr (swz_V) {
                     const int v_lin = (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<T_A_VKQ, stride_tile_V, swz_V>(
-                        A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<stride_tile_V>(A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
                 } else {
-                    load_ldmatrix_trans(
-                        A, tile_V_i + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
+                    load_ldmatrix_trans(A, tile_V_i + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
                 }
                 if constexpr (T_B_KQ::I == 8) {
                     mma(VKQ_C[i_VKQ_0/T_A_VKQ::I], A, B[k00/(np*T_A_VKQ::J)]);
@@ -1031,8 +1032,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 T_A_VKQ A; // Transposed in both SRAM and registers, load normally.
                 if constexpr (swz_V) {
                     const int v_lin = (int)(tile_V_i - tile_V) + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_VKQ, stride_tile_V, swz_V>(
-                        A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_V>(A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
                 } else {
                     load_ldmatrix(A, tile_V_i + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
                 }
@@ -1200,11 +1200,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
 
     constexpr int stride_tile_Q = DKQ/2     + 4;
     // swizzle the tile stride for K and V based on the batch size.
-    constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
-    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
+    constexpr int stride_tile_K = ggml_cuda_fattn_smem_swizzle::tile_stride(nbatch_K2);
+    constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_smem_swizzle::tile_stride(nbatch_V2);
     constexpr int stride_tile_KV_max = stride_tile_K > stride_tile_V ? stride_tile_K : stride_tile_V;
-    constexpr bool swz_K = ggml_cuda_fattn_swz_enabled(nbatch_K2);
-    constexpr bool swz_V = V_is_K_view ? swz_K : ggml_cuda_fattn_swz_enabled(nbatch_V2);
+    constexpr bool swz_K = ggml_cuda_fattn_smem_swizzle::enabled(nbatch_K2);
+    constexpr bool swz_V = V_is_K_view ? swz_K : ggml_cuda_fattn_smem_swizzle::enabled(nbatch_V2);
 
     extern __shared__ half2 tile_Q[];
     half2 * tile_K    = Q_in_reg              ? tile_Q                             : tile_Q + ncols     * stride_tile_Q;
@@ -1958,8 +1958,8 @@ void ggml_cuda_flash_attn_ext_mma_f16_case(ggml_backend_cuda_context & ctx, ggml
     constexpr bool V_is_K_view = DKQ == 576; // Guaranteed by the kernel selection logic in fattn.cu
 
     // KV tile strides must match flash_attn_ext_f16_iter / _process_tile.
-    const int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2, cc);
-    const int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2, cc);
+    const int stride_tile_K = ggml_cuda_fattn_smem_swizzle::tile_stride(nbatch_K2, cc);
+    const int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_smem_swizzle::tile_stride(nbatch_V2, cc);
     const size_t nbytes_shared_KV_1stage = nbatch_fa            * std::max(stride_tile_K,  stride_tile_V) * sizeof(half2);
     const size_t nbytes_shared_KV_2stage = nbatch_fa            *         (stride_tile_K + stride_tile_V) * sizeof(half2);
     const size_t nbytes_shared_Q         = ncols                * (DKQ/2 + 4)                             * sizeof(half2);

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -361,7 +361,7 @@ static constexpr __device__ int ggml_cuda_fattn_mma_get_nstages(const int DKQ, c
 
 // ------------------------------------------------------------------------------------------------------------------
 
-template<int stride_tile, int nwarps, int nbatch_fa, bool use_cp_async, bool oob_check>
+template<int stride_tile, bool swz, int nwarps, int nbatch_fa, bool use_cp_async, bool oob_check>
 static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
         const half2 * const __restrict__ KV, half2 * const __restrict__ tile_KV, const int D2, const int stride_KV, const int i_sup) {
     constexpr int warp_size = ggml_cuda_get_physical_warp_size();
@@ -398,7 +398,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                 for (int k0 = k0_start; k0 < k0_stop; k0 += stride_k) {
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
-                    const int smem_offs_b = ggml_cuda_fattn_swz_bytes_rc<stride_tile>(i, k*h2_per_chunk);
+                    const int smem_offs_b = ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk);
                     cp_async_cg_16<preload>(tile_KV_32 + smem_offs_b, KV + i*stride_KV + k*h2_per_chunk);
                 }
             }
@@ -434,7 +434,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_load_tile(
                 for (int k0 = k0_start; k0 < k0_stop; k0 += stride_k) {
                     const int k = k0 + (stride_k == warp_size ? threadIdx.x : threadIdx.x % stride_k);
 
-                    ggml_cuda_memcpy_1<16>((char*)tile_KV + ggml_cuda_fattn_swz_bytes_rc<stride_tile>(i, k*h2_per_chunk),
+                    ggml_cuda_memcpy_1<16>((char*)tile_KV + ggml_cuda_fattn_swz_bytes_rc<stride_tile, swz>(i, k*h2_per_chunk),
                         !oob_check || i < i_sup ? KV + i*stride_KV + k*h2_per_chunk : zero);
                 }
             }
@@ -571,6 +571,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
     constexpr int  nstages         = ggml_cuda_fattn_mma_get_nstages  (DKQ, DV, ncols1, ncols2);
 
     // swizzle the tile stride for K and V based on the batch size.
+    constexpr bool swz_K        = ggml_cuda_fattn_swz_enabled(nbatch_K2);
+    constexpr bool swz_V        = V_is_K_view ? swz_K        : ggml_cuda_fattn_swz_enabled(nbatch_V2);
     constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
     constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
 
@@ -590,7 +592,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         constexpr bool use_cp_async = true;
         cp_async_wait_all();
         __syncthreads();
-        flash_attn_ext_f16_load_tile<stride_tile_V, nwarps, nbatch_fa, use_cp_async, oob_check>
+        flash_attn_ext_f16_load_tile<stride_tile_V, swz_V, nwarps, nbatch_fa, use_cp_async, oob_check>
             (V_h2 + int64_t(k_VKQ_0)*stride_V, tile_V, nbatch_V2, stride_V, k_VKQ_sup);
     } else {
         constexpr bool use_cp_async = nstages == 1;
@@ -609,7 +611,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         if constexpr (nstages <= 1) {
             const int k0_diff = k0_stop - k0_start;
             constexpr bool use_cp_async = nstages == 1;
-            flash_attn_ext_f16_load_tile<stride_tile_K, nwarps, nbatch_fa, use_cp_async, oob_check>
+            flash_attn_ext_f16_load_tile<stride_tile_K, swz_K, nwarps, nbatch_fa, use_cp_async, oob_check>
                 (K_h2 + int64_t(k_VKQ_0)*stride_K + k0_start, tile_K, k0_diff, stride_K, k_VKQ_sup);
             if (use_cp_async) {
                 cp_async_wait_all();
@@ -625,7 +627,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #pragma unroll
                 for (int k_KQ_0 = k0_start; k_KQ_0 < k0_stop; k_KQ_0 += T_A_KQ::J) {
                     T_A_KQ K_A;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K>(
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K, swz_K>(
                         K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[k_KQ_0/T_A_KQ::J]);
@@ -652,7 +654,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                     const int i_KQ_0 = i_KQ_00 + (threadIdx.y % np)*T_A_KQ::I;
 
                     T_A_KQ K_A;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K>(
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_KQ, stride_tile_K, swz_K>(
                         K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
 
                     if constexpr (cols_per_warp == 8) {
@@ -947,7 +949,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 flash_attn_ext_f16_load_mask<ncols1, nwarps, nbatch_fa, use_cp_async, oob_check>
                     (mask_h + k_VKQ_0 + nbatch_fa, tile_mask, stride_mask, k_VKQ_sup, jt*ncols1, ne01);
             }
-            flash_attn_ext_f16_load_tile<stride_tile_K, nwarps, nbatch_fa, use_cp_async, oob_check>
+            flash_attn_ext_f16_load_tile<stride_tile_K, swz_K, nwarps, nbatch_fa, use_cp_async, oob_check>
                 (K_h2 + int64_t(k_VKQ_0 + nbatch_fa)*stride_K, tile_K, nbatch_K2, stride_K, k_VKQ_sup);
         }
     }
@@ -963,7 +965,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
             const int i0_diff = i0_stop - i0_start;
             if (!V_is_K_view || i0_stop > 2*nbatch_K2) {
                 constexpr bool use_cp_async = nstages == 1;
-                flash_attn_ext_f16_load_tile<stride_tile_V, nwarps, nbatch_fa, use_cp_async, oob_check>
+                flash_attn_ext_f16_load_tile<stride_tile_V, swz_V, nwarps, nbatch_fa, use_cp_async, oob_check>
                     (V_h2 + int64_t(k_VKQ_0)*stride_V + i0_start/2, tile_V, i0_diff/2, stride_V, k_VKQ_sup);
                 if (use_cp_async) {
                     cp_async_wait_all();
@@ -983,7 +985,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
                 T_A_VKQ A; // Transposed in SRAM but not in registers, gets transposed on load.
                 const int v_lin = (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<T_A_VKQ, stride_tile_V>(
+                ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<T_A_VKQ, stride_tile_V, swz_V>(
                     A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
                 if constexpr (T_B_KQ::I == 8) {
                     mma(VKQ_C[i_VKQ_0/T_A_VKQ::I], A, B[k00/(np*T_A_VKQ::J)]);
@@ -1011,7 +1013,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
                 T_A_VKQ A; // Transposed in both SRAM and registers, load normally.
                 const int v_lin = (int)(tile_V_i - tile_V) + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_VKQ, stride_tile_V>(
+                ggml_cuda_fattn_smem_swizzle::load_ldmatrix<T_A_VKQ, stride_tile_V, swz_V>(
                     A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
                 mma(VKQ_C[i_VKQ_0/i0_stride], B[k00/(np*T_A_VKQ::I)], A);
             }
@@ -1177,6 +1179,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
 
     constexpr int stride_tile_Q = DKQ/2     + 4;
     // swizzle the tile stride for K and V based on the batch size.
+    constexpr bool swz_K        = ggml_cuda_fattn_swz_enabled(nbatch_K2);
     constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
     constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
     constexpr int stride_tile_KV_max = stride_tile_K > stride_tile_V ? stride_tile_K : stride_tile_V;
@@ -1273,7 +1276,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
             flash_attn_ext_f16_load_mask<ncols1, nwarps, nbatch_fa, use_cp_async, oob_check>
                 (mask_h + kb0*nbatch_fa, tile_mask, stride_mask, k_VKQ_sup, jt*ncols1, ne01);
         }
-        flash_attn_ext_f16_load_tile<stride_tile_K, nwarps, nbatch_fa, use_cp_async, oob_check>
+        flash_attn_ext_f16_load_tile<stride_tile_K, swz_K, nwarps, nbatch_fa, use_cp_async, oob_check>
             (K_h2 + int64_t(kb0)*nbatch_fa*stride_K, tile_K, nbatch_K2, stride_K, k_VKQ_sup);
     }
 

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -571,10 +571,10 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
     constexpr int  nstages         = ggml_cuda_fattn_mma_get_nstages  (DKQ, DV, ncols1, ncols2);
 
     // swizzle the tile stride for K and V based on the batch size.
-    constexpr bool swz_K        = ggml_cuda_fattn_swz_enabled(nbatch_K2);
-    constexpr bool swz_V        = V_is_K_view ? swz_K        : ggml_cuda_fattn_swz_enabled(nbatch_V2);
     constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
     constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
+    constexpr bool swz_K = ggml_cuda_fattn_swz_enabled(nbatch_K2);
+    constexpr bool swz_V = V_is_K_view ? swz_K : ggml_cuda_fattn_swz_enabled(nbatch_V2);
 
     const int k_VKQ_0 = kb0 * nbatch_fa;
 #if defined(TURING_MMA_AVAILABLE)
@@ -1179,10 +1179,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
 
     constexpr int stride_tile_Q = DKQ/2     + 4;
     // swizzle the tile stride for K and V based on the batch size.
-    constexpr bool swz_K        = ggml_cuda_fattn_swz_enabled(nbatch_K2);
     constexpr int stride_tile_K = ggml_cuda_fattn_swz_tile_stride(nbatch_K2);
     constexpr int stride_tile_V = V_is_K_view ? stride_tile_K : ggml_cuda_fattn_swz_tile_stride(nbatch_V2);
     constexpr int stride_tile_KV_max = stride_tile_K > stride_tile_V ? stride_tile_K : stride_tile_V;
+    constexpr bool swz_K = ggml_cuda_fattn_swz_enabled(nbatch_K2);
+    constexpr bool swz_V = V_is_K_view ? swz_K : ggml_cuda_fattn_swz_enabled(nbatch_V2);
 
     extern __shared__ half2 tile_Q[];
     half2 * tile_K    = Q_in_reg              ? tile_Q                             : tile_Q + ncols     * stride_tile_Q;
@@ -1441,12 +1442,16 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
     constexpr int tile_stride = nbatch_combine + 4;
     static_assert((DV/2) % nbatch_combine == 0, "bad nbatch_combine");
 
+    constexpr bool combine_needs_sync = swz_K || swz_V;
+
     if constexpr (cols_per_warp == 8) {
         const int jc_cwmo = (threadIdx.x % (2*T_C_VKQ::J)) / T_C_VKQ::J; // jc combine write meta offset
         const int jc_cwm = threadIdx.y*(2*T_C_VKQ::J) + 2*T_C_VKQ::get_j(-1) + jc_cwmo; // jc combine write meta
         const float2 KQ_cmr = make_float2(KQ_max[jc_cwmo], KQ_rowsum[jc_cwmo]); // KQ combine max rowsum
 
-        __syncthreads();
+        if constexpr (combine_needs_sync) {
+            __syncthreads();
+        }
 
         if (((!needs_fixup && !is_fixup) || np > 1) && threadIdx.x < 2*T_C_VKQ::J) {
             // Use the 16 bytes of padding in each row to store the meta data: KQ max, KQ rowsum, KQ max scale.
@@ -1484,7 +1489,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
         const bool thread_should_write = T_C_KQ::J == 8 || T_C_KQ::get_j(threadIdx.x & 2) < 8;
 #endif // defined(TURING_MMA_AVAILABLE)
 
-        __syncthreads();
+        if constexpr (combine_needs_sync) {
+            __syncthreads();
+        }
 
         if (((!needs_fixup && !is_fixup) || np > 1) && thread_should_write) {
             ((float2 *) tile_Q)[jc_cwm*(tile_stride/2) + nbatch_combine/2] = KQ_cmr;

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1443,6 +1443,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
         const int jc_cwm = threadIdx.y*(2*T_C_VKQ::J) + 2*T_C_VKQ::get_j(-1) + jc_cwmo; // jc combine write meta
         const float2 KQ_cmr = make_float2(KQ_max[jc_cwmo], KQ_rowsum[jc_cwmo]); // KQ combine max rowsum
 
+        __syncthreads();
+
         if (((!needs_fixup && !is_fixup) || np > 1) && threadIdx.x < 2*T_C_VKQ::J) {
             // Use the 16 bytes of padding in each row to store the meta data: KQ max, KQ rowsum, KQ max scale.
             ((float2 *) tile_Q)[jc_cwm*(tile_stride/2) + nbatch_combine/2] = KQ_cmr;
@@ -1478,6 +1480,8 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
         const float2 KQ_cmr = make_float2(KQ_max[(threadIdx.x & 2) / 2], KQ_rowsum[(threadIdx.x & 2) / 2]);
         const bool thread_should_write = T_C_KQ::J == 8 || T_C_KQ::get_j(threadIdx.x & 2) < 8;
 #endif // defined(TURING_MMA_AVAILABLE)
+
+        __syncthreads();
 
         if (((!needs_fixup && !is_fixup) || np > 1) && thread_should_write) {
             ((float2 *) tile_Q)[jc_cwm*(tile_stride/2) + nbatch_combine/2] = KQ_cmr;

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -636,11 +636,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #pragma unroll
                 for (int k_KQ_0 = k0_start; k_KQ_0 < k0_stop; k_KQ_0 += T_A_KQ::J) {
                     T_A_KQ K_A;
-                    if constexpr (swz_K) {
-                        ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
-                    } else {
-                        load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
-                    }
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K, swz_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[k_KQ_0/T_A_KQ::J]);
                     } else {
@@ -666,11 +662,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                     const int i_KQ_0 = i_KQ_00 + (threadIdx.y % np)*T_A_KQ::I;
 
                     T_A_KQ K_A;
-                    if constexpr (swz_K) {
-                        ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
-                    } else {
-                        load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
-                    }
+                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K, swz_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
 
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[0]);
@@ -999,12 +991,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::J;
 
                 T_A_VKQ A; // Transposed in SRAM but not in registers, gets transposed on load.
-                if constexpr (swz_V) {
-                    const int v_lin = (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<stride_tile_V>(A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
-                } else {
-                    load_ldmatrix_trans(A, tile_V_i + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
-                }
+                ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<stride_tile_V, swz_V>(A, tile_V, (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2);
                 if constexpr (T_B_KQ::I == 8) {
                     mma(VKQ_C[i_VKQ_0/T_A_VKQ::I], A, B[k00/(np*T_A_VKQ::J)]);
                 } else {
@@ -1030,12 +1017,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::I;
 
                 T_A_VKQ A; // Transposed in both SRAM and registers, load normally.
-                if constexpr (swz_V) {
-                    const int v_lin = (int)(tile_V_i - tile_V) + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2;
-                    ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_V>(A, tile_V, v_lin / stride_tile_V, v_lin % stride_tile_V);
-                } else {
-                    load_ldmatrix(A, tile_V_i + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
-                }
+                ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_V, swz_V>(A, tile_V, (int)(tile_V_i - tile_V) + k0*stride_tile_V + (i_VKQ_0 - i0_start)/2);
                 mma(VKQ_C[i_VKQ_0/i0_stride], B[k00/(np*T_A_VKQ::I)], A);
             }
         }

--- a/ggml/src/ggml-cuda/fattn-swizzle.cuh
+++ b/ggml/src/ggml-cuda/fattn-swizzle.cuh
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "common.cuh"
+#include "mma.cuh"
+
+// XOR swizzle for K/V SMEM tiles to avoid bank conflicts without row padding (Turing+ only).
+// Stride must be a power-of-two >= 32 half2 columns,otherwise we keep +4 row padding.
+
+static __host__ __device__ constexpr bool ggml_cuda_fattn_swz_pow2_stride(const int nbatch_2) {
+    return nbatch_2 >= 32 && (nbatch_2 & (nbatch_2 - 1)) == 0;
+}
+
+static __device__ constexpr bool ggml_cuda_fattn_swz_enabled(const int nbatch_2) {
+#if defined(TURING_MMA_AVAILABLE)
+    return ggml_cuda_fattn_swz_pow2_stride(nbatch_2);
+#else
+    GGML_UNUSED(nbatch_2);
+    return false;
+#endif
+}
+
+static __host__ bool ggml_cuda_fattn_swz_enabled(const int nbatch_2, const int cc) {
+#ifdef GGML_USE_HIP
+    GGML_UNUSED(nbatch_2);
+    GGML_UNUSED(cc);
+    return false;
+#else
+    return turing_mma_available(cc) && ggml_cuda_fattn_swz_pow2_stride(nbatch_2);
+#endif
+}
+
+static __device__ constexpr int ggml_cuda_fattn_swz_tile_stride(const int nbatch_2) {
+    return ggml_cuda_fattn_swz_enabled(nbatch_2) ? nbatch_2 : nbatch_2 + 4;
+}
+
+static __host__ int ggml_cuda_fattn_swz_tile_stride(const int nbatch_2, const int cc) {
+    return ggml_cuda_fattn_swz_enabled(nbatch_2, cc) ? nbatch_2 : nbatch_2 + 4;
+}
+
+// Swizzled byte offset for tile element (row, col_h2); same map used for writes and reads.
+template<int stride_h2>
+static __device__ __forceinline__ int ggml_cuda_fattn_swz_bytes_rc(const int row, const int col_h2) {
+    int off_bytes = (row * stride_h2 + col_h2) * (int) sizeof(half2);
+    if constexpr (ggml_cuda_fattn_swz_enabled(stride_h2)) {
+        off_bytes ^= (row & 7) << 4;
+    }
+    return off_bytes;
+}
+
+namespace ggml_cuda_fattn_smem_swizzle {
+
+// ldmatrix.x4 from a 32-bit .shared address (lower register pressure than 64-bit generic pointers).
+static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4(int * xi, const uint32_t saddr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0, %1, %2, %3}, [%4];"
+        : "=r"(xi[0]), "=r"(xi[1]), "=r"(xi[2]), "=r"(xi[3])
+        : "r"(saddr));
+}
+static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4_trans(int * xi, const uint32_t saddr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.b16 {%0, %1, %2, %3}, [%4];"
+        : "=r"(xi[0]), "=r"(xi[2]), "=r"(xi[1]), "=r"(xi[3])
+        : "r"(saddr));
+}
+
+// Per-lane swizzled .shared address for tile<16,8> ldmatrix.
+template<int stride_h2>
+static __device__ __forceinline__ uint32_t ggml_cuda_fattn_swz_saddr(
+        const half2 * tile_base, const int base_row, const int base_col_h2, const int I, const int J) {
+    const int lane_row = threadIdx.x % I;
+    const int lane_col = (threadIdx.x / I) * (J / 2);
+    const uint32_t base = __cvta_generic_to_shared(tile_base);
+    uint32_t byte_off = (uint32_t)((base_row + lane_row) * stride_h2 + base_col_h2 + lane_col) * (uint32_t)sizeof(half2);
+    if constexpr (ggml_cuda_fattn_swz_enabled(stride_h2)) {
+        byte_off ^= (uint32_t)(((base_row + lane_row) & 7) << 4);
+    }
+    return base + byte_off;
+}
+
+template<typename TileT, int stride_h2>
+static __device__ __forceinline__ void load_ldmatrix(
+        TileT & t, half2 * tile_base, const int base_row, const int base_col_h2) {
+    using Tile = typename std::remove_reference<TileT>::type;
+    constexpr int I = Tile::I;
+    constexpr int J = Tile::J;
+#if defined(TURING_MMA_AVAILABLE)
+    if constexpr (I == 16 && J == 8 && ggml_cuda_fattn_swz_enabled(stride_h2)) {
+        const uint32_t saddr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
+        ggml_cuda_fattn_ldmatrix_x4((int *) t.x, saddr);
+        return;
+    }
+#endif // TURING_MMA_AVAILABLE
+    ggml_cuda_mma::load_ldmatrix(t, tile_base + base_row * stride_h2 + base_col_h2, stride_h2);
+}
+
+template<typename TileT, int stride_h2>
+static __device__ __forceinline__ void load_ldmatrix_trans(
+        TileT & t, half2 * tile_base, const int base_row, const int base_col_h2) {
+    using Tile = typename std::remove_reference<TileT>::type;
+    constexpr int I = Tile::I;
+    constexpr int J = Tile::J;
+#if defined(TURING_MMA_AVAILABLE)
+    if constexpr (I == 16 && J == 8 && ggml_cuda_fattn_swz_enabled(stride_h2)) {
+        const uint32_t saddr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
+        ggml_cuda_fattn_ldmatrix_x4_trans((int *) t.x, saddr);
+        return;
+    }
+#endif // TURING_MMA_AVAILABLE
+    ggml_cuda_mma::load_ldmatrix_trans(t, tile_base + base_row * stride_h2 + base_col_h2, stride_h2);
+}
+
+} // namespace ggml_cuda_fattn_smem_swizzle

--- a/ggml/src/ggml-cuda/fattn-swizzle.cuh
+++ b/ggml/src/ggml-cuda/fattn-swizzle.cuh
@@ -49,30 +49,29 @@ static __device__ __forceinline__ int ggml_cuda_fattn_swz_bytes_rc(const int row
 
 namespace ggml_cuda_fattn_smem_swizzle {
 
-// ldmatrix.x4 from a 32-bit .shared address (lower register pressure than 64-bit generic pointers).
-static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4(int * xi, const uint32_t saddr) {
+// ldmatrix.x4 via 64-bit generic pointer.
+static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4(int * xi, const half2 * addr) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0, %1, %2, %3}, [%4];"
         : "=r"(xi[0]), "=r"(xi[1]), "=r"(xi[2]), "=r"(xi[3])
-        : "r"(saddr));
+        : "l"(addr));
 }
-static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4_trans(int * xi, const uint32_t saddr) {
+static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4_trans(int * xi, const half2 * addr) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.b16 {%0, %1, %2, %3}, [%4];"
         : "=r"(xi[0]), "=r"(xi[2]), "=r"(xi[1]), "=r"(xi[3])
-        : "r"(saddr));
+        : "l"(addr));
 }
 
-// Per-lane swizzled .shared address for tile<16,8> ldmatrix.
+// Per-lane swizzled generic pointer for tile<16,8> ldmatrix.
 template<int stride_h2>
-static __device__ __forceinline__ uint32_t ggml_cuda_fattn_swz_saddr(
+static __device__ __forceinline__ const half2 * ggml_cuda_fattn_swz_saddr(
         const half2 * tile_base, const int base_row, const int base_col_h2, const int I, const int J) {
     const int lane_row = threadIdx.x % I;
     const int lane_col = (threadIdx.x / I) * (J / 2);
-    const uint32_t base = __cvta_generic_to_shared(tile_base);
     uint32_t byte_off = (uint32_t)((base_row + lane_row) * stride_h2 + base_col_h2 + lane_col) * (uint32_t)sizeof(half2);
     if constexpr (ggml_cuda_fattn_swz_enabled(stride_h2)) {
         byte_off ^= (uint32_t)(((base_row + lane_row) & 7) << 4);
     }
-    return base + byte_off;
+    return (const half2 *) ((const char *) tile_base + byte_off);
 }
 
 template<typename TileT, int stride_h2>
@@ -83,8 +82,8 @@ static __device__ __forceinline__ void load_ldmatrix(
     constexpr int J = Tile::J;
 #if defined(TURING_MMA_AVAILABLE)
     if constexpr (I == 16 && J == 8 && ggml_cuda_fattn_swz_enabled(stride_h2)) {
-        const uint32_t saddr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
-        ggml_cuda_fattn_ldmatrix_x4((int *) t.x, saddr);
+        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
+        ggml_cuda_fattn_ldmatrix_x4((int *) t.x, addr);
         return;
     }
 #endif // TURING_MMA_AVAILABLE
@@ -99,8 +98,8 @@ static __device__ __forceinline__ void load_ldmatrix_trans(
     constexpr int J = Tile::J;
 #if defined(TURING_MMA_AVAILABLE)
     if constexpr (I == 16 && J == 8 && ggml_cuda_fattn_swz_enabled(stride_h2)) {
-        const uint32_t saddr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
-        ggml_cuda_fattn_ldmatrix_x4_trans((int *) t.x, saddr);
+        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
+        ggml_cuda_fattn_ldmatrix_x4_trans((int *) t.x, addr);
         return;
     }
 #endif // TURING_MMA_AVAILABLE

--- a/ggml/src/ggml-cuda/fattn-swizzle.cuh
+++ b/ggml/src/ggml-cuda/fattn-swizzle.cuh
@@ -38,10 +38,11 @@ static __host__ int ggml_cuda_fattn_swz_tile_stride(const int nbatch_2, const in
 }
 
 // Swizzled byte offset for tile element (row, col_h2); same map used for writes and reads.
-template<int stride_h2>
+template<int stride_h2, bool swz>
 static __device__ __forceinline__ int ggml_cuda_fattn_swz_bytes_rc(const int row, const int col_h2) {
+    static_assert(!swz || ggml_cuda_fattn_swz_pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
     int off_bytes = (row * stride_h2 + col_h2) * (int) sizeof(half2);
-    if constexpr (ggml_cuda_fattn_swz_enabled(stride_h2)) {
+    if constexpr (swz) {
         off_bytes ^= (row & 7) << 4;
     }
     return off_bytes;
@@ -62,27 +63,28 @@ static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4_trans(int * x
 }
 
 // Per-lane swizzled generic pointer for tile<16,8> ldmatrix.
-template<int stride_h2>
+template<int stride_h2, bool swz>
 static __device__ __forceinline__ const half2 * ggml_cuda_fattn_swz_saddr(
         const half2 * tile_base, const int base_row, const int base_col_h2, const int I, const int J) {
+    static_assert(!swz || ggml_cuda_fattn_swz_pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
     const int lane_row = threadIdx.x % I;
     const int lane_col = (threadIdx.x / I) * (J / 2);
     uint32_t byte_off = (uint32_t)((base_row + lane_row) * stride_h2 + base_col_h2 + lane_col) * (uint32_t)sizeof(half2);
-    if constexpr (ggml_cuda_fattn_swz_enabled(stride_h2)) {
+    if constexpr (swz) {
         byte_off ^= (uint32_t)(((base_row + lane_row) & 7) << 4);
     }
     return (const half2 *) ((const char *) tile_base + byte_off);
 }
 
-template<typename TileT, int stride_h2>
+template<typename TileT, int stride_h2, bool swz>
 static __device__ __forceinline__ void load_ldmatrix(
         TileT & t, half2 * tile_base, const int base_row, const int base_col_h2) {
     using Tile = typename std::remove_reference<TileT>::type;
     constexpr int I = Tile::I;
     constexpr int J = Tile::J;
 #if defined(TURING_MMA_AVAILABLE)
-    if constexpr (I == 16 && J == 8 && ggml_cuda_fattn_swz_enabled(stride_h2)) {
-        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
+    if constexpr (I == 16 && J == 8 && swz) {
+        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2, swz>(tile_base, base_row, base_col_h2, I, J);
         ggml_cuda_fattn_ldmatrix_x4((int *) t.x, addr);
         return;
     }
@@ -90,15 +92,15 @@ static __device__ __forceinline__ void load_ldmatrix(
     ggml_cuda_mma::load_ldmatrix(t, tile_base + base_row * stride_h2 + base_col_h2, stride_h2);
 }
 
-template<typename TileT, int stride_h2>
+template<typename TileT, int stride_h2, bool swz>
 static __device__ __forceinline__ void load_ldmatrix_trans(
         TileT & t, half2 * tile_base, const int base_row, const int base_col_h2) {
     using Tile = typename std::remove_reference<TileT>::type;
     constexpr int I = Tile::I;
     constexpr int J = Tile::J;
 #if defined(TURING_MMA_AVAILABLE)
-    if constexpr (I == 16 && J == 8 && ggml_cuda_fattn_swz_enabled(stride_h2)) {
-        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2>(tile_base, base_row, base_col_h2, I, J);
+    if constexpr (I == 16 && J == 8 && swz) {
+        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2, swz>(tile_base, base_row, base_col_h2, I, J);
         ggml_cuda_fattn_ldmatrix_x4_trans((int *) t.x, addr);
         return;
     }

--- a/ggml/src/ggml-cuda/fattn-swizzle.cuh
+++ b/ggml/src/ggml-cuda/fattn-swizzle.cuh
@@ -6,108 +6,92 @@
 // XOR swizzle for K/V SMEM tiles to avoid bank conflicts without row padding (Turing+ only).
 // Stride must be a power-of-two >= 32 half2 columns,otherwise we keep +4 row padding.
 
-static __host__ __device__ constexpr bool ggml_cuda_fattn_swz_pow2_stride(const int nbatch_2) {
+namespace ggml_cuda_fattn_smem_swizzle {
+
+static __host__ __device__ constexpr bool pow2_stride(const int nbatch_2) {
     return nbatch_2 >= 32 && (nbatch_2 & (nbatch_2 - 1)) == 0;
 }
 
-static __device__ constexpr bool ggml_cuda_fattn_swz_enabled(const int nbatch_2) {
+static __device__ constexpr bool enabled(const int nbatch_2) {
 #if defined(TURING_MMA_AVAILABLE)
-    return ggml_cuda_fattn_swz_pow2_stride(nbatch_2);
+    return pow2_stride(nbatch_2);
 #else
     GGML_UNUSED(nbatch_2);
     return false;
-#endif
+#endif // defined(TURING_MMA_AVAILABLE)
 }
 
-static __host__ bool ggml_cuda_fattn_swz_enabled(const int nbatch_2, const int cc) {
+static __host__ bool enabled(const int nbatch_2, const int cc) {
 #ifdef GGML_USE_HIP
     GGML_UNUSED(nbatch_2);
     GGML_UNUSED(cc);
     return false;
 #else
-    return turing_mma_available(cc) && ggml_cuda_fattn_swz_pow2_stride(nbatch_2);
-#endif
+    return turing_mma_available(cc) && pow2_stride(nbatch_2);
+#endif // GGML_USE_HIP
 }
 
-static __device__ constexpr int ggml_cuda_fattn_swz_tile_stride(const int nbatch_2) {
-    return ggml_cuda_fattn_swz_enabled(nbatch_2) ? nbatch_2 : nbatch_2 + 4;
+static __device__ constexpr int tile_stride(const int nbatch_2) {
+    return enabled(nbatch_2) ? nbatch_2 : nbatch_2 + 4;
 }
 
-static __host__ int ggml_cuda_fattn_swz_tile_stride(const int nbatch_2, const int cc) {
-    return ggml_cuda_fattn_swz_enabled(nbatch_2, cc) ? nbatch_2 : nbatch_2 + 4;
+static __host__ int tile_stride(const int nbatch_2, const int cc) {
+    return enabled(nbatch_2, cc) ? nbatch_2 : nbatch_2 + 4;
 }
 
 // Swizzled byte offset for tile element (row, col_h2); same map used for writes and reads.
-template<int stride_h2, bool swz>
-static __device__ __forceinline__ int ggml_cuda_fattn_swz_bytes_rc(const int row, const int col_h2) {
-    static_assert(!swz || ggml_cuda_fattn_swz_pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
-    int off_bytes = (row * stride_h2 + col_h2) * (int) sizeof(half2);
-    if constexpr (swz) {
-        off_bytes ^= (row & 7) << 4;
-    }
-    return off_bytes;
+template<int stride_h2>
+static __device__ __forceinline__ int bytes_rc(const int row, const int col_h2) {
+    static_assert(pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
+    return ((row * stride_h2 + col_h2) * (int) sizeof(half2)) ^ ((row & 7) << 4);
 }
-
-namespace ggml_cuda_fattn_smem_swizzle {
 
 #if defined(TURING_MMA_AVAILABLE)
 // ldmatrix.x4 via 64-bit generic pointer.
-static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4(int * xi, const half2 * addr) {
+static __device__ __forceinline__ void ldmatrix_x4(int * xi, const half2 * addr) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0, %1, %2, %3}, [%4];"
         : "=r"(xi[0]), "=r"(xi[1]), "=r"(xi[2]), "=r"(xi[3])
         : "l"(addr));
 }
-static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4_trans(int * xi, const half2 * addr) {
+
+static __device__ __forceinline__ void ldmatrix_x4_trans(int * xi, const half2 * addr) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.b16 {%0, %1, %2, %3}, [%4];"
         : "=r"(xi[0]), "=r"(xi[2]), "=r"(xi[1]), "=r"(xi[3])
         : "l"(addr));
 }
 #endif // defined(TURING_MMA_AVAILABLE)
 
-// Per-lane swizzled generic pointer for tile<16,8> ldmatrix.
-template<int stride_h2, bool swz>
-static __device__ __forceinline__ const half2 * ggml_cuda_fattn_swz_saddr(
-        const half2 * tile_base, const int base_row, const int base_col_h2, const int I, const int J) {
-    static_assert(!swz || ggml_cuda_fattn_swz_pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
-    const int lane_row = threadIdx.x % I;
-    const int lane_col = (threadIdx.x / I) * (J / 2);
-    uint32_t byte_off = (uint32_t)((base_row + lane_row) * stride_h2 + base_col_h2 + lane_col) * (uint32_t)sizeof(half2);
-    if constexpr (swz) {
-        byte_off ^= (uint32_t)(((base_row + lane_row) & 7) << 4);
-    }
+// Per-lane swizzled address for one tile<16, 8, half2> ldmatrix: 16 rows, 4 half2 columns per lane.
+template<int stride_h2>
+static __device__ __forceinline__ const half2 * lane_addr(
+        const half2 * tile_base, const int base_row, const int base_col_h2) {
+    static_assert(pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
+    const int row = base_row    + threadIdx.x % 16;
+    const int col = base_col_h2 + (threadIdx.x / 16) * 4;
+    const uint32_t byte_off = (uint32_t) ((row * stride_h2 + col) * (int) sizeof(half2)) ^ (uint32_t) ((row & 7) << 4);
     return (const half2 *) ((const char *) tile_base + byte_off);
 }
 
-template<typename TileT, int stride_h2, bool swz>
+template<int stride_h2>
 static __device__ __forceinline__ void load_ldmatrix(
-        TileT & t, half2 * tile_base, const int base_row, const int base_col_h2) {
-    using Tile = typename std::remove_reference<TileT>::type;
-    constexpr int I = Tile::I;
-    constexpr int J = Tile::J;
+        ggml_cuda_mma::tile<16, 8, half2> & t, const half2 * tile_base, const int base_row, const int base_col_h2) {
 #if defined(TURING_MMA_AVAILABLE)
-    if constexpr (I == 16 && J == 8 && swz) {
-        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2, swz>(tile_base, base_row, base_col_h2, I, J);
-        ggml_cuda_fattn_ldmatrix_x4((int *) t.x, addr);
-        return;
-    }
-#endif // TURING_MMA_AVAILABLE
-    ggml_cuda_mma::load_ldmatrix(t, tile_base + base_row * stride_h2 + base_col_h2, stride_h2);
+    ldmatrix_x4((int *) t.x, lane_addr<stride_h2>(tile_base, base_row, base_col_h2));
+#else
+    GGML_UNUSED_VARS(t, tile_base, base_row, base_col_h2);
+    NO_DEVICE_CODE;
+#endif // defined(TURING_MMA_AVAILABLE)
 }
 
-template<typename TileT, int stride_h2, bool swz>
+template<int stride_h2>
 static __device__ __forceinline__ void load_ldmatrix_trans(
-        TileT & t, half2 * tile_base, const int base_row, const int base_col_h2) {
-    using Tile = typename std::remove_reference<TileT>::type;
-    constexpr int I = Tile::I;
-    constexpr int J = Tile::J;
+        ggml_cuda_mma::tile<16, 8, half2> & t, const half2 * tile_base, const int base_row, const int base_col_h2) {
 #if defined(TURING_MMA_AVAILABLE)
-    if constexpr (I == 16 && J == 8 && swz) {
-        const half2 * addr = ggml_cuda_fattn_swz_saddr<stride_h2, swz>(tile_base, base_row, base_col_h2, I, J);
-        ggml_cuda_fattn_ldmatrix_x4_trans((int *) t.x, addr);
-        return;
-    }
-#endif // TURING_MMA_AVAILABLE
-    ggml_cuda_mma::load_ldmatrix_trans(t, tile_base + base_row * stride_h2 + base_col_h2, stride_h2);
+    ldmatrix_x4_trans((int *) t.x, lane_addr<stride_h2>(tile_base, base_row, base_col_h2));
+#else
+    GGML_UNUSED_VARS(t, tile_base, base_row, base_col_h2);
+    NO_DEVICE_CODE;
+#endif // defined(TURING_MMA_AVAILABLE)
 }
 
 } // namespace ggml_cuda_fattn_smem_swizzle

--- a/ggml/src/ggml-cuda/fattn-swizzle.cuh
+++ b/ggml/src/ggml-cuda/fattn-swizzle.cuh
@@ -50,6 +50,7 @@ static __device__ __forceinline__ int ggml_cuda_fattn_swz_bytes_rc(const int row
 
 namespace ggml_cuda_fattn_smem_swizzle {
 
+#if defined(TURING_MMA_AVAILABLE)
 // ldmatrix.x4 via 64-bit generic pointer.
 static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4(int * xi, const half2 * addr) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0, %1, %2, %3}, [%4];"
@@ -61,6 +62,7 @@ static __device__ __forceinline__ void ggml_cuda_fattn_ldmatrix_x4_trans(int * x
         : "=r"(xi[0]), "=r"(xi[2]), "=r"(xi[1]), "=r"(xi[3])
         : "l"(addr));
 }
+#endif // defined(TURING_MMA_AVAILABLE)
 
 // Per-lane swizzled generic pointer for tile<16,8> ldmatrix.
 template<int stride_h2, bool swz>

--- a/ggml/src/ggml-cuda/fattn-swizzle.cuh
+++ b/ggml/src/ggml-cuda/fattn-swizzle.cuh
@@ -4,17 +4,17 @@
 #include "mma.cuh"
 
 // XOR swizzle for K/V SMEM tiles to avoid bank conflicts without row padding (Turing+ only).
-// Stride must be a power-of-two >= 32 half2 columns,otherwise we keep +4 row padding.
+// Stride must be a multiple of 32 half2 columns, otherwise we keep +4 row padding.
 
 namespace ggml_cuda_fattn_smem_swizzle {
 
-static __host__ __device__ constexpr bool pow2_stride(const int nbatch_2) {
-    return nbatch_2 >= 32 && (nbatch_2 & (nbatch_2 - 1)) == 0;
+static __host__ __device__ constexpr bool bank_aligned(const int nbatch_2) {
+    return nbatch_2 >= 32 && nbatch_2 % 32 == 0;
 }
 
 static __device__ constexpr bool enabled(const int nbatch_2) {
 #if defined(TURING_MMA_AVAILABLE)
-    return pow2_stride(nbatch_2);
+    return bank_aligned(nbatch_2);
 #else
     GGML_UNUSED(nbatch_2);
     return false;
@@ -27,7 +27,7 @@ static __host__ bool enabled(const int nbatch_2, const int cc) {
     GGML_UNUSED(cc);
     return false;
 #else
-    return turing_mma_available(cc) && pow2_stride(nbatch_2);
+    return turing_mma_available(cc) && bank_aligned(nbatch_2);
 #endif // GGML_USE_HIP
 }
 
@@ -42,7 +42,7 @@ static __host__ int tile_stride(const int nbatch_2, const int cc) {
 // Swizzled byte offset for tile element (row, col_h2), same map used for writes and reads.
 template<int stride_h2>
 static __device__ __forceinline__ int bytes_rc(const int row, const int col_h2) {
-    static_assert(pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
+    static_assert(bank_aligned(stride_h2), "swizzled tile needs a stride that is a multiple of 32");
     return ((row * stride_h2 + col_h2) * (int) sizeof(half2)) ^ ((row & 7) << 4);
 }
 
@@ -73,7 +73,7 @@ static __device__ __forceinline__ void ldmatrix_x4_trans(int * xi, const half2 *
 template<int stride_h2>
 static __device__ __forceinline__ const half2 * lane_addr(
         const half2 * tile_base, const int base_row, const int base_col_h2, const int I, const int J) {
-    static_assert(pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
+    static_assert(bank_aligned(stride_h2), "swizzled tile needs a stride that is a multiple of 32");
     const int lane_row = threadIdx.x % I;
     const int lane_col = (threadIdx.x / I) * (J / 2);
     uint32_t byte_off = (uint32_t) ((base_row + lane_row)*stride_h2 + base_col_h2 + lane_col) * (uint32_t) sizeof(half2);

--- a/ggml/src/ggml-cuda/fattn-swizzle.cuh
+++ b/ggml/src/ggml-cuda/fattn-swizzle.cuh
@@ -39,59 +39,88 @@ static __host__ int tile_stride(const int nbatch_2, const int cc) {
     return enabled(nbatch_2, cc) ? nbatch_2 : nbatch_2 + 4;
 }
 
-// Swizzled byte offset for tile element (row, col_h2); same map used for writes and reads.
+// Swizzled byte offset for tile element (row, col_h2), same map used for writes and reads.
 template<int stride_h2>
 static __device__ __forceinline__ int bytes_rc(const int row, const int col_h2) {
     static_assert(pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
     return ((row * stride_h2 + col_h2) * (int) sizeof(half2)) ^ ((row & 7) << 4);
 }
 
-#if defined(TURING_MMA_AVAILABLE)
 // ldmatrix.x4 via 64-bit generic pointer.
 static __device__ __forceinline__ void ldmatrix_x4(int * xi, const half2 * addr) {
+#if defined(TURING_MMA_AVAILABLE)
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.b16 {%0, %1, %2, %3}, [%4];"
         : "=r"(xi[0]), "=r"(xi[1]), "=r"(xi[2]), "=r"(xi[3])
         : "l"(addr));
+#else
+    GGML_UNUSED_VARS(xi, addr);
+    NO_DEVICE_CODE;
+#endif // defined(TURING_MMA_AVAILABLE)
 }
 
 static __device__ __forceinline__ void ldmatrix_x4_trans(int * xi, const half2 * addr) {
+#if defined(TURING_MMA_AVAILABLE)
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.b16 {%0, %1, %2, %3}, [%4];"
         : "=r"(xi[0]), "=r"(xi[2]), "=r"(xi[1]), "=r"(xi[3])
         : "l"(addr));
-}
+#else
+    GGML_UNUSED_VARS(xi, addr);
+    NO_DEVICE_CODE;
 #endif // defined(TURING_MMA_AVAILABLE)
+}
 
 // Per-lane swizzled address for one tile<16, 8, half2> ldmatrix: 16 rows, 4 half2 columns per lane.
 template<int stride_h2>
 static __device__ __forceinline__ const half2 * lane_addr(
-        const half2 * tile_base, const int base_row, const int base_col_h2) {
+        const half2 * tile_base, const int base_row, const int base_col_h2, const int I, const int J) {
     static_assert(pow2_stride(stride_h2), "swizzled tile needs a pow2 stride");
-    const int row = base_row    + threadIdx.x % 16;
-    const int col = base_col_h2 + (threadIdx.x / 16) * 4;
-    const uint32_t byte_off = (uint32_t) ((row * stride_h2 + col) * (int) sizeof(half2)) ^ (uint32_t) ((row & 7) << 4);
+    const int lane_row = threadIdx.x % I;
+    const int lane_col = (threadIdx.x / I) * (J / 2);
+    uint32_t byte_off = (uint32_t) ((base_row + lane_row)*stride_h2 + base_col_h2 + lane_col) * (uint32_t) sizeof(half2);
+    byte_off ^= (uint32_t) (((base_row + lane_row) & 7) << 4);
     return (const half2 *) ((const char *) tile_base + byte_off);
 }
 
-template<int stride_h2>
+template<int stride_h2, bool swz, typename TileT>
 static __device__ __forceinline__ void load_ldmatrix(
-        ggml_cuda_mma::tile<16, 8, half2> & t, const half2 * tile_base, const int base_row, const int base_col_h2) {
-#if defined(TURING_MMA_AVAILABLE)
-    ldmatrix_x4((int *) t.x, lane_addr<stride_h2>(tile_base, base_row, base_col_h2));
-#else
-    GGML_UNUSED_VARS(t, tile_base, base_row, base_col_h2);
-    NO_DEVICE_CODE;
-#endif // defined(TURING_MMA_AVAILABLE)
+        TileT & t, const half2 * tile_base, const int base_row, const int base_col_h2) {
+    if constexpr (swz) {
+        static_assert(std::is_same_v<TileT, ggml_cuda_mma::tile<16, 8, half2>>,
+            "the swizzled layout is only supported for tile<16, 8, half2>");
+        ldmatrix_x4((int *) t.x, lane_addr<stride_h2>(tile_base, base_row, base_col_h2, TileT::I, TileT::J));
+    } else {
+        ggml_cuda_mma::load_ldmatrix(t, tile_base + base_row*stride_h2 + base_col_h2, stride_h2);
+    }
 }
 
-template<int stride_h2>
+template<int stride_h2, bool swz, typename TileT>
+static __device__ __forceinline__ void load_ldmatrix(TileT & t, const half2 * tile_base, const int off_h2) {
+    if constexpr (swz) {
+        load_ldmatrix<stride_h2, swz>(t, tile_base, off_h2 / stride_h2, off_h2 % stride_h2);
+    } else {
+        ggml_cuda_mma::load_ldmatrix(t, tile_base + off_h2, stride_h2);
+    }
+}
+
+template<int stride_h2, bool swz, typename TileT>
 static __device__ __forceinline__ void load_ldmatrix_trans(
-        ggml_cuda_mma::tile<16, 8, half2> & t, const half2 * tile_base, const int base_row, const int base_col_h2) {
-#if defined(TURING_MMA_AVAILABLE)
-    ldmatrix_x4_trans((int *) t.x, lane_addr<stride_h2>(tile_base, base_row, base_col_h2));
-#else
-    GGML_UNUSED_VARS(t, tile_base, base_row, base_col_h2);
-    NO_DEVICE_CODE;
-#endif // defined(TURING_MMA_AVAILABLE)
+        TileT & t, const half2 * tile_base, const int base_row, const int base_col_h2) {
+    if constexpr (swz) {
+        static_assert(std::is_same_v<TileT, ggml_cuda_mma::tile<16, 8, half2>>,
+            "the swizzled layout is only supported for tile<16, 8, half2>");
+        ldmatrix_x4_trans((int *) t.x, lane_addr<stride_h2>(tile_base, base_row, base_col_h2, TileT::I, TileT::J));
+    } else {
+        ggml_cuda_mma::load_ldmatrix_trans(t, tile_base + base_row*stride_h2 + base_col_h2, stride_h2);
+    }
+}
+
+template<int stride_h2, bool swz, typename TileT>
+static __device__ __forceinline__ void load_ldmatrix_trans(TileT & t, const half2 * tile_base, const int off_h2) {
+    if constexpr (swz) {
+        load_ldmatrix_trans<stride_h2, swz>(t, tile_base, off_h2 / stride_h2, off_h2 % stride_h2);
+    } else {
+        ggml_cuda_mma::load_ldmatrix_trans(t, tile_base + off_h2, stride_h2);
+    }
 }
 
 } // namespace ggml_cuda_fattn_smem_swizzle

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9604,6 +9604,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                                         GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     }
 
+    // FLASH_ATTN_EXT MMA: non-pow2 head size and MLA K/V view.
+    test_cases.emplace_back(new test_flash_attn_ext(192, 128, 8, {8, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   10, 5, 4, 3}));
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {30000, 1, 1, 1}));
     test_cases.emplace_back(new test_cross_entropy_loss_back(GGML_TYPE_F32, {   10, 5, 4, 3}));
@@ -9953,10 +9957,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 8, {8, 1}, 7680,   1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0));
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 8, {8, 1}, 7680, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0));
 
-    for (int kv : { 4096, 8192, 16384, }) {
-        for (int hs : { 64, 128, }) {
-            for (int nr : { 1, 4, }) {
-                test_cases.emplace_back(new test_flash_attn_ext(hs, hs, 8, {nr, 1}, kv, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    for (int kv : { 4096, 8192, 16384,32768, 65536, }) {
+        for (int hs : { 64, 128, 256, }) {
+            for (int nr : { 1, 4, 8, }) {
+                for (int nb : { 1, 4096, }) {
+                    test_cases.emplace_back(new test_flash_attn_ext(hs, hs, 8, {nr, 1}, kv, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+                }
             }
         }
     }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9608,6 +9608,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext(192, 128, 8, {8, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
 
+    // FLASH_ATTN_EXT MMA, swizzled K/V tiles: nbatch_K2 = 32, 64, 128, 256.
+    test_cases.emplace_back(new test_flash_attn_ext( 64,  64, 8, {8, 1}, 4096,  4, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(128, 128, 8, {4, 1}, 4096,  8, true,  true, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {2, 1}, 1024, 32, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(512, 512, 4, {2, 1}, 1024,  4, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+
+
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   10, 5, 4, 3}));
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {30000, 1, 1, 1}));
     test_cases.emplace_back(new test_cross_entropy_loss_back(GGML_TYPE_F32, {   10, 5, 4, 3}));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10078,12 +10078,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext(192, 128, 8, {8, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16, {0, 1, 2, 3}, true, true));
 
-    // FLASH_ATTN_EXT MMA, swizzled K/V tiles: nbatch_K2 = 32, 64, 128, 256.
+    // FLASH_ATTN_EXT MMA, swizzled K/V tiles, power-of-two stride: nbatch_K2 = 32, 64, 128, 256.
     test_cases.emplace_back(new test_flash_attn_ext( 64,  64, 8, {8, 1}, 4096,  4, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(128, 128, 8, {4, 1}, 4096,  8, true,  true, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {2, 1}, 1024, 32, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(512, 512, 4, {2, 1}, 1024,  4, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
-
 
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   10, 5, 4, 3}));
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {30000, 1, 1, 1}));
@@ -10482,10 +10481,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {16, 1}, 20000, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
 
     for (int kv : { 4096, 8192, 16384,32768, 65536, }) {
-        for (int hs : { 64, 128, 256, }) {
+        for (int hs : { 64, 128, 256, 576, }) {
+            const int  hsv    = hs == 576 ? 512 : hs;
+            const bool v_view = hs == 576;
             for (int nr : { 1, 4, 8, }) {
                 for (int nb : { 1, 4096, }) {
-                    test_cases.emplace_back(new test_flash_attn_ext(hs, hs, 8, {nr, 1}, kv, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+                    test_cases.emplace_back(new test_flash_attn_ext(hs, hsv, 8, {nr, 1}, kv, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16, {0, 1, 2, 3}, true, v_view));
                 }
             }
         }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10074,6 +10074,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 1024, 75, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, {0, 2, 1, 3}, false));
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 512, 75, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, {0, 1, 2, 3}, false));
 
+    // FLASH_ATTN_EXT MMA: non-pow2 head size and MLA K/V view.
+    test_cases.emplace_back(new test_flash_attn_ext(192, 128, 8, {8, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   10, 5, 4, 3}));
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {30000, 1, 1, 1}));
     test_cases.emplace_back(new test_cross_entropy_loss_back(GGML_TYPE_F32, {   10, 5, 4, 3}));
@@ -10470,10 +10474,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {16, 1}, 10000, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {16, 1}, 20000, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
 
-    for (int kv : { 4096, 8192, 16384, }) {
-        for (int hs : { 64, 128, }) {
-            for (int nr : { 1, 4, }) {
-                test_cases.emplace_back(new test_flash_attn_ext(hs, hs, 8, {nr, 1}, kv, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    for (int kv : { 4096, 8192, 16384,32768, 65536, }) {
+        for (int hs : { 64, 128, 256, }) {
+            for (int nr : { 1, 4, 8, }) {
+                for (int nb : { 1, 4096, }) {
+                    test_cases.emplace_back(new test_flash_attn_ext(hs, hs, 8, {nr, 1}, kv, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+                }
             }
         }
     }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10076,7 +10076,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     // FLASH_ATTN_EXT MMA: non-pow2 head size and MLA K/V view.
     test_cases.emplace_back(new test_flash_attn_ext(192, 128, 8, {8, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
-    test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16, {0, 1, 2, 3}, true, true));
 
     // FLASH_ATTN_EXT MMA, swizzled K/V tiles: nbatch_K2 = 32, 64, 128, 256.
     test_cases.emplace_back(new test_flash_attn_ext( 64,  64, 8, {8, 1}, 4096,  4, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10078,6 +10078,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext(192, 128, 8, {8, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(576, 512, 1, {20, 1}, 512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
 
+    // FLASH_ATTN_EXT MMA, swizzled K/V tiles: nbatch_K2 = 32, 64, 128, 256.
+    test_cases.emplace_back(new test_flash_attn_ext( 64,  64, 8, {8, 1}, 4096,  4, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(128, 128, 8, {4, 1}, 4096,  8, true,  true, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {2, 1}, 1024, 32, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(512, 512, 4, {2, 1}, 1024,  4, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+
+
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   10, 5, 4, 3}));
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {30000, 1, 1, 1}));
     test_cases.emplace_back(new test_cross_entropy_loss_back(GGML_TYPE_F32, {   10, 5, 4, 3}));


### PR DESCRIPTION
## Overview

This PR adds XOR swizzling for K/V shared-memory tiles in the CUDA flash-attention fp16 MMA kernel (fattn-mma-f16.cuh), replacing row padding (+4) as the primary fix for shared-memory bank conflicts on cp.async stores and ldmatrix loads. On Turing+ (Ampere/Ada/Blackwell), when the K/V tile stride is a power-of-two ≥ 32, the kernel uses a pow2 stride with per-row XOR address remapping instead of padded row stride. 

## Additional information

Followed resource : https://lubits.ch/flash/Part-4

This change helped in improving perf for very high context, collected data for 65K depth

Performance DGX -SPARK
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/ynankani/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/ynankani/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Percent;}
-->

</head>

<body link="#467886" vlink="#96607D">

<div data-scroll-padding=4 data-visibility=hover data-direction=horizontal
style='--tw-space-y-reverse: 0;margin-block: 0px 16px;--scroll-area-scroll-padding: 4px;
--scrollbar-inset: 1px;--scrollbar-size: 6px;--scrollbar-thumb-top-offset: 6px;
grid-template: 1fr / 1fr;border-radius: 6px;display:grid;border-color:color(srgb 0.941176 0.941176 0.941176 / 0.08);
font-variant-ligatures: normal;font-variant-caps: normal;orphans: 2;text-align:
start;widows: 2;-webkit-text-stroke-width: 0px;text-decoration-thickness: initial;
text-decoration-style: initial;text-decoration-color: initial'>


Model | Metric | ToT | Swizzle | Δ
-- | -- | -- | -- | --
Gemma-4-26B-A4B-NVFP4 | pp2048 @   d65536 | 1616.61 ±   2.94 | 1644.18 ±   1.80 | 1.71%
Gemma-4-26B-A4B-NVFP4 | tg128 @   d65536 | 29.30 ± 0.04 | 30.32 ± 0.03 | 3.48%
Qwen3.6-27B-Q4_K_M | pp2048 @   d65536 | 574.91 ±   1.19 | 583.02 ±   1.44 | 1.41%
Qwen3.6-27B-Q4_K_M | tg128 @   d65536 | 9.43 ± 0.01 | 9.76 ± 0.01 | 3.50%
Qwen3.6-27B-NVFP4 | pp2048 @   d65536 | 648.32 ±   0.77 | 665.23 ±   0.60 | 2.61%
Qwen3.6-27B-NVFP4 | tg128 @   d65536 | 8.29 ± 0.00 | 8.53 ± 0.01 | 2.89%
Qwen3.6-35B-A3B-NVFP4 | pp2048 @   d65536 | 1729.35 ±   8.33 | 1758.57 ±   3.19 | 1.69%
Qwen3.6-35B-A3B-NVFP4 | tg128 @   d65536 | 49.22 ± 0.20 | 52.39 ± 0.15 | 6.44%
Qwen3.6-35B-A3B-UD-Q4_K_M | pp2048 @   d65536 | 1662.27 ±   4.71 | 1680.99 ±   3.85 | 1.13%
Qwen3.6-35B-A3B-UD-Q4_K_M | tg128 @   d65536 | 46.24 ± 0.20 | 48.48 ± 0.63 | 4.84%



</body>

</html>

Performance RTX6000-PRO-BLACKWELL
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/ynankani/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/ynankani/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Percent;}
-->

</head>

<div data-scroll-padding=4 data-visibility=hover data-direction=horizontal
style='--tw-space-y-reverse: 0;margin-block: 0px 16px;--scroll-area-scroll-padding: 4px;
--scrollbar-inset: 1px;--scrollbar-size: 6px;--scrollbar-thumb-top-offset: 6px;
grid-template: 1fr / 1fr;border-radius: 6px;display:grid;border-color:color(srgb 0.941176 0.941176 0.941176 / 0.08);
font-variant-ligatures: normal;font-variant-caps: normal;orphans: 2;text-align:
start;widows: 2;-webkit-text-stroke-width: 0px;text-decoration-thickness: initial;
text-decoration-style: initial;text-decoration-color: initial'>

<div style='grid-area: 1 / 1;border-radius: inherit;scrollbar-width: none;
max-height: 100%;min-height: 0px;overflow:hidden;overscroll-behavior: contain auto;
scroll-padding: 0px 4px'>

<div style='box-sizing: border-box;display:flex;flex-direction: row;height:
fit-content;max-width:100%;min-height: 100%;min-width: 100%'>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

<div style='overflow-wrap: break-word;min-width: max(6ch, 100%)'></div>

</div>

</div>

</div>

<body link="#467886" vlink="#96607D">


Model | Metric | ToT (t/s) | Swizzle (t/s) | Δ
-- | -- | -- | -- | --
Qwen3.6-35B-A3B   NVFP4 (W4A16) | pp2048 @   d65536 | 5105.62 ±   8.83 | 5213.21 ±   7.96 | 2.11%
Qwen3.6-35B-A3B   NVFP4 (W4A16) | tg128 @   d65536 | 191.42 ±   3.47 | 193.00 ±   2.71 | 0.83%
Qwen3.6-35B-A3B-UD-Q4_K_M | pp2048 @   d65536 | 4757.63 ±   13.50 | 4947.80 ±   9.65 | 4.00%
Qwen3.6-35B-A3B-UD-Q4_K_M | tg128 @   d65536 | 197.44 ±   2.57 | 197.45 ±   2.75 | 0.01%
Qwen3.6-27B-NVFP4 | pp2048 @   d65536 | 1805.03 ±   4.16 | 1868.25 ±   2.47 | 3.50%
Qwen3.6-27B-NVFP4 | tg128 @   d65536 | 53.91 ± 0.20 | 53.71 ± 0.23 | −0.37%
Qwen3.6-27B-Q4_K_M | pp2048 @   d65536 | 1518.74 ±   1.59 | 1630.54 ±   5.56 | 7.36%
Qwen3.6-27B-Q4_K_M | tg128 @   d65536 | 54.70 ± 0.21 | 55.91 ± 0.15 | 2.21%
Gemma-4-26B-A4B-NVFP4 | pp2048 @   d65536 | 4997.70 ±   36.84 | 5213.21 ±   7.96 | 4.31%
Gemma-4-26B-A4B-NVFP4 | tg128 @   d65536 | 144.94 ±   0.51 | 143.93 ±   0.87 | −0.70%



</body>

</html>


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, paired with Claude on this 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->