### PR TITLE
server: classify mid-decode context exhaustion as ERROR_TYPE_EXCEED_CONTEXT_SIZE

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3670,9 +3670,12 @@ private:
                             // risk aborting the whole process on a slot that doesn't hold that
                             // invariant. slot.n_ctx is set at slot init and is always > 0; n_tokens()
                             // is non-zero for any is_processing() slot in practice but isn't statically
-                            // guaranteed, so the check stays explicit.
+                            // guaranteed, so the check stays explicit. slot.task is also checked
+                            // explicitly rather than assuming is_processing() implies non-null, since
+                            // that pairing is a state invariant this guard exists precisely because we
+                            // don't want to trust unconditionally.
                             const enum error_type type = (err_type == ERROR_TYPE_EXCEED_CONTEXT_SIZE &&
-                                                          slot.n_ctx > 0 && slot.task->n_tokens() > 0)
+                                                          slot.n_ctx > 0 && slot.task && slot.task->n_tokens() > 0)
                                                        ? err_type : ERROR_TYPE_SERVER;
                             send_error(slot, err, type);
                             slot.release();

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3640,11 +3640,13 @@ private:
         if (ret != 0) {
             {
                 std::string err;
+                enum error_type err_type = ERROR_TYPE_SERVER;
 
                 if (n_batch == 1 && ret == 1) {
                     // TODO: try to terminate only the largest active slot/sequence and continue with the rest
                     //       need to remove the tokens from the current batch too
                     err = "Context size has been exceeded.";
+                    err_type = ERROR_TYPE_EXCEED_CONTEXT_SIZE;
                 }
 
                 if (ret == -1) {
@@ -3663,7 +3665,16 @@ private:
 
                     for (auto & slot : slots) {
                         if (slot.is_processing()) {
-                            send_error(slot, err);
+                            // ERROR_TYPE_EXCEED_CONTEXT_SIZE asserts n_ctx > 0 && n_prompt_tokens > 0
+                            // (send_error / GGML_ASSERT); degrade to ERROR_TYPE_SERVER rather than
+                            // risk aborting the whole process on a slot that doesn't hold that
+                            // invariant. slot.n_ctx is set at slot init and is always > 0; n_tokens()
+                            // is non-zero for any is_processing() slot in practice but isn't statically
+                            // guaranteed, so the check stays explicit.
+                            const enum error_type type = (err_type == ERROR_TYPE_EXCEED_CONTEXT_SIZE &&
+                                                          slot.n_ctx > 0 && slot.task->n_tokens() > 0)
+                                                       ? err_type : ERROR_TYPE_SERVER;
+                            send_error(slot, err, type);
                             slot.release();
 
                             // note: it's complicated to keep track of how much of the current batch has been


### PR DESCRIPTION
## Summary

The mid-decode over-context branch in `update_slots()` (the `n_batch == 1 && ret == 1` case, `tools/server/server-context.cpp`) calls `send_error(slot, err)` with no `type` argument, which defaults to `ERROR_TYPE_SERVER` and returns HTTP `500` / `"server_error"`.

The **admission** path already classifies the identical "out of context" condition correctly, using `ERROR_TYPE_EXCEED_CONTEXT_SIZE` (HTTP `400` / `"exceed_context_size_error"`) — see the two existing `send_error(..., ERROR_TYPE_EXCEED_CONTEXT_SIZE)` calls earlier in this file. This PR makes the decode path agree with the admission path: both now report the same `error.type` for the same underlying condition, so a client can distinguish "your request was rejected" (400, retryable/failover-able) from "the server is broken" (500) regardless of which code path caught it.

`ERROR_TYPE_EXCEED_CONTEXT_SIZE` triggers a `GGML_ASSERT(n_ctx > 0 && n_prompt_tokens > 0)` inside `send_error()`. `slot.n_ctx` is set at slot init and is always `> 0` on this path; `slot.task->n_tokens()` is non-zero for any `is_processing()` slot in practice but isn't statically guaranteed, so the new type is only emitted when both hold — otherwise it falls back to the previous `ERROR_TYPE_SERVER` behaviour, so this change cannot turn a failed request into an aborted process (`GGML_ASSERT` aborts the whole server, not just the request).

## Motivation / how this was found

We build `llama-server` from a pinned commit for a small on-prem inference lab (unified KV cache, `--parallel 3`). Under concurrency, several individually-small requests can collectively exceed the shared KV pool. Because that failure surfaced as a `500`, a proxy in front of the server that branches on HTTP status (retry/failover on 4xx, mark backend degraded on 5xx) treated a **capacity** condition as a **backend outage**. Full root-cause writeup (including the source-level trace to this exact call site) is at https://github.com/Pixel-Directive-LLC/lab-orchestrator-core/issues/107.

## Testing

Live before/after test against a real build with `--kv-unified --parallel 3`: concurrent requests individually under `n_ctx` but collectively exceeding the shared pool returned `500`/`server_error` on every affected slot **before** this change, and `400`/`exceed_context_size_error` **after**, with `n_prompt_tokens`/`n_ctx` populated on the error response. The admission path (a single prompt larger than `n_ctx`) is unaffected — verified unchanged before and after.

We're carrying this as a small local patch downstream in the meantime; happy to adjust to match project conventions.
