### PR TITLE
vulkan: do not enable MMVQ for speculative-decode steps on AMD

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -9005,6 +9005,11 @@ static void ggml_vk_mul_mat_q_f16(ggml_backend_vk_context * ctx, vk_context& sub
 }
 
 // Device tuning
+// Upper bound on n for a step to be treated as decode-like rather than batched.
+// A speculative-decode step evaluates n = 1 + n_draft tokens; common draft widths
+// sit well inside this. Prefill uses far larger n and is unaffected.
+static constexpr uint32_t MMVQ_MAX_DECODE_LIKE_N = 8;
+
 static bool ggml_vk_should_use_mmvq(const vk_device& device, uint32_t m, uint32_t n, uint32_t k, ggml_type src0_type) {
     if (device->mmvq_mode == 1) {
         return true;
@@ -9026,8 +9031,18 @@ static bool ggml_vk_should_use_mmvq(const vk_device& device, uint32_t m, uint32_
         return false;
     }
 
-    // MMVQ is generally good for batches
-    if (n > 1) {
+    // MMVQ is generally good for batches.
+    //
+    // A speculative-decode step is the exception: it evaluates only
+    // n = 1 + n_draft tokens, and typical draft widths are small. At those n the
+    // Q8_1 quantization of the activations does not amortize, and it perturbs the
+    // logits enough that the draft and the target disagree on tokens they should
+    // agree on, which lowers draft acceptance.
+    //
+    // The per-vendor heuristics below predate speculative decoding and were only
+    // ever reached at n == 1. Let decode-like n reach them too, so each vendor's
+    // existing small-k thresholds apply; none of those thresholds are changed here.
+    if (n > MMVQ_MAX_DECODE_LIKE_N) {
         return true;
     }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -9012,6 +9012,13 @@ static bool ggml_vk_should_use_mmvq(const vk_device& device, uint32_t m, uint32_
         return false;
     }
 
+    const bool is_k_quant =
+        src0_type == GGML_TYPE_Q2_K ||
+        src0_type == GGML_TYPE_Q3_K ||
+        src0_type == GGML_TYPE_Q4_K ||
+        src0_type == GGML_TYPE_Q5_K ||
+        src0_type == GGML_TYPE_Q6_K;
+
     // q6_k only has 2-byte alignment which makes it somewhat problematic,
     // using MMVQ is only a win on Intel.
     bool mmvq_q6 = device->vendor_id == VK_VENDOR_ID_INTEL;
@@ -9051,7 +9058,9 @@ static bool ggml_vk_should_use_mmvq(const vk_device& device, uint32_t m, uint32_
         case GGML_TYPE_Q8_0:
             return device->architecture == vk_device_architecture::AMD_GCN;
         default:
-            return true;
+            // For k-quants the extra Q8_1 quantization does not pay for itself at
+            // small k; plain DMMV is faster.
+            return !is_k_quant || k >= 4096;
         }
     case VK_VENDOR_ID_INTEL:
         if (device->architecture == vk_device_architecture::INTEL_XE2) {


### PR DESCRIPTION
## Disclosure

I used AI assistance (Claude) for the investigation, benchmarking and drafting of this PR, including this description and the commit messages. I have reviewed and validated everything myself; all measurements below were run on my own hardware and are reproducible. Flagging this explicitly per CONTRIBUTING.md.

## Summary

`ggml_vk_should_use_mmvq()` returns early with *"MMVQ is generally good for batches"* for any `n > 1`. A speculative-decode step evaluates `n = 1 + n_draft` tokens, so it takes that path and enables MMVQ — bypassing the per-vendor small-`k` heuristics below it.

Those heuristics predate speculative decoding and were only ever reachable at `n == 1`. This PR raises the cutoff so decode-like `n` reaches them too. **No vendor threshold is changed** — they simply now apply at the small `n` a speculative step actually uses.

Enabling MMVQ there costs twice:

1. The Q8_1 quantization of the activations does not amortize at such small `n`.
2. It **perturbs the logits**, so the draft and the target disagree on tokens they should agree on — lowering **draft acceptance**.

The second effect is the less obvious one: MMVQ was not merely slower in the speculative path, it was degrading speculation quality.

## Commits

- `vulkan: don't use MMVQ for k-quants at small k on AMD` — AMD-specific tuning: for k-quants the Q8_1 quantization does not pay for itself at small `k`; DMMV is faster.
- `vulkan: treat a speculative-decode step as decode, not as a batch` — vendor-agnostic; raises the `n > 1` cutoff to `MMVQ_MAX_DECODE_LIKE_N`.

## Testing

AMD Ryzen AI Max+ 395 "Strix Halo" (gfx1151, 40 CU, RADV/Mesa), 128 GB unified memory.
Model: 35B-A3B MoE, Q6_K attention + Q4_K FFN. MTP self-speculation (`--spec-type draft-mtp --spec-draft-n-max 2`), ~33k context, 2 runs each, against master `7f575c39d`.

| | master | this PR |
|---|---|---|
| TG, speculative | 75.2 t/s | **84.9 t/s** (+12.9%) |
| draft acceptance | 72–75% | **83–85%** |
| TG, non-speculative | 72.9 t/s | 73.9 t/s |
| PP (prefill), pp4096 | 679.4 t/s | 677.5 t/s (unchanged) |

Prefill is unaffected because `n` there is far larger — with a 2048 ubatch the per-expert token counts are ~64+, well above the cutoff, so batched MMVQ is retained.

An op-level trace of the MMVQ decisions during a speculative step on master shows the mechanism directly:

```
984x  n=3 k=2048 m=512  q4_K -> MMVQ     (expert up/gate)
492x  n=3 k=512  m=2048 q4_K -> MMVQ     (expert down)
220x  n=1 ...          q4_K -> dmmv      (plain decode, correctly bypassed)
```

## Caveats

- **I could only test gfx1151.** The second commit now applies to all vendors per review feedback, but I have no NVIDIA or Intel hardware to validate against. Numbers from someone with a dGPU would be very welcome — particularly whether MMVQ at `n = 2..8` is a win on those backends, since if so the cutoff may need to stay vendor-conditional.
- The first commit changes AMD behaviour at `n == 1` and therefore also affects **discrete** RDNA cards, which I likewise could not test. It is kept as a separate commit so it can be dropped independently.
- `MMVQ_MAX_DECODE_LIKE_N = 8` is a bound chosen to cover common draft widths. Happy to derive it from the actual draft width instead if you'd prefer something less arbitrary.
