### PR TITLE
I have used int32_t for llama_memory_seq_div

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -761,7 +761,7 @@ extern "C" {
               llama_seq_id seq_id,
                  llama_pos p0,
                  llama_pos p1,
-                       int d);
+                       int32_t d);
 
     // Returns the smallest position present in the memory for the specified sequence
     // This is typically non-zero only for SWA caches


### PR DESCRIPTION
I have researched the llama.h and find a memory sequence divisorfunction to change type to guideline as guided in https://github.com/ggml-org/llama.cpp/issues/4574 (for fixed width integer standart)

BEFORE
"""
    LLAMA_API void llama_memory_seq_div(
            llama_memory_t mem,
              llama_seq_id seq_id,
                 llama_pos p0,
                 llama_pos p1,
                       int d);
"""

AFTER
"""
    LLAMA_API void llama_memory_seq_div(
            llama_memory_t mem,
              llama_seq_id seq_id,
                 llama_pos p0,
                 llama_pos p1,
                       int32_t d);
"""

Closes #4574 