### PR TITLE
ggml-backend-meta: fix device and buffer type names

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -64,13 +64,14 @@ struct ggml_backend_meta_device_context {
             simple_devs(std::move(simple_devs)), get_split_state(get_split_state), get_split_state_ud(get_split_state_ud) {
         name        = std::string("Meta(");
         description = std::string("Meta(");
-        for (size_t i = 0; i < simple_devs.size(); i++) {
+        // note: use the member, not the moved-from constructor parameter of the same name
+        for (size_t i = 0; i < this->simple_devs.size(); i++) {
             if (i > 0) {
                 name        += ",";
                 description += ",";
             }
-            name        += ggml_backend_dev_name       (simple_devs[i]);
-            description += ggml_backend_dev_description(simple_devs[i]);
+            name        += ggml_backend_dev_name       (this->simple_devs[i]);
+            description += ggml_backend_dev_description(this->simple_devs[i]);
         }
         name        += ")";
         description += ")";
@@ -253,11 +254,12 @@ struct ggml_backend_meta_buffer_type_context {
 
     ggml_backend_meta_buffer_type_context(std::vector<ggml_backend_buffer_type_t> simple_bufts) : simple_bufts(std::move(simple_bufts)) {
         name = "Meta(";
-        for (size_t i = 0; i < simple_bufts.size(); i++) {
+        // note: use the member, not the moved-from constructor parameter of the same name
+        for (size_t i = 0; i < this->simple_bufts.size(); i++) {
             if (i > 0) {
                 name += ",";
             }
-            name += ggml_backend_buft_name(simple_bufts[i]);
+            name += ggml_backend_buft_name(this->simple_bufts[i]);
         }
         name += ")";
     }


### PR DESCRIPTION
## Overview

Fixes the names of meta devices and meta buffer types: the constructors iterate the moved-from constructor parameter instead of the member of the same name, so every meta device and buffer type is named "Meta()".

With a single meta device this is cosmetic (the current -sm tensor path), but any code that distinguishes buffer types by name breaks as soon as more than one meta device exists — e.g. the KV cache context map in llama-kv-cache.cpp collapses the buffer types of distinct meta devices into one entry, allocating all layers' caches on the first device.

Verified: with two meta devices, names render as `Meta(CUDA0,CUDA1)` / `Meta(CUDA2,CUDA3)` and the per-layer buffer-type maps no longer collapse.

## Additional information

Found while experimenting with tensor parallelism for MLA architectures on a 12x RTX 3090 rig (multiple meta devices in one process). Related follow-up work will be proposed separately.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)[1]
- AI usage disclosure: YES. the bug was found, the fix authored, and the validation runs executed by an AI coding agent operating my hardware under my direction.


[1] I am NOT a cpp programmer, so I'm not in a position to evaluate the quality as I would with my main programming languages. That's my way on contributing back to this project. Given the contributing guidelines, I'll understand if you don't accept the PR.



-----
Edit:
### Results from the follow-up work (for context)

  On 12x RTX 3090 (PCIe Gen4), GLM-5.2 744B-A40B at UD-IQ2_M:

  | config | decode (novel text) | decode (code rewrite) | context |
  |---|---|---|---|
  | `-sm layer` (baseline) | 23 t/s | 23 t/s | 384K |
  | MLA TP, hybrid 2x6 + spec | 33 t/s | 69 t/s | 96K |
  | MLA TP, hybrid 4x3 + spec | 42 t/s | 107 t/s | 48K |

  "spec" = `--spec-type ngram-map-k4v,draft-mtp` (the GLM MTP head, ported from #24868 to
  GLM-DSA). TP output verified byte-identical to `-sm layer` on GLM-4.7-Flash before any
  speculative decoding was added.

  Branches: 
  [mla-tensor-parallel](https://github.com/Frozenlock/llama.cpp/tree/mla-tensor-parallel)
  [hybrid-tp-pp](https://github.com/Frozenlock/llama.cpp/tree/hybrid-tp-pp)
  [mla-mtp](https://github.com/Frozenlock/llama.cpp/tree/mla-mtp)

