### PR TITLE
CUDA: fall back to generic mul_mat_id when mm_ids_helper doesn't fit in shared memory

### DIFF
--- a/ggml/src/ggml-cuda/mmf.cu
+++ b/ggml/src/ggml-cuda/mmf.cu
@@ -160,6 +160,13 @@ bool ggml_cuda_should_use_mmf(enum ggml_type type, int cc, int warp_size, const 
     }
 
     if (mul_mat_id) {
+        // For more than 16 columns the compact-ids kernel is used, which relies on mm_ids_helper.
+        // Its shared-memory scratch scales with the token count, so fall back to the generic path
+        // when it does not fit: e.g. when the driver reports a bogus sharedMemPerBlockOptin (0 has
+        // been observed on Blackwell), or for very large token counts on any device.
+        if (src1_ncols > 16 && !ggml_cuda_mm_ids_helper_fits(src1_ncols)) {
+            return false;
+        }
         if (src0_ne[1] <= 1024 && src1_ncols > 512) {
             return false;
         } else if(src0_ne[1] > 1024 && src1_ncols > 128) {

--- a/ggml/src/ggml-cuda/mmid.cu
+++ b/ggml/src/ggml-cuda/mmid.cu
@@ -140,6 +140,12 @@ static void launch_mm_ids_helper(
         (ids, ids_src1, ids_dst, expert_bounds, n_tokens, n_expert_used_var, nchannels_y, si1, sis1, write_inverse);
 }
 
+bool ggml_cuda_mm_ids_helper_fits(const int n_tokens) {
+    const int    id    = ggml_cuda_get_device();
+    const size_t smpbo = ggml_cuda_info().devices[id].smpbo;
+    return n_tokens*sizeof(mm_ids_helper_store) <= smpbo;
+}
+
 void ggml_cuda_launch_mm_ids_helper(
         const int32_t * __restrict__ ids, int32_t * __restrict__ ids_src1, int32_t * __restrict__ ids_dst, int32_t * __restrict__ expert_bounds,
         const int n_experts, const int n_tokens, const int n_expert_used, const int nchannels_y, const int si1, const int sis1, const bool write_inverse, cudaStream_t stream) {

--- a/ggml/src/ggml-cuda/mmid.cuh
+++ b/ggml/src/ggml-cuda/mmid.cuh
@@ -1,5 +1,11 @@
 #pragma once
 
+// Whether the mm_ids_helper kernel's per-block shared-memory scratch (n_tokens entries) fits
+// within the shared memory available on the current device. Callers that would otherwise launch
+// mm_ids_helper must check this and fall back to a path that does not need it, because the kernel
+// requires the scratch to be in shared memory and cannot itself degrade gracefully.
+bool ggml_cuda_mm_ids_helper_fits(int n_tokens);
+
 void ggml_cuda_launch_mm_ids_helper(
         const int32_t * ids, int32_t * ids_src1, int32_t * ids_dst, int32_t * expert_bounds,
         int n_experts, int n_tokens, int n_expert_used, int nchannels_y, int si1, int sis1, bool write_inverse, cudaStream_t stream);


### PR DESCRIPTION
## What

`ggml_cuda_should_use_mmf()` selects the mmf path for `mul_mat_id`, which uses the compact-ids kernel (`mm_ids_helper`) for more than 16 columns. `launch_mm_ids_helper()` hard-aborts via `GGML_ASSERT(nbytes_shared <= smpbo)` when the per-block shared-memory scratch does not fit — so `mul_mat_id` aborts the whole process instead of falling back, unlike the sibling shared-memory kernels (`soft_max`, `mmq`, `cross_entropy`) which degrade gracefully. #26141 added this kind of fallback to the mmq path; the mmf path was left unguarded.

## Reproduction

On an RTX 5090 (CUDA 13.1, WSL2, driver 591.86) the driver reports `sharedMemPerBlockOptin == 0` (`cudaDeviceGetAttribute(cudaDevAttrMaxSharedMemoryPerBlockOptin)` correctly returns 101376). With `smpbo == 0` the assert fires for any MoE model with more than 16 tokens — same class of crash as #23385 / #24937:

```
tests/test-backend-ops test -b CUDA0 -o MUL_MAT_ID
...
ggml/src/ggml-cuda/mmid.cu:138: GGML_ASSERT(nbytes_shared <= smpbo) failed
```

## Fix

Add `ggml_cuda_mm_ids_helper_fits()` and make `should_use_mmf()` return false when the helper's scratch does not fit, so `mul_mat_id` falls through to the generic path instead of aborting. This is a no-op on hardware that reports a valid shared-memory size.

## Testing

RTX 5090 D v2, CUDA 13.1:
- Before: `test-backend-ops test -b CUDA0 -o MUL_MAT_ID` aborts at the first f32 MoE case with more than 16 tokens.
- After: full `test-backend-ops test -b CUDA0` → **2/2 backends passed, 0 failures**.
