### PR TITLE
ggml-cuda : disable MMQ on devices with less than 48 KiB shared memory

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -296,6 +296,15 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         return false;
     }
 
+    // MMQ tiles require at least 48 KiB per-block shared memory; fall back to BLAS otherwise.
+    {
+        const int    id    = ggml_cuda_get_device();
+        const size_t smpbo = ggml_cuda_info().devices[id].smpbo;
+        if (smpbo < 48 * 1024) {
+            return false;
+        }
+    }
+
     if (turing_mma_available(cc)) {
         return true;
     }


### PR DESCRIPTION
## Overview

`ggml_cuda_should_use_mmq()` currently selects MMQ purely from the quantization type. The current MMQ configurations are designed and maintained against a minimum of 48 KiB per-block shared memory, the limit provided by NVIDIA Pascal GPUs and later. On devices that report less, no supported MMQ tile fits and `mul_mat_q_switch_J()` aborts when every tile size exceeds the device's per-block shared memory budget.

This PR disables MMQ when `smpbo < 48 KiB` so the caller falls back to the BLAS path instead of hitting `GGML_ABORT`. Some current MUSA QY1 devices report only 28 KiB and are covered by this guard.


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, This is an issue that Claude found and fixed when I was adapting LLAMA.CPP for MUSA RWKV7 downstream
