### PR TITLE
llama : add n_layer_all upper bound check to prevent OOB write

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1080,6 +1080,10 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ATTENTION_CAUSAL,        hparams.causal_attn,     false);
     ml.get_key(LLM_KV_POOLING_TYPE,            hparams.pooling_type,    false);
     ml.get_key(LLM_KV_BLOCK_COUNT,             hparams.n_layer_all);
+    if (hparams.n_layer_all > LLAMA_MAX_LAYERS) {
+        throw std::runtime_error(format("invalid block_count: %u exceeds maximum of %d layers",
+                                        hparams.n_layer_all, LLAMA_MAX_LAYERS));
+    }
     ml.get_key(LLM_KV_EXPERT_COUNT,            hparams.n_expert,        false);
     ml.get_key(LLM_KV_EXPERT_USED_COUNT,       hparams.n_expert_used,   false);
     ml.get_key(LLM_KV_EXPERT_GROUP_COUNT,      hparams.n_expert_groups, false);


### PR DESCRIPTION
GGUF metadata key block_count was not validated against LLAMA_MAX_LAYERS (512). A crafted .gguf with block_count > 512 causes OOB write via set_swa_pattern() and OOB read via n_head()/n_ff() on std::array members of llama_hparams. Add GGML_ASSERT to fail early with a clear message.