### PR TITLE
conversion: accept BitNetForCausalLM architecture name

### DIFF
--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -31,6 +31,7 @@ TEXT_MODEL_MAP: dict[str, str] = {
     "BertForSequenceClassification": "bert",
     "BertModel": "bert",
     "BitnetForCausalLM": "bitnet",
+    "BitNetForCausalLM": "bitnet",
     "BloomForCausalLM": "bloom",
     "BloomModel": "bloom",
     "CamembertModel": "bert",

--- a/conversion/bitnet.py
+++ b/conversion/bitnet.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 from .base import ModelBase, TextModel, gguf
 
 
-@ModelBase.register("BitnetForCausalLM")
+@ModelBase.register("BitnetForCausalLM", "BitNetForCausalLM")
 class BitnetModel(TextModel):
     model_arch = gguf.MODEL_ARCH.BITNET
 


### PR DESCRIPTION
## Overview

Fixes #25629

Microsoft BitNet Hugging Face checkpoints expose architecture `BitNetForCausalLM`, but the HF→GGUF converter only registered `BitnetForCausalLM`. Conversion fails with:

```
ERROR:hf-to-gguf:Model BitNetForCausalLM is not supported
```

This PR registers both spellings in `TEXT_MODEL_MAP` and on the Bitnet model class so either naming convention resolves to the same converter.

## Additional information

- Related discussion in #25629 (community-reported mismatch between `--print-supported-models` output and runtime architecture check)
- Change is limited to two alias registrations; no converter logic changes

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — used a coding assistant to locate the issue and draft the PR description; the code change was reviewed manually before submission