### PR TITLE
llama : add backends of the other model to the context

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -333,6 +333,32 @@ llama_context::llama_context(
             backends.emplace_back(backend);
         }
 
+        // add backends for the devices of the other model (if any)
+        // some models (e.g. Gemma4Assistant, Eagle3, DFlash, DSpark) share tensors
+        // with the target model through ctx_other, and those tensors may be
+        // pre-allocated on devices that are not part of this model's device list
+        if (cparams.ctx_other != nullptr) {
+            const llama_model * model_other = llama_get_model(cparams.ctx_other);
+            for (const auto & dev : model_other->devices) {
+                bool found = false;
+                for (const auto & dev_self : model.devices) {
+                    if (dev_self.dev == dev.dev) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    ggml_backend_t backend = ggml_backend_dev_init(dev.dev, nullptr);
+                    if (backend == nullptr) {
+                        throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev.dev)));
+                    }
+                    LLAMA_LOG_INFO("%s: adding backend for device %s: shared tensors with the other model (e.g. tok_embd, output)\n",
+                            __func__, ggml_backend_dev_name(dev.dev));
+                    backends.emplace_back(backend);
+                }
+            }
+        }
+
         // add ACCEL backends (such as BLAS)
         for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
             ggml_backend_dev_t dev = ggml_backend_dev_get(i);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -337,6 +337,32 @@ llama_context::llama_context(
             backends.emplace_back(backend);
         }
 
+        // add backends for the devices of the other model (if any)
+        // some models (e.g. Gemma4Assistant, Eagle3, DFlash, DSpark) share tensors
+        // with the target model through ctx_other, and those tensors may be
+        // pre-allocated on devices that are not part of this model's device list
+        if (cparams.ctx_other != nullptr) {
+            const llama_model * model_other = llama_get_model(cparams.ctx_other);
+            for (const auto & dev : model_other->devices) {
+                bool found = false;
+                for (const auto & dev_self : model.devices) {
+                    if (dev_self.dev == dev.dev) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    ggml_backend_t backend = ggml_backend_dev_init(dev.dev, nullptr);
+                    if (backend == nullptr) {
+                        throw std::runtime_error(format("failed to initialize %s backend", ggml_backend_dev_name(dev.dev)));
+                    }
+                    LLAMA_LOG_INFO("%s: adding backend for device %s: shared tensors with the other model (e.g. tok_embd, output)\n",
+                            __func__, ggml_backend_dev_name(dev.dev));
+                    backends.emplace_back(backend);
+                }
+            }
+        }
+
         // add ACCEL backends (such as BLAS)
         for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
             ggml_backend_dev_t dev = ggml_backend_dev_get(i);


### PR DESCRIPTION
For models that share tensors with another model through ctx_other (e.g. Gemma4Assistant, Eagle3, DFlash, DSpark), add the other model's device backends to the context scheduler so that pre-allocated shared tensors (tok_embd, output) can be scheduled. Fixes an abort when the speculative draft model uses a device list that does not cover the GPU holding the target model's output projection.

Assisted-by: opencode

## Overview

## Bug (observed behavior)
- Abort during llama_context construction: "pre-allocated tensor (output.weight) in a buffer (CUDA10) that cannot run the operation (NONE)"
- Location: ggml/src/ggml-backend.cpp (line ~898/930 depending on version), called from llama_context::sched_reserve -> graph_reserve -> resolve_fused_ops
- Trigger: speculative decoding with ctx_other (draft-dspark / draft-dflash / draft-mtp), draft model on its own device via --device-draft/--spec-draft-device, target model on other GPU(s)
- Root cause : the draft context scheduler only had backends for the draft's own devices; shared pre-allocated tensors (tok_embd/output.weight, taken from the target model via ctx_other in src/models/dflash.cpp) live in buffers on the target's devices; scheduler found no backend for those buffers and aborted

## Reproduction (your setup)
- llama-server in router mode, model preset:
  - device = CUDA3,CUDA4,CUDA5,CUDA7,CUDA8,CUDA9,CUDA10 (--split-mode layer)
  - spec-type = draft-dspark, spec-draft-n-max = 8
  - spec-draft-device = CUDA0
  - model-draft = dspark/dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf
- Before fix: GGML_ABORT, spec model failed to load
- After fix: draft context logs "adding backend for device CUDA3..CUDA10: shared tensors with the other model (e.g. tok_embd, output)", speculative implementation 'draft-dspark' initializes (n_max=8, block_size=5), server healthy
- Verified with CI-built image version 10282 (34ec9c9bb) on 15-GPU host (RTX 3080/4080/4090/3090), CUDA 12, 16x 3090-class workload


## Additional information

## Related issues
- #26475 - "using -devd CUDA0 on draft-dspark causes model to crash": same abort message (output.weight, CUDA8), same stack, draft-dspark + tensor split. Directly matches. (open)
- #24492 - Gemma 4 31B MTP, Vulkan: "pre-allocated tensor (cache_k_l58) ... cannot run the operation (NONE)" - same abort class, ctx_other/KV sharing; mechanism may differ (Vulkan backend support), unknown whether fixed
- #24366 - Gemma MTP, tensor split, buffer "Meta()": same abort class; unknown whether fixed
- #26339 - "Dspark model fails to load with -sm tensor on MI50": possible same class; unknown
 
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - opencode + ds4


