### PR TITLE
ggml-backend-meta: do not scale view offsets internal to a split unit

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -1184,6 +1184,11 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
                 // The offset can be internal to the data split, in those cases the view offset should not be scaled.
                 // If however, the offset is larger than the data split then it needs to be scaled proportionally.
                 bool split_internal_offset = t_ij->view_offs <= tensor->view_src->nb[split_dim_view_src];
+                // An offset smaller than the stride of one split unit stays within each unit and
+                // must not be scaled (e.g. a view at a fixed offset into rows split by that unit).
+                if (t_ij->view_offs < tensor->nb[split_dim]) {
+                    split_internal_offset = true;
+                }
                 for (int i = 0; i < GGML_MAX_DIMS; i++) {
                     const size_t dim_size = tensor->ne[i] * tensor->nb[i];
                     if (tensor->view_offs <= dim_size && dim_size < tensor->nb[split_dim]) {


### PR DESCRIPTION
## Overview

The heuristic classifying a view offset as internal vs. proportional misses offsets smaller than the stride of one split unit — e.g. a strided view at a fixed offset into rows that are split along that unit. Such offsets apply within every unit on every device and must be preserved as-is; scaling them makes devices holding distributed slices read from the wrong position.

Concrete case: an MLA attention graph's rope view (offset 768 into 1024-byte per-head rows, rows split by head). The proportional scaling turned the offset into 384, landing mid-row, corrupting output whenever heads were actually distributed across devices. With the fix, -sm tensor output on GLM-4.7-Flash is byte-identical to -sm layer on even and skewed splits.

## Additional information

Prerequisite for MLA-architecture tensor parallelism (DeepSeek2/GLM-DSA), which I intend to propose as a follow-up; see the split scheme sketched by @gaugarg-nv in #19378.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)[1]
- AI usage disclosure: YES. the bug was found, the fix authored, and the validation runs executed by an AI coding agent operating my hardware under my direction.


[1] I am NOT a cpp programmer, so I'm not in a position to evaluate the quality as I would with my main programming languages. That's my way on contributing back to this project. Given the contributing guidelines, I'll understand if you don't accept the PR.
