### PR TITLE
hexagon: partial im2col support

### DIFF
--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -3345,6 +3345,31 @@ static bool ggml_hexagon_supported_ssm_conv(const struct ggml_hexagon_session * 
     GGML_UNUSED(sess);
 }
 
+// is_2D, F32 image in, F16/F32 column out, contiguous IO. The device dispatcher
+// routes the clean non-overlapping patch-embed regime to a VTCM-staged DMA
+// kernel and everything else (padding/dilation/stride edges) to a pure-DDR
+// HVX convert-copy. 1D (is_2D=0) and non-contiguous fall back to CPU.
+static bool ggml_hexagon_supported_im2col(const struct ggml_hexagon_session * sess, const struct ggml_tensor * op) {
+    const struct ggml_tensor * src1 = op->src[1];
+    const struct ggml_tensor * dst  = op;
+
+    const bool is_2D = ((const int32_t *) op->op_params)[6] == 1;
+    if (!is_2D) {
+        return false;
+    }
+
+    if (src1->type != GGML_TYPE_F32 || (dst->type != GGML_TYPE_F16 && dst->type != GGML_TYPE_F32)) {
+        return false;
+    }
+
+    if (!ggml_is_contiguous(src1) || !ggml_is_contiguous(dst)) {
+        return false;
+    }
+
+    GGML_UNUSED(sess);
+    return true;
+}
+
 static bool ggml_hexagon_supported_pad(const struct ggml_hexagon_session * sess, const struct ggml_tensor * op) {
     const struct ggml_tensor * src0 = op->src[0];
     const struct ggml_tensor * dst  = op;
@@ -3494,6 +3519,7 @@ static htp_op_code op_remap_to_htp(const ggml_tensor * t) {
         case GGML_OP_SOLVE_TRI:       return HTP_OP_SOLVE_TRI;
         case GGML_OP_TRI:             return HTP_OP_TRI;
         case GGML_OP_PAD:             return HTP_OP_PAD;
+        case GGML_OP_IM2COL:          return HTP_OP_IM2COL;
 
         case GGML_OP_UNARY:
             switch (ggml_get_unary_op(t)) {
@@ -4211,6 +4237,10 @@ static bool ggml_backend_hexagon_device_supports_op(ggml_backend_dev_t dev, cons
 
         case GGML_OP_SSM_CONV:
             supp = ggml_hexagon_supported_ssm_conv(sess, op);
+            break;
+
+        case GGML_OP_IM2COL:
+            supp = ggml_hexagon_supported_im2col(sess, op);
             break;
 
         case GGML_OP_GATED_DELTA_NET:

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -3345,10 +3345,6 @@ static bool ggml_hexagon_supported_ssm_conv(const struct ggml_hexagon_session * 
     GGML_UNUSED(sess);
 }
 
-// is_2D, F32 image in, F16/F32 column out, contiguous IO. The device dispatcher
-// routes the clean non-overlapping patch-embed regime to a VTCM-staged DMA
-// kernel and everything else (padding/dilation/stride edges) to a pure-DDR
-// HVX convert-copy. 1D (is_2D=0) and non-contiguous fall back to CPU.
 static bool ggml_hexagon_supported_im2col(const struct ggml_hexagon_session * sess, const struct ggml_tensor * op) {
     const struct ggml_tensor * src1 = op->src[1];
     const struct ggml_tensor * dst  = op;
@@ -3358,11 +3354,19 @@ static bool ggml_hexagon_supported_im2col(const struct ggml_hexagon_session * se
         return false;
     }
 
+    // For now support F32->F32 and F32->F16 only.
     if (src1->type != GGML_TYPE_F32 || (dst->type != GGML_TYPE_F16 && dst->type != GGML_TYPE_F32)) {
         return false;
     }
 
     if (!ggml_is_contiguous(src1) || !ggml_is_contiguous(dst)) {
+        return false;
+    }
+
+    // For now keep padded OPs on CPU. Will revisit once we expand coverage past patch-embed OPs.
+    const int32_t p0 = ((const int32_t *) op->op_params)[2];
+    const int32_t p1 = ((const int32_t *) op->op_params)[3];
+    if (p0 != 0 || p1 != 0) {
         return false;
     }
 

--- a/ggml/src/ggml-hexagon/htp/CMakeLists.txt
+++ b/ggml/src/ggml-hexagon/htp/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(${HTP_LIB} SHARED
     solve-tri-ops.c
     pad-ops.c
     argsort-ops.c
+    im2col-ops.c
 )
 
 target_compile_definitions(${HTP_LIB} PRIVATE

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -134,5 +134,6 @@ int op_diag(struct htp_ops_context * octx);
 int op_solve_tri(struct htp_ops_context * octx);
 int op_gated_delta_net(struct htp_ops_context * octx);
 int op_pad(struct htp_ops_context * octx);
+int op_im2col(struct htp_ops_context * octx);
 
 #endif /* HTP_CTX_H */

--- a/ggml/src/ggml-hexagon/htp/htp-ops.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ops.h
@@ -98,6 +98,7 @@ enum htp_op_code {
     HTP_OP_NORM,
     HTP_OP_CONCAT,
     HTP_OP_CLAMP,
+    HTP_OP_IM2COL,
 
     HTP_OP_INVALID
 };

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -15,30 +15,13 @@
 #include "hvx-utils.h"
 #include "hex-dma.h"
 
-// IM2COL for the VLM patch-embed conv (is_2D, F32 image -> F16 columns).
-//
-// src1 image : [N, IC, IH, IW]  NCHW, F32
-// dst        : [N, OH, OW, IC*KH*KW]  F16, patch block channel-outermost
-//
-// Each (iic, ikh) kernel tap-row maps to a contiguous run of KW elements in
-// both src and dst (validated for the non-overlapping patch-embed regime),
-// so the op is a strided F32->F16 convert-copy: no permute needed.
-//
-// Two kernels:
-//   im2col_patchembed_thread     - pure-DDR convert-copy, handles any is_2D F16
-//                                  shape (incl. padding/dilation/stride edges).
-//   im2col_patchembed_dma_thread - VTCM-staged DMA kernel for the clean
-//                                  non-overlapping regime (s0==KW, s1==KH,
-//                                  p0==p1==0, d0==d1==1); faster on real
-//                                  patch-embed shapes.
-
 struct htp_im2col_context {
     struct htp_ops_context * octx;
-    uint32_t                 npatches_per_thread; // patches = N*OH*OW (pure-DDR kernel)
-    // patch-embed DMA kernel
-    uint32_t pe_rows_per_thread;  // N*OH rows per worker
-    uint32_t pe_src_row_bytes;    // one output row's source: IC*KH*IW*4, rounded 256
-    uint32_t pe_dst_row_bytes;    // one output row's dst: OW*patch_stride*2, rounded 256
+    uint32_t                 npatches_per_thread;  // patches = N*OH*OW (pure-DDR kernel)
+
+    uint32_t pe_rows_per_thread;                   // N*OH rows per worker
+    uint32_t pe_src_row_bytes;                     // one output row's source: IC*KH*IW*4, rounded 256
+    uint32_t pe_dst_row_bytes;                     // one output row's dst: OW*patch_stride*2, rounded 256
 };
 
 #define IM2COL_PATCHEMBED_BODY(FNAME, DST_CTYPE, COPY_FN, DST_ELEM, TAG)                                             \
@@ -70,7 +53,6 @@ struct htp_im2col_context {
         if (patch_start >= patch_end) {                                                                              \
             return;                                                                                                  \
         }                                                                                                            \
-        const uint64_t t1 = HAP_perf_get_qtimer_count();                                                             \
         for (uint32_t p = patch_start; p < patch_end; p++) {                                                         \
             const uint32_t iow             = p % OW;                                                                 \
             const uint32_t ioh             = (p / OW) % OH;                                                          \
@@ -100,32 +82,11 @@ struct htp_im2col_context {
                 }                                                                                                    \
             }                                                                                                        \
         }                                                                                                            \
-        const uint64_t t2 = HAP_perf_get_qtimer_count();                                                             \
-        FARF(HIGH, "im2col-" TAG " %u/%u: patches %u..%u of %u, IC=%u KHxKW=%ux%u OHxOW=%ux%u usec %u\n", ith, nth,  \
-             patch_start, patch_end, npatches, IC, KH, KW, OH, OW, (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1)); \
     }
 
-IM2COL_PATCHEMBED_BODY(im2col_patchembed_thread,     __fp16, hvx_copy_f16_f32_uu, sizeof(__fp16), "f32-f16")
-IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float,  hvx_copy_f32_uu,     sizeof(float),  "f32-f32")
+IM2COL_PATCHEMBED_BODY(im2col_patchembed_thread, __fp16, hvx_copy_f16_f32_uu, sizeof(__fp16), "f32-f16")
+IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, sizeof(float), "f32-f32")
 
-
-// Patch-embed DMA kernel (clean regime: s0==KW, s1==KH, p0==p1==0, d0==d1==1,
-// F16 dst). Per output row (in,ioh): gather IC*KH source rows (each IW f32)
-// DDR->VTCM, convert OW patches VTCM->VTCM, store the packed row VTCM->DDR.
-//
-// DMA ring discipline: strictly per-row self-contained cycles.  Each iteration
-// pushes IC*KH gather descriptors, pops them all (ring now empty), computes,
-// pushes exactly one store descriptor, then flushes it (ring now empty again).
-// The ring is always empty at both the top and the bottom of every iteration,
-// so push/pop counts can never desync regardless of the number of rows.
-//
-// Overlap note: gather-to-compute overlap is intentionally dropped here in
-// favour of unambiguous FIFO correctness (dma_queue_flush drains the entire
-// ring, so a pre-loaded next-row gather would be consumed by the current row's
-// store flush).  We still get the primary bandwidth win: one fat DDR->VTCM DMA
-// per (iic,ikh) row and one fat VTCM->DDR store per output row instead of many
-// small per-patch transfers.  Overlap can be reintroduced in a follow-up once a
-// two-queue or descriptor-typed scheme is available.
 #define IM2COL_PATCHEMBED_DMA_BODY(FNAME, DST_CTYPE, COPY_FN, DST_ELEM, TAG)                                         \
     static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                             \
         struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                                \
@@ -149,7 +110,6 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float,  hvx_copy_f32_uu,   
         const uint32_t row_end          = MIN(row_start + per_thread, nrows);                                        \
         if (row_start >= row_end)                                                                                    \
             return;                                                                                                  \
-        const uint64_t t1 = HAP_perf_get_qtimer_count();                                                             \
         for (uint32_t r = row_start; r < row_end; r++) {                                                             \
             const uint32_t in  = r / OH;                                                                             \
             const uint32_t ioh = r % OH;                                                                             \
@@ -187,56 +147,55 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float,  hvx_copy_f32_uu,   
                                        OW * patch_stride * (DST_ELEM), OW * patch_stride * (DST_ELEM), 1);           \
             dma_queue_flush(dmaq);                                                                                   \
         }                                                                                                            \
-        const uint64_t t2 = HAP_perf_get_qtimer_count();                                                             \
-        FARF(HIGH, "im2col-" TAG " %u/%u: rows %u..%u of %u, IC=%u KHxKW=%ux%u OHxOW=%ux%u usec %u\n", ith, nth,     \
-             row_start, row_end, nrows, IC, KH, KW, OH, OW, (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));        \
     }
 
 IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_thread,     __fp16, hvx_copy_f16_f32_uu, sizeof(__fp16), "pe-dma-f16")
 IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_f32_thread, float,  hvx_copy_f32_uu,     sizeof(float),  "pe-dma-f32")
 
-// Patch-embed DMA/compute-overlap path (default ON; beats the pure-DDR
-// im2col_patchembed_thread 1.1x-2.5x on patch-embed shapes, biggest wins on
-// large images that fall off the pure-DDR cache cliff). Handles ONLY the clean
-// non-overlapping contiguous F16 regime: is_2D, F16 dst, s0==KW, s1==KH,
-// p0==p1==0, d0==d1==1; everything else uses the pure-DDR kernel. Set to 0 to
-// always use the pure-DDR kernel. See
-// docs/superpowers/specs/2026-06-20-im2col-patchembed-dma-overlap-design.md
-#define IM2COL_PATCHEMBED_DMA 1
-
 static bool im2col_use_patchembed_dma(const struct htp_ops_context * octx) {
-    if (!IM2COL_PATCHEMBED_DMA) return false;
     const int32_t s0 = octx->op_params[0], s1 = octx->op_params[1];
     const int32_t p0 = octx->op_params[2], p1 = octx->op_params[3];
     const int32_t d0 = octx->op_params[4], d1 = octx->op_params[5];
-    const int      is_2D = octx->op_params[6] == 1;
-    if (!is_2D) return false;
-    if (octx->dst->type != HTP_TYPE_F16 && octx->dst->type != HTP_TYPE_F32) return false;
+    const int     is_2D = octx->op_params[6] == 1;
+    if (!is_2D) {
+        return false;
+    }
+    if (octx->dst->type != HTP_TYPE_F16 && octx->dst->type != HTP_TYPE_F32) {
+        return false;
+    }
     const uint32_t KH = octx->src[0]->ne[1], KW = octx->src[0]->ne[0];
-    if (s0 != (int32_t) KW || s1 != (int32_t) KH) return false; // non-overlapping
-    if (p0 != 0 || p1 != 0) return false;                        // no padding
-    if (d0 != 1 || d1 != 1) return false;                        // no dilation
+    if (s0 != (int32_t) KW || s1 != (int32_t) KH) {
+        return false;  // non-overlapping
+    }
+    if (p0 != 0 || p1 != 0) {
+        return false;  // no padding
+    }
+    if (d0 != 1 || d1 != 1) {
+        return false;  // no dilation
+    }
     return true;
 }
 
 // Sizes the per-thread 2x(src,dst) VTCM ping-pong for the patch-embed DMA path.
 // Returns false if it doesn't fit the VTCM budget (caller falls back).
-static bool im2col_patchembed_dma_fits(struct htp_ops_context * octx,
+static bool im2col_patchembed_dma_fits(struct htp_ops_context *    octx,
                                        struct htp_im2col_context * ictx,
-                                       uint32_t n_threads) {
+                                       uint32_t                    n_threads) {
     const uint32_t IC = octx->src[1]->ne[2], IW = octx->src[1]->ne[0];
     const uint32_t KH = octx->src[0]->ne[1], KW = octx->src[0]->ne[0];
-    const uint32_t OW = octx->dst->ne[1];
+    const uint32_t OW           = octx->dst->ne[1];
     const uint32_t patch_stride = IC * KH * KW;
 
-    ictx->pe_src_row_bytes = hex_round_up(IC * KH * IW * sizeof(float), 256);
+    ictx->pe_src_row_bytes  = hex_round_up(IC * KH * IW * sizeof(float), 256);
     const uint32_t dst_elem = (octx->dst->type == HTP_TYPE_F16) ? sizeof(__fp16) : sizeof(float);
-    ictx->pe_dst_row_bytes = hex_round_up(OW * patch_stride * dst_elem, 256);
+    ictx->pe_dst_row_bytes  = hex_round_up(OW * patch_stride * dst_elem, 256);
 
     // 2 src + 2 dst buffers per thread (ping-pong).
     const uint64_t per_thread = 2ull * ictx->pe_src_row_bytes + 2ull * ictx->pe_dst_row_bytes;
-    const uint64_t total = per_thread * n_threads;
-    if (total > octx->ctx->vtcm_size) return false;
+    const uint64_t total      = per_thread * n_threads;
+    if (total > octx->ctx->vtcm_size) {
+        return false;
+    }
 
     // src buffers first, then dst buffers, in vtcm.
     octx->src1_spad.size_per_thread = 2 * ictx->pe_src_row_bytes;
@@ -257,10 +216,10 @@ int op_im2col(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
-    const uint32_t N  = src1->ne[3];
-    const uint32_t OH = dst->ne[2];
-    const uint32_t OW = dst->ne[1];
-    const uint32_t npatches = N * OH * OW;
+    const uint32_t N         = src1->ne[3];
+    const uint32_t OH        = dst->ne[2];
+    const uint32_t OW        = dst->ne[1];
+    const uint32_t npatches  = N * OH * OW;
     const uint32_t n_threads = MIN(octx->n_threads, npatches);
 
     if ((octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) || n_threads == 0) {
@@ -268,14 +227,14 @@ int op_im2col(struct htp_ops_context * octx) {
     }
 
     struct htp_im2col_context ictx = { 0 };
-    ictx.octx                = octx;
-    ictx.npatches_per_thread = (npatches + n_threads - 1) / n_threads;
+    ictx.octx                      = octx;
+    ictx.npatches_per_thread       = (npatches + n_threads - 1) / n_threads;
 
     // Clean non-overlapping patch-embed -> DMA kernel (if it fits VTCM);
     // everything else (padding/dilation/stride edges) -> pure-DDR kernel.
     if (im2col_use_patchembed_dma(octx)) {
         const uint32_t nrows = N * OH;
-        const uint32_t pth = MIN(octx->n_threads, nrows);
+        const uint32_t pth   = MIN(octx->n_threads, nrows);
         if (pth > 0 && im2col_patchembed_dma_fits(octx, &ictx, pth)) {
             ictx.pe_rows_per_thread = (nrows + pth - 1) / pth;
             if (dst->type == HTP_TYPE_F16) {

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -1,0 +1,297 @@
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+
+#include <HAP_farf.h>
+#include <HAP_perf.h>
+#include <hexagon_protos.h>
+#include <hexagon_types.h>
+#include <string.h>
+
+#define GGML_COMMON_DECL_C
+#include "ggml-common.h"
+#include "htp-ctx.h"
+#include "htp-ops.h"
+#include "hvx-utils.h"
+#include "hex-dma.h"
+
+// IM2COL for the VLM patch-embed conv (is_2D, F32 image -> F16 columns).
+//
+// src1 image : [N, IC, IH, IW]  NCHW, F32
+// dst        : [N, OH, OW, IC*KH*KW]  F16, patch block channel-outermost
+//
+// Each (iic, ikh) kernel tap-row maps to a contiguous run of KW elements in
+// both src and dst (validated for the non-overlapping patch-embed regime),
+// so the op is a strided F32->F16 convert-copy: no permute needed.
+//
+// Two kernels:
+//   im2col_patchembed_thread     - pure-DDR convert-copy, handles any is_2D F16
+//                                  shape (incl. padding/dilation/stride edges).
+//   im2col_patchembed_dma_thread - VTCM-staged DMA kernel for the clean
+//                                  non-overlapping regime (s0==KW, s1==KH,
+//                                  p0==p1==0, d0==d1==1); faster on real
+//                                  patch-embed shapes.
+
+struct htp_im2col_context {
+    struct htp_ops_context * octx;
+    uint32_t                 npatches_per_thread; // patches = N*OH*OW (pure-DDR kernel)
+    // patch-embed DMA kernel
+    uint32_t pe_rows_per_thread;  // N*OH rows per worker
+    uint32_t pe_src_row_bytes;    // one output row's source: IC*KH*IW*4, rounded 256
+    uint32_t pe_dst_row_bytes;    // one output row's dst: OW*patch_stride*2, rounded 256
+};
+
+#define IM2COL_PATCHEMBED_BODY(FNAME, DST_CTYPE, COPY_FN, DST_ELEM, TAG)                                             \
+    static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                             \
+        struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                                \
+        struct htp_ops_context *    octx        = ictx->octx;                                                        \
+        const struct htp_tensor * restrict src1 = octx->src[1];                                                      \
+        const struct htp_tensor * restrict dst  = octx->dst;                                                         \
+        const int32_t  s0                       = octx->op_params[0];                                                \
+        const int32_t  s1                       = octx->op_params[1];                                                \
+        const int32_t  p0                       = octx->op_params[2];                                                \
+        const int32_t  p1                       = octx->op_params[3];                                                \
+        const int32_t  d0                       = octx->op_params[4];                                                \
+        const int32_t  d1                       = octx->op_params[5];                                                \
+        const uint32_t N                        = src1->ne[3];                                                       \
+        const uint32_t IC                       = src1->ne[2];                                                       \
+        const uint32_t IH                       = src1->ne[1];                                                       \
+        const uint32_t IW                       = src1->ne[0];                                                       \
+        const uint32_t KH                       = octx->src[0]->ne[1];                                               \
+        const uint32_t KW                       = octx->src[0]->ne[0];                                               \
+        const uint32_t OH                       = dst->ne[2];                                                        \
+        const uint32_t OW                       = dst->ne[1];                                                        \
+        const uint32_t patch_stride             = IC * KH * KW;                                                      \
+        const float * restrict src_data         = (const float *) src1->data;                                        \
+        DST_CTYPE * restrict dst_data           = (DST_CTYPE *) dst->data;                                           \
+        const uint32_t npatches                 = N * OH * OW;                                                       \
+        const uint32_t patch_start              = ictx->npatches_per_thread * ith;                                   \
+        const uint32_t patch_end                = MIN(patch_start + ictx->npatches_per_thread, npatches);            \
+        if (patch_start >= patch_end) {                                                                              \
+            return;                                                                                                  \
+        }                                                                                                            \
+        const uint64_t t1 = HAP_perf_get_qtimer_count();                                                             \
+        for (uint32_t p = patch_start; p < patch_end; p++) {                                                         \
+            const uint32_t iow             = p % OW;                                                                 \
+            const uint32_t ioh             = (p / OW) % OH;                                                          \
+            const uint32_t in              = p / (OW * OH);                                                          \
+            DST_CTYPE * restrict dst_patch = dst_data + (uint64_t) p * patch_stride;                                 \
+            for (uint32_t iic = 0; iic < IC; iic++) {                                                                \
+                const float * restrict src_plane = src_data + ((uint64_t) in * IC + iic) * IH * IW;                  \
+                for (uint32_t ikh = 0; ikh < KH; ikh++) {                                                            \
+                    const int32_t iih            = (int32_t) ioh * s1 + (int32_t) ikh * d1 - p1;                     \
+                    DST_CTYPE * restrict out_run = dst_patch + iic * (KH * KW) + ikh * KW;                           \
+                    if (iih < 0 || iih >= (int32_t) IH) {                                                            \
+                        memset(out_run, 0, KW * (DST_ELEM));                                                         \
+                        continue;                                                                                    \
+                    }                                                                                                \
+                    const int32_t iiw0             = (int32_t) iow * s0 - p0;                                        \
+                    const float * restrict src_run = src_plane + (uint64_t) iih * IW + iiw0;                         \
+                    if (d0 == 1 && iiw0 >= 0 && iiw0 + (int32_t) KW <= (int32_t) IW) {                               \
+                        COPY_FN((uint8_t *) out_run, (const uint8_t *) src_run, KW);                                 \
+                        continue;                                                                                    \
+                    }                                                                                                \
+                    for (uint32_t ikw = 0; ikw < KW; ikw++) {                                                        \
+                        const int32_t iiw = (int32_t) iow * s0 + (int32_t) ikw * d0 - p0;                            \
+                        out_run[ikw]      = (iiw < 0 || iiw >= (int32_t) IW) ?                                       \
+                                                (DST_CTYPE) 0.0f :                                                   \
+                                                (DST_CTYPE) src_plane[(uint64_t) iih * IW + iiw];                    \
+                    }                                                                                                \
+                }                                                                                                    \
+            }                                                                                                        \
+        }                                                                                                            \
+        const uint64_t t2 = HAP_perf_get_qtimer_count();                                                             \
+        FARF(HIGH, "im2col-" TAG " %u/%u: patches %u..%u of %u, IC=%u KHxKW=%ux%u OHxOW=%ux%u usec %u\n", ith, nth,  \
+             patch_start, patch_end, npatches, IC, KH, KW, OH, OW, (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1)); \
+    }
+
+IM2COL_PATCHEMBED_BODY(im2col_patchembed_thread,     __fp16, hvx_copy_f16_f32_uu, sizeof(__fp16), "f32-f16")
+IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float,  hvx_copy_f32_uu,     sizeof(float),  "f32-f32")
+
+
+// Patch-embed DMA kernel (clean regime: s0==KW, s1==KH, p0==p1==0, d0==d1==1,
+// F16 dst). Per output row (in,ioh): gather IC*KH source rows (each IW f32)
+// DDR->VTCM, convert OW patches VTCM->VTCM, store the packed row VTCM->DDR.
+//
+// DMA ring discipline: strictly per-row self-contained cycles.  Each iteration
+// pushes IC*KH gather descriptors, pops them all (ring now empty), computes,
+// pushes exactly one store descriptor, then flushes it (ring now empty again).
+// The ring is always empty at both the top and the bottom of every iteration,
+// so push/pop counts can never desync regardless of the number of rows.
+//
+// Overlap note: gather-to-compute overlap is intentionally dropped here in
+// favour of unambiguous FIFO correctness (dma_queue_flush drains the entire
+// ring, so a pre-loaded next-row gather would be consumed by the current row's
+// store flush).  We still get the primary bandwidth win: one fat DDR->VTCM DMA
+// per (iic,ikh) row and one fat VTCM->DDR store per output row instead of many
+// small per-patch transfers.  Overlap can be reintroduced in a follow-up once a
+// two-queue or descriptor-typed scheme is available.
+#define IM2COL_PATCHEMBED_DMA_BODY(FNAME, DST_CTYPE, COPY_FN, DST_ELEM, TAG)                                         \
+    static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                             \
+        struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                                \
+        struct htp_ops_context *    octx        = ictx->octx;                                                        \
+        const struct htp_tensor * restrict src1 = octx->src[1];                                                      \
+        const struct htp_tensor * restrict dst  = octx->dst;                                                         \
+        const uint32_t N = src1->ne[3], IC = src1->ne[2], IH = src1->ne[1], IW = src1->ne[0];                        \
+        const uint32_t KH = octx->src[0]->ne[1], KW = octx->src[0]->ne[0];                                           \
+        const uint32_t OH = dst->ne[2], OW = dst->ne[1];                                                             \
+        const uint32_t patch_stride     = IC * KH * KW;                                                              \
+        const float * restrict src_data = (const float *) src1->data;                                                \
+        DST_CTYPE * restrict dst_data   = (DST_CTYPE *) dst->data;                                                   \
+        dma_queue *    dmaq             = octx->ctx->dma[ith];                                                       \
+        uint8_t *      src_base         = octx->src1_spad.data + ith * octx->src1_spad.size_per_thread;              \
+        uint8_t *      dst_base         = octx->dst_spad.data + ith * octx->dst_spad.size_per_thread;                \
+        float *        srcb             = (float *) src_base;                                                        \
+        DST_CTYPE *    dstb             = (DST_CTYPE *) dst_base;                                                    \
+        const uint32_t nrows            = N * OH;                                                                    \
+        const uint32_t per_thread       = ictx->pe_rows_per_thread;                                                  \
+        const uint32_t row_start        = per_thread * ith;                                                          \
+        const uint32_t row_end          = MIN(row_start + per_thread, nrows);                                        \
+        if (row_start >= row_end)                                                                                    \
+            return;                                                                                                  \
+        const uint64_t t1 = HAP_perf_get_qtimer_count();                                                             \
+        for (uint32_t r = row_start; r < row_end; r++) {                                                             \
+            const uint32_t in  = r / OH;                                                                             \
+            const uint32_t ioh = r % OH;                                                                             \
+            for (uint32_t ikh = 0; ikh < KH; ikh++) {                                                                \
+                int32_t iih = (int32_t) ioh * (int32_t) KH + (int32_t) ikh;                                          \
+                int     ok  = (iih >= 0 && iih < (int32_t) IH);                                                      \
+                for (uint32_t iic = 0; iic < IC; iic++) {                                                            \
+                    float *       vdst = srcb + ((uint64_t) (iic * KH + ikh)) * IW;                                  \
+                    const float * _vsrc =                                                                            \
+                        ok ? (src_data + ((uint64_t) (in * IC + iic) * IH + iih) * IW) : (const float *) vdst;       \
+                    dma_queue_push_ddr_to_vtcm(                                                                      \
+                        dmaq, dma_make_ptr((uint8_t *) vdst, ok ? (const uint8_t *) _vsrc : (const uint8_t *) vdst), \
+                        IW * sizeof(float), IW * sizeof(float), ok ? 1 : 0);                                         \
+                }                                                                                                    \
+            }                                                                                                        \
+            for (uint32_t i = 0; i < IC * KH; i++)                                                                   \
+                dma_queue_pop(dmaq);                                                                                 \
+            for (uint32_t iow = 0; iow < OW; iow++) {                                                                \
+                DST_CTYPE * dst_patch = dstb + (uint64_t) iow * patch_stride;                                        \
+                for (uint32_t ikh = 0; ikh < KH; ikh++) {                                                            \
+                    int32_t iih = (int32_t) ioh * (int32_t) KH + (int32_t) ikh;                                      \
+                    for (uint32_t iic = 0; iic < IC; iic++) {                                                        \
+                        DST_CTYPE * out_run = dst_patch + iic * (KH * KW) + ikh * KW;                                \
+                        if (iih < 0 || iih >= (int32_t) IH) {                                                        \
+                            memset(out_run, 0, KW * (DST_ELEM));                                                     \
+                            continue;                                                                                \
+                        }                                                                                            \
+                        const float * src_run = srcb + ((uint64_t) (iic * KH + ikh)) * IW + (uint64_t) iow * KW;     \
+                        COPY_FN((uint8_t *) out_run, (const uint8_t *) src_run, KW);                                 \
+                    }                                                                                                \
+                }                                                                                                    \
+            }                                                                                                        \
+            DST_CTYPE * ddr_row = dst_data + ((uint64_t) (in * OH + ioh) * OW) * patch_stride;                       \
+            dma_queue_push_vtcm_to_ddr(dmaq, dma_make_ptr((uint8_t *) ddr_row, (uint8_t *) dstb),                    \
+                                       OW * patch_stride * (DST_ELEM), OW * patch_stride * (DST_ELEM), 1);           \
+            dma_queue_flush(dmaq);                                                                                   \
+        }                                                                                                            \
+        const uint64_t t2 = HAP_perf_get_qtimer_count();                                                             \
+        FARF(HIGH, "im2col-" TAG " %u/%u: rows %u..%u of %u, IC=%u KHxKW=%ux%u OHxOW=%ux%u usec %u\n", ith, nth,     \
+             row_start, row_end, nrows, IC, KH, KW, OH, OW, (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));        \
+    }
+
+IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_thread,     __fp16, hvx_copy_f16_f32_uu, sizeof(__fp16), "pe-dma-f16")
+IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_f32_thread, float,  hvx_copy_f32_uu,     sizeof(float),  "pe-dma-f32")
+
+// Patch-embed DMA/compute-overlap path (default ON; beats the pure-DDR
+// im2col_patchembed_thread 1.1x-2.5x on patch-embed shapes, biggest wins on
+// large images that fall off the pure-DDR cache cliff). Handles ONLY the clean
+// non-overlapping contiguous F16 regime: is_2D, F16 dst, s0==KW, s1==KH,
+// p0==p1==0, d0==d1==1; everything else uses the pure-DDR kernel. Set to 0 to
+// always use the pure-DDR kernel. See
+// docs/superpowers/specs/2026-06-20-im2col-patchembed-dma-overlap-design.md
+#define IM2COL_PATCHEMBED_DMA 1
+
+static bool im2col_use_patchembed_dma(const struct htp_ops_context * octx) {
+    if (!IM2COL_PATCHEMBED_DMA) return false;
+    const int32_t s0 = octx->op_params[0], s1 = octx->op_params[1];
+    const int32_t p0 = octx->op_params[2], p1 = octx->op_params[3];
+    const int32_t d0 = octx->op_params[4], d1 = octx->op_params[5];
+    const int      is_2D = octx->op_params[6] == 1;
+    if (!is_2D) return false;
+    if (octx->dst->type != HTP_TYPE_F16 && octx->dst->type != HTP_TYPE_F32) return false;
+    const uint32_t KH = octx->src[0]->ne[1], KW = octx->src[0]->ne[0];
+    if (s0 != (int32_t) KW || s1 != (int32_t) KH) return false; // non-overlapping
+    if (p0 != 0 || p1 != 0) return false;                        // no padding
+    if (d0 != 1 || d1 != 1) return false;                        // no dilation
+    return true;
+}
+
+// Sizes the per-thread 2x(src,dst) VTCM ping-pong for the patch-embed DMA path.
+// Returns false if it doesn't fit the VTCM budget (caller falls back).
+static bool im2col_patchembed_dma_fits(struct htp_ops_context * octx,
+                                       struct htp_im2col_context * ictx,
+                                       uint32_t n_threads) {
+    const uint32_t IC = octx->src[1]->ne[2], IW = octx->src[1]->ne[0];
+    const uint32_t KH = octx->src[0]->ne[1], KW = octx->src[0]->ne[0];
+    const uint32_t OW = octx->dst->ne[1];
+    const uint32_t patch_stride = IC * KH * KW;
+
+    ictx->pe_src_row_bytes = hex_round_up(IC * KH * IW * sizeof(float), 256);
+    const uint32_t dst_elem = (octx->dst->type == HTP_TYPE_F16) ? sizeof(__fp16) : sizeof(float);
+    ictx->pe_dst_row_bytes = hex_round_up(OW * patch_stride * dst_elem, 256);
+
+    // 2 src + 2 dst buffers per thread (ping-pong).
+    const uint64_t per_thread = 2ull * ictx->pe_src_row_bytes + 2ull * ictx->pe_dst_row_bytes;
+    const uint64_t total = per_thread * n_threads;
+    if (total > octx->ctx->vtcm_size) return false;
+
+    // src buffers first, then dst buffers, in vtcm.
+    octx->src1_spad.size_per_thread = 2 * ictx->pe_src_row_bytes;
+    octx->src1_spad.size            = octx->src1_spad.size_per_thread * n_threads;
+    octx->src1_spad.data            = octx->ctx->vtcm_base;
+    octx->dst_spad.size_per_thread  = 2 * ictx->pe_dst_row_bytes;
+    octx->dst_spad.size             = octx->dst_spad.size_per_thread * n_threads;
+    octx->dst_spad.data             = octx->src1_spad.data + octx->src1_spad.size;
+    return true;
+}
+
+int op_im2col(struct htp_ops_context * octx) {
+    const struct htp_tensor * src1 = octx->src[1];
+    const struct htp_tensor * dst  = octx->dst;
+
+    if (src1->type != HTP_TYPE_F32 || (dst->type != HTP_TYPE_F16 && dst->type != HTP_TYPE_F32)) {
+        FARF(ERROR, "im2col: only (F32 image -> F16/F32 columns) supported");
+        return HTP_STATUS_NO_SUPPORT;
+    }
+
+    const uint32_t N  = src1->ne[3];
+    const uint32_t OH = dst->ne[2];
+    const uint32_t OW = dst->ne[1];
+    const uint32_t npatches = N * OH * OW;
+    const uint32_t n_threads = MIN(octx->n_threads, npatches);
+
+    if ((octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) || n_threads == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    struct htp_im2col_context ictx = { 0 };
+    ictx.octx                = octx;
+    ictx.npatches_per_thread = (npatches + n_threads - 1) / n_threads;
+
+    // Clean non-overlapping patch-embed -> DMA kernel (if it fits VTCM);
+    // everything else (padding/dilation/stride edges) -> pure-DDR kernel.
+    if (im2col_use_patchembed_dma(octx)) {
+        const uint32_t nrows = N * OH;
+        const uint32_t pth = MIN(octx->n_threads, nrows);
+        if (pth > 0 && im2col_patchembed_dma_fits(octx, &ictx, pth)) {
+            ictx.pe_rows_per_thread = (nrows + pth - 1) / pth;
+            if (dst->type == HTP_TYPE_F16) {
+                worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_dma_thread, &ictx, pth);
+            } else {
+                worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_dma_f32_thread, &ictx, pth);
+            }
+            return HTP_STATUS_OK;
+        }
+        // else: doesn't fit -> fall through to the pure-DDR kernel below.
+    }
+
+    if (dst->type == HTP_TYPE_F16) {
+        worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_thread, &ictx, n_threads);
+    } else {
+        worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_f32_thread, &ictx, n_threads);
+    }
+    return HTP_STATUS_OK;
+}

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -15,6 +15,7 @@
 #include "hvx-utils.h"
 #include "hex-dma.h"
 #include "hex-profile.h"
+#include "htp-vtcm.h"
 
 struct htp_im2col_context {
     struct htp_ops_context * octx;
@@ -23,7 +24,34 @@ struct htp_im2col_context {
     uint32_t pe_rows_per_thread;                   // N*OH rows per worker
     uint32_t pe_src_row_bytes;                     // one output row's source: IC*KH*IW*4, rounded 256
     uint32_t pe_dst_row_bytes;                     // one output row's dst: OW*patch_stride*2, rounded 256
+
+    // Patch-embed DMA path VTCM ping-pong.
+    uint8_t * pe_vtcm_src;                         // base of the 2x src buffers region
+    uint8_t * pe_vtcm_dst;                         // base of the 2x dst buffers region
+    uint32_t  pe_src_size_per_thread;              // 2 * pe_src_row_bytes
+    uint32_t  pe_dst_size_per_thread;              // 2 * pe_dst_row_bytes
 };
+
+// Per-op VTCM layout for the patch-embed DMA path
+struct htp_im2col_vtcm_layout {
+    size_t off_src;
+    size_t off_dst;
+    size_t src_bytes_per_thread;
+    size_t dst_bytes_per_thread;
+    size_t total_bytes;
+};
+
+static inline void htp_im2col_vtcm_layout_build(struct htp_im2col_vtcm_layout * L,
+                                                size_t                          src_row_bytes,
+                                                size_t                          dst_row_bytes,
+                                                uint32_t                        n_threads) {
+    L->src_bytes_per_thread = 2 * src_row_bytes;
+    L->dst_bytes_per_thread = 2 * dst_row_bytes;
+
+    L->off_src     = 0;
+    L->off_dst     = L->off_src + L->src_bytes_per_thread * n_threads;
+    L->total_bytes = L->off_dst + L->dst_bytes_per_thread * n_threads;
+}
 
 #define IM2COL_PATCHEMBED_BODY(FNAME, DST_CTYPE, COPY_FN, SPLAT_FN, DST_ELEM, TAG)                        \
     static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                  \
@@ -108,7 +136,7 @@ struct htp_im2col_context {
 IM2COL_PATCHEMBED_BODY(im2col_patchembed_thread, __fp16, hvx_copy_f16_f32_uu, hvx_splat_f16_u, sizeof(__fp16), "f32-f16")
 IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, hvx_splat_f32_u, sizeof(float), "f32-f32")
 
-#define IM2COL_PATCHEMBED_DMA_BODY(FNAME, DST_CTYPE, COPY_FN, SPLAT_FN, DST_ELEM, TAG)                                \
+#define IM2COL_PATCHEMBED_DMA_BODY(FNAME, DST_CTYPE, COPY_FN, SPLAT_FN, DST_ELEM, TAG)                               \
     static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                             \
         struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                                \
         struct htp_ops_context *    octx        = ictx->octx;                                                        \
@@ -122,8 +150,8 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, hvx
         const float * restrict src_data = (const float *) src1->data;                                                \
         DST_CTYPE * restrict dst_data   = (DST_CTYPE *) dst->data;                                                   \
         dma_queue *    dmaq             = octx->ctx->dma[ith];                                                       \
-        uint8_t *      src_base         = octx->src1_spad.data + ith * octx->src1_spad.size_per_thread;              \
-        uint8_t *      dst_base         = octx->dst_spad.data + ith * octx->dst_spad.size_per_thread;                \
+        uint8_t *      src_base         = ictx->pe_vtcm_src + ith * ictx->pe_src_size_per_thread;                    \
+        uint8_t *      dst_base         = ictx->pe_vtcm_dst + ith * ictx->pe_dst_size_per_thread;                    \
         float *        srcb             = (float *) src_base;                                                        \
         DST_CTYPE *    dstb             = (DST_CTYPE *) dst_base;                                                    \
         const uint32_t nrows            = N * OH;                                                                    \
@@ -214,20 +242,18 @@ static bool im2col_patchembed_dma_fits(struct htp_ops_context *    octx,
     const uint32_t dst_elem = (octx->dst->type == HTP_TYPE_F16) ? sizeof(__fp16) : sizeof(float);
     ictx->pe_dst_row_bytes  = hex_round_up(OW * patch_stride * dst_elem, 256);
 
-    // 2 src + 2 dst buffers per thread (ping-pong).
-    const uint64_t per_thread = 2ull * ictx->pe_src_row_bytes + 2ull * ictx->pe_dst_row_bytes;
-    const uint64_t total      = per_thread * n_threads;
-    if (total > octx->ctx->vtcm_size) {
+    // 2 src + 2 dst buffers per thread (ping-pong), src region first then dst.
+    struct htp_im2col_vtcm_layout L;
+    htp_im2col_vtcm_layout_build(&L, ictx->pe_src_row_bytes, ictx->pe_dst_row_bytes, n_threads);
+    if (L.total_bytes > octx->ctx->vtcm_size) {
         return false;
     }
 
-    // src buffers first, then dst buffers, in vtcm.
-    octx->src1_spad.size_per_thread = 2 * ictx->pe_src_row_bytes;
-    octx->src1_spad.size            = octx->src1_spad.size_per_thread * n_threads;
-    octx->src1_spad.data            = octx->ctx->vtcm_base;
-    octx->dst_spad.size_per_thread  = 2 * ictx->pe_dst_row_bytes;
-    octx->dst_spad.size             = octx->dst_spad.size_per_thread * n_threads;
-    octx->dst_spad.data             = octx->src1_spad.data + octx->src1_spad.size;
+    uint8_t * const base        = octx->ctx->vtcm_base;
+    ictx->pe_vtcm_src           = VTCM_LAYOUT_PTR(uint8_t, base, L.off_src);
+    ictx->pe_vtcm_dst           = VTCM_LAYOUT_PTR(uint8_t, base, L.off_dst);
+    ictx->pe_src_size_per_thread = (uint32_t) L.src_bytes_per_thread;
+    ictx->pe_dst_size_per_thread = (uint32_t) L.dst_bytes_per_thread;
     return true;
 }
 

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -14,6 +14,7 @@
 #include "htp-ops.h"
 #include "hvx-utils.h"
 #include "hex-dma.h"
+#include "hex-profile.h"
 
 struct htp_im2col_context {
     struct htp_ops_context * octx;
@@ -24,73 +25,94 @@ struct htp_im2col_context {
     uint32_t pe_dst_row_bytes;                     // one output row's dst: OW*patch_stride*2, rounded 256
 };
 
-#define IM2COL_PATCHEMBED_BODY(FNAME, DST_CTYPE, COPY_FN, DST_ELEM, TAG)                                             \
-    static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                             \
-        struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                                \
-        struct htp_ops_context *    octx        = ictx->octx;                                                        \
-        const struct htp_tensor * restrict src1 = octx->src[1];                                                      \
-        const struct htp_tensor * restrict dst  = octx->dst;                                                         \
-        const int32_t  s0                       = octx->op_params[0];                                                \
-        const int32_t  s1                       = octx->op_params[1];                                                \
-        const int32_t  p0                       = octx->op_params[2];                                                \
-        const int32_t  p1                       = octx->op_params[3];                                                \
-        const int32_t  d0                       = octx->op_params[4];                                                \
-        const int32_t  d1                       = octx->op_params[5];                                                \
-        const uint32_t N                        = src1->ne[3];                                                       \
-        const uint32_t IC                       = src1->ne[2];                                                       \
-        const uint32_t IH                       = src1->ne[1];                                                       \
-        const uint32_t IW                       = src1->ne[0];                                                       \
-        const uint32_t KH                       = octx->src[0]->ne[1];                                               \
-        const uint32_t KW                       = octx->src[0]->ne[0];                                               \
-        const uint32_t OH                       = dst->ne[2];                                                        \
-        const uint32_t OW                       = dst->ne[1];                                                        \
-        const uint32_t patch_stride             = IC * KH * KW;                                                      \
-        const float * restrict src_data         = (const float *) src1->data;                                        \
-        DST_CTYPE * restrict dst_data           = (DST_CTYPE *) dst->data;                                           \
-        const uint32_t npatches                 = N * OH * OW;                                                       \
-        const uint32_t patch_start              = ictx->npatches_per_thread * ith;                                   \
-        const uint32_t patch_end                = MIN(patch_start + ictx->npatches_per_thread, npatches);            \
-        if (patch_start >= patch_end) {                                                                              \
-            return;                                                                                                  \
-        }                                                                                                            \
-        for (uint32_t p = patch_start; p < patch_end; p++) {                                                         \
-            const uint32_t iow             = p % OW;                                                                 \
-            const uint32_t ioh             = (p / OW) % OH;                                                          \
-            const uint32_t in              = p / (OW * OH);                                                          \
-            DST_CTYPE * restrict dst_patch = dst_data + (uint64_t) p * patch_stride;                                 \
-            for (uint32_t iic = 0; iic < IC; iic++) {                                                                \
-                const float * restrict src_plane = src_data + ((uint64_t) in * IC + iic) * IH * IW;                  \
-                for (uint32_t ikh = 0; ikh < KH; ikh++) {                                                            \
-                    const int32_t iih            = (int32_t) ioh * s1 + (int32_t) ikh * d1 - p1;                     \
-                    DST_CTYPE * restrict out_run = dst_patch + iic * (KH * KW) + ikh * KW;                           \
-                    if (iih < 0 || iih >= (int32_t) IH) {                                                            \
-                        memset(out_run, 0, KW * (DST_ELEM));                                                         \
-                        continue;                                                                                    \
-                    }                                                                                                \
-                    const int32_t iiw0             = (int32_t) iow * s0 - p0;                                        \
-                    const float * restrict src_run = src_plane + (uint64_t) iih * IW + iiw0;                         \
-                    if (d0 == 1 && iiw0 >= 0 && iiw0 + (int32_t) KW <= (int32_t) IW) {                               \
-                        COPY_FN((uint8_t *) out_run, (const uint8_t *) src_run, KW);                                 \
-                        continue;                                                                                    \
-                    }                                                                                                \
-                    for (uint32_t ikw = 0; ikw < KW; ikw++) {                                                        \
-                        const int32_t iiw = (int32_t) iow * s0 + (int32_t) ikw * d0 - p0;                            \
-                        out_run[ikw]      = (iiw < 0 || iiw >= (int32_t) IW) ?                                       \
-                                                (DST_CTYPE) 0.0f :                                                   \
-                                                (DST_CTYPE) src_plane[(uint64_t) iih * IW + iiw];                    \
-                    }                                                                                                \
-                }                                                                                                    \
-            }                                                                                                        \
-        }                                                                                                            \
+#define IM2COL_PATCHEMBED_BODY(FNAME, DST_CTYPE, COPY_FN, SPLAT_FN, DST_ELEM, TAG)                        \
+    static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                  \
+        struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                     \
+        struct htp_ops_context *    octx        = ictx->octx;                                             \
+        struct htp_thread_trace * restrict tr   = &octx->ctx->trace[ith];                                 \
+        const struct htp_tensor * restrict src1 = octx->src[1];                                           \
+        const struct htp_tensor * restrict dst  = octx->dst;                                              \
+        const int32_t  s0                       = octx->op_params[0];                                     \
+        const int32_t  s1                       = octx->op_params[1];                                     \
+        const int32_t  p0                       = octx->op_params[2];                                     \
+        const int32_t  p1                       = octx->op_params[3];                                     \
+        const int32_t  d0                       = octx->op_params[4];                                     \
+        const int32_t  d1                       = octx->op_params[5];                                     \
+        const uint32_t N                        = src1->ne[3];                                            \
+        const uint32_t IC                       = src1->ne[2];                                            \
+        const uint32_t IH                       = src1->ne[1];                                            \
+        const uint32_t IW                       = src1->ne[0];                                            \
+        const uint32_t KH                       = octx->src[0]->ne[1];                                    \
+        const uint32_t KW                       = octx->src[0]->ne[0];                                    \
+        const uint32_t OH                       = dst->ne[2];                                             \
+        const uint32_t OW                       = dst->ne[1];                                             \
+        const uint32_t patch_stride             = IC * KH * KW;                                           \
+        const float * restrict src_data         = (const float *) src1->data;                             \
+        DST_CTYPE * restrict dst_data           = (DST_CTYPE *) dst->data;                                \
+        const uint32_t npatches                 = N * OH * OW;                                            \
+        const uint32_t patch_start              = ictx->npatches_per_thread * ith;                        \
+        const uint32_t patch_end                = MIN(patch_start + ictx->npatches_per_thread, npatches); \
+        if (patch_start >= patch_end) {                                                                   \
+            return;                                                                                       \
+        }                                                                                                 \
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, patch_start);                                   \
+        for (uint32_t p = patch_start; p < patch_end; p++) {                                              \
+            const uint32_t iow             = p % OW;                                                      \
+            const uint32_t ioh             = (p / OW) % OH;                                               \
+            const uint32_t in              = p / (OW * OH);                                               \
+            DST_CTYPE * restrict dst_patch = dst_data + (uint64_t) p * patch_stride;                      \
+            for (uint32_t iic = 0; iic < IC; iic++) {                                                     \
+                const float * restrict src_plane = src_data + ((uint64_t) in * IC + iic) * IH * IW;       \
+                for (uint32_t ikh = 0; ikh < KH; ikh++) {                                                 \
+                    const int32_t iih            = (int32_t) ioh * s1 + (int32_t) ikh * d1 - p1;          \
+                    DST_CTYPE * restrict out_run = dst_patch + iic * (KH * KW) + ikh * KW;                \
+                    if (iih < 0 || iih >= (int32_t) IH) {                                                 \
+                        SPLAT_FN(out_run, 0.0f, KW);                                                      \
+                        continue;                                                                         \
+                    }                                                                                     \
+                    const int32_t iiw0             = (int32_t) iow * s0 - p0;                             \
+                    const float * restrict src_run = src_plane + (uint64_t) iih * IW + iiw0;              \
+                    if (d0 == 1) {                                                                        \
+                        /* contiguous source run: [lo,hi) is in-bounds, tails are zero pad */             \
+                        const int32_t lo = iiw0 < 0 ? -iiw0 : 0;                                          \
+                        int32_t       hi = (int32_t) IW - iiw0;                                           \
+                        if (hi > (int32_t) KW) {                                                          \
+                            hi = (int32_t) KW;                                                            \
+                        }                                                                                 \
+                        if (hi <= lo) {                                                                   \
+                            SPLAT_FN(out_run, 0.0f, KW);                                                  \
+                        } else {                                                                          \
+                            if (lo > 0) {                                                                 \
+                                SPLAT_FN(out_run, 0.0f, (uint32_t) lo);                                   \
+                            }                                                                             \
+                            COPY_FN((uint8_t *) (out_run + lo), (const uint8_t *) (src_run + lo),         \
+                                    (uint32_t) (hi - lo));                                                \
+                            if (hi < (int32_t) KW) {                                                      \
+                                SPLAT_FN(out_run + hi, 0.0f, (KW - (uint32_t) hi));                       \
+                            }                                                                             \
+                        }                                                                                 \
+                        continue;                                                                         \
+                    }                                                                                     \
+                    for (uint32_t ikw = 0; ikw < KW; ikw++) {                                             \
+                        const int32_t iiw = (int32_t) iow * s0 + (int32_t) ikw * d0 - p0;                 \
+                        out_run[ikw]      = (iiw < 0 || iiw >= (int32_t) IW) ?                            \
+                                                (DST_CTYPE) 0.0f :                                        \
+                                                (DST_CTYPE) src_plane[(uint64_t) iih * IW + iiw];         \
+                    }                                                                                     \
+                }                                                                                         \
+            }                                                                                             \
+        }                                                                                                 \
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, patch_start);                                    \
     }
 
-IM2COL_PATCHEMBED_BODY(im2col_patchembed_thread, __fp16, hvx_copy_f16_f32_uu, sizeof(__fp16), "f32-f16")
-IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, sizeof(float), "f32-f32")
+IM2COL_PATCHEMBED_BODY(im2col_patchembed_thread, __fp16, hvx_copy_f16_f32_uu, hvx_splat_f16_u, sizeof(__fp16), "f32-f16")
+IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, hvx_splat_f32_u, sizeof(float), "f32-f32")
 
-#define IM2COL_PATCHEMBED_DMA_BODY(FNAME, DST_CTYPE, COPY_FN, DST_ELEM, TAG)                                         \
+#define IM2COL_PATCHEMBED_DMA_BODY(FNAME, DST_CTYPE, COPY_FN, SPLAT_FN, DST_ELEM, TAG)                                \
     static void FNAME(unsigned int nth, unsigned int ith, void * data) {                                             \
         struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                                \
         struct htp_ops_context *    octx        = ictx->octx;                                                        \
+        struct htp_thread_trace * restrict tr   = &octx->ctx->trace[ith];                                            \
         const struct htp_tensor * restrict src1 = octx->src[1];                                                      \
         const struct htp_tensor * restrict dst  = octx->dst;                                                         \
         const uint32_t N = src1->ne[3], IC = src1->ne[2], IH = src1->ne[1], IW = src1->ne[0];                        \
@@ -127,6 +149,7 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, siz
             }                                                                                                        \
             for (uint32_t i = 0; i < IC * KH; i++)                                                                   \
                 dma_queue_pop(dmaq);                                                                                 \
+            htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, r);                                                    \
             for (uint32_t iow = 0; iow < OW; iow++) {                                                                \
                 DST_CTYPE * dst_patch = dstb + (uint64_t) iow * patch_stride;                                        \
                 for (uint32_t ikh = 0; ikh < KH; ikh++) {                                                            \
@@ -134,7 +157,7 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, siz
                     for (uint32_t iic = 0; iic < IC; iic++) {                                                        \
                         DST_CTYPE * out_run = dst_patch + iic * (KH * KW) + ikh * KW;                                \
                         if (iih < 0 || iih >= (int32_t) IH) {                                                        \
-                            memset(out_run, 0, KW * (DST_ELEM));                                                     \
+                            SPLAT_FN(out_run, 0.0f, KW);                                                             \
                             continue;                                                                                \
                         }                                                                                            \
                         const float * src_run = srcb + ((uint64_t) (iic * KH + ikh)) * IW + (uint64_t) iow * KW;     \
@@ -142,6 +165,7 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, siz
                     }                                                                                                \
                 }                                                                                                    \
             }                                                                                                        \
+            htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, r);                                                     \
             DST_CTYPE * ddr_row = dst_data + ((uint64_t) (in * OH + ioh) * OW) * patch_stride;                       \
             dma_queue_push_vtcm_to_ddr(dmaq, dma_make_ptr((uint8_t *) ddr_row, (uint8_t *) dstb),                    \
                                        OW * patch_stride * (DST_ELEM), OW * patch_stride * (DST_ELEM), 1);           \
@@ -149,8 +173,8 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, siz
         }                                                                                                            \
     }
 
-IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_thread,     __fp16, hvx_copy_f16_f32_uu, sizeof(__fp16), "pe-dma-f16")
-IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_f32_thread, float,  hvx_copy_f32_uu,     sizeof(float),  "pe-dma-f32")
+IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_thread,     __fp16, hvx_copy_f16_f32_uu, hvx_splat_f16_u, sizeof(__fp16), "pe-dma-f16")
+IM2COL_PATCHEMBED_DMA_BODY(im2col_patchembed_dma_f32_thread, float,  hvx_copy_f32_uu,     hvx_splat_f32_u, sizeof(float),  "pe-dma-f32")
 
 static bool im2col_use_patchembed_dma(const struct htp_ops_context * octx) {
     const int32_t s0 = octx->op_params[0], s1 = octx->op_params[1];
@@ -238,9 +262,9 @@ int op_im2col(struct htp_ops_context * octx) {
         if (pth > 0 && im2col_patchembed_dma_fits(octx, &ictx, pth)) {
             ictx.pe_rows_per_thread = (nrows + pth - 1) / pth;
             if (dst->type == HTP_TYPE_F16) {
-                worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_dma_thread, &ictx, pth);
+                work_queue_run(octx->ctx->work_queue, im2col_patchembed_dma_thread, &ictx, pth);
             } else {
-                worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_dma_f32_thread, &ictx, pth);
+                work_queue_run(octx->ctx->work_queue, im2col_patchembed_dma_f32_thread, &ictx, pth);
             }
             return HTP_STATUS_OK;
         }
@@ -248,9 +272,9 @@ int op_im2col(struct htp_ops_context * octx) {
     }
 
     if (dst->type == HTP_TYPE_F16) {
-        worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_thread, &ictx, n_threads);
+        work_queue_run(octx->ctx->work_queue, im2col_patchembed_thread, &ictx, n_threads);
     } else {
-        worker_pool_run_func(octx->ctx->worker_pool, im2col_patchembed_f32_thread, &ictx, n_threads);
+        work_queue_run(octx->ctx->work_queue, im2col_patchembed_f32_thread, &ictx, n_threads);
     }
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -781,6 +781,9 @@ static int execute_op(struct htp_ops_context * octx) {
         case HTP_OP_PAD:
             return op_pad(octx);
 
+        case HTP_OP_IM2COL:
+            return op_im2col(octx);
+
         case HTP_OP_CONCAT:
             return op_concat(octx);
 


### PR DESCRIPTION
## Overview

This PR adds support for patch-embed sized im2col OPs to Hexagon backend. Full support for all im2col configurations will be added in a follow up. Support for F32->F32 and F32->F16 OPs.

Measured 1.5x-3.5x latency uplift for im2cols in Qwen3 VL and SigLIP VEs (per op).

## Additional information

IM2COL perf CPU vs HTP0 on 8 Elite Gen5:
```
Testing 2 devices

Backend 1/2: HTP0
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[224,224,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 24573 runs -    46.01 us/run -     2205 kB/run -   45.70 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[225,225,3,1],ne_kernel=[3,3,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                   81910 runs -    13.12 us/run -      667 kB/run -   48.53 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[256,256,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 24573 runs -    50.97 us/run -     2688 kB/run -   50.29 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[512,512,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 10924 runs -   166.30 us/run -     6144 kB/run -   35.24 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[896,896,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  2145 runs -   485.52 us/run -    15648 kB/run -   30.74 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[448,448,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  6918 runs -   148.67 us/run -     4851 kB/run -   31.12 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[896,896,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  2174 runs -   550.43 us/run -    15435 kB/run -   26.75 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[384,384,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 16382 runs -   115.65 us/run -     3888 kB/run -   32.06 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[512,512,3,1],ne_kernel=[16,16,3,1280],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 10282 runs -   166.68 us/run -     6528 kB/run -   37.35 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[896,896,3,1],ne_kernel=[42,42,3,1152],s0=42,s1=42,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  2594 runs -   654.60 us/run -    25873 kB/run -   37.70 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[1024,1024,3,1],ne_kernel=[16,16,3,768],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 1714 runs -   634.94 us/run -    19584 kB/run -   29.43 GB/s
  IM2COL(type_input=f32,type_kernel=f32,dst_type=f32,ne_input=[256,256,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 21846 runs -    51.53 us/run -     4608 kB/run -   85.28 GB/s
  IM2COL(type_input=f32,type_kernel=f32,dst_type=f32,ne_input=[512,512,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  7282 runs -   171.09 us/run -     9216 kB/run -   51.38 GB/s
  IM2COL(type_input=f32,type_kernel=f32,dst_type=f32,ne_input=[1024,1024,3,1],ne_kernel=[16,16,3,768],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 2498 runs -   651.64 us/run -    26880 kB/run -   39.35 GB/s
  Backend HTP0: OK

Backend 2/2: CPU

  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[224,224,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  7610 runs -   145.70 us/run -     2205 kB/run -   14.43 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[225,225,3,1],ne_kernel=[3,3,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                   98292 runs -    10.65 us/run -      667 kB/run -   59.80 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[256,256,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  9363 runs -   153.57 us/run -     2688 kB/run -   16.69 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[512,512,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  2732 runs -   645.02 us/run -     6144 kB/run -    9.09 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[896,896,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                   537 runs -  2019.13 us/run -    15648 kB/run -    7.40 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[448,448,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  3460 runs -   510.00 us/run -     4851 kB/run -    9.07 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[896,896,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                   544 runs -  1989.99 us/run -    15435 kB/run -    7.41 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[384,384,3,1],ne_kernel=[14,14,3,1152],s0=14,s1=14,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  4316 runs -   364.40 us/run -     3888 kB/run -   10.18 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[512,512,3,1],ne_kernel=[16,16,3,1280],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  2572 runs -   682.20 us/run -     6528 kB/run -    9.13 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[896,896,3,1],ne_kernel=[42,42,3,1152],s0=42,s1=42,p0=0,p1=0,d0=1,d1=1,is_2D=1):                   650 runs -  1910.59 us/run -    25873 kB/run -   12.93 GB/s
  IM2COL(type_input=f32,type_kernel=f16,dst_type=f16,ne_input=[1024,1024,3,1],ne_kernel=[16,16,3,768],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  429 runs -  2792.11 us/run -    19584 kB/run -    6.70 GB/s
  IM2COL(type_input=f32,type_kernel=f32,dst_type=f32,ne_input=[256,256,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                 14568 runs -    77.21 us/run -     4608 kB/run -   56.93 GB/s
  IM2COL(type_input=f32,type_kernel=f32,dst_type=f32,ne_input=[512,512,3,1],ne_kernel=[16,16,3,1024],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  3644 runs -   305.21 us/run -     9216 kB/run -   28.81 GB/s
  IM2COL(type_input=f32,type_kernel=f32,dst_type=f32,ne_input=[1024,1024,3,1],ne_kernel=[16,16,3,768],s0=16,s1=16,p0=0,p1=0,d0=1,d1=1,is_2D=1):                  939 runs -  1214.19 us/run -    26880 kB/run -   21.14 GB/s
  Backend CPU: OK
2/2 backends passed
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->Yes, to reason about the compute flow and to review the implementation.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
