### PR TITLE
cuda: add GGML_CUDA_BLOCKING_SYNC to eliminate 100% CPU busy-wait on full GPU offload

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -217,6 +217,22 @@ static int ggml_cuda_parse_id(char devName[]) {
 static ggml_cuda_device_info ggml_cuda_init() {
     ggml_cuda_device_info info = {};
 
+    // Optionally use blocking synchronization so that the host thread sleeps
+    // instead of busy-waiting while the GPU is working. This greatly reduces
+    // CPU usage for fully offloaded inference at the cost of a small increase
+    // in synchronization latency. Must be set before any CUDA context is
+    // created on the device.
+    const char * blocking_sync_env = getenv("GGML_CUDA_BLOCKING_SYNC");
+    if (blocking_sync_env != nullptr && std::atoi(blocking_sync_env) != 0) {
+        cudaError_t flags_err = cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+        if (flags_err != cudaSuccess) {
+            GGML_LOG_WARN("%s: failed to set cudaDeviceScheduleBlockingSync: %s\n",
+                          __func__, cudaGetErrorString(flags_err));
+        } else {
+            GGML_LOG_INFO("%s: using cudaDeviceScheduleBlockingSync\n", __func__);
+        }
+    }
+
     cudaError_t err = cudaGetDeviceCount(&info.physical_device_count);
     if (err != cudaSuccess) {
         GGML_LOG_ERROR("%s: failed to initialize " GGML_CUDA_NAME ": %s\n", __func__, cudaGetErrorString(err));


### PR DESCRIPTION
## Overview

When running `llama-server` with full GPU offload (`--n-gpu-layers 99`), the host thread that drives decoding ends up busy-waiting inside `cudaStreamSynchronize`. This makes one CPU core sit at 100% even though the GPU is doing all the work.

This PR adds an opt-in environment variable `GGML_CUDA_BLOCKING_SYNC`. When set to a non-zero value, llama.cpp calls `cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync)` before the CUDA primary context is created, turning the busy-poll into a blocking sleep and dropping host CPU usage to near zero during decode. Throughput stays essentially the same; the only expected cost is a small increase in host-GPU synchronization latency.

## Additional information

- Related discussion that validated this fix: #22238.
- Tested on a Proxmox LXC running Debian 12, with an NVIDIA Quadro P5000 (Pascal, sm_61), CUDA 12.6, using the `Qwen3.5-9B-UD-IQ2_M.gguf` model.
- Both a heavy request (1000 tokens) and a long-context request (~31k tokens) completed successfully without CPU saturation.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md).
- [x] AI usage disclosure: YES — I used an AI assistant to help draft the PR description and the initial patch. I reviewed, tested, and verified the changes on my own hardware.
