### PR TITLE
HIP: RDNA 4 MUL_MAT optimizations

### DIFF
--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -1064,7 +1064,7 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
                 for (int l = 0; l < tile_C::ne; ++l) {
                     const int i = i0 + n*tile_C::I + tile_C::get_i(l);
                     const int8_t * sc = (const int8_t *) (x_sc + i*sram_stride + k00/16);
-                    sum[(j0/tile_C::J + n)*tile_C::ne + l] += C.x[l] * sc[k01/4] * x_df[i*sram_stride] * dB;
+                    sum[(j0/tile_C::J + n)*tile_C::ne + l] += ((float) C.x[l]) * sc[k01/4] * x_df[i*sram_stride] * dB;
                 }
             }
         }
@@ -1248,4 +1248,3 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
         }
     }
 }
-

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -700,6 +700,7 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
     const int i0 = (threadIdx.y / ntx) * rows_per_warp;
 
+#pragma unroll 1
     for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += 4) {
         const int k0 = k00 + k01;
 

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -693,6 +693,7 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
     const int i0 = (threadIdx.y / ntx) * rows_per_warp;
 
+#pragma unroll 1
     for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += 4) {
         const int k0 = k00 + k01;
 

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -1055,7 +1055,7 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
                 for (int l = 0; l < tile_C::ne; ++l) {
                     const int i = i0 + n*tile_C::I + tile_C::get_i(l);
                     const int8_t * sc = (const int8_t *) (x_sc + i*sram_stride + k00/16);
-                    sum[(j0/tile_C::J + n)*tile_C::ne + l] += C.x[l] * sc[k01/4] * x_df[i*sram_stride] * dB;
+                    sum[(j0/tile_C::J + n)*tile_C::ne + l] += ((float) C.x[l]) * sc[k01/4] * x_df[i*sram_stride] * dB;
                 }
             }
         }
@@ -1237,4 +1237,3 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
         }
     }
 }
-

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -355,8 +355,31 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
             }
         }
 
-        // For RDNA4 MMQ is consistently faster than dequantization + hipBLAS:
-        // https://github.com/ggml-org/llama.cpp/pull/18537#issuecomment-3706422301
+        if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+            // For RDNA4 MMQ is consistently faster than dequantization + hipBLAS:
+            // https://github.com/ggml-org/llama.cpp/pull/18537#issuecomment-3706422301
+            if (n_experts > 0) {
+                return true;
+            }
+
+            switch (type) {
+                case GGML_TYPE_Q4_K:
+                case GGML_TYPE_Q5_K:
+                case GGML_TYPE_Q4_0:
+                case GGML_TYPE_Q4_1:
+                    return ne11 <= 512;
+                case GGML_TYPE_Q5_0:
+                    return ne11 <= 336;
+                case GGML_TYPE_Q6_K:
+                case GGML_TYPE_Q5_1:
+                    return ne11 <= 256;
+                case GGML_TYPE_Q2_K:
+                    return ne11 <= 96;
+                default:
+                    break;
+            }
+        }
+
         return true;
     }
 

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -377,8 +377,31 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
             }
         }
 
-        // For RDNA4 MMQ is consistently faster than dequantization + hipBLAS:
-        // https://github.com/ggml-org/llama.cpp/pull/18537#issuecomment-3706422301
+        if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+            // For RDNA4 MMQ is consistently faster than dequantization + hipBLAS:
+            // https://github.com/ggml-org/llama.cpp/pull/18537#issuecomment-3706422301
+            if (n_experts > 0) {
+                return true;
+            }
+
+            switch (type) {
+                case GGML_TYPE_Q4_K:
+                case GGML_TYPE_Q5_K:
+                case GGML_TYPE_Q4_0:
+                case GGML_TYPE_Q4_1:
+                    return ne11 <= 512;
+                case GGML_TYPE_Q5_0:
+                    return ne11 <= 336;
+                case GGML_TYPE_Q6_K:
+                case GGML_TYPE_Q5_1:
+                    return ne11 <= 256;
+                case GGML_TYPE_Q2_K:
+                    return ne11 <= 96;
+                default:
+                    break;
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Overview

RDNA4 fixes for Q6_K and Q2_K and updates for mmq conditions.

## Additional information

Checked with `test-backend-ops test -o MUL_MAT` and `test-backend-ops grad -o MUL_MAT -p "type_a=(q2_K|q4_0|q4_1|q4_K|q5_0|q5_1|q5_K|q6_K)"`. Compiled using ROCM 7.15 (TheRock 20260717)

For both Q6_K and Q2_K, it seems like rocm llvm doesn't handle current code appropriately (Q6_K doesn't do float conversion before int multiplication and Q2_K loop unrolls and spill into scratch).

For the quants sweep, tried to sweep both n (ne11) and n_experts.

### test-backend-ops perf -o MUL_MAT

| type | n = 1 | n = 1 (PR) | delta | n=512 | n=512 (PR) | delta |
|---|---|---|---|---|---|---|
| Q4_0 | 3.59 | 3.66 | +1.9% | 78.40 | 82.54 | +5.3% |
| Q4_1 | 4.13 | 4.18 | +1.2% | 76.80 | 78.32 | +2.0% |
| Q5_0 | 2.99 | 3.02 | +1.0% | 66.13 | 63.66 | -3.7% |
| Q5_1 | 3.26 | 3.33 | +2.1% | 59.14 | 63.43 | +7.3% |
| Q2_K | 2.80 | 2.83 | +1.1% | 2.51 | 70.78 | +28.2x |
| Q4_K | 2.57 | 2.74 | +6.6% | 77.69 | 78.01 | +0.4% |
| Q5_K | 2.37 | 2.51 | +5.9% | 75.00 | 75.82 | +1.1% |
| Q6_K | 1.87 | 2.06 | +10.2% | 36.62 | 69.66 | +1.90x |

### llama-bench -m Qwen3.5-9B-Q4_K_M.gguf -p 512,2048,4096 -n 128 -r 3

| test | master | PR | delta |
|---|---|---|---|
| pp512 | 3205.84 ± 264.03 | 3642.47 ± 365.29 | +13.6% |
| pp2048 | 3282.09 ± 2.08 | 3801.26 ± 1.25 | +15.8% |
| pp4096 | 3221.14 ± 1.70 | 3716.26 ± 2.82 | +15.4% |
| tg128 | 80.59 ± 0.16 | 78.99 ± 0.15 | -2.0% |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used Claude & Kimi K3 to investigate root cause and perform sweep across different quants
