### PR TITLE
ggml-cuda: enable CUB via hipCUB on HIP for device-wide primitives

### DIFF
--- a/ggml/src/ggml-cuda/argsort.cu
+++ b/ggml/src/ggml-cuda/argsort.cu
@@ -1,12 +1,19 @@
 #include "argsort.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
-#    include <cub/cub.cuh>
+#    ifdef GGML_HIP_USE_HIPCUB
+#    include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#    else
+#        include <cub/cub.cuh>
+#    endif  // GGML_HIP_USE_HIPCUB
 #    if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 1)
 #        define STRIDED_ITERATOR_AVAILABLE
 #        include <cuda/iterator>
 #    endif
-using namespace cub;
+using cub::DeviceRadixSort;
+using cub::DeviceSegmentedRadixSort;
+using cub::DeviceSegmentedSort;
 #endif  // GGML_CUDA_USE_CUB
 
 static __global__ void init_indices(int * indices, const int ncols, const int nrows) {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -109,6 +109,13 @@
 
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
 #    define GGML_CUDA_USE_CUB
+#elif defined(GGML_USE_HIP) && !defined(GGML_HIP_NO_HIPCUB) && __has_include(<hipcub/hipcub.hpp>)
+// hipCUB provides a CUB-compatible interface over rocPRIM (hipcub:: namespace).
+// Without it, argsort/top_k on rows > 1024 fall back to the CPU backend — for DSA
+// models (DeepSeek-V4) that puts the per-token indexer top_k on the CPU, with cost
+// growing with context depth.
+#    define GGML_CUDA_USE_CUB
+#    define GGML_HIP_USE_HIPCUB
 #endif  // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
 
 // PDL host-side support (cudaLaunchKernelEx) requires CUDART >= 11.8.

--- a/ggml/src/ggml-cuda/cumsum.cu
+++ b/ggml/src/ggml-cuda/cumsum.cu
@@ -5,7 +5,12 @@
 #include "ggml.h"
 
 #ifdef GGML_CUDA_USE_CUB
-#   include <cub/cub.cuh>
+#    ifdef GGML_HIP_USE_HIPCUB
+#    include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#    else
+#        include <cub/cub.cuh>
+#    endif  // GGML_HIP_USE_HIPCUB
 #endif // GGML_CUDA_USE_CUB
 
 template<typename T, int BLOCK_SIZE>

--- a/ggml/src/ggml-cuda/mean.cu
+++ b/ggml/src/ggml-cuda/mean.cu
@@ -2,8 +2,13 @@
 #include "reduce_rows.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
+#ifdef GGML_HIP_USE_HIPCUB
+#include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#else
 #include <cub/cub.cuh>
-using namespace cub;
+#endif  // GGML_HIP_USE_HIPCUB
+using cub::DeviceReduce;
 #endif  // GGML_CUDA_USE_CUB
 
 template <typename T> __global__ void divide_by_count(T * result, size_t count) {

--- a/ggml/src/ggml-cuda/ssm-scan.cu
+++ b/ggml/src/ggml-cuda/ssm-scan.cu
@@ -1,10 +1,19 @@
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
 #define USE_CUB
+#elif defined(GGML_USE_HIP) && !defined(GGML_HIP_NO_HIPCUB) && __has_include(<hipcub/hipcub.hpp>)
+#define USE_CUB
+#define GGML_HIP_USE_HIPCUB_SSM
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
 
 #ifdef USE_CUB
+#ifdef GGML_HIP_USE_HIPCUB_SSM
+#include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#else
 #include <cub/cub.cuh>
-using namespace cub;
+#endif  // GGML_HIP_USE_HIPCUB_SSM
+using cub::BlockLoad;
+using cub::BlockStore;
 #endif // USE_CUB
 
 #include "ssm-scan.cuh"

--- a/ggml/src/ggml-cuda/sum.cu
+++ b/ggml/src/ggml-cuda/sum.cu
@@ -2,8 +2,13 @@
 #include "sumrows.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
+#ifdef GGML_HIP_USE_HIPCUB
+#include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#else
 #include <cub/cub.cuh>
-using namespace cub;
+#endif  // GGML_HIP_USE_HIPCUB
+using cub::DeviceReduce;
 #endif  // GGML_CUDA_USE_CUB
 
 #include <cstdint>

--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -2,7 +2,12 @@
 #include "top-k.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
-#    include <cub/cub.cuh>
+#    ifdef GGML_HIP_USE_HIPCUB
+#    include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#    else
+#        include <cub/cub.cuh>
+#    endif  // GGML_HIP_USE_HIPCUB
 #    if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2)
 #        define CUB_TOP_K_AVAILABLE
 #        include <cuda/iterator>

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -117,6 +117,9 @@
 #define cudaStreamNonBlocking hipStreamNonBlocking
 #define cudaStreamPerThread hipStreamPerThread
 #define cudaStreamSynchronize hipStreamSynchronize
+#define cudaStreamIsCapturing hipStreamIsCapturing
+#define cudaStreamCaptureStatus hipStreamCaptureStatus
+#define cudaStreamCaptureStatusNone hipStreamCaptureStatusNone
 #define cudaStreamWaitEvent hipStreamWaitEvent
 #define cudaGraphExec_t hipGraphExec_t
 #define cudaGraphNode_t hipGraphNode_t


### PR DESCRIPTION
## Overview

Enable the CUB code paths on HIP by using hipCUB (the CUB-compatible API that ships with rocPRIM), so AMD builds stop falling back to the slow/CPU paths for device-wide primitives.

Today `GGML_CUDA_USE_CUB` is only defined for CUDA (`CUDART_VERSION >= 11070`), so on HIP:

* `argsort` / `top_k` with `ncols > 1024` exceed the single-block bitonic path and fall back to the **CPU backend**. For DeepSeek-Sparse-Attention models (DeepSeek-V4, DeepSeek-3.2, GLM-DSA, MiniMax-M3) the per-token indexer `top_k` runs over the whole context, so this fallback is hit on **every token**, with cost growing as context grows.
* `sum`, `mean`, `cumsum` and `ssm_scan` use their inefficient fallbacks. `ggml/src/ggml-cuda/sum.cu` already notes this:

  > `// For AMD there is rocPRIM which could be used as a drop-in replacement via hipcub but this would require...`

## Implementation

`common.cuh` enables the existing CUB paths when hipCUB is available:

```c
#elif defined(GGML_USE_HIP) && !defined(GGML_HIP_NO_HIPCUB) && __has_include(<hipcub/hipcub.hpp>)
#    define GGML_CUDA_USE_CUB
#    define GGML_HIP_USE_HIPCUB
```

* **Feature-detected**, so ROCm installs without `hipcub-dev` keep building exactly as before.
* **Opt-out** via `-DGGML_HIP_NO_HIPCUB`.
* Call sites are unchanged — each translation unit does `namespace cub = hipcub;` and pulls in the specific symbols it uses, rather than dumping the namespace globally.
* `vendors/hip.h` gains the `cudaStreamIsCapturing` / `cudaStreamCaptureStatus` mappings the CUB paths need.

8 files changed, 53 insertions(+), 7 deletions(-).

## Correctness

`test-backend-ops test` passes on the ROCm backend for every affected op: `ARGSORT`, `TOP_K`, `SUM`, `MEAN`, `CUMSUM`, `SSM_SCAN`.

## Performance

Hardware: Radeon 8060S iGPU (**gfx1151**, Strix Halo), 128 GB unified memory, ROCm 7.2.4, Debian.

Both arms built from the same commit, differing only by this patch. `llama-bench -p 0 -n 64 -d <depth> -fa 1 -mmp 0`, ROCm backend.

**DeepSeek-V4-Flash** (284B-A13B, IQ2_XXS, KV `q4_0`, `-b/-ub 2048`), tg t/s:

| depth | master | this PR | delta |
|------:|-------:|--------:|------:|
| 0      | 12.60 ± 1.15 | 12.65 ± 0.09 | +0.4% |
| 8192   | 10.54 ± 0.40 | 11.95 ± 0.79 | **+13%** |
| 32768  |  8.27 ± 0.17 | 11.36 ± 0.35 | **+37%** |
| 65536  |  7.54 ± 0.14 |  9.81 ± 0.21 | **+30%** |
| 131072 |  6.40 ± 0.08 |  8.02 ± 0.15 | **+25%** |

Depth 0 is the natural control: with no context there is no indexer `top_k` work and the two builds are identical. The gain appears as soon as context exists and stays ≥25% out to 128K — consistent with removing a fallback whose cost scales with depth.

Models that do **not** use these ops are unaffected, as expected:

| model | class | tg @32K master → this PR |
|---|---|---|
| Qwen3.6-35B-A3B Q4_K_M | MoE (routing uses the fused `topk-moe` path, ≤256 cols) | 47.72 → 46.62 |
| Gemma-4-31B Q4_K_XL | dense | 8.40 → 8.46 |

Those two are within run-to-run noise (arms were run sequentially, so the second arm sees slightly warmer hardware).

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
