### PR TITLE
UI: fix Settings/Display tool call content toggle

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
@@ -43,7 +43,7 @@
 
 	const renderThinkingAsMarkdown = $derived(config().renderThinkingAsMarkdown as boolean);
 	const showThoughtInProgress = $derived(Boolean(config().showThoughtInProgress));
-	const showToolCallInProgress = $derived(Boolean(config().showToolCallInProgress));
+	const alwaysShowToolCallContent = $derived(Boolean(config().alwaysShowToolCallContent));
 	const showMessageStats = $derived(Boolean(config().showMessageStats));
 	const showAgenticTurnStats = $derived(showMessageStats && Boolean(config().showAgenticTurnStats));
 
@@ -141,7 +141,7 @@
 			section.type === AgenticSectionType.TOOL_CALL_PENDING ||
 			section.type === AgenticSectionType.TOOL_CALL_STREAMING
 		) {
-			return showToolCallInProgress;
+			return alwaysShowToolCallContent;
 		}
 
 		if (section.type === AgenticSectionType.REASONING_PENDING) {

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
@@ -43,6 +43,7 @@
 
 	const renderThinkingAsMarkdown = $derived(config().renderThinkingAsMarkdown as boolean);
 	const showThoughtInProgress = $derived(Boolean(config().showThoughtInProgress));
+	const showToolCallInProgress = $derived(Boolean(config().showToolCallInProgress));
 	const showMessageStats = $derived(Boolean(config().showMessageStats));
 	const showAgenticTurnStats = $derived(showMessageStats && Boolean(config().showAgenticTurnStats));
 
@@ -98,19 +99,6 @@
 		isStreaming ? agenticExecutingToolCallId(message.convId) : null
 	);
 
-	// Skip sections the user manually collapsed - we never override an explicit false.
-	let lastSeenExecutingToolCallId: string | null = null;
-	$effect(() => {
-		const current = currentlyExecutingToolCallId;
-		const previous = lastSeenExecutingToolCallId;
-		lastSeenExecutingToolCallId = current;
-		if (!current || current === previous) return;
-		const idx = sections.findIndex((s) => s.toolCallId === current);
-		if (idx >= 0 && expandedStates[idx] === undefined) {
-			expandedStates[idx] = true;
-		}
-	});
-
 	type TurnGroup = {
 		sections: AgenticSection[];
 		flatIndices: number[];
@@ -149,10 +137,11 @@
 
 	function getDefaultExpanded(section: AgenticSection): boolean {
 		if (
+			section.type === AgenticSectionType.TOOL_CALL ||
 			section.type === AgenticSectionType.TOOL_CALL_PENDING ||
 			section.type === AgenticSectionType.TOOL_CALL_STREAMING
 		) {
-			return false;
+			return showToolCallInProgress;
 		}
 
 		if (section.type === AgenticSectionType.REASONING_PENDING) {

--- a/tools/ui/src/lib/constants/settings-keys.ts
+++ b/tools/ui/src/lib/constants/settings-keys.ts
@@ -60,7 +60,7 @@ export const SETTINGS_KEYS = {
 	MCP_SERVERS: 'mcpServers',
 	MCP_REQUEST_TIMEOUT_SECONDS: 'mcpRequestTimeoutSeconds',
 	AGENTIC_MAX_TURNS: 'agenticMaxTurns',
-	SHOW_TOOL_CALL_IN_PROGRESS: 'showToolCallInProgress',
+	ALWAYS_SHOW_TOOL_CALL_CONTENT: 'alwaysShowToolCallContent',
 	// Performance
 	PRE_ENCODE_CONVERSATION: 'preEncodeConversation',
 	// Developer

--- a/tools/ui/src/lib/constants/settings-registry.ts
+++ b/tools/ui/src/lib/constants/settings-registry.ts
@@ -253,14 +253,14 @@ const SETTINGS_REGISTRY: Record<string, SettingsSectionEntry> = {
 				}
 			},
 			{
-				key: SETTINGS_KEYS.SHOW_TOOL_CALL_IN_PROGRESS,
-				label: 'Show tool call in progress',
+				key: SETTINGS_KEYS.ALWAYS_SHOW_TOOL_CALL_CONTENT,
+				label: 'Always show tool call content',
 				help: 'Automatically expand tool call details while executing and keep them expanded after completion.',
 				defaultValue: false,
 				type: SettingsFieldType.CHECKBOX,
 				section: SETTINGS_SECTION_SLUGS.DISPLAY,
 				sync: {
-					serverKey: SETTINGS_KEYS.SHOW_TOOL_CALL_IN_PROGRESS,
+					serverKey: SETTINGS_KEYS.ALWAYS_SHOW_TOOL_CALL_CONTENT,
 					paramType: SyncableParameterType.BOOLEAN
 				}
 			},


### PR DESCRIPTION
## Overview

Fixes about this toggle :

The toggle had no effect, it now controls the default expansion of tool call blocks in both cases: 1) live during inference and 2) when loading a saved conversation.

The setting is renamed to "Always show tool call content", along with its JSON key :
"showToolCallInProgress" -> "alwaysShowToolCallContent"
Because it keeps the content expanded after completion, unlike "Show thought in progress" which only applies while inference is running.

## Additional information

Fixes #25743

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES Frontier models + Self-hosted computer use infrastructure

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
