### PR TITLE
Optimize ROCm decode

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1488,6 +1488,15 @@ struct ggml_backend_cuda_context {
         return cublas_handle(device);
     }
 
+    struct prequant_q8_1_entry { const void * q8_1; int64_t ne10; int64_t ne10_padded; };
+    std::unordered_map<const ggml_tensor *, prequant_q8_1_entry> prequant_q8_1_map;
+    std::vector<std::unique_ptr<ggml_cuda_pool_alloc<char>>> prequant_q8_1_bufs;
+
+    void prequant_q8_1_reset() {
+        prequant_q8_1_map.clear();
+        prequant_q8_1_bufs.clear();
+    }
+
     // pool
     std::unique_ptr<ggml_cuda_pool> pools[GGML_CUDA_MAX_DEVICES][GGML_CUDA_MAX_STREAMS];
 

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1520,6 +1520,7 @@ struct ggml_cuda_mm_fusion_args_host {
     const ggml_tensor * gate_bias = nullptr;
     const ggml_tensor * x_scale = nullptr;
     const ggml_tensor * gate_scale = nullptr;
+    const ggml_tensor * dst_scale = nullptr;
     ggml_glu_op glu_op;
 };
 struct ggml_cuda_mm_fusion_args_device {
@@ -1528,6 +1529,7 @@ struct ggml_cuda_mm_fusion_args_device {
     const void * gate_bias = nullptr;
     const void * x_scale = nullptr;
     const void * gate_scale = nullptr;
+    const void * dst_scale = nullptr;
     ggml_glu_op glu_op;
 };
 

--- a/ggml/src/ggml-cuda/getrows.cu
+++ b/ggml/src/ggml-cuda/getrows.cu
@@ -55,23 +55,47 @@ static __global__ void k_get_rows_float(
     dst_t         * GGML_CUDA_RESTRICT dst  = dst_ptr;
     ggml_cuda_pdl_sync();
     for (int64_t z = blockIdx.z; z < ne11*(int64_t)ne12_fdv.z; z += gridDim.z) {
+        // The x and y dimensions of the grid are swapped because the maximum allowed grid size for x is higher.
+        const int i10 = blockIdx.x;
+        const uint2 dm = fast_div_modulo((uint32_t)z, ne12_fdv);
+        const int i11 = dm.x;
+        const int i12 = dm.y;
+
+        const int i01 = src1[i10*s10 + i11*s11 + i12*s12];
+
+        dst_t * GGML_CUDA_RESTRICT dst_row = dst + i10*s1 + i11*s2 + i12*s3;
+        const src0_t * GGML_CUDA_RESTRICT src0_row = (const src0_t *)((const char *) src0 + i01*nb01 + i11*nb02 + i12*nb03);
+
         for (int64_t i00 = blockIdx.y*blockDim.x + threadIdx.x; i00 < ne00; i00 += gridDim.y*blockDim.x) {
-            // The x and y dimensions of the grid are swapped because the maximum allowed grid size for x is higher.
-            const int i10 = blockIdx.x;
-            const uint2 dm = fast_div_modulo((uint32_t)z, ne12_fdv);
-            const int i11 = dm.x;
-            const int i12 = dm.y;
-
-            if (i00 >= ne00) {
-                return;
-            }
-
-            const int i01 = src1[i10*s10 + i11*s11 + i12*s12];
-
-            dst_t * dst_row = dst + i10*s1 + i11*s2 + i12*s3;
-            const src0_t * src0_row = (const src0_t *)((const char *) src0 + i01*nb01 + i11*nb02 + i12*nb03);
-
             dst_row[i00] = ggml_cuda_cast<dst_t>(src0_row[i00]);
+        }
+    }
+}
+
+template<typename dst_t>
+static __global__ void k_get_rows_float_vec(
+        const dst_t * src0_ptr, const int32_t * src1_ptr, dst_t * dst_ptr,
+        const int64_t ne00v,
+        const int64_t ne11, const uint3 ne12_fdv,
+        const size_t s1, const size_t s2, const size_t s3,
+        const size_t nb01, const size_t nb02, const size_t nb03,
+        const size_t s10, const size_t s11, const size_t s12) {
+
+    ggml_cuda_pdl_lc();
+    ggml_cuda_pdl_sync();
+    for (int64_t z = blockIdx.z; z < ne11*(int64_t)ne12_fdv.z; z += gridDim.z) {
+        const int i10 = blockIdx.x;
+        const uint2 dm = fast_div_modulo((uint32_t)z, ne12_fdv);
+        const int i11 = dm.x;
+        const int i12 = dm.y;
+
+        const int i01 = src1_ptr[i10*s10 + i11*s11 + i12*s12];
+
+        int4       * GGML_CUDA_RESTRICT dst_row  = (int4 *)      (dst_ptr + i10*s1 + i11*s2 + i12*s3);
+        const int4 * GGML_CUDA_RESTRICT src0_row = (const int4 *)((const char *) src0_ptr + i01*nb01 + i11*nb02 + i12*nb03);
+
+        for (int64_t i = blockIdx.y*blockDim.x + threadIdx.x; i < ne00v; i += gridDim.y*blockDim.x) {
+            dst_row[i] = src0_row[i];
         }
     }
 }
@@ -148,8 +172,6 @@ static void get_rows_cuda_float(
         const size_t nb1, const size_t nb2, const size_t nb3,
         cudaStream_t stream) {
     const dim3 block_dims(CUDA_GET_ROWS_BLOCK_SIZE, 1, 1);
-    const int block_num_y = (ne00 + CUDA_GET_ROWS_BLOCK_SIZE - 1) / CUDA_GET_ROWS_BLOCK_SIZE;
-    const dim3 block_nums(ne10, MIN(block_num_y, UINT16_MAX), MIN(ne11*ne12, UINT16_MAX));
 
     // strides in elements
     // const size_t s0 = nb0 / sizeof(dst_t);
@@ -165,6 +187,34 @@ static void get_rows_cuda_float(
     GGML_ASSERT(ne12 > 0);
     GGML_ASSERT(ne11 <= std::numeric_limits<uint32_t>::max() / ne12);
     const uint3 ne12_fdv = init_fastdiv_values(ne12);
+
+    if constexpr (std::is_same<src0_t, dst_t>::value) {
+        constexpr int VEC = 16 / sizeof(dst_t);
+        const int64_t ne00v = ne00 / VEC;
+        const int64_t vec_block_num_y = (ne00v + CUDA_GET_ROWS_BLOCK_SIZE - 1) / CUDA_GET_ROWS_BLOCK_SIZE;
+        const bool enough_blocks = vec_block_num_y * ne10 * ne11 * ne12 >= 128;
+        const bool can_vec = VEC > 1 && enough_blocks &&
+            (ne00 % VEC == 0) &&
+            (nb01 % 16 == 0) && (nb02 % 16 == 0) && (nb03 % 16 == 0) &&
+            (nb1  % 16 == 0) && (nb2  % 16 == 0) && (nb3  % 16 == 0) &&
+            (((uintptr_t) src0_d) % 16 == 0) && (((uintptr_t) dst_d) % 16 == 0);
+
+        if (can_vec) {
+            const int block_num_y = vec_block_num_y;
+            const dim3 block_nums(ne10, MIN(block_num_y, UINT16_MAX), MIN(ne11*ne12, UINT16_MAX));
+            const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params{block_nums, block_dims, 0, stream};
+            ggml_cuda_kernel_launch(k_get_rows_float_vec<dst_t>, launch_params,
+                (const dst_t *) src0_d, src1_d, dst_d,
+                ne00v, ne11, ne12_fdv,
+                s1, s2, s3,
+                nb01, nb02, nb03,
+                s10, s11, s12);
+            return;
+        }
+    }
+
+    const int block_num_y = (ne00 + CUDA_GET_ROWS_BLOCK_SIZE - 1) / CUDA_GET_ROWS_BLOCK_SIZE;
+    const dim3 block_nums(ne10, MIN(block_num_y, UINT16_MAX), MIN(ne11*ne12, UINT16_MAX));
 
     const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params{block_nums, block_dims, 0, stream};
     ggml_cuda_kernel_launch(k_get_rows_float<src0_t, dst_t>, launch_params,

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3765,6 +3765,25 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
         return fused_node_count - 1;
     }
 
+    if (node->op == GGML_OP_MUL_MAT_ID &&
+            ggml_can_fuse_subgraph(cgraph, i, { GGML_OP_MUL_MAT_ID, GGML_OP_MUL }, { i + 1 })) {
+        ggml_tensor * mm_node  = node;
+        ggml_tensor * mul_node = cgraph->nodes[i + 1];
+        ggml_tensor * weights  = (mul_node->src[0] == mm_node) ? mul_node->src[1] :
+                                 (mul_node->src[1] == mm_node) ? mul_node->src[0] : nullptr;
+        const bool weights_ok = weights && weights->type == GGML_TYPE_F32 && ggml_is_contiguous(weights) &&
+                                weights->ne[0] == 1 && weights->ne[1] == mm_node->ne[1] &&
+                                weights->ne[2] == mm_node->ne[2] && weights->ne[3] == mm_node->ne[3];
+        int out_nodes[] = { i + 1 };
+        if (weights_ok && ggml_cuda_should_fuse_mul_mat_vec_q(mm_node) &&
+                ggml_cuda_check_fusion_memory_ranges(cgraph, i, 2, out_nodes, 1)) {
+            ggml_cuda_mm_fusion_args_host fusion_data{};
+            fusion_data.dst_scale = weights;
+            ggml_cuda_mul_mat_vec_q(*cuda_ctx, mm_node->src[0], mm_node->src[1], mm_node->src[2], mul_node, &fusion_data);
+            return 1;
+        }
+    }
+
     // mul_mat + add
     for (ggml_op op : { GGML_OP_MUL_MAT, GGML_OP_MUL_MAT_ID }) {
         const ggml_op bias_op = op == GGML_OP_MUL_MAT ? GGML_OP_ADD : GGML_OP_ADD_ID;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -702,6 +702,10 @@ ggml_backend_cuda_context::~ggml_backend_cuda_context() {
     std::unique_lock<std::mutex> lock(ggml_cuda_lock);
     ggml_cuda_lock_cv.wait(lock, []{ return ggml_cuda_lock_counter.load(std::memory_order_relaxed) == 0; });
 
+    // release the producer-side q8_1 fusion buffers (last graph's) before the pools they were allocated
+    // from are destroyed, otherwise the pool destructor asserts on the outstanding allocations.
+    prequant_q8_1_reset();
+
     if (copy_event != nullptr) {
         CUDA_CHECK(cudaEventDestroy(copy_event));
     }
@@ -3123,6 +3127,26 @@ static bool ggml_cuda_can_fuse(const struct ggml_cgraph *                cgraph,
 }
 
 // try and fuse nodes and return the number of nodes to skip
+static bool ggml_cuda_norm_feeds_quant_mmvq(const ggml_cgraph * cgraph, int mul_idx,
+                                            const ggml_tensor * mul_out, int64_t & ncols_padded) {
+    if (ggml_nrows(mul_out) != 1 || mul_out->ne[0] % QK8_1 != 0) { // single-token only: one q8_1 row
+        return false;
+    }
+    for (int j = mul_idx + 1; j < cgraph->n_nodes; ++j) {
+        const ggml_tensor * n = cgraph->nodes[j];
+        if (n->op != GGML_OP_MUL_MAT && n->op != GGML_OP_MUL_MAT_ID) {
+            continue;
+        }
+        const ggml_tensor * s1 = n->src[1];
+        const bool matches = s1 == mul_out || (s1 && s1->view_src == mul_out);
+        if (matches && n->src[0] && ggml_is_quantized(n->src[0]->type) && s1->type == GGML_TYPE_F32) {
+            ncols_padded = GGML_PAD(mul_out->ne[0], MATRIX_ROW_PADDING);
+            return true;
+        }
+    }
+    return false;
+}
+
 static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph * cgraph, int i) {
 
     static bool disable_fusion = getenv("GGML_CUDA_DISABLE_FUSION") != nullptr && std::atoi(getenv("GGML_CUDA_DISABLE_FUSION"));
@@ -3808,7 +3832,19 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
     }
 
     if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL }, {})) {
-        ggml_cuda_op_rms_norm_fused(*cuda_ctx, node, cgraph->nodes[i + 1]);
+        ggml_tensor * mul_out = cgraph->nodes[i + 1];
+
+        int64_t ncols_padded = 0;
+        if (ggml_cuda_norm_feeds_quant_mmvq(cgraph, i + 1, mul_out, ncols_padded)) {
+            const size_t buf_sz = (size_t) (ncols_padded / QK8_1) * sizeof(block_q8_1); // single row
+            auto buf = std::make_unique<ggml_cuda_pool_alloc<char>>(cuda_ctx->pool(), buf_sz);
+            void * q8_ptr = buf->get();
+            ggml_cuda_op_rms_norm_fused_q8(*cuda_ctx, node, mul_out, q8_ptr, ncols_padded);
+            cuda_ctx->prequant_q8_1_map[mul_out] = { q8_ptr, mul_out->ne[0], ncols_padded };
+            cuda_ctx->prequant_q8_1_bufs.push_back(std::move(buf));
+        } else {
+            ggml_cuda_op_rms_norm_fused(*cuda_ctx, node, mul_out);
+        }
         return 1;
     }
 
@@ -4077,6 +4113,8 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
 
     ggml_cuda_set_device(cuda_ctx->device);
+
+    cuda_ctx->prequant_q8_1_reset();
 
     bool use_cuda_graph             = false;
     bool cuda_graph_update_required = false;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3850,6 +3850,21 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
         return 2;
     }
 
+    // pair the deltanet q/k L2-norms: they are adjacent siblings separated by a no-op VIEW of k
+    // (L2_NORM(q) -> VIEW(k) -> L2_NORM(k)), so normalize both in one dispatch.
+    if (node->op == GGML_OP_L2_NORM && i + 2 < cgraph->n_nodes) {
+        ggml_tensor * l2q = node;
+        ggml_tensor * mid = cgraph->nodes[i + 1];
+        ggml_tensor * l2k = cgraph->nodes[i + 2];
+        if (mid->op == GGML_OP_VIEW && l2k->op == GGML_OP_L2_NORM && l2k->src[0] == mid &&
+                l2q->src[0] && l2q->src[0]->type == GGML_TYPE_F32 && l2k->src[0]->type == GGML_TYPE_F32 &&
+                ggml_is_contiguous(l2q) && ggml_is_contiguous(l2k) && ggml_are_same_shape(l2q, l2k) &&
+                memcmp(l2q->op_params, l2k->op_params, sizeof(float)) == 0) {
+            ggml_cuda_op_l2_norm_pair(*cuda_ctx, l2q, l2k);
+            return 2; // skip the view and the k L2_NORM
+        }
+    }
+
     // fused residual-add + rms_norm * mul: the pre-norm residual ADD -> RMS_NORM -> MUL that transformer
     // blocks emit. The dedicated kernel writes the residual sum back for the downstream residual.
     if (node->op == GGML_OP_ADD &&

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3850,6 +3850,43 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
         return 2;
     }
 
+    // fused residual-add + rms_norm * mul: the pre-norm residual ADD -> RMS_NORM -> MUL that transformer
+    // blocks emit. The dedicated kernel writes the residual sum back for the downstream residual.
+    if (node->op == GGML_OP_ADD &&
+            ggml_can_fuse_subgraph(cgraph, i, { GGML_OP_ADD, GGML_OP_RMS_NORM, GGML_OP_MUL }, { i, i + 2 })) {
+        ggml_tensor * add_node = node;
+        ggml_tensor * rms_node = cgraph->nodes[i + 1];
+        ggml_tensor * mul_node = cgraph->nodes[i + 2];
+        const ggml_tensor * a = add_node->src[0];
+        const ggml_tensor * b = add_node->src[1];
+        const bool ok = rms_node->src[0] == add_node && a && b &&
+                        a->type == GGML_TYPE_F32 && b->type == GGML_TYPE_F32 &&
+                        ggml_is_contiguous(add_node) && ggml_is_contiguous(a) && ggml_is_contiguous(b) &&
+                        ggml_are_same_shape(a, b) && ggml_are_same_shape(a, add_node);
+        // The kernel reads a[col]/b[col] then writes the residual sum in the same output pass, so an
+        // in-place add (add_node aliasing a or b) is safe; the only unsafe overlap is the norm output
+        // (mul_node) clobbering the residual sum (add_node), which is consumed downstream.
+        auto overlaps = [](const ggml_tensor * x, const ggml_tensor * y) {
+            const int64_t xs = (int64_t) x->data, xe = xs + ggml_nbytes(x);
+            const int64_t ys = (int64_t) y->data, ye = ys + ggml_nbytes(y);
+            return (ys <= xs && xs < ye) || (xs <= ys && ys < xe);
+        };
+        if (ok && !overlaps(mul_node, add_node)) {
+            int64_t ncols_padded = 0;
+            if (ggml_cuda_norm_feeds_quant_mmvq(cgraph, i + 2, mul_node, ncols_padded)) {
+                const size_t buf_sz = (size_t) (ncols_padded / QK8_1) * sizeof(block_q8_1);
+                auto buf = std::make_unique<ggml_cuda_pool_alloc<char>>(cuda_ctx->pool(), buf_sz);
+                void * q8_ptr = buf->get();
+                ggml_cuda_op_rms_norm_fused_prev_add(*cuda_ctx, rms_node, mul_node, add_node, q8_ptr, ncols_padded);
+                cuda_ctx->prequant_q8_1_map[mul_node] = { q8_ptr, mul_node->ne[0], ncols_padded };
+                cuda_ctx->prequant_q8_1_bufs.push_back(std::move(buf));
+            } else {
+                ggml_cuda_op_rms_norm_fused_prev_add(*cuda_ctx, rms_node, mul_node, add_node, nullptr, 0);
+            }
+            return 2;
+        }
+    }
+
     if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL }, {})) {
         ggml_tensor * mul_out = cgraph->nodes[i + 1];
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -523,11 +523,13 @@ static __global__ void mul_mat_vec_q(
     bool use_gate_bias = false;
     bool use_scale = false;
     bool use_gate_scale = false;
+    bool use_dst_scale = false;
     [[maybe_unused]] const void * vgate = nullptr;
     const float * x_bias = nullptr;
     const float * gate_bias = nullptr;
     const float * x_scale = nullptr;
     const float * gate_scale = nullptr;
+    const float * dst_scale = nullptr;
     ggml_glu_op active_glu;
 
     if constexpr (has_fusion) {
@@ -538,6 +540,8 @@ static __global__ void mul_mat_vec_q(
         x_bias        = (const float *) fusion.x_bias;
         gate_bias     = (const float *) fusion.gate_bias;
         active_glu    = fusion.glu_op;
+        use_dst_scale = fusion.dst_scale != nullptr;
+        dst_scale     = (const float *) fusion.dst_scale;
         if constexpr (type == GGML_TYPE_NVFP4) {
             use_scale      = fusion.x_scale    != nullptr;
             use_gate_scale = fusion.gate_scale != nullptr && use_gate;
@@ -545,6 +549,7 @@ static __global__ void mul_mat_vec_q(
             gate_scale     = (const float *) fusion.gate_scale;
         }
     }
+    const float dst_scale_val = use_dst_scale ? dst_scale[channel_dst] : 1.0f;
 
 
     [[maybe_unused]] float x_biases[ncols_dst]    = { 0.0f };
@@ -684,6 +689,7 @@ static __global__ void mul_mat_vec_q(
                                 break;
                         }
                     }
+                    result *= dst_scale_val;
                 }
                 dst[j*stride_col_dst + i] = result;
             }
@@ -691,7 +697,7 @@ static __global__ void mul_mat_vec_q(
     }
 
     if constexpr (!has_fusion) {
-        GGML_UNUSED_VARS(use_gate, use_bias, use_gate_bias, use_scale, use_gate_scale, active_glu, gate_bias, x_bias, x_scale, gate_scale, tmp_gate);
+        GGML_UNUSED_VARS(use_gate, use_bias, use_gate_bias, use_scale, use_gate_scale, active_glu, gate_bias, x_bias, x_scale, gate_scale, tmp_gate, use_dst_scale, dst_scale, dst_scale_val);
     }
     if constexpr (type != GGML_TYPE_NVFP4) {
         GGML_UNUSED_VARS(use_scale, use_gate_scale, x_scale, gate_scale, x_scales, gate_scales);
@@ -791,7 +797,7 @@ static void mul_mat_vec_q_switch_fusion(
         const uint32_t ids_stride, cudaStream_t stream) {
 
     const bool has_fusion = fusion.gate != nullptr || fusion.x_bias != nullptr || fusion.gate_bias != nullptr ||
-                            fusion.x_scale != nullptr || fusion.gate_scale != nullptr;
+                            fusion.x_scale != nullptr || fusion.gate_scale != nullptr || fusion.dst_scale != nullptr;
     if constexpr (c_ncols_dst == 1) {
         if (has_fusion) {
             const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, nbytes_shared, stream);
@@ -1204,6 +1210,13 @@ void ggml_cuda_mul_mat_vec_q(
             GGML_ASSERT(ggml_is_contiguous(fusion->gate_scale));
             GGML_ASSERT(ggml_nelements(fusion->gate_scale) == (ids ? src0->ne[2] : 1));
             fusion_local.gate_scale = fusion->gate_scale->data;
+        }
+        if (fusion->dst_scale) {
+            GGML_ASSERT(fusion->dst_scale->type == GGML_TYPE_F32);
+            GGML_ASSERT(ggml_is_contiguous(fusion->dst_scale));
+            GGML_ASSERT(fusion->dst_scale->ne[0] == 1);
+            GGML_ASSERT(ggml_nelements(fusion->dst_scale) == (ids ? dst->ne[1] : 1));
+            fusion_local.dst_scale = fusion->dst_scale->data;
         }
         fusion_local.glu_op = fusion->glu_op;
     }

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1220,12 +1220,26 @@ void ggml_cuda_mul_mat_vec_q(
     }
 
     const int64_t ne10_padded = GGML_PAD(ne10, MATRIX_ROW_PADDING);
-    ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1);
+
+    ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool());
+    const char * src1_q8_1_ptr = nullptr;
     {
-        const int64_t s11 = src1->nb[1] / ts_src1;
-        const int64_t s12 = src1->nb[2] / ts_src1;
-        const int64_t s13 = src1->nb[3] / ts_src1;
-        quantize_row_q8_1_cuda(src1_d, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded, ne11, ne12, ne13, stream);
+        auto it = ctx.prequant_q8_1_map.find(src1);
+        if (it == ctx.prequant_q8_1_map.end() && src1->view_src) {
+            it = ctx.prequant_q8_1_map.find(src1->view_src);
+        }
+        const bool single_token = ne11*ne12*ne13 == 1;
+        if (it != ctx.prequant_q8_1_map.end() && single_token &&
+                it->second.ne10 == ne10 && it->second.ne10_padded == ne10_padded) {
+            src1_q8_1_ptr = (const char *) it->second.q8_1;
+        } else {
+            src1_q8_1.alloc(ctx.pool(), ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1);
+            src1_q8_1_ptr = src1_q8_1.get();
+            const int64_t s11 = src1->nb[1] / ts_src1;
+            const int64_t s12 = src1->nb[2] / ts_src1;
+            const int64_t s13 = src1->nb[3] / ts_src1;
+            quantize_row_q8_1_cuda(src1_d, nullptr, src1_q8_1.get(), src0->type, ne10, s11, s12, s13, ne10_padded, ne11, ne12, ne13, stream);
+        }
     }
 
     const int64_t s01 = src0->nb[1] / ts_src0;
@@ -1251,7 +1265,7 @@ void ggml_cuda_mul_mat_vec_q(
     const int64_t ids_stride = ids ? ids->nb[1] / ggml_type_size(ids->type) : 0;
 
     mul_mat_vec_q_switch_type(
-        src0->data, src0->type, src1_q8_1.get(), ids_d, fusion_local, dst_d, ne00,
+        src0->data, src0->type, src1_q8_1_ptr, ids_d, fusion_local, dst_d, ne00,
         ne01,              ncols_dst,     s01, stride_col_y,     stride_col_dst,
         ne02, nchannels_y, nchannels_dst, s02, stride_channel_y, stride_channel_dst,
         ne03,              ne3,           s03, s13,              s3,               ids_stride, stream);

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -170,6 +170,76 @@ static __global__ void rms_norm_f32(const float * x,
     }
 }
 
+// Fused residual-add + rms_norm * mul (+ optional q8_1): computes s = a + b, normalizes s and scales by
+// mul, and writes s back to add_dst for the downstream residual. a/b/add_dst are contiguous, same-shape.
+// The add may be in-place (add_dst aliasing a or b), so s is written in the output pass, after the
+// reduction has already read every input element.
+template <int block_size, bool do_quant>
+static __global__ void rms_norm_fused_prev_add_f32(
+        const float * a, const float * b, float * add_dst, float * rms_dst, float * dst,
+        const int ncols, const int ncols_padded,
+        const int64_t stride_row, const int64_t stride_channel, const int64_t stride_sample,
+        const float eps,
+        const float * mul, const int64_t mul_stride_row, const int64_t mul_stride_channel, const int64_t mul_stride_sample,
+        const uint3 mul_ncols_packed, const uint3 mul_nrows_packed, const uint3 mul_nchannels_packed, const uint3 mul_nsamples_packed,
+        void * dst_q8) {
+    ggml_cuda_pdl_lc();
+    const int nrows     = gridDim.x;
+    const int nchannels = gridDim.y;
+
+    const int row     = blockIdx.x;
+    const int channel = blockIdx.y;
+    const int sample  = blockIdx.z;
+    const int tid     = threadIdx.x;
+
+    const int64_t base = sample*stride_sample + channel*stride_channel + row*stride_row;
+    a       += base;
+    b       += base;
+    add_dst += base;
+    const int64_t dst_off = ((sample*nchannels + channel)*nrows + row)*ncols;
+    rms_dst += dst_off;
+    dst     += dst_off;
+
+    block_q8_1 * yq = nullptr;
+    if constexpr (do_quant) {
+        yq = (block_q8_1 *) dst_q8 + ((int64_t)(sample*nchannels + channel)*nrows + row) * (ncols_padded / QK8_1);
+    }
+
+    const uint32_t mul_row     = fastmodulo(row, mul_nrows_packed);
+    const uint32_t mul_channel = fastmodulo(channel, mul_nchannels_packed);
+    const uint32_t mul_sample  = fastmodulo(sample, mul_nsamples_packed);
+    mul += mul_sample * mul_stride_sample + mul_channel * mul_stride_channel + mul_row * mul_stride_row;
+
+    float tmp = 0.0f;
+    ggml_cuda_pdl_sync();
+    for (int col = tid; col < ncols; col += block_size) {
+        const float s = a[col] + b[col];
+        tmp += s * s;
+    }
+
+    extern __shared__ float s_sum[];
+    tmp = block_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
+
+    const float scale = rsqrtf(tmp / ncols + eps);
+
+    const int col_end = do_quant ? ncols_padded : ncols;
+    for (int col = tid; col < col_end; col += block_size) {
+        float val = 0.0f;
+        if (col < ncols) {
+            const float s = a[col] + b[col];
+            add_dst[col] = s;
+            const float normed = scale * s;
+            rms_dst[col] = normed;
+            const int mul_col = fastmodulo(col, mul_ncols_packed);
+            val = normed * mul[mul_col];
+            dst[col] = val;
+        }
+        if constexpr (do_quant) {
+            quantize_q8_1_val(val, col / QK8_1, col % QK8_1, yq);
+        }
+    }
+}
+
 template <int block_size>
 static __global__ void rms_norm_back_f32(
         const float * grad, const float * xf, float * dst, const int ncols, const float eps) {
@@ -470,6 +540,49 @@ static void rms_norm_mul_q8_f32_cuda(const float *  x,
     }
 }
 
+static void rms_norm_add_mul_f32_cuda(const float *  a,
+                                      const float *  b,
+                                      float *        add_dst,
+                                      float *        rms_dst,
+                                      const float *  mul,
+                                      float *        dst,
+                                      void *         dst_q8,
+                                      const int      ncols,
+                                      const int      ncols_padded,
+                                      const int      nrows,
+                                      const int      nchannels,
+                                      const int      nsamples,
+                                      const int64_t  stride_row,
+                                      const int64_t  stride_channel,
+                                      const int64_t  stride_sample,
+                                      const int64_t  mul_stride_row,
+                                      const int64_t  mul_stride_channel,
+                                      const int64_t  mul_stride_sample,
+                                      const uint32_t mul_ncols,
+                                      const uint32_t mul_nrows,
+                                      const uint32_t mul_nchannels,
+                                      const uint32_t mul_nsamples,
+                                      const float    eps,
+                                      cudaStream_t   stream) {
+    const dim3  blocks_num(nrows, nchannels, nsamples);
+    const uint3 mp0 = init_fastdiv_values(mul_ncols);
+    const uint3 mp1 = init_fastdiv_values(mul_nrows);
+    const uint3 mp2 = init_fastdiv_values(mul_nchannels);
+    const uint3 mp3 = init_fastdiv_values(mul_nsamples);
+    const bool   q  = dst_q8 != nullptr;
+    const int    bs = ncols < 1024 ? 256 : 1024;
+    const dim3   block_dims(bs, 1, 1);
+    const size_t shmem = bs > WARP_SIZE ? 32 * sizeof(float) : 0;
+    const ggml_cuda_kernel_launch_params lp{blocks_num, block_dims, shmem, stream};
+#define RMS_ADD_LAUNCH(BS, Q)                                                                          \
+    ggml_cuda_kernel_launch(rms_norm_fused_prev_add_f32<BS, Q>, lp,                                    \
+        a, b, add_dst, rms_dst, dst, ncols, ncols_padded, stride_row, stride_channel, stride_sample, eps, \
+        mul, mul_stride_row, mul_stride_channel, mul_stride_sample, mp0, mp1, mp2, mp3, dst_q8)
+    if (bs == 256) { if (q) { RMS_ADD_LAUNCH(256, true); } else { RMS_ADD_LAUNCH(256, false); } }
+    else           { if (q) { RMS_ADD_LAUNCH(1024, true); } else { RMS_ADD_LAUNCH(1024, false); } }
+#undef RMS_ADD_LAUNCH
+}
+
 static void rms_norm_back_f32_cuda(const float * grad, const float * xf, float * dst, const int ncols, const int nrows, const float eps, cudaStream_t stream) {
     if (ncols < 1024) {
         const dim3 block_dims(WARP_SIZE, 1, 1);
@@ -670,6 +783,50 @@ void ggml_cuda_op_rms_norm_fused_q8(ggml_backend_cuda_context & ctx, ggml_tensor
     rms_norm_mul_q8_f32_cuda(src0_d, mul_d, dst_d, dst_q8, ne00, (int) ncols_padded, ne01, ne02, ne03,
                              s01, s02, s03, mul_s01, mul_s02, mul_s03,
                              mul_src->ne[0], mul_src->ne[1], mul_src->ne[2], mul_src->ne[3], eps, stream);
+}
+
+void ggml_cuda_op_rms_norm_fused_prev_add(ggml_backend_cuda_context & ctx,
+                                          ggml_tensor *               rms_norm,
+                                          ggml_tensor *               mul_tensor,
+                                          ggml_tensor *               add_tensor,
+                                          void *                      dst_q8,
+                                          int64_t                     ncols_padded) {
+    float eps = 0.0f;
+    memcpy(&eps, rms_norm->op_params, sizeof(float));
+
+    const ggml_tensor * a = add_tensor->src[0];
+    const ggml_tensor * b = add_tensor->src[1];
+    const ggml_tensor * mul_src = (mul_tensor->src[0] == rms_norm) ? mul_tensor->src[1] : mul_tensor->src[0];
+
+    GGML_ASSERT(a->type == GGML_TYPE_F32 && b->type == GGML_TYPE_F32);
+    GGML_ASSERT(rms_norm->type == GGML_TYPE_F32 && mul_tensor->type == GGML_TYPE_F32);
+    GGML_ASSERT(eps >= 0.0f);
+
+    const int64_t ne00 = a->ne[0];
+    const int64_t ne01 = a->ne[1];
+    const int64_t ne02 = a->ne[2];
+    const int64_t ne03 = a->ne[3];
+
+    const size_t ts0 = ggml_type_size(a->type);
+    GGML_ASSERT(a->nb[0] == ts0);
+    const int64_t s01 = a->nb[1] / ts0;
+    const int64_t s02 = a->nb[2] / ts0;
+    const int64_t s03 = a->nb[3] / ts0;
+
+    const size_t ts_mul = ggml_type_size(mul_src->type);
+    GGML_ASSERT(mul_src->nb[0] == ts_mul);
+    const int64_t mul_s01 = mul_src->nb[1] / ts_mul;
+    const int64_t mul_s02 = mul_src->nb[2] / ts_mul;
+    const int64_t mul_s03 = mul_src->nb[3] / ts_mul;
+
+    rms_norm_add_mul_f32_cuda(
+        (const float *) a->data, (const float *) b->data, (float *) add_tensor->data,
+        (float *) rms_norm->data, (const float *) mul_src->data, (float *) mul_tensor->data, dst_q8,
+        ne00, (int) ncols_padded, ne01, ne02, ne03,
+        s01, s02, s03,
+        mul_s01, mul_s02, mul_s03,
+        mul_src->ne[0], mul_src->ne[1], mul_src->ne[2], mul_src->ne[3],
+        eps, ctx.stream());
 }
 
 void ggml_cuda_op_rms_norm_fused_add(ggml_backend_cuda_context & ctx,

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -1,4 +1,5 @@
 #include "norm.cuh"
+#include "quantize.cuh"
 #include <cstdint>
 
 template <int block_size>
@@ -73,7 +74,7 @@ static __global__ void group_norm_f32(const float * x, float * dst, const int gr
     }
 }
 
-template <int block_size, bool do_multiply = false, bool do_add = false>
+template <int block_size, bool do_multiply = false, bool do_add = false, bool do_quant = false>
 static __global__ void rms_norm_f32(const float * x,
                                     float *       dst,
                                     const int     ncols,
@@ -96,7 +97,9 @@ static __global__ void rms_norm_f32(const float * x,
                                     const uint3   add_ncols_packed     = make_uint3(0, 0, 0),
                                     const uint3   add_nrows_packed     = make_uint3(0, 0, 0),
                                     const uint3   add_nchannels_packed = make_uint3(0, 0, 0),
-                                    const uint3   add_nsamples_packed  = make_uint3(0, 0, 0)) {
+                                    const uint3   add_nsamples_packed  = make_uint3(0, 0, 0),
+                                    void *        dst_q8               = nullptr,
+                                    const int     ncols_padded         = 0) {
     ggml_cuda_pdl_lc();
     const int nrows     = gridDim.x;
     const int nchannels = gridDim.y;
@@ -110,6 +113,11 @@ static __global__ void rms_norm_f32(const float * x,
 
     x   += sample*stride_sample + channel*stride_channel + row*stride_row;
     dst += ((sample*nchannels + channel)*nrows + row)*ncols;
+
+    block_q8_1 * yq = nullptr;
+    if constexpr (do_quant) {
+        yq = (block_q8_1 *) dst_q8 + ((int64_t)(sample*nchannels + channel)*nrows + row) * (ncols_padded / QK8_1);
+    }
 
     if constexpr (do_multiply) {
         const uint32_t mul_row     = fastmodulo(row, mul_nrows_packed);
@@ -140,16 +148,24 @@ static __global__ void rms_norm_f32(const float * x,
     const float mean = tmp / ncols;
     const float scale = rsqrtf(mean + eps);
 
-    for (int col = tid; col < ncols; col += block_size) {
-        if constexpr (do_multiply && do_add) {
-            const int mul_col = fastmodulo(col, mul_ncols_packed);
-            const int add_col = fastmodulo(col, add_ncols_packed);
-            dst[col]          = scale * x[col] * mul[mul_col] + add[add_col];
-        } else if constexpr (do_multiply) {
-            const int mul_col = fastmodulo(col, mul_ncols_packed);
-            dst[col]          = scale * x[col] * mul[mul_col];
-        } else {
-            dst[col] = scale * x[col];
+    const int col_end = do_quant ? ncols_padded : ncols;
+    for (int col = tid; col < col_end; col += block_size) {
+        float val = 0.0f;
+        if (col < ncols) {
+            if constexpr (do_multiply && do_add) {
+                const int mul_col = fastmodulo(col, mul_ncols_packed);
+                const int add_col = fastmodulo(col, add_ncols_packed);
+                val = scale * x[col] * mul[mul_col] + add[add_col];
+            } else if constexpr (do_multiply) {
+                const int mul_col = fastmodulo(col, mul_ncols_packed);
+                val = scale * x[col] * mul[mul_col];
+            } else {
+                val = scale * x[col];
+            }
+            dst[col] = val;
+        }
+        if constexpr (do_quant) {
+            quantize_q8_1_val(val, col / QK8_1, col % QK8_1, yq);
         }
     }
 }
@@ -312,14 +328,14 @@ static void rms_norm_f32_cuda(
             x, dst, ncols, stride_row, stride_channel, stride_sample, eps,
         // underlying cudaLaunchKernelEx does not support default params
         nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0),
-        nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0));
+        nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), nullptr, 0);
     } else {
         const dim3 block_dims(1024, 1, 1);
         const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params{blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream};
         ggml_cuda_kernel_launch(rms_norm_f32<1024, false>, launch_params, x, dst, ncols, stride_row, stride_channel, stride_sample, eps,
         // underlying cudaLaunchKernelEx does not support default params
         nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0),
-        nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0));
+        nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), nullptr, 0);
     }
 }
 
@@ -367,7 +383,7 @@ static void rms_norm_mul_f32_cuda(const float *  x,
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed,
                 // underlying cudaLaunchKernelEx does not support default params
-            nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0));
+            nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), nullptr, 0);
         } else {
             const dim3 block_dims(1024, 1, 1);
             const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params{blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream};
@@ -375,7 +391,7 @@ static void rms_norm_mul_f32_cuda(const float *  x,
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed,
                 // underlying cudaLaunchKernelEx does not support default params
-            nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0));
+            nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), nullptr, 0);
         }
     } else {
         const uint3 mul_ncols_packed     = init_fastdiv_values(mul_ncols);
@@ -394,7 +410,7 @@ static void rms_norm_mul_f32_cuda(const float *  x,
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed, add,
                 add_stride_row, add_stride_channel, add_stride_sample, add_ncols_packed, add_nrows_packed,
-                add_nchannels_packed, add_nsamples_packed);
+                add_nchannels_packed, add_nsamples_packed, nullptr, 0);
         } else {
             const dim3 block_dims(1024, 1, 1);
             const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params{blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream};
@@ -402,8 +418,55 @@ static void rms_norm_mul_f32_cuda(const float *  x,
                 x, dst, ncols, stride_row, stride_channel, stride_sample, eps, mul, mul_stride_row, mul_stride_channel,
                 mul_stride_sample, mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed, add,
                 add_stride_row, add_stride_channel, add_stride_sample, add_ncols_packed, add_nrows_packed,
-                add_nchannels_packed, add_nsamples_packed);
+                add_nchannels_packed, add_nsamples_packed, nullptr, 0);
         }
+    }
+}
+
+static void rms_norm_mul_q8_f32_cuda(const float *  x,
+                                     const float *  mul,
+                                     float *        dst,
+                                     void *         dst_q8,
+                                     const int      ncols,
+                                     const int      ncols_padded,
+                                     const int      nrows,
+                                     const int      nchannels,
+                                     const int      nsamples,
+                                     const int64_t  stride_row,
+                                     const int64_t  stride_channel,
+                                     const int64_t  stride_sample,
+                                     const int64_t  mul_stride_row,
+                                     const int64_t  mul_stride_channel,
+                                     const int64_t  mul_stride_sample,
+                                     const uint32_t mul_ncols,
+                                     const uint32_t mul_nrows,
+                                     const uint32_t mul_nchannels,
+                                     const uint32_t mul_nsamples,
+                                     const float    eps,
+                                     cudaStream_t   stream) {
+    const dim3 blocks_num(nrows, nchannels, nsamples);
+    const uint3 mul_ncols_packed     = init_fastdiv_values(mul_ncols);
+    const uint3 mul_nrows_packed     = init_fastdiv_values(mul_nrows);
+    const uint3 mul_nchannels_packed = init_fastdiv_values(mul_nchannels);
+    const uint3 mul_nsamples_packed  = init_fastdiv_values(mul_nsamples);
+    if (ncols < 1024) {
+        const dim3 block_dims(256, 1, 1);
+        const ggml_cuda_kernel_launch_params launch_params = {blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float) : 0, stream};
+        ggml_cuda_kernel_launch(rms_norm_f32<256, true, false, true>, launch_params,
+            x, dst, ncols, stride_row, stride_channel, stride_sample, eps,
+            mul, mul_stride_row, mul_stride_channel, mul_stride_sample,
+            mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed,
+            nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0),
+            dst_q8, ncols_padded);
+    } else {
+        const dim3 block_dims(1024, 1, 1);
+        const ggml_cuda_kernel_launch_params launch_params = {blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float) : 0, stream};
+        ggml_cuda_kernel_launch(rms_norm_f32<1024, true, false, true>, launch_params,
+            x, dst, ncols, stride_row, stride_channel, stride_sample, eps,
+            mul, mul_stride_row, mul_stride_channel, mul_stride_sample,
+            mul_ncols_packed, mul_nrows_packed, mul_nchannels_packed, mul_nsamples_packed,
+            nullptr, 0, 0, 0, make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0), make_uint3(0, 0, 0),
+            dst_q8, ncols_padded);
     }
 }
 
@@ -557,6 +620,56 @@ void ggml_cuda_op_rms_norm_fused(ggml_backend_cuda_context & ctx, ggml_tensor * 
                           /*add_s00*/ 0, 0, 0,
                           0, 0, 0, 0,
                           eps, stream);
+}
+
+void ggml_cuda_op_rms_norm_fused_q8(ggml_backend_cuda_context & ctx, ggml_tensor * dst, ggml_tensor * mul_tensor,
+                                    void * dst_q8, int64_t ncols_padded) {
+    const ggml_tensor * rms_norm_src = (ggml_tensor *) dst->src[0];
+    float eps = 0.0f;
+    memcpy(&eps, dst->op_params, sizeof(float));
+
+    const float * src0_d = (const float *) rms_norm_src->data;
+    const float * mul_d  = nullptr;
+    const ggml_tensor * mul_src = nullptr;
+
+    if (mul_tensor->src[0] == dst) {
+        mul_d = (float *) mul_tensor->src[1]->data;
+        mul_src = mul_tensor->src[1];
+    } else if (mul_tensor->src[1] == dst) {
+        mul_d = (float *) mul_tensor->src[0]->data;
+        mul_src = mul_tensor->src[0];
+    } else {
+        GGML_ASSERT(false);
+    }
+
+    float * dst_d = (float *) mul_tensor->data;
+    cudaStream_t stream = ctx.stream();
+
+    GGML_ASSERT(rms_norm_src->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(mul_tensor->type == GGML_TYPE_F32);
+    GGML_ASSERT(eps >= 0.0f);
+
+    const int64_t ne00 = rms_norm_src->ne[0];
+    const int64_t ne01 = rms_norm_src->ne[1];
+    const int64_t ne02 = rms_norm_src->ne[2];
+    const int64_t ne03 = rms_norm_src->ne[3];
+
+    const size_t ts0 = ggml_type_size(rms_norm_src->type);
+    GGML_ASSERT(rms_norm_src->nb[0] == ts0);
+    const int64_t s01 = rms_norm_src->nb[1] / ts0;
+    const int64_t s02 = rms_norm_src->nb[2] / ts0;
+    const int64_t s03 = rms_norm_src->nb[3] / ts0;
+
+    const size_t ts_mul = ggml_type_size(mul_src->type);
+    GGML_ASSERT(mul_src->nb[0] == ts_mul);
+    const int64_t mul_s01 = mul_src->nb[1] / ts_mul;
+    const int64_t mul_s02 = mul_src->nb[2] / ts_mul;
+    const int64_t mul_s03 = mul_src->nb[3] / ts_mul;
+
+    rms_norm_mul_q8_f32_cuda(src0_d, mul_d, dst_d, dst_q8, ne00, (int) ncols_padded, ne01, ne02, ne03,
+                             s01, s02, s03, mul_s01, mul_s02, mul_s03,
+                             mul_src->ne[0], mul_src->ne[1], mul_src->ne[2], mul_src->ne[3], eps, stream);
 }
 
 void ggml_cuda_op_rms_norm_fused_add(ggml_backend_cuda_context & ctx,

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -363,6 +363,52 @@ static __global__ void l2_norm_f32(
     }
 }
 
+// Two independent L2-norms (e.g. the deltanet q and k) of the same shape in one dispatch. Each block
+// normalizes q[row] and k[row]; q/k may be strided (views), outputs are contiguous.
+template <int block_size>
+static __global__ void l2_norm_pair_f32(
+        const float * q, float * q_dst, const float * k, float * k_dst, const int ncols,
+        const int64_t q_stride_row, const int64_t q_stride_channel, const int64_t q_stride_sample,
+        const int64_t k_stride_row, const int64_t k_stride_channel, const int64_t k_stride_sample,
+        const float eps) {
+    const int nrows     = gridDim.x;
+    const int nchannels = gridDim.y;
+
+    const int row     = blockIdx.x;
+    const int channel = blockIdx.y;
+    const int sample  = blockIdx.z;
+    const int tid     = threadIdx.x;
+
+    q += sample*q_stride_sample + channel*q_stride_channel + row*q_stride_row;
+    k += sample*k_stride_sample + channel*k_stride_channel + row*k_stride_row;
+    const int64_t dst_off = ((sample*nchannels + channel)*nrows + row)*ncols;
+    q_dst += dst_off;
+    k_dst += dst_off;
+
+    float tq = 0.0f, tk = 0.0f;
+    ggml_cuda_pdl_sync();
+    for (int col = tid; col < ncols; col += block_size) {
+        const float qi = q[col];
+        const float ki = k[col];
+        tq += qi * qi;
+        tk += ki * ki;
+    }
+
+    extern __shared__ float s_sum[];
+    tq = block_reduce<block_reduce_method::SUM, block_size>(tq, s_sum);
+    __syncthreads();
+    tk = block_reduce<block_reduce_method::SUM, block_size>(tk, s_sum);
+    ggml_cuda_pdl_lc();
+
+    const float sq = rsqrtf(fmaxf(tq, eps * eps));
+    const float sk = rsqrtf(fmaxf(tk, eps * eps));
+
+    for (int col = tid; col < ncols; col += block_size) {
+        q_dst[col] = sq * q[col];
+        k_dst[col] = sk * k[col];
+    }
+}
+
 static void norm_f32_cuda(
         const float * x, float * dst, const int ncols, const int nrows, const int nchannels, const int nsamples,
         const int64_t stride_row, const int64_t stride_channel, const int64_t stride_sample, const float eps, cudaStream_t stream) {
@@ -605,6 +651,26 @@ static void l2_norm_f32_cuda(
         const dim3 block_dims(1024, 1, 1);
         const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params{blocks_num, block_dims, block_dims.x > WARP_SIZE ? 32 * sizeof(float): 0, stream};
         ggml_cuda_kernel_launch(l2_norm_f32<1024>, launch_params, x, dst, ncols, stride_row, stride_channel, stride_sample, eps);
+    }
+}
+
+static void l2_norm_pair_f32_cuda(
+        const float * q, float * q_dst, const float * k, float * k_dst,
+        const int ncols, const int nrows, const int nchannels, const int nsamples,
+        const int64_t q_stride_row, const int64_t q_stride_channel, const int64_t q_stride_sample,
+        const int64_t k_stride_row, const int64_t k_stride_channel, const int64_t k_stride_sample,
+        const float eps, cudaStream_t stream) {
+    const dim3 blocks_num(nrows, nchannels, nsamples);
+    if (ncols < 1024) {
+        const dim3 block_dims(WARP_SIZE, 1, 1);
+        const ggml_cuda_kernel_launch_params lp{blocks_num, block_dims, 0, stream};
+        ggml_cuda_kernel_launch(l2_norm_pair_f32<WARP_SIZE>, lp, q, q_dst, k, k_dst, ncols,
+            q_stride_row, q_stride_channel, q_stride_sample, k_stride_row, k_stride_channel, k_stride_sample, eps);
+    } else {
+        const dim3 block_dims(1024, 1, 1);
+        const ggml_cuda_kernel_launch_params lp{blocks_num, block_dims, 32 * sizeof(float), stream};
+        ggml_cuda_kernel_launch(l2_norm_pair_f32<1024>, lp, q, q_dst, k, k_dst, ncols,
+            q_stride_row, q_stride_channel, q_stride_sample, k_stride_row, k_stride_channel, k_stride_sample, eps);
     }
 }
 
@@ -965,4 +1031,37 @@ void ggml_cuda_op_l2_norm(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const int64_t s03 = nb03 / ts0;
 
     l2_norm_f32_cuda(src0_d, dst_d, ne00, ne01, ne02, ne03, s01, s02, s03, eps, stream);
+}
+
+void ggml_cuda_op_l2_norm_pair(ggml_backend_cuda_context & ctx, ggml_tensor * l2q, ggml_tensor * l2k) {
+    const ggml_tensor * q = l2q->src[0];
+    const ggml_tensor * k = l2k->src[0];
+
+    GGML_ASSERT(q->type == GGML_TYPE_F32 && k->type == GGML_TYPE_F32);
+    GGML_ASSERT(l2q->type == GGML_TYPE_F32 && l2k->type == GGML_TYPE_F32);
+
+    float eps;
+    memcpy(&eps, l2q->op_params, sizeof(float));
+    GGML_ASSERT(eps >= 0.0f);
+
+    const int64_t ne00 = q->ne[0];
+    const int64_t ne01 = q->ne[1];
+    const int64_t ne02 = q->ne[2];
+    const int64_t ne03 = q->ne[3];
+
+    const size_t tsq = ggml_type_size(q->type);
+    GGML_ASSERT(q->nb[0] == tsq);
+    const int64_t q_s01 = q->nb[1] / tsq;
+    const int64_t q_s02 = q->nb[2] / tsq;
+    const int64_t q_s03 = q->nb[3] / tsq;
+
+    const size_t tsk = ggml_type_size(k->type);
+    GGML_ASSERT(k->nb[0] == tsk);
+    const int64_t k_s01 = k->nb[1] / tsk;
+    const int64_t k_s02 = k->nb[2] / tsk;
+    const int64_t k_s03 = k->nb[3] / tsk;
+
+    l2_norm_pair_f32_cuda(
+        (const float *) q->data, (float *) l2q->data, (const float *) k->data, (float *) l2k->data,
+        ne00, ne01, ne02, ne03, q_s01, q_s02, q_s03, k_s01, k_s02, k_s03, eps, ctx.stream());
 }

--- a/ggml/src/ggml-cuda/norm.cuh
+++ b/ggml/src/ggml-cuda/norm.cuh
@@ -8,6 +8,9 @@ void ggml_cuda_op_rms_norm(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_rms_norm_fused(ggml_backend_cuda_context & ctx, ggml_tensor * dst, ggml_tensor * mul_tensor);
 
+void ggml_cuda_op_rms_norm_fused_q8(ggml_backend_cuda_context & ctx, ggml_tensor * dst, ggml_tensor * mul_tensor,
+                                    void * dst_q8, int64_t ncols_padded);
+
 void ggml_cuda_op_rms_norm_fused_add(ggml_backend_cuda_context & ctx,
                                      ggml_tensor *               dst,
                                      ggml_tensor *               mul_tensor,

--- a/ggml/src/ggml-cuda/norm.cuh
+++ b/ggml/src/ggml-cuda/norm.cuh
@@ -23,3 +23,5 @@ void ggml_cuda_op_rms_norm_fused_add(ggml_backend_cuda_context & ctx,
 void ggml_cuda_op_rms_norm_back(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
 void ggml_cuda_op_l2_norm(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
+
+void ggml_cuda_op_l2_norm_pair(ggml_backend_cuda_context & ctx, ggml_tensor * l2q, ggml_tensor * l2k);

--- a/ggml/src/ggml-cuda/norm.cuh
+++ b/ggml/src/ggml-cuda/norm.cuh
@@ -11,6 +11,10 @@ void ggml_cuda_op_rms_norm_fused(ggml_backend_cuda_context & ctx, ggml_tensor * 
 void ggml_cuda_op_rms_norm_fused_q8(ggml_backend_cuda_context & ctx, ggml_tensor * dst, ggml_tensor * mul_tensor,
                                     void * dst_q8, int64_t ncols_padded);
 
+void ggml_cuda_op_rms_norm_fused_prev_add(ggml_backend_cuda_context & ctx, ggml_tensor * rms_norm,
+                                          ggml_tensor * mul_tensor, ggml_tensor * add_tensor,
+                                          void * dst_q8, int64_t ncols_padded);
+
 void ggml_cuda_op_rms_norm_fused_add(ggml_backend_cuda_context & ctx,
                                      ggml_tensor *               dst,
                                      ggml_tensor *               mul_tensor,

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -33,22 +33,8 @@ static __global__ void quantize_q8_1(
 
     ggml_cuda_pdl_sync();
     const float xi = i0 < ne00 ? x[i03*s03 + i02*s02 + i01*s01 + i00] : 0.0f;
-    float amax = fabsf(xi);
-    float sum = xi;
 
-    amax = warp_reduce_max<QK8_1>(amax);
-    sum  = warp_reduce_sum<QK8_1>(sum);
-
-    const float  d = amax / 127.0f;
-    const int8_t q = amax == 0.0f ? 0 : roundf(xi / d);
-
-    y[ib].qs[iqs] = q;
-
-    if (iqs > 0) {
-        return;
-    }
-
-    y[ib].ds = make_half2(d, sum);
+    quantize_q8_1_val(xi, ib, iqs, y);
 }
 
 __device__ __forceinline__ uint8_t compute_e8m0_scale(float amax) {

--- a/ggml/src/ggml-cuda/quantize.cuh
+++ b/ggml/src/ggml-cuda/quantize.cuh
@@ -64,3 +64,14 @@ void quantize_scatter_mmq_q8_1_cuda(const float *   x,
                                     int64_t         nrows_dst,
                                     int             n_expert_used,
                                     cudaStream_t    stream);
+
+static __device__ __forceinline__ void quantize_q8_1_val(const float v, const int64_t ib, const int iqs, block_q8_1 * y) {
+    const float amax = warp_reduce_max<QK8_1>(fabsf(v));
+    const float sum  = warp_reduce_sum<QK8_1>(v);
+
+    const float d = amax / 127.0f;
+    y[ib].qs[iqs] = amax == 0.0f ? 0 : roundf(v / d);
+    if (iqs == 0) {
+        y[ib].ds = make_half2(d, sum);
+    }
+}

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3591,6 +3591,46 @@ struct test_rms_norm_mul_add : public test_case {
     }
 };
 
+// GGML_OP_ADD + GGML_OP_RMS_NORM + GGML_OP_MUL (fused residual-add + rms_norm * weight)
+struct test_add_rms_norm_mul : public test_case {
+    const ggml_type type;
+    const std::array<int64_t, 4> ne;
+    const float eps;
+
+    std::string op_desc(ggml_tensor * t) override { GGML_UNUSED(t); return "ADD_RMS_NORM_MUL"; }
+    bool run_whole_graph() override { return true; }
+    std::string vars() override { return VARS_TO_STR3(type, ne, eps); }
+
+    test_add_rms_norm_mul(ggml_type type = GGML_TYPE_F32,
+            std::array<int64_t, 4> ne = {64, 5, 4, 3}, float eps = 1e-6f)
+        : type(type), ne(ne), eps(eps) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne.data());
+        ggml_tensor * b = ggml_new_tensor(ctx, type, 4, ne.data());
+        ggml_set_param(a); ggml_set_name(a, "a");
+        ggml_set_param(b); ggml_set_name(b, "b");
+
+        // The mul weight must already be "used" (here: b, also an add operand), otherwise a fresh leaf
+        // becomes an OP_NONE node between rms_norm and mul and breaks the contiguous {ADD,RMS_NORM,MUL}
+        // pattern. 'add' (the residual) is consumed by the norm AND the trailing add, mimicking a
+        // transformer residual, so the fusion (which writes the residual back) actually fires.
+        ggml_tensor * add = ggml_add(ctx, a, b);
+        ggml_set_name(add, "add");
+        ggml_tensor * norm = ggml_mul(ctx, ggml_rms_norm(ctx, add, eps), b);
+        ggml_set_name(norm, "norm");
+        ggml_tensor * out = ggml_add(ctx, norm, add);
+        ggml_set_name(out, "out");
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            init_tensor_uniform(t, -10.f, 10.f);
+        }
+    }
+};
+
 // GGML_OP_ADD + GGML_OP_RMS_NORM (fused operation)
 struct test_add_rms_norm : public test_case {
     const ggml_type type;
@@ -8528,6 +8568,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_norm_mul_add(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, true));
             test_cases.emplace_back(new test_add_rms_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, false));
             test_cases.emplace_back(new test_add_rms_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, true));
+            test_cases.emplace_back(new test_add_rms_norm_mul(GGML_TYPE_F32, { n, 5, 4, 3 }, eps));
+            test_cases.emplace_back(new test_add_rms_norm_mul(GGML_TYPE_F32, { n, 1, 1, 1 }, eps));
         }
     }
     for (uint32_t n : {1, 511, 1025, 8192, 33*512}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6406,6 +6406,46 @@ struct test_l2_norm : public test_case {
     }
 };
 
+// two GGML_OP_L2_NORM (deltanet q/k pair): two L2_NORMs of same-shape views, separated by the k view
+struct test_l2_norm_pair : public test_case {
+    const ggml_type type;
+    const std::array<int64_t, 4> ne; // per-half (q and k each)
+    const float eps;
+
+    std::string op_desc(ggml_tensor * t) override { GGML_UNUSED(t); return "L2_NORM_PAIR"; }
+    bool run_whole_graph() override { return true; }
+    std::string vars() override { return VARS_TO_STR3(type, ne, eps); }
+
+    test_l2_norm_pair(ggml_type type = GGML_TYPE_F32,
+            std::array<int64_t, 4> ne = {128, 16, 2, 1}, float eps = 1e-6f)
+        : type(type), ne(ne), eps(eps) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        // base stacks q and k along dim1; q/k are views of it, like the deltanet conv output
+        const std::array<int64_t, 4> bne = {ne[0], ne[1]*2, ne[2], ne[3]};
+        ggml_tensor * base = ggml_new_tensor(ctx, type, 4, bne.data());
+        ggml_set_param(base); ggml_set_name(base, "base");
+
+        ggml_tensor * q = ggml_view_4d(ctx, base, ne[0], ne[1], ne[2], ne[3],
+            base->nb[1], base->nb[2], base->nb[3], 0);
+        ggml_tensor * qn = ggml_l2_norm(ctx, q, eps);
+        ggml_set_name(qn, "qn");
+        ggml_tensor * k = ggml_view_4d(ctx, base, ne[0], ne[1], ne[2], ne[3],
+            base->nb[1], base->nb[2], base->nb[3], ne[1]*base->nb[1]);
+        ggml_tensor * kn = ggml_l2_norm(ctx, k, eps);
+        ggml_set_name(kn, "kn");
+        ggml_tensor * out = ggml_add(ctx, qn, kn);
+        ggml_set_name(out, "out");
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            init_tensor_uniform(t, -10.f, 10.f);
+        }
+    }
+};
+
 // GGML_OP_ACC
 struct test_acc : public test_case {
     const ggml_type type;
@@ -8554,6 +8594,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_l2_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, false));
             test_cases.emplace_back(new test_l2_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, true));
             test_cases.emplace_back(new test_l2_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, false, true));
+            test_cases.emplace_back(new test_l2_norm_pair(GGML_TYPE_F32, { n, 16, 2, 1 }, eps));
         }
     }
 


### PR DESCRIPTION
## Overview

Some fusions and optimizations for ROCm decode.

## Additional information

Before:
| model                          |       size |     params | backend    | threads | dev          |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ------------ | --------------: | -------------------: |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |           pp512 |      1159.39 ± 15.17 |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |           tg128 |         62.23 ± 0.07 |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |  pp512 @ d30000 |        631.11 ± 6.92 |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |  tg128 @ d30000 |         53.31 ± 0.19 |

After:
| model                          |       size |     params | backend    | threads | dev          |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ------------ | --------------: | -------------------: |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |           pp512 |      1178.13 ± 10.09 |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |           tg128 |         64.92 ± 0.11 |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |  pp512 @ d30000 |        630.38 ± 6.93 |
| qwen35moe 35B.A3B Q4_K - Medium |  17.57 GiB |    34.66 B | ROCm,Vulkan,BLAS |      16 | ROCm0        |  tg128 @ d30000 |         55.23 ± 0.15 |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, mostly driven by Opus under my guidance