### PR TITLE
metal : use real threadgroups for conv_transpose_1d

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -602,6 +602,8 @@ typedef struct {
     int32_t  IL;
     int32_t  K;
     int32_t  s0;
+    int32_t  OL;
+    int32_t  OC;
     uint64_t nb0;
     uint64_t nb1;
 } ggml_metal_kargs_conv_transpose_1d;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -3977,6 +3977,8 @@ int ggml_metal_op_conv_transpose_1d(ggml_metal_op_t ctx, int idx) {
         /*.IL  =*/ IL,
         /*.K   =*/ K,
         /*.s0  =*/ s0,
+        /*.OL  =*/ OL,
+        /*.OC  =*/ OC,
         /*.nb0 =*/ nb0,
         /*.nb1 =*/ nb1,
     };
@@ -3989,7 +3991,9 @@ int ggml_metal_op_conv_transpose_1d(ggml_metal_op_t ctx, int idx) {
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
     ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
 
-    ggml_metal_encoder_dispatch_threadgroups(enc, OL, OC, 1, 1, 1, 1);
+    const int nth = std::min(ggml_metal_pipeline_max_theads_per_threadgroup(pipeline), 256);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, (OL + nth - 1)/nth, OC, 1, nth, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -5298,8 +5298,12 @@ typedef void (conv_transpose_1d_t)(
         device const float * src1,
         device        char * dst,
         uint3   tgpig[[threadgroup_position_in_grid]],
-        uint3    tgpg[[threadgroups_per_grid]]);
+        uint3   tpitg[[thread_position_in_threadgroup]],
+        uint3     ntg[[threads_per_threadgroup]]);
 
+// One thread per output element (j, oc), 256-thread threadgroups. The previous
+// dispatch used one-thread threadgroups (31/32 SIMD lanes idle), which made this
+// kernel dispatch-bound on long sequences.
 template <typename T>
 kernel void kernel_conv_transpose_1d(
         constant ggml_metal_kargs_conv_transpose_1d & args,
@@ -5307,17 +5311,23 @@ kernel void kernel_conv_transpose_1d(
         device const float * src1,
         device        char * dst,
         uint3   tgpig[[threadgroup_position_in_grid]],
-        uint3   tgpg[[threadgroups_per_grid]]) {
+        uint3   tpitg[[thread_position_in_threadgroup]],
+        uint3     ntg[[threads_per_threadgroup]]) {
 
     // For output position j on the time axis, only input positions
     //   i such that i*s0 <= j < i*s0 + K
     // contribute -- i.e. i in [ceil((j - K + 1)/s0), floor(j/s0)]
     // intersected with [0, IL-1]. That's at most ceil(K/s0) values
     // (typically 2 for stride==K/2 transposed convs).
-    const int32_t j  = tgpig[0];
+    const int32_t j  = tgpig[0] * ntg[0] + tpitg[0];
+    const int32_t oc = tgpig[1];
     const int32_t s0 = args.s0;
     const int32_t K  = args.K;
     const int32_t IL = args.IL;
+
+    if (j >= args.OL) {
+        return;
+    }
 
     int32_t i_min;
     {
@@ -5329,8 +5339,8 @@ kernel void kernel_conv_transpose_1d(
 
     float v = 0.0f;
     if (i_min <= i_max) {
-        for (int64_t c = 0; c < args.IC; c++) {
-            const int32_t kernel_offset = c * tgpg[1] * K + K * tgpig[1];
+        for (int32_t c = 0; c < args.IC; c++) {
+            const int32_t kernel_offset = (c * args.OC + oc) * K;
             const int32_t input_offset  = c * IL;
 
             for (int32_t i = i_min; i <= i_max; i++) {
@@ -5339,7 +5349,7 @@ kernel void kernel_conv_transpose_1d(
         }
     }
 
-    device float * dst_ptr = (device float *) (dst + tgpig[0] * args.nb0 + tgpig[1] * args.nb1);
+    device float * dst_ptr = (device float *) (dst + j * args.nb0 + oc * args.nb1);
 
     dst_ptr[0] = v;
 }
@@ -5351,7 +5361,8 @@ kernel void kernel_conv_transpose_1d<float>(
     device const float * src1,
     device        char * dst,
     uint3   tgpig[[threadgroup_position_in_grid]],
-    uint3    tgpg[[threadgroups_per_grid]]);
+    uint3   tpitg[[thread_position_in_threadgroup]],
+    uint3     ntg[[threads_per_threadgroup]]);
 
 template [[host_name("kernel_conv_transpose_1d_f16_f32")]]
 kernel void kernel_conv_transpose_1d<half>(
@@ -5360,7 +5371,8 @@ kernel void kernel_conv_transpose_1d<half>(
     device const float * src1,
     device        char * dst,
     uint3   tgpig[[threadgroup_position_in_grid]],
-    uint3    tgpg[[threadgroups_per_grid]]);
+    uint3   tpitg[[thread_position_in_threadgroup]],
+    uint3     ntg[[threads_per_threadgroup]]);
 
 
 template <typename T>


### PR DESCRIPTION
The Metal `conv_transpose_1d` kernel is dispatched as `OL*OC` threadgroups of a **single thread** each, which leaves 31/32 SIMD lanes idle and makes the op dispatch-bound on long sequences. Audio decoders (DAC/VoxCPM-style vocoders) upsample by 8-16x per stage, so `OL` easily reaches tens of thousands of elements — on those workloads this kernel dominated the graph.

This PR dispatches 256-thread threadgroups with one thread per output element and an `OL` bounds check. `OL`/`OC` move into the kernel arguments since the grid no longer encodes them.

### Numbers

M3 Max, single-op graph, CPU-reference parity checked (max abs diff within f16 tolerance), timings include per-process pipeline setup, master `91f8c9c` vs this branch:

| shape | master | PR |
|---|---|---|
| IL=16000 IC=192 OC=96 K=4 s0=2 (f16 w) | 129.5 ms | 49.8 ms |
| IL=3200 IC=384 OC=192 K=10 s0=5 (f16 w) | 200.1 ms | 23.7 ms |
| IL=48000 IC=64 OC=32 K=4 s0=2 (f32 w) | 72.3 ms | 6.6 ms |

`test-backend-ops test -o CONV_TRANSPOSE_1D`: all 117 cases pass on Metal.

Background: an earlier revision of this kernel (before the `i_min`/`i_max` inner-loop fix on master) combined with the 1-thread threadgroups made a VoxCPM.cpp AudioVAE decode run for minutes at 100% GPU and wedge the macOS AGX driver until a cold boot; the occupancy half of that fix is what this PR upstreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)