### PR TITLE
server: expose the prompt token total in /slots

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -691,6 +691,7 @@ struct server_slot {
         if (ptask) {
             res["id_task"] = ptask->id;
             res["n_prompt_tokens"]           = (int32_t) prompt.tokens.size();
+            res["n_prompt_tokens_total"]     = ptask->n_tokens();
             res["n_prompt_tokens_processed"] = n_prompt_tokens_processed;
             res["n_prompt_tokens_cache"]     = n_prompt_tokens_cache;
             res["params"] = ptask->params.to_json(only_metrics);


### PR DESCRIPTION
ref: `tools/server/server-context.cpp`

`/slots` reports how far a prefill has got but not how far it has to go, so external monitoring cannot compute prompt-processing progress.

`n_prompt_tokens` is `prompt.tokens.size()` — the slot's current prompt cache, which climbs during prefill — and `n_prompt_tokens_processed` climbs with it. Neither is the target, so while a slot is processing a prompt both fields report the work done so far and there is no denominator. Sampling `/slots` through a 60k-token cold prefill:

```
total=2560   processed=2560   cached=0
total=5120   processed=5120   cached=0
total=51200  processed=51200  cached=0
```

The server already computes the ratio for its own log line in `print_timings_pp()`:

```cpp
const double f_progress = (float) prompt.n_tokens() / task->n_tokens();
```

which produces `prompt processing, n_tokens = 124806, progress = 0.93, ...`. But `task->n_tokens()` is not serialized at any verbosity, so that figure is reachable only by scraping stderr.

The two existing progress paths do not cover an observer:

- `return_progress` emits progress events to the **requesting** client in stream mode, which does not help a third party such as a monitoring dashboard.
- `LLAMA_SERVER_SLOTS_DEBUG` adds `res["prompt"]`, the full detokenized prompt. That is far too heavy to poll (conversations here reach ~250k tokens) and puts conversation content in a monitoring surface.

This adds `n_prompt_tokens_total` to `server_slot::to_json()` so the same ratio the log prints can be derived from the endpoint.

Additive and unconditional — no new field is removed or renamed, `ptask` is already in scope two lines above, and `server_task::n_tokens()` is an existing public accessor. Verified with a `llama-server` build (`GGML_CUDA=OFF`).