### PR TITLE
spec: fix dflash target tokenizer mismatch during conversion

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -652,7 +652,7 @@ class DFlashModel(Qwen3Model):
         target_cls = get_model_class(target_arch)
 
         if target_cls is not type(self):
-            target_cls.set_vocab(self)
+            target_cls.set_vocab(self)  # ty: ignore[unresolved-attribute]
         else:
             super().set_vocab()
 

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from typing import Any, Callable, Iterable, TYPE_CHECKING
 
 import torch
@@ -641,7 +643,19 @@ class DFlashModel(Qwen3Model):
         logger.info(f"DFlash: Using tokenizer from target model: {self.target_model_dir}")
         original_dir = self.dir_model
         self.dir_model = self.target_model_dir
-        super().set_vocab()
+
+        # Reuse the target model's own vocab handler (e.g. Gemma-4 needs its
+        # own tokenizer logic, not the Qwen default).
+        from . import get_model_class
+        with open(self.target_model_dir / "config.json", "r", encoding="utf-8") as f:
+            target_arch = json.load(f)["architectures"][0]
+        target_cls = get_model_class(target_arch)
+
+        if target_cls is not type(self):
+            target_cls.set_vocab(self)
+        else:
+            super().set_vocab()
+
         self.dir_model = original_dir
 
         mask_token_id = self.hparams.get("dflash_config", {}).get("mask_token_id")


### PR DESCRIPTION
## Overview

Fix DFlash conversion issue. See https://github.com/ggml-org/llama.cpp/pull/22105#issuecomment-4981963436 

Root cause: `DFlashDraftModel` always used the Qwen vocab path, so target models needing different tokenizer handling (e.g. Gemma-4, which has no `tokenizer.model`) failed with `"BPE pre-tokenizer was not recognized"`. 

Solution: set `set_vocab` to read the target's architecture from its `config.json` and dispatches to that architecture's own `set_vocab`.


Tested with Gemma4 DFlash models, works as expected. 


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, paired with cursor

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
