### PR TITLE
common : add env to override n_rs_seq

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -384,6 +384,10 @@ struct common_params_speculative {
     }
 
     uint32_t need_n_rs_seq() const {
+        if (const char* env = std::getenv("LLAMA_N_RS_SEQ"); env != nullptr) {
+            return std::stoi(env);
+        }
+
         bool needs_rs_seq = std::any_of(types.begin(), types.end(), [&](auto t) {
             return t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP || t == COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3 || t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
         });


### PR DESCRIPTION
## Overview

This allows us to manually specify how many recurrent state rollback states we use for speculation. Currently it is set to 0 for all non-draft-model speculators, which can hurt performance a lot. But on the other side you have to be careful to be conservative with the rollback states, as they balloon quick as they are unquantized f32.

## Additional information

**Without rollback, partial accepted sequences need to perform a full checkpoint rollback**, and on my setup that is prohibitively expensive.


Exampel I use:
```
$ LLAMA_N_RS_SEQ=7 GGML_OP_OFFLOAD_MIN_BATCH=8 llama-server ... --spec-type ngram-mod --spec-ngram-mod-n-min 7 --spec-ngram-mod-n-max 7 --spec-ngram-mod-n-match 24
```
which for qwen_3_5_moe with 168192ctx gives:
```
llama_context: n_rs_seq      = 7
llama_context: n_outputs_max = 8
llama_context: n_ctx_seq (168192) < n_ctx_train (262144) -- the full capacity of the model will not be utilized
llama_context:  CUDA_Host  output buffer size =     0.95 MiB
llama_kv_cache:      CUDA0 KV buffer size =  1745.16 MiB
llama_kv_cache: size = 1745.16 MiB (168192 cells,  10 layers,  1/1 seqs), K (q8_0):  872.58 MiB, V (q8_0):  872.58 MiB
llama_kv_cache: attn_rot_k = 1, n_embd_head_k_all = 256
llama_kv_cache: attn_rot_v = 1, n_embd_head_k_all = 256
llama_memory_recurrent:      CUDA0 RS buffer size =   502.50 MiB
llama_memory_recurrent: size =  502.50 MiB (     1 cells,  40 layers,  1 seqs  7 rs_seq), R (f32):   22.50 MiB, S (f32):  480.00 MiB
```
which is 500MiB of recurrent memory, which is a lot on a 8gig card.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yea I had ornith 35B on a leash for >100k tokens before it sniffed out whats wrong.