### PR TITLE
CUDA : add warp-per-row WKV7 kernel for single-token decode

### DIFF
--- a/ggml/src/ggml-cuda/wkv.cu
+++ b/ggml/src/ggml-cuda/wkv.cu
@@ -141,6 +141,57 @@ static __global__ void rwkv_wkv7_f32(const int B, const int T, const int C, cons
     }
 }
 
+template <int rows_per_block>
+static __global__ void __launch_bounds__(WARP_SIZE * rows_per_block, 2)
+rwkv_wkv7_f32_t1_warp_row(const int T, const int C, const int H, const float * r, const float * w, const float * k, const float * v, const float * a, const float * b, const float * s, float * dst) {
+    constexpr int head_size = CUDA_WKV_BLOCK_SIZE;
+    constexpr int half_head = head_size / 2;
+
+    const int lane = threadIdx.x;
+    const int row  = blockIdx.y * rows_per_block + threadIdx.y;
+    const int bid  = blockIdx.x;
+
+    const int batch_i = bid / H;
+    const int head_i  = bid % H;
+    const int state_size = C * head_size;
+    const int head_off = head_i * head_size;
+    const int t = batch_i * C + head_off + row;
+
+    __shared__ float _r[head_size], _w[head_size], _k[head_size], _a[head_size], _b[head_size];
+
+    if (threadIdx.y == 0) {
+        _r[lane] = r[batch_i * C + head_off + lane];
+        _w[lane] = w[batch_i * C + head_off + lane];
+        _k[lane] = k[batch_i * C + head_off + lane];
+        _a[lane] = a[batch_i * C + head_off + lane];
+        _b[lane] = b[batch_i * C + head_off + lane];
+
+        _r[lane + half_head] = r[batch_i * C + head_off + lane + half_head];
+        _w[lane + half_head] = w[batch_i * C + head_off + lane + half_head];
+        _k[lane + half_head] = k[batch_i * C + head_off + lane + half_head];
+        _a[lane + half_head] = a[batch_i * C + head_off + lane + half_head];
+        _b[lane + half_head] = b[batch_i * C + head_off + lane + half_head];
+    }
+    __syncthreads();
+
+    const int64_t state_base = batch_i * state_size + head_i * head_size * head_size + row * head_size;
+    const float s0 = s[state_base + lane];
+    const float s1 = s[state_base + lane + half_head];
+    const float sa = warp_reduce_sum(_a[lane] * s0 + _a[lane + half_head] * s1);
+
+    const float vt  = v[t];
+    const float st0 = s0 * _w[lane]             + _k[lane]             * vt + sa * _b[lane];
+    const float st1 = s1 * _w[lane + half_head] + _k[lane + half_head] * vt + sa * _b[lane + half_head];
+    const float y   = warp_reduce_sum(st0 * _r[lane] + st1 * _r[lane + half_head]);
+
+    dst[T * C + state_base + lane]             = st0;
+    dst[T * C + state_base + lane + half_head] = st1;
+
+    if (lane == 0) {
+        dst[t] = y;
+    }
+}
+
 void ggml_cuda_op_rwkv_wkv6(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const float * k_d  = (const float *)dst->src[0]->data;
     const float * v_d  = (const float *)dst->src[1]->data;
@@ -191,7 +242,10 @@ void ggml_cuda_op_rwkv_wkv7(ggml_backend_cuda_context & ctx, ggml_tensor * dst) 
     GGML_ASSERT(C % H == 0);
     GGML_ASSERT(C / H == CUDA_WKV_BLOCK_SIZE || C / H == CUDA_WKV_BLOCK_SIZE * 2);
 
-    if (C / H == CUDA_WKV_BLOCK_SIZE) {
+    if (T / B == 1 && C / H == CUDA_WKV_BLOCK_SIZE) {
+        constexpr int rows_per_block = 4;
+        rwkv_wkv7_f32_t1_warp_row<rows_per_block><<<dim3(B * H, CUDA_WKV_BLOCK_SIZE / rows_per_block), dim3(WARP_SIZE, rows_per_block), 0, stream>>>(T, C, H, r_d, w_d, k_d, v_d, a_d, b_d, s_d, dst_d);
+    } else if (C / H == CUDA_WKV_BLOCK_SIZE) {
         rwkv_wkv7_f32<CUDA_WKV_BLOCK_SIZE><<<B * H, C / H, 0, stream>>>(B, T, C, H, r_d, w_d, k_d, v_d, a_d, b_d, s_d, dst_d);
     } else {
         rwkv_wkv7_f32<CUDA_WKV_BLOCK_SIZE * 2><<<B * H, C / H, 0, stream>>>(B, T, C, H, r_d, w_d, k_d, v_d, a_d, b_d, s_d, dst_d);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8777,6 +8777,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 128, 4));
 
     test_cases.emplace_back(new test_rwkv_wkv7(GGML_TYPE_F32, 32, 64, 1, 1));
+    test_cases.emplace_back(new test_rwkv_wkv7(GGML_TYPE_F32, 32, 64, 1, 4));
     test_cases.emplace_back(new test_rwkv_wkv7(GGML_TYPE_F32, 32, 64, 32, 1));
     test_cases.emplace_back(new test_rwkv_wkv7(GGML_TYPE_F32, 32, 64, 32, 4));
     test_cases.emplace_back(new test_rwkv_wkv7(GGML_TYPE_F32, 32, 64, 128, 4));


### PR DESCRIPTION
## Overview

Follow-up to #26080.

This one speeds up the T/B == 1, C/H == 64 case of WKV7 — basically single-token decode on head size 64 models.

Right now each state row is handled by a single thread that keeps its own float state[64] and does the two 64-wide reductions serially. That's a pretty heavy thread, and there's no parallelism in the reduction. So I wrote a new kernel (rwkv_wkv7_f32_t1_warp_row) where a whole warp works on one row — each lane takes care of two columns, and reductions just use warp shuffles.

If the shape doesn't match, it falls back to the existing kernel, nothing changes there.

## Additional information

How it's launched:

```cpp
constexpr int rows_per_block = 4;
block = (32, 4);     // WARP_SIZE x rows_per_block
grid  = (B * H, 16); // CUDA_WKV_BLOCK_SIZE / rows_per_block
```

The kernel is templated on rows_per_block and carries __launch_bounds__(WARP_SIZE * rows_per_block, 2).

I tried rows_per_block = 2, 4 and 8 on my 4080 and got 293.1 / 293.3 / 293.4 tok/s, so it's basically noise — stuck with 4.

What changed:
- ggml/src/ggml-cuda/wkv.cu — the new kernel and the dispatch branch
- tests/test-backend-ops.cpp — added wkv7(F32, H=32, D=64, T=1, B=4) since multi-seq decode wasn't covered

Checked against the CPU backend with F32 inputs (NMSE < 1e-7):

```text
head_count=32, head_size=64, n_seq_tokens=1,   n_seqs=1   PASS
head_count=32, head_size=64, n_seq_tokens=1,   n_seqs=4   PASS
head_count=32, head_size=64, n_seq_tokens=32,  n_seqs=1   PASS
head_count=32, head_size=64, n_seq_tokens=32,  n_seqs=4   PASS
head_count=32, head_size=64, n_seq_tokens=128, n_seqs=4   PASS
5/5 passed
```

The T=32/T=128 ones go through the old kernel, so the fallback path gets a bit of coverage too.

Benchmarks on RWKV7 1.5B Q4_K_M (gen 128, 10 runs, ngl 999, no prompt):

| GPU | CUDA | master | this PR | |
| --- | ---: | ---: | ---: | ---: |
| V100 32GB | 12.8.93 | 146.1 tok/s | 151.9 tok/s | +4.0% |
| RTX 4080 | 13.0.88 | 283.2 tok/s | 293.3 tok/s | +3.5% |

HIP shares this .cu file but I don't have any AMD hardware, so no ROCm numbers unfortunately.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — I used AI to poke around the codebase and sketch early versions of the kernel. The final code and all the benchmarks are mine.