### PR TITLE
cuda: fix race condition in async tensor copy on virtual devices

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2468,6 +2468,7 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
         const int dst_physical = ggml_cuda_get_physical_device(cuda_ctx_dst->device);
         if (src_physical == dst_physical) {
             CUDA_CHECK(cudaMemcpyAsync(dst->data, src->data, ggml_nbytes(dst), cudaMemcpyDeviceToDevice, cuda_ctx_src->stream()));
+            CUDA_CHECK(cudaStreamSynchronize(cuda_ctx_src->stream()));
         } else {
 #ifdef GGML_CUDA_NO_PEER_COPY
             return false;


### PR DESCRIPTION
## Overview

I've been running some tests with tensor split on cuda virtual devices and encountered some non-deterministic behavior. 

Multiple calls to llama-completion with same arguments should produce same results if `--top-k 1` is set - as described in https://github.com/ggml-org/llama.cpp/pull/19378#issuecomment-3861799503

## Additional information

I've tested only wih AMD Radeon RX 6600. I don't know if this affects CUDA as a whole or is HIP specific.

Test command:
```
repeat 100; GGML_CUDA_DEVICES=2  build/bin/llama-completion -lv 1 --fit off -c 4096  -m /models/qwen3.6-35B-A3B/Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf -no-cnv -p "I believe the meaning of life is" -n 32 --top-k 1 -cmoe  -sm tensor 
```
Upstream with `-sm layer`
100 out of 100 runs produced the same response.

Upstream with `-sm tensor`
69 out of 100 runs produced the same response

With additional synchronization
96 out of 100 runs produced the same response


So far I wasn't able to pinpoint the second race condition that caused those 4 runs to fail.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, finding the root cause
