### PR TITLE
docs: use ROCM_PATH instead of HIP_PATH in linux HIP build command (#26060)

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -354,7 +354,7 @@ You can download it from your Linux distro's package manager or from here: [ROCm
 
 - Using `CMake` for Linux (assuming a gfx1030-compatible AMD GPU):
   ```bash
-  HIPCXX="$(hipconfig -l)/clang" HIP_PATH="$(hipconfig -R)" \
+  HIPCXX="$(hipconfig -l)/clang" ROCM_PATH="$(hipconfig -R)" \
       cmake -S . -B build -DGGML_HIP=ON -DGPU_TARGETS=gfx1030 -DCMAKE_BUILD_TYPE=Release \
       && cmake --build build --config Release -- -j 16
   ```


### PR DESCRIPTION
## Overview

The documented linux HIP compile command in[ docs/build.md](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#hip) sets HIP_PATH="$(hipconfig -R)" but the [ggml-hip cmake](https://github.com/ggml-org/llama.cpp/blob/master/ggml/src/ggml-hip/CMakeLists.txt) locates ROCm with the ROCM_PATH environ var and never reads HIP_PATH. 

So when using a pip-installed ROCm, it always fails compilation (directly or indirectly):
pip ROCm only (no global apt install): Cmake error of not finding hip-config.cmake
pip ROCm used (while global exists): wrongly compiles with hipcc used from /opt/rocm + library conflict warning

## Additional information
More info present in the [Issue](https://github.com/ggml-org/llama.cpp/issues/26060) I created 

It is worth noting that line 373 also in docs/build.md will need this change but as I haven't manually verified that command, I'm not including it in this PR.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - all testing and confirmation was done manually by me but AI was used to verify my findings and confirm that I didn't leave behind a testcase or miss something when reproducing the issue across multiple iterations.

Fixes #26060