### PR TITLE
readme : add Chaty to UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 
 - [AI Sublime Text plugin](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) (MIT)
 - [BonzAI App](https://apps.apple.com/us/app/bonzai-your-local-ai-agent/id6752847988) (proprietary)
+- [Chaty](https://github.com/Fangyuan025/Chaty) (MIT)
 - [cztomsik/ava](https://github.com/cztomsik/ava) (MIT)
 - [Dot](https://github.com/alexpinel/Dot) (GPL)
 - [eva](https://github.com/ylsdamxssjxxdd/eva) (MIT)


### PR DESCRIPTION
## Overview

- Adds [Chaty](https://github.com/Fangyuan025/Chaty) (MIT) to the UIs list, alphabetically.

- Chaty is an open-source desktop app (Windows + macOS) built on llama.cpp via the [llama-cpp-2](https://github.com/utilityai/llama-cpp-rs) bindings — the dependency is stated in the README's first line and in the About dialog.

## Additional information

- Official website: https://chaty.ca

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
