### PR TITLE
ui: re-enable reasoning by default

### DIFF
--- a/tools/ui/src/lib/stores/conversations.svelte.ts
+++ b/tools/ui/src/lib/stores/conversations.svelte.ts
@@ -92,13 +92,13 @@ class ConversationsStore {
 	private lastNonOffEffort: ReasoningEffort | null = null;
 
 	/** Load reasoning effort default from localStorage */
-	private static loadReasoningEffortDefault(): ReasoningEffort | ReasoningEffort.OFF {
-		if (typeof globalThis.localStorage === 'undefined') return ReasoningEffort.OFF;
+	private static loadReasoningEffortDefault(): ReasoningEffort {
+		if (typeof globalThis.localStorage === 'undefined') return ReasoningEffort.MEDIUM;
 		try {
 			const raw = localStorage.getItem(REASONING_EFFORT_DEFAULT_LOCALSTORAGE_KEY);
-			return (raw as ReasoningEffort | ReasoningEffort.OFF) || ReasoningEffort.OFF;
+			return (raw as ReasoningEffort | ReasoningEffort.OFF) || ReasoningEffort.MEDIUM;
 		} catch {
-			return ReasoningEffort.OFF;
+			return ReasoningEffort.MEDIUM;
 		}
 	}
 


### PR DESCRIPTION
## Overview

This makes llama-server match llama-cli's behavior of enabling reasoning by default again.

Upgrading from April's llama.cpp, I thought a regression broke reasoning support. https://www.reddit.com/r/LocalLLaMA/comments/1u2yufo/cant_seem_to_enable_reasoning_in_llamacpp/ shows other people struggling with this. I tried `--reasoning on` and `--reasoning-budget -1` to no avail. Unlike Claude and Gemini which have the thinking option on the model selection button, somehow we have our reasoning limit buried in the multimedia button, where coders and text-only users would never look.

I reenabled reasoning by default. Most people would want to default to using the full capabilities of the model, instead of silently restricting it.

## Additional information

#25340 changed the default from MEDIUM to OFF.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
