### PR TITLE
cmake(ppc64le): Add clang toolchain

### DIFF
--- a/cmake/clang.cmake
+++ b/cmake/clang.cmake
@@ -1,0 +1,2 @@
+set( CMAKE_C_COMPILER    clang )
+set( CMAKE_CXX_COMPILER  clang++ )

--- a/docs/build.md
+++ b/docs/build.md
@@ -15,6 +15,7 @@ The following sections describe how to build with different backends and options
 
 * [CPU Build](#cpu-build)
 * [BLAS Build](#blas-build)
+* [Clang Build](#clang-build)
 * [Metal Build](#metal-build)
 * [SYCL](#sycl)
 * [CUDA](#cuda)
@@ -129,6 +130,15 @@ Check [Optimizing and Running LLaMA2 on Intel® CPU](https://builders.intel.com/
 ### Other BLAS libraries
 
 Any other BLAS library can be used by setting the `GGML_BLAS_VENDOR` option. See the [CMake documentation](https://cmake.org/cmake/help/latest/module/FindBLAS.html#blas-lapack-vendors) for a list of supported vendors.
+
+## Clang Build
+
+If you prefer Clang over GCC, you can force Clang using `CMake` on Linux:
+
+```bash
+cmake -B build -DCMAKE_TOOLCHAIN_FILE="$PWD/cmake/clang.cmake"
+cmake --build build --config Release
+```
 
 ## Metal Build
 


### PR DESCRIPTION
## Overview

Yields a nontrivial speedup relative to GCC on POWER9 (ppc64le).

## Additional information

Fixes https://github.com/ggml-org/llama.cpp/discussions/17562

To work around https://github.com/ggml-org/llama.cpp/issues/25376 (until that issue is fixed), Clang/POWER9 users should disable flash attention. That is orthogonal to this PR, and I don't see any reason to block this PR on that issue. Clang (with flash attention disabled) is much faster than GCC (regardless of flash attention) on my POWER9 system.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
