### PR TITLE
metal : add missing mul_mv f32_f16 kernel instantiations

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -4351,6 +4351,7 @@ kernel void kernel_mul_mv_t_t(
 typedef decltype(kernel_mul_mv_t_t<half, half>) mul_mv_t_t;
 
 template [[host_name("kernel_mul_mv_f32_f32")]]   kernel mul_mv_t_t kernel_mul_mv_t_t<float, float>;
+template [[host_name("kernel_mul_mv_f32_f16")]]   kernel mul_mv_t_t kernel_mul_mv_t_t<float, half>;
 template [[host_name("kernel_mul_mv_f16_f32")]]   kernel mul_mv_t_t kernel_mul_mv_t_t<half,  float>;
 template [[host_name("kernel_mul_mv_f16_f16")]]   kernel mul_mv_t_t kernel_mul_mv_t_t<half,  half>;
 #if defined(GGML_METAL_HAS_BF16)
@@ -4475,6 +4476,7 @@ kernel void kernel_mul_mv_t_t_4(
 typedef decltype(kernel_mul_mv_t_t_4<half, half4, half, half4>) mul_mv_t_t_4;
 
 template [[host_name("kernel_mul_mv_f32_f32_4")]]   kernel mul_mv_t_t_4 kernel_mul_mv_t_t_4<float, float4, float, float4>;
+template [[host_name("kernel_mul_mv_f32_f16_4")]]   kernel mul_mv_t_t_4 kernel_mul_mv_t_t_4<float, float4, half,  half4>;
 template [[host_name("kernel_mul_mv_f16_f32_4")]]   kernel mul_mv_t_t_4 kernel_mul_mv_t_t_4<half,  half4,  float, float4>;
 template [[host_name("kernel_mul_mv_f16_f16_4")]]   kernel mul_mv_t_t_4 kernel_mul_mv_t_t_4<half,  half4,  half,  half4>;
 #if defined(GGML_METAL_HAS_BF16)
@@ -4540,6 +4542,7 @@ kernel void kernel_mul_mv_t_t_short(
 typedef decltype(kernel_mul_mv_t_t_short<half, half>) mul_mv_t_t_short_t;
 
 template [[host_name("kernel_mul_mv_f32_f32_short")]]  kernel mul_mv_t_t_short_t kernel_mul_mv_t_t_short<float, float>;
+template [[host_name("kernel_mul_mv_f32_f16_short")]]  kernel mul_mv_t_t_short_t kernel_mul_mv_t_t_short<float, half>;
 template [[host_name("kernel_mul_mv_f16_f32_short")]]  kernel mul_mv_t_t_short_t kernel_mul_mv_t_t_short<half,  float>;
 template [[host_name("kernel_mul_mv_f16_f16_short")]]  kernel mul_mv_t_t_short_t kernel_mul_mv_t_t_short<half,  half>;
 #if defined(GGML_METAL_HAS_BF16)


### PR DESCRIPTION
`supports_op` accepts `GGML_OP_MUL_MAT` with `src0=F32, src1=F16`, but the mul_mv pipelines for that type combination were never instantiated. Any graph that reaches the mul_mv path with it fails at pipeline creation:

```
ggml_metal_library_compile_pipeline: Error Domain=MTLLibraryErrorDomain Code=5
"Function kernel_mul_mv_f32_f16_4 was not found in the library"
```

and the encoder then dereferences the nil pipeline (crash). Reachable e.g. via `ggml_conv_1d_dw` with F16 weights, whose lowering calls `ggml_mul_mat(im2col_f32, weight_f16)` with the operands inverted relative to the usual weights-first pattern — that is how VoxCPM.cpp's depthwise convolutions hit it.

Minimal reproducer: a single `ggml_mul_mat` node with `a = F32 [64,100]`, `b = F16 [64,1]` on the Metal backend (ne11=1 routes to mul_mv). With this PR the same graph computes correctly (verified against the CPU backend).

Adds the `f32_f16` instantiations to the `mul_mv`, `mul_mv_4` and `mul_mv_short` families, mirroring the existing `f16_f32` ones. `test-backend-ops test -o MUL_MAT` passes on Metal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)