### PR TITLE
ggml-metal: FWHT kernel for metal backend

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1252,6 +1252,21 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort_merge(gg
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_fwht(ggml_metal_library_t lib, int n) {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_fwht_f32_%d", n);
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
 // note: reuse the argsort kernel for top_k
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k(ggml_metal_library_t lib, const ggml_tensor * op) {
     assert(op->op == GGML_OP_TOP_K);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -139,6 +139,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_id
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argmax            (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort_merge     (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_fwht              (ggml_metal_library_t lib, int n);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k             (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k_merge       (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin               (ggml_metal_library_t lib, const struct ggml_tensor * op, int32_t n_fuse );

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -1157,6 +1157,10 @@ typedef struct {
     int32_t  len;
 } ggml_metal_kargs_argsort_merge;
 
+typedef struct  {
+    int32_t nrows;
+} ggml_metal_kargs_fwht;
+
 typedef struct {
     int64_t  ne0;
     float    start;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -1157,7 +1157,7 @@ typedef struct {
     int32_t  len;
 } ggml_metal_kargs_argsort_merge;
 
-typedef struct  {
+typedef struct {
     int32_t nrows;
 } ggml_metal_kargs_fwht;
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1979,7 +1979,7 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
-//supported FWHT sizes, must stay in sync with the
+// supported FWHT sizes, must stay in sync with the
 // kernel_fwht_f32_<N> templates in ggml-metal.metal
 static bool ggml_metal_fwht_supported_size(int64_t n) {
     return n == 64 || n == 128 || n == 256 || n == 512;
@@ -1997,7 +1997,7 @@ int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
     const int64_t nrows = ggml_nrows(src1);
 
     ggml_metal_kargs_fwht args = {
-        /*.nrows = */ (int32_t) nrows,
+        /*.nrows = */ nrows,
     };
 
     auto pipeline = ggml_metal_library_get_pipeline_fwht(lib, n);
@@ -2018,7 +2018,6 @@ int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
 
     return 1;
 }
-
 
 int ggml_metal_op_pool_2d(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2087,7 +2087,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     ggml_metal_encoder_t enc = ctx->enc;
 
     const int32_t hint = ggml_get_op_params_i32(op, 1);
-    
+
     if (hint == GGML_HINT_SRC0_IS_HADAMARD) {
         if (op->src[1]->type == GGML_TYPE_F32 &&
             op->type == GGML_TYPE_F32 &&

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -10,7 +10,6 @@
 
 #include <cassert>
 #include <algorithm>
-#include <cstdlib>
 #include <limits>
 #include <cmath>
 
@@ -1980,6 +1979,12 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
+//supported FWHT sizes, must stay in sync with the
+// kernel_fwht_f32_<N> templates in ggml-metal.metal
+static bool ggml_metal_fwht_supported_size(int64_t n) {
+    return n == 64 || n == 128 || n == 256 || n == 512;
+}
+
 int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
@@ -1990,7 +1995,6 @@ int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
 
     const int64_t n = src1->ne[0];
     const int64_t nrows = ggml_nrows(src1);
-    
 
     ggml_metal_kargs_fwht args = {
         /*.nrows = */ (int32_t) nrows,
@@ -2005,7 +2009,7 @@ int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
 
     const int th_max = ggml_metal_pipeline_max_theads_per_threadgroup(pipeline);
     const int simd_size = 32;
-    
+
     int sg_per_tg = 2;
     sg_per_tg = std::min(sg_per_tg, th_max/simd_size);
     sg_per_tg = std::max(sg_per_tg, 1);
@@ -2085,12 +2089,12 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     const int32_t hint = ggml_get_op_params_i32(op, 1);
     
     if (hint == GGML_HINT_SRC0_IS_HADAMARD) {
-        const int64_t n = op->src[1]->ne[0];
-        if(op->src[1]->type == GGML_TYPE_F32 &&
+        if (op->src[1]->type == GGML_TYPE_F32 &&
             op->type == GGML_TYPE_F32 &&
             ggml_is_contiguous(op->src[1]) &&
             ggml_is_contiguous(op) &&
-            ( n == 64 || n == 128 || n == 256 || n == 512 )
+            ggml_are_same_shape(op->src[1], op) &&
+            ggml_metal_fwht_supported_size(op->src[1]->ne[0])
         ) {
             return ggml_metal_op_fwht(ctx, idx);
         }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -10,6 +10,7 @@
 
 #include <cassert>
 #include <algorithm>
+#include <cstdlib>
 #include <limits>
 #include <cmath>
 
@@ -1979,6 +1980,41 @@ int ggml_metal_op_pool_1d(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
+int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    ggml_tensor * src1 = op->src[1];
+
+    const int64_t n = src1->ne[0];
+    const int64_t nrows = ggml_nrows(src1);
+    
+
+    ggml_metal_kargs_fwht args = {
+        /*.nrows = */ (int32_t) nrows,
+    };
+
+    auto pipeline = ggml_metal_library_get_pipeline_fwht(lib, n);
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes(enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(src1), 1);
+    ggml_metal_encoder_set_buffer(enc, ggml_metal_get_buffer_id(op), 2);
+
+    const int th_max = ggml_metal_pipeline_max_theads_per_threadgroup(pipeline);
+    const int simd_size = 32;
+    
+    int sg_per_tg = 2;
+    sg_per_tg = std::min(sg_per_tg, th_max/simd_size);
+    sg_per_tg = std::max(sg_per_tg, 1);
+    const int64_t n_tg = (nrows + sg_per_tg - 1) / sg_per_tg;
+    ggml_metal_encoder_dispatch_threadgroups(enc, n_tg, 1, 1, 32*sg_per_tg, 1, 1);
+
+    return 1;
+}
+
 
 int ggml_metal_op_pool_2d(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
@@ -2046,6 +2082,19 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     ggml_metal_library_t lib = ctx->lib;
     ggml_metal_encoder_t enc = ctx->enc;
 
+    const int32_t hint = ggml_get_op_params_i32(op, 1);
+    
+    if (hint == GGML_HINT_SRC0_IS_HADAMARD) {
+        const int64_t n = op->src[1]->ne[0];
+        if(op->src[1]->type == GGML_TYPE_F32 &&
+            op->type == GGML_TYPE_F32 &&
+            ggml_is_contiguous(op->src[1]) &&
+            ggml_is_contiguous(op) &&
+            ( n == 64 || n == 128 || n == 256 || n == 512 )
+        ) {
+            return ggml_metal_op_fwht(ctx, idx);
+        }
+    }
     const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
 
     GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2013,6 +2013,7 @@ int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
     int sg_per_tg = 2;
     sg_per_tg = std::min(sg_per_tg, th_max/simd_size);
     sg_per_tg = std::max(sg_per_tg, 1);
+
     const int64_t n_tg = (nrows + sg_per_tg - 1) / sg_per_tg;
     ggml_metal_encoder_dispatch_threadgroups(enc, n_tg, 1, 1, 32*sg_per_tg, 1, 1);
 
@@ -2093,8 +2094,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
             ggml_is_contiguous(op->src[1]) &&
             ggml_is_contiguous(op) &&
             ggml_are_same_shape(op->src[1], op) &&
-            ggml_metal_fwht_supported_size(op->src[1]->ne[0])
-        ) {
+            ggml_metal_fwht_supported_size(op->src[1]->ne[0])) {
             return ggml_metal_op_fwht(ctx, idx);
         }
     }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1997,7 +1997,7 @@ int ggml_metal_op_fwht(ggml_metal_op_t ctx, int idx) {
     const int64_t nrows = ggml_nrows(src1);
 
     ggml_metal_kargs_fwht args = {
-        /*.nrows = */ nrows,
+        /*.nrows = */ (int32_t) nrows,
     };
 
     auto pipeline = ggml_metal_library_get_pipeline_fwht(lib, n);

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -64,6 +64,7 @@ int ggml_metal_op_set               (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_cpy               (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_pool_1d           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_pool_2d           (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_fwht              (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_mul_mat           (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_mul_mat_id        (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_add_id            (ggml_metal_op_t ctx, int idx);

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -6192,12 +6192,12 @@ kernel void kernel_fwht_f32(
     if (r >= args.nrows) {
         return;
     }
-    
+
     src += r * N;
     dst += r * N;
 
     const int lane = tiisg;
-    
+
     float reg[el_w];
     for (int i = 0; i < el_w; i++) {
         reg[i] = src[i * simd_size + lane] * scale;
@@ -6210,7 +6210,7 @@ kernel void kernel_fwht_f32(
             reg[j] = (lane & i) == 0 ? val2 + val : val2 - val;
         }
     }
-    
+
     for (int i = simd_size; i < N; i *= 2) {
         const int step = i / simd_size;
         for (int j = 0; j < el_w; j += (2 * step)) {
@@ -6222,7 +6222,7 @@ kernel void kernel_fwht_f32(
             }
         }
     }
-    
+
     for (int i = 0; i < el_w; i++) {
         dst[i*simd_size + lane] = reg[i];
     }

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -5762,7 +5762,7 @@ kernel void kernel_upscale_bicubic_f32(
     const float w_y2 = bicubic_weight1(1.0f - fd1);
     const float w_y3 = bicubic_weight2(2.0f - fd1);
 
-    const device const char * src_slice = src0 + i03 * args.nb03 + i02 * args.nb02;
+    const device char * src_slice = src0 + i03 * args.nb03 + i02 * args.nb02;
 
     device float * dst_ptr = (device float *)(dst + i3 * args.nb3 + i2 * args.nb2 + i1 * args.nb1);
 
@@ -6171,6 +6171,69 @@ kernel void kernel_argsort_merge_f32_i32(
 
 template [[host_name("kernel_argsort_merge_f32_i32_asc")]]  kernel argsort_merge_t kernel_argsort_merge_f32_i32<GGML_SORT_ORDER_ASC>;
 template [[host_name("kernel_argsort_merge_f32_i32_desc")]] kernel argsort_merge_t kernel_argsort_merge_f32_i32<GGML_SORT_ORDER_DESC>;
+
+template<int N>
+kernel void kernel_fwht_f32(
+        constant ggml_metal_kargs_fwht & args,
+        device const float * src,
+        device float * dst,
+        uint3 tgpig[[threadgroup_position_in_grid]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort3 ntg[[threads_per_threadgroup]]
+) {
+
+    constexpr int simd_size = 32;
+    constexpr int el_w = N / simd_size;
+    const float scale = 1.0f / sqrt((float) N);
+
+    const int sg_per_tg = ntg.x / simd_size;
+    const int64_t r = tgpig.x * sg_per_tg + sgitg;
+    if (r >= args.nrows) {
+        return;
+    }
+    
+    src += r * N;
+    dst += r * N;
+
+    const int lane = tiisg;
+    
+    float reg[el_w];
+    for (int i = 0; i < el_w; i++) {
+        reg[i] = src[i * simd_size + lane] * scale;
+    }
+    
+    for (int i = 1; i < simd_size; i *= 2) {
+        for (int j = 0; j < el_w; j++) {
+            const float val = reg[j];
+            const float val2 = simd_shuffle_xor(val, i);
+            reg[j] = (lane & i) == 0 ? val2 + val : val2 - val;
+        }
+    }
+    
+    for (int i = simd_size; i < N; i *= 2) {
+        const int step = i / simd_size;
+        for (int j = 0; j < el_w; j += (2 * step)) {
+            for (int k = 0; k < step; k++) {
+                const float x = reg[j+k];
+                const float y = reg[j+k+step];
+                reg[j+k] = x + y;
+                reg[j+k+step] = x - y;
+            }
+        }
+    }
+    
+    for (int i = 0; i < el_w; i++) {
+        dst[i*simd_size + lane] = reg[i];
+    }
+}
+
+typedef decltype(kernel_fwht_f32<64>) kernel_fwht_t;
+template [[host_name("kernel_fwht_f32_64")]] kernel kernel_fwht_t kernel_fwht_f32<64>;
+template [[host_name("kernel_fwht_f32_128")]] kernel kernel_fwht_t kernel_fwht_f32<128>;
+template [[host_name("kernel_fwht_f32_256")]] kernel kernel_fwht_t kernel_fwht_f32<256>;
+template [[host_name("kernel_fwht_f32_512")]] kernel kernel_fwht_t kernel_fwht_f32<512>;
+
 
 constant bool FC_flash_attn_ext_pad_has_mask [[function_constant(FC_FLASH_ATTN_EXT_PAD + 0)]];
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -6202,7 +6202,6 @@ kernel void kernel_fwht_f32(
     for (int i = 0; i < el_w; i++) {
         reg[i] = src[i * simd_size + lane] * scale;
     }
-1
     for (int i = 1; i < simd_size; i *= 2) {
         for (int j = 0; j < el_w; j++) {
             const float val = reg[j];
@@ -6233,7 +6232,6 @@ template [[host_name("kernel_fwht_f32_64")]] kernel kernel_fwht_t kernel_fwht_f3
 template [[host_name("kernel_fwht_f32_128")]] kernel kernel_fwht_t kernel_fwht_f32<128>;
 template [[host_name("kernel_fwht_f32_256")]] kernel kernel_fwht_t kernel_fwht_f32<256>;
 template [[host_name("kernel_fwht_f32_512")]] kernel kernel_fwht_t kernel_fwht_f32<512>;
-
 
 constant bool FC_flash_attn_ext_pad_has_mask [[function_constant(FC_FLASH_ATTN_EXT_PAD + 0)]];
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -6202,7 +6202,7 @@ kernel void kernel_fwht_f32(
     for (int i = 0; i < el_w; i++) {
         reg[i] = src[i * simd_size + lane] * scale;
     }
-    
+1
     for (int i = 1; i < simd_size; i *= 2) {
         for (int j = 0; j < el_w; j++) {
             const float val = reg[j];

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -6177,17 +6177,17 @@ kernel void kernel_fwht_f32(
         constant ggml_metal_kargs_fwht & args,
         device const float * src,
         device float * dst,
-        uint3 tgpig[[threadgroup_position_in_grid]],
+        uint3  tgpig[[threadgroup_position_in_grid]],
         ushort sgitg[[simdgroup_index_in_threadgroup]],
         ushort tiisg[[thread_index_in_simdgroup]],
-        ushort3 ntg[[threads_per_threadgroup]]
-) {
+        ushort3  ntg[[threads_per_threadgroup]]) {
 
-    constexpr int simd_size = 32;
-    constexpr int el_w = N / simd_size;
+    constexpr int NW = N_SIMDWIDTH;
+    constexpr int NE = N / NW;
+
     const float scale = 1.0f / sqrt((float) N);
 
-    const int sg_per_tg = ntg.x / simd_size;
+    const int sg_per_tg = ntg.x / NW;
     const int64_t r = tgpig.x * sg_per_tg + sgitg;
     if (r >= args.nrows) {
         return;
@@ -6198,37 +6198,38 @@ kernel void kernel_fwht_f32(
 
     const int lane = tiisg;
 
-    float reg[el_w];
-    for (int i = 0; i < el_w; i++) {
-        reg[i] = src[i * simd_size + lane] * scale;
+    float reg[NE];
+    for (int i = 0; i < NE; i++) {
+        reg[i] = src[i*NW + lane]*scale;
     }
-    for (int i = 1; i < simd_size; i *= 2) {
-        for (int j = 0; j < el_w; j++) {
+    for (int i = 1; i < NW; i *= 2) {
+        for (int j = 0; j < NE; j++) {
             const float val = reg[j];
             const float val2 = simd_shuffle_xor(val, i);
             reg[j] = (lane & i) == 0 ? val2 + val : val2 - val;
         }
     }
 
-    for (int i = simd_size; i < N; i *= 2) {
-        const int step = i / simd_size;
-        for (int j = 0; j < el_w; j += (2 * step)) {
+    for (int i = NW; i < N; i *= 2) {
+        const int step = i / NW;
+        for (int j = 0; j < NE; j += (2 * step)) {
             for (int k = 0; k < step; k++) {
-                const float x = reg[j+k];
-                const float y = reg[j+k+step];
-                reg[j+k] = x + y;
-                reg[j+k+step] = x - y;
+                const float x = reg[j + k ];
+                const float y = reg[j + k + step];
+                reg[j + k]        = x + y;
+                reg[j + k + step] = x - y;
             }
         }
     }
 
-    for (int i = 0; i < el_w; i++) {
-        dst[i*simd_size + lane] = reg[i];
+    for (int i = 0; i < NE; i++) {
+        dst[i*NW + lane] = reg[i];
     }
 }
 
 typedef decltype(kernel_fwht_f32<64>) kernel_fwht_t;
-template [[host_name("kernel_fwht_f32_64")]] kernel kernel_fwht_t kernel_fwht_f32<64>;
+
+template [[host_name("kernel_fwht_f32_64")]]  kernel kernel_fwht_t kernel_fwht_f32<64>;
 template [[host_name("kernel_fwht_f32_128")]] kernel kernel_fwht_t kernel_fwht_f32<128>;
 template [[host_name("kernel_fwht_f32_256")]] kernel kernel_fwht_t kernel_fwht_f32<256>;
 template [[host_name("kernel_fwht_f32_512")]] kernel kernel_fwht_t kernel_fwht_f32<512>;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8791,6 +8791,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 512, 1, 512));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 128, 32, 128));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 128, 4, 128, {2, 3}));
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 256, 512, 256)); // many rows
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 32, 1, 32)); // too small (N<64)
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 1024, 1, 1024)); // too big (N>512)
 
 #if 0
     // > 4GB A matrix. Too slow to be enabled by default.
@@ -9800,6 +9803,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 64, 1, 64));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 256, 1, 256));
     test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 128, 32, 128));
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 64, 2048, 64));
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 128, 2048, 128));
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 256, 2048, 256));
+    test_cases.emplace_back(new test_mul_mat_hadamard(GGML_TYPE_F32, GGML_TYPE_F32, 512, 2048, 512));
 
     test_cases.emplace_back(new test_solve_tri(GGML_TYPE_F32, { 64, 64, 4, 4 }, { 32, 64, 4, 4 }));
     test_cases.emplace_back(new test_solve_tri(GGML_TYPE_F32, { 128, 128, 4, 2 }, { 32, 128, 4, 2 }));


### PR DESCRIPTION
## Overview

Adds support for the Fast Walsh-Hadamard Transform to the metal backend. Largely mirrors the implementation in `./ggml/src/ggml-cuda/fwht.cu`, with the exception of the number of simd groups per threadgroup (CUDA uses 4 warp/tg, I found the optimal number to be 2 on metal, evidence below).

## Additional information

I was working on some experiments where I was applying the hadamard matrix to models with weight tensors with particularly high kurtosis as a means to blunt the outliers to improve IQ quants (TL;DR, Qwen 2.5 1.5B IQ_3S with selective hadaquant regains ~65% of KLD losses relative to a regular IQ3_S quant, though it doesn't seem to holod on other models, going to continue investigating). During this work, I noticed that metal backend doesn't have the same FWHT support as CUDA, instead offloading that operation to the fallback GEMM kernel. 

### Performance

we see between 1.5x and 2.5x increases in speed when compared to the current baseline based on the perf suite (I added a perf test for N={64, 128, 256, 512}), these gains represent only ~2% of the prefill/decode time on models I can run on my hardware, so the gains are absorbed by noise there.

Latency (µs/run, lower is better)

| Problem | Baseline | sg=1 | sg=2 | sg=4 | sg=8 |
|---|---:|---:|---:|---:|---:|
| 128 × 1 × 128 | 4.03 | 2.89 | 2.92 | 2.96 | **2.87** |
| 64 × 1 × 64 | 3.83 | 2.50 | 2.54 | 2.58 | **2.47** |
| 256 × 1 × 256 | 4.41 | 3.67 | 3.65 | 3.82 | **3.56** |
| 128 × 32 × 128 | 7.72 | **2.84** | 2.90 | 3.58 | 4.20 |
| 64 × 2048 × 64 | 8.79 | 5.30 | **4.96** | 5.15 | 5.64 |
| 128 × 2048 × 128 | 19.60 | 9.80 | 9.02 | **8.82** | 9.66 |
| 256 × 2048 × 256 | 53.14 | 26.56 | **22.66** | 24.40 | 23.92 |
| 512 × 2048 × 512 | 184.98 | 80.69 | **76.88** | 78.83 | 78.09 |

### Speedup vs. baseline (higher is better)

| Problem | sg=1 | sg=2 | sg=4 | sg=8 |
|---|---:|---:|---:|---:|
| 128 × 1 × 128 | 1.39 | 1.38 | 1.36 | **1.40** |
| 64 × 1 × 64 | 1.53 | 1.51 | 1.48 | **1.55** |
| 256 × 1 × 256 | 1.20 | 1.21 | 1.15 | **1.24** |
| 128 × 32 × 128 | **2.72** | 2.66 | 2.16 | 1.84 |
| 64 × 2048 × 64 | 1.66 | **1.77** | 1.71 | 1.56 |
| 128 × 2048 × 128 | 2.00 | 2.17 | **2.22** | 2.03 |
| 256 × 2048 × 256 | 2.00 | **2.34** | 2.18 | 2.22 |
| 512 × 2048 × 512 | 2.29 | **2.41** | 2.35 | 2.37 |
| **Peak throughput (largest case)** | 13.31 TF | **13.97 TF** | 13.62 TF | 13.75 TF

### Additional Testing Requested

DeepseekV4 uses the Hadamard on every layer and every forward pass, some test results by someone who can run the model on a metal backed would be greatly appreciated.

## Reviewer Notes

Please review this PR with extreme prejudice, this is my first time attempting to write a kernel, so any and all feedback is welcome and appreciated.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

AI was used extensively as a learning tool in the process of writing this PR. I have never written a GPU kernel before (or a kernel of any kind) but have been looking for an opportunity to learn. Since I understood the math behind the hadamard and the FWHT, I wanted to push myself to actually learn this layer of inference optimization.

AI wrote 0% of the code in this PR, I used it to explore the codebase, understand the CUDA implementation, and help me find the metal API equivalents. It also guided me on where to add certain sections of the code, particularly with the dispatch logic, but again 100% of the code has been understood and written by me.

