### PR TITLE
Prefer npm ci over install for security

### DIFF
--- a/scripts/ui-assets.cmake
+++ b/scripts/ui-assets.cmake
@@ -123,15 +123,15 @@ function(npm_build out_var)
     endif()
 
     if(need_install)
-        message(STATUS "UI: running npm install")
+        message(STATUS "UI: running npm ci")
         execute_process(
-            COMMAND ${NPM_EXECUTABLE} install
+            COMMAND ${NPM_EXECUTABLE} ci
             WORKING_DIRECTORY "${WORK_DIR}"
             RESULT_VARIABLE rc
             ERROR_VARIABLE  err
         )
         if(NOT rc EQUAL 0)
-            message(STATUS "UI: npm install failed (${rc})")
+            message(STATUS "UI: npm ci failed (${rc})")
             message(STATUS "  stderr: ${err}")
             return()
         endif()

--- a/tools/ui/README.md
+++ b/tools/ui/README.md
@@ -89,7 +89,7 @@ Llama UI supports two server operation modes:
 
 ```bash
 cd tools/ui
-npm install
+npm ci
 ```
 
 ### 2. Start llama-server

--- a/tools/ui/scripts/dev.sh
+++ b/tools/ui/scripts/dev.sh
@@ -14,7 +14,7 @@ cd ../../
 # Ensure node_modules are installed
 if [ ! -d "tools/ui/node_modules" ]; then
     echo "📦 Installing npm dependencies..."
-    cd tools/ui && npm install && cd ../../
+    cd tools/ui && npm ci && cd ../../
 fi
 
 # Check and install git hooks if missing

--- a/tools/ui/scripts/git-hooks/pre-commit.sh
+++ b/tools/ui/scripts/git-hooks/pre-commit.sh
@@ -14,7 +14,7 @@ cd "$REPO_ROOT/tools/ui"
 
 # Check that node_modules exists
 if [ ! -d "node_modules" ]; then
-    echo "❌ node_modules not found. Run 'npm install' first."
+    echo "❌ node_modules not found. Run 'npm ci' first."
     exit 1
 fi
 

--- a/tools/ui/scripts/git-hooks/pre-push.sh
+++ b/tools/ui/scripts/git-hooks/pre-push.sh
@@ -30,7 +30,7 @@ cd "$REPO_ROOT/tools/ui"
 
 # Check that node_modules exists
 if [ ! -d "node_modules" ]; then
-    echo "❌ node_modules not found. Run 'npm install' first."
+    echo "❌ node_modules not found. Run 'npm ci' first."
     exit 1
 fi
 


### PR DESCRIPTION
## Overview

Replace `npm install` in the UI build with `npm ci`. This greatly improves the security of the build against npm supply-chain attacks, which have been [very serious lately](https://research.jfrog.com/post/shai-hulud-is-back-august/).

## Additional information

The full differences are listed at https://docs.npmjs.com/cli/v12/commands/npm-ci but the tl;dr is:
- `npm ci` is guaranteed to respect the versions and package hashes in the lockfile
- `npm install` is not

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: no AI used