### PR TITLE
Add more benchmarks to llama-eval

### DIFF
--- a/examples/llama-eval/README.md
+++ b/examples/llama-eval/README.md
@@ -24,3 +24,160 @@ python3 llama-eval.py \
   --dataset aime2025 --n_cases 240 \
   --grader-type regex
 ```
+
+## Code suites (HumanEval, ClassEval)
+
+`--dataset humaneval` runs the 164 OpenAI HumanEval problems; `--dataset
+classeval` runs the 100 ClassEval class-generation tasks. Unlike the other
+suites these are not graded by matching text: the model's reply is parsed for a
+```` ```python ```` block, that code is combined with the task's own unit tests,
+and the result is **executed**.
+
+ClassEval asks for a whole class rather than one function, so it is scored the
+way upstream does — **class level** (every one of the task's tests passes, which
+is what feeds pass@k) and **method level** (what fraction of all 2196 test
+methods passed). The second number separates "generated nothing usable" from
+"got most of the class right", and both are printed at the end of a run.
+
+Give it more room to generate than HumanEval — a class with ten methods does not
+fit in a short budget:
+
+```bash
+python3 llama-eval.py \
+  --server http://localhost:8033 --model my-model \
+  --dataset classeval --threads 8 --n_predict 4096 --temperature 0
+```
+
+```bash
+# pass@1, greedy
+python3 llama-eval.py \
+  --server http://localhost:8033 --model my-model \
+  --dataset humaneval --threads 8 --n_predict 1024 --temperature 0
+
+# pass@10 -- each extra multiple of 164 is another sample per problem
+python3 llama-eval.py \
+  --server http://localhost:8033 --model my-model \
+  --dataset humaneval --n_cases 1640 --temperature 0.8 --top-p 0.95
+```
+
+`--grader-type exec` is the default for code suites, so neither it nor
+`--dataset-source` normally needs to be passed.
+
+### Execution sandbox — no Docker required
+
+Generated code is untrusted, but these suites need far less than a container to
+run safely. **The package set is derived from the dataset's own imports at
+startup**, not hardcoded and not taken from the upstream `requirements.txt` —
+which for ClassEval lists `torch`, `openai` and `transformers` that its *tests*
+never touch. So each suite installs exactly what it needs:
+
+| suite | third-party packages |
+|---|---|
+| HumanEval | **none** — every problem imports only stdlib (`typing, math, random, copy, string, collections, hashlib, re`) |
+| ClassEval | 13: `beautifulsoup4, gensim, lxml, netifaces, nltk, numpy, openpyxl, pandas, pillow, pypdf2, python-docx, reportlab, scipy` |
+
+Two of ClassEval's are *declared* rather than derived, because no import
+statement mentions them: `lxml` is selected by string
+(`BeautifulSoup(html, 'lxml')`, ClassEval_44 — without it that task silently
+drops from 23/23 to 7/23), and `scipy` is a hard gensim requirement. Note also
+that `PyPDF2` must **not** be modernised to `pypdf`: ClassEval_69's test imports
+`PdfFileReader`, a name pypdf removed.
+
+The venv is cached under `~/.cache/llama-eval/` (override with
+`LLAMA_EVAL_CACHE`) and rebuilt only when the package set, interpreter version
+or provisioning steps change; force one with `--rebuild-sandbox`. `uv` is used
+when available, which makes even the ClassEval venv build in seconds.
+
+**Interpreter selection.** A suite can prefer a different Python than the one
+running the tool, and declares it: ClassEval asks for 3.13, because gensim
+publishes no wheel past cp313 and its generated C no longer compiles on 3.14
+(it still uses `PyLongObject.ob_digit`). That interpreter is found automatically,
+including via `uv python`; `--sandbox-python` overrides it.
+
+3.14 is fully supported anyway. ClassEval uses exactly two gensim APIs
+(`utils.decode_htmlentities`, `matutils.unitvec`), both pure Python upstream, so
+on 3.14+ the suite drops gensim from the install set and provisions a small shim
+instead. Both paths score **100/100**.
+
+**Offline provisioning.** A suite that would otherwise fetch data at test time
+declares a provisioning step that runs once at venv build time, while the
+network is still up. ClassEval uses this to pre-seed exactly three nltk corpora
+(`punkt_tab`, `averaged_perceptron_tagger_eng`, `wordnet`, ~33 MB), so the tests
+themselves run with no network at all. Those are the *current* names — the
+dataset asks for `punkt` and `averaged_perceptron_tagger`, which nltk has since
+renamed, and seeding the legacy names too is not harmless: with a network
+available nltk considers them satisfied and re-fetches the modern ones anyway.
+The corpora are written *inside* the venv, not `~/nltk_data`, because `$HOME` is
+a tmpfs under the strongest isolation tier.
+
+Each candidate program runs in a throwaway directory as its own process group,
+under the strongest isolation the host offers:
+
+| tier | requires | isolates |
+|---|---|---|
+| `bwrap` | bubblewrap installed | read-only root, tmpfs `/tmp` and `$HOME`, **no network** |
+| `unshare` | `unshare --map-current-user` | **no network** |
+| `unshare-root` | any `unshare -r` | no network, but **runs as uid 0** — see below |
+| `rlimit` | always available | cpu/memory/file-size/process caps only |
+
+**Candidate code must not run as root**, which is why `unshare -r` is a
+last-resort tier that prints a warning. Root bypasses file permission bits, so a
+test asserting that writing to a `chmod 0444` file *fails* instead sees it
+succeed — ClassEval_50 scores 14/16 under uid 0 and 16/16 under uid 1000, with
+nothing in the output to suggest the sandbox caused it. Install bubblewrap.
+
+All tiers additionally cap CPU time, address space (4 GiB), file size and core
+dumps, and kill the whole process group on timeout (`--exec-timeout`, default
+15 s — raise it for ClassEval, whose tests do real work). Writes to the
+throwaway working directory are allowed, which is all the file-handling tasks in
+ClassEval need.
+
+Note that the weakest tier does not contain filesystem access. If you are
+scoring output from a model you do not trust, check the tier printed at startup.
+
+### Reproducibility
+
+Several tasks draw their test inputs from the *global, unseeded* RNG, so a
+verdict is not reproducible run to run — which adds noise exactly when you are
+comparing two models or two quantisations. `--exec-seed` (default `0`) seeds the
+RNG before each test; pass `--exec-seed -1` for the stock upstream behaviour.
+This does not change what the model is asked to compute.
+
+It matters more than it sounds. HumanEval/38, /50 and /53 are affected, and
+ClassEval_58 (duplicate mine placement) fails about 30% of the time on its own
+*reference* solution — measured here at 21/30 passes unseeded versus **30/30
+seeded**.
+
+### Dataset fidelity
+
+The canonical dataset runs **unmodified on current Python** — all 164 reference
+solutions pass on CPython 3.14 with no patches, so no forked or re-hosted copy
+is needed. `--dataset-source` accepts a local `.jsonl` or a HuggingFace repo id
+if you do want to point at a modified copy.
+
+HumanEval does contain a handful of long-standing defects where the *prompt*
+contradicts the graded test (notably HumanEval/47, /116 and /148). Those
+penalise a model that reads the docstring carefully, but correcting them makes
+the benchmark marginally easier and the resulting scores no longer comparable
+with published HumanEval numbers, so nothing is patched by default.
+
+ClassEval is different: the upstream data has defects that cap the achievable
+score below 100% for reasons unrelated to the model, so `--dataset classeval`
+defaults to a **patched fork**,
+[`ilintar/ClassEval`](https://huggingface.co/datasets/ilintar/ClassEval).
+Six edits over five tasks lift the reference solutions from 96/100 classes and
+2182/2196 test methods to **100/100 and 2196/2196**. Three repair tests nothing
+could pass:
+
+- **ClassEval_17** was a time bomb — a hard-coded 2024 date checked against
+  `datetime.now()`, unpassable since January 2024.
+- **ClassEval_48** asserted `get_hostname('0.0.0.0') == 'LAPTOP-2CS86KUM'`, the
+  dataset author's own machine name.
+- **ClassEval_31** compared floats with `assertEqual`, failing on a 4-ULP numpy
+  difference.
+
+The other three fix only the *reference* solutions (NumPy 2.0 removals in
+ClassEval_51, a 30%-flaky mine generator in ClassEval_58) and cannot affect a
+model's score. No `skeleton` was touched, so what the model is asked to write is
+byte-identical to upstream. Pass `--dataset-source FudanSELab/ClassEval` for the
+unpatched original.

--- a/examples/llama-eval/README.md
+++ b/examples/llama-eval/README.md
@@ -25,6 +25,82 @@ python3 llama-eval.py \
   --grader-type regex
 ```
 
+## Agentic suite
+
+`--dataset agentic` is a different shape from the other code suites. It runs
+**SACB** (Simple Agent Coding Benchmark), hosted at
+[`ilintar/SACB`](https://huggingface.co/datasets/ilintar/SACB) -- 60 tasks over
+three hand-written repositories, in Python and TypeScript. Rather than
+answering one prompt, the model is given a small but real repository, a
+deliberately narrow tool set, and a bug report, and drives its own multi-turn
+conversation until it declares itself finished. It is then graded by running a
+test suite it was never allowed to see.
+
+```bash
+python3 llama-eval.py \
+  --server http://localhost:8033 --model my-model \
+  --dataset agentic --threads 1 --temperature 0
+```
+
+### The tools
+
+| tool | purpose |
+|---|---|
+| `list_files` | enumerate the tree |
+| `read_file` | read, with 1-based line numbers and optional line-range narrowing |
+| `search` | regular-expression search across the repository |
+| `edit_lines` | replace an inclusive line range |
+| `edit_replace` | replace an exact snippet, which must be unique |
+| `write_file` | write a whole file |
+| `lint` | run the language's linter and type checker |
+| `finish` | declare the change complete |
+
+Three constraints are deliberate:
+
+**There is no shell and no way to run the tests.** The only feedback channel is
+`lint`. A syntax or type error can be driven out mechanically; a logic error has
+to be reasoned about. A harness that lets an agent iterate against the test
+suite measures something closer to search than to understanding.
+
+**There are two edit tools**, one line-addressed and one content-addressed.
+Which one a model reaches for, and whether it keeps line numbers straight after
+its own earlier edit, is itself a signal.
+
+**The tests never touch the working tree.** They are held outside it and copied
+into a throwaway copy only after the agent has stopped, so they can be neither
+read nor edited. Every tool path is resolved and confinement-checked against the
+repository root, so a symlink planted inside the tree cannot reach outside it.
+
+### Scoring
+
+A task is **resolved** when every test that was failing now passes *and* nothing
+that was already passing broke. Both sets are derived by running the tests twice
+when the corpus is built -- once against the defective tree and once against the
+reference fix -- never hand-written, so a task whose defect no test exercises is
+rejected rather than shipped.
+
+Because many tasks contain several independent defects, the fraction of target
+tests passed is reported alongside, which separates "fixed two of the three
+faults" from "changed nothing". Process metrics are reported too: turns, tool
+calls, rejected calls, edits, and the peak conversation size.
+
+### Dependencies
+
+Nothing here is installed unless you select this suite, and then only for the
+language you actually run. `--agentic-lang python` provisions ruff and mypy;
+`--agentic-lang typescript` provisions the TypeScript compiler and uses node's
+own test runner. Neither touches the other, and no other suite touches either.
+
+### Useful flags
+
+| flag | meaning |
+|---|---|
+| `--agentic-lang` | restrict to one language, and provision only its toolchain |
+| `--agentic-max-turns` | give up after this many assistant turns (default 50) |
+| `--agentic-max-tokens` | cap generation per turn (default 2048); bounds a model that falls into a repetition loop |
+| `--agentic-context-limit` | abandon an episode once its context exceeds this many tokens |
+
+
 ## Code suites (HumanEval, ClassEval)
 
 `--dataset humaneval` runs the 164 OpenAI HumanEval problems; `--dataset

--- a/examples/llama-eval/README.md
+++ b/examples/llama-eval/README.md
@@ -25,6 +25,31 @@ python3 llama-eval.py \
   --grader-type regex
 ```
 
+### Authentication
+
+A server started with `--api-key` (or any OpenAI-compatible endpoint behind a
+token) needs one here too. `--api-key` is sent as `Authorization: Bearer` on
+every eval request; it falls back to `$LLAMA_API_KEY`, which keeps the secret
+out of your shell history and off the process list.
+
+```bash
+# One key for every server
+python3 llama-eval.py --server http://localhost:8033 --api-key sk-... ...
+
+# From the environment
+export LLAMA_API_KEY=sk-...
+python3 llama-eval.py --server http://localhost:8033 ...
+
+# One key per server, in --server order
+python3 llama-eval.py \
+  --server http://server1:8033,http://server2:8033 \
+  --api-key sk-one,sk-two --threads 16,16 ...
+```
+
+The LLM grader authenticates too. It reuses the key of the server it runs on,
+so `--grader-type llm` without `--grader-server` needs nothing extra; a grader
+on a separate endpoint takes `--grader-api-key`.
+
 ## Agentic suite
 
 `--dataset agentic` is a different shape from the other code suites. It runs

--- a/examples/llama-eval/agentic_eval.py
+++ b/examples/llama-eval/agentic_eval.py
@@ -1,0 +1,879 @@
+#!/usr/bin/env python3
+"""Multi-turn agentic coding eval: tools over a real working tree.
+
+The existing code suites are single-shot -- one prompt, one reply, execute,
+grade. This one is not. The model is given a small but real repository and a
+deliberately narrow tool set, and has to find its way to the defect before it
+can fix it. That shape is what puts a run in the tens-of-thousands-of-tokens
+range without any artificial padding: the context grows because the model
+chose to read things.
+
+Three deliberate constraints:
+
+* No shell, and no way to run the tests. The only feedback channel is `lint`.
+  A syntax or type error can be driven out mechanically; a logic error has to
+  be reasoned about. Suites that let an agent iterate against the test suite
+  measure something closer to search than to understanding.
+* Two edit tools, one line-addressed and one content-addressed. Which one a
+  model reaches for, and whether it keeps line numbers straight after its own
+  earlier edit, is itself a signal.
+* Tests never touch the working tree. They are held outside it and copied in
+  after the agent has stopped, so they can be neither read nor edited.
+
+Everything here is imported lazily by llama-eval.py, and every dependency it
+needs is scoped to the language actually under test, so none of it is
+installed for anyone running the other suites.
+"""
+
+import json
+import os
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# Tool output caps. These bound context growth without hiding anything the
+# model asked for precisely: a narrowed read is never truncated, only a lazy
+# whole-file read of something large.
+MAX_READ_LINES = 400
+MAX_TOOL_CHARS = 12000
+MAX_SEARCH_HITS = 60
+
+
+# --------------------------------------------------------------------------
+# languages
+# --------------------------------------------------------------------------
+
+@dataclass
+class LangSpec:
+    """Everything language-specific: how to lint, how to test, what to install.
+
+    Kept as data so adding a language is a corpus concern rather than a harness
+    change, and so a run only ever provisions the toolchain for the language it
+    is actually evaluating.
+    """
+    name: str
+    exts: Tuple[str, ...]
+    packages: Tuple[str, ...] = ()
+    provision: Tuple[str, ...] = ()
+    env: Dict[str, str] = field(default_factory=dict)
+    # Passed straight to Sandbox. Only raised where a runtime reserves a large
+    # virtual address space it never commits.
+    address_space_limit: Optional[int] = 4 * 1024 * 1024 * 1024
+
+    def source_files(self, root: Path) -> List[Path]:
+        return sorted(p for p in root.rglob("*")
+                      if p.is_file() and p.suffix in self.exts)
+
+
+PYTHON = LangSpec(
+    name="python",
+    exts=(".py",),
+    # ruff catches syntax and obvious defects, mypy the type errors. Both are
+    # pure-wheel installs, so the venv builds in seconds and needs no compiler.
+    packages=("ruff==0.14.2", "mypy==1.18.2"),
+)
+
+TYPESCRIPT = LangSpec(
+    name="typescript",
+    exts=(".ts",),
+    # tsc is the linter and the type checker at once. Tests run on node's own
+    # runner against stripped types, so there is no build step, no bundler and
+    # no test framework to install.
+    # node strips types through a WebAssembly module, and each WASM instance
+    # reserves gigabytes of address space up front. At the default 4 GiB cap it
+    # aborts with an out-of-memory error that reads like a fault in the code
+    # under test rather than a sandbox limit.
+    address_space_limit=16 * 1024 * 1024 * 1024,
+    provision=(
+        "import os, subprocess, shutil, sys\n"
+        "npm = shutil.which('npm')\n"
+        "if not npm: sys.exit('npm not found on PATH; needed for the typescript suite')\n"
+        "dest = os.path.join(os.environ['SANDBOX_VENV'], 'node')\n"
+        "os.makedirs(dest, exist_ok=True)\n"
+        "r = subprocess.run([npm, 'install', '--silent', '--no-audit', '--no-fund',\n"
+        "                    '--prefix', dest, 'typescript@5.9.3'],\n"
+        "                   capture_output=True, text=True)\n"
+        "sys.exit(0 if r.returncode == 0 else (r.stderr or r.stdout)[-2000:])\n",
+    ),
+)
+
+LANGS: Dict[str, LangSpec] = {"python": PYTHON, "typescript": TYPESCRIPT}
+
+
+# --------------------------------------------------------------------------
+# workspace
+# --------------------------------------------------------------------------
+
+class PathEscape(Exception):
+    """A tool was handed a path outside the repository."""
+
+
+class Workspace:
+    """A private, writable copy of one task's repository.
+
+    Every tool path is resolved through here. Confinement is checked on the
+    fully-resolved path, so a symlink planted inside the tree cannot be used to
+    read or write outside it.
+    """
+
+    def __init__(self, root: Path):
+        self.root = root.resolve()
+        self.escape_attempts = 0
+
+    def resolve(self, rel: str) -> Path:
+        if rel is None or not str(rel).strip():
+            raise PathEscape("no path given")
+        raw = Path(str(rel))
+        # An absolute path is honoured when it genuinely points inside the
+        # workspace, because models emit them routinely and rejecting them
+        # would measure path formatting rather than coding. What it must never
+        # do is get silently reinterpreted as relative: stripping the leading
+        # slash turns /etc/passwd into <repo>/etc/passwd, which is a different
+        # file than the one asked for and fails for a misleading reason.
+        base = raw if raw.is_absolute() else (self.root / raw)
+        candidate = base.resolve()
+        if candidate != self.root and self.root not in candidate.parents:
+            self.escape_attempts += 1
+            raise PathEscape(f"path {rel!r} is outside the repository")
+        return candidate
+
+    def rel(self, path: Path) -> str:
+        return str(path.relative_to(self.root))
+
+    def files(self) -> List[Path]:
+        return sorted(p for p in self.root.rglob("*")
+                      if p.is_file() and "__pycache__" not in p.parts)
+
+    def snapshot(self) -> Dict[str, str]:
+        out = {}
+        for p in self.files():
+            try:
+                out[self.rel(p)] = p.read_text()
+            except (UnicodeDecodeError, OSError):
+                pass
+        return out
+
+
+def _clip(text: str, limit: int = MAX_TOOL_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n... [truncated, {len(text) - limit} more characters]"
+
+
+def _numbered(lines: Sequence[str], start: int) -> str:
+    width = len(str(start + len(lines) - 1))
+    return "\n".join(f"{start + i:>{width}}\t{ln}" for i, ln in enumerate(lines))
+
+
+# --------------------------------------------------------------------------
+# tools
+# --------------------------------------------------------------------------
+
+def tool_schemas() -> List[Dict[str, Any]]:
+    """OpenAI-format function schemas for the whole tool set."""
+    def fn(name, desc, props, required=()):
+        return {"type": "function", "function": {
+            "name": name, "description": desc,
+            "parameters": {"type": "object", "properties": props,
+                           "required": list(required)}}}
+
+    return [
+        fn("list_files", "List files in the repository.",
+           {"path": {"type": "string",
+                     "description": "Directory relative to the repository root. "
+                                    "Omit for the whole tree."}}),
+        fn("read_file",
+           "Read a file. Output is prefixed with 1-based line numbers. Give "
+           "start_line/end_line to read only part of a large file.",
+           {"path": {"type": "string", "description": "File path relative to the repository root."},
+            "start_line": {"type": "integer", "description": "First line to read, 1-based, inclusive."},
+            "end_line": {"type": "integer", "description": "Last line to read, 1-based, inclusive."}},
+           ["path"]),
+        fn("search",
+           "Search the repository with a regular expression. Returns matching "
+           "lines with their file and line number.",
+           {"pattern": {"type": "string", "description": "Python regular expression."},
+            "path": {"type": "string", "description": "Limit the search to this subdirectory."},
+            "glob": {"type": "string", "description": "Limit to files matching this glob, e.g. '*.py'."}},
+           ["pattern"]),
+        fn("edit_lines",
+           "Replace an inclusive 1-based line range with new text. Line numbers "
+           "refer to the file as it is now, so re-read it after any edit that "
+           "changed the number of lines.",
+           {"path": {"type": "string", "description": "File path relative to the repository root."},
+            "start_line": {"type": "integer", "description": "First line to replace, 1-based, inclusive."},
+            "end_line": {"type": "integer", "description": "Last line to replace, 1-based, inclusive."},
+            "new_text": {"type": "string", "description": "Replacement text. Use an empty string to delete the range."}},
+           ["path", "start_line", "end_line", "new_text"]),
+        fn("edit_replace",
+           "Replace an exact snippet of text. The snippet must occur exactly "
+           "once in the file unless replace_all is set.",
+           {"path": {"type": "string", "description": "File path relative to the repository root."},
+            "old_text": {"type": "string", "description": "Exact text to find, including indentation."},
+            "new_text": {"type": "string", "description": "Replacement text."},
+            "replace_all": {"type": "boolean", "description": "Replace every occurrence instead of requiring exactly one."}},
+           ["path", "old_text", "new_text"]),
+        fn("write_file",
+           "Write a whole file, creating or overwriting it. Prefer the edit "
+           "tools for changes to existing files.",
+           {"path": {"type": "string", "description": "File path relative to the repository root."},
+            "content": {"type": "string", "description": "Full new file contents."}},
+           ["path", "content"]),
+        fn("lint",
+           "Run the language's linter and type checker over the repository and "
+           "return the diagnostics. This is the only feedback available; the "
+           "test suite cannot be run.",
+           {"path": {"type": "string", "description": "Limit to this file or directory."}}),
+        fn("finish",
+           "Declare the task complete. Call this once the change is made.",
+           {"summary": {"type": "string", "description": "Brief description of the change made."}}),
+    ]
+
+
+class ToolBox:
+    """Executes tool calls against one workspace. Returns plain text results.
+
+    Failures are reported as ordinary text rather than raised, because how a
+    model recovers from a rejected edit is part of what is being measured.
+    """
+
+    def __init__(self, ws: Workspace, linter=None):
+        self.ws = ws
+        self.linter = linter
+        self.calls = 0
+        self.errors = 0
+        self.edits = 0
+        self.finished = False
+        self.finish_summary: Optional[str] = None
+        self.per_tool: Dict[str, int] = {}
+
+    def dispatch(self, name: str, args: Dict[str, Any]) -> str:
+        self.calls += 1
+        self.per_tool[name] = self.per_tool.get(name, 0) + 1
+        handler = getattr(self, f"_t_{name}", None)
+        if handler is None:
+            result = f"Error: unknown tool {name!r}."
+        else:
+            try:
+                result = handler(args)
+            except PathEscape as e:
+                result = f"Error: {e}"
+            except KeyError as e:
+                result = f"Error: missing required argument {e}."
+            except Exception as e:
+                result = f"Error: {type(e).__name__}: {e}"
+        # One counting point for every failure, raised or returned -- a tool
+        # that rejects an edit is just as much a failed call as one that
+        # throws, and the two must not be tallied differently.
+        if result.startswith("Error:"):
+            self.errors += 1
+        return _clip(result)
+
+    # -- read-only -------------------------------------------------------
+
+    def _t_list_files(self, a):
+        base = self.ws.resolve(a.get("path") or ".")
+        if not base.exists():
+            return f"Error: {a.get('path')!r} does not exist."
+        paths = [p for p in self.ws.files() if p == base or base in p.parents]
+        if not paths:
+            return "(no files)"
+        return "\n".join(f"{self.ws.rel(p)}\t{p.stat().st_size} bytes" for p in paths)
+
+    def _t_read_file(self, a):
+        path = self.ws.resolve(a["path"])
+        if not path.is_file():
+            return f"Error: {a['path']!r} is not a file."
+        lines = path.read_text().splitlines()
+        start = max(1, int(a.get("start_line") or 1))
+        end = int(a.get("end_line") or len(lines))
+        end = min(end, len(lines))
+        if start > len(lines):
+            return f"Error: {a['path']!r} has only {len(lines)} lines."
+        window = lines[start - 1:end]
+        note = ""
+        if len(window) > MAX_READ_LINES:
+            window = window[:MAX_READ_LINES]
+            note = (f"\n... [showing {MAX_READ_LINES} of {end - start + 1} requested "
+                    f"lines; re-read with start_line/end_line for the rest]")
+        header = f"{a['path']} ({len(lines)} lines total)\n"
+        return header + _numbered(window, start) + note
+
+    def _t_search(self, a):
+        try:
+            rx = re.compile(a["pattern"])
+        except re.error as e:
+            return f"Error: bad regular expression: {e}"
+        base = self.ws.resolve(a.get("path") or ".")
+        glob = a.get("glob")
+        hits, scanned = [], 0
+        for p in self.ws.files():
+            if not (p == base or base in p.parents):
+                continue
+            if glob and not p.match(glob):
+                continue
+            try:
+                text = p.read_text()
+            except (UnicodeDecodeError, OSError):
+                continue
+            scanned += 1
+            for i, line in enumerate(text.splitlines(), 1):
+                if rx.search(line):
+                    hits.append(f"{self.ws.rel(p)}:{i}:{line.strip()[:200]}")
+                    if len(hits) >= MAX_SEARCH_HITS:
+                        return ("\n".join(hits) +
+                                f"\n... [stopped at {MAX_SEARCH_HITS} matches; narrow the pattern]")
+        if not hits:
+            return f"No matches for {a['pattern']!r} in {scanned} file(s)."
+        return "\n".join(hits)
+
+    # -- mutating --------------------------------------------------------
+
+    def _t_edit_lines(self, a):
+        path = self.ws.resolve(a["path"])
+        if not path.is_file():
+            return f"Error: {a['path']!r} is not a file."
+        lines = path.read_text().splitlines()
+        start, end = int(a["start_line"]), int(a["end_line"])
+        if start < 1 or start > len(lines):
+            return (f"Error: start_line {start} out of range; "
+                    f"{a['path']!r} has {len(lines)} lines.")
+        if end < start or end > len(lines):
+            return (f"Error: end_line {end} out of range; must be between "
+                    f"{start} and {len(lines)}.")
+        new = str(a["new_text"]).splitlines()
+        path.write_text("\n".join(lines[:start - 1] + new + lines[end:]) + "\n")
+        self.edits += 1
+        delta = len(new) - (end - start + 1)
+        return (f"Replaced lines {start}-{end} of {a['path']} "
+                f"({end - start + 1} -> {len(new)} lines, {delta:+d}). "
+                f"Later line numbers have shifted." if delta else
+                f"Replaced lines {start}-{end} of {a['path']}.")
+
+    def _t_edit_replace(self, a):
+        path = self.ws.resolve(a["path"])
+        if not path.is_file():
+            return f"Error: {a['path']!r} is not a file."
+        text = path.read_text()
+        old, new = str(a["old_text"]), str(a["new_text"])
+        if not old:
+            return "Error: old_text must not be empty."
+        n = text.count(old)
+        if n == 0:
+            return (f"Error: old_text not found in {a['path']}. It must match "
+                    f"exactly, including indentation.")
+        if n > 1 and not a.get("replace_all"):
+            return (f"Error: old_text occurs {n} times in {a['path']}. Include "
+                    f"more surrounding context to make it unique, or set "
+                    f"replace_all.")
+        path.write_text(text.replace(old, new))
+        self.edits += 1
+        return f"Replaced {n} occurrence(s) in {a['path']}."
+
+    def _t_write_file(self, a):
+        path = self.ws.resolve(a["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existed = path.is_file()
+        path.write_text(str(a["content"]))
+        self.edits += 1
+        return f"{'Overwrote' if existed else 'Created'} {a['path']}."
+
+    # -- feedback --------------------------------------------------------
+
+    def _t_lint(self, a):
+        if self.linter is None:
+            return "Error: no linter is configured for this task."
+        target = a.get("path")
+        if target:
+            self.ws.resolve(target)  # confinement check only
+        return self.linter(target)
+
+    def _t_finish(self, a):
+        self.finished = True
+        self.finish_summary = a.get("summary")
+        return "Task marked complete."
+
+
+# --------------------------------------------------------------------------
+# linting and testing
+# --------------------------------------------------------------------------
+
+# Emits per-test outcomes rather than a pass/fail exit code, so a partly
+# correct change earns partial credit and a regression can be told apart from
+# a fix that simply did not go far enough.
+PY_TEST_RUNNER = r'''
+import json, os, random, sys, unittest
+sys.path.insert(0, os.getcwd())
+random.seed(0)
+
+class Collect(unittest.TestResult):
+    def __init__(self):
+        super().__init__()
+        self.outcomes = {}
+    def addSuccess(self, t): self.outcomes[t.id()] = "pass"
+    def addFailure(self, t, e): self.outcomes[t.id()] = "fail"
+    def addError(self, t, e): self.outcomes[t.id()] = "error"
+    def addSkip(self, t, r): self.outcomes[t.id()] = "skip"
+    def addExpectedFailure(self, t, e): self.outcomes[t.id()] = "pass"
+    def addUnexpectedSuccess(self, t): self.outcomes[t.id()] = "fail"
+
+def flatten(s):
+    for t in s:
+        if isinstance(t, unittest.TestSuite):
+            yield from flatten(t)
+        else:
+            yield t
+
+out = {"tests": {}}
+try:
+    suite = unittest.TestLoader().discover(os.environ.get("TEST_DIR", "tests"),
+                                           top_level_dir=".")
+    res = Collect()
+    for t in flatten(suite):
+        tid = t.id()
+        try:
+            t.run(res)
+        except Exception:
+            pass
+        res.outcomes.setdefault(tid, "error")
+    out["tests"] = res.outcomes
+except Exception as e:
+    out["error"] = f"{type(e).__name__}: {e}"
+
+print("###RESULT###")
+print(json.dumps(out))
+'''
+
+
+def _node_roots() -> List[Path]:
+    """Directories that must stay visible for node to start under bwrap."""
+    node = shutil.which("node")
+    if not node:
+        return []
+    real = Path(node).resolve()
+    return [Path(node).parent.parent, real.parent.parent]
+
+
+class Runner:
+    """Runs the linter and the hidden tests for one language, in the sandbox."""
+
+    def __init__(self, sandbox, lang: LangSpec, timeout: float = 90.0):
+        self.sandbox = sandbox
+        self.lang = lang
+        self.timeout = timeout
+
+    def _binds(self) -> List[Path]:
+        return _node_roots() if self.lang.name == "typescript" else []
+
+    def _env(self) -> Dict[str, str]:
+        if self.lang.name != "typescript":
+            return {}
+        node = shutil.which("node")
+        return {"PATH": f"{Path(node).parent}:/usr/bin:/bin"} if node else {}
+
+    # -- lint ------------------------------------------------------------
+
+    def lint(self, workdir: Path, target: Optional[str] = None) -> str:
+        if self.lang.name == "python":
+            return self._lint_python(workdir, target)
+        return self._lint_typescript(workdir, target)
+
+    def _lint_python(self, workdir: Path, target: Optional[str]) -> str:
+        venv = self.sandbox.venv_dir
+        tgt = target or "."
+        chunks = []
+        r = self.sandbox.run_argv(
+            [str(venv / "bin" / "ruff"), "check", "--no-cache",
+             "--output-format", "concise", tgt],
+            workdir, timeout=self.timeout)
+        # ruff announces success on stdout; that is not a diagnostic, and
+        # passing it through would tell the model it has findings when it does
+        # not.
+        text = (r.stdout or r.stderr).strip()
+        if text and "All checks passed" not in text:
+            chunks.append(text)
+        r = self.sandbox.run_argv(
+            [str(venv / "bin" / "mypy"), "--no-color-output", "--no-error-summary",
+             "--cache-dir", "/dev/null", "--ignore-missing-imports", tgt],
+            workdir, timeout=self.timeout)
+        text = (r.stdout or r.stderr).strip()
+        if text and not text.startswith("Success:"):
+            chunks.append(text)
+        return "\n".join(chunks) if chunks else "No problems found."
+
+    def _lint_typescript(self, workdir: Path, target: Optional[str]) -> str:
+        tsc = self.sandbox.venv_dir / "node" / "node_modules" / "typescript" / "bin" / "tsc"
+        files = [str(p.relative_to(workdir)) for p in sorted(workdir.rglob("*.ts"))
+                 if "node_modules" not in p.parts]
+        if target:
+            t = (workdir / target).resolve()
+            files = [f for f in files if (workdir / f).resolve() == t
+                     or t in (workdir / f).resolve().parents]
+        if not files:
+            return "No TypeScript files to check."
+        # Flags are passed explicitly rather than read from a tsconfig in the
+        # tree, so the checking strictness cannot be weakened by editing it.
+        r = self.sandbox.run_argv(
+            ["node", str(tsc), "--noEmit", "--strict", "--target", "es2022",
+             "--module", "esnext", "--moduleResolution", "bundler",
+             "--allowImportingTsExtensions", *files],
+            workdir, timeout=self.timeout, env=self._env(), ro_binds=self._binds())
+        out = (r.stdout or "") + (r.stderr or "")
+        return out.strip() or "No problems found."
+
+    # -- tests -----------------------------------------------------------
+
+    def test(self, workdir: Path) -> Dict[str, Any]:
+        if self.lang.name == "python":
+            return self._test_python(workdir)
+        return self._test_typescript(workdir)
+
+    def _test_python(self, workdir: Path) -> Dict[str, Any]:
+        runner = workdir / "__run_tests.py"
+        runner.write_text(PY_TEST_RUNNER)
+        r = self.sandbox.run_argv(
+            [str(self.sandbox.python), "-I", "-B", str(runner)],
+            workdir, timeout=self.timeout, env={"TEST_DIR": "tests"})
+        return self._parse_json_result(r)
+
+    def _parse_json_result(self, r) -> Dict[str, Any]:
+        if r.status == "timeout":
+            return {"tests": {}, "error": "timeout"}
+        marker = "###RESULT###"
+        if marker not in (r.stdout or ""):
+            return {"tests": {},
+                    "error": f"no result: {(r.stderr or r.stdout or '')[-400:]}"}
+        try:
+            return json.loads(r.stdout.split(marker, 1)[1].strip())
+        except Exception as e:
+            return {"tests": {}, "error": f"unparseable result: {e}"}
+
+    def _test_typescript(self, workdir: Path) -> Dict[str, Any]:
+        tests = sorted(p for p in (workdir / "tests").rglob("*.ts")) \
+            if (workdir / "tests").is_dir() else []
+        if not tests:
+            return {"tests": {}, "error": "no test files"}
+        r = self.sandbox.run_argv(
+            ["node", "--test", "--experimental-strip-types",
+             "--test-reporter=tap",
+             *[str(p.relative_to(workdir)) for p in tests]],
+            workdir, timeout=self.timeout, env=self._env(), ro_binds=self._binds())
+        return self._parse_tap(r)
+
+    @staticmethod
+    def _parse_tap(r) -> Dict[str, Any]:
+        if r.status == "timeout":
+            return {"tests": {}, "error": "timeout"}
+        text = (r.stdout or "") + "\n" + (r.stderr or "")
+        outcomes: Dict[str, str] = {}
+        for line in text.splitlines():
+            m = re.match(r"\s*(not )?ok\s+\d+\s*-\s*(.+?)\s*$", line)
+            if not m:
+                continue
+            name = m.group(2).strip()
+            if name.endswith(" # SKIP") or " # SKIP" in name:
+                outcomes[name.split(" # ")[0]] = "skip"
+                continue
+            # node reports each file as a test too; keep the worst outcome so a
+            # failing file cannot be masked by its own passing summary line
+            verdict = "fail" if m.group(1) else "pass"
+            if outcomes.get(name) != "fail":
+                outcomes[name] = verdict
+        if not outcomes:
+            return {"tests": {},
+                    "error": f"no TAP output: {text.strip()[-400:]}"}
+        return {"tests": outcomes}
+
+
+# --------------------------------------------------------------------------
+# tasks and episodes
+# --------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """You are an expert {lang} engineer working in an existing repository.
+
+Resolve the user's request by editing files with the tools provided.
+
+Important constraints:
+- You cannot run the code, the tests, or any shell command. The only feedback
+  available is the `lint` tool, which reports syntax and type problems.
+- The repository already has a test suite that will be run against your work
+  after you finish, but you cannot see it or run it. Do not create test files.
+- Read enough of the code to understand it before editing. A change that only
+  makes the symptom go away will usually fail the tests.
+- Make the smallest correct change. Do not reformat or refactor unrelated code.
+
+Call `finish` when the change is complete."""
+
+
+@dataclass
+class AgenticTask:
+    task_id: str
+    lang: str
+    category: str            # syntax | type | logic | feature
+    difficulty: int
+    instruction: str
+    files: Dict[str, str]
+    tests: Dict[str, str]
+    gold: Dict[str, str] = field(default_factory=dict)
+    fail_to_pass: List[str] = field(default_factory=list)
+    pass_to_pass: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_record(cls, rec: Dict[str, Any]) -> "AgenticTask":
+        def as_map(v):
+            return v if isinstance(v, dict) else json.loads(v or "{}")
+        def as_list(v):
+            return v if isinstance(v, list) else json.loads(v or "[]")
+        return cls(
+            task_id=rec["task_id"], lang=rec["lang"], category=rec["category"],
+            difficulty=int(rec.get("difficulty", 3)),
+            instruction=rec["instruction"],
+            files=as_map(rec["files"]), tests=as_map(rec["tests"]),
+            gold=as_map(rec.get("gold")),
+            fail_to_pass=as_list(rec.get("fail_to_pass")),
+            pass_to_pass=as_list(rec.get("pass_to_pass")),
+        )
+
+    @property
+    def spec(self) -> LangSpec:
+        return LANGS[self.lang]
+
+
+def materialise(files: Dict[str, str], dest: Path) -> Path:
+    """Write a file map out as a real directory tree."""
+    dest.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        p = dest / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return dest
+
+
+def repo_overview(files: Dict[str, str]) -> str:
+    """A compact tree, so a run is not lost merely to not finding the files."""
+    lines = []
+    for rel in sorted(files):
+        n = files[rel].count("\n") + 1
+        lines.append(f"  {rel} ({n} lines)")
+    return "\n".join(lines)
+
+
+def user_prompt(task: AgenticTask) -> str:
+    return (f"Repository files:\n{repo_overview(task.files)}\n\n"
+            f"Task:\n{task.instruction}")
+
+
+@dataclass
+class EpisodeResult:
+    stop_reason: str = "unknown"
+    turns: int = 0
+    tool_calls: int = 0
+    tool_errors: int = 0
+    edits: int = 0
+    escape_attempts: int = 0
+    finished: bool = False
+    bad_tool_json: int = 0
+    nudges: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    peak_context: int = 0
+    per_tool: Dict[str, int] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+# Sent when a turn arrives with no tool calls and no `finish`. Models routinely
+# narrate their analysis in prose mid-task; treating that as "done" would end
+# the episode with no edits and score a reasoning failure that never happened.
+# Deliberately neutral: it points at the protocol, never at the defect.
+NUDGE = ("You did not call any tool. If your change is complete, call `finish`. "
+         "Otherwise continue working using the tools.")
+
+
+def run_episode(task: AgenticTask, toolbox: ToolBox, chat,
+                max_turns: int = 50,
+                context_limit: Optional[int] = None,
+                max_nudges: int = 3) -> Tuple[EpisodeResult, List[Dict]]:
+    """Drive one multi-turn tool-calling episode.
+
+    `chat(messages, tools) -> response dict` is supplied by the caller so this
+    module stays free of any HTTP concerns.
+    """
+    tools = tool_schemas()
+    messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": SYSTEM_PROMPT.format(lang=task.spec.name)},
+        {"role": "user", "content": user_prompt(task)},
+    ]
+    res = EpisodeResult()
+
+    for turn in range(max_turns):
+        res.turns = turn + 1
+        try:
+            reply = chat(messages, tools)
+        except Exception as e:
+            res.stop_reason, res.error = "request_failed", f"{type(e).__name__}: {e}"
+            break
+
+        usage = reply.get("usage") or {}
+        pt = int(usage.get("prompt_tokens") or 0)
+        ct = int(usage.get("completion_tokens") or 0)
+        res.prompt_tokens += pt
+        res.completion_tokens += ct
+        res.peak_context = max(res.peak_context, pt + ct)
+
+        choices = reply.get("choices") or []
+        if not choices:
+            res.stop_reason, res.error = "no_choices", json.dumps(reply)[:300]
+            break
+        msg = choices[0].get("message") or {}
+        calls = msg.get("tool_calls") or []
+
+        # Echo the assistant turn back verbatim; the server needs the exact
+        # tool_call ids to match the results that follow.
+        messages.append({
+            "role": "assistant",
+            "content": msg.get("content") or "",
+            **({"tool_calls": calls} if calls else {}),
+        })
+
+        if not calls:
+            if toolbox.finished:
+                res.stop_reason = "finished"
+                break
+            if res.nudges >= max_nudges:
+                res.stop_reason = "no_tool_calls"
+                break
+            res.nudges += 1
+            messages.append({"role": "user", "content": NUDGE})
+            continue
+
+        for call in calls:
+            fn = call.get("function") or {}
+            name = fn.get("name") or ""
+            raw = fn.get("arguments")
+            if isinstance(raw, dict):
+                args = raw
+            else:
+                try:
+                    args = json.loads(raw or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    # Small models routinely emit unparseable arguments. That is
+                    # a real failure mode worth counting rather than hiding, so
+                    # it is reported back like any other tool error.
+                    res.bad_tool_json += 1
+                    args = None
+            output = (toolbox.dispatch(name, args) if args is not None else
+                      f"Error: arguments for {name!r} were not valid JSON.")
+            messages.append({"role": "tool",
+                             "tool_call_id": call.get("id") or f"call_{res.tool_calls}",
+                             "content": output})
+
+        if toolbox.finished:
+            res.stop_reason = "finished"
+            break
+        if context_limit and res.peak_context > context_limit:
+            res.stop_reason = "context_limit"
+            break
+    else:
+        res.stop_reason = "max_turns"
+
+    res.tool_calls = toolbox.calls
+    res.tool_errors = toolbox.errors
+    res.edits = toolbox.edits
+    res.escape_attempts = toolbox.ws.escape_attempts
+    res.finished = toolbox.finished
+    res.per_tool = dict(toolbox.per_tool)
+    return res, messages
+
+
+# --------------------------------------------------------------------------
+# grading
+# --------------------------------------------------------------------------
+
+def run_tests_against(files: Dict[str, str], task: AgenticTask, runner: Runner,
+                      workroot: Path, label: str) -> Dict[str, str]:
+    """Materialise a tree, drop the hidden tests in, and run them.
+
+    The tests are only ever written into this throwaway copy, never into the
+    tree the agent worked in, so there is no window in which they could have
+    been read or edited.
+    """
+    dest = workroot / f"grade-{label}"
+    shutil.rmtree(dest, ignore_errors=True)
+    materialise(files, dest)
+    materialise(task.tests, dest)
+    return runner.test(dest).get("tests", {})
+
+
+def score(task: AgenticTask, outcomes: Dict[str, str]) -> Dict[str, Any]:
+    """Resolved means every target test passes and nothing previously passing broke."""
+    def passing(tid):
+        return outcomes.get(tid) == "pass"
+
+    f2p_ok = [t for t in task.fail_to_pass if passing(t)]
+    p2p_ok = [t for t in task.pass_to_pass if passing(t)]
+    regressions = [t for t in task.pass_to_pass if not passing(t)]
+    resolved = (len(f2p_ok) == len(task.fail_to_pass)
+                and not regressions and bool(task.fail_to_pass))
+    return {
+        "resolved": resolved,
+        "f2p_passed": len(f2p_ok), "f2p_total": len(task.fail_to_pass),
+        "p2p_passed": len(p2p_ok), "p2p_total": len(task.pass_to_pass),
+        "regressions": regressions[:10],
+        "n_regressions": len(regressions),
+        "partial": (len(f2p_ok) / len(task.fail_to_pass)) if task.fail_to_pass else 0.0,
+    }
+
+
+def make_sandbox(lang_name: str, sandbox_cls, cache_root=None, base_python=None):
+    """A sandbox carrying only the toolchain for `lang_name`.
+
+    Keyed per language rather than per suite: running the Python tasks must
+    never provision node, and vice versa.
+    """
+    lang = LANGS[lang_name]
+    return sandbox_cls(
+        name=f"agentic-{lang_name}",
+        packages=list(lang.packages),
+        provision=list(lang.provision),
+        env=dict(lang.env),
+        address_space_limit=lang.address_space_limit,
+        cache_root=cache_root,
+        base_python=base_python,
+    )
+
+
+def run_task(task: AgenticTask, chat, sandbox, workroot: Optional[Path] = None,
+             max_turns: int = 50, context_limit: Optional[int] = None,
+             test_timeout: float = 90.0) -> Dict[str, Any]:
+    """One full attempt: fresh workspace, agent episode, then hidden tests."""
+    root = Path(tempfile.mkdtemp(prefix=f"agentic-{task.task_id}-",
+                                 dir=str(workroot) if workroot else None))
+    try:
+        ws_root = root / "repo"
+        materialise(task.files, ws_root)
+        ws = Workspace(ws_root)
+        runner = Runner(sandbox, task.spec, timeout=test_timeout)
+        toolbox = ToolBox(ws, linter=lambda t: runner.lint(ws_root, t))
+
+        episode, messages = run_episode(task, toolbox, chat,
+                                        max_turns=max_turns,
+                                        context_limit=context_limit)
+        final = ws.snapshot()
+        changed = sorted(k for k in final
+                         if final[k] != task.files.get(k)) + \
+                  sorted(k for k in task.files if k not in final)
+
+        outcomes = run_tests_against(final, task, runner, root, "final")
+        result = score(task, outcomes)
+        result.update({
+            "task_id": task.task_id, "lang": task.lang,
+            "category": task.category, "difficulty": task.difficulty,
+            "changed_files": changed,
+            "episode": {k: v for k, v in vars(episode).items()},
+        })
+        return result
+    finally:
+        shutil.rmtree(root, ignore_errors=True)

--- a/examples/llama-eval/eval_sandbox.py
+++ b/examples/llama-eval/eval_sandbox.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Lightweight sandboxed execution for code-generation evals (HumanEval, ClassEval).
+
+Replaces the usual Docker-per-suite setup with a cached venv plus whatever
+process isolation the host can give us without root:
+
+    tier 1  bubblewrap   read-only root, tmpfs /tmp and $HOME, no network
+    tier 2  unshare -rn  no network (home still visible)
+    tier 3  rlimits only last resort, still capped on cpu/memory/procs/files
+
+Every tier also applies rlimits and runs the candidate program in a throwaway
+working directory as its own process group, so a runaway solution is killed
+along with anything it spawned.
+"""
+
+import json
+import os
+import re
+import resource
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import venv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+DEFAULT_CACHE_ROOT = Path(
+    os.environ.get("LLAMA_EVAL_CACHE", Path.home() / ".cache" / "llama-eval")
+)
+
+# rlimits applied to every candidate program
+LIMIT_AS_BYTES = 4 * 1024 * 1024 * 1024  # 4 GiB address space
+LIMIT_CPU_SECONDS_SLACK = 5              # cpu limit = wall timeout + slack
+LIMIT_NPROC = 256
+LIMIT_FSIZE_BYTES = 64 * 1024 * 1024
+
+
+@dataclass
+class ExecResult:
+    passed: bool
+    status: str           # "ok" | "failed" | "timeout" | "error"
+    stdout: str = ""
+    stderr: str = ""
+    returncode: Optional[int] = None
+    duration: float = 0.0
+
+    def summary(self, max_chars: int = 400) -> str:
+        """Short human-readable reason, for grader logs."""
+        if self.passed:
+            return "ok"
+        if self.status == "timeout":
+            return "timeout"
+        tail = (self.stderr or self.stdout).strip()
+        if not tail:
+            return f"{self.status} (rc={self.returncode})"
+        lines = [ln for ln in tail.splitlines() if ln.strip()]
+        # the last line of a traceback is the actual exception
+        reason = lines[-1] if lines else tail
+        return reason[:max_chars]
+
+
+def resolve_python(spec: Optional[str]) -> Optional[str]:
+    """Turn '3.13' or a path into a usable interpreter, or None if unavailable.
+
+    Suites can need an older interpreter than the one running this tool, because
+    a dependency has no wheel (or no working source build) for the newest
+    CPython. Accepts an explicit path, a bare version, or an executable name.
+    """
+    if not spec:
+        return None
+
+    candidate = Path(spec).expanduser()
+    if candidate.exists() and candidate.is_file():
+        return str(candidate)
+
+    # For a bare version, ask uv before searching PATH. A `pythonX.Y` on PATH is
+    # often a shim into wherever it happened to be installed -- including a
+    # scratch directory that will be deleted -- whereas uv reports its own
+    # managed install, which is stable.
+    uv = shutil.which("uv")
+    if uv and re.fullmatch(r"\d+\.\d+(\.\d+)?", spec):
+        try:
+            r = subprocess.run([uv, "python", "find", spec],
+                               capture_output=True, text=True, timeout=120)
+            path = r.stdout.strip()
+            if r.returncode == 0 and path and Path(path).exists():
+                return path
+        except Exception:
+            pass
+
+    return shutil.which(spec) or shutil.which(f"python{spec}")
+
+
+def _detect_isolation() -> str:
+    """Pick the strongest isolation tier this host supports, once."""
+    probe = "import sys; sys.exit(0)"
+
+    if shutil.which("bwrap"):
+        try:
+            r = subprocess.run(
+                _bwrap_argv(Path.cwd(), [sys.executable, "-I", "-c", probe]),
+                capture_output=True, timeout=20,
+            )
+            if r.returncode == 0:
+                return "bwrap"
+        except Exception:
+            pass
+
+    if shutil.which("unshare"):
+        # Prefer the form that keeps the caller's uid. With `unshare -r` the
+        # program runs as root inside the namespace, which silently changes
+        # behaviour: root bypasses file permission bits, so a test asserting
+        # that a write to a chmod 0444 file fails would instead see it succeed.
+        for tier, argv in (
+            ("unshare", ["unshare", "--user", "--map-current-user", "--net"]),
+            ("unshare-root", ["unshare", "-rn"]),
+        ):
+            try:
+                r = subprocess.run(
+                    [*argv, sys.executable, "-I", "-c", probe],
+                    capture_output=True, timeout=20,
+                )
+                if r.returncode == 0:
+                    return tier
+            except Exception:
+                continue
+
+    return "rlimit"
+
+
+UNSHARE_ARGV = {
+    "unshare": ["unshare", "--user", "--map-current-user", "--net"],
+    "unshare-root": ["unshare", "-rn"],
+}
+
+
+def _under(path: Path, parent: str) -> bool:
+    return bool(parent) and (str(path) == parent
+                             or str(path).startswith(parent.rstrip("/") + os.sep))
+
+
+def _bwrap_argv(workdir: Path, inner: Sequence[str],
+                ro_binds: Sequence[Path] = ()) -> List[str]:
+    home = os.path.expanduser("~")
+    argv = [
+        "bwrap",
+        "--ro-bind", "/", "/",
+        "--dev", "/dev",
+        "--proc", "/proc",
+        "--tmpfs", "/tmp",
+    ]
+    # Hide the real home so candidate code cannot read the user's files. The
+    # venv usually lives under ~/.cache, so bind it back afterwards -- bwrap
+    # applies these in order, and a later bind wins over the earlier tmpfs.
+    if home and home != "/":
+        argv += ["--tmpfs", home]
+    # Only paths the tmpfs just hid need restoring. Re-binding anything else is
+    # not merely redundant: bwrap cannot mount onto a symlink, so a bind whose
+    # destination is one (version-manager alias directories usually are) fails
+    # outright. Under the tmpfs the destination is recreated as a real
+    # directory, which is exactly why the same bind works there.
+    for path in ro_binds:
+        if _under(path, home):
+            argv += ["--ro-bind", str(path), str(path)]
+    argv += [
+        "--bind", str(workdir), str(workdir),
+        "--chdir", str(workdir),
+        "--unshare-all",
+        "--die-with-parent",
+        "--new-session",
+        "--",
+    ]
+    return argv + list(inner)
+
+
+def _nproc_ceiling() -> int:
+    """A process cap that bounds a fork bomb without tripping on existing load.
+
+    RLIMIT_NPROC is enforced per real UID across the whole system, not per
+    process tree, so it has to sit above whatever the user is already running.
+    """
+    try:
+        current = len(os.listdir("/proc"))
+    except OSError:
+        current = 512
+    return max(current * 2, 1024)
+
+
+def _apply_rlimits(timeout: float, with_nproc: bool):
+    def _preexec():
+        os.setsid()
+        cpu = int(timeout) + LIMIT_CPU_SECONDS_SLACK
+        limits = [
+            (resource.RLIMIT_CPU, (cpu, cpu)),
+            (resource.RLIMIT_AS, (LIMIT_AS_BYTES, LIMIT_AS_BYTES)),
+            (resource.RLIMIT_FSIZE, (LIMIT_FSIZE_BYTES, LIMIT_FSIZE_BYTES)),
+            (resource.RLIMIT_CORE, (0, 0)),
+        ]
+        # Only in the no-namespace fallback: with bwrap/unshare the PID
+        # namespace already contains a fork bomb, and clamping NPROC there
+        # makes clone(CLONE_NEWUSER) fail outright with EAGAIN.
+        if with_nproc:
+            ceiling = _nproc_ceiling()
+            limits.append((resource.RLIMIT_NPROC, (ceiling, ceiling)))
+        for res, lim in limits:
+            try:
+                resource.setrlimit(res, lim)
+            except (ValueError, OSError):
+                pass
+    return _preexec
+
+
+class Sandbox:
+    """A cached venv plus an isolated runner for untrusted candidate programs."""
+
+    def __init__(
+        self,
+        name: str,
+        packages: Optional[Sequence[str]] = None,
+        cache_root: Optional[Path] = None,
+        base_python: Optional[str] = None,
+        isolation: Optional[str] = None,
+        provision: Optional[Sequence[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+    ):
+        self.name = name
+        self.packages = sorted(set(packages or []))
+        # Python snippets run once at build time, while the network is still
+        # reachable -- this is how a suite that would otherwise download data at
+        # test time (nltk corpora, tokenizer models) gets to run offline later.
+        self.provision = list(provision or [])
+        # Extra environment for every run. Values may contain the literal token
+        # {venv}, replaced with the venv path -- data downloaded at provisioning
+        # time must live inside the venv, because $HOME is a tmpfs in the
+        # strongest isolation tier and anything under it disappears.
+        self.env = dict(env or {})
+        self.cache_root = Path(cache_root or DEFAULT_CACHE_ROOT)
+        self.base_python = base_python or sys.executable
+        self.venv_dir = self.cache_root / f"{name}-venv"
+        self._python: Optional[Path] = None
+        self._isolation = isolation
+        self._base_prefix: List[Path] = []
+
+    # -- provisioning ----------------------------------------------------
+
+    @property
+    def python(self) -> Path:
+        if self._python is None:
+            raise RuntimeError("Sandbox.ensure() must be called first")
+        return self._python
+
+    @property
+    def isolation(self) -> str:
+        if self._isolation is None:
+            self._isolation = _detect_isolation()
+        return self._isolation
+
+    def _stamp_path(self) -> Path:
+        return self.venv_dir / ".llama-eval-stamp.json"
+
+    def _stamp_matches(self) -> bool:
+        try:
+            stamp = json.loads(self._stamp_path().read_text())
+        except Exception:
+            return False
+        return (
+            stamp.get("packages") == self.packages
+            and stamp.get("py") == self._base_version()
+            and stamp.get("provision") == self.provision
+        )
+
+    def _resolved_env(self) -> Dict[str, str]:
+        return {k: v.replace("{venv}", str(self.venv_dir)) for k, v in self.env.items()}
+
+    def _base_version(self) -> str:
+        r = subprocess.run(
+            [self.base_python, "-c",
+             "import sys;print('.'.join(map(str,sys.version_info[:3])))"],
+            capture_output=True, text=True,
+        )
+        return r.stdout.strip()
+
+    def ensure(self, force: bool = False, quiet: bool = False) -> Path:
+        """Create/refresh the venv. Idempotent and cheap when already valid."""
+        py = self.venv_dir / "bin" / "python"
+        if force and self.venv_dir.exists():
+            shutil.rmtree(self.venv_dir)
+
+        if py.exists() and self._stamp_matches():
+            self._python = py
+            self._base_prefix = self._detect_base_prefix(py)
+            return py
+
+        if not quiet:
+            pkgs = ", ".join(self.packages) if self.packages else "stdlib only"
+            print(f"[sandbox] provisioning venv {self.venv_dir} ({pkgs})")
+
+        self.cache_root.mkdir(parents=True, exist_ok=True)
+        if self.venv_dir.exists():
+            shutil.rmtree(self.venv_dir)
+
+        uv = shutil.which("uv")
+        if uv:
+            subprocess.run(
+                [uv, "venv", "--python", self.base_python, str(self.venv_dir)],
+                check=True, capture_output=True,
+            )
+        elif Path(self.base_python).resolve() == Path(sys.executable).resolve():
+            venv.EnvBuilder(with_pip=bool(self.packages), clear=True).create(self.venv_dir)
+        else:
+            subprocess.run(
+                [self.base_python, "-m", "venv", str(self.venv_dir)],
+                check=True, capture_output=True,
+            )
+
+        if self.packages:
+            if uv:
+                cmd = [uv, "pip", "install", "--python", str(py), *self.packages]
+            else:
+                cmd = [str(py), "-m", "pip", "install", "--quiet",
+                       "--disable-pip-version-check", *self.packages]
+            r = subprocess.run(cmd, capture_output=True, text=True)
+            if r.returncode != 0:
+                raise RuntimeError(
+                    f"failed to install {len(self.packages)} package(s) into "
+                    f"{self.venv_dir}:\n{(r.stderr or r.stdout)[-3000:]}"
+                )
+
+        for i, snippet in enumerate(self.provision, 1):
+            if not quiet:
+                print(f"[sandbox] provisioning step {i}/{len(self.provision)}")
+            # deliberately unsandboxed: this is the one point where the suite is
+            # allowed network access, so that test time never needs it
+            prov_env = dict(os.environ)
+            prov_env["SANDBOX_VENV"] = str(self.venv_dir)
+            prov_env.update(self._resolved_env())
+            r = subprocess.run([str(py), "-c", snippet], env=prov_env,
+                               capture_output=True, text=True, timeout=1800)
+            if r.returncode != 0:
+                raise RuntimeError(
+                    f"provisioning step {i} failed:\n{(r.stderr or r.stdout)[-3000:]}"
+                )
+
+        self._stamp_path().write_text(json.dumps({
+            "packages": self.packages,
+            "py": self._base_version(),
+            "provision": self.provision,
+        }))
+        self._python = py
+        self._base_prefix = self._detect_base_prefix(py)
+        if not quiet:
+            print(f"[sandbox] ready ({self.isolation} isolation)")
+        if self.isolation == "unshare-root":
+            print("Warning: this host's unshare cannot keep the caller's uid, so "
+                  "candidate code runs as root inside the namespace. Tests that "
+                  "assert a permission denial will not see one. Install "
+                  "bubblewrap (bwrap) for correct results.")
+        return py
+
+    @staticmethod
+    def _detect_base_prefix(py: Path) -> List[Path]:
+        """Every directory that must stay visible for the venv to start.
+
+        A venv is only symlinks into its base interpreter, so the whole install
+        tree has to survive the tmpfs that hides $HOME -- and binding just the
+        resolved tree is not enough. Version-managed interpreters (uv, pyenv)
+        are commonly reached through an unversioned alias symlink
+        (cpython-3.13-... -> cpython-3.13.14-...), and startup resolves through
+        the alias path, so both spellings need to be mounted. Walk the chain
+        and keep every install root it passes through.
+        """
+        roots: List[Path] = []
+
+        def add(path: Path):
+            if path.exists() and path not in roots:
+                roots.append(path)
+
+        cur, hops = py, 0
+        while hops < 16:
+            hops += 1
+            add(cur.parent.parent)
+            if cur.is_symlink():
+                target = Path(os.readlink(cur))
+                cur = target if target.is_absolute() else (cur.parent / target)
+            else:
+                break
+
+        try:
+            r = subprocess.run([str(py), "-c", "import sys; print(sys.base_prefix)"],
+                               capture_output=True, text=True, timeout=60)
+            if r.returncode == 0 and r.stdout.strip():
+                add(Path(r.stdout.strip()))
+        except Exception:
+            pass
+
+        # a base prefix of /usr is already covered by the read-only root bind
+        return [p for p in roots if str(p) not in ("/", "/usr", "/usr/local")]
+
+    # -- execution -------------------------------------------------------
+
+    def run(self, code: str, timeout: float = 15.0,
+            env: Optional[Dict[str, str]] = None) -> ExecResult:
+        """Run `code` to completion in the sandbox. Exit 0 == passed."""
+        import time
+
+        workdir = Path(tempfile.mkdtemp(prefix=f"{self.name}-", dir="/tmp"))
+        try:
+            prog = workdir / "candidate.py"
+            prog.write_text(code)
+
+            inner = [str(self.python), "-I", "-B", str(prog)]
+            if self.isolation == "bwrap":
+                # the venv, and the base interpreter tree it symlinks into, must
+                # stay visible through the tmpfs that hides $HOME
+                argv = _bwrap_argv(
+                    workdir, inner,
+                    ro_binds=[self.venv_dir, *(self._base_prefix or [])],
+                )
+            elif self.isolation in UNSHARE_ARGV:
+                argv = [*UNSHARE_ARGV[self.isolation], *inner]
+            else:
+                argv = inner
+
+            run_env = {
+                "PATH": "/usr/bin:/bin",
+                "HOME": str(workdir),
+                "TMPDIR": str(workdir),
+                "LC_ALL": "C.UTF-8",
+                "PYTHONHASHSEED": "0",
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "OPENBLAS_NUM_THREADS": "1",
+                "OMP_NUM_THREADS": "1",
+            }
+            run_env.update(self._resolved_env())
+            if env:
+                run_env.update(env)
+
+            started = time.monotonic()
+            proc = subprocess.Popen(
+                argv,
+                cwd=str(workdir),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                errors="replace",
+                env=run_env,
+                preexec_fn=_apply_rlimits(timeout, with_nproc=self.isolation == "rlimit"),
+            )
+            try:
+                out, err = proc.communicate(timeout=timeout)
+                duration = time.monotonic() - started
+            except subprocess.TimeoutExpired:
+                _kill_tree(proc)
+                out, err = proc.communicate()
+                return ExecResult(False, "timeout", out or "", err or "",
+                                  None, time.monotonic() - started)
+
+            if proc.returncode == 0:
+                return ExecResult(True, "ok", out, err, 0, duration)
+            return ExecResult(False, "failed", out, err, proc.returncode, duration)
+
+        except Exception as e:  # sandbox itself misbehaved
+            return ExecResult(False, "error", "", f"{type(e).__name__}: {e}")
+        finally:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _kill_tree(proc: subprocess.Popen):
+    """Kill the candidate and everything it spawned."""
+    for sig in (signal.SIGKILL,):
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError):
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass

--- a/examples/llama-eval/eval_sandbox.py
+++ b/examples/llama-eval/eval_sandbox.py
@@ -22,6 +22,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 import venv
 from dataclasses import dataclass
 from pathlib import Path
@@ -94,14 +95,25 @@ def resolve_python(spec: Optional[str]) -> Optional[str]:
     return shutil.which(spec) or shutil.which(f"python{spec}")
 
 
-def _detect_isolation() -> str:
-    """Pick the strongest isolation tier this host supports, once."""
+def _detect_isolation(probe_python: Optional[str] = None,
+                      ro_binds: Sequence[Path] = ()) -> str:
+    """Pick the strongest isolation tier this host supports, once.
+
+    The probe must run the *same* interpreter the suite will, with the same
+    binds. Probing a bare sys.executable silently downgrades the tier whenever
+    this tool is itself run from a venv under $HOME -- which is the usual case,
+    since it needs `datasets`. bwrap tmpfs-mounts the home directory, the
+    interpreter disappears, the probe fails, and the sandbox falls back to a
+    tier that does not hide $HOME at all. Nothing about the results looks wrong
+    when that happens, so it has to be got right here.
+    """
+    py = probe_python or sys.executable
     probe = "import sys; sys.exit(0)"
 
     if shutil.which("bwrap"):
         try:
             r = subprocess.run(
-                _bwrap_argv(Path.cwd(), [sys.executable, "-I", "-c", probe]),
+                _bwrap_argv(Path.cwd(), [py, "-I", "-c", probe], ro_binds=ro_binds),
                 capture_output=True, timeout=20,
             )
             if r.returncode == 0:
@@ -120,7 +132,7 @@ def _detect_isolation() -> str:
         ):
             try:
                 r = subprocess.run(
-                    [*argv, sys.executable, "-I", "-c", probe],
+                    [*argv, py, "-I", "-c", probe],
                     capture_output=True, timeout=20,
                 )
                 if r.returncode == 0:
@@ -189,16 +201,25 @@ def _nproc_ceiling() -> int:
     return max(current * 2, 1024)
 
 
-def _apply_rlimits(timeout: float, with_nproc: bool):
+def _apply_rlimits(timeout: float, with_nproc: bool,
+                   as_bytes: Optional[int] = LIMIT_AS_BYTES):
     def _preexec():
         os.setsid()
         cpu = int(timeout) + LIMIT_CPU_SECONDS_SLACK
         limits = [
             (resource.RLIMIT_CPU, (cpu, cpu)),
-            (resource.RLIMIT_AS, (LIMIT_AS_BYTES, LIMIT_AS_BYTES)),
             (resource.RLIMIT_FSIZE, (LIMIT_FSIZE_BYTES, LIMIT_FSIZE_BYTES)),
             (resource.RLIMIT_CORE, (0, 0)),
         ]
+        # RLIMIT_AS caps reserved address space, not resident memory, so it is
+        # the wrong instrument for any runtime that reserves a large region up
+        # front and commits little of it. Node's TypeScript type-stripping goes
+        # through WebAssembly, which reserves multiple gigabytes per instance
+        # and dies at 4 GiB with an out-of-memory error that looks like a bug
+        # in the code under test. Suites needing such a runtime raise or drop
+        # it; the wall-clock timeout and RLIMIT_FSIZE still bound a runaway.
+        if as_bytes:
+            limits.append((resource.RLIMIT_AS, (as_bytes, as_bytes)))
         # Only in the no-namespace fallback: with bwrap/unshare the PID
         # namespace already contains a fork bomb, and clamping NPROC there
         # makes clone(CLONE_NEWUSER) fail outright with EAGAIN.
@@ -225,6 +246,7 @@ class Sandbox:
         isolation: Optional[str] = None,
         provision: Optional[Sequence[str]] = None,
         env: Optional[Dict[str, str]] = None,
+        address_space_limit: Optional[int] = LIMIT_AS_BYTES,
     ):
         self.name = name
         self.packages = sorted(set(packages or []))
@@ -237,6 +259,8 @@ class Sandbox:
         # time must live inside the venv, because $HOME is a tmpfs in the
         # strongest isolation tier and anything under it disappears.
         self.env = dict(env or {})
+        # None drops the RLIMIT_AS cap entirely -- see _apply_rlimits
+        self.address_space_limit = address_space_limit
         self.cache_root = Path(cache_root or DEFAULT_CACHE_ROOT)
         self.base_python = base_python or sys.executable
         self.venv_dir = self.cache_root / f"{name}-venv"
@@ -255,7 +279,15 @@ class Sandbox:
     @property
     def isolation(self) -> str:
         if self._isolation is None:
-            self._isolation = _detect_isolation()
+            if self._python:
+                py = str(self._python)
+                roots = [self.venv_dir, *(self._base_prefix or [])]
+            else:
+                # probed before the venv exists: still bind the interpreter's
+                # own tree, or the probe fails for the wrong reason
+                py = sys.executable
+                roots = self._detect_base_prefix(Path(py))
+            self._isolation = _detect_isolation(py, roots)
         return self._isolation
 
     def _stamp_path(self) -> Path:
@@ -401,46 +433,53 @@ class Sandbox:
 
     # -- execution -------------------------------------------------------
 
-    def run(self, code: str, timeout: float = 15.0,
-            env: Optional[Dict[str, str]] = None) -> ExecResult:
-        """Run `code` to completion in the sandbox. Exit 0 == passed."""
-        import time
+    def _isolate(self, argv: Sequence[str], workdir: Path,
+                 ro_binds: Sequence[Path] = ()) -> List[str]:
+        """Wrap a command in the strongest isolation tier this host supports."""
+        if self.isolation == "bwrap":
+            # the venv, and the base interpreter tree it symlinks into, must
+            # stay visible through the tmpfs that hides $HOME
+            return _bwrap_argv(
+                workdir, argv,
+                ro_binds=[self.venv_dir, *(self._base_prefix or []), *ro_binds],
+            )
+        if self.isolation in UNSHARE_ARGV:
+            return [*UNSHARE_ARGV[self.isolation], *argv]
+        return list(argv)
 
-        workdir = Path(tempfile.mkdtemp(prefix=f"{self.name}-", dir="/tmp"))
+    def _base_env(self, workdir: Path) -> Dict[str, str]:
+        env = {
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(workdir),
+            "TMPDIR": str(workdir),
+            "LC_ALL": "C.UTF-8",
+            "PYTHONHASHSEED": "0",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "OPENBLAS_NUM_THREADS": "1",
+            "OMP_NUM_THREADS": "1",
+        }
+        env.update(self._resolved_env())
+        return env
+
+    def run_argv(self, argv: Sequence[str], workdir: Path,
+                 timeout: float = 15.0, env: Optional[Dict[str, str]] = None,
+                 ro_binds: Sequence[Path] = ()) -> ExecResult:
+        """Run an arbitrary command in `workdir`, which stays writable.
+
+        Unlike run(), the caller owns the directory and it survives the call.
+        That is what a multi-step agent needs: its edits have to persist across
+        many tool invocations before anything is graded. Taking an argv rather
+        than a source string is what lets a suite drive a linter or a test
+        runner for a language other than Python.
+        """
+        run_env = self._base_env(workdir)
+        if env:
+            run_env.update(env)
+
+        started = time.monotonic()
         try:
-            prog = workdir / "candidate.py"
-            prog.write_text(code)
-
-            inner = [str(self.python), "-I", "-B", str(prog)]
-            if self.isolation == "bwrap":
-                # the venv, and the base interpreter tree it symlinks into, must
-                # stay visible through the tmpfs that hides $HOME
-                argv = _bwrap_argv(
-                    workdir, inner,
-                    ro_binds=[self.venv_dir, *(self._base_prefix or [])],
-                )
-            elif self.isolation in UNSHARE_ARGV:
-                argv = [*UNSHARE_ARGV[self.isolation], *inner]
-            else:
-                argv = inner
-
-            run_env = {
-                "PATH": "/usr/bin:/bin",
-                "HOME": str(workdir),
-                "TMPDIR": str(workdir),
-                "LC_ALL": "C.UTF-8",
-                "PYTHONHASHSEED": "0",
-                "PYTHONDONTWRITEBYTECODE": "1",
-                "OPENBLAS_NUM_THREADS": "1",
-                "OMP_NUM_THREADS": "1",
-            }
-            run_env.update(self._resolved_env())
-            if env:
-                run_env.update(env)
-
-            started = time.monotonic()
             proc = subprocess.Popen(
-                argv,
+                self._isolate(argv, workdir, ro_binds),
                 cwd=str(workdir),
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
@@ -448,21 +487,35 @@ class Sandbox:
                 text=True,
                 errors="replace",
                 env=run_env,
-                preexec_fn=_apply_rlimits(timeout, with_nproc=self.isolation == "rlimit"),
+                preexec_fn=_apply_rlimits(timeout,
+                                          with_nproc=self.isolation == "rlimit",
+                                          as_bytes=self.address_space_limit),
             )
-            try:
-                out, err = proc.communicate(timeout=timeout)
-                duration = time.monotonic() - started
-            except subprocess.TimeoutExpired:
-                _kill_tree(proc)
-                out, err = proc.communicate()
-                return ExecResult(False, "timeout", out or "", err or "",
-                                  None, time.monotonic() - started)
+        except Exception as e:  # sandbox itself misbehaved
+            return ExecResult(False, "error", "", f"{type(e).__name__}: {e}")
 
-            if proc.returncode == 0:
-                return ExecResult(True, "ok", out, err, 0, duration)
-            return ExecResult(False, "failed", out, err, proc.returncode, duration)
+        try:
+            out, err = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _kill_tree(proc)
+            out, err = proc.communicate()
+            return ExecResult(False, "timeout", out or "", err or "",
+                              None, time.monotonic() - started)
 
+        duration = time.monotonic() - started
+        if proc.returncode == 0:
+            return ExecResult(True, "ok", out, err, 0, duration)
+        return ExecResult(False, "failed", out, err, proc.returncode, duration)
+
+    def run(self, code: str, timeout: float = 15.0,
+            env: Optional[Dict[str, str]] = None) -> ExecResult:
+        """Run `code` to completion in the sandbox. Exit 0 == passed."""
+        workdir = Path(tempfile.mkdtemp(prefix=f"{self.name}-", dir="/tmp"))
+        try:
+            prog = workdir / "candidate.py"
+            prog.write_text(code)
+            return self.run_argv([str(self.python), "-I", "-B", str(prog)],
+                                 workdir, timeout=timeout, env=env)
         except Exception as e:  # sandbox itself misbehaved
             return ExecResult(False, "error", "", f"{type(e).__name__}: {e}")
         finally:

--- a/examples/llama-eval/llama-eval.py
+++ b/examples/llama-eval/llama-eval.py
@@ -28,6 +28,18 @@ class ServerConfig:
     url: str
     threads: int
     name: str = ""
+    api_key: Optional[str] = None
+
+    def headers(self) -> Dict[str, str]:
+        return auth_headers(self.api_key)
+
+
+def auth_headers(api_key: Optional[str]) -> Dict[str, str]:
+    """Standard request headers, carrying a bearer token when one is configured."""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
 
 def wilson_interval(correct: int, total: int, z: float = 1.96) -> Tuple[float, float]:
     """Wilson score confidence interval for a proportion."""
@@ -1712,6 +1724,7 @@ class Grader:
         grader_script: Optional[str] = None,
         grader_model_name: Optional[str] = None,
         grader_server_url: str = "",
+        grader_api_key: Optional[str] = None,
         dataset_type: str = "aime",
         sandbox: Optional[Sandbox] = None,
         exec_timeout: float = 15.0,
@@ -1722,6 +1735,7 @@ class Grader:
         self.grader_script = grader_script
         self.grader_model_name = grader_model_name
         self.grader_server_url = grader_server_url
+        self.grader_api_key = grader_api_key
         self.dataset_type = dataset_type
         self.sandbox = sandbox
         self.exec_timeout = exec_timeout
@@ -1822,7 +1836,7 @@ When extracting the answer, provide only the extracted answer itself, nothing el
 Please provide only the extracted answer, nothing else. If there is no clear answer that can be extracted from the response, reply with 'no answer'."""
 
         url = f"{self.grader_server_url}/v1/chat/completions"
-        headers = {"Content-Type": "application/json"}
+        headers = auth_headers(self.grader_api_key)
         data = {
             "model": self.grader_model_name,
             "messages": [
@@ -1899,7 +1913,7 @@ class Processor:
     def _check_server(server_config: ServerConfig) -> List[str]:
         url = f"{server_config.url}/v1/models"
         try:
-            response = requests.get(url)
+            response = requests.get(url, headers=server_config.headers())
             response.raise_for_status()
             models = [m["id"] for m in response.json().get("data", [])]
             return models
@@ -1911,7 +1925,7 @@ class Processor:
         self, server_config: ServerConfig, eval_state: EvalState, prompt: str
     ) -> Tuple[Dict[str, Any], int, Optional[float], Optional[float], str]:
         url = f"{server_config.url}/v1/chat/completions"
-        headers = {"Content-Type": "application/json"}
+        headers = server_config.headers()
         data = {
             "model": self.model_name if self.model_name else "llama",
             "messages": [{"role": "user", "content": prompt}],
@@ -2041,7 +2055,7 @@ class Processor:
                 value = eval_state.sampling_config.get(key)
                 if value is not None:
                     data[key] = value
-            response = requests.post(url, headers={"Content-Type": "application/json"},
+            response = requests.post(url, headers=server_config.headers(),
                                      json=data, timeout=1800)
             response.raise_for_status()
             return response.json()
@@ -2296,6 +2310,13 @@ def main():
         help="Comma-separated display names for servers (default: use URLs)"
     )
     parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="Bearer token for the eval servers: one key for all of them, or a "
+             "comma-separated key per --server (default: $LLAMA_API_KEY, else none)"
+    )
+    parser.add_argument(
         "--dataset",
         type=str,
         default="aime",
@@ -2429,6 +2450,13 @@ def main():
         help="Model name for LLM grader (default: same as main model)"
     )
     parser.add_argument(
+        "--grader-api-key",
+        type=str,
+        default=None,
+        help="Bearer token for the LLM grader server (default: the first "
+             "--api-key when the grader runs on the main server, else none)"
+    )
+    parser.add_argument(
         "--agentic-lang",
         type=str,
         default=None,
@@ -2499,10 +2527,33 @@ def main():
     else:
         server_names = server_urls  # fallback to URLs
 
+    # One key shared by every server is the common case; a comma-separated list
+    # covers a mixed run where each endpoint has its own credentials.
+    api_key_arg = args.api_key if args.api_key is not None else os.environ.get("LLAMA_API_KEY")
+    if api_key_arg:
+        api_keys = [k.strip() for k in api_key_arg.split(",")]
+        if len(api_keys) == 1:
+            api_keys = api_keys * len(server_urls)
+        elif len(api_keys) != len(server_urls):
+            print(f"Error: --api-key ({len(api_keys)} keys) must be a single key or "
+                  f"match --server ({len(server_urls)} URLs)")
+            sys.exit(1)
+    else:
+        api_keys = [None] * len(server_urls)
+
     server_configs = [
-        ServerConfig(url=url, threads=threads, name=name)
-        for url, threads, name in zip(server_urls, thread_counts, server_names)
+        ServerConfig(url=url, threads=threads, name=name, api_key=key)
+        for url, threads, name, key in zip(server_urls, thread_counts, server_names, api_keys)
     ]
+
+    # The grader usually runs on one of the eval servers, so it inherits that
+    # server's key unless it was given one of its own.
+    if args.grader_api_key is not None:
+        grader_api_key = args.grader_api_key
+    else:
+        grader_url = args.grader_server or server_configs[0].url
+        grader_api_key = next(
+            (s.api_key for s in server_configs if s.url == grader_url), None)
 
     if args.dataset == "gpqa" and args.grader_type != "llm":
         print("Error: GPQA dataset requires --grader-type llm")
@@ -2548,6 +2599,7 @@ def main():
             grader_script=args.grader_script,
             grader_model_name=grader_model_name,
             grader_server_url=grader_server_url,
+            grader_api_key=grader_api_key,
             dataset_type=eval_state.dataset_type
         )
         resume = True
@@ -2567,6 +2619,7 @@ def main():
             grader_script=args.grader_script,
             grader_model_name=grader_model_name,
             grader_server_url=grader_server_url,
+            grader_api_key=grader_api_key,
             dataset_type=args.dataset
         )
 

--- a/examples/llama-eval/llama-eval.py
+++ b/examples/llama-eval/llama-eval.py
@@ -170,6 +170,24 @@ AGENTIC_OPTS: Dict[str, Any] = {}
 class BaseDataset(ABC):
     questions: List[Dict]
 
+    # -- agentic hooks ----------------------------------------------------
+    # A suite that drives its own multi-turn tool conversation sets this, and
+    # the Processor hands it the whole episode instead of making one request.
+
+    is_agentic: bool = False
+
+    def prepare(self, base_python: Optional[str] = None, force: bool = False) -> None:
+        """Provision whatever the suite needs before any task runs.
+
+        Single-shot suites are provisioned from required_packages() instead, so
+        this is a no-op for them.
+        """
+
+    def run(self, index: int, chat) -> Dict[str, Any]:
+        """Drive one episode to completion and return its scored result."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not drive its own conversation")
+
     # -- code-suite hooks -------------------------------------------------
     # Only consulted when the exec grader is active. They let a suite own how
     # its generated code is assembled and scored, which differs a lot: one
@@ -281,6 +299,13 @@ class EvalState:
         self.processed = 0
         self.total_time: float = 0.0
         self._lock = threading.Lock()
+
+    @property
+    def loaded_dataset(self) -> BaseDataset:
+        """The dataset, once loaded. Raises rather than handing back None."""
+        if self.dataset is None:
+            raise RuntimeError("dataset not loaded; call load_dataset() first")
+        return self.dataset
 
     def load_dataset(self, seed: int = 1234):
         if self.dataset_type == "aime":
@@ -1931,7 +1956,7 @@ class Processor:
             problem_idx=problem_idx,
         )
 
-        if getattr(eval_state.dataset, "is_agentic", False):
+        if eval_state.loaded_dataset.is_agentic:
             return self._process_agentic_case(
                 server_config, eval_state, i, task_id, task_state)
 
@@ -2029,7 +2054,7 @@ class Processor:
     ) -> TaskState:
         """Run one whole tool-driven episode and grade the tree it leaves behind."""
         try:
-            result = eval_state.dataset.run(
+            result = eval_state.loaded_dataset.run(
                 i, self._agentic_chat(server_config, eval_state))
         except Exception as e:
             # Record the failure rather than only marking the in-memory state.
@@ -2573,37 +2598,38 @@ def main():
 
     # The execution venv is derived from the dataset, so it is built only once
     # the dataset is known -- true on both the fresh and the resume path.
-    if args.grader_type == "exec" and getattr(eval_state.dataset, "is_agentic", False):
-        # One venv per language in the selected tasks, rather than one per suite
-        eval_state.dataset.prepare(base_python=args.sandbox_python,
-                                   force=args.rebuild_sandbox)
-    elif args.grader_type == "exec":
-        dataset = eval_state.dataset
+    if args.grader_type == "exec":
+        dataset = eval_state.loaded_dataset
 
-        base_python = args.sandbox_python
-        if not base_python and dataset.preferred_python():
+        if dataset.is_agentic:
+            # One venv per language in the selected tasks, not one per suite
+            dataset.prepare(base_python=args.sandbox_python,
+                            force=args.rebuild_sandbox)
+        else:
+            base_python = args.sandbox_python
             want = dataset.preferred_python()
-            base_python = resolve_python(want)
-            if base_python:
-                print(f"[sandbox] using Python {want} for {eval_state.dataset_type} "
-                      f"({base_python})")
+            if not base_python and want:
+                base_python = resolve_python(want)
+                if base_python:
+                    print(f"[sandbox] using Python {want} for "
+                          f"{eval_state.dataset_type} ({base_python})")
 
-        dataset.configure_python(base_python or sys.executable)
+            dataset.configure_python(base_python or sys.executable)
 
-        sandbox = Sandbox(
-            name=eval_state.dataset_type,
-            packages=dataset.required_packages(),
-            provision=dataset.provision_steps(),
-            env=dataset.sandbox_env(),
-            base_python=base_python,
-        )
-        sandbox.ensure(force=args.rebuild_sandbox)
-        preflight_sandbox(sandbox)
-        grader.sandbox = sandbox
-        grader.dataset = dataset
-        grader.exec_timeout = (args.exec_timeout if args.exec_timeout is not None
-                               else dataset.default_exec_timeout())
-        grader.exec_seed = None if args.exec_seed < 0 else args.exec_seed
+            sandbox = Sandbox(
+                name=eval_state.dataset_type,
+                packages=dataset.required_packages(),
+                provision=dataset.provision_steps(),
+                env=dataset.sandbox_env(),
+                base_python=base_python,
+            )
+            sandbox.ensure(force=args.rebuild_sandbox)
+            preflight_sandbox(sandbox)
+            grader.sandbox = sandbox
+            grader.dataset = dataset
+            grader.exec_timeout = (args.exec_timeout if args.exec_timeout is not None
+                                   else dataset.default_exec_timeout())
+            grader.exec_seed = None if args.exec_seed < 0 else args.exec_seed
 
     processor = Processor(
         server_configs=server_configs,

--- a/examples/llama-eval/llama-eval.py
+++ b/examples/llama-eval/llama-eval.py
@@ -134,7 +134,11 @@ any imports the class needs. Do not include tests, example usage, or explanation
 # Suites graded by running the generated code instead of matching its text.
 # The venv is provisioned from the dataset's own import inventory, so it only
 # ever carries what the suite actually needs.
-CODE_SUITES = {"humaneval", "classeval"}
+CODE_SUITES = {"humaneval", "classeval", "agentic"}
+
+# Suites where the model drives its own multi-turn tool loop rather than
+# answering a single prompt. The Processor hands the whole episode over.
+AGENTIC_SUITES = {"agentic"}
 
 # Import name -> pip name, for the cases where they differ. Anything not listed
 # is assumed to install under the name it imports as.
@@ -158,6 +162,9 @@ PIP_NAMES = {
 # Overridden by --dataset-source; lets a suite be pointed at a patched copy
 # (local .jsonl or a HuggingFace repo) without touching the loader.
 DATASET_SOURCE: Optional[str] = None
+
+# Extra construction options for the agentic suite, set from the CLI.
+AGENTIC_OPTS: Dict[str, Any] = {}
 
 
 class BaseDataset(ABC):
@@ -290,6 +297,8 @@ class EvalState:
             self.dataset = HumanEvalDataset(source=DATASET_SOURCE)
         elif self.dataset_type == "classeval":
             self.dataset = ClassEvalDataset(source=DATASET_SOURCE)
+        elif self.dataset_type == "agentic":
+            self.dataset = AgenticDataset(source=DATASET_SOURCE, **AGENTIC_OPTS)
         else:
             raise ValueError(f"Unknown dataset type: {self.dataset_type}")
 
@@ -1531,6 +1540,103 @@ class ClassEvalDataset(BaseDataset):
         )
 
 
+class AgenticDataset(BaseDataset):
+    """Multi-turn tool-driven repair tasks over a small real repository.
+
+    The other code suites answer one prompt. Here the model is handed a tool
+    set and drives its own conversation, so the Processor delegates the whole
+    episode rather than making a single request.
+
+    Everything language-specific is imported lazily and provisioned per
+    language, so selecting the Python tasks never installs a node toolchain --
+    and running any other suite installs none of it.
+    """
+
+    HF_REPO = "ilintar/SACB"
+    is_agentic = True
+
+    def __init__(self, source: Optional[str] = None, lang: Optional[str] = None,
+                 max_turns: int = 50, context_limit: Optional[int] = None,
+                 max_tokens: int = 2048):
+        self.source = source or self.HF_REPO
+        self.lang_filter = lang
+        self.max_turns = max_turns
+        self.context_limit = context_limit
+        self.max_tokens = max_tokens
+        self._sandboxes: Dict[str, Any] = {}
+        self._load_dataset()
+
+    def _load_dataset(self):
+        # imported here rather than at module scope so the other suites never
+        # pay for it, in import time or in dependencies
+        import agentic_eval as ae
+        self.ae = ae
+
+        print(f"Loading agentic dataset (source: {self.source})...")
+        path = Path(self.source)
+        if path.exists():
+            rows = [json.loads(line) for line in path.read_text().splitlines()
+                    if line.strip()]
+        else:
+            from datasets import load_dataset
+            rows = [dict(r) for r in load_dataset(self.source, split="test")]
+
+        if self.lang_filter:
+            rows = [r for r in rows if r.get("lang") == self.lang_filter]
+        if not rows:
+            raise ValueError(
+                f"no agentic tasks in {self.source}"
+                + (f" for language {self.lang_filter!r}" if self.lang_filter else ""))
+
+        self.tasks = [ae.AgenticTask.from_record(r) for r in rows]
+        self.languages = sorted({t.lang for t in self.tasks})
+        print(f"Agentic dataset loaded: {len(self.tasks)} tasks "
+              f"({', '.join(self.languages)})")
+
+    # -- BaseDataset surface --------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self.tasks)
+
+    def get_question(self, index: int) -> Dict:
+        return {"index": index}
+
+    def get_question_text(self, question: Dict) -> str:
+        task = self.tasks[question["index"]]
+        first = task.instruction.strip().splitlines()[0]
+        return f"[{task.task_id}] {first}"
+
+    def get_answer(self, question: Dict) -> str:
+        task = self.tasks[question["index"]]
+        return json.dumps({"task_id": task.task_id, "index": question["index"]})
+
+    def get_prompt(self, question: Dict) -> str:
+        return self.ae.user_prompt(self.tasks[question["index"]])
+
+    def default_exec_timeout(self) -> float:
+        return 90.0
+
+    def required_packages(self) -> List[str]:
+        return []          # provisioned per language instead, see prepare()
+
+    # -- agentic surface -------------------------------------------------
+
+    def prepare(self, base_python: Optional[str] = None, force: bool = False):
+        """Provision one sandbox per language present in the selected tasks."""
+        for lang in self.languages:
+            sandbox = self.ae.make_sandbox(lang, Sandbox, base_python=base_python)
+            sandbox.ensure(force=force)
+            self._sandboxes[lang] = sandbox
+        return self._sandboxes
+
+    def run(self, index: int, chat) -> Dict[str, Any]:
+        task = self.tasks[index]
+        return self.ae.run_task(
+            task, chat, self._sandboxes[task.lang],
+            max_turns=self.max_turns, context_limit=self.context_limit,
+            test_timeout=self.default_exec_timeout())
+
+
 def _as_text(value: Any) -> str:
     """Some dataset fields arrive as a list of lines rather than a blob."""
     if not value:
@@ -1825,6 +1931,10 @@ class Processor:
             problem_idx=problem_idx,
         )
 
+        if getattr(eval_state.dataset, "is_agentic", False):
+            return self._process_agentic_case(
+                server_config, eval_state, i, task_id, task_state)
+
         try:
             response, tokens, tps_gen, t_gen_ms, finish_reason = self._make_request(server_config, eval_state, prompt)
             result = response["choices"][0]["message"]["content"]
@@ -1880,6 +1990,84 @@ class Processor:
         except Exception as e:
             task_state.status = f"error: {str(e)}"
 
+        return task_state
+
+    def _agentic_chat(self, server_config: ServerConfig, eval_state: EvalState):
+        """A chat callable for agentic_eval: messages + tools in, response out."""
+        url = f"{server_config.url}/v1/chat/completions"
+
+        def chat(messages, tools):
+            data = {
+                "model": self.model_name if self.model_name else "llama",
+                "messages": messages,
+                "tools": tools,
+                "tool_choice": "auto",
+            }
+            # Cap each turn. A model that falls into a repetition loop would
+            # otherwise generate until the context runs out, burning the whole
+            # run's wall clock on one turn; capped, it costs a single turn and
+            # the episode carries on.
+            per_turn = getattr(eval_state.dataset, "max_tokens", 0)
+            if self.n_predict and self.n_predict > 0:
+                data["max_tokens"] = self.n_predict
+            elif per_turn:
+                data["max_tokens"] = per_turn
+            for key in ("temperature", "top_k", "top_p", "min_p"):
+                value = eval_state.sampling_config.get(key)
+                if value is not None:
+                    data[key] = value
+            response = requests.post(url, headers={"Content-Type": "application/json"},
+                                     json=data, timeout=1800)
+            response.raise_for_status()
+            return response.json()
+
+        return chat
+
+    def _process_agentic_case(
+        self, server_config: ServerConfig, eval_state: EvalState, i: int,
+        task_id: str, task_state: TaskState
+    ) -> TaskState:
+        """Run one whole tool-driven episode and grade the tree it leaves behind."""
+        try:
+            result = eval_state.dataset.run(
+                i, self._agentic_chat(server_config, eval_state))
+        except Exception as e:
+            # Record the failure rather than only marking the in-memory state.
+            # Without this the case is persisted as "pending" and the summary
+            # quietly counts a smaller denominator, so a run where most
+            # episodes crashed reports a high score over the few that survived.
+            task_state.status = f"error: {type(e).__name__}: {e}"
+            eval_state.add_result(
+                task_id, task_state.prompt, task_state.expected,
+                task_state.status, None,
+                {"error": f"{type(e).__name__}: {e}", "resolved": False},
+                False, task_state.status, 0, None, None, None,
+                server_config.name, task_state.chunk_idx, i,
+            )
+            eval_state.dump()
+            return task_state
+
+        episode = result.get("episode", {})
+        task_state.tokens = episode.get("completion_tokens", 0)
+        task_state.correct = bool(result["resolved"])
+        task_state.answer = ", ".join(result.get("changed_files", [])) or None
+        task_state.grader_log = result
+        task_state.status = "ok"
+        task_state.response = (
+            f"stop={episode.get('stop_reason')} turns={episode.get('turns')} "
+            f"calls={episode.get('tool_calls')} edits={episode.get('edits')} "
+            f"errors={episode.get('tool_errors')} nudges={episode.get('nudges')} "
+            f"peak_ctx={episode.get('peak_context')}\n"
+            f"changed: {task_state.answer or '(nothing)'}"
+        )
+
+        eval_state.add_result(
+            task_id, task_state.prompt, task_state.expected, task_state.response,
+            task_state.answer, result, task_state.correct, "ok",
+            task_state.tokens, None, None, None, server_config.name,
+            task_state.chunk_idx, i,
+        )
+        eval_state.dump()
         return task_state
 
     @staticmethod
@@ -2086,7 +2274,8 @@ def main():
         "--dataset",
         type=str,
         default="aime",
-        choices=["aime", "aime2025", "aime2026", "gsm8k", "gpqa", "humaneval", "classeval"],
+        choices=["aime", "aime2025", "aime2026", "gsm8k", "gpqa", "humaneval",
+                 "classeval", "agentic"],
         help="Dataset type (default: aime)"
     )
     parser.add_argument(
@@ -2215,6 +2404,34 @@ def main():
         help="Model name for LLM grader (default: same as main model)"
     )
     parser.add_argument(
+        "--agentic-lang",
+        type=str,
+        default=None,
+        choices=["python", "typescript"],
+        help="Restrict the agentic suite to one language. Only that language's "
+             "toolchain is then provisioned."
+    )
+    parser.add_argument(
+        "--agentic-max-turns",
+        type=int,
+        default=50,
+        help="Maximum assistant turns per agentic episode (default: 50)"
+    )
+    parser.add_argument(
+        "--agentic-max-tokens",
+        type=int,
+        default=2048,
+        help="Cap on generated tokens per agentic turn (default: 2048). Bounds "
+             "a model that falls into a repetition loop."
+    )
+    parser.add_argument(
+        "--agentic-context-limit",
+        type=int,
+        default=None,
+        help="Abandon an agentic episode once its context exceeds this many "
+             "tokens (default: no limit)"
+    )
+    parser.add_argument(
         "--resume",
         action="store_true",
         help="Resume from existing eval state"
@@ -2222,8 +2439,14 @@ def main():
 
     args = parser.parse_args()
 
-    global DATASET_SOURCE
+    global DATASET_SOURCE, AGENTIC_OPTS
     DATASET_SOURCE = args.dataset_source
+    AGENTIC_OPTS = {
+        "lang": args.agentic_lang,
+        "max_turns": args.agentic_max_turns,
+        "context_limit": args.agentic_context_limit,
+        "max_tokens": args.agentic_max_tokens,
+    }
 
     # Code suites are graded by execution; everything else keeps the llm default.
     if args.grader_type is None:
@@ -2350,7 +2573,11 @@ def main():
 
     # The execution venv is derived from the dataset, so it is built only once
     # the dataset is known -- true on both the fresh and the resume path.
-    if args.grader_type == "exec":
+    if args.grader_type == "exec" and getattr(eval_state.dataset, "is_agentic", False):
+        # One venv per language in the selected tasks, rather than one per suite
+        eval_state.dataset.prepare(base_python=args.sandbox_python,
+                                   force=args.rebuild_sandbox)
+    elif args.grader_type == "exec":
         dataset = eval_state.dataset
 
         base_python = args.sandbox_python

--- a/examples/llama-eval/llama-eval.py
+++ b/examples/llama-eval/llama-eval.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import ast
 import json
 import os
 import re
@@ -18,6 +19,8 @@ import requests
 from tqdm import tqdm
 import random
 from math import sqrt
+
+from eval_sandbox import Sandbox, resolve_python
 
 
 @dataclass
@@ -107,11 +110,108 @@ B) {B}
 C) {C}
 D) {D}
 """,
+    "humaneval": """Complete the following Python function.
+
+```python
+{question}
+```
+
+Reply with the complete function in a single ```python code block, including the \
+signature and any imports it needs. Do not include tests, example usage, or explanation.
+""",
+    "classeval": """Complete the following Python class.
+
+```python
+{question}
+```
+
+Reply with the complete class in a single ```python code block: keep the class name \
+and every method signature exactly as given, implement every method body, and include \
+any imports the class needs. Do not include tests, example usage, or explanation.
+""",
 }
+
+# Suites graded by running the generated code instead of matching its text.
+# The venv is provisioned from the dataset's own import inventory, so it only
+# ever carries what the suite actually needs.
+CODE_SUITES = {"humaneval", "classeval"}
+
+# Import name -> pip name, for the cases where they differ. Anything not listed
+# is assumed to install under the name it imports as.
+PIP_NAMES = {
+    "bs4": "beautifulsoup4",
+    "PIL": "pillow",
+    "docx": "python-docx",
+    "fitz": "pymupdf",
+    "sklearn": "scikit-learn",
+    "yaml": "PyYAML",
+    "cv2": "opencv-python-headless",
+    "PyPDF2": "pypdf2",
+    "Levenshtein": "levenshtein",
+    "dateutil": "python-dateutil",
+    "attr": "attrs",
+    "OpenSSL": "pyOpenSSL",
+    "serial": "pyserial",
+    "Crypto": "pycryptodome",
+}
+
+# Overridden by --dataset-source; lets a suite be pointed at a patched copy
+# (local .jsonl or a HuggingFace repo) without touching the loader.
+DATASET_SOURCE: Optional[str] = None
 
 
 class BaseDataset(ABC):
     questions: List[Dict]
+
+    # -- code-suite hooks -------------------------------------------------
+    # Only consulted when the exec grader is active. They let a suite own how
+    # its generated code is assembled and scored, which differs a lot: one
+    # HumanEval problem is a single function judged by one assert, whereas one
+    # ClassEval task is a whole class judged by many independent test methods.
+
+    def required_packages(self) -> List[str]:
+        """Third-party pip packages the suite's tests need."""
+        return []
+
+    def provision_steps(self) -> List[str]:
+        """Python snippets run once at venv build time, with network access."""
+        return []
+
+    def preferred_python(self) -> Optional[str]:
+        """Interpreter the suite's dependencies need, if not the current one."""
+        return None
+
+    def configure_python(self, python: str):
+        """Told which interpreter the sandbox will use, before it is built.
+
+        Lets a suite adapt its package set to what that version can actually
+        install.
+        """
+
+    def default_exec_timeout(self) -> float:
+        """Per-task wall-clock limit that suits this suite's workload."""
+        return 15.0
+
+    def sandbox_env(self) -> Dict[str, str]:
+        """Extra env for every run; '{venv}' expands to the venv path."""
+        return {}
+
+    def extract(self, response: str, question: Dict) -> str:
+        """Pull the candidate code out of a chat reply."""
+        return extract_code(response)
+
+    def build_program(self, question: Dict, completion: str,
+                      seed: Optional[int] = None) -> str:
+        """Assemble the program whose exit status decides pass/fail."""
+        raise NotImplementedError
+
+    def interpret(self, result: Any, question: Dict) -> Tuple[bool, Dict[str, Any]]:
+        """Turn an ExecResult into (passed, detail-for-the-log)."""
+        return result.passed, {
+            "status": result.status,
+            "reason": result.summary(),
+            "duration": round(result.duration, 3),
+        }
 
     @abstractmethod
     def get_question(self, index: int) -> Dict:
@@ -186,6 +286,10 @@ class EvalState:
             self.dataset = Gsm8kDataset()
         elif self.dataset_type == "gpqa":
             self.dataset = GpqaDataset(variant="diamond", seed=seed)
+        elif self.dataset_type == "humaneval":
+            self.dataset = HumanEvalDataset(source=DATASET_SOURCE)
+        elif self.dataset_type == "classeval":
+            self.dataset = ClassEvalDataset(source=DATASET_SOURCE)
         else:
             raise ValueError(f"Unknown dataset type: {self.dataset_type}")
 
@@ -263,20 +367,42 @@ class EvalState:
 
             self.correct = sum(1 for c in self.task_states.get("cases", {}).values() if c.get("correct", False))
 
+    def _display_pair(self, task_state: TaskState) -> Tuple[str, str]:
+        """The (expected, answer) columns, kept narrow for code suites.
+
+        There the gold value is a whole JSON test harness and the answer is a
+        whole function, so show the task id and the failure cause instead.
+        """
+        if self.dataset_type not in CODE_SUITES:
+            return (
+                task_state.expected,
+                task_state.answer if task_state.answer else "N/A",
+            )
+        try:
+            expected = json.loads(task_state.expected)["task_id"]
+        except (ValueError, KeyError, TypeError):
+            expected = self.dataset_type
+        reason = (task_state.grader_log or {}).get("reason", "")
+        if task_state.correct:
+            reason = "ok"
+        return expected, (reason[:28] or "N/A")
+
     def print_progress(self, task_state: TaskState, total_tasks: int, n_correct: int = 0):
-        display_answer = task_state.answer if task_state.answer else "N/A"
+        display_expected, display_answer = self._display_pair(task_state)
         display_tokens = str(task_state.tokens) if task_state.tokens is not None else "N/A"
         display_tps = f"{task_state.tps_gen:.1f}" if task_state.tps_gen is not None else "N/A"
         display_t_gen = f"{task_state.t_gen_ms/1000:.1f}" if task_state.t_gen_ms is not None else "N/A"
         display_server = task_state.server_name if task_state.server_name else "N/A"
         success_ratio = n_correct / self.processed if self.processed > 0 else 0.0
-        first_line = task_state.question_text.split('\n')[0]
+        first_line = next(
+            (ln for ln in task_state.question_text.split('\n') if ln.strip()), ""
+        )
         truncated_question = first_line[:43]
         if len(first_line) > 43:
             truncated_question += "..."
         else:
             truncated_question = truncated_question.ljust(43) + "..."
-        print(f"{self.processed:3}/{total_tasks:3}  {task_state.task_id:<20} {self.dataset_type.upper()}   {truncated_question:<40}    {task_state.expected:<10} {display_answer:<10} {display_tokens:<6} {display_tps:<6} {display_t_gen:<8} {'✓' if task_state.correct else '✗'}  [{n_correct:3}/{self.processed:3}, {success_ratio:.3f}]  {display_server}")
+        print(f"{self.processed:3}/{total_tasks:3}  {task_state.task_id:<20} {self.dataset_type.upper()}   {truncated_question:<40}    {display_expected:<16} {display_answer:<28} {display_tokens:<6} {display_tps:<6} {display_t_gen:<8} {'✓' if task_state.correct else '✗'}  [{n_correct:3}/{self.processed:3}, {success_ratio:.3f}]  {display_server}")
 
     def print_summary(self):
         if self.total == 0:
@@ -974,6 +1100,480 @@ class GpqaDataset(BaseDataset):
             D=question["shuffled_answers"][3]
         )
 
+FENCE_RE = re.compile(r"```[ \t]*([A-Za-z0-9_+-]*)[ \t]*\n(.*?)(?:```|\Z)", re.DOTALL)
+
+RESULT_MARKER = "__LLAMA_EVAL__"
+
+# gensim publishes no wheel past cp313 and its Cython-generated C no longer
+# compiles (it still uses PyLongObject.ob_digit, removed in 3.12). ClassEval
+# touches exactly two gensim APIs, both pure Python upstream, so on 3.14+ they
+# are provided directly rather than losing the two tasks that need them.
+GENSIM_SHIM = {
+    "__init__.py": (
+        '"""Minimal stand-in for the two gensim entry points ClassEval uses."""\n'
+        "from . import utils, matutils  # noqa: F401\n"
+    ),
+    "utils.py": (
+        "import re, html\n"
+        "RE_ENTITY = re.compile(r'&(#?)([xX]?)(\\w{1,8});')\n"
+        "def decode_htmlentities(text):\n"
+        "    return RE_ENTITY.sub(lambda m: html.unescape(m.group(0)), text)\n"
+    ),
+    "matutils.py": (
+        "import numpy as np\n"
+        "def unitvec(vec, norm='l2', return_norm=False):\n"
+        "    v = np.asarray(vec, dtype=float)\n"
+        "    n = float(np.sum(np.abs(v))) if norm == 'l1' "
+        "else float(np.sqrt(np.sum(v ** 2)))\n"
+        "    if n == 0.0:\n"
+        "        return (v, 1.0) if return_norm else v\n"
+        "    out = v / n\n"
+        "    return (out, n) if return_norm else out\n"
+    ),
+}
+
+# Runs before the suite's test code. Some tasks end with the usual
+# `if __name__ == "__main__": unittest.main()`, and unittest.main() exits the
+# process -- which would kill the reporting harness appended after it.
+UNITTEST_PROLOGUE = '''
+import unittest as _ut_pre
+_ut_pre.main = lambda *a, **k: None
+'''
+
+# Appended to suites whose tasks are judged by many independent unit tests, so
+# a partially-correct answer can be scored as such instead of just pass/fail.
+# Discovers TestCase subclasses from the module namespace rather than trusting a
+# dataset field to name them.
+UNITTEST_RUNNER = f'''
+
+if True:
+    import json as _json, os as _os, unittest as _ut
+    _loader = _ut.TestLoader()
+    _suite = _ut.TestSuite()
+    for _c in [v for v in list(globals().values())
+               if isinstance(v, type) and issubclass(v, _ut.TestCase)
+               and v is not _ut.TestCase]:
+        _suite.addTests(_loader.loadTestsFromTestCase(_c))
+    with open(_os.devnull, "w") as _null:
+        _res = _ut.TextTestRunner(stream=_null, verbosity=0).run(_suite)
+    _bad = {{t.id() for t, _ in _res.failures}} | {{t.id() for t, _ in _res.errors}}
+    _total = _res.testsRun
+    print("{RESULT_MARKER}" + _json.dumps({{
+        "total": _total,
+        "passed": _total - len(_bad),
+        "failed": sorted(_bad),
+        "first_error": (_res.failures + _res.errors)[0][1].strip().splitlines()[-1]
+                       if (_res.failures or _res.errors) else None,
+    }}))
+'''
+
+
+def parse_test_report(stdout: str) -> Optional[Dict[str, Any]]:
+    """Read the JSON line emitted by UNITTEST_RUNNER, if the program got that far."""
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(RESULT_MARKER):
+            try:
+                return json.loads(line[len(RESULT_MARKER):])
+            except ValueError:
+                return None
+    return None
+
+
+def extract_code(response: str, entry_point: Optional[str] = None,
+                 class_name: Optional[str] = None) -> str:
+    """Pull the candidate program out of a chat reply.
+
+    Prefers a fenced block that actually defines the thing being asked for,
+    since models like to emit a usage example or a test in a second block.
+    """
+    if not response:
+        return ""
+
+    if class_name:
+        wanted = rf"^\s*class\s+{re.escape(class_name)}\s*[:\(]"
+    elif entry_point:
+        wanted = rf"^\s*(?:async\s+)?def\s+{re.escape(entry_point)}\s*\("
+    else:
+        wanted = None
+
+    blocks = [(lang.lower(), body) for lang, body in FENCE_RE.findall(response)]
+    if blocks:
+        py = [b for lang, b in blocks if lang in ("python", "py", "python3", "")]
+        candidates = py or [b for _, b in blocks]
+        if wanted:
+            defining = [b for b in candidates if re.search(wanted, b, re.M)]
+            if defining:
+                return defining[-1].strip("\n")
+        return candidates[0].strip("\n")
+
+    # No fence at all: some models just emit bare code.
+    return response.strip("\n")
+
+
+def _import_preamble(prompt: str) -> str:
+    """The import lines from the original stub.
+
+    A chat model often returns just the function and drops the imports that the
+    stub had above it; replaying them keeps that from being scored as a failure.
+    """
+    lines = []
+    for line in prompt.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("import ", "from ")) and not line.startswith((" ", "\t")):
+            lines.append(stripped)
+    return "\n".join(lines)
+
+
+def build_program(question: Dict, completion: str, seed: Optional[int] = 0) -> str:
+    """Assemble the full program that decides pass/fail for one problem."""
+    entry_point = question["entry_point"]
+    code = completion
+
+    # If the model returned only a body (no signature), graft it onto the stub.
+    if not re.search(rf"^\s*(?:async\s+)?def\s+{re.escape(entry_point)}\s*\(", code, re.M):
+        body = completion if completion.startswith((" ", "\t")) else \
+            "\n".join("    " + ln for ln in completion.splitlines())
+        code = question["prompt"] + "\n" + body
+
+    # HumanEval/38, /50 and /53 draw their test inputs from the *global* unseeded
+    # RNG. A correct solution always passes, but a subtly wrong one can flip
+    # between runs -- which makes A/B comparisons of two models noisy. Seeding
+    # here fixes the inputs without changing what the model is asked to compute.
+    prologue = f"import random; random.seed({seed})" if seed is not None else ""
+
+    return "\n\n".join(part for part in [
+        _import_preamble(question["prompt"]),
+        code,
+        question["test"],
+        prologue,
+        f"check({entry_point})",
+    ] if part)
+
+
+def pass_at_k(n: int, c: int, k: int) -> float:
+    """Unbiased pass@k estimator from the Codex paper (arXiv:2107.03374).
+
+    n samples drawn, c of them correct. Computed as 1 - C(n-c,k)/C(n,k) via a
+    product so it stays stable for large n.
+    """
+    if n - c < k:
+        return 1.0
+    prod = 1.0
+    for i in range(n - c + 1, n + 1):
+        prod *= 1.0 - k / i
+    return 1.0 - prod
+
+
+class HumanEvalDataset(BaseDataset):
+    """OpenAI HumanEval, 164 hand-written Python problems.
+
+    Every problem in this suite imports only from the standard library, so the
+    execution venv needs no pip installs at all -- see `required_packages`.
+    """
+
+    HF_REPO = "openai/openai_humaneval"
+
+    def __init__(self, source: Optional[str] = None, split: str = "test"):
+        self.source = source or self.HF_REPO
+        self.split = split
+        self.questions: List[Dict] = []
+        self._load_dataset()
+
+    def _load_dataset(self):
+        print(f"Loading HumanEval dataset (source: {self.source})...")
+
+        local = Path(self.source)
+        if local.exists():
+            rows = [json.loads(ln) for ln in local.read_text().splitlines() if ln.strip()]
+        else:
+            from datasets import load_dataset
+            rows = [dict(r) for r in load_dataset(self.source, split=self.split)]
+
+        required = {"task_id", "prompt", "entry_point", "test"}
+        for row in rows:
+            missing = required - row.keys()
+            if missing:
+                raise ValueError(
+                    f"{self.source}: record {row.get('task_id', '?')} is missing {sorted(missing)}"
+                )
+            row["dataset_type"] = "humaneval"
+            self.questions.append(row)
+
+        print(f"HumanEval dataset loaded: {len(self.questions)} problems")
+
+    def required_packages(self) -> List[str]:
+        """Third-party pip packages this suite needs. Derived, not hardcoded."""
+        return sorted(third_party_imports(
+            "\n".join(q["prompt"] + "\n" + q["test"] for q in self.questions)
+        ))
+
+    def extract(self, response: str, question: Dict) -> str:
+        return extract_code(response, question.get("entry_point"))
+
+    def build_program(self, question: Dict, completion: str,
+                      seed: Optional[int] = None) -> str:
+        return build_program(question, completion, seed=seed)
+
+    def get_question(self, index: int) -> Dict:
+        return self.questions[index]
+
+    def get_question_text(self, question: Dict) -> str:
+        return question["prompt"]
+
+    def get_answer(self, question: Dict) -> str:
+        # The "gold answer" for a code suite is the harness that judges it.
+        # Carried as JSON so it survives the state file and --resume.
+        return json.dumps({
+            "task_id": question["task_id"],
+            "entry_point": question["entry_point"],
+            "prompt": question["prompt"],
+            "test": question["test"],
+        })
+
+    def get_prompt(self, question: Dict) -> str:
+        return TEMPLATE_REGISTRY["humaneval"].format(
+            question=self.get_question_text(question).rstrip(),
+        )
+
+
+class ClassEvalDataset(BaseDataset):
+    """ClassEval: 100 class-level Python generation tasks.
+
+    A task is a whole class judged by several independent unittest classes, so
+    it is scored twice -- class level (every test passes) and method level
+    (what fraction of tests passed), matching the upstream protocol.
+    """
+
+    HF_REPO = "ilintar/ClassEval"
+
+    def __init__(self, source: Optional[str] = None):
+        self.source = source or self.HF_REPO
+        self.questions: List[Dict] = []
+        self._gensim_shim = False
+        self._load_dataset()
+
+    def _load_dataset(self):
+        print(f"Loading ClassEval dataset (source: {self.source})...")
+
+        local = Path(self.source)
+        if local.exists():
+            text = local.read_text()
+            rows = (json.loads(text) if local.suffix == ".json"
+                    else [json.loads(ln) for ln in text.splitlines() if ln.strip()])
+        else:
+            from datasets import load_dataset
+            rows = [dict(r) for r in load_dataset(self.source, split="test")]
+
+        required = {"task_id", "skeleton", "test", "class_name"}
+        for row in rows:
+            missing = required - row.keys()
+            if missing:
+                raise ValueError(
+                    f"{self.source}: record {row.get('task_id', '?')} is missing {sorted(missing)}"
+                )
+            row["dataset_type"] = "classeval"
+            # Denominator for the method-level score when the program dies
+            # before the runner can report (syntax error, bad import, timeout).
+            row["n_tests"] = _count_test_methods(row["test"])
+            self.questions.append(row)
+
+        print(f"ClassEval dataset loaded: {len(self.questions)} classes, "
+              f"{sum(q['n_tests'] for q in self.questions)} test methods")
+
+    # Dependencies that no import statement mentions, so scanning the source
+    # cannot find them. They must be declared or the suite silently loses tests.
+    EXTRA_PACKAGES = [
+        # ClassEval_44 selects the parser by *string*: BeautifulSoup(html,
+        # 'lxml'). Without it bs4 raises FeatureNotFound and that task drops
+        # from 23/23 to 7/23. It happens to arrive via python-docx today, but
+        # relying on someone else's transitive dependency is not a plan.
+        "lxml",
+        # Hard requirement of gensim, listed explicitly for the same reason.
+        "scipy",
+    ]
+
+    def configure_python(self, python: str):
+        """gensim stops at cp313, so on 3.14+ swap it for a small local shim."""
+        try:
+            r = subprocess.run(
+                [python, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+                capture_output=True, text=True, timeout=60,
+            )
+            major, minor = (int(x) for x in r.stdout.strip().split("."))
+        except Exception:
+            return
+        self._gensim_shim = (major, minor) >= (3, 14)
+
+    def required_packages(self) -> List[str]:
+        blob = "\n\n".join(
+            "\n\n".join(_as_text(q.get(f)) for f in
+                        ("skeleton", "test", "solution_code", "import_statement"))
+            for q in self.questions
+        )
+        found = {PIP_NAMES.get(m, m) for m in third_party_imports(blob)}
+        found |= set(self.EXTRA_PACKAGES)
+        if self._gensim_shim:
+            found.discard("gensim")
+        return sorted(found)
+
+    # Exactly what the suite's nltk tasks need, ~33 MB. These are the current
+    # names: the dataset asks for 'punkt' and 'averaged_perceptron_tagger',
+    # which nltk has since renamed. Seeding the legacy names as well is not
+    # harmless -- with a network available nltk treats them as satisfied and
+    # then re-fetches the modern ones anyway, tripling the download.
+    NLTK_CORPORA = ("punkt_tab", "averaged_perceptron_tagger_eng", "wordnet")
+
+    def provision_steps(self) -> List[str]:
+        steps = []
+
+        if any("nltk" in _as_text(q.get("skeleton")) + _as_text(q.get("test"))
+               for q in self.questions):
+            # Pre-seed the corpora so test time never needs the network.
+            steps.append(
+                "import os, nltk\n"
+                "target = os.path.join(os.environ['SANDBOX_VENV'], 'nltk_data')\n"
+                "os.makedirs(target, exist_ok=True)\n"
+                f"for corpus in {self.NLTK_CORPORA!r}:\n"
+                "    nltk.download(corpus, download_dir=target, quiet=True)\n"
+            )
+
+        if self._gensim_shim:
+            steps.append(
+                "import os, sysconfig\n"
+                "pkg = os.path.join(sysconfig.get_paths()['purelib'], 'gensim')\n"
+                "os.makedirs(pkg, exist_ok=True)\n"
+                f"files = {GENSIM_SHIM!r}\n"
+                "for name, body in files.items():\n"
+                "    open(os.path.join(pkg, name), 'w').write(body)\n"
+                "import gensim.utils, gensim.matutils\n"  # fail loudly if broken
+            )
+
+        return steps
+
+    def sandbox_env(self) -> Dict[str, str]:
+        # $HOME is a tmpfs under the strongest isolation tier, so the corpora
+        # have to be found inside the venv, which stays mounted.
+        return {"NLTK_DATA": "{venv}/nltk_data"}
+
+    def preferred_python(self) -> Optional[str]:
+        # gensim has no wheel for 3.14 and its generated C no longer compiles
+        # there (it still uses PyLongObject.ob_digit). 3.13 is the newest
+        # interpreter that takes the whole dependency set.
+        return "3.13"
+
+    def default_exec_timeout(self) -> float:
+        # These tasks do real work -- the slowest reference solution takes ~6 s
+        # (a BFS puzzle solver), and importing pandas or loading an nltk corpus
+        # costs seconds on its own.
+        return 30.0
+
+    def extract(self, response: str, question: Dict) -> str:
+        return extract_code(response, class_name=question.get("class_name"))
+
+    def build_program(self, question: Dict, completion: str,
+                      seed: Optional[int] = None) -> str:
+        prologue = f"import random; random.seed({seed})" if seed is not None else ""
+        return "\n\n".join(part for part in [
+            _as_text(question.get("import_statement")),
+            UNITTEST_PROLOGUE,
+            completion,
+            question["test"],
+            prologue,
+            UNITTEST_RUNNER,
+        ] if part)
+
+    def interpret(self, result: Any, question: Dict) -> Tuple[bool, Dict[str, Any]]:
+        # The denominator is what the task *should* run, taken from the dataset.
+        # Using the observed count would let a class that fails to even import
+        # score 0/0 and quietly shrink the total, inflating the method rate.
+        expected = question.get("n_tests", 0)
+
+        report = parse_test_report(result.stdout)
+        if report is None:
+            # never reached the runner -- syntax error, bad import or timeout
+            return False, {
+                "status": result.status if result.status != "ok" else "no-report",
+                "reason": result.summary(),
+                "tests_total": expected,
+                "tests_passed": 0,
+                "duration": round(result.duration, 3),
+            }
+
+        total, passed = report.get("total", 0) or expected, report.get("passed", 0)
+        ok = total > 0 and passed == total
+        return ok, {
+            "status": "ok" if ok else "failed",
+            "reason": "ok" if ok else (report.get("first_error")
+                                       or f"{passed}/{total} tests passed")[:200],
+            "tests_total": total,
+            "tests_passed": passed,
+            "duration": round(result.duration, 3),
+        }
+
+    def get_question(self, index: int) -> Dict:
+        return self.questions[index]
+
+    def get_question_text(self, question: Dict) -> str:
+        return question["skeleton"]
+
+    def get_answer(self, question: Dict) -> str:
+        return json.dumps({
+            "task_id": question["task_id"],
+            "class_name": question["class_name"],
+            "import_statement": _as_text(question.get("import_statement")),
+            "test": question["test"],
+            "n_tests": question["n_tests"],
+        })
+
+    def get_prompt(self, question: Dict) -> str:
+        return TEMPLATE_REGISTRY["classeval"].format(
+            question=self.get_question_text(question).rstrip(),
+        )
+
+
+def _as_text(value: Any) -> str:
+    """Some dataset fields arrive as a list of lines rather than a blob."""
+    if not value:
+        return ""
+    if isinstance(value, (list, tuple)):
+        return "\n".join(str(v) for v in value)
+    return str(value)
+
+
+def _count_test_methods(test_code: str) -> int:
+    """How many `def test_*` a task's test suite defines."""
+    try:
+        tree = ast.parse(test_code)
+    except SyntaxError:
+        return len(re.findall(r"^\s*def\s+test\w*\s*\(", test_code, re.M))
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test")
+    )
+
+
+def third_party_imports(source: str) -> set:
+    """Top-level modules imported by `source` that are not in the stdlib."""
+    import ast
+
+    mods = set()
+    for chunk in source.split("\n\n"):
+        try:
+            tree = ast.parse(chunk)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                mods.update(a.name.split(".")[0] for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                mods.add(node.module.split(".")[0])
+
+    stdlib = set(sys.stdlib_module_names)
+    return {m for m in mods if m and m not in stdlib}
+
+
 class Grader:
     def __init__(
         self,
@@ -981,14 +1581,28 @@ class Grader:
         grader_script: Optional[str] = None,
         grader_model_name: Optional[str] = None,
         grader_server_url: str = "",
-        dataset_type: str = "aime"
+        dataset_type: str = "aime",
+        sandbox: Optional[Sandbox] = None,
+        exec_timeout: float = 15.0,
+        exec_seed: Optional[int] = 0,
+        dataset: Optional[BaseDataset] = None,
     ):
         self.grader_type = grader_type
         self.grader_script = grader_script
         self.grader_model_name = grader_model_name
         self.grader_server_url = grader_server_url
         self.dataset_type = dataset_type
+        self.sandbox = sandbox
+        self.exec_timeout = exec_timeout
+        self.exec_seed = exec_seed
+        self.dataset = dataset
         self.pattern = self._get_pattern()
+        # grading runs on the worker pool, so per-run exec detail is per-thread
+        self._local = threading.local()
+
+    @property
+    def last_exec(self) -> Dict[str, Any]:
+        return getattr(self._local, "exec_info", {})
 
     def _get_pattern(self) -> Optional[str]:
         if self.grader_type == "regex":
@@ -1102,6 +1716,28 @@ Please provide only the extracted answer, nothing else. If there is no clear ans
         lines = response.split('\n')
         return '\n'.join(lines[-max_lines:]) if len(lines) > max_lines else response
 
+    def _grade_exec(self, gold: str, pred: str) -> Tuple[bool, Optional[str]]:
+        """Grade by running the generated code against the suite's own tests.
+
+        `gold` is the JSON harness produced by the dataset's get_answer(); the
+        dataset owns how the program is assembled and how its result is read.
+        """
+        if self.sandbox is None or self.dataset is None:
+            raise ValueError("exec grader requires a sandbox and a dataset")
+
+        question = json.loads(gold)
+        completion = self.dataset.extract(pred, question)
+        if not completion.strip():
+            self._local.exec_info = {"status": "empty", "reason": "no code in reply"}
+            return False, None
+
+        program = self.dataset.build_program(question, completion, seed=self.exec_seed)
+        result = self.sandbox.run(program, timeout=self.exec_timeout)
+        passed, detail = self.dataset.interpret(result, question)
+
+        self._local.exec_info = detail
+        return passed, completion
+
     def grade(self, gold: str, pred: str, problem: str = "") -> Tuple[bool, Optional[str]]:
         """Grade the response"""
         if self.grader_type == "regex":
@@ -1110,6 +1746,8 @@ Please provide only the extracted answer, nothing else. If there is no clear ans
             return self._grade_cli(gold, pred)
         elif self.grader_type == "llm":
             return self._grade_llm(gold, pred, problem)
+        elif self.grader_type == "exec":
+            return self._grade_exec(gold, pred)
         else:
             raise ValueError(f"Unknown grader type: {self.grader_type}")
 
@@ -1208,15 +1846,22 @@ class Processor:
                 eval_state.dump()
                 return task_state
 
-            result_truncated = self.grader._truncate_response(result, max_lines=10)
-            is_correct, answer = self.grader.grade(expected, result_truncated, prompt)
+            # Text graders only ever look at the tail of a reply, but the exec
+            # grader needs the whole thing -- the code block is not at the end.
+            if self.grader.grader_type == "exec":
+                graded_text = result
+            else:
+                graded_text = self.grader._truncate_response(result, max_lines=10)
+            is_correct, answer = self.grader.grade(expected, graded_text, prompt)
 
             grader_log = {
-                "pred": result_truncated,
+                "pred": graded_text,
                 "grader_type": self.grader.grader_type
             }
             if self.grader.grader_type == "regex" and self.grader.pattern:
                 grader_log["pattern"] = self.grader.pattern
+            if self.grader.grader_type == "exec":
+                grader_log.update(self.grader.last_exec)
 
             task_state.correct = is_correct
             task_state.answer = answer
@@ -1342,6 +1987,85 @@ class Processor:
         eval_state.print_summary()
         eval_state.dump()
 
+def preflight_sandbox(sandbox: Sandbox):
+    """Catch host policies that would fail problems for non-model reasons.
+
+    A FIPS-enforcing OpenSSL makes hashlib.md5() raise, which would sink
+    HumanEval/162 no matter what the model generated.
+    """
+    probe = sandbox.run("import hashlib; hashlib.md5(b'x').hexdigest()", timeout=15)
+    if not probe.passed:
+        print(f"Warning: md5 is unavailable in the execution venv "
+              f"({probe.summary(120)}). Problems that hash with md5 will fail "
+              f"regardless of the model -- this is a host policy, not a model result.")
+
+
+def print_pass_at_k(eval_state: "EvalState"):
+    """Report pass@k plus a breakdown of how the failures failed.
+
+    Each chunk is one full pass over the suite, so running --n_cases at a
+    multiple of the dataset size gives n samples per problem for free.
+    """
+    cases = eval_state.task_states.get("cases", {})
+    if not cases:
+        return
+
+    by_problem: Dict[int, List[bool]] = {}
+    reasons: Dict[str, int] = {}
+    for case in cases.values():
+        by_problem.setdefault(case.get("problem_idx", 0), []).append(
+            bool(case.get("correct", False))
+        )
+        if not case.get("correct", False):
+            status = (case.get("grader_log") or {}).get("status", case.get("status", "?"))
+            reasons[status] = reasons.get(status, 0) + 1
+
+    n = min(len(v) for v in by_problem.values())
+    n_problems = len(by_problem)
+
+    print(f"\n{'=' * 60}")
+    print(f"  {eval_state.dataset_type}: {n_problems} problems, {n} sample(s) each")
+    print(f"{'=' * 60}")
+
+    for k in sorted({1, 5, 10, 100, n}):
+        if k > n:
+            continue
+        score = sum(
+            pass_at_k(len(v), sum(v), k) for v in by_problem.values()
+        ) / n_problems
+        print(f"  pass@{k:<4d} {score:.4f}")
+
+    if n == 1:
+        solved = sum(1 for v in by_problem.values() if v[0])
+        lo, hi = wilson_interval(solved, n_problems)
+        print(f"  {solved}/{n_problems} solved   95% CI [{lo:.4f}, {hi:.4f}]")
+
+    # Suites judged by many unit tests per task also get a partial-credit score,
+    # which separates "generated nothing usable" from "got most of it right".
+    # A case that never reached the grader (truncated generation, HTTP error)
+    # still owes its tests to the denominator, so fall back to the count the
+    # dataset recorded in the gold blob -- otherwise those tests silently
+    # disappear and the rate is computed against a smaller total.
+    t_total = t_passed = 0
+    for case in cases.values():
+        log = case.get("grader_log") or {}
+        if "tests_total" in log:
+            t_total += log["tests_total"]
+        else:
+            try:
+                t_total += json.loads(case.get("expected") or "{}").get("n_tests", 0)
+            except ValueError:
+                pass
+        t_passed += log.get("tests_passed", 0)
+    if t_total:
+        print(f"\n  test methods passed  {t_passed}/{t_total}  ({t_passed / t_total:.4f})")
+
+    if reasons:
+        print("\n  failures by cause:")
+        for status, count in sorted(reasons.items(), key=lambda kv: -kv[1]):
+            print(f"    {status:<12s} {count}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Simplified evaluation tool for llama.cpp"
@@ -1362,8 +2086,15 @@ def main():
         "--dataset",
         type=str,
         default="aime",
-        choices=["aime", "aime2025", "aime2026", "gsm8k", "gpqa"],
+        choices=["aime", "aime2025", "aime2026", "gsm8k", "gpqa", "humaneval", "classeval"],
         help="Dataset type (default: aime)"
+    )
+    parser.add_argument(
+        "--dataset-source",
+        type=str,
+        default=None,
+        help="Override the dataset location: a local .jsonl path or a HuggingFace "
+             "repo id (e.g. a patched HumanEval). Default: the suite's canonical repo"
     )
     parser.add_argument(
         "--n_cases",
@@ -1433,9 +2164,37 @@ def main():
     parser.add_argument(
         "--grader-type",
         type=str,
-        default="llm",
-        choices=["regex", "cli", "llm"],
-        help="Grader type: regex, cli, or llm (default: llm)"
+        default=None,
+        choices=["regex", "cli", "llm", "exec"],
+        help="Grader type: regex, cli, llm, or exec (default: exec for code suites, "
+             "llm otherwise). 'exec' runs the generated code against the suite tests "
+             "in a sandboxed venv"
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        type=float,
+        default=None,
+        help="Per-problem wall-clock limit for the exec grader, in seconds "
+             "(default: per-suite, 15s for humaneval, 30s for classeval)"
+    )
+    parser.add_argument(
+        "--exec-seed",
+        type=int,
+        default=0,
+        help="Seed the global RNG before running each test, so suites whose tests "
+             "draw random inputs score reproducibly (default: 0). Use -1 to leave "
+             "the RNG unseeded, matching the stock upstream harness"
+    )
+    parser.add_argument(
+        "--sandbox-python",
+        type=str,
+        default=None,
+        help="Base interpreter used to build the execution venv (default: this one)"
+    )
+    parser.add_argument(
+        "--rebuild-sandbox",
+        action="store_true",
+        help="Discard and re-provision the cached execution venv"
     )
     parser.add_argument(
         "--grader-script",
@@ -1462,6 +2221,18 @@ def main():
     )
 
     args = parser.parse_args()
+
+    global DATASET_SOURCE
+    DATASET_SOURCE = args.dataset_source
+
+    # Code suites are graded by execution; everything else keeps the llm default.
+    if args.grader_type is None:
+        args.grader_type = "exec" if args.dataset in CODE_SUITES else "llm"
+
+    if args.grader_type == "exec" and args.dataset not in CODE_SUITES:
+        print(f"Error: --grader-type exec is only meaningful for code suites "
+              f"({', '.join(sorted(CODE_SUITES))}), not '{args.dataset}'")
+        sys.exit(1)
 
     # Parse server URLs and thread counts
     server_urls = [u.strip() for u in args.server.split(",") if u.strip()]
@@ -1577,6 +2348,36 @@ def main():
 
         eval_state.print_all_tasks()
 
+    # The execution venv is derived from the dataset, so it is built only once
+    # the dataset is known -- true on both the fresh and the resume path.
+    if args.grader_type == "exec":
+        dataset = eval_state.dataset
+
+        base_python = args.sandbox_python
+        if not base_python and dataset.preferred_python():
+            want = dataset.preferred_python()
+            base_python = resolve_python(want)
+            if base_python:
+                print(f"[sandbox] using Python {want} for {eval_state.dataset_type} "
+                      f"({base_python})")
+
+        dataset.configure_python(base_python or sys.executable)
+
+        sandbox = Sandbox(
+            name=eval_state.dataset_type,
+            packages=dataset.required_packages(),
+            provision=dataset.provision_steps(),
+            env=dataset.sandbox_env(),
+            base_python=base_python,
+        )
+        sandbox.ensure(force=args.rebuild_sandbox)
+        preflight_sandbox(sandbox)
+        grader.sandbox = sandbox
+        grader.dataset = dataset
+        grader.exec_timeout = (args.exec_timeout if args.exec_timeout is not None
+                               else dataset.default_exec_timeout())
+        grader.exec_seed = None if args.exec_seed < 0 else args.exec_seed
+
     processor = Processor(
         server_configs=server_configs,
         grader=grader,
@@ -1585,6 +2386,10 @@ def main():
     )
 
     processor.evaluate(eval_state, verbose=args.verbose, resume=resume)
+
+    if args.grader_type == "exec":
+        print_pass_at_k(eval_state)
+
     print(f"\nEval state dumped to {args.output}")
 
 if __name__ == "__main__":

--- a/examples/llama-eval/llama-server-simulator.py
+++ b/examples/llama-eval/llama-server-simulator.py
@@ -13,7 +13,8 @@ from typing import Dict, List, Optional
 from dataclasses import dataclass
 from pathlib import Path
 
-import datasets
+# `datasets` is imported lazily by the loaders that need it, so a suite backed
+# by a local .jsonl works without the HuggingFace stack installed.
 
 # Set cache directory for HuggingFace datasets
 cache_dir = Path.home() / ".cache" / "huggingface" / "datasets"
@@ -76,6 +77,8 @@ class AimeDataset:
         return question.get("problem", question.get("question", ""))
 
     def _load_dataset(self):
+        import datasets
+
         if self.dataset_type == "aime":
             print(f"Loading AIME dataset (split: {self.split})...")
             cache_path = Path.home() / ".cache" / "huggingface" / "datasets" / "AI-MO___aimo-validation-aime" / "default" / "0.0.0"
@@ -164,6 +167,60 @@ class AimeDataset:
             return str(normalized) if normalized is not None else answer
         return str(answer)
 
+class CodeDataset:
+    """Stand-in for a code model: replays canonical solutions as chat replies.
+
+    Handles both code suites: HumanEval keys off the function stub, ClassEval
+    off the class skeleton.
+    """
+
+    DEFAULT_SOURCE = {
+        "humaneval": "openai/openai_humaneval",
+        "classeval": "FudanSELab/ClassEval",
+    }
+
+    def __init__(self, dataset_type: str, source: Optional[str] = None):
+        self.dataset_type = dataset_type
+        self.source = source or self.DEFAULT_SOURCE[dataset_type]
+        self.questions: List[Dict] = []
+        self._load_dataset()
+
+    def _load_dataset(self):
+        print(f"Loading {self.dataset_type} dataset (source: {self.source})...")
+        local = Path(self.source)
+        if local.exists():
+            text = local.read_text()
+            if local.suffix == ".json":
+                rows = json.loads(text)
+            else:
+                rows = [json.loads(ln) for ln in text.splitlines() if ln.strip()]
+        else:
+            import datasets
+            rows = [dict(r) for r in datasets.load_dataset(self.source, split="test")]
+        self.questions = rows
+        print(f"{self.dataset_type} dataset loaded: {len(self.questions)} questions")
+
+    def _stub_field(self) -> str:
+        return "skeleton" if self.dataset_type == "classeval" else "prompt"
+
+    def _get_question_text(self, question: Dict) -> str:
+        return question[self._stub_field()]
+
+    def find_question(self, request_text: str) -> Optional[Dict]:
+        # The prompt template embeds the stub verbatim, so an exact containment
+        # test is enough and avoids fuzzy mismatches.
+        for question in self.questions:
+            stub = question[self._stub_field()].rstrip()
+            if stub and stub in request_text:
+                return question
+        return None
+
+    def get_answer(self, question: Dict) -> str:
+        if self.dataset_type == "classeval":
+            return question["solution_code"]
+        return question["prompt"] + question["canonical_solution"]
+
+
 class Simulator:
     def __init__(
         self,
@@ -171,12 +228,17 @@ class Simulator:
         host: str = "localhost",
         success_rate: float = 0.8,
         dataset_split: str = "train",
-        dataset_type: str = "aime"
+        dataset_type: str = "aime",
+        dataset_source: Optional[str] = None
     ):
         self.port = port
         self.host = host
         self.success_rate = success_rate
-        self.dataset = AimeDataset(dataset_split, dataset_type)
+        self.dataset_type = dataset_type
+        if dataset_type in ("humaneval", "classeval"):
+            self.dataset = CodeDataset(dataset_type, dataset_source)
+        else:
+            self.dataset = AimeDataset(dataset_split, dataset_type)
         self.eval_state = EvalState(
             id=dataset_type,
             tasks=[dataset_type],
@@ -195,6 +257,13 @@ class Simulator:
             response_text = expected_answer
         else:
             response_text = self._generate_wrong_answer(question)
+
+        if self.dataset_type in ("humaneval", "classeval"):
+            # dress it up the way a chat model would actually answer
+            response_text = (
+                f"Here is the implementation:\n\n```python\n{response_text}\n```\n\n"
+                "Let me know if you want it optimised further."
+            )
 
         comp_tokens = random.randint(10000, 60000)
         tps_gen = random.uniform(90.0, 110.0)
@@ -228,6 +297,14 @@ class Simulator:
 
     def _generate_wrong_answer(self, question: Dict) -> str:
         expected_answer = self.dataset.get_answer(question)
+
+        if self.dataset_type == "classeval":
+            # keep the class, gut the methods -- a plausible wrong answer
+            return re.sub(r"(\n\s+def [^\n]+:\n)", r"\1        return None\n",
+                          question["skeleton"])
+        if self.dataset_type == "humaneval":
+            # keep the signature, replace the body -- a plausible wrong answer
+            return question["prompt"] + "    return None\n"
 
         if expected_answer.isdigit():
             wrong_answer = str(int(expected_answer) + 1)
@@ -335,7 +412,7 @@ def main():
         "--dataset",
         type=str,
         default="aime",
-        choices=["aime", "aime2025"],
+        choices=["aime", "aime2025", "humaneval", "classeval"],
         help="Dataset type (default: aime)"
     )
     parser.add_argument(
@@ -343,6 +420,12 @@ def main():
         type=str,
         default="train",
         help="AIME dataset split to use (default: train)"
+    )
+    parser.add_argument(
+        "--dataset-source",
+        type=str,
+        default=None,
+        help="Override the dataset location (local .jsonl path or HuggingFace repo id)"
     )
 
     args = parser.parse_args()
@@ -353,7 +436,8 @@ def main():
         host=args.host,
         success_rate=args.success_rate,
         dataset_split=args.dataset_split,
-        dataset_type=args.dataset
+        dataset_type=args.dataset,
+        dataset_source=args.dataset_source
     )
 
     server = HTTPServer((args.host, args.port), RequestHandler)


### PR DESCRIPTION
## Overview

This PR adds three code-oriented evals to llama-eval:
* ClassEval and HumanEval - classic one-shot coding evals. Pretty saturated by now, but still good at gauging raw coding ability. Executed in a Python sandboxed venv.
* SACB (Simple Agentic Coding Benchmark) - a synthetic (Opus 5) generated benchmark that measures real agentic capability in a multi-turn session, with sandboxes for Python/TypeScript and a few simple tools. Tuned to be hard for mid-sized models: Qwen3.5-4B gets 16%, Ornith 35B IQ4XS gets 41.6%, Laguna S.1 Q5_K_S gets 46.6%, Qwen3.6 27B Q8 gets 55% and Hy3 Q2_K_XL gets 61.6%.

## Additional information

The new benchmark (and the ClassEval / HumanEval fixed so that they all run on new Python distributions) are available on my HuggingFace.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, used Opus 5 to generate the synthetic benchmark.