### PR TITLE
ggml: fix size wrap in allocator and gguf alignment read

### DIFF
--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -74,12 +74,39 @@ struct ggml_tallocr ggml_tallocr_new(ggml_backend_buffer_t buffer) {
 
 enum ggml_status ggml_tallocr_alloc(struct ggml_tallocr * talloc, struct ggml_tensor * tensor) {
     size_t size = ggml_backend_buffer_get_alloc_size(talloc->buffer, tensor);
+
+    // Defensive: GGML_PAD below relies on alignment being a non-zero power of two.
+    // The constructor already asserts this, but assertions may be disabled in
+    // release builds and callers should not be able to crash the allocator.
+    if (talloc->alignment == 0 || (talloc->alignment & (talloc->alignment - 1)) != 0) {
+        GGML_LOG_ERROR("%s: invalid alignment %zu for tensor %s (must be non-zero power of two)\n",
+                __func__, talloc->alignment, tensor->name);
+        return GGML_STATUS_FAILED;
+    }
+
+    // Prevent integer overflow in GGML_PAD: size + alignment - 1 must not wrap.
+    // With alignment > 0 validated above, SIZE_MAX - alignment + 1 cannot underflow.
+    if (size > SIZE_MAX - talloc->alignment + 1) {
+        GGML_LOG_ERROR("%s: allocation size overflow for tensor %s (size %zu, alignment %zu)\n",
+                __func__, tensor->name, size, talloc->alignment);
+        return GGML_STATUS_FAILED;
+    }
+
     size = GGML_PAD(size, talloc->alignment);
 
-    if (talloc->offset + size > ggml_backend_buffer_get_size(talloc->buffer)) {
+    // Reject zero-byte allocations: they would return a valid pointer to a buffer
+    // that is too small for the tensor's declared dimensions.
+    if (size == 0) {
+        GGML_LOG_ERROR("%s: zero-size allocation requested for tensor %s\n",
+                __func__, tensor->name);
+        return GGML_STATUS_FAILED;
+    }
+
+    const size_t buf_size = ggml_backend_buffer_get_size(talloc->buffer);
+    if (talloc->offset > buf_size || size > buf_size - talloc->offset) {
         GGML_LOG_ERROR("%s: not enough space in the buffer to allocate %s (needed %zu, available %zu)\n",
-                __func__, tensor->name, size, ggml_backend_buffer_get_size(talloc->buffer) - talloc->offset);
-        GGML_ABORT("not enough space in the buffer");
+                __func__, tensor->name, size, buf_size - talloc->offset);
+        return GGML_STATUS_FAILED;
     }
 
     void * addr = (char *)ggml_backend_buffer_get_base(talloc->buffer) + talloc->offset;

--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -611,7 +611,15 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
         GGML_ASSERT(int64_t(ctx->kv.size()) == n_kv);
 
         const int alignment_idx = gguf_find_key(ctx, GGUF_KEY_GENERAL_ALIGNMENT);
-        ctx->alignment = alignment_idx == -1 ? GGUF_DEFAULT_ALIGNMENT : gguf_get_val_u32(ctx, alignment_idx);
+        if (alignment_idx == -1) {
+            ctx->alignment = GGUF_DEFAULT_ALIGNMENT;
+        } else if (ctx->kv[alignment_idx].type == GGUF_TYPE_UINT32) {
+            ctx->alignment = gguf_get_val_u32(ctx, alignment_idx);
+        } else {
+            GGML_LOG_WARN("%s: key '%s' has unexpected type %d, using default alignment %d\n",
+                    __func__, GGUF_KEY_GENERAL_ALIGNMENT, (int)ctx->kv[alignment_idx].type, GGUF_DEFAULT_ALIGNMENT);
+            ctx->alignment = GGUF_DEFAULT_ALIGNMENT;
+        }
 
         if (ctx->alignment == 0 || (ctx->alignment & (ctx->alignment - 1)) != 0) {
             GGML_LOG_ERROR("%s: alignment %zu is not a power of 2\n", __func__, ctx->alignment);

--- a/tests/test-alloc.cpp
+++ b/tests/test-alloc.cpp
@@ -583,6 +583,38 @@ static void test_reallocation() {
     }
 }
 
+static void test_tallocr_alloc_overflow() {
+    // Regression test for integer overflow in ggml_tallocr_alloc.
+    // A tensor with a dimension that makes ggml_nbytes wrap around SIZE_MAX
+    // must be rejected instead of returning a pointer into an undersized buffer.
+    dummy_backend backend = dummy_backend_init(512, /*align*/ 32);
+    ggml_backend_buffer_t buf = ggml_backend_buft_alloc_buffer(&backend.buffer_type, 512);
+    GGML_ASSERT(buf != nullptr);
+
+    struct ggml_tallocr talloc = ggml_tallocr_new(buf);
+
+    struct ggml_init_params params = {
+        /*.mem_size   =*/ 1024,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    GGML_ASSERT(ctx != nullptr);
+
+    ggml_tensor * t = ggml_new_tensor_1d(ctx, GGML_TYPE_I8, 1);
+    // Craft ne[0] so that ggml_nbytes is near SIZE_MAX. After GGML_PAD this
+    // would wrap to 0 or a small value, bypassing the buffer bounds check.
+    t->ne[0] = SIZE_MAX - 15;
+    t->nb[0] = 1;
+
+    const enum ggml_status status = ggml_tallocr_alloc(&talloc, t);
+    GGML_ASSERT(status == GGML_STATUS_FAILED);
+    GGML_ASSERT(t->data == nullptr);
+
+    ggml_free(ctx);
+    ggml_backend_buffer_free(buf);
+}
+
 static void run(const char * name, void (*f)()) {
     printf("%s ", name);
     fflush(stdout);
@@ -604,5 +636,6 @@ int main() {
     run("test_multiple_buffer_types", test_multiple_buffer_types);
     run("test_buffer_size_zero", test_buffer_size_zero);
     run("test_reallocation", test_reallocation);
+    run("test_tallocr_alloc_overflow", test_tallocr_alloc_overflow);
     return 0;
 }

--- a/tests/test-gguf.cpp
+++ b/tests/test-gguf.cpp
@@ -31,6 +31,7 @@ enum handcrafted_file_type {
     // HANDCRAFTED_KV_BAD_VALUE_SIZE          =  30 + offset_has_kv, // removed because it can result in allocations > 1 TB (default sanitizer limit)
     HANDCRAFTED_KV_DUPLICATE_KEY           =  40 + offset_has_kv,
     HANDCRAFTED_KV_BAD_ALIGN               =  50 + offset_has_kv,
+    HANDCRAFTED_KV_ALIGNMENT_WRONG_TYPE    =  60 + offset_has_kv,
     HANDCRAFTED_KV_SUCCESS                 = 800 + offset_has_kv,
 
     HANDCRAFTED_TENSORS_BAD_NAME_SIZE      =  10 + offset_has_tensors,
@@ -69,6 +70,7 @@ static std::string handcrafted_file_type_name(const enum handcrafted_file_type h
         case HANDCRAFTED_KV_BAD_TYPE:                return "KV_BAD_TYPE";
         case HANDCRAFTED_KV_DUPLICATE_KEY:           return "KV_DUPLICATE_KEY";
         case HANDCRAFTED_KV_BAD_ALIGN:               return "KV_BAD_ALIGN";
+        case HANDCRAFTED_KV_ALIGNMENT_WRONG_TYPE:    return "KV_ALIGNMENT_WRONG_TYPE";
         case HANDCRAFTED_KV_SUCCESS:                 return "KV_RANDOM_KV";
 
         case HANDCRAFTED_TENSORS_BAD_NAME_SIZE:      return "TENSORS_BAD_NAME_SIZE";
@@ -99,7 +101,9 @@ static bool expect_context_not_null(const enum handcrafted_file_type hft) {
         return hft >= HANDCRAFTED_HEADER_EMPTY;
     }
     if (hft < offset_has_tensors) {
-        return hft >= HANDCRAFTED_KV_SUCCESS;
+        // KV_ALIGNMENT_WRONG_TYPE is a malformed-but-recoverable file: the parser
+        // should fall back to the default alignment instead of aborting.
+        return hft >= HANDCRAFTED_KV_SUCCESS || hft == HANDCRAFTED_KV_ALIGNMENT_WRONG_TYPE;
     }
     if (hft < offset_has_data) {
         return hft >= HANDCRAFTED_TENSORS_SUCCESS;
@@ -357,6 +361,20 @@ static FILE * get_handcrafted_file(const unsigned int seed, const enum handcraft
 
         alignment = expect_context_not_null(hft) ? 1 : 13;
         helper_write(file, alignment);
+    }
+
+    if (hft == HANDCRAFTED_KV_ALIGNMENT_WRONG_TYPE) {
+        const uint64_t n = strlen(GGUF_KEY_GENERAL_ALIGNMENT);
+        helper_write(file, n);
+        helper_write(file, GGUF_KEY_GENERAL_ALIGNMENT, n);
+
+        // Write general.alignment with a non-UINT32 type (e.g., INT32).
+        // A robust parser should fall back to GGUF_DEFAULT_ALIGNMENT instead of aborting.
+        const int32_t type = gguf_type(GGUF_TYPE_INT32);
+        helper_write(file, type);
+
+        const int32_t value = 64;
+        helper_write(file, value);
     }
 
     if (hft < offset_has_tensors) {
@@ -747,6 +765,7 @@ static std::pair<int, int> test_handcrafted_file(const unsigned int seed) {
         HANDCRAFTED_KV_BAD_TYPE,
         HANDCRAFTED_KV_DUPLICATE_KEY,
         HANDCRAFTED_KV_BAD_ALIGN,
+        HANDCRAFTED_KV_ALIGNMENT_WRONG_TYPE,
         HANDCRAFTED_KV_SUCCESS,
 
         HANDCRAFTED_TENSORS_BAD_NAME_SIZE,


### PR DESCRIPTION
## Overview

我在 fuzzing GGUF 加载器时发现一个问题：分配器返回成功，但后续写入会覆盖相邻 tensor 的数据。

追查后发现是 ggml_tallocr_alloc 里的 GGML_PAD 宏在做 (size + align - 1) 时溢出了。当 size 接近最大值时，加法回绕成很小的数，导致分配了太小的 buffer，但 tensor 元数据仍以为 size 很大，结果越界。

这个和之前修过的 GHSA-vgg9 不是同一个问题——那个在 GGUF 解析层，这个在更底层的分配器 ggml-alloc.c，所以之前的补丁没覆盖到。

我的改法：

在 GGML_PAD 之前加一个溢出检查，如果会溢出就返回错误（不 abort）。

同时拒绝 size=0 的分配，并校验 alignment 必须是合法值。

顺便还修了一个小问题：general.alignment 在读取前没有检查类型，如果文件里写成 INT32 会触发断言崩溃。我改成先检查类型，不对就用默认值并打印警告。

已经加了两个回归测试，所有现有测试都通过了。

因为项目目前禁用了私有安全报告，所以直接发公开 PR。欢迎审阅，有任何意见请告诉我。

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES（仅用AI讨论过技术思路，PR描述由本人独立撰写。）
