### PR TITLE
docs: fix inaccurate non-terminal naming rules in GBNF README

### DIFF
--- a/grammars/README.md
+++ b/grammars/README.md
@@ -36,7 +36,7 @@ castle ::= ...
 
 ## Non-Terminals and Terminals
 
-Non-terminal symbols (rule names) stand for a pattern of terminals and other non-terminals. They are required to be a dashed lowercase word, like `move`, `castle`, or `check-mate`.
+Non-terminal symbols (rule names) stand for a pattern of terminals and other non-terminals. They may contain letters, digits, hyphens, and underscores, and typically start with a lowercase letter — though camelCase names are also valid (e.g. `dataType`, `relationOperator`). Examples: `move`, `castle`, `check-mate`, `dataType`.
 
 Terminals are actual characters ([code points](https://en.wikipedia.org/wiki/Code_point)). They can be specified as a sequence like `"1"` or `"O-O"` or as ranges like `[1-9]` or `[NBKQR]`.
 


### PR DESCRIPTION
Fixes #7720

The README section on Non-Terminals claimed that rule names are required to be dashed lowercase words, but the grammar examples (e.g. c.gbnf) freely use camelCase names like dataType, relationOperator, argList, etc.

This PR updates the description to reflect actual GBNF behavior - non-terminals can contain letters, digits, hyphens, and underscores, and camelCase names work fine.

No code changes; documentation only.