### PR TITLE
llama: add forward-telescoping rollback engine for recurrent models (prep for #22746)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(llama
             llama-memory-hybrid.cpp
             llama-memory-hybrid-iswa.cpp
             llama-memory-recurrent.cpp
+            llama-rollback-telescope.cpp
             llama-mmap.cpp
             llama-model-loader.cpp
             llama-model-saver.cpp

--- a/src/llama-rollback-telescope.cpp
+++ b/src/llama-rollback-telescope.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Song Wei
+// SPDX-License-Identifier: MIT
+//
+// CPU reference implementation of the forward-telescoping rollback engine.
+// See llama-rollback-telescope.h for the design contract.
+
+#include "llama-rollback-telescope.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace llama {
+
+static constexpr uint32_t META_INVALID_POS = 0xFFFFFFFFu;
+
+telescope_rollback::telescope_rollback(const telescope_config & cfg) : cfg_(cfg) {
+    const uint32_t ring = std::max(cfg_.ring_cap, 1u);
+    const uint32_t sl   = std::max(cfg_.slots, 1u);
+    const size_t per_token =
+        (size_t) cfg_.L_meta * cfg_.H * (2 * cfg_.d + 2);
+    meta_ring_.assign((size_t) ring * per_token, 0.0f);
+    meta_pos_.assign(ring, META_INVALID_POS);
+    anchor_ring_.assign((size_t) sl * cfg_.L * cfg_.H * cfg_.d * cfg_.d, 0.0f);
+    anchor_pos_.assign(sl, META_INVALID_POS);
+    anchor_valid_.assign(sl, false);
+}
+
+void telescope_rollback::capture(uint32_t pos, const float * k, const float * v,
+                                 const float * beta, const float * gate) {
+    const uint32_t slot = pos % cfg_.ring_cap;
+    const size_t per_token = (size_t) cfg_.L_meta * cfg_.H * (2 * cfg_.d + 2);
+    float * dst = meta_ring_.data() + (size_t) slot * per_token;
+    // layout per (layer, head): k[d] v[d] beta gamma
+    for (uint32_t l = 0; l < cfg_.L_meta; ++l) {
+        const float * kl = k + (size_t) l * cfg_.H * cfg_.d;
+        const float * vl = v + (size_t) l * cfg_.H * cfg_.d;
+        const float * bl = beta + (size_t) l * cfg_.H;
+        const float * gl = gate + (size_t) l * cfg_.H;
+        for (uint32_t h = 0; h < cfg_.H; ++h) {
+            float * dk = dst + (size_t) l * cfg_.H * (2 * cfg_.d + 2) + h * (2 * cfg_.d + 2);
+            memcpy(dk, kl + (size_t) h * cfg_.d, cfg_.d * sizeof(float));
+            memcpy(dk + cfg_.d, vl + (size_t) h * cfg_.d, cfg_.d * sizeof(float));
+            dk[2 * cfg_.d]     = bl[h];
+            dk[2 * cfg_.d + 1] = gl[h];
+        }
+    }
+    meta_pos_[slot] = pos;
+}
+
+void telescope_rollback::place_anchor(uint32_t pos, const float * S) {
+    // find the slot for pos (pos % (window*slots) would be the natural index;
+    // we keep it simple: rotate over slots by absolute position)
+    const uint32_t slot = (pos / std::max(cfg_.window, 1u)) % cfg_.slots;
+    const size_t n = (size_t) cfg_.L * cfg_.H * cfg_.d * cfg_.d;
+    memcpy(anchor_ring_.data() + (size_t) slot * n, S, n * sizeof(float));
+    anchor_pos_[slot]   = pos;
+    anchor_valid_[slot] = true;
+}
+
+uint32_t telescope_rollback::locate_anchor(uint32_t p0) const {
+    uint32_t best = META_INVALID_POS;
+    for (uint32_t s = 0; s < cfg_.slots; ++s) {
+        if (anchor_valid_[s] && anchor_pos_[s] <= p0) {
+            if (best == META_INVALID_POS || anchor_pos_[s] > best) {
+                best = anchor_pos_[s];
+            }
+        }
+    }
+    return best;
+}
+
+bool telescope_rollback::resident(uint32_t a, uint32_t p0) const {
+    if (a == META_INVALID_POS || p0 <= a) return false;
+    const uint32_t dist = p0 - a;
+    if (dist > cfg_.window) return false;
+    // every position in (a, p0] must be present in the metadata ring
+    for (uint32_t pos = a + 1; pos <= p0; ++pos) {
+        const uint32_t slot = pos % cfg_.ring_cap;
+        if (meta_pos_[slot] != pos) return false;
+    }
+    return true;
+}
+
+void telescope_rollback::fwd_telescope_execute(uint32_t a, uint32_t p0, float * S_out) const {
+    // load anchor state
+    const uint32_t aslot = (a / std::max(cfg_.window, 1u)) % cfg_.slots;
+    const size_t n_state = (size_t) cfg_.L * cfg_.H * cfg_.d * cfg_.d;
+    const float * Sa = anchor_ring_.data() + (size_t) aslot * n_state;
+    memcpy(S_out, Sa, n_state * sizeof(float));
+
+    const uint32_t dist = (p0 > a + 1) ? (p0 - a - 1) : 0;  // replay (a, p0): S_after_{p0-1} per seq_rm semantics
+    const size_t per_token = (size_t) cfg_.L_meta * cfg_.H * (2 * cfg_.d + 2);
+
+    // replay (a, p0]: S <- gamma*S - beta*k*(k^T S) + beta*k*v^T
+    // layers are independent -> parallelize over layers
+    #pragma omp parallel for collapse(1) schedule(static)
+    for (int64_t li = 0; li < (int64_t) cfg_.L_meta; ++li) {
+        const uint32_t l = (uint32_t) li;
+        for (uint32_t h = 0; h < cfg_.H; ++h) {
+            float * S_lh = S_out + ((size_t) l * cfg_.H + h) * cfg_.d * cfg_.d;
+            for (uint32_t t = 0; t < dist; ++t) {
+                const uint32_t slot = (a + 1 + t) % cfg_.ring_cap;
+                const float * m = meta_ring_.data() + (size_t) slot * per_token
+                                + (size_t) l * cfg_.H * (2 * cfg_.d + 2) + h * (2 * cfg_.d + 2);
+                const float * k = m;
+                const float * v = m + cfg_.d;
+                const float  b  = m[2 * cfg_.d];
+                const float  g  = m[2 * cfg_.d + 1]; // gamma multiplier (already exp(gate logit))
+                // w = k^T S  (d x d matrix-vector per head)
+                for (uint32_t c = 0; c < cfg_.d; ++c) {
+                    double w = 0.0;
+                    const float * kk = k;
+                    const float * Sc = S_lh + c;
+                    for (uint32_t r = 0; r < cfg_.d; ++r) {
+                        w += (double) kk[r] * (double) Sc[(size_t) r * cfg_.d];
+                    }
+                    // S[.,c] <- g*S[.,c] - b*k*w + b*k*v[c]
+                    const double bv = (double) b * (double) v[c];
+                    const double bw = (double) b * w;
+                    for (uint32_t r = 0; r < cfg_.d; ++r) {
+                        const double kr = (double) kk[r];
+                        S_lh[(size_t) r * cfg_.d + c] = (float) ((double) g * (double) S_lh[(size_t) r * cfg_.d + c]
+                            - bw * kr + bv * kr);
+                    }
+                }
+            }
+        }
+    }
+}
+
+rollback_result telescope_rollback::rollback(uint32_t p0, float * S_out) {
+    rollback_result res;
+    const uint32_t a = locate_anchor(p0);
+    if (a == META_INVALID_POS || !resident(a, p0)) {
+        // explicit fallback: caller performs full recompute
+        ++fallback_count_;
+        res.fallback_count = fallback_count_;
+        return res;
+    }
+    fwd_telescope_execute(a, p0, S_out);
+    res.ok     = true;
+    res.anchor = a;
+    res.fallback_count = fallback_count_;
+    return res;
+}
+
+size_t telescope_rollback::resident_bytes() const {
+    const size_t per_token = (size_t) cfg_.L_meta * cfg_.H * (2 * cfg_.d + 2);
+    const size_t ring = meta_ring_.size() * sizeof(float);
+    const size_t anchor = anchor_ring_.size() * sizeof(float);
+    return ring + anchor;
+}
+
+} // namespace llama

--- a/src/llama-rollback-telescope.h
+++ b/src/llama-rollback-telescope.h
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Song Wei
+// SPDX-License-Identifier: MIT
+//
+// Forward-telescoping rollback for recurrent (Gated DeltaNet) models.
+//
+// A partial rollback (`seq_rm(p0)`) on a recurrent model normally forces a
+// full prompt re-evaluation, because the recurrent state depends on the whole
+// prefix. The forward-telescoping approach replaces "recompute everything"
+// with "replay the exact linear state map from the nearest anchor":
+//
+//     S_t = (gamma_t*I - beta_t*k_t*k_t^T) * S_{t-1} + beta_t * k_t * v_t^T
+//
+// which is the exact per-step recurrence (code-verified, see
+// delta-net-base.cpp) and requires no division, no gating scans and no layer
+// re-evaluation: k/v/beta/gamma are captured in a metadata ring during the
+// normal forward pass, and the state S is replayed forward from an fp32
+// anchor snapshot. Window error saturates at u/(1-gamma_bar) and is
+// independent of the total rollback depth (the heavy-tailed gate that would
+// amplify division-based inversion instead damps the forward product).
+//
+// ---------------------------------------------------------------------------
+// INTEGRATION GUIDE (this PR ships the engine + tests; wiring is a follow-up)
+// ---------------------------------------------------------------------------
+// The class is self-contained and CPU-first; the GPU kernel is a drop-in
+// replacement for `fwd_telescope_execute`. To wire it into llama.cpp:
+//
+// 1. CAPTURE HOOK (required): in `build_recurrent_attn`
+//    (src/models/qwen35.cpp / delta-net-base.cpp), after the conv projection
+//    and before the state update, capture (k, v, beta, gate_logit) per
+//    (layer, head) into the metadata ring. Gate semantics to verify first
+//    (P0 gate): `gamma = exp(gate_logit)` with gate_logit = softplus(x*W_a +
+//    dt)*A_log, gamma in (0,1]. Assert the operator identity with fp64
+//    (rel-err <= 1e-6) before enabling.
+//
+// 2. SEQ_RM BRANCH: in `llama_memory_recurrent::seq_rm`
+//    (src/llama-memory-recurrent.cpp), the partial-rollback path currently
+//    returns false when `rollback > n_rs_seq`. Add a telescope branch:
+//    if `rollback` is within `cfg.window` and the engine is enabled, call
+//    `rollback(p0, S_out)` and write S_out back into the s_l tensors for the
+//    sequence's tail cell; set cell.pos = p0-1. Otherwise keep the existing
+//    fallback (full recompute).
+//
+// 3. CLI: add `--rollback-window` / `--rollback-coverage` to llama-server /
+//    llama-cli (defaults 40 / 600), mapping to the telescope_config fields.
+//
+// 4. ACCEPTANCE: replay error <= 5e-4 on synthetic gates (const 0.9876,
+//    heavy-tailed, real 30-layer sample) for depths 64..118000; latency
+//    >= 90x vs full recompute on a real Gated DeltaNet model.
+// ---------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace llama {
+
+struct telescope_config {
+    uint32_t window   = 40;    // B: anchor spacing = max replay window (tokens)
+    uint32_t coverage = 600;   // R: anchor history horizon = slots * window
+    uint32_t slots    = 15;    // = ceil(R / B)
+    uint32_t L        = 0;     // total layers (GGUF-calibrated at runtime)
+    uint32_t L_meta   = 0;     // replay layers (GGUF-calibrated)
+    uint32_t H        = 0;     // value heads
+    uint32_t d        = 0;     // ssm_d_state
+    uint32_t ring_cap = 41;    // metadata ring = B + 1 (correction C1)
+    float    posterior_tol = 1e-3f;
+};
+
+struct rollback_result {
+    bool     ok = false;
+    uint32_t anchor = 0;
+    float    posterior_err = 0.0f;
+    uint64_t fallback_count = 0;
+};
+
+// Forward-telescoping rollback engine: metadata ring + anchor ring + replay.
+//
+// The class is deliberately self-contained and CPU-first (OpenMP-parallel
+// across layers); the GPU kernel is a drop-in replacement for
+// `fwd_telescope_execute` in a follow-up.
+class telescope_rollback {
+public:
+    explicit telescope_rollback(const telescope_config & cfg);
+
+    // Capture the per-token per-layer metadata (k/v/beta/gamma) for the
+    // metadata ring. `k`/`v` are [L_meta][H][d]; `beta`/`gamma` are [L_meta][H]
+    // with gamma being the per-step multiplier (already exp(gate logit)).
+    void capture(uint32_t pos, const float * k, const float * v,
+                 const float * beta, const float * gamma);
+
+    // Snapshot the full state S[L][H][d][d] at `pos` (every `window` tokens).
+    void place_anchor(uint32_t pos, const float * S);
+
+    // Roll back the recurrent state to position `p0` (exclusive). Writes the
+    // restored state into `S_out` (caller-owned [L][H][d][d]).
+    rollback_result rollback(uint32_t p0, float * S_out);
+
+    // True if the replay window (a, p0] is fully covered by the metadata ring.
+    bool resident(uint32_t a, uint32_t p0) const;
+
+    uint64_t fallback_count() const { return fallback_count_; }
+    size_t   resident_bytes() const;
+    const telescope_config & config() const { return cfg_; }
+
+private:
+    uint32_t locate_anchor(uint32_t p0) const;   // largest anchor pos <= p0
+    void fwd_telescope_execute(uint32_t a, uint32_t p0, float * S_out) const;
+
+    telescope_config cfg_;
+
+    // metadata ring: [ring_cap][L_meta][H][2d+2] fp32, absolute-position indexed
+    std::vector<float> meta_ring_;
+    std::vector<uint32_t> meta_pos_;   // absolute pos per ring slot (valid flag via sentinel)
+    // anchor ring: [slots][L][H][d][d] fp32
+    std::vector<float> anchor_ring_;
+    std::vector<uint32_t> anchor_pos_;
+    std::vector<bool>    anchor_valid_;
+
+    uint64_t fallback_count_ = 0;
+};
+
+} // namespace llama

--- a/tests/test_telescope.cpp
+++ b/tests/test_telescope.cpp
@@ -1,0 +1,117 @@
+// Standalone test: llama-rollback-telescope CPU reference vs independent replay.
+//
+// Build (Windows, nvcc as host compiler or any C++17 compiler):
+//   nvcc -O2 -std=c++17 -I src test_telescope.cpp src/llama-rollback-telescope.cpp
+// or with clang/g++:
+//   c++ -O2 -std=c++17 -I src -fopenmp test_telescope.cpp src/llama-rollback-telescope.cpp
+//
+// Verifies: (1) rollback succeeds within the window with zero fallbacks,
+// (2) the forward-telescoped state matches an independent replay of the exact
+// per-step map S <- gamma*S - beta*k*(k^T S) + beta*k*v^T (rel-err 0 in fp32).
+#include "llama-rollback-telescope.h"
+#include <cstdio>
+#include <cmath>
+#include <random>
+#include <vector>
+
+using namespace llama;
+
+static double rel_err(const std::vector<float> & a, const std::vector<float> & b) {
+    double na = 0, nb = 0, d = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        na += (double) a[i] * a[i];
+        nb += (double) b[i] * b[i];
+        d  += ((double) a[i] - b[i]) * ((double) a[i] - b[i]);
+    }
+    return std::sqrt(d / std::max(nb, 1e-30));
+}
+
+int main() {
+    const uint32_t L = 2, H = 4, d = 32;
+    const uint32_t window = 8, slots = 5, ring_cap = window + 1;
+    const uint32_t total = 24, p0 = 20;
+
+    telescope_config cfg;
+    cfg.window = window; cfg.coverage = window * slots; cfg.slots = slots;
+    cfg.L = L; cfg.L_meta = L; cfg.H = H; cfg.d = d; cfg.ring_cap = ring_cap;
+    telescope_rollback tel(cfg);
+
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> ud(0.0f, 1.0f);
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+
+    // initial state S0 (kept for independent reference)
+    std::vector<float> S0((size_t) L * H * d * d);
+    for (auto & x : S0) x = nd(rng) * 0.1f;
+
+    std::vector<std::vector<float>> k_hist(total), v_hist(total), b_hist(total), g_hist(total);
+
+    // forward pass with capture/anchor
+    std::vector<float> S = S0;
+    for (uint32_t t = 0; t < total; ++t) {
+        std::vector<float> k((size_t) L * H * d), v((size_t) L * H * d), b((size_t) L * H), g((size_t) L * H);
+        for (uint32_t l = 0; l < L; ++l) for (uint32_t h = 0; h < H; ++h) {
+            for (uint32_t c = 0; c < d; ++c) {
+                k[(size_t) l * H * d + h * d + c] = nd(rng) * 0.1f;
+                v[(size_t) l * H * d + h * d + c] = nd(rng) * 0.1f;
+            }
+            b[(size_t) l * H + h] = 0.3f + 0.6f * ud(rng);
+            // gamma mix: 90% long-memory (0.9-1.0), 10% strong decay (1e-3-0.5)
+            g[(size_t) l * H + h] = ud(rng) < 0.9f ? (0.9f + 0.1f * ud(rng)) : (1e-3f + 0.5f * ud(rng));
+        }
+        k_hist[t] = k; v_hist[t] = v; b_hist[t] = b; g_hist[t] = g;
+        tel.capture(t, k.data(), v.data(), b.data(), g.data());
+
+        // forward step (fp32, same formula as telescope)
+        for (uint32_t l = 0; l < L; ++l) for (uint32_t h = 0; h < H; ++h) {
+            float * Slh = S.data() + ((size_t) l * H + h) * d * d;
+            const float * kk = k.data() + (size_t) l * H * d + h * d;
+            const float * vv = v.data() + (size_t) l * H * d + h * d;
+            const float gg = g[(size_t) l * H + h], bb = b[(size_t) l * H + h];
+            for (uint32_t c = 0; c < d; ++c) {
+                double w = 0;
+                for (uint32_t r = 0; r < d; ++r) w += (double) kk[r] * (double) Slh[(size_t) r * d + c];
+                for (uint32_t r = 0; r < d; ++r)
+                    Slh[(size_t) r * d + c] = (float)((double) gg * Slh[(size_t) r * d + c]
+                        - (double) bb * w * kk[r] + (double) bb * vv[c] * kk[r]);
+            }
+        }
+        // anchor semantics: S_after_pos (state after processing `t`)
+        if (t % window == 0) tel.place_anchor(t, S.data());
+    }
+
+    // telescope rollback to p0
+    std::vector<float> S_out((size_t) L * H * d * d);
+    auto res = tel.rollback(p0, S_out.data());
+    printf("rollback: ok=%d anchor=%u fallback=%llu\n", res.ok, res.anchor,
+           (unsigned long long) res.fallback_count);
+    if (!res.ok) { printf("FAIL: rollback not ok\n"); return 1; }
+    if (res.fallback_count != 0) { printf("FAIL: unexpected fallback\n"); return 1; }
+
+    // independent reference: forward S0 -> p0 using hist
+    std::vector<float> S_ref = S0;
+    for (uint32_t t = 0; t < p0; ++t) {
+        const auto & k = k_hist[t], & v = v_hist[t], & b = b_hist[t], & g = g_hist[t];
+        for (uint32_t l = 0; l < L; ++l) for (uint32_t h = 0; h < H; ++h) {
+            float * Slh = S_ref.data() + ((size_t) l * H + h) * d * d;
+            const float * kk = k.data() + (size_t) l * H * d + h * d;
+            const float * vv = v.data() + (size_t) l * H * d + h * d;
+            const float gg = g[(size_t) l * H + h], bb = b[(size_t) l * H + h];
+            for (uint32_t c = 0; c < d; ++c) {
+                double w = 0;
+                for (uint32_t r = 0; r < d; ++r) w += (double) kk[r] * (double) Slh[(size_t) r * d + c];
+                for (uint32_t r = 0; r < d; ++r)
+                    Slh[(size_t) r * d + c] = (float)((double) gg * Slh[(size_t) r * d + c]
+                        - (double) bb * w * kk[r] + (double) bb * vv[c] * kk[r]);
+            }
+        }
+    }
+
+    const double err = rel_err(S_out, S_ref);
+    printf("telescope vs independent replay rel-err = %.3e (tolerance 1e-4)\n", err);
+    if (err > 1e-4) { printf("FAIL: replay mismatch\n"); return 1; }
+
+    printf("resident_bytes = %.2f MiB\n", tel.resident_bytes() / 1048576.0);
+    printf("ALL PASS\n");
+    return 0;
+}


### PR DESCRIPTION
## Overview

Partial sequence rollback (seq_rm) on recurrent models (Gated DeltaNet) currently triggers full prompt re-evaluation, because the recurrent state depends on the whole prefix. The root cause is a +r position-shift bug in the RS snapshot planes (analysis in #22746). This PR adds the first building block of a fix: a standalone forward-telescoping rollback engine.

The engine replays the exact per-step linear state map forward from the nearest fp32 anchor snapshot:

    S_t = (gamma_t I - beta_t k_t k_t^T) S_{t-1} + beta_t k_t v_t^T

No division, no snapshot planes, no layer re-evaluation. A metadata ring captures (k, v, beta, gamma) during the forward pass; an anchor ring stores full fp32 state snapshots every `window` tokens.

## Additional information

- CPU reference implementation, OpenMP-parallel across layers; the GPU kernel is a drop-in replacement for `fwd_telescope_execute` (follow-up).
- Integration guide (capture hook, seq_rm branch, CLI, acceptance criteria) is included in the header comment — wiring is a follow-up PR.
- Tested: `tests/test_telescope.cpp` — all cases pass, zero relative error vs independent replay.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes - used for design and implementation. All changes were reviewed and verified by me before submission.