### PR TITLE
llama: fix DeepSeek4 state restore and sequence migration

### DIFF
--- a/src/llama-kv-cache-dsv4.cpp
+++ b/src/llama-kv-cache-dsv4.cpp
@@ -1368,7 +1368,9 @@ void llama_kv_cache_dsv4::state_write(llama_io_write_i & io, llama_seq_id seq_id
     io.write(&version, sizeof(version));
     io.write(&mode,    sizeof(mode));
 
-    kv_raw->state_write(io, seq_id, flags);
+    // DeepSeek4 compressor updates require the complete raw SWA history after
+    // a sequence state is restored into another stream.
+    kv_raw->state_write(io, seq_id, flags, true);
 
     if (!partial_only) {
         const llama_pos pos_max = seq_id >= 0 ? kv_raw->seq_pos_max(seq_id) : -1;

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -257,11 +257,19 @@ bool llama_kv_cache_iswa::get_can_shift() const {
 }
 
 void llama_kv_cache_iswa::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {
+    state_write(io, seq_id, flags, false);
+}
+
+void llama_kv_cache_iswa::state_write(
+        llama_io_write_i      & io,
+        llama_seq_id            seq_id,
+        llama_state_seq_flags   flags,
+        bool                    include_swa_masked) const {
     if ((flags & LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY) == 0) {
-        kv_base->state_write(io, seq_id, flags);
+        kv_base->state_write(io, seq_id, flags, include_swa_masked);
     }
 
-    kv_swa->state_write(io, seq_id, flags);
+    kv_swa->state_write(io, seq_id, flags, include_swa_masked);
 }
 
 void llama_kv_cache_iswa::state_read(llama_io_read_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) {

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -83,6 +83,12 @@ public:
     void state_write(llama_io_write_i & io, llama_seq_id seq_id = -1, llama_state_seq_flags flags = 0) const override;
     void state_read (llama_io_read_i  & io, llama_seq_id seq_id = -1, llama_state_seq_flags flags = 0) override;
 
+    void state_write(
+            llama_io_write_i      & io,
+            llama_seq_id            seq_id,
+            llama_state_seq_flags   flags,
+            bool                    include_swa_masked) const;
+
     //
     // llama_kv_cache_iswa specific API
     //

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -2312,7 +2312,8 @@ bool llama_kv_cache::state_read_meta(llama_io_read_i & io, uint32_t strm, uint32
             sinfo.idxs[0][i] = i;
         }
 
-        head = 0;
+        // Full-state restore compacts the cells into [0, cell_count).
+        head = cell_count;
     }
 
     return true;

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1955,6 +1955,14 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
 }
 
 void llama_kv_cache::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {
+    state_write(io, seq_id, flags, false);
+}
+
+void llama_kv_cache::state_write(
+        llama_io_write_i      & io,
+        llama_seq_id            seq_id,
+        llama_state_seq_flags   flags,
+        bool                    include_swa_masked) const {
     // TODO: refactor [TAG_KV_CACHE_SHARE_CELLS]
     if (other) {
         return;
@@ -1982,7 +1990,7 @@ void llama_kv_cache::state_write(llama_io_write_i & io, llama_seq_id seq_id, lla
             add_cell = add_cell && (seq_id == -1 || cells.seq_has(i, seq_id));
 
             // check the cell is not SWA-masked
-            if (add_cell && seq_id != -1) {
+            if (add_cell && seq_id != -1 && !include_swa_masked) {
                 const bool is_masked = llama_hparams::is_masked_swa(n_swa, swa_type, cells.pos_get(i), cells.seq_pos_max(seq_id));
 
                 add_cell = !is_masked;

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -149,6 +149,12 @@ public:
     void state_write(llama_io_write_i & io, llama_seq_id seq_id = -1, llama_state_seq_flags flags = 0) const override;
     void state_read (llama_io_read_i  & io, llama_seq_id seq_id = -1, llama_state_seq_flags flags = 0) override;
 
+    void state_write(
+            llama_io_write_i      & io,
+            llama_seq_id            seq_id,
+            llama_state_seq_flags   flags,
+            bool                    include_swa_masked) const;
+
     //
     // llama_kv_cache specific API
     //


### PR DESCRIPTION
## Overview

This PR fixes two state restoration issues exposed by DeepSeek4 after crossing its first 128-token HCA compression boundary.

First, full KV state loading restores cells into a compact `[0, cell_count)` range but resets the cache search head to zero. The restored cache should continue searching after the compact restored range, so the head is set to `cell_count`.

Second, single-sequence state serialization normally omits SWA-masked cells. DeepSeek4 still needs the complete raw SWA history when updating its compressed attention state. This PR adds an opt-in `include_swa_masked` path and enables it only for the DeepSeek4 raw cache.

The state file format is not changed.

## Reproduction

With an unmodified build, `test-save-load-state` produces identical results at 128 prompt tokens but diverges from 129 tokens onward.

At 129 tokens:

```text
direct baseline: 10239, 45075, 10184, ...
full state load: 9753, 73664, 25692, ...
```

The host and device sequence migration paths also produce the same divergent sequence.

## Validation

Tested with DeepSeek-V4-Flash IQ2_XXS-XL on 4 x A100-PCIE-40GB using CUDA, layer split, Flash Attention and `-np 2`.

The following prompt lengths passed:

```text
127, 128, 129, 130
255, 256, 257
383, 384, 385
511, 512, 513
```

For every tested length:

- full state load matched the direct baseline;
- host sequence migration matched the direct baseline;
- device sequence migration matched the direct baseline;
- all generated token sequences were identical.

The default state serialization path was also tested with TinyLlama on CPU for 20 consecutive runs: 20/20 passed.

## Scope

The new SWA serialization option defaults to disabled. Only the DeepSeek4 raw cache enables it, so other architectures retain the existing sequence-state behavior.

## Requirements

I have read and agree with the contributing guidelines:
https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md