### PR TITLE
opencl: extend, speed up and widen the MQ/cluster decode flash-attention (head sizes 64-512, GQA 2-16)

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -5869,9 +5869,21 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     const char * e = getenv("GGML_OPENCL_FA_Q8_MHRED");
                     return !(e && e[0] == '0');
                 }();
+                // Mask broadcast + hoist. The mask was read inside the per-head
+                // score loop, after the cluster reduce: deleting it outright
+                // measured +8.8/+14.0% at d4096/d8192, which is the entire
+                // remaining deficit against f16.
+                // GGML_OPENCL_FA_Q8_MASK_BCAST=0 opts out.
+                static const bool q8_maskb_on = []{
+                    const char * e = getenv("GGML_OPENCL_FA_Q8_MASK_BCAST");
+                    return !(e && e[0] == '0');
+                }();
+                const std::string opts_q8_maskb =
+                    q8_maskb_on ? " -D FA_CL_MASK_BCAST=1" : "";
                 const std::string opts_q8_g8c16 = opts +
                     " -D MQ_GQA=8 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16" +
-                    (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_int;
+                    (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_maskb +
+                    opts_q8_int;
                 cl_program prog_q8_g8c16 = build_program_from_source_ex(
                     backend_ctx->context, backend_ctx->device, src.c_str(), opts_q8_g8c16,
                     /*fatal=*/false, "fa q8_0 c16 GQA8 dk64", backend_ctx->queue);
@@ -5905,7 +5917,8 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     const std::string opts_q8_hs2 = opts +
                         " -D MQ_GQA=4 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16"
                         " -D FA_HEAD_SUB=2" +
-                        (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_int;
+                        (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_maskb +
+                        opts_q8_int;
                     cl_program prog_q8_hs2 = build_program_from_source_ex(
                         backend_ctx->context, backend_ctx->device, src.c_str(), opts_q8_hs2,
                         /*fatal=*/false, "fa q8_0 c16 GQA4 hs2 dk64", backend_ctx->queue);

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -5880,9 +5880,22 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 }();
                 const std::string opts_q8_maskb =
                     q8_maskb_on ? " -D FA_CL_MASK_BCAST=1" : "";
+                // Stage the mask a subgroup-block at a time: over FA_CL_C
+                // iterations the clusters touch Q1_WG_SIZE consecutive
+                // positions, so one coalesced load plus shuffles replaces
+                // FA_CL_C scattered ones. Needs the broadcast path (that is
+                // what makes the value one-per-position). Costs no LDS, which
+                // matters because this kernel is occupancy-bound.
+                // GGML_OPENCL_FA_Q8_MASK_SG=0 opts out.
+                static const bool q8_masksg_on = []{
+                    const char * e = getenv("GGML_OPENCL_FA_Q8_MASK_SG");
+                    return !(e && e[0] == '0');
+                }();
+                const std::string opts_q8_masksg =
+                    (q8_maskb_on && q8_masksg_on) ? " -D FA_CL_MASK_SG=1" : "";
                 const std::string opts_q8_g8c16 = opts +
                     " -D MQ_GQA=8 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16" +
-                    (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_maskb +
+                    (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_maskb + opts_q8_masksg +
                     opts_q8_int;
                 cl_program prog_q8_g8c16 = build_program_from_source_ex(
                     backend_ctx->context, backend_ctx->device, src.c_str(), opts_q8_g8c16,
@@ -5917,7 +5930,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                     const std::string opts_q8_hs2 = opts +
                         " -D MQ_GQA=4 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16"
                         " -D FA_HEAD_SUB=2" +
-                        (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_maskb +
+                        (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_maskb + opts_q8_masksg +
                         opts_q8_int;
                     cl_program prog_q8_hs2 = build_program_from_source_ex(
                         backend_ctx->context, backend_ctx->device, src.c_str(), opts_q8_hs2,

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -513,6 +513,11 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_c8;
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8_c8;  // GQA8 cluster (dk=64)
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_hs2;
+    // Per-shape workgroup size and head-split factor for the above. fa_hs_wg /
+    // fa_hs_sub below are single scalars written by the DK=64 build site; once a
+    // second head dimension builds the same family they stop being unambiguous.
+    std::map<std::pair<int, int>, int>       f32_f16_q1_vec_mq_split_g8_hs2_wg;
+    std::map<std::pair<int, int>, int>       f32_f16_q1_vec_mq_split_g8_hs2_sub;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_gqa4_hs2;
     // q1_vec_mq_split built alone (FA_MQ_SPLIT_ONLY) for a specific
     // (dk, dv, gqa), with its own MQ_NSG_SPLIT / FA_HEAD_SUB. Used where the
@@ -5558,6 +5563,83 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                         }
                         clReleaseProgram(prog_gn);
                     }
+                }
+            }
+            // gqa=8 at DK=128 served by an MQ_GQA=4 kernel spread over
+            // FA_HEAD_SUB workgroups per KV head. That treatment exists only at
+            // dk=64 today, and dk=64 is where it turned gpt-oss from a loss into
+            // a win. The dk=128 evidence points the same way: every dk=128 model
+            // that GAINS from -fa 1 at depth on the X2-90 (Qwen3-4B, Qwen3-8B,
+            // Llama-3-8B, +11..17% tg @d8192) runs MQ_GQA=4, and the one that
+            // LOSES ~20% there (Qwen3-30B-A3B) is the only dk=128 shape running
+            // MQ_GQA=8. Cost is the usual head-split trade: per-lane o_acc/m_i/
+            // l_i/slope halve and the grid doubles, paying one extra read of
+            // each KV row.
+            //
+            // Deliberately the GQA4 c8 options plus FA_HEAD_SUB and nothing else
+            // -- no MHRED, no mask broadcast -- so the measurement attributes to
+            // the head split alone rather than to a bundle.
+            //
+            // DEFAULT ON, opt out with GGML_OPENCL_FA_G8_HS_DK128=0. No device
+            // predicate, matching the gqa 4 / 8 arms it sits beside: all three
+            // generations that reach this dispatch were measured and none
+            // inverts. Per-op (test-backend-ops perf, dk=128 gqa=8 f16, nb=1),
+            // route off -> on:
+            //
+            //   X2-90       kv4096  552 ->  368 us (+50%)   kv8192 1100 ->  725 (+52%)
+            //   840  (A8X)  kv4096 2082 -> 1144 us (+82%)   kv8192 3470 -> 2235 (+55%)
+            //   X1-85 (X1E) kv4096 1596 ->  751 us (+112%)  kv8192 3214 -> 1466 (+119%)
+            //
+            // FLASH_ATTN_EXT is 0 FAIL in both routings on each of them, matching
+            // that device's own unpatched baseline (X2 2696 OK, 840 2699, X1-85
+            // 2696). End-to-end is X2-only on purpose: Qwen3-30B-A3B is the
+            // fleet's only dk=128 gqa=8 model and neither the 840 (19.5 GB
+            // MemAvailable) nor X1-85 (~6 GB per-context cap) can hold it, so the
+            // per-op number is what carries the other two generations.
+            static const bool g8_hs_dk128_on = []{
+                const char * e = std::getenv("GGML_OPENCL_FA_G8_HS_DK128");
+                return !(e != nullptr && e[0] == '0');
+            }();
+            if (!fa_decode_only && dk == 128 && dv == 128 &&
+                backend_ctx->has_subgroup_shuffle && g8_hs_dk128_on) {
+                // 4 is the measured optimum, not an extrapolation. X2-90 tg128 at
+                // d4096/d8192: 31.1/24.7 at FA_HEAD_SUB=2, 33.0/25.7 at 4, and
+                // 30.5/23.3 at 8 -- MQ_GQA=1 overshoots and lands BELOW 2, so the
+                // grid mechanism saturates here rather than continuing.
+                static const int hs_n = []{
+                    const char * e = std::getenv("GGML_OPENCL_FA_G8_HS_DK128_SUB");
+                    const int v = (e && e[0]) ? atoi(e) : 4;
+                    return (v == 2 || v == 4 || v == 8) ? v : 4;
+                }();
+                static const int hs_nsg = []{
+                    const char * e = std::getenv("GGML_OPENCL_FA_G8_HS_DK128_NSG");
+                    const int v = (e && e[0]) ? atoi(e) : 2;
+                    return (v >= 1 && v <= 4) ? v : 2;
+                }();
+                const size_t hs_wg = (size_t) (64 * hs_nsg);
+                const std::string opts_hs = opts +
+                    " -D FA_MQ_ONLY -D MQ_GQA=" + std::to_string(8 / hs_n) +
+                    " -D MQ_NSG=" + std::to_string(hs_nsg) +
+                    " -D MQ_NSG_SPLIT=" + std::to_string(hs_nsg) +
+                    " -D FA_HEAD_SUB=" + std::to_string(hs_n) + opts_cl_c_gqa4;
+                const std::string tag_hs = "fa f32_f16 MQ_GQA=" + std::to_string(8 / hs_n) +
+                    " dk128 g8 headsub" + std::to_string(hs_n) + " wg" + std::to_string(hs_wg);
+                cl_program prog_hs = build_program_from_source_ex(
+                    backend_ctx->context, backend_ctx->device, src.c_str(), opts_hs,
+                    /*fatal=*/false, tag_hs.c_str(), backend_ctx->queue);
+                if (prog_hs) {
+                    cl_kernel k_hs = clCreateKernel(prog_hs, "flash_attn_f32_f16_q1_vec_mq_split_c8", &err);
+                    if (err == CL_SUCCESS) {
+                        if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_hs, hs_wg, tag_hs.c_str(), dk, dv)) {
+                            backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2[{dk, dv}]     = k_hs;
+                            backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2_wg[{dk, dv}]  = (int) hs_wg;
+                            backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2_sub[{dk, dv}] = hs_n;
+                            ggml_opencl_log_fa_kernel_spill(backend_ctx, k_hs, tag_hs.c_str(), dk, dv);
+                        } else {
+                            clReleaseKernel(k_hs);
+                        }
+                    }
+                    clReleaseProgram(prog_hs);
                 }
             }
             // NSG_SPLIT=2 programs for the cluster-parallel kernel: its register
@@ -16014,6 +16096,20 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_c32.at(dk_dv);
                 use_fd_mq  = true;
                 fd_mq_wg   = 128;
+            // Head-split g8 at DK=128 (Qwen3-30B-A3B class): MQ_GQA=4 over
+            // FA_HEAD_SUB workgroups per KV head. Checked BEFORE the stock g8
+            // cluster branch below so the A/B is one route against the other in
+            // the same binary; the program only exists when its build-side
+            // opt-in is set, so the default path is untouched.
+            } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 8 &&
+                d_head_q == 128 && d_head_v == 128 &&
+                n_head == n_head_kv * 8 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2.count(dk_dv) > 0 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2_wg.count(dk_dv) > 0) {
+                fd_k_split  = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2.at(dk_dv);
+                use_fd_mq   = true;
+                fd_mq_wg    = (size_t) backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2_wg.at(dk_dv);
+                fd_head_sub = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2_sub.at(dk_dv);
             // Cluster-parallel decode for the g8
             } else if (is_mixed && gqa_ratio_dispatch == 8 &&
                 d_head_q == 128 && d_head_v == 128 &&

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -513,7 +513,16 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_c8;
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8_c8;  // GQA8 cluster (dk=64)
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_hs2;
-    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_gqa4_hs2;  // gqa4 via MQ_GQA=2 x 2 WGs  // gqa8 via MQ_GQA=4 x 2 WGs
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_gqa4_hs2;
+    // q1_vec_mq_split built alone (FA_MQ_SPLIT_ONLY) for a specific
+    // (dk, dv, gqa), with its own MQ_NSG_SPLIT / FA_HEAD_SUB. Used where the
+    // shared program either cannot hold the MQ family (DK=512) or produces a
+    // kernel the device refuses to launch at the required workgroup size
+    // (DK=256 gqa=8: per-kernel max 128 < required 192 on the X2-90).
+    std::map<std::tuple<int, int, int>, cl_kernel> mq_narrow;
+    std::map<std::tuple<int, int, int>, cl_kernel> mq_narrow_k_img;  // same, K as image1d_buffer_t
+    std::map<std::tuple<int, int, int>, int>       mq_narrow_wg;
+    std::map<std::tuple<int, int, int>, int>       mq_narrow_hs;  // gqa4 via MQ_GQA=2 x 2 WGs  // gqa8 via MQ_GQA=4 x 2 WGs
     int fa_hs_wg  = 128;  // workgroup size of the head-split program
     int fa_hs_sub = 2;    // FA_HEAD_SUB it was built with
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0;               // prefill (baseline)
@@ -4899,6 +4908,128 @@ static bool ggml_opencl_ensure_fa_f32_f16_prefill_512(ggml_backend_opencl_contex
     return true;
 }
 
+// DK=512 (Gemma-4 global layers) decode: q1_vec in its own minimal program.
+//
+// The shared DK=512 decode program is built -D FA_DECODE_MINIMAL, which drops
+// q1_vec, because its DV=512 vector arrays dominate the shader compiler's host
+// memory and made the build fragile. The fallback is flash_attn_f32_f16_q1,
+// whose ACC_TYPE4 o_acc[DV_VEC] is 2 KB of private array per work item at
+// DV=512 — it spills to DDR, walks K twice, and runs on n_head workgroups with
+// no K-split. Measured on gemma-4-E4B @d4096 (X2-90): ~30 ms/token for the 7
+// global layers = 3.9 GB/s against a ~130 GB/s roofline.
+//
+// FA_VEC_ONLY isolates q1_vec exactly as FA_PREFILL_ONLY isolates the BM tile,
+// so the compiler only ever sees one kernel. Best-effort: on failure the
+// dispatch falls back to q1 as before.
+static bool ggml_opencl_ensure_fa_f32_f16_vec_512(ggml_backend_opencl_context * backend_ctx) {
+    const int dk = 512, dv = 512;
+    const std::pair<int, int> dk_dv = {dk, dv};
+    if (backend_ctx->fa.f32_f16_q1_vec.count(dk_dv) > 0) return true;
+
+    static bool failed = false;
+    if (failed) return false;
+
+    const ggml_opencl_fa_dim * cfg = nullptr;
+    for (const auto & d : g_opencl_fa_dims) {
+        if (d.dk == dk && d.dv == dv) { cfg = &d; break; }
+    }
+    if (cfg == nullptr) { failed = true; return false; }
+
+    const std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, FA_VARIANT_F32_F16) +
+                             " -D FA_DECODE_ONLY -D FA_VEC_ONLY";
+    cl_program prog = build_program_from_source_ex(
+        backend_ctx->context, backend_ctx->device,
+        ggml_opencl_fa_kernel_src(FA_VARIANT_F32_F16).c_str(), opts,
+        /*fatal=*/false, "fa f32_f16 decode512 vec", backend_ctx->queue);
+    if (!prog) { failed = true; return false; }
+
+    cl_int err;
+    cl_kernel k = clCreateKernel(prog, "flash_attn_f32_f16_q1_vec", &err);
+    if (err != CL_SUCCESS) { clReleaseProgram(prog); failed = true; return false; }
+    if (!ggml_opencl_fa_kernel_fits_wg(backend_ctx, k, 256,
+                                       "flash_attn_f32_f16_q1_vec (decode512)", dk, dv)) {
+        clReleaseKernel(k);
+        clReleaseProgram(prog);
+        failed = true;
+        return false;
+    }
+    backend_ctx->fa.f32_f16_q1_vec[dk_dv] = k;
+    ggml_opencl_log_fa_kernel_spill(backend_ctx, k, "flash_attn_f32_f16_q1_vec (decode512)", dk, dv);
+    clReleaseProgram(prog);
+    return true;
+}
+
+// DK=512 decode, KV-head-coalesced + flash-decoding split, in its own program.
+//
+// q1_vec still reads the KV cache once per QUERY head: gemma-4-E4B is
+// n_head 8 / n_head_kv 2, so its global layers stream 4x more KV than they
+// have to (E2B, n_head_kv 1, streams 8x). The MQ split kernel gives one
+// workgroup all MQ_GQA query heads of a KV head — the KV row is read once and
+// shared — and splits n_kv across workgroups, which the DK=512 decode path has
+// never had (q1/q1_vec run n_head workgroups, no K-split).
+//
+// FA_MQ_ONLY drops the prefill tile and the legacy decode kernels;
+// FA_MQ_SPLIT_ONLY additionally drops q1_vec_mq, the cluster (c8) forms and the
+// K-image form, leaving exactly one kernel — the same isolation trick that lets
+// the BM tile and q1_vec build at DK=512 at all.
+// head_sub > 1 runs an MQ_GQA = gqa/head_sub program on head_sub workgroups per
+// KV head: per-head lane state (o_acc, m_i, l_i, slope) shrinks by that factor
+// and the grid grows by it, paying one extra read of each KV row. At DV=512 the
+// per-head state is large (E2B's gqa=8 form measures 752 B/work-item, past the
+// 512 B occupancy cliff) and the grid is small (E2B has a single KV head), so
+// both sides of that trade point the same way.
+static bool ggml_opencl_ensure_fa_mq_narrow(ggml_backend_opencl_context * backend_ctx,
+                                           int dk, int dv, int gqa, int head_sub, int nsg_split,
+                                           bool k_img) {
+    const std::tuple<int, int, int> key = {dk, dv, gqa};
+    const int mq_gqa = gqa / head_sub;
+    auto & target = k_img ? backend_ctx->fa.mq_narrow_k_img : backend_ctx->fa.mq_narrow;
+    if (target.count(key) > 0) return true;
+
+    static std::set<std::tuple<int, int, int, int>> failed;
+    const std::tuple<int, int, int, int> fkey = {dk, dv, gqa, k_img ? 1 : 0};
+    if (failed.count(fkey) > 0) return false;
+
+    const ggml_opencl_fa_dim * cfg = nullptr;
+    for (const auto & d : g_opencl_fa_dims) {
+        if (d.dk == dk && d.dv == dv) { cfg = &d; break; }
+    }
+    if (cfg == nullptr) { failed.insert(fkey); return false; }
+
+    const size_t wg = (size_t) 64 * nsg_split;
+    const std::string opts = ggml_opencl_fa_compile_opts(backend_ctx, cfg, FA_VARIANT_F32_F16) +
+                             " -D FA_MQ_ONLY -D FA_MQ_SPLIT_ONLY -D MQ_GQA=" + std::to_string(mq_gqa) +
+                             " -D MQ_NSG_SPLIT=" + std::to_string(nsg_split) +
+                             " -D FA_HEAD_SUB=" + std::to_string(head_sub) +
+                             (k_img ? " -D FA_MQ_KIMG" : "");
+    const std::string tag = std::string("fa f32_f16 mq_split narrow") + (k_img ? " k_img" : "") +
+                            " dk" + std::to_string(dk) +
+                            " gqa" + std::to_string(gqa) + " mq" + std::to_string(mq_gqa) +
+                            " hs" + std::to_string(head_sub) + " wg" + std::to_string(wg);
+    cl_program prog = build_program_from_source_ex(
+        backend_ctx->context, backend_ctx->device,
+        ggml_opencl_fa_kernel_src(FA_VARIANT_F32_F16).c_str(), opts,
+        /*fatal=*/false, tag.c_str(), backend_ctx->queue);
+    if (!prog) { failed.insert(fkey); return false; }
+
+    cl_int err;
+    cl_kernel k = clCreateKernel(prog,
+        k_img ? "flash_attn_f32_f16_q1_vec_mq_split_k_img" : "flash_attn_f32_f16_q1_vec_mq_split", &err);
+    if (err != CL_SUCCESS) { clReleaseProgram(prog); failed.insert(fkey); return false; }
+    if (!ggml_opencl_fa_kernel_fits_wg(backend_ctx, k, wg, tag.c_str(), dk, dv)) {
+        clReleaseKernel(k);
+        clReleaseProgram(prog);
+        failed.insert(fkey);
+        return false;
+    }
+    target[key]                       = k;
+    backend_ctx->fa.mq_narrow_wg[key] = (int) wg;
+    backend_ctx->fa.mq_narrow_hs[key] = head_sub;
+    ggml_opencl_log_fa_kernel_spill(backend_ctx, k, tag.c_str(), dk, dv);
+    clReleaseProgram(prog);
+    return true;
+}
+
 // Compile one (variant, dk, dv); memoised. false = compiler rejected.
 static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_ctx, int dk, int dv, ggml_opencl_fa_variant variant) {
     const std::pair<int, int> dk_dv = {dk, dv};
@@ -8206,10 +8337,24 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                     return false;
                 }
                 if (q->ne[1] == 1) {
-                    // DK=512 decode is bandwidth-bound and slower on the GPU
-                    // than on the CPU; decline it here so it runs on the CPU.
-                    // Prefill (n_q > 1) stays on the GPU.
-                    return false;
+                    // Declining DK=512 decode is NOT free: it makes every
+                    // global-attention layer a CPU island whose K and V views
+                    // (8.4 MB each at n_kv=4096) are copied device->host every
+                    // token - 17 graph splits against 3, and ~13 ms/token of
+                    // host time on gemma-4-E4B. It was still the better trade
+                    // while the only DK=512 decode kernel was q1, which holds
+                    // 2 KB/work-item of o_acc at DV=512 and spills it. With the
+                    // DV-split q1_vec and the KV-head-coalescing split kernel
+                    // (both built in their own minimal programs below) keeping
+                    // it on the GPU wins 44-61% tg at depth on the X2-90 and
+                    // 34-36% on the A8X. Opt out: GGML_OPENCL_FA_DK512_DECODE=0.
+                    static const char * dk512_env = getenv("GGML_OPENCL_FA_DK512_DECODE");
+                    if (dk512_env != NULL && dk512_env[0] == '0') {
+                        return false;
+                    }
+                    if (!ggml_opencl_ensure_fa_f32_f16_vec_512(backend_ctx)) {
+                        return false;
+                    }
                 } else {
                     // prefill, BM-tile in its own FA_PREFILL_ONLY program
                     if (!ggml_opencl_ensure_fa_f32_f16_prefill_512(backend_ctx, /*split=*/false)) {
@@ -15351,6 +15496,13 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     } else if (is_mixed) {
         ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_F32_F16);
         if (fa_decode_only_512) {
+            // DK=512 decode: q1_vec lives in its own FA_VEC_ONLY program (the
+            // shared decode program must drop it to stay under the compiler's
+            // host-memory ceiling). Without it decode falls back to q1, which
+            // spills 2 KB/work-item of o_acc at DV=512.
+            if (n_q == 1) {
+                ggml_opencl_ensure_fa_f32_f16_vec_512(backend_ctx);
+            }
             // DK=512: the BM-tile prefill kernels are specifically compiled from
             // FA_PREFILL_ONLY
             if (n_q > 1) {
@@ -15380,6 +15532,52 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         }
     } else {
         ggml_opencl_ensure_fa_variant(backend_ctx, d_head_q, d_head_v, FA_VARIANT_F32);
+    }
+
+    // Narrow (one-kernel) MQ split programs for the shapes where the shared
+    // program cannot serve decode: gemma-4's DK=512 global layers (the MQ
+    // family does not fit the compiler there) and its DK=256 gqa=8 SWA layers
+    // (the stock g8 kernel needs a 192-thread workgroup, which the X2-90
+    // refuses per-kernel). Both otherwise fall back to a per-query-head kernel
+    // that re-reads the KV cache gqa times.
+    if (n_q == 1 && is_mixed && d_head_q == d_head_v &&
+        (d_head_q == 512 || d_head_q == 256) && n_head_kv > 0) {
+        const int gqa = n_head / n_head_kv;
+        if (gqa == 4 || gqa == 8) {
+            // hs/nsg defaults are per-shape measurements on the X2-90; the env
+            // knobs exist to re-tune them elsewhere. DK=256 gqa=8 must stay at
+            // a 128-thread workgroup - the stock 192-thread g8 kernel is what
+            // the X2-90 refuses per-kernel.
+            int hs  = (d_head_q == 512) ? ((gqa == 8) ? 4 : 1) : ((gqa == 8) ? 2 : 1);
+            int nsg = (d_head_q == 256 && gqa == 8) ? 2 : 4;
+            static const int hs_env  = []{ const char * e = getenv("GGML_OPENCL_FA_MQN_HS");
+                                           return (e && e[0]) ? atoi(e) : 0; }();
+            static const int nsg_env = []{ const char * e = getenv("GGML_OPENCL_FA_MQN_NSG");
+                                           return (e && e[0]) ? atoi(e) : 0; }();
+            if (hs_env  > 0) hs  = hs_env;
+            if (nsg_env > 0) nsg = nsg_env;
+            // K through the texture cache (image1d_buffer_t) instead of a plain
+            // buffer. Measured on the X2-90 (palindromed, non-overlapping):
+            // E4B (gqa=4, head_sub=1) +3.5% @d4096 / +3.8% @d8192, but E2B
+            // (gqa=8, head_sub=4) -4.5% / -9.3%. The split tracks head_sub: with
+            // head_sub > 1 every KV row is re-read by that many workgroups, and
+            // the texture path's per-access latency is paid on each re-read
+            // instead of being amortised over one streaming pass. So enable it
+            // only where one workgroup owns the whole gqa group.
+            // GGML_OPENCL_FA_MQN_KIMG=0/1 forces it either way.
+            static const int mqn_kimg_env = []{
+                const char * e = getenv("GGML_OPENCL_FA_MQN_KIMG");
+                if (e == NULL || e[0] == 0) return -1;
+                return (e[0] != '0') ? 1 : 0;
+            }();
+            const bool mqn_kimg = (mqn_kimg_env >= 0) ? (mqn_kimg_env == 1) : (hs == 1);
+            if (gqa % hs == 0) {
+                ggml_opencl_ensure_fa_mq_narrow(backend_ctx, d_head_q, d_head_v, gqa, hs, nsg, false);
+                if (mqn_kimg) {
+                    ggml_opencl_ensure_fa_mq_narrow(backend_ctx, d_head_q, d_head_v, gqa, hs, nsg, true);
+                }
+            }
+        }
     }
 
     const std::pair<int, int> dk_dv = {d_head_q, d_head_v};
@@ -15692,10 +15890,26 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             const char * e = getenv("GGML_OPENCL_FD_MIN_N_KV_MQ");
             return (e && e[0]) ? atoi(e) : FD_MIN_N_KV;
         }();
+        // A shape with a narrow (purpose-built) MQ kernel carries its own,
+        // much lower n_kv floor. Those kernels exist only for shapes whose
+        // alternative is a per-query-head kernel re-reading the KV cache gqa
+        // times, so the KV-sharing win starts well below the split-tuned
+        // FD_MIN_N_KV -- and gemma-4's sliding window caps n_kv at 1024/256 on
+        // most layers, which would otherwise never reach any MQ route. Scoped
+        // to those shapes so no other model's decode routing changes.
+        static const int mq_narrow_min_n_kv = []{
+            const char * e = getenv("GGML_OPENCL_FA_MQN_MIN_N_KV");
+            return (e && e[0]) ? atoi(e) : 128;
+        }();
+        const bool have_mq_narrow =
+            backend_ctx->fa.mq_narrow.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0;
+        const int mq_n_kv_floor = have_mq_narrow
+            ? std::min(fd_min_n_kv_mq, mq_narrow_min_n_kv)
+            : fd_min_n_kv_mq;
         if (mq_enabled && mq_kv_ok && nq_in_vec_range && !is_causal &&
             backend_ctx->gpu_family != INTEL &&
             !use_local_tile &&
-            n_kv >= fd_min_n_kv_mq &&
+            n_kv >= mq_n_kv_floor &&
             backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
             if (nq1_only && lmq_on && is_mixed && d_head_q == 128 && d_head_v == 128 &&
                 gqa_ratio_dispatch == 8 &&
@@ -15717,6 +15931,21 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 use_fd_mq   = true;
                 fd_mq_wg    = 128;
                 fd_head_sub = 2;
+            // Narrow one-kernel MQ split program (gemma-4 DK=512 global layers
+            // and DK=256 gqa=8 SWA layers). Carries its own workgroup size and
+            // FA_HEAD_SUB, both chosen when it was built.
+            } else if (nq1_only && is_mixed &&
+                backend_ctx->fa.mq_narrow.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0) {
+                const std::tuple<int, int, int> nk = {d_head_q, d_head_v, gqa_ratio_dispatch};
+                if (backend_ctx->fa.mq_narrow_k_img.count(nk) > 0) {
+                    fd_k_split   = backend_ctx->fa.mq_narrow_k_img.at(nk);
+                    use_fa_k_img = true;
+                } else {
+                    fd_k_split   = backend_ctx->fa.mq_narrow.at(nk);
+                }
+                use_fd_mq   = true;
+                fd_mq_wg    = (size_t) backend_ctx->fa.mq_narrow_wg.at(nk);
+                fd_head_sub = backend_ctx->fa.mq_narrow_hs.at(nk);
             } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
                 ((d_head_q == 256 && d_head_v == 256) ||
                  (d_head_q == 128 && d_head_v == 128)) &&
@@ -16169,7 +16398,9 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                     k_pixels, (size_t) backend_ctx->image_max_buffer_size);
             }
             if (k_img == nullptr) {
-                if (backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0) {
+                if (backend_ctx->fa.mq_narrow.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0) {
+                    k_split = backend_ctx->fa.mq_narrow.at({d_head_q, d_head_v, gqa_ratio_dispatch});
+                } else if (backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0) {
                     k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.at({d_head_q, d_head_v, gqa_ratio_dispatch});
                 } else if (gqa_ratio_dispatch == 4 &&
                     backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -43,6 +43,7 @@ typedef const void * (*get_adreno_bin_kernel_func_t)(
 #include <string>
 #include <cmath>
 #include <map>
+#include <tuple>
 #include <memory>
 #include <charconv>
 #include <mutex>
@@ -468,6 +469,12 @@ struct ggml_opencl_fa_kernels {
     // MQ_GQA=8 specializations
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_g8;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8;
+    // MQ_GQA=2/3 specializations, key {dk, dv, gqa}: without them non-GQA4
+    // models (e.g. gqa=3 Llama-3.2) fall back to the register-spilled
+    // q1_split kernels at depth.
+    std::map<std::tuple<int, int, int>, cl_kernel> f32_f16_q1_vec_mq_split_gqa;
+    std::map<std::tuple<int, int, int>, cl_kernel> f32_f16_q1_vec_mq_split_gqa_k_img;
+    std::map<std::tuple<int, int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_gqa;
     // k-image variant of MQ_G8 vec_mq_split
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_k_img;
     // k-image variant of MQ_GQA=4 vec_mq_split
@@ -504,6 +511,11 @@ struct ggml_opencl_fa_kernels {
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8;
     // Cluster-parallel q8_0 decode
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_c8;
+    std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8_c8;  // GQA8 cluster (dk=64)
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_hs2;
+    std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_gqa4_hs2;  // gqa4 via MQ_GQA=2 x 2 WGs  // gqa8 via MQ_GQA=4 x 2 WGs
+    int fa_hs_wg  = 128;  // workgroup size of the head-split program
+    int fa_hs_sub = 2;    // FA_HEAD_SUB it was built with
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0;               // prefill (baseline)
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_split;         // N_SPLIT>1 variant
     std::map<std::pair<int, int>, int>       f32_q8_0_split_wg_size;        // wg_size = bm*n_split
@@ -535,6 +547,15 @@ struct ggml_opencl_fa_kernels {
     // attempted (variant, (dk, dv))
     // all attempted FA kernels appear here, but those not registered failed compilation
     std::set<std::pair<int, std::pair<int, int>>> variant_attempted;
+
+    // Flash-decoding partials scratch, reused across FA calls. Decode issues
+    // one FD dispatch per attention layer, so a per-call clCreateBuffer /
+    // clReleaseMemObject pair costs one driver round-trip per layer per token.
+    // Reuse is safe on the in-order queue: the split kernel fully writes the
+    // range the immediately following merge reads, and no FA call outlives its
+    // own merge.
+    cl_mem fd_partial_pool      = nullptr;
+    size_t fd_partial_pool_size = 0;
 };
 
 // backend context
@@ -1123,6 +1144,13 @@ struct ggml_backend_opencl_context {
             write_profiling_info();
             profiling_results.clear();
 #endif
+            // Release the flash-decoding partials scratch.
+            if (fa.fd_partial_pool) {
+                CL_CHECK(clReleaseMemObject(fa.fd_partial_pool));
+                fa.fd_partial_pool      = nullptr;
+                fa.fd_partial_pool_size = 0;
+            }
+
             // release pooled image1d_buffer views over KV cache layers.
             for (auto & kv : kq_img_pool) {
                 if (kv.second.image)      { CL_CHECK(clReleaseMemObject(kv.second.image)); }
@@ -4995,6 +5023,24 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
     const int fa_cl_c_gqa4 = fa_cl_c_env ? fa_cl_c_env
         : (backend_ctx->adreno_gen == ADRENO_GPU_GEN::X2E ||
            backend_ctx->adreno_gen == ADRENO_GPU_GEN::X1E ? 16 : 0);
+
+    // dp4a QK dot in the q8_0 decode kernels: +3% tg at depth on the A8X
+    // (mq_split stays at the 512 B/WI boundary), -1..-2% on the X2E (its c8
+    // kernel sits exactly AT the boundary and the packing state pushes it
+    // over). Enable only where measured positive.
+    // dp4a int-QK in the q8_0 decode FA kernels. Default A8X-only: it measured
+    // -1.3/-2.2% on X2-90, attributed at the time to the Q-packing state pushing
+    // the kernel past a 512 B/WI spill cliff. That mechanism is now in doubt (a
+    // 216 B/WI decode FA kernel measured 31x SLOWER than the 576 B cluster one),
+    // so keep it forceable either way for re-measurement.
+    static const int fa_q8_int_env = []{
+        const char * e = getenv("GGML_OPENCL_FA_Q8_INT_QK");
+        if (e == NULL || e[0] == 0) { return -1; }
+        return (e[0] != '0') ? 1 : 0;
+    }();
+    const bool fa_q8_int_qk = (fa_q8_int_env >= 0)
+        ? (fa_q8_int_env == 1)
+        : (backend_ctx->adreno_gen == ADRENO_GPU_GEN::A8X);
     const std::string opts_cl_c_gqa4 = fa_cl_c_gqa4
         ? " -D FA_CL_C=" + std::to_string(fa_cl_c_gqa4) : std::string();
     const std::string fa_cl_c_g8_val = std::to_string(fa_cl_c_gqa4 ? fa_cl_c_gqa4 * 2 : 16);
@@ -5011,8 +5057,13 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
         case FA_VARIANT_Q4_0_SPLIT:      tag = "fa q4_0 split";      break;
         default: break;
     }
+    std::string opts_q8_int;
+    if ((variant == FA_VARIANT_Q8_0 || variant == FA_VARIANT_Q8_0_SPLIT) && !fa_q8_int_qk) {
+        opts_q8_int = " -D FA_Q8_INT_QK_OFF";
+    }
+
     cl_program prog = build_program_from_source_ex(
-        backend_ctx->context, backend_ctx->device, src.c_str(), opts + opts_cl_c_gqa4,
+        backend_ctx->context, backend_ctx->device, src.c_str(), opts + opts_cl_c_gqa4 + opts_q8_int,
         /*fatal=*/false, tag, backend_ctx->queue);
     if (!prog) { return false; }
 
@@ -5205,6 +5256,179 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 }
                 clReleaseProgram(prog_g8);
             }
+            // dk=64 gqa8 (gpt-oss-class): a C=16 cluster-parallel g8 program.
+            // Every lane stays active (DK_VEC=16 = one quartet per cluster
+            // lane) and each K/V row is read once for all 8 heads, vs the
+            // q1_split fallback's per-head WGs re-reading the same KV 8x.
+            // Lighter than the fallback too (840: 784 vs 912 B/WI).
+            // The plain mq_split was measured -48% here (48/64 lanes idle) -
+            // the cluster layout is the only MQ shape that fits dk=64.
+            // Same head split for the GQA4 DK=128 program (Qwen3 / Llama /
+            // Mistral class), which sits at exactly 512 B/WI. MQ_GQA=2 spread
+            // over two workgroups per KV head halves o_acc/m/l/slope.
+            // Default on; opt out with GGML_OPENCL_FA_HS_GQA4=0. Measured
+            // X2E +4.8% (Qwen3-4B) / +3.2% (Llama-3-8B), X1E +18.0%, and
+            // A8X +61% / +42% / +33% (Qwen3-4B / Llama-3-8B / Mistral-7B),
+            // where it also makes FA-on beat FA-off on this shape.
+            // No device gate is needed because those three families are the
+            // only ones that reach this dispatch: A7X declines every mixed and
+            // quantized FA combination above (compiler SIGSEGV) and E17
+            // declines FLASH_ATTN_EXT outright, so the kernel is unreachable on
+            // the 740 and the 850 -- both confirmed on device.
+            if (!fa_decode_only && dk == 128 && dv == 128 && backend_ctx->has_subgroup_shuffle &&
+                !(getenv("GGML_OPENCL_FA_HS_GQA4") && getenv("GGML_OPENCL_FA_HS_GQA4")[0] == '0')) {
+                const std::string opts_hs4 = opts +
+                    " -D FA_MQ_ONLY -D MQ_GQA=2 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2"
+                    " -D FA_CL_C=16 -D FA_HEAD_SUB=2 -D FA_CL_MHRED=1";
+                cl_program prog_hs4 = build_program_from_source_ex(
+                    backend_ctx->context, backend_ctx->device, src.c_str(), opts_hs4,
+                    /*fatal=*/false, "fa f32_f16 MQ_GQA=2 c16 dk128 headsub2", backend_ctx->queue);
+                if (prog_hs4) {
+                    cl_kernel k = clCreateKernel(prog_hs4, "flash_attn_f32_f16_q1_vec_mq_split_c8", &err);
+                    if (err == CL_SUCCESS) {
+                        if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k, 128,
+                                                          "flash_attn_f32_f16_q1_vec_mq_split_c8 (hs gqa4)", dk, dv)) {
+                            backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa4_hs2[{dk, dv}] = k;
+                            ggml_opencl_log_fa_kernel_spill(backend_ctx, k,
+                                "flash_attn_f32_f16_q1_vec_mq_split_gqa4_hs2", dk, dv);
+                        } else {
+                            clReleaseKernel(k);
+                        }
+                    }
+                    clReleaseProgram(prog_hs4);
+                }
+            }
+            if (!fa_decode_only && dk == 64 && dv == 64 && backend_ctx->has_subgroup_shuffle) {
+                // Fold the 8 per-head cluster butterflies into one halving
+                // butterfly: 15 shuffles per KV row instead of 32, with the
+                // rounds ordered so each head's summation tree is unchanged
+                // (bit-identical scores). Applied at this one build site, so
+                // every other program compiles the byte-exact original.
+                // Opt-out for diagnosis: GGML_OPENCL_FA_MHRED=0.
+                // Tuning knobs for the head-split program (defaults = shipped config).
+                static const int fa_head_sub_n = []{
+                    const char * e = std::getenv("GGML_OPENCL_FA_HEAD_SUB_N");
+                    const int v = (e && e[0]) ? atoi(e) : 2;
+                    return (v == 2 || v == 4) ? v : 2;
+                }();
+                // One subgroup per workgroup. The kernel has a barrier (Q staging),
+                // so WG=128 forces two waves co-resident on a CU; WG=64 lets the
+                // scheduler pack independent workgroups instead. +1.5/+2.1/+4.4%
+                // over MQ_NSG_SPLIT=2 at the same 368 B/WI.
+                static const int fa_hs_nsg = []{
+                    const char * e = std::getenv("GGML_OPENCL_FA_HS_NSG");
+                    const int v = (e && e[0]) ? atoi(e) : 1;
+                    return (v == 1 || v == 2) ? v : 1;
+                }();
+                static const bool mhred_on = []{
+                    const char * e = std::getenv("GGML_OPENCL_FA_MHRED");
+                    return !(e && e[0] == '0');
+                }();
+                const std::string opts_g8c16 = opts +
+                    " -D FA_MQ_ONLY -D MQ_GQA=8 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16"
+                    " -D FA_CL_MASK_BCAST=1" +
+                    (mhred_on ? " -D FA_CL_MHRED=1" : "");
+
+                // gqa=8 served by an MQ_GQA=4 kernel across two workgroups per KV
+                // head. Halves every per-lane per-head array (o_acc, m_i, l_i,
+                // slope) and doubles the grid; costs a 2x KV re-read, which is
+                // affordable while the kernel runs at ~34 GB/s against a measured
+                // 136 GB/s streaming floor. Probe for the "waves resident per CU"
+                // hypothesis -- register footprint is the only mechanism left after
+                // spill, workgroup count, MLP and load path were all falsified.
+                {
+                    const std::string opts_hs2 = opts +
+                        " -D FA_MQ_ONLY -D MQ_GQA=" + std::to_string(8 / fa_head_sub_n) +
+                        " -D MQ_NSG=" + std::to_string(fa_hs_nsg) +
+                        " -D MQ_NSG_SPLIT=" + std::to_string(fa_hs_nsg) +
+                        " -D FA_CL_C=16 -D FA_HEAD_SUB=" + std::to_string(fa_head_sub_n) +
+                        " -D FA_CL_MASK_BCAST=1" +
+                        (mhred_on ? " -D FA_CL_MHRED=1" : "");
+                    cl_program prog_hs2 = build_program_from_source_ex(
+                        backend_ctx->context, backend_ctx->device, src.c_str(), opts_hs2,
+                        /*fatal=*/false, "fa f32_f16 MQ_GQA=4 c16 dk64 headsub2",
+                        backend_ctx->queue);
+                    if (prog_hs2) {
+                        cl_kernel k_hs2 = clCreateKernel(prog_hs2, "flash_attn_f32_f16_q1_vec_mq_split_c8", &err);
+                        if (err == CL_SUCCESS) {
+                            if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_hs2, (size_t)(64 * fa_hs_nsg),
+                                                              "flash_attn_f32_f16_q1_vec_mq_split_c8 (hs2)", dk, dv)) {
+                                backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2[{dk, dv}] = k_hs2;
+                                backend_ctx->fa.fa_hs_wg  = 64 * fa_hs_nsg;
+                                backend_ctx->fa.fa_hs_sub = fa_head_sub_n;
+                                ggml_opencl_log_fa_kernel_spill(backend_ctx, k_hs2,
+                                    "flash_attn_f32_f16_q1_vec_mq_split_g8_hs2", dk, dv);
+                            } else {
+                                clReleaseKernel(k_hs2);
+                            }
+                        }
+                        clReleaseProgram(prog_hs2);
+                    }
+                }
+
+                // Same cluster kernel with K read through image1d_buffer_t. The buffer
+                // path streams KV at ~22 GB/s while the GEMVs in the same graph reach
+                // ~118 GB/s; the texture path is what those GEMVs use. Env-gated until
+                // measured.
+                const std::string opts_g8c16_kimg = opts_g8c16 + " -D FA_K_IMG";
+                cl_program prog_g8c16_kimg = build_program_from_source_ex(
+                    backend_ctx->context, backend_ctx->device, src.c_str(), opts_g8c16_kimg,
+                    /*fatal=*/false, "fa f32_f16 MQ_GQA=8 c16 dk64 k_img", backend_ctx->queue);
+                if (prog_g8c16_kimg) {
+                    cl_kernel k_g8c16_kimg = clCreateKernel(prog_g8c16_kimg, "flash_attn_f32_f16_q1_vec_mq_split_c8", &err);
+                    if (err == CL_SUCCESS) {
+                        if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_g8c16_kimg, 128,
+                                                          "fa f32_f16 MQ_GQA=8 c16 dk64 k_img", dk, dv)) {
+                            backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa_k_img[{dk, dv, 8}] = k_g8c16_kimg;
+                            ggml_opencl_log_fa_kernel_spill(backend_ctx, k_g8c16_kimg, "fa f32_f16 MQ_GQA=8 c16 dk64 k_img", dk, dv);
+                        } else {
+                            clReleaseKernel(k_g8c16_kimg);
+                        }
+                    }
+                    clReleaseProgram(prog_g8c16_kimg);
+                }
+                cl_program prog_g8c16 = build_program_from_source_ex(
+                    backend_ctx->context, backend_ctx->device, src.c_str(), opts_g8c16,
+                    /*fatal=*/false, "fa f32_f16 MQ_GQA=8 c16 dk64", backend_ctx->queue);
+                if (prog_g8c16) {
+                    cl_kernel k_g8c16 = clCreateKernel(prog_g8c16, "flash_attn_f32_f16_q1_vec_mq_split_c8", &err);
+                    if (err == CL_SUCCESS) {
+                        if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_g8c16, 128,
+                                                          "fa f32_f16 MQ_GQA=8 c16 dk64", dk, dv)) {
+                            backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa[{dk, dv, 8}] = k_g8c16;
+                            ggml_opencl_log_fa_kernel_spill(backend_ctx, k_g8c16, "fa f32_f16 MQ_GQA=8 c16 dk64", dk, dv);
+                        } else {
+                            clReleaseKernel(k_g8c16);
+                        }
+                    }
+                    clReleaseProgram(prog_g8c16);
+                }
+            }
+            // MQ_GQA=2/3 specializations (dk=dv=128 models only): give gqa=2/3
+            // models the healthy MQ decode kernel instead of the spilled
+            // q1_split fallback (1168 B/WI on DX.50, 192-thread cap).
+            if (!fa_decode_only && dk == 128 && dv == 128) {
+                for (int gqa_n = 2; gqa_n <= 3; ++gqa_n) {
+                    const std::string opts_gn = opts + " -D FA_MQ_ONLY -D MQ_GQA=" + std::to_string(gqa_n);
+                    const std::string tag_gn  = "fa f32_f16 MQ_GQA=" + std::to_string(gqa_n);
+                    cl_program prog_gn = build_program_from_source_ex(
+                        backend_ctx->context, backend_ctx->device, src.c_str(), opts_gn,
+                        /*fatal=*/false, tag_gn.c_str(), backend_ctx->queue);
+                    if (prog_gn) {
+                        cl_kernel k_gn = clCreateKernel(prog_gn, "flash_attn_f32_f16_q1_vec_mq_split", &err);
+                        if (err == CL_SUCCESS) {
+                            if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_gn, 256,
+                                                              tag_gn.c_str(), dk, dv)) {
+                                backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa[{dk, dv, gqa_n}] = k_gn;
+                                ggml_opencl_log_fa_kernel_spill(backend_ctx, k_gn, tag_gn.c_str(), dk, dv);
+                            } else {
+                                clReleaseKernel(k_gn);
+                            }
+                        }
+                        clReleaseProgram(prog_gn);
+                    }
+                }
+            }
             // NSG_SPLIT=2 programs for the cluster-parallel kernel: its register
             // footprint caps the per-kernel WG at 128 on X2 (< the stock 256/192
             // requirement), so it can never register from the stock programs.
@@ -5337,7 +5561,7 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             // Second compile with MQ_GQA=8, MQ_NSG=3, MQ_NSG_SPLIT=3
             auto & m_mq_split_g8 = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8
                                          : backend_ctx->fa.f32_q4_0_q1_vec_mq_split_g8;
-            const std::string opts_mq_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3";
+            const std::string opts_mq_g8 = opts + " -D MQ_GQA=8 -D MQ_NSG=3 -D MQ_NSG_SPLIT=3" + opts_q8_int;
             cl_program prog_mq_g8 = build_program_from_source_ex(
                 backend_ctx->context, backend_ctx->device, src.c_str(), opts_mq_g8,
                 /*fatal=*/false, is_q8 ? "fa q8_0 MQ_GQA=8" : "fa q4_0 MQ_GQA=8",
@@ -5356,12 +5580,36 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                 }
                 clReleaseProgram(prog_mq_g8);
             }
+            // MQ_GQA=2/3 specializations (q8_0, dk=dv=128): replace the
+            // spilled q1_split fallback for gqa=2/3 models.
+            if (is_q8 && dk == 128 && dv == 128) {
+                for (int gqa_n = 2; gqa_n <= 3; ++gqa_n) {
+                    const std::string opts_gn = opts + " -D MQ_GQA=" + std::to_string(gqa_n) + opts_q8_int;
+                    const std::string tag_gn  = "fa q8_0 MQ_GQA=" + std::to_string(gqa_n);
+                    cl_program prog_gn = build_program_from_source_ex(
+                        backend_ctx->context, backend_ctx->device, src.c_str(), opts_gn,
+                        /*fatal=*/false, tag_gn.c_str(), backend_ctx->queue);
+                    if (prog_gn) {
+                        cl_kernel k_gn = clCreateKernel(prog_gn, name_mq_split.c_str(), &err);
+                        if (err == CL_SUCCESS) {
+                            if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_gn, 256,
+                                                              tag_gn.c_str(), dk, dv)) {
+                                backend_ctx->fa.f32_q8_0_q1_vec_mq_split_gqa[{dk, dv, gqa_n}] = k_gn;
+                                ggml_opencl_log_fa_kernel_spill(backend_ctx, k_gn, tag_gn.c_str(), dk, dv);
+                            } else {
+                                clReleaseKernel(k_gn);
+                            }
+                        }
+                        clReleaseProgram(prog_gn);
+                    }
+                }
+            }
             // GQA=4 cluster-parallel program (NSG_SPLIT=2 / WG=128)
             if (backend_ctx->has_subgroup_shuffle) {
                 auto & m_c8_gqa4 = is_q8 ? backend_ctx->fa.f32_q8_0_q1_vec_mq_split_c8
                                          : backend_ctx->fa.f32_q4_0_q1_vec_mq_split_c8;
                 const std::string name_c8_gqa4 = name_q1 + "_vec_mq_split_c8";
-                const std::string opts_c8_gqa4 = opts + " -D MQ_GQA=4 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2" + opts_cl_c_gqa4;
+                const std::string opts_c8_gqa4 = opts + " -D MQ_GQA=4 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2" + opts_cl_c_gqa4 + opts_q8_int;
                 cl_program prog_c8_gqa4 = build_program_from_source_ex(
                     backend_ctx->context, backend_ctx->device, src.c_str(), opts_c8_gqa4,
                     /*fatal=*/false, is_q8 ? "fa q8_0 c8 GQA4 NSG2" : "fa q4_0 c8 GQA4 NSG2",
@@ -5378,6 +5626,33 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                         }
                     }
                     clReleaseProgram(prog_c8_gqa4);
+                }
+            }
+            // Cluster-parallel q8_0 GQA8 decode kernel. gpt-oss-class shapes
+            // (dk=dv=64, gqa=8) had no q8_0 MQ route at all: every q8_0 gqa8 gate
+            // required dk=128, so quantizing the KV cache dropped the model from
+            // the C=16 f16 cluster kernel onto the spilled scalar q1_split. Same
+            // FA_CL_C as the f16 dk=64 program -- at DK_VEC=16 a width of 8 would
+            // double the per-lane o_acc for MQ_GQA=8.
+            if (is_q8 && dk == 64 && dv == 64 && backend_ctx->has_subgroup_shuffle) {
+                const std::string opts_q8_g8c16 = opts +
+                    " -D MQ_GQA=8 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16" + opts_q8_int;
+                cl_program prog_q8_g8c16 = build_program_from_source_ex(
+                    backend_ctx->context, backend_ctx->device, src.c_str(), opts_q8_g8c16,
+                    /*fatal=*/false, "fa q8_0 c16 GQA8 dk64", backend_ctx->queue);
+                if (prog_q8_g8c16) {
+                    cl_kernel k = clCreateKernel(prog_q8_g8c16, "flash_attn_f32_q8_0_q1_vec_mq_split_c8", &err);
+                    if (err == CL_SUCCESS) {
+                        if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k, 128,
+                                                          "flash_attn_f32_q8_0_q1_vec_mq_split_c8 (g8 c16)", dk, dv)) {
+                            backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8[{dk, dv}] = k;
+                            ggml_opencl_log_fa_kernel_spill(backend_ctx, k,
+                                "flash_attn_f32_q8_0_q1_vec_mq_split_g8_c8", dk, dv);
+                        } else {
+                            clReleaseKernel(k);
+                        }
+                    }
+                    clReleaseProgram(prog_q8_g8c16);
                 }
             }
             // Cluster-parallel q4_0 decode kernel
@@ -15367,6 +15642,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     cl_kernel fd_k_split = NULL;
     bool use_fd_mq = false;
     size_t fd_mq_wg = 256;  // MQ_GQA=4 kernel: Q1_WG_SIZE(64) * MQ_NSG_SPLIT(4)
+    int    fd_head_sub = 1; // workgroups per gqa group (FA_HEAD_SUB in the kernel)
     bool use_fa_k_img = false;  // K bound as image1d_buffer_t instead of (buf, offset)
 
     {
@@ -15395,10 +15671,31 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         const bool c8_f16_on = (c8_env_state >= 0) ? (c8_env_state == 1) : c8_default_on;
         // Quant-KV (q4_0/q8_0) GQA4 c8: default-on X2E + X1E
         const bool c8_quant_on = (c8_env_state >= 0) ? (c8_env_state == 1) : c8_default_on;
+        // dk=64 gqa8 served by an MQ_GQA=4 kernel across two workgroups per KV
+        // head: private_mem 576 -> 368 B/WI and twice the grid. Default on;
+        // opt-out GGML_OPENCL_FA_HEAD_SUB=0.
+        static const bool head_sub_on = []{
+            const char * e = getenv("GGML_OPENCL_FA_HEAD_SUB");
+            return !(e && e[0] == '0');
+        }();
+        // Minimum n_kv for the MQ (KV-sharing) decode routes. FD_MIN_N_KV is
+        // tuned for the flash-decoding split, but the MQ kernels also buy a
+        // gqa-fold of the KV reads, which pays below that: models with
+        // alternating SWA layers (gpt-oss: swa_period=2, window 128) sit at
+        // n_kv == 256 on half their layers and so never reach any KV-sharing
+        // kernel at any depth -- they run the legacy per-head q1 instead.
+        // Opt-in (GGML_OPENCL_FD_MIN_N_KV_MQ=128): worth ~+1.2% tg32 on
+        // gpt-oss-20b/X2-90 once the partials buffer is pooled, but it changes
+        // decode routing for every model below FD_MIN_N_KV and has only been
+        // measured on one. Default is unchanged.
+        static const int fd_min_n_kv_mq = []{
+            const char * e = getenv("GGML_OPENCL_FD_MIN_N_KV_MQ");
+            return (e && e[0]) ? atoi(e) : FD_MIN_N_KV;
+        }();
         if (mq_enabled && mq_kv_ok && nq_in_vec_range && !is_causal &&
             backend_ctx->gpu_family != INTEL &&
             !use_local_tile &&
-            n_kv >= FD_MIN_N_KV &&
+            n_kv >= fd_min_n_kv_mq &&
             backend_ctx->fa.f32_merge.count(dk_dv) > 0) {
             if (nq1_only && lmq_on && is_mixed && d_head_q == 128 && d_head_v == 128 &&
                 gqa_ratio_dispatch == 8 &&
@@ -15412,6 +15709,14 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 fd_k_split = backend_ctx->fa.f32_f16_q1_local_mq_split.at(dk_dv);
                 use_fd_mq  = true;
                 fd_mq_wg   = 64;
+            } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
+                d_head_q == 128 && d_head_v == 128 &&
+                n_head == n_head_kv * 4 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa4_hs2.count(dk_dv) > 0) {
+                fd_k_split  = backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa4_hs2.at(dk_dv);
+                use_fd_mq   = true;
+                fd_mq_wg    = 128;
+                fd_head_sub = 2;
             } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 4 &&
                 ((d_head_q == 256 && d_head_v == 256) ||
                  (d_head_q == 128 && d_head_v == 128)) &&
@@ -15468,12 +15773,52 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 use_fd_mq    = true;
                 fd_mq_wg     = 192;
                 use_fa_k_img = true;
+            // NOTE (2026-07-29): routing dk=64 gqa8 (gpt-oss-class) to a g8
+            // NSG2 mq_split was measured at −48% vs the spilled q1_split
+            // fallback on the 840: at DK_VEC=16 the mq kernel idles 75% of
+            // each subgroup, and full lane utilization beats spill relief.
+            // The C=16 cluster kernel below keeps every lane active instead.
+            } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 8 &&
+                d_head_q == 64 && d_head_v == 64 &&
+                n_head == n_head_kv * 8 &&
+                head_sub_on &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2.count({64, 64}) > 0) {
+                fd_k_split   = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8_hs2.at({64, 64});
+                use_fd_mq    = true;
+                fd_mq_wg     = (size_t) backend_ctx->fa.fa_hs_wg;
+                fd_head_sub  = backend_ctx->fa.fa_hs_sub;
+            } else if (nq1_only && is_mixed && gqa_ratio_dispatch == 8 &&
+                d_head_q == 64 && d_head_v == 64 &&
+                n_head == n_head_kv * 8 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.count({64, 64, 8}) > 0) {
+                static const bool gqa_k_img_env = []{
+                    const char * e = std::getenv("GGML_OPENCL_FA_GQA_K_IMG");
+                    return e && e[0] && e[0] != '0';
+                }();
+                if (gqa_k_img_env &&
+                    backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa_k_img.count({64, 64, 8}) > 0) {
+                    fd_k_split   = backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa_k_img.at({64, 64, 8});
+                    use_fa_k_img = true;
+                } else {
+                    fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.at({64, 64, 8});
+                }
+                use_fd_mq  = true;
+                fd_mq_wg   = 128;
             } else if (is_mixed && gqa_ratio_dispatch == 8 &&
                 d_head_q == 128 && d_head_v == 128 &&
                 backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.count(dk_dv) > 0) {
                 fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_g8.at(dk_dv);
                 use_fd_mq  = true;
                 fd_mq_wg   = 192;
+            } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 8 &&
+                d_head_q == 64 && d_head_v == 64 &&
+                n_head == n_head_kv * 8 &&
+                backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8.count(dk_dv) > 0) {
+                // gpt-oss-class q8_0 KV: without this the model falls all the way
+                // back to the spilled scalar q1_split.
+                fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8.at(dk_dv);
+                use_fd_mq  = true;
+                fd_mq_wg   = 128;
             } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 8 &&
                 d_head_q == 128 && d_head_v == 128 &&
                 backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8.count(dk_dv) > 0) {
@@ -15491,6 +15836,20 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                 } else {
                     fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split.at(dk_dv);
                 }
+                use_fd_mq  = true;
+            } else if (nq1_only && is_mixed &&
+                (gqa_ratio_dispatch == 2 || gqa_ratio_dispatch == 3) &&
+                n_head == n_head_kv * gqa_ratio_dispatch &&
+                d_head_q == 128 && d_head_v == 128 &&
+                backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0) {
+                fd_k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.at({d_head_q, d_head_v, gqa_ratio_dispatch});
+                use_fd_mq  = true;
+            } else if (nq1_only && is_q8_0 &&
+                (gqa_ratio_dispatch == 2 || gqa_ratio_dispatch == 3) &&
+                n_head == n_head_kv * gqa_ratio_dispatch &&
+                d_head_q == 128 && d_head_v == 128 &&
+                backend_ctx->fa.f32_q8_0_q1_vec_mq_split_gqa.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0) {
+                fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split_gqa.at({d_head_q, d_head_v, gqa_ratio_dispatch});
                 use_fd_mq  = true;
             } else if (nq1_only && is_q4_0) {
                 const char * q4_mq_env = getenv("GGML_OPENCL_FA_Q4_MQ");
@@ -15554,6 +15913,22 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         }
     }
     const bool use_fd = (fd_k_split != NULL);
+
+    static const bool fa_debug = getenv("GGML_OPENCL_FA_DEBUG") != NULL;
+    if (fa_debug && use_fd) {
+        char fd_kname[128] = {0};
+        clGetKernelInfo(fd_k_split, CL_KERNEL_FUNCTION_NAME, sizeof(fd_kname) - 1, fd_kname, NULL);
+        GGML_LOG_INFO("ggml_opencl: FA-decode kernel: %s (n_q=%d n_kv=%d dk=%d dv=%d gqa=%d)\n",
+                      fd_kname, n_q, n_kv, d_head_q, d_head_v, gqa_ratio_dispatch);
+    } else if (fa_debug) {
+        // Print the non-FD dispatch too. Without this, "no line" reads as
+        // "path not taken" when it can equally mean "fell back to the generic
+        // kernel", which is what hid half of gpt-oss's layers on the legacy q1.
+        char kname[128] = {0};
+        clGetKernelInfo(kernel, CL_KERNEL_FUNCTION_NAME, sizeof(kname) - 1, kname, NULL);
+        GGML_LOG_INFO("ggml_opencl: FA kernel (no FD): %s (n_q=%d n_kv=%d dk=%d dv=%d gqa=%d)\n",
+                      kname, n_q, n_kv, d_head_q, d_head_v, gqa_ratio_dispatch);
+    }
 
     const int n_q_blocks = n_q > 1 ? (n_q + block_m - 1) / block_m : 0;
     const int n_kv_blocks = (n_kv > 0 && block_n > 0) ? (n_kv + block_n - 1) / block_n : 0;
@@ -15679,22 +16054,94 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         int n_splits = (n_kv + fd_kv_per_split - 1) / fd_kv_per_split;
         if (n_splits < FD_MIN_SPLITS) { n_splits = FD_MIN_SPLITS; }
         if (n_splits > fd_max_splits) { n_splits = fd_max_splits; }
+
+        // Workgroup floor for the MQ routes. Their grid is
+        // (n_head_kv * n_batch) x n_splits workgroups, NOT one per query head:
+        // MQ_GQA query heads share a workgroup, so an 8-KV-head model at a
+        // short n_kv lands on 8 * FD_MIN_SPLITS = 16 workgroups, which is at
+        // or below the compute-unit count and leaves the device idle. Split
+        // the KV range further until every SP has work, but only while the
+        // slices stay wide enough to keep the cluster's lanes busy -- the
+        // split count is otherwise tuned for the deep layers, where raising
+        // it costs merge work and redundant Q loads (measured: a blanket
+        // kv_per_split of 64 is -2.5% at d4096, 32 is -8.7%).
+        // CL_DEVICE_MAX_COMPUTE_UNITS, queried once.
+        static const int fd_compute_units = [&]{
+            cl_uint n = 0;
+            clGetDeviceInfo(backend_ctx->device, CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(n), &n, NULL);
+            return (int) n;
+        }();
+        if (use_fd_mq && fd_compute_units > 0) {
+            const int wg_per_split = n_head_kv * n_batch;
+            static const int wg_mult = []{
+                const char * e = getenv("GGML_OPENCL_FD_MQ_WG_MULT");
+                return (e && e[0]) ? atoi(e) : 4;
+            }();
+            const int wg_target    = wg_mult * fd_compute_units;
+            const int min_kv_per_split = 32;
+            while (wg_per_split * n_splits < wg_target &&
+                   n_splits < fd_max_splits &&
+                   n_kv / (n_splits + 1) >= min_kv_per_split) {
+                n_splits++;
+            }
+        }
+
         const int kv_per_split = (n_kv + n_splits - 1) / n_splits;
 
         const int fa_partial_floats = 2 + d_head_v;
         const size_t partial_size_bytes =
             (size_t) n_batch * n_head * n_q * n_splits * fa_partial_floats * sizeof(float);
 
-        ggml_cl_flash_attn_temp_buffer temp_partial;
+        // Opt-out for diagnosis. Force-disabled while recordable queues are in
+        // use: a recording bakes the cl_mem handle into the captured dispatch,
+        // and a pool that grows afterwards would leave the replay pointing at a
+        // released buffer.
+        static const bool fd_pool_env_on = []{
+            const char * e = getenv("GGML_OPENCL_FD_PARTIAL_POOL");
+            return !(e && e[0] == '0');
+        }();
+        // NOTE: if a recordable-queue path is ever added, it must disable this
+        // pool -- a recording bakes the cl_mem handle into the captured dispatch
+        // and a later grow-realloc would leave the replay pointing at a freed
+        // buffer.
+        const bool fd_pool_on = fd_pool_env_on;
+
+        ggml_cl_flash_attn_temp_buffer temp_partial;  // unused when pooling
+        cl_mem partial_buffer = NULL;
         cl_int err;
-        temp_partial.data = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE,
+        if (fd_pool_on) {
+            // Grow-only, so a context whose split count varies per layer does
+            // not thrash the allocator.
+            if (backend_ctx->fa.fd_partial_pool_size < partial_size_bytes) {
+                if (backend_ctx->fa.fd_partial_pool != nullptr) {
+                    CL_CHECK(clFinish(backend_ctx->queue));
+                    CL_CHECK(clReleaseMemObject(backend_ctx->fa.fd_partial_pool));
+                    backend_ctx->fa.fd_partial_pool      = nullptr;
+                    backend_ctx->fa.fd_partial_pool_size = 0;
+                }
+                cl_mem grown = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE,
+                                              partial_size_bytes, NULL, &err);
+                if (err != CL_SUCCESS) {
+                    CL_CHECK(clFinish(backend_ctx->queue));
+                    grown = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE,
                                            partial_size_bytes, NULL, &err);
-        if (err != CL_SUCCESS) {
-            CL_CHECK(clFinish(backend_ctx->queue));
+                }
+                CL_CHECK(err);
+                backend_ctx->fa.fd_partial_pool      = grown;
+                backend_ctx->fa.fd_partial_pool_size = partial_size_bytes;
+            }
+            partial_buffer = backend_ctx->fa.fd_partial_pool;
+        } else {
             temp_partial.data = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE,
                                                partial_size_bytes, NULL, &err);
+            if (err != CL_SUCCESS) {
+                CL_CHECK(clFinish(backend_ctx->queue));
+                temp_partial.data = clCreateBuffer(backend_ctx->context, CL_MEM_READ_WRITE,
+                                                   partial_size_bytes, NULL, &err);
+            }
+            CL_CHECK(err);
+            partial_buffer = temp_partial.data;
         }
-        CL_CHECK(err);
 
         cl_kernel k_split = fd_k_split;
         int argi = 0;
@@ -15715,10 +16162,16 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
                     backend_ctx, backend_ctx->kq_img_pool,
                     k_data_device, offset_k, k_bytes, CL_HALF_FLOAT);
             }
-
             // if image creation fails, fallback to buffer based kernels
+            if (getenv("GGML_OPENCL_FA_DEBUG")) {
+                GGML_LOG_INFO("ggml_opencl: FA k_img %s (pixels=%zu max=%zu)\n",
+                    k_img ? "CREATED -> texture path" : "FAILED -> buffer fallback",
+                    k_pixels, (size_t) backend_ctx->image_max_buffer_size);
+            }
             if (k_img == nullptr) {
-                if (gqa_ratio_dispatch == 4 &&
+                if (backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.count({d_head_q, d_head_v, gqa_ratio_dispatch}) > 0) {
+                    k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split_gqa.at({d_head_q, d_head_v, gqa_ratio_dispatch});
+                } else if (gqa_ratio_dispatch == 4 &&
                     backend_ctx->fa.f32_f16_q1_vec_mq_split.count(dk_dv) > 0) {
                     k_split = backend_ctx->fa.f32_f16_q1_vec_mq_split.at(dk_dv);
                 } else {
@@ -15762,7 +16215,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_ulong), &mask_nb3));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &mask_ne2));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &mask_ne3));
-        CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &temp_partial.data));
+        CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(cl_mem),   &partial_buffer));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &n_splits));
         CL_CHECK(clSetKernelArg(k_split, argi++, sizeof(int),      &kv_per_split));
 
@@ -15770,7 +16223,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         // matches Q1_WG_SIZE * NSG (MQ_GQA=4 -> 256; MQ_GQA=8 -> 192)
         const size_t fd_wg = use_fd_mq ? fd_mq_wg : 64;
         const size_t fd_head_dim = use_fd_mq
-            ? (size_t)(n_head_kv * n_batch)
+            ? (size_t)(n_head_kv * fd_head_sub * n_batch)
             : (size_t)(n_head     * n_batch);
         size_t fd_lws[3] = { fd_wg, 1, 1 };
         // gid(2) packs q_idx * n_splits + split_idx.
@@ -15779,7 +16232,7 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
 
         cl_kernel k_merge = backend_ctx->fa.f32_merge.at(dk_dv);
         argi = 0;
-        CL_CHECK(clSetKernelArg(k_merge, argi++, sizeof(cl_mem),   &temp_partial.data));
+        CL_CHECK(clSetKernelArg(k_merge, argi++, sizeof(cl_mem),   &partial_buffer));
         CL_CHECK(clSetKernelArg(k_merge, argi++, sizeof(cl_mem),   &extra_o->data_device));
         CL_CHECK(clSetKernelArg(k_merge, argi++, sizeof(cl_ulong), &offset_o));
         CL_CHECK(clSetKernelArg(k_merge, argi++, sizeof(int),      &n_head));

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -4934,6 +4934,13 @@ static bool ggml_opencl_ensure_fa_f32_f16_vec_512(ggml_backend_opencl_context * 
     static bool failed = false;
     if (failed) return false;
 
+    // Decline WITHOUT latching if the shared compile options are not up yet. This is
+    // reachable from supports_op, which llama.cpp calls before load_cl_kernels() has
+    // run, and a build attempted with an empty option prefix is missing -cl-std and
+    // fails on every subgroup builtin. Latching that would disable this kernel for
+    // the rest of the process rather than for one call.
+    if (backend_ctx->kernel_compile_opts.empty()) return false;
+
     const ggml_opencl_fa_dim * cfg = nullptr;
     for (const auto & d : g_opencl_fa_dims) {
         if (d.dk == dk && d.dv == dv) { cfg = &d; break; }

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -15999,13 +15999,31 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         // alternating SWA layers (gpt-oss: swa_period=2, window 128) sit at
         // n_kv == 256 on half their layers and so never reach any KV-sharing
         // kernel at any depth -- they run the legacy per-head q1 instead.
-        // Opt-in (GGML_OPENCL_FD_MIN_N_KV_MQ=128): worth ~+1.2% tg32 on
-        // gpt-oss-20b/X2-90 once the partials buffer is pooled, but it changes
-        // decode routing for every model below FD_MIN_N_KV and has only been
-        // measured on one. Default is unchanged.
+        // This defaulted to FD_MIN_N_KV (2048) and was left opt-in on the grounds
+        // that it changes decode routing for every model below that and had only
+        // been measured on one. It has now been measured on four, and inheriting
+        // the split-tuned constant was simply wrong: below 2048 the MQ routes --
+        // including the dk=128 gqa=8 head split -- did not engage AT ALL, so a
+        // model spent its whole shallow-context life on the legacy per-head q1.
+        //
+        // X2-90 tg128, floor 2048 -> 32, each arm bracketed by an off arm either
+        // side:
+        //
+        //   Qwen3-30B-A3B  d0 41.3 -> 46.5 (+12%)  d1024 25.7 -> 41.8 (+63%)
+        //   Qwen3-4B       d0 38.8 -> 42.6 (+10%)  d1024 27.2 -> 39.0 (+43%)
+        //   gpt-oss-20b    d0 39.1 -> 39.6 (+1%)   d1024 35.8 -> 38.6 (+8%)
+        //   gemma-4-26B    d0 37.7 -> 37.5         d1024 33.8 -> 33.4
+        //
+        // and d4096 is flat everywhere (-0.9% to +2.0%), which is the control:
+        // above the old floor the routing is unchanged, so those columns should
+        // not move and they do not. gemma-4-26B is the neutral case rather than a
+        // regression -- its deltas sit inside the spread of its own two off arms.
+        //
+        // 32 rather than 128 because the d0 win needs a floor below n_kv there.
+        // GGML_OPENCL_FD_MIN_N_KV_MQ restores any value, including the old 2048.
         static const int fd_min_n_kv_mq = []{
             const char * e = getenv("GGML_OPENCL_FD_MIN_N_KV_MQ");
-            return (e && e[0]) ? atoi(e) : FD_MIN_N_KV;
+            return (e && e[0]) ? atoi(e) : 32;
         }();
         // A shape with a narrow (purpose-built) MQ kernel carries its own,
         // much lower n_kv floor. Those kernels exist only for shapes whose

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -15544,15 +15544,39 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
         (d_head_q == 512 || d_head_q == 256) && n_head_kv > 0) {
         const int gqa = n_head / n_head_kv;
         // gqa == 2 is gemma-4-26B's SWA shape (n_head 16 / n_head_kv 8, 25 of its
-        // 30 layers). Without it those layers take the per-query-head kernel and
-        // re-read the KV cache twice; measured on the X2-90 that is the whole of
-        // the model's -fa 1 regression. Opt-in while it is characterised: only two
-        // query heads amortise each KV read here, a quarter of the gqa 8 sharing,
-        // so this is expected to reach parity with the unfused path rather than
-        // beat it. GGML_OPENCL_FA_MQN_GQA2=1.
+        // 30 layers). Without this arm those layers take the per-query-head
+        // kernel and re-read the KV cache twice, which is the whole of that
+        // model's -fa 1 decode regression.
+        //
+        // On by default; GGML_OPENCL_FA_MQN_GQA2=0 opts out. It was opt-in while
+        // the expectation was that only two query heads per KV read -- a quarter
+        // of the gqa 8 sharing -- could not amortise it well enough to beat the
+        // unfused path. Measurement says otherwise, so that reasoning is removed
+        // rather than left standing next to a default it argues against.
+        // X2-90, gemma-4-26B q4_0, tg128, one binary, this arm off -> on:
+        //
+        //   d0     36.16 -> 35.76    -1.1%   (inside run-to-run spread)
+        //   d1024  27.55 -> 32.31   +17.3%
+        //   d2048  26.56 -> 31.85   +19.9%
+        //   d4096  25.81 -> 30.60   +18.6%
+        //
+        // A separate build of the same commit reproduces this to within 2%.
+        //
+        // and on the 840 (A8X) +4.7% at d0, +21.2% at d2048. Two generations, no
+        // inversion at any depth measured. This only ever changes which decode
+        // kernel is picked, so d0 parity is the floor rather than a risk.
+        //
+        // No device predicate, matching the gqa 4 and 8 arms it sits beside.
+        // X1E is the one generation with no perf number, and it is deliberately
+        // not gated out rather than silently included: this is the only gqa == 2
+        // model on the fleet, and an X1-class per-context allocation cap (~6 GB)
+        // stops it loading at full offload there, so the shape is unreachable on
+        // X1E in practice rather than untested-and-risky. FLASH_ATTN_EXT coverage
+        // does run there. A7X and E17 never reach this function at all --
+        // supports_op declines f16-KV flash attention on both.
         static const bool mqn_gqa2 = []{
             const char * e = getenv("GGML_OPENCL_FA_MQN_GQA2");
-            return e != NULL && e[0] != '0';
+            return e == NULL || e[0] != '0';
         }();
         if (gqa == 4 || gqa == 8 || (gqa == 2 && mqn_gqa2)) {
             // hs/nsg defaults are per-shape measurements on the X2-90; the env

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -15543,7 +15543,18 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
     if (n_q == 1 && is_mixed && d_head_q == d_head_v &&
         (d_head_q == 512 || d_head_q == 256) && n_head_kv > 0) {
         const int gqa = n_head / n_head_kv;
-        if (gqa == 4 || gqa == 8) {
+        // gqa == 2 is gemma-4-26B's SWA shape (n_head 16 / n_head_kv 8, 25 of its
+        // 30 layers). Without it those layers take the per-query-head kernel and
+        // re-read the KV cache twice; measured on the X2-90 that is the whole of
+        // the model's -fa 1 regression. Opt-in while it is characterised: only two
+        // query heads amortise each KV read here, a quarter of the gqa 8 sharing,
+        // so this is expected to reach parity with the unfused path rather than
+        // beat it. GGML_OPENCL_FA_MQN_GQA2=1.
+        static const bool mqn_gqa2 = []{
+            const char * e = getenv("GGML_OPENCL_FA_MQN_GQA2");
+            return e != NULL && e[0] != '0';
+        }();
+        if (gqa == 4 || gqa == 8 || (gqa == 2 && mqn_gqa2)) {
             // hs/nsg defaults are per-shape measurements on the X2-90; the env
             // knobs exist to re-tune them elsewhere. DK=256 gqa=8 must stay at
             // a 128-thread workgroup - the stock 192-thread g8 kernel is what

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -5855,8 +5855,19 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             // FA_CL_C as the f16 dk=64 program -- at DK_VEC=16 a width of 8 would
             // double the per-lane o_acc for MQ_GQA=8.
             if (is_q8 && dk == 64 && dv == 64 && backend_ctx->has_subgroup_shuffle) {
+                // The f16 g8/c16 program has carried FA_CL_MHRED since the
+                // gpt-oss FD round; this fork never got it, and the shuffle
+                // chain it removes is what this kernel is actually spending its
+                // time on -- deleting the KV read outright still left it behind
+                // f16, so the gap is not the dequant.
+                // Opt out with GGML_OPENCL_FA_Q8_MHRED=0.
+                static const bool q8_mhred_on = []{
+                    const char * e = getenv("GGML_OPENCL_FA_Q8_MHRED");
+                    return !(e && e[0] == '0');
+                }();
                 const std::string opts_q8_g8c16 = opts +
-                    " -D MQ_GQA=8 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16" + opts_q8_int;
+                    " -D MQ_GQA=8 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16" +
+                    (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_int;
                 cl_program prog_q8_g8c16 = build_program_from_source_ex(
                     backend_ctx->context, backend_ctx->device, src.c_str(), opts_q8_g8c16,
                     /*fatal=*/false, "fa q8_0 c16 GQA8 dk64", backend_ctx->queue);

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -512,6 +512,10 @@ struct ggml_opencl_fa_kernels {
     // Cluster-parallel q8_0 decode
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_c8;
     std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8_c8;  // GQA8 cluster (dk=64)
+    // Head-split sibling of the above: MQ_GQA=4 x FA_HEAD_SUB=2 workgroups per
+    // KV head, to cut the 592 B/WI the GQA8 form reports (f16's head-split
+    // kernel is at 368 for the same shape).
+    std::map<std::pair<int, int>, cl_kernel> f32_q8_0_q1_vec_mq_split_g8_c8_hs2;
     std::map<std::pair<int, int>, cl_kernel> f32_f16_q1_vec_mq_split_g8_hs2;
     // Per-shape workgroup size and head-split factor for the above. fa_hs_wg /
     // fa_hs_sub below are single scalars written by the DK=64 build site; once a
@@ -5884,6 +5888,41 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
                         }
                     }
                     clReleaseProgram(prog_q8_g8c16);
+                }
+                // Head-split sibling: FA_HEAD_SUB=2 runs the gqa=8 shape as two
+                // MQ_GQA=4 workgroups per KV head. The measured reason to want
+                // it -- the q8 g8/c16 kernel reports private_mem 592 B/WI where
+                // the f16 head-split kernel for the same dk=64 gqa8 shape is at
+                // 368, and that occupancy gap is what the measured ceiling with
+                // the KV read removed pinned the deficit on. Costs one extra
+                // read of each KV row.
+                // Opt out with GGML_OPENCL_FA_Q8_HEAD_SUB=0.
+                static const bool q8_hs_on = []{
+                    const char * e = getenv("GGML_OPENCL_FA_Q8_HEAD_SUB");
+                    return !(e && e[0] == '0');
+                }();
+                if (q8_hs_on) {
+                    const std::string opts_q8_hs2 = opts +
+                        " -D MQ_GQA=4 -D MQ_NSG=2 -D MQ_NSG_SPLIT=2 -D FA_CL_C=16"
+                        " -D FA_HEAD_SUB=2" +
+                        (q8_mhred_on ? " -D FA_CL_MHRED=1" : "") + opts_q8_int;
+                    cl_program prog_q8_hs2 = build_program_from_source_ex(
+                        backend_ctx->context, backend_ctx->device, src.c_str(), opts_q8_hs2,
+                        /*fatal=*/false, "fa q8_0 c16 GQA4 hs2 dk64", backend_ctx->queue);
+                    if (prog_q8_hs2) {
+                        cl_kernel k_hs = clCreateKernel(prog_q8_hs2, "flash_attn_f32_q8_0_q1_vec_mq_split_c8", &err);
+                        if (err == CL_SUCCESS) {
+                            if (ggml_opencl_fa_kernel_fits_wg(backend_ctx, k_hs, 128,
+                                                              "flash_attn_f32_q8_0_q1_vec_mq_split_c8 (hs2)", dk, dv)) {
+                                backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8_hs2[{dk, dv}] = k_hs;
+                                ggml_opencl_log_fa_kernel_spill(backend_ctx, k_hs,
+                                    "flash_attn_f32_q8_0_q1_vec_mq_split_g8_c8_hs2", dk, dv);
+                            } else {
+                                clReleaseKernel(k_hs);
+                            }
+                        }
+                        clReleaseProgram(prog_q8_hs2);
+                    }
                 }
             }
             // Cluster-parallel q4_0 decode kernel
@@ -16240,10 +16279,22 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 8 &&
                 d_head_q == 64 && d_head_v == 64 &&
                 n_head == n_head_kv * 8 &&
-                backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8.count(dk_dv) > 0) {
+                (backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8.count(dk_dv) > 0 ||
+                 backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8_hs2.count(dk_dv) > 0)) {
                 // gpt-oss-class q8_0 KV: without this the model falls all the way
                 // back to the spilled scalar q1_split.
-                fd_k_split = backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8.at(dk_dv);
+                //
+                // Prefer the head-split sibling where it built: the GQA8 form
+                // reports private_mem 592 B/WI against the f16 head-split
+                // kernel's 368 for this same dk=64 gqa8 shape, and that
+                // occupancy gap -- not the dequant -- is what the measured
+                // ceiling with the KV read removed left unexplained.
+                if (backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8_hs2.count(dk_dv) > 0) {
+                    fd_k_split   = backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8_hs2.at(dk_dv);
+                    fd_head_sub  = 2;
+                } else {
+                    fd_k_split   = backend_ctx->fa.f32_q8_0_q1_vec_mq_split_g8_c8.at(dk_dv);
+                }
                 use_fd_mq  = true;
                 fd_mq_wg   = 128;
             } else if (nq1_only && is_q8_0 && gqa_ratio_dispatch == 8 &&

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -15660,12 +15660,43 @@ static void ggml_cl_flash_attn(ggml_backend_t backend, const ggml_tensor * q, co
             const char * e = getenv("GGML_OPENCL_FA_MQN_GQA2");
             return e == NULL || e[0] != '0';
         }();
-        if (gqa == 4 || gqa == 8 || (gqa == 2 && mqn_gqa2)) {
+        // gqa == 16 is gemma-4-12B's global-attention shape (n_head 16, n_head_kv 1,
+        // DK=DV=512). It matches none of the arms above, so every one of its decode
+        // dispatches lands on the legacy q1_vec kernel with no flash-decoding split
+        // and no multi-query sharing -- dispatch-traced on the X2-90: 40/40 decode
+        // FA calls were `q1_vec (dk=512 dv=512 gqa=16)`. That kernel re-reads the KV
+        // cache once per query head, 16x here.
+        // head_sub 8 (not 4) so the program is MQ_GQA=2: at DV=512 the per-head lane
+        // state is what pushes this shape past the ~512 B/work-item occupancy cliff,
+        // which is the same reason dk512/gqa8 runs head_sub 4 rather than 2.
+        // On by default; GGML_OPENCL_FA_MQN_GQA16=0 opts out. Measured on two
+        // generations, gemma-4-12B Q4_0 tg32 at d8192, this route off -> on:
+        // X2-90 10.37 -> 13.79 (+33.0%), and A8X 3.63 -> 4.46 (+22.7%, three
+        // matched pairs from the same start temperature, the on arms agreeing to
+        // 0.2%). d0 is parity on the X2-90 (15.65 -> 15.72) because the MQ route
+        // barely engages at shallow n_kv, so shallow contexts are the floor here
+        // rather than a risk. Against `-fa 0` the same X2-90 arm turns -7.4% /
+        // -16.0% at d4096 / d8192 into +8.9% / +11.7%.
+        //
+        // No device predicate, matching the gqa 4, 8 and 2 arms it sits beside.
+        // X1E is the one generation with no usable number and is deliberately not
+        // gated out: gemma-4-12B is 6.26 GiB against an X1-class per-context
+        // allocation cap near 6 GB, so runs there abort in clCreateBuffer
+        // non-deterministically (d1024 aborted while d2048 ran) and the survivors
+        // carry a +-20% spread. The shape is unreachable in practice on X1E
+        // rather than untested-and-risky, and the aborts reproduce with this
+        // route off. A7X and E17 never reach this function at all -- supports_op
+        // declines f16-KV flash attention on both.
+        static const bool mqn_gqa16 = []{
+            const char * e = getenv("GGML_OPENCL_FA_MQN_GQA16");
+            return e == NULL || e[0] != '0';
+        }();
+        if (gqa == 4 || gqa == 8 || (gqa == 2 && mqn_gqa2) || (gqa == 16 && mqn_gqa16)) {
             // hs/nsg defaults are per-shape measurements on the X2-90; the env
             // knobs exist to re-tune them elsewhere. DK=256 gqa=8 must stay at
             // a 128-thread workgroup - the stock 192-thread g8 kernel is what
             // the X2-90 refuses per-kernel.
-            int hs  = (d_head_q == 512) ? ((gqa == 8) ? 4 : 1) : ((gqa == 8) ? 2 : 1);
+            int hs  = (d_head_q == 512) ? ((gqa == 8) ? 4 : ((gqa == 16) ? 8 : 1)) : ((gqa == 8) ? 2 : 1);
             int nsg = (d_head_q == 256 && gqa == 8) ? 2 : 4;
             static const int hs_env  = []{ const char * e = getenv("GGML_OPENCL_FA_MQN_HS");
                                            return (e && e[0]) ? atoi(e) : 0; }();

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -672,7 +672,13 @@ __kernel void FA_TILE_NAME(
 
 // allow bypassing decode kernels to avoid compiler crash for DK=512 on Adreno GPUs
 #ifndef FA_PREFILL_ONLY
-#ifndef FA_MQ_ONLY  // q1 excluded from the MQ-only (g8) program
+// FA_VEC_ONLY builds a program holding ONLY flash_attn_f32_f16_q1_vec. It exists
+// for DK=512 (Gemma-4 global layers), where the shared decode program has to set
+// FA_DECODE_MINIMAL -- dropping q1_vec -- to keep the Adreno shader compiler under
+// its host-memory ceiling. Isolating q1_vec gives those layers the DV-split
+// decode kernel back: the fallback q1 holds o_acc[DV_VEC] = 2 KB of private
+// array per work item at DV=512 and spills it to DDR.
+#if !defined(FA_MQ_ONLY) && !defined(FA_VEC_ONLY)  // q1 excluded from the MQ-only (g8) and vec-only programs
 REQD_FA_SG
 __kernel void flash_attn_f32_f16_q1(
     const global void * q_void, ulong q_offset,
@@ -1392,6 +1398,9 @@ __kernel void flash_attn_f32_f16_q1_local_mq_split(
 #endif
 #define MQ_WG_SIZE (Q1_WG_SIZE * MQ_NSG)
 
+// FA_MQ_SPLIT_ONLY narrows an MQ program down to q1_vec_mq_split alone. Used at
+// DK=512, where the shader compiler cannot hold the whole MQ family at once.
+#ifndef FA_MQ_SPLIT_ONLY
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_vec_mq(
     const global void * q_void, ulong q_offset,
@@ -1634,8 +1643,14 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
     }
 }
 
+#endif  // !FA_MQ_SPLIT_ONLY (q1_vec_mq)
+
 #ifndef MQ_NSG_SPLIT
 #define MQ_NSG_SPLIT 4
+#endif
+// Workgroups per gqa group; 1 = one WG owns all MQ_GQA heads of a KV head.
+#ifndef FA_HEAD_SUB
+#define FA_HEAD_SUB 1
 #endif
 #define MQ_SPLIT_WG_SIZE (Q1_WG_SIZE * MQ_NSG_SPLIT)
 
@@ -1643,6 +1658,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
 #define FA_PARTIAL_FLOATS (2 + DV)
 #endif
 
+#ifndef FA_MQ_KIMG   // the k_img-only program carries the image form instead
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     const global void * q_void, ulong q_offset,
@@ -1680,8 +1696,17 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     const int split_idx        = split_q_idx % n_splits;
     const int q_idx            = split_q_idx / n_splits;
 
-    const int batch_idx   = kvhead_batch_idx / n_head_kv;
-    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+    // FA_HEAD_SUB > 1 splits the gqa group across that many workgroups, so a
+    // gqa=8 model can run an MQ_GQA=4 kernel: half the per-head state per lane
+    // (o_acc, m_i, l_i, slope) and twice the grid, at the cost of reading each
+    // KV row FA_HEAD_SUB times. At FA_HEAD_SUB == 1 this is the original
+    // indexing exactly. Same scheme as the cluster kernel.
+    const int hgroups     = n_head_kv * FA_HEAD_SUB;
+    const int batch_idx   = kvhead_batch_idx / hgroups;
+    const int hg          = kvhead_batch_idx % hgroups;
+    const int head_kv_idx = hg / FA_HEAD_SUB;
+    const int head_sub    = hg % FA_HEAD_SUB;
+#define FA_MQS_HEAD_IDX(h) (head_kv_idx * (MQ_GQA * FA_HEAD_SUB) + head_sub * MQ_GQA + (h))
 
     const int kv_start = split_idx * kv_per_split;
     const int kv_end   = min(kv_start + kv_per_split, n_kv);
@@ -1694,7 +1719,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         if (tid == 0) {
             #pragma unroll
             for (int h = 0; h < MQ_GQA; ++h) {
-                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const int head_idx = FA_MQS_HEAD_IDX(h);
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
@@ -1713,7 +1738,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     ACC_TYPE4 q_reg[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const int head_idx = FA_MQS_HEAD_IDX(h);
         const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
         const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
         q_reg[h] = (tid_sg < DK_VEC) ? CONVERT_Q_ACC4(q_ptr[tid_sg]) : (ACC_TYPE4)(0.0f);
@@ -1724,7 +1749,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE) {
         const int h        = i / DK_VEC;
         const int k        = i % DK_VEC;
-        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const int head_idx = FA_MQS_HEAD_IDX(h);
         const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
         const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
         q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
@@ -1735,7 +1760,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+        slope[h] = get_alibi_slope(max_bias, FA_MQS_HEAD_IDX(h), n_head_log2, m0, m1);
     }
 
     const global char * mask_base[MQ_GQA];
@@ -1746,7 +1771,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
                                           (ulong) q_idx * mask_nb1;
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
-            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int head_idx      = FA_MQS_HEAD_IDX(h);
             const int mask_head_idx = head_idx % mask_ne2;
             mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
         }
@@ -1859,7 +1884,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         barrier(CLK_LOCAL_MEM_FENCE);
 
         if (sgid == 0) {
-            const int head_idx = head_kv_idx * MQ_GQA + h;
+            const int head_idx = FA_MQS_HEAD_IDX(h);
 
             // fold per-subgroup (m, l) into split-level (m_c, l_c)
             ACC_TYPE m_c = sg_m[h][0];
@@ -1919,8 +1944,11 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
 // (p = exp(FA_M_INIT - m) underflows to 0, so clamped-row reads are inert).
 // Register cost vs baseline: o_acc grows from DV_VEC/64 to DV_VEC/FA_CL_C
 // float4 per lane per head — FA_CL_C=8 / MQ_GQA=4 => 16 float4 (256B).
+#undef FA_MQS_HEAD_IDX
 
-#ifdef HAS_SUBGROUP_SHUFFLE  // cluster reduce/merge needs shuffles; absent -> kernel dropped, dispatch falls back
+#endif  // !FA_MQ_KIMG (q1_vec_mq_split, buffer form)
+
+#if defined(HAS_SUBGROUP_SHUFFLE) && !defined(FA_MQ_SPLIT_ONLY)  // cluster reduce/merge needs shuffles; absent -> kernel dropped, dispatch falls back
 
 #ifndef FA_CL_C
 #define FA_CL_C 8
@@ -2531,6 +2559,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
 #endif  // DK_VEC/DV_VEC divisible by FA_CL_C
 #endif  // HAS_SUBGROUP_SHUFFLE (q1_vec_mq_split_c8)
 
+#if !defined(FA_MQ_SPLIT_ONLY) || defined(FA_MQ_KIMG)
 REQD_SUBGROUP_SIZE_64
 #undef FA_HEAD_IDX
 
@@ -2570,8 +2599,17 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
     const int split_idx        = split_q_idx % n_splits;
     const int q_idx            = split_q_idx / n_splits;
 
-    const int batch_idx   = kvhead_batch_idx / n_head_kv;
-    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+    // FA_HEAD_SUB > 1 splits the gqa group across that many workgroups, so a
+    // gqa=8 model can run an MQ_GQA=4 kernel: half the per-head state per lane
+    // (o_acc, m_i, l_i, slope) and twice the grid, at the cost of reading each
+    // KV row FA_HEAD_SUB times. At FA_HEAD_SUB == 1 this is the original
+    // indexing exactly. Same scheme as the cluster kernel.
+    const int hgroups     = n_head_kv * FA_HEAD_SUB;
+    const int batch_idx   = kvhead_batch_idx / hgroups;
+    const int hg          = kvhead_batch_idx % hgroups;
+    const int head_kv_idx = hg / FA_HEAD_SUB;
+    const int head_sub    = hg % FA_HEAD_SUB;
+#define FA_MQI_HEAD_IDX(h) (head_kv_idx * (MQ_GQA * FA_HEAD_SUB) + head_sub * MQ_GQA + (h))
 
     const int kv_start = split_idx * kv_per_split;
     const int kv_end   = min(kv_start + kv_per_split, n_kv);
@@ -2582,7 +2620,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
         if (tid == 0) {
             #pragma unroll
             for (int h = 0; h < MQ_GQA; ++h) {
-                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const int head_idx = FA_MQI_HEAD_IDX(h);
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
@@ -2600,7 +2638,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE) {
         const int h        = i / DK_VEC;
         const int k        = i % DK_VEC;
-        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const int head_idx = FA_MQI_HEAD_IDX(h);
         const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
         const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
         q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
@@ -2610,7 +2648,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+        slope[h] = get_alibi_slope(max_bias, FA_MQI_HEAD_IDX(h), n_head_log2, m0, m1);
     }
 
     const global char * mask_base[MQ_GQA];
@@ -2621,7 +2659,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
                                           (ulong) q_idx * mask_nb1;
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
-            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int head_idx      = FA_MQI_HEAD_IDX(h);
             const int mask_head_idx = head_idx % mask_ne2;
             mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
         }
@@ -2730,7 +2768,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
         barrier(CLK_LOCAL_MEM_FENCE);
 
         if (sgid == 0) {
-            const int head_idx = head_kv_idx * MQ_GQA + h;
+            const int head_idx = FA_MQI_HEAD_IDX(h);
 
             ACC_TYPE m_c = sg_m[h][0];
             #pragma unroll
@@ -2765,9 +2803,13 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 }
+#undef FA_MQI_HEAD_IDX
+
+#endif  // !FA_MQ_SPLIT_ONLY || FA_MQ_KIMG (q1_vec_mq_split_k_img)
+
 #endif  // !FA_DECODE_ONLY
 
-#ifndef FA_MQ_ONLY  // q1_split + merge excluded from the MQ-only (g8) program
+#if !defined(FA_MQ_ONLY) && !defined(FA_VEC_ONLY)  // q1_split + merge excluded from the MQ-only (g8) and vec-only programs
 __kernel void flash_attn_f32_f16_q1_split(
     const global void * q_void, ulong q_offset,
     const global void * k_void, ulong k_offset,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_f16.cl
@@ -54,6 +54,13 @@
 #endif
 #define Q1_WG_SIZE FA_SG
 
+// Decode (q1) MQ kernels: when DK_VEC <= FA_SG each lane owns exactly one Q
+// quartet for the entire KV sweep, so Q lives in registers instead of a
+// staging LDS array (drops the array and the entry barrier).
+#if (DK/4) <= FA_SG
+#define FA_Q1_Q_REG 1
+#endif
+
 // The kernels are built with -cl-finite-math-only. On some older Adreno GPUs,
 // infinite operand can cause undefined behavior and miscompilation for exp.
 // Therefore, a large negative value is used instead.
@@ -1429,6 +1436,16 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
     const global char * v_base = (const global char *) v_void + v_offset;
     global       char * o_base = (global       char *) o_void + o_offset;
 
+#ifdef FA_Q1_Q_REG
+    ACC_TYPE4 q_reg[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        q_reg[h] = (tid_sg < DK_VEC) ? CONVERT_Q_ACC4(q_ptr[tid_sg]) : (ACC_TYPE4)(0.0f);
+    }
+#else
     __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_WG_SIZE) {
         const int h        = i / DK_VEC;
@@ -1439,6 +1456,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
         q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
     }
     barrier(CLK_LOCAL_MEM_FENCE);
+#endif
 
     // per-h ALiBi slope
     float slope[MQ_GQA];
@@ -1496,6 +1514,15 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
         ACC_TYPE4 dot4[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
+#ifdef FA_Q1_Q_REG
+        if (tid_sg < DK_VEC) {
+            const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_ptr[tid_sg]);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                dot4[h] = mad(q_reg[h], k_vec, dot4[h]);
+            }
+        }
+#else
         for (int k = tid_sg; k < DK_VEC; k += Q1_WG_SIZE) {
             const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_ptr[k]);
             #pragma unroll
@@ -1503,6 +1530,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq(
                 dot4[h] = mad(q_shared[h * DK_VEC + k], k_vec, dot4[h]);
             }
         }
+#endif
 
         ACC_TYPE score[MQ_GQA];
         #pragma unroll
@@ -1681,6 +1709,16 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
     const global char * k_base = (const global char *) k_void + k_offset;
     const global char * v_base = (const global char *) v_void + v_offset;
 
+#ifdef FA_Q1_Q_REG
+    ACC_TYPE4 q_reg[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
+        const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
+        q_reg[h] = (tid_sg < DK_VEC) ? CONVERT_Q_ACC4(q_ptr[tid_sg]) : (ACC_TYPE4)(0.0f);
+    }
+#else
     // stage MQ_GQA Q rows in __local once (uniform across WG)
     __local ACC_TYPE4 q_shared[MQ_GQA * DK_VEC];
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE) {
@@ -1692,6 +1730,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
     }
     barrier(CLK_LOCAL_MEM_FENCE);
+#endif
 
     float slope[MQ_GQA];
     #pragma unroll
@@ -1742,6 +1781,15 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
         ACC_TYPE4 dot4[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
+#ifdef FA_Q1_Q_REG
+        if (tid_sg < DK_VEC) {
+            const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_ptr[tid_sg]);
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                dot4[h] = mad(q_reg[h], k_vec, dot4[h]);
+            }
+        }
+#else
         for (int k = tid_sg; k < DK_VEC; k += Q1_WG_SIZE) {
             const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_ptr[k]);
             #pragma unroll
@@ -1749,6 +1797,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
                 dot4[h] = mad(q_shared[h * DK_VEC + k], k_vec, dot4[h]);
             }
         }
+#endif
 
         ACC_TYPE score[MQ_GQA];
         #pragma unroll
@@ -1876,6 +1925,10 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
 #ifndef FA_CL_C
 #define FA_CL_C 8
 #endif
+// Workgroups per gqa group (1 = one WG owns all MQ_GQA heads of a KV head).
+#ifndef FA_HEAD_SUB
+#define FA_HEAD_SUB 1
+#endif
 
 // The lane striping requires DK/DV to divide evenly across the cluster;
 // otherwise (e.g. DK=40 with FA_CL_C=16 -> zero-size arrays) compile the
@@ -1900,7 +1953,11 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split(
 FA_C8_SG_ATTR
 __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
     const global void * q_void, ulong q_offset,
+#ifdef FA_K_IMG
+    __read_only image1d_buffer_t k_img,
+#else
     const global void * k_void, ulong k_offset,
+#endif
     const global void * v_void, ulong v_offset,
     const float scale,
     const int n_q,
@@ -1936,8 +1993,17 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
     const int split_idx        = split_q_idx % n_splits;
     const int q_idx            = split_q_idx / n_splits;
 
-    const int batch_idx   = kvhead_batch_idx / n_head_kv;
-    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+    // FA_HEAD_SUB > 1 splits the gqa group across that many workgroups, so a
+    // gqa=8 model can run an MQ_GQA=4 kernel: half the per-head state per lane
+    // (o_acc, m_i, l_i, slope) and twice the grid, at the cost of reading each
+    // KV row FA_HEAD_SUB times. At FA_HEAD_SUB == 1 this is the original
+    // indexing exactly.
+    const int hgroups     = n_head_kv * FA_HEAD_SUB;
+    const int batch_idx   = kvhead_batch_idx / hgroups;
+    const int hg          = kvhead_batch_idx % hgroups;
+    const int head_kv_idx = hg / FA_HEAD_SUB;
+    const int head_sub    = hg % FA_HEAD_SUB;
+#define FA_HEAD_IDX(h) (head_kv_idx * (MQ_GQA * FA_HEAD_SUB) + head_sub * MQ_GQA + (h))
 
     const int kv_start = split_idx * kv_per_split;
     const int kv_end   = min(kv_start + kv_per_split, n_kv);
@@ -1948,7 +2014,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
         if (tid == 0) {
             #pragma unroll
             for (int h = 0; h < MQ_GQA; ++h) {
-                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const int head_idx = FA_HEAD_IDX(h);
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
@@ -1960,7 +2026,9 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
     }
 
     const global char * q_base = (const global char *) q_void + q_offset;
+#ifndef FA_K_IMG
     const global char * k_base = (const global char *) k_void + k_offset;
+#endif
     const global char * v_base = (const global char *) v_void + v_offset;
 
     // Stage MQ_GQA Q rows in __local once (uniform across WG).
@@ -1968,7 +2036,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE) {
         const int h        = i / DK_VEC;
         const int k        = i % DK_VEC;
-        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const int head_idx = FA_HEAD_IDX(h);
         const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
         const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
         q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
@@ -1978,9 +2046,23 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+        slope[h] = get_alibi_slope(max_bias, FA_HEAD_IDX(h), n_head_log2, m0, m1);
     }
 
+#ifdef FA_CL_MASK_BCAST
+    // At mask_ne2 == 1 every clustered head reads the same mask row, so keep
+    // one base and load the element once per position instead of once per
+    // head. Only a win where the saved dependent loads outweigh the extra
+    // live value: +2.9/+4.2% at dk=64 MQ_GQA=8, but -4/-5% at dk=128 MQ_GQA=4
+    // (private_mem 352 -> 368), hence the per-program gate.
+    const global char * mask_base_b = NULL;
+    if (mask_void != NULL) {
+        mask_base_b = (const global char *) mask_void + mask_offset +
+                      (batch_idx % mask_ne3) * mask_nb3 +
+                      (ulong) q_idx * mask_nb1;
+    }
+    const int mask_bcast = mask_base_b != NULL && mask_ne2 == 1;
+#else
     const global char * mask_base[MQ_GQA];
     if (mask_void != NULL) {
         const int mask_batch_idx = batch_idx % mask_ne3;
@@ -1989,7 +2071,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
                                           (ulong) q_idx * mask_nb1;
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
-            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int head_idx      = FA_HEAD_IDX(h);
             const int mask_head_idx = head_idx % mask_ne2;
             mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
         }
@@ -1997,6 +2079,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
     }
+#endif
 
     // Per-CLUSTER online-softmax state (uniform across the cluster's lanes);
     // o_acc holds this lane's DV slice {lic + FA_CL_C*i}.
@@ -2028,9 +2111,213 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
         const int valid = k_idx < kv_hi;
         const int k_safe = valid ? k_idx : (kv_hi - 1);
 
+#ifdef FA_K_IMG
+        const int k_px = (int) ((kv_row_base + (ulong) k_safe * k_nb1) >> 3);
+#else
         const global KV_DATA_TYPE4 * k_ptr = (const global KV_DATA_TYPE4 *) (k_base + kv_row_base + (ulong) k_safe * k_nb1);
+#endif
         const global KV_DATA_TYPE4 * v_ptr = (const global KV_DATA_TYPE4 *) (v_base + v_row_base  + (ulong) k_safe * v_nb1);
 
+#ifdef FA_CL_MASK_BCAST
+        // Issue the broadcast mask load with the K row so both are in flight.
+        ACC_TYPE mask_val = (ACC_TYPE) 0.0f;
+        if (mask_bcast) {
+            mask_val = (ACC_TYPE) ((const global MASK_DATA_TYPE *) mask_base_b)[k_safe];
+        }
+#endif
+
+#if FA_CL_DK == 1 && FA_CL_DV == 1
+        // Single pass per head. At FA_CL_DK/DV == 1 each lane owns exactly one K and
+        // one V quartet, so score/p/sp never need to be live for all MQ_GQA heads at
+        // once, and the float4 dot accumulator collapses to a scalar. Same arithmetic,
+        // same order within a head; heads are independent.
+#ifdef FA_K_IMG
+        const ACC_TYPE4 k_vec_1 = CONVERT_KV_ACC4(read_imageh(k_img, k_px + lic));
+#else
+        const ACC_TYPE4 k_vec_1 = CONVERT_KV_ACC4(k_ptr[lic]);
+#endif
+        const ACC_TYPE4 v_vec_1 = CONVERT_KV_ACC4(v_ptr[lic]);
+
+#if defined(FA_CL_MHRED) && MQ_GQA == 2 && FA_CL_C == 16
+        // Multi-head fused cluster reduce, MQ_GQA=2 form: 2 values per lane fold
+        // to 1 over 2 lanes (1 shuffle), three plain steps finish the 16-lane
+        // sum, 1 shuffle expands both heads back -- 5 instead of 2*log2(16)=8.
+        const int mh_b0 = lic & 1;
+
+        ACC_TYPE mh_p[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE4 d4 = mad(q_shared[h * DK_VEC + lic], k_vec_1, (ACC_TYPE4)(0.0f));
+            mh_p[h] = d4.s0 + d4.s1 + d4.s2 + d4.s3;
+        }
+        ACC_TYPE mh_r1 = (mh_b0 ? mh_p[1] : mh_p[0]) +
+                         sub_group_shuffle_xor(mh_b0 ? mh_p[0] : mh_p[1], 1);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 2);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 4);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 8);
+
+        ACC_TYPE mh_s[MQ_GQA];
+        {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_r1, 1);
+            mh_s[0] = mh_b0 ? other  : mh_r1;
+            mh_s[1] = mh_b0 ? mh_r1  : other;
+        }
+#endif
+
+#if defined(FA_CL_MHRED) && MQ_GQA == 4 && FA_CL_C == 16
+        // Multi-head fused cluster reduce, MQ_GQA=4 form. Same halving butterfly
+        // as the MQ_GQA=8 case: 4 values per lane fold to 1 over 4 lanes (2+1
+        // shuffles), two plain steps finish the 16-lane sum, and 3 shuffles
+        // expand every head back to every lane -- 8 instead of MQ_GQA*log2(C)=16.
+        // Rounds run in increasing xor distance, so each head's summation tree is
+        // pairwise identical to the per-head butterfly's and the scores are
+        // bit-identical.
+        const int mh_b0 = lic & 1;
+        const int mh_b1 = lic & 2;
+
+        ACC_TYPE mh_p[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE4 d4 = mad(q_shared[h * DK_VEC + lic], k_vec_1, (ACC_TYPE4)(0.0f));
+            mh_p[h] = d4.s0 + d4.s1 + d4.s2 + d4.s3;
+        }
+
+        ACC_TYPE mh_r2[2];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE keep = mh_b0 ? mh_p[j + 2] : mh_p[j];
+            const ACC_TYPE send = mh_b0 ? mh_p[j]     : mh_p[j + 2];
+            mh_r2[j] = keep + sub_group_shuffle_xor(send, 1);
+        }
+        ACC_TYPE mh_r1 = (mh_b1 ? mh_r2[1] : mh_r2[0]) +
+                         sub_group_shuffle_xor(mh_b1 ? mh_r2[0] : mh_r2[1], 2);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 4);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 8);
+
+        ACC_TYPE mh_e2[2];
+        {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_r1, 2);
+            mh_e2[0] = mh_b1 ? other  : mh_r1;
+            mh_e2[1] = mh_b1 ? mh_r1  : other;
+        }
+        ACC_TYPE mh_s[MQ_GQA];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_e2[j], 1);
+            mh_s[j]     = mh_b0 ? other     : mh_e2[j];
+            mh_s[j + 2] = mh_b0 ? mh_e2[j]  : other;
+        }
+#endif
+
+#if defined(FA_CL_MHRED) && MQ_GQA == 8 && FA_CL_C == 16
+        // Multi-head fused cluster reduce.
+        //
+        // The per-head loop below runs MQ_GQA independent all-reduces over
+        // FA_CL_C lanes = MQ_GQA * log2(FA_CL_C) = 32 shuffles per KV row,
+        // against 16 bytes of KV read. Folding them into one halving butterfly
+        // -- each round halves the values a lane carries while doubling the
+        // lane span -- costs 4+2+1+1 = 8 shuffles to reduce to one head per
+        // lane and 1+2+4 = 7 to expand every head back to every lane: 15
+        // instead of 32.
+        //
+        // The rounds run in INCREASING xor distance so each head's summation
+        // tree is pairwise identical to the per-head butterfly's (distance 1,
+        // then 2, 4, 8). Same operand order => bit-identical scores, not just
+        // mathematically equivalent ones.
+        const int mh_b0 = lic & 1;
+        const int mh_b1 = lic & 2;
+        const int mh_b2 = lic & 4;
+
+        ACC_TYPE mh_p[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            const ACC_TYPE4 d4 = mad(q_shared[h * DK_VEC + lic], k_vec_1, (ACC_TYPE4)(0.0f));
+            mh_p[h] = d4.s0 + d4.s1 + d4.s2 + d4.s3;
+        }
+
+        // Reduce 8 -> 4 -> 2 -> 1 values per lane, then one plain step to close
+        // the distance-8 pair, whose two lanes hold the same head.
+        ACC_TYPE mh_r4[4];
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const ACC_TYPE keep = mh_b0 ? mh_p[j + 4] : mh_p[j];
+            const ACC_TYPE send = mh_b0 ? mh_p[j]     : mh_p[j + 4];
+            mh_r4[j] = keep + sub_group_shuffle_xor(send, 1);
+        }
+        ACC_TYPE mh_r2[2];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE keep = mh_b1 ? mh_r4[j + 2] : mh_r4[j];
+            const ACC_TYPE send = mh_b1 ? mh_r4[j]     : mh_r4[j + 2];
+            mh_r2[j] = keep + sub_group_shuffle_xor(send, 2);
+        }
+        ACC_TYPE mh_r1 = (mh_b2 ? mh_r2[1] : mh_r2[0]) +
+                         sub_group_shuffle_xor(mh_b2 ? mh_r2[0] : mh_r2[1], 4);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 8);
+
+        // Expand: mirror the reduce, doubling the values a lane carries.
+        ACC_TYPE mh_e2[2];
+        {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_r1, 4);
+            mh_e2[0] = mh_b2 ? other : mh_r1;
+            mh_e2[1] = mh_b2 ? mh_r1 : other;
+        }
+        ACC_TYPE mh_e4[4];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_e2[j], 2);
+            mh_e4[j]     = mh_b1 ? other    : mh_e2[j];
+            mh_e4[j + 2] = mh_b1 ? mh_e2[j] : other;
+        }
+        ACC_TYPE mh_s[MQ_GQA];
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_e4[j], 1);
+            mh_s[j]     = mh_b0 ? other    : mh_e4[j];
+            mh_s[j + 4] = mh_b0 ? mh_e4[j] : other;
+        }
+#endif
+
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+#if defined(FA_CL_MHRED) && (MQ_GQA == 8 || MQ_GQA == 4 || MQ_GQA == 2) && FA_CL_C == 16
+            ACC_TYPE s = mh_s[h];
+#else
+            const ACC_TYPE4 d4 = mad(q_shared[h * DK_VEC + lic], k_vec_1, (ACC_TYPE4)(0.0f));
+            ACC_TYPE s = d4.s0 + d4.s1 + d4.s2 + d4.s3;
+            #pragma unroll
+            for (int step = 1; step < FA_CL_C; step <<= 1) {
+                s += sub_group_shuffle_xor(s, step);
+            }
+#endif
+            s *= scale;
+#ifdef FA_CL_MASK_BCAST
+            if (mask_bcast) {
+                s += slope[h] * mask_val;
+            } else if (mask_base_b != NULL) {
+                const int mask_head_idx = (FA_HEAD_IDX(h)) % mask_ne2;
+                const global MASK_DATA_TYPE * mask_ptr =
+                    (const global MASK_DATA_TYPE *) (mask_base_b + mask_head_idx * mask_nb2);
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_safe];
+            }
+#else
+            if (mask_base[h] != NULL) {
+                const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_safe];
+            }
+#endif
+            if (logit_softcap > 0.0f) {
+                s = logit_softcap * tanh(s / logit_softcap);
+            }
+            const ACC_TYPE sc    = valid ? s : FA_M_INIT;
+            const ACC_TYPE m_new = max(m_i[h], sc);
+            const ACC_TYPE sp    = native_exp(m_i[h] - m_new);
+            const ACC_TYPE p     = native_exp(sc - m_new);
+            l_i[h] = l_i[h] * sp + p;
+            m_i[h] = m_new;
+            o_acc[h][0] = mad(p, v_vec_1, o_acc[h][0] * sp);
+        }
+#else
         // Dot: this lane covers DK elements {lic + FA_CL_C*i} of the cluster's row.
         ACC_TYPE4 dot4[MQ_GQA];
         #pragma unroll
@@ -2038,7 +2325,11 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
         #pragma unroll
         for (int i = 0; i < FA_CL_DK; ++i) {
             const int kk = lic + FA_CL_C * i;
+#ifdef FA_K_IMG
+            const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(read_imageh(k_img, k_px + kk));
+#else
             const ACC_TYPE4 k_vec = CONVERT_KV_ACC4(k_ptr[kk]);
+#endif
             #pragma unroll
             for (int h = 0; h < MQ_GQA; ++h) {
                 dot4[h] = mad(q_shared[h * DK_VEC + kk], k_vec, dot4[h]);
@@ -2046,19 +2337,71 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
         }
 
         // Cluster-reduce (xor steps < FA_CL_C stay inside the cluster) + score.
+#if defined(FA_CL_MHRED) && MQ_GQA == 4 && FA_CL_C == 16
+        // Halving butterfly fed from the multi-quartet dot accumulator, so it
+        // also covers DK=128 (FA_CL_DK=2). 8 shuffles per KV row instead of
+        // MQ_GQA*log2(FA_CL_C)=16; increasing xor distance keeps each head's
+        // summation tree, and therefore the score, unchanged.
+        const int mh_b0 = lic & 1;
+        const int mh_b1 = lic & 2;
+        ACC_TYPE mh_p[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            mh_p[h] = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+        }
+        ACC_TYPE mh_r2[2];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE keep = mh_b0 ? mh_p[j + 2] : mh_p[j];
+            const ACC_TYPE send = mh_b0 ? mh_p[j]     : mh_p[j + 2];
+            mh_r2[j] = keep + sub_group_shuffle_xor(send, 1);
+        }
+        ACC_TYPE mh_r1 = (mh_b1 ? mh_r2[1] : mh_r2[0]) +
+                         sub_group_shuffle_xor(mh_b1 ? mh_r2[0] : mh_r2[1], 2);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 4);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 8);
+        ACC_TYPE mh_e2[2];
+        {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_r1, 2);
+            mh_e2[0] = mh_b1 ? other : mh_r1;
+            mh_e2[1] = mh_b1 ? mh_r1 : other;
+        }
+        ACC_TYPE mh_sg[MQ_GQA];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_e2[j], 1);
+            mh_sg[j]     = mh_b0 ? other    : mh_e2[j];
+            mh_sg[j + 2] = mh_b0 ? mh_e2[j] : other;
+        }
+#endif
         ACC_TYPE score[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
+#if defined(FA_CL_MHRED) && MQ_GQA == 4 && FA_CL_C == 16
+            ACC_TYPE s = mh_sg[h];
+#else
             ACC_TYPE s = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
             #pragma unroll
             for (int step = 1; step < FA_CL_C; step <<= 1) {
                 s += sub_group_shuffle_xor(s, step);
             }
+#endif
             s *= scale;
+#ifdef FA_CL_MASK_BCAST
+            if (mask_bcast) {
+                s += slope[h] * mask_val;
+            } else if (mask_base_b != NULL) {
+                const int mask_head_idx = (FA_HEAD_IDX(h)) % mask_ne2;
+                const global MASK_DATA_TYPE * mask_ptr =
+                    (const global MASK_DATA_TYPE *) (mask_base_b + mask_head_idx * mask_nb2);
+                s += slope[h] * (ACC_TYPE) mask_ptr[k_safe];
+            }
+#else
             if (mask_base[h] != NULL) {
                 const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
                 s += slope[h] * (ACC_TYPE) mask_ptr[k_safe];
             }
+#endif
             if (logit_softcap > 0.0f) {
                 s = logit_softcap * tanh(s / logit_softcap);
             }
@@ -2087,6 +2430,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
                 o_acc[h][i] = mad(p_h[h], v_vec, o_acc[h][i] * sp_h[h]);
             }
         }
+#endif
     }
 
     // Merge stage 1: fold the FA_CL_NCL cluster partials inside the subgroup.
@@ -2148,7 +2492,7 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
         barrier(CLK_LOCAL_MEM_FENCE);
 
         if (sgid == 0) {
-            const int head_idx = head_kv_idx * MQ_GQA + h;
+            const int head_idx = FA_HEAD_IDX(h);
 
             ACC_TYPE m_c = sg_m[h][0];
             #pragma unroll
@@ -2188,6 +2532,8 @@ __kernel void flash_attn_f32_f16_q1_vec_mq_split_c8(
 #endif  // HAS_SUBGROUP_SHUFFLE (q1_vec_mq_split_c8)
 
 REQD_SUBGROUP_SIZE_64
+#undef FA_HEAD_IDX
+
 __kernel void flash_attn_f32_f16_q1_vec_mq_split_k_img(
     const global void * q_void, ulong q_offset,
     __read_only image1d_buffer_t k_img,

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -714,7 +714,7 @@ __kernel void flash_attn_f32_q8_0_q1_split(
     }
 }
 
-// Prefill: q8_0 K/V, n_q > 1. BLOCK_M × BLOCK_N tiling.
+// Prefill: q8_0 K/V, n_q > 1. BLOCK_M ? BLOCK_N tiling.
 // K path keeps packed int8 in local for dp4a QK dot; V path dequant -> half in local.
 // Requires DK % QK8_0 == 0 and DV % QK8_0 == 0 (gated in supports_op).
 #define KV_DATA_TYPE4 half4
@@ -801,7 +801,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
     const ulong record_stride = (ulong) FA_PARTIAL_FLOATS;
 
     if (kv_start >= kv_end) {
-        // Empty split — write sentinel for each of the MQ_GQA Q-heads.
+        // Empty split ? write sentinel for each of the MQ_GQA Q-heads.
         if (tid == 0) {
             #pragma unroll
             for (int h = 0; h < MQ_GQA; ++h) {
@@ -1058,6 +1058,11 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
 #define FA_CL_C 8
 #endif
 
+// Workgroups per gqa group (1 = one WG owns all MQ_GQA heads of a KV head).
+#ifndef FA_HEAD_SUB
+#define FA_HEAD_SUB 1
+#endif
+
 // Lane striping requires DK/DV to divide across the cluster (see f16 c8).
 #if (DK_VEC % FA_CL_C) == 0 && (DV_VEC % FA_CL_C) == 0
 #define FA_CL_NCL  (Q1_WG_SIZE / FA_CL_C)   // clusters (position streams) per subgroup
@@ -1109,8 +1114,21 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
     const int split_idx        = split_q_idx % n_splits;
     const int q_idx            = split_q_idx / n_splits;
 
-    const int batch_idx   = kvhead_batch_idx / n_head_kv;
-    const int head_kv_idx = kvhead_batch_idx % n_head_kv;
+    // FA_HEAD_SUB > 1 splits the gqa group across that many workgroups, so a
+    // gqa=8 model can run an MQ_GQA=4 kernel: half the per-head state per lane
+    // (o_acc, m_i, l_i, slope) and twice the grid, at the cost of reading each
+    // KV row FA_HEAD_SUB times. At FA_HEAD_SUB == 1 this is the original
+    // indexing exactly. Same scheme as the f16 kernel, where it took the
+    // dk=64 gqa8 shape from 576 to 368 B/WI -- this fork still sits at 592 for
+    // the same shape, which is the measured cause of its decode deficit.
+    // head_kv_idx still selects the KV head, so every sub-group reads the same
+    // K/V rows; only the Q heads it owns differ.
+    const int hgroups     = n_head_kv * FA_HEAD_SUB;
+    const int batch_idx   = kvhead_batch_idx / hgroups;
+    const int hg          = kvhead_batch_idx % hgroups;
+    const int head_kv_idx = hg / FA_HEAD_SUB;
+    const int head_sub    = hg % FA_HEAD_SUB;
+#define FA_Q8CL_HEAD_IDX(h) (head_kv_idx * (MQ_GQA * FA_HEAD_SUB) + head_sub * MQ_GQA + (h))
 
     const int kv_start = split_idx * kv_per_split;
     const int kv_end   = min(kv_start + kv_per_split, n_kv);
@@ -1121,7 +1139,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         if (tid == 0) {
             #pragma unroll
             for (int h = 0; h < MQ_GQA; ++h) {
-                const int head_idx = head_kv_idx * MQ_GQA + h;
+                const int head_idx = FA_Q8CL_HEAD_IDX(h);
                 const ulong rec_idx = ((((ulong) batch_idx * n_head + head_idx) * n_q + q_idx)
                                        * n_splits + split_idx);
                 global float * rec = partial_void + rec_idx * record_stride;
@@ -1141,7 +1159,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
     for (int i = tid; i < MQ_GQA * DK_VEC; i += MQ_SPLIT_WG_SIZE_Q8) {
         const int h        = i / DK_VEC;
         const int k        = i % DK_VEC;
-        const int head_idx = head_kv_idx * MQ_GQA + h;
+        const int head_idx = FA_Q8CL_HEAD_IDX(h);
         const ulong q_row_offset = batch_idx * q_nb3 + head_idx * q_nb2 + (ulong) q_idx * q_nb1;
         const global Q_DATA_TYPE4 * q_ptr = (const global Q_DATA_TYPE4 *) (q_base + q_row_offset);
         q_shared[h * DK_VEC + k] = CONVERT_Q_ACC4(q_ptr[k]);
@@ -1173,7 +1191,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
-        slope[h] = get_alibi_slope(max_bias, head_kv_idx * MQ_GQA + h, n_head_log2, m0, m1);
+        slope[h] = get_alibi_slope(max_bias, FA_Q8CL_HEAD_IDX(h), n_head_log2, m0, m1);
     }
 
     const global char * mask_base[MQ_GQA];
@@ -1184,7 +1202,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
                                           (ulong) q_idx * mask_nb1;
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
-            const int head_idx      = head_kv_idx * MQ_GQA + h;
+            const int head_idx      = FA_Q8CL_HEAD_IDX(h);
             const int mask_head_idx = head_idx % mask_ne2;
             mask_base[h] = mask_base_b + mask_head_idx * mask_nb2;
         }
@@ -1271,6 +1289,42 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
 #endif
         }
 
+#if defined(FA_CL_MHRED) && MQ_GQA == 4 && FA_CL_C == 16 && FA_CL_DKQ == 1
+        // MQ_GQA=4 form, for the head-split program (FA_HEAD_SUB=2 turns a
+        // gqa=8 model into two MQ_GQA=4 workgroups). 4 values per lane fold to
+        // 1 over 4 lanes (2+1 shuffles), two plain steps finish the 16-lane
+        // sum, 3 shuffles expand -- 8 instead of MQ_GQA*log2(C)=16. Increasing
+        // xor distance, so scores stay bit-identical.
+        const int mh_b0 = lic & 1;
+        const int mh_b1 = lic & 2;
+
+        ACC_TYPE mh_r2[2];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE keep = mh_b0 ? mh_p[j + 2] : mh_p[j];
+            const ACC_TYPE send = mh_b0 ? mh_p[j]     : mh_p[j + 2];
+            mh_r2[j] = keep + sub_group_shuffle_xor(send, 1);
+        }
+        ACC_TYPE mh_r1 = (mh_b1 ? mh_r2[1] : mh_r2[0]) +
+                         sub_group_shuffle_xor(mh_b1 ? mh_r2[0] : mh_r2[1], 2);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 4);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 8);
+
+        ACC_TYPE mh_e2[2];
+        {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_r1, 2);
+            mh_e2[0] = mh_b1 ? other : mh_r1;
+            mh_e2[1] = mh_b1 ? mh_r1 : other;
+        }
+        ACC_TYPE mh_s[MQ_GQA];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_e2[j], 1);
+            mh_s[j]     = mh_b0 ? other    : mh_e2[j];
+            mh_s[j + 2] = mh_b0 ? mh_e2[j] : other;
+        }
+#endif
+
 #if defined(FA_CL_MHRED) && MQ_GQA == 8 && FA_CL_C == 16 && FA_CL_DKQ == 1
         // Multi-head fused cluster reduce, ported from the f16 kernel, which
         // got it in the gpt-oss FD round while this fork did not.
@@ -1334,7 +1388,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         ACC_TYPE score[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
-#if defined(FA_CL_MHRED) && MQ_GQA == 8 && FA_CL_C == 16 && FA_CL_DKQ == 1
+#if defined(FA_CL_MHRED) && (MQ_GQA == 8 || MQ_GQA == 4) && FA_CL_C == 16 && FA_CL_DKQ == 1
             ACC_TYPE s = mh_s[h];
 #else
             ACC_TYPE s = mh_p[h];
@@ -1433,7 +1487,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         barrier(CLK_LOCAL_MEM_FENCE);
 
         if (sgid == 0) {
-            const int head_idx = head_kv_idx * MQ_GQA + h;
+            const int head_idx = FA_Q8CL_HEAD_IDX(h);
 
             ACC_TYPE m_c = sg_m[h][0];
             #pragma unroll
@@ -1687,7 +1741,7 @@ __kernel void flash_attn_f32_q8_0(
             }
 #endif
         }
-        // V tile load — strategy-dependent.
+        // V tile load ? strategy-dependent.
 #if FA_V_STRATEGY == 2
         {
             // Int8 packed V in local memory + per-block scale. Accumulate

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -1194,6 +1194,31 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         slope[h] = get_alibi_slope(max_bias, FA_Q8CL_HEAD_IDX(h), n_head_log2, m0, m1);
     }
 
+#ifdef FA_CL_MASK_BCAST
+    // At mask_ne2 == 1 every clustered head reads the same mask row, so keep
+    // one base and load the element ONCE PER POSITION rather than once per
+    // head -- and, more to the point, issue that load at the top of the KV
+    // iteration alongside the K row instead of inside the per-head score loop.
+    //
+    // In this kernel the mask was a late, scattered, dependent load with
+    // nothing to hide it: deleting it outright measured +8.8% @d4096 /
+    // +14.0% @d8192, the entire remaining deficit against the f16 kernel.
+    const global char * mask_base_b = NULL;
+    if (mask_void != NULL) {
+        mask_base_b = (const global char *) mask_void + mask_offset +
+                      (batch_idx % mask_ne3) * mask_nb3 +
+                      (ulong) q_idx * mask_nb1;
+    }
+    const int mask_bcast = mask_base_b != NULL && mask_ne2 == 1;
+    // Heads still need their own row whenever the mask is per-head.
+    const global char * mask_base[MQ_GQA];
+    #pragma unroll
+    for (int h = 0; h < MQ_GQA; ++h) {
+        mask_base[h] = (mask_base_b != NULL && !mask_bcast)
+            ? mask_base_b + (FA_Q8CL_HEAD_IDX(h) % mask_ne2) * mask_nb2
+            : NULL;
+    }
+#else
     const global char * mask_base[MQ_GQA];
     if (mask_void != NULL) {
         const int mask_batch_idx = batch_idx % mask_ne3;
@@ -1210,6 +1235,7 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) mask_base[h] = NULL;
     }
+#endif
 
     // Per-CLUSTER online state; o_acc holds this lane's V quartets {lic + FA_CL_C*i}.
     ACC_TYPE4 o_acc[MQ_GQA][FA_CL_DVQ];
@@ -1241,6 +1267,17 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
 
         const global char * k_row = k_base + k_row_base + (ulong) k_safe * k_nb1;
         const global char * v_row = v_base + v_row_base + (ulong) k_safe * v_nb1;
+
+#ifdef FA_CL_MASK_BCAST
+        // Issue the broadcast mask load with the K row so both are in flight.
+        // This is the point of the change: previously the mask was read inside
+        // the per-head score loop, i.e. AFTER the cluster reduce, where its
+        // latency is fully exposed.
+        ACC_TYPE mask_val = (ACC_TYPE) 0.0f;
+        if (mask_bcast) {
+            mask_val = (ACC_TYPE) ((const global MASK_DATA_TYPE *) mask_base_b)[k_safe];
+        }
+#endif
 
 #ifdef FA_Q8_INT_QK
         // dp4a K dot over this lane's quartets of the cluster's row.
@@ -1398,6 +1435,11 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
             }
 #endif
             s *= scale;
+#ifdef FA_CL_MASK_BCAST
+            if (mask_bcast) {
+                s += slope[h] * mask_val;
+            } else
+#endif
             if (mask_base[h] != NULL) {
                 const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
                 s += slope[h] * (ACC_TYPE) mask_ptr[k_safe];

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -338,8 +338,19 @@ __kernel void flash_attn_f32_q8_0_q1(
 inline float4 dequant_q8_0_lane(const global char * block_ptr, int lane) {
     const float d = vload_half(0, (const global half *)block_ptr);
     const global char * qs = block_ptr + 2 + lane * 4;
+    // Keep the scalar char loads: a vload4/convert_float4 form measured
+    // -1.6..-2.8% tg on the X2-90 (DX.50.39) - the compiler does better here
+    // than the explicit vector load.
     return d * (float4)((float)qs[0], (float)qs[1], (float)qs[2], (float)qs[3]);
 }
+
+// dp4a QK dot for the decode (q1) kernels: staged Q rows are requantized to
+// packed int8 once per WG (same requantization as the q1_split int path), so
+// the KV sweep replaces dequant+float-mad with one integer dot per quartet.
+// Requires each lane's quartet index to fit one sweep (DK_VEC <= subgroup).
+#if defined(FA_HAVE_INT_DOT) && (DK_VEC <= FA_SG) && !defined(FA_Q8_INT_QK_OFF)
+#define FA_Q8_INT_QK 1
+#endif
 
 REQD_SUBGROUP_SIZE_64
 __kernel void flash_attn_f32_q8_0_q1_vec(
@@ -820,6 +831,29 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
+#ifdef FA_Q8_INT_QK
+    // Requantize the staged Q rows to packed int8 once per WG: one thread per
+    // (head, block). The KV sweep then runs dp4a against raw q8_0 K bytes.
+    __local uint  q_packed_l[MQ_GQA * DK_Q8_BLOCKS * 8];
+    __local float q_d_l[MQ_GQA * DK_Q8_BLOCKS];
+    for (int i = tid; i < MQ_GQA * DK_Q8_BLOCKS; i += MQ_SPLIT_WG_SIZE_Q8) {
+        const int h = i / DK_Q8_BLOCKS;
+        const int b = i % DK_Q8_BLOCKS;
+        ACC_TYPE4 qb[8];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            qb[j] = q_shared[h * DK_VEC + b * 8 + j];
+        }
+        uint packed_tmp[8];
+        q_d_l[i] = quant_q_block_int8_packed(qb, packed_tmp);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            q_packed_l[i * 8 + j] = packed_tmp[j];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+#endif
+
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
@@ -859,10 +893,46 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
     const int kv_lo     = kv_start + sgid * kv_per_sg;
     const int kv_hi     = min(kv_end, kv_lo + kv_per_sg);
 
+#ifdef FA_Q8_INT_QK
+    // DK_VEC <= subgroup size: this lane's quartet index is fixed for the
+    // whole sweep, so its packed-Q words and block scales hoist to registers.
+    uint  qp_h[MQ_GQA];
+    float qd_h[MQ_GQA];
+    {
+        const int b = tid_sg / 8;
+        const int j = tid_sg % 8;
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+            if (tid_sg < DK_VEC) {
+                qp_h[h] = q_packed_l[(h * DK_Q8_BLOCKS + b) * 8 + j];
+                qd_h[h] = q_d_l[h * DK_Q8_BLOCKS + b];
+            } else {
+                qp_h[h] = 0;
+                qd_h[h] = 0.0f;
+            }
+        }
+    }
+#endif
+
     for (int k_idx = kv_lo; k_idx < kv_hi; ++k_idx) {
         const global char * k_row = k_base + batch_idx * k_nb3 + head_kv_idx * k_nb2 + k_idx * k_nb1;
         const global char * v_row = v_base + batch_idx * v_nb3 + head_kv_idx * v_nb2 + k_idx * v_nb1;
 
+#ifdef FA_Q8_INT_QK
+        ACC_TYPE dot_s[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) dot_s[h] = 0.0f;
+        if (tid_sg < DK_VEC) {
+            const global char * kb = k_row + (tid_sg / 8) * Q8_0_BLOCK_SIZE;
+            const float kd       = vload_half(0, (const global half *) kb);
+            const uint  k_packed = as_uint(vload4(tid_sg % 8, (const global uchar *)(kb + 2)));
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const int idot = dot_acc_sat_4x8packed_ss_int(qp_h[h], k_packed, 0);
+                dot_s[h] = mad((ACC_TYPE) idot, qd_h[h] * kd, dot_s[h]);
+            }
+        }
+#else
         ACC_TYPE4 dot4[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) dot4[h] = (ACC_TYPE4)(0.0f);
@@ -876,12 +946,17 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split(
                 dot4[h] = mad(q_shared[h * DK_VEC + qk], k_v, dot4[h]);
             }
         }
+#endif
 
         ACC_TYPE score[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
+#ifdef FA_Q8_INT_QK
+            ACC_TYPE s = sub_group_reduce_add(dot_s[h]) * scale;
+#else
             const ACC_TYPE dot_partial = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
             ACC_TYPE s = sub_group_reduce_add(dot_partial) * scale;
+#endif
             if (mask_base[h] != NULL) {
                 const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];
                 s += slope[h] * (ACC_TYPE) mask_ptr[k_idx];
@@ -1073,6 +1148,28 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
+#ifdef FA_Q8_INT_QK
+    // Same once-per-WG Q requantization as the mq_split kernel above.
+    __local uint  q_packed_l[MQ_GQA * DK_Q8_BLOCKS * 8];
+    __local float q_d_l[MQ_GQA * DK_Q8_BLOCKS];
+    for (int i = tid; i < MQ_GQA * DK_Q8_BLOCKS; i += MQ_SPLIT_WG_SIZE_Q8) {
+        const int h = i / DK_Q8_BLOCKS;
+        const int b = i % DK_Q8_BLOCKS;
+        ACC_TYPE4 qb[8];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            qb[j] = q_shared[h * DK_VEC + b * 8 + j];
+        }
+        uint packed_tmp[8];
+        q_d_l[i] = quant_q_block_int8_packed(qb, packed_tmp);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            q_packed_l[i * 8 + j] = packed_tmp[j];
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+#endif
+
     float slope[MQ_GQA];
     #pragma unroll
     for (int h = 0; h < MQ_GQA; ++h) {
@@ -1127,6 +1224,27 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         const global char * k_row = k_base + k_row_base + (ulong) k_safe * k_nb1;
         const global char * v_row = v_base + v_row_base + (ulong) k_safe * v_nb1;
 
+#ifdef FA_Q8_INT_QK
+        // dp4a K dot over this lane's quartets of the cluster's row.
+        ACC_TYPE dot_s[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) dot_s[h] = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < FA_CL_DKQ; ++i) {
+            const int qk = lic + FA_CL_C * i;
+            const int b  = qk / 8;
+            const int j  = qk % 8;
+            const global char * kb = k_row + b * Q8_0_BLOCK_SIZE;
+            const float kd       = vload_half(0, (const global half *) kb);
+            const uint  k_packed = as_uint(vload4(j, (const global uchar *)(kb + 2)));
+            #pragma unroll
+            for (int h = 0; h < MQ_GQA; ++h) {
+                const int idot = dot_acc_sat_4x8packed_ss_int(
+                    q_packed_l[(h * DK_Q8_BLOCKS + b) * 8 + j], k_packed, 0);
+                dot_s[h] = mad((ACC_TYPE) idot, q_d_l[h * DK_Q8_BLOCKS + b] * kd, dot_s[h]);
+            }
+        }
+#else
         // Float-dequant K dot over this lane's quartets of the cluster's row.
         ACC_TYPE4 dot4[MQ_GQA];
         #pragma unroll
@@ -1140,12 +1258,17 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
                 dot4[h] = mad(q_shared[h * DK_VEC + qk], k_v, dot4[h]);
             }
         }
+#endif
 
         // Cluster-reduce (xor steps < FA_CL_C stay inside the cluster) + score.
         ACC_TYPE score[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
+#ifdef FA_Q8_INT_QK
+            ACC_TYPE s = dot_s[h];
+#else
             ACC_TYPE s = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+#endif
             #pragma unroll
             for (int step = 1; step < FA_CL_C; step <<= 1) {
                 s += sub_group_shuffle_xor(s, step);

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -1260,6 +1260,28 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
     const ulong k_row_base = batch_idx * k_nb3 + head_kv_idx * k_nb2;
     const ulong v_row_base = batch_idx * v_nb3 + head_kv_idx * v_nb2;
 
+#if defined(FA_CL_MASK_BCAST) && defined(FA_CL_MASK_SG)
+    // Subgroup-staged mask.
+    //
+    // What is left of the mask cost is neither redundancy (the broadcast took
+    // that) nor issue distance (pipelining it measured 0, at identical
+    // private_mem), so it is the transaction itself: one extra scattered
+    // stream touched every iteration.
+    //
+    // The access pattern removes that for free. Cluster cl at iteration it
+    // reads kv_lo + cl + it*FA_CL_NCL, so across FA_CL_C iterations the
+    // subgroup's clusters touch exactly Q1_WG_SIZE CONSECUTIVE positions --
+    // one per lane. Load the block once, fully coalesced, and redistribute it
+    // by shuffle: FA_CL_C scattered loads become 1 coalesced load plus
+    // FA_CL_C shuffles.
+    //
+    // Deliberately NOT staged in LDS: this kernel is occupancy-bound (the
+    // head-split's 592 -> 352 B/WI bought +4.6/+7.2%) and that same change
+    // doubled the workgroups per KV head, so LDS would be spending exactly
+    // the resource the last win came from. Shuffles cost none.
+    ACC_TYPE mask_sg = (ACC_TYPE) 0.0f;
+#endif
+
     for (int it = 0; it < n_iter; ++it) {
         const int k_idx  = kv_lo + cl + it * FA_CL_NCL;
         const int valid  = k_idx < kv_hi;
@@ -1268,7 +1290,22 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         const global char * k_row = k_base + k_row_base + (ulong) k_safe * k_nb1;
         const global char * v_row = v_base + v_row_base + (ulong) k_safe * v_nb1;
 
-#ifdef FA_CL_MASK_BCAST
+#if defined(FA_CL_MASK_BCAST) && defined(FA_CL_MASK_SG)
+        // Restage every FA_CL_C iterations, then shuffle out this cluster's
+        // element. mblk and mask_bcast are subgroup-uniform, so the reload is
+        // convergent and the shuffle index (cl + FA_CL_NCL*mblk) covers
+        // 0..Q1_WG_SIZE-1 exactly once per block. Tail lanes clamp like
+        // k_safe; their iterations are already dropped to FA_M_INIT.
+        const int mblk = it % FA_CL_C;
+        if (mask_bcast && mblk == 0) {
+            const int k_stg = kv_lo + it * FA_CL_NCL + tid_sg;
+            mask_sg = (ACC_TYPE) ((const global MASK_DATA_TYPE *) mask_base_b)
+                          [k_stg < kv_hi ? k_stg : (kv_hi - 1)];
+        }
+        const ACC_TYPE mask_val = mask_bcast
+            ? sub_group_shuffle(mask_sg, cl + FA_CL_NCL * mblk)
+            : (ACC_TYPE) 0.0f;
+#elif defined(FA_CL_MASK_BCAST)
         // Issue the broadcast mask load with the K row so both are in flight.
         // This is the point of the change: previously the mask was read inside
         // the per-head score loop, i.e. AFTER the cluster reduce, where its

--- a/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
+++ b/ggml/src/ggml-opencl/kernels/flash_attn_f32_q8_0.cl
@@ -1260,19 +1260,89 @@ __kernel void flash_attn_f32_q8_0_q1_vec_mq_split_c8(
         }
 #endif
 
+        // This lane's partial score per head, before the cluster all-reduce.
+        ACC_TYPE mh_p[MQ_GQA];
+        #pragma unroll
+        for (int h = 0; h < MQ_GQA; ++h) {
+#ifdef FA_Q8_INT_QK
+            mh_p[h] = dot_s[h];
+#else
+            mh_p[h] = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
+#endif
+        }
+
+#if defined(FA_CL_MHRED) && MQ_GQA == 8 && FA_CL_C == 16 && FA_CL_DKQ == 1
+        // Multi-head fused cluster reduce, ported from the f16 kernel, which
+        // got it in the gpt-oss FD round while this fork did not.
+        //
+        // The per-head loop below runs MQ_GQA independent all-reduces over
+        // FA_CL_C lanes = MQ_GQA * log2(FA_CL_C) = 32 shuffles per KV row --
+        // and a probe showed this kernel's cost is NOT its KV read (deleting
+        // the read entirely still left it behind f16), so the shuffle chain is
+        // what there is to cut. One halving butterfly costs 4+2+1+1 = 8
+        // shuffles to reach one head per lane and 1+2+4 = 7 to expand every
+        // head back: 15 instead of 32.
+        //
+        // Rounds run in INCREASING xor distance so each head's summation tree
+        // is pairwise identical to the per-head butterfly's => bit-identical
+        // scores, not merely mathematically equivalent ones.
+        const int mh_b0 = lic & 1;
+        const int mh_b1 = lic & 2;
+        const int mh_b2 = lic & 4;
+
+        ACC_TYPE mh_r4[4];
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const ACC_TYPE keep = mh_b0 ? mh_p[j + 4] : mh_p[j];
+            const ACC_TYPE send = mh_b0 ? mh_p[j]     : mh_p[j + 4];
+            mh_r4[j] = keep + sub_group_shuffle_xor(send, 1);
+        }
+        ACC_TYPE mh_r2[2];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE keep = mh_b1 ? mh_r4[j + 2] : mh_r4[j];
+            const ACC_TYPE send = mh_b1 ? mh_r4[j]     : mh_r4[j + 2];
+            mh_r2[j] = keep + sub_group_shuffle_xor(send, 2);
+        }
+        ACC_TYPE mh_r1 = (mh_b2 ? mh_r2[1] : mh_r2[0]) +
+                         sub_group_shuffle_xor(mh_b2 ? mh_r2[0] : mh_r2[1], 4);
+        mh_r1 += sub_group_shuffle_xor(mh_r1, 8);
+
+        ACC_TYPE mh_e2[2];
+        {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_r1, 4);
+            mh_e2[0] = mh_b2 ? other : mh_r1;
+            mh_e2[1] = mh_b2 ? mh_r1 : other;
+        }
+        ACC_TYPE mh_e4[4];
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_e2[j], 2);
+            mh_e4[j]     = mh_b1 ? other    : mh_e2[j];
+            mh_e4[j + 2] = mh_b1 ? mh_e2[j] : other;
+        }
+        ACC_TYPE mh_s[MQ_GQA];
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const ACC_TYPE other = sub_group_shuffle_xor(mh_e4[j], 1);
+            mh_s[j]     = mh_b0 ? other    : mh_e4[j];
+            mh_s[j + 4] = mh_b0 ? mh_e4[j] : other;
+        }
+#endif
+
         // Cluster-reduce (xor steps < FA_CL_C stay inside the cluster) + score.
         ACC_TYPE score[MQ_GQA];
         #pragma unroll
         for (int h = 0; h < MQ_GQA; ++h) {
-#ifdef FA_Q8_INT_QK
-            ACC_TYPE s = dot_s[h];
+#if defined(FA_CL_MHRED) && MQ_GQA == 8 && FA_CL_C == 16 && FA_CL_DKQ == 1
+            ACC_TYPE s = mh_s[h];
 #else
-            ACC_TYPE s = dot4[h].s0 + dot4[h].s1 + dot4[h].s2 + dot4[h].s3;
-#endif
+            ACC_TYPE s = mh_p[h];
             #pragma unroll
             for (int step = 1; step < FA_CL_C; step <<= 1) {
                 s += sub_group_shuffle_xor(s, step);
             }
+#endif
             s *= scale;
             if (mask_base[h] != NULL) {
                 const global MASK_DATA_TYPE * mask_ptr = (const global MASK_DATA_TYPE *) mask_base[h];


### PR DESCRIPTION

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This PR widens kernel selection to the shapes that were falling through, speeds up the cluster
kernel, and moves gemma-4's DK=512 decode onto the GPU via FA on. Massive gains on TG are observed:
a number of models now run faster with FA on than off.

### Issues
The Adreno decode flash-attention path selected its multi-query (MQ) and cluster kernels for a narrow set of shapes; everything else fell back to the `q1`/`q1_split` kernels. Those fallbacks are bad in two specific ways:
- **Register pressure.** `flash_attn_f32_f16_q1_split` reports 1168 bytes of private memory per work item (the q8_0 twin 1664, the DV=512 `q1` 2048) against the ~512-byte budget where this compiler stops spilling; their workgroup cap drops to 192.
- **Redundant traffic.** They run one workgroup per *query* head, so every head in a GQA group re-reads the same K and V rows. The MQ kernels read each row once per KV head.

### Solutions
**Commit 1 - coverage and cluster performance.**
- Adds `MQ_GQA=2/3` programs at head_dim 128, an `MQ_GQA=8`/`FA_CL_C=16` cluster at head_dim 64 (the stock GQA=8 width fails the `DK_VEC % FA_CL_C` check there), and the same cluster for q8_0 KV, which previously had no MQ route at all. - Four performance changes follow:
  -  pooling the flash-decoding partials buffer (it was a `clCreateBuffer` per attention layer per token);
  -  folding the per-head cluster reductions into one halving butterfly (32 `sub_group_shuffle_xor` per KV row down to 15, bit-identical)
  - a head split that runs an `MQ_GQA = gqa/N` program on N workgroups per KV head.
  - a 64-thread workgroup for it.

**Commit 2 - gemma-4 DK=512 decode.**
- gemma-4 interleaves DK=256 sliding-window layers with DK=512 global ones. `supports_op` declined FLASH_ATTN_EXT for DK=512 at decode, so every global layer became a CPU island: 17 graph splits against 3, with that layer's K and V views (8.4 MB each at n_kv=4096) copied device-to-host every token.
- Declining was nevertheless the better trade, because the only DK=512 decode kernel was the 2 KB/work-item `q1` - forcing that back onto the GPU measures 27% *slower* than paying for the CPU islands.

The shared DK=512 program is built `-D FA_DECODE_MINIMAL` (dropping `q1_vec`) to stay under the shader compiler's host-memory ceiling, so that spilled fallback was all those layers had. Two new single-kernel programs fix that, the way `FA_PREFILL_ONLY` already isolates the BM tile:
- `FA_VEC_ONLY` builds `q1_vec` alone (2 KB -> 192 B per work item) and `FA_MQ_SPLIT_ONLY` builds`q1_vec_mq_split` alone. The same narrow build also serves DK=256 GQA=8, whose stock kernel requests a 192-thread workgroup that the X2-90 refuses per-kernel - it registered as compiled and then never dispatched.
- These shapes carry their own `n_kv` floor, since gemma-4's window caps n_kv at 1024/256, below the split-tuned `FD_MIN_N_KV`; the floor is scoped to shapes that have a narrow kernel, so no other model's decode routing changes.

### Results

tg32 at depth 4096 against the same tree with the new paths disabled, as base/patched/patched/base
sequences with a clock proxy sampled per arm.

| model | shape | X2-90 | X1-85 | Adreno 840 |
|---|---|---|---|---|
| gpt-oss-20b MXFP4 | dk 64, GQA 8 | +7.7% (+19.8% at d16384) | - | +8.3% |
| Qwen3-4B Q4_K_M | dk 128, GQA 4 | +4.8% (+5.9% at d16384) | +18.0% | +61% |
| Llama-3-8B Q4_0 | dk 128, GQA 4 | +3.2% | - | +42% |
| Mistral-7B v0.3 Q4_K_M | dk 128, GQA 4 | - | - | +33% |
| gemma-4 E4B Q4_0 | dk 512 + dk 256 | +44.5% (+59.6% at d8192) | +21…37% | +34…36% |
| gemma-4 E2B Q4_0 | dk 512 + dk 256 | +53.9% (+60.1% at d8192) | +17…45% | +96% |

Two notes:

- On the Adreno 840, GQA=4 at head_dim 128 previously ran *slower* with flash attention than
  without.
   - FA-on now beats FA-off by 9-13% on all three GQA=4 models there, so the "use `-fa 0` on  this device" workaround is no longer needed for that shape.
   - GQA=3 still trails FA-off by ~10% and is not addressed here.
- On gemma-4, `-fa auto` previously resolved to **disabled**, because the DK=512 decline fired at the `n_q == 1` probe shape. It now resolves to **enabled**. Users who never passed `-fa` will see this change.

## Additional shapes and kernel improvements

Four further gaps in the same routing table, added after the first review pass.

### Head size 128: the head split, and an `n_kv` floor of its own

**The head-split program was never built at head size 128.** It was fenced to head size 64, and the
narrow multi-query builder to head sizes 256 and 512, so a GQA-8 shape at 128 — Qwen3-30B-A3B's
decode shape — had no head-split form to route to and ran one work-group per KV head. Building it
there is worth, per-op on `test-backend-ops` at KV 4096 and 8192 with the split off then on:
+49.9% / +51.8% on an Adreno X2-90, +82.1% / +55.3% on an Adreno 840, and +112.4% / +119.3% on an
X1-85. Three generations, no inversion. End to end on Qwen3-30B-A3B that is +23.5% and +28.8% tg at
4096 and 8192 tokens of depth.

**The multi-query routes inherited the flash-decoding split's `n_kv` floor**, which answers a
different question — whether splitting the KV range across work-groups pays — and at 2048 it meant
the MQ routes did not engage at all below that length. Giving them their own floor at 32 gains, at
depth 0 and 1024: +12% / +63% on Qwen3-30B-A3B, +10% / +43% on Qwen3-4B, +1% / +8% on gpt-oss-20b,
and neutral on gemma-4-26B. Depth 4096 is flat everywhere, which is the control — above the old
floor the routing does not change, and it does not move.

`FLASH_ATTN_EXT` in `test-backend-ops`: 5117 and 2696 cases OK, 0 FAIL, unchanged from the
unpatched baseline build on the same device.

### GQA ratio 16

gemma-4-12B has 16 query heads over a single KV head on its 8 global-attention layers, i.e.
DK=DV=512 at GQA ratio 16. The narrow multi-query decode gate admits ratios 4, 8 and 2, so that
shape matched no arm and every one of its decode dispatches fell back to
`flash_attn_f32_f16_q1_vec`, which has neither the flash-decoding split nor any query sharing and
therefore reads the whole KV cache once per query head — 16 times here. A dispatch trace on an
Adreno X2-90 shows 40 of 40 global-layer decode calls landing there. The model's SWA layers
(head size 256 at ratio 2) were already served by the narrow kernel and are unchanged.

Ratio 16 is now admitted with a head split of 8, so the program is MQ_GQA=2. At DV=512 the
per-head lane state is what pushes this shape past the occupancy cliff at roughly 512 bytes per
work item, which is the same reason the DK=512 ratio-8 shape uses a head split of 4 rather than 2.
That is measured rather than assumed: a head split of 4 (MQ_GQA=4) gains nothing at a 4096-token
depth and about a third of the gain at 8192.

gemma-4-12B Q4_0, tg32, one binary, this route off then on. Adreno X2-90 at the shipped default,
bracketed by opt-out arms that agree to 1%: 12.19 → 14.33 t/s (+17.6%) at depth 4096, and
10.28 → 13.40 (+30.3%) at 8192. Depth 0 is parity, because the MQ route barely engages at shallow
KV lengths. Against `-fa 0` the same arm turns −7.4% and −16.0% at those depths into +8.9% and
+11.7%. On an Adreno 840, three matched pairs taken from the same start temperature: 3.63 → 4.46
(+22.9%) at depth 8192, with the three on-arms agreeing to 0.4%.

It is on by default, `GGML_OPENCL_FA_MQN_GQA16=0` opts out, and there is no device predicate,
matching the ratio 4, 8 and 2 arms beside it. An X1-class part is the one generation with no usable
number and is deliberately not gated out: this model is 6.26 GiB against a per-context allocation
cap near 6 GB there, so runs abort in `clCreateBuffer` non-deterministically with this route off as
well. A7X and E17 parts never reach this function, since `supports_op` declines f16-KV flash
attention on both.

`test-backend-ops` gains the shape, which the suite has never covered — its generic sweep caps the
ratio-16 broadcast at head size 192, so a backend that selects its decode kernel per head size and
ratio had no correctness gate here at all. `FLASH_ATTN_EXT` reports 2698 OK / 0 FAIL at the shipped
default and with the route forced off.

One note for anyone reading those numbers on an Adreno device: the process exits without flushing
its final line, so whichever test case is emitted last silently never reports a verdict. The run
itself completes — only the tail line is lost — but it means case ordering matters. The new cases
are placed ahead of the existing head-size-512 block so that the `kv=4099` tail case, which
exercises the non-multiple KV remainder, does not land in that slot.

### DK=512: a build attempted before the compile options no longer latches

The DK=512 programs added here are compiled lazily from inside `supports_op`, which is reached
through the `-fa auto` probe during context creation. Their option string starts from
`backend_ctx->kernel_compile_opts`, and that field is written by `load_cl_kernels()`, which does not
run until the first buffer allocation. Nothing orders the two, so the probe can run with an empty
prefix — the build then loses `-cl-std`, the compiler rejects the subgroup extensions, and the
`ensure_` helper latches a static `failed` flag that disables the shape for the rest of the process
even after the options exist.

The helper now declines to latch when the prefix is not up yet, so an early attempt is retried
rather than made permanent. The ordering problem itself is fixed separately and upstream, by
building the prefix in `ggml_cl_init()`; this change is the part that belongs with the DK=512
kernels.

### The q8_0 cluster decode kernel: four improvements

The q8_0 cluster kernel `flash_attn_f32_q8_0_q1_vec_mq_split_c8` introduced above for the
gpt-oss-class dk=64/gqa=8 shape is a fork of the f16 cluster kernel, and had not received an
optimisation round the f16 side did — so it was running an older shape of the same algorithm:

1. **Fused multi-head cluster reduce.** The per-head loop ran `MQ_GQA` independent all-reduces over
   `FA_CL_C` lanes = 32 shuffles per KV row. A halving butterfly does it in 15. Rounds run in
   increasing xor distance, so each head's summation tree is pairwise identical to the per-head
   butterfly's and the scores are bit-identical.
2. **Head split.** The gqa=8 shape now runs as two `MQ_GQA=4` workgroups per KV head, halving the
   per-lane head state: `private_mem` **592 → 352 B/WI**, against the f16 kernel's 368 for the same
   shape. Costs one extra read of each KV row.
3. **Mask broadcast and hoist.** The mask was read inside the per-head score loop, after the cluster
   reduce — a late, scattered, dependent load, one per head where every head shares a row. At
   `mask_ne2 == 1` it is now loaded once per position and issued at the top of the KV iteration
   alongside the K row.
4. **Mask subgroup staging.** Over `FA_CL_C` iterations the subgroup's clusters touch exactly
   `Q1_WG_SIZE` consecutive mask positions — one per lane — so one coalesced load plus shuffles
   replaces `FA_CL_C` scattered loads. Deliberately not staged in local memory: the kernel is
   occupancy-bound and the head split already doubled the workgroups per KV head.

gpt-oss-20b (MXFP4, q8_0 attention weights) on the Adreno X2-90, `-fa 1 -ctk q8_0 -ctv q8_0`,
tg128. Each step measured as matched pairs in a single binary behind its own opt-out, alternating
which arm leads:

| step | @d4096 | @d8192 |
| --- | --- | --- |
| baseline | 30.96 | 26.96 |
| + fused cluster reduce | 31.57 (+2.0%) | 28.02 (+3.9%) |
| + head split | 33.01 (+4.6%) | 29.86 (+6.8%) |
| + mask broadcast/hoist | 34.15 (+3.3%) | 31.63 (+5.4%) |
| + mask subgroup staging | **34.54 (+1.1%)** | **32.14 (+1.7%)** |
| **cumulative** | **+11.6%** | **+19.2%** |

For reference an f16 KV cache on the same model and build is 35.70 / 33.46, so the gap to it
narrows from −13.3/−19.4% to −3.2/−3.9%. The value of a q8_0 KV cache here is capacity rather than
speed; this makes that capacity close to free.

What established that the deficit was not the dequantisation was a set of numerically-wrong
instrumented builds: deleting the KV read outright still left the kernel behind f16 (33.37 / 30.56
against 35.70 / 33.46), and dropping the per-lane scale load alone measured exactly 0. That is what
pointed at occupancy, and then at the mask. Those builds are not part of this PR.

`test-backend-ops -o FLASH_ATTN_EXT` on the X2-90: 2696 OK / 0 FAIL at every step of the work
above, with each knob both on and off. On this branch as it stands the suite reports **2724 OK / 0
FAIL** with the four knobs at their defaults and the same 2724 OK / 0 FAIL with all four forced
off, on an X2-90 and on an X1-85 alike. On both devices the head-split program is built only in the
first of those two runs, so the two arms are genuinely different code rather than a knob that
failed to reach the build.

Opt-outs, all default-on: `GGML_OPENCL_FA_Q8_MHRED=0`, `GGML_OPENCL_FA_Q8_HEAD_SUB=0`,
`GGML_OPENCL_FA_Q8_MASK_BCAST=0`, `GGML_OPENCL_FA_Q8_MASK_SG=0`.

This one is measured on a single device and a single model — no other device on hand has a
q8_0-KV gqa=8 head-size-64 shape — which is why every step is default-on behind its own opt-out.

## Additional information

**Verification.**

- `test-backend-ops -o FLASH_ATTN_EXT`: Adreno X2-90 **2716 OK / 0 FAIL**, Adreno 840 **2719 OK / 0 FAIL**.
- Greedy generation at ~2700 tokens of context is byte-identical to `-fa 0` on gemma-4 E2B and E4B.
- Shapes outside the widened set are unchanged: Qwen3-4B-Q4_K_M -0.1%, gpt-oss-20b -0.8%, both inside run-to-run spread.
- The Adreno 740 and 850 cannot reach these kernels: the A7X declines every mixed and quantized FA combination (`clBuildProgram` SIGSEGV) and E17 declines FLASH_ATTN_EXT outright. Confirmed on both devices.

**K as a texture.** In the narrow MQ programs K is bound as an `image1d_buffer_t` where one workgroup owns the whole GQA group. That is +3.5/+3.8% there, but -4.5/-9.3% where the group is split across workgroups, since each KV row is then re-read by every one of them and the texture path pays its per-access latency on each re-read rather than amortising it over one streaming pass. The path is gated on that condition.

**Opt-outs**, all default-on: `GGML_OPENCL_FA_DK512_DECODE=0` restores the previous DK=512 decline, `GGML_OPENCL_FA_HS_GQA4=0` the pre-head-split GQA=4 program, `GGML_OPENCL_FA_MQN_KIMG=0` the buffer K path, `GGML_OPENCL_FA_MQN_GQA16=0` the ratio-16 route, and the four `GGML_OPENCL_FA_Q8_*` knobs listed above.

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) Yes
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, for prototyping and testing.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->

