### PR TITLE
dont (immedietly) promote fa-auto -> fa-on

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3562,15 +3562,9 @@ llama_context * llama_init_from_model(
         return nullptr;
     }
 
-    if (ggml_is_quantized(params.type_v) && params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_ENABLED) {
-        if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO) {
-            LLAMA_LOG_INFO("%s: enabling flash_attn since it is required for quantized V cache\n", __func__);
-            params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
-        }
-        if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED) {
-            LLAMA_LOG_ERROR("%s: quantized V cache requires flash_attn to be enabled\n", __func__);
-            return nullptr;
-        }
+    if (ggml_is_quantized(params.type_v) && params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED) {
+        LLAMA_LOG_ERROR("%s: quantized V cache requires flash_attn to be enabled\n", __func__);
+        return nullptr;
     }
 
     if (params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED && ggml_is_quantized(params.type_k)) {


### PR DESCRIPTION
## Overview

in #25871 if FA was set to AUTO and ctv is quantized, then it automatically sets FA to enabled. That causes the check on `src/llama-context.cpp:550` to never run, and causes the guard on `src/llama-context.cpp:459` to never trip. Which means flash attention automatically offloads to CPU in case it is not supported in backend (often when ctk != ctv) 
There is no log line showing this is happening, which means performance is quietly degraded, and debugging is very difficult. 

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
  - AI was used to identify why performance of the model was (much) lower than expected, and was used to identify the code responsible for the issue.
