### PR TITLE
cli : persist reasoning_content in chat history

### DIFF
--- a/tools/cli/cli-context.cpp
+++ b/tools/cli/cli-context.cpp
@@ -628,8 +628,6 @@ int cli_context::run() {
             {"role",    "assistant"},
             {"content", content.content}
         };
-        // Keep reasoning so templates with preserve_thinking / --reasoning-preserve
-        // can re-inject prior thoughts on later turns (e.g. Qwen3.6).
         if (!content.reasoning.empty()) {
             assistant_msg["reasoning_content"] = content.reasoning;
         }

--- a/tools/cli/cli-context.cpp
+++ b/tools/cli/cli-context.cpp
@@ -624,10 +624,16 @@ int cli_context::run() {
         generated_content content;
         generate_completion(content, timings);
 
-        impl->messages.push_back({
+        json assistant_msg = {
             {"role",    "assistant"},
             {"content", content.content}
-        });
+        };
+        // Keep reasoning so templates with preserve_thinking / --reasoning-preserve
+        // can re-inject prior thoughts on later turns (e.g. Qwen3.6).
+        if (!content.reasoning.empty()) {
+            assistant_msg["reasoning_content"] = content.reasoning;
+        }
+        impl->messages.push_back(std::move(assistant_msg));
 
         if (output_file) {
             std::string out_content = "Assistant:\n";


### PR DESCRIPTION
## Overview

There's a bug where llama-cli essentially ignores `--reasoning-preserve` arg or  templates with `preserve_thinking` (e.g. Qwen3.6). It was caused by content.reasoning not being filled in on subsequent turns' templates.

llama-cli streams assistant thinking into `content.reasoning`, but when appending the assistant message to chat history it only stored `content.content` and not content.reasoning. On the next turn the prompt had no prior thoughts.

## Additional information

Manual check:

- Build llama-cli
- Run a reasoning model with `--reasoning-preserve`
- Turn 1: ask it to pick a secret number 1-100 and only reply "OK ready"
- Note the number in the thinking / reasoning output
- Turn 2: guess a wrong number and ask yes/no plus the actual number
- Confirm turn 2 reasoning/answer matches the turn 1 number

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Cursor used to locate the CLI history append path and apply the one-file change