### PR TITLE
CUDA: fix duplicate expert id handling in mul_mat_id CPU fallback

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1932,7 +1932,9 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor * 
                     ids_from_sorted_host[i12*n_expert_used + iex] = ids_to_sorted_host.size();
                     ids_to_sorted_host.push_back(i12*ne11 + iex % ne11);
                     tokens_per_expert[i02]++;
-                    break;
+                    // note: no break here -- a token's routing table can assign the
+                    // same expert to more than one slot (duplicate/degenerate ids),
+                    // and each such slot needs its own compacted row.
                 }
             }
         }

--- a/ggml/src/ggml-cuda/mmid.cu
+++ b/ggml/src/ggml-cuda/mmid.cu
@@ -71,8 +71,25 @@ static __global__ void mm_ids_helper(
             const int iex_used = expert_used == expert ? iex : -1;
             nex_prev += expert_used < expert;
 
-            // Whether the threads at this token position have used the expert:
-            const int it_compact_add_self = warp_reduce_any<neu_padded>(iex_used != -1);
+            // ids can contain more than one occurrence of the same expert id for a single
+            // token (e.g. a degenerate/duplicate routing table). In that case more than one
+            // lane in this token's group of neu_padded lanes can have iex_used != -1, so a
+            // plain "did any lane match" flag is not enough -- we need the actual number of
+            // matches for this token, plus this lane's rank among them, so that every match
+            // gets its own slot in `store` instead of racing on a single shared slot.
+            int it_compact_add_self = iex_used != -1 ? 1 : 0;
+#pragma unroll
+            for (int offset = 1; offset < neu_padded; offset *= 2) {
+                const int tmp = __shfl_up_sync(0xFFFFFFFF, it_compact_add_self, offset, neu_padded);
+                if ((threadIdx.x % neu_padded) >= static_cast<unsigned int>(offset)) {
+                    it_compact_add_self += tmp;
+                }
+            }
+            // it_compact_add_self is now an inclusive prefix sum of matches within this
+            // token's lane group; derive this lane's rank among same-token matches, then
+            // reduce to the total match count for this token (held by the last lane).
+            const int rank_in_token = it_compact_add_self - (iex_used != -1 ? 1 : 0);
+            it_compact_add_self = __shfl_sync(0xFFFFFFFF, it_compact_add_self, neu_padded - 1, neu_padded);
 
             // Do a scan over threads at lower token positions in warp to get the correct index for writing data:
             int it_compact_add_lower = 0;
@@ -85,7 +102,7 @@ static __global__ void mm_ids_helper(
             }
 
             if (iex_used != -1) {
-                store[it_compact + it_compact_add_lower] = mm_ids_helper_store(it, iex_used);
+                store[it_compact + it_compact_add_lower + rank_in_token] = mm_ids_helper_store(it, iex_used);
             }
 
             // The thread with the highest index in the warp always has the sum over the whole warp, use it to increment all threads:

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4400,7 +4400,7 @@ struct test_mul_mat_hadamard : public test_mul_mat {
     }
 };
 
-static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
+static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats, bool force_duplicate_id = false) {
     std::random_device rd;
     std::default_random_engine rng(rd());
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
@@ -4413,6 +4413,12 @@ static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
                     data[i] = i % n_mats;
                 }
                 std::shuffle(data.begin(), data.end(), rng);
+                // Regression case for issue #24591: force one row to route the same expert
+                // id at two different slots. Opt-in and guarded on t->ne[0] so it only
+                // affects the one test case that asks for it, not the rest of this suite.
+                if (force_duplicate_id && r == 1 && t->ne[0] > 3) {
+                    data[2] = data[3];
+                }
                 ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
             }
         } else {
@@ -4431,6 +4437,7 @@ struct test_mul_mat_id : public test_case {
     const int64_t m;
     const int64_t n;
     const int64_t k;
+    const bool force_duplicate_id; // regression case for issue #24591
 
     std::string vars() override {
         return VARS_TO_STR8(type_a, type_b, n_mats, n_used, b, m, n, k);
@@ -4455,9 +4462,9 @@ struct test_mul_mat_id : public test_case {
 
     test_mul_mat_id(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
             int n_mats = 8, int n_used = 2, bool b = false,
-            int64_t m = 32, int64_t n = 32, int64_t k = 32)
+            int64_t m = 32, int64_t n = 32, int64_t k = 32, bool force_duplicate_id = false)
         : type_a(type_a), type_b(type_b), n_mats(n_mats), n_used(n_used), b(b),
-            m(m), n(n), k(k) {
+            m(m), n(n), k(k), force_duplicate_id(force_duplicate_id) {
             GGML_ASSERT(n_used <= n_mats);
         }
 
@@ -4483,7 +4490,7 @@ struct test_mul_mat_id : public test_case {
     }
 
     void initialize_tensors(ggml_context * ctx) override {
-        init_mul_mat_id_tensors(ctx, n_mats);
+        init_mul_mat_id_tensors(ctx, n_mats, force_duplicate_id);
     }
 };
 
@@ -9045,6 +9052,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             }
         }
     }
+
+    // Regression test for issue #24591: duplicate expert ids in the same token's
+    // top-k row must not silently drop a slot in the compacted src1/dst mapping.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 144, 6, true, 2048, 9, 4096, /*force_duplicate_id=*/true));
 
     for (int bs : {1, 4, 512}) {
         for (ggml_type type_a : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9057,6 +9057,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     // top-k row must not silently drop a slot in the compacted src1/dst mapping.
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 144, 6, true, 2048, 9, 4096, /*force_duplicate_id=*/true));
 
+    // Regression test for the CUDA mul_mat_id CPU-fallback path: a token's
+    // top-k row can name the same expert at more than one slot (duplicate/
+    // degenerate routing table). The fallback's ids_to_sorted_host builder used
+    // to break out of the per-token expert scan after the first match, silently
+    // dropping later slots and undercounting ids_to_sorted_host below
+    // ne_get_rows, which tripped a GGML_ASSERT. This shape (F16/F32,
+    // n_mats=n_used=16, m=50, n_tokens=200, k=64) is chosen to actually route
+    // through the CPU fallback rather than the CUDA MMQ/MMF paths.
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_F16, GGML_TYPE_F32, 16, 16, false, 50, 200, 64, /*force_duplicate_id=*/true));
+
     for (int bs : {1, 4, 512}) {
         for (ggml_type type_a : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K}) {
             for (ggml_type type_b : {GGML_TYPE_F32}) {


### PR DESCRIPTION
## Overview

The CPU-fallback path in `ggml_cuda_mul_mat_id` (`ggml/src/ggml-cuda/ggml-cuda.cu`, used when neither the CUDA MMQ nor MMF kernels apply) built `ids_to_sorted_host` / `ids_from_sorted_host` by scanning each token's `n_expert_used` routing slots for the current expert and breaking out of the inner loop on the first match. If a token's routing table names the same expert at more than one slot (a degenerate but not invalid routing table), every slot after the first was silently dropped, leaving `ids_to_sorted_host.size()` short of `ne_get_rows` and tripping the `GGML_ASSERT` right after the loop.

Removing the `break` lets every matching (expert, token, slot) triple get its own compacted-row entry, matching the CUDA kernel path in `mmid.cu` (fixed for the same class of bug in #26294).

This looks like the same failure mode reported on real 512-expert MoE workloads in #19672 and #19705 (both closed without a code fix), so the impact is not purely synthetic — it can hit large-MoE users whose quant/GPU combination routes through the CPU fallback.

## Additional information

Stacked on #26294 — the first commit here is that PR's fix (the regression test reuses its `force_duplicate_id` injection); only the second commit (`9e81139`) is new. I'll rebase once #26294 lands.

Regression case added to `test_mul_mat_id` (F16/F32, n_mats=n_used=16, m=50, n=200, k=64) — this shape is confirmed to actually route through the CPU fallback rather than MMQ/MMF.

Tested on an RTX 3080 Laptop GPU (CUDA 12.4):
- Before the fix: the new case aborts with `ggml-cuda.cu:1941: GGML_ASSERT(ids_to_sorted_host.size() == size_t(ne_get_rows)) failed`.
- After the fix: the same case passes (both batched and non-batched variants), and the full MUL_MAT_ID op suite passes 792/792, 2/2 backends OK, no regressions.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — the fix and test were developed with AI assistance (Claude, via Claude Code) under my direction; I have reviewed the change and am responsible for it. The commit carries an `Assisted-by:` trailer per AGENTS.md. All test results above are from real runs on my hardware.
