### PR TITLE
Enable CUDA graphs on Volta+Turing

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3978,7 +3978,7 @@ static bool ggml_cuda_graph_set_enabled(ggml_backend_cuda_context * cuda_ctx, co
     ggml_cuda_graph * graph = cuda_ctx->cuda_graph(graph_key);
 
     if (graph->graph == nullptr) {
-        if (ggml_cuda_info().devices[cuda_ctx->device].cc < GGML_CUDA_CC_AMPERE) {
+        if (ggml_cuda_info().devices[cuda_ctx->device].cc < GGML_CUDA_CC_VOLTA) {
             if (!graph->disable_due_to_gpu_arch) {
                 GGML_LOG_DEBUG("%s: disabling CUDA graphs due to GPU architecture\n", __func__);
             }


### PR DESCRIPTION
## Overview

This PR expands the check for whether or not CUDA graphs are enabled so that it includes Volta and Turing archs.

I haven't been able to find a reason for this to not be enabled, there's no perplexity difference and performance seems equal or better across the board (mostly the same in -sm layer case, with some major gains in -sm tensor).

Outputs are coherent but I haven't tested any conversations past a few turns. I also have not tested Turing as I don't have access to any hardware, but I would presume that if it works good on Volta it will probably be fine on Turing as well?

## Additional information

For context I'm running Debian 13 on a dual socket E5-2696 v4 system, 8 x V100 32GB cards with 8x Gen3 PCIE each (4 cards per NUMA node), nvidia driver 580.105.08, and llama.cpp built w/ CUDA 12.9

I did some llama-perplexity runs on wikitext-2 and for performance I ran llama-bench on a bunch of currently popular models using -sm layer, as well as -sm tensor when possible:

<details>
<summary>Master Performance</summary>

```console
alexander@alexander-compute:~/.llama-server/models$ llama-bench -sm layer -m deepseek-v4-flash-mxfp4.gguf,gemma-4-12b-it-f16.gguf,gemma-4-26b-a4b-f16.gguf,mistral-medium-3.5-128b-q8_0.gguf,nvidia-nemotron-3-super-120b-a12b-q8_0.gguf,qwen3.5-122b-a10b-q8_0.gguf,qwen3.6-27b-f16.gguf,qwen3.6-35b-a3b-f16.gguf,gemma-4-31b-it-f16.gguf,minimax-m2.7-ud-q6_k.gguf
ggml_cuda_init: found 8 CUDA devices (Total VRAM: 259953 MiB):
  Device 0: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 1: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 2: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 3: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 4: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 5: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 6: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 7: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| deepseek4 ?B MXFP4 MoE         | 145.29 GiB |   284.33 B | CUDA       |  -1 |           pp512 |        200.74 ± 0.49 |
| deepseek4 ?B MXFP4 MoE         | 145.29 GiB |   284.33 B | CUDA       |  -1 |           tg128 |         13.19 ± 0.47 |
| gemma4 ?B F16                  |  22.18 GiB |    11.91 B | CUDA       |  -1 |           pp512 |      2562.05 ± 10.88 |
| gemma4 ?B F16                  |  22.18 GiB |    11.91 B | CUDA       |  -1 |           tg128 |         29.71 ± 0.04 |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 |           pp512 |      1915.59 ± 15.92 |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 |           tg128 |         62.46 ± 0.18 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 |           pp512 |        200.78 ± 2.14 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 |           tg128 |          5.84 ± 0.04 |
| nemotron_h_moe 120B.A12B Q8_0  | 119.64 GiB |   120.67 B | CUDA       |  -1 |           pp512 |        304.08 ± 3.13 |
| nemotron_h_moe 120B.A12B Q8_0  | 119.64 GiB |   120.67 B | CUDA       |  -1 |           tg128 |         40.86 ± 0.05 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 |           pp512 |       472.95 ± 10.87 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 |           tg128 |         41.94 ± 3.80 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 |           pp512 |       1141.03 ± 1.40 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 |           tg128 |         14.98 ± 0.01 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 |           pp512 |      1468.10 ± 11.47 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 |           tg128 |         73.58 ± 0.53 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 |           pp512 |       1011.51 ± 2.61 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 |           tg128 |         12.85 ± 0.03 |
| minimax-m2 230B.A10B Q6_K      | 175.14 GiB |   228.69 B | CUDA       |  -1 |           pp512 |        310.00 ± 2.55 |
| minimax-m2 230B.A10B Q6_K      | 175.14 GiB |   228.69 B | CUDA       |  -1 |           tg128 |         50.66 ± 0.76 |

build: 505b1ed15 (10034)



alexander@alexander-compute:~/.llama-server/models$ llama-bench -sm tensor -m gemma-4-26b-a4b-f16.gguf,mistral-medium-3.5-128b-q8_0.gguf,
qwen3.5-122b-a10b-q8_0.gguf,qwen3.6-27b-f16.gguf,qwen3.6-35b-a3b-f16.gguf,gemma-4-31b-it-f16.gguf
ggml_cuda_init: found 8 CUDA devices (Total VRAM: 259953 MiB):
  Device 0: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 1: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 2: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 3: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 4: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 5: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 6: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 7: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
| model                          |       size |     params | backend    | ngl |     sm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --------------: | -------------------: |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 | tensor |           pp512 |       871.09 ± 10.45 |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 | tensor |           tg128 |         26.78 ± 0.20 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 | tensor |           pp512 |        263.29 ± 0.35 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 | tensor |           tg128 |         16.45 ± 0.28 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 | tensor |           pp512 |         91.73 ± 1.39 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 | tensor |           tg128 |         17.47 ± 0.17 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 | tensor |           pp512 |        863.04 ± 1.36 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 | tensor |           tg128 |         20.00 ± 0.13 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 | tensor |           pp512 |       654.86 ± 11.00 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 | tensor |           tg128 |         24.73 ± 0.19 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 | tensor |           pp512 |        852.69 ± 1.11 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 | tensor |           tg128 |         24.46 ± 0.14 |

build: 505b1ed15 (10034)
```

</details>

<details>
<summary>Master Perplexity</summary>

```console
alexander@alexander-compute:~/.llama-server/models$ llama-perplexity -m qwen3.6-35b-a3b-f16.gguf -f wikitext-2-raw/wiki.test.raw
1.23.056.672 I
1.23.056.791 I system_info: n_threads = 44 (n_threads_batch = 44) / 88 | CUDA : ARCHS = 700 | USE_GRAPHS = 1 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 |
1.23.056.806 I perplexity: tokenizing the input ..
1.23.699.601 I perplexity: tokenization took 642.785 ms
1.23.700.135 I perplexity: calculating perplexity over 580 chunks, n_ctx=512, batch_size=2048, n_seq=4
1.26.188.425 I perplexity: 2.49 seconds per pass - ETA 6.00 minutes
[1]4.0650,[2]5.8142,[3]5.1449,[4]5.1424,[5]5.2781,[6]5.4537,[7]5.6992,[8]6.2053,[9]6.6769,[10]7.0606,[11]6.9882,[12]7.1031,[13]7.5161,[14]7.0982,[15]7.0534,[16]7.0866,[17]6.7024,[18]6.7583,[19]6.6863,[20]6.6119,[21]6.4351,[22]6.3794,[23]6.1563,[24]5.8996,[25]5.7758,[26]5.6492,[27]5.5573,[28]5.5005,[29]5.5105,[30]5.4766,[31]5.4436,[32]5.4744,[33]5.4669,[34]5.5134,[35]5.5935,[36]5.7167,[37]5.7845,[38]5.7665,[39]5.7882,[40]5.8349,[41]5.8523,[42]5.9008,[43]5.8994,[44]5.8851,[45]5.9434,[46]5.9131,[47]6.0215,[48]6.0712,[49]6.0383,[50]6.0534,[51]6.0475,[52]6.0936,[53]6.1433,[54]6.1637,[55]6.1781,[56]6.2012,[57]6.2115,[58]6.2196,[59]6.2208,[60]6.2516,[61]6.2836,[62]6.3379,[63]6.3845,[64]6.4315,[65]6.4905,[66]6.5180,[67]6.5836,[68]6.6149,[69]6.6275,[70]6.5941,[71]6.6402,[72]6.6550,[73]6.6849,[74]6.6818,[75]6.6700,[76]6.6654,[77]6.7023,[78]6.7136,[79]6.5993,[80]6.5475,[81]6.5264,[82]6.5394,[83]6.5503,[84]6.5466,[85]6.5647,[86]6.5989,[87]6.6021,[88]6.6131,[89]6.5875,[90]6.5740,[91]6.5739,[92]6.5598,[93]6.5860,[94]6.5966,[95]6.6126,[96]6.6088,[97]6.5944,[98]6.5890,[99]6.5942,[100]6.6200,[101]6.6308,[102]6.6294,[103]6.6229,[104]6.6100,[105]6.6108,[106]6.6308,[107]6.6611,[108]6.7124,[109]6.7031,[110]6.7596,[111]6.7902,[112]6.8060,[113]6.8358,[114]6.8805,[115]6.9051,[116]6.8516,[117]6.8460,[118]6.8488,[119]6.8182,[120]6.8240,[121]6.8061,[122]6.7900,[123]6.7791,[124]6.7530,[125]6.7322,[126]6.7093,[127]6.6856,[128]6.6401,[129]6.6092,[130]6.5849,[131]6.5616,[132]6.5733,[133]6.5712,[134]6.5740,[135]6.5808,[136]6.5673,[137]6.5474,[138]6.5485,[139]6.5597,[140]6.5600,[141]6.5729,[142]6.5844,[143]6.5812,[144]6.5882,[145]6.5631,[146]6.5482,[147]6.5235,[148]6.5083,[149]6.4716,[150]6.4494,[151]6.4386,[152]6.4174,[153]6.3896,[154]6.3819,[155]6.3647,[156]6.3382,[157]6.3180,[158]6.3015,[159]6.2769,[160]6.2590,[161]6.2533,[162]6.2361,[163]6.2161,[164]6.2126,[165]6.2247,[166]6.2160,[167]6.2396,[168]6.2430,[169]6.2758,[170]6.2806,[171]6.3162,[172]6.3531,[173]6.3734,[174]6.4214,[175]6.4405,[176]6.4744,[177]6.4992,[178]6.5039,[179]6.4971,[180]6.4913,[181]6.5140,[182]6.5211,[183]6.5247,[184]6.5343,[185]6.5348,[186]6.5384,[187]6.5438,[188]6.5554,[189]6.5742,[190]6.5893,[191]6.5933,[192]6.5956,[193]6.6117,[194]6.6308,[195]6.6531,[196]6.6634,[197]6.6499,[198]6.6482,[199]6.6388,[200]6.6417,[201]6.6457,[202]6.6670,[203]6.6912,[204]6.7101,[205]6.7010,[206]6.7176,[207]6.7043,[208]6.7110,[209]6.7057,[210]6.7053,[211]6.7072,[212]6.7111,[213]6.6961,[214]6.6843,[215]6.6715,[216]6.6721,[217]6.6624,[218]6.6438,[219]6.6191,[220]6.6103,[221]6.6052,[222]6.6039,[223]6.6133,[224]6.5973,[225]6.5871,[226]6.5889,[227]6.5736,[228]6.5619,[229]6.5531,[230]6.5354,[231]6.5254,[232]6.5252,[233]6.5220,[234]6.5200,[235]6.5090,[236]6.5033,[237]6.4924,[238]6.4820,[239]6.4762,[240]6.4739,[241]6.4731,[242]6.4784,[243]6.4936,[244]6.4947,[245]6.5043,[246]6.5169,[247]6.5323,[248]6.5426,[249]6.5523,[250]6.5648,[251]6.5724,[252]6.5858,[253]6.6098,[254]6.6123,[255]6.6138,[256]6.6203,[257]6.6150,[258]6.5957,[259]6.5832,[260]6.5681,[261]6.5536,[262]6.5581,[263]6.5647,[264]6.5682,[265]6.5744,[266]6.5688,[267]6.5608,[268]6.5601,[269]6.5536,[270]6.5414,[271]6.5363,[272]6.5235,[273]6.5271,[274]6.5245,[275]6.5257,[276]6.5235,[277]6.5227,[278]6.5245,[279]6.5257,[280]6.5088,[281]6.5148,[282]6.4957,[283]6.4890,[284]6.4932,[285]6.4910,[286]6.4756,[287]6.4690,[288]6.4721,[289]6.4828,[290]6.4950,[291]6.5067,[292]6.5139,[293]6.5201,[294]6.5365,[295]6.5348,[296]6.5406,[297]6.5315,[298]6.5280,[299]6.5226,[300]6.5183,[301]6.5132,[302]6.5042,[303]6.5113,[304]6.5160,[305]6.5129,[306]6.5131,[307]6.5128,[308]6.5106,[309]6.5132,[310]6.5194,[311]6.5173,[312]6.5207,[313]6.5215,[314]6.5136,[315]6.5066,[316]6.5215,[317]6.5279,[318]6.5402,[319]6.5128,[320]6.4985,[321]6.4856,[322]6.4880,[323]6.4871,[324]6.4927,[325]6.4879,[326]6.4877,[327]6.4838,[328]6.4812,[329]6.4757,[330]6.4702,[331]6.4711,[332]6.4647,[333]6.4598,[334]6.4681,[335]6.4620,[336]6.4654,[337]6.4655,[338]6.4650,[339]6.4611,[340]6.4535,[341]6.4599,[342]6.4608,[343]6.4627,[344]6.4623,[345]6.4533,[346]6.4543,[347]6.4472,[348]6.4461,[349]6.4431,[350]6.4486,[351]6.4459,[352]6.4398,[353]6.4499,[354]6.4578,[355]6.4658,[356]6.4584,[357]6.4580,[358]6.4530,[359]6.4558,[360]6.4496,[361]6.4438,[362]6.4413,[363]6.4515,[364]6.4730,[365]6.4870,[366]6.5101,[367]6.5235,[368]6.5338,[369]6.5512,[370]6.5703,[371]6.5747,[372]6.5829,[373]6.5963,[374]6.6093,[375]6.6161,[376]6.6256,[377]6.6343,[378]6.6500,[379]6.6629,[380]6.6712,[381]6.6827,[382]6.6906,[383]6.7104,[384]6.7247,[385]6.7259,[386]6.7271,[387]6.7331,[388]6.7531,[389]6.7675,[390]6.7656,[391]6.7609,[392]6.7522,[393]6.7528,[394]6.7554,[395]6.7570,[396]6.7562,[397]6.7579,[398]6.7612,[399]6.7641,[400]6.7578,[401]6.7490,[402]6.7402,[403]6.7286,[404]6.7283,[405]6.7344,[406]6.7387,[407]6.7395,[408]6.7390,[409]6.7491,[410]6.7465,[411]6.7447,[412]6.7423,[413]6.7327,[414]6.7293,[415]6.7316,[416]6.7305,[417]6.7275,[418]6.7194,[419]6.7209,[420]6.7135,[421]6.7075,[422]6.7036,[423]6.6977,[424]6.6996,[425]6.7065,[426]6.7090,[427]6.7131,[428]6.7044,[429]6.7021,[430]6.7045,[431]6.6954,[432]6.6942,[433]6.6964,[434]6.6962,[435]6.7030,[436]6.7015,[437]6.6911,[438]6.6960,[439]6.7005,[440]6.7018,[441]6.6973,[442]6.6955,[443]6.6869,[444]6.6858,[445]6.6847,[446]6.6857,[447]6.6765,[448]6.6780,[449]6.6762,[450]6.6738,[451]6.6699,[452]6.6647,[453]6.6687,[454]6.6738,[455]6.6797,[456]6.6895,[457]6.6837,[458]6.6833,[459]6.6856,[460]6.6925,[461]6.6967,[462]6.7001,[463]6.7046,[464]6.7089,[465]6.7159,[466]6.7236,[467]6.7250,[468]6.7233,[469]6.7230,[470]6.7191,[471]6.7194,[472]6.7262,[473]6.7271,[474]6.7218,[475]6.7207,[476]6.7143,[477]6.7188,[478]6.7290,[479]6.7336,[480]6.7374,[481]6.7414,[482]6.7397,[483]6.7406,[484]6.7399,[485]6.7353,[486]6.7275,[487]6.7280,[488]6.7234,[489]6.7166,[490]6.7139,[491]6.7140,[492]6.7107,[493]6.7104,[494]6.7179,[495]6.7243,[496]6.7185,[497]6.7205,[498]6.7185,[499]6.7187,[500]6.7306,[501]6.7305,[502]6.7309,[503]6.7316,[504]6.7310,[505]6.7340,[506]6.7357,[507]6.7343,[508]6.7421,[509]6.7350,[510]6.7332,[511]6.7325,[512]6.7316,[513]6.7296,[514]6.7230,[515]6.7197,[516]6.7211,[517]6.7279,[518]6.7258,[519]6.7220,[520]6.7233,[521]6.7266,[522]6.7312,[523]6.7264,[524]6.7269,[525]6.7194,[526]6.7166,[527]6.7138,[528]6.7186,[529]6.7155,[530]6.7132,[531]6.7139,[532]6.7133,[533]6.7085,[534]6.7097,[535]6.7120,[536]6.7139,[537]6.7199,[538]6.7194,[539]6.7140,[540]6.7191,[541]6.7199,[542]6.7231,[543]6.7191,[544]6.7088,[545]6.7009,[546]6.7057,[547]6.6996,[548]6.6934,[549]6.6840,[550]6.6722,[551]6.6696,[552]6.6735,[553]6.6804,[554]6.6817,[555]6.6883,[556]6.6930,[557]6.6978,[558]6.7014,[559]6.7098,[560]6.7156,[561]6.7225,[562]6.7193,[563]6.7215,[564]6.7131,[565]6.7150,[566]6.7098,[567]6.7132,[568]6.7146,[569]6.7163,[570]6.7124,[571]6.7117,[572]6.7182,[573]6.7144,[574]6.7170,[575]6.7170,[576]6.7231,[577]6.7263,[578]6.7325,[579]6.7246,[580]6.7214,
5.49.180.011 I Final estimate: PPL = 6.7214 +/- 0.04370
```

</details>

<details>
<summary>PR Performance</summary>

```console
alexander@alexander-compute:~/.llama-server/models$ llama-bench -sm layer -m deepseek-v4-flash-mxfp4.gguf,gemma-4-12b-it-f16.gguf,gemma-4-26b-a4b-f16.gguf,mistral-medium-3.5-128b-q8_0.gguf,nvidia-nemotron-3-super-120b-a12b-q8_0.gguf,qwen3.5-122b-a10b-q8_0.gguf,qwen3.6-27b-f16.gguf,qwen3.6-35b-a3b-f16.gguf,gemma-4-31b-it-f16.gguf,minimax-m2.7-ud-q6_k.gguf
ggml_cuda_init: found 8 CUDA devices (Total VRAM: 259953 MiB):
  Device 0: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 1: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 2: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 3: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 4: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 5: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 6: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 7: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| deepseek4 ?B MXFP4 MoE         | 145.29 GiB |   284.33 B | CUDA       |  -1 |           pp512 |        199.71 ± 0.60 |
| deepseek4 ?B MXFP4 MoE         | 145.29 GiB |   284.33 B | CUDA       |  -1 |           tg128 |         13.01 ± 0.45 |
| gemma4 ?B F16                  |  22.18 GiB |    11.91 B | CUDA       |  -1 |           pp512 |      2553.16 ± 22.35 |
| gemma4 ?B F16                  |  22.18 GiB |    11.91 B | CUDA       |  -1 |           tg128 |         29.80 ± 0.01 |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 |           pp512 |      1995.71 ± 10.81 |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 |           tg128 |         64.99 ± 0.07 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 |           pp512 |        210.29 ± 1.20 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 |           tg128 |          5.97 ± 0.03 |
| nemotron_h_moe 120B.A12B Q8_0  | 119.64 GiB |   120.67 B | CUDA       |  -1 |           pp512 |        309.51 ± 3.92 |
| nemotron_h_moe 120B.A12B Q8_0  | 119.64 GiB |   120.67 B | CUDA       |  -1 |           tg128 |         41.21 ± 0.07 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 |           pp512 |        501.28 ± 4.13 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 |           tg128 |         47.68 ± 0.04 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 |           pp512 |      1130.75 ± 13.39 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 |           tg128 |         15.03 ± 0.00 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 |           pp512 |      1463.54 ± 18.62 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 |           tg128 |         73.76 ± 0.15 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 |           pp512 |      1014.14 ± 17.22 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 |           tg128 |         12.88 ± 0.04 |
| minimax-m2 230B.A10B Q6_K      | 175.14 GiB |   228.69 B | CUDA       |  -1 |           pp512 |        302.60 ± 3.82 |
| minimax-m2 230B.A10B Q6_K      | 175.14 GiB |   228.69 B | CUDA       |  -1 |           tg128 |         50.84 ± 0.59 |

build: e22c572e6 (10037)



alexander@alexander-compute:~/.llama-server/models$ llama-bench -sm tensor -m gemma-4-26b-a4b-f16.gguf,mistral-medium-3.5-128b-q8_0.gguf,qwen3.5-122b-a10b-q8_0.gguf,qwen3.6-27b-f16.gguf,qwen3.6-35b-a3b-f16.gguf,gemma-4-31b-it-f16.gguf
ggml_cuda_init: found 8 CUDA devices (Total VRAM: 259953 MiB):
  Device 0: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 1: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 2: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 3: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 4: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 5: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 6: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
  Device 7: Tesla V100-SXM2-32GB, compute capability 7.0, VMM: yes, VRAM: 32494 MiB
| model                          |       size |     params | backend    | ngl |     sm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | -----: | --------------: | -------------------: |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 | tensor |           pp512 |       880.18 ± 49.01 |
| gemma4 26B.A4B F16             |  47.02 GiB |    25.23 B | CUDA       |  -1 | tensor |           tg128 |         50.11 ± 0.60 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 | tensor |           pp512 |        263.77 ± 0.74 |
| mistral3 ?B Q8_0               | 123.72 GiB |   125.03 B | CUDA       |  -1 | tensor |           tg128 |         20.94 ± 0.15 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 | tensor |           pp512 |         94.19 ± 0.68 |
| qwen35moe 122B.A10B Q8_0       | 123.44 GiB |   124.64 B | CUDA       |  -1 | tensor |           tg128 |         58.25 ± 3.27 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 | tensor |           pp512 |        860.89 ± 4.04 |
| qwen35 27B F16                 |  50.89 GiB |    27.32 B | CUDA       |  -1 | tensor |           tg128 |         40.96 ± 1.13 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 | tensor |           pp512 |       636.08 ± 35.59 |
| qwen35moe 35B.A3B F16          |  64.60 GiB |    34.66 B | CUDA       |  -1 | tensor |           tg128 |         57.92 ± 1.26 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 | tensor |           pp512 |       848.42 ± 17.10 |
| gemma4 31B F16                 |  57.18 GiB |    30.70 B | CUDA       |  -1 | tensor |           tg128 |         35.59 ± 0.46 |

build: e22c572e6 (10037)
```

</details>

<details>
<summary>PR Perplexity</summary>

```console
alexander@alexander-compute:~/.llama-server/models$ llama-perplexity -m qwen3.6-35b-a3b-f16.gguf -f wikitext-2-raw/wiki.test.raw
0.18.830.909 I
0.18.831.015 I system_info: n_threads = 44 (n_threads_batch = 44) / 88 | CUDA : ARCHS = 700 | USE_GRAPHS = 1 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 |
0.18.831.028 I perplexity: tokenizing the input ..
0.19.473.118 I perplexity: tokenization took 642.081 ms
0.19.473.633 I perplexity: calculating perplexity over 580 chunks, n_ctx=512, batch_size=2048, n_seq=4
0.21.944.581 I perplexity: 2.47 seconds per pass - ETA 5.97 minutes
[1]4.0650,[2]5.8142,[3]5.1449,[4]5.1424,[5]5.2781,[6]5.4537,[7]5.6992,[8]6.2053,[9]6.6769,[10]7.0606,[11]6.9882,[12]7.1031,[13]7.5161,[14]7.0982,[15]7.0534,[16]7.0866,[17]6.7024,[18]6.7583,[19]6.6863,[20]6.6119,[21]6.4351,[22]6.3794,[23]6.1563,[24]5.8996,[25]5.7758,[26]5.6492,[27]5.5573,[28]5.5005,[29]5.5105,[30]5.4766,[31]5.4436,[32]5.4744,[33]5.4669,[34]5.5134,[35]5.5935,[36]5.7167,[37]5.7845,[38]5.7665,[39]5.7882,[40]5.8349,[41]5.8523,[42]5.9008,[43]5.8994,[44]5.8851,[45]5.9434,[46]5.9131,[47]6.0215,[48]6.0712,[49]6.0383,[50]6.0534,[51]6.0475,[52]6.0936,[53]6.1433,[54]6.1637,[55]6.1781,[56]6.2012,[57]6.2115,[58]6.2196,[59]6.2208,[60]6.2516,[61]6.2836,[62]6.3379,[63]6.3845,[64]6.4315,[65]6.4905,[66]6.5180,[67]6.5836,[68]6.6149,[69]6.6275,[70]6.5941,[71]6.6402,[72]6.6550,[73]6.6849,[74]6.6818,[75]6.6700,[76]6.6654,[77]6.7023,[78]6.7136,[79]6.5993,[80]6.5475,[81]6.5264,[82]6.5394,[83]6.5503,[84]6.5466,[85]6.5647,[86]6.5989,[87]6.6021,[88]6.6131,[89]6.5875,[90]6.5740,[91]6.5739,[92]6.5598,[93]6.5860,[94]6.5966,[95]6.6126,[96]6.6088,[97]6.5944,[98]6.5890,[99]6.5942,[100]6.6200,[101]6.6308,[102]6.6294,[103]6.6229,[104]6.6100,[105]6.6108,[106]6.6308,[107]6.6611,[108]6.7124,[109]6.7031,[110]6.7596,[111]6.7902,[112]6.8060,[113]6.8358,[114]6.8805,[115]6.9051,[116]6.8516,[117]6.8460,[118]6.8488,[119]6.8182,[120]6.8240,[121]6.8061,[122]6.7900,[123]6.7791,[124]6.7530,[125]6.7322,[126]6.7093,[127]6.6856,[128]6.6401,[129]6.6092,[130]6.5849,[131]6.5616,[132]6.5733,[133]6.5712,[134]6.5740,[135]6.5808,[136]6.5673,[137]6.5474,[138]6.5485,[139]6.5597,[140]6.5600,[141]6.5729,[142]6.5844,[143]6.5812,[144]6.5882,[145]6.5631,[146]6.5482,[147]6.5235,[148]6.5083,[149]6.4716,[150]6.4494,[151]6.4386,[152]6.4174,[153]6.3896,[154]6.3819,[155]6.3647,[156]6.3382,[157]6.3180,[158]6.3015,[159]6.2769,[160]6.2590,[161]6.2533,[162]6.2361,[163]6.2161,[164]6.2126,[165]6.2247,[166]6.2160,[167]6.2396,[168]6.2430,[169]6.2758,[170]6.2806,[171]6.3162,[172]6.3531,[173]6.3734,[174]6.4214,[175]6.4405,[176]6.4744,[177]6.4992,[178]6.5039,[179]6.4971,[180]6.4913,[181]6.5140,[182]6.5211,[183]6.5247,[184]6.5343,[185]6.5348,[186]6.5384,[187]6.5438,[188]6.5554,[189]6.5742,[190]6.5893,[191]6.5933,[192]6.5956,[193]6.6117,[194]6.6308,[195]6.6531,[196]6.6634,[197]6.6499,[198]6.6482,[199]6.6388,[200]6.6417,[201]6.6457,[202]6.6670,[203]6.6912,[204]6.7101,[205]6.7010,[206]6.7176,[207]6.7043,[208]6.7110,[209]6.7057,[210]6.7053,[211]6.7072,[212]6.7111,[213]6.6961,[214]6.6843,[215]6.6715,[216]6.6721,[217]6.6624,[218]6.6438,[219]6.6191,[220]6.6103,[221]6.6052,[222]6.6039,[223]6.6133,[224]6.5973,[225]6.5871,[226]6.5889,[227]6.5736,[228]6.5619,[229]6.5531,[230]6.5354,[231]6.5254,[232]6.5252,[233]6.5220,[234]6.5200,[235]6.5090,[236]6.5033,[237]6.4924,[238]6.4820,[239]6.4762,[240]6.4739,[241]6.4731,[242]6.4784,[243]6.4936,[244]6.4947,[245]6.5043,[246]6.5169,[247]6.5323,[248]6.5426,[249]6.5523,[250]6.5648,[251]6.5724,[252]6.5858,[253]6.6098,[254]6.6123,[255]6.6138,[256]6.6203,[257]6.6150,[258]6.5957,[259]6.5832,[260]6.5681,[261]6.5536,[262]6.5581,[263]6.5647,[264]6.5682,[265]6.5744,[266]6.5688,[267]6.5608,[268]6.5601,[269]6.5536,[270]6.5414,[271]6.5363,[272]6.5235,[273]6.5271,[274]6.5245,[275]6.5257,[276]6.5235,[277]6.5227,[278]6.5245,[279]6.5257,[280]6.5088,[281]6.5148,[282]6.4957,[283]6.4890,[284]6.4932,[285]6.4910,[286]6.4756,[287]6.4690,[288]6.4721,[289]6.4828,[290]6.4950,[291]6.5067,[292]6.5139,[293]6.5201,[294]6.5365,[295]6.5348,[296]6.5406,[297]6.5315,[298]6.5280,[299]6.5226,[300]6.5183,[301]6.5132,[302]6.5042,[303]6.5113,[304]6.5160,[305]6.5129,[306]6.5131,[307]6.5128,[308]6.5106,[309]6.5132,[310]6.5194,[311]6.5173,[312]6.5207,[313]6.5215,[314]6.5136,[315]6.5066,[316]6.5215,[317]6.5279,[318]6.5402,[319]6.5128,[320]6.4985,[321]6.4856,[322]6.4880,[323]6.4871,[324]6.4927,[325]6.4879,[326]6.4877,[327]6.4838,[328]6.4812,[329]6.4757,[330]6.4702,[331]6.4711,[332]6.4647,[333]6.4598,[334]6.4681,[335]6.4620,[336]6.4654,[337]6.4655,[338]6.4650,[339]6.4611,[340]6.4535,[341]6.4599,[342]6.4608,[343]6.4627,[344]6.4623,[345]6.4533,[346]6.4543,[347]6.4472,[348]6.4461,[349]6.4431,[350]6.4486,[351]6.4459,[352]6.4398,[353]6.4499,[354]6.4578,[355]6.4658,[356]6.4584,[357]6.4580,[358]6.4530,[359]6.4558,[360]6.4496,[361]6.4438,[362]6.4413,[363]6.4515,[364]6.4730,[365]6.4870,[366]6.5101,[367]6.5235,[368]6.5338,[369]6.5512,[370]6.5703,[371]6.5747,[372]6.5829,[373]6.5963,[374]6.6093,[375]6.6161,[376]6.6256,[377]6.6343,[378]6.6500,[379]6.6629,[380]6.6712,[381]6.6827,[382]6.6906,[383]6.7104,[384]6.7247,[385]6.7259,[386]6.7271,[387]6.7331,[388]6.7531,[389]6.7675,[390]6.7656,[391]6.7609,[392]6.7522,[393]6.7528,[394]6.7554,[395]6.7570,[396]6.7562,[397]6.7579,[398]6.7612,[399]6.7641,[400]6.7578,[401]6.7490,[402]6.7402,[403]6.7286,[404]6.7283,[405]6.7344,[406]6.7387,[407]6.7395,[408]6.7390,[409]6.7491,[410]6.7465,[411]6.7447,[412]6.7423,[413]6.7327,[414]6.7293,[415]6.7316,[416]6.7305,[417]6.7275,[418]6.7194,[419]6.7209,[420]6.7135,[421]6.7075,[422]6.7036,[423]6.6977,[424]6.6996,[425]6.7065,[426]6.7090,[427]6.7131,[428]6.7044,[429]6.7021,[430]6.7045,[431]6.6954,[432]6.6942,[433]6.6964,[434]6.6962,[435]6.7030,[436]6.7015,[437]6.6911,[438]6.6960,[439]6.7005,[440]6.7018,[441]6.6973,[442]6.6955,[443]6.6869,[444]6.6858,[445]6.6847,[446]6.6857,[447]6.6765,[448]6.6780,[449]6.6762,[450]6.6738,[451]6.6699,[452]6.6647,[453]6.6687,[454]6.6738,[455]6.6797,[456]6.6895,[457]6.6837,[458]6.6833,[459]6.6856,[460]6.6925,[461]6.6967,[462]6.7001,[463]6.7046,[464]6.7089,[465]6.7159,[466]6.7236,[467]6.7250,[468]6.7233,[469]6.7230,[470]6.7191,[471]6.7194,[472]6.7262,[473]6.7271,[474]6.7218,[475]6.7207,[476]6.7143,[477]6.7188,[478]6.7290,[479]6.7336,[480]6.7374,[481]6.7414,[482]6.7397,[483]6.7406,[484]6.7399,[485]6.7353,[486]6.7275,[487]6.7280,[488]6.7234,[489]6.7166,[490]6.7139,[491]6.7140,[492]6.7107,[493]6.7104,[494]6.7179,[495]6.7243,[496]6.7185,[497]6.7205,[498]6.7185,[499]6.7187,[500]6.7306,[501]6.7305,[502]6.7309,[503]6.7316,[504]6.7310,[505]6.7340,[506]6.7357,[507]6.7343,[508]6.7421,[509]6.7350,[510]6.7332,[511]6.7325,[512]6.7316,[513]6.7296,[514]6.7230,[515]6.7197,[516]6.7211,[517]6.7279,[518]6.7258,[519]6.7220,[520]6.7233,[521]6.7266,[522]6.7312,[523]6.7264,[524]6.7269,[525]6.7194,[526]6.7166,[527]6.7138,[528]6.7186,[529]6.7155,[530]6.7132,[531]6.7139,[532]6.7133,[533]6.7085,[534]6.7097,[535]6.7120,[536]6.7139,[537]6.7199,[538]6.7194,[539]6.7140,[540]6.7191,[541]6.7199,[542]6.7231,[543]6.7191,[544]6.7088,[545]6.7009,[546]6.7057,[547]6.6996,[548]6.6934,[549]6.6840,[550]6.6722,[551]6.6696,[552]6.6735,[553]6.6804,[554]6.6817,[555]6.6883,[556]6.6930,[557]6.6978,[558]6.7014,[559]6.7098,[560]6.7156,[561]6.7225,[562]6.7193,[563]6.7215,[564]6.7131,[565]6.7150,[566]6.7098,[567]6.7132,[568]6.7146,[569]6.7163,[570]6.7124,[571]6.7117,[572]6.7182,[573]6.7144,[574]6.7170,[575]6.7170,[576]6.7231,[577]6.7263,[578]6.7325,[579]6.7246,[580]6.7214,
4.42.650.020 I Final estimate: PPL = 6.7214 +/- 0.04370
```

</details>

The -sm layer tests seem to have had a few decent improvements, but mostly insignificant up/down fluctuations, while the -sm tensor cases definitely had the more interesting highlights. Most notable for me would probably be qwen3.6 27b going from 20tps to 41tps, and gemma 4 31b going from 24tps to 36tps. qwen3.5 122b is also an interesting case with a huge jump from 17tps to 58tps, but the pp is still quite bad with tensor split on this model.

As an aside, I seem to remember getting better -sm tensor performance before I upgraded from 6 to 8 GPUs, I would guess because that forced me to bifurcate two of my 16x lanes into 8x ones? Unsure if this is at all relevant to this PR but I thought it was at least worth mentioning in case these numbers look off from other V100 + sm tensor test results that may be out there.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, asked Gemini 3.5 flash via antigravity cli whether or not cuda graphs were enabled for volta