### PR TITLE
server: (router) add LRU scheduler

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -70,8 +70,8 @@ struct server_subproc {
     }
 };
 
-struct lru_sched {
-    lru_sched(server_models & models) : models(models) {}
+struct server_lru_sched {
+    server_lru_sched(server_models & models) : models(models) {}
 
     bool has_capacity(std::unique_lock<std::mutex> & lk) {
         check_lock(lk);
@@ -412,7 +412,7 @@ server_models::server_models(
               base_params(params),
               base_env(get_environment()),
               base_preset(ctx_preset.load_from_args(argc, argv)),
-              sched(std::make_unique<lru_sched>(*this)) {
+              sched(std::make_unique<server_lru_sched>(*this)) {
     // clean up base preset
     unset_reserved_args(base_preset, true);
     // set binary path
@@ -424,7 +424,7 @@ server_models::server_models(
         LOG_WRN("using original argv[0] as fallback: %s\n", argv[0]);
     }
     load_models();
-    debug_fake_timing = !common_get_env("LLAMA_DEBUG_FAKE_TIMING").empty();
+    debug_fake_timing = !common_get_env("LLAMA_SERVER_DEBUG_FAKE_TIMING").empty();
 }
 
 server_models::~server_models() = default;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1882,7 +1882,9 @@ void server_models_routes::init_routes() {
         // this request instead of leaving an orphan generation
         std::string conv_id = server_stream_conv_id_from_headers(req.headers);
         uint64_t ticket = models.conv_models.remember(conv_id, name);
-        bool waited = autoload && models.ensure_model_ready(name, req.should_stop);
+        // a dead socket must not cancel a session request, only a stop does (checked right below)
+        auto should_stop = ticket == 0 ? req.should_stop : nullptr;
+        bool waited = autoload && models.ensure_model_ready(name, should_stop);
         if (ticket != 0 && !models.conv_models.alive(conv_id, ticket)) {
             SRV_INF("request for conv_id=%s cancelled while model name=%s was loading\n",
                     conv_id.c_str(), name.c_str());

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -70,6 +70,156 @@ struct server_subproc {
     }
 };
 
+struct lru_sched {
+    lru_sched(server_models & models) : models(models) {}
+
+    bool has_capacity(std::unique_lock<std::mutex> & lk) {
+        check_lock(lk);
+        return models.base_params.models_max <= 0
+            || count_running() < (size_t) models.base_params.models_max;
+    }
+
+    // returns "" if no model can be given up
+    std::string pick_victim(std::unique_lock<std::mutex> & lk, const std::string & exclude) {
+        check_lock(lk);
+        std::string victim;
+        int64_t victim_last_used = 0;
+        for (const auto & m : models.mapping) {
+            if (m.first == exclude) {
+                continue;
+            }
+            // a busy model is mid-request, one still coming up has no request to finish
+            if (m.second.req_count != 0 || !m.second.meta.is_ready_or_sleep()) {
+                continue;
+            }
+            if (victim.empty() || m.second.meta.last_used < victim_last_used) {
+                victim           = m.first;
+                victim_last_used = m.second.meta.last_used;
+            }
+        }
+        return victim;
+    }
+
+    uint64_t enqueue(std::unique_lock<std::mutex> & lk, const std::string & model_id, bool front = false) {
+        check_lock(lk);
+        uint64_t req_id = next_req_id++;
+        if (front) {
+            queue.push_front({ req_id, model_id, false });
+        } else {
+            queue.push_back({ req_id, model_id, false });
+        }
+        SRV_INF("models_max reached, request for name=%s queued at position %zu\n",
+                model_id.c_str(), front ? (size_t) 1 : queue.size());
+        return req_id;
+    }
+
+    void dequeue(std::unique_lock<std::mutex> & lk, uint64_t req_id) {
+        check_lock(lk);
+        if (req_id == 0) {
+            return;
+        }
+        for (auto it = queue.begin(); it != queue.end(); ++it) {
+            if (it->req_id == req_id) {
+                queue.erase(it);
+                return;
+            }
+        }
+    }
+
+    bool is_head(std::unique_lock<std::mutex> & lk, uint64_t req_id) {
+        check_lock(lk);
+        return req_id != 0 && !queue.empty() && queue.front().req_id == req_id;
+    }
+
+    bool queue_empty(std::unique_lock<std::mutex> & lk) {
+        check_lock(lk);
+        return queue.empty();
+    }
+
+    // a model is on its way out for this entry, so other requests do not also give up one
+    void mark_slot_pending(std::unique_lock<std::mutex> & lk, uint64_t req_id) {
+        check_lock(lk);
+        for (auto & e : queue) {
+            if (e.req_id == req_id) {
+                e.slot_pending = true;
+                return;
+            }
+        }
+    }
+
+    // model_id went idle: give up its slot if a queued request needs one
+    // thread-safe, caller must NOT hold models.mutex
+    void on_model_idle(const std::string & model_id) {
+        if (models.base_params.models_max <= 0) {
+            return; // no limit, nothing is ever queued
+        }
+        {
+            std::unique_lock<std::mutex> lk(models.mutex);
+            if (queue.empty()) {
+                return;
+            }
+            size_t promised     = 0;
+            bool   has_unserved = false;
+            for (const auto & e : queue) {
+                if (e.slot_pending) {
+                    promised++;
+                } else {
+                    has_unserved = true;
+                }
+            }
+            if (!has_unserved) {
+                return;
+            }
+            if ((int) count_running() - (int) promised < models.base_params.models_max) {
+                return; // a slot is already on its way
+            }
+            // never give up a model that a queued request wants
+            for (const auto & e : queue) {
+                if (e.model_id == model_id) {
+                    return;
+                }
+            }
+            auto it = models.mapping.find(model_id);
+            if (it == models.mapping.end() || it->second.req_count != 0 || !it->second.meta.is_ready_or_sleep()) {
+                return;
+            }
+            for (auto & e : queue) {
+                if (!e.slot_pending) {
+                    e.slot_pending = true;
+                    break;
+                }
+            }
+        }
+        SRV_INF("model name=%s went idle, giving up its slot to a queued request\n", model_id.c_str());
+        models.unload(model_id);
+    }
+
+  private:
+    struct entry_t {
+        uint64_t    req_id;
+        std::string model_id;
+        bool        slot_pending; // a model is already being evicted for this entry
+    };
+
+    void check_lock(std::unique_lock<std::mutex> & lk) {
+        GGML_ASSERT(lk.owns_lock() && lk.mutex() == &models.mutex);
+    }
+
+    size_t count_running() {
+        size_t count = 0;
+        for (const auto & m : models.mapping) {
+            if (m.second.meta.is_running()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    server_models &     models;
+    std::deque<entry_t> queue;
+    uint64_t            next_req_id = 1;
+};
+
 // short loopback budget for the resumable stream router to child JSON calls (probe, lookup,
 // delete). distinct from params.timeout_read/write which only applies to the generation proxy
 static constexpr int STREAM_LOOKUP_TIMEOUT_MS = 250;
@@ -229,7 +379,8 @@ server_models::server_models(
             : ctx_preset(LLAMA_EXAMPLE_SERVER),
               base_params(params),
               base_env(get_environment()),
-              base_preset(ctx_preset.load_from_args(argc, argv)) {
+              base_preset(ctx_preset.load_from_args(argc, argv)),
+              sched(std::make_unique<lru_sched>(*this)) {
     // clean up base preset
     unset_reserved_args(base_preset, true);
     // set binary path
@@ -242,6 +393,8 @@ server_models::server_models(
     }
     load_models();
 }
+
+server_models::~server_models() = default;
 
 void server_models::add_model(server_model_meta && meta) {
     if (mapping.find(meta.name) != mapping.end()) {
@@ -713,24 +866,15 @@ void server_models::unload_lru() {
         return; // no limit
     }
     // remove one of the servers if we passed the models_max (least recently used - LRU)
-    std::string lru_model_name = "";
-    int64_t lru_last_used = ggml_time_ms();
-    size_t count_active = 0;
+    std::string lru_model_name;
     {
         std::unique_lock<std::mutex> lk(mutex);
-        for (const auto & m : mapping) {
-            if (m.second.meta.is_running()) {
-                count_active++;
-                // do not evict busy one
-                bool is_model_idle = m.second.req_count == 0 && m.second.meta.is_ready_or_sleep();
-                if (is_model_idle && m.second.meta.last_used < lru_last_used) {
-                    lru_model_name = m.first;
-                    lru_last_used = m.second.meta.last_used;
-                }
-            }
+        if (sched->has_capacity(lk)) {
+            return;
         }
+        lru_model_name = sched->pick_victim(lk, "");
     }
-    if (!lru_model_name.empty() && count_active >= (size_t)base_params.models_max) {
+    if (!lru_model_name.empty()) {
         SRV_INF("models_max limit reached, removing LRU name=%s\n", lru_model_name.c_str());
         unload(lru_model_name);
         // wait for unload to complete
@@ -741,7 +885,6 @@ void server_models::unload_lru() {
             });
         }
     }
-    // TODO @ngxson : if no idle model is found, queue the load request
 }
 
 void server_models::load(const std::string & name) {
@@ -1141,7 +1284,7 @@ void server_models::wait(std::unique_lock<std::mutex> & lk, const std::string & 
     });
 }
 
-bool server_models::ensure_model_ready(const std::string & name) {
+bool server_models::ensure_model_ready(const std::string & name, const std::function<bool()> & should_stop) {
     auto meta = get_meta(name);
     if (!meta.has_value()) {
         throw std::runtime_error("model name=" + name + " is not found");
@@ -1152,25 +1295,105 @@ bool server_models::ensure_model_ready(const std::string & name) {
     if (meta->status == SERVER_MODEL_STATUS_SLEEPING) {
         return false; // child is sleeping but still running; new request will wake it up
     }
-    if (meta->status == SERVER_MODEL_STATUS_UNLOADED) {
-        SRV_INF("model name=%s is not loaded, loading...\n", name.c_str());
-        load(name);
-    }
 
-    // wait for loading to complete
-    SRV_INF("waiting until model name=%s is fully loaded...\n", name.c_str());
-    wait(name, [&meta](const server_model_meta & new_meta) {
-        if (new_meta.status != SERVER_MODEL_STATUS_LOADING) {
-            meta = new_meta; // update meta for final check after wait
-            return true;
+    uint64_t req_id = 0;
+    std::string victim;
+    bool did_load = false;
+    {
+        std::unique_lock<std::mutex> lk(mutex);
+        auto it = mapping.find(name);
+        if (it != mapping.end() && it->second.meta.status == SERVER_MODEL_STATUS_UNLOADED) {
+            bool has_capacity = sched->has_capacity(lk);
+            if (has_capacity && sched->queue_empty(lk)) {
+                lk.unlock();
+                SRV_INF("model name=%s is not loaded, loading...\n", name.c_str());
+                load(name);
+                did_load = true;
+            } else {
+                // also queue when a slot looks free but others wait already, else they starve
+                req_id = sched->enqueue(lk, name);
+                if (!has_capacity) {
+                    // an idle model may sit here right now, do not wait for a request to end
+                    victim = sched->pick_victim(lk, name);
+                    if (!victim.empty()) {
+                        sched->mark_slot_pending(lk, req_id);
+                    }
+                }
+            }
         }
-        return false;
-    });
-
-    // check final status
-    if (!meta.has_value() || meta->is_failed()) {
-        throw std::runtime_error("model name=" + name + " failed to load");
     }
+    if (!victim.empty()) {
+        SRV_INF("evicting idle LRU name=%s to make room for name=%s\n", victim.c_str(), name.c_str());
+        unload(victim);
+    }
+
+    // while queued, this is also where the load happens: the head of the queue does it
+    SRV_INF("waiting until model name=%s is fully loaded...\n", name.c_str());
+    std::unique_lock<std::mutex> lk(mutex);
+    // req_id by reference: a lost race for a slot re-queues under a new id
+    auto erase_entry = [this, &req_id, &lk]() { sched->dequeue(lk, req_id); };
+
+    try {
+        bool saw_loading = false;
+        while (true) {
+            auto it = mapping.find(name);
+            if (it == mapping.end()) {
+                break; // removed by another code path, nothing to wait for
+            }
+            const server_model_status status = it->second.meta.status;
+
+            if (status == SERVER_MODEL_STATUS_LOADED || status == SERVER_MODEL_STATUS_SLEEPING) {
+                break;
+            }
+            if (status == SERVER_MODEL_STATUS_DOWNLOADING || status == SERVER_MODEL_STATUS_DOWNLOADED) {
+                break; // do not wait on a download child
+            }
+            if (status == SERVER_MODEL_STATUS_LOADING) {
+                saw_loading = true;
+            } else if (status == SERVER_MODEL_STATUS_UNLOADED) {
+                if (did_load || saw_loading) {
+                    // a spawn happened and the instance came back down
+                    if (it->second.meta.is_failed()) {
+                        throw std::runtime_error("model name=" + name + " failed to load");
+                    }
+                    break; // unloaded by another code path, caller reports "not running"
+                }
+                if (req_id == 0) {
+                    break; // not queued, and the load someone else started fell over
+                }
+            }
+
+            if (should_stop && should_stop()) {
+                // if a model was evicted for us, the free slot goes to the next waiter
+                throw std::runtime_error("request cancelled while waiting for model name=" + name);
+            }
+
+            // our turn: head of the queue, and a slot really did free up
+            if (status == SERVER_MODEL_STATUS_UNLOADED && sched->is_head(lk, req_id) && sched->has_capacity(lk)) {
+                erase_entry();
+                lk.unlock();
+                try {
+                    SRV_INF("slot available, loading queued model name=%s\n", name.c_str());
+                    load(name);
+                    did_load = true;
+                } catch (const std::exception & e) {
+                    // lost a race for the slot; get back in line and retry
+                    SRV_WRN("queued load of name=%s did not go through: %s\n", name.c_str(), e.what());
+                    lk.lock();
+                    req_id = sched->enqueue(lk, name, /* front */ true);
+                    continue;
+                }
+                lk.lock();
+                continue;
+            }
+
+            cv.wait_for(lk, std::chrono::milliseconds(500));
+        }
+    } catch (...) {
+        erase_entry();
+        throw;
+    }
+    erase_entry();
 
     return true;
 }
@@ -1213,10 +1436,17 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
             );
 
     proxy->cleanup = [this, name]() {
-        std::unique_lock<std::mutex> lk(mutex);
-        auto it = mapping.find(name);
-        if (it != mapping.end() && it->second.req_count > 0) {
-            it->second.req_count--;
+        bool went_idle = false;
+        {
+            std::unique_lock<std::mutex> lk(mutex);
+            auto it = mapping.find(name);
+            if (it != mapping.end() && it->second.req_count > 0) {
+                it->second.req_count--;
+                went_idle = it->second.req_count == 0;
+            }
+        }
+        if (went_idle) {
+            sched->on_model_idle(name);
         }
     };
 
@@ -1583,7 +1813,7 @@ void server_models_routes::init_routes() {
             return error_res;
         }
         if (autoload) {
-            models.ensure_model_ready(name);
+            models.ensure_model_ready(name, req.should_stop);
         }
         return models.proxy_request(req, method, name, false);
     };
@@ -1603,7 +1833,7 @@ void server_models_routes::init_routes() {
         // this request instead of leaving an orphan generation
         std::string conv_id = server_stream_conv_id_from_headers(req.headers);
         uint64_t ticket = models.conv_models.remember(conv_id, name);
-        bool waited = autoload && models.ensure_model_ready(name);
+        bool waited = autoload && models.ensure_model_ready(name, req.should_stop);
         if (ticket != 0 && !models.conv_models.alive(conv_id, ticket)) {
             SRV_INF("request for conv_id=%s cancelled while model name=%s was loading\n",
                     conv_id.c_str(), name.c_str());

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -424,6 +424,7 @@ server_models::server_models(
         LOG_WRN("using original argv[0] as fallback: %s\n", argv[0]);
     }
     load_models();
+    debug_fake_timing = !common_get_env("LLAMA_DEBUG_FAKE_TIMING").empty();
 }
 
 server_models::~server_models() = default;
@@ -924,6 +925,11 @@ void server_models::load(const std::string & name) {
 }
 
 void server_models::load(const std::string & name, const load_options & opts) {
+    if (debug_fake_timing) {
+        // do not hold the mutex here, other requests must keep making progress
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+    }
+
     if (!opts.custom_meta.has_value()) {
         if (!has_model(name)) {
             throw std::runtime_error("model name=" + name + " is not found");
@@ -1426,7 +1432,7 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
                 continue;
             }
 
-            cv.wait_for(lk, std::chrono::milliseconds(500));
+            cv.wait_for(lk, std::chrono::milliseconds(200));
         }
     } catch (...) {
         leave_queue();
@@ -1451,6 +1457,10 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
             mapping[name].meta.last_used = ggml_time_ms();
         }
         mapping[name].req_count++;
+    }
+    if (debug_fake_timing) {
+        // sleep after req_count++, so the model counts as busy while we wait here
+        std::this_thread::sleep_for(std::chrono::seconds(2));
     }
     SRV_INF("proxying request to model %s on port %d\n", name.c_str(), meta->port);
     std::string proxy_path = req.path;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -100,35 +100,30 @@ struct lru_sched {
         return victim;
     }
 
-    uint64_t enqueue(std::unique_lock<std::mutex> & lk, const std::string & model_id, bool front = false) {
+    // requests wanting the same model share one entry, so they all need only one slot
+    // and all get unblocked by the single load that entry performs
+    void join(std::unique_lock<std::mutex> & lk, const std::string & model_id) {
         check_lock(lk);
-        uint64_t req_id = next_req_id++;
-        if (front) {
-            queue.push_front({ req_id, model_id, false });
-        } else {
-            queue.push_back({ req_id, model_id, false });
-        }
-        SRV_INF("models_max reached, request for name=%s queued at position %zu\n",
-                model_id.c_str(), front ? (size_t) 1 : queue.size());
-        return req_id;
-    }
-
-    void dequeue(std::unique_lock<std::mutex> & lk, uint64_t req_id) {
-        check_lock(lk);
-        if (req_id == 0) {
+        if (entry_t * e = find(model_id)) {
+            e->n_waiters++;
+            SRV_INF("request for name=%s joined the queue, %d waiting\n", model_id.c_str(), e->n_waiters);
             return;
         }
+        queue.push_back({ model_id, 1, false, false });
+        SRV_INF("models_max reached, request for name=%s queued at position %zu\n",
+                model_id.c_str(), queue.size());
+    }
+
+    void leave(std::unique_lock<std::mutex> & lk, const std::string & model_id) {
+        check_lock(lk);
         for (auto it = queue.begin(); it != queue.end(); ++it) {
-            if (it->req_id == req_id) {
-                queue.erase(it);
+            if (it->model_id == model_id) {
+                if (--it->n_waiters <= 0) {
+                    queue.erase(it); // last one waiting for this model went away
+                }
                 return;
             }
         }
-    }
-
-    bool is_head(std::unique_lock<std::mutex> & lk, uint64_t req_id) {
-        check_lock(lk);
-        return req_id != 0 && !queue.empty() && queue.front().req_id == req_id;
     }
 
     bool queue_empty(std::unique_lock<std::mutex> & lk) {
@@ -136,14 +131,39 @@ struct lru_sched {
         return queue.empty();
     }
 
-    // a model is on its way out for this entry, so other requests do not also give up one
-    void mark_slot_pending(std::unique_lock<std::mutex> & lk, uint64_t req_id) {
+    // true if it is this model's turn to load, and nobody is loading it yet
+    bool try_claim(std::unique_lock<std::mutex> & lk, const std::string & model_id) {
         check_lock(lk);
-        for (auto & e : queue) {
-            if (e.req_id == req_id) {
-                e.slot_pending = true;
+        if (queue.empty() || queue.front().model_id != model_id || queue.front().loading) {
+            return false;
+        }
+        if (!has_capacity(lk)) {
+            return false;
+        }
+        queue.front().loading = true;
+        return true;
+    }
+
+    // ok means the model is up: drop the entry, the other waiters just watch its status now
+    void claim_done(std::unique_lock<std::mutex> & lk, const std::string & model_id, bool ok) {
+        check_lock(lk);
+        for (auto it = queue.begin(); it != queue.end(); ++it) {
+            if (it->model_id == model_id) {
+                if (ok) {
+                    queue.erase(it);
+                } else {
+                    it->loading = false;
+                }
                 return;
             }
+        }
+    }
+
+    // a model is on its way out for this entry, so other requests do not also give up one
+    void mark_slot_pending(std::unique_lock<std::mutex> & lk, const std::string & model_id) {
+        check_lock(lk);
+        if (entry_t * e = find(model_id)) {
+            e->slot_pending = true;
         }
     }
 
@@ -161,10 +181,10 @@ struct lru_sched {
             size_t promised     = 0;
             bool   has_unserved = false;
             for (const auto & e : queue) {
-                if (e.slot_pending) {
-                    promised++;
-                } else {
+                if (e.needs_slot()) {
                     has_unserved = true;
+                } else {
+                    promised++;
                 }
             }
             if (!has_unserved) {
@@ -196,10 +216,23 @@ struct lru_sched {
 
   private:
     struct entry_t {
-        uint64_t    req_id;
         std::string model_id;
-        bool        slot_pending; // a model is already being evicted for this entry
+        int  n_waiters;    // requests waiting for this model
+        bool slot_pending; // a model is already being evicted for this entry
+        bool loading;      // one of the waiters is doing the load right now
+
+        // a slot is already coming, or already taken by the load in flight
+        bool needs_slot() const { return !slot_pending && !loading; }
     };
+
+    entry_t * find(const std::string & model_id) {
+        for (auto & e : queue) {
+            if (e.model_id == model_id) {
+                return &e;
+            }
+        }
+        return nullptr;
+    }
 
     void check_lock(std::unique_lock<std::mutex> & lk) {
         GGML_ASSERT(lk.owns_lock() && lk.mutex() == &models.mutex);
@@ -215,9 +248,8 @@ struct lru_sched {
         return count;
     }
 
-    server_models &     models;
+    server_models & models;
     std::deque<entry_t> queue;
-    uint64_t            next_req_id = 1;
 };
 
 // short loopback budget for the resumable stream router to child JSON calls (probe, lookup,
@@ -1296,9 +1328,9 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
         return false; // child is sleeping but still running; new request will wake it up
     }
 
-    uint64_t req_id = 0;
-    std::string victim;
+    bool queued   = false;
     bool did_load = false;
+    std::string victim;
     {
         std::unique_lock<std::mutex> lk(mutex);
         auto it = mapping.find(name);
@@ -1311,12 +1343,13 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
                 did_load = true;
             } else {
                 // also queue when a slot looks free but others wait already, else they starve
-                req_id = sched->enqueue(lk, name);
+                sched->join(lk, name);
+                queued = true;
                 if (!has_capacity) {
                     // an idle model may sit here right now, do not wait for a request to end
                     victim = sched->pick_victim(lk, name);
                     if (!victim.empty()) {
-                        sched->mark_slot_pending(lk, req_id);
+                        sched->mark_slot_pending(lk, name);
                     }
                 }
             }
@@ -1330,8 +1363,12 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
     // while queued, this is also where the load happens: the head of the queue does it
     SRV_INF("waiting until model name=%s is fully loaded...\n", name.c_str());
     std::unique_lock<std::mutex> lk(mutex);
-    // req_id by reference: a lost race for a slot re-queues under a new id
-    auto erase_entry = [this, &req_id, &lk]() { sched->dequeue(lk, req_id); };
+    auto leave_queue = [this, &queued, &lk, &name]() {
+        if (queued) {
+            sched->leave(lk, name);
+            queued = false;
+        }
+    };
 
     try {
         bool saw_loading = false;
@@ -1358,7 +1395,7 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
                     }
                     break; // unloaded by another code path, caller reports "not running"
                 }
-                if (req_id == 0) {
+                if (!queued) {
                     break; // not queued, and the load someone else started fell over
                 }
             }
@@ -1368,32 +1405,34 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
                 throw std::runtime_error("request cancelled while waiting for model name=" + name);
             }
 
-            // our turn: head of the queue, and a slot really did free up
-            if (status == SERVER_MODEL_STATUS_UNLOADED && sched->is_head(lk, req_id) && sched->has_capacity(lk)) {
-                erase_entry();
+            // our turn: our model is at the head, and a slot really did free up
+            if (status == SERVER_MODEL_STATUS_UNLOADED && sched->try_claim(lk, name)) {
                 lk.unlock();
+                bool ok = true;
                 try {
                     SRV_INF("slot available, loading queued model name=%s\n", name.c_str());
                     load(name);
                     did_load = true;
                 } catch (const std::exception & e) {
-                    // lost a race for the slot; get back in line and retry
+                    // lost a race for the slot, stay in line and retry
                     SRV_WRN("queued load of name=%s did not go through: %s\n", name.c_str(), e.what());
-                    lk.lock();
-                    req_id = sched->enqueue(lk, name, /* front */ true);
-                    continue;
+                    ok = false;
                 }
                 lk.lock();
+                sched->claim_done(lk, name, ok);
+                if (ok) {
+                    queued = false; // entry is gone, the other waiters watch the status now
+                }
                 continue;
             }
 
             cv.wait_for(lk, std::chrono::milliseconds(500));
         }
     } catch (...) {
-        erase_entry();
+        leave_queue();
         throw;
     }
-    erase_entry();
+    leave_queue();
 
     return true;
 }

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -106,12 +106,12 @@ struct server_model_meta {
 };
 
 struct server_models_routes;
-struct server_subproc; // defined in server-models.cpp
-struct lru_sched;      // defined in server-models.cpp
+struct server_subproc;   // defined in server-models.cpp
+struct server_lru_sched; // defined in server-models.cpp
 
 struct server_models {
     friend struct server_models_routes;
-    friend struct lru_sched;
+    friend struct server_lru_sched;
 
 private:
     struct instance_t {
@@ -198,7 +198,7 @@ private:
     common_preset base_preset; // base preset from llama-server CLI args
 
     // queue of requests waiting for a models_max slot
-    std::unique_ptr<lru_sched> sched;
+    std::unique_ptr<server_lru_sched> sched;
 
     // if true, add some delay to simulate works (useful for testing)
     bool debug_fake_timing = false;

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -107,9 +107,11 @@ struct server_model_meta {
 
 struct server_models_routes;
 struct server_subproc; // defined in server-models.cpp
+struct lru_sched;      // defined in server-models.cpp
 
 struct server_models {
     friend struct server_models_routes;
+    friend struct lru_sched;
 
 private:
     struct instance_t {
@@ -195,6 +197,9 @@ private:
     std::vector<std::string> base_env;
     common_preset base_preset; // base preset from llama-server CLI args
 
+    // queue of requests waiting for a models_max slot
+    std::unique_ptr<lru_sched> sched;
+
     void update_meta(const std::string & name, const server_model_meta & meta);
 
     // unload least recently used models if the limit is reached
@@ -211,6 +216,7 @@ public:
     conv_model_tracker conv_models;
 
     server_models(const common_params & params, int argc, char ** argv);
+    ~server_models();
 
     server_response sse; // for real-time updates via SSE endpoint
 
@@ -267,7 +273,9 @@ public:
     // ensure the model is in ready state (thread-safe)
     // return false if model is ready
     // otherwise, load the model and blocking wait until it's ready, then return true (meta may need to be refreshed)
-    bool ensure_model_ready(const std::string & name);
+    // if models_max is reached, the request waits in a queue until a slot frees up
+    // throws if the load fails, or if should_stop fires while waiting
+    bool ensure_model_ready(const std::string & name, const std::function<bool()> & should_stop = nullptr);
 
     // proxy an HTTP request to the model instance
     server_http_res_ptr proxy_request(const server_http_req & req, const std::string & method, const std::string & name, bool update_last_used, bool detached = false);

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -200,6 +200,9 @@ private:
     // queue of requests waiting for a models_max slot
     std::unique_ptr<lru_sched> sched;
 
+    // if true, add some delay to simulate works (useful for testing)
+    bool debug_fake_timing = false;
+
     void update_meta(const std::string & name, const server_model_meta & meta);
 
     // unload least recently used models if the limit is reached

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -145,6 +145,156 @@ def test_router_models_max_evicts_lru():
     assert _get_model_status(first) == "unloaded"
 
 
+# lru_sched tests (relying on LLAMA_DEBUG_FAKE_TIMING)
+
+MODEL_A = "ggml-org/tinygemma3-GGUF:Q8_0"
+MODEL_B = "ggml-org/test-model-stories260K:F32"
+MODEL_C = "ggml-org/test-model-stories260K-infill:F32"
+
+
+def _tokenize(model_id: str, timeout: float | None = DEFAULT_REQUEST_TIMEOUT) -> ServerResponse:
+    return server.make_request(
+        "POST", "/tokenize", data={"model": model_id, "content": "hello world"}, timeout=timeout
+    )
+
+
+class _Bg:
+    """runs one request in a thread, keeps its result, error and finish time"""
+
+    def __init__(self, fn):
+        self.result = None
+        self.error: Exception | None = None
+        self.done_at: float = 0.0
+        self._thread = threading.Thread(target=self._run, args=(fn,), daemon=True)
+
+    def _run(self, fn):
+        try:
+            self.result = fn()
+        except Exception as e:
+            self.error = e
+        self.done_at = time.time()
+
+    def start(self):
+        self._thread.start()
+        return self
+
+    def join(self, timeout: int = 180):
+        self._thread.join(timeout)
+        assert not self._thread.is_alive(), "background request did not finish in time"
+        return self
+
+    def assert_ok(self, what: str):
+        assert self.error is None, f"{what} raised {self.error!r}"
+        assert self.result is not None and self.result.status_code == 200, \
+            f"{what} failed: {self.result.status_code if self.result else None} {self.result.body if self.result else None}"
+
+
+def test_router_queue_does_not_evict_busy_model():
+    """a request that finds no free slot waits, and the model serving a request survives it"""
+    global server
+    server.models_max = 1
+    server.start()
+
+    _load_model_and_wait(MODEL_A, timeout=120)
+
+    busy = _Bg(lambda: _tokenize(MODEL_A)).start()
+    time.sleep(0.5)  # let the request reach the child and take the only slot
+
+    # no slot free and MODEL_A is busy, so this queues instead of evicting mid-request
+    queued = _Bg(lambda: _tokenize(MODEL_B)).start()
+
+    busy.join()
+    queued.join()
+
+    # had MODEL_A been evicted while serving, its own request would have died
+    busy.assert_ok("request against the busy model")
+    queued.assert_ok("queued request")
+
+    _wait_for_model_status(MODEL_B, {"loaded"}, timeout=120)
+    assert _get_model_status(MODEL_A) == "unloaded"
+
+
+def test_router_queue_coalesces_requests_for_same_model():
+    """many requests for one missing model share a slot, so only one model is given up"""
+    global server
+    server.models_max = 2
+    server.start()
+
+    _load_model_and_wait(MODEL_A, timeout=120)
+    _load_model_and_wait(MODEL_B, timeout=120)
+
+    # keep MODEL_A busy so MODEL_B is the only model that can be given up
+    busy = _Bg(lambda: _tokenize(MODEL_A)).start()
+    time.sleep(0.5)
+
+    waiters = [_Bg(lambda: _tokenize(MODEL_C)).start() for _ in range(3)]
+
+    busy.join()
+    for w in waiters:
+        w.join()
+
+    busy.assert_ok("request against the busy model")
+    for i, w in enumerate(waiters):
+        w.assert_ok(f"queued request {i}")
+
+    _wait_for_model_status(MODEL_C, {"loaded"}, timeout=120)
+    # one entry for 3 requests means one eviction: MODEL_B goes, MODEL_A is left alone.
+    # without coalescing the leftover entries still ask for a slot,
+    # and MODEL_A is taken too as soon as it goes idle
+    assert _get_model_status(MODEL_A) == "loaded"
+    assert _get_model_status(MODEL_B) == "unloaded"
+
+
+def test_router_queue_client_disconnect_keeps_model():
+    """a client that leaves while queued must not cost a running model its slot"""
+    global server
+    server.models_max = 1
+    server.start()
+
+    _load_model_and_wait(MODEL_A, timeout=120)
+
+    busy = _Bg(lambda: _tokenize(MODEL_A)).start()
+    time.sleep(0.5)
+
+    # queues behind MODEL_A, then gives up long before MODEL_A goes idle
+    with pytest.raises(requests.exceptions.RequestException):
+        _tokenize(MODEL_B, timeout=1)
+
+    busy.join()
+    busy.assert_ok("request against the busy model")
+
+    # nobody is waiting anymore, so MODEL_A keeps its slot
+    time.sleep(3)
+    assert _get_model_status(MODEL_A) == "loaded"
+    assert _get_model_status(MODEL_B) == "unloaded"
+
+
+def test_router_queue_is_fifo():
+    """the queue is served in arrival order"""
+    global server
+    server.models_max = 1
+    server.start()
+
+    _load_model_and_wait(MODEL_A, timeout=120)
+
+    busy = _Bg(lambda: _tokenize(MODEL_A)).start()
+    time.sleep(0.5)
+
+    first = _Bg(lambda: _tokenize(MODEL_B)).start()
+    time.sleep(1)  # keep the arrival order unambiguous
+    second = _Bg(lambda: _tokenize(MODEL_C)).start()
+
+    busy.join()
+    first.join()
+    second.join()
+
+    busy.assert_ok("request against the busy model")
+    first.assert_ok("first queued request")
+    second.assert_ok("second queued request")
+
+    assert first.done_at < second.done_at, "queue was not served in arrival order"
+
+
 def test_router_no_models_autoload():
     global server
     server.no_models_autoload = True

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -145,7 +145,7 @@ def test_router_models_max_evicts_lru():
     assert _get_model_status(first) == "unloaded"
 
 
-# lru_sched tests (relying on LLAMA_DEBUG_FAKE_TIMING)
+# server_lru_sched tests (relying on LLAMA_SERVER_DEBUG_FAKE_TIMING)
 
 MODEL_A = "ggml-org/tinygemma3-GGUF:Q8_0"
 MODEL_B = "ggml-org/test-model-stories260K:F32"

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -134,7 +134,7 @@ class ServerProcess:
     def start(self, timeout_seconds: int = DEFAULT_HTTP_TIMEOUT) -> None:
         env = {
             **os.environ,
-            "LLAMA_DEBUG_FAKE_TIMING": "1",
+            "LLAMA_SERVER_DEBUG_FAKE_TIMING": "1",
         }
         if "LLAMA_CACHE" not in os.environ:
             env["LLAMA_CACHE"] = "tmp"

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -132,7 +132,10 @@ class ServerProcess:
         self.external_server = "DEBUG_EXTERNAL" in os.environ
 
     def start(self, timeout_seconds: int = DEFAULT_HTTP_TIMEOUT) -> None:
-        env = {**os.environ}
+        env = {
+            **os.environ,
+            "LLAMA_DEBUG_FAKE_TIMING": "1",
+        }
         if "LLAMA_CACHE" not in os.environ:
             env["LLAMA_CACHE"] = "tmp"
         if self.external_server:


### PR DESCRIPTION
## Overview

Add LRU scheduler that queue the eviction requests

If server capacity runs out, `ensure_model_ready()` spawn a wait loop until the requested model is loaded. All queued requests waiting for same model will be unblocked at the same time.

If waiting req suddenly disconnects, it will clear itself from LRU queue

Fix https://github.com/ggml-org/llama.cpp/issues/21678

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: initial idea was made by me, AI used for iterating from that <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
