### PR TITLE
Webui bugfix for imported conversation

### DIFF
--- a/tools/ui/src/lib/stores/conversations.svelte.ts
+++ b/tools/ui/src/lib/stores/conversations.svelte.ts
@@ -532,9 +532,17 @@ class ConversationsStore {
 	 */
 	async updateCurrentNode(nodeId: string): Promise<void> {
 		if (!this.activeConversation) return;
+		const convId = this.activeConversation.id;
 
-		await DatabaseService.updateCurrentNode(this.activeConversation.id, nodeId);
-		this.activeConversation = { ...this.activeConversation, currNode: nodeId };
+		await DatabaseService.updateCurrentNode(convId, nodeId);
+		if (this.activeConversation?.id === convId) {
+			this.activeConversation = { ...this.activeConversation, currNode: nodeId };
+		}
+
+		const index = this.conversations.findIndex((c) => c.id === convId);
+		if (index !== -1) {
+			this.conversations[index] = { ...this.conversations[index], currNode: nodeId };
+		}
 	}
 
 	/**

--- a/tools/ui/src/lib/stores/conversations.svelte.ts
+++ b/tools/ui/src/lib/stores/conversations.svelte.ts
@@ -284,18 +284,13 @@ class ConversationsStore {
 
 			this.activeConversation = conversation;
 
-			if (conversation.currNode) {
-				const allMessages = await DatabaseService.getConversationMessages(convId);
-				const filteredMessages = filterByLeafNodeId(
-					allMessages,
-					conversation.currNode,
-					false
-				) as DatabaseMessage[];
-				this.activeMessages = filteredMessages;
-			} else {
-				const messages = await DatabaseService.getConversationMessages(convId);
-				this.activeMessages = messages;
-			}
+			// Resolve one path even without a currNode.
+			const allMessages = await DatabaseService.getConversationMessages(convId);
+			this.activeMessages = filterByLeafNodeId(
+				allMessages,
+				conversation.currNode ?? '',
+				false
+			) as DatabaseMessage[];
 
 			return true;
 		} catch (error) {

--- a/tools/ui/tests/unit/conversation-load-path.test.ts
+++ b/tools/ui/tests/unit/conversation-load-path.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { filterByLeafNodeId } from '$lib/utils/branching';
+import { MessageRole, MessageType } from '$lib/enums';
+import type { DatabaseMessage } from '$lib/types';
+
+/**
+ * Loading a conversation must resolve a path even when currNode is missing
+ * (imported records can carry an empty currNode).
+ */
+
+const store: DatabaseMessage[] = [];
+
+function add(
+	msg: Partial<DatabaseMessage> & { role: MessageRole; type: MessageType },
+	parentId: string | null,
+	timestamp: number
+): DatabaseMessage {
+	const node: DatabaseMessage = {
+		id: msg.content ? String(msg.content) : `m${store.length + 1}`,
+		convId: 'c1',
+		content: '',
+		toolCalls: '',
+		children: [],
+		parent: parentId,
+		timestamp,
+		...msg
+	};
+	store.push(node);
+	if (parentId) {
+		const parent = store.find((m) => m.id === parentId);
+		if (parent) parent.children = [...parent.children, node.id];
+	}
+	return node;
+}
+
+/** root -> u1 -> a1 -> {u2a -> a2a | u2b -> a2b}: two branches from a1. */
+function branchedConversation() {
+	store.length = 0;
+	add({ role: MessageRole.USER, type: MessageType.ROOT, id: 'root' }, null, 10);
+	add({ role: MessageRole.USER, type: MessageType.TEXT, content: 'u1' }, 'root', 20);
+	add({ role: MessageRole.ASSISTANT, type: MessageType.TEXT, content: 'a1' }, 'u1', 30);
+	add({ role: MessageRole.USER, type: MessageType.TEXT, content: 'u2a' }, 'a1', 40);
+	add({ role: MessageRole.ASSISTANT, type: MessageType.TEXT, content: 'a2a' }, 'u2a', 50);
+	add({ role: MessageRole.USER, type: MessageType.TEXT, content: 'u2b' }, 'a1', 60);
+	add({ role: MessageRole.ASSISTANT, type: MessageType.TEXT, content: 'a2b' }, 'u2b', 70);
+}
+
+/** What loadConversation must produce for a given (possibly empty) currNode. */
+const resolve = (currNode: string) =>
+	(filterByLeafNodeId(store, currNode, false) as DatabaseMessage[]).map((m) => m.id);
+
+describe('conversation load path resolution', () => {
+	it('resolves a single branch for a valid currNode', () => {
+		branchedConversation();
+		expect(resolve('a2a')).toEqual(['u1', 'a1', 'u2a', 'a2a']);
+	});
+
+	it('empty currNode still resolves one branch, not every branch', () => {
+		branchedConversation();
+		const ids = resolve('');
+		expect(ids).toEqual(['u1', 'a1', 'u2b', 'a2b']);
+		expect(ids).not.toContain('u2a');
+		expect(ids).not.toContain('root');
+	});
+
+	it('unknown currNode falls back to the latest branch', () => {
+		branchedConversation();
+		expect(resolve('does-not-exist')).toEqual(['u1', 'a1', 'u2b', 'a2b']);
+	});
+});


### PR DESCRIPTION
## Overview

Webui bugfix for imported conversation

## Additional information

When loading a new conversation with branch, all branch are displayed unless user perform a branch switch.
This is due to the output conversation jsonl "currNode" field being empty so a new import cannot resolve a branch.

To recreate it

1. Load the webui fresh, then create a new conversation in that same page session (don't reload afterwards).
2. Send 2–3 messages, then regenerate one to create the branch.
3. Settings → Export (use the bulk export, not per-conversation sidebar export, which reads DB and unaffected).
4. Inspect the exported .jsonl, it'll contain "currNode":"".
5. Delete the conversation and import the file.
6. All branches will be displayed at first, click the switching branch arrow, back to normal.

Shown below

<img width="1919" height="2159" alt="After_import" src="https://github.com/user-attachments/assets/79599286-10f9-45b9-abf0-eeec7c6a5cce" />
&nbsp;
<img width="1918" height="2159" alt="After_branch_switch" src="https://github.com/user-attachments/assets/a0338533-24ef-4f2c-813e-8b887247cac2" />
&nbsp;

Fix: 

1. Resolve one path even without a currNode (via filterByLeafNodeId, which default to newest leaf)
2. In `updateCurrentNode`, update the conversations list (which setting export snapshots from)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to help draft and refine the implementation.