### PR TITLE
grammar : cap parser nesting and rule-chain depth to prevent stack exhaustion

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -11,6 +11,11 @@
 #include <stdexcept>
 
 #define MAX_REPETITION_THRESHOLD 2000
+// max nesting of (...) groups and rule-ref chain depth accepted by the grammar
+// parser/validator - guards against stack exhaustion (SIGSEGV) from
+// pathological grammars (e.g. via llama-server /completion "grammar" param)
+#define LLAMA_GRAMMAR_MAX_NESTING 1000
+#define LLAMA_GRAMMAR_MAX_RULE_DEPTH 1000
 //
 // helpers
 //
@@ -590,11 +595,15 @@ const char * llama_grammar_parser::parse_sequence(
             n_prev_rules = 1;
             rule.push_back({LLAMA_GRETYPE_RULE_REF, ref_rule_id});
         } else if (*pos == '(') { // grouping
+            if (++parse_depth > LLAMA_GRAMMAR_MAX_NESTING) {
+                throw std::runtime_error("grammar nesting too deep");
+            }
             // parse nested alternates into synthesized rule
             pos = parse_space(pos + 1, true);
             uint32_t n_rules_before = symbol_ids.size();
             uint32_t sub_rule_id = generate_symbol_id(rule_name);
             pos = parse_alternates(pos, rule_name, sub_rule_id, true);
+            parse_depth--;
             n_prev_rules = std::max(1u, (uint32_t)symbol_ids.size() - n_rules_before);
             last_sym_start = rule.size();
             // output reference to synthesized rule
@@ -957,7 +966,12 @@ static bool llama_grammar_detect_left_recursion(
         size_t rule_index,
         std::vector<bool> * rules_visited,
         std::vector<bool> * rules_in_progress,
-        std::vector<bool> * rules_may_be_empty) {
+        std::vector<bool> * rules_may_be_empty,
+        size_t depth = 0) {
+    if (depth > LLAMA_GRAMMAR_MAX_RULE_DEPTH) {
+        LLAMA_LOG_ERROR("%s: grammar rule chain too deep (> %d), rejecting\n", __func__, (int)LLAMA_GRAMMAR_MAX_RULE_DEPTH);
+        return true;
+    }
     if ((*rules_in_progress)[rule_index]) {
         return true;
     }
@@ -986,7 +1000,7 @@ static bool llama_grammar_detect_left_recursion(
     bool recurse_into_nonterminal = true;
     for (size_t i = 0; i < rule.size(); i++) {
         if (rule[i].type == LLAMA_GRETYPE_RULE_REF && recurse_into_nonterminal) {
-            if (llama_grammar_detect_left_recursion(rules, (size_t)rule[i].value, rules_visited, rules_in_progress, rules_may_be_empty)) {
+            if (llama_grammar_detect_left_recursion(rules, (size_t)rule[i].value, rules_visited, rules_in_progress, rules_may_be_empty, depth + 1)) {
                 return true;
             }
             if (!((*rules_may_be_empty)[(size_t)rule[i].value])) {

--- a/src/llama-grammar.h
+++ b/src/llama-grammar.h
@@ -88,6 +88,7 @@ struct llama_grammar_parser {
     std::map<std::string, uint32_t> symbol_ids;
 
     llama_grammar_rules rules;
+    uint32_t parse_depth = 0; // current (...) nesting depth, capped by LLAMA_GRAMMAR_MAX_NESTING
 
     llama_grammar_parser(const struct llama_vocab * vocab = nullptr) : vocab(vocab) {}
 

--- a/tests/test-grammar-parser.cpp
+++ b/tests/test-grammar-parser.cpp
@@ -141,6 +141,15 @@ static void verify_failure(const char * grammar_bytes) {
 
 int main()
 {
+    // regression: deeply nested (...) groups must be rejected cleanly,
+    // not crash the parser with a stack overflow
+    {
+        std::string deep = "root ::= ";
+        for (int i = 0; i < 60000; i++) { deep += "("; }
+        deep += "\"a\"";
+        for (int i = 0; i < 60000; i++) { deep += ")"; }
+        verify_failure(deep.c_str());
+    }
     verify_failure(R"""(
         root ::= "a"{,}"
     )""");


### PR DESCRIPTION
## Overview

A pathological GBNF grammar crashes any llama.cpp process that parses it — including llama-server, where a single unauthenticated POST to /completion with ~60k nested groups (~120 KB payload) kills the process (SIGSEGV, stack exhaustion). Reproduced on a vanilla RelWithDebInfo build, no sanitizers. Fixes #26600.

Two unbounded recursion sites in src/llama-grammar.cpp, both missed by 990e4d969 (which covered the advance-stack recursion and {m,n} blowup):

1. parse_sequence → parse_alternates → parse_sequence recurses once per '(' with no depth counter
2. llama_grammar_detect_left_recursion recurses through rule-reference chains with no cap (MAX_REPETITION_THRESHOLD only gates {m,n})

The fix adds a nesting counter (LLAMA_GRAMMAR_MAX_NESTING = 1000, throw → parse() catches → clean rejection) and a rule-chain depth cap (LLAMA_GRAMMAR_MAX_RULE_DEPTH = 1000, reject). 1000 is far above any legitimate grammar depth (JSON-schema conversion nesting is bounded by the JSON parser's own depth limit).

## Additional information

Verified end-to-end on llama-server (master @ a6aa6f5):
- 60k-nesting payload, unpatched: process dies, SIGSEGV (rc 139)
- same payload, patched: HTTP 400, log 'error parsing grammar: grammar nesting too deep', server stays up
- 5000-rule chain (r0 ::= r1, r1 ::= r2, ...), patched: HTTP 400 'rule chain too deep', server stays up
- valid grammar (root ::= [0-9]+) still constrains output normally

Regression test added to tests/test-grammar-parser.cpp (60k-nested-group grammar): segfaults (rc 139) without this change, passes with it. test-llama-grammar and test-grammar-integration also pass. Note: test-json-schema-to-grammar fails identically on unpatched master (integer/minimum case) — pre-existing and unrelated to this change.

Related: #24144 (documents the intended 400-on-bad-grammar contract this fix restores for the crash case).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI-assisted pattern audit and patch drafting; every line manually reviewed, and all tests/reproductions run and verified by me before submitting