### PR TITLE
llama : bump LLAMA_MAX_EXPERTS to 1024 for Kimi-K3 (896 experts)

### DIFF
--- a/src/llama-hparams.h
+++ b/src/llama-hparams.h
@@ -7,7 +7,7 @@
 
 // bump if necessary
 #define LLAMA_MAX_LAYERS  512
-#define LLAMA_MAX_EXPERTS 512 // Qwen3 Next
+#define LLAMA_MAX_EXPERTS 1024 // Kimi-K3
 
 enum llama_expert_gating_func_type {
     LLAMA_EXPERT_GATING_FUNC_TYPE_NONE           = 0,


### PR DESCRIPTION
﻿`LLAMA_MAX_EXPERTS` has been 512 since Qwen3 Next. Kimi-K3 has **896** routed experts, so it trips the arch-generic assert in `llama_model_base::load_hparams` before any arch hook runs:

```
src/llama-hparams.h:10   #define LLAMA_MAX_EXPERTS 512 // Qwen3 Next
src/llama-model.cpp:1115 GGML_ASSERT(hparams.n_expert <= LLAMA_MAX_EXPERTS);
```

`moonshotai/Kimi-K3` reports `num_experts = 896` in `text_config`, and `convert_hf_to_gguf.py` on #26185 emits `gguf: expert count = 896`. This cannot be worked around on the file side: understating `expert_count` contradicts `ne[2] = 896` on the `ffn_*_exps` tensors.

`LLAMA_MAX_EXPERTS` sizes exactly one object in the tree:

```
src/llama-graph.cpp:2128  ggml_tensor * cur_experts[LLAMA_MAX_EXPERTS] = { nullptr };
```

Only `[0, n_expert_used)` of it is ever written or read, so raising the bound to 1024 costs 4 KB of stack in `build_moe_ffn` and changes no behaviour for existing models.

This unblocks #26185 (`model: add Kimi-K3 text model`), which is otherwise complete on the conversion side — I verified its `repack_mxfp4_blocks` is bit-exact against an independent implementation (0 mismatches over 11,010,048 values on a real K3 expert tensor) and that the converter reaches `prepare_tensors()` with a fully mapped tensor set for all 93 layers. Details in https://github.com/ggml-org/llama.cpp/pull/26185#issuecomment-5095928939

Not verified: I have not built or run inference with a Kimi-K3 GGUF, so this change is argued from the assert and the single array it bounds, not from a successful load.

AI usage disclosure: yes. The line references were read from master with an AI agent; the reasoning and the one-line change are as described above.
