### PR TITLE
mtp nextn offload

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -136,7 +136,7 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data_impl(
         devs.push_back(llama_model_get_device(model, i));
     }
 
-    hp_ngl         = llama_model_n_layer(model);
+    hp_ngl         = llama_model_n_layer(model) + llama_model_n_layer_nextn(model);
     hp_n_ctx_train = llama_model_n_ctx_train(model);
     hp_n_expert    = llama_model_n_expert(model);
 


### PR DESCRIPTION
## Overview

1-line warning fix and ~10% tg performance improvement for MTP using `--fit` (tested on Qwen 3.6 35B A3B). 

## Additional information

People in https://github.com/ggml-org/llama.cpp/issues/24712  already tested this fix and told me to create a PR.

On MTP GGUFs, `--fit` doesn't count the nextn blocks, so it offloads one layer too few and leaves layer 0 on CPU, which disables the fused Gated Delta Net kernel and the scheduler prints:

```
sched_reserve: layer 0 is assigned to device CPU but the fused Gated Delta Net tensor is assigned to device CUDA0 (usually due to missing support)
sched_reserve: fused Gated Delta Net (chunked) not supported, set to disabled
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I used it to solve the warning for me.
