### PR TITLE
server : add stuck-loop escape for ngram-mod (WIP)

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -690,6 +690,9 @@ std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sample
         result.push_back(id);
 
         if (draft[i] != id) {
+            const float * logits = llama_get_logits_ith(ctx, idxs[i]);
+            LOG_DBG("[issue#23268] VERIFY_FAIL: idx=%zu draft=%d (logit=%.4f) sampled=%d (logit=%.4f)\n",
+                    i, draft[i], logits[draft[i]], id, logits[id]);
             break;
         }
     }

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -670,6 +670,9 @@ std::vector<llama_token> common_sampler_sample_and_accept_n(struct common_sample
         result.push_back(id);
 
         if (draft[i] != id) {
+            const float * logits = llama_get_logits_ith(ctx, idxs[i]);
+            LOG_DBG("[issue#23268] VERIFY_FAIL: idx=%zu draft=%d (logit=%.4f) sampled=%d (logit=%.4f)\n",
+                    i, draft[i], logits[draft[i]], id, logits[id]);
             break;
         }
     }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -209,6 +209,8 @@ struct server_slot {
     common_speculative * spec;
 
     llama_tokens spec_draft;
+    int issue_23268_spec_rollback_streak = 0;
+    bool issue_23268_spec_disabled_this_turn = false;
     llama_tokens spec_prompt;
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
@@ -350,6 +352,7 @@ struct server_slot {
             spec_i_batch.clear();
             spec_ckpt.clear();
         }
+        issue_23268_spec_disabled_this_turn = false;
         generated_tokens.clear();
         generated_token_probs.clear();
         json_schema = json();
@@ -463,7 +466,7 @@ struct server_slot {
     int get_n_draft_max() const {
         GGML_ASSERT(task);
 
-        if (!can_speculate()) {
+        if (!can_speculate() || issue_23268_spec_disabled_this_turn) {
             return 0;
         }
 
@@ -3009,6 +3012,9 @@ private:
                 if (n_draft_max > 0) {
                     GGML_ASSERT(slot.can_speculate());
 
+                    SLT_DBG(slot, "[issue#23268] PRE_DRAFT: spec_draft.empty() = %s, n_past = %d\n",
+                            slot.spec_draft.empty() ? "yes" : "no", slot.prompt.n_tokens());
+
                     if (!slot.spec_draft.empty()) {
                         // we have a previous (partial) draft to reuse
                         if (use_ckpt_tgt) {
@@ -3831,6 +3837,8 @@ private:
 
             slot.n_decoded += 1;
 
+            slot.issue_23268_spec_rollback_streak = 0;
+
             if (slot.n_decoded == 1) {
                 slot.t_start_generation = t_now;
                 slot.t_print_last = t_now;
@@ -3869,6 +3877,8 @@ private:
                 return;
             }
 
+            constexpr int issue_23268_spec_stuck_threshold = 3;
+
             // save the original draft size
             const size_t n_draft = slot.spec_draft.size();
 
@@ -3881,6 +3891,8 @@ private:
 
                 GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
                 auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
+
+                const int32_t issue_23268_fail_batch_idx = slot.spec_i_batch[accepted.size() - 1];
                 slot.spec_i_batch.clear();
 
                 GGML_ASSERT(accepted.size() >= 1);
@@ -3900,7 +3912,35 @@ private:
 
                         // partial acceptance is not supported by the context -> truncate the draft and restore the state
                         slot.spec_is_replay = true;
+
+                        // issue #23268: too many no-progress rollbacks in a row -> report, then escape the loop by
+                        // dropping the unstable correction token so the matched prefix commits on the next step.
+                        if (++slot.issue_23268_spec_rollback_streak > issue_23268_spec_stuck_threshold) {
+                            const size_t      fail_idx    = accepted.size() - 1;
+                            const llama_token tok_draft   = slot.spec_draft[fail_idx];
+                            const llama_token tok_sampled = accepted.back();
+                            const float *     logits      = llama_get_logits_ith(slot.ctx_tgt, issue_23268_fail_batch_idx);
+                            SLT_WRN(slot,
+                                "[issue#23268] STUCK speculative loop: %d consecutive checkpoint restores with no progress "
+                                "(matched %zu/%zu draft tokens), diverging at draft index %zu: "
+                                "draft %d ('%s', logit %.4f) vs sampled %d ('%s', logit %.4f). "
+                                "Applying mitigation to force progress - please report with server logs at "
+                                "https://github.com/ggml-org/llama.cpp/issues/23268\n",
+                                slot.issue_23268_spec_rollback_streak, fail_idx, slot.spec_draft.size(), fail_idx,
+                                tok_draft,   common_token_to_piece(slot.ctx_tgt, tok_draft).c_str(),   logits[tok_draft],
+                                tok_sampled, common_token_to_piece(slot.ctx_tgt, tok_sampled).c_str(), logits[tok_sampled]);
+
+                            if (accepted.size() == 1) {
+                                slot.issue_23268_spec_disabled_this_turn = true;
+                            }
+
+                            accepted.pop_back();
+                        }
+
                         slot.spec_draft = std::move(accepted);
+
+                        SLT_DBG(slot, "[issue#23268] ROLLBACK: streak = %d, spec_draft = %zu tokens\n",
+                                slot.issue_23268_spec_rollback_streak, slot.spec_draft.size());
 
                         const auto & ckpt = slot.spec_ckpt;
 
@@ -3926,6 +3966,12 @@ private:
                 }
 
                 common_speculative_accept(spec.get(), slot.id, accepted.size() - 1);
+
+                if (slot.issue_23268_spec_rollback_streak > issue_23268_spec_stuck_threshold) {
+                    SLT_INF(slot, "[issue#23268] recovered from stuck speculative loop after %d iterations\n",
+                            slot.issue_23268_spec_rollback_streak);
+                }
+                slot.issue_23268_spec_rollback_streak = 0;
 
                 slot.spec_draft = std::move(accepted);
             }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -209,6 +209,8 @@ struct server_slot {
     common_speculative * spec;
 
     llama_tokens spec_draft;
+    int issue_23268_spec_rollback_streak = 0;
+    bool issue_23268_spec_disabled_this_turn = false;
     llama_tokens spec_prompt;
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
@@ -340,6 +342,7 @@ struct server_slot {
             spec_i_batch.clear();
             spec_ckpt.clear();
         }
+        issue_23268_spec_disabled_this_turn = false;
         generated_tokens.clear();
         generated_token_probs.clear();
         json_schema = json();
@@ -439,7 +442,7 @@ struct server_slot {
     int get_n_draft_max() const {
         GGML_ASSERT(task);
 
-        if (!can_speculate()) {
+        if (!can_speculate() || issue_23268_spec_disabled_this_turn) {
             return 0;
         }
 
@@ -2901,6 +2904,9 @@ private:
                 if (n_draft_max > 0) {
                     GGML_ASSERT(slot.can_speculate());
 
+                    SLT_DBG(slot, "[issue#23268] PRE_DRAFT: spec_draft.empty() = %s, n_past = %d\n",
+                            slot.spec_draft.empty() ? "yes" : "no", slot.prompt.n_tokens());
+
                     if (!slot.spec_draft.empty()) {
                         // we have a previous (partial) draft to reuse
                         if (use_ckpt_tgt) {
@@ -3732,6 +3738,8 @@ private:
 
             slot.stats.n_gen += 1;
 
+            slot.issue_23268_spec_rollback_streak = 0;
+
             if (slot.stats.n_gen == 1) {
                 slot.stats.update_prompt_last();
                 slot.t_print_last = t_now;
@@ -3768,6 +3776,8 @@ private:
                 return;
             }
 
+            constexpr int issue_23268_spec_stuck_threshold = 3;
+
             // save the original draft size
             const size_t n_draft = slot.spec_draft.size();
 
@@ -3779,6 +3789,8 @@ private:
 
                 GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
                 auto accepted = common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft);
+
+                const int32_t issue_23268_fail_batch_idx = slot.spec_i_batch[accepted.size() - 1];
                 slot.spec_i_batch.clear();
 
                 GGML_ASSERT(accepted.size() >= 1);
@@ -3798,7 +3810,35 @@ private:
 
                         // partial acceptance is not supported by the context -> truncate the draft and restore the state
                         slot.spec_is_replay = true;
+
+                        // issue #23268: too many no-progress rollbacks in a row -> report, then escape the loop by
+                        // dropping the unstable correction token so the matched prefix commits on the next step.
+                        if (++slot.issue_23268_spec_rollback_streak > issue_23268_spec_stuck_threshold) {
+                            const size_t      fail_idx    = accepted.size() - 1;
+                            const llama_token tok_draft   = slot.spec_draft[fail_idx];
+                            const llama_token tok_sampled = accepted.back();
+                            const float *     logits      = llama_get_logits_ith(slot.ctx_tgt, issue_23268_fail_batch_idx);
+                            SLT_WRN(slot,
+                                "[issue#23268] STUCK speculative loop: %d consecutive checkpoint restores with no progress "
+                                "(matched %zu/%zu draft tokens), diverging at draft index %zu: "
+                                "draft %d ('%s', logit %.4f) vs sampled %d ('%s', logit %.4f). "
+                                "Applying mitigation to force progress - please report with server logs at "
+                                "https://github.com/ggml-org/llama.cpp/issues/23268\n",
+                                slot.issue_23268_spec_rollback_streak, fail_idx, slot.spec_draft.size(), fail_idx,
+                                tok_draft,   common_token_to_piece(slot.ctx_tgt, tok_draft).c_str(),   logits[tok_draft],
+                                tok_sampled, common_token_to_piece(slot.ctx_tgt, tok_sampled).c_str(), logits[tok_sampled]);
+
+                            if (accepted.size() == 1) {
+                                slot.issue_23268_spec_disabled_this_turn = true;
+                            }
+
+                            accepted.pop_back();
+                        }
+
                         slot.spec_draft = std::move(accepted);
+
+                        SLT_DBG(slot, "[issue#23268] ROLLBACK: streak = %d, spec_draft = %zu tokens\n",
+                                slot.issue_23268_spec_rollback_streak, slot.spec_draft.size());
 
                         const auto & ckpt = slot.spec_ckpt;
 
@@ -3824,6 +3864,12 @@ private:
                 }
 
                 common_speculative_accept(spec.get(), slot.id, accepted.size() - 1);
+
+                if (slot.issue_23268_spec_rollback_streak > issue_23268_spec_stuck_threshold) {
+                    SLT_INF(slot, "[issue#23268] recovered from stuck speculative loop after %d iterations\n",
+                            slot.issue_23268_spec_rollback_streak);
+                }
+                slot.issue_23268_spec_rollback_streak = 0;
 
                 slot.spec_draft = std::move(accepted);
             }


### PR DESCRIPTION
# :exclamation: This is WiP and a mitigation PR, not an actual fix.
## Overview

When ngram-mod speculative decoding fails verification, `spec_draft` is set to the accepted tokens (including the correction token) and the checkpoint is restored. On the next iteration the draft is reused instead of regenerated and sometimes fails again, creating a loop with non-deterministic end condition.

This PRs adds logs to diagnose the problem, and a "band-aid" mitigation - it detects loop, and breaks out of it. However, the root cause of the loop is not yet clear.

### Logs

Here are the logs that shows the issue:

```
❯ grep -B 60 -r "^8.36.225.102" debug-logs/ | grep 'issue#23268'
debug-logs/llama-20260717-144519.log-8.34.175.998 D slot   operator(): id  7 | task 0 | [issue#23268] PRE_DRAFT: spec_draft.empty() = no, n_past = 47206
debug-logs/llama-20260717-144519.log-8.34.690.806 D [issue#23268] VERIFY_FAIL: idx=20 draft=63 (logit=24.2188) sampled=7561 (logit=24.2500)
debug-logs/llama-20260717-144519.log-8.34.690.816 D slot   operator(): id  7 | task 0 | [issue#23268] ROLLBACK: streak = 2, spec_draft = 21 tokens
debug-logs/llama-20260717-144519.log-8.34.696.216 D slot   operator(): id  7 | task 0 | [issue#23268] PRE_DRAFT: spec_draft.empty() = no, n_past = 47206
debug-logs/llama-20260717-144519.log-8.35.205.159 D [issue#23268] VERIFY_FAIL: idx=20 draft=7561 (logit=24.2188) sampled=63 (logit=24.3125)
debug-logs/llama-20260717-144519.log-8.35.205.170 D slot   operator(): id  7 | task 0 | [issue#23268] ROLLBACK: streak = 3, spec_draft = 21 tokens
debug-logs/llama-20260717-144519.log-8.35.210.298 D slot   operator(): id  7 | task 0 | [issue#23268] PRE_DRAFT: spec_draft.empty() = no, n_past = 47206
debug-logs/llama-20260717-144519.log-8.35.717.474 D [issue#23268] VERIFY_FAIL: idx=20 draft=63 (logit=24.2188) sampled=7561 (logit=24.2500)
debug-logs/llama-20260717-144519.log-8.35.717.489 W slot   operator(): id  7 | task 0 | [issue#23268] STUCK speculative loop: 4 consecutive checkpoint restores with no progress (matched 20/21 draft tokens), diverging at draft index 20: draft 63 ('`', logit 24.2188) vs sampled 7561 ('`,', logit 24.2500). Applying mitigation to force progress - please report with server logs at https://github.com/ggml-org/llama.cpp/issues/23268
debug-logs/llama-20260717-144519.log-8.35.717.491 D slot   operator(): id  7 | task 0 | [issue#23268] ROLLBACK: streak = 4, spec_draft = 20 tokens
debug-logs/llama-20260717-144519.log-8.35.721.472 D slot   operator(): id  7 | task 0 | [issue#23268] PRE_DRAFT: spec_draft.empty() = no, n_past = 47206
debug-logs/llama-20260717-144519.log:8.36.225.102 I slot   operator(): id  7 | task 0 | [issue#23268] recovered from stuck speculative loop after 4 iterations

```

## Additional information

- https://github.com/ggml-org/llama.cpp/issues/23268

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, llama.cpp + qwen3.6 35b-a3b + pi
