### PR TITLE
mtmd: use align_corners for Qwen3-VL vision position-embedding interpolation

### DIFF
--- a/tools/mtmd/models/qwen3vl.cpp
+++ b/tools/mtmd/models/qwen3vl.cpp
@@ -37,7 +37,7 @@ ggml_cgraph * clip_graph_qwen3vl::build() {
     }
 
     // calculate absolute position embedding and apply
-    ggml_tensor * learned_pos_embd = resize_position_embeddings();
+    ggml_tensor * learned_pos_embd = resize_position_embeddings(GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ALIGN_CORNERS);
     learned_pos_embd = ggml_cont_4d(
         ctx0, learned_pos_embd,
         n_embd * 2, n_patches_x / 2, n_patches_y, batch_size);


### PR DESCRIPTION
## Summary

Qwen3-VL's learned absolute vision position embedding is interpolated to the runtime patch grid in
`tools/mtmd/models/qwen3vl.cpp` via `resize_position_embeddings()`, which uses the default
`GGML_SCALE_MODE_BILINEAR | GGML_SCALE_FLAG_ANTIALIAS` - in other words, **align_corners=False** (half-pixel).

However, the reference transformers implementation uses **align_corners=True**.
`transformers` its `get_vision_bilinear_indices_and_weights` builds the sampling grid with
`torch.linspace(0, side - 1, T)`, so pinned to `[0, side-1]`.

This fixes that.

## Additional information

This is regarding my own experience and the comment at the end of #16880 (which is now closed).
The 0–1000 relative-coordinate rescale discussed is correct, but @sucubus666's point was also correct:
after applying the 0–1000 rescale there is still a residual spatial error that grows with image size,
is per-axis for non-square images, and isn't corrected for. That residual is this backend
interpolation-convention mismatch.

You can verify this yourself using a non-square image and prompting it to do detection of something
small, like a word. It will output a box that appears to be scaled outwards from the center of the
image.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): YES
- AI usage disclosure: YES, it helped me find the problem. However, I made this PR and reviewed and compared it myself as well, making sure it's correct.