### PR TITLE
docs(server): note OpenAI client base_url for multi-model gateways

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1295,6 +1295,8 @@ completion = client.chat.completions.create(
 print(completion.choices[0].message)
 ```
 
+Tip: the same OpenAI client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not self-hosting llama-server — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 ... or raw HTTP requests:
 
 ```shell


### PR DESCRIPTION
## Summary

The llama-server docs already show the OpenAI Python client via `base_url` against a local server.

This PR adds a short tip that the same client pattern works with OpenAI-compatible multi-model gateways when not self-hosting llama-server, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Server README tip renders
- [ ] Local llama-server client example unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>