### PR TITLE
OpenCL: Disable unsupported allocation of Adreno large buffers to fix compilation failure in OpenCL 2.x

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -10525,10 +10525,12 @@ static ggml_backend_buffer_t ggml_backend_opencl_buffer_type_alloc_buffer(ggml_b
 
     cl_int err;
     cl_mem mem = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE, size, NULL, &err);
+#if CL_TARGET_OPENCL_VERSION >= 300
     if (err != CL_SUCCESS && backend_ctx->adreno_use_large_buffer) {
         cl_mem_properties props[] = { 0x41A6 /* CL_LARGE_BUFFER_QCOM */, 1, 0 };
         mem = clCreateBufferWithProperties(backend_ctx->context, props, CL_MEM_READ_WRITE, size, NULL, &err);
     }
+#endif
 
     if (err != CL_SUCCESS) {
         GGML_LOG_INFO("%s: failed to allocate %.2f MiB\n", __func__, size / 1024.0 / 1024.0);


### PR DESCRIPTION
## Overview

This change disables the Adreno large buffer fallback when targeting OpenCL 2.x and older. This is necessary because the `clCreateBufferWithProperties` API is not available in OpenCL earlier than 3.0.

## Additional information

This restores the ability to compile with `GGML_OPENCL_TARGET_VERSION` set to 210 or less, which failed because of undefined symbols before. I do not expect this to negatively affect Adreno support, because this was only usable with OpenCL 3.0 so far anyway. As this is the only failure currently preventing OpenCL 2.x compilation, I believe this is still worth fixing (even if few people are using this variant).

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO