### PR TITLE
Add GGML_BACKEND_DL_IMPL invocation for OpenVINO backend

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -1378,3 +1378,5 @@ GGML_BACKEND_API ggml_backend_reg_t ggml_backend_openvino_reg(void) {
 
     return &reg;
 }
+
+GGML_BACKEND_DL_IMPL(ggml_backend_openvino_reg)


### PR DESCRIPTION
## Overview

This adds the missing `GGML_BACKEND_DL_IMPL()` macro invocation, that other backends have, to register dynamic loading functionality. I don't know whether it was missing on purpose, though. Seems to have made it work for me, at least.

## Additional information

Fixes #25586

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO