### PR TITLE
context: add cumulative mean pooling state

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2183,11 +2183,12 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_sampling().set_env("LLAMA_ARG_BACKEND_SAMPLING"));
     add_opt(common_arg(
-        {"--pooling"}, "{none,mean,cls,last,rank}",
+        {"--pooling"}, "{none,mean,mean-cumulative,cls,last,rank}",
         "pooling type for embeddings, use model default if unspecified",
         [](common_params & params, const std::string & value) {
             /**/ if (value == "none") { params.pooling_type = LLAMA_POOLING_TYPE_NONE; }
             else if (value == "mean") { params.pooling_type = LLAMA_POOLING_TYPE_MEAN; }
+            else if (value == "mean-cumulative") { params.pooling_type = LLAMA_POOLING_TYPE_MEAN_CUMULATIVE; }
             else if (value == "cls")  { params.pooling_type = LLAMA_POOLING_TYPE_CLS;  }
             else if (value == "last") { params.pooling_type = LLAMA_POOLING_TYPE_LAST; }
             else if (value == "rank") { params.pooling_type = LLAMA_POOLING_TYPE_RANK; }

--- a/include/llama.h
+++ b/include/llama.h
@@ -179,6 +179,9 @@ extern "C" {
         LLAMA_POOLING_TYPE_CLS  = 2,
         LLAMA_POOLING_TYPE_LAST = 3,
         LLAMA_POOLING_TYPE_RANK = 4, // used by reranking models to attach the classification head to the graph
+        // Exact FP32 mean over all token embeddings decoded for each sequence.
+        // Unlike MEAN, the accumulator persists across llama_decode() calls.
+        LLAMA_POOLING_TYPE_MEAN_CUMULATIVE = 5,
     };
 
     enum llama_attention_type {
@@ -1046,6 +1049,46 @@ extern "C" {
     // when pooling_type == LLAMA_POOLING_TYPE_RANK, returns float[n_cls_out] with the rank(s) of the sequence
     // otherwise: float[n_embd] (1-dimensional)
     LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
+
+    // Cumulative pooling state API.
+    //
+    // These functions operate only when pooling_type is
+    // LLAMA_POOLING_TYPE_MEAN_CUMULATIVE. The state is independent from the
+    // model memory state: callers that roll back, copy, or remove model memory
+    // must perform the corresponding pooling-state operation.
+    //
+    // Get the number of token embeddings accumulated for a sequence.
+    // Returns 0 when no cumulative state exists.
+    LLAMA_API uint64_t llama_pooling_seq_get_count(
+            struct llama_context * ctx,
+                    llama_seq_id   seq_id);
+
+    // Get the exact size needed to snapshot cumulative pooling state.
+    // Returns 0 when no cumulative state exists or cumulative pooling is off.
+    LLAMA_API size_t llama_pooling_seq_get_size(
+            struct llama_context * ctx,
+                    llama_seq_id   seq_id);
+
+    // Copy opaque cumulative pooling state into dst.
+    // Returns the bytes written, or 0 on failure.
+    LLAMA_API size_t llama_pooling_seq_get_data(
+            struct llama_context * ctx,
+                         uint8_t * dst,
+                          size_t   size,
+                    llama_seq_id   seq_id);
+
+    // Restore opaque cumulative pooling state into dest_seq_id.
+    // Returns the bytes consumed, or 0 on failure.
+    LLAMA_API size_t llama_pooling_seq_set_data(
+            struct llama_context * ctx,
+                   const uint8_t * src,
+                          size_t   size,
+                    llama_seq_id   dest_seq_id);
+
+    // Remove cumulative pooling state for a sequence.
+    LLAMA_API void llama_pooling_seq_rm(
+            struct llama_context * ctx,
+                    llama_seq_id   seq_id);
 
     //
     // backend sampling API [EXPERIMENTAL]

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -927,6 +927,134 @@ float * llama_context::get_embeddings_seq(llama_seq_id seq_id) {
     return it->second.data();
 }
 
+uint64_t llama_context::pooling_seq_get_count(llama_seq_id seq_id) const {
+    if (cparams.pooling_type != LLAMA_POOLING_TYPE_MEAN_CUMULATIVE) {
+        return 0;
+    }
+
+    const auto it = embd_seq_cumulative.find(seq_id);
+    return it == embd_seq_cumulative.end() ? 0 : it->second.count;
+}
+
+namespace {
+
+constexpr uint32_t cumulative_pooling_magic   = 0x43504d4c; // "LMPC"
+constexpr uint32_t cumulative_pooling_version = 1;
+constexpr size_t cumulative_pooling_header_size =
+    sizeof(uint32_t) * 3 + sizeof(uint64_t);
+
+}
+
+size_t llama_context::pooling_seq_get_size(llama_seq_id seq_id) const {
+    if (cparams.pooling_type != LLAMA_POOLING_TYPE_MEAN_CUMULATIVE) {
+        return 0;
+    }
+
+    const auto it = embd_seq_cumulative.find(seq_id);
+    if (it == embd_seq_cumulative.end() || it->second.count == 0) {
+        return 0;
+    }
+
+    return cumulative_pooling_header_size
+        + it->second.sum.size() * sizeof(float);
+}
+
+size_t llama_context::pooling_seq_get_data(
+        llama_seq_id seq_id,
+        uint8_t * dst,
+        size_t size) const {
+    const auto it = embd_seq_cumulative.find(seq_id);
+    const size_t expected = pooling_seq_get_size(seq_id);
+    if (expected == 0 || dst == nullptr || size < expected) {
+        return 0;
+    }
+
+    const uint32_t dimension =
+        static_cast<uint32_t>(it->second.sum.size());
+    size_t offset = 0;
+    const auto write = [&](const void * src, size_t count) {
+        std::memcpy(dst + offset, src, count);
+        offset += count;
+    };
+    write(&cumulative_pooling_magic, sizeof(cumulative_pooling_magic));
+    write(&cumulative_pooling_version, sizeof(cumulative_pooling_version));
+    write(&dimension, sizeof(dimension));
+    write(&it->second.count, sizeof(it->second.count));
+    write(it->second.sum.data(), it->second.sum.size() * sizeof(float));
+
+    GGML_ASSERT(offset == expected);
+    return offset;
+}
+
+size_t llama_context::pooling_seq_set_data(
+        llama_seq_id seq_id,
+        const uint8_t * src,
+        size_t size) {
+    if (cparams.pooling_type != LLAMA_POOLING_TYPE_MEAN_CUMULATIVE
+        || src == nullptr
+        || seq_id < 0
+        || seq_id >= static_cast<llama_seq_id>(
+            cparams.kv_unified ? LLAMA_MAX_SEQ : cparams.n_seq_max)
+        || size < cumulative_pooling_header_size) {
+        return 0;
+    }
+
+    uint32_t magic = 0;
+    uint32_t version = 0;
+    uint32_t dimension = 0;
+    uint64_t count = 0;
+    size_t offset = 0;
+    const auto read = [&](void * dst, size_t bytes) {
+        std::memcpy(dst, src + offset, bytes);
+        offset += bytes;
+    };
+    read(&magic, sizeof(magic));
+    read(&version, sizeof(version));
+    read(&dimension, sizeof(dimension));
+    read(&count, sizeof(count));
+
+    const uint32_t expected_dimension = model.hparams.n_embd_out();
+    if (magic != cumulative_pooling_magic
+        || version != cumulative_pooling_version
+        || dimension != expected_dimension
+        || count == 0) {
+        return 0;
+    }
+
+    const size_t expected =
+        cumulative_pooling_header_size
+        + static_cast<size_t>(dimension) * sizeof(float);
+    if (size != expected) {
+        return 0;
+    }
+
+    cumulative_pooling_state restored;
+    restored.count = count;
+    restored.sum.resize(dimension);
+    read(restored.sum.data(), restored.sum.size() * sizeof(float));
+    GGML_ASSERT(offset == expected);
+
+    std::vector<float> mean(dimension);
+    for (size_t i = 0; i < restored.sum.size(); ++i) {
+        if (!std::isfinite(restored.sum[i])) {
+            return 0;
+        }
+        mean[i] = restored.sum[i] / static_cast<float>(restored.count);
+        if (!std::isfinite(mean[i])) {
+            return 0;
+        }
+    }
+
+    embd_seq_cumulative[seq_id] = std::move(restored);
+    embd_seq[seq_id] = std::move(mean);
+    return expected;
+}
+
+void llama_context::pooling_seq_rm(llama_seq_id seq_id) {
+    embd_seq_cumulative.erase(seq_id);
+    embd_seq.erase(seq_id);
+}
+
 float * llama_context::get_embeddings_nextn() {
     output_reorder();
 
@@ -1396,6 +1524,11 @@ int llama_context::encode(const llama_batch & batch_inp) {
         return -1;
     }
 
+    if (cparams.pooling_type == LLAMA_POOLING_TYPE_MEAN_CUMULATIVE) {
+        LLAMA_LOG_ERROR("%s: cumulative mean pooling is supported only by llama_decode\n", __func__);
+        return -1;
+    }
+
     const auto & hparams = model.hparams;
 
     // eagle3/DFlash: features as encoder input, and non-draft paths fall back to model's input dim
@@ -1481,6 +1614,7 @@ int llama_context::encode(const llama_batch & batch_inp) {
 
         switch (cparams.pooling_type) {
             case LLAMA_POOLING_TYPE_NONE:
+            case LLAMA_POOLING_TYPE_MEAN_CUMULATIVE:
                 {
                     // extract token embeddings
                     GGML_ASSERT(embd.data != nullptr);
@@ -1767,8 +1901,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
     }
     n_queued_tokens += n_tokens_all;
 
-    // TODO: this clear of the buffer can easily be forgotten - need something better
-    embd_seq.clear();
+    // Batch-local pooling replaces the previous output. Cumulative pooling
+    // retains per-sequence state until the caller explicitly removes or
+    // restores it.
+    if (cparams.pooling_type != LLAMA_POOLING_TYPE_MEAN_CUMULATIVE) {
+        embd_seq.clear();
+    }
     output_swaps.clear();
 
     sched_reserve();
@@ -1921,6 +2059,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
             switch (cparams.pooling_type) {
                 case LLAMA_POOLING_TYPE_NONE:
+                case LLAMA_POOLING_TYPE_MEAN_CUMULATIVE:
                     {
                         // extract token embeddings
                         GGML_ASSERT(embd.data != nullptr);
@@ -2059,6 +2198,16 @@ int llama_context::decode(const llama_batch & batch_inp) {
             for (uint32_t i = 0; i < n_outputs; ++i) {
                 output_ids[out_ids[i]] = i;
             }
+        }
+    }
+
+    if (cparams.pooling_type == LLAMA_POOLING_TYPE_MEAN_CUMULATIVE) {
+        // The backend copies above are asynchronous. Wait once, after every
+        // ubatch has succeeded, then update the accumulator transactionally.
+        synchronize();
+        if (!accumulate_cumulative_pooling(balloc->get_batch())) {
+            LLAMA_LOG_ERROR("%s: failed to update cumulative mean pooling state\n", __func__);
+            return -3;
         }
     }
 
@@ -2327,6 +2476,91 @@ void llama_context::output_reorder() {
     }
 
     output_swaps.clear();
+}
+
+bool llama_context::accumulate_cumulative_pooling(const llama_batch & batch) {
+    if (cparams.pooling_type != LLAMA_POOLING_TYPE_MEAN_CUMULATIVE
+        || !embd.has_data()
+        || batch.n_tokens <= 0
+        || static_cast<uint32_t>(batch.n_tokens) != n_outputs) {
+        return false;
+    }
+
+    const size_t dimension = model.hparams.n_embd_out();
+    std::map<llama_seq_id, cumulative_pooling_state> pending;
+
+    const auto pending_state = [&](llama_seq_id seq_id) -> cumulative_pooling_state * {
+        auto it = pending.find(seq_id);
+        if (it != pending.end()) {
+            return &it->second;
+        }
+
+        const auto existing = embd_seq_cumulative.find(seq_id);
+        cumulative_pooling_state state;
+        if (existing != embd_seq_cumulative.end()) {
+            state = existing->second;
+        } else {
+            state.sum.assign(dimension, 0.0f);
+        }
+        if (state.sum.size() != dimension) {
+            return nullptr;
+        }
+        return &pending.emplace(seq_id, std::move(state)).first->second;
+    };
+
+    for (int32_t token = 0; token < batch.n_tokens; ++token) {
+        const int32_t row = output_ids[token];
+        if (row < 0 || static_cast<uint32_t>(row) >= n_outputs) {
+            return false;
+        }
+        const float * embedding = embd.data + static_cast<size_t>(row) * dimension;
+        for (size_t component = 0; component < dimension; ++component) {
+            if (!std::isfinite(embedding[component])) {
+                return false;
+            }
+        }
+
+        const int32_t n_seq_id = batch.n_seq_id ? batch.n_seq_id[token] : 1;
+        for (int32_t s = 0; s < n_seq_id; ++s) {
+            const llama_seq_id seq_id = batch.seq_id ? batch.seq_id[token][s] : 0;
+            if (seq_id < 0
+                || seq_id >= static_cast<llama_seq_id>(
+                    cparams.kv_unified ? LLAMA_MAX_SEQ : cparams.n_seq_max)) {
+                return false;
+            }
+
+            cumulative_pooling_state * state = pending_state(seq_id);
+            if (state == nullptr || state->count == std::numeric_limits<uint64_t>::max()) {
+                return false;
+            }
+            for (size_t component = 0; component < dimension; ++component) {
+                state->sum[component] += embedding[component];
+                if (!std::isfinite(state->sum[component])) {
+                    return false;
+                }
+            }
+            ++state->count;
+        }
+    }
+
+    // Commit only after every output row and sequence membership validates.
+    for (auto & [seq_id, state] : pending) {
+        if (state.count == 0) {
+            return false;
+        }
+
+        std::vector<float> mean(dimension);
+        for (size_t component = 0; component < dimension; ++component) {
+            mean[component] = state.sum[component] / static_cast<float>(state.count);
+            if (!std::isfinite(mean[component])) {
+                return false;
+            }
+        }
+        embd_seq_cumulative[seq_id] = std::move(state);
+        embd_seq[seq_id] = std::move(mean);
+    }
+
+    return true;
 }
 
 //
@@ -3713,6 +3947,43 @@ float * llama_get_embeddings_seq(llama_context * ctx, llama_seq_id seq_id) {
     ctx->synchronize();
 
     return ctx->get_embeddings_seq(seq_id);
+}
+
+uint64_t llama_pooling_seq_get_count(llama_context * ctx, llama_seq_id seq_id) {
+    ctx->synchronize();
+
+    return ctx->pooling_seq_get_count(seq_id);
+}
+
+size_t llama_pooling_seq_get_size(llama_context * ctx, llama_seq_id seq_id) {
+    ctx->synchronize();
+
+    return ctx->pooling_seq_get_size(seq_id);
+}
+
+size_t llama_pooling_seq_get_data(
+        llama_context * ctx,
+        uint8_t * dst,
+        size_t size,
+        llama_seq_id seq_id) {
+    ctx->synchronize();
+
+    return ctx->pooling_seq_get_data(seq_id, dst, size);
+}
+
+size_t llama_pooling_seq_set_data(
+        llama_context * ctx,
+        const uint8_t * src,
+        size_t size,
+        llama_seq_id seq_id) {
+    ctx->synchronize();
+
+    return ctx->pooling_seq_set_data(seq_id, src, size);
+}
+
+void llama_pooling_seq_rm(llama_context * ctx, llama_seq_id seq_id) {
+    ctx->synchronize();
+    ctx->pooling_seq_rm(seq_id);
 }
 
 void llama_set_embeddings_nextn(llama_context * ctx, bool value, bool masked) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -84,6 +84,11 @@ struct llama_context {
     float * get_embeddings();
     float * get_embeddings_ith(int32_t i);
     float * get_embeddings_seq(llama_seq_id seq_id);
+    uint64_t pooling_seq_get_count(llama_seq_id seq_id) const;
+    size_t pooling_seq_get_size(llama_seq_id seq_id) const;
+    size_t pooling_seq_get_data(llama_seq_id seq_id, uint8_t * dst, size_t size) const;
+    size_t pooling_seq_set_data(llama_seq_id seq_id, const uint8_t * src, size_t size);
+    void pooling_seq_rm(llama_seq_id seq_id);
 
     float * get_embeddings_nextn();
     float * get_embeddings_nextn_ith(int32_t i);
@@ -230,6 +235,8 @@ private:
     // map the output row index `i` to batch index
     int64_t output_resolve_row(int32_t i) const;
 
+    bool accumulate_cumulative_pooling(const llama_batch & batch);
+
     // async-copy enabled layer-input tensors (per cparams.output_layer_inp)
     // from backend into host-side embd_layer_inp buffers
     void extract_layer_inputs(const llm_graph_result * res, size_t token_offset, size_t n_tokens);
@@ -292,7 +299,7 @@ private:
     buffer_view<float> logits = {nullptr, 0};
 
     // embeddings output (2-dimensional array: [n_outputs][n_embd])
-    // populated only when pooling_type == LLAMA_POOLING_TYPE_NONE
+    // populated for per-token and cumulative-mean pooling
     buffer_view<float> embd = {nullptr, 0};
 
     // hidden state required by the nextn layers (2-dimensional array: [n_outputs][n_embd])
@@ -326,6 +333,15 @@ private:
     // sequence embeddings output (map of [n_embd] vectors)
     // populated only when pooling_type != LLAMA_POOLING_TYPE_NONE
     std::map<llama_seq_id, std::vector<float>> embd_seq;
+
+    struct cumulative_pooling_state {
+        uint64_t count = 0;
+        std::vector<float> sum;
+    };
+
+    // Exact FP32 sum/count, retained across decode calls only for
+    // LLAMA_POOLING_TYPE_MEAN_CUMULATIVE.
+    std::map<llama_seq_id, cumulative_pooling_state> embd_seq_cumulative;
 
     // reuse the batch_allocr to avoid unnecessary memory allocations
     std::unique_ptr<llama_batch_allocr> balloc;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -3337,6 +3337,7 @@ void llm_graph_context::build_pooling(
 
     switch (pooling_type) {
         case LLAMA_POOLING_TYPE_NONE:
+        case LLAMA_POOLING_TYPE_MEAN_CUMULATIVE:
             {
                 cur = inp;
             } break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -278,6 +278,10 @@ set_tests_properties(test-state-restore-fragmented PROPERTIES FIXTURES_REQUIRED 
 llama_build_and_test(test-save-load-state.cpp LABEL "model" ARGS -m "${MODEL_DEST}")
 set_tests_properties(test-save-load-state PROPERTIES FIXTURES_REQUIRED test-download-model)
 
+# Exact FP32 cumulative mean pooling and opaque pooling-state checkpoints.
+llama_build_and_test(test-cumulative-pooling.cpp LABEL "model" ARGS "${MODEL_DEST}")
+set_tests_properties(test-cumulative-pooling PROPERTIES FIXTURES_REQUIRED test-download-model)
+
 if (NOT GGML_BACKEND_DL)
     # these tests use the backends directly and cannot be built with dynamic loading
     llama_build_and_test(test-barrier.cpp)

--- a/tests/test-cumulative-pooling.cpp
+++ b/tests/test-cumulative-pooling.cpp
@@ -1,0 +1,175 @@
+#include "get-model.h"
+#include "llama.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+struct batch_owner {
+    llama_batch batch;
+
+    batch_owner(int32_t n_tokens, int32_t n_seq_max) : batch(llama_batch_init(n_tokens, 0, n_seq_max)) {}
+
+    ~batch_owner() { llama_batch_free(batch); }
+
+    batch_owner(const batch_owner &)             = delete;
+    batch_owner & operator=(const batch_owner &) = delete;
+};
+
+bool expect(bool condition, const char * message) {
+    if (!condition) {
+        std::fprintf(stderr, "FAILED: %s\n", message);
+    }
+    return condition;
+}
+
+std::vector<llama_token> tokenize(const llama_vocab * vocab, const char * text) {
+    const int32_t required = -llama_tokenize(vocab, text, std::strlen(text), nullptr, 0, true, true);
+    if (required <= 0) {
+        return {};
+    }
+
+    std::vector<llama_token> tokens(required);
+    const int32_t written = llama_tokenize(vocab, text, std::strlen(text), tokens.data(), tokens.size(), true, true);
+    if (written != required) {
+        return {};
+    }
+    return tokens;
+}
+
+bool decode_and_check(llama_context *                  ctx,
+                      const std::vector<llama_token> & tokens,
+                      size_t                           begin,
+                      size_t                           end,
+                      std::vector<float> &             manual_sum) {
+    batch_owner owner(static_cast<int32_t>(end - begin), 1);
+    owner.batch.n_tokens = static_cast<int32_t>(end - begin);
+    for (size_t i = begin; i < end; ++i) {
+        const size_t row           = i - begin;
+        owner.batch.token[row]     = tokens[i];
+        owner.batch.pos[row]       = static_cast<llama_pos>(i);
+        owner.batch.n_seq_id[row]  = 1;
+        owner.batch.seq_id[row][0] = 0;
+        owner.batch.logits[row]    = 1;
+    }
+
+    if (llama_decode(ctx, owner.batch) != 0) {
+        return expect(false, "llama_decode failed");
+    }
+
+    const size_t dimension = manual_sum.size();
+    for (size_t row = 0; row < end - begin; ++row) {
+        const float * embedding = llama_get_embeddings_ith(ctx, static_cast<int32_t>(row));
+        if (!expect(embedding != nullptr, "missing token embedding")) {
+            return false;
+        }
+        for (size_t component = 0; component < dimension; ++component) {
+            manual_sum[component] += embedding[component];
+        }
+    }
+
+    if (!expect(llama_pooling_seq_get_count(ctx, 0) == end, "cumulative token count drifted")) {
+        return false;
+    }
+
+    const float * mean = llama_get_embeddings_seq(ctx, 0);
+    if (!expect(mean != nullptr, "missing cumulative sequence embedding")) {
+        return false;
+    }
+    for (size_t component = 0; component < dimension; ++component) {
+        const float expected = manual_sum[component] / static_cast<float>(end);
+        if (!expect(mean[component] == expected, "cumulative mean differs from exact FP32 sum/count")) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv) {
+    llama_backend_init();
+
+    llama_model_params model_params = llama_model_default_params();
+    model_params.n_gpu_layers       = 0;
+    llama_model * model             = llama_model_load_from_file(get_model_or_exit(argc, argv), model_params);
+    if (!expect(model != nullptr, "failed to load model")) {
+        return EXIT_FAILURE;
+    }
+
+    llama_context_params context_params = llama_context_default_params();
+    context_params.n_ctx                = 128;
+    context_params.n_batch              = 64;
+    context_params.n_ubatch             = 64;
+    context_params.n_seq_max            = 2;
+    context_params.embeddings           = true;
+    context_params.pooling_type         = LLAMA_POOLING_TYPE_MEAN_CUMULATIVE;
+    context_params.attention_type       = LLAMA_ATTENTION_TYPE_CAUSAL;
+    llama_context * ctx                 = llama_init_from_model(model, context_params);
+    if (!expect(ctx != nullptr, "failed to create cumulative pooling context")) {
+        llama_model_free(model);
+        llama_backend_free();
+        return EXIT_FAILURE;
+    }
+
+    const std::vector<llama_token> tokens =
+        tokenize(llama_model_get_vocab(model), "Cumulative masked mean pooling must remain exact across decode calls.");
+    if (!expect(tokens.size() >= 4, "test prompt tokenized too short")) {
+        llama_free(ctx);
+        llama_model_free(model);
+        llama_backend_free();
+        return EXIT_FAILURE;
+    }
+
+    bool               ok    = true;
+    const size_t       split = tokens.size() / 2;
+    std::vector<float> manual_sum(llama_model_n_embd_out(model), 0.0f);
+
+    ok                                      = ok && decode_and_check(ctx, tokens, 0, split, manual_sum);
+    const std::vector<float> checkpoint_sum = manual_sum;
+
+    std::vector<uint8_t> checkpoint(llama_pooling_seq_get_size(ctx, 0));
+    if (!ok || !expect(!checkpoint.empty(), "pooling checkpoint is empty") ||
+        !expect(llama_pooling_seq_get_data(ctx, checkpoint.data(), checkpoint.size(), 0) == checkpoint.size(),
+                "failed to snapshot cumulative pooling state")) {
+        llama_free(ctx);
+        llama_model_free(model);
+        llama_backend_free();
+        return EXIT_FAILURE;
+    }
+
+    ok = ok && decode_and_check(ctx, tokens, split, tokens.size(), manual_sum);
+
+    ok = ok && expect(llama_pooling_seq_set_data(ctx, checkpoint.data(), checkpoint.size(), 1) == checkpoint.size(),
+                      "failed to restore cumulative pooling state");
+    ok = ok && expect(llama_pooling_seq_get_count(ctx, 1) == split, "restored cumulative count drifted");
+
+    const float * restored = llama_get_embeddings_seq(ctx, 1);
+    ok                     = ok && expect(restored != nullptr, "restored mean is missing");
+    if (restored != nullptr) {
+        for (size_t component = 0; component < manual_sum.size(); ++component) {
+            const float expected = checkpoint_sum[component] / static_cast<float>(split);
+            ok                   = ok && expect(restored[component] == expected, "restored cumulative mean drifted");
+        }
+    }
+
+    const uint64_t restored_count = llama_pooling_seq_get_count(ctx, 1);
+    checkpoint[0] ^= 0xff;
+    ok = ok && expect(llama_pooling_seq_set_data(ctx, checkpoint.data(), checkpoint.size(), 1) == 0,
+                      "corrupted cumulative pooling state was accepted");
+    ok = ok && expect(llama_pooling_seq_get_count(ctx, 1) == restored_count,
+                      "failed restore mutated existing cumulative state");
+
+    llama_pooling_seq_rm(ctx, 0);
+    ok = ok && expect(llama_pooling_seq_get_count(ctx, 0) == 0, "pooling state removal did not reset the count");
+    ok = ok && expect(llama_get_embeddings_seq(ctx, 0) == nullptr, "pooling state removal left a stale mean");
+
+    llama_free(ctx);
+    llama_model_free(model);
+    llama_backend_free();
+    return ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

- add opt-in cumulative mean pooling across repeated `llama_decode` calls
- expose opaque per-sequence snapshot, restore, and removal APIs so recurrent consumers can keep pooling state aligned with model-memory checkpoints
- preserve the existing `LLAMA_POOLING_TYPE_MEAN` behavior unchanged
- reject corrupt or incompatible serialized pooling state

## Motivation

Mean pooling is currently batch-local. Incremental embedding consumers therefore cannot reproduce the clean full-history mean after decoding a sequence in multiple chunks without duplicating internal accumulator behavior. The new cumulative mode retains the exact FP32 sum and count per sequence while keeping the state opaque to callers.

## Validation

- `test-cumulative-pooling` verifies split-decode accumulation
- verifies snapshot/restore into another sequence
- verifies corrupt snapshot rejection
- verifies state removal
- exercised with Qwen3.5-0.8B on Apple Metal

The new behavior is opt-in; existing pooling modes and callers are unaffected.
