### PR TITLE
metal: fix `threadgroup half4x4` compilation error in lightning indexer

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -11328,8 +11328,8 @@ kernel void kernel_lightning_indexer(
     const int i_kv_0   = tgpig.x*NK;            // first key of this threadgroup
     const int i_kv     = i_kv_0 + sgitg*NKPSG;  // first key of this simdgroup
 
-    threadgroup half4x4   sk4x4[NK*DK16];
-    threadgroup half    * sk = (threadgroup half *) sk4x4;
+    threadgroup half sk[NK * DK16 * 16];
+    threadgroup half4x4 * sk4x4 = (threadgroup half4x4 *) sk;
 
     for (short i = tiitg; i < NK*DK16; i += NTG) {
         const short ik  = i/DK16;


### PR DESCRIPTION


<img width="2598" height="1055" alt="image" src="https://github.com/user-attachments/assets/add934ae-e5bc-406e-a797-26484286b2a2" />


- In MSL, declaring an array of matrix types like `threadgroup half4x4` causes a 'no matching constructor' compilation error because MSL matrix types do not have zero-argument default constructors and threadgroup variables cannot have initializers.


- Fix this by declaring a POD `threadgroup half` array instead and casting to `threadgroup half4x4 *` for matrix indexing.

## Overview

In #25893, `kernel_lightning_indexer` declared an array of `threadgroup half4x4`.
MSL does not support implicit zero-argument constructors for matrix types,
causing a 'no matching constructor' build failure on Metal.

This fixes the issue by declaring a POD `threadgroup half` array and casting
it to `threadgroup half4x4 *`.

After this patch:

<img width="1870" height="1166" alt="image" src="https://github.com/user-attachments/assets/3a43096a-f834-4bc1-8b82-0522912a4538" />

## Additional information

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/957a2ae6-b39c-4f38-8571-a34c2f956dd8" />

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
