### PR TITLE
tests: synchronize save-load-state generation

### DIFF
--- a/tests/test-save-load-state.cpp
+++ b/tests/test-save-load-state.cpp
@@ -44,6 +44,8 @@ static llama_tokens generate_tokens(llama_context * ctx, llama_sampler * smpl, i
         n_past++;
     }
 
+    llama_synchronize(ctx);
+
     return result;
 }
 


### PR DESCRIPTION
## Overview

  This PR adds a `llama_synchronize(ctx)` call at the end of token generation in `test-save-load-state`.

  The test generates tokens and then immediately saves / compares state. On async backends, the last decode work may still be
  pending when generation returns, so the test can observe state before all backend work has completed.

  Synchronizing here makes the test wait until generation is fully finished before the saved state is used.

  ## Additional information

  This only changes the test helper. It does not change model inference behavior.

  Tested with the CUDA backend on 4 x A100-PCIE-40GB using TinyLlama and -np 2, repeated 20 times:

  Before: 0/20 passed
  
  After: 20/20 passed

  ```bash
  ctest -R test-save-load-state --output-on-failure

  ## Requirements

  I have read and agree with the contributing guidelines (https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
