### PR TITLE
mtmd: bound InternVL preproc_max_tiles read from GGUF

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1353,6 +1353,13 @@ struct clip_model_loader {
                         get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
                         get_u32(KEY_PREPROC_MIN_TILES, hparams.preproc_min_tiles, false);
                         get_u32(KEY_PREPROC_MAX_TILES, hparams.preproc_max_tiles, false);
+                        // bound the untrusted GGUF value: set_internvl_dhr_res_candidates() grows a vector by ~O(n log n) in it (real configs use a handful of tiles, default 12)
+                        constexpr int32_t PREPROC_MAX_TILES_LIMIT = 1024;
+                        if (hparams.preproc_max_tiles > PREPROC_MAX_TILES_LIMIT) {
+                            throw std::runtime_error(string_format(
+                                "%s: clip.vision.preproc_max_tiles (%d) exceeds the maximum supported value (%d)\n",
+                                __func__, hparams.preproc_max_tiles, PREPROC_MAX_TILES_LIMIT));
+                        }
                         GGML_ASSERT(hparams.preproc_min_tiles <= hparams.preproc_max_tiles && hparams.preproc_max_tiles < INT32_MAX);
                         set_internvl_dhr_res_candidates(model);
                     } break;


### PR DESCRIPTION
### What

The `PROJECTOR_TYPE_INTERNVL` branch of `clip_model_loader::load_hparams()` (`tools/mtmd/clip.cpp`) reads `clip.vision.preproc_max_tiles` straight from the vision-projector GGUF and validates it only against `INT32_MAX`:

```cpp
get_u32(KEY_PREPROC_MAX_TILES, hparams.preproc_max_tiles, false);
GGML_ASSERT(hparams.preproc_min_tiles <= hparams.preproc_max_tiles && hparams.preproc_max_tiles < INT32_MAX);
set_internvl_dhr_res_candidates(model);
```

`set_internvl_dhr_res_candidates()` then runs a nested loop whose `std::vector::push_back` count grows on the order of `max_tiles * log(max_tiles)`. A crafted `--mmproj` file with e.g. `preproc_max_tiles = 200000000` therefore drives an unbounded allocation and the loading process is OOM-killed (or hangs without a memory limit) at model-load time — before any image, prompt, or LLM weight is processed. It affects anything that loads a vision projector this way (`llama-mtmd-cli --mmproj`, `llama-server --mmproj`, embedders of `libmtmd`).

Real InternVL configs use single/low-double-digit tile counts (the hardcoded default here is 12), so this is purely a missing upper bound on an untrusted field.

### Fix

Reject `preproc_max_tiles` above a generous sane ceiling (1024) with a normal `std::runtime_error` — consistent with the other validation throws in this loader, and caught by `clip_init`'s existing `try/catch` — instead of trusting the file up to `INT32_MAX`. Legitimate models are unaffected; the existing `min <= max < INT32_MAX` assert is retained.

### Reproduction (before this patch)

Craft a ~640-byte GGUF with `projector_type = "internvl"` and `clip.vision.preproc_max_tiles = 200000000`, then load it as an mmproj file. The process RSS climbs by gigabytes/second inside `load_hparams()` and is OOM-killed in ~1-2s (with a memory cgroup) or exhausts host memory otherwise. With this patch the load fails cleanly with `clip.vision.preproc_max_tiles (200000000) exceeds the maximum supported value (1024)`.