### PR TITLE
server : fix checkpoints not being freed when a slot's prompt is cleared

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -159,6 +159,10 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     llama_build_and_test(test-chat.cpp WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
     target_include_directories(test-chat PRIVATE ${PROJECT_SOURCE_DIR}/tools/server)
     target_link_libraries(test-chat PRIVATE server-context)
+
+    llama_build_and_test(test-server-prompt-checkpoints.cpp)
+    target_include_directories(test-server-prompt-checkpoints PRIVATE ${PROJECT_SOURCE_DIR}/tools/server)
+    target_link_libraries(test-server-prompt-checkpoints PRIVATE server-context)
     # TODO: disabled on loongarch64 because the ggml-ci node lacks Python 3.8
     if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "loongarch64")
         llama_build_and_test(test-json-schema-to-grammar.cpp   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/tests/test-server-prompt-checkpoints.cpp
+++ b/tests/test-server-prompt-checkpoints.cpp
@@ -1,0 +1,57 @@
+#include "server-task.h"
+
+#include <cassert>
+#include <cstdio>
+
+int main() {
+    server_prompt prompt;
+
+    // populate tokens, mirroring a slot that has processed a prompt
+    for (llama_token t = 0; t < 32; t++) {
+        prompt.tokens.push_back(t);
+    }
+
+    // populate checkpoints, mirroring the context-checkpoint mechanism
+    // (server-context.cpp creates these via slot.prompt.checkpoints.emplace_back())
+    for (int i = 0; i < 4; i++) {
+        common_prompt_checkpoint ckpt;
+        ckpt.n_tokens = 16;
+        ckpt.pos_min  = 0;
+        ckpt.pos_max  = 15;
+        ckpt.data_tgt = std::vector<uint8_t>(1024, 0xAB); // stand-in for a real KV-cache state blob
+
+        prompt.checkpoints.push_back(std::move(ckpt));
+    }
+
+    // sanity check on the fixture itself
+    assert(prompt.tokens.size() == 32);
+    assert(prompt.checkpoints.size() == 4);
+    assert(prompt.size() > 0); // dominated by the checkpoint buffers
+
+    const size_t size_before = prompt.size();
+
+    prompt.clear();
+
+    if (!prompt.tokens.empty()) {
+        fprintf(stderr, "FAIL: prompt.tokens not cleared (size = %zu)\n", prompt.tokens.size());
+        return 1;
+    }
+
+    if (!prompt.checkpoints.empty()) {
+        fprintf(stderr, "FAIL: prompt.checkpoints not cleared (size = %zu) - checkpoint buffers leaked "
+                         "(this reproduces https://github.com/ggml-org/llama.cpp/issues/25437)\n",
+                prompt.checkpoints.size());
+        return 1;
+    }
+
+    if (prompt.size() != 0) {
+        fprintf(stderr, "FAIL: prompt.size() == %zu after clear (was %zu before) - memory still held\n",
+                prompt.size(), size_before);
+        return 1;
+    }
+
+    printf("[test-server-prompt-checkpoints] OK: %zu bytes across %d checkpoints freed by prompt.clear()\n",
+           size_before, 4);
+
+    return 0;
+}

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -264,7 +264,7 @@ struct server_slot {
             common_context_seq_rm(ctx_dft, id, -1, -1);
         }
 
-        prompt.tokens.clear();
+        prompt.clear();
     }
 
     std::vector<common_adapter_lora_info> lora;

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -600,6 +600,12 @@ struct server_prompt {
 
     std::list<common_prompt_checkpoint> checkpoints;
 
+    // drops tokens and checkpoint to avoid buffers leaking once the underlying KV-cache rows are removed
+    void clear() {
+        tokens.clear();
+        checkpoints.clear();
+    }
+
     size_t size() const {
         size_t res = 0;
 


### PR DESCRIPTION
## Overview
This pull request addresses: 
server_slot::prompt_clear() cleared prompt.tokens but not prompt.checkpoints. 

Fixes #25437. 

Turns out checkpoints hold independent copies of KV-cache state (data_tgt/data_dft/data_spec), so they leaked every time a slot's context (prefix tokens) was cleared/reassigned. fix: added server_prompt::clear() clearing both; prompt_clear() now calls it. I have also added a regression test at tests/test-server-prompt-checkpoints.cpp. Also, the reporter's second suggested fix (excluding checkpoints from server_prompt_cache::alloc()) is already superseded by 6c487e2f7 upstream, so this PR only implements the smaller scoped fix of clearing the stray checkpoints.

Note that this is an edge case for sliding window attention where prefix context and sliding window need to either have the full slots context or discard the slots. For this specific attention pattern the system is forced to take a snapshot to keep the full context to restore checkpoints (needs full attention map for the corresponding layers + sliding attention context).

## Additional information
Fixes #25437

## Requirements

- [x] I have read and agree with the contributing guidelines
- [x] AI usage disclosure: YES | Understand the code base