### PR TITLE
MUSA:add GGML_MUSA_WMMA_FATTN option

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -221,6 +221,7 @@ option(GGML_HIP_MMQ_MFMA                    "ggml: enable MFMA MMA for CDNA in M
 option(GGML_HIP_EXPORT_METRICS              "ggml: enable kernel perf metrics output"         OFF)
 option(GGML_MUSA_GRAPHS                     "ggml: use MUSA graph, experimental, unstable"    OFF)
 option(GGML_MUSA_MUDNN_COPY                 "ggml: enable muDNN for accelerated copy"         OFF)
+option(GGML_MUSA_WMMA_FATTN                 "ggml: enable MUSA WMMA for FlashAttention"       OFF)
 option(GGML_VULKAN                          "ggml: use Vulkan"                                OFF)
 option(GGML_VULKAN_CHECK_RESULTS            "ggml: run Vulkan op checks"                      OFF)
 option(GGML_VULKAN_DEBUG                    "ggml: enable Vulkan debug output"                OFF)

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -291,9 +291,13 @@ static const char * cu_get_error_str(CUresult err) {
 #define CP_ASYNC_AVAILABLE
 #endif // !defined(GGML_USE_HIP) && __CUDA_ARCH__ >= GGML_CUDA_CC_AMPERE
 
-#if !defined(GGML_CUDA_NO_FA) && !(defined(GGML_USE_MUSA) && __MUSA_ARCH__ < 220)
+#if defined(GGML_USE_MUSA) && (__MUSA_ARCH__ < 220) && !defined(GGML_MUSA_WMMA_FATTN)
+#define GGML_MUSA_NO_FA
+#endif // defined(GGML_USE_MUSA) && (__MUSA_ARCH__ < 220) && !defined(GGML_MUSA_WMMA_FATTN)
+
+#if !defined(GGML_CUDA_NO_FA) && !defined(GGML_MUSA_NO_FA)
 #define FLASH_ATTN_AVAILABLE
-#endif // !defined(GGML_CUDA_NO_FA) && !(defined(GGML_USE_MUSA) && __MUSA_ARCH__ < 220)
+#endif // !defined(GGML_CUDA_NO_FA) && !defined(GGML_MUSA_NO_FA)
 
 static bool fp16_available(const int cc) {
     return ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_PASCAL ||

--- a/ggml/src/ggml-cuda/fattn-wmma-f16.cu
+++ b/ggml/src/ggml-cuda/fattn-wmma-f16.cu
@@ -45,7 +45,7 @@ static __global__ void flash_attn_ext_f16(
                             const int32_t nb21, const int32_t nb22, const int64_t nb23,
                             const int32_t ne31, const int32_t ne32, const int32_t ne33,
                             const int32_t nb31, const int32_t nb32, const int64_t nb33) {
-#if defined(FLASH_ATTN_AVAILABLE) && (defined(GGML_HIP_ROCWMMA_FATTN) && defined(GGML_USE_WMMA_FATTN))
+#if defined(FLASH_ATTN_AVAILABLE) && defined(GGML_USE_WMMA_FATTN) && (defined(GGML_HIP_ROCWMMA_FATTN) || defined(GGML_MUSA_WMMA_FATTN))
     const char * GGML_CUDA_RESTRICT Q        = Q_ptr;
     const char * GGML_CUDA_RESTRICT K        = K_ptr;
     const char * GGML_CUDA_RESTRICT V        = V_ptr;

--- a/ggml/src/ggml-cuda/fattn-wmma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-wmma-f16.cuh
@@ -24,7 +24,7 @@
 
 // WMMA flash attention requires FP16 matrix instructions to be available for ggml code.
 static bool ggml_cuda_should_use_wmma_fattn(const int cc) {
-#if defined(GGML_USE_HIP) && !defined(GGML_HIP_ROCWMMA_FATTN)
+#if (defined(GGML_USE_HIP) && !defined(GGML_HIP_ROCWMMA_FATTN)) || (defined(GGML_USE_MUSA) && !defined(GGML_MUSA_WMMA_FATTN))
     return false;
 #else
     if ((GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) == GGML_CUDA_CC_VOLTA) ||

--- a/ggml/src/ggml-musa/CMakeLists.txt
+++ b/ggml/src/ggml-musa/CMakeLists.txt
@@ -101,6 +101,10 @@ if (MUSAToolkit_FOUND)
         add_compile_definitions(GGML_CUDA_NO_PEER_COPY)
     endif()
 
+    if (GGML_MUSA_WMMA_FATTN)
+        add_compile_definitions(GGML_MUSA_WMMA_FATTN)
+    endif()
+
     if (GGML_STATIC)
         target_link_libraries(ggml-musa PRIVATE MUSA::musart_static MUSA::mublas_static)
         # TODO: mudnn has not provided static libraries yet


### PR DESCRIPTION


## Overview

    1. Add the GGML_MUSA_WMMA_FATTN build option for enabling the MUSA WMMA-based Flash Attention implementation, disable as default.
    2. Disable the regular Flash Attention kernels on MUSA architectures below 220 unless MUSA WMMA Flash Attention is enabled, using GGML_MUSA_NO_FA.
    3. Define FLASH_ATTN_AVAILABLE only when Flash Attention has not been disabled globally and is supported by the selected MUSA architecture.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI only assisted with comment polishing

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
