### PR TITLE
mtmd: rebase Gemma 4 unified-vision fixes onto master

### DIFF
--- a/tools/mtmd/models/gemma4uv.cpp
+++ b/tools/mtmd/models/gemma4uv.cpp
@@ -20,6 +20,9 @@ ggml_cgraph * clip_graph_gemma4uv::build() {
         // inp shape: [patch_size * patch_size * c, n_patches]
 
         inp = ggml_mul_mat(ctx0, model.patch_embeddings_0, inp);
+        // 6912-wide reduction over high-contrast patches overflows F16 accumulation
+        // (GGML_CUDA_F16) -> Inf/NaN; force F32 accumulation like other clip projectors.
+        ggml_mul_mat_set_prec(inp, GGML_PREC_F32);
         inp = ggml_add(ctx0, inp, model.patch_bias);
         // inp shape: [n_embd, n_patches]
 
@@ -63,6 +66,7 @@ ggml_cgraph * clip_graph_gemma4uv::build() {
         // embedding_pre_projection_norm
         cur = ggml_rms_norm(ctx0, cur, hparams.eps);
         cur = build_mm(model.mm_input_proj_w, cur);
+        ggml_mul_mat_set_prec(cur, GGML_PREC_F32);
         cb(cur, "projected", -1);
     }
 

--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -190,6 +190,21 @@ struct img_tool {
         return {w_bar, h_bar};
     }
 
+    static clip_image_size calc_size_fill_budget(const clip_image_size & inp_size, const int align_size, const int target_pixels) {
+        GGML_ASSERT(align_size > 0);
+        if (inp_size.width <= 0 || inp_size.height <= 0 || target_pixels <= 0) {
+            return {0, 0};
+        }
+        const double total_px = (double) inp_size.width * (double) inp_size.height;
+        const double factor   = std::sqrt((double) target_pixels / total_px);
+        auto floor_by_factor = [f = align_size](double x) {
+            return std::max(f, static_cast<int>(std::floor(x / static_cast<double>(f))) * f);
+        };
+        const int target_width  = floor_by_factor(factor * inp_size.width);
+        const int target_height = floor_by_factor(factor * inp_size.height);
+        return {target_width, target_height};
+    }
+
     // draw src image into dst image at offset (offset_x, offset_y)
     static void composite(clip_image_u8 & dst, const clip_image_u8 & src, int offset_x, int offset_y) {
         if (src.is_placeholder()) {
@@ -948,6 +963,26 @@ mtmd_image_preproc_out mtmd_image_preprocessor_dyn_size::preprocess(const clip_i
     output.append(hparams, resized_image, true);
     return output;
 }
+
+bool mtmd_image_preprocessor_gemma4::preprocess(const clip_image_u8 & img, clip_image_f32_batch & output) {
+    GGML_ASSERT(hparams.image_max_pixels > 0);
+    clip_image_u8 resized_image;
+    const clip_image_size original_size{img.nx, img.ny};
+    const int cur_merge = hparams.n_merge == 0 ? 1 : hparams.n_merge;
+    const int align     = hparams.patch_size * cur_merge;
+    const clip_image_size target_size = img_tool::calc_size_fill_budget(
+        original_size,
+        align,
+        hparams.image_max_pixels);
+    img_tool::resize(img, resized_image, target_size,
+                        RESIZE_ALGO_BICUBIC,
+                        PAD_NONE);
+    clip_image_f32_ptr img_f32(clip_image_f32_init());
+    img_u8_to_f32(resized_image, *img_f32, hparams.image_mean, hparams.image_std);
+    output.entries.push_back(std::move(img_f32));
+    return true;
+}
+
 
 //
 // mtmd_image_preprocessor_longest_edge

--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -967,7 +967,7 @@ mtmd_image_preproc_out mtmd_image_preprocessor_dyn_size::preprocess(const clip_i
 bool mtmd_image_preprocessor_gemma4::preprocess(const clip_image_u8 & img, clip_image_f32_batch & output) {
     GGML_ASSERT(hparams.image_max_pixels > 0);
     clip_image_u8 resized_image;
-    const clip_image_size original_size{img.nx, img.ny};
+    const clip_image_size original_size = img.get_size();
     const int cur_merge = hparams.n_merge == 0 ? 1 : hparams.n_merge;
     const int align     = hparams.patch_size * cur_merge;
     const clip_image_size target_size = img_tool::calc_size_fill_budget(

--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -964,7 +964,7 @@ mtmd_image_preproc_out mtmd_image_preprocessor_dyn_size::preprocess(const clip_i
     return output;
 }
 
-bool mtmd_image_preprocessor_gemma4::preprocess(const clip_image_u8 & img, clip_image_f32_batch & output) {
+mtmd_image_preproc_out mtmd_image_preprocessor_gemma4::preprocess(const clip_image_u8 & img) {
     GGML_ASSERT(hparams.image_max_pixels > 0);
     clip_image_u8 resized_image;
     const clip_image_size original_size = img.get_size();
@@ -977,10 +977,9 @@ bool mtmd_image_preprocessor_gemma4::preprocess(const clip_image_u8 & img, clip_
     img_tool::resize(img, resized_image, target_size,
                         RESIZE_ALGO_BICUBIC,
                         PAD_NONE);
-    clip_image_f32_ptr img_f32(clip_image_f32_init());
-    img_u8_to_f32(resized_image, *img_f32, hparams.image_mean, hparams.image_std);
-    output.entries.push_back(std::move(img_f32));
-    return true;
+    mtmd_image_preproc_out output;
+    output.append(hparams, resized_image, true);
+    return output;
 }
 
 

--- a/tools/mtmd/mtmd-image.h
+++ b/tools/mtmd/mtmd-image.h
@@ -123,6 +123,14 @@ struct mtmd_image_preprocessor_dyn_size : mtmd_image_preprocessor {
     mtmd_image_preproc_out preprocess(const clip_image_u8 & img) override;
 };
 
+// Gemma4 unified vision: aspect-ratio-preserving resize that always fills the soft-token
+// patch budget (image_max_pixels), aligned to patch_size. ref:
+// transformers Gemma4UnifiedImageProcessor.get_aspect_ratio_preserving_size
+struct mtmd_image_preprocessor_gemma4 : mtmd_image_preprocessor {
+    mtmd_image_preprocessor_gemma4(const clip_ctx * ctx) : mtmd_image_preprocessor(ctx) {}
+    bool preprocess(const clip_image_u8 & img, clip_image_f32_batch & output) override;
+};
+
 // similar to mtmd_image_preprocessor_dyn_size, but resize the image to have longest edge equal to hparams.image_longest_edge, while preserving aspect ratio
 struct mtmd_image_preprocessor_longest_edge : mtmd_image_preprocessor {
     mtmd_image_preprocessor_longest_edge(const clip_ctx * ctx) : mtmd_image_preprocessor(ctx) {}

--- a/tools/mtmd/mtmd-image.h
+++ b/tools/mtmd/mtmd-image.h
@@ -128,7 +128,7 @@ struct mtmd_image_preprocessor_dyn_size : mtmd_image_preprocessor {
 // transformers Gemma4UnifiedImageProcessor.get_aspect_ratio_preserving_size
 struct mtmd_image_preprocessor_gemma4 : mtmd_image_preprocessor {
     mtmd_image_preprocessor_gemma4(const clip_ctx * ctx) : mtmd_image_preprocessor(ctx) {}
-    bool preprocess(const clip_image_u8 & img, clip_image_f32_batch & output) override;
+    mtmd_image_preproc_out preprocess(const clip_image_u8 & img) override;
 };
 
 // similar to mtmd_image_preprocessor_dyn_size, but resize the image to have longest edge equal to hparams.image_longest_edge, while preserving aspect ratio

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -625,12 +625,18 @@ struct mtmd_context {
                     image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
                 } break;
             case PROJECTOR_TYPE_GEMMA4V:
-            case PROJECTOR_TYPE_GEMMA4UV:
                 {
-                    // <|image> ... (image embeddings) ... <image|>
                     img_beg = "<|image>";
                     img_end = "<image|>";
                     image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
+                } break;
+            case PROJECTOR_TYPE_GEMMA4UV:
+                {
+                    img_beg = "<|image>";
+                    img_end = "<image|>";
+                    // encoder-free unified vision: aspect-preserving resize that fills the
+                    // soft-token budget, then 48px patches re-packed HWC in the graph
+                    image_preproc = std::make_unique<mtmd_image_preprocessor_gemma4>(ctx_v);
                 } break;
             case PROJECTOR_TYPE_DEEPSEEKOCR:
             case PROJECTOR_TYPE_DEEPSEEKOCR2:


### PR DESCRIPTION
## Summary

Rebases the three existing Gemma 4 unified-vision fixes onto current `master` (`221f0f635`):

- force F32 accumulation for the two overflow-prone projection matmuls;
- use Gemma 4's aspect-ratio-preserving, patch-budget-filling image preprocessor; and
- retain the accessor/API compatibility adjustment for current mtmd.

The patch set is intentionally limited to the four mtmd files touched by the original work.

## Why

The homelab Gemma 4 vision path needs the F32 precision guard for high-contrast inputs and Gemma-specific preprocessing for non-square images. Current upstream still routes `GEMMA4UV` through the generic dynamic-size preprocessor.

## Validation

- `git diff --check upstream/master`
- CPU mtmd static-library build with CMake/Ninja (success)

## Pending validation

- CUDA build and model-backed image regressions for high-contrast and non-square inputs. This workstation has an NVIDIA driver but no CUDA compiler or local Gemma 4 vision weights; those need a CUDA-capable CI or model host.
