### PR TITLE
server : add realtime inference stats to /slots endpoint

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -904,6 +904,19 @@ This endpoint is enabled by default and can be disabled with `--no-slots`. It ca
 
 If query param `?fail_on_no_slot=1` is set, this endpoint will respond with status code 503 if there is no available slots.
 
+Each slot object includes the following realtime inference fields:
+
+- `state`: numeric slot state machine value
+- `state_name`: slot state, one of `idle`, `wait_other`, `started`, `processing_prompt`, `done_prompt`, `generating`
+- `pp_progress`: prompt-processing (prefill) completion ratio in `[0, 1]`. Only meaningful while the slot is processing; reaches `1.0` once prefill is done
+- `pp_time_ms`: total prompt-processing time in milliseconds (finalized once prefill completes)
+- `pp_tps`: prompt-processing throughput in tokens/second
+- `tg_tokens_generated`: number of tokens generated so far in the generation phase
+- `tg_time_ms`: total generation time in milliseconds
+- `tg_tps`: generation throughput in tokens/second
+
+These fields are only emitted while a slot is actively processing; an idle slot reports only its basic state.
+
 **Response format**
 
 <details>

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -64,6 +64,18 @@ enum slot_state {
     SLOT_STATE_GENERATING,
 };
 
+static const char * slot_state_to_string(slot_state s) {
+    switch (s) {
+        case SLOT_STATE_IDLE:              return "idle";
+        case SLOT_STATE_WAIT_OTHER:        return "wait_other";
+        case SLOT_STATE_STARTED:           return "started";
+        case SLOT_STATE_PROCESSING_PROMPT: return "processing_prompt";
+        case SLOT_STATE_DONE_PROMPT:       return "done_prompt";
+        case SLOT_STATE_GENERATING:        return "generating";
+        default:                           return "unknown";
+    }
+}
+
 struct server_slot; // forward declaration
 
 struct server_batch {
@@ -643,6 +655,8 @@ struct server_slot {
             {"n_ctx",         n_ctx},
             {"speculative",   can_speculate()},
             {"is_processing", is_processing()},
+            {"state",         (int)state},
+            {"state_name",    slot_state_to_string(state)},
         };
 
         const auto & ptask = task ? task : task_prev;
@@ -661,6 +675,32 @@ struct server_slot {
                     {"n_decoded",      n_decoded},
                 }
             };
+            
+            if (is_processing()) {
+                const int32_t pp_total = ptask->n_tokens();
+                int32_t pp_processed = 0;
+                if (state == SLOT_STATE_PROCESSING_PROMPT) {
+                    pp_processed = std::min<int32_t>((int32_t) prompt.tokens.size(), pp_total);
+                } else if (state == SLOT_STATE_DONE_PROMPT || state == SLOT_STATE_GENERATING) {
+                    pp_processed = pp_total;
+                }
+
+                const bool has_pp_timing =
+                    state == SLOT_STATE_PROCESSING_PROMPT ||
+                    state == SLOT_STATE_DONE_PROMPT ||
+                    state == SLOT_STATE_GENERATING;
+                
+                const double pp_time_ms = has_pp_timing ? t_prompt_processing : 0.0;
+
+                res["pp_progress"] = pp_total > 0 ? std::min(1.0, (double) pp_processed / pp_total) : 0.0;
+                res["pp_time_ms"] = pp_time_ms;
+                res["pp_tps"] = pp_time_ms > 1.0 ? (1e3 / pp_time_ms * n_prompt_tokens_processed) : 0.0;
+                
+                const bool is_generating = state == SLOT_STATE_GENERATING;
+                res["tg_tokens_generated"] = is_generating ? n_decoded : 0;
+                res["tg_time_ms"]          = is_generating ? t_token_generation : 0.0;
+                res["tg_tps"]              = is_generating && t_token_generation > 0.0 ? (1e3 / t_token_generation * n_decoded) : 0.0;
+            }
 
             if (!only_metrics) {
                 res["prompt"] = ptask->tokens.detokenize(ctx_tgt, true);

--- a/tools/server/tests/unit/test_basic.py
+++ b/tools/server/tests/unit/test_basic.py
@@ -61,6 +61,10 @@ def test_server_slots():
     assert server.n_ctx is not None and server.n_slots is not None
     assert res.body[0]["n_ctx"] == server.n_ctx / server.n_slots
     assert "params" not in res.body[0]
+    assert res.body[0]["state_name"] == "idle"
+    assert res.body[0]["state"] == 0
+    assert "pp_progress" not in res.body[0]
+    assert "tg_tps" not in res.body[0]
 
 
 def test_load_split_model():


### PR DESCRIPTION
## Overview
Extends the `/slots` endpoint with realtime per-slot inference stats, addressing #25519.

Currently `/slots` exposes basic slot infos, but not the running job's progress or throughput. So the users have to tail the server log to see how prompt processing or generation going. This adds data to the existing `server_slot::to_json()`, reusing the metrics task that already powers `/slots`, NO NEW endpoint and NO NEW data collection.

## Design notes
- Extended `/slots` instead of adding a new `/realtime` endpoint — all the source data already lives on the slot and is collected via the existing metrics task, so a separate endpoint would return largely overlapping data. Happy to reshape this if you'd prefer.
- `pp_progress` is clamped to 0->1 — the raw ratio can exceed 1 during generation since the running token count grows; the denominator uses the task's input token count so it stays a clean prefill-completion percentage. Generation is tracked separately via `tg_tokens_generated`.
- Phase/idle gating — pp/tg fields are only emitted while the slot is actually processing; an idle slot won't report stale stats from its previous task.

## Testing
Tested locally (gemma-3-1b, Metal); 
and the values match the server's own timing logs (e.g. `tg_tps` ≈ 51). 
Add an assertion to `test_server_slots` for the idle case; passes locally.

## Added fields
`state` / `state_name`: slot state machine value and name
`pp_progress`, `pp_time_ms`, `pp_tps`: prompt-processing progress and throughput
`tg_tokens_generated`, `tg_time_ms`, `tg_tps`: generation progress and throughput

## Additional information
Ref #25519 

## Requirements
- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — I used an AI assistant to help me understand the server code and review the approach. The implementation, design decisions, and testing are my own, and I take responsibility for the change.