### PR TITLE
tests: Mitigate test-model-resolution crashing on MSYS2 UCRT64 environment

### DIFF
--- a/tests/test-model-resolution.cpp
+++ b/tests/test-model-resolution.cpp
@@ -195,7 +195,7 @@ static const std::vector<std::string> dspark_dflash = {
 
 struct plan_case {
     const char * name;
-    const std::vector<std::string> & files;
+    const std::vector<std::string> files;
     const char * hf_repo;
     const char * hf_file;
     bool sidecars;        // request mmproj + mtp + dflash + eagle3 + dspark


### PR DESCRIPTION
## Overview

Fixes #26552. Mitigates crashing issue occurring in Windows MSYS2 UCRT64 environment. While I haven't fully checked, the original code maybe undefined behavior since we're initializing `&files` (reference to a vector) with a temporary vector where its lifetime is not guaranteed.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for analysis and fix proposal<!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
