### PR TITLE
vulkan: keep p021/nc mat-vec paths for large row counts (chunked dispatch), add GQA sharing to nc

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2023,6 +2023,9 @@ private:
 std::mutex vk_memory_logger::log_mutex;
 
 static bool vk_perf_logger_enabled = false;
+// GGML_VK_MAX_WG_Y_DEBUG: cap the row-chunk size of the p021/nc mat-vec
+// dispatches so the chunked path can be tested below the device limit.
+static uint32_t vk_max_wg_y_debug = 0;
 static bool vk_perf_logger_concurrent = false;
 static bool vk_enable_sync_logger = false;
 // number of calls between perf logger prints
@@ -7247,6 +7250,9 @@ static void ggml_vk_instance_init() {
     }
 
     vk_perf_logger_enabled = getenv("GGML_VK_PERF_LOGGER") != nullptr;
+    if (const char * dbg = getenv("GGML_VK_MAX_WG_Y_DEBUG")) {
+        vk_max_wg_y_debug = (uint32_t)std::max(1, atoi(dbg));
+    }
     vk_perf_logger_concurrent = getenv("GGML_VK_PERF_LOGGER_CONCURRENT") != nullptr;
     vk_enable_sync_logger = getenv("GGML_VK_SYNC_LOGGER") != nullptr;
     vk_memory_logger_enabled = getenv("GGML_VK_MEMORY_LOGGER") != nullptr;
@@ -8957,13 +8963,8 @@ static void ggml_vk_quantize_q8_1(ggml_backend_vk_context * ctx, vk_context& sub
 }
 
 static uint32_t ggml_vk_max_wg_y(ggml_backend_vk_context * ctx) {
-    uint32_t max_wg_y = ctx->device->properties.limits.maxComputeWorkGroupCount[1];
-    // GGML_VK_MAX_WG_Y_DEBUG forces a smaller chunk size so the row-chunked
-    // dispatch path can be correctness-tested below the real device limit.
-    if (const char * dbg = getenv("GGML_VK_MAX_WG_Y_DEBUG")) {
-        max_wg_y = std::min(max_wg_y, (uint32_t)std::max(1, atoi(dbg)));
-    }
-    return max_wg_y;
+    const uint32_t max_wg_y = ctx->device->properties.limits.maxComputeWorkGroupCount[1];
+    return vk_max_wg_y_debug ? std::min(max_wg_y, vk_max_wg_y_debug) : max_wg_y;
 }
 
 static vk_pipeline ggml_vk_get_64b_indexing_pipeline(ggml_backend_vk_context * ctx, vk_pipeline &pipeline) {
@@ -9612,9 +9613,8 @@ static void ggml_vk_mul_mat_vec_p021_f16_f32(ggml_backend_vk_context * ctx, vk_c
     }
 
     {
-        // Request descriptor sets — one per row chunk (see the dispatch loop)
-        const uint32_t wg_y = ggml_vk_max_wg_y(ctx);
-        ggml_pipeline_request_descriptor_sets(ctx, pipeline, ((uint32_t)src0->ne[1] + wg_y - 1) / wg_y);
+        // Request descriptor sets (one per row chunk, see the dispatch loop)
+        ggml_pipeline_request_descriptor_sets(ctx, pipeline, CEIL_DIV((uint32_t)src0->ne[1], ggml_vk_max_wg_y(ctx)));
     }
 
     vk_subbuffer d_D = ggml_vk_tensor_subbuffer(ctx, cgraph->nodes[node_idx + ctx->num_additional_fused_ops], true);
@@ -9656,7 +9656,7 @@ static void ggml_vk_mul_mat_vec_p021_f16_f32(ggml_backend_vk_context * ctx, vk_c
         workgroups_z /= gqa_ratio;
     }
 
-    // ne01 (n_kv rows for attention K·Q) can exceed the device's max
+    // ne01 (n_kv rows for attention K*Q) can exceed the device's max
     // workgroup count in y; chunk the dispatch with a row_base offset.
     const uint32_t max_wg_y = ggml_vk_max_wg_y(ctx);
 
@@ -9729,9 +9729,8 @@ static void ggml_vk_mul_mat_vec_nc_f16_f32(ggml_backend_vk_context * ctx, vk_con
     }
 
     {
-        // Request descriptor sets — one per row chunk (see the dispatch loop)
-        const uint32_t wg_y = ggml_vk_max_wg_y(ctx);
-        ggml_pipeline_request_descriptor_sets(ctx, pipeline, ((uint32_t)ne01 + wg_y - 1) / wg_y);
+        // Request descriptor sets (one per row chunk, see the dispatch loop)
+        ggml_pipeline_request_descriptor_sets(ctx, pipeline, CEIL_DIV((uint32_t)ne01, ggml_vk_max_wg_y(ctx)));
     }
 
     vk_subbuffer d_D = ggml_vk_tensor_subbuffer(ctx, cgraph->nodes[node_idx + ctx->num_additional_fused_ops], true);
@@ -9772,7 +9771,7 @@ static void ggml_vk_mul_mat_vec_nc_f16_f32(ggml_backend_vk_context * ctx, vk_con
         workgroups_z /= gqa_ratio;
     }
 
-    // ne01 (the row count — n_kv for attention K·Q) can exceed the device's
+    // ne01 (the row count, n_kv for attention K*Q) can exceed the device's
     // max workgroup count in y; chunk the dispatch with a row_base offset.
     const uint32_t max_wg_y = ggml_vk_max_wg_y(ctx);
 
@@ -9899,17 +9898,11 @@ static void ggml_vk_mul_mat(ggml_backend_vk_context * ctx, vk_context& subctx, c
         src1->nb[1] <= src1->nb[3] &&
         src0->ne[3] == 1 &&
         src1->ne[3] == 1 &&
-        // no ne[1] (row count) limit: the dispatch is chunked over rows, so
-        // large-context attention (n_kv > maxComputeWorkGroupCount[1]) stays
-        // on this GQA-aware path instead of the generic mat-vec
         src1->ne[2] <= ctx->device->properties.limits.maxComputeWorkGroupCount[2]) {
         ggml_vk_mul_mat_vec_p021_f16_f32(ctx, subctx, cgraph, node_idx);
     } else if (src0->type == GGML_TYPE_F16 && !ggml_is_contiguous(src0) && !ggml_is_transposed(src1) && dst->ne[1] == 1 &&
                !ggml_is_permuted(src0) && !ggml_is_permuted(src1) &&
                src0->ne[3] <= ctx->device->properties.limits.maxComputeWorkGroupCount[0] &&
-               // no ne[1] (row count) limit: the dispatch is chunked over rows,
-               // so large-context attention (n_kv > maxComputeWorkGroupCount[1])
-               // stays on this path instead of the generic mat-vec
                src1->ne[2] <= ctx->device->properties.limits.maxComputeWorkGroupCount[2]) {
         ggml_vk_mul_mat_vec_nc_f16_f32(ctx, subctx, cgraph, node_idx);
     // mul_mat_vec supports batching ne12*ne13 when ne11==1, or treating ne11 as the batch size (up to four)

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -885,7 +885,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_dequant_mul_mat_vec_id_q8_1_f32[DMMV_WG_SIZE_COUNT][GGML_TYPE_COUNT];
 
     vk_pipeline pipeline_mul_mat_vec_p021_f16_f32[p021_max_gqa_ratio];
-    vk_pipeline pipeline_mul_mat_vec_nc_f16_f32;
+    vk_pipeline pipeline_mul_mat_vec_nc_f16_f32[p021_max_gqa_ratio];
     vk_pipeline pipeline_get_rows[GGML_TYPE_COUNT];
     vk_pipeline pipeline_get_rows_f32[GGML_TYPE_COUNT];
     vk_pipeline pipeline_get_rows_back_f32;
@@ -1216,6 +1216,7 @@ struct vk_mat_vec_p021_push_constants {
     uint32_t b_offset;
     uint32_t d_offset;
     uint32_t fusion_flags;
+    uint32_t row_base;
 };
 
 struct vk_mat_vec_nc_push_constants {
@@ -1232,6 +1233,7 @@ struct vk_mat_vec_nc_push_constants {
     uint32_t nb13;
     uint32_t nb23;
     uint32_t fusion_flags;
+    uint32_t row_base;
 };
 
 struct vk_mat_mat_id_push_constants {
@@ -5334,7 +5336,9 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             ggml_vk_create_pipeline2(device, device->pipeline_mul_mat_vec_p021_f16_f32[i], "mul_mat_vec_p021_f16_f32"+std::to_string(i+1), mul_mat_vec_p021_f16_f32_len,              mul_mat_vec_p021_f16_f32_data,              "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_p021_push_constants), {1, 1, 1}, {device->subgroup_size, i + 1}, 1, true);
         }
     }
-    ggml_vk_create_pipeline(device, device->pipeline_mul_mat_vec_nc_f16_f32, "mul_mat_vec_nc_f16_f32", mul_mat_vec_nc_f16_f32_len, mul_mat_vec_nc_f16_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_nc_push_constants), {1, 1, 1}, {}, 1);
+    for (uint32_t i = 0; i < p021_max_gqa_ratio; ++i) {
+        ggml_vk_create_pipeline2(device, device->pipeline_mul_mat_vec_nc_f16_f32[i], "mul_mat_vec_nc_f16_f32"+std::to_string(i+1), mul_mat_vec_nc_f16_f32_len, mul_mat_vec_nc_f16_f32_data, "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_nc_push_constants), {1, 1, 1}, {32, i + 1}, 1);
+    }
 
     ggml_vk_create_pipeline(device, device->pipeline_norm_f32, "norm_f32", norm_f32_len, norm_f32_data, "main", 2, sizeof(vk_op_unary_push_constants), {1, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_group_norm_f32, "group_norm_f32", group_norm_f32_len, group_norm_f32_data, "main", 2, sizeof(vk_op_push_constants), {1, 1, 1}, {}, 1);
@@ -8952,6 +8956,16 @@ static void ggml_vk_quantize_q8_1(ggml_backend_vk_context * ctx, vk_context& sub
     ggml_vk_sync_buffers(ctx, subctx);
 }
 
+static uint32_t ggml_vk_max_wg_y(ggml_backend_vk_context * ctx) {
+    uint32_t max_wg_y = ctx->device->properties.limits.maxComputeWorkGroupCount[1];
+    // GGML_VK_MAX_WG_Y_DEBUG forces a smaller chunk size so the row-chunked
+    // dispatch path can be correctness-tested below the real device limit.
+    if (const char * dbg = getenv("GGML_VK_MAX_WG_Y_DEBUG")) {
+        max_wg_y = std::min(max_wg_y, (uint32_t)std::max(1, atoi(dbg)));
+    }
+    return max_wg_y;
+}
+
 static vk_pipeline ggml_vk_get_64b_indexing_pipeline(ggml_backend_vk_context * ctx, vk_pipeline &pipeline) {
     GGML_UNUSED(ctx);
 #if defined(VK_EXT_shader_64bit_indexing)
@@ -9598,8 +9612,9 @@ static void ggml_vk_mul_mat_vec_p021_f16_f32(ggml_backend_vk_context * ctx, vk_c
     }
 
     {
-        // Request descriptor sets
-        ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+        // Request descriptor sets — one per row chunk (see the dispatch loop)
+        const uint32_t wg_y = ggml_vk_max_wg_y(ctx);
+        ggml_pipeline_request_descriptor_sets(ctx, pipeline, ((uint32_t)src0->ne[1] + wg_y - 1) / wg_y);
     }
 
     vk_subbuffer d_D = ggml_vk_tensor_subbuffer(ctx, cgraph->nodes[node_idx + ctx->num_additional_fused_ops], true);
@@ -9630,7 +9645,7 @@ static void ggml_vk_mul_mat_vec_p021_f16_f32(ggml_backend_vk_context * ctx, vk_c
 
     vk_mat_vec_p021_push_constants pc = {
         (uint32_t)ne00, (uint32_t)ne01, (uint32_t)ne02, (uint32_t)ne12,
-        0, 0, fusion_flags
+        0, 0, fusion_flags, 0
     };
 
     init_pushconst_tensor_offsets(ctx, pc, src0, src1, nullptr, nullptr, cgraph->nodes[node_idx + ctx->num_additional_fused_ops]);
@@ -9641,14 +9656,22 @@ static void ggml_vk_mul_mat_vec_p021_f16_f32(ggml_backend_vk_context * ctx, vk_c
         workgroups_z /= gqa_ratio;
     }
 
-    ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
-        {
-            d_Qx,
-            d_Qy,
-            d_D,
-            d_F0,
-            d_F1,
-        }, pc, { 1, (uint32_t)ne01, workgroups_z });
+    // ne01 (n_kv rows for attention K·Q) can exceed the device's max
+    // workgroup count in y; chunk the dispatch with a row_base offset.
+    const uint32_t max_wg_y = ggml_vk_max_wg_y(ctx);
+
+    for (uint32_t row0 = 0; row0 < (uint32_t)ne01; row0 += max_wg_y) {
+        const uint32_t chunk_rows = std::min(max_wg_y, (uint32_t)ne01 - row0);
+        pc.row_base = row0;
+        ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
+            {
+                d_Qx,
+                d_Qy,
+                d_D,
+                d_F0,
+                d_F1,
+            }, pc, { 1, chunk_rows, workgroups_z });
+    }
 }
 
 static void ggml_vk_mul_mat_vec_nc_f16_f32(ggml_backend_vk_context * ctx, vk_context& subctx, const struct ggml_cgraph * cgraph, int node_idx) {
@@ -9691,14 +9714,24 @@ static void ggml_vk_mul_mat_vec_nc_f16_f32(ggml_backend_vk_context * ctx, vk_con
     const uint32_t channel_stride_x = nb02 / sizeof(ggml_fp16_t);
     const uint32_t channel_stride_y = nb12 / sizeof(float);
 
-    vk_pipeline pipeline = ctx->device->pipeline_mul_mat_vec_nc_f16_f32;
+    // Grouped-query attention: when gqa_ratio channels of src1 (the query
+    // heads) share each channel of src0 (the K cache), one workgroup handles
+    // the whole group and loads src0 only once, saving gqa_ratio-1 redundant
+    // passes over the K cache. Same scheme as ggml_vk_mul_mat_vec_p021_f16_f32.
+    uint32_t gqa_ratio = (uint32_t)(ne12 / ne02);
+    if (gqa_ratio > p021_max_gqa_ratio || gqa_ratio == 0 || ne12 != ne02 * gqa_ratio) {
+        gqa_ratio = 1;
+    }
+
+    vk_pipeline pipeline = ctx->device->pipeline_mul_mat_vec_nc_f16_f32[gqa_ratio - 1];
     if (ggml_nbytes(src0) > ctx->device->properties.limits.maxStorageBufferRange) {
         pipeline = ggml_vk_get_64b_indexing_pipeline(ctx, pipeline);
     }
 
     {
-        // Request descriptor sets
-        ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+        // Request descriptor sets — one per row chunk (see the dispatch loop)
+        const uint32_t wg_y = ggml_vk_max_wg_y(ctx);
+        ggml_pipeline_request_descriptor_sets(ctx, pipeline, ((uint32_t)ne01 + wg_y - 1) / wg_y);
     }
 
     vk_subbuffer d_D = ggml_vk_tensor_subbuffer(ctx, cgraph->nodes[node_idx + ctx->num_additional_fused_ops], true);
@@ -9730,19 +9763,33 @@ static void ggml_vk_mul_mat_vec_nc_f16_f32(ggml_backend_vk_context * ctx, vk_con
         row_stride_x, channel_stride_x, channel_stride_y,
         (uint32_t)(ne12 / ne02), (uint32_t)ne12,
         0, 0,
-        nb03, nb13, nb23, fusion_flags
+        nb03, nb13, nb23, fusion_flags, 0
     };
+
+    uint32_t workgroups_z = (uint32_t)ne12;
+    // When gqa_ratio > 1, each workgroup does gqa_ratio channels and we can launch fewer workgroups
+    if (gqa_ratio > 1) {
+        workgroups_z /= gqa_ratio;
+    }
+
+    // ne01 (the row count — n_kv for attention K·Q) can exceed the device's
+    // max workgroup count in y; chunk the dispatch with a row_base offset.
+    const uint32_t max_wg_y = ggml_vk_max_wg_y(ctx);
 
     init_pushconst_tensor_offsets(ctx, pc, src0, src1, nullptr, nullptr, cgraph->nodes[node_idx + ctx->num_additional_fused_ops]);
 
-    ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
-        {
-            d_Qx,
-            d_Qy,
-            d_D,
-            d_F0,
-            d_F1,
-        }, pc, { (uint32_t)ne03, (uint32_t)ne01, (uint32_t)ne12 });
+    for (uint32_t row0 = 0; row0 < (uint32_t)ne01; row0 += max_wg_y) {
+        const uint32_t chunk_rows = std::min(max_wg_y, (uint32_t)ne01 - row0);
+        pc.row_base = row0;
+        ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
+            {
+                d_Qx,
+                d_Qy,
+                d_D,
+                d_F0,
+                d_F1,
+            }, pc, { (uint32_t)ne03, chunk_rows, workgroups_z });
+    }
 }
 
 static int ggml_vk_fwht_pipeline_idx(int64_t n) {
@@ -9852,13 +9899,17 @@ static void ggml_vk_mul_mat(ggml_backend_vk_context * ctx, vk_context& subctx, c
         src1->nb[1] <= src1->nb[3] &&
         src0->ne[3] == 1 &&
         src1->ne[3] == 1 &&
-        src0->ne[1] <= ctx->device->properties.limits.maxComputeWorkGroupCount[1] &&
+        // no ne[1] (row count) limit: the dispatch is chunked over rows, so
+        // large-context attention (n_kv > maxComputeWorkGroupCount[1]) stays
+        // on this GQA-aware path instead of the generic mat-vec
         src1->ne[2] <= ctx->device->properties.limits.maxComputeWorkGroupCount[2]) {
         ggml_vk_mul_mat_vec_p021_f16_f32(ctx, subctx, cgraph, node_idx);
     } else if (src0->type == GGML_TYPE_F16 && !ggml_is_contiguous(src0) && !ggml_is_transposed(src1) && dst->ne[1] == 1 &&
                !ggml_is_permuted(src0) && !ggml_is_permuted(src1) &&
                src0->ne[3] <= ctx->device->properties.limits.maxComputeWorkGroupCount[0] &&
-               src0->ne[1] <= ctx->device->properties.limits.maxComputeWorkGroupCount[1] &&
+               // no ne[1] (row count) limit: the dispatch is chunked over rows,
+               // so large-context attention (n_kv > maxComputeWorkGroupCount[1])
+               // stays on this path instead of the generic mat-vec
                src1->ne[2] <= ctx->device->properties.limits.maxComputeWorkGroupCount[2]) {
         ggml_vk_mul_mat_vec_nc_f16_f32(ctx, subctx, cgraph, node_idx);
     // mul_mat_vec supports batching ne12*ne13 when ne11==1, or treating ne11 as the batch size (up to four)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_nc.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_nc.comp
@@ -3,12 +3,18 @@
 #extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
 
-#define BLOCK_SIZE 32
 #define FLOAT_TYPE float
 
-layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
 #include "mul_mat_vec_iface.glsl"
+
+layout(constant_id = 0) const int BLOCK_SIZE = 32;
+// gqa_ratio is in the range [1,8]. When > 1, each workgroup loads rows of A
+// (the K cache in attention) once and dots them against gqa_ratio B channels
+// (the query heads sharing that KV head), avoiding gqa_ratio-times redundant
+// reads of A. Mirrors the same optimization in mul_mat_vec_p021.comp.
+layout(constant_id = 1) const uint gqa_ratio = 1;
 
 layout (push_constant) uniform parameter
 {
@@ -25,100 +31,113 @@ layout (push_constant) uniform parameter
     uint nb13;
     uint nb23;
     uint fusion_flags;
+    uint row_base;
 } p;
 
-shared FLOAT_TYPE tmp[BLOCK_SIZE];
+shared FLOAT_TYPE tmp[8][BLOCK_SIZE];
 
 void main() {
     const uint tid       = gl_LocalInvocationID.x;
-    const uint row_x     = gl_GlobalInvocationID.y;
-    const uint channel   = gl_GlobalInvocationID.z;
+    // row_base supports dispatches chunked over rows when the row count
+    // exceeds the device's max workgroup count in y (large n_kv).
+    const uint row_x     = p.row_base + gl_GlobalInvocationID.y;
     const uint i3        = gl_WorkGroupID.x;
-    const uint channel_x = channel / p.channel_x_divisor;
-    const uint channel_y = channel % p.ne12;
+
+    uint channel, channel_x;
+    // When gqa_ratio > 1, each workgroup handles one channel of A
+    // (channel_x) and the gqa_ratio channels of B that map onto it:
+    // [channel, channel + gqa_ratio).
+    if (gqa_ratio > 1) {
+        channel_x = gl_GlobalInvocationID.z;
+        channel   = channel_x * gqa_ratio;
+    } else {
+        channel   = gl_GlobalInvocationID.z;
+        channel_x = channel / p.channel_x_divisor;
+    }
 
     const uint nrows_y   = p.ncols_x;
     const uint nrows_dst = p.nrows_x;
     const uint row_dst   = row_x;
 
-    const uint idst = i3*p.nb23 + channel*nrows_dst + row_dst;
+    // Per-channel base offsets, hoisted out of the reduction loop. All
+    // channel indexing (including the gqa==1 modulo) happens exactly once.
+    uint ybase[8];
+    uint dbase[8];
+    [[unroll]] for (uint c = 0; c < gqa_ratio; ++c) {
+        const uint channel_y = (gqa_ratio > 1) ? (channel + c) : (channel % p.ne12);
+        ybase[c] = i3*p.nb13 + channel_y*p.channel_stride_y;
+        dbase[c] = i3*p.nb23 + channel_y*nrows_dst;
+    }
+    const uint xbase = i3*p.nb03 + channel_x*p.channel_stride_x + row_x*p.row_stride_x;
 
-    FLOAT_TYPE temp = 0.0f;
+    FLOAT_TYPE temp[8];
+    [[unroll]] for (uint c = 0; c < 8; ++c) {
+        temp[c] = FLOAT_TYPE(0.0f);
+    }
 
     // Detect alignment for vector loads
-    bool is_aligned = (p.ncols_x % 4) == 0 && (p.row_stride_x % 4) == 0 && (p.channel_stride_x % 4) == 0;
+    bool is_aligned = (p.ncols_x % 4) == 0 && (p.row_stride_x % 4) == 0 && (p.channel_stride_x % 4) == 0 && (p.channel_stride_y % 4) == 0;
 
     for (uint col_x0 = 0; col_x0 < p.ncols_x;) {
 
-        // Unroll 2x and do vec4 loads if aligned
-        const uint unroll_count = 2;
+        // For gqa_ratio == 1, unroll 2x as before. For gqa_ratio > 1 the
+        // per-iteration work is already gqa_ratio dots; skip the extra
+        // unroll to keep register pressure sane.
+        const uint unroll_count = (gqa_ratio > 1) ? 1 : 2;
         if (col_x0 + unroll_count * 4 * BLOCK_SIZE <= p.ncols_x && is_aligned) {
             [[unroll]] for (uint i = 0; i < unroll_count; ++i) {
                 const uint col_x = col_x0 + 4*tid;
 
-                const uint row_y = col_x;
+                const vec4 av4 = vec4(data_a_v4[(xbase + col_x) / 4]);
 
-                const uint ix = i3*p.nb03 + channel_x*p.channel_stride_x + row_x*p.row_stride_x + col_x;
-                const uint iy = i3*p.nb13 + channel_y*p.channel_stride_y + row_y;
-
-                const vec4 av4 = vec4(data_a_v4[ix / 4]);
-                const vec4 bv4 = vec4(data_b_v4[iy / 4]);
-
-                temp += dot(av4, bv4);
+                [[unroll]] for (uint c = 0; c < gqa_ratio; ++c) {
+                    const vec4 bv4 = vec4(data_b_v4[(ybase[c] + col_x) / 4]);
+                    temp[c] += dot(av4, bv4);
+                }
 
                 col_x0 += 4*BLOCK_SIZE;
             }
-        // do vec4 loads if aligned
-        } else if (col_x0 + 4*BLOCK_SIZE <= p.ncols_x && is_aligned) {
-            const uint col_x = col_x0 + 4*tid;
-
-            const uint row_y = col_x;
-
-            const uint ix = i3*p.nb03 + channel_x*p.channel_stride_x + row_x*p.row_stride_x + col_x;
-            const uint iy = i3*p.nb13 + channel_y*p.channel_stride_y + row_y;
-
-            const vec4 av4 = vec4(data_a_v4[ix / 4]);
-            const vec4 bv4 = vec4(data_b_v4[iy / 4]);
-
-            temp += dot(av4, bv4);
-
-            col_x0 += 4*BLOCK_SIZE;
         } else {
             const uint col_x = col_x0 + tid;
             if (col_x >= p.ncols_x) {
                 break;
             }
 
-            const uint row_y = col_x;
+            const FLOAT_TYPE xi = FLOAT_TYPE(data_a[xbase + col_x]);
 
-            const uint ix = i3*p.nb03 + channel_x*p.channel_stride_x + row_x*p.row_stride_x + col_x;
-            const uint iy = i3*p.nb13 + channel_y*p.channel_stride_y + row_y;
-
-            const FLOAT_TYPE xi = FLOAT_TYPE(data_a[ix]);
-
-            temp = fma(xi, FLOAT_TYPE(data_b[iy]), temp);
+            [[unroll]] for (uint c = 0; c < gqa_ratio; ++c) {
+                temp[c] = fma(xi, FLOAT_TYPE(data_b[ybase[c] + col_x]), temp[c]);
+            }
             col_x0 += BLOCK_SIZE;
         }
     }
 
-    tmp[tid] = temp;
+    [[unroll]] for (uint c = 0; c < gqa_ratio; ++c) {
+        tmp[c][tid] = temp[c];
+    }
 
     // sum up partial sums and write back result
     barrier();
     [[unroll]] for (int s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
         if (tid < s) {
-            tmp[tid] += tmp[tid + s];
+            [[unroll]] for (uint c = 0; c < gqa_ratio; ++c) {
+                tmp[c][tid] += tmp[c][tid + s];
+            }
         }
         barrier();
     }
 
     if (tid == 0) {
-        if ((p.fusion_flags & MAT_VEC_FUSION_FLAGS_BIAS0) != 0) {
-            tmp[0] += FLOAT_TYPE(data_fuse0[idst]);
+        [[unroll]] for (uint c = 0; c < gqa_ratio; ++c) {
+            const uint idst = dbase[c] + row_dst;
+            FLOAT_TYPE result = tmp[c][0];
+            if ((p.fusion_flags & MAT_VEC_FUSION_FLAGS_BIAS0) != 0) {
+                result += FLOAT_TYPE(data_fuse0[idst]);
+            }
+            if ((p.fusion_flags & MAT_VEC_FUSION_FLAGS_BIAS1) != 0) {
+                result += FLOAT_TYPE(data_fuse1[idst]);
+            }
+            data_d[idst] = result;
         }
-        if ((p.fusion_flags & MAT_VEC_FUSION_FLAGS_BIAS1) != 0) {
-            tmp[0] += FLOAT_TYPE(data_fuse1[idst]);
-        }
-        data_d[idst] = tmp[0];
     }
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_p021.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_p021.comp
@@ -25,6 +25,7 @@ layout (push_constant) uniform parameter
     uint b_offset;
     uint d_offset;
     uint fusion_flags;
+    uint row_base;
 } p;
 
 #if !USE_SUBGROUP_ADD
@@ -33,7 +34,9 @@ shared FLOAT_TYPE tmp[8][BLOCK_SIZE];
 
 void main() {
     const uint tid = gl_LocalInvocationID.x;
-    const uint row_x = gl_GlobalInvocationID.y;
+    // row_base supports dispatches chunked over rows when the row count
+    // exceeds the device's max workgroup count in y (large n_kv).
+    const uint row_x = p.row_base + gl_GlobalInvocationID.y;
 
     uint channel, channel_x;
 


### PR DESCRIPTION
Addresses the main finding of #26581.

## Problem

The specialized f16 mat-vec paths used by attention decode
(`ggml_vk_mul_mat_vec_p021_f16_f32` / `ggml_vk_mul_mat_vec_nc_f16_f32`) are
gated on `src0->ne[1] <= maxComputeWorkGroupCount[1]`, which is 65,535 on
Mesa/ANV (and the spec minimum). For the K·Q op `ne[1]` is n_kv, so **past
~64k context the op silently falls back to the generic mat-vec path, which
has no GQA load sharing**: it re-reads the K cache once per query head. With
a 16Q:2KV model that is 8× the necessary DRAM traffic.

Measured on Intel Arc Pro B70 (Battlemage, 32 GB) with Qwen3.6-35B-A3B
Q4_K_M: the K·Q kernel below the gate runs at 1,905 GFLOPS (p021, GQA-shared);
above the gate it drops to 424 GFLOPS — exactly DRAM bandwidth saturated with
gqa_ratio-redundant reads. Decode collapses from its ~50 t/s trend to 20 t/s
at 127k context. This gate is also why the depth cliff lands abruptly between
32k and 64k for every GQA model we tested (Qwen3 MoE, Qwen3.6 hybrid, Gemma 4).

## Changes

- Dispatch p021/nc in row chunks of `maxComputeWorkGroupCount[1]` using a new
  `row_base` push constant, and drop the `ne[1]` eligibility gates — large
  n_kv stays on the specialized GQA-aware path.
- Port the `gqa_ratio` specialization that p021 already had to the nc shader
  (one workgroup loads each A row once and dots it against the whole query
  group). Non-GQA dispatches compile to the same code as before
  (`gqa_ratio = 1` spec constant).
- `GGML_VK_MAX_WG_Y_DEBUG` env var forces a small chunk size so the chunked
  path can be exercised by tests below the real device limit.

## Performance (Arc Pro B70, Qwen3.6-35B-A3B Q4_K_M, tg256, fa off, ub 512)

| | d0 | d32768 | d65536 | d126976 |
|---|---|---|---|---|
| master (measured at b10235) | 70.7 | 58.4 | 32.2 | 20.7 |
| this PR | 70.2 | 58.3 | **49.0** | **37.0** |

K·Q op time at 65k context: 1269 µs → 254 µs (5.0×). d0/d32k unchanged
(within single-rep variance).

## Correctness

- `test-backend-ops -o MUL_MAT` on ANV/Battlemage: no new failures vs master
  (the two pre-existing `per=[0,2,1,3]` f32 tolerance failures are unchanged).
- With `GGML_VK_MAX_WG_Y_DEBUG=7`, the existing permuted MUL_MAT cases run
  multi-chunk and pass.
- Temperature-0 generations are token-identical to master, including
  70k-token prompts that cross the 65,535-row chunk boundary.

## Environment

Mesa 26.1.6 (ANV, KHR_coopmat), kernel 6.17/xe, Arc Pro B70 32 GB via VFIO
passthrough. Happy to run additional benchmarks or tests on this hardware.

Disclosure: this fix was diagnosed and developed with AI assistance
(Claude); all measurements were taken on real hardware and the patch was
validated as described above.
