### PR TITLE
rpc: parallelize cached tensor hashing during model load

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -484,28 +484,64 @@ static void ggml_backend_rpc_buffer_memset_tensor(
 }
 
 static void ggml_backend_rpc_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
+    // Parallel model-loading workers can call set_tensor concurrently.
+    // Serialize complete set-tensor request/response transactions because
+    // RPC devices for the same endpoint may share one socket.
+    static std::mutex set_tensor_mutex;
+
     ggml_backend_rpc_buffer_context * ctx = (ggml_backend_rpc_buffer_context *)buffer->context;
     rpc_tensor rpc_tensor = serialize_tensor(tensor);
     if (size > HASH_THRESHOLD) {
+        // Keep the expensive byte-at-a-time FNV pass outside the socket lock.
+        const uint64_t hash = fnv_hash((const uint8_t *) data, size);
         rpc_msg_set_tensor_hash_req request;
         request.tensor = rpc_tensor;
         request.offset = offset;
-        request.hash = fnv_hash((const uint8_t*)data, size);
+        request.hash = hash;
         rpc_msg_set_tensor_hash_rsp response;
+        // Keep the hash query and any cold-cache fallback upload together as
+        // one transaction on the shared socket.
+        std::lock_guard<std::mutex> lock(set_tensor_mutex);
         bool status = send_rpc_cmd(ctx->sock, RPC_CMD_SET_TENSOR_HASH, &request, sizeof(request), &response, sizeof(response));
         RPC_STATUS_ASSERT(status);
         if (response.result) {
-            // the server has the same data, no need to send it
+            // The server already has identical cached tensor data, no need to send it
             return;
         }
+
+        // Input format:
+        // | rpc_tensor | offset (8 bytes) | data (size bytes) |
+        const size_t input_size =
+            sizeof(rpc_tensor) + sizeof(uint64_t) + size;
+
+        std::vector<uint8_t> input(input_size, 0);
+        memcpy(input.data(), &rpc_tensor, sizeof(rpc_tensor));
+        memcpy(input.data() + sizeof(rpc_tensor), &offset, sizeof(offset));
+        memcpy(
+            input.data() + sizeof(rpc_tensor) + sizeof(offset),
+            data,
+            size);
+
+        status = send_rpc_cmd(
+            ctx->sock,
+            RPC_CMD_SET_TENSOR,
+            input.data(),
+            input.size());
+
+        RPC_STATUS_ASSERT(status);
+        return;
     }
     // input serialization format: | rpc_tensor | offset (8 bytes) | data (size bytes)
-    size_t input_size = sizeof(rpc_tensor) + sizeof(uint64_t) + size;
+    // Small tensors skip the cache hash lookup but still share the socket.
+    const size_t input_size = sizeof(rpc_tensor) + sizeof(uint64_t) + size;
+
     std::vector<uint8_t> input(input_size, 0);
     memcpy(input.data(), &rpc_tensor, sizeof(rpc_tensor));
     memcpy(input.data() + sizeof(rpc_tensor), &offset, sizeof(offset));
     memcpy(input.data() + sizeof(rpc_tensor) + sizeof(offset), data, size);
-    bool status = send_rpc_cmd(ctx->sock, RPC_CMD_SET_TENSOR, input.data(), input.size());
+    std::lock_guard<std::mutex> lock(set_tensor_mutex);
+    const bool status = send_rpc_cmd(ctx->sock, RPC_CMD_SET_TENSOR, input.data(), input.size());
+
     RPC_STATUS_ASSERT(status);
 }
 

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -7,12 +7,20 @@
 #include "llama.h"
 
 #include <algorithm>
+#include <atomic>
 #include <array>
+#include <chrono>
 #include <cinttypes>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <future>
+#include <mutex>
 #include <regex>
+#include <thread>
+#include <unordered_set>
+#include <vector>
 
 static const size_t kiB = 1024;
 static const size_t MiB = 1024*kiB;
@@ -1051,6 +1059,38 @@ static bool weight_buft_supported(const llama_hparams & hparams, ggml_tensor * w
     return op_supported;
 }
 
+// RPC cache hits still require the client to hash the complete tensor before
+// asking the server for the cached copy. The RPC backend uses a byte-at-a-time
+// FNV-1a hash, so doing this in the normal tensor loop pins one CPU core.
+//
+// With mmap, the source bytes remain stable for the entire load. This lets us
+// submit independent RPC tensors from multiple workers. Hashing happens in
+// parallel; the RPC backend must serialize complete socket transactions.
+static bool ggml_buffer_is_rpc(ggml_backend_buffer_t buffer) {
+    if (buffer == nullptr) {
+        return false;
+    }
+
+    ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buffer);
+    const char * name = buft ? ggml_backend_buft_name(buft) : nullptr;
+    return name != nullptr && std::strncmp(name, "RPC", 3) == 0;
+}
+
+static size_t ggml_rpc_load_threads() {
+    const char * value = std::getenv("GGML_RPC_LOAD_THREADS");
+    if (value == nullptr || value[0] == '\0') {
+        return 0;
+    }
+
+    char * end = nullptr;
+    const unsigned long parsed = std::strtoul(value, &end, 10);
+    if (end == value || *end != '\0' || parsed < 2) {
+        return 0;
+    }
+
+    return std::min<size_t>(parsed, 64);
+}
+
 // find the first buffer type in the list that can use the tensor
 static ggml_backend_buffer_type_t select_weight_buft(const llama_hparams & hparams, ggml_tensor * tensor, ggml_op op, const buft_list_t * buft_list) {
     GGML_ASSERT(!buft_list->empty());
@@ -1538,6 +1578,108 @@ bool llama_model_loader::load_all_data(
             ggml_backend_name(upload_backend));
     }
 
+    std::unordered_set<ggml_tensor *> rpc_preloaded;
+
+    // Opt-in and mmap-only: source pointers remain valid and each worker
+    // touches a distinct tensor. HASH_THRESHOLD is 10 MiB in ggml-rpc; smaller
+    // tensors are sent directly and do not benefit from parallel cache hashing.
+    //
+    // IMPORTANT: the RPC backend must protect each complete request/response
+    // transaction on its shared endpoint socket. Without that companion RPC
+    // lock, concurrent ggml_backend_tensor_set() calls are not safe.
+    const size_t rpc_threads = ggml_rpc_load_threads();
+    if (use_mmap && !check_tensors && rpc_threads > 1) {
+        constexpr size_t rpc_hash_threshold = 10 * MiB;
+
+        struct rpc_load_job {
+            ggml_tensor * tensor;
+            const void  * data;
+            size_t        size;
+        };
+
+        std::vector<rpc_load_job> jobs;
+        std::unordered_set<size_t> job_files;
+        size_t jobs_bytes = 0;
+
+        for (ggml_tensor * tensor = ggml_get_first_tensor(ctx);
+             tensor != nullptr;
+             tensor = ggml_get_next_tensor(ctx, tensor)) {
+            const auto * weight = get_weight(ggml_get_name(tensor));
+            if (weight == nullptr || tensor->data == nullptr || !ggml_buffer_is_rpc(tensor->buffer)) {
+                continue;
+            }
+
+            const size_t tensor_size = ggml_nbytes(tensor);
+            if (tensor_size <= rpc_hash_threshold) {
+                continue;
+            }
+
+            const auto & mapping = mappings.at(weight->idx);
+            const void * data = (const uint8_t *) mapping->addr() + weight->offs;
+            jobs.push_back({tensor, data, tensor_size});
+            job_files.insert(weight->idx);
+            jobs_bytes += tensor_size;
+        }
+
+        if (!jobs.empty()) {
+            const size_t n_workers = std::min(rpc_threads, jobs.size());
+            LLAMA_LOG_INFO("%s: preloading %zu RPC tensors (%.2f GiB across %zu GGUF shards) with %zu mmap workers\n",
+                    __func__, jobs.size(), jobs_bytes / (double) GiB, job_files.size(), n_workers);
+
+            const auto preload_start = std::chrono::steady_clock::now();
+            std::atomic<size_t> next_job {0};
+            std::atomic<bool> stop_workers {false};
+            std::exception_ptr worker_error;
+            std::mutex worker_error_mutex;
+            std::vector<std::thread> workers;
+            workers.reserve(n_workers);
+
+            for (size_t i = 0; i < n_workers; ++i) {
+                workers.emplace_back([&]() {
+                    try {
+                        while (!stop_workers.load(std::memory_order_relaxed)) {
+                            const size_t job_index = next_job.fetch_add(1, std::memory_order_relaxed);
+                            if (job_index >= jobs.size()) {
+                                break;
+                            }
+
+                            const rpc_load_job & job = jobs[job_index];
+                            ggml_backend_tensor_set(job.tensor, job.data, 0, job.size);
+                        }
+                    } catch (...) {
+                        stop_workers.store(true, std::memory_order_relaxed);
+                        std::lock_guard<std::mutex> lock(worker_error_mutex);
+                        if (!worker_error) {
+                            worker_error = std::current_exception();
+                        }
+                    }
+                });
+            }
+
+            for (std::thread & worker : workers) {
+                worker.join();
+            }
+            if (worker_error) {
+                std::rethrow_exception(worker_error);
+            }
+
+            rpc_preloaded.reserve(jobs.size());
+            for (const rpc_load_job & job : jobs) {
+                rpc_preloaded.insert(job.tensor);
+            }
+
+            const double preload_seconds = std::chrono::duration<double>(
+                    std::chrono::steady_clock::now() - preload_start).count();
+            const double gib_per_second = preload_seconds > 0.0
+                    ? jobs_bytes / (double) GiB / preload_seconds
+                    : 0.0;
+            LLAMA_LOG_INFO("%s: parallel RPC preload complete in %.2f s (%.2f GiB/s)\n",
+                    __func__, preload_seconds, gib_per_second);
+        }
+    } else if (rpc_threads > 1 && !use_mmap) {
+        LLAMA_LOG_WARN("%s: GGML_RPC_LOAD_THREADS requires mmap; disable --direct-io and enable mmap\n", __func__);
+    }
+
     for (struct ggml_tensor * cur = ggml_get_first_tensor(ctx); cur != NULL; cur = ggml_get_next_tensor(ctx, cur)) {
         const auto * weight = get_weight(ggml_get_name(cur));
         if (weight == nullptr) {
@@ -1552,6 +1694,11 @@ bool llama_model_loader::load_all_data(
         }
 
         size_t n_size = ggml_nbytes(cur);
+
+        if (rpc_preloaded.find(cur) != rpc_preloaded.end()) {
+            size_done += n_size;
+            continue;
+        }
 
         if (use_mmap) {
             const auto & mapping = mappings.at(weight->idx);

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -7,12 +7,20 @@
 #include "llama.h"
 
 #include <algorithm>
+#include <atomic>
 #include <array>
+#include <chrono>
 #include <cinttypes>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <future>
+#include <mutex>
 #include <regex>
+#include <thread>
+#include <unordered_set>
+#include <vector>
 
 static const size_t kiB = 1024;
 static const size_t MiB = 1024*kiB;
@@ -1024,6 +1032,38 @@ static bool weight_buft_supported(const llama_hparams & hparams, ggml_tensor * w
     return op_supported;
 }
 
+// RPC cache hits still require the client to hash the complete tensor before
+// asking the server for the cached copy. The RPC backend uses a byte-at-a-time
+// FNV-1a hash, so doing this in the normal tensor loop pins one CPU core.
+//
+// With mmap, the source bytes remain stable for the entire load. This lets us
+// submit independent RPC tensors from multiple workers. Hashing happens in
+// parallel; the RPC backend must serialize complete socket transactions.
+static bool ggml_buffer_is_rpc(ggml_backend_buffer_t buffer) {
+    if (buffer == nullptr) {
+        return false;
+    }
+
+    ggml_backend_buffer_type_t buft = ggml_backend_buffer_get_type(buffer);
+    const char * name = buft ? ggml_backend_buft_name(buft) : nullptr;
+    return name != nullptr && std::strncmp(name, "RPC", 3) == 0;
+}
+
+static size_t ggml_rpc_load_threads() {
+    const char * value = std::getenv("GGML_RPC_LOAD_THREADS");
+    if (value == nullptr || value[0] == '\0') {
+        return 0;
+    }
+
+    char * end = nullptr;
+    const unsigned long parsed = std::strtoul(value, &end, 10);
+    if (end == value || *end != '\0' || parsed < 2) {
+        return 0;
+    }
+
+    return std::min<size_t>(parsed, 64);
+}
+
 // find the first buffer type in the list that can use the tensor
 static ggml_backend_buffer_type_t select_weight_buft(const llama_hparams & hparams, ggml_tensor * tensor, ggml_op op, const buft_list_t * buft_list) {
     GGML_ASSERT(!buft_list->empty());
@@ -1514,6 +1554,108 @@ bool llama_model_loader::load_all_data(
             ggml_backend_name(upload_backend));
     }
 
+    std::unordered_set<ggml_tensor *> rpc_preloaded;
+
+    // Opt-in and mmap-only: source pointers remain valid and each worker
+    // touches a distinct tensor. HASH_THRESHOLD is 10 MiB in ggml-rpc; smaller
+    // tensors are sent directly and do not benefit from parallel cache hashing.
+    //
+    // IMPORTANT: the RPC backend must protect each complete request/response
+    // transaction on its shared endpoint socket. Without that companion RPC
+    // lock, concurrent ggml_backend_tensor_set() calls are not safe.
+    const size_t rpc_threads = ggml_rpc_load_threads();
+    if (use_mmap && !check_tensors && rpc_threads > 1) {
+        constexpr size_t rpc_hash_threshold = 10 * MiB;
+
+        struct rpc_load_job {
+            ggml_tensor * tensor;
+            const void  * data;
+            size_t        size;
+        };
+
+        std::vector<rpc_load_job> jobs;
+        std::unordered_set<size_t> job_files;
+        size_t jobs_bytes = 0;
+
+        for (ggml_tensor * tensor = ggml_get_first_tensor(ctx);
+             tensor != nullptr;
+             tensor = ggml_get_next_tensor(ctx, tensor)) {
+            const auto * weight = get_weight(ggml_get_name(tensor));
+            if (weight == nullptr || tensor->data == nullptr || !ggml_buffer_is_rpc(tensor->buffer)) {
+                continue;
+            }
+
+            const size_t tensor_size = ggml_nbytes(tensor);
+            if (tensor_size <= rpc_hash_threshold) {
+                continue;
+            }
+
+            const auto & mapping = mappings.at(weight->idx);
+            const void * data = (const uint8_t *) mapping->addr() + weight->offs;
+            jobs.push_back({tensor, data, tensor_size});
+            job_files.insert(weight->idx);
+            jobs_bytes += tensor_size;
+        }
+
+        if (!jobs.empty()) {
+            const size_t n_workers = std::min(rpc_threads, jobs.size());
+            LLAMA_LOG_INFO("%s: preloading %zu RPC tensors (%.2f GiB across %zu GGUF shards) with %zu mmap workers\n",
+                    __func__, jobs.size(), jobs_bytes / (double) GiB, job_files.size(), n_workers);
+
+            const auto preload_start = std::chrono::steady_clock::now();
+            std::atomic<size_t> next_job {0};
+            std::atomic<bool> stop_workers {false};
+            std::exception_ptr worker_error;
+            std::mutex worker_error_mutex;
+            std::vector<std::thread> workers;
+            workers.reserve(n_workers);
+
+            for (size_t i = 0; i < n_workers; ++i) {
+                workers.emplace_back([&]() {
+                    try {
+                        while (!stop_workers.load(std::memory_order_relaxed)) {
+                            const size_t job_index = next_job.fetch_add(1, std::memory_order_relaxed);
+                            if (job_index >= jobs.size()) {
+                                break;
+                            }
+
+                            const rpc_load_job & job = jobs[job_index];
+                            ggml_backend_tensor_set(job.tensor, job.data, 0, job.size);
+                        }
+                    } catch (...) {
+                        stop_workers.store(true, std::memory_order_relaxed);
+                        std::lock_guard<std::mutex> lock(worker_error_mutex);
+                        if (!worker_error) {
+                            worker_error = std::current_exception();
+                        }
+                    }
+                });
+            }
+
+            for (std::thread & worker : workers) {
+                worker.join();
+            }
+            if (worker_error) {
+                std::rethrow_exception(worker_error);
+            }
+
+            rpc_preloaded.reserve(jobs.size());
+            for (const rpc_load_job & job : jobs) {
+                rpc_preloaded.insert(job.tensor);
+            }
+
+            const double preload_seconds = std::chrono::duration<double>(
+                    std::chrono::steady_clock::now() - preload_start).count();
+            const double gib_per_second = preload_seconds > 0.0
+                    ? jobs_bytes / (double) GiB / preload_seconds
+                    : 0.0;
+            LLAMA_LOG_INFO("%s: parallel RPC preload complete in %.2f s (%.2f GiB/s)\n",
+                    __func__, preload_seconds, gib_per_second);
+        }
+    } else if (rpc_threads > 1 && !use_mmap) {
+        LLAMA_LOG_WARN("%s: GGML_RPC_LOAD_THREADS requires mmap; disable --direct-io and enable mmap\n", __func__);
+    }
+
     for (struct ggml_tensor * cur = ggml_get_first_tensor(ctx); cur != NULL; cur = ggml_get_next_tensor(ctx, cur)) {
         const auto * weight = get_weight(ggml_get_name(cur));
         if (weight == nullptr) {
@@ -1528,6 +1670,11 @@ bool llama_model_loader::load_all_data(
         }
 
         size_t n_size = ggml_nbytes(cur);
+
+        if (rpc_preloaded.find(cur) != rpc_preloaded.end()) {
+            size_done += n_size;
+            continue;
+        }
 
         if (use_mmap) {
             const auto & mapping = mappings.at(weight->idx);

--- a/tools/rpc/README.md
+++ b/tools/rpc/README.md
@@ -83,6 +83,20 @@ $ llama-cli -hf ggml-org/gemma-3-1b-it-GGUF -ngl 99 --rpc 192.168.88.10:50052,19
 By default, llama.cpp distributes model weights and the KV cache across all available devices -- both local and remote -- in proportion to each device's available memory.
 You can override this behavior with the `--tensor-split` option and set custom proportions when splitting tensor data across devices.
 
+### RPC load threads
+
+For mmap model loads, large RPC-backed tensors can be prepared using multiple
+worker threads on the main host by setting `GGML_RPC_LOAD_THREADS`:
+
+```bash
+$ GGML_RPC_LOAD_THREADS=8 llama-cli ... --rpc 192.168.88.10:50052
+```
+
+This uses multiple CPU workers for the client-side read/hash work during model
+loading and can significantly reduce load time. RPC load threads are currently
+supported only with mmap, as the workers require stable mapped tensor data. The
+feature is disabled when the variable is unset.
+
 ### Local cache
 
 The RPC server can use a local cache to store large tensors and avoid transferring them over the network.


### PR DESCRIPTION
## Overview

Related to #25890.

Up to 20-60% lower RPC model load time by adding GGML_RPC_LOAD_THREADS. 

On RPC-cache loads, the client fully FNV-hashes each large RPC tensor one at a time before dispatching it. For large models, this can pin a single CPU core at 100% while the remaining cores sit mostly idle.

This change:
- Uses an opt-in worker pool (GGML_RPC_LOAD_THREADS) to hash large mmap-backed RPC tensors concurrently.
- Serializes complete set_tensor transactions, because RPC devices for the same endpoint may share a socket (e.g. RPC0 and RPC1 will share a socket).
- Makes no changes to the default loading path, RPC protocol, or cache format

## Additional information

Main host: Ryzen 9 3900X, 128 GB RAM, 2× RTX 4060 Ti 16 GB, 
RPC host: Ryzen 5 9600X, 192 GB RAM, 1× RTX 4060 Ti 16 GB
Connected via 2.5gbps peer to peer lan. 
Model: Kimi-K2.7-Code UD-IQ2_M, 318 GiB, 8 files
RPC CPU allocation: approximately 143 GiB
GGML_RPC_LOAD_THREADS=12

On this very limited hardware, we see a near 3x improvement to the loading phase:
 
##### On b10173 - "state":"loading" 4min54sec
```
load-mode = mmap

[55965] 1.57.697.172 I load_tensors: RPC0[10.44.0.2:50052] model buffer size =   594.13 MiB
[55965] 1.57.697.173 I load_tensors: RPC1[10.44.0.2:50052] model buffer size = 143149.18 MiB
[55965] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":0.0}}
[55965] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":1.0}}
[55965] 6.51.217.230 I cmn  common_init_: added [EOS] logit bias = -inf

```

##### With this PR and GGML_RPC_LOAD_THREADS 12 - "state":"loading" 1min38sec
```
-- env GGML_RPC_LOAD_THREADS 12 
load-mode = mmap

[49635] 1.58.187.278 I load_tensors: RPC0[10.44.0.2:50052] model buffer size =   594.13 MiB
[49635] 1.58.187.278 I load_tensors: RPC1[10.44.0.2:50052] model buffer size = 143149.18 MiB
[49635] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":0.0}}
[49635] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":0.5258322954177856}}
[49635] 2.06.980.323 I load_all_data: preloading 20 RPC tensors (0.39 GiB across 1 GGUF shards) with 12 mmap workers
[49635] 2.07.513.035 I load_all_data: parallel RPC preload complete in 0.53 s (0.73 GiB/s)
[49635] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":0.5276646614074707}}
[49635] 2.08.208.854 I load_all_data: preloading 265 RPC tensors (138.07 GiB across 7 GGUF shards) with 12 mmap workers
[49635] 3.25.386.061 I load_all_data: parallel RPC preload complete in 77.17 s (1.79 GiB/s)
[49635] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":1.0}}
[49635] 3.36.552.404 I cmn  common_init_: added [EOS] logit bias = -inf

```

##### With this PR and GGML_RPC_LOAD_THREADS not set - "state":"loading" 4min47sec
Test the existing code path to ensure we dont regress
```
load-mode = mmap

 [59581] 2.07.956.707 I load_tensors: RPC0[10.44.0.2:50052] model buffer size =   594.13 MiB
[59581] 2.07.956.707 I load_tensors: RPC1[10.44.0.2:50052] model buffer size = 143149.18 MiB
[59581] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":0.0}}
[59581] cmd_child_to_router:state:{"state":"loading","payload":{"stages":["text_model"],"current":"text_model","value":1.0}}
[59581] 6.54.513.444 I cmn  common_init_: added [EOS] logit bias = -inf

```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
YES. 
Grok to find the problem / single threaded slowdown. 
GPT + dozens of human hours to try out various approaches.
Grok to refine the solution. 
GPT and pi to harden & test corner cases 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
