### PR TITLE
server : fix dry_sequence_breakers missing from GET /props generation settings

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -60,6 +60,7 @@ json task_params::to_json(bool only_metrics) const {
             {"dry_base",                  sampling.dry_base},
             {"dry_allowed_length",        sampling.dry_allowed_length},
             {"dry_penalty_last_n",        sampling.dry_penalty_last_n},
+            {"dry_sequence_breakers",     sampling.dry_sequence_breakers},
             {"mirostat",                  sampling.mirostat},
             {"mirostat_tau",              sampling.mirostat_tau},
             {"mirostat_eta",              sampling.mirostat_eta},

--- a/tools/server/tests/unit/test_basic.py
+++ b/tools/server/tests/unit/test_basic.py
@@ -29,6 +29,7 @@ def test_server_props():
     assert server.n_ctx is not None and server.n_slots is not None
     assert default_val["n_ctx"] == server.n_ctx / server.n_slots
     assert default_val["params"]["seed"] == server.seed
+    assert "dry_sequence_breakers" in default_val["params"]
 
 
 def test_server_models():


### PR DESCRIPTION
Prb:
When you hit GET /props, the default_generation_settings.params payload is generated using the only_metrics branch of task_params::to_json(). It turns out we completely missed adding the dry_sequence_breakers field to this branch, even though the full completion-response branch has it.Every other DRY-related parameter (dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n) exists in both places. This was just a simple oversight when the field was originally introduced. Because of this, GET /props provides an incomplete view of the active DRY sampler configuration and doesn't match the completion response's generation_settings.I noticed this while digging through the same area of the codebase for #25803.
Changes:
ools/server/server-task.cpp: Added dry_sequence_breakers to the only_metrics block, positioning it right after dry_penalty_last_n to match the full block.tools/server/tests/unit/test_basic.py: Added a quick assertion to test_server_props() to ensure dry_sequence_breakers shows up in default_generation_settings.params.
Verification:
curl -s localhost:8080/props | jq '.default_generation_settings.params | has("dry_sequence_breakers")'
Use code with caution.RequirementsI have read and agree with the contributing guidelines (github.com)AI usage disclosure: NO