### PR TITLE
use standard base64::decode in server-common..

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -170,64 +170,15 @@ std::vector<size_t> lora_get_enabled_ids(const std::vector<common_adapter_lora_i
 // base64 utils (TODO: use the base64::decode from base64.hpp)
 //
 
-static const std::string base64_chars =
-             "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-             "abcdefghijklmnopqrstuvwxyz"
-             "0123456789+/";
-
-static inline bool is_base64(uint8_t c) {
-    return (isalnum(c) || (c == '+') || (c == '/'));
-}
-
 static inline raw_buffer base64_decode(const std::string & encoded_string) {
-    int i = 0;
-    int j = 0;
-    int in_ = 0;
-
-    int in_len = encoded_string.size();
-
-    uint8_t char_array_4[4];
-    uint8_t char_array_3[3];
-
     raw_buffer ret;
-
-    while (in_len-- && (encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
-        char_array_4[i++] = encoded_string[in_]; in_++;
-        if (i == 4) {
-            for (i = 0; i < 4; i++) {
-                char_array_4[i] = base64_chars.find(char_array_4[i]);
-            }
-
-            char_array_3[0] = ((char_array_4[0]      ) << 2) + ((char_array_4[1] & 0x30) >> 4);
-            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) +   char_array_4[3];
-
-            for (i = 0; (i < 3); i++) {
-                ret.push_back(char_array_3[i]);
-            }
-
-            i = 0;
-        }
+    ret.reserve(base64::max_decode_size(encoded_string.length()));
+    try {
+        base64::decode(encoded_string.begin(), encoded_string.end(), std::back_inserter(ret));
+    } catch (const base64_error & e) {
+        SRV_DBG("base64_decode failed: %s\n", e.what());
+        ret.clear();
     }
-
-    if (i) {
-        for (j = i; j < 4; j++) {
-            char_array_4[j] = 0;
-        }
-
-        for (j = 0; j < 4; j++) {
-            char_array_4[j] = base64_chars.find(char_array_4[j]);
-        }
-
-        char_array_3[0] = ((char_array_4[0]      ) << 2) + ((char_array_4[1] & 0x30) >> 4);
-        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) +   char_array_4[3];
-
-        for (j = 0; j < i - 1; j++) {
-            ret.push_back(char_array_3[j]);
-        }
-    }
-
     return ret;
 }
 


### PR DESCRIPTION
While going through tools/server/server-common.cpp, I spotted a TODO asking to replace the local base64 decoder with base64::decode from the common library. The old code was redundant and locale-sensitive. I removed it and swapped in the standard utility, catching only base64_error and logging failures at debug level. No API changes, just cleaner and safer code.

