### PR TITLE
ggml: add support for MXFP8 CPU

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -154,6 +154,7 @@ class ModelBase:
         self.dir_model_card = dir_model  # overridden in convert_lora_to_gguf.py
         self._is_nvfp4 = False
         self._is_mxfp4 = False
+        self._is_mxfp8 = False
         self._fp8_as_q8 = fp8_as_q8
         self._fp8_dequantized: set[str] = set()
 
@@ -784,8 +785,34 @@ class ModelBase:
 
         del experts, merged
 
+    def _generate_mxfp8_tensors(self):
+        consumed: list[str] = []
+        block_size, type_size = gguf.GGML_QUANT_SIZES[gguf.GGMLQuantizationType.MXFP8]
+
+        for name in self.model_tensors.keys():
+            if not name.endswith(".weight"):
+                continue
+            scale_name = name.removesuffix(".weight") + ".weight_scale"
+            if scale_name not in self.model_tensors:
+                continue
+
+            qs = LazyTorchTensor.to_eager(self.model_tensors[name]()).view(torch.uint8).contiguous().numpy()
+            e = LazyTorchTensor.to_eager(self.model_tensors[scale_name]()).contiguous().numpy()
+            n = qs.shape[-1] // block_size
+            data = np.concatenate(
+                (qs.reshape(*qs.shape[:-1], n, block_size), e.reshape(*e.shape[:-1], n, block_size // 32)),
+                axis=-1,
+            ).reshape(*qs.shape[:-1], n * type_size)
+            new_name = self.map_tensor_name(name)
+            logger.info(f"Repacked {new_name} with shape {list(qs.shape)} and quantization MXFP8")
+            self.gguf_writer.add_tensor(new_name, data, raw_dtype=gguf.GGMLQuantizationType.MXFP8)
+            consumed.extend((name, scale_name))
+
+        for name in consumed:
+            del self.model_tensors[name]
+
     def prepare_tensors(self):
-        # detect NVFP4 quantization (ModelOpt and Compressed-tensors formats)
+        # detect NVFP4/MXFP8 quantization (ModelOpt and Compressed-tensors formats)
         quantization_config = self.hparams.get("quantization_config") or {}
         quant_algo = quantization_config.get("quant_algo")
         quant_method = quantization_config.get("quant_method")
@@ -825,6 +852,7 @@ class ModelBase:
 
         self._is_nvfp4 = quant_algo == "NVFP4"
         self._is_mxfp4 = quant_method == "mxfp4"
+        self._is_mxfp8 = quant_algo == "MXFP8"
 
         # NVFP4 weights are repacked and written directly to gguf_writer.
         # This must run before dequant_model so NVFP4 tensors are removed
@@ -853,6 +881,8 @@ class ModelBase:
                         if input_scale_name not in self.model_tensors:
                             self.model_tensors[input_scale_name] = inverse_scale(self.model_tensors.pop(name))
             self._generate_nvfp4_tensors()
+        elif self._is_mxfp8:
+            self._generate_mxfp8_tensors()
 
         self.dequant_model()
 
@@ -1002,6 +1032,8 @@ class ModelBase:
                 self.ftype = gguf.LlamaFileType.MOSTLY_NVFP4
             elif self._is_mxfp4:
                 self.ftype = gguf.LlamaFileType.MOSTLY_MXFP4_MOE
+            elif self._is_mxfp8:
+                self.ftype = gguf.LlamaFileType.MOSTLY_MXFP8
 
         # Generate parameter weight class (useful for leader boards) if not yet determined
         if self.metadata.size_label is None and total_params > 0:

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -160,6 +160,7 @@ class ModelBase:
         self.dir_model_card = dir_model  # overridden in convert_lora_to_gguf.py
         self._is_nvfp4 = False
         self._is_mxfp4 = False
+        self._is_mxfp8 = False
         self._fp8_as_q8 = fp8_as_q8
         self._fp8_dequantized: set[str] = set()
 
@@ -827,8 +828,34 @@ class ModelBase:
 
         del experts, merged
 
+    def _generate_mxfp8_tensors(self):
+        consumed: list[str] = []
+        block_size, type_size = gguf.GGML_QUANT_SIZES[gguf.GGMLQuantizationType.MXFP8]
+
+        for name in self.model_tensors.keys():
+            if not name.endswith(".weight"):
+                continue
+            scale_name = name.removesuffix(".weight") + ".weight_scale"
+            if scale_name not in self.model_tensors:
+                continue
+
+            qs = LazyTorchTensor.to_eager(self.model_tensors[name]()).view(torch.uint8).contiguous().numpy()
+            e = LazyTorchTensor.to_eager(self.model_tensors[scale_name]()).contiguous().numpy()
+            n = qs.shape[-1] // block_size
+            data = np.concatenate(
+                (qs.reshape(*qs.shape[:-1], n, block_size), e.reshape(*e.shape[:-1], n, block_size // 32)),
+                axis=-1,
+            ).reshape(*qs.shape[:-1], n * type_size)
+            new_name = self.map_tensor_name(name)
+            logger.info(f"Repacked {new_name} with shape {list(qs.shape)} and quantization MXFP8")
+            self.gguf_writer.add_tensor(new_name, data, raw_dtype=gguf.GGMLQuantizationType.MXFP8)
+            consumed.extend((name, scale_name))
+
+        for name in consumed:
+            del self.model_tensors[name]
+
     def prepare_tensors(self):
-        # detect NVFP4 quantization (ModelOpt and Compressed-tensors formats)
+        # detect NVFP4/MXFP8 quantization (ModelOpt and Compressed-tensors formats)
         quantization_config = self.hparams.get("quantization_config") or {}
         quant_algo = quantization_config.get("quant_algo")
         quant_method = quantization_config.get("quant_method")
@@ -868,6 +895,7 @@ class ModelBase:
 
         self._is_nvfp4 = quant_algo in ("NVFP4", "W4A16_NVFP4")
         self._is_mxfp4 = quant_method == "mxfp4"
+        self._is_mxfp8 = quant_algo == "MXFP8"
 
         # NVFP4 weights are repacked and written directly to gguf_writer.
         # This must run before dequant_model so NVFP4 tensors are removed
@@ -896,6 +924,8 @@ class ModelBase:
                         if input_scale_name not in self.model_tensors:
                             self.model_tensors[input_scale_name] = inverse_scale(self.model_tensors.pop(name))
             self._generate_nvfp4_tensors()
+        elif self._is_mxfp8:
+            self._generate_mxfp8_tensors()
 
         self.dequant_model()
 
@@ -1049,6 +1079,8 @@ class ModelBase:
                 self.ftype = gguf.LlamaFileType.MOSTLY_NVFP4
             elif self._is_mxfp4:
                 self.ftype = gguf.LlamaFileType.MOSTLY_MXFP4_MOE
+            elif self._is_mxfp8:
+                self.ftype = gguf.LlamaFileType.MOSTLY_MXFP8
 
         # Generate parameter weight class (useful for leader boards) if not yet determined
         if self.metadata.size_label is None and total_params > 0:

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -430,7 +430,8 @@ extern "C" {
         GGML_TYPE_NVFP4   = 40, // NVFP4 (4 blocks, E4M3 scale)
         GGML_TYPE_Q1_0    = 41,
         GGML_TYPE_Q2_0    = 42,
-        GGML_TYPE_COUNT   = 43,
+        GGML_TYPE_MXFP8   = 43,
+        GGML_TYPE_COUNT   = 44,
     };
 
     // precision
@@ -475,6 +476,7 @@ extern "C" {
         GGML_FTYPE_MOSTLY_NVFP4   = 26, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q1_0    = 27, // except 1d tensors
         GGML_FTYPE_MOSTLY_Q2_0    = 28, // except 1d tensors
+        GGML_FTYPE_MOSTLY_MXFP8   = 29, // except 1d tensors
     };
 
     // available tensor operations:

--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -218,6 +218,14 @@ typedef struct {
 } block_mxfp4;
 static_assert(sizeof(block_mxfp4) == sizeof(uint8_t) + QK_MXFP4/2, "wrong mxfp4 block size/padding");
 
+#define QK_MXFP8 256
+#define QK_MXFP8_SUB 32
+typedef struct {
+    uint8_t qs[QK_MXFP8 / QK_MXFP8_SUB][QK_MXFP8_SUB];
+    uint8_t e[QK_MXFP8 / QK_MXFP8_SUB];
+} block_mxfp8;
+static_assert(sizeof(block_mxfp8) == sizeof(uint8_t)*(QK_MXFP8/QK_MXFP8_SUB) + QK_MXFP8, "wrong mxfp8 block size/padding");
+
 #define QK_NVFP4 64
 #define QK_NVFP4_SUB 16  // sub-block size for per-group scales
 typedef struct {
@@ -1127,6 +1135,27 @@ GGML_TABLE_BEGIN(int8_t, kvalues_fp4, 16)
     0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12,
 GGML_TABLE_END()
 #define kvalues_mxfp4 kvalues_fp4
+
+#if defined(GGML_COMMON_IMPL_C)
+GGML_TABLE_BEGIN(int32_t, kvalues_mxfp8, 128)
+    0, 1, 2, 3, 4, 5, 6, 7,
+    8, 9, 10, 11, 12, 13, 14, 15,
+    16, 18, 20, 22, 24, 26, 28, 30,
+    32, 36, 40, 44, 48, 52, 56, 60,
+    64, 72, 80, 88, 96, 104, 112, 120,
+    128, 144, 160, 176, 192, 208, 224, 240,
+    256, 288, 320, 352, 384, 416, 448, 480,
+    512, 576, 640, 704, 768, 832, 896, 960,
+    1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920,
+    2048, 2304, 2560, 2816, 3072, 3328, 3584, 3840,
+    4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680,
+    8192, 9216, 10240, 11264, 12288, 13312, 14336, 15360,
+    16384, 18432, 20480, 22528, 24576, 26624, 28672, 30720,
+    32768, 36864, 40960, 45056, 49152, 53248, 57344, 61440,
+    65536, 73728, 81920, 90112, 98304, 106496, 114688, 122880,
+    131072, 147456, 163840, 180224, 196608, 212992, 229376, 0,
+GGML_TABLE_END()
+#endif
 
 #define NGRID_IQ1S 2048
 #define IQ1S_DELTA 0.125f

--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -15,6 +15,7 @@
 #define ggml_vec_dot_q5_1_q8_1_generic ggml_vec_dot_q5_1_q8_1
 #define ggml_vec_dot_q8_0_q8_0_generic ggml_vec_dot_q8_0_q8_0
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
+#define ggml_vec_dot_mxfp8_q8_0_generic ggml_vec_dot_mxfp8_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
@@ -113,6 +114,7 @@
 // ref: https://github.com/ggml-org/llama.cpp/pull/14146#issuecomment-2972561679
 // quants.c
 #define quantize_row_q8_K_generic quantize_row_q8_K
+#define ggml_vec_dot_mxfp8_q8_0_generic ggml_vec_dot_mxfp8_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
@@ -163,6 +165,7 @@
 #define ggml_vec_dot_tq2_0_q8_K_generic ggml_vec_dot_tq2_0_q8_K
 #define ggml_vec_dot_iq1_m_q8_K_generic ggml_vec_dot_iq1_m_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
+#define ggml_vec_dot_mxfp8_q8_0_generic ggml_vec_dot_mxfp8_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
@@ -205,6 +208,7 @@
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
 #elif defined(__riscv)
 // quants.c
+#define ggml_vec_dot_mxfp8_q8_0_generic ggml_vec_dot_mxfp8_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
 // repack.cpp
@@ -246,6 +250,7 @@
 #elif defined(__s390x__)
 // quants.c
 #define quantize_row_q8_K_generic quantize_row_q8_K
+#define ggml_vec_dot_mxfp8_q8_0_generic ggml_vec_dot_mxfp8_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
@@ -310,6 +315,7 @@
 #define ggml_vec_dot_iq4_nl_q8_0_generic ggml_vec_dot_iq4_nl_q8_0
 #define ggml_vec_dot_iq4_xs_q8_K_generic ggml_vec_dot_iq4_xs_q8_K
 #define ggml_vec_dot_mxfp4_q8_0_generic ggml_vec_dot_mxfp4_q8_0
+#define ggml_vec_dot_mxfp8_q8_0_generic ggml_vec_dot_mxfp8_q8_0
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
 #define ggml_vec_dot_q1_0_q8_0_generic ggml_vec_dot_q1_0_q8_0
 #define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0

--- a/ggml/src/ggml-cpu/arch/arm/quants.c
+++ b/ggml/src/ggml-cpu/arch/arm/quants.c
@@ -807,6 +807,65 @@ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
     *s = sumf;
 }
 
+void ggml_vec_dot_mxfp8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    assert(n % QK_MXFP8 == 0);
+    static_assert(QK_MXFP8_SUB == QK8_0, "QK_MXFP8_SUB and QK8_0 must be the same");
+
+#if defined(__ARM_NEON)
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+
+    const block_mxfp8 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_MXFP8;
+    const int n_sub = QK_MXFP8 / QK_MXFP8_SUB;
+
+    const uint32x4_t one = vdupq_n_u32(1);
+    const uint32x4_t seven = vdupq_n_u32(7);
+    const uint32x4_t eight = vdupq_n_u32(8);
+    const uint32x4_t mask = vdupq_n_u32(0x7f);
+
+    float sumf = 0;
+
+    for (int ib = 0; ib < nb; ++ib) {
+        for (int s_idx = 0; s_idx < n_sub; ++s_idx) {
+            const block_q8_0 * yb = &y[ib*n_sub + s_idx];
+            int32x4_t sumi = vdupq_n_s32(0);
+
+            for (int i = 0; i < QK_MXFP8_SUB; i += 8) {
+                const uint16x8_t codes16 = vmovl_u8(vld1_u8(x[ib].qs[s_idx] + i));
+                const int16x8_t qy16 = vmovl_s8(vld1_s8(yb->qs + i));
+
+                for (int j = 0; j < 2; ++j) {
+                    const uint32x4_t codes = vmovl_u16(j ? vget_high_u16(codes16) : vget_low_u16(codes16));
+                    const uint32x4_t ax = vandq_u32(codes, mask);
+                    const uint32x4_t exp = vshrq_n_u32(ax, 3);
+                    const uint32x4_t man = vandq_u32(ax, seven);
+                    uint32x4_t mag = vshlq_u32(vaddq_u32(man, eight), vreinterpretq_s32_u32(vsubq_u32(exp, one)));
+                    mag = vbslq_u32(vceqq_u32(exp, vdupq_n_u32(0)), man, mag);
+                    mag = vbicq_u32(mag, vceqq_u32(ax, mask));
+                    const int32x4_t sign = vshrq_n_s32(vreinterpretq_s32_u32(vshlq_n_u32(codes, 24)), 31);
+                    const int32x4_t qx = vsubq_s32(veorq_s32(vreinterpretq_s32_u32(mag), sign), sign);
+                    const int32x4_t qy = vmovl_s16(j ? vget_high_s16(qy16) : vget_low_s16(qy16));
+                    sumi = vmlaq_s32(sumi, qx, qy);
+                }
+            }
+
+            const float d = GGML_CPU_FP16_TO_FP32(yb->d) * GGML_E8M0_TO_FP32(x[ib].e[s_idx]) * (1.0f / 512.0f);
+            sumf += d * vaddvq_s32(sumi);
+        }
+    }
+
+    *s = sumf;
+#else
+    ggml_vec_dot_mxfp8_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
+#endif
+}
+
 void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     assert(nrc == 1);
     UNUSED(nrc);

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -1001,6 +1001,64 @@ void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const vo
     *s = sumf;
 }
 
+void ggml_vec_dot_mxfp8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    assert(n % QK_MXFP8 == 0);
+    static_assert(QK_MXFP8_SUB == QK8_0, "QK_MXFP8_SUB and QK8_0 must be the same");
+
+#if defined(__AVX2__)
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+
+    const block_mxfp8 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_MXFP8;
+    const int n_sub = QK_MXFP8 / QK_MXFP8_SUB;
+
+    __m256 sumf = _mm256_setzero_ps();
+    const __m256i subnormals = _mm256_setr_epi16(
+        0x0000, 0x1800, 0x1c00, 0x1e00, 0x2000, 0x2100, 0x2200, 0x2300,
+        0x0000, 0x1800, 0x1c00, 0x1e00, 0x2000, 0x2100, 0x2200, 0x2300);
+    const __m256i mask = _mm256_set1_epi16(0x7f);
+
+    for (int ib = 0; ib < nb; ++ib) {
+        for (int s_idx = 0; s_idx < n_sub; ++s_idx) {
+            const block_q8_0 * yb = &y[ib*n_sub + s_idx];
+            __m256 sumi = _mm256_setzero_ps();
+
+            for (int i = 0; i < QK_MXFP8_SUB; i += 16) {
+                const __m256i codes = _mm256_cvtepu8_epi16(_mm_loadu_si128((const __m128i *) (x[ib].qs[s_idx] + i)));
+                const __m256i ax = _mm256_and_si256(codes, mask);
+                const __m256i idx = _mm256_add_epi16(
+                    _mm256_mullo_epi16(_mm256_and_si256(ax, _mm256_set1_epi16(7)), _mm256_set1_epi16(0x0202)),
+                    _mm256_set1_epi16(0x0100));
+                const __m256i normal = _mm256_slli_epi16(_mm256_add_epi16(ax, _mm256_set1_epi16(64)), 7);
+                __m256i fp16 = _mm256_blendv_epi8(normal, _mm256_shuffle_epi8(subnormals, idx),
+                                                  _mm256_cmpgt_epi16(_mm256_set1_epi16(8), ax));
+                fp16 = _mm256_xor_si256(fp16, _mm256_and_si256(_mm256_slli_epi16(codes, 8), _mm256_set1_epi16(-32768)));
+                fp16 = _mm256_andnot_si256(_mm256_cmpeq_epi16(ax, mask), fp16);
+
+                const __m128i q8 = _mm_loadu_si128((const __m128i *) (yb->qs + i));
+                const __m256 qy0 = _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(q8));
+                const __m256 qy1 = _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(q8, 8)));
+                sumi = _mm256_fmadd_ps(_mm256_cvtph_ps(_mm256_castsi256_si128(fp16)), qy0, sumi);
+                sumi = _mm256_fmadd_ps(_mm256_cvtph_ps(_mm256_extracti128_si256(fp16, 1)), qy1, sumi);
+            }
+
+            const __m256 d = _mm256_set1_ps(GGML_CPU_FP16_TO_FP32(yb->d) * GGML_E8M0_TO_FP32(x[ib].e[s_idx]));
+            sumf = _mm256_fmadd_ps(d, sumi, sumf);
+        }
+    }
+
+    *s = hsum_float_8(sumf);
+#else
+    ggml_vec_dot_mxfp8_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
+#endif
+}
+
 void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     assert(nrc == 1);
     UNUSED(nrc);

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -289,6 +289,11 @@ static const struct ggml_type_traits_cpu type_traits_cpu[GGML_TYPE_COUNT] = {
         .vec_dot_type             = GGML_TYPE_Q8_0,
         .nrows                    = 1,
     },
+    [GGML_TYPE_MXFP8] = {
+        .vec_dot                  = ggml_vec_dot_mxfp8_q8_0,
+        .vec_dot_type             = GGML_TYPE_Q8_0,
+        .nrows                    = 1,
+    },
     [GGML_TYPE_NVFP4] = {
         .from_float               = quantize_row_nvfp4,
         .vec_dot                  = ggml_vec_dot_nvfp4_q8_0,

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -4528,6 +4528,7 @@ void ggml_compute_forward_out_prod(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP8:
         case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
@@ -5030,6 +5031,7 @@ void ggml_compute_forward_get_rows(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP8:
         case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
@@ -5787,6 +5789,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP8:
         case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:

--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -4657,6 +4657,7 @@ void ggml_compute_forward_out_prod(
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP8:
         case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
@@ -5159,6 +5160,7 @@ void ggml_compute_forward_get_rows(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP8:
         case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
@@ -5916,6 +5918,7 @@ void ggml_compute_forward_clamp(
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_Q8_1:
         case GGML_TYPE_MXFP4:
+        case GGML_TYPE_MXFP8:
         case GGML_TYPE_NVFP4:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:

--- a/ggml/src/ggml-cpu/quants.c
+++ b/ggml/src/ggml-cpu/quants.c
@@ -326,6 +326,39 @@ void ggml_vec_dot_mxfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, 
     *s = sumf;
 }
 
+void ggml_vec_dot_mxfp8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+    assert(n % QK_MXFP8 == 0);
+    static_assert(QK_MXFP8_SUB == QK8_0, "QK_MXFP8_SUB and QK8_0 must be the same");
+
+    const block_mxfp8 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const int nb = n / QK_MXFP8;
+    const int n_sub = QK_MXFP8 / QK_MXFP8_SUB;
+
+    float sumf = 0;
+
+    for (int ib = 0; ib < nb; ++ib) {
+        for (int s_idx = 0; s_idx < n_sub; ++s_idx) {
+            const block_q8_0 * yb = &y[ib*n_sub + s_idx];
+            int32_t sumi = 0;
+            for (int j = 0; j < QK_MXFP8_SUB; ++j) {
+                const uint8_t q = x[ib].qs[s_idx][j];
+                const int32_t v = kvalues_mxfp8[q & 0x7F];
+                sumi += (q & 0x80 ? -v : v) * yb->qs[j];
+            }
+            const float d = GGML_CPU_FP16_TO_FP32(yb->d) * GGML_E8M0_TO_FP32(x[ib].e[s_idx]) * (1.0f / 512.0f);
+            sumf += d * sumi;
+        }
+    }
+    *s = sumf;
+}
+
 // NVFP4: super-block of 64 elements = 4 sub-blocks of 16 = 2 q8_0 blocks
 void ggml_vec_dot_nvfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     assert(nrc == 1);

--- a/ggml/src/ggml-cpu/quants.h
+++ b/ggml/src/ggml-cpu/quants.h
@@ -47,6 +47,7 @@ void ggml_vec_dot_q5_1_q8_1(int n, float * GGML_RESTRICT s, size_t bs, const voi
 void ggml_vec_dot_q8_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_mxfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_mxfp8_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_nvfp4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_q2_K_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
@@ -81,6 +82,7 @@ void ggml_vec_dot_q5_1_q8_1_generic(int n, float * GGML_RESTRICT s, size_t bs, c
 void ggml_vec_dot_q8_0_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_mxfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
+void ggml_vec_dot_mxfp8_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 void ggml_vec_dot_nvfp4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);
 
 void ggml_vec_dot_tq1_0_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc);

--- a/ggml/src/ggml-quants.c
+++ b/ggml/src/ggml-quants.c
@@ -586,6 +586,29 @@ void dequantize_row_mxfp4(const block_mxfp4 * GGML_RESTRICT x, float * GGML_REST
     }
 }
 
+void dequantize_row_mxfp8(const block_mxfp8 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
+    static const int qk = QK_MXFP8;
+    static const int qk_sub = QK_MXFP8_SUB;
+    static const int n_sub = QK_MXFP8 / QK_MXFP8_SUB;
+
+    assert(k % qk == 0);
+
+    const int nb = k / qk;
+
+    for (int i = 0; i < nb; i++) {
+        for (int s = 0; s < n_sub; s++) {
+            const float d = GGML_E8M0_TO_FP32(x[i].e[s]) * (1.0f / 512.0f);
+            float * yb = y + i*qk + s*qk_sub;
+
+            for (int j = 0; j < qk_sub; j++) {
+                const uint8_t q = x[i].qs[s][j];
+                const float v = d * kvalues_mxfp8[q & 0x7F];
+                yb[j] = q & 0x80 ? -v : v;
+            }
+        }
+    }
+}
+
 void dequantize_row_nvfp4(const block_nvfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
     static const int qk = QK_NVFP4;
     static const int qk_sub = QK_NVFP4_SUB;
@@ -5396,6 +5419,16 @@ static bool validate_e_e8m0(uint8_t e, size_t i) {
         } \
     }
 
+#define VALIDATE_ROW_DATA_EVEC_E8M0_IMPL(type, data, nb, nr) \
+    const type * q = (const type *) (data); \
+    for (size_t i = 0; i < (nb); ++i) { \
+        for (size_t j = 0; j < (nr); ++j) { \
+            if (!validate_e_e8m0(q[i].e[j], i)) { \
+                return false; \
+            } \
+        } \
+    }
+
 #define VALIDATE_ROW_DATA_DVEC_F16_IMPL(type, data, nb, nr) \
     const type * q = (const type *) (data); \
     for (size_t i = 0; i < (nb); ++i) { \
@@ -5560,6 +5593,10 @@ bool ggml_validate_row_data(enum ggml_type type, const void * data, size_t nbyte
         case GGML_TYPE_MXFP4:
             {
                 VALIDATE_ROW_DATA_E_E8M0_IMPL(block_mxfp4, data, nb);
+            } break;
+        case GGML_TYPE_MXFP8:
+            {
+                VALIDATE_ROW_DATA_EVEC_E8M0_IMPL(block_mxfp8, data, nb, QK_MXFP8 / QK_MXFP8_SUB);
             } break;
         case GGML_TYPE_NVFP4:
             {

--- a/ggml/src/ggml-quants.h
+++ b/ggml/src/ggml-quants.h
@@ -53,6 +53,7 @@ GGML_API void dequantize_row_q8_0(const block_q8_0 * GGML_RESTRICT x, float * GG
 //GGML_API void dequantize_row_q8_1(const block_q8_1 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_mxfp4(const block_mxfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
+GGML_API void dequantize_row_mxfp8(const block_mxfp8 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 GGML_API void dequantize_row_nvfp4(const block_nvfp4 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);
 
 GGML_API void dequantize_row_q2_K(const block_q2_K * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k);

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -756,6 +756,13 @@ static const struct ggml_type_traits type_traits[GGML_TYPE_COUNT] = {
         .to_float                 = (ggml_to_float_t) dequantize_row_mxfp4,
         .from_float_ref           = (ggml_from_float_t)quantize_row_mxfp4_ref,
     },
+    [GGML_TYPE_MXFP8] = {
+        .type_name                = "mxfp8",
+        .blck_size                = QK_MXFP8,
+        .type_size                = sizeof(block_mxfp8),
+        .is_quantized             = true,
+        .to_float                 = (ggml_to_float_t) dequantize_row_mxfp8,
+    },
     [GGML_TYPE_NVFP4] = {
         .type_name                = "nvfp4",
         .blck_size                = QK_NVFP4,
@@ -1438,6 +1445,7 @@ enum ggml_type ggml_ftype_to_ggml_type(enum ggml_ftype ftype) {
         case GGML_FTYPE_MOSTLY_Q5_1:          wtype = GGML_TYPE_Q5_1;  break;
         case GGML_FTYPE_MOSTLY_Q8_0:          wtype = GGML_TYPE_Q8_0;  break;
         case GGML_FTYPE_MOSTLY_MXFP4:         wtype = GGML_TYPE_MXFP4; break;
+        case GGML_FTYPE_MOSTLY_MXFP8:         wtype = GGML_TYPE_MXFP8; break;
         case GGML_FTYPE_MOSTLY_NVFP4:         wtype = GGML_TYPE_NVFP4; break;
         case GGML_FTYPE_MOSTLY_Q2_K:          wtype = GGML_TYPE_Q2_K;  break;
         case GGML_FTYPE_MOSTLY_Q3_K:          wtype = GGML_TYPE_Q3_K;  break;

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -4639,6 +4639,7 @@ class GGMLQuantizationType(IntEnum):
     NVFP4   = 40
     Q1_0    = 41
     Q2_0    = 42
+    MXFP8   = 43
 
 
 class ExpertGatingFuncType(IntEnum):
@@ -4695,6 +4696,7 @@ class LlamaFileType(IntEnum):
     MOSTLY_NVFP4         = 39  # except 1d tensors
     MOSTLY_Q1_0          = 40  # except 1d tensors
     MOSTLY_Q2_0          = 41  # except 1d tensors
+    MOSTLY_MXFP8         = 42  # except 1d tensors
 
     GUESSED              = 1024  # not specified in the model file
 
@@ -4822,6 +4824,7 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.NVFP4:   (64, 4 + 32),
     GGMLQuantizationType.Q1_0:    (128, 2 + 16),
     GGMLQuantizationType.Q2_0:    (64, 2 + 16),
+    GGMLQuantizationType.MXFP8:   (256, 256 + 8),
 }
 
 

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -5511,6 +5511,7 @@ class GGMLQuantizationType(IntEnum):
     NVFP4   = 40
     Q1_0    = 41
     Q2_0    = 42
+    MXFP8   = 43
 
 
 class ExpertGatingFuncType(IntEnum):
@@ -5567,6 +5568,7 @@ class LlamaFileType(IntEnum):
     MOSTLY_NVFP4         = 39  # except 1d tensors
     MOSTLY_Q1_0          = 40  # except 1d tensors
     MOSTLY_Q2_0          = 41  # except 1d tensors
+    MOSTLY_MXFP8         = 42  # except 1d tensors
 
     GUESSED              = 1024  # not specified in the model file
 
@@ -5703,6 +5705,7 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.NVFP4:   (64, 4 + 32),
     GGMLQuantizationType.Q1_0:    (128, 2 + 16),
     GGMLQuantizationType.Q2_0:    (64, 2 + 16),
+    GGMLQuantizationType.MXFP8:   (256, 256 + 8),
 }
 
 

--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -764,6 +764,22 @@ class NVFP4(__Quant, qtype=GGMLQuantizationType.NVFP4):
         return (d * vals.astype(np.float32)).reshape(n_super, 64)
 
 
+class MXFP8(__Quant, qtype=GGMLQuantizationType.MXFP8):
+    @classmethod
+    def dequantize_blocks(cls, blocks: np.ndarray) -> np.ndarray:
+        n_blocks = blocks.shape[0]
+        n_sub = cls.block_size // 32
+
+        qs, e = np.hsplit(blocks, [cls.block_size])
+        qs = qs.reshape(n_blocks, n_sub, 32)
+        values = np.float32(2.0) * NVFP4.ue4m3_to_fp32(qs & np.uint8(0x7F))
+        values = np.where(qs & np.uint8(0x80), -values, values)
+
+        with np.errstate(over="ignore", invalid="ignore"):
+            scale = np.float32(2.0) * MXFP4.e8m0_to_fp32_half(e)
+            return (scale[..., None] * values).reshape(-1, cls.block_size).astype(np.float32)
+
+
 class IQ2_XXS(__Quant, qtype=GGMLQuantizationType.IQ2_XXS):
     ksigns: bytes = (
         b"\x00\x81\x82\x03\x84\x05\x06\x87\x88\x09\x0a\x8b\x0c\x8d\x8e\x0f"

--- a/gguf-py/tests/test_quants.py
+++ b/gguf-py/tests/test_quants.py
@@ -68,6 +68,7 @@ class GGMLQuants:
             "q2_K", "q3_K", "q4_K", "q5_K", "q6_K",
             "tq1_0", "tq2_0",
             "mxfp4",
+            "mxfp8",
             "nvfp4",
             "iq2_xxs", "iq2_xs", "iq2_s", "iq3_xxs", "iq3_s", "iq1_s", "iq1_m",
             "iq4_nl", "iq4_xs",

--- a/include/llama.h
+++ b/include/llama.h
@@ -156,6 +156,7 @@ extern "C" {
         LLAMA_FTYPE_MOSTLY_NVFP4         = 39, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q1_0          = 40, // except 1d tensors
         LLAMA_FTYPE_MOSTLY_Q2_0          = 41, // except 1d tensors
+        LLAMA_FTYPE_MOSTLY_MXFP8         = 42, // except 1d tensors
 
         LLAMA_FTYPE_GUESSED = 1024, // not specified in the model file
     };

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -45,6 +45,7 @@ const char * llama_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q5_1:      name = LLAMA_FTYPE_PREFIX "Q5_1"; break;
         case LLAMA_FTYPE_MOSTLY_Q8_0:      name = LLAMA_FTYPE_PREFIX "Q8_0"; break;
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: name = LLAMA_FTYPE_PREFIX "MXFP4 MoE"; break;
+        case LLAMA_FTYPE_MOSTLY_MXFP8:     name = LLAMA_FTYPE_PREFIX "MXFP8"; break;
         case LLAMA_FTYPE_MOSTLY_NVFP4:     name = LLAMA_FTYPE_PREFIX "NVFP4"; break;
         case LLAMA_FTYPE_MOSTLY_Q2_K:      name = LLAMA_FTYPE_PREFIX "Q2_K - Medium"; break;
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:    name = LLAMA_FTYPE_PREFIX "Q2_K - Small"; break;
@@ -755,6 +756,7 @@ llama_model_loader::llama_model_loader(
             case GGML_TYPE_IQ4_NL:  ftype = LLAMA_FTYPE_MOSTLY_IQ4_NL;  break;
             case GGML_TYPE_IQ4_XS:  ftype = LLAMA_FTYPE_MOSTLY_IQ4_XS;  break;
             case GGML_TYPE_IQ3_S:   ftype = LLAMA_FTYPE_MOSTLY_IQ3_S;   break;
+            case GGML_TYPE_MXFP8:   ftype = LLAMA_FTYPE_MOSTLY_MXFP8;   break;
             case GGML_TYPE_NVFP4:   ftype = LLAMA_FTYPE_MOSTLY_NVFP4;   break;
             case GGML_TYPE_Q1_0:    ftype = LLAMA_FTYPE_MOSTLY_Q1_0;    break;
             case GGML_TYPE_Q2_0:    ftype = LLAMA_FTYPE_MOSTLY_Q2_0;    break;

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -45,6 +45,7 @@ const char * llama_ftype_name(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q5_1:      name = LLAMA_FTYPE_PREFIX "Q5_1"; break;
         case LLAMA_FTYPE_MOSTLY_Q8_0:      name = LLAMA_FTYPE_PREFIX "Q8_0"; break;
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: name = LLAMA_FTYPE_PREFIX "MXFP4 MoE"; break;
+        case LLAMA_FTYPE_MOSTLY_MXFP8:     name = LLAMA_FTYPE_PREFIX "MXFP8"; break;
         case LLAMA_FTYPE_MOSTLY_NVFP4:     name = LLAMA_FTYPE_PREFIX "NVFP4"; break;
         case LLAMA_FTYPE_MOSTLY_Q2_K:      name = LLAMA_FTYPE_PREFIX "Q2_K - Medium"; break;
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:    name = LLAMA_FTYPE_PREFIX "Q2_K - Small"; break;
@@ -769,6 +770,7 @@ llama_model_loader::llama_model_loader(
             case GGML_TYPE_IQ4_NL:  ftype = LLAMA_FTYPE_MOSTLY_IQ4_NL;  break;
             case GGML_TYPE_IQ4_XS:  ftype = LLAMA_FTYPE_MOSTLY_IQ4_XS;  break;
             case GGML_TYPE_IQ3_S:   ftype = LLAMA_FTYPE_MOSTLY_IQ3_S;   break;
+            case GGML_TYPE_MXFP8:   ftype = LLAMA_FTYPE_MOSTLY_MXFP8;   break;
             case GGML_TYPE_NVFP4:   ftype = LLAMA_FTYPE_MOSTLY_NVFP4;   break;
             case GGML_TYPE_Q1_0:    ftype = LLAMA_FTYPE_MOSTLY_Q1_0;    break;
             case GGML_TYPE_Q2_0:    ftype = LLAMA_FTYPE_MOSTLY_Q2_0;    break;


### PR DESCRIPTION
## Overview

This PR adds MXFP8 support (CPU only) and includes accelerated x86, ARM, and generic fallback kernels. 
Blackwell specific CUDA kernels with native MXFP8 support are ready and to immediately follow.
Support for converting existing Huggingface `MXFP8` checkpoints to GGML is included.

MXFP8 is a OCP MX block scaled quantization format at 8.25bpw; native hardware acceleration is currently supported on Blackwell. 
It uses one FP8 (E4M3) scale per 32 weights.

The `block_mxfp8` form used in this implementation has a block size of 256 with a subb;ock size of 32.
```
#define QK_MXFP8 256
#define QK_MXFP8_SUB 32
typedef struct {
    uint8_t qs[QK_MXFP8 / QK_MXFP8_SUB][QK_MXFP8_SUB];
    uint8_t e[QK_MXFP8 / QK_MXFP8_SUB];
} block_mxfp8;
```
This requires no padding and is perfectly aligned for GPU kernels.

## Additional information
Significant testing and evaluation of MXFP8 with FP8 was described in https://github.com/ggml-org/llama.cpp/pull/25336 .  
Testing showed the best performance and quality came from MXFP8 standalone as its own native format. 

The use case justification for bringing in `MXFP8` into llama.cpp:
- Some existing checkpoints already exist on Huggingface and can be converted [The quantizer was left out of this initial PR]
- MXFP8 is a universal, open format that likely will get future hardware blockscaling acceleration (or even further accelerated) on other upcoming platforms
- Initial POC CUDA testing demonstrated that MXFP8 had faster prefill than Q8 or BF16, with nearly matched tg.  Further optimization may push this ahead.  MXFP8 is an excellent option for creating Blackwell-specific model quantizations using mixed NVFP4/MXFP8 layers for overall best performance and quality

## Quality

The results below are from `Qwen3.5-4B Base` using WikiText-2, using full KLD/PPL evaluation against complete BF16 logits.

| Format | PPL | PPL(Q) / PPL(base) | Mean KLD | RMS Δp | Same top token |
|---|---:|---:|---:|---:|---:|
| BF16 | 8.348271 | 1.0 | — | — | — |
| Q8_0 | 8.352002  | 1.000447  | 0.000845  | 0.836 % | 97.814 % |
| MXFP8 | 8.427964  | 1.009546  | 0.009009  | 2.613 % | 94.110 % |

## Performance

CPU results  are for only a basic CPU implementation included in this initial PR.  A  higher performing implementation is possible, but is not trivial and would expand this PR, so can be added at a later time.

| Type | Size | pp512 | tg128 |
|---|---:|---:|---:|
| BF16 | 7.84 GiB | 51.46| 4.42  |
| Q8_0 | 4.16 GiB | 65.69 | 7.01 |
| MXFP8 | 4.04 GiB | 9.58 | 4.35 |

## Example MXFP8 GGUF models

- [Qwen3.5-0.8B MXFP8](https://huggingface.co/michaelw9999/Qwen3.5-0.8B-MXFP8-GGUF/blob/main/Qwen3.5-0.8B-MXFP8.gguf)
- [Qwen3.5-4B Base MXFP8](https://huggingface.co/michaelw9999/Qwen3.5-4B-MXFP8-GGUF/blob/main/Qwen3.5-4B-MXFP8.gguf)
- [Qwen3.5-4B Instruct MXFP8](https://huggingface.co/michaelw9999/Qwen3.5-4B-Instruct-MXFP8-GGUF/blob/main/Qwen3.5-4B-Instruct-MXFP8.gguf)
- [Qwen3.5-9B Instruct MXFP8](https://huggingface.co/michaelw9999/Qwen3.5-9B-Instruct-MXFP8-GGUF/blob/main/Qwen3.5-9B-Instruct-MXFP8.gguf)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes
- AI usage disclosure: 
Yes, AI was used to optimize and generate the CPU kernels. The generated code was exhaustively pruned and hand edited to be concise, minimal, and match llama.cpp style and standards.  Verifying and validating the model outputs were done manually with `llama-cli` and `llama-server`.