### PR TITLE
metal : fix null-pipeline crash for F16 src1 mul_mat/mul_mat_id

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -1,9 +1,26 @@
 #include "ggml-metal-common.h"
 
+#include "ggml.h"
 #include "ggml-impl.h"
 #include "ggml-backend-impl.h"
 
 #include <vector>
+
+bool ggml_metal_op_mul_mat_use_mm(const struct ggml_tensor * op, bool has_simdgroup_mm) {
+    const int64_t ne00 = op->src[0]->ne[0];
+    const int64_t ne11 = op->src[1]->ne[1];
+
+    return !ggml_is_transposed(op->src[0]) &&
+           !ggml_is_transposed(op->src[1]) &&
+           has_simdgroup_mm && ne00 >= 64 && ne11 > 8;
+}
+
+bool ggml_metal_op_mul_mat_id_use_mm(const struct ggml_tensor * op, bool has_simdgroup_mm) {
+    const int64_t ne00 = op->src[0]->ne[0];
+    const int64_t ne21 = op->src[2]->ne[1];
+
+    return has_simdgroup_mm && ne00 >= 64 && ne21 >= 32;
+}
 
 // represents a memory range (i.e. an interval from a starting address p0 to an ending address p1 in a given buffer pb)
 // the type indicates whether it is a source range (i.e. ops read data from it) or a destination range (i.e. ops write data to it)

--- a/ggml/src/ggml-metal/ggml-metal-common.h
+++ b/ggml/src/ggml-metal/ggml-metal-common.h
@@ -47,6 +47,10 @@ bool ggml_mem_ranges_check(ggml_mem_ranges_t mrs, const struct ggml_tensor * ten
 //       if it proves to work well, we can start using it for other backends in the future
 void ggml_graph_optimize(struct ggml_cgraph * gf);
 
+// mat-mat vs mat-vec dispatch; used by both supports_op and ggml_metal_op_mul_mat*
+bool ggml_metal_op_mul_mat_use_mm   (const struct ggml_tensor * op, bool has_simdgroup_mm);
+bool ggml_metal_op_mul_mat_id_use_mm(const struct ggml_tensor * op, bool has_simdgroup_mm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1273,9 +1273,53 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_GATED_DELTA_NET:
             return has_simdgroup_reduction && op->src[2]->ne[0] % 32 == 0;
         case GGML_OP_SOLVE_TRI:
-        case GGML_OP_MUL_MAT:
-        case GGML_OP_MUL_MAT_ID:
             return has_simdgroup_reduction && op->src[0]->type != GGML_TYPE_NVFP4;
+        case GGML_OP_MUL_MAT:
+            {
+                if (!has_simdgroup_reduction || op->src[0]->type == GGML_TYPE_NVFP4) {
+                    return false;
+                }
+
+                // the mat-vec kernels only have an f16 x f16 variant when src0 is F16;
+                // for BF16 there is no f16-src1 kernel at all (mat-mat included), and for
+                // F32/quantized src0 there is no kernel_mul_mv_<type>_f16 (only _f32), so
+                // those shapes must take the mat-mat path instead, which does have full
+                // f16 coverage (see ggml_metal_op_mul_mat for the matching dispatch logic)
+                if (op->src[1]->type == GGML_TYPE_F16 && op->src[0]->type != GGML_TYPE_F16) {
+                    if (op->src[0]->type == GGML_TYPE_BF16) {
+                        return false;
+                    }
+
+                    return !ggml_is_transposed(op->src[0]) &&
+                           !ggml_is_transposed(op->src[1]) &&
+                           has_simdgroup_mm &&
+                           op->src[0]->ne[0] >= 64 &&
+                           op->src[1]->ne[1] > 8;
+                }
+
+                return true;
+            }
+        case GGML_OP_MUL_MAT_ID:
+            {
+                if (!has_simdgroup_reduction || op->src[0]->type == GGML_TYPE_NVFP4) {
+                    return false;
+                }
+
+                // the mat-vec-id kernels have no f16-src1 variant for any src0 type (only
+                // f32); f16 src1 is only supported via the mat-mat-id path, and even that
+                // path has no f16-src1 kernel for BF16 src0
+                if (op->src[1]->type == GGML_TYPE_F16) {
+                    if (op->src[0]->type == GGML_TYPE_BF16) {
+                        return false;
+                    }
+
+                    return has_simdgroup_mm &&
+                           op->src[0]->ne[0] >= 64 &&
+                           op->src[2]->ne[1] >= 32;
+                }
+
+                return true;
+            }
         case GGML_OP_SET:
         case GGML_OP_CPY:
         case GGML_OP_DUP:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -3,6 +3,7 @@
 #import "ggml-impl.h"
 #import "ggml-backend-impl.h"
 #import "ggml-metal-impl.h"
+#import "ggml-metal-common.h"
 
 #include <Foundation/Foundation.h>
 
@@ -1742,17 +1743,11 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_MUL_MAT:
             return ggml_metal_supports_mul_mat_op(
                     has_simdgroup_reduction, op, true,
-                    !ggml_is_transposed(op->src[0]) &&
-                    !ggml_is_transposed(op->src[1]) &&
-                    has_simdgroup_mm &&
-                    op->src[0]->ne[0] >= 64 &&
-                    op->src[1]->ne[1] > 8);
+                    ggml_metal_op_mul_mat_use_mm(op, has_simdgroup_mm));
         case GGML_OP_MUL_MAT_ID:
             return ggml_metal_supports_mul_mat_op(
                     has_simdgroup_reduction, op, false,
-                    has_simdgroup_mm &&
-                    op->src[0]->ne[0] >= 64 &&
-                    op->src[2]->ne[1] >= 32);
+                    ggml_metal_op_mul_mat_id_use_mm(op, has_simdgroup_mm));
         case GGML_OP_SET:
         case GGML_OP_CPY:
         case GGML_OP_DUP:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1710,9 +1710,53 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_GATED_DELTA_NET:
             return has_simdgroup_reduction && op->src[2]->ne[0] % 32 == 0;
         case GGML_OP_SOLVE_TRI:
-        case GGML_OP_MUL_MAT:
-        case GGML_OP_MUL_MAT_ID:
             return has_simdgroup_reduction && op->src[0]->type != GGML_TYPE_NVFP4;
+        case GGML_OP_MUL_MAT:
+            {
+                if (!has_simdgroup_reduction || op->src[0]->type == GGML_TYPE_NVFP4) {
+                    return false;
+                }
+
+                // the mat-vec kernels only have an f16 x f16 variant when src0 is F16;
+                // for BF16 there is no f16-src1 kernel at all (mat-mat included), and for
+                // F32/quantized src0 there is no kernel_mul_mv_<type>_f16 (only _f32), so
+                // those shapes must take the mat-mat path instead, which does have full
+                // f16 coverage (see ggml_metal_op_mul_mat for the matching dispatch logic)
+                if (op->src[1]->type == GGML_TYPE_F16 && op->src[0]->type != GGML_TYPE_F16) {
+                    if (op->src[0]->type == GGML_TYPE_BF16) {
+                        return false;
+                    }
+
+                    return !ggml_is_transposed(op->src[0]) &&
+                           !ggml_is_transposed(op->src[1]) &&
+                           has_simdgroup_mm &&
+                           op->src[0]->ne[0] >= 64 &&
+                           op->src[1]->ne[1] > 8;
+                }
+
+                return true;
+            }
+        case GGML_OP_MUL_MAT_ID:
+            {
+                if (!has_simdgroup_reduction || op->src[0]->type == GGML_TYPE_NVFP4) {
+                    return false;
+                }
+
+                // the mat-vec-id kernels have no f16-src1 variant for any src0 type (only
+                // f32); f16 src1 is only supported via the mat-mat-id path, and even that
+                // path has no f16-src1 kernel for BF16 src0
+                if (op->src[1]->type == GGML_TYPE_F16) {
+                    if (op->src[0]->type == GGML_TYPE_BF16) {
+                        return false;
+                    }
+
+                    return has_simdgroup_mm &&
+                           op->src[0]->ne[0] >= 64 &&
+                           op->src[2]->ne[1] >= 32;
+                }
+
+                return true;
+            }
         case GGML_OP_SET:
         case GGML_OP_CPY:
         case GGML_OP_DUP:

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -788,6 +788,12 @@ void ggml_metal_encoder_debug_group_pop (ggml_metal_encoder_t encoder) {
 }
 
 void ggml_metal_encoder_set_pipeline(ggml_metal_encoder_t encoder, struct ggml_metal_pipeline_with_params pipeline) {
+    // compile_pipeline already logs the missing kernel name; dummy_kernel probes
+    // use compile_pipeline directly and must still be allowed to return nil
+    if (!pipeline.pipeline) {
+        GGML_ABORT("%s: nil Metal pipeline (missing kernel; see compile_pipeline log above)\n", __func__);
+    }
+
     [encoder->obj setComputePipelineState:pipeline.pipeline->obj];
 }
 

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -788,8 +788,6 @@ void ggml_metal_encoder_debug_group_pop (ggml_metal_encoder_t encoder) {
 }
 
 void ggml_metal_encoder_set_pipeline(ggml_metal_encoder_t encoder, struct ggml_metal_pipeline_with_params pipeline) {
-    // compile_pipeline already logs the missing kernel name; dummy_kernel probes
-    // use compile_pipeline directly and must still be allowed to return nil
     if (!pipeline.pipeline) {
         GGML_ABORT("%s: nil Metal pipeline (missing kernel; see compile_pipeline log above)\n", __func__);
     }
@@ -1413,6 +1411,30 @@ void ggml_metal_device_get_memory(ggml_metal_device_t dev, size_t * free, size_t
     }
 }
 
+static bool ggml_metal_supports_mul_mat_op(
+        bool has_simdgroup_reduction,
+        const struct ggml_tensor * op,
+        bool src0_f16_has_mv,
+        bool mm_path) {
+    if (!has_simdgroup_reduction || op->src[0]->type == GGML_TYPE_NVFP4) {
+        return false;
+    }
+
+    if (op->src[1]->type != GGML_TYPE_F16) {
+        return true;
+    }
+
+    if (op->src[0]->type == GGML_TYPE_BF16) {
+        return false;
+    }
+
+    if (src0_f16_has_mv && op->src[0]->type == GGML_TYPE_F16) {
+        return true;
+    }
+
+    return mm_path;
+}
+
 bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_tensor * op) {
     const bool has_simdgroup_mm        = dev->props.has_simdgroup_mm;
     const bool has_simdgroup_reduction = dev->props.has_simdgroup_reduction;
@@ -1716,53 +1738,21 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
         case GGML_OP_GATED_DELTA_NET:
             return has_simdgroup_reduction && op->src[2]->ne[0] % 32 == 0;
         case GGML_OP_SOLVE_TRI:
-            return has_simdgroup_reduction && op->src[0]->type != GGML_TYPE_NVFP4;
+            return has_simdgroup_reduction && op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_MUL_MAT:
-            {
-                if (!has_simdgroup_reduction || op->src[0]->type == GGML_TYPE_NVFP4) {
-                    return false;
-                }
-
-                // the mat-vec kernels only have an f16 x f16 variant when src0 is F16;
-                // for BF16 there is no f16-src1 kernel at all (mat-mat included), and for
-                // F32/quantized src0 there is no kernel_mul_mv_<type>_f16 (only _f32), so
-                // those shapes must take the mat-mat path instead, which does have full
-                // f16 coverage (see ggml_metal_op_mul_mat for the matching dispatch logic)
-                if (op->src[1]->type == GGML_TYPE_F16 && op->src[0]->type != GGML_TYPE_F16) {
-                    if (op->src[0]->type == GGML_TYPE_BF16) {
-                        return false;
-                    }
-
-                    return !ggml_is_transposed(op->src[0]) &&
-                           !ggml_is_transposed(op->src[1]) &&
-                           has_simdgroup_mm &&
-                           op->src[0]->ne[0] >= 64 &&
-                           op->src[1]->ne[1] > 8;
-                }
-
-                return true;
-            }
+            return ggml_metal_supports_mul_mat_op(
+                    has_simdgroup_reduction, op, true,
+                    !ggml_is_transposed(op->src[0]) &&
+                    !ggml_is_transposed(op->src[1]) &&
+                    has_simdgroup_mm &&
+                    op->src[0]->ne[0] >= 64 &&
+                    op->src[1]->ne[1] > 8);
         case GGML_OP_MUL_MAT_ID:
-            {
-                if (!has_simdgroup_reduction || op->src[0]->type == GGML_TYPE_NVFP4) {
-                    return false;
-                }
-
-                // the mat-vec-id kernels have no f16-src1 variant for any src0 type (only
-                // f32); f16 src1 is only supported via the mat-mat-id path, and even that
-                // path has no f16-src1 kernel for BF16 src0
-                if (op->src[1]->type == GGML_TYPE_F16) {
-                    if (op->src[0]->type == GGML_TYPE_BF16) {
-                        return false;
-                    }
-
-                    return has_simdgroup_mm &&
-                           op->src[0]->ne[0] >= 64 &&
-                           op->src[2]->ne[1] >= 32;
-                }
-
-                return true;
-            }
+            return ggml_metal_supports_mul_mat_op(
+                    has_simdgroup_reduction, op, false,
+                    has_simdgroup_mm &&
+                    op->src[0]->ne[0] >= 64 &&
+                    op->src[2]->ne[1] >= 32);
         case GGML_OP_SET:
         case GGML_OP_CPY:
         case GGML_OP_DUP:

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2040,6 +2040,16 @@ int ggml_metal_op_pool_2d(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
+// defense in depth: a missing Metal kernel should be a clear, actionable abort instead of
+// a null-pipeline dereference deep in the encoder (ggml_metal_library_compile_pipeline
+// already logs the underlying MTLLibraryErrorDomain error before returning a nil pipeline)
+static void ggml_metal_op_mul_mat_check_pipeline(const ggml_metal_pipeline_with_params & pipeline, const ggml_tensor * op) {
+    if (!pipeline.pipeline) {
+        GGML_ABORT("%s: no Metal kernel for op = %s, src0 type = %s, src1 type = %s",
+                __func__, ggml_op_name(op->op), ggml_type_name(op->src[0]->type), ggml_type_name(op->src[1]->type));
+    }
+}
+
 int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
@@ -2140,6 +2150,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         };
 
         auto pipeline = ggml_metal_library_get_pipeline_mul_mv_ext(lib, op, nsg, nxpsg, r1ptg);
+        ggml_metal_op_mul_mat_check_pipeline(pipeline, op);
 
         ggml_metal_kargs_mul_mv_ext args = {
             /*.ne00  =*/ ne00,
@@ -2187,6 +2198,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         //}
 
         auto pipeline = ggml_metal_library_get_pipeline_mul_mm(lib, op);
+        ggml_metal_op_mul_mat_check_pipeline(pipeline, op);
 
         ggml_metal_kargs_mul_mm args = {
             /*.ne00 =*/ ne00,
@@ -2222,6 +2234,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_dispatch_threadgroups(enc, ((ne11 + nr1 - 1) / nr1), ((ne01 + nr0 - 1) / nr0), ne12 * ne13, 32, nsg, 1);
     } else {
         auto pipeline = ggml_metal_library_get_pipeline_mul_mv(lib, op);
+        ggml_metal_op_mul_mat_check_pipeline(pipeline, op);
 
         const int nr0 = pipeline.nr0;
         const int nr1 = pipeline.nr1;
@@ -2382,6 +2395,7 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
 
         {
             auto pipeline = ggml_metal_library_get_pipeline_mul_mm_id(lib, op);
+            ggml_metal_op_mul_mat_check_pipeline(pipeline, op);
 
             ggml_metal_kargs_mul_mm_id args = {
                 /*.ne00  =*/ ne00,
@@ -2418,6 +2432,7 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
         }
     } else {
         auto pipeline = ggml_metal_library_get_pipeline_mul_mv_id(lib, op);
+        ggml_metal_op_mul_mat_check_pipeline(pipeline, op);
 
         const int nr0 = pipeline.nr0;
         const int nr1 = pipeline.nr1;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2362,10 +2362,6 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     const int16_t r2 = ne12/ne02;
     const int16_t r3 = ne13/ne03;
 
-    // find the break-even point where the matrix-matrix kernel becomes more efficient compared
-    // to the matrix-vector kernel
-    const int ne11_mm_min = 8;
-
     // first try to use small-batch mat-mv kernels
     // these should be efficient for BS [2, ~8]
     if (op->src[1]->type == GGML_TYPE_F32 && (ne00%128 == 0) &&
@@ -2468,12 +2464,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
 
         ggml_metal_encoder_dispatch_threadgroups(enc, ((ne01 + r0ptg - 1)/r0ptg), ((ne11 + r1ptg - 1)/r1ptg), ne12*ne13, 32, nsg, 1);
-    } else if (
-        !ggml_is_transposed(op->src[0]) &&
-        !ggml_is_transposed(op->src[1]) &&
-        // for now the matrix-matrix multiplication kernel only works on A14+/M1+ SoCs
-        // AMD GPU and older A-chips will reuse matrix-vector multiplication kernel
-        props_dev->has_simdgroup_mm && ne00 >= 64 && ne11 > ne11_mm_min) {
+    } else if (ggml_metal_op_mul_mat_use_mm(op, props_dev->has_simdgroup_mm)) {
         //GGML_LOG_INFO("matrix: ne00 = %6d, ne01 = %6d, ne02 = %6d, ne11 = %6d, ne12 = %6d\n", ne00, ne01, ne02, ne11, ne12);
 
         // some Metal matrix data types require aligned pointers
@@ -2622,13 +2613,7 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
     const uint32_t r2 = 1;
     const uint32_t r3 = 1;
 
-    // find the break-even point where the matrix-matrix kernel becomes more efficient compared
-    // to the matrix-vector kernel
-    // ne20 = n_used_experts
-    // ne21 = n_rows (batch size)
-    const int ne21_mm_id_min = 32;
-
-    if (props_dev->has_simdgroup_mm && ne00 >= 64 && (ne21 >= ne21_mm_id_min)) {
+    if (ggml_metal_op_mul_mat_id_use_mm(op, props_dev->has_simdgroup_mm)) {
         // some Metal matrix data types require aligned pointers
         // ref: https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf (Table 2.5)
         //switch (op->src[0]->type) {


### PR DESCRIPTION
## Overview

Fixes #27949

`supports_op` accepts MUL_MAT/MUL_MAT_ID with quantized src0 and F16 src1 for any shape, but only the mat-mat kernels have F16 src1 variants: `kernel_mul_mm_<type>_f16` exists for all quantized types, `kernel_mul_mv_<type>_f16` for none. Shapes that dispatch to the mat-vec path request a kernel that does not exist, `ggml_metal_library_compile_pipeline` logs the error and returns a nil pipeline, and `ggml_metal_encoder_set_pipeline` dereferences it:

```
ggml_metal_library_compile_pipeline: Error Domain=MTLLibraryErrorDomain Code=5
"Function kernel_mul_mv_q8_0_f16 was not found in the library"
* thread #1, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: ggml_metal_encoder_set_pipeline
```

Changes:

- `supports_op`: for F16 src1 with non-F16 src0, only accept shapes that take the mat-mat path, mirroring the dispatch conditions in `ggml_metal_op_mul_mat` / `ggml_metal_op_mul_mat_id`. Other shapes now fall back to the CPU backend instead of crashing.
- MUL_MAT_ID has the same issue but worse coverage: the mat-vec-id kernels have no F16 src1 variant for any src0 type. Same gating applied.
- BF16 src0 with F16 src1 is rejected outright: there is no F16-src1 kernel for BF16 on any path (mat-mat included), so routing it to mat-mat would just move the crash.
- Defense in depth: `ggml_metal_encoder_set_pipeline` aborts on a nil pipeline instead of dereferencing it, so any future kernel-coverage gap fails loudly (same symptom as #21381).

Why the existing tests never caught this: `test-backend-ops` only executes a case when both the tested backend and the CPU reference support it, and the CPU backend rejects quantized src0 with F16 src1 (src1 must be F32 or the vec_dot type). So the F16-src1 MUL_MAT cases in the test matrix were always skipped on Metal and the crash path was never exercised.

Tested on M1:

- Two standalone reproducers (MUL_MAT q8_0 x F16 with ne11 <= 8, MUL_MAT_ID q8_0 x F16): before the fix `supports_op` returns true and graph compute crashes with SIGSEGV; after the fix `supports_op` returns false and Metal-only compute aborts with `unsupported op` instead of SIGSEGV.
- Full `test-backend-ops` suite passes with no regressions (full test-backend-ops suite still passes); the affected small-batch F16-src1 combinations now correctly report "not supported".

## Additional information

CUDA already rejects this combination in `supports_op` (`b->type == GGML_TYPE_F16 && a->type != GGML_TYPE_F16`); Vulkan supports it via src1-parameterized mat-vec shaders. Adding `kernel_mul_mv_<type>_f16` is out of scope here.

Downstream context: hit this while testing an F16 activation path in a ggml-based ASR engine - short audio inputs produce narrow batches (ne11 <= 8) that route to the mat-vec path.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used for analysis and review, I wrote and finalized the change myself.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
