### PR TITLE
convert : support mixed FP8 and NVFP4 compressed-tensors

### DIFF
--- a/.github/workflows/python-type-check.yml
+++ b/.github/workflows/python-type-check.yml
@@ -41,3 +41,6 @@ jobs:
       - name: Type-check with ty
         run: |
             ty check --output-format=github
+      - name: Test model conversion
+        run: |
+            python -m unittest discover -s tests -p 'test_convert_hf_to_gguf.py' -v

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -292,6 +292,54 @@ class ModelBase:
     def _scale_is_trivial(scale: Tensor) -> bool:
         return scale.numel() <= 1 and abs(float(scale.float().sum()) - 1.0) < 1e-6
 
+    @staticmethod
+    def _compressed_tensors_nvfp4_config(
+        quant_method: str | None,
+        quant_format: str | None,
+        groups: dict[str, Any],
+    ) -> tuple[bool, bool]:
+        if quant_method != "compressed-tensors":
+            return False, False
+        if quant_format == "nvfp4-pack-quantized":
+            return True, False
+        if quant_format != "mixed-precision" or not groups:
+            return False, False
+
+        has_nvfp4 = False
+        has_fp8 = False
+        for group in groups.values():
+            if not isinstance(group, dict):
+                return False, False
+            group_format = group.get("format")
+            if group_format == "nvfp4-pack-quantized":
+                weights = group.get("weights") or {}
+                expected = {
+                    "type": "float",
+                    "num_bits": 4,
+                    "strategy": "tensor_group",
+                    "group_size": 16,
+                    "block_structure": None,
+                }
+                if any(weights.get(key) != value for key, value in expected.items()):
+                    return False, False
+                has_nvfp4 = True
+            elif group_format == "float-quantized":
+                weights = group.get("weights") or {}
+                expected = {
+                    "type": "float",
+                    "num_bits": 8,
+                    "strategy": "channel",
+                    "group_size": None,
+                    "block_structure": None,
+                }
+                if any(weights.get(key) != value for key, value in expected.items()):
+                    return False, False
+                has_fp8 = True
+            else:
+                return False, False
+
+        return has_nvfp4, has_nvfp4 and has_fp8
+
     def _write_scale_tensor(self, scale_name: str, scale: Tensor):
         if not self._scale_is_trivial(scale):
             scale_f32 = scale.float().numpy().flatten()
@@ -479,18 +527,32 @@ class ModelBase:
             elif quant_method == "compressed-tensors":
                 quant_format = quant_config["format"]
                 groups = quant_config["config_groups"]
-                nvfp4_compressed_tensors = (
-                    quant_format == "nvfp4-pack-quantized"
-                    or quant_format == "mixed-precision"
-                    and bool(groups)
-                    and all(g.get("format") == "nvfp4-pack-quantized" for g in groups.values() if isinstance(g, dict))
-                )
+                nvfp4_compressed_tensors, mixed_fp8_compressed_tensors = self._compressed_tensors_nvfp4_config(quant_method, quant_format, groups)
 
                 if len(groups) > 1 and not nvfp4_compressed_tensors:
                     raise NotImplementedError("Can't handle multiple config groups for compressed-tensors yet")
-                weight_config = tuple(groups.values())[0]["weights"]
+                if mixed_fp8_compressed_tensors:
+                    def dequant_fp8(weight: Tensor, scale: Tensor, name: str) -> Tensor:
+                        if weight.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+                            raise ValueError(f"Expected FP8 weight for compressed-tensors tensor {name!r}, got {weight.dtype}")
+                        return dequant_simple(weight, scale, None)
 
-                if quant_format == "float-quantized" or quant_format == "int-quantized" or quant_format == "naive-quantized":
+                    for name in self.model_tensors.keys():
+                        if name.endswith(".weight_scale"):
+                            weight_name = name.removesuffix("_scale")
+                            if weight_name not in self.model_tensors:
+                                tensors_to_remove.append(name)
+                                continue
+                            w = self.model_tensors[weight_name]
+                            s = self.model_tensors[name]
+                            self.model_tensors[weight_name] = lambda w=w, s=s, n=weight_name: dequant_fp8(w(), s(), n)
+                            tensors_to_remove.append(name)
+                            if self._fp8_as_q8:
+                                self._fp8_dequantized.add(weight_name)
+                        if name.endswith((".input_scale", ".k_scale", ".v_scale")):
+                            tensors_to_remove.append(name)
+                elif quant_format == "float-quantized" or quant_format == "int-quantized" or quant_format == "naive-quantized":
+                    weight_config = tuple(groups.values())[0]["weights"]
                     block_size = weight_config.get("block_structure", None)
                     strategy = weight_config.get("strategy")
                     assert strategy == "channel" or strategy == "block"
@@ -510,6 +572,7 @@ class ModelBase:
                             if self._fp8_as_q8 and is_fp8:
                                 self._fp8_dequantized.add(weight_name)
                 elif quant_format == "pack-quantized":
+                    weight_config = tuple(groups.values())[0]["weights"]
                     assert weight_config.get("strategy") == "group"
                     assert weight_config.get("type", "int") == "int"
                     num_bits = weight_config.get("num_bits")
@@ -687,7 +750,7 @@ class ModelBase:
         self._write_scale_tensor(new_name.replace(".weight", ".scale"), scale2)
         self._write_scale_tensor(new_name.replace(".weight", ".input_scale"), input_scale)
 
-    def _generate_nvfp4_tensors(self):
+    def _generate_nvfp4_tensors(self, packed_weights: set[str] | None = None):
         # Per-layer expert merging to avoid holding all experts in memory
         expert_blocks: dict[tuple[int, str], list[tuple[int, np.ndarray]]] = {}
         expert_scales: dict[tuple[int, str], list[tuple[int, float]]] = {}
@@ -699,18 +762,23 @@ class ModelBase:
         for name in self.model_tensors.keys():
             if not name.endswith(".weight"):
                 continue
+            if packed_weights is not None and name not in packed_weights:
+                continue
             scale_name = name.replace(".weight", ".weight_scale")
             scale2_name = name.replace(".weight", ".weight_scale_2")
             input_scale_name = name.replace(".weight", ".input_scale")
             if scale_name not in self.model_tensors:
+                if packed_weights is not None:
+                    raise ValueError(f"Packed NVFP4 weight {name!r} has no weight scale")
                 continue
             # Force eager materialization of lazy tensors
             weight = LazyTorchTensor.to_eager(self.model_tensors[name]())
             scale = LazyTorchTensor.to_eager(self.model_tensors[scale_name]())
 
-            # Skip non-NVFP4 tensors (e.g. FP8 with per-channel 1D scales)
-            if scale.ndim < 2:
+            if packed_weights is None and scale.ndim < 2:
                 continue
+            if packed_weights is not None and (weight.dtype != torch.uint8 or scale.dtype != torch.float8_e4m3fn or scale.ndim != 2 or weight.numel() != scale.numel() * 8):
+                raise ValueError(f"Invalid packed NVFP4 tensors for {name!r}: weight {weight.dtype} {list(weight.shape)}, scale {scale.dtype} {list(scale.shape)}")
 
             scale2 = LazyTorchTensor.to_eager(self.model_tensors.get(scale2_name, lambda: torch.tensor(1.0))())
             input_scale = LazyTorchTensor.to_eager(self.model_tensors.get(input_scale_name, lambda: torch.tensor(1.0))())
@@ -811,12 +879,7 @@ class ModelBase:
 
         # Some models use per-tensor quant_algo (e.g. "MIXED_PRECISION" with
         # per-layer NVFP4/FP8) instead of a single global "NVFP4" value.
-        nvfp4_compressed_tensors = quant_method == "compressed-tensors" and (
-            quant_format == "nvfp4-pack-quantized"
-            or quant_format == "mixed-precision"
-            and bool(quant_groups)
-            and all(g.get("format") == "nvfp4-pack-quantized" for g in quant_groups.values() if isinstance(g, dict))
-        )
+        nvfp4_compressed_tensors, mixed_fp8_compressed_tensors = self._compressed_tensors_nvfp4_config(quant_method, quant_format, quant_groups)
         if quant_algo != "NVFP4":
             if nvfp4_compressed_tensors:
                 quant_algo = "NVFP4"
@@ -830,7 +893,11 @@ class ModelBase:
         # This must run before dequant_model so NVFP4 tensors are removed
         # from model_tensors, leaving only non-NVFP4 (e.g. FP8) for dequant.
         if self._is_nvfp4:
+            packed_weights: set[str] | None = None
             if nvfp4_compressed_tensors:
+                if mixed_fp8_compressed_tensors:
+                    packed_weights = set()
+
                 # Convert compressed-tensors 'global' scales into the reciprocal
                 def inverse_scale(gen):
                     def load():
@@ -842,8 +909,13 @@ class ModelBase:
                 for name in list(self.model_tensors.keys()):
                     if name.endswith(".weight_packed"):
                         weight_name = name.removesuffix("_packed")
-                        if weight_name not in self.model_tensors:
-                            self.model_tensors[weight_name] = self.model_tensors.pop(name)
+                        if packed_weights is not None:
+                            packed_weights.add(weight_name)
+                        if weight_name in self.model_tensors:
+                            if packed_weights is not None:
+                                raise ValueError(f"Packed NVFP4 weight {name!r} conflicts with {weight_name!r}")
+                            continue
+                        self.model_tensors[weight_name] = self.model_tensors.pop(name)
                     elif name.endswith(".weight_global_scale"):
                         scale2_name = name.replace(".weight_global_scale", ".weight_scale_2")
                         if scale2_name not in self.model_tensors:
@@ -852,7 +924,9 @@ class ModelBase:
                         input_scale_name = name.replace(".input_global_scale", ".input_scale")
                         if input_scale_name not in self.model_tensors:
                             self.model_tensors[input_scale_name] = inverse_scale(self.model_tensors.pop(name))
-            self._generate_nvfp4_tensors()
+                if packed_weights is not None and not packed_weights:
+                    raise ValueError("Mixed FP8 and NVFP4 compressed-tensors model has no packed NVFP4 weights")
+            self._generate_nvfp4_tensors(packed_weights)
 
         self.dequant_model()
 

--- a/conversion/gemma.py
+++ b/conversion/gemma.py
@@ -716,7 +716,7 @@ class Gemma4Model(Gemma3Model):
         rope_freqs_full = torch.tensor(values, dtype=torch.float32)
         yield (self.format_tensor_name(gguf.MODEL_TENSOR.ROPE_FREQS), rope_freqs_full)
 
-    def _generate_nvfp4_tensors(self):
+    def _generate_nvfp4_tensors(self, packed_weights: set[str] | None = None):
         # Gemma-4 stores a per-layer router.per_expert_scale ([n_expert]) that scales
         # each expert's contribution. It's mathematically equivalent to a per-expert
         # scalar on the down_proj output, which is exactly where ffn_down_exps_s is
@@ -738,7 +738,7 @@ class Gemma4Model(Gemma3Model):
             for e, w2 in enumerate(w2_targets):
                 s = self.model_tensors[w2]
                 self.model_tensors[w2] = lambda s=s, r=r, i=e: s() * r()[i]
-        super()._generate_nvfp4_tensors()
+        super()._generate_nvfp4_tensors(packed_weights)
 
     @classmethod
     def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:

--- a/tests/test_convert_hf_to_gguf.py
+++ b/tests/test_convert_hf_to_gguf.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any, cast
+
+import gguf
+import numpy as np
+import torch
+
+from conversion.base import ModelBase
+
+
+def mixed_config_groups() -> dict[str, dict[str, Any]]:
+    return {
+        "group_0": {
+            "format": "float-quantized",
+            "weights": {
+                "type": "float",
+                "num_bits": 8,
+                "strategy": "channel",
+                "group_size": None,
+                "block_structure": None,
+            },
+        },
+        "group_1": {
+            "format": "nvfp4-pack-quantized",
+            "weights": {
+                "type": "float",
+                "num_bits": 4,
+                "strategy": "tensor_group",
+                "group_size": 16,
+                "block_structure": None,
+            },
+        },
+    }
+
+
+def make_model(tensors: dict[str, torch.Tensor], *, fp8_as_q8: bool = False) -> ModelBase:
+    model = ModelBase.__new__(ModelBase)
+    model.hparams = {
+        "quantization_config": {
+            "quant_method": "compressed-tensors",
+            "format": "mixed-precision",
+            "config_groups": mixed_config_groups(),
+        },
+    }
+    model.model_tensors = {name: (lambda tensor=tensor: tensor) for name, tensor in tensors.items()}
+    model._is_nvfp4 = True
+    model._fp8_as_q8 = fp8_as_q8
+    model._fp8_dequantized = set()
+    return model
+
+
+class TensorWriter:
+    def __init__(self) -> None:
+        self.tensors: dict[str, tuple[np.ndarray, gguf.GGMLQuantizationType | None]] = {}
+
+    def add_tensor(self, name: str, data: np.ndarray, raw_dtype: gguf.GGMLQuantizationType | None = None) -> None:
+        self.tensors[name] = data, raw_dtype
+
+
+class TestMixedCompressedTensors(unittest.TestCase):
+    def test_dequantizes_fp8(self) -> None:
+        weight_name = "model.layers.32.mlp.experts.0.gate_proj.weight"
+        scale_name = weight_name + "_scale"
+        weight = torch.tensor([[1.0, -2.0, 3.0, -4.0], [2.0, 4.0, -1.0, -3.0]], dtype=torch.float8_e4m3fn)
+        scale = torch.tensor([[0.5], [0.25]], dtype=torch.bfloat16)
+        model = make_model({weight_name: weight, scale_name: scale}, fp8_as_q8=True)
+
+        model.dequant_model()
+
+        self.assertNotIn(scale_name, model.model_tensors)
+        self.assertIn(weight_name, model._fp8_dequantized)
+        self.assertEqual(model.tensor_force_quant(weight_name, weight_name, None, 2), gguf.GGMLQuantizationType.Q8_0)
+        torch.testing.assert_close(model.model_tensors[weight_name](), weight.float() * scale.float())
+
+    def test_nvfp4_repacking_uses_packed_weight_provenance(self) -> None:
+        nvfp4_name = "model.layers.31.mlp.shared_expert.gate_proj.weight"
+        fp8_name = "model.layers.32.mlp.shared_expert.gate_proj.weight"
+        model = make_model({
+            nvfp4_name: torch.arange(64, dtype=torch.uint8).reshape(2, 32),
+            nvfp4_name + "_scale": torch.ones((2, 4), dtype=torch.float8_e4m3fn),
+            fp8_name: torch.ones((2, 32), dtype=torch.float8_e4m3fn),
+            fp8_name + "_scale": torch.ones((2, 1), dtype=torch.bfloat16),
+        })
+        writer = TensorWriter()
+        cast(Any, model).gguf_writer = writer
+        model.hparams["num_local_experts"] = 0
+        cast(Any, model).map_tensor_name = lambda name: name
+
+        model._generate_nvfp4_tensors({nvfp4_name})
+
+        self.assertEqual(writer.tensors[nvfp4_name][1], gguf.GGMLQuantizationType.NVFP4)
+        self.assertNotIn(nvfp4_name, model.model_tensors)
+        self.assertIn(fp8_name, model.model_tensors)
+        self.assertIn(fp8_name + "_scale", model.model_tensors)
+
+    def test_nvfp4_repacking_rejects_malformed_packed_weight(self) -> None:
+        weight_name = "model.layers.31.mlp.shared_expert.gate_proj.weight"
+        model = make_model({
+            weight_name: torch.ones((2, 32), dtype=torch.float8_e4m3fn),
+            weight_name + "_scale": torch.ones((2, 4), dtype=torch.float8_e4m3fn),
+        })
+
+        with self.assertRaisesRegex(ValueError, "Invalid packed NVFP4 tensors"):
+            model._generate_nvfp4_tensors({weight_name})
+
+    def test_rejects_unknown_group(self) -> None:
+        model = make_model({})
+        model._is_nvfp4 = False
+        groups = model.hparams["quantization_config"]["config_groups"]
+        groups["group_2"] = {"format": "int-quantized", "weights": {"num_bits": 4}}
+
+        with self.assertRaisesRegex(NotImplementedError, "multiple config groups"):
+            model.dequant_model()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview

Support mixed-precision compressed-tensors checkpoints containing channel-scaled FP8 and packed NVFP4 weights.

Converter now validates supported group formats, identifies NVFP4 tensors from `.weight_packed` provenance, dequantizes remaining FP8 weights, preserves `--fp8-as-q8`, and rejects malformed packed tensors. Gemma NVFP4 override forwards provenance through its existing preprocessing.

## Additional information

Reproduced with `unsloth/Qwen3.6-35B-A3B-NVFP4` at revision `739af1e7aac320af1682ed1e0cce369af4c5265d`. Before this change, conversion rejected multiple compressed-tensors groups.

Validation:

- Focused converter tests: 4/4
- Flake8: clean
- `ty check`: passed with existing unused-ignore warnings
- Full 24.7 GiB checkpoint conversion: 1,137 tensors, including 192 NVFP4
- Derived 20 GB Q4_K_M GGUF matched proven output byte-for-byte
- GPU smoke: coding 6/6 at 52.63 tok/s, reasoning, MTP, and vision passed

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Codex assisted with implementation, test design, review, and validation.