### PR TITLE
Thinking sampling parametrization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,76 @@
+
+
+  # Shared-State Reasoning Sampling Implementation
+
+  ## Summary
+
+  Replace the two complete sampler chains with one logical chain whose eligible parameter values switch at reasoning boundaries. Preserve continuous RNG, history, adaptive,
+  and Mirostat state.
+
+  Terra drives implementation. Codex or Sol handles sampler-state and clone reviews. Luna or smaller models handle bounded searches, field inventories, documentation tables,
+  and command execution. Terra remains the sole editor when work overlaps to avoid concurrent mutations.
+
+  ## Implementation Changes
+
+  - Replace chain_think with one top-level chain containing:
+      - Section-aware wrappers for top-k, top-p, min-p, typical-p, top-n-sigma, temperature/dynatemp, penalties, and DRY.
+      - One specialized section-aware XTC wrapper.
+      - Exactly one terminal dist, adaptive-p, or Mirostat sampler.
+
+  - Generic wrappers own base and reasoning children:
+      - Apply only the active child.
+      - Accept and reset both children so penalty and DRY histories cover the complete token timeline.
+      - Clone both children and preserve the active section.
+
+  - Before every chain application, including grammar resampling, derive the active section from the reasoning-budget sampler and update all section-aware wrappers.
+  - Remove the reasoning seed, Mirostat mode/tau/eta, and adaptive target/decay fields from parameters, CLI options, server schema, tests, and documentation.
+  - Continue supporting reasoning overrides for ordinary filters, temperature, penalties, DRY, XTC, and min_keep.
+  - Do not change sampler topology at section boundaries. If an overridden sampler is absent from params.samplers, log that the override is inert.
+  - When base Mirostat is enabled, allow only reasoning_temp; reject other reasoning overrides because their components are absent from that topology.
+  - Keep completion's delayed marker configuration and current backend-sampling fallback unchanged. Missing-tag and per-turn generation-prompt lifecycle improvements remain
+    separate work.
+
+  ## Public API and Clone Behavior
+
+  - Add:
+
+    LLAMA_API void llama_sampler_xtc_set(
+            struct llama_sampler * smpl,
+            float probability,
+            float threshold,
+            size_t min_keep);
+
+  - Make XTC coefficients mutable while preserving its seed, current seed, and RNG state. The setter must not reset or reseed the sampler.
+  - The common-layer XTC wrapper owns one XTC sampler and switches coefficients before applying it. A disabled active profile skips application without consuming RNG.
+  - After cloning the top-level chain, rediscover section wrappers through llama_sampler_chain_get() rather than copying source pointers.
+  - Correct llama_sampler_penalties_clone() to copy both the token ring and token_count, enabling faithful speculative rollback with reasoning penalty overrides.
+  - Leave the unrelated pre-existing Mirostat and adaptive-p clone defects outside this change.
+
+  ## Tests and Verification
+
+  - Update test-reasoning-overrides:
+      - Remove seed, Mirostat, and adaptive reasoning-override cases.
+      - Retain behavioral coverage for every supported override.
+      - Add fixed-seed equal-value comparisons against no override.
+      - Cover initial reasoning state, generated start/end markers, forced endings, multiple blocks, history continuity, reset, clone, and rollback.
+      - Verify XTC uses one continuous RNG across boundaries.
+
+  - Extend test-sampling with:
+      - XTC coefficient changes that preserve RNG progress and clone state.
+      - Penalties clone equivalence after accepted history.
+
+  - Update argument-parser and server/chat schema tests for retained and removed fields.
+  - Build llama-server, llama-completion, and the four targeted tests, then run:
+
+    ctest --test-dir build --output-on-failure \
+        -R '^(test-sampling|test-arg-parser|test-chat|test-reasoning-overrides)$'
+
+  - Finish with static checks confirming no production references remain for chain_think, reasoning_seed, reasoning_mirostat, or reasoning_adaptive.
+
+  ## Execution Controls and Assumptions
+
+  - This is for a private fork, so Terra-led implementation is permitted.
+  - No commit, push, PR creation, PR text, GitHub comment, or reviewer response will be produced.
+  - Existing untracked prompt.md and gpt_sol_analysis.md remain untouched.
+  - Terra pauses if the implementation requires a broader core sampler API or lifecycle redesign than the XTC setter and internal wrappers described above.
+  - Execution starts only after explicit confirmation because this is a substantial custom-sampler refactor.

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1821,7 +1821,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "temperature override while inside the reasoning block (default: inherit)",
         [](common_params & params, const std::string & value) {
             params.sampling.reasoning_temp = std::max(std::stof(value), 0.0f);
-            params.sampling.reasoning_sampling = true;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
         }
     ).set_sampling());
     add_opt(common_arg(
@@ -1829,7 +1829,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "top-k override while inside the reasoning block (default: inherit)",
         [](common_params & params, int value) {
             params.sampling.reasoning_top_k = value;
-            params.sampling.reasoning_sampling = true;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
         }
     ).set_sampling());
     add_opt(common_arg(
@@ -1837,7 +1837,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "top-p override while inside the reasoning block (default: inherit)",
         [](common_params & params, const std::string & value) {
             params.sampling.reasoning_top_p = std::stof(value);
-            params.sampling.reasoning_sampling = true;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_TOP_P;
         }
     ).set_sampling());
     add_opt(common_arg(
@@ -1845,7 +1845,67 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "min-p override while inside the reasoning block (default: inherit)",
         [](common_params & params, const std::string & value) {
             params.sampling.reasoning_min_p = std::stof(value);
-            params.sampling.reasoning_sampling = true;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIN_P;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-top-n-sigma"}, "N",
+        "top-n-sigma override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_top_n_sigma = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-xtc-probability"}, "N",
+        "XTC probability override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_xtc_probability = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-xtc-threshold"}, "N",
+        "XTC threshold override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_xtc_threshold = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-typical-p"}, "N",
+        "locally typical sampling override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_typ_p = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-dynatemp-range"}, "N",
+        "dynamic temperature range override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_dynatemp_range = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-dynatemp-exp", "--reasoning-dynatemp-exponent"}, "N",
+        "dynamic temperature exponent override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_dynatemp_exponent = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-repeat-last-n"}, "N",
+        "repeat history override while inside the reasoning block (default: inherit)",
+        [](common_params & params, int value) {
+            if (value < -1) {
+                throw std::runtime_error(string_format("error: invalid reasoning-repeat-last-n = %d\n", value));
+            }
+            params.sampling.reasoning_penalty_last_n = value;
+            params.sampling.n_prev = std::max(params.sampling.n_prev, value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N;
         }
     ).set_sampling());
     add_opt(common_arg(
@@ -1853,7 +1913,118 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         "repeat-penalty override while inside the reasoning block (default: inherit)",
         [](common_params & params, const std::string & value) {
             params.sampling.reasoning_penalty_repeat = std::stof(value);
-            params.sampling.reasoning_sampling = true;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-presence-penalty"}, "N",
+        "presence penalty override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_penalty_present = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-frequency-penalty"}, "N",
+        "frequency penalty override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_penalty_freq = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-dry-multiplier"}, "N",
+        "DRY multiplier override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_dry_multiplier = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-dry-base"}, "N",
+        "DRY base override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            const float base = std::stof(value);
+            if (base < 1.0f) {
+                return;
+            }
+            params.sampling.reasoning_dry_base = base;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-dry-allowed-length"}, "N",
+        "DRY allowed length override while inside the reasoning block (default: inherit)",
+        [](common_params & params, int value) {
+            params.sampling.reasoning_dry_allowed_length = value;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-dry-penalty-last-n"}, "N",
+        "DRY history override while inside the reasoning block (default: inherit)",
+        [](common_params & params, int value) {
+            if (value < -1) {
+                throw std::runtime_error(string_format("error: invalid reasoning-dry-penalty-last-n = %d\n", value));
+            }
+            params.sampling.reasoning_dry_penalty_last_n = value;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-mirostat"}, "N",
+        "Mirostat mode override while inside the reasoning block (default: inherit)",
+        [](common_params & params, int value) {
+            params.sampling.reasoning_mirostat = value;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-mirostat-ent", "--reasoning-mirostat-tau"}, "N",
+        "Mirostat target entropy override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_mirostat_tau = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-mirostat-lr", "--reasoning-mirostat-eta"}, "N",
+        "Mirostat learning rate override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_mirostat_eta = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-adaptive-target"}, "N",
+        "adaptive sampling target override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_adaptive_target = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-adaptive-decay"}, "N",
+        "adaptive sampling decay override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_adaptive_decay = std::stof(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-min-keep"}, "N",
+        "minimum candidate count override while inside the reasoning block (default: inherit)",
+        [](common_params & params, int value) {
+            params.sampling.reasoning_min_keep = value;
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-seed"}, "SEED",
+        "RNG seed override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_seed = std::stoul(value);
+            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_SEED;
         }
     ).set_sampling());
     add_opt(common_arg(

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1818,7 +1818,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_sampling());
     add_opt(common_arg(
         {"--reasoning-temp"}, "N",
-        "temperature override while inside the reasoning block (default: inherit)",
+        "temperature override while inside the reasoning block; uses the existing sampling chain with continuous RNG and history state (default: inherit)",
         [](common_params & params, const std::string & value) {
             params.sampling.reasoning_temp = std::max(std::stof(value), 0.0f);
             params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
@@ -1972,59 +1972,11 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_sampling());
     add_opt(common_arg(
-        {"--reasoning-mirostat"}, "N",
-        "Mirostat mode override while inside the reasoning block (default: inherit)",
-        [](common_params & params, int value) {
-            params.sampling.reasoning_mirostat = value;
-            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT;
-        }
-    ).set_sampling());
-    add_opt(common_arg(
-        {"--reasoning-mirostat-ent", "--reasoning-mirostat-tau"}, "N",
-        "Mirostat target entropy override while inside the reasoning block (default: inherit)",
-        [](common_params & params, const std::string & value) {
-            params.sampling.reasoning_mirostat_tau = std::stof(value);
-            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU;
-        }
-    ).set_sampling());
-    add_opt(common_arg(
-        {"--reasoning-mirostat-lr", "--reasoning-mirostat-eta"}, "N",
-        "Mirostat learning rate override while inside the reasoning block (default: inherit)",
-        [](common_params & params, const std::string & value) {
-            params.sampling.reasoning_mirostat_eta = std::stof(value);
-            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA;
-        }
-    ).set_sampling());
-    add_opt(common_arg(
-        {"--reasoning-adaptive-target"}, "N",
-        "adaptive sampling target override while inside the reasoning block (default: inherit)",
-        [](common_params & params, const std::string & value) {
-            params.sampling.reasoning_adaptive_target = std::stof(value);
-            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET;
-        }
-    ).set_sampling());
-    add_opt(common_arg(
-        {"--reasoning-adaptive-decay"}, "N",
-        "adaptive sampling decay override while inside the reasoning block (default: inherit)",
-        [](common_params & params, const std::string & value) {
-            params.sampling.reasoning_adaptive_decay = std::stof(value);
-            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY;
-        }
-    ).set_sampling());
-    add_opt(common_arg(
         {"--reasoning-min-keep"}, "N",
         "minimum candidate count override while inside the reasoning block (default: inherit)",
         [](common_params & params, int value) {
             params.sampling.reasoning_min_keep = value;
             params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP;
-        }
-    ).set_sampling());
-    add_opt(common_arg(
-        {"--reasoning-seed"}, "SEED",
-        "RNG seed override while inside the reasoning block (default: inherit)",
-        [](common_params & params, const std::string & value) {
-            params.sampling.reasoning_seed = std::stoul(value);
-            params.sampling.reasoning_sampling |= COMMON_PARAMS_SAMPLING_CONFIG_SEED;
         }
     ).set_sampling());
     add_opt(common_arg(

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1817,6 +1817,46 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_sampling());
     add_opt(common_arg(
+        {"--reasoning-temp"}, "N",
+        "temperature override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_temp = std::max(std::stof(value), 0.0f);
+            params.sampling.reasoning_sampling = true;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-top-k"}, "N",
+        "top-k override while inside the reasoning block (default: inherit)",
+        [](common_params & params, int value) {
+            params.sampling.reasoning_top_k = value;
+            params.sampling.reasoning_sampling = true;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-top-p"}, "N",
+        "top-p override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_top_p = std::stof(value);
+            params.sampling.reasoning_sampling = true;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-min-p"}, "N",
+        "min-p override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_min_p = std::stof(value);
+            params.sampling.reasoning_sampling = true;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
+        {"--reasoning-repeat-penalty"}, "N",
+        "repeat-penalty override while inside the reasoning block (default: inherit)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_penalty_repeat = std::stof(value);
+            params.sampling.reasoning_sampling = true;
+        }
+    ).set_sampling());
+    add_opt(common_arg(
         {"--top-nsigma", "--top-n-sigma"}, "N",
         string_format("top-n-sigma sampling (default: %.2f, -1.0 = disabled)", params.sampling.top_n_sigma),
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -152,18 +152,32 @@ struct common_grammar_trigger {
 };
 
 enum common_params_sampling_config : uint64_t {
-    COMMON_PARAMS_SAMPLING_CONFIG_SAMPLERS        = 1 << 0,
-    COMMON_PARAMS_SAMPLING_CONFIG_TOP_K           = 1 << 1,
-    COMMON_PARAMS_SAMPLING_CONFIG_TOP_P           = 1 << 2,
-    COMMON_PARAMS_SAMPLING_CONFIG_MIN_P           = 1 << 3,
-    COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY = 1 << 4,
-    COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD   = 1 << 5,
-    COMMON_PARAMS_SAMPLING_CONFIG_TEMP            = 1 << 6,
-    COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N  = 1 << 7,
-    COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT  = 1 << 8,
-    COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT        = 1 << 9,
-    COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU    = 1 << 10,
-    COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA    = 1 << 11,
+    COMMON_PARAMS_SAMPLING_CONFIG_SAMPLERS          = 1ULL << 0,
+    COMMON_PARAMS_SAMPLING_CONFIG_TOP_K             = 1ULL << 1,
+    COMMON_PARAMS_SAMPLING_CONFIG_TOP_P             = 1ULL << 2,
+    COMMON_PARAMS_SAMPLING_CONFIG_MIN_P             = 1ULL << 3,
+    COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY   = 1ULL << 4,
+    COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD     = 1ULL << 5,
+    COMMON_PARAMS_SAMPLING_CONFIG_TEMP              = 1ULL << 6,
+    COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N    = 1ULL << 7,
+    COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT    = 1ULL << 8,
+    COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT          = 1ULL << 9,
+    COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU      = 1ULL << 10,
+    COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA      = 1ULL << 11,
+    COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA       = 1ULL << 12,
+    COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P         = 1ULL << 13,
+    COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE    = 1ULL << 14,
+    COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT = 1ULL << 15,
+    COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ      = 1ULL << 16,
+    COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT   = 1ULL << 17,
+    COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER    = 1ULL << 18,
+    COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE          = 1ULL << 19,
+    COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN   = 1ULL << 20,
+    COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N = 1ULL << 21,
+    COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET   = 1ULL << 22,
+    COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY    = 1ULL << 23,
+    COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP          = 1ULL << 24,
+    COMMON_PARAMS_SAMPLING_CONFIG_SEED              = 1ULL << 25,
 };
 
 enum common_speculative_type {
@@ -290,18 +304,35 @@ struct common_params_sampling {
     std::string              reasoning_budget_message;         // message injected before end tag when budget exhausted
     bool                     reasoning_control = false;        // create the budget sampler on demand so reasoning can be ended at runtime
 
-    // reasoning-section sampling overrides
-    // when enabled, a second sampler chain is built and used while generation is
-    // inside the reasoning block (between reasoning_budget_start and reasoning_budget_end),
-    // allowing e.g. a higher exploratory temperature for thinking and a sharper,
-    // stricter configuration for the final response / code / tool calls.
-    // values < 0 (INT32_MIN for top_k) inherit the base setting.
-    bool    reasoning_sampling      = false;
-    float   reasoning_temp          = -1.0f;
-    int32_t reasoning_top_k         = INT32_MIN;
-    float   reasoning_top_p         = -1.0f;
-    float   reasoning_min_p         = -1.0f;
-    float   reasoning_penalty_repeat = -1.0f;
+    // Sampling overrides used while inside the reasoning block. The bitfield
+    // records which values override the base chain.
+    uint64_t reasoning_sampling = 0;
+
+    uint32_t reasoning_seed               = LLAMA_DEFAULT_SEED;
+    int32_t  reasoning_min_keep           = 0;
+    int32_t  reasoning_top_k              = 40;
+    float    reasoning_top_p              = 0.95f;
+    float    reasoning_min_p              = 0.05f;
+    float    reasoning_xtc_probability    = 0.00f;
+    float    reasoning_xtc_threshold      = 0.10f;
+    float    reasoning_typ_p              = 1.00f;
+    float    reasoning_temp               = 0.80f;
+    float    reasoning_dynatemp_range     = 0.00f;
+    float    reasoning_dynatemp_exponent  = 1.00f;
+    int32_t  reasoning_penalty_last_n     = 64;
+    float    reasoning_penalty_repeat     = 1.00f;
+    float    reasoning_penalty_freq       = 0.00f;
+    float    reasoning_penalty_present    = 0.00f;
+    float    reasoning_dry_multiplier     = 0.00f;
+    float    reasoning_dry_base           = 1.75f;
+    int32_t  reasoning_dry_allowed_length = 2;
+    int32_t  reasoning_dry_penalty_last_n = -1;
+    float    reasoning_adaptive_target    = -1.00f;
+    float    reasoning_adaptive_decay     = 0.90f;
+    int32_t  reasoning_mirostat           = 0;
+    float    reasoning_top_n_sigma        = -1.00f;
+    float    reasoning_mirostat_tau       = 5.00f;
+    float    reasoning_mirostat_eta       = 0.10f;
 
     bool backend_sampling = false;
 

--- a/common/common.h
+++ b/common/common.h
@@ -290,6 +290,19 @@ struct common_params_sampling {
     std::string              reasoning_budget_message;         // message injected before end tag when budget exhausted
     bool                     reasoning_control = false;        // create the budget sampler on demand so reasoning can be ended at runtime
 
+    // reasoning-section sampling overrides
+    // when enabled, a second sampler chain is built and used while generation is
+    // inside the reasoning block (between reasoning_budget_start and reasoning_budget_end),
+    // allowing e.g. a higher exploratory temperature for thinking and a sharper,
+    // stricter configuration for the final response / code / tool calls.
+    // values < 0 (INT32_MIN for top_k) inherit the base setting.
+    bool    reasoning_sampling      = false;
+    float   reasoning_temp          = -1.0f;
+    int32_t reasoning_top_k         = INT32_MIN;
+    float   reasoning_top_p         = -1.0f;
+    float   reasoning_min_p         = -1.0f;
+    float   reasoning_penalty_repeat = -1.0f;
+
     bool backend_sampling = false;
 
     bool has_logit_bias() const {

--- a/common/common.h
+++ b/common/common.h
@@ -174,10 +174,7 @@ enum common_params_sampling_config : uint64_t {
     COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE          = 1ULL << 19,
     COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN   = 1ULL << 20,
     COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N = 1ULL << 21,
-    COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET   = 1ULL << 22,
-    COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY    = 1ULL << 23,
     COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP          = 1ULL << 24,
-    COMMON_PARAMS_SAMPLING_CONFIG_SEED              = 1ULL << 25,
 };
 
 enum common_speculative_type {
@@ -305,10 +302,9 @@ struct common_params_sampling {
     bool                     reasoning_control = false;        // create the budget sampler on demand so reasoning can be ended at runtime
 
     // Sampling overrides used while inside the reasoning block. The bitfield
-    // records which values override the base chain.
+    // records which parameter values change within the shared sampler chain.
     uint64_t reasoning_sampling = 0;
 
-    uint32_t reasoning_seed               = LLAMA_DEFAULT_SEED;
     int32_t  reasoning_min_keep           = 0;
     int32_t  reasoning_top_k              = 40;
     float    reasoning_top_p              = 0.95f;
@@ -327,12 +323,7 @@ struct common_params_sampling {
     float    reasoning_dry_base           = 1.75f;
     int32_t  reasoning_dry_allowed_length = 2;
     int32_t  reasoning_dry_penalty_last_n = -1;
-    float    reasoning_adaptive_target    = -1.00f;
-    float    reasoning_adaptive_decay     = 0.90f;
-    int32_t  reasoning_mirostat           = 0;
     float    reasoning_top_n_sigma        = -1.00f;
-    float    reasoning_mirostat_tau       = 5.00f;
-    float    reasoning_mirostat_eta       = 0.10f;
 
     bool backend_sampling = false;
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -114,6 +114,7 @@ struct common_sampler {
     struct llama_sampler * grmr;
     struct llama_sampler * rbudget;
     struct llama_sampler * chain;
+    struct llama_sampler * chain_think; // optional: applied while inside the reasoning block
 
     ring_buffer<llama_token> prev;
 
@@ -125,6 +126,10 @@ struct common_sampler {
         prev.clear();
 
         llama_sampler_reset(chain);
+
+        if (chain_think) {
+            llama_sampler_reset(chain_think);
+        }
     }
 
     void set_logits(struct llama_context * ctx, int idx) {
@@ -184,18 +189,107 @@ std::string common_params_sampling::print() const {
     return std::string(result);
 }
 
-struct common_sampler * common_sampler_init(const struct llama_model * model, struct common_params_sampling & params) {
+// build a sampler chain from the given sampling parameters
+// used for the main chain and, when reasoning-section sampling is enabled,
+// for a second chain that is active inside the reasoning block
+static llama_sampler * common_sampler_chain_build(const struct llama_model * model, const struct common_params_sampling & params) {
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
     llama_sampler_chain_params lparams = llama_sampler_chain_default_params();
 
     lparams.no_perf = params.no_perf;
 
-    llama_sampler * grmr = nullptr;
-    llama_sampler * rbudget = nullptr;
     llama_sampler * chain = llama_sampler_chain_init(lparams);
 
     std::vector<llama_sampler *> samplers;
+
+    if (params.has_logit_bias()) {
+        samplers.push_back(llama_sampler_init_logit_bias(llama_vocab_n_tokens(vocab), params.logit_bias.size(), params.logit_bias.data()));
+    }
+
+    if (params.mirostat == 0) {
+
+        bool use_adaptive_p = false; // see below
+
+        for (const auto & cnstr : params.samplers) {
+            switch (cnstr) {
+                case COMMON_SAMPLER_TYPE_DRY:
+                    {
+                        std::vector<const char *> c_breakers;
+                        c_breakers.reserve(params.dry_sequence_breakers.size());
+                        for (const auto & str : params.dry_sequence_breakers) {
+                            c_breakers.push_back(str.c_str());
+                        }
+                        samplers.push_back(llama_sampler_init_dry(vocab, llama_model_n_ctx_train(model), params.dry_multiplier, params.dry_base, params.dry_allowed_length, params.dry_penalty_last_n, c_breakers.data(), c_breakers.size()));
+                    }
+                    break;
+                case COMMON_SAMPLER_TYPE_TOP_K:
+                    samplers.push_back(llama_sampler_init_top_k(params.top_k));
+                    break;
+                case COMMON_SAMPLER_TYPE_TOP_P:
+                    samplers.push_back(llama_sampler_init_top_p(params.top_p, params.min_keep));
+                    break;
+                case COMMON_SAMPLER_TYPE_TOP_N_SIGMA:
+                    samplers.push_back(llama_sampler_init_top_n_sigma(params.top_n_sigma));
+                    break;
+                case COMMON_SAMPLER_TYPE_MIN_P:
+                    samplers.push_back(llama_sampler_init_min_p(params.min_p, params.min_keep));
+                    break;
+                case COMMON_SAMPLER_TYPE_XTC:
+                    samplers.push_back(llama_sampler_init_xtc(params.xtc_probability, params.xtc_threshold, params.min_keep, params.seed));
+                    break;
+                case COMMON_SAMPLER_TYPE_TYPICAL_P:
+                    samplers.push_back(llama_sampler_init_typical(params.typ_p, params.min_keep));
+                    break;
+                case COMMON_SAMPLER_TYPE_TEMPERATURE:
+                    samplers.push_back(llama_sampler_init_temp_ext(params.temp, params.dynatemp_range, params.dynatemp_exponent));
+                    break;
+                case COMMON_SAMPLER_TYPE_INFILL:
+                    samplers.push_back(llama_sampler_init_infill(vocab));
+                    break;
+                case COMMON_SAMPLER_TYPE_PENALTIES:
+                    samplers.push_back(llama_sampler_init_penalties(params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
+                    break;
+                case COMMON_SAMPLER_TYPE_ADAPTIVE_P:
+                    // the `adaptive-p` sampler is like `dist` and `mirostat` in that it selects
+                    // a single token, so we will add `dist` at the end of the chain by default,
+                    // unless the user specifically included `adaptive-p`. we set this flag here
+                    // so we know to add the sampler at the very end.
+                    use_adaptive_p = true;
+                    break;
+                default:
+                    GGML_ASSERT(false && "unknown sampler type");
+            }
+        }
+        if (use_adaptive_p) {
+            // only if user explicitly included adaptive-p sampler
+            samplers.push_back(llama_sampler_init_adaptive_p(params.adaptive_target, params.adaptive_decay, params.seed));
+        } else {
+            // default: sample from distribution
+            samplers.push_back(llama_sampler_init_dist(params.seed));
+        }
+    } else if (params.mirostat == 1) {
+        samplers.push_back(llama_sampler_init_temp(params.temp));
+        samplers.push_back(llama_sampler_init_mirostat(llama_vocab_n_tokens(vocab), params.seed, params.mirostat_tau, params.mirostat_eta, 100));
+    } else if (params.mirostat == 2) {
+        samplers.push_back(llama_sampler_init_temp(params.temp));
+        samplers.push_back(llama_sampler_init_mirostat_v2(params.seed, params.mirostat_tau, params.mirostat_eta));
+    } else {
+        GGML_ASSERT(false && "unknown mirostat version");
+    }
+
+    for (auto * smpl : samplers) {
+        llama_sampler_chain_add(chain, smpl);
+    }
+
+    return chain;
+}
+
+struct common_sampler * common_sampler_init(const struct llama_model * model, struct common_params_sampling & params) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+
+    llama_sampler * grmr = nullptr;
+    llama_sampler * rbudget = nullptr;
 
     const std::string & grammar_str = common_grammar_value(params.grammar);
     if (grammar_str.compare(0, 11, "%llguidance") == 0) {
@@ -296,7 +390,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
     }
 
     // reasoning budget sampler (skip when budget is unlimited unless a lazy grammar is active, which needs rbudget for thinking-block suppression)
-    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0 || params.reasoning_control)) {
+    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0 || params.reasoning_control || params.reasoning_sampling)) {
         rbudget = common_reasoning_budget_init(
             vocab,
             params.reasoning_budget_start,
@@ -310,83 +404,18 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         }
     }
 
-    if (params.has_logit_bias()) {
-        samplers.push_back(llama_sampler_init_logit_bias(llama_vocab_n_tokens(vocab), params.logit_bias.size(), params.logit_bias.data()));
-    }
+    llama_sampler * chain = common_sampler_chain_build(model, params);
 
-    if (params.mirostat == 0) {
+    llama_sampler * chain_think = nullptr;
+    if (params.reasoning_sampling) {
+        common_params_sampling params_think = params;
+        if (params.reasoning_temp  >= 0.0f)     { params_think.temp  = params.reasoning_temp;  }
+        if (params.reasoning_top_k != INT32_MIN) { params_think.top_k = params.reasoning_top_k; }
+        if (params.reasoning_top_p >= 0.0f)     { params_think.top_p = params.reasoning_top_p; }
+        if (params.reasoning_min_p >= 0.0f)     { params_think.min_p = params.reasoning_min_p; }
+        if (params.reasoning_penalty_repeat >= 0.0f) { params_think.penalty_repeat = params.reasoning_penalty_repeat; }
 
-        bool use_adaptive_p = false; // see below
-
-        for (const auto & cnstr : params.samplers) {
-            switch (cnstr) {
-                case COMMON_SAMPLER_TYPE_DRY:
-                    {
-                        std::vector<const char *> c_breakers;
-                        c_breakers.reserve(params.dry_sequence_breakers.size());
-                        for (const auto & str : params.dry_sequence_breakers) {
-                            c_breakers.push_back(str.c_str());
-                        }
-                        samplers.push_back(llama_sampler_init_dry(vocab, llama_model_n_ctx_train(model), params.dry_multiplier, params.dry_base, params.dry_allowed_length, params.dry_penalty_last_n, c_breakers.data(), c_breakers.size()));
-                    }
-                    break;
-                case COMMON_SAMPLER_TYPE_TOP_K:
-                    samplers.push_back(llama_sampler_init_top_k(params.top_k));
-                    break;
-                case COMMON_SAMPLER_TYPE_TOP_P:
-                    samplers.push_back(llama_sampler_init_top_p(params.top_p, params.min_keep));
-                    break;
-                case COMMON_SAMPLER_TYPE_TOP_N_SIGMA:
-                    samplers.push_back(llama_sampler_init_top_n_sigma(params.top_n_sigma));
-                    break;
-                case COMMON_SAMPLER_TYPE_MIN_P:
-                    samplers.push_back(llama_sampler_init_min_p(params.min_p, params.min_keep));
-                    break;
-                case COMMON_SAMPLER_TYPE_XTC:
-                    samplers.push_back(llama_sampler_init_xtc(params.xtc_probability, params.xtc_threshold, params.min_keep, params.seed));
-                    break;
-                case COMMON_SAMPLER_TYPE_TYPICAL_P:
-                    samplers.push_back(llama_sampler_init_typical(params.typ_p, params.min_keep));
-                    break;
-                case COMMON_SAMPLER_TYPE_TEMPERATURE:
-                    samplers.push_back(llama_sampler_init_temp_ext(params.temp, params.dynatemp_range, params.dynatemp_exponent));
-                    break;
-                case COMMON_SAMPLER_TYPE_INFILL:
-                    samplers.push_back(llama_sampler_init_infill(vocab));
-                    break;
-                case COMMON_SAMPLER_TYPE_PENALTIES:
-                    samplers.push_back(llama_sampler_init_penalties(params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
-                    break;
-                case COMMON_SAMPLER_TYPE_ADAPTIVE_P:
-                    // the `adaptive-p` sampler is like `dist` and `mirostat` in that it selects
-                    // a single token, so we will add `dist` at the end of the chain by default,
-                    // unless the user specifically included `adaptive-p`. we set this flag here
-                    // so we know to add the sampler at the very end.
-                    use_adaptive_p = true;
-                    break;
-                default:
-                    GGML_ASSERT(false && "unknown sampler type");
-            }
-        }
-        if (use_adaptive_p) {
-            // only if user explicitly included adaptive-p sampler
-            samplers.push_back(llama_sampler_init_adaptive_p(params.adaptive_target, params.adaptive_decay, params.seed));
-        } else {
-            // default: sample from distribution
-            samplers.push_back(llama_sampler_init_dist(params.seed));
-        }
-    } else if (params.mirostat == 1) {
-        samplers.push_back(llama_sampler_init_temp(params.temp));
-        samplers.push_back(llama_sampler_init_mirostat(llama_vocab_n_tokens(vocab), params.seed, params.mirostat_tau, params.mirostat_eta, 100));
-    } else if (params.mirostat == 2) {
-        samplers.push_back(llama_sampler_init_temp(params.temp));
-        samplers.push_back(llama_sampler_init_mirostat_v2(params.seed, params.mirostat_tau, params.mirostat_eta));
-    } else {
-        GGML_ASSERT(false && "unknown mirostat version");
-    }
-
-    for (auto * smpl : samplers) {
-        llama_sampler_chain_add(chain, smpl);
+        chain_think = common_sampler_chain_build(model, params_think);
     }
 
     if (grmr && params.backend_sampling) {
@@ -405,7 +434,8 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         /* .params  = */ params,
         /* .grmr    = */ grmr,
         /* .rbudget = */ rbudget,
-        /* .chain   = */ chain,
+        /* .chain       = */ chain,
+        /* .chain_think = */ chain_think,
         /* .prev    = */ ring_buffer<llama_token>(std::max(32, params.n_prev)),
         /* .cur     = */ {},
         /* .cur_p   = */ {},
@@ -422,6 +452,7 @@ void common_sampler_free(struct common_sampler * gsmpl) {
     llama_sampler_free(gsmpl->grmr);
     llama_sampler_free(gsmpl->rbudget);
     llama_sampler_free(gsmpl->chain);
+    llama_sampler_free(gsmpl->chain_think);
 
     delete gsmpl;
 }
@@ -439,6 +470,27 @@ static bool grammar_should_apply(struct common_sampler * gsmpl) {
         return state == REASONING_BUDGET_IDLE || state == REASONING_BUDGET_DONE;
     }
     return true;
+}
+
+// true while generation is inside the reasoning block (as tracked by the
+// reasoning budget sampler), i.e. after the start tag and before the end tag
+static bool common_sampler_reasoning_active(const struct common_sampler * gsmpl) {
+    if (!gsmpl->rbudget) {
+        return false;
+    }
+    const auto state = common_reasoning_budget_get_state(gsmpl->rbudget);
+    return state == REASONING_BUDGET_COUNTING ||
+           state == REASONING_BUDGET_WAITING_UTF8 ||
+           state == REASONING_BUDGET_FORCING;
+}
+
+// select the sampler chain for the current position:
+// the reasoning chain inside the reasoning block (if configured), the base chain otherwise
+static llama_sampler * common_sampler_active_chain(struct common_sampler * gsmpl) {
+    if (gsmpl->chain_think && common_sampler_reasoning_active(gsmpl)) {
+        return gsmpl->chain_think;
+    }
+    return gsmpl->chain;
 }
 
 void common_sampler_accept(struct common_sampler * gsmpl, llama_token token, bool is_generated) {
@@ -461,6 +513,10 @@ void common_sampler_accept(struct common_sampler * gsmpl, llama_token token, boo
 
     llama_sampler_accept(gsmpl->chain, token);
 
+    if (gsmpl->chain_think) {
+        llama_sampler_accept(gsmpl->chain_think, token);
+    }
+
     gsmpl->prev.push_back(token);
 }
 
@@ -477,7 +533,8 @@ struct common_sampler * common_sampler_clone(common_sampler * gsmpl) {
         /* .params  = */ gsmpl->params,
         /* .grmr    = */ llama_sampler_clone(gsmpl->grmr),
         /* .rbudget = */ llama_sampler_clone(gsmpl->rbudget),
-        /* .chain   = */ llama_sampler_clone(gsmpl->chain),
+        /* .chain       = */ llama_sampler_clone(gsmpl->chain),
+        /* .chain_think = */ gsmpl->chain_think ? llama_sampler_clone(gsmpl->chain_think) : nullptr,
         /* .prev    = */ gsmpl->prev,
         /* .cur     = */ gsmpl->cur,
         /* .cur_p   = */ gsmpl->cur_p,
@@ -547,7 +604,7 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
 
     auto & grmr  = gsmpl->grmr;
     auto & rbudget = gsmpl->rbudget;
-    auto & chain = gsmpl->chain;
+    auto * chain = common_sampler_active_chain(gsmpl);
     auto & cur_p = gsmpl->cur_p; // initialized by set_logits
 
     gsmpl->set_logits(ctx, idx);

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -12,6 +12,7 @@
 #include <climits>
 #include <cmath>
 #include <cstring>
+#include <stdexcept>
 #include <unordered_map>
 #include <vector>
 
@@ -108,13 +109,208 @@ struct ring_buffer {
     std::vector<T> data;
 };
 
+struct common_sampler_section {
+    llama_sampler * base;
+    llama_sampler * reasoning;
+    bool reasoning_active;
+};
+
+static llama_sampler * common_sampler_section_init(
+        llama_sampler * base,
+        llama_sampler * reasoning,
+        bool reasoning_active = false);
+
+static const char * common_sampler_section_name(const llama_sampler * smpl) {
+    const auto * ctx = (const common_sampler_section *) smpl->ctx;
+    return llama_sampler_name(ctx->base);
+}
+
+static void common_sampler_section_accept(llama_sampler * smpl, llama_token token) {
+    auto * ctx = (common_sampler_section *) smpl->ctx;
+    llama_sampler_accept(ctx->base, token);
+    llama_sampler_accept(ctx->reasoning, token);
+}
+
+static void common_sampler_section_apply(llama_sampler * smpl, llama_token_data_array * cur_p) {
+    auto * ctx = (common_sampler_section *) smpl->ctx;
+    llama_sampler_apply(ctx->reasoning_active ? ctx->reasoning : ctx->base, cur_p);
+}
+
+static void common_sampler_section_reset(llama_sampler * smpl) {
+    auto * ctx = (common_sampler_section *) smpl->ctx;
+    llama_sampler_reset(ctx->base);
+    llama_sampler_reset(ctx->reasoning);
+}
+
+static llama_sampler * common_sampler_section_clone(const llama_sampler * smpl) {
+    const auto * ctx = (const common_sampler_section *) smpl->ctx;
+    return common_sampler_section_init(
+            llama_sampler_clone(ctx->base),
+            llama_sampler_clone(ctx->reasoning),
+            ctx->reasoning_active);
+}
+
+static void common_sampler_section_free(llama_sampler * smpl) {
+    auto * ctx = (common_sampler_section *) smpl->ctx;
+    llama_sampler_free(ctx->base);
+    llama_sampler_free(ctx->reasoning);
+    delete ctx;
+}
+
+static llama_sampler_i common_sampler_section_i = {
+    /* .name              = */ common_sampler_section_name,
+    /* .accept            = */ common_sampler_section_accept,
+    /* .apply             = */ common_sampler_section_apply,
+    /* .reset             = */ common_sampler_section_reset,
+    /* .clone             = */ common_sampler_section_clone,
+    /* .free              = */ common_sampler_section_free,
+    /* .backend_init      = */ nullptr,
+    /* .backend_accept    = */ nullptr,
+    /* .backend_apply     = */ nullptr,
+    /* .backend_set_input = */ nullptr,
+};
+
+static llama_sampler * common_sampler_section_init(
+        llama_sampler * base,
+        llama_sampler * reasoning,
+        bool reasoning_active) {
+    return llama_sampler_init(
+            &common_sampler_section_i,
+            new common_sampler_section {
+                /* .base             = */ base,
+                /* .reasoning        = */ reasoning,
+                /* .reasoning_active = */ reasoning_active,
+            });
+}
+
+struct common_sampler_section_xtc_config {
+    float probability;
+    float threshold;
+    size_t min_keep;
+};
+
+struct common_sampler_section_xtc {
+    llama_sampler * sampler;
+    common_sampler_section_xtc_config base;
+    common_sampler_section_xtc_config reasoning;
+    bool reasoning_active;
+};
+
+static llama_sampler * common_sampler_section_xtc_init_with_sampler(
+        llama_sampler * sampler,
+        common_sampler_section_xtc_config base,
+        common_sampler_section_xtc_config reasoning,
+        bool reasoning_active);
+
+static bool common_sampler_section_xtc_enabled(const common_sampler_section_xtc_config & config) {
+    return config.probability > 0.0f && config.threshold <= 0.5f;
+}
+
+static const char * common_sampler_section_xtc_name(const llama_sampler * /* smpl */) {
+    return "xtc";
+}
+
+static void common_sampler_section_xtc_apply(llama_sampler * smpl, llama_token_data_array * cur_p) {
+    auto * ctx = (common_sampler_section_xtc *) smpl->ctx;
+    const auto & config = ctx->reasoning_active ? ctx->reasoning : ctx->base;
+
+    if (!common_sampler_section_xtc_enabled(config)) {
+        return;
+    }
+
+    llama_sampler_xtc_set(ctx->sampler, config.probability, config.threshold, config.min_keep);
+    llama_sampler_apply(ctx->sampler, cur_p);
+}
+
+static void common_sampler_section_xtc_reset(llama_sampler * smpl) {
+    auto * ctx = (common_sampler_section_xtc *) smpl->ctx;
+    llama_sampler_reset(ctx->sampler);
+}
+
+static llama_sampler * common_sampler_section_xtc_clone(const llama_sampler * smpl) {
+    const auto * ctx = (const common_sampler_section_xtc *) smpl->ctx;
+    return common_sampler_section_xtc_init_with_sampler(
+            llama_sampler_clone(ctx->sampler),
+            ctx->base,
+            ctx->reasoning,
+            ctx->reasoning_active);
+}
+
+static void common_sampler_section_xtc_free(llama_sampler * smpl) {
+    auto * ctx = (common_sampler_section_xtc *) smpl->ctx;
+    llama_sampler_free(ctx->sampler);
+    delete ctx;
+}
+
+static llama_sampler_i common_sampler_section_xtc_i = {
+    /* .name              = */ common_sampler_section_xtc_name,
+    /* .accept            = */ nullptr,
+    /* .apply             = */ common_sampler_section_xtc_apply,
+    /* .reset             = */ common_sampler_section_xtc_reset,
+    /* .clone             = */ common_sampler_section_xtc_clone,
+    /* .free              = */ common_sampler_section_xtc_free,
+    /* .backend_init      = */ nullptr,
+    /* .backend_accept    = */ nullptr,
+    /* .backend_apply     = */ nullptr,
+    /* .backend_set_input = */ nullptr,
+};
+
+static llama_sampler * common_sampler_section_xtc_init_with_sampler(
+        llama_sampler * sampler,
+        common_sampler_section_xtc_config base,
+        common_sampler_section_xtc_config reasoning,
+        bool reasoning_active) {
+    return llama_sampler_init(
+            &common_sampler_section_xtc_i,
+            new common_sampler_section_xtc {
+                /* .sampler          = */ sampler,
+                /* .base             = */ base,
+                /* .reasoning        = */ reasoning,
+                /* .reasoning_active = */ reasoning_active,
+            });
+}
+
+static llama_sampler * common_sampler_section_xtc_init(
+        common_sampler_section_xtc_config base,
+        common_sampler_section_xtc_config reasoning,
+        uint32_t seed) {
+    const auto & initial = common_sampler_section_xtc_enabled(base) ? base : reasoning;
+    auto * sampler = llama_sampler_init_xtc(initial.probability, initial.threshold, initial.min_keep, seed);
+    return common_sampler_section_xtc_init_with_sampler(sampler, base, reasoning, false);
+}
+
+static bool common_sampler_is_section(const llama_sampler * smpl) {
+    return smpl->iface == &common_sampler_section_i || smpl->iface == &common_sampler_section_xtc_i;
+}
+
+static void common_sampler_section_set_reasoning(llama_sampler * smpl, bool reasoning_active) {
+    if (smpl->iface == &common_sampler_section_i) {
+        ((common_sampler_section *) smpl->ctx)->reasoning_active = reasoning_active;
+        return;
+    }
+
+    GGML_ASSERT(smpl->iface == &common_sampler_section_xtc_i);
+    ((common_sampler_section_xtc *) smpl->ctx)->reasoning_active = reasoning_active;
+}
+
+static std::vector<llama_sampler *> common_sampler_sections(llama_sampler * chain) {
+    std::vector<llama_sampler *> result;
+    for (int32_t i = 0; i < llama_sampler_chain_n(chain); ++i) {
+        auto * smpl = llama_sampler_chain_get(chain, i);
+        if (common_sampler_is_section(smpl)) {
+            result.push_back(smpl);
+        }
+    }
+    return result;
+}
+
 struct common_sampler {
     common_params_sampling params;
 
     struct llama_sampler * grmr;
     struct llama_sampler * rbudget;
     struct llama_sampler * chain;
-    struct llama_sampler * chain_think;
+    std::vector<llama_sampler *> sections;
 
     std::vector<llama_token> prefill_tokens;
     bool grmr_prefilled;
@@ -129,10 +325,6 @@ struct common_sampler {
         prev.clear();
 
         llama_sampler_reset(chain);
-
-        if (chain_think) {
-            llama_sampler_reset(chain_think);
-        }
 
         if (rbudget) {
             llama_sampler_reset(rbudget);
@@ -199,14 +391,132 @@ std::string common_params_sampling::print() const {
     return std::string(result);
 }
 
-static llama_sampler * common_sampler_chain_build(const struct llama_model * model, const struct common_params_sampling & params) {
+static const uint64_t COMMON_SAMPLER_REASONING_SUPPORTED =
+        COMMON_PARAMS_SAMPLING_CONFIG_TOP_K |
+        COMMON_PARAMS_SAMPLING_CONFIG_TOP_P |
+        COMMON_PARAMS_SAMPLING_CONFIG_MIN_P |
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY |
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD |
+        COMMON_PARAMS_SAMPLING_CONFIG_TEMP |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT |
+        COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA |
+        COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P |
+        COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE |
+        COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT |
+        COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER |
+        COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE |
+        COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN |
+        COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N |
+        COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP;
+
+static void common_sampler_reasoning_validate(const common_params_sampling & params) {
+    const uint64_t unsupported = params.reasoning_sampling & ~COMMON_SAMPLER_REASONING_SUPPORTED;
+    if (unsupported != 0) {
+        throw std::invalid_argument("unsupported reasoning sampling override");
+    }
+
+    if (params.mirostat != 0 && params.reasoning_sampling != 0 &&
+        params.reasoning_sampling != COMMON_PARAMS_SAMPLING_CONFIG_TEMP) {
+        throw std::invalid_argument("only reasoning temperature can be overridden with Mirostat");
+    }
+}
+
+static common_params_sampling common_sampler_reasoning_params(const common_params_sampling & params) {
+    common_params_sampling result = params;
+    const uint64_t config = params.reasoning_sampling;
+
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP)           { result.min_keep           = params.reasoning_min_keep; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_K)              { result.top_k              = params.reasoning_top_k; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_P)              { result.top_p              = params.reasoning_top_p; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIN_P)              { result.min_p              = params.reasoning_min_p; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY)    { result.xtc_probability    = params.reasoning_xtc_probability; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD)      { result.xtc_threshold      = params.reasoning_xtc_threshold; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P)          { result.typ_p              = params.reasoning_typ_p; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_TEMP)               { result.temp               = params.reasoning_temp; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE)     { result.dynatemp_range     = params.reasoning_dynatemp_range; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT)  { result.dynatemp_exponent  = params.reasoning_dynatemp_exponent; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N)     { result.penalty_last_n     = params.reasoning_penalty_last_n; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT)     { result.penalty_repeat     = params.reasoning_penalty_repeat; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ)       { result.penalty_freq       = params.reasoning_penalty_freq; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT)    { result.penalty_present    = params.reasoning_penalty_present; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER)     { result.dry_multiplier     = params.reasoning_dry_multiplier; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE)           { result.dry_base           = params.reasoning_dry_base; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN)    { result.dry_allowed_length = params.reasoning_dry_allowed_length; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N) { result.dry_penalty_last_n = params.reasoning_dry_penalty_last_n; }
+    if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA)        { result.top_n_sigma        = params.reasoning_top_n_sigma; }
+
+    return result;
+}
+
+struct common_sampler_chain_result {
+    llama_sampler * chain;
+    std::vector<llama_sampler *> sections;
+    uint64_t reasoning_used;
+};
+
+static void common_sampler_chain_add_section(
+        common_sampler_chain_result & result,
+        std::vector<llama_sampler *> & samplers,
+        llama_sampler * base,
+        llama_sampler * reasoning,
+        uint64_t config) {
+    auto * section = common_sampler_section_init(base, reasoning);
+    samplers.push_back(section);
+    result.sections.push_back(section);
+    result.reasoning_used |= config;
+}
+
+static void common_sampler_reasoning_warn_unused(uint64_t configured, uint64_t used) {
+    struct override_name {
+        uint64_t flag;
+        const char * name;
+    };
+
+    const override_name names[] = {
+        { COMMON_PARAMS_SAMPLING_CONFIG_TOP_K,             "top_k" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_TOP_P,             "top_p" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_MIN_P,             "min_p" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY,   "xtc_probability" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD,     "xtc_threshold" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_TEMP,              "temperature" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N,    "repeat_last_n" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT,    "repeat_penalty" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA,       "top_n_sigma" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P,         "typical_p" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE,    "dynatemp_range" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT, "dynatemp_exponent" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ,      "frequency_penalty" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT,   "presence_penalty" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER,    "dry_multiplier" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE,          "dry_base" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN,   "dry_allowed_length" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N, "dry_penalty_last_n" },
+        { COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP,           "min_keep" },
+    };
+
+    for (const auto & entry : names) {
+        if ((configured & entry.flag) && !(used & entry.flag)) {
+            LOG_WRN("reasoning override '%s' has no matching sampler and will be ignored\n", entry.name);
+        }
+    }
+}
+
+static common_sampler_chain_result common_sampler_chain_build(const struct llama_model * model, const struct common_params_sampling & params) {
     const llama_vocab * vocab = llama_model_get_vocab(model);
+    const common_params_sampling reasoning = common_sampler_reasoning_params(params);
 
     llama_sampler_chain_params lparams = llama_sampler_chain_default_params();
 
     lparams.no_perf = params.no_perf;
 
-    llama_sampler * chain = llama_sampler_chain_init(lparams);
+    common_sampler_chain_result result {
+        /* .chain          = */ llama_sampler_chain_init(lparams),
+        /* .sections       = */ {},
+        /* .reasoning_used = */ 0,
+    };
 
     std::vector<llama_sampler *> samplers;
 
@@ -227,35 +537,173 @@ static llama_sampler * common_sampler_chain_build(const struct llama_model * mod
                         for (const auto & str : params.dry_sequence_breakers) {
                             c_breakers.push_back(str.c_str());
                         }
-                        samplers.push_back(llama_sampler_init_dry(vocab, llama_model_n_ctx_train(model), params.dry_multiplier, params.dry_base, params.dry_allowed_length, params.dry_penalty_last_n, c_breakers.data(), c_breakers.size()));
+                        const uint64_t config = params.reasoning_sampling & (
+                                COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER |
+                                COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE |
+                                COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN |
+                                COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N);
+                        if (config) {
+                            common_sampler_chain_add_section(
+                                    result,
+                                    samplers,
+                                    llama_sampler_init_dry(vocab, llama_model_n_ctx_train(model), params.dry_multiplier, params.dry_base, params.dry_allowed_length, params.dry_penalty_last_n, c_breakers.data(), c_breakers.size()),
+                                    llama_sampler_init_dry(vocab, llama_model_n_ctx_train(model), reasoning.dry_multiplier, reasoning.dry_base, reasoning.dry_allowed_length, reasoning.dry_penalty_last_n, c_breakers.data(), c_breakers.size()),
+                                    config);
+                        } else {
+                            samplers.push_back(llama_sampler_init_dry(vocab, llama_model_n_ctx_train(model), params.dry_multiplier, params.dry_base, params.dry_allowed_length, params.dry_penalty_last_n, c_breakers.data(), c_breakers.size()));
+                        }
                     }
                     break;
                 case COMMON_SAMPLER_TYPE_TOP_K:
-                    samplers.push_back(llama_sampler_init_top_k(params.top_k));
+                    if (params.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_TOP_K) {
+                        common_sampler_chain_add_section(
+                                result,
+                                samplers,
+                                llama_sampler_init_top_k(params.top_k),
+                                llama_sampler_init_top_k(reasoning.top_k),
+                                COMMON_PARAMS_SAMPLING_CONFIG_TOP_K);
+                    } else {
+                        samplers.push_back(llama_sampler_init_top_k(params.top_k));
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_TOP_P:
-                    samplers.push_back(llama_sampler_init_top_p(params.top_p, params.min_keep));
+                    {
+                        const uint64_t config = params.reasoning_sampling & (
+                                COMMON_PARAMS_SAMPLING_CONFIG_TOP_P |
+                                COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP);
+                        if (config) {
+                            common_sampler_chain_add_section(
+                                    result,
+                                    samplers,
+                                    llama_sampler_init_top_p(params.top_p, params.min_keep),
+                                    llama_sampler_init_top_p(reasoning.top_p, reasoning.min_keep),
+                                    config);
+                        } else {
+                            samplers.push_back(llama_sampler_init_top_p(params.top_p, params.min_keep));
+                        }
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_TOP_N_SIGMA:
-                    samplers.push_back(llama_sampler_init_top_n_sigma(params.top_n_sigma));
+                    if (params.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA) {
+                        common_sampler_chain_add_section(
+                                result,
+                                samplers,
+                                llama_sampler_init_top_n_sigma(params.top_n_sigma),
+                                llama_sampler_init_top_n_sigma(reasoning.top_n_sigma),
+                                COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA);
+                    } else {
+                        samplers.push_back(llama_sampler_init_top_n_sigma(params.top_n_sigma));
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_MIN_P:
-                    samplers.push_back(llama_sampler_init_min_p(params.min_p, params.min_keep));
+                    {
+                        const uint64_t config = params.reasoning_sampling & (
+                                COMMON_PARAMS_SAMPLING_CONFIG_MIN_P |
+                                COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP);
+                        if (config) {
+                            common_sampler_chain_add_section(
+                                    result,
+                                    samplers,
+                                    llama_sampler_init_min_p(params.min_p, params.min_keep),
+                                    llama_sampler_init_min_p(reasoning.min_p, reasoning.min_keep),
+                                    config);
+                        } else {
+                            samplers.push_back(llama_sampler_init_min_p(params.min_p, params.min_keep));
+                        }
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_XTC:
-                    samplers.push_back(llama_sampler_init_xtc(params.xtc_probability, params.xtc_threshold, params.min_keep, params.seed));
+                    {
+                        const uint64_t config = params.reasoning_sampling & (
+                                COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY |
+                                COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD |
+                                COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP);
+                        if (config) {
+                            const common_sampler_section_xtc_config base_config = {
+                                params.xtc_probability,
+                                params.xtc_threshold,
+                                (size_t) params.min_keep,
+                            };
+                            const common_sampler_section_xtc_config reasoning_config = {
+                                reasoning.xtc_probability,
+                                reasoning.xtc_threshold,
+                                (size_t) reasoning.min_keep,
+                            };
+
+                            if (common_sampler_section_xtc_enabled(base_config) ||
+                                common_sampler_section_xtc_enabled(reasoning_config)) {
+                                auto * section = common_sampler_section_xtc_init(base_config, reasoning_config, params.seed);
+                                samplers.push_back(section);
+                                result.sections.push_back(section);
+                            } else {
+                                samplers.push_back(llama_sampler_init_xtc(
+                                        params.xtc_probability,
+                                        params.xtc_threshold,
+                                        params.min_keep,
+                                        params.seed));
+                            }
+                            result.reasoning_used |= config;
+                        } else {
+                            samplers.push_back(llama_sampler_init_xtc(params.xtc_probability, params.xtc_threshold, params.min_keep, params.seed));
+                        }
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_TYPICAL_P:
-                    samplers.push_back(llama_sampler_init_typical(params.typ_p, params.min_keep));
+                    {
+                        const uint64_t config = params.reasoning_sampling & (
+                                COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P |
+                                COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP);
+                        if (config) {
+                            common_sampler_chain_add_section(
+                                    result,
+                                    samplers,
+                                    llama_sampler_init_typical(params.typ_p, params.min_keep),
+                                    llama_sampler_init_typical(reasoning.typ_p, reasoning.min_keep),
+                                    config);
+                        } else {
+                            samplers.push_back(llama_sampler_init_typical(params.typ_p, params.min_keep));
+                        }
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_TEMPERATURE:
-                    samplers.push_back(llama_sampler_init_temp_ext(params.temp, params.dynatemp_range, params.dynatemp_exponent));
+                    {
+                        const uint64_t config = params.reasoning_sampling & (
+                                COMMON_PARAMS_SAMPLING_CONFIG_TEMP |
+                                COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE |
+                                COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT);
+                        if (config) {
+                            common_sampler_chain_add_section(
+                                    result,
+                                    samplers,
+                                    llama_sampler_init_temp_ext(params.temp, params.dynatemp_range, params.dynatemp_exponent),
+                                    llama_sampler_init_temp_ext(reasoning.temp, reasoning.dynatemp_range, reasoning.dynatemp_exponent),
+                                    config);
+                        } else {
+                            samplers.push_back(llama_sampler_init_temp_ext(params.temp, params.dynatemp_range, params.dynatemp_exponent));
+                        }
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_INFILL:
                     samplers.push_back(llama_sampler_init_infill(vocab));
                     break;
                 case COMMON_SAMPLER_TYPE_PENALTIES:
-                    samplers.push_back(llama_sampler_init_penalties(params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
+                    {
+                        const uint64_t config = params.reasoning_sampling & (
+                                COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N |
+                                COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT |
+                                COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ |
+                                COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT);
+                        if (config) {
+                            common_sampler_chain_add_section(
+                                    result,
+                                    samplers,
+                                    llama_sampler_init_penalties(params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present),
+                                    llama_sampler_init_penalties(reasoning.penalty_last_n, reasoning.penalty_repeat, reasoning.penalty_freq, reasoning.penalty_present),
+                                    config);
+                        } else {
+                            samplers.push_back(llama_sampler_init_penalties(params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
+                        }
+                    }
                     break;
                 case COMMON_SAMPLER_TYPE_ADAPTIVE_P:
                     // the `adaptive-p` sampler is like `dist` and `mirostat` in that it selects
@@ -276,20 +724,40 @@ static llama_sampler * common_sampler_chain_build(const struct llama_model * mod
             samplers.push_back(llama_sampler_init_dist(params.seed));
         }
     } else if (params.mirostat == 1) {
-        samplers.push_back(llama_sampler_init_temp(params.temp));
+        if (params.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_TEMP) {
+            common_sampler_chain_add_section(
+                    result,
+                    samplers,
+                    llama_sampler_init_temp(params.temp),
+                    llama_sampler_init_temp(reasoning.temp),
+                    COMMON_PARAMS_SAMPLING_CONFIG_TEMP);
+        } else {
+            samplers.push_back(llama_sampler_init_temp(params.temp));
+        }
         samplers.push_back(llama_sampler_init_mirostat(llama_vocab_n_tokens(vocab), params.seed, params.mirostat_tau, params.mirostat_eta, 100));
     } else if (params.mirostat == 2) {
-        samplers.push_back(llama_sampler_init_temp(params.temp));
+        if (params.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_TEMP) {
+            common_sampler_chain_add_section(
+                    result,
+                    samplers,
+                    llama_sampler_init_temp(params.temp),
+                    llama_sampler_init_temp(reasoning.temp),
+                    COMMON_PARAMS_SAMPLING_CONFIG_TEMP);
+        } else {
+            samplers.push_back(llama_sampler_init_temp(params.temp));
+        }
         samplers.push_back(llama_sampler_init_mirostat_v2(params.seed, params.mirostat_tau, params.mirostat_eta));
     } else {
         GGML_ASSERT(false && "unknown mirostat version");
     }
 
     for (auto * smpl : samplers) {
-        llama_sampler_chain_add(chain, smpl);
+        llama_sampler_chain_add(result.chain, smpl);
     }
 
-    return chain;
+    common_sampler_reasoning_warn_unused(params.reasoning_sampling, result.reasoning_used);
+
+    return result;
 }
 
 static llama_sampler * common_sampler_reasoning_budget_init(
@@ -367,6 +835,8 @@ static bool common_sampler_grammar_prefill(
 }
 
 struct common_sampler * common_sampler_init(const struct llama_model * model, struct common_params_sampling & params) {
+    common_sampler_reasoning_validate(params);
+
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
     llama_sampler * grmr = nullptr;
@@ -444,41 +914,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
 
     rbudget = common_sampler_reasoning_budget_init(vocab, params, prefill_tokens);
 
-    llama_sampler * chain = common_sampler_chain_build(model, params);
-
-    llama_sampler * chain_think = nullptr;
-    if (params.reasoning_sampling) {
-        common_params_sampling params_think = params;
-
-        const auto config = params.reasoning_sampling;
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_SEED)               { params_think.seed               = params.reasoning_seed; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP)           { params_think.min_keep           = params.reasoning_min_keep; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_K)              { params_think.top_k              = params.reasoning_top_k; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_P)              { params_think.top_p              = params.reasoning_top_p; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIN_P)              { params_think.min_p              = params.reasoning_min_p; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY)    { params_think.xtc_probability    = params.reasoning_xtc_probability; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD)      { params_think.xtc_threshold      = params.reasoning_xtc_threshold; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P)          { params_think.typ_p              = params.reasoning_typ_p; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TEMP)               { params_think.temp               = params.reasoning_temp; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE)     { params_think.dynatemp_range     = params.reasoning_dynatemp_range; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT)  { params_think.dynatemp_exponent  = params.reasoning_dynatemp_exponent; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N)     { params_think.penalty_last_n     = params.reasoning_penalty_last_n; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT)     { params_think.penalty_repeat     = params.reasoning_penalty_repeat; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ)       { params_think.penalty_freq       = params.reasoning_penalty_freq; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT)    { params_think.penalty_present    = params.reasoning_penalty_present; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER)     { params_think.dry_multiplier     = params.reasoning_dry_multiplier; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE)           { params_think.dry_base           = params.reasoning_dry_base; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN)    { params_think.dry_allowed_length = params.reasoning_dry_allowed_length; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N) { params_think.dry_penalty_last_n = params.reasoning_dry_penalty_last_n; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET)    { params_think.adaptive_target    = params.reasoning_adaptive_target; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY)     { params_think.adaptive_decay     = params.reasoning_adaptive_decay; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT)           { params_think.mirostat           = params.reasoning_mirostat; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA)        { params_think.top_n_sigma        = params.reasoning_top_n_sigma; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU)       { params_think.mirostat_tau       = params.reasoning_mirostat_tau; }
-        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA)       { params_think.mirostat_eta       = params.reasoning_mirostat_eta; }
-
-        chain_think = common_sampler_chain_build(model, params_think);
-    }
+    auto chain_result = common_sampler_chain_build(model, params);
 
     if (grmr && params.backend_sampling) {
         LOG_WRN("%s: backend sampling is not compatible with grammar, disabling\n", __func__);
@@ -496,8 +932,8 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         /* .params         = */ params,
         /* .grmr           = */ grmr,
         /* .rbudget        = */ rbudget,
-        /* .chain          = */ chain,
-        /* .chain_think    = */ chain_think,
+        /* .chain          = */ chain_result.chain,
+        /* .sections       = */ std::move(chain_result.sections),
         /* .prefill_tokens = */ std::move(prefill_tokens),
         /* .grmr_prefilled = */ grmr_prefilled,
         /* .prev           = */ ring_buffer<llama_token>(std::max(32, params.n_prev)),
@@ -542,7 +978,6 @@ void common_sampler_free(struct common_sampler * gsmpl) {
     llama_sampler_free(gsmpl->grmr);
     llama_sampler_free(gsmpl->rbudget);
     llama_sampler_free(gsmpl->chain);
-    llama_sampler_free(gsmpl->chain_think);
 
     delete gsmpl;
 }
@@ -574,13 +1009,13 @@ static bool common_sampler_reasoning_active(const struct common_sampler * gsmpl)
            state == REASONING_BUDGET_FORCING;
 }
 
-// select the sampler chain for the current position:
-// the reasoning chain inside the reasoning block (if configured), the base chain otherwise
-static llama_sampler * common_sampler_active_chain(struct common_sampler * gsmpl) {
-    if (gsmpl->chain_think && common_sampler_reasoning_active(gsmpl)) {
-        return gsmpl->chain_think;
+static void common_sampler_apply_chain(common_sampler * gsmpl, llama_token_data_array * cur_p) {
+    const bool reasoning_active = common_sampler_reasoning_active(gsmpl);
+    for (auto * smpl : gsmpl->sections) {
+        common_sampler_section_set_reasoning(smpl, reasoning_active);
     }
-    return gsmpl->chain;
+
+    llama_sampler_apply(gsmpl->chain, cur_p);
 }
 
 void common_sampler_accept(struct common_sampler * gsmpl, llama_token token, bool is_generated) {
@@ -603,10 +1038,6 @@ void common_sampler_accept(struct common_sampler * gsmpl, llama_token token, boo
 
     llama_sampler_accept(gsmpl->chain, token);
 
-    if (gsmpl->chain_think) {
-        llama_sampler_accept(gsmpl->chain_think, token);
-    }
-
     gsmpl->prev.push_back(token);
 }
 
@@ -619,12 +1050,13 @@ void common_sampler_reset(struct common_sampler * gsmpl) {
 }
 
 struct common_sampler * common_sampler_clone(common_sampler * gsmpl) {
+    auto * chain = llama_sampler_clone(gsmpl->chain);
     return new common_sampler {
         /* .params         = */ gsmpl->params,
         /* .grmr           = */ llama_sampler_clone(gsmpl->grmr),
         /* .rbudget        = */ llama_sampler_clone(gsmpl->rbudget),
-        /* .chain          = */ llama_sampler_clone(gsmpl->chain),
-        /* .chain_think    = */ gsmpl->chain_think ? llama_sampler_clone(gsmpl->chain_think) : nullptr,
+        /* .chain          = */ chain,
+        /* .sections       = */ common_sampler_sections(chain),
         /* .prefill_tokens = */ gsmpl->prefill_tokens,
         /* .grmr_prefilled = */ gsmpl->grmr_prefilled,
         /* .prev           = */ gsmpl->prev,
@@ -696,7 +1128,6 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
 
     auto & grmr  = gsmpl->grmr;
     auto & rbudget = gsmpl->rbudget;
-    auto * chain = common_sampler_active_chain(gsmpl);
     auto & cur_p = gsmpl->cur_p; // initialized by set_logits
 
     gsmpl->set_logits(ctx, idx);
@@ -730,7 +1161,7 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
         llama_sampler_apply(grmr, &cur_p);
     }
 
-    llama_sampler_apply(chain, &cur_p);
+    common_sampler_apply_chain(gsmpl, &cur_p);
 
     id = cur_p.data[cur_p.selected].id;
 
@@ -761,7 +1192,7 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
         llama_sampler_apply(grmr,  &cur_p);
     }
 
-    llama_sampler_apply(chain, &cur_p);
+    common_sampler_apply_chain(gsmpl, &cur_p);
 
     GGML_ASSERT(cur_p.selected != -1 && "no selected token during sampling - check your sampling configuration");
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -200,7 +200,6 @@ std::string common_params_sampling::print() const {
 
 static llama_sampler * common_sampler_chain_build(const struct llama_model * model, const struct common_params_sampling & params) {
     const llama_vocab * vocab = llama_model_get_vocab(model);
-    const int32_t penalty_last_n = params.penalty_last_n == -1 ? llama_model_n_ctx_train(model) : params.penalty_last_n;
 
     llama_sampler_chain_params lparams = llama_sampler_chain_default_params();
 
@@ -255,7 +254,7 @@ static llama_sampler * common_sampler_chain_build(const struct llama_model * mod
                     samplers.push_back(llama_sampler_init_infill(vocab));
                     break;
                 case COMMON_SAMPLER_TYPE_PENALTIES:
-                    samplers.push_back(llama_sampler_init_penalties(penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
+                    samplers.push_back(llama_sampler_init_penalties(params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
                     break;
                 case COMMON_SAMPLER_TYPE_ADAPTIVE_P:
                     // the `adaptive-p` sampler is like `dist` and `mirostat` in that it selects

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -114,7 +114,9 @@ struct common_sampler {
     struct llama_sampler * grmr;
     struct llama_sampler * rbudget;
     struct llama_sampler * chain;
-    struct llama_sampler * chain_think; // optional: applied while inside the reasoning block
+    struct llama_sampler * chain_think;
+
+    std::vector<llama_token> prefill_tokens;
 
     ring_buffer<llama_token> prev;
 
@@ -129,6 +131,13 @@ struct common_sampler {
 
         if (chain_think) {
             llama_sampler_reset(chain_think);
+        }
+
+        if (rbudget) {
+            llama_sampler_reset(rbudget);
+            for (const auto & token : prefill_tokens) {
+                llama_sampler_accept(rbudget, token);
+            }
         }
     }
 
@@ -189,9 +198,6 @@ std::string common_params_sampling::print() const {
     return std::string(result);
 }
 
-// build a sampler chain from the given sampling parameters
-// used for the main chain and, when reasoning-section sampling is enabled,
-// for a second chain that is active inside the reasoning block
 static llama_sampler * common_sampler_chain_build(const struct llama_model * model, const struct common_params_sampling & params) {
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
@@ -285,6 +291,54 @@ static llama_sampler * common_sampler_chain_build(const struct llama_model * mod
     return chain;
 }
 
+static llama_sampler * common_sampler_reasoning_budget_init(
+        const llama_vocab * vocab,
+        const common_params_sampling & params,
+        const std::vector<llama_token> & prefill_tokens) {
+    if (params.reasoning_budget_start.empty() || params.reasoning_budget_end.empty() ||
+        !(params.grammar_lazy || params.reasoning_budget_tokens >= 0 || params.reasoning_control || params.reasoning_sampling)) {
+        return nullptr;
+    }
+
+    auto * rbudget = common_reasoning_budget_init(
+        vocab,
+        params.reasoning_budget_start,
+        params.reasoning_budget_end,
+        params.reasoning_budget_forced,
+        params.reasoning_budget_tokens < 0 ? INT_MAX : params.reasoning_budget_tokens);
+
+    for (const auto & token : prefill_tokens) {
+        llama_sampler_accept(rbudget, token);
+        LOG_DBG("%s: reasoning-budget accepted prefill token (%d)\n", __func__, token);
+    }
+
+    return rbudget;
+}
+
+static std::vector<llama_token> common_sampler_prefill_tokens(
+        const llama_vocab * vocab,
+        const std::string & generation_prompt) {
+    std::vector<llama_token> result;
+    if (generation_prompt.empty()) {
+        return result;
+    }
+
+    GGML_ASSERT(vocab != nullptr);
+    auto tokens = common_tokenize(vocab, generation_prompt, false, true);
+    for (size_t i = 0; i < tokens.size(); i++) {
+        std::string piece = common_token_to_piece(vocab, tokens[i], true);
+        if (i == 0 && !piece.empty() &&
+            std::isspace(static_cast<unsigned char>(piece[0])) &&
+            !std::isspace(static_cast<unsigned char>(generation_prompt[0]))) {
+            continue;
+        }
+        LOG_DBG("%s: prefill token: %d = %s\n", __func__, tokens[i], piece.c_str());
+        result.push_back(tokens[i]);
+    }
+
+    return result;
+}
+
 struct common_sampler * common_sampler_init(const struct llama_model * model, struct common_params_sampling & params) {
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
@@ -357,21 +411,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         throw std::runtime_error("failed to parse grammar");
     }
 
-    // Compute prefill tokens from the generation prompt
-    std::vector<llama_token> prefill_tokens;
-    if (!params.generation_prompt.empty()) {
-        GGML_ASSERT(vocab != nullptr);
-        auto tokens = common_tokenize(vocab, params.generation_prompt, false, true);
-        for (size_t i = 0; i < tokens.size(); i++) {
-            std::string piece = common_token_to_piece(vocab, tokens[i], true);
-            if (i == 0 && std::isspace(piece[0]) && !std::isspace(params.generation_prompt[0])) {
-                // Some tokenizers will add a space before the first special token, need to exclude
-                continue;
-            }
-            LOG_DBG("%s: prefill token: %d = %s\n", __func__, tokens[i], piece.c_str());
-            prefill_tokens.push_back(tokens[i]);
-        }
-    }
+    auto prefill_tokens = common_sampler_prefill_tokens(vocab, params.generation_prompt);
 
     // Feed generation prompt tokens to the grammar sampler so it advances past
     // tokens the template already placed in the prompt.
@@ -389,31 +429,40 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         }
     }
 
-    // reasoning budget sampler (skip when budget is unlimited unless a lazy grammar is active, which needs rbudget for thinking-block suppression)
-    if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0 || params.reasoning_control || params.reasoning_sampling)) {
-        rbudget = common_reasoning_budget_init(
-            vocab,
-            params.reasoning_budget_start,
-            params.reasoning_budget_end,
-            params.reasoning_budget_forced,
-            params.reasoning_budget_tokens < 0 ? INT_MAX : params.reasoning_budget_tokens);
-
-        for (const auto & token : prefill_tokens) {
-            llama_sampler_accept(rbudget, token);
-            LOG_DBG("%s: reasoning-budget accepted prefill token (%d)\n", __func__, token);
-        }
-    }
+    rbudget = common_sampler_reasoning_budget_init(vocab, params, prefill_tokens);
 
     llama_sampler * chain = common_sampler_chain_build(model, params);
 
     llama_sampler * chain_think = nullptr;
     if (params.reasoning_sampling) {
         common_params_sampling params_think = params;
-        if (params.reasoning_temp  >= 0.0f)     { params_think.temp  = params.reasoning_temp;  }
-        if (params.reasoning_top_k != INT32_MIN) { params_think.top_k = params.reasoning_top_k; }
-        if (params.reasoning_top_p >= 0.0f)     { params_think.top_p = params.reasoning_top_p; }
-        if (params.reasoning_min_p >= 0.0f)     { params_think.min_p = params.reasoning_min_p; }
-        if (params.reasoning_penalty_repeat >= 0.0f) { params_think.penalty_repeat = params.reasoning_penalty_repeat; }
+
+        const auto config = params.reasoning_sampling;
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_SEED)               { params_think.seed               = params.reasoning_seed; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP)           { params_think.min_keep           = params.reasoning_min_keep; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_K)              { params_think.top_k              = params.reasoning_top_k; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_P)              { params_think.top_p              = params.reasoning_top_p; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIN_P)              { params_think.min_p              = params.reasoning_min_p; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY)    { params_think.xtc_probability    = params.reasoning_xtc_probability; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD)      { params_think.xtc_threshold      = params.reasoning_xtc_threshold; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P)          { params_think.typ_p              = params.reasoning_typ_p; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TEMP)               { params_think.temp               = params.reasoning_temp; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE)     { params_think.dynatemp_range     = params.reasoning_dynatemp_range; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT)  { params_think.dynatemp_exponent  = params.reasoning_dynatemp_exponent; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N)     { params_think.penalty_last_n     = params.reasoning_penalty_last_n; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT)     { params_think.penalty_repeat     = params.reasoning_penalty_repeat; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ)       { params_think.penalty_freq       = params.reasoning_penalty_freq; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT)    { params_think.penalty_present    = params.reasoning_penalty_present; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER)     { params_think.dry_multiplier     = params.reasoning_dry_multiplier; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE)           { params_think.dry_base           = params.reasoning_dry_base; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN)    { params_think.dry_allowed_length = params.reasoning_dry_allowed_length; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N) { params_think.dry_penalty_last_n = params.reasoning_dry_penalty_last_n; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET)    { params_think.adaptive_target    = params.reasoning_adaptive_target; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY)     { params_think.adaptive_decay     = params.reasoning_adaptive_decay; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT)           { params_think.mirostat           = params.reasoning_mirostat; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA)        { params_think.top_n_sigma        = params.reasoning_top_n_sigma; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU)       { params_think.mirostat_tau       = params.reasoning_mirostat_tau; }
+        if (config & COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA)       { params_think.mirostat_eta       = params.reasoning_mirostat_eta; }
 
         chain_think = common_sampler_chain_build(model, params_think);
     }
@@ -424,24 +473,47 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         params.backend_sampling = false;
     }
 
-    if (rbudget && params.backend_sampling) {
-        LOG_WRN("%s: backend sampling is not compatible with reasoning budget, disabling\n", __func__);
+    if ((rbudget || params.reasoning_sampling) && params.backend_sampling) {
+        LOG_WRN("%s: backend sampling is not compatible with reasoning sampling or budgets, disabling\n", __func__);
 
         params.backend_sampling = false;
     }
 
     auto * result = new common_sampler {
-        /* .params  = */ params,
-        /* .grmr    = */ grmr,
-        /* .rbudget = */ rbudget,
-        /* .chain       = */ chain,
-        /* .chain_think = */ chain_think,
-        /* .prev    = */ ring_buffer<llama_token>(std::max(32, params.n_prev)),
-        /* .cur     = */ {},
-        /* .cur_p   = */ {},
+        /* .params         = */ params,
+        /* .grmr           = */ grmr,
+        /* .rbudget        = */ rbudget,
+        /* .chain          = */ chain,
+        /* .chain_think    = */ chain_think,
+        /* .prefill_tokens = */ std::move(prefill_tokens),
+        /* .prev           = */ ring_buffer<llama_token>(std::max(32, params.n_prev)),
+        /* .cur            = */ {},
+        /* .cur_p          = */ {},
     };
 
     return result;
+}
+
+void common_sampler_configure_reasoning(
+        struct common_sampler * gsmpl,
+        const llama_vocab * vocab,
+        const common_params_sampling & params) {
+    if (!gsmpl) {
+        return;
+    }
+
+    gsmpl->params.generation_prompt        = params.generation_prompt;
+    gsmpl->params.reasoning_budget_start   = params.reasoning_budget_start;
+    gsmpl->params.reasoning_budget_end     = params.reasoning_budget_end;
+    gsmpl->params.reasoning_budget_forced  = params.reasoning_budget_forced;
+    gsmpl->params.reasoning_budget_tokens  = params.reasoning_budget_tokens;
+    gsmpl->params.reasoning_budget_message = params.reasoning_budget_message;
+    gsmpl->params.reasoning_control        = params.reasoning_control;
+
+    gsmpl->prefill_tokens = common_sampler_prefill_tokens(vocab, params.generation_prompt);
+
+    llama_sampler_free(gsmpl->rbudget);
+    gsmpl->rbudget = common_sampler_reasoning_budget_init(vocab, gsmpl->params, gsmpl->prefill_tokens);
 }
 
 void common_sampler_free(struct common_sampler * gsmpl) {
@@ -530,14 +602,15 @@ void common_sampler_reset(struct common_sampler * gsmpl) {
 
 struct common_sampler * common_sampler_clone(common_sampler * gsmpl) {
     return new common_sampler {
-        /* .params  = */ gsmpl->params,
-        /* .grmr    = */ llama_sampler_clone(gsmpl->grmr),
-        /* .rbudget = */ llama_sampler_clone(gsmpl->rbudget),
-        /* .chain       = */ llama_sampler_clone(gsmpl->chain),
-        /* .chain_think = */ gsmpl->chain_think ? llama_sampler_clone(gsmpl->chain_think) : nullptr,
-        /* .prev    = */ gsmpl->prev,
-        /* .cur     = */ gsmpl->cur,
-        /* .cur_p   = */ gsmpl->cur_p,
+        /* .params         = */ gsmpl->params,
+        /* .grmr           = */ llama_sampler_clone(gsmpl->grmr),
+        /* .rbudget        = */ llama_sampler_clone(gsmpl->rbudget),
+        /* .chain          = */ llama_sampler_clone(gsmpl->chain),
+        /* .chain_think    = */ gsmpl->chain_think ? llama_sampler_clone(gsmpl->chain_think) : nullptr,
+        /* .prefill_tokens = */ gsmpl->prefill_tokens,
+        /* .prev           = */ gsmpl->prev,
+        /* .cur            = */ gsmpl->cur,
+        /* .cur_p          = */ gsmpl->cur_p,
     };
 }
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -117,6 +117,7 @@ struct common_sampler {
     struct llama_sampler * chain_think;
 
     std::vector<llama_token> prefill_tokens;
+    bool grmr_prefilled;
 
     ring_buffer<llama_token> prev;
 
@@ -339,6 +340,32 @@ static std::vector<llama_token> common_sampler_prefill_tokens(
     return result;
 }
 
+// Feed generation prompt tokens to the grammar sampler so it advances past
+// tokens the template already placed in the prompt.
+// Only applies to output-format and tool-call grammars; user-supplied grammars must not be prefilled.
+// Returns true when the grammar was advanced, so callers can avoid feeding it twice.
+static bool common_sampler_grammar_prefill(
+        struct llama_sampler * grmr,
+        const common_params_sampling & params,
+        const std::vector<llama_token> & prefill_tokens) {
+    if (!grmr || params.grammar_lazy || !common_grammar_needs_prefill(params.grammar) || prefill_tokens.empty()) {
+        return false;
+    }
+
+    try {
+        for (const auto & token : prefill_tokens) {
+            llama_sampler_accept(grmr, token);
+            LOG_DBG("%s: grammar accepted prefill token (%d)\n", __func__, token);
+        }
+    } catch (std::exception &e) {
+        LOG_ERR("%s: error initializing grammar sampler for grammar:\n%s\n\nGeneration prompt:\n'%s'\n", __func__,
+            common_grammar_value(params.grammar).c_str(), params.generation_prompt.c_str());
+        throw e;
+    }
+
+    return true;
+}
+
 struct common_sampler * common_sampler_init(const struct llama_model * model, struct common_params_sampling & params) {
     const llama_vocab * vocab = llama_model_get_vocab(model);
 
@@ -413,21 +440,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
 
     auto prefill_tokens = common_sampler_prefill_tokens(vocab, params.generation_prompt);
 
-    // Feed generation prompt tokens to the grammar sampler so it advances past
-    // tokens the template already placed in the prompt.
-    // Only applies to output-format and tool-call grammars; user-supplied grammars must not be prefilled.
-    if (grmr && !params.grammar_lazy && common_grammar_needs_prefill(params.grammar)) {
-        try {
-            for (const auto & token : prefill_tokens) {
-                llama_sampler_accept(grmr, token);
-                LOG_DBG("%s: grammar accepted prefill token (%d)\n", __func__, token);
-            }
-        } catch (std::exception &e) {
-            LOG_ERR("%s: error initializing grammar sampler for grammar:\n%s\n\nGeneration prompt:\n'%s'\n", __func__,
-                common_grammar_value(params.grammar).c_str(), params.generation_prompt.c_str());
-            throw e;
-        }
-    }
+    const bool grmr_prefilled = common_sampler_grammar_prefill(grmr, params, prefill_tokens);
 
     rbudget = common_sampler_reasoning_budget_init(vocab, params, prefill_tokens);
 
@@ -486,6 +499,7 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         /* .chain          = */ chain,
         /* .chain_think    = */ chain_think,
         /* .prefill_tokens = */ std::move(prefill_tokens),
+        /* .grmr_prefilled = */ grmr_prefilled,
         /* .prev           = */ ring_buffer<llama_token>(std::max(32, params.n_prev)),
         /* .cur            = */ {},
         /* .cur_p          = */ {},
@@ -511,6 +525,10 @@ void common_sampler_configure_reasoning(
     gsmpl->params.reasoning_control        = params.reasoning_control;
 
     gsmpl->prefill_tokens = common_sampler_prefill_tokens(vocab, params.generation_prompt);
+
+    if (!gsmpl->grmr_prefilled) {
+        gsmpl->grmr_prefilled = common_sampler_grammar_prefill(gsmpl->grmr, gsmpl->params, gsmpl->prefill_tokens);
+    }
 
     llama_sampler_free(gsmpl->rbudget);
     gsmpl->rbudget = common_sampler_reasoning_budget_init(vocab, gsmpl->params, gsmpl->prefill_tokens);
@@ -608,6 +626,7 @@ struct common_sampler * common_sampler_clone(common_sampler * gsmpl) {
         /* .chain          = */ llama_sampler_clone(gsmpl->chain),
         /* .chain_think    = */ gsmpl->chain_think ? llama_sampler_clone(gsmpl->chain_think) : nullptr,
         /* .prefill_tokens = */ gsmpl->prefill_tokens,
+        /* .grmr_prefilled = */ gsmpl->grmr_prefilled,
         /* .prev           = */ gsmpl->prev,
         /* .cur            = */ gsmpl->cur,
         /* .cur_p          = */ gsmpl->cur_p,

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -200,6 +200,7 @@ std::string common_params_sampling::print() const {
 
 static llama_sampler * common_sampler_chain_build(const struct llama_model * model, const struct common_params_sampling & params) {
     const llama_vocab * vocab = llama_model_get_vocab(model);
+    const int32_t penalty_last_n = params.penalty_last_n == -1 ? llama_model_n_ctx_train(model) : params.penalty_last_n;
 
     llama_sampler_chain_params lparams = llama_sampler_chain_default_params();
 
@@ -254,7 +255,7 @@ static llama_sampler * common_sampler_chain_build(const struct llama_model * mod
                     samplers.push_back(llama_sampler_init_infill(vocab));
                     break;
                 case COMMON_SAMPLER_TYPE_PENALTIES:
-                    samplers.push_back(llama_sampler_init_penalties(params.penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
+                    samplers.push_back(llama_sampler_init_penalties(penalty_last_n, params.penalty_repeat, params.penalty_freq, params.penalty_present));
                     break;
                 case COMMON_SAMPLER_TYPE_ADAPTIVE_P:
                     // the `adaptive-p` sampler is like `dist` and `mirostat` in that it selects

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -39,6 +39,12 @@ struct common_sampler;
 // note: can mutate params in some cases
 struct common_sampler * common_sampler_init(const struct llama_model * model, struct common_params_sampling & params);
 
+// Update reasoning markers after applying a chat template.
+void common_sampler_configure_reasoning(
+        struct common_sampler * gsmpl,
+        const llama_vocab * vocab,
+        const common_params_sampling & params);
+
 void common_sampler_free(struct common_sampler * gsmpl);
 
 // if is_generated is true, the token is accepted by the sampling chain, the reasoning budget sampler, and the grammar sampler

--- a/include/llama.h
+++ b/include/llama.h
@@ -1349,6 +1349,8 @@ extern "C" {
 
     /// @details XTC sampler as described in https://github.com/oobabooga/text-generation-webui/pull/6335
     LLAMA_API struct llama_sampler * llama_sampler_init_xtc        (float   p, float   t,     size_t min_keep, uint32_t seed);
+    /// Update a non-empty XTC sampler without resetting its RNG state.
+    LLAMA_API void                   llama_sampler_xtc_set         (struct llama_sampler * smpl, float p, float t, size_t min_keep);
 
     /// @details Top n sigma sampling as described in academic paper "Top-nσ: Not All Logits Are You Need" https://arxiv.org/pdf/2411.07641
     LLAMA_API struct llama_sampler * llama_sampler_init_top_n_sigma(float   n);

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -2101,9 +2101,9 @@ struct llama_sampler * llama_sampler_init_temp_ext(float temp, float delta, floa
 // xtc
 
 struct llama_sampler_xtc {
-    const float    probability;
-    const float    threshold;
-    const size_t   min_keep;
+    float          probability;
+    float          threshold;
+    size_t         min_keep;
 
     const uint32_t seed;
     uint32_t       seed_cur;
@@ -2114,6 +2114,8 @@ struct llama_sampler_xtc {
 static const char * llama_sampler_xtc_name(const struct llama_sampler * /*smpl*/) {
     return "xtc";
 }
+
+static struct llama_sampler * llama_sampler_init_xtc_impl(float p, float t, size_t min_keep, uint32_t seed);
 
 static void llama_sample_xtc_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
     auto * ctx = (llama_sampler_xtc *) smpl->ctx;
@@ -2150,13 +2152,14 @@ static void llama_sample_xtc_apply(struct llama_sampler * smpl, llama_token_data
 
 static struct llama_sampler * llama_sampler_xtc_clone(const struct llama_sampler * smpl) {
     const auto * ctx = (const llama_sampler_xtc *) smpl->ctx;
-    auto * result = llama_sampler_init_xtc(ctx->probability, ctx->threshold, ctx->min_keep, ctx->seed);
+    auto * result = llama_sampler_init_xtc_impl(ctx->probability, ctx->threshold, ctx->min_keep, ctx->seed);
 
     // copy the state
     {
         auto * result_ctx = (llama_sampler_xtc *) result->ctx;
 
-        result_ctx->rng = ctx->rng;
+        result_ctx->seed_cur = ctx->seed_cur;
+        result_ctx->rng      = ctx->rng;
     }
 
     return result;
@@ -2192,6 +2195,10 @@ struct llama_sampler * llama_sampler_init_xtc(float p, float t, size_t min_keep,
         return llama_sampler_init_empty("?xtc");
     }
 
+    return llama_sampler_init_xtc_impl(p, t, min_keep, seed);
+}
+
+static struct llama_sampler * llama_sampler_init_xtc_impl(float p, float t, size_t min_keep, uint32_t seed) {
     const auto seed_cur = get_rng_seed(seed);
 
     return llama_sampler_init(
@@ -2205,6 +2212,15 @@ struct llama_sampler * llama_sampler_init_xtc(float p, float t, size_t min_keep,
             /* .rng           = */ std::mt19937(seed_cur),
         }
     );
+}
+
+void llama_sampler_xtc_set(struct llama_sampler * smpl, float p, float t, size_t min_keep) {
+    GGML_ASSERT(smpl && smpl->iface == &llama_sampler_xtc_i);
+
+    auto * ctx = (llama_sampler_xtc *) smpl->ctx;
+    ctx->probability = p;
+    ctx->threshold   = t;
+    ctx->min_keep    = min_keep;
 }
 
 // mirostat
@@ -2717,7 +2733,8 @@ static struct llama_sampler * llama_sampler_penalties_clone(const struct llama_s
     {
         auto * result_ctx = (llama_sampler_penalties *) result->ctx;
 
-        result_ctx->prev = ctx->prev;
+        result_ctx->prev        = ctx->prev;
+        result_ctx->token_count = ctx->token_count;
     }
 
     return result;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -244,6 +244,8 @@ llama_build_and_test(test-backend-ops.cpp)
 llama_build_and_test(test-model-load-cancel.cpp LABEL "model")
 llama_build_and_test(test-autorelease.cpp       LABEL "model")
 llama_build_and_test(test-backend-sampler.cpp   LABEL "model")
+llama_build_and_test(test-reasoning-overrides.cpp LABEL "model" ARGS "${MODEL_DEST}")
+set_tests_properties(test-reasoning-overrides PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 # Test for state restore with fragmented KV cache
 # Requires a model, uses same args pattern as test-thread-safety

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -132,6 +132,26 @@ static void test(void) {
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
     assert(params.speculative.draft.n_max == 123);
 
+    common_params reasoning_params;
+    argv = {
+        "binary_name",
+        "--model", "model_file.gguf",
+        "--reasoning-temp", "1.25",
+        "--reasoning-top-k", "17",
+        "--reasoning-presence-penalty", "-0.2",
+        "--reasoning-frequency-penalty", "0.4",
+        "--reasoning-dry-multiplier", "0.8",
+        "--reasoning-mirostat", "2",
+    };
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), reasoning_params, LLAMA_EXAMPLE_COMPLETION));
+    assert(reasoning_params.sampling.reasoning_temp == 1.25f);
+    assert(reasoning_params.sampling.reasoning_top_k == 17);
+    assert(reasoning_params.sampling.reasoning_penalty_present == -0.2f);
+    assert(reasoning_params.sampling.reasoning_penalty_freq == 0.4f);
+    assert(reasoning_params.sampling.reasoning_dry_multiplier == 0.8f);
+    assert(reasoning_params.sampling.reasoning_mirostat == 2);
+    assert(reasoning_params.sampling.reasoning_sampling != 0);
+
     // multi-value args (CSV)
     argv = {"binary_name", "--lora", "file1.gguf,\"file2,2.gguf\",\"file3\"\"3\"\".gguf\",file4\".gguf"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -141,7 +141,9 @@ static void test(void) {
         "--reasoning-presence-penalty", "-0.2",
         "--reasoning-frequency-penalty", "0.4",
         "--reasoning-dry-multiplier", "0.8",
-        "--reasoning-mirostat", "2",
+        "--reasoning-xtc-probability", "0.3",
+        "--reasoning-xtc-threshold", "0.2",
+        "--reasoning-min-keep", "3",
     };
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), reasoning_params, LLAMA_EXAMPLE_COMPLETION));
     assert(reasoning_params.sampling.reasoning_temp == 1.25f);
@@ -149,8 +151,33 @@ static void test(void) {
     assert(reasoning_params.sampling.reasoning_penalty_present == -0.2f);
     assert(reasoning_params.sampling.reasoning_penalty_freq == 0.4f);
     assert(reasoning_params.sampling.reasoning_dry_multiplier == 0.8f);
-    assert(reasoning_params.sampling.reasoning_mirostat == 2);
+    assert(reasoning_params.sampling.reasoning_xtc_probability == 0.3f);
+    assert(reasoning_params.sampling.reasoning_xtc_threshold == 0.2f);
+    assert(reasoning_params.sampling.reasoning_min_keep == 3);
     assert(reasoning_params.sampling.reasoning_sampling != 0);
+
+    {
+        const auto ctx_arg = common_params_parser_init(reasoning_params, LLAMA_EXAMPLE_COMPLETION);
+        std::unordered_set<std::string> reasoning_args;
+        for (const auto & opt : ctx_arg.options) {
+            const auto opt_args = opt.get_args();
+            reasoning_args.insert(opt_args.begin(), opt_args.end());
+        }
+
+        const std::vector<std::string> removed_args = {
+            "--reasoning-mirostat",
+            "--reasoning-mirostat-ent",
+            "--reasoning-mirostat-tau",
+            "--reasoning-mirostat-lr",
+            "--reasoning-mirostat-eta",
+            "--reasoning-adaptive-target",
+            "--reasoning-adaptive-decay",
+            "--reasoning-seed",
+        };
+        for (const auto & arg : removed_args) {
+            assert(reasoning_args.find(arg) == reasoning_args.end());
+        }
+    }
 
     // multi-value args (CSV)
     argv = {"binary_name", "--lora", "file1.gguf,\"file2,2.gguf\",\"file3\"\"3\"\".gguf\",file4\".gguf"};

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -13,6 +13,7 @@
 #include "common.h"
 #include "ggml.h"
 #include "log.h"
+#include "server-schema.h"
 
 #include <algorithm>
 #include <exception>
@@ -5983,6 +5984,47 @@ static void test_reasoning_budget_message_per_request() {
     }
 }
 
+static void test_reasoning_sampling_per_request() {
+    common_params params_base;
+    const json body = {
+        {"reasoning_temp", 1.25f},
+        {"reasoning_top_k", 17},
+        {"reasoning_top_p", 0.82f},
+        {"reasoning_min_p", 0.03f},
+        {"reasoning_repeat_last_n", -1},
+        {"reasoning_repeat_penalty", 1.08f},
+        {"reasoning_frequency_penalty", -0.2f},
+        {"reasoning_presence_penalty", 0.4f},
+        {"reasoning_dry_penalty_last_n", -1},
+    };
+    const std::vector<llama_logit_bias> logit_bias_eog;
+
+    auto params = server_schema::eval_llama_cmpl_schema(
+        nullptr, params_base, 4096, logit_bias_eog, body);
+
+    assert_equals(1.25f, params.sampling.reasoning_temp);
+    assert_equals(17, params.sampling.reasoning_top_k);
+    assert_equals(0.82f, params.sampling.reasoning_top_p);
+    assert_equals(0.03f, params.sampling.reasoning_min_p);
+    assert_equals(4096, params.sampling.reasoning_penalty_last_n);
+    assert_equals(1.08f, params.sampling.reasoning_penalty_repeat);
+    assert_equals(-0.2f, params.sampling.reasoning_penalty_freq);
+    assert_equals(0.4f, params.sampling.reasoning_penalty_present);
+    assert_equals(4096, params.sampling.reasoning_dry_penalty_last_n);
+
+    const uint64_t expected =
+        COMMON_PARAMS_SAMPLING_CONFIG_TEMP |
+        COMMON_PARAMS_SAMPLING_CONFIG_TOP_K |
+        COMMON_PARAMS_SAMPLING_CONFIG_TOP_P |
+        COMMON_PARAMS_SAMPLING_CONFIG_MIN_P |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT |
+        COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N;
+    assert_equals(expected, params.sampling.reasoning_sampling);
+}
+
 static void test_msg_diffs_compute() {
     LOG_DBG("%s\n", __func__);
     {
@@ -6142,6 +6184,7 @@ int main(int argc, char ** argv) {
         test_template_generation_prompt();
         test_reasoning_budget_tokens_per_request();
         test_reasoning_budget_message_per_request();
+        test_reasoning_sampling_per_request();
         test_template_output_peg_parsers(detailed_debug);
         std::cout << "\n[chat] All tests passed!" << '\n';
     }

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -5991,11 +5991,16 @@ static void test_reasoning_sampling_per_request() {
         {"reasoning_top_k", 17},
         {"reasoning_top_p", 0.82f},
         {"reasoning_min_p", 0.03f},
+        {"reasoning_xtc_probability", 0.25f},
+        {"reasoning_xtc_threshold", 0.15f},
+        {"reasoning_typical_p", params_base.sampling.typ_p},
+        {"reasoning_dynatemp_range", nullptr},
         {"reasoning_repeat_last_n", -1},
         {"reasoning_repeat_penalty", 1.08f},
         {"reasoning_frequency_penalty", -0.2f},
         {"reasoning_presence_penalty", 0.4f},
         {"reasoning_dry_penalty_last_n", -1},
+        {"reasoning_min_keep", 3},
     };
     const std::vector<llama_logit_bias> logit_bias_eog;
 
@@ -6006,23 +6011,52 @@ static void test_reasoning_sampling_per_request() {
     assert_equals(17, params.sampling.reasoning_top_k);
     assert_equals(0.82f, params.sampling.reasoning_top_p);
     assert_equals(0.03f, params.sampling.reasoning_min_p);
+    assert_equals(0.25f, params.sampling.reasoning_xtc_probability);
+    assert_equals(0.15f, params.sampling.reasoning_xtc_threshold);
+    assert_equals(params_base.sampling.typ_p, params.sampling.reasoning_typ_p);
     assert_equals(4096, params.sampling.reasoning_penalty_last_n);
     assert_equals(1.08f, params.sampling.reasoning_penalty_repeat);
     assert_equals(-0.2f, params.sampling.reasoning_penalty_freq);
     assert_equals(0.4f, params.sampling.reasoning_penalty_present);
     assert_equals(4096, params.sampling.reasoning_dry_penalty_last_n);
+    assert_equals(3, params.sampling.reasoning_min_keep);
 
     const uint64_t expected =
         COMMON_PARAMS_SAMPLING_CONFIG_TEMP |
         COMMON_PARAMS_SAMPLING_CONFIG_TOP_K |
         COMMON_PARAMS_SAMPLING_CONFIG_TOP_P |
         COMMON_PARAMS_SAMPLING_CONFIG_MIN_P |
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY |
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD |
+        COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P |
         COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N |
         COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT |
         COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ |
         COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT |
-        COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N;
+        COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N |
+        COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP;
     assert_equals(expected, params.sampling.reasoning_sampling);
+
+    task_params schema_params;
+    const auto schema = server_schema::make_llama_cmpl_schema(params_base, schema_params);
+    const std::vector<std::string> removed_fields = {
+        "reasoning_mirostat",
+        "reasoning_mirostat_tau",
+        "reasoning_mirostat_eta",
+        "reasoning_adaptive_target",
+        "reasoning_adaptive_decay",
+        "reasoning_seed",
+    };
+    for (const auto & removed : removed_fields) {
+        const bool found = std::any_of(schema.begin(), schema.end(), [&](const auto & field) {
+            return std::any_of(field->name.begin(), field->name.end(), [&](const char * name) {
+                return removed == name;
+            });
+        });
+        if (found) {
+            throw std::runtime_error("removed reasoning field is still present in the server schema: " + removed);
+        }
+    }
 }
 
 static void test_msg_diffs_compute() {

--- a/tests/test-reasoning-overrides.cpp
+++ b/tests/test-reasoning-overrides.cpp
@@ -10,6 +10,7 @@
 #endif
 
 #include <cstdlib>
+#include <cmath>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -41,6 +42,92 @@ static std::vector<llama_token> decode_prompt(llama_context * ctx, const std::st
     require(llama_decode(ctx, batch) == 0, "failed to decode prompt");
 
     return tokens;
+}
+
+struct sample_stats {
+    size_t candidate_count = 0;
+    llama_token top_token = LLAMA_TOKEN_NULL;
+    float top_prob = 0.0f;
+};
+
+struct candidate_observation {
+    size_t candidate_count = 0;
+    size_t target_rank = SIZE_MAX;
+    float target_prob = 0.0f;
+};
+
+static sample_stats sample_reasoning_stats(
+        llama_model * model,
+        llama_context * ctx,
+        common_params_sampling params,
+        const std::vector<llama_token> & prompt_tokens,
+        const std::vector<llama_token> & generated_tokens) {
+    common_sampler_ptr sampler { common_sampler_init(model, params) };
+    require(static_cast<bool>(sampler), "failed to initialize common sampler");
+
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+    }
+
+    for (const auto token : generated_tokens) {
+        common_sampler_accept(sampler.get(), token, true);
+    }
+
+    const int idx = static_cast<int>(prompt_tokens.size()) - 1;
+    require(idx >= 0, "prompt must contain at least one token");
+
+    (void) common_sampler_sample(sampler.get(), ctx, idx);
+
+    auto * candidates = common_sampler_get_candidates(sampler.get(), true);
+    require(candidates != nullptr, "sampler did not expose candidates");
+    require(candidates->size > 0, "sampler returned no candidates");
+
+    return sample_stats {
+        candidates->size,
+        candidates->data[0].id,
+        candidates->data[0].p,
+    };
+}
+
+static candidate_observation sample_candidate_observation(
+        llama_model * model,
+        llama_context * ctx,
+        common_params_sampling params,
+        const std::vector<llama_token> & prompt_tokens,
+        const std::vector<llama_token> & generated_tokens,
+        llama_token target_token) {
+    common_sampler_ptr sampler { common_sampler_init(model, params) };
+    require(static_cast<bool>(sampler), "failed to initialize common sampler");
+
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+    }
+
+    for (const auto token : generated_tokens) {
+        common_sampler_accept(sampler.get(), token, true);
+    }
+
+    const int idx = static_cast<int>(prompt_tokens.size()) - 1;
+    require(idx >= 0, "prompt must contain at least one token");
+
+    (void) common_sampler_sample(sampler.get(), ctx, idx);
+
+    auto * candidates = common_sampler_get_candidates(sampler.get(), true);
+    require(candidates != nullptr, "sampler did not expose candidates");
+    require(candidates->size > 0, "sampler returned no candidates");
+
+    candidate_observation obs;
+    obs.candidate_count = candidates->size;
+    for (size_t i = 0; i < candidates->size; ++i) {
+        if (candidates->data[i].id == target_token) {
+            obs.target_rank = i;
+            obs.target_prob = candidates->data[i].p;
+            break;
+        }
+    }
+
+    require(obs.target_rank != SIZE_MAX, "target token not found in candidate list");
+    return obs;
 }
 
 static size_t sample_candidate_count(
@@ -103,6 +190,133 @@ static void test_reasoning_override_chain_switch(llama_model * model) {
     require(after_end_candidates == 40, "sampler did not return to the base chain after the reasoning end tag");
 }
 
+static void test_reasoning_override_top_p(llama_model * model) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    require(vocab != nullptr, "failed to read model vocab");
+
+    const int n_vocab = llama_vocab_n_tokens(vocab);
+    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TOP_P };
+    params.top_p = 1.0f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_P;
+    params.reasoning_top_p = 0.01f;
+    params.reasoning_budget_tokens = 8;
+
+    const llama_token start_token = n_vocab - 2;
+    const llama_token end_token = n_vocab - 1;
+    params.reasoning_budget_start = { start_token };
+    params.reasoning_budget_end = { end_token };
+    params.reasoning_budget_forced = { end_token };
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const auto base_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, {});
+    const auto think_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, { start_token });
+
+    require(think_stats.candidate_count < base_stats.candidate_count, "reasoning top_p did not shrink the candidate set");
+}
+
+static void test_reasoning_override_min_p(llama_model * model) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    require(vocab != nullptr, "failed to read model vocab");
+
+    const int n_vocab = llama_vocab_n_tokens(vocab);
+    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_MIN_P };
+    params.min_p = 0.0f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIN_P;
+    params.reasoning_min_p = 0.50f;
+    params.reasoning_budget_tokens = 8;
+
+    const llama_token start_token = n_vocab - 2;
+    const llama_token end_token = n_vocab - 1;
+    params.reasoning_budget_start = { start_token };
+    params.reasoning_budget_end = { end_token };
+    params.reasoning_budget_forced = { end_token };
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const auto base_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, {});
+    const auto think_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, { start_token });
+
+    require(think_stats.candidate_count < base_stats.candidate_count, "reasoning min_p did not shrink the candidate set");
+}
+
+static void test_reasoning_override_temp(llama_model * model) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    require(vocab != nullptr, "failed to read model vocab");
+
+    const int n_vocab = llama_vocab_n_tokens(vocab);
+    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params.top_k = 40;
+    params.temp = 0.80f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
+    params.reasoning_temp = 1.80f;
+    params.reasoning_budget_tokens = 8;
+
+    const llama_token start_token = n_vocab - 2;
+    const llama_token end_token = n_vocab - 1;
+    params.reasoning_budget_start = { start_token };
+    params.reasoning_budget_end = { end_token };
+    params.reasoning_budget_forced = { end_token };
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const auto base_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, {});
+    const auto think_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, { start_token });
+
+    require(base_stats.candidate_count == 40, "base chain did not keep the configured top_k candidate count");
+    require(std::fabs(base_stats.top_prob - think_stats.top_prob) > 1e-6f, "reasoning temperature did not change candidate probabilities");
+}
+
+static void test_reasoning_override_penalties(llama_model * model) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    require(vocab != nullptr, "failed to read model vocab");
+
+    const int n_vocab = llama_vocab_n_tokens(vocab);
+    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_PENALTIES };
+    params.penalty_last_n = 64;
+    params.penalty_repeat = 1.0f;
+    params.penalty_freq = 0.0f;
+    params.penalty_present = 0.0f;
+    params.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT;
+    params.reasoning_penalty_repeat = 1.50f;
+    params.reasoning_penalty_freq = 0.50f;
+    params.reasoning_penalty_present = 0.50f;
+    params.reasoning_budget_tokens = 8;
+
+    const llama_token start_token = n_vocab - 2;
+    const llama_token end_token = n_vocab - 1;
+    params.reasoning_budget_start = { start_token };
+    params.reasoning_budget_end = { end_token };
+    params.reasoning_budget_forced = { end_token };
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning penalties did not reduce repeated-token probability");
+}
+
 int main(int argc, char ** argv) {
     llama_backend_init();
 
@@ -112,6 +326,10 @@ int main(int argc, char ** argv) {
     require(static_cast<bool>(model), std::string("failed to load model: ") + model_path);
 
     test_reasoning_override_chain_switch(model.get());
+    test_reasoning_override_top_p(model.get());
+    test_reasoning_override_min_p(model.get());
+    test_reasoning_override_temp(model.get());
+    test_reasoning_override_penalties(model.get());
 
     return 0;
 }

--- a/tests/test-reasoning-overrides.cpp
+++ b/tests/test-reasoning-overrides.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 static void require(bool cond, const std::string & msg) {
@@ -55,6 +56,27 @@ struct candidate_observation {
     size_t target_rank = SIZE_MAX;
     float target_prob = 0.0f;
 };
+
+static std::pair<llama_token, llama_token> reasoning_sentinels(llama_model * model) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    require(vocab != nullptr, "failed to read model vocab");
+
+    const int n_vocab = llama_vocab_n_tokens(vocab);
+    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+
+    return { n_vocab - 2, n_vocab - 1 };
+}
+
+static void set_reasoning_budget(
+        common_params_sampling & params,
+        llama_token start_token,
+        llama_token end_token,
+        int32_t budget_tokens = 8) {
+    params.reasoning_budget_tokens = budget_tokens;
+    params.reasoning_budget_start = { start_token };
+    params.reasoning_budget_end = { end_token };
+    params.reasoning_budget_forced = { end_token };
+}
 
 static sample_stats sample_reasoning_stats(
         llama_model * model,
@@ -158,25 +180,78 @@ static size_t sample_candidate_count(
     return candidates->size;
 }
 
-static void test_reasoning_override_chain_switch(llama_model * model) {
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-    require(vocab != nullptr, "failed to read model vocab");
+static std::vector<llama_token> generate_reasoning_sequence(
+        llama_model * model,
+        const std::string & prompt,
+        common_params_sampling params,
+        const std::vector<llama_token> & accepted_tokens,
+        size_t n_steps) {
+    auto ctx = make_context(model);
 
-    const int n_vocab = llama_vocab_n_tokens(vocab);
-    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+    auto prompt_tokens = common_tokenize(ctx.get(), prompt, true);
+    require(!prompt_tokens.empty(), "prompt tokenization produced no tokens");
+
+    auto prompt_batch = llama_batch_get_one(prompt_tokens.data(), prompt_tokens.size());
+    require(llama_decode(ctx.get(), prompt_batch) == 0, "failed to decode prompt");
+
+    common_sampler_ptr sampler { common_sampler_init(model, params) };
+    require(static_cast<bool>(sampler), "failed to initialize common sampler");
+
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+    }
+
+    for (const auto token : accepted_tokens) {
+        common_sampler_accept(sampler.get(), token, true);
+        llama_token accepted = token;
+        auto batch = llama_batch_get_one(&accepted, 1);
+        require(llama_decode(ctx.get(), batch) == 0, "failed to decode accepted token");
+    }
+
+    std::vector<llama_token> result;
+    result.reserve(n_steps);
+
+    int idx = accepted_tokens.empty() ? static_cast<int>(prompt_tokens.size()) - 1 : 0;
+    for (size_t i = 0; i < n_steps; ++i) {
+        require(idx >= 0, "generation context is empty");
+
+        const llama_token token = common_sampler_sample(sampler.get(), ctx.get(), idx);
+        common_sampler_accept(sampler.get(), token, true);
+
+        llama_token generated = token;
+        auto batch = llama_batch_get_one(&generated, 1);
+        require(llama_decode(ctx.get(), batch) == 0, "failed to decode generated token");
+
+        result.push_back(token);
+        idx = 0;
+    }
+
+    return result;
+}
+
+static void require_sequence_equal(
+        const std::vector<llama_token> & a,
+        const std::vector<llama_token> & b,
+        const std::string & msg) {
+    require(a == b, msg);
+}
+
+static void require_sequence_different(
+        const std::vector<llama_token> & a,
+        const std::vector<llama_token> & b,
+        const std::string & msg) {
+    require(a != b, msg);
+}
+
+static void test_reasoning_override_chain_switch(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
 
     common_params_sampling params;
     params.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
     params.top_k = 40;
     params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
     params.reasoning_top_k = 1;
-    params.reasoning_budget_tokens = 8;
-
-    const llama_token start_token = n_vocab - 2;
-    const llama_token end_token = n_vocab - 1;
-    params.reasoning_budget_start = { start_token };
-    params.reasoning_budget_end = { end_token };
-    params.reasoning_budget_forced = { end_token };
+    set_reasoning_budget(params, start_token, end_token);
 
     auto ctx = make_context(model);
     const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
@@ -191,24 +266,14 @@ static void test_reasoning_override_chain_switch(llama_model * model) {
 }
 
 static void test_reasoning_override_top_p(llama_model * model) {
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-    require(vocab != nullptr, "failed to read model vocab");
-
-    const int n_vocab = llama_vocab_n_tokens(vocab);
-    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+    const auto [start_token, end_token] = reasoning_sentinels(model);
 
     common_params_sampling params;
     params.samplers = { COMMON_SAMPLER_TYPE_TOP_P };
     params.top_p = 1.0f;
     params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_P;
     params.reasoning_top_p = 0.01f;
-    params.reasoning_budget_tokens = 8;
-
-    const llama_token start_token = n_vocab - 2;
-    const llama_token end_token = n_vocab - 1;
-    params.reasoning_budget_start = { start_token };
-    params.reasoning_budget_end = { end_token };
-    params.reasoning_budget_forced = { end_token };
+    set_reasoning_budget(params, start_token, end_token);
 
     auto ctx = make_context(model);
     const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
@@ -220,24 +285,14 @@ static void test_reasoning_override_top_p(llama_model * model) {
 }
 
 static void test_reasoning_override_min_p(llama_model * model) {
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-    require(vocab != nullptr, "failed to read model vocab");
-
-    const int n_vocab = llama_vocab_n_tokens(vocab);
-    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+    const auto [start_token, end_token] = reasoning_sentinels(model);
 
     common_params_sampling params;
     params.samplers = { COMMON_SAMPLER_TYPE_MIN_P };
     params.min_p = 0.0f;
     params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIN_P;
     params.reasoning_min_p = 0.50f;
-    params.reasoning_budget_tokens = 8;
-
-    const llama_token start_token = n_vocab - 2;
-    const llama_token end_token = n_vocab - 1;
-    params.reasoning_budget_start = { start_token };
-    params.reasoning_budget_end = { end_token };
-    params.reasoning_budget_forced = { end_token };
+    set_reasoning_budget(params, start_token, end_token);
 
     auto ctx = make_context(model);
     const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
@@ -249,11 +304,7 @@ static void test_reasoning_override_min_p(llama_model * model) {
 }
 
 static void test_reasoning_override_temp(llama_model * model) {
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-    require(vocab != nullptr, "failed to read model vocab");
-
-    const int n_vocab = llama_vocab_n_tokens(vocab);
-    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+    const auto [start_token, end_token] = reasoning_sentinels(model);
 
     common_params_sampling params;
     params.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
@@ -261,13 +312,7 @@ static void test_reasoning_override_temp(llama_model * model) {
     params.temp = 0.80f;
     params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
     params.reasoning_temp = 1.80f;
-    params.reasoning_budget_tokens = 8;
-
-    const llama_token start_token = n_vocab - 2;
-    const llama_token end_token = n_vocab - 1;
-    params.reasoning_budget_start = { start_token };
-    params.reasoning_budget_end = { end_token };
-    params.reasoning_budget_forced = { end_token };
+    set_reasoning_budget(params, start_token, end_token);
 
     auto ctx = make_context(model);
     const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
@@ -279,12 +324,8 @@ static void test_reasoning_override_temp(llama_model * model) {
     require(std::fabs(base_stats.top_prob - think_stats.top_prob) > 1e-6f, "reasoning temperature did not change candidate probabilities");
 }
 
-static void test_reasoning_override_penalties(llama_model * model) {
-    const llama_vocab * vocab = llama_model_get_vocab(model);
-    require(vocab != nullptr, "failed to read model vocab");
-
-    const int n_vocab = llama_vocab_n_tokens(vocab);
-    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+static void test_reasoning_override_penalty_repeat(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
 
     common_params_sampling params;
     params.samplers = { COMMON_SAMPLER_TYPE_PENALTIES };
@@ -292,20 +333,9 @@ static void test_reasoning_override_penalties(llama_model * model) {
     params.penalty_repeat = 1.0f;
     params.penalty_freq = 0.0f;
     params.penalty_present = 0.0f;
-    params.reasoning_sampling =
-        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT |
-        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ |
-        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT;
     params.reasoning_penalty_repeat = 1.50f;
-    params.reasoning_penalty_freq = 0.50f;
-    params.reasoning_penalty_present = 0.50f;
-    params.reasoning_budget_tokens = 8;
-
-    const llama_token start_token = n_vocab - 2;
-    const llama_token end_token = n_vocab - 1;
-    params.reasoning_budget_start = { start_token };
-    params.reasoning_budget_end = { end_token };
-    params.reasoning_budget_forced = { end_token };
+    set_reasoning_budget(params, start_token, end_token);
 
     auto ctx = make_context(model);
     const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
@@ -314,7 +344,466 @@ static void test_reasoning_override_penalties(llama_model * model) {
     const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token }, target_token);
     const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token }, target_token);
 
-    require(think_obs.target_prob < base_obs.target_prob, "reasoning penalties did not reduce repeated-token probability");
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning repeat penalty did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_penalty_frequency(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_PENALTIES };
+    params.penalty_last_n = 64;
+    params.penalty_repeat = 1.0f;
+    params.penalty_freq = 0.0f;
+    params.penalty_present = 0.0f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ;
+    params.reasoning_penalty_freq = 0.50f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning frequency penalty did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_penalty_presence(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_PENALTIES };
+    params.penalty_last_n = 64;
+    params.penalty_repeat = 1.0f;
+    params.penalty_freq = 0.0f;
+    params.penalty_present = 0.0f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT;
+    params.reasoning_penalty_present = 0.50f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning presence penalty did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_penalty_last_n(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_PENALTIES };
+    params.penalty_last_n = 0;
+    params.penalty_repeat = 1.0f;
+    params.penalty_freq = 0.0f;
+    params.penalty_present = 0.0f;
+    params.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT;
+    params.reasoning_penalty_last_n = 64;
+    params.reasoning_penalty_repeat = 1.50f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning penalty_last_n did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_min_keep(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TOP_P };
+    params.top_p = 0.01f;
+    params.min_keep = 1;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_P | COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP;
+    params.reasoning_top_p = 0.01f;
+    params.reasoning_min_keep = 5;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const auto base_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, {});
+    const auto think_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, { start_token });
+
+    require(base_stats.candidate_count == 1, "base top_p did not keep the expected single candidate");
+    require(think_stats.candidate_count >= 5, "reasoning min_keep did not keep enough candidates");
+}
+
+static void test_reasoning_override_typical(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TYPICAL_P };
+    params.typ_p = 1.0f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P;
+    params.reasoning_typ_p = 0.10f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const auto base_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, {});
+    const auto think_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, { start_token });
+
+    require(think_stats.candidate_count < base_stats.candidate_count, "reasoning typical_p did not shrink the candidate set");
+}
+
+static void test_reasoning_override_top_n_sigma(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TOP_N_SIGMA };
+    params.top_n_sigma = -1.0f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA;
+    params.reasoning_top_n_sigma = 0.001f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, {}, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning top_n_sigma did not reduce tail-token probability");
+}
+
+static void test_reasoning_override_xtc_probability(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_XTC };
+    params.min_keep = 1;
+    params.xtc_probability = 0.0f;
+    params.xtc_threshold = 0.0f;
+    params.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY |
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD;
+    params.reasoning_xtc_probability = 1.0f;
+    params.reasoning_xtc_threshold = 0.0f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const auto base_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, {});
+    const auto think_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, { start_token });
+
+    require(think_stats.candidate_count < base_stats.candidate_count, "reasoning xtc_probability did not shrink the candidate set");
+}
+
+static void test_reasoning_override_xtc_threshold(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_XTC };
+    params.min_keep = 1;
+    params.xtc_probability = 1.0f;
+    params.xtc_threshold = 0.99f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD;
+    params.reasoning_xtc_threshold = 0.0f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const auto base_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, {});
+    const auto think_stats = sample_reasoning_stats(model, ctx.get(), params, prompt_tokens, { start_token });
+
+    require(think_stats.candidate_count < base_stats.candidate_count, "reasoning xtc_threshold did not shrink the candidate set");
+}
+
+static void test_reasoning_override_seed(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_a;
+    params_a.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params_a.top_k = 40;
+    params_a.temp = 0.80f;
+    params_a.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_SEED;
+    params_a.reasoning_seed = 123456u;
+    set_reasoning_budget(params_a, start_token, end_token);
+
+    auto params_b = params_a;
+    params_b.reasoning_seed = 654321u;
+
+    const auto seq_a_1 = generate_reasoning_sequence(model, "Hello", params_a, { start_token }, 8);
+    const auto seq_a_2 = generate_reasoning_sequence(model, "Hello", params_a, { start_token }, 8);
+    const auto seq_b = generate_reasoning_sequence(model, "Hello", params_b, { start_token }, 8);
+
+    require_sequence_equal(seq_a_1, seq_a_2, "same reasoning seed did not reproduce the same sequence");
+    require_sequence_different(seq_a_1, seq_b, "reasoning seed override did not change the sampled sequence");
+}
+
+static void test_reasoning_override_dynatemp_range(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_base;
+    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params_base.top_k = 40;
+    params_base.temp = 0.80f;
+    params_base.dynatemp_range = 0.0f;
+    params_base.dynatemp_exponent = 1.0f;
+    params_base.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE |
+        COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT;
+    params_base.reasoning_dynatemp_range = 0.0f;
+    params_base.reasoning_dynatemp_exponent = 1.0f;
+    params_base.reasoning_seed = 777u;
+    set_reasoning_budget(params_base, start_token, end_token);
+
+    auto params_think = params_base;
+    params_think.reasoning_dynatemp_range = 0.75f;
+
+    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
+    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
+
+    require_sequence_different(seq_base, seq_think, "reasoning dynatemp_range did not change the sampled sequence");
+}
+
+static void test_reasoning_override_dynatemp_exponent(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_base;
+    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params_base.top_k = 40;
+    params_base.temp = 0.80f;
+    params_base.dynatemp_range = 0.75f;
+    params_base.dynatemp_exponent = 1.0f;
+    params_base.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE |
+        COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT;
+    params_base.reasoning_dynatemp_range = 0.75f;
+    params_base.reasoning_dynatemp_exponent = 1.0f;
+    params_base.reasoning_seed = 888u;
+    set_reasoning_budget(params_base, start_token, end_token);
+
+    auto params_think = params_base;
+    params_think.reasoning_dynatemp_exponent = 2.5f;
+
+    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
+    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
+
+    require_sequence_different(seq_base, seq_think, "reasoning dynatemp_exponent did not change the sampled sequence");
+}
+
+static void test_reasoning_override_dry_multiplier(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_DRY };
+    params.dry_multiplier = 0.0f;
+    params.dry_base = 1.75f;
+    params.dry_allowed_length = 2;
+    params.dry_penalty_last_n = 64;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER;
+    params.reasoning_dry_multiplier = 0.8f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning dry_multiplier did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_dry_base(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_DRY };
+    params.dry_multiplier = 0.8f;
+    params.dry_base = 1.0f;
+    params.dry_allowed_length = 2;
+    params.dry_penalty_last_n = 64;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE;
+    params.reasoning_dry_base = 2.0f;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning dry_base did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_dry_allowed_length(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_DRY };
+    params.dry_multiplier = 0.8f;
+    params.dry_base = 1.75f;
+    params.dry_allowed_length = 5;
+    params.dry_penalty_last_n = 64;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN;
+    params.reasoning_dry_allowed_length = 1;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning dry_allowed_length did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_dry_penalty_last_n(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_DRY };
+    params.dry_multiplier = 0.8f;
+    params.dry_base = 1.75f;
+    params.dry_allowed_length = 2;
+    params.dry_penalty_last_n = 1;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N;
+    params.reasoning_dry_penalty_last_n = 64;
+    set_reasoning_budget(params, start_token, end_token);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto base_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { target_token, target_token, target_token, target_token }, target_token);
+    const auto think_obs = sample_candidate_observation(model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, target_token, target_token }, target_token);
+
+    require(think_obs.target_prob < base_obs.target_prob, "reasoning dry_penalty_last_n did not reduce repeated-token probability");
+}
+
+static void test_reasoning_override_adaptive_target(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_base;
+    params_base.samplers = { COMMON_SAMPLER_TYPE_ADAPTIVE_P };
+    params_base.adaptive_target = -1.0f;
+    params_base.adaptive_decay = 0.90f;
+    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET;
+    params_base.reasoning_adaptive_target = -1.0f;
+    params_base.reasoning_seed = 42u;
+    set_reasoning_budget(params_base, start_token, end_token);
+
+    auto params_think = params_base;
+    params_think.reasoning_adaptive_target = 0.30f;
+
+    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
+    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
+
+    require_sequence_different(seq_base, seq_think, "reasoning adaptive_target did not change the sampled sequence");
+}
+
+static void test_reasoning_override_adaptive_decay(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_base;
+    params_base.samplers = { COMMON_SAMPLER_TYPE_ADAPTIVE_P };
+    params_base.adaptive_target = 0.20f;
+    params_base.adaptive_decay = 0.20f;
+    params_base.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET |
+        COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY;
+    params_base.reasoning_adaptive_target = 0.20f;
+    params_base.reasoning_adaptive_decay = 0.20f;
+    params_base.reasoning_seed = 314u;
+    set_reasoning_budget(params_base, start_token, end_token);
+
+    auto params_think = params_base;
+    params_think.reasoning_adaptive_decay = 0.95f;
+
+    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
+    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
+
+    require_sequence_different(seq_base, seq_think, "reasoning adaptive_decay did not change the sampled sequence");
+}
+
+static void test_reasoning_override_mirostat(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_base;
+    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params_base.top_k = 40;
+    params_base.temp = 0.80f;
+    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT;
+    params_base.reasoning_mirostat = 0;
+    params_base.reasoning_mirostat_tau = 5.0f;
+    params_base.reasoning_mirostat_eta = 0.10f;
+    params_base.reasoning_seed = 11u;
+    set_reasoning_budget(params_base, start_token, end_token);
+
+    auto params_think = params_base;
+    params_think.reasoning_mirostat = 2;
+
+    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
+    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
+
+    require_sequence_different(seq_base, seq_think, "reasoning mirostat did not change the sampled sequence");
+}
+
+static void test_reasoning_override_mirostat_tau(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_base;
+    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params_base.top_k = 40;
+    params_base.temp = 0.80f;
+    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU;
+    params_base.reasoning_mirostat = 2;
+    params_base.reasoning_mirostat_tau = 3.0f;
+    params_base.reasoning_mirostat_eta = 0.10f;
+    params_base.reasoning_seed = 22u;
+    set_reasoning_budget(params_base, start_token, end_token);
+
+    auto params_think = params_base;
+    params_think.reasoning_mirostat_tau = 7.0f;
+
+    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
+    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
+
+    require_sequence_different(seq_base, seq_think, "reasoning mirostat_tau did not change the sampled sequence");
+}
+
+static void test_reasoning_override_mirostat_eta(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params_base;
+    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params_base.top_k = 40;
+    params_base.temp = 0.80f;
+    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA;
+    params_base.reasoning_mirostat = 2;
+    params_base.reasoning_mirostat_tau = 5.0f;
+    params_base.reasoning_mirostat_eta = 0.05f;
+    params_base.reasoning_seed = 33u;
+    set_reasoning_budget(params_base, start_token, end_token);
+
+    auto params_think = params_base;
+    params_think.reasoning_mirostat_eta = 0.30f;
+
+    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
+    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
+
+    require_sequence_different(seq_base, seq_think, "reasoning mirostat_eta did not change the sampled sequence");
 }
 
 int main(int argc, char ** argv) {
@@ -329,7 +818,27 @@ int main(int argc, char ** argv) {
     test_reasoning_override_top_p(model.get());
     test_reasoning_override_min_p(model.get());
     test_reasoning_override_temp(model.get());
-    test_reasoning_override_penalties(model.get());
+    test_reasoning_override_penalty_repeat(model.get());
+    test_reasoning_override_penalty_frequency(model.get());
+    test_reasoning_override_penalty_presence(model.get());
+    test_reasoning_override_penalty_last_n(model.get());
+    test_reasoning_override_min_keep(model.get());
+    test_reasoning_override_typical(model.get());
+    test_reasoning_override_top_n_sigma(model.get());
+    test_reasoning_override_xtc_probability(model.get());
+    test_reasoning_override_xtc_threshold(model.get());
+    test_reasoning_override_seed(model.get());
+    test_reasoning_override_dynatemp_range(model.get());
+    test_reasoning_override_dynatemp_exponent(model.get());
+    test_reasoning_override_dry_multiplier(model.get());
+    test_reasoning_override_dry_base(model.get());
+    test_reasoning_override_dry_allowed_length(model.get());
+    test_reasoning_override_dry_penalty_last_n(model.get());
+    test_reasoning_override_adaptive_target(model.get());
+    test_reasoning_override_adaptive_decay(model.get());
+    test_reasoning_override_mirostat(model.get());
+    test_reasoning_override_mirostat_tau(model.get());
+    test_reasoning_override_mirostat_eta(model.get());
 
     return 0;
 }

--- a/tests/test-reasoning-overrides.cpp
+++ b/tests/test-reasoning-overrides.cpp
@@ -1,0 +1,117 @@
+#include "ggml.h"
+#include "llama.h"
+
+#include "common.h"
+#include "get-model.h"
+#include "sampling.h"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+static void require(bool cond, const std::string & msg) {
+    if (!cond) {
+        throw std::runtime_error(msg);
+    }
+}
+
+static llama_context_ptr make_context(llama_model * model) {
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx = 256;
+    cparams.n_batch = 256;
+    cparams.n_seq_max = 1;
+
+    llama_context_ptr ctx { llama_init_from_model(model, cparams) };
+    require(static_cast<bool>(ctx), "failed to create llama context");
+
+    return ctx;
+}
+
+static std::vector<llama_token> decode_prompt(llama_context * ctx, const std::string & prompt) {
+    auto tokens = common_tokenize(ctx, prompt, true);
+    require(!tokens.empty(), "prompt tokenization produced no tokens");
+
+    auto batch = llama_batch_get_one(tokens.data(), tokens.size());
+    require(llama_decode(ctx, batch) == 0, "failed to decode prompt");
+
+    return tokens;
+}
+
+static size_t sample_candidate_count(
+        const llama_model * model,
+        llama_context * ctx,
+        common_params_sampling params,
+        const std::vector<llama_token> & prompt_tokens,
+        const std::vector<llama_token> & generated_tokens) {
+    common_sampler_ptr sampler { common_sampler_init(model, params) };
+    require(static_cast<bool>(sampler), "failed to initialize common sampler");
+
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+    }
+
+    for (const auto token : generated_tokens) {
+        common_sampler_accept(sampler.get(), token, true);
+    }
+
+    const int idx = static_cast<int>(prompt_tokens.size()) - 1;
+    require(idx >= 0, "prompt must contain at least one token");
+
+    (void) common_sampler_sample(sampler.get(), ctx, idx);
+
+    auto * candidates = common_sampler_get_candidates(sampler.get(), false);
+    require(candidates != nullptr, "sampler did not expose candidates");
+
+    return candidates->size;
+}
+
+static void test_reasoning_override_chain_switch(llama_model * model) {
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+    require(vocab != nullptr, "failed to read model vocab");
+
+    const int n_vocab = llama_vocab_n_tokens(vocab);
+    require(n_vocab > 2, "model vocab too small for reasoning sentinels");
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
+    params.top_k = 40;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
+    params.reasoning_top_k = 1;
+    params.reasoning_budget_tokens = 8;
+
+    const llama_token start_token = n_vocab - 2;
+    const llama_token end_token = n_vocab - 1;
+    params.reasoning_budget_start = { start_token };
+    params.reasoning_budget_end = { end_token };
+    params.reasoning_budget_forced = { end_token };
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const size_t base_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, {});
+    const size_t think_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, { start_token });
+    const size_t after_end_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, { start_token, end_token });
+
+    require(base_candidates == 40, "base chain did not keep the configured top_k candidate count");
+    require(think_candidates == 1, "reasoning chain did not switch to the override top_k");
+    require(after_end_candidates == 40, "sampler did not return to the base chain after the reasoning end tag");
+}
+
+int main(int argc, char ** argv) {
+    llama_backend_init();
+
+    const char * model_path = get_model_or_exit(argc, argv);
+
+    llama_model_ptr model { llama_model_load_from_file(model_path, llama_model_default_params()) };
+    require(static_cast<bool>(model), std::string("failed to load model: ") + model_path);
+
+    test_reasoning_override_chain_switch(model.get());
+
+    return 0;
+}

--- a/tests/test-reasoning-overrides.cpp
+++ b/tests/test-reasoning-overrides.cpp
@@ -243,6 +243,467 @@ static void require_sequence_different(
     require(a != b, msg);
 }
 
+static void accept_and_decode(
+        common_sampler * sampler,
+        llama_context * ctx,
+        llama_token token) {
+    common_sampler_accept(sampler, token, true);
+
+    auto batch = llama_batch_get_one(&token, 1);
+    require(llama_decode(ctx, batch) == 0, "failed to decode generated token");
+}
+
+static llama_token sample_accept_and_decode(
+        common_sampler * sampler,
+        llama_context * ctx,
+        int idx) {
+    const llama_token token = common_sampler_sample(sampler, ctx, idx);
+    accept_and_decode(sampler, ctx, token);
+    return token;
+}
+
+static std::vector<llama_token> generate_boundary_sequence(
+        llama_model * model,
+        common_params_sampling params,
+        llama_token start_token,
+        llama_token end_token) {
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    common_sampler_ptr sampler { common_sampler_init(model, params) };
+    require(static_cast<bool>(sampler), "failed to initialize common sampler");
+
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+    }
+
+    std::vector<llama_token> result;
+    auto sample_n = [&](size_t n, int & idx) {
+        for (size_t i = 0; i < n; ++i) {
+            result.push_back(sample_accept_and_decode(sampler.get(), ctx.get(), idx));
+            idx = 0;
+        }
+    };
+
+    int idx = static_cast<int>(prompt_tokens.size()) - 1;
+    sample_n(1, idx);
+
+    accept_and_decode(sampler.get(), ctx.get(), start_token);
+    idx = 0;
+    sample_n(3, idx);
+
+    accept_and_decode(sampler.get(), ctx.get(), end_token);
+    idx = 0;
+    sample_n(2, idx);
+
+    accept_and_decode(sampler.get(), ctx.get(), start_token);
+    idx = 0;
+    sample_n(2, idx);
+
+    accept_and_decode(sampler.get(), ctx.get(), end_token);
+    idx = 0;
+    sample_n(2, idx);
+
+    return result;
+}
+
+static void require_candidates_equal(
+        common_sampler * a,
+        common_sampler * b,
+        const std::string & msg) {
+    auto * candidates_a = common_sampler_get_candidates(a, true);
+    auto * candidates_b = common_sampler_get_candidates(b, true);
+
+    require(candidates_a != nullptr && candidates_b != nullptr, msg + ": missing candidates");
+    require(candidates_a->size == candidates_b->size, msg + ": candidate count differs");
+
+    for (size_t i = 0; i < candidates_a->size; ++i) {
+        const auto & lhs = candidates_a->data[i];
+        const auto & rhs = candidates_b->data[i];
+        require(lhs.id == rhs.id, msg + ": candidate token differs");
+        require(lhs.logit == rhs.logit || std::fabs(lhs.logit - rhs.logit) < 1e-6f,
+                msg + ": candidate logit differs");
+        require(std::fabs(lhs.p - rhs.p) < 1e-6f, msg + ": candidate probability differs");
+    }
+}
+
+static void test_reasoning_equal_value_rng_continuity(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = {
+        COMMON_SAMPLER_TYPE_TOP_K,
+        COMMON_SAMPLER_TYPE_TEMPERATURE,
+    };
+    params.seed = 12345;
+    params.top_k = 40;
+    params.temp = 0.80f;
+    params.logit_bias = {
+        { start_token, -INFINITY },
+        { end_token,   -INFINITY },
+    };
+    set_reasoning_budget(params, start_token, end_token, 64);
+
+    auto params_equal_temp = params;
+    params_equal_temp.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
+    params_equal_temp.reasoning_temp = params.temp;
+
+    const auto base_temp = generate_boundary_sequence(model, params, start_token, end_token);
+    const auto equal_temp = generate_boundary_sequence(model, params_equal_temp, start_token, end_token);
+    require_sequence_equal(base_temp, equal_temp, "equal temperature override changed the global dist sequence");
+
+    params.samplers = {
+        COMMON_SAMPLER_TYPE_TOP_K,
+        COMMON_SAMPLER_TYPE_XTC,
+        COMMON_SAMPLER_TYPE_TEMPERATURE,
+    };
+    params.seed = 54321;
+    params.min_keep = 1;
+    params.xtc_probability = 0.50f;
+    params.xtc_threshold = 0.05f;
+
+    auto params_equal_xtc = params;
+    params_equal_xtc.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY |
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD;
+    params_equal_xtc.reasoning_xtc_probability = params.xtc_probability;
+    params_equal_xtc.reasoning_xtc_threshold = params.xtc_threshold;
+
+    const auto base_xtc = generate_boundary_sequence(model, params, start_token, end_token);
+    const auto equal_xtc = generate_boundary_sequence(model, params_equal_xtc, start_token, end_token);
+    require_sequence_equal(base_xtc, equal_xtc, "equal XTC override changed the shared RNG sequence");
+
+    params.samplers = {
+        COMMON_SAMPLER_TYPE_TOP_K,
+        COMMON_SAMPLER_TYPE_TEMPERATURE,
+        COMMON_SAMPLER_TYPE_ADAPTIVE_P,
+    };
+    params.seed = 13579;
+    params.adaptive_target = 0.20f;
+    params.adaptive_decay = 0.80f;
+
+    auto params_equal_adaptive = params;
+    params_equal_adaptive.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
+    params_equal_adaptive.reasoning_temp = params.temp;
+
+    const auto base_adaptive = generate_boundary_sequence(model, params, start_token, end_token);
+    const auto equal_adaptive = generate_boundary_sequence(model, params_equal_adaptive, start_token, end_token);
+    require_sequence_equal(base_adaptive, equal_adaptive, "equal override changed the shared adaptive-p sequence");
+
+    params.samplers.clear();
+    params.seed = 97531;
+    params.mirostat = 2;
+    params.mirostat_tau = 5.0f;
+    params.mirostat_eta = 0.1f;
+
+    auto params_equal_mirostat = params;
+    params_equal_mirostat.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
+    params_equal_mirostat.reasoning_temp = params.temp;
+
+    const auto base_mirostat = generate_boundary_sequence(model, params, start_token, end_token);
+    const auto equal_mirostat = generate_boundary_sequence(model, params_equal_mirostat, start_token, end_token);
+    require_sequence_equal(base_mirostat, equal_mirostat, "equal override changed the shared Mirostat sequence");
+}
+
+static void test_reasoning_initial_state(llama_model * model) {
+    const llama_token end_token = reasoning_sentinels(model).second;
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
+    params.top_k = 40;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
+    params.reasoning_top_k = 1;
+    params.generation_prompt = " Hello";
+    params.reasoning_budget_start = common_tokenize(vocab, params.generation_prompt, false, true);
+    require(!params.reasoning_budget_start.empty(), "generation prompt tokenization produced no tokens");
+    params.reasoning_budget_end = { end_token };
+    params.reasoning_budget_forced = { end_token };
+    params.reasoning_budget_tokens = 64;
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    const size_t initial_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, {});
+    require(initial_candidates == 1, "generation prompt did not initialize the reasoning sampling state");
+
+    params.generation_prompt.clear();
+    const size_t idle_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, {});
+    require(idle_candidates == 40, "reasoning override activated without a generated or prefilled start marker");
+}
+
+static void test_reasoning_forced_ending(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TOP_K };
+    params.top_k = 40;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
+    params.reasoning_top_k = 1;
+    set_reasoning_budget(params, start_token, end_token, 1);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token forced_prefix = prompt_tokens.back();
+    params.reasoning_budget_forced = { forced_prefix, end_token };
+
+    common_sampler_ptr sampler { common_sampler_init(model, params) };
+    require(static_cast<bool>(sampler), "failed to initialize forced-ending sampler");
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+    }
+
+    common_sampler_accept(sampler.get(), start_token, true);
+    common_sampler_accept(sampler.get(), forced_prefix, true);
+
+    const int idx = static_cast<int>(prompt_tokens.size()) - 1;
+    const llama_token first_forced = common_sampler_sample(sampler.get(), ctx.get(), idx);
+    require(first_forced == forced_prefix, "reasoning budget did not force the budget message token");
+    common_sampler_accept(sampler.get(), first_forced, true);
+
+    const llama_token final_forced = common_sampler_sample(sampler.get(), ctx.get(), idx);
+    require(final_forced == end_token, "reasoning budget did not force the reasoning end token");
+    common_sampler_accept(sampler.get(), final_forced, true);
+
+    (void) common_sampler_sample(sampler.get(), ctx.get(), idx);
+    auto * candidates = common_sampler_get_candidates(sampler.get(), false);
+    require(candidates != nullptr && candidates->size == 40,
+            "base sampling parameters were not restored after the forced ending");
+}
+
+static void test_reasoning_inert_override(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_TEMPERATURE };
+    params.seed = 86420;
+    params.temp = 0.80f;
+    params.logit_bias = {
+        { start_token, -INFINITY },
+        { end_token,   -INFINITY },
+    };
+    set_reasoning_budget(params, start_token, end_token, 64);
+
+    auto inert = params;
+    inert.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
+    inert.reasoning_top_k = 1;
+
+    const auto base_sequence = generate_boundary_sequence(model, params, start_token, end_token);
+    const auto inert_sequence = generate_boundary_sequence(model, inert, start_token, end_token);
+    require_sequence_equal(base_sequence, inert_sequence, "absent top-k override changed the sampler topology");
+}
+
+static void test_reasoning_mirostat_validation(llama_model * model) {
+    common_params_sampling params;
+    params.mirostat = 2;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TOP_K;
+    params.reasoning_top_k = 1;
+
+    bool rejected = false;
+    try {
+        common_sampler_ptr sampler { common_sampler_init(model, params) };
+    } catch (const std::invalid_argument &) {
+        rejected = true;
+    }
+    require(rejected, "Mirostat accepted an override for a sampler outside its topology");
+
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_TEMP;
+    params.reasoning_temp = 1.0f;
+    common_sampler_ptr sampler { common_sampler_init(model, params) };
+    require(static_cast<bool>(sampler), "Mirostat rejected the supported reasoning temperature override");
+}
+
+static void test_reasoning_penalty_history_continuity(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_PENALTIES };
+    params.penalty_last_n = 64;
+    params.penalty_repeat = 1.0f;
+    params.penalty_freq = 0.50f;
+    params.penalty_present = 0.0f;
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ;
+    params.reasoning_penalty_freq = 0.75f;
+    set_reasoning_budget(params, start_token, end_token, 64);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto reasoning_without_pre = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens, { start_token }, target_token);
+    const auto reasoning_with_pre = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens, { target_token, target_token, start_token }, target_token);
+    require(reasoning_with_pre.target_prob < reasoning_without_pre.target_prob,
+            "reasoning penalties did not retain pre-reasoning history");
+
+    const auto base_without_reasoning = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens, { start_token, end_token }, target_token);
+    const auto base_with_reasoning = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens, { start_token, target_token, target_token, end_token }, target_token);
+    require(base_with_reasoning.target_prob < base_without_reasoning.target_prob,
+            "base penalties did not retain reasoning history");
+
+    const auto second_without_history = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens, { start_token, end_token, start_token }, target_token);
+    const auto second_with_history = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens,
+            { start_token, target_token, end_token, target_token, start_token }, target_token);
+    require(second_with_history.target_prob < second_without_history.target_prob,
+            "second reasoning block did not retain the complete token history");
+}
+
+static void test_reasoning_dry_history_continuity(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = { COMMON_SAMPLER_TYPE_DRY };
+    params.dry_multiplier = 0.80f;
+    params.dry_base = 1.75f;
+    params.dry_allowed_length = 2;
+    params.dry_penalty_last_n = 64;
+    params.dry_sequence_breakers.clear();
+    params.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER;
+    params.reasoning_dry_multiplier = params.dry_multiplier;
+    set_reasoning_budget(params, start_token, end_token, 64);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+    const llama_token target_token = prompt_tokens.back();
+
+    const auto reasoning_without_pre = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens,
+            { start_token, target_token, target_token }, target_token);
+    const auto reasoning_with_pre = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens,
+            { target_token, target_token, target_token, start_token, target_token, target_token }, target_token);
+    require(reasoning_with_pre.target_prob < reasoning_without_pre.target_prob,
+            "reasoning DRY sampler did not retain pre-reasoning history");
+
+    const auto base_without_reasoning = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens,
+            { start_token, end_token, target_token, target_token }, target_token);
+    const auto base_with_reasoning = sample_candidate_observation(
+            model, ctx.get(), params, prompt_tokens,
+            { start_token, target_token, target_token, target_token, end_token, target_token, target_token }, target_token);
+    require(base_with_reasoning.target_prob < base_without_reasoning.target_prob,
+            "base DRY sampler did not retain reasoning history");
+}
+
+static void test_reasoning_clone_and_reset(llama_model * model) {
+    const auto [start_token, end_token] = reasoning_sentinels(model);
+
+    common_params_sampling params;
+    params.samplers = {
+        COMMON_SAMPLER_TYPE_PENALTIES,
+        COMMON_SAMPLER_TYPE_DRY,
+        COMMON_SAMPLER_TYPE_TOP_K,
+        COMMON_SAMPLER_TYPE_XTC,
+        COMMON_SAMPLER_TYPE_TEMPERATURE,
+    };
+    params.seed = 24680;
+    params.top_k = 40;
+    params.min_keep = 1;
+    params.xtc_probability = 0.65f;
+    params.xtc_threshold = 0.05f;
+    params.temp = 0.80f;
+    params.penalty_last_n = 64;
+    params.penalty_repeat = 1.10f;
+    params.dry_multiplier = 0.50f;
+    params.dry_base = 1.75f;
+    params.dry_allowed_length = 2;
+    params.dry_penalty_last_n = 64;
+    params.dry_sequence_breakers.clear();
+    params.reasoning_sampling =
+        COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY |
+        COMMON_PARAMS_SAMPLING_CONFIG_TEMP |
+        COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT |
+        COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER;
+    params.reasoning_xtc_probability = 0.35f;
+    params.reasoning_temp = 1.10f;
+    params.reasoning_penalty_repeat = 1.30f;
+    params.reasoning_dry_multiplier = 0.80f;
+    params.logit_bias = {
+        { start_token, -INFINITY },
+        { end_token,   -INFINITY },
+    };
+    set_reasoning_budget(params, start_token, end_token, 64);
+
+    auto ctx = make_context(model);
+    const auto prompt_tokens = decode_prompt(ctx.get(), "Hello");
+
+    auto init_params = params;
+    common_sampler_ptr sampler { common_sampler_init(model, init_params) };
+    require(static_cast<bool>(sampler), "failed to initialize common sampler");
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+    }
+
+    (void) sample_accept_and_decode(
+            sampler.get(), ctx.get(), static_cast<int>(prompt_tokens.size()) - 1);
+    accept_and_decode(sampler.get(), ctx.get(), start_token);
+    (void) sample_accept_and_decode(sampler.get(), ctx.get(), 0);
+
+    common_sampler_ptr clone { common_sampler_clone(sampler.get()) };
+    require(static_cast<bool>(clone), "failed to clone common sampler");
+
+    for (int i = 0; i < 4; ++i) {
+        const llama_token source_token = common_sampler_sample(sampler.get(), ctx.get(), 0);
+        const llama_token clone_token = common_sampler_sample(clone.get(), ctx.get(), 0);
+        require(source_token == clone_token, "reasoning clone changed the sampled token");
+        require_candidates_equal(sampler.get(), clone.get(), "reasoning clone");
+
+        common_sampler_accept(sampler.get(), source_token, true);
+        common_sampler_accept(clone.get(), clone_token, true);
+        llama_token decoded = source_token;
+        auto batch = llama_batch_get_one(&decoded, 1);
+        require(llama_decode(ctx.get(), batch) == 0, "failed to decode cloned sample");
+    }
+
+    clone.reset();
+    common_sampler_reset(sampler.get());
+
+    auto fresh_params = params;
+    common_sampler_ptr fresh { common_sampler_init(model, fresh_params) };
+    require(static_cast<bool>(fresh), "failed to initialize reset reference sampler");
+    for (const auto token : prompt_tokens) {
+        common_sampler_accept(sampler.get(), token, false);
+        common_sampler_accept(fresh.get(), token, false);
+    }
+
+    const llama_token reset_base = common_sampler_sample(sampler.get(), ctx.get(), 0);
+    const llama_token fresh_base = common_sampler_sample(fresh.get(), ctx.get(), 0);
+    require(reset_base == fresh_base, "reset did not restore the base sampling state");
+    require_candidates_equal(sampler.get(), fresh.get(), "base state after reset");
+
+    common_sampler_accept(sampler.get(), start_token, true);
+    common_sampler_accept(fresh.get(), start_token, true);
+    const llama_token reset_reasoning = common_sampler_sample(sampler.get(), ctx.get(), 0);
+    const llama_token fresh_reasoning = common_sampler_sample(fresh.get(), ctx.get(), 0);
+    require(reset_reasoning == fresh_reasoning, "reset did not restore the reasoning sampling state");
+    require_candidates_equal(sampler.get(), fresh.get(), "reasoning state after reset");
+
+    common_sampler_ptr checkpoint { common_sampler_clone(sampler.get()) };
+    common_sampler_ptr rollback_reference { common_sampler_clone(sampler.get()) };
+    require(static_cast<bool>(checkpoint) && static_cast<bool>(rollback_reference),
+            "failed to clone reasoning sampler for rollback");
+
+    for (int i = 0; i < 3; ++i) {
+        const llama_token token = common_sampler_sample(sampler.get(), ctx.get(), 0);
+        common_sampler_accept(sampler.get(), token, true);
+    }
+    sampler = std::move(checkpoint);
+
+    for (int i = 0; i < 4; ++i) {
+        const llama_token restored_token = common_sampler_sample(sampler.get(), ctx.get(), 0);
+        const llama_token reference_token = common_sampler_sample(rollback_reference.get(), ctx.get(), 0);
+        require(restored_token == reference_token, "reasoning sampler rollback changed the sampled token");
+        require_candidates_equal(sampler.get(), rollback_reference.get(), "reasoning sampler rollback");
+        common_sampler_accept(sampler.get(), restored_token, true);
+        common_sampler_accept(rollback_reference.get(), reference_token, true);
+    }
+}
+
 static void test_reasoning_override_chain_switch(llama_model * model) {
     const auto [start_token, end_token] = reasoning_sentinels(model);
 
@@ -259,10 +720,12 @@ static void test_reasoning_override_chain_switch(llama_model * model) {
     const size_t base_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, {});
     const size_t think_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, { start_token });
     const size_t after_end_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, { start_token, end_token });
+    const size_t second_think_candidates = sample_candidate_count(model, ctx.get(), params, prompt_tokens, { start_token, end_token, start_token });
 
     require(base_candidates == 40, "base chain did not keep the configured top_k candidate count");
     require(think_candidates == 1, "reasoning chain did not switch to the override top_k");
     require(after_end_candidates == 40, "sampler did not return to the base chain after the reasoning end tag");
+    require(second_think_candidates == 1, "sampler did not reactivate the override for a second reasoning block");
 }
 
 static void test_reasoning_override_top_p(llama_model * model) {
@@ -526,28 +989,6 @@ static void test_reasoning_override_xtc_threshold(llama_model * model) {
     require(think_stats.candidate_count < base_stats.candidate_count, "reasoning xtc_threshold did not shrink the candidate set");
 }
 
-static void test_reasoning_override_seed(llama_model * model) {
-    const auto [start_token, end_token] = reasoning_sentinels(model);
-
-    common_params_sampling params_a;
-    params_a.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
-    params_a.top_k = 40;
-    params_a.temp = 0.80f;
-    params_a.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_SEED;
-    params_a.reasoning_seed = 123456u;
-    set_reasoning_budget(params_a, start_token, end_token);
-
-    auto params_b = params_a;
-    params_b.reasoning_seed = 654321u;
-
-    const auto seq_a_1 = generate_reasoning_sequence(model, "Hello", params_a, { start_token }, 8);
-    const auto seq_a_2 = generate_reasoning_sequence(model, "Hello", params_a, { start_token }, 8);
-    const auto seq_b = generate_reasoning_sequence(model, "Hello", params_b, { start_token }, 8);
-
-    require_sequence_equal(seq_a_1, seq_a_2, "same reasoning seed did not reproduce the same sequence");
-    require_sequence_different(seq_a_1, seq_b, "reasoning seed override did not change the sampled sequence");
-}
-
 static void test_reasoning_override_dynatemp_range(llama_model * model) {
     const auto [start_token, end_token] = reasoning_sentinels(model);
 
@@ -562,7 +1003,7 @@ static void test_reasoning_override_dynatemp_range(llama_model * model) {
         COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT;
     params_base.reasoning_dynatemp_range = 0.0f;
     params_base.reasoning_dynatemp_exponent = 1.0f;
-    params_base.reasoning_seed = 777u;
+    params_base.seed = 777u;
     set_reasoning_budget(params_base, start_token, end_token);
 
     auto params_think = params_base;
@@ -588,7 +1029,7 @@ static void test_reasoning_override_dynatemp_exponent(llama_model * model) {
         COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT;
     params_base.reasoning_dynatemp_range = 0.75f;
     params_base.reasoning_dynatemp_exponent = 1.0f;
-    params_base.reasoning_seed = 888u;
+    params_base.seed = 888u;
     set_reasoning_budget(params_base, start_token, end_token);
 
     auto params_think = params_base;
@@ -692,120 +1133,6 @@ static void test_reasoning_override_dry_penalty_last_n(llama_model * model) {
     require(think_obs.target_prob < base_obs.target_prob, "reasoning dry_penalty_last_n did not reduce repeated-token probability");
 }
 
-static void test_reasoning_override_adaptive_target(llama_model * model) {
-    const auto [start_token, end_token] = reasoning_sentinels(model);
-
-    common_params_sampling params_base;
-    params_base.samplers = { COMMON_SAMPLER_TYPE_ADAPTIVE_P };
-    params_base.adaptive_target = -1.0f;
-    params_base.adaptive_decay = 0.90f;
-    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET;
-    params_base.reasoning_adaptive_target = -1.0f;
-    params_base.reasoning_seed = 42u;
-    set_reasoning_budget(params_base, start_token, end_token);
-
-    auto params_think = params_base;
-    params_think.reasoning_adaptive_target = 0.30f;
-
-    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
-    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
-
-    require_sequence_different(seq_base, seq_think, "reasoning adaptive_target did not change the sampled sequence");
-}
-
-static void test_reasoning_override_adaptive_decay(llama_model * model) {
-    const auto [start_token, end_token] = reasoning_sentinels(model);
-
-    common_params_sampling params_base;
-    params_base.samplers = { COMMON_SAMPLER_TYPE_ADAPTIVE_P };
-    params_base.adaptive_target = 0.20f;
-    params_base.adaptive_decay = 0.20f;
-    params_base.reasoning_sampling =
-        COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET |
-        COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY;
-    params_base.reasoning_adaptive_target = 0.20f;
-    params_base.reasoning_adaptive_decay = 0.20f;
-    params_base.reasoning_seed = 314u;
-    set_reasoning_budget(params_base, start_token, end_token);
-
-    auto params_think = params_base;
-    params_think.reasoning_adaptive_decay = 0.95f;
-
-    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
-    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
-
-    require_sequence_different(seq_base, seq_think, "reasoning adaptive_decay did not change the sampled sequence");
-}
-
-static void test_reasoning_override_mirostat(llama_model * model) {
-    const auto [start_token, end_token] = reasoning_sentinels(model);
-
-    common_params_sampling params_base;
-    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
-    params_base.top_k = 40;
-    params_base.temp = 0.80f;
-    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT;
-    params_base.reasoning_mirostat = 0;
-    params_base.reasoning_mirostat_tau = 5.0f;
-    params_base.reasoning_mirostat_eta = 0.10f;
-    params_base.reasoning_seed = 11u;
-    set_reasoning_budget(params_base, start_token, end_token);
-
-    auto params_think = params_base;
-    params_think.reasoning_mirostat = 2;
-
-    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
-    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
-
-    require_sequence_different(seq_base, seq_think, "reasoning mirostat did not change the sampled sequence");
-}
-
-static void test_reasoning_override_mirostat_tau(llama_model * model) {
-    const auto [start_token, end_token] = reasoning_sentinels(model);
-
-    common_params_sampling params_base;
-    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
-    params_base.top_k = 40;
-    params_base.temp = 0.80f;
-    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU;
-    params_base.reasoning_mirostat = 2;
-    params_base.reasoning_mirostat_tau = 3.0f;
-    params_base.reasoning_mirostat_eta = 0.10f;
-    params_base.reasoning_seed = 22u;
-    set_reasoning_budget(params_base, start_token, end_token);
-
-    auto params_think = params_base;
-    params_think.reasoning_mirostat_tau = 7.0f;
-
-    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
-    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
-
-    require_sequence_different(seq_base, seq_think, "reasoning mirostat_tau did not change the sampled sequence");
-}
-
-static void test_reasoning_override_mirostat_eta(llama_model * model) {
-    const auto [start_token, end_token] = reasoning_sentinels(model);
-
-    common_params_sampling params_base;
-    params_base.samplers = { COMMON_SAMPLER_TYPE_TOP_K, COMMON_SAMPLER_TYPE_TEMPERATURE };
-    params_base.top_k = 40;
-    params_base.temp = 0.80f;
-    params_base.reasoning_sampling = COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA;
-    params_base.reasoning_mirostat = 2;
-    params_base.reasoning_mirostat_tau = 5.0f;
-    params_base.reasoning_mirostat_eta = 0.05f;
-    params_base.reasoning_seed = 33u;
-    set_reasoning_budget(params_base, start_token, end_token);
-
-    auto params_think = params_base;
-    params_think.reasoning_mirostat_eta = 0.30f;
-
-    const auto seq_base = generate_reasoning_sequence(model, "Hello", params_base, { start_token }, 8);
-    const auto seq_think = generate_reasoning_sequence(model, "Hello", params_think, { start_token }, 8);
-
-    require_sequence_different(seq_base, seq_think, "reasoning mirostat_eta did not change the sampled sequence");
-}
-
 int main(int argc, char ** argv) {
     llama_backend_init();
 
@@ -813,6 +1140,15 @@ int main(int argc, char ** argv) {
 
     llama_model_ptr model { llama_model_load_from_file(model_path, llama_model_default_params()) };
     require(static_cast<bool>(model), std::string("failed to load model: ") + model_path);
+
+    test_reasoning_equal_value_rng_continuity(model.get());
+    test_reasoning_initial_state(model.get());
+    test_reasoning_forced_ending(model.get());
+    test_reasoning_inert_override(model.get());
+    test_reasoning_mirostat_validation(model.get());
+    test_reasoning_penalty_history_continuity(model.get());
+    test_reasoning_dry_history_continuity(model.get());
+    test_reasoning_clone_and_reset(model.get());
 
     test_reasoning_override_chain_switch(model.get());
     test_reasoning_override_top_p(model.get());
@@ -827,18 +1163,12 @@ int main(int argc, char ** argv) {
     test_reasoning_override_top_n_sigma(model.get());
     test_reasoning_override_xtc_probability(model.get());
     test_reasoning_override_xtc_threshold(model.get());
-    test_reasoning_override_seed(model.get());
     test_reasoning_override_dynatemp_range(model.get());
     test_reasoning_override_dynatemp_exponent(model.get());
     test_reasoning_override_dry_multiplier(model.get());
     test_reasoning_override_dry_base(model.get());
     test_reasoning_override_dry_allowed_length(model.get());
     test_reasoning_override_dry_penalty_last_n(model.get());
-    test_reasoning_override_adaptive_target(model.get());
-    test_reasoning_override_adaptive_decay(model.get());
-    test_reasoning_override_mirostat(model.get());
-    test_reasoning_override_mirostat_tau(model.get());
-    test_reasoning_override_mirostat_eta(model.get());
 
     return 0;
 }

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -126,6 +126,60 @@ static void test_xtc(const std::vector<float> & probs, const std::vector<float> 
     tester.check();
 }
 
+static size_t apply_xtc_count(llama_sampler * sampler) {
+    std::vector<llama_token_data> candidates = {
+        { 0, logf(0.4f), 0.0f },
+        { 1, logf(0.3f), 0.0f },
+        { 2, logf(0.2f), 0.0f },
+        { 3, logf(0.1f), 0.0f },
+    };
+    llama_token_data_array cur_p = { candidates.data(), candidates.size(), -1, false };
+
+    llama_sampler_apply(sampler, &cur_p);
+    return cur_p.size;
+}
+
+static void test_xtc_set() {
+    constexpr uint32_t seed = 12345;
+
+    auto * sampler = llama_sampler_init_xtc(1.0f, 0.0f, 2, seed);
+    auto * control = llama_sampler_init_xtc(0.5f, 0.0f, 1, seed);
+
+    GGML_ASSERT(apply_xtc_count(sampler) == 4);
+    (void) apply_xtc_count(control);
+
+    llama_sampler_xtc_set(sampler, 1.0f, 0.0f, 1);
+    GGML_ASSERT(apply_xtc_count(sampler) == 1);
+    (void) apply_xtc_count(control);
+
+    llama_sampler_xtc_set(sampler, 0.5f, 0.0f, 1);
+    auto * clone = llama_sampler_clone(sampler);
+
+    for (int i = 0; i < 64; ++i) {
+        const size_t count = apply_xtc_count(sampler);
+        GGML_ASSERT(count == apply_xtc_count(control));
+        GGML_ASSERT(count == apply_xtc_count(clone));
+    }
+
+    llama_sampler_xtc_set(sampler, 0.0f, 0.0f, 1);
+    auto * disabled_clone = llama_sampler_clone(sampler);
+    for (int i = 0; i < 4; ++i) {
+        GGML_ASSERT(apply_xtc_count(sampler) == 4);
+        GGML_ASSERT(apply_xtc_count(disabled_clone) == 4);
+    }
+
+    llama_sampler_xtc_set(sampler,        0.5f, 0.0f, 1);
+    llama_sampler_xtc_set(disabled_clone, 0.5f, 0.0f, 1);
+    for (int i = 0; i < 16; ++i) {
+        GGML_ASSERT(apply_xtc_count(sampler) == apply_xtc_count(disabled_clone));
+    }
+
+    llama_sampler_free(disabled_clone);
+    llama_sampler_free(clone);
+    llama_sampler_free(control);
+    llama_sampler_free(sampler);
+}
+
 static void test_typical(const std::vector<float> & probs, const std::vector<float> & probs_expected, float p) {
     sampler_tester tester(probs, probs_expected);
 
@@ -156,6 +210,39 @@ static void test_penalties(
     DUMP(&tester.cur_p);
 
     tester.check();
+}
+
+static void test_penalties_clone() {
+    auto * sampler = llama_sampler_init_penalties(64, 1.0f, 0.5f, 0.5f);
+
+    llama_sampler_accept(sampler, 0);
+    llama_sampler_accept(sampler, 1);
+    llama_sampler_accept(sampler, 0);
+
+    auto * clone = llama_sampler_clone(sampler);
+
+    std::vector<llama_token_data> source_data = {
+        { 0, 1.0f, 0.0f },
+        { 1, 1.0f, 0.0f },
+        { 2, 1.0f, 0.0f },
+    };
+    auto clone_data = source_data;
+
+    llama_token_data_array source_p = { source_data.data(), source_data.size(), -1, false };
+    llama_token_data_array clone_p  = { clone_data.data(),  clone_data.size(),  -1, false };
+
+    llama_sampler_apply(sampler, &source_p);
+    llama_sampler_apply(clone, &clone_p);
+
+    GGML_ASSERT(source_data[0].logit < source_data[1].logit);
+    GGML_ASSERT(source_data[1].logit < source_data[2].logit);
+    for (size_t i = 0; i < source_data.size(); ++i) {
+        GGML_ASSERT(source_data[i].id == clone_data[i].id);
+        GGML_ASSERT(source_data[i].logit == clone_data[i].logit);
+    }
+
+    llama_sampler_free(clone);
+    llama_sampler_free(sampler);
 }
 
 static void test_dry(
@@ -341,6 +428,7 @@ int main(void) {
 
     printf("XTC should not:\n");
     test_xtc({0.4f, 0.3f, 0.2f, 0.1f},   {0.4f, 0.3f, 0.2f, 0.1f},              0.99f, 0.39f);
+    test_xtc_set();
 
     test_typical({0.97f, 0.01f, 0.01f, 0.01f}, {0.97f},            0.5f);
     test_typical({0.4f, 0.2f, 0.2f, 0.2f},     {0.2f, 0.2f, 0.2f}, 0.5f);
@@ -352,6 +440,7 @@ int main(void) {
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0},             {0.000011f, 0.249997f, 0.249997f, 0.249997f, 0.249997f}, 1.0f, 5.0f, 5.0f);
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2},       {0.000023f, 0.000023f, 0.000023f, 0.499966f, 0.499966f}, 1.0f, 5.0f, 5.0f);
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 0}, {0.000000f, 0.000023f, 0.000023f, 0.499977f, 0.499977f}, 1.0f, 5.0f, 5.0f);
+    test_penalties_clone();
 
 
     test_dry({0.25f, 0.25f, 0.25f, 0.25f}, {0, 1}, {0.25f, 0.25f, 0.25f, 0.25f}, 1.0f, 1.1f, 2, 4, {});

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -110,6 +110,32 @@
 | `--top-k N` | top-k sampling (default: 40, 0 = disabled)<br/>(env: LLAMA_ARG_TOP_K) |
 | `--top-p N` | top-p sampling (default: 0.95, 1.0 = disabled) |
 | `--min-p N` | min-p sampling (default: 0.05, 0.0 = disabled) |
+| `--reasoning-temp N` | temperature override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-k N` | top-k override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-p N` | top-p override while inside the reasoning block (default: inherit) |
+| `--reasoning-min-p N` | min-p override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-n-sigma N` | top-n-sigma override while inside the reasoning block (default: inherit) |
+| `--reasoning-xtc-probability N` | XTC probability override while inside the reasoning block (default: inherit) |
+| `--reasoning-xtc-threshold N` | XTC threshold override while inside the reasoning block (default: inherit) |
+| `--reasoning-typical-p N` | locally typical sampling override while inside the reasoning block (default: inherit) |
+| `--reasoning-dynatemp-range N` | dynamic temperature range override while inside the reasoning block (default: inherit) |
+| `--reasoning-dynatemp-exp, --reasoning-dynatemp-exponent N` | dynamic temperature exponent override while inside the reasoning block (default: inherit) |
+| `--reasoning-repeat-last-n N` | repeat history override while inside the reasoning block (default: inherit) |
+| `--reasoning-repeat-penalty N` | repeat-penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-presence-penalty N` | presence penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-frequency-penalty N` | frequency penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-multiplier N` | DRY multiplier override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-base N` | DRY base override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-allowed-length N` | DRY allowed length override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-penalty-last-n N` | DRY history override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat N` | Mirostat mode override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat-ent, --reasoning-mirostat-tau N` | Mirostat target entropy override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat-lr, --reasoning-mirostat-eta N` | Mirostat learning rate override while inside the reasoning block (default: inherit) |
+| `--reasoning-adaptive-target N` | adaptive sampling target override while inside the reasoning block (default: inherit) |
+| `--reasoning-adaptive-decay N` | adaptive sampling decay override while inside the reasoning block (default: inherit) |
+| `--reasoning-min-keep N` | minimum candidate count override while inside the reasoning block (default: inherit) |
+| `--reasoning-seed SEED` | RNG seed override while inside the reasoning block (default: inherit) |
+| `--reasoning-preserve, --no-reasoning-preserve` | preserve reasoning trace in the full history, not just the last assistant message (default: template default)<br/>compatible with certain templates having 'supports_preserve_reasoning' capability<br/>example: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking<br/>(env: LLAMA_ARG_REASONING_PRESERVE) |
 | `--top-nsigma, --top-n-sigma N` | top-n-sigma sampling (default: -1.00, -1.0 = disabled) |
 | `--xtc-probability N` | xtc probability (default: 0.00, 0.0 = disabled) |
 | `--xtc-threshold N` | xtc threshold (default: 0.10, 1.0 = disabled) |

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -110,7 +110,7 @@
 | `--top-k N` | top-k sampling (default: 40, 0 = disabled)<br/>(env: LLAMA_ARG_TOP_K) |
 | `--top-p N` | top-p sampling (default: 0.95, 1.0 = disabled) |
 | `--min-p N` | min-p sampling (default: 0.05, 0.0 = disabled) |
-| `--reasoning-temp N` | temperature override while inside the reasoning block (default: inherit) |
+| `--reasoning-temp N` | temperature override while inside the reasoning block; uses the existing sampling chain with continuous RNG and history state (default: inherit) |
 | `--reasoning-top-k N` | top-k override while inside the reasoning block (default: inherit) |
 | `--reasoning-top-p N` | top-p override while inside the reasoning block (default: inherit) |
 | `--reasoning-min-p N` | min-p override while inside the reasoning block (default: inherit) |
@@ -128,13 +128,7 @@
 | `--reasoning-dry-base N` | DRY base override while inside the reasoning block (default: inherit) |
 | `--reasoning-dry-allowed-length N` | DRY allowed length override while inside the reasoning block (default: inherit) |
 | `--reasoning-dry-penalty-last-n N` | DRY history override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat N` | Mirostat mode override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat-ent, --reasoning-mirostat-tau N` | Mirostat target entropy override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat-lr, --reasoning-mirostat-eta N` | Mirostat learning rate override while inside the reasoning block (default: inherit) |
-| `--reasoning-adaptive-target N` | adaptive sampling target override while inside the reasoning block (default: inherit) |
-| `--reasoning-adaptive-decay N` | adaptive sampling decay override while inside the reasoning block (default: inherit) |
 | `--reasoning-min-keep N` | minimum candidate count override while inside the reasoning block (default: inherit) |
-| `--reasoning-seed SEED` | RNG seed override while inside the reasoning block (default: inherit) |
 | `--reasoning-preserve, --no-reasoning-preserve` | preserve reasoning trace in the full history, not just the last assistant message (default: template default)<br/>compatible with certain templates having 'supports_preserve_reasoning' capability<br/>example: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking<br/>(env: LLAMA_ARG_REASONING_PRESERVE) |
 | `--top-nsigma, --top-n-sigma N` | top-n-sigma sampling (default: -1.00, -1.0 = disabled) |
 | `--xtc-probability N` | xtc probability (default: 0.00, 0.0 = disabled) |
@@ -246,3 +240,7 @@
 | `--spec-default` | enable default speculative decoding config |
 
 <!-- HELP_END -->
+
+## Reasoning sampling overrides
+
+Supported `--reasoning-*` options switch parameter values in the existing sampler chain while generation is inside a reasoning block. Unset options inherit their base values. RNG, token histories, Mirostat state and adaptive-p state remain continuous. Seed, sampler ordering, Mirostat configuration and adaptive-p configuration cannot vary by reasoning section.

--- a/tools/completion/README.md
+++ b/tools/completion/README.md
@@ -193,6 +193,32 @@ llama-completion.exe -m models\gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
 | `--top-k N` | top-k sampling (default: 40, 0 = disabled)<br/>(env: LLAMA_ARG_TOP_K) |
 | `--top-p N` | top-p sampling (default: 0.95, 1.0 = disabled) |
 | `--min-p N` | min-p sampling (default: 0.05, 0.0 = disabled) |
+| `--reasoning-temp N` | temperature override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-k N` | top-k override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-p N` | top-p override while inside the reasoning block (default: inherit) |
+| `--reasoning-min-p N` | min-p override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-n-sigma N` | top-n-sigma override while inside the reasoning block (default: inherit) |
+| `--reasoning-xtc-probability N` | XTC probability override while inside the reasoning block (default: inherit) |
+| `--reasoning-xtc-threshold N` | XTC threshold override while inside the reasoning block (default: inherit) |
+| `--reasoning-typical-p N` | locally typical sampling override while inside the reasoning block (default: inherit) |
+| `--reasoning-dynatemp-range N` | dynamic temperature range override while inside the reasoning block (default: inherit) |
+| `--reasoning-dynatemp-exp, --reasoning-dynatemp-exponent N` | dynamic temperature exponent override while inside the reasoning block (default: inherit) |
+| `--reasoning-repeat-last-n N` | repeat history override while inside the reasoning block (default: inherit) |
+| `--reasoning-repeat-penalty N` | repeat-penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-presence-penalty N` | presence penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-frequency-penalty N` | frequency penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-multiplier N` | DRY multiplier override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-base N` | DRY base override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-allowed-length N` | DRY allowed length override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-penalty-last-n N` | DRY history override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat N` | Mirostat mode override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat-ent, --reasoning-mirostat-tau N` | Mirostat target entropy override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat-lr, --reasoning-mirostat-eta N` | Mirostat learning rate override while inside the reasoning block (default: inherit) |
+| `--reasoning-adaptive-target N` | adaptive sampling target override while inside the reasoning block (default: inherit) |
+| `--reasoning-adaptive-decay N` | adaptive sampling decay override while inside the reasoning block (default: inherit) |
+| `--reasoning-min-keep N` | minimum candidate count override while inside the reasoning block (default: inherit) |
+| `--reasoning-seed SEED` | RNG seed override while inside the reasoning block (default: inherit) |
+| `--reasoning-preserve, --no-reasoning-preserve` | preserve reasoning trace in the full history, not just the last assistant message (default: template default)<br/>compatible with certain templates having 'supports_preserve_reasoning' capability<br/>example: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking<br/>(env: LLAMA_ARG_REASONING_PRESERVE) |
 | `--top-nsigma, --top-n-sigma N` | top-n-sigma sampling (default: -1.00, -1.0 = disabled) |
 | `--xtc-probability N` | xtc probability (default: 0.00, 0.0 = disabled) |
 | `--xtc-threshold N` | xtc threshold (default: 0.10, 1.0 = disabled) |

--- a/tools/completion/README.md
+++ b/tools/completion/README.md
@@ -193,7 +193,7 @@ llama-completion.exe -m models\gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
 | `--top-k N` | top-k sampling (default: 40, 0 = disabled)<br/>(env: LLAMA_ARG_TOP_K) |
 | `--top-p N` | top-p sampling (default: 0.95, 1.0 = disabled) |
 | `--min-p N` | min-p sampling (default: 0.05, 0.0 = disabled) |
-| `--reasoning-temp N` | temperature override while inside the reasoning block (default: inherit) |
+| `--reasoning-temp N` | temperature override while inside the reasoning block; uses the existing sampling chain with continuous RNG and history state (default: inherit) |
 | `--reasoning-top-k N` | top-k override while inside the reasoning block (default: inherit) |
 | `--reasoning-top-p N` | top-p override while inside the reasoning block (default: inherit) |
 | `--reasoning-min-p N` | min-p override while inside the reasoning block (default: inherit) |
@@ -211,13 +211,7 @@ llama-completion.exe -m models\gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
 | `--reasoning-dry-base N` | DRY base override while inside the reasoning block (default: inherit) |
 | `--reasoning-dry-allowed-length N` | DRY allowed length override while inside the reasoning block (default: inherit) |
 | `--reasoning-dry-penalty-last-n N` | DRY history override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat N` | Mirostat mode override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat-ent, --reasoning-mirostat-tau N` | Mirostat target entropy override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat-lr, --reasoning-mirostat-eta N` | Mirostat learning rate override while inside the reasoning block (default: inherit) |
-| `--reasoning-adaptive-target N` | adaptive sampling target override while inside the reasoning block (default: inherit) |
-| `--reasoning-adaptive-decay N` | adaptive sampling decay override while inside the reasoning block (default: inherit) |
 | `--reasoning-min-keep N` | minimum candidate count override while inside the reasoning block (default: inherit) |
-| `--reasoning-seed SEED` | RNG seed override while inside the reasoning block (default: inherit) |
 | `--reasoning-preserve, --no-reasoning-preserve` | preserve reasoning trace in the full history, not just the last assistant message (default: template default)<br/>compatible with certain templates having 'supports_preserve_reasoning' capability<br/>example: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking<br/>(env: LLAMA_ARG_REASONING_PRESERVE) |
 | `--top-nsigma, --top-n-sigma N` | top-n-sigma sampling (default: -1.00, -1.0 = disabled) |
 | `--xtc-probability N` | xtc probability (default: 0.00, 0.0 = disabled) |
@@ -285,6 +279,10 @@ llama-completion.exe -m models\gemma-1.1-7b-it.Q4_K_M.gguf --ignore-eos -n -1
 | `--simple-io` | use basic IO for better compatibility in subprocesses and limited consoles |
 
 <!-- HELP_END -->
+
+## Reasoning Sampling Overrides
+
+Supported `--reasoning-*` options switch parameter values in the existing sampler chain while generation is inside a reasoning block. Unset options inherit their base values. RNG, token histories, Mirostat state and adaptive-p state remain continuous. Seed, sampler ordering, Mirostat configuration and adaptive-p configuration cannot vary by reasoning section.
 
 ## Common Options
 

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -286,6 +286,22 @@ int llama_completion(int argc, char ** argv) {
         return formatted;
     };
 
+    auto configure_reasoning_sampler = [&](const common_chat_params & chat_params) {
+        if (chat_params.thinking_start_tag.empty() || chat_params.thinking_end_tag.empty()) {
+            return;
+        }
+
+        sparams.generation_prompt       = chat_params.generation_prompt;
+        sparams.reasoning_budget_start  = common_tokenize(vocab, chat_params.thinking_start_tag, false, true);
+        sparams.reasoning_budget_end    = common_tokenize(vocab, chat_params.thinking_end_tag, false, true);
+        sparams.reasoning_budget_forced = common_tokenize(vocab, sparams.reasoning_budget_message + chat_params.thinking_end_tag, false, true);
+
+        common_sampler_configure_reasoning(smpl, vocab, sparams);
+    };
+
+    const bool needs_reasoning_sampler = sparams.reasoning_sampling ||
+        sparams.reasoning_budget_tokens >= 0 || sparams.reasoning_control;
+
     std::string prompt;
     {
         if (params.conversation_mode && params.enable_chat_template) {
@@ -308,7 +324,11 @@ int llama_completion(int argc, char ** argv) {
                 inputs.add_generation_prompt = !params.prompt.empty();
                 inputs.force_pure_content = params.force_pure_content_parser;
 
-                prompt = common_chat_templates_apply(chat_templates.get(), inputs).prompt;
+                auto chat_params = common_chat_templates_apply(chat_templates.get(), inputs);
+                prompt = chat_params.prompt;
+                if (needs_reasoning_sampler) {
+                    configure_reasoning_sampler(chat_params);
+                }
             }
         } else {
             // otherwise use the prompt as is
@@ -909,6 +929,14 @@ int llama_completion(int argc, char ** argv) {
                     std::string user_inp = format_chat
                         ? chat_add_and_format("user", std::move(buffer))
                         : std::move(buffer);
+                    if (format_chat && needs_reasoning_sampler) {
+                        common_chat_templates_inputs inputs;
+                        inputs.use_jinja             = params.use_jinja;
+                        inputs.messages              = chat_msgs;
+                        inputs.add_generation_prompt = true;
+                        inputs.force_pure_content    = params.force_pure_content_parser;
+                        configure_reasoning_sampler(common_chat_templates_apply(chat_templates.get(), inputs));
+                    }
                     // TODO: one inconvenient of current chat template implementation is that we can't distinguish between user input and special tokens (prefix/postfix)
                     const auto line_pfx = common_tokenize(ctx, params.input_prefix, false, true);
                     const auto line_inp = common_tokenize(ctx, user_inp,            false, format_chat);

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -288,6 +288,10 @@ int llama_completion(int argc, char ** argv) {
 
     auto configure_reasoning_sampler = [&](const common_chat_params & chat_params) {
         if (chat_params.thinking_start_tag.empty() || chat_params.thinking_end_tag.empty()) {
+            if (sparams.reasoning_sampling) {
+                LOG_WRN("%s: --reasoning-* sampling overrides are set but the chat template has no thinking tags; "
+                        "the overrides will have no effect\n", __func__);
+            }
             return;
         }
 

--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -286,7 +286,13 @@ int llama_completion(int argc, char ** argv) {
         return formatted;
     };
 
+    // the thinking tags and generation prompt do not change between turns, so this only needs to run
+    // once, on the first template application
+    bool reasoning_sampler_configured = false;
+
     auto configure_reasoning_sampler = [&](const common_chat_params & chat_params) {
+        reasoning_sampler_configured = true;
+
         if (chat_params.thinking_start_tag.empty() || chat_params.thinking_end_tag.empty()) {
             if (sparams.reasoning_sampling) {
                 LOG_WRN("%s: --reasoning-* sampling overrides are set but the chat template has no thinking tags; "
@@ -933,7 +939,9 @@ int llama_completion(int argc, char ** argv) {
                     std::string user_inp = format_chat
                         ? chat_add_and_format("user", std::move(buffer))
                         : std::move(buffer);
-                    if (format_chat && needs_reasoning_sampler) {
+                    if (format_chat && needs_reasoning_sampler && !reasoning_sampler_configured) {
+                        // only reached when the startup path had no prompt to format; the markers
+                        // do not change between turns, so one application is enough
                         common_chat_templates_inputs inputs;
                         inputs.use_jinja             = params.use_jinja;
                         inputs.messages              = chat_msgs;

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -127,6 +127,32 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--top-k N` | top-k sampling (default: 40, 0 = disabled)<br/>(env: LLAMA_ARG_TOP_K) |
 | `--top-p N` | top-p sampling (default: 0.95, 1.0 = disabled) |
 | `--min-p N` | min-p sampling (default: 0.05, 0.0 = disabled) |
+| `--reasoning-temp N` | temperature override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-k N` | top-k override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-p N` | top-p override while inside the reasoning block (default: inherit) |
+| `--reasoning-min-p N` | min-p override while inside the reasoning block (default: inherit) |
+| `--reasoning-top-n-sigma N` | top-n-sigma override while inside the reasoning block (default: inherit) |
+| `--reasoning-xtc-probability N` | XTC probability override while inside the reasoning block (default: inherit) |
+| `--reasoning-xtc-threshold N` | XTC threshold override while inside the reasoning block (default: inherit) |
+| `--reasoning-typical-p N` | locally typical sampling override while inside the reasoning block (default: inherit) |
+| `--reasoning-dynatemp-range N` | dynamic temperature range override while inside the reasoning block (default: inherit) |
+| `--reasoning-dynatemp-exp, --reasoning-dynatemp-exponent N` | dynamic temperature exponent override while inside the reasoning block (default: inherit) |
+| `--reasoning-repeat-last-n N` | repeat history override while inside the reasoning block (default: inherit) |
+| `--reasoning-repeat-penalty N` | repeat-penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-presence-penalty N` | presence penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-frequency-penalty N` | frequency penalty override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-multiplier N` | DRY multiplier override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-base N` | DRY base override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-allowed-length N` | DRY allowed length override while inside the reasoning block (default: inherit) |
+| `--reasoning-dry-penalty-last-n N` | DRY history override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat N` | Mirostat mode override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat-ent, --reasoning-mirostat-tau N` | Mirostat target entropy override while inside the reasoning block (default: inherit) |
+| `--reasoning-mirostat-lr, --reasoning-mirostat-eta N` | Mirostat learning rate override while inside the reasoning block (default: inherit) |
+| `--reasoning-adaptive-target N` | adaptive sampling target override while inside the reasoning block (default: inherit) |
+| `--reasoning-adaptive-decay N` | adaptive sampling decay override while inside the reasoning block (default: inherit) |
+| `--reasoning-min-keep N` | minimum candidate count override while inside the reasoning block (default: inherit) |
+| `--reasoning-seed SEED` | RNG seed override while inside the reasoning block (default: inherit) |
+| `--reasoning-preserve, --no-reasoning-preserve` | preserve reasoning trace in the full history, not just the last assistant message (default: template default)<br/>compatible with certain templates having 'supports_preserve_reasoning' capability<br/>example: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking<br/>(env: LLAMA_ARG_REASONING_PRESERVE) |
 | `--top-nsigma, --top-n-sigma N` | top-n-sigma sampling (default: -1.00, -1.0 = disabled) |
 | `--xtc-probability N` | xtc probability (default: 0.00, 0.0 = disabled) |
 | `--xtc-threshold N` | xtc threshold (default: 0.10, 1.0 = disabled) |
@@ -506,6 +532,8 @@ These words will not be included in the completion, so make sure to add them to 
 `n_probs`: If greater than 0, the response also contains the probabilities of top N tokens for each generated token given the sampling settings. Note that for temperature < 0 the tokens are sampled greedily but token probabilities are still being calculated via a simple softmax of the logits without considering any other sampler settings. Default: `0`
 
 `min_keep`: If greater than 0, force samplers to return N possible tokens at minimum. Default: `0`
+
+`reasoning_*`: Sampling overrides applied only while generation is inside the model's reasoning (thinking) block; outside of it the base values above are used. Each base sampling parameter has a reasoning counterpart: `reasoning_temp` (alias `reasoning_temperature`), `reasoning_top_k`, `reasoning_top_p`, `reasoning_min_p`, `reasoning_top_n_sigma`, `reasoning_xtc_probability`, `reasoning_xtc_threshold`, `reasoning_typical_p`, `reasoning_dynatemp_range`, `reasoning_dynatemp_exponent`, `reasoning_repeat_last_n`, `reasoning_repeat_penalty`, `reasoning_presence_penalty`, `reasoning_frequency_penalty`, `reasoning_dry_multiplier`, `reasoning_dry_base`, `reasoning_dry_allowed_length`, `reasoning_dry_penalty_last_n`, `reasoning_mirostat`, `reasoning_mirostat_tau`, `reasoning_mirostat_eta`, `reasoning_adaptive_target`, `reasoning_adaptive_decay`, `reasoning_min_keep` and `reasoning_seed`. Any parameter that is not set inherits the base value. The overrides require the reasoning start/end tags to be known: on `/v1/chat/completions` they are picked up automatically from chat templates with thinking support, while `/completion` requests must also provide `reasoning_budget_start_tag` and `reasoning_budget_end_tag`; without tags the overrides are ignored (a warning is logged). Default: inherit
 
 `t_max_predict_ms`: Set a time limit in milliseconds for the prediction (a.k.a. text-generation) phase. The timeout will trigger if the generation takes more than the specified time (measured since the first token was generated) and if a new-line character has already been generated. Useful for FIM applications. Default: `0`, which is disabled.
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -127,7 +127,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--top-k N` | top-k sampling (default: 40, 0 = disabled)<br/>(env: LLAMA_ARG_TOP_K) |
 | `--top-p N` | top-p sampling (default: 0.95, 1.0 = disabled) |
 | `--min-p N` | min-p sampling (default: 0.05, 0.0 = disabled) |
-| `--reasoning-temp N` | temperature override while inside the reasoning block (default: inherit) |
+| `--reasoning-temp N` | temperature override while inside the reasoning block; uses the existing sampling chain with continuous RNG and history state (default: inherit) |
 | `--reasoning-top-k N` | top-k override while inside the reasoning block (default: inherit) |
 | `--reasoning-top-p N` | top-p override while inside the reasoning block (default: inherit) |
 | `--reasoning-min-p N` | min-p override while inside the reasoning block (default: inherit) |
@@ -145,13 +145,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--reasoning-dry-base N` | DRY base override while inside the reasoning block (default: inherit) |
 | `--reasoning-dry-allowed-length N` | DRY allowed length override while inside the reasoning block (default: inherit) |
 | `--reasoning-dry-penalty-last-n N` | DRY history override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat N` | Mirostat mode override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat-ent, --reasoning-mirostat-tau N` | Mirostat target entropy override while inside the reasoning block (default: inherit) |
-| `--reasoning-mirostat-lr, --reasoning-mirostat-eta N` | Mirostat learning rate override while inside the reasoning block (default: inherit) |
-| `--reasoning-adaptive-target N` | adaptive sampling target override while inside the reasoning block (default: inherit) |
-| `--reasoning-adaptive-decay N` | adaptive sampling decay override while inside the reasoning block (default: inherit) |
 | `--reasoning-min-keep N` | minimum candidate count override while inside the reasoning block (default: inherit) |
-| `--reasoning-seed SEED` | RNG seed override while inside the reasoning block (default: inherit) |
 | `--reasoning-preserve, --no-reasoning-preserve` | preserve reasoning trace in the full history, not just the last assistant message (default: template default)<br/>compatible with certain templates having 'supports_preserve_reasoning' capability<br/>example: https://docs.z.ai/guides/capabilities/thinking-mode#preserved-thinking<br/>(env: LLAMA_ARG_REASONING_PRESERVE) |
 | `--top-nsigma, --top-n-sigma N` | top-n-sigma sampling (default: -1.00, -1.0 = disabled) |
 | `--xtc-probability N` | xtc probability (default: 0.00, 0.0 = disabled) |
@@ -312,6 +306,10 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--spec-default` | enable default speculative decoding config |
 
 <!-- HELP_END -->
+
+## Reasoning sampling overrides
+
+Supported `--reasoning-*` options switch parameter values in the existing sampler chain while generation is inside a reasoning block. Unset options inherit their base values. RNG, token histories, Mirostat state and adaptive-p state remain continuous. Seed, sampler ordering, Mirostat configuration and adaptive-p configuration cannot vary by reasoning section.
 
 Note: If both command line argument and environment variable are both set for the same param, the argument will take precedence over env var.
 
@@ -533,7 +531,7 @@ These words will not be included in the completion, so make sure to add them to 
 
 `min_keep`: If greater than 0, force samplers to return N possible tokens at minimum. Default: `0`
 
-`reasoning_*`: Sampling overrides applied only while generation is inside the model's reasoning (thinking) block; outside of it the base values above are used. Each base sampling parameter has a reasoning counterpart: `reasoning_temp` (alias `reasoning_temperature`), `reasoning_top_k`, `reasoning_top_p`, `reasoning_min_p`, `reasoning_top_n_sigma`, `reasoning_xtc_probability`, `reasoning_xtc_threshold`, `reasoning_typical_p`, `reasoning_dynatemp_range`, `reasoning_dynatemp_exponent`, `reasoning_repeat_last_n`, `reasoning_repeat_penalty`, `reasoning_presence_penalty`, `reasoning_frequency_penalty`, `reasoning_dry_multiplier`, `reasoning_dry_base`, `reasoning_dry_allowed_length`, `reasoning_dry_penalty_last_n`, `reasoning_mirostat`, `reasoning_mirostat_tau`, `reasoning_mirostat_eta`, `reasoning_adaptive_target`, `reasoning_adaptive_decay`, `reasoning_min_keep` and `reasoning_seed`. Any parameter that is not set inherits the base value. The overrides require the reasoning start/end tags to be known: on `/v1/chat/completions` they are picked up automatically from chat templates with thinking support, while `/completion` requests must also provide `reasoning_budget_start_tag` and `reasoning_budget_end_tag`; without tags the overrides are ignored (a warning is logged). Default: inherit
+`reasoning_*`: Supported reasoning overrides switch parameter values in the existing sampler chain while generation is inside the model's reasoning (thinking) block; outside of it the base values above are used. RNG, token histories, Mirostat state and adaptive-p state remain continuous. Unset reasoning values inherit their base values. Seed, sampler ordering, Mirostat configuration and adaptive-p configuration cannot vary by reasoning section. Supported fields are `reasoning_temp` (alias `reasoning_temperature`), `reasoning_top_k`, `reasoning_top_p`, `reasoning_min_p`, `reasoning_top_n_sigma`, `reasoning_xtc_probability`, `reasoning_xtc_threshold`, `reasoning_typical_p`, `reasoning_dynatemp_range`, `reasoning_dynatemp_exponent`, `reasoning_repeat_last_n`, `reasoning_repeat_penalty`, `reasoning_presence_penalty`, `reasoning_frequency_penalty`, `reasoning_dry_multiplier`, `reasoning_dry_base`, `reasoning_dry_allowed_length`, `reasoning_dry_penalty_last_n` and `reasoning_min_keep`. The overrides require the reasoning start/end tags to be known: on `/v1/chat/completions` they are picked up automatically from chat templates with thinking support, while `/completion` requests must also provide `reasoning_budget_start_tag` and `reasoning_budget_end_tag`; without tags the overrides are ignored (a warning is logged). Default: inherit
 
 `t_max_predict_ms`: Set a time limit in milliseconds for the prediction (a.k.a. text-generation) phase. The timeout will trigger if the generation takes more than the specified time (measured since the first token was generated) and if a new-line character has already been generated. Useful for FIM applications. Default: `0`, which is disabled.
 

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -1,6 +1,7 @@
 #include "server-schema.h"
 
 #include "json-schema-to-grammar.h"
+#include "log.h"
 
 namespace server_schema {
 
@@ -669,6 +670,13 @@ task_params eval_llama_cmpl_schema(
         if ((params.sampling.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N) &&
             params.sampling.reasoning_dry_penalty_last_n == -1) {
             params.sampling.reasoning_dry_penalty_last_n = n_ctx_slot;
+        }
+
+        if (params.sampling.reasoning_sampling &&
+            (params.sampling.reasoning_budget_start.empty() || params.sampling.reasoning_budget_end.empty())) {
+            LOG_WRN("%s: reasoning_* sampling overrides are set but no reasoning start/end tags are available "
+                    "(chat template without thinking tags, or missing reasoning_budget_start_tag/reasoning_budget_end_tag); "
+                    "the overrides will have no effect\n", __func__);
         }
 
         // if "reasoning_format" is not provided, its handler will not be called, we will need to handle it here

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -190,6 +190,96 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
     add((new field_bool("post_sampling_probs", params.post_sampling_probs))
         ->set_desc("Return probabilities of top n_probs tokens after applying the sampling chain"));
 
+    add((new field_num("reasoning_temp", params.sampling.reasoning_temp))
+        ->set_limits(0.0f, std::numeric_limits<float>::infinity())
+        ->add_alias("reasoning_temperature")
+        ->set_desc("Temperature override inside reasoning blocks"));
+
+    add((new field_num("reasoning_top_k", params.sampling.reasoning_top_k))
+        ->set_limits(0, INT32_MAX)
+        ->set_desc("Top-k override inside reasoning blocks"));
+
+    add((new field_num("reasoning_top_p", params.sampling.reasoning_top_p))
+        ->set_limits(0.0f, 1.0f)
+        ->set_desc("Top-p override inside reasoning blocks"));
+
+    add((new field_num("reasoning_min_p", params.sampling.reasoning_min_p))
+        ->set_limits(0.0f, 1.0f)
+        ->set_desc("Min-p override inside reasoning blocks"));
+
+    add((new field_num("reasoning_top_n_sigma", params.sampling.reasoning_top_n_sigma))
+        ->set_desc("Top-n-sigma override inside reasoning blocks"));
+
+    add((new field_num("reasoning_xtc_probability", params.sampling.reasoning_xtc_probability))
+        ->set_limits(0.0f, 1.0f)
+        ->set_desc("XTC probability override inside reasoning blocks"));
+
+    add((new field_num("reasoning_xtc_threshold", params.sampling.reasoning_xtc_threshold))
+        ->set_limits(0.0f, 1.0f)
+        ->set_desc("XTC threshold override inside reasoning blocks"));
+
+    add((new field_num("reasoning_typical_p", params.sampling.reasoning_typ_p))
+        ->set_desc("Locally typical sampling override inside reasoning blocks"));
+
+    add((new field_num("reasoning_dynatemp_range", params.sampling.reasoning_dynatemp_range))
+        ->set_desc("Dynamic temperature range override inside reasoning blocks"));
+
+    add((new field_num("reasoning_dynatemp_exponent", params.sampling.reasoning_dynatemp_exponent))
+        ->set_desc("Dynamic temperature exponent override inside reasoning blocks"));
+
+    add((new field_num("reasoning_repeat_last_n", params.sampling.reasoning_penalty_last_n))
+        ->set_hard_limits(-1, INT32_MAX)
+        ->set_desc("Repeat history override inside reasoning blocks"));
+
+    add((new field_num("reasoning_repeat_penalty", params.sampling.reasoning_penalty_repeat))
+        ->set_desc("Repeat penalty override inside reasoning blocks"));
+
+    add((new field_num("reasoning_frequency_penalty", params.sampling.reasoning_penalty_freq))
+        ->set_desc("Frequency penalty override inside reasoning blocks"));
+
+    add((new field_num("reasoning_presence_penalty", params.sampling.reasoning_penalty_present))
+        ->set_desc("Presence penalty override inside reasoning blocks"));
+
+    add((new field_num("reasoning_dry_multiplier", params.sampling.reasoning_dry_multiplier))
+        ->set_desc("DRY multiplier override inside reasoning blocks"));
+
+    add((new field_num("reasoning_dry_base", params.sampling.reasoning_dry_base))
+        ->set_limits(1.0f, std::numeric_limits<float>::infinity())
+        ->set_desc("DRY base override inside reasoning blocks"));
+
+    add((new field_num("reasoning_dry_allowed_length", params.sampling.reasoning_dry_allowed_length))
+        ->set_hard_limits(0, INT32_MAX)
+        ->set_desc("DRY allowed length override inside reasoning blocks"));
+
+    add((new field_num("reasoning_dry_penalty_last_n", params.sampling.reasoning_dry_penalty_last_n))
+        ->set_hard_limits(-1, INT32_MAX)
+        ->set_desc("DRY history override inside reasoning blocks"));
+
+    add((new field_num("reasoning_mirostat", params.sampling.reasoning_mirostat))
+        ->set_limits(0, 2)
+        ->set_desc("Mirostat mode override inside reasoning blocks"));
+
+    add((new field_num("reasoning_mirostat_tau", params.sampling.reasoning_mirostat_tau))
+        ->set_desc("Mirostat target entropy override inside reasoning blocks"));
+
+    add((new field_num("reasoning_mirostat_eta", params.sampling.reasoning_mirostat_eta))
+        ->set_desc("Mirostat learning rate override inside reasoning blocks"));
+
+    add((new field_num("reasoning_adaptive_target", params.sampling.reasoning_adaptive_target))
+        ->set_limits(-std::numeric_limits<float>::max(), 1.0f)
+        ->set_desc("Adaptive sampling target override inside reasoning blocks"));
+
+    add((new field_num("reasoning_adaptive_decay", params.sampling.reasoning_adaptive_decay))
+        ->set_hard_limits(0.0f, 0.99f)
+        ->set_desc("Adaptive sampling decay override inside reasoning blocks"));
+
+    add((new field_num("reasoning_min_keep", params.sampling.reasoning_min_keep))
+        ->set_hard_limits(0, INT32_MAX)
+        ->set_desc("Minimum candidate count override inside reasoning blocks"));
+
+    add((new field_num("reasoning_seed", params.sampling.reasoning_seed))
+        ->set_desc("RNG seed override inside reasoning blocks"));
+
     //
     // Speculative decoding params
     //
@@ -536,6 +626,49 @@ task_params eval_llama_cmpl_schema(
 
         if (params.sampling.dry_penalty_last_n == -1) {
             params.sampling.dry_penalty_last_n = n_ctx_slot;
+        }
+
+        auto enable_reasoning_override = [&](const char * name, uint64_t flag) {
+            auto it = data.find(name);
+            if (it != data.end() && !it->is_null()) {
+                params.sampling.reasoning_sampling |= flag;
+            }
+        };
+
+        enable_reasoning_override("reasoning_temp",               COMMON_PARAMS_SAMPLING_CONFIG_TEMP);
+        enable_reasoning_override("reasoning_temperature",        COMMON_PARAMS_SAMPLING_CONFIG_TEMP);
+        enable_reasoning_override("reasoning_top_k",              COMMON_PARAMS_SAMPLING_CONFIG_TOP_K);
+        enable_reasoning_override("reasoning_top_p",              COMMON_PARAMS_SAMPLING_CONFIG_TOP_P);
+        enable_reasoning_override("reasoning_min_p",              COMMON_PARAMS_SAMPLING_CONFIG_MIN_P);
+        enable_reasoning_override("reasoning_top_n_sigma",        COMMON_PARAMS_SAMPLING_CONFIG_TOP_N_SIGMA);
+        enable_reasoning_override("reasoning_xtc_probability",    COMMON_PARAMS_SAMPLING_CONFIG_XTC_PROBABILITY);
+        enable_reasoning_override("reasoning_xtc_threshold",      COMMON_PARAMS_SAMPLING_CONFIG_XTC_THRESHOLD);
+        enable_reasoning_override("reasoning_typical_p",          COMMON_PARAMS_SAMPLING_CONFIG_TYPICAL_P);
+        enable_reasoning_override("reasoning_dynatemp_range",     COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_RANGE);
+        enable_reasoning_override("reasoning_dynatemp_exponent",  COMMON_PARAMS_SAMPLING_CONFIG_DYNATEMP_EXPONENT);
+        enable_reasoning_override("reasoning_repeat_last_n",      COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N);
+        enable_reasoning_override("reasoning_repeat_penalty",     COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_REPEAT);
+        enable_reasoning_override("reasoning_frequency_penalty",  COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_FREQ);
+        enable_reasoning_override("reasoning_presence_penalty",   COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_PRESENT);
+        enable_reasoning_override("reasoning_dry_multiplier",     COMMON_PARAMS_SAMPLING_CONFIG_DRY_MULTIPLIER);
+        enable_reasoning_override("reasoning_dry_base",           COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE);
+        enable_reasoning_override("reasoning_dry_allowed_length", COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN);
+        enable_reasoning_override("reasoning_dry_penalty_last_n", COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N);
+        enable_reasoning_override("reasoning_mirostat",           COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT);
+        enable_reasoning_override("reasoning_mirostat_tau",       COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU);
+        enable_reasoning_override("reasoning_mirostat_eta",       COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA);
+        enable_reasoning_override("reasoning_adaptive_target",    COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET);
+        enable_reasoning_override("reasoning_adaptive_decay",     COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY);
+        enable_reasoning_override("reasoning_min_keep",           COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP);
+        enable_reasoning_override("reasoning_seed",               COMMON_PARAMS_SAMPLING_CONFIG_SEED);
+
+        if ((params.sampling.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N) &&
+            params.sampling.reasoning_penalty_last_n == -1) {
+            params.sampling.reasoning_penalty_last_n = n_ctx_slot;
+        }
+        if ((params.sampling.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N) &&
+            params.sampling.reasoning_dry_penalty_last_n == -1) {
+            params.sampling.reasoning_dry_penalty_last_n = n_ctx_slot;
         }
 
         // if "reasoning_format" is not provided, its handler will not be called, we will need to handle it here

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -194,7 +194,7 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
     add((new field_num("reasoning_temp", params.sampling.reasoning_temp))
         ->set_limits(0.0f, std::numeric_limits<float>::infinity())
         ->add_alias("reasoning_temperature")
-        ->set_desc("Temperature override inside reasoning blocks"));
+        ->set_desc("Temperature override inside reasoning blocks; uses the existing sampling chain with continuous RNG and history state"));
 
     add((new field_num("reasoning_top_k", params.sampling.reasoning_top_k))
         ->set_limits(0, INT32_MAX)
@@ -256,30 +256,9 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
         ->set_hard_limits(-1, INT32_MAX)
         ->set_desc("DRY history override inside reasoning blocks"));
 
-    add((new field_num("reasoning_mirostat", params.sampling.reasoning_mirostat))
-        ->set_limits(0, 2)
-        ->set_desc("Mirostat mode override inside reasoning blocks"));
-
-    add((new field_num("reasoning_mirostat_tau", params.sampling.reasoning_mirostat_tau))
-        ->set_desc("Mirostat target entropy override inside reasoning blocks"));
-
-    add((new field_num("reasoning_mirostat_eta", params.sampling.reasoning_mirostat_eta))
-        ->set_desc("Mirostat learning rate override inside reasoning blocks"));
-
-    add((new field_num("reasoning_adaptive_target", params.sampling.reasoning_adaptive_target))
-        ->set_limits(-std::numeric_limits<float>::max(), 1.0f)
-        ->set_desc("Adaptive sampling target override inside reasoning blocks"));
-
-    add((new field_num("reasoning_adaptive_decay", params.sampling.reasoning_adaptive_decay))
-        ->set_hard_limits(0.0f, 0.99f)
-        ->set_desc("Adaptive sampling decay override inside reasoning blocks"));
-
     add((new field_num("reasoning_min_keep", params.sampling.reasoning_min_keep))
         ->set_hard_limits(0, INT32_MAX)
         ->set_desc("Minimum candidate count override inside reasoning blocks"));
-
-    add((new field_num("reasoning_seed", params.sampling.reasoning_seed))
-        ->set_desc("RNG seed override inside reasoning blocks"));
 
     //
     // Speculative decoding params
@@ -655,13 +634,7 @@ task_params eval_llama_cmpl_schema(
         enable_reasoning_override("reasoning_dry_base",           COMMON_PARAMS_SAMPLING_CONFIG_DRY_BASE);
         enable_reasoning_override("reasoning_dry_allowed_length", COMMON_PARAMS_SAMPLING_CONFIG_DRY_ALLOWED_LEN);
         enable_reasoning_override("reasoning_dry_penalty_last_n", COMMON_PARAMS_SAMPLING_CONFIG_DRY_PENALTY_LAST_N);
-        enable_reasoning_override("reasoning_mirostat",           COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT);
-        enable_reasoning_override("reasoning_mirostat_tau",       COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_TAU);
-        enable_reasoning_override("reasoning_mirostat_eta",       COMMON_PARAMS_SAMPLING_CONFIG_MIROSTAT_ETA);
-        enable_reasoning_override("reasoning_adaptive_target",    COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_TARGET);
-        enable_reasoning_override("reasoning_adaptive_decay",     COMMON_PARAMS_SAMPLING_CONFIG_ADAPTIVE_DECAY);
         enable_reasoning_override("reasoning_min_keep",           COMMON_PARAMS_SAMPLING_CONFIG_MIN_KEEP);
-        enable_reasoning_override("reasoning_seed",               COMMON_PARAMS_SAMPLING_CONFIG_SEED);
 
         if ((params.sampling.reasoning_sampling & COMMON_PARAMS_SAMPLING_CONFIG_PENALTY_LAST_N) &&
             params.sampling.reasoning_penalty_last_n == -1) {


### PR DESCRIPTION
## Overview

Sampling params like temperature apply uniformly across the thinking sections and the non thinking sections of the model output. I think many of us see an advantage of different sampling parameter values, such as temperature at 1 for thinking, and normal output temperature of 0.7 for normal output e.g. coding, this example is for Qwen 3.6, the 27B one, since higher temperature, is an example of parameter that can help those thinking loops and repetition, those token trajectory attractors that occupy so much of the output of such a local model in my experience at least.

## Requirements

Sampling params like temperature can currently be set but apply across the output (across the thinking sections and the normal output sections). We would very much like to be able to specify a different temperature for the thinking section and for the non thinking section. We have a working PR we hope for this purpose and can adapt to maintainer feedback to best implement this at the right extension point or lever to obtain the section aware sampling parametrization goal.

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, Anthropic Fable 5 and GPT 5.6 Sol were used in design, coding, test generation, review, iterating


## Design notes (feedback welcome)

- **How it works**: the reasoning overrides build a second sampler chain (`chain_think`) next to the base chain; both accept every token (so penalty/DRY history spans the whole output), and the chain used for sampling is selected by the reasoning-budget sampler's state (inside vs. outside the thinking block).
- **Activation**: the overrides only take effect when the reasoning start/end tags are known. `/v1/chat/completions` picks them up automatically from chat templates with thinking support; `/completion` requests must also pass `reasoning_budget_start_tag`/`reasoning_budget_end_tag`. A warning is now logged when overrides are set but no tags are available, instead of silently ignoring them.
- **Extension-point shape**: each overridable parameter is currently registered in 5 places (struct field + enum flag in `common/common.h`, CLI arg in `common/arg.cpp`, schema field + override mapping in `tools/server/server-schema.cpp`, merge line in `common/sampling.cpp`). This mirrors the existing per-parameter patterns, but happy to restructure — e.g. a nested overrides struct or a single table that the CLI args, schema fields and merge are generated from — per maintainer preference.
- The earlier commit resolving the `penalty_last_n == -1` sentinel in the base chain was reverted as out of scope for this PR (it changed base-chain behavior for CLI tools).

