### PR TITLE
ggml-cuda: enable MMA FlashAttention for head dim 256 on AMD RDNA

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -612,6 +612,16 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
     constexpr bool swz_V = V_is_K_view ? swz_K : ggml_cuda_fattn_smem_swizzle::enabled(nbatch_V2);
 
     const int k_VKQ_0 = kb0 * nbatch_fa;
+
+#if defined(AMD_WMMA_AVAILABLE)
+    if constexpr (DKQ > 128) {
+        assert(((uintptr_t)K_h2 & 15) == 0 && "K_h2 must be 16-byte aligned");
+        assert(((uintptr_t)V_h2 & 15) == 0 && "V_h2 must be 16-byte aligned");
+        assert(((stride_K * sizeof(half2)) & 15) == 0 && "stride_K must be 16-byte aligned");
+        assert(((stride_V * sizeof(half2)) & 15) == 0 && "stride_V must be 16-byte aligned");
+    }
+#endif // AMD_WMMA_AVAILABLE
+
 #if defined(TURING_MMA_AVAILABLE)
     T_C_KQ KQ_C[nbatch_fa/(np*(cols_per_warp == 8 ? T_C_KQ::I : T_C_KQ::J))];
 #elif defined(AMD_WMMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE)
@@ -651,10 +661,10 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         const int k0_stop = k0_start + nbatch_K2 < DKQ/2 ? k0_start + nbatch_K2 : DKQ/2;
 
         if constexpr (nstages <= 1) {
-            const int k0_diff = k0_stop - k0_start;
 #if defined(AMD_WMMA_AVAILABLE)
             if (DKQ <= 128) {
 #endif // AMD_WMMA_AVAILABLE
+            const int k0_diff = k0_stop - k0_start;
             constexpr bool use_cp_async = nstages == 1;
             flash_attn_ext_f16_load_tile<stride_tile_K, swz_K, nwarps, nbatch_fa, use_cp_async, oob_check, use_sparse>
                 (K_h2 + k0_start, tile_K, k0_diff, stride_K, k_VKQ_0, k_VKQ_sup, indices);
@@ -663,8 +673,6 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
             }
             __syncthreads();
 #if defined(AMD_WMMA_AVAILABLE)
-            } else {
-                GGML_UNUSED(k0_diff);
             }
 #endif // AMD_WMMA_AVAILABLE
         }
@@ -1024,10 +1032,10 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         const int i0_stop = i0_start + 2*nbatch_V2;
 
         if constexpr (nstages <= 1) {
-            const int i0_diff = i0_stop - i0_start;
 #if defined(AMD_WMMA_AVAILABLE)
             if (DKQ <= 128) {
 #endif // AMD_WMMA_AVAILABLE
+            const int i0_diff = i0_stop - i0_start;
             if (!V_is_K_view || i0_stop > 2*nbatch_K2) {
                 constexpr bool use_cp_async = nstages == 1;
                 flash_attn_ext_f16_load_tile<stride_tile_V, swz_V, nwarps, nbatch_fa, use_cp_async, oob_check, use_sparse>
@@ -1038,12 +1046,14 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 __syncthreads();
             }
 #if defined(AMD_WMMA_AVAILABLE)
-            } else {
-                GGML_UNUSED(i0_diff);
             }
 #endif // AMD_WMMA_AVAILABLE
         }
 #if defined(AMD_WMMA_AVAILABLE)
+        // For DKQ > 128 on AMD WMMA, K and V bypass LDS staging completely and are loaded
+        // directly from VRAM via V_h2. If V_is_K_view were set (e.g. MLA), V_h2 and K_h2 point
+        // to the same memory, so reading directly from V_h2 is always valid.
+        assert(!V_is_K_view || V_h2 == K_h2);
         const half2 * tile_V_i = DKQ > 128 ?
             V_h2 + int64_t(k_VKQ_0)*stride_V + i0_start/2 :
             (!V_is_K_view || i0_stop > 2*nbatch_K2 ? tile_V : tile_V + i0_start/2);

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -636,6 +636,12 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
             flash_attn_ext_f16_load_mask<ncols1, nwarps, nbatch_fa, use_cp_async, oob_check, use_sparse>
                 (mask_h, tile_mask, stride_mask, k_VKQ_0, k_VKQ_sup, jt*ncols1, ne01, indices);
         }
+#if defined(AMD_WMMA_AVAILABLE)
+        // For large head dims, K/V bypass LDS staging below so sync mask here.
+        if (DKQ > 128 && (ncols2 > 1 || mask_h)) {
+            __syncthreads();
+        }
+#endif // AMD_WMMA_AVAILABLE
     }
 
     // For MLA K and V have the same data.
@@ -646,6 +652,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
         if constexpr (nstages <= 1) {
             const int k0_diff = k0_stop - k0_start;
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128) {
+#endif // AMD_WMMA_AVAILABLE
             constexpr bool use_cp_async = nstages == 1;
             flash_attn_ext_f16_load_tile<stride_tile_K, swz_K, nwarps, nbatch_fa, use_cp_async, oob_check, use_sparse>
                 (K_h2 + k0_start, tile_K, k0_diff, stride_K, k_VKQ_0, k_VKQ_sup, indices);
@@ -653,6 +662,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 cp_async_wait_all();
             }
             __syncthreads();
+#if defined(AMD_WMMA_AVAILABLE)
+            } else {
+                GGML_UNUSED(k0_diff);
+            }
+#endif // AMD_WMMA_AVAILABLE
         }
 
         // Calculate tile of KQ:
@@ -663,6 +677,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #pragma unroll
                 for (int k_KQ_0 = k0_start; k_KQ_0 < k0_stop; k_KQ_0 += T_A_KQ::J) {
                     T_A_KQ K_A;
+#if defined(AMD_WMMA_AVAILABLE)
+                    if (DKQ > 128) {
+                        load_ldmatrix(K_A, K_h2 + int64_t(k_VKQ_0 + i_KQ_0)*stride_K + k_KQ_0, stride_K);
+                    } else
+#endif // AMD_WMMA_AVAILABLE
                     ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K, swz_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[k_KQ_0/T_A_KQ::J]);
@@ -689,6 +708,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                     const int i_KQ_0 = i_KQ_00 + (threadIdx.y % np)*T_A_KQ::I;
 
                     T_A_KQ K_A;
+#if defined(AMD_WMMA_AVAILABLE)
+                    if (DKQ > 128) {
+                        load_ldmatrix(K_A, K_h2 + int64_t(k_VKQ_0 + i_KQ_0)*stride_K + k_KQ_0, stride_K);
+                    } else
+#endif // AMD_WMMA_AVAILABLE
                     ggml_cuda_fattn_smem_swizzle::load_ldmatrix<stride_tile_K, swz_K>(K_A, tile_K, i_KQ_0, k_KQ_0 - k0_start);
 
                     if constexpr (cols_per_warp == 8) {
@@ -708,6 +732,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         }
 
         if constexpr (nstages <= 1) {
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128)
+#endif // AMD_WMMA_AVAILABLE
             __syncthreads(); // Only needed if tile_K == tile_V.
         }
     }
@@ -998,6 +1025,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
         if constexpr (nstages <= 1) {
             const int i0_diff = i0_stop - i0_start;
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128) {
+#endif // AMD_WMMA_AVAILABLE
             if (!V_is_K_view || i0_stop > 2*nbatch_K2) {
                 constexpr bool use_cp_async = nstages == 1;
                 flash_attn_ext_f16_load_tile<stride_tile_V, swz_V, nwarps, nbatch_fa, use_cp_async, oob_check, use_sparse>
@@ -1007,8 +1037,19 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 }
                 __syncthreads();
             }
+#if defined(AMD_WMMA_AVAILABLE)
+            } else {
+                GGML_UNUSED(i0_diff);
+            }
+#endif // AMD_WMMA_AVAILABLE
         }
+#if defined(AMD_WMMA_AVAILABLE)
+        const half2 * tile_V_i = DKQ > 128 ?
+            V_h2 + int64_t(k_VKQ_0)*stride_V + i0_start/2 :
+            (!V_is_K_view || i0_stop > 2*nbatch_K2 ? tile_V : tile_V + i0_start/2);
+#else
         const half2 * tile_V_i = !V_is_K_view || i0_stop > 2*nbatch_K2 ? tile_V : tile_V + i0_start/2;
+#endif // AMD_WMMA_AVAILABLE
 
 #if defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE)
 #pragma unroll
@@ -1019,6 +1060,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::J;
 
                 T_A_VKQ A; // Transposed in SRAM but not in registers, gets transposed on load.
+#if defined(AMD_WMMA_AVAILABLE)
+                if (DKQ > 128) {
+                    load_ldmatrix_trans(A, tile_V_i + 2*k0*stride_V + (i_VKQ_0 - i0_start)/2, stride_V);
+                } else
+#endif // AMD_WMMA_AVAILABLE
                 ggml_cuda_fattn_smem_swizzle::load_ldmatrix_trans<stride_tile_V, swz_V>(A, tile_V, (int)(tile_V_i - tile_V) + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2);
                 if constexpr (T_B_KQ::I == 8) {
                     mma(VKQ_C[i_VKQ_0/T_A_VKQ::I], A, B[k00/(np*T_A_VKQ::J)]);
@@ -1052,6 +1098,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #endif // defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE)
 
         if constexpr (nstages <= 1) {
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128)
+#endif // AMD_WMMA_AVAILABLE
             __syncthreads(); // Only needed if tile_K == tile_V.
         }
     }

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1099,9 +1099,13 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
         if constexpr (nstages <= 1) {
 #if defined(AMD_WMMA_AVAILABLE)
-            if (DKQ <= 128)
+            // When DKQ > 128, K/V bypass LDS so tile_K/tile_V barriers are unnecessary.
+            // However, tile_mask still lives in LDS — the next iteration's load_mask
+            // would overwrite it while a slow warp might still be reading it in softmax.
+            // Keep the barrier when mask is active to prevent this WAR hazard.
+            if (DKQ <= 128 || ncols2 > 1 || mask_h)
 #endif // AMD_WMMA_AVAILABLE
-            __syncthreads(); // Only needed if tile_K == tile_V.
+            __syncthreads(); // Needed if tile_K == tile_V, or if tile_mask is in use.
         }
     }
 #else

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -158,8 +158,8 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
 
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256,  8,  64, 2,  32, 128, 128, 128, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 16,  64, 2,  32, 128, 128, 128, 1, true);
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 32, 128, 2,  64, 128, 128,  64, 1, true);
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 128, 2,  64, 128, 128,  64, 1, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 32, 128, 2,  64, 128, 128, 128, 1, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 128, 2,  64, 128, 128, 128, 1, true);
 
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(320, 256, 32, 128, 2,  32, 160, 128, 128, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(320, 256, 64, 128, 2,  32, 160, 128, 128, 1, true);
@@ -1875,7 +1875,7 @@ static __global__ void flash_attn_ext_f16(
 #endif // __CUDA_ARCH__ == GGML_CUDA_CC_TURING
 
 #if defined(AMD_WMMA_AVAILABLE)
-    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 128) {
+    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 256) {
         NO_DEVICE_CODE;
         return;
     }

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1058,9 +1058,13 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
         if constexpr (nstages <= 1) {
 #if defined(AMD_WMMA_AVAILABLE)
-            if (DKQ <= 128)
+            // When DKQ > 128, K/V bypass LDS so tile_K/tile_V barriers are unnecessary.
+            // However, tile_mask still lives in LDS — the next iteration's load_mask
+            // would overwrite it while a slow warp might still be reading it in softmax.
+            // Keep the barrier when mask is active to prevent this WAR hazard.
+            if (DKQ <= 128 || ncols2 > 1 || mask_h)
 #endif // AMD_WMMA_AVAILABLE
-            __syncthreads(); // Only needed if tile_K == tile_V.
+            __syncthreads(); // Needed if tile_K == tile_V, or if tile_mask is in use.
         }
     }
 #else

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -596,6 +596,12 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
             flash_attn_ext_f16_load_mask<ncols1, nwarps, nbatch_fa, use_cp_async, oob_check>
                 (mask_h + k_VKQ_0, tile_mask, stride_mask, k_VKQ_sup, jt*ncols1, ne01);
         }
+#if defined(AMD_WMMA_AVAILABLE)
+        // For large head dims, K/V bypass LDS staging below so sync mask here.
+        if (DKQ > 128 && (ncols2 > 1 || mask_h)) {
+            __syncthreads();
+        }
+#endif // AMD_WMMA_AVAILABLE
     }
 
     // For MLA K and V have the same data.
@@ -606,6 +612,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
         if constexpr (nstages <= 1) {
             const int k0_diff = k0_stop - k0_start;
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128) {
+#endif // AMD_WMMA_AVAILABLE
             constexpr bool use_cp_async = nstages == 1;
             flash_attn_ext_f16_load_tile<stride_tile_K, nwarps, nbatch_fa, use_cp_async, oob_check>
                 (K_h2 + int64_t(k_VKQ_0)*stride_K + k0_start, tile_K, k0_diff, stride_K, k_VKQ_sup);
@@ -613,6 +622,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 cp_async_wait_all();
             }
             __syncthreads();
+#if defined(AMD_WMMA_AVAILABLE)
+            } else {
+                GGML_UNUSED(k0_diff);
+            }
+#endif // AMD_WMMA_AVAILABLE
         }
 
         // Calculate tile of KQ:
@@ -623,6 +637,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #pragma unroll
                 for (int k_KQ_0 = k0_start; k_KQ_0 < k0_stop; k_KQ_0 += T_A_KQ::J) {
                     T_A_KQ K_A;
+#if defined(AMD_WMMA_AVAILABLE)
+                    if (DKQ > 128) {
+                        load_ldmatrix(K_A, K_h2 + int64_t(k_VKQ_0 + i_KQ_0)*stride_K + k_KQ_0, stride_K);
+                    } else
+#endif // AMD_WMMA_AVAILABLE
                     load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
                     if constexpr (cols_per_warp == 8) {
                         mma(KQ_C[i_KQ_00/(np*T_A_KQ::I)], K_A, Q_B[k_KQ_0/T_A_KQ::J]);
@@ -649,6 +668,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                     const int i_KQ_0 = i_KQ_00 + (threadIdx.y % np)*T_A_KQ::I;
 
                     T_A_KQ K_A;
+#if defined(AMD_WMMA_AVAILABLE)
+                    if (DKQ > 128) {
+                        load_ldmatrix(K_A, K_h2 + int64_t(k_VKQ_0 + i_KQ_0)*stride_K + k_KQ_0, stride_K);
+                    } else
+#endif // AMD_WMMA_AVAILABLE
                     load_ldmatrix(K_A, tile_K + i_KQ_0*stride_tile_K + (k_KQ_0 - k0_start), stride_tile_K);
 
                     if constexpr (cols_per_warp == 8) {
@@ -668,6 +692,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         }
 
         if constexpr (nstages <= 1) {
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128)
+#endif // AMD_WMMA_AVAILABLE
             __syncthreads(); // Only needed if tile_K == tile_V.
         }
     }
@@ -957,6 +984,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 
         if constexpr (nstages <= 1) {
             const int i0_diff = i0_stop - i0_start;
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128) {
+#endif // AMD_WMMA_AVAILABLE
             if (!V_is_K_view || i0_stop > 2*nbatch_K2) {
                 constexpr bool use_cp_async = nstages == 1;
                 flash_attn_ext_f16_load_tile<stride_tile_V, nwarps, nbatch_fa, use_cp_async, oob_check>
@@ -966,8 +996,19 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 }
                 __syncthreads();
             }
+#if defined(AMD_WMMA_AVAILABLE)
+            } else {
+                GGML_UNUSED(i0_diff);
+            }
+#endif // AMD_WMMA_AVAILABLE
         }
+#if defined(AMD_WMMA_AVAILABLE)
+        const half2 * tile_V_i = DKQ > 128 ?
+            V_h2 + int64_t(k_VKQ_0)*stride_V + i0_start/2 :
+            (!V_is_K_view || i0_stop > 2*nbatch_K2 ? tile_V : tile_V + i0_start/2);
+#else
         const half2 * tile_V_i = !V_is_K_view || i0_stop > 2*nbatch_K2 ? tile_V : tile_V + i0_start/2;
+#endif // AMD_WMMA_AVAILABLE
 
 #if defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE)
 #pragma unroll
@@ -978,6 +1019,11 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
                 const int k0 = k00 + (threadIdx.y % np)*T_A_VKQ::J;
 
                 T_A_VKQ A; // Transposed in SRAM but not in registers, gets transposed on load.
+#if defined(AMD_WMMA_AVAILABLE)
+                if (DKQ > 128) {
+                    load_ldmatrix_trans(A, tile_V_i + 2*k0*stride_V + (i_VKQ_0 - i0_start)/2, stride_V);
+                } else
+#endif // AMD_WMMA_AVAILABLE
                 load_ldmatrix_trans(A, tile_V_i + 2*k0*stride_tile_V + (i_VKQ_0 - i0_start)/2, stride_tile_V);
                 if constexpr (T_B_KQ::I == 8) {
                     mma(VKQ_C[i_VKQ_0/T_A_VKQ::I], A, B[k00/(np*T_A_VKQ::J)]);
@@ -1011,6 +1057,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #endif // defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE)
 
         if constexpr (nstages <= 1) {
+#if defined(AMD_WMMA_AVAILABLE)
+            if (DKQ <= 128)
+#endif // AMD_WMMA_AVAILABLE
             __syncthreads(); // Only needed if tile_K == tile_V.
         }
     }

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -157,8 +157,8 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
 
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256,  8,  64, 2,  32, 128, 128, 128, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 16,  64, 2,  32, 128, 128, 128, 1, true);
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 32, 128, 2,  64, 128, 128,  64, 1, true);
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 128, 2,  64, 128, 128,  64, 1, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 32, 128, 2,  64, 128, 128, 128, 1, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 128, 2,  64, 128, 128, 128, 1, true);
 
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(320, 256, 32, 128, 2,  32, 160, 128, 128, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(320, 256, 64, 128, 2,  32, 160, 128, 128, 1, true);
@@ -1808,7 +1808,7 @@ static __global__ void flash_attn_ext_f16(
 #endif // __CUDA_ARCH__ == GGML_CUDA_CC_TURING
 
 #if defined(AMD_WMMA_AVAILABLE)
-    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 128) {
+    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 256) {
         NO_DEVICE_CODE;
         return;
     }

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -645,8 +645,13 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     }
 
     // AMD WMMA is always faster than the tile kernel if the full tile width of 16 can be utilized.
-    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 128) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
-        return BEST_FATTN_KERNEL_MMA_F16;
+    if (amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] != 40 && Q->ne[0] != 72) {
+        if (Q->ne[0] <= 128 && Q->ne[1] * gqa_ratio_eff > 8) {
+            return BEST_FATTN_KERNEL_MMA_F16;
+        }
+        if (Q->ne[0] <= 256 && Q->ne[1] * gqa_ratio_eff > 64) {
+            return BEST_FATTN_KERNEL_MMA_F16;
+        }
     }
 
     // If there are no tensor cores available, use the generic tile kernel:

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -512,8 +512,13 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     }
 
     // AMD WMMA is always faster than the tile kernel if the full tile width of 16 can be utilized.
-    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 128) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
-        return BEST_FATTN_KERNEL_MMA_F16;
+    if (amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] != 40 && Q->ne[0] != 72) {
+        if (Q->ne[0] <= 128 && Q->ne[1] * gqa_ratio_eff > 8) {
+            return BEST_FATTN_KERNEL_MMA_F16;
+        }
+        if (Q->ne[0] <= 256 && Q->ne[1] * gqa_ratio_eff > 64) {
+            return BEST_FATTN_KERNEL_MMA_F16;
+        }
     }
 
     // If there are no tensor cores available, use the generic tile kernel:

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -649,7 +649,7 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         if (Q->ne[0] <= 128 && Q->ne[1] * gqa_ratio_eff > 8) {
             return BEST_FATTN_KERNEL_MMA_F16;
         }
-        if (Q->ne[0] <= 256 && Q->ne[1] * gqa_ratio_eff > 64) {
+        if (GGML_CUDA_CC_IS_RDNA4(cc) && Q->ne[0] <= 256 && Q->ne[1] * gqa_ratio_eff > 64) {
             return BEST_FATTN_KERNEL_MMA_F16;
         }
     }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10614,6 +10614,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     // large-KV F16 cases (Qwen3.6-27B geometry and a llama-class control): the upstream matrix
     // stops at kv=1024, blind to long-context FA bugs (e.g. the oneDNN SDPA ordering race on BMG).
+    // For DKQ>128 on AMD WMMA, K/V bypass LDS but tile_mask stays in shared memory, so the end-of-loop
+    // barrier must still fire when a mask is active. kv=16384 with gqa_ratio>=4 (ncols2>=4) gives 256+
+    // attention loop iterations, stressing this synchronization path.
     for (int64_t kv : { 4096, 16384 }) {
         test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, kv, 512, true, false, 0, 0,
                                                         GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9594,6 +9594,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     // large-KV F16 cases (Qwen3.6-27B geometry and a llama-class control): the upstream matrix
     // stops at kv=1024, blind to long-context FA bugs (e.g. the oneDNN SDPA ordering race on BMG).
+    // For DKQ>128 on AMD WMMA, K/V bypass LDS but tile_mask stays in shared memory, so the end-of-loop
+    // barrier must still fire when a mask is active. kv=16384 with gqa_ratio>=4 (ncols2>=4) gives 256+
+    // attention loop iterations, stressing this synchronization path.
     for (int64_t kv : { 4096, 16384 }) {
         test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, kv, 512, true, false, 0, 0,
                                                         GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));


### PR DESCRIPTION
## Overview

Fixes #26220 

After the removal of rocWMMA Flash Attention kernel path, the replacement had slower prompt processing at deep context on RDNA 4. The regression was caused by WMMA tensor cores not being used at all for head dim 256.

This PR widens `flash_attn_ext_f16` device guard to unblock MMA at head dim 256. Without it, the tile kernel is used instead which works, but slows down with more context.  The config table also needed a precision fix for DKQ=256. `nbatch_combine` was too small, causing multi-pass FP16 accumulation errors in test-backend-ops.

Additionally, for DKQ>128 on WMMA K/V is loaded directly from VRAM instead of going through LDS. Without it, MMA is actually slower than the tile kernel.

## Additional information

Below are benchmark numbers to confirm no regressions and the speedup. It's worth to mention that, while prompt processing is faster than current master(a7a6d0d2), it's still about 12-20% slower the old rocWMMA kernel depending on context size. There's definitely room for further improvement.

GPU: AMD Radeon AI PRO R9700 (gfx1201, RDNA4), ROCm 7.2.4
Baseline: master a7a6d0d2, 3 runs per data point

test-backend-ops -o FLASH_ATTN_EXT: 2920/2920 passed

### Qwen3.6-35B-A3B Q4_K_M (head dim 256)

| Benchmark | Baseline (t/s) | PR (t/s) | Delta |
|-----------|----------------|----------|-------|
| pp4096 @ d0 | 2580 +/- 14 | 2592 +/- 12 | +0.4% |
| pp4096 @ d16384 | 1679 +/- 3 | 1907 +/- 8 | +13.6% |
| pp4096 @ d65536 | 832 +/- 0.4 | 990 +/- 0.6 | +19.1% |
| pp4096 @ d126976 | 511 +/- 0.02 | 623 +/- 0.4 | +21.8% |
| tg64 @ d0 | 87.1 +/- 1.7 | 86.9 +/- 1.7 | -0.2% |
| tg64 @ d16384 | 80.9 +/- 1.4 | 81.0 +/- 1.4 | +0.1% |
| tg64 @ d65536 | 69.0 +/- 0.9 | 69.0 +/- 0.8 | 0.0% |
| tg64 @ d126976 | 58.6 +/- 0.7 | 58.5 +/- 0.6 | -0.3% |

### Why LDS bypass is needed (Qwen3.6-35B-A3B, MMA enabled but without LDS bypass)

| Benchmark | Baseline/tile (t/s) | MMA without LDS bypass (t/s) | Delta |
|-----------|---------------------|------------------------------|-------|
| pp4096 @ d0 | 2584 | 2536 | -1.9% |
| pp4096 @ d16384 | 1680 | 1719 | +2.3% |
| pp4096 @ d65536 | 831 | 761 | -8.4% |
| pp4096 @ d126976 | 510 | 458 | -10.3% |

### Llama-3.1-8B-Instruct Q4_K_M (head dim 128, regression check)

| Benchmark | Baseline (t/s) | PR (t/s) | Delta |
|-----------|----------------|----------|-------|
| pp4096 @ d0 | 3817 +/- 3 | 3830 +/- 2 | +0.3% |
| pp4096 @ d16384 | 2068 +/- 5 | 2077 +/- 3 | +0.4% |
| pp4096 @ d65536 | 917 +/- 0.3 | 917 +/- 0.3 | 0.0% |
| pp4096 @ d126976 | 539 +/- 0.6 | 539 +/- 0.6 | 0.0% |
| tg64 @ d0 | 99.3 +/- 0.4 | 99.6 +/- 0.5 | +0.4% |
| tg64 @ d16384 | 74.8 +/- 0.1 | 75.0 +/- 0.2 | +0.3% |
| tg64 @ d65536 | 42.7 +/- 0.04 | 42.7 +/- 0.06 | 0.0% |
| tg64 @ d126976 | 27.8 +/- 0.02 | 27.8 +/- 0.02 | 0.0% |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used antigravity harness with Gemini/Opus to write the code, ran the benchmarks to confirm the numbers and tested the changes locally using llama server with the same model used to run the benchmarks.