### PR TITLE
llama-context : sync pending async copies before clearing embd_seq

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -451,6 +451,9 @@ llama_context::llama_context(
 }
 
 llama_context::~llama_context() {
+    // wait for any pending asynchronous copies into the output buffers before they are freed
+    synchronize();
+
     if (!model.hparams.no_alloc) {
         for (size_t i = 0; i < backend_ptrs.size(); ++i) {
             ggml_backend_t             backend = backend_ptrs[i];
@@ -1386,12 +1389,16 @@ int llama_context::encode(const llama_batch & batch_inp) {
     // micro-batching is not possible for non-causal encoding, so we process the batch in a single shot
     GGML_ASSERT(cparams.n_ubatch >= n_tokens && "encoder requires n_ubatch >= n_tokens");
 
+    // TODO: this clear of the buffer can easily be forgotten - need something better
+    // sync first so any in-flight async copies into embd_seq complete before it is freed
+    if (!embd_seq.empty()) {
+        synchronize();
+    }
+    embd_seq.clear();
+
     if (t_compute_start_us == 0) {
         t_compute_start_us = ggml_time_us();
     }
-
-    // TODO: this clear of the buffer can easily be forgotten - need something better
-    embd_seq.clear();
 
     sched_reserve();
 
@@ -1731,13 +1738,18 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     GGML_ASSERT((cparams.causal_attn || cparams.n_ubatch >= n_tokens_all) && "non-causal attention requires n_ubatch >= n_tokens");
 
+    // TODO: this clear of the buffer can easily be forgotten - need something better
+    // sync first so any in-flight async copies into embd_seq complete before it is freed
+    if (!embd_seq.empty()) {
+        synchronize();
+    }
+    embd_seq.clear();
+
     if (t_compute_start_us == 0) {
         t_compute_start_us = ggml_time_us();
     }
     n_queued_tokens += n_tokens_all;
 
-    // TODO: this clear of the buffer can easily be forgotten - need something better
-    embd_seq.clear();
     output_swaps.clear();
 
     sched_reserve();


### PR DESCRIPTION
## Overview

Fixes #25654

Pooled embeddings (`--pooling last/mean/cls`) are written into the per-sequence `embd_seq` buffers with an asynchronous backend copy. `embd_seq` is freed at the start of the next `decode()` / `encode()` (both clear it) and by the destructor, without waiting for the copy.

Without that synchronization, the copy can complete after the buffer is freed, writing into freed memory and corrupting the allocator's metadata, which aborts the process on the next allocation:

> llama-server(89298,0x1f9140c00) malloc: Incorrect checksum for freed object 0x13c888c00: probably modified after being freed.
Corrupt value: 0xc09339813e8a7d6f

This PR synchronizes before `embd_seq` is cleared in `decode()` / `encode()`, and in the destructor before the output buffers are freed.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES