### PR TITLE
server: fix prompt cache entry selection and f_keep filter

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1738,7 +1738,28 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
     return &states.back();
 }
 
+// how many tokens of a cached prompt could actually be reused if we restored it.
+// without a rollback-capable memory module (hybrid/recurrent), the restored state
+// is usable only up to its newest context checkpoint at or below the divergence
+// point - that checkpoint is what the caller falls back to instead of
+// reprocessing the prompt from scratch
+static int64_t server_prompt_cache_n_reusable(const server_prompt_cache_state & state, int lcp) {
+    int64_t res = 0;
+
+    for (const auto & ckpt : state.prompt.checkpoints) {
+        if (ckpt.n_tokens <= lcp) {
+            res = std::max(res, ckpt.n_tokens);
+        }
+    }
+
+    return res;
+}
+
 bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_tgt, llama_context * ctx_dft, int32_t id_slot) {
+    // minimum salvage before we accept consuming a cached entry despite a low
+    // f_keep - restoring costs a state copy, so a tiny salvage is not worth it
+    constexpr int64_t n_reuse_min = 4096;
+
     const int lcp_best = prompt.tokens.get_common_prefix(tokens_new);
 
     float f_keep_best = prompt.tokens.size() > 0 ? float(lcp_best) / prompt.tokens.size() : -1.0f; // empty slot: any cache entry wins
@@ -1757,12 +1778,26 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
 
         SRV_TRC("   - prompt with length %7zu, lcp = %7d, f_keep = %.3f, sim = %.3f\n", it->prompt.tokens.size(), lcp_cur, f_keep_cur, sim_cur);
 
-        // don't trash large prompts
-        if (f_keep_cur < 0.25f) {
+        // don't consume a large cached prompt for a marginal salvage: restoring an
+        // entry removes it from the cache (states.erase() below).
+        //
+        // an entry that still carries a context checkpoint at or below the
+        // divergence point is worth taking even at a low f_keep - for
+        // hybrid/recurrent memory that checkpoint is the difference between
+        // resuming from the prefix and reprocessing the whole prompt
+        // ref: https://github.com/ggml-org/llama.cpp/issues/22746
+        if (f_keep_cur < 0.25f &&
+                server_prompt_cache_n_reusable(*it, lcp_cur) < n_reuse_min) {
             continue;
         }
 
-        if (f_keep_best < f_keep_cur && sim_best < sim_cur) {
+        // prefer whichever entry covers most of the new prompt, i.e. saves the
+        // most work. the slot's own prompt was already stored by prompt_save()
+        // before we got here, so picking a candidate can never lose it -
+        // requiring the candidate to also beat the slot's f_keep would reject
+        // useful entries whenever the slot happens to hold a small unrelated
+        // prompt, whose f_keep is then trivially high
+        if (sim_best < sim_cur) {
             f_keep_best = f_keep_cur;
             sim_best    = sim_cur;
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1738,12 +1738,24 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
     return &states.back();
 }
 
-// how many tokens of a cached prompt could actually be reused if we restored it.
-// without a rollback-capable memory module (hybrid/recurrent), the restored state
-// is usable only up to its newest context checkpoint at or below the divergence
-// point - that checkpoint is what the caller falls back to instead of
-// reprocessing the prompt from scratch
+// how many tokens of a cached prompt could actually be reused if we restored it
 static int64_t server_prompt_cache_n_reusable(const server_prompt_cache_state & state, int lcp) {
+    // the cached prompt is fully contained in the new one - nothing has to be
+    // rolled back, so all of it is reusable
+    if (lcp == (int) state.prompt.tokens.size()) {
+        return lcp;
+    }
+
+    // no checkpoints - the memory can be rolled back to an arbitrary position,
+    // so the entire common prefix is reusable
+    if (state.prompt.checkpoints.empty()) {
+        return lcp;
+    }
+
+    // without a rollback-capable memory module (hybrid/recurrent), the restored
+    // state is usable only up to its newest context checkpoint at or below the
+    // divergence point - that checkpoint is what the caller falls back to
+    // instead of reprocessing the prompt from scratch
     int64_t res = 0;
 
     for (const auto & ckpt : state.prompt.checkpoints) {


### PR DESCRIPTION
## Overview

Fixes #22746.

llama.cpp still fully reprocesses prompts with hybrid/recurrent models like Qwen3.5/3.6, especially during long-running agentic tasks.

After trying several proposed patches and forks which didn't solve the problem entirely for me, I decided to ask Claude Opus to find a fix for this.

It seems that there are two issues in server-task.cpp:

1. A filter (the `f_keep < 0.25` guard) discards cache entries when less than 25% of them would remain, without checking whether they still contain reusable content.
2. When deciding which cache entry to pick next there are two measurements:
    A. the remaining percentage after choosing it (`f_keep`)
    B. how much of the new work has been done already (`sim`)

    The code favors the first, even though the second would make more sense. The result: a small entry displaces a possibly more relevant larger one.

## Additional information

Opus was instructed to find the cause of the problem and it came up with a small patch to server-task.cpp, as documented at
[prompt-cache-fkeep-22746.md](https://gist.github.com/q-g-j/fed26ad4c144e1042975d60768b6c696)

Tested with several long multi-turn agentic tasks in Hermes CLI. There might still be small reprocessing, but no minute-long full reprocessing anymore in my tests.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - discovery and fix by Claude Opus 5; PR written by human
