### PR TITLE
ggml-metal: add chunked SSD MMA for Mamba-2 prefill optimization

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -602,7 +602,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma
     char name[256];
 
     snprintf(base, 256, "kernel_ssm_scan_ssd_mma_%s", ggml_type_name(op->src[0]->type));
-    snprintf(name, 256, "%s_cs=%d_nsg=%d", base, GGML_METAL_SSM_SCAN_SSD_CS, GGML_METAL_SSM_SCAN_SSD_MMA_NSG);
+    snprintf(name, 256, "%s", base, OP_SSM_SCAN_SSD_CS, OP_SSM_SCAN_SSD_NSG);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
     if (!res.pipeline) {
@@ -610,10 +610,10 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma
     }
 
     // acs/exp(acs)/state-decay vectors + dtX + SAM rows + two 8x8 tiles per simdgroup
-    res.smem = (3*GGML_METAL_SSM_SCAN_SSD_CS +
-                GGML_METAL_SSM_SCAN_SSD_CS*64 +
-                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*8*GGML_METAL_SSM_SCAN_SSD_CS +
-                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*2*8*8)*sizeof(float);
+    res.smem = (3*OP_SSM_SCAN_SSD_CS +
+                OP_SSM_SCAN_SSD_CS*64 +
+                OP_SSM_SCAN_SSD_NSG*8*OP_SSM_SCAN_SSD_CS +
+                OP_SSM_SCAN_SSD_NSG*2*8*8)*sizeof(float);
 
     return res;
 }

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -597,30 +597,6 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
     return res;
 }
 
-// kernel_ssm_scan_ssd_f32 implements the chunked SSD algorithm (SPEC.md §6, §8.1); its
-// threadgroup memory holds the per-chunk segsum cumsum + dt*x tile (2 * CS floats) plus the
-// cross-simdgroup output reduction scratch (nsg floats) -- see kernel body for the exact layout.
-ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd(ggml_metal_library_t lib, const ggml_tensor * op)  {
-    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
-
-    char base[256];
-    char name[256];
-
-    const int nsg = (ne00 + 31)/32;
-
-    snprintf(base, 256, "kernel_ssm_scan_ssd_%s", ggml_type_name(op->src[0]->type));
-    snprintf(name, 256, "%s_nsg=%d", base, nsg);
-
-    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
-    if (!res.pipeline) {
-        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
-    }
-
-    res.smem = (2*GGML_METAL_SSM_SCAN_SSD_CS + nsg)*sizeof(float);
-
-    return res;
-}
-
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(ggml_metal_library_t lib, const ggml_tensor * op)  {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -597,6 +597,51 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
     return res;
 }
 
+// kernel_ssm_scan_ssd_f32 implements the chunked SSD algorithm (SPEC.md §6, §8.1); its
+// threadgroup memory holds the per-chunk segsum cumsum + dt*x tile (2 * CS floats) plus the
+// cross-simdgroup output reduction scratch (nsg floats) -- see kernel body for the exact layout.
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd(ggml_metal_library_t lib, const ggml_tensor * op)  {
+    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
+
+    char base[256];
+    char name[256];
+
+    const int nsg = (ne00 + 31)/32;
+
+    snprintf(base, 256, "kernel_ssm_scan_ssd_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, 256, "%s_nsg=%d", base, nsg);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    res.smem = (2*GGML_METAL_SSM_SCAN_SSD_CS + nsg)*sizeof(float);
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(ggml_metal_library_t lib, const ggml_tensor * op)  {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_ssm_scan_ssd_mma_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, 256, "%s_cs=%d_nsg=%d", base, GGML_METAL_SSM_SCAN_SSD_CS, GGML_METAL_SSM_SCAN_SSD_MMA_NSG);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    // acs/exp(acs)/state-decay vectors + dtX + SAM rows + two 8x8 tiles per simdgroup
+    res.smem = (3*GGML_METAL_SSM_SCAN_SSD_CS +
+                GGML_METAL_SSM_SCAN_SSD_CS*64 +
+                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*8*GGML_METAL_SSM_SCAN_SSD_CS +
+                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*2*8*8)*sizeof(float);
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rwkv(ggml_metal_library_t lib, const ggml_tensor * op) {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -598,30 +598,6 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
     return res;
 }
 
-// kernel_ssm_scan_ssd_f32 implements the chunked SSD algorithm (SPEC.md §6, §8.1); its
-// threadgroup memory holds the per-chunk segsum cumsum + dt*x tile (2 * CS floats) plus the
-// cross-simdgroup output reduction scratch (nsg floats) -- see kernel body for the exact layout.
-ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd(ggml_metal_library_t lib, const ggml_tensor * op)  {
-    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
-
-    char base[256];
-    char name[256];
-
-    const int nsg = (ne00 + 31)/32;
-
-    snprintf(base, 256, "kernel_ssm_scan_ssd_%s", ggml_type_name(op->src[0]->type));
-    snprintf(name, 256, "%s_nsg=%d", base, nsg);
-
-    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
-    if (!res.pipeline) {
-        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
-    }
-
-    res.smem = (2*GGML_METAL_SSM_SCAN_SSD_CS + nsg)*sizeof(float);
-
-    return res;
-}
-
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(ggml_metal_library_t lib, const ggml_tensor * op)  {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -598,6 +598,51 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
     return res;
 }
 
+// kernel_ssm_scan_ssd_f32 implements the chunked SSD algorithm (SPEC.md §6, §8.1); its
+// threadgroup memory holds the per-chunk segsum cumsum + dt*x tile (2 * CS floats) plus the
+// cross-simdgroup output reduction scratch (nsg floats) -- see kernel body for the exact layout.
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd(ggml_metal_library_t lib, const ggml_tensor * op)  {
+    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
+
+    char base[256];
+    char name[256];
+
+    const int nsg = (ne00 + 31)/32;
+
+    snprintf(base, 256, "kernel_ssm_scan_ssd_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, 256, "%s_nsg=%d", base, nsg);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    res.smem = (2*GGML_METAL_SSM_SCAN_SSD_CS + nsg)*sizeof(float);
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(ggml_metal_library_t lib, const ggml_tensor * op)  {
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_ssm_scan_ssd_mma_%s", ggml_type_name(op->src[0]->type));
+    snprintf(name, 256, "%s_cs=%d_nsg=%d", base, GGML_METAL_SSM_SCAN_SSD_CS, GGML_METAL_SSM_SCAN_SSD_MMA_NSG);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    // acs/exp(acs)/state-decay vectors + dtX + SAM rows + two 8x8 tiles per simdgroup
+    res.smem = (3*GGML_METAL_SSM_SCAN_SSD_CS +
+                GGML_METAL_SSM_SCAN_SSD_CS*64 +
+                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*8*GGML_METAL_SSM_SCAN_SSD_CS +
+                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*2*8*8)*sizeof(float);
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rwkv(ggml_metal_library_t lib, const ggml_tensor * op) {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -603,7 +603,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma
     char name[256];
 
     snprintf(base, 256, "kernel_ssm_scan_ssd_mma_%s", ggml_type_name(op->src[0]->type));
-    snprintf(name, 256, "%s_cs=%d_nsg=%d", base, GGML_METAL_SSM_SCAN_SSD_CS, GGML_METAL_SSM_SCAN_SSD_MMA_NSG);
+    snprintf(name, 256, "%s", base, OP_SSM_SCAN_SSD_CS, OP_SSM_SCAN_SSD_NSG);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
     if (!res.pipeline) {
@@ -611,10 +611,10 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma
     }
 
     // acs/exp(acs)/state-decay vectors + dtX + SAM rows + two 8x8 tiles per simdgroup
-    res.smem = (3*GGML_METAL_SSM_SCAN_SSD_CS +
-                GGML_METAL_SSM_SCAN_SSD_CS*64 +
-                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*8*GGML_METAL_SSM_SCAN_SSD_CS +
-                GGML_METAL_SSM_SCAN_SSD_MMA_NSG*2*8*8)*sizeof(float);
+    res.smem = (3*OP_SSM_SCAN_SSD_CS +
+                OP_SSM_SCAN_SSD_CS*64 +
+                OP_SSM_SCAN_SSD_NSG*8*OP_SSM_SCAN_SSD_CS +
+                OP_SSM_SCAN_SSD_NSG*2*8*8)*sizeof(float);
 
     return res;
 }

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -580,18 +580,12 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
 
     const int nsg = (ne00 + 31)/32;
 
-    snprintf(base, 256, "kernel_ssm_scan_%s", ggml_type_name(op->src[0]->type));
-    snprintf(name, 256, "%s_nsg=%d_tail=%d", base, nsg, tail);
+    snprintf(base, 256, "kernel_ssm_scan_%s%s", ggml_type_name(op->src[0]->type), tail ? "_tail" : "");
+    snprintf(name, 256, "%s_nsg=%d", base, nsg);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
     if (!res.pipeline) {
-        ggml_metal_cv_t cv = ggml_metal_cv_init();
-
-        ggml_metal_cv_set_bool(cv, tail, FC_SSM_SCAN + 0);
-
-        res = ggml_metal_library_compile_pipeline(lib, base, name, cv);
-
-        ggml_metal_cv_free(cv);
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
     }
 
     // Shared memory layout:
@@ -618,7 +612,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma
 
     // acs/exp(acs)/state-decay vectors + dtX + SAM rows + two 8x8 tiles per simdgroup
     res.smem = (3*OP_SSM_SCAN_SSD_CS +
-                OP_SSM_SCAN_SSD_CS*64 +
+                OP_SSM_SCAN_SSD_CS*OP_SSM_SCAN_SSD_HD +
                 OP_SSM_SCAN_SSD_NSG*8*OP_SSM_SCAN_SSD_CS +
                 OP_SSM_SCAN_SSD_NSG*2*8*8)*sizeof(float);
 

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -603,7 +603,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma
     char name[256];
 
     snprintf(base, 256, "kernel_ssm_scan_ssd_mma_%s", ggml_type_name(op->src[0]->type));
-    snprintf(name, 256, "%s", base, OP_SSM_SCAN_SSD_CS, OP_SSM_SCAN_SSD_NSG);
+    snprintf(name, 256, "%s", base);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
     if (!res.pipeline) {

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -572,7 +572,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv_batched
     return res;
 }
 
-ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_metal_library_t lib, const ggml_tensor * op)  {
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_metal_library_t lib, const ggml_tensor * op, bool tail)  {
     GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
 
     char base[256];
@@ -581,11 +581,17 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan(ggml_me
     const int nsg = (ne00 + 31)/32;
 
     snprintf(base, 256, "kernel_ssm_scan_%s", ggml_type_name(op->src[0]->type));
-    snprintf(name, 256, "%s_nsg=%d", base, nsg);
+    snprintf(name, 256, "%s_nsg=%d_tail=%d", base, nsg, tail);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
     if (!res.pipeline) {
-        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+        ggml_metal_cv_t cv = ggml_metal_cv_init();
+
+        ggml_metal_cv_set_bool(cv, tail, FC_SSM_SCAN + 0);
+
+        res = ggml_metal_library_compile_pipeline(lib, base, name, cv);
+
+        ggml_metal_cv_free(cv);
     }
 
     // Shared memory layout:

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -130,6 +130,8 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_dsv4_hc  
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv          (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv_batched  (ggml_metal_library_t lib, const struct ggml_tensor * op, int ssm_conv_bs);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan          (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma  (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rwkv              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_gated_delta_net   (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_solve_tri         (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -130,7 +130,6 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_dsv4_hc  
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv          (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv_batched  (ggml_metal_library_t lib, const struct ggml_tensor * op, int ssm_conv_bs);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan          (ggml_metal_library_t lib, const struct ggml_tensor * op);
-struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd      (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma  (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rwkv              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_gated_delta_net   (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -129,7 +129,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_lightning
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_dsv4_hc           (ggml_metal_library_t lib, enum ggml_op op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv          (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_conv_batched  (ggml_metal_library_t lib, const struct ggml_tensor * op, int ssm_conv_bs);
-struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan          (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan          (ggml_metal_library_t lib, const struct ggml_tensor * op, bool tail);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_ssm_scan_ssd_mma  (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_rwkv              (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_gated_delta_net   (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -155,8 +155,8 @@
 #define OP_SUM_ROWS_NUM_SUM_ROWS 10
 #define OP_SUM_ROWS_NUM_MEAN     11
 
-#define OP_SSM_SCAN_SSD_CS 64
-#define OP_SSM_SCAN_SSD_NSG 4
+#define OP_SSM_SCAN_SSD_CS 64 // Metal-specific; Chunk Size; 64 is largest multiple of 8 (simdgroup tile) fitting into 32 KiB Metal threadgroup mem limit (~26.75 KiB, see ggml-metal.metal line 2492)
+#define OP_SSM_SCAN_SSD_NSG 4 // Metal-specific; Number of SimdGroups per threadgroup;  4 × 32 = 128 threads, 4 gives 128 threads total per threadgroup to match dispatch
 
 // kernel argument structs
 //

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -870,8 +870,7 @@ typedef struct {
     uint64_t nb2;
 } ggml_metal_kargs_ssm_conv;
 
-// chunk length for kernel_ssm_scan_ssd_f32 (SSD/chunked-scan path); shared between the kernel
-// and the host-side threadgroup-memory sizing in ggml_metal_library_get_pipeline_ssm_scan_ssd
+// chunk length for the MMA SSD path; shared between the kernel and host-side memory sizing
 #define GGML_METAL_SSM_SCAN_SSD_CS 64
 #define GGML_METAL_SSM_SCAN_SSD_MMA_NSG 4
 
@@ -881,7 +880,10 @@ typedef struct {
     int64_t  n_head;
     int64_t  n_group;
     int64_t  n_seq_tokens;
+    int64_t  n_seq_tokens_total;
+    int64_t  token_offset;
     int64_t  n_seqs;
+    bool     state_from_dst;
     uint64_t s_off;
     uint64_t nb00;
     uint64_t nb01;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -870,6 +870,11 @@ typedef struct {
     uint64_t nb2;
 } ggml_metal_kargs_ssm_conv;
 
+// chunk length for kernel_ssm_scan_ssd_f32 (SSD/chunked-scan path); shared between the kernel
+// and the host-side threadgroup-memory sizing in ggml_metal_library_get_pipeline_ssm_scan_ssd
+#define GGML_METAL_SSM_SCAN_SSD_CS 64
+#define GGML_METAL_SSM_SCAN_SSD_MMA_NSG 4
+
 typedef struct {
     int64_t  d_state;
     int64_t  d_inner;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -155,6 +155,9 @@
 #define OP_SUM_ROWS_NUM_SUM_ROWS 10
 #define OP_SUM_ROWS_NUM_MEAN     11
 
+#define OP_SSM_SCAN_SSD_CS 64
+#define OP_SSM_SCAN_SSD_NSG 4
+
 // kernel argument structs
 //
 // - element counters (e.g. ne00) typically use int32_t to reduce register usage
@@ -870,10 +873,6 @@ typedef struct {
     uint64_t nb2;
 } ggml_metal_kargs_ssm_conv;
 
-// chunk length for the MMA SSD path; shared between the kernel and host-side memory sizing
-#define GGML_METAL_SSM_SCAN_SSD_CS 64
-#define GGML_METAL_SSM_SCAN_SSD_MMA_NSG 4
-
 typedef struct {
     int64_t  d_state;
     int64_t  d_inner;
@@ -883,7 +882,6 @@ typedef struct {
     int64_t  n_seq_tokens_total;
     int64_t  token_offset;
     int64_t  n_seqs;
-    bool     state_from_dst;
     uint64_t s_off;
     uint64_t nb00;
     uint64_t nb01;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -158,8 +158,8 @@
 #define OP_SUM_ROWS_NUM_SUM_ROWS 10
 #define OP_SUM_ROWS_NUM_MEAN     11
 
-#define OP_SSM_SCAN_SSD_CS 64
-#define OP_SSM_SCAN_SSD_NSG 4
+#define OP_SSM_SCAN_SSD_CS 64 // Metal-specific; Chunk Size; 64 is largest multiple of 8 (simdgroup tile) fitting into 32 KiB Metal threadgroup mem limit (~26.75 KiB, see ggml-metal.metal line 2492)
+#define OP_SSM_SCAN_SSD_NSG 4 // Metal-specific; Number of SimdGroups per threadgroup;  4 × 32 = 128 threads, 4 gives 128 threads total per threadgroup to match dispatch
 
 // kernel argument structs
 //

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -158,6 +158,9 @@
 #define OP_SUM_ROWS_NUM_SUM_ROWS 10
 #define OP_SUM_ROWS_NUM_MEAN     11
 
+#define OP_SSM_SCAN_SSD_CS 64
+#define OP_SSM_SCAN_SSD_NSG 4
+
 // kernel argument structs
 //
 // - element counters (e.g. ne00) typically use int32_t to reduce register usage
@@ -887,10 +890,6 @@ typedef struct {
     uint64_t nb2;
 } ggml_metal_kargs_ssm_conv;
 
-// chunk length for the MMA SSD path; shared between the kernel and host-side memory sizing
-#define GGML_METAL_SSM_SCAN_SSD_CS 64
-#define GGML_METAL_SSM_SCAN_SSD_MMA_NSG 4
-
 typedef struct {
     int64_t  d_state;
     int64_t  d_inner;
@@ -901,7 +900,6 @@ typedef struct {
     int64_t  token_offset;
     int64_t  n_seqs;
     int64_t  K;
-    bool     state_from_dst;
     uint64_t s_off;
     uint64_t nb00;
     uint64_t nb01;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -887,8 +887,7 @@ typedef struct {
     uint64_t nb2;
 } ggml_metal_kargs_ssm_conv;
 
-// chunk length for kernel_ssm_scan_ssd_f32 (SSD/chunked-scan path); shared between the kernel
-// and the host-side threadgroup-memory sizing in ggml_metal_library_get_pipeline_ssm_scan_ssd
+// chunk length for the MMA SSD path; shared between the kernel and host-side memory sizing
 #define GGML_METAL_SSM_SCAN_SSD_CS 64
 #define GGML_METAL_SSM_SCAN_SSD_MMA_NSG 4
 
@@ -898,8 +897,11 @@ typedef struct {
     int64_t  n_head;
     int64_t  n_group;
     int64_t  n_seq_tokens;
+    int64_t  n_seq_tokens_total;
+    int64_t  token_offset;
     int64_t  n_seqs;
     int64_t  K;
+    bool     state_from_dst;
     uint64_t s_off;
     uint64_t nb00;
     uint64_t nb01;

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -107,7 +107,6 @@
 #define FC_SUM_ROWS                    1400
 #define FC_UPSCALE                     1500
 #define FC_GATED_DELTA_NET             1600
-#define FC_SSM_SCAN                    1700
 
 // op-specific constants
 #define OP_FLASH_ATTN_EXT_NQPSG 8
@@ -159,8 +158,9 @@
 #define OP_SUM_ROWS_NUM_SUM_ROWS 10
 #define OP_SUM_ROWS_NUM_MEAN     11
 
-#define OP_SSM_SCAN_SSD_CS 64 // Metal-specific; Chunk Size; 64 is largest multiple of 8 (simdgroup tile) fitting into 32 KiB Metal threadgroup mem limit (~26.75 KiB shared mem; see smem layout comment in kernel_ssm_scan_ssd_mma_f32)
-#define OP_SSM_SCAN_SSD_NSG 4 // Metal-specific; Number of SimdGroups per threadgroup;  4 × 32 = 128 threads, 4 gives 128 threads total per threadgroup to match dispatch
+#define OP_SSM_SCAN_SSD_CS  64 // Metal-specific; Chunk Size; 64 is largest multiple of 8 (simdgroup tile) fitting into 32 KiB Metal threadgroup mem limit (~26.75 KiB shared mem; see smem layout comment in kernel_ssm_scan_ssd_mma_f32)
+#define OP_SSM_SCAN_SSD_HD  64 // Metal-specific; Head Dim the MMA kernel is specialized for (Mamba-2); use_mma gates on d_inner == this
+#define OP_SSM_SCAN_SSD_NSG 4  // Metal-specific; Number of SimdGroups per threadgroup; NSG*32 == threads dispatched per threadgroup
 
 // kernel argument structs
 //

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -107,6 +107,7 @@
 #define FC_SUM_ROWS                    1400
 #define FC_UPSCALE                     1500
 #define FC_GATED_DELTA_NET             1600
+#define FC_SSM_SCAN                    1700
 
 // op-specific constants
 #define OP_FLASH_ATTN_EXT_NQPSG 8

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -158,7 +158,7 @@
 #define OP_SUM_ROWS_NUM_SUM_ROWS 10
 #define OP_SUM_ROWS_NUM_MEAN     11
 
-#define OP_SSM_SCAN_SSD_CS 64 // Metal-specific; Chunk Size; 64 is largest multiple of 8 (simdgroup tile) fitting into 32 KiB Metal threadgroup mem limit (~26.75 KiB, see ggml-metal.metal line 2492)
+#define OP_SSM_SCAN_SSD_CS 64 // Metal-specific; Chunk Size; 64 is largest multiple of 8 (simdgroup tile) fitting into 32 KiB Metal threadgroup mem limit (~26.75 KiB shared mem; see smem layout comment in kernel_ssm_scan_ssd_mma_f32)
 #define OP_SSM_SCAN_SSD_NSG 4 // Metal-specific; Number of SimdGroups per threadgroup;  4 × 32 = 128 threads, 4 gives 128 threads total per threadgroup to match dispatch
 
 // kernel argument structs

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -887,6 +887,11 @@ typedef struct {
     uint64_t nb2;
 } ggml_metal_kargs_ssm_conv;
 
+// chunk length for kernel_ssm_scan_ssd_f32 (SSD/chunked-scan path); shared between the kernel
+// and the host-side threadgroup-memory sizing in ggml_metal_library_get_pipeline_ssm_scan_ssd
+#define GGML_METAL_SSM_SCAN_SSD_CS 64
+#define GGML_METAL_SSM_SCAN_SSD_MMA_NSG 4
+
 typedef struct {
     int64_t  d_state;
     int64_t  d_inner;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1721,7 +1721,6 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.n_seq_tokens_total =*/ n_seq_tokens,
         /*.token_offset =*/ 0,
         /*.n_seqs       =*/ n_seqs,
-        /*.state_from_dst =*/ false,
         /*.s_off        =*/ ggml_nelements(op->src[1]) * sizeof(float),
         /*.nb00         =*/ nb00,
         /*.nb01         =*/ nb01,
@@ -1749,7 +1748,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.nb0          =*/ nb0,
     };
 
-    constexpr int64_t CHUNK = GGML_METAL_SSM_SCAN_SSD_CS;
+    constexpr int64_t CHUNK = OP_SSM_SCAN_SSD_CS;
 
     const int64_t mma_tokens = n_seq_tokens / CHUNK * CHUNK;
     const bool use_mma =
@@ -1784,7 +1783,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
     args.n_seq_tokens = mma_tokens;
     dispatch(
         ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op),
-        GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32,
+        OP_SSM_SCAN_SSD_NSG*32,
         1);
 
     if (mma_tokens < n_seq_tokens) {
@@ -1792,7 +1791,6 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
         args.n_seq_tokens = n_seq_tokens - mma_tokens;
         args.token_offset = mma_tokens;
-        args.state_from_dst = true;
         dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
     }
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1718,7 +1718,10 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.n_head       =*/ n_head,
         /*.n_group      =*/ n_group,
         /*.n_seq_tokens =*/ n_seq_tokens,
+        /*.n_seq_tokens_total =*/ n_seq_tokens,
+        /*.token_offset =*/ 0,
         /*.n_seqs       =*/ n_seqs,
+        /*.state_from_dst =*/ false,
         /*.s_off        =*/ ggml_nelements(op->src[1]) * sizeof(float),
         /*.nb00         =*/ nb00,
         /*.nb01         =*/ nb01,
@@ -1746,45 +1749,52 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.nb0          =*/ nb0,
     };
 
-    // use the chunked SSD kernel for large multi-token prefill, sequential kernel otherwise
-    // ne30 != 1 means per-channel A (Mamba-1), which the SSD kernel does not support
-    constexpr int64_t CHUNK = 64;
+    constexpr int64_t CHUNK = GGML_METAL_SSM_SCAN_SSD_CS;
 
-    const bool use_ssd = ne30 == 1 && n_seq_tokens >= CHUNK;
-    const bool use_mma = use_ssd &&
+    const int64_t mma_tokens = n_seq_tokens / CHUNK * CHUNK;
+    const bool use_mma =
+        mma_tokens > 0 &&
+        ne30 == 1 &&
         props_dev->has_simdgroup_mm &&
-        d_state      % 8     == 0 &&
-        d_inner              == 64 &&
-        n_seq_tokens % CHUNK == 0;
+        d_state % 8 == 0 &&
+        d_inner == 64;
 
-    auto pipeline = use_mma ?
-        ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op) :
-        use_ssd ?
-            ggml_metal_library_get_pipeline_ssm_scan_ssd(lib, op) :
-            ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+    const auto dispatch = [&](ggml_metal_pipeline_with_params pipeline, int64_t nth, int64_t n_tg_x) {
+        GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
 
-    const int64_t nth = use_mma ? GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32 : d_state;
-    GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[2]), 3);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[3]), 4);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[4]), 5);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[5]), 6);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[6]), 7);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         8);
+        ggml_metal_encoder_set_threadgroup_memory_size(enc, pipeline.smem, 0);
+        ggml_metal_encoder_dispatch_threadgroups(enc, n_tg_x, n_head, n_seqs, nth, 1, 1);
+    };
 
-    const size_t smem = pipeline.smem;
+    if (!use_mma) {
+        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
+        return 1;
+    }
 
-    ggml_metal_encoder_set_pipeline(enc, pipeline);
-    ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[2]), 3);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[3]), 4);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[4]), 5);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[5]), 6);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[6]), 7);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         8);
+    args.n_seq_tokens = mma_tokens;
+    dispatch(
+        ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op),
+        GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32,
+        1);
 
-    ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
+    if (mma_tokens < n_seq_tokens) {
+        ggml_metal_encoder_memory_barrier(enc);
 
-    ggml_metal_encoder_dispatch_threadgroups(
-        enc,
-        use_mma ? 1 : d_inner, n_head, n_seqs,
-        nth, 1, 1);
+        args.n_seq_tokens = n_seq_tokens - mma_tokens;
+        args.token_offset = mma_tokens;
+        args.state_from_dst = true;
+        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
+    }
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1753,10 +1753,10 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
     const int64_t mma_tokens = (n_seq_tokens / CHUNK) * CHUNK; // largest multiple of CHUNK <= n_seq_tokens
     const bool use_mma =
         mma_tokens > 0 &&
-        ne30 == 1 &&
-        props_dev->has_simdgroup_mm &&
-        d_state % 8 == 0 &&
-        d_inner == 64;
+        ne30 == 1 && // checks that A tensor is set to scalar decay per head (A shape {1, n_head})
+        props_dev->has_simdgroup_mm && // hardware check for M1 or newer
+        d_state % 8 == 0 && // d_state must be multiple of 8 to align with simdgroup_float 8x8 tiles
+        d_inner == 64; // mma kernel hardcodes HD=64 to follow Mamba-2 head dim standard; this checks it
 
     const auto dispatch = [&](ggml_metal_pipeline_with_params pipeline, int64_t nth, int64_t n_tg_x) {
         GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1750,7 +1750,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     constexpr int64_t CHUNK = OP_SSM_SCAN_SSD_CS;
 
-    const int64_t mma_tokens = n_seq_tokens / CHUNK * CHUNK;
+    const int64_t mma_tokens = (n_seq_tokens / CHUNK) * CHUNK; // largest multiple of CHUNK <= n_seq_tokens
     const bool use_mma =
         mma_tokens > 0 &&
         ne30 == 1 &&

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1676,6 +1676,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     ggml_metal_library_t lib = ctx->lib;
     ggml_metal_encoder_t enc = ctx->enc;
+    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
 
     GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
     GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
@@ -1745,9 +1746,25 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.nb0          =*/ nb0,
     };
 
-    auto pipeline = ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+    // use the chunked SSD kernel for large multi-token prefill, sequential kernel otherwise
+    // ne30 != 1 means per-channel A (Mamba-1), which the SSD kernel does not support
+    constexpr int64_t CHUNK = 64;
 
-    GGML_ASSERT(d_state <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+    const bool use_ssd = ne30 == 1 && n_seq_tokens >= CHUNK;
+    const bool use_mma = use_ssd &&
+        props_dev->has_simdgroup_mm &&
+        d_state      % 8     == 0 &&
+        d_inner              == 64 &&
+        n_seq_tokens % CHUNK == 0;
+
+    auto pipeline = use_mma ?
+        ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op) :
+        use_ssd ?
+            ggml_metal_library_get_pipeline_ssm_scan_ssd(lib, op) :
+            ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+
+    const int64_t nth = use_mma ? GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32 : d_state;
+    GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
 
     const size_t smem = pipeline.smem;
 
@@ -1764,7 +1781,10 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
 
-    ggml_metal_encoder_dispatch_threadgroups(enc, d_inner, n_head, n_seqs, d_state, 1, 1);
+    ggml_metal_encoder_dispatch_threadgroups(
+        enc,
+        use_mma ? 1 : d_inner, n_head, n_seqs,
+        nth, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1763,10 +1763,11 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         ne30 == 1 && // checks that A tensor is set to scalar decay per head (A shape {1, n_head})
         props_dev->has_simdgroup_mm && // hardware check for M1 or newer
         d_state % 8 == 0 && // d_state must be multiple of 8 to align with simdgroup_float 8x8 tiles
-        d_inner == 64; // mma kernel hardcodes HD=64 to follow Mamba-2 head dim standard; this checks it
+        d_inner == OP_SSM_SCAN_SSD_HD; // mma kernel is specialized for the Mamba-2 head dim; this checks it
 
     const auto dispatch = [&](ggml_metal_pipeline_with_params pipeline, int64_t nth, int64_t n_tg_x) {
         GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+        GGML_ASSERT(pipeline.smem <= props_dev->max_theadgroup_memory_size);
 
         ggml_metal_encoder_set_pipeline(enc, pipeline);
         ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1723,8 +1723,11 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.n_head       =*/ n_head,
         /*.n_group      =*/ n_group,
         /*.n_seq_tokens =*/ n_seq_tokens,
+        /*.n_seq_tokens_total =*/ n_seq_tokens,
+        /*.token_offset =*/ 0,
         /*.n_seqs       =*/ n_seqs,
         /*.K            =*/ K,
+        /*.state_from_dst =*/ false,
         /*.s_off        =*/ ggml_nelements(op->src[1]) * sizeof(float),
         /*.nb00         =*/ nb00,
         /*.nb01         =*/ nb01,
@@ -1752,45 +1755,52 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.nb0          =*/ nb0,
     };
 
-    // use the chunked SSD kernel for large multi-token prefill, sequential kernel otherwise
-    // ne30 != 1 means per-channel A (Mamba-1), which the SSD kernel does not support
-    constexpr int64_t CHUNK = 64;
+    constexpr int64_t CHUNK = GGML_METAL_SSM_SCAN_SSD_CS;
 
-    const bool use_ssd = ne30 == 1 && n_seq_tokens >= CHUNK;
-    const bool use_mma = use_ssd &&
+    const int64_t mma_tokens = n_seq_tokens / CHUNK * CHUNK;
+    const bool use_mma =
+        mma_tokens > 0 &&
+        ne30 == 1 &&
         props_dev->has_simdgroup_mm &&
-        d_state      % 8     == 0 &&
-        d_inner              == 64 &&
-        n_seq_tokens % CHUNK == 0;
+        d_state % 8 == 0 &&
+        d_inner == 64;
 
-    auto pipeline = use_mma ?
-        ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op) :
-        use_ssd ?
-            ggml_metal_library_get_pipeline_ssm_scan_ssd(lib, op) :
-            ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+    const auto dispatch = [&](ggml_metal_pipeline_with_params pipeline, int64_t nth, int64_t n_tg_x) {
+        GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
 
-    const int64_t nth = use_mma ? GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32 : d_state;
-    GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[2]), 3);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[3]), 4);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[4]), 5);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[5]), 6);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[6]), 7);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         8);
+        ggml_metal_encoder_set_threadgroup_memory_size(enc, pipeline.smem, 0);
+        ggml_metal_encoder_dispatch_threadgroups(enc, n_tg_x, n_head, n_seqs, nth, 1, 1);
+    };
 
-    const size_t smem = pipeline.smem;
+    if (!use_mma) {
+        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
+        return 1;
+    }
 
-    ggml_metal_encoder_set_pipeline(enc, pipeline);
-    ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[2]), 3);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[3]), 4);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[4]), 5);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[5]), 6);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[6]), 7);
-    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         8);
+    args.n_seq_tokens = mma_tokens;
+    dispatch(
+        ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op),
+        GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32,
+        1);
 
-    ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
+    if (mma_tokens < n_seq_tokens) {
+        ggml_metal_encoder_memory_barrier(enc);
 
-    ggml_metal_encoder_dispatch_threadgroups(
-        enc,
-        use_mma ? 1 : d_inner, n_head, n_seqs,
-        nth, 1, 1);
+        args.n_seq_tokens = n_seq_tokens - mma_tokens;
+        args.token_offset = mma_tokens;
+        args.state_from_dst = true;
+        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
+    }
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1756,7 +1756,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     constexpr int64_t CHUNK = OP_SSM_SCAN_SSD_CS;
 
-    const int64_t mma_tokens = n_seq_tokens / CHUNK * CHUNK;
+    const int64_t mma_tokens = (n_seq_tokens / CHUNK) * CHUNK; // largest multiple of CHUNK <= n_seq_tokens
     const bool use_mma =
         mma_tokens > 0 &&
         ne30 == 1 &&

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1677,6 +1677,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     ggml_metal_library_t lib = ctx->lib;
     ggml_metal_encoder_t enc = ctx->enc;
+    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
 
     GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
     GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
@@ -1751,9 +1752,25 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.nb0          =*/ nb0,
     };
 
-    auto pipeline = ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+    // use the chunked SSD kernel for large multi-token prefill, sequential kernel otherwise
+    // ne30 != 1 means per-channel A (Mamba-1), which the SSD kernel does not support
+    constexpr int64_t CHUNK = 64;
 
-    GGML_ASSERT(d_state <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+    const bool use_ssd = ne30 == 1 && n_seq_tokens >= CHUNK;
+    const bool use_mma = use_ssd &&
+        props_dev->has_simdgroup_mm &&
+        d_state      % 8     == 0 &&
+        d_inner              == 64 &&
+        n_seq_tokens % CHUNK == 0;
+
+    auto pipeline = use_mma ?
+        ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op) :
+        use_ssd ?
+            ggml_metal_library_get_pipeline_ssm_scan_ssd(lib, op) :
+            ggml_metal_library_get_pipeline_ssm_scan(lib, op);
+
+    const int64_t nth = use_mma ? GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32 : d_state;
+    GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
 
     const size_t smem = pipeline.smem;
 
@@ -1770,7 +1787,10 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     ggml_metal_encoder_set_threadgroup_memory_size(enc, smem, 0);
 
-    ggml_metal_encoder_dispatch_threadgroups(enc, d_inner, n_head, n_seqs, d_state, 1, 1);
+    ggml_metal_encoder_dispatch_threadgroups(
+        enc,
+        use_mma ? 1 : d_inner, n_head, n_seqs,
+        nth, 1, 1);
 
     return 1;
 }

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1756,7 +1756,8 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
     constexpr int64_t CHUNK = OP_SSM_SCAN_SSD_CS;
 
-    const int64_t mma_tokens = (n_seq_tokens / CHUNK) * CHUNK; // largest multiple of CHUNK <= n_seq_tokens
+    const int64_t snap_reserve = K > 1 ? K : 0; // tokens reserved for sequential kernel rollback snapshots
+    const int64_t mma_tokens = ((n_seq_tokens - snap_reserve) / CHUNK) * CHUNK; // largest multiple of CHUNK that leaves snap_reserve for the tail
     const bool use_mma =
         mma_tokens > 0 &&
         ne30 == 1 && // checks that A tensor is set to scalar decay per head (A shape {1, n_head})

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1727,7 +1727,6 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.token_offset =*/ 0,
         /*.n_seqs       =*/ n_seqs,
         /*.K            =*/ K,
-        /*.state_from_dst =*/ false,
         /*.s_off        =*/ ggml_nelements(op->src[1]) * sizeof(float),
         /*.nb00         =*/ nb00,
         /*.nb01         =*/ nb01,
@@ -1755,7 +1754,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         /*.nb0          =*/ nb0,
     };
 
-    constexpr int64_t CHUNK = GGML_METAL_SSM_SCAN_SSD_CS;
+    constexpr int64_t CHUNK = OP_SSM_SCAN_SSD_CS;
 
     const int64_t mma_tokens = n_seq_tokens / CHUNK * CHUNK;
     const bool use_mma =
@@ -1790,7 +1789,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
     args.n_seq_tokens = mma_tokens;
     dispatch(
         ggml_metal_library_get_pipeline_ssm_scan_ssd_mma(lib, op),
-        GGML_METAL_SSM_SCAN_SSD_MMA_NSG*32,
+        OP_SSM_SCAN_SSD_NSG*32,
         1);
 
     if (mma_tokens < n_seq_tokens) {
@@ -1798,7 +1797,6 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
         args.n_seq_tokens = n_seq_tokens - mma_tokens;
         args.token_offset = mma_tokens;
-        args.state_from_dst = true;
         dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
     }
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1783,7 +1783,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
     };
 
     if (!use_mma) {
-        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
+        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op, false), d_state, d_inner);
         return 1;
     }
 
@@ -1798,7 +1798,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
 
         args.n_seq_tokens = n_seq_tokens - mma_tokens;
         args.token_offset = mma_tokens;
-        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op), d_state, d_inner);
+        dispatch(ggml_metal_library_get_pipeline_ssm_scan(lib, op, true), d_state, d_inner);
     }
 
     return 1;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1794,7 +1794,7 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
         1);
 
     if (mma_tokens < n_seq_tokens) {
-        ggml_metal_encoder_memory_barrier(enc);
+        ggml_metal_op_concurrency_reset(ctx);
 
         args.n_seq_tokens = n_seq_tokens - mma_tokens;
         args.token_offset = mma_tokens;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -1759,10 +1759,10 @@ int ggml_metal_op_ssm_scan(ggml_metal_op_t ctx, int idx) {
     const int64_t mma_tokens = (n_seq_tokens / CHUNK) * CHUNK; // largest multiple of CHUNK <= n_seq_tokens
     const bool use_mma =
         mma_tokens > 0 &&
-        ne30 == 1 &&
-        props_dev->has_simdgroup_mm &&
-        d_state % 8 == 0 &&
-        d_inner == 64;
+        ne30 == 1 && // checks that A tensor is set to scalar decay per head (A shape {1, n_head})
+        props_dev->has_simdgroup_mm && // hardware check for M1 or newer
+        d_state % 8 == 0 && // d_state must be multiple of 8 to align with simdgroup_float 8x8 tiles
+        d_inner == 64; // mma kernel hardcodes HD=64 to follow Mamba-2 head dim standard; this checks it
 
     const auto dispatch = [&](ggml_metal_pipeline_with_params pipeline, int64_t nth, int64_t n_tg_x) {
         GGML_ASSERT(nth <= ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2462,6 +2462,348 @@ kernel void kernel_ssm_scan_f32(
     s_buff[i] = s;
 }
 
+// dispatch target for n_seq_tokens >= CHUNK, selected in ggml_metal_op_ssm_scan.
+//
+// Implements the chunked SSD (structured state-space duality) reformulation of the Mamba-2
+// recurrence, SPEC.md §6 / §8.1 ("v1", correctness-first, scalar, single-dispatch):
+//
+//   a[t]      = dt[t]*A                                  (dt after softplus; A < 0, scalar/head)
+//   acs[t]    = cumsum_{tau<=t within chunk} a[tau]       (segsum cumsum, reset to 0 each chunk)
+//   Lmat[i,j] = exp(acs[i] - acs[j])  for j <= i           (segsum decay, computed on the fly,
+//                                                            never materialized as a {CS,CS} tile)
+//   y_diag[i] = sum_{j<=i} Lmat[i,j] * (C[i]*B[j]) * (dt[j]*x[j])     (intra-chunk)
+//   S_c       = sum_j exp(acs[last]-acs[j]) * dt[j]*B[j]*x[j]         (this chunk's state contrib)
+//   y[i]      = y_diag[i] + exp(acs[i]) * (C[i] * S_prev)             (inter-chunk correction)
+//   S_prev'   = exp(acs[last]) * S_prev + S_c                        (sequential state passing)
+//
+// Threadgroup/thread layout is unchanged from kernel_ssm_scan_f32 (one threadgroup per
+// (channel, head, seq), d_state threads per threadgroup) -- no host-side dispatch changes needed
+// beyond pipeline selection. Each thread owns one d_state index (i0) of the state vector and
+// caches its own B/C column for the chunk in registers; dt/x (per head/token, not per d_state)
+// are staged once per chunk in threadgroup memory to avoid n_head-fold redundant global loads.
+// n_group > 1 uses index arithmetic (g = head / (n_head/n_group)), same as the sequential kernel
+// -- no repeat/repeat_interleave op, so it is correct by construction for grouped models.
+kernel void kernel_ssm_scan_ssd_f32(
+        constant ggml_metal_kargs_ssm_scan & args,
+        device const void * src0,
+        device const void * src1,
+        device const void * src2,
+        device const void * src3,
+        device const void * src4,
+        device const void * src5,
+        device const void * src6,
+        device      float * dst,
+        threadgroup float * shared [[threadgroup(0)]],
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort3 tpitg[[thread_position_in_threadgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort  sgptg[[simdgroups_per_threadgroup]],
+        uint3    tgpg[[threadgroups_per_grid]]) {
+    constexpr short CS = GGML_METAL_SSM_SCAN_SSD_CS;
+
+    // Shared memory layout (sized by ggml_metal_library_get_pipeline_ssm_scan_ssd):
+    // [0..CS-1]:          shared_acs -- a[t] on write, converted in-place to cumsum acs[t]
+    // [CS..2*CS-1]:       shared_dtx -- dt_softplus[t] * x[t, channel] for this threadgroup's channel
+    // [2*CS..2*CS+sgptg-1]: shared_sums -- cross-simdgroup partial-sum scratch for one output token
+    threadgroup float * shared_acs  = shared;
+    threadgroup float * shared_dtx  = shared + CS;
+    threadgroup float * shared_sums = shared + 2*CS;
+
+    const int32_t i0 = tpitg.x; // this thread's d_state index
+    const int32_t i1 = tgpig.x; // current channel (head_dim index)
+    const int32_t ir = tgpig.y; // current head
+    const int32_t i3 = tgpig.z; // current seq
+
+    const int32_t nc  = args.d_state;
+    const int32_t nr  = args.d_inner;
+    const int32_t nh  = args.n_head;
+    const int32_t ng  = args.n_group;
+    const int32_t n_t = args.n_seq_tokens;
+
+    const int32_t s_off = args.s_off;
+
+    device const int32_t * ids = (device const int32_t *) src6;
+
+    device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
+    device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + s_off);
+
+    const int32_t i = i0 + i1*nc;
+    const int32_t g = ir / (nh / ng); // repeat_interleave
+
+    // running inter-chunk state for this (channel, d_state) pair; updated once per chunk
+    float S_prev = s0_buff[i];
+
+    device const float * A = (device const float *) ((device const char *) src3 + ir*args.nb31); // {ne30, nh}
+
+    const float A0 = A[i0%args.ne30];
+
+    device const float * x  = (device const float *)((device const char *) src1 + i1*args.nb10  + ir*args.nb11 + i3*args.nb13); // {dim, nh, nt, ns}
+    device const float * dt = (device const float *)((device const char *) src2 + ir*args.nb20  + i3*args.nb22);                // {nh, nt, ns}
+    device const float * B  = (device const float *)((device const char *) src4 +  g*args.nb41  + i3*args.nb43);                // {d_state, ng, nt, ns}
+    device const float * C  = (device const float *)((device const char *) src5 +  g*args.nb51  + i3*args.nb53);                // {d_state, ng, nt, ns}
+
+    device float * y = dst + (i1 + ir*(nr) + i3*(n_t*nh*nr)); // {dim, nh, nt, ns}
+
+    float B_local[CS];
+    float C_local[CS];
+
+    for (int32_t t0 = 0; t0 < n_t; t0 += CS) {
+        const int32_t len = min((int32_t) CS, n_t - t0);
+
+        // Phase A: stage per-token a[t] (-> cumsum) and dt_softplus[t]*x[t] in threadgroup memory.
+        // dt/x depend only on (head, token, channel), not on this thread's d_state index, so the
+        // work is striped across threads (each token computed by exactly one thread) instead of
+        // duplicated by all of them.
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (int32_t t = i0; t < len; t += nc) {
+            const float dt0  = dt[t * (int32_t) args.ns21];
+            const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
+
+            shared_acs[t] = dtsp * A0; // a[t], turned into a cumsum below
+            shared_dtx[t] = x[t * (int32_t) args.ns12] * dtsp;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (i0 == 0) {
+            float acc = 0.0f;
+            for (int32_t t = 0; t < len; ++t) {
+                acc += shared_acs[t];
+                shared_acs[t] = acc; // acs[t], monotonically non-increasing (A < 0, dt > 0)
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // Phase B: cache this thread's (channel, d_state) column of B/C for the whole chunk, so
+        // the intra-chunk double sum below only touches registers, not device memory.
+        for (int32_t t = 0; t < len; ++t) {
+            B_local[t] = B[i0];
+            C_local[t] = C[i0];
+
+            B += args.ns42;
+            C += args.ns52;
+        }
+
+        // Phase C: intra-chunk output (segsum decay applied via direct acs[i]-acs[j] differences,
+        // never via a ratio of exponentials -- always <= 0 since acs is non-increasing, so this
+        // is stable for arbitrarily long chunks) plus the inter-chunk correction from S_prev.
+        float S_c = 0.0f; // == the i == len-1 iteration's intra-chunk partial sum, saved below
+
+        for (int32_t i2 = 0; i2 < len; ++i2) {
+            const float acs_i = shared_acs[i2];
+
+            float partial = 0.0f;
+            for (int32_t j = 0; j <= i2; ++j) {
+                partial += exp(acs_i - shared_acs[j]) * B_local[j] * shared_dtx[j];
+            }
+
+            if (i2 == len - 1) {
+                S_c = partial;
+            }
+
+            const float combined = partial + exp(acs_i) * S_prev;
+            const float term     = combined * C_local[i2];
+
+            const float part = simd_sum(term);
+            if (tiisg == 0) {
+                shared_sums[sgitg] = part;
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            if (i0 == 0) {
+                float total = 0.0f;
+                for (int32_t k = 0; k < sgptg; ++k) {
+                    total += shared_sums[k];
+                }
+                y[0] = total;
+            }
+
+            y += nh*nr;
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        // Phase D: sequential state passing across chunks (SPEC.md §6): S' = exp(acs[last])*S + S_c
+        S_prev = exp(shared_acs[len - 1]) * S_prev + S_c;
+
+        x  += len * args.ns12;
+        dt += len * args.ns21;
+    }
+
+    s_buff[i] = S_prev;
+}
+
+// MMA fast path for the common Mamba-2 layout (head_dim=64). One threadgroup owns a complete
+// (head, sequence) pair so the channel-independent C*B^T matrix is computed once per chunk and
+// reused for all eight 8-channel output tiles.
+kernel void kernel_ssm_scan_ssd_mma_f32(
+        constant ggml_metal_kargs_ssm_scan & args,
+        device const void * src0,
+        device const void * src1,
+        device const void * src2,
+        device const void * src3,
+        device const void * src4,
+        device const void * src5,
+        device const void * src6,
+        device      float * dst,
+        threadgroup float * shared [[threadgroup(0)]],
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort  tiitg[[thread_index_in_threadgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]],
+        ushort  tiisg[[thread_index_in_simdgroup]]) {
+    constexpr short CS  = GGML_METAL_SSM_SCAN_SSD_CS;
+    constexpr short TC  = 8;
+    constexpr short HD  = 64;
+    constexpr short NSG = GGML_METAL_SSM_SCAN_SSD_MMA_NSG;
+
+    // acs/exp(acs)/state-decay vectors, dtX[CS][HD], four private SAM row tiles [8][CS],
+    // and two 8x8 scratch tiles per simdgroup. Total: 26.75 KiB.
+    threadgroup float * shared_acs         = shared;
+    threadgroup float * shared_exp_acs     = shared + CS;
+    threadgroup float * shared_state_decay = shared + 2*CS;
+    threadgroup float * shared_dtx         = shared + 3*CS;
+    threadgroup float * shared_sam         = shared + 3*CS + CS*HD;
+    threadgroup float * sam_rows    = shared_sam + sgitg*TC*CS;
+    threadgroup float * shared_tile = shared_sam + NSG*TC*CS;
+    threadgroup float * tile0       = shared_tile + sgitg*2*TC*TC;
+    threadgroup float * tile1       = tile0 + TC*TC;
+
+    const int32_t ir = tgpig.y;
+    const int32_t i3 = tgpig.z;
+
+    const int32_t nc  = args.d_state;
+    const int32_t nr  = args.d_inner;
+    const int32_t nh  = args.n_head;
+    const int32_t ng  = args.n_group;
+    const int32_t n_t = args.n_seq_tokens;
+    const int32_t g   = ir / (nh / ng);
+
+    device const int32_t * ids = (device const int32_t *) src6;
+
+    device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
+    device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + args.s_off);
+
+    device const float * A  = (device const float *) ((device const char *) src3 + ir*args.nb31);
+    device const float * x  = (device const float *) ((device const char *) src1 + ir*args.nb11 + i3*args.nb13);
+    device const float * dt = (device const float *) ((device const char *) src2 + ir*args.nb20 + i3*args.nb22);
+    device const float * B  = (device const float *) ((device const char *) src4 +  g*args.nb41 + i3*args.nb43);
+    device const float * C  = (device const float *) ((device const char *) src5 +  g*args.nb51 + i3*args.nb53);
+
+    device float * y = dst + (ir*nr + i3*(n_t*nh*nr));
+
+    for (int32_t t0 = 0; t0 < n_t; t0 += CS) {
+        for (int32_t idx = tiitg; idx < CS*HD; idx += NSG*N_SIMDWIDTH) {
+            const int32_t t = idx / HD;
+            const int32_t c = idx % HD;
+            const float dt0  = dt[(t0 + t) * (int32_t) args.ns21];
+            const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
+            shared_dtx[idx] = x[(t0 + t) * (int32_t) args.ns12 + c] * dtsp;
+        }
+        if (tiitg < CS) {
+            const float dt0  = dt[(t0 + tiitg) * (int32_t) args.ns21];
+            const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
+            shared_acs[tiitg] = dtsp * A[0];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiitg == 0) {
+            float acc = 0.0f;
+            for (short t = 0; t < CS; ++t) {
+                acc += shared_acs[t];
+                shared_acs[t] = acc;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tiitg < CS) {
+            shared_exp_acs[tiitg] = exp(shared_acs[tiitg]);
+            shared_state_decay[tiitg] = exp(shared_acs[CS - 1] - shared_acs[tiitg]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        device const float * state = t0 == 0 ? s0_buff : s_buff;
+
+        // Build one 8x64 row tile of SAM per simdgroup, then reuse it across every channel tile.
+        for (short ib = sgitg; ib < CS/TC; ib += NSG) {
+            for (short jb = 0; jb < CS/TC; ++jb) {
+                simdgroup_float8x8 cb = make_filled_simdgroup_matrix<float, 8>(0.0f);
+
+                for (int32_t k0 = 0; k0 < nc; k0 += TC) {
+                    simdgroup_float8x8 mc;
+                    simdgroup_float8x8 mb;
+                    simdgroup_load(mc, C + (t0 + ib*TC)*(int32_t) args.ns52 + k0, args.ns52);
+                    simdgroup_load(mb, B + (t0 + jb*TC)*(int32_t) args.ns42 + k0, args.ns42, 0, true);
+                    simdgroup_multiply_accumulate(cb, mc, mb, cb);
+                }
+
+                threadgroup float * sam = sam_rows + jb*TC;
+                simdgroup_store(cb, sam, CS);
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+                for (short e = tiisg; e < TC*TC; e += N_SIMDWIDTH) {
+                    const short ri = e / TC;
+                    const short rj = e % TC;
+                    const short i  = ib*TC + ri;
+                    const short j  = jb*TC + rj;
+                    sam[ri*CS + rj] = j <= i ?
+                        sam[ri*CS + rj] * exp(shared_acs[i] - shared_acs[j]) : 0.0f;
+                }
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+            }
+
+            for (short cb = 0; cb < HD/TC; ++cb) {
+                simdgroup_float8x8 y_diag  = make_filled_simdgroup_matrix<float, 8>(0.0f);
+                simdgroup_float8x8 y_inter = make_filled_simdgroup_matrix<float, 8>(0.0f);
+
+                for (short jb = 0; jb < CS/TC; ++jb) {
+                    simdgroup_float8x8 sam;
+                    simdgroup_float8x8 mdtx;
+                    simdgroup_load(sam,  sam_rows + jb*TC,                   CS);
+                    simdgroup_load(mdtx, shared_dtx + jb*TC*HD + cb*TC,     HD);
+                    simdgroup_multiply_accumulate(y_diag, sam, mdtx, y_diag);
+                }
+
+                for (int32_t k0 = 0; k0 < nc; k0 += TC) {
+                    simdgroup_float8x8 mc;
+                    simdgroup_float8x8 ms;
+                    simdgroup_load(mc, C + (t0 + ib*TC)*(int32_t) args.ns52 + k0, args.ns52);
+                    simdgroup_load(ms, state + cb*TC*nc + k0, nc, 0, true);
+                    simdgroup_multiply_accumulate(y_inter, mc, ms, y_inter);
+                }
+
+                simdgroup_store(y_diag,  tile0, TC);
+                simdgroup_store(y_inter, tile1, TC);
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+                for (short e = tiisg; e < TC*TC; e += N_SIMDWIDTH) {
+                    const short ri = e / TC;
+                    const short ci = e % TC;
+                    const int32_t token = t0 + ib*TC + ri;
+                    y[token*nh*nr + cb*TC + ci] =
+                        tile0[e] + shared_exp_acs[ib*TC + ri] * tile1[e];
+                }
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+            }
+        }
+
+        // Keep the carried-state reduction in token order. Reassociating this particular product
+        // with MMA compounds rounding differences at every chunk boundary; CB, y_diag, and C*S
+        // remain on the matrix unit.
+        const float chunk_decay = exp(shared_acs[CS - 1]);
+        for (int32_t idx = tiitg; idx < nc*HD; idx += NSG*N_SIMDWIDTH) {
+            const int32_t ci = idx / nc;
+            const int32_t si = idx % nc;
+            float state_c = 0.0f;
+            for (short t = 0; t < CS; ++t) {
+                state_c += shared_state_decay[t] *
+                    B[(t0 + t)*(int32_t) args.ns42 + si] *
+                    shared_dtx[t*HD + ci];
+            }
+            s_buff[idx] = chunk_decay * state[idx] + state_c;
+        }
+
+        // All state tiles must be visible before the next chunk consumes s_buff as S_prev.
+        threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+    }
+}
+
 kernel void kernel_rwkv_wkv6_f32(
     device const float * k,
     device const float * v,

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2390,7 +2390,7 @@ kernel void kernel_ssm_scan_f32(
     device const int32_t * ids = (device const int32_t *) src6;
 
     device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + s_off);
-    device const float * s0_buff = args.state_from_dst ?
+    device const float * s0_buff = t_off != 0 ?
         s_buff :
         (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
 
@@ -2484,10 +2484,10 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
         ushort  tiitg[[thread_index_in_threadgroup]],
         ushort  sgitg[[simdgroup_index_in_threadgroup]],
         ushort  tiisg[[thread_index_in_simdgroup]]) {
-    constexpr short CS  = GGML_METAL_SSM_SCAN_SSD_CS;
+    constexpr short CS  = OP_SSM_SCAN_SSD_CS;
     constexpr short TC  = 8;
     constexpr short HD  = 64;
-    constexpr short NSG = GGML_METAL_SSM_SCAN_SSD_MMA_NSG;
+    constexpr short NSG = OP_SSM_SCAN_SSD_NSG;
 
     // acs/exp(acs)/state-decay vectors, dtX[CS][HD], four private SAM row tiles [8][CS],
     // and two 8x8 scratch tiles per simdgroup. Total: 26.75 KiB.

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2382,13 +2382,17 @@ kernel void kernel_ssm_scan_f32(
     const int32_t nh  = args.n_head;
     const int32_t ng  = args.n_group;
     const int32_t n_t = args.n_seq_tokens;
+    const int32_t n_t_total = args.n_seq_tokens_total;
+    const int32_t t_off = args.token_offset;
 
     const int32_t s_off = args.s_off;
 
     device const int32_t * ids = (device const int32_t *) src6;
 
-    device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
     device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + s_off);
+    device const float * s0_buff = args.state_from_dst ?
+        s_buff :
+        (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
 
     const int32_t i = i0 + i1*nc;
     const int32_t g = ir / (nh / ng); // repeat_interleave
@@ -2400,12 +2404,12 @@ kernel void kernel_ssm_scan_f32(
 
     const float A0 = A[i0%args.ne30];
 
-    device const float * x  = (device const float *)((device const char *) src1 + i1*args.nb10  + ir*args.nb11 + i3*args.nb13); // {dim, nh, nt, ns}
-    device const float * dt = (device const float *)((device const char *) src2 + ir*args.nb20  + i3*args.nb22);                // {nh, nt, ns}
-    device const float * B  = (device const float *)((device const char *) src4 +  g*args.nb41  + i3*args.nb43);                // {d_state, ng, nt, ns}
-    device const float * C  = (device const float *)((device const char *) src5 +  g*args.nb51  + i3*args.nb53);                // {d_state, ng, nt, ns}
+    device const float * x  = (device const float *)((device const char *) src1 + i1*args.nb10 + ir*args.nb11 + t_off*args.nb12 + i3*args.nb13); // {dim, nh, nt, ns}
+    device const float * dt = (device const float *)((device const char *) src2 + ir*args.nb20 + t_off*args.nb21 + i3*args.nb22);                 // {nh, nt, ns}
+    device const float * B  = (device const float *)((device const char *) src4 + g*args.nb41 + t_off*args.nb42 + i3*args.nb43);                  // {d_state, ng, nt, ns}
+    device const float * C  = (device const float *)((device const char *) src5 + g*args.nb51 + t_off*args.nb52 + i3*args.nb53);                  // {d_state, ng, nt, ns}
 
-    device float * y = dst + (i1 + ir*(nr) + i3*(n_t*nh*nr)); // {dim, nh, nt, ns}
+    device float * y = dst + (i1 + ir*nr + t_off*nh*nr + i3*(n_t_total*nh*nr)); // {dim, nh, nt, ns}
 
     for (int i2 = 0; i2 < n_t; i2 += sgptg) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -2462,177 +2466,6 @@ kernel void kernel_ssm_scan_f32(
     s_buff[i] = s;
 }
 
-// dispatch target for n_seq_tokens >= CHUNK, selected in ggml_metal_op_ssm_scan.
-//
-// Implements the chunked SSD (structured state-space duality) reformulation of the Mamba-2
-// recurrence, SPEC.md §6 / §8.1 ("v1", correctness-first, scalar, single-dispatch):
-//
-//   a[t]      = dt[t]*A                                  (dt after softplus; A < 0, scalar/head)
-//   acs[t]    = cumsum_{tau<=t within chunk} a[tau]       (segsum cumsum, reset to 0 each chunk)
-//   Lmat[i,j] = exp(acs[i] - acs[j])  for j <= i           (segsum decay, computed on the fly,
-//                                                            never materialized as a {CS,CS} tile)
-//   y_diag[i] = sum_{j<=i} Lmat[i,j] * (C[i]*B[j]) * (dt[j]*x[j])     (intra-chunk)
-//   S_c       = sum_j exp(acs[last]-acs[j]) * dt[j]*B[j]*x[j]         (this chunk's state contrib)
-//   y[i]      = y_diag[i] + exp(acs[i]) * (C[i] * S_prev)             (inter-chunk correction)
-//   S_prev'   = exp(acs[last]) * S_prev + S_c                        (sequential state passing)
-//
-// Threadgroup/thread layout is unchanged from kernel_ssm_scan_f32 (one threadgroup per
-// (channel, head, seq), d_state threads per threadgroup) -- no host-side dispatch changes needed
-// beyond pipeline selection. Each thread owns one d_state index (i0) of the state vector and
-// caches its own B/C column for the chunk in registers; dt/x (per head/token, not per d_state)
-// are staged once per chunk in threadgroup memory to avoid n_head-fold redundant global loads.
-// n_group > 1 uses index arithmetic (g = head / (n_head/n_group)), same as the sequential kernel
-// -- no repeat/repeat_interleave op, so it is correct by construction for grouped models.
-kernel void kernel_ssm_scan_ssd_f32(
-        constant ggml_metal_kargs_ssm_scan & args,
-        device const void * src0,
-        device const void * src1,
-        device const void * src2,
-        device const void * src3,
-        device const void * src4,
-        device const void * src5,
-        device const void * src6,
-        device      float * dst,
-        threadgroup float * shared [[threadgroup(0)]],
-        uint3   tgpig[[threadgroup_position_in_grid]],
-        ushort3 tpitg[[thread_position_in_threadgroup]],
-        ushort  sgitg[[simdgroup_index_in_threadgroup]],
-        ushort  tiisg[[thread_index_in_simdgroup]],
-        ushort  sgptg[[simdgroups_per_threadgroup]],
-        uint3    tgpg[[threadgroups_per_grid]]) {
-    constexpr short CS = GGML_METAL_SSM_SCAN_SSD_CS;
-
-    // Shared memory layout (sized by ggml_metal_library_get_pipeline_ssm_scan_ssd):
-    // [0..CS-1]:          shared_acs -- a[t] on write, converted in-place to cumsum acs[t]
-    // [CS..2*CS-1]:       shared_dtx -- dt_softplus[t] * x[t, channel] for this threadgroup's channel
-    // [2*CS..2*CS+sgptg-1]: shared_sums -- cross-simdgroup partial-sum scratch for one output token
-    threadgroup float * shared_acs  = shared;
-    threadgroup float * shared_dtx  = shared + CS;
-    threadgroup float * shared_sums = shared + 2*CS;
-
-    const int32_t i0 = tpitg.x; // this thread's d_state index
-    const int32_t i1 = tgpig.x; // current channel (head_dim index)
-    const int32_t ir = tgpig.y; // current head
-    const int32_t i3 = tgpig.z; // current seq
-
-    const int32_t nc  = args.d_state;
-    const int32_t nr  = args.d_inner;
-    const int32_t nh  = args.n_head;
-    const int32_t ng  = args.n_group;
-    const int32_t n_t = args.n_seq_tokens;
-
-    const int32_t s_off = args.s_off;
-
-    device const int32_t * ids = (device const int32_t *) src6;
-
-    device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
-    device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + s_off);
-
-    const int32_t i = i0 + i1*nc;
-    const int32_t g = ir / (nh / ng); // repeat_interleave
-
-    // running inter-chunk state for this (channel, d_state) pair; updated once per chunk
-    float S_prev = s0_buff[i];
-
-    device const float * A = (device const float *) ((device const char *) src3 + ir*args.nb31); // {ne30, nh}
-
-    const float A0 = A[i0%args.ne30];
-
-    device const float * x  = (device const float *)((device const char *) src1 + i1*args.nb10  + ir*args.nb11 + i3*args.nb13); // {dim, nh, nt, ns}
-    device const float * dt = (device const float *)((device const char *) src2 + ir*args.nb20  + i3*args.nb22);                // {nh, nt, ns}
-    device const float * B  = (device const float *)((device const char *) src4 +  g*args.nb41  + i3*args.nb43);                // {d_state, ng, nt, ns}
-    device const float * C  = (device const float *)((device const char *) src5 +  g*args.nb51  + i3*args.nb53);                // {d_state, ng, nt, ns}
-
-    device float * y = dst + (i1 + ir*(nr) + i3*(n_t*nh*nr)); // {dim, nh, nt, ns}
-
-    float B_local[CS];
-    float C_local[CS];
-
-    for (int32_t t0 = 0; t0 < n_t; t0 += CS) {
-        const int32_t len = min((int32_t) CS, n_t - t0);
-
-        // Phase A: stage per-token a[t] (-> cumsum) and dt_softplus[t]*x[t] in threadgroup memory.
-        // dt/x depend only on (head, token, channel), not on this thread's d_state index, so the
-        // work is striped across threads (each token computed by exactly one thread) instead of
-        // duplicated by all of them.
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        for (int32_t t = i0; t < len; t += nc) {
-            const float dt0  = dt[t * (int32_t) args.ns21];
-            const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
-
-            shared_acs[t] = dtsp * A0; // a[t], turned into a cumsum below
-            shared_dtx[t] = x[t * (int32_t) args.ns12] * dtsp;
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-        if (i0 == 0) {
-            float acc = 0.0f;
-            for (int32_t t = 0; t < len; ++t) {
-                acc += shared_acs[t];
-                shared_acs[t] = acc; // acs[t], monotonically non-increasing (A < 0, dt > 0)
-            }
-        }
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-
-        // Phase B: cache this thread's (channel, d_state) column of B/C for the whole chunk, so
-        // the intra-chunk double sum below only touches registers, not device memory.
-        for (int32_t t = 0; t < len; ++t) {
-            B_local[t] = B[i0];
-            C_local[t] = C[i0];
-
-            B += args.ns42;
-            C += args.ns52;
-        }
-
-        // Phase C: intra-chunk output (segsum decay applied via direct acs[i]-acs[j] differences,
-        // never via a ratio of exponentials -- always <= 0 since acs is non-increasing, so this
-        // is stable for arbitrarily long chunks) plus the inter-chunk correction from S_prev.
-        float S_c = 0.0f; // == the i == len-1 iteration's intra-chunk partial sum, saved below
-
-        for (int32_t i2 = 0; i2 < len; ++i2) {
-            const float acs_i = shared_acs[i2];
-
-            float partial = 0.0f;
-            for (int32_t j = 0; j <= i2; ++j) {
-                partial += exp(acs_i - shared_acs[j]) * B_local[j] * shared_dtx[j];
-            }
-
-            if (i2 == len - 1) {
-                S_c = partial;
-            }
-
-            const float combined = partial + exp(acs_i) * S_prev;
-            const float term     = combined * C_local[i2];
-
-            const float part = simd_sum(term);
-            if (tiisg == 0) {
-                shared_sums[sgitg] = part;
-            }
-
-            threadgroup_barrier(mem_flags::mem_threadgroup);
-
-            if (i0 == 0) {
-                float total = 0.0f;
-                for (int32_t k = 0; k < sgptg; ++k) {
-                    total += shared_sums[k];
-                }
-                y[0] = total;
-            }
-
-            y += nh*nr;
-
-            threadgroup_barrier(mem_flags::mem_threadgroup);
-        }
-
-        // Phase D: sequential state passing across chunks (SPEC.md §6): S' = exp(acs[last])*S + S_c
-        S_prev = exp(shared_acs[len - 1]) * S_prev + S_c;
-
-        x  += len * args.ns12;
-        dt += len * args.ns21;
-    }
-
-    s_buff[i] = S_prev;
-}
-
 // MMA fast path for the common Mamba-2 layout (head_dim=64). One threadgroup owns a complete
 // (head, sequence) pair so the channel-independent C*B^T matrix is computed once per chunk and
 // reused for all eight 8-channel output tiles.
@@ -2676,6 +2509,7 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
     const int32_t nh  = args.n_head;
     const int32_t ng  = args.n_group;
     const int32_t n_t = args.n_seq_tokens;
+    const int32_t n_t_total = args.n_seq_tokens_total;
     const int32_t g   = ir / (nh / ng);
 
     device const int32_t * ids = (device const int32_t *) src6;
@@ -2689,7 +2523,7 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
     device const float * B  = (device const float *) ((device const char *) src4 +  g*args.nb41 + i3*args.nb43);
     device const float * C  = (device const float *) ((device const char *) src5 +  g*args.nb51 + i3*args.nb53);
 
-    device float * y = dst + (ir*nr + i3*(n_t*nh*nr));
+    device float * y = dst + (ir*nr + i3*(n_t_total*nh*nr));
 
     for (int32_t t0 = 0; t0 < n_t; t0 += CS) {
         for (int32_t idx = tiitg; idx < CS*HD; idx += NSG*N_SIMDWIDTH) {

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2466,9 +2466,9 @@ kernel void kernel_ssm_scan_f32(
     s_buff[i] = s;
 }
 
-// MMA fast path for the common Mamba-2 layout (head_dim=64). One threadgroup owns a complete
-// (head, sequence) pair so the channel-independent C*B^T matrix is computed once per chunk and
-// reused for all eight 8-channel output tiles.
+// Chunked SSD SSM scan via Metal simdgroup MMatrix Multiply-Accumulate (simdgroup_float8x8) fast path. 
+// One threadgroup per (head, sequence) and tokens are processed in chunks.
+// C*B^T computed in each chunk one time and reused across the head_dim channel tiles.
 kernel void kernel_ssm_scan_ssd_mma_f32(
         constant ggml_metal_kargs_ssm_scan & args,
         device const void * src0,

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -2485,8 +2485,8 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
         ushort  sgitg[[simdgroup_index_in_threadgroup]],
         ushort  tiisg[[thread_index_in_simdgroup]]) {
     constexpr short CS  = OP_SSM_SCAN_SSD_CS;
-    constexpr short TC  = 8;
-    constexpr short HD  = 64;
+    constexpr short TC  = 8; // Tile Count of each edge in a simdgroup 8x8 tile
+    constexpr short HD  = 64; // Head Dim chosen for Mamba-2 
     constexpr short NSG = OP_SSM_SCAN_SSD_NSG;
 
     // acs/exp(acs)/state-decay vectors, dtX[CS][HD], four private SAM row tiles [8][CS],
@@ -2501,8 +2501,8 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
     threadgroup float * tile0       = shared_tile + sgitg*2*TC*TC;
     threadgroup float * tile1       = tile0 + TC*TC;
 
-    const int32_t ir = tgpig.y;
-    const int32_t i3 = tgpig.z;
+    const int32_t ir = tgpig.y; // current head
+    const int32_t i3 = tgpig.z; // current seq
 
     const int32_t nc  = args.d_state;
     const int32_t nr  = args.d_inner;

--- a/ggml/src/ggml-metal/kernels/ssm.metal
+++ b/ggml/src/ggml-metal/kernels/ssm.metal
@@ -157,6 +157,7 @@ kernel void kernel_ssm_conv_f32_f32_batched_4(
     x[0] = sumf;
 }
 
+constant bool FC_ssm_scan_tail [[function_constant(FC_SSM_SCAN + 0)]];
 // ref: ggml.c:ggml_compute_forward_ssm_scan_f32, Mamba-2 part
 // Optimized version: reduces redundant memory loads by having one thread load shared values
 kernel void kernel_ssm_scan_f32(
@@ -200,13 +201,17 @@ kernel void kernel_ssm_scan_f32(
     const int32_t n_t = args.n_seq_tokens;
     const int32_t n_s = args.n_seqs;
     const int32_t K   = args.K;
+    const int32_t n_t_total = args.n_seq_tokens_total;
+    const int32_t t_off = FC_ssm_scan_tail ? args.token_offset : 0;
 
     const int32_t s_off = args.s_off;
 
     device const int32_t * ids = (device const int32_t *) src6;
 
-    device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
     device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + s_off);
+    device const float * s0_buff = t_off != 0 ?
+        s_buff :
+        (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
 
     const int32_t i = i0 + i1*nc;
     const int32_t g = ir / (nh / ng); // repeat_interleave
@@ -218,12 +223,12 @@ kernel void kernel_ssm_scan_f32(
 
     const float A0 = A[i0%args.ne30];
 
-    device const float * x  = (device const float *)((device const char *) src1 + i1*args.nb10  + ir*args.nb11 + i3*args.nb13); // {dim, nh, nt, ns}
-    device const float * dt = (device const float *)((device const char *) src2 + ir*args.nb20  + i3*args.nb22);                // {nh, nt, ns}
-    device const float * B  = (device const float *)((device const char *) src4 +  g*args.nb41  + i3*args.nb43);                // {d_state, ng, nt, ns}
-    device const float * C  = (device const float *)((device const char *) src5 +  g*args.nb51  + i3*args.nb53);                // {d_state, ng, nt, ns}
+    device const float * x  = (device const float *)((device const char *) src1 + i1*args.nb10 + ir*args.nb11 + t_off*args.nb12 + i3*args.nb13); // {dim, nh, nt, ns}
+    device const float * dt = (device const float *)((device const char *) src2 + ir*args.nb20 + t_off*args.nb21 + i3*args.nb22);                 // {nh, nt, ns}
+    device const float * B  = (device const float *)((device const char *) src4 + g*args.nb41 + t_off*args.nb42 + i3*args.nb43);                  // {d_state, ng, nt, ns}
+    device const float * C  = (device const float *)((device const char *) src5 + g*args.nb51 + t_off*args.nb52 + i3*args.nb53);                  // {d_state, ng, nt, ns}
 
-    device float * y = dst + (i1 + ir*(nr) + i3*(n_t*nh*nr)); // {dim, nh, nt, ns}
+    device float * y = dst + (i1 + ir*nr + t_off*nh*nr + i3*(n_t_total*nh*nr)); // {dim, nh, nt, ns}
 
     for (int i2 = 0; i2 < n_t; i2 += sgptg) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -284,4 +289,179 @@ kernel void kernel_ssm_scan_f32(
     }
 
     s_buff[i] = s;
+}
+
+// Chunked SSD SSM scan via Metal simdgroup MMatrix Multiply-Accumulate (simdgroup_float8x8) fast path.
+// One threadgroup per (head, sequence) and tokens are processed in chunks.
+// C*B^T computed in each chunk one time and reused across the head_dim channel tiles.
+kernel void kernel_ssm_scan_ssd_mma_f32(
+        constant ggml_metal_kargs_ssm_scan & args,
+        device const void * src0,
+        device const void * src1,
+        device const void * src2,
+        device const void * src3,
+        device const void * src4,
+        device const void * src5,
+        device const void * src6,
+        device      float * dst,
+        threadgroup float * shared [[threadgroup(0)]],
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort  tiitg[[thread_index_in_threadgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]],
+        ushort  tiisg[[thread_index_in_simdgroup]]) {
+    constexpr short CS  = OP_SSM_SCAN_SSD_CS;
+    constexpr short TC  = 8; // Tile Count of each edge in a simdgroup 8x8 tile
+    constexpr short HD  = 64; // Head Dim chosen for Mamba-2
+    constexpr short NSG = OP_SSM_SCAN_SSD_NSG;
+
+    // acs/exp(acs)/state-decay vectors, dtX[CS][HD], four private SAM row tiles [8][CS],
+    // and two 8x8 scratch tiles per simdgroup. Total: 26.75 KiB.
+    threadgroup float * shared_acs         = shared;
+    threadgroup float * shared_exp_acs     = shared + CS;
+    threadgroup float * shared_state_decay = shared + 2*CS;
+    threadgroup float * shared_dtx         = shared + 3*CS;
+    threadgroup float * shared_sam         = shared + 3*CS + CS*HD;
+    threadgroup float * sam_rows    = shared_sam + sgitg*TC*CS;
+    threadgroup float * shared_tile = shared_sam + NSG*TC*CS;
+    threadgroup float * tile0       = shared_tile + sgitg*2*TC*TC;
+    threadgroup float * tile1       = tile0 + TC*TC;
+
+    const int32_t ir = tgpig.y; // current head
+    const int32_t i3 = tgpig.z; // current seq
+
+    const int32_t nc  = args.d_state;
+    const int32_t nr  = args.d_inner;
+    const int32_t nh  = args.n_head;
+    const int32_t ng  = args.n_group;
+    const int32_t n_t = args.n_seq_tokens;
+    const int32_t n_t_total = args.n_seq_tokens_total;
+    const int32_t g   = ir / (nh / ng);
+
+    device const int32_t * ids = (device const int32_t *) src6;
+
+    device const float * s0_buff = (device const float *) ((device const char *) src0 + ir*args.nb02 + ids[i3]*args.nb03);
+    device       float * s_buff  = (device       float *) ((device       char *) dst  + ir*args.nb02 +      i3*args.nb03 + args.s_off);
+
+    device const float * A  = (device const float *) ((device const char *) src3 + ir*args.nb31);
+    device const float * x  = (device const float *) ((device const char *) src1 + ir*args.nb11 + i3*args.nb13);
+    device const float * dt = (device const float *) ((device const char *) src2 + ir*args.nb20 + i3*args.nb22);
+    device const float * B  = (device const float *) ((device const char *) src4 +  g*args.nb41 + i3*args.nb43);
+    device const float * C  = (device const float *) ((device const char *) src5 +  g*args.nb51 + i3*args.nb53);
+
+    device float * y = dst + (ir*nr + i3*(n_t_total*nh*nr));
+
+    for (int32_t t0 = 0; t0 < n_t; t0 += CS) {
+        for (int32_t idx = tiitg; idx < CS*HD; idx += NSG*N_SIMDWIDTH) {
+            const int32_t t = idx / HD;
+            const int32_t c = idx % HD;
+            const float dt0  = dt[(t0 + t) * (int32_t) args.ns21];
+            const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
+            shared_dtx[idx] = x[(t0 + t) * (int32_t) args.ns12 + c] * dtsp;
+        }
+        if (tiitg < CS) {
+            const float dt0  = dt[(t0 + tiitg) * (int32_t) args.ns21];
+            const float dtsp = dt0 <= 20.0f ? log(1.0f + exp(dt0)) : dt0;
+            shared_acs[tiitg] = dtsp * A[0];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (tiitg == 0) {
+            float acc = 0.0f;
+            for (short t = 0; t < CS; ++t) {
+                acc += shared_acs[t];
+                shared_acs[t] = acc;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tiitg < CS) {
+            shared_exp_acs[tiitg] = exp(shared_acs[tiitg]);
+            shared_state_decay[tiitg] = exp(shared_acs[CS - 1] - shared_acs[tiitg]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        device const float * state = t0 == 0 ? s0_buff : s_buff;
+
+        // Build one 8x64 row tile of SAM per simdgroup, then reuse it across every channel tile.
+        for (short ib = sgitg; ib < CS/TC; ib += NSG) {
+            for (short jb = 0; jb <= ib; ++jb) {
+                simdgroup_float8x8 cb = make_filled_simdgroup_matrix<float, 8>(0.0f);
+
+                for (int32_t k0 = 0; k0 < nc; k0 += TC) {
+                    simdgroup_float8x8 mc;
+                    simdgroup_float8x8 mb;
+                    simdgroup_load(mc, C + (t0 + ib*TC)*(int32_t) args.ns52 + k0, args.ns52);
+                    simdgroup_load(mb, B + (t0 + jb*TC)*(int32_t) args.ns42 + k0, args.ns42, 0, true);
+                    simdgroup_multiply_accumulate(cb, mc, mb, cb);
+                }
+
+                threadgroup float * sam = sam_rows + jb*TC;
+                simdgroup_store(cb, sam, CS);
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+                for (short e = tiisg; e < TC*TC; e += N_SIMDWIDTH) {
+                    const short ri = e / TC;
+                    const short rj = e % TC;
+                    const short i  = ib*TC + ri;
+                    const short j  = jb*TC + rj;
+                    sam[ri*CS + rj] = j <= i ?
+                        sam[ri*CS + rj] * exp(shared_acs[i] - shared_acs[j]) : 0.0f;
+                }
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+            }
+
+            for (short cb = 0; cb < HD/TC; ++cb) {
+                simdgroup_float8x8 y_diag  = make_filled_simdgroup_matrix<float, 8>(0.0f);
+                simdgroup_float8x8 y_inter = make_filled_simdgroup_matrix<float, 8>(0.0f);
+
+                for (short jb = 0; jb <= ib; ++jb) {
+                    simdgroup_float8x8 sam;
+                    simdgroup_float8x8 mdtx;
+                    simdgroup_load(sam,  sam_rows + jb*TC,                   CS);
+                    simdgroup_load(mdtx, shared_dtx + jb*TC*HD + cb*TC,     HD);
+                    simdgroup_multiply_accumulate(y_diag, sam, mdtx, y_diag);
+                }
+
+                for (int32_t k0 = 0; k0 < nc; k0 += TC) {
+                    simdgroup_float8x8 mc;
+                    simdgroup_float8x8 ms;
+                    simdgroup_load(mc, C + (t0 + ib*TC)*(int32_t) args.ns52 + k0, args.ns52);
+                    simdgroup_load(ms, state + cb*TC*nc + k0, nc, 0, true);
+                    simdgroup_multiply_accumulate(y_inter, mc, ms, y_inter);
+                }
+
+                simdgroup_store(y_diag,  tile0, TC);
+                simdgroup_store(y_inter, tile1, TC);
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+                for (short e = tiisg; e < TC*TC; e += N_SIMDWIDTH) {
+                    const short ri = e / TC;
+                    const short ci = e % TC;
+                    const int32_t token = t0 + ib*TC + ri;
+                    y[token*nh*nr + cb*TC + ci] =
+                        tile0[e] + shared_exp_acs[ib*TC + ri] * tile1[e];
+                }
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+            }
+        }
+
+        // All simdgroups must finish reading s_buff before any thread overwrites it.
+        threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+
+        // Keep the carried-state reduction in token order. Reassociating this particular product
+        // with MMA compounds rounding differences at every chunk boundary; CB, y_diag, and C*S
+        // remain on the matrix unit.
+        const float chunk_decay = exp(shared_acs[CS - 1]);
+        for (int32_t idx = tiitg; idx < nc*HD; idx += NSG*N_SIMDWIDTH) {
+            const int32_t ci = idx / nc;
+            const int32_t si = idx % nc;
+            float state_c = 0.0f;
+            for (short t = 0; t < CS; ++t) {
+                state_c += shared_state_decay[t] *
+                    B[(t0 + t)*(int32_t) args.ns42 + si] *
+                    shared_dtx[t*HD + ci];
+            }
+            s_buff[idx] = chunk_decay * state[idx] + state_c;
+        }
+
+        // All state tiles must be visible before the next chunk consumes s_buff as S_prev.
+        threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+    }
 }

--- a/ggml/src/ggml-metal/kernels/ssm.metal
+++ b/ggml/src/ggml-metal/kernels/ssm.metal
@@ -157,10 +157,11 @@ kernel void kernel_ssm_conv_f32_f32_batched_4(
     x[0] = sumf;
 }
 
-constant bool FC_ssm_scan_tail [[function_constant(FC_SSM_SCAN + 0)]];
 // ref: ggml.c:ggml_compute_forward_ssm_scan_f32, Mamba-2 part
 // Optimized version: reduces redundant memory loads by having one thread load shared values
-kernel void kernel_ssm_scan_f32(
+// TAIL == false is the whole-sequence / decode path: token_offset folds away at compile time.
+template<bool TAIL>
+kernel void kernel_ssm_scan_impl(
         constant ggml_metal_kargs_ssm_scan & args,
         device const void * src0,
         device const void * src1,
@@ -201,8 +202,8 @@ kernel void kernel_ssm_scan_f32(
     const int32_t n_t = args.n_seq_tokens;
     const int32_t n_s = args.n_seqs;
     const int32_t K   = args.K;
-    const int32_t n_t_total = args.n_seq_tokens_total;
-    const int32_t t_off = FC_ssm_scan_tail ? args.token_offset : 0;
+    const int32_t n_t_total = TAIL ? args.n_seq_tokens_total : n_t;
+    const int32_t t_off     = TAIL ? args.token_offset       : 0;
 
     const int32_t s_off = args.s_off;
 
@@ -291,6 +292,11 @@ kernel void kernel_ssm_scan_f32(
     s_buff[i] = s;
 }
 
+typedef decltype(kernel_ssm_scan_impl<false>) kernel_ssm_scan_t;
+
+template [[host_name("kernel_ssm_scan_f32")]]      kernel kernel_ssm_scan_t kernel_ssm_scan_impl<false>;
+template [[host_name("kernel_ssm_scan_f32_tail")]] kernel kernel_ssm_scan_t kernel_ssm_scan_impl<true>;
+
 // Chunked SSD SSM scan via Metal simdgroup MMatrix Multiply-Accumulate (simdgroup_float8x8) fast path.
 // One threadgroup per (head, sequence) and tokens are processed in chunks.
 // C*B^T computed in each chunk one time and reused across the head_dim channel tiles.
@@ -311,7 +317,7 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
         ushort  tiisg[[thread_index_in_simdgroup]]) {
     constexpr short CS  = OP_SSM_SCAN_SSD_CS;
     constexpr short TC  = 8; // Tile Count of each edge in a simdgroup 8x8 tile
-    constexpr short HD  = 64; // Head Dim chosen for Mamba-2
+    constexpr short HD  = OP_SSM_SCAN_SSD_HD;
     constexpr short NSG = OP_SSM_SCAN_SSD_NSG;
 
     // acs/exp(acs)/state-decay vectors, dtX[CS][HD], four private SAM row tiles [8][CS],
@@ -408,7 +414,7 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
                 simdgroup_barrier(mem_flags::mem_threadgroup);
             }
 
-            for (short cb = 0; cb < HD/TC; ++cb) {
+            for (short ch = 0; ch < HD/TC; ++ch) {
                 simdgroup_float8x8 y_diag  = make_filled_simdgroup_matrix<float, 8>(0.0f);
                 simdgroup_float8x8 y_inter = make_filled_simdgroup_matrix<float, 8>(0.0f);
 
@@ -416,7 +422,7 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
                     simdgroup_float8x8 sam;
                     simdgroup_float8x8 mdtx;
                     simdgroup_load(sam,  sam_rows + jb*TC,                   CS);
-                    simdgroup_load(mdtx, shared_dtx + jb*TC*HD + cb*TC,     HD);
+                    simdgroup_load(mdtx, shared_dtx + jb*TC*HD + ch*TC,     HD);
                     simdgroup_multiply_accumulate(y_diag, sam, mdtx, y_diag);
                 }
 
@@ -424,7 +430,7 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
                     simdgroup_float8x8 mc;
                     simdgroup_float8x8 ms;
                     simdgroup_load(mc, C + (t0 + ib*TC)*(int32_t) args.ns52 + k0, args.ns52);
-                    simdgroup_load(ms, state + cb*TC*nc + k0, nc, 0, true);
+                    simdgroup_load(ms, state + ch*TC*nc + k0, nc, 0, true);
                     simdgroup_multiply_accumulate(y_inter, mc, ms, y_inter);
                 }
 
@@ -435,7 +441,7 @@ kernel void kernel_ssm_scan_ssd_mma_f32(
                     const short ri = e / TC;
                     const short ci = e % TC;
                     const int32_t token = t0 + ib*TC + ri;
-                    y[token*nh*nr + cb*TC + ci] =
+                    y[token*nh*nr + ch*TC + ci] =
                         tile0[e] + shared_exp_acs[ib*TC + ri] * tile1[e];
                 }
                 simdgroup_barrier(mem_flags::mem_threadgroup);

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10047,8 +10047,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_ssm_conv(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1})); // generate
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {515, 3328, 1, 1}, {4, 3328, 1, 1}, true));  // prefill
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1}, true));  // generate
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512,  1)); // prefill
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,    1)); // generate
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512, 1)); // prefill
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,   1)); // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B prefill
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 1,   1)); // Nemotron-9B generate
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8798,7 +8798,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 256, 1)); // Nemotron-9B SSD path
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B SSD multi-chunk (2 aligned chunks)
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 80, 8, 300, 2)); // Mamba-2 SSD multi-chunk (partial 2nd chunk, 2 seqs)
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 64, 4)); // Metal SSD one chunk MMA only, no seq tail
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 64, 4)); // Metal SSD one chunk MMA only, no tail; above test case hits multichunk + tail
 
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4017,10 +4017,19 @@ struct test_ssm_scan : public test_case {
         return (head_dim > 1) ? 2e-7 : 1e-7;
     }
 
+    double max_nmse_err(ggml_backend_t backend) override {
+        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(ggml_backend_get_device(backend));
+        if (n_seq_tokens >= 64 && strcmp(ggml_backend_reg_name(reg), "Metal") == 0) {
+            return 5e-4; // simdgroup MMA reassociation drift over long prompts
+        }
+        return max_nmse_err();
+    }
+
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * s   = ggml_new_tensor_4d(ctx, type, d_state,  head_dim,     n_head,       n_seqs);
         ggml_tensor * dt  = ggml_new_tensor_3d(ctx, type, n_head,   n_seq_tokens, n_seqs);
         ggml_tensor * A   = ggml_new_tensor_2d(ctx, type, (head_dim > 1) ? 1 : d_state, n_head);
+        ggml_set_name(A, "A");
         ggml_tensor * x;
         ggml_tensor * B;
         ggml_tensor * C;
@@ -8799,6 +8808,17 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B SSD multi-chunk (2 aligned chunks)
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 80, 8, 300, 2)); // Mamba-2 SSD multi-chunk (partial 2nd chunk, 2 seqs)
 
+    // sweep n_seq_tokens across the SSD dispatch threshold (64) and n_group across 1/2/8
+    // (repeat_interleave group indexing)
+    for (int64_t n_seq_tokens : {64, 128, 512, 2048}) {
+        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, n_seq_tokens, 4)); // Granite-style, n_group=1
+        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 2, n_seq_tokens, 4)); // n_group=2
+        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, n_seq_tokens, 4)); // Nemotron-style, n_group=8
+    }
+    // non-multiple tails must stay on the masked scalar SSD fallback
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1,  65, 2));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, 100, 2));
+
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 4));
@@ -10046,8 +10066,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_ssm_conv(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1})); // generate
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {515, 3328, 1, 1}, {4, 3328, 1, 1}, true));  // prefill
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1}, true));  // generate
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512, 1)); // prefill
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,   1)); // generate
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512,  1)); // prefill
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 2048, 1)); // prefill, above SSD threshold
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,    1)); // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B prefill
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 1,   1)); // Nemotron-9B generate
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4037,7 +4037,7 @@ struct test_ssm_scan : public test_case {
         if (xbc_overlap) {
             ggml_tensor * xbc = ggml_new_tensor_4d(ctx, type, d_state, n_head, n_seq_tokens, 2 * n_seqs);
             x = ggml_view_4d(ctx, xbc, head_dim, n_head, n_seq_tokens, n_seqs,
-                             xbc->nb[1], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
+                             head_dim * xbc->nb[0], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
             B = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
                              xbc->nb[1], xbc->nb[2], xbc->nb[3], 0);
             C = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
@@ -8808,16 +8808,15 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B SSD multi-chunk (2 aligned chunks)
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 80, 8, 300, 2)); // Mamba-2 SSD multi-chunk (partial 2nd chunk, 2 seqs)
 
-    // sweep n_seq_tokens across the SSD dispatch threshold (64) and n_group across 1/2/8
-    // (repeat_interleave group indexing)
-    for (int64_t n_seq_tokens : {64, 128, 512, 2048}) {
-        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, n_seq_tokens, 4)); // Granite-style, n_group=1
-        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 2, n_seq_tokens, 4)); // n_group=2
-        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, n_seq_tokens, 4)); // Nemotron-style, n_group=8
+    // sequential-only, MMA-only, and MMA-prefix plus sequential-tail boundaries
+    for (int64_t n_seq_tokens : {63, 64, 65, 127, 128, 129}) {
+        for (int64_t n_group : {1, 2, 8}) {
+            test_cases.emplace_back(new test_ssm_scan(
+                GGML_TYPE_F32, 128, 64, 8, n_group, n_seq_tokens, 4));
+        }
     }
-    // non-multiple tails must stay on the masked scalar SSD fallback
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1,  65, 2));
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, 100, 2));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 2,  65, 2, true));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 8, 129, 2, true));
 
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4017,19 +4017,10 @@ struct test_ssm_scan : public test_case {
         return (head_dim > 1) ? 2e-7 : 1e-7;
     }
 
-    double max_nmse_err(ggml_backend_t backend) override {
-        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(ggml_backend_get_device(backend));
-        if (n_seq_tokens >= 64 && strcmp(ggml_backend_reg_name(reg), "Metal") == 0) {
-            return 5e-4; // simdgroup MMA reassociation drift over long prompts
-        }
-        return max_nmse_err();
-    }
-
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * s   = ggml_new_tensor_4d(ctx, type, d_state,  head_dim,     n_head,       n_seqs);
         ggml_tensor * dt  = ggml_new_tensor_3d(ctx, type, n_head,   n_seq_tokens, n_seqs);
         ggml_tensor * A   = ggml_new_tensor_2d(ctx, type, (head_dim > 1) ? 1 : d_state, n_head);
-        ggml_set_name(A, "A");
         ggml_tensor * x;
         ggml_tensor * B;
         ggml_tensor * C;
@@ -4037,7 +4028,7 @@ struct test_ssm_scan : public test_case {
         if (xbc_overlap) {
             ggml_tensor * xbc = ggml_new_tensor_4d(ctx, type, d_state, n_head, n_seq_tokens, 2 * n_seqs);
             x = ggml_view_4d(ctx, xbc, head_dim, n_head, n_seq_tokens, n_seqs,
-                             head_dim * xbc->nb[0], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
+                             xbc->nb[1], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
             B = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
                              xbc->nb[1], xbc->nb[2], xbc->nb[3], 0);
             C = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
@@ -8807,16 +8798,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 256, 1)); // Nemotron-9B SSD path
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B SSD multi-chunk (2 aligned chunks)
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 80, 8, 300, 2)); // Mamba-2 SSD multi-chunk (partial 2nd chunk, 2 seqs)
-
-    // sequential-only, MMA-only, and MMA-prefix plus sequential-tail boundaries
-    for (int64_t n_seq_tokens : {63, 64, 65, 127, 128, 129}) {
-        for (int64_t n_group : {1, 2, 8}) {
-            test_cases.emplace_back(new test_ssm_scan(
-                GGML_TYPE_F32, 128, 64, 8, n_group, n_seq_tokens, 4));
-        }
-    }
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 2,  65, 2, true));
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 8, 129, 2, true));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 64, 4)); // Metal SSD one chunk MMA only, no seq tail
 
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));
@@ -10066,7 +10048,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {515, 3328, 1, 1}, {4, 3328, 1, 1}, true));  // prefill
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1}, true));  // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512,  1)); // prefill
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 2048, 1)); // prefill, above SSD threshold
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,    1)); // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B prefill
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 1,   1)); // Nemotron-9B generate

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4141,19 +4141,10 @@ struct test_ssm_scan : public test_case {
         return (head_dim > 1) ? 2e-7 : 1e-7;
     }
 
-    double max_nmse_err(ggml_backend_t backend) override {
-        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(ggml_backend_get_device(backend));
-        if (n_seq_tokens >= 64 && strcmp(ggml_backend_reg_name(reg), "Metal") == 0) {
-            return 5e-4; // simdgroup MMA reassociation drift over long prompts
-        }
-        return max_nmse_err();
-    }
-
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * s   = ggml_new_tensor_4d(ctx, type, d_state,  head_dim,     n_head,       n_seqs);
         ggml_tensor * dt  = ggml_new_tensor_3d(ctx, type, n_head,   n_seq_tokens, n_seqs);
         ggml_tensor * A   = ggml_new_tensor_2d(ctx, type, (head_dim > 1) ? 1 : d_state, n_head);
-        ggml_set_name(A, "A");
         ggml_tensor * x;
         ggml_tensor * B;
         ggml_tensor * C;
@@ -4161,7 +4152,7 @@ struct test_ssm_scan : public test_case {
         if (xbc_overlap) {
             ggml_tensor * xbc = ggml_new_tensor_4d(ctx, type, d_state, n_head, n_seq_tokens, 2 * n_seqs);
             x = ggml_view_4d(ctx, xbc, head_dim, n_head, n_seq_tokens, n_seqs,
-                             head_dim * xbc->nb[0], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
+                             xbc->nb[1], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
             B = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
                              xbc->nb[1], xbc->nb[2], xbc->nb[3], 0);
             C = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
@@ -9120,16 +9111,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 4, 2, false, /*K=*/4)); // Mamba-2 rollback snapshots
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, false, /*K=*/3)); // Mamba-2 rollback overflow
     test_cases.emplace_back(new test_ssm_scan_rollback(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, /*K=*/3)); // rollback snapshots match prefix states
-
-    // sequential-only, MMA-only, and MMA-prefix plus sequential-tail boundaries
-    for (int64_t n_seq_tokens : {63, 64, 65, 127, 128, 129}) {
-        for (int64_t n_group : {1, 2, 8}) {
-            test_cases.emplace_back(new test_ssm_scan(
-                GGML_TYPE_F32, 128, 64, 8, n_group, n_seq_tokens, 4));
-        }
-    }
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 2,  65, 2, true));
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 8, 129, 2, true));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 64, 4)); // Metal SSD one chunk MMA only, no seq tail
 
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));
@@ -10483,7 +10465,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {515, 3328, 1, 1}, {4, 3328, 1, 1}, true));  // prefill
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1}, true));  // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512,  1)); // prefill
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 2048, 1)); // prefill, above SSD threshold
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,    1)); // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B prefill
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 1,   1)); // Nemotron-9B generate

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4120,9 +4120,10 @@ struct test_ssm_scan : public test_case {
     const int64_t n_seqs;
     const bool    xbc_overlap;
     const int64_t K;
+    const bool    weak_decay;
 
     std::string vars() override {
-        return VARS_TO_STR9(type, d_state, head_dim, n_head, n_group, n_seq_tokens, n_seqs, xbc_overlap, K);
+        return VARS_TO_STR10(type, d_state, head_dim, n_head, n_group, n_seq_tokens, n_seqs, xbc_overlap, K, weak_decay);
     }
 
     test_ssm_scan(ggml_type type = GGML_TYPE_F32,
@@ -4133,8 +4134,9 @@ struct test_ssm_scan : public test_case {
             int64_t n_seq_tokens = 32,
             int64_t n_seqs = 32,
             bool xbc_overlap = false,
-            int64_t K = 1)
-        : type(type), d_state(d_state), head_dim(head_dim), n_head(n_head), n_group(n_group), n_seq_tokens(n_seq_tokens), n_seqs(n_seqs), xbc_overlap(xbc_overlap), K(K) {}
+            int64_t K = 1,
+            bool weak_decay = false)
+        : type(type), d_state(d_state), head_dim(head_dim), n_head(n_head), n_group(n_group), n_seq_tokens(n_seq_tokens), n_seqs(n_seqs), xbc_overlap(xbc_overlap), K(K), weak_decay(weak_decay) {}
 
     double max_nmse_err() override {
         // SSD path (head_dim > 1) uses FP16 intermediates (M matrix, X_dt); Mamba-1 is pure FP32.
@@ -4187,7 +4189,7 @@ struct test_ssm_scan : public test_case {
                 continue;
             } else if (t->ne[1] == n_head && t->ne[2] == 1) {
                 // A {1 or d_state, n_head}: negative decay (2-D tensor, ne[2]==1 distinguishes from 3-D/4-D tensors)
-                init_tensor_uniform(t, -1.0f, -0.5f);
+                init_tensor_uniform(t, weak_decay ? -0.02f : -1.0f, weak_decay ? -0.005f : -0.5f);
             } else {
                 init_tensor_uniform(t);
             }
@@ -9112,6 +9114,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, false, /*K=*/3)); // Mamba-2 rollback overflow
     test_cases.emplace_back(new test_ssm_scan_rollback(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, /*K=*/3)); // rollback snapshots match prefix states
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 64, 4)); // Metal SSD one chunk MMA only, no seq tail
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 65, 2)); // SSD one chunk + 1-token sequential tail
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 128, 2)); // SSD multi-chunk, no tail (exercises the chunk-to-chunk state handoff)
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 128, 2, false, /*K=*/1, /*weak_decay=*/true)); // SSD multi-chunk, carried state not numerically negligible
 
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4161,7 +4161,7 @@ struct test_ssm_scan : public test_case {
         if (xbc_overlap) {
             ggml_tensor * xbc = ggml_new_tensor_4d(ctx, type, d_state, n_head, n_seq_tokens, 2 * n_seqs);
             x = ggml_view_4d(ctx, xbc, head_dim, n_head, n_seq_tokens, n_seqs,
-                             xbc->nb[1], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
+                             head_dim * xbc->nb[0], xbc->nb[2], xbc->nb[3], xbc->nb[3]);
             B = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
                              xbc->nb[1], xbc->nb[2], xbc->nb[3], 0);
             C = ggml_view_4d(ctx, xbc, d_state, n_group, n_seq_tokens, n_seqs,
@@ -9121,16 +9121,15 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, false, /*K=*/3)); // Mamba-2 rollback overflow
     test_cases.emplace_back(new test_ssm_scan_rollback(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, /*K=*/3)); // rollback snapshots match prefix states
 
-    // sweep n_seq_tokens across the SSD dispatch threshold (64) and n_group across 1/2/8
-    // (repeat_interleave group indexing)
-    for (int64_t n_seq_tokens : {64, 128, 512, 2048}) {
-        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, n_seq_tokens, 4)); // Granite-style, n_group=1
-        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 2, n_seq_tokens, 4)); // n_group=2
-        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, n_seq_tokens, 4)); // Nemotron-style, n_group=8
+    // sequential-only, MMA-only, and MMA-prefix plus sequential-tail boundaries
+    for (int64_t n_seq_tokens : {63, 64, 65, 127, 128, 129}) {
+        for (int64_t n_group : {1, 2, 8}) {
+            test_cases.emplace_back(new test_ssm_scan(
+                GGML_TYPE_F32, 128, 64, 8, n_group, n_seq_tokens, 4));
+        }
     }
-    // non-multiple tails must stay on the masked scalar SSD fallback
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1,  65, 2));
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, 100, 2));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 2,  65, 2, true));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 8, 8, 129, 2, true));
 
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10464,8 +10464,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_ssm_conv(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1})); // generate
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {515, 3328, 1, 1}, {4, 3328, 1, 1}, true));  // prefill
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1}, true));  // generate
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512,  1)); // prefill
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,    1)); // generate
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512, 1)); // prefill
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,   1)); // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B prefill
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 1,   1)); // Nemotron-9B generate
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4141,10 +4141,19 @@ struct test_ssm_scan : public test_case {
         return (head_dim > 1) ? 2e-7 : 1e-7;
     }
 
+    double max_nmse_err(ggml_backend_t backend) override {
+        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(ggml_backend_get_device(backend));
+        if (n_seq_tokens >= 64 && strcmp(ggml_backend_reg_name(reg), "Metal") == 0) {
+            return 5e-4; // simdgroup MMA reassociation drift over long prompts
+        }
+        return max_nmse_err();
+    }
+
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * s   = ggml_new_tensor_4d(ctx, type, d_state,  head_dim,     n_head,       n_seqs);
         ggml_tensor * dt  = ggml_new_tensor_3d(ctx, type, n_head,   n_seq_tokens, n_seqs);
         ggml_tensor * A   = ggml_new_tensor_2d(ctx, type, (head_dim > 1) ? 1 : d_state, n_head);
+        ggml_set_name(A, "A");
         ggml_tensor * x;
         ggml_tensor * B;
         ggml_tensor * C;
@@ -9112,6 +9121,17 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, false, /*K=*/3)); // Mamba-2 rollback overflow
     test_cases.emplace_back(new test_ssm_scan_rollback(GGML_TYPE_F32, 128, 64, 16, 2, 8, 2, /*K=*/3)); // rollback snapshots match prefix states
 
+    // sweep n_seq_tokens across the SSD dispatch threshold (64) and n_group across 1/2/8
+    // (repeat_interleave group indexing)
+    for (int64_t n_seq_tokens : {64, 128, 512, 2048}) {
+        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, n_seq_tokens, 4)); // Granite-style, n_group=1
+        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 2, n_seq_tokens, 4)); // n_group=2
+        test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, n_seq_tokens, 4)); // Nemotron-style, n_group=8
+    }
+    // non-multiple tails must stay on the masked scalar SSD fallback
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1,  65, 2));
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 8, 100, 2));
+
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 1, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 1));
     test_cases.emplace_back(new test_rwkv_wkv6(GGML_TYPE_F32, 32, 64, 32, 4));
@@ -10463,8 +10483,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_ssm_conv(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1})); // generate
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {515, 3328, 1, 1}, {4, 3328, 1, 1}, true));  // prefill
     test_cases.emplace_back(new test_ssm_conv_bias_silu(GGML_TYPE_F32, {4,   3328, 1, 1}, {4, 3328, 1, 1}, true));  // generate
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512, 1)); // prefill
-    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,   1)); // generate
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 512,  1)); // prefill
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 2048, 1)); // prefill, above SSD threshold
+    test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 64, 48, 1, 1,    1)); // generate
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 512, 1)); // Nemotron-9B prefill
     test_cases.emplace_back(new test_ssm_scan(GGML_TYPE_F32, 128, 80, 128, 1, 1,   1)); // Nemotron-9B generate
 


### PR DESCRIPTION
## Overview

Similar to [BLSharda's PR](https://github.com/ggml-org/llama.cpp/pull/22675), this PR adds a chunked SSD matmul path using Mamba-2 style prefill, but for Metal devices. For token sequences that fit 64 token chunks, parallel simdgroup matmuls are used in place of sequential, per-token scans. Any remaining tokens that do not fit in the 64 token chunks fallback to using sequential scan.

Performance gains are best at batched, larger prefills, see the benchmark results below:

| Prompt tokens | Parallel prompts | Baseline (t/s) | MMA (t/s) | Δ |
|---:|---:|---:|---:|---:|
| 1024 | 1 | 660.03 | 693.80 | +5.12% |
| 1024 | 4 | 1010.01 | 1058.19 | +4.77% |
| 1024 | 8 | 1087.13 | 1137.92 | +4.67% |
| 4096 | 1 | 1319.01 | 1445.44 | +9.59% |
| 4096 | 4 | 1613.06 | 1784.91 | +10.65% |
| 4096 | 8 | 1658.10 | 1826.80 | +10.17% |
| 8192 | 1 | 1609.57 | 1797.35 | +11.67% |
| 8192 | 4 | 1790.94 | 2005.24 | +11.97% |
| 8192 | 8 | 1819.37 | 2029.98 | +11.58% |

Ran on M4 Pro:
```bash
./build/bin/llama-batched-bench -m <granite-4.0-h-1b-Q8_0.gguf> -c 131072 -b 2048 -ub 2048 -npp 1024,4096,8192 -ntg 128 -npl 1,4,8 -ngl 99
```

I found no change in Perplexity:

| Metric | Baseline | SSD | Difference |
|---|---:|---:|---:|
| Final PPL | 9.1594 | 9.1593 | -0.0001 |
| PPL uncertainty | ±0.06642 | ±0.06642 | 0 |

```bash
./build/bin/llama-perplexity -m <granite-4.0-h-1b-Q8_0.gguf> -f <wikitext-2-raw> -ngl 99 -c 8192 -fa 1
```

## Additional information

Files changed:
* ggml/src/ggml-metal/ggml-metal-device.cpp and ggml/src/ggml-metal/ggml-metal-device.h : added new pipeline struct to use the new ssd kernel
* ggml/src/ggml-metal/ggml-metal-impl.h : added constants for new kernel op's Chunk Size and Number of Simdgroups; added token offset tracking args to kernel args struct
* ggml/src/ggml-metal/ggml-metal-ops.cpp : added gate to the new ssd path so gpus without simdgroup architecture remain on sequential scan; added dispatch for the new ssd path with sequential scan fallback and token offset tail for remaining tokens
* ggml/src/ggml-metal/ggml-metal.metal : added the new kernel and updated the existing sequential scan kernel to be used for leftover tokens via token offset tracking
* tests/test-backend-ops.cpp : added one test_ssm_scan test case for a single 64 token chunk with no tail.

Sources:
* [Mamba-2 White Paper](https://arxiv.org/abs/2405.21060)
* @gabe-l-hart original mamba 1 metal implementation and work on mamba 2 implementation [here](https://github.com/ggml-org/llama.cpp/pull/16982)
* the CUDA equivalent mentioned earlier [here](https://github.com/ggml-org/llama.cpp/pull/22675)


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, AI was used to help draft, refine and optimize the new kernel pipeline based on my initial designs I derived from the sources mentioned in Additional Information above.
