### PR TITLE
model : bitnet uses squared-ReLU FFN, not SILU

### DIFF
--- a/src/models/bitnet.cpp
+++ b/src/models/bitnet.cpp
@@ -129,7 +129,7 @@ llama_model_bitnet::graph::graph(const llama_model & model, const llm_graph_para
                 model.layers[il].ffn_gate, NULL, model.layers[il].ffn_gate_s,
                 NULL,                      NULL, NULL,
                 NULL,
-                LLM_FFN_SILU, LLM_FFN_PAR, il);
+                LLM_FFN_RELU_SQR, LLM_FFN_PAR, il);
         cb(cur, "ffn_sub_out", il);
 
         cur = build_norm(cur,


### PR DESCRIPTION
## Summary

BitNet b1.58 2B-4T specifies a **squared-ReLU (relu²)** FFN activation, but the BitNet graph in `src/models/bitnet.cpp` was built with `LLM_FFN_SILU`. This is a one-token correctness bug that severely miscalibrates FFN outputs.

```diff
-                LLM_FFN_SILU, LLM_FFN_PAR, il);
+                LLM_FFN_RELU_SQR, LLM_FFN_PAR, il);
```

`LLM_FFN_RELU_SQR` is already handled in `build_ffn` (yields `relu(x)²`), so this is a minimal, self-contained fix.

## Impact (measured)

Clean-room reproduction on stock upstream across three CPU backends, wikitext-2 perplexity:

| Backend / kernel | SILU (buggy) | ReLU² (fixed) |
|---|---|---|
| x86 I2_S (Intel) | 99.8178 | **17.1086** |
| x86 I2_S (AMD)   | 99.8178 (bit-identical) | **17.1086** |
| ARM TL1          | 78.6877 | **14.9641** |

End-to-end throughput unchanged (activation swap only); correctness restored across all backends.

## Notes

- The same bug is present at the commit `microsoft/BitNet` currently pins as its `llama.cpp` submodule (`isHuangXin/llama.cpp@390c3077`, `src/models/bitnet.cpp:133`). A companion issue is being filed on `microsoft/BitNet` recommending a re-sync once this lands.
- Change is a single token; no kernel or graph-shape changes.
