### PR TITLE
server : support slot save/restore with media inputs

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -881,6 +881,7 @@ extern "C" {
                const llama_token * tokens,
                           size_t   n_token_count);
 
+    // If tokens_out is NULL, only the token count is reported through n_token_count_out and no state is loaded
     LLAMA_API size_t llama_state_seq_load_file(
             struct llama_context * ctx,
                       const char * filepath,

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3096,6 +3096,17 @@ size_t llama_context::state_seq_load_file(llama_seq_id seq_id, const char * file
     {
         const uint32_t n_token_count = file.read_u32();
 
+        if (tokens_out == nullptr) {
+            const size_t n_token_max = (file.size() - file.tell()) / sizeof(llama_token);
+            if (n_token_count > n_token_max) {
+                LLAMA_LOG_ERROR("%s: token count in sequence state file exceeds the file size! %u > %zu\n", __func__, n_token_count, n_token_max);
+                return 0;
+            }
+
+            *n_token_count_out = n_token_count;
+            return file.tell();
+        }
+
         if (n_token_count > n_token_capacity) {
             LLAMA_LOG_ERROR("%s: token count in sequence state file exceeded capacity! %u > %zu\n", __func__, n_token_count, n_token_capacity);
             return 0;

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <limits>
 #include <cstring>
+#include <type_traits>
 
 json format_error_response(const std::string & message, const enum error_type type) {
     std::string type_str;
@@ -240,11 +241,53 @@ namespace {
 
 constexpr uint32_t SERVER_TOKENS_STATE_VERSION = 1;
 
-template <typename T>
-void server_tokens_state_write(std::vector<char> & data, T value) {
-    const auto * ptr = reinterpret_cast<const char *>(&value);
-    data.insert(data.end(), ptr, ptr + sizeof(value));
+uint32_t server_tokens_state_u32(size_t value) {
+    if (value > std::numeric_limits<uint32_t>::max()) {
+        throw std::runtime_error("Server tokens state is too large");
+    }
+    return value;
 }
+
+class server_tokens_state_writer {
+public:
+    template <typename T>
+    void write(T value) {
+        static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
+        const auto * ptr = reinterpret_cast<const char *>(&value);
+        data.insert(data.end(), ptr, ptr + sizeof(value));
+    }
+
+    template <typename T>
+    void write(const std::vector<T> & values) {
+        static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
+        write(server_tokens_state_u32(values.size()));
+        if (values.empty()) {
+            return;
+        }
+        const auto * ptr = reinterpret_cast<const char *>(values.data());
+        data.insert(data.end(), ptr, ptr + values.size() * sizeof(T));
+    }
+
+    void write_image_chunk(const mtmd_input_chunk * chunk) {
+        size_t chunk_size = 0;
+        if (mtmd_input_chunk_save(chunk, nullptr, 0, &chunk_size) != 0 || chunk_size == 0) {
+            throw std::runtime_error("Cannot serialize image chunk in server tokens");
+        }
+        std::vector<char> chunk_data(server_tokens_state_u32(chunk_size));
+        if (mtmd_input_chunk_save(chunk, chunk_data.data(), chunk_data.size(), nullptr) != 0) {
+            throw std::runtime_error("Cannot serialize image chunk in server tokens");
+        }
+        write(chunk_data);
+    }
+
+    std::vector<char> take() {
+        data.resize((data.size() + sizeof(llama_token) - 1) / sizeof(llama_token) * sizeof(llama_token), 0);
+        return std::move(data);
+    }
+
+private:
+    std::vector<char> data;
+};
 
 class server_tokens_state_reader {
 public:
@@ -252,6 +295,7 @@ public:
 
     template <typename T>
     T read() {
+        static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
         if (size - pos < sizeof(T)) {
             throw std::runtime_error("Unexpected end of server tokens state");
         }
@@ -261,23 +305,20 @@ public:
         return value;
     }
 
-    void read_raw(void * dst, size_t length) {
-        if (size - pos < length) {
+    template <typename T>
+    std::vector<T> read_vector() {
+        static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
+        const uint32_t n_values = read<uint32_t>();
+        // reject before resizing, so that a small corrupted payload cannot request a huge allocation
+        if (n_values > remaining() / sizeof(T)) {
             throw std::runtime_error("Unexpected end of server tokens state");
         }
-        if (length > 0) {
-            std::memcpy(dst, data + pos, length);
+        std::vector<T> values(n_values);
+        if (n_values > 0) {
+            std::memcpy(values.data(), data + pos, values.size() * sizeof(T));
+            pos += values.size() * sizeof(T);
         }
-        pos += length;
-    }
-
-    std::string read_string(size_t length) {
-        if (size - pos < length) {
-            throw std::runtime_error("Unexpected end of server tokens state");
-        }
-        std::string value(data + pos, length);
-        pos += length;
-        return value;
+        return values;
     }
 
     bool done() const {
@@ -293,13 +334,6 @@ private:
     size_t size;
     size_t pos = 0;
 };
-
-uint32_t server_tokens_state_u32(size_t value) {
-    if (value > std::numeric_limits<uint32_t>::max()) {
-        throw std::runtime_error("Server tokens state is too large");
-    }
-    return value;
-}
 
 } // namespace
 
@@ -479,15 +513,17 @@ const llama_tokens & server_tokens::get_tokens() const {
 std::vector<char> server_tokens::serialize() const {
     static_assert(sizeof(llama_token) == sizeof(uint32_t), "unexpected llama_token size");
 
-    std::vector<char> data;
-    server_tokens_state_write(data, (llama_token) LLAMA_TOKEN_NULL);
-    server_tokens_state_write(data, SERVER_TOKENS_STATE_VERSION);
-    server_tokens_state_write(data, server_tokens_state_u32(tokens.size()));
+    server_tokens_state_writer writer;
+    writer.write((llama_token) LLAMA_TOKEN_NULL);
+    writer.write(SERVER_TOKENS_STATE_VERSION);
+    writer.write(tokens);
 
-    const auto * tokens_bytes = reinterpret_cast<const char *>(tokens.data());
-    data.insert(data.end(), tokens_bytes, tokens_bytes + tokens.size() * sizeof(llama_token));
-
-    server_tokens_state_write(data, server_tokens_state_u32(map_idx_to_media.size()));
+    std::vector<uint32_t> media_keys;
+    media_keys.reserve(map_idx_to_media.size());
+    for (const auto & item : map_idx_to_media) {
+        media_keys.push_back(server_tokens_state_u32(item.first));
+    }
+    writer.write(media_keys);
 
     for (const auto & item : map_idx_to_media) {
         const auto * chunk = item.second.get();
@@ -506,23 +542,10 @@ std::vector<char> server_tokens::serialize() const {
             throw std::runtime_error("Slot save with image tokens without an ID is not supported");
         }
 
-        size_t chunk_size = 0;
-        if (mtmd_input_chunk_save(chunk, nullptr, 0, &chunk_size) != 0 || chunk_size == 0) {
-            throw std::runtime_error("Cannot serialize image chunk in server tokens");
-        }
-        server_tokens_state_write(data, server_tokens_state_u32(item.first));
-        server_tokens_state_write(data, server_tokens_state_u32(chunk_size));
-        const size_t offset = data.size();
-        data.resize(offset + chunk_size);
-        if (mtmd_input_chunk_save(chunk, data.data() + offset, chunk_size, nullptr) != 0) {
-            throw std::runtime_error("Cannot serialize image chunk in server tokens");
-        }
+        writer.write_image_chunk(chunk);
     }
 
-    // zero-pad the byte stream into whole tokens
-    data.resize((data.size() + sizeof(llama_token) - 1) / sizeof(llama_token) * sizeof(llama_token), 0);
-
-    return data;
+    return writer.take();
 }
 
 server_tokens server_tokens::deserialize(const llama_tokens & packed, bool has_mtmd) {
@@ -539,25 +562,23 @@ server_tokens server_tokens::deserialize(const llama_tokens & packed, bool has_m
         throw std::runtime_error("Unsupported server tokens state version");
     }
 
-    const uint32_t n_tokens = reader.read<uint32_t>();
-    if (n_tokens > reader.remaining() / sizeof(llama_token)) {
-        throw std::runtime_error("Unexpected end of server tokens state");
-    }
-    llama_tokens tokens(n_tokens);
-    reader.read_raw(tokens.data(), (size_t) n_tokens * sizeof(llama_token));
+    const llama_tokens tokens = reader.read_vector<llama_token>();
 
-    const uint32_t n_media = reader.read<uint32_t>();
-    if (n_media > 0 && !has_mtmd) {
+    // the image start indices, followed by the image chunks in the same order
+    const std::vector<uint32_t> media_keys = reader.read_vector<uint32_t>();
+    if (!media_keys.empty() && !has_mtmd) {
         throw std::runtime_error("Cannot restore image tokens without an mmproj");
     }
 
     server_tokens result(tokens, has_mtmd);
     size_t last_end = 0;
 
-    for (uint32_t i = 0; i < n_media; ++i) {
-        const size_t start_idx = reader.read<uint32_t>();
-        const size_t chunk_size = reader.read<uint32_t>();
-        const std::string chunk_data = reader.read_string(chunk_size);
+    for (const uint32_t key : media_keys) {
+        const size_t start_idx = key;
+        const std::vector<char> chunk_data = reader.read_vector<char>();
+        if (chunk_data.empty()) {
+            throw std::runtime_error("Cannot load image chunk from server tokens state");
+        }
 
         mtmd::input_chunk_ptr chunk(mtmd_input_chunk_load(chunk_data.data(), chunk_data.size()));
         if (!chunk) {

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <fstream>
 #include <limits>
+#include <cstring>
 
 json format_error_response(const std::string & message, const enum error_type type) {
     std::string type_str;
@@ -235,6 +236,60 @@ static inline raw_buffer base64_decode(const std::string & encoded_string) {
 // server_tokens implementation
 //
 
+namespace {
+
+constexpr uint32_t SERVER_TOKENS_STATE_MAGIC   = 0x53544d4d; // 'STMM'
+constexpr uint32_t SERVER_TOKENS_STATE_VERSION = 1;
+
+template <typename T>
+void server_tokens_state_write(std::vector<uint8_t> & data, T value) {
+    const auto * ptr = reinterpret_cast<const uint8_t *>(&value);
+    data.insert(data.end(), ptr, ptr + sizeof(value));
+}
+
+class server_tokens_state_reader {
+public:
+    server_tokens_state_reader(const uint8_t * data, size_t size) : data(data), size(size) {}
+
+    template <typename T>
+    T read() {
+        if (size - pos < sizeof(T)) {
+            throw std::runtime_error("Unexpected end of server tokens state");
+        }
+        T value;
+        std::memcpy(&value, data + pos, sizeof(value));
+        pos += sizeof(value);
+        return value;
+    }
+
+    std::string read_string(size_t length) {
+        if (size - pos < length) {
+            throw std::runtime_error("Unexpected end of server tokens state");
+        }
+        std::string value(reinterpret_cast<const char *>(data + pos), length);
+        pos += length;
+        return value;
+    }
+
+    bool done() const {
+        return pos == size;
+    }
+
+private:
+    const uint8_t * data;
+    size_t size;
+    size_t pos = 0;
+};
+
+uint32_t server_tokens_state_u32(size_t value) {
+    if (value > std::numeric_limits<uint32_t>::max()) {
+        throw std::runtime_error("Server tokens state is too large");
+    }
+    return value;
+}
+
+} // namespace
+
 server_tokens::server_tokens(mtmd::input_chunks & mtmd_chunks, bool has_mtmd) : has_mtmd(has_mtmd) {
     for (size_t i = 0; i < mtmd_chunks.size(); ++i) {
         push_back(mtmd_chunks[i]);
@@ -406,6 +461,126 @@ void server_tokens::insert(const llama_tokens & inp_tokens) {
 const llama_tokens & server_tokens::get_tokens() const {
     GGML_ASSERT(!has_mtmd);
     return tokens;
+}
+
+const llama_tokens & server_tokens::get_tokens_for_save() const {
+    return tokens;
+}
+
+std::vector<uint8_t> server_tokens::serialize_media_state() const {
+    if (map_idx_to_media.empty()) {
+        return {};
+    }
+
+    std::vector<uint8_t> data;
+    server_tokens_state_write(data, SERVER_TOKENS_STATE_MAGIC);
+    server_tokens_state_write(data, SERVER_TOKENS_STATE_VERSION);
+    server_tokens_state_write(data, server_tokens_state_u32(map_idx_to_media.size()));
+
+    for (const auto & item : map_idx_to_media) {
+        const auto * chunk = item.second.get();
+        const auto type = mtmd_input_chunk_get_type(chunk);
+        if (type != MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+            throw std::runtime_error("Slot save with audio tokens is not supported");
+        }
+
+        const size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk);
+        const llama_pos n_pos = mtmd_input_chunk_get_n_pos(chunk);
+        const char * id = mtmd_input_chunk_get_id(chunk);
+        if (n_tokens == 0 || n_pos <= 0) {
+            throw std::runtime_error("Invalid image chunk in server tokens");
+        }
+        if (id == nullptr || id[0] == '\0') {
+            throw std::runtime_error("Slot save with image tokens without an ID is not supported");
+        }
+
+        size_t chunk_size = 0;
+        if (mtmd_input_chunk_save(chunk, nullptr, 0, &chunk_size) != 0 || chunk_size == 0) {
+            throw std::runtime_error("Cannot serialize image chunk in server tokens");
+        }
+        server_tokens_state_write(data, server_tokens_state_u32(item.first));
+        server_tokens_state_write(data, server_tokens_state_u32(chunk_size));
+        const size_t offset = data.size();
+        data.resize(offset + chunk_size);
+        if (mtmd_input_chunk_save(chunk, reinterpret_cast<char *>(data.data() + offset), chunk_size, nullptr) != 0) {
+            throw std::runtime_error("Cannot serialize image chunk in server tokens");
+        }
+    }
+
+    return data;
+}
+
+server_tokens server_tokens::deserialize_media_state(
+        const llama_tokens & tokens, bool has_mtmd, const uint8_t * data, size_t size) {
+    if (!has_mtmd) {
+        throw std::runtime_error("Cannot restore image tokens without an mmproj");
+    }
+
+    server_tokens_state_reader reader(data, size);
+    if (reader.read<uint32_t>() != SERVER_TOKENS_STATE_MAGIC) {
+        throw std::runtime_error("Invalid server tokens state magic");
+    }
+    if (reader.read<uint32_t>() != SERVER_TOKENS_STATE_VERSION) {
+        throw std::runtime_error("Unsupported server tokens state version");
+    }
+
+    const uint32_t n_media = reader.read<uint32_t>();
+    if (n_media == 0) {
+        throw std::runtime_error("Server tokens state contains no images");
+    }
+
+    server_tokens result(tokens, true);
+    size_t last_end = 0;
+
+    for (uint32_t i = 0; i < n_media; ++i) {
+        const size_t start_idx = reader.read<uint32_t>();
+        const size_t chunk_size = reader.read<uint32_t>();
+        const std::string chunk_data = reader.read_string(chunk_size);
+
+        mtmd::input_chunk_ptr chunk(mtmd_input_chunk_load(chunk_data.data(), chunk_data.size()));
+        if (!chunk) {
+            throw std::runtime_error("Cannot load image chunk from server tokens state");
+        }
+        if (mtmd_input_chunk_get_type(chunk.get()) != MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+            throw std::runtime_error("Unsupported media type in server tokens state");
+        }
+        const char * id = mtmd_input_chunk_get_id(chunk.get());
+        if (id == nullptr || id[0] == '\0') {
+            throw std::runtime_error("Image ID is missing in server tokens state");
+        }
+        const size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk.get());
+        const llama_pos n_pos = mtmd_input_chunk_get_n_pos(chunk.get());
+        if (n_tokens == 0 || n_pos <= 0 || start_idx < last_end ||
+                start_idx > tokens.size() || n_tokens > tokens.size() - start_idx) {
+            throw std::runtime_error("Invalid image range in server tokens state");
+        }
+        for (size_t j = start_idx; j < start_idx + n_tokens; ++j) {
+            if (tokens[j] != LLAMA_TOKEN_NULL) {
+                throw std::runtime_error("Image range does not match server tokens");
+            }
+        }
+
+        result.map_idx_to_media[start_idx] = std::move(chunk);
+        last_end = start_idx + n_tokens;
+    }
+
+    if (!reader.done()) {
+        throw std::runtime_error("Trailing data in server tokens state");
+    }
+
+    for (size_t i = 0; i < tokens.size();) {
+        if (tokens[i] != LLAMA_TOKEN_NULL) {
+            ++i;
+            continue;
+        }
+        const auto it = result.map_idx_to_media.find(i);
+        if (it == result.map_idx_to_media.end()) {
+            throw std::runtime_error("Image token has no descriptor");
+        }
+        i += mtmd_input_chunk_get_n_tokens(it->second.get());
+    }
+
+    return result;
 }
 
 llama_tokens server_tokens::get_text_tokens() const {

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -321,10 +321,6 @@ public:
         return values;
     }
 
-    bool done() const {
-        return pos == size;
-    }
-
     size_t remaining() const {
         return size - pos;
     }
@@ -567,20 +563,11 @@ server_tokens server_tokens::deserialize(const llama_tokens & packed, bool has_m
         if (!chunk) {
             throw std::runtime_error("Cannot load media chunk from server tokens state");
         }
-        const auto type = mtmd_input_chunk_get_type(chunk.get());
-        if (type != MTMD_INPUT_CHUNK_TYPE_IMAGE && type != MTMD_INPUT_CHUNK_TYPE_AUDIO) {
-            throw std::runtime_error("Unsupported media type in server tokens state");
-        }
         result.map_idx_to_media[start_idx] = std::move(chunk);
     }
 
     if (reader.remaining() >= sizeof(llama_token)) {
         throw std::runtime_error("Trailing data in server tokens state");
-    }
-    while (!reader.done()) {
-        if (reader.read<uint8_t>() != 0) {
-            throw std::runtime_error("Invalid padding in server tokens state");
-        }
     }
 
     return result;
@@ -715,6 +702,9 @@ bool server_tokens::validate(const struct llama_context * ctx) const {
         if (t == LLAMA_TOKEN_NULL) {
             try {
                 const auto & chunk = find_chunk(i);
+                if (mtmd_input_chunk_get_type(chunk.get()) == MTMD_INPUT_CHUNK_TYPE_TEXT) {
+                    return false;
+                }
                 const size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk.get());
                 const llama_pos n_pos = mtmd_input_chunk_get_n_pos(chunk.get());
                 if (n_tokens == 0 || n_pos <= 0 || n_tokens > tokens.size() - i) {

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -268,14 +268,14 @@ public:
         data.insert(data.end(), ptr, ptr + values.size() * sizeof(T));
     }
 
-    void write_image_chunk(const mtmd_input_chunk * chunk) {
+    void write_media_chunk(const mtmd_input_chunk * chunk) {
         size_t chunk_size = 0;
         if (mtmd_input_chunk_save(chunk, nullptr, 0, &chunk_size) != 0 || chunk_size == 0) {
-            throw std::runtime_error("Cannot serialize image chunk in server tokens");
+            throw std::runtime_error("Cannot serialize media chunk in server tokens");
         }
         std::vector<char> chunk_data(server_tokens_state_u32(chunk_size));
         if (mtmd_input_chunk_save(chunk, chunk_data.data(), chunk_data.size(), nullptr) != 0) {
-            throw std::runtime_error("Cannot serialize image chunk in server tokens");
+            throw std::runtime_error("Cannot serialize media chunk in server tokens");
         }
         write(chunk_data);
     }
@@ -526,23 +526,7 @@ std::vector<char> server_tokens::serialize() const {
     writer.write(media_keys);
 
     for (const auto & item : map_idx_to_media) {
-        const auto * chunk = item.second.get();
-        const auto type = mtmd_input_chunk_get_type(chunk);
-        if (type != MTMD_INPUT_CHUNK_TYPE_IMAGE) {
-            throw std::runtime_error("Slot save with audio tokens is not supported");
-        }
-
-        const size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk);
-        const llama_pos n_pos = mtmd_input_chunk_get_n_pos(chunk);
-        const char * id = mtmd_input_chunk_get_id(chunk);
-        if (n_tokens == 0 || n_pos <= 0) {
-            throw std::runtime_error("Invalid image chunk in server tokens");
-        }
-        if (id == nullptr || id[0] == '\0') {
-            throw std::runtime_error("Slot save with image tokens without an ID is not supported");
-        }
-
-        writer.write_image_chunk(chunk);
+        writer.write_media_chunk(item.second.get());
     }
 
     return writer.take();
@@ -564,47 +548,30 @@ server_tokens server_tokens::deserialize(const llama_tokens & packed, bool has_m
 
     const llama_tokens tokens = reader.read_vector<llama_token>();
 
-    // the image start indices, followed by the image chunks in the same order
+    // the media start indices, followed by the media chunks in the same order
     const std::vector<uint32_t> media_keys = reader.read_vector<uint32_t>();
     if (!media_keys.empty() && !has_mtmd) {
-        throw std::runtime_error("Cannot restore image tokens without an mmproj");
+        throw std::runtime_error("Cannot restore media tokens without an mmproj");
     }
 
     server_tokens result(tokens, has_mtmd);
-    size_t last_end = 0;
 
     for (const uint32_t key : media_keys) {
         const size_t start_idx = key;
         const std::vector<char> chunk_data = reader.read_vector<char>();
         if (chunk_data.empty()) {
-            throw std::runtime_error("Cannot load image chunk from server tokens state");
+            throw std::runtime_error("Cannot load media chunk from server tokens state");
         }
 
         mtmd::input_chunk_ptr chunk(mtmd_input_chunk_load(chunk_data.data(), chunk_data.size()));
         if (!chunk) {
-            throw std::runtime_error("Cannot load image chunk from server tokens state");
+            throw std::runtime_error("Cannot load media chunk from server tokens state");
         }
-        if (mtmd_input_chunk_get_type(chunk.get()) != MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+        const auto type = mtmd_input_chunk_get_type(chunk.get());
+        if (type != MTMD_INPUT_CHUNK_TYPE_IMAGE && type != MTMD_INPUT_CHUNK_TYPE_AUDIO) {
             throw std::runtime_error("Unsupported media type in server tokens state");
         }
-        const char * id = mtmd_input_chunk_get_id(chunk.get());
-        if (id == nullptr || id[0] == '\0') {
-            throw std::runtime_error("Image ID is missing in server tokens state");
-        }
-        const size_t n_chunk_tokens = mtmd_input_chunk_get_n_tokens(chunk.get());
-        const llama_pos n_pos = mtmd_input_chunk_get_n_pos(chunk.get());
-        if (n_chunk_tokens == 0 || n_pos <= 0 || start_idx < last_end ||
-                start_idx > tokens.size() || n_chunk_tokens > tokens.size() - start_idx) {
-            throw std::runtime_error("Invalid image range in server tokens state");
-        }
-        for (size_t j = start_idx; j < start_idx + n_chunk_tokens; ++j) {
-            if (tokens[j] != LLAMA_TOKEN_NULL) {
-                throw std::runtime_error("Image range does not match server tokens");
-            }
-        }
-
         result.map_idx_to_media[start_idx] = std::move(chunk);
-        last_end = start_idx + n_chunk_tokens;
     }
 
     if (reader.remaining() >= sizeof(llama_token)) {
@@ -614,18 +581,6 @@ server_tokens server_tokens::deserialize(const llama_tokens & packed, bool has_m
         if (reader.read<uint8_t>() != 0) {
             throw std::runtime_error("Invalid padding in server tokens state");
         }
-    }
-
-    for (size_t i = 0; i < tokens.size();) {
-        if (tokens[i] != LLAMA_TOKEN_NULL) {
-            ++i;
-            continue;
-        }
-        const auto it = result.map_idx_to_media.find(i);
-        if (it == result.map_idx_to_media.end()) {
-            throw std::runtime_error("Image token has no descriptor");
-        }
-        i += mtmd_input_chunk_get_n_tokens(it->second.get());
     }
 
     return result;
@@ -753,14 +708,25 @@ bool server_tokens::validate(const struct llama_context * ctx) const {
     const llama_model * model = llama_get_model(ctx);
     const llama_vocab * vocab = llama_model_get_vocab(model);
     const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+    size_t n_media = 0;
 
     for (size_t i = 0; i < tokens.size(); ++i) {
         const auto & t = tokens[i];
         if (t == LLAMA_TOKEN_NULL) {
             try {
                 const auto & chunk = find_chunk(i);
-                size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk.get());
-                i += n_tokens - 1; // will be +1 by the for loop
+                const size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk.get());
+                const llama_pos n_pos = mtmd_input_chunk_get_n_pos(chunk.get());
+                if (n_tokens == 0 || n_pos <= 0 || n_tokens > tokens.size() - i) {
+                    return false;
+                }
+                for (size_t j = i; j < i + n_tokens; ++j) {
+                    if (tokens[j] != LLAMA_TOKEN_NULL) {
+                        return false;
+                    }
+                }
+                ++n_media;
+                i += n_tokens - 1;
             } catch (const std::exception & e) {
                 return false;
             }
@@ -768,7 +734,7 @@ bool server_tokens::validate(const struct llama_context * ctx) const {
             return false;
         }
     }
-    return true;
+    return n_media == map_idx_to_media.size();
 }
 
 server_tokens server_tokens::clone() const {

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -238,18 +238,17 @@ static inline raw_buffer base64_decode(const std::string & encoded_string) {
 
 namespace {
 
-constexpr uint32_t SERVER_TOKENS_STATE_MAGIC   = 0x53544d4d; // 'STMM'
 constexpr uint32_t SERVER_TOKENS_STATE_VERSION = 1;
 
 template <typename T>
-void server_tokens_state_write(std::vector<uint8_t> & data, T value) {
-    const auto * ptr = reinterpret_cast<const uint8_t *>(&value);
+void server_tokens_state_write(std::vector<char> & data, T value) {
+    const auto * ptr = reinterpret_cast<const char *>(&value);
     data.insert(data.end(), ptr, ptr + sizeof(value));
 }
 
 class server_tokens_state_reader {
 public:
-    server_tokens_state_reader(const uint8_t * data, size_t size) : data(data), size(size) {}
+    server_tokens_state_reader(const char * data, size_t size) : data(data), size(size) {}
 
     template <typename T>
     T read() {
@@ -262,11 +261,21 @@ public:
         return value;
     }
 
+    void read_raw(void * dst, size_t length) {
+        if (size - pos < length) {
+            throw std::runtime_error("Unexpected end of server tokens state");
+        }
+        if (length > 0) {
+            std::memcpy(dst, data + pos, length);
+        }
+        pos += length;
+    }
+
     std::string read_string(size_t length) {
         if (size - pos < length) {
             throw std::runtime_error("Unexpected end of server tokens state");
         }
-        std::string value(reinterpret_cast<const char *>(data + pos), length);
+        std::string value(data + pos, length);
         pos += length;
         return value;
     }
@@ -275,8 +284,12 @@ public:
         return pos == size;
     }
 
+    size_t remaining() const {
+        return size - pos;
+    }
+
 private:
-    const uint8_t * data;
+    const char * data;
     size_t size;
     size_t pos = 0;
 };
@@ -463,18 +476,17 @@ const llama_tokens & server_tokens::get_tokens() const {
     return tokens;
 }
 
-const llama_tokens & server_tokens::get_tokens_for_save() const {
-    return tokens;
-}
+std::vector<char> server_tokens::serialize() const {
+    static_assert(sizeof(llama_token) == sizeof(uint32_t), "unexpected llama_token size");
 
-std::vector<uint8_t> server_tokens::serialize_media_state() const {
-    if (map_idx_to_media.empty()) {
-        return {};
-    }
-
-    std::vector<uint8_t> data;
-    server_tokens_state_write(data, SERVER_TOKENS_STATE_MAGIC);
+    std::vector<char> data;
+    server_tokens_state_write(data, (llama_token) LLAMA_TOKEN_NULL);
     server_tokens_state_write(data, SERVER_TOKENS_STATE_VERSION);
+    server_tokens_state_write(data, server_tokens_state_u32(tokens.size()));
+
+    const auto * tokens_bytes = reinterpret_cast<const char *>(tokens.data());
+    data.insert(data.end(), tokens_bytes, tokens_bytes + tokens.size() * sizeof(llama_token));
+
     server_tokens_state_write(data, server_tokens_state_u32(map_idx_to_media.size()));
 
     for (const auto & item : map_idx_to_media) {
@@ -502,34 +514,44 @@ std::vector<uint8_t> server_tokens::serialize_media_state() const {
         server_tokens_state_write(data, server_tokens_state_u32(chunk_size));
         const size_t offset = data.size();
         data.resize(offset + chunk_size);
-        if (mtmd_input_chunk_save(chunk, reinterpret_cast<char *>(data.data() + offset), chunk_size, nullptr) != 0) {
+        if (mtmd_input_chunk_save(chunk, data.data() + offset, chunk_size, nullptr) != 0) {
             throw std::runtime_error("Cannot serialize image chunk in server tokens");
         }
     }
 
+    // zero-pad the byte stream into whole tokens
+    data.resize((data.size() + sizeof(llama_token) - 1) / sizeof(llama_token) * sizeof(llama_token), 0);
+
     return data;
 }
 
-server_tokens server_tokens::deserialize_media_state(
-        const llama_tokens & tokens, bool has_mtmd, const uint8_t * data, size_t size) {
-    if (!has_mtmd) {
-        throw std::runtime_error("Cannot restore image tokens without an mmproj");
+server_tokens server_tokens::deserialize(const llama_tokens & packed, bool has_mtmd) {
+    static_assert(sizeof(llama_token) == sizeof(uint32_t), "unexpected llama_token size");
+
+    if (packed.empty() || packed[0] != LLAMA_TOKEN_NULL) {
+        // plain token list, as written by older versions
+        return server_tokens(packed, has_mtmd);
     }
 
-    server_tokens_state_reader reader(data, size);
-    if (reader.read<uint32_t>() != SERVER_TOKENS_STATE_MAGIC) {
-        throw std::runtime_error("Invalid server tokens state magic");
-    }
+    server_tokens_state_reader reader(reinterpret_cast<const char *>(packed.data()), packed.size() * sizeof(llama_token));
+    reader.read<llama_token>(); // format marker
     if (reader.read<uint32_t>() != SERVER_TOKENS_STATE_VERSION) {
         throw std::runtime_error("Unsupported server tokens state version");
     }
 
+    const uint32_t n_tokens = reader.read<uint32_t>();
+    if (n_tokens > reader.remaining() / sizeof(llama_token)) {
+        throw std::runtime_error("Unexpected end of server tokens state");
+    }
+    llama_tokens tokens(n_tokens);
+    reader.read_raw(tokens.data(), (size_t) n_tokens * sizeof(llama_token));
+
     const uint32_t n_media = reader.read<uint32_t>();
-    if (n_media == 0) {
-        throw std::runtime_error("Server tokens state contains no images");
+    if (n_media > 0 && !has_mtmd) {
+        throw std::runtime_error("Cannot restore image tokens without an mmproj");
     }
 
-    server_tokens result(tokens, true);
+    server_tokens result(tokens, has_mtmd);
     size_t last_end = 0;
 
     for (uint32_t i = 0; i < n_media; ++i) {
@@ -548,24 +570,29 @@ server_tokens server_tokens::deserialize_media_state(
         if (id == nullptr || id[0] == '\0') {
             throw std::runtime_error("Image ID is missing in server tokens state");
         }
-        const size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk.get());
+        const size_t n_chunk_tokens = mtmd_input_chunk_get_n_tokens(chunk.get());
         const llama_pos n_pos = mtmd_input_chunk_get_n_pos(chunk.get());
-        if (n_tokens == 0 || n_pos <= 0 || start_idx < last_end ||
-                start_idx > tokens.size() || n_tokens > tokens.size() - start_idx) {
+        if (n_chunk_tokens == 0 || n_pos <= 0 || start_idx < last_end ||
+                start_idx > tokens.size() || n_chunk_tokens > tokens.size() - start_idx) {
             throw std::runtime_error("Invalid image range in server tokens state");
         }
-        for (size_t j = start_idx; j < start_idx + n_tokens; ++j) {
+        for (size_t j = start_idx; j < start_idx + n_chunk_tokens; ++j) {
             if (tokens[j] != LLAMA_TOKEN_NULL) {
                 throw std::runtime_error("Image range does not match server tokens");
             }
         }
 
         result.map_idx_to_media[start_idx] = std::move(chunk);
-        last_end = start_idx + n_tokens;
+        last_end = start_idx + n_chunk_tokens;
     }
 
-    if (!reader.done()) {
+    if (reader.remaining() >= sizeof(llama_token)) {
         throw std::runtime_error("Trailing data in server tokens state");
+    }
+    while (!reader.done()) {
+        if (reader.read<uint8_t>() != 0) {
+            throw std::runtime_error("Invalid padding in server tokens state");
+        }
     }
 
     for (size_t i = 0; i < tokens.size();) {

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -206,7 +206,7 @@ public:
 
     llama_tokens get_text_tokens() const;
 
-    // packed into the token payload of a sequence state file: [LLAMA_TOKEN_NULL][version][n_tokens][tokens][n_media][start_idx]...([chunk_size][image chunk])...[zero padding]
+    // packed into the token payload of a sequence state file: [LLAMA_TOKEN_NULL][version][n_tokens][tokens][n_media][start_idx]...([chunk_size][media chunk])...[zero padding]
     // a payload that does not start with LLAMA_TOKEN_NULL is a plain token list, as written by older versions
     std::vector<char> serialize() const;
     static server_tokens deserialize(const llama_tokens & packed, bool has_mtmd);
@@ -235,7 +235,7 @@ public:
     // split the tokens into message spans, skipping over media chunks
     common_chat_msg_spans find_message_spans(const common_chat_msg_delimiters & delims) const;
 
-    // make sure all text tokens are within the vocab range
+    // check text token IDs and the mapping between media chunks and token ranges
     bool validate(const struct llama_context * ctx) const;
 
     server_tokens clone() const;

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -206,7 +206,7 @@ public:
 
     llama_tokens get_text_tokens() const;
 
-    // packed into the token payload of a sequence state file: [LLAMA_TOKEN_NULL][version][n_tokens][tokens][n_media]([start_idx][chunk_size][image chunk])...[zero padding]
+    // packed into the token payload of a sequence state file: [LLAMA_TOKEN_NULL][version][n_tokens][tokens][n_media][start_idx]...([chunk_size][image chunk])...[zero padding]
     // a payload that does not start with LLAMA_TOKEN_NULL is a plain token list, as written by older versions
     std::vector<char> serialize() const;
     static server_tokens deserialize(const llama_tokens & packed, bool has_mtmd);

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -201,14 +201,15 @@ public:
     // for compatibility with context shift and prompt truncation
     void insert(const llama_tokens & inp_tokens);
 
-    // for compatibility with speculative decoding, ctx shift, slot save/load
+    // for compatibility with speculative decoding, ctx shift
     const llama_tokens & get_tokens() const;
-    const llama_tokens & get_tokens_for_save() const;
 
     llama_tokens get_text_tokens() const;
 
-    std::vector<uint8_t> serialize_media_state() const;
-    static server_tokens deserialize_media_state(const llama_tokens & tokens, bool has_mtmd, const uint8_t * data, size_t size);
+    // packed into the token payload of a sequence state file: [LLAMA_TOKEN_NULL][version][n_tokens][tokens][n_media]([start_idx][chunk_size][image chunk])...[zero padding]
+    // a payload that does not start with LLAMA_TOKEN_NULL is a plain token list, as written by older versions
+    std::vector<char> serialize() const;
+    static server_tokens deserialize(const llama_tokens & packed, bool has_mtmd);
 
     // for compatibility with speculative decoding
     void set_token(llama_pos pos, llama_token id);

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -216,9 +216,6 @@ public:
 
     bool empty() const { return tokens.empty(); }
 
-    // true if the sequence actually contains image/audio chunks.
-    bool has_media() const { return !map_idx_to_media.empty(); }
-
     void clear() {
         map_idx_to_media.clear();
         tokens.clear();

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -206,8 +206,6 @@ public:
 
     llama_tokens get_text_tokens() const;
 
-    // packed into the token payload of a sequence state file: [LLAMA_TOKEN_NULL][version][n_tokens][tokens][n_media][start_idx]...([chunk_size][media chunk])...[zero padding]
-    // a payload that does not start with LLAMA_TOKEN_NULL is a plain token list, as written by older versions
     std::vector<char> serialize() const;
     static server_tokens deserialize(const llama_tokens & packed, bool has_mtmd);
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -203,8 +203,12 @@ public:
 
     // for compatibility with speculative decoding, ctx shift, slot save/load
     const llama_tokens & get_tokens() const;
+    const llama_tokens & get_tokens_for_save() const;
 
     llama_tokens get_text_tokens() const;
+
+    std::vector<uint8_t> serialize_media_state() const;
+    static server_tokens deserialize_media_state(const llama_tokens & tokens, bool has_mtmd, const uint8_t * data, size_t size);
 
     // for compatibility with speculative decoding
     void set_token(llama_pos pos, llama_token id);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -54,6 +54,32 @@ static uint32_t server_n_outputs_max(const common_params & params) {
     return std::max<uint32_t>(1, std::min<uint64_t>(n_batch, n_outputs));
 }
 
+// the token payload of a sequence state file holds a packed server_tokens object (see server_tokens::serialize()), so it can be longer than the number of tokens the slot holds.
+// read its size from the file header, falling back to n_ctx if the header cannot be trusted - llama_state_seq_load_file() then reports the malformed file.
+// TODO: remove this once llama_state_seq_save_file() can store arbitrary user data
+static size_t state_file_payload_size(const std::string & filepath, size_t fallback) {
+    constexpr std::streamoff header_size = 3 * sizeof(uint32_t); // magic, version, payload size
+
+    std::ifstream file(filepath, std::ios::binary | std::ios::ate);
+    if (!file) {
+        return fallback;
+    }
+
+    const std::streamoff file_size = file.tellg();
+    if (file_size < header_size) {
+        return fallback;
+    }
+
+    uint32_t payload_size = 0;
+    file.seekg(header_size - sizeof(payload_size), std::ios::beg);
+    file.read(reinterpret_cast<char *>(&payload_size), sizeof(payload_size));
+    if (!file || payload_size > (file_size - header_size) / (std::streamoff) sizeof(llama_token)) {
+        return fallback;
+    }
+
+    return payload_size;
+}
+
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
 enum slot_state {
     SLOT_STATE_IDLE,
@@ -2081,8 +2107,7 @@ private:
         queue_results.send(std::move(res));
     }
 
-    // Gate erase on slot content (does it hold media), not model capability:
-    // a multimodal model may hold a pure-text slot.
+    // Gate erase on slot content (does it hold media), not model capability: a multimodal model may hold a pure-text slot.
     bool check_slot_no_media_for_erase(const server_slot & slot, const int id_task) {
         if (slot.prompt.tokens.has_media()) {
             send_error(id_task,
@@ -2598,36 +2623,21 @@ private:
                     std::string filename = task.slot_action.filename;
                     std::string filepath = task.slot_action.filepath;
 
-                    std::vector<uint8_t> media_state;
+                    std::vector<char> packed;
                     try {
-                        media_state = slot->prompt.tokens.serialize_media_state();
+                        packed = slot->prompt.tokens.serialize();
                     } catch (const std::exception & err) {
                         send_error(task, err.what(), ERROR_TYPE_NOT_SUPPORTED);
                         break;
                     }
 
-                    const llama_tokens tokens = media_state.empty()
-                        ? slot->prompt.tokens.get_text_tokens()
-                        : slot->prompt.tokens.get_tokens_for_save();
-                    const size_t token_count = tokens.size();
-                    size_t nwrite = llama_state_seq_save_file(
-                        ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
+                    GGML_ASSERT(packed.size() % sizeof(llama_token) == 0);
+                    const size_t nwrite = llama_state_seq_save_file(
+                        ctx_tgt, filepath.c_str(), slot->id,
+                        reinterpret_cast<const llama_token *>(packed.data()), packed.size() / sizeof(llama_token));
                     if (nwrite == 0) {
                         send_error(task, "Unable to save slot", ERROR_TYPE_SERVER);
                         break;
-                    }
-
-                    if (!media_state.empty()) {
-                        std::ofstream file(filepath, std::ios::binary | std::ios::app);
-                        file.write(reinterpret_cast<const char *>(media_state.data()), media_state.size());
-                        file.close();
-                        if (!file) {
-                            std::error_code ec;
-                            std::filesystem::remove(filepath, ec);
-                            send_error(task, "Unable to save image tokens", ERROR_TYPE_SERVER);
-                            break;
-                        }
-                        nwrite += media_state.size();
                     }
 
                     const int64_t t_end = ggml_time_us();
@@ -2638,7 +2648,7 @@ private:
                     res->id_slot  = id_slot;
                     res->filename = filename;
                     res->is_save  = true;
-                    res->n_tokens = token_count;
+                    res->n_tokens = slot->prompt.tokens.size();
                     res->n_bytes  = nwrite;
                     res->t_ms     = t_save_ms;
                     queue_results.send(std::move(res));
@@ -2663,38 +2673,21 @@ private:
                     std::string filename = task.slot_action.filename;
                     std::string filepath = task.slot_action.filepath;
 
-                    llama_tokens tokens;
-                    tokens.resize(slot->n_ctx);
-                    size_t token_count = 0;
-                    size_t nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), tokens.size(), &token_count);
-                    if (nread == 0) {
-                        slot->prompt.clear(); // KV may already been invalidated?
-                        send_error(task, "Unable to restore slot, no available space in KV cache or invalid slot save file", ERROR_TYPE_INVALID_REQUEST);
-                        break;
-                    }
-                    tokens.resize(token_count);
+                    size_t nread = 0;
                     try {
-                        server_tokens restored(tokens, mctx != nullptr);
-
-                        std::ifstream file(filepath, std::ios::binary | std::ios::ate);
-                        if (!file) {
-                            throw std::runtime_error("Unable to open slot save file");
+                        llama_tokens packed;
+                        packed.resize(state_file_payload_size(filepath, slot->n_ctx));
+                        size_t n_packed = 0;
+                        nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, packed.data(), packed.size(), &n_packed);
+                        if (nread == 0) {
+                            throw std::runtime_error("No available space in KV cache or invalid slot save file");
                         }
-                        const std::streamoff file_size = file.tellg();
-                        if (file_size < 0 || static_cast<size_t>(file_size) < nread) {
-                            throw std::runtime_error("Invalid slot save file size");
-                        }
+                        packed.resize(n_packed);
 
-                        if (static_cast<size_t>(file_size) > nread) {
-                            std::vector<uint8_t> media_state(static_cast<size_t>(file_size) - nread);
-                            file.seekg(static_cast<std::streamoff>(nread), std::ios::beg);
-                            file.read(reinterpret_cast<char *>(media_state.data()), media_state.size());
-                            if (!file) {
-                                throw std::runtime_error("Unable to read server tokens state");
-                            }
-                            restored = server_tokens::deserialize_media_state(
-                                tokens, mctx != nullptr, media_state.data(), media_state.size());
-                            nread = static_cast<size_t>(file_size);
+                        server_tokens restored = server_tokens::deserialize(packed, mctx != nullptr);
+
+                        if (restored.size() > (size_t) slot->n_ctx) {
+                            throw std::runtime_error("Restored prompt does not fit in the slot context");
                         }
 
                         if (!restored.validate(ctx_tgt)) {
@@ -2704,8 +2697,7 @@ private:
                         slot->prompt.clear();
                         slot->prompt.tokens = std::move(restored);
                     } catch (const std::exception & err) {
-                        llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot->id, -1, -1);
-                        slot->prompt.clear();
+                        slot->prompt_clear();
                         send_error(task, std::string("Unable to restore slot: ") + err.what(), ERROR_TYPE_INVALID_REQUEST);
                         break;
                     }
@@ -2718,7 +2710,7 @@ private:
                     res->id_slot  = id_slot;
                     res->filename = filename;
                     res->is_save  = false;
-                    res->n_tokens = token_count;
+                    res->n_tokens = slot->prompt.tokens.size();
                     res->n_bytes  = nread;
                     res->t_ms     = t_restore_ms;
                     queue_results.send(std::move(res));

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2081,9 +2081,9 @@ private:
         queue_results.send(std::move(res));
     }
 
-    // Gate slot save/restore/erase on slot content (does it hold media),
-    // not model capability: a multimodal model may hold a pure-text slot.
-    bool check_slot_no_media(const server_slot & slot, const int id_task) {
+    // Gate erase on slot content (does it hold media), not model capability:
+    // a multimodal model may hold a pure-text slot.
+    bool check_slot_no_media_for_erase(const server_slot & slot, const int id_task) {
         if (slot.prompt.tokens.has_media()) {
             send_error(id_task,
                 "This operation is not supported while the slot holds image/audio tokens (a pure-text prefix is supported)",
@@ -2586,9 +2586,6 @@ private:
                         send_error(task, "Invalid slot ID", ERROR_TYPE_INVALID_REQUEST);
                         break;
                     }
-                    if (!check_slot_no_media(*slot, task.id)) {
-                        break;
-                    }
                     if (slot->is_processing()) {
                         // if requested slot is unavailable, we defer this task for processing later
                         SRV_DBG("requested slot is unavailable, defer task, id_task = %d\n", task.id);
@@ -2601,9 +2598,37 @@ private:
                     std::string filename = task.slot_action.filename;
                     std::string filepath = task.slot_action.filepath;
 
-                    const llama_tokens tokens = slot->prompt.tokens.get_text_tokens();
+                    std::vector<uint8_t> media_state;
+                    try {
+                        media_state = slot->prompt.tokens.serialize_media_state();
+                    } catch (const std::exception & err) {
+                        send_error(task, err.what(), ERROR_TYPE_NOT_SUPPORTED);
+                        break;
+                    }
+
+                    const llama_tokens tokens = media_state.empty()
+                        ? slot->prompt.tokens.get_text_tokens()
+                        : slot->prompt.tokens.get_tokens_for_save();
                     const size_t token_count = tokens.size();
-                    const size_t nwrite = llama_state_seq_save_file(ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
+                    size_t nwrite = llama_state_seq_save_file(
+                        ctx_tgt, filepath.c_str(), slot->id, tokens.data(), token_count);
+                    if (nwrite == 0) {
+                        send_error(task, "Unable to save slot", ERROR_TYPE_SERVER);
+                        break;
+                    }
+
+                    if (!media_state.empty()) {
+                        std::ofstream file(filepath, std::ios::binary | std::ios::app);
+                        file.write(reinterpret_cast<const char *>(media_state.data()), media_state.size());
+                        file.close();
+                        if (!file) {
+                            std::error_code ec;
+                            std::filesystem::remove(filepath, ec);
+                            send_error(task, "Unable to save image tokens", ERROR_TYPE_SERVER);
+                            break;
+                        }
+                        nwrite += media_state.size();
+                    }
 
                     const int64_t t_end = ggml_time_us();
                     const double t_save_ms = (t_end - t_start) / 1000.0;
@@ -2648,8 +2673,42 @@ private:
                         break;
                     }
                     tokens.resize(token_count);
-                    slot->prompt.clear();
-                    slot->prompt.tokens.insert(tokens);
+                    try {
+                        server_tokens restored(tokens, mctx != nullptr);
+
+                        std::ifstream file(filepath, std::ios::binary | std::ios::ate);
+                        if (!file) {
+                            throw std::runtime_error("Unable to open slot save file");
+                        }
+                        const std::streamoff file_size = file.tellg();
+                        if (file_size < 0 || static_cast<size_t>(file_size) < nread) {
+                            throw std::runtime_error("Invalid slot save file size");
+                        }
+
+                        if (static_cast<size_t>(file_size) > nread) {
+                            std::vector<uint8_t> media_state(static_cast<size_t>(file_size) - nread);
+                            file.seekg(static_cast<std::streamoff>(nread), std::ios::beg);
+                            file.read(reinterpret_cast<char *>(media_state.data()), media_state.size());
+                            if (!file) {
+                                throw std::runtime_error("Unable to read server tokens state");
+                            }
+                            restored = server_tokens::deserialize_media_state(
+                                tokens, mctx != nullptr, media_state.data(), media_state.size());
+                            nread = static_cast<size_t>(file_size);
+                        }
+
+                        if (!restored.validate(ctx_tgt)) {
+                            throw std::runtime_error("Invalid tokens in slot save file");
+                        }
+
+                        slot->prompt.clear();
+                        slot->prompt.tokens = std::move(restored);
+                    } catch (const std::exception & err) {
+                        llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot->id, -1, -1);
+                        slot->prompt.clear();
+                        send_error(task, std::string("Unable to restore slot: ") + err.what(), ERROR_TYPE_INVALID_REQUEST);
+                        break;
+                    }
 
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
@@ -2672,8 +2731,7 @@ private:
                         send_error(task, "Invalid slot ID", ERROR_TYPE_INVALID_REQUEST);
                         break;
                     }
-                    // Gate on slot content, consistent with save/restore.
-                    if (!check_slot_no_media(*slot, task.id)) {
+                    if (!check_slot_no_media_for_erase(*slot, task.id)) {
                         break;
                     }
                     if (slot->is_processing()) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2081,17 +2081,6 @@ private:
         queue_results.send(std::move(res));
     }
 
-    // Gate erase on slot content (does it hold media), not model capability: a multimodal model may hold a pure-text slot.
-    bool check_slot_no_media_for_erase(const server_slot & slot, const int id_task) {
-        if (slot.prompt.tokens.has_media()) {
-            send_error(id_task,
-                "This operation is not supported while the slot holds image/audio tokens (a pure-text prefix is supported)",
-                ERROR_TYPE_NOT_SUPPORTED);
-            return false;
-        }
-        return true;
-    }
-
     void send_partial_response(server_slot & slot, const completion_token_output & tkn, bool is_progress, bool is_begin = false) {
         auto res = std::make_unique<server_task_result_cmpl_partial>();
 
@@ -2698,9 +2687,6 @@ private:
                     server_slot * slot = get_slot_by_id(id_slot);
                     if (slot == nullptr) {
                         send_error(task, "Invalid slot ID", ERROR_TYPE_INVALID_REQUEST);
-                        break;
-                    }
-                    if (!check_slot_no_media_for_erase(*slot, task.id)) {
                         break;
                     }
                     if (slot->is_processing()) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -54,32 +54,6 @@ static uint32_t server_n_outputs_max(const common_params & params) {
     return std::max<uint32_t>(1, std::min<uint64_t>(n_batch, n_outputs));
 }
 
-// the token payload of a sequence state file holds a packed server_tokens object (see server_tokens::serialize()), so it can be longer than the number of tokens the slot holds.
-// read its size from the file header, falling back to n_ctx if the header cannot be trusted - llama_state_seq_load_file() then reports the malformed file.
-// TODO: remove this once llama_state_seq_save_file() can store arbitrary user data
-static size_t state_file_payload_size(const std::string & filepath, size_t fallback) {
-    constexpr std::streamoff header_size = 3 * sizeof(uint32_t); // magic, version, payload size
-
-    std::ifstream file(filepath, std::ios::binary | std::ios::ate);
-    if (!file) {
-        return fallback;
-    }
-
-    const std::streamoff file_size = file.tellg();
-    if (file_size < header_size) {
-        return fallback;
-    }
-
-    uint32_t payload_size = 0;
-    file.seekg(header_size - sizeof(payload_size), std::ios::beg);
-    file.read(reinterpret_cast<char *>(&payload_size), sizeof(payload_size));
-    if (!file || payload_size > (file_size - header_size) / (std::streamoff) sizeof(llama_token)) {
-        return fallback;
-    }
-
-    return payload_size;
-}
-
 // state diagram: https://github.com/ggml-org/llama.cpp/pull/9283
 enum slot_state {
     SLOT_STATE_IDLE,
@@ -2675,10 +2649,13 @@ private:
 
                     size_t nread = 0;
                     try {
-                        llama_tokens packed;
-                        packed.resize(state_file_payload_size(filepath, slot->n_ctx));
                         size_t n_packed = 0;
-                        nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, packed.data(), packed.size(), &n_packed);
+                        llama_tokens packed;
+                        nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, nullptr, 0, &n_packed);
+                        if (nread != 0) {
+                            packed.resize(std::max<size_t>(1, n_packed));
+                            nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, packed.data(), packed.size(), &n_packed);
+                        }
                         if (nread == 0) {
                             throw std::runtime_error("No available space in KV cache or invalid slot save file");
                         }

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -6,15 +6,6 @@ import struct
 
 # sequence state file: magic(4) version(4) payload_size(4), then payload_size llama_token words
 STATE_FILE_HEADER_SIZE = 12
-# the token payload holds a packed server_tokens object (see server_tokens::serialize()):
-#   LLAMA_TOKEN_NULL(4) version(4) n_tokens(4) tokens, media list, zero padding to whole tokens
-PACKED_HEADER_SIZE = 12  # LLAMA_TOKEN_NULL, version, n_tokens
-LLAMA_TOKEN_NULL = 0xFFFFFFFF  # -1 read back as an unsigned word
-
-# media list layout in the packed payload: n_media(4), then per image: start_idx(4) chunk_size(4) chunk blob
-N_MEDIA_FIELD_SIZE = 4
-START_IDX_FIELD_SIZE = 4
-CHUNK_SIZE_FIELD_SIZE = 4
 
 server = ServerPreset.tinyllama2()
 
@@ -107,13 +98,15 @@ def test_slot_restore_legacy_token_list():
     with open(path, "rb") as f:
         data = bytearray(f.read())
 
+    # the payload written by this server starts with a packed header: LLAMA_TOKEN_NULL(4) version(4) n_tokens(4)
+    packed_header_size = 12
+
     payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
     payload_end = STATE_FILE_HEADER_SIZE + payload_size * 4
-    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
     n_tokens = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE + 8)[0]
     assert n_tokens == 84
 
-    tokens_start = STATE_FILE_HEADER_SIZE + PACKED_HEADER_SIZE
+    tokens_start = STATE_FILE_HEADER_SIZE + packed_header_size
     data = data[:STATE_FILE_HEADER_SIZE] + data[tokens_start:tokens_start + n_tokens * 4] + data[payload_end:]
     struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, n_tokens)
 
@@ -135,177 +128,6 @@ def test_slot_restore_legacy_token_list():
     assert res.status_code == 200
     assert res.body["timings"]["prompt_n"] == 6  # only the different part is processed
 
-
-def test_slot_restore_unsupported_state_version():
-    global server
-    server.start()
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "What is the capital of France?",
-        "id_slot": 1,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-    res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "slot_bad_version.bin",
-    })
-    assert res.status_code == 200
-
-    # a payload with an unknown format version must be rejected, not guessed at
-    path = os.path.join("tmp", "slot_bad_version.bin")
-    with open(path, "rb") as f:
-        data = bytearray(f.read())
-
-    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
-    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE + 4, 99)  # version
-
-    with open(path, "wb") as f:
-        f.write(data)
-
-    res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "slot_bad_version.bin",
-    })
-    assert res.status_code == 400
-    assert "Unsupported server tokens state version" in res.body["error"]["message"]
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox",
-        "id_slot": 0,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-
-def test_slot_restore_truncated_file():
-    global server
-    server.start()
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "What is the capital of France?",
-        "id_slot": 1,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-    res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "slot_truncated.bin",
-    })
-    assert res.status_code == 200
-
-    # cut the file inside the token payload: the payload size in the header can no longer be trusted, so the restore buffer falls back to n_ctx and loading reports the malformed file
-    path = os.path.join("tmp", "slot_truncated.bin")
-    with open(path, "r+b") as f:
-        f.truncate(STATE_FILE_HEADER_SIZE + 4)
-
-    res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "slot_truncated.bin",
-    })
-    assert res.status_code == 400
-    assert "No available space in KV cache or invalid slot save file" in res.body["error"]["message"]
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox",
-        "id_slot": 0,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-
-def test_slot_restore_corrupt_payload_size():
-    global server
-    server.start()
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "What is the capital of France?",
-        "id_slot": 1,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-    res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "slot_bad_payload_size.bin",
-    })
-    assert res.status_code == 200
-
-    # a payload size claiming ~4G tokens contradicts the actual file size, so it must not be trusted (or allocated): the restore buffer falls back to n_ctx and loading reports the malformed file
-    path = os.path.join("tmp", "slot_bad_payload_size.bin")
-    with open(path, "rb") as f:
-        data = bytearray(f.read())
-
-    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, 0xFFFFFFF0)
-
-    with open(path, "wb") as f:
-        f.write(data)
-
-    res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "slot_bad_payload_size.bin",
-    })
-    assert res.status_code == 400
-    assert "No available space in KV cache or invalid slot save file" in res.body["error"]["message"]
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox",
-        "id_slot": 0,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-
-def test_slot_restore_prompt_larger_than_slot_context():
-    global server
-    server.start()
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "What is the capital of France?",
-        "id_slot": 1,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-    res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "slot_large_prompt.bin",
-    })
-    assert res.status_code == 200
-
-    # the slot context, as the server computed it (n_ctx split across the slots)
-    res = server.make_request("GET", "/props")
-    assert res.status_code == 200
-    n_ctx_slot = res.body["default_generation_settings"]["n_ctx"]
-
-    # grow the logical token list past the slot context while the KV section keeps its cells: only the restored prompt length check can reject such a file
-    path = os.path.join("tmp", "slot_large_prompt.bin")
-    with open(path, "rb") as f:
-        data = bytearray(f.read())
-
-    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
-    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
-    n_tokens = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE + 8)[0]
-    assert n_tokens == 84
-
-    tokens_start = STATE_FILE_HEADER_SIZE + PACKED_HEADER_SIZE
-    tokens = data[tokens_start:tokens_start + n_tokens * 4]
-    filler = tokens * (n_ctx_slot // n_tokens + 1)
-    filler = filler[:(n_ctx_slot + 1 - n_tokens) * 4]
-    data = data[:tokens_start] + tokens + filler + data[tokens_start + n_tokens * 4:]
-    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, payload_size + len(filler) // 4)
-    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE + 8, n_ctx_slot + 1)
-
-    with open(path, "wb") as f:
-        f.write(data)
-
-    res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "slot_large_prompt.bin",
-    })
-    assert res.status_code == 400
-    assert "Restored prompt does not fit in the slot context" in res.body["error"]["message"]
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox",
-        "id_slot": 0,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
 
 
 def test_slot_erase():
@@ -353,13 +175,6 @@ def _get_img_base64(url: str) -> str:
     return base64.b64encode(response.content).decode("utf-8")
 
 
-def _media_list_offset(data: bytearray) -> int:
-    """Offset of the media list (the n_media field) inside the packed token payload."""
-    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
-    n_tokens = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE + 8)[0]
-    return STATE_FILE_HEADER_SIZE + PACKED_HEADER_SIZE + n_tokens * 4
-
-
 @pytest.fixture
 def mmproj_server():
     # tinygemma3 is a small multimodal model: the mmproj is provided by the HF registry API and auto-downloaded on first run.
@@ -399,8 +214,7 @@ def test_slot_save_restore_text_only_on_multimodal(mmproj_server):
     assert res.status_code == 200
     assert res.body["n_restored"] == n_saved
 
-    # The restored slot is usable for a follow-up completion.
-    # We do NOT assert prefix reuse here: tinygemma3 is a SWA model, which forces full prompt re-processing after a restore (a model property, not the save/restore gate under test).
+    # Prefix reuse is not checked with the default SWA cache.
     res = server.make_request("POST", "/completion", data={
         "prompt": "The quick brown fox jumps over the lazy dog.",
         "id_slot": 0,
@@ -411,7 +225,7 @@ def test_slot_save_restore_text_only_on_multimodal(mmproj_server):
 
 def test_slot_save_restore_with_image(mmproj_server):
     server = mmproj_server
-    # the SWA cache cannot be rolled back after a restore (checkpoints are not part of the save file), which would force full re-processing and hide the prefix reuse being verified below; use the full-size SWA cache instead
+    # Use the full SWA cache so the restored image prefix can be reused.
     server.swa_full = True
     server.start()
 
@@ -586,7 +400,6 @@ def test_slot_save_restore_with_image_across_restart(mmproj_server):
 
 
 def test_slot_save_restore_image_payload_larger_than_context(mmproj_server):
-    # the token payload holds the packed server_tokens object (tokens plus media state), so it is longer than the number of tokens the slot holds: the restore buffer is sized from the file, not from n_ctx
     server = mmproj_server
     server.swa_full = True
     server.start()
@@ -695,192 +508,27 @@ def test_slot_restore_media_file_without_mmproj(mmproj_server):
     assert res.status_code == 400
     assert "Cannot restore image tokens without an mmproj" in res.body["error"]["message"]
 
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox",
-        "id_slot": 0,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-
-def test_slot_restore_corrupt_media_state(mmproj_server):
-    server = mmproj_server
-    server.start()
-
-    prompt_cat = {
-        "prompt_string": "What is this: <__media__>\n",
-        "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
-    }
+    # A failed restore must leave the slot empty and usable.
     res = server.make_request("POST", "/completions", data={
         "temperature": 0.0,
         "top_k": 1,
         "id_slot": 1,
         "cache_prompt": True,
-        "prompt": prompt_cat,
+        "prompt": "The quick brown fox",
     })
     assert res.status_code == 200
     content = res.body["content"]
 
-    res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "mm_slot_corrupt.bin",
-    })
-    assert res.status_code == 200
-
-    # corrupt the media state: grow the declared chunk size past the end of the payload
-    path = os.path.join("tmp", "mm_slot_corrupt.bin")
-    with open(path, "rb") as f:
-        data = bytearray(f.read())
-
-    media_offset = _media_list_offset(data)
-    assert struct.unpack_from("=I", data, media_offset)[0] == 1  # n_media
-    chunk_size_offset = media_offset + N_MEDIA_FIELD_SIZE + START_IDX_FIELD_SIZE
-    struct.pack_into("=I", data, chunk_size_offset, 0x7FFFFFFF)
-
-    with open(path, "wb") as f:
-        f.write(data)
-
-    res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "mm_slot_corrupt.bin",
-    })
-    assert res.status_code == 400
-    assert "Unexpected end of server tokens state" in res.body["error"]["message"]
-
-    # the failed restore must leave slot 0 empty: no reusable prefix, and no stale KV cells that would corrupt greedy decoding
     res = server.make_request("POST", "/completions", data={
         "temperature": 0.0,
         "top_k": 1,
         "id_slot": 0,
         "cache_prompt": True,
-        "prompt": prompt_cat,
+        "prompt": "The quick brown fox",
     })
     assert res.status_code == 200
     assert res.body["timings"]["cache_n"] == 0
     assert res.body["content"] == content
-
-
-def test_slot_restore_corrupt_state_padding(mmproj_server):
-    server = mmproj_server
-    server.start()
-
-    res = server.make_request("POST", "/completions", data={
-        "temperature": 0.0,
-        "top_k": 1,
-        "id_slot": 1,
-        "cache_prompt": True,
-        "prompt": {
-            "prompt_string": "What is this: <__media__>\n",
-            "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
-        },
-    })
-    assert res.status_code == 200
-
-    res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "mm_slot_padding.bin",
-    })
-    assert res.status_code == 200
-
-    # a non-zero byte in the zero padding at the end of the payload must be rejected
-    path = os.path.join("tmp", "mm_slot_padding.bin")
-    with open(path, "rb") as f:
-        data = bytearray(f.read())
-
-    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
-    payload_end = STATE_FILE_HEADER_SIZE + payload_size * 4
-
-    media_offset = _media_list_offset(data)
-    assert struct.unpack_from("=I", data, media_offset)[0] == 1  # n_media
-    chunk_size_offset = media_offset + N_MEDIA_FIELD_SIZE + START_IDX_FIELD_SIZE
-    chunk_size = struct.unpack_from("=I", data, chunk_size_offset)[0]
-    stream_end = chunk_size_offset + CHUNK_SIZE_FIELD_SIZE + chunk_size
-
-    assert payload_end - stream_end > 0  # this image must leave padding bytes to corrupt
-    data[stream_end] = 0xFF
-
-    with open(path, "wb") as f:
-        f.write(data)
-
-    res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "mm_slot_padding.bin",
-    })
-    assert res.status_code == 400
-    assert "Invalid padding in server tokens state" in res.body["error"]["message"]
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox",
-        "id_slot": 0,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-
-
-def test_slot_restore_media_state_without_image_id(mmproj_server):
-    server = mmproj_server
-    server.start()
-
-    res = server.make_request("POST", "/completions", data={
-        "temperature": 0.0,
-        "top_k": 1,
-        "id_slot": 1,
-        "cache_prompt": True,
-        "prompt": {
-            "prompt_string": "What is this: <__media__>\n",
-            "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
-        },
-    })
-    assert res.status_code == 200
-
-    res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "mm_slot_empty_image_id.bin",
-    })
-    assert res.status_code == 200
-
-    path = os.path.join("tmp", "mm_slot_empty_image_id.bin")
-    with open(path, "rb") as f:
-        data = bytearray(f.read())
-
-    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
-    payload_end = STATE_FILE_HEADER_SIZE + payload_size * 4
-
-    media_offset = _media_list_offset(data)
-    assert struct.unpack_from("=I", data, media_offset)[0] == 1  # n_media
-    # chunk blob (mtmd serialization v1): version(8) type(4) n_text_tokens(8) has_image(1)
-    #   nx(4) ny(4) pos(4) image_idx(4) n_temporal_merge(4) id_size(8) id bytes ...
-    blob_header_size = 41  # version, type, n_text_tokens, has_image, nx, ny, pos, image_idx, n_temporal_merge
-    id_size_field_size = 8
-
-    chunk_size_offset = media_offset + N_MEDIA_FIELD_SIZE + START_IDX_FIELD_SIZE
-    chunk_size = struct.unpack_from("=I", data, chunk_size_offset)[0]
-    blob_start = chunk_size_offset + CHUNK_SIZE_FIELD_SIZE
-    stream_end = blob_start + chunk_size  # end of the packed payload, before the zero padding
-
-    id_size_offset = blob_start + blob_header_size
-    id_size = struct.unpack_from("=Q", data, id_size_offset)[0]
-    assert id_size > 0
-    struct.pack_into("=Q", data, id_size_offset, 0)
-    struct.pack_into("=I", data, chunk_size_offset, chunk_size - id_size)
-
-    # drop the id bytes and re-pad the payload to whole tokens
-    id_offset = id_size_offset + id_size_field_size
-    payload = data[STATE_FILE_HEADER_SIZE:id_offset] + data[id_offset + id_size:stream_end]
-    payload += bytes(-len(payload) % 4)
-    data = data[:STATE_FILE_HEADER_SIZE] + payload + data[payload_end:]
-    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, len(payload) // 4)
-
-    with open(path, "wb") as f:
-        f.write(data)
-
-    res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "mm_slot_empty_image_id.bin",
-    })
-    assert res.status_code == 400
-    assert "Image ID is missing in server tokens state" in res.body["error"]["message"]
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox",
-        "id_slot": 0,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
 
 
 def test_slot_erase_text_only_on_multimodal(mmproj_server):

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -4,6 +4,18 @@ import base64
 import requests
 import struct
 
+# sequence state file: magic(4) version(4) payload_size(4), then payload_size llama_token words
+STATE_FILE_HEADER_SIZE = 12
+# the token payload holds a packed server_tokens object (see server_tokens::serialize()):
+#   LLAMA_TOKEN_NULL(4) version(4) n_tokens(4) tokens, media list, zero padding to whole tokens
+PACKED_HEADER_SIZE = 12  # LLAMA_TOKEN_NULL, version, n_tokens
+LLAMA_TOKEN_NULL = 0xFFFFFFFF  # -1 read back as an unsigned word
+
+# media list layout in the packed payload: n_media(4), then per image: start_idx(4) chunk_size(4) chunk blob
+N_MEDIA_FIELD_SIZE = 4
+START_IDX_FIELD_SIZE = 4
+CHUNK_SIZE_FIELD_SIZE = 4
+
 server = ServerPreset.tinyllama2()
 
 @pytest.fixture(autouse=True)
@@ -73,6 +85,229 @@ def test_slot_save_restore():
     assert res.body["timings"]["prompt_n"] == 1
 
 
+def test_slot_restore_legacy_token_list():
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of France?",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "slot_legacy.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_saved"] == 84
+
+    # rewrite the token payload into a plain token list, as written by servers that predate the packed server_tokens format
+    path = os.path.join("tmp", "slot_legacy.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
+    payload_end = STATE_FILE_HEADER_SIZE + payload_size * 4
+    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
+    n_tokens = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE + 8)[0]
+    assert n_tokens == 84
+
+    tokens_start = STATE_FILE_HEADER_SIZE + PACKED_HEADER_SIZE
+    data = data[:STATE_FILE_HEADER_SIZE] + data[tokens_start:tokens_start + n_tokens * 4] + data[payload_end:]
+    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, n_tokens)
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    # the plain token list must restore, and the restored KV must be reusable
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "slot_legacy.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_restored"] == 84
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of Germany?",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["prompt_n"] == 6  # only the different part is processed
+
+
+def test_slot_restore_unsupported_state_version():
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of France?",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "slot_bad_version.bin",
+    })
+    assert res.status_code == 200
+
+    # a payload with an unknown format version must be rejected, not guessed at
+    path = os.path.join("tmp", "slot_bad_version.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
+    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE + 4, 99)  # version
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "slot_bad_version.bin",
+    })
+    assert res.status_code == 400
+    assert "Unsupported server tokens state version" in res.body["error"]["message"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+
+def test_slot_restore_truncated_file():
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of France?",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "slot_truncated.bin",
+    })
+    assert res.status_code == 200
+
+    # cut the file inside the token payload: the payload size in the header can no longer be trusted, so the restore buffer falls back to n_ctx and loading reports the malformed file
+    path = os.path.join("tmp", "slot_truncated.bin")
+    with open(path, "r+b") as f:
+        f.truncate(STATE_FILE_HEADER_SIZE + 4)
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "slot_truncated.bin",
+    })
+    assert res.status_code == 400
+    assert "No available space in KV cache or invalid slot save file" in res.body["error"]["message"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+
+def test_slot_restore_corrupt_payload_size():
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of France?",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "slot_bad_payload_size.bin",
+    })
+    assert res.status_code == 200
+
+    # a payload size claiming ~4G tokens contradicts the actual file size, so it must not be trusted (or allocated): the restore buffer falls back to n_ctx and loading reports the malformed file
+    path = os.path.join("tmp", "slot_bad_payload_size.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, 0xFFFFFFF0)
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "slot_bad_payload_size.bin",
+    })
+    assert res.status_code == 400
+    assert "No available space in KV cache or invalid slot save file" in res.body["error"]["message"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+
+def test_slot_restore_prompt_larger_than_slot_context():
+    global server
+    server.start()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "What is the capital of France?",
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "slot_large_prompt.bin",
+    })
+    assert res.status_code == 200
+
+    # the slot context, as the server computed it (n_ctx split across the slots)
+    res = server.make_request("GET", "/props")
+    assert res.status_code == 200
+    n_ctx_slot = res.body["default_generation_settings"]["n_ctx"]
+
+    # grow the logical token list past the slot context while the KV section keeps its cells: only the restored prompt length check can reject such a file
+    path = os.path.join("tmp", "slot_large_prompt.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
+    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
+    n_tokens = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE + 8)[0]
+    assert n_tokens == 84
+
+    tokens_start = STATE_FILE_HEADER_SIZE + PACKED_HEADER_SIZE
+    tokens = data[tokens_start:tokens_start + n_tokens * 4]
+    filler = tokens * (n_ctx_slot // n_tokens + 1)
+    filler = filler[:(n_ctx_slot + 1 - n_tokens) * 4]
+    data = data[:tokens_start] + tokens + filler + data[tokens_start + n_tokens * 4:]
+    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, payload_size + len(filler) // 4)
+    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE + 8, n_ctx_slot + 1)
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "slot_large_prompt.bin",
+    })
+    assert res.status_code == 400
+    assert "Restored prompt does not fit in the slot context" in res.body["error"]["message"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+
 def test_slot_erase():
     global server
     server.start()
@@ -104,8 +339,8 @@ def test_slot_erase():
 #
 # Multimodal server (mmproj loaded) slot save/restore.
 #
-# A pure-text slot on a multimodal server and a slot containing images must
-# both support save/restore. Erase remains gated on the slot's content.
+# A pure-text slot on a multimodal server and a slot containing images must both support save/restore.
+# Erase remains gated on the slot's content.
 #
 
 IMG_URL_CAT = "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/test/91_cat.png"
@@ -118,10 +353,16 @@ def _get_img_base64(url: str) -> str:
     return base64.b64encode(response.content).decode("utf-8")
 
 
+def _media_list_offset(data: bytearray) -> int:
+    """Offset of the media list (the n_media field) inside the packed token payload."""
+    assert struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE)[0] == LLAMA_TOKEN_NULL
+    n_tokens = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE + 8)[0]
+    return STATE_FILE_HEADER_SIZE + PACKED_HEADER_SIZE + n_tokens * 4
+
+
 @pytest.fixture
 def mmproj_server():
-    # tinygemma3 is a small multimodal model: the mmproj is provided by the HF
-    # registry API and auto-downloaded on first run.
+    # tinygemma3 is a small multimodal model: the mmproj is provided by the HF registry API and auto-downloaded on first run.
     os.environ['LLAMA_MEDIA_MARKER'] = '<__media__>'
     mm_server = ServerPreset.tinygemma3()
     mm_server.slot_save_path = "./tmp"
@@ -158,10 +399,8 @@ def test_slot_save_restore_text_only_on_multimodal(mmproj_server):
     assert res.status_code == 200
     assert res.body["n_restored"] == n_saved
 
-    # The restored slot is usable for a follow-up completion. We do NOT assert
-    # prefix reuse here: tinygemma3 is a SWA model, which forces full prompt
-    # re-processing after a restore (a model property, not the save/restore gate
-    # under test).
+    # The restored slot is usable for a follow-up completion.
+    # We do NOT assert prefix reuse here: tinygemma3 is a SWA model, which forces full prompt re-processing after a restore (a model property, not the save/restore gate under test).
     res = server.make_request("POST", "/completion", data={
         "prompt": "The quick brown fox jumps over the lazy dog.",
         "id_slot": 0,
@@ -172,9 +411,7 @@ def test_slot_save_restore_text_only_on_multimodal(mmproj_server):
 
 def test_slot_save_restore_with_image(mmproj_server):
     server = mmproj_server
-    # the SWA cache cannot be rolled back after a restore (checkpoints are not
-    # part of the save file), which would force full re-processing and hide the
-    # prefix reuse being verified below; use the full-size SWA cache instead
+    # the SWA cache cannot be rolled back after a restore (checkpoints are not part of the save file), which would force full re-processing and hide the prefix reuse being verified below; use the full-size SWA cache instead
     server.swa_full = True
     server.start()
 
@@ -216,8 +453,7 @@ def test_slot_save_restore_with_image(mmproj_server):
     assert res.body["n_restored"] == n_saved
     assert res.body["n_read"] == n_written
 
-    # a different image must not reuse the restored image tokens; only the
-    # text prefix before the image is common
+    # a different image must not reuse the restored image tokens; only the text prefix before the image is common
     res = server.make_request("POST", "/completions", data={
         "temperature": 0.0,
         "top_k": 1,
@@ -233,8 +469,7 @@ def test_slot_save_restore_with_image(mmproj_server):
     assert cache_n < 16
     assert res.body["timings"]["prompt_n"] == prompt_n_full - cache_n
 
-    # restore again and resend the same image: the image tokens must be
-    # reused and greedy sampling must reproduce the original content
+    # restore again and resend the same image: the image tokens must be reused and greedy sampling must reproduce the original content
     res = server.make_request("POST", "/slots/0?action=restore", data={
         "filename": "mm_slot_image.bin",
     })
@@ -327,8 +562,7 @@ def test_slot_save_restore_with_image_across_restart(mmproj_server):
     assert res.status_code == 200
     n_saved = res.body["n_saved"]
 
-    # restart the server with the same model and mmproj: the saved file must
-    # restore in the new process and the image KV must be reused
+    # restart the server with the same model and mmproj: the saved file must restore in the new process and the image KV must be reused
     server.stop()
     server.start()
 
@@ -349,6 +583,84 @@ def test_slot_save_restore_with_image_across_restart(mmproj_server):
     assert res.body["timings"]["cache_n"] == prompt_n_full - 1
     assert res.body["timings"]["prompt_n"] == 1
     assert res.body["content"] == content
+
+
+def test_slot_save_restore_image_payload_larger_than_context(mmproj_server):
+    # the token payload holds the packed server_tokens object (tokens plus media state), so it is longer than the number of tokens the slot holds: the restore buffer is sized from the file, not from n_ctx
+    server = mmproj_server
+    server.swa_full = True
+    server.start()
+
+    # the slot context, as the server computed it (n_ctx split across the slots)
+    res = server.make_request("GET", "/props")
+    assert res.status_code == 200
+    n_ctx_slot = res.body["default_generation_settings"]["n_ctx"]
+
+    # a filler token, used to grow the prompt up to the slot context
+    res = server.make_request("POST", "/tokenize", data={"content": " hello" * 8})
+    assert res.status_code == 200
+    assert len(res.body["tokens"]) == 8
+
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": {
+            "prompt_string": "What is this: <__media__>\n",
+            "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
+        },
+    })
+    assert res.status_code == 200
+
+    prompt_cat = {
+        "prompt_string": "What is this: <__media__>\n" + " hello" * (n_ctx_slot - res.body["timings"]["prompt_n"] - 8),
+        "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
+    }
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    prompt_n_full = res.body["timings"]["cache_n"] + res.body["timings"]["prompt_n"]
+
+    res = server.make_request("POST", "/slots/0?action=save", data={
+        "filename": "mm_slot_large_payload.bin",
+    })
+    assert res.status_code == 200
+
+    path = os.path.join("tmp", "mm_slot_large_payload.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
+    assert payload_size > n_ctx_slot  # the scenario under test: the payload does not fit in n_ctx
+
+    # drop the image from the slot, then restore it from the file
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_large_payload.bin",
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] == prompt_n_full - 1
+    assert res.body["timings"]["prompt_n"] == 1
 
 
 def test_slot_restore_media_file_without_mmproj(mmproj_server):
@@ -372,8 +684,7 @@ def test_slot_restore_media_file_without_mmproj(mmproj_server):
     })
     assert res.status_code == 200
 
-    # restart the same model without the mmproj: restoring the media file must
-    # fail gracefully and leave the slot usable
+    # restart the same model without the mmproj: restoring the media file must fail gracefully and leave the slot usable
     server.stop()
     server.no_mmproj = True
     server.start()
@@ -392,7 +703,62 @@ def test_slot_restore_media_file_without_mmproj(mmproj_server):
     assert res.status_code == 200
 
 
-def test_slot_restore_corrupt_media_trailer(mmproj_server):
+def test_slot_restore_corrupt_media_state(mmproj_server):
+    server = mmproj_server
+    server.start()
+
+    prompt_cat = {
+        "prompt_string": "What is this: <__media__>\n",
+        "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
+    }
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 1,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    content = res.body["content"]
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "mm_slot_corrupt.bin",
+    })
+    assert res.status_code == 200
+
+    # corrupt the media state: grow the declared chunk size past the end of the payload
+    path = os.path.join("tmp", "mm_slot_corrupt.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    media_offset = _media_list_offset(data)
+    assert struct.unpack_from("=I", data, media_offset)[0] == 1  # n_media
+    chunk_size_offset = media_offset + N_MEDIA_FIELD_SIZE + START_IDX_FIELD_SIZE
+    struct.pack_into("=I", data, chunk_size_offset, 0x7FFFFFFF)
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_corrupt.bin",
+    })
+    assert res.status_code == 400
+    assert "Unexpected end of server tokens state" in res.body["error"]["message"]
+
+    # the failed restore must leave slot 0 empty: no reusable prefix, and no stale KV cells that would corrupt greedy decoding
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] == 0
+    assert res.body["content"] == content
+
+
+def test_slot_restore_corrupt_state_padding(mmproj_server):
     server = mmproj_server
     server.start()
 
@@ -409,21 +775,35 @@ def test_slot_restore_corrupt_media_trailer(mmproj_server):
     assert res.status_code == 200
 
     res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "mm_slot_corrupt.bin",
+        "filename": "mm_slot_padding.bin",
     })
     assert res.status_code == 200
 
-    # truncate the media trailer by one byte
-    path = os.path.join("tmp", "mm_slot_corrupt.bin")
-    with open(path, "r+b") as f:
-        f.seek(0, os.SEEK_END)
-        f.truncate(f.tell() - 1)
+    # a non-zero byte in the zero padding at the end of the payload must be rejected
+    path = os.path.join("tmp", "mm_slot_padding.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
+    payload_end = STATE_FILE_HEADER_SIZE + payload_size * 4
+
+    media_offset = _media_list_offset(data)
+    assert struct.unpack_from("=I", data, media_offset)[0] == 1  # n_media
+    chunk_size_offset = media_offset + N_MEDIA_FIELD_SIZE + START_IDX_FIELD_SIZE
+    chunk_size = struct.unpack_from("=I", data, chunk_size_offset)[0]
+    stream_end = chunk_size_offset + CHUNK_SIZE_FIELD_SIZE + chunk_size
+
+    assert payload_end - stream_end > 0  # this image must leave padding bytes to corrupt
+    data[stream_end] = 0xFF
+
+    with open(path, "wb") as f:
+        f.write(data)
 
     res = server.make_request("POST", "/slots/0?action=restore", data={
-        "filename": "mm_slot_corrupt.bin",
+        "filename": "mm_slot_padding.bin",
     })
     assert res.status_code == 400
-    assert "Unexpected end of server tokens state" in res.body["error"]["message"]
+    assert "Invalid padding in server tokens state" in res.body["error"]["message"]
 
     res = server.make_request("POST", "/completion", data={
         "prompt": "The quick brown fox",
@@ -433,7 +813,7 @@ def test_slot_restore_corrupt_media_trailer(mmproj_server):
     assert res.status_code == 200
 
 
-def test_slot_restore_media_trailer_without_image_id(mmproj_server):
+def test_slot_restore_media_state_without_image_id(mmproj_server):
     server = mmproj_server
     server.start()
 
@@ -458,27 +838,33 @@ def test_slot_restore_media_trailer_without_image_id(mmproj_server):
     with open(path, "rb") as f:
         data = bytearray(f.read())
 
-    trailer_start = data.rfind(struct.pack("=I", 0x53544D4D))
-    assert trailer_start >= 0
-    # trailer: magic(4) version(4) n_media(4), then per image: start_idx(4) chunk_size(4) chunk blob
-    trailer_header_size = 12  # magic, version, n_media
-    start_idx_field_size = 4
-    chunk_size_field_size = 4
+    payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
+    payload_end = STATE_FILE_HEADER_SIZE + payload_size * 4
+
+    media_offset = _media_list_offset(data)
+    assert struct.unpack_from("=I", data, media_offset)[0] == 1  # n_media
     # chunk blob (mtmd serialization v1): version(8) type(4) n_text_tokens(8) has_image(1)
     #   nx(4) ny(4) pos(4) image_idx(4) n_temporal_merge(4) id_size(8) id bytes ...
     blob_header_size = 41  # version, type, n_text_tokens, has_image, nx, ny, pos, image_idx, n_temporal_merge
     id_size_field_size = 8
 
-    chunk_size_offset = trailer_start + trailer_header_size + start_idx_field_size
-    blob_start = chunk_size_offset + chunk_size_field_size
+    chunk_size_offset = media_offset + N_MEDIA_FIELD_SIZE + START_IDX_FIELD_SIZE
+    chunk_size = struct.unpack_from("=I", data, chunk_size_offset)[0]
+    blob_start = chunk_size_offset + CHUNK_SIZE_FIELD_SIZE
+    stream_end = blob_start + chunk_size  # end of the packed payload, before the zero padding
+
     id_size_offset = blob_start + blob_header_size
     id_size = struct.unpack_from("=Q", data, id_size_offset)[0]
     assert id_size > 0
     struct.pack_into("=Q", data, id_size_offset, 0)
-    id_offset = id_size_offset + id_size_field_size
-    del data[id_offset:id_offset + id_size]
-    chunk_size = struct.unpack_from("=I", data, chunk_size_offset)[0]
     struct.pack_into("=I", data, chunk_size_offset, chunk_size - id_size)
+
+    # drop the id bytes and re-pad the payload to whole tokens
+    id_offset = id_size_offset + id_size_field_size
+    payload = data[STATE_FILE_HEADER_SIZE:id_offset] + data[id_offset + id_size:stream_end]
+    payload += bytes(-len(payload) % 4)
+    data = data[:STATE_FILE_HEADER_SIZE] + payload + data[payload_end:]
+    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, len(payload) // 4)
 
     with open(path, "wb") as f:
         f.write(data)

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -506,7 +506,7 @@ def test_slot_restore_media_file_without_mmproj(mmproj_server):
         "filename": "mm_slot_no_mmproj.bin",
     })
     assert res.status_code == 400
-    assert "Cannot restore image tokens without an mmproj" in res.body["error"]["message"]
+    assert "Cannot restore media tokens without an mmproj" in res.body["error"]["message"]
 
     # A failed restore must leave the slot empty and usable.
     res = server.make_request("POST", "/completions", data={

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -2,6 +2,7 @@ import pytest
 from utils import *
 import base64
 import requests
+import struct
 
 server = ServerPreset.tinyllama2()
 
@@ -103,14 +104,12 @@ def test_slot_erase():
 #
 # Multimodal server (mmproj loaded) slot save/restore.
 #
-# Regression coverage for issue #21133: slot save/restore/erase must be gated on
-# the slot's CONTENT (does it actually hold image/audio tokens) rather than the
-# model's CAPABILITY (is an mmproj loaded). A pure-text slot on a multimodal
-# server must save/restore/erase normally; a slot that actually holds an image
-# must be rejected with ERROR_TYPE_NOT_SUPPORTED (HTTP 501).
+# A pure-text slot on a multimodal server and a slot containing images must
+# both support save/restore. Erase remains gated on the slot's content.
 #
 
 IMG_URL_CAT = "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/test/91_cat.png"
+IMG_URL_TRUCK = "https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/test/11_truck.png"
 
 
 def _get_img_base64(url: str) -> str:
@@ -171,11 +170,232 @@ def test_slot_save_restore_text_only_on_multimodal(mmproj_server):
     assert res.status_code == 200
 
 
-def test_slot_save_rejected_when_slot_holds_image(mmproj_server):
+def test_slot_save_restore_with_image(mmproj_server):
+    server = mmproj_server
+    # the SWA cache cannot be rolled back after a restore (checkpoints are not
+    # part of the save file), which would force full re-processing and hide the
+    # prefix reuse being verified below; use the full-size SWA cache instead
+    server.swa_full = True
+    server.start()
+
+    prompt_cat = {
+        "prompt_string": "What is this: <__media__>\n",
+        "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
+    }
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 1,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    content_cat = res.body["content"]
+    prompt_n_full = res.body["timings"]["prompt_n"]
+    assert res.body["timings"]["cache_n"] == 0
+    assert prompt_n_full > 32  # text plus image tokens are all processed
+
+    # erase remains gated on media content
+    res = server.make_request("POST", "/slots/1?action=erase")
+    assert res.status_code == 501
+    assert res.body["error"]["type"] == "not_supported_error"
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "mm_slot_image.bin",
+    })
+    assert res.status_code == 200
+    n_saved = res.body["n_saved"]
+    n_written = res.body["n_written"]
+    assert n_saved > 0
+    assert n_written > 0
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_image.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_restored"] == n_saved
+    assert res.body["n_read"] == n_written
+
+    # a different image must not reuse the restored image tokens; only the
+    # text prefix before the image is common
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": {
+            "prompt_string": "What is this: <__media__>\n",
+            "multimodal_data": [_get_img_base64(IMG_URL_TRUCK)],
+        },
+    })
+    assert res.status_code == 200
+    cache_n = res.body["timings"]["cache_n"]
+    assert cache_n < 16
+    assert res.body["timings"]["prompt_n"] == prompt_n_full - cache_n
+
+    # restore again and resend the same image: the image tokens must be
+    # reused and greedy sampling must reproduce the original content
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_image.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_restored"] == n_saved
+
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] == prompt_n_full - 1
+    assert res.body["timings"]["prompt_n"] == 1
+    assert res.body["content"] == content_cat
+
+
+def test_slot_save_restore_with_two_images(mmproj_server):
+    server = mmproj_server
+    server.swa_full = True
+    server.n_ctx = 2048  # two images need more than the default 512 per slot
+    server.start()
+
+    prompt = {
+        "prompt_string": "A: <__media__> B: <__media__>\n",
+        "multimodal_data": [_get_img_base64(IMG_URL_CAT), _get_img_base64(IMG_URL_TRUCK)],
+    }
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 1,
+        "cache_prompt": True,
+        "prompt": prompt,
+    })
+    assert res.status_code == 200
+    content = res.body["content"]
+    prompt_n_full = res.body["timings"]["prompt_n"]
+    assert prompt_n_full > 64
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "mm_slot_two_images.bin",
+    })
+    assert res.status_code == 200
+    n_saved = res.body["n_saved"]
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_two_images.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_restored"] == n_saved
+
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": prompt,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] == prompt_n_full - 1
+    assert res.body["timings"]["prompt_n"] == 1
+    assert res.body["content"] == content
+
+
+def test_slot_save_restore_with_image_across_restart(mmproj_server):
+    server = mmproj_server
+    server.swa_full = True
+    server.start()
+
+    prompt_cat = {
+        "prompt_string": "What is this: <__media__>\n",
+        "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
+    }
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    content = res.body["content"]
+    prompt_n_full = res.body["timings"]["prompt_n"]
+
+    res = server.make_request("POST", "/slots/0?action=save", data={
+        "filename": "mm_slot_restart.bin",
+    })
+    assert res.status_code == 200
+    n_saved = res.body["n_saved"]
+
+    # restart the server with the same model and mmproj: the saved file must
+    # restore in the new process and the image KV must be reused
+    server.stop()
+    server.start()
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_restart.bin",
+    })
+    assert res.status_code == 200
+    assert res.body["n_restored"] == n_saved
+
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": prompt_cat,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] == prompt_n_full - 1
+    assert res.body["timings"]["prompt_n"] == 1
+    assert res.body["content"] == content
+
+
+def test_slot_restore_media_file_without_mmproj(mmproj_server):
     server = mmproj_server
     server.start()
 
-    # Process a prompt that actually contains an image on slot 1.
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 0,
+        "cache_prompt": True,
+        "prompt": {
+            "prompt_string": "What is this: <__media__>\n",
+            "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
+        },
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/0?action=save", data={
+        "filename": "mm_slot_no_mmproj.bin",
+    })
+    assert res.status_code == 200
+
+    # restart the same model without the mmproj: restoring the media file must
+    # fail gracefully and leave the slot usable
+    server.stop()
+    server.no_mmproj = True
+    server.start()
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_no_mmproj.bin",
+    })
+    assert res.status_code == 400
+    assert "Cannot restore image tokens without an mmproj" in res.body["error"]["message"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+
+def test_slot_restore_corrupt_media_trailer(mmproj_server):
+    server = mmproj_server
+    server.start()
+
     res = server.make_request("POST", "/completions", data={
         "temperature": 0.0,
         "top_k": 1,
@@ -183,18 +403,98 @@ def test_slot_save_rejected_when_slot_holds_image(mmproj_server):
         "cache_prompt": True,
         "prompt": {
             "prompt_string": "What is this: <__media__>\n",
-            "multimodal_data": [ _get_img_base64(IMG_URL_CAT) ],
+            "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
         },
     })
     assert res.status_code == 200
 
-    # Saving a slot that holds image tokens must be rejected (HTTP 501,
-    # not_supported_error).
     res = server.make_request("POST", "/slots/1?action=save", data={
-        "filename": "mm_slot_image.bin",
+        "filename": "mm_slot_corrupt.bin",
     })
-    assert res.status_code != 200
-    assert res.body["error"]["type"] == "not_supported_error"
+    assert res.status_code == 200
+
+    # truncate the media trailer by one byte
+    path = os.path.join("tmp", "mm_slot_corrupt.bin")
+    with open(path, "r+b") as f:
+        f.seek(0, os.SEEK_END)
+        f.truncate(f.tell() - 1)
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_corrupt.bin",
+    })
+    assert res.status_code == 400
+    assert "Unexpected end of server tokens state" in res.body["error"]["message"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+
+
+def test_slot_restore_media_trailer_without_image_id(mmproj_server):
+    server = mmproj_server
+    server.start()
+
+    res = server.make_request("POST", "/completions", data={
+        "temperature": 0.0,
+        "top_k": 1,
+        "id_slot": 1,
+        "cache_prompt": True,
+        "prompt": {
+            "prompt_string": "What is this: <__media__>\n",
+            "multimodal_data": [_get_img_base64(IMG_URL_CAT)],
+        },
+    })
+    assert res.status_code == 200
+
+    res = server.make_request("POST", "/slots/1?action=save", data={
+        "filename": "mm_slot_empty_image_id.bin",
+    })
+    assert res.status_code == 200
+
+    path = os.path.join("tmp", "mm_slot_empty_image_id.bin")
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+
+    trailer_start = data.rfind(struct.pack("=I", 0x53544D4D))
+    assert trailer_start >= 0
+    # trailer: magic(4) version(4) n_media(4), then per image: start_idx(4) chunk_size(4) chunk blob
+    trailer_header_size = 12  # magic, version, n_media
+    start_idx_field_size = 4
+    chunk_size_field_size = 4
+    # chunk blob (mtmd serialization v1): version(8) type(4) n_text_tokens(8) has_image(1)
+    #   nx(4) ny(4) pos(4) image_idx(4) n_temporal_merge(4) id_size(8) id bytes ...
+    blob_header_size = 41  # version, type, n_text_tokens, has_image, nx, ny, pos, image_idx, n_temporal_merge
+    id_size_field_size = 8
+
+    chunk_size_offset = trailer_start + trailer_header_size + start_idx_field_size
+    blob_start = chunk_size_offset + chunk_size_field_size
+    id_size_offset = blob_start + blob_header_size
+    id_size = struct.unpack_from("=Q", data, id_size_offset)[0]
+    assert id_size > 0
+    struct.pack_into("=Q", data, id_size_offset, 0)
+    id_offset = id_size_offset + id_size_field_size
+    del data[id_offset:id_offset + id_size]
+    chunk_size = struct.unpack_from("=I", data, chunk_size_offset)[0]
+    struct.pack_into("=I", data, chunk_size_offset, chunk_size - id_size)
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    res = server.make_request("POST", "/slots/0?action=restore", data={
+        "filename": "mm_slot_empty_image_id.bin",
+    })
+    assert res.status_code == 400
+    assert "Image ID is missing in server tokens state" in res.body["error"]["message"]
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "The quick brown fox",
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
 
 
 def test_slot_erase_text_only_on_multimodal(mmproj_server):

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -246,11 +246,6 @@ def test_slot_save_restore_with_image(mmproj_server):
     assert res.body["timings"]["cache_n"] == 0
     assert prompt_n_full > 32  # text plus image tokens are all processed
 
-    # erase remains gated on media content
-    res = server.make_request("POST", "/slots/1?action=erase")
-    assert res.status_code == 501
-    assert res.body["error"]["type"] == "not_supported_error"
-
     res = server.make_request("POST", "/slots/1?action=save", data={
         "filename": "mm_slot_image.bin",
     })
@@ -259,6 +254,9 @@ def test_slot_save_restore_with_image(mmproj_server):
     n_written = res.body["n_written"]
     assert n_saved > 0
     assert n_written > 0
+
+    res = server.make_request("POST", "/slots/1?action=erase")
+    assert res.status_code == 200
 
     res = server.make_request("POST", "/slots/0?action=restore", data={
         "filename": "mm_slot_image.bin",
@@ -529,30 +527,3 @@ def test_slot_restore_media_file_without_mmproj(mmproj_server):
     assert res.status_code == 200
     assert res.body["timings"]["cache_n"] == 0
     assert res.body["content"] == content
-
-
-def test_slot_erase_text_only_on_multimodal(mmproj_server):
-    server = mmproj_server
-    server.start()
-
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox jumps over the lazy dog.",
-        "id_slot": 1,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-    prompt_n = res.body["timings"]["prompt_n"]
-    assert prompt_n > 0  # all tokens are processed
-
-    # Erasing a pure-text slot must succeed even though an mmproj is loaded.
-    res = server.make_request("POST", "/slots/1?action=erase")
-    assert res.status_code == 200
-
-    # Re-running the same prompt should process all tokens again.
-    res = server.make_request("POST", "/completion", data={
-        "prompt": "The quick brown fox jumps over the lazy dog.",
-        "id_slot": 1,
-        "cache_prompt": True,
-    })
-    assert res.status_code == 200
-    assert res.body["timings"]["prompt_n"] == prompt_n  # all tokens are processed again

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -86,6 +86,7 @@ class ServerProcess:
     server_reranking: bool | None = False
     server_metrics: bool | None = False
     kv_unified: bool | None = False
+    swa_full: bool | None = False
     server_slots: bool | None = False
     pooling: str | None = None
     api_key: str | None = None
@@ -106,6 +107,7 @@ class ServerProcess:
     chat_template_file: str | None = None
     server_path: str | None = None
     mmproj_url: str | None = None
+    no_mmproj: bool | None = None
     media_path: str | None = None
     sleep_idle_seconds: int | None = None
     cache_ram: int | None = None
@@ -194,6 +196,8 @@ class ServerProcess:
             server_args.append("--metrics")
         if self.kv_unified:
             server_args.append("--kv-unified")
+        if self.swa_full:
+            server_args.append("--swa-full")
         if self.server_slots:
             server_args.append("--slots")
         else:
@@ -255,6 +259,8 @@ class ServerProcess:
             server_args.extend(["--chat-template-file", self.chat_template_file])
         if self.mmproj_url:
             server_args.extend(["--mmproj-url", self.mmproj_url])
+        if self.no_mmproj:
+            server_args.append("--no-mmproj")
         if self.media_path:
             server_args.extend(["--media-path", self.media_path])
         if self.sleep_idle_seconds is not None:


### PR DESCRIPTION
## Overview

This PR adds support for **saving and restoring slots that contain media input**. Upstream stores the KV sequence state and a plain token list, but does not preserve the media positions and `mtmd_input_chunk` state required to reconstruct a media-containing slot, so saving such a slot is currently rejected with HTTP 501.

This PR uses `mtmd_input_chunk_save()` / `mtmd_input_chunk_load()` from #26645 and stores the complete `server_tokens` state - tokens, media start positions, and serialized media chunks - as a single versioned packed payload. The same format is used for both text-only and media-containing slots.

Because the packed payload can be larger than the slot's `n_ctx`, the restore path first queries the saved payload size through `llama_state_seq_load_file()` before allocating the restore buffer. After restore, the reconstructed media state can participate in the existing media matching / prefix reuse path.

Closes #25854

## Serialization format

Newly saved slots use the same packed `server_tokens` format for both text-only and media-containing slots.

```text
[LLAMA_TOKEN_NULL]
[version]
[n_tokens][tokens...]
[n_media][start_idx...]
(
  [chunk_size][serialized media chunk]
)...
[zero padding]
```

The current format version is `1`.

`n_tokens` and `n_media` are stored as element counts for their respective vectors. All media start indices are written first, followed by the serialized media chunks in the same order.

* A text-only slot has `n_media = 0`
* The byte stream is zero-padded with 0-3 trailing bytes so that it can be stored as whole `llama_token` words

## Backward compatibility

Slot files written before this PR contain a plain token list in the token payload.

The restore path distinguishes the formats as follows:

* starts with `LLAMA_TOKEN_NULL`: versioned packed `server_tokens` format
* otherwise: legacy plain token list

Therefore, **text-only slot files saved by older servers can still be restored after this PR**.

Newly saved text-only slots use the packed format as well, so restoring a new-format slot file on an older server is not supported.

## `server_tokens` serialization

This PR adds `server_tokens::serialize()` and `server_tokens::deserialize()`.

Internal reader / writer helpers handle scalar and vector fields. Media chunks are serialized through `mtmd_input_chunk_save()` and restored through `mtmd_input_chunk_load()`.

The packed state stores the token sequence, media start positions, and serialized media chunks. `deserialize()` validates the format and payload boundaries, reconstructs the media chunks, checks the supported media types (IMAGE and AUDIO), and validates trailing padding. After deserialization, `server_tokens::validate()` validates text token IDs against the current vocabulary and checks the mapping between media chunks and their token ranges.

An `mmproj` is required only when the restored state actually contains media.

## Slot save

`llama_state_seq_save_file()` returning `0` is handled as an error. The `n_saved` API field continues to report the **logical number of tokens held by the slot**, rather than the size of the packed representation.

## Slot restore

Serialized media chunks can make the packed payload larger than the slot's `n_ctx`.

This PR therefore allows `llama_state_seq_load_file()` to query the saved payload count when `tokens_out == nullptr`, without restoring the sequence state. The server uses that count to allocate the payload buffer before performing the actual load.

After deserialization, the logical token count is checked against the slot's `n_ctx` and the restored tokens are validated against the current model. If restore or validation fails, the slot is cleared before returning the error.

## Slot erase

Erase remains unsupported for slots containing media; its media gate is unchanged.

## Testing

Local validation:

* `test-mtmd-c-api` with assertions enabled: **passed**
* `test_slot_save.py` + `test_vision_api.py`: **28 passed**

Main API-level cases verified:

* text-only and image-containing slot save / restore
* restore of a legacy plain-token slot file
* multiple images
* same-image prefix reuse, including across a server restart
* no image-prefix reuse with a different image
* restoration of a packed payload larger than `n_ctx`
* graceful failure without an `mmproj`, leaving the slot usable

## Benchmark

Qwen3.5-2B Q8_0 + BF16 projector / RTX 4070 / Flash Attention (`-fa on`) / `--cache-ram 0`

3316-token multimodal prompt with a 3303-token reusable prefix, median of 3 runs:

* cold prompt processing: **292.38 ms**
* restore + same image prompt processing: **21.82 ms**
* prompt processing speedup: **13.4x**
* cold completion HTTP request: **298.77 ms**
* restore + same image completion HTTP request: **28.16 ms**
* completion HTTP speedup: **10.6x**
* restore API: **9.80 ms**
* saved state size: **60.9 MB**

With a different image, the restored image prefix was not reused.

## Additional information

* Media slot files are expected to be restored with the same model / `mmproj` configuration.
* Broader portability across server versions or endianness is not guaranteed.
* For SWA models, prefix reuse after restore requires `--swa-full`.
* A future sequence-state API for arbitrary raw user data could remove the current `llama_token`-width packing and padding workaround.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

* I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES

  * **Motivation & Design:** I designed the slot save / restore integration based on the proposal in #25076 and updated it to use the `mtmd_input_chunk` serialization API introduced in #26645.
  * **Investigation & Code Review (Fable 5 / Opus 5, 4.8):** AI agents were used to investigate the relevant multimodal and slot-state paths and assist with code review under my instructions.
  * **Implementation (Opus 5, 4.8 / Fable 5):** AI assistance was used to draft parts of the implementation and tests based on my technical instructions.
  * **Draft Translation (Opus 5 / Fable 5):** The PR text was written by me in Japanese first, with AI used to assist with the English translation.
  * **Validation & Responsibility:** I manually reviewed the submitted changes, ran the local tests and GPU benchmarks, and take full responsibility for the submitted changes.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
