### PR TITLE
opencl: do not treat NULL-mask flash attention as causal

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -14609,7 +14609,11 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
 
     // Flash-Decoding K-split decision. Resolved here, before the prefill
     // prepass, because KV-pad and blk prepass are pure overhead when FD fires.
-    const int is_causal = (mask == NULL && n_q > 1 && n_q == n_kv);
+    // Do not infer causality from tensor shapes: a NULL mask means full
+    // (bidirectional) attention, e.g. ViT encoders, where n_q == n_kv as well.
+    // Causal attention in llama.cpp always comes with an explicit KQ mask.
+    // Inferring is_causal here corrupted mmproj output on OpenCL (see #23800).
+    const int is_causal = 0;
     const int fd_max_n_q = (d_head_q <= FD_MAX_DK_MULTI) ? FD_MAX_N_Q_MULTI : 1;
     cl_kernel fd_k_split = NULL;
     bool use_fd_mq = false;


### PR DESCRIPTION
Fixes #23800 (closed by the stale bot without a fix; the root-cause analysis there is correct).

## Problem

`ggml_cl_flash_attn` in `ggml-opencl.cpp` infers causal masking from tensor shapes alone:

```c
const int is_causal = (mask == NULL && n_q > 1 && n_q == n_kv);
```

This misfires for ViT full (bidirectional) attention: the visual encoder passes no KQ mask and has `n_q == n_kv`, so causal masking is silently applied to it. As a result, offloading the mmproj of multimodal models to the OpenCL backend produces corrupted visual tokens — the model hallucinates unrelated content for any input image, while the CPU path is correct.

## Fix

Causal attention graphs built by llama.cpp always come with an explicit KQ mask, so a NULL mask must mean full attention. Drop the shape-based inference (`is_causal = 0`).

## Testing

Device: POCO F6 (Snapdragon 8s Gen 3, Adreno 735), Android 14, OpenCL backend, `-ngl 99` with mmproj offloaded.

Models: Qwen3-VL-2B-Instruct (Q4_K_M + Q8_0 mmproj), Qwen2.5-VL-3B-Instruct (Q4_K_M + F16 mmproj).

Task: transcription of a photo showing a test question (llama-mtmd-cli, `--temp 0`).

- Before: both models output hallucination loops unrelated to the image (e.g. repeated invented lines); `--no-mmproj-offload` (ViT on CPU) is correct, confirming the ViT path as the culprit.
- After: full-GPU output matches the CPU-ViT reference transcription; encode time for a 1024px image drops from 39–68 s (CPU ViT) to 12.3 s (OpenCL ViT).
- `--flash-attn off` is not a workaround: the non-FA ViT path tries to allocate a ~9.4 GB buffer at this image size and crashes.

Note: heavier prefill-time causal FA optimizations for LLMs (if any relied on this heuristic) are unaffected, because LLM graphs always pass a mask.