### PR TITLE
common/jinja: add recursion depth guards to parser and macro calls

### DIFF
--- a/common/jinja/parser.cpp
+++ b/common/jinja/parser.cpp
@@ -18,11 +18,29 @@ static bool is_type(const statement_ptr & ptr) {
     return dynamic_cast<const T*>(ptr.get()) != nullptr;
 }
 
+namespace {
+// RAII counter for recursion-depth guards: increments on entry, decrements on
+// ANY exit path (parse_any has many early returns); throws past the cap.
+struct depth_guard {
+    int & depth;
+    depth_guard(int & d, int max, const char * msg, const std::string & src, size_t pos) : depth(d) {
+        if (++depth > max) {
+            throw parser_exception(msg, src, pos);
+        }
+    }
+    ~depth_guard() { --depth; }
+};
+} // namespace
+
 class parser {
     const std::vector<token> & tokens;
     size_t current = 0;
 
     std::string source; // for error reporting
+
+    static constexpr int MAX_PARSE_DEPTH = 256; // guard vs stack exhaustion on adversarial nesting
+    int expr_depth = 0;
+    int stmt_depth = 0;
 
 public:
     parser(const std::vector<token> & t, const std::string & src) : tokens(t), source(src) {}
@@ -94,6 +112,7 @@ private:
     }
 
     statement_ptr parse_any() {
+        depth_guard guard(stmt_depth, MAX_PARSE_DEPTH, "block nesting too deep", source, current);
         size_t start_pos = current;
         switch (peek().t) {
             case token::comment:
@@ -326,6 +345,7 @@ private:
 
     statement_ptr parse_expression() {
         // Choose parse function with lowest precedence
+        depth_guard guard(expr_depth, MAX_PARSE_DEPTH, "expression nesting too deep", source, current);
         return parse_if_expression();
     }
 

--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -738,8 +738,12 @@ value macro_statement::execute_impl(context & ctx) {
     }
     std::string name = cast_stmt<identifier>(this->name)->val;
 
+    static constexpr int MAX_CALL_DEPTH = 256; // guard vs stack exhaustion from recursive macros
     const func_handler func = [this, name](const func_args & args) -> value {
         context macro_ctx(args.ctx); // new scope for macro execution
+        if (++macro_ctx.call_depth > MAX_CALL_DEPTH) {
+            throw std::runtime_error("macro call depth limit exceeded (recursive macro?)");
+        }
 
         bind_parameters(name, this->args, args, macro_ctx);
 

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -74,6 +74,7 @@ struct context {
     }
     ~context() = default;
 
+    int call_depth = 0; // macro/caller recursion guard (propagated through scope copies)
     context(const context & parent) : context() {
         // inherit variables (for example, when entering a new scope)
         auto & pvar = parent.env->as_ordered_object();
@@ -83,6 +84,7 @@ struct context {
         current_time = parent.current_time;
         is_get_stats = parent.is_get_stats;
         src = parent.src;
+        call_depth = parent.call_depth;
     }
 
     value get_val(const std::string & name) {


### PR DESCRIPTION
### Problem

The new jinja engine (`common/jinja`, PR #18462) implements expression parsing and macro execution as unbounded recursion with **no depth limit anywhere**. A chat template is model-file data (GGUF `tokenizer.chat_template` KV), so a single malicious model crashes any process that applies its chat template:

1. **Parser** — nested `(` recurses `parse_expression → … → parse_primary_expression → parse_expression` with no counter; block-level `{% if %}/{% for %}/{% macro %}` nesting recurses `parse_any`, also unguarded.
2. **Runtime** — macro invocation re-enters `exec_statements` through a fresh `context` with no call-depth counter; a self-calling macro recurses until thread stack exhaustion (ASAN `stack-overflow`).

Reproducers (official tool, pristine master):

```bash
# runtime vector
printf '{%% macro x() %%}{{ x() }}{%% endmacro %%}{{ x() }}' > macro.jinja
./build/bin/llama-debug-template-parser macro.jinja   # ASAN stack-overflow

# parser vector: {% macro foo(n) %}{% if n > 5 %} followed by ~150 ')'
# characters, then {{ foo(n - 0) }}{% endif %}{% endmacro %}{{ foo(8) }}
# → ASAN stack-overflow
```

(Related: #19085 proposes a recursion limit for the same class; this patch covers both the parser and runtime axes with per-layer counters.)

### Fix

256-level guard at each layer:

- **Parser** (`parser.cpp`): RAII `depth_guard` in `parse_any()` and `parse_expression()` throwing `parser_exception` past 256. RAII because `parse_any` has many early returns — and because flat templates with many *top-level* statements must not accumulate depth (the counter decrements on every exit path).
- **Runtime** (`runtime.h/cpp`): `call_depth` field on `context`, propagated through scope copies, incremented and checked at macro invocation; over-limit throws `std::runtime_error("macro call depth limit exceeded")`.

Over-limit input now raises a clean, catchable error instead of crashing the process.

### Verification (master @ 876a432, ASAN+UBSAN)

| Input | Before | After |
|---|---|---|
| nested-parens parse bomb | ASAN stack-overflow | `parser: expression nesting too deep` (rc=1) |
| self-calling macro | ASAN stack-overflow | `macro call depth limit exceeded` (rc=1) |
| `test-jinja` suite | — | **319 tests / 1435 assertions, 0 failures** |
| `test-chat-template` suite | — | **all passed** |
