### PR TITLE
common : skip empty implicit default preset

### DIFF
--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -330,6 +330,10 @@ common_presets common_preset_context::load_from_ini(const std::string & path, co
             }
         }
 
+        if (preset.name == COMMON_PRESET_DEFAULT_NAME && preset.options.empty()) {
+            continue;
+        }
+
         if (preset.name == "*") {
             // handle global preset
             global = preset;


### PR DESCRIPTION
## Overview

The INI parser creates an implicit default section for top-level metadata. After reserved keys such as `version` are skipped, that section can have no model options but was still added and exposed in router mode.

Skip only the empty implicit default while preserving real default presets, named presets, and the global `[*]` settings.

## Additional information

Fixes #22364

Verification performed:

- Successfully built the CPU version of `llama-server`.
- Confirmed that a metadata-only default is no longer exposed as a model in router mode.
- Confirmed that a real default containing `model=...` is still preserved.
- Confirmed that global `[*]` settings are still applied without being exposed as a model.
- Confirmed that `git diff --check` passes.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I designed the solution and wrote the core code myself. AI suggested using the existing `COMMON_PRESET_DEFAULT_NAME` constant instead of the literal `"default"`, ran the build and three router-mode tests, and helped verify the diff. I reviewed the change, understand how it works, and take responsibility for it.