### PR TITLE
ggml-cpu: add x86 VNNI Q2_0 dot product -- 3x speed improvement for VNNI-compatible CPUs

### DIFF
--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -82,8 +82,6 @@
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
 #define ggml_gemm_q2_K_8x8_q8_K_generic ggml_gemm_q2_K_8x8_q8_K
 #elif defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
-// quants.c
-#define ggml_vec_dot_q2_0_q8_0_generic ggml_vec_dot_q2_0_q8_0
 // repack.cpp
 #define ggml_quantize_mat_q8_0_4x4_generic ggml_quantize_mat_q8_0_4x4
 #define ggml_quantize_mat_q8_K_4x4_generic ggml_quantize_mat_q8_K_4x4

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -578,11 +578,11 @@ void ggml_vec_dot_q2_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
     const __m128i idxhi = _mm_setr_epi8(4,4,4,4,5,5,5,5,6,6,6,6,7,7,7,7);
     const __m256i mul   = _mm256_setr_epi16(64,16,4,1, 64,16,4,1, 64,16,4,1, 64,16,4,1);
     const __m256i three = _mm256_set1_epi16(3);
-    float sumf = 0.0f;
+    __m256 acc = _mm256_setzero_ps();
 
     for (int i = 0; i < nb; i++) {
         const float d0 = GGML_CPU_FP16_TO_FP32(x[i].d);
-        float sumi = 0.0f;
+        __m256 acc_block = _mm256_setzero_ps();
         for (int k = 0; k < 2; k++) {
             const block_q8_0 * GGML_RESTRICT yb = &y[i * 2 + k];
             const float d1 = GGML_CPU_FP16_TO_FP32(yb->d);
@@ -594,14 +594,15 @@ void ggml_vec_dot_q2_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const voi
             r0 = _mm256_and_si256(_mm256_srli_epi16(_mm256_mullo_epi16(r0, mul), 6), three);
             r1 = _mm256_and_si256(_mm256_srli_epi16(_mm256_mullo_epi16(r1, mul), 6), three);
             const __m256i codes = _mm256_permute4x64_epi64(_mm256_packus_epi16(r0, r1), 0xD8);
-            const int dp = hsum_i32_8(GGML_DPBUSD_256(_mm256_setzero_si256(), codes, qy));
-            const int sy = hsum_i32_8(GGML_DPBUSD_256(_mm256_setzero_si256(), ones, qy));
-            sumi += d1 * (float) (dp - sy);
+            const __m256i dp = GGML_DPBUSD_256(_mm256_setzero_si256(), codes, qy);
+            const __m256i sy = GGML_DPBUSD_256(_mm256_setzero_si256(), ones, qy);
+            const __m256 dot = _mm256_cvtepi32_ps(_mm256_sub_epi32(dp, sy));
+            acc_block = _mm256_add_ps(acc_block, _mm256_mul_ps(_mm256_set1_ps(d1), dot));
         }
-        sumf += d0 * sumi;
+        acc = _mm256_add_ps(acc, _mm256_mul_ps(_mm256_set1_ps(d0), acc_block));
     }
 
-    *s = sumf;
+    *s = hsum_float_8(acc);
 #else
     ggml_vec_dot_q2_0_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
 #endif

--- a/ggml/src/ggml-cpu/arch/x86/quants.c
+++ b/ggml/src/ggml-cpu/arch/x86/quants.c
@@ -552,6 +552,61 @@ static inline __m128i get_scale_shuffle(int i) {
 }
 #endif
 
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+#  define GGML_DPBUSD_256 _mm256_dpbusd_epi32
+#elif defined(__AVXVNNI__)
+#  define GGML_DPBUSD_256 _mm256_dpbusd_avx_epi32
+#endif
+
+void ggml_vec_dot_q2_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
+#if (defined(__AVX512VNNI__) && defined(__AVX512VL__)) || defined(__AVXVNNI__)
+    const int qk = QK2_0;
+    const int nb = n / qk;
+
+    assert(n % qk == 0);
+    assert(nrc == 1);
+    UNUSED(nrc);
+    UNUSED(bx);
+    UNUSED(by);
+    UNUSED(bs);
+
+    const block_q2_0 * GGML_RESTRICT x = vx;
+    const block_q8_0 * GGML_RESTRICT y = vy;
+
+    const __m256i ones  = _mm256_set1_epi8(1);
+    const __m128i idxlo = _mm_setr_epi8(0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3);
+    const __m128i idxhi = _mm_setr_epi8(4,4,4,4,5,5,5,5,6,6,6,6,7,7,7,7);
+    const __m256i mul   = _mm256_setr_epi16(64,16,4,1, 64,16,4,1, 64,16,4,1, 64,16,4,1);
+    const __m256i three = _mm256_set1_epi16(3);
+    float sumf = 0.0f;
+
+    for (int i = 0; i < nb; i++) {
+        const float d0 = GGML_CPU_FP16_TO_FP32(x[i].d);
+        float sumi = 0.0f;
+        for (int k = 0; k < 2; k++) {
+            const block_q8_0 * GGML_RESTRICT yb = &y[i * 2 + k];
+            const float d1 = GGML_CPU_FP16_TO_FP32(yb->d);
+            const __m256i qy = _mm256_loadu_si256((const __m256i *) yb->qs);
+            const __m128i src = _mm_loadl_epi64((const __m128i *) &x[i].qs[k * 8]);
+            const __m256i rep = MM256_SET_M128I(_mm_shuffle_epi8(src, idxhi), _mm_shuffle_epi8(src, idxlo));
+            __m256i r0 = _mm256_cvtepu8_epi16(_mm256_castsi256_si128(rep));
+            __m256i r1 = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(rep, 1));
+            r0 = _mm256_and_si256(_mm256_srli_epi16(_mm256_mullo_epi16(r0, mul), 6), three);
+            r1 = _mm256_and_si256(_mm256_srli_epi16(_mm256_mullo_epi16(r1, mul), 6), three);
+            const __m256i codes = _mm256_permute4x64_epi64(_mm256_packus_epi16(r0, r1), 0xD8);
+            const int dp = hsum_i32_8(GGML_DPBUSD_256(_mm256_setzero_si256(), codes, qy));
+            const int sy = hsum_i32_8(GGML_DPBUSD_256(_mm256_setzero_si256(), ones, qy));
+            sumi += d1 * (float) (dp - sy);
+        }
+        sumf += d0 * sumi;
+    }
+
+    *s = sumf;
+#else
+    ggml_vec_dot_q2_0_q8_0_generic(n, s, bs, vx, bx, vy, by, nrc);
+#endif
+}
+
 void ggml_vec_dot_q1_0_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {
     const int qk = QK1_0;
     const int nb = n / qk;


### PR DESCRIPTION
## Overview

This PR adds an optimized x86 implementation of the existing `ggml_vec_dot_q2_0_q8_0` operation for builds targeting AVX-VNNI or AVX-512 VNNI with AVX-512 VL. `test-quantize-fns` passes, and 14,000 randomized comparisons between the generic and optimized implementations matched bit-for-bit across SSE4.2 and AVX2 generic builds, an AVX-VNNI build, and a native AVX-512 VNNI build.

I also ran a perplexity smoke test, and saw that despite the op being identical to the generic implementation in isolation, it does cause differences in perplexity that are small but repeatable; mean KLD differed `0.000310 +/- 0.000044`, and the two implementations had the same top token `99.216 +/- 0.554%` of the time. After some additional investigation supported by OpenAI Codex, I believe the difference comes from different handling for floating point operations after the `ggml_vec_dot_q2_0_q8_0` call: GCC emits separate multiply and add instructions for the generic path, but the optimized path gets fused multiply-add instructions. Disabling floating-point contraction made the implementations bit-identical and reproduced the baseline perplexity, but I think the fused instruction is probably the right one, and a similar numerical drift was present and accepted in PR #21636 for Q1_0 support.

## Additional information

I used Codex to run benchmarks to compare identical clean builds of `master` (`5f55650a78f92aff4d48d671423e888fac0469ff`) and this implementation on an AMD EPYC 9645 using eight CPU cores.

Build: `GGML_NATIVE=ON`, OpenMP enabled, BLAS disabled
Configuration: CPU-only, `-t 8 -ngl 0 -fa off`
Measurements: mean ± standard deviation, 3 runs after normal warmup
Models: group-64 Q2_0 GGUFs of Bonsai
1.7B–8B command: `llama-bench -t 8 -r 3 -p 512 -n 128 -ngl 0 -fa off`
27B command: `llama-bench -t 8 -r 3 -p 128 -n 32 -ngl 0 -fa off`

Model | Test | Upstream master | VNNI implementation | Speedup
-- | -- | -- | -- | --
Bonsai 1.7B | pp512 | 14.069 ± 0.018 tok/s | 50.472 ± 0.231 tok/s | 3.59×
Bonsai 1.7B | tg128 | 10.224 ± 0.057 tok/s | 33.280 ± 0.247 tok/s | 3.26×
Bonsai 4B | pp512 | 5.405 ± 0.014 tok/s | 19.402 ± 0.182 tok/s | 3.59×
Bonsai 4B | tg128 | 4.452 ± 0.019 tok/s | 13.359 ± 0.496 tok/s | 3.00×
Bonsai 8B | pp512 | 2.815 ± 0.014 tok/s | 10.257 ± 0.063 tok/s | 3.64×
Bonsai 8B | tg128 | 2.388 ± 0.008 tok/s | 8.199 ± 0.021 tok/s | 3.43×
Bonsai 27B | pp128 | 0.793 ± 0.002 tok/s | 2.846 ± 0.028 tok/s | 3.59×
Bonsai 27B | tg32 | 0.716 ± 0.003 tok/s | 2.374 ± 0.016 tok/s | 3.32×

The 27B model uses the shorter `pp128`/`tg32` workload because its baseline `pp128` pass took almost three minutes.

### Models benchmarked

- [Bonsai 1.7B - Q2_0 group-64](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-gguf/blob/main/Ternary-Bonsai-1.7B-Q2_0_g64.gguf)
- [Bonsai 4B - Q2_0 group-64](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-gguf/blob/main/Ternary-Bonsai-4B-Q2_0_g64.gguf)
- [Bonsai 8B - Q2_0 group-64](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf/blob/main/Ternary-Bonsai-8B-Q2_0_g64.gguf)
- [Bonsai 27B - Q2 group-64](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-gguf/blob/main/Ternary-Bonsai-27B-Q2_g64.gguf)

### Reference implementation

This implementation was adapted from Prism's group-128 Q2_0 x86 kernel:

- [Original group-128 AVX-512-VNNI implementation](https://github.com/PrismML-Eng/llama.cpp/commit/4d88cd4eb3a2da571b3baf446ecb89c587836005)
- [AVX-VNNI follow-up](https://github.com/PrismML-Eng/llama.cpp/commit/79697f23a2c8f3aa2ccb2fd7406095a8dbfbb454)
- [Resulting x86 kernel source](https://github.com/PrismML-Eng/llama.cpp/blob/79697f23a2c8f3aa2ccb2fd7406095a8dbfbb454/ggml/src/ggml-cpu/arch/x86/quants.c#L555-L611)

The Prism implementation operates on four Q8_0 blocks per group-128 Q2_0
block. This change adapts the same unpacking and VNNI dot-product approach
for the group-64 format, which uses two Q8_0 blocks per Q2_0 block.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, OpenAI Codex was used to identify this performance uplift possibility; it was also used to draft the first version of `ggml_vec_dot_q2_0_q8_0` from the reference implementation above, and draft commands to generate the benchmarks.