### PR TITLE
ggml-cuda: pad matmul weight rows to avoid cache-set aliasing on RDNA3.5

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -648,11 +648,12 @@ extern "C" {
 
     // this tensor...
     enum ggml_tensor_flag {
-        GGML_TENSOR_FLAG_INPUT   =  1, // ...is an input for the GGML compute graph
-        GGML_TENSOR_FLAG_OUTPUT  =  2, // ...is an output for the GGML compute graph
-        GGML_TENSOR_FLAG_PARAM   =  4, // ...contains trainable parameters
-        GGML_TENSOR_FLAG_LOSS    =  8, // ...defines loss for numerical optimization (multiple loss tensors add up)
-        GGML_TENSOR_FLAG_COMPUTE = 16, // ...must be computed
+        GGML_TENSOR_FLAG_INPUT    =  1, // ...is an input for the GGML compute graph
+        GGML_TENSOR_FLAG_OUTPUT   =  2, // ...is an output for the GGML compute graph
+        GGML_TENSOR_FLAG_PARAM    =  4, // ...contains trainable parameters
+        GGML_TENSOR_FLAG_LOSS     =  8, // ...defines loss for numerical optimization (multiple loss tensors add up)
+        GGML_TENSOR_FLAG_COMPUTE  = 16, // ...must be computed
+        GGML_TENSOR_FLAG_PAD_ROWS = 32, // ...is a matmul weight whose row stride a backend may pad to avoid cache-set aliasing
     };
 
     enum ggml_tri_type {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1134,6 +1134,12 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ3_S> {
 
 //////////////////////
 
+// both values come from the cache geometry, which CUDA and HIP do not report
+struct ggml_cuda_row_pad_params {
+    size_t alias_stride; // packed row sizes that are a multiple of this alias in the cache
+    size_t pad;          // bytes added to the row stride; 0 disables the padding
+};
+
 struct ggml_cuda_device_info {
     int device_count;           // number of (possibly virtual) devices exposed to the rest of ggml
     int physical_device_count;  // number of physical CUDA devices actually present
@@ -1152,6 +1158,7 @@ struct ggml_cuda_device_info {
         int     physical_device;                // backing physical CUDA device for this (virtual) device
         int     physical_share_count;           // number of (virtual) devices sharing this device's physical GPU
         int     virtual_index;                  // index of this (virtual) device among those sharing its physical GPU
+        ggml_cuda_row_pad_params row_pad;       // weight row-stride padding
     };
 
     cuda_device_info devices[GGML_CUDA_MAX_DEVICES] = {};

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -214,6 +214,69 @@ static int ggml_cuda_parse_id(char devName[]) {
 }
 #endif // defined(GGML_USE_HIP)
 
+// an architecture is opted in only once the padding has been measured on it, the rest keep packed rows
+static ggml_cuda_row_pad_params ggml_cuda_row_pad_params_for(int cc) {
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+        return { 2048, 128 }; // one cache line added to rows that alias every 2 KiB
+    }
+
+    return { 0, 0 };
+}
+
+// returns the override for name, or -1 when it is unset or not a number
+static int64_t ggml_cuda_row_pad_env(const char * name) {
+    const char * val = getenv(name);
+    if (!val || !val[0]) {
+        return -1;
+    }
+
+    char * end = nullptr;
+    const int64_t parsed = strtoll(val, &end, 0);
+    if (*end != '\0' || parsed < 0) {
+        GGML_LOG_WARN("%s: ignoring %s=%s, expected a non-negative integer\n", __func__, name, val);
+        return -1;
+    }
+
+    return parsed;
+}
+
+// runs once per device, so an invalid setting warns once instead of per tensor
+static ggml_cuda_row_pad_params ggml_cuda_resolve_row_pad(int cc) {
+    if (ggml_cuda_row_pad_env("GGML_CUDA_NO_PAD_WEIGHTS") > 0) {
+        return { 0, 0 };
+    }
+
+    ggml_cuda_row_pad_params params = ggml_cuda_row_pad_params_for(cc);
+
+    const int64_t alias_stride_override = ggml_cuda_row_pad_env("GGML_CUDA_ROW_ALIAS_STRIDE");
+    const int64_t pad_override          = ggml_cuda_row_pad_env("GGML_CUDA_ROW_PAD");
+    if (alias_stride_override >= 0) {
+        params.alias_stride = alias_stride_override;
+    }
+    if (pad_override >= 0) {
+        params.pad = pad_override;
+    }
+
+    if (params.pad == 0) {
+        return { 0, 0 };
+    }
+
+    if (params.alias_stride == 0 || (params.alias_stride & (params.alias_stride - 1)) != 0) {
+        GGML_LOG_WARN("%s: disabling weight row padding, alias stride %zu is not a power of two\n",
+                      __func__, params.alias_stride);
+        return { 0, 0 };
+    }
+
+    // a pad that is itself a multiple of the alias stride leaves the rows aliasing
+    if (params.pad % params.alias_stride == 0) {
+        GGML_LOG_WARN("%s: disabling weight row padding, pad %zu is a multiple of alias stride %zu\n",
+                      __func__, params.pad, params.alias_stride);
+        return { 0, 0 };
+    }
+
+    return params;
+}
+
 static ggml_cuda_device_info ggml_cuda_init() {
     ggml_cuda_device_info info = {};
 
@@ -370,6 +433,8 @@ static ggml_cuda_device_info ggml_cuda_init() {
         }
 
 #endif  // defined(GGML_USE_HIP)
+
+        info.devices[id].row_pad = ggml_cuda_resolve_row_pad(info.devices[id].cc);
     }
 
     if (ggml_cuda_highest_compiled_arch(GGML_CUDA_CC_TURING) >= GGML_CUDA_CC_TURING && !turing_devices_without_mma.empty()) {
@@ -750,11 +815,70 @@ static void * ggml_backend_cuda_buffer_get_base(ggml_backend_buffer_t buffer) {
     return ctx->dev_ptr;
 }
 
+static size_t ggml_cuda_padded_row_size(const ggml_tensor * tensor, int device) {
+    return ggml_row_size(tensor->type, tensor->ne[0]) + ggml_cuda_info().devices[device].row_pad.pad;
+}
+
+// the pad is resolved per device but the kernels are picked per type, so the cost is only known here
+static void ggml_cuda_warn_padded_row_stride(ggml_type type, size_t row_stride) {
+    const bool mmf  = ggml_cuda_mmf_supports_row_stride(type, row_stride);
+    const bool mmvf = ggml_cuda_mmvf_supports_row_stride(type, row_stride);
+
+    if (mmf && mmvf) {
+        return;
+    }
+
+    static_assert(GGML_TYPE_COUNT <= 64, "one bit per type");
+    static std::atomic<uint64_t> warned;
+
+    const uint64_t bit = uint64_t(1) << type;
+    if (warned.fetch_or(bit) & bit) {
+        return;
+    }
+
+    GGML_LOG_WARN("%s: a row stride of %zu disables the %s kernels for %s weights\n", __func__,
+                  row_stride, mmf ? "mmvf" : (mmvf ? "mmf" : "mmf and mmvf"), ggml_type_name(type));
+}
+
+// quantized weights are excluded: mmq and mmvq need nb[1]/type_size to divide exactly
+static bool ggml_cuda_should_pad_weight(const ggml_tensor * tensor, int device) {
+    const ggml_cuda_row_pad_params & row_pad = ggml_cuda_info().devices[device].row_pad;
+
+    if (row_pad.pad == 0 || !(tensor->flags & GGML_TENSOR_FLAG_PAD_ROWS)) {
+        return false;
+    }
+
+    if (tensor->view_src != nullptr || ggml_is_quantized(tensor->type) || tensor->ne[1] <= 1) {
+        return false;
+    }
+
+    if (ggml_row_size(tensor->type, tensor->ne[0]) % row_pad.alias_stride != 0) {
+        return false;
+    }
+
+    // a stride that mmf or mmvf cannot index falls back to cuBLAS: prefill gains, decode loses
+    // the pad is honoured anyway, a caller may only want prefill
+    ggml_cuda_warn_padded_row_stride(tensor->type, ggml_cuda_padded_row_size(tensor, device));
+
+    return true;
+}
+
 static enum ggml_status ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
     ggml_backend_cuda_buffer_context * ctx = (ggml_backend_cuda_buffer_context *)buffer->context;
 
     if (tensor->view_src != NULL) {
         assert(tensor->view_src->buffer->buft == buffer->buft);
+        return GGML_STATUS_SUCCESS;
+    }
+
+    if (ggml_cuda_should_pad_weight(tensor, ctx->device)) {
+        tensor->nb[1] = ggml_cuda_padded_row_size(tensor, ctx->device);
+        tensor->nb[2] = tensor->nb[1]*tensor->ne[1];
+        tensor->nb[3] = tensor->nb[2]*tensor->ne[2];
+
+        // the gaps between rows are never written, initialize them to 0 to avoid possible NaN values
+        ggml_cuda_set_device(ctx->device);
+        CUDA_CHECK(cudaMemset(tensor->data, 0, ggml_backend_buft_get_alloc_size(buffer->buft, tensor)));
         return GGML_STATUS_SUCCESS;
     }
 
@@ -916,6 +1040,11 @@ static size_t ggml_backend_cuda_buffer_type_get_alloc_size(ggml_backend_buffer_t
             GGML_ASSERT(tensor->nb[0] == ggml_element_size(tensor));
             size += ggml_row_size(tensor->type, MATRIX_ROW_PADDING - ne0 % MATRIX_ROW_PADDING);
         }
+    }
+
+    // reserve room for the row stride that ggml_backend_cuda_buffer_init_tensor will assign
+    if (ggml_cuda_should_pad_weight(tensor, buft_ctx->device)) {
+        size = ggml_cuda_padded_row_size(tensor, buft_ctx->device)*ggml_nrows(tensor);
     }
 
     return size;

--- a/ggml/src/ggml-cuda/mmf.cu
+++ b/ggml/src/ggml-cuda/mmf.cu
@@ -130,6 +130,14 @@ void ggml_cuda_mul_mat_f(ggml_backend_cuda_context & ctx, const ggml_tensor * sr
     }
 }
 
+bool ggml_cuda_mmf_supports_row_stride(ggml_type type, size_t row_stride) {
+    // mul_mat_f indexes rows in units of the type it loads and needs that stride to be even
+    // float, half2 and nv_bfloat162 are all 4 bytes, so this asks for 8
+    const size_t ts_load = type == GGML_TYPE_F32 ? sizeof(float) : 2*ggml_type_size(type);
+
+    return row_stride % (2*ts_load) == 0;
+}
+
 bool ggml_cuda_should_use_mmf(enum ggml_type type, int cc, int warp_size, const int64_t * src0_ne,
         const size_t * src0_nb, const int src1_ncols, bool mul_mat_id) {
     if (ggml_is_quantized(type)) {
@@ -150,6 +158,10 @@ bool ggml_cuda_should_use_mmf(enum ggml_type type, int cc, int warp_size, const 
         if (src0_nb[i] % (2*ts) != 0) {
             return false;
         }
+    }
+
+    if (!ggml_cuda_mmf_supports_row_stride(type, src0_nb[1])) {
+        return false;
     }
     if (src0_ne[1] % mmf_get_rows_per_block(cc) != 0) {
         return false;

--- a/ggml/src/ggml-cuda/mmf.cuh
+++ b/ggml/src/ggml-cuda/mmf.cuh
@@ -43,6 +43,8 @@ struct mmf_ids_data {
 
 void ggml_cuda_mul_mat_f(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst);
 
+bool ggml_cuda_mmf_supports_row_stride(ggml_type type, size_t row_stride);
+
 bool ggml_cuda_should_use_mmf(enum ggml_type type, int cc, int warp_size, const int64_t * scr0_ne, const size_t * src0_nb, const int src1_ncols, bool mul_mat_id);
 
 template <typename T, int rows_per_block, int cols_per_block, int nwarps, bool has_ids>

--- a/ggml/src/ggml-cuda/mmvf.cu
+++ b/ggml/src/ggml-cuda/mmvf.cu
@@ -783,6 +783,10 @@ void ggml_cuda_op_mul_mat_vec_f(
     GGML_UNUSED_VARS(ctx, src1, dst, src1_ddq_i, src1_ncols, src1_padded_row_size);
 }
 
+bool ggml_cuda_mmvf_supports_row_stride(ggml_type type, size_t row_stride) {
+    return row_stride % (2*ggml_type_size(type)) == 0;
+}
+
 bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0_ne, const size_t * src0_nb, int64_t ne11) {
     if (src0_ne[0] % 2 != 0) {
         return false;
@@ -795,7 +799,7 @@ bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0
 
     // Pointers not aligned to the size of half2/nv_bfloat162/float2 would result in a crash:
     for (size_t i = 1; i < GGML_MAX_DIMS; ++i) {
-        if (src0_nb[i] % (2*ts) != 0) {
+        if (!ggml_cuda_mmvf_supports_row_stride(type, src0_nb[i])) {
             return false;
         }
     }

--- a/ggml/src/ggml-cuda/mmvf.cuh
+++ b/ggml/src/ggml-cuda/mmvf.cuh
@@ -11,4 +11,6 @@ void ggml_cuda_op_mul_mat_vec_f(
     const char * src1_ddq_i, float * dst_dd_i, const int64_t row_low, const int64_t row_high, const int64_t src1_ncols,
     const int64_t src1_padded_row_size, cudaStream_t stream);
 
+bool ggml_cuda_mmvf_supports_row_stride(ggml_type type, size_t row_stride);
+
 bool ggml_cuda_should_use_mmvf(enum ggml_type type, int cc, const int64_t * src0_ne, const size_t * src0_nb, int64_t ne11);

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1056,6 +1056,17 @@ static ggml_backend_buffer_type_t select_weight_buft(const llama_hparams & hpara
     return nullptr;
 }
 
+// some models use the token embedding tensor as the output, but since these are used in different layers and with different ops
+// the tensor is duplicated
+// to handle this, we check if the tensor is duplicated, and if so, we assume that it is being loaded as the output tensor
+static llm_tensor resolve_tn_tensor(const LLM_TN_IMPL & tn, int flags) {
+    if (tn.tensor == LLM_TENSOR_TOKEN_EMBD && (flags & llama_model_loader::TENSOR_DUPLICATED)) {
+        return LLM_TENSOR_OUTPUT;
+    }
+
+    return tn.tensor;
+}
+
 struct ggml_tensor * llama_model_loader::create_tensor(
         const llama_hparams & hparams, const buft_list_t * buft_list_cpu, const buft_list_t * buft_list_input, const buft_list_t * buft_list_output,
         const buft_list_t * buft_list_layer, const LLM_TN_IMPL & tn, const std::initializer_list<int64_t> & ne, int flags) {
@@ -1097,17 +1108,9 @@ struct ggml_tensor * llama_model_loader::create_tensor(
             throw std::runtime_error(format("missing tensor '%s'", tn.str().c_str()));
         }
 
-        // some models use the token embedding tensor as the output, but since these are used in different layers and with different ops
-        // the tensor is duplicated
-        // to handle this, we check if the tensor is duplicated, and if so, we assume that it is being loaded as the output tensor
-        llm_tensor tn_tensor = tn.tensor;
-        if (tn.tensor == LLM_TENSOR_TOKEN_EMBD && (flags & TENSOR_DUPLICATED)) {
-            tn_tensor = LLM_TENSOR_OUTPUT;
-        }
-
         llm_tensor_info info;
         try {
-            info = llm_tensor_info_for(tn_tensor);
+            info = llm_tensor_info_for(resolve_tn_tensor(tn, flags));
         } catch (const std::out_of_range & e) {
             throw std::runtime_error(format("missing tensor info mapping for %s", tn.str().c_str()));
         }
@@ -1295,6 +1298,15 @@ struct ggml_tensor * llama_model_loader::create_tensor(
 
     struct ggml_tensor * tensor = ggml_dup_tensor(ctx, &t_meta);
     ggml_set_name(tensor, ggml_get_name(&t_meta));
+
+    // flag the weights that feed a matrix multiplication, backends may pad their row stride
+    const bool is_weight = tn.suffix == nullptr || strcmp(tn.suffix, "weight") == 0;
+    if (is_weight) {
+        const ggml_op op = llm_tensor_info_for(resolve_tn_tensor(tn, flags)).op;
+        if (op == GGML_OP_MUL_MAT || op == GGML_OP_MUL_MAT_ID) {
+            tensor->flags |= GGML_TENSOR_FLAG_PAD_ROWS;
+        }
+    }
 
     if (duplicated) {
         size_data += ggml_nbytes(&t_meta);
@@ -1524,7 +1536,12 @@ bool llama_model_loader::load_all_data(
             }
         }
 
-        size_t n_size = ggml_nbytes(cur);
+        // the file data is packed, a destination with a padded row stride needs a 2D copy
+        const size_t  packed_row_size = ggml_row_size(cur->type, cur->ne[0]);
+        const int64_t n_rows          = ggml_nelements(cur) / cur->ne[0];
+        const bool    row_padded      = cur->nb[1] != packed_row_size;
+
+        const size_t n_size = row_padded ? packed_row_size*n_rows : ggml_nbytes(cur);
 
         if (use_mmap) {
             const auto & mapping = mappings.at(weight->idx);
@@ -1551,6 +1568,8 @@ bool llama_model_loader::load_all_data(
                 auto & mmap_used = mmaps_used[weight->idx];
                 mmap_used.first  = std::min(mmap_used.first,  weight->offs);
                 mmap_used.second = std::max(mmap_used.second, weight->offs + n_size);
+            } else if (row_padded) {
+                ggml_backend_tensor_set_2d(cur, data, 0, packed_row_size, n_rows, cur->nb[1], packed_row_size);
             } else {
                 ggml_backend_tensor_set(cur, data, 0, n_size);
             }
@@ -1567,7 +1586,7 @@ bool llama_model_loader::load_all_data(
                 }
             } else {
                 // If upload_backend is valid load the tensor in chunks to pinned memory and upload the buffers asynchronously to the GPU.
-                if (upload_backend) {
+                if (upload_backend && !row_padded) {
                     size_t offset = weight->offs;
                     alignment = file->read_alignment();
                     size_t aligned_offset = offset & ~(alignment - 1);
@@ -1623,7 +1642,11 @@ bool llama_model_loader::load_all_data(
                     read_buf.resize(n_size);
                     file->seek(weight->offs, SEEK_SET);
                     file->read_raw(read_buf.data(), n_size);
-                    ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
+                    if (row_padded) {
+                        ggml_backend_tensor_set_2d(cur, read_buf.data(), 0, packed_row_size, n_rows, cur->nb[1], packed_row_size);
+                    } else {
+                        ggml_backend_tensor_set(cur, read_buf.data(), 0, n_size);
+                    }
                     if (check_tensors && !ggml_validate_row_data(cur->type, read_buf.data(), n_size)) {
                         throw std::runtime_error(format("tensor '%s' has invalid data", ggml_get_name(cur)));
                     }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9009,6 +9009,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // row stride of 260 bytes: a multiple of 2*type_size, but not of the vector mul_mat_f indexes with
+    for (ggml_type type : {GGML_TYPE_F16, GGML_TYPE_BF16}) {
+        test_cases.emplace_back(new test_mul_mat(type, GGML_TYPE_F32, 64, 8, 128, {1, 1}, {1, 1}, {0, 1, 2, 3}, 130));
+    }
+
     // sycl backend will limit task global_range < MAX_INT
     // test case for f16-type-convert-to-fp32 kernel with large k under fp32 compute dtype (occurs in stable-diffusion)
     // however this case needs to alloc more memory which may fail in some devices (Intel Arc770, etc.)


### PR DESCRIPTION
## Overview

Weight matrices whose packed row size is a multiple of 2048 bytes map every row onto the same L2 cache sets, so a matmul walking down a column thrashes a single set. On RDNA3.5 this costs up to 20% of prefill throughput and 10% of decode.

This adds one cache line (128 B) to the row stride of such weights at buffer-init time so that consecutive rows land in different sets.

## Provenance

https://github.com/ggml-org/llama.cpp/discussions/26379

## Additional information

### Tuning and disabling

| variable | effect |
| --- | --- |
| `GGML_CUDA_ROW_ALIAS_STRIDE` | override the aliasing period (must be a power of two) |
| `GGML_CUDA_ROW_PAD` | override the pad; `0` disables |
| `GGML_CUDA_NO_PAD_WEIGHTS` | `1` disables; `0` and unset keep the architecture default |


### Benchmarks

AMD Radeon 8060S Graphics, gfx1151 (RDNA3.5), 32 GiB VRAM. All models BF16.

```
ROCBLAS_USE_HIPBLASLT=1 llama-bench -m <model> <flags> \
  -r 150 -ngl 999 -t 8 -fa 1 --poll 50 -ctk f16 -ctv f16
```

Prefill: `-p 128,2048,4096 -n 0`. Decode: `-d 128 -n 128 -p 0`.
Values are t/s ± standard deviation over 150 repetitions. `delta` is the gain from padding.
Measured with **ROCBLAS_USE_HIPBLASLT=1**

### pp128

| model | nopad (t/s) | pad (t/s) | delta |
| --- | ---: | ---: | ---: |
| Qwen3.5-2B | 2853.09 ± 129.22 | 4133.33 ± 290.41 | +44.9% |
| Ministral-3-3B | 2301.11 ± 99.94 | 2402.36 ± 92.56 | +4.4% |
| Nemotron-3-Nano-4B | 1786.82 ± 156.44 | 1746.82 ± 248.79 | -2.2% |
| Ministral-3-8B | 947.20 ± 12.38 | 1092.42 ± 66.44 | +15.3% |
| granite-4.1-8b | 953.68 ± 16.90 | 1043.35 ± 94.20 | +9.4% |
| Qwen3.5-9B | 930.84 ± 51.28 | 1050.74 ± 139.95 | +12.9% |
| gemma-4-12b | 676.92 ± 32.62 | 764.10 ± 13.16 | +12.9% |

### pp2048

| model | nopad (t/s) | pad (t/s) | delta |
| --- | ---: | ---: | ---: |
| Qwen3.5-2B | 4899.59 ± 23.93 | 6004.73 ± 103.75 | +22.6% |
| Ministral-3-3B | 3437.30 ± 34.67 | 3624.95 ± 31.01 | +5.5% |
| Nemotron-3-Nano-4B | 2360.18 ± 26.32 | 2359.12 ± 21.42 | -0.0% |
| Ministral-3-8B | 1426.92 ± 11.89 | 1710.45 ± 15.09 | +19.9% |
| granite-4.1-8b | 1396.54 ± 34.77 | 1585.47 ± 10.62 | +13.5% |
| Qwen3.5-9B | 1419.33 ± 7.96 | 1690.63 ± 16.92 | +19.1% |
| gemma-4-12b | 993.64 ± 3.89 | 999.69 ± 19.09 | +0.6% |

### pp4096

| model | nopad (t/s) | pad (t/s) | delta |
| --- | ---: | ---: | ---: |
| Qwen3.5-2B | 4789.99 ± 28.12 | 5795.82 ± 70.51 | +21.0% |
| Ministral-3-3B | 3178.34 ± 17.27 | 3328.16 ± 26.72 | +4.7% |
| Nemotron-3-Nano-4B | 2328.00 ± 9.56 | 2326.94 ± 10.82 | -0.0% |
| Ministral-3-8B | 1367.75 ± 3.41 | 1620.60 ± 5.02 | +18.5% |
| granite-4.1-8b | 1329.52 ± 3.24 | 1494.82 ± 5.18 | +12.4% |
| Qwen3.5-9B | 1389.47 ± 4.39 | 1646.00 ± 5.85 | +18.5% |
| gemma-4-12b | 941.55 ± 1.76 | 947.47 ± 1.76 | +0.6% |

### tg128 @ d128

| model | nopad (t/s) | pad (t/s) | delta |
| --- | ---: | ---: | ---: |
| Qwen3.5-2B | 47.18 ± 0.13 | 50.49 ± 0.19 | +7.0% |
| Ministral-3-3B | 30.31 ± 0.33 | 30.84 ± 0.08 | +1.7% |
| Nemotron-3-Nano-4B | 28.35 ± 0.04 | 28.36 ± 0.09 | +0.0% |
| Ministral-3-8B | 11.37 ± 0.01 | 12.45 ± 0.02 | +9.5% |
| granite-4.1-8b | 11.16 ± 0.02 | 12.31 ± 0.01 | +10.3% |
| Qwen3.5-9B | 11.62 ± 0.01 | 12.61 ± 0.03 | +8.5% |
| gemma-4-12b | 8.86 ± 0.02 | 8.92 ± 0.02 | +0.7% |

### Memory cost

The padding grows the model buffer. Measured as the `ROCm0 model buffer size` reported at load:

| model | nopad (MiB) | pad (MiB) | extra (MiB) | extra % |
| --- | ---: | ---: | ---: | ---: |
| Qwen3.5-2B | 3590.35 | 3690.48 | +100.13 | 2.79% |
| Ministral-3-3B | 6540.62 | 6654.12 | +113.50 | 1.74% |
| Nemotron-3-Nano-4B | 6797.48 | 6799.01 | +1.53 | 0.02% |
| Ministral-3-8B | 15169.08 | 15363.58 | +194.50 | 1.28% |
| granite-4.1-8b | 15985.27 | 16172.52 | +187.25 | 1.17% |
| Qwen3.5-9B | 15140.05 | 15344.55 | +204.50 | 1.35% |
| gemma-4-12b | 22712.94 | 22757.94 | +45.00 | 0.20% |

Note: As expected **Nemotron-3-Nano-4B** got added almost no padding and perf did not change because their shapes+dtype are not aligned.

### Note on quantized models

For models which are quantized, some layers may be left as fp32 for accuracy reasons. Those models also see a benefit. Eg:

Qwen3.5-35B-A3B Q4_K_M:
 - tg128@d128:  **+1.23%**

## Correctness

Greedy generation (`--temp 0`) is token-for-token identical with and without padding.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, research, POC. Latter iteration on implementation. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
