### PR TITLE
llama : fix dist sampler crash on degenerate logits

### DIFF
--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1071,6 +1071,13 @@ static void llama_sampler_dist_apply(struct llama_sampler * smpl, llama_token_da
         sum_cum += p;
     }
 
+    // degenerate logits (e.g. all -inf/NaN, seen with MTP draft heads on long contexts)
+    // - sample the last candidate instead of aborting
+    if (!std::isfinite(sum_cum) || sum_cum <= 0.0f) {
+        cur_p->selected = cur_p->size - 1;
+        return;
+    }
+
 #if 1
     // sample from the obtained probabilities and normalize the probs in a single pass
     // this is ~3x faster on Mac with full gpt-oss vocab than the version below
@@ -1096,8 +1103,7 @@ static void llama_sampler_dist_apply(struct llama_sampler * smpl, llama_token_da
         cur_p->data[i].p /= sum_cum;
     }
 
-    // fallback to the last token (don't think this can happen)
-    assert(found);
+    // fallback to the last token (can happen with degenerate logits)
     if (!found) {
         cur_p->selected = cur_p->size - 1;
     }

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1183,6 +1183,13 @@ static void llama_sampler_dist_apply(struct llama_sampler * smpl, llama_token_da
         sum_cum += p;
     }
 
+    // degenerate logits (e.g. all -inf/NaN, seen with MTP draft heads on long contexts)
+    // - sample the last candidate instead of aborting
+    if (!std::isfinite(sum_cum) || sum_cum <= 0.0f) {
+        cur_p->selected = cur_p->size - 1;
+        return;
+    }
+
 #if 1
     // sample from the obtained probabilities and normalize the probs in a single pass
     // this is ~3x faster on Mac with full gpt-oss vocab than the version below
@@ -1207,8 +1214,7 @@ static void llama_sampler_dist_apply(struct llama_sampler * smpl, llama_token_da
         cur_p->data[i].p /= sum_cum;
     }
 
-    // fallback to the last token (don't think this can happen)
-    assert(found);
+    // fallback to the last token (can happen with degenerate logits)
     if (!found) {
         cur_p->selected = cur_p->size - 1;
     }

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -136,6 +136,26 @@ static void test_typical(const std::vector<float> & probs, const std::vector<flo
     tester.check();
 }
 
+static void test_dist_degenerate() {
+    // degenerate distributions (all logits -inf or NaN) must fall back to the last
+    // candidate instead of aborting via assert(found), see llama_sampler_dist_apply
+    for (int mode = 0; mode < 2; mode++) {
+        std::vector<llama_token_data> data(4);
+        for (size_t i = 0; i < data.size(); i++) {
+            const float logit = mode == 0 ? -INFINITY : NAN;
+            data[i] = { (llama_token) i, logit, 0.0f };
+        }
+        llama_token_data_array cur_p = { data.data(), data.size(), -1, false };
+
+        llama_sampler * sampler = llama_sampler_init_dist(0);
+        llama_sampler_apply(sampler, &cur_p);
+        llama_sampler_free(sampler);
+
+        GGML_ASSERT(cur_p.selected == (llama_token) cur_p.size - 1);
+        printf("Degenerate dist distribution (%s) OK\n", mode == 0 ? "-inf" : "NaN");
+    }
+}
+
 static void test_penalties(
     const std::vector<float> & probs, const std::vector<llama_token> & last_tokens,
     const std::vector<float> & probs_expected, float repeat_penalty, float alpha_frequency, float alpha_presence
@@ -344,6 +364,8 @@ int main(void) {
 
     test_typical({0.97f, 0.01f, 0.01f, 0.01f}, {0.97f},            0.5f);
     test_typical({0.4f, 0.2f, 0.2f, 0.2f},     {0.2f, 0.2f, 0.2f}, 0.5f);
+
+    test_dist_degenerate();
 
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0}, {0, 0.25f, 0.25f, 0.25f, 0.25f},   50.0f, 0.0f, 0.0f);
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2}, {0, 0, 0, 0.5f, 0.5f},       50.0f, 0.0f, 0.0f);

--- a/tests/test-sampling.cpp
+++ b/tests/test-sampling.cpp
@@ -165,6 +165,26 @@ static void test_typical(const std::vector<float> & probs, const std::vector<flo
     tester.check();
 }
 
+static void test_dist_degenerate() {
+    // degenerate distributions (all logits -inf or NaN) must fall back to the last
+    // candidate instead of aborting via assert(found), see llama_sampler_dist_apply
+    for (int mode = 0; mode < 2; mode++) {
+        std::vector<llama_token_data> data(4);
+        for (size_t i = 0; i < data.size(); i++) {
+            const float logit = mode == 0 ? -INFINITY : NAN;
+            data[i] = { (llama_token) i, logit, 0.0f };
+        }
+        llama_token_data_array cur_p = { data.data(), data.size(), -1, false };
+
+        llama_sampler * sampler = llama_sampler_init_dist(0);
+        llama_sampler_apply(sampler, &cur_p);
+        llama_sampler_free(sampler);
+
+        GGML_ASSERT(cur_p.selected == (llama_token) cur_p.size - 1);
+        printf("Degenerate dist distribution (%s) OK\n", mode == 0 ? "-inf" : "NaN");
+    }
+}
+
 static void test_penalties(
     const std::vector<float> & probs, const std::vector<llama_token> & last_tokens,
     const std::vector<float> & probs_expected, float repeat_penalty, float alpha_frequency, float alpha_presence
@@ -375,6 +395,8 @@ int main(void) {
 
     test_typical({0.97f, 0.01f, 0.01f, 0.01f}, {0.97f},            0.5f);
     test_typical({0.4f, 0.2f, 0.2f, 0.2f},     {0.2f, 0.2f, 0.2f}, 0.5f);
+
+    test_dist_degenerate();
 
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0}, {0, 0.25f, 0.25f, 0.25f, 0.25f},   50.0f, 0.0f, 0.0f);
     test_penalties({0.2f, 0.2f, 0.2f, 0.2f, 0.2f}, {0, 1, 2}, {0, 0, 0, 0.5f, 0.5f},       50.0f, 0.0f, 0.0f);


### PR DESCRIPTION
Assisted-by: opencode (deepseek v4-flash 0731)

## Overview

llama-server crashed with **Assertion 'found' failed** in **llama_sampler_dist_apply** when using mtp speculative decoding _--spec-type draft-mtp_ on long contexts, 30k+ tokens in my cases. 
Reproduction environment: _ryzen 5700X + radeon rx6800xt ROCm HIP_ with _qwen3.6:35b-a3b q4_K_M_ with partial offloading to ram, arch Linux (up-to-date at the time of writing), _--batch-size 512 --ubatch-size 512_. Without MTP everything is stable.

Root cause is the dist sampler could not handle a degenerate distribution. When the MTP draft head produced only -inf logits, the softmax turned them into NaN, the token selection loop could not find a candidate, and assert(found) terminated the process with SIGABRT.

The crash occurred with the official Arch Linux package (llama-cpp build with CMAKE_BUILD_TYPE=None), which keeps asserts enabled. I build same flags for testing and working. The regression test covers was tested after all day working normaly,  arch official package still crashing if i downgrade. It fails before the fix (same Assertion 'found' failed, SIGABRT) and passes after. The crash only happens in builds with asserts enabled (CMAKE_BUILD_TYPE=None - the **official Arch package**  or Debug). With -DCMAKE_BUILD_TYPE=Release (NDEBUG) the assert is removed so there is no crash - the sampler silently picks the last candidate instead. 

## Additional information

Fixes: #26648 (my issue for this PR)
Related: #22136 (looks similar but closed, i have my issue not sure its same)
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, opencode with deepseek help to debug and fix in code, and describe how it works. I has reviewed manually, and test manually. All i wrote here is verified by me, not neuroslope <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
