### PR TITLE
tests: actually exercise `test-recurrent-state-rollback`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,8 @@ if (LLAMA_LLGUIDANCE)
     llama_build_and_test(test-grammar-llguidance.cpp ARGS ${PROJECT_SOURCE_DIR}/models/ggml-vocab-llama-bpe.gguf)
 endif ()
 
+llama_build(test-recurrent-state-rollback.cpp get-model.cpp)
+
 if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     # these tests are disabled on Windows because they use internal functions not exported with LLAMA_API (when building with shared libraries)
     llama_build_and_test(test-sampling.cpp)
@@ -193,6 +195,30 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     # llama_build_and_test(test-double-float.cpp) # SLOW
 
     llama_build_and_test(test-llama-archs.cpp)
+
+    set(QWEN35_ROLLBACK_MODEL_DIR "${CMAKE_CURRENT_BINARY_DIR}/test-models/qwen35")
+    set(QWEN35_ROLLBACK_MODEL     "${QWEN35_ROLLBACK_MODEL_DIR}/qwen35-dense.gguf")
+
+    file(MAKE_DIRECTORY "${QWEN35_ROLLBACK_MODEL_DIR}")
+
+    llama_test(
+        test-llama-archs
+        NAME test-generate-qwen35-rollback-model
+        LABEL main
+        ARGS -a qwen35 -s 1234 -o "${QWEN35_ROLLBACK_MODEL_DIR}"
+    )
+    set_tests_properties(test-generate-qwen35-rollback-model PROPERTIES
+        FIXTURES_SETUP qwen35-rollback-model
+    )
+
+    llama_test(
+        test-recurrent-state-rollback
+        LABEL main
+        ARGS -m "${QWEN35_ROLLBACK_MODEL}" -ngl 0
+    )
+    set_tests_properties(test-recurrent-state-rollback PROPERTIES
+        FIXTURES_REQUIRED qwen35-rollback-model
+    )
 endif()
 
 llama_build_and_test(test-chat-peg-parser.cpp peg-parser/simple-tokenize.cpp)
@@ -249,9 +275,6 @@ llama_build_and_test(test-backend-sampler.cpp   LABEL "model")
 # Requires a model, uses same args pattern as test-thread-safety
 llama_build_and_test(test-state-restore-fragmented.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
 set_tests_properties(test-state-restore-fragmented PROPERTIES FIXTURES_REQUIRED test-download-model)
-
-llama_build_and_test(test-recurrent-state-rollback.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
-set_tests_properties(test-recurrent-state-rollback PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 # Test state save/load functionality
 llama_build_and_test(test-save-load-state.cpp LABEL "model" ARGS -m "${MODEL_DEST}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,28 +196,26 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
 
     llama_build_and_test(test-llama-archs.cpp)
 
-    set(QWEN35_ROLLBACK_MODEL_DIR "${CMAKE_CURRENT_BINARY_DIR}/test-models/qwen35")
-    set(QWEN35_ROLLBACK_MODEL     "${QWEN35_ROLLBACK_MODEL_DIR}/qwen35-dense.gguf")
-
-    file(MAKE_DIRECTORY "${QWEN35_ROLLBACK_MODEL_DIR}")
+    set(MODEL_DIR "${CMAKE_CURRENT_BINARY_DIR}/test-models/")
+    file(MAKE_DIRECTORY "${MODEL_DIR}")
 
     llama_test(
         test-llama-archs
-        NAME test-generate-qwen35-rollback-model
+        NAME test-generate-models
         LABEL main
-        ARGS -a qwen35 -s 1234 -o "${QWEN35_ROLLBACK_MODEL_DIR}"
+        ARGS -o "${MODEL_DIR}"
     )
-    set_tests_properties(test-generate-qwen35-rollback-model PROPERTIES
-        FIXTURES_SETUP qwen35-rollback-model
+    set_tests_properties(test-generate-models PROPERTIES
+        FIXTURES_SETUP generate-models
     )
 
     llama_test(
         test-recurrent-state-rollback
         LABEL main
-        ARGS -m "${QWEN35_ROLLBACK_MODEL}" -ngl 0
+        ARGS -m "${MODEL_DIR}/qwen35-dense.gguf"
     )
     set_tests_properties(test-recurrent-state-rollback PROPERTIES
-        FIXTURES_REQUIRED qwen35-rollback-model
+        FIXTURES_REQUIRED generate-models
     )
 endif()
 

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -465,7 +465,7 @@ static int save_models(const llm_arch target_arch, const size_t seed, const ggml
             if (!moe && moe_mandatory(arch)) {
                 continue;
             }
-            if (!llama_model_saver_supports_arch(arch)) {
+            if (!llama_model_saver_supports_arch(arch) || !arch_supported(arch)) {
                 LOG_INF("%s: %s model (%s) is unsupported, skipping\n", __func__, llm_arch_name(arch), moe ? "MoE" : "dense");
                 continue;
             }

--- a/tests/test-recurrent-state-rollback.cpp
+++ b/tests/test-recurrent-state-rollback.cpp
@@ -79,7 +79,12 @@ int main(int argc, char ** argv) {
         return 0;
     }
 
-    std::vector<llama_token> tokens = common_tokenize(ctx_src, "The quick brown fox jumps", true);
+    std::vector<llama_token> tokens;
+    if (llama_vocab_type(vocab) == LLAMA_VOCAB_TYPE_NONE) {
+        tokens = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    } else {
+        tokens = common_tokenize(ctx_src, "The quick brown fox jumps", true);
+    }
     const uint32_t n_rs_seq = llama_n_rs_seq(ctx_src);
     if (tokens.size() > n_rs_seq + 1) {
         tokens.resize(n_rs_seq + 1);

--- a/tests/test-recurrent-state-rollback.cpp
+++ b/tests/test-recurrent-state-rollback.cpp
@@ -20,7 +20,7 @@ static llama_context * make_ctx(const common_params & params, llama_model * mode
 static bool decode_tokens(llama_context * ctx, const std::vector<llama_token> & tokens, uint32_t count) {
     llama_batch batch = llama_batch_init(count, 0, 1);
     for (uint32_t pos = 0; pos < count; ++pos) {
-        common_batch_add(batch, tokens[pos], pos, { 0 }, false);
+        common_batch_add(batch, tokens[pos], pos, { 0 }, pos + 1 == count);
     }
     const bool ok = llama_decode(ctx, batch) == 0;
     llama_batch_free(batch);


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Currently `test-recurrent-state-rollback` is not exercised, this PR creates a small qwen35 to exercise it.


## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES, paired with codex

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
