### PR TITLE
llama-quant : exclude i32 ffn_gate_tid2eid routing table from quantization

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -306,6 +306,9 @@ static bool tensor_allows_quantization(const llama_model_quantize_params * param
     // NOTE: can't use LLM_TN here because the layer number is not known
     quantize &= name.find("ffn_gate_inp.weight") == std::string::npos;
 
+    // do not quantize the i32 token-id -> expert-id routing table (DeepSeek-V4)
+    quantize &= name.find("ffn_gate_tid2eid.weight") == std::string::npos;
+
     // these are very small (e.g. 4x4)
     quantize &= name.find("altup")  == std::string::npos;
     quantize &= name.find("laurel") == std::string::npos;


### PR DESCRIPTION
## Problem

`llama-quantize` fails on DeepSeek-V4 models. The `ffn_gate_tid2eid` tensor is an i32 token-id -> expert-id routing/index table (used via `GGML_OP_GET_ROWS`), not weights, but it was never added to the name-based quantization exclusion list alongside `ffn_gate_inp.weight`. So `llama-quantize` tries to quantize it and fails, since an i32 tensor cannot be converted to a float quant type (rejected in `tensor_allows_quantization`).

## Fix

Add `ffn_gate_tid2eid.weight` to the same exclusion in `tensor_allows_quantization` (`src/llama-quant.cpp`), mirroring the existing `ffn_gate_inp.weight` guard, so the routing table is kept at its original type.

The tensor is created as `tn(LLM_TENSOR_FFN_GATE_TID2EID, "weight", i)` (`src/models/deepseek4.cpp`), so its full name is `blk.N.ffn_gate_tid2eid.weight`, which the guard matches.

## Verification

`llama-quantize` builds cleanly with the change. A full end-to-end quantize needs a DeepSeek-V4 GGUF, which I did not run; the fix is a one-line name exclusion mirroring the existing pattern.

Fixes #25754.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md).
- AI usage disclosure: YES - an automated (AI) coding tool located the existing exclusion list and drafted the three-line guard; the change was reviewed before submission.
