### PR TITLE
ci: fix the ctest sanitize runs

### DIFF
--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
         - sanitizer: ADDRESS
-          runs-on: [self-hosted, X64, Linux]
+          machine: [self-hosted, X64, Linux]
         - sanitizer: THREAD
           # only certain machines can run the thread sanitizer without crashing, see #26593
           machine: ${{ 'ggml-6-x86-vulkan-t4' || 'ggml-8-x86-nvidia-a10' }}
@@ -48,6 +48,7 @@ jobs:
           machine: [self-hosted, X64, Linux]
 
     runs-on: ${{ matrix.machine }}
+    
     steps:
       - name: Clone
         id: checkout

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   ctest:
-    runs-on: [self-hosted, X64, CPU, Linux]
+    runs-on: [self-hosted, X64, Linux]
 
     continue-on-error: true
 

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -48,7 +48,7 @@ jobs:
           machine: [self-hosted, X64, Linux]
 
     runs-on: ${{ matrix.machine }}
-    
+
     steps:
       - name: Clone
         id: checkout

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -34,14 +34,20 @@ env:
 
 jobs:
   ctest:
-    runs-on: [self-hosted, X64, Linux]
-
     continue-on-error: true
 
     strategy:
       matrix:
-        sanitizer: [ADDRESS, THREAD, UNDEFINED]
+        include:
+        - sanitizer: ADDRESS
+          runs-on: [self-hosted, X64, Linux]
+        - sanitizer: THREAD
+          # only certain machines can run the thread sanitizer without crashing, see #26593
+          machine: ${{ 'ggml-6-x86-vulkan-t4' || 'ggml-8-x86-nvidia-a10' }}
+        - sanitizer: UNDEFINED
+          machine: [self-hosted, X64, Linux]
 
+    runs-on: ${{ matrix.machine }}
     steps:
       - name: Clone
         id: checkout

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -41,9 +41,9 @@ jobs:
         include:
         - sanitizer: ADDRESS
           machine: [self-hosted, X64, Linux]
+        # thread doesn't run properly on some self hosted machines, so run it on Github instead
         - sanitizer: THREAD
-          # only certain machines can run the thread sanitizer without crashing, see #26593
-          machine: ${{ 'ggml-6-x86-vulkan-t4' || 'ggml-8-x86-nvidia-a10' }}
+          machine: ubuntu-24.04
         - sanitizer: UNDEFINED
           machine: [self-hosted, X64, Linux]
 
@@ -53,6 +53,15 @@ jobs:
       - name: Clone
         id: checkout
         uses: actions/checkout@v6
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        if: ${{ matrix.sanitizer == 'THREAD' }}
+        with:
+          key: ctest-thread-ubuntu-24.04
+          variant: ccache
+          evict-old-files: 1d
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
       # with UNDEFINED sanitizer, we have to build in Debug to avoid GCC 13 false-positive warnings
       - name: Build (undefined)

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -15,6 +15,12 @@ on:
       '**/*.cpp'
     ]
 
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths: [
+      '.github/workflows/build-sanitize.yml'
+    ]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Those jobs are getting stuck as we only have three machines with the cpu tag.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
