### PR TITLE
sycl: single-device still requires sync

### DIFF
--- a/ggml/src/ggml-sycl/fattn-onednn.cpp
+++ b/ggml/src/ggml-sycl/fattn-onednn.cpp
@@ -245,16 +245,11 @@ void ggml_sycl_flash_attn_ext_onednn(ggml_backend_sycl_context & ctx, ggml_tenso
     E.cp.execute(strm, ti, {to});
 
     permute_sdpa_out_sycl(outf.get(), (float *) dst->data, mb, H, q, d, stream);
-    // Single device: no sync is required, and actually PP perf is ~6% > wait_and_throw() (tested on llama-3.1-8b & qwen3.6-27b, both Q8_0, with Arc B70).
-    // Any future multi-GPU refactor MUST re-measure this single-device path and keep the best
-    // single-device PP speed. Otherwise (multiple devices/streams can race the reuse):
-    if (ggml_sycl_info().device_count > 1) {
-        // cont_to_f16 -> oneDNN execute -> permute is async on this stream, but the
-        // pool_alloc*s above free their device buffers at host return. Without this wait the next
-        // scheduler op re-acquires those bytes while the GPU is still computing the SDPA, turning
-        // it into garbage and collapsing multi-turn output to a single repeated token ("GGGGG...").
-        stream->wait_and_throw();
-    }
+    // cont_to_f16 -> oneDNN execute -> permute is async on this stream, but the
+    // pool_alloc*s above free their device buffers at host return. Without this wait the next
+    // scheduler op re-acquires those bytes while the GPU is still computing the SDPA, turning
+    // it into garbage and collapsing multi-turn output to a single repeated token ("GGGGG...").
+    stream->wait_and_throw();
 }
 catch (const std::exception & e) {
     // any oneDNN/SYCL failure is non-fatal: fall back to the existing kernel (strictly additive).


### PR DESCRIPTION
## Overview

Fix garbage output generated on second prompt in multi-turn conversation with model Qwen3-14B-Q4_K_M.

## Additional information

This can be reproduced with:

    $ ./build/bin/llama-cli -m /models/Qwen3-14B-Q4_K_M.gguf -ngl 100
    > foo
    # good output
    > bar
    # garbage output

The problematic commit, 32b741c336decea914e4c1c24a9c9815485901b2, was identified with help from git bisect.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, help to identify issue once the right commit was found.
