### PR TITLE
cmake : fall back to empty UI on stale assets when provisioning is disabled

### DIFF
--- a/scripts/ui-assets.cmake
+++ b/scripts/ui-assets.cmake
@@ -289,7 +289,7 @@ function(emit_files dist_dir)
     )
     if(NOT rc EQUAL 0)
         if(NOT BUILD_UI AND NOT HF_ENABLED)
-            message(WARNING "UI: could not embed assets from ${dist_dir}; UI provisioning is disabled, building without an embedded UI")
+            message(WARNING "UI: could not embed assets from ${dist_dir}; UI provisioning is disabled (LLAMA_BUILD_UI=OFF, LLAMA_USE_PREBUILT_UI=OFF), building without an embedded UI. Remove ${dist_dir} to silence this.")
             execute_process(
                 COMMAND "${LLAMA_UI_EMBED}" "${UI_CPP}" "${UI_H}"
                 RESULT_VARIABLE rc

--- a/scripts/ui-assets.cmake
+++ b/scripts/ui-assets.cmake
@@ -288,6 +288,16 @@ function(emit_files dist_dir)
         RESULT_VARIABLE rc
     )
     if(NOT rc EQUAL 0)
+        if(NOT BUILD_UI AND NOT HF_ENABLED)
+            message(WARNING "UI: could not embed assets from ${dist_dir}; UI provisioning is disabled, building without an embedded UI")
+            execute_process(
+                COMMAND "${LLAMA_UI_EMBED}" "${UI_CPP}" "${UI_H}"
+                RESULT_VARIABLE rc
+            )
+            if(rc EQUAL 0)
+                return()
+            endif()
+        endif()
         message(FATAL_ERROR "UI: llama-ui-embed failed (${rc})")
     endif()
 endfunction()

--- a/tests/test-ui-assets.cmake
+++ b/tests/test-ui-assets.cmake
@@ -1,0 +1,111 @@
+if(NOT DEFINED UI_ASSETS_SCRIPT OR NOT DEFINED LLAMA_UI_EMBED OR NOT DEFINED TEST_WORK_DIR)
+    message(FATAL_ERROR "missing test configuration")
+endif()
+
+function(make_complete_dist dist_dir)
+    file(WRITE "${dist_dir}/index.html" "<html></html>")
+    set(probe_dir "${dist_dir}/../probe")
+    file(MAKE_DIRECTORY "${probe_dir}")
+    set(probe_args "${probe_dir}/probe.cpp" "${probe_dir}/probe.h" "${dist_dir}")
+
+    execute_process(
+        COMMAND "${LLAMA_UI_EMBED}" ${probe_args}
+        RESULT_VARIABLE probe_result
+        OUTPUT_VARIABLE probe_output
+        ERROR_VARIABLE probe_error
+    )
+    if(probe_result EQUAL 0)
+        return()
+    endif()
+
+    set(probe_log "${probe_output}${probe_error}")
+    string(REGEX MATCH "missing required asset\\(s\\):\n([^\n]+\n)+hint:" missing_block "${probe_log}")
+    if("${missing_block}" STREQUAL "")
+        message(FATAL_ERROR "could not determine required UI assets:\n${probe_log}")
+    endif()
+
+    string(REGEX REPLACE "^missing required asset\\(s\\):\n" "" missing_block "${missing_block}")
+    string(REGEX REPLACE "\nhint:$" "" missing_block "${missing_block}")
+    string(REPLACE "\n" ";" missing_assets "${missing_block}")
+    foreach(asset IN LISTS missing_assets)
+        string(STRIP "${asset}" asset)
+        string(REPLACE "[hash]" "abc123" asset "${asset}")
+        get_filename_component(asset_dir "${dist_dir}/${asset}" DIRECTORY)
+        file(MAKE_DIRECTORY "${asset_dir}")
+        file(WRITE "${dist_dir}/${asset}" "test")
+    endforeach()
+
+    execute_process(
+        COMMAND "${LLAMA_UI_EMBED}" ${probe_args}
+        RESULT_VARIABLE probe_result
+        OUTPUT_VARIABLE probe_output
+        ERROR_VARIABLE probe_error
+    )
+    if(NOT probe_result EQUAL 0)
+        message(FATAL_ERROR "derived UI assets are still incomplete:\n${probe_output}${probe_error}")
+    endif()
+endfunction()
+
+function(test_assets name build_ui hf_enabled expected_result)
+    set(test_dir   "${TEST_WORK_DIR}/${name}")
+    set(source_dir "${test_dir}/source")
+    set(binary_dir "${test_dir}/binary")
+
+    file(REMOVE_RECURSE "${test_dir}")
+    file(MAKE_DIRECTORY "${source_dir}/dist" "${binary_dir}")
+    if(expected_result STREQUAL "embedded")
+        make_complete_dist("${source_dir}/dist")
+    else()
+        file(WRITE "${source_dir}/dist/index.html" "<html></html>")
+    endif()
+
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}"
+            "-DUI_SOURCE_DIR=${source_dir}"
+            "-DUI_BINARY_DIR=${binary_dir}"
+            "-DLLAMA_SOURCE_DIR=${source_dir}"
+            "-DLLAMA_BUILD_NUMBER=1"
+            "-DHF_BUCKET=ggml-org/llama-ui"
+            "-DHF_VERSION=b1"
+            "-DHF_ENABLED=${hf_enabled}"
+            "-DBUILD_UI=${build_ui}"
+            "-DLLAMA_UI_EMBED=${LLAMA_UI_EMBED}"
+            "-DLLAMA_UI_GZIP=OFF"
+            -P "${UI_ASSETS_SCRIPT}"
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+
+    if(expected_result STREQUAL "fatal")
+        if(result EQUAL 0)
+            message(FATAL_ERROR "${name} unexpectedly accepted incomplete assets")
+        endif()
+        if(NOT "${output}${error}" MATCHES "llama-ui-embed failed")
+            message(FATAL_ERROR "${name} failed for an unexpected reason:\n${output}${error}")
+        endif()
+    else()
+        if(NOT result EQUAL 0)
+            message(FATAL_ERROR "${name} failed unexpectedly:\n${output}${error}")
+        endif()
+        if(NOT EXISTS "${binary_dir}/ui.cpp" OR NOT EXISTS "${binary_dir}/ui.h")
+            message(FATAL_ERROR "${name} did not generate UI sources")
+        endif()
+        file(READ "${binary_dir}/ui.cpp" ui_source)
+        if(expected_result STREQUAL "empty" AND ui_source MATCHES "index\\.html")
+            message(FATAL_ERROR "${name} embedded incomplete assets")
+        endif()
+        if(expected_result STREQUAL "empty" AND NOT "${output}${error}" MATCHES "building without an embedded UI")
+            message(FATAL_ERROR "${name} did not warn about the incomplete assets")
+        endif()
+        if(expected_result STREQUAL "embedded" AND NOT ui_source MATCHES "index\\.html")
+            message(FATAL_ERROR "${name} did not embed the valid local assets")
+        endif()
+    endif()
+endfunction()
+
+test_assets(provisioning-disabled OFF OFF empty)
+test_assets(build-enabled         ON  OFF fatal)
+# Priority 1 fails before the prebuilt path can access the network.
+test_assets(prebuilt-enabled      OFF ON  fatal)
+test_assets(valid-local-assets    OFF OFF embedded)

--- a/tools/ui/CMakeLists.txt
+++ b/tools/ui/CMakeLists.txt
@@ -105,3 +105,15 @@ endif()
 target_include_directories(${TARGET} PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+if (BUILD_TESTING AND LLAMA_BUILD_TESTS)
+    add_test(
+        NAME test-ui-assets
+        COMMAND ${CMAKE_COMMAND}
+            "-DUI_ASSETS_SCRIPT=${PROJECT_SOURCE_DIR}/scripts/ui-assets.cmake"
+            "-DLLAMA_UI_EMBED=${LLAMA_UI_EMBED_EXE}"
+            "-DTEST_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/test-ui-assets"
+            -P "${PROJECT_SOURCE_DIR}/tests/test-ui-assets.cmake"
+    )
+    set_tests_properties(test-ui-assets PROPERTIES LABELS main)
+endif()


### PR DESCRIPTION
## Overview

With `LLAMA_BUILD_UI=OFF` and `LLAMA_USE_PREBUILT_UI=OFF`, a leftover `tools/ui/dist` (gitignored, so it silently survives `git pull`) still reached `llama-ui-embed`, which hard-fails on an incomplete asset set and broke the whole `llama-server` build.

This PR makes the embed step, when both provisioning options are disabled, warn and fall back to the empty-UI embed (the same path taken when no assets exist) instead of failing the build. The fatal error is preserved whenever npm building or prebuilt downloads are enabled, and a valid local dist is still embedded as before.

Also adds a CTest (`tests/test-ui-assets.cmake`) that runs `ui-assets.cmake` in script mode against temporary directories and checks the four flag/asset combinations: incomplete assets with provisioning disabled falls back and warns, incomplete assets with either provisioning option enabled still fails, and complete local assets still embed. The required asset list is derived from `llama-ui-embed`'s own error output so the test doesn't go stale when the list changes.

Fixes #25443

## Additional information

The fix is based on the approach proposed by the reporter in #25443. Reproduced on current master before the change: with both flags OFF, a dist containing only a stale `index.html` fails the build with `UI: llama-ui-embed failed (1)`; after the change it warns and builds successfully. Verified a full `llama-server` build with the fix applied.

## Requirements

- [x] I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used Claude (Fable 5) for design review and code review; I wrote/adapted the implementation and ran all reproduction and test steps myself.