### PR TITLE
ggml-blas: disable support for hadamard matmul

### DIFF
--- a/ggml/src/ggml-blas/ggml-blas.cpp
+++ b/ggml/src/ggml-blas/ggml-blas.cpp
@@ -1,3 +1,4 @@
+#include "ggml.h"
 #include "ggml-impl.h"
 #include "ggml-blas.h"
 #include "ggml-backend-impl.h"
@@ -414,6 +415,12 @@ static bool ggml_backend_blas_device_supports_op(ggml_backend_dev_t dev, const s
 
             // TODO: find the optimal value
             const int64_t min_batch = 32;
+
+            // default back to CPU fast path
+            // see: https://github.com/ggml-org/llama.cpp/issues/25565
+            if (ggml_get_op_params_i32(op, 1) == GGML_HINT_SRC0_IS_HADAMARD) {
+                return false;
+            }
 
             return ggml_is_contiguous(src0) &&
                    ggml_is_contiguous(src1) &&


### PR DESCRIPTION
## Overview

fixes #25565.

This PR re-routes matrix multiplication tensors hinted with `GGML_HINT_SRC0_IS_HADAMARD` back to the CPU backend as it is faster there.

While I was unable to reproduce the problem locally (too little resources to run DeepSeek 4), @/jaholmesuk has reported that this PR fixes the token generation regression.

Quoting https://github.com/ggml-org/llama.cpp/issues/25565#issuecomment-4952856018:

>  build decode tg128 prefill pp512
>
>  A: BLAS unpatched 8.36 32.3
>
>  B: BLAS + your patch 9.97 32.3
>
>  C: no-BLAS 10.00 79.2
>
>  Your patch fully fixes decode: 9.97 vs the no-BLAS 10.00, up from 8.36. 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
