### PR TITLE
sycl: Update gate logic for Alchemist GPUs regarding OneDNN features.

### DIFF
--- a/ggml/src/ggml-sycl/fattn-onednn.cpp
+++ b/ggml/src/ggml-sycl/fattn-onednn.cpp
@@ -52,7 +52,6 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
             }
         }
     }
-    
     // This is the improved SPDA gate. Rather than gating Alchemist GPUs from all SPDA features, we instead target only the failing shapes.
     // If the GPU being assessed isn't in the grouping below, it has full access to all SPDA shapes. Otherwise, if it's an Alchemist GPU, we block only the shapes with head sizes that fail.
     // It is much easier to compare the device to a small list of failing cases than to define all the passing ones.
@@ -64,7 +63,6 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
     if (!support_spda && K->ne[0] == 64) {
         return false;
     }
-
     // Optional KV-length ceiling (GGML_SYCL_FA_ONEDNN_MAX_KV, 0 = unlimited). Escape hatch:
     // very long sequences make the fused SDPA slow enough to risk the xe driver watchdog on
     // some stacks; past the cap we fall back to the native FA kernel instead.

--- a/ggml/src/ggml-sycl/fattn-onednn.cpp
+++ b/ggml/src/ggml-sycl/fattn-onednn.cpp
@@ -53,7 +53,7 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
         }
     }
     const gpu_arch arch = ggml_sycl_info().devices[ggml_sycl_get_device()].hw_info.arch;
-    const bool is_bmg = (arch == gpu_arch::intel_gpu_bmg_g21);
+    const bool is_bmg = (arch == gpu_arch::intel_gpu_bmg_g21 || arch == gpu_arch::intel_gpu_bmg_g31);
     const bool is_dg2 = (arch == gpu_arch::intel_gpu_dg2_g10 ||
                           arch == gpu_arch::intel_gpu_dg2_g11 ||
                           arch == gpu_arch::intel_gpu_dg2_g12);   // verified that dg2_x works alongside acm_gx

--- a/ggml/src/ggml-sycl/fattn-onednn.cpp
+++ b/ggml/src/ggml-sycl/fattn-onednn.cpp
@@ -52,18 +52,18 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
             }
         }
     }
-    const gpu_arch arch = ggml_sycl_info().devices[ggml_sycl_get_device()].hw_info.arch;
-    const bool is_bmg = (arch == gpu_arch::intel_gpu_bmg_g21 || arch == gpu_arch::intel_gpu_bmg_g31);
-    const bool is_dg2 = (arch == gpu_arch::intel_gpu_dg2_g10 ||
-                          arch == gpu_arch::intel_gpu_dg2_g11 ||
-                          arch == gpu_arch::intel_gpu_dg2_g12);   // verified that dg2_x works alongside acm_gx
+    
+    // This is the improved SPDA gate. Rather than gating Alchemist GPUs from all SPDA features, we instead target only the failing shapes.
+    // If the GPU being assessed isn't in the grouping below, it has full access to all SPDA shapes. Otherwise, if it's an Alchemist GPU, we block only the shapes with head sizes that fail.
+    // It is much easier to compare the device to a small list of failing cases than to define all the passing ones.
+    bool support_spda = !(arch == gpu_arch::intel_gpu_dg2_g10 ||
+                         arch == gpu_arch::intel_gpu_dg2_g11 ||
+                         arch == gpu_arch::intel_gpu_dg2_g12);
 
-    if (!is_bmg && !is_dg2) {
-        return false;   // unverified/untested arch: stay conservative
+    if (!support_spda && K->ne[0] == 64) {
+        return false;
     }
-    if (is_dg2 && K->ne[0] == 64) {
-        return false;   // known-bad shape on this family
-    }
+
     // Optional KV-length ceiling (GGML_SYCL_FA_ONEDNN_MAX_KV, 0 = unlimited). Escape hatch:
     // very long sequences make the fused SDPA slow enough to risk the xe driver watchdog on
     // some stacks; past the cap we fall back to the native FA kernel instead.

--- a/ggml/src/ggml-sycl/fattn-onednn.cpp
+++ b/ggml/src/ggml-sycl/fattn-onednn.cpp
@@ -21,14 +21,6 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
     if (!g_ggml_sycl_fa_onednn) {
         return false;
     }
-    // Battlemage (Xe2) only, for now. On other Intel archs oneDNN's fused SDPA returns wrong results
-    // for some shapes (e.g. head_dim=64 on Arc / xe_hpg) -- an oneDNN bug tracked upstream at
-    // https://github.com/uxlfoundation/oneDNN/issues/5510. Remove this hardware limitation once that
-    // is fixed; until then non-BMG archs fall back to the existing FA kernel.
-    const gpu_arch arch = ggml_sycl_info().devices[ggml_sycl_get_device()].hw_info.arch;
-    if (arch != gpu_arch::intel_gpu_bmg_g21 && arch != gpu_arch::intel_gpu_bmg_g31) {
-        return false;
-    }
     const ggml_tensor * Q     = dst->src[0];
     const ggml_tensor * K     = dst->src[1];
     const ggml_tensor * V     = dst->src[2];
@@ -59,6 +51,19 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
                 return false;
             }
         }
+    }
+    const gpu_arch arch = ggml_sycl_info().devices[ggml_sycl_get_device()].hw_info.arch;
+    const bool is_bmg = (arch == gpu_arch::intel_gpu_bmg_g21 ||
+                          arch == gpu_arch::intel_gpu_bmg_g31);   // verify bmg_g31 actually exists in this enum
+    const bool is_dg2 = (arch == gpu_arch::intel_gpu_dg2_g10 ||
+                          arch == gpu_arch::intel_gpu_dg2_g11 ||
+                          arch == gpu_arch::intel_gpu_dg2_g12);   // verify naming: dg2_* vs acm_* below
+
+    if (!is_bmg && !is_dg2) {
+        return false;   // unverified/untested arch: stay conservative
+    }
+    if (is_dg2 && K->ne[0] == 64) {
+        return false;   // known-bad shape on this family
     }
     // Optional KV-length ceiling (GGML_SYCL_FA_ONEDNN_MAX_KV, 0 = unlimited). Escape hatch:
     // very long sequences make the fused SDPA slow enough to risk the xe driver watchdog on

--- a/ggml/src/ggml-sycl/fattn-onednn.cpp
+++ b/ggml/src/ggml-sycl/fattn-onednn.cpp
@@ -56,6 +56,7 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
     // This is the improved SPDA gate. Rather than gating Alchemist GPUs from all SPDA features, we instead target only the failing shapes.
     // If the GPU being assessed isn't in the grouping below, it has full access to all SPDA shapes. Otherwise, if it's an Alchemist GPU, we block only the shapes with head sizes that fail.
     // It is much easier to compare the device to a small list of failing cases than to define all the passing ones.
+    const gpu_arch arch = ggml_sycl_info().devices[ggml_sycl_get_device()].hw_info.arch;
     bool support_spda = !(arch == gpu_arch::intel_gpu_dg2_g10 ||
                          arch == gpu_arch::intel_gpu_dg2_g11 ||
                          arch == gpu_arch::intel_gpu_dg2_g12);

--- a/ggml/src/ggml-sycl/fattn-onednn.cpp
+++ b/ggml/src/ggml-sycl/fattn-onednn.cpp
@@ -53,11 +53,10 @@ bool ggml_sycl_flash_attn_ext_onednn_supported(const ggml_tensor * dst) {
         }
     }
     const gpu_arch arch = ggml_sycl_info().devices[ggml_sycl_get_device()].hw_info.arch;
-    const bool is_bmg = (arch == gpu_arch::intel_gpu_bmg_g21 ||
-                          arch == gpu_arch::intel_gpu_bmg_g31);   // verify bmg_g31 actually exists in this enum
+    const bool is_bmg = (arch == gpu_arch::intel_gpu_bmg_g21);
     const bool is_dg2 = (arch == gpu_arch::intel_gpu_dg2_g10 ||
                           arch == gpu_arch::intel_gpu_dg2_g11 ||
-                          arch == gpu_arch::intel_gpu_dg2_g12);   // verify naming: dg2_* vs acm_* below
+                          arch == gpu_arch::intel_gpu_dg2_g12);   // verified that dg2_x works alongside acm_gx
 
     if (!is_bmg && !is_dg2) {
         return false;   // unverified/untested arch: stay conservative


### PR DESCRIPTION
## Overview

There have been a few recent OneDNN specific features that have aimed to increase the performance of prompt processing on Intel GPUs. Unfortunately, in pull #25222 it was found that SPDA routes threw incorrect results on Alchemist GPUs. As a result, Alchemist GPUs were gated from the SPDA paths.
The PR also left Alchemist users a testing script to verify whether the SPDA paths were correct or not by comparing it to a known good CPU result. When running this, I found that it was only the SPDA shapes with a head size of d=64 that failed.

Instead of gating all SPDA routes, I rewrote the gate to block Alchemist users from SPDA shapes with a head size of d=64, instead having them fall back to the regular SYCL FA routes. This allowed all other routes to run as OneDNN SPDAs. 

## Additional information

Prompt processing for models with head sizes !=64 is greatly increased. Qwen3.6-27B sees speeds of around 590-680t/s PP.
Prompt processing for models with head sizes = 64 is unchanged, but very performant given that most models with smaller head sizes are small.

The OneDNN issue with regards to head sizes of 64 is tracked in their repo and is reportedly in "triage" according to Intel. When the script shows that the failed shapes now pass, this gate can be completely removed.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Claude helped me to understand what the testing script did, I wrote the new gate.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
