### PR TITLE
ggml-hip : add target-derived build RPATH

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -361,6 +361,20 @@ You can download it from your Linux distro's package manager or from here: [ROCm
 
   Note: `GPU_TARGETS` is optional, omitting it will build the code for all GPUs in the current system.
 
+  Select one ROCm installation root before configuring llama.cpp. The build tree follows the imported ROCm targets discovered through `ROCM_PATH`. To pin the installed tree to the same root, use the standard `CMAKE_INSTALL_RPATH` setting:
+  ```bash
+  ROCM_ROOT=/opt/rocm                                # active native package
+  # ROCM_ROOT=/opt/rocm/core-7.14                   # version-pinned package
+  # ROCM_ROOT="$(rocm-sdk path --root)"             # Python package
+  # ROCM_ROOT=/path/to/extracted/rocm               # tarball or custom prefix
+  ROCM_PATH="$ROCM_ROOT" \
+      cmake -S . -B build -DGGML_HIP=ON \
+      -DCMAKE_INSTALL_RPATH="\$ORIGIN/../lib;$ROCM_ROOT/lib"
+  cmake --build build
+  cmake --install build --prefix /path/to/llama
+  ```
+  Omit `CMAKE_INSTALL_RPATH` to leave ROCm selection to the runtime environment. `/opt/rocm/lib` follows the active system ROCm alternative. This host-library selection is independent of `GPU_TARGETS`; TheRock packages architecture-neutral host libraries separately from GPU-specific kernel packs. Packagers must validate the complete dependency closure and distribution requirements before bundling ROCm libraries beside llama.cpp.
+
   Note that if you get the following error:
   ```
   clang: error: cannot find ROCm device library; provide its path via '--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -154,3 +154,14 @@ if (GGML_HIP_RCCL)
 endif()
 
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
+
+if (UNIX)
+    set(GGML_HIP_BUILD_RPATH
+        "$<TARGET_FILE_DIR:roc::rocblas>"
+        "$<TARGET_FILE_DIR:roc::hipblas>"
+        "$<TARGET_FILE_DIR:hip::amdhip64>")
+    if (GGML_HIP_RCCL)
+        list(APPEND GGML_HIP_BUILD_RPATH "$<TARGET_FILE_DIR:roc::rccl>")
+    endif()
+    set_property(TARGET ggml-hip APPEND PROPERTY BUILD_RPATH ${GGML_HIP_BUILD_RPATH})
+endif()


### PR DESCRIPTION
## Overview

Addresses #25807.

ROCm 7.14 native packages can configure and link the HIP backend, but `libggml-hip.so` does not retain search paths for its direct ROCm dependencies. An executable's `DT_RUNPATH` is not inherited when the loader resolves indirect dependencies, so a clean launch fails on `libhipblas.so.3` unless the ROCm library path is supplied through the environment.

This adds target-derived `BUILD_RPATH` entries to `ggml-hip` for rocBLAS, hipBLAS, the HIP runtime, and RCCL when enabled. The scope is build-tree binaries only: installation behavior, native-package defaults, and older llama.cpp revisions remain unchanged.

## Additional information

Validated on current `master`:

- In the official ROCm 7.14 image, the baseline clean launch exits 127 on `libhipblas.so.3`; the patched build tree exits 0 without a ROCm loader environment override.
- The default install tree remains unchanged and does not retain the added ROCm paths.
- CMake configure/generate passes with the minimum supported ROCm 6.1 line.
- On ROCm 7.2.1 / gfx1151, the patched `llama-cli --list-devices` exits 0 and enumerates the AMD GPU without `LD_LIBRARY_PATH`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted with investigation, validation automation, and preparation of the code and draft. I reviewed the design and every changed line and can explain and maintain the change.

---
*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*
