### PR TITLE
hexagon: check tensor type when reusing descriptors

### DIFF
--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -1286,7 +1286,8 @@ struct ggml_hexagon_opbatch {
         int64_t nb2 = is_repack ? nb1 * ne1 : t->nb[2];
         int64_t nb3 = is_repack ? nb2 * t->ne[2] : t->nb[3];
 
-        return (h->ne[0] == ne0) && (h->ne[1] == ne1) && (h->ne[2] == t->ne[2]) && (h->ne[3] == t->ne[3]) &&
+        return (h->type == t->type) &&
+               (h->ne[0] == ne0) && (h->ne[1] == ne1) && (h->ne[2] == t->ne[2]) && (h->ne[3] == t->ne[3]) &&
                (h->nb[0] == t->nb[0]) && (h->nb[1] == nb1) && (h->nb[2] == nb2) && (h->nb[3] == nb3);
     }
 


### PR DESCRIPTION
## Overview

This PR fixes incorrect reuse of Hexagon tensor descriptors exposed by Qwen3-VL-2B.

For a full 512-token ubatch, Qwen3-VL's M-RoPE position input tensor is `I32[2048]`, while the `GET_ROWS` output is `F32[2048, 1]`. Since the hexagon op-batch descriptor lookup currently does not compare `type`, the `F32` output can reuse the `I32` descriptor. `GET_ROWS` then returns `HTP_STATUS_NO_SUPPORT` because `dst->type != HTP_TYPE_F32`, and leaves the inference path with invalid logits.

This change includes a `type` check in `same_shape()`, which is only used in `add_tensor()`.

## Additional information
### Reproduction
Tested on Hexagon v73 and v75.
Using [Qwen3-VL-2B-Instruct Q8_0](https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF) on a hexagon device:
```
adb shell "cd /data/local/tmp/llama && \
    LD_LIBRARY_PATH=./lib ADSP_LIBRARY_PATH=./lib \
    ./bin/llama-bench -m /data/local/tmp/gguf/Qwen3VL-2B-Instruct-Q8_0.gguf \
    -p 1024 -n 0 -dev HTP0 -r 1 --no-warmup -v"
```
or
```
adb shell 'cd /data/local/tmp/llama && \
    LD_LIBRARY_PATH=./lib ADSP_LIBRARY_PATH=./lib \
    ./bin/llama-completion -m /data/local/tmp/gguf/Qwen3VL-2B-Instruct-Q8_0.gguf \
    -ngl 99 -dev HTP0 -p "$(printf " test%.0s" $(seq 1016))" -n 32 --temp 0 --no-display-prompt'
```
Before this change, the output contains the error:
```
ggml-hex: HTP0 dspcall : dsp-rsp: NO-SUPPORT
```
And although `llama-completion` produces output, the results do not match the CPU reference.

### Cause
Qwen3-VL-2B has a hidden size of 2048, which happens to align two unrelated dimensions:
- 4 position IDs per token $\times$ 512 (ubatch) tokens = 2048
- hidden size $\times$ one output token = 2048

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Codex was used to assist with the investigation.
