### PR TITLE
Disable pipeline parallelism on -parallel 1

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -421,6 +421,7 @@ llama_context::llama_context(
         // TODO: move these checks to ggml_backend_sched
         // enabling pipeline parallelism in the scheduler increases memory usage, so it is only done when necessary
         bool pipeline_parallel =
+            cparams.n_seq_max > 1 &&
             model.n_devices() > 1 &&
             model.n_gpu_layers() > model.hparams.n_layer_all &&
             model.split_mode() == LLAMA_SPLIT_MODE_LAYER &&


### PR DESCRIPTION
## Overview

This PR disables pipeline parallelism when only one slot (--parallel 1 / -np 1) is served. This saves me 1.2 GB of VRAM.

## Additional information

That additionally allows random startup order of llama.cpp and other GPU workloads (like local whisper) because llama.cpp doesn't dynamically grab more or less VRAM.

Usually non-patched llama.cpp will output "retrying without pipeline parallelism" when limited by VRAM.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
