### PR TITLE
ggml: force single thread on wasi

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2769,6 +2769,11 @@ struct ggml_cplan ggml_graph_plan(
     n_threads = 1;
 #endif
 
+#if defined(__wasi__)
+    // WASI doesn't support parallelism yet
+    n_threads = 1;
+#endif
+
     size_t work_size = 0;
 
     struct ggml_cplan cplan;


### PR DESCRIPTION
## Overview
WASI threads are cooperatively scheduled and never run in parallel, so a thread that spin-waits blocks all progress. With n_threads > 1, the main thread and workers deadlock in ggml_barrier.

Fix: clamp `n_threads` to 1, same as the Emscripten-without-pthreads clamp directly above.

## Additional information
More on wasi cooperative threads: https://github.com/WebAssembly/wasi-sdk/issues/589

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES
- Code reviewed by AI before opening PR

