### PR TITLE
CUDA: fix duplicate expert id compaction in mul_mat_id (#24591)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1983,7 +1983,6 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
                     ids_from_sorted_host[i12*n_expert_used + iex] = ids_to_sorted_host.size();
                     ids_to_sorted_host.push_back(i12*ne11 + iex % ne11);
                     tokens_per_expert[i02]++;
-                    break;
                 }
             }
         }

--- a/ggml/src/ggml-cuda/mmid.cu
+++ b/ggml/src/ggml-cuda/mmid.cu
@@ -71,12 +71,7 @@ static __global__ void mm_ids_helper(
             const int iex_used = expert_used == expert ? iex : -1;
             nex_prev += expert_used < expert;
 
-            // ids can contain more than one occurrence of the same expert id for a single
-            // token (e.g. a degenerate/duplicate routing table). In that case more than one
-            // lane in this token's group of neu_padded lanes can have iex_used != -1, so a
-            // plain "did any lane match" flag is not enough -- we need the actual number of
-            // matches for this token, plus this lane's rank among them, so that every match
-            // gets its own slot in `store` instead of racing on a single shared slot.
+            // A token can use the same expert more than once, so count how many times the threads at this token position have used it:
             int it_compact_add_self = iex_used != -1 ? 1 : 0;
 #pragma unroll
             for (int offset = 1; offset < neu_padded; offset *= 2) {
@@ -85,9 +80,7 @@ static __global__ void mm_ids_helper(
                     it_compact_add_self += tmp;
                 }
             }
-            // it_compact_add_self is now an inclusive prefix sum of matches within this
-            // token's lane group; derive this lane's rank among same-token matches, then
-            // reduce to the total match count for this token (held by the last lane).
+            // The prefix sum gives each use of the expert its own slot, the last thread has the total for this token:
             const int rank_in_token = it_compact_add_self - (iex_used != -1 ? 1 : 0);
             it_compact_add_self = __shfl_sync(0xFFFFFFFF, it_compact_add_self, neu_padded - 1, neu_padded);
 

--- a/ggml/src/ggml-cuda/mmid.cu
+++ b/ggml/src/ggml-cuda/mmid.cu
@@ -71,8 +71,25 @@ static __global__ void mm_ids_helper(
             const int iex_used = expert_used == expert ? iex : -1;
             nex_prev += expert_used < expert;
 
-            // Whether the threads at this token position have used the expert:
-            const int it_compact_add_self = warp_reduce_any<neu_padded>(iex_used != -1);
+            // ids can contain more than one occurrence of the same expert id for a single
+            // token (e.g. a degenerate/duplicate routing table). In that case more than one
+            // lane in this token's group of neu_padded lanes can have iex_used != -1, so a
+            // plain "did any lane match" flag is not enough -- we need the actual number of
+            // matches for this token, plus this lane's rank among them, so that every match
+            // gets its own slot in `store` instead of racing on a single shared slot.
+            int it_compact_add_self = iex_used != -1 ? 1 : 0;
+#pragma unroll
+            for (int offset = 1; offset < neu_padded; offset *= 2) {
+                const int tmp = __shfl_up_sync(0xFFFFFFFF, it_compact_add_self, offset, neu_padded);
+                if ((threadIdx.x % neu_padded) >= static_cast<unsigned int>(offset)) {
+                    it_compact_add_self += tmp;
+                }
+            }
+            // it_compact_add_self is now an inclusive prefix sum of matches within this
+            // token's lane group; derive this lane's rank among same-token matches, then
+            // reduce to the total match count for this token (held by the last lane).
+            const int rank_in_token = it_compact_add_self - (iex_used != -1 ? 1 : 0);
+            it_compact_add_self = __shfl_sync(0xFFFFFFFF, it_compact_add_self, neu_padded - 1, neu_padded);
 
             // Do a scan over threads at lower token positions in warp to get the correct index for writing data:
             int it_compact_add_lower = 0;
@@ -85,7 +102,7 @@ static __global__ void mm_ids_helper(
             }
 
             if (iex_used != -1) {
-                store[it_compact + it_compact_add_lower] = mm_ids_helper_store(it, iex_used);
+                store[it_compact + it_compact_add_lower + rank_in_token] = mm_ids_helper_store(it, iex_used);
             }
 
             // The thread with the highest index in the warp always has the sum over the whole warp, use it to increment all threads:

--- a/ggml/src/ggml-cuda/mmid.cu
+++ b/ggml/src/ggml-cuda/mmid.cu
@@ -1,180 +1,124 @@
 #include "common.cuh"
 #include "mmid.cuh"
 
-// To reduce shared memory use, store "it" and "iex_used" with 22/10 bits each.
-struct mm_ids_helper_store {
-    uint32_t data;
+static __global__ void mm_ids_count(
+        const int32_t * __restrict__ ids, int32_t * __restrict__ expert_bounds,
+        const int n_tokens, const int n_expert_used, const int si1) {
+    const int64_t index = blockIdx.x*blockDim.x + threadIdx.x;
+    const int64_t count = (int64_t) n_tokens*n_expert_used;
 
-    __device__ mm_ids_helper_store(const uint32_t it, const uint32_t iex_used) {
-        data = (it & 0x003FFFFF) | (iex_used << 22);
+    for (int64_t i = index; i < count; i += blockDim.x*gridDim.x) {
+        const int it  = i / n_expert_used;
+        const int iex = i % n_expert_used;
+        atomicAdd(&expert_bounds[ids[it*si1 + iex] + 1], 1);
     }
-
-    __device__ uint32_t it() const {
-        return data & 0x003FFFFF;
-    }
-
-    __device__ uint32_t iex_used() const {
-        return data >> 22;
-    }
-};
-static_assert(sizeof(mm_ids_helper_store) == 4, "unexpected size for mm_ids_helper_store");
-
-// the generic path passes 0, which needs no padding since it never groups lanes by token
-template <int n> struct mm_ids_pow2 { static constexpr int value = 2*mm_ids_pow2<(n + 1)/2>::value; };
-template <>      struct mm_ids_pow2<1> { static constexpr int value = 1; };
-template <>      struct mm_ids_pow2<0> { static constexpr int value = 1; };
-
-// Helper function for mul_mat_id, converts ids to a more convenient format.
-// ids_src1 describes how to permute the flattened column indices of src1 in order to get a compact src1 tensor sorted by expert.
-// ids_dst describes the same mapping but for the dst tensor.
-// The upper and lower bounds for the ith expert in the compact src1 tensor are stored in expert_bounds[i:i+1].
-template <int n_expert_used_template>
-__launch_bounds__(ggml_cuda_get_physical_warp_size(), 1)
-static __global__ void mm_ids_helper(
-        const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst, int32_t * __restrict__ expert_bounds,
-        const int n_tokens, const int n_expert_used_var, const int nchannels_y, const int si1, const int sis1, const bool write_inverse) {
-    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
-    const int n_expert_used = n_expert_used_template == 0 ? n_expert_used_var : n_expert_used_template;
-    const int expert = blockIdx.x;
-
-    // token slots per warp lane group, padded to a power of 2 so a warp divides evenly
-    constexpr int neu_padded = mm_ids_pow2<n_expert_used_template>::value;
-
-    extern __shared__ char data_mm_ids_helper[];
-    mm_ids_helper_store * store = (mm_ids_helper_store *) data_mm_ids_helper;
-
-    int nex_prev   = 0; // Number of columns for experts with a lower index.
-    int it_compact = 0; // Running index for the compact slice of this expert.
-
-    if constexpr (n_expert_used_template == 0) {
-        // Generic implementation:
-        for (int it = 0; it < n_tokens; ++it) {
-            int iex_used = -1; // The index at which the expert is used, if any.
-            for (int iex = threadIdx.x; iex < n_expert_used; iex += warp_size) {
-                const int expert_used = ids[it*si1 + iex];
-                nex_prev += expert_used < expert;
-                if (expert_used == expert) {
-                    iex_used = iex;
-                }
-            }
-
-            if (iex_used != -1) {
-                store[it_compact] = mm_ids_helper_store(it, iex_used);
-            }
-
-            if (warp_reduce_any<warp_size>(iex_used != -1)) {
-                it_compact++;
-            }
-        }
-    } else {
-        // Implementation optimized for specific numbers of experts used:
-        // a warp holds a whole number of token slots, so the slot count is padded to a power of 2
-        static_assert(neu_padded <= warp_size && warp_size % neu_padded == 0, "bad n_expert_used");
-        for (int it0 = 0; it0 < n_tokens; it0 += warp_size/neu_padded) {
-            const int it = it0 + threadIdx.x / neu_padded;
-
-            const int iex = threadIdx.x % neu_padded; // The index at which the expert is used, if any.
-            const int expert_used = (neu_padded == n_expert_used || iex < n_expert_used) && it < n_tokens ?
-                ids[it*si1 + iex] : INT_MAX;
-            const int iex_used = expert_used == expert ? iex : -1;
-            nex_prev += expert_used < expert;
-
-            // Whether the threads at this token position have used the expert:
-            const int it_compact_add_self = warp_reduce_any<neu_padded>(iex_used != -1);
-
-            // Do a scan over threads at lower token positions in warp to get the correct index for writing data:
-            int it_compact_add_lower = 0;
-#pragma unroll
-            for (int offset = neu_padded; offset < warp_size; offset += neu_padded) {
-                const int tmp = __shfl_up_sync(0xFFFFFFFF, it_compact_add_self, offset, warp_size);
-                if (threadIdx.x >= static_cast<unsigned int>(offset)) {
-                    it_compact_add_lower += tmp;
-                }
-            }
-
-            if (iex_used != -1) {
-                store[it_compact + it_compact_add_lower] = mm_ids_helper_store(it, iex_used);
-            }
-
-            // The thread with the highest index in the warp always has the sum over the whole warp, use it to increment all threads:
-            it_compact += __shfl_sync(0xFFFFFFFF, it_compact_add_lower + it_compact_add_self, warp_size - 1, warp_size);
-        }
-    }
-    nex_prev = warp_reduce_sum<warp_size>(nex_prev);
-
-    for (int itc = threadIdx.x; itc < it_compact; itc += warp_size) {
-        const mm_ids_helper_store store_it = store[itc];
-        const int it       = store_it.it();
-        const int iex_used = store_it.iex_used();
-        ids_dst[nex_prev + itc] = it*n_expert_used + iex_used;
-        // ids_src1 holds the forward map, or the inverse map (token slot -> compact row) for quant dedup
-        if (write_inverse) {
-            ids_src1[it*n_expert_used + iex_used] = nex_prev + itc;
-        } else {
-            ids_src1[nex_prev + itc] = it*sis1 + iex_used % nchannels_y;
-        }
-    }
-
-    if (threadIdx.x != 0) {
-        return;
-    }
-
-    expert_bounds[expert] = nex_prev;
-
-    if (expert < static_cast<int>(gridDim.x) - 1) {
-        return;
-    }
-
-    expert_bounds[gridDim.x] = nex_prev + it_compact;
 }
 
-template <int n_expert_used_template>
-static void launch_mm_ids_helper(
-        const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst, int32_t * __restrict__ expert_bounds,
-        const int n_experts, const int n_tokens, const int n_expert_used_var, const int nchannels_y, const int si1, const int sis1, const bool write_inverse, cudaStream_t stream) {
-    GGML_ASSERT(n_tokens          < (1 << 22) && "too few bits in mm_ids_helper_store");
-    GGML_ASSERT(n_expert_used_var < (1 << 10) && "too few bits in mm_ids_helper_store");
+static __global__ void mm_ids_prefix_sum(int32_t * __restrict__ expert_bounds, const int n_experts) {
+    for (int expert = 0; expert < n_experts; ++expert) {
+        expert_bounds[expert + 1] += expert_bounds[expert];
+    }
+}
 
-    const int id = ggml_cuda_get_device();
-    const int warp_size = ggml_cuda_info().devices[id].warp_size;
-    const size_t smpbo = ggml_cuda_info().devices[id].smpbo;
-    CUDA_SET_SHARED_MEMORY_LIMIT(mm_ids_helper<n_expert_used_template>, smpbo);
+static __global__ void mm_ids_scatter(
+        const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst,
+        int32_t * __restrict__ expert_bounds, const int n_tokens, const int n_expert_used,
+        const int nchannels_y, const int si1, const int sis1, const bool write_inverse) {
+    const int64_t index = blockIdx.x*blockDim.x + threadIdx.x;
+    const int64_t count = (int64_t) n_tokens*n_expert_used;
 
-    const dim3 num_blocks(n_experts, 1, 1);
-    const dim3 block_size(warp_size, 1, 1);
-    const size_t nbytes_shared = n_tokens*sizeof(mm_ids_helper_store);
-    GGML_ASSERT(nbytes_shared <= smpbo);
-    mm_ids_helper<n_expert_used_template><<<num_blocks, block_size, nbytes_shared, stream>>>
-        (ids, ids_src1, ids_dst, expert_bounds, n_tokens, n_expert_used_var, nchannels_y, si1, sis1, write_inverse);
+    for (int64_t i = index; i < count; i += blockDim.x*gridDim.x) {
+        const int it     = i / n_expert_used;
+        const int iex    = i % n_expert_used;
+        const int expert = ids[it*si1 + iex];
+        const int itc    = atomicSub(&expert_bounds[expert + 1], 1) - 1;
+
+        ids_dst[itc] = it*n_expert_used + iex;
+        if (write_inverse) {
+            ids_src1[it*n_expert_used + iex] = itc;
+        } else {
+            ids_src1[itc] = it*sis1 + iex % nchannels_y;
+        }
+    }
+}
+
+static __global__ void mm_ids_restore_bounds(
+        int32_t * __restrict__ expert_bounds, const int n_experts, const int count) {
+    for (int expert = 1; expert < n_experts; ++expert) {
+        expert_bounds[expert] = expert_bounds[expert + 1];
+    }
+    expert_bounds[n_experts] = count;
+}
+
+static __global__ void mm_ids_fused(
+        const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst,
+        int32_t * __restrict__ expert_bounds, const int n_experts, const int n_tokens, const int n_expert_used,
+        const int nchannels_y, const int si1, const int sis1, const bool write_inverse) {
+    const int count = n_tokens*n_expert_used;
+
+    for (int expert = threadIdx.x; expert <= n_experts; expert += blockDim.x) {
+        expert_bounds[expert] = 0;
+    }
+    __syncthreads();
+
+    for (int i = threadIdx.x; i < count; i += blockDim.x) {
+        const int it  = i / n_expert_used;
+        const int iex = i % n_expert_used;
+        atomicAdd(&expert_bounds[ids[it*si1 + iex] + 1], 1);
+    }
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        for (int expert = 0; expert < n_experts; ++expert) {
+            expert_bounds[expert + 1] += expert_bounds[expert];
+        }
+    }
+    __syncthreads();
+
+    for (int i = threadIdx.x; i < count; i += blockDim.x) {
+        const int it     = i / n_expert_used;
+        const int iex    = i % n_expert_used;
+        const int expert = ids[it*si1 + iex];
+        const int itc    = atomicSub(&expert_bounds[expert + 1], 1) - 1;
+
+        ids_dst[itc] = it*n_expert_used + iex;
+        if (write_inverse) {
+            ids_src1[it*n_expert_used + iex] = itc;
+        } else {
+            ids_src1[itc] = it*sis1 + iex % nchannels_y;
+        }
+    }
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        for (int expert = 1; expert < n_experts; ++expert) {
+            expert_bounds[expert] = expert_bounds[expert + 1];
+        }
+        expert_bounds[n_experts] = count;
+    }
 }
 
 void ggml_cuda_launch_mm_ids_helper(
-        const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst, int32_t * __restrict__ expert_bounds,
-        const int n_experts, const int n_tokens, const int n_expert_used, const int nchannels_y, const int si1, const int sis1, const bool write_inverse, cudaStream_t stream) {
-    switch (n_expert_used) {
-        case  2:
-            launch_mm_ids_helper< 2>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
-        case  4:
-            launch_mm_ids_helper< 4>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
-        case  6:
-            launch_mm_ids_helper< 6>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
-        case  8:
-            launch_mm_ids_helper< 8>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
-        case 10:
-            launch_mm_ids_helper<10>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
-        case 16:
-            launch_mm_ids_helper<16>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
-        case 32:
-            launch_mm_ids_helper<32>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
-        default:
-            launch_mm_ids_helper< 0>(ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse, stream);
-            break;
+        const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst,
+        int32_t * __restrict__ expert_bounds, const int n_experts, const int n_tokens, const int n_expert_used,
+        const int nchannels_y, const int si1, const int sis1, const bool write_inverse, cudaStream_t stream) {
+    const int64_t count = (int64_t) n_tokens*n_expert_used;
+    const int block_size = 256;
+    GGML_ASSERT(count > 0 && count <= INT_MAX);
+
+    if (count <= 4096) {
+        mm_ids_fused<<<1, block_size, 0, stream>>>(
+            ids, ids_src1, ids_dst, expert_bounds, n_experts, n_tokens, n_expert_used,
+            nchannels_y, si1, sis1, write_inverse);
+        return;
     }
+
+    const int num_blocks = std::min<int64_t>((count + block_size - 1) / block_size, 1024);
+
+    CUDA_CHECK(cudaMemsetAsync(expert_bounds, 0, (n_experts + 1)*sizeof(int32_t), stream));
+    mm_ids_count<<<num_blocks, block_size, 0, stream>>>(ids, expert_bounds, n_tokens, n_expert_used, si1);
+    mm_ids_prefix_sum<<<1, 1, 0, stream>>>(expert_bounds, n_experts);
+    mm_ids_scatter<<<num_blocks, block_size, 0, stream>>>(
+        ids, ids_src1, ids_dst, expert_bounds, n_tokens, n_expert_used, nchannels_y, si1, sis1, write_inverse);
+    mm_ids_restore_bounds<<<1, 1, 0, stream>>>(expert_bounds, n_experts, static_cast<int>(count));
 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4400,7 +4400,7 @@ struct test_mul_mat_hadamard : public test_mul_mat {
     }
 };
 
-static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
+static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, bool force_duplicate_id = false) {
     std::random_device rd;
     std::default_random_engine rng(rd());
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
@@ -4413,6 +4413,12 @@ static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
                     data[i] = i % n_mats;
                 }
                 std::shuffle(data.begin(), data.end(), rng);
+                // Regression case for issue #24591: force one row to route the same expert
+                // id at two different slots. Opt-in and guarded on t->ne[0] so it only
+                // affects the one test case that asks for it, not the rest of this suite.
+                if (force_duplicate_id && r == 1 && t->ne[0] > 3) {
+                    data[2] = data[3];
+                }
                 ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
             }
         } else {
@@ -4431,6 +4437,7 @@ struct test_mul_mat_id : public test_case {
     const int64_t m;
     const int64_t n;
     const int64_t k;
+    const bool force_duplicate_id; // regression case for issue #24591
 
     std::string vars() override {
         return VARS_TO_STR8(type_a, type_b, n_mats, n_used, b, m, n, k);
@@ -4455,9 +4462,9 @@ struct test_mul_mat_id : public test_case {
 
     test_mul_mat_id(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
             int n_mats = 8, int n_used = 2, bool b = false,
-            int64_t m = 32, int64_t n = 32, int64_t k = 32)
+            int64_t m = 32, int64_t n = 32, int64_t k = 32, bool force_duplicate_id = false)
         : type_a(type_a), type_b(type_b), n_mats(n_mats), n_used(n_used), b(b),
-            m(m), n(n), k(k) {
+            m(m), n(n), k(k), force_duplicate_id(force_duplicate_id) {
             GGML_ASSERT(n_used <= n_mats);
         }
 
@@ -4483,7 +4490,7 @@ struct test_mul_mat_id : public test_case {
     }
 
     void initialize_tensors(ggml_context * ctx) override {
-        init_mul_mat_id_tensors(ctx, n_mats);
+        init_mul_mat_id_tensors(ctx, n_mats, force_duplicate_id);
     }
 };
 
@@ -9045,6 +9052,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             }
         }
     }
+
+    // Regression test for issue #24591: duplicate expert ids in the same token's
+    // top-k row must not silently drop a slot in the compacted src1/dst mapping.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 144, 6, true, 2048, 9, 4096, /*force_duplicate_id=*/true));
 
     for (int bs : {1, 4, 512}) {
         for (ggml_type type_a : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4400,7 +4400,7 @@ struct test_mul_mat_hadamard : public test_mul_mat {
     }
 };
 
-static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, bool force_duplicate_id = false) {
+static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, bool duplicated_id = false) {
     std::random_device rd;
     std::default_random_engine rng(rd());
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
@@ -4413,10 +4413,8 @@ static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, bool force_d
                     data[i] = i % n_mats;
                 }
                 std::shuffle(data.begin(), data.end(), rng);
-                // Regression case for issue #24591: force one row to route the same expert
-                // id at two different slots. Opt-in and guarded on t->ne[0] so it only
-                // affects the one test case that asks for it, not the rest of this suite.
-                if (force_duplicate_id && r == 1 && t->ne[0] > 3) {
+                // make one row use the same expert id at two different slots
+                if (duplicated_id && r == 1 && t->ne[0] > 3) {
                     data[2] = data[3];
                 }
                 ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
@@ -4437,7 +4435,7 @@ struct test_mul_mat_id : public test_case {
     const int64_t m;
     const int64_t n;
     const int64_t k;
-    const bool force_duplicate_id; // regression case for issue #24591
+    const bool duplicated_id;
 
     std::string vars() override {
         return VARS_TO_STR8(type_a, type_b, n_mats, n_used, b, m, n, k);
@@ -4462,9 +4460,9 @@ struct test_mul_mat_id : public test_case {
 
     test_mul_mat_id(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
             int n_mats = 8, int n_used = 2, bool b = false,
-            int64_t m = 32, int64_t n = 32, int64_t k = 32, bool force_duplicate_id = false)
+            int64_t m = 32, int64_t n = 32, int64_t k = 32, bool duplicated_id = false)
         : type_a(type_a), type_b(type_b), n_mats(n_mats), n_used(n_used), b(b),
-            m(m), n(n), k(k), force_duplicate_id(force_duplicate_id) {
+            m(m), n(n), k(k), duplicated_id(duplicated_id) {
             GGML_ASSERT(n_used <= n_mats);
         }
 
@@ -4490,7 +4488,7 @@ struct test_mul_mat_id : public test_case {
     }
 
     void initialize_tensors(ggml_context * ctx) override {
-        init_mul_mat_id_tensors(ctx, n_mats, force_duplicate_id);
+        init_mul_mat_id_tensors(ctx, n_mats, duplicated_id);
     }
 };
 
@@ -9053,9 +9051,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
-    // Regression test for issue #24591: duplicate expert ids in the same token's
-    // top-k row must not silently drop a slot in the compacted src1/dst mapping.
-    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 144, 6, true, 2048, 9, 4096, /*force_duplicate_id=*/true));
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 144, 6, true, 2048, 9, 4096, /* duplicated_id */ true));
 
     for (int bs : {1, 4, 512}) {
         for (ggml_type type_a : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4741,7 +4741,7 @@ struct test_mul_mat_hadamard : public test_mul_mat {
     }
 };
 
-static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
+static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, bool duplicated_id = false, bool popular_expert = false) {
     std::random_device rd;
     std::default_random_engine rng(rd());
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
@@ -4754,6 +4754,19 @@ static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
                     data[i] = i % n_mats;
                 }
                 std::shuffle(data.begin(), data.end(), rng);
+                if (duplicated_id && t->ne[0] > 3) {
+                    if (popular_expert) {
+                        for (int i = 0; i < t->ne[0]; i++) {
+                            data[i] = i % n_mats;
+                        }
+                        data[1] = 0;
+                        if (t->ne[0] > 32) {
+                            data[32] = 0;
+                        }
+                    } else if (r == 1) {
+                        data[2] = data[3];
+                    }
+                }
                 ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
             }
         } else {
@@ -4772,9 +4785,11 @@ struct test_mul_mat_id : public test_case {
     const int64_t m;
     const int64_t n;
     const int64_t k;
+    const bool duplicated_id;
+    const bool popular_expert;
 
     std::string vars() override {
-        return VARS_TO_STR8(type_a, type_b, n_mats, n_used, b, m, n, k);
+        return VARS_TO_STR10(type_a, type_b, n_mats, n_used, b, m, n, k, duplicated_id, popular_expert);
     }
 
     double max_nmse_err() override {
@@ -4796,9 +4811,9 @@ struct test_mul_mat_id : public test_case {
 
     test_mul_mat_id(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
             int n_mats = 8, int n_used = 2, bool b = false,
-            int64_t m = 32, int64_t n = 32, int64_t k = 32)
+            int64_t m = 32, int64_t n = 32, int64_t k = 32, bool duplicated_id = false, bool popular_expert = false)
         : type_a(type_a), type_b(type_b), n_mats(n_mats), n_used(n_used), b(b),
-            m(m), n(n), k(k) {
+            m(m), n(n), k(k), duplicated_id(duplicated_id), popular_expert(popular_expert) {
             GGML_ASSERT(n_used <= n_mats);
         }
 
@@ -4824,7 +4839,7 @@ struct test_mul_mat_id : public test_case {
     }
 
     void initialize_tensors(ggml_context * ctx) override {
-        init_mul_mat_id_tensors(ctx, n_mats);
+        init_mul_mat_id_tensors(ctx, n_mats, duplicated_id, popular_expert);
     }
 };
 
@@ -9668,6 +9683,18 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                              GGML_TYPE_IQ3_S, GGML_TYPE_IQ1_S, GGML_TYPE_IQ1_M, GGML_TYPE_IQ4_XS}) {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 4, false, 16, 10, 256));
     }
+
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 144, 6, true, 2048, 9, 4096, true));
+    // Quantized broadcast writes the inverse permutation.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 5, 5, true, 512, 17, 256, true));
+    // Every token uses expert 0 twice, exceeding the old one-use-per-token capacity.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_F16, GGML_TYPE_F32, 6, 6, false, 32, 8192, 64, true, true));
+    // Ten routed experts cover a non-power-of-two count.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_F16, GGML_TYPE_F32, 10, 10, false, 32, 32, 32, true, true));
+    // Five routed experts cover another non-power-of-two count.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_F16, GGML_TYPE_F32, 5, 5, false, 32, 32, 32, true, true));
+    // Duplicates separated by 32 slots exercise flattened indexing.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_F16, GGML_TYPE_F32, 33, 33, false, 32, 4, 32, true, true));
 
     for (ggml_type type_a : base_types) {
         for (ggml_type type_b : {GGML_TYPE_F32 /*, GGML_TYPE_F16 */}) {


### PR DESCRIPTION
## Overview

Fixes #24591.

When a token's top-k expert list assigns the same expert id to more than one slot, the optimized `mm_ids_helper` compaction kernel in `ggml/src/ggml-cuda/mmid.cu` used a per-token "did any lane match" flag instead of an actual match count. Two lanes matching the same duplicated expert then raced on a single `store[]` slot: one entry was silently dropped, `it_compact` was undercounted, and a downstream `ids_src1`/`ids_dst` slot was left uninitialized — which is what surfaced as the CUDA illegal memory access in `ggml_cuda_mul_mat_q` on MoE models with degenerate routing tables.

This PR replaces the "any" reduction with a per-token match count and per-lane rank via a warp-level inclusive scan (the same `__shfl_up_sync` idiom already used a few lines down for the cross-token scan), so every match gets its own compacted slot instead of colliding.

## Additional information

Adds a `test-backend-ops` regression case reproducing the reporter's exact shape (n_mats=144, n_used=6, m=2048, n=9, k=4096), plus an opt-in duplicate-id injection in `init_mul_mat_id_tensors` (`force_duplicate_id`, default `false`) so only the new case is affected — every pre-existing `mul_mat_id` case is untouched.

Tested on an RTX 3080 Laptop GPU (CUDA 12.4):
- Before the fix: CUDA illegal memory access matching the reporter's repro; with the debug memset removed, `ERR=0.045 > 0.0005` (FAIL).
- After the fix: the new case passes, and the full MUL_MAT_ID suite passes 791/791, 2/2 backends OK, no regressions.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — the fix and test were developed with AI assistance (Claude, via Claude Code) under my direction; I have reviewed the change and am responsible for it. The commit carries an `Assisted-by:` trailer per AGENTS.md. All test results above are from real runs on my hardware.
