### PR TITLE
CUDA: add GGML_CUDA_DISABLE_TF32 for strict FP32 math

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -200,6 +200,7 @@ option(GGML_CUDA                            "ggml: use CUDA"                    
 option(GGML_MUSA                            "ggml: use MUSA"                                  OFF)
 option(GGML_CUDA_FORCE_MMQ                  "ggml: use mmq kernels instead of cuBLAS"         OFF)
 option(GGML_CUDA_FORCE_CUBLAS               "ggml: always use cuBLAS instead of mmq kernels"  OFF)
+option(GGML_CUDA_DISABLE_TF32               "ggml: use strict FP32 instead of TF32 for F32 math" OFF)
 set   (GGML_CUDA_PEER_MAX_BATCH_SIZE "128" CACHE STRING
                                             "ggml: max. batch size for using peer access")
 option(GGML_CUDA_NO_PEER_COPY               "ggml: do not use peer to peer copies"            OFF)

--- a/ggml/src/ggml-cuda/CMakeLists.txt
+++ b/ggml/src/ggml-cuda/CMakeLists.txt
@@ -143,6 +143,10 @@ if (CUDAToolkit_FOUND)
         add_compile_definitions(GGML_CUDA_FORCE_CUBLAS)
     endif()
 
+    if (GGML_CUDA_DISABLE_TF32)
+        add_compile_definitions(GGML_CUDA_DISABLE_TF32)
+    endif()
+
     if (GGML_CUDA_NO_VMM)
         add_compile_definitions(GGML_CUDA_NO_VMM)
     endif()

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1491,7 +1491,11 @@ struct ggml_backend_cuda_context {
         if (cublas_handles[device] == nullptr) {
             ggml_cuda_set_device(device);
             CUBLAS_CHECK(cublasCreate(&cublas_handles[device]));
+#ifdef GGML_CUDA_DISABLE_TF32
+            CUBLAS_CHECK(cublasSetMathMode(cublas_handles[device], CUBLAS_DEFAULT_MATH));
+#else
             CUBLAS_CHECK(cublasSetMathMode(cublas_handles[device], CUBLAS_TF32_TENSOR_OP_MATH));
+#endif // GGML_CUDA_DISABLE_TF32
         }
         return cublas_handles[device];
     }

--- a/ggml/src/ggml-cuda/mmf.cu
+++ b/ggml/src/ggml-cuda/mmf.cu
@@ -180,7 +180,13 @@ bool ggml_cuda_should_use_mmf(enum ggml_type type, int cc, int warp_size, const 
 
     switch (type) {
         case GGML_TYPE_F32:
+#ifdef GGML_CUDA_DISABLE_TF32
+            // The F32 tile path computes via tf32 MMA; strict-FP32 builds
+            // must fall back to mmvf or cuBLAS SGEMM.
+            return false;
+#else
             return ampere_mma_available(cc) || amd_mfma_available(cc);
+#endif // GGML_CUDA_DISABLE_TF32
         case GGML_TYPE_F16:
             return volta_mma_available(cc) || turing_mma_available(cc) || amd_wmma_available(cc) || amd_mfma_available(cc);
         case GGML_TYPE_BF16:

--- a/ggml/src/ggml-cuda/solve_tri.cu
+++ b/ggml/src/ggml-cuda/solve_tri.cu
@@ -73,7 +73,11 @@ static void solve_tri_f32_cublas(ggml_backend_cuda_context & ctx,
                                     CUBLAS_DIAG_NON_UNIT, k, n, &alpha, A_ptrs_dev, n, X_ptrs_dev, k, total_batches));
 
     // revert to standard mode from common.cuh
+#ifdef GGML_CUDA_DISABLE_TF32
+    CUBLAS_CHECK(cublasSetMathMode(ctx.cublas_handle(id), CUBLAS_DEFAULT_MATH));
+#else
     CUBLAS_CHECK(cublasSetMathMode(ctx.cublas_handle(id), CUBLAS_TF32_TENSOR_OP_MATH));
+#endif // GGML_CUDA_DISABLE_TF32
 
     GGML_UNUSED_VARS(s12, s13);
 }


### PR DESCRIPTION
$\textcolor{red}{\textbf{(USER WAS BANNED FOR THIS POST)}}$

`GGML_CUDA_DISABLE_TF32` does not exist upstream yet; this PR adds it as an opt-in (default OFF) compile option for workloads that need FP32-faithful math on CUDA. With the option OFF nothing changes — every hunk is behind `#ifdef GGML_CUDA_DISABLE_TF32`.

TF32 currently enters F32 math in two places:

1. **cuBLAS**: the math mode is set to `CUBLAS_TF32_TENSOR_OP_MATH` unconditionally (`common.cuh`, and the restore path in `solve_tri.cu`).
2. **The mmf tile kernels**: `ggml_cuda_should_use_mmf` routes every F32 mul_mat with `src1_ncols <= 16` on Ampere+ to tiles that execute `mma.sync...f32.tf32.tf32.f32`, i.e. inputs truncated to a 10-bit mantissa.

The option gates both.

### Motivation and measurements

We port TTS models (synthesize.cpp) and validate tensor-by-tensor against the PyTorch reference. On a GB10 (sm_121), an ALBERT-style encoder stage shows a precision cliff exactly at the mmf dispatch boundary — CUDA-vs-CPU relative deviation on the same F32 weights:

| src1 columns (tokens) | master (mmf/TF32) | with `GGML_CUDA_DISABLE_TF32=ON` |
| --- | --- | --- |
| 4–16 | 1.0e-3 … 2.1e-3 | 2.1e-6 … 7.2e-6 |
| 17–32 (cuBLAS either way) | 1.9e-6 … 5.3e-6 | identical |

Downstream in that model the TF32 noise is consequential: an F0 (pitch) regression head deviated by up to 0.99 Hz, which a phase-accumulating vocoder amplifies into audible-scale spectrum divergence. With the gate, F0 deviation drops to 0.003 Hz.

End-to-end synthesis wall time was unchanged on both our longest and shortest test utterances (the graphs are dominated by wide matmuls that never used mmf); the fallback for ≤16-column F32 is mmvf or cuBLAS SGEMM.

F16/BF16 mmf paths are deliberately untouched: a reduced-precision storage type is its own precision statement, whereas F32 storage carries a strict-FP32 expectation.

### Testing

- Built with `-DGGML_CUDA=ON -DGGML_CUDA_DISABLE_TF32=ON` on GB10 (CUDA 13.0, sm_121); `test-backend-ops` passes (`MUL_MAT`, `SOLVE_TRI` included).
- Default build (option OFF) is textually a no-op: all changes are inside `#ifdef` blocks that are not defined.
