### PR TITLE
common/jinja: guard zero divisor and INT64_MIN%-1 in divisibleby test

### DIFF
--- a/common/jinja/value.cpp
+++ b/common/jinja/value.cpp
@@ -444,7 +444,13 @@ const func_builtins & global_builtins() {
         }},
         {"test_is_divisibleby", [](const func_args & args) -> value {
             args.ensure_vals<value_int, value_int>();
-            bool res = args.get_pos(0)->val_int % args.get_pos(1)->val_int == 0;
+            const int64_t num = args.get_pos(0)->val_int;
+            const int64_t den = args.get_pos(1)->val_int;
+            // guard both x86 idiv traps: divisor 0 and INT64_MIN / -1 overflow
+            if (den == 0 || (den == -1 && num == INT64_MIN)) {
+                return mk_val<value_bool>(false);
+            }
+            bool res = num % den == 0;
             return mk_val<value_bool>(res);
         }},
         {"test_is_string", test_type_fn<value_string>},


### PR DESCRIPTION
### Problem

`test_is_divisibleby` (`common/jinja/value.cpp`) evaluates `val_int % val_int` with no divisor validation:

```cpp
bool res = args.get_pos(0)->val_int % args.get_pos(1)->val_int == 0;
```

A chat template containing a literal zero divisor traps in `idiv` and kills the process with SIGFPE at template-application time. Chat templates are model-file data (GGUF `tokenizer.chat_template` KV), so a single model carrying this template crashes any deployment that loads it and starts a chat — pre-inference, no user text required.

Reproducer (official tool, pristine master):

```bash
printf '{{ 2 is divisibleby(0) }}' > bomb.jinja
./build/bin/llama-debug-template-parser bomb.jinja
# UBSan: common/jinja/value.cpp:447: runtime error: division by zero
# AddressSanitizer: FPE  (in jinja::global_builtins()::$_8 via test_expression::execute_impl)
```

The same site is reachable through the second x86 idiv trap: `INT64_MIN % -1` (quotient overflow).

Infix `/` and `%` are evaluated in `double` precision (`runtime.cpp:193-203`, IEEE-defined inf/NaN), so this integer modulo is the only unguarded division in the engine.

### Fix

Guard both idiv traps and return `false` (test-predicate semantics):

```cpp
const int64_t num = args.get_pos(0)->val_int;
const int64_t den = args.get_pos(1)->val_int;
// guard both x86 idiv traps: divisor 0 and INT64_MIN / -1 overflow
if (den == 0 || (den == -1 && num == INT64_MIN)) {
    return mk_val<value_bool>(false);
}
```

### Verification (master @ 876a432, ASAN+UBSAN)

| Input | Before | After |
|---|---|---|
| `{{ 2 is divisibleby(0) }}` | UBSAN div-by-zero + ASAN FPE | renders clean (`false`) |
| `{{ 2 is divisibleby(4) }}` (control) | clean | clean |
| `{{ (-9223372036854775807 - 1) is divisibleby(-1) }}` | idiv overflow trap | renders clean |
