### PR TITLE
Add LlamaNet to the list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 - [semperai/amica](https://github.com/semperai/amica) (MIT)
 - [withcatai/catai](https://github.com/withcatai/catai) (MIT)
 - [Autopen](https://github.com/blackhole89/autopen) (GPL)
+- [LlamaNet](https://github.com/machaao/llama-net) (Apache-2.0)
 
 </details>
 


### PR DESCRIPTION
## Overview

Add LlamaNet to the list of projects in the README.

This PR adds a link to the LlamaNet project (https://github.com/machaao/llama-net) under the existing list of related projects, including its Apache-2.0 license. No code or functionality is changed.

## Additional information

LlamaNet is an open-source distributed inference network that provides an OpenAI-compatible API for serving and routing LLM inference across connected nodes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — AI was used to help draft the pull request description only. The repository change (adding the README entry) was authored and reviewed by me.