### PR TITLE
metal : add F16 support for ADD/SUB/MUL/DIV

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1142,13 +1142,17 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                         return false;
                 }
             }
+        case GGML_OP_ADD_ID:
+        case GGML_OP_ACC:
+            return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]) && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_ADD:
         case GGML_OP_SUB:
         case GGML_OP_MUL:
         case GGML_OP_DIV:
-        case GGML_OP_ADD_ID:
-        case GGML_OP_ACC:
-            return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]) && op->src[0]->type == GGML_TYPE_F32;
+            return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]) &&
+                (op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16) &&
+                op->src[1]->type == op->src[0]->type &&
+                op->type == op->src[0]->type;
         case GGML_OP_REPEAT:
         case GGML_OP_CONV_TRANSPOSE_1D:
             return true;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -3093,8 +3093,8 @@ int ggml_metal_op_bin(ggml_metal_op_t ctx, int idx) {
     GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
     GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
 
-    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32);
-    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16);
+    GGML_ASSERT(op->src[1]->type == op->src[0]->type);
 
     GGML_ASSERT(ggml_is_contiguous_rows(op->src[0]));
     GGML_ASSERT(ggml_is_contiguous_rows(op->src[1]));

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -1207,7 +1207,7 @@ constant short FC_bin_f  [[function_constant(FC_BIN + 1)]];
 constant bool  FC_bin_rb [[function_constant(FC_BIN + 2)]];
 constant bool  FC_bin_cb [[function_constant(FC_BIN + 3)]];
 
-template <typename T0, typename T1, typename T>
+template <typename T0, typename T1, typename T, typename TC>
 kernel void kernel_bin_fuse_impl(
         constant ggml_metal_kargs_bin & args,
         device const char * src0,
@@ -1233,48 +1233,48 @@ kernel void kernel_bin_fuse_impl(
             device const T1 * src1_row = (device const T1 *) (src1 + args.o1[0]);
 
             if (FC_OP == 0) {
-                dst_row[i0] = src0_row[i0] + src1_row[i1];
+                dst_row[i0] = (T) (TC(src0_row[i0]) + TC(src1_row[i1]));
             }
 
             if (FC_OP == 1) {
-                dst_row[i0] = src0_row[i0] - src1_row[i1];
+                dst_row[i0] = (T) (TC(src0_row[i0]) - TC(src1_row[i1]));
             }
 
             if (FC_OP == 2) {
-                dst_row[i0] = src0_row[i0] * src1_row[i1];
+                dst_row[i0] = (T) (TC(src0_row[i0]) * TC(src1_row[i1]));
             }
 
             if (FC_OP == 3) {
-                dst_row[i0] = src0_row[i0] / src1_row[i1];
+                dst_row[i0] = (T) (TC(src0_row[i0]) / TC(src1_row[i1]));
             }
         } else {
-            T0 res = src0_row[i0];
+            TC res = TC(src0_row[i0]);
 
             if (FC_OP == 0) {
                 FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                    res += ((device const T1 *) (src1 + args.o1[j]))[i1];
+                    res += TC(((device const T1 *) (src1 + args.o1[j]))[i1]);
                 }
             }
 
             if (FC_OP == 1) {
                 FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                    res -= ((device const T1 *) (src1 + args.o1[j]))[i1];
+                    res -= TC(((device const T1 *) (src1 + args.o1[j]))[i1]);
                 }
             }
 
             if (FC_OP == 2) {
                 FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                    res *= ((device const T1 *) (src1 + args.o1[j]))[i1];
+                    res *= TC(((device const T1 *) (src1 + args.o1[j]))[i1]);
                 }
             }
 
             if (FC_OP == 3) {
                 FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                    res /= ((device const T1 *) (src1 + args.o1[j]))[i1];
+                    res /= TC(((device const T1 *) (src1 + args.o1[j]))[i1]);
                 }
             }
 
-            dst_row[i0] = res;
+            dst_row[i0] = (T) res;
         }
     } else {
         const int i03 = tgpig.z;
@@ -1299,19 +1299,19 @@ kernel void kernel_bin_fuse_impl(
                 const int i10 = FC_CB ? i0%args.ne10 : i0;
 
                 if (FC_OP == 0) {
-                    dst_ptr[i0] = src0_ptr[i0] + src1_ptr[i10];
+                    dst_ptr[i0] = (T) (TC(src0_ptr[i0]) + TC(src1_ptr[i10]));
                 }
 
                 if (FC_OP == 1) {
-                    dst_ptr[i0] = src0_ptr[i0] - src1_ptr[i10];
+                    dst_ptr[i0] = (T) (TC(src0_ptr[i0]) - TC(src1_ptr[i10]));
                 }
 
                 if (FC_OP == 2) {
-                    dst_ptr[i0] = src0_ptr[i0] * src1_ptr[i10];
+                    dst_ptr[i0] = (T) (TC(src0_ptr[i0]) * TC(src1_ptr[i10]));
                 }
 
                 if (FC_OP == 3) {
-                    dst_ptr[i0] = src0_ptr[i0] / src1_ptr[i10];
+                    dst_ptr[i0] = (T) (TC(src0_ptr[i0]) / TC(src1_ptr[i10]));
                 }
             }
         } else {
@@ -1323,33 +1323,33 @@ kernel void kernel_bin_fuse_impl(
             for (int i0 = tpitg.x; i0 < args.ne0; i0 += ntg.x) {
                 const int i10 = FC_CB ? i0%args.ne10 : i0;
 
-                T res = src0_ptr[i0];
+                TC res = TC(src0_ptr[i0]);
 
                 if (FC_OP == 0) {
                     FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                        res += src1_ptr[j][i10];
+                        res += TC(src1_ptr[j][i10]);
                     }
                 }
 
                 if (FC_OP == 1) {
                     FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                        res -= src1_ptr[j][i10];
+                        res -= TC(src1_ptr[j][i10]);
                     }
                 }
 
                 if (FC_OP == 2) {
                     FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                        res *= src1_ptr[j][i10];
+                        res *= TC(src1_ptr[j][i10]);
                     }
                 }
 
                 if (FC_OP == 3) {
                     FOR_UNROLL (short j = 0; j < FC_F; ++j) {
-                        res /= src1_ptr[j][i10];
+                        res /= TC(src1_ptr[j][i10]);
                     }
                 }
 
-                dst_ptr[i0] = res;
+                dst_ptr[i0] = (T) res;
             }
         }
     }
@@ -1360,10 +1360,12 @@ kernel void kernel_bin_fuse_impl(
 #undef FC_CB
 }
 
-typedef decltype(kernel_bin_fuse_impl<float, float, float>) kernel_bin_fuse_t;
+typedef decltype(kernel_bin_fuse_impl<float, float, float, float>) kernel_bin_fuse_t;
 
-template [[host_name("kernel_bin_fuse_f32_f32_f32")]]   kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float,  float,  float>;
-template [[host_name("kernel_bin_fuse_f32_f32_f32_4")]] kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float4, float4, float4>;
+template [[host_name("kernel_bin_fuse_f32_f32_f32")]]   kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float,  float,  float,  float>;
+template [[host_name("kernel_bin_fuse_f32_f32_f32_4")]] kernel kernel_bin_fuse_t kernel_bin_fuse_impl<float4, float4, float4, float4>;
+template [[host_name("kernel_bin_fuse_f16_f16_f16")]]   kernel kernel_bin_fuse_t kernel_bin_fuse_impl<half,   half,   half,   float>;
+template [[host_name("kernel_bin_fuse_f16_f16_f16_4")]] kernel kernel_bin_fuse_t kernel_bin_fuse_impl<half4,  half4,  half4,  float4>;
 
 kernel void kernel_add_id(
         constant ggml_metal_kargs_add_id & args,


### PR DESCRIPTION
## Overview

Add F16 support for the binary ops ADD/SUB/MUL/DIV in the Metal backend.

Currently these ops only support F32 on Metal, so F16 tensors fall back to the CPU backend and cause graph splits. CUDA and Vulkan already support F16 for these ops.

- Add half/half4 instantiations of `kernel_bin_fuse_impl`, using float intermediate precision (same pattern as `kernel_unary_impl`)
- Relax `supports_op` and the asserts in `ggml_metal_op_bin` for ADD/SUB/MUL/DIV only, requiring matching src0/src1/dst types
- ADD_ID and ACC remain F32-only

Tested with `test-backend-ops` on M1: the previously skipped F16 cases now pass (ADD 79/79, SUB/MUL/DIV 71/71 each), and the full suite passes with no regressions.

## Additional information

Related to #14909.

Downstream context: I'm exploring an F16 activation path for the encoder of a ggml-based ASR engine (elementwise ops there are bandwidth-bound); Metal F16 support for binary ops is a prerequisite for that.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used for analysis and review, I wrote and finalized the change myself.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
