### PR TITLE
server: correct accepted tokens when need draft token replay

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -289,6 +289,7 @@ struct server_slot {
     int32_t n_draft_accepted = 0;   // Draft tokens actually accepted
     int32_t n_draft_verif_steps = 0; // Total draft token verification steps by the target model
     std::vector<int32_t> n_accepted_per_pos; // Accepted tokens per draft position
+    bool is_draft_replay = false;
 
     void reset() {
         SLT_DBG(*this, "%s", "\n");
@@ -317,6 +318,7 @@ struct server_slot {
         n_draft_accepted = 0;
         n_draft_verif_steps = 0;
         n_accepted_per_pos.clear();
+        is_draft_replay = false;
 
         task_prev = std::move(task);
         task.reset();
@@ -3815,6 +3817,7 @@ private:
                         }
 
                         // partial acceptance is not supported by the context -> truncate the draft and restore the state
+                        slot.is_draft_replay = true;
                         slot.spec_draft = std::move(accepted);
 
                         const auto & ckpt = slot.spec_ckpt;
@@ -3848,17 +3851,22 @@ private:
             const int64_t t_now = ggml_time_us();
 
             const auto ids = std::move(slot.spec_draft);
+            size_t n_accepted_stats = ids.size() - 1;
+            if (slot.is_draft_replay && n_accepted_stats > 0) {
+                n_accepted_stats--;
+            }
+            slot.is_draft_replay = false;
 
             slot.t_token_generation = std::max<int64_t>(1, t_now - slot.t_start_generation) / 1e3;
 
             // update how many tokens out of those tested were accepted
-            slot.n_draft_accepted += ids.size() - 1;
+            slot.n_draft_accepted += n_accepted_stats;
             slot.n_draft_verif_steps += 1;
 
             if (slot.n_accepted_per_pos.empty()) {
                 slot.n_accepted_per_pos.resize(common_speculative_n_max(&params_base.speculative), 0);
             }
-            for (size_t i = 0; i < ids.size() - 1 && i < slot.n_accepted_per_pos.size(); ++i) {
+            for (size_t i = 0; i < n_accepted_stats && i < slot.n_accepted_per_pos.size(); ++i) {
                 slot.n_accepted_per_pos[i]++;
             }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -177,6 +177,7 @@ struct server_slot {
     llama_tokens spec_prompt;
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
+    bool spec_is_replay = false;
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
     //       see https://github.com/ggml-org/llama.cpp/pull/18283#issuecomment-3710175837
@@ -289,10 +290,11 @@ struct server_slot {
     int32_t n_draft_accepted = 0;   // Draft tokens actually accepted
     int32_t n_draft_verif_steps = 0; // Total draft token verification steps by the target model
     std::vector<int32_t> n_accepted_per_pos; // Accepted tokens per draft position
-    bool is_draft_replay = false;
 
     void reset() {
         SLT_DBG(*this, "%s", "\n");
+
+        spec_is_replay = false;
 
         n_prompt_tokens_cache = 0;
 
@@ -318,7 +320,6 @@ struct server_slot {
         n_draft_accepted = 0;
         n_draft_verif_steps = 0;
         n_accepted_per_pos.clear();
-        is_draft_replay = false;
 
         task_prev = std::move(task);
         task.reset();
@@ -3817,7 +3818,7 @@ private:
                         }
 
                         // partial acceptance is not supported by the context -> truncate the draft and restore the state
-                        slot.is_draft_replay = true;
+                        slot.spec_is_replay = true;
                         slot.spec_draft = std::move(accepted);
 
                         const auto & ckpt = slot.spec_ckpt;
@@ -3851,22 +3852,23 @@ private:
             const int64_t t_now = ggml_time_us();
 
             const auto ids = std::move(slot.spec_draft);
-            size_t n_accepted_stats = ids.size() - 1;
-            if (slot.is_draft_replay && n_accepted_stats > 0) {
-                n_accepted_stats--;
+
+            size_t n_accepted = ids.size() - 1;
+            if (slot.spec_is_replay && n_accepted > 0) {
+                n_accepted--;
             }
-            slot.is_draft_replay = false;
+            slot.spec_is_replay = false;
 
             slot.t_token_generation = std::max<int64_t>(1, t_now - slot.t_start_generation) / 1e3;
 
             // update how many tokens out of those tested were accepted
-            slot.n_draft_accepted += n_accepted_stats;
+            slot.n_draft_accepted += n_accepted;
             slot.n_draft_verif_steps += 1;
 
             if (slot.n_accepted_per_pos.empty()) {
                 slot.n_accepted_per_pos.resize(common_speculative_n_max(&params_base.speculative), 0);
             }
-            for (size_t i = 0; i < n_accepted_stats && i < slot.n_accepted_per_pos.size(); ++i) {
+            for (size_t i = 0; i < n_accepted && i < slot.n_accepted_per_pos.size(); ++i) {
                 slot.n_accepted_per_pos[i]++;
             }
 
@@ -3902,7 +3904,7 @@ private:
 
             slot.print_timings_tg();
 
-            SLT_DBG(slot, "accepted %d/%d draft tokens, new n_tokens = %d\n", (int) ids.size() - 1, (int) n_draft, slot.prompt.n_tokens());
+            SLT_DBG(slot, "accepted %d/%d draft tokens, new n_tokens = %d\n", (int) n_accepted, (int) n_draft, slot.prompt.n_tokens());
         });
     }
 


### PR DESCRIPTION
## Overview

When the target context can't roll back a partially-accepted speculative draft in place — i.e. it falls back to a full checkpoint restore (`COMMON_CONTEXT_SEQ_RM_TYPE_FULL`, or `RS` with `n_rollback > n_rs_seq`) — the server restores the checkpoint and replays the accepted prefix plus the target's own correction token as the next draft. 

On that replayed step every token is accepted, so the per-request speculative stats counted the target-generated correction token as an accepted draft token, inflating draft acceptance, per-position acceptance and mean len by 1 for each checkpoint restore.

This marks the slot when a checkpoint replay is queued (`is_draft_replay`) and excludes that single correction token from the acceptance statistics on the replayed step.

This change only affects reported per-request stats only.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, paired with Cursor

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
