### PR TITLE
convert : fetch tokenizer vocab and remote code with --remote

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -184,7 +184,7 @@ def main() -> None:
     if args.remote:
         hf_repo_id = args.model
         from huggingface_hub import snapshot_download
-        allowed_patterns = ["LICENSE", "*.json", "*.md", "*.txt", "tokenizer.model"]
+        # "*.model" covers tokenizer.model and tiktoken.model; "*.py" is needed\n        # because several converters call AutoTokenizer with trust_remote_code=True,\n        # which resolves tokenizer code from the model directory.\n        allowed_patterns = ["LICENSE", "*.json", "*.md", "*.txt", "*.model", "*.py"]
         if args.sentence_transformers_dense_modules:
             # include sentence-transformers dense modules safetensors files
             allowed_patterns.append("*.safetensors")

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -184,7 +184,10 @@ def main() -> None:
     if args.remote:
         hf_repo_id = args.model
         from huggingface_hub import snapshot_download
-        # "*.model" covers tokenizer.model and tiktoken.model; "*.py" is needed\n        # because several converters call AutoTokenizer with trust_remote_code=True,\n        # which resolves tokenizer code from the model directory.\n        allowed_patterns = ["LICENSE", "*.json", "*.md", "*.txt", "*.model", "*.py"]
+        # "*.model" covers tokenizer.model and tiktoken.model; "*.py" is needed
+        # because several converters call AutoTokenizer with trust_remote_code=True,
+        # which resolves tokenizer code from the model directory.
+        allowed_patterns = ["LICENSE", "*.json", "*.md", "*.txt", "*.model", "*.py"]
         if args.sentence_transformers_dense_modules:
             # include sentence-transformers dense modules safetensors files
             allowed_patterns.append("*.safetensors")


### PR DESCRIPTION
﻿`--remote` currently downloads `["LICENSE", "*.json", "*.md", "*.txt", "tokenizer.model"]`. Two kinds of tokenizer files are not covered, so `set_vocab()` fails for models that need them even though the same model converts fine from a full local snapshot:

- **`tiktoken.model`** — where Kimi K2 / K2.5 / K3 keep their vocabulary. Not matched by `tokenizer.model`.
- **`*.py`** — several converters call `AutoTokenizer.from_pretrained(self.dir_model, trust_remote_code=True)`, which resolves the tokenizer class from the model directory. For Kimi that is `tokenization_kimi.py`, which in turn relative-imports `encoding_k3.py`.

Concretely, on `moonshotai/Kimi-K3` via `kimi_linear.py`:

```
OSError: ... does not appear to have a file named tokenization_kimi.py
```

`deepseek.py` reaches the same call for Kimi-K2/K2.5, so this is not specific to one architecture.

Measured on `moonshotai/Kimi-K3` with `snapshot_download`:

| | files | size | `tiktoken.model` | `tokenization_kimi.py` | `encoding_k3.py` |
|---|---|---|---|---|---|
| before | 15 | 57.05 MiB | missing | missing | missing |
| after | 33 | 59.89 MiB | ok | ok | ok |

`+2.84 MiB`. Most of the 57 MiB in both cases is `model.safetensors.index.json`, already pulled by `*.json`.

`*.model` subsumes the existing `tokenizer.model` entry, so that one is dropped rather than kept alongside.

On `*.py`: this only makes `--remote` match what already happens for a local directory. The converters that need these files already run them via `trust_remote_code=True`; today the download simply omits them and the conversion aborts. If pulling model code unconditionally is not wanted, the alternative is to pass the already-available `self.remote_hf_model_id` to `AutoTokenizer.from_pretrained` so transformers resolves the code from the Hub, but that touches every converter that makes the call rather than one line here.

Not verified: I have not run a full `--remote` conversion to completion on a model that needs this — the download side is what I measured. Found while testing #26185 (`model: add Kimi-K3 text model`), where `--remote` stops in `set_vocab` for this reason; details in https://github.com/ggml-org/llama.cpp/pull/26185#issuecomment-5095928939

AI usage disclosure: yes. The before/after file listing above is output from a command I ran; the change is the one line shown in the diff.
