### PR TITLE
DeepseekV4: support bounded partial rollback

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -968,6 +968,7 @@ bool llm_arch_supports_rs_rollback(const llm_arch & arch) {
     switch (arch) {
         case LLM_ARCH_QWEN35:
         case LLM_ARCH_QWEN35MOE:
+        case LLM_ARCH_DEEPSEEK4:
             return true;
         default:
             return false;

--- a/src/llama-kv-cache-dsv4.cpp
+++ b/src/llama-kv-cache-dsv4.cpp
@@ -979,13 +979,15 @@ llama_kv_cache_dsv4::llama_kv_cache_dsv4(
                  uint32_t   n_seq_max,
                  uint32_t   n_ubatch,
                  uint32_t   n_pad,
+                 uint32_t   n_rs_seq,
     const layer_filter_cb & filter,
     const  layer_reuse_cb & reuse) :
     hparams_raw(model.hparams),
     hparams_csa(model.hparams),
     hparams_hca(model.hparams),
     hparams_lid(model.hparams),
-    n_seq_max(n_seq_max) {
+    n_seq_max(n_seq_max),
+    n_rs_seq(n_rs_seq) {
 
     const layer_filter_cb filter_raw = [&](int32_t il) {
         if (filter && !filter(il)) {
@@ -1065,19 +1067,19 @@ llama_kv_cache_dsv4::llama_kv_cache_dsv4(
     LLAMA_LOG_INFO("%s: creating DSV4 CSA compressor state\n", __func__);
 
     csa_state = std::make_unique<llama_dsv4_comp_state>(
-            model, offload, unified_compressed, n_seq_max, DSV4_CSA_RATIO, 2*DSV4_CSA_RATIO,
+            model, offload, unified_compressed, n_seq_max, DSV4_CSA_RATIO, 2*DSV4_CSA_RATIO + n_rs_seq,
             2*model.hparams.n_embd_head_k(), "csa", filter_csa);
 
     LLAMA_LOG_INFO("%s: creating DSV4 HCA compressor state\n", __func__);
 
     hca_state = std::make_unique<llama_dsv4_comp_state>(
-            model, offload, unified_compressed, n_seq_max, DSV4_HCA_RATIO, DSV4_HCA_RATIO,
+            model, offload, unified_compressed, n_seq_max, DSV4_HCA_RATIO, DSV4_HCA_RATIO + n_rs_seq,
             model.hparams.n_embd_head_k(), "hca", filter_hca);
 
     LLAMA_LOG_INFO("%s: creating DSV4 lightning-indexer compressor state\n", __func__);
 
     lid_state = std::make_unique<llama_dsv4_comp_state>(
-            model, offload, unified_compressed, n_seq_max, DSV4_CSA_RATIO, 2*DSV4_CSA_RATIO,
+            model, offload, unified_compressed, n_seq_max, DSV4_CSA_RATIO, 2*DSV4_CSA_RATIO + n_rs_seq,
             2*model.hparams.indexer_head_size, "lid", filter_csa);
 
     // DSV4 attention reads compressed-K / compressor-state rows that the current
@@ -1212,8 +1214,22 @@ bool llama_kv_cache_dsv4::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1
     }
 
     if (p0 > 0) {
-        if (seq_id < 0 || (uint32_t) seq_id >= n_seq_max ||
-                p0 <= kv_raw->seq_pos_max(seq_id)) {
+        if (seq_id < 0 || (uint32_t) seq_id >= n_seq_max) {
+            return false;
+        }
+
+        // A compressed block row is derived from a compressor-state ring addressed by
+        // pos%state_size, so a token cannot be removed once the rows it wrote have been
+        // overwritten. The rings are oversized by n_rs_seq rows, which makes exactly the last
+        // n_rs_seq positions removable: their rows have not aliased onto any row that an
+        // unfinished block still reads, and they are simply rewritten by whatever is decoded
+        // next. A compressed row that a removed token completed keeps stale contents, but it
+        // sits at block index pos/ratio and is only exposed to a token once (pos + 1)/ratio
+        // exceeds it - which cannot happen again before that same position is re-decoded and
+        // rewrites the row.
+        const llama_pos rollback = kv_raw->seq_pos_max(seq_id) - (p0 - 1);
+
+        if (rollback > (llama_pos) n_rs_seq) {
             return false;
         }
 

--- a/src/llama-kv-cache-dsv4.h
+++ b/src/llama-kv-cache-dsv4.h
@@ -93,6 +93,7 @@ public:
                      uint32_t   n_seq_max,
                      uint32_t   n_ubatch,
                      uint32_t   n_pad,
+                     uint32_t   n_rs_seq,
         const layer_filter_cb & filter,
         const  layer_reuse_cb & reuse);
 
@@ -148,6 +149,11 @@ private:
     llama_hparams hparams_lid;
 
     const uint32_t n_seq_max;
+
+    // rollback budget: the compressor-state rings are oversized by this many rows so that the last
+    // n_rs_seq tokens can be removed without having overwritten a row that an unfinished block still
+    // has to read. 0 disables partial rollback.
+    const uint32_t n_rs_seq;
 
     std::unique_ptr<llama_kv_cache_iswa> kv_raw;
     std::unique_ptr<llama_kv_cache>      kv_csa;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2194,6 +2194,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                                 cparams.n_seq_max,
                                 cparams.n_ubatch,
                                 1,
+                                cparams.n_rs_seq,
                                 filter,
                                 reuse);
                     } else if (hparams.swa_type != LLAMA_SWA_TYPE_NONE) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,9 @@ set_tests_properties(test-state-restore-fragmented PROPERTIES FIXTURES_REQUIRED 
 llama_build_and_test(test-recurrent-state-rollback.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
 set_tests_properties(test-recurrent-state-rollback PROPERTIES FIXTURES_REQUIRED test-download-model)
 
+llama_build_and_test(test-dsv4-rollback.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
+set_tests_properties(test-dsv4-rollback PROPERTIES FIXTURES_REQUIRED test-download-model)
+
 # Test state save/load functionality
 llama_build_and_test(test-save-load-state.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
 set_tests_properties(test-save-load-state PROPERTIES FIXTURES_REQUIRED test-download-model)

--- a/tests/test-dsv4-rollback.cpp
+++ b/tests/test-dsv4-rollback.cpp
@@ -1,0 +1,163 @@
+// DSV4 bounded partial rollback.
+//
+// The DSV4 compressed caches are derived from a compressor-state ring addressed by pos%state_size.
+// Rolling back the last k tokens is only sound if the rows those tokens wrote had not aliased onto
+// rows an unfinished block still has to read. This checks exactly that: decode a prompt, decode k
+// wrong tokens on top (a rejected draft), roll them back, decode the real k tokens, and require the
+// resulting logits to match a context that decoded the real tokens all along.
+//
+// An end-to-end speculative-vs-greedy comparison cannot serve as this gate: the target evaluates a
+// draft as one batch, which reorders float reductions, so greedy speculative output may legitimately
+// differ from greedy non-speculative output on near-ties regardless of rollback correctness.
+
+#include "arg.h"
+#include "common.h"
+#include "llama.h"
+
+#include <clocale>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+static constexpr uint32_t N_ROLLBACK = 5;
+
+static llama_context * make_ctx(const common_params & params, llama_model * model) {
+    auto cparams = common_context_params_to_llama(params);
+    cparams.n_seq_max = 1;
+    cparams.n_rs_seq  = N_ROLLBACK;
+    cparams.n_batch   = std::max(cparams.n_batch,  (uint32_t) (cparams.n_rs_seq + 1));
+    cparams.n_ubatch  = std::max(cparams.n_ubatch, (uint32_t) (cparams.n_rs_seq + 1));
+    return llama_init_from_model(model, cparams);
+}
+
+static bool decode_range(llama_context * ctx, const std::vector<llama_token> & tokens,
+                         size_t first, size_t last, bool logits_last) {
+    llama_batch batch = llama_batch_init(last - first, 0, 1);
+    for (size_t pos = first; pos < last; ++pos) {
+        common_batch_add(batch, tokens[pos], (llama_pos) pos, { 0 }, logits_last && pos + 1 == last);
+    }
+    const bool ok = llama_decode(ctx, batch) == 0;
+    llama_batch_free(batch);
+    return ok;
+}
+
+int main(int argc, char ** argv) {
+    std::setlocale(LC_NUMERIC, "C");
+
+    common_params params;
+    params.sampling.seed = 1234;
+    params.n_predict = 1;
+
+    common_init();
+
+    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_COMMON)) {
+        return 1;
+    }
+
+    ggml_backend_load_all();
+
+    common_init_result_ptr llama_init = common_init_from_params(params);
+    llama_model * model = llama_init->model();
+    if (model == nullptr) {
+        fprintf(stderr, "%s : failed to init model\n", __func__);
+        return 1;
+    }
+
+    llama_context * ctx_ref = make_ctx(params, model);
+    llama_context * ctx_rb  = make_ctx(params, model);
+    if (ctx_ref == nullptr || ctx_rb == nullptr) {
+        fprintf(stderr, "%s : failed to init contexts\n", __func__);
+        return 1;
+    }
+
+    if (llama_n_rs_seq(ctx_ref) == 0) {
+        fprintf(stderr, "%s : skipping, the model does not support bounded rollback\n", __func__);
+        return 0;
+    }
+
+    const llama_vocab * vocab   = llama_model_get_vocab(model);
+    const int           n_vocab = llama_vocab_n_tokens(vocab);
+
+    // The rolled-back span has to complete a block of every compressed cache, otherwise the rollback
+    // of that cache is never exercised: CSA and the indexer compress every 4 positions, but HCA only
+    // every 128. Decode N_TOKENS positions and remove the last N_ROLLBACK, so that the HCA boundary
+    // at position DSV4_HCA_RATIO - 1 falls inside the removed span and has to be recomputed.
+    constexpr size_t DSV4_HCA_RATIO = 128;
+    constexpr size_t N_TOKENS       = DSV4_HCA_RATIO + 2;                 // 130
+    constexpr size_t N_KEEP         = N_TOKENS - N_ROLLBACK;              // 125
+    static_assert(N_KEEP <= DSV4_HCA_RATIO - 1 && DSV4_HCA_RATIO - 1 < N_TOKENS,
+            "the HCA block boundary must fall inside the rolled-back span");
+
+    std::vector<llama_token> tokens;
+    while (tokens.size() < N_TOKENS) {
+        std::vector<llama_token> chunk = common_tokenize(ctx_ref,
+                "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. "
+                "How vexingly quick daft zebras jump! The five boxing wizards jump quickly. ",
+                tokens.empty());
+        tokens.insert(tokens.end(), chunk.begin(), chunk.end());
+    }
+    tokens.resize(N_TOKENS);
+
+    const size_t n_keep = N_KEEP;
+
+    // reference: decode the prompt as prefix + the real tail
+    if (!decode_range(ctx_ref, tokens, 0, n_keep, false) ||
+        !decode_range(ctx_ref, tokens, n_keep, tokens.size(), true)) {
+        fprintf(stderr, "%s : reference decode failed\n", __func__);
+        return 1;
+    }
+
+    // rollback: same prefix, then a wrong tail (a rejected draft), rolled back, then the real tail
+    std::vector<llama_token> wrong = tokens;
+    for (size_t i = n_keep; i < wrong.size(); ++i) {
+        wrong[i] = (wrong[i] + 1) % n_vocab;
+    }
+
+    if (!decode_range(ctx_rb, tokens, 0, n_keep, false) ||
+        !decode_range(ctx_rb, wrong, n_keep, wrong.size(), false)) {
+        fprintf(stderr, "%s : draft decode failed\n", __func__);
+        return 1;
+    }
+
+    if (!llama_memory_seq_rm(llama_get_memory(ctx_rb), 0, (llama_pos) n_keep, -1)) {
+        fprintf(stderr, "%s : rollback of %u tokens was refused\n", __func__, N_ROLLBACK);
+        return 1;
+    }
+
+    if (!decode_range(ctx_rb, tokens, n_keep, tokens.size(), true)) {
+        fprintf(stderr, "%s : replay decode failed\n", __func__);
+        return 1;
+    }
+
+    const float * logits_ref = llama_get_logits_ith(ctx_ref, -1);
+    const float * logits_rb  = llama_get_logits_ith(ctx_rb,  -1);
+    if (logits_ref == nullptr || logits_rb == nullptr) {
+        fprintf(stderr, "%s : missing logits\n", __func__);
+        return 1;
+    }
+
+    constexpr float eps = 1e-3f;
+
+    float max_diff = 0.0f;
+    int   arg_ref = 0;
+    int   arg_rb  = 0;
+    for (int i = 0; i < n_vocab; ++i) {
+        max_diff = std::max(max_diff, std::fabs(logits_ref[i] - logits_rb[i]));
+        if (logits_ref[i] > logits_ref[arg_ref]) { arg_ref = i; }
+        if (logits_rb [i] > logits_rb [arg_rb ]) { arg_rb  = i; }
+    }
+
+    fprintf(stderr, "%s : max logit diff = %g, argmax ref = %d, argmax rollback = %d\n",
+            __func__, (double) max_diff, arg_ref, arg_rb);
+
+    if (max_diff > eps || arg_ref != arg_rb) {
+        fprintf(stderr, "%s : FAILED - rollback did not reconstruct the reference state\n", __func__);
+        return 1;
+    }
+
+    fprintf(stderr, "%s : bounded rollback reconstructs the reference state\n", __func__);
+
+    llama_free(ctx_ref);
+    llama_free(ctx_rb);
+    return 0;
+}


### PR DESCRIPTION
A DSV4 context refuses any partial seq_rm: a compressed block row is derived from a compressor-state ring addressed by pos%state_size, so a token cannot be removed once the rows it wrote have been overwritten. Speculative decoding therefore has to checkpoint and restore the whole sequence state on every draft, and re-evaluate the accepted tokens.

Size the rings with the same rollback budget the recurrent caches already use (n_rs_seq): oversizing them by n_rs_seq rows makes exactly the last n_rs_seq positions removable, because their rows have not aliased onto any row that an unfinished block still reads. A compressed row a removed token completed keeps stale contents, but it sits at block index pos/ratio and is not exposed to a token until (pos + 1)/ratio exceeds it, which cannot happen again before that position is re-decoded and rewrites the row.

The rings only grow when a rollback budget is requested (n_rs_seq = 0 otherwise), so a context without speculative decoding is unchanged.

test-dsv4-rollback decodes a prompt, decodes a wrong tail on top of it, rolls the tail back and replays the real one, and requires the logits to match a context that never rolled back.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
