### PR TITLE
convert : fix DeepseekV4 rope parameters with transformers 5.x

### DIFF
--- a/conversion/deepseek.py
+++ b/conversion/deepseek.py
@@ -533,6 +533,13 @@ class DeepseekV4Model(TextModel):
         for key, value in raw_hparams.items():
             self.hparams.setdefault(key, value)
 
+        # workaround for special rope_parameters (main/compress) in transformers 5.x
+        if self.rope_parameters.get("full_attention", self.rope_parameters).get("rope_type") is None:
+            if (rope_scaling := raw_hparams.get("rope_scaling")) is not None:
+                if "rope_type" not in rope_scaling and (rope_type := rope_scaling.get("type")) is not None:
+                    rope_scaling["rope_type"] = rope_type
+                self.rope_parameters.update(**rope_scaling)
+
         self.block_count = self.hparams["num_hidden_layers"]
         if self.mtp_only:
             self.block_count += self.hparams.get("num_nextn_predict_layers", 0)


### PR DESCRIPTION
## Overview

Converting DeepseekV4 with `transformers` `5.x` would result in missing rope parameters (`YaRN`).

## Additional information

The issue was caused by `transformers` using a special `rope_parameters` layout for this model, see [configuration_deepseek_v4.py](https://github.com/huggingface/transformers/blob/fa6c8308e22dade298c10c72d44937e41b962353/src/transformers/models/deepseek_v4/configuration_deepseek_v4.py#L294-L321) for more details.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Nahániri
- Language disclosure: Guaraní