### PR TITLE
opencl: fix fused RMS norm mul view offset

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -12772,7 +12772,7 @@ static void ggml_opencl_op_rms_norm_fused(ggml_backend_t backend, ggml_tensor * 
     ggml_tensor_extra_cl * extrad = (ggml_tensor_extra_cl *)dst->extra;
 
     cl_ulong offset0 = extra0->offset + src0->view_offs;
-    cl_ulong offset1 = extra1->offset + src0->view_offs;
+    cl_ulong offset1 = extra1->offset + src1->view_offs;
     cl_ulong offsetd = extrad->offset + dst->view_offs;
 
     ggml_backend_opencl_context *backend_ctx = (ggml_backend_opencl_context *)backend->context;


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

  This change fixes an incorrect input address in the fused OpenCL RMS_NORM -> MUL path.

  The offset for the second multiplication input, src1, was incorrectly calculated using src0->view_offs. It now correctly uses src1->view_offs.

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES - AI was used to assist with identifying the bug.

