### PR TITLE
chat : add qwen3 specialized parser

### DIFF
--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -6,6 +6,9 @@
 
 #include <nlohmann/json.hpp>
 
+#include <cstdint>
+#include <functional>
+
 using ordered_json = nlohmann::ordered_json;
 
 static std::string_view trim_trailing_space(std::string_view sv, int max = -1) {
@@ -233,6 +236,43 @@ common_peg_parser common_chat_peg_builder::tag_with_safe_content(const std::stri
     }
     auto content_chunk = rule(tag_name, content(negate(literal(marker)) + any() + until(marker)));
     return zero_or_more(choice({ p, content_chunk }));
+}
+
+common_peg_parser common_chat_peg_builder::permute(const std::string &                    rule_prefix,
+                                                   const std::vector<common_peg_parser> & parsers) {
+    if (parsers.empty()) {
+        return eps();
+    }
+
+    if (parsers.size() == 1 || parsers.size() > COMMON_CHAT_MAX_PERMUTE) {
+        return sequence(parsers);
+    }
+
+    std::map<uint32_t, common_peg_parser>      rules;
+    std::function<common_peg_parser(uint32_t)> remaining_of;
+
+    remaining_of = [&](uint32_t remaining) -> common_peg_parser {
+        if (remaining == 0) {
+            return eps();
+        }
+
+        auto cached = rules.find(remaining);
+        if (cached != rules.end()) {
+            return cached->second;
+        }
+
+        auto alternatives = choice();
+        for (size_t i = 0; i < parsers.size(); i++) {
+            const uint32_t bit = 1u << i;
+            if (remaining & bit) {
+                alternatives |= parsers[i] + remaining_of(remaining & ~bit);
+            }
+        }
+
+        return rules.emplace(remaining, rule(rule_prefix + "-" + std::to_string(remaining), alternatives)).first->second;
+    };
+
+    return remaining_of((1u << parsers.size()) - 1);
 }
 
 std::string & common_chat_peg_mapper::args_target() {

--- a/common/chat-peg-parser.h
+++ b/common/chat-peg-parser.h
@@ -55,6 +55,8 @@ class common_chat_peg_minimax_m3_mapper : public common_chat_peg_mapper {
 struct content_structure;
 struct tool_call_structure;
 
+constexpr size_t COMMON_CHAT_MAX_PERMUTE = 6;
+
 class common_chat_peg_builder : public common_peg_parser_builder {
   public:
     // Tag constants (from former common_chat_peg_base_builder)
@@ -104,6 +106,9 @@ class common_chat_peg_builder : public common_peg_parser_builder {
     common_peg_parser tool_arg_string_value(const common_peg_parser & p) { return tag(TOOL_ARG_STRING_VALUE, p); }
     common_peg_parser tool_arg_json_value(const common_peg_parser & p) { return tag(TOOL_ARG_VALUE, p); }
 
+
+    // Matches every parser exactly once, in any order.
+    common_peg_parser permute(const std::string & rule_prefix, const std::vector<common_peg_parser> & parsers);
 
     // Return a parser that parses the prefix of a string, up to a given delimiter.
     common_peg_parser prefix(const std::string & s, const std::string & delimiter = {});

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1137,8 +1137,8 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
 
     data.message_delimiters = {
         { COMMON_CHAT_ROLE_ASSISTANT, "<|im_start|>assistant"             },
-        { COMMON_CHAT_ROLE_TOOL,      "<|im_start|>user\n<tool_response>" },
-        { COMMON_CHAT_ROLE_TOOL,      "<|im_start|>tool"                  },
+        { COMMON_CHAT_ROLE_TOOL,      "<|im_start|>user\n<tool_response>" }, // Qwen3-Coder, Qwen3.5, Nemotron Nano 3
+        { COMMON_CHAT_ROLE_TOOL,      "<|im_start|>tool_response"         }, // StepFun-3.5-Flash
         { COMMON_CHAT_ROLE_USER,      "<|im_start|>user"                  },
         { COMMON_CHAT_ROLE_SYSTEM,    "<|im_start|>system"                },
     };

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1110,6 +1110,153 @@ static common_chat_params common_chat_params_init_ministral_3(const common_chat_
     return data;
 }
 
+static common_chat_params common_chat_params_init_tagged_thinking_tools(const common_chat_template & tmpl,
+                                                                const autoparser::generation_params & inputs) {
+    common_chat_params data;
+
+    const bool has_tools         = inputs.tools.is_array() && !inputs.tools.empty();
+    const bool extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+
+    data.supports_thinking      = true;
+    data.thinking_start_tag     = "<think>";
+    data.thinking_end_tag       = "</think>";
+    data.prompt                 = common_chat_template_direct_apply(tmpl, inputs);
+    data.generation_prompt      = common_chat_template_generation_prompt(tmpl, inputs);
+    data.format                 = COMMON_CHAT_FORMAT_PEG_NATIVE;
+    data.strict_eof_on_complete = true;
+    data.preserved_tokens       = {
+        "<think>",
+        "</think>",
+        "<tool_call>",
+        "</tool_call>",
+    };
+
+    if (!has_tools || inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_NONE) {
+        return data;
+    }
+
+    auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {
+        auto generation_prompt = p.literal(data.generation_prompt);
+        auto tool_choices = p.choice();
+
+        foreach_function(inputs.tools, [&](const json & tool) {
+            const auto & function = tool.at("function");
+            const auto   name     = function.at("name").get<std::string>();
+
+            auto arg_choices = p.choice();
+            foreach_parameter(function, [&](const std::string & prop_name, const json & prop_schema, bool) {
+                const bool is_string = prop_schema.value("type", "") == "string";
+
+                auto value_until = [&](const std::string & marker) {
+                    return is_string ?
+                        p.tool_arg_string_value(p.until(marker)) :
+                        p.tool_arg_value(p.until(marker));
+                };
+
+                auto arg_open = p.tool_arg_open(
+                    p.literal("<parameter=") + p.tool_arg_name(p.literal(prop_name)) + p.literal(">"));
+
+                auto arg = p.tool_arg(arg_open + p.choice({
+                    p.literal("\n") + value_until("\n</parameter>") + p.tool_arg_close(p.literal("\n</parameter>")),
+                    value_until("</parameter>") + p.tool_arg_close(p.literal("</parameter>")),
+                }));
+                arg_choices |= p.rule("tool-" + name + "-arg-" + prop_name, arg);
+            });
+
+            auto args = p.tool_args(p.zero_or_more(arg_choices + p.space()));
+            auto func = p.tool(
+                p.tool_open(p.literal("<function=") + p.tool_name(p.literal(name)) + p.literal(">")) +
+                p.space() + args + p.space() +
+                p.tool_close(p.literal("</function>")));
+
+            tool_choices |= p.rule("tool-" + name, func);
+        });
+
+        auto tool_call =
+            p.literal("<tool_call>") + p.space() + tool_choices + p.space() + p.literal("</tool_call>");
+
+        const int max_calls = inputs.parallel_tool_calls ? -1 : 1;
+        auto tool_calls     = p.repeat(tool_call + p.space(), 1, max_calls);
+
+        p.rule("tool-tail", [&]() {
+            auto content_until_boundary = p.content(p.until_one_of({"<tool_call>", "</think>"}));
+            return p.choice({
+                p.literal("</think>") + p.space() + p.content(p.rest()),
+                content_until_boundary + p.choice({
+                    p.ref("tool-call"),
+                    p.literal("</think>") + p.space() + p.content(p.rest()),
+                    p.content(p.rest()),
+                }),
+            });
+        });
+        auto tool_suffix = p.trigger_rule("tool-call", tool_calls + p.ref("tool-tail"));
+
+        auto outside = p.choice({
+            p.content(p.until("<tool_call>")) + tool_suffix,
+            p.content(p.rest()),
+        });
+
+        if (!extract_reasoning || !inputs.enable_thinking) {
+            return generation_prompt + outside;
+        }
+
+        // Classify the emitted completion rather than the generation prompt. Some
+        // templates prefill "<think>\n", but Qwen-style models may omit the
+        // matching close tag for tool-call and final-answer turns. In practice:
+        //   - emitted </think> closes reasoning;
+        //   - emitted <tool_call> makes any preceding text reasoning;
+        //   - no emitted reasoning/tool tags means final assistant content.
+        auto reasoning_before_boundary =
+            p.reasoning(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"})) +
+            p.optional(p.literal("\n"));
+
+        auto reasoning_until_tool =
+            p.peek(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"}) + p.literal("\n<tool_call>")) +
+            reasoning_before_boundary +
+            tool_suffix;
+
+        auto reasoning_until_close =
+            p.peek(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"}) + p.choice({
+                p.literal("</think>"),
+                p.literal("\n</think>"),
+            })) +
+            reasoning_before_boundary +
+            p.literal("</think>") + p.space() + outside;
+
+        auto reasoning_then_boundary = p.choice({
+            tool_suffix,
+            reasoning_until_tool,
+            reasoning_until_close,
+            p.content(p.rest()),
+        });
+
+        auto generated_reasoning = p.literal("<think>") + p.space() + reasoning_then_boundary;
+
+        return generation_prompt + p.choice({
+            generated_reasoning,
+            reasoning_then_boundary,
+        });
+    });
+
+    data.parser       = parser.save();
+    data.grammar_lazy = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_AUTO;
+    data.grammar      = build_grammar([&](const common_grammar_builder & builder) {
+        foreach_function(inputs.tools, [&](const json & tool) {
+            const auto & function = tool.at("function");
+            auto         schema   = function.at("parameters");
+            builder.resolve_refs(schema);
+        });
+        parser.build_grammar(builder, data.grammar_lazy);
+    });
+    if (data.grammar_lazy) {
+        data.grammar_triggers = {
+            { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<tool_call>" },
+        };
+    }
+
+    return data;
+}
+
 static common_chat_params common_chat_params_init_gpt_oss(const common_chat_template &    tmpl,
                                                           const autoparser::generation_params & inputs) {
     common_chat_params data;
@@ -2917,6 +3064,20 @@ std::optional<common_chat_params> common_chat_try_specialized_template(
         return common_chat_params_init_ministral_3(tmpl, params);
     }
 
+    // Tagged thinking/tool protocol: reasoning uses <think>...</think> and tools use
+    // <tool_call><function=name><parameter=arg>...</parameter></function></tool_call>.
+    if (params.tools.is_array() && !params.tools.empty() &&
+        params.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE &&
+        src.find("<think>") != std::string::npos &&
+        src.find("</think>") != std::string::npos &&
+        src.find("<tool_call>") != std::string::npos &&
+        src.find("</tool_call>") != std::string::npos &&
+        src.find("<function=") != std::string::npos &&
+        src.find("<parameter=") != std::string::npos) {
+        LOG_DBG("Using specialized template: tagged thinking tools\n");
+        return common_chat_params_init_tagged_thinking_tools(tmpl, params);
+    }
+
     // GPT-OSS - has unique channel-based structure that needs dedicated handler
     if (src.find("<|channel|>") != std::string::npos) {
         LOG_DBG("Using specialized template: GPT-OSS\n");
@@ -3256,6 +3417,15 @@ common_chat_msg common_chat_peg_parse(const common_peg_arena &          src_pars
 
     common_peg_parse_context ctx(effective_input, flags);
     auto result = parser.parse(ctx);
+
+    // Streaming parses are lenient so an unterminated prefix can still produce deltas.
+    // Some complete parses intentionally use EOF as a boundary; retry those strictly
+    // when requested so "until"/"rest" parsers can commit at the actual end.
+    if (!is_partial && params.strict_eof_on_complete && result.need_more_input()) {
+        flags = common_peg_parse_flags(flags & ~COMMON_PEG_PARSE_FLAG_LENIENT);
+        ctx = common_peg_parse_context(effective_input, flags);
+        result = parser.parse(ctx);
+    }
 
     if (result.fail()) {
         // During partial parsing, return partial results if any AST nodes were captured

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1265,8 +1265,10 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
 
         if (data.grammar_lazy) {
             data.grammar_triggers = {
-                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD,    "<tool_call>" },
-                { COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN, "<function=" },
+                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<tool_call>" },
+                // Trigger on "<function" and not "<function=" because the trailing "=" is part of
+                // the token with the function name e.g. "=read"
+                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<function"   },
             };
         }
     }

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1131,6 +1131,7 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
     if (supports_reasoning) {
         data.thinking_start_tag = "<think>";
         // Support both </think> and <tool_call> as reasoning end sequences.
+        // <function= is omitted, as it is a workaround for Qwen3-Coder which is not a thinking model
         data.thinking_end_tags = { "</think>", "<tool_call>" };
         data.preserved_tokens.insert(data.preserved_tokens.end(), { "<think>", "</think>" });
     }

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1110,148 +1110,157 @@ static common_chat_params common_chat_params_init_ministral_3(const common_chat_
     return data;
 }
 
-static common_chat_params common_chat_params_init_tagged_thinking_tools(const common_chat_template & tmpl,
-                                                                const autoparser::generation_params & inputs) {
+static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_template &          tmpl,
+                                                              const autoparser::generation_params & inputs) {
     common_chat_params data;
 
-    const bool has_tools         = inputs.tools.is_array() && !inputs.tools.empty();
-    const bool extract_reasoning = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+    const std::string GEN_PREFIX = "<|im_start|>assistant\n";
 
-    data.supports_thinking      = true;
-    data.thinking_start_tag     = "<think>";
-    data.thinking_end_tag       = "</think>";
-    data.prompt                 = common_chat_template_direct_apply(tmpl, inputs);
-    data.generation_prompt      = common_chat_template_generation_prompt(tmpl, inputs);
-    data.format                 = COMMON_CHAT_FORMAT_PEG_NATIVE;
-    data.strict_eof_on_complete = true;
-    data.preserved_tokens       = {
-        "<think>",
-        "</think>",
+    data.prompt            = common_chat_template_direct_apply_impl(tmpl, inputs);
+    data.generation_prompt = common_chat_template_generation_prompt_impl(tmpl, inputs);
+    data.format            = COMMON_CHAT_FORMAT_PEG_NATIVE;
+
+    auto supports_reasoning = tmpl.source().find("<think>") != std::string::npos;
+
+    data.supports_thinking = supports_reasoning;
+    data.preserved_tokens  = {
         "<tool_call>",
         "</tool_call>",
     };
 
-    if (!has_tools || inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_NONE) {
-        return data;
+    if (supports_reasoning) {
+        data.thinking_start_tag = "<think>";
+        // Support both </think> and <tool_call> as reasoning end sequences.
+        data.thinking_end_tags = { "</think>", "<tool_call>" };
+        data.preserved_tokens.insert(data.preserved_tokens.end(), { "<think>", "</think>" });
+    }
+
+    data.message_delimiters = {
+        { COMMON_CHAT_ROLE_ASSISTANT, "<|im_start|>assistant"             },
+        { COMMON_CHAT_ROLE_TOOL,      "<|im_start|>user\n<tool_response>" },
+        { COMMON_CHAT_ROLE_TOOL,      "<|im_start|>tool"                  },
+        { COMMON_CHAT_ROLE_USER,      "<|im_start|>user"                  },
+        { COMMON_CHAT_ROLE_SYSTEM,    "<|im_start|>system"                },
+    };
+
+    auto has_tools           = inputs.tools.is_array() && !inputs.tools.empty();
+    auto has_response_format = inputs.json_schema.is_object() && !inputs.json_schema.empty();
+    auto extract_reasoning   = inputs.reasoning_format != COMMON_REASONING_FORMAT_NONE;
+    auto include_grammar     = has_response_format || (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE);
+
+    if (inputs.has_continuation()) {
+        const auto & msg = inputs.continue_msg;
+
+        data.generation_prompt = GEN_PREFIX;
+        if (supports_reasoning) {
+            data.generation_prompt += "<think>\n" + msg.reasoning_content;
+            if (inputs.continue_final_message == COMMON_CHAT_CONTINUATION_CONTENT) {
+                data.generation_prompt += "\n</think>\n\n";
+            }
+        }
+        if (inputs.continue_final_message == COMMON_CHAT_CONTINUATION_CONTENT) {
+            data.generation_prompt += msg.render_content();
+        }
+
+        data.prompt += data.generation_prompt;
     }
 
     auto parser = build_chat_peg_parser([&](common_chat_peg_builder & p) {
-        auto generation_prompt = p.literal(data.generation_prompt);
-        auto tool_choices = p.choice();
+        auto generation_prompt = p.literal(GEN_PREFIX);
 
-        foreach_function(inputs.tools, [&](const json & tool) {
-            const auto & function = tool.at("function");
-            const auto   name     = function.at("name").get<std::string>();
-
-            auto arg_choices = p.choice();
-            foreach_parameter(function, [&](const std::string & prop_name, const json & prop_schema, bool) {
-                const bool is_string = prop_schema.value("type", "") == "string";
-
-                auto value_until = [&](const std::string & marker) {
-                    return is_string ?
-                        p.tool_arg_string_value(p.until(marker)) :
-                        p.tool_arg_value(p.until(marker));
-                };
-
-                auto arg_open = p.tool_arg_open(
-                    p.literal("<parameter=") + p.tool_arg_name(p.literal(prop_name)) + p.literal(">"));
-
-                auto arg = p.tool_arg(arg_open + p.choice({
-                    p.literal("\n") + value_until("\n</parameter>") + p.tool_arg_close(p.literal("\n</parameter>")),
-                    value_until("</parameter>") + p.tool_arg_close(p.literal("</parameter>")),
-                }));
-                arg_choices |= p.rule("tool-" + name + "-arg-" + prop_name, arg);
-            });
-
-            auto args = p.tool_args(p.zero_or_more(arg_choices + p.space()));
-            auto func = p.tool(
-                p.tool_open(p.literal("<function=") + p.tool_name(p.literal(name)) + p.literal(">")) +
-                p.space() + args + p.space() +
-                p.tool_close(p.literal("</function>")));
-
-            tool_choices |= p.rule("tool-" + name, func);
-        });
-
-        auto tool_call =
-            p.literal("<tool_call>") + p.space() + tool_choices + p.space() + p.literal("</tool_call>");
-
-        const int max_calls = inputs.parallel_tool_calls ? -1 : 1;
-        auto tool_calls     = p.repeat(tool_call + p.space(), 1, max_calls);
-
-        p.rule("tool-tail", [&]() {
-            auto content_until_boundary = p.content(p.until_one_of({"<tool_call>", "</think>"}));
-            return p.choice({
-                p.literal("</think>") + p.space() + p.content(p.rest()),
-                content_until_boundary + p.choice({
-                    p.ref("tool-call"),
-                    p.literal("</think>") + p.space() + p.content(p.rest()),
-                    p.content(p.rest()),
-                }),
-            });
-        });
-        auto tool_suffix = p.trigger_rule("tool-call", tool_calls + p.ref("tool-tail"));
-
-        auto outside = p.choice({
-            p.content(p.until("<tool_call>")) + tool_suffix,
-            p.content(p.rest()),
-        });
-
-        if (!extract_reasoning || !inputs.enable_thinking) {
-            return generation_prompt + outside;
+        auto reasoning = p.eps();
+        if (supports_reasoning && extract_reasoning) {
+            reasoning = p.optional("<think>" + p.space() +
+                                   p.reasoning(p.until_one_of({ "</think>", "<tool_call>" })) +
+                                   (p.literal("</think>") | p.peek(p.literal("<tool_call>"))));
         }
 
-        // Classify the emitted completion rather than the generation prompt. Some
-        // templates prefill "<think>\n", but Qwen-style models may omit the
-        // matching close tag for tool-call and final-answer turns. In practice:
-        //   - emitted </think> closes reasoning;
-        //   - emitted <tool_call> makes any preceding text reasoning;
-        //   - no emitted reasoning/tool tags means final assistant content.
-        auto reasoning_before_boundary =
-            p.reasoning(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"})) +
-            p.optional(p.literal("\n"));
+        // Response format parser
+        if (has_response_format) {
+            return generation_prompt + (reasoning << p.content(p.schema(p.json(), "response-format", inputs.json_schema)));
+        }
 
-        auto reasoning_until_tool =
-            p.peek(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"}) + p.literal("\n<tool_call>")) +
-            reasoning_before_boundary +
-            tool_suffix;
+        // Tool call parser
+        if (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE) {
+            auto arg_close  = p.tool_arg_close(p.literal("\n</parameter>\n"));
+            auto arg_string = p.rule("xml-arg-string",
+                p.ac(p.tool_arg_string_value(p.until("\n</parameter>\n")) + arg_close, "\n</parameter>\n"));
 
-        auto reasoning_until_close =
-            p.peek(p.until_one_of({"</think>", "\n</think>", "\n<tool_call>"}) + p.choice({
-                p.literal("</think>"),
-                p.literal("\n</think>"),
-            })) +
-            reasoning_before_boundary +
-            p.literal("</think>") + p.space() + outside;
+            auto tool_choice = p.choice();
+            foreach_function(inputs.tools, [&](const json & tool) {
+                const auto & function   = tool.at("function");
+                std::string  name       = function.at("name");
+                auto         parameters = function.contains("parameters") ? function.at("parameters") : json::object();
 
-        auto reasoning_then_boundary = p.choice({
-            tool_suffix,
-            reasoning_until_tool,
-            reasoning_until_close,
-            p.content(p.rest()),
-        });
+                auto schema_info = common_schema_info();
+                schema_info.resolve_refs(parameters);
 
-        auto generated_reasoning = p.literal("<think>") + p.space() + reasoning_then_boundary;
+                std::vector<common_peg_parser> required_args;
+                std::vector<common_peg_parser> optional_args;
 
-        return generation_prompt + p.choice({
-            generated_reasoning,
-            reasoning_then_boundary,
-        });
+                foreach_parameter(function, [&](const std::string & param_name, const json & param_schema, bool is_required) {
+                    auto rule_name = "tool-" + name + "-arg-" + param_name;
+
+                    auto arg_open = p.tool_arg_open("<parameter=" + p.tool_arg_name(p.literal(param_name)) + ">\n");
+
+                    auto arg_value = schema_info.resolves_to_string(param_schema) ?
+                        arg_string :
+                        p.tool_arg_json_value(p.schema(p.json(), rule_name + "-schema", param_schema)) + arg_close;
+
+                    auto arg_rule = p.rule(rule_name, p.tool_arg(arg_open + arg_value));
+
+                    (is_required ? required_args : optional_args).push_back(arg_rule);
+                });
+
+                // Accept required arguments in any order, as Qwen does not always adhere to the
+                // order provided.
+                auto args = p.permute("tool-" + name + "-args", required_args);
+                if (!optional_args.empty()) {
+                    args = args + p.zero_or_more(p.choice(optional_args));
+                }
+
+                auto func = p.tool(p.tool_open("<function=" + p.tool_name(p.literal(name)) + ">\n") +
+                                   p.tool_args(args) +
+                                   p.tool_close(p.literal("</function>\n")));
+
+                tool_choice |= p.rule("tool-" + name, func);
+            });
+
+            auto min_calls  = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED ? 1 : 0;
+            auto max_calls  = inputs.parallel_tool_calls ? -1 : 1;
+            auto tool_call  = p.rule("tool-call", "<tool_call>\n" + tool_choice + "</tool_call>" + p.space());
+            auto tool_calls = p.trigger_rule("tool-call-root", p.repeat(tool_call, min_calls, max_calls));
+
+            return generation_prompt + (reasoning << p.content(p.until("<tool_call>")) << tool_calls);
+        }
+
+        // Content only parser
+        return generation_prompt + (reasoning << p.content(p.rest()));
     });
 
-    data.parser       = parser.save();
-    data.grammar_lazy = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_AUTO;
-    data.grammar      = build_grammar([&](const common_grammar_builder & builder) {
-        foreach_function(inputs.tools, [&](const json & tool) {
-            const auto & function = tool.at("function");
-            auto         schema   = function.at("parameters");
-            builder.resolve_refs(schema);
+    data.parser = parser.save();
+
+    if (include_grammar) {
+        data.grammar_lazy = has_tools && inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_AUTO;
+
+        data.grammar = build_grammar([&](const common_grammar_builder & builder) {
+            foreach_function(inputs.tools, [&](const json & tool) {
+                const auto & function = tool.at("function");
+                auto         schema   = function.contains("parameters") ? function.at("parameters") : json::object();
+                builder.resolve_refs(schema);
+            });
+            if (has_response_format) {
+                auto schema = inputs.json_schema;
+                builder.resolve_refs(schema);
+            }
+            parser.build_grammar(builder, data.grammar_lazy);
         });
-        parser.build_grammar(builder, data.grammar_lazy);
-    });
-    if (data.grammar_lazy) {
-        data.grammar_triggers = {
-            { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<tool_call>" },
-        };
+
+        if (data.grammar_lazy) {
+            data.grammar_triggers = {
+                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<tool_call>" }
+            };
+        }
     }
 
     return data;
@@ -3064,20 +3073,6 @@ std::optional<common_chat_params> common_chat_try_specialized_template(
         return common_chat_params_init_ministral_3(tmpl, params);
     }
 
-    // Tagged thinking/tool protocol: reasoning uses <think>...</think> and tools use
-    // <tool_call><function=name><parameter=arg>...</parameter></function></tool_call>.
-    if (params.tools.is_array() && !params.tools.empty() &&
-        params.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE &&
-        src.find("<think>") != std::string::npos &&
-        src.find("</think>") != std::string::npos &&
-        src.find("<tool_call>") != std::string::npos &&
-        src.find("</tool_call>") != std::string::npos &&
-        src.find("<function=") != std::string::npos &&
-        src.find("<parameter=") != std::string::npos) {
-        LOG_DBG("Using specialized template: tagged thinking tools\n");
-        return common_chat_params_init_tagged_thinking_tools(tmpl, params);
-    }
-
     // GPT-OSS - has unique channel-based structure that needs dedicated handler
     if (src.find("<|channel|>") != std::string::npos) {
         LOG_DBG("Using specialized template: GPT-OSS\n");
@@ -3165,6 +3160,14 @@ std::optional<common_chat_params> common_chat_try_specialized_template(
         src.find("<param name=\"") != std::string::npos) {
         LOG_DBG("Using specialized template: MiniCPM5\n");
         return common_chat_params_init_minicpm5(tmpl, params);
+    }
+
+    // Qwen3-Coder XML tool calls, also used by Nemotron Nano 3, Qwen3.5 and StepFun-3.5-Flash
+    if (src.find("<tool_call>") != std::string::npos &&
+        src.find("<function=") != std::string::npos &&
+        src.find("<parameter=") != std::string::npos) {
+        LOG_DBG("Using specialized template: Qwen3-Coder\n");
+        return common_chat_params_init_qwen3_coder(tmpl, params);
     }
 
     return std::nullopt;
@@ -3417,15 +3420,6 @@ common_chat_msg common_chat_peg_parse(const common_peg_arena &          src_pars
 
     common_peg_parse_context ctx(effective_input, flags);
     auto result = parser.parse(ctx);
-
-    // Streaming parses are lenient so an unterminated prefix can still produce deltas.
-    // Some complete parses intentionally use EOF as a boundary; retry those strictly
-    // when requested so "until"/"rest" parsers can commit at the actual end.
-    if (!is_partial && params.strict_eof_on_complete && result.need_more_input()) {
-        flags = common_peg_parse_flags(flags & ~COMMON_PEG_PARSE_FLAG_LENIENT);
-        ctx = common_peg_parse_context(effective_input, flags);
-        result = parser.parse(ctx);
-    }
 
     if (result.fail()) {
         // During partial parsing, return partial results if any AST nodes were captured

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1226,12 +1226,18 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
                 tool_choice |= p.rule("tool-" + name, func);
             });
 
-            auto min_calls  = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED ? 1 : 0;
-            auto max_calls  = inputs.parallel_tool_calls ? -1 : 1;
-            auto tool_call  = p.rule("tool-call", "<tool_call>\n" + tool_choice + "</tool_call>" + p.space());
-            auto tool_calls = p.trigger_rule("tool-call-root", p.repeat(tool_call, min_calls, max_calls));
+            auto min_calls = inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED ? 1 : 0;
 
-            return generation_prompt + (reasoning << p.content(p.until("<tool_call>")) << tool_calls);
+            // Qwen3-Coder models may occasionally omit the <tool_call> token.
+            auto tool_call_body  = tool_choice + "</tool_call>" + p.space();
+            auto tool_call_first = p.rule("tool-call-first", p.optional(p.literal("<tool_call>\n")) + tool_call_body);
+            auto tool_call       = p.rule("tool-call", "<tool_call>\n" + tool_call_body);
+
+            auto calls      = inputs.parallel_tool_calls ? tool_call_first + p.zero_or_more(tool_call) : tool_call_first;
+            auto tool_calls = p.trigger_rule("tool-call-root", p.repeat(calls, min_calls, 1));
+
+            return generation_prompt +
+                   (reasoning << p.content(p.until_one_of({ "<tool_call>", "<function=" })) << tool_calls);
         }
 
         // Content only parser
@@ -1258,7 +1264,8 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
 
         if (data.grammar_lazy) {
             data.grammar_triggers = {
-                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, "<tool_call>" }
+                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD,    "<tool_call>" },
+                { COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN, "<function=" },
             };
         }
     }

--- a/common/chat.h
+++ b/common/chat.h
@@ -280,9 +280,6 @@ struct common_chat_params {
     std::vector<std::string>            preserved_tokens;
     std::vector<std::string>            additional_stops;
     std::string                         parser;
-    // If a complete parse reports NEED_MORE in lenient streaming mode, retry without
-    // leniency so EOF can be used as a real boundary by parsers that opt in.
-    bool                                strict_eof_on_complete = false;
     common_chat_msg_delimiters          message_delimiters;
 };
 
@@ -298,13 +295,11 @@ struct common_chat_parser_params {
     bool                    is_continuation      = false;
     bool                    echo                 = false;  // Include assistant prefilled msg in output
     bool                    debug                = false;  // Enable debug output for PEG parser
-    bool                    strict_eof_on_complete = false;
     common_peg_arena        parser               = {};
     common_chat_parser_params() = default;
     common_chat_parser_params(const common_chat_params & chat_params) {
-        format                 = chat_params.format;
-        generation_prompt      = chat_params.generation_prompt;
-        strict_eof_on_complete = chat_params.strict_eof_on_complete;
+        format  = chat_params.format;
+        generation_prompt = chat_params.generation_prompt;
     }
 };
 

--- a/common/chat.h
+++ b/common/chat.h
@@ -280,6 +280,9 @@ struct common_chat_params {
     std::vector<std::string>            preserved_tokens;
     std::vector<std::string>            additional_stops;
     std::string                         parser;
+    // If a complete parse reports NEED_MORE in lenient streaming mode, retry without
+    // leniency so EOF can be used as a real boundary by parsers that opt in.
+    bool                                strict_eof_on_complete = false;
     common_chat_msg_delimiters          message_delimiters;
 };
 
@@ -295,11 +298,13 @@ struct common_chat_parser_params {
     bool                    is_continuation      = false;
     bool                    echo                 = false;  // Include assistant prefilled msg in output
     bool                    debug                = false;  // Enable debug output for PEG parser
+    bool                    strict_eof_on_complete = false;
     common_peg_arena        parser               = {};
     common_chat_parser_params() = default;
     common_chat_parser_params(const common_chat_params & chat_params) {
-        format  = chat_params.format;
-        generation_prompt = chat_params.generation_prompt;
+        format                 = chat_params.format;
+        generation_prompt      = chat_params.generation_prompt;
+        strict_eof_on_complete = chat_params.strict_eof_on_complete;
     }
 };
 

--- a/tests/test-chat-peg-parser.cpp
+++ b/tests/test-chat-peg-parser.cpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <numeric>
+#include <regex>
 #include <string>
 
 #include "nlohmann/json.hpp"
@@ -21,6 +22,7 @@ static void test_example_qwen3_non_coder(testing & t);
 static void test_command7_parser_compare(testing & t);
 static void test_prefix_tool_names(testing & t);
 static void test_tagged_peg_parser(testing & t);
+static void test_permute(testing & t);
 
 int main(int argc, char * argv[]) {
     testing t(std::cout);
@@ -39,6 +41,7 @@ int main(int argc, char * argv[]) {
     t.test("comparison", test_command7_parser_compare);
     t.test("prefix tool names", test_prefix_tool_names);
     t.test("tagged peg parser", test_tagged_peg_parser);
+    t.test("permute", test_permute);
 
     return t.summary();
 }
@@ -979,5 +982,105 @@ static void test_tagged_peg_parser(testing & t) {
         t.assert_true("success", result.result.success());
         t.assert_equal("fun_pre should be '<function='", "<function=", result.tags["fun_pre"]);
         t.assert_equal("fun_post should be '>'", ">", result.tags["fun_post"]);
+    });
+}
+
+static void test_permute(testing & t) {
+    auto accepts = [](const common_peg_arena & parser, const std::string & input) {
+        common_peg_parse_context ctx(input);
+        return parser.parse(ctx).success();
+    };
+
+    auto gbnf_of = [](const common_peg_arena & parser) {
+        return build_grammar([&](const common_grammar_builder & builder) { parser.build_grammar(builder); });
+    };
+
+    auto assert_gbnf_equal = [](testing & t, const std::string & expected, const std::string & actual) {
+        static const std::regex leading_ws_re = std::regex(R"((^|\n)\s+)");
+        t.assert_equal("gbnf are equal", std::regex_replace(expected, leading_ws_re, "$1"), actual);
+    };
+
+    auto count_rules = [](const std::string & gbnf, const std::string & prefix) {
+        size_t count = 0;
+        for (const auto & line : string_split<std::string>(gbnf, '\n')) {
+            if (line.rfind(prefix, 0) == 0) {
+                count++;
+            }
+        }
+        return count;
+    };
+
+    t.test("accepts every ordering", [&](testing & t) {
+        auto parser = build_chat_peg_parser([](common_chat_peg_builder & p) {
+            return p.permute("abc", { p.literal("a"), p.literal("b"), p.literal("c") }) + p.end();
+        });
+
+        for (const std::string input : { "abc", "acb", "bac", "bca", "cab", "cba" }) {
+            t.assert_true("accepts " + input, accepts(parser, input));
+        }
+    });
+
+    t.test("single element", [&](testing & t) {
+        auto parser = build_chat_peg_parser([](common_chat_peg_builder & p) {
+            return p.permute("a", { p.literal("a") }) + p.end();
+        });
+
+        t.assert_true("accepts a", accepts(parser, "a"));
+        t.assert_true("rejects aa", !accepts(parser, "aa"));
+    });
+
+    t.test("grammar left-factorizes shared tails", [&](testing & t) {
+        auto parser = build_chat_peg_parser([](common_chat_peg_builder & p) {
+            return p.permute("abc", { p.literal("a"), p.literal("b"), p.literal("c") }) + p.end();
+        });
+
+        // Every rule is one remaining subset, keyed by bitmask: abc-3 is {a,b}, abc-7 is {a,b,c}.
+        // Each subset is emitted once and shared by every branch that leads into it.
+        assert_gbnf_equal(t, R"""(
+            abc-1 ::= "a"
+            abc-2 ::= "b"
+            abc-3 ::= "a" abc-2 | "b" abc-1
+            abc-4 ::= "c"
+            abc-5 ::= "a" abc-4 | "c" abc-1
+            abc-6 ::= "b" abc-4 | "c" abc-2
+            abc-7 ::= "a" abc-6 | "b" abc-5 | "c" abc-3
+            root ::= abc-7
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )""", gbnf_of(parser));
+    });
+
+    t.test("grammar emits one rule per remaining subset", [&](testing & t) {
+        auto parser = build_chat_peg_parser([](common_chat_peg_builder & p) {
+            return p.permute("abcd", { p.literal("a"), p.literal("b"), p.literal("c"), p.literal("d") }) + p.end();
+        });
+
+        // 2^4 - 1 non-empty subsets, one rule each - not the 4! = 24 orderings.
+        t.assert_equal("permute rule count", 15u, count_rules(gbnf_of(parser), "abcd-"));
+    });
+
+    t.test("grammar emits no rules for a single element", [&](testing & t) {
+        auto parser = build_chat_peg_parser([](common_chat_peg_builder & p) {
+            return p.permute("a", { p.literal("a") }) + p.end();
+        });
+
+        assert_gbnf_equal(t, R"""(
+            root ::= "a"
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )""", gbnf_of(parser));
+    });
+
+    t.test("grammar falls back to the given order when too large", [&](testing & t) {
+        auto parser = build_chat_peg_parser([](common_chat_peg_builder & p) {
+            std::vector<common_peg_parser> parsers;
+            for (size_t i = 0; i <= COMMON_CHAT_MAX_PERMUTE; i++) {
+                parsers.push_back(p.literal(std::string(1, (char) ('a' + i))));
+            }
+            return p.permute("big", parsers) + p.end();
+        });
+
+        assert_gbnf_equal(t, R"""(
+            root ::= "a" "b" "c" "d" "e" "f" "g"
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )""", gbnf_of(parser));
     });
 }

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -3511,6 +3511,61 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_reconstruction()
             .run();
 
+        // Some models skip the opening <tool_call> and go straight to <function=>
+        tst.test(
+               "<function=special_function>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ special_function_tool })
+            .expect(message_assist_call)
+            .run();
+
+        tst.test(
+               "Let me call it.\n"
+               "<function=special_function>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ special_function_tool })
+            .expect_content("Let me call it.\n")
+            .expect_tool_calls({
+                { "special_function", R"({"arg1": 1})", {} },
+            })
+            .run();
+
+        // Only the first call may omit it, the rest keep the </tool_call>\n<tool_call> separator
+        tst.test(
+               "<function=special_function>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "<tool_call>\n"
+               "<function=special_function_with_opt>\n"
+               "<parameter=arg1>\n"
+               "1\n"
+               "</parameter>\n"
+               "<parameter=arg2>\n"
+               "2\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .parallel_tool_calls(true)
+            .tools({
+                special_function_tool, special_function_tool_with_optional_param
+        })
+            .expect_tool_calls({
+                { "special_function", R"({"arg1": 1})", {} },
+                { "special_function_with_opt", R"({"arg1": 1, "arg2": 2})", {} },
+            })
+            .run();
+
         tst.test(
                "<tool_call>\n"
                "<function=special_function>\n"

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1451,6 +1451,11 @@ class peg_tester {
         template_path_(template_path),
         detailed_debug_(detailed_debug) {}
 
+    explicit peg_tester(common_chat_templates_ptr tmpls, const std::string & template_path, const bool detailed_debug = false) :
+        tmpls_(std::move(tmpls)),
+        template_path_(template_path),
+        detailed_debug_(detailed_debug) {}
+
     const std::string & template_path() const { return template_path_; }
 
     peg_test_builder test(const std::string & input);
@@ -2247,7 +2252,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             })
             .run();
 
-
         // test code that starts with indent
         tst.test(
                "<tool_call>\n"
@@ -2264,6 +2268,100 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
         })
             .expect_tool_calls({
                 { "python", "{\"code\": \"    print(\\\"Hello, world!\\\")\"}", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need to inspect the current directory.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "</think>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ run_in_terminal_tool })
+            .expect_reasoning("Need to inspect the current directory.")
+            .expect_content("Done.")
+            .expect_tool_calls({
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need to inspect the current directory.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ run_in_terminal_tool })
+            .expect_reasoning("Need to inspect the current directory.")
+            .expect_content("Done.")
+            .expect_tool_calls({
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
+            })
+            .run();
+
+        tst.test(
+               "<tool_call>\n"
+               "<function=edit>\n"
+               "<parameter=newString>\n"
+               "new text\n"
+               "</parameter>\n"
+               "<parameter=oldString>\n"
+               "old text\n"
+               "</parameter>\n"
+               "<parameter=filename>\n"
+               "foo.cpp\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .enable_thinking(false)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ edit_tool })
+            .expect_tool_calls({
+                { "edit", R"({"newString": "new text", "oldString": "old text", "filename": "foo.cpp"})", {} },
+            })
+            .run();
+
+        tst.test(
+               "Need the directory.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "Need the files.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "ls\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>\n"
+               "</think>\n"
+               "Done.")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .parallel_tool_calls(true)
+            .tools({ run_in_terminal_tool })
+            .expect_reasoning("Need the directory.")
+            .expect_content("Need the files.\nDone.")
+            .expect_tool_calls({
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
+                { "run_in_terminal", R"({"command": "ls"})", {} },
             })
             .run();
 
@@ -2357,7 +2455,7 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({
                 special_function_tool
         })
-            .expect_reasoning("<think>\n\n")
+            .expect_reasoning("")
             .expect_tool_calls({ { "special_function", "{\"arg1\": 1}", "" } })
             .run();
 
@@ -2472,6 +2570,13 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_content("Final answer without tools.")
             .run();
 
+        tst.test("Final answer without thinking.")
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .enable_thinking(true)
+            .tools({ run_in_terminal_tool })
+            .expect_content("Final answer without thinking.")
+            .run();
+
         // Continuation tests
         tst.test("world!\nWhat's up?")
             .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
@@ -2576,6 +2681,93 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
                 .expect_tool_calls({
                     { "run_in_terminal", R"({"command": "pwd"})", {} },
                 })
+                .run();
+        }
+
+        {
+            auto src = read_file("models/templates/Qwen3.5-4B.jinja");
+            string_replace_all(src,
+                "{%- if add_generation_prompt %}\n"
+                "    {{- '<|im_start|>assistant\\n' }}\n"
+                "    {%- if enable_thinking is defined and enable_thinking is false %}\n"
+                "        {{- '<think>\\n\\n</think>\\n\\n' }}\n"
+                "    {%- else %}\n"
+                "        {{- '<think>\\n' }}\n"
+                "    {%- endif %}\n"
+                "{%- endif %}",
+                "{%- if add_generation_prompt %}\n"
+                "    {{- '<|im_start|>assistant\\n' }}\n"
+                "{%- endif %}");
+
+            auto no_prefill = peg_tester(
+                common_chat_templates_ptr(common_chat_templates_init(/* model= */ nullptr, src)),
+                "models/templates/Qwen3.5-4B-no-prefill-think.jinja",
+                detailed_debug);
+
+            no_prefill.test(
+                   "<think>\n"
+                   "I need to run a terminal command.\n"
+                   "</think>\n\n"
+                   "<tool_call>\n"
+                   "<function=run_in_terminal>\n"
+                   "<parameter=command>\n"
+                   "pwd\n"
+                   "</parameter>\n"
+                   "</function>\n"
+                   "</tool_call>")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_reasoning("I need to run a terminal command.")
+                .expect_tool_calls({
+                    { "run_in_terminal", R"({"command": "pwd"})", {} },
+                })
+                .run();
+
+            no_prefill.test(
+                   "<think>\n"
+                   "I need to run a terminal command.\n"
+                   "<tool_call>\n"
+                   "<function=run_in_terminal>\n"
+                   "<parameter=command>\n"
+                   "pwd\n"
+                   "</parameter>\n"
+                   "</function>\n"
+                   "</tool_call>\n"
+                   "Done.")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_reasoning("I need to run a terminal command.")
+                .expect_content("Done.")
+                .expect_tool_calls({
+                    { "run_in_terminal", R"({"command": "pwd"})", {} },
+                })
+                .run();
+
+            no_prefill.test(
+                   "I need to run a terminal command.\n"
+                   "<tool_call>\n"
+                   "<function=run_in_terminal>\n"
+                   "<parameter=command>\n"
+                   "pwd\n"
+                   "</parameter>\n"
+                   "</function>\n"
+                   "</tool_call>")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_reasoning("I need to run a terminal command.")
+                .expect_tool_calls({
+                    { "run_in_terminal", R"({"command": "pwd"})", {} },
+                })
+                .run();
+
+            no_prefill.test("Final answer without thinking.")
+                .enable_thinking(true)
+                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+                .tools({ run_in_terminal_tool })
+                .expect_content("Final answer without thinking.")
                 .run();
         }
     }

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1451,11 +1451,6 @@ class peg_tester {
         template_path_(template_path),
         detailed_debug_(detailed_debug) {}
 
-    explicit peg_tester(common_chat_templates_ptr tmpls, const std::string & template_path, const bool detailed_debug = false) :
-        tmpls_(std::move(tmpls)),
-        template_path_(template_path),
-        detailed_debug_(detailed_debug) {}
-
     const std::string & template_path() const { return template_path_; }
 
     peg_test_builder test(const std::string & input);
@@ -2252,6 +2247,7 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             })
             .run();
 
+
         // test code that starts with indent
         tst.test(
                "<tool_call>\n"
@@ -2272,100 +2268,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .run();
 
         tst.test(
-               "Need to inspect the current directory.\n"
-               "<tool_call>\n"
-               "<function=run_in_terminal>\n"
-               "<parameter=command>\n"
-               "pwd\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n"
-               "</think>\n"
-               "Done.")
-            .enable_thinking(true)
-            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .tools({ run_in_terminal_tool })
-            .expect_reasoning("Need to inspect the current directory.")
-            .expect_content("Done.")
-            .expect_tool_calls({
-                { "run_in_terminal", R"({"command": "pwd"})", {} },
-            })
-            .run();
-
-        tst.test(
-               "Need to inspect the current directory.\n"
-               "<tool_call>\n"
-               "<function=run_in_terminal>\n"
-               "<parameter=command>\n"
-               "pwd\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n"
-               "Done.")
-            .enable_thinking(true)
-            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .tools({ run_in_terminal_tool })
-            .expect_reasoning("Need to inspect the current directory.")
-            .expect_content("Done.")
-            .expect_tool_calls({
-                { "run_in_terminal", R"({"command": "pwd"})", {} },
-            })
-            .run();
-
-        tst.test(
-               "<tool_call>\n"
-               "<function=edit>\n"
-               "<parameter=newString>\n"
-               "new text\n"
-               "</parameter>\n"
-               "<parameter=oldString>\n"
-               "old text\n"
-               "</parameter>\n"
-               "<parameter=filename>\n"
-               "foo.cpp\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>")
-            .enable_thinking(false)
-            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .tools({ edit_tool })
-            .expect_tool_calls({
-                { "edit", R"({"newString": "new text", "oldString": "old text", "filename": "foo.cpp"})", {} },
-            })
-            .run();
-
-        tst.test(
-               "Need the directory.\n"
-               "<tool_call>\n"
-               "<function=run_in_terminal>\n"
-               "<parameter=command>\n"
-               "pwd\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n"
-               "Need the files.\n"
-               "<tool_call>\n"
-               "<function=run_in_terminal>\n"
-               "<parameter=command>\n"
-               "ls\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n"
-               "</think>\n"
-               "Done.")
-            .enable_thinking(true)
-            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .parallel_tool_calls(true)
-            .tools({ run_in_terminal_tool })
-            .expect_reasoning("Need the directory.")
-            .expect_content("Need the files.\nDone.")
-            .expect_tool_calls({
-                { "run_in_terminal", R"({"command": "pwd"})", {} },
-                { "run_in_terminal", R"({"command": "ls"})", {} },
-            })
-            .run();
-
-        tst.test(
                "I need to output the invoice details in JSON\n"
                "</think>\n\n"
                R"({"amount": 123.45, "date": "2025-12-03"})")
@@ -2376,46 +2278,39 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_content(R"({"amount": 123.45, "date": "2025-12-03"})")
             .run();
 
-        // tool call segment in reasoning
+        // a tool call ends the prefilled thinking block, with or without a closing </think>
         tst.test(
-               "Let's call a tool: <tool_call>\n"
-               "<function=python>\n"
-               "<parameter=code>\n"
-               "def hello():\n"
-               "    print(\"Not the real call!\")\n"
-               "\n"
-               "hello()\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n</think>\n\n"
                "<tool_call>\n"
-               "<function=python>\n"
-               "<parameter=code>\n"
-               "def hello():\n"
-               "    print(\"Hello, world!\")\n"
-               "\n"
-               "hello()\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
                "</parameter>\n"
                "</function>\n"
                "</tool_call>")
             .enable_thinking(true)
             .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .tools({
-                python_tool
-        })
-            .expect_reasoning(
-                "Let's call a tool: <tool_call>\n"
-                "<function=python>\n"
-                "<parameter=code>\n"
-                "def hello():\n"
-                "    print(\"Not the real call!\")\n"
-                "\n"
-                "hello()\n"
-                "</parameter>\n"
-                "</function>\n"
-                "</tool_call>")
+            .tools({ run_in_terminal_tool })
             .expect_tool_calls({
-                { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
+            })
+            .run();
+
+        // ...including after the model has thought about it
+        tst.test(
+               "Need to inspect the current directory.\n"
+               "<tool_call>\n"
+               "<function=run_in_terminal>\n"
+               "<parameter=command>\n"
+               "pwd\n"
+               "</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .enable_thinking(true)
+            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
+            .tools({ run_in_terminal_tool })
+            .expect_reasoning("Need to inspect the current directory.")
+            .expect_tool_calls({
+                { "run_in_terminal", R"({"command": "pwd"})", {} },
             })
             .run();
 
@@ -2455,7 +2350,7 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .tools({
                 special_function_tool
         })
-            .expect_reasoning("")
+            .expect_reasoning("<think>\n\n")
             .expect_tool_calls({ { "special_function", "{\"arg1\": 1}", "" } })
             .run();
 
@@ -2557,24 +2452,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_tool_calls({
                 { "run_in_terminal", R"({"command": "pwd"})", {} },
             })
-            .run();
-
-        tst.test(
-               "I might call <tool_call> later, but I am still thinking.\n"
-               "</think>\n\n"
-               "Final answer without tools.")
-            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .enable_thinking(true)
-            .tools({ run_in_terminal_tool })
-            .expect_reasoning("I might call <tool_call> later, but I am still thinking.")
-            .expect_content("Final answer without tools.")
-            .run();
-
-        tst.test("Final answer without thinking.")
-            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .enable_thinking(true)
-            .tools({ run_in_terminal_tool })
-            .expect_content("Final answer without thinking.")
             .run();
 
         // Continuation tests
@@ -2681,93 +2558,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
                 .expect_tool_calls({
                     { "run_in_terminal", R"({"command": "pwd"})", {} },
                 })
-                .run();
-        }
-
-        {
-            auto src = read_file("models/templates/Qwen3.5-4B.jinja");
-            string_replace_all(src,
-                "{%- if add_generation_prompt %}\n"
-                "    {{- '<|im_start|>assistant\\n' }}\n"
-                "    {%- if enable_thinking is defined and enable_thinking is false %}\n"
-                "        {{- '<think>\\n\\n</think>\\n\\n' }}\n"
-                "    {%- else %}\n"
-                "        {{- '<think>\\n' }}\n"
-                "    {%- endif %}\n"
-                "{%- endif %}",
-                "{%- if add_generation_prompt %}\n"
-                "    {{- '<|im_start|>assistant\\n' }}\n"
-                "{%- endif %}");
-
-            auto no_prefill = peg_tester(
-                common_chat_templates_ptr(common_chat_templates_init(/* model= */ nullptr, src)),
-                "models/templates/Qwen3.5-4B-no-prefill-think.jinja",
-                detailed_debug);
-
-            no_prefill.test(
-                   "<think>\n"
-                   "I need to run a terminal command.\n"
-                   "</think>\n\n"
-                   "<tool_call>\n"
-                   "<function=run_in_terminal>\n"
-                   "<parameter=command>\n"
-                   "pwd\n"
-                   "</parameter>\n"
-                   "</function>\n"
-                   "</tool_call>")
-                .enable_thinking(true)
-                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-                .tools({ run_in_terminal_tool })
-                .expect_reasoning("I need to run a terminal command.")
-                .expect_tool_calls({
-                    { "run_in_terminal", R"({"command": "pwd"})", {} },
-                })
-                .run();
-
-            no_prefill.test(
-                   "<think>\n"
-                   "I need to run a terminal command.\n"
-                   "<tool_call>\n"
-                   "<function=run_in_terminal>\n"
-                   "<parameter=command>\n"
-                   "pwd\n"
-                   "</parameter>\n"
-                   "</function>\n"
-                   "</tool_call>\n"
-                   "Done.")
-                .enable_thinking(true)
-                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-                .tools({ run_in_terminal_tool })
-                .expect_reasoning("I need to run a terminal command.")
-                .expect_content("Done.")
-                .expect_tool_calls({
-                    { "run_in_terminal", R"({"command": "pwd"})", {} },
-                })
-                .run();
-
-            no_prefill.test(
-                   "I need to run a terminal command.\n"
-                   "<tool_call>\n"
-                   "<function=run_in_terminal>\n"
-                   "<parameter=command>\n"
-                   "pwd\n"
-                   "</parameter>\n"
-                   "</function>\n"
-                   "</tool_call>")
-                .enable_thinking(true)
-                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-                .tools({ run_in_terminal_tool })
-                .expect_reasoning("I need to run a terminal command.")
-                .expect_tool_calls({
-                    { "run_in_terminal", R"({"command": "pwd"})", {} },
-                })
-                .run();
-
-            no_prefill.test("Final answer without thinking.")
-                .enable_thinking(true)
-                .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-                .tools({ run_in_terminal_tool })
-                .expect_content("Final answer without thinking.")
                 .run();
         }
     }
@@ -2966,49 +2756,6 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .json_schema(invoice_schema)
             .expect_reasoning("I need to output the invoice details in JSON")
             .expect_content(R"({"amount": 123.45, "date": "2025-12-03"})")
-            .run();
-
-        // tool call segment in reasoning
-        tst.test(
-               "Let's call a tool: <tool_call>\n"
-               "<function=python>\n"
-               "<parameter=code>\n"
-               "def hello():\n"
-               "    print(\"Not the real call!\")\n"
-               "\n"
-               "hello()\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n</think>\n"
-               "<tool_call>\n"
-               "<function=python>\n"
-               "<parameter=code>\n"
-               "def hello():\n"
-               "    print(\"Hello, world!\")\n"
-               "\n"
-               "hello()\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n"
-            )
-            .enable_thinking(true)
-            .reasoning_format(COMMON_REASONING_FORMAT_AUTO)
-            .tools({
-                python_tool
-        })
-            .expect_reasoning("Let's call a tool: <tool_call>\n"
-               "<function=python>\n"
-               "<parameter=code>\n"
-               "def hello():\n"
-               "    print(\"Not the real call!\")\n"
-               "\n"
-               "hello()\n"
-               "</parameter>\n"
-               "</function>\n"
-               "</tool_call>\n")
-            .expect_tool_calls({
-                { "python", "{\"code\": \"def hello():\\n    print(\\\"Hello, world!\\\")\\n\\nhello()\"}", {} },
-            })
             .run();
 
         // Continuation tests
@@ -3868,6 +3615,37 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
         })
             .expect_tool_calls({
                 { "todo_list", "{\"todos\": [{\"item\": \"Check stuff\", \"selected\": false}, {\"item\": \"Prepare stuff\", \"selected\": true}]}", {} },
+            })
+            .expect_reconstruction()
+            .run();
+
+        // Test flexible required argument ordering (required args still come first, in any order)
+        tst.test(
+               "<tool_call>\n"
+               "<function=edit>\n"
+               "<parameter=newString>\n#include\n</parameter>\n"
+               "<parameter=filename>\nfoo.c\n</parameter>\n"
+               "<parameter=oldString>\n#iclunde\n</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ edit_tool })
+            .expect_tool_calls({
+                { "edit", R"({"newString": "#include", "filename": "foo.c", "oldString": "#iclunde"})", {} },
+            })
+            .expect_reconstruction()
+            .run();
+
+        tst.test(
+               "<tool_call>\n"
+               "<function=tool_2req_4opt>\n"
+               "<parameter=req2>\n42\n</parameter>\n"
+               "<parameter=req1>\nhello\n</parameter>\n"
+               "<parameter=opt2>\n200\n</parameter>\n"
+               "</function>\n"
+               "</tool_call>")
+            .tools({ tool_2req_4opt })
+            .expect_tool_calls({
+                { "tool_2req_4opt", R"({"req2": 42, "req1": "hello", "opt2": 200})", {} },
             })
             .expect_reconstruction()
             .run();


### PR DESCRIPTION
## Overview

Supersedes #24202, #26244

Qwen 3 models may occasionally emit a `<tool_call>` after `<think>\n`, usually without any reasoning which leads me to believe this is a valid tool call and not a reasoning trace.

This PR supports both `</think>` and `<tool_call>` as reasoning end sequences. It also adds support for older models that sometimes omit `<tool_call>`. Although I rather not support these outdated models, it seems there is community desire for support.

Additionally, we bring back argument permutation support, previously tried by @pwilkin, but optimized to minimize the number of active stacks in the grammar sampler at any one point in time. We have seen Qwen 3 try really hard to order arguments differently, to the point we had to impose harsher grammar constraints. Rather than fight it, we might as well allow it.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, predominately written with Opus 5.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
