### PR TITLE
llama : wire up ggml_backend_register_host_buffer for mmap'd weights

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -3,6 +3,7 @@
 #include "llama-impl.h"
 
 #include "ggml.h"
+#include "ggml-backend.h"
 
 #include <cstring>
 #include <climits>
@@ -617,8 +618,49 @@ struct llama_mmap::impl {
     size_t size;
 };
 
-llama_mmap::llama_mmap(struct llama_file * file, size_t prefetch, bool numa) : pimpl(std::make_unique<impl>(file, prefetch, numa)) {}
-llama_mmap::~llama_mmap() = default;
+// Page-lock the mapped weights so host->device copies use DMA rather than the
+// driver's internal bounce buffer. Backends gate this themselves (the CUDA
+// backend requires GGML_CUDA_REGISTER_HOST), so it is a no-op unless requested.
+//
+// Registration makes the pages non-pageable, so it is deliberately opt-in:
+// pinning a mapping that is large relative to physical RAM will fail or put the
+// system under pressure. A failed registration is ignored and the unpinned path
+// is used unchanged.
+using llama_host_register_fn   = bool (*)(void *, size_t);
+using llama_host_unregister_fn = void (*)(void *);
+
+template <typename Fn>
+static Fn llama_get_host_register_proc(const char * name) {
+    for (size_t i = 0; i < ggml_backend_reg_count(); i++) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+        if (reg == nullptr) {
+            continue;
+        }
+        if (void * fn = ggml_backend_reg_get_proc_address(reg, name)) {
+            return (Fn) fn;
+        }
+    }
+    return nullptr;
+}
+
+llama_mmap::llama_mmap(struct llama_file * file, size_t prefetch, bool numa) : pimpl(std::make_unique<impl>(file, prefetch, numa)) {
+    auto reg_fn = llama_get_host_register_proc<llama_host_register_fn>("ggml_backend_register_host_buffer");
+    if (reg_fn != nullptr && reg_fn(pimpl->addr, pimpl->size)) {
+        host_registered = true;
+        LLAMA_LOG_INFO("%s: page-locked %.2f MiB of mapped weights for DMA\n",
+                __func__, pimpl->size / 1024.0 / 1024.0);
+    }
+}
+
+llama_mmap::~llama_mmap() {
+    if (host_registered) {
+        // must run before impl unmaps the region
+        auto unreg_fn = llama_get_host_register_proc<llama_host_unregister_fn>("ggml_backend_unregister_host_buffer");
+        if (unreg_fn != nullptr) {
+            unreg_fn(pimpl->addr);
+        }
+    }
+}
 
 size_t llama_mmap::size() const { return pimpl->size; }
 void * llama_mmap::addr() const { return pimpl->addr; }

--- a/src/llama-mmap.h
+++ b/src/llama-mmap.h
@@ -55,6 +55,9 @@ struct llama_mmap {
 private:
     struct impl;
     std::unique_ptr<impl> pimpl;
+
+    // true if the mapping was page-locked for DMA (see llama_mmap ctor)
+    bool host_registered = false;
 };
 
 struct llama_mlock {


### PR DESCRIPTION
## Summary

`ggml_backend_cuda_register_host_buffer()` is defined and exposed through
`get_proc_address` by both the CUDA and SYCL backends — but nothing in the
repository calls it. Page-locking of mmap'd model weights is unreachable today.

A code search across `master` finds only the two definitions and no consumer.
PR #15615 extended the function to HIP in Aug 2025, so it appears intended to be
used rather than deprecated; the call site simply seems never to have landed.

This adds it.

## Implementation

The call goes in `llama_mmap`'s ctor/dtor because their lifetime matches the
mapping exactly — `llama_model` takes ownership of the loader's `mappings`, so
registering from the loader would unregister too early.

Resolved through `ggml_backend_reg_get_proc_address`, so `src/` gains no
backend-specific dependency and backends without the hook fall through
unchanged. The CUDA backend gates on `GGML_CUDA_REGISTER_HOST`, so this is a
no-op unless explicitly requested.

+47/-2 across two files.

## Why it helps

Pinned host memory lets host→device copies use DMA instead of the driver's
internal bounce buffer. This matters on MoE offload paths, where expert weights
are uploaded from host memory during batched prefill.

## Measurements

OLMoE-1B-7B-0125 Q6_K, RTX A2000 12GB, `-ncmoe 16 -ngl 999 -p 8192`, mmap on,
alternating rounds to rule out page-cache ordering effects:

| round | condition | pp8192 tok/s |
|---|---|---|
| 1 | unpinned | 996.55 ± 1.25 |
| 1 | **pinned** | **1675.77 ± 13.32** |
| 2 | unpinned | 1010.15 ± 18.40 |
| 2 | **pinned** | **1666.20 ± 12.30** |

**~1.67x on prefill.** Round 2's unpinned run executes fourth, fully warm, and
still matches the cold first run — so the effect tracks the condition, not
position in the sequence.

Perplexity is unchanged: `PPL = 4.1871 +/- 0.30585` with and without.

This is consistent with the ~+64% reported independently by the
`fable5/host-register` work on an RTX 3060.

## Limitations

Stated plainly, since I can only test one configuration:

- Measured on a single GPU (A2000), a single model, and Windows only. No Linux,
  ROCm, SYCL, or multi-GPU numbers.
- **Page-locking makes pages non-pageable.** Registering a mapping that is large
  relative to physical RAM fails — I hit this directly: a 17.35GB mapping on a
  32GB host returns false. That path is handled (registration failure is ignored
  and the unpinned path is used unchanged), but it is the reason this is opt-in
  rather than default.
- No benefit to decode paths where experts are computed on the CPU; this only
  helps paths that actually upload weights.

Happy to add Linux and larger-model numbers, or to change the opt-in mechanism
if an env var is not the preferred interface here.
