### PR TITLE
cuda: support row-contiguous SUM_ROWS

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5109,6 +5109,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             return true;
 #endif
         case GGML_OP_SUM_ROWS:
+            return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 && ggml_is_contiguous_rows(op->src[0]);
         case GGML_OP_MEAN:
         case GGML_OP_GROUP_NORM:
             return ggml_is_contiguous(op->src[0]);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5111,6 +5111,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_SUM_ROWS:
             return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 && ggml_is_contiguous_rows(op->src[0]);
         case GGML_OP_MEAN:
+            return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 && ggml_is_contiguous_rows(op->src[0]);
         case GGML_OP_GROUP_NORM:
             return ggml_is_contiguous(op->src[0]);
         case GGML_OP_PAD:

--- a/ggml/src/ggml-cuda/mean.cu
+++ b/ggml/src/ggml-cuda/mean.cu
@@ -18,7 +18,7 @@ void ggml_cuda_op_mean(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
-    GGML_ASSERT(ggml_is_contiguous(src0));
+    GGML_ASSERT(ggml_is_contiguous_rows(src0));
 
     const int64_t ncols = src0->ne[0];
     const int64_t nrows = ggml_nrows(src0);
@@ -65,13 +65,15 @@ void ggml_cuda_op_mean(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     // Heuristic for block size selection to optimize occupancy.
     // See discussion in: https://github.com/ggml-org/llama.cpp/pull/15132
-    if ((nrows / nsm) < 2) {
-        const dim3 block_dims(512, 1, 1);
-        const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
+    const dim3 block_dims((nrows / nsm) < 2 ? 512 : (ncols < 1024 ? 32 : 128), 1, 1);
+    const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
+
+    if (ggml_is_contiguous(src0)) {
         ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/true>, launch_params, src0_d, dst_d, ncols);
-    } else {
-        const dim3 block_dims(ncols < 1024 ? 32 : 128, 1, 1);
-        const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
-        ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/true>, launch_params, src0_d, dst_d, ncols);
+        return;
     }
+
+    const char * src0_d_bytes = (const char *) src0->data;
+    ggml_cuda_kernel_launch(reduce_rows_f32_strided</*norm=*/true>, launch_params, src0_d_bytes, dst_d, ncols,
+            src0->ne[1], src0->ne[2], src0->nb[1], src0->nb[2], src0->nb[3]);
 }

--- a/ggml/src/ggml-cuda/mean.cu
+++ b/ggml/src/ggml-cuda/mean.cu
@@ -65,7 +65,12 @@ void ggml_cuda_op_mean(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     // Heuristic for block size selection to optimize occupancy.
     // See discussion in: https://github.com/ggml-org/llama.cpp/pull/15132
-    const dim3 block_dims((nrows / nsm) < 2 ? 512 : (ncols < 1024 ? 32 : 128), 1, 1);
+    dim3 block_dims;
+    if ((nrows / nsm) < 2) {
+        block_dims = dim3(512, 1, 1);
+    } else {
+        block_dims = dim3(ncols < 1024 ? 32 : 128, 1, 1);
+    }
     const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
 
     if (ggml_is_contiguous(src0)) {

--- a/ggml/src/ggml-cuda/reduce_rows.cuh
+++ b/ggml/src/ggml-cuda/reduce_rows.cuh
@@ -1,11 +1,6 @@
 #include "common.cuh"
 
-// Row reduction kernel template - compute sum (norm=false) or mean (norm=true)
-template <bool norm>
-static __global__ void reduce_rows_f32(const float * x_ptr, float * dst_ptr, const int ncols) {
-    const float * GGML_CUDA_RESTRICT x   = x_ptr;
-    float       * GGML_CUDA_RESTRICT dst = dst_ptr;
-    const int row = blockIdx.x;
+static __device__ __forceinline__ float reduce_row_f32(const float * x, const int ncols) {
     const int col = threadIdx.x;
 
     float     sum        = 0.0f;
@@ -17,7 +12,7 @@ static __global__ void reduce_rows_f32(const float * x_ptr, float * dst_ptr, con
     for (int i = col; i < ncols;) {
         for (int j = 0; j < num_unroll; ++j) {
             if (i < ncols) {
-                temp[j] = x[row * ncols + i];
+                temp[j] = x[i];
             } else {
                 temp[j] = 0;
             }
@@ -34,6 +29,40 @@ static __global__ void reduce_rows_f32(const float * x_ptr, float * dst_ptr, con
     // sum up partial sums
     __shared__ float shared_vals[32];
     sum = block_reduce<block_reduce_method::SUM>(sum, shared_vals);
+
+    return sum;
+}
+
+// Row reduction kernel template - compute sum (norm=false) or mean (norm=true)
+template <bool norm>
+static __global__ void reduce_rows_f32(const float * x_ptr, float * dst_ptr, const int ncols) {
+    float       * GGML_CUDA_RESTRICT dst = dst_ptr;
+    const int64_t row = blockIdx.x;
+    const int col = threadIdx.x;
+
+    const float * GGML_CUDA_RESTRICT x = x_ptr + row*ncols;
+    const float sum = reduce_row_f32(x, ncols);
+
+    if (col != 0) {
+        return;
+    }
+
+    dst[row] = norm ? sum / ncols : sum;
+}
+
+template <bool norm>
+static __global__ void reduce_rows_f32_strided(const char * x_ptr, float * dst_ptr, const int ncols,
+        const int64_t ne1, const int64_t ne2, const int64_t nb1, const int64_t nb2, const int64_t nb3) {
+    float       * GGML_CUDA_RESTRICT dst = dst_ptr;
+    const int64_t row = blockIdx.x;
+    const int col = threadIdx.x;
+
+    const int64_t i1 = row % ne1;
+    const int64_t i2 = (row / ne1) % ne2;
+    const int64_t i3 = row / (ne1 * ne2);
+
+    const float * GGML_CUDA_RESTRICT x = (const float *) (x_ptr + i1*nb1 + i2*nb2 + i3*nb3);
+    const float sum = reduce_row_f32(x, ncols);
 
     if (col != 0) {
         return;

--- a/ggml/src/ggml-cuda/sumrows.cu
+++ b/ggml/src/ggml-cuda/sumrows.cu
@@ -16,51 +16,6 @@ void sum_rows_f32_cuda(const float * x, float * dst, const int ncols, const int 
     }
 }
 
-static __global__ void sum_rows_f32_strided(const char * x_ptr, float * dst_ptr, const int ncols,
-        const int64_t ne1, const int64_t ne2, const int64_t nb1, const int64_t nb2, const int64_t nb3) {
-    const int64_t row = blockIdx.x;
-    const int     col = threadIdx.x;
-
-    const int64_t i1  = row % ne1;
-    const int64_t i2  = (row / ne1) % ne2;
-    const int64_t i3  = row / (ne1 * ne2);
-
-    const float * GGML_CUDA_RESTRICT x   = (const float *) (x_ptr + i1*nb1 + i2*nb2 + i3*nb3);
-    float       * GGML_CUDA_RESTRICT dst = dst_ptr;
-
-    float     sum        = 0.0f;
-    const int num_unroll = 8;
-    float     temp[num_unroll];
-    float     sum_temp[num_unroll] = { 0.0f };
-
-    ggml_cuda_pdl_sync();
-    for (int i = col; i < ncols;) {
-        for (int j = 0; j < num_unroll; ++j) {
-            if (i < ncols) {
-                temp[j] = x[i];
-            } else {
-                temp[j] = 0;
-            }
-            i += blockDim.x;
-        }
-        for (int j = 0; j < num_unroll; ++j) {
-            sum_temp[j] += temp[j];
-        }
-    }
-    for (int j = 0; j < num_unroll; ++j) {
-        sum += sum_temp[j];
-    }
-
-    __shared__ float shared_vals[32];
-    sum = block_reduce<block_reduce_method::SUM>(sum, shared_vals);
-
-    if (col != 0) {
-        return;
-    }
-
-    dst[row] = sum;
-}
-
 void ggml_cuda_op_sum_rows(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0 = dst->src[0];
     const float * src0_d = (const float *)src0->data;
@@ -74,35 +29,18 @@ void ggml_cuda_op_sum_rows(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const int64_t ncols = src0->ne[0];
     const int64_t nrows = ggml_nrows(src0);
 
+    if (ggml_is_contiguous(src0)) {
+        sum_rows_f32_cuda(src0_d, dst_d, ncols, nrows, stream);
+        return;
+    }
+
     const dim3 block_nums(nrows, 1, 1);
 
     const int id  = ggml_cuda_get_device();
     const int nsm = ggml_cuda_info().devices[id].nsm;
-    if (ggml_is_contiguous(src0)) {
-        if ((nrows / nsm) < 2) {
-            // Increase num threads to 512 for small nrows to better hide the latency
-            const dim3 block_dims(512, 1, 1);
-            const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
-            ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/false>, launch_params, src0_d, dst_d, ncols);
-        } else {
-            // Enough active SMs to hide latency, use smaller blocks to allow better scheduling
-            const dim3 block_dims(ncols < 1024 ? 32 : 128, 1, 1);
-            const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
-            ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/false>, launch_params, src0_d, dst_d, ncols);
-        }
-        return;
-    }
-
+    const dim3 block_dims((nrows / nsm) < 2 ? 512 : (ncols < 1024 ? 32 : 128), 1, 1);
+    const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
     const char * src0_d_bytes = (const char *) src0->data;
-    if ((nrows / nsm) < 2) {
-        const dim3 block_dims(512, 1, 1);
-        const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
-        ggml_cuda_kernel_launch(sum_rows_f32_strided, launch_params, src0_d_bytes, dst_d, ncols,
-                src0->ne[1], src0->ne[2], src0->nb[1], src0->nb[2], src0->nb[3]);
-    } else {
-        const dim3 block_dims(ncols < 1024 ? 32 : 128, 1, 1);
-        const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
-        ggml_cuda_kernel_launch(sum_rows_f32_strided, launch_params, src0_d_bytes, dst_d, ncols,
-                src0->ne[1], src0->ne[2], src0->nb[1], src0->nb[2], src0->nb[3]);
-    }
+    ggml_cuda_kernel_launch(reduce_rows_f32_strided</*norm=*/false>, launch_params, src0_d_bytes, dst_d, ncols,
+            src0->ne[1], src0->ne[2], src0->nb[1], src0->nb[2], src0->nb[3]);
 }

--- a/ggml/src/ggml-cuda/sumrows.cu
+++ b/ggml/src/ggml-cuda/sumrows.cu
@@ -16,6 +16,51 @@ void sum_rows_f32_cuda(const float * x, float * dst, const int ncols, const int 
     }
 }
 
+static __global__ void sum_rows_f32_strided(const char * x_ptr, float * dst_ptr, const int ncols,
+        const int64_t ne1, const int64_t ne2, const int64_t nb1, const int64_t nb2, const int64_t nb3) {
+    const int64_t row = blockIdx.x;
+    const int     col = threadIdx.x;
+
+    const int64_t i1  = row % ne1;
+    const int64_t i2  = (row / ne1) % ne2;
+    const int64_t i3  = row / (ne1 * ne2);
+
+    const float * GGML_CUDA_RESTRICT x   = (const float *) (x_ptr + i1*nb1 + i2*nb2 + i3*nb3);
+    float       * GGML_CUDA_RESTRICT dst = dst_ptr;
+
+    float     sum        = 0.0f;
+    const int num_unroll = 8;
+    float     temp[num_unroll];
+    float     sum_temp[num_unroll] = { 0.0f };
+
+    ggml_cuda_pdl_sync();
+    for (int i = col; i < ncols;) {
+        for (int j = 0; j < num_unroll; ++j) {
+            if (i < ncols) {
+                temp[j] = x[i];
+            } else {
+                temp[j] = 0;
+            }
+            i += blockDim.x;
+        }
+        for (int j = 0; j < num_unroll; ++j) {
+            sum_temp[j] += temp[j];
+        }
+    }
+    for (int j = 0; j < num_unroll; ++j) {
+        sum += sum_temp[j];
+    }
+
+    __shared__ float shared_vals[32];
+    sum = block_reduce<block_reduce_method::SUM>(sum, shared_vals);
+
+    if (col != 0) {
+        return;
+    }
+
+    dst[row] = sum;
+}
+
 void ggml_cuda_op_sum_rows(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0 = dst->src[0];
     const float * src0_d = (const float *)src0->data;
@@ -24,7 +69,7 @@ void ggml_cuda_op_sum_rows(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT( dst->type == GGML_TYPE_F32);
-    GGML_ASSERT(ggml_is_contiguous(src0));
+    GGML_ASSERT(ggml_is_contiguous_rows(src0));
 
     const int64_t ncols = src0->ne[0];
     const int64_t nrows = ggml_nrows(src0);
@@ -33,15 +78,31 @@ void ggml_cuda_op_sum_rows(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     const int id  = ggml_cuda_get_device();
     const int nsm = ggml_cuda_info().devices[id].nsm;
+    if (ggml_is_contiguous(src0)) {
+        if ((nrows / nsm) < 2) {
+            // Increase num threads to 512 for small nrows to better hide the latency
+            const dim3 block_dims(512, 1, 1);
+            const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
+            ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/false>, launch_params, src0_d, dst_d, ncols);
+        } else {
+            // Enough active SMs to hide latency, use smaller blocks to allow better scheduling
+            const dim3 block_dims(ncols < 1024 ? 32 : 128, 1, 1);
+            const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
+            ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/false>, launch_params, src0_d, dst_d, ncols);
+        }
+        return;
+    }
+
+    const char * src0_d_bytes = (const char *) src0->data;
     if ((nrows / nsm) < 2) {
-        // Increase num threads to 512 for small nrows to better hide the latency
         const dim3 block_dims(512, 1, 1);
         const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
-        ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/false>, launch_params, src0_d, dst_d, ncols);
+        ggml_cuda_kernel_launch(sum_rows_f32_strided, launch_params, src0_d_bytes, dst_d, ncols,
+                src0->ne[1], src0->ne[2], src0->nb[1], src0->nb[2], src0->nb[3]);
     } else {
-        // Enough active SMs to hide latency, use smaller blocks to allow better scheduling
         const dim3 block_dims(ncols < 1024 ? 32 : 128, 1, 1);
         const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
-        ggml_cuda_kernel_launch(reduce_rows_f32</*norm=*/false>, launch_params, src0_d, dst_d, ncols);
+        ggml_cuda_kernel_launch(sum_rows_f32_strided, launch_params, src0_d_bytes, dst_d, ncols,
+                src0->ne[1], src0->ne[2], src0->nb[1], src0->nb[2], src0->nb[3]);
     }
 }

--- a/ggml/src/ggml-cuda/sumrows.cu
+++ b/ggml/src/ggml-cuda/sumrows.cu
@@ -38,7 +38,14 @@ void ggml_cuda_op_sum_rows(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     const int id  = ggml_cuda_get_device();
     const int nsm = ggml_cuda_info().devices[id].nsm;
-    const dim3 block_dims((nrows / nsm) < 2 ? 512 : (ncols < 1024 ? 32 : 128), 1, 1);
+    dim3 block_dims;
+    if ((nrows / nsm) < 2) {
+        // Increase num threads to 512 for small nrows to better hide the latency
+        block_dims = dim3(512, 1, 1);
+    } else {
+        // Enough active SMs to hide latency, use smaller blocks to allow better scheduling
+        block_dims = dim3(ncols < 1024 ? 32 : 128, 1, 1);
+    }
     const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params(block_nums, block_dims, 0, stream);
     const char * src0_d_bytes = (const char *) src0->data;
     ggml_cuda_kernel_launch(reduce_rows_f32_strided</*norm=*/false>, launch_params, src0_d_bytes, dst_d, ncols,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6343,19 +6343,31 @@ struct test_sum_rows : public test_case {
 struct test_mean : public test_case {
     const ggml_type type;
     const std::array<int64_t, 4> ne;
+    const bool permute;
+    const bool slice;
 
     std::string vars() override {
-        return VARS_TO_STR2(type, ne);
+        return VARS_TO_STR4(type, ne, permute, slice);
     }
 
     test_mean(ggml_type type = GGML_TYPE_F32,
-            std::array<int64_t, 4> ne = {10, 5, 4, 3})
-        : type(type), ne(ne) {}
+            std::array<int64_t, 4> ne = {10, 5, 4, 3},
+            bool permute = false, bool slice = false)
+        : type(type), ne(ne), permute(permute), slice(slice) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * a = ggml_new_tensor(ctx, type, 4, ne.data());
         ggml_set_param(a);
         ggml_set_name(a, "a");
+
+        if (slice) {
+            a = ggml_view_4d(ctx, a,
+                             ne[0], ne[1], ne[2] / 2, ne[3] - 1,
+                             a->nb[1], a->nb[2] * 2, a->nb[3], /*offset=*/a->nb[3]);
+        }
+        if (permute) {
+            a = ggml_permute(ctx, a, 0, 2, 3, 1);
+        }
 
         ggml_tensor * out = ggml_mean(ctx, a);
         ggml_set_name(out, "out");
@@ -9380,6 +9392,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mean(GGML_TYPE_F32, { 32, 1, 1, 1 }));
     test_cases.emplace_back(new test_mean(GGML_TYPE_F32, { 32, 256, 1, 1 }));
     test_cases.emplace_back(new test_mean(GGML_TYPE_F32, { 32768, 1, 1, 1 }));
+    test_cases.emplace_back(new test_mean(GGML_TYPE_F32, { 11, 5, 6, 3 }, true, false));
+    test_cases.emplace_back(new test_mean(GGML_TYPE_F32, { 11, 5, 6, 3 }, false, true));
+    test_cases.emplace_back(new test_mean(GGML_TYPE_F32, { 11, 5, 6, 3 }, true, true));
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 1, 1, 1 }));
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 1024, 1, 1 }));
     test_cases.emplace_back(new test_sum(GGML_TYPE_F32, { 33, 256, 1, 1 }));


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This is straightforward, the PR extends CUDA `GGML_OP_SUM_ROWS` from fully contiguous tensors to F32 row-contiguous tensors. What is does is that it adds a stride-aware kernel that derives the logical `i1`, `i2`, and `i3` coordinates for each row and calculates its address using `nb[1..3]`. It also preserve the current behavio by using the existing reduction kernel as the fast path for fully contiguous tensors for the use cases it would be more suitable for. 

The validation/testing results is also complete (with focus on related stuff)
- `SUM_ROWS: 10/10`
- `SUM: 7/7`
-  `MEAN: 7/7` 


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

Yes, AI was used. I used an agent to explore the codebase for codebase patterns and inspect possible style or merge-conflict problems. It also was used to see the test log files. But in both cases, I did re-check everything manually. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
