### PR TITLE
vulkan: tiled transpose for 0<->2 permuted CONT

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -962,6 +962,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_cpy_f32_quant[GGML_TYPE_COUNT];
     vk_pipeline pipeline_cpy_quant_f32[GGML_TYPE_COUNT];
     vk_pipeline pipeline_cpy_transpose_16, pipeline_cpy_transpose_32;
+    vk_pipeline pipeline_cpy_transpose_02_16, pipeline_cpy_transpose_02_32;
     // [src0 0=fp32,1=fp16][dst]
     vk_pipeline pipeline_set_rows_i32[2][GGML_TYPE_COUNT];
     vk_pipeline pipeline_set_rows_i64[2][GGML_TYPE_COUNT];
@@ -5500,6 +5501,8 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
 
     ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_32, "cpy_transpose_32", cpy_transpose_32_len, cpy_transpose_32_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_16, "cpy_transpose_16", cpy_transpose_16_len, cpy_transpose_16_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_02_32, "cpy_transpose_02_32", cpy_transpose_02_32_len, cpy_transpose_02_32_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_02_16, "cpy_transpose_02_16", cpy_transpose_02_16_len, cpy_transpose_02_16_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q1_0], "cpy_f32_q1_0", cpy_f32_q1_0_len, cpy_f32_q1_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q2_0], "cpy_f32_q2_0", cpy_f32_q2_0_len, cpy_f32_q2_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
@@ -8902,6 +8905,20 @@ static vk_pipeline ggml_vk_get_cpy_pipeline(ggml_backend_vk_context * ctx, const
         }
     }
 
+    // Same idea for a 0<->2 swap (ggml_cont(ggml_permute(x, 2, 1, 0, 3))): src
+    // dim2 is innermost. Without this it falls to the generic strided copy,
+    // whose reads stride by ne0*ne1 -- one cache line per lane.
+    bool transpose02 = dst && !contig && src->nb[2] == ggml_type_size(to) &&
+                       ggml_is_contiguous(dst) && ggml_are_same_shape(dst, src);
+
+    if (transpose02 && src->type == to) {
+        if (ggml_type_size(to) == 4) {
+            return ctx->device->pipeline_cpy_transpose_02_32;
+        } else if (ggml_type_size(to) == 2) {
+            return ctx->device->pipeline_cpy_transpose_02_16;
+        }
+    }
+
     if (src->type == GGML_TYPE_F32 && to == GGML_TYPE_F32) {
         if (contig) {
             return ctx->device->pipeline_contig_cpy_f32_f32;
@@ -12163,7 +12180,16 @@ static void ggml_vk_op_f32(ggml_backend_vk_context * ctx, vk_context& subctx, co
                 elements = { ne, 1, 1 };
             }
 
-            if (pipeline == ctx->device->pipeline_cpy_transpose_32 ||
+            if (pipeline == ctx->device->pipeline_cpy_transpose_02_32 ||
+                pipeline == ctx->device->pipeline_cpy_transpose_02_16) {
+                // 32x32 tiles over dims 0 and 2; dim1 and dim3 are the batch
+                elements[0] = (uint32_t)CEIL_DIV(dst->ne[0], 32);
+                elements[1] = (uint32_t)CEIL_DIV(dst->ne[2], 32);
+                elements[2] = (uint32_t)(dst->ne[1]*dst->ne[3]);
+                elements[0] = std::min(elements[0], ctx->device->properties.limits.maxComputeWorkGroupCount[0]);
+                elements[1] = std::min(elements[1], ctx->device->properties.limits.maxComputeWorkGroupCount[1]);
+                elements[2] = std::min(elements[2], ctx->device->properties.limits.maxComputeWorkGroupCount[2]);
+            } else if (pipeline == ctx->device->pipeline_cpy_transpose_32 ||
                 pipeline == ctx->device->pipeline_cpy_transpose_16) {
                 // 32x32 tiles
                 elements[0] = (uint32_t)CEIL_DIV(dst->ne[0], 32);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -926,6 +926,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_cpy_f32_quant[GGML_TYPE_COUNT];
     vk_pipeline pipeline_cpy_quant_f32[GGML_TYPE_COUNT];
     vk_pipeline pipeline_cpy_transpose_16, pipeline_cpy_transpose_32;
+    vk_pipeline pipeline_cpy_transpose_02_16, pipeline_cpy_transpose_02_32;
     // [src0 0=fp32,1=fp16][dst]
     vk_pipeline pipeline_set_rows_i32[2][GGML_TYPE_COUNT];
     vk_pipeline pipeline_set_rows_i64[2][GGML_TYPE_COUNT];
@@ -5364,6 +5365,8 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
 
     ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_32, "cpy_transpose_32", cpy_transpose_32_len, cpy_transpose_32_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_16, "cpy_transpose_16", cpy_transpose_16_len, cpy_transpose_16_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_02_32, "cpy_transpose_02_32", cpy_transpose_02_32_len, cpy_transpose_02_32_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_cpy_transpose_02_16, "cpy_transpose_02_16", cpy_transpose_02_16_len, cpy_transpose_02_16_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
 
     ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q1_0], "cpy_f32_q1_0", cpy_f32_q1_0_len, cpy_f32_q1_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q2_0], "cpy_f32_q2_0", cpy_f32_q2_0_len, cpy_f32_q2_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
@@ -8745,6 +8748,20 @@ static vk_pipeline ggml_vk_get_cpy_pipeline(ggml_backend_vk_context * ctx, const
         }
     }
 
+    // Same idea for a 0<->2 swap (ggml_cont(ggml_permute(x, 2, 1, 0, 3))): src
+    // dim2 is innermost. Without this it falls to the generic strided copy,
+    // whose reads stride by ne0*ne1 -- one cache line per lane.
+    bool transpose02 = dst && !contig && src->nb[2] == ggml_type_size(to) &&
+                       ggml_is_contiguous(dst) && ggml_are_same_shape(dst, src);
+
+    if (transpose02 && src->type == to) {
+        if (ggml_type_size(to) == 4) {
+            return ctx->device->pipeline_cpy_transpose_02_32;
+        } else if (ggml_type_size(to) == 2) {
+            return ctx->device->pipeline_cpy_transpose_02_16;
+        }
+    }
+
     if (src->type == GGML_TYPE_F32 && to == GGML_TYPE_F32) {
         if (contig) {
             return ctx->device->pipeline_contig_cpy_f32_f32;
@@ -12001,7 +12018,16 @@ static void ggml_vk_op_f32(ggml_backend_vk_context * ctx, vk_context& subctx, co
                 elements = { ne, 1, 1 };
             }
 
-            if (pipeline == ctx->device->pipeline_cpy_transpose_32 ||
+            if (pipeline == ctx->device->pipeline_cpy_transpose_02_32 ||
+                pipeline == ctx->device->pipeline_cpy_transpose_02_16) {
+                // 32x32 tiles over dims 0 and 2; dim1 and dim3 are the batch
+                elements[0] = (uint32_t)CEIL_DIV(dst->ne[0], 32);
+                elements[1] = (uint32_t)CEIL_DIV(dst->ne[2], 32);
+                elements[2] = (uint32_t)(dst->ne[1]*dst->ne[3]);
+                elements[0] = std::min(elements[0], ctx->device->properties.limits.maxComputeWorkGroupCount[0]);
+                elements[1] = std::min(elements[1], ctx->device->properties.limits.maxComputeWorkGroupCount[1]);
+                elements[2] = std::min(elements[2], ctx->device->properties.limits.maxComputeWorkGroupCount[2]);
+            } else if (pipeline == ctx->device->pipeline_cpy_transpose_32 ||
                 pipeline == ctx->device->pipeline_cpy_transpose_16) {
                 // 32x32 tiles
                 elements[0] = (uint32_t)CEIL_DIV(dst->ne[0], 32);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8905,9 +8905,7 @@ static vk_pipeline ggml_vk_get_cpy_pipeline(ggml_backend_vk_context * ctx, const
         }
     }
 
-    // Same idea for a 0<->2 swap (ggml_cont(ggml_permute(x, 2, 1, 0, 3))): src
-    // dim2 is innermost. Without this it falls to the generic strided copy,
-    // whose reads stride by ne0*ne1 -- one cache line per lane.
+    // Same, for a 0<->2 swap: src dim2 is the innermost dimension.
     bool transpose02 = dst && !contig && src->nb[2] == ggml_type_size(to) &&
                        ggml_is_contiguous(dst) && ggml_are_same_shape(dst, src);
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/copy_transpose_02.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/copy_transpose_02.comp
@@ -1,0 +1,74 @@
+#version 450
+
+#include "types.glsl"
+#include "generic_unary_head.glsl"
+
+// Tiled transpose for a 0<->2 axis swap, i.e. ggml_cont(ggml_permute(x, 2, 1, 0, 3)).
+// copy_transpose.comp handles the 0<->1 case (src dim1 innermost); here src dim2
+// is the innermost (stride-1) dimension and dst dim0 is, with dim1 acting as a
+// batch dimension that both sides index with their own strides.
+//
+// Without this the op falls back to the generic per-element strided copy, whose
+// source reads are strided by ne0*ne1 elements -- one cache line per lane.
+// Measured on DeepSeek-V4 indexer shapes that ran at ~1-9 GB/s on a ~200 GB/s part.
+
+// workgroup does 32x32 tile, but uses 32x8 threads
+#define TILE_DIM 32
+layout(local_size_x = 32, local_size_y = 8, local_size_z = 1) in;
+
+// +1 padding avoids shared-memory bank conflicts on the transposed read
+shared uint sh[TILE_DIM][TILE_DIM + 1];
+
+void iter(uvec3 wg_id) {
+    const uint tile_i0 = wg_id.x;   // tiles dst ne10 (== src ne00)
+    const uint tile_i2 = wg_id.y;   // tiles dst ne12 (== src ne02)
+
+    const uint tid_col = gl_LocalInvocationID.x;
+    const uint tid_row = gl_LocalInvocationID.y;
+
+    const uint i1 = wg_id.z % p.ne11;
+    const uint i3 = wg_id.z / p.ne11;
+    const uint i01 = i1;
+    const uint i03 = i3;
+
+    // Read: tid_col walks src dim2, which is contiguous, so lanes within a
+    // subgroup read adjacent addresses.
+    [[unroll]] for (uint y = 0; y < 4; ++y) {
+        const uint i00 = tile_i0 * TILE_DIM + tid_row + 8 * y;
+        const uint i02 = tile_i2 * TILE_DIM + tid_col;
+        if (i00 < p.ne00 && i01 < p.ne01 && i02 < p.ne02 && i03 < p.ne03) {
+            const uint src_idx = i00 * p.nb00 + i01 * p.nb01 + i02 * p.nb02 + i03 * p.nb03;
+            sh[tid_row + 8 * y][tid_col] = uint(data_a[get_aoffset() + src_idx]);
+        }
+    }
+
+    barrier();
+
+    // Write: tid_col walks dst dim0, which is contiguous, so the stores coalesce
+    // too. The transpose happens in shared memory, not in global addressing.
+    [[unroll]] for (uint y = 0; y < 4; ++y) {
+        const uint i0 = tile_i0 * TILE_DIM + tid_col;
+        const uint i2 = tile_i2 * TILE_DIM + tid_row + 8 * y;
+        if (i0 < p.ne10 && i1 < p.ne11 && i2 < p.ne12 && i3 < p.ne13) {
+            const uint dst_idx = i0 * p.nb10 + i1 * p.nb11 + i2 * p.nb12 + i3 * p.nb13;
+            data_d[get_doffset() + dst_idx] = D_TYPE(sh[tid_col][tid_row + 8 * y]);
+        }
+    }
+}
+
+#define CEIL_DIV(a, b) (((a) + (b) - 1) / (b))
+
+void main() {
+    bool need_barrier = false;
+    for (uint z = gl_WorkGroupID.z; z < p.ne11 * p.ne13; z += gl_NumWorkGroups.z) {
+        for (uint y = gl_WorkGroupID.y; y < CEIL_DIV(p.ne12, TILE_DIM); y += gl_NumWorkGroups.y) {
+            for (uint x = gl_WorkGroupID.x; x < CEIL_DIV(p.ne10, TILE_DIM); x += gl_NumWorkGroups.x) {
+                if (need_barrier) {
+                    barrier();
+                }
+                need_barrier = true;
+                iter(uvec3(x, y, z));
+            }
+        }
+    }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/copy_transpose_02.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/copy_transpose_02.comp
@@ -3,15 +3,6 @@
 #include "types.glsl"
 #include "generic_unary_head.glsl"
 
-// Tiled transpose for a 0<->2 axis swap, i.e. ggml_cont(ggml_permute(x, 2, 1, 0, 3)).
-// copy_transpose.comp handles the 0<->1 case (src dim1 innermost); here src dim2
-// is the innermost (stride-1) dimension and dst dim0 is, with dim1 acting as a
-// batch dimension that both sides index with their own strides.
-//
-// Without this the op falls back to the generic per-element strided copy, whose
-// source reads are strided by ne0*ne1 elements -- one cache line per lane.
-// Measured on DeepSeek-V4 indexer shapes that ran at ~1-9 GB/s on a ~200 GB/s part.
-
 // workgroup does 32x32 tile, but uses 32x8 threads
 #define TILE_DIM 32
 layout(local_size_x = 32, local_size_y = 8, local_size_z = 1) in;
@@ -31,8 +22,6 @@ void iter(uvec3 wg_id) {
     const uint i01 = i1;
     const uint i03 = i3;
 
-    // Read: tid_col walks src dim2, which is contiguous, so lanes within a
-    // subgroup read adjacent addresses.
     [[unroll]] for (uint y = 0; y < 4; ++y) {
         const uint i00 = tile_i0 * TILE_DIM + tid_row + 8 * y;
         const uint i02 = tile_i2 * TILE_DIM + tid_col;
@@ -44,8 +33,6 @@ void iter(uvec3 wg_id) {
 
     barrier();
 
-    // Write: tid_col walks dst dim0, which is contiguous, so the stores coalesce
-    // too. The transpose happens in shared memory, not in global addressing.
     [[unroll]] for (uint y = 0; y < 4; ++y) {
         const uint i0 = tile_i0 * TILE_DIM + tid_col;
         const uint i2 = tile_i2 * TILE_DIM + tid_row + 8 * y;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -825,6 +825,8 @@ void process_shaders() {
 
     string_to_spv("cpy_transpose_16", "copy_transpose.comp", {{"A_TYPE", "uint16_t"}, {"D_TYPE", "uint16_t"}});
     string_to_spv("cpy_transpose_32", "copy_transpose.comp", {{"A_TYPE", "uint"}, {"D_TYPE", "uint"}});
+    string_to_spv("cpy_transpose_02_16", "copy_transpose_02.comp", {{"A_TYPE", "uint16_t"}, {"D_TYPE", "uint16_t"}});
+    string_to_spv("cpy_transpose_02_32", "copy_transpose_02.comp", {{"A_TYPE", "uint"}, {"D_TYPE", "uint"}});
 
     for (std::string t : {"q1_0", "q2_0", "q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "iq4_nl"}) {
         string_to_spv("cpy_f32_" + t, "copy_to_quant.comp", {{"DATA_A_" + to_uppercase(t), "1"}, {"S_TYPE", "float"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3095,6 +3095,41 @@ struct test_cont : public test_case {
     }
 };
 
+// GGML_OP_CONT of an arbitrary permutation.
+// test_cont above only exercises ggml_transpose (a 0<->1 swap), which the Vulkan
+// backend routes to its tiled shared-memory transpose shader. A 0<->2 swap --
+// e.g. ggml_cont(ggml_permute(x, 2, 1, 0, 3)), which DeepSeek-V4's lightning
+// indexer performs on a [n_kv, n_tokens, n_head] tensor -- takes a different
+// path entirely and was previously uncovered.
+struct test_cont_permute : public test_case {
+    const ggml_type type;
+    const std::array<int64_t, 4> ne;
+    const std::array<int, 4> perm;
+
+    std::string vars() override {
+        return VARS_TO_STR3(type, ne, perm);
+    }
+
+    test_cont_permute(ggml_type type = GGML_TYPE_F32,
+            std::array<int64_t, 4> ne = {10, 10, 10, 1},
+            std::array<int, 4> perm = {2, 1, 0, 3})
+        : type(type), ne(ne), perm(perm) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne.data());
+        ggml_set_param(src);
+        ggml_set_name(src, "src");
+
+        ggml_tensor * permuted = ggml_permute(ctx, src, perm[0], perm[1], perm[2], perm[3]);
+        ggml_set_name(permuted, "src_permuted");
+
+        ggml_tensor * out = ggml_cont(ctx, permuted);
+        ggml_set_name(out, "out");
+
+        return out;
+    }
+};
+
 // GGML_OP_ADD
 // GGML_OP_SUB
 // GGML_OP_MUL
@@ -8637,6 +8672,22 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    for (ggml_type type_dst : { GGML_TYPE_F32, GGML_TYPE_F16 }) {
+        for (std::array<int64_t, 4> ne : std::initializer_list<std::array<int64_t, 4>>{
+                {10, 10, 10, 1}, {33, 5, 7, 1}, {64, 3, 65, 1}, {2, 3, 5, 7},
+                // Large, tile-aligned and tile-unaligned, matching the shapes the
+                // perf cases use. Perf mode does NOT verify results, so without
+                // these the fast path would only ever be checked on tiny tensors.
+                {1024, 64, 64, 1}, {2304, 64, 64, 1}, {1000, 33, 65, 1} }) {
+            for (std::array<int, 4> perm : std::initializer_list<std::array<int, 4>>{
+                    {2, 1, 0, 3},   // 0<->2 swap (the DeepSeek-V4 indexer pattern)
+                    {1, 2, 0, 3},   // 3-cycle
+                    {0, 2, 1, 3} }) {
+                test_cases.emplace_back(new test_cont_permute(type_dst, ne, perm));
+            }
+        }
+    }
+
     auto add_test_bin_bcast = [&](ggml_type type, std::array<int64_t, 4> ne, std::array<int, 4> nr, bool perm1 = false, bool src_overlap = false) {
         for (auto op : {ggml_add, ggml_sub, ggml_mul, ggml_div}) {
             test_cases.emplace_back(new test_bin_bcast(op, type, ne, nr, 1, perm1, src_overlap));
@@ -9746,6 +9797,21 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 // Test cases for performance evaluation: should be representative of real-world use cases
 static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     std::vector<std::unique_ptr<test_case>> test_cases;
+
+    // CONT of a 0<->2 permute at DeepSeek-V4 lightning-indexer shapes:
+    // indexer_kq is [n_kv, n_tokens, n_head=64] and gets ggml_cont(ggml_permute(.., 2,1,0,3)).
+    // Measured on Vulkan/gfx1151 this ran at ~1 GB/s of a ~200 GB/s box and was
+    // 43% of DeepSeek-V4 prefill. n_kv values include power-of-two and
+    // non-power-of-two neighbours because the two differed by ~2.4x.
+    // NOTE: n_tokens is 64 here, not the production 512. At 512 a single
+    // dispatch takes ~273 ms on the slow path, and perf mode loops it -- which
+    // trips the amdgpu watchdog and forces a GPU hard recovery (observed
+    // 2026-08-02; it can take other contexts on the box down with it). 64 keeps
+    // one dispatch in the tens of ms while preserving the access pattern.
+    for (int64_t n_kv : { 1024, 1280, 2048, 2304 }) {
+        test_cases.emplace_back(new test_cont_permute(
+            GGML_TYPE_F32, {n_kv, 64, 64, 1}, {2, 1, 0, 3}));
+    }
 
     // Conv2d: K=CRS=NPQ=4096 matmul performance
     uint32_t                        iwh_idx  = 0;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9776,15 +9776,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
 
     // CONT of a 0<->2 permute at DeepSeek-V4 lightning-indexer shapes:
     // indexer_kq is [n_kv, n_tokens, n_head=64] and gets ggml_cont(ggml_permute(.., 2,1,0,3)).
-    // Measured on Vulkan/gfx1151 this ran at ~1 GB/s of a ~200 GB/s box and was
-    // 43% of DeepSeek-V4 prefill. n_kv values include power-of-two and
-    // non-power-of-two neighbours because the two differed by ~2.4x.
-    // NOTE: the n_tokens=64 shapes keep a single slow-path dispatch in the
-    // tens of ms; at 512 the OLD path took ~273 ms per dispatch and perf
-    // mode's looping tripped the amdgpu watchdog (observed 2026-08-02).
-    // The n_tokens=512 shapes are ~270-300 MB so they exceed GPU L2 on
-    // large parts, where the 64-token shapes fit in cache and read above
-    // memory bandwidth.
     for (int64_t n_kv : { 1024, 1280, 2048, 2304 }) {
         test_cases.emplace_back(new test_cont(
             GGML_TYPE_F32, {n_kv, 64, 64, 1}, false, {2, 1, 0, 3}));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3058,28 +3058,39 @@ struct test_cpy : public test_case {
 };
 
 // GGML_OP_CONT
+// permute = {0, 0, 0, 0} means no permutation: the source is transposed (or
+// view-sliced). A non-identity permute exercises ggml_cont of an arbitrary
+// ggml_permute -- e.g. the 0<->2 swap DeepSeek-V4's lightning indexer performs
+// on a [n_kv, n_tokens, n_head] tensor -- which takes a different backend path
+// than the 0<->1 transpose and was previously uncovered.
 struct test_cont : public test_case {
     const ggml_type type;
     const std::array<int64_t, 4> ne;
     bool use_view_slice;
+    const std::array<int64_t, 4> permute;
 
     std::string vars() override {
-        return VARS_TO_STR3(type, ne, use_view_slice);
+        return VARS_TO_STR4(type, ne, use_view_slice, permute);
     }
 
     test_cont(ggml_type type = GGML_TYPE_F32,
             std::array<int64_t, 4> ne = {10, 10, 10, 1},
-            bool use_view_slice = false)
-        : type(type), ne(ne), use_view_slice(use_view_slice) {}
+            bool use_view_slice = false,
+            std::array<int64_t, 4> permute = {0, 0, 0, 0})
+        : type(type), ne(ne), use_view_slice(use_view_slice), permute(permute) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne.data());
         ggml_set_param(src);
         ggml_set_name(src, "src");
 
+        const bool permuted = permute[0] != 0 || permute[1] != 0 || permute[2] != 0 || permute[3] != 0;
 
         ggml_tensor * dst;
-        if (use_view_slice) {
+        if (permuted) {
+            dst = ggml_permute(ctx, src, permute[0], permute[1], permute[2], permute[3]);
+            ggml_set_name(dst, "src_permuted");
+        } else if (use_view_slice) {
             dst = ggml_view_4d(ctx, src, src->ne[0], 1, src->ne[2], src->ne[3],
                 src->nb[1], src->nb[2], src->nb[3], src->nb[0] * (src->ne[1] - 1));
             ggml_set_name(dst, "src_view_slice");
@@ -3089,41 +3100,6 @@ struct test_cont : public test_case {
         }
 
         ggml_tensor * out = ggml_cont(ctx, dst);
-        ggml_set_name(out, "out");
-
-        return out;
-    }
-};
-
-// GGML_OP_CONT of an arbitrary permutation.
-// test_cont above only exercises ggml_transpose (a 0<->1 swap), which the Vulkan
-// backend routes to its tiled shared-memory transpose shader. A 0<->2 swap --
-// e.g. ggml_cont(ggml_permute(x, 2, 1, 0, 3)), which DeepSeek-V4's lightning
-// indexer performs on a [n_kv, n_tokens, n_head] tensor -- takes a different
-// path entirely and was previously uncovered.
-struct test_cont_permute : public test_case {
-    const ggml_type type;
-    const std::array<int64_t, 4> ne;
-    const std::array<int, 4> perm;
-
-    std::string vars() override {
-        return VARS_TO_STR3(type, ne, perm);
-    }
-
-    test_cont_permute(ggml_type type = GGML_TYPE_F32,
-            std::array<int64_t, 4> ne = {10, 10, 10, 1},
-            std::array<int, 4> perm = {2, 1, 0, 3})
-        : type(type), ne(ne), perm(perm) {}
-
-    ggml_tensor * build_graph(ggml_context * ctx) override {
-        ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne.data());
-        ggml_set_param(src);
-        ggml_set_name(src, "src");
-
-        ggml_tensor * permuted = ggml_permute(ctx, src, perm[0], perm[1], perm[2], perm[3]);
-        ggml_set_name(permuted, "src_permuted");
-
-        ggml_tensor * out = ggml_cont(ctx, permuted);
         ggml_set_name(out, "out");
 
         return out;
@@ -8679,11 +8655,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                 // perf cases use. Perf mode does NOT verify results, so without
                 // these the fast path would only ever be checked on tiny tensors.
                 {1024, 64, 64, 1}, {2304, 64, 64, 1}, {1000, 33, 65, 1} }) {
-            for (std::array<int, 4> perm : std::initializer_list<std::array<int, 4>>{
+            for (std::array<int64_t, 4> perm : std::initializer_list<std::array<int64_t, 4>>{
                     {2, 1, 0, 3},   // 0<->2 swap (the DeepSeek-V4 indexer pattern)
                     {1, 2, 0, 3},   // 3-cycle
                     {0, 2, 1, 3} }) {
-                test_cases.emplace_back(new test_cont_permute(type_dst, ne, perm));
+                test_cases.emplace_back(new test_cont(type_dst, ne, false, perm));
             }
         }
     }
@@ -9803,14 +9779,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     // Measured on Vulkan/gfx1151 this ran at ~1 GB/s of a ~200 GB/s box and was
     // 43% of DeepSeek-V4 prefill. n_kv values include power-of-two and
     // non-power-of-two neighbours because the two differed by ~2.4x.
-    // NOTE: n_tokens is 64 here, not the production 512. At 512 a single
-    // dispatch takes ~273 ms on the slow path, and perf mode loops it -- which
-    // trips the amdgpu watchdog and forces a GPU hard recovery (observed
-    // 2026-08-02; it can take other contexts on the box down with it). 64 keeps
-    // one dispatch in the tens of ms while preserving the access pattern.
+    // NOTE: the n_tokens=64 shapes keep a single slow-path dispatch in the
+    // tens of ms; at 512 the OLD path took ~273 ms per dispatch and perf
+    // mode's looping tripped the amdgpu watchdog (observed 2026-08-02).
+    // The n_tokens=512 shapes are ~270-300 MB so they exceed GPU L2 on
+    // large parts, where the 64-token shapes fit in cache and read above
+    // memory bandwidth.
     for (int64_t n_kv : { 1024, 1280, 2048, 2304 }) {
-        test_cases.emplace_back(new test_cont_permute(
-            GGML_TYPE_F32, {n_kv, 64, 64, 1}, {2, 1, 0, 3}));
+        test_cases.emplace_back(new test_cont(
+            GGML_TYPE_F32, {n_kv, 64, 64, 1}, false, {2, 1, 0, 3}));
+    }
+    for (int64_t n_kv : { 2048, 2304 }) {
+        test_cases.emplace_back(new test_cont(
+            GGML_TYPE_F32, {n_kv, 512, 64, 1}, false, {2, 1, 0, 3}));
     }
 
     // Conv2d: K=CRS=NPQ=4096 matmul performance

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3061,28 +3061,39 @@ struct test_cpy : public test_case {
 };
 
 // GGML_OP_CONT
+// permute = {0, 0, 0, 0} means no permutation: the source is transposed (or
+// view-sliced). A non-identity permute exercises ggml_cont of an arbitrary
+// ggml_permute -- e.g. the 0<->2 swap DeepSeek-V4's lightning indexer performs
+// on a [n_kv, n_tokens, n_head] tensor -- which takes a different backend path
+// than the 0<->1 transpose and was previously uncovered.
 struct test_cont : public test_case {
     const ggml_type type;
     const std::array<int64_t, 4> ne;
     bool use_view_slice;
+    const std::array<int64_t, 4> permute;
 
     std::string vars() override {
-        return VARS_TO_STR3(type, ne, use_view_slice);
+        return VARS_TO_STR4(type, ne, use_view_slice, permute);
     }
 
     test_cont(ggml_type type = GGML_TYPE_F32,
             std::array<int64_t, 4> ne = {10, 10, 10, 1},
-            bool use_view_slice = false)
-        : type(type), ne(ne), use_view_slice(use_view_slice) {}
+            bool use_view_slice = false,
+            std::array<int64_t, 4> permute = {0, 0, 0, 0})
+        : type(type), ne(ne), use_view_slice(use_view_slice), permute(permute) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne.data());
         ggml_set_param(src);
         ggml_set_name(src, "src");
 
+        const bool permuted = permute[0] != 0 || permute[1] != 0 || permute[2] != 0 || permute[3] != 0;
 
         ggml_tensor * dst;
-        if (use_view_slice) {
+        if (permuted) {
+            dst = ggml_permute(ctx, src, permute[0], permute[1], permute[2], permute[3]);
+            ggml_set_name(dst, "src_permuted");
+        } else if (use_view_slice) {
             dst = ggml_view_4d(ctx, src, src->ne[0], 1, src->ne[2], src->ne[3],
                 src->nb[1], src->nb[2], src->nb[3], src->nb[0] * (src->ne[1] - 1));
             ggml_set_name(dst, "src_view_slice");
@@ -3092,41 +3103,6 @@ struct test_cont : public test_case {
         }
 
         ggml_tensor * out = ggml_cont(ctx, dst);
-        ggml_set_name(out, "out");
-
-        return out;
-    }
-};
-
-// GGML_OP_CONT of an arbitrary permutation.
-// test_cont above only exercises ggml_transpose (a 0<->1 swap), which the Vulkan
-// backend routes to its tiled shared-memory transpose shader. A 0<->2 swap --
-// e.g. ggml_cont(ggml_permute(x, 2, 1, 0, 3)), which DeepSeek-V4's lightning
-// indexer performs on a [n_kv, n_tokens, n_head] tensor -- takes a different
-// path entirely and was previously uncovered.
-struct test_cont_permute : public test_case {
-    const ggml_type type;
-    const std::array<int64_t, 4> ne;
-    const std::array<int, 4> perm;
-
-    std::string vars() override {
-        return VARS_TO_STR3(type, ne, perm);
-    }
-
-    test_cont_permute(ggml_type type = GGML_TYPE_F32,
-            std::array<int64_t, 4> ne = {10, 10, 10, 1},
-            std::array<int, 4> perm = {2, 1, 0, 3})
-        : type(type), ne(ne), perm(perm) {}
-
-    ggml_tensor * build_graph(ggml_context * ctx) override {
-        ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne.data());
-        ggml_set_param(src);
-        ggml_set_name(src, "src");
-
-        ggml_tensor * permuted = ggml_permute(ctx, src, perm[0], perm[1], perm[2], perm[3]);
-        ggml_set_name(permuted, "src_permuted");
-
-        ggml_tensor * out = ggml_cont(ctx, permuted);
         ggml_set_name(out, "out");
 
         return out;
@@ -8692,11 +8668,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                 // perf cases use. Perf mode does NOT verify results, so without
                 // these the fast path would only ever be checked on tiny tensors.
                 {1024, 64, 64, 1}, {2304, 64, 64, 1}, {1000, 33, 65, 1} }) {
-            for (std::array<int, 4> perm : std::initializer_list<std::array<int, 4>>{
+            for (std::array<int64_t, 4> perm : std::initializer_list<std::array<int64_t, 4>>{
                     {2, 1, 0, 3},   // 0<->2 swap (the DeepSeek-V4 indexer pattern)
                     {1, 2, 0, 3},   // 3-cycle
                     {0, 2, 1, 3} }) {
-                test_cases.emplace_back(new test_cont_permute(type_dst, ne, perm));
+                test_cases.emplace_back(new test_cont(type_dst, ne, false, perm));
             }
         }
     }
@@ -9835,14 +9811,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     // Measured on Vulkan/gfx1151 this ran at ~1 GB/s of a ~200 GB/s box and was
     // 43% of DeepSeek-V4 prefill. n_kv values include power-of-two and
     // non-power-of-two neighbours because the two differed by ~2.4x.
-    // NOTE: n_tokens is 64 here, not the production 512. At 512 a single
-    // dispatch takes ~273 ms on the slow path, and perf mode loops it -- which
-    // trips the amdgpu watchdog and forces a GPU hard recovery (observed
-    // 2026-08-02; it can take other contexts on the box down with it). 64 keeps
-    // one dispatch in the tens of ms while preserving the access pattern.
+    // NOTE: the n_tokens=64 shapes keep a single slow-path dispatch in the
+    // tens of ms; at 512 the OLD path took ~273 ms per dispatch and perf
+    // mode's looping tripped the amdgpu watchdog (observed 2026-08-02).
+    // The n_tokens=512 shapes are ~270-300 MB so they exceed GPU L2 on
+    // large parts, where the 64-token shapes fit in cache and read above
+    // memory bandwidth.
     for (int64_t n_kv : { 1024, 1280, 2048, 2304 }) {
-        test_cases.emplace_back(new test_cont_permute(
-            GGML_TYPE_F32, {n_kv, 64, 64, 1}, {2, 1, 0, 3}));
+        test_cases.emplace_back(new test_cont(
+            GGML_TYPE_F32, {n_kv, 64, 64, 1}, false, {2, 1, 0, 3}));
+    }
+    for (int64_t n_kv : { 2048, 2304 }) {
+        test_cases.emplace_back(new test_cont(
+            GGML_TYPE_F32, {n_kv, 512, 64, 1}, false, {2, 1, 0, 3}));
     }
 
     // Conv2d: K=CRS=NPQ=4096 matmul performance

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3098,6 +3098,41 @@ struct test_cont : public test_case {
     }
 };
 
+// GGML_OP_CONT of an arbitrary permutation.
+// test_cont above only exercises ggml_transpose (a 0<->1 swap), which the Vulkan
+// backend routes to its tiled shared-memory transpose shader. A 0<->2 swap --
+// e.g. ggml_cont(ggml_permute(x, 2, 1, 0, 3)), which DeepSeek-V4's lightning
+// indexer performs on a [n_kv, n_tokens, n_head] tensor -- takes a different
+// path entirely and was previously uncovered.
+struct test_cont_permute : public test_case {
+    const ggml_type type;
+    const std::array<int64_t, 4> ne;
+    const std::array<int, 4> perm;
+
+    std::string vars() override {
+        return VARS_TO_STR3(type, ne, perm);
+    }
+
+    test_cont_permute(ggml_type type = GGML_TYPE_F32,
+            std::array<int64_t, 4> ne = {10, 10, 10, 1},
+            std::array<int, 4> perm = {2, 1, 0, 3})
+        : type(type), ne(ne), perm(perm) {}
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * src = ggml_new_tensor(ctx, type, 4, ne.data());
+        ggml_set_param(src);
+        ggml_set_name(src, "src");
+
+        ggml_tensor * permuted = ggml_permute(ctx, src, perm[0], perm[1], perm[2], perm[3]);
+        ggml_set_name(permuted, "src_permuted");
+
+        ggml_tensor * out = ggml_cont(ctx, permuted);
+        ggml_set_name(out, "out");
+
+        return out;
+    }
+};
+
 // GGML_OP_ADD
 // GGML_OP_SUB
 // GGML_OP_MUL
@@ -8650,6 +8685,22 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    for (ggml_type type_dst : { GGML_TYPE_F32, GGML_TYPE_F16 }) {
+        for (std::array<int64_t, 4> ne : std::initializer_list<std::array<int64_t, 4>>{
+                {10, 10, 10, 1}, {33, 5, 7, 1}, {64, 3, 65, 1}, {2, 3, 5, 7},
+                // Large, tile-aligned and tile-unaligned, matching the shapes the
+                // perf cases use. Perf mode does NOT verify results, so without
+                // these the fast path would only ever be checked on tiny tensors.
+                {1024, 64, 64, 1}, {2304, 64, 64, 1}, {1000, 33, 65, 1} }) {
+            for (std::array<int, 4> perm : std::initializer_list<std::array<int, 4>>{
+                    {2, 1, 0, 3},   // 0<->2 swap (the DeepSeek-V4 indexer pattern)
+                    {1, 2, 0, 3},   // 3-cycle
+                    {0, 2, 1, 3} }) {
+                test_cases.emplace_back(new test_cont_permute(type_dst, ne, perm));
+            }
+        }
+    }
+
     auto add_test_bin_bcast = [&](ggml_type type, std::array<int64_t, 4> ne, std::array<int, 4> nr, bool perm1 = false, bool src_overlap = false) {
         for (auto op : {ggml_add, ggml_sub, ggml_mul, ggml_div}) {
             test_cases.emplace_back(new test_bin_bcast(op, type, ne, nr, 1, perm1, src_overlap));
@@ -9777,6 +9828,21 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
             test_cases.emplace_back(new test_glu(GGML_GLU_OP_SWIGLU, type, { 2*17408, n_tokens, 1, 1 }, 0, false));
             test_cases.emplace_back(new test_glu_split(GGML_GLU_OP_SWIGLU, type, { 17408, n_tokens, 1, 1 }, 0));
         }
+    }
+
+    // CONT of a 0<->2 permute at DeepSeek-V4 lightning-indexer shapes:
+    // indexer_kq is [n_kv, n_tokens, n_head=64] and gets ggml_cont(ggml_permute(.., 2,1,0,3)).
+    // Measured on Vulkan/gfx1151 this ran at ~1 GB/s of a ~200 GB/s box and was
+    // 43% of DeepSeek-V4 prefill. n_kv values include power-of-two and
+    // non-power-of-two neighbours because the two differed by ~2.4x.
+    // NOTE: n_tokens is 64 here, not the production 512. At 512 a single
+    // dispatch takes ~273 ms on the slow path, and perf mode loops it -- which
+    // trips the amdgpu watchdog and forces a GPU hard recovery (observed
+    // 2026-08-02; it can take other contexts on the box down with it). 64 keeps
+    // one dispatch in the tens of ms while preserving the access pattern.
+    for (int64_t n_kv : { 1024, 1280, 2048, 2304 }) {
+        test_cases.emplace_back(new test_cont_permute(
+            GGML_TYPE_F32, {n_kv, 64, 64, 1}, {2, 1, 0, 3}));
     }
 
     // Conv2d: K=CRS=NPQ=4096 matmul performance

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3062,10 +3062,7 @@ struct test_cpy : public test_case {
 
 // GGML_OP_CONT
 // permute = {0, 0, 0, 0} means no permutation: the source is transposed (or
-// view-sliced). A non-identity permute exercises ggml_cont of an arbitrary
-// ggml_permute -- e.g. the 0<->2 swap DeepSeek-V4's lightning indexer performs
-// on a [n_kv, n_tokens, n_head] tensor -- which takes a different backend path
-// than the 0<->1 transpose and was previously uncovered.
+// view-sliced). A non-identity permute applies ggml_permute before ggml_cont.
 struct test_cont : public test_case {
     const ggml_type type;
     const std::array<int64_t, 4> ne;
@@ -8664,12 +8661,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     for (ggml_type type_dst : { GGML_TYPE_F32, GGML_TYPE_F16 }) {
         for (std::array<int64_t, 4> ne : std::initializer_list<std::array<int64_t, 4>>{
                 {10, 10, 10, 1}, {33, 5, 7, 1}, {64, 3, 65, 1}, {2, 3, 5, 7},
-                // Large, tile-aligned and tile-unaligned, matching the shapes the
-                // perf cases use. Perf mode does NOT verify results, so without
-                // these the fast path would only ever be checked on tiny tensors.
+                // large, tile-aligned and tile-unaligned, matching the perf cases
                 {1024, 64, 64, 1}, {2304, 64, 64, 1}, {1000, 33, 65, 1} }) {
             for (std::array<int64_t, 4> perm : std::initializer_list<std::array<int64_t, 4>>{
-                    {2, 1, 0, 3},   // 0<->2 swap (the DeepSeek-V4 indexer pattern)
+                    {2, 1, 0, 3},   // 0<->2 swap
                     {1, 2, 0, 3},   // 3-cycle
                     {0, 2, 1, 3} }) {
                 test_cases.emplace_back(new test_cont(type_dst, ne, false, perm));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9808,15 +9808,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
 
     // CONT of a 0<->2 permute at DeepSeek-V4 lightning-indexer shapes:
     // indexer_kq is [n_kv, n_tokens, n_head=64] and gets ggml_cont(ggml_permute(.., 2,1,0,3)).
-    // Measured on Vulkan/gfx1151 this ran at ~1 GB/s of a ~200 GB/s box and was
-    // 43% of DeepSeek-V4 prefill. n_kv values include power-of-two and
-    // non-power-of-two neighbours because the two differed by ~2.4x.
-    // NOTE: the n_tokens=64 shapes keep a single slow-path dispatch in the
-    // tens of ms; at 512 the OLD path took ~273 ms per dispatch and perf
-    // mode's looping tripped the amdgpu watchdog (observed 2026-08-02).
-    // The n_tokens=512 shapes are ~270-300 MB so they exceed GPU L2 on
-    // large parts, where the 64-token shapes fit in cache and read above
-    // memory bandwidth.
     for (int64_t n_kv : { 1024, 1280, 2048, 2304 }) {
         test_cases.emplace_back(new test_cont(
             GGML_TYPE_F32, {n_kv, 64, 64, 1}, false, {2, 1, 0, 3}));


### PR DESCRIPTION
## Overview

ggml_vk_get_cpy_pipeline only routed to the tiled shared-memory transpose shader when dim1 was the innermost dimension, i.e. ggml_transpose (a 0<->1 swap). A 0<->2 swap -- ggml_cont(ggml_permute(x, 2, 1, 0, 3)) -- fell back to the generic per-element strided copy, whose source reads stride by ne0*ne1 elements: one cache line per lane.

DeepSeek-V4's lightning indexer performs exactly that permute on a [n_kv, n_tokens, n_head] tensor. On Vulkan/RADV gfx1151 it ran at ~7-20 GB/s of a ~200 GB/s part and accounted for 43% of total prefill time.

Add copy_transpose_02.comp, mirroring copy_transpose.comp but tiling over dst dims (0, 2) with dims 1 and 3 as the batch, so reads walk src dim2 and writes walk dst dim0 -- both contiguous. The selection condition additionally requires a non-contiguous source and a contiguous destination so it cannot take cases the contiguous-copy shader already handles.

test-backend-ops only exercised ggml_transpose for CONT, so the strided path was untested. Add test_cont_permute covering (2,1,0,3), (1,2,0,3) and (0,2,1,3) over f32/f16 at tile-aligned, tile-unaligned and large shapes. The large shapes are in the eval set rather than only in perf because perf mode does not verify results.

Measured on gfx1151, ne=[n_kv,64,64,1], perm=(2,1,0,3), f32:

| n_kv | before | after |
|---|---|---|
| 1024 | 9.08 GB/s | 579.85 GB/s |
| 1280 | 20.03 GB/s | 153.71 GB/s |
| 2048 | 7.11 GB/s | 91.68 GB/s |
| 2304 | 16.24 GB/s | 86.49 GB/s |

The ~2.2x penalty previously seen at power-of-two n_kv (destination-stride aliasing) is gone. End to end, DeepSeek-V4-Flash IQ3_XXS prefill on a 9k-token prompt goes from 56.33 t/s to 103.74 t/s (+84%).

Note: at n_tokens=512 a single slow-path dispatch takes ~273 ms and looping it in perf mode can trip the GPU watchdog, so the perf cases use n_tokens=64.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used to generate code with a human in the loop, to collect and reduce data from test and benchmark runs, and to organize that information into this PR description. All submitted changes were reviewed by me, and I am responsible for them.