### PR TITLE
opencl: keep the vocab-scale K-quant lm_head on the CPU for Adreno A7X (compiler issue workaround)

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7393,19 +7393,10 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                        op->src[0]->type == GGML_TYPE_Q4_K  ||
                        op->src[0]->type == GGML_TYPE_Q5_K  ||
                        op->src[0]->type == GGML_TYPE_Q6_K) {
-                // The Adreno A7X (E031.41) compiler miscompiles the flat K-quant GEMV
-                // (kernel_mul_mv_q*_K_f32_flat) so severely that a vocab-scale lm_head runs
-                // ~54x slower than on the A8X (390 vs 7 ms/token on gemma) and dominates
-                // decode. Declining it here makes llama BOTH place that weight in a CPU
-                // buffer at load time (weight_buft_supported consults supports_op) AND run
-                // the op on the CPU -- so there is no per-token weight copy, matching an
-                // explicit "-ot token_embd.weight=CPU". Do NOT also gate on src1->ne[1]==1:
-                // that made the placement probe (batch>1) pass while the decode op (batch==1)
-                // declined, stranding the weight on the GPU and copying it every token.
-                // Measured tg on the A7X: gemma-4-E2B 2.2->15.2 (+583%), gemma-4-E4B 1.5->9.4,
-                // Qwen3-4B 6.7->14.0 (+110%). The A8X runs the same kernel fine, so A7X-only.
-                // Gate on a vocab-scale weight so only the lm_head/embedding is affected.
-                // Override with GGML_OPENCL_A7X_LMHEAD_CPU=0.
+                // The E031.41 compiler (usually with A7x) miscompiles the flat K-quant
+                // GEMV kernels (kernel_mul_mv_q*_K_f32_flat) and makes lm_head run much
+                // slower than it should. So, make it fallback to CPU to preserve performance
+                // for this compiler series.
                 static const char * a7x_lmhead_env = getenv("GGML_OPENCL_A7X_LMHEAD_CPU");
                 static const bool   a7x_lmhead_cpu = (a7x_lmhead_env == nullptr || a7x_lmhead_env[0] != '0');
                 if (a7x_lmhead_cpu &&

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7393,6 +7393,28 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
                        op->src[0]->type == GGML_TYPE_Q4_K  ||
                        op->src[0]->type == GGML_TYPE_Q5_K  ||
                        op->src[0]->type == GGML_TYPE_Q6_K) {
+                // The Adreno A7X (E031.41) compiler miscompiles the flat K-quant GEMV
+                // (kernel_mul_mv_q*_K_f32_flat) so severely that a vocab-scale lm_head runs
+                // ~54x slower than on the A8X (390 vs 7 ms/token on gemma) and dominates
+                // decode. Declining it here makes llama BOTH place that weight in a CPU
+                // buffer at load time (weight_buft_supported consults supports_op) AND run
+                // the op on the CPU -- so there is no per-token weight copy, matching an
+                // explicit "-ot token_embd.weight=CPU". Do NOT also gate on src1->ne[1]==1:
+                // that made the placement probe (batch>1) pass while the decode op (batch==1)
+                // declined, stranding the weight on the GPU and copying it every token.
+                // Measured tg on the A7X: gemma-4-E2B 2.2->15.2 (+583%), gemma-4-E4B 1.5->9.4,
+                // Qwen3-4B 6.7->14.0 (+110%). The A8X runs the same kernel fine, so A7X-only.
+                // Gate on a vocab-scale weight so only the lm_head/embedding is affected.
+                // Override with GGML_OPENCL_A7X_LMHEAD_CPU=0.
+                static const char * a7x_lmhead_env = getenv("GGML_OPENCL_A7X_LMHEAD_CPU");
+                static const bool   a7x_lmhead_cpu = (a7x_lmhead_env == nullptr || a7x_lmhead_env[0] != '0');
+                if (a7x_lmhead_cpu &&
+                    backend_ctx->adreno_gen == ADRENO_GPU_GEN::A7X &&
+                    (op->src[0]->type == GGML_TYPE_Q4_K || op->src[0]->type == GGML_TYPE_Q5_K ||
+                     op->src[0]->type == GGML_TYPE_Q6_K) &&
+                    op->src[0]->ne[1] >= 32768) {   // vocab-scale weight; no FFN/attn weight is this tall
+                    return false;
+                }
                 return op->src[1]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]) && ggml_is_contiguous(op->src[1]);
             } else if (op->src[0]->type == GGML_TYPE_Q8_0) {
                 return op->src[1]->type == GGML_TYPE_F32;


### PR DESCRIPTION
 
## Overview

The issue: 
- On the A7X (Adreno 740), gemma/Qwen **decode** was  very slow. 
- This is an A7X E031.41 **compiler codegen pathology** on the flat K-quant GEMV kernel: kernel_mul_mv_q4_K_f32_flat
- Everything else on the 740 is fine (q4_0 noshuffle GEMV = 0.13 ms). 
- The flat kernel is bound to the `GGML_OPENCL_SOA_Q` build and the non-flat kernel needs a different weight layout, so the kernels can't just be swapped.

### Fix

- Decline that one op in `ggml_opencl_supports_op` (MUL_MAT) on the A7X when the weight is Q4_K/Q5_K/Q6_K and **vocab-scale**   
- Puts the weight in a **CPU buffer at load** *and* runs the op on CPU — **no per-token weight copy**  
- Equivalent to an explicit `-ot token_embd.weight=CPU`, but automatic/zero-config. 
- Env override with `GGML_OPENCL_A7X_LMHEAD_CPU=0`.


 <!-- Describe what this PR does and why. Be concise but complete -->

## Additional information
Numbers (740 / A7X, fa-off, GGML_OPENCL_A7X_LMHEAD_CPU 0→1)

| model | tg | pp512 |
|---|---|---|
| gemma-4-E2B Q4_0 | 2.22 → **15.12** (+581%) | 50.7 → 53.4 (no regression) |
| gemma-4-E4B Q4_0 | 1.49 → **9.18** (+516%) | 32.2 → 34.2 |
| Qwen3-4B Q4_0 | 6.78 → **13.52** (+99%) | 109 → 118 |
 
**A7X-only** by construction (`adreno_gen == ADRENO_GPU_GEN::A7X`). The A8X runs the same kernel is untouched.
 
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) Yes.
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, testing. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
