### PR TITLE
CUDA: use batched argsort for multi row top-k

### DIFF
--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -12,6 +12,9 @@ using namespace cub;
 
 #ifdef CUB_TOP_K_AVAILABLE
 
+// process at most this many rows with sequential per-row DeviceTopK dispatches
+#define GGML_CUDA_TOP_K_SEQ_MAX_NROWS 16
+
 static void top_k_cub(ggml_cuda_pool & pool,
                       const float *    src,
                       int *            dst,
@@ -36,7 +39,9 @@ static void top_k_cub(ggml_cuda_pool & pool,
                          ncols, k, env));
 }
 
-#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+#endif  // CUB_TOP_K_AVAILABLE
+
+#ifdef GGML_CUDA_USE_CUB
 
 static int next_power_of_2(int x) {
     int n = 1;
@@ -46,37 +51,20 @@ static int next_power_of_2(int x) {
     return n;
 }
 
-#endif                            // CUB_TOP_K_AVAILABLE
-
-void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
-    const ggml_tensor * src0   = dst->src[0];
-    const float *       src0_d = (const float *) src0->data;
-    int *               dst_d  = (int *) dst->data;
-    cudaStream_t        stream = ctx.stream();
-
-    // are these asserts truly necessary?
-    GGML_ASSERT(src0->type == GGML_TYPE_F32);
-    GGML_ASSERT(dst->type == GGML_TYPE_I32);
-    GGML_ASSERT(ggml_is_contiguous(src0));
-
-    const int64_t    ncols = src0->ne[0];
-    const int64_t    nrows = ggml_nrows(src0);
-    const int64_t    k     = dst->ne[0];
-    ggml_cuda_pool & pool  = ctx.pool();
-#ifdef CUB_TOP_K_AVAILABLE
-    // TODO: Switch to `DeviceSegmentedTopK` for multi-row TopK once implemented
-    // https://github.com/NVIDIA/cccl/issues/6391
-    // TODO: investigate if there exists a point where parallelized argsort is faster than sequential top-k
-    for (int i = 0; i < nrows; i++) {
-        top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
-    }
-#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
-    // Fall back to argsort + copy
+// batched top k via full argsort of all rows and strided copy of the first k columns
+static void top_k_via_argsort(ggml_cuda_pool & pool,
+                              const float *    src0_d,
+                              int *            dst_d,
+                              const int64_t    ncols,
+                              const int64_t    nrows,
+                              const int64_t    k,
+                              const size_t     nb01,
+                              cudaStream_t     stream) {
     const int    ncols_pad      = next_power_of_2(ncols);
     const size_t shared_mem     = ncols_pad * sizeof(int);
     const size_t max_shared_mem = ggml_cuda_info().devices[ggml_cuda_get_device()].smpb;
     const bool   use_bitonic    = shared_mem <= max_shared_mem && ncols <= 1024;
-    const int    chunk_nrows    = argsort_f32_i32_cuda_cub_chunk_nrows(src0->nb[1], nrows);
+    const int    chunk_nrows    = argsort_f32_i32_cuda_cub_chunk_nrows(nb01, nrows);
 
     ggml_cuda_pool_alloc<int> temp_dst_alloc(pool, ncols * chunk_nrows);
     int *                     tmp_dst = temp_dst_alloc.get();
@@ -95,6 +83,48 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         src0_d += ncols * iter_nrows;
         dst_d  += k     * iter_nrows;
     }
+}
+
+#endif  // GGML_CUDA_USE_CUB
+
+void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0   = dst->src[0];
+    const float *       src0_d = (const float *) src0->data;
+    int *               dst_d  = (int *) dst->data;
+    cudaStream_t        stream = ctx.stream();
+
+    // are these asserts truly necessary?
+    GGML_ASSERT(src0->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_I32);
+    GGML_ASSERT(ggml_is_contiguous(src0));
+
+    const int64_t    ncols = src0->ne[0];
+    const int64_t    nrows = ggml_nrows(src0);
+    const int64_t    k     = dst->ne[0];
+    ggml_cuda_pool & pool  = ctx.pool();
+#ifdef CUB_TOP_K_AVAILABLE
+    // DeviceTopK has no batched/segmented variant yet, therefore multi row inputs require one sequential dispatch per row
+    // The dispatch overhead is catastrophic for batch workloads, and batched argsort is much faster.
+    // TODO: Switch to `DeviceSegmentedTopK` once implemented:
+    // https://github.com/NVIDIA/cccl/issues/6391
+    bool use_seq_top_k = nrows <= GGML_CUDA_TOP_K_SEQ_MAX_NROWS;
+#ifdef USE_CUDA_GRAPH
+    if (use_seq_top_k) {
+        // DeviceTopK stream capture is not guaranteed. The argsort handles capture explicitly.
+        cudaStreamCaptureStatus capture_status;
+        CUDA_CHECK(cudaStreamIsCapturing(stream, &capture_status));
+        use_seq_top_k = capture_status == cudaStreamCaptureStatusNone;
+    }
+#endif  // USE_CUDA_GRAPH
+    if (use_seq_top_k) {
+        for (int i = 0; i < nrows; i++) {
+            top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+        }
+    } else {
+        top_k_via_argsort(pool, src0_d, dst_d, ncols, nrows, k, src0->nb[1], stream);
+    }
+#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+    top_k_via_argsort(pool, src0_d, dst_d, ncols, nrows, k, src0->nb[1], stream);
 #else                             // GGML_CUDA_USE_CUB
     ggml_cuda_pool_alloc<int> temp_dst_alloc(pool, ncols * nrows);
     int *                     tmp_dst = temp_dst_alloc.get();


### PR DESCRIPTION
## Overview

With CCCL >= 3.2, top-k processes multi-row inputs with one sequential DeviceTopK dispatch per row. This is ok for a few rows and is even optimal for single row or large ncols cases, but for batch workloads it serializes thousands of dispatches per graph. More specifically MiniMax M3's block selection calls top-k with HD * n_tokens rows, causing a massive prompt processing regression (1250 - 77 t/s on 3 * RTX 6000s  https://github.com/ggml-org/llama.cpp/pull/26297#issuecomment-5146180851 vs https://github.com/ggml-org/llama.cpp/pull/26297#issuecomment-5146982417. ) for anyone on CUDA toolkit >= 13.2 or with the official release binaries.

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

This PR keeps the per row DeviceTopK path for nrows <= 16, and routes larger row counts to the existing batched argsort + copy path. (behaviour for CCCL < 3.2 is unchanged). Also routes stream capture to the argsort path, which has explicit capture handling, since DeviceTopK's support is not verified. I can drop that if it is known safe.

Long term the proper fix is DeviceSegmentedTopK when CCCL implements it.

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
