### PR TITLE
sampling: allow backend sampling to work with reasoning budget

### DIFF
--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -140,19 +140,26 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
     }
 }
 
-static void common_reasoning_budget_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
-    auto * ctx = (common_reasoning_budget_ctx *) smpl->ctx;
-
+static llama_token common_reasoning_budget_get_current_forced_token(const common_reasoning_budget_ctx * ctx) {
     if (ctx->state != REASONING_BUDGET_FORCING) {
-        // passthrough — don't modify logits
-        return;
+        return LLAMA_TOKEN_NULL;
     }
 
     if (ctx->force_pos >= ctx->forced_tokens.size()) {
-        return;
+        return LLAMA_TOKEN_NULL;
     }
 
-    const llama_token forced = ctx->forced_tokens[ctx->force_pos];
+    return ctx->forced_tokens[ctx->force_pos];
+}
+
+static void common_reasoning_budget_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
+    auto * ctx = (common_reasoning_budget_ctx *) smpl->ctx;
+
+    const llama_token forced = common_reasoning_budget_get_current_forced_token(ctx);
+    if (forced == LLAMA_TOKEN_NULL) {
+        // passthrough — don't modify logits
+        return;
+    }
 
     // set all logits to -inf except the forced token
     for (size_t i = 0; i < cur_p->size; i++) {
@@ -267,4 +274,14 @@ bool common_reasoning_budget_force(struct llama_sampler * smpl) {
     COM_TRC("%s", "forced into forcing state (manual transition)\n");
 
     return true;
+}
+
+llama_token common_reasoning_budget_get_forced_token(const struct llama_sampler * smpl) {
+    if (!smpl) {
+        return LLAMA_TOKEN_NULL;
+    }
+
+    const auto * ctx = (const common_reasoning_budget_ctx *) smpl->ctx;
+
+    return common_reasoning_budget_get_current_forced_token(ctx);
 }

--- a/common/reasoning-budget.h
+++ b/common/reasoning-budget.h
@@ -44,3 +44,6 @@ common_reasoning_budget_state common_reasoning_budget_get_state(const struct lla
 // Manually transition the reasoning budget sampler into the FORCING state.
 // Returns true if the transition occurred.
 bool common_reasoning_budget_force(struct llama_sampler * smpl);
+// get the current forced token if the sampler is in FORCING state
+// returns LLAMA_TOKEN_NULL if not in FORCING state
+llama_token common_reasoning_budget_get_forced_token(const struct llama_sampler * smpl);

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -395,12 +395,6 @@ struct common_sampler * common_sampler_init(const struct llama_model * model, st
         params.backend_sampling = false;
     }
 
-    if (rbudget && params.backend_sampling) {
-        LOG_WRN("%s: backend sampling is not compatible with reasoning budget, disabling\n", __func__);
-
-        params.backend_sampling = false;
-    }
-
     auto * result = new common_sampler {
         /* .params  = */ params,
         /* .grmr    = */ grmr,
@@ -560,8 +554,15 @@ llama_token common_sampler_sample(struct common_sampler * gsmpl, struct llama_co
         if (id != LLAMA_TOKEN_NULL) {
             LOG_DBG("%s: Backend sampler selected token: '%d'. Will not run any CPU samplers\n", __func__, id);
 
-            GGML_ASSERT(!gsmpl->grmr    && "using grammar in combination with backend sampling is not supported");
-            GGML_ASSERT(!gsmpl->rbudget && "using reasoning budget in combination with backend sampling is not supported");
+            GGML_ASSERT(!gsmpl->grmr && "using grammar in combination with backend sampling is not supported");
+
+            if (gsmpl->rbudget && common_reasoning_budget_get_state(gsmpl->rbudget) == REASONING_BUDGET_FORCING) {
+                const llama_token forced = common_reasoning_budget_get_forced_token(gsmpl->rbudget);
+                if (forced != LLAMA_TOKEN_NULL) {
+                    id = forced;
+                    LOG_DBG("%s: Reasoning budget in FORCING. Overriding with forced token: '%d'\n", __func__, id);
+                }
+            }
 
             for (size_t i = 0; i < cur_p.size; ++i) {
                 if (cur_p.data[i].id == id) {
@@ -681,17 +682,21 @@ llama_token_data_array * common_sampler_get_candidates(struct common_sampler * g
 
     if (do_sort && !res->sorted) {
         // remember the selected token before sorting
-        const llama_token id = res->data[res->selected].id;
+        const bool has_selected = res->selected >= 0 && (size_t)res->selected < res->size;
+        const llama_token id = has_selected ? res->data[res->selected].id : LLAMA_TOKEN_NULL;
 
         std::sort(res->data, res->data + res->size, [](const llama_token_data & a, const llama_token_data & b) {
             return a.p > b.p;
         });
 
         // restore the selected token after sorting
-        for (size_t i = 0; i < res->size; ++i) {
-            if (res->data[i].id == id) {
-                res->selected = i;
-                break;
+        res->selected = -1;
+        if (has_selected) {
+            for (size_t i = 0; i < res->size; ++i) {
+                if (res->data[i].id == id) {
+                    res->selected = i;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
## Overview

This patch allows `--backend-sampling` and `--reasoning-budget` to be combined, yielding ~5% improved performance in certain scenarios in my testing.
Previously, the reasoning budget sampler enforced forced tokens by masking candidate logits on the CPU sampling path.
This patch instead exposes the currently forced token so it can override the backend-selected token when necessary, allowing backend sampling to remain enabled.

## Additional information

I tested the patch for correctness and to characterize performance differences.
I ran a test matrix of humaneval+ runs with:
- thinking off/on
- backend sampling off/on
- reasoning budget -1/0/10/64/128/512/1024/4096
- reasoning budget message set
- unpatched/patched

[data.csv](https://github.com/user-attachments/files/30200474/data.csv)

I found no regressions in wall time, tokens/s, mtp draft acceptance, or pass@1.
In my testing, this improved token generation speed by approximately 5% when backend sampling and reasoning budget were both enabled.
I verified that reasoning budget exhaustion still triggers with the patch.

47/47 CI tests pass.

The change in `common_sampler_get_candidates()` is needed because we don't always select a token. 
Since backend-selected tokens can now be replaced with a forced token that was not present in the candidate list, `cur_p.selected` is no longer guaranteed to reference a valid entry (it can be -1). The additional guards in `common_sampler_get_candidates()` are required to handle that case.

I performed additional testing to see how returned logprobs were affected by this patch, but could not find any issues with the output (tested with mtp off).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I did have assistance from Claude and DeepSeek in reviewing my patch, helping me match the coding style and conventions of the project, and to ensure my patch would not conflict with other open patches that are touching the same files (both to ensure that I wasn't duplicating existing PRs and that I wasn't breaking something that would be needed by someone else). Claude also pointed out that `cur_p.selected` could be -1 after this patch, which might yield unexpected results when the -1 value is encountered downstream (perhaps in logprob metrics), but from what I can tell this is not an issue and does not produce any unwanted side effects. I merely mention it here in case I'm missing something. All code and claims have been manually reviewed and thoroughly tested/vetted to the best of my ability.