### PR TITLE
server: support "reasoning_effort": "none" in OAI API

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1247,7 +1247,7 @@ The `response_format` parameter supports both plain JSON output (e.g. `{"type": 
 
 `chat_template_kwargs`: Allows sending additional parameters to the json templating system. For example: `{"enable_thinking": false}`
 
-`reasoning_effort`: If set to `none`, reasoning will be disabled for this request. Other values (e.g., `low`, `high`) are not yet supported.
+`reasoning_effort`: If set to `none`, reasoning will be disabled for this request. Other values (e.g., `low`, `max`) have no effect on reasoning.
 
 `reasoning_format`: The reasoning format to be parsed. If set to `none`, it will output the raw generated text.
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1247,6 +1247,8 @@ The `response_format` parameter supports both plain JSON output (e.g. `{"type": 
 
 `chat_template_kwargs`: Allows sending additional parameters to the json templating system. For example: `{"enable_thinking": false}`
 
+`reasoning_effort`: If set to `none`, reasoning will be disabled for this request. Other values (e.g., `low`, `high`) are not yet supported.
+
 `reasoning_format`: The reasoning format to be parsed. If set to `none`, it will output the raw generated text.
 
 `reasoning_control`: Arms realtime reasoning control for this completion so it can be ended early via `/v1/chat/completions/control`. Defaults to `false`.

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -283,6 +283,15 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
         chatcmpl_body["max_tokens"] = response_body["max_output_tokens"];
     }
 
+    if (response_body.contains("reasoning")) {
+        // Only "effort" is handled so far
+        const json & reasoning = response_body.at("reasoning");
+        if (reasoning.contains("effort")) {
+            chatcmpl_body["reasoning_effort"] = reasoning.at("effort");
+        }
+        chatcmpl_body.erase("reasoning");
+    }
+
     return chatcmpl_body;
 }
 

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1086,6 +1086,14 @@ json oaicompat_chat_params_parse(
         throw std::invalid_argument("invalid type for \"enable_thinking\" (expected boolean, got string)");
     }
 
+    // Parse also the OAI "reasoning_effort": "none" specific value
+    if (body.contains("reasoning_effort")) {
+        std::string reasoning_effort = body.at("reasoning_effort").get<std::string>();
+        if (reasoning_effort == "none") {
+            inputs.enable_thinking = false;
+        } // other reasoning_effort values are model-specific and not yet handled
+    }
+
     inputs.force_pure_content = opt.force_pure_content;
 
     // Apply chat template to the list of messages

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1088,7 +1088,7 @@ json oaicompat_chat_params_parse(
 
     // Parse also the OAI "reasoning_effort": "none" specific value
     if (body.contains("reasoning_effort")) {
-        std::string reasoning_effort = body.at("reasoning_effort").get<std::string>();
+        auto reasoning_effort = json_value(body, "reasoning_effort", std::string(""));
         if (reasoning_effort == "none") {
             inputs.enable_thinking = false;
         } // other reasoning_effort values are model-specific and not yet handled


### PR DESCRIPTION
## Overview

The server already has a way to disable reasoning in the OpenAI-compatible chat completions API, via `chat_template_kwargs`, but this is a bit annoying because it is non-canonical so it works for llama.cpp and not for other software, and vice versa. The OAI API already [has a defined way to disable reasoning](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create#(resource)%20chat.completions%20%3E%20(method)%20create%20%3E%20(params)%200.non_streaming%20%3E%20(param)%20reasoning_effort%20%3E%20(schema)), via `"reasoning_effort": "none"`.

Of course, `reasoning_effort` can also do low/medium/etc. model-specific things, which free models generally do not support as far as I can tell, but it is relatively trivial to support the special case of `none` at least. This will make it easier to support software that uses the OAI chat completions endpoint for super low-latency tasks without adding a special case for llama.cpp.

## Additional information

Example how to test:

```bash
curl -X POST http://127.0.0.1:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen3.5-4B-Q8_0",
    "messages": [{"role": "user", "content": "What is the exact value of 1729 * 463 - 89234 / 17? Just give the number."}],
    "reasoning_effort": "none"
  }'
```

Observe without `reasoning_effort` or with `reasoning_effort` set to anything other than "none", it will reason for a while.

### Responses API example

It also works with the [responses API](https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(method)%20create%20%3E%20(params)%200.non_streaming%20%3E%20(param)%20reasoning%20%3E%20(schema)%20%2B%20(resource)%20%24shared%20%3E%20(model)%20reasoning%20%3E%20(schema)%20%3E%20(property)%20effort) now, which uses a nested `reasoning.effort` variable instead. For example

```bash
curl -X POST http://127.0.0.1:8080/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen3.5-4B-Q8_0",
    "input": "What is the exact value of 1729 * 463 - 89234 / 17? Just give the number.",
    "reasoning": {
      "effort": "none"
    }
  }'
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, pi + llama.cpp + Qwen 3.6-27B for exploration and writing some test scripts to make sure behavior matched across other providers. Final code written by me because it turned out to be super simple.