### PR TITLE
convert_hf_to_gguf.py: Refactor how `--mtp` / `--no-mtp` is enabled for a model

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -109,7 +109,9 @@ class ModelBase:
     sentence_transformers_dense_modules: bool = False
 
     # MTP (multi-token prediction) export modes; set by main() before instantiation.
-    # Architectures opt in by overriding the handling (see _Qwen35MtpMixin).
+    # Architectures that implement the filtering/export behavior opt in by
+    # setting supports_mtp_export = True on their model class or a mixin.
+    supports_mtp_export: bool = False
     mtp_only: bool = False
     no_mtp: bool = False
 

--- a/conversion/hunyuan.py
+++ b/conversion/hunyuan.py
@@ -361,6 +361,7 @@ class HunyuanVLTextModel(HunYuanModel):
 @ModelBase.register("HYV3ForCausalLM")
 class HYV3Model(TextModel):
     model_arch = gguf.MODEL_ARCH.HY_V3
+    supports_mtp_export = True
 
     # Trunk layer count, stashed before indexing so the classmethod
     # filter_tensors can identify the appended MTP block(s) (mirrors

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -541,6 +541,7 @@ class _Qwen35MtpMixin:
     `mtp.*` to the standard layer-indexed nextn naming so the existing
     tensor_map handles them."""
 
+    supports_mtp_export = True
     hparams: dict[str, Any]
     model_arch: gguf.MODEL_ARCH
     gguf_writer: gguf.GGUFWriter

--- a/conversion/step3.py
+++ b/conversion/step3.py
@@ -98,6 +98,7 @@ class Step3VLTextModel(Qwen3Model):
 @ModelBase.register("Step3p5ForCausalLM", "Step3p7ForConditionalGeneration")
 class Step35Model(TextModel):
     model_arch = gguf.MODEL_ARCH.STEP35
+    supports_mtp_export = True
 
     # The --mtp / --no-mtp toggles are ModelBase.mtp_only / no_mtp (set in
     # convert_hf_to_gguf.py main()). Unlike Qwen3.5, which stores MTP under a

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -259,10 +259,8 @@ def main() -> None:
             sys.exit(1)
 
         if args.mtp or args.no_mtp:
-            from conversion.qwen import _Qwen35MtpMixin
-            from conversion.step3 import Step35Model
-            if not (issubclass(model_class, _Qwen35MtpMixin) or issubclass(model_class, Step35Model)):
-                logger.error("--mtp / --no-mtp are only supported for Qwen3.5/3.6 and Step3.5 text variants today")
+            if not model_class.supports_mtp_export:
+                logger.error("--mtp / --no-mtp are not supported for %s", model_architecture)
                 sys.exit(1)
             if args.no_mtp:
                 model_class.no_mtp = True


### PR DESCRIPTION
## Overview

--no-mtp/--mtp doesn't currently work on Hy3 (https://github.com/ggml-org/llama.cpp/pull/25395) despite the model supporting MTP.

Refactor how that those options are added by adding a flag to the ModelBase class and enabling for Qwen 3.x, Stepfun and Hy3.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I used codex to show me how this mtp/no-mtp option was enabled and refactored the code myself.