### PR TITLE
ggml : fix for non-virtual destructor issue of gguf_writer_base

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -1424,7 +1424,7 @@ void gguf_set_tensor_data(struct gguf_context * ctx, const char * name, const vo
 struct gguf_writer_base {
     size_t written_bytes {0u};
 
-    ~gguf_writer_base(void) = default;
+    virtual ~gguf_writer_base(void) = default;
 
     // we bet on devirtualization
     virtual void write(int8_t val) = 0;


### PR DESCRIPTION
## Overview

`gguf_writer_base` declares virtual member functions but its destructor
was non-virtual. Deleting a derived writer instance through a
`gguf_writer_base*` (or any base-class pointer/reference) skips the
derived class's destructor, because it is not virtual.

This can leak resources owned by the derived writer and is undefined behavior per the C++
standard when the dynamic type differs from the static type at the
point of deletion.

### Change

Add `virtual` to `gguf_writer_base`'s destructor in `ggml/src/gguf.cpp`.

```cpp
-    ~gguf_writer_base(void) = default;
+    virtual ~gguf_writer_base(void) = default;
```

## Additional information

Found while cross-compiling ggml/llama.cpp as a static library inside
an AOSP tree (vendor partition), which enables
`-Werror=non-virtual-dtor` unconditionally by AOSP build rule.

Confirmed the class has no other polymorphic-deletion issues after the fix; build completes
cleanly with this flag enabled.

No functional change to existing single-inheritance, base-pointer-free
usage; this only affects correctness when a derived writer is deleted
via a base pointer, which is the intended usage pattern given the
virtual methods already present on the class.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES (Claude Sonnet5, Just debug for my AOSP build issue, and this PR is fuilly written by myself)<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->