### PR TITLE
server : preserve context checkpoints across slot save/restore

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2340,6 +2340,103 @@ private:
                 cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024);
     }
 
+    // Context checkpoints are appended to the slot save file, after the llama state
+    // payload. Without them, a restored slot loses the ability to partially reuse its
+    // cache on models that need a checkpoint to roll back to (SWA and hybrid/recurrent
+    // memory): the next divergent prompt then always triggers "forcing full prompt
+    // re-processing due to lack of cache data", even though the restored state is
+    // intact. Checkpoints cannot be recreated from the final state alone (a recurrent
+    // state cannot be rewound), so they have to travel with the save file.
+    static constexpr uint32_t SLOT_CKPT_MAGIC   = 0x504b4353; // "SCKP"
+    static constexpr uint32_t SLOT_CKPT_VERSION = 1;
+
+    static bool ckpt_read(std::ifstream & ifs, void * dst, size_t size) {
+        return bool(ifs.read((char *) dst, size));
+    }
+
+    static bool ckpt_read_buf(std::ifstream & ifs, std::vector<uint8_t> & buf) {
+        uint64_t n = 0;
+        // refuse absurd blob sizes (> 16 GiB) from a corrupted/truncated appendix
+        if (!ckpt_read(ifs, &n, sizeof(n)) || n > (1ull << 34)) {
+            return false;
+        }
+        buf.resize(n);
+        return n == 0 || ckpt_read(ifs, buf.data(), n);
+    }
+
+    static void ckpt_write(std::ofstream & ofs, const void * src, size_t size) {
+        ofs.write((const char *) src, size);
+    }
+
+    static void ckpt_write_buf(std::ofstream & ofs, const std::vector<uint8_t> & buf) {
+        const uint64_t n = buf.size();
+        ckpt_write(ofs, &n, sizeof(n));
+        if (n > 0) {
+            ckpt_write(ofs, buf.data(), n);
+        }
+    }
+
+    void save_slot_checkpoints(const std::string & filepath, const server_slot & slot) const {
+        std::ofstream ofs(filepath, std::ios::binary | std::ios::app);
+        if (!ofs) {
+            SRV_WRN("failed to append context checkpoints to '%s'\n", filepath.c_str());
+            return;
+        }
+        const uint32_t magic   = SLOT_CKPT_MAGIC;
+        const uint32_t version = SLOT_CKPT_VERSION;
+        const uint32_t count   = (uint32_t) slot.prompt.checkpoints.size();
+        ckpt_write(ofs, &magic,   sizeof(magic));
+        ckpt_write(ofs, &version, sizeof(version));
+        ckpt_write(ofs, &count,   sizeof(count));
+        for (const auto & cur : slot.prompt.checkpoints) {
+            ckpt_write(ofs, &cur.n_tokens, sizeof(cur.n_tokens));
+            ckpt_write(ofs, &cur.pos_min,  sizeof(cur.pos_min));
+            ckpt_write(ofs, &cur.pos_max,  sizeof(cur.pos_max));
+            ckpt_write_buf(ofs, cur.data_tgt);
+            ckpt_write_buf(ofs, cur.data_dft);
+            ckpt_write_buf(ofs, cur.data_spec);
+        }
+        SRV_INF("appended %u context checkpoint(s) to '%s'\n", count, filepath.c_str());
+    }
+
+    void load_slot_checkpoints(const std::string & filepath, size_t offset, server_slot & slot) const {
+        std::ifstream ifs(filepath, std::ios::binary);
+        if (!ifs || !ifs.seekg(offset)) {
+            return;
+        }
+        uint32_t magic   = 0;
+        uint32_t version = 0;
+        uint32_t count   = 0;
+        if (!ckpt_read(ifs, &magic, sizeof(magic)) || magic != SLOT_CKPT_MAGIC) {
+            return; // save file without a checkpoint appendix (older format) - nothing to do
+        }
+        if (!ckpt_read(ifs, &version, sizeof(version)) || version != SLOT_CKPT_VERSION ||
+            !ckpt_read(ifs, &count,   sizeof(count))   || count > 1024) {
+            SRV_WRN("invalid context checkpoint appendix in '%s' - ignored\n", filepath.c_str());
+            return;
+        }
+        std::list<common_prompt_checkpoint> checkpoints;
+        for (uint32_t i = 0; i < count; ++i) {
+            common_prompt_checkpoint cur;
+            cur.id_task = -1; // task ids are not meaningful across save/restore
+            if (!ckpt_read(ifs, &cur.n_tokens, sizeof(cur.n_tokens)) ||
+                !ckpt_read(ifs, &cur.pos_min,  sizeof(cur.pos_min))  ||
+                !ckpt_read(ifs, &cur.pos_max,  sizeof(cur.pos_max))  ||
+                !ckpt_read_buf(ifs, cur.data_tgt) ||
+                !ckpt_read_buf(ifs, cur.data_dft) ||
+                !ckpt_read_buf(ifs, cur.data_spec)) {
+                SRV_WRN("truncated context checkpoint appendix in '%s' - ignored\n", filepath.c_str());
+                return;
+            }
+            checkpoints.push_back(std::move(cur));
+        }
+        while (checkpoints.size() > (size_t) params_base.n_ctx_checkpoints) {
+            checkpoints.pop_front();
+        }
+        slot.prompt.checkpoints = std::move(checkpoints);
+        SRV_INF("restored %zu context checkpoint(s) from '%s'\n", slot.prompt.checkpoints.size(), filepath.c_str());
+    }
+
     void process_single_task(server_task && task) {
         switch (task.type) {
             case SERVER_TASK_TYPE_COMPLETION:
@@ -2535,6 +2632,12 @@ private:
                     const size_t token_count = tokens.size();
                     const size_t nwrite = llama_state_seq_save_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
 
+                    // append the context checkpoints so that a restore can preserve
+                    // partial cache reuse (see SLOT_RESTORE below)
+                    if (nwrite > 0) {
+                        save_slot_checkpoints(filepath, *slot);
+                    }
+
                     const int64_t t_end = ggml_time_us();
                     const double t_save_ms = (t_end - t_start) / 1000.0;
 
@@ -2580,6 +2683,13 @@ private:
                     tokens.resize(token_count);
                     slot->prompt.clear();
                     slot->prompt.tokens.insert(tokens);
+
+                    // restore the context checkpoints appended to the save file (if any):
+                    // slot->prompt.clear() above discarded the slot's checkpoints, and without
+                    // them SWA and hybrid/recurrent memory models cannot partially reuse the
+                    // restored cache on the next divergent prompt (nread is the end offset of
+                    // the llama state payload within the file)
+                    load_slot_checkpoints(filepath, nread, *slot);
 
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2288,6 +2288,117 @@ private:
                 cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024);
     }
 
+    // checkpoints are appended to the slot save file, after the llama state payload
+    // they cannot be recreated from the final state alone (a recurrent state cannot be rewound)
+    static constexpr uint32_t SLOT_CKPT_MAGIC   = 0x504b4353; // "SCKP"
+    static constexpr uint32_t SLOT_CKPT_VERSION = 1;
+
+    static bool ckpt_read(std::ifstream & ifs, void * dst, size_t size, size_t & n_read) {
+        if (!ifs.read((char *) dst, size)) {
+            return false;
+        }
+        n_read += size;
+        return true;
+    }
+
+    static bool ckpt_read_buf(std::ifstream & ifs, std::vector<uint8_t> & buf, size_t & n_read) {
+        uint64_t n = 0;
+        // 16 GiB cap, in case the size field itself is corrupted
+        if (!ckpt_read(ifs, &n, sizeof(n), n_read) || n > (1ull << 34)) {
+            return false;
+        }
+        buf.resize(n);
+        return n == 0 || ckpt_read(ifs, buf.data(), n, n_read);
+    }
+
+    static void ckpt_write(std::ofstream & ofs, const void * src, size_t size, size_t & n_written) {
+        ofs.write((const char *) src, size);
+        n_written += size;
+    }
+
+    static void ckpt_write_buf(std::ofstream & ofs, const std::vector<uint8_t> & buf, size_t & n_written) {
+        const uint64_t n = buf.size();
+        ckpt_write(ofs, &n, sizeof(n), n_written);
+        if (n > 0) {
+            ckpt_write(ofs, buf.data(), n, n_written);
+        }
+    }
+
+    size_t save_slot_checkpoints(const std::string & filepath, const server_slot & slot) const {
+        if (slot.prompt.checkpoints.empty()) {
+            return 0;
+        }
+        std::ofstream ofs(filepath, std::ios::binary | std::ios::app);
+        if (!ofs) {
+            SRV_WRN("failed to append context checkpoints to '%s'\n", filepath.c_str());
+            return 0;
+        }
+        size_t n_written = 0;
+        const uint32_t magic   = SLOT_CKPT_MAGIC;
+        const uint32_t version = SLOT_CKPT_VERSION;
+        const uint32_t count   = (uint32_t) slot.prompt.checkpoints.size();
+        ckpt_write(ofs, &magic,   sizeof(magic),   n_written);
+        ckpt_write(ofs, &version, sizeof(version), n_written);
+        ckpt_write(ofs, &count,   sizeof(count),   n_written);
+        for (const auto & cur : slot.prompt.checkpoints) {
+            ckpt_write(ofs, &cur.n_tokens, sizeof(cur.n_tokens), n_written);
+            ckpt_write(ofs, &cur.pos_min,  sizeof(cur.pos_min),  n_written);
+            ckpt_write(ofs, &cur.pos_max,  sizeof(cur.pos_max),  n_written);
+            ckpt_write_buf(ofs, cur.data_tgt,  n_written);
+            ckpt_write_buf(ofs, cur.data_dft,  n_written);
+            ckpt_write_buf(ofs, cur.data_spec, n_written);
+        }
+        ofs.flush();
+        if (!ofs) {
+            SRV_WRN("failed to append context checkpoints to '%s' - the appendix is incomplete\n", filepath.c_str());
+            return 0;
+        }
+        SRV_INF("appended %u context checkpoint(s) (%.3f MiB) to '%s'\n",
+                count, (float) n_written / 1024 / 1024, filepath.c_str());
+        return n_written;
+    }
+
+    // returns the number of bytes consumed, 0 if there is no usable appendix
+    size_t load_slot_checkpoints(const std::string & filepath, size_t offset, server_slot & slot) const {
+        std::ifstream ifs(filepath, std::ios::binary);
+        if (!ifs || !ifs.seekg(offset)) {
+            return 0;
+        }
+        size_t n_read = 0;
+        uint32_t magic   = 0;
+        uint32_t version = 0;
+        uint32_t count   = 0;
+        if (!ckpt_read(ifs, &magic, sizeof(magic), n_read) || magic != SLOT_CKPT_MAGIC) {
+            return 0;
+        }
+        if (!ckpt_read(ifs, &version, sizeof(version), n_read) || version != SLOT_CKPT_VERSION ||
+            !ckpt_read(ifs, &count,   sizeof(count),   n_read) || count > 1024) {
+            SRV_WRN("invalid context checkpoint appendix in '%s' - ignored\n", filepath.c_str());
+            return 0;
+        }
+        std::list<common_prompt_checkpoint> checkpoints;
+        for (uint32_t i = 0; i < count; ++i) {
+            common_prompt_checkpoint cur;
+            cur.id_task = -1;
+            if (!ckpt_read(ifs, &cur.n_tokens, sizeof(cur.n_tokens), n_read) ||
+                !ckpt_read(ifs, &cur.pos_min,  sizeof(cur.pos_min),  n_read) ||
+                !ckpt_read(ifs, &cur.pos_max,  sizeof(cur.pos_max),  n_read) ||
+                !ckpt_read_buf(ifs, cur.data_tgt,  n_read) ||
+                !ckpt_read_buf(ifs, cur.data_dft,  n_read) ||
+                !ckpt_read_buf(ifs, cur.data_spec, n_read)) {
+                SRV_WRN("truncated context checkpoint appendix in '%s' - ignored\n", filepath.c_str());
+                return 0;
+            }
+            checkpoints.push_back(std::move(cur));
+        }
+        while (checkpoints.size() > (size_t) params_base.n_ctx_checkpoints) {
+            checkpoints.pop_front();
+        }
+        slot.prompt.checkpoints = std::move(checkpoints);
+        SRV_INF("restored %zu context checkpoint(s) from '%s'\n", slot.prompt.checkpoints.size(), filepath.c_str());
+        return n_read;
+    }
+
     // returns false to decline the task, it is offered again after the decode is done
     bool process_single_task(server_task && task, bool is_yielding) {
         // while yielding, an encode / decode is running and only accessing metrics is safe
@@ -2485,6 +2596,8 @@ private:
                         break;
                     }
 
+                    const size_t nwrite_ckpt = save_slot_checkpoints(filepath, *slot);
+
                     const int64_t t_end = ggml_time_us();
                     const double t_save_ms = (t_end - t_start) / 1000.0;
 
@@ -2494,7 +2607,7 @@ private:
                     res->filename = filename;
                     res->is_save  = true;
                     res->n_tokens = slot->prompt.tokens.size();
-                    res->n_bytes  = nwrite;
+                    res->n_bytes  = nwrite + nwrite_ckpt;
                     res->t_ms     = t_save_ms;
                     queue_results.send(std::move(res));
                 } break;
@@ -2550,6 +2663,9 @@ private:
                         break;
                     }
 
+                    // nread is the end offset of the llama state payload within the file
+                    const size_t nread_ckpt = load_slot_checkpoints(filepath, nread, *slot);
+
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
 
@@ -2559,7 +2675,7 @@ private:
                     res->filename = filename;
                     res->is_save  = false;
                     res->n_tokens = slot->prompt.tokens.size();
-                    res->n_bytes  = nread;
+                    res->n_bytes  = nread + nread_ckpt;
                     res->t_ms     = t_restore_ms;
                     queue_results.send(std::move(res));
                 } break;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2340,93 +2340,106 @@ private:
                 cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024);
     }
 
-    // Context checkpoints are appended to the slot save file, after the llama state
-    // payload. Without them, a restored slot loses the ability to partially reuse its
-    // cache on models that need a checkpoint to roll back to (SWA and hybrid/recurrent
-    // memory): the next divergent prompt then always triggers "forcing full prompt
-    // re-processing due to lack of cache data", even though the restored state is
-    // intact. Checkpoints cannot be recreated from the final state alone (a recurrent
-    // state cannot be rewound), so they have to travel with the save file.
+    // checkpoints are appended to the slot save file, after the llama state payload
+    // they cannot be recreated from the final state alone (a recurrent state cannot be rewound)
     static constexpr uint32_t SLOT_CKPT_MAGIC   = 0x504b4353; // "SCKP"
     static constexpr uint32_t SLOT_CKPT_VERSION = 1;
 
-    static bool ckpt_read(std::ifstream & ifs, void * dst, size_t size) {
-        return bool(ifs.read((char *) dst, size));
+    static bool ckpt_read(std::ifstream & ifs, void * dst, size_t size, size_t & n_read) {
+        if (!ifs.read((char *) dst, size)) {
+            return false;
+        }
+        n_read += size;
+        return true;
     }
 
-    static bool ckpt_read_buf(std::ifstream & ifs, std::vector<uint8_t> & buf) {
+    static bool ckpt_read_buf(std::ifstream & ifs, std::vector<uint8_t> & buf, size_t & n_read) {
         uint64_t n = 0;
-        // refuse absurd blob sizes (> 16 GiB) from a corrupted/truncated appendix
-        if (!ckpt_read(ifs, &n, sizeof(n)) || n > (1ull << 34)) {
+        // 16 GiB cap, in case the size field itself is corrupted
+        if (!ckpt_read(ifs, &n, sizeof(n), n_read) || n > (1ull << 34)) {
             return false;
         }
         buf.resize(n);
-        return n == 0 || ckpt_read(ifs, buf.data(), n);
+        return n == 0 || ckpt_read(ifs, buf.data(), n, n_read);
     }
 
-    static void ckpt_write(std::ofstream & ofs, const void * src, size_t size) {
+    static void ckpt_write(std::ofstream & ofs, const void * src, size_t size, size_t & n_written) {
         ofs.write((const char *) src, size);
+        n_written += size;
     }
 
-    static void ckpt_write_buf(std::ofstream & ofs, const std::vector<uint8_t> & buf) {
+    static void ckpt_write_buf(std::ofstream & ofs, const std::vector<uint8_t> & buf, size_t & n_written) {
         const uint64_t n = buf.size();
-        ckpt_write(ofs, &n, sizeof(n));
+        ckpt_write(ofs, &n, sizeof(n), n_written);
         if (n > 0) {
-            ckpt_write(ofs, buf.data(), n);
+            ckpt_write(ofs, buf.data(), n, n_written);
         }
     }
 
-    void save_slot_checkpoints(const std::string & filepath, const server_slot & slot) const {
+    size_t save_slot_checkpoints(const std::string & filepath, const server_slot & slot) const {
+        if (slot.prompt.checkpoints.empty()) {
+            return 0; // keep the file byte-identical to the previous format
+        }
         std::ofstream ofs(filepath, std::ios::binary | std::ios::app);
         if (!ofs) {
             SRV_WRN("failed to append context checkpoints to '%s'\n", filepath.c_str());
-            return;
+            return 0;
         }
+        size_t n_written = 0;
         const uint32_t magic   = SLOT_CKPT_MAGIC;
         const uint32_t version = SLOT_CKPT_VERSION;
         const uint32_t count   = (uint32_t) slot.prompt.checkpoints.size();
-        ckpt_write(ofs, &magic,   sizeof(magic));
-        ckpt_write(ofs, &version, sizeof(version));
-        ckpt_write(ofs, &count,   sizeof(count));
+        ckpt_write(ofs, &magic,   sizeof(magic),   n_written);
+        ckpt_write(ofs, &version, sizeof(version), n_written);
+        ckpt_write(ofs, &count,   sizeof(count),   n_written);
         for (const auto & cur : slot.prompt.checkpoints) {
-            ckpt_write(ofs, &cur.n_tokens, sizeof(cur.n_tokens));
-            ckpt_write(ofs, &cur.pos_min,  sizeof(cur.pos_min));
-            ckpt_write(ofs, &cur.pos_max,  sizeof(cur.pos_max));
-            ckpt_write_buf(ofs, cur.data_tgt);
-            ckpt_write_buf(ofs, cur.data_dft);
-            ckpt_write_buf(ofs, cur.data_spec);
+            ckpt_write(ofs, &cur.n_tokens, sizeof(cur.n_tokens), n_written);
+            ckpt_write(ofs, &cur.pos_min,  sizeof(cur.pos_min),  n_written);
+            ckpt_write(ofs, &cur.pos_max,  sizeof(cur.pos_max),  n_written);
+            ckpt_write_buf(ofs, cur.data_tgt,  n_written);
+            ckpt_write_buf(ofs, cur.data_dft,  n_written);
+            ckpt_write_buf(ofs, cur.data_spec, n_written);
         }
-        SRV_INF("appended %u context checkpoint(s) to '%s'\n", count, filepath.c_str());
+        ofs.flush();
+        if (!ofs) {
+            SRV_WRN("failed to append context checkpoints to '%s' - the appendix is incomplete\n", filepath.c_str());
+            return 0;
+        }
+        SRV_INF("appended %u context checkpoint(s) (%.3f MiB) to '%s'\n",
+                count, (float) n_written / 1024 / 1024, filepath.c_str());
+        return n_written;
     }
 
-    void load_slot_checkpoints(const std::string & filepath, size_t offset, server_slot & slot) const {
+    // returns the number of bytes consumed, 0 if there is no usable appendix
+    size_t load_slot_checkpoints(const std::string & filepath, size_t offset, server_slot & slot) const {
         std::ifstream ifs(filepath, std::ios::binary);
         if (!ifs || !ifs.seekg(offset)) {
-            return;
+            return 0;
         }
+        size_t n_read = 0;
         uint32_t magic   = 0;
         uint32_t version = 0;
         uint32_t count   = 0;
-        if (!ckpt_read(ifs, &magic, sizeof(magic)) || magic != SLOT_CKPT_MAGIC) {
-            return; // save file without a checkpoint appendix (older format) - nothing to do
+        if (!ckpt_read(ifs, &magic, sizeof(magic), n_read) || magic != SLOT_CKPT_MAGIC) {
+            return 0; // save file written without an appendix
         }
-        if (!ckpt_read(ifs, &version, sizeof(version)) || version != SLOT_CKPT_VERSION ||
-            !ckpt_read(ifs, &count,   sizeof(count))   || count > 1024) {
+        if (!ckpt_read(ifs, &version, sizeof(version), n_read) || version != SLOT_CKPT_VERSION ||
+            !ckpt_read(ifs, &count,   sizeof(count),   n_read) || count > 1024) {
             SRV_WRN("invalid context checkpoint appendix in '%s' - ignored\n", filepath.c_str());
-            return;
+            return 0;
         }
         std::list<common_prompt_checkpoint> checkpoints;
         for (uint32_t i = 0; i < count; ++i) {
             common_prompt_checkpoint cur;
             cur.id_task = -1; // task ids are not meaningful across save/restore
-            if (!ckpt_read(ifs, &cur.n_tokens, sizeof(cur.n_tokens)) ||
-                !ckpt_read(ifs, &cur.pos_min,  sizeof(cur.pos_min))  ||
-                !ckpt_read(ifs, &cur.pos_max,  sizeof(cur.pos_max))  ||
-                !ckpt_read_buf(ifs, cur.data_tgt) ||
-                !ckpt_read_buf(ifs, cur.data_dft) ||
-                !ckpt_read_buf(ifs, cur.data_spec)) {
+            if (!ckpt_read(ifs, &cur.n_tokens, sizeof(cur.n_tokens), n_read) ||
+                !ckpt_read(ifs, &cur.pos_min,  sizeof(cur.pos_min),  n_read) ||
+                !ckpt_read(ifs, &cur.pos_max,  sizeof(cur.pos_max),  n_read) ||
+                !ckpt_read_buf(ifs, cur.data_tgt,  n_read) ||
+                !ckpt_read_buf(ifs, cur.data_dft,  n_read) ||
+                !ckpt_read_buf(ifs, cur.data_spec, n_read)) {
                 SRV_WRN("truncated context checkpoint appendix in '%s' - ignored\n", filepath.c_str());
-                return;
+                return 0;
             }
             checkpoints.push_back(std::move(cur));
         }
@@ -2435,6 +2448,7 @@ private:
         }
         slot.prompt.checkpoints = std::move(checkpoints);
         SRV_INF("restored %zu context checkpoint(s) from '%s'\n", slot.prompt.checkpoints.size(), filepath.c_str());
+        return n_read;
     }
 
     void process_single_task(server_task && task) {
@@ -2632,10 +2646,9 @@ private:
                     const size_t token_count = tokens.size();
                     const size_t nwrite = llama_state_seq_save_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
 
-                    // append the context checkpoints so that a restore can preserve
-                    // partial cache reuse (see SLOT_RESTORE below)
+                    size_t nwrite_ckpt = 0;
                     if (nwrite > 0) {
-                        save_slot_checkpoints(filepath, *slot);
+                        nwrite_ckpt = save_slot_checkpoints(filepath, *slot);
                     }
 
                     const int64_t t_end = ggml_time_us();
@@ -2647,7 +2660,7 @@ private:
                     res->filename = filename;
                     res->is_save  = true;
                     res->n_tokens = token_count;
-                    res->n_bytes  = nwrite;
+                    res->n_bytes  = nwrite + nwrite_ckpt;
                     res->t_ms     = t_save_ms;
                     queue_results.send(std::move(res));
                 } break;
@@ -2684,12 +2697,8 @@ private:
                     slot->prompt.clear();
                     slot->prompt.tokens.insert(tokens);
 
-                    // restore the context checkpoints appended to the save file (if any):
-                    // slot->prompt.clear() above discarded the slot's checkpoints, and without
-                    // them SWA and hybrid/recurrent memory models cannot partially reuse the
-                    // restored cache on the next divergent prompt (nread is the end offset of
-                    // the llama state payload within the file)
-                    load_slot_checkpoints(filepath, nread, *slot);
+                    // nread is the end offset of the llama state payload within the file
+                    const size_t nread_ckpt = load_slot_checkpoints(filepath, nread, *slot);
 
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
@@ -2700,7 +2709,7 @@ private:
                     res->filename = filename;
                     res->is_save  = false;
                     res->n_tokens = token_count;
-                    res->n_bytes  = nread;
+                    res->n_bytes  = nread + nread_ckpt;
                     res->t_ms     = t_restore_ms;
                     queue_results.send(std::move(res));
                 } break;

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -160,9 +160,9 @@ def test_slot_save_restore_text_only_on_multimodal(mmproj_server):
     assert res.body["n_restored"] == n_saved
 
     # The restored slot is usable for a follow-up completion. We do NOT assert
-    # prefix reuse here: tinygemma3 is a SWA model, which forces full prompt
-    # re-processing after a restore (a model property, not the save/restore gate
-    # under test).
+    # prefix reuse here (it depends on the restored checkpoint positions vs the
+    # re-sent prompt) - checkpoint preservation across save/restore is covered
+    # by test_slot_restore_preserves_context_checkpoints below.
     res = server.make_request("POST", "/completion", data={
         "prompt": "The quick brown fox jumps over the lazy dog.",
         "id_slot": 0,
@@ -222,3 +222,99 @@ def test_slot_erase_text_only_on_multimodal(mmproj_server):
     })
     assert res.status_code == 200
     assert res.body["timings"]["prompt_n"] == prompt_n  # all tokens are processed again
+
+
+#
+# Context checkpoints across save/restore.
+#
+# SWA and hybrid/recurrent models need a context checkpoint to roll back to in
+# order to partially reuse their cache on a divergent re-prompt. Checkpoints
+# used to be discarded on restore (and were not part of the save file), forcing
+# full prompt re-processing even when most of the prefix matched. They are now
+# appended to the save file and restored with the slot: a restored slot must
+# behave exactly like the live slot it was saved from.
+#
+
+
+@pytest.fixture
+def swa_server():
+    # tinygemma3 is a SWA model - its partial cache reuse relies on checkpoints.
+    swa = ServerPreset.tinygemma3()
+    swa.slot_save_path = "./tmp"
+    swa.temperature = 0.0
+    # the host prompt cache would transparently rescue the overwritten slot and
+    # hide the save/restore path under test
+    swa.cache_ram = 0
+    # prompt-processing checkpoints are placed at (end - 4 - n_ubatch) and
+    # (end - 4): keep n_ubatch small so that the first one lands before the
+    # divergence point of the re-prompts below
+    swa.n_ubatch = 32
+    return swa
+
+
+def test_slot_restore_preserves_context_checkpoints(swa_server):
+    server = swa_server
+    server.start()
+
+    base = "The quick brown fox jumps over the lazy dog. " * 20
+
+    # reference: on a live slot, a divergent re-prompt rolls back to a
+    # mid-prompt checkpoint and only re-processes from there
+    # the endings must span more tokens than the last checkpoint offset (4), so
+    # that the checkpoint at (end - 4 - n_ubatch) sits before the divergence
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "The first ending of this story is a happy one.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    n_full = res.body["timings"]["prompt_n"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "But the second ending was different and sad.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    n_live = res.body["timings"]["prompt_n"]
+    assert n_live < n_full  # partial reuse via checkpoint rollback
+
+    # now the same divergent re-prompt, but after save -> overwrite -> restore
+    res = server.make_request("POST", "/slots/1?action=erase")
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "The first ending of this story is a happy one.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "ckpt_slot1.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_saved"] > 0
+
+    # overwrite the slot with an unrelated prompt
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "Unrelated text with no common prefix occupies the slot now.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=restore", data={
+        "filename": "ckpt_slot1.bin",
+    })
+    assert res.status_code == 200
+
+    # the restored slot must roll back to the restored checkpoint, exactly like
+    # the live slot did (before the fix: full re-processing, prompt_n == n_full)
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "But the second ending was different and sad.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["prompt_n"] == n_live

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -33,6 +33,9 @@ def test_slot_save_restore():
     })
     assert res.status_code == 200
     assert res.body["n_saved"] == 84
+    # This model has no checkpoints, so the file carries no appendix
+    slot_file = os.path.join(server.slot_save_path, "slot1.bin")
+    assert res.body["n_written"] == os.path.getsize(slot_file)
 
     # Since we have cache, this should only process the last tokens
     res = server.make_request("POST", "/completion", data={
@@ -50,6 +53,7 @@ def test_slot_save_restore():
     })
     assert res.status_code == 200
     assert res.body["n_restored"] == 84
+    assert res.body["n_read"] == os.path.getsize(slot_file)
 
     # Since we have cache, slot 0 should only process the last tokens
     res = server.make_request("POST", "/completion", data={
@@ -159,10 +163,8 @@ def test_slot_save_restore_text_only_on_multimodal(mmproj_server):
     assert res.status_code == 200
     assert res.body["n_restored"] == n_saved
 
-    # The restored slot is usable for a follow-up completion. We do NOT assert
-    # prefix reuse here (it depends on the restored checkpoint positions vs the
-    # re-sent prompt) - checkpoint preservation across save/restore is covered
-    # by test_slot_restore_preserves_context_checkpoints below.
+    # The restored slot is usable for a follow-up completion, prefix reuse is not
+    # asserted here - see test_slot_restore_preserves_context_checkpoints below
     res = server.make_request("POST", "/completion", data={
         "prompt": "The quick brown fox jumps over the lazy dog.",
         "id_slot": 0,
@@ -224,30 +226,16 @@ def test_slot_erase_text_only_on_multimodal(mmproj_server):
     assert res.body["timings"]["prompt_n"] == prompt_n  # all tokens are processed again
 
 
-#
-# Context checkpoints across save/restore.
-#
-# SWA and hybrid/recurrent models need a context checkpoint to roll back to in
-# order to partially reuse their cache on a divergent re-prompt. Checkpoints
-# used to be discarded on restore (and were not part of the save file), forcing
-# full prompt re-processing even when most of the prefix matched. They are now
-# appended to the save file and restored with the slot: a restored slot must
-# behave exactly like the live slot it was saved from.
-#
-
-
 @pytest.fixture
 def swa_server():
     # tinygemma3 is a SWA model - its partial cache reuse relies on checkpoints.
     swa = ServerPreset.tinygemma3()
     swa.slot_save_path = "./tmp"
     swa.temperature = 0.0
-    # the host prompt cache would transparently rescue the overwritten slot and
-    # hide the save/restore path under test
+    # The host prompt cache would rescue the overwritten slot and hide the path under test
     swa.cache_ram = 0
-    # prompt-processing checkpoints are placed at (end - 4 - n_ubatch) and
-    # (end - 4): keep n_ubatch small so that the first one lands before the
-    # divergence point of the re-prompts below
+    # Checkpoints are placed at (end - 4 - n_ubatch) and (end - 4), keep n_ubatch small
+    # so the first one lands before the divergence point of the re-prompts below
     swa.n_ubatch = 32
     return swa
 
@@ -258,10 +246,8 @@ def test_slot_restore_preserves_context_checkpoints(swa_server):
 
     base = "The quick brown fox jumps over the lazy dog. " * 20
 
-    # reference: on a live slot, a divergent re-prompt rolls back to a
-    # mid-prompt checkpoint and only re-processes from there
-    # the endings must span more tokens than the last checkpoint offset (4), so
-    # that the checkpoint at (end - 4 - n_ubatch) sits before the divergence
+    # On a live slot, a divergent re-prompt rolls back to a mid-prompt checkpoint
+    # and only re-processes from there
     res = server.make_request("POST", "/completion", data={
         "prompt": base + "The first ending of this story is a happy one.",
         "id_slot": 1,
@@ -279,7 +265,7 @@ def test_slot_restore_preserves_context_checkpoints(swa_server):
     n_live = res.body["timings"]["prompt_n"]
     assert n_live < n_full  # partial reuse via checkpoint rollback
 
-    # now the same divergent re-prompt, but after save -> overwrite -> restore
+    # Now the same divergent re-prompt, but after save -> overwrite -> restore
     res = server.make_request("POST", "/slots/1?action=erase")
     assert res.status_code == 200
 
@@ -295,8 +281,11 @@ def test_slot_restore_preserves_context_checkpoints(swa_server):
     })
     assert res.status_code == 200
     assert res.body["n_saved"] > 0
+    # This save file carries a checkpoint appendix, which the byte count must cover
+    ckpt_file = os.path.join(server.slot_save_path, "ckpt_slot1.bin")
+    assert res.body["n_written"] == os.path.getsize(ckpt_file)
 
-    # overwrite the slot with an unrelated prompt
+    # Overwrite the slot with an unrelated prompt
     res = server.make_request("POST", "/completion", data={
         "prompt": "Unrelated text with no common prefix occupies the slot now.",
         "id_slot": 1,
@@ -308,9 +297,9 @@ def test_slot_restore_preserves_context_checkpoints(swa_server):
         "filename": "ckpt_slot1.bin",
     })
     assert res.status_code == 200
+    assert res.body["n_read"] == os.path.getsize(ckpt_file)
 
-    # the restored slot must roll back to the restored checkpoint, exactly like
-    # the live slot did (before the fix: full re-processing, prompt_n == n_full)
+    # The restored slot must roll back to a checkpoint, like the live slot did
     res = server.make_request("POST", "/completion", data={
         "prompt": base + "But the second ending was different and sad.",
         "id_slot": 1,

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -37,6 +37,8 @@ def test_slot_save_restore():
     })
     assert res.status_code == 200
     assert res.body["n_saved"] == 84
+    slot_file = os.path.join(server.slot_save_path, "slot1.bin")
+    assert res.body["n_written"] == os.path.getsize(slot_file)
 
     # Since we have cache, this should only process the last tokens
     res = server.make_request("POST", "/completion", data={
@@ -54,6 +56,7 @@ def test_slot_save_restore():
     })
     assert res.status_code == 200
     assert res.body["n_restored"] == 84
+    assert res.body["n_read"] == os.path.getsize(slot_file)
 
     # Since we have cache, slot 0 should only process the last tokens
     res = server.make_request("POST", "/completion", data={
@@ -527,3 +530,77 @@ def test_slot_restore_media_file_without_mmproj(mmproj_server):
     assert res.status_code == 200
     assert res.body["timings"]["cache_n"] == 0
     assert res.body["content"] == content
+
+
+@pytest.fixture
+def swa_server():
+    swa = ServerPreset.tinygemma3()
+    swa.slot_save_path = "./tmp"
+    swa.temperature = 0.0
+    swa.cache_ram = 0
+    # Keep the first prompt checkpoint before the divergence point.
+    swa.n_ubatch = 32
+    return swa
+
+
+def test_slot_restore_preserves_context_checkpoints(swa_server):
+    server = swa_server
+    server.start()
+
+    base = "The quick brown fox jumps over the lazy dog. " * 20
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "The first ending of this story is a happy one.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    n_full = res.body["timings"]["prompt_n"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "But the second ending was different and sad.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    n_live = res.body["timings"]["prompt_n"]
+    assert n_live < n_full
+
+    res = server.make_request("POST", "/slots/1?action=erase")
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "The first ending of this story is a happy one.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "ckpt_slot1.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_saved"] > 0
+    ckpt_file = os.path.join(server.slot_save_path, "ckpt_slot1.bin")
+    assert res.body["n_written"] == os.path.getsize(ckpt_file)
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "Unrelated text with no common prefix occupies the slot now.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=restore", data={
+        "filename": "ckpt_slot1.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_read"] == os.path.getsize(ckpt_file)
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": base + "But the second ending was different and sad.",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["prompt_n"] == n_live


### PR DESCRIPTION
## Overview

Fix the full re-prefill after `slot save → restore` for SWA and hybrid/recurrent models (e.g. Qwen3.5 / Qwen3-Next).

When a slot is restored, the server rebuilds the token cache but not the context checkpoints (`slot->prompt.clear()` discards them, and they are not part of the save file). SWA and hybrid/recurrent models cannot rewind their state without a checkpoint, so the next divergent prompt triggers "forcing full prompt re-processing due to lack of cache data" even when it shares a long prefix with the saved state. Since a recurrent state cannot be rewound, checkpoints are not reconstructible after the fact, they have to travel with the save file.

This PR preserves the context checkpoints inside the slot save file:

- `save_slot_checkpoints()` appends a tagged payload (`SCKP` magic + version + count + per-checkpoint pos fields and state blobs) after the llama state payload
- `load_slot_checkpoints()` reads it back at the offset returned by `llama_state_seq_load_file` and reattaches the checkpoints to the slot
- Backward/forward compatible: old files restore exactly as before (no magic → silent skip), and new files load fine on older servers (they stop reading at the end of their own payload)
- Guards against corrupted files: count cap (1024), per-blob size cap, truncation → warning and clean abort (no partial state)
- `id_task` is not serialized and is reset to `-1` on load (task ids are not meaningful across save/restore)
- `n_written`/`n_read` include the appended checkpoint bytes, so the reported size matches the file on disk; no appendix is written when the slot holds no checkpoints, leaving those files byte-identical to the format without this feature

The change is confined to `tools/server/server-context.cpp` (+120 lines), using `std::ifstream`/`std::ofstream` with small read/write helpers. Total diff is 195 insertions and 2 deletions across the implementation and its test.

Independently reproduced and confirmed by 7 users across CUDA, Metal, Vulkan and an ollama integration, including a cross-machine CUDA → Metal restore. Details below.

## Additional information

Test included: `test_slot_restore_preserves_context_checkpoints` in `tools/server/tests/unit/test_slot_save.py`:

1. Send a long prompt (reference: a divergent re-prompt on the live slot rolls back to a checkpoint → partial reuse, `n_live` tokens processed)
2. `save` the slot
3. Overwrite the slot with an unrelated prompt
4. `restore` the slot
5. Send the same divergent re-prompt, the test asserts `prompt_n == n_live`

Without the fix, step 5 re-processes the full prompt. The fixture sets `cache_ram = 0` (the host prompt cache would otherwise mask the path under test) and `n_ubatch = 32` (so a prompt-processing checkpoint lands before the divergence point).

The new test passes locally against this branch after the rebase, and the same scenario fails on master (`assert 210 == 31`). The file now also carries the multimodal slot tests that came in with #26640; the full server suite is left to CI.

**Rebase note.** #26640 ("server : support slot save/restore with media inputs") reworked the same `SLOT_SAVE` / `SLOT_RESTORE` handlers: the save now writes a packed `server_tokens::serialize()` payload including media chunks instead of `get_text_tokens()`, and the restore does a two-pass `llama_state_seq_load_file` + `deserialize()` + `validate()`. This PR was rebased onto master and flattened to a single commit. The split is unchanged: the state payload belongs to master, the checkpoint appendix belongs to this PR, it is still appended after the payload, and the load offset is still the end of the payload returned by `llama_state_seq_load_file`.

Fixes #25913, same root cause reported there (checkpoints never persisted, cleared on restore).

Related: #22384 fixed the checkpoint lookup for recurrent models in a live slot; this PR addresses the save/restore path, which loses the checkpoints entirely.

User-reported results:

| Reporter | Date | Setup | Result |
|---|---|---|---|
| wagi-sho | Jul 23 | Vulkan, Radeon 8050S (`gfx1151`), Qwen3.5-35B-A3B (Gated DeltaNet) | With the fix: **181.9 s → 4.7 s (38.7x)**; 58,202 → 516 tokens |
| terisuke | Jul 25 | Cross-machine: CUDA GB10 → Metal M3 Ultra | With the fix: `cache_n` **0 → 310**; identical output verified by SHA-256 |
| kfiramar | Aug 14 | Qwen3.8 | Confirmed; no measurements provided |
| YUXUANCHENG | Aug 16 | Not specified | Confirmed; no measurements provided |
| yitizi | Aug 31 | Qwen3.8-27B, hybrid SSM, strict-prefix extension | Bug on master: **8 tokens processed without a restore in between vs 2,005 with one** |
| dgabehar | Sep 08 | Vulkan, Radeon 780M (`gfx1103`), Qwen3.8-27B + draft-MTP | With the fix: **~71 s → ~3 s (23.7x)** on a 4,500-token prefix |
| m4xw | Sep 15 | Ollama integration, Anthropic-style caching | With the fix: avoided the full prefill after a process restart |

## Requirements



\- \[x] I have read and agree with the \[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

\- AI usage disclosure: YES — the implementation and the test were primarily AI-generated (Claude), working under my direction from a bug I found and measured on my hardware. I reviewed the code, ran the repro and the tests on real models (SWA and hybrid), and validated the fix end-to-end. This description was also drafted with AI assistance.



