### PR TITLE
common : recognize 'thinking' as reasoning alias in chat diff analyzer

### DIFF
--- a/common/chat-diff-analyzer.cpp
+++ b/common/chat-diff-analyzer.cpp
@@ -456,7 +456,8 @@ void analyze_reasoning::compare_reasoning_presence() {
     json assistant_with_reasoning = json{
         { "role",              "assistant"                },
         { "content",           ASSISTANT_MSG              },
-        { "reasoning_content", THINKING_CONTENT           }
+        { "reasoning_content", THINKING_CONTENT           },
+        { "thinking",          THINKING_CONTENT           }
     };
 
     template_params params;
@@ -589,13 +590,15 @@ void analyze_reasoning::compare_reasoning_scope() {
     json assistant_reasoning_content = json{
         { "role",              "assistant"      },
         { "content",           ASSISTANT_MSG    },
-        { "reasoning_content", THINKING_CONTENT }
+        { "reasoning_content", THINKING_CONTENT },
+        { "thinking",          THINKING_CONTENT }
     };
 
     json assistant_reasoning_tools = json{
         { "role",              "assistant"                                                                  },
         { "content",           nullptr                                                                      },
         { "reasoning_content", THINKING_CONTENT                                                             },
+        { "thinking",          THINKING_CONTENT                                                             },
         { "tool_calls",
          json::array({ build_tool_call(FUN_FIRST, json{ { ARG_FIRST, "VVVV" }, { ARG_SECOND, "XXXX" } }) }) }
     };
@@ -664,7 +667,8 @@ analyze_content::analyze_content(const common_chat_template & tmpl, const analyz
     json assistant_with_reasoning = json{
         { "role",              "assistant"      },
         { "content",           ""               },
-        { "reasoning_content", THINKING_CONTENT }
+        { "reasoning_content", THINKING_CONTENT },
+        { "thinking",          THINKING_CONTENT }
     };
 
     template_params params_content_only;

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -880,6 +880,29 @@ static void foreach_parameter(const json &                                      
     }
 }
 
+// Expose the canonical `reasoning_content` under the flat `thinking` alias that
+// some chat templates read directly (e.g. gpt-oss, LFM2, and the growing set of
+// vLLM-style templates that adopted `thinking` as the reasoning field). This is a
+// non-destructive alias: it only adds `thinking` when a string `reasoning_content`
+// is present and `thinking` is not already set, so templates that ignore the field
+// are unaffected.
+static json common_chat_alias_reasoning_as_thinking(const json & messages) {
+    if (!messages.is_array()) {
+        return messages;
+    }
+    json aliased = json::array();
+    for (auto msg : messages) {
+        if (msg.is_object()
+            && msg.contains("reasoning_content")
+            && msg.at("reasoning_content").is_string()
+            && !msg.contains("thinking")) {
+            msg["thinking"] = msg.at("reasoning_content");
+        }
+        aliased.push_back(std::move(msg));
+    }
+    return aliased;
+}
+
 static std::string common_chat_template_direct_apply_impl(
     const common_chat_template & tmpl,
     const autoparser::generation_params & inputs,
@@ -889,7 +912,8 @@ static std::string common_chat_template_direct_apply_impl(
     jinja::context ctx(tmpl.source());
 
     nlohmann::ordered_json inp = nlohmann::ordered_json{
-        {"messages", messages_override.has_value() ? *messages_override : inputs.messages},
+        {"messages", common_chat_alias_reasoning_as_thinking(
+                         messages_override.has_value() ? *messages_override : inputs.messages)},
         {"bos_token", tmpl.bos_token()},
         {"eos_token", tmpl.eos_token()},
         {"enable_thinking", inputs.enable_thinking},

--- a/tests/test-chat-auto-parser.cpp
+++ b/tests/test-chat-auto-parser.cpp
@@ -60,6 +60,7 @@ static void test_nemotron_tool_format(testing & t);
 
 // CohereForAI template analysis tests
 static void test_cohere_reasoning_detection(testing & t);
+static void test_thinking_alias_reasoning_detection(testing & t);
 static void test_cohere_analysis(testing & t);
 
 // SmolLM3 template analysis tests
@@ -1384,6 +1385,26 @@ static common_chat_template load_cohere_template(testing & t) {
 
 static void test_cohere_analysis(testing & t) {
     t.test("Cohere reasoning detection", test_cohere_reasoning_detection);
+    t.test("thinking field reasoning detection", test_thinking_alias_reasoning_detection);
+}
+
+static void test_thinking_alias_reasoning_detection(testing & t) {
+    const std::string template_source = R"(
+{%- for message in messages %}
+{%- if message.role == 'user' %}<|USER|>{{ message.content }}
+{%- elif message.role == 'assistant' %}<|ASSISTANT|>{% if message.thinking %}<|START_THINKING|>{{ message.thinking }}<|END_THINKING|>{% endif %}<|START_RESPONSE|>{{ message.content }}<|END_RESPONSE|>
+{%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}<|ASSISTANT|>{% endif %})";
+    common_chat_template tmpl(template_source, "", "");
+
+    struct autoparser analysis;
+    analysis.analyze_template(tmpl);
+
+    t.assert_equal("thinking alias should use tag-based reasoning", reasoning_mode::TAG_BASED,
+                   analysis.reasoning.mode);
+    t.assert_equal("thinking alias start marker", "<|START_THINKING|>", analysis.reasoning.start);
+    t.assert_equal("thinking alias end marker", "<|END_THINKING|>", analysis.reasoning.end);
 }
 
 static void test_cohere_reasoning_detection(testing & t) {

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -5878,6 +5878,27 @@ static void test_template_generation_prompt() {
         check(tmpls, continuation_content(),   "<|im_start|>assistant\n<think>\nI'm thinking\n</think>\n\nHello, ");
         check(tmpls, continuation_reasoning(), "<|im_start|>assistant\n<think>\nI'm");
     }
+
+    {
+        // A template that reads the flat `thinking` field directly (the vLLM-style
+        // reasoning alias) should still render prior-turn reasoning even though
+        // llama.cpp populates `reasoning_content`. This exercises the generic
+        // reasoning_content -> thinking alias applied for every template, with no
+        // template-specific copy loop.
+        const std::string mock_template =
+            "{%- for message in messages -%}\n"
+            "  {{- '<|' + message.role + '|>' -}}\n"
+            "  {%- if message.thinking -%}{{- '<think>' + message.thinking + '</think>' -}}{%- endif -%}\n"
+            "  {{- message.content -}}\n"
+            "{%- endfor -%}";
+        auto tmpls = common_chat_templates_ptr(
+            common_chat_templates_init(/* model= */ nullptr, mock_template));
+
+        common_chat_templates_inputs inputs;
+        inputs.messages = { message_user, message_assist_thoughts };
+        auto params     = common_chat_templates_apply(tmpls.get(), inputs);
+        assert_contains(params.prompt, "<think>I'm\nthinking</think>");
+    }
 }
 
 // Test the developer role to system workaround with a simple mock template


### PR DESCRIPTION
I was trying out a cohere model, and the template analyzer probe missed this kind of thinking field it uses to mark reasoning.

A small patch to widen what it detects (really an alias). 

- [x] read and agree with contributing guidelines
- [x] **AI usage disclosure:** I yelled at my agent (on the mesh-llm project) to come up with this patch and test it. Typos/grammar here are all my own mistakes. 
