### PR TITLE
tests: fix quantize buffer overrun in test-quantize-fns

### DIFF
--- a/tests/test-quantize-fns.cpp
+++ b/tests/test-quantize-fns.cpp
@@ -49,8 +49,8 @@ static float array_rmse(const float * a1, const float * a2, size_t n) {
 }
 
 // Total quantization error on test data
-static float total_quantization_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, size_t test_size, const float * test_data) {
-    std::vector<uint8_t> tmp_q(2*test_size);
+static float total_quantization_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, ggml_type type, size_t test_size, const float * test_data) {
+    std::vector<uint8_t> tmp_q(ggml_row_size(type, test_size));
     std::vector<float> tmp_out(test_size);
 
     qfns_cpu->from_float(test_data, tmp_q.data(), test_size);
@@ -59,8 +59,8 @@ static float total_quantization_error(const ggml_type_traits * qfns, const ggml_
 }
 
 // Total quantization error on test data
-static float reference_quantization_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, size_t test_size, const float * test_data) {
-    std::vector<uint8_t> tmp_q(2*test_size);
+static float reference_quantization_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, ggml_type type, size_t test_size, const float * test_data) {
+    std::vector<uint8_t> tmp_q(ggml_row_size(type, test_size));
     std::vector<float> tmp_out(test_size);
     std::vector<float> tmp_out_ref(test_size);
 
@@ -83,11 +83,15 @@ static float dot_product(const float * a1, const float * a2, size_t test_size) {
 }
 
 // Total dot product error
-static float dot_product_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, size_t test_size, const float * test_data1, const float * test_data2) {
+static float dot_product_error(const ggml_type_traits * qfns, const ggml_type_traits_cpu * qfns_cpu, ggml_type type, size_t test_size, const float * test_data1, const float * test_data2) {
     GGML_UNUSED(qfns);
 
-    std::vector<uint8_t> tmp_q1(2*test_size);
-    std::vector<uint8_t> tmp_q2(2*test_size);
+    const size_t row_size       = ggml_row_size(type, test_size);
+    const size_t row_size_vdot  = ggml_row_size(qfns_cpu->vec_dot_type, test_size);
+    const size_t buf_size       = std::max(row_size, row_size_vdot);
+
+    std::vector<uint8_t> tmp_q1(buf_size);
+    std::vector<uint8_t> tmp_q2(buf_size);
 
     const auto * vdot = ggml_get_type_traits_cpu(qfns_cpu->vec_dot_type);
 
@@ -153,7 +157,7 @@ static int test_vec_dot_q(bool verbose) {
         ggml_quantize_init(ei);
 
         if (qfns_cpu->from_float && qfns->to_float) {
-            const float total_error = total_quantization_error(qfns, qfns_cpu, test_size, test_data.data());
+            const float total_error = total_quantization_error(qfns, qfns_cpu, type, test_size, test_data.data());
             const float max_quantization_error =
                 type == GGML_TYPE_Q1_0    ? MAX_QUANTIZATION_TOTAL_ERROR_BINARY :
                 type == GGML_TYPE_TQ1_0   ? MAX_QUANTIZATION_TOTAL_ERROR_TERNARY :
@@ -171,14 +175,14 @@ static int test_vec_dot_q(bool verbose) {
                 printf("%5s absolute quantization error:    %s (%f)\n", ggml_type_name(type), RESULT_STR[failed], total_error);
             }
 
-            const float reference_error = reference_quantization_error(qfns, qfns_cpu, test_size, test_data.data());
+            const float reference_error = reference_quantization_error(qfns, qfns_cpu, type, test_size, test_data.data());
             failed = !(reference_error < MAX_QUANTIZATION_REFERENCE_ERROR);
             num_failed += failed;
             if (failed || verbose) {
                 printf("%5s reference implementation error: %s (%f)\n", ggml_type_name(type), RESULT_STR[failed], reference_error);
             }
 
-            const float vec_dot_error = dot_product_error(qfns, qfns_cpu, test_size, test_data.data(), test_data2.data());
+            const float vec_dot_error = dot_product_error(qfns, qfns_cpu, type, test_size, test_data.data(), test_data2.data());
             const float max_allowed_error = type == GGML_TYPE_Q2_K || type == GGML_TYPE_IQ2_XS || type == GGML_TYPE_IQ2_XXS ||
                 type == GGML_TYPE_IQ3_XXS || type == GGML_TYPE_IQ3_S || type == GGML_TYPE_IQ2_S
                 ? MAX_DOT_PRODUCT_ERROR_LOWBIT


### PR DESCRIPTION
## Overview
Fix buffer overrun in test-quantize-fns test case.
Original code used hardcoded 2*test_size buffer allocation which causes ASan heap overflow when vec_dot_type uses larger row size.
Replace fixed-size allocation with dynamic buffer size calculation via ggml_row_size, use max row size for temporary buffers tmp_q1/tmp_q2 to avoid out-of-bounds memory access.

## Additional information
This PR resolves crash reported in #25858.
Changes only affect test file tests/test-quantize-fns.cpp:
- Remove hardcoded buffer length (2*test_size)
- Calculate real required row size with ggml_row_size
- Allocate temporary buffers based on max of regular row size and vec_dot_type row size

Note: After fixing the overflow inside test-quantize-fns, ASan reports an unrelated heap allocation error from another source file. That separate bug is out of scope for this PR and will be fixed in a follow-up PR.

## Requirements
- [x] I have read and agree with the contributing guidelines
- [x] Target test case test-quantize-fns no longer triggers ASan heap overflow
- [x] AI usage disclosure: AI assisted with analyzing memory logic and drafting fix code; final debugging and parameter tuning done manually
