### PR TITLE
vulkan : disable FA GQA packing for multi-token queries

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan-fa-gqa.h
+++ b/ggml/src/ggml-vulkan/ggml-vulkan-fa-gqa.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+// Host-side predicate for Vulkan FA GQA packing (N := gqa_ratio, rows = heads).
+// Only valid for single-token decode (neq1 == 1). Multi-token speculative verify
+// must use the normal FA path.
+inline bool ggml_vk_fa_should_pack_gqa(
+        uint32_t neq1,
+        uint32_t N,
+        uint32_t qk_ratio,
+        uint32_t max_gqa,
+        uint32_t nek2,
+        uint32_t neq2,
+        uint32_t nev2,
+        uint32_t nem2) {
+    return neq1 == 1 && N <= 8 && qk_ratio > 1 && qk_ratio <= max_gqa &&
+           qk_ratio * nek2 == neq2 && nek2 == nev2 && nem2 <= 1;
+}

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -94,6 +94,7 @@ typedef struct VkPhysicalDeviceCooperativeMatrixDecodeVectorFeaturesNV {
 #include "ggml-backend-impl.h"
 
 #include "ggml-vulkan-shaders.hpp"
+#include "ggml-vulkan-fa-gqa.h"
 
 // remove this once it's more widely available in the SDK
 #if !defined(VK_KHR_shader_bfloat16)
@@ -10587,8 +10588,7 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
     const uint32_t max_gqa = std::min(tuning_params.block_rows, 32u);
 
     // GQA packing (N := gqa_ratio) is only valid for single-token decode
-    if (neq1 == 1 && N <= 8 && qk_ratio > 1 && qk_ratio <= max_gqa &&
-        qk_ratio * nek2 == neq2 && nek2 == nev2 && nem2 <= 1) {
+    if (ggml_vk_fa_should_pack_gqa(neq1, N, qk_ratio, max_gqa, nek2, neq2, nev2, nem2)) {
         // grouped query attention - make the N dimension equal to gqa_ratio, reduce
         // workgroups proportionally in y dimension. The shader will detect gqa_ratio > 1
         // and change addressing calculations to index Q's dimension 2.

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10586,7 +10586,8 @@ static void ggml_vk_flash_attn(ggml_backend_vk_context * ctx, vk_context& subctx
     vk_fa_tuning_params tuning_params = get_fa_tuning_params(ctx->device, HSK, HSV, 512, KV, k->type, v->type, f32acc);
     const uint32_t max_gqa = std::min(tuning_params.block_rows, 32u);
 
-    if (N <= 8 && qk_ratio > 1 && qk_ratio <= max_gqa &&
+    // GQA packing (N := gqa_ratio) is only valid for single-token decode
+    if (neq1 == 1 && N <= 8 && qk_ratio > 1 && qk_ratio <= max_gqa &&
         qk_ratio * nek2 == neq2 && nek2 == nev2 && nem2 <= 1) {
         // grouped query attention - make the N dimension equal to gqa_ratio, reduce
         // workgroups proportionally in y dimension. The shader will detect gqa_ratio > 1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -265,6 +265,12 @@ if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
 endif()
 llama_build_and_test(test-backend-ops.cpp)
 
+# Vulkan FA GQA packing gate (header-only predicate; no GPU required)
+if (GGML_VULKAN)
+    llama_build_and_test(test-vk-fa-gqa-pack.cpp LABEL "Vulkan")
+    target_include_directories(test-vk-fa-gqa-pack PRIVATE ${CMAKE_SOURCE_DIR}/ggml/src/ggml-vulkan)
+endif()
+
 llama_build_and_test(test-model-load-cancel.cpp LABEL "model")
 llama_build_and_test(test-autorelease.cpp       LABEL "model")
 llama_build_and_test(test-backend-sampler.cpp   LABEL "model")

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9565,6 +9565,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // Speculative-verify shapes: GQA + multi-token queries (neq1 in 2..8).
+    // Vulkan GQA packing must not treat these as single-token decode.
+    for (int nb : { 2, 4, 5, 7, 8 }) {
+        test_cases.emplace_back(new test_flash_attn_ext(128, 128, 8, {4, 1}, 512, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+        test_cases.emplace_back(new test_flash_attn_ext(64, 64, 8, {4, 1}, 512, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    }
+
     // mixed quant and Q1_0 test cases
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 128, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q4_0));
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 128, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q4_0, GGML_TYPE_F16));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9565,13 +9565,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
-    // Speculative-verify shapes: GQA + multi-token queries (neq1 in 2..8).
-    // Vulkan GQA packing must not treat these as single-token decode.
-    for (int nb : { 2, 4, 5, 7, 8 }) {
-        test_cases.emplace_back(new test_flash_attn_ext(128, 128, 8, {4, 1}, 512, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
-        test_cases.emplace_back(new test_flash_attn_ext(64, 64, 8, {4, 1}, 512, nb, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
-    }
-
     // mixed quant and Q1_0 test cases
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 128, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q4_0));
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 128, 2, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q4_0, GGML_TYPE_F16));

--- a/tests/test-vk-fa-gqa-pack.cpp
+++ b/tests/test-vk-fa-gqa-pack.cpp
@@ -1,0 +1,57 @@
+// Regression for Vulkan FA GQA packing gate (PR #26358 / issue #25618).
+//
+// The old host condition packed whenever N<=8 (query tokens), which is wrong for
+// multi-token speculative verify. Op-level NMSE vs CPU does not catch that path
+// (error stays ~1e-5 either way). This test asserts the packing predicate itself:
+// pack only for single-token decode (neq1 == 1).
+//
+// Fails before the fix (old predicate returns true for neq1 in 2..8).
+// Passes after (neq1 == 1 required).
+
+#include "ggml-vulkan-fa-gqa.h"
+
+#include <cstdio>
+
+static int fails = 0;
+
+static void expect(bool cond, const char * msg) {
+    if (!cond) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        ++fails;
+    }
+}
+
+int main() {
+    const uint32_t max_gqa = 16;
+    // Qwen3-like: 32 Q heads, 8 KV heads -> qk_ratio 4
+    const uint32_t qk = 4, nek2 = 8, neq2 = 32, nev2 = 8, nem2 = 1;
+
+    expect(ggml_vk_fa_should_pack_gqa(1, 1, qk, max_gqa, nek2, neq2, nev2, nem2),
+           "single-token GQA decode should pack");
+
+    const uint32_t multi[] = { 2, 3, 4, 5, 7, 8 };
+    for (uint32_t i = 0; i < sizeof(multi) / sizeof(multi[0]); ++i) {
+        const uint32_t neq1 = multi[i];
+        char buf[128];
+        snprintf(buf, sizeof(buf), "multi-token neq1=%u must not pack", neq1);
+        expect(!ggml_vk_fa_should_pack_gqa(neq1, neq1, qk, max_gqa, nek2, neq2, nev2, nem2), buf);
+    }
+
+    // Old broken predicate (N<=8 only) would pack these - document the delta.
+    auto old_pack = [](uint32_t N, uint32_t qk_ratio, uint32_t max_gqa,
+                       uint32_t nek2, uint32_t neq2, uint32_t nev2, uint32_t nem2) {
+        return N <= 8 && qk_ratio > 1 && qk_ratio <= max_gqa &&
+               qk_ratio * nek2 == neq2 && nek2 == nev2 && nem2 <= 1;
+    };
+    expect(old_pack(8, qk, max_gqa, nek2, neq2, nev2, nem2),
+           "sanity: old predicate would pack neq1=8");
+    expect(!ggml_vk_fa_should_pack_gqa(8, 8, qk, max_gqa, nek2, neq2, nev2, nem2),
+           "new predicate must disagree with old for neq1=8");
+
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    printf("test-vk-fa-gqa-pack: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Overview

disable FA GQA packing for multi-token queries

## Additional information

Speculative verify runs flash attention with neq1 > 1 (several query tokens at once). Vulkan’s GQA-packed FA path treated N <= 8 as “use GQA packing,” then overwrote N with gqa_ratio and remapped workgroups as if there were a single query token. That is only valid for single-token decode, so multi-token parallel verify disagreed with sequential FA and drifted logits (e.g. wrong-draft windows with n_win >= 4)

Related to #25618

## Validation

Setup1: Qwen3-8B Q4 + DSpark n_max=7 using vulkan on strix halo
Before Fix: Diverging output as compared to just vanilla model at same seed & zero temp
After Fix: Exact Match

Setup2: Gemma-4 Q4 + MTP n_max=4
Result: Still diverging, there are other bugs as well that I plan to handle in other PRs. See #25618

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Assisted by AI