### PR TITLE
readme : add Chaty to UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 
 - [AI Sublime Text plugin](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) (MIT)
 - [BonzAI App](https://apps.apple.com/us/app/bonzai-your-local-ai-agent/id6752847988) (proprietary)
+- [Chaty](https://github.com/Fangyuan025/Chaty) (MIT)
 - [cztomsik/ava](https://github.com/cztomsik/ava) (MIT)
 - [Dot](https://github.com/alexpinel/Dot) (GPL)
 - [eva](https://github.com/ylsdamxssjxxdd/eva) (MIT)


### PR DESCRIPTION
Adds [Chaty](https://github.com/Fangyuan025/Chaty) (MIT) to the UIs list, alphabetically.

Chaty is a free, open-source desktop app (Windows + macOS) built on llama.cpp via the [`llama-cpp-2`](https://github.com/utilityai/llama-cpp-rs) bindings — the dependency is stated in the README's first line and in the About dialog. Chat with GGUF models (multimodal via `mtmd`), a local coding agent, document knowledge base (RAG), and offline voice — 100% local.