### PR TITLE
mtmd : fix llava CLS token ordering (#25814)

### DIFF
--- a/tools/mtmd/models/llava.cpp
+++ b/tools/mtmd/models/llava.cpp
@@ -33,7 +33,7 @@ ggml_cgraph * clip_graph_llava::build() {
 
     // concat class_embeddings and patch_embeddings
     if (model.class_embedding) {
-        inp = ggml_concat(ctx0, inp, model.class_embedding, 1);
+        inp = ggml_concat(ctx0, model.class_embedding, inp, 1);
     }
 
     ggml_tensor * positions = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_pos);


### PR DESCRIPTION
## Overview

Fixes #25814.

Since the graph refactor #13321, the llava graph concatenates the class
embedding after the patch embeddings (`models/llava.cpp`), while the runtime
inputs still assume the old CLS-first layout: `"positions"` is filled with the
identity `0..n_pos-1` and `"patches"` with `[1..n_patches]` (`clip.cpp`). As a
result, for every CLIP-encoder model on this graph: each patch receives its
neighbor's position embedding, patch 0's output is dropped, and the projected
[CLS] output is fed to the LLM as an image token.

This PR restores CLS-first ordering by swapping the concat operands - one
line. Both runtime fills (and the comment describing them) are correct again,
matching the pre-refactor ggml_acc-based layout exactly. SigLIP-encoder models
(no class embedding) are unaffected by construction.

Verification (LLaVA-1.5-7B F16 mmproj, fixed input, fp32 reference validated
against HF `get_image_features()` at ~1.0 cosine - method and raw data in the
repo linked below):

| build   | vs CLS-last (defect) simulation | vs CLS-first simulation |
|---------|--------------------------------|-------------------------|
| master  | 0.998 mean per-token cos       | 0.505                   |
| this PR | 0.505                          | 0.996                   |

The residual gap to the HF reference is the separate layer-count defect
(#25817); with both fixes applied the output matches the reference at 0.9965
(the F16/flash-attn floor). The one-row shift signature inverts with this fix
alone (row i vs reference patch i: 0.50 -> 0.95), and on LLaVA-1.6 the
per-tile [CLS] injection disappears (last tile row vs projected [CLS]:
0.999998 -> 0.19 with both fixes).

`tools/mtmd/tests.sh` llava vision tests (`second-state/Llava-v1.5-7B-GGUF:Q2_K`,
`cjpais/llava-1.6-mistral-7b-gguf:Q3_K_M`) pass with this fix alone and with
both fixes. No measurable performance impact (within the noise of master under
identical conditions).

## Additional information

- Companion issue: #25817 (vision layer count) - independent change on the
  same graph. The one-commit change is ready on my `mtmd-fix-llava-layer-count`
  branch (previously draft #25845, closed per the single-open-PR rule for new
  contributors) and will follow after this PR; happy to combine it into this
  PR instead if preferred.
- Generated outputs will change for the affected families (LLaVA-1.5/1.6
  verified; BakLLaVA, ShareGPT4V, Yi-VL, MobileVLM by code path) - expected,
  since the previous embeddings were shifted/corrupted.
- The alternative fix direction (keep CLS last, adjust both runtime fills) is
  equivalent but touches two sites; this PR takes the one-line direction
  discussed in #25814.
- `models/internvl.cpp` / `cogvlm.cpp` / `deepseekocr.cpp` carry the same
  CLS-concatenated-last pattern; correctness there depends on each
  checkpoint's position-embedding row order and is deliberately not touched
  here.
- Full verification harness, raw comparison data, and repro scripts:
  https://github.com/waleedabujaish/llama.cpp-visual-token-pruning

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI-assisted analysis and verification tooling
  (embedding-comparison harness in the linked repo); the fix itself and all
  verification runs were executed and reviewed by me.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
