### PR TITLE
common : fix leading pipe syntax error in gbnf_excluding_grammar

### DIFF
--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -1614,14 +1614,12 @@ static std::string gbnf_excluding_grammar(const common_grammar_builder & builder
            const std::map<size_t, std::vector<uint32_t>> & buckets,
            const std::vector<uint32_t> & specific,
            const std::function<std::string(size_t)> & state_name) {
-            // every state is accepting and completing chars get no
-            // alternative, so a forbidden string can never be matched
-            std::string rhs = "|";
+            std::vector<std::string> alts;
             for (const auto & [d, chars] : buckets) {
-                rhs += " " + gbnf_char_class(chars, false) + " " + state_name(d) + " |";
+                alts.push_back(gbnf_char_class(chars, false) + " " + state_name(d));
             }
-            rhs += " " + gbnf_char_class(specific, true) + " " + state_name(0);
-            return rhs;
+            alts.push_back(gbnf_char_class(specific, true) + " " + state_name(0));
+            return string_join(alts, " | ");
         });
 }
 


### PR DESCRIPTION
## Overview

Fixes a GBNF syntax error in `gbnf_excluding_grammar()` inside `common/peg-parser.cpp` (resolving issue #24863).

When generating Aho-Corasick excluding grammars (`gbnf_excluding_grammar`), `std::string rhs = "|";` initialized the RHS string with a leading pipe `|`. This produced invalid GBNF rule definitions starting with a leading pipe, e.g.:
```
until-25-13 ::= | [^\n] until-25
```
As a result, `llama_grammar_parser::parse` failed with `"failed to parse grammar"` during tool-calling.

The fix replaces manual string concatenation starting with `"|"` with `std::vector<std::string> alts` and `string_join(alts, " | ")`, matching the implementation pattern used in `gbnf_including_grammar`.

## Additional information

- Fixes #24863

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
