### PR TITLE
fix: persist resolved ctx size to params_base on main model load

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1322,6 +1322,9 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
         return;
     }
 
+    // persist resolved context size back to params
+    params.n_ctx = llama_n_ctx(lctx);
+
     pimpl->context.reset(lctx);
 }
 


### PR DESCRIPTION
## Overview

When fit is enabled and no `ctx-size` is provided, `common_init_result` uses `common_fit_params` to estimate a reasonable `n_ctx` for the main model.

At least within `load_model`, the `common_params` object used to initialize the main model is never updated with this `n_ctx` (`params_base.n_ctx` remains zero).  As a result, any subsequent usage of `params_base` defaults to the model's `n_ctx_train`, rather than the resolved `n_ctx`. For example, the speculative decoder initialized later in `load_model` will allocate for `n_ctx_train`, rather than the main model's `n_ctx`.

This commit persists the resolved `n_ctx` by updating the passed-in `common_params`.

## Additional information

This PR pulls a one line fix out of https://github.com/ggml-org/llama.cpp/pull/25465.

Admittedly, this fixes only half the problem. As detailed in the above PR, when no `ctx-size` is provided, `load_model` estimates fit for the speculative decoder _before_ touching the main model - and because the main model fit hasn't run yet, the speculative decoder is _always_ assumed to require `n_ctx_train` worth of space. 

This PR ensures that, at least, the amount _actually reserved_ is the resolved `n_ctx` - but this does not change the original estimation.

I'm submitting this separately because:
- solving the estimation problem is a little trickier and my last PR has been waiting on review for a while
- I'm working on other changes and keep running into the issue where `params_base` isn't updated

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes!
- AI usage disclosure: No.
