### PR TITLE
metal : gated_delta_net cache fusion

### DIFF
--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -665,6 +665,7 @@ static inline bool ggml_node_has_n_uses(const struct ggml_cgraph * cgraph, int n
 // - all nodes except the last have only one use and are not views/outputs (see ggml_node_has_N_uses).
 // - all nodes except the last are a src of the following node.
 // - all nodes are the same shape.
+//
 // TODO: Consider allowing GGML_OP_NONE nodes in between
 static inline bool ggml_can_fuse_ext(const struct ggml_cgraph * cgraph, const int * node_idxs, const enum ggml_op * ops, int num_ops) {
     for (int i = 0; i < num_ops; ++i) {
@@ -679,11 +680,15 @@ static inline bool ggml_can_fuse_ext(const struct ggml_cgraph * cgraph, const in
         if ((node->flags & GGML_TENSOR_FLAG_COMPUTE) == 0) {
             return false;
         }
-        if (i < num_ops - 1 && !ggml_node_has_n_uses(cgraph, node_idxs[i], 1)) {
+
+        const bool is_last = i == num_ops - 1;
+
+        if (!is_last && !ggml_node_has_n_uses(cgraph, node_idxs[i], 1)) {
             return false;
         }
         if (i > 0) {
             struct ggml_tensor * prev = cgraph->nodes[node_idxs[i - 1]];
+
             if (node->src[0] != prev && node->src[1] != prev) {
                 return false;
             }

--- a/ggml/src/ggml-metal/ggml-metal-common.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-common.cpp
@@ -310,11 +310,17 @@ static std::vector<int> ggml_metal_graph_optimize_reorder(const std::vector<node
 
         const auto & node0 = nodes[i0];
 
+        // a cpy that scatters gated_delta_net state snapshots into the cache must stay right after
+        // its gdn node, otherwise the gdn+copy fusion cannot apply. do not pull other nodes in front of it.
+        const bool pinned = node0.op() == GGML_OP_CPY &&
+                            node0.node->src[0] && node0.node->src[0]->view_src &&
+                            node0.node->src[0]->view_src->op == GGML_OP_GATED_DELTA_NET;
+
         // the node is not concurrent with the existing concurrent set, so we have to "put a barrier" (i.e reset mrs0)
         // but before we do that, look forward for some other nodes that can be added to the concurrent set mrs0
         //
         // note: we can always add empty nodes to the concurrent set as they don't read nor write anything
-        if (!node0.is_empty() && !h_check(mrs0, node0)) {
+        if (!pinned && !node0.is_empty() && !h_check(mrs0, node0)) {
             // this will hold the set of memory ranges from the nodes that haven't been processed yet
             // if a node is not concurrent with this set, we cannot reorder it
             ggml_mem_ranges_reset(mrs1);

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -925,6 +925,7 @@ typedef struct {
     int32_t  ns02;
     int32_t  ns12;
     int32_t  ns22;
+    int32_t  state_out_stride; // stride between snapshot slots in the state_out buffer
     int32_t  ne0;
     int32_t  ne1;
     int32_t  ne2;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -950,6 +950,7 @@ typedef struct {
     int32_t  ns02;
     int32_t  ns12;
     int32_t  ns22;
+    int32_t  state_out_stride; // stride between snapshot slots in the state_out buffer
     int32_t  ne0;
     int32_t  ne1;
     int32_t  ne2;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -88,6 +88,17 @@ struct ggml_metal_op {
         return ggml_can_fuse_ext(gf, idxs.data() + i0, ops, n_ops);
     }
 
+    // mark the consumed node at position i as elided: the fusing op already wrote its dst,
+    // so the encode loop must not add its mem ranges to the concurrency tracker. Otherwise a
+    // later op reading that dst would see a false overlap and trigger a spurious barrier.
+    void fuse_elide_dst(int i) {
+        dst_elided.push_back(i);
+    }
+
+    bool is_dst_elided(int i) const {
+        return std::find(dst_elided.begin(), dst_elided.end(), i) != dst_elided.end();
+    }
+
     ggml_metal_device_t  dev;
     ggml_metal_library_t lib;
     ggml_metal_encoder_t enc;
@@ -108,6 +119,9 @@ private:
 
     // non-empty node indices
     std::vector<int> idxs;
+
+    // positions of fused nodes whose dst must not be tracked (see fuse_elide_dst)
+    std::vector<int> dst_elided;
 };
 
 ggml_metal_op_t ggml_metal_op_init(
@@ -496,6 +510,9 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
 
     // update the mem ranges in the encoding context
     for (int i = 0; i < n_fuse; ++i) {
+        if (ctx->is_dst_elided(idx + i)) {
+            continue;
+        }
         if (!ggml_metal_op_concurrency_add(ctx, ctx->node(idx + i))) {
             ggml_metal_op_concurrency_reset(ctx);
         }
@@ -1599,6 +1616,61 @@ int ggml_metal_op_rwkv(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
+// Match gated_delta_net + the trailing cpy that scatters its state snapshots into the
+// recurrent cache, so the kernel writes them straight to the cache and the cpy is elided.
+// The cpy reads the gdn output through a view of a different shape, so ctx->can_fuse() cannot
+// express it; the linkage and geometry are validated directly instead.
+static bool ggml_metal_op_can_fuse_gdn_cache(ggml_metal_op_t        ctx,
+                                             int                    idx,
+                                             ggml_metal_buffer_id * cache_buf_id,
+                                             int32_t              * slot_stride) {
+    const ggml_tensor * gdn = ctx->node(idx);
+
+    if (gdn->op != GGML_OP_GATED_DELTA_NET || gdn->type != GGML_TYPE_F32) {
+        return false;
+    }
+
+    const int64_t S_v      = gdn->src[2]->ne[0];
+    const int64_t H        = gdn->src[2]->ne[1];
+    const int64_t n_tokens = gdn->src[2]->ne[2];
+    const int64_t n_seqs   = gdn->src[2]->ne[3];
+    const int64_t K        = ggml_get_op_params_i32(gdn, 0);
+    const size_t  tail_off = ggml_row_size(GGML_TYPE_F32, S_v * H * n_tokens * n_seqs);
+
+    const int64_t D         = S_v * S_v * H;
+    const int64_t n_written = std::min<int64_t>(n_tokens, K);
+
+    // the scatter cpy is the next real op (views are filtered out of the node list)
+    if (idx + 1 >= ctx->n_nodes()) {
+        return false;
+    }
+
+    const ggml_tensor * cpy = ctx->node(idx + 1);
+    if (cpy->op != GGML_OP_CPY) {
+        return false;
+    }
+
+    const ggml_tensor * src = cpy->src[0]; // gdn snapshot tail view
+    const ggml_tensor * dst = cpy->src[1]; // cache view
+
+    if (src->view_src != gdn || src->view_offs != tail_off || !ggml_is_contiguous(src)) {
+        return false;
+    }
+
+    const int64_t expected_ne[GGML_MAX_DIMS] = { D, n_seqs, n_written, 1 };
+    if (dst->type != GGML_TYPE_F32 || dst->data == nullptr ||
+        !std::equal(expected_ne, expected_ne + GGML_MAX_DIMS, dst->ne) ||
+        dst->nb[0] != ggml_type_size(GGML_TYPE_F32) ||
+        dst->nb[1] != (size_t) ggml_row_size(GGML_TYPE_F32, D)) {
+        return false;
+    }
+
+    *cache_buf_id = ggml_metal_get_buffer_id(dst);
+    *slot_stride  = K > 1 ? (int32_t) (dst->nb[2] / sizeof(float)) : 0;
+
+    return true;
+}
+
 int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
@@ -1615,7 +1687,19 @@ int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
     GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
     GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
 
+    // try to fuse the trailing cpy that scatters state snapshots into the recurrent cache
+    ggml_metal_buffer_id cache_buf_id = { nullptr, 0 };
+    int32_t slot_stride = 0;
+    const bool fused = ctx->use_fusion && ggml_metal_op_can_fuse_gdn_cache(ctx, idx, &cache_buf_id, &slot_stride);
+
     auto pipeline = ggml_metal_library_get_pipeline_gated_delta_net(lib, op);
+
+    if (!fused) {
+        // unfused: snapshots go to the dst tail, right after the attn scores
+        cache_buf_id  = ggml_metal_get_buffer_id(op);
+        cache_buf_id.offs += (size_t) ggml_row_size(GGML_TYPE_F32, ne20 * ne21 * ne22 * ne23);
+        slot_stride   = ne20 * ne20 * ne21 * ne23;
+    }
 
     int ida = 0;
 
@@ -1647,6 +1731,7 @@ int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
         /*.ns02 =*/ (int32_t) (nb02/sizeof(float)),
         /*.ns12 =*/ (int32_t) (nb12/sizeof(float)),
         /*.ns22 =*/ (int32_t) (nb22/sizeof(float)),
+        /*.state_out_stride =*/ slot_stride,
         /*.ne0  =*/ ne0,
         /*.ne1  =*/ ne1,
         /*.ne2  =*/ ne2,
@@ -1665,11 +1750,19 @@ int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[3]), ida++); // gate
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[4]), ida++); // beta
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[5]), ida++); // state
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         ida++); // dst
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         ida++); // dst (attn scores)
+    ggml_metal_encoder_set_buffer  (enc, cache_buf_id,                         ida++); // state_out
 
     const int nsg = pipeline.nsg;
 
     ggml_metal_encoder_dispatch_threadgroups(enc, op->src[2]->ne[0]/nsg, op->src[2]->ne[1], op->src[2]->ne[3], 32, nsg, 1);
+
+    if (fused) {
+        // the kernel wrote the snapshots straight to the cache, so the cpy is redundant:
+        // consume it and keep its cache range out of the concurrency tracker
+        ctx->fuse_elide_dst(idx + 1);
+        return 2;
+    }
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -89,6 +89,19 @@ struct ggml_metal_op {
         return ggml_can_fuse_ext(gf, idxs.data() + i0, ops, n_ops);
     }
 
+    // true if node i consumes the previous node through a view.
+    // the fusing op writes its dst directly, so its mem ranges must not be tracked.
+    bool is_view_consumer(int i) const {
+        if (i <= 0) {
+            return false;
+        }
+
+        const ggml_tensor * node = ggml_graph_node(gf, idxs[i]);
+        const ggml_tensor * prev = ggml_graph_node(gf, idxs[i - 1]);
+
+        return node->src[0] && node->src[0]->view_src == prev;
+    }
+
     ggml_metal_device_t  dev;
     ggml_metal_library_t lib;
     ggml_metal_encoder_t enc;
@@ -511,6 +524,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
 
     // update the mem ranges in the encoding context
     for (int i = 0; i < n_fuse; ++i) {
+        // skip view consumers: the fusing op wrote their dst directly (see is_view_consumer)
+        if (i > 0 && ctx->is_view_consumer(idx + i)) {
+            continue;
+        }
         if (!ggml_metal_op_concurrency_add(ctx, ctx->node(idx + i))) {
             ggml_metal_op_concurrency_reset(ctx);
         }
@@ -1816,6 +1833,65 @@ int ggml_metal_op_rwkv(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
+// Match gated_delta_net + the trailing cpy that scatters its state snapshots into the
+// recurrent cache, so the kernel writes them straight to the cache and the cpy is elided.
+// Mirrors ggml_cuda_try_gdn_cache_fusion. The gdn output has other consumers (the attn
+// scores view), so unlike ggml_can_fuse this does not require the gdn to have a single use.
+static bool ggml_metal_op_can_fuse_gdn_cache(ggml_metal_op_t        ctx,
+                                             int                    idx,
+                                             ggml_metal_buffer_id * cache_buf_id,
+                                             int32_t              * slot_stride) {
+    const ggml_tensor * gdn = ctx->node(idx);
+
+    // the kernel skips the snapshot tail, so the gdn output must not be a graph output
+    if (gdn->op != GGML_OP_GATED_DELTA_NET || gdn->type != GGML_TYPE_F32 ||
+        (gdn->flags & GGML_TENSOR_FLAG_OUTPUT)) {
+        return false;
+    }
+
+    if (idx + 1 >= ctx->n_nodes()) {
+        return false;
+    }
+
+    const ggml_tensor * cpy = ctx->node(idx + 1);
+
+    if (cpy->op != GGML_OP_CPY || (cpy->flags & GGML_TENSOR_FLAG_OUTPUT)) {
+        return false;
+    }
+
+    const int64_t S_v      = gdn->src[2]->ne[0];
+    const int64_t H        = gdn->src[2]->ne[1];
+    const int64_t n_tokens = gdn->src[2]->ne[2];
+    const int64_t n_seqs   = gdn->src[2]->ne[3];
+    const int64_t K        = ggml_get_op_params_i32(gdn, 0);
+    const size_t  tail_off = ggml_row_size(GGML_TYPE_F32, S_v * H * n_tokens * n_seqs);
+
+    const int64_t D         = S_v * S_v * H;
+    const int64_t n_written = std::min<int64_t>(n_tokens, K);
+
+    const ggml_tensor * src = cpy->src[0]; // gdn snapshot tail view
+    const ggml_tensor * dst = cpy->src[1]; // cache view
+
+    // src must be this gdn's snapshot tail (contiguous, at the tail offset)
+    if (src->op != GGML_OP_VIEW || src->view_src != gdn ||
+        src->view_offs != tail_off || !ggml_is_contiguous(src)) {
+        return false;
+    }
+
+    const int64_t expected_ne[GGML_MAX_DIMS] = { D, n_seqs, n_written, 1 };
+    if (dst->type != GGML_TYPE_F32 || dst->data == nullptr ||
+        !std::equal(expected_ne, expected_ne + GGML_MAX_DIMS, dst->ne) ||
+        dst->nb[0] != ggml_type_size(GGML_TYPE_F32) ||
+        dst->nb[1] != (size_t) ggml_row_size(GGML_TYPE_F32, D)) {
+        return false;
+    }
+
+    *cache_buf_id = ggml_metal_get_buffer_id(dst);
+    *slot_stride  = K > 1 ? (int32_t) (dst->nb[2] / sizeof(float)) : 0;
+
+    return true;
+}
+
 int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
@@ -1832,7 +1908,19 @@ int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
     GGML_TENSOR_LOCALS( int32_t, ne,  op,         ne);
     GGML_TENSOR_LOCALS(uint64_t, nb,  op,         nb);
 
+    // try to fuse the trailing cpy that scatters state snapshots into the cache
+    ggml_metal_buffer_id cache_buf_id = { nullptr, 0 };
+    int32_t slot_stride = 0;
+    const bool fused = ctx->use_fusion && ggml_metal_op_can_fuse_gdn_cache(ctx, idx, &cache_buf_id, &slot_stride);
+
     auto pipeline = ggml_metal_library_get_pipeline_gated_delta_net(lib, op);
+
+    if (!fused) {
+        // unfused: snapshots go to the dst tail, right after the attn scores
+        cache_buf_id = ggml_metal_get_buffer_id(op);
+        cache_buf_id.offs += (size_t) ggml_row_size(GGML_TYPE_F32, ne20 * ne21 * ne22 * ne23);
+        slot_stride = ne20 * ne20 * ne21 * ne23;
+    }
 
     int ida = 0;
 
@@ -1864,6 +1952,7 @@ int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
         /*.ns02 =*/ (int32_t) (nb02/sizeof(float)),
         /*.ns12 =*/ (int32_t) (nb12/sizeof(float)),
         /*.ns22 =*/ (int32_t) (nb22/sizeof(float)),
+        /*.state_out_stride =*/ slot_stride,
         /*.ne0  =*/ ne0,
         /*.ne1  =*/ ne1,
         /*.ne2  =*/ ne2,
@@ -1883,10 +1972,16 @@ int ggml_metal_op_gated_delta_net(ggml_metal_op_t ctx, int idx) {
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[4]), ida++); // beta
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[5]), ida++); // state
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         ida++); // dst
+    ggml_metal_encoder_set_buffer  (enc, cache_buf_id,                         ida++); // state_out
 
     const int nsg = pipeline.nsg;
 
     ggml_metal_encoder_dispatch_threadgroups(enc, op->src[2]->ne[0]/nsg, op->src[2]->ne[1], op->src[2]->ne[3], 32, nsg, 1);
+
+    if (fused) {
+        // the kernel wrote the snapshots straight to the cache
+        return 2;
+    }
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2639,6 +2639,7 @@ kernel void kernel_gated_delta_net_impl(
         device const char * b,
         device const char * s,
         device       char * dst,
+        device       char * state_out, // dst snapshot tail, or the cache buffer when fused
         uint3 tgpig[[threadgroup_position_in_grid]],
         uint3 tpitg[[thread_position_in_threadgroup]],
         uint3   ntg[[threads_per_threadgroup]])  {
@@ -2679,14 +2680,7 @@ kernel void kernel_gated_delta_net_impl(
     device const float * b_ptr = (device const float *) (b) + (i23*args.ne22*args.ne21 + i21);
     device const float * g_ptr = (device const float *) (g) + (i23*args.ne22*args.ne21 + i21)*G;
 
-    // snapshot slot mapping: slot 0 = most recent state, slot s = s tokens back.
-    // When n_tokens < K, only slots 0..n_tokens-1 are written; older slots are caller-owned.
-
-    // output state base offset: after attention scores
-    const uint attn_size = args.ne22 * args.ne21 * S_v * args.ne23;
-    // output state per-slot size: S_v * S_v * H * n_seqs
-    const uint state_size_per_snap = S_v * S_v * args.ne21 * args.ne23;
-    // per-(seq,head) offset within a slot
+    // per-(seq,head) offset within a snapshot slot
     const uint state_out_base = (i23*args.ne21 + i21)*S_v*S_v + i20*S_v;
 
     for (short t = 0; t < args.ne22; t++) {
@@ -2738,9 +2732,10 @@ kernel void kernel_gated_delta_net_impl(
         g_ptr += args.ne21*G;
 
         if (K > 1) {
+            // slot 0 = most recent state, slot s = s tokens back
             const int target_slot = (int)args.ne22 - 1 - (int)t;
             if (target_slot >= 0 && target_slot < (int)K) {
-                device float * dst_state = (device float *) (dst) + attn_size + (uint)target_slot * state_size_per_snap + state_out_base;
+                device float * dst_state = (device float *) (state_out) + (uint)target_slot * args.state_out_stride + state_out_base;
                 FOR_UNROLL (short j = 0; j < NSG; j++) {
                     const short is = tx*NSG + j;
                     dst_state[is] = ls[j];
@@ -2750,7 +2745,7 @@ kernel void kernel_gated_delta_net_impl(
     }
 
     if (K == 1) {
-        device float * dst_state = (device float *) (dst) + attn_size + state_out_base;
+        device float * dst_state = (device float *) (state_out) + state_out_base;
         FOR_UNROLL (short j = 0; j < NSG; j++) {
             const short is = tx*NSG + j;
             dst_state[is] = ls[j];

--- a/ggml/src/ggml-metal/kernels/gated_delta_net.metal
+++ b/ggml/src/ggml-metal/kernels/gated_delta_net.metal
@@ -15,6 +15,7 @@ kernel void kernel_gated_delta_net_impl(
         device const char * b,
         device const char * s,
         device       char * dst,
+        device       char * state_out, // dst snapshot tail, or the cache buffer when fused
         uint3 tgpig[[threadgroup_position_in_grid]],
         uint3 tpitg[[thread_position_in_threadgroup]],
         uint3   ntg[[threads_per_threadgroup]])  {
@@ -55,14 +56,7 @@ kernel void kernel_gated_delta_net_impl(
     device const float * b_ptr = (device const float *) (b) + (i23*args.ne22*args.ne21 + i21);
     device const float * g_ptr = (device const float *) (g) + (i23*args.ne22*args.ne21 + i21)*G;
 
-    // snapshot slot mapping: slot 0 = most recent state, slot s = s tokens back.
-    // When n_tokens < K, only slots 0..n_tokens-1 are written; older slots are caller-owned.
-
-    // output state base offset: after attention scores
-    const uint attn_size = args.ne22 * args.ne21 * S_v * args.ne23;
-    // output state per-slot size: S_v * S_v * H * n_seqs
-    const uint state_size_per_snap = S_v * S_v * args.ne21 * args.ne23;
-    // per-(seq,head) offset within a slot
+    // per-(seq,head) offset within a snapshot slot
     const uint state_out_base = (i23*args.ne21 + i21)*S_v*S_v + i20*S_v;
 
     for (short t = 0; t < args.ne22; t++) {
@@ -114,9 +108,10 @@ kernel void kernel_gated_delta_net_impl(
         g_ptr += args.ne21*G;
 
         if (K > 1) {
+            // slot 0 = most recent state, slot s = s tokens back
             const int target_slot = (int)args.ne22 - 1 - (int)t;
             if (target_slot >= 0 && target_slot < (int)K) {
-                device float * dst_state = (device float *) (dst) + attn_size + (uint)target_slot * state_size_per_snap + state_out_base;
+                device float * dst_state = (device float *) (state_out) + (uint)target_slot * args.state_out_stride + state_out_base;
                 FOR_UNROLL (short j = 0; j < NSG; j++) {
                     const short is = tx*NSG + j;
                     dst_state[is] = ls[j];
@@ -126,7 +121,7 @@ kernel void kernel_gated_delta_net_impl(
     }
 
     if (K == 1) {
-        device float * dst_state = (device float *) (dst) + attn_size + state_out_base;
+        device float * dst_state = (device float *) (state_out) + state_out_base;
         FOR_UNROLL (short j = 0; j < NSG; j++) {
             const short is = tx*NSG + j;
             dst_state[is] = ls[j];

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4157,6 +4157,118 @@ struct test_gated_delta_net : public test_case {
     }
 };
 
+// GDN cache fusion: gdn (K > 1) + the trailing cpy into the recurrent cache (delta-net-base.cpp)
+struct test_gated_delta_net_cache_fusion : public test_case {
+    const ggml_type type;
+
+    const int64_t head_count;
+    const int64_t head_size;
+    const int64_t n_seq_tokens;
+    const int64_t n_seqs;
+    const int64_t K; // snapshot slot count (>1)
+
+    ggml_tensor * attn_node = nullptr;
+    ggml_tensor * cpy_node = nullptr;
+
+    std::string vars() override {
+        return VARS_TO_STR6(type, head_count, head_size, n_seq_tokens, n_seqs, K);
+    }
+
+    test_gated_delta_net_cache_fusion(ggml_type type = GGML_TYPE_F32,
+            int64_t head_count = 4, int64_t head_size = 32, int64_t n_seq_tokens = 2, int64_t n_seqs = 1,
+            int64_t K = 2)
+        : type(type), head_count(head_count), head_size(head_size), n_seq_tokens(n_seq_tokens), n_seqs(n_seqs), K(K) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        const int64_t S_v = head_size;
+        const int64_t H_v = head_count;
+        const int64_t H_k = head_count;
+        const int64_t D   = S_v * S_v * H_v;
+        const int64_t n_written = std::min<int64_t>(n_seq_tokens, K);
+
+        ggml_tensor * q     = ggml_new_tensor_4d(ctx, type, head_size, H_k, n_seq_tokens, n_seqs);
+        ggml_tensor * k     = ggml_new_tensor_4d(ctx, type, head_size, H_k, n_seq_tokens, n_seqs);
+        ggml_tensor * v     = ggml_new_tensor_4d(ctx, type, head_size, H_v, n_seq_tokens, n_seqs);
+        ggml_set_name(q, "q");
+        ggml_set_name(k, "k");
+        ggml_set_name(v, "v");
+        ggml_tensor * g     = ggml_new_tensor_4d(ctx, type, 1, H_v, n_seq_tokens, n_seqs);
+        ggml_tensor * beta  = ggml_new_tensor_4d(ctx, type, 1, H_v, n_seq_tokens, n_seqs);
+        ggml_tensor * state = ggml_new_tensor_4d(ctx, type, head_size, head_size, H_v, n_seqs);
+        ggml_set_name(g,     "g");
+        ggml_set_name(beta,  "beta");
+        ggml_set_name(state, "state");
+
+        q = ggml_l2_norm(ctx, q, 1e-6f);
+        k = ggml_l2_norm(ctx, k, 1e-6f);
+
+        ggml_tensor * gdn_out = ggml_gated_delta_net(ctx, q, k, v, g, beta, state, K);
+        ggml_set_name(gdn_out, "gdn_out");
+
+        // attn scores view (first part of the gdn output)
+        ggml_tensor * attn = ggml_view_4d(ctx, gdn_out,
+                S_v, H_v, n_seq_tokens, n_seqs,
+                ggml_row_size(gdn_out->type, S_v),
+                ggml_row_size(gdn_out->type, S_v * H_v),
+                ggml_row_size(gdn_out->type, S_v * H_v * n_seq_tokens), 0);
+        ggml_set_name(attn, "attn");
+        attn_node = attn;
+
+        // snapshot tail view [D, n_seqs, n_written]
+        const int64_t attn_score_elems = S_v * H_v * n_seq_tokens * n_seqs;
+        ggml_tensor * src = ggml_view_3d(ctx, gdn_out,
+                D, n_seqs, n_written,
+                ggml_row_size(gdn_out->type, D),
+                ggml_row_size(gdn_out->type, D * n_seqs),
+                ggml_row_size(gdn_out->type, attn_score_elems));
+
+        // recurrent cache view [D, n_seqs, n_written]
+        ggml_tensor * cache = ggml_new_tensor_3d(ctx, type, D, n_seqs, n_written);
+        ggml_set_name(cache, "cache");
+        ggml_tensor * dst = ggml_view_3d(ctx, cache,
+                D, n_seqs, n_written,
+                ggml_row_size(cache->type, D),
+                ggml_row_size(cache->type, D * n_seqs), 0);
+
+        ggml_tensor * cpy = ggml_cpy(ctx, src, dst);
+        ggml_set_name(cpy, "gdn_cache_cpy");
+        cpy_node = cpy;
+        return cpy;
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "GATED_DELTA_NET_CACHE_FUSION";
+    }
+
+    bool run_whole_graph() override { return true; } // needed for graph-level fusion to fire
+    std::vector<ggml_tensor *> fusion_test_nodes() override { return { attn_node, cpy_node }; }
+
+    uint64_t op_flops(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        const uint64_t S_v = head_size;
+        const uint64_t H_v  = head_count;
+        const uint64_t T   = n_seq_tokens;
+        const uint64_t B   = n_seqs;
+        return (4ull*S_v + 2ull*S_v*S_v) * H_v * T * B;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            if (ggml_is_view_op(t->op)) { continue; }
+            if (strcmp(t->name, "g") == 0) {
+                init_tensor_uniform(t, -20.0f, -1e-4f);
+            } else if (strcmp(t->name, "beta") == 0) {
+                init_tensor_uniform(t, 0.0f, 1.0f);
+            } else if (strcmp(t->name, "v") == 0) {
+                init_tensor_uniform(t, -0.3f, 5.0f);
+            } else {
+                init_tensor_uniform(t);
+            }
+        }
+    }
+};
+
 // GGML_OP_GATED_LINEAR_ATTN
 struct test_gla : public test_case {
     const ggml_type type;
@@ -9646,6 +9758,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 32,   8, 1, 1, false, false, /*K=*/3));
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 64,  16, 2, 1, false, false, /*K=*/4));
 
+    // GDN cache fusion (K>1 rollback pattern); last case exercises n_tokens > K
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 32, 2, 1, 2));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 64, 4, 1, 2));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 32, 4, 1, 4));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 8, 32, 4, 2, 4));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 32, 8, 1, 4));
+
 #if 0
     // these tests are disabled to save execution time, sbut they can be handy for debugging
     test_cases.emplace_back(new test_llama(2, true));
@@ -9996,6 +10115,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 128, 512, 1));  // 4h PP-512
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 128, 1024, 1)); // 4h PP-1024
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 32, 128, 64, 1, 1, false, true)); // KDA PP-64
+
+    // GDN cache-fusion perf: gdn+cpy rollback (K>1), fused on Metal/CUDA
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 64, 1, 2));  // PP-64, K=2
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 256, 1, 2)); // PP-256, K=2
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 64, 1, 4));  // PP-64, K=4
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 256, 1, 4)); // PP-256, K=4
 
     // lightning_indexer
     for (int kv : { 256, 4096, 65536 }) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4403,6 +4403,118 @@ struct test_gated_delta_net : public test_case {
     }
 };
 
+// GGML_OP_GATED_DELTA_NET cache fusion
+struct test_gated_delta_net_cache_fusion : public test_case {
+    const ggml_type type;
+
+    const int64_t head_count;
+    const int64_t head_size;
+    const int64_t n_seq_tokens;
+    const int64_t n_seqs;
+    const int64_t K; // snapshot slot count (>1)
+
+    ggml_tensor * attn_node = nullptr;
+    ggml_tensor * cpy_node = nullptr;
+
+    std::string vars() override {
+        return VARS_TO_STR6(type, head_count, head_size, n_seq_tokens, n_seqs, K);
+    }
+
+    test_gated_delta_net_cache_fusion(ggml_type type = GGML_TYPE_F32,
+            int64_t head_count = 4, int64_t head_size = 32, int64_t n_seq_tokens = 2, int64_t n_seqs = 1,
+            int64_t K = 2)
+        : type(type), head_count(head_count), head_size(head_size), n_seq_tokens(n_seq_tokens), n_seqs(n_seqs), K(K) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        const int64_t S_v = head_size;
+        const int64_t H_v = head_count;
+        const int64_t H_k = head_count;
+        const int64_t D   = S_v * S_v * H_v;
+        const int64_t n_written = std::min<int64_t>(n_seq_tokens, K);
+
+        ggml_tensor * q     = ggml_new_tensor_4d(ctx, type, head_size, H_k, n_seq_tokens, n_seqs);
+        ggml_tensor * k     = ggml_new_tensor_4d(ctx, type, head_size, H_k, n_seq_tokens, n_seqs);
+        ggml_tensor * v     = ggml_new_tensor_4d(ctx, type, head_size, H_v, n_seq_tokens, n_seqs);
+        ggml_set_name(q, "q");
+        ggml_set_name(k, "k");
+        ggml_set_name(v, "v");
+        ggml_tensor * g     = ggml_new_tensor_4d(ctx, type, 1, H_v, n_seq_tokens, n_seqs);
+        ggml_tensor * beta  = ggml_new_tensor_4d(ctx, type, 1, H_v, n_seq_tokens, n_seqs);
+        ggml_tensor * state = ggml_new_tensor_4d(ctx, type, head_size, head_size, H_v, n_seqs);
+        ggml_set_name(g,     "g");
+        ggml_set_name(beta,  "beta");
+        ggml_set_name(state, "state");
+
+        q = ggml_l2_norm(ctx, q, 1e-6f);
+        k = ggml_l2_norm(ctx, k, 1e-6f);
+
+        ggml_tensor * gdn_out = ggml_gated_delta_net(ctx, q, k, v, g, beta, state, K);
+        ggml_set_name(gdn_out, "gdn_out");
+
+        // attn scores view (first part of the gdn output)
+        ggml_tensor * attn = ggml_view_4d(ctx, gdn_out,
+                S_v, H_v, n_seq_tokens, n_seqs,
+                ggml_row_size(gdn_out->type, S_v),
+                ggml_row_size(gdn_out->type, S_v * H_v),
+                ggml_row_size(gdn_out->type, S_v * H_v * n_seq_tokens), 0);
+        ggml_set_name(attn, "attn");
+        attn_node = attn;
+
+        // snapshot tail view [D, n_seqs, n_written]
+        const int64_t attn_score_elems = S_v * H_v * n_seq_tokens * n_seqs;
+        ggml_tensor * src = ggml_view_3d(ctx, gdn_out,
+                D, n_seqs, n_written,
+                ggml_row_size(gdn_out->type, D),
+                ggml_row_size(gdn_out->type, D * n_seqs),
+                ggml_row_size(gdn_out->type, attn_score_elems));
+
+        // recurrent cache view [D, n_seqs, n_written]
+        ggml_tensor * cache = ggml_new_tensor_3d(ctx, type, D, n_seqs, n_written);
+        ggml_set_name(cache, "cache");
+        ggml_tensor * dst = ggml_view_3d(ctx, cache,
+                D, n_seqs, n_written,
+                ggml_row_size(cache->type, D),
+                ggml_row_size(cache->type, D * n_seqs), 0);
+
+        ggml_tensor * cpy = ggml_cpy(ctx, src, dst);
+        ggml_set_name(cpy, "gdn_cache_cpy");
+        cpy_node = cpy;
+        return cpy;
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "GATED_DELTA_NET_CACHE_FUSION";
+    }
+
+    bool run_whole_graph() override { return true; }
+    std::vector<ggml_tensor *> fusion_test_nodes() override { return { attn_node, cpy_node }; }
+
+    uint64_t op_flops(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        const uint64_t S_v = head_size;
+        const uint64_t H_v = head_count;
+        const uint64_t T   = n_seq_tokens;
+        const uint64_t B   = n_seqs;
+        return (4ull*S_v + 2ull*S_v*S_v) * H_v * T * B;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            if (ggml_is_view_op(t->op)) { continue; }
+            if (strcmp(t->name, "g") == 0) {
+                init_tensor_uniform(t, -20.0f, -1e-4f);
+            } else if (strcmp(t->name, "beta") == 0) {
+                init_tensor_uniform(t, 0.0f, 1.0f);
+            } else if (strcmp(t->name, "v") == 0) {
+                init_tensor_uniform(t, -0.3f, 5.0f);
+            } else {
+                init_tensor_uniform(t);
+            }
+        }
+    }
+};
+
 // GGML_OP_GATED_LINEAR_ATTN
 struct test_gla : public test_case {
     const ggml_type type;
@@ -10091,6 +10203,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 32,   8, 1, 1, false, false, /*K=*/3));
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 64,  16, 2, 1, false, false, /*K=*/4));
 
+    // GDN cache fusion (K>1 rollback pattern); last case has n_tokens > K
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 32, 2, 1, 2));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 64, 4, 1, 2));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 32, 4, 1, 4));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 8, 32, 4, 2, 4));
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 4, 32, 8, 1, 4));
+
 #if 0
     // these tests are disabled to save execution time, sbut they can be handy for debugging
     test_cases.emplace_back(new test_llama(2, true));
@@ -10492,6 +10611,12 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 128, 512, 1));  // 4h PP-512
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 4, 128, 1024, 1)); // 4h PP-1024
     test_cases.emplace_back(new test_gated_delta_net(GGML_TYPE_F32, 32, 128, 64, 1, 1, false, true)); // KDA PP-64
+
+    // GDN cache-fusion perf: gdn+cpy rollback (K>1), fused on Metal/CUDA
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 64, 1, 2));  // PP-64, K=2
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 256, 1, 2)); // PP-256, K=2
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 64, 1, 4));  // PP-64, K=4
+    test_cases.emplace_back(new test_gated_delta_net_cache_fusion(GGML_TYPE_F32, 32, 128, 256, 1, 4)); // PP-256, K=4
 
     // lightning_indexer
     for (int kv : { 256, 4096, 65536 }) {


### PR DESCRIPTION
gated_delta_net cache fusion

## Overview

Mirror the CUDA backend's `ggml_cuda_try_gdn_cache_fusion`: route the KV cache pointer into the kernel so it writes recurrent-state snapshots directly into the cache and skips the redundant per-layer cpy.

## Additional information

| CPU                  | Model                            | Test   |   t/s OLD |   t/s NEW |   Speedup |
|:---------------------|:---------------------------------|:-------|----------:|----------:|----------:|
| Accelerate, Apple M3 | gemma3 270M Q4_0                 | pp512  |   5942.93 |   5786.28 |      0.97 |
| Accelerate, Apple M3 | gemma3 270M Q4_0                 | tg128  |    145.18 |    145.59 |      1.00 |
| Accelerate, Apple M3 | qwen35 0.8B BF16                 | pp512  |   1580.12 |   1865.99 |      1.18 |
| Accelerate, Apple M3 | qwen35 0.8B BF16                 | tg128  |     26.68 |     34.96 |      1.31 |
| Accelerate, Apple M3 | qwen35 0.8B IQ2_M - 2.7 bpw      | pp512  |   1211.22 |   1448.67 |      1.20 |
| Accelerate, Apple M3 | qwen35 0.8B IQ2_M - 2.7 bpw      | tg128  |     51.27 |     64.71 |      1.26 |
| Accelerate, Apple M3 | qwen35 0.8B IQ2_XXS - 2.0625 bpw | pp512  |   1593.18 |   1874.77 |      1.18 |
| Accelerate, Apple M3 | qwen35 0.8B IQ2_XXS - 2.0625 bpw | tg128  |     52.47 |    130.20 |      2.48 |
| Accelerate, Apple M3 | qwen35 0.8B IQ3_XXS - 3.0625 bpw | pp512  |   1132.65 |   1842.77 |      1.63 |
| Accelerate, Apple M3 | qwen35 0.8B IQ3_XXS - 3.0625 bpw | tg128  |     48.02 |    123.24 |      2.57 |
| Accelerate, Apple M3 | qwen35 0.8B IQ4_NL - 4.5 bpw     | pp512  |   1407.56 |   1364.16 |      0.97 |
| Accelerate, Apple M3 | qwen35 0.8B IQ4_NL - 4.5 bpw     | tg128  |     49.81 |     62.94 |      1.26 |
| Accelerate, Apple M3 | qwen35 0.8B IQ4_XS - 4.25 bpw    | pp512  |   1049.38 |   1762.12 |      1.68 |
| Accelerate, Apple M3 | qwen35 0.8B IQ4_XS - 4.25 bpw    | tg128  |     47.59 |    117.57 |      2.47 |
| Accelerate, Apple M3 | qwen35 0.8B Q2_K_M               | pp512  |   1399.04 |   1198.09 |      0.86 |
| Accelerate, Apple M3 | qwen35 0.8B Q2_K_M               | tg128  |     53.94 |     63.83 |      1.18 |
| Accelerate, Apple M3 | qwen35 0.8B Q3_K_M               | pp512  |   1245.84 |   1307.13 |      1.05 |
| Accelerate, Apple M3 | qwen35 0.8B Q3_K_M               | tg128  |     50.72 |     59.40 |      1.17 |
| Accelerate, Apple M3 | qwen35 0.8B Q3_K_S               | pp512  |   1122.24 |   1274.85 |      1.14 |
| Accelerate, Apple M3 | qwen35 0.8B Q3_K_S               | tg128  |     47.41 |     56.63 |      1.19 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_0                 | pp512  |   1387.63 |   1191.85 |      0.86 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_0                 | tg128  |     55.75 |     51.60 |      0.93 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_1                 | pp512  |   1307.73 |   1750.53 |      1.34 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_1                 | tg128  |     50.79 |    104.04 |      2.05 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_K_M               | pp512  |   1225.77 |   1269.81 |      1.04 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_K_M               | tg128  |     48.16 |     52.95 |      1.10 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_K_S               | pp512  |   1148.35 |   1407.57 |      1.23 |
| Accelerate, Apple M3 | qwen35 0.8B Q4_K_S               | tg128  |     47.66 |     64.60 |      1.36 |
| Accelerate, Apple M3 | qwen35 0.8B Q5_K_M               | pp512  |   1219.83 |   1296.53 |      1.06 |
| Accelerate, Apple M3 | qwen35 0.8B Q5_K_M               | tg128  |     44.42 |     49.93 |      1.12 |
| Accelerate, Apple M3 | qwen35 0.8B Q5_K_S               | pp512  |   1248.74 |   1210.40 |      0.97 |
| Accelerate, Apple M3 | qwen35 0.8B Q5_K_S               | tg128  |     43.06 |     50.01 |      1.16 |
| Accelerate, Apple M3 | qwen35 0.8B Q6_K                 | pp512  |   1169.88 |   1667.61 |      1.43 |
| Accelerate, Apple M3 | qwen35 0.8B Q6_K                 | tg128  |     42.13 |     93.17 |      2.21 |
| Accelerate, Apple M3 | qwen35 0.8B Q8_0                 | pp512  |   1510.92 |   1378.43 |      0.91 |
| Accelerate, Apple M3 | qwen35 0.8B Q8_0                 | tg128  |     33.95 |     36.59 |      1.08 |

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES GLM-5.2

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
