### PR TITLE
vulkan: use mul_mat_vec_id for high-expert-count MoE decode

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10279,7 +10279,19 @@ static bool ggml_vk_use_mul_mat_vec_id(const struct ggml_cgraph * cgraph, int no
     ggml_tensor * dst = cgraph->nodes[node_idx];
     ggml_tensor * src0 = dst->src[0];
     ggml_tensor * src2 = dst->src[2];
-    return (src2->ne[1] <= 8) && (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type));
+    const bool type_ok = (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type));
+    // Small batches (single-token decode) always use the vec path.
+    if (src2->ne[1] <= 8 && type_ok) {
+        return true;
+    }
+    // High-expert-count MoE (>64 experts, e.g. DeepSeek-V3/V4-class 256-expert models):
+    // route the decode regime (batch <= 256) to mul_mat_vec_id. On RADV the mul_mat_id
+    // shader for >=256 experts stalls during pipeline compilation at high -ngl; the vec
+    // path avoids this and is also faster per-dispatch for token generation.
+    if (src0->ne[2] > 64 && src2->ne[1] <= 256 && type_ok) {
+        return true;
+    }
+    return false;
 }
 
 static void ggml_vk_mul_mat_id(ggml_backend_vk_context * ctx, vk_context& subctx, const struct ggml_cgraph * cgraph, int node_idx) {


### PR DESCRIPTION
Extends `ggml_vk_use_mul_mat_vec_id()` to route MoE models with a large number of experts (>64, e.g. DeepSeek-V3/V4-class 256-expert models) to the `mul_mat_vec_id` path in the decode regime (batch <= 256).

## Motivation
On RADV (Mesa; tested on an AMD Radeon 680M / gfx1035, Mesa 26.1.4) the `mul_mat_id` shader for >=256-expert MoE models stalls during pipeline compilation at high `--n-gpu-layers`, wedging the device (SMU becomes unresponsive: `SMU: No response`, `Ring sdma0 reset failed`, `GPU reset ... ret=-62`). Routing these dispatches to the existing `mul_mat_vec_id` path avoids the stall and is also faster per-dispatch for token generation.

## Change
`ggml_vk_use_mul_mat_vec_id()`: alongside the existing small-batch case (batch <= 8), also return true when `src0->ne[2] > 64` (>64 experts) and `src2->ne[1] <= 256`, restricting the change to the decode regime so large prefill batches are unaffected.

## Testing
AMD Radeon 680M (gfx1035), Vulkan/RADV, Mesa 26.1.4, build b10066.

- Without the change: a 256-expert MoE (Qwen3.6-35B-A3B-class) hangs during shader compilation at `-ngl 99` (empty output, device wedge requiring a GPU reset).
- With the change: the same model loads and generates coherently at `-ngl 99`.
- No behavioral change for models with <=64 experts or for batch > 256.
