### PR TITLE
metal : add GGML_OP_CROSS_ENTROPY_LOSS

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -2235,3 +2235,20 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_count_equal(ggml
 
     return res;
 }
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cross_entropy_loss(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_CROSS_ENTROPY_LOSS);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_cross_entropy_loss_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -2225,3 +2225,20 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_count_equal(ggml
 
     return res;
 }
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cross_entropy_loss(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_CROSS_ENTROPY_LOSS);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_cross_entropy_loss_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -169,6 +169,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_opt_step_
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_opt_step_sgd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_memset            (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_count_equal       (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_cross_entropy_loss(ggml_metal_library_t lib, const struct ggml_tensor * op);
 
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_flash_attn_ext_pad(
         ggml_metal_library_t lib,

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1227,6 +1227,13 @@ bool ggml_metal_device_supports_op(ggml_metal_device_t dev, const struct ggml_te
                 op->src[0]->type == GGML_TYPE_I32 &&
                 op->src[1]->type == GGML_TYPE_I32 &&
                 op->type == GGML_TYPE_I64;
+        case GGML_OP_CROSS_ENTROPY_LOSS:
+            return has_simdgroup_reduction &&
+                op->src[0]->type == GGML_TYPE_F32 &&
+                op->src[1]->type == GGML_TYPE_F32 &&
+                op->type == GGML_TYPE_F32 &&
+                ggml_is_contiguous(op->src[0]) &&
+                ggml_is_contiguous(op->src[1]);
         case GGML_OP_ARGMAX:
             return has_simdgroup_reduction;
         case GGML_OP_NORM:

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -1254,6 +1254,11 @@ typedef struct {
 } ggml_metal_kargs_count_equal;
 
 typedef struct {
+    int64_t ne00;
+    int64_t nrows;
+} ggml_metal_kargs_cross_entropy_loss;
+
+typedef struct {
     int32_t  k0;
     int32_t  k1;
     int32_t  s0;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -1258,6 +1258,11 @@ typedef struct {
 } ggml_metal_kargs_count_equal;
 
 typedef struct {
+    int64_t ne00;
+    int64_t nrows;
+} ggml_metal_kargs_cross_entropy_loss;
+
+typedef struct {
     int32_t  k0;
     int32_t  k1;
     int32_t  s0;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -495,6 +495,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_count_equal(ctx, idx);
             } break;
+        case GGML_OP_CROSS_ENTROPY_LOSS:
+            {
+                n_fuse = ggml_metal_op_cross_entropy_loss(ctx, idx);
+            } break;
         default:
             {
                 GGML_LOG_ERROR("%s: error: node %3d, op = %8s not implemented\n", __func__, idx, ggml_op_name(node->op));
@@ -5153,6 +5157,51 @@ int ggml_metal_op_count_equal(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
         ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne02, ne03, nth, 1, 1);
     }
+
+    return 1;
+}
+
+int ggml_metal_op_cross_entropy_loss(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_ASSERT(ggml_is_contiguous(op->src[0]));
+    GGML_ASSERT(ggml_is_contiguous(op->src[1]));
+    GGML_ASSERT(ggml_are_same_shape(op->src[0], op->src[1]));
+    GGML_ASSERT(ggml_is_scalar(op));
+
+    const int64_t ne00  = op->src[0]->ne[0];
+    const int64_t nrows = ggml_nrows(op->src[0]);
+
+    ggml_metal_kargs_cross_entropy_loss args = {
+        /*.ne00  =*/ ne00,
+        /*.nrows =*/ nrows,
+    };
+
+    auto pipeline = ggml_metal_library_get_pipeline_cross_entropy_loss(lib, op);
+
+    int nth = 32; // SIMD width
+
+    while (nth < ne00 && nth < ggml_metal_pipeline_max_theads_per_threadgroup(pipeline)) {
+        nth *= 2;
+    }
+
+    nth = std::min(nth, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+    nth = std::min(nth, (int) ne00);
+
+    const int nsg = (nth + 31)/32;
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
+
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, nsg*sizeof(float), 0);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, 1, 1, 1, nth, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -495,6 +495,10 @@ static int ggml_metal_op_encode_impl(ggml_metal_op_t ctx, int idx) {
             {
                 n_fuse = ggml_metal_op_count_equal(ctx, idx);
             } break;
+        case GGML_OP_CROSS_ENTROPY_LOSS:
+            {
+                n_fuse = ggml_metal_op_cross_entropy_loss(ctx, idx);
+            } break;
         default:
             {
                 GGML_LOG_ERROR("%s: error: node %3d, op = %8s not implemented\n", __func__, idx, ggml_op_name(node->op));
@@ -5148,6 +5152,51 @@ int ggml_metal_op_count_equal(ggml_metal_op_t ctx, int idx) {
         ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
         ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne02, ne03, nth, 1, 1);
     }
+
+    return 1;
+}
+
+int ggml_metal_op_cross_entropy_loss(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_ASSERT(ggml_is_contiguous(op->src[0]));
+    GGML_ASSERT(ggml_is_contiguous(op->src[1]));
+    GGML_ASSERT(ggml_are_same_shape(op->src[0], op->src[1]));
+    GGML_ASSERT(ggml_is_scalar(op));
+
+    const int64_t ne00  = op->src[0]->ne[0];
+    const int64_t nrows = ggml_nrows(op->src[0]);
+
+    ggml_metal_kargs_cross_entropy_loss args = {
+        /*.ne00  =*/ ne00,
+        /*.nrows =*/ nrows,
+    };
+
+    auto pipeline = ggml_metal_library_get_pipeline_cross_entropy_loss(lib, op);
+
+    int nth = 32; // SIMD width
+
+    while (nth < ne00 && nth < ggml_metal_pipeline_max_theads_per_threadgroup(pipeline)) {
+        nth *= 2;
+    }
+
+    nth = std::min(nth, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+    nth = std::min(nth, (int) ne00);
+
+    const int nsg = (nth + 31)/32;
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
+
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, nsg*sizeof(float), 0);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, 1, 1, 1, nth, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.h
+++ b/ggml/src/ggml-metal/ggml-metal-ops.h
@@ -98,6 +98,7 @@ int ggml_metal_op_tri               (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_adamw    (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_opt_step_sgd      (ggml_metal_op_t ctx, int idx);
 int ggml_metal_op_count_equal       (ggml_metal_op_t ctx, int idx);
+int ggml_metal_op_cross_entropy_loss(ggml_metal_op_t ctx, int idx);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -11601,3 +11601,87 @@ kernel void kernel_dsv4_hc_post_f32(
         *(device float *) (dst + i0*args.nb_d0 + idst*args.nb_d1 + it*args.nb_d2) = result[idst];
     }
 }
+
+kernel void kernel_cross_entropy_loss_f32(
+        constant ggml_metal_kargs_cross_entropy_loss & args,
+        device const float * src0,
+        device const float * src1,
+        device       float * dst,
+        threadgroup  float * shmem_f32 [[threadgroup(0)]],
+        ushort3 tpitg[[thread_position_in_threadgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort3   ntg[[threads_per_threadgroup]]) {
+    const short nsg = (ntg.x + 31)/32;
+
+    float sum_loss = 0.0f;
+
+    for (int64_t i1 = 0; i1 < args.nrows; ++i1) {
+        device const float * logits = src0 + i1*args.ne00;
+        device const float * labels = src1 + i1*args.ne00;
+
+        // max of the row, used to avoid overflow in exp
+        float vmax = -INFINITY;
+        for (int64_t i0 = tpitg.x; i0 < args.ne00; i0 += ntg.x) {
+            vmax = max(vmax, logits[i0]);
+        }
+        vmax = simd_max(vmax);
+
+        if (tiisg == 0) {
+            shmem_f32[sgitg] = vmax;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        vmax = shmem_f32[0];
+        for (short s = 1; s < nsg; ++s) {
+            vmax = max(vmax, shmem_f32[s]);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // log(sum(exp(logits - vmax)))
+        float vsum = 0.0f;
+        for (int64_t i0 = tpitg.x; i0 < args.ne00; i0 += ntg.x) {
+            vsum += exp(logits[i0] - vmax);
+        }
+        vsum = simd_sum(vsum);
+
+        if (tiisg == 0) {
+            shmem_f32[sgitg] = vsum;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        vsum = 0.0f;
+        for (short s = 0; s < nsg; ++s) {
+            vsum += shmem_f32[s];
+        }
+
+        const float lse = log(vsum);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        float vloss = 0.0f;
+        for (int64_t i0 = tpitg.x; i0 < args.ne00; i0 += ntg.x) {
+            vloss += (logits[i0] - vmax - lse)*labels[i0];
+        }
+        vloss = simd_sum(vloss);
+
+        if (tiisg == 0) {
+            shmem_f32[sgitg] = vloss;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (short s = 0; s < nsg; ++s) {
+            sum_loss += shmem_f32[s];
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tpitg.x == 0) {
+        dst[0] = -sum_loss/(float) args.nrows;
+    }
+}

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -11818,3 +11818,87 @@ kernel void kernel_dsv4_hc_post_f32(
         *(device float *) (dst + i0*args.nb_d0 + idst*args.nb_d1 + it*args.nb_d2) = result[idst];
     }
 }
+
+kernel void kernel_cross_entropy_loss_f32(
+        constant ggml_metal_kargs_cross_entropy_loss & args,
+        device const float * src0,
+        device const float * src1,
+        device       float * dst,
+        threadgroup  float * shmem_f32 [[threadgroup(0)]],
+        ushort3 tpitg[[thread_position_in_threadgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort3   ntg[[threads_per_threadgroup]]) {
+    const short nsg = (ntg.x + 31)/32;
+
+    float sum_loss = 0.0f;
+
+    for (int64_t i1 = 0; i1 < args.nrows; ++i1) {
+        device const float * logits = src0 + i1*args.ne00;
+        device const float * labels = src1 + i1*args.ne00;
+
+        // max of the row, used to avoid overflow in exp
+        float vmax = -INFINITY;
+        for (int64_t i0 = tpitg.x; i0 < args.ne00; i0 += ntg.x) {
+            vmax = max(vmax, logits[i0]);
+        }
+        vmax = simd_max(vmax);
+
+        if (tiisg == 0) {
+            shmem_f32[sgitg] = vmax;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        vmax = shmem_f32[0];
+        for (short s = 1; s < nsg; ++s) {
+            vmax = max(vmax, shmem_f32[s]);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // log(sum(exp(logits - vmax)))
+        float vsum = 0.0f;
+        for (int64_t i0 = tpitg.x; i0 < args.ne00; i0 += ntg.x) {
+            vsum += exp(logits[i0] - vmax);
+        }
+        vsum = simd_sum(vsum);
+
+        if (tiisg == 0) {
+            shmem_f32[sgitg] = vsum;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        vsum = 0.0f;
+        for (short s = 0; s < nsg; ++s) {
+            vsum += shmem_f32[s];
+        }
+
+        const float lse = log(vsum);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        float vloss = 0.0f;
+        for (int64_t i0 = tpitg.x; i0 < args.ne00; i0 += ntg.x) {
+            vloss += (logits[i0] - vmax - lse)*labels[i0];
+        }
+        vloss = simd_sum(vloss);
+
+        if (tiisg == 0) {
+            shmem_f32[sgitg] = vloss;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (short s = 0; s < nsg; ++s) {
+            sum_loss += shmem_f32[s];
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tpitg.x == 0) {
+        dst[0] = -sum_loss/(float) args.nrows;
+    }
+}

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9884,6 +9884,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     }
 
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   10, 5, 4, 3}));
+    // row lengths that leave a partial simdgroup on Metal
+    test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   33, 5, 4, 3}));
+    test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, { 1000, 1, 1, 1}));
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {30000, 1, 1, 1}));
     test_cases.emplace_back(new test_cross_entropy_loss_back(GGML_TYPE_F32, {   10, 5, 4, 3}));
     test_cases.emplace_back(new test_cross_entropy_loss_back(GGML_TYPE_F32, {30000, 1, 1, 1}));


### PR DESCRIPTION
## Overview

Add Metal support for GGML_OP_CROSS_ENTROPY_LOSS (forward only).

## Additional information

Differs from closed without merging. #21542: forward-only, 
single TG over rows instead of one TG per row + atomic float adds.

Related: #14909

Full verification on Apple M1 / macOS 26.6.1, post-#26980:
CROSS_ENTROPY_LOSS ne=[10,5,4,3]     OK
CROSS_ENTROPY_LOSS ne=[33,5,4,3]     OK    ← partial simdgroup
CROSS_ENTROPY_LOSS ne=[1000,1,1,1]   OK    ← partial simdgroup
CROSS_ENTROPY_LOSS ne=[30000,1,1,1]  OK
full Metal suite:  14183/14183 tests passed   (exit 0)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - an AI coding assistant helped draft the Metal kernel and host wiring

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
