### PR TITLE
server : remote speculative decoding via ethernet

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3912,6 +3912,24 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_MODEL"));
     add_opt(common_arg(
+        {"--spec-draft-model-url"}, "URL",
+        "URL for remote draft model using OpenAI API format (e.g., http://localhost:8080/v1) (default: unused)",
+        [](common_params & params, const std::string & value) {
+            params.speculative.draft.api_url = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_DRAFT_MODEL_URL"));
+    add_opt(common_arg(
+        {"--spec-draft-context-limit"}, "N",
+        string_format("maximum context tokens to send to remote draft model, used for anchor-based windowing (default: %d)",
+            params.speculative.draft.context_limit),
+        [](common_params & params, int value) {
+            if (value < 1) {
+                throw std::invalid_argument("context limit must be at least 1");
+            }
+            params.speculative.draft.context_limit = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--spec-type"}, common_speculative_all_types_str(),
         string_format("comma-separated list of types of speculative decoding to use (default: %s)\n",
             common_speculative_type_name_str(params.speculative.types).c_str()),

--- a/common/common.h
+++ b/common/common.h
@@ -172,6 +172,7 @@ enum common_speculative_type {
     COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3,  // Eagle3 speculative decoding
     COMMON_SPECULATIVE_TYPE_DRAFT_MTP,     // Multi-token prediction
     COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH,  // DFlash speculative decoding
+    COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE,  // Remote draft model via API
     COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE,  // simple self-speculative decoding based on n-grams
     COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K,   // self-speculative decoding with n-gram keys only
     COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V, // self-speculative decoding with n-gram keys and 4 m-gram values
@@ -348,6 +349,11 @@ struct common_params_speculative_draft {
     std::vector<ggml_backend_dev_t> devices; // devices to use for offloading
 
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
+
+    // Remote draft model parameters (when api_url is not empty, use remote model instead of local)
+    std::string api_url;           // URL of the remote draft model API (e.g., "http://192.168.1.100:8080/v1"), empty = use local model
+    int32_t context_limit = 8192;  // maximum context length to send to remote model
+    int32_t timeout_seconds = 3;   // timeout for API requests in seconds
 };
 
 struct common_params_speculative_ngram_mod {
@@ -382,7 +388,11 @@ struct common_params_speculative {
     common_params_speculative_ngram_cache ngram_cache;
 
     bool has_dft() const {
-        return !draft.mparams.empty();
+        return !draft.mparams.empty() || !draft.api_url.empty();
+    }
+
+    bool is_draft_remote() const {
+        return !draft.api_url.empty();
     }
 
     uint32_t need_n_rs_seq() const {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -8,6 +8,7 @@
 #include "ngram-map.h"
 #include "ngram-mod.h"
 #include "sampling.h"
+#include "http.h"
 
 #include "../src/llama-ext.h" // staging API: llama_set_embeddings_nextn / llama_get_embeddings_nextn_ith (used by MTP)
 
@@ -17,6 +18,11 @@
 #include <iomanip>
 #include <map>
 #include <cinttypes>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
 
 #define SPC_DBG(fmt, ...) LOG_DBG("spec %12.*s: " fmt, 12, __func__, __VA_ARGS__)
 #define SPC_TRC(fmt, ...) LOG_TRC("spec %12.*s: " fmt, 12, __func__, __VA_ARGS__)
@@ -34,6 +40,7 @@ const std::map<std::string, common_speculative_type> common_speculative_type_fro
     {"draft-eagle3",  COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3},
     {"draft-mtp",     COMMON_SPECULATIVE_TYPE_DRAFT_MTP},
     {"draft-dflash",  COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH},
+    {"draft-remote",  COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE},
     {"ngram-simple",  COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE},
     {"ngram-map-k",   COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K},
     {"ngram-map-k4v", COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V},
@@ -2077,6 +2084,245 @@ struct common_speculative_impl_ngram_cache : public common_speculative_impl {
     }
 };
 
+// Remote draft model via llama-server /completion endpoint
+struct common_speculative_impl_remote_draft : public common_speculative_impl {
+    common_params_speculative_draft params;
+
+    // Reusable HTTP client - created once in constructor, reused for every draft() call
+    httplib::Client *http_cli = nullptr;
+    common_http_url url_parts;
+
+    // Per-sequence state for anchor-based context windowing.
+    std::vector<int32_t> context_start_idx;
+
+    common_speculative_impl_remote_draft(
+            const common_params_speculative & p, uint32_t n_seq)
+        : common_speculative_impl(COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE, n_seq)
+        , params(p.draft)
+        , context_start_idx(n_seq, 0)
+    {
+
+        // Parse URL once and create the HTTP client for reuse
+        try {
+            url_parts = common_http_parse_url(params.api_url);
+        } catch (const std::exception &e) {
+            SPC_ERR("failed to parse draft API URL '%s': %s\n", params.api_url.c_str(), e.what());
+            return;
+        }
+
+        std::string base_url = url_parts.scheme + "://" + common_http_format_host(url_parts.host) + ":" + std::to_string(url_parts.port);
+        http_cli = new httplib::Client(base_url);
+        http_cli->set_follow_location(true);
+        http_cli->set_read_timeout(params.timeout_seconds, 0);
+        http_cli->set_tcp_nodelay(true);
+
+        // Set default headers once on the client
+        http_cli->set_default_headers({
+            {"Content-Type", "application/json"},
+        });
+
+        SPC_TRC("%s", "adding speculative implementation 'draft-remote'\n");
+        SPC_TRC("- url=%s, n_max=%d, context_limit=%d\n",
+                this->params.api_url.c_str(),
+                this->params.n_max, this->params.context_limit);
+    }
+
+    ~common_speculative_impl_remote_draft() {
+        delete http_cli;
+    }
+
+    void begin(llama_seq_id seq_id, const llama_tokens & /*prompt*/) override {
+        // Reset context windowing state for the given sequence at the start of each new generation
+        context_start_idx[seq_id] = 0;
+    }
+
+    bool process(const llama_batch & /*batch*/) override {
+        // noop
+        return true;
+    }
+
+    void draft(common_speculative_draft_params_vec & dparams) override {
+        // Wrap entire method in try-catch to prevent server crashes
+        try {
+            if (!this->params.ctx_tgt) {
+                SPC_DBG("%s", "ctx_tgt is null, skipping");
+                return;
+            }
+
+        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+            auto & dp = dparams[seq_id];
+            if (!dp.drafting) {
+                continue;
+            }
+
+            auto & result = *dp.result;
+            result.clear();
+
+            const auto & prompt = *dp.prompt;
+            if (prompt.empty()) {
+                continue;
+            }
+
+            // As the conversation grows, we incrementally add to the history portion.
+            // When history exceeds max_history, we shift context_start_idx forward, then grow again
+            const int32_t limit        = params.context_limit;
+            const int32_t n_keep       = limit / 4;         // system prompt anchor
+            const int32_t max_history  = limit / 2;         // max dynamic history budget
+            const int32_t reset_to     = limit / 4;         // history size after shift
+            const int32_t prompt_size  = (int32_t) prompt.size();
+
+            // Edge case: prompt smaller than anchor, just send everything
+            if (prompt_size <= n_keep) {
+                // Nothing to shift, use full prompt
+            } else {
+                // Calculate current history size (tokens after anchor, starting from context_start_idx)
+                const int32_t history_start = std::max(context_start_idx[seq_id], n_keep);
+                const int32_t current_history = prompt_size - history_start;
+
+                if (current_history > max_history) {
+                    // History exceeded max, shift forward to shrink it to reset_to
+                    context_start_idx[seq_id] = prompt_size - reset_to;
+                    if (context_start_idx[seq_id] < n_keep) {
+                        context_start_idx[seq_id] = n_keep;
+                    }
+                }
+                // Else: within budget, keep context_start_idx as-is (incremental growth)
+            }
+
+            // Build the context tokens: anchor + dynamic history
+            const int32_t history_start = std::max(context_start_idx[seq_id], n_keep);
+            nlohmann::json prompt_array = nlohmann::json::array();
+
+            // Add anchor (system prompt prefix)
+            for (int32_t i = 0; i < n_keep && i < prompt_size; ++i) {
+                prompt_array.push_back(prompt[i]);
+            }
+
+            // Add dynamic history portion
+            for (int32_t i = history_start; i < prompt_size; ++i) {
+                prompt_array.push_back(prompt[i]);
+            }
+
+            if (prompt_array.empty()) {
+                continue;
+            }
+
+            // Append the last sampled token
+            prompt_array.push_back(dp.id_last);
+
+            // Build JSON request for native /completion endpoint
+            nlohmann::json req;
+            req["prompt"] = prompt_array;
+            req["n_predict"] = params.n_max;
+            req["stream"] = true;
+            req["keep_alive"] = true;
+            // Use native /completion  endpoint
+            std::string path = "/completion";
+
+            SPC_DBG("sending POST to %s%s\n", common_http_show_masked_url(url_parts).c_str(), path.c_str());
+
+            // Make streaming POST request using the reusable HTTP client
+            auto res = http_cli->Post(path, req.dump(), "application/json");
+            if (!res || res->status != 200) {
+                SPC_ERR("HTTP request failed with status %d\n", res ? res->status : 0);
+                continue;
+            }
+
+            // Parse SSE streaming response
+            // Each SSE data line contains JSON with a "tokens" array of token IDs
+            std::string body = res->body;
+
+            std::istringstream stream(body);
+            std::string line;
+
+            while (std::getline(stream, line)) {
+                // Remove trailing \r if present
+                if (!line.empty() && line.back() == '\r') {
+                    line.pop_back();
+                }
+
+                // Skip empty lines and SSE comments
+                if (line.empty() || line[0] == ':') {
+                    continue;
+                }
+
+                // Parse "data: {...}" lines
+                if (line.rfind("data:", 0) != 0) {
+                    continue;
+                }
+
+                std::string data = line.substr(5);
+
+                // Check for [DONE]
+                if (data == "[DONE]") {
+                    break;
+                }
+
+                try {
+                    auto j = nlohmann::json::parse(data, nullptr, false);
+
+                    // Extract "tokens" array from native /completion stream response
+                    if (j.contains("tokens") && j["tokens"].is_array()) {
+                        for (auto & token : j["tokens"]) {
+                            if (token.is_number_integer()) {
+                                llama_token t = token.get<llama_token>();
+                                result.push_back(t);
+                                SPC_DBG("received token: %d\n", t);
+                            }
+                        }
+                    }
+
+                    // Check for "stop" field indicating end of generation
+                    if (j.contains("stop") && j["stop"].is_boolean() && j["stop"].get<bool>()) {
+                        break;
+                    }
+                } catch (...) {
+                    SPC_DBG("%s", "JSON parse error, skipping line");
+                    continue;
+                }
+
+                // Stop if we have collected enough tokens
+                if ((int) result.size() >= params.n_max) {
+                    break;
+                }
+            }
+
+            if (result.empty()) {
+                SPC_DBG("%s", "(no tokens received)");
+                continue;
+            }
+
+            // Truncate to n_max if we got too many tokens
+            if ((int) result.size() > params.n_max) {
+                result.resize(params.n_max);
+            }
+
+            // Check minimum tokens requirement (require at least 2 tokens)
+            if ((int) result.size() < 2) {
+                SPC_DBG("draft too short (%d < 2), clearing", (int) result.size());
+                result.clear();
+            }
+
+            if (!result.empty()) {
+                SPC_DBG("drafted %zu tokens from remote model", result.size());
+            }
+        }
+        } catch (const std::exception & e) {
+            SPC_ERR("draft exception: %s\n", e.what());
+        } catch (...) {
+            SPC_ERR("%s", "draft exception (unknown)\n");
+        }
+    }
+
+    void accept(llama_seq_id /*seq_id*/, uint16_t /*n_accepted*/, bool /*is_other*/) override {
+        // noop
+    }
+
+    bool need_embd() const override {
+        return false;
+    }
+};
+
 struct common_speculative {
     common_speculative_draft_params_vec dparams;
 
@@ -2145,6 +2391,7 @@ std::string common_speculative_type_to_str(common_speculative_type type) {
         case COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3:  return "draft-eagle3";
         case COMMON_SPECULATIVE_TYPE_DRAFT_MTP:     return "draft-mtp";
         case COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH:  return "draft-dflash";
+        case COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE:  return "draft-remote";
         case COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE:  return "ngram-simple";
         case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K:   return "ngram-map-k";
         case COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V: return "ngram-map-k4v";
@@ -2214,6 +2461,9 @@ int32_t common_speculative_n_max(const common_params_speculative * spec) {
                 break;
             case COMMON_SPECULATIVE_TYPE_NGRAM_CACHE:
                 n_max = std::max(n_max, (int32_t) 8);
+                break;
+            case COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE:
+                n_max = std::max(n_max, std::max(0, spec->draft.n_max));
                 break;
             case COMMON_SPECULATIVE_TYPE_NONE:
             case COMMON_SPECULATIVE_TYPE_COUNT:
@@ -2350,9 +2600,10 @@ common_speculative * common_speculative_init(common_params_speculative & params,
         bool has_ngram_map_k   = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K));
         bool has_ngram_map_k4v = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V));
         bool has_ngram_mod     = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_NGRAM_MOD));
+        bool has_draft_remote  = (enabled_configs & (1u << COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE)) && params.is_draft_remote();
 
         // when adding a new type - update here the logic above
-        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 10);
+        static_assert(COMMON_SPECULATIVE_TYPE_COUNT == 11);
 
         // this list here defines the priority of the speculators
         // the one with highest priority are listed first
@@ -2384,6 +2635,9 @@ common_speculative * common_speculative_init(common_params_speculative & params,
         }
         if (has_draft_dflash) {
             configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH, params));
+        }
+        if (has_draft_remote) {
+            configs.push_back(common_speculative_config(COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE, params));
         }
     }
 
@@ -2450,6 +2704,10 @@ common_speculative * common_speculative_init(common_params_speculative & params,
                         params.ngram_cache.lookup_cache_static,
                         params.ngram_cache.lookup_cache_dynamic);
                 impls.push_back(std::make_unique<common_speculative_impl_ngram_cache>(state));
+                break;
+            }
+            case COMMON_SPECULATIVE_TYPE_DRAFT_REMOTE: {
+                impls.push_back(std::make_unique<common_speculative_impl_remote_draft>(config.params, n_seq));
                 break;
             }
             default:

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -466,6 +466,7 @@ struct server_slot {
             for (auto token : spec_draft) {
                 add_ok &= batch.add(this->id, token, pos0++, true);
             }
+
         }
 
         GGML_ASSERT(add_ok && "batch must be large enough to hold the sampled and draft tokens");
@@ -1012,7 +1013,8 @@ private:
         const bool spec_mtp = std::find(params_base.speculative.types.begin(),
                                         params_base.speculative.types.end(),
                                         COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end();
-        const bool has_spec = has_draft || spec_mtp;
+        const bool has_remote_draft = params.speculative.is_draft_remote();
+        const bool has_spec = has_draft || spec_mtp || has_remote_draft;
 
         if (callback_state) {
             std::vector<std::string> stages = {"text_model"};
@@ -1081,7 +1083,7 @@ private:
 
         // optionally reserve VRAM for the draft / MTP context before fitting the target model
         if (params_base.fit_params) {
-            if (has_spec) {
+            if (has_spec && !has_remote_draft) {
                 // MTP draft context lives on the target model, only context+compute are new
                 bool measure_model_bytes = has_draft;
 
@@ -1158,7 +1160,8 @@ private:
 
         add_bos_token = llama_vocab_get_add_bos(vocab);
 
-        if (has_spec) {
+        // For remote draft, ctx_tgt is already set in draft.ctx_tgt (shared field)
+        if (has_spec && !has_remote_draft) {
             // spec_mtp doesn't use load a model internally, so we report 0.0 and 1.0 manually
             load_progress_callback(0.0f, &load_progress_spec);
             load_progress_spec.t_last_load_progress_ms = 0;  // reset so internal cbs aren't delayed
@@ -1268,6 +1271,11 @@ private:
         // initialize slots
         for (int i = 0; i < params_base.n_parallel; i++) {
             slots.emplace_back();
+        }
+
+        // For remote draft, set ctx_tgt since there's no local draft model to provide it
+        if (has_remote_draft) {
+            params_base.speculative.draft.ctx_tgt = ctx_tgt;
         }
 
         // try speculative decoding
@@ -3807,10 +3815,22 @@ private:
                 common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
 
                 GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
+
                 auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
                 slot.spec_i_batch.clear();
 
                 GGML_ASSERT(accepted.size() >= 1);
+
+                // track acceptance stats for every verification step (before checkpoint restore early return)
+                slot.n_draft_accepted += accepted.size() - 1;
+                slot.n_draft_verif_steps += 1;
+
+                if (slot.n_accepted_per_pos.empty()) {
+                    slot.n_accepted_per_pos.resize(common_speculative_n_max(&params_base.speculative), 0);
+                }
+                for (size_t i = 0; i < accepted.size() - 1 && i < slot.n_accepted_per_pos.size(); ++i) {
+                    slot.n_accepted_per_pos[i]++;
+                }
 
                 const uint32_t n_rollback = slot.spec_draft.size() + 1 - accepted.size();
 
@@ -3865,17 +3885,6 @@ private:
             const auto ids = std::move(slot.spec_draft);
 
             slot.t_token_generation = std::max<int64_t>(1, t_now - slot.t_start_generation) / 1e3;
-
-            // update how many tokens out of those tested were accepted
-            slot.n_draft_accepted += ids.size() - 1;
-            slot.n_draft_verif_steps += 1;
-
-            if (slot.n_accepted_per_pos.empty()) {
-                slot.n_accepted_per_pos.resize(common_speculative_n_max(&params_base.speculative), 0);
-            }
-            for (size_t i = 0; i < ids.size() - 1 && i < slot.n_accepted_per_pos.size(); ++i) {
-                slot.n_accepted_per_pos[i]++;
-            }
 
             // add accepted tokens to the prompt
             slot.prompt.tokens.keep_first(slot.prompt.n_tokens() - n_draft);

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -200,6 +200,11 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
     add((new field_num("speculative.n_max", params.speculative.draft.n_max))
         ->set_hard_limits(0, INT32_MAX)
         ->set_desc("Maximum number of tokens to draft during speculative decoding"));
+    add((new field_str("speculative.remote_draft_url"))
+        ->set_desc("URL for remote draft model using OpenAI API format (e.g., http://localhost:8080/v1)")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            ctx.params.speculative.draft.api_url = data.at("speculative.remote_draft_url").get<std::string>();
+        }));
 
     add((new field_num("speculative.n_min", params.speculative.draft.n_min))
         ->set_hard_limits(0, INT32_MAX)


### PR DESCRIPTION
## Overview

Added possibility to do speculative drafting via network connection. Re-using existing /completion API in llamaserver as well as existing functionality to run speculative draft tokens in a model. I only added the communication and passing of tokens, as well as some selection of token history to the remote draft model. Speedup is 0-300% depending on use case.

CLI options for remote draft:
--spec-type draft-remote (added draft-remote to existing --spec-type)
--spec-draft-model-url (new)
--spec-draft-context-limit (new, optional, default: 8192)
--spec-draft-n-max (use existing parameter value in this use case, optional, used to set nbr draft tokens that we request from remote model, default is 3)

## Additional information

Basic requirement for this to work is that main model and draft model share the exact same token libraries, which below two test examples do have,

I also corrected a minor problem in server-context.cpp where acceptance statics for Qwen pair excluded some failures giving me 1.0 acceptance statistics always in first draft position, which obviously is impossible for a 2B model to achieve.

**Test setup**
Two computers with direct connection using a 10Gbit/s ethernet point to point connection. Main model is running on an RTX 6000 Pro Blackwell and draft model is running on a RTX 5090.
First model test:
Main model: Qwen3.6 BF16 (KV: BF16, ctx_length: 256k)
Draft model:  Qwen3.5-2B-UD-Q4_K_XL (KV: BF16, ctx_length: 8k), 400-600 tokens/second
Second model test:
Main model: Devstral-2-123B-Instruct-2512-Q4_K_M (KV: q8_0, ctx_length: 128k)
Draft model: Ministral-3-3B-Instruct-2512-Q4_K_M (KV: q8_0, ctx_length: 8k), 300-400 tokens/second

**Results**
I just put below test prompts inside llama-server web chat interface and note results from UI and log.

Test prompt 1: Write me a snake game in a self contained html file
8 draft tokens were used.
**Qwen3.6 27B BF16 without draft model: 28.35 t/s
Qwen3.6 27B BF16 with draft model over TCP/IP:  60.03 t/s**
slot print_timing: id  3 | task 707 | draft acceptance = 0.92692 ( 1928 accepted /  2080 generated), mean len =  6.54
slot print_timing: id  3 | task 707 |      acc per pos = (0.948, 0.851, 0.759, 0.687, 0.632, 0.586, 0.557, 0.520)
**Devstral-2-123B-Instruct-2512-Q4_K_M without draft model: 16.73 t/s
Devstral-2-123B-Instruct-2512-Q4_K_M with draft model of TCP/IP: 73.34 t/s**
slot print_timing: id  3 | task 0 | draft acceptance = 0.80067 ( 1189 accepted /  1485 generated), mean len =  7.39
slot print_timing: id  3 | task 0 |      acc per pos = (0.925, 0.882, 0.833, 0.790, 0.774, 0.758, 0.720, 0.710)

Test prompt 2: Tell me about the history of Europe
6 draft tokens were used.
**Qwen3.6 27B BF16 without draft model: 28.48 t/s
Qwen3.6 27B BF16 with draft model over TCP/IP:  28.94 t/s**
slot print_timing: id  3 | task 505 | draft acceptance = 0.74612 ( 1925 accepted /  2580 generated), mean len =  3.47
slot print_timing: id  3 | task 505 |      acc per pos = (0.860, 0.603, 0.408, 0.279, 0.191, 0.130)

**Devstral-2-123B-Instruct-2512-Q4_K_M without draft model: 16.73 t/s
Devstral-2-123B-Instruct-2512-Q4_K_M with draft model of TCP/IP: 27.92 t/s**
6.10.418.328 I slot print_timing: id  3 | task 633 | draft acceptance = 0.52462 ( 1204 accepted /  2295 generated), mean len =  4.14
6.10.418.328 I slot print_timing: id  3 | task 633 |      acc per pos = (0.770, 0.629, 0.538, 0.465, 0.402, 0.339)

**Example commands** when testing (code benefits from higher spec-draft-n-max) 
draft model start:
/home/1/llama.cpp/build/bin/llama-server --model /home/mir/services/models/Ministral-3-3B-Instruct-2512-Q4_K_M.gguf  -fa on -ctk q8_0  -ctv q8_0 -c 8192 -ngl 99 -b 1024 -ub 1024 --jinja --kv-unified --no-mmap --parallel 4 --threads 8 --temp 0.0 --top-k 1 --host 0.0.0.0 --port 3535

main model start:
/home/2/llama.cpp/build/bin/llama-server --model /home/mir/services/models/Devstral-2-123B-Instruct-2512-Q4_K_M-00001-of-00002.gguf -fa on -ctk q8_0 -ctv q8_0 -c 131072 --no-mmap --parallel 4 --jinja --threads 16 --spec-type draft-remote --spec-draft-model-url http://x.y.z.q:3535/v1 --spec-draft-n-max 8 --port 3536

Next steps possibilities:
- Main model to self-evaluate draft model acceptance rates and automatically adjust number of draft tokens requested on the fly.
- Optimize what context is sent to the draft model in the situation of TCP/IP overhead playing into the equation. Accuracy should normally be prioritized here due to the extra overhead cost?

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
Since I am new to this project, I used AI to explain to me the architecture, what files that do what and where good places to add code would be. I also used AI to help me fix bugs and optimizations, and for code review. I used AI to help me do the first PR of my life to this project.

