### PR TITLE
server : expose per-device memory usage on /metrics and GET /memory

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3421,6 +3421,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_METRICS"));
     add_opt(common_arg(
+        {"--memory"},
+        string_format("enable the /memory endpoint reporting per-device memory usage (default: %s)", params.endpoint_memory ? "enabled" : "disabled"),
+        [](common_params & params) {
+            params.endpoint_memory = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_MEMORY"));
+    add_opt(common_arg(
         {"--props"},
         string_format("enable changing global properties via POST /props (default: %s)", params.endpoint_props ? "enabled" : "disabled"),
         [](common_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -664,6 +664,7 @@ struct common_params {
     bool endpoint_slots   = true;
     bool endpoint_props   = false; // only control POST requests, not GET
     bool endpoint_metrics = false;
+    bool endpoint_memory  = false;
 
     // enable built-in tools
     std::vector<std::string> server_tools;

--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -72,29 +72,18 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data_impl(
     const size_t nd = llama_model_n_devices(model);
     std::vector<llama_device_memory_data> ret(nd + 1);
 
-    llama_memory_breakdown memory_breakdown = llama_get_memory_breakdown(ctx);
-
-    for (const auto & [buft, mb] : memory_breakdown) {
-        if (ggml_backend_buft_is_host(buft)) {
-            ret.back().mb.model   += mb.model;
-            ret.back().mb.context += mb.context;
-            ret.back().mb.compute += mb.compute;
-            continue;
-        }
-
-        ggml_backend_dev_t dev = ggml_backend_buft_get_device(buft);
-        if (!dev) {
-            continue;
-        }
-        for (size_t i = 0; i < nd; i++) {
-            if (dev == llama_model_get_device(model, i)) {
-                ret[i].mb.model   += mb.model;
-                ret[i].mb.context += mb.context;
-                ret[i].mb.compute += mb.compute;
-                break;
-            }
-        }
+    // rows are the model devices in order, then the host, then leftover buffer types (dropped here)
+    const std::vector<common_memory_breakdown_row> rows = common_memory_breakdown_get(ctx);
+    GGML_ASSERT(rows.size() >= nd + 1 && !rows[nd].is_device);
+    for (size_t i = 0; i < nd; i++) {
+        GGML_ASSERT(rows[i].name == ggml_backend_dev_name(llama_model_get_device(model, i)));
+        ret[i].mb.model   = rows[i].mem.model;
+        ret[i].mb.context = rows[i].mem.context;
+        ret[i].mb.compute = rows[i].mem.compute;
     }
+    ret.back().mb.model   = rows[nd].mem.model;
+    ret.back().mb.context = rows[nd].mem.context;
+    ret.back().mb.compute = rows[nd].mem.compute;
 
     {
         ggml_backend_dev_t cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
@@ -110,9 +99,8 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data_impl(
     for (size_t i = 0; i < nd; i++) {
         ggml_backend_dev_t dev = llama_model_get_device(model, i);
 
-        size_t free;
-        size_t total;
-        ggml_backend_dev_memory(dev, &free, &total);
+        size_t free  = static_cast<size_t>(rows[i].mem.free);
+        size_t total = static_cast<size_t>(rows[i].mem.total);
 
         // Some non-GPU accelerator backends, such as BLAS, report 0/0 and rely on
         // the host-memory fallback. For GPU-like backends, keep 0/0 so --fit does
@@ -811,27 +799,16 @@ enum common_params_fit_status common_fit_params(
     return status;
 }
 
-void common_memory_breakdown_print(const struct llama_context * ctx) {
-    //const auto & devices = ctx->get_model().devices;
+std::vector<common_memory_breakdown_row> common_memory_breakdown_get(const struct llama_context * ctx) {
     const auto * model = llama_get_model(ctx);
 
     std::vector<ggml_backend_dev_t> devices;
+    devices.reserve(llama_model_n_devices(model));
     for (int i = 0; i < llama_model_n_devices(model); i++) {
         devices.push_back(llama_model_get_device(model, i));
     }
 
     llama_memory_breakdown memory_breakdown = llama_get_memory_breakdown(ctx);
-
-    std::vector<std::array<std::string, 9>> table_data;
-    table_data.reserve(devices.size());
-    const std::string template_header = "%s: | %s | %s   %s    %s   %s   %s   %s    %s |\n";
-    const std::string template_gpu    = "%s: | %s | %s = %s + (%s = %s + %s + %s) + %s |\n";
-    const std::string template_other  = "%s: | %s | %s   %s    %s = %s + %s + %s    %s |\n";
-
-    table_data.push_back({template_header, "memory breakdown [MiB]", "total", "free", "self", "model", "context", "compute", "unaccounted"});
-
-    constexpr size_t MiB = 1024 * 1024;
-    const std::vector<std::string> desc_prefixes_strip = {"NVIDIA ", "GeForce ", "Tesla ", "AMD ", "Radeon ", "Instinct "};
 
     // track seen buffer types to avoid double counting:
     std::set<ggml_backend_buffer_type_t> seen_buffer_types;
@@ -869,72 +846,105 @@ void common_memory_breakdown_print(const struct llama_context * ctx) {
         }
     }
 
-    // print memory breakdown for each device:
+    std::vector<common_memory_breakdown_row> rows;
+    rows.reserve(devices.size() + 1);
+
     for (size_t i = 0; i < devices.size(); i++) {
-        ggml_backend_dev_t dev = devices[i];
-        llama_memory_breakdown_data mb = mb_dev[i];
+        size_t free;
+        size_t total;
+        ggml_backend_dev_memory(devices[i], &free, &total);
 
-        const std::string name = ggml_backend_dev_name(dev);
-        std::string desc = ggml_backend_dev_description(dev);
-        for (const std::string & prefix : desc_prefixes_strip) {
-            if (desc.length() >= prefix.length() && desc.substr(0, prefix.length()) == prefix) {
-                desc = desc.substr(prefix.length());
-            }
-        }
-
-        size_t free, total;
-        ggml_backend_dev_memory(dev, &free, &total);
-
-        const size_t self = mb.model + mb.context + mb.compute;
-        const int64_t unaccounted = static_cast<int64_t>(total) - static_cast<int64_t>(free) - static_cast<int64_t>(self);
-
-        table_data.push_back({
-            template_gpu,
-            "  - " + name + " (" + desc + ")",
-            std::to_string(total / MiB),
-            std::to_string(free / MiB),
-            std::to_string(self / MiB),
-            std::to_string(mb.model / MiB),
-            std::to_string(mb.context / MiB),
-            std::to_string(mb.compute / MiB),
-            std::to_string(unaccounted / static_cast<int64_t>(MiB))});
+        common_memory_breakdown_row row;
+        row.name        = ggml_backend_dev_name(devices[i]);
+        row.description = ggml_backend_dev_description(devices[i]);
+        row.is_device   = true;
+        row.mem.total   = static_cast<int64_t>(total);
+        row.mem.free    = static_cast<int64_t>(free);
+        row.mem.model   = mb_dev[i].model;
+        row.mem.context = mb_dev[i].context;
+        row.mem.compute = mb_dev[i].compute;
+        rows.push_back(std::move(row));
     }
 
-    // print memory breakdown for host:
     {
-        const size_t self = mb_host.model + mb_host.context + mb_host.compute;
-        table_data.push_back({
-            template_other,
-            "  - Host",
-            "", // total
-            "", // free
-            std::to_string(self / MiB),
-            std::to_string(mb_host.model / MiB),
-            std::to_string(mb_host.context / MiB),
-            std::to_string(mb_host.compute / MiB),
-            ""}); // unaccounted
+        common_memory_breakdown_row row;
+        row.name        = "Host";
+        row.mem.model   = mb_host.model;
+        row.mem.context = mb_host.context;
+        row.mem.compute = mb_host.compute;
+        rows.push_back(std::move(row));
     }
 
-    // print memory breakdown for all remaining buffer types:
     for (const auto & buft_mb : memory_breakdown) {
         ggml_backend_buffer_type_t          buft = buft_mb.first;
         const llama_memory_breakdown_data & mb   = buft_mb.second;
         if (seen_buffer_types.count(buft) == 1) {
             continue;
         }
-        const std::string name = ggml_backend_buft_name(buft);
-        const size_t self = mb.model + mb.context + mb.compute;
-        table_data.push_back({
-            template_other,
-            "  - " + name,
-            "", // total
-            "", // free
-            std::to_string(self / MiB),
-            std::to_string(mb.model / MiB),
-            std::to_string(mb.context / MiB),
-            std::to_string(mb.compute / MiB),
-            ""}); // unaccounted
+        common_memory_breakdown_row row;
+        row.name        = ggml_backend_buft_name(buft);
+        row.mem.model   = mb.model;
+        row.mem.context = mb.context;
+        row.mem.compute = mb.compute;
+        rows.push_back(std::move(row));
         seen_buffer_types.insert(buft);
+    }
+
+    return rows;
+}
+
+void common_memory_breakdown_print(const struct llama_context * ctx) {
+    const std::vector<common_memory_breakdown_row> rows = common_memory_breakdown_get(ctx);
+
+    std::vector<std::array<std::string, 9>> table_data;
+    table_data.reserve(rows.size() + 1);
+    const std::string template_header = "%s: | %s | %s   %s    %s   %s   %s   %s    %s |\n";
+    const std::string template_gpu    = "%s: | %s | %s = %s + (%s = %s + %s + %s) + %s |\n";
+    const std::string template_other  = "%s: | %s | %s   %s    %s = %s + %s + %s    %s |\n";
+
+    table_data.push_back({template_header, "memory breakdown [MiB]", "total", "free", "self", "model", "context", "compute", "unaccounted"});
+
+    constexpr size_t MiB = 1024 * 1024;
+    const std::vector<std::string> desc_prefixes_strip = {"NVIDIA ", "GeForce ", "Tesla ", "AMD ", "Radeon ", "Instinct "};
+
+    for (const common_memory_breakdown_row & row : rows) {
+        const common_device_memory_data & mem = row.mem;
+
+        const size_t self = mem.model + mem.context + mem.compute;
+
+        if (!row.is_device) {
+            table_data.push_back({
+                template_other,
+                "  - " + row.name,
+                "", // total
+                "", // free
+                std::to_string(self / MiB),
+                std::to_string(mem.model / MiB),
+                std::to_string(mem.context / MiB),
+                std::to_string(mem.compute / MiB),
+                ""}); // unaccounted
+            continue;
+        }
+
+        std::string desc = row.description;
+        for (const std::string & prefix : desc_prefixes_strip) {
+            if (desc.length() >= prefix.length() && desc.substr(0, prefix.length()) == prefix) {
+                desc = desc.substr(prefix.length());
+            }
+        }
+
+        const int64_t unaccounted = mem.total - mem.free - static_cast<int64_t>(self);
+
+        table_data.push_back({
+            template_gpu,
+            "  - " + row.name + " (" + desc + ")",
+            std::to_string(mem.total / static_cast<int64_t>(MiB)),
+            std::to_string(mem.free  / static_cast<int64_t>(MiB)),
+            std::to_string(self / MiB),
+            std::to_string(mem.model / MiB),
+            std::to_string(mem.context / MiB),
+            std::to_string(mem.compute / MiB),
+            std::to_string(unaccounted / static_cast<int64_t>(MiB))});
     }
 
     for (size_t j = 1; j < table_data[0].size(); j++) {

--- a/common/fit.h
+++ b/common/fit.h
@@ -3,6 +3,7 @@
 #include "ggml.h"
 #include "llama.h"
 
+#include <string>
 #include <vector>
 
 enum common_params_fit_status {
@@ -43,6 +44,19 @@ struct common_device_memory_data {
 };
 
 using common_device_memory_data_vec = std::vector<common_device_memory_data>;
+
+// one line of the memory breakdown: a device the model is using, the host, or a buffer type belonging to neither
+struct common_memory_breakdown_row {
+    std::string name;        // ggml_backend_dev_name, "Host", or ggml_backend_buft_name
+    std::string description; // device description, empty on the other rows
+    bool        is_device = false; // total and free are only meaningful when true
+
+    common_device_memory_data mem = {};
+};
+
+// memory ctx has allocated, in the rows common_memory_breakdown_print renders
+// note: the measured counterpart of common_get_device_memory_data below, which projects the same figures from a no_alloc load
+std::vector<common_memory_breakdown_row> common_memory_breakdown_get(const llama_context * ctx);
 
 // Load a model + context with no_alloc and return the per-device memory breakdown.
 common_device_memory_data_vec common_get_device_memory_data(

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3224,6 +3224,9 @@ llama_memory_breakdown llama_context::memory_breakdown() const {
             ret[buft].context += size;
         }
     }
+    if (buf_output) {
+        ret[ggml_backend_buffer_get_type(buf_output.get())].context += ggml_backend_buffer_get_size(buf_output.get());
+    }
     if (model.hparams.no_alloc) {
         for (size_t i = 0; i < backends.size(); ++i) {
             ggml_backend_t             backend = backends[i].get();

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -2148,22 +2148,26 @@ std::map<ggml_backend_dev_t, size_t> mtmd_get_memory_usage(const char * mmproj_f
         mtmd_log_set(stub_log_callback, nullptr); // suppress logging
         ctx.reset(new mtmd_context(mmproj_fname, nullptr, ctx_params, true));
         mtmd_log_set(saved_log_callback, saved_log_user_data); // restore log callback
-        std::map<ggml_backend_dev_t, size_t> total_mem;
-        auto merge = [&](const struct clip_ctx * c) {
-            for (auto & [dev, size] : clip_get_mem_usage(c)) {
-                total_mem[dev] += size;
-            }
-        };
-        if (ctx->ctx_v) {
-            merge(ctx->ctx_v);
-        }
-        if (ctx->ctx_a) {
-            merge(ctx->ctx_a);
-        }
-        return total_mem;
+        return mtmd_get_ctx_memory_usage(ctx.get());
     } catch (const std::exception & e) {
         mtmd_log_set(saved_log_callback, saved_log_user_data); // restore log callback
         LOG_ERR("%s: error: %s\n", __func__, e.what());
         return {};
     }
+}
+
+std::map<ggml_backend_dev_t, size_t> mtmd_get_ctx_memory_usage(const mtmd_context * ctx) {
+    std::map<ggml_backend_dev_t, size_t> total_mem;
+    auto merge = [&](const struct clip_ctx * c) {
+        for (auto & [dev, size] : clip_get_mem_usage(c)) {
+            total_mem[dev] += size;
+        }
+    };
+    if (ctx->ctx_v) {
+        merge(ctx->ctx_v);
+    }
+    if (ctx->ctx_a) {
+        merge(ctx->ctx_a);
+    }
+    return total_mem;
 }

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -342,6 +342,9 @@ MTMD_API mtmd_input_chunks * mtmd_test_create_input_chunks(void);
 MTMD_API std::map<ggml_backend_dev_t, size_t> mtmd_get_memory_usage(
     const char * mmproj_fname,
     struct mtmd_context_params ctx_params);
+
+// Note: same caveat as above; reports the memory currently allocated by a loaded context
+MTMD_API std::map<ggml_backend_dev_t, size_t> mtmd_get_ctx_memory_usage(const mtmd_context * ctx);
 #endif
 
 //

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -214,6 +214,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--cache-prompt, --no-cache-prompt` | whether to enable prompt caching (default: enabled)<br/>(env: LLAMA_ARG_CACHE_PROMPT) |
 | `--cache-reuse N` | min chunk size to attempt reusing from the cache via KV shifting, requires prompt caching to be enabled (default: 0)<br/>[(card)](https://ggml.ai/f0.png)<br/>(env: LLAMA_ARG_CACHE_REUSE) |
 | `--metrics` | enable prometheus compatible metrics endpoint (default: disabled)<br/>(env: LLAMA_ARG_ENDPOINT_METRICS) |
+| `--memory` | enable the /memory endpoint reporting per-device memory usage (default: disabled)<br/>(env: LLAMA_ARG_ENDPOINT_MEMORY) |
 | `--props` | enable changing global properties via POST /props (default: disabled)<br/>(env: LLAMA_ARG_ENDPOINT_PROPS) |
 | `--slots, --no-slots` | expose slots monitoring endpoint (default: enabled)<br/>(env: LLAMA_ARG_ENDPOINT_SLOTS) |
 | `--slot-save-path PATH` | path to save slot kv cache (default: disabled) |
@@ -1074,6 +1075,40 @@ In *router mode* the query param `?model={model_id}` has to be set. This endpoin
 | `llamacpp:n_tokens_max` | Counter | High watermark of the context size observed. |
 | `llamacpp:n_decode_total` | Counter | Total Number of llama_decode() calls. |
 | `llamacpp:n_busy_slots_per_decode` | Gauge | Average number of busy slots per llama_decode() call. |
+| `llamacpp:model_n_layer` | Gauge | Number of layers in the model. |
+| `llamacpp:memory_mmproj_bytes` | Gauge | Memory allocated for the multimodal projector, in bytes. Present only when one is loaded. |
+| `llamacpp:memory_model_bytes` | Gauge | Memory allocated for the model weights, in bytes. |
+| `llamacpp:memory_context_bytes` | Gauge | Memory allocated for the context, in bytes. |
+| `llamacpp:memory_compute_bytes` | Gauge | Memory allocated for compute buffers, in bytes. |
+| `llamacpp:memory_total_bytes` | Gauge | Total memory of the device, in bytes. |
+| `llamacpp:memory_free_bytes` | Gauge | Free memory of the device, in bytes. |
+
+The `memory_*` metrics carry a `device` label holding the backend's own device name, the same name `--device` and `--list-devices` use:
+
+```
+llamacpp:memory_model_bytes{device="CUDA0"} 17825792000
+llamacpp:memory_model_bytes{device="Host"} 13191648
+```
+
+They report the same figures as the memory breakdown printed on exit at trace verbosity (`-lv 4`). `Host` covers the host buffer types, and buffer types belonging to none of the model's devices (such as `CPU_REPACK`) are reported under their own name. `memory_total_bytes` and `memory_free_bytes` come from the backend and describe the whole device, not this process, so they are only present on real devices.
+
+### GET `/memory`: Get the per-device memory breakdown as JSON
+
+The same figures as the `memory_*` metrics above, for API consumers. Requires `--memory`.
+
+**Response format**
+
+```json
+{
+  "n_layer": 12,
+  "data": [
+    {"name": "MTL0", "model": 83349984, "context": 0, "compute": 22559744, "total": 22906503168, "free": 22800187392},
+    {"name": "Host", "model": 13191648, "context": 500640, "compute": 3684352}
+  ]
+}
+```
+
+`n_layer` is the model's layer count. One entry per device, then the host, then any buffer types belonging to none of the model's devices. All memory values are bytes. With a multimodal projector loaded (`--mmproj`), rows also carry `mmproj`, its memory on that device. `total` and `free` describe the whole device and are only present on real devices.
 
 ### POST `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -23,6 +23,7 @@
 #include <exception>
 #include <memory>
 #include <filesystem>
+#include <set>
 #include <utility>
 #include <fstream>
 
@@ -2480,9 +2481,45 @@ private:
                     }
                     SRV_DBG("n_idle_slots = %d, n_processing_slots = %d\n", n_idle_slots, n_processing_slots);
 
+                    json memory_data = json::array();
+                    if (task.metrics_memory) {
+                        // the multimodal projector allocates outside the llama context
+                        std::map<std::string, size_t> mmproj_mem;
+                        if (mctx) {
+                            for (const auto & [dev, size] : mtmd_get_ctx_memory_usage(mctx)) {
+                                const bool is_host = ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_CPU;
+                                mmproj_mem[is_host ? "Host" : ggml_backend_dev_name(dev)] += size;
+                            }
+                        }
+                        const std::vector<common_memory_breakdown_row> mb = common_memory_breakdown_get(ctx_tgt);
+                        for (const common_memory_breakdown_row & row : mb) {
+                            json entry = {
+                                { "name",    row.name        },
+                                { "model",   row.mem.model   },
+                                { "context", row.mem.context },
+                                { "compute", row.mem.compute },
+                            };
+                            const auto it = mmproj_mem.find(row.name);
+                            if (it != mmproj_mem.end()) {
+                                entry["mmproj"] = it->second;
+                                mmproj_mem.erase(it);
+                            }
+                            if (row.is_device) {
+                                entry["total"] = row.mem.total;
+                                entry["free"]  = row.mem.free;
+                            }
+                            memory_data.push_back(std::move(entry));
+                        }
+                        // devices used by the projector but not the model
+                        for (const auto & [name, size] : mmproj_mem) {
+                            memory_data.push_back(json {{ "name", name }, { "mmproj", size }});
+                        }
+                    }
+
                     auto res = std::make_unique<server_task_result_metrics>();
                     res->id                  = task.id;
                     res->slots_data          = std::move(slots_data);
+                    res->memory_data         = std::move(memory_data);
                     res->n_idle_slots        = n_idle_slots;
                     res->n_processing_slots  = n_processing_slots;
                     res->n_tasks_deferred    = queue_tasks.queue_tasks_deferred_size();
@@ -3997,6 +4034,7 @@ server_context_meta server_context::get_meta() const {
         /* model_vocab_type       */ llama_vocab_type(impl->vocab),
         /* model_vocab_n_tokens   */ llama_vocab_n_tokens(impl->vocab),
         /* model_n_ctx_train      */ llama_model_n_ctx_train(impl->model_tgt),
+        /* model_n_layer          */ llama_model_n_layer(impl->model_tgt),
         /* model_n_embd_inp       */ llama_model_n_embd(impl->model_tgt),
         /* model_n_params         */ llama_model_n_params(impl->model_tgt),
         /* model_size             */ llama_model_size(impl->model_tgt),
@@ -4348,6 +4386,7 @@ void server_routes::init_routes() {
         {
             server_task task(SERVER_TASK_TYPE_METRICS);
             task.id = res->rd.get_new_id();
+            task.metrics_memory = true;
             res->rd.post_task(std::move(task), true); // high-priority task
         }
 
@@ -4415,10 +4454,50 @@ void server_routes::init_routes() {
                     {"name",  "n_busy_slots_per_decode"},
                     {"help",  "Average number of busy slots per llama_decode() call"},
                     {"value",  (float) res_task->n_busy_slots_total / std::max((float) res_task->n_decode_total, 1.f)}
+            },{
+                    {"name",  "model_n_layer"},
+                    {"help",  "Number of layers in the model."},
+                    {"value",  meta->model_n_layer}
             }}}
         };
 
+        // memory is reported per device, so several series share each metric name
+        {
+            struct mem_field {
+                const char * key;
+                const char * help;
+            };
+            static constexpr mem_field mem_fields[] = {
+                { "model",   "Memory allocated for the model weights, in bytes."          },
+                { "context", "Memory allocated for the context, in bytes."                },
+                { "compute", "Memory allocated for compute buffers, in bytes."            },
+                { "mmproj",  "Memory allocated for the multimodal projector, in bytes."   },
+                { "total",   "Total memory of the device, in bytes."                      },
+                { "free",    "Free memory of the device, in bytes."                       },
+            };
+
+            json & gauges = all_metrics_def.at("gauge");
+            for (const mem_field & field : mem_fields) {
+                for (const json & entry : res_task->memory_data) {
+                    // skip fields the row does not carry: mmproj is optional, total and free exist only on device rows
+                    const auto it = entry.find(field.key);
+                    if (it == entry.end()) {
+                        continue;
+                    }
+                    gauges.push_back(json {
+                        { "name",   std::string("memory_") + field.key + "_bytes" },
+                        { "help",   field.help                                    },
+                        { "labels", json {{ "device", entry.at("name") }}         },
+                        { "value",  *it                                           },
+                    });
+                }
+            }
+        }
+
         std::stringstream prometheus;
+
+        // a metric name may carry several label sets, but is only described once
+        std::set<std::string> described;
 
         for (const auto & el : all_metrics_def.items()) {
             const auto & type        = el.key();
@@ -4428,10 +4507,37 @@ void server_routes::init_routes() {
                 const std::string name = metric_def.at("name");
                 const std::string help = metric_def.at("help");
 
-                auto value = json_value(metric_def, "value", 0.);
-                prometheus << "# HELP llamacpp:" << name << " " << help  << "\n"
-                            << "# TYPE llamacpp:" << name << " " << type  << "\n"
-                            << "llamacpp:"        << name << " " << value << "\n";
+                if (described.insert(name).second) {
+                    prometheus << "# HELP llamacpp:" << name << " " << help << "\n"
+                               << "# TYPE llamacpp:" << name << " " << type << "\n";
+                }
+
+                std::string labels;
+                if (metric_def.contains("labels")) {
+                    for (const auto & label : metric_def.at("labels").items()) {
+                        // the exposition format requires backslash, quote and newline escaped in label values
+                        std::string value = label.value().get<std::string>();
+                        string_replace_all(value, "\\", "\\\\");
+                        string_replace_all(value, "\"", "\\\"");
+                        string_replace_all(value, "\n", "\\n");
+                        labels += labels.empty() ? "{" : ",";
+                        labels += label.key() + "=\"" + value + "\"";
+                    }
+                    if (!labels.empty()) {
+                        labels += "}";
+                    }
+                }
+
+                // dump() keeps integers exact, streaming them as double rounds to 6 significant digits
+                // floats stay on the stream because dump() writes inf and nan as null
+                const json value = json_value(metric_def, "value", json(0));
+                prometheus << "llamacpp:" << name << labels << " ";
+                if (value.is_number_integer()) {
+                    prometheus << value.dump();
+                } else {
+                    prometheus << value.get<double>();
+                }
+                prometheus << "\n";
             }
         }
 
@@ -4439,6 +4545,43 @@ void server_routes::init_routes() {
         res->content_type = "text/plain; version=0.0.4";
         res->status = 200;
         res->data = prometheus.str();
+        return res;
+    };
+
+    this->get_memory = [this](const server_http_req & req) {
+        auto res = create_response();
+        if (!params.endpoint_memory) {
+            res->error(format_error_response("This server does not support memory endpoint. Start it with `--memory`", ERROR_TYPE_NOT_SUPPORTED));
+            return res;
+        }
+
+        {
+            server_task task(SERVER_TASK_TYPE_METRICS);
+            task.id = res->rd.get_new_id();
+            task.metrics_memory = true;
+            res->rd.post_task(std::move(task), true); // high-priority task
+        }
+
+        auto result = res->rd.next(req.should_stop);
+        if (!result) {
+            // connection was closed
+            GGML_ASSERT(req.should_stop());
+            return res;
+        }
+
+        if (result->is_error()) {
+            res->error(result->to_json());
+            return res;
+        }
+
+        // TODO: get rid of this dynamic_cast
+        auto res_task = dynamic_cast<server_task_result_metrics*>(result.get());
+        GGML_ASSERT(res_task != nullptr);
+
+        res->ok(json {
+            { "n_layer", meta->model_n_layer               },
+            { "data",    std::move(res_task->memory_data)  },
+        });
         return res;
     };
 
@@ -4551,6 +4694,7 @@ void server_routes::init_routes() {
             { "endpoint_slots",              params.endpoint_slots },
             { "endpoint_props",              params.endpoint_props },
             { "endpoint_metrics",            params.endpoint_metrics },
+            { "endpoint_memory",             params.endpoint_memory },
             { "ui",                          params.ui },
             { "ui_settings",                 meta->json_ui_settings },
             { "chat_template",               tmpl_default },

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -47,6 +47,7 @@ struct server_context_meta {
     enum llama_vocab_type model_vocab_type;
     int32_t model_vocab_n_tokens;
     int32_t model_n_ctx_train;
+    int32_t model_n_layer;
     int32_t model_n_embd_inp;
     uint64_t model_n_params;
     uint64_t model_size;
@@ -129,6 +130,7 @@ struct server_routes {
     // they won't be called until ctx_http.is_ready is set to true
     server_http_context::handler_t get_health;
     server_http_context::handler_t get_metrics;
+    server_http_context::handler_t get_memory;
     server_http_context::handler_t get_slots;
     server_http_context::handler_t post_slots;
     server_http_context::handler_t get_props;

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -35,6 +35,7 @@ static void log_server_request(const httplib::Request & req, const httplib::Resp
         || req.path == "/v1/models"
         || req.path == "/props"
         || req.path == "/metrics"
+        || req.path == "/memory"
     ) {
         return;
     }

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -171,6 +171,8 @@ struct server_task {
 
     // used by SERVER_TASK_TYPE_METRICS
     bool metrics_reset_bucket = false;
+    // querying the devices is only worth it for /metrics and /memory, /slots discards it
+    bool metrics_memory = false;
 
     // used by SERVER_TASK_TYPE_SET_LORA
     std::map<int, float> set_lora; // mapping adapter ID -> scale
@@ -535,6 +537,9 @@ struct server_task_result_metrics : server_task_result {
     // while we can also use std::vector<server_slot> this requires copying the slot object which can be quite messy
     // therefore, we use json to temporarily store the slot.to_json() result
     json slots_data = json::array();
+
+    // one entry per common_memory_breakdown_row, empty unless the task asked for it
+    json memory_data = json::array();
 
     virtual json to_json() override;
 };

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -196,6 +196,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
         // proxy handlers
         // note: routes.get_health stays the same
         routes.get_metrics                 = models_routes->proxy_get;
+        routes.get_memory                  = models_routes->proxy_get;
         routes.post_props                  = models_routes->proxy_post;
         routes.post_completions            = models_routes->proxy_post;
         routes.post_completions_oai        = models_routes->proxy_post;
@@ -233,6 +234,7 @@ int llama_server(common_params & params, int argc, char ** argv) {
     ctx_http.get ("/health",                   ex_wrapper(routes.get_health)); // public endpoint (no API key check)
     ctx_http.get ("/v1/health",                ex_wrapper(routes.get_health)); // public endpoint (no API key check)
     ctx_http.get ("/metrics",                  ex_wrapper(routes.get_metrics));
+    ctx_http.get ("/memory",                   ex_wrapper(routes.get_memory));
     ctx_http.get ("/props",                    ex_wrapper(routes.get_props));
     ctx_http.post("/props",                    ex_wrapper(routes.post_props));
     ctx_http.get ("/models",                   ex_wrapper(routes.get_models)); // public endpoint (no API key check)

--- a/tools/server/tests/unit/test_metrics.py
+++ b/tools/server/tests/unit/test_metrics.py
@@ -1,0 +1,122 @@
+import re
+
+import pytest
+import requests
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+    server.server_metrics = True
+    server.server_memory = True
+
+
+def fetch_metrics() -> str:
+    global server
+    server.start()
+    res = requests.get(f"http://{server.server_host}:{server.server_port}/metrics")
+    assert res.status_code == 200
+    return res.text
+
+
+def parse_series(text: str) -> dict[str, str]:
+    # "llamacpp:name{label="value"} 123" -> {'name{label="value"}': "123"}
+    series = {}
+    for line in text.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        key, _, value = line.partition(" ")
+        series[key.removeprefix("llamacpp:")] = value
+    return series
+
+
+@pytest.mark.parametrize("path", ["/metrics", "/memory"])
+def test_endpoints_disabled_by_default(path: str):
+    global server
+    server.server_metrics = False
+    server.server_memory = False
+    server.start()
+    res = server.make_request("GET", path)
+    assert res.status_code == 501
+
+
+@pytest.mark.parametrize("metrics_on,memory_on", [(True, False), (False, True)])
+def test_gates_are_independent(metrics_on: bool, memory_on: bool):
+    global server
+    server.server_metrics = metrics_on
+    server.server_memory = memory_on
+    server.start()
+    assert server.make_request("GET", "/metrics").status_code == (200 if metrics_on else 501)
+    assert server.make_request("GET", "/memory").status_code == (200 if memory_on else 501)
+
+
+def test_memory_endpoint_reports_devices_as_json():
+    global server
+    server.start()
+    res = server.make_request("GET", "/memory")
+    assert res.status_code == 200
+    assert isinstance(res.body["n_layer"], int) and res.body["n_layer"] > 0
+    rows = res.body["data"]
+    assert isinstance(rows, list) and rows
+    for row in rows:
+        assert isinstance(row["name"], str), row
+        for field in ["model", "context", "compute"]:
+            assert isinstance(row[field], int), row
+        for field in ["total", "free"]:
+            if field in row:
+                assert isinstance(row[field], int), row
+        assert ("total" in row) == ("free" in row), row
+    # the host row is always present and describes no whole device
+    host = next(row for row in rows if row["name"] == "Host")
+    assert "total" not in host and "free" not in host
+
+
+def test_metrics_reports_memory_per_device():
+    series = parse_series(fetch_metrics())
+
+    devices = set()
+    for key in series:
+        match = re.fullmatch(r'memory_model_bytes\{device="([^"]+)"\}', key)
+        if match:
+            devices.add(match.group(1))
+
+    # a CPU-only build still allocates the weights on the host
+    assert devices
+    assert re.fullmatch(r"\d+", series["model_n_layer"]) and int(series["model_n_layer"]) > 0
+    for device in devices:
+        for field in ["model", "context", "compute"]:
+            assert f'memory_{field}_bytes{{device="{device}"}}' in series
+
+
+def test_metrics_byte_values_are_exact_integers():
+    # a byte count streamed as double is rounded to 6 significant digits
+    series = parse_series(fetch_metrics())
+    byte_series = {k: v for k, v in series.items() if k.startswith("memory_")}
+    assert byte_series
+    for key, value in byte_series.items():
+        assert re.fullmatch(r"-?\d+", value), f"{key} is not an exact integer: {value}"
+
+
+def test_metrics_describe_each_name_once():
+    # the exposition format allows only one HELP/TYPE line per metric name; strict parsers reject duplicates
+    text = fetch_metrics()
+    help_names = re.findall(r"^# HELP (\S+)", text, re.MULTILINE)
+    type_names = re.findall(r"^# TYPE (\S+)", text, re.MULTILINE)
+    assert help_names
+    assert len(help_names) == len(set(help_names))
+    assert help_names == type_names
+
+
+def test_memory_reports_mmproj():
+    global server
+    server = ServerPreset.tinygemma3()
+    server.server_memory = True
+    server.start(timeout_seconds=60)
+    res = server.make_request("GET", "/memory")
+    assert res.status_code == 200
+    rows = res.body["data"]
+    assert any(isinstance(row.get("mmproj"), int) and row["mmproj"] > 0 for row in rows), rows

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -85,6 +85,7 @@ class ServerProcess:
     server_embeddings: bool | None = False
     server_reranking: bool | None = False
     server_metrics: bool | None = False
+    server_memory: bool | None = False
     kv_unified: bool | None = False
     server_slots: bool | None = False
     pooling: str | None = None
@@ -192,6 +193,8 @@ class ServerProcess:
             server_args.append("--reranking")
         if self.server_metrics:
             server_args.append("--metrics")
+        if self.server_memory:
+            server_args.append("--memory")
         if self.kv_unified:
             server_args.append("--kv-unified")
         if self.server_slots:


### PR DESCRIPTION
## Overview

Closes #26129

llama-server now reports its memory usage: how many bytes it allocated on each GPU (and in host RAM), split into model weights, context/KV cache, and compute buffers - plus each device's total and free memory.

Two surfaces over the same data: `/metrics` for Prometheus/Grafana, and `GET /memory` for JSON consumers.

`--metrics` enables the Prometheus surface; a new `--memory` flag enables the JSON one (the `--slots` pattern: one flag per endpoint).

The server has always known these numbers - it prints them at startup and shutdown - but never exposed them anywhere a program can read. I run several llama-server instances sharing a set of GPUs and need to know what each one actually allocated on each card. Today the only way is scraping log lines, which breaks whenever the log format changes.

**1. `common`: made the per-device summary usable on its own.**

The numbers were computed inside the function that prints the shutdown table, so the only way to get them was as text.

They now come from `common_memory_breakdown_get()`: one row per device, plus one for host memory. The print function just renders those rows - same table as before. `--fit`'s memory projection had its own copy of this aggregation and now uses the same function.

One accounting fix along the way: the context's output buffer was missing from the breakdown (and so from the printed table). It's counted now.

No new use of the staging header `src/llama-ext.h`.

**2. `server`: the breakdown on `/metrics` (Prometheus) and `GET /memory` (JSON), plus the model's layer count and the multimodal projector's memory.**

```
llamacpp:memory_model_bytes{device="MTL0"} 83349984
llamacpp:memory_model_bytes{device="Host"} 13191648
llamacpp:memory_total_bytes{device="MTL0"} 22906503168
llamacpp:model_n_layer 12
```

```json
{
  "n_layer": 12,
  "data": [
    {
      "name": "MTL0",
      "model": 83349984,
      "context": 0,
      "compute": 22559744,
      "total": 22906503168,
      "free": 22800187392
    },
    {
      "name": "Host",
      "model": 13191648,
      "context": 500640,
      "compute": 3684352
    }
  ]
}
```

The `device` label / `name` is the backend's own device name - the same `CUDA0` / `MTL0` names that `--list-devices` prints and `--device` accepts.

`/metrics` stays behind `--metrics`. `/memory` gets its own `--memory` flag, advertised on `/props` and refusing with 501 when disabled, like the other optional endpoints.

The JSON response is an object so fields can be added later without breaking clients - `n_layer` next to `data` is the first.

Both endpoints reuse the existing internal metrics task - no new task type. `/slots` uses that task too and skips the device query.

With a multimodal projector loaded, rows carry its per-device memory too - via a new `mtmd_get_ctx_memory_usage()` that reads the live clip contexts instead of re-estimating from the file. Real output, `tinygemma3` on Metal:

```json
{
  "n_layer": 8,
  "data": [
    {"name": "MTL0", "model": 40707072, "context": 510656512, "compute": 165136416, "mmproj": 2181120, "total": 22906503168, "free": 22187376640},
    {"name": "Host", "model": 35660288, "context": 4195328, "compute": 152064032, "mmproj": 12288}
  ]
}
```

**3. Bug fix the new metrics ran into: `/metrics` rounded large values.**

The exporter formatted every value as a `double`, which silently rounds anything past 6 significant digits. Byte counts made it obvious:

```
# before
llamacpp:memory_total_bytes{device="MTL0"} 2.29065e+10

# after
llamacpp:memory_total_bytes{device="MTL0"} 22906503168
```

This was already quietly affecting `prompt_tokens_total` past a million tokens. Integers are now emitted exactly; float metrics (the throughput averages) keep their old formatting. `# HELP` / `# TYPE` are also emitted once per metric name now that one name can carry several `{device=...}` series.

## Additional information

### Using it

Grafana / Prometheus, straight off `/metrics` - graph VRAM per card, or alert on headroom:

```promql
llamacpp:memory_model_bytes{device="CUDA0"}

# alert: less than 10% of the device left free
(llamacpp:memory_free_bytes / llamacpp:memory_total_bytes) < 0.10
```

Python, off `GET /memory`:

```python
import requests

resp = requests.get("http://localhost:8080/memory").json()
print("layers:", resp["n_layer"])
for row in resp["data"]:
    print(row["name"], f'{row["model"] / 2**20:.1f} MiB weights')
```

```
layers: 12
MTL0 79.5 MiB weights
Host 12.6 MiB weights
```

C++, from anything that links `common`:

```cpp
for (const common_memory_breakdown_row & row : common_memory_breakdown_get(ctx)) {
    printf("%s: model %zu, context %zu, compute %zu bytes\n",
        row.name.c_str(), row.mem.model, row.mem.context, row.mem.compute);
}
```

### Verification

| Check | macOS M1 Pro (Metal) | macOS (CPU-only) | RunPod A40 (CUDA) |
| --- | --- | --- | --- |
| Build: `llama-server`, `llama-cli`, `llama-perplexity`, `llama-bench`, `llama-fit-params` | ok | ok | `llama-server` |
| `/metrics` vs the shutdown breakdown table, same run | exact match (table below) | - | exact match (table below) |
| `GET /memory` JSON | ok (output above) | - | ok (below) |
| `tools/server/tests/unit/test_metrics.py` (9 tests, incl. a vision model exercising `mmproj`) | pass | - | - |
| ASan/UBSan under concurrent `/metrics` + `/memory` + embeddings, and again with `tinygemma3` (mmproj path) | 0 reports | - | - |
| TSan under concurrent `/metrics` + `/memory`, embeddings, and `tinygemma3` (mmproj path) | - | 0 warnings | - |
| `/metrics` wakes a sleeping server (`--sleep-idle-seconds`) | ok | - | - |

Metal cross-check (`nomic-embed-text-v1.5.Q4_K_M`):

| Field | Printed table | `/metrics` |
| --- | --- | --- |
| MTL0 model | 79 MiB | 79.49 MiB |
| MTL0 compute | 21 | 21.51 |
| MTL0 total | 21845 | 21845.34 |
| MTL0 free | 21743 | 21743.95 |
| Host model | 12 | 12.58 |
| Host compute | 3 | 3.51 |

RunPod A40 (CUDA 12.4) cross-check, same model:

| Field | Printed table | `/metrics` |
| --- | --- | --- |
| CUDA0 model | 66 MiB | 66.92 MiB |
| CUDA0 compute | 21 | 21.51 |
| CUDA0 total | 45498 | 45498.00 |
| CUDA0 free | 45109 | 45109.62 |

`GET /memory` on the pod (captured one revision earlier - with the output-buffer accounting, `Host.context` additionally reports the ~0.5 MiB output buffer, as in the Metal example above):

```json
{
  "n_layer": 12,
  "data": [
    {
      "name": "CUDA0",
      "model": 70170624,
      "context": 0,
      "compute": 22559744,
      "total": 47708110848,
      "free": 47301066752
    },
    {
      "name": "Host",
      "model": 13191648,
      "context": 0,
      "compute": 3684352
    }
  ]
}
```

A CPU-only run on the same pod (GPU masked) returns the host-plus-buffer-type shape (`Host` and `CPU_REPACK` rows, no `total`/`free`).

### Prebuilt Binaries 

Prebuilt binaries of this PR for all platforms (built with the repo's own release workflow on my fork): https://github.com/tobocop2/llama.cpp/releases/tag/build-memory-metrics-release-b10139-b11c3a9

### Notes

- `n_layer` rides the memory surfaces because layers are the unit of memory planning (`-ngl`).
- Only device names are exposed, not descriptions - the name is what `--device` takes. Label values are still escaped per the exposition format, since RPC device names embed the user's endpoint string.

Related demand: #23926 (users asking for these numbers after the load report moved out of the default log level).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I designed this change and understand all of it. I used AI assistance to write much of the code and to check it: sanitizer runs (ASan/UBSan/TSan), thread-safety analysis of the metrics task path, and review passes for allocations and project conventions. I reviewed the result line by line.
