### PR TITLE
server : contain slot save/restore paths within --slot-save-path (#26315)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -5076,6 +5076,20 @@ json server_routes::get_model_info() const {
     };
 }
 
+// The textual `fs_validate_filename()` check does not resolve symlinks, so a symlink
+// placed inside the configured root can still redirect the operation outside of it.
+// Compare the *resolved* path against the resolved root before touching the file.
+static bool fs_path_is_within(const std::filesystem::path & root, const std::filesystem::path & path) {
+    auto root_it = root.begin();
+    auto path_it = path.begin();
+    for (; root_it != root.end() && path_it != path.end(); ++root_it, ++path_it) {
+        if (*root_it != *path_it) {
+            return false;
+        }
+    }
+    return root_it == root.end();
+}
+
 std::unique_ptr<server_res_generator> server_routes::handle_slots_save(const server_http_req & req, int id_slot) {
     auto res = create_response();
     const json request_data = json::parse(req.body);
@@ -5084,7 +5098,14 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_save(const ser
         res->error(format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
         return res;
     }
-    std::string filepath = params.slot_save_path + filename;
+    const auto slot_root     = std::filesystem::weakly_canonical(std::filesystem::path(params.slot_save_path));
+    const auto resolved_path = std::filesystem::weakly_canonical(slot_root / filename);
+    if (!fs_path_is_within(slot_root, resolved_path)) {
+        res->error(format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
+        return res;
+    }
+
+    std::string filepath = resolved_path.string();
 
     auto & rd = res->rd;
     {
@@ -5120,7 +5141,14 @@ std::unique_ptr<server_res_generator> server_routes::handle_slots_restore(const 
         res->error(format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
         return res;
     }
-    std::string filepath = params.slot_save_path + filename;
+    const auto slot_root     = std::filesystem::weakly_canonical(std::filesystem::path(params.slot_save_path));
+    const auto resolved_path = std::filesystem::weakly_canonical(slot_root / filename);
+    if (!fs_path_is_within(slot_root, resolved_path)) {
+        res->error(format_error_response("Invalid filename", ERROR_TYPE_INVALID_REQUEST));
+        return res;
+    }
+
+    std::string filepath = resolved_path.string();
 
     auto & rd = res->rd;
     {

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -222,3 +222,82 @@ def test_slot_erase_text_only_on_multimodal(mmproj_server):
     })
     assert res.status_code == 200
     assert res.body["timings"]["prompt_n"] == prompt_n  # all tokens are processed again
+
+
+#
+# Path containment for --slot-save-path.
+#
+# fs_validate_filename() is a textual filter: it blocks ".." and absolute paths
+# but does not resolve symlinks. A symlink placed inside the configured slot
+# directory therefore used to redirect the save to an arbitrary path, letting a
+# /slots?action=save request truncate and overwrite a file outside that
+# directory. Containment has to be checked on the resolved path.
+#
+
+
+def _plant_symlink_slot_dir(tmp_path):
+    slot_dir = tmp_path / "slots"
+    outside = tmp_path / "outside"
+    slot_dir.mkdir()
+    outside.mkdir()
+
+    victim = outside / "victim.bin"
+    victim.write_bytes(b"ORIGINAL_CONTENT")
+    os.symlink(os.path.join("..", "outside", "victim.bin"), slot_dir / "evil.bin")
+
+    return slot_dir, victim
+
+
+def test_slot_save_rejects_symlink_escape(tmp_path):
+    global server
+    slot_dir, victim = _plant_symlink_slot_dir(tmp_path)
+    server.slot_save_path = str(slot_dir) + os.sep
+    server.start()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of France?",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "evil.bin",
+    })
+    assert res.status_code == 400
+    assert victim.read_bytes() == b"ORIGINAL_CONTENT"
+
+
+def test_slot_restore_rejects_symlink_escape(tmp_path):
+    # The symlink must point at a REAL slot blob, otherwise restore fails on
+    # "not a valid slot file" and the test would pass without the containment
+    # check ever running.
+    global server
+    slot_dir = tmp_path / "slots"
+    outside = tmp_path / "outside"
+    slot_dir.mkdir()
+    outside.mkdir()
+
+    server.slot_save_path = str(slot_dir) + os.sep
+    server.start()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of France?",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "legit.bin",
+    })
+    assert res.status_code == 200
+
+    # move the valid blob out of the slot directory and link to it from inside
+    os.rename(slot_dir / "legit.bin", outside / "legit.bin")
+    os.symlink(os.path.join("..", "outside", "legit.bin"), slot_dir / "evil.bin")
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "evil.bin",
+    })
+    assert res.status_code == 400


### PR DESCRIPTION
Fixes #26315

## Overview

Prevent the slot save and restore endpoints from escaping `--slot-save-path` through symbolic links.

`POST /slots/:id_slot?action=save` could overwrite files outside the configured slot directory, while `action=restore` could read files from outside it. This PR resolves the slot directory and target path before use and rejects targets that are not contained within the configured directory.

## Additional information

Both handlers previously validated the caller-supplied filename using `fs_validate_filename()` and then constructed the target path through string concatenation:

```cpp
std::string filepath = params.slot_save_path + filename;
```

Although `fs_validate_filename()` rejects absolute paths and `..`, it only performs textual validation. The resulting path is passed to `llama_state_seq_save_file()` or `llama_state_seq_load_file()`, which follow symbolic links.

For example, if `slots/evil.bin` is a symbolic link to `../outside/target.bin`, a documented slot save request can truncate and overwrite the external target file while the server reports success.

### Fix

Resolve both the configured slot directory and the requested target using `std::filesystem::weakly_canonical()`, and reject the request unless the resolved target remains inside the resolved slot directory.

The containment check is applied to:

* `handle_slots_save()`
* `handle_slots_restore()`

The existing `400 Invalid filename` response is reused, so no new error format is introduced and existing clients continue to receive an error they already handle.

`fs_validate_filename()` is called without `allow_subdirs` in these handlers, so the filename cannot contain path separators and `slot_root / filename` is safe to join before canonicalization.

### Tests

Two test cases were added to `tools/server/tests/unit/test_slot_save.py`:

* `test_slot_save_rejects_symlink_escape`

  * Creates `slots/evil.bin` as a symbolic link to `../outside/victim.bin`.
  * Populates slot 1 and attempts to save it as `evil.bin`.
  * Verifies that the server returns HTTP 400 and that the victim file remains unchanged.

* `test_slot_restore_rejects_symlink_escape`

  * Creates a valid slot file, moves it outside the slot directory, and links to it from inside the directory.
  * Attempts to restore through the symbolic link.
  * Verifies that the server returns HTTP 400.

The restore test uses a valid slot file so that, without the containment check, parsing would succeed. This ensures the test specifically exercises the symlink containment check.

Results on commit `9b2a088819cda774bdbf713168ee1eee8498cda5`:

* Before this change: 2 new tests failed.
* After this change: 2 new tests passed.
* Existing `test_slot_save_restore` and `test_slot_erase`: 2 passed with no regressions.

Manual verification on commit `d0bfb1981266c271cd0536a8aa7c5e863e7cdf61`:

```text
Before:
{"id_slot":1,"filename":"evil.bin","n_saved":19,"n_written":12616,...}
outside/target.bin: 21 bytes -> 12616 bytes

After:
{"error":{"code":400,"message":"Invalid filename","type":"invalid_request_error"}}
outside/target.bin: 21 bytes, unchanged
```

`--media-path` and `--log-prompts-dir` appear to use the same textual-validation-then-concatenation pattern. They are intentionally left for separate changes so that each issue can be reviewed independently.

Reproduction material:

[slot-save-symlink-write.zip](https://github.com/user-attachments/files/30543993/slot-save-symlink-write.zip)

## Requirements

* I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: **YES** — AI was used to assist with preparing the patch and validating the vulnerability. All changes and test results were reviewed by the submitter.