### PR TITLE
server: fix read_file append_loc space breaking edit_file match

### DIFF
--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -289,7 +289,7 @@ struct server_tool_read_file : server_tool {
             {"function", {
                 {"name", name},
                 {"description", "Read the contents of a file. Optionally specify a 1-based line range. "
-                                "If append_loc is true, each line is prefixed with its line number (e.g. \"1\u2192 ...\")."},
+                                "If append_loc is true, each line is prefixed with its line number (e.g. \"1\u2192...\")."},
                 {"parameters", {
                     {"type", "object"},
                     {"properties", {
@@ -339,7 +339,7 @@ struct server_tool_read_file : server_tool {
 
             std::string out_line;
             if (append_loc) {
-                out_line = std::to_string(lineno) + "\u2192 " + line + "\n";
+                out_line = std::to_string(lineno) + "\u2192" + line + "\n";
             } else {
                 out_line = line + "\n";
             }


### PR DESCRIPTION
## Overview

Fixes the edit_file tool so it stops failing to match after a read_file with line numbers.

## Additional information

read_file with append_loc prints "{n}→ {line}". That space after the arrow is just a separator, but the model can't tell it apart from real indentation: it strips "{n}→" and keeps the space. The old_text it then hands to edit_file starts with a phantom space, so the match fails every time (fuzzy matching only trims trailing whitespace, never leading). The model retries, burns thousands of tokens, and eventually gives up and rewrites the whole file.

Fix: drop the separator space so the arrow sits right against the content. Strip "{n}→" and you get the exact line back, indentation intact. The bad case simply can't happen anymore.

Fixes #25694

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES Fable 5 / Self-hosted MCP sandbox servers with shared GPUs

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
