### PR TITLE
ui: fix context gauge for single-model usage

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ContextGaugeDetails.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ContextGaugeDetails.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { ChevronDown } from '@lucide/svelte';
+	import { persisted } from '$lib/stores/persisted.svelte';
 	import * as Collapsible from '$lib/components/ui/collapsible';
-	import { STATS_UNITS } from '$lib/constants';
+	import { STATS_UNITS, CONTEXT_GAUGE_DETAILS_OPEN_LOCALSTORAGE_KEY } from '$lib/constants';
 	import ContextGaugeDetailRow from './ContextGaugeDetailRow.svelte';
 
 	interface Props {
@@ -30,7 +31,11 @@
 		transientDetails
 	}: Props = $props();
 
-	let open = $state(false);
+	const detailsOpen = persisted<boolean>(CONTEXT_GAUGE_DETAILS_OPEN_LOCALSTORAGE_KEY, false);
+	let open = $state(detailsOpen.value);
+	$effect(() => {
+		detailsOpen.value = open;
+	});
 
 	const hasCumulative = $derived(cumulativeRead > 0 || cumulativeOutput > 0);
 	const hasCurrent = $derived(currentRead > 0 || currentOutput > 0);

--- a/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ContextGaugeDetails.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatForm/ChatFormContextGauge/ContextGaugeDetails.svelte
@@ -3,6 +3,7 @@
 	import { ChevronDown } from '@lucide/svelte';
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import { STATS_UNITS } from '$lib/constants';
+	import { gaugePopup } from '$lib/stores/context-gauge-popup.svelte';
 
 	interface Props {
 		currentRead: number;
@@ -30,19 +31,19 @@
 		transientDetails
 	}: Props = $props();
 
-	let open = $state(false);
-
 	const hasCumulative = $derived(cumulativeRead > 0 || cumulativeOutput > 0);
 	const hasCurrent = $derived(currentRead > 0 || currentOutput > 0);
 </script>
 
-<Collapsible.Root bind:open class="mt-3 border-t border-border/50 pt-4">
+<Collapsible.Root bind:open={gaugePopup.detailsOpen} class="mt-3 border-t border-border/50 pt-4">
 	<Collapsible.Trigger
 		class="flex w-full cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
 	>
 		<span>Token usage details</span>
 
-		<ChevronDown class={'ml-auto h-3 w-3 transition-transform' + (open ? ' rotate-180' : '')} />
+		<ChevronDown
+			class={'ml-auto h-3 w-3 transition-transform' + (gaugePopup.detailsOpen ? ' rotate-180' : '')}
+		/>
 	</Collapsible.Trigger>
 
 	<Collapsible.Content class="flex flex-col gap-4 text-xs pt-4">

--- a/tools/ui/src/lib/constants/storage.ts
+++ b/tools/ui/src/lib/constants/storage.ts
@@ -16,6 +16,7 @@ export const DB_APP_NAME_DEPRECATED = 'LlamacppWebui';
 
 export const ALWAYS_ALLOWED_TOOLS_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.alwaysAllowedTools`;
 export const CONFIG_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.config`;
+export const CONTEXT_GAUGE_DETAILS_OPEN_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.contextGaugeDetailsOpen`;
 export const DISABLED_TOOLS_LOCALSTORAGE_KEY = `${STORAGE_APP_NAME}.disabledTools`;
 
 /** Disabled tools keyed by stable selection identity, no migration from the name based key */

--- a/tools/ui/src/lib/hooks/use-context-gauge.svelte.ts
+++ b/tools/ui/src/lib/hooks/use-context-gauge.svelte.ts
@@ -107,7 +107,7 @@ export function useContextGauge(): UseContextGaugeReturn {
 	});
 
 	const isActiveModelLoaded = $derived(
-		activeModelId !== null && modelsStore.isModelLoaded(activeModelId)
+		activeModelId !== null && (!isRouterMode() || modelsStore.isModelLoaded(activeModelId))
 	);
 
 	const isActiveModelLoading = $derived(

--- a/tools/ui/src/lib/hooks/use-context-gauge.svelte.ts
+++ b/tools/ui/src/lib/hooks/use-context-gauge.svelte.ts
@@ -112,7 +112,7 @@ export function useContextGauge(): UseContextGaugeReturn {
 		return chatStore.getConversationModel(activeMessages() as DatabaseMessage[]);
 	});
 	const isActiveModelLoaded = $derived(
-		activeModelId !== null && modelsStore.isModelLoaded(activeModelId)
+		activeModelId !== null && (!isRouterMode() || modelsStore.isModelLoaded(activeModelId))
 	);
 	const isActiveModelLoading = $derived(
 		activeModelId !== null && modelsStore.isModelOperationInProgress(activeModelId)

--- a/tools/ui/src/lib/stores/context-gauge-popup.svelte.ts
+++ b/tools/ui/src/lib/stores/context-gauge-popup.svelte.ts
@@ -16,7 +16,7 @@ import {
 let closeTimer: ReturnType<typeof setTimeout> | undefined;
 let lastPointerType = '';
 
-export const gaugePopup = $state({ bottom: 0, centerX: 0, open: false });
+export const gaugePopup = $state({ bottom: 0, centerX: 0, detailsOpen: false, open: false });
 
 function openFrom(trigger: HTMLElement): void {
 	clearTimeout(closeTimer);


### PR DESCRIPTION
## Overview

Webui bugfix for single-model mode usage

## Additional information

In single-model (non-router) mode the server always has its model loaded and the /models/load endpoint does not exist. Current context gauge report the model as unloaded and showed a "Load model" button that will hit /models/load and errored.

See below:

<img width="3839" height="2159" alt="origin" src="https://github.com/user-attachments/assets/eb08d7c3-3d25-4354-a811-5c1e201f6619"/>
&nbsp;
<img width="3839" height="2159" alt="origin_1" src="https://github.com/user-attachments/assets/b928892f-bb74-4ded-812b-a0a2f74b29bb"/>

Cause: isModelLoaded only checks routerModels, which is empty when not in router mode, so isActiveModelLoaded always false there.

Fix: When not in router mode, treat as model loaded so the gauge hide the load prompt.

---

Second commit keeps the "Token usage details" open state in gauge popup store, so the open state persist without a localStorage entry or a new setting, reset on hard refresh.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to help draft and refine the implementation.