### PR TITLE
sampling : fix heap corruption in llama_sampler_init_dry_testing

### DIFF
--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -3451,6 +3451,12 @@ struct llama_sampler * llama_sampler_init_dry(const struct llama_vocab * vocab, 
 struct llama_sampler * llama_sampler_init_dry_testing(float dry_multiplier, float dry_base, int32_t dry_allowed_length, int32_t dry_penalty_last_n, const std::vector<std::vector<llama_token>>& seq_breakers) {
     llama_vocab dummy_vocab;
     auto * result = llama_sampler_init_dry(&dummy_vocab, dry_multiplier, dry_base, dry_allowed_length, dry_penalty_last_n, NULL, 0);
+
+    // when DRY is disabled, llama_sampler_init_dry() returns a no-op sampler whose ctx is not a llama_sampler_dry
+    if (result->iface != &llama_sampler_dry_i) {
+        return result;
+    }
+
     auto * ctx = (llama_sampler_dry *) result->ctx;
 
     // Process the token-based sequence breakers

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -359,6 +359,10 @@ int main(void) {
     test_dry({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 3, 4, 0, 1}, {0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, 1.0f, 1.1f, 2, 6, {{3}});
     test_dry({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 1}, {0.241818f, 0.241818f, 0.032727f, 0.241818f, 0.241818f}, 2.0f, 1.1f, 2, 5, {});
     test_dry({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 3, 4, 0, 1}, {0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, 1.0f, 1.1f, 4, 7, {});
+    // disabled DRY configurations must be no-ops (multiplier == 0, base < 1, penalty_last_n == 0)
+    test_dry({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 1}, {0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, 0.0f, 1.1f, 2, 5, {{3}});
+    test_dry({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 1}, {0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, 1.0f, 0.0f, 2, 5, {{3}});
+    test_dry({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2, 0, 1}, {0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, 1.0f, 1.1f, 2, 0, {{3}});
 
     test_top_n_sigma({0.1f, 0.2f, 0.3f, 0.4f}, {0.0f, 0.0f, 0.428571f, 0.571429f}, 1.00f);
     test_top_n_sigma({0.1f, 0.2f, 0.3f, 0.4f}, {0.1f, 0.2f, 0.3f, 0.4f}, 0.00f); // top_n_sigma == 0 now represents a no-op rather than greedy decoding as of PR#13345


### PR DESCRIPTION
## Overview

`llama_sampler_init_dry_testing` casts `result->ctx` to `llama_sampler_dry *`, but with DRY disabled (`dry_multiplier == 0`, `dry_base < 1`, or `dry_penalty_last_n == 0`) `llama_sampler_init_dry` returns a no-op sampler whose ctx is not a `llama_sampler_dry`, so the write attempt corrupts the heap (segfault on release; ASAN aborts, with the exact report depending on base and toolchain).

The guard returns early when `result->iface != &llama_sampler_dry_i`. A no-op sampler has no breakers to install. The 3 added `test_dry` cases crash without it and pass with it.

## Additional information

The blind cast has been unsafe since the no-op early exit was added in #17004. No `test_dry` case combined a disabled config with breakers, so nothing caught it.

<details><summary>ASAN, unpatched master ec928150 (gcc 12)</summary>

```
==2641411==ERROR: AddressSanitizer: SEGV on unknown address 0x7963d8478870 (pc 0x7963d9844688 bp 0x7fff344ac090 sp 0x7fff344ac050 T0)
==2641411==The signal is caused by a WRITE memory access.
    #0 0x7963d9844688 in bool __sanitizer::atomic_compare_exchange_strong<__sanitizer::atomic_uint8_t>(__sanitizer::atomic_uint8_t volatile*, __sanitizer::atomic_uint8_t::Type*, __sanitizer::atomic_uint8_t::Type, __sanitizer::memory_order) ../../../../src/libsanitizer/sanitizer_common/sanitizer_atomic_clang.h:81
    #1 0x7963d9844688 in __asan::Allocator::AtomicallySetQuarantineFlagIfAllocated(__asan::AsanChunk*, void*, __sanitizer::BufferedStackTrace*) ../../../../src/libsanitizer/asan/asan_allocator.cpp:668
    [...]
    #16 0x7963d84ae5df in std::unordered_multimap<int, std::vector<int, std::allocator<int> >, std::hash<int>, std::equal_to<int>, std::allocator<std::pair<int const, std::vector<int, std::allocator<int> > > > >::clear() /usr/include/c++/12/bits/unordered_map.h:1736
    #17 0x7963d84ae5df in llama_sampler_init_dry_testing(float, float, int, int, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > > const&) src/llama-sampler.cpp:3696
    #18 0x5dd03767e2ef in test_dry tests/test-sampling.cpp:201
    #19 0x5dd037678649 in main tests/test-sampling.cpp:395
    [...]
SUMMARY: AddressSanitizer: SEGV ../../../../src/libsanitizer/sanitizer_common/sanitizer_atomic_clang.h:81 in bool __sanitizer::atomic_compare_exchange_strong<__sanitizer::atomic_uint8_t>(__sanitizer::atomic_uint8_t volatile*, __sanitizer::atomic_uint8_t::Type*, __sanitizer::atomic_uint8_t::Type, __sanitizer::memory_order)
```
</details>

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES: the bug was found and the fix drafted with AI assistance. I have reviewed and tested every line and am responsible for all submitted changes.


