### PR TITLE
CUDA: add f16 support for OUT_PROD

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4846,7 +4846,9 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                 }
             } break;
         case GGML_OP_OUT_PROD:
-            return op->type == GGML_TYPE_F32 && op->src[0]->type == GGML_TYPE_F32 && op->src[1]->type == GGML_TYPE_F32;
+            return op->type == GGML_TYPE_F32 &&
+                (op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16) &&
+                op->src[1]->type == GGML_TYPE_F32;
         case GGML_OP_GET_ROWS:
             {
                 switch (op->src[0]->type) {

--- a/ggml/src/ggml-cuda/out-prod.cu
+++ b/ggml/src/ggml-cuda/out-prod.cu
@@ -1,4 +1,5 @@
 #include "out-prod.cuh"
+#include "convert.cuh"
 
 #include <cstdint>
 
@@ -30,7 +31,7 @@ void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
-    GGML_ASSERT(src0->type == GGML_TYPE_F32);
+    GGML_ASSERT(src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16);
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
     GGML_ASSERT(dst->type  == GGML_TYPE_F32);
 
@@ -44,9 +45,7 @@ void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT(ne2 == src1->ne[2]);
     GGML_ASSERT(ne3 == src1->ne[3]);
 
-    const float * src0_d = (const float *) src0->data;
-    const float * src1_d = (const float *) src1->data;
-    float       *  dst_d = (float       *)  dst->data;
+    float * dst_d = (float *) dst->data;
 
     cudaStream_t   stream = ctx.stream();
     cublasHandle_t handle = ctx.cublas_handle();
@@ -56,8 +55,38 @@ void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     CUBLAS_CHECK(cublasSetStream(handle, stream));
 
-    const int64_t lda = nb01 / sizeof(float);
-    const int64_t ldc = nb1  / sizeof(float);
+    // the GEMMs below are F32-only, so an F16 src0 is first converted into a
+    // contiguous F32 scratch buffer and its strides recomputed accordingly
+    ggml_cuda_pool_alloc<float> src0_f32(ctx.pool());
+
+    const float * src0_d;
+    int64_t       lda;
+    size_t        s02;
+    size_t        s03;
+
+    if (src0->type == GGML_TYPE_F16) {
+        const size_t ts0 = ggml_type_size(src0->type);
+        GGML_ASSERT(nb00 == ts0);
+
+        src0_d = src0_f32.alloc(ggml_nelements(src0));
+        ggml_get_to_fp32_nc_cuda(src0->type)(
+            src0->data, src0_f32.get(), ne00, ne01, ne02, ne03,
+            nb01/ts0, nb02/ts0, nb03/ts0, stream);
+
+        lda = ne00;
+        s02 = ne00*ne01;
+        s03 = ne00*ne01*ne02;
+    } else {
+        src0_d = (const float *) src0->data;
+
+        lda = nb01 / sizeof(float);
+        s02 = nb02 / sizeof(float);
+        s03 = nb03 / sizeof(float);
+    }
+
+    const float * src1_d = (const float *) src1->data;
+
+    const int64_t ldc = nb1 / sizeof(float);
 
     const bool src1_T = ggml_is_transposed(src1);
     const cublasOperation_t src1_cublas_op =  src1_T ? CUBLAS_OP_N : CUBLAS_OP_T;
@@ -65,8 +94,6 @@ void ggml_cuda_out_prod(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT(                             (src1_T ?        nb11 :        nb10) == sizeof(float));
 
     // data strides in dimensions 2/3
-    const size_t s02 = nb02 / sizeof(float);
-    const size_t s03 = nb03 / sizeof(float);
     const size_t s12 = nb12 / sizeof(float);
     const size_t s13 = nb13 / sizeof(float);
     const size_t s2  = nb2  / sizeof(float);


### PR DESCRIPTION
CUDA's OUT_PROD op didn't support f16 inputs before, it would fall back to CPU. This PR adds f16 support by converting to f32 on-device before running the existing f32 implementation, so it stays on GPU instead of falling back. This only applies to src0; src1 stays f32, matching ggml_compute_forward_out_prod_f16_f32 on the CPU.

Testing

test-backend-ops -o OUT_PROD -b CUDA0: 87/87 passed
Full backend suite: 13,010/13,010 passed, no regressions
OUT_PROD support matrix went from 71 → 135 of 1415 cases
Didn't need new tests since base_types already covers GGML_TYPE_F16

Notes

Didn't regenerate docs/ops.md, that would touch 1,467 unrelated rows for only 64 actually-relevant changes
#14909

AI usage disclosure: Used Claude Opus for implementation help. I reviewed, tested, and integrated the changes myself.