### PR TITLE
llama : fix null pointer dereference by checking for rotation buffer in K-cache shifts

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1859,14 +1859,20 @@ ggml_tensor * llama_kv_cache::build_rope_shift(
         tmp = ggml_cast(ctx, cur, GGML_TYPE_F32);
 
         // rotate back
-        tmp = llama_mul_mat_hadamard(ctx, tmp, rot);
+        // rot is only built when the cache uses the K rotation scheme (attn_rot_k);
+        // a standard quantized K cache reaches this branch with rot == nullptr
+        if (rot) {
+            tmp = llama_mul_mat_hadamard(ctx, tmp, rot);
+        }
 
         tmp = ggml_rope_ext(ctx, tmp,
                 shift, factors, n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
                 yarn_ext_factor, yarn_attn_factor, yarn_beta_fast, yarn_beta_slow);
 
         // rotate fwd
-        tmp = llama_mul_mat_hadamard(ctx, tmp, rot);
+        if (rot) {
+            tmp = llama_mul_mat_hadamard(ctx, tmp, rot);
+        }
 
         tmp = ggml_cpy(ctx, tmp, cur);
     } else {


### PR DESCRIPTION
## Overview

Upstream AUTO-ACTIVATES Hadamard rotation (`attn_rot_k`) when the K cache is quantized and the head size is divisible by 64... In these cases, `rot` is not null and DOES NOT crash (with Qwen head-128 it does not reproduce). The actual window:

1. `LLAMA_ATTN_ROT_DISABLE=1` (src/llama-kv-cache.cpp ~329) + quantized K + context shift -> crash.

2. Models with head size NOT divisible by 64 (there are: 80, 96, 112) + quantized K + context shift -> same crash, without touching any environment.

Mechanics: `build_input_k_rot` returns nullptr when `attn_rot_k` is false (~1413)... `build_rope_shift` calls `llama_mul_mat_hadamard(ctx, tmp, rot)` unconditionally on the quantized branch (~1862/1869)... the helper does `rot->ne[0]` without checking (src/llama-impl.h ~61). The fix: skip rotation when no rotation is configured. With `attn_rot_k` active, nothing changes.

To reproduce the error, you can run these commands in main and it should crash as it did for me.

```bash
LLAMA_ATTN_ROT_DISABLE=1 ./build/bin/llama-server \
  -m Qwen3-0.6B-Q4_0.gguf -ngl 0 -ctk q8_0 -c 512 --context-shift \
  --port 8199 --host 127.0.0.1

curl -s http://127.0.0.1:8199/completion -H "Content-Type: application/json" \
  -d '{"prompt":"Write a very long story about a lighthouse keeper.","n_predict":700,"ignore_eos":true,"temperature":0}'
```
Without fix: dies upon reaching the "slot context shift" (~450 tokens). With fix: completes the 700.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
Yes, I used assistance to reproduce the error, but the fix and implementation are mine. I had to fix it to implement llama.cpp in the ToshLLM app for Intel Macs.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
