### PR TITLE
qwen3 : add sliding-window attention pattern support

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -217,6 +217,18 @@ class Qwen3Model(Qwen2Model):
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
+
+        # Emit sliding-window attention config when present in the HF config.
+        # Guarded so this is a no-op for standard Qwen3 models that do not set
+        # use_sliding_window (i.e. all first-party Alibaba Qwen3 dense models).
+        use_sliding_window = self.hparams.get("use_sliding_window", False)
+        sliding_window = self.hparams.get("sliding_window")
+        layer_types = self.hparams.get("layer_types")
+        if use_sliding_window and sliding_window and layer_types:
+            is_swa = [lt == "sliding_attention" for lt in layer_types]
+            self.gguf_writer.add_sliding_window(sliding_window)
+            self.gguf_writer.add_sliding_window_pattern(is_swa)
+
         if self.is_rerank:
             self.gguf_writer.add_pooling_type(gguf.PoolingType.RANK)
             self.gguf_writer.add_classifier_output_labels(["yes", "no"])

--- a/examples/embedding/embedding.cpp
+++ b/examples/embedding/embedding.cpp
@@ -6,6 +6,8 @@
 #include <clocale>
 #include <ctime>
 #include <algorithm>
+#include <sstream>
+#include <unordered_set>
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
@@ -27,10 +29,12 @@ static std::vector<std::string> split_lines(const std::string & s, const std::st
     return lines;
 }
 
-static void batch_add_seq(llama_batch & batch, const std::vector<int32_t> & tokens, llama_seq_id seq_id) {
+static void batch_add_seq(llama_batch & batch, const std::vector<int32_t> & tokens, llama_seq_id seq_id,
+                          const std::unordered_set<int32_t> & output_ids = {}) {
     size_t n_tokens = tokens.size();
     for (size_t i = 0; i < n_tokens; i++) {
-        common_batch_add(batch, tokens[i], i, { seq_id }, true);
+        bool is_output = output_ids.empty() || output_ids.count(tokens[i]) > 0;
+        common_batch_add(batch, tokens[i], i, { seq_id }, is_output);
     }
 }
 
@@ -46,6 +50,7 @@ static void batch_decode(llama_context * ctx, llama_batch & batch, float * outpu
         LOG_ERR("%s : failed to process\n", __func__);
     }
 
+    int out_idx = 0; // compact sequential index into the output buffer for pooling=none
     for (int i = 0; i < batch.n_tokens; i++) {
         if (!batch.logits[i]) {
             continue;
@@ -57,7 +62,8 @@ static void batch_decode(llama_context * ctx, llama_batch & batch, float * outpu
         if (pooling_type == LLAMA_POOLING_TYPE_NONE) {
             // try to get token embeddings
             embd = llama_get_embeddings_ith(ctx, i);
-            embd_pos = i;
+            // use compact position: only output tokens are stored, in encounter order
+            embd_pos = out_idx++;
             GGML_ASSERT(embd != NULL && "failed to get token embeddings");
         } else {
             // try to get sequence embeddings - supported only when pooling_type is not NONE
@@ -96,6 +102,30 @@ static void print_raw_embeddings(const float * emb,
 
 int main(int argc, char ** argv) {
     std::setlocale(LC_NUMERIC, "C");
+
+    // Parse --output-token-ids before common_params_parse (unknown flag would error otherwise).
+    // When set, only tokens whose ID is in the set are marked as output; the result is a compact
+    // embedding array containing only those token positions (in encounter order).
+    std::unordered_set<int32_t> output_token_ids;
+    {
+        std::vector<char*> argv2;
+        argv2.push_back(argv[0]);
+        for (int i = 1; i < argc; i++) {
+            if (std::string(argv[i]) == "--output-token-ids" && i + 1 < argc) {
+                std::stringstream ss(argv[++i]);
+                std::string tok;
+                while (std::getline(ss, tok, ',')) {
+                    if (!tok.empty()) {
+                        output_token_ids.insert(std::stoi(tok));
+                    }
+                }
+            } else {
+                argv2.push_back(argv[i]);
+            }
+        }
+        argc = (int)argv2.size();
+        std::copy(argv2.begin(), argv2.end(), argv);
+    }
 
     common_params params;
 
@@ -248,7 +278,13 @@ int main(int argc, char ** argv) {
     int n_embd_count = 0;
     if (pooling_type == LLAMA_POOLING_TYPE_NONE) {
         for (int k = 0; k < n_prompts; k++) {
-            n_embd_count += inputs[k].size();
+            if (output_token_ids.empty()) {
+                n_embd_count += inputs[k].size();
+            } else {
+                for (auto t : inputs[k]) {
+                    if (output_token_ids.count(t)) n_embd_count++;
+                }
+            }
         }
     } else {
         n_embd_count = n_prompts;
@@ -272,13 +308,20 @@ int main(int argc, char ** argv) {
         if (batch.n_tokens + n_toks > n_batch || s >= n_seq_max) {
             float * out = emb + e * n_embd_out;
             batch_decode(ctx, batch, out, s, n_embd_out, params.embd_normalize);
-            e += pooling_type == LLAMA_POOLING_TYPE_NONE ? batch.n_tokens : s;
+            if (pooling_type == LLAMA_POOLING_TYPE_NONE) {
+                // count only the output-marked tokens (compact buffer)
+                int n_out = 0;
+                for (int j = 0; j < batch.n_tokens; j++) n_out += batch.logits[j] != 0;
+                e += n_out;
+            } else {
+                e += s;
+            }
             s = 0;
             common_batch_clear(batch);
         }
 
         // add to batch
-        batch_add_seq(batch, inp, s);
+        batch_add_seq(batch, inp, s, output_token_ids);
         s += 1;
     }
 

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -533,6 +533,7 @@ struct llama_model_qwen3 : public llama_model_base {
     void load_arch_hparams(llama_model_loader & ml) override;
     void load_arch_tensors(llama_model_loader & ml) override;
 
+    template <bool iswa>
     struct graph : public llm_graph_context {
         graph(const llama_model & model, const llm_graph_params & params);
     };

--- a/src/models/qwen3.cpp
+++ b/src/models/qwen3.cpp
@@ -175,13 +175,15 @@ llama_model_qwen3::graph<iswa>::graph(const llama_model & model, const llm_graph
     cb(cur, "result_norm", -1);
     res->t_embd = cur;
 
-    // lm_head
-    cur = build_lora_mm(model.output, cur, model.output_s);
+    // skip lm_head in embedding mode with pooling=none (logit tensor is too large for long-context)
+    if (!cparams.embeddings || pooling_type != LLAMA_POOLING_TYPE_NONE) {
+        cur = build_lora_mm(model.output, cur, model.output_s);
 
-    cb(cur, "result_output", -1);
-    res->t_logits = cur;
+        cb(cur, "result_output", -1);
+        res->t_logits = cur;
 
-    ggml_build_forward_expand(gf, cur);
+        ggml_build_forward_expand(gf, cur);
+    }
 }
 
 template struct llama_model_qwen3::graph<false>;

--- a/src/models/qwen3.cpp
+++ b/src/models/qwen3.cpp
@@ -10,6 +10,21 @@ void llama_model_qwen3::load_arch_hparams(llama_model_loader & ml) {
         case 64: type = LLM_TYPE_32B; break;
         default: type = LLM_TYPE_UNKNOWN;
     }
+
+    // sliding-window attention (optional - absent in standard Qwen3 GGUFs)
+    const bool found_swa = ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false);
+    if (found_swa && hparams.n_swa > 0) {
+        hparams.swa_type = LLAMA_SWA_TYPE_STANDARD;
+        // try scalar period (uniform interleave); fall back to per-layer bool array
+        uint32_t swa_period = 0;
+        if (ml.get_key_or_arr(LLM_KV_ATTENTION_SLIDING_WINDOW_PATTERN, swa_period, false)) {
+            hparams.set_swa_pattern(swa_period, true);
+        } else {
+            ml.get_key_or_arr(LLM_KV_ATTENTION_SLIDING_WINDOW_PATTERN, hparams.is_swa_impl, hparams.n_layer());
+        }
+    } else {
+        hparams.swa_type = LLAMA_SWA_TYPE_NONE;
+    }
 }
 
 void llama_model_qwen3::load_arch_tensors(llama_model_loader &) {
@@ -47,10 +62,15 @@ void llama_model_qwen3::load_arch_tensors(llama_model_loader &) {
 }
 
 std::unique_ptr<llm_graph_context> llama_model_qwen3::build_arch_graph(const llm_graph_params & params) const {
-    return std::make_unique<graph>(*this, params);
+    if (hparams.swa_type == LLAMA_SWA_TYPE_STANDARD) {
+        return std::make_unique<graph<true>>(*this, params);
+    } else {
+        return std::make_unique<graph<false>>(*this, params);
+    }
 }
 
-llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+template <bool iswa>
+llama_model_qwen3::graph<iswa>::graph(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
     const int64_t n_embd_head = hparams.n_embd_head_v();
 
     GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
@@ -64,7 +84,13 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
     // inp_pos - contains the positions
     ggml_tensor * inp_pos = build_inp_pos();
 
-    auto * inp_attn = build_attn_inp_kv();
+    using inp_attn_type = std::conditional_t<iswa, llm_graph_input_attn_kv_iswa, llm_graph_input_attn_kv>;
+    inp_attn_type * inp_attn = nullptr;
+    if constexpr (iswa) {
+        inp_attn = build_attn_inp_kv_iswa();
+    } else {
+        inp_attn = build_attn_inp_kv();
+    }
 
     ggml_tensor * inp_out_ids = build_inp_out_ids();
 
@@ -157,3 +183,6 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
 
     ggml_build_forward_expand(gf, cur);
 }
+
+template struct llama_model_qwen3::graph<false>;
+template struct llama_model_qwen3::graph<true>;


### PR DESCRIPTION
## Overview
Add SWA (sliding window attention) support to Qwen3 type models.
Currently, a per-layer `sliding_window_pattern` bool array is ignored at model loading time for Qwen3 models. This PR adds functionality to enable converting, and loading Qwen3-based architectures (e.g. jina-reranker-v3.5) with custom/irregular SWA patterns. Fallback (no sliding window) ensures model runs with full attention.
Also optimizes : 
- GPU mem usage by avoiding building the full logit tensor when not required by the model (cparams.embeddings && pooling_type == NONE)
- speed, by reducing JSON outputs on llama-embedding (adds `--output-token-ids`)


## Additional information
tested:
[pass] llama-embedding --pooling last and --pooling none on Qwen3-0.6B produces correct embeddings
[pass] jina-reranker-v3.5 BF16 GGUF: NDCG@10 = 0.4604 vs HF reference 0.4616 on 50 queries of AILAStatutes
[fail] llama-bench/llama-perplexity failure due to pre-existing bug: GGML_ASSERT(buffer) in llm_graph_input_out_ids::set_input, llama-graph.cpp:201

## Requirements
- I have read and agree with the contributing guidelines
- AI usage disclosure: YES — used for mechanical code completion on established design
