### PR TITLE
quant : do not require imatrix when the tensor keeps its type

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -1050,7 +1050,9 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
             metadata[i].target_type = tensor->type;
         }
 
-        metadata[i].requires_imatrix = tensor_requires_imatrix(tensor->name, metadata[i].target_type, ftype);
+        // tensors that keep their type are copied as-is and do not require an imatrix
+        metadata[i].requires_imatrix = metadata[i].target_type != tensor->type &&
+            tensor_requires_imatrix(tensor->name, metadata[i].target_type, ftype);
 
         if (params->imatrix) {
             metadata[i].remapped_imatrix_name = remap_imatrix(tensor->name, mapped);


### PR DESCRIPTION
## Overview

While claude was requantizing the deepseek iq3xxs model while pinning the experts in place, it came across a regression. Minimal repro on any model that already contains an imatrix-requiring type, pinning that type in place:

```
llama-quantize --allow-requantize --tensor-type ffn_up=iq2_xxs \
    model-iq2_xxs.gguf model-q8_0.gguf Q8_0
```

aborts in the pre-quantization validation with `ERROR: this quantization requires an importance matrix!` even though the pinned tensors are byte-copied rather than quantized (regression introduced with the early validation pass in #19770).

To fix the regression you can avoid setting `requires_imatrix` when `target_type` and `tensor->type` are the same.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the bug was found and the patch written with Claude Code; reviewed and repro-tested by me (CPU build, fix-side repro, `--dry-run`, and a still-aborts control on a genuinely converting pin).
