### PR TITLE
convert : add missing return after setting tekken vocab

### DIFF
--- a/conversion/llama.py
+++ b/conversion/llama.py
@@ -119,7 +119,7 @@ class LlamaModel(TextModel):
         path_tekken_json = self.dir_model / "tekken.json"
         path_tokenizer_json = self.dir_model / "tokenizer.json"
         if path_tekken_json.is_file() and not path_tokenizer_json.is_file():
-            self._set_vocab_mistral()
+            return self._set_vocab_mistral()
 
         tokenizer_config_file = self.dir_model / 'tokenizer_config.json'
         if tokenizer_config_file.is_file():


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Issue #25359: 

Failure to convert for HF-layout model with tekken.json and no tokenizer.json

```AttributeError: 'MistralCommonTokenizer' object has no attribute 'vocab'```

- LlamaModel.set_vocab calls _set_vocab_mistral() in that branch but doesn't return


Originally it had the return in #14862 but was dropped by a refactor in #14737, which renamed set_vocab_tekken() to _set_vocab_mistral(). Behavior carried over when #17114 moved it to conversion/llama.py.

Fix: Adding return to the tekken branch, restoring the behavior from #14862.


## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Reproduced by running

```
hf download mistralai/Voxtral-Mini-3B-2507 --exclude consolidated.safetensors --local-dir models/Voxtral-Mini-3B-2507
py convert_hf_to_gguf.py models/Voxtral-Mini-3B-2507 --outfile voxtral.gguf --outtype q8_0
```


Before:

```
INFO:hf-to-gguf:Set model tokenizer
INFO:gguf.vocab:Loading Mistral tokenizer from models\Voxtral-Mini-3B-2507
INFO:mistral_common.tokens.tokenizers.tekken:Non special vocabulary size is 130072 with 1000 special tokens.
INFO:mistral_common.tokens.tokenizers.tekken:Cutting non special vocabulary to first 130072 tokens.
INFO:hf-to-gguf:Converting tokenizer MistralTokenizerType.tekken of size 131072.
INFO:hf-to-gguf:Setting bos, eos, unk and pad token IDs to 1, 2, 0, 11.
WARNING:gguf.gguf_writer:Duplicated key name 'llama.vocab_size', overwriting it with new value 131072 of type UINT32
INFO:mistral_common.tokens.tokenizers.tekken:Non special vocabulary size is 130072 with 1000 special tokens.
INFO:mistral_common.tokens.tokenizers.tekken:Cutting non special vocabulary to first 130072 tokens.
Traceback (most recent call last):
  File "llama.cpp\conversion\llama.py", line 123, in set_vocab
    self._set_vocab_sentencepiece()
  File "llama.cpp\conversion\base.py", line 1828, in _set_vocab_sentencepiece
    tokens, scores, toktypes = self._create_vocab_sentencepiece()
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "llama.cpp\conversion\base.py", line 1845, in _create_vocab_sentencepiece
    raise FileNotFoundError(f"File not found: {tokenizer_path}")
FileNotFoundError: File not found: models\Voxtral-Mini-3B-2507\tokenizer.model

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "llama.cpp\conversion\llama.py", line 126, in set_vocab
    self._set_vocab_llama_hf()
  File "llama.cpp\conversion\base.py", line 1930, in _set_vocab_llama_hf
    vocab = gguf.LlamaHfVocab(self.dir_model)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "llama.cpp\gguf-py\gguf\vocab.py", line 555, in __init__
    with open(fname_tokenizer, encoding='utf-8') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'models\\Voxtral-Mini-3B-2507\\tokenizer.json'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "llama.cpp\convert_hf_to_gguf.py", line 296, in <module>
    main()
  File "llama.cpp\convert_hf_to_gguf.py", line 290, in main
    model_instance.write()
  File "llama.cpp\conversion\base.py", line 1026, in write
    self.prepare_metadata(vocab_only=False)
  File "llama.cpp\conversion\base.py", line 1193, in prepare_metadata
    self.set_vocab()
  File "llama.cpp\conversion\llama.py", line 129, in set_vocab
    self._set_vocab_gpt2()
  File "llama.cpp\conversion\base.py", line 1711, in _set_vocab_gpt2
    tokens, toktypes, tokpre = self.get_vocab_base()
                               ^^^^^^^^^^^^^^^^^^^^^
  File "llama.cpp\conversion\base.py", line 1348, in get_vocab_base
    vocab_size = self.hparams.get("vocab_size", len(tokenizer.vocab))  # ty: ignore[unresolved-attribute]
                                                    ^^^^^^^^^^^^^^^
AttributeError: 'MistralCommonTokenizer' object has no attribute 'vocab'
```

After:

```
INFO:hf-to-gguf:Set model tokenizer
INFO:gguf.vocab:Loading Mistral tokenizer from models\Voxtral-Mini-3B-2507
INFO:mistral_common.tokens.tokenizers.tekken:Non special vocabulary size is 130072 with 1000 special tokens.
INFO:mistral_common.tokens.tokenizers.tekken:Cutting non special vocabulary to first 130072 tokens.
INFO:hf-to-gguf:Converting tokenizer MistralTokenizerType.tekken of size 131072.
INFO:hf-to-gguf:Setting bos, eos, unk and pad token IDs to 1, 2, 0, 11.
WARNING:gguf.gguf_writer:Duplicated key name 'llama.vocab_size', overwriting it with new value 131072 of type UINT32
INFO:gguf.gguf_writer:Writing the following files:
INFO:gguf.gguf_writer:voxtral.gguf: n_tensors = 273, total_size = 4.3G
Writing: 100%|████████| 4.27G/4.27G [01:54<00:00, 37.2Mbyte/s]
INFO:hf-to-gguf:Model successfully exported to voxtral.gguf
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes with claude to recreate issue and trace regression
