### PR TITLE
Add Vulkan SDK setup and caching to ubuntu release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,25 @@ jobs:
             echo "CC=gcc-14" >> "$GITHUB_ENV"
             echo "CXX=g++-14" >> "$GITHUB_ENV"
           fi
+          
+      - name: Get latest Vulkan SDK version
+        id: vulkan_sdk_version
+        run: |
+          echo "VULKAN_SDK_VERSION=$(curl https://vulkan.lunarg.com/sdk/latest/linux.txt)" >> "$GITHUB_ENV"
+
+      - name: Use Vulkan SDK Cache
+        uses: actions/cache@v5
+        id: cache-sdk
+        with:
+          path: ./vulkan_sdk
+          key: cache-gha-vulkan-sdk-${{ env.VULKAN_SDK_VERSION }}-${{ runner.os }}
+
+      - name: Setup Vulkan SDK
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        uses: ./.github/actions/linux-setup-vulkan
+        with:
+          path: ./vulkan_sdk
+          version: ${{ env.VULKAN_SDK_VERSION }}
 
       - name: ccache
         uses: ggml-org/ccache-action@v1.2.21
@@ -307,6 +326,7 @@ jobs:
       - name: Build
         id: cmake_build
         run: |
+          source ./vulkan_sdk/setup-env.sh
           cmake -B build \
             -DCMAKE_INSTALL_RPATH='$ORIGIN' \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Get latest Vulkan SDK version
         id: vulkan_sdk_version
         run: |
-          echo "VULKAN_SDK_VERSION=$(curl https://vulkan.lunarg.com/sdk/latest/linux.txt)" >> "$GITHUB_ENV"
+          echo "VULKAN_SDK_VERSION=1.4.357.0" >> "$GITHUB_ENV"
 
       - name: Use Vulkan SDK Cache
         uses: actions/cache@v5


### PR DESCRIPTION
## Overview

tentative fix for:
https://github.com/ggml-org/llama.cpp/issues/26306

may not work just copy pasted from vulkan-ci action..

## Additional information

similar to Windows request:
https://github.com/ggml-org/llama.cpp/issues/26299
it's for allowing building  Ubunut Vulkan releases with new NV VK optimizations (new extensions present in code) which require new Vulkan SDK 1.4.357 ..

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

