### PR TITLE
opencl: limit local workgroup size for GLU operation

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -24259,7 +24259,7 @@ static void ggml_cl_glu(ggml_backend_t backend, const ggml_tensor * src0, const 
     }
 
     const size_t nrows = ggml_nrows(src0);
-    size_t nth = 512;
+    size_t nth = backend_ctx->max_workgroup_size < 512 ? backend_ctx->max_workgroup_size : 512;
     size_t global_work_size[] = {nrows*nth, 1, 1};
     size_t local_work_size[] = {nth, 1, 1};
 


### PR DESCRIPTION
## Overview

This is something I bumped into when trying to benchmark a legacy Intel UHD 620 GPU: this model has a `max_workgroup_size` of 256, so `enqueue_ndrange_kernel` fails in a GLU operation with `CL_INVALID_WORK_GROUP_SIZE`.

I am not fully sure I understand the interaction between local and global workgroup size and the rationale behind the choice of 512 for `nth`, so I am just putting this fix up for discussion, as it was the main obstacle for running on this GPU, and it might also affect other architectures.

## Additional information

For full Intel UHD 620 compatibility, it is also necessary to comment out the `mul_mv_f16_f32_l4` kernel, probably due to an LLVM or library bug in the OpenCL driver, but this is a separate issue.

On my i7-8550U laptop, the UHD 620 with OpenCL 2.1 actually achieves *lower* throughput than the CPU backend at the moment, so this fix is mostly of historic interest.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO