### PR TITLE
ui: stabilize the rendering of tool invocations 

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/ChatMessageToolCallBlockReadFile.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/ChatMessageToolCallBlockReadFile.svelte
@@ -20,7 +20,7 @@
 <ToolCallBlock {section} {open} {isStreaming} meta={readFileMeta} {onToggle}>
 	{#snippet titleSnippet()}
 		<span class="text-muted-foreground">Read file </span>
-		<span class="font-mono">{readFileMeta?.fileName}</span>
+		<span class="font-mono">{readFileMeta?.filePath}</span>
 		{#if readFileMeta?.lineRange}
 			<span class="text-muted-foreground"
 				>&nbsp;(lines {readFileMeta.lineRange.start}-{readFileMeta.lineRange.end})</span

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file.ts
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file.ts
@@ -4,7 +4,6 @@
 // `error` fields.
 
 import { BuiltInTool } from '$lib/enums';
-import { FILE_PATH_SEPARATOR_REGEX } from '$lib/constants';
 import { tryParseToolResultObject, type AgenticSection } from '$lib/utils';
 import { truncatedArgKey } from '$lib/utils/parse-partial-json-args';
 import { parseToolArgs } from './_shared';
@@ -15,7 +14,6 @@ export type EditFileEdit = {
 };
 
 export type EditFileMeta = {
-	fileName: string;
 	filePath: string;
 	edits: EditFileEdit[];
 	resultMessage?: string;
@@ -31,15 +29,6 @@ export function parseEditFileMeta(section: AgenticSection): EditFileMeta | null 
 		args.path != null ? 'path' : args.file_path != null ? 'file_path' : ('filePath' as const);
 	const rawPath = args[pathKey];
 	if (typeof rawPath !== 'string' || !rawPath) return null;
-
-	// Matches read_file / write_file: a basename taken from a half-streamed path
-	// walks through every segment. This block renders `filePath` today, so the
-	// guard is here to keep the three parsers consistent rather than to fix a
-	// visible flicker.
-	const pathComplete = truncatedArgKey(section.toolArgs ?? '') !== pathKey;
-	const fileName = pathComplete
-		? rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath
-		: rawPath;
 
 	// Filter the streamed edits array strictly: each entry must be an
 	// object with a non-empty `old_text`. Edits without an old_text
@@ -83,7 +72,6 @@ export function parseEditFileMeta(section: AgenticSection): EditFileMeta | null 
 	}
 
 	return {
-		fileName,
 		filePath: rawPath,
 		edits,
 		resultMessage,

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file.ts
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file.ts
@@ -44,6 +44,16 @@ export function parseEditFileMeta(section: AgenticSection): EditFileMeta | null 
 	// Filter the streamed edits array strictly: each entry must be an
 	// object with a non-empty `old_text`. Edits without an old_text
 	// would diff against empty and render as a full re-write.
+	//
+	// The same applies in reverse, and it is the common case while streaming:
+	// `old_text` arrives in full before `new_text` begins, so an edit rendered in
+	// that window diffs a complete old value against an empty new one and shows
+	// every line as deleted, then snaps once the replacement lands. Hold the edit
+	// back until `new_text` has actual content. An empty `new_text` mid-stream is
+	// ambiguous - it reads the same whether the replacement is a genuine deletion
+	// or simply has not arrived - so resolve it by waiting: once the args close, a
+	// real deletion (`new_text: ""`) renders normally.
+	const argsComplete = truncatedArgKey(section.toolArgs ?? '') === null;
 	const rawEdits = Array.isArray(args.edits) ? args.edits : [];
 	const edits: EditFileEdit[] = [];
 	for (const e of rawEdits) {
@@ -51,7 +61,9 @@ export function parseEditFileMeta(section: AgenticSection): EditFileMeta | null 
 		const obj = e as Record<string, unknown>;
 		const oldText = typeof obj.old_text === 'string' ? obj.old_text : '';
 		if (!oldText) continue;
-		const newText = typeof obj.new_text === 'string' ? obj.new_text : '';
+		const streamedNewText = typeof obj.new_text === 'string' ? obj.new_text : '';
+		if (!argsComplete && streamedNewText.length === 0) continue;
+		const newText = streamedNewText;
 		edits.push({ oldText, newText });
 	}
 

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file.ts
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file.ts
@@ -6,6 +6,7 @@
 import { BuiltInTool } from '$lib/enums';
 import { FILE_PATH_SEPARATOR_REGEX } from '$lib/constants';
 import { tryParseToolResultObject, type AgenticSection } from '$lib/utils';
+import { truncatedArgKey } from '$lib/utils/parse-partial-json-args';
 import { parseToolArgs } from './_shared';
 
 export type EditFileEdit = {
@@ -26,10 +27,19 @@ export function parseEditFileMeta(section: AgenticSection): EditFileMeta | null 
 	const args = parseToolArgs(BuiltInTool.EDIT_FILE, section, { partial: true });
 	if (!args) return null;
 
-	const rawPath = args.path ?? args.file_path ?? args.filePath;
+	const pathKey =
+		args.path != null ? 'path' : args.file_path != null ? 'file_path' : ('filePath' as const);
+	const rawPath = args[pathKey];
 	if (typeof rawPath !== 'string' || !rawPath) return null;
 
-	const fileName = rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath;
+	// Matches read_file / write_file: a basename taken from a half-streamed path
+	// walks through every segment. This block renders `filePath` today, so the
+	// guard is here to keep the three parsers consistent rather than to fix a
+	// visible flicker.
+	const pathComplete = truncatedArgKey(section.toolArgs ?? '') !== pathKey;
+	const fileName = pathComplete
+		? rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath
+		: rawPath;
 
 	// Filter the streamed edits array strictly: each entry must be an
 	// object with a non-empty `old_text`. Edits without an old_text

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/read-file.ts
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/read-file.ts
@@ -10,6 +10,7 @@ import {
 	TEXT_LANGUAGE_PREFIX_REGEX
 } from '$lib/constants';
 import { getFileTypeByExtension, type AgenticSection } from '$lib/utils';
+import { truncatedArgKey } from '$lib/utils/parse-partial-json-args';
 import { parseToolArgs } from './_shared';
 
 export type ReadFileMeta = {
@@ -22,10 +23,18 @@ export function parseReadFileMeta(section: AgenticSection): ReadFileMeta | null 
 	const args = parseToolArgs(BuiltInTool.READ_FILE, section, { partial: true });
 	if (!args) return null;
 
-	const rawPath = args.path ?? args.file_path ?? args.filePath;
+	const pathKey =
+		args.path != null ? 'path' : args.file_path != null ? 'file_path' : ('filePath' as const);
+	const rawPath = args[pathKey];
 	if (typeof rawPath !== 'string' || !rawPath) return null;
 
-	const fileName = rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath;
+	// While the path is still streaming, show it whole. Taking the basename of a
+	// partial path makes the header flicker through every segment in turn
+	// ("/Us" -> "Us", "/Users/za" -> "za", ...).
+	const pathComplete = truncatedArgKey(section.toolArgs ?? '') !== pathKey;
+	const fileName = pathComplete
+		? rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath
+		: rawPath;
 
 	// Models emit range arguments under several aliases. Accept all to
 	// stay forgiving across prompt variations.
@@ -45,7 +54,9 @@ export function parseReadFileMeta(section: AgenticSection): ReadFileMeta | null 
 		}
 	}
 
-	const fileType = getFileTypeByExtension(fileName);
+	// Same reasoning for the language: a partial extension resolves to a different
+	// grammar every few tokens and re-highlights the whole block each time.
+	const fileType = pathComplete ? getFileTypeByExtension(fileName) : null;
 	const language = fileType ? fileType.replace(TEXT_LANGUAGE_PREFIX_REGEX, '') : DEFAULT_LANGUAGE;
 
 	return { fileName, lineRange, language };

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/read-file.ts
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/read-file.ts
@@ -4,17 +4,28 @@
 // can render incrementally as the file path streams in.
 
 import { BuiltInTool } from '$lib/enums';
-import {
-	DEFAULT_LANGUAGE,
-	FILE_PATH_SEPARATOR_REGEX,
-	TEXT_LANGUAGE_PREFIX_REGEX
-} from '$lib/constants';
+import { DEFAULT_LANGUAGE, TEXT_LANGUAGE_PREFIX_REGEX } from '$lib/constants';
 import { getFileTypeByExtension, type AgenticSection } from '$lib/utils';
 import { truncatedArgKey } from '$lib/utils/parse-partial-json-args';
 import { parseToolArgs } from './_shared';
 
+/** Every alias the range arguments arrive under, for the in-flight check below. */
+const RANGE_ARG_KEYS = new Set([
+	'start_line',
+	'line_start',
+	'startLine',
+	'from_line',
+	'end_line',
+	'line_end',
+	'endLine',
+	'to_line',
+	'line_count',
+	'count',
+	'num_lines'
+]);
+
 export type ReadFileMeta = {
-	fileName: string;
+	filePath: string;
 	lineRange: { start: number; end: number } | null;
 	language: string;
 };
@@ -28,13 +39,13 @@ export function parseReadFileMeta(section: AgenticSection): ReadFileMeta | null 
 	const rawPath = args[pathKey];
 	if (typeof rawPath !== 'string' || !rawPath) return null;
 
-	// While the path is still streaming, show it whole. Taking the basename of a
-	// partial path makes the header flicker through every segment in turn
-	// ("/Us" -> "Us", "/Users/za" -> "za", ...).
-	const pathComplete = truncatedArgKey(section.toolArgs ?? '') !== pathKey;
-	const fileName = pathComplete
-		? rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath
-		: rawPath;
+	const truncatedKey = truncatedArgKey(section.toolArgs ?? '');
+
+	// The path is shown whole, matching write_file and edit_file. Collapsing it to
+	// a basename used to make the header walk through every segment as the value
+	// streamed in ("/Us" -> "Us", "/Users/za" -> "za", ...); rendering the raw
+	// value is monotonic, so there is nothing to guard against.
+	const pathComplete = truncatedKey !== pathKey;
 
 	// Models emit range arguments under several aliases. Accept all to
 	// stay forgiving across prompt variations.
@@ -42,10 +53,16 @@ export function parseReadFileMeta(section: AgenticSection): ReadFileMeta | null 
 	const endRaw = args.end_line ?? args.line_end ?? args.endLine ?? args.to_line;
 	const countRaw = args.line_count ?? args.count ?? args.num_lines;
 
+	// Numbers stream digit by digit, so a range built from the in-flight value
+	// renders "1-4" and then "1-40". Withhold it until the value is closed.
+	const rangeStillStreaming = truncatedKey !== null && RANGE_ARG_KEYS.has(truncatedKey);
+
 	let lineRange: { start: number; end: number } | null = null;
 	const sNum = Number(startRaw);
 	const eNum = Number(endRaw);
-	if (startRaw != null && endRaw != null && Number.isFinite(sNum) && Number.isFinite(eNum)) {
+	if (rangeStillStreaming) {
+		lineRange = null;
+	} else if (startRaw != null && endRaw != null && Number.isFinite(sNum) && Number.isFinite(eNum)) {
 		lineRange = { start: sNum, end: eNum };
 	} else if (startRaw != null && countRaw != null) {
 		const cNum = Number(countRaw);
@@ -54,10 +71,10 @@ export function parseReadFileMeta(section: AgenticSection): ReadFileMeta | null 
 		}
 	}
 
-	// Same reasoning for the language: a partial extension resolves to a different
-	// grammar every few tokens and re-highlights the whole block each time.
-	const fileType = pathComplete ? getFileTypeByExtension(fileName) : null;
+	// The language does still need the guard: a partial extension resolves to a
+	// different grammar every few tokens and re-highlights the whole block.
+	const fileType = pathComplete ? getFileTypeByExtension(rawPath) : null;
 	const language = fileType ? fileType.replace(TEXT_LANGUAGE_PREFIX_REGEX, '') : DEFAULT_LANGUAGE;
 
-	return { fileName, lineRange, language };
+	return { filePath: rawPath, lineRange, language };
 }

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/write-file.ts
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/write-file.ts
@@ -10,6 +10,7 @@ import {
 	TEXT_LANGUAGE_PREFIX_REGEX
 } from '$lib/constants';
 import { getFileTypeByExtension, tryParseToolResultObject, type AgenticSection } from '$lib/utils';
+import { truncatedArgKey } from '$lib/utils/parse-partial-json-args';
 import { parseToolArgs } from './_shared';
 
 export type WriteFileMeta = {
@@ -28,13 +29,22 @@ export function parseWriteFileMeta(section: AgenticSection): WriteFileMeta | nul
 
 	// Tool contracts drifted over time: some models emit `path`,
 	// others `file_path` / `filePath`. Accept all three.
-	const rawPath = args.path ?? args.file_path ?? args.filePath;
+	const pathKey =
+		args.path != null ? 'path' : args.file_path != null ? 'file_path' : ('filePath' as const);
+	const rawPath = args[pathKey];
 	if (typeof rawPath !== 'string' || !rawPath) return null;
 
-	const fileName = rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath;
+	// Deriving the basename or the highlight language from a half-streamed path
+	// makes the header and the syntax highlighting thrash - hold off until the
+	// path value is closed. `content` streams after `path`, so this settles early.
+	const pathComplete = truncatedArgKey(section.toolArgs ?? '') !== pathKey;
+	const fileName = pathComplete
+		? rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath
+		: rawPath;
 	const content = typeof args.content === 'string' ? args.content : '';
-	const language =
-		getFileTypeByExtension(rawPath)?.replace(TEXT_LANGUAGE_PREFIX_REGEX, '') ?? DEFAULT_LANGUAGE;
+	const language = pathComplete
+		? (getFileTypeByExtension(rawPath)?.replace(TEXT_LANGUAGE_PREFIX_REGEX, '') ?? DEFAULT_LANGUAGE)
+		: DEFAULT_LANGUAGE;
 
 	const resultObj = tryParseToolResultObject(section.toolResult);
 	const bytesWritten =

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/write-file.ts
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/write-file.ts
@@ -4,17 +4,12 @@
 // result blob.
 
 import { BuiltInTool } from '$lib/enums';
-import {
-	DEFAULT_LANGUAGE,
-	FILE_PATH_SEPARATOR_REGEX,
-	TEXT_LANGUAGE_PREFIX_REGEX
-} from '$lib/constants';
+import { DEFAULT_LANGUAGE, TEXT_LANGUAGE_PREFIX_REGEX } from '$lib/constants';
 import { getFileTypeByExtension, tryParseToolResultObject, type AgenticSection } from '$lib/utils';
 import { truncatedArgKey } from '$lib/utils/parse-partial-json-args';
 import { parseToolArgs } from './_shared';
 
 export type WriteFileMeta = {
-	fileName: string;
 	filePath: string;
 	language: string;
 	content: string;
@@ -34,13 +29,10 @@ export function parseWriteFileMeta(section: AgenticSection): WriteFileMeta | nul
 	const rawPath = args[pathKey];
 	if (typeof rawPath !== 'string' || !rawPath) return null;
 
-	// Deriving the basename or the highlight language from a half-streamed path
-	// makes the header and the syntax highlighting thrash - hold off until the
-	// path value is closed. `content` streams after `path`, so this settles early.
+	// The highlight language must wait for the whole path: a partial extension
+	// resolves to a different grammar every few tokens and re-highlights the
+	// block each time. `content` streams after `path`, so this settles early.
 	const pathComplete = truncatedArgKey(section.toolArgs ?? '') !== pathKey;
-	const fileName = pathComplete
-		? rawPath.split(FILE_PATH_SEPARATOR_REGEX).pop() || rawPath
-		: rawPath;
 	const content = typeof args.content === 'string' ? args.content : '';
 	const language = pathComplete
 		? (getFileTypeByExtension(rawPath)?.replace(TEXT_LANGUAGE_PREFIX_REGEX, '') ?? DEFAULT_LANGUAGE)
@@ -53,7 +45,6 @@ export function parseWriteFileMeta(section: AgenticSection): WriteFileMeta | nul
 	const errorMessage = typeof resultObj?.error === 'string' ? resultObj.error : undefined;
 
 	return {
-		fileName,
 		filePath: rawPath,
 		language,
 		content,

--- a/tools/ui/src/lib/components/app/content/MarkdownContent/MarkdownContent.svelte
+++ b/tools/ui/src/lib/components/app/content/MarkdownContent/MarkdownContent.svelte
@@ -90,6 +90,8 @@
 		id: string;
 		html: string;
 		contentHash?: string;
+		/** Source offset where this block ends, used to commit a settled prefix. */
+		endOffset?: number;
 	}
 
 	let { content, attachments, class: className = '', disableMath = false }: Props = $props();
@@ -142,10 +144,45 @@
 	let pendingMarkdown: string | null = null;
 	let isProcessing = false;
 
+	// A blank line: the only separator appended text can never reach back across.
+	const BLOCK_BOUNDARY = '\n\n';
+
 	// Per-instance transform cache, avoids re-transforming stable blocks during streaming
 	// Garbage collected when component is destroyed (on conversation change)
 	const transformCache = new SvelteMap<string, string>();
 	let previousContent = '';
+
+	// Blocks whose source can no longer change, and the offset where they end.
+	// Everything before `committedEndOffset` is skipped by the parser on the next
+	// append, which is what keeps a long streaming message from re-parsing itself
+	// from offset 0 on every frame (9.3ms at 26KB, versus 0.1ms for the tail).
+	let committedBlocks: MarkdownBlock[] = [];
+	let committedEndOffset = 0;
+
+	function resetCommittedPrefix() {
+		committedBlocks = [];
+		committedEndOffset = 0;
+	}
+
+	/**
+	 * Shift top-level node offsets back into whole-document space after parsing
+	 * only a tail slice, so block hashes and ids match what a full parse produces
+	 * and the transform cache keeps hitting across frames.
+	 */
+	function rebaseTopLevelOffsets(children: unknown[], baseOffset: number) {
+		for (const child of children) {
+			const position = (
+				child as { position?: { start?: { offset?: number }; end?: { offset?: number } } }
+			).position;
+
+			if (position?.start?.offset != null) position.start.offset += baseOffset;
+			if (position?.end?.offset != null) position.end.offset += baseOffset;
+		}
+	}
+
+	function blockEndOffset(child: unknown): number | undefined {
+		return (child as { position?: { end?: { offset?: number } } }).position?.end?.offset;
+	}
 
 	const themeStyleId = `highlight-theme-${(window.idxThemeStyle = (window.idxThemeStyle ?? 0) + 1)}`;
 
@@ -351,6 +388,7 @@
 			unstableBlockHtml = '';
 			incompleteCodeBlock = null;
 			previousContent = '';
+			resetCommittedPrefix();
 			return;
 		}
 
@@ -358,6 +396,11 @@
 		const incompleteBlock = detectIncompleteCodeBlock(markdown);
 
 		if (incompleteBlock) {
+			// This branch tracks `previousContent` as the prefix rather than the whole
+			// document, so a committed offset taken against the full source would no
+			// longer line up. Drop it and let this path re-parse its prefix.
+			resetCommittedPrefix();
+
 			// Process only the prefix (content before the incomplete code block)
 			const prefixMarkdown = markdown.slice(0, incompleteBlock.openingIndex);
 
@@ -415,22 +458,39 @@
 
 		const normalized = preprocessLaTeX(markdown);
 		const processorInstance = processor();
-		const ast = processorInstance.parse(normalized) as MdastRoot;
-		const mdastChildren = (ast as { children?: unknown[] }).children ?? [];
-		const stableCount = Math.max(mdastChildren.length - 1, 0);
-		const nextBlocks: MarkdownBlock[] = [];
 
 		// Check if we're in append mode for cache reuse
 		const appendMode = isAppendMode(markdown, previousContent);
+
+		// When math is present preprocessLaTeX rewrites the string, so mdast
+		// offsets no longer line up with source offsets and a committed prefix
+		// cannot be trusted. That path simply re-parses in full, as before.
+		const offsetsArePreserved = normalized === markdown;
+
+		if (!appendMode || !offsetsArePreserved) resetCommittedPrefix();
+
+		const baseOffset = committedEndOffset;
+		const parseSource = baseOffset > 0 ? normalized.slice(baseOffset) : normalized;
+		const ast = processorInstance.parse(parseSource) as MdastRoot;
+		const mdastChildren = (ast as { children?: unknown[] }).children ?? [];
+
+		if (baseOffset > 0) rebaseTopLevelOffsets(mdastChildren, baseOffset);
+
+		const prefixBlocks = baseOffset > 0 ? committedBlocks : [];
+		const stableCount = Math.max(mdastChildren.length - 1, 0);
+		const nextBlocks: MarkdownBlock[] = [...prefixBlocks];
 		const previousBlockCount = appendMode ? renderedBlocks.length : 0;
 
 		for (let index = 0; index < stableCount; index++) {
 			const child = mdastChildren[index];
+			// Blocks are addressed by their position in the whole document, not in
+			// the slice that was parsed, so ids and hashes stay stable.
+			const documentIndex = prefixBlocks.length + index;
 
 			// In append mode, reuse previous blocks if unchanged
-			if (appendMode && index < previousBlockCount) {
-				const prevBlock = renderedBlocks[index];
-				const currentHash = getMdastNodeHash(child, index);
+			if (appendMode && documentIndex < previousBlockCount) {
+				const prevBlock = renderedBlocks[documentIndex];
+				const currentHash = getMdastNodeHash(child, documentIndex);
 				if (prevBlock?.contentHash === currentHash) {
 					nextBlocks.push(prevBlock);
 
@@ -439,13 +499,13 @@
 			}
 
 			// Transform this block (with caching)
-			const { html, hash } = await transformMdastNode(processorInstance, child, index);
+			const { html, hash } = await transformMdastNode(processorInstance, child, documentIndex);
 			const id = getHastNodeId(
 				{ position: (child as { position?: unknown }).position } as HastRootContent,
-				index
+				documentIndex
 			);
 
-			nextBlocks.push({ id, html, contentHash: hash });
+			nextBlocks.push({ id, html, contentHash: hash, endOffset: blockEndOffset(child) });
 		}
 
 		let unstableHtml = '';
@@ -458,6 +518,31 @@
 			)) as HastRoot;
 
 			unstableHtml = processorInstance.stringify(transformedRoot);
+		}
+
+		// Commit every leading block that ends before the last blank line. A blank
+		// line is a hard block boundary in CommonMark - lazy continuation and setext
+		// underlines cannot reach across one - so appended text can no longer alter
+		// those blocks, and the next frame can start parsing after them.
+		if (offsetsArePreserved) {
+			const lastBlankLine = normalized.lastIndexOf(BLOCK_BOUNDARY);
+
+			if (lastBlankLine > 0) {
+				const committed: MarkdownBlock[] = [];
+				let committedEnd = committedEndOffset;
+
+				for (const block of nextBlocks) {
+					if (block.endOffset == null || block.endOffset > lastBlankLine) break;
+
+					committed.push(block);
+					committedEnd = block.endOffset;
+				}
+
+				if (committed.length > 0) {
+					committedBlocks = committed;
+					committedEndOffset = committedEnd;
+				}
+			}
 		}
 
 		renderedBlocks = nextBlocks;

--- a/tools/ui/src/lib/components/app/content/MarkdownContent/MarkdownContent.svelte
+++ b/tools/ui/src/lib/components/app/content/MarkdownContent/MarkdownContent.svelte
@@ -487,12 +487,15 @@
 			// the slice that was parsed, so ids and hashes stay stable.
 			const documentIndex = prefixBlocks.length + index;
 
-			// In append mode, reuse previous blocks if unchanged
+			// In append mode, reuse previous blocks if unchanged. Recompute
+			// endOffset from the current (rebased) node: a block reused from the
+			// incomplete-code-block branch never carried one, and the commit loop
+			// stops at the first block without it.
 			if (appendMode && documentIndex < previousBlockCount) {
 				const prevBlock = renderedBlocks[documentIndex];
 				const currentHash = getMdastNodeHash(child, documentIndex);
 				if (prevBlock?.contentHash === currentHash) {
-					nextBlocks.push(prevBlock);
+					nextBlocks.push({ ...prevBlock, endOffset: blockEndOffset(child) });
 
 					continue;
 				}

--- a/tools/ui/src/lib/utils/parse-partial-json-args.ts
+++ b/tools/ui/src/lib/utils/parse-partial-json-args.ts
@@ -25,6 +25,57 @@ function cacheResult(input: string, result: Record<string, unknown> | null): voi
 	partialJsonCache.set(input, result);
 }
 
+/**
+ * Re-close `toolArgsString` after discarding the final, still-incomplete member.
+ *
+ * Used when the normal closure produced invalid JSON because the tail is a bare
+ * key (`,"start_l`) or a key with no value yet (`,"start_line":`). Truncating at
+ * the last member separator that sits outside a string keeps every member that
+ * did arrive intact. Returns null when there is nothing to salvage.
+ */
+function dropTrailingPartialMember(toolArgsString: string, stack: ('{' | '[')[]): string | null {
+	let inString = false;
+	let escape = false;
+	let cutIndex = -1;
+	let depth = 0;
+
+	for (let i = 0; i < toolArgsString.length; i++) {
+		const ch = toolArgsString[i];
+
+		if (escape) {
+			escape = false;
+			continue;
+		}
+		if (ch === JSON_BACKSLASH && inString) {
+			escape = true;
+			continue;
+		}
+		if (ch === JSON_QUOTE) {
+			inString = !inString;
+			continue;
+		}
+		if (inString) continue;
+
+		if (ch === JSON_OBJECT_OPEN || ch === JSON_ARRAY_OPEN) depth++;
+		else if (ch === JSON_OBJECT_CLOSE || ch === JSON_ARRAY_CLOSE) depth--;
+		// Only separators in the outermost object delimit the members we keep.
+		else if (ch === ',' && depth === 1) cutIndex = i;
+	}
+
+	if (cutIndex === -1) {
+		// No complete member at all - the object is still just `{"pa`.
+		return stack.length > 0 && stack[0] === JSON_OBJECT_OPEN ? '{}' : null;
+	}
+
+	let completed = toolArgsString.slice(0, cutIndex);
+
+	for (let i = stack.length - 1; i >= 0; i--) {
+		completed += stack[i] === JSON_OBJECT_OPEN ? JSON_OBJECT_CLOSE : JSON_ARRAY_CLOSE;
+	}
+
+	return completed;
+}
+
 // Parse partial tool-arg JSON streamed token-by-token. Closes any
 // unterminated string and dangling open containers (in reverse order),
 // so parsers can still surface keys already received while the call
@@ -102,6 +153,25 @@ function scanPartialJson(toolArgsString: string): Record<string, unknown> | null
 			? (parsed as Record<string, unknown>)
 			: null;
 	} catch {
+		// A member that has arrived as a bare key so far (`,"start_l`, or
+		// `,"start_line":` with no value yet) closes into `{"a":1,"start_l"}`,
+		// which is invalid - so the whole object would vanish for as many
+		// frames as the key name takes to stream, blanking the UI between
+		// parameters. Drop that trailing partial member and keep the members
+		// already complete.
+		const withoutTrailingMember = dropTrailingPartialMember(toolArgsString, stack);
+
+		if (withoutTrailingMember !== null) {
+			try {
+				const parsed: unknown = JSON.parse(withoutTrailingMember);
+				if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+					return parsed as Record<string, unknown>;
+				}
+			} catch {
+				return null;
+			}
+		}
+
 		return null;
 	}
 }

--- a/tools/ui/src/lib/utils/parse-partial-json-args.ts
+++ b/tools/ui/src/lib/utils/parse-partial-json-args.ts
@@ -37,7 +37,11 @@ function dropTrailingPartialMember(toolArgsString: string, stack: ('{' | '[')[])
 	let inString = false;
 	let escape = false;
 	let cutIndex = -1;
-	let depth = 0;
+	const open: ('{' | '[')[] = [];
+	// Containers still open at `cutIndex`. Closing the caller's final stack
+	// instead would emit closers for containers that the truncation removed,
+	// producing something like `{"path":"x"}]}`.
+	let openAtCut: ('{' | '[')[] = [];
 
 	for (let i = 0; i < toolArgsString.length; i++) {
 		const ch = toolArgsString[i];
@@ -56,10 +60,13 @@ function dropTrailingPartialMember(toolArgsString: string, stack: ('{' | '[')[])
 		}
 		if (inString) continue;
 
-		if (ch === JSON_OBJECT_OPEN || ch === JSON_ARRAY_OPEN) depth++;
-		else if (ch === JSON_OBJECT_CLOSE || ch === JSON_ARRAY_CLOSE) depth--;
+		if (ch === JSON_OBJECT_OPEN || ch === JSON_ARRAY_OPEN) open.push(ch);
+		else if (ch === JSON_OBJECT_CLOSE || ch === JSON_ARRAY_CLOSE) open.pop();
 		// Only separators in the outermost object delimit the members we keep.
-		else if (ch === ',' && depth === 1) cutIndex = i;
+		else if (ch === ',' && open.length === 1) {
+			cutIndex = i;
+			openAtCut = [...open];
+		}
 	}
 
 	if (cutIndex === -1) {
@@ -69,8 +76,8 @@ function dropTrailingPartialMember(toolArgsString: string, stack: ('{' | '[')[])
 
 	let completed = toolArgsString.slice(0, cutIndex);
 
-	for (let i = stack.length - 1; i >= 0; i--) {
-		completed += stack[i] === JSON_OBJECT_OPEN ? JSON_OBJECT_CLOSE : JSON_ARRAY_CLOSE;
+	for (let i = openAtCut.length - 1; i >= 0; i--) {
+		completed += openAtCut[i] === JSON_OBJECT_OPEN ? JSON_OBJECT_CLOSE : JSON_ARRAY_CLOSE;
 	}
 
 	return completed;
@@ -135,9 +142,11 @@ function scanPartialJson(toolArgsString: string): Record<string, unknown> | null
 
 	let completed = toolArgsString;
 	if (escape) {
-		// Dangling escape at end of partial JSON: escape the trailing
-		// backslash as a literal so we can close the string cleanly.
-		completed += JSON_BACKSLASH;
+		// Dangling escape at the end of partial JSON: the sequence is half of
+		// an escape (`\` of a `\n`), so drop it. Keeping it as a literal
+		// backslash flashes a stray character on screen that turns into a
+		// newline once the next token lands.
+		completed = completed.slice(0, -1);
 	}
 	if (inString) completed += JSON_QUOTE;
 	if (!inString) completed = completed.replace(TRAILING_JSON_PUNCTUATION_REGEX, '');

--- a/tools/ui/src/lib/utils/parse-partial-json-args.ts
+++ b/tools/ui/src/lib/utils/parse-partial-json-args.ts
@@ -105,3 +105,27 @@ function scanPartialJson(toolArgsString: string): Record<string, unknown> | null
 		return null;
 	}
 }
+
+/**
+ * Name of the argument whose value may still be mid-flight, or `null` when the
+ * blob is already valid JSON and every value is final.
+ *
+ * Object keys arrive in order, so only the last one present can be truncated.
+ * Callers use this to avoid deriving stable display values (a basename, a
+ * highlight language) from a half-streamed string - doing so makes headers walk
+ * through every path segment and makes the highlighter swap grammars mid-render.
+ */
+export function truncatedArgKey(toolArgsString: string): string | null {
+	try {
+		JSON.parse(toolArgsString);
+
+		return null;
+	} catch {
+		const partial = parsePartialJsonArgs(toolArgsString);
+		if (!partial) return null;
+
+		const keys = Object.keys(partial);
+
+		return keys.length > 0 ? keys[keys.length - 1] : null;
+	}
+}

--- a/tools/ui/tests/client/components/MarkdownStreamWrapper.svelte
+++ b/tools/ui/tests/client/components/MarkdownStreamWrapper.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import MarkdownContent from '$lib/components/app/content/MarkdownContent/MarkdownContent.svelte';
+	import { markdownState } from './markdown-stream-state.svelte';
+</script>
+
+<div data-testid="markdown-host">
+	<MarkdownContent content={markdownState.content} />
+</div>

--- a/tools/ui/tests/client/components/markdown-stream-state.svelte.ts
+++ b/tools/ui/tests/client/components/markdown-stream-state.svelte.ts
@@ -1,0 +1,3 @@
+// Reactive content holder for the MarkdownContent streaming-equivalence test.
+
+export const markdownState = $state<{ content: string }>({ content: '' });

--- a/tools/ui/tests/client/markdown-stream-equivalence.svelte.test.ts
+++ b/tools/ui/tests/client/markdown-stream-equivalence.svelte.test.ts
@@ -119,7 +119,14 @@ const BOUNDARY_SENSITIVE_DOCS: Array<[string, string]> = [
 	['list item continuation', '- item\n  continued\n\nAfter.'],
 	// The hard case: a definition at the END of the document changes how an
 	// EARLIER paragraph renders, so committing that paragraph early is wrong.
-	['link reference definition', 'See [foo] here.\n\nMore text.\n\n[foo]: /url\n']
+	['link reference definition', 'See [foo] here.\n\nMore text.\n\n[foo]: /url\n'],
+	// Prose, then a fence that CLOSES mid-stream, then more prose. Exercises the
+	// hand-off from the incomplete-code-block branch back to the standard path,
+	// where reused blocks must re-acquire an endOffset for the commit loop.
+	[
+		'prose then closed fence then prose',
+		'Intro paragraph before any code.\n\n```ts\nconst a = 1;\nconst b = a + 1;\n```\n\nMiddle prose after the fence.\n\n```js\nlet c = 3;\n```\n\nClosing paragraph.'
+	]
 ];
 
 describe('MarkdownContent streaming matches one-shot rendering', () => {

--- a/tools/ui/tests/client/markdown-stream-equivalence.svelte.test.ts
+++ b/tools/ui/tests/client/markdown-stream-equivalence.svelte.test.ts
@@ -1,0 +1,165 @@
+// Safety net for MarkdownContent's incremental rendering.
+//
+// The component renders streamed markdown by caching already-settled blocks and
+// only re-rendering the trailing one. Whatever it does internally, the result
+// after streaming a document in must be identical to rendering that same
+// document in one shot. These tests pin that invariant so the incremental
+// machinery can be changed with confidence.
+
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { tick } from 'svelte';
+import MarkdownStreamWrapper from './components/MarkdownStreamWrapper.svelte';
+import { markdownState } from './components/markdown-stream-state.svelte';
+
+function nextFrame(): Promise<void> {
+	return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+/** Let MarkdownContent's rAF-coalesced processing drain. */
+async function settle() {
+	for (let i = 0; i < 4; i++) {
+		await tick();
+		await nextFrame();
+	}
+	await tick();
+}
+
+/**
+ * Code blocks get ids from a global counter that advances every time one is
+ * rendered, so a streamed document (which renders its trailing block repeatedly)
+ * legitimately lands on higher numbers than a one-shot render. Normalise them so
+ * the comparison is about structure and content, not render count.
+ */
+function normalize(html: string): string {
+	return html.replace(/code-\d+/g, 'code-N');
+}
+
+function host(): HTMLElement {
+	const el = document.querySelector('[data-testid="markdown-host"]');
+	if (!el) throw new Error('markdown host not mounted');
+	return el as HTMLElement;
+}
+
+/** Render `doc` in one shot and return the resulting markup. */
+async function renderWhole(doc: string): Promise<string> {
+	markdownState.content = '';
+	const { unmount } = render(MarkdownStreamWrapper);
+	await settle();
+
+	markdownState.content = doc;
+	await settle();
+
+	const html = normalize(host().innerHTML);
+	await unmount();
+
+	return html;
+}
+
+/** Stream `doc` in `chunks` pieces and return the resulting markup. */
+async function renderStreamed(doc: string, chunks: number): Promise<string> {
+	markdownState.content = '';
+	const { unmount } = render(MarkdownStreamWrapper);
+	await settle();
+
+	const size = Math.ceil(doc.length / chunks);
+	for (let i = 0; i < doc.length; i += size) {
+		markdownState.content = doc.slice(0, i + size);
+		await settle();
+	}
+
+	markdownState.content = doc;
+	await settle();
+
+	const html = normalize(host().innerHTML);
+	await unmount();
+
+	return html;
+}
+
+const DOCS: Array<[string, string]> = [
+	['plain paragraphs', 'First paragraph here.\n\nSecond paragraph.\n\nThird one to finish.'],
+	[
+		'headings and lists',
+		'# Title\n\nIntro text.\n\n## Section\n\n- alpha\n- beta\n- gamma\n\n1. one\n2. two\n\nClosing words.'
+	],
+	[
+		'fenced code between prose',
+		'Before the block.\n\n```ts\nconst x: number = 1;\nconsole.log(x);\n```\n\nAfter the block.'
+	],
+	[
+		'table then prose',
+		'Intro.\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n\nTrailing paragraph.'
+	],
+	[
+		'blockquote and emphasis',
+		'> quoted line\n> continues here\n\nSome **bold** and _italic_ text.'
+	],
+	['single long paragraph', `A single unbroken paragraph. ${'More words follow. '.repeat(40)}`],
+	[
+		'inline math and currency',
+		'Cost is $5 today.\n\nThe identity $e^{i\\pi} + 1 = 0$ is famous.\n\nDone.'
+	],
+	[
+		'nested list with code',
+		'- outer\n  - inner one\n  - inner two\n\n```js\nlet y = 2;\n```\n\nEnd.'
+	]
+];
+
+// Constructs whose meaning depends on a line that arrives *later*, so a naive
+// incremental parser that commits at every newline would settle them wrongly:
+// the setext underline retitles the line above it, the table separator turns the
+// header row into a table, and lazy continuation glues lines into one paragraph.
+const BOUNDARY_SENSITIVE_DOCS: Array<[string, string]> = [
+	['setext heading', 'Title\n=====\n\nBody.'],
+	['setext h2', 'Sub\n---\n\nBody.'],
+	['table needs its separator', '| a | b |\n| --- | --- |\n| 1 | 2 |\n\nAfter.'],
+	['lazy continuation', 'One line\ncontinued lazily.\n\nNext para.'],
+	['blockquote lazy continuation', '> quoted\nstill quoted\n\nOut.'],
+	['list item continuation', '- item\n  continued\n\nAfter.'],
+	// The hard case: a definition at the END of the document changes how an
+	// EARLIER paragraph renders, so committing that paragraph early is wrong.
+	['link reference definition', 'See [foo] here.\n\nMore text.\n\n[foo]: /url\n']
+];
+
+describe('MarkdownContent streaming matches one-shot rendering', () => {
+	for (const [label, doc] of DOCS) {
+		it(`${label}: streamed in 5 chunks equals whole`, { timeout: 60_000 }, async () => {
+			const whole = await renderWhole(doc);
+			const streamed = await renderStreamed(doc, 5);
+
+			if (streamed !== whole) {
+				// Print a compact first-difference report instead of two 10KB blobs.
+				let i = 0;
+				while (i < Math.min(streamed.length, whole.length) && streamed[i] === whole[i]) i++;
+				console.log(
+					`\n[${label}] first diff at ${i}\n` +
+						`  whole:    ...${JSON.stringify(whole.slice(Math.max(0, i - 60), i + 120))}\n` +
+						`  streamed: ...${JSON.stringify(streamed.slice(Math.max(0, i - 60), i + 120))}`
+				);
+			}
+
+			expect(streamed).toBe(whole);
+		});
+	}
+
+	it('token-by-token streaming equals whole', { timeout: 120_000 }, async () => {
+		const doc = DOCS[1][1];
+		const whole = await renderWhole(doc);
+		const streamed = await renderStreamed(doc, doc.length);
+
+		expect(streamed).toBe(whole);
+	});
+
+	// These are the cases that decide where a streaming parser may safely stop
+	// re-parsing. Streamed character by character, so every intermediate state is
+	// exercised - including the one just before the disambiguating line arrives.
+	for (const [label, doc] of BOUNDARY_SENSITIVE_DOCS) {
+		it(`${label}: token-by-token equals whole`, { timeout: 120_000 }, async () => {
+			const whole = await renderWhole(doc);
+			const streamed = await renderStreamed(doc, doc.length);
+
+			expect(streamed).toBe(whole);
+		});
+	}
+});

--- a/tools/ui/tests/unit/helpers/streaming-stability.ts
+++ b/tools/ui/tests/unit/helpers/streaming-stability.ts
@@ -1,0 +1,138 @@
+// A general contract for tool-call meta parsers under streaming.
+//
+// Tool args arrive token by token, so every parser sees a long tail of partial
+// JSON before it sees the real thing. Five separate UI bugs came from parsers
+// deriving a display value from a half-arrived one - a basename from a partial
+// path, a highlight language from a partial extension, a line range from a
+// half-typed number, a whole object from a mid-stream key, and a diff from an
+// `old_text` whose `new_text` had not landed yet. In every case the renderer
+// could not tell "this value is empty" from "this value has not arrived".
+//
+// Rather than re-testing each of those by hand, this states the invariant once:
+//
+//   1. AVAILABILITY - once a parser yields meta, it must keep yielding meta.
+//      Dropping back to null blanks the block for a frame.
+//   2. SETTLEDNESS  - any value shown must already be its final value, except
+//      that a string may grow toward its final value, and a field may sit at a
+//      declared placeholder until it settles.
+//
+// A parser that satisfies both cannot flicker, because nothing it displays can
+// change into something unrelated.
+
+export interface StreamingStabilityCase {
+	/** Parses one streamed prefix of the args blob into display meta. */
+	parse: (argsBlob: string) => unknown;
+	/** The complete args object, serialised and replayed prefix by prefix. */
+	args: unknown;
+	/**
+	 * Values a field may legitimately hold before it settles, keyed by dotted
+	 * path (array indices use `[]`). Example: a highlight language sits at
+	 * `'text'` until the file extension has arrived.
+	 */
+	placeholders?: Record<string, unknown[]>;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Compare one observed value against the settled one, collecting violations.
+ *
+ * Strings may be a prefix of their final value (they are still arriving).
+ * Arrays may be shorter (later elements have not arrived). Everything else must
+ * already equal what it will finally be.
+ */
+function checkSettled(
+	observed: unknown,
+	settled: unknown,
+	path: string,
+	placeholders: Record<string, unknown[]>,
+	violations: string[]
+): void {
+	const allowed = placeholders[path];
+	if (allowed?.some((candidate) => JSON.stringify(candidate) === JSON.stringify(observed))) {
+		return;
+	}
+
+	if (typeof observed === 'string' && typeof settled === 'string') {
+		if (!settled.startsWith(observed)) {
+			violations.push(
+				`${path}: showed ${JSON.stringify(observed)}, which is not a prefix of the final ${JSON.stringify(settled)}`
+			);
+		}
+		return;
+	}
+
+	if (Array.isArray(observed) && Array.isArray(settled)) {
+		if (observed.length > settled.length) {
+			violations.push(
+				`${path}: showed ${observed.length} items, more than the final ${settled.length}`
+			);
+			return;
+		}
+		observed.forEach((item, index) => {
+			checkSettled(item, settled[index], `${path}[]`, placeholders, violations);
+		});
+		return;
+	}
+
+	if (isPlainObject(observed) && isPlainObject(settled)) {
+		for (const key of Object.keys(observed)) {
+			checkSettled(
+				observed[key],
+				settled[key],
+				path ? `${path}.${key}` : key,
+				placeholders,
+				violations
+			);
+		}
+		return;
+	}
+
+	if (JSON.stringify(observed) !== JSON.stringify(settled)) {
+		violations.push(
+			`${path}: showed ${JSON.stringify(observed)} before settling on ${JSON.stringify(settled)}`
+		);
+	}
+}
+
+/**
+ * Replay `args` one character at a time and report every way the parser's output
+ * would visibly change into something other than its final value. An empty array
+ * means the parser cannot flicker for this input.
+ */
+export function findStreamingViolations(testCase: StreamingStabilityCase): string[] {
+	const argsBlob = JSON.stringify(testCase.args);
+	const placeholders = testCase.placeholders ?? {};
+	const settled = testCase.parse(argsBlob);
+
+	if (settled == null) {
+		return ['parser returned null for the complete args blob - the case itself is wrong'];
+	}
+
+	const violations: string[] = [];
+	let becameAvailableAt = -1;
+
+	for (let i = 1; i <= argsBlob.length; i++) {
+		const observed = testCase.parse(argsBlob.slice(0, i));
+
+		if (observed == null) {
+			if (becameAvailableAt !== -1) {
+				violations.push(
+					`availability: went blank at prefix ${i} after first rendering at ${becameAvailableAt}`
+				);
+				// One report is enough; the rest would be the same gap.
+				break;
+			}
+			continue;
+		}
+
+		if (becameAvailableAt === -1) becameAvailableAt = i;
+
+		checkSettled(observed, settled, '', placeholders, violations);
+	}
+
+	// Collapse duplicates: the same violation repeats for every frame it spans.
+	return [...new Set(violations)];
+}

--- a/tools/ui/tests/unit/tool-call-path-flicker.test.ts
+++ b/tools/ui/tests/unit/tool-call-path-flicker.test.ts
@@ -8,7 +8,9 @@
 import { describe, expect, it } from 'vitest';
 import { parseReadFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/read-file';
 import { parseWriteFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/write-file';
-import { AgenticSectionType } from '../../src/lib/enums';
+import { parseEditFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file';
+import { computeLineDiff } from '../../src/lib/utils/compute-line-diff';
+import { AgenticSectionType, DiffLineKind } from '../../src/lib/enums';
 import type { AgenticSection } from '../../src/lib/utils';
 
 const FULL_PATH = '/Users/zach/Dev/llama.cpp/tools/ui/src/lib/utils/code.ts';
@@ -138,5 +140,105 @@ describe('write_file header stability while streaming', () => {
 		}
 
 		expect(languages.size).toBeLessThanOrEqual(2);
+	});
+});
+
+describe('edit_file diff stability while streaming', () => {
+	// `old_text` streams to completion before `new_text` begins. In that window the
+	// edit has a full old value and an empty new one, so a diff built from it shows
+	// every line as deleted - then snaps back as the replacement arrives.
+	const OLD = 'const a = 1;\nconst b = 2;\nconst c = 3;';
+	const NEW = 'const a = 10;\nconst b = 2;\nconst c = 30;';
+	const argsBlob = JSON.stringify({
+		path: '/src/thing.ts',
+		edits: [{ old_text: OLD, new_text: NEW }]
+	});
+
+	it('never renders an all-deletions diff mid-stream', () => {
+		const oldLineCount = OLD.split('\n').length;
+		const offenders: Array<{ at: number; removed: number; added: number }> = [];
+
+		for (let i = 1; i <= argsBlob.length; i++) {
+			const meta = parseEditFileMeta(section('edit_file', argsBlob.slice(0, i)));
+			if (!meta || meta.edits.length === 0) continue;
+
+			for (const edit of meta.edits) {
+				const diff = computeLineDiff(edit.oldText, edit.newText);
+				const removed = diff.filter((line) => line.kind === DiffLineKind.REMOVE).length;
+				const added = diff.filter((line) => line.kind === DiffLineKind.ADD).length;
+
+				// Every old line deleted and nothing added is the "snap" state.
+				if (removed >= oldLineCount && added === 0) {
+					offenders.push({ at: i, removed, added });
+				}
+			}
+		}
+
+		expect(offenders).toEqual([]);
+	});
+
+	it('still produces the correct final diff', () => {
+		const meta = parseEditFileMeta(section('edit_file', argsBlob));
+
+		expect(meta?.edits).toHaveLength(1);
+
+		const diff = computeLineDiff(meta!.edits[0].oldText, meta!.edits[0].newText);
+		const added = diff.filter((line) => line.kind === DiffLineKind.ADD).length;
+		const removed = diff.filter((line) => line.kind === DiffLineKind.REMOVE).length;
+
+		expect(added).toBe(2);
+		expect(removed).toBe(2);
+	});
+});
+
+describe('edit_file withholding does not swallow legitimate edits', () => {
+	it('renders a genuine deletion once the args are complete', () => {
+		const argsBlob = JSON.stringify({
+			path: '/src/thing.ts',
+			edits: [{ old_text: 'gone line one\ngone line two', new_text: '' }]
+		});
+		const meta = parseEditFileMeta(section('edit_file', argsBlob));
+
+		expect(meta?.edits).toHaveLength(1);
+
+		const diff = computeLineDiff(meta!.edits[0].oldText, meta!.edits[0].newText);
+		const removed = diff.filter((line) => line.kind === DiffLineKind.REMOVE).length;
+
+		expect(removed).toBe(2);
+		expect(diff.filter((line) => line.kind === DiffLineKind.ADD)).toHaveLength(0);
+	});
+
+	it('keeps completed edits visible while a later one streams', () => {
+		const full = JSON.stringify({
+			path: '/src/thing.ts',
+			edits: [
+				{ old_text: 'aaa', new_text: 'AAA' },
+				{ old_text: 'bbb', new_text: 'BBB' }
+			]
+		});
+
+		// Cut partway through the second edit's new_text.
+		const cut = full.indexOf('BBB');
+		const meta = parseEditFileMeta(section('edit_file', full.slice(0, cut)));
+
+		// The first edit is complete and must still render.
+		expect(meta?.edits.length).toBeGreaterThanOrEqual(1);
+		expect(meta?.edits[0]).toEqual({ oldText: 'aaa', newText: 'AAA' });
+	});
+
+	it('renders every edit once the call completes', () => {
+		const full = JSON.stringify({
+			path: '/src/thing.ts',
+			edits: [
+				{ old_text: 'aaa', new_text: 'AAA' },
+				{ old_text: 'bbb', new_text: 'BBB' }
+			]
+		});
+		const meta = parseEditFileMeta(section('edit_file', full));
+
+		expect(meta?.edits).toEqual([
+			{ oldText: 'aaa', newText: 'AAA' },
+			{ oldText: 'bbb', newText: 'BBB' }
+		]);
 	});
 });

--- a/tools/ui/tests/unit/tool-call-path-flicker.test.ts
+++ b/tools/ui/tests/unit/tool-call-path-flicker.test.ts
@@ -1,0 +1,102 @@
+// Reproduces the mid-stream flicker in read_file / write_file headers.
+//
+// Tool args arrive token by token, so `path` is a partial string for most of the
+// call. Deriving a basename from it makes the header walk through every path
+// segment ("Us" -> "za" -> "Dev" -> ... -> "foo.ts"), and deriving a language
+// from it makes the syntax highlighter swap grammars mid-render.
+
+import { describe, expect, it } from 'vitest';
+import { parseReadFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/read-file';
+import { parseWriteFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/write-file';
+import { AgenticSectionType } from '../../src/lib/enums';
+import type { AgenticSection } from '../../src/lib/utils';
+
+const FULL_PATH = '/Users/zach/Dev/llama.cpp/tools/ui/src/lib/utils/code.ts';
+
+function section(toolName: string, argsBlob: string): AgenticSection {
+	return {
+		type: AgenticSectionType.TOOL_CALL_STREAMING,
+		content: '',
+		toolName,
+		toolArgs: argsBlob,
+		toolCallId: 'call_1'
+	};
+}
+
+/** Every prefix of the args blob, as the stream would deliver them. */
+function streamPrefixes(argsBlob: string): string[] {
+	const out: string[] = [];
+	for (let i = 1; i <= argsBlob.length; i++) out.push(argsBlob.slice(0, i));
+	return out;
+}
+
+describe('read_file header stability while streaming', () => {
+	const argsBlob = JSON.stringify({ path: FULL_PATH });
+
+	it('settles on the basename once the path is complete', () => {
+		const meta = parseReadFileMeta(section('read_file', argsBlob));
+		expect(meta?.fileName).toBe('code.ts');
+	});
+
+	it('never shows a shrinking or non-monotonic header mid-stream', () => {
+		const seen: string[] = [];
+
+		for (const prefix of streamPrefixes(argsBlob)) {
+			const meta = parseReadFileMeta(section('read_file', prefix));
+			if (meta?.fileName) seen.push(meta.fileName);
+		}
+
+		// Each header must either extend the previous one or be the final
+		// basename. Anything else is a visible flicker.
+		const final = seen[seen.length - 1];
+		const flickers = seen.filter(
+			(value, i) => i > 0 && !value.startsWith(seen[i - 1]) && value !== final
+		);
+
+		expect(flickers).toEqual([]);
+	});
+
+	it('does not swap the highlight language while the path streams', () => {
+		const languages = new Set<string>();
+
+		for (const prefix of streamPrefixes(argsBlob)) {
+			const meta = parseReadFileMeta(section('read_file', prefix));
+			if (meta) languages.add(meta.language);
+		}
+
+		// A language may go from "unknown" to the real one exactly once; more than
+		// two distinct values means the highlighter is thrashing.
+		expect(languages.size).toBeLessThanOrEqual(2);
+	});
+});
+
+describe('write_file header stability while streaming', () => {
+	const argsBlob = JSON.stringify({ path: FULL_PATH, content: 'const a = 1;\nconst b = 2;\n' });
+
+	it('never shows a shrinking or non-monotonic header mid-stream', () => {
+		const seen: string[] = [];
+
+		for (const prefix of streamPrefixes(argsBlob)) {
+			const meta = parseWriteFileMeta(section('write_file', prefix));
+			if (meta?.filePath) seen.push(meta.filePath);
+		}
+
+		const final = seen[seen.length - 1];
+		const flickers = seen.filter(
+			(value, i) => i > 0 && !value.startsWith(seen[i - 1]) && value !== final
+		);
+
+		expect(flickers).toEqual([]);
+	});
+
+	it('does not swap the highlight language while the path streams', () => {
+		const languages = new Set<string>();
+
+		for (const prefix of streamPrefixes(argsBlob)) {
+			const meta = parseWriteFileMeta(section('write_file', prefix));
+			if (meta) languages.add(meta.language);
+		}
+
+		expect(languages.size).toBeLessThanOrEqual(2);
+	});
+});

--- a/tools/ui/tests/unit/tool-call-path-flicker.test.ts
+++ b/tools/ui/tests/unit/tool-call-path-flicker.test.ts
@@ -33,9 +33,9 @@ function streamPrefixes(argsBlob: string): string[] {
 describe('read_file header stability while streaming', () => {
 	const argsBlob = JSON.stringify({ path: FULL_PATH });
 
-	it('settles on the basename once the path is complete', () => {
+	it('shows the full path, matching write_file and edit_file', () => {
 		const meta = parseReadFileMeta(section('read_file', argsBlob));
-		expect(meta?.fileName).toBe('code.ts');
+		expect(meta?.filePath).toBe(FULL_PATH);
 	});
 
 	it('never shows a shrinking or non-monotonic header mid-stream', () => {
@@ -43,15 +43,12 @@ describe('read_file header stability while streaming', () => {
 
 		for (const prefix of streamPrefixes(argsBlob)) {
 			const meta = parseReadFileMeta(section('read_file', prefix));
-			if (meta?.fileName) seen.push(meta.fileName);
+			if (meta?.filePath) seen.push(meta.filePath);
 		}
 
-		// Each header must either extend the previous one or be the final
-		// basename. Anything else is a visible flicker.
-		const final = seen[seen.length - 1];
-		const flickers = seen.filter(
-			(value, i) => i > 0 && !value.startsWith(seen[i - 1]) && value !== final
-		);
+		// Rendering the raw path makes this strictly monotonic - every frame
+		// extends the previous one, with no transition at the end.
+		const flickers = seen.filter((value, i) => i > 0 && !value.startsWith(seen[i - 1]));
 
 		expect(flickers).toEqual([]);
 	});
@@ -67,6 +64,49 @@ describe('read_file header stability while streaming', () => {
 		// A language may go from "unknown" to the real one exactly once; more than
 		// two distinct values means the highlighter is thrashing.
 		expect(languages.size).toBeLessThanOrEqual(2);
+	});
+});
+
+describe('multi-param tool calls do not blank out between parameters', () => {
+	// While a *key name* streams (`,"start_l`), naive closure yields
+	// `{"path":"...","start_l"}` - invalid JSON. That made the parser return null
+	// for every such frame, so the whole block rendered empty between parameters.
+	const argsBlob = JSON.stringify({ path: FULL_PATH, start_line: 1, end_line: 40 });
+
+	it('keeps the path visible for every frame after it arrives', () => {
+		const prefixes = streamPrefixes(argsBlob);
+		const firstWithPath = prefixes.findIndex(
+			(p) => parseReadFileMeta(section('read_file', p))?.filePath
+		);
+
+		expect(firstWithPath).toBeGreaterThan(-1);
+
+		const blankFrames = prefixes
+			.slice(firstWithPath)
+			.map((p, i) => ({ i: i + firstWithPath, meta: parseReadFileMeta(section('read_file', p)) }))
+			.filter((row) => !row.meta?.filePath);
+
+		expect(blankFrames.map((row) => row.i)).toEqual([]);
+	});
+
+	it('still reports the final line range', () => {
+		const meta = parseReadFileMeta(section('read_file', argsBlob));
+
+		expect(meta?.lineRange).toEqual({ start: 1, end: 40 });
+		expect(meta?.filePath).toBe(FULL_PATH);
+	});
+
+	it('never shows a partially-streamed line range', () => {
+		// A range that appears then changes is the same class of flicker.
+		const ranges = new Set<string>();
+
+		for (const prefix of streamPrefixes(argsBlob)) {
+			const meta = parseReadFileMeta(section('read_file', prefix));
+			if (meta?.lineRange) ranges.add(`${meta.lineRange.start}-${meta.lineRange.end}`);
+		}
+
+		// Only the settled range should ever be displayed.
+		expect([...ranges]).toEqual(['1-40']);
 	});
 });
 

--- a/tools/ui/tests/unit/tool-call-streaming-stability.test.ts
+++ b/tools/ui/tests/unit/tool-call-streaming-stability.test.ts
@@ -1,0 +1,144 @@
+// Streaming-stability contract for every tool-call meta parser.
+//
+// ADDING A TOOL BLOCK? Add its parser here. The check replays the args blob one
+// character at a time and fails if the block would ever show a value that later
+// changes into something unrelated - which is what produces visible flicker.
+//
+// See helpers/streaming-stability.ts for the two invariants and why they exist.
+
+import { describe, expect, it } from 'vitest';
+import { AgenticSectionType, BuiltInTool } from '$lib/enums';
+import { DEFAULT_LANGUAGE } from '$lib/constants';
+import type { AgenticSection } from '$lib/utils';
+import { findStreamingViolations } from './helpers/streaming-stability';
+
+import { parseReadFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/read-file';
+import { parseWriteFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/write-file';
+import { parseEditFileMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/edit-file';
+import { parseExecShellCommandMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/exec-shell-command';
+import { parseGrepSearchMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/grep-search';
+import { parseFileGlobSearchMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/file-glob-search';
+import { parseRunJavascriptMeta } from '../../src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageToolCall/parsers/run-javascript';
+
+const FILE_PATH = '/Users/dev/project/src/lib/utils/code.ts';
+
+function sectionFor(toolName: string, argsBlob: string): AgenticSection {
+	return {
+		type: AgenticSectionType.TOOL_CALL_STREAMING,
+		content: '',
+		toolName,
+		toolArgs: argsBlob,
+		toolCallId: 'call_1'
+	};
+}
+
+interface ParserCase {
+	name: string;
+	tool: BuiltInTool;
+	parse: (section: AgenticSection) => unknown;
+	args: unknown;
+	placeholders?: Record<string, unknown[]>;
+}
+
+const CASES: ParserCase[] = [
+	{
+		name: 'read_file (path only)',
+		tool: BuiltInTool.READ_FILE,
+		parse: parseReadFileMeta,
+		args: { path: FILE_PATH },
+		// The highlight language cannot be known until the extension has arrived.
+		placeholders: { language: [DEFAULT_LANGUAGE] }
+	},
+	{
+		name: 'read_file (with line range)',
+		tool: BuiltInTool.READ_FILE,
+		parse: parseReadFileMeta,
+		args: { path: FILE_PATH, start_line: 12, end_line: 480 },
+		placeholders: { language: [DEFAULT_LANGUAGE], lineRange: [null] }
+	},
+	{
+		name: 'write_file',
+		tool: BuiltInTool.WRITE_FILE,
+		parse: parseWriteFileMeta,
+		args: { path: FILE_PATH, content: 'const a = 1;\nconst b = 2;\nexport { a, b };\n' },
+		placeholders: { language: [DEFAULT_LANGUAGE] }
+	},
+	{
+		name: 'edit_file (single edit)',
+		tool: BuiltInTool.EDIT_FILE,
+		parse: parseEditFileMeta,
+		args: {
+			path: FILE_PATH,
+			edits: [{ old_text: 'const a = 1;\nconst b = 2;', new_text: 'const a = 10;\nconst b = 2;' }]
+		}
+	},
+	{
+		name: 'edit_file (multiple edits)',
+		tool: BuiltInTool.EDIT_FILE,
+		parse: parseEditFileMeta,
+		args: {
+			path: FILE_PATH,
+			edits: [
+				{ old_text: 'alpha', new_text: 'ALPHA' },
+				{ old_text: 'beta\ngamma', new_text: 'BETA\nGAMMA' }
+			]
+		}
+	},
+	{
+		name: 'exec_shell_command',
+		tool: BuiltInTool.EXEC_SHELL_COMMAND,
+		parse: parseExecShellCommandMeta,
+		args: { command: 'grep -rn "needle" src/ | head -50' }
+	},
+	{
+		name: 'grep_search',
+		tool: BuiltInTool.GREP_SEARCH,
+		parse: parseGrepSearchMeta,
+		args: { pattern: 'TODO\\(perf\\)', path: 'src/lib', include: '*.ts' }
+	},
+	{
+		name: 'file_glob_search',
+		tool: BuiltInTool.FILE_GLOB_SEARCH,
+		parse: parseFileGlobSearchMeta,
+		// This parser reads `path` + `include`; the stability helper flagged a
+		// `pattern`-only fixture as an invalid case rather than a parser bug.
+		args: { path: 'src/lib', include: '**/*.svelte' }
+	},
+	{
+		name: 'run_javascript',
+		tool: BuiltInTool.RUN_JAVASCRIPT,
+		parse: parseRunJavascriptMeta,
+		args: { code: 'const total = [1, 2, 3].reduce((a, b) => a + b, 0);\nconsole.log(total);' }
+	}
+];
+
+describe('tool-call parsers are stable while their args stream in', () => {
+	for (const testCase of CASES) {
+		it(`${testCase.name}: never shows a value it later changes`, () => {
+			const violations = findStreamingViolations({
+				parse: (argsBlob) => testCase.parse(sectionFor(testCase.tool, argsBlob)),
+				args: testCase.args,
+				placeholders: testCase.placeholders
+			});
+
+			expect(violations).toEqual([]);
+		});
+	}
+
+	it('covers every parser that has a tool block', () => {
+		// Guards against a new tool block being added without a case above.
+		const covered = new Set(CASES.map((testCase) => testCase.tool));
+
+		expect([...covered].sort()).toEqual(
+			[
+				BuiltInTool.READ_FILE,
+				BuiltInTool.WRITE_FILE,
+				BuiltInTool.EDIT_FILE,
+				BuiltInTool.EXEC_SHELL_COMMAND,
+				BuiltInTool.GREP_SEARCH,
+				BuiltInTool.FILE_GLOB_SEARCH,
+				BuiltInTool.RUN_JAVASCRIPT
+			].sort()
+		);
+	});
+});

--- a/tools/ui/tests/unit/tool-calls.test.ts
+++ b/tools/ui/tests/unit/tool-calls.test.ts
@@ -173,11 +173,14 @@ describe('parseEditFileMeta', () => {
 });
 
 describe('parseReadFileMeta', () => {
-	it('parses file name alone (no range)', () => {
+	it('parses the file path alone (no range)', () => {
 		const meta = parseReadFileMeta(
 			makeSection({ toolArgs: '{"path":"/foo.txt"}' }, BuiltInTool.READ_FILE)
 		);
-		expect(meta?.fileName).toBe('foo.txt');
+		// The header renders the whole path, like write_file and edit_file. It used
+		// to collapse to a basename, which made it flicker through every segment as
+		// the value streamed in.
+		expect(meta?.filePath).toBe('/foo.txt');
 		expect(meta?.lineRange).toBeNull();
 	});
 


### PR DESCRIPTION
## Overview

This PR addresses instabilities in the rendering of **tool invocations** in the `llama-server` UI.

This is a **UI-only** PR; no `cpp` core is touched.

## Additional information

acd7a2d3c verifies a processing-state subscription leak as non-issue (lmk if we should keep this)
f25d4bf81 hardens tool call parsing; reduces header renders from 19 -> 1; language highlights 3 -> 1
9cdf7fa54 eradicates 24 blank frames during read-file parsing, reduces header renders from 2 -> 1
9a740427b MarkdownContent 11.50ms -> 2.18ms p95 per streamed token at 26KB
77fce09de edit-file; 16 all-deletion diff frames -> 0 per streamed edit 
e1f38cf91 streaming stability contract across 7 parsers (flicker === gone)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) (YES)
- AI usage disclosure: yes; this is the second half of the work I did with Opus (followup to #26053).

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
