### PR TITLE
server: display client IP address in logs

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2351,6 +2351,7 @@ private:
                     }
 
                     const int id_task = task.id;
+                    const std::string client_ip = task.remote_addr.empty() ? "unknown" : task.remote_addr;
 
                     server_slot * slot = get_available_slot(task);
 
@@ -2371,6 +2372,13 @@ private:
                         queue_tasks.defer(std::move(task));
                         break;
                     }
+
+                    // log client IP when task starts processing
+                    SRV_INF("%s task %d from %s (slot %d)\n",
+                        task.type == SERVER_TASK_TYPE_COMPLETION ? "completion" :
+                        task.type == SERVER_TASK_TYPE_INFILL ? "infill" :
+                        task.type == SERVER_TASK_TYPE_EMBEDDING ? "embedding" : "other",
+                        id_task, client_ip.c_str(), slot->id);
 
                     if (task.is_parent()) {
                         // try getting free slots for all child tasks
@@ -4090,6 +4098,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             server_task task = server_task(type);
 
             task.id = rd.get_new_id();
+            task.remote_addr = req.remote_addr; // store client IP
 
             task.tokens = std::move(inputs[i]);
             task.params = server_schema::eval_llama_cmpl_schema(
@@ -4969,8 +4978,9 @@ void server_routes::init_routes() {
             for (size_t i = 0; i < documents.size(); i++) {
                 auto tmp = format_prompt_rerank(ctx_server.model_tgt, ctx_server.vocab, ctx_server.mctx, query, documents[i]);
                 server_task task = server_task(SERVER_TASK_TYPE_RERANK);
-                task.id     = rd.get_new_id();
-                task.tokens = std::move(tmp);
+                task.id          = rd.get_new_id();
+                task.remote_addr = req.remote_addr; // store client IP
+                task.tokens      = std::move(tmp);
                 tasks.push_back(std::move(task));
             }
             rd.post_tasks(std::move(tasks));
@@ -5011,7 +5021,8 @@ void server_routes::init_routes() {
         auto & rd = res->rd;
         {
             server_task task(SERVER_TASK_TYPE_GET_LORA);
-            task.id = rd.get_new_id();
+            task.id          = rd.get_new_id();
+            task.remote_addr = req.remote_addr; // store client IP
             rd.post_task(std::move(task));
         }
 
@@ -5044,8 +5055,9 @@ void server_routes::init_routes() {
         auto & rd = res->rd;
         {
             server_task task(SERVER_TASK_TYPE_SET_LORA);
-            task.id = rd.get_new_id();
-            task.set_lora = parse_lora_request(body);
+            task.id          = rd.get_new_id();
+            task.remote_addr = req.remote_addr; // store client IP
+            task.set_lora    = parse_lora_request(body);
             rd.post_task(std::move(task));
         }
 
@@ -5102,7 +5114,8 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_save(const ser
     auto & rd = res->rd;
     {
         server_task task(SERVER_TASK_TYPE_SLOT_SAVE);
-        task.id = rd.get_new_id();
+        task.id          = rd.get_new_id();
+        task.remote_addr = req.remote_addr; // store client IP
         task.slot_action.id_slot  = id_slot;
         task.slot_action.filename = filename;
         task.slot_action.filepath = filepath;
@@ -5138,7 +5151,8 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_restore(const 
     auto & rd = res->rd;
     {
         server_task task(SERVER_TASK_TYPE_SLOT_RESTORE);
-        task.id = rd.get_new_id();
+        task.id          = rd.get_new_id();
+        task.remote_addr = req.remote_addr; // store client IP
         task.slot_action.id_slot  = id_slot;
         task.slot_action.filename = filename;
         task.slot_action.filepath = filepath;
@@ -5167,7 +5181,8 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_erase(const se
     auto & rd = res->rd;
     {
         server_task task(SERVER_TASK_TYPE_SLOT_ERASE);
-        task.id = rd.get_new_id();
+        task.id          = rd.get_new_id();
+        task.remote_addr = req.remote_addr; // store client IP
         task.slot_action.id_slot = id_slot;
         rd.post_task(std::move(task));
     }
@@ -5251,11 +5266,12 @@ std::unique_ptr<server_res_generator> server_routes::handle_embeddings_impl(cons
         for (size_t i = 0; i < tokenized_prompts.size(); i++) {
             server_task task = server_task(SERVER_TASK_TYPE_EMBEDDING);
 
-            task.id     = rd.get_new_id();
-            task.tokens = std::move(tokenized_prompts[i]);
+            task.id             = rd.get_new_id();
+            task.remote_addr    = req.remote_addr; // store client IP
+            task.tokens         = std::move(tokenized_prompts[i]);
 
             // OAI-compat
-            task.params.res_type = res_type;
+            task.params.res_type       = res_type;
             task.params.embd_normalize = embd_normalize;
 
             tasks.push_back(std::move(task));

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -534,6 +534,38 @@ static std::string build_query_string(const httplib::Request & req) {
     return qs;
 }
 
+// Helper function to extract real client IP from proxy headers
+static std::string get_client_ip(const httplib::Request & req) {
+    // First, check X-Forwarded-For header (comma-separated list, first IP is original client)
+    auto x_forwarded_for = req.get_header_value("X-Forwarded-For");
+    if (!x_forwarded_for.empty()) {
+        // Get the first IP in the list (original client)
+        size_t comma_pos = x_forwarded_for.find(',');
+        if (comma_pos != std::string::npos) {
+            x_forwarded_for = x_forwarded_for.substr(0, comma_pos);
+        }
+        // Trim whitespace
+        x_forwarded_for.erase(0, x_forwarded_for.find_first_not_of(" \t"));
+        x_forwarded_for.erase(x_forwarded_for.find_last_not_of(" \t") + 1);
+        if (!x_forwarded_for.empty()) {
+            return x_forwarded_for;
+        }
+    }
+
+    // Check X-Real-IP header (single IP)
+    auto x_real_ip = req.get_header_value("X-Real-IP");
+    if (!x_real_ip.empty()) {
+        x_real_ip.erase(0, x_real_ip.find_first_not_of(" \t"));
+        x_real_ip.erase(x_real_ip.find_last_not_of(" \t") + 1);
+        if (!x_real_ip.empty()) {
+            return x_real_ip;
+        }
+    }
+
+    // Fall back to connection remote address
+    return req.remote_addr.empty() ? "unknown" : req.remote_addr;
+}
+
 // using unique_ptr for request to allow safe capturing in lambdas
 using server_http_req_ptr = std::unique_ptr<server_http_req>;
 
@@ -587,7 +619,8 @@ void server_http_context::get(const std::string & path, const server_http_contex
             build_query_string(req),
             req.body,
             {},
-            req.is_connection_closed
+            req.is_connection_closed,
+            get_client_ip(req)
         });
         server_http_res_ptr response = handler(*request);
         process_handler_response(std::move(request), response, res);
@@ -634,7 +667,8 @@ void server_http_context::post(const std::string & path, const server_http_conte
             build_query_string(req),
             body,
             std::move(files),
-            req.is_connection_closed
+            req.is_connection_closed,
+            get_client_ip(req)
         });
         server_http_res_ptr response = handler(*request);
         process_handler_response(std::move(request), response, res);
@@ -651,7 +685,8 @@ void server_http_context::del(const std::string & path, const server_http_contex
             build_query_string(req),
             req.body,
             {},
-            req.is_connection_closed
+            req.is_connection_closed,
+            get_client_ip(req)
         });
         server_http_res_ptr response = handler(*request);
         process_handler_response(std::move(request), response, res);
@@ -807,6 +842,7 @@ void server_http_context::register_gcp_compat() const {
                         payload.dump(),
                         {},
                         req.should_stop,
+                        req.remote_addr  // preserve client IP for GCP proxy
                     };
 
                     server_http_res_ptr internal_res = handlers.at(dispatch_path)(internal_req);

--- a/tools/server/server-http.h
+++ b/tools/server/server-http.h
@@ -54,6 +54,7 @@ struct server_http_req {
     std::string body;
     std::map<std::string, uploaded_file> files; // used for file uploads (form data)
     const std::function<bool()> & should_stop;
+    std::string remote_addr; // client IP address
 
     std::string get_param(const std::string & key, const std::string & def = "") const {
         auto it = params.find(key);

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1227,13 +1227,27 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
     if (!req.query_string.empty()) {
         proxy_path += '?' + req.query_string;
     }
+
+    // Preserve original client IP when proxying to child server
+    std::map<std::string, std::string> forwarded_headers = req.headers;
+    std::string client_ip = req.remote_addr;
+    if (!client_ip.empty() && client_ip != "unknown") {
+        // Check if X-Forwarded-For already exists and append to it
+        auto existing_xff = forwarded_headers.find("X-Forwarded-For");
+        if (existing_xff != forwarded_headers.end()) {
+            forwarded_headers["X-Forwarded-For"] = existing_xff->second + ", " + client_ip;
+        } else {
+            forwarded_headers["X-Forwarded-For"] = client_ip;
+        }
+    }
+
     auto proxy = std::make_unique<server_http_proxy>(
             method,
             "http",
             CHILD_ADDR,
             meta->port,
             proxy_path,
-            req.headers,
+            forwarded_headers,
             req.body,
             req.files,
             req.should_stop,
@@ -1833,13 +1847,26 @@ void server_models_routes::init_routes() {
         }
         SRV_TRC("proxying stream resume to model %s on port %d, path=%s\n",
                 owner->name.c_str(), owner->port, child_path.c_str());
+
+        // Preserve original client IP when proxying to child server
+        std::map<std::string, std::string> forwarded_headers = req.headers;
+        std::string client_ip = req.remote_addr;
+        if (!client_ip.empty() && client_ip != "unknown") {
+            auto existing_xff = forwarded_headers.find("X-Forwarded-For");
+            if (existing_xff != forwarded_headers.end()) {
+                forwarded_headers["X-Forwarded-For"] = existing_xff->second + ", " + client_ip;
+            } else {
+                forwarded_headers["X-Forwarded-For"] = client_ip;
+            }
+        }
+
         auto proxy = std::make_unique<server_http_proxy>(
                 "GET",
                 "http",
                 CHILD_ADDR,
                 owner->port,
                 child_path,
-                req.headers,
+                forwarded_headers,
                 req.body,
                 req.files,
                 req.should_stop,

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -175,6 +175,9 @@ struct server_task {
     // used by SERVER_TASK_TYPE_SET_LORA
     std::map<int, float> set_lora; // mapping adapter ID -> scale
 
+    // client IP address for logging
+    std::string remote_addr;
+
     server_task() = default;
 
     server_task(server_task_type type) : type(type) {}


### PR DESCRIPTION
## Overview

Adds client IP address display in llama-server logs. Shows the real IP of the client making requests, which is especially useful when running behind a proxy or in router mode.

## Changes

**HTTP layer** (`tools/server/server-http.cpp`, `tools/server/server-http.h`):
- Added `remote_addr` field to `server_http_req` structure
- Created `get_client_ip()` helper function that extracts IP from:
  - `X-Forwarded-For` header (comma-separated list, first IP is original client)
  - `X-Real-IP` header (single IP)
  - Falls back to `req.remote_addr` if no proxy headers present

**Router mode** (`tools/server/server-models.cpp`):
- When proxying requests from router to child servers, adds `X-Forwarded-For` header with original client IP
- Preserves client IP across the router -> child server hop

**Task layer** (`tools/server/server-task.h`, `tools/server/server-context.cpp`):
- Added `remote_addr` field to `server_task` structure
- IP is passed to all task types (completion, embedding, rerank, etc.)
- Logs client IP when task starts processing

## Additional information

- Log format: `srv  process_single_task: completion task 5 from 172.16.30.11 (slot 2)`
- Log level must be INFO or higher to see the IP addresses
- Works with standard proxy headers (`X-Forwarded-For`, `X-Real-IP`)
- Router mode correctly forwards client IP to child servers

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted with code implementation (IP extraction from proxy headers, router proxy forwarding)
