### PR TITLE
CUDA: add support for non-contiguous tensors in CEIL op

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4765,12 +4765,13 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_ELU:
                 case GGML_UNARY_OP_XIELU:
                 case GGML_UNARY_OP_FLOOR:
-                case GGML_UNARY_OP_CEIL:
                 case GGML_UNARY_OP_ROUND:
                 case GGML_UNARY_OP_TRUNC:
-                    // TODO: should become:
-                    //return ggml_is_contiguous_rows(op->src[0]);
+                // TODO: should become:
+                //return ggml_is_contiguous_rows(op->src[0]);
                     return ggml_is_contiguous(op->src[0]);
+                case GGML_UNARY_OP_CEIL:
+                    return ggml_is_contiguous_rows(op->src[0]);
                 default:
                     return false;
             }

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4768,7 +4768,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_ROUND:
                 case GGML_UNARY_OP_TRUNC:
                 // TODO: should become:
-                //return ggml_is_contiguous_rows(op->src[0]);
+                    //return ggml_is_contiguous_rows(op->src[0]);
                     return ggml_is_contiguous(op->src[0]);
                 case GGML_UNARY_OP_CEIL:
                     return ggml_is_contiguous_rows(op->src[0]);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4767,7 +4767,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_FLOOR:
                 case GGML_UNARY_OP_ROUND:
                 case GGML_UNARY_OP_TRUNC:
-                // TODO: should become:
+                    // TODO: should become:
                     //return ggml_is_contiguous_rows(op->src[0]);
                     return ggml_is_contiguous(op->src[0]);
                 case GGML_UNARY_OP_CEIL:

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4901,7 +4901,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_FLOOR:
                 case GGML_UNARY_OP_ROUND:
                 case GGML_UNARY_OP_TRUNC:
-                // TODO: should become:
+                    // TODO: should become:
                     //return ggml_is_contiguous_rows(op->src[0]);
                     return ggml_is_contiguous(op->src[0]);
                 case GGML_UNARY_OP_CEIL:

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4902,7 +4902,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_ROUND:
                 case GGML_UNARY_OP_TRUNC:
                 // TODO: should become:
-                //return ggml_is_contiguous_rows(op->src[0]);
+                    //return ggml_is_contiguous_rows(op->src[0]);
                     return ggml_is_contiguous(op->src[0]);
                 case GGML_UNARY_OP_CEIL:
                     return ggml_is_contiguous_rows(op->src[0]);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4899,12 +4899,13 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 case GGML_UNARY_OP_ELU:
                 case GGML_UNARY_OP_XIELU:
                 case GGML_UNARY_OP_FLOOR:
-                case GGML_UNARY_OP_CEIL:
                 case GGML_UNARY_OP_ROUND:
                 case GGML_UNARY_OP_TRUNC:
-                    // TODO: should become:
-                    //return ggml_is_contiguous_rows(op->src[0]);
+                // TODO: should become:
+                //return ggml_is_contiguous_rows(op->src[0]);
                     return ggml_is_contiguous(op->src[0]);
+                case GGML_UNARY_OP_CEIL:
+                    return ggml_is_contiguous_rows(op->src[0]);
                 default:
                     return false;
             }

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -172,18 +172,16 @@ void ggml_cuda_op_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT( dst->type == GGML_TYPE_F32 ||  dst->type == GGML_TYPE_F16);
     GGML_ASSERT(src0->type == dst->type);
 
-    const int64_t n_total = ggml_nelements(src0);
-    if(ggml_is_contiguous(src0)){
-        
-        if (src0->type == GGML_TYPE_F16) {
-            unary_cuda<op>((const half *)src0_d, (half *)dst_d, n_total, stream);
-        } else {
-            unary_cuda<op>((const float *)src0_d, (float *)dst_d, n_total, stream);
-        }
+const int64_t n_total = ggml_nelements(src0);
+if (ggml_is_contiguous(src0) && n_total <= INT_MAX) {
+    if (src0->type == GGML_TYPE_F16) {
+        unary_cuda<op>((const half *) src0_d, (half *) dst_d, (int) n_total, stream);
+    } else {
+        unary_cuda<op>((const float *) src0_d, (float *) dst_d, (int) n_total, stream);
+    }
+} else {
 
-    }else {
-
-        const size_t type_size = ggml_type_size(src0->type);
+    const size_t type_size = ggml_type_size(src0->type);
 
         const int64_t ne0 = src0->ne[0];
         const int64_t ne1 = src0->ne[1] > 0 ? src0->ne[1] : 1;

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -134,20 +134,24 @@ static __global__ void unary_op_kernel_strided(const T * x,T * dst,
                                                const int64_t sx0, const int64_t sx1, const int64_t sx2, const int64_t sx3,
                                                const int64_t sd0, const int64_t sd1, const int64_t sd2, const int64_t sd3
 ) {
-    const int64_t i = blockDim.x * blockIdx.x + threadIdx.x;
-    if (i >= ne_total) return;
+    ggml_cuda_pdl_lc();
+    const int64_t i = (int64_t) blockDim.x * blockIdx.x + threadIdx.x;
+     if (i >= ne_total) {
+         return;
+     }
 
-    int64_t i3 = i / (ne0 * ne1 * ne2);
-    int64_t rem = i - i3 * (ne0 * ne1 * ne2);
-    int64_t i2 = rem / (ne0 * ne1);
-    rem -= i2 * (ne0 * ne1);
-    int64_t i1 = rem / ne0;
-    int64_t i0 = rem - i1 * ne0;
-
-    int64_t src_off = i0 * sx0 + i1 * sx1 + i2 * sx2 + i3 * sx3;
-    int64_t dst_off = i0 * sd0 + i1 * sd1 + i2 * sd2 + i3 * sd3;
-
-    dst[dst_off] = (T)op((float)x[src_off]);
+     const int64_t ne01  = ne0 * ne1;
+     const int64_t ne012 = ne01 * ne2;
+     const int64_t i3 = i / ne012;
+     int64_t rem = i - i3 * ne012;
+     const int64_t i2 = rem / ne01;
+     rem -= i2 * ne01;
+     const int64_t i1 = rem / ne0;
+     const int64_t i0 = rem - i1 * ne0;
+     const int64_t src_off = i0 * sx0 + i1 * sx1 + i2 * sx2 + i3 * sx3;
+     const int64_t dst_off = i0 * sd0 + i1 * sd1 + i2 * sd2 + i3 * sd3;
+     ggml_cuda_pdl_sync();
+     dst[dst_off] = (T) op((float) x[src_off]);
 }
 
 template <float (*op)(float), typename T>

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -200,19 +200,22 @@ void ggml_cuda_op_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         const int64_t sd2 = dst->nb[2] / type_size;
         const int64_t sd3 = dst->nb[3] / type_size;
 
-        const int block_size = CUDA_NEG_BLOCK_SIZE;
-        const int grid_size = (n_total + block_size - 1) / block_size;
+        const int64_t block_size = CUDA_NEG_BLOCK_SIZE;
+        const int64_t block_num = (n_total + block_size - 1) / block_size;
+        GGML_ASSERT(block_num <= INT_MAX);
+        const int grid_size = static_cast<int>(block_num);
+
         const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params((dim3)grid_size, block_size, 0, stream);
 
         if (src0->type == GGML_TYPE_F16) {
             ggml_cuda_kernel_launch(unary_op_kernel_strided<op, half>,
-                launch_params,(const half*)src0->data, (half*)dst->data,
+                launch_params,(const half*)src0_d, (half*)dst_d,
                 ne0, ne1, ne2, ne3, n_total,
                 sx0, sx1, sx2, sx3,
                 sd0, sd1, sd2, sd3);
         } else {
             ggml_cuda_kernel_launch(unary_op_kernel_strided<op, float>,
-                launch_params,(const float*)src0->data, (float*)dst->data,
+                launch_params,(const float*)src0_d, (float*)dst_d,
                 ne0, ne1, ne2, ne3, n_total,
                 sx0, sx1, sx2, sx3,
                 sd0, sd1, sd2, sd3);

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -128,6 +128,29 @@ static __global__ void unary_op_kernel(const T * x, T * dst, const int k) {
 }
 
 template <float (*op)(float), typename T>
+static __global__ void unary_op_kernel_strided(const T * x,T * dst,
+                                               const int64_t ne0, const int64_t ne1, const int64_t ne2, const int64_t ne3,
+                                               const int64_t ne_total,
+                                               const int64_t sx0, const int64_t sx1, const int64_t sx2, const int64_t sx3,
+                                               const int64_t sd0, const int64_t sd1, const int64_t sd2, const int64_t sd3
+) {
+    const int64_t i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i >= ne_total) return;
+
+    int64_t i3 = i / (ne0 * ne1 * ne2);
+    int64_t rem = i - i3 * (ne0 * ne1 * ne2);
+    int64_t i2 = rem / (ne0 * ne1);
+    rem -= i2 * (ne0 * ne1);
+    int64_t i1 = rem / ne0;
+    int64_t i0 = rem - i1 * ne0;
+
+    int64_t src_off = i0 * sx0 + i1 * sx1 + i2 * sx2 + i3 * sx3;
+    int64_t dst_off = i0 * sd0 + i1 * sd1 + i2 * sd2 + i3 * sd3;
+
+    dst[dst_off] = (T)op((float)x[src_off]);
+}
+
+template <float (*op)(float), typename T>
 static void unary_cuda(const T * x, T * dst, const int k, cudaStream_t stream) {
     const int num_blocks = (k + CUDA_NEG_BLOCK_SIZE - 1) / CUDA_NEG_BLOCK_SIZE;
     const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params((dim3)num_blocks, CUDA_NEG_BLOCK_SIZE, 0, stream);
@@ -141,16 +164,55 @@ void ggml_cuda_op_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     void * dst_d = dst->data;
     cudaStream_t stream = ctx.stream();
 
-    GGML_ASSERT(ggml_is_contiguous(src0));
-
+    GGML_ASSERT(ggml_is_contiguous(src0)   ||ggml_is_contiguous_rows(src0));
     GGML_ASSERT(src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16);
     GGML_ASSERT( dst->type == GGML_TYPE_F32 ||  dst->type == GGML_TYPE_F16);
     GGML_ASSERT(src0->type == dst->type);
 
-    if (src0->type == GGML_TYPE_F16) {
-        unary_cuda<op>((const half *)src0_d, (half *)dst_d, ggml_nelements(src0), stream);
-    } else {
-        unary_cuda<op>((const float *)src0_d, (float *)dst_d, ggml_nelements(src0), stream);
+    const int64_t n_total = ggml_nelements(src0);
+    if(ggml_is_contiguous(src0)){
+        
+        if (src0->type == GGML_TYPE_F16) {
+            unary_cuda<op>((const half *)src0_d, (half *)dst_d, n_total, stream);
+        } else {
+            unary_cuda<op>((const float *)src0_d, (float *)dst_d, n_total, stream);
+        }
+    }else {
+
+        const size_t type_size = ggml_type_size(src0->type);
+
+        const int64_t ne0 = src0->ne[0];
+        const int64_t ne1 = src0->ne[1] > 0 ? src0->ne[1] : 1;
+        const int64_t ne2 = src0->ne[2] > 0 ? src0->ne[2] : 1;
+        const int64_t ne3 = src0->ne[3] > 0 ? src0->ne[3] : 1;
+
+        const int64_t sx0 = src0->nb[0] / type_size;
+        const int64_t sx1 = src0->nb[1] / type_size;
+        const int64_t sx2 = src0->nb[2] / type_size;
+        const int64_t sx3 = src0->nb[3] / type_size;
+
+        const int64_t sd0 = dst->nb[0] / type_size;
+        const int64_t sd1 = dst->nb[1] / type_size;
+        const int64_t sd2 = dst->nb[2] / type_size;
+        const int64_t sd3 = dst->nb[3] / type_size;
+
+        const int block_size = CUDA_NEG_BLOCK_SIZE;
+        const int grid_size = (n_total + block_size - 1) / block_size;
+        const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params((dim3)grid_size, block_size, 0, stream);
+
+        if (src0->type == GGML_TYPE_F16) {
+            ggml_cuda_kernel_launch(unary_op_kernel_strided<op, half>,
+                launch_params,(const half*)src0->data, (half*)dst->data,
+                ne0, ne1, ne2, ne3, n_total,
+                sx0, sx1, sx2, sx3,
+                sd0, sd1, sd2, sd3);
+        } else {
+            ggml_cuda_kernel_launch(unary_op_kernel_strided<op, float>,
+                launch_params,(const float*)src0->data, (float*)dst->data,
+                ne0, ne1, ne2, ne3, n_total,
+                sx0, sx1, sx2, sx3,
+                sd0, sd1, sd2, sd3);
+        }
     }
 }
 

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -128,12 +128,11 @@ static __global__ void unary_op_kernel(const T * x, T * dst, const int k) {
 }
 
 template <float (*op)(float), typename T>
-static __global__ void unary_op_kernel_strided(const T * x,T * dst,
+static __global__ void unary_op_kernel_strided(const T * x, T * dst,
                                                const int64_t ne0, const int64_t ne1, const int64_t ne2, const int64_t ne3,
                                                const int64_t ne_total,
-                                               const int64_t sx0, const int64_t sx1, const int64_t sx2, const int64_t sx3,
-                                               const int64_t sd0, const int64_t sd1, const int64_t sd2, const int64_t sd3
-) {
+                                               const int64_t sx0, const int64_t sx1, const int64_t sx2, const int64_t sx3, 
+                                               const int64_t sd0, const int64_t sd1, const int64_t sd2, const int64_t sd3) {
     ggml_cuda_pdl_lc();
     const int64_t i = (int64_t) blockDim.x * blockIdx.x + threadIdx.x;
      if (i >= ne_total) {
@@ -168,7 +167,7 @@ void ggml_cuda_op_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     void * dst_d = dst->data;
     cudaStream_t stream = ctx.stream();
 
-    GGML_ASSERT(ggml_is_contiguous(src0)   ||ggml_is_contiguous_rows(src0));
+    GGML_ASSERT(ggml_is_contiguous_rows(src0));
     GGML_ASSERT(src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16);
     GGML_ASSERT( dst->type == GGML_TYPE_F32 ||  dst->type == GGML_TYPE_F16);
     GGML_ASSERT(src0->type == dst->type);
@@ -181,6 +180,7 @@ void ggml_cuda_op_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         } else {
             unary_cuda<op>((const float *)src0_d, (float *)dst_d, n_total, stream);
         }
+
     }else {
 
         const size_t type_size = ggml_type_size(src0->type);
@@ -209,13 +209,13 @@ void ggml_cuda_op_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
         if (src0->type == GGML_TYPE_F16) {
             ggml_cuda_kernel_launch(unary_op_kernel_strided<op, half>,
-                launch_params,(const half*)src0_d, (half*)dst_d,
+                launch_params, (const half*)src0_d, (half*)dst_d,
                 ne0, ne1, ne2, ne3, n_total,
                 sx0, sx1, sx2, sx3,
                 sd0, sd1, sd2, sd3);
         } else {
             ggml_cuda_kernel_launch(unary_op_kernel_strided<op, float>,
-                launch_params,(const float*)src0_d, (float*)dst_d,
+                launch_params, (const float*)src0_d, (float*)dst_d,
                 ne0, ne1, ne2, ne3, n_total,
                 sx0, sx1, sx2, sx3,
                 sd0, sd1, sd2, sd3);

--- a/ggml/src/ggml-cuda/unary.cu
+++ b/ggml/src/ggml-cuda/unary.cu
@@ -128,29 +128,39 @@ static __global__ void unary_op_kernel(const T * x, T * dst, const int k) {
 }
 
 template <float (*op)(float), typename T>
-static __global__ void unary_op_kernel_strided(const T * x, T * dst,
-                                               const int64_t ne0, const int64_t ne1, const int64_t ne2, const int64_t ne3,
+static __global__ void unary_op_kernel_strided(const T *     x,
+                                               T *           dst,
+                                               const int64_t ne0,
+                                               const int64_t ne1,
+                                               const int64_t ne2,
+                                               const int64_t ne3,
                                                const int64_t ne_total,
-                                               const int64_t sx0, const int64_t sx1, const int64_t sx2, const int64_t sx3, 
-                                               const int64_t sd0, const int64_t sd1, const int64_t sd2, const int64_t sd3) {
+                                               const int64_t sx0,
+                                               const int64_t sx1,
+                                               const int64_t sx2,
+                                               const int64_t sx3,
+                                               const int64_t sd0,
+                                               const int64_t sd1,
+                                               const int64_t sd2,
+                                               const int64_t sd3) {
     ggml_cuda_pdl_lc();
     const int64_t i = (int64_t) blockDim.x * blockIdx.x + threadIdx.x;
-     if (i >= ne_total) {
-         return;
-     }
+    if (i >= ne_total) {
+        return;
+    }
 
-     const int64_t ne01  = ne0 * ne1;
-     const int64_t ne012 = ne01 * ne2;
-     const int64_t i3 = i / ne012;
-     int64_t rem = i - i3 * ne012;
-     const int64_t i2 = rem / ne01;
-     rem -= i2 * ne01;
-     const int64_t i1 = rem / ne0;
-     const int64_t i0 = rem - i1 * ne0;
-     const int64_t src_off = i0 * sx0 + i1 * sx1 + i2 * sx2 + i3 * sx3;
-     const int64_t dst_off = i0 * sd0 + i1 * sd1 + i2 * sd2 + i3 * sd3;
-     ggml_cuda_pdl_sync();
-     dst[dst_off] = (T) op((float) x[src_off]);
+    const int64_t ne01  = ne0 * ne1;
+    const int64_t ne012 = ne01 * ne2;
+    const int64_t i3    = i / ne012;
+    int64_t       rem   = i - i3 * ne012;
+    const int64_t i2    = rem / ne01;
+    rem -= i2 * ne01;
+    const int64_t i1      = rem / ne0;
+    const int64_t i0      = rem - i1 * ne0;
+    const int64_t src_off = i0 * sx0 + i1 * sx1 + i2 * sx2 + i3 * sx3;
+    const int64_t dst_off = i0 * sd0 + i1 * sd1 + i2 * sd2 + i3 * sd3;
+    ggml_cuda_pdl_sync();
+    dst[dst_off] = (T) op((float) x[src_off]);
 }
 
 template <float (*op)(float), typename T>
@@ -172,16 +182,15 @@ void ggml_cuda_op_unary(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT( dst->type == GGML_TYPE_F32 ||  dst->type == GGML_TYPE_F16);
     GGML_ASSERT(src0->type == dst->type);
 
-const int64_t n_total = ggml_nelements(src0);
-if (ggml_is_contiguous(src0) && n_total <= INT_MAX) {
-    if (src0->type == GGML_TYPE_F16) {
-        unary_cuda<op>((const half *) src0_d, (half *) dst_d, (int) n_total, stream);
+    const int64_t n_total = ggml_nelements(src0);
+    if (ggml_is_contiguous(src0) && n_total <= INT_MAX) {
+        if (src0->type == GGML_TYPE_F16) {
+            unary_cuda<op>((const half *) src0_d, (half *) dst_d, (int) n_total, stream);
+        } else {
+            unary_cuda<op>((const float *) src0_d, (float *) dst_d, (int) n_total, stream);
+        }
     } else {
-        unary_cuda<op>((const float *) src0_d, (float *) dst_d, (int) n_total, stream);
-    }
-} else {
-
-    const size_t type_size = ggml_type_size(src0->type);
+        const size_t type_size = ggml_type_size(src0->type);
 
         const int64_t ne0 = src0->ne[0];
         const int64_t ne1 = src0->ne[1] > 0 ? src0->ne[1] : 1;
@@ -199,24 +208,21 @@ if (ggml_is_contiguous(src0) && n_total <= INT_MAX) {
         const int64_t sd3 = dst->nb[3] / type_size;
 
         const int64_t block_size = CUDA_NEG_BLOCK_SIZE;
-        const int64_t block_num = (n_total + block_size - 1) / block_size;
+        const int64_t block_num  = (n_total + block_size - 1) / block_size;
         GGML_ASSERT(block_num <= INT_MAX);
         const int grid_size = static_cast<int>(block_num);
 
-        const ggml_cuda_kernel_launch_params launch_params = ggml_cuda_kernel_launch_params((dim3)grid_size, block_size, 0, stream);
+        const ggml_cuda_kernel_launch_params launch_params =
+            ggml_cuda_kernel_launch_params((dim3) grid_size, block_size, 0, stream);
 
         if (src0->type == GGML_TYPE_F16) {
-            ggml_cuda_kernel_launch(unary_op_kernel_strided<op, half>,
-                launch_params, (const half*)src0_d, (half*)dst_d,
-                ne0, ne1, ne2, ne3, n_total,
-                sx0, sx1, sx2, sx3,
-                sd0, sd1, sd2, sd3);
+            ggml_cuda_kernel_launch(unary_op_kernel_strided<op, half>, launch_params, (const half *) src0_d,
+                                    (half *) dst_d, ne0, ne1, ne2, ne3, n_total, sx0, sx1, sx2, sx3, sd0, sd1, sd2,
+                                    sd3);
         } else {
-            ggml_cuda_kernel_launch(unary_op_kernel_strided<op, float>,
-                launch_params, (const float*)src0_d, (float*)dst_d,
-                ne0, ne1, ne2, ne3, n_total,
-                sx0, sx1, sx2, sx3,
-                sd0, sd1, sd2, sd3);
+            ggml_cuda_kernel_launch(unary_op_kernel_strided<op, float>, launch_params, (const float *) src0_d,
+                                    (float *) dst_d, ne0, ne1, ne2, ne3, n_total, sx0, sx1, sx2, sx3, sd0, sd1, sd2,
+                                    sd3);
         }
     }
 }


### PR DESCRIPTION
## Overview

Upgraded the CUDA version of the ceil operator to achieve full support
This Pr fulfills issue #14909 by supporting a contiguous_row CUDA CEIL operator.

## Additional information
     Due to the difference of cross-platform,local executions of the full test suite yielded non-deterministic results for unrelated operators.Consequently,no changes were made to ops.md
     But benchmarking confirms the changes are isolated:under identical environments,the CUDA CEIL operator is only component exhibiting behavioral differences.
[diff.md](https://github.com/user-attachments/files/30651177/diff.md)


<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->Yes
- AI-assisted only :Suggestions,glossary translation and refrence lookup
- Code and text were written entirely by myself

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
