### PR TITLE
chat : tolerate dropped tool-call wrapper in tag-based formats

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -105,6 +105,20 @@ common_chat_params peg_generator::generate_parser(const common_chat_template &  
             data.grammar_triggers = {
                 { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, trigger_marker }
             };
+            // A dropped wrapper can still leave a well-formed call starting at per_call_start
+            // or function.name_prefix (see build_tool_parser_tag_tagged). Trigger on both too,
+            // when distinct, so sampling still gets grammar-constrained in that case.
+            if (!autoparser.tools.format.per_call_start.empty() &&
+                autoparser.tools.format.per_call_start != trigger_marker) {
+                data.grammar_triggers.push_back(
+                    { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, autoparser.tools.format.per_call_start });
+            }
+            if (!autoparser.tools.function.name_prefix.empty() &&
+                autoparser.tools.function.name_prefix != trigger_marker &&
+                autoparser.tools.function.name_prefix != autoparser.tools.format.per_call_start) {
+                data.grammar_triggers.push_back(
+                    { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, autoparser.tools.function.name_prefix });
+            }
             if (autoparser.tools.format.openai_wrapper_trigger) {
                 // model emits the OpenAI function wrapper, trigger on it
                 data.grammar_triggers.push_back({ COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "{\"type\": \"function\"," });
@@ -345,7 +359,13 @@ common_peg_parser analyze_tools::build_tool_parser_tag_json(parser_build_context
     common_peg_parser tool_calls = p.eps();
 
     if (!format.per_call_start.empty()) {
-        auto wrapped_call = format.per_call_start + tool_choice + format.per_call_end;
+        // See the equivalent handling in build_tool_parser_tag_tagged below for the full
+        // reasoning: both the per-call marker and the outer section wrapper (further down)
+        // can be dropped by the model independently, so make each optional rather than
+        // mandatory - the function tag itself (inside tool_choice) stays mandatory.
+        auto call_open    = p.optional(p.literal(format.per_call_start));
+        auto call_close   = format.per_call_end.empty() ? p.eps() : p.optional(p.literal(format.per_call_end));
+        auto wrapped_call = call_open + tool_choice + call_close;
         if (inputs.parallel_tool_calls) {
             tool_calls = p.trigger_rule("tool-call", wrapped_call + p.zero_or_more(p.space() + wrapped_call));
         } else {
@@ -353,8 +373,8 @@ common_peg_parser analyze_tools::build_tool_parser_tag_json(parser_build_context
         }
         if (!format.section_start.empty()) {
             tool_calls = p.trigger_rule("tool-calls",
-                                        p.literal(format.section_start) + p.space() + tool_calls + p.space() +
-                                            (format.section_end.empty() ? p.end() : p.literal(format.section_end)));
+                                        p.optional(p.literal(format.section_start)) + p.space() + tool_calls + p.space() +
+                                            (format.section_end.empty() ? p.end() : p.optional(p.literal(format.section_end))));
         }
     } else {
         std::string separator = ", ";  // Default
@@ -370,8 +390,18 @@ common_peg_parser analyze_tools::build_tool_parser_tag_json(parser_build_context
         tool_calls = p.optional(tool_calls);
     }
 
-    std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
-    auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
+    // See the equivalent content_before_tools handling in build_tool_parser_tag_tagged below:
+    // only widen the scan past section_start when section_start itself is empty.
+    std::vector<std::string> content_stop_markers;
+    if (!format.section_start.empty()) {
+        content_stop_markers.push_back(format.section_start);
+    } else if (!format.per_call_start.empty()) {
+        content_stop_markers.push_back(format.per_call_start);
+        if (!function.name_prefix.empty() && function.name_prefix != format.per_call_start) {
+            content_stop_markers.push_back(function.name_prefix);
+        }
+    }
+    auto content_before_tools = content_stop_markers.empty() ? p.eps() : p.until_one_of(content_stop_markers);
     return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
 }
 
@@ -473,16 +503,23 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
     common_peg_parser tool_calls = p.eps();
 
     if (!format.per_call_start.empty()) {
-        auto wrapped_call = format.per_call_start + p.space() + tool_choice + p.space() + format.per_call_end;
+        // Models occasionally skip the per-call wrapper and jump straight to the function tag
+        // (a separate literal, function.name_prefix). Make per_call_start/per_call_end
+        // independently optional; the function tag itself (inside tool_choice) stays mandatory.
+        auto call_open     = p.optional(p.literal(format.per_call_start) + p.space());
+        auto call_close    = format.per_call_end.empty() ? p.eps() : p.optional(p.literal(format.per_call_end));
+        auto wrapped_call  = call_open + tool_choice + p.space() + call_close;
         if (inputs.parallel_tool_calls) {
             tool_calls = p.trigger_rule("tool-call", wrapped_call + p.zero_or_more(p.space() + wrapped_call) + p.space());
         } else {
             tool_calls = p.trigger_rule("tool-call", wrapped_call + p.space());
         }
         if (!format.section_start.empty()) {
+            // Same reasoning as per_call_start/per_call_end above, one level up: the outer
+            // section wrapper can be dropped too, independently of the per-call one.
             tool_calls = p.trigger_rule("tool-calls",
-                                        p.literal(format.section_start) + p.space() + tool_calls + p.space() +
-                                            (format.section_end.empty() ? p.end() : p.literal(format.section_end) + p.space()));
+                                        p.optional(p.literal(format.section_start) + p.space()) + tool_calls + p.space() +
+                                            (format.section_end.empty() ? p.end() : p.optional(p.literal(format.section_end)) + p.space()));
         }
     } else {
         std::string separator = ", ";  // Default
@@ -501,8 +538,20 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
         tool_calls = p.optional(tool_calls);
     }
 
-    std::string trigger_marker       = !format.section_start.empty() ? format.section_start : format.per_call_start;
-    auto        content_before_tools = trigger_marker.empty() ? p.eps() : p.until(trigger_marker);
+    // Stop the content-before-tools scan at the marker that actually begins a tool call. Only
+    // widen past section_start when it's empty (per_call_start IS the wrapper there, see
+    // above) - otherwise a chatty model quoting per_call_start/function.name_prefix-shaped
+    // text before the real section_start would truncate legitimate content early.
+    std::vector<std::string> content_stop_markers;
+    if (!format.section_start.empty()) {
+        content_stop_markers.push_back(format.section_start);
+    } else if (!format.per_call_start.empty()) {
+        content_stop_markers.push_back(format.per_call_start);
+        if (!function.name_prefix.empty() && function.name_prefix != format.per_call_start) {
+            content_stop_markers.push_back(function.name_prefix);
+        }
+    }
+    auto content_before_tools = content_stop_markers.empty() ? p.eps() : p.until_one_of(content_stop_markers);
     return ctx.reasoning_parser + p.optional(p.content(content_before_tools)) + tool_calls + p.end();
 }
 

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -3422,6 +3422,19 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             })
             .run();
 
+        // The model sometimes drops the <seed:tool_call> wrapper while still emitting a
+        // well-formed <function=...></function> block (build_tool_parser_tag_json must
+        // tolerate this the same way build_tool_parser_tag_tagged does for Qwen3-Coder).
+        tst.test(
+               "<function=special_function>\n"
+               "<parameter=arg1>1</parameter>\n"
+               "</function>\n")
+            .tools({ special_function_tool })
+            .expect_tool_calls({
+                { "special_function", R"({"arg1": 1})", {} },
+            })
+            .run();
+
         tst.test(
                "<seed:tool_call>\n"
                "<function=todo_list>\n"
@@ -3717,6 +3730,84 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({ enum_no_type_tool })
             .expect_tool_calls({
                 { "set_unit", R"({"unit": "celsius"})", {} },
+            })
+            .run();
+
+        // The model sometimes drops the outer <tool_call> wrapper (per_call_start/
+        // per_call_end) while still emitting a well-formed <function=...></function>
+        // block. Since Qwen3-Coder's format.section_start is empty (per_call_start is
+        // itself the wrapper here, not a separate outer section), this must still parse
+        // as a proper tool call rather than falling through to plain content.
+        tst.test(
+               "<function=special_function>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "</function>\n")
+            .tools({ special_function_tool })
+            .expect_tool_calls({
+                { "special_function", R"({"arg1": 1})", {} },
+            })
+            .run();
+
+        // Same as above, but with the leading chatter a model commonly emits before
+        // deciding to call a tool ("I'll help you ...").
+        tst.test(
+               "I'll help with that.\n\n"
+               "<function=special_function>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "</function>\n")
+            .tools({ special_function_tool })
+            .expect_content("I'll help with that.\n\n")
+            .expect_tool_calls({
+                { "special_function", R"({"arg1": 1})", {} },
+            })
+            .run();
+
+        // Asymmetric case: the opening <tool_call> wrapper is dropped but a trailing
+        // </tool_call> is still emitted. Both sides of the wrapper are independently
+        // optional, so this must parse too.
+        tst.test(
+               "<function=special_function>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ special_function_tool })
+            .expect_tool_calls({
+                { "special_function", R"({"arg1": 1})", {} },
+            })
+            .run();
+
+        // Parallel calls where only the first wrapper is dropped and the second is
+        // well-formed - the optional wrapper must be evaluated independently per call,
+        // not just once for the whole sequence.
+        tst.test(
+               "<function=special_function>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "</function>\n"
+               "<tool_call>\n"
+               "<function=special_function_with_opt>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "<parameter=arg2>\n"
+               "2\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .parallel_tool_calls(true)
+            .tools({
+                special_function_tool, special_function_tool_with_optional_param
+        })
+            .expect_tool_calls({
+                { "special_function", R"({"arg1": 1})", {} },
+                { "special_function_with_opt", R"({"arg1": 1, "arg2": 2})", {} },
             })
             .run();
 


### PR DESCRIPTION
## Overview

Several chat templates use a tagged tool-call format where `<tool_call>` is the wrapper around an inner `<function=name>...</function>` block (Qwen3-Coder, Nemotron, Seed-OSS, and others). Testing found that some models (see below) sometimes emit the well-formed inner block but skip the outer wrapper. Before this change, that was rejected entirely - the whole response fell back to plain text, dropping the tool call.

What changed (`common/chat-auto-parser-generator.cpp`):
- The wrapper's open/close tags are now optional in the grammar rather than mandatory - the inner function tag stays mandatory, so this can't misfire on unrelated text
- The scan that looks for "where does the tool call start" now also checks the inner function tag as a fallback, not just the wrapper, so a dropped wrapper doesn't cause the whole response to be swallowed as content
- The same leniency was applied to both of the two sibling code paths that share this exact pattern (tag_tagged and tag_json formats), for consistency

Test coverage (`tests/test-chat.cpp`): five new cases covering the dropped-wrapper scenario, an asymmetric case (open tag missing, close tag present), and a parallel-calls case where only one of two calls is missing its wrapper - across both affected code paths.

## Additional information

- Model: unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF
- Setup: served via llama-server with --jinja (native template handling), dual NVIDIA GPU (RTX 3080 + RTX 3060, 12GB each)
- Failure rate: measured over batches of 20-30 identical requests - roughly 1 in 3 requests (~33%) failed before the fix
- After the fix: 0 failures across 70 trials of the same request

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI-assisted diagnosis and implementation, with my own validation (against my system and the project's test suite)
