### PR TITLE
ggml : handle graph buffer reservation failure

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1528,7 +1528,10 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
             ggml_backend_synchronize(sched->backends[i]);
         }
 
-        ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids);
+        if (!ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids)) {
+            GGML_LOG_ERROR("%s: failed to reserve graph buffers\n", __func__);
+            return false;
+        }
         if (!ggml_gallocr_alloc_graph(sched->galloc, &sched->graph)) {
             GGML_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             return false;


### PR DESCRIPTION
## Overview

This PR handles failures from `ggml_gallocr_reserve_n()` in `ggml_backend_sched_alloc_splits()`.

Previously, the return value was ignored and execution continued to `ggml_gallocr_alloc_graph()`, which could cause a null-pointer crash after graph-buffer reservation failed under memory pressure. The scheduler now logs the failure and returns `false`, allowing the existing error path to handle it safely.

Successful allocation and inference behavior are unchanged.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO