### PR TITLE
sampling : reshape logits in backend top_k sampler

### DIFF
--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1309,6 +1309,8 @@ static void llama_sampler_top_k_backend_apply(
 
     struct ggml_tensor * logits_rows = ggml_reshape_2d(ctx, logits, 1, logits->ne[0]);
     data->logits = ggml_get_rows(ctx, logits_rows, top_k);
+    data->logits = ggml_reshape_1d(ctx, data->logits, sctx->k);
+    GGML_ASSERT(ggml_n_dims(data->logits) == 1 && "top_k must leave logits as 1D tensor");
     ggml_set_name(data->logits, "top_k_rows");
 
     GGML_UNUSED(gf);


### PR DESCRIPTION
## Overview

This commit reshapes the data->logits tensor after ggml_get_rows so that it is not a 2D tensor.

## Additional information

The motivation for this change was that when reviewing https://github.com/ggml-org/llama.cpp/pull/25262, which introduces a backend penalty sampler, there was a failing tests where the top_k sampler was before the penalty sampler in the sampling chain. This caused an error because data->logits was not a 1d tensors as expected.

<details><summary>test failure output</summary>

```console
Testing backend top-k followed by penalties
...
/home/danbev/work/ai/llama.cpp/ggml/src/ggml.c:3649: GGML_ASSERT(ggml_nelements(a) == ne0) failed

Thread 1 "test-backend-sa" received signal SIGABRT, Aborted.
__pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
warning: 44	./nptl/pthread_kill.c: No such file or directory
(gdb) up
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
78	in ./nptl/pthread_kill.c
(gdb) 
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
89	in ./nptl/pthread_kill.c
(gdb) 
#3  0x00007ffff584527e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
warning: 26	../sysdeps/posix/raise.c: No such file or directory
(gdb) 
#4  0x00007ffff58288ff in __GI_abort () at ./stdlib/abort.c:79
warning: 79	./stdlib/abort.c: No such file or directory
(gdb) 
#5  0x00007ffff6105058 in ggml_abort (file=0x7ffff61b52d8 "/home/danbev/work/ai/llama.cpp/ggml/src/ggml.c", 
    line=3649, fmt=0x7ffff61b5017 "GGML_ASSERT(%s) failed") at /home/danbev/work/ai/llama.cpp/ggml/src/ggml.c:271
271	    abort();
(gdb) 
#6  0x00007ffff610bd09 in ggml_reshape_1d (ctx=0x5555555d68c0, a=0x555556040ac0, ne0=1)
    at /home/danbev/work/ai/llama.cpp/ggml/src/ggml.c:3649
3649	    GGML_ASSERT(ggml_nelements(a) == ne0);
(gdb) 
#7  0x00007ffff6961dcc in llama_sampler_penalties_backend_apply (smpl=0x5555555d7d00, ctx=0x5555555d68c0, 
    gf=0x555555fd3a00, data=0x7fffffff4de0) at /home/danbev/work/ai/llama.cpp/src/llama-sampler.cpp:2833
2833	        counts_f32 = ggml_reshape_1d(ctx, counts_f32, n_candidates);
(gdb) f
#7  0x00007ffff6961dcc in llama_sampler_penalties_backend_apply (smpl=0x5555555d7d00, ctx=0x5555555d68c0, 
    gf=0x555555fd3a00, data=0x7fffffff4de0) at /home/danbev/work/ai/llama.cpp/src/llama-sampler.cpp:2833
2833	        counts_f32 = ggml_reshape_1d(ctx, counts_f32, n_candidates);
(gdb) l
2828	        ggml_tensor * counts_rows = ggml_fill(
2829	                ctx, ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, sctx->n_vocab), 0.0f);
2830	        ggml_tensor * scatter_rows = ggml_reshape_2d(ctx, counts_f32, 1, sctx->n_max);
2831	        counts_rows = ggml_set_rows(ctx, counts_rows, scatter_rows, sctx->inp_token_ids);
2832	        counts_f32 = ggml_get_rows(ctx, counts_rows, data->candidates);
2833	        counts_f32 = ggml_reshape_1d(ctx, counts_f32, n_candidates);
2834	    } else {
2835	        ggml_tensor * logits_rows = ggml_reshape_2d(ctx, data->logits, 1, ggml_nelements(data->logits));
2836	        gathered = ggml_get_rows(ctx, logits_rows, sctx->inp_token_ids);
2837	        gathered = ggml_reshape_1d(ctx, gathered, sctx->n_max);
(gdb) p data->logits->ne
$2 = {1, 8, 1, 1}

```

</details>

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
