### PR TITLE
metal: fix NaN in mul_mm_id when activations exceed f16 range

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -954,6 +954,40 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv(ggml_meta
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id_amax_part(ggml_metal_library_t lib) {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_mul_mm_id_amax_part_f32");
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    res.smem = 32*sizeof(float);
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id_amax(ggml_metal_library_t lib) {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_mul_mm_id_amax_f32");
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    res.smem = 32*sizeof(float);
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id_map0(ggml_metal_library_t lib, int ne02, int ne20) {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -134,6 +134,8 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_ex
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm            (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv            (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id_map0    (ggml_metal_library_t lib, int ne02, int ne20);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id_amax(ggml_metal_library_t lib);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id_amax_part(ggml_metal_library_t lib);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id         (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_id         (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argmax            (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -14,6 +14,8 @@
 #define N_MM_SIMD_GROUP_X 2
 #define N_MM_SIMD_GROUP_Y 2
 
+#define N_MM_NPART_AMAX 256
+
 // kernel parameters for mat-vec threadgroups
 //
 // N_R0: number of src0 rows to process per simdgroup

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -509,6 +509,14 @@ typedef struct {
 
 typedef struct {
     int32_t  ne00;
+    int32_t  ne01;
+    int32_t  ne02;
+    uint64_t nb01;
+    uint64_t nb02;
+} ggml_metal_kargs_mul_mm_id_amax;
+
+typedef struct {
+    int32_t  ne00;
     int32_t  ne02;
     uint64_t nb01;
     uint64_t nb02;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2437,17 +2437,6 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
             ggml_metal_encoder_dispatch_threadgroups(enc, N_MM_NPART_AMAX, 1, 1, 256, 1, 1);
         }
 
-        ggml_metal_op_concurrency_reset(ctx);
-
-        {
-            auto pipeline = ggml_metal_library_get_pipeline_mul_mm_id_amax(lib);
-
-            ggml_metal_encoder_set_pipeline(enc, pipeline);
-            ggml_metal_encoder_set_buffer  (enc, bid_amax, 0);
-
-            ggml_metal_encoder_dispatch_threadgroups(enc, 1, 1, 1, 32, 1, 1);
-        }
-
         {
             ggml_metal_kargs_mul_mm_id_map0 args = {
                 ne02,
@@ -2479,7 +2468,18 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
             ggml_metal_encoder_dispatch_threadgroups(enc, 1, 1, 1, ne02, 1, 1);
         }
 
-        // this barrier is always needed because the next kernel has to wait for the id maps to be computed
+        ggml_metal_op_concurrency_reset(ctx);
+
+        {
+            auto pipeline = ggml_metal_library_get_pipeline_mul_mm_id_amax(lib);
+
+            ggml_metal_encoder_set_pipeline(enc, pipeline);
+            ggml_metal_encoder_set_buffer  (enc, bid_amax, 0);
+
+            ggml_metal_encoder_dispatch_threadgroups(enc, 1, 1, 1, 32, 1, 1);
+        }
+
+        // the next kernel has to wait for the amax data
         ggml_metal_op_concurrency_reset(ctx);
 
         {

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2341,6 +2341,17 @@ size_t ggml_metal_op_mul_mat_id_extra_ids(const ggml_tensor * op) {
     return ggml_type_size(GGML_TYPE_I32)*ne02*ne21;
 }
 
+size_t ggml_metal_op_mul_mat_id_extra_amax(const ggml_tensor * op) {
+    assert(op->op == GGML_OP_MUL_MAT_ID);
+
+    GGML_UNUSED(op);
+
+    // 16 bytes for the factor pair (inverse scale applied to src1 on
+    // load, scale applied to the f32 accumulator on store), then one
+    // float per stage-1 partial.
+    return 16 + 256*sizeof(float);
+}
+
 int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
@@ -2397,6 +2408,48 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
 
         ggml_metal_buffer_id bid_ids = bid_tpe;
         bid_ids.offs += ggml_metal_op_mul_mat_id_extra_tpe(op);
+
+        ggml_metal_buffer_id bid_amax = bid_ids;
+        bid_amax.offs += ggml_metal_op_mul_mat_id_extra_ids(op);
+
+        // src1 rescale factors, computed before the matmul so the
+        // narrowing to the half MMA operands cannot overflow. See
+        // kernel_mul_mm_id_amax_f32.
+        {
+            ggml_metal_kargs_mul_mm_id_amax args = {
+                /*.ne00 =*/ ne10,
+                /*.ne01 =*/ ne11,
+                /*.ne02 =*/ ne12,
+                /*.nb01 =*/ nb11,
+                /*.nb02 =*/ nb12,
+            };
+
+            auto pipeline = ggml_metal_library_get_pipeline_mul_mm_id_amax_part(lib);
+
+            const size_t smem = pipeline.smem;
+
+            GGML_ASSERT(smem <= props_dev->max_theadgroup_memory_size);
+
+            ggml_metal_encoder_set_pipeline(enc, pipeline);
+            ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+            ggml_metal_encoder_set_buffer  (enc, bid_src1, 1);
+            ggml_metal_encoder_set_buffer  (enc, bid_amax, 2);
+
+            ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
+
+            ggml_metal_encoder_dispatch_threadgroups(enc, 256, 1, 1, 256, 1, 1);
+        }
+
+        ggml_metal_op_concurrency_reset(ctx);
+
+        {
+            auto pipeline = ggml_metal_library_get_pipeline_mul_mm_id_amax(lib);
+
+            ggml_metal_encoder_set_pipeline(enc, pipeline);
+            ggml_metal_encoder_set_buffer  (enc, bid_amax, 0);
+
+            ggml_metal_encoder_dispatch_threadgroups(enc, 1, 1, 1, 32, 1, 1);
+        }
 
         {
             ggml_metal_kargs_mul_mm_id_map0 args = {
@@ -2461,6 +2514,7 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
             ggml_metal_encoder_set_buffer  (enc, bid_tpe,  3);
             ggml_metal_encoder_set_buffer  (enc, bid_ids,  4);
             ggml_metal_encoder_set_buffer  (enc, bid_dst,  5);
+            ggml_metal_encoder_set_buffer  (enc, bid_amax, 6);
 
             const size_t smem = pipeline.smem;
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2346,10 +2346,8 @@ size_t ggml_metal_op_mul_mat_id_extra_amax(const ggml_tensor * op) {
 
     GGML_UNUSED(op);
 
-    // 16 bytes for the factor pair (inverse scale applied to src1 on
-    // load, scale applied to the f32 accumulator on store), then one
-    // float per stage-1 partial.
-    return 16 + 256*sizeof(float);
+    // 2 scaling factors (8 bytes) + N_MM_NPART_AMAX per-threadgroup scales for stage-1
+    return 8 + N_MM_NPART_AMAX*sizeof(float);
 }
 
 int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
@@ -2412,9 +2410,8 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
         ggml_metal_buffer_id bid_amax = bid_ids;
         bid_amax.offs += ggml_metal_op_mul_mat_id_extra_ids(op);
 
-        // src1 rescale factors, computed before the matmul so the
-        // narrowing to the half MMA operands cannot overflow. See
-        // kernel_mul_mm_id_amax_f32.
+        // src1 rescale factors, computed before the matmul
+        // ref: https://github.com/ggml-org/llama.cpp/pull/26223
         {
             ggml_metal_kargs_mul_mm_id_amax args = {
                 /*.ne00 =*/ ne10,
@@ -2437,7 +2434,7 @@ int ggml_metal_op_mul_mat_id(ggml_metal_op_t ctx, int idx) {
 
             ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
 
-            ggml_metal_encoder_dispatch_threadgroups(enc, 256, 1, 1, 256, 1, 1);
+            ggml_metal_encoder_dispatch_threadgroups(enc, N_MM_NPART_AMAX, 1, 1, 256, 1, 1);
         }
 
         ggml_metal_op_concurrency_reset(ctx);

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -35,6 +35,7 @@ size_t ggml_metal_op_mul_mat_id_extra_tpe(const struct ggml_tensor * op);
 
 // id map [n_tokens, n_expert]
 size_t ggml_metal_op_mul_mat_id_extra_ids(const struct ggml_tensor * op);
+size_t ggml_metal_op_mul_mat_id_extra_amax(const struct ggml_tensor * op);
 
 // return true if we should use the FA vector kernel for this op
 bool ggml_metal_op_flash_attn_ext_use_vec(const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -219,6 +219,7 @@ static size_t ggml_backend_metal_buffer_type_get_alloc_size(ggml_backend_buffer_
             {
                 res += ggml_metal_op_mul_mat_id_extra_tpe(tensor);
                 res += ggml_metal_op_mul_mat_id_extra_ids(tensor);
+                res += ggml_metal_op_mul_mat_id_extra_amax(tensor);
             } break;
         case GGML_OP_FLASH_ATTN_EXT:
             {

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -10420,27 +10420,6 @@ kernel void kernel_mul_mm_id_map0(
     tpe_u32[ide] = n_all;
 }
 
-// Compute max(|x|) over src1 and derive a power-of-two scale that
-// brings the activations inside f16 range.
-//
-// kernel_mul_mm_id narrows src1 to `half` for the simdgroup MMA
-// operands. f16 saturates at 65504, so a model whose activations exceed
-// that yields inf, and simdgroup_multiply_accumulate then poisons the
-// whole accumulator tile with NaN. Scaling src1 down by a power of two
-// on load and scaling the f32 accumulator back up on store is exact —
-// powers of two are exact in binary floating point and the dot product
-// is linear, so a single tensor-wide factor introduces no error at all.
-//
-// When amax fits already (the overwhelmingly common case) the factor is
-// 1.0 and the result is bit-identical to not doing this.
-//
-// Two stages so the pass stays bandwidth-bound rather than serialized
-// on one threadgroup: stage 1 reduces rows across GGML_METAL_AMAX_NPART
-// threadgroups into partials, stage 2 folds the partials and writes the
-// factor pair.
-
-#define GGML_METAL_AMAX_NPART 256
-
 kernel void kernel_mul_mm_id_amax_part_f32(
         constant ggml_metal_kargs_mul_mm_id_amax & args,
         device   const char * src1,
@@ -10455,7 +10434,7 @@ kernel void kernel_mul_mm_id_amax_part_f32(
 
     float lmax = 0.0f;
 
-    for (int ir = tgpig; ir < nrow; ir += GGML_METAL_AMAX_NPART) {
+    for (int ir = tgpig; ir < nrow; ir += N_MM_NPART_AMAX) {
         const int i01 = ir % args.ne01;
         const int i02 = ir / args.ne01;
 
@@ -10486,30 +10465,29 @@ kernel void kernel_mul_mm_id_amax_part_f32(
     }
 
     if (tiitg == 0) {
-        // partials live after the two-float factor pair
-        ((device float *) (dst + 16))[tgpig] = amax;
+        ((device float *) (dst + 8))[tgpig] = amax;
     }
 }
 
 kernel void kernel_mul_mm_id_amax_f32(
         device char * dst,
         ushort tiitg[[thread_index_in_threadgroup]]) {
-    device const float * part = (device const float *) (dst + 16);
+    device const float * part = (device const float *) (dst + 8);
 
     float amax = 0.0f;
 
-    for (int i = tiitg; i < GGML_METAL_AMAX_NPART; i += N_SIMDWIDTH) {
+    for (int i = tiitg; i < N_MM_NPART_AMAX; i += N_SIMDWIDTH) {
         amax = max(amax, part[i]);
     }
 
     amax = simd_max(amax);
 
     if (tiitg == 0) {
-        // Leave a comfortable margin below the f16 max of 65504: the
-        // products feeding the accumulator stay in f32, so only the
-        // operand itself has to fit.
+        // leave a comfortable margin below the f16 max of 65504
         float scale = 1.0f;
 
+        // isfinite: src1 already inf/nan is not ours to fix - keep the
+        // scale at 1.0 instead of turning it into a different failure
         if (isfinite(amax) && amax > 32768.0f) {
             scale = exp2(ceil(log2(amax)) - 15.0f);
         }
@@ -10609,9 +10587,7 @@ kernel void kernel_mul_mm_id(
     S0_8x8 ma[4];
     S1_8x8 mb[2];
 
-    // Power-of-two rescale so activations outside f16 range survive the
-    // narrowing to the `half` MMA operands. Both factors are exactly 1.0
-    // unless src1 needed it, in which case they are exact powers of two.
+    // power-of-two rescaling
     const float s1_inv   = ((device const float *) amax)[0];
     const float s1_scale = ((device const float *) amax)[1];
 

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -10420,6 +10420,107 @@ kernel void kernel_mul_mm_id_map0(
     tpe_u32[ide] = n_all;
 }
 
+// Compute max(|x|) over src1 and derive a power-of-two scale that
+// brings the activations inside f16 range.
+//
+// kernel_mul_mm_id narrows src1 to `half` for the simdgroup MMA
+// operands. f16 saturates at 65504, so a model whose activations exceed
+// that yields inf, and simdgroup_multiply_accumulate then poisons the
+// whole accumulator tile with NaN. Scaling src1 down by a power of two
+// on load and scaling the f32 accumulator back up on store is exact —
+// powers of two are exact in binary floating point and the dot product
+// is linear, so a single tensor-wide factor introduces no error at all.
+//
+// When amax fits already (the overwhelmingly common case) the factor is
+// 1.0 and the result is bit-identical to not doing this.
+//
+// Two stages so the pass stays bandwidth-bound rather than serialized
+// on one threadgroup: stage 1 reduces rows across GGML_METAL_AMAX_NPART
+// threadgroups into partials, stage 2 folds the partials and writes the
+// factor pair.
+
+#define GGML_METAL_AMAX_NPART 256
+
+kernel void kernel_mul_mm_id_amax_part_f32(
+        constant ggml_metal_kargs_mul_mm_id_amax & args,
+        device   const char * src1,
+        device         char * dst,
+        threadgroup    char * shmem [[threadgroup(0)]],
+        uint  tgpig[[threadgroup_position_in_grid]],
+        ushort tiitg[[thread_index_in_threadgroup]],
+        ushort tiisg[[thread_index_in_simdgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]],
+        ushort   ntg[[threads_per_threadgroup]]) {
+    const int nrow = args.ne01*args.ne02;
+
+    float lmax = 0.0f;
+
+    for (int ir = tgpig; ir < nrow; ir += GGML_METAL_AMAX_NPART) {
+        const int i01 = ir % args.ne01;
+        const int i02 = ir / args.ne01;
+
+        device const float * row = (device const float *) (src1 + i02*args.nb02 + i01*args.nb01);
+
+        for (int i00 = tiitg; i00 < args.ne00; i00 += ntg) {
+            lmax = max(lmax, fabs(row[i00]));
+        }
+    }
+
+    float amax = simd_max(lmax);
+
+    threadgroup float * shared_amax = (threadgroup float *) shmem;
+
+    if (ntg > N_SIMDWIDTH) {
+        if (sgitg == 0) {
+            shared_amax[tiisg] = 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiisg == 0) {
+            shared_amax[sgitg] = amax;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        amax = shared_amax[tiisg];
+        amax = simd_max(amax);
+    }
+
+    if (tiitg == 0) {
+        // partials live after the two-float factor pair
+        ((device float *) (dst + 16))[tgpig] = amax;
+    }
+}
+
+kernel void kernel_mul_mm_id_amax_f32(
+        device char * dst,
+        ushort tiitg[[thread_index_in_threadgroup]]) {
+    device const float * part = (device const float *) (dst + 16);
+
+    float amax = 0.0f;
+
+    for (int i = tiitg; i < GGML_METAL_AMAX_NPART; i += N_SIMDWIDTH) {
+        amax = max(amax, part[i]);
+    }
+
+    amax = simd_max(amax);
+
+    if (tiitg == 0) {
+        // Leave a comfortable margin below the f16 max of 65504: the
+        // products feeding the accumulator stay in f32, so only the
+        // operand itself has to fit.
+        float scale = 1.0f;
+
+        if (isfinite(amax) && amax > 32768.0f) {
+            scale = exp2(ceil(log2(amax)) - 15.0f);
+        }
+
+        device float * d = (device float *) dst;
+
+        d[0] = 1.0f/scale; // exact: scale is a power of two
+        d[1] = scale;
+    }
+}
+
 typedef decltype(kernel_mul_mm_id_map0<1>) kernel_mul_mm_id_map0_t;
 
 template [[host_name("kernel_mul_mm_id_map0_ne20_1" )]] kernel kernel_mul_mm_id_map0_t kernel_mul_mm_id_map0<1>;
@@ -10440,6 +10541,7 @@ kernel void kernel_mul_mm_id(
         device const char * htpe,
         device const char * hids,
         device       char * dst,
+        device const char * amax,
         threadgroup  char * shmem [[threadgroup(0)]],
         uint3  tgpig[[threadgroup_position_in_grid]],
         ushort tiitg[[thread_index_in_threadgroup]],
@@ -10506,6 +10608,12 @@ kernel void kernel_mul_mm_id(
 #ifndef GGML_METAL_HAS_TENSOR
     S0_8x8 ma[4];
     S1_8x8 mb[2];
+
+    // Power-of-two rescale so activations outside f16 range survive the
+    // narrowing to the `half` MMA operands. Both factors are exactly 1.0
+    // unless src1 needed it, in which case they are exact powers of two.
+    const float s1_inv   = ((device const float *) amax)[0];
+    const float s1_scale = ((device const float *) amax)[1];
 
     simdgroup_float8x8 mc[8];
 
@@ -10579,7 +10687,7 @@ kernel void kernel_mul_mm_id(
 
                 const short ib = 4*sx + sy;
 
-                *(sb + 64*ib + 8*ly + lx) = loop_k + iy + i < args.ne00 ? (S1) *((device T1 *) y + i) : 0;
+                *(sb + 64*ib + 8*ly + lx) = loop_k + iy + i < args.ne00 ? (S1) (*((device T1 *) y + i) * (T1) s1_inv) : 0;
             }
         } else {
             const short sx = (tiitg%NL1);
@@ -10592,7 +10700,7 @@ kernel void kernel_mul_mm_id(
 
             const short ib = 4*sx + sy;
 
-            *(threadgroup S1_2x4 *)(sb + 64*ib + 8*ly) = (S1_2x4)(*((device T1_2x4 *) y));
+            *(threadgroup S1_2x4 *)(sb + 64*ib + 8*ly) = (S1_2x4)((*((device T1_2x4 *) y)) * (T1) s1_inv);
         }
 #else
         // load data and store to threadgroup memory
@@ -10640,7 +10748,7 @@ kernel void kernel_mul_mm_id(
                 //const short lx = (tiitg/NL1)%8;
                 //const short ly = i;
 
-                *(sb + NK*(8*sy + ly) + 8*sx + lx) = loop_k + iy + i < args.ne00 ? (S1) *((device T1 *) y + i) : 0;
+                *(sb + NK*(8*sy + ly) + 8*sx + lx) = loop_k + iy + i < args.ne00 ? (S1) (*((device T1 *) y + i) * (T1) s1_inv) : 0;
             }
         } else {
             const short sx = (tiitg%NL1);
@@ -10651,7 +10759,7 @@ kernel void kernel_mul_mm_id(
             //const short lx = (tiitg/NL1)%8;
             //const short ly = i;
 
-            *(threadgroup S1_2x4 *)(sb + NK*(8*sy + ly) + 8*sx) = (S1_2x4)(*((device T1_2x4 *) y));
+            *(threadgroup S1_2x4 *)(sb + NK*(8*sy + ly) + 8*sx) = (S1_2x4)((*((device T1_2x4 *) y)) * (T1) s1_inv);
         }
 #endif
 
@@ -10727,12 +10835,12 @@ kernel void kernel_mul_mm_id(
 
         int i = tiisg;
         for (; i < nr0/4; i += 32) {
-            *(D4 + i) = *(C4 + i);
+            *(D4 + i) = *(C4 + i) * s1_scale;
         }
 
         i = (4*(nr0/4)) + tiisg;
         for (; i < nr0; i += 32) {
-            *(D + i) = *(C + i);
+            *(D + i) = *(C + i) * s1_scale;
         }
     }
 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4404,7 +4404,7 @@ struct test_mul_mat_hadamard : public test_mul_mat {
     }
 };
 
-static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
+static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, float amax = 1.0f) {
     std::random_device rd;
     std::default_random_engine rng(rd());
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
@@ -4419,6 +4419,10 @@ static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
                 std::shuffle(data.begin(), data.end(), rng);
                 ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
             }
+        } else if (amax != 1.0f && t->type == GGML_TYPE_F32) {
+            // src1 (activations) only — the weights stay in their normal
+            // range so this isolates activation magnitude.
+            init_tensor_uniform(t, -amax, amax);
         } else {
             init_tensor_uniform(t);
         }
@@ -4435,9 +4439,16 @@ struct test_mul_mat_id : public test_case {
     const int64_t m;
     const int64_t n;
     const int64_t k;
+    // Magnitude of the src1 activations. Default 1.0f reproduces the
+    // historical uniform [-1, 1] init. Larger values exercise backends
+    // that narrow the activations to a lower-range type internally:
+    // Metal's mul_mm_id feeds simdgroup_half8x8, and f16 saturates at
+    // 65504, so real models whose activations exceed that produce inf
+    // and then NaN on that path while the mul_mv_id path is correct.
+    const float amax;
 
     std::string vars() override {
-        return VARS_TO_STR8(type_a, type_b, n_mats, n_used, b, m, n, k);
+        return VARS_TO_STR9(type_a, type_b, n_mats, n_used, b, m, n, k, amax);
     }
 
     double max_nmse_err() override {
@@ -4459,9 +4470,10 @@ struct test_mul_mat_id : public test_case {
 
     test_mul_mat_id(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
             int n_mats = 8, int n_used = 2, bool b = false,
-            int64_t m = 32, int64_t n = 32, int64_t k = 32)
+            int64_t m = 32, int64_t n = 32, int64_t k = 32,
+            float amax = 1.0f)
         : type_a(type_a), type_b(type_b), n_mats(n_mats), n_used(n_used), b(b),
-            m(m), n(n), k(k) {
+            m(m), n(n), k(k), amax(amax) {
             GGML_ASSERT(n_used <= n_mats);
         }
 
@@ -4487,7 +4499,7 @@ struct test_mul_mat_id : public test_case {
     }
 
     void initialize_tensors(ggml_context * ctx) override {
-        init_mul_mat_id_tensors(ctx, n_mats);
+        init_mul_mat_id_tensors(ctx, n_mats, amax);
     }
 };
 
@@ -9028,6 +9040,22 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     for (ggml_type type_a : all_types) {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 16, 3*ggml_blck_size(type_a)));
+    }
+
+    // Activations outside f16 range. Backends that narrow src1 to a
+    // half-precision type for a matrix-multiply path (Metal's
+    // mul_mm_id feeds simdgroup_half8x8) saturate at 65504 and produce
+    // inf, then NaN — while the vector path on the same backend, and
+    // every CPU path, are correct. Real models hit this: Mistral
+    // Small 4 (arch mistral4, 128 experts / 4 active) has a layer whose
+    // ffn activations reach ~1e5, so on Metal every prefill of >= 32
+    // tokens returns an all-NaN vocabulary, and fewer than 32 tokens is
+    // correct (ne21_mm_id_min switches mul_mv_id -> mul_mm_id at 32).
+    // n = 32 and 64 sit above that switch; n = 16 below it is the
+    // control that must stay green.
+    for (int n : {16, 32, 64}) {
+        test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q4_K, GGML_TYPE_F32, 128, 4, false, 4096, n, 2048, 1e5f));
+        test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 8,   2, false, 512,  n, 256,  1e5f));
     }
 
     for (ggml_type type_a : base_types) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4420,8 +4420,6 @@ static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, float amax =
                 ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
             }
         } else if (amax != 1.0f && t->type == GGML_TYPE_F32) {
-            // src1 (activations) only — the weights stay in their normal
-            // range so this isolates activation magnitude.
             init_tensor_uniform(t, -amax, amax);
         } else {
             init_tensor_uniform(t);
@@ -4439,13 +4437,7 @@ struct test_mul_mat_id : public test_case {
     const int64_t m;
     const int64_t n;
     const int64_t k;
-    // Magnitude of the src1 activations. Default 1.0f reproduces the
-    // historical uniform [-1, 1] init. Larger values exercise backends
-    // that narrow the activations to a lower-range type internally:
-    // Metal's mul_mm_id feeds simdgroup_half8x8, and f16 saturates at
-    // 65504, so real models whose activations exceed that produce inf
-    // and then NaN on that path while the mul_mv_id path is correct.
-    const float amax;
+    const float amax; // magnitude of src1
 
     std::string vars() override {
         return VARS_TO_STR9(type_a, type_b, n_mats, n_used, b, m, n, k, amax);
@@ -9042,17 +9034,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 16, 3*ggml_blck_size(type_a)));
     }
 
-    // Activations outside f16 range. Backends that narrow src1 to a
-    // half-precision type for a matrix-multiply path (Metal's
-    // mul_mm_id feeds simdgroup_half8x8) saturate at 65504 and produce
-    // inf, then NaN — while the vector path on the same backend, and
-    // every CPU path, are correct. Real models hit this: Mistral
-    // Small 4 (arch mistral4, 128 experts / 4 active) has a layer whose
-    // ffn activations reach ~1e5, so on Metal every prefill of >= 32
-    // tokens returns an all-NaN vocabulary, and fewer than 32 tokens is
-    // correct (ne21_mm_id_min switches mul_mv_id -> mul_mm_id at 32).
-    // n = 32 and 64 sit above that switch; n = 16 below it is the
-    // control that must stay green.
+    // test src1 f16 overflow
     for (int n : {16, 32, 64}) {
         test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q4_K, GGML_TYPE_F32, 128, 4, false, 4096, n, 2048, 1e5f));
         test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 8,   2, false, 512,  n, 256,  1e5f));


### PR DESCRIPTION
Fixes an all-NaN output from `mul_mm_id` on Metal when a model's activations exceed f16 range. Likely fixes #25722; #20668 may be the same defect attributed to a bad GGUF.

## The bug

`kernel_mul_mm_id` narrows src1 to `half` for the simdgroup MMA operands — `S1 = half` in every instantiation. f16 saturates at 65504, so activations above that become `inf` on load, and `simdgroup_multiply_accumulate` then propagates NaN across the entire 8x8 accumulator tile. The output is not degraded, it is **entirely NaN**.

The conversion sites are `ggml-metal.metal` in `kernel_mul_mm_id`:

```cpp
*(sb + 64*ib + 8*ly + lx) = loop_k + iy + i < args.ne00 ? (S1) *((device T1 *) y + i) : 0;
*(threadgroup S1_2x4 *)(sb + 64*ib + 8*ly) = (S1_2x4)(*((device T1_2x4 *) y));
```

(plus the two mirrors in the `GGML_METAL_HAS_TENSOR` path)

Because the `mul_mv_id` path taken below `ne21_mm_id_min` (32) keeps the same values in f32, **the same model produces correct logits for short prompts and NaN for long ones**, with the switch at exactly 32 tokens. Accumulation was already f32 and was never the problem — only the operand narrowing.

## Reproducer

The first commit adds one. This class of bug was previously untestable: `init_mul_mat_id_tensors` initializes uniform `[-1, 1]`, so no existing case can drive an operand out of f16 range. `test_mul_mat_id` gains an `amax` parameter (default `1.0f`, preserving the historical init exactly) that scales only the f32 activations, leaving quantized weights in their normal range.

Six cases, two shapes — `n=16` is the control on the `mul_mv_id` path and must stay green; `n=32`/`n=64` are above the switch:

```
MUL_MAT_ID(type_a=q8_0,type_b=f32,n_mats=8,n_used=2,b=0,m=512,n=32,k=256,amax=100000.000000):
  [MUL_MAT_ID] NaN at index 0 (MTL0=nan CPU=583442.375000) FAIL
```

It reproduces at minimal size (8 experts, 2 active, 512x256), so this is not specific to any model or geometry.

## The fix

Rescale src1 by a power of two so it fits, and undo the scale on the f32 accumulator at the store. A two-stage reduction computes `max(|src1|)` and writes `(1/scale, scale)` into scratch chained off the destination buffer, in the same style as the existing `tpe`/`ids` id-mapping scratch.

This is **exact, not approximate**, for two reasons: the dot product is linear, so one tensor-wide factor commutes through the accumulation; and the factor is a power of two, so both multiplications are exact in binary floating point. When `max(|src1|)` already fits — every model that works today — the factor is exactly `1.0` and **the output is bit-identical to before**.

The reduction is two-stage (256 threadgroups into partials, then one threadgroup folding them) specifically so it stays bandwidth-bound; a single-threadgroup version was measured first and cost up to **+451%** on prefill. It is dispatched only on the mm path, so decode never pays for it.

## Performance

Apple M2 Max, `test-backend-ops perf -o MUL_MAT_ID -b MTL0`, 99 cases, against the same build without this change:

| n | path | median |
|---|---|---|
| 1 / 4 / 8 | `mul_mv_id` (decode) | -0.76% / -0.84% / -0.39% (noise) |
| 32 | `mul_mm_id` (prefill) | +1.73% |
| 64 | | +1.30% |
| 128 | | +1.80% |
| 256 | | +3.98% |
| 512 | | +3.74% (worst case +7.20%) |
| **overall** | | **+1.14%** |

## Validation

- the six new cases go from 4 FAIL / 2 OK to all OK, `n=16` controls unchanged
- `test-backend-ops -b MTL0` full run: **0 failures**, no regression
- Mistral-Small-4-119B (arch `mistral4`, 128 experts / 4 active) generates correctly at the default `n_ubatch` of 512 in both `UD-IQ3_S` and `UD-Q4_K_XL`. Before this, every prefill of >=32 tokens returned an all-NaN vocabulary, and only `n_ubatch <= 31` — forcing the `mul_mv_id` path — worked.

## Not covered

- `kernel_mul_mm` (dense) has the identical narrowing at the corresponding load sites and is expected to fail the same way. Left alone here to keep this reviewable; happy to extend if you'd prefer one change.
- The scale could be per output column rather than per tensor, which would preserve more precision when a single token is the hot one. Not needed for the bug.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->

This bug was found, diagnosed, reproduced and fixed by **Claude Opus 5 (via Claude Code)**, working from a real-model failure. I reviewed and understand the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
