### PR TITLE
embeddings: skip logits and lm head during inference

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2118,6 +2118,12 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             else { throw std::invalid_argument("invalid value"); }
         }
     ).set_examples({LLAMA_EXAMPLE_EMBEDDING}));
+    add_opt(common_arg({ "--no-logits-for-embeddings" },
+                       "skip raw logits and the LM head when extracting embeddings without backend samplers",
+                       [](common_params & params) { params.no_logits_for_embeddings = true; })
+                .set_examples(
+                    { LLAMA_EXAMPLE_EMBEDDING, LLAMA_EXAMPLE_RETRIEVAL, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_DEBUG })
+                .set_env("LLAMA_ARG_NO_LOGITS_FOR_EMBEDDINGS"));
     add_opt(common_arg(
         {"--rope-scaling"}, "{none,linear,yarn}",
         "RoPE frequency scaling method, defaults to linear unless specified by the model",

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1600,6 +1600,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.n_threads_batch   = params.cpuparams_batch.n_threads == -1 ?
                                 params.cpuparams.n_threads : params.cpuparams_batch.n_threads;
     cparams.embeddings        = params.embedding;
+    cparams.no_logits_for_embeddings = params.no_logits_for_embeddings;
     cparams.rope_scaling_type = params.rope_scaling_type;
     cparams.rope_freq_base    = params.rope_freq_base;
     cparams.rope_freq_scale   = params.rope_freq_scale;

--- a/common/common.h
+++ b/common/common.h
@@ -607,6 +607,7 @@ struct common_params {
 
     // embedding
     bool embedding         = false; // get only sentence embedding
+    bool no_logits_for_embeddings = false;  // skip raw logits and the LM head when extracting embeddings
     int32_t embd_normalize = 2;     // normalisation for embeddings (-1=none, 0=max absolute int16, 1=taxicab, 2=euclidean, >2=p-norm)
     std::string embd_out   = "";    // empty = default, "array" = [[],[]...], "json" = openai style, "json+" = same "json" + cosine similarity matrix
     std::string embd_sep   = "\n";  // separator of embeddings

--- a/examples/embedding/README.md
+++ b/examples/embedding/README.md
@@ -21,6 +21,10 @@ llama-embedding.exe -m ./path/to/model --pooling mean --log-disable -p "Hello Wo
 The above command will output space-separated float values.
 
 ## extra parameters
+### --no-logits-for-embeddings
+
+Skip the vocabulary logits and LM head when extracting embeddings. This reduces compute and host output memory for causal models; backend sampler paths retain the logits graph.
+
 ### --embd-normalize $integer$
 | $integer$ | description         | formula |
 |-----------|---------------------|---------|

--- a/include/llama.h
+++ b/include/llama.h
@@ -376,7 +376,7 @@ extern "C" {
         void *              abort_callback_data;
 
         // Keep the booleans together and at the end of the struct to avoid misalignment during copy-by-value.
-        bool embeddings;  // if true, extract embeddings (together with logits)
+        bool embeddings;  // if true, extract embeddings (together with logits by default)
         bool offload_kqv; // offload the KQV ops (including the KV cache) to GPU
         bool no_perf;     // measure performance timings
         bool op_offload;  // offload host tensor operations to device
@@ -386,6 +386,8 @@ extern "C" {
         bool kv_unified;  // use a unified buffer across the input sequences when computing the attention
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
+        bool
+            no_logits_for_embeddings;  // if true, skip logits and the LM head for embeddings in default contexts without backend samplers
 
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)
@@ -1007,13 +1009,14 @@ extern "C" {
     // in the order they have appeared in the batch.
     // Rows: number of tokens for which llama_batch.logits[i] != 0
     // Cols: n_vocab
+    // Returns NULL if logits are disabled with llama_context_params.no_logits_for_embeddings.
     // TODO: deprecate in favor of llama_get_logits_ith() (ref: https://github.com/ggml-org/llama.cpp/pull/14853#issuecomment-3113143522)
     LLAMA_API float * llama_get_logits(struct llama_context * ctx);
 
     // Logits for the ith token. For positive indices, Equivalent to:
     // llama_get_logits(ctx) + ctx->output_ids[i]*n_vocab
     // Negative indices can be used to access logits in reverse order, -1 is the last logit.
-    // returns NULL for invalid ids.
+    // returns NULL for invalid ids or when logits are disabled with llama_context_params.no_logits_for_embeddings.
     LLAMA_API float * llama_get_logits_ith(struct llama_context * ctx, int32_t i);
 
     // Get all output token embeddings.

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -114,6 +114,7 @@ llama_context::llama_context(
     cparams.yarn_beta_fast          = params.yarn_beta_fast   >= 0.0f ? params.yarn_beta_fast   : hparams.yarn_beta_fast;
     cparams.yarn_beta_slow          = params.yarn_beta_slow   >= 0.0f ? params.yarn_beta_slow   : hparams.yarn_beta_slow;
     cparams.embeddings              = params.embeddings;
+    cparams.no_logits_for_embeddings = params.no_logits_for_embeddings;
     cparams.embeddings_nextn        = false;
     cparams.embeddings_nextn_masked = false;
     cparams.offload_kqv             = params.offload_kqv;
@@ -868,13 +869,13 @@ int64_t llama_context::output_resolve_row(int32_t i) const {
 }
 
 float * llama_context::get_logits_ith(int32_t i) {
+    if (logits.data == nullptr) {
+        return nullptr;
+    }
+
     output_reorder();
 
     try {
-        if (logits.data == nullptr) {
-            throw std::runtime_error("no logits");
-        }
-
         const int64_t j = output_resolve_row(i);
         return logits.data + j*model.vocab.n_tokens();
     } catch (const std::exception & err) {
@@ -2083,13 +2084,14 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
     const auto n_embd     = hparams.n_embd;
     const auto n_embd_out = hparams.n_embd_out();
 
-    bool has_logits     = true;
+    const bool skip_logits = llama_skip_logits_for_embeddings(cparams, !sampling.samplers.empty());
+
+    bool has_logits     = !skip_logits;
     bool has_embd       = cparams.embeddings;
     bool has_embd_nextn = cparams.embeddings_nextn;
 
     // TODO: hacky enc-dec support
     if (model.arch == LLM_ARCH_T5) {
-        has_logits = true;
         has_embd   = true;
     }
 
@@ -3463,42 +3465,43 @@ void llama_context::opt_epoch(
 
 llama_context_params llama_context_default_params() {
     llama_context_params result = {
-        /*.n_ctx                       =*/ 512,
-        /*.n_batch                     =*/ 2048,
-        /*.n_ubatch                    =*/ 512,
-        /*.n_seq_max                   =*/ 1,
-        /*.n_rs_seq                    =*/ 0,
-        /*.n_outputs_max               =*/ 0,
-        /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
-        /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
-        /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,
-        /*.rope_scaling_type           =*/ LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED,
-        /*.pooling_type                =*/ LLAMA_POOLING_TYPE_UNSPECIFIED,
-        /*.attention_type              =*/ LLAMA_ATTENTION_TYPE_UNSPECIFIED,
-        /*.flash_attn_type             =*/ LLAMA_FLASH_ATTN_TYPE_AUTO,
-        /*.rope_freq_base              =*/ 0.0f,
-        /*.rope_freq_scale             =*/ 0.0f,
-        /*.yarn_ext_factor             =*/ -1.0f,
-        /*.yarn_attn_factor            =*/ -1.0f,
-        /*.yarn_beta_fast              =*/ -1.0f,
-        /*.yarn_beta_slow              =*/ -1.0f,
-        /*.yarn_orig_ctx               =*/ 0,
-        /*.defrag_thold                =*/ -1.0f,
-        /*.cb_eval                     =*/ nullptr,
-        /*.cb_eval_user_data           =*/ nullptr,
-        /*.type_k                      =*/ GGML_TYPE_F16,
-        /*.type_v                      =*/ GGML_TYPE_F16,
-        /*.abort_callback              =*/ nullptr,
-        /*.abort_callback_data         =*/ nullptr,
-        /*.embeddings                  =*/ false,
-        /*.offload_kqv                 =*/ true,
-        /*.no_perf                     =*/ true,
-        /*.op_offload                  =*/ true,
-        /*.swa_full                    =*/ true,
-        /*.kv_unified                  =*/ false,
-        /*.sampler                     =*/ nullptr,
-        /*.n_sampler                   =*/ 0,
-        /*.ctx_other                   =*/ nullptr,
+        /*.n_ctx                       =*/512,
+        /*.n_batch                     =*/2048,
+        /*.n_ubatch                    =*/512,
+        /*.n_seq_max                   =*/1,
+        /*.n_rs_seq                    =*/0,
+        /*.n_outputs_max               =*/0,
+        /*.n_threads                   =*/GGML_DEFAULT_N_THREADS,  // TODO: better default
+        /*.n_threads_batch             =*/GGML_DEFAULT_N_THREADS,
+        /*.ctx_type                    =*/LLAMA_CONTEXT_TYPE_DEFAULT,
+        /*.rope_scaling_type           =*/LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED,
+        /*.pooling_type                =*/LLAMA_POOLING_TYPE_UNSPECIFIED,
+        /*.attention_type              =*/LLAMA_ATTENTION_TYPE_UNSPECIFIED,
+        /*.flash_attn_type             =*/LLAMA_FLASH_ATTN_TYPE_AUTO,
+        /*.rope_freq_base              =*/0.0f,
+        /*.rope_freq_scale             =*/0.0f,
+        /*.yarn_ext_factor             =*/-1.0f,
+        /*.yarn_attn_factor            =*/-1.0f,
+        /*.yarn_beta_fast              =*/-1.0f,
+        /*.yarn_beta_slow              =*/-1.0f,
+        /*.yarn_orig_ctx               =*/0,
+        /*.defrag_thold                =*/-1.0f,
+        /*.cb_eval                     =*/nullptr,
+        /*.cb_eval_user_data           =*/nullptr,
+        /*.type_k                      =*/GGML_TYPE_F16,
+        /*.type_v                      =*/GGML_TYPE_F16,
+        /*.abort_callback              =*/nullptr,
+        /*.abort_callback_data         =*/nullptr,
+        /*.embeddings                  =*/false,
+        /*.offload_kqv                 =*/true,
+        /*.no_perf                     =*/true,
+        /*.op_offload                  =*/true,
+        /*.swa_full                    =*/true,
+        /*.kv_unified                  =*/false,
+        /*.no_logits_for_embeddings    =*/false,
+        /*.sampler                     =*/nullptr,
+        /*.n_sampler                   =*/0,
+        /*.ctx_other                   =*/nullptr,
     };
 
     return result;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -32,6 +32,7 @@ struct llama_cparams {
     float yarn_beta_slow;
 
     bool embeddings;
+    bool no_logits_for_embeddings;
     bool embeddings_nextn;        // also extract the hidden state before the final output norm
     bool embeddings_nextn_masked; // extract for only rows where batch.logits != 0
     bool causal_attn;
@@ -63,3 +64,8 @@ struct llama_cparams {
 
     llama_context * ctx_other;
 };
+
+inline bool llama_skip_logits_for_embeddings(const llama_cparams & cparams, bool has_backend_samplers) {
+    return cparams.embeddings && cparams.no_logits_for_embeddings && cparams.ctx_type == LLAMA_CONTEXT_TYPE_DEFAULT &&
+           !has_backend_samplers;
+}

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1371,7 +1371,20 @@ void llm_graph_context::cb(ggml_tensor * cur, const char * name, int il) const {
     }
 }
 
+bool llm_graph_context::should_build_logits() const {
+    return !llama_skip_logits_for_embeddings(cparams, !samplers.empty());
+}
 
+void llm_graph_context::build_output() const {
+    if (!should_build_logits()) {
+        res->t_logits = nullptr;
+    }
+
+    ggml_tensor * output = res->t_logits ? res->t_logits : res->t_embd;
+
+    GGML_ASSERT(output != nullptr);
+    ggml_build_forward_expand(gf, output);
+}
 
 ggml_tensor * llm_graph_context::build_cvec(
          ggml_tensor * cur,

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -772,16 +772,12 @@ struct llm_graph_params {
             return false;
         }
 
-        return
-            cparams.embeddings              == other.cparams.embeddings              &&
-            cparams.embeddings_nextn        == other.cparams.embeddings_nextn        &&
-            cparams.embeddings_nextn_masked == other.cparams.embeddings_nextn_masked &&
-            cparams.causal_attn             == other.cparams.causal_attn             &&
-            arch  == other.arch  &&
-            gtype == other.gtype &&
-            cvec  == other.cvec  &&
-            loras == other.loras &&
-            cross == other.cross;
+        return cparams.embeddings == other.cparams.embeddings &&
+               cparams.no_logits_for_embeddings == other.cparams.no_logits_for_embeddings &&
+               cparams.embeddings_nextn == other.cparams.embeddings_nextn &&
+               cparams.embeddings_nextn_masked == other.cparams.embeddings_nextn_masked &&
+               cparams.causal_attn == other.cparams.causal_attn && arch == other.arch && gtype == other.gtype &&
+               cvec == other.cvec && loras == other.loras && cross == other.cross;
     }
 };
 
@@ -941,6 +937,9 @@ struct llm_graph_context {
     virtual ~llm_graph_context() = default;
 
     void cb(ggml_tensor * cur, const char * name, int il) const;
+
+    bool should_build_logits() const;
+    void build_output() const;
 
     //
     // common

--- a/src/models/afmoe.cpp
+++ b/src/models/afmoe.cpp
@@ -281,5 +281,5 @@ llama_model_afmoe::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/apertus.cpp
+++ b/src/models/apertus.cpp
@@ -166,5 +166,5 @@ llama_model_apertus::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/arcee.cpp
+++ b/src/models/arcee.cpp
@@ -153,5 +153,5 @@ llama_model_arcee::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/arctic.cpp
+++ b/src/models/arctic.cpp
@@ -176,5 +176,5 @@ llama_model_arctic::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/arwkv7.cpp
+++ b/src/models/arwkv7.cpp
@@ -198,5 +198,5 @@ llama_model_arwkv7::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/baichuan.cpp
+++ b/src/models/baichuan.cpp
@@ -151,5 +151,5 @@ llama_model_baichuan::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/bailingmoe.cpp
+++ b/src/models/bailingmoe.cpp
@@ -176,5 +176,5 @@ llama_model_bailingmoe::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/bailingmoe2.cpp
+++ b/src/models/bailingmoe2.cpp
@@ -210,5 +210,5 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/bitnet.cpp
+++ b/src/models/bitnet.cpp
@@ -166,5 +166,5 @@ llama_model_bitnet::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/bloom.cpp
+++ b/src/models/bloom.cpp
@@ -147,5 +147,5 @@ llama_model_bloom::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/chameleon.cpp
+++ b/src/models/chameleon.cpp
@@ -200,5 +200,5 @@ llama_model_chameleon::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/chatglm.cpp
+++ b/src/models/chatglm.cpp
@@ -157,5 +157,5 @@ llama_model_chatglm::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/codeshell.cpp
+++ b/src/models/codeshell.cpp
@@ -149,5 +149,5 @@ llama_model_codeshell::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/cogvlm.cpp
+++ b/src/models/cogvlm.cpp
@@ -154,5 +154,5 @@ llama_model_cogvlm::graph::graph(const llama_model & model, const llm_graph_para
     cur = build_lora_mm(model.output, cur, model.output_s);
     cb(cur, "result_output", -1);
     res->t_logits = cur;
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/cohere2.cpp
+++ b/src/models/cohere2.cpp
@@ -157,5 +157,5 @@ llama_model_cohere2::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/cohere2moe.cpp
+++ b/src/models/cohere2moe.cpp
@@ -289,7 +289,7 @@ llama_model_cohere2moe::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 llama_model_cohere2moe::graph_mtp::graph_mtp(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
@@ -439,5 +439,5 @@ llama_model_cohere2moe::graph_mtp::graph_mtp(const llama_model & model, const ll
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/command-r.cpp
+++ b/src/models/command-r.cpp
@@ -140,5 +140,5 @@ llama_model_command_r::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/dbrx.cpp
+++ b/src/models/dbrx.cpp
@@ -150,5 +150,5 @@ llama_model_dbrx::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/deci.cpp
+++ b/src/models/deci.cpp
@@ -187,5 +187,5 @@ llama_model_deci::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/deepseek.cpp
+++ b/src/models/deepseek.cpp
@@ -190,5 +190,5 @@ llama_model_deepseek::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/deepseek2.cpp
+++ b/src/models/deepseek2.cpp
@@ -434,5 +434,5 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/deepseek32.cpp
+++ b/src/models/deepseek32.cpp
@@ -502,5 +502,5 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/deepseek4.cpp
+++ b/src/models/deepseek4.cpp
@@ -1195,5 +1195,5 @@ llama_model_deepseek4::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -289,5 +289,5 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/dots1.cpp
+++ b/src/models/dots1.cpp
@@ -189,5 +189,5 @@ llama_model_dots1::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/dream.cpp
+++ b/src/models/dream.cpp
@@ -134,5 +134,5 @@ llama_model_dream::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/ernie4-5-moe.cpp
+++ b/src/models/ernie4-5-moe.cpp
@@ -129,5 +129,5 @@ llama_model_ernie4_5_moe::graph::graph(const llama_model & model, const llm_grap
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/ernie4-5.cpp
+++ b/src/models/ernie4-5.cpp
@@ -160,5 +160,5 @@ llama_model_ernie4_5::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/exaone-moe.cpp
+++ b/src/models/exaone-moe.cpp
@@ -240,5 +240,5 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/exaone.cpp
+++ b/src/models/exaone.cpp
@@ -132,5 +132,5 @@ llama_model_exaone::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/exaone4.cpp
+++ b/src/models/exaone4.cpp
@@ -187,7 +187,7 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // Explicit template instantiations

--- a/src/models/falcon-h1.cpp
+++ b/src/models/falcon-h1.cpp
@@ -205,5 +205,5 @@ llama_model_falcon_h1::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/falcon.cpp
+++ b/src/models/falcon.cpp
@@ -157,5 +157,5 @@ llama_model_falcon::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/gemma.cpp
+++ b/src/models/gemma.cpp
@@ -135,5 +135,5 @@ llama_model_gemma::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/gemma2.cpp
+++ b/src/models/gemma2.cpp
@@ -173,5 +173,5 @@ llama_model_gemma2::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/gemma3.cpp
+++ b/src/models/gemma3.cpp
@@ -218,7 +218,7 @@ llama_model_gemma3::graph<iswa>::graph(const llama_model & model, const llm_grap
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 template struct llama_model_gemma3::graph<false>;

--- a/src/models/gemma3n.cpp
+++ b/src/models/gemma3n.cpp
@@ -307,7 +307,7 @@ llama_model_gemma3n::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 ggml_tensor * llama_model_gemma3n::graph::calc_magnitude(ggml_tensor * x) {

--- a/src/models/gemma4.cpp
+++ b/src/models/gemma4.cpp
@@ -432,7 +432,7 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
     // apply logits bias if needed (e.g. for gemma4_unified patch)
     // this is to mirror the suppress_tokens patch on transformers, to avoid model from outputing <image|> and <audio|> tokens (which is a known issue related to the checkpoint)
     // TODO: maybe handle this inside the sampling system in the future
-    if (!model.vocab.get_suppress_tokens().empty()) {
+    if (should_build_logits() && !model.vocab.get_suppress_tokens().empty()) {
         auto inp_bias = std::make_unique<llm_graph_input_logits_bias>(model.vocab);
         inp_bias->logits_bias = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, inp_bias->arr.size());
         cur = ggml_add(ctx0, cur, inp_bias->logits_bias);
@@ -442,7 +442,7 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // equivalent to get_per_layer_inputs() in python code

--- a/src/models/glm4-moe.cpp
+++ b/src/models/glm4-moe.cpp
@@ -276,5 +276,5 @@ llama_model_glm4_moe::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/glm4.cpp
+++ b/src/models/glm4.cpp
@@ -186,5 +186,5 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/gpt2.cpp
+++ b/src/models/gpt2.cpp
@@ -144,5 +144,5 @@ llama_model_gpt2::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/gptneox.cpp
+++ b/src/models/gptneox.cpp
@@ -215,5 +215,5 @@ llama_model_gptneox::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/granite-hybrid.cpp
+++ b/src/models/granite-hybrid.cpp
@@ -195,7 +195,7 @@ llama_model_granite_hybrid::graph::graph(const llama_model & model, const llm_gr
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 ggml_tensor * llama_model_granite_hybrid::graph::build_attention_layer(ggml_tensor *             cur,

--- a/src/models/granite.cpp
+++ b/src/models/granite.cpp
@@ -189,7 +189,7 @@ llama_model_granite::graph::graph(
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 ggml_tensor * llama_model_granite::graph::build_attention_layer(

--- a/src/models/grok.cpp
+++ b/src/models/grok.cpp
@@ -219,5 +219,5 @@ llama_model_grok::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/grovemoe.cpp
+++ b/src/models/grovemoe.cpp
@@ -189,5 +189,5 @@ llama_model_grovemoe::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/hunyuan-moe.cpp
+++ b/src/models/hunyuan-moe.cpp
@@ -183,5 +183,5 @@ llama_model_hunyuan_moe::graph::graph(const llama_model & model, const llm_graph
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/hunyuan-vl.cpp
+++ b/src/models/hunyuan-vl.cpp
@@ -185,5 +185,5 @@ llama_model_hunyuan_vl::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/hy-v3.cpp
+++ b/src/models/hy-v3.cpp
@@ -227,7 +227,7 @@ llama_model_hy_v3::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // LLM_GRAPH_TYPE_DECODER_MTP draft head for HY V3 (MoE).
@@ -386,5 +386,5 @@ llama_model_hy_v3::graph_mtp::graph_mtp(const llama_model & model, const llm_gra
     cb(cur, "result_output", -1);
 
     res->t_logits = cur;
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/internlm2.cpp
+++ b/src/models/internlm2.cpp
@@ -135,5 +135,5 @@ llama_model_internlm2::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/jais.cpp
+++ b/src/models/jais.cpp
@@ -128,5 +128,5 @@ llama_model_jais::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/jais2.cpp
+++ b/src/models/jais2.cpp
@@ -157,5 +157,5 @@ llama_model_jais2::graph::graph(const llama_model & model, const llm_graph_param
 
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/jamba.cpp
+++ b/src/models/jamba.cpp
@@ -194,5 +194,5 @@ llama_model_jamba::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/kimi-linear.cpp
+++ b/src/models/kimi-linear.cpp
@@ -546,5 +546,5 @@ llama_model_kimi_linear::graph::graph(const llama_model & model, const llm_graph
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/llada-moe.cpp
+++ b/src/models/llada-moe.cpp
@@ -159,5 +159,5 @@ llama_model_llada_moe::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/llada.cpp
+++ b/src/models/llada.cpp
@@ -154,5 +154,5 @@ llama_model_llada::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -236,14 +236,16 @@ llama_model_llama::graph<embed>::graph(const llama_model & model, const llm_grap
     res->t_embd = cur;
 
     if constexpr (!embed) {
-        // lm_head
-        cur = build_lora_mm(model.output, cur, model.output_s);
+        if (should_build_logits()) {
+            // lm_head
+            cur = build_lora_mm(model.output, cur, model.output_s);
 
-        cb(cur, "result_output", -1);
-        res->t_logits = cur;
+            cb(cur, "result_output", -1);
+            res->t_logits = cur;
+        }
     }
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 template struct llama_model_llama::graph<false>;

--- a/src/models/llama4.cpp
+++ b/src/models/llama4.cpp
@@ -266,7 +266,7 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // Explicit template instantiations

--- a/src/models/maincoder.cpp
+++ b/src/models/maincoder.cpp
@@ -147,5 +147,5 @@ llama_model_maincoder::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/mamba.cpp
+++ b/src/models/mamba.cpp
@@ -133,5 +133,5 @@ llama_model_mamba::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/mellum.cpp
+++ b/src/models/mellum.cpp
@@ -218,7 +218,7 @@ llama_model_mellum::graph<iswa>::graph(const llama_model & model, const llm_grap
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 template struct llama_model_mellum::graph<false>;

--- a/src/models/mimo2.cpp
+++ b/src/models/mimo2.cpp
@@ -231,5 +231,5 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/minicpm3.cpp
+++ b/src/models/minicpm3.cpp
@@ -256,5 +256,5 @@ llama_model_minicpm3::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/minimax-m2.cpp
+++ b/src/models/minimax-m2.cpp
@@ -165,5 +165,5 @@ llama_model_minimax_m2::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/mistral3.cpp
+++ b/src/models/mistral3.cpp
@@ -231,5 +231,5 @@ llama_model_mistral3::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/mpt.cpp
+++ b/src/models/mpt.cpp
@@ -166,5 +166,5 @@ llama_model_mpt::graph::graph(const llama_model & model, const llm_graph_params 
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/nemotron-h.cpp
+++ b/src/models/nemotron-h.cpp
@@ -178,7 +178,7 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 ggml_tensor * llama_model_nemotron_h::graph::build_attention_layer(ggml_tensor *             cur,

--- a/src/models/nemotron.cpp
+++ b/src/models/nemotron.cpp
@@ -146,5 +146,5 @@ llama_model_nemotron::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/olmo.cpp
+++ b/src/models/olmo.cpp
@@ -138,5 +138,5 @@ llama_model_olmo::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/olmo2.cpp
+++ b/src/models/olmo2.cpp
@@ -203,7 +203,7 @@ llama_model_olmo2::graph<iswa>::graph(const llama_model & model, const llm_graph
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // Explicit template instantiations

--- a/src/models/olmoe.cpp
+++ b/src/models/olmoe.cpp
@@ -170,5 +170,5 @@ llama_model_olmoe::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/openai-moe.cpp
+++ b/src/models/openai-moe.cpp
@@ -167,5 +167,5 @@ llama_model_openai_moe::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/openelm.cpp
+++ b/src/models/openelm.cpp
@@ -167,5 +167,5 @@ llama_model_openelm::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/orion.cpp
+++ b/src/models/orion.cpp
@@ -137,5 +137,5 @@ llama_model_orion::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/paddleocr.cpp
+++ b/src/models/paddleocr.cpp
@@ -103,5 +103,5 @@ llama_model_paddleocr::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/pangu-embed.cpp
+++ b/src/models/pangu-embed.cpp
@@ -158,5 +158,5 @@ llama_model_pangu_embed::graph::graph(const llama_model & model, const llm_graph
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/phi2.cpp
+++ b/src/models/phi2.cpp
@@ -138,5 +138,5 @@ llama_model_phi2::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/phi3.cpp
+++ b/src/models/phi3.cpp
@@ -188,7 +188,7 @@ llama_model_phi3::graph<iswa>::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // Explicit template instantiations

--- a/src/models/plamo.cpp
+++ b/src/models/plamo.cpp
@@ -132,5 +132,5 @@ llama_model_plamo::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/plamo2.cpp
+++ b/src/models/plamo2.cpp
@@ -197,7 +197,7 @@ llama_model_plamo2::graph::graph(const llama_model & model, const llm_graph_para
 
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 ggml_tensor * llama_model_plamo2::graph::build_plamo2_attn_layer(llm_graph_input_attn_kv * inp,

--- a/src/models/plamo3.cpp
+++ b/src/models/plamo3.cpp
@@ -189,7 +189,7 @@ llama_model_plamo3::graph<iswa>::graph(const llama_model & model, const llm_grap
     cur = build_lora_mm(model.output, cur, model.output_s);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // Explicit template instantiations

--- a/src/models/plm.cpp
+++ b/src/models/plm.cpp
@@ -210,5 +210,5 @@ llama_model_plm::graph::graph(const llama_model & model, const llm_graph_params 
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen.cpp
+++ b/src/models/qwen.cpp
@@ -136,5 +136,5 @@ llama_model_qwen::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen2.cpp
+++ b/src/models/qwen2.cpp
@@ -150,5 +150,5 @@ llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen2moe.cpp
+++ b/src/models/qwen2moe.cpp
@@ -190,5 +190,5 @@ llama_model_qwen2moe::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen2vl.cpp
+++ b/src/models/qwen2vl.cpp
@@ -139,5 +139,5 @@ llama_model_qwen2vl::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen3.cpp
+++ b/src/models/qwen3.cpp
@@ -155,5 +155,5 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -224,7 +224,7 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 std::pair<ggml_tensor *, ggml_tensor *> llama_model_qwen35::graph::build_qkvz(
@@ -640,5 +640,5 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     cb(cur, "result_output", -1);
 
     res->t_logits = cur;
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -248,7 +248,7 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 std::pair<ggml_tensor *, ggml_tensor *> llama_model_qwen35moe::graph::build_qkvz(
@@ -737,5 +737,5 @@ llama_model_qwen35moe::graph_mtp::graph_mtp(const llama_model & model, const llm
     cb(cur, "result_output", -1);
 
     res->t_logits = cur;
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen3moe.cpp
+++ b/src/models/qwen3moe.cpp
@@ -175,5 +175,5 @@ llama_model_qwen3moe::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen3next.cpp
+++ b/src/models/qwen3next.cpp
@@ -183,7 +183,7 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // utility to get one slice from the third dimension

--- a/src/models/qwen3vl.cpp
+++ b/src/models/qwen3vl.cpp
@@ -169,5 +169,5 @@ llama_model_qwen3vl::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/qwen3vlmoe.cpp
+++ b/src/models/qwen3vlmoe.cpp
@@ -186,5 +186,5 @@ llama_model_qwen3vlmoe::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/refact.cpp
+++ b/src/models/refact.cpp
@@ -156,5 +156,5 @@ llama_model_refact::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/rnd1.cpp
+++ b/src/models/rnd1.cpp
@@ -173,5 +173,5 @@ llama_model_rnd1::graph::graph(const llama_model & model, const llm_graph_params
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/rwkv6.cpp
+++ b/src/models/rwkv6.cpp
@@ -181,5 +181,5 @@ llama_model_rwkv6::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/rwkv6qwen2.cpp
+++ b/src/models/rwkv6qwen2.cpp
@@ -163,5 +163,5 @@ llama_model_rwkv6qwen2::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/rwkv7.cpp
+++ b/src/models/rwkv7.cpp
@@ -207,5 +207,5 @@ llama_model_rwkv7::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/seed-oss.cpp
+++ b/src/models/seed-oss.cpp
@@ -147,5 +147,5 @@ llama_model_seed_oss::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/smallthinker.cpp
+++ b/src/models/smallthinker.cpp
@@ -182,7 +182,7 @@ llama_model_smallthinker::graph<iswa>::graph(const llama_model & model, const ll
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // Explicit template instantiations

--- a/src/models/smollm3.cpp
+++ b/src/models/smollm3.cpp
@@ -148,5 +148,5 @@ llama_model_smollm3::graph::graph(const llama_model & model, const llm_graph_par
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/stablelm.cpp
+++ b/src/models/stablelm.cpp
@@ -168,5 +168,5 @@ llama_model_stablelm::graph::graph(const llama_model & model, const llm_graph_pa
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/starcoder.cpp
+++ b/src/models/starcoder.cpp
@@ -141,5 +141,5 @@ llama_model_starcoder::graph::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/starcoder2.cpp
+++ b/src/models/starcoder2.cpp
@@ -154,5 +154,5 @@ llama_model_starcoder2::graph::graph(const llama_model & model, const llm_graph_
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/step35.cpp
+++ b/src/models/step35.cpp
@@ -359,7 +359,7 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 // LLM_GRAPH_TYPE_DECODER_MTP draft head for Step3p5 (MoE)
@@ -552,5 +552,5 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     cb(cur, "result_output", -1);
 
     res->t_logits = cur;
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/t5.cpp
+++ b/src/models/t5.cpp
@@ -270,7 +270,7 @@ llama_model_t5::graph<false>::graph(const llama_model & model, const llm_graph_p
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }
 
 template <>

--- a/src/models/talkie.cpp
+++ b/src/models/talkie.cpp
@@ -145,5 +145,5 @@ llama_model_talkie::graph::graph(const llama_model & model, const llm_graph_para
 
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/src/models/xverse.cpp
+++ b/src/models/xverse.cpp
@@ -132,5 +132,5 @@ llama_model_xverse::graph::graph(const llama_model & model, const llm_graph_para
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+    build_output();
 }

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -127,6 +127,13 @@ static void test(void) {
     assert(params.n_predict == 6789);
     assert(params.n_batch == 9090);
 
+    common_params embedding_params;
+    argv = { "binary_name", "-m", "model_file.gguf", "--no-logits-for-embeddings" };
+    assert(true ==
+           common_params_parse(argv.size(), list_str_to_char(argv).data(), embedding_params, LLAMA_EXAMPLE_EMBEDDING));
+    assert(embedding_params.no_logits_for_embeddings);
+    assert(common_context_params_to_llama(embedding_params).no_logits_for_embeddings);
+
     // --draft cannot be used outside llama-speculative
     argv = {"binary_name", "--spec-draft-n-max", "123"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -22,6 +22,10 @@
 #include <utility>
 #include <vector>
 
+static_assert(offsetof(llama_context_params, no_logits_for_embeddings) ==
+                  offsetof(llama_context_params, kv_unified) + sizeof(bool),
+              "new llama_context_params booleans must be appended after existing fields");
+
 // normalized mean squared error = mse(a, b) / mse(a, 0)
 static double nmse(const std::vector<float> & a, const std::vector<float> & b) {
     GGML_ASSERT(a.size() == b.size());
@@ -203,6 +207,10 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
     ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,      uint32_t(8));
     ms.add_kv(LLM_KV_ROPE_DIMENSION_SECTIONS, std::vector<uint32_t>({n_embd_head/4, n_embd_head/4, n_embd_head/4, n_embd_head/4}));
     ms.add_kv(LLM_KV_TOKENIZER_MODEL,         "no_vocab");
+    if (arch == LLM_ARCH_BERT) {
+        // BERT requires a nonzero token type count even when the optional type embedding is absent.
+        ms.add_kv(LLM_KV_TOKENIZER_TOKEN_TYPE_COUNT, uint32_t(1));
+    }
     // ms.add_kv(LLM_KV_DENSE_2_FEAT_OUT,     n_embd);
     // ms.add_kv(LLM_KV_DENSE_3_FEAT_IN,      n_embd);
 
@@ -319,6 +327,218 @@ static std::vector<float> get_logits(
     }
     llama_batch_free(batch);
     return ret;
+}
+
+static std::vector<float> get_embeddings(llama_model *                    model,
+                                         llama_context *                  lctx,
+                                         const std::vector<llama_token> & tokens) {
+    const uint32_t n_embd   = llama_model_n_embd(model);
+    const uint32_t n_tokens = tokens.size();
+
+    llama_batch batch = llama_batch_init(n_tokens, 0, 1);
+    for (uint32_t pos = 0; pos < n_tokens; pos++) {
+        common_batch_add(batch, tokens[pos], pos, { 0 }, true);
+    }
+    batch.n_tokens = n_tokens;
+
+    if (llama_decode(lctx, batch) != 0) {
+        llama_batch_free(batch);
+        throw std::runtime_error("failed to decode embedding batch");
+    }
+
+    std::vector<float> ret;
+    ret.reserve(n_tokens * n_embd);
+    for (uint32_t i = 0; i < n_tokens; i++) {
+        const float * embd_ith = llama_get_embeddings_ith(lctx, i);
+        if (embd_ith == nullptr) {
+            llama_batch_free(batch);
+            throw std::runtime_error("failed to get embedding output");
+        }
+        ret.insert(ret.end(), embd_ith, embd_ith + n_embd);
+    }
+
+    llama_batch_free(batch);
+    return ret;
+}
+
+static std::vector<float> get_pooled_embedding(llama_model *                    model,
+                                               llama_context *                  lctx,
+                                               const std::vector<llama_token> & tokens) {
+    const uint32_t n_embd   = llama_model_n_embd(model);
+    const uint32_t n_tokens = tokens.size();
+
+    llama_batch batch = llama_batch_init(n_tokens, 0, 1);
+    for (uint32_t pos = 0; pos < n_tokens; pos++) {
+        common_batch_add(batch, tokens[pos], pos, { 0 }, true);
+    }
+    batch.n_tokens = n_tokens;
+
+    if (llama_decode(lctx, batch) != 0) {
+        llama_batch_free(batch);
+        throw std::runtime_error("failed to decode pooled embedding batch");
+    }
+
+    const float * embd = llama_get_embeddings_seq(lctx, 0);
+    if (embd == nullptr) {
+        llama_batch_free(batch);
+        throw std::runtime_error("failed to get pooled embedding output");
+    }
+
+    std::vector<float> ret(embd, embd + n_embd);
+    llama_batch_free(batch);
+    return ret;
+}
+
+struct graph_node_observer {
+    bool saw_result_output = false;
+};
+
+static bool observe_graph_node(ggml_tensor * tensor, bool ask, void * user_data) {
+    if (ask) {
+        auto * observer = static_cast<graph_node_observer *>(user_data);
+        observer->saw_result_output |= strcmp(tensor->name, "result_output") == 0;
+    }
+
+    return false;
+}
+
+static void test_embedding_no_logits(const llm_arch arch, const size_t seed) {
+    constexpr uint32_t n_tokens = 4;
+
+    gguf_context_ptr gguf_ctx      = get_gguf_ctx(arch, false);
+    auto             model_and_ctx = get_model_and_ctx(gguf_ctx.get(), nullptr, seed, {});
+    llama_model_ptr  model         = std::move(model_and_ctx.first);
+    model_and_ctx.second.reset();
+
+    llama_context_params params = llama_context_default_params();
+    params.n_ctx                = n_tokens;
+    params.n_batch              = n_tokens;
+    params.n_ubatch             = n_tokens;
+    params.embeddings           = true;
+    params.pooling_type         = LLAMA_POOLING_TYPE_NONE;
+
+    const std::vector<llama_token> tokens = get_tokens(n_tokens, 128, seed);
+
+    graph_node_observer observer_with_logits;
+    params.cb_eval           = observe_graph_node;
+    params.cb_eval_user_data = &observer_with_logits;
+    llama_context_ptr ctx_with_logits(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_with_logits != nullptr);
+    const std::vector<float> embeddings_with_logits = get_embeddings(model.get(), ctx_with_logits.get(), tokens);
+    GGML_ASSERT(llama_get_logits(ctx_with_logits.get()) != nullptr);
+    GGML_ASSERT(observer_with_logits.saw_result_output);
+
+    params.no_logits_for_embeddings = true;
+    graph_node_observer observer_without_logits;
+    params.cb_eval_user_data = &observer_without_logits;
+    llama_context_ptr ctx_without_logits(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_without_logits != nullptr);
+    const std::vector<float> embeddings_without_logits = get_embeddings(model.get(), ctx_without_logits.get(), tokens);
+    GGML_ASSERT(llama_get_logits(ctx_without_logits.get()) == nullptr);
+    GGML_ASSERT(llama_get_logits_ith(ctx_without_logits.get(), 0) == nullptr);
+    GGML_ASSERT(!observer_without_logits.saw_result_output);
+    GGML_ASSERT(embeddings_with_logits == embeddings_without_logits);
+
+    params.pooling_type             = LLAMA_POOLING_TYPE_LAST;
+    params.no_logits_for_embeddings = false;
+    params.cb_eval                  = nullptr;
+    params.cb_eval_user_data        = nullptr;
+    llama_context_ptr ctx_pooled_with_logits(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_pooled_with_logits != nullptr);
+    const std::vector<float> pooled_with_logits =
+        get_pooled_embedding(model.get(), ctx_pooled_with_logits.get(), tokens);
+    GGML_ASSERT(llama_get_logits(ctx_pooled_with_logits.get()) != nullptr);
+
+    params.no_logits_for_embeddings = true;
+    llama_context_ptr ctx_pooled_without_logits(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_pooled_without_logits != nullptr);
+    const std::vector<float> pooled_without_logits =
+        get_pooled_embedding(model.get(), ctx_pooled_without_logits.get(), tokens);
+    GGML_ASSERT(llama_get_logits(ctx_pooled_without_logits.get()) == nullptr);
+    GGML_ASSERT(pooled_with_logits == pooled_without_logits);
+
+    params.embeddings               = false;
+    params.no_logits_for_embeddings = false;
+    params.pooling_type             = LLAMA_POOLING_TYPE_NONE;
+    params.cb_eval                  = nullptr;
+    params.cb_eval_user_data        = nullptr;
+    llama_context_ptr ctx_generation_baseline(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_generation_baseline != nullptr);
+    const std::vector<float> generation_logits_baseline =
+        get_logits(model.get(), ctx_generation_baseline.get(), tokens);
+
+    params.no_logits_for_embeddings = true;
+    llama_context_ptr ctx_generation_with_flag(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_generation_with_flag != nullptr);
+    const std::vector<float> generation_logits_with_flag =
+        get_logits(model.get(), ctx_generation_with_flag.get(), tokens);
+    GGML_ASSERT(generation_logits_baseline == generation_logits_with_flag);
+}
+
+static void test_embedding_no_logits_without_lm_head(const llm_arch arch, const size_t seed) {
+    constexpr uint32_t n_tokens = 4;
+
+    gguf_context_ptr gguf_ctx      = get_gguf_ctx(arch, false);
+    auto             model_and_ctx = get_model_and_ctx(gguf_ctx.get(), nullptr, seed, {});
+    llama_model_ptr  model         = std::move(model_and_ctx.first);
+    model_and_ctx.second.reset();
+
+    llama_context_params params = llama_context_default_params();
+    params.n_ctx                = n_tokens;
+    params.n_batch              = n_tokens;
+    params.n_ubatch             = n_tokens;
+    params.embeddings           = true;
+    params.pooling_type         = LLAMA_POOLING_TYPE_NONE;
+
+    const std::vector<llama_token> tokens = get_tokens(n_tokens, 128, seed);
+
+    llama_context_ptr ctx_with_logits(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_with_logits != nullptr);
+    const std::vector<float> embeddings_with_logits = get_embeddings(model.get(), ctx_with_logits.get(), tokens);
+    GGML_ASSERT(llama_get_logits(ctx_with_logits.get()) != nullptr);
+
+    params.no_logits_for_embeddings = true;
+    llama_context_ptr ctx_without_logits(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx_without_logits != nullptr);
+    const std::vector<float> embeddings_without_logits = get_embeddings(model.get(), ctx_without_logits.get(), tokens);
+    GGML_ASSERT(llama_get_logits(ctx_without_logits.get()) == nullptr);
+    GGML_ASSERT(embeddings_with_logits == embeddings_without_logits);
+}
+
+static void test_embedding_no_logits_with_backend_sampler(const size_t seed) {
+    constexpr uint32_t n_tokens = 1;
+
+    gguf_context_ptr gguf_ctx      = get_gguf_ctx(LLM_ARCH_QWEN3, false);
+    auto             model_and_ctx = get_model_and_ctx(gguf_ctx.get(), nullptr, seed, {});
+    llama_model_ptr  model         = std::move(model_and_ctx.first);
+    model_and_ctx.second.reset();
+
+    llama_sampler_ptr sampler_chain(llama_sampler_chain_init(llama_sampler_chain_default_params()));
+    llama_sampler_chain_add(sampler_chain.get(), llama_sampler_init_greedy());
+    std::vector<llama_sampler_seq_config> sampler_configs = {
+        {0, sampler_chain.get()}
+    };
+
+    llama_context_params params     = llama_context_default_params();
+    params.n_ctx                    = n_tokens;
+    params.n_batch                  = n_tokens;
+    params.n_ubatch                 = n_tokens;
+    params.embeddings               = true;
+    params.no_logits_for_embeddings = true;
+    params.pooling_type             = LLAMA_POOLING_TYPE_NONE;
+    params.samplers                 = sampler_configs.data();
+    params.n_samplers               = sampler_configs.size();
+
+    graph_node_observer observer;
+    params.cb_eval           = observe_graph_node;
+    params.cb_eval_user_data = &observer;
+    llama_context_ptr ctx(llama_init_from_model(model.get(), params));
+    GGML_ASSERT(ctx != nullptr);
+
+    const std::vector<llama_token> tokens = get_tokens(n_tokens, 128, seed);
+    get_embeddings(model.get(), ctx.get(), tokens);
+    GGML_ASSERT(llama_get_logits(ctx.get()) != nullptr);
+    GGML_ASSERT(observer.saw_result_output);
 }
 
 static bool moe_mandatory(const llm_arch arch) {
@@ -698,6 +918,11 @@ int main(int argc, char ** argv) {
         if (!out.empty()) {
             return save_models(arch, seed, log_level, out);
         }
+        test_embedding_no_logits(LLM_ARCH_QWEN3, seed);
+        test_embedding_no_logits(LLM_ARCH_LLAMA, seed);
+        test_embedding_no_logits_without_lm_head(LLM_ARCH_BERT, seed);
+        test_embedding_no_logits_without_lm_head(LLM_ARCH_LLAMA_EMBED, seed);
+        test_embedding_no_logits_with_backend_sampler(seed);
         return test_backends(arch, seed, log_level);
     } catch (const std::exception & err) {
         fprintf(stderr, "encountered runtime error: %s\n", err.what());

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -173,6 +173,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--warmup, --no-warmup` | whether to perform warmup with an empty run (default: enabled) |
 | `--spm-infill` | use Suffix/Prefix/Middle pattern for infill (instead of Prefix/Suffix/Middle) as some models prefer this. (default: disabled) |
 | `--pooling {none,mean,cls,last,rank}` | pooling type for embeddings, use model default if unspecified<br/>(env: LLAMA_ARG_POOLING) |
+| `--no-logits-for-embeddings` | skip raw logits and the LM head when extracting embeddings without backend samplers<br/>(env: LLAMA_ARG_NO_LOGITS_FOR_EMBEDDINGS) |
 | `-np, --parallel N` | number of server slots (default: -1, -1 = auto)<br/>(env: LLAMA_ARG_N_PARALLEL) |
 | `-cb, --cont-batching, -nocb, --no-cont-batching` | whether to enable continuous batching (a.k.a dynamic batching) (default: enabled)<br/>(env: LLAMA_ARG_CONT_BATCHING) |
 | `-mm, --mmproj FILE` | path to a multimodal projector file. see tools/mtmd/README.md<br/>note: if -hf is used, this argument can be omitted<br/>(env: LLAMA_ARG_MMPROJ) |


### PR DESCRIPTION
## Overview

This PR adds the no-logits mode which is an optional optimization for embedding workloads. When a causal model is used only for embeddings, the request needs the hidden states and pooled embeddings, but the regular path may still run the vocabulary projection and copy the unused logits to host memory. Enabling this mode skips that extra work while leaving the embedding calculation itself unchanged.

## Additional information

- `llama_context_params` now includes a public `no_logits_for_embeddings` option, which is disabled by default.
- The option is available through `--no-logits-for-embeddings` and `LLAMA_ARG_NO_LOGITS_FOR_EMBEDDINGS`.
- The logits path is bypassed only for embedding requests that enable this option, use `LLAMA_CONTEXT_TYPE_DEFAULT`, and do not configure a backend sampler.
- In that case, the computation graph is built from the embedding tensor rather than the logits tensor, leaving the vocabulary projection or LM head out of the graph.
- Because no logits output is needed, the runtime also skips allocating and copying the host-side raw-logits buffer. On this path, `llama_get_logits()` and `llama_get_logits_ith()` return `NULL`.
- Token-level and pooled embeddings continue to follow the same computation path as before.
- Existing behavior is retained when the option is disabled, as well as for generation, non-embedding requests, and requests that use a backend sampler.
- Graph-cache compatibility checks also take this option into account, so graphs with different output behavior are kept separate.

For example, a Qwen3 embedding request using LAST pooling would normally compute the hidden states and then run the LM head to produce a `[tokens, vocabulary]` logits tensor, even though those logits are not used afterward. With `--no-logits-for-embeddings` enabled, the graph ends at the embedding output instead. LAST pooling still uses the same embedding result, while the LM-head computation and host-side logits buffer are left out.

The tests cover the option from the CLI through to the runtime context. For Llama and Qwen3, they compare the enabled and disabled paths and expect both per-token and pooled embeddings to match exactly. There is also coverage for BERT and Llama Embed models, which do not have an LM head. Additional cases check that eligible embedding requests leave out the LM-head/logits branch, while text-generation and backend-sampler requests continue to produce logits.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used to review the implementation and assist with writing and running tests.<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
