### PR TITLE
vulkan: fix submission batching size, add debug tools for diagnosing causes of DeviceLost drivers errors

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -186,9 +186,17 @@ static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
 
 #define VK_DEVICE_DESCRIPTOR_POOL_SIZE 256
 
-#define VK_CHECK(err, msg)                                          \
+#define VK_CHECK(err, msg, dev)                                     \
     do {                                                            \
-        vk::Result err_ = (err);                                    \
+        vk::Result err_;                                            \
+        try {                                                       \
+            err_ = (err);                                           \
+        } catch (vk::DeviceLostError &) {                           \
+            ggml_vk_print_device_fault_info(dev);                   \
+            fprintf(stderr, "ggml_vulkan: %s error VK_ERROR_DEVICE_LOST at %s:%d\n", \
+                #err, __FILE__, __LINE__);                          \
+            exit(1);                                                \
+        }                                                           \
         if (err_ != vk::Result::eSuccess) {                         \
             fprintf(stderr, "ggml_vulkan: %s error %s at %s:%d\n",  \
                 #err, to_string(err_).c_str(), __FILE__, __LINE__); \
@@ -302,9 +310,12 @@ struct vk_command_pool {
     }
 };
 
+static void ggml_vk_print_device_fault_info(const vk_device& device);
+
 // Prevent simultaneous submissions to the same queue.
 struct vk_queue_handle {
     vk::Queue queue;
+    vk_device device;
     virtual void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) = 0;
     virtual void lock()   {}   // no-op by default (internally synchronized case)
     virtual void unlock() {}
@@ -315,7 +326,12 @@ struct vk_queue_handle_synchronized : vk_queue_handle {
     std::mutex mutex;
     void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) override {
         std::lock_guard<std::mutex> guard(mutex);
-        queue.submit(submits, fence);
+        try {
+            queue.submit(submits, fence);
+        } catch (vk::DeviceLostError &) {
+            ggml_vk_print_device_fault_info(device);
+            throw;
+        }
     }
     void lock()   override { mutex.lock(); }
     void unlock() override { mutex.unlock(); }
@@ -324,7 +340,12 @@ struct vk_queue_handle_synchronized : vk_queue_handle {
 struct vk_queue_handle_unsynchronized : vk_queue_handle {
     void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) override {
         // Driver guarantees internal synchronization via VK_KHR_internally_synchronized_queues
-        queue.submit(submits, fence);
+        try {
+            queue.submit(submits, fence);
+        } catch (vk::DeviceLostError &) {
+            ggml_vk_print_device_fault_info(device);
+            throw;
+        }
     }
     // lock()/unlock() inherited no-ops
 };
@@ -811,6 +832,11 @@ struct vk_device_struct {
 
     bool pipeline_executable_properties_support {};
 
+    bool device_fault {};
+    PFN_vkGetDeviceFaultInfoEXT pfn_vkGetDeviceFaultInfoEXT {};
+
+    bool serialize_submissions {};
+
     size_t idx;
 
     bool mul_mat_l[GGML_TYPE_COUNT];
@@ -1090,6 +1116,57 @@ void vk_command_pool::destroy(vk::Device& device) {
     device.destroyCommandPool(pool);
     pool = nullptr;
     cmd_buffers.clear();
+}
+
+static void ggml_vk_print_device_fault_info(const vk_device& device) {
+    if (!device->device_fault || !device->pfn_vkGetDeviceFaultInfoEXT) {
+        return;
+    }
+
+    VkDeviceFaultCountsEXT fault_counts {};
+    fault_counts.sType = VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT;
+    VkResult res = device->pfn_vkGetDeviceFaultInfoEXT(device->device, &fault_counts, nullptr);
+    if (res != VK_SUCCESS) {
+        fprintf(stderr, "ggml_vulkan: vkGetDeviceFaultInfoEXT (counts) failed: %d\n", res);
+        return;
+    }
+
+    std::vector<VkDeviceFaultAddressInfoEXT> address_infos(fault_counts.addressInfoCount);
+    std::vector<VkDeviceFaultVendorInfoEXT> vendor_infos(fault_counts.vendorInfoCount);
+
+    VkDeviceFaultInfoEXT fault_info {};
+    fault_info.sType = VK_STRUCTURE_TYPE_DEVICE_FAULT_INFO_EXT;
+    fault_info.pAddressInfos = address_infos.data();
+    fault_info.pVendorInfos = vendor_infos.data();
+
+    res = device->pfn_vkGetDeviceFaultInfoEXT(device->device, &fault_counts, &fault_info);
+    if (res != VK_SUCCESS) {
+        fprintf(stderr, "ggml_vulkan: vkGetDeviceFaultInfoEXT (info) failed: %d\n", res);
+        return;
+    }
+
+    if (fault_counts.addressInfoCount == 0 && fault_counts.vendorInfoCount == 0 && fault_info.description[0] == '\0') {
+        return;
+    }
+
+    if (fault_info.description[0] != '\0') {
+        fprintf(stderr, "ggml_vulkan: device fault on %s: %s\n", device->name.c_str(), fault_info.description);
+    }
+
+    for (uint32_t i = 0; i < fault_counts.addressInfoCount; i++) {
+        const auto& info = address_infos[i];
+        fprintf(stderr, "  address fault %u: type=%d address=0x%llx precision=0x%llx\n",
+                i, (int)info.addressType,
+                (unsigned long long)info.reportedAddress,
+                (unsigned long long)info.addressPrecision);
+    }
+    for (uint32_t i = 0; i < fault_counts.vendorInfoCount; i++) {
+        const auto& info = vendor_infos[i];
+        fprintf(stderr, "  vendor fault %u: %s (code=0x%llx data=0x%llx)\n",
+                i, info.description,
+                (unsigned long long)info.vendorFaultCode,
+                (unsigned long long)info.vendorFaultData);
+    }
 }
 
 struct vk_buffer_struct {
@@ -2014,6 +2091,25 @@ static uint64_t ggml_vk_get_node_flops(const ggml_tensor * node) {
     return 0;
 }
 
+static void ggml_vk_print_node_list(const ggml_cgraph * cgraph, int start, int end) {
+    uint64_t total_flops = 0;
+    int n_ops = 0;
+    for (int j = start; j <= end && j < cgraph->n_nodes; j++) {
+        uint64_t flops = ggml_vk_get_node_flops(cgraph->nodes[j]);
+        total_flops += flops;
+        n_ops++;
+        if (flops > 0) {
+            fprintf(stderr, "  node %d: %s (%s) [%.2f GFLOP]\n",
+                    j, cgraph->nodes[j]->name, ggml_op_name(cgraph->nodes[j]->op),
+                    flops / 1e9);
+        } else {
+            fprintf(stderr, "  node %d: %s (%s)\n",
+                    j, cgraph->nodes[j]->name, ggml_op_name(cgraph->nodes[j]->op));
+        }
+    }
+    fprintf(stderr, "  total: %d ops, %.2f GFLOP\n", n_ops, total_flops / 1e9);
+}
+
 class vk_perf_logger {
   public:
     void print_timings(bool force = false) {
@@ -2426,14 +2522,24 @@ static void ggml_vk_wait_for_fence(ggml_backend_vk_context * ctx) {
     // Use waitForFences while most of the graph executes. Hopefully the CPU can sleep
     // during this wait.
     if (ctx->almost_ready_fence_pending) {
-        VK_CHECK(ctx->device->device.waitForFences({ ctx->almost_ready_fence }, true, UINT64_MAX), "almost_ready_fence");
+        VK_CHECK(ctx->device->device.waitForFences({ ctx->almost_ready_fence }, true, UINT64_MAX), "almost_ready_fence", ctx->device);
         ctx->device->device.resetFences({ ctx->almost_ready_fence });
         ctx->almost_ready_fence_pending = false;
     }
 
     // Spin (w/pause) waiting for the graph to finish executing.
     vk::Result result;
-    while ((result = ctx->device->device.getFenceStatus(ctx->fence)) != vk::Result::eSuccess) {
+    for (;;) {
+        try {
+            result = ctx->device->device.getFenceStatus(ctx->fence);
+        } catch (vk::DeviceLostError &) {
+            ggml_vk_print_device_fault_info(ctx->device);
+            fprintf(stderr, "ggml_vulkan: getFenceStatus VK_ERROR_DEVICE_LOST at %s:%d\n", __FILE__, __LINE__);
+            exit(1);
+        }
+        if (result == vk::Result::eSuccess) {
+            break;
+        }
         if (result != vk::Result::eNotReady) {
             fprintf(stderr, "ggml_vulkan: error %s at %s:%d\n", to_string(result).c_str(), __FILE__, __LINE__);
             exit(1);
@@ -3127,6 +3233,7 @@ static std::unique_ptr<vk_queue> ggml_vk_create_queue(vk_device& device, uint32_
     }
 
     h->queue = device->device.getQueue2(queue_info2);
+    h->device = device;
     q->handle = h;
 
     q->cmd_pool.init(device, q.get());
@@ -6067,6 +6174,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
 #endif
             } else if (strcmp(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME, properties.extensionName) == 0) {
                 internally_sync_support = true;
+            } else if (strcmp("VK_EXT_device_fault", properties.extensionName) == 0) {
+                device->device_fault = true;
             }
         }
 
@@ -6421,7 +6530,17 @@ static vk_device ggml_vk_get_device(size_t idx) {
         }
 #endif
 
+        VkPhysicalDeviceFaultFeaturesEXT fault_features {};
+        fault_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT;
+        if (device->device_fault) {
+            last_struct->pNext = (VkBaseOutStructure *)&fault_features;
+            last_struct = (VkBaseOutStructure *)&fault_features;
+            device_extensions.push_back("VK_EXT_device_fault");
+        }
+
         vkGetPhysicalDeviceFeatures2(device->physical_device, &device_features2);
+
+        device->device_fault = device->device_fault && fault_features.deviceFault;
 
         device->has_internally_synchronized_queues = internally_synchronized_queues_features.internallySynchronizedQueues;
 
@@ -6721,6 +6840,11 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device_create_info.setPNext(&device_features2);
         device->device = device->physical_device.createDevice(device_create_info);
 
+        if (device->device_fault) {
+            device->pfn_vkGetDeviceFaultInfoEXT = (PFN_vkGetDeviceFaultInfoEXT)
+                vkGetDeviceProcAddr(device->device, "vkGetDeviceFaultInfoEXT");
+        }
+
         // Queues
         device->compute_queue = ggml_vk_create_queue(device, compute_queue_family_index, 0, { vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eTransfer }, false);
 
@@ -6842,6 +6966,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->fence = device->device.createFence({});
 
         device->idx = idx;
+
+        device->serialize_submissions = getenv("GGML_VK_SERIALIZE_SUBMISSIONS") != nullptr;
 
         device->disable_fusion = getenv("GGML_VK_DISABLE_FUSION") != nullptr;
 
@@ -8269,7 +8395,7 @@ static void ggml_vk_buffer_write_2d(vk_buffer& dst, size_t offset, const void * 
         }
 
         ggml_vk_submit(subctx, dst->device->fence);
-        VK_CHECK(dst->device->device.waitForFences({ dst->device->fence }, true, UINT64_MAX), "vk_buffer_write_2d waitForFences");
+        VK_CHECK(dst->device->device.waitForFences({ dst->device->fence }, true, UINT64_MAX), "vk_buffer_write_2d waitForFences", dst->device);
         dst->device->device.resetFences({ dst->device->fence });
         ggml_vk_queue_command_pools_cleanup(dst->device);
     }
@@ -8381,7 +8507,7 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
         ggml_vk_ctx_end(subctx);
         ggml_vk_submit(subctx, src->device->fence);
         VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX),
-                 "vk_buffer_read_2d uma waitForFences");
+                 "vk_buffer_read_2d uma waitForFences", src->device);
         src->device->device.resetFences({ src->device->fence });
         ggml_vk_queue_command_pools_cleanup(src->device);
 
@@ -8402,7 +8528,7 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
         ggml_vk_ctx_end(subctx);
 
         ggml_vk_submit(subctx, src->device->fence);
-        VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX), "vk_buffer_read_2d waitForFences");
+        VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX), "vk_buffer_read_2d waitForFences", src->device);
         src->device->device.resetFences({ src->device->fence });
         ggml_vk_queue_command_pools_cleanup(src->device);
 
@@ -8437,7 +8563,7 @@ static void ggml_vk_buffer_copy(vk_buffer& dst, size_t dst_offset, vk_buffer& sr
         ggml_vk_buffer_copy_async(subctx, dst, dst_offset, src, src_offset, size);
         ggml_vk_ctx_end(subctx);
         ggml_vk_submit(subctx, src->device->fence);
-        VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX), "vk_buffer_copy waitForFences");
+        VK_CHECK(src->device->device.waitForFences({ src->device->fence }, true, UINT64_MAX), "vk_buffer_copy waitForFences", src->device);
         src->device->device.resetFences({ src->device->fence });
         ggml_vk_queue_command_pools_cleanup(src->device);
     } else {
@@ -8481,7 +8607,7 @@ static void ggml_vk_buffer_memset(vk_buffer& dst, size_t offset, uint32_t c, siz
     ggml_vk_ctx_end(subctx);
 
     ggml_vk_submit(subctx, dst->device->fence);
-    VK_CHECK(dst->device->device.waitForFences({ dst->device->fence }, true, UINT64_MAX), "vk_memset waitForFences");
+    VK_CHECK(dst->device->device.waitForFences({ dst->device->fence }, true, UINT64_MAX), "vk_memset waitForFences", dst->device);
     dst->device->device.resetFences({ dst->device->fence });
     ggml_vk_queue_command_pools_cleanup(dst->device);
 }
@@ -14129,7 +14255,7 @@ static void ggml_vk_test_matmul(ggml_backend_vk_context * ctx, size_t m, size_t 
 
     auto begin = std::chrono::high_resolution_clock::now();
     ggml_vk_submit(subctx, ctx->fence);
-    VK_CHECK(ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX), "ggml_vk_test_matmul waitForFences");
+    VK_CHECK(ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX), "ggml_vk_test_matmul waitForFences", ctx->device);
     ctx->device->device.resetFences({ ctx->fence });
     ggml_vk_queue_command_pools_cleanup(ctx->device);
 
@@ -14331,7 +14457,7 @@ static void ggml_vk_test_dequant(ggml_backend_vk_context * ctx, size_t ne, ggml_
     auto begin = std::chrono::high_resolution_clock::now();
 
     ggml_vk_submit(subctx, ctx->fence);
-    VK_CHECK(ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX), "ggml_vk_test_dequant waitForFences");
+    VK_CHECK(ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX), "ggml_vk_test_dequant waitForFences", ctx->device);
     ctx->device->device.resetFences({ ctx->fence });
     ggml_vk_queue_command_pools_cleanup(ctx->device);
 
@@ -14617,7 +14743,7 @@ static void ggml_vk_test_dequant_matmul(ggml_backend_vk_context * ctx, size_t m,
     auto begin = std::chrono::high_resolution_clock::now();
 
     ggml_vk_submit(subctx, ctx->fence);
-    VK_CHECK(ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX), "ggml_vk_test_dequant waitForFences");
+    VK_CHECK(ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX), "ggml_vk_test_dequant waitForFences", ctx->device);
     ctx->device->device.resetFences({ ctx->fence });
     ggml_vk_queue_command_pools_cleanup(ctx->device);
 
@@ -15407,7 +15533,9 @@ static void ggml_vk_compute_forward(ggml_backend_vk_context * ctx, ggml_cgraph *
             memset(mset.dst, mset.val, mset.n);
         }
 
-        if (almost_ready && !ctx->almost_ready_fence_pending) {
+        if (ctx->device->serialize_submissions) {
+            ggml_vk_submit(subctx, ctx->fence);
+        } else if (almost_ready && !ctx->almost_ready_fence_pending) {
             ggml_vk_submit(subctx, ctx->almost_ready_fence);
             ctx->almost_ready_fence_pending = true;
         } else {
@@ -16018,12 +16146,30 @@ static void ggml_vk_synchronize(ggml_backend_vk_context * ctx) {
             memcpy(cpy.dst, cpy.src, cpy.n);
         }
 
-        ggml_vk_submit(compute_ctx, {});
+        if (ctx->device->serialize_submissions) {
+            try {
+                ggml_vk_submit(compute_ctx, ctx->fence);
+                auto res = ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX);
+                if (res != vk::Result::eSuccess) {
+                    fprintf(stderr, "ggml_vulkan: waitForFences error in synchronize\n");
+                    exit(1);
+                }
+            } catch (vk::DeviceLostError &) {
+                ggml_vk_print_device_fault_info(ctx->device);
+                fprintf(stderr, "ggml_vulkan: device lost during synchronize submission\n");
+                throw;
+            }
+            ctx->device->device.resetFences({ ctx->fence });
+        } else {
+            ggml_vk_submit(compute_ctx, {});
+        }
         ctx->submit_pending = true;
     }
 
     if (ctx->submit_pending) {
-        if (ctx->device->async_use_transfer_queue && ctx->transfer_semaphore_last_submitted < ctx->transfer_semaphore.value) {
+        if (ctx->device->serialize_submissions) {
+            ctx->submit_pending = false;
+        } else if (ctx->device->async_use_transfer_queue && ctx->transfer_semaphore_last_submitted < ctx->transfer_semaphore.value) {
             vk::TimelineSemaphoreSubmitInfo tl_info{
                 1, &ctx->transfer_semaphore.value,
                 0, nullptr,
@@ -16040,7 +16186,9 @@ static void ggml_vk_synchronize(ggml_backend_vk_context * ctx) {
         } else {
             ctx->device->compute_queue->handle->submit({}, ctx->fence);
         }
-        ggml_vk_wait_for_fence(ctx);
+        if (!ctx->device->serialize_submissions) {
+            ggml_vk_wait_for_fence(ctx);
+        }
         ctx->submit_pending = false;
         if (cmd_buf) {
             cmd_buf->in_use = false;
@@ -16621,6 +16769,8 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
 
     bool first_node_in_batch = true; // true if next node will be first node in a batch
     int submit_node_idx = 0; // index to first node in a batch
+    int prev_submit_start = -1;
+    int prev_submit_end = -1;
 
     ggml_vk_submit_transfer_ctx(ctx);
 
@@ -16912,7 +17062,18 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
                       (i + ctx->num_additional_fused_ops >= last_node) ||
                       (almost_ready && !ctx->almost_ready_fence_pending);
 
-        bool enqueued = ggml_vk_build_graph(ctx, cgraph, i, cgraph->nodes[submit_node_idx], submit_node_idx, i + ctx->num_additional_fused_ops >= last_node, almost_ready, submit);
+        bool enqueued;
+        try {
+            enqueued = ggml_vk_build_graph(ctx, cgraph, i, cgraph->nodes[submit_node_idx], submit_node_idx, i + ctx->num_additional_fused_ops >= last_node, almost_ready, submit);
+        } catch (vk::DeviceLostError &) {
+            ggml_vk_print_device_fault_info(ctx->device);
+            if (ctx->device->serialize_submissions && prev_submit_start >= 0) {
+                fprintf(stderr, "ggml_vulkan: device lost, likely caused by previous submission (nodes %d to %d):\n",
+                        prev_submit_start, prev_submit_end);
+                ggml_vk_print_node_list(cgraph, prev_submit_start, prev_submit_end);
+            }
+            throw;
+        }
 
         if (vk_perf_logger_enabled && enqueued) {
             compute_ctx = ggml_vk_get_compute_ctx(ctx);
@@ -16940,6 +17101,27 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         }
 
         if (submit && enqueued) {
+            if (ctx->device->serialize_submissions) {
+                int end_node = i + (int)ctx->num_additional_fused_ops;
+                try {
+                    auto res = ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX);
+                    if (res != vk::Result::eSuccess) {
+                        fprintf(stderr, "ggml_vulkan: waitForFences error during serialized submission\n");
+                        exit(1);
+                    }
+                } catch (vk::DeviceLostError &) {
+                    ggml_vk_print_device_fault_info(ctx->device);
+                    fprintf(stderr, "ggml_vulkan: device lost waiting for submission (nodes %d to %d):\n",
+                            submit_node_idx, end_node);
+                    ggml_vk_print_node_list(cgraph, submit_node_idx, end_node);
+                    throw;
+                }
+                ctx->device->device.resetFences({ ctx->fence });
+                ctx->submit_pending = false;
+                prev_submit_start = submit_node_idx;
+                prev_submit_end = end_node;
+            }
+
             first_node_in_batch = true;
             submitted_nodes = 0;
             batch_flops = 0;
@@ -16962,13 +17144,13 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         ggml_vk_ctx_end(compute_ctx);
 
         ggml_vk_submit(compute_ctx, ctx->device->fence);
-        VK_CHECK(ctx->device->device.waitForFences({ ctx->device->fence }, true, UINT64_MAX), "GGML_VULKAN_PERF waitForFences");
+        VK_CHECK(ctx->device->device.waitForFences({ ctx->device->fence }, true, UINT64_MAX), "GGML_VULKAN_PERF waitForFences", ctx->device);
         ctx->device->device.resetFences({ ctx->device->fence });
         ctx->compute_ctx.reset();
 
         // Get the results and pass them to the logger
         std::vector<uint64_t> timestamps(cgraph->n_nodes + 1);
-        VK_CHECK(ctx->device->device.getQueryPoolResults(ctx->query_pool, 0, ctx->query_idx, (cgraph->n_nodes + 1)*sizeof(uint64_t), timestamps.data(), sizeof(uint64_t), vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait), "get timestamp results");
+        VK_CHECK(ctx->device->device.getQueryPoolResults(ctx->query_pool, 0, ctx->query_idx, (cgraph->n_nodes + 1)*sizeof(uint64_t), timestamps.data(), sizeof(uint64_t), vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait), "get timestamp results", ctx->device);
         if (!vk_perf_logger_concurrent) {
             // Log each op separately
             for (int i = 1; i < ctx->query_idx; i++) {
@@ -18186,7 +18368,7 @@ static void ggml_backend_vk_device_event_synchronize(ggml_backend_dev_t dev, ggm
         vk::Semaphore sem = vkev->tl_semaphore.s;
         uint64_t val = vkev->tl_semaphore.value;
         vk::SemaphoreWaitInfo swi{vk::SemaphoreWaitFlags{}, sem, val};
-        VK_CHECK(device->device.waitSemaphores(swi, UINT64_MAX), "event_synchronize");
+        VK_CHECK(device->device.waitSemaphores(swi, UINT64_MAX), "event_synchronize", device);
 
         // Reset and move submitted events
         for (auto& event : vkev->events_submitted) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -317,7 +317,7 @@ static void ggml_vk_print_device_lost_info(const vk_device& device);
 // Prevent simultaneous submissions to the same queue.
 struct vk_queue_handle {
     vk::Queue queue;
-    vk_device device;
+    vk_device_ref device;
     virtual void submit(vk::ArrayProxy<const vk::SubmitInfo> submits, vk::Fence fence) = 0;
     virtual void lock()   {}   // no-op by default (internally synchronized case)
     virtual void unlock() {}
@@ -331,7 +331,9 @@ struct vk_queue_handle_synchronized : vk_queue_handle {
         try {
             queue.submit(submits, fence);
         } catch (vk::DeviceLostError &) {
-            ggml_vk_print_device_lost_info(device);
+            if (auto dev = device.lock()) {
+                ggml_vk_print_device_lost_info(dev);
+            }
             throw;
         }
     }
@@ -345,7 +347,9 @@ struct vk_queue_handle_unsynchronized : vk_queue_handle {
         try {
             queue.submit(submits, fence);
         } catch (vk::DeviceLostError &) {
-            ggml_vk_print_device_lost_info(device);
+            if (auto dev = device.lock()) {
+                ggml_vk_print_device_lost_info(dev);
+            }
             throw;
         }
     }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -193,14 +193,15 @@ static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
             err_ = (err);                                           \
         } catch (vk::DeviceLostError &) {                           \
             ggml_vk_print_device_lost_info(dev);                    \
-            fprintf(stderr, "ggml_vulkan: %s at %s:%d\n",           \
+            GGML_LOG_ERROR("ggml_vulkan: %s at %s:%d\n",            \
                 #err, __FILE__, __LINE__);                          \
-            exit(1);                                                \
+            throw;                                                  \
         }                                                           \
         if (err_ != vk::Result::eSuccess) {                         \
-            fprintf(stderr, "ggml_vulkan: %s error %s at %s:%d\n",  \
+            GGML_LOG_ERROR("ggml_vulkan: %s error %s at %s:%d\n",   \
                 #err, to_string(err_).c_str(), __FILE__, __LINE__); \
-            exit(1);                                                \
+            throw vk::SystemError(vk::make_error_code(err_),        \
+                "ggml_vulkan: " msg);                               \
         }                                                           \
     } while (0)
 
@@ -1132,7 +1133,7 @@ static void ggml_vk_print_device_fault_info(const vk_device& device) {
     fault_counts.sType = VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT;
     VkResult res = device->pfn_vkGetDeviceFaultInfoEXT(device->device, &fault_counts, nullptr);
     if (res != VK_SUCCESS) {
-        fprintf(stderr, "ggml_vulkan: vkGetDeviceFaultInfoEXT (counts) failed: %d\n", res);
+        GGML_LOG_ERROR("ggml_vulkan: vkGetDeviceFaultInfoEXT (counts) failed: %d\n", res);
         return;
     }
 
@@ -1146,7 +1147,7 @@ static void ggml_vk_print_device_fault_info(const vk_device& device) {
 
     res = device->pfn_vkGetDeviceFaultInfoEXT(device->device, &fault_counts, &fault_info);
     if (res != VK_SUCCESS) {
-        fprintf(stderr, "ggml_vulkan: vkGetDeviceFaultInfoEXT (info) failed: %d\n", res);
+        GGML_LOG_ERROR("ggml_vulkan: vkGetDeviceFaultInfoEXT (info) failed: %d\n", res);
         return;
     }
 
@@ -1155,19 +1156,19 @@ static void ggml_vk_print_device_fault_info(const vk_device& device) {
     }
 
     if (fault_info.description[0] != '\0') {
-        fprintf(stderr, "ggml_vulkan: device fault on %s: %s\n", device->name.c_str(), fault_info.description);
+        GGML_LOG_ERROR("ggml_vulkan: device fault on %s: %s\n", device->name.c_str(), fault_info.description);
     }
 
     for (uint32_t i = 0; i < fault_counts.addressInfoCount; i++) {
         const auto& info = address_infos[i];
-        fprintf(stderr, "  address fault %u: type=%d address=0x%llx precision=0x%llx\n",
+        GGML_LOG_CONT("  address fault %u: type=%d address=0x%llx precision=0x%llx\n",
                 i, (int)info.addressType,
                 (unsigned long long)info.reportedAddress,
                 (unsigned long long)info.addressPrecision);
     }
     for (uint32_t i = 0; i < fault_counts.vendorInfoCount; i++) {
         const auto& info = vendor_infos[i];
-        fprintf(stderr, "  vendor fault %u: %s (code=0x%llx data=0x%llx)\n",
+        GGML_LOG_CONT("  vendor fault %u: %s (code=0x%llx data=0x%llx)\n",
                 i, info.description,
                 (unsigned long long)info.vendorFaultCode,
                 (unsigned long long)info.vendorFaultData);
@@ -2104,25 +2105,25 @@ static void ggml_vk_print_node_list(const ggml_cgraph * cgraph, int start, int e
         total_flops += flops;
         n_ops++;
         if (flops > 0) {
-            fprintf(stderr, "  node %d: %s (%s) [%.2f GFLOP]\n",
+            GGML_LOG_CONT("  node %d: %s (%s) [%.2f GFLOP]\n",
                     j, cgraph->nodes[j]->name, ggml_op_name(cgraph->nodes[j]->op),
                     flops / 1e9);
         } else {
-            fprintf(stderr, "  node %d: %s (%s)\n",
+            GGML_LOG_CONT("  node %d: %s (%s)\n",
                     j, cgraph->nodes[j]->name, ggml_op_name(cgraph->nodes[j]->op));
         }
     }
-    fprintf(stderr, "  total: %d ops, %.2f GFLOP\n", n_ops, total_flops / 1e9);
+    GGML_LOG_CONT("  total: %d ops, %.2f GFLOP\n", n_ops, total_flops / 1e9);
 }
 
 static void ggml_vk_print_device_lost_info(const vk_device& device) {
     ggml_vk_print_device_fault_info(device);
     if (device->serialize_submissions && device->diag_cgraph != nullptr && device->diag_prev_start >= 0) {
-        fprintf(stderr, "ggml_vulkan: device lost on %s, likely caused by previous submission (nodes %d to %d):\n",
+        GGML_LOG_ERROR("ggml_vulkan: device lost on %s, likely caused by previous submission (nodes %d to %d):\n",
                 device->name.c_str(), device->diag_prev_start, device->diag_prev_end);
         ggml_vk_print_node_list(device->diag_cgraph, device->diag_prev_start, device->diag_prev_end);
     } else {
-        fprintf(stderr, "ggml_vulkan: device lost on %s\n", device->name.c_str());
+        GGML_LOG_ERROR("ggml_vulkan: device lost on %s\n", device->name.c_str());
     }
 }
 
@@ -2550,15 +2551,15 @@ static void ggml_vk_wait_for_fence(ggml_backend_vk_context * ctx) {
             result = ctx->device->device.getFenceStatus(ctx->fence);
         } catch (vk::DeviceLostError &) {
             ggml_vk_print_device_lost_info(ctx->device);
-            fprintf(stderr, "ggml_vulkan: getFenceStatus at %s:%d\n", __FILE__, __LINE__);
-            exit(1);
+            GGML_LOG_ERROR("ggml_vulkan: getFenceStatus at %s:%d\n", __FILE__, __LINE__);
+            throw;
         }
         if (result == vk::Result::eSuccess) {
             break;
         }
         if (result != vk::Result::eNotReady) {
-            fprintf(stderr, "ggml_vulkan: error %s at %s:%d\n", to_string(result).c_str(), __FILE__, __LINE__);
-            exit(1);
+            GGML_LOG_ERROR("ggml_vulkan: error %s at %s:%d\n", to_string(result).c_str(), __FILE__, __LINE__);
+            throw vk::SystemError(vk::make_error_code(result), "ggml_vulkan: getFenceStatus");
         }
         for (uint32_t i = 0; i < 100; ++i) {
             YIELD();
@@ -16850,12 +16851,12 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
             try {
                 auto res = ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX);
                 if (res != vk::Result::eSuccess) {
-                    fprintf(stderr, "ggml_vulkan: waitForFences error during serialized submission\n");
-                    exit(1);
+                    GGML_LOG_ERROR("ggml_vulkan: waitForFences error during serialized submission\n");
+                    throw vk::SystemError(vk::make_error_code(res), "ggml_vulkan: waitForFences during serialized submission");
                 }
             } catch (vk::DeviceLostError &) {
                 ggml_vk_print_device_fault_info(ctx->device);
-                fprintf(stderr, "ggml_vulkan: device lost on %s waiting for submission (nodes %d to %d):\n",
+                GGML_LOG_ERROR("ggml_vulkan: device lost on %s waiting for submission (nodes %d to %d):\n",
                         ctx->device->name.c_str(), start, end);
                 ggml_vk_print_node_list(cgraph, start, end);
                 throw;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -192,8 +192,8 @@ static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
         try {                                                       \
             err_ = (err);                                           \
         } catch (vk::DeviceLostError &) {                           \
-            ggml_vk_print_device_fault_info(dev);                   \
-            fprintf(stderr, "ggml_vulkan: %s error VK_ERROR_DEVICE_LOST at %s:%d\n", \
+            ggml_vk_print_device_lost_info(dev);                    \
+            fprintf(stderr, "ggml_vulkan: %s at %s:%d\n",           \
                 #err, __FILE__, __LINE__);                          \
             exit(1);                                                \
         }                                                           \
@@ -311,6 +311,7 @@ struct vk_command_pool {
 };
 
 static void ggml_vk_print_device_fault_info(const vk_device& device);
+static void ggml_vk_print_device_lost_info(const vk_device& device);
 
 // Prevent simultaneous submissions to the same queue.
 struct vk_queue_handle {
@@ -329,7 +330,7 @@ struct vk_queue_handle_synchronized : vk_queue_handle {
         try {
             queue.submit(submits, fence);
         } catch (vk::DeviceLostError &) {
-            ggml_vk_print_device_fault_info(device);
+            ggml_vk_print_device_lost_info(device);
             throw;
         }
     }
@@ -343,7 +344,7 @@ struct vk_queue_handle_unsynchronized : vk_queue_handle {
         try {
             queue.submit(submits, fence);
         } catch (vk::DeviceLostError &) {
-            ggml_vk_print_device_fault_info(device);
+            ggml_vk_print_device_lost_info(device);
             throw;
         }
     }
@@ -836,6 +837,10 @@ struct vk_device_struct {
     PFN_vkGetDeviceFaultInfoEXT pfn_vkGetDeviceFaultInfoEXT {};
 
     bool serialize_submissions {};
+
+    const ggml_cgraph * diag_cgraph {};
+    int diag_prev_start = -1;
+    int diag_prev_end = -1;
 
     size_t idx;
 
@@ -2110,6 +2115,17 @@ static void ggml_vk_print_node_list(const ggml_cgraph * cgraph, int start, int e
     fprintf(stderr, "  total: %d ops, %.2f GFLOP\n", n_ops, total_flops / 1e9);
 }
 
+static void ggml_vk_print_device_lost_info(const vk_device& device) {
+    ggml_vk_print_device_fault_info(device);
+    if (device->serialize_submissions && device->diag_cgraph != nullptr && device->diag_prev_start >= 0) {
+        fprintf(stderr, "ggml_vulkan: device lost on %s, likely caused by previous submission (nodes %d to %d):\n",
+                device->name.c_str(), device->diag_prev_start, device->diag_prev_end);
+        ggml_vk_print_node_list(device->diag_cgraph, device->diag_prev_start, device->diag_prev_end);
+    } else {
+        fprintf(stderr, "ggml_vulkan: device lost on %s\n", device->name.c_str());
+    }
+}
+
 class vk_perf_logger {
   public:
     void print_timings(bool force = false) {
@@ -2533,8 +2549,8 @@ static void ggml_vk_wait_for_fence(ggml_backend_vk_context * ctx) {
         try {
             result = ctx->device->device.getFenceStatus(ctx->fence);
         } catch (vk::DeviceLostError &) {
-            ggml_vk_print_device_fault_info(ctx->device);
-            fprintf(stderr, "ggml_vulkan: getFenceStatus VK_ERROR_DEVICE_LOST at %s:%d\n", __FILE__, __LINE__);
+            ggml_vk_print_device_lost_info(ctx->device);
+            fprintf(stderr, "ggml_vulkan: getFenceStatus at %s:%d\n", __FILE__, __LINE__);
             exit(1);
         }
         if (result == vk::Result::eSuccess) {
@@ -16147,18 +16163,8 @@ static void ggml_vk_synchronize(ggml_backend_vk_context * ctx) {
         }
 
         if (ctx->device->serialize_submissions) {
-            try {
-                ggml_vk_submit(compute_ctx, ctx->fence);
-                auto res = ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX);
-                if (res != vk::Result::eSuccess) {
-                    fprintf(stderr, "ggml_vulkan: waitForFences error in synchronize\n");
-                    exit(1);
-                }
-            } catch (vk::DeviceLostError &) {
-                ggml_vk_print_device_fault_info(ctx->device);
-                fprintf(stderr, "ggml_vulkan: device lost during synchronize submission\n");
-                throw;
-            }
+            ggml_vk_submit(compute_ctx, ctx->fence);
+            VK_CHECK(ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX), "synchronize waitForFences", ctx->device);
             ctx->device->device.resetFences({ ctx->fence });
         } else {
             ggml_vk_submit(compute_ctx, {});
@@ -16744,6 +16750,10 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
     VK_LOG_DEBUG("ggml_backend_vk_graph_compute(" << cgraph->n_nodes << " nodes)");
     ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
 
+    ctx->device->diag_cgraph = nullptr;
+    ctx->device->diag_prev_start = -1;
+    ctx->device->diag_prev_end = -1;
+
     if (vk_instance.debug_utils_support) {
         vk::DebugUtilsLabelEXT dul = {};
         dul.pLabelName = "ggml_backend_vk_graph_compute";
@@ -16769,8 +16779,6 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
 
     bool first_node_in_batch = true; // true if next node will be first node in a batch
     int submit_node_idx = 0; // index to first node in a batch
-    int prev_submit_start = -1;
-    int prev_submit_end = -1;
 
     ggml_vk_submit_transfer_ctx(ctx);
 
@@ -16837,6 +16845,36 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
     }
     uint64_t flops_per_submit = std::min(flops_cap, ctx->last_total_flops / 40u);
 
+    auto const submit_after = [&](int start, int end) {
+        if (ctx->device->serialize_submissions) {
+            try {
+                auto res = ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX);
+                if (res != vk::Result::eSuccess) {
+                    fprintf(stderr, "ggml_vulkan: waitForFences error during serialized submission\n");
+                    exit(1);
+                }
+            } catch (vk::DeviceLostError &) {
+                ggml_vk_print_device_fault_info(ctx->device);
+                fprintf(stderr, "ggml_vulkan: device lost on %s waiting for submission (nodes %d to %d):\n",
+                        ctx->device->name.c_str(), start, end);
+                ggml_vk_print_node_list(cgraph, start, end);
+                throw;
+            }
+            ctx->device->device.resetFences({ ctx->fence });
+            ctx->submit_pending = false;
+            ctx->device->diag_cgraph = cgraph;
+            ctx->device->diag_prev_start = start;
+            ctx->device->diag_prev_end = end;
+        }
+        first_node_in_batch = true;
+        submitted_nodes = 0;
+        batch_flops = 0;
+        if (submit_count < 3) {
+            flops_per_submit *= 2;
+        }
+        submit_count++;
+    };
+
     for (int i = 0; i < cgraph->n_nodes; i++) {
         if (first_node_in_batch) {
             submit_node_idx = i;
@@ -16844,8 +16882,20 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
 
         {
             auto node_flops = ggml_vk_get_node_flops(cgraph->nodes[i]);
-            batch_flops += node_flops;
             total_flops += node_flops;
+
+            // Flush the current batch before recording a node that would push it over the flop threshold
+            if (flops_per_submit != 0 && submitted_nodes > 0 && batch_flops + node_flops >= flops_per_submit) {
+                vk_context flush_ctx = ggml_vk_get_compute_ctx(ctx);
+                ggml_vk_ctx_end(flush_ctx);
+                flush_ctx->exit_tensor_idx = -1;
+                ctx->compute_ctx.reset();
+                ggml_vk_compute_forward(ctx, cgraph, cgraph->nodes[submit_node_idx], submit_node_idx, false);
+                submit_after(submit_node_idx, i - 1);
+                submit_node_idx = i;
+            }
+
+            batch_flops += node_flops;
         }
 
         // op_srcs_fused_elementwise indicates whether an op's srcs all contribute to
@@ -17062,18 +17112,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
                       (i + ctx->num_additional_fused_ops >= last_node) ||
                       (almost_ready && !ctx->almost_ready_fence_pending);
 
-        bool enqueued;
-        try {
-            enqueued = ggml_vk_build_graph(ctx, cgraph, i, cgraph->nodes[submit_node_idx], submit_node_idx, i + ctx->num_additional_fused_ops >= last_node, almost_ready, submit);
-        } catch (vk::DeviceLostError &) {
-            ggml_vk_print_device_fault_info(ctx->device);
-            if (ctx->device->serialize_submissions && prev_submit_start >= 0) {
-                fprintf(stderr, "ggml_vulkan: device lost, likely caused by previous submission (nodes %d to %d):\n",
-                        prev_submit_start, prev_submit_end);
-                ggml_vk_print_node_list(cgraph, prev_submit_start, prev_submit_end);
-            }
-            throw;
-        }
+        bool enqueued = ggml_vk_build_graph(ctx, cgraph, i, cgraph->nodes[submit_node_idx], submit_node_idx, i + ctx->num_additional_fused_ops >= last_node, almost_ready, submit);
 
         if (vk_perf_logger_enabled && enqueued) {
             compute_ctx = ggml_vk_get_compute_ctx(ctx);
@@ -17101,34 +17140,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         }
 
         if (submit && enqueued) {
-            if (ctx->device->serialize_submissions) {
-                int end_node = i + (int)ctx->num_additional_fused_ops;
-                try {
-                    auto res = ctx->device->device.waitForFences({ ctx->fence }, true, UINT64_MAX);
-                    if (res != vk::Result::eSuccess) {
-                        fprintf(stderr, "ggml_vulkan: waitForFences error during serialized submission\n");
-                        exit(1);
-                    }
-                } catch (vk::DeviceLostError &) {
-                    ggml_vk_print_device_fault_info(ctx->device);
-                    fprintf(stderr, "ggml_vulkan: device lost waiting for submission (nodes %d to %d):\n",
-                            submit_node_idx, end_node);
-                    ggml_vk_print_node_list(cgraph, submit_node_idx, end_node);
-                    throw;
-                }
-                ctx->device->device.resetFences({ ctx->fence });
-                ctx->submit_pending = false;
-                prev_submit_start = submit_node_idx;
-                prev_submit_end = end_node;
-            }
-
-            first_node_in_batch = true;
-            submitted_nodes = 0;
-            batch_flops = 0;
-            if (submit_count < 3) {
-                flops_per_submit *= 2;
-            }
-            submit_count++;
+            submit_after(submit_node_idx, i + (int)ctx->num_additional_fused_ops);
         }
         i += ctx->num_additional_fused_ops;
         ctx->num_additional_fused_ops = 0;


### PR DESCRIPTION
## Overview

We get a lot of DeviceLost error reports, especially from AMD users on Linux. Most of these are a driver submission timeout. It is currently not easy to figure out what tensor or tensors timed out, to improve that I added two things in this PR:
- Support for `VK_EXT_device_fault` extension to get more information about an error from the driver. Sadly this does not provide any information about the timeouts, but it may still be useful for other issues.
- A new `GGML_VK_SERIALIZE_SUBMISSIONS` env var that submits all submission sequentially and stores what tensors were last submitted. If the driver then throws a DeviceLost error, it reports what was submitted. That way you can see if too much was submitted at once, or if a specific operator is running too slow.

This already showed an issue with submission batching, currently it only stops a batch once it has exceeded the flops threshold, not before a tensor would push it over the limit. I patched this as well to make submissions smaller where necessary, as was intended. Possibly this already reduces the amount of driver timeouts.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used for writing the code, I manually reviewed and tested.