### PR TITLE
spec: support speculators-format checkpoints for DSpark

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -932,6 +932,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     // draft-dspark: the draft carries a Markov head and uses an anchor-first block layout
     const bool is_dspark;
 
+    // dspark speculators exports: DFlash 1+N block, the anchor is not a prediction slot
+    bool bonus_anchor = false;
+
     const int32_t * target_layer_ids   = nullptr; // model_dft's extract layer indices
     uint32_t        target_layer_ids_n = 0;
 
@@ -969,13 +972,21 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         }
         mask_token_id = llama_vocab_mask(llama_model_get_vocab(model_dft));
 
+        if (is_dspark) {
+            char buf[8] = {};
+            if (llama_model_meta_val_str(model_dft, "dflash.bonus_anchor", buf, sizeof(buf)) >= 0) {
+                bonus_anchor = std::strcmp(buf, "true") == 0;
+            }
+        }
+
         LOG_INF("%s: adding speculative implementation '%s'\n", __func__, common_speculative_type_to_str(type).c_str());
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);
-        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u\n", __func__, block_size, mask_token_id, target_layer_ids_n);
+        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u%s\n", __func__, block_size, mask_token_id, target_layer_ids_n,
+                bonus_anchor ? ", bonus_anchor" : "");
 
         // DFlash input is [id_last, <mask> * (block_size-1)]: in-place denoising yields at most
-        // block_size-1 draft tokens, DSpark yield a full block_size draft tokens
-        const int32_t n_draft_max = is_dspark ? block_size : block_size - 1;
+        // block_size-1 draft tokens, anchor-first DSpark yields a full block_size draft tokens
+        const int32_t n_draft_max = is_dspark && !bonus_anchor ? block_size : block_size - 1;
         if (this->params.n_max > n_draft_max || this->params.n_min > n_draft_max) {
             LOG_WRN("%s: requested draft size (n_max=%d, n_min=%d) exceeds the trained block size %d -- clamping to %d\n",
                     __func__, this->params.n_max, this->params.n_min, block_size, n_draft_max);
@@ -1146,7 +1157,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
             const int32_t n_draft = params.n_max;
 
-            const int32_t n_block_tokens = n_draft + (is_dspark ? 0 : 1);
+            const int32_t n_block_tokens = n_draft + (is_dspark && !bonus_anchor ? 0 : 1);
             i_block_beg[seq_id] = batch.n_tokens;
             n_block    [seq_id] = n_block_tokens;
             for (int32_t i = 0; i < n_block_tokens; ++i) {
@@ -1179,11 +1190,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             auto & result = *dp.result;
 
             if (is_dspark) {
-                // DSpark predicts the next token from position 0 and optionally truncates
-                // at the first position below the confidence threshold.
+                // DSpark: read from the first prediction slot, truncate below the confidence threshold
                 const float * conf = params.p_min > 0.0f ? llama_get_embeddings_nextn(ctx_dft) : nullptr;
-
-                for (int32_t i = 0; i < n_block_tokens; ++i) {
+                // bonus-anchor drafts read the mask positions only, like DFlash
+                const int32_t i0 = bonus_anchor ? 1 : 0;
+                for (int32_t i = i0; i < n_block_tokens; ++i) {
                     const int32_t idx = beg + i;
 
                     if (conf && conf[(size_t) idx * n_embd_dec] < params.p_min) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1193,8 +1193,8 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
                 // DSpark: read from the first prediction slot, truncate below the confidence threshold
                 const float * conf = params.p_min > 0.0f ? llama_get_embeddings_nextn(ctx_dft) : nullptr;
                 // bonus-anchor drafts read the mask positions only, like DFlash
-                const int32_t i0 = bonus_anchor ? 1 : 0;
-                for (int32_t i = i0; i < n_block_tokens; ++i) {
+                const int32_t i_first_pred = bonus_anchor ? 1 : 0;
+                for (int32_t i = i_first_pred; i < n_block_tokens; ++i) {
                     const int32_t idx = beg + i;
 
                     if (conf && conf[(size_t) idx * n_embd_dec] < params.p_min) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -926,7 +926,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     // draft-dspark: the draft carries a Markov head and uses an anchor-first block layout
     const bool is_dspark;
 
-    // dspark speculators exports: DFlash 1+N block, the anchor is not a prediction slot
+    // dspark speculators
     bool sample_from_anchor = true;
 
     const int32_t * target_layer_ids   = nullptr; // model_dft's extract layer indices
@@ -971,8 +971,8 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
         LOG_INF("%s: adding speculative implementation '%s'\n", __func__, common_speculative_type_to_str(type).c_str());
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);
-        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u%s\n", __func__, block_size, mask_token_id, target_layer_ids_n,
-                sample_from_anchor ? "" : ", sample_from_anchor=false");
+        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u, sample_from_anchor=%s\n", __func__,
+                block_size, mask_token_id, target_layer_ids_n, sample_from_anchor ? "true" : "false");
 
         // DFlash input is [id_last, <mask> * (block_size-1)]: in-place denoising yields at most
         // block_size-1 draft tokens, anchor-first DSpark yields a full block_size draft tokens
@@ -1215,11 +1215,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             auto & result = *dp.result;
 
             if (is_dspark) {
-                // DSpark: read from the first prediction slot, truncate below the confidence threshold
+                // DSpark: read from the first draft slot, truncate below the confidence threshold
                 const float * conf = params.p_min > 0.0f ? llama_get_embeddings_nextn(ctx_dft) : nullptr;
                 // bonus-anchor drafts read the mask positions only, like DFlash
-                const int32_t i_first_pred = sample_from_anchor ? 0 : 1;
-                for (int32_t i = i_first_pred; i < n_block_tokens; ++i) {
+                const int32_t i_draft_beg = sample_from_anchor ? 0 : 1;
+                for (int32_t i = i_draft_beg; i < n_block_tokens; ++i) {
                     const int32_t idx = beg + i;
 
                     if (conf && conf[(size_t) idx * n_embd_dec] < params.p_min) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -926,6 +926,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     // draft-dspark: the draft carries a Markov head and uses an anchor-first block layout
     const bool is_dspark;
 
+    // dspark speculators exports: DFlash 1+N block, the anchor is not a prediction slot
+    bool bonus_anchor = false;
+
     const int32_t * target_layer_ids   = nullptr; // model_dft's extract layer indices
     uint32_t        target_layer_ids_n = 0;
 
@@ -963,13 +966,21 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         }
         mask_token_id = llama_vocab_mask(llama_model_get_vocab(model_dft));
 
+        if (is_dspark) {
+            char buf[8] = {};
+            if (llama_model_meta_val_str(model_dft, "dflash.bonus_anchor", buf, sizeof(buf)) >= 0) {
+                bonus_anchor = std::strcmp(buf, "true") == 0;
+            }
+        }
+
         LOG_INF("%s: adding speculative implementation '%s'\n", __func__, common_speculative_type_to_str(type).c_str());
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);
-        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u\n", __func__, block_size, mask_token_id, target_layer_ids_n);
+        LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u%s\n", __func__, block_size, mask_token_id, target_layer_ids_n,
+                bonus_anchor ? ", bonus_anchor" : "");
 
         // DFlash input is [id_last, <mask> * (block_size-1)]: in-place denoising yields at most
-        // block_size-1 draft tokens, DSpark yield a full block_size draft tokens
-        const int32_t n_draft_max = is_dspark ? block_size : block_size - 1;
+        // block_size-1 draft tokens, anchor-first DSpark yields a full block_size draft tokens
+        const int32_t n_draft_max = is_dspark && !bonus_anchor ? block_size : block_size - 1;
         if (this->params.n_max > n_draft_max || this->params.n_min > n_draft_max) {
             LOG_WRN("%s: requested draft size (n_max=%d, n_min=%d) exceeds the trained block size %d -- clamping to %d\n",
                     __func__, this->params.n_max, this->params.n_min, block_size, n_draft_max);
@@ -1175,7 +1186,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
             const int32_t n_draft = params.n_max;
 
-            const int32_t n_block_tokens = n_draft + (is_dspark ? 0 : 1);
+            const int32_t n_block_tokens = n_draft + (is_dspark && !bonus_anchor ? 0 : 1);
             i_block_beg[seq_id] = batch.n_tokens;
             n_block    [seq_id] = n_block_tokens;
             for (int32_t i = 0; i < n_block_tokens; ++i) {
@@ -1208,11 +1219,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             auto & result = *dp.result;
 
             if (is_dspark) {
-                // DSpark predicts the next token from position 0 and optionally truncates
-                // at the first position below the confidence threshold.
+                // DSpark: read from the first prediction slot, truncate below the confidence threshold
                 const float * conf = params.p_min > 0.0f ? llama_get_embeddings_nextn(ctx_dft) : nullptr;
-
-                for (int32_t i = 0; i < n_block_tokens; ++i) {
+                // bonus-anchor drafts read the mask positions only, like DFlash
+                const int32_t i0 = bonus_anchor ? 1 : 0;
+                for (int32_t i = i0; i < n_block_tokens; ++i) {
                     const int32_t idx = beg + i;
 
                     if (conf && conf[(size_t) idx * n_embd_dec] < params.p_min) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1222,8 +1222,8 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
                 // DSpark: read from the first prediction slot, truncate below the confidence threshold
                 const float * conf = params.p_min > 0.0f ? llama_get_embeddings_nextn(ctx_dft) : nullptr;
                 // bonus-anchor drafts read the mask positions only, like DFlash
-                const int32_t i0 = bonus_anchor ? 1 : 0;
-                for (int32_t i = i0; i < n_block_tokens; ++i) {
+                const int32_t i_first_pred = bonus_anchor ? 1 : 0;
+                for (int32_t i = i_first_pred; i < n_block_tokens; ++i) {
                     const int32_t idx = beg + i;
 
                     if (conf && conf[(size_t) idx * n_embd_dec] < params.p_min) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -927,7 +927,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     const bool is_dspark;
 
     // dspark speculators exports: DFlash 1+N block, the anchor is not a prediction slot
-    bool bonus_anchor = false;
+    bool sample_from_anchor = true;
 
     const int32_t * target_layer_ids   = nullptr; // model_dft's extract layer indices
     uint32_t        target_layer_ids_n = 0;
@@ -968,19 +968,19 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
         if (is_dspark) {
             char buf[8] = {};
-            if (llama_model_meta_val_str(model_dft, "dflash.bonus_anchor", buf, sizeof(buf)) >= 0) {
-                bonus_anchor = std::strcmp(buf, "true") == 0;
+            if (llama_model_meta_val_str(model_dft, "dflash.sample_from_anchor", buf, sizeof(buf)) >= 0) {
+                sample_from_anchor = std::strcmp(buf, "true") == 0;
             }
         }
 
         LOG_INF("%s: adding speculative implementation '%s'\n", __func__, common_speculative_type_to_str(type).c_str());
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);
         LOG_INF("%s: - block_size=%d, mask_token_id=%d, n_extract=%u%s\n", __func__, block_size, mask_token_id, target_layer_ids_n,
-                bonus_anchor ? ", bonus_anchor" : "");
+                sample_from_anchor ? "" : ", sample_from_anchor=false");
 
         // DFlash input is [id_last, <mask> * (block_size-1)]: in-place denoising yields at most
         // block_size-1 draft tokens, anchor-first DSpark yields a full block_size draft tokens
-        const int32_t n_draft_max = is_dspark && !bonus_anchor ? block_size : block_size - 1;
+        const int32_t n_draft_max = is_dspark && sample_from_anchor ? block_size : block_size - 1;
         if (this->params.n_max > n_draft_max || this->params.n_min > n_draft_max) {
             LOG_WRN("%s: requested draft size (n_max=%d, n_min=%d) exceeds the trained block size %d -- clamping to %d\n",
                     __func__, this->params.n_max, this->params.n_min, block_size, n_draft_max);
@@ -1186,7 +1186,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
             const int32_t n_draft = params.n_max;
 
-            const int32_t n_block_tokens = n_draft + (is_dspark && !bonus_anchor ? 0 : 1);
+            const int32_t n_block_tokens = n_draft + (is_dspark && sample_from_anchor ? 0 : 1);
             i_block_beg[seq_id] = batch.n_tokens;
             n_block    [seq_id] = n_block_tokens;
             for (int32_t i = 0; i < n_block_tokens; ++i) {
@@ -1222,7 +1222,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
                 // DSpark: read from the first prediction slot, truncate below the confidence threshold
                 const float * conf = params.p_min > 0.0f ? llama_get_embeddings_nextn(ctx_dft) : nullptr;
                 // bonus-anchor drafts read the mask positions only, like DFlash
-                const int32_t i_first_pred = bonus_anchor ? 1 : 0;
+                const int32_t i_first_pred = sample_from_anchor ? 0 : 1;
                 for (int32_t i = i_first_pred; i < n_block_tokens; ++i) {
                     const int32_t idx = beg + i;
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -963,15 +963,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             if (llama_model_meta_val_str(model_dft, "dflash.block_size", buf, sizeof(buf)) >= 0) {
                 block_size = std::atoi(buf);
             }
-        }
-        mask_token_id = llama_vocab_mask(llama_model_get_vocab(model_dft));
-
-        if (is_dspark) {
-            char buf[8] = {};
             if (llama_model_meta_val_str(model_dft, "dflash.sample_from_anchor", buf, sizeof(buf)) >= 0) {
                 sample_from_anchor = std::strcmp(buf, "true") == 0;
             }
         }
+        mask_token_id = llama_vocab_mask(llama_model_get_vocab(model_dft));
 
         LOG_INF("%s: adding speculative implementation '%s'\n", __func__, common_speculative_type_to_str(type).c_str());
         LOG_INF("%s: - n_max=%d, n_min=%d, p_min=%.2f\n", __func__, this->params.n_max, this->params.n_min, this->params.p_min);

--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -55,6 +55,8 @@ TEXT_MODEL_MAP: dict[str, str] = {
     "DeepseekV32ForCausalLM": "deepseek",
     "DFlashDraftModel": "qwen",
     "Qwen3DSparkModel": "qwen",
+    "DSparkDraftModel": "qwen",
+    "DSparkSpeculator": "qwen",
     "DeepseekV4ForCausalLM": "deepseek",
     "DeepseekV4DSparkModel": "deepseek",
     "DistilBertForMaskedLM": "bert",

--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -54,6 +54,8 @@ TEXT_MODEL_MAP: dict[str, str] = {
     "DeepseekV32ForCausalLM": "deepseek",
     "DFlashDraftModel": "qwen",
     "Qwen3DSparkModel": "qwen",
+    "DSparkDraftModel": "qwen",
+    "DSparkSpeculator": "qwen",
     "DeepseekV4ForCausalLM": "deepseek",
     "DeepseekV4DSparkModel": "deepseek",
     "DistilBertForMaskedLM": "bert",

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -689,43 +689,33 @@ class DFlashModel(Qwen3Model):
         return super().filter_tensors((name, gen))
 
 
-@ModelBase.register("Qwen3DSparkModel")
+@ModelBase.register("Qwen3DSparkModel", "DSparkDraftModel", "DSparkSpeculator")
 class DSparkModel(DFlashModel):
-    # DSpark = DFlash + a semi-autoregressive Markov head
-    model_arch = gguf.MODEL_ARCH.DFLASH
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # normalize the flat DeepSpec schema to DFlash's nested dflash_config
-        self.hparams.setdefault("dflash_config", {
-            k: self.hparams[k] for k in ("target_layer_ids", "mask_token_id") if k in self.hparams
-        })
-
-    @classmethod
-    def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
-        name, gen = item
-        if name.endswith(("embed_tokens.weight", "lm_head.weight")):
-            return None
-        return super().filter_tensors((name, gen))
-
-
-@ModelBase.register("DSparkDraftModel", "DSparkSpeculator")
-class DSparkSpeculatorsModel(DFlashModel):
-    # speculators-format (SpecForge) DSpark: 1+N bonus-anchor block, optional d2t-reduced draft vocab
+    # DSpark = DFlash + a semi-autoregressive Markov head.
     model_arch = gguf.MODEL_ARCH.DFLASH
 
     def __init__(self, dir_model, *args, **kwargs):
         hparams = kwargs.pop("hparams", None)
         if hparams is None:
             hparams = ModelBase.load_hparams(dir_model, False)
-        if "transformer_layer_config" in hparams:
+
+        # only the arch name separates the SpecForge drafts from the DeepSpec ones
+        self._is_specforge = hparams["architectures"][0] in ("DSparkDraftModel", "DSparkSpeculator")
+        if "transformer_layer_config" in hparams:  # speculators nests the backbone hparams
             hparams = {**hparams, **hparams["transformer_layer_config"]}
-        if "aux_hidden_state_layer_ids" in hparams:
-            hparams.setdefault("dflash_config", {
-                "mask_token_id": hparams.get("mask_token_id"),
-                "target_layer_ids": [i - 1 for i in hparams["aux_hidden_state_layer_ids"]],
-            })
+
         super().__init__(dir_model, *args, hparams=hparams, **kwargs)
+
+        # normalize both schemas to DFlash's nested dflash_config
+        if "aux_hidden_state_layer_ids" in self.hparams:
+            self.hparams.setdefault("dflash_config", {
+                "mask_token_id": self.hparams.get("mask_token_id"),
+                "target_layer_ids": [i - 1 for i in self.hparams["aux_hidden_state_layer_ids"]],
+            })
+        else:
+            self.hparams.setdefault("dflash_config", {
+                k: self.hparams[k] for k in ("target_layer_ids", "mask_token_id") if k in self.hparams
+            })
 
         if (markov_head_type := self.hparams.get("markov_head_type", "vanilla")) != "vanilla":
             raise ValueError(f"unsupported markov_head_type {markov_head_type!r} (only 'vanilla' is supported)")
@@ -739,13 +729,13 @@ class DSparkSpeculatorsModel(DFlashModel):
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
-        # 1+N fill-in block: the anchor slot is a bonus token, not a prediction slot
-        # (newer speculators exports carry the layout explicitly as sample_from_anchor)
-        self.gguf_writer.add_bonus_anchor(not self.hparams.get("sample_from_anchor", False))
+        if self._is_specforge:
+            # 1+N fill-in block: the anchor slot is a bonus token, not a prediction slot
+            self.gguf_writer.add_bonus_anchor(not self.hparams.get("sample_from_anchor", False))
 
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
-        name, gen = item
+        name = item[0]
         if name == "t2d":  # training-only target->draft mask
             return None
         if name == "d2t" or name.startswith("lm_head."):
@@ -775,6 +765,10 @@ class DSparkSpeculatorsModel(DFlashModel):
             pending, self._pending_reduced = self._pending_reduced, []
             for pending_name, pending_data in pending:
                 yield from self._expand_reduced_vocab(pending_data, pending_name)
+            return
+
+        if not self._is_specforge and name.endswith(("embed_tokens.weight", "lm_head.weight")):
+            # DeepSpec drafts share the target's embeddings and head via ctx_other
             return
 
         is_reduced = self._n_vocab_draft < self.hparams["vocab_size"] \

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -9,7 +9,7 @@ import torch
 if TYPE_CHECKING:
     from torch import Tensor
 
-from .base import ModelBase, TextModel, gguf, logger
+from .base import LazyTorchTensor, ModelBase, TextModel, gguf, logger
 
 
 @ModelBase.register("QWenLMHeadModel")
@@ -707,3 +707,89 @@ class DSparkModel(DFlashModel):
         if name.endswith(("embed_tokens.weight", "lm_head.weight")):
             return None
         return super().filter_tensors((name, gen))
+
+
+@ModelBase.register("DSparkDraftModel", "DSparkSpeculator")
+class DSparkSpeculatorsModel(DFlashModel):
+    # speculators-format (SpecForge) DSpark: 1+N bonus-anchor block, optional d2t-reduced draft vocab
+    model_arch = gguf.MODEL_ARCH.DFLASH
+
+    def __init__(self, dir_model, *args, **kwargs):
+        hparams = kwargs.pop("hparams", None)
+        if hparams is None:
+            hparams = ModelBase.load_hparams(dir_model, False)
+        if "transformer_layer_config" in hparams:
+            hparams = {**hparams, **hparams["transformer_layer_config"]}
+        if "aux_hidden_state_layer_ids" in hparams:
+            hparams.setdefault("dflash_config", {
+                "mask_token_id": hparams.get("mask_token_id"),
+                "target_layer_ids": [i - 1 for i in hparams["aux_hidden_state_layer_ids"]],
+            })
+        super().__init__(dir_model, *args, hparams=hparams, **kwargs)
+
+        if (markov_head_type := self.hparams.get("markov_head_type", "vanilla")) != "vanilla":
+            raise ValueError(f"unsupported markov_head_type {markov_head_type!r} (only 'vanilla' is supported)")
+
+        n_vocab = self.hparams["vocab_size"]
+        self._n_vocab_draft = self.hparams.get("draft_vocab_size") or n_vocab
+        if self._n_vocab_draft > n_vocab:
+            raise ValueError(f"draft_vocab_size {self._n_vocab_draft} exceeds vocab_size {n_vocab}")
+        self._d2t: Tensor | None = None
+        self._pending_reduced: list[tuple[str, Tensor]] = []
+
+    def set_gguf_parameters(self):
+        super().set_gguf_parameters()
+        # 1+N fill-in block: the anchor slot is a bonus token, not a prediction slot
+        # (newer speculators exports carry the layout explicitly as sample_from_anchor)
+        self.gguf_writer.add_bonus_anchor(not self.hparams.get("sample_from_anchor", False))
+
+    @classmethod
+    def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
+        name, gen = item
+        if name == "t2d":  # training-only target->draft mask
+            return None
+        if name == "d2t" or name.startswith("lm_head."):
+            # keep un-prefixed: d2t is consumed below, lm_head maps to output
+            return TextModel.filter_tensors(item)
+        return super().filter_tensors(item)
+
+    def _expand_reduced_vocab(self, data_torch: Tensor, name: str) -> Iterable[tuple[str, Tensor]]:
+        assert self._d2t is not None
+        # the scatter needs real values (d2t indexing), so leave lazy-land here
+        data_torch = LazyTorchTensor.to_eager(data_torch)
+        n_vocab = self.hparams["vocab_size"]
+        rows = torch.arange(data_torch.shape[0], dtype=torch.long) + self._d2t
+        full = data_torch.new_zeros((n_vocab, data_torch.shape[1]))
+        full[rows] = data_torch
+        yield from super().modify_tensors(full, name, None)
+        if name.startswith("lm_head."):
+            # mask the target-vocab rows the draft cannot produce
+            bias = torch.full((n_vocab,), -1e9, dtype=torch.float32)
+            bias[rows] = 0.0
+            yield from super().modify_tensors(bias, "lm_head.bias", None)
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        if name == "d2t":
+            # d2t[i] is the offset from draft row i to its target token id
+            self._d2t = LazyTorchTensor.to_eager(data_torch).to(torch.long)
+            pending, self._pending_reduced = self._pending_reduced, []
+            for pending_name, pending_data in pending:
+                yield from self._expand_reduced_vocab(pending_data, pending_name)
+            return
+
+        is_reduced = self._n_vocab_draft < self.hparams["vocab_size"] \
+            and (name.startswith("lm_head.") or name.endswith("markov_head.markov_w2.weight"))
+        if is_reduced:
+            if self._d2t is None:
+                self._pending_reduced.append((name, data_torch))
+            else:
+                yield from self._expand_reduced_vocab(data_torch, name)
+            return
+
+        yield from super().modify_tensors(data_torch, name, bid)
+
+    def prepare_tensors(self):
+        super().prepare_tensors()
+        if self._pending_reduced:
+            raise ValueError("reduced-vocab tensors present but no d2t table found: "
+                             + ", ".join(name for name, _ in self._pending_reduced))

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -708,44 +708,34 @@ class DFlashModel(Qwen3Model):
         yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("Qwen3DSparkModel")
+@ModelBase.register("Qwen3DSparkModel", "DSparkDraftModel", "DSparkSpeculator")
 @ModelBase.example("satgeze/Qwen3.6-27B-DSpark")
 class DSparkModel(DFlashModel):
-    # DSpark = DFlash + a semi-autoregressive Markov head
-    model_arch = gguf.MODEL_ARCH.DFLASH
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # normalize the flat DeepSpec schema to DFlash's nested dflash_config
-        self.hparams.setdefault("dflash_config", {
-            k: self.hparams[k] for k in ("target_layer_ids", "mask_token_id") if k in self.hparams
-        })
-
-    @classmethod
-    def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
-        name, gen = item
-        if name.endswith(("embed_tokens.weight", "lm_head.weight")):
-            return None
-        return super().filter_tensors((name, gen))
-
-
-@ModelBase.register("DSparkDraftModel", "DSparkSpeculator")
-class DSparkSpeculatorsModel(DFlashModel):
-    # speculators-format (SpecForge) DSpark: 1+N bonus-anchor block, optional d2t-reduced draft vocab
+    # DSpark = DFlash + a semi-autoregressive Markov head.
     model_arch = gguf.MODEL_ARCH.DFLASH
 
     def __init__(self, dir_model, *args, **kwargs):
         hparams = kwargs.pop("hparams", None)
         if hparams is None:
             hparams = ModelBase.load_hparams(dir_model, False)
-        if "transformer_layer_config" in hparams:
+
+        # only the arch name separates the SpecForge drafts from the DeepSpec ones
+        self._is_specforge = hparams["architectures"][0] in ("DSparkDraftModel", "DSparkSpeculator")
+        if "transformer_layer_config" in hparams:  # speculators nests the backbone hparams
             hparams = {**hparams, **hparams["transformer_layer_config"]}
-        if "aux_hidden_state_layer_ids" in hparams:
-            hparams.setdefault("dflash_config", {
-                "mask_token_id": hparams.get("mask_token_id"),
-                "target_layer_ids": [i - 1 for i in hparams["aux_hidden_state_layer_ids"]],
-            })
+
         super().__init__(dir_model, *args, hparams=hparams, **kwargs)
+
+        # normalize both schemas to DFlash's nested dflash_config
+        if "aux_hidden_state_layer_ids" in self.hparams:
+            self.hparams.setdefault("dflash_config", {
+                "mask_token_id": self.hparams.get("mask_token_id"),
+                "target_layer_ids": [i - 1 for i in self.hparams["aux_hidden_state_layer_ids"]],
+            })
+        else:
+            self.hparams.setdefault("dflash_config", {
+                k: self.hparams[k] for k in ("target_layer_ids", "mask_token_id") if k in self.hparams
+            })
 
         if (markov_head_type := self.hparams.get("markov_head_type", "vanilla")) != "vanilla":
             raise ValueError(f"unsupported markov_head_type {markov_head_type!r} (only 'vanilla' is supported)")
@@ -759,13 +749,13 @@ class DSparkSpeculatorsModel(DFlashModel):
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
-        # 1+N fill-in block: the anchor slot is a bonus token, not a prediction slot
-        # (newer speculators exports carry the layout explicitly as sample_from_anchor)
-        self.gguf_writer.add_bonus_anchor(not self.hparams.get("sample_from_anchor", False))
+        if self._is_specforge:
+            # 1+N fill-in block: the anchor slot is a bonus token, not a prediction slot
+            self.gguf_writer.add_bonus_anchor(not self.hparams.get("sample_from_anchor", False))
 
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
-        name, gen = item
+        name = item[0]
         if name == "t2d":  # training-only target->draft mask
             return None
         if name == "d2t" or name.startswith("lm_head."):
@@ -795,6 +785,10 @@ class DSparkSpeculatorsModel(DFlashModel):
             pending, self._pending_reduced = self._pending_reduced, []
             for pending_name, pending_data in pending:
                 yield from self._expand_reduced_vocab(pending_data, pending_name)
+            return
+
+        if not self._is_specforge and name.endswith(("embed_tokens.weight", "lm_head.weight")):
+            # DeepSpec drafts share the target's embeddings and head via ctx_other
             return
 
         is_reduced = self._n_vocab_draft < self.hparams["vocab_size"] \

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -755,16 +755,12 @@ class DSparkModel(DFlashModel):
 
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
-        name = item[0]
-        if name == "t2d":  # not used at runtime
+        if item[0] == "t2d":  # not used at runtime
             return None
-        if name == "d2t" or name.startswith("lm_head."):
-            # keep un-prefixed: d2t is consumed in prepare_tensors, lm_head maps to output
-            return TextModel.filter_tensors(item)
         return super().filter_tensors(item)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
-        if name == "d2t":
+        if name == "model.d2t":
             self._d2t = data_torch
             return
 

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -9,7 +9,7 @@ import torch
 if TYPE_CHECKING:
     from torch import Tensor
 
-from .base import ModelBase, TextModel, gguf, logger
+from .base import LazyTorchTensor, ModelBase, TextModel, gguf, logger
 
 
 @ModelBase.register("QWenLMHeadModel")
@@ -727,3 +727,89 @@ class DSparkModel(DFlashModel):
         if name.endswith(("embed_tokens.weight", "lm_head.weight")):
             return None
         return super().filter_tensors((name, gen))
+
+
+@ModelBase.register("DSparkDraftModel", "DSparkSpeculator")
+class DSparkSpeculatorsModel(DFlashModel):
+    # speculators-format (SpecForge) DSpark: 1+N bonus-anchor block, optional d2t-reduced draft vocab
+    model_arch = gguf.MODEL_ARCH.DFLASH
+
+    def __init__(self, dir_model, *args, **kwargs):
+        hparams = kwargs.pop("hparams", None)
+        if hparams is None:
+            hparams = ModelBase.load_hparams(dir_model, False)
+        if "transformer_layer_config" in hparams:
+            hparams = {**hparams, **hparams["transformer_layer_config"]}
+        if "aux_hidden_state_layer_ids" in hparams:
+            hparams.setdefault("dflash_config", {
+                "mask_token_id": hparams.get("mask_token_id"),
+                "target_layer_ids": [i - 1 for i in hparams["aux_hidden_state_layer_ids"]],
+            })
+        super().__init__(dir_model, *args, hparams=hparams, **kwargs)
+
+        if (markov_head_type := self.hparams.get("markov_head_type", "vanilla")) != "vanilla":
+            raise ValueError(f"unsupported markov_head_type {markov_head_type!r} (only 'vanilla' is supported)")
+
+        n_vocab = self.hparams["vocab_size"]
+        self._n_vocab_draft = self.hparams.get("draft_vocab_size") or n_vocab
+        if self._n_vocab_draft > n_vocab:
+            raise ValueError(f"draft_vocab_size {self._n_vocab_draft} exceeds vocab_size {n_vocab}")
+        self._d2t: Tensor | None = None
+        self._pending_reduced: list[tuple[str, Tensor]] = []
+
+    def set_gguf_parameters(self):
+        super().set_gguf_parameters()
+        # 1+N fill-in block: the anchor slot is a bonus token, not a prediction slot
+        # (newer speculators exports carry the layout explicitly as sample_from_anchor)
+        self.gguf_writer.add_bonus_anchor(not self.hparams.get("sample_from_anchor", False))
+
+    @classmethod
+    def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
+        name, gen = item
+        if name == "t2d":  # training-only target->draft mask
+            return None
+        if name == "d2t" or name.startswith("lm_head."):
+            # keep un-prefixed: d2t is consumed below, lm_head maps to output
+            return TextModel.filter_tensors(item)
+        return super().filter_tensors(item)
+
+    def _expand_reduced_vocab(self, data_torch: Tensor, name: str) -> Iterable[tuple[str, Tensor]]:
+        assert self._d2t is not None
+        # the scatter needs real values (d2t indexing), so leave lazy-land here
+        data_torch = LazyTorchTensor.to_eager(data_torch)
+        n_vocab = self.hparams["vocab_size"]
+        rows = torch.arange(data_torch.shape[0], dtype=torch.long) + self._d2t
+        full = data_torch.new_zeros((n_vocab, data_torch.shape[1]))
+        full[rows] = data_torch
+        yield from super().modify_tensors(full, name, None)
+        if name.startswith("lm_head."):
+            # mask the target-vocab rows the draft cannot produce
+            bias = torch.full((n_vocab,), -1e9, dtype=torch.float32)
+            bias[rows] = 0.0
+            yield from super().modify_tensors(bias, "lm_head.bias", None)
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        if name == "d2t":
+            # d2t[i] is the offset from draft row i to its target token id
+            self._d2t = LazyTorchTensor.to_eager(data_torch).to(torch.long)
+            pending, self._pending_reduced = self._pending_reduced, []
+            for pending_name, pending_data in pending:
+                yield from self._expand_reduced_vocab(pending_data, pending_name)
+            return
+
+        is_reduced = self._n_vocab_draft < self.hparams["vocab_size"] \
+            and (name.startswith("lm_head.") or name.endswith("markov_head.markov_w2.weight"))
+        if is_reduced:
+            if self._d2t is None:
+                self._pending_reduced.append((name, data_torch))
+            else:
+                yield from self._expand_reduced_vocab(data_torch, name)
+            return
+
+        yield from super().modify_tensors(data_torch, name, bid)
+
+    def prepare_tensors(self):
+        super().prepare_tensors()
+        if self._pending_reduced:
+            raise ValueError("reduced-vocab tensors present but no d2t table found: "
+                             + ", ".join(name for name, _ in self._pending_reduced))

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -723,7 +723,7 @@ class DSparkModel(DFlashModel):
         # block layout default by arch: speculators drafts are 1+N, DeepSpec ones sample from the anchor
         self._sample_from_anchor = hparams.get(
             "sample_from_anchor", hparams["architectures"][0] not in ("DSparkDraftModel", "DSparkSpeculator"))
-        if "transformer_layer_config" in hparams:  # speculators nests the backbone hparams
+        if "transformer_layer_config" in hparams:
             hparams = {**hparams, **hparams["transformer_layer_config"]}
 
         super().__init__(dir_model, *args, hparams=hparams, **kwargs)
@@ -750,29 +750,24 @@ class DSparkModel(DFlashModel):
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
-        # false: 1+N fill-in block, the anchor slot is a bonus token, not a prediction slot
         self.gguf_writer.add_sample_from_anchor(self._sample_from_anchor)
 
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
         name = item[0]
         if name in ("d2t", "t2d") or name.startswith("lm_head."):
-            # keep un-prefixed: d2t/t2d are consumed below, lm_head maps to output
             return TextModel.filter_tensors(item)
         return super().filter_tensors(item)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         if name == "d2t":
-            # store for manual int64 handling in prepare_tensors (avoid F32 conversion)
             self._d2t = data_torch
             return
 
         if name == "t2d":
-            # not used at runtime, skip
             return
 
         if self._n_vocab_draft == self.hparams["vocab_size"] and name.endswith(("embed_tokens.weight", "lm_head.weight")):
-            # full-vocab drafts share the target's embeddings and head via ctx_other
             return
 
         yield from super().modify_tensors(data_torch, name, bid)

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -4,6 +4,7 @@ import json
 
 from typing import Any, Callable, Iterable, TYPE_CHECKING
 
+import numpy as np
 import torch
 
 if TYPE_CHECKING:
@@ -719,8 +720,9 @@ class DSparkModel(DFlashModel):
         if hparams is None:
             hparams = ModelBase.load_hparams(dir_model, False)
 
-        # only the arch name separates the SpecForge drafts from the DeepSpec ones
-        self._is_specforge = hparams["architectures"][0] in ("DSparkDraftModel", "DSparkSpeculator")
+        # block layout default by arch: speculators drafts are 1+N, DeepSpec ones sample from the anchor
+        self._sample_from_anchor = hparams.get("sample_from_anchor",
+            hparams["architectures"][0] not in ("DSparkDraftModel", "DSparkSpeculator"))
         if "transformer_layer_config" in hparams:  # speculators nests the backbone hparams
             hparams = {**hparams, **hparams["transformer_layer_config"]}
 
@@ -745,65 +747,52 @@ class DSparkModel(DFlashModel):
         if self._n_vocab_draft > n_vocab:
             raise ValueError(f"draft_vocab_size {self._n_vocab_draft} exceeds vocab_size {n_vocab}")
         self._d2t: Tensor | None = None
-        self._pending_reduced: list[tuple[str, Tensor]] = []
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
-        if self._is_specforge:
-            # 1+N fill-in block: the anchor slot is a bonus token, not a prediction slot
-            self.gguf_writer.add_bonus_anchor(not self.hparams.get("sample_from_anchor", False))
+        # false: 1+N fill-in block, the anchor slot is a bonus token, not a prediction slot
+        self.gguf_writer.add_sample_from_anchor(self._sample_from_anchor)
 
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
         name = item[0]
-        if name == "t2d":  # training-only target->draft mask
-            return None
-        if name == "d2t" or name.startswith("lm_head."):
-            # keep un-prefixed: d2t is consumed below, lm_head maps to output
+        if name in ("d2t", "t2d") or name.startswith("lm_head."):
+            # keep un-prefixed: d2t/t2d are consumed below, lm_head maps to output
             return TextModel.filter_tensors(item)
         return super().filter_tensors(item)
 
-    def _expand_reduced_vocab(self, data_torch: Tensor, name: str) -> Iterable[tuple[str, Tensor]]:
-        assert self._d2t is not None
-        # the scatter needs real values (d2t indexing), so leave lazy-land here
-        data_torch = LazyTorchTensor.to_eager(data_torch)
-        n_vocab = self.hparams["vocab_size"]
-        rows = torch.arange(data_torch.shape[0], dtype=torch.long) + self._d2t
-        full = data_torch.new_zeros((n_vocab, data_torch.shape[1]))
-        full[rows] = data_torch
-        yield from super().modify_tensors(full, name, None)
-        if name.startswith("lm_head."):
-            # mask the target-vocab rows the draft cannot produce
-            bias = torch.full((n_vocab,), -1e9, dtype=torch.float32)
-            bias[rows] = 0.0
-            yield from super().modify_tensors(bias, "lm_head.bias", None)
-
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         if name == "d2t":
-            # d2t[i] is the offset from draft row i to its target token id
-            self._d2t = LazyTorchTensor.to_eager(data_torch).to(torch.long)
-            pending, self._pending_reduced = self._pending_reduced, []
-            for pending_name, pending_data in pending:
-                yield from self._expand_reduced_vocab(pending_data, pending_name)
+            # store for manual int64 handling in prepare_tensors (avoid F32 conversion)
+            self._d2t = data_torch
             return
 
-        if not self._is_specforge and name.endswith(("embed_tokens.weight", "lm_head.weight")):
-            # DeepSpec drafts share the target's embeddings and head via ctx_other
+        if name == "t2d":
+            # not used at runtime, skip
             return
 
-        is_reduced = self._n_vocab_draft < self.hparams["vocab_size"] \
-            and (name.startswith("lm_head.") or name.endswith("markov_head.markov_w2.weight"))
-        if is_reduced:
-            if self._d2t is None:
-                self._pending_reduced.append((name, data_torch))
-            else:
-                yield from self._expand_reduced_vocab(data_torch, name)
+        if self._n_vocab_draft == self.hparams["vocab_size"] and name.endswith(("embed_tokens.weight", "lm_head.weight")):
+            # full-vocab drafts share the target's embeddings and head via ctx_other
             return
 
         yield from super().modify_tensors(data_torch, name, bid)
 
     def prepare_tensors(self):
         super().prepare_tensors()
-        if self._pending_reduced:
-            raise ValueError("reduced-vocab tensors present but no d2t table found: "
-                             + ", ".join(name for name, _ in self._pending_reduced))
+
+        n_vocab = self.hparams["vocab_size"]
+        if self._n_vocab_draft < n_vocab and self._d2t is None:
+            raise ValueError(f"draft_vocab_size {self._n_vocab_draft} < vocab_size {n_vocab} but no d2t table found")
+
+        # write d2t as absolute target token ids
+        if self._d2t is not None:
+            data = LazyTorchTensor.to_eager(self._d2t).to(torch.int64).cpu().numpy().reshape(-1)
+            if data.size != self._n_vocab_draft:
+                raise ValueError(f"d2t size {data.size} does not match draft_vocab_size {self._n_vocab_draft}")
+            data = data + np.arange(data.size, dtype=np.int64)
+            if np.any((data < 0) | (data >= n_vocab)):
+                raise ValueError(f"d2t target ids out of range for target vocab size {n_vocab}")
+            if np.unique(data).size != data.size:
+                raise ValueError("d2t contains duplicate target ids")
+            logger.info(f"{'d2t,':<30} --> I64, shape = {{{data.size}}}")
+            self.gguf_writer.add_tensor("d2t", data, raw_dtype=gguf.GGMLQuantizationType.I64)

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -721,8 +721,8 @@ class DSparkModel(DFlashModel):
             hparams = ModelBase.load_hparams(dir_model, False)
 
         # block layout default by arch: speculators drafts are 1+N, DeepSpec ones sample from the anchor
-        self._sample_from_anchor = hparams.get("sample_from_anchor",
-            hparams["architectures"][0] not in ("DSparkDraftModel", "DSparkSpeculator"))
+        self._sample_from_anchor = hparams.get(
+            "sample_from_anchor", hparams["architectures"][0] not in ("DSparkDraftModel", "DSparkSpeculator"))
         if "transformer_layer_config" in hparams:  # speculators nests the backbone hparams
             hparams = {**hparams, **hparams["transformer_layer_config"]}
 

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -720,9 +720,10 @@ class DSparkModel(DFlashModel):
         if hparams is None:
             hparams = ModelBase.load_hparams(dir_model, False)
 
-        # block layout default by arch: speculators drafts are 1+N, DeepSpec ones sample from the anchor
+        # EAGLE3-style exports use the 1+N bonus-anchor block, DFlash-lineage exports sample from the anchor
         self._sample_from_anchor = hparams.get(
-            "sample_from_anchor", hparams["architectures"][0] not in ("DSparkDraftModel", "DSparkSpeculator"))
+            "sample_from_anchor",
+            "transformer_layer_config" not in hparams and "aux_hidden_state_layer_ids" not in hparams)
         if "transformer_layer_config" in hparams:
             hparams = {**hparams, **hparams["transformer_layer_config"]}
 

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -756,16 +756,16 @@ class DSparkModel(DFlashModel):
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
         name = item[0]
-        if name in ("d2t", "t2d") or name.startswith("lm_head."):
+        if name == "t2d":  # not used at runtime
+            return None
+        if name == "d2t" or name.startswith("lm_head."):
+            # keep un-prefixed: d2t is consumed in prepare_tensors, lm_head maps to output
             return TextModel.filter_tensors(item)
         return super().filter_tensors(item)
 
     def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
         if name == "d2t":
             self._d2t = data_torch
-            return
-
-        if name == "t2d":
             return
 
         if self._n_vocab_draft == self.hparams["vocab_size"] and name.endswith(("embed_tokens.weight", "lm_head.weight")):

--- a/docs/speculative.md
+++ b/docs/speculative.md
@@ -106,6 +106,10 @@ acceptance (from the draft's confidence head, if present) falls below `P` (defau
 Currently only drafts with a Qwen3 backbone are supported; support for other backbones
 (e.g. Gemma4) is planned.
 
+DSpark drafts exported in the [speculators](https://github.com/vllm-project/speculators) format
+(for example [`RedHatAI/gemma-4-31B-it-speculator.dspark`](https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dspark))
+convert the same way.
+
 See:
 
 - #25173

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -160,6 +160,7 @@ class Keys:
         TARGET_LAYERS                     = "{arch}.target_layers"
         TARGET_HIDDEN_SIZE                = "{arch}.target_hidden_size"
         BLOCK_SIZE                        = "{arch}.block_size"
+        BONUS_ANCHOR                      = "{arch}.bonus_anchor"
         NORM_BEFORE_RESIDUAL              = "{arch}.norm_before_residual"
         NORM_BEFORE_FC                    = "{arch}.norm_before_fc"
 
@@ -4381,6 +4382,8 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.D2T,
     ],
     MODEL_ARCH.DFLASH: [
+        MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT,
         MODEL_TENSOR.OUTPUT_NORM,
         MODEL_TENSOR.ATTN_NORM,
         MODEL_TENSOR.ATTN_Q,

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -162,6 +162,7 @@ class Keys:
         TARGET_LAYERS                     = "{arch}.target_layers"
         TARGET_HIDDEN_SIZE                = "{arch}.target_hidden_size"
         BLOCK_SIZE                        = "{arch}.block_size"
+        BONUS_ANCHOR                      = "{arch}.bonus_anchor"
         NORM_BEFORE_RESIDUAL              = "{arch}.norm_before_residual"
         NORM_BEFORE_FC                    = "{arch}.norm_before_fc"
 
@@ -4819,6 +4820,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
     ],
     MODEL_ARCH.DFLASH: [
         MODEL_TENSOR.TOKEN_EMBD,
+        MODEL_TENSOR.OUTPUT,
         MODEL_TENSOR.OUTPUT_NORM,
         MODEL_TENSOR.ATTN_NORM,
         MODEL_TENSOR.ATTN_Q,

--- a/gguf-py/gguf/constants.py
+++ b/gguf-py/gguf/constants.py
@@ -162,7 +162,7 @@ class Keys:
         TARGET_LAYERS                     = "{arch}.target_layers"
         TARGET_HIDDEN_SIZE                = "{arch}.target_hidden_size"
         BLOCK_SIZE                        = "{arch}.block_size"
-        BONUS_ANCHOR                      = "{arch}.bonus_anchor"
+        SAMPLE_FROM_ANCHOR                = "{arch}.sample_from_anchor"
         NORM_BEFORE_RESIDUAL              = "{arch}.norm_before_residual"
         NORM_BEFORE_FC                    = "{arch}.norm_before_fc"
 
@@ -4860,6 +4860,7 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
         MODEL_TENSOR.FFN_UP_SHEXP,
         MODEL_TENSOR.FC,
         MODEL_TENSOR.ENC_OUTPUT_NORM,
+        MODEL_TENSOR.D2T,
         # optional DSpark heads
         MODEL_TENSOR.DSPARK_MARKOV_W1,
         MODEL_TENSOR.DSPARK_MARKOV_W2,

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -962,6 +962,9 @@ class GGUFWriter:
     def add_block_size(self, value: int) -> None:
         self.add_uint32(Keys.LLM.BLOCK_SIZE.format(arch=self.arch), value)
 
+    def add_bonus_anchor(self, value: bool) -> None:
+        self.add_bool(Keys.LLM.BONUS_ANCHOR.format(arch=self.arch), value)
+
     def add_target_layers(self, value: Sequence[int]) -> None:
         self.add_array(Keys.LLM.TARGET_LAYERS.format(arch=self.arch), value)
 

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -981,8 +981,8 @@ class GGUFWriter:
     def add_block_size(self, value: int) -> None:
         self.add_uint32(Keys.LLM.BLOCK_SIZE.format(arch=self.arch), value)
 
-    def add_bonus_anchor(self, value: bool) -> None:
-        self.add_bool(Keys.LLM.BONUS_ANCHOR.format(arch=self.arch), value)
+    def add_sample_from_anchor(self, value: bool) -> None:
+        self.add_bool(Keys.LLM.SAMPLE_FROM_ANCHOR.format(arch=self.arch), value)
 
     def add_target_layers(self, value: Sequence[int]) -> None:
         self.add_array(Keys.LLM.TARGET_LAYERS.format(arch=self.arch), value)

--- a/gguf-py/gguf/gguf_writer.py
+++ b/gguf-py/gguf/gguf_writer.py
@@ -981,6 +981,9 @@ class GGUFWriter:
     def add_block_size(self, value: int) -> None:
         self.add_uint32(Keys.LLM.BLOCK_SIZE.format(arch=self.arch), value)
 
+    def add_bonus_anchor(self, value: bool) -> None:
+        self.add_bool(Keys.LLM.BONUS_ANCHOR.format(arch=self.arch), value)
+
     def add_target_layers(self, value: Sequence[int]) -> None:
         self.add_array(Keys.LLM.TARGET_LAYERS.format(arch=self.arch), value)
 

--- a/gguf-py/gguf/tensor_mapping.py
+++ b/gguf-py/gguf/tensor_mapping.py
@@ -76,14 +76,14 @@ class TensorNameMap:
         # Output
         MODEL_TENSOR.OUTPUT: (
             "embed_out",                 # gptneox
-            "lm_head",                   # gpt2 mpt falcon llama-hf baichuan qwen mamba dbrx jais nemotron exaone olmoe olmo2 phimoe plamo2
+            "lm_head",                   # gpt2 mpt falcon llama-hf baichuan qwen mamba dbrx jais nemotron exaone olmoe olmo2 phimoe plamo2 llama4
             "output",                    # llama-pth bloom internlm2
             "word_embeddings_for_head",  # persimmon
             "lm_head.linear",            # phi2
             "output_layer",              # chatglm
             "head",                      # rwkv
             "head.out",                  # wavtokenizer
-            "lm_head",                   # llama4
+            "model.lm_head",             # dflash
             "model.transformer.ff_out",  # llada
             "head.decoder",              # modern-bert
         ),

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -240,9 +240,10 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     const int64_t block_size = std::stoi(it->second);
     GGML_ASSERT(block_size > 0);
 
-    // bonus anchor (speculators exports): position 0 is not a prediction slot, drafting starts at the first mask
+    // bonus anchor (SpecForge exports): slot 0 holds a bonus token, not a prediction slot
     const auto it_ba = model.gguf_kv.find("dflash.bonus_anchor");
-    const int64_t i0 = it_ba != model.gguf_kv.end() && it_ba->second == "true" ? 1 : 0;
+    const bool    bonus_anchor  = it_ba != model.gguf_kv.end() && it_ba->second == "true";
+    const int64_t i_first_pred  = bonus_anchor ? 1 : 0;
 
     const int64_t n_blocks = g.ubatch.n_seqs_unq;
     GGML_ASSERT(n_blocks > 0 && n_tok % n_blocks == 0 && "DSpark markov head requires equal-size blocks");
@@ -265,7 +266,7 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     ggml_tensor * cat      = nullptr;
     ggml_tensor * cat_conf = nullptr;
 
-    if (i0 > 0) {
+    if (bonus_anchor) {
         // bonus anchor slot: pass the logits through unbiased, pad the (unread) confidence column
         cat      = ggml_cont(ctx0, ggml_view_2d(ctx0, base, n_vocab, n_blocks, base_stride, 0));
         cat_conf = ggml_sigmoid(ctx0, ggml_cont(ctx0, ggml_view_2d(ctx0, base, 1, n_blocks, base_stride, 0)));
@@ -273,7 +274,7 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
 
     // TODO: the in-graph chain is greedy (argmax); sampling params affect only the final
     //       token pick, not the Markov conditioning path
-    for (int64_t i = i0; i < block_drafts; ++i) {
+    for (int64_t i = i_first_pred; i < block_drafts; ++i) {
         ggml_tensor * w1_prev = ggml_get_rows(ctx0, w1, prev);   // [R, n_blocks]
         ggml_tensor * bias    = ggml_mul_mat(ctx0, w2, w1_prev); // [n_vocab, n_blocks]
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -150,6 +150,11 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
         return;
     }
 
+    // optional: reduced-vocab drafts ship their own, full-vocab drafts share the target's via ctx_other
+    tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
+    output   = create_tensor(tn(LLM_TENSOR_OUTPUT,     "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
+    output_b = create_tensor(tn(LLM_TENSOR_OUTPUT,     "bias"),   { n_vocab },         TENSOR_NOT_REQUIRED);
+
     for (int i = 0; i < n_layer; ++i) {
         auto & layer = layers[i];
 
@@ -235,6 +240,10 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     const int64_t block_size = std::stoi(it->second);
     GGML_ASSERT(block_size > 0);
 
+    // bonus anchor (speculators exports): position 0 is not a prediction slot, drafting starts at the first mask
+    const auto it_ba = model.gguf_kv.find("dflash.bonus_anchor");
+    const int64_t i0 = it_ba != model.gguf_kv.end() && it_ba->second == "true" ? 1 : 0;
+
     const int64_t n_blocks = g.ubatch.n_seqs_unq;
     GGML_ASSERT(n_blocks > 0 && n_tok % n_blocks == 0 && "DSpark markov head requires equal-size blocks");
     // runtime tokens per block in this ubatch (anchor + drafted positions), bounded by training block_size
@@ -256,9 +265,15 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     ggml_tensor * cat      = nullptr;
     ggml_tensor * cat_conf = nullptr;
 
+    if (i0 > 0) {
+        // bonus anchor slot: pass the logits through unbiased, pad the (unread) confidence column
+        cat      = ggml_cont(ctx0, ggml_view_2d(ctx0, base, n_vocab, n_blocks, base_stride, 0));
+        cat_conf = ggml_sigmoid(ctx0, ggml_cont(ctx0, ggml_view_2d(ctx0, base, 1, n_blocks, base_stride, 0)));
+    }
+
     // TODO: the in-graph chain is greedy (argmax); sampling params affect only the final
     //       token pick, not the Markov conditioning path
-    for (int64_t i = 0; i < block_drafts; ++i) {
+    for (int64_t i = i0; i < block_drafts; ++i) {
         ggml_tensor * w1_prev = ggml_get_rows(ctx0, w1, prev);   // [R, n_blocks]
         ggml_tensor * bias    = ggml_mul_mat(ctx0, w2, w1_prev); // [n_vocab, n_blocks]
 
@@ -488,6 +503,10 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
     }
 
     cur = build_lora_mm(output, cur);
+    if (model.output_b) {
+        // reduced-draft-vocab exports: -1e9 on the target rows the draft cannot produce
+        cur = ggml_add(ctx0, cur, model.output_b);
+    }
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -157,6 +157,11 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
         return;
     }
 
+    // optional: reduced-vocab drafts ship their own, full-vocab drafts share the target's via ctx_other
+    tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
+    output   = create_tensor(tn(LLM_TENSOR_OUTPUT,     "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
+    output_b = create_tensor(tn(LLM_TENSOR_OUTPUT,     "bias"),   { n_vocab },         TENSOR_NOT_REQUIRED);
+
     for (int i = 0; i < n_layer; ++i) {
         auto & layer = layers[i];
 
@@ -242,6 +247,10 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     const int64_t block_size = std::stoi(it->second);
     GGML_ASSERT(block_size > 0);
 
+    // bonus anchor (speculators exports): position 0 is not a prediction slot, drafting starts at the first mask
+    const auto it_ba = model.gguf_kv.find("dflash.bonus_anchor");
+    const int64_t i0 = it_ba != model.gguf_kv.end() && it_ba->second == "true" ? 1 : 0;
+
     const int64_t n_blocks = g.ubatch.n_seqs_unq;
     GGML_ASSERT(n_blocks > 0 && n_tok % n_blocks == 0 && "DSpark markov head requires equal-size blocks");
     // runtime tokens per block in this ubatch (anchor + drafted positions), bounded by training block_size
@@ -263,9 +272,15 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     ggml_tensor * cat      = nullptr;
     ggml_tensor * cat_conf = nullptr;
 
+    if (i0 > 0) {
+        // bonus anchor slot: pass the logits through unbiased, pad the (unread) confidence column
+        cat      = ggml_cont(ctx0, ggml_view_2d(ctx0, base, n_vocab, n_blocks, base_stride, 0));
+        cat_conf = ggml_sigmoid(ctx0, ggml_cont(ctx0, ggml_view_2d(ctx0, base, 1, n_blocks, base_stride, 0)));
+    }
+
     // TODO: the in-graph chain is greedy (argmax); sampling params affect only the final
     //       token pick, not the Markov conditioning path
-    for (int64_t i = 0; i < block_drafts; ++i) {
+    for (int64_t i = i0; i < block_drafts; ++i) {
         ggml_tensor * w1_prev = ggml_get_rows(ctx0, w1, prev);   // [R, n_blocks]
         ggml_tensor * bias    = ggml_mul_mat(ctx0, w2, w1_prev); // [n_vocab, n_blocks]
 
@@ -497,6 +512,10 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
     }
 
     cur = build_lora_mm(output, cur, output_s);
+    if (model.output_b) {
+        // reduced-draft-vocab exports: -1e9 on the target rows the draft cannot produce
+        cur = ggml_add(ctx0, cur, model.output_b);
+    }
     cb(cur, "result_output", -1);
     res->t_logits = cur;
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -255,10 +255,10 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     const int64_t block_size = std::stoi(it->second);
     GGML_ASSERT(block_size > 0);
 
-    // bonus anchor (SpecForge exports): slot 0 holds a bonus token, not a prediction slot
-    const auto it_sample_from_anchor = model.gguf_kv.find("dflash.sample_from_anchor");
-    const bool    sample_from_anchor = it_sample_from_anchor == model.gguf_kv.end() || it_sample_from_anchor->second == "true";
-    const int64_t i_first_pred       = sample_from_anchor ? 0 : 1;
+    // bonus anchor (SpecForge exports): slot 0 is a bonus token, not a prediction slot
+    const auto it_anchor          = model.gguf_kv.find("dflash.sample_from_anchor");
+    const bool sample_from_anchor = it_anchor == model.gguf_kv.end() || it_anchor->second == "true";
+    const int64_t i_draft_beg    = sample_from_anchor ? 0 : 1;
 
     const int64_t n_blocks = g.ubatch.n_seqs_unq;
     GGML_ASSERT(n_blocks > 0 && n_tok % n_blocks == 0 && "DSpark markov head requires equal-size blocks");
@@ -289,7 +289,7 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
 
     // TODO: the in-graph chain is greedy (argmax); sampling params affect only the final
     //       token pick, not the Markov conditioning path
-    for (int64_t i = i_first_pred; i < block_drafts; ++i) {
+    for (int64_t i = i_draft_beg; i < block_drafts; ++i) {
         ggml_tensor * w1_prev = ggml_get_rows(ctx0, w1, prev);   // [R, n_blocks]
         ggml_tensor * bias    = ggml_mul_mat(ctx0, w2, w1_prev); // [n_vocab_draft, n_blocks]
         if (model.d2t) {

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -247,9 +247,10 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     const int64_t block_size = std::stoi(it->second);
     GGML_ASSERT(block_size > 0);
 
-    // bonus anchor (speculators exports): position 0 is not a prediction slot, drafting starts at the first mask
+    // bonus anchor (SpecForge exports): slot 0 holds a bonus token, not a prediction slot
     const auto it_ba = model.gguf_kv.find("dflash.bonus_anchor");
-    const int64_t i0 = it_ba != model.gguf_kv.end() && it_ba->second == "true" ? 1 : 0;
+    const bool    bonus_anchor  = it_ba != model.gguf_kv.end() && it_ba->second == "true";
+    const int64_t i_first_pred  = bonus_anchor ? 1 : 0;
 
     const int64_t n_blocks = g.ubatch.n_seqs_unq;
     GGML_ASSERT(n_blocks > 0 && n_tok % n_blocks == 0 && "DSpark markov head requires equal-size blocks");
@@ -272,7 +273,7 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     ggml_tensor * cat      = nullptr;
     ggml_tensor * cat_conf = nullptr;
 
-    if (i0 > 0) {
+    if (bonus_anchor) {
         // bonus anchor slot: pass the logits through unbiased, pad the (unread) confidence column
         cat      = ggml_cont(ctx0, ggml_view_2d(ctx0, base, n_vocab, n_blocks, base_stride, 0));
         cat_conf = ggml_sigmoid(ctx0, ggml_cont(ctx0, ggml_view_2d(ctx0, base, 1, n_blocks, base_stride, 0)));
@@ -280,7 +281,7 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
 
     // TODO: the in-graph chain is greedy (argmax); sampling params affect only the final
     //       token pick, not the Markov conditioning path
-    for (int64_t i = i0; i < block_drafts; ++i) {
+    for (int64_t i = i_first_pred; i < block_drafts; ++i) {
         ggml_tensor * w1_prev = ggml_get_rows(ctx0, w1, prev);   // [R, n_blocks]
         ggml_tensor * bias    = ggml_mul_mat(ctx0, w2, w1_prev); // [n_vocab, n_blocks]
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -85,6 +85,16 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
     const int64_t n_embd_inp = hparams.n_embd_inp_enc();
 
     tok_embd        = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD,       "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
+
+    // reduced draft vocab (optional): d2t maps draft rows to target token ids
+    int64_t n_vocab_draft = n_vocab;
+    const struct ggml_tensor * d2t_meta = ml->get_tensor_meta("d2t");
+    if (d2t_meta) {
+        n_vocab_draft = d2t_meta->ne[0];
+        d2t = create_tensor(tn(LLM_TENSOR_D2T), { n_vocab_draft }, 0);
+        LLAMA_LOG_INFO("%s: DFlash using d2t mapping (draft_vocab_size = %lld)\n", __func__, (long long) n_vocab_draft);
+    }
+
     // DSpark = DFlash + a semi-autoregressive Markov head and Confidence head
     //
     // TODO: only Qwen3-style backbones are supported for now; other backbones (e.g. Gemma4)
@@ -94,7 +104,7 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
         const int64_t dspark_markov_rank = markov_meta->ne[0];
 
         dspark_markov_w1 = create_tensor(tn(LLM_TENSOR_DSPARK_MARKOV_W1, "weight"), { dspark_markov_rank, n_vocab }, 0);
-        dspark_markov_w2 = create_tensor(tn(LLM_TENSOR_DSPARK_MARKOV_W2, "weight"), { dspark_markov_rank, n_vocab }, 0);
+        dspark_markov_w2 = create_tensor(tn(LLM_TENSOR_DSPARK_MARKOV_W2, "weight"), { dspark_markov_rank, n_vocab_draft }, 0);
 
         dspark_conf_proj   = create_tensor(tn(LLM_TENSOR_DSPARK_CONF_PROJ, "weight"), { n_embd + dspark_markov_rank, 1 }, 0);
         dspark_conf_proj_b = create_tensor(tn(LLM_TENSOR_DSPARK_CONF_PROJ, "bias"),   { 1 },             TENSOR_NOT_REQUIRED);
@@ -158,9 +168,7 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
     }
 
     // optional: reduced-vocab drafts ship their own, full-vocab drafts share the target's via ctx_other
-    tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
-    output   = create_tensor(tn(LLM_TENSOR_OUTPUT,     "weight"), { n_embd, n_vocab }, TENSOR_NOT_REQUIRED);
-    output_b = create_tensor(tn(LLM_TENSOR_OUTPUT,     "bias"),   { n_vocab },         TENSOR_NOT_REQUIRED);
+    output   = create_tensor(tn(LLM_TENSOR_OUTPUT,     "weight"), { n_embd, n_vocab_draft }, TENSOR_NOT_REQUIRED);
 
     for (int i = 0; i < n_layer; ++i) {
         auto & layer = layers[i];
@@ -248,9 +256,9 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     GGML_ASSERT(block_size > 0);
 
     // bonus anchor (SpecForge exports): slot 0 holds a bonus token, not a prediction slot
-    const auto it_ba = model.gguf_kv.find("dflash.bonus_anchor");
-    const bool    bonus_anchor  = it_ba != model.gguf_kv.end() && it_ba->second == "true";
-    const int64_t i_first_pred  = bonus_anchor ? 1 : 0;
+    const auto it_sample_from_anchor = model.gguf_kv.find("dflash.sample_from_anchor");
+    const bool    sample_from_anchor = it_sample_from_anchor == model.gguf_kv.end() || it_sample_from_anchor->second == "true";
+    const int64_t i_first_pred       = sample_from_anchor ? 0 : 1;
 
     const int64_t n_blocks = g.ubatch.n_seqs_unq;
     GGML_ASSERT(n_blocks > 0 && n_tok % n_blocks == 0 && "DSpark markov head requires equal-size blocks");
@@ -273,7 +281,7 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     ggml_tensor * cat      = nullptr;
     ggml_tensor * cat_conf = nullptr;
 
-    if (bonus_anchor) {
+    if (!sample_from_anchor) {
         // bonus anchor slot: pass the logits through unbiased, pad the (unread) confidence column
         cat      = ggml_cont(ctx0, ggml_view_2d(ctx0, base, n_vocab, n_blocks, base_stride, 0));
         cat_conf = ggml_sigmoid(ctx0, ggml_cont(ctx0, ggml_view_2d(ctx0, base, 1, n_blocks, base_stride, 0)));
@@ -283,7 +291,16 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     //       token pick, not the Markov conditioning path
     for (int64_t i = i_first_pred; i < block_drafts; ++i) {
         ggml_tensor * w1_prev = ggml_get_rows(ctx0, w1, prev);   // [R, n_blocks]
-        ggml_tensor * bias    = ggml_mul_mat(ctx0, w2, w1_prev); // [n_vocab, n_blocks]
+        ggml_tensor * bias    = ggml_mul_mat(ctx0, w2, w1_prev); // [n_vocab_draft, n_blocks]
+        if (model.d2t) {
+            // reduced draft vocab: scatter the bias to the target rows (base is -inf on the others)
+            const int64_t n_draft_vocab = bias->ne[0];
+            ggml_tensor * full = ggml_fill(ctx0, ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, 1, n_vocab, n_blocks), 0.0f);
+            bias = ggml_set_rows(ctx0, full,
+                    ggml_reshape_3d(ctx0, bias,      1,             n_draft_vocab, n_blocks),
+                    ggml_reshape_3d(ctx0, model.d2t, n_draft_vocab, 1,             1));
+            bias = ggml_reshape_2d(ctx0, bias, n_vocab, n_blocks);
+        }
 
         // position i of every block: strided view [n_vocab, n_blocks]
         ggml_tensor * base_i = ggml_view_2d(ctx0, base, n_vocab, n_blocks, base_stride, i*base->nb[1]);
@@ -513,9 +530,21 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
     }
 
     cur = build_lora_mm(output, cur, output_s);
-    if (model.output_b) {
-        // reduced-draft-vocab exports: -1e9 on the target rows the draft cannot produce
-        cur = ggml_add(ctx0, cur, model.output_b);
+
+    // reduced-draft-vocab exports: scatter the draft logits to the target vocabulary via d2t
+    if (model.d2t) {
+        const int64_t n_draft_vocab = cur->ne[0];
+        const int64_t n_outputs     = cur->ne[1];
+        const int64_t n_vocab       = (int64_t) model.vocab.n_tokens();
+
+        GGML_ASSERT(model.d2t->type == GGML_TYPE_I64);
+        GGML_ASSERT(model.d2t->ne[0] == n_draft_vocab);
+
+        ggml_tensor * logits = ggml_fill(ctx0, ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, 1, n_vocab, n_outputs), -INFINITY);
+        cur = ggml_set_rows(ctx0, logits,
+                ggml_reshape_3d(ctx0, cur,       1,             n_draft_vocab, n_outputs),
+                ggml_reshape_3d(ctx0, model.d2t, n_draft_vocab, 1,             1));
+        cur = ggml_reshape_2d(ctx0, cur, n_vocab, n_outputs);
     }
     cb(cur, "result_output", -1);
     res->t_logits = cur;


### PR DESCRIPTION
## Overview
Follow-up to #25173. This adds support for DSpark drafts exported in the [speculators](https://github.com/vllm-project/speculators) format (SpecForge / RedHat), which vLLM gained in vllm-project/vllm#47093.
## Format differences
These checkpoints differ from the dense DeepSpec checkpoints in same ways:

The speculators config uses `sample_from_anchor` to declare the block layout: `true` selects anchor-first, matching dense DeepSpec where every slot predicts a token; `false` selects DFlash-style `1+N` infilling, where the anchor slot contains the bonus token and `1 + n_max` slots produce n_max draft tokens. A missing field defaults to false, since legacy exports only use the `1+N` layout.

A checkpoint may use a pruned draft output vocabulary `(draft_vocab_size < vocab_size)` together with a draft-to-target `(d2t)` remapping table.
<!-- Describe what this PR does and why. Be concise but complete -->

## Verification
[`makora-ai/gemma4-26b-a4b-dspark`](https://huggingface.co/makora-ai/gemma4-26b-a4b-dspark)
```
category       base_avg_pred_t/s  spec_avg_pred_t/s  decode_speedup  base_avg_latency  spec_avg_latency  latency_speedup  accept_rate
  -------------  -----------------  -----------------  --------------  ----------------  ----------------  ---------------  -----------
  coding         82.59              145.53             1.76x           32.130s           18.790s           1.71x            0.5777
  humanities     83.68              89.31              1.07x           16.266s           17.955s           0.91x            0.2816
  math           83.87              96.88              1.16x           13.976s           14.484s           0.96x            0.3016
  qa             84.36              89.16              1.06x           10.334s           9.125s            1.13x            0.3173
  rag            83.29              104.72             1.26x           11.497s           10.121s           1.14x            0.3347
  reasoning      83.83              88.92              1.06x           15.457s           17.113s           0.90x            0.2790
  stem           83.95              89.88              1.07x           13.436s           16.299s           0.82x            0.2823
  writing        81.62              81.47              1.00x           32.122s           31.942s           1.01x            0.2379
  multilingual   84.05              91.50              1.09x           11.673s           10.677s           1.09x            0.3052
  summarization  84.51              92.09              1.09x           6.422s            5.352s            1.20x            0.2873
  roleplay       83.12              83.53              1.00x           33.010s           32.700s           1.01x            0.2678
  overall        83.53              95.73              1.15x           17.848s           16.778s           1.06x            0.3079
```
[`RedHatAI/gemma-4-31B-it-speculator.dspark`](https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dspark)
```
Comparison: baseline=baseline.json speculative=dspark.json
category       base_avg_pred_t/s  spec_avg_pred_t/s  decode_speedup  base_avg_latency  spec_avg_latency  latency_speedup  accept_rate
-------------  -----------------  -----------------  --------------  ----------------  ----------------  ---------------  -----------
coding         14.56              45.15              3.10x           121.646s          40.026s           3.04x            0.4527     
humanities     14.69              29.65              2.02x           56.045s           24.973s           2.24x            0.2536     
math           14.71              33.19              2.26x           44.351s           18.708s           2.37x            0.2829     
qa             14.78              30.67              2.08x           26.889s           13.033s           2.06x            0.2420     
rag            14.60              36.29              2.49x           46.995s           21.810s           2.15x            0.2871     
reasoning      14.71              29.17              1.98x           43.860s           20.688s           2.12x            0.2279     
stem           14.71              29.23              1.99x           39.184s           17.862s           2.19x            0.2294     
writing        14.40              31.40              2.18x           152.613s          74.782s           2.04x            0.2514     
multilingual   14.65              31.12              2.12x           69.500s           32.204s           2.16x            0.2646     
summarization  14.73              28.12              1.91x           33.126s           17.515s           1.89x            0.2150     
roleplay       14.60              29.71              2.04x           128.897s          66.507s           1.94x            0.2397     
overall        14.65              32.15              2.19x           69.373s           31.646s           2.19x            0.2720    
```
[qwen3.8-27B-dspark](https://huggingface.co/RadixArk/Qwen3.8-27B-DSpark)
```
Comparison: baseline=baseline.json speculative=dspark.json
category       base_avg_pred_t/s  spec_avg_pred_t/s  decode_speedup  base_avg_latency  spec_avg_latency  latency_speedup  accept_rate
  -------------  -----------------  -----------------  --------------  ----------------  ----------------  ---------------  -----------
  coding         30.69              64.01              2.09x           117.807s          58.013s           2.03x            0.2974
  humanities     30.72              56.07              1.83x           80.424s           27.638s           2.91x            0.2541
  math           30.76              62.44              2.03x           62.089s           17.632s           3.52x            0.2702
  qa             30.83              54.68              1.77x           35.403s           28.461s           1.24x            0.2545
  rag            30.82              70.27              2.28x           23.925s           10.134s           2.36x            0.3510
  reasoning      30.71              56.35              1.83x           74.643s           21.051s           3.55x            0.2617
  stem           30.71              56.21              1.83x           72.119s           20.270s           3.56x            0.2614
  writing        30.61              58.19              1.90x           111.408s          65.433s           1.70x            0.2410
  multilingual   30.77              61.50              2.00x           41.699s           28.240s           1.48x            0.3058
  summarization  30.85              56.27              1.82x           9.774s            3.635s            2.69x            0.2610
  roleplay       30.72              56.53              1.84x           94.722s           43.616s           2.17x            0.2830
  overall        30.74              59.32              1.93x           65.819s           29.466s           2.23x            0.2723
```
## Additional information
**Testing and feedback are welcome.**
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
