### PR TITLE
tokenize : drop --stdin mutual-exclusion check

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2927,7 +2927,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_TOKENIZE}));
     add_opt(common_arg(
         {"--stdin"},
-        string_format("read the prompt from stdin (mutually exclusive with -f/--file and -p/--prompt) (default: %s)", params.tokenize_stdin ? "true" : "false"),
+        string_format("read the prompt from stdin (takes precedence over -f/--file and -p/--prompt) (default: %s)", params.tokenize_stdin ? "true" : "false"),
         [](common_params & params) {
             params.tokenize_stdin = true;
         }

--- a/tools/tokenize/tokenize.cpp
+++ b/tools/tokenize/tokenize.cpp
@@ -103,18 +103,10 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    // which prompt source was requested?
-    // -p/--prompt and -f/--file both end up in params.prompt (common's -f also
-    // strips a single trailing newline), but -f additionally records the path
-    // in params.prompt_file, so we use that to tell them apart.
+    // -f and -p both land in params.prompt; -f also sets prompt_file. -f and -p
+    // resolve like the other tools (no mutual exclusion), --stdin takes precedence.
     const bool use_stdin = params.tokenize_stdin;
     const bool use_file  = !params.prompt_file.empty();
-
-    // sanity check: --stdin is mutually exclusive with -f/--file and -p/--prompt
-    if (use_stdin && (use_file || !params.prompt.empty())) {
-        LOG_ERR("error: --stdin is mutually exclusive with --file and --prompt\n");
-        return 1;
-    }
 
     // must have some prompt
     if (!use_stdin && !use_file && params.prompt.empty()) {


### PR DESCRIPTION


## Overview

Drop `--stdin` mutual-exclusion check in `llama tokenize`

## Additional information

Match `llama cli` and `llama completion`, which don't enforce it.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
