### PR TITLE
server : add trace logs for slot prefix similarity computation

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1557,7 +1557,11 @@ private:
                 }
 
                 // fraction of the Longest Common Prefix length with respect to the input prompt length
-                const float sim_cur = float(tokens.get_common_prefix(task.tokens)) / task.tokens.size();
+                const int32_t n_prefix = tokens.get_common_prefix(task.tokens);
+                const float sim_cur = float(n_prefix) / task.tokens.size();
+
+                SLT_TRC(slot, "prefix similarity check: n_prefix = %d, n_task_tokens = %d, sim_cur = %.3f, sim_best = %.3f, threshold = %.3f\n",
+                        n_prefix, (int) task.tokens.size(), sim_cur, sim_best, slot_prompt_similarity);
 
                 // select the current slot if the criteria match
                 if (sim_cur > sim_best && sim_cur > slot_prompt_similarity) {


### PR DESCRIPTION
## Overview

Log the computed prefix similarity values for each slot during slot selection, including the common prefix length, task token count, current similarity, best similarity so far, and the threshold.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.6-27B