### PR TITLE
mtmd: honor image max tokens for LightOnOCR

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,6 +300,11 @@ llama_build_and_test(test-mtmd-c-api.c)
 target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
 unset(LLAMA_TEST_NAME)
 
+set(LLAMA_TEST_NAME test-mtmd-hparams)
+llama_build_and_test(test-mtmd-hparams.cpp)
+target_link_libraries(${LLAMA_TEST_NAME} PRIVATE mtmd)
+unset(LLAMA_TEST_NAME)
+
 # GGUF model data fetcher library for tests that need real model metadata
 # Only compile when cpp-httplib has SSL support (CPPHTTPLIB_OPENSSL_SUPPORT)
 if (TARGET cpp-httplib)

--- a/tests/test-mtmd-hparams.cpp
+++ b/tests/test-mtmd-hparams.cpp
@@ -1,0 +1,55 @@
+#include "clip-model.h"
+
+#undef NDEBUG
+#include <cassert>
+
+static clip_hparams lightonocr_hparams() {
+    clip_hparams hparams;
+    hparams.patch_size = 14;
+    hparams.n_merge = 2;
+    hparams.image_longest_edge = 1540;
+    return hparams;
+}
+
+int main() {
+    {
+        auto hparams = lightonocr_hparams();
+        hparams.set_limit_image_tokens_longest_edge(256);
+        assert(hparams.image_longest_edge == 1540);
+        assert(hparams.warmup_image_size == 448);
+    }
+
+    {
+        auto hparams = lightonocr_hparams();
+        hparams.custom_image_max_tokens = 2025;
+        hparams.set_limit_image_tokens_longest_edge(256);
+        assert(hparams.image_longest_edge == 1260);
+        assert(hparams.warmup_image_size == 448);
+    }
+
+    {
+        auto hparams = lightonocr_hparams();
+        hparams.custom_image_max_tokens = 2000;
+        hparams.set_limit_image_tokens_longest_edge(256);
+        assert(hparams.image_longest_edge == 1232);
+        assert(hparams.warmup_image_size == 448);
+    }
+
+    {
+        auto hparams = lightonocr_hparams();
+        hparams.custom_image_max_tokens = 200;
+        hparams.set_limit_image_tokens_longest_edge(256);
+        assert(hparams.image_longest_edge == 392);
+        assert(hparams.warmup_image_size == 392);
+    }
+
+    {
+        auto hparams = lightonocr_hparams();
+        hparams.custom_image_max_tokens = 4096;
+        hparams.set_limit_image_tokens_longest_edge(256);
+        assert(hparams.image_longest_edge == 1792);
+        assert(hparams.warmup_image_size == 448);
+    }
+
+    return 0;
+}

--- a/tools/mtmd/clip-model.h
+++ b/tools/mtmd/clip-model.h
@@ -170,6 +170,15 @@ struct clip_hparams {
         warmup_image_size = static_cast<int>(std::sqrt(image_max_pixels));
     }
 
+    void set_limit_image_tokens_longest_edge(int n_tokens_warmup) {
+        if (custom_image_max_tokens > 0) {
+            const int max_tokens_per_edge = static_cast<int>(std::sqrt(custom_image_max_tokens));
+            image_longest_edge = max_tokens_per_edge * patch_size * n_merge;
+            n_tokens_warmup = std::min(n_tokens_warmup, max_tokens_per_edge * max_tokens_per_edge);
+        }
+        set_warmup_n_tokens(n_tokens_warmup);
+    }
+
     void set_warmup_n_tokens(int n_tokens) {
         int n_tok_per_side = static_cast<int>(std::sqrt(n_tokens));
         GGML_ASSERT(n_tok_per_side * n_tok_per_side == n_tokens && "n_tokens must be n*n");

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1470,7 +1470,7 @@ struct clip_model_loader {
                         get_u32(KEY_SPATIAL_MERGE_SIZE, hparams.n_merge, false);
                         hparams.image_longest_edge = hparams.image_size;
                         get_u32(KEY_PREPROC_IMAGE_SIZE, hparams.image_longest_edge, false);
-                        hparams.set_warmup_n_tokens(256); // avoid OOM on warmup
+                        hparams.set_limit_image_tokens_longest_edge(256); // avoid OOM on warmup
                     } break;
                 case PROJECTOR_TYPE_DOTS_OCR:
                     {


### PR DESCRIPTION
Assisted-by: Codex

## Overview

This is a bug fix for LightOnOCR. Honor custom image max-token limits for LightOnOCR by deriving `image_longest_edge` from the largest square token grid within the requested budget. Warmup remains capped at 256 image tokens, or is reduced further when the custom limit is smaller. When no custom limit is set, the model-provided longest edge is preserved.

Add a focused `test-mtmd-hparams` target covering default behavior, exact and non-square limits, and limits above and below the warmup cap.

## Additional information

For non-square limits, the token-grid edge is rounded down before being converted to pixels using the model's patch and merge sizes. This keeps the resulting square grid within the requested token budget.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Codex was used to review the changed files and propose a fix