### PR TITLE
Keep Minimax's indexer tensors at F32 for speed and accuracy

### DIFF
--- a/conversion/minimax.py
+++ b/conversion/minimax.py
@@ -59,7 +59,7 @@ class MiniMaxM3Model(MiniMaxM2Model):
     model_arch = gguf.MODEL_ARCH.MINIMAXM3
 
     def tensor_force_quant(self, name, new_name, bid, n_dims):
-        if ".indexer." in name:
+        if ".indexer." in new_name:
             return gguf.GGMLQuantizationType.F32
         return super().tensor_force_quant(name, new_name, bid, n_dims)
 

--- a/conversion/minimax.py
+++ b/conversion/minimax.py
@@ -58,6 +58,11 @@ class MiniMaxM2Model(TextModel):
 class MiniMaxM3Model(MiniMaxM2Model):
     model_arch = gguf.MODEL_ARCH.MINIMAXM3
 
+    def tensor_force_quant(self, name, new_name, bid, n_dims):
+        if ".indexer." in name:
+            return gguf.GGMLQuantizationType.F32
+        return super().tensor_force_quant(name, new_name, bid, n_dims)
+
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
 

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -326,6 +326,10 @@ static bool tensor_allows_quantization(const llama_model_quantize_params * param
     quantize &= name.find("ssm_conv1d") == std::string::npos;
     quantize &= name.find("shortconv.conv.weight") == std::string::npos;
 
+    // do not quantize MiniMax's indexer projection weights, they are tiny
+    quantize &= name.find("indexer.k_proj.weight") == std::string::npos;
+    quantize &= name.find("indexer.q_proj.weight") == std::string::npos;
+
     // do not quantize RWKV's small yet 2D weights
     quantize &= name.find("time_mix_first.weight") == std::string::npos;
     quantize &= name.find("time_mix_w0.weight") == std::string::npos;


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Keeps the indexer tensors at F32, bf16 is sometimes slow, and quantizing them saves negligible space anyways.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  NO<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->

Will test this before undrafting though should be safe