### PR TITLE
ui: fix collapsed user bubble with markdown rendering

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageSystem/ChatMessageSystem.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageSystem/ChatMessageSystem.svelte
@@ -157,10 +157,7 @@
 						>
 							{#if currentConfig.renderUserContentAsMarkdown}
 								<div bind:this={messageElement} class={isExpanded ? 'cursor-text' : ''}>
-									<MarkdownContent
-										class="markdown-system-content -my-4"
-										content={message.content}
-									/>
+									<MarkdownContent class="markdown-system-content" content={message.content} />
 								</div>
 							{:else}
 								<span

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUserBubble.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUserBubble.svelte
@@ -65,7 +65,7 @@
 	>
 		{#if renderMarkdown && currentConfig.renderUserContentAsMarkdown}
 			<div bind:this={messageElement}>
-				<MarkdownContent class="markdown-user-content -my-4" {content} />
+				<MarkdownContent class="markdown-user-content" {content} />
 			</div>
 		{:else}
 			<span bind:this={messageElement} class="text-md whitespace-pre-wrap">


### PR DESCRIPTION
## Overview

Before :
<img width="384" height="145" alt="Before" src="https://github.com/user-attachments/assets/7c4ee7f1-4625-4380-bdc3-8b312289ca6e" />

After :
<img width="364" height="183" alt="After" src="https://github.com/user-attachments/assets/0221e53b-70e9-4c20-9ecd-76760b282111" />

## Additional information

Fixes #25861 #25737

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
