### PR TITLE
server : add /slots endpoint action=clone_to (KV clone between slots)

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1151,8 +1151,8 @@ Unlike `save`/`restore`, this action performs no disk I/O and therefore does **n
 
 *Notes:*
 
-- Returns HTTP 400 if either slot ID is out of range, if source and target are the same slot, or if the source slot is empty (nothing to clone).
-- Not supported with `--ctx-shift` or `--cache-reuse`: the cloned cells are shared by reference, so shifting or reusing them would silently corrupt all branches (HTTP 501).
+- Returns HTTP 400 if either slot ID is out of range, if source and target are the same slot, if the source slot is empty (nothing to clone), or if `target` is missing/invalid.
+- Not supported with `--context-shift` or `--cache-reuse`: the cloned cells are shared by reference, so shifting or reusing them would silently corrupt all branches (HTTP 501).
 - The clone has point-in-time semantics: the target receives the source state as it is at clone time. Clone while the trunk is idle; further generation on either slot afterwards diverges independently.
 
 ### GET `/lora-adapters`: Get list of all LoRA adapters

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1126,6 +1126,35 @@ In *router mode* the query param `?model={model_id}` has to be set. This endpoin
 }
 ```
 
+### POST `/slots/{id_slot}?action=clone_to`: Clone the prompt cache of the specified slot into another slot.
+
+Copies the KV cache of the source slot into the target slot **by reference**, without any recomputation. This is useful for parallel branching: fork multiple independent continuations (branches) from a common trunk prompt while paying the prefill cost only once.
+
+Unlike `save`/`restore`, this action performs no disk I/O and therefore does **not** require `--slot-save-path`.
+
+*Options:*
+
+`target`: ID of the destination slot. Can be passed as a query parameter (`?action=clone_to&target=1`) or in the request body (`{"target": 1}`).
+
+**Response format**
+
+```json
+{
+    "id_slot": 0,
+    "id_slot_target": 1,
+    "n_cloned": 1745,
+    "timings": {
+        "clone_ms": 0.042
+    }
+}
+```
+
+*Notes:*
+
+- Returns HTTP 400 if either slot ID is out of range, if source and target are the same slot, or if the source slot is empty (nothing to clone).
+- Not supported with `--ctx-shift` or `--cache-reuse`: the cloned cells are shared by reference, so shifting or reusing them would silently corrupt all branches (HTTP 501).
+- The clone has point-in-time semantics: the target receives the source state as it is at clone time. Clone while the trunk is idle; further generation on either slot afterwards diverges independently.
+
 ### GET `/lora-adapters`: Get list of all LoRA adapters
 
 This endpoint returns the loaded LoRA adapters. You can add adapters using `--lora` when starting the server, for example: `--lora my_adapter_1.gguf --lora my_adapter_2.gguf ...`

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2628,8 +2628,8 @@ private:
                 {
                     const int id_slot   = task.slot_action.id_slot;
                     const int id_target = task.slot_action.id_slot_target;
-                    // controllo esplicito: get_slot_by_id fa wrap-around per
-                    // design, ma per la clonazione un id fuori range e' un errore
+                    // explicit range check: get_slot_by_id wraps around by
+                    // design, but for cloning an out-of-range id is an error
                     if (id_slot < 0 || id_slot >= (int) slots.size()
                             || id_target < 0 || id_target >= (int) slots.size()) {
                         send_error(task, "Invalid slot ID (out of range)", ERROR_TYPE_INVALID_REQUEST);
@@ -2649,14 +2649,14 @@ private:
                         break;
                     }
                     if (slot->is_processing() || target->is_processing()) {
-                        // slot occupato: si ritenta piu' tardi, come save/restore
+                        // slot busy: defer and retry later, same as save/restore
                         SRV_DBG("requested slot is unavailable, defer task, id_task = %d\n", task.id);
                         queue_tasks.defer(std::move(task));
                         break;
                     }
-                    // GUARDIA ctx_shift: con KV shifting o context shift attivi le
-                    // celle condivise per riferimento si sposterebbero per TUTTI i
-                    // rami -> corruzione silenziosa cross-ramo. Rifiuto esplicito.
+                    // ctx_shift guard: with KV shifting or cache reuse active,
+                    // cells shared by reference would be shifted for ALL
+                    // branches -> silent cross-branch corruption. Reject it.
                     if (params_base.ctx_shift || params_base.n_cache_reuse > 0) {
                         send_error(task, "clone_to is incompatible with --ctx-shift/--cache-reuse "
                                          "(shared KV cells would shift across branches)",
@@ -2671,10 +2671,10 @@ private:
 
                     const int64_t t_start = ggml_time_us();
 
-                    // clone KV senza ricalcolo: la sequenza del target viene
-                    // cancellata e sostituita con RIFERIMENTI alle celle KV del
-                    // source (seq_cp); il prompt clonato permette al prossimo
-                    // task sul target di trovare il prefisso in cache.
+                    // clone the KV without recomputation: the target sequence
+                    // is erased and replaced with REFERENCES to the source KV
+                    // cells (seq_cp); the cloned prompt lets the next task on
+                    // the target find the prefix in cache.
                     common_context_seq_rm(ctx_tgt, target->id, -1, -1);
                     common_context_seq_cp(ctx_tgt, slot->id, target->id, -1, -1);
                     if (ctx_dft) {
@@ -4573,8 +4573,8 @@ void server_routes::init_routes() {
 
         std::string action = req.get_param("action");
 
-        // kvclone: clonazione KV fra slot dello stesso server, nessun I/O su
-        // disco -> NON richiede --slot-save-path
+        // clone_to copies the KV between slots of the same server with no
+        // disk I/O, so it does NOT require --slot-save-path
         if (action == "clone_to") {
             return handle_slots_clone_to(req, id_slot);
         }
@@ -5277,7 +5277,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_erase(const se
 std::unique_ptr<server_res_generator> server_routes::handle_slots_clone_to(const server_http_req & req, int id_slot) {
     auto res = create_response();
 
-    // target da query param (?action=clone_to&target=N), fallback body {"target": N}
+    // target from query param (?action=clone_to&target=N), fallback to body {"target": N}
     std::string target_str = req.get_param("target");
     if (target_str.empty() && !req.body.empty()) {
         try {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2654,6 +2654,15 @@ private:
                         queue_tasks.defer(std::move(task));
                         break;
                     }
+                    // GUARDIA ctx_shift: con KV shifting o context shift attivi le
+                    // celle condivise per riferimento si sposterebbero per TUTTI i
+                    // rami -> corruzione silenziosa cross-ramo. Rifiuto esplicito.
+                    if (params_base.ctx_shift || params_base.n_cache_reuse > 0) {
+                        send_error(task, "clone_to is incompatible with --ctx-shift/--cache-reuse "
+                                         "(shared KV cells would shift across branches)",
+                                   ERROR_TYPE_NOT_SUPPORTED);
+                        break;
+                    }
                     const size_t n_tokens = slot->prompt.tokens.size();
                     if (n_tokens == 0) {
                         send_error(task, "Source slot is empty, nothing to clone", ERROR_TYPE_INVALID_REQUEST);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2658,7 +2658,7 @@ private:
                     // cells shared by reference would be shifted for ALL
                     // branches -> silent cross-branch corruption. Reject it.
                     if (params_base.ctx_shift || params_base.n_cache_reuse > 0) {
-                        send_error(task, "clone_to is incompatible with --ctx-shift/--cache-reuse "
+                        send_error(task, "clone_to is incompatible with --context-shift/--cache-reuse "
                                          "(shared KV cells would shift across branches)",
                                    ERROR_TYPE_NOT_SUPPORTED);
                         break;
@@ -5317,6 +5317,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_clone_to(const
         return res;
     }
 
+    GGML_ASSERT(dynamic_cast<server_task_result_slot_clone *>(result.get()) != nullptr);
     res->ok(result->to_json());
     return res;
 }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2624,6 +2624,70 @@ private:
                     res->n_erased = n_erased;
                     queue_results.send(std::move(res));
                 } break;
+            case SERVER_TASK_TYPE_SLOT_CLONE:
+                {
+                    const int id_slot   = task.slot_action.id_slot;
+                    const int id_target = task.slot_action.id_slot_target;
+                    // controllo esplicito: get_slot_by_id fa wrap-around per
+                    // design, ma per la clonazione un id fuori range e' un errore
+                    if (id_slot < 0 || id_slot >= (int) slots.size()
+                            || id_target < 0 || id_target >= (int) slots.size()) {
+                        send_error(task, "Invalid slot ID (out of range)", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
+                    server_slot * slot   = get_slot_by_id(id_slot);
+                    server_slot * target = get_slot_by_id(id_target);
+                    if (slot == nullptr || target == nullptr) {
+                        send_error(task, "Invalid slot ID", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
+                    if (slot == target) {
+                        send_error(task, "Source and target slots must be different", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
+                    if (!check_slot_no_media(*slot, task.id) || !check_slot_no_media(*target, task.id)) {
+                        break;
+                    }
+                    if (slot->is_processing() || target->is_processing()) {
+                        // slot occupato: si ritenta piu' tardi, come save/restore
+                        SRV_DBG("requested slot is unavailable, defer task, id_task = %d\n", task.id);
+                        queue_tasks.defer(std::move(task));
+                        break;
+                    }
+                    const size_t n_tokens = slot->prompt.tokens.size();
+                    if (n_tokens == 0) {
+                        send_error(task, "Source slot is empty, nothing to clone", ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
+
+                    const int64_t t_start = ggml_time_us();
+
+                    // clone KV senza ricalcolo: la sequenza del target viene
+                    // cancellata e sostituita con RIFERIMENTI alle celle KV del
+                    // source (seq_cp); il prompt clonato permette al prossimo
+                    // task sul target di trovare il prefisso in cache.
+                    common_context_seq_rm(ctx_tgt, target->id, -1, -1);
+                    common_context_seq_cp(ctx_tgt, slot->id, target->id, -1, -1);
+                    if (ctx_dft) {
+                        common_context_seq_rm(ctx_dft, target->id, -1, -1);
+                        common_context_seq_cp(ctx_dft, slot->id, target->id, -1, -1);
+                    }
+                    target->prompt = slot->prompt.clone();
+                    target->n_decoded   = slot->n_decoded;
+                    target->n_remaining = slot->n_remaining;
+                    target->n_prompt_tokens_cache     = slot->n_prompt_tokens_cache;
+                    target->n_prompt_tokens_processed = slot->n_prompt_tokens_processed;
+
+                    const int64_t t_end = ggml_time_us();
+
+                    auto res = std::make_unique<server_task_result_slot_clone>();
+                    res->id             = task.id;
+                    res->id_slot        = id_slot;
+                    res->id_slot_target = id_target;
+                    res->n_tokens       = n_tokens;
+                    res->t_ms           = (t_end - t_start) / 1000.0;
+                    queue_results.send(std::move(res));
+                } break;
             case SERVER_TASK_TYPE_GET_LORA:
                 {
                     // TODO @ngxson : make lora_adapters a dedicated member of server_context
@@ -4487,10 +4551,6 @@ void server_routes::init_routes() {
 
     this->post_slots = [this](const server_http_req & req) {
         auto res = create_response();
-        if (params.slot_save_path.empty()) {
-            res->error(format_error_response("This server does not support slots action. Start it with `--slot-save-path`", ERROR_TYPE_NOT_SUPPORTED));
-            return res;
-        }
 
         std::string id_slot_str = req.get_param("id_slot");
 
@@ -4503,6 +4563,17 @@ void server_routes::init_routes() {
         }
 
         std::string action = req.get_param("action");
+
+        // kvclone: clonazione KV fra slot dello stesso server, nessun I/O su
+        // disco -> NON richiede --slot-save-path
+        if (action == "clone_to") {
+            return handle_slots_clone_to(req, id_slot);
+        }
+
+        if (params.slot_save_path.empty()) {
+            res->error(format_error_response("This server does not support slots action. Start it with `--slot-save-path`", ERROR_TYPE_NOT_SUPPORTED));
+            return res;
+        }
 
         if (action == "save") {
             return handle_slots_save(req, id_slot);
@@ -5190,6 +5261,53 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_erase(const se
     }
 
     GGML_ASSERT(dynamic_cast<server_task_result_slot_erase*>(result.get()) != nullptr);
+    res->ok(result->to_json());
+    return res;
+}
+
+std::unique_ptr<server_res_generator> server_routes::handle_slots_clone_to(const server_http_req & req, int id_slot) {
+    auto res = create_response();
+
+    // target da query param (?action=clone_to&target=N), fallback body {"target": N}
+    std::string target_str = req.get_param("target");
+    if (target_str.empty() && !req.body.empty()) {
+        try {
+            const json request_data = json::parse(req.body);
+            if (request_data.contains("target")) {
+                target_str = std::to_string(request_data.at("target").get<int>());
+            }
+        } catch (const std::exception &) {}
+    }
+
+    int id_target;
+    try {
+        id_target = std::stoi(target_str);
+    } catch (const std::exception &) {
+        res->error(format_error_response("Invalid or missing target slot ID", ERROR_TYPE_INVALID_REQUEST));
+        return res;
+    }
+
+    auto & rd = res->rd;
+    {
+        server_task task(SERVER_TASK_TYPE_SLOT_CLONE);
+        task.id = rd.get_new_id();
+        task.slot_action.id_slot        = id_slot;
+        task.slot_action.id_slot_target = id_target;
+        rd.post_task(std::move(task));
+    }
+
+    auto result = rd.next(req.should_stop);
+    if (!result) {
+        // connection was closed
+        GGML_ASSERT(req.should_stop());
+        return res;
+    }
+
+    if (result->is_error()) {
+        res->error(result->to_json());
+        return res;
+    }
+
     res->ok(result->to_json());
     return res;
 }

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -167,6 +167,7 @@ private:
     std::unique_ptr<server_res_generator> handle_slots_save(const server_http_req & req, int id_slot);
     std::unique_ptr<server_res_generator> handle_slots_restore(const server_http_req & req, int id_slot);
     std::unique_ptr<server_res_generator> handle_slots_erase(const server_http_req &, int id_slot);
+    std::unique_ptr<server_res_generator> handle_slots_clone_to(const server_http_req & req, int id_slot);
     std::unique_ptr<server_res_generator> handle_embeddings_impl(const server_http_req & req, task_response_type res_type);
     std::unique_ptr<server_res_generator> handle_count_tokens(const llama_vocab * vocab, mtmd_context * mctx, const server_http_req & req, task_response_type res_type);
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1602,6 +1602,20 @@ json server_task_result_slot_erase::to_json() {
 }
 
 //
+// server_task_result_slot_clone
+//
+json server_task_result_slot_clone::to_json() {
+    return json {
+        { "id_slot",        id_slot },
+        { "id_slot_target", id_slot_target },
+        { "n_cloned",       n_tokens },
+        { "timings", {
+            { "clone_ms", t_ms }
+        }},
+    };
+}
+
+//
 // server_task_result_get_lora
 //
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -25,6 +25,7 @@ enum server_task_type {
     SERVER_TASK_TYPE_SLOT_SAVE,
     SERVER_TASK_TYPE_SLOT_RESTORE,
     SERVER_TASK_TYPE_SLOT_ERASE,
+    SERVER_TASK_TYPE_SLOT_CLONE,
     SERVER_TASK_TYPE_GET_LORA,
     SERVER_TASK_TYPE_SET_LORA,
 };
@@ -166,6 +167,7 @@ struct server_task {
         int id_slot;
         std::string filename;
         std::string filepath;
+        int id_slot_target = -1; // used by SERVER_TASK_TYPE_SLOT_CLONE
     };
     slot_action slot_action;
 
@@ -552,6 +554,14 @@ struct server_task_result_slot_save_load : server_task_result {
 
 struct server_task_result_slot_erase : server_task_result {
     size_t n_erased;
+
+    virtual json to_json() override;
+};
+
+struct server_task_result_slot_clone : server_task_result {
+    int    id_slot_target = -1;
+    size_t n_tokens;
+    double t_ms;
 
     virtual json to_json() override;
 };

--- a/tools/server/tests/unit/test_slot_clone.py
+++ b/tools/server/tests/unit/test_slot_clone.py
@@ -1,0 +1,103 @@
+import pytest
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+
+LONG_TEXT = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+""".strip()
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+    server.temperature = 0.0
+
+
+def test_slot_clone_to():
+    global server
+    server.start()
+
+    # Process a long prompt on slot 0
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_TEXT,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "n_predict": 16,
+    })
+    assert res.status_code == 200
+    n_prompt_full = res.body["timings"]["prompt_n"]
+    assert n_prompt_full > 0  # all tokens are processed
+
+    # Clone the KV cache of slot 0 into slot 1
+    res = server.make_request("POST", "/slots/0?action=clone_to&target=1")
+    assert res.status_code == 200
+    assert res.body["id_slot"] == 0
+    assert res.body["id_slot_target"] == 1
+    assert res.body["n_cloned"] > 0
+    assert "clone_ms" in res.body["timings"]
+
+    # A short suffix on slot 1 should reuse the cloned prefix:
+    # only the suffix tokens are processed
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_TEXT + " The end.",
+        "id_slot": 1,
+        "cache_prompt": True,
+        "n_predict": 16,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["prompt_n"] < 16  # only the suffix is processed
+    assert res.body["timings"]["prompt_n"] < n_prompt_full
+
+    # The source slot must not be corrupted by the clone:
+    # the same suffix on slot 0 hits the cache too
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_TEXT + " The end.",
+        "id_slot": 0,
+        "cache_prompt": True,
+        "n_predict": 16,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["prompt_n"] < 16
+
+
+def test_slot_clone_to_errors():
+    global server
+    server.start()
+
+    # Process a prompt on slot 0
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_TEXT,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "n_predict": 8,
+    })
+    assert res.status_code == 200
+
+    # Target slot out of range
+    res = server.make_request("POST", "/slots/0?action=clone_to&target=5")
+    assert res.status_code == 400
+    assert res.body["error"]["type"] == "invalid_request_error"
+
+    # Source and target must be different
+    res = server.make_request("POST", "/slots/0?action=clone_to&target=0")
+    assert res.status_code == 400
+    assert res.body["error"]["type"] == "invalid_request_error"
+
+    # Missing target
+    res = server.make_request("POST", "/slots/0?action=clone_to")
+    assert res.status_code == 400
+    assert res.body["error"]["type"] == "invalid_request_error"
+
+
+def test_slot_clone_to_empty_source():
+    global server
+    server.start()
+
+    # Cloning from a slot that never processed a prompt must fail
+    res = server.make_request("POST", "/slots/1?action=clone_to&target=0")
+    assert res.status_code == 400
+    assert res.body["error"]["type"] == "invalid_request_error"

--- a/tools/server/tests/unit/test_slot_clone.py
+++ b/tools/server/tests/unit/test_slot_clone.py
@@ -31,13 +31,25 @@ def test_slot_clone_to():
     assert res.status_code == 200
     n_prompt_full = res.body["timings"]["prompt_n"]
     assert n_prompt_full > 0  # all tokens are processed
+    n_predicted = res.body["tokens_predicted"]
 
-    # Clone the KV cache of slot 0 into slot 1
+    # Occupy slot 1 with a different prompt: cloning must replace its state
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of Germany?",
+        "id_slot": 1,
+        "cache_prompt": True,
+        "n_predict": 8,
+    })
+    assert res.status_code == 200
+
+    # Clone the KV cache of slot 0 into slot 1 (target already occupied)
     res = server.make_request("POST", "/slots/0?action=clone_to&target=1")
     assert res.status_code == 200
     assert res.body["id_slot"] == 0
     assert res.body["id_slot_target"] == 1
-    assert res.body["n_cloned"] > 0
+    # n_cloned is the exact source slot state: prompt + generated tokens,
+    # minus the last sampled token which is returned but not cached in the slot
+    assert res.body["n_cloned"] == n_prompt_full + n_predicted - 1
     assert "clone_ms" in res.body["timings"]
 
     # A short suffix on slot 1 should reuse the cloned prefix:
@@ -101,3 +113,56 @@ def test_slot_clone_to_empty_source():
     res = server.make_request("POST", "/slots/1?action=clone_to&target=0")
     assert res.status_code == 400
     assert res.body["error"]["type"] == "invalid_request_error"
+
+
+def test_slot_clone_to_target_in_body():
+    global server
+    server.start()
+
+    # Process a prompt on slot 0
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_TEXT,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "n_predict": 8,
+    })
+    assert res.status_code == 200
+
+    # target passed in the request body instead of the query string
+    res = server.make_request("POST", "/slots/0?action=clone_to", data={
+        "target": 1,
+    })
+    assert res.status_code == 200
+    assert res.body["id_slot"] == 0
+    assert res.body["id_slot_target"] == 1
+    assert res.body["n_cloned"] > 0
+
+    # The cloned prefix is reused on slot 1
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_TEXT + " The end.",
+        "id_slot": 1,
+        "cache_prompt": True,
+        "n_predict": 8,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["prompt_n"] < 8  # only the suffix is processed
+
+
+def test_slot_clone_to_ctx_shift_not_supported():
+    global server
+    server.enable_ctx_shift = True
+    server.start()
+
+    # Process a prompt on slot 0
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_TEXT,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "n_predict": 8,
+    })
+    assert res.status_code == 200
+
+    # clone_to is rejected with context shift enabled (HTTP 501)
+    res = server.make_request("POST", "/slots/0?action=clone_to&target=1")
+    assert res.status_code == 501
+    assert res.body["error"]["type"] == "not_supported_error"


### PR DESCRIPTION
## Overview

I add an endpoint that copies the KV cache from one slot to another, so multiple parallel requests can start the work from the same shared prefix without repeating the initial prefill step.

I find the existing mechanisms are not enough: --cache-ram only works in sequence, save/restore goes through disk, and copy_state_to is limited. With k=4 simultaneous branches on a cold server the built-in prefix reuse finds nothing to reuse (cache_n = 0 on every branch), because the branches start at the same time.

I work on Apple M3 Max / Metal with gemma-4-26b Q4_K_M, 4 branches and a shared 7,403-token trunk:

- wall time 2.12x faster (42.9 s reduced to 20.2 s with clone_to, against the warmed-up built-in reuse; 1.71x against no cache)
- if I compare with --cache-ram it is 1.70x, from 9.42 s to 5.54 s
- clone_to prefills 25 tokens instead of 7,403 for every branch
- cloning a 3,131-token KV cache takes near 22 ms
- after a clone the branch picks the same top-1 token as a fresh prefill, 24/24 prompts (median logprob delta 1.4e-4, max 0.051, measured on the first-token logits)

## Additional information

Wall time for the same workload (k=4 simultaneous branches, cold server, greedy, fixed seed):

| configuration | wall time | cache_n per branch |
|---|---|---|
| no cache | 34.7 s | 0, 0, 0, 0 |
| built-in prefix reuse | 37.2 s | 0, 0, 0, 0 |
| built-in prefix reuse, warmed up | 42.9 s | — |
| clone_to | 20.2 s | ~7378 (prefill: 25 tokens instead of 7403) |

Known limitations: if a slot has already seen the document, the built-in reuse wins (6.7 s vs 10.5 s): clone_to helps on the first hit, not on revisited prompts. The performance improvement is smaller when the shared prefix is below about 1,000 tokens because of the current SWA checkpoint mechanism. On hybrid SSM models the speedup is lower. Note that --cache-ram is enabled by default (8192 MiB) and shared between slots; the numbers above are identical with it on or off. Also, these numbers come from tests on a single Apple Silicon machine using Metal, so CUDA and CPU results still need to be evaluated.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. I developed this contribution with AI support as part of an agent-based coding and testing workflow. The final implementation, benchmarks and documentation were reviewed and checked by me. All the benchmark results reported here come from controlled experiments. The contribution also includes pytest unit tests and an updated README.
