### PR TITLE
server: server tools - get_datetime in UTC ISO format

### DIFF
--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -7,6 +7,7 @@
 #include <regex>
 #include <thread>
 #include <chrono>
+#include <ctime>
 #include <atomic>
 #include <cstring>
 #include <climits>
@@ -1039,7 +1040,7 @@ private:
 struct server_tool_get_datetime : server_tool {
     server_tool_get_datetime() {
         name = "get_datetime";
-        display_name = "Get Date & Time";
+        display_name = "Get Date & Time in UTC, ISO format";
         permission_write = false;
     }
 
@@ -1048,7 +1049,7 @@ struct server_tool_get_datetime : server_tool {
             {"type", "function"},
             {"function", {
                 {"name", name},
-                {"description", "Returns the current date and time"},
+                {"description", "Returns the current date and time in UTC, ISO format"},
             }},
         };
     }
@@ -1056,8 +1057,10 @@ struct server_tool_get_datetime : server_tool {
     json invoke(json, server_tool::stream *) const override {
         auto now = std::chrono::system_clock::now();
         auto time = std::chrono::system_clock::to_time_t(now);
-
-        return {{"result", std::ctime(&time)}};
+        auto tm = std::gmtime(&time);
+        char buf[sizeof("YYYY-MM-DDTHH:MM:SSZ")];
+        std::strftime(buf, sizeof(buf), "%FT%TZ", tm);
+        return {{"result", buf}};
     }
 };
 


### PR DESCRIPTION
## Overview

This change affects the `get_datetime` server tools function.  
It now returns the datetime in UTC, ISO format (`yyyy-mm-ddThh:mm:ssZ`), instead of the C-formatted local time (`Fri Jul 17 22:39:30 2026` - notice the missing timezone).  
UTC timestamps can then be converted by the running model to any local time.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I used Codex to review the code; but otherwise this change is a [textbook example][1]. 

[1]: https://cppreference.com/cpp/chrono/c/strftime 

