### PR TITLE
server: add support for `stream: true` and OpenAI fallback

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -681,6 +681,28 @@ static json parse_gcp_predict_response(const server_http_res_ptr & res) {
     }
 }
 
+struct gcp_forwarded_stream_response : server_http_res {
+    std::shared_ptr<server_http_req> forwarded_req;
+    server_http_res_ptr forwarded_res;
+
+    gcp_forwarded_stream_response(
+            std::shared_ptr<server_http_req> forwarded_req,
+            server_http_res_ptr forwarded_res)
+        : forwarded_req(std::move(forwarded_req)),
+          forwarded_res(std::move(forwarded_res)) {
+        content_type = this->forwarded_res->content_type;
+        status = this->forwarded_res->status;
+        headers = this->forwarded_res->headers;
+        next = [this](std::string & output) {
+            return this->forwarded_res->next(output);
+        };
+    }
+
+    void on_complete() override {
+        forwarded_res->on_complete();
+    }
+};
+
 void server_http_context::register_gcp_compat() const {
     const gcp_params gcp;
 
@@ -712,6 +734,51 @@ void server_http_context::register_gcp_compat() const {
             return json {{"error", format_error_response(message, type)}};
         };
 
+        const auto error_response = [](const std::string & message, error_type type) -> server_http_res_ptr {
+            auto res = std::make_unique<server_http_res>();
+            res->status = type == ERROR_TYPE_INVALID_REQUEST ? 400 : 500;
+            res->data = safe_json_to_str({{"error", format_error_response(message, type)}});
+            return res;
+        };
+
+        const auto dispatch = [this, &req, &alias_to_path](json payload, const std::string & default_format) -> server_http_res_ptr {
+            std::string format = default_format;
+            if (payload.contains("@requestFormat")) {
+                if (!payload.at("@requestFormat").is_string()) {
+                    throw std::invalid_argument("@requestFormat must be a string");
+                }
+                format = payload.at("@requestFormat").get<std::string>();
+                payload.erase("@requestFormat");
+            }
+
+            std::string dispatch_path;
+            auto it_alias = alias_to_path.find(format);
+            if (it_alias != alias_to_path.end()) {
+                dispatch_path = it_alias->second;
+            } else if (handlers.count(format)) {
+                dispatch_path = format;
+            } else {
+                throw std::invalid_argument("no handler registered for @requestFormat: " + format);
+            }
+
+            auto internal_req = std::make_shared<server_http_req>(server_http_req {
+                req.params,
+                req.headers,
+                path_prefix + dispatch_path,
+                req.query_string,
+                payload.dump(),
+                {},
+                req.should_stop,
+            });
+
+            server_http_res_ptr internal_res = handlers.at(dispatch_path)(*internal_req);
+            if (internal_res != nullptr && internal_res->is_stream()) {
+                return std::make_unique<gcp_forwarded_stream_response>(
+                    std::move(internal_req), std::move(internal_res));
+            }
+            return internal_res;
+        };
+
         json data;
         try {
             data = json::parse(req.body);
@@ -727,7 +794,20 @@ void server_http_context::register_gcp_compat() const {
             res->data = safe_json_to_str({{"error", format_error_response("request body must be a JSON object", ERROR_TYPE_INVALID_REQUEST)}});
             return res;
         }
-        if (!data.contains("instances") || !data.at("instances").is_array()) {
+
+        if (!data.contains("instances")) {
+            try {
+                return dispatch(std::move(data), "chatCompletions");
+            } catch (const std::invalid_argument & e) {
+                return error_response(e.what(), ERROR_TYPE_INVALID_REQUEST);
+            } catch (const std::exception & e) {
+                return error_response(e.what(), ERROR_TYPE_SERVER);
+            } catch (...) {
+                return error_response("unknown error", ERROR_TYPE_SERVER);
+            }
+        }
+
+        if (!data.at("instances").is_array()) {
             auto res = std::make_unique<server_http_res>();
             res->status = 400;
             res->data = safe_json_to_str({{"error", format_error_response("request body must include an array field named instances", ERROR_TYPE_INVALID_REQUEST)}});
@@ -743,11 +823,42 @@ void server_http_context::register_gcp_compat() const {
             return res;
         }
 
+        const auto is_streaming = [](const json & instance) {
+            return instance.is_object()
+                && instance.contains("stream")
+                && instance.at("stream").is_boolean()
+                && instance.at("stream").get<bool>();
+        };
+
+        if (instances.size() > 1) {
+            for (const auto & instance : instances) {
+                if (is_streaming(instance)) {
+                    return error_response("streaming is only supported for a single instance", ERROR_TYPE_INVALID_REQUEST);
+                }
+            }
+        }
+
+        if (instances.size() == 1 && is_streaming(instances.at(0))) {
+            const json & instance = instances.at(0);
+            if (!instance.contains("@requestFormat")) {
+                return error_response("each instance must include a string @requestFormat", ERROR_TYPE_INVALID_REQUEST);
+            }
+            try {
+                return dispatch(instance, "");
+            } catch (const std::invalid_argument & e) {
+                return error_response(e.what(), ERROR_TYPE_INVALID_REQUEST);
+            } catch (const std::exception & e) {
+                return error_response(e.what(), ERROR_TYPE_SERVER);
+            } catch (...) {
+                return error_response("unknown error", ERROR_TYPE_SERVER);
+            }
+        }
+
         std::vector<std::future<json>> futures;
         futures.reserve(instances.size());
 
         for (const auto & instance : instances) {
-            futures.push_back(std::async(std::launch::async, [this, &req, &alias_to_path, instance]() -> json {
+            futures.push_back(std::async(std::launch::async, [&dispatch, instance]() -> json {
                 if (!instance.is_object()) {
                     return build_error("each instance must be a JSON object", ERROR_TYPE_INVALID_REQUEST);
                 }
@@ -756,37 +867,7 @@ void server_http_context::register_gcp_compat() const {
                 }
 
                 try {
-                    json payload = instance;
-                    const std::string format = payload.at("@requestFormat").get<std::string>();
-                    payload.erase("@requestFormat");
-
-                    if (payload.contains("stream")) {
-                        SRV_WRN("%s", "ignoring client-provided stream field in instance, streaming is not supported in predict route\n");
-                        payload["stream"] = false;
-                    }
-
-                    // accept both camelCase aliases (e.g. "chatCompletions") and direct paths
-                    std::string dispatch_path;
-                    auto it_alias = alias_to_path.find(format);
-                    if (it_alias != alias_to_path.end()) {
-                        dispatch_path = it_alias->second;
-                    } else if (handlers.count(format)) {
-                        dispatch_path = format;
-                    } else {
-                        return build_error("no handler registered for @requestFormat: " + format, ERROR_TYPE_INVALID_REQUEST);
-                    }
-
-                    const server_http_req internal_req {
-                        req.params,
-                        req.headers,
-                        path_prefix + dispatch_path,
-                        req.query_string,
-                        payload.dump(),
-                        {},
-                        req.should_stop,
-                    };
-
-                    server_http_res_ptr internal_res = handlers.at(dispatch_path)(internal_req);
+                    server_http_res_ptr internal_res = dispatch(instance, "");
                     return parse_gcp_predict_response(internal_res);
                 } catch (const std::invalid_argument & e) {
                     return build_error(e.what(), ERROR_TYPE_INVALID_REQUEST);

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -751,6 +751,7 @@ void server_http_context::register_gcp_compat() const {
                 payload.erase("@requestFormat");
             }
 
+            // accept both camelCase aliases (e.g. "chatCompletions") and direct paths
             std::string dispatch_path;
             auto it_alias = alias_to_path.find(format);
             if (it_alias != alias_to_path.end()) {

--- a/tools/server/tests/unit/test_compat_gcp.py
+++ b/tools/server/tests/unit/test_compat_gcp.py
@@ -45,11 +45,13 @@ def test_gcp_predict_multiple_instances():
                 "@requestFormat": "chatCompletions",
                 "max_tokens": 8,
                 "messages": [{"role": "user", "content": "Say hello"}],
+                "stream": False,
             },
             {
                 "@requestFormat": "chatCompletions",
                 "max_tokens": 8,
                 "messages": [{"role": "user", "content": "Say world"}],
+                "stream": False,
             },
         ],
     })
@@ -58,3 +60,79 @@ def test_gcp_predict_multiple_instances():
     for prediction in res.body["predictions"]:
         assert "choices" in prediction
         assert len(prediction["choices"][0]["message"]["content"]) > 0
+
+
+def test_gcp_predict_openai_chat_completion():
+    global server
+    server.start()
+    res = server.make_request("POST", "/predict", data={
+        "max_tokens": 8,
+        "messages": [
+            {"role": "user", "content": "What is the meaning of life?"},
+        ],
+    })
+    assert res.status_code == 200
+    assert "predictions" not in res.body
+    assert len(res.body["choices"]) == 1
+    assert res.body["choices"][0]["message"]["role"] == "assistant"
+    assert len(res.body["choices"][0]["message"]["content"]) > 0
+
+
+@pytest.mark.parametrize("vertex_request", [False, True])
+def test_gcp_predict_stream_chat_completion(vertex_request: bool):
+    global server
+    server.start()
+    payload = {
+        "max_tokens": 8,
+        "messages": [
+            {"role": "user", "content": "What is the meaning of life?"},
+        ],
+        "stream": True,
+    }
+    if vertex_request:
+        payload["@requestFormat"] = "chatCompletions"
+        payload = {"instances": [payload]}
+
+    content = ""
+    for data in server.make_stream_request("POST", "/predict", data=payload):
+        if data["choices"]:
+            content += data["choices"][0]["delta"].get("content") or ""
+    assert len(content) > 0
+
+
+@pytest.mark.parametrize("vertex_request", [False, True])
+def test_gcp_predict_stream_response_format(vertex_request: bool):
+    global server
+    server.start()
+    payload = {
+        "@requestFormat": "responses",
+        "input": "What is the meaning of life?",
+        "max_output_tokens": 8,
+        "stream": True,
+    }
+    if vertex_request:
+        payload = {"instances": [payload]}
+
+    events = server.make_stream_request("POST", "/predict", data=payload)
+    assert any(event["type"] == "response.completed" for event in events)
+
+
+def test_gcp_predict_rejects_multiple_streaming_instances():
+    global server
+    server.start()
+    res = server.make_request("POST", "/predict", data={
+        "instances": [
+            {
+                "@requestFormat": "chatCompletions",
+                "messages": [{"role": "user", "content": "Say hello"}],
+                "stream": True,
+            },
+            {
+                "@requestFormat": "chatCompletions",
+                "messages": [{"role": "user", "content": "Say world"}],
+                "stream": False,
+            },
+        ],
+    })
+    assert res.status_code == 400
+    assert "streaming is only supported for a single instance" in res.body["error"]["message"]


### PR DESCRIPTION
## Overview

This PR is a follow-up of https://github.com/ggml-org/llama.cpp/pull/22545 where support for Google Cloud Vertex AI / Agent Platform Spec was included under the `AIP_MODE=PREDICTION`, so that the router includes `AIP_PREDICTION_ROUTE` that can be e.g., `/prediction` which is a Vertex AI compliant route.

This PR adds support for `stream: true` which was formerly dropped due to incompatible with the public-facing spec, but after discussing with Google Cloud (as part of our partnership with them) it's required and there's a (hacky) way to make it work with their spec. Additionally, this PR also makes `AIP_PREDICTION_ROUTE` be fully compatible with Chat Completions API too, so that it accepts and emits the OpenAI Chat Completions API spec too, besides the Vertex AI spec when applicable.

cc @ngxson 

## Additional information

Find below some context on the Vertex AI spec, and how is the `AIP_PREDICTION_ROUTE` supposed to behave depending on the input and parameters that get to it.

Vertex AI spec under e.g., /predictions, expects an input that matches the spec and returns an output that matches the spec, which is `{"instances":[{"@requestFormat": "chatCompletions", "messages":[{"role":"user","content":"What is Deep Learning?"}], "max_tokens":128}]}`, where `instances` can be a list of one or more instances, and it forwards those to whichever is the underlying OpenAI endpoint, in this case /v1/chat/completions based on the @requestFormat parameter.

But if the user sends a request to the /predictions endpoint with a Chat Completions API payload, it should work out of the box and reply normally as if the user was hitting Chat Completions API. Additionally, for `stream: true` to work, users need to either send the Chat Completions API request in the first place and they will receive the streams, or rather call the /predictions endpoint with the Vertex AI input spec i.e., `{"instances":[{"@requestFormat": "chatCompletions", "messages":[{"role":"user","content":"What is Deep Learning?"}], "max_tokens":128, "stream": true}]}`, for which /predictions will reply with the standard Chat Completions API streaming output. But that will work only because `instances` just contains one entry, if it contains more, then it should fail.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for tests and validation mainly; the rest was developed / written solely by me, including this PR