### PR TITLE
convert : accept "ExaoneMoeForCausalLM" arch spelling

### DIFF
--- a/conversion/__init__.py
+++ b/conversion/__init__.py
@@ -70,6 +70,7 @@ TEXT_MODEL_MAP: dict[str, str] = {
     "Exaone4ForCausalLM": "exaone",
     "ExaoneForCausalLM": "exaone",
     "ExaoneMoEForCausalLM": "exaone",
+    "ExaoneMoeForCausalLM": "exaone",
     "FalconForCausalLM": "falcon",
     "FalconH1ForCausalLM": "falcon_h1",
     "FalconMambaForCausalLM": "mamba",

--- a/conversion/exaone.py
+++ b/conversion/exaone.py
@@ -123,7 +123,9 @@ class Exaone4Model(TextModel):
                 yield (self.format_tensor_name(gguf.MODEL_TENSOR.ROPE_FREQS), torch.tensor(rope_factors, dtype=torch.float32))
 
 
-@ModelBase.register("ExaoneMoEForCausalLM")
+# note: transformers >= 5.1 renamed the class to "ExaoneMoeForCausalLM" (lowercase 'e'),
+#       so accept both spellings - LG AI have updated the configs of already-released models
+@ModelBase.register("ExaoneMoEForCausalLM", "ExaoneMoeForCausalLM")
 class ExaoneMoEModel(Exaone4Model):
     model_arch = gguf.MODEL_ARCH.EXAONE_MOE
 


### PR DESCRIPTION
## Overview
LG AI Research renamed the architecture from ExaoneMoEForCausalLM to ExaoneMoeForCausalLM when exaone_moe was upstreamed into Transformers v5, and updated the configs of already-released models accordingly (K-EXAONE-236B-A23B config.json, commit f7db87a, "Update README.md and config.json for Transformers v5").

Freshly downloaded K-EXAONE-236B-A23B and K-EXAONE-2.0-750B-A37B checkpoints therefore fail conversion with

  `ERROR:hf-to-gguf:Model ExaoneMoeForCausalLM is not supported`

even though the architecture is implemented. The spelling comes from the checkpoint's own config.json, so it is unaffected by the installed Transformers version.

Register both spellings so that older local copies keep working,

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Tested works, fresh GGUF
[DevQuasar/LGAI-EXAONE.K-EXAONE-236B-A23B-GGUF](https://huggingface.co/DevQuasar/LGAI-EXAONE.K-EXAONE-236B-A23B-GGUF)  

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
YES
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
YES - Opus did the edit. I not even realized the slight change in the architecture name...

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
