### PR TITLE
build : add ROCm component directories to ggml-hip RPATH

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -159,4 +159,15 @@ endif()
 
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
 
+if (UNIX)
+    set_property(TARGET ggml-hip APPEND PROPERTY BUILD_RPATH
+                 "$<TARGET_FILE_DIR:roc::rocblas>"
+                 "$<TARGET_FILE_DIR:roc::hipblas>"
+                 "$<TARGET_FILE_DIR:hip::amdhip64>")
+    set_property(TARGET ggml-hip APPEND PROPERTY INSTALL_RPATH
+                 "$<TARGET_FILE_DIR:roc::rocblas>"
+                 "$<TARGET_FILE_DIR:roc::hipblas>"
+                 "$<TARGET_FILE_DIR:hip::amdhip64>")
+endif()
+
 target_compile_options(ggml-hip PRIVATE "$<$<COMPILE_LANGUAGE:HIP>:-ffast-math;-fno-finite-math-only>")


### PR DESCRIPTION
## Overview

- ROCm 7.14 resolves rocBLAS, hipBLAS, and the HIP runtime from component directories.
- `libggml-hip.so` directly needs all three, but its own RUNPATH does not contain their directories; an executable's `DT_RUNPATH` is not recursively inherited for those dependencies.
- Add the `roc::rocblas`, `roc::hipblas`, and `hip::amdhip64` target directories to `ggml-hip` `BUILD_RPATH` and `INSTALL_RPATH`.
- Derive every path from its imported target; do not hard-code a ROCm version or installation prefix.

Fixes #25807.

## Validation

- On master `571d0d5` in the official ROCm 7.14 image, the baseline builds but clean launch exits 127 on `libhipblas.so.3`; supplying the component path succeeds.
- With the patch, build-tree and install-tree launches exit 0 without a ROCm path in `LD_LIBRARY_PATH`.
- A ROCm 7.2 build and clean-launch control also pass with the same three-target patch.
