### PR TITLE
spec: respect safe draft caps before block decode

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1134,6 +1134,33 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         std::vector<int32_t> i_block_beg(n_seq, -1);
         std::vector<int32_t> n_block    (n_seq,  0);
 
+        int32_t dspark_n_draft_uniform = params.n_max;
+        bool dspark_n_draft_same = true;
+        bool dspark_n_draft_seen = false;
+
+        if (is_dspark) {
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                auto & dp = dparams[seq_id];
+                if (!dp.drafting) {
+                    continue;
+                }
+
+                if (dp.n_max <= 0) {
+                    dspark_n_draft_same = false;
+                    continue;
+                }
+
+                const int32_t n_draft_eff = std::min(params.n_max, dp.n_max);
+
+                if (!dspark_n_draft_seen) {
+                    dspark_n_draft_uniform = n_draft_eff;
+                    dspark_n_draft_seen = true;
+                } else if (dspark_n_draft_uniform != n_draft_eff) {
+                    dspark_n_draft_same = false;
+                }
+            }
+        }
+
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
             if (!dp.drafting) {
@@ -1144,7 +1171,16 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
             const int32_t n = (int32_t) dp.n_past;
 
-            const int32_t n_draft = params.n_max;
+            // Respect the caller's remaining-context clamp before decoding whenever it is
+            // layout-safe to do so. For DSpark we must keep every active block the same
+            // size; if the active sequences disagree, fall back to the full block and let
+            // central truncation trim the sampled result afterwards.
+            const int32_t n_draft =
+                is_dspark
+                    ? (dspark_n_draft_seen && dspark_n_draft_same
+                        ? dspark_n_draft_uniform
+                        : params.n_max)
+                    : (dp.n_max > 0 ? std::min(params.n_max, dp.n_max) : params.n_max);
 
             const int32_t n_block_tokens = n_draft + (is_dspark ? 0 : 1);
             i_block_beg[seq_id] = batch.n_tokens;


### PR DESCRIPTION
## Overview

This PR updates the `draft-dflash` / `draft-dspark` batching path to respect the effective per-sequence draft cap before constructing the draft decode block, where doing so is layout-safe.

For non-DSpark drafts, the decoded draft length is now capped with `min(params.n_max, dp.n_max)` instead of always decoding the full shared `params.n_max`.

For DSpark, the existing uniform-block requirement is preserved. If all actively drafting sequences share the same effective cap, we decode that smaller uniform block. Otherwise, the previous behavior is retained and the existing truncation in `common_speculative_draft()` handles the result.

This addresses the behavior discussed in #26478, where the draft decode path could advance speculative state beyond a sequence's effective draft budget before truncation, which appears related to the reported gap in KV positions near the 16k context boundary.

## Additional information

This is intentionally a narrow change.

* Only the shared DFlash/DSpark draft batching path is modified.
* Verification, acceptance, rollback, and server-side prompt bookkeeping are unchanged.
* The existing DSpark fallback for mixed per-sequence draft limits is preserved.
* **Note on testing:** Since `speculative.n_max` is currently disabled in the server schema (`tools/server/server-schema.cpp`), testing the cap via the request field will not work. Please test using the server startup parameter instead (e.g., `--spec-draft-n-max 5`).

I inspected the affected code path and verified the logic locally. I wasn't able to run a full build because `cmake` was unavailable in my environment, so this change should still receive the usual CI and maintainer validation.

## Requirements

* [x] I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* [x] AI usage disclosure: **YES** — AI was used to help analyze the existing implementation, discuss possible approaches, and improve the wording of this PR description. I manually inspected the code, implemented the change, reviewed the diff, and take responsibility for the submitted code.