### PR TITLE
opencl: disable FA and MoE weights repack to work around compiler issues for Adreno 850 GPU

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -265,7 +265,8 @@ static ADRENO_GPU_GEN get_adreno_gpu_gen(const char *device_name) {
     }
 
     if (strstr(device_name, "830") ||
-        strstr(device_name, "840")) {
+        strstr(device_name, "840") ||
+        strstr(device_name, "850")) {
         return ADRENO_GPU_GEN::A8X;
     }
 
@@ -280,14 +281,6 @@ static ADRENO_GPU_GEN get_adreno_gpu_gen(const char *device_name) {
     return ADRENO_GPU_GEN::ADRENO_UNKNOWN;
 }
 
-// The art.api37 (E17) shader compiler miscompiles or crashes on several kernels. These are
-// CORRECTNESS workarounds (a compiler SIGSEGV and silently garbage weights), so they are
-// keyed on the compiler class and stay ON until a fixed compiler is verified -- they do not
-// lift themselves on a version bump. GGML_OPENCL_ART_QUIRKS=0 turns them all off in one run,
-// which is how a new compiler gets re-verified without a rebuild.
-struct ggml_backend_opencl_context;
-static bool adreno_art_compiler_quirks(const ggml_backend_opencl_context *backend_ctx);
-
 static ggml_cl_compiler_version get_adreno_cl_compiler_version(const char *driver_version) {
     std::string driver_ver_str(driver_version);
     ADRENO_CL_COMPILER_TYPE type = ADRENO_CL_COMPILER_TYPE::E031;
@@ -298,8 +291,6 @@ static ggml_cl_compiler_version get_adreno_cl_compiler_version(const char *drive
     size_t compiler_patch_offset = 11;
 
     if (compiler_ver_pos == std::string::npos) {
-        // "Compiler E17.51.05.00" -- the art.api37 driver series. Its prefix is three
-        // characters, so every field sits one earlier than in the E031 layout.
         compiler_ver_pos = driver_ver_str.find("E17");
         if (compiler_ver_pos != std::string::npos) {
             type = ADRENO_CL_COMPILER_TYPE::E17;
@@ -318,6 +309,8 @@ static ggml_cl_compiler_version get_adreno_cl_compiler_version(const char *drive
         type = ADRENO_CL_COMPILER_TYPE::DX;
         compiler_ver_len = 11;
         compiler_major_offset = 3;
+        compiler_minor_offset = 6;
+        compiler_patch_offset = 9;
     }
 
     std::string compiler_ver_str = driver_ver_str.substr(compiler_ver_pos, compiler_ver_len);
@@ -6969,12 +6962,12 @@ inline bool use_adreno_kernels(const ggml_backend_opencl_context *backend_ctx, c
     return threashold_ok;
 }
 
-static bool adreno_art_compiler_quirks(const ggml_backend_opencl_context *backend_ctx) {
+static bool adreno_e17_compiler_quirks(const ggml_backend_opencl_context *backend_ctx) {
     if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO ||
         backend_ctx->adreno_cl_compiler_version.type != ADRENO_CL_COMPILER_TYPE::E17) {
         return false;
     }
-    const char * env = getenv("GGML_OPENCL_ART_QUIRKS");
+    const char * env = getenv("GGML_OPENCL_ADRENO_E17_QUIRKS");
     return !(env && env[0] == '0');
 }
 
@@ -6990,7 +6983,7 @@ inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ct
         return false;
     }
 
-    if (adreno_art_compiler_quirks(backend_ctx)) {
+    if (adreno_e17_compiler_quirks(backend_ctx)) {
         return false;
     }
 
@@ -7326,10 +7319,8 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
         case GGML_OP_MEAN:
             return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_FLASH_ATTN_EXT: {
-            // The art.api37 (E17) shader compiler segfaults while building the flash_attn
-            // programs, which kills the process. Decline FA there; attention falls back to
-            // the unfused path, which is correct.
-            if (adreno_art_compiler_quirks(backend_ctx)) {
+            // The E17 compilers segfault while building FA kernels, skip E17 for now
+            if (adreno_e17_compiler_quirks(backend_ctx)) {
                 return false;
             }
             const ggml_tensor * q = op->src[0];

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -123,6 +123,7 @@ enum ADRENO_GPU_GEN {
 
 enum ADRENO_CL_COMPILER_TYPE {
     E031,
+    E17,
     DX,
 };
 
@@ -279,6 +280,14 @@ static ADRENO_GPU_GEN get_adreno_gpu_gen(const char *device_name) {
     return ADRENO_GPU_GEN::ADRENO_UNKNOWN;
 }
 
+// The art.api37 (E17) shader compiler miscompiles or crashes on several kernels. These are
+// CORRECTNESS workarounds (a compiler SIGSEGV and silently garbage weights), so they are
+// keyed on the compiler class and stay ON until a fixed compiler is verified -- they do not
+// lift themselves on a version bump. GGML_OPENCL_ART_QUIRKS=0 turns them all off in one run,
+// which is how a new compiler gets re-verified without a rebuild.
+struct ggml_backend_opencl_context;
+static bool adreno_art_compiler_quirks(const ggml_backend_opencl_context *backend_ctx);
+
 static ggml_cl_compiler_version get_adreno_cl_compiler_version(const char *driver_version) {
     std::string driver_ver_str(driver_version);
     ADRENO_CL_COMPILER_TYPE type = ADRENO_CL_COMPILER_TYPE::E031;
@@ -287,6 +296,19 @@ static ggml_cl_compiler_version get_adreno_cl_compiler_version(const char *drive
     size_t compiler_major_offset = 5;
     size_t compiler_minor_offset = 8;
     size_t compiler_patch_offset = 11;
+
+    if (compiler_ver_pos == std::string::npos) {
+        // "Compiler E17.51.05.00" -- the art.api37 driver series. Its prefix is three
+        // characters, so every field sits one earlier than in the E031 layout.
+        compiler_ver_pos = driver_ver_str.find("E17");
+        if (compiler_ver_pos != std::string::npos) {
+            type = ADRENO_CL_COMPILER_TYPE::E17;
+            compiler_ver_len = 12;
+            compiler_major_offset = 4;
+            compiler_minor_offset = 7;
+            compiler_patch_offset = 10;
+        }
+    }
 
     if (compiler_ver_pos == std::string::npos) {
         compiler_ver_pos = driver_ver_str.find("DX");
@@ -1655,6 +1677,7 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
     // those compiler versions since it is anyway not used for Adreno.
     if (backend_ctx->gpu_family != ADRENO ||
         backend_ctx->adreno_cl_compiler_version.newer_than_or_same(E031, 38, 11, 0) ||
+        backend_ctx->adreno_cl_compiler_version.type == E17 ||
         backend_ctx->adreno_cl_compiler_version.type == DX) {
 #ifdef GGML_OPENCL_EMBED_KERNELS
         const std::string kernel_src {
@@ -6946,6 +6969,15 @@ inline bool use_adreno_kernels(const ggml_backend_opencl_context *backend_ctx, c
     return threashold_ok;
 }
 
+static bool adreno_art_compiler_quirks(const ggml_backend_opencl_context *backend_ctx) {
+    if (!backend_ctx || backend_ctx->gpu_family != GPU_FAMILY::ADRENO ||
+        backend_ctx->adreno_cl_compiler_version.type != ADRENO_CL_COMPILER_TYPE::E17) {
+        return false;
+    }
+    const char * env = getenv("GGML_OPENCL_ART_QUIRKS");
+    return !(env && env[0] == '0');
+}
+
 inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ctx, const ggml_tensor *tensor) {
     // The moe weight repack kernels *_trans4_ns alias a private ushort8 through a uchar*.
     // Certain compilers (found with some A7x and A6x) miscompiles this, corrupting the weights.
@@ -6957,6 +6989,11 @@ inline bool use_adreno_moe_kernels(const ggml_backend_opencl_context *backend_ct
                         backend_ctx->adreno_gen == ADRENO_GPU_GEN::ADRENO_UNKNOWN)) {
         return false;
     }
+
+    if (adreno_art_compiler_quirks(backend_ctx)) {
+        return false;
+    }
+
     int ne01 = tensor->ne[1];
     return (((strstr(tensor->name, "ffn") != NULL) && (strstr(tensor->name, "exps") != NULL)) || (strstr(tensor->name, "as") != NULL)) && (ne01 % 32 == 0);
 }
@@ -7289,6 +7326,12 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
         case GGML_OP_MEAN:
             return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_FLASH_ATTN_EXT: {
+            // The art.api37 (E17) shader compiler segfaults while building the flash_attn
+            // programs, which kills the process. Decline FA there; attention falls back to
+            // the unfused path, which is correct.
+            if (adreno_art_compiler_quirks(backend_ctx)) {
+                return false;
+            }
             const ggml_tensor * q = op->src[0];
             const ggml_tensor * k = op->src[1];
             const ggml_tensor * v = op->src[2];

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
@@ -274,9 +274,7 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         shared_b[b_local_offset.y] = bx8_f16.hi;
 
         // Dequantization
-        // Cast the e8m0 scale to half: a bare half8 * float is a vector-by-higher-rank-scalar
-        // multiply, which the art.api37 (E17) shader compiler rejects. OpenCL converts the
-        // scalar to the vector element type anyway, so this is identical on every device.
+        // Cast the e8m0 scale to half to satisfy E17 compilers
         reg_a.lo = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.lo)) * (half)s;
         reg_a.hi = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.hi)) * (half)s;
 
@@ -307,9 +305,7 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         shared_b[b_local_offset.y] = bx8_f16.hi;
 
         // Dequantization
-        // Cast the e8m0 scale to half: a bare half8 * float is a vector-by-higher-rank-scalar
-        // multiply, which the art.api37 (E17) shader compiler rejects. OpenCL converts the
-        // scalar to the vector element type anyway, so this is identical on every device.
+        // Cast the e8m0 scale to half to satisfy E17 compilers
         reg_a.lo = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.lo)) * (half)s;
         reg_a.hi = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.hi)) * (half)s;
 

--- a/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
+++ b/ggml/src/ggml-opencl/kernels/gemm_moe_mxfp4_f32_ns.cl
@@ -274,8 +274,11 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         shared_b[b_local_offset.y] = bx8_f16.hi;
 
         // Dequantization
-        reg_a.lo = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.lo)) * s;
-        reg_a.hi = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.hi)) * s;
+        // Cast the e8m0 scale to half: a bare half8 * float is a vector-by-higher-rank-scalar
+        // multiply, which the art.api37 (E17) shader compiler rejects. OpenCL converts the
+        // scalar to the vector element type anyway, so this is identical on every device.
+        reg_a.lo = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.lo)) * (half)s;
+        reg_a.hi = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.hi)) * (half)s;
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 
@@ -304,8 +307,11 @@ kernel void kernel_gemm_moe_mxfp4_f32_ns(
         shared_b[b_local_offset.y] = bx8_f16.hi;
 
         // Dequantization
-        reg_a.lo = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.lo)) * s;
-        reg_a.hi = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.hi)) * s;
+        // Cast the e8m0 scale to half: a bare half8 * float is a vector-by-higher-rank-scalar
+        // multiply, which the art.api37 (E17) shader compiler rejects. OpenCL converts the
+        // scalar to the vector element type anyway, so this is identical on every device.
+        reg_a.lo = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.lo)) * (half)s;
+        reg_a.hi = mxfp4_to_fp16_packed8(as_ushort2(mxfp4x16.hi)) * (half)s;
 
         sub_group_barrier(CLK_LOCAL_MEM_FENCE);
 

--- a/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32.cl
+++ b/ggml/src/ggml-opencl/kernels/mul_mv_q4_k_f32.cl
@@ -1,3 +1,5 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 #ifdef cl_intel_required_subgroup_size
 #pragma OPENCL EXTENSION cl_intel_required_subgroup_size : enable
 #define INTEL_GPU 1


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This PR temporally disables FA and MoE weights repack to work around compatibility issues in the compiler of Adreno 850 GPU. 

We will update the workaround in the future when its compiler is more mature. 

## Additional information

For Adreno 850 GPU only. 

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) Yes
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, testing. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
