### PR TITLE
server : add experimental MCP (stdio) server support

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -850,8 +850,9 @@ static bool common_params_parse_ex(int argc, char ** argv, common_params_context
         params.kv_overrides.back().key[0] = 0;
     }
 
-    if (!params.server_tools.empty() && !params.cors_origins_explicit) {
-        LOG_WRN("server tools are enabled, using localhost as default CORS origin (change via --cors-origins)\n");
+    const bool mcp_enabled = !params.mcp_servers_config.empty() || !params.mcp_servers_json.empty();
+    if ((!params.server_tools.empty() || mcp_enabled) && !params.cors_origins_explicit) {
+        LOG_WRN("server tools or MCP servers are enabled, using localhost as default CORS origin (change via --cors-origins)\n");
         params.cors_origins = "localhost";
     }
 
@@ -3261,6 +3262,22 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.server_tools = parse_csv_row(value);
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_TOOLS"));
+    add_opt(common_arg(
+        {"--mcp-servers-config"}, "PATH",
+        "experimental: path to JSON file with MCP server definitions (Cursor-compatible format) - do not enable in untrusted environments (default: none)\n"
+        "note: for security reasons, this will limit --cors-origins to localhost by default",
+        [](common_params & params, const std::string & value) {
+            params.mcp_servers_config = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MCP_SERVERS_CONFIG"));
+    add_opt(common_arg(
+        {"--mcp-servers-json"}, "JSON",
+        "experimental: inline JSON with MCP server definitions (Cursor-compatible format) - do not enable in untrusted environments (default: none)\n"
+        "note: for security reasons, this will limit --cors-origins to localhost by default",
+        [](common_params & params, const std::string & value) {
+            params.mcp_servers_json = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MCP_SERVERS_JSON"));
     add_opt(common_arg(
         {"-ag", "--agent"},
         {"-no-ag", "--no-agent"},

--- a/common/common.h
+++ b/common/common.h
@@ -668,6 +668,10 @@ struct common_params {
     // enable built-in tools
     std::vector<std::string> server_tools;
 
+    // MCP server configs (Cursor-compatible JSON)
+    std::string mcp_servers_config;   // path to JSON file with MCP server definitions
+    std::string mcp_servers_json;     // inline JSON with MCP server definitions
+
     // router server configs
     std::string models_dir    = "";     // directory containing models for the router server
     std::string models_preset = "";     // directory containing model presets for the router server

--- a/scripts/sync_vendor.py
+++ b/scripts/sync_vendor.py
@@ -21,7 +21,7 @@ vendor = {
     f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/split.py":  "split.py",
     f"https://raw.githubusercontent.com/yhirose/cpp-httplib/{HTTPLIB_VERSION}/LICENSE":   "vendor/cpp-httplib/LICENSE",
 
-    "https://raw.githubusercontent.com/sheredom/subprocess.h/b49c56e9fe214488493021017bf3954b91c7c1f5/subprocess.h": "vendor/sheredom/subprocess.h",
+    "https://raw.githubusercontent.com/sheredom/subprocess.h/8671cee1fc09f11a70ce3782a0ee13177c3aa387/subprocess.h": "vendor/sheredom/subprocess.h",
 }
 
 for url, filename in vendor.items():

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(${TARGET} STATIC
     server-stream.h
     server-tools.cpp
     server-tools.h
+    server-mcp.cpp
+    server-mcp.h
     server-schema.cpp
     server-schema.h
 )

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -9,9 +9,15 @@
 #define JSON_ASSERT GGML_ASSERT
 #include <nlohmann/json.hpp>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cinttypes>
+#include <functional>
+#include <mutex>
+#include <queue>
 #include <string>
 #include <vector>
-#include <cinttypes>
 
 using json = nlohmann::ordered_json;
 
@@ -376,3 +382,54 @@ server_tokens format_prompt_rerank(
         mtmd_context * mctx,
         const std::string & query,
         const std::string & doc);
+
+// simple implementation of a pipe
+// used for streaming data between threads
+template<typename T>
+struct server_pipe {
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::queue<T> queue;
+    std::atomic<bool> writer_closed{false};
+    std::atomic<bool> reader_closed{false};
+
+    void close_write() {
+        writer_closed.store(true, std::memory_order_relaxed);
+        cv.notify_all();
+    }
+
+    void close_read() {
+        reader_closed.store(true, std::memory_order_relaxed);
+        cv.notify_all();
+    }
+
+    bool read(T & output, const std::function<bool()> & should_stop) {
+        std::unique_lock<std::mutex> lk(mutex);
+        constexpr auto poll_interval = std::chrono::milliseconds(500);
+        while (true) {
+            if (!queue.empty()) {
+                output = std::move(queue.front());
+                queue.pop();
+                return true;
+            }
+            if (writer_closed.load()) {
+                return false; // clean EOF
+            }
+            if (should_stop()) {
+                close_read(); // signal broken pipe to writer
+                return false; // cancelled / reader no longer alive
+            }
+            cv.wait_for(lk, poll_interval);
+        }
+    }
+
+    bool write(T && data) {
+        std::lock_guard<std::mutex> lk(mutex);
+        if (reader_closed.load()) {
+            return false; // broken pipe
+        }
+        queue.push(std::move(data));
+        cv.notify_one();
+        return true;
+    }
+};

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -393,6 +393,12 @@ struct server_pipe {
     std::atomic<bool> writer_closed{false};
     std::atomic<bool> reader_closed{false};
 
+    // 0 = unbounded (default; streaming consumers must not lose data). When > 0, write()
+    // drops the oldest item once the queue is full, bounding memory for consumers that only
+    // care about the latest items (e.g. an MCP session where unread notifications pile up
+    // between requests). Set it before any concurrent use.
+    size_t max_size = 0;
+
     void close_write() {
         writer_closed.store(true, std::memory_order_relaxed);
         cv.notify_all();
@@ -427,6 +433,11 @@ struct server_pipe {
         std::lock_guard<std::mutex> lk(mutex);
         if (reader_closed.load()) {
             return false; // broken pipe
+        }
+        if (max_size > 0) {
+            while (queue.size() >= max_size) {
+                queue.pop(); // drop oldest to stay bounded
+            }
         }
         queue.push(std::move(data));
         cv.notify_one();

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -393,10 +393,8 @@ struct server_pipe {
     std::atomic<bool> writer_closed{false};
     std::atomic<bool> reader_closed{false};
 
-    // 0 = unbounded (default; streaming consumers must not lose data). When > 0, write()
-    // drops the oldest item once the queue is full, bounding memory for consumers that only
-    // care about the latest items (e.g. an MCP session where unread notifications pile up
-    // between requests). Set it before any concurrent use.
+    // 0 = unbounded (default)
+    // > 0, write() drops the oldest item once the queue is full
     size_t max_size = 0;
 
     void close_write() {

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -227,13 +227,35 @@ void server_mcp_stdio::writer_loop() {
 }
 
 void server_mcp_stdio::errlog_loop() {
+    static constexpr size_t ERR_TAIL_MAX = 4096;
+    std::string buf;
     char chunk[4096];
     for (;;) {
         size_t n = fread(chunk, 1, sizeof(chunk), proc->err);
         if (n == 0) {
             break;
         }
-        SRV_DBG("MCP '%s' stderr: %.*s", name.c_str(), (int) n, chunk);
+        buf.append(chunk, n);
+
+        size_t pos;
+        while ((pos = buf.find('\n')) != std::string::npos) {
+            std::string line = buf.substr(0, pos);
+            buf.erase(0, pos + 1);
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            if (line.empty()) {
+                continue;
+            }
+            SRV_DBG("MCP '%s' stderr: %s\n", name.c_str(), line.c_str());
+
+            std::lock_guard<std::mutex> lk(err_mu);
+            err_tail += line;
+            err_tail += '\n';
+            if (err_tail.size() > ERR_TAIL_MAX) {
+                err_tail.erase(0, err_tail.size() - ERR_TAIL_MAX);
+            }
+        }
     }
 }
 

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -86,7 +86,7 @@ static std::string rpc_error_message(const json & resp) {
 }
 
 json server_mcp_transport::send_rpc(const json & request, const std::function<bool()> & should_stop) {
-    if (!to_server.write(json(request))) {
+    if (!to_server.write(request.dump())) {
         return {{"error", {{"code", -32603}, {"message", "transport closed"}}}};
     }
 
@@ -96,8 +96,17 @@ json server_mcp_transport::send_rpc(const json & request, const std::function<bo
         return (should_stop && should_stop()) || std::chrono::steady_clock::now() >= deadline;
     };
 
-    json reply;
-    while (from_server.read(reply, stop)) {
+    std::string frame;
+    while (from_server.read(frame, stop)) {
+        json reply;
+        try {
+            reply = json::parse(frame);
+        } catch (...) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                break;
+            }
+            continue; // skip malformed frame
+        }
         // a message without an id is a notification; a mismatched id is a stale reply from an
         // earlier timed-out request (ids are monotonic, so it can never match a future one)
         if (!has_id || (reply.contains("id") && reply.at("id") == request.at("id"))) {
@@ -139,7 +148,8 @@ bool server_mcp_transport::ensure_init(const std::function<bool()> & should_stop
     }
 
     // notifications/initialized: no id, no reply expected
-    to_server.write({{"jsonrpc", "2.0"}, {"method", "notifications/initialized"}});
+    json notif = {{"jsonrpc", "2.0"}, {"method", "notifications/initialized"}};
+    to_server.write(notif.dump());
 
     initialized = true;
     return true;
@@ -336,13 +346,7 @@ void server_mcp_stdio::reader_loop() {
             if (line.empty()) {
                 continue;
             }
-            json msg;
-            try {
-                msg = json::parse(line);
-            } catch (...) {
-                continue; // skip malformed line
-            }
-            if (!from_server.write(std::move(msg))) {
+            if (!from_server.write(std::move(line))) {
                 return; // consumer gone
             }
         }
@@ -354,11 +358,10 @@ void server_mcp_stdio::reader_loop() {
 
 void server_mcp_stdio::writer_loop() {
     auto should_stop = [this] { return !running.load(); };
-    json msg;
+    std::string msg;
     while (to_server.read(msg, should_stop)) {
-        std::string data = msg.dump();
-        data.push_back('\n');
-        if (fwrite(data.data(), 1, data.size(), proc->in) != data.size() || fflush(proc->in) != 0) {
+        msg.push_back('\n');
+        if (fwrite(msg.data(), 1, msg.size(), proc->in) != msg.size() || fflush(proc->in) != 0) {
             break; // child gone
         }
     }

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -1,6 +1,16 @@
 #include "server-mcp.h"
 
+#include <sheredom/subprocess.h>
+
+#include <cstdio>
+#include <cstring>
 #include <fstream>
+
+#if defined(_WIN32)
+#  include <windows.h>
+#else
+extern char ** environ;
+#endif
 
 //
 // server_mcp_server_config
@@ -54,6 +64,197 @@ std::vector<server_mcp_server_config> server_mcp_server_config::parse_cursor_for
 
     return result;
 }
+
+
+//
+// server_mcp_stdio
+//
+
+struct server_mcp_stdio::process_handle {
+    subprocess_s sp;
+    FILE * in  = nullptr; // child stdin
+    FILE * out = nullptr; // child stdout
+    FILE * err = nullptr; // child stderr
+};
+
+static std::vector<std::string> mcp_parent_env() {
+    std::vector<std::string> env;
+#if defined(_WIN32)
+    LPCH block = GetEnvironmentStringsA();
+    if (block) {
+        for (LPCH e = block; *e; e += strlen(e) + 1) {
+            env.emplace_back(e);
+        }
+        FreeEnvironmentStringsA(block);
+    }
+#else
+    if (environ) {
+        for (char ** e = environ; *e; ++e) {
+            env.emplace_back(*e);
+        }
+    }
+#endif
+    return env;
+}
+
+// parent env with the config overrides applied, in "KEY=VALUE" form
+static std::vector<std::string> mcp_build_env(const std::map<std::string, std::string> & overrides) {
+    std::vector<std::string> env;
+    for (auto & e : mcp_parent_env()) {
+        size_t eq = e.find('=');
+        std::string key = eq == std::string::npos ? e : e.substr(0, eq);
+        if (overrides.find(key) == overrides.end()) {
+            env.push_back(e);
+        }
+    }
+    for (auto & [k, v] : overrides) {
+        env.push_back(k + "=" + v);
+    }
+    return env;
+}
+
+server_mcp_stdio::server_mcp_stdio(const server_mcp_server_config & config) : config(config) {
+    name = config.name;
+    timeout_ms = config.timeout_ms;
+}
+
+server_mcp_stdio::~server_mcp_stdio() {
+    join_pumps();
+}
+
+bool server_mcp_stdio::start() {
+    std::vector<std::string> argv_s;
+    argv_s.push_back(config.command);
+    argv_s.insert(argv_s.end(), config.args.begin(), config.args.end());
+
+    int options = subprocess_option_no_window | subprocess_option_search_user_path;
+    std::vector<std::string> envp_s;
+    if (config.env.empty()) {
+        options |= subprocess_option_inherit_environment;
+    } else {
+        envp_s = mcp_build_env(config.env);
+    }
+
+    auto to_ptrs = [](std::vector<std::string> & v) {
+        std::vector<const char *> p;
+        p.reserve(v.size() + 1);
+        for (auto & s : v) {
+            p.push_back(s.c_str());
+        }
+        p.push_back(nullptr);
+        return p;
+    };
+    auto argv = to_ptrs(argv_s);
+    auto envp = to_ptrs(envp_s);
+
+    auto handle = std::make_unique<process_handle>();
+    int rc = subprocess_create_ex(argv.data(), options,
+                                  config.env.empty() ? nullptr : envp.data(),
+                                  config.cwd.empty() ? nullptr : config.cwd.c_str(),
+                                  &handle->sp);
+    if (rc != 0) {
+        SRV_WRN("MCP '%s': failed to spawn '%s'\n", config.name.c_str(), config.command.c_str());
+        return false;
+    }
+    handle->in  = subprocess_stdin(&handle->sp);
+    handle->out = subprocess_stdout(&handle->sp);
+    handle->err = subprocess_stderr(&handle->sp);
+
+    proc = std::move(handle);
+    running.store(true);
+    reader = std::thread([this] { reader_loop(); });
+    writer = std::thread([this] { writer_loop(); });
+    errlog = std::thread([this] { errlog_loop(); });
+    return true;
+}
+
+void server_mcp_stdio::close() {
+    join_pumps();
+}
+
+bool server_mcp_stdio::is_alive() const {
+    return running.load();
+}
+
+void server_mcp_stdio::reader_loop() {
+    std::string buf;
+    char chunk[4096];
+    for (;;) {
+        size_t n = fread(chunk, 1, sizeof(chunk), proc->out);
+        if (n == 0) {
+            break; // EOF or error
+        }
+        buf.append(chunk, n);
+
+        size_t pos;
+        while ((pos = buf.find('\n')) != std::string::npos) {
+            std::string line = buf.substr(0, pos);
+            buf.erase(0, pos + 1);
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            if (line.empty()) {
+                continue;
+            }
+            json msg;
+            try {
+                msg = json::parse(line);
+            } catch (...) {
+                continue; // skip malformed line
+            }
+            if (!from_server.write(std::move(msg))) {
+                return; // consumer gone
+            }
+        }
+    }
+    running.store(false);
+    to_server.close_write();   // stop the writer
+    from_server.close_write(); // EOF to any waiting caller
+}
+
+void server_mcp_stdio::writer_loop() {
+    auto should_stop = [this] { return !running.load(); };
+    json msg;
+    while (to_server.read(msg, should_stop)) {
+        std::string data = msg.dump();
+        data.push_back('\n');
+        if (fwrite(data.data(), 1, data.size(), proc->in) != data.size() || fflush(proc->in) != 0) {
+            break; // child gone
+        }
+    }
+    running.store(false);
+    from_server.close_write();
+}
+
+void server_mcp_stdio::errlog_loop() {
+    char chunk[4096];
+    for (;;) {
+        size_t n = fread(chunk, 1, sizeof(chunk), proc->err);
+        if (n == 0) {
+            break;
+        }
+        SRV_DBG("MCP '%s' stderr: %.*s", name.c_str(), (int) n, chunk);
+    }
+}
+
+void server_mcp_stdio::join_pumps() {
+    if (!proc) {
+        return;
+    }
+    running.store(false);
+    to_server.close_write();   // wake the writer if it waits for a message
+    from_server.close_write(); // wake any caller waiting for a reply
+
+    subprocess_terminate(&proc->sp); // child death unblocks the blocked fread/fwrite
+
+    if (writer.joinable()) writer.join();
+    if (reader.joinable()) reader.join();
+    if (errlog.joinable()) errlog.join();
+
+    subprocess_destroy(&proc->sp); // safe now: no thread touches the FILE* anymore
+    proc.reset();
+}
+
 
 //
 // server_mcp

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -1,0 +1,187 @@
+#include "server-mcp.h"
+
+#include <fstream>
+
+//
+// server_mcp_server_config
+//
+
+std::vector<server_mcp_server_config> server_mcp_server_config::parse_from_file(const std::string & path) {
+    std::ifstream f(path);
+    if (!f) {
+        throw std::runtime_error("failed to open MCP config file: " + path);
+    }
+    json j;
+    f >> j;
+    return parse_cursor_format(j);
+}
+
+std::vector<server_mcp_server_config> server_mcp_server_config::parse_from_json(const std::string & json_str) {
+    return parse_cursor_format(json::parse(json_str));
+}
+
+std::vector<server_mcp_server_config> server_mcp_server_config::parse_cursor_format(const json & j) {
+    std::vector<server_mcp_server_config> result;
+
+    if (!j.contains("mcpServers") || !j.at("mcpServers").is_object()) {
+        return result;
+    }
+
+    for (const auto & [name, cfg] : j.at("mcpServers").items()) {
+        server_mcp_server_config sc;
+        sc.name = name;
+        sc.command = cfg.value("command", std::string());
+        sc.cwd = cfg.value("cwd", std::string());
+        sc.timeout_ms = cfg.value("timeout_ms", sc.timeout_ms);
+
+        if (cfg.contains("args") && cfg.at("args").is_array()) {
+            for (const auto & a : cfg.at("args")) {
+                sc.args.push_back(a.get<std::string>());
+            }
+        }
+        if (cfg.contains("env") && cfg.at("env").is_object()) {
+            for (const auto & [k, v] : cfg.at("env").items()) {
+                sc.env[k] = v.get<std::string>();
+            }
+        }
+
+        if (sc.command.empty()) {
+            SRV_WRN("MCP server '%s' has no command, skipping\n", name.c_str());
+            continue;
+        }
+        result.push_back(std::move(sc));
+    }
+
+    return result;
+}
+
+//
+// server_mcp
+//
+
+static constexpr int MCP_COOLDOWN_SECONDS = 5;
+
+server_mcp::server_mcp(std::vector<server_mcp_server_config> configs)
+    : configs(std::move(configs)) {}
+
+server_mcp::~server_mcp() {
+    shutdown();
+
+    std::vector<std::shared_ptr<server_mcp_transport>> to_close;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        for (auto & [name, t] : transports) {
+            to_close.push_back(std::move(t));
+        }
+        transports.clear();
+    }
+    for (auto & t : to_close) {
+        t->close();
+    }
+}
+
+std::shared_ptr<server_mcp_transport> server_mcp::create_transport(const server_mcp_server_config & cfg) {
+    return std::make_shared<server_mcp_stdio>(cfg);
+}
+
+void server_mcp::shutdown() {
+    stopping.store(true);
+}
+
+const server_mcp_server_config * server_mcp::find_config(const std::string & name) const {
+    for (const auto & c : configs) {
+        if (c.name == name) {
+            return &c;
+        }
+    }
+    return nullptr;
+}
+
+void server_mcp::start() {
+    auto should_stop = [this]() { return stopping.load(); };
+
+    std::vector<server_mcp_tool_def> discovered;
+    for (const auto & cfg : configs) {
+        auto t = create_transport(cfg);
+        if (!t->start()) {
+            SRV_WRN("MCP warmup: failed to spawn '%s'\n", cfg.name.c_str());
+            continue;
+        }
+        auto tools = t->list_tools(should_stop);
+        SRV_INF("MCP warmup: '%s' discovered %zu tools\n", cfg.name.c_str(), tools.size());
+        discovered.insert(discovered.end(), tools.begin(), tools.end());
+        t->close();
+    }
+
+    std::lock_guard<std::mutex> lock(mutex);
+    registry.swap(discovered);
+}
+
+std::vector<server_mcp_tool_def> server_mcp::list_tools() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return registry;
+}
+
+json server_mcp::call_tool(const std::string & server_name,
+                           const std::string & tool_name,
+                           const json & arguments,
+                           const std::function<bool()> & should_stop) {
+    auto transport = get_or_create(server_name);
+    if (!transport) {
+        return {{"error", "MCP server unavailable: " + server_name}};
+    }
+
+    auto stop = [this, &should_stop]() {
+        return stopping.load() || (should_stop && should_stop());
+    };
+    return transport->call_tool(tool_name, arguments, stop);
+}
+
+std::shared_ptr<server_mcp_transport> server_mcp::get_or_create(const std::string & name) {
+    std::vector<std::shared_ptr<server_mcp_transport>> to_close; // closed after unlock
+    std::shared_ptr<server_mcp_transport> result;
+
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (stopping.load()) {
+            return nullptr;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        auto dead_it = dead_servers.find(name);
+        if (dead_it != dead_servers.end()) {
+            if (now < dead_it->second) {
+                return nullptr;
+            }
+            dead_servers.erase(dead_it);
+        }
+
+        auto it = transports.find(name);
+        if (it != transports.end()) {
+            if (it->second->is_alive()) {
+                return it->second;
+            }
+            to_close.push_back(std::move(it->second));
+            transports.erase(it);
+        }
+
+        const server_mcp_server_config * cfg = find_config(name);
+        if (cfg) {
+            auto fresh = create_transport(*cfg);
+            if (fresh->start() && fresh->is_alive()) {
+                transports[name] = fresh;
+                result = fresh;
+            } else {
+                to_close.push_back(std::move(fresh));
+                dead_servers[name] = now + std::chrono::seconds(MCP_COOLDOWN_SECONDS);
+            }
+        }
+    }
+
+    for (auto & t : to_close) {
+        t->close(); // blocking call, no leaks
+    }
+
+    return result;
+}
+

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -67,6 +67,146 @@ std::vector<server_mcp_server_config> server_mcp_server_config::parse_cursor_for
 
 
 //
+// server_mcp_transport
+//
+
+static constexpr const char * MCP_PROTOCOL_VERSION = "2024-11-05";
+
+static std::string rpc_error_message(const json & resp) {
+    if (resp.contains("error")) {
+        const json & e = resp.at("error");
+        if (e.is_object()) {
+            return e.value("message", "unknown error");
+        }
+        if (e.is_string()) {
+            return e.get<std::string>();
+        }
+    }
+    return "unknown error";
+}
+
+json server_mcp_transport::send_rpc(const json & request, const std::function<bool()> & should_stop) {
+    if (!to_server.write(json(request))) {
+        return {{"error", {{"code", -32603}, {"message", "transport closed"}}}};
+    }
+
+    const bool has_id = request.contains("id");
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    auto stop = [&]() {
+        return (should_stop && should_stop()) || std::chrono::steady_clock::now() >= deadline;
+    };
+
+    json reply;
+    while (from_server.read(reply, stop)) {
+        // a message without an id is a notification; a mismatched id is a stale reply from an
+        // earlier timed-out request (ids are monotonic, so it can never match a future one)
+        if (!has_id || (reply.contains("id") && reply.at("id") == request.at("id"))) {
+            return reply;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            break; // a flood of notifications must not outrun the deadline
+        }
+    }
+
+    if (should_stop && should_stop()) {
+        return {{"error", {{"code", -32603}, {"message", "cancelled"}}}};
+    }
+    if (std::chrono::steady_clock::now() >= deadline) {
+        return {{"error", {{"code", -32603}, {"message", "request timed out"}}}};
+    }
+    return {{"error", {{"code", -32603}, {"message", "transport closed"}}}};
+}
+
+bool server_mcp_transport::ensure_init(const std::function<bool()> & should_stop) {
+    if (initialized) {
+        return true;
+    }
+
+    json init_req = {
+        {"jsonrpc", "2.0"},
+        {"id", next_id++},
+        {"method", "initialize"},
+        {"params", {
+            {"protocolVersion", MCP_PROTOCOL_VERSION},
+            {"capabilities", json::object()},
+            {"clientInfo", {{"name", "llama.cpp"}, {"version", "1.0"}}},
+        }},
+    };
+    json resp = send_rpc(init_req, should_stop);
+    if (!resp.contains("result")) {
+        last_error = "initialize failed: " + rpc_error_message(resp);
+        return false;
+    }
+
+    // notifications/initialized: no id, no reply expected
+    to_server.write({{"jsonrpc", "2.0"}, {"method", "notifications/initialized"}});
+
+    initialized = true;
+    return true;
+}
+
+bool server_mcp_transport::handshake(const std::function<bool()> & should_stop) {
+    std::lock_guard<std::mutex> lock(rpc_mutex);
+    return ensure_init(should_stop);
+}
+
+std::vector<server_mcp_tool_def> server_mcp_transport::list_tools(const std::function<bool()> & should_stop) {
+    std::lock_guard<std::mutex> lock(rpc_mutex);
+    if (!ensure_init(should_stop)) {
+        return {};
+    }
+    if (!tools.empty()) {
+        return tools;
+    }
+
+    json req = {{"jsonrpc", "2.0"}, {"id", next_id++}, {"method", "tools/list"}};
+    json resp = send_rpc(req, should_stop);
+    if (!resp.contains("result")) {
+        last_error = "tools/list failed: " + rpc_error_message(resp);
+        return {};
+    }
+
+    const json & result = resp.at("result");
+    if (result.contains("tools") && result.at("tools").is_array()) {
+        for (const auto & t : result.at("tools")) {
+            server_mcp_tool_def def;
+            def.server_name = name;
+            def.name = t.value("name", "");
+            def.description = t.value("description", "");
+            if (t.contains("inputSchema")) {
+                def.input_schema = t.at("inputSchema");
+            }
+            tools.push_back(std::move(def));
+        }
+    }
+    return tools;
+}
+
+json server_mcp_transport::call_tool(const std::string & tool_name,
+                                     const json & arguments,
+                                     const std::function<bool()> & should_stop) {
+    std::lock_guard<std::mutex> lock(rpc_mutex);
+    if (!ensure_init(should_stop)) {
+        return {{"error", last_error}};
+    }
+
+    json req = {
+        {"jsonrpc", "2.0"},
+        {"id", next_id++},
+        {"method", "tools/call"},
+        {"params", {{"name", tool_name}, {"arguments", arguments}}},
+    };
+    json resp = send_rpc(req, should_stop);
+    if (resp.contains("error")) {
+        return resp;
+    }
+    if (resp.contains("result")) {
+        return resp.at("result");
+    }
+    return {{"error", {{"code", -32603}, {"message", "invalid response"}}}};
+}
+
+//
 // server_mcp_stdio
 //
 
@@ -223,7 +363,8 @@ void server_mcp_stdio::writer_loop() {
         }
     }
     running.store(false);
-    from_server.close_write();
+    to_server.close_read();    // fail fast on any further send_rpc write
+    from_server.close_write(); // wake any caller waiting for a reply
 }
 
 void server_mcp_stdio::errlog_loop() {

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <fstream>
 #include <functional>
+#include <sstream>
 #include <thread>
 
 #if defined(_WIN32)
@@ -108,16 +109,6 @@ static void mcp_pump_ndjson(FILE * f, std::atomic<bool> & running,
 //
 // server_mcp_server_config
 //
-
-std::vector<server_mcp_server_config> server_mcp_server_config::parse_from_file(const std::string & path) {
-    std::ifstream f(path);
-    if (!f) {
-        throw std::runtime_error("failed to open MCP config file: " + path);
-    }
-    json j;
-    f >> j;
-    return parse_cursor_format(j);
-}
 
 std::vector<server_mcp_server_config> server_mcp_server_config::parse_from_json(const std::string & json_str) {
     return parse_cursor_format(json::parse(json_str));
@@ -625,8 +616,19 @@ void server_mcp_stdio::join_pumps() {
 
 static constexpr int MCP_COOLDOWN_SECONDS = 5;
 
-server_mcp::server_mcp(std::vector<server_mcp_server_config> configs)
-    : configs(std::move(configs)) {}
+void server_mcp::init(std::ifstream file) {
+    if (!file) {
+        throw std::runtime_error("failed to open MCP config file");
+    }
+    std::stringstream ss;
+    ss << file.rdbuf();
+    init(ss.str());
+}
+
+void server_mcp::init(const std::string & json_str) {
+    auto parsed = server_mcp_server_config::parse_from_json(json_str);
+    configs.insert(configs.end(), std::make_move_iterator(parsed.begin()), std::make_move_iterator(parsed.end()));
+}
 
 server_mcp::~server_mcp() {
     shutdown();
@@ -662,6 +664,10 @@ const server_mcp_server_config * server_mcp::find_config(const std::string & nam
 }
 
 void server_mcp::start() {
+    if (configs.empty()) {
+        return;
+    }
+
     auto should_stop = [this]() { return stopping.load(); };
 
     std::vector<server_mcp_tool_def> discovered;

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -2,15 +2,112 @@
 
 #include <sheredom/subprocess.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <functional>
+#include <thread>
 
 #if defined(_WIN32)
+#  include <io.h>
 #  include <windows.h>
 #else
+#  include <errno.h>
+#  include <fcntl.h>
+#  include <poll.h>
+#  include <unistd.h>
 extern char ** environ;
 #endif
+
+// Read NDJSON lines from a child pipe (stdout or stderr), invoking on_line for each complete
+// line, until `running` clears, EOF, an error, or on_line returns false. The read is polled with
+// a short timeout instead of blocking, so teardown (which clears `running`) is never held hostage
+// by a process the MCP server spawned that inherited the pipe's write end and keeps it open --
+// subprocess_terminate() only SIGKILLs the direct child, so a surviving grandchild would leave a
+// blocking read waiting forever for an EOF that never comes.
+static void mcp_pump_ndjson(FILE * f, std::atomic<bool> & running,
+                            const std::function<bool(std::string &&)> & on_line) {
+    if (!f) {
+        return;
+    }
+    const int poll_ms = 50;
+#if defined(_WIN32)
+    HANDLE h = (HANDLE) _get_osfhandle(_fileno(f));
+#else
+    int fd = fileno(f);
+    int fl = fcntl(fd, F_GETFL, 0);
+    if (fl >= 0) {
+        fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+    }
+#endif
+    std::string buf;
+    char        chunk[4096];
+    while (running.load()) {
+        size_t n = 0;
+#if defined(_WIN32)
+        DWORD avail = 0;
+        if (!PeekNamedPipe(h, NULL, 0, NULL, &avail, NULL)) {
+            break; // pipe broken / child gone
+        }
+        if (avail == 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(poll_ms));
+            continue;
+        }
+        DWORD to_read = avail < (DWORD) sizeof(chunk) ? avail : (DWORD) sizeof(chunk);
+        DWORD got     = 0;
+        if (!ReadFile(h, chunk, to_read, &got, NULL) || got == 0) {
+            break;
+        }
+        n = (size_t) got;
+#else
+        struct pollfd pfd;
+        pfd.fd      = fd;
+        pfd.events  = POLLIN;
+        pfd.revents = 0;
+        int pr      = poll(&pfd, 1, poll_ms);
+        if (pr < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            break;
+        }
+        if (pr == 0) {
+            continue; // timeout -> re-check running
+        }
+        if (pfd.revents & (POLLERR | POLLNVAL)) {
+            break;
+        }
+        ssize_t r = read(fd, chunk, sizeof(chunk));
+        if (r < 0) {
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;
+            }
+            break;
+        }
+        if (r == 0) {
+            break; // EOF: child (and any pipe writers) closed the stream
+        }
+        n = (size_t) r;
+#endif
+        buf.append(chunk, n);
+        size_t pos;
+        while ((pos = buf.find('\n')) != std::string::npos) {
+            std::string line = buf.substr(0, pos);
+            buf.erase(0, pos + 1);
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            if (line.empty()) {
+                continue;
+            }
+            if (!on_line(std::move(line))) {
+                return;
+            }
+        }
+    }
+}
 
 //
 // server_mcp_server_config
@@ -227,15 +324,92 @@ struct server_mcp_stdio::process_handle {
     FILE * err = nullptr; // child stderr
 };
 
+#if defined(_WIN32)
+// MCP config strings are UTF-8 (they come from a JSON document) and the vendored subprocess.h
+// spawns via CreateProcessW after a CP_UTF8 -> wide conversion, so everything handed to it -- env
+// included -- must be UTF-8, never the active code page.
+static std::wstring mcp_utf8_to_wide(const std::string & s) {
+    if (s.empty()) {
+        return std::wstring();
+    }
+    int n = MultiByteToWideChar(CP_UTF8, 0, s.data(), (int) s.size(), NULL, 0);
+    if (n <= 0) {
+        return std::wstring();
+    }
+    std::wstring w((size_t) n, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.data(), (int) s.size(), &w[0], n);
+    return w;
+}
+
+static std::string mcp_wide_to_utf8(const wchar_t * s, int len /* -1 for NUL-terminated */) {
+    int n = WideCharToMultiByte(CP_UTF8, 0, s, len, NULL, 0, NULL, NULL);
+    if (n <= 0) {
+        return std::string();
+    }
+    std::string out((size_t) n, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, s, len, &out[0], n, NULL, NULL);
+    if (len == -1 && !out.empty() && out.back() == '\0') {
+        out.pop_back(); // drop the terminator WideCharToMultiByte counts for -1
+    }
+    return out;
+}
+
+// CreateProcess (subprocess.h passes lpApplicationName = NULL) only appends ".exe" to an
+// extensionless command and never consults PATHEXT, so a "command": "npx" (npm ships npx.cmd,
+// never npx.exe) fails on Windows though it works on POSIX, where posix_spawnp does a PATH search.
+// Resolve through PATHEXT ourselves so both platforms accept the same Cursor-format config.
+static std::string mcp_resolve_command_windows(const std::string & command) {
+    std::wstring wcmd = mcp_utf8_to_wide(command);
+    wchar_t      buf[MAX_PATH * 4];
+    const DWORD  cap = (DWORD) (sizeof(buf) / sizeof(buf[0]));
+
+    auto search = [&](const wchar_t * ext) -> std::string {
+        DWORD n = SearchPathW(NULL, wcmd.c_str(), ext, cap, buf, NULL);
+        return (n > 0 && n < cap) ? mcp_wide_to_utf8(buf, (int) n) : std::string();
+    };
+
+    std::string found = search(NULL); // exact path / already-extensioned / .exe on PATH
+    if (!found.empty()) {
+        return found;
+    }
+
+    std::wstring pathext;
+    DWORD        need = GetEnvironmentVariableW(L"PATHEXT", NULL, 0);
+    if (need > 0) {
+        pathext.resize(need);
+        DWORD got = GetEnvironmentVariableW(L"PATHEXT", &pathext[0], need);
+        pathext.resize(got);
+    }
+    if (pathext.empty()) {
+        pathext = L".COM;.EXE;.BAT;.CMD";
+    }
+    for (size_t start = 0; start <= pathext.size();) {
+        size_t       sep = pathext.find(L';', start);
+        std::wstring ext = pathext.substr(start, sep == std::wstring::npos ? std::wstring::npos : sep - start);
+        if (!ext.empty()) {
+            found = search(ext.c_str());
+            if (!found.empty()) {
+                return found;
+            }
+        }
+        if (sep == std::wstring::npos) {
+            break;
+        }
+        start = sep + 1;
+    }
+    return command; // give up and let subprocess.h report the spawn error
+}
+#endif // _WIN32
+
 static std::vector<std::string> mcp_parent_env() {
     std::vector<std::string> env;
 #if defined(_WIN32)
-    LPCH block = GetEnvironmentStringsA();
+    LPWCH block = GetEnvironmentStringsW();
     if (block) {
-        for (LPCH e = block; *e; e += strlen(e) + 1) {
-            env.emplace_back(e);
+        for (LPWCH e = block; *e; e += wcslen(e) + 1) {
+            env.emplace_back(mcp_wide_to_utf8(e, -1));
         }
-        FreeEnvironmentStringsA(block);
+        FreeEnvironmentStringsW(block);
     }
 #else
     if (environ) {
@@ -266,6 +440,9 @@ static std::vector<std::string> mcp_build_env(const std::map<std::string, std::s
 server_mcp_stdio::server_mcp_stdio(const server_mcp_server_config & config) : config(config) {
     name = config.name;
     timeout_ms = config.timeout_ms;
+    // bound the reply queue: a server that streams unsolicited notifications while no request is
+    // in flight would otherwise grow it without limit (send_rpc only drains during a call)
+    from_server.max_size = 65536;
 }
 
 server_mcp_stdio::~server_mcp_stdio() {
@@ -274,7 +451,11 @@ server_mcp_stdio::~server_mcp_stdio() {
 
 bool server_mcp_stdio::start() {
     std::vector<std::string> argv_s;
+#if defined(_WIN32)
+    argv_s.push_back(mcp_resolve_command_windows(config.command));
+#else
     argv_s.push_back(config.command);
+#endif
     argv_s.insert(argv_s.end(), config.args.begin(), config.args.end());
 
     int options = subprocess_option_no_window | subprocess_option_search_user_path;
@@ -327,33 +508,79 @@ bool server_mcp_stdio::is_alive() const {
 }
 
 void server_mcp_stdio::reader_loop() {
-    std::string buf;
-    char chunk[4096];
-    for (;;) {
-        size_t n = fread(chunk, 1, sizeof(chunk), proc->out);
-        if (n == 0) {
-            break; // EOF or error
-        }
-        buf.append(chunk, n);
-
-        size_t pos;
-        while ((pos = buf.find('\n')) != std::string::npos) {
-            std::string line = buf.substr(0, pos);
-            buf.erase(0, pos + 1);
-            if (!line.empty() && line.back() == '\r') {
-                line.pop_back();
-            }
-            if (line.empty()) {
-                continue;
-            }
-            if (!from_server.write(std::move(line))) {
-                return; // consumer gone
-            }
-        }
-    }
+    mcp_pump_ndjson(proc->out, running, [this](std::string && line) {
+        return from_server.write(std::move(line)); // false => consumer gone, stop
+    });
     running.store(false);
     to_server.close_write();   // stop the writer
     from_server.close_write(); // EOF to any waiting caller
+}
+
+// Write all of `data` to the child's stdin without letting teardown hang: non-blocking write,
+// polled for writability, bailing if `running` clears (e.g. the child died but a grandchild holds
+// the stdin read end, leaving a full pipe with no reader). Returns false on error/close/shutdown.
+static bool mcp_write_all(FILE * f, const std::string & data, std::atomic<bool> & running) {
+    if (!f) {
+        return false;
+    }
+    size_t total = 0;
+#if defined(_WIN32)
+    HANDLE h      = (HANDLE) _get_osfhandle(_fileno(f));
+    DWORD  nowait = PIPE_NOWAIT;
+    SetNamedPipeHandleState(h, &nowait, NULL, NULL);
+    while (total < data.size() && running.load()) {
+        DWORD written = 0;
+        BOOL  ok      = WriteFile(h, data.data() + total, (DWORD) (data.size() - total), &written, NULL);
+        if (ok && written > 0) {
+            total += written;
+            continue;
+        }
+        if (!ok) {
+            DWORD err = GetLastError();
+            if (err != ERROR_NO_DATA && err != ERROR_PIPE_BUSY) {
+                return false;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+#else
+    int fd = fileno(f);
+    int fl = fcntl(fd, F_GETFL, 0);
+    if (fl >= 0) {
+        fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+    }
+    while (total < data.size() && running.load()) {
+        ssize_t n = write(fd, data.data() + total, data.size() - total);
+        if (n > 0) {
+            total += (size_t) n;
+            continue;
+        }
+        if (n == 0) {
+            return false;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            return false;
+        }
+        struct pollfd pfd;
+        pfd.fd      = fd;
+        pfd.events  = POLLOUT;
+        pfd.revents = 0;
+        int pr      = poll(&pfd, 1, 50);
+        if (pr < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return false;
+        }
+        if (pfd.revents & (POLLERR | POLLNVAL | POLLHUP)) {
+            return false;
+        }
+    }
+#endif
+    return total == data.size();
 }
 
 void server_mcp_stdio::writer_loop() {
@@ -361,8 +588,8 @@ void server_mcp_stdio::writer_loop() {
     std::string msg;
     while (to_server.read(msg, should_stop)) {
         msg.push_back('\n');
-        if (fwrite(msg.data(), 1, msg.size(), proc->in) != msg.size() || fflush(proc->in) != 0) {
-            break; // child gone
+        if (!mcp_write_all(proc->in, msg, running)) {
+            break; // child gone or shutting down
         }
     }
     running.store(false);
@@ -372,35 +599,20 @@ void server_mcp_stdio::writer_loop() {
 
 void server_mcp_stdio::errlog_loop() {
     static constexpr size_t ERR_TAIL_MAX = 4096;
-    std::string buf;
-    char chunk[4096];
-    for (;;) {
-        size_t n = fread(chunk, 1, sizeof(chunk), proc->err);
-        if (n == 0) {
-            break;
+    // stderr is the MCP server's only diagnostic channel: stdout is reserved for the JSON-RPC
+    // stream, so anything the server wants to log goes here. Drain it (an undrained stderr pipe
+    // would eventually block the child), forward it to the debug log, and keep a bounded tail for
+    // reporting when the server dies.
+    mcp_pump_ndjson(proc->err, running, [this](std::string && line) {
+        SRV_DBG("MCP '%s' stderr: %s\n", name.c_str(), line.c_str());
+        std::lock_guard<std::mutex> lk(err_mu);
+        err_tail += line;
+        err_tail += '\n';
+        if (err_tail.size() > ERR_TAIL_MAX) {
+            err_tail.erase(0, err_tail.size() - ERR_TAIL_MAX);
         }
-        buf.append(chunk, n);
-
-        size_t pos;
-        while ((pos = buf.find('\n')) != std::string::npos) {
-            std::string line = buf.substr(0, pos);
-            buf.erase(0, pos + 1);
-            if (!line.empty() && line.back() == '\r') {
-                line.pop_back();
-            }
-            if (line.empty()) {
-                continue;
-            }
-            SRV_DBG("MCP '%s' stderr: %s\n", name.c_str(), line.c_str());
-
-            std::lock_guard<std::mutex> lk(err_mu);
-            err_tail += line;
-            err_tail += '\n';
-            if (err_tail.size() > ERR_TAIL_MAX) {
-                err_tail.erase(0, err_tail.size() - ERR_TAIL_MAX);
-            }
-        }
-    }
+        return true;
+    });
 }
 
 void server_mcp_stdio::join_pumps() {

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -5,7 +5,6 @@
 #include <atomic>
 #include <chrono>
 #include <cstdio>
-#include <cstring>
 #include <fstream>
 #include <functional>
 #include <sstream>
@@ -651,8 +650,15 @@ const server_mcp_server_config * server_mcp::find_config(const std::string & nam
 
 void server_mcp::start(const common_params & params) {
     auto append = [this](const std::string & json_str) {
-        auto parsed = server_mcp_server_config::parse_from_json(json_str);
-        configs.insert(configs.end(), std::make_move_iterator(parsed.begin()), std::make_move_iterator(parsed.end()));
+        try {
+            auto parsed = server_mcp_server_config::parse_from_json(json_str);
+            if (parsed.empty()) {
+                SRV_WRN("%s", "MCP config: no servers found in JSON\n");
+            }
+            configs.insert(configs.end(), std::make_move_iterator(parsed.begin()), std::make_move_iterator(parsed.end()));
+        } catch (const std::exception & e) {
+            throw std::runtime_error(std::string("failed to parse MCP config JSON: ") + e.what());
+        }
     };
     if (!params.mcp_servers_config.empty()) {
         std::ifstream f = fs_open_ifstream(params.mcp_servers_config, std::ios::in);

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -616,20 +616,6 @@ void server_mcp_stdio::join_pumps() {
 
 static constexpr int MCP_COOLDOWN_SECONDS = 5;
 
-void server_mcp::init(std::ifstream file) {
-    if (!file) {
-        throw std::runtime_error("failed to open MCP config file");
-    }
-    std::stringstream ss;
-    ss << file.rdbuf();
-    init(ss.str());
-}
-
-void server_mcp::init(const std::string & json_str) {
-    auto parsed = server_mcp_server_config::parse_from_json(json_str);
-    configs.insert(configs.end(), std::make_move_iterator(parsed.begin()), std::make_move_iterator(parsed.end()));
-}
-
 server_mcp::~server_mcp() {
     shutdown();
 
@@ -663,7 +649,24 @@ const server_mcp_server_config * server_mcp::find_config(const std::string & nam
     return nullptr;
 }
 
-void server_mcp::start() {
+void server_mcp::start(const common_params & params) {
+    auto append = [this](const std::string & json_str) {
+        auto parsed = server_mcp_server_config::parse_from_json(json_str);
+        configs.insert(configs.end(), std::make_move_iterator(parsed.begin()), std::make_move_iterator(parsed.end()));
+    };
+    if (!params.mcp_servers_config.empty()) {
+        std::ifstream f = fs_open_ifstream(params.mcp_servers_config, std::ios::in);
+        if (!f) {
+            throw std::runtime_error("failed to open MCP config file: " + params.mcp_servers_config);
+        }
+        std::stringstream ss;
+        ss << f.rdbuf();
+        append(ss.str());
+    }
+    if (!params.mcp_servers_json.empty()) {
+        append(params.mcp_servers_json);
+    }
+
     if (configs.empty()) {
         return;
     }

--- a/tools/server/server-mcp.cpp
+++ b/tools/server/server-mcp.cpp
@@ -21,12 +21,8 @@
 extern char ** environ;
 #endif
 
-// Read NDJSON lines from a child pipe (stdout or stderr), invoking on_line for each complete
-// line, until `running` clears, EOF, an error, or on_line returns false. The read is polled with
-// a short timeout instead of blocking, so teardown (which clears `running`) is never held hostage
-// by a process the MCP server spawned that inherited the pipe's write end and keeps it open --
-// subprocess_terminate() only SIGKILLs the direct child, so a surviving grandchild would leave a
-// blocking read waiting forever for an EOF that never comes.
+// read NDJSON lines from a child pipe, calling on_line per line until `running` clears, EOF/error, or on_line returns false.
+// polled, not blocking: a grandchild can inherit the pipe's write end and hold it open (terminate() kills only the direct child), so a blocking read would hang teardown on an EOF that never comes.
 static void mcp_pump_ndjson(FILE * f, std::atomic<bool> & running,
                             const std::function<bool(std::string &&)> & on_line) {
     if (!f) {
@@ -204,8 +200,7 @@ json server_mcp_transport::send_rpc(const json & request, const std::function<bo
             }
             continue; // skip malformed frame
         }
-        // a message without an id is a notification; a mismatched id is a stale reply from an
-        // earlier timed-out request (ids are monotonic, so it can never match a future one)
+        // no id: a notification. mismatched id: a stale reply from a timed-out request (ids are monotonic, never a future one)
         if (!has_id || (reply.contains("id") && reply.at("id") == request.at("id"))) {
             return reply;
         }
@@ -325,10 +320,8 @@ struct server_mcp_stdio::process_handle {
 };
 
 #if defined(_WIN32)
-// MCP config strings are UTF-8 (they come from a JSON document) and the vendored subprocess.h
-// spawns via CreateProcessW after a CP_UTF8 -> wide conversion, so everything handed to it -- env
-// included -- must be UTF-8, never the active code page.
-static std::wstring mcp_utf8_to_wide(const std::string & s) {
+// config strings are UTF-8 (from JSON) and subprocess.h converts them with CP_UTF8, so inputs must be UTF-8, not the active code page
+static std::wstring windows_utf8_to_wide(const std::string & s) {
     if (s.empty()) {
         return std::wstring();
     }
@@ -341,7 +334,7 @@ static std::wstring mcp_utf8_to_wide(const std::string & s) {
     return w;
 }
 
-static std::string mcp_wide_to_utf8(const wchar_t * s, int len /* -1 for NUL-terminated */) {
+static std::string windows_wide_to_utf8(const wchar_t * s, int len /* -1 for NUL-terminated */) {
     int n = WideCharToMultiByte(CP_UTF8, 0, s, len, NULL, 0, NULL, NULL);
     if (n <= 0) {
         return std::string();
@@ -353,19 +346,18 @@ static std::string mcp_wide_to_utf8(const wchar_t * s, int len /* -1 for NUL-ter
     }
     return out;
 }
+#endif
 
-// CreateProcess (subprocess.h passes lpApplicationName = NULL) only appends ".exe" to an
-// extensionless command and never consults PATHEXT, so a "command": "npx" (npm ships npx.cmd,
-// never npx.exe) fails on Windows though it works on POSIX, where posix_spawnp does a PATH search.
-// Resolve through PATHEXT ourselves so both platforms accept the same Cursor-format config.
-static std::string mcp_resolve_command_windows(const std::string & command) {
-    std::wstring wcmd = mcp_utf8_to_wide(command);
+static std::string mcp_resolve_command(const std::string & command) {
+#if defined(_WIN32)
+    // For Windows: make sure we handle ".exe" correctly, as well as UTF-8
+    std::wstring wcmd = windows_utf8_to_wide(command);
     wchar_t      buf[MAX_PATH * 4];
     const DWORD  cap = (DWORD) (sizeof(buf) / sizeof(buf[0]));
 
     auto search = [&](const wchar_t * ext) -> std::string {
         DWORD n = SearchPathW(NULL, wcmd.c_str(), ext, cap, buf, NULL);
-        return (n > 0 && n < cap) ? mcp_wide_to_utf8(buf, (int) n) : std::string();
+        return (n > 0 && n < cap) ? windows_wide_to_utf8(buf, (int) n) : std::string();
     };
 
     std::string found = search(NULL); // exact path / already-extensioned / .exe on PATH
@@ -398,8 +390,10 @@ static std::string mcp_resolve_command_windows(const std::string & command) {
         start = sep + 1;
     }
     return command; // give up and let subprocess.h report the spawn error
-}
+#else
+    return command;
 #endif // _WIN32
+}
 
 static std::vector<std::string> mcp_parent_env() {
     std::vector<std::string> env;
@@ -407,7 +401,7 @@ static std::vector<std::string> mcp_parent_env() {
     LPWCH block = GetEnvironmentStringsW();
     if (block) {
         for (LPWCH e = block; *e; e += wcslen(e) + 1) {
-            env.emplace_back(mcp_wide_to_utf8(e, -1));
+            env.emplace_back(windows_wide_to_utf8(e, -1));
         }
         FreeEnvironmentStringsW(block);
     }
@@ -440,8 +434,7 @@ static std::vector<std::string> mcp_build_env(const std::map<std::string, std::s
 server_mcp_stdio::server_mcp_stdio(const server_mcp_server_config & config) : config(config) {
     name = config.name;
     timeout_ms = config.timeout_ms;
-    // bound the reply queue: a server that streams unsolicited notifications while no request is
-    // in flight would otherwise grow it without limit (send_rpc only drains during a call)
+    // bound the reply queue: send_rpc only drains during a call, so unsolicited notifications would otherwise grow it without limit
     from_server.max_size = 65536;
 }
 
@@ -451,11 +444,7 @@ server_mcp_stdio::~server_mcp_stdio() {
 
 bool server_mcp_stdio::start() {
     std::vector<std::string> argv_s;
-#if defined(_WIN32)
-    argv_s.push_back(mcp_resolve_command_windows(config.command));
-#else
-    argv_s.push_back(config.command);
-#endif
+    argv_s.push_back(mcp_resolve_command(config.command));
     argv_s.insert(argv_s.end(), config.args.begin(), config.args.end());
 
     int options = subprocess_option_no_window | subprocess_option_search_user_path;
@@ -516,9 +505,7 @@ void server_mcp_stdio::reader_loop() {
     from_server.close_write(); // EOF to any waiting caller
 }
 
-// Write all of `data` to the child's stdin without letting teardown hang: non-blocking write,
-// polled for writability, bailing if `running` clears (e.g. the child died but a grandchild holds
-// the stdin read end, leaving a full pipe with no reader). Returns false on error/close/shutdown.
+// write all of `data` to child stdin, non-blocking and polled so teardown never hangs (a grandchild can hold the read end of a full pipe open). returns false on error/close/shutdown.
 static bool mcp_write_all(FILE * f, const std::string & data, std::atomic<bool> & running) {
     if (!f) {
         return false;
@@ -599,10 +586,8 @@ void server_mcp_stdio::writer_loop() {
 
 void server_mcp_stdio::errlog_loop() {
     static constexpr size_t ERR_TAIL_MAX = 4096;
-    // stderr is the MCP server's only diagnostic channel: stdout is reserved for the JSON-RPC
-    // stream, so anything the server wants to log goes here. Drain it (an undrained stderr pipe
-    // would eventually block the child), forward it to the debug log, and keep a bounded tail for
-    // reporting when the server dies.
+    // drain stderr (an undrained pipe blocks the child):
+    // log it, and keep a bounded tail for reporting when the server dies
     mcp_pump_ndjson(proc->err, running, [this](std::string && line) {
         SRV_DBG("MCP '%s' stderr: %s\n", name.c_str(), line.c_str());
         std::lock_guard<std::mutex> lk(err_mu);

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -1,0 +1,165 @@
+#pragma once
+
+// Experimental MCP (Model Context Protocol) client support for llama-server.
+// See MCP_SERVER_SPEC.md for the behavioral contract.
+//
+//   server_mcp           - manager, owns the configured servers and their tools
+//   server_mcp_transport - one MCP server session (abstract), JSON-RPC 2.0
+//   server_mcp_stdio     - child process speaking NDJSON JSON-RPC over stdio
+//
+// Blocking I/O lives on the transport's worker threads; callers touch only the in-process queues.
+// Shutdown is RAII and blocking (~server_mcp joins everything), so no async-signal-safe path is needed.
+
+#include "server-common.h"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+//
+// Configuration (Cursor-compatible "mcpServers" JSON)
+//
+
+struct server_mcp_server_config {
+    std::string name; // config key, e.g. "filesystem"
+    std::string command;
+    std::vector<std::string> args;
+    std::map<std::string, std::string> env; // merged over the parent env
+    std::string cwd;
+    int timeout_ms = 30000; // per-tool-call timeout
+
+    // from_file/from_json throw on I/O or parse errors; a missing "mcpServers" yields an empty list, and entries without a "command" are skipped
+    static std::vector<server_mcp_server_config> parse_from_file(const std::string & path);
+    static std::vector<server_mcp_server_config> parse_from_json(const std::string & json_str);
+    static std::vector<server_mcp_server_config> parse_cursor_format(const json & j);
+};
+
+// a tool advertised by an MCP server
+struct server_mcp_tool_def {
+    std::string server_name;
+    std::string name; // bare tool name, no "<server>_" prefix
+    std::string description;
+    json input_schema; // JSON Schema for the arguments, or null
+};
+
+//
+// server_mcp_transport: one MCP server session over a message conduit.
+//
+//   caller --send_rpc--> to_server   --[writer thread]--> server stdin
+//   caller <--send_rpc-- from_server <--[reader thread]-- server stdout
+//
+// The base runs the JSON-RPC session; a subclass only pumps I/O into/out of the two queues.
+//
+
+struct server_mcp_transport {
+    std::string name;
+    int timeout_ms = 30000;
+
+    server_pipe<json> to_server;
+    server_pipe<json> from_server;
+
+    virtual ~server_mcp_transport() = default;
+
+    virtual bool start() = 0;
+    virtual void close() = 0; // blocking and idempotent
+    virtual bool is_alive() const = 0; // never blocks behind an in-flight send_rpc()
+
+    bool handshake(const std::function<bool()> & should_stop);
+
+    std::vector<server_mcp_tool_def> list_tools(const std::function<bool()> & should_stop);
+
+    json call_tool(const std::string & tool_name,
+                   const json & arguments,
+                   const std::function<bool()> & should_stop);
+
+protected:
+    // per-transport, not shared: send_rpc() holds it across the wait for a reply, so a shared lock would stall every server behind one slow call
+    // all members below are touched only under it
+    std::mutex rpc_mutex;
+    uint64_t next_id = 1; // reset to 1 per (re)spawn
+    bool initialized = false;
+    std::string last_error;
+    std::vector<server_mcp_tool_def> tools;
+
+    // returns the matching reply, or an {"error": ...} object
+    json send_rpc(const json & request, const std::function<bool()> & should_stop);
+};
+
+//
+// server_mcp_stdio: child process, NDJSON JSON-RPC over stdio (stderr inherited)
+//
+
+struct server_mcp_stdio : server_mcp_transport {
+    explicit server_mcp_stdio(const server_mcp_server_config & config);
+    ~server_mcp_stdio() override;
+
+    bool start() override;
+    void close() override;
+    bool is_alive() const override;
+
+private:
+    server_mcp_server_config config;
+
+    // defined in the .cpp so <windows.h> stays out of this header
+    struct process_handle;
+    std::unique_ptr<process_handle> proc;
+
+    std::thread reader; // child stdout -> NDJSON framing -> from_server
+    std::thread writer; // to_server -> child stdin
+
+    // cleared by close() or by the reader on stdout EOF; read without rpc_mutex
+    std::atomic<bool> running{false};
+
+    void reader_loop();
+    void writer_loop();
+    void join_pumps();
+};
+
+//
+// server_mcp
+// manager lives inside main_server(); declare it before the HTTP context so it outlives every /tools handler.
+//
+
+class server_mcp {
+public:
+    explicit server_mcp(std::vector<server_mcp_server_config> configs);
+    ~server_mcp();
+
+    // spawn each server once, list its tools, shut it down. failures are logged, not fatal.
+    void start();
+
+    std::vector<server_mcp_tool_def> list_tools() const;
+
+    // lazily (re)spawns the transport. returns the MCP result or an {"error": ...} object. should_stop is OR-ed with the manager's cancel flag.
+    json call_tool(const std::string & server_name,
+                   const std::string & tool_name,
+                   const json & arguments,
+                   const std::function<bool()> & should_stop = nullptr);
+
+    // flip the cancel flag so in-flight calls return; blocking teardown is in the destructor. call before the HTTP server drains.
+    void shutdown();
+
+private:
+    std::vector<server_mcp_server_config> configs;
+
+    mutable std::mutex mutex; // guards transports, dead_servers, registry
+    std::map<std::string, std::shared_ptr<server_mcp_transport>> transports;
+    std::map<std::string, std::chrono::steady_clock::time_point> dead_servers; // spawn-failure cooldown
+    std::vector<server_mcp_tool_def> registry;
+
+    std::atomic<bool> stopping{false};
+
+    const server_mcp_server_config * find_config(const std::string & name) const;
+
+    // the only place that names a concrete transport
+    std::shared_ptr<server_mcp_transport> create_transport(const server_mcp_server_config & cfg);
+
+    // nullptr during cooldown or shutdown
+    std::shared_ptr<server_mcp_transport> get_or_create(const std::string & name);
+};

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -112,12 +112,14 @@ private:
 
     std::thread reader; // child stdout -> NDJSON framing -> from_server
     std::thread writer; // to_server -> child stdin
+    std::thread errlog; // child stderr -> debug log (must be drained or the child blocks)
 
     // cleared by close() or by the reader on stdout EOF; read without rpc_mutex
     std::atomic<bool> running{false};
 
     void reader_loop();
     void writer_loop();
+    void errlog_loop();
     void join_pumps();
 };
 

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -87,8 +87,9 @@ protected:
     std::string last_error;
     std::vector<server_mcp_tool_def> tools;
 
-    // returns the matching reply, or an {"error": ...} object
-    json send_rpc(const json & request, const std::function<bool()> & should_stop);
+    // both assume rpc_mutex is already held by the public caller
+    bool ensure_init(const std::function<bool()> & should_stop); // initialize handshake, once
+    json send_rpc(const json & request, const std::function<bool()> & should_stop); // returns the reply, or an {"error": ...} object
 };
 
 //

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -1,15 +1,5 @@
 #pragma once
 
-// Experimental MCP (Model Context Protocol) client support for llama-server.
-// See MCP_SERVER_SPEC.md for the behavioral contract.
-//
-//   server_mcp           - manager, owns the configured servers and their tools
-//   server_mcp_transport - one MCP server session (abstract), JSON-RPC 2.0
-//   server_mcp_stdio     - child process speaking NDJSON JSON-RPC over stdio
-//
-// Blocking I/O lives on the transport's worker threads; callers touch only the in-process queues.
-// Shutdown is RAII and blocking (~server_mcp joins everything), so no async-signal-safe path is needed.
-
 #include "server-common.h"
 
 #include <atomic>
@@ -49,20 +39,21 @@ struct server_mcp_tool_def {
 };
 
 //
-// server_mcp_transport: one MCP server session over a message conduit.
+// server_mcp_transport: one MCP server session.
 //
-//   caller --send_rpc--> to_server   --[writer thread]--> server stdin
-//   caller <--send_rpc-- from_server <--[reader thread]-- server stdout
+//   caller --send_rpc--> to_server   --[writer]--> framing --> server
+//   caller <--send_rpc-- from_server <--[reader]-- framing <-- server
 //
-// The base runs the JSON-RPC session; a subclass only pumps I/O into/out of the two queues.
+// Each queue item is one complete serialized JSON message
+// A subclass owns the byte I/O and framing (stdio: NDJSON); the base owns json (parse/dump) and the JSON-RPC session (handshake, id correlation).
 //
 
 struct server_mcp_transport {
     std::string name;
     int timeout_ms = 30000;
 
-    server_pipe<json> to_server;
-    server_pipe<json> from_server;
+    server_pipe<std::string> to_server;   // serialized messages we send to the server
+    server_pipe<std::string> from_server; // serialized messages read from the server
 
     virtual ~server_mcp_transport() = default;
 
@@ -79,8 +70,7 @@ struct server_mcp_transport {
                    const std::function<bool()> & should_stop);
 
 protected:
-    // per-transport, not shared: send_rpc() holds it across the wait for a reply, so a shared lock would stall every server behind one slow call
-    // all members below are touched only under it
+    // per-transport, not shared: send_rpc() holds it across the wait for a reply, so a shared lock would stall every server behind one slow call all members below are touched only under it
     std::mutex rpc_mutex;
     uint64_t next_id = 1; // reset to 1 per (re)spawn
     bool initialized = false;
@@ -111,8 +101,8 @@ private:
     struct process_handle;
     std::unique_ptr<process_handle> proc;
 
-    std::thread reader; // child stdout -> NDJSON framing -> from_server
-    std::thread writer; // to_server -> child stdin
+    std::thread reader; // child stdout -> NDJSON de-framing -> from_server
+    std::thread writer; // to_server -> NDJSON framing -> child stdin
     std::thread errlog; // child stderr -> debug log (must be drained or the child blocks)
 
     // cleared by close() or by the reader on stdout EOF; read without rpc_mutex

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -117,6 +117,10 @@ private:
     // cleared by close() or by the reader on stdout EOF; read without rpc_mutex
     std::atomic<bool> running{false};
 
+    // bounded tail of the child's stderr, for diagnostics when it dies
+    std::mutex err_mu;
+    std::string err_tail;
+
     void reader_loop();
     void writer_loop();
     void errlog_loop();

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <fstream>
 #include <functional>
 #include <map>
 #include <memory>
@@ -24,8 +25,7 @@ struct server_mcp_server_config {
     std::string cwd;
     int timeout_ms = 30000; // per-tool-call timeout
 
-    // throw on I/O or parse errors; missing "mcpServers" yields an empty list; entries without a "command" are skipped
-    static std::vector<server_mcp_server_config> parse_from_file(const std::string & path);
+    // throw on parse errors; missing "mcpServers" yields an empty list; entries without a "command" are skipped
     static std::vector<server_mcp_server_config> parse_from_json(const std::string & json_str);
     static std::vector<server_mcp_server_config> parse_cursor_format(const json & j);
 };
@@ -125,8 +125,15 @@ private:
 
 class server_mcp {
 public:
-    explicit server_mcp(std::vector<server_mcp_server_config> configs);
+    server_mcp() = default;
     ~server_mcp();
+
+    // parse Cursor-format JSON and append the servers it declares; throws on parse errors
+    void init(std::ifstream file); // reads the whole stream, then forwards to init(json_str)
+    void init(const std::string & json_str);
+
+    // true until init() has added at least one server
+    bool empty() const { return configs.empty(); }
 
     // spawn each server once, list its tools, shut it down. failures are logged, not fatal.
     void start();
@@ -140,6 +147,7 @@ public:
                    const std::function<bool()> & should_stop = nullptr);
 
     // flip the cancel flag so in-flight calls return; blocking teardown is in the destructor. call before the HTTP server drains.
+    // multiple calls are idempotent
     void shutdown();
 
 private:

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -4,7 +4,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <fstream>
 #include <functional>
 #include <map>
 #include <memory>
@@ -128,15 +127,13 @@ public:
     server_mcp() = default;
     ~server_mcp();
 
-    // parse Cursor-format JSON and append the servers it declares; throws on parse errors
-    void init(std::ifstream file); // reads the whole stream, then forwards to init(json_str)
-    void init(const std::string & json_str);
+    // parse the MCP config from params (file and/or inline JSON),
+    // then spawn each server once,  list its tools, and shut it down
+    // throws on config parse errors; spawn failures are logged.
+    void start(const common_params & params);
 
-    // true until init() has added at least one server
+    // true until start() has parsed at least one server from the config
     bool empty() const { return configs.empty(); }
-
-    // spawn each server once, list its tools, shut it down. failures are logged, not fatal.
-    void start();
 
     std::vector<server_mcp_tool_def> list_tools() const;
 
@@ -147,7 +144,7 @@ public:
                    const std::function<bool()> & should_stop = nullptr);
 
     // flip the cancel flag so in-flight calls return; blocking teardown is in the destructor. call before the HTTP server drains.
-    // multiple calls are idempotent
+    // note: multiple calls are idempotent
     void shutdown();
 
 private:

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -151,6 +151,8 @@ private:
     std::vector<server_mcp_server_config> configs;
 
     mutable std::mutex mutex; // guards transports, dead_servers, registry
+
+    // shared_ptr: call_tool() hands a transport to the caller and drops the lock for the blocking RPC, so a concurrent evict/respawn must not destroy it mid-call
     std::map<std::string, std::shared_ptr<server_mcp_transport>> transports;
     std::map<std::string, std::chrono::steady_clock::time_point> dead_servers; // spawn-failure cooldown
     std::vector<server_mcp_tool_def> registry;

--- a/tools/server/server-mcp.h
+++ b/tools/server/server-mcp.h
@@ -24,7 +24,7 @@ struct server_mcp_server_config {
     std::string cwd;
     int timeout_ms = 30000; // per-tool-call timeout
 
-    // from_file/from_json throw on I/O or parse errors; a missing "mcpServers" yields an empty list, and entries without a "command" are skipped
+    // throw on I/O or parse errors; missing "mcpServers" yields an empty list; entries without a "command" are skipped
     static std::vector<server_mcp_server_config> parse_from_file(const std::string & path);
     static std::vector<server_mcp_server_config> parse_from_json(const std::string & json_str);
     static std::vector<server_mcp_server_config> parse_cursor_format(const json & j);
@@ -44,8 +44,8 @@ struct server_mcp_tool_def {
 //   caller --send_rpc--> to_server   --[writer]--> framing --> server
 //   caller <--send_rpc-- from_server <--[reader]-- framing <-- server
 //
-// Each queue item is one complete serialized JSON message
-// A subclass owns the byte I/O and framing (stdio: NDJSON); the base owns json (parse/dump) and the JSON-RPC session (handshake, id correlation).
+// each queue item is one complete serialized JSON message.
+// subclass owns byte I/O and framing; base owns JSON and the JSON-RPC session (handshake, id correlation).
 //
 
 struct server_mcp_transport {
@@ -70,7 +70,7 @@ struct server_mcp_transport {
                    const std::function<bool()> & should_stop);
 
 protected:
-    // per-transport, not shared: send_rpc() holds it across the wait for a reply, so a shared lock would stall every server behind one slow call all members below are touched only under it
+    // per-transport: send_rpc() holds it across the reply wait, so sharing it would stall every server behind one slow call. guards all members below.
     std::mutex rpc_mutex;
     uint64_t next_id = 1; // reset to 1 per (re)spawn
     bool initialized = false;
@@ -79,11 +79,11 @@ protected:
 
     // both assume rpc_mutex is already held by the public caller
     bool ensure_init(const std::function<bool()> & should_stop); // initialize handshake, once
-    json send_rpc(const json & request, const std::function<bool()> & should_stop); // returns the reply, or an {"error": ...} object
+    json send_rpc(const json & request, const std::function<bool()> & should_stop); // returns the reply or an {"error": ...}
 };
 
 //
-// server_mcp_stdio: child process, NDJSON JSON-RPC over stdio (stderr inherited)
+// server_mcp_stdio: child process, NDJSON JSON-RPC over stdio (stderr drained to the debug log)
 //
 
 struct server_mcp_stdio : server_mcp_transport {
@@ -120,7 +120,7 @@ private:
 
 //
 // server_mcp
-// manager lives inside main_server(); declare it before the HTTP context so it outlives every /tools handler.
+// declare before the HTTP context so it outlives every /tools handler.
 //
 
 class server_mcp {
@@ -133,7 +133,7 @@ public:
 
     std::vector<server_mcp_tool_def> list_tools() const;
 
-    // lazily (re)spawns the transport. returns the MCP result or an {"error": ...} object. should_stop is OR-ed with the manager's cancel flag.
+    // lazily (re)spawns the transport. returns the MCP result or an {"error": ...}. should_stop is OR-ed with the manager's cancel flag.
     json call_tool(const std::string & server_name,
                    const std::string & tool_name,
                    const json & arguments,

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -852,7 +852,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
         //                so that we can use stdout for commands and stderr for logging
         int options = subprocess_option_no_window | subprocess_option_combined_stdout_stderr;
         inst.subproc->sproc.emplace();
-        int result = subprocess_create_ex(argv.data(), options, envp.data(), &inst.subproc->get());
+        int result = subprocess_create_ex(argv.data(), options, envp.data(), nullptr, &inst.subproc->get());
         if (result != 0) {
             throw std::runtime_error("failed to spawn server instance");
         }

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1944,53 +1944,6 @@ void server_models_routes::init_routes() {
 // server_http_proxy
 //
 
-// simple implementation of a pipe
-// used for streaming data between threads
-template<typename T>
-struct pipe_t {
-    std::mutex mutex;
-    std::condition_variable cv;
-    std::queue<T> queue;
-    std::atomic<bool> writer_closed{false};
-    std::atomic<bool> reader_closed{false};
-    void close_write() {
-        writer_closed.store(true, std::memory_order_relaxed);
-        cv.notify_all();
-    }
-    void close_read() {
-        reader_closed.store(true, std::memory_order_relaxed);
-        cv.notify_all();
-    }
-    bool read(T & output, const std::function<bool()> & should_stop) {
-        std::unique_lock<std::mutex> lk(mutex);
-        constexpr auto poll_interval = std::chrono::milliseconds(500);
-        while (true) {
-            if (!queue.empty()) {
-                output = std::move(queue.front());
-                queue.pop();
-                return true;
-            }
-            if (writer_closed.load()) {
-                return false; // clean EOF
-            }
-            if (should_stop()) {
-                close_read(); // signal broken pipe to writer
-                return false; // cancelled / reader no longer alive
-            }
-            cv.wait_for(lk, poll_interval);
-        }
-    }
-    bool write(T && data) {
-        std::lock_guard<std::mutex> lk(mutex);
-        if (reader_closed.load()) {
-            return false; // broken pipe
-        }
-        queue.push(std::move(data));
-        cv.notify_one();
-        return true;
-    }
-};
-
 static std::string to_lower_copy(const std::string & value) {
     std::string lowered(value.size(), '\0');
     std::transform(value.begin(), value.end(), lowered.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -2100,7 +2053,7 @@ server_http_proxy::server_http_proxy(
         ) {
     // shared between reader and writer threads
     auto cli  = std::make_shared<httplib::ClientImpl>(host, port);
-    auto pipe = std::make_shared<pipe_t<msg_t>>();
+    auto pipe = std::make_shared<server_pipe<msg_t>>();
 
     if (scheme == "https") {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <unordered_set>
 #include <functional>
+#include <memory>
 
 namespace fs = std::filesystem;
 
@@ -24,7 +25,7 @@ json server_tool::to_json() const {
     return {
         {"display_name", display_name},
         {"tool", name},
-        {"type", "builtin"},
+        {"type", type()},
         {"permissions", json{
             {"write", permission_write}
         }},
@@ -1102,6 +1103,60 @@ struct server_tools_res : server_http_res {
     }
 };
 
+//
+// server_mcp_tool: exposes one tool from a running MCP server as a server_tool.
+// Invocation delegates to server_mcp::call_tool, which lazily (re)spawns the transport.
+//
+struct server_mcp_tool : server_tool {
+    std::string        server_name;
+    std::string        tool_name;
+    server_mcp_tool_def def;
+    // non-owning: the manager is owned by a shared_ptr in llama_server() and outlives every tool
+    // invocation (the HTTP server is drained before it is destroyed in clean_up())
+    server_mcp * mcp_mgr = nullptr;
+
+    server_mcp_tool(server_mcp_tool_def d, server_mcp * mgr)
+        : server_name(d.server_name)
+        , tool_name(d.name)
+        , def(std::move(d))
+        , mcp_mgr(mgr)
+    {
+        name = server_name + "_" + tool_name;
+        display_name = name;
+        permission_write = false;
+        support_stream = false;
+    }
+
+    std::string type() const override { return "mcp"; }
+
+    json get_definition() const override {
+        json schema = def.input_schema;
+        if (schema.is_null() || !schema.is_object()) {
+            schema = json::object();
+        }
+        return {
+            {"type", "function"},
+            {"function", {
+                {"name", name},
+                {"description", def.description},
+                {"parameters", schema},
+            }},
+        };
+    }
+
+    json invoke(json params, server_tool::stream * st) const override {
+        if (!mcp_mgr) {
+            return {{"error", "MCP manager not available"}};
+        }
+        // pass the caller's liveness through so a disconnect cancels the in-flight RPC
+        std::function<bool()> should_stop = nullptr;
+        if (st) {
+            should_stop = [st]() { return !st->alive(); };
+        }
+        return mcp_mgr->call_tool(server_name, tool_name, params, should_stop);
+    }
+};
+
 static server_tool & find_tool(std::vector<std::unique_ptr<server_tool>> & tools, const std::string & name, bool require_stream) {
     for (auto & t : tools) {
         if (t->name == name) {
@@ -1130,7 +1185,8 @@ static std::vector<std::unique_ptr<server_tool>> build_tools() {
     return tools;
 }
 
-void server_tools::setup(const std::vector<std::string> & enabled_tools) {
+void server_tools::setup(const std::vector<std::string> & enabled_tools,
+                         server_mcp * mcp_mgr) {
     if (!enabled_tools.empty()) {
         std::unordered_set<std::string> enabled_set(enabled_tools.begin(), enabled_tools.end());
         auto all_tools = build_tools();
@@ -1158,6 +1214,30 @@ void server_tools::setup(const std::vector<std::string> & enabled_tools) {
             if (enabled_set.count(t->name) > 0 || enabled_set.count("all") > 0) {
                 tools.push_back(std::move(t));
             }
+        }
+    }
+
+    // append MCP tools (discovered during warmup), skipping any that collide with a built-in
+    // or another MCP tool of the same "<server>_<tool>" name
+    if (mcp_mgr) {
+        std::unordered_set<std::string> seen_names;
+        for (auto & t : tools) {
+            seen_names.insert(t->name);
+        }
+        size_t n_added = 0;
+        for (const auto & def : mcp_mgr->list_tools()) {
+            std::string mcp_name = def.server_name + "_" + def.name;
+            if (seen_names.count(mcp_name)) {
+                SRV_WRN("MCP tool \"%s\" from server \"%s\" collides with an existing tool, skipping\n",
+                    mcp_name.c_str(), def.server_name.c_str());
+                continue;
+            }
+            seen_names.insert(mcp_name);
+            tools.push_back(std::make_unique<server_mcp_tool>(def, mcp_mgr));
+            n_added++;
+        }
+        if (n_added > 0) {
+            SRV_INF("Added %zu MCP tools\n", n_added);
         }
     }
 

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <atomic>
 #include <cstring>
-#include <climits>
 #include <algorithm>
 #include <unordered_set>
 #include <functional>

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -1105,17 +1105,14 @@ struct server_tools_res : server_http_res {
 
 //
 // server_mcp_tool: exposes one tool from a running MCP server as a server_tool.
-// Invocation delegates to server_mcp::call_tool, which lazily (re)spawns the transport.
 //
 struct server_mcp_tool : server_tool {
-    std::string        server_name;
-    std::string        tool_name;
+    std::string server_name;
+    std::string tool_name;
     server_mcp_tool_def def;
-    // non-owning: the manager is owned by a shared_ptr in llama_server() and outlives every tool
-    // invocation (the HTTP server is drained before it is destroyed in clean_up())
-    server_mcp * mcp_mgr = nullptr;
+    server_mcp & mcp_mgr;
 
-    server_mcp_tool(server_mcp_tool_def d, server_mcp * mgr)
+    server_mcp_tool(server_mcp_tool_def d, server_mcp & mgr)
         : server_name(d.server_name)
         , tool_name(d.name)
         , def(std::move(d))
@@ -1145,15 +1142,12 @@ struct server_mcp_tool : server_tool {
     }
 
     json invoke(json params, server_tool::stream * st) const override {
-        if (!mcp_mgr) {
-            return {{"error", "MCP manager not available"}};
-        }
         // pass the caller's liveness through so a disconnect cancels the in-flight RPC
         std::function<bool()> should_stop = nullptr;
         if (st) {
             should_stop = [st]() { return !st->alive(); };
         }
-        return mcp_mgr->call_tool(server_name, tool_name, params, should_stop);
+        return mcp_mgr.call_tool(server_name, tool_name, params, should_stop);
     }
 };
 
@@ -1186,7 +1180,7 @@ static std::vector<std::unique_ptr<server_tool>> build_tools() {
 }
 
 void server_tools::setup(const std::vector<std::string> & enabled_tools,
-                         server_mcp * mcp_mgr) {
+                         server_mcp & mcp_mgr) {
     if (!enabled_tools.empty()) {
         std::unordered_set<std::string> enabled_set(enabled_tools.begin(), enabled_tools.end());
         auto all_tools = build_tools();
@@ -1217,15 +1211,14 @@ void server_tools::setup(const std::vector<std::string> & enabled_tools,
         }
     }
 
-    // append MCP tools (discovered during warmup), skipping any that collide with a built-in
-    // or another MCP tool of the same "<server>_<tool>" name
-    if (mcp_mgr) {
+    // append MCP tools, skipping any that collide with a built-in or another MCP tool of the same "<server>_<tool>" name
+    if (!mcp_mgr.empty()) {
         std::unordered_set<std::string> seen_names;
         for (auto & t : tools) {
             seen_names.insert(t->name);
         }
         size_t n_added = 0;
-        for (const auto & def : mcp_mgr->list_tools()) {
+        for (const auto & def : mcp_mgr.list_tools()) {
             std::string mcp_name = def.server_name + "_" + def.name;
             if (seen_names.count(mcp_name)) {
                 SRV_WRN("MCP tool \"%s\" from server \"%s\" collides with an existing tool, skipping\n",

--- a/tools/server/server-tools.h
+++ b/tools/server/server-tools.h
@@ -3,9 +3,11 @@
 #include "server-common.h"
 #include "server-http.h"
 #include "server-queue.h"
+#include "server-mcp.h"
 
 #include <atomic>
 #include <functional>
+#include <memory>
 
 struct server_tool {
     std::string name;
@@ -15,6 +17,7 @@ struct server_tool {
 
     virtual ~server_tool() = default;
     virtual json get_definition() const = 0;
+    virtual std::string type() const { return "builtin"; }
 
     struct stream {
         server_response & qr;
@@ -34,7 +37,8 @@ struct server_tools {
     server_response queue_res;
     std::atomic<int> res_id{0};
 
-    void setup(const std::vector<std::string> & enabled_tools);
+    void setup(const std::vector<std::string> & enabled_tools,
+               server_mcp * mcp_mgr);
 
     server_http_context::handler_t handle_get;
     server_http_context::handler_t handle_post;

--- a/tools/server/server-tools.h
+++ b/tools/server/server-tools.h
@@ -38,7 +38,7 @@ struct server_tools {
     std::atomic<int> res_id{0};
 
     void setup(const std::vector<std::string> & enabled_tools,
-               server_mcp * mcp_mgr);
+               server_mcp & mcp_mgr);
 
     server_http_context::handler_t handle_get;
     server_http_context::handler_t handle_post;

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -88,6 +88,12 @@ static server_http_context::handler_t ex_wrapper(server_http_context::handler_t 
 int llama_server(int argc, char ** argv) {
     std::setlocale(LC_NUMERIC, "C");
 
+#ifndef _WIN32
+    // Ignore SIGPIPE so the server does not crash if an MCP child exits while we are writing to
+    // its stdin; the write returns EPIPE, which the MCP writer treats as the child being gone.
+    signal(SIGPIPE, SIG_IGN);
+#endif
+
     // own arguments required by this example
     common_params params;
 
@@ -326,17 +332,53 @@ int llama_server(common_params & params, int argc, char ** argv) {
         ctx_http.post("/cors-proxy",      ex_wrapper(res_403));
     }
 
-    // EXPERIMENTAL built-in tools
-    if (!params.server_tools.empty()) {
+    // EXPERIMENTAL built-in tools and MCP servers
+    // note: mcp_mgr must outlive the HTTP handlers and the clean_up lambdas below, which is why
+    // it is declared here in the function body rather than inside the block
+    std::shared_ptr<server_mcp> mcp_mgr;
+    const bool has_mcp = !params.mcp_servers_config.empty() || !params.mcp_servers_json.empty();
+
+    if (has_mcp) {
+        std::vector<server_mcp_server_config> mcp_configs;
         try {
-            tools.setup(params.server_tools);
+            if (!params.mcp_servers_config.empty()) {
+                auto file_configs = server_mcp_server_config::parse_from_file(params.mcp_servers_config);
+                mcp_configs.insert(mcp_configs.end(), file_configs.begin(), file_configs.end());
+            }
+            if (!params.mcp_servers_json.empty()) {
+                auto json_configs = server_mcp_server_config::parse_from_json(params.mcp_servers_json);
+                mcp_configs.insert(mcp_configs.end(), json_configs.begin(), json_configs.end());
+            }
+        } catch (const std::exception & e) {
+            SRV_ERR("MCP config parsing failed: %s\n", e.what());
+            return 1;
+        }
+        if (!mcp_configs.empty()) {
+            mcp_mgr = std::make_shared<server_mcp>(std::move(mcp_configs));
+            // warmup: spawn each server once, list its tools, then shut it down
+            try {
+                mcp_mgr->start();
+            } catch (const std::exception & e) {
+                SRV_WRN("MCP warmup failed: %s\n", e.what());
+            }
+        }
+    }
+
+    if (!params.server_tools.empty() || mcp_mgr) {
+        try {
+            tools.setup(params.server_tools, mcp_mgr.get());
         } catch (const std::exception & e) {
             SRV_ERR("tools setup failed: %s\n", e.what());
             return 1;
         }
         ctx_http.get ("/tools",           ex_wrapper(tools.handle_get));
         ctx_http.post("/tools",           ex_wrapper(tools.handle_post));
-        warn_names.push_back("built-in tools (experimental)");
+        if (!params.server_tools.empty()) {
+            warn_names.push_back("built-in tools (experimental)");
+        }
+        if (mcp_mgr) {
+            warn_names.push_back("MCP servers (experimental)");
+        }
     } else {
         ctx_http.get ("/tools",           ex_wrapper(res_403));
         ctx_http.post("/tools",           ex_wrapper(res_403));
@@ -378,13 +420,17 @@ int llama_server(common_params & params, int argc, char ** argv) {
     if (is_router_server) {
         SRV_INF("%s", "starting server in router mode. models will be automatically loaded on-demand\n");
 
-        clean_up = [&models_routes]() {
+        clean_up = [&models_routes, &mcp_mgr]() {
             SRV_INF("%s: cleaning up before exit...\n", __func__);
             // stop the session GC first, it finalizes live sessions and wakes pending readers
             server_stream_session_manager_stop();
             if (models_routes.has_value()) {
                 models_routes->stopping.store(true); // maybe redundant, but just to be safe
                 models_routes->models.unload_all();
+            }
+            if (mcp_mgr) {
+                mcp_mgr->shutdown(); // flip cancel; the reset triggers the blocking teardown
+                mcp_mgr.reset();
             }
             llama_backend_free();
         };
@@ -401,17 +447,26 @@ int llama_server(common_params & params, int argc, char ** argv) {
                 // important to disconnect any SSE clients
                 models_routes->stopping.store(true);
             }
+            // must run before the HTTP server drains: an in-flight MCP tool call would otherwise
+            // hold its handler thread until the RPC times out
+            if (mcp_mgr) {
+                mcp_mgr->shutdown();
+            }
             ctx_http.stop();
         };
 
     } else {
         // setup clean up function, to be called before exit
-        clean_up = [&ctx_http, &ctx_server]() {
+        clean_up = [&ctx_http, &ctx_server, &mcp_mgr]() {
             SRV_INF("%s: cleaning up before exit...\n", __func__);
             // stop the session GC first, it finalizes live sessions and wakes pending readers
             server_stream_session_manager_stop();
             ctx_http.stop();
             ctx_server.terminate();
+            if (mcp_mgr) {
+                mcp_mgr->shutdown(); // flip cancel; the reset triggers the blocking teardown
+                mcp_mgr.reset();
+            }
             llama_backend_free();
         };
 
@@ -444,6 +499,11 @@ int llama_server(common_params & params, int argc, char ** argv) {
         SRV_INF("%s", "model loaded\n");
 
         shutdown_handler = [&](int) {
+            // must run before the HTTP server drains: an in-flight MCP tool call would otherwise
+            // hold its handler thread until the RPC times out
+            if (mcp_mgr) {
+                mcp_mgr->shutdown();
+            }
             // this will unblock start_loop()
             ctx_server.terminate();
         };

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -163,6 +163,9 @@ int llama_server(common_params & params, int argc, char ** argv) {
         params.model_alias.insert(model_name);
     }
 
+    // note: this is guaranteed to out-live ctx_http and tools
+    server_mcp mcp_mgr;
+
     // struct that contains llama context and inference
     server_context ctx_server;
 
@@ -332,24 +335,11 @@ int llama_server(common_params & params, int argc, char ** argv) {
         ctx_http.post("/cors-proxy",      ex_wrapper(res_403));
     }
 
-    server_mcp mcp_mgr;
-    {
-        try {
-            if (!params.mcp_servers_config.empty()) {
-                mcp_mgr.init(fs_open_ifstream(params.mcp_servers_config, std::ios::in));
-            }
-            if (!params.mcp_servers_json.empty()) {
-                mcp_mgr.init(params.mcp_servers_json);
-            }
-        } catch (const std::exception & e) {
-            SRV_ERR("MCP config parsing failed: %s\n", e.what());
-            return 1;
-        }
-        try {
-            mcp_mgr.start();
-        } catch (const std::exception & e) {
-            SRV_WRN("MCP starting failed: %s\n", e.what());
-        }
+    try {
+        mcp_mgr.start(params);
+    } catch (const std::exception & e) {
+        SRV_ERR("MCP config parsing failed: %s\n", e.what());
+        return 1;
     }
 
     if (!params.server_tools.empty() || !mcp_mgr.empty()) {

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -89,8 +89,7 @@ int llama_server(int argc, char ** argv) {
     std::setlocale(LC_NUMERIC, "C");
 
 #ifndef _WIN32
-    // Ignore SIGPIPE so the server does not crash if an MCP child exits while we are writing to
-    // its stdin; the write returns EPIPE, which the MCP writer treats as the child being gone.
+    // Ignore SIGPIPE so the server does not crash if an MCP child exits while we are writing to its stdin
     signal(SIGPIPE, SIG_IGN);
 #endif
 
@@ -338,7 +337,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
     try {
         mcp_mgr.start(params);
     } catch (const std::exception & e) {
-        SRV_ERR("MCP config parsing failed: %s\n", e.what());
+        SRV_ERR("MCP starting failed: %s\n", e.what());
         return 1;
     }
 

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -332,41 +332,29 @@ int llama_server(common_params & params, int argc, char ** argv) {
         ctx_http.post("/cors-proxy",      ex_wrapper(res_403));
     }
 
-    // EXPERIMENTAL built-in tools and MCP servers
-    // note: mcp_mgr must outlive the HTTP handlers and the clean_up lambdas below, which is why
-    // it is declared here in the function body rather than inside the block
-    std::shared_ptr<server_mcp> mcp_mgr;
-    const bool has_mcp = !params.mcp_servers_config.empty() || !params.mcp_servers_json.empty();
-
-    if (has_mcp) {
-        std::vector<server_mcp_server_config> mcp_configs;
+    server_mcp mcp_mgr;
+    {
         try {
             if (!params.mcp_servers_config.empty()) {
-                auto file_configs = server_mcp_server_config::parse_from_file(params.mcp_servers_config);
-                mcp_configs.insert(mcp_configs.end(), file_configs.begin(), file_configs.end());
+                mcp_mgr.init(fs_open_ifstream(params.mcp_servers_config, std::ios::in));
             }
             if (!params.mcp_servers_json.empty()) {
-                auto json_configs = server_mcp_server_config::parse_from_json(params.mcp_servers_json);
-                mcp_configs.insert(mcp_configs.end(), json_configs.begin(), json_configs.end());
+                mcp_mgr.init(params.mcp_servers_json);
             }
         } catch (const std::exception & e) {
             SRV_ERR("MCP config parsing failed: %s\n", e.what());
             return 1;
         }
-        if (!mcp_configs.empty()) {
-            mcp_mgr = std::make_shared<server_mcp>(std::move(mcp_configs));
-            // warmup: spawn each server once, list its tools, then shut it down
-            try {
-                mcp_mgr->start();
-            } catch (const std::exception & e) {
-                SRV_WRN("MCP warmup failed: %s\n", e.what());
-            }
+        try {
+            mcp_mgr.start();
+        } catch (const std::exception & e) {
+            SRV_WRN("MCP starting failed: %s\n", e.what());
         }
     }
 
-    if (!params.server_tools.empty() || mcp_mgr) {
+    if (!params.server_tools.empty() || !mcp_mgr.empty()) {
         try {
-            tools.setup(params.server_tools, mcp_mgr.get());
+            tools.setup(params.server_tools, mcp_mgr);
         } catch (const std::exception & e) {
             SRV_ERR("tools setup failed: %s\n", e.what());
             return 1;
@@ -376,7 +364,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
         if (!params.server_tools.empty()) {
             warn_names.push_back("built-in tools (experimental)");
         }
-        if (mcp_mgr) {
+        if (!mcp_mgr.empty()) {
             warn_names.push_back("MCP servers (experimental)");
         }
     } else {
@@ -428,10 +416,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
                 models_routes->stopping.store(true); // maybe redundant, but just to be safe
                 models_routes->models.unload_all();
             }
-            if (mcp_mgr) {
-                mcp_mgr->shutdown(); // flip cancel; the reset triggers the blocking teardown
-                mcp_mgr.reset();
-            }
+            mcp_mgr.shutdown();
             llama_backend_free();
         };
 
@@ -447,11 +432,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
                 // important to disconnect any SSE clients
                 models_routes->stopping.store(true);
             }
-            // must run before the HTTP server drains: an in-flight MCP tool call would otherwise
-            // hold its handler thread until the RPC times out
-            if (mcp_mgr) {
-                mcp_mgr->shutdown();
-            }
+            mcp_mgr.shutdown();
             ctx_http.stop();
         };
 
@@ -463,10 +444,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
             server_stream_session_manager_stop();
             ctx_http.stop();
             ctx_server.terminate();
-            if (mcp_mgr) {
-                mcp_mgr->shutdown(); // flip cancel; the reset triggers the blocking teardown
-                mcp_mgr.reset();
-            }
+            mcp_mgr.shutdown();
             llama_backend_free();
         };
 
@@ -499,11 +477,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
         SRV_INF("%s", "model loaded\n");
 
         shutdown_handler = [&](int) {
-            // must run before the HTTP server drains: an in-flight MCP tool call would otherwise
-            // hold its handler thread until the RPC times out
-            if (mcp_mgr) {
-                mcp_mgr->shutdown();
-            }
+            mcp_mgr.shutdown();
             // this will unblock start_loop()
             ctx_server.terminate();
         };

--- a/tools/server/tests/fixtures/mcp_burst_server.py
+++ b/tools/server/tests/fixtures/mcp_burst_server.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Minimal MCP server that writes notification + response in a single write() with no flush.
+This reproduces the buffering bug where read_message() can strand the response.
+"""
+import json
+import sys
+import os
+
+TOOLS = [
+    {
+        "name": "echo",
+        "description": "Echo back the input message",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "message": {"type": "string"}
+            },
+            "required": ["message"]
+        }
+    }
+]
+
+def handle_initialize(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "burst-test", "version": "1.0"}
+        }
+    }
+
+def handle_tools_list(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {"tools": TOOLS}
+    }
+
+def handle_tools_call(params, req_id):
+    tool_name = params.get("name")
+    arguments = params.get("arguments", {})
+
+    if tool_name == "echo":
+        message = arguments.get("message", "")
+        notif = {
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": {"progress": 50, "total": 100}
+        }
+        response = {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": f"echo: {message}"}]
+            }
+        }
+        # Single os.write() call: both lines land in one pipe packet atomically.
+        # This is the key difference from mcp_malformed_server.py which flushes between writes.
+        data = (json.dumps(notif) + "\n" + json.dumps(response) + "\n").encode("utf-8")
+        os.write(sys.stdout.fileno(), data)
+        return None  # already written
+    else:
+        response = {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
+        }
+        return response
+
+HANDLERS = {
+    "initialize": handle_initialize,
+    "tools/list": handle_tools_list,
+    "tools/call": handle_tools_call,
+}
+
+# notifications have no id and don't expect a response
+NOTIFICATION_HANDLERS = {
+    "notifications/initialized": lambda params, req_id: None,
+}
+
+def main():
+    # Use line-buffered text mode for regular responses, but the burst write
+    # uses os.write() directly to guarantee a single kernel write().
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", buffering=1)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = request.get("method")
+        req_id = request.get("id")
+        params = request.get("params", {})
+
+        # Check notification handlers first (no response expected)
+        if not req_id and method in NOTIFICATION_HANDLERS:
+            NOTIFICATION_HANDLERS[method](params, req_id)
+            continue
+
+        handler = HANDLERS.get(method)
+        if handler:
+            response = handler(params, req_id)
+            if response is not None:
+                sys.stdout.write(json.dumps(response) + "\n")
+                sys.stdout.flush()
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"}
+            }
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+if __name__ == "__main__":
+    main()

--- a/tools/server/tests/fixtures/mcp_crash_server.py
+++ b/tools/server/tests/fixtures/mcp_crash_server.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+MCP server that crashes after receiving a specific tool call.
+"""
+import json
+import sys
+import os
+
+def handle_initialize(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "crash-test", "version": "1.0"}
+        }
+    }
+
+def handle_tools_list(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "tools": [
+                {
+                    "name": "echo",
+                    "description": "Echo back the input message",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"}
+                        }
+                    }
+                },
+                {
+                    "name": "crash",
+                    "description": "Crash the server",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            ]
+        }
+    }
+
+def handle_tools_call(params, req_id):
+    tool_name = params.get("name")
+    arguments = params.get("arguments", {})
+
+    if tool_name == "echo":
+        message = arguments.get("message", "")
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": f"echo: {message}"}]
+            }
+        }
+    elif tool_name == "crash":
+        # Send a partial response then exit
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": {"content": [{"type": "text", "text": "crashing..."}]}}) + "\n")
+        sys.stdout.flush()
+        os._exit(1)
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
+        }
+
+HANDLERS = {
+    "initialize": handle_initialize,
+    "tools/list": handle_tools_list,
+    "tools/call": handle_tools_call,
+}
+
+def main():
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", buffering=1)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = request.get("method")
+        req_id = request.get("id")
+        params = request.get("params", {})
+
+        # JSON-RPC 2.0: a message without an id is a notification and must not receive a response
+        if req_id is None:
+            continue
+
+        handler = HANDLERS.get(method)
+        if handler:
+            response = handler(params, req_id)
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"}
+            }
+
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+if __name__ == "__main__":
+    main()

--- a/tools/server/tests/fixtures/mcp_echo_server.py
+++ b/tools/server/tests/fixtures/mcp_echo_server.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Minimal MCP server for testing.
+Implements JSON-RPC 2.0 over stdio (line-delimited JSON).
+"""
+import json
+import sys
+import os
+
+# Ensure we use python3 from the current environment
+if sys.platform == "win32":
+    # On Windows, we need to use the same python interpreter
+    pass
+
+TOOLS = [
+    {
+        "name": "echo",
+        "description": "Echo back the input message",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "message": {"type": "string", "description": "Message to echo"}
+            },
+            "required": ["message"]
+        }
+    },
+    {
+        "name": "add",
+        "description": "Add two numbers",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "a": {"type": "number"},
+                "b": {"type": "number"}
+            },
+            "required": ["a", "b"]
+        }
+    },
+    {
+        "name": "fail_once",
+        "description": "Fails on first call, succeeds on subsequent calls",
+        "inputSchema": {
+            "type": "object",
+            "properties": {}
+        }
+    }
+]
+
+_state = {"fail_once_called": False}
+
+def handle_initialize(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "echo-test", "version": "1.0"}
+        }
+    }
+
+def handle_tools_list(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {"tools": TOOLS}
+    }
+
+def handle_tools_call(params, req_id):
+    tool_name = params.get("name")
+    arguments = params.get("arguments", {})
+
+    if tool_name == "echo":
+        message = arguments.get("message", "")
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": f"echo: {message}"}]
+            }
+        }
+    elif tool_name == "add":
+        a = arguments.get("a", 0)
+        b = arguments.get("b", 0)
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": str(a + b)}]
+            }
+        }
+    elif tool_name == "fail_once":
+        if not _state["fail_once_called"]:
+            _state["fail_once_called"] = True
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32000, "message": "transient error"}
+            }
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": "ok"}]
+            }
+        }
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32602, "message": f"Unknown tool: {tool_name}"}
+        }
+
+def handle_ping(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {}
+    }
+
+HANDLERS = {
+    "initialize": handle_initialize,
+    "tools/list": handle_tools_list,
+    "tools/call": handle_tools_call,
+    "ping": handle_ping,
+}
+
+def main():
+    # Use unbuffered output
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", buffering=1)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = request.get("method")
+        req_id = request.get("id")
+        params = request.get("params", {})
+
+        # JSON-RPC 2.0: a message without an id is a notification and must not receive a response
+        if req_id is None:
+            continue
+
+        handler = HANDLERS.get(method)
+        if handler:
+            response = handler(params, req_id)
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"}
+            }
+
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+if __name__ == "__main__":
+    main()

--- a/tools/server/tests/fixtures/mcp_grandchild_server.py
+++ b/tools/server/tests/fixtures/mcp_grandchild_server.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+MCP server (NDJSON JSON-RPC over stdio) that spawns a long-lived grandchild which inherits
+this process's stdin/stdout/stderr and keeps them open.
+
+This reproduces the reader-teardown deadlock: killing the direct MCP child (SIGKILL, which is
+all subprocess_terminate() does) does NOT close the stdout/stderr pipe write ends, because the
+grandchild still holds them. A server that reads those pipes with a blocking read would then
+wait forever for an EOF that never arrives, hanging teardown (both warmup shutdown at startup
+and process shutdown). The polled, running-aware reader must exit regardless.
+"""
+import json
+import os
+import subprocess
+import sys
+
+# Spawn a grandchild that inherits our std handles (fds 0/1/2 = the MCP pipes) and lives well
+# past any teardown in the tests. We do NOT redirect its stdio, so it keeps the pipe write ends
+# open even after this process is killed.
+subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+
+TOOLS = [
+    {
+        "name": "echo",
+        "description": "Echo back the input message",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"message": {"type": "string", "description": "Message to echo"}},
+            "required": ["message"],
+        },
+    }
+]
+
+
+def handle_initialize(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "grandchild-test", "version": "1.0"},
+        },
+    }
+
+
+def handle_tools_list(params, req_id):
+    return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": TOOLS}}
+
+
+def handle_tools_call(params, req_id):
+    if params.get("name") == "echo":
+        message = params.get("arguments", {}).get("message", "")
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"content": [{"type": "text", "text": f"echo: {message}"}]},
+        }
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": "Unknown tool"}}
+
+
+HANDLERS = {
+    "initialize": handle_initialize,
+    "tools/list": handle_tools_list,
+    "tools/call": handle_tools_call,
+}
+
+
+def main():
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", buffering=1)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = request.get("method")
+        req_id = request.get("id")
+        params = request.get("params", {})
+
+        if req_id is None:
+            continue  # notification, no response
+
+        handler = HANDLERS.get(method)
+        if handler:
+            response = handler(params, req_id)
+        else:
+            response = {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": f"Method not found: {method}"}}
+
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/server/tests/fixtures/mcp_malformed_server.py
+++ b/tools/server/tests/fixtures/mcp_malformed_server.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+MCP server that sends malformed responses and notifications during requests.
+"""
+import json
+import sys
+import os
+
+def handle_initialize(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "malformed-test", "version": "1.0"}
+        }
+    }
+
+def handle_tools_list(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "tools": [
+                {
+                    "name": "echo",
+                    "description": "Echo back the input message",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string"}
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+def handle_tools_call(params, req_id):
+    tool_name = params.get("name")
+    arguments = params.get("arguments", {})
+
+    if tool_name == "echo":
+        message = arguments.get("message", "")
+        # Send a notification first (no id field)
+        notif = {
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": {"progress": 50, "total": 100}
+        }
+        sys.stdout.write(json.dumps(notif) + "\n")
+        sys.stdout.flush()
+        # Then send the actual response
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": f"echo: {message}"}]
+            }
+        }
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
+        }
+
+HANDLERS = {
+    "initialize": handle_initialize,
+    "tools/list": handle_tools_list,
+    "tools/call": handle_tools_call,
+}
+
+def main():
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", buffering=1)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            # Send malformed JSON response
+            sys.stdout.write("THIS IS NOT JSON\n")
+            sys.stdout.flush()
+            continue
+
+        method = request.get("method")
+        req_id = request.get("id")
+        params = request.get("params", {})
+
+        handler = HANDLERS.get(method)
+        if handler:
+            response = handler(params, req_id)
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"}
+            }
+
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+if __name__ == "__main__":
+    main()

--- a/tools/server/tests/fixtures/mcp_slow_server.py
+++ b/tools/server/tests/fixtures/mcp_slow_server.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+MCP server that sleeps before responding, for timeout testing.
+"""
+import json
+import sys
+import os
+import time
+import argparse
+
+TOOLS = [
+    {
+        "name": "sleep",
+        "description": "Sleep for a given number of seconds",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "seconds": {"type": "number", "description": "Seconds to sleep"}
+            },
+            "required": ["seconds"]
+        }
+    }
+]
+
+def handle_initialize(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "slow-test", "version": "1.0"}
+        }
+    }
+
+def handle_tools_list(params, req_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {"tools": TOOLS}
+    }
+
+def handle_tools_call(params, req_id):
+    tool_name = params.get("name")
+    arguments = params.get("arguments", {})
+
+    if tool_name == "sleep":
+        seconds = arguments.get("seconds", 1)
+        time.sleep(seconds)
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": f"slept {seconds}s"}]
+            }
+        }
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
+        }
+
+HANDLERS = {
+    "initialize": handle_initialize,
+    "tools/list": handle_tools_list,
+    "tools/call": handle_tools_call,
+}
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--delay", type=float, default=5.0, help="Delay in seconds for sleep tool")
+    args = parser.parse_args()
+
+    # Override the sleep duration
+    global handle_tools_call
+    def handle_tools_call(params, req_id):
+        tool_name = params.get("name")
+        arguments = params.get("arguments", {})
+
+        if tool_name == "sleep":
+            seconds = arguments.get("seconds", args.delay)
+            time.sleep(seconds)
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "content": [{"type": "text", "text": f"slept {seconds}s"}]
+                }
+            }
+        else:
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"}
+            }
+
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", buffering=1)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        method = request.get("method")
+        req_id = request.get("id")
+        params = request.get("params", {})
+
+        # JSON-RPC 2.0: a message without an id is a notification and must not receive a response
+        if req_id is None:
+            continue
+
+        handler = HANDLERS.get(method)
+        if handler:
+            response = handler(params, req_id)
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"}
+            }
+
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+
+if __name__ == "__main__":
+    main()

--- a/tools/server/tests/unit/test_mcp_servers.py
+++ b/tools/server/tests/unit/test_mcp_servers.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+"""
+Tests for MCP server integration via the /tools endpoint.
+
+Invariants verified:
+1. MCP tools appear in /tools listing when configured
+2. MCP tools use <server>:<tool> naming
+3. MCP tools can be invoked and return correct results
+4. Misconfigured MCP servers do not crash the server
+5. Multiple MCP servers can be configured simultaneously
+6. Warmup populates the tool list at startup
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+
+import pytest
+
+from utils import *
+
+# Path to the test MCP server fixture
+FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "fixtures")
+MCP_ECHO_SERVER = os.path.join(FIXTURES_DIR, "mcp_echo_server.py")
+
+server: ServerProcess
+
+
+def _mcp_config_json(servers: dict) -> str:
+    """Create a JSON config string for --mcp-servers-json."""
+    return json.dumps({"mcpServers": servers})
+
+
+def _start_server_with_mcp(mcp_json: str, **kwargs) -> ServerProcess:
+    """Helper to start a router server with MCP config."""
+    srv = ServerPreset.router()
+    srv.server_tools = "all"
+    srv.no_ui = True
+    srv.server_port = 8085  # avoid conflict with load_all() which uses 8080
+    srv.mcp_servers_json = mcp_json
+    for k, v in kwargs.items():
+        setattr(srv, k, v)
+    srv.start()
+    return srv
+
+
+def test_mcp_tools_listed_in_tools_endpoint():
+    """MCP tools should appear in GET /tools with server:tool naming."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+
+        tools = res.body
+        assert isinstance(tools, list), f"Expected list, got {type(tools)}"
+
+        # Find MCP tools - name is in "tool" field or definition.function.name
+        def get_tool_name(t):
+            return t.get("tool", "") or t.get("definition", {}).get("function", {}).get("name", "")
+
+        mcp_tools = [t for t in tools if get_tool_name(t).startswith("echo_")]
+        assert len(mcp_tools) >= 2, f"Expected at least 2 echo_ tools, got {len(mcp_tools)}: {mcp_tools}"
+
+        tool_names = {get_tool_name(t) for t in mcp_tools}
+        assert "echo_echo" in tool_names
+        assert "echo_add" in tool_names
+
+        # Verify tool structure
+        echo_tool = next(t for t in mcp_tools if get_tool_name(t) == "echo_echo")
+        assert "description" in echo_tool or "definition" in echo_tool
+    finally:
+        server.stop()
+
+
+def test_mcp_tool_invocation():
+    """MCP tools should be callable via POST /tools and return correct results."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # Call echo_echo
+        res = server.make_request("POST", "/tools", data={
+            "tool": "echo_echo",
+            "params": {"message": "hello world"}
+        })
+        assert res.status_code == 200, res.body
+        body = res.body
+        assert "error" not in body, body
+        # The result format depends on the tool implementation
+        # For MCP tools, it should contain the tool result
+        assert "plain_text_response" in body or "result" in body or "content" in body, body
+
+        # Call echo_add
+        res = server.make_request("POST", "/tools", data={
+            "tool": "echo_add",
+            "params": {"a": 3, "b": 5}
+        })
+        assert res.status_code == 200, res.body
+        body = res.body
+        assert "error" not in body, body
+    finally:
+        server.stop()
+
+
+def test_mcp_bad_command_does_not_crash():
+    """A misconfigured MCP server should not crash the llama-server."""
+    global server
+    mcp_json = _mcp_config_json({
+        "nonexistent": {
+            "command": "this_executable_does_not_exist_12345",
+            "args": [],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # Server should still be healthy
+        res = server.make_request("GET", "/health")
+        assert res.status_code == 200, res.body
+
+        # Builtin tools should still work
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+        tools = res.body
+        # Should have builtin tools but no MCP tools from the bad server
+        mcp_tools = [t for t in tools if t.get("name", "").startswith("nonexistent_")]
+        assert len(mcp_tools) == 0, f"Expected no nonexistent_ tools, got {mcp_tools}"
+    finally:
+        server.stop()
+
+
+def test_mcp_multiple_servers():
+    """Multiple MCP servers can be configured simultaneously."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        },
+        "echo2": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+
+        tools = res.body
+
+        def get_tool_name(t):
+            return t.get("tool", "") or t.get("definition", {}).get("function", {}).get("name", "")
+
+        echo_tools = [t for t in tools if get_tool_name(t).startswith("echo_")]
+        echo2_tools = [t for t in tools if get_tool_name(t).startswith("echo2_")]
+
+        assert len(echo_tools) >= 2, f"Expected echo_ tools, got {echo_tools}"
+        assert len(echo2_tools) >= 2, f"Expected echo2_ tools, got {echo2_tools}"
+    finally:
+        server.stop()
+
+
+def test_mcp_tools_not_listed_when_not_configured():
+    """Without MCP config, no MCP tools should appear."""
+    global server
+    server = ServerPreset.router()
+    server.server_tools = "all"
+    server.no_ui = True
+    server.server_port = 8085
+    server.start()
+
+    try:
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+
+        tools = res.body
+
+        def get_tool_name(t):
+            return t.get("tool", "") or t.get("definition", {}).get("function", {}).get("name", "")
+
+        # Should only have builtin tools, no server: prefixed tools
+        mcp_tools = [t for t in tools if ":" in get_tool_name(t)]
+        assert len(mcp_tools) == 0, f"Expected no MCP tools, got {mcp_tools}"
+    finally:
+        server.stop()
+
+
+def test_mcp_fail_once_tool_eventual_success():
+    """Test that a tool that fails once eventually succeeds (tests instance respawn)."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # First call should succeed (warmup already spawned and shut down the instance,
+        # but the first actual tool call will spawn a fresh instance)
+        res = server.make_request("POST", "/tools", data={
+            "tool": "echo_fail_once",
+            "params": {}
+        })
+        # It might fail on first call if the warmup instance was shut down
+        # and a new instance is spawned. The fail_once state is per-process,
+        # so a fresh process will fail once then succeed.
+        # Actually, warmup spawns, lists, then shuts down. So the first tool call
+        # spawns a new process which will fail once.
+        assert res.status_code in (200, 500), res.body
+    finally:
+        server.stop()
+
+
+def test_mcp_tools_via_json_config_file():
+    """Test that --mcp-servers-config (file) works as well as --mcp-servers-json."""
+    global server
+    config = {
+        "mcpServers": {
+            "echo": {
+                "command": sys.executable,
+                "args": [MCP_ECHO_SERVER],
+            }
+        }
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(config, f)
+        config_path = f.name
+
+    try:
+        server = ServerPreset.router()
+        server.server_tools = "all"
+        server.no_ui = True
+        server.server_port = 8085
+        server.mcp_servers_config = config_path
+        server.start()
+
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+
+        tools = res.body
+
+        def get_tool_name(t):
+            return t.get("tool", "") or t.get("definition", {}).get("function", {}).get("name", "")
+
+        mcp_tools = [t for t in tools if get_tool_name(t).startswith("echo_")]
+        assert len(mcp_tools) >= 2, f"Expected echo_ tools, got {mcp_tools}"
+    finally:
+        os.unlink(config_path)
+        server.stop()
+
+
+def test_mcp_tools_slot_independent():
+    """MCP tools should work without any slot concept; /tools is slot-independent."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # Call /tools without any slot binding - should succeed
+        res = server.make_request("POST", "/tools", data={
+            "tool": "echo_echo",
+            "params": {"message": "hello"}
+        })
+        assert res.status_code == 200, res.body
+        body = res.body
+        assert "error" not in body, body
+    finally:
+        server.stop()
+
+
+def test_mcp_concurrent_tool_calls():
+    """Concurrent POST /tools to same MCP server should all succeed."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        def call_tool():
+            return server.make_request("POST", "/tools", data={
+                "tool": "echo_echo",
+                "params": {"message": "hi"}
+            })
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(call_tool) for _ in range(10)]
+            results = [f.result() for f in futures]
+
+        for res in results:
+            assert res.status_code == 200, res.body
+            assert "error" not in res.body, res.body
+    finally:
+        server.stop()
+
+
+def test_mcp_tool_timeout():
+    """Tool call should timeout if MCP server is too slow."""
+    global server
+    MCP_SLOW_SERVER = os.path.join(FIXTURES_DIR, "mcp_slow_server.py")
+    mcp_json = _mcp_config_json({
+        "slow": {
+            "command": sys.executable,
+            "args": [MCP_SLOW_SERVER, "--delay", "5"],
+            "timeout_ms": 500
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        res = server.make_request("POST", "/tools", data={
+            "tool": "slow_sleep",
+            "params": {"seconds": 5}
+        })
+        assert res.status_code == 200, res.body
+        body = res.body
+        assert "error" in body, body
+    finally:
+        server.stop()
+
+
+def test_mcp_warmup_partial_failure():
+    """Good server's tools should appear even if bad server fails warmup."""
+    global server
+    mcp_json = _mcp_config_json({
+        "good": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        },
+        "bad": {
+            "command": "nonexistent",
+            "args": []
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+        tools = res.body
+
+        def get_tool_name(t):
+            return t.get("tool", "") or t.get("definition", {}).get("function", {}).get("name", "")
+
+        # good server tools should be present
+        assert any("good_" in get_tool_name(t) for t in tools), f"Expected good: tools in {tools}"
+    finally:
+        server.stop()
+
+
+def test_mcp_notification_during_request():
+    """Notification during request should not be returned as response."""
+    global server
+    MCP_MALFORMED_SERVER = os.path.join(FIXTURES_DIR, "mcp_malformed_server.py")
+    mcp_json = _mcp_config_json({
+        "notifying": {
+            "command": sys.executable,
+            "args": [MCP_MALFORMED_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        res = server.make_request("POST", "/tools", data={
+            "tool": "notifying_echo",
+            "params": {"message": "hi"}
+        })
+        assert res.status_code == 200, res.body
+        body = res.body
+        assert "error" not in body, body
+    finally:
+        server.stop()
+
+
+def test_mcp_instance_respawn_after_crash():
+    """Tool call after process crash should respawn and succeed."""
+    global server
+    MCP_CRASH_SERVER = os.path.join(FIXTURES_DIR, "mcp_crash_server.py")
+    mcp_json = _mcp_config_json({
+        "crash": {
+            "command": sys.executable,
+            "args": [MCP_CRASH_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # First call succeeds
+        res1 = server.make_request("POST", "/tools", data={
+            "tool": "crash_echo",
+            "params": {"message": "hi"}
+        })
+        assert res1.status_code == 200, res1.body
+        assert "error" not in res1.body, res1.body
+
+        # Second call should also succeed (respawned instance)
+        res2 = server.make_request("POST", "/tools", data={
+            "tool": "crash_echo",
+            "params": {"message": "hi2"}
+        })
+        assert res2.status_code == 200, res2.body
+        assert "error" not in res2.body, res2.body
+    finally:
+        server.stop()
+
+
+
+
+def test_mcp_fail_once_eventual_success_verified():
+    """Verify that fail_once tool eventually succeeds after respawn."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # First call may fail (fresh process)
+        res1 = server.make_request("POST", "/tools", data={
+            "tool": "echo_fail_once",
+            "params": {}
+        })
+        # Second call should succeed
+        res2 = server.make_request("POST", "/tools", data={
+            "tool": "echo_fail_once",
+            "params": {}
+        })
+        assert res2.status_code == 200, res2.body
+        assert "error" not in res2.body, res2.body
+    finally:
+        server.stop()
+
+
+def test_mcp_config_file_errors():
+    """Invalid JSON config and missing file should cause server to fail to start."""
+    # Invalid JSON - server should fail to start
+    server = ServerPreset.router()
+    server.server_tools = "all"
+    server.no_ui = True
+    server.server_port = 8085
+    server.mcp_servers_json = "not valid json"
+    try:
+        server.start()
+        assert False, "Server should not have started with invalid MCP JSON config"
+    except RuntimeError:
+        pass  # Expected: server process dies due to bad config
+
+    # Missing file - server should fail to start
+    server = ServerPreset.router()
+    server.server_tools = "all"
+    server.no_ui = True
+    server.server_port = 8085
+    server.mcp_servers_config = "/nonexistent/path.json"
+    try:
+        server.start()
+        assert False, "Server should not have started with missing config file"
+    except RuntimeError:
+        pass  # Expected: server process dies due to missing config
+
+
+def test_mcp_empty_tool_list():
+    """MCP server reporting zero tools should result in empty tool list."""
+    global server
+    # Create a minimal server that returns empty tools list
+    empty_server = os.path.join(FIXTURES_DIR, "_empty_mcp_server.py")
+    with open(empty_server, "w") as f:
+        f.write('''#!/usr/bin/env python3
+import json, sys, os
+def main():
+    sys.stdout = os.fdopen(sys.stdout.fileno(), "w", buffering=1)
+    for line in sys.stdin:
+        line = line.strip()
+        if not line: continue
+        try: request = json.loads(line)
+        except: continue
+        method = request.get("method")
+        req_id = request.get("id")
+        if method == "initialize":
+            resp = {"jsonrpc": "2.0", "id": req_id, "result": {"protocolVersion": "2024-11-05", "capabilities": {"tools": {}}, "serverInfo": {"name": "empty", "version": "1.0"}}}
+        elif method == "tools/list":
+            resp = {"jsonrpc": "2.0", "id": req_id, "result": {"tools": []}}
+        else:
+            resp = {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": "Method not found"}}
+        sys.stdout.write(json.dumps(resp) + "\\n")
+        sys.stdout.flush()
+if __name__ == "__main__":
+    main()
+''')
+    try:
+        mcp_json = _mcp_config_json({
+            "empty": {
+                "command": sys.executable,
+                "args": [empty_server],
+            }
+        })
+        server = _start_server_with_mcp(mcp_json)
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+        tools = res.body
+        def get_tool_name(t):
+            return t.get("tool", "") or t.get("definition", {}).get("function", {}).get("name", "")
+        mcp_tools = [t for t in tools if get_tool_name(t).startswith("empty:")]
+        assert len(mcp_tools) == 0, f"Expected no empty: tools, got {mcp_tools}"
+    finally:
+        os.unlink(empty_server)
+        server.stop()
+
+
+def test_mcp_rapid_succession_calls():
+    """Many rapid calls should increment next_id correctly and correlate responses."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        for i in range(20):
+            res = server.make_request("POST", "/tools", data={
+                "tool": "echo_echo",
+                "params": {"message": f"msg{i}"}
+            })
+            assert res.status_code == 200, res.body
+            assert "error" not in res.body, res.body
+    finally:
+        server.stop()
+
+
+def test_mcp_notification_burst():
+    """Notification + response in a single write() with no flush should not strand the response."""
+    global server
+    MCP_BURST_SERVER = os.path.join(FIXTURES_DIR, "mcp_burst_server.py")
+    mcp_json = _mcp_config_json({
+        "burst": {
+            "command": sys.executable,
+            "args": [MCP_BURST_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        res = server.make_request("POST", "/tools", data={
+            "tool": "burst_echo",
+            "params": {"message": "burst test"}
+        })
+        assert res.status_code == 200, res.body
+        body = res.body
+        assert "error" not in body, body
+    finally:
+        server.stop()
+
+
+def test_mcp_tool_definition_shape_via_chat_completions():
+    """MCP tool definitions returned by GET /tools should have the correct shape for chat/completions."""
+    global server
+    mcp_json = _mcp_config_json({
+        "echo": {
+            "command": sys.executable,
+            "args": [MCP_ECHO_SERVER],
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # Get MCP tool definitions
+        res = server.make_request("GET", "/tools")
+        assert res.status_code == 200, res.body
+        tools = res.body
+
+        def get_tool_name(t):
+            return t.get("tool", "") or t.get("definition", {}).get("function", {}).get("name", "")
+
+        echo_tools = [t for t in tools if get_tool_name(t).startswith("echo_")]
+        assert len(echo_tools) >= 2, f"Expected echo_ tools, got {echo_tools}"
+
+        echo_tool = next(t for t in echo_tools if get_tool_name(t) == "echo_echo")
+        definition = echo_tool.get("definition", echo_tool)
+
+        # Verify the definition has the standard function-calling shape
+        assert definition.get("type") == "function", f"Expected type=function, got {definition.get('type')}"
+        func = definition.get("function", {})
+        assert "name" in func, "Missing function.name"
+        assert "description" in func, "Missing function.description"
+        assert "parameters" in func, f"Missing function.parameters, got keys: {list(func.keys())}"
+        params = func["parameters"]
+        assert params.get("type") == "object", f"Expected parameters.type=object, got {params.get('type')}"
+        assert "properties" in params, "Missing parameters.properties"
+    finally:
+        server.stop()
+
+
+def test_mcp_slow_tool_call_slot_release():
+    """A slow tool call should not stall server shutdown for the full I/O timeout."""
+    global server
+    MCP_SLOW_SERVER = os.path.join(FIXTURES_DIR, "mcp_slow_server.py")
+    mcp_json = _mcp_config_json({
+        "slow": {
+            "command": sys.executable,
+            "args": [MCP_SLOW_SERVER, "--delay", "10"],
+            "timeout_ms": 30000
+        }
+    })
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # Start a slow tool call in a background thread
+        def slow_call():
+            return server.make_request("POST", "/tools", data={
+                "tool": "slow_sleep",
+                "params": {"seconds": 10}
+            })
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(slow_call)
+
+            # Wait a moment for the call to start
+            time.sleep(2)
+
+            # Stop the server while the tool call is in progress.
+            # With global MCP instances, close_all() is called explicitly at shutdown
+            # (not from slot release), so shutdown should complete promptly.
+            start_time = time.time()
+            server.stop()
+            elapsed = time.time() - start_time
+
+            # The server should stop quickly, not wait for the full 30s I/O timeout.
+            # With the terminating flag, send_rpc() bails out within one select()
+            # slice (~50ms). This threshold MUST stay below the 5s force-kill
+            # fallback in ServerProcess.stop(): without the flag, shutdown stalls
+            # on the instance mutex and only completes when stop() sends SIGKILL
+            # at ~5s -- which any threshold above 5 would still accept.
+            assert elapsed < 3, f"Server stop took {elapsed:.1f}s, expected < 3s"
+
+            # Wait for the future to complete (it will get an error response or timeout)
+            try:
+                res = future.result(timeout=5)
+                # If we got a response, it should be an error since the server stopped
+                if hasattr(res, 'status_code'):
+                    assert res.status_code in (200, 500, 502, 503, 504), f"Unexpected status: {res.status_code}"
+            except Exception:
+                # Thread may have raised due to connection error - that's acceptable
+                pass
+    finally:
+        server.stop()
+
+
+def test_mcp_grandchild_holding_pipes_does_not_deadlock():
+    """An MCP server that leaves a grandchild inheriting its stdout/stderr must not deadlock
+    teardown.
+
+    subprocess_terminate() only SIGKILLs the direct MCP child, so the inherited pipe write ends
+    stay open and a blocking read on them would never see EOF. That hung both warmup shutdown
+    (the server would never reach "ready") and process shutdown. The polled, running-aware reader
+    must exit regardless, so the server both starts and stops promptly here.
+    """
+    global server
+    MCP_GRANDCHILD_SERVER = os.path.join(FIXTURES_DIR, "mcp_grandchild_server.py")
+    mcp_json = _mcp_config_json({
+        "gc": {
+            "command": sys.executable,
+            "args": [MCP_GRANDCHILD_SERVER],
+        }
+    })
+
+    # If warmup teardown deadlocked, the server would never become ready and start() would time out.
+    server = _start_server_with_mcp(mcp_json)
+
+    try:
+        # invoking the tool spawns a live transport whose reader thread holds the inherited pipe
+        res = server.make_request("POST", "/tools", data={
+            "tool": "gc_echo",
+            "params": {"message": "hello"}
+        })
+        assert res.status_code == 200, res.body
+        assert "error" not in res.body, res.body
+
+        # shutdown must be prompt: a deadlocked reader-join would stall until the 5s SIGKILL
+        # fallback in ServerProcess.stop(), so the threshold has to stay below that
+        start = time.time()
+        server.stop()
+        elapsed = time.time() - start
+        assert elapsed < 3, f"server shutdown took {elapsed:.1f}s (expected < 3s) — teardown likely deadlocked"
+    finally:
+        server.stop()

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -115,6 +115,8 @@ class ServerProcess:
     backend_sampling: bool = False
     gcp_compat: bool = False
     server_tools: str | None = None
+    mcp_servers_config: str | None = None
+    mcp_servers_json: str | None = None
     cors_origins: str | None = None
 
     # session variables
@@ -265,6 +267,10 @@ class ServerProcess:
             server_args.append("--ui-mcp-proxy")
         if self.server_tools:
             server_args.extend(["--tools", self.server_tools])
+        if self.mcp_servers_config:
+            server_args.extend(["--mcp-servers-config", self.mcp_servers_config])
+        if self.mcp_servers_json:
+            server_args.extend(["--mcp-servers-json", self.mcp_servers_json])
         if self.backend_sampling:
             server_args.append("--backend_sampling")
         if self.gcp_compat:

--- a/vendor/sheredom/subprocess.h
+++ b/vendor/sheredom/subprocess.h
@@ -89,7 +89,25 @@ enum subprocess_option_e {
   // Search for program names in the PATH variable. Always enabled on Windows.
   // Note: this will **not** search for paths in any provided custom environment
   // and instead uses the PATH of the spawning process.
-  subprocess_option_search_user_path = 0x10
+  subprocess_option_search_user_path = 0x10,
+
+  // Make subprocess_read_stdout and subprocess_read_stderr return immediately
+  // with 0 if no data is available. Requires subprocess_option_enable_async.
+  subprocess_option_enable_async_no_wait = 0x20
+};
+
+// Error codes returned by subprocess_create and subprocess_create_ex.
+// subprocess_error_success is always zero; all errors are non-zero.
+enum subprocess_error_e {
+  subprocess_error_success = 0,
+  subprocess_error_unknown = -1,
+  subprocess_error_invalid_options = -2,
+  subprocess_error_invalid_environment = -3,
+  subprocess_error_not_found = -4,
+  subprocess_error_permission_denied = -5,
+  subprocess_error_no_memory = -6,
+  subprocess_error_pipe = -7,
+  subprocess_error_spawn = -8
 };
 
 #if defined(__cplusplus)
@@ -99,11 +117,14 @@ extern "C" {
 /// @brief Create a process.
 /// @param command_line An array of strings for the command line to execute for
 /// this process. The last element must be NULL to signify the end of the array.
-/// The memory backing this parameter only needs to persist until this function
-/// returns.
+/// On Windows these strings are interpreted as UTF-8 and passed to the Unicode
+/// process creation APIs. The memory backing this parameter only needs to
+/// persist until this function returns.
 /// @param options A bit field of subprocess_option_e's to pass.
 /// @param out_process The newly created process.
-/// @return On success zero is returned.
+/// @return On success zero is returned. On failure a non-zero
+/// `subprocess_error_e` value is returned; inspect `errno` on POSIX platforms
+/// or `GetLastError()` on Windows for the platform-specific failure reason.
 subprocess_weak int subprocess_create(const char *const command_line[],
                                       int options,
                                       struct subprocess_s *const out_process);
@@ -111,20 +132,28 @@ subprocess_weak int subprocess_create(const char *const command_line[],
 /// @brief Create a process (extended create).
 /// @param command_line An array of strings for the command line to execute for
 /// this process. The last element must be NULL to signify the end of the array.
-/// The memory backing this parameter only needs to persist until this function
-/// returns.
+/// On Windows these strings are interpreted as UTF-8 and passed to the Unicode
+/// process creation APIs. The memory backing this parameter only needs to
+/// persist until this function returns.
 /// @param options A bit field of subprocess_option_e's to pass.
 /// @param environment An optional array of strings for the environment to use
 /// for a child process (each element of the form FOO=BAR). The last element
-/// must be NULL to signify the end of the array.
+/// must be NULL to signify the end of the array. On Windows these strings are
+/// interpreted as UTF-8.
+/// @param process_cwd The current working directory of the newly created
+/// process. If NULL, will be the same as the parent process. On Windows this
+/// string is interpreted as UTF-8.
 /// @param out_process The newly created process.
-/// @return On success zero is returned.
+/// @return On success zero is returned. On failure a non-zero
+/// `subprocess_error_e` value is returned; inspect `errno` on POSIX platforms
+/// or `GetLastError()` on Windows for the platform-specific failure reason.
 ///
 /// If `options` contains `subprocess_option_inherit_environment`, then
 /// `environment` must be NULL.
 subprocess_weak int
 subprocess_create_ex(const char *const command_line[], int options,
                      const char *const environment[],
+                     const char *const process_cwd,
                      struct subprocess_s *const out_process);
 
 /// @brief Get the standard input file for a process.
@@ -189,7 +218,8 @@ subprocess_weak int subprocess_terminate(struct subprocess_s *const process);
 /// @param buffer The buffer to read into.
 /// @param size The maximum number of bytes to read.
 /// @return The number of bytes actually read into buffer. Can only be 0 if the
-/// process has complete.
+/// process has complete, or if the process was created with
+/// `subprocess_option_enable_async_no_wait` and no data is currently available.
 ///
 /// The only safe way to read from the standard output of a process during it's
 /// execution is to use the `subprocess_option_enable_async` option in
@@ -203,7 +233,8 @@ subprocess_read_stdout(struct subprocess_s *const process, char *const buffer,
 /// @param buffer The buffer to read into.
 /// @param size The maximum number of bytes to read.
 /// @return The number of bytes actually read into buffer. Can only be 0 if the
-/// process has complete.
+/// process has complete, or if the process was created with
+/// `subprocess_option_enable_async_no_wait` and no data is currently available.
 ///
 /// The only safe way to read from the standard error of a process during it's
 /// execution is to use the `subprocess_option_enable_async` option in
@@ -230,15 +261,37 @@ subprocess_weak int subprocess_alive(struct subprocess_s *const process);
 #endif
 
 #if !defined(_WIN32)
+#include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <spawn.h>
 #include <stdlib.h>
+#if defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#endif
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #endif
 
 #if defined(_WIN32)
+
+#include <wchar.h>
+
+#if defined(__clang__)
+#if __has_warning("-Wc++-keyword")
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++-keyword"
+#endif
+#endif
+
+typedef wchar_t subprocess_wchar_t;
+
+#if defined(__clang__)
+#if __has_warning("-Wc++-keyword")
+#pragma clang diagnostic pop
+#endif
+#endif
 
 #if (_MSC_VER < 1920)
 #ifdef _WIN64
@@ -262,7 +315,7 @@ typedef size_t subprocess_size_t;
 
 typedef struct _PROCESS_INFORMATION *LPPROCESS_INFORMATION;
 typedef struct _SECURITY_ATTRIBUTES *LPSECURITY_ATTRIBUTES;
-typedef struct _STARTUPINFOA *LPSTARTUPINFOA;
+typedef struct _STARTUPINFOW *LPSTARTUPINFOW;
 typedef struct _OVERLAPPED *LPOVERLAPPED;
 
 #ifdef __clang__
@@ -275,6 +328,10 @@ typedef struct _OVERLAPPED *LPOVERLAPPED;
 #ifdef __MINGW32__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
 #endif
 
 struct subprocess_subprocess_information_s {
@@ -292,9 +349,9 @@ struct subprocess_security_attributes_s {
 
 struct subprocess_startup_info_s {
   unsigned long cb;
-  char *lpReserved;
-  char *lpDesktop;
-  char *lpTitle;
+  subprocess_wchar_t *lpReserved;
+  subprocess_wchar_t *lpDesktop;
+  subprocess_wchar_t *lpTitle;
   unsigned long dwX;
   unsigned long dwY;
   unsigned long dwXSize;
@@ -325,6 +382,9 @@ struct subprocess_overlapped_s {
   void *hEvent;
 };
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #ifdef __MINGW32__
 #pragma GCC diagnostic pop
 #endif
@@ -333,6 +393,7 @@ struct subprocess_overlapped_s {
 #endif
 
 __declspec(dllimport) unsigned long __stdcall GetLastError(void);
+__declspec(dllimport) void __stdcall SetLastError(unsigned long);
 __declspec(dllimport) int __stdcall SetHandleInformation(void *, unsigned long,
                                                          unsigned long);
 __declspec(dllimport) int __stdcall CreatePipe(void **, void **,
@@ -352,9 +413,12 @@ __declspec(dllimport) void *__stdcall CreateFileA(const char *, unsigned long,
                                                   void *);
 __declspec(dllimport) void *__stdcall CreateEventA(LPSECURITY_ATTRIBUTES, int,
                                                    int, const char *);
-__declspec(dllimport) int __stdcall CreateProcessA(
-    const char *, char *, LPSECURITY_ATTRIBUTES, LPSECURITY_ATTRIBUTES, int,
-    unsigned long, void *, const char *, LPSTARTUPINFOA, LPPROCESS_INFORMATION);
+__declspec(dllimport) int __stdcall CreateProcessW(
+    const subprocess_wchar_t *, subprocess_wchar_t *, LPSECURITY_ATTRIBUTES,
+    LPSECURITY_ATTRIBUTES, int, unsigned long, void *,
+    const subprocess_wchar_t *, LPSTARTUPINFOW, LPPROCESS_INFORMATION);
+__declspec(dllimport) int __stdcall MultiByteToWideChar(
+    unsigned int, unsigned long, const char *, int, subprocess_wchar_t *, int);
 __declspec(dllimport) int __stdcall CloseHandle(void *);
 __declspec(dllimport) unsigned long __stdcall WaitForSingleObject(
     void *, unsigned long);
@@ -365,6 +429,10 @@ __declspec(dllimport) unsigned long __stdcall WaitForMultipleObjects(
     unsigned long, void *const *, int, unsigned long);
 __declspec(dllimport) int __stdcall GetOverlappedResult(void *, LPOVERLAPPED,
                                                         unsigned long *, int);
+__declspec(dllimport) int __stdcall PeekNamedPipe(void *, void *, unsigned long,
+                                                  unsigned long *,
+                                                  unsigned long *,
+                                                  unsigned long *);
 
 #if defined(_DLL)
 #define SUBPROCESS_DLLIMPORT __declspec(dllimport)
@@ -380,6 +448,7 @@ __declspec(dllimport) int __stdcall GetOverlappedResult(void *, LPOVERLAPPED,
 SUBPROCESS_DLLIMPORT int __cdecl _fileno(FILE *);
 SUBPROCESS_DLLIMPORT int __cdecl _open_osfhandle(subprocess_intptr_t, int);
 SUBPROCESS_DLLIMPORT subprocess_intptr_t __cdecl _get_osfhandle(int);
+SUBPROCESS_DLLIMPORT int __cdecl _close(int);
 
 #ifndef __MINGW32__
 void *__cdecl _alloca(subprocess_size_t);
@@ -414,10 +483,66 @@ struct subprocess_s {
   int return_status;
 #endif
 
-  subprocess_size_t alive;
+  int alive;
+  int no_wait;
 };
 #ifdef __clang__
 #pragma clang diagnostic pop
+#endif
+
+#if defined(_WIN32)
+subprocess_weak int subprocess_error_from_windows_error(unsigned long error);
+int subprocess_error_from_windows_error(unsigned long error) {
+  enum {
+    errorFileNotFound = 2,
+    errorPathNotFound = 3,
+    errorTooManyOpenFiles = 4,
+    errorAccessDenied = 5,
+    errorInvalidHandle = 6,
+    errorNotEnoughMemory = 8,
+    errorOutOfMemory = 14,
+    errorInvalidDrive = 15,
+    errorBadPathname = 161,
+    errorDirectory = 267
+  };
+
+  switch (error) {
+  case errorFileNotFound:
+  case errorPathNotFound:
+  case errorInvalidDrive:
+  case errorBadPathname:
+  case errorDirectory:
+    return subprocess_error_not_found;
+  case errorAccessDenied:
+    return subprocess_error_permission_denied;
+  case errorTooManyOpenFiles:
+  case errorNotEnoughMemory:
+  case errorOutOfMemory:
+    return subprocess_error_no_memory;
+  case errorInvalidHandle:
+    return subprocess_error_pipe;
+  default:
+    return subprocess_error_unknown;
+  }
+}
+#else
+subprocess_weak int subprocess_error_from_errno(int error);
+int subprocess_error_from_errno(int error) {
+  switch (error) {
+  case ENOENT:
+  case ENOTDIR:
+    return subprocess_error_not_found;
+  case EACCES:
+  case EPERM:
+    return subprocess_error_permission_denied;
+  case EMFILE:
+  case ENFILE:
+  case ENOMEM:
+    return subprocess_error_no_memory;
+  default:
+    return subprocess_error_unknown;
+  }
+}
 #endif
 
 #if defined(__clang__)
@@ -429,6 +554,18 @@ struct subprocess_s {
 
 #if defined(_WIN32)
 subprocess_weak int subprocess_create_named_pipe_helper(void **rd, void **wr);
+subprocess_weak void subprocess_close_handle(void **handle);
+void subprocess_close_handle(void **handle) {
+  const void *const invalidHandleValue =
+      SUBPROCESS_PTR_CAST(void *, ~(SUBPROCESS_CAST(subprocess_intptr_t, 0)));
+
+  if (*handle && (invalidHandleValue != *handle)) {
+    CloseHandle(*handle);
+  }
+
+  *handle = SUBPROCESS_NULL;
+}
+
 int subprocess_create_named_pipe_helper(void **rd, void **wr) {
   const unsigned long pipeAccessInbound = 0x00000001;
   const unsigned long fileFlagOverlapped = 0x40000000;
@@ -442,8 +579,22 @@ int subprocess_create_named_pipe_helper(void **rd, void **wr) {
   struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
                                                     SUBPROCESS_NULL, 1};
   char name[256] = {0};
+#if defined(__clang__)
+#if __has_warning("-Wunique-object-duplication")
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunique-object-duplication"
+#endif
+#endif
   static subprocess_tls long index = 0;
+#if defined(__clang__)
+#if __has_warning("-Wunique-object-duplication")
+#pragma clang diagnostic pop
+#endif
+#endif
   const long unique = index++;
+
+  *rd = SUBPROCESS_NULL;
+  *wr = SUBPROCESS_NULL;
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #pragma warning(push, 1)
@@ -472,6 +623,7 @@ int subprocess_create_named_pipe_helper(void **rd, void **wr) {
                     openExisting, fileAttributeNormal, SUBPROCESS_NULL);
 
   if (invalidHandleValue == *wr) {
+    subprocess_close_handle(rd);
     return -1;
   }
 
@@ -482,27 +634,41 @@ int subprocess_create_named_pipe_helper(void **rd, void **wr) {
 int subprocess_create(const char *const commandLine[], int options,
                       struct subprocess_s *const out_process) {
   return subprocess_create_ex(commandLine, options, SUBPROCESS_NULL,
-                              out_process);
+                              SUBPROCESS_NULL, out_process);
 }
 
 int subprocess_create_ex(const char *const commandLine[], int options,
                          const char *const environment[],
+                         const char *const process_cwd,
                          struct subprocess_s *const out_process) {
 #if defined(_WIN32)
   int fd;
-  void *rd, *wr;
+  int async_no_wait;
+  void *rd = SUBPROCESS_NULL;
+  void *wr = SUBPROCESS_NULL;
   char *commandLineCombined;
+  subprocess_wchar_t *commandLineCombinedWide = SUBPROCESS_NULL;
+  subprocess_wchar_t *process_cwd_wide = SUBPROCESS_NULL;
   subprocess_size_t len;
+  int wide_len;
   int i, j;
   int need_quoting;
   unsigned long flags = 0;
+  unsigned long last_error = 0;
+  int result = subprocess_error_unknown;
+  const unsigned int codePageUtf8 = 65001;
+  const unsigned long mbErrInvalidChars = 0x00000008;
   const unsigned long startFUseStdHandles = 0x00000100;
   const unsigned long handleFlagInherit = 0x00000001;
   const unsigned long createNoWindow = 0x08000000;
-  struct subprocess_subprocess_information_s processInfo;
+  const unsigned long createUnicodeEnvironment = 0x00000400;
+  struct subprocess_subprocess_information_s processInfo = {SUBPROCESS_NULL,
+                                                            SUBPROCESS_NULL, 0,
+                                                            0};
   struct subprocess_security_attributes_s saAttr = {sizeof(saAttr),
                                                     SUBPROCESS_NULL, 1};
-  char *used_environment = SUBPROCESS_NULL;
+  subprocess_wchar_t empty_environment[2] = {0, 0};
+  subprocess_wchar_t *used_environment = SUBPROCESS_NULL;
   struct subprocess_startup_info_s startInfo = {0,
                                                 SUBPROCESS_NULL,
                                                 SUBPROCESS_NULL,
@@ -522,6 +688,14 @@ int subprocess_create_ex(const char *const commandLine[], int options,
                                                 SUBPROCESS_NULL,
                                                 SUBPROCESS_NULL};
 
+  async_no_wait = subprocess_option_enable_async_no_wait ==
+                  (options & subprocess_option_enable_async_no_wait);
+
+  if (async_no_wait && (subprocess_option_enable_async !=
+                        (options & subprocess_option_enable_async))) {
+    return subprocess_error_invalid_options;
+  }
+
   startInfo.cb = sizeof(startInfo);
   startInfo.dwFlags = startFUseStdHandles;
 
@@ -529,93 +703,142 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     flags |= createNoWindow;
   }
 
+  memset(out_process, 0, sizeof(*out_process));
+
   if (subprocess_option_inherit_environment !=
       (options & subprocess_option_inherit_environment)) {
+    flags |= createUnicodeEnvironment;
+
     if (SUBPROCESS_NULL == environment) {
-      used_environment = SUBPROCESS_CONST_CAST(char *, "\0\0");
+      used_environment = empty_environment;
     } else {
-      // We always end with two null terminators.
-      len = 2;
+      // We always end with two null terminators. MultiByteToWideChar includes
+      // each environment string's null terminator, so start with one extra.
+      len = 1;
 
       for (i = 0; environment[i]; i++) {
-        for (j = 0; '\0' != environment[i][j]; j++) {
-          len++;
+        wide_len = MultiByteToWideChar(codePageUtf8, mbErrInvalidChars,
+                                       environment[i], -1, SUBPROCESS_NULL, 0);
+        if (0 == wide_len) {
+          result = subprocess_error_from_windows_error(GetLastError());
+          if (subprocess_error_unknown == result) {
+            result = subprocess_error_spawn;
+          }
+          goto cleanup;
         }
 
-        // For the null terminator too.
-        len++;
+        len += SUBPROCESS_CAST(subprocess_size_t, wide_len);
       }
 
-      used_environment = SUBPROCESS_CAST(char *, _alloca(len));
+      if (((SUBPROCESS_CAST(subprocess_size_t, -1)) /
+           sizeof(subprocess_wchar_t)) < len) {
+        result = subprocess_error_no_memory;
+        goto cleanup;
+      }
 
-      // Re-use len for the insertion position
+      used_environment = SUBPROCESS_CAST(
+          subprocess_wchar_t *, _alloca(len * sizeof(subprocess_wchar_t)));
+      if (!used_environment) {
+        result = subprocess_error_no_memory;
+        goto cleanup;
+      }
+
+      // Re-use len for the insertion position.
       len = 0;
 
       for (i = 0; environment[i]; i++) {
-        for (j = 0; '\0' != environment[i][j]; j++) {
-          used_environment[len++] = environment[i][j];
+        wide_len = MultiByteToWideChar(codePageUtf8, mbErrInvalidChars,
+                                       environment[i], -1, SUBPROCESS_NULL, 0);
+        if (0 == wide_len) {
+          result = subprocess_error_from_windows_error(GetLastError());
+          if (subprocess_error_unknown == result) {
+            result = subprocess_error_spawn;
+          }
+          goto cleanup;
         }
 
-        used_environment[len++] = '\0';
+        if (0 == MultiByteToWideChar(codePageUtf8, mbErrInvalidChars,
+                                     environment[i], -1,
+                                     &used_environment[len], wide_len)) {
+          result = subprocess_error_from_windows_error(GetLastError());
+          if (subprocess_error_unknown == result) {
+            result = subprocess_error_spawn;
+          }
+          goto cleanup;
+        }
+
+        len += SUBPROCESS_CAST(subprocess_size_t, wide_len);
       }
 
-      // End with the two null terminators.
-      used_environment[len++] = '\0';
-      used_environment[len++] = '\0';
+      // End with the second null terminator.
+      used_environment[len++] = 0;
     }
   } else {
     if (SUBPROCESS_NULL != environment) {
-      return -1;
+      return subprocess_error_invalid_environment;
     }
   }
 
   if (!CreatePipe(&rd, &wr, SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr),
                   0)) {
-    return -1;
+    result = subprocess_error_pipe;
+    goto cleanup;
   }
 
   if (!SetHandleInformation(wr, handleFlagInherit, 0)) {
-    return -1;
+    result = subprocess_error_pipe;
+    goto cleanup;
   }
 
   fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, wr), 0);
+  if (-1 == fd) {
+    result = subprocess_error_pipe;
+    goto cleanup;
+  }
+  wr = SUBPROCESS_NULL;
 
-  if (-1 != fd) {
-    out_process->stdin_file = _fdopen(fd, "wb");
-
-    if (SUBPROCESS_NULL == out_process->stdin_file) {
-      return -1;
-    }
+  out_process->stdin_file = _fdopen(fd, "wb");
+  if (SUBPROCESS_NULL == out_process->stdin_file) {
+    _close(fd);
+    goto cleanup;
   }
 
   startInfo.hStdInput = rd;
+  rd = SUBPROCESS_NULL;
 
   if (options & subprocess_option_enable_async) {
     if (subprocess_create_named_pipe_helper(&rd, &wr)) {
-      return -1;
+      result = subprocess_error_pipe;
+      goto cleanup;
     }
   } else {
     if (!CreatePipe(&rd, &wr,
                     SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
-      return -1;
+      result = subprocess_error_pipe;
+      goto cleanup;
     }
   }
 
   if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
-    return -1;
+    result = subprocess_error_pipe;
+    goto cleanup;
   }
 
   fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+  if (-1 == fd) {
+    result = subprocess_error_pipe;
+    goto cleanup;
+  }
+  rd = SUBPROCESS_NULL;
 
-  if (-1 != fd) {
-    out_process->stdout_file = _fdopen(fd, "rb");
-
-    if (SUBPROCESS_NULL == out_process->stdout_file) {
-      return -1;
-    }
+  out_process->stdout_file = _fdopen(fd, "rb");
+  if (SUBPROCESS_NULL == out_process->stdout_file) {
+    _close(fd);
+    goto cleanup;
   }
 
   startInfo.hStdOutput = wr;
+  wr = SUBPROCESS_NULL;
 
   if (subprocess_option_combined_stdout_stderr ==
       (options & subprocess_option_combined_stdout_stderr)) {
@@ -624,30 +847,37 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   } else {
     if (options & subprocess_option_enable_async) {
       if (subprocess_create_named_pipe_helper(&rd, &wr)) {
-        return -1;
+        result = subprocess_error_pipe;
+        goto cleanup;
       }
     } else {
       if (!CreatePipe(&rd, &wr,
                       SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 0)) {
-        return -1;
+        result = subprocess_error_pipe;
+        goto cleanup;
       }
     }
 
     if (!SetHandleInformation(rd, handleFlagInherit, 0)) {
-      return -1;
+      result = subprocess_error_pipe;
+      goto cleanup;
     }
 
     fd = _open_osfhandle(SUBPROCESS_PTR_CAST(subprocess_intptr_t, rd), 0);
+    if (-1 == fd) {
+      result = subprocess_error_pipe;
+      goto cleanup;
+    }
+    rd = SUBPROCESS_NULL;
 
-    if (-1 != fd) {
-      out_process->stderr_file = _fdopen(fd, "rb");
-
-      if (SUBPROCESS_NULL == out_process->stderr_file) {
-        return -1;
-      }
+    out_process->stderr_file = _fdopen(fd, "rb");
+    if (SUBPROCESS_NULL == out_process->stderr_file) {
+      _close(fd);
+      goto cleanup;
     }
 
     startInfo.hStdError = wr;
+    wr = SUBPROCESS_NULL;
   }
 
   if (options & subprocess_option_enable_async) {
@@ -657,6 +887,13 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     out_process->hEventError =
         CreateEventA(SUBPROCESS_PTR_CAST(LPSECURITY_ATTRIBUTES, &saAttr), 1, 1,
                      SUBPROCESS_NULL);
+    if (!out_process->hEventOutput || !out_process->hEventError) {
+      result = subprocess_error_from_windows_error(GetLastError());
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_no_memory;
+      }
+      goto cleanup;
+    }
   } else {
     out_process->hEventOutput = SUBPROCESS_NULL;
     out_process->hEventError = SUBPROCESS_NULL;
@@ -694,7 +931,8 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   commandLineCombined = SUBPROCESS_CAST(char *, _alloca(len));
 
   if (!commandLineCombined) {
-    return -1;
+    result = subprocess_error_no_memory;
+    goto cleanup;
   }
 
   // Gonna re-use len to store the write index into commandLineCombined
@@ -735,27 +973,93 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 
   commandLineCombined[len] = '\0';
 
-  if (!CreateProcessA(
+  wide_len = MultiByteToWideChar(codePageUtf8, mbErrInvalidChars,
+                                 commandLineCombined, -1, SUBPROCESS_NULL, 0);
+  if (0 == wide_len) {
+    result = subprocess_error_from_windows_error(GetLastError());
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
+  }
+
+  commandLineCombinedWide = SUBPROCESS_CAST(
+      subprocess_wchar_t *,
+      _alloca(SUBPROCESS_CAST(subprocess_size_t, wide_len) *
+              sizeof(subprocess_wchar_t)));
+  if (!commandLineCombinedWide) {
+    result = subprocess_error_no_memory;
+    goto cleanup;
+  }
+
+  if (0 == MultiByteToWideChar(codePageUtf8, mbErrInvalidChars,
+                               commandLineCombined, -1,
+                               commandLineCombinedWide, wide_len)) {
+    result = subprocess_error_from_windows_error(GetLastError());
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
+  }
+
+  if (process_cwd) {
+    wide_len = MultiByteToWideChar(codePageUtf8, mbErrInvalidChars, process_cwd,
+                                   -1, SUBPROCESS_NULL, 0);
+    if (0 == wide_len) {
+      result = subprocess_error_from_windows_error(GetLastError());
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
+    }
+
+    process_cwd_wide = SUBPROCESS_CAST(
+        subprocess_wchar_t *,
+        _alloca(SUBPROCESS_CAST(subprocess_size_t, wide_len) *
+                sizeof(subprocess_wchar_t)));
+    if (!process_cwd_wide) {
+      result = subprocess_error_no_memory;
+      goto cleanup;
+    }
+
+    if (0 == MultiByteToWideChar(codePageUtf8, mbErrInvalidChars, process_cwd,
+                                 -1, process_cwd_wide, wide_len)) {
+      result = subprocess_error_from_windows_error(GetLastError());
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
+    }
+  }
+
+  if (!CreateProcessW(
           SUBPROCESS_NULL,
-          commandLineCombined, // command line
-          SUBPROCESS_NULL,     // process security attributes
-          SUBPROCESS_NULL,     // primary thread security attributes
-          1,                   // handles are inherited
-          flags,               // creation flags
-          used_environment,    // used environment
-          SUBPROCESS_NULL,     // use parent's current directory
-          SUBPROCESS_PTR_CAST(LPSTARTUPINFOA,
+          commandLineCombinedWide, // command line
+          SUBPROCESS_NULL,         // process security attributes
+          SUBPROCESS_NULL,         // primary thread security attributes
+          1,                       // handles are inherited
+          flags,                   // creation flags
+          used_environment,        // used environment
+          process_cwd_wide,        // use specified current directory
+          SUBPROCESS_PTR_CAST(LPSTARTUPINFOW,
                               &startInfo), // STARTUPINFO pointer
           SUBPROCESS_PTR_CAST(LPPROCESS_INFORMATION, &processInfo))) {
-    return -1;
+    result = subprocess_error_from_windows_error(GetLastError());
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
   }
 
   out_process->hProcess = processInfo.hProcess;
+  processInfo.hProcess = SUBPROCESS_NULL;
 
   out_process->hStdInput = startInfo.hStdInput;
+  startInfo.hStdInput = SUBPROCESS_NULL;
 
   // We don't need the handle of the primary thread in the called process.
   CloseHandle(processInfo.hThread);
+  processInfo.hThread = SUBPROCESS_NULL;
 
   if (SUBPROCESS_NULL != startInfo.hStdOutput) {
     CloseHandle(startInfo.hStdOutput);
@@ -763,40 +1067,111 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     if (startInfo.hStdError != startInfo.hStdOutput) {
       CloseHandle(startInfo.hStdError);
     }
+
+    startInfo.hStdOutput = SUBPROCESS_NULL;
+    startInfo.hStdError = SUBPROCESS_NULL;
   }
 
   out_process->alive = 1;
+  out_process->no_wait = async_no_wait;
 
   return 0;
+
+cleanup:
+  last_error = GetLastError();
+
+  if (subprocess_error_unknown == result) {
+    result = subprocess_error_from_windows_error(last_error);
+  }
+
+  if (out_process->stdin_file) {
+    fclose(out_process->stdin_file);
+    out_process->stdin_file = SUBPROCESS_NULL;
+  }
+
+  if (out_process->stdout_file) {
+    fclose(out_process->stdout_file);
+    if (out_process->stderr_file &&
+        (out_process->stdout_file != out_process->stderr_file)) {
+      fclose(out_process->stderr_file);
+    }
+    out_process->stdout_file = SUBPROCESS_NULL;
+    out_process->stderr_file = SUBPROCESS_NULL;
+  }
+
+  subprocess_close_handle(&rd);
+  subprocess_close_handle(&wr);
+  subprocess_close_handle(&startInfo.hStdInput);
+
+  if (startInfo.hStdOutput == startInfo.hStdError) {
+    subprocess_close_handle(&startInfo.hStdOutput);
+    startInfo.hStdError = SUBPROCESS_NULL;
+  } else {
+    subprocess_close_handle(&startInfo.hStdOutput);
+    subprocess_close_handle(&startInfo.hStdError);
+  }
+
+  subprocess_close_handle(&out_process->hEventOutput);
+  subprocess_close_handle(&out_process->hEventError);
+  subprocess_close_handle(&processInfo.hThread);
+  subprocess_close_handle(&processInfo.hProcess);
+
+  SetLastError(last_error);
+
+  return result;
 #else
-  int stdinfd[2];
-  int stdoutfd[2];
-  int stderrfd[2];
-  pid_t child;
+  int stdinfd[2] = {-1, -1};
+  int stdoutfd[2] = {-1, -1};
+  int stderrfd[2] = {-1, -1};
+  int fd, fd_flags;
+  int async_no_wait;
+  int actions_created = 0;
+  int result = subprocess_error_unknown;
+  int saved_errno = 0;
+  int posix_error;
+  pid_t child = 0;
   extern char **environ;
   char *const empty_environment[1] = {SUBPROCESS_NULL};
   posix_spawn_file_actions_t actions;
   char *const *used_environment;
 
+  async_no_wait = subprocess_option_enable_async_no_wait ==
+                  (options & subprocess_option_enable_async_no_wait);
+
+  if (async_no_wait && (subprocess_option_enable_async !=
+                        (options & subprocess_option_enable_async))) {
+    errno = EINVAL;
+    return subprocess_error_invalid_options;
+  }
+
   if (subprocess_option_inherit_environment ==
       (options & subprocess_option_inherit_environment)) {
     if (SUBPROCESS_NULL != environment) {
-      return -1;
+      errno = EINVAL;
+      return subprocess_error_invalid_environment;
     }
   }
 
+  memset(out_process, 0, sizeof(*out_process));
+
   if (0 != pipe(stdinfd)) {
-    return -1;
+    saved_errno = errno;
+    result = subprocess_error_pipe;
+    goto cleanup;
   }
 
   if (0 != pipe(stdoutfd)) {
-    return -1;
+    saved_errno = errno;
+    result = subprocess_error_pipe;
+    goto cleanup;
   }
 
   if (subprocess_option_combined_stdout_stderr !=
       (options & subprocess_option_combined_stdout_stderr)) {
     if (0 != pipe(stderrfd)) {
-      return -1;
+      saved_errno = errno;
+      result = subprocess_error_pipe;
+      goto cleanup;
     }
   }
 
@@ -817,54 +1192,120 @@ int subprocess_create_ex(const char *const commandLine[], int options,
     used_environment = empty_environment;
   }
 
-  if (0 != posix_spawn_file_actions_init(&actions)) {
-    return -1;
+  posix_error = posix_spawn_file_actions_init(&actions);
+  if (0 != posix_error) {
+    saved_errno = posix_error;
+    result = subprocess_error_from_errno(posix_error);
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
+  }
+  actions_created = 1;
+
+  // Set working directory
+  if (process_cwd) {
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
+    posix_error = posix_spawn_file_actions_addchdir(&actions, process_cwd);
+#else
+#if defined(__APPLE__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    posix_error = posix_spawn_file_actions_addchdir_np(&actions, process_cwd);
+#if defined(__APPLE__) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#endif
+    if (0 != posix_error) {
+      saved_errno = posix_error;
+      result = subprocess_error_from_errno(posix_error);
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
+    }
   }
 
   // Close the stdin write end
-  if (0 != posix_spawn_file_actions_addclose(&actions, stdinfd[1])) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+  posix_error = posix_spawn_file_actions_addclose(&actions, stdinfd[1]);
+  if (0 != posix_error) {
+    saved_errno = posix_error;
+    result = subprocess_error_from_errno(posix_error);
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
   }
 
   // Map the read end to stdin
-  if (0 !=
-      posix_spawn_file_actions_adddup2(&actions, stdinfd[0], STDIN_FILENO)) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+  posix_error =
+      posix_spawn_file_actions_adddup2(&actions, stdinfd[0], STDIN_FILENO);
+  if (0 != posix_error) {
+    saved_errno = posix_error;
+    result = subprocess_error_from_errno(posix_error);
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
   }
 
   // Close the stdout read end
-  if (0 != posix_spawn_file_actions_addclose(&actions, stdoutfd[0])) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+  posix_error = posix_spawn_file_actions_addclose(&actions, stdoutfd[0]);
+  if (0 != posix_error) {
+    saved_errno = posix_error;
+    result = subprocess_error_from_errno(posix_error);
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
   }
 
   // Map the write end to stdout
-  if (0 !=
-      posix_spawn_file_actions_adddup2(&actions, stdoutfd[1], STDOUT_FILENO)) {
-    posix_spawn_file_actions_destroy(&actions);
-    return -1;
+  posix_error =
+      posix_spawn_file_actions_adddup2(&actions, stdoutfd[1], STDOUT_FILENO);
+  if (0 != posix_error) {
+    saved_errno = posix_error;
+    result = subprocess_error_from_errno(posix_error);
+    if (subprocess_error_unknown == result) {
+      result = subprocess_error_spawn;
+    }
+    goto cleanup;
   }
 
   if (subprocess_option_combined_stdout_stderr ==
       (options & subprocess_option_combined_stdout_stderr)) {
-    if (0 != posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
-                                              STDERR_FILENO)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+    posix_error = posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
+                                                   STDERR_FILENO);
+    if (0 != posix_error) {
+      saved_errno = posix_error;
+      result = subprocess_error_from_errno(posix_error);
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
     }
   } else {
     // Close the stderr read end
-    if (0 != posix_spawn_file_actions_addclose(&actions, stderrfd[0])) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+    posix_error = posix_spawn_file_actions_addclose(&actions, stderrfd[0]);
+    if (0 != posix_error) {
+      saved_errno = posix_error;
+      result = subprocess_error_from_errno(posix_error);
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
     }
     // Map the write end to stdout
-    if (0 != posix_spawn_file_actions_adddup2(&actions, stderrfd[1],
-                                              STDERR_FILENO)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+    posix_error = posix_spawn_file_actions_adddup2(&actions, stderrfd[1],
+                                                   STDERR_FILENO);
+    if (0 != posix_error) {
+      saved_errno = posix_error;
+      result = subprocess_error_from_errno(posix_error);
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
     }
   }
 
@@ -875,18 +1316,30 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 #endif
   if (subprocess_option_search_user_path ==
       (options & subprocess_option_search_user_path)) {
-    if (0 != posix_spawnp(&child, commandLine[0], &actions, SUBPROCESS_NULL,
-                          SUBPROCESS_CONST_CAST(char *const *, commandLine),
-                          used_environment)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+    posix_error = posix_spawnp(&child, commandLine[0], &actions,
+                               SUBPROCESS_NULL,
+                               SUBPROCESS_CONST_CAST(char *const *, commandLine),
+                               used_environment);
+    if (0 != posix_error) {
+      saved_errno = posix_error;
+      result = subprocess_error_from_errno(posix_error);
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
     }
   } else {
-    if (0 != posix_spawn(&child, commandLine[0], &actions, SUBPROCESS_NULL,
-                         SUBPROCESS_CONST_CAST(char *const *, commandLine),
-                         used_environment)) {
-      posix_spawn_file_actions_destroy(&actions);
-      return -1;
+    posix_error = posix_spawn(&child, commandLine[0], &actions,
+                              SUBPROCESS_NULL,
+                              SUBPROCESS_CONST_CAST(char *const *, commandLine),
+                              used_environment);
+    if (0 != posix_error) {
+      saved_errno = posix_error;
+      result = subprocess_error_from_errno(posix_error);
+      if (subprocess_error_unknown == result) {
+        result = subprocess_error_spawn;
+      }
+      goto cleanup;
     }
   }
 #ifdef __clang__
@@ -895,13 +1348,34 @@ int subprocess_create_ex(const char *const commandLine[], int options,
 
   // Close the stdin read end
   close(stdinfd[0]);
+  stdinfd[0] = -1;
   // Store the stdin write end
   out_process->stdin_file = fdopen(stdinfd[1], "wb");
+  if (SUBPROCESS_NULL == out_process->stdin_file) {
+    saved_errno = errno;
+    result = subprocess_error_from_errno(saved_errno);
+    goto cleanup;
+  }
+  stdinfd[1] = -1;
 
   // Close the stdout write end
   close(stdoutfd[1]);
+  stdoutfd[1] = -1;
   // Store the stdout read end
   out_process->stdout_file = fdopen(stdoutfd[0], "rb");
+  if (SUBPROCESS_NULL == out_process->stdout_file) {
+    saved_errno = errno;
+    result = subprocess_error_from_errno(saved_errno);
+    goto cleanup;
+  }
+  stdoutfd[0] = -1;
+
+  // Set non blocking if we are async and asked not to wait.
+  if (async_no_wait) {
+    fd = fileno(out_process->stdout_file);
+    fd_flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, fd_flags | O_NONBLOCK);
+  }
 
   if (subprocess_option_combined_stdout_stderr ==
       (options & subprocess_option_combined_stdout_stderr)) {
@@ -909,17 +1383,92 @@ int subprocess_create_ex(const char *const commandLine[], int options,
   } else {
     // Close the stderr write end
     close(stderrfd[1]);
+    stderrfd[1] = -1;
     // Store the stderr read end
     out_process->stderr_file = fdopen(stderrfd[0], "rb");
+    if (SUBPROCESS_NULL == out_process->stderr_file) {
+      saved_errno = errno;
+      result = subprocess_error_from_errno(saved_errno);
+      goto cleanup;
+    }
+    stderrfd[0] = -1;
+
+    // Set non blocking if we are async and asked not to wait.
+    if (async_no_wait) {
+      fd = fileno(out_process->stderr_file);
+      fd_flags = fcntl(fd, F_GETFL, 0);
+      fcntl(fd, F_SETFL, fd_flags | O_NONBLOCK);
+    }
   }
 
   // Store the child's pid
   out_process->child = child;
+  child = 0;
 
   out_process->alive = 1;
+  out_process->no_wait = async_no_wait;
 
-  posix_spawn_file_actions_destroy(&actions);
-  return 0;
+  result = 0;
+
+cleanup:
+  if ((0 != result) && (0 == saved_errno)) {
+    saved_errno = errno;
+  }
+
+  if ((subprocess_error_unknown == result) && (0 != saved_errno)) {
+    result = subprocess_error_from_errno(saved_errno);
+  }
+
+  if (actions_created) {
+    posix_spawn_file_actions_destroy(&actions);
+  }
+
+  if (0 != result) {
+    if (child) {
+      kill(child, 9);
+      waitpid(child, SUBPROCESS_NULL, 0);
+    }
+
+    if (out_process->stdin_file) {
+      fclose(out_process->stdin_file);
+      out_process->stdin_file = SUBPROCESS_NULL;
+    }
+
+    if (out_process->stdout_file) {
+      fclose(out_process->stdout_file);
+      if (out_process->stderr_file &&
+          (out_process->stdout_file != out_process->stderr_file)) {
+        fclose(out_process->stderr_file);
+      }
+      out_process->stdout_file = SUBPROCESS_NULL;
+      out_process->stderr_file = SUBPROCESS_NULL;
+    }
+  }
+
+  if (-1 != stdinfd[0]) {
+    close(stdinfd[0]);
+  }
+  if (-1 != stdinfd[1]) {
+    close(stdinfd[1]);
+  }
+  if (-1 != stdoutfd[0]) {
+    close(stdoutfd[0]);
+  }
+  if (-1 != stdoutfd[1]) {
+    close(stdoutfd[1]);
+  }
+  if (-1 != stderrfd[0]) {
+    close(stderrfd[0]);
+  }
+  if (-1 != stderrfd[1]) {
+    close(stderrfd[1]);
+  }
+
+  if ((0 != result) && (0 != saved_errno)) {
+    errno = saved_errno;
+  }
+
+  return result;
 #endif
 }
 
@@ -1060,12 +1609,24 @@ unsigned subprocess_read_stdout(struct subprocess_s *const process,
                                 char *const buffer, unsigned size) {
 #if defined(_WIN32)
   void *handle;
+  unsigned long bytes_available = 0;
   unsigned long bytes_read = 0;
   struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
   overlapped.hEvent = process->hEventOutput;
 
   handle = SUBPROCESS_PTR_CAST(void *,
                                _get_osfhandle(_fileno(process->stdout_file)));
+
+  if (process->no_wait) {
+    if (!PeekNamedPipe(handle, SUBPROCESS_NULL, 0, SUBPROCESS_NULL,
+                       &bytes_available, SUBPROCESS_NULL)) {
+      return 0;
+    }
+
+    if (0 == bytes_available) {
+      return 0;
+    }
+  }
 
   if (!ReadFile(handle, buffer, size, &bytes_read,
                 SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {
@@ -1074,14 +1635,20 @@ unsigned subprocess_read_stdout(struct subprocess_s *const process,
 
     // Means we've got an async read!
     if (error == errorIoPending) {
+      const uintptr_t statusPending = 0x00000103;
+
+      const int wait = statusPending == overlapped.Internal;
+
       if (!GetOverlappedResult(handle,
                                SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped),
-                               &bytes_read, 1)) {
-        const unsigned long errorIoIncomplete = 996;
+                               &bytes_read, wait)) {
         const unsigned long errorHandleEOF = 38;
+        const unsigned long errorBrokenPipe = 109;
+        const unsigned long errorIoIncomplete = 996;
         error = GetLastError();
 
-        if ((error != errorIoIncomplete) && (error != errorHandleEOF)) {
+        if ((errorHandleEOF != error) && (errorBrokenPipe != error) &&
+            (errorIoIncomplete != error)) {
           return 0;
         }
       }
@@ -1105,12 +1672,24 @@ unsigned subprocess_read_stderr(struct subprocess_s *const process,
                                 char *const buffer, unsigned size) {
 #if defined(_WIN32)
   void *handle;
+  unsigned long bytes_available = 0;
   unsigned long bytes_read = 0;
   struct subprocess_overlapped_s overlapped = {0, 0, {{0, 0}}, SUBPROCESS_NULL};
   overlapped.hEvent = process->hEventError;
 
   handle = SUBPROCESS_PTR_CAST(void *,
                                _get_osfhandle(_fileno(process->stderr_file)));
+
+  if (process->no_wait) {
+    if (!PeekNamedPipe(handle, SUBPROCESS_NULL, 0, SUBPROCESS_NULL,
+                       &bytes_available, SUBPROCESS_NULL)) {
+      return 0;
+    }
+
+    if (0 == bytes_available) {
+      return 0;
+    }
+  }
 
   if (!ReadFile(handle, buffer, size, &bytes_read,
                 SUBPROCESS_PTR_CAST(LPOVERLAPPED, &overlapped))) {


### PR DESCRIPTION
## Overview

Adds support for connecting llama-server to external MCP (Model Context Protocol) servers over stdio, exposing their tools through the existing /tools endpoint alongside the built-in ones.

Servers are configured in the Cursor-compatible JSON format, via either `--mcp-servers-config <path>` or `--mcp-servers-json <inline>`. At startup each configured server is spawned once to discover its tools, then shut down; instances are spawned lazily on first tool call and kept for the lifetime of the server process.

## Additional information

Important limitation for now: **MCP instances are global rather than per-slot**. The /tools endpoint has no slot binding, so keying instances by slot would tie external process lifetime to an unrelated inference slot's release, tearing down stateful MCP servers on every completion.

The feature is off by default and marked experimental: enabling it lets the server spawn arbitrary local processes, so it should not be used in untrusted environments.

Tool names are exposed as <server>_<tool> and skipped on collision with an existing tool, so an MCP server cannot shadow a built-in one.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, an adversarial framework with a coding council of StepFun 3.7 + DS4Pro as coders + Claude Opus 4.8 as the reviewer, based on my specs.