### PR TITLE
ggml-backend-meta: fix axis bounds check off-by-one

### DIFF
--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -790,7 +790,7 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
             ggml_backend_dev_t dev = ggml_backend_buft_get_device(ggml_backend_buffer_get_type(tensor->buffer));
             const ggml_backend_meta_device_context * dev_ctx = (const ggml_backend_meta_device_context *) dev->context;
             ggml_backend_meta_split_state ret = dev_ctx->get_split_state(tensor, dev_ctx->get_split_state_ud);
-            if (ret.axis >= 0 && ret.axis <= GGML_MAX_DIMS) {
+            if (ret.axis >= 0 && ret.axis < GGML_MAX_DIMS) {
                 const int64_t granularity = ret.axis == GGML_BACKEND_SPLIT_AXIS_0 ? ggml_blck_size(tensor->type) : 1;
                 int64_t ne_sum = 0;
                 for (size_t s = 0; s < ret.n_segments; s++) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -285,6 +285,7 @@ endif()
 if (NOT GGML_BACKEND_DL)
     # these tests use the backends directly and cannot be built with dynamic loading
     llama_build_and_test(test-barrier.cpp)
+    llama_build_and_test(test-meta-split-state.cpp)
     llama_build_and_test(test-quantize-fns.cpp)
     llama_build_and_test(test-quantize-perf.cpp)
     llama_build_and_test(test-rope.cpp)

--- a/tests/test-meta-split-state.cpp
+++ b/tests/test-meta-split-state.cpp
@@ -1,0 +1,66 @@
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+// Regression test for https://github.com/ggml-org/llama.cpp/issues/26367
+//
+// A host-side get_split_state callback that returns `axis == GGML_MAX_DIMS`
+// (an invalid value) used to be accepted by the bounds check in
+// `ggml_backend_meta_get_split_state` because it compared with `<=` instead
+// of `<`. The following `tensor->ne[ret.axis]` then read one element past the
+// end of the ne[] array (which only has GGML_MAX_DIMS entries), hitting
+// tensor->nb[0] and failing the `ne_sum == tensor->ne[ret.axis]` assertion.
+static ggml_backend_meta_get_split_state_t invalid_split_state = [](const ggml_tensor * tensor, void * ud) {
+    GGML_UNUSED(tensor);
+    GGML_UNUSED(ud);
+
+    struct ggml_backend_meta_split_state st = {};
+    st.axis       = (ggml_backend_meta_split_axis) GGML_MAX_DIMS;
+    st.n_segments = 1;
+    st.ne[0]      = 0;
+    st.nr[0]      = 1;
+    return st;
+};
+
+int main() {
+    ggml_backend_dev_t cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    if (cpu_dev == nullptr) {
+        fprintf(stderr, "no CPU backend available\n");
+        return 1;
+    }
+
+    ggml_backend_dev_t meta_dev = ggml_backend_meta_device(&cpu_dev, 1, invalid_split_state, nullptr);
+    if (meta_dev == nullptr) {
+        fprintf(stderr, "failed to create meta device\n");
+        return 1;
+    }
+
+    ggml_backend_buffer_type_t buft = ggml_backend_dev_buffer_type(meta_dev);
+    ggml_backend_buffer_t buffer = ggml_backend_buft_alloc_buffer(buft, 4096);
+    if (buffer == nullptr) {
+        fprintf(stderr, "failed to allocate meta buffer\n");
+        return 1;
+    }
+
+    struct ggml_init_params params = {
+        /* .mem_size   = */ 4096,
+        /* .mem_buffer = */ nullptr,
+        /* .no_alloc   = */ true,
+    };
+    struct ggml_context * ctx = ggml_init(params);
+    if (ctx == nullptr) {
+        fprintf(stderr, "failed to init ggml context\n");
+        return 1;
+    }
+
+    struct ggml_tensor * tensor = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 16, 16);
+    ggml_backend_tensor_alloc(buffer, tensor, ggml_backend_buffer_get_base(buffer));
+
+    ggml_free(ctx);
+    ggml_backend_buffer_free(buffer);
+
+    printf("ok\n");
+    return 0;
+}


### PR DESCRIPTION
## Overview

The bounds check for a host-provided split state in `ggml_backend_meta_get_split_state` accepted `ret.axis == GGML_MAX_DIMS` because it compared with `<=` instead of `<`. Since `tensor->ne[]` only has `GGML_MAX_DIMS` entries, that value made the subsequent `tensor->ne[ret.axis]` access read one element past the end of the array (landing on `tensor->nb[0]`), failing the `ne_sum == tensor->ne[ret.axis]` assertion when a host-side `get_split_state` callback returned the invalid axis.

Fix: change `<=` to `<` so the check matches the `axis >= 0 && axis < GGML_MAX_DIMS` contract documented in ggml-backend.h, and add a regression test that drives the meta backend with a `get_split_state` callback returning `axis == GGML_MAX_DIMS`.

## Additional information

The old test binary for this path aborts with `GGML_ASSERT(ne_sum == tensor->ne[ret.axis]) failed` on the unfixed code; it passes after the fix.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI (an automated coding agent) was used to draft the fix and the regression test, and to run the build/test verification; the change and test were reviewed and verified by a human before submission.

## Verification

- `cmake --build build --target test-meta-split-state` builds cleanly and the test passes (`ok`) with the fix
- Reverting the one-character fix makes the new test abort with `GGML_ASSERT(ne_sum == tensor->ne[ret.axis]) failed`, confirming it reproduces the issue
- `ggml` target builds cleanly with `cmake --build build --target ggml`
- One-character behavioral change, no effect on valid axes (0..GGML_MAX_DIMS-1)
