### PR TITLE
ggml-cpu/repack: size mul_mat_id row list by slots x tokens

### DIFF
--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -4171,11 +4171,14 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
                     size = GGML_PAD(size, sizeof(int64_t)); // + padding for next block.
 
                     const int64_t ne02 = op->src[0]->ne[2]; // n_as, n_expert
-                    const int64_t ne12 = op->src[1]->ne[2]; // n_tokens
+
+                    // an expert can be referenced by several ids of the same
+                    // token, so the row list is sized by ids->ne[0]*ids->ne[1]
+                    const int64_t n_ids_total = op->src[2]->ne[0]*op->src[2]->ne[1];
 
                     const size_t sizeof_mmid_row_mapping = sizeof(int64_t);
 
-                    size += sizeof_mmid_row_mapping*ne02*(ne12 + 1);
+                    size += sizeof_mmid_row_mapping*ne02*(n_ids_total + 1);
 
                     return true;
                 }
@@ -4425,17 +4428,22 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             int32_t i2;
         };
 
+        // an expert can be referenced by several ids of the same token, so the
+        // per-expert row list is sized by ids->ne[0]*ids->ne[1], as in the
+        // generic path in ggml-cpu.c
+        const int64_t n_ids_total = ids->ne[0]*ids->ne[1];
+
         GGML_ASSERT(params->wsize >=
                 (GGML_PAD(nbw3, sizeof(int64_t)) +
-                 n_as*(ne12 + 1)*sizeof(mmid_row_mapping))
+                 n_as*(n_ids_total + 1)*sizeof(mmid_row_mapping))
                 );
 
         auto * wdata          = (char *)params->wdata;
         auto * wdata_src1_end = (char *)wdata + GGML_PAD(nbw3, sizeof(int64_t));
 
-        // total of [n_as][ne12 + 1] elements of type mmid_row_mapping (2*int32_t = int64_t)
+        // total of [n_as][n_ids_total + 1] elements of type mmid_row_mapping (2*int32_t = int64_t)
         auto * matrix_row_counts = (int64_t *) (wdata_src1_end);                                        // [n_as]
-        struct mmid_row_mapping * matrix_rows = (struct mmid_row_mapping *) (matrix_row_counts + n_as); // [n_as][ne12]
+        struct mmid_row_mapping * matrix_rows = (struct mmid_row_mapping *) (matrix_row_counts + n_as); // [n_as][n_ids_total]
 
         // src1: float32 => param type
         for (int64_t i12 = 0; i12 < ne12; ++i12) {
@@ -4446,7 +4454,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS, ggml_type PAR
             }
         }
 
-#define MMID_MATRIX_ROW(row_id, i1) matrix_rows[(row_id) * ne12 + (i1)]
+#define MMID_MATRIX_ROW(row_id, i1) matrix_rows[(row_id) * n_ids_total + (i1)]
 
         if (ith == 0) {
             // initialize matrix_row_counts


### PR DESCRIPTION
# ggml-cpu/repack: size the mul_mat_id row list by slots × tokens, not tokens

## Summary

`repack.cpp`'s `mul_mat_id` assumes an expert is referenced by **at most one id per
token**. When that does not hold, one expert's row list overflows into the next
expert's, silently producing wrong results — no crash, no assert, just numbers that
are a few percent off.

The generic implementation in `ggml-cpu.c` does not make that assumption:

```c
// ggml-cpu.c
#define MMID_MATRIX_ROW(row_id, i1) matrix_rows[(row_id)*ids->ne[0]*ids->ne[1] + (i1)]

// repack.cpp  (before this patch)
#define MMID_MATRIX_ROW(row_id, i1) matrix_rows[(row_id) * ne12 + (i1)]
```

`ids->ne[0]*ids->ne[1]` is slots × tokens; `ne12` is tokens alone. The two paths
implement the same op with different capacity contracts, and `repack.cpp`'s
`work_size()` reserves the smaller amount to match.

This patch widens the stride and the reservation in `repack.cpp` to match the generic
path. It changes no behaviour for inputs that already satisfied the narrower
assumption.

## Why it matters

`ggml_mul_mat_id` is a public op. Nothing in its documentation or asserts requires
ids to be distinct within a token, and the generic path handles duplicates
correctly, so a caller has every reason to expect it to work.

A concrete case: splitting a MoE layer's experts into two tensors (e.g. to place the
frequently-selected ones on GPU and the rest on CPU) requires routing the ids that do
not belong to a branch at some row of that branch. Any such scheme repeats one row id
many times per token and hits this.

## How it was found and verified

On Qwen3-VL-30B-A3B (Q4_K_M, 48 layers × 128 experts, top-8), with each layer's
experts split into two tensors and non-belonging ids pointed at row 0:

| build | first MoE tensor of layer 0, Σ\|x\| | |
|---|---|---|
| repack, before patch | 6062.70 | **wrong, −4.7%** |
| repack, after patch  | 6359.25707318 | matches |
| **reference (unsplit model)** | **6359.25707318** | |
| `GGML_CPU_REPACK=OFF`, before patch | 6359.25724557 | matches (generic path) |

The `-4.7%` is not float noise: the engine's own run-to-run variation on this model
perturbs 7 of 48 layers' expert selections, while the bug perturbed 47 of 48.

The magnitude tracks how many ids collapse onto one row, which is why the bug hides
in the degenerate cases — with a single-expert branch, `row_id * stride + i`
degenerates to flat indexing and no aliasing is possible:

| experts per branch | result |
|---|---|
| 1 / 127 | correct (degenerate) |
| 32 / 96 | −4.7% |
| 64 / 64 | −2.7% |
| 127 / 1 | correct (degenerate) |

## Testing gap — please read

I could not exercise this through `test-backend-ops`: it validates each backend
against CPU as the reference, so with CPU as the only backend it reports
`Skipping CPU backend` and runs nothing. The verification above is end-to-end on a
real model, not a unit test.

A proper regression test would need a `MUL_MAT_ID` case whose ids repeat within a
token, compared between a repack-eligible quantised `src0` and the same op on an
unrepacked type. I have not written one; a maintainer will know better than I do
where that belongs.

## Base

Rebased on `b2f221684` (`Remove custom cpu op from the M3 graph, express with stock ops (#26297)`). Verified after the rebase that upstream still carries
the narrower sizing — `matrix_rows[(row_id) * ne12 + (i1)]` and
`sizeof_mmid_row_mapping*ne02*(ne12 + 1)` — and that the generic path in
`ggml-cpu.c` still strides by `ids->ne[0]*ids->ne[1]`, so the asymmetry this
patch removes is real and current.
