### PR TITLE
Vulkan: add hoisting support for row IDs and expert count in shaders

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1327,6 +1327,8 @@ struct vk_mat_mat_id_push_constants {
     uint32_t batch_stride_a; uint32_t batch_stride_b; uint32_t batch_stride_d;
     uint32_t nei0; uint32_t nei1; uint32_t nbi1; uint32_t ne11;
     uint32_t padded_N;
+    uint32_t n_experts;
+    uint32_t hoist_row_ids;
 };
 struct vk_mat_vec_id_push_constants {
     uint32_t ncols;
@@ -1407,6 +1409,8 @@ struct vk_op_count_experts_push_constants {
     uint32_t nb00;
     uint32_t nb01;
     uint32_t a_offset;
+    uint32_t n_experts;
+    uint32_t hoist_row_ids;
 };
 
 struct vk_op_glu_push_constants {
@@ -8869,13 +8873,18 @@ static void ggml_vk_matmul_id(
         uint32_t m, uint32_t n, uint32_t k, uint32_t stride_a, uint32_t stride_b, uint32_t stride_d,
         uint32_t batch_stride_a, uint32_t batch_stride_b, uint32_t batch_stride_d,
         uint32_t n_as, uint32_t nei0, uint32_t nei1, uint32_t nbi1, uint32_t ne11,
-        uint32_t padded_n) {
+        uint32_t padded_n, bool hoist_row_ids) {
     VK_LOG_DEBUG("ggml_vk_matmul_id(a: (" << a.buffer->buffer << ", " << a.offset << ", " << a.size << "), b: (" << b.buffer->buffer << ", " << b.offset << ", " << b.size << "), d: (" << d.buffer->buffer << ", " << d.offset << ", " << d.size << "), ids: (" << ids.buffer->buffer << ", " << ids.offset << ", " << ids.size << "), expert_count: (" << expert_count_buf.buffer->buffer << ", " << expert_count_buf.offset << ", " << expert_count_buf.size << "), " <<
         "m: " << m << ", n: " << n << ", k: " << k << ", stride_a: " << stride_a << ", stride_b: " << stride_b << ", stride_d: " << stride_d << ", " <<
         "batch_stride_a: " << batch_stride_a << ", batch_stride_b: " << batch_stride_b << ", batch_stride_d: " << batch_stride_d << ", " <<
         "n_as: " << n_as << ", nei0: " << nei0 << ", nei1: " << nei1 << ", nbi1: " << nbi1 << ", ne11: " << ne11 << ")");
     const vk_mat_mat_id_push_constants pc = { m, n, k, stride_a, stride_b, stride_d, batch_stride_a, batch_stride_b, batch_stride_d,
-                                              nei0, nei1, nbi1, ne11, padded_n };
+                                              nei0, nei1, nbi1, ne11, padded_n, n_as, uint32_t(hoist_row_ids) };
+    if (vk_perf_logger_enabled) {
+        std::cerr << "ggml_vulkan: MUL_MAT_ID pipeline=" << pipeline->name
+                  << " row_ids=" << (hoist_row_ids ? "hoisted" : "workgroup-scan")
+                  << " m=" << m << " n=" << n << " k=" << k << std::endl;
+    }
     ggml_vk_dispatch_pipeline(ctx, subctx, pipeline, { a, b, d, ids, expert_count_buf }, pc, { m, nei1, n_as });
 }
 
@@ -10049,6 +10058,10 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     // const uint64_t ne23 = dst->ne[3];
 
     const uint64_t n_as = ne02;
+    const uint64_t hoisted_row_id_words = 2 * n_as + 1 + nei0 * nei1;
+    const bool hoist_row_ids = n_as <= 256 && nei0 <= 0xffff && nei1 <= 0xffff &&
+                                hoisted_row_id_words * sizeof(uint32_t) <=
+                                    ctx->device->properties.limits.maxStorageBufferRange;
 
     ggml_backend_vk_buffer_context * dst_buf_ctx = (ggml_backend_vk_buffer_context *)dst->buffer->context;
     ggml_backend_vk_buffer_context * src0_buf_ctx = (ggml_backend_vk_buffer_context *)src0->buffer->context;
@@ -10189,7 +10202,8 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     }
     vk_pipeline count_experts = ctx->device->pipeline_count_experts;
 
-    uint32_t expert_count_size = sizeof(uint32_t) * n_as;
+    const size_t expert_data_size = sizeof(uint32_t) *
+        (hoist_row_ids ? hoisted_row_id_words : n_as);
 
     {
         if (
@@ -10205,8 +10219,8 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
             ctx->prealloc_size_y = y_sz;
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
-        if (ctx->prealloc_size_split_k < expert_count_size) {
-            ctx->prealloc_size_split_k = expert_count_size;
+        if (ctx->prealloc_size_split_k < expert_data_size) {
+            ctx->prealloc_size_split_k = expert_data_size;
             ggml_vk_preallocate_buffers(ctx, subctx);
         }
 
@@ -10272,7 +10286,7 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
         }
     }
     // Count how many times each expert is used
-    vk_subbuffer expert_count_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_split_k, 0);
+    vk_subbuffer expert_count_buf = { ctx->prealloc_split_k, 0, expert_data_size };
     if (ctx->prealloc_split_k_need_sync) {
         ggml_vk_sync_buffers(ctx, subctx);
     }
@@ -10281,9 +10295,12 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
                                            (uint32_t)nei1,
                                            (uint32_t)(nbi0 / ggml_type_size(ids->type)),
                                            (uint32_t)(nbi1 / ggml_type_size(ids->type)),
-                                           (uint32_t)(get_misalign_bytes(ctx, ids) / ggml_type_size(ids->type)) };
+                                           (uint32_t)(get_misalign_bytes(ctx, ids) / ggml_type_size(ids->type)),
+                                           (uint32_t)n_as,
+                                           uint32_t(hoist_row_ids) };
         ggml_vk_dispatch_pipeline(ctx, subctx, count_experts,
-            { vk_subbuffer{ d_ids, ids_buf_offset, ids_sz }, expert_count_buf }, pc, { (uint32_t)n_as, 1, 1});
+            { vk_subbuffer{ d_ids, ids_buf_offset, ids_sz }, expert_count_buf }, pc,
+            { hoist_row_ids ? 1u : (uint32_t)n_as, 1, 1});
     }
 
     if (x_non_contig) {
@@ -10352,7 +10369,7 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
         { d_D, d_buf_offset, d_sz }, { d_ids, ids_buf_offset, ids_sz }, expert_count_buf,
         ne01, ne21, ne10, ne10, stride_b_y, ne01,
         stride_batch_x, stride_batch_y, ne20*ne21,
-        n_as, nei0, nei1, nbi1 / ggml_type_size(ids->type), ne11, padded_n
+        n_as, nei0, nei1, nbi1 / ggml_type_size(ids->type), ne11, padded_n, hoist_row_ids
     );  // NOLINT
 
     if (x_non_contig || qx_needs_dequant) {

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10063,10 +10063,8 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     // const uint64_t ne23 = dst->ne[3];
 
     const uint64_t n_as = ne02;
-    // Size of the hoisted row id table built by count_experts: n_as counts, n_as start
-    // offsets, one total, then one packed row id per (expert, token) pair. See the layout
-    // comment in count_experts.comp. Only hoist when the indices fit the packing used
-    // there (16 bits each) and the table fits a storage buffer binding.
+    // n_as counts, n_as offsets, one total, then one packed row id per (expert, token).
+    // Hoisting requires 16-bit indices for the packing and a table that fits one binding.
     const uint64_t hoisted_row_id_words = 2 * n_as + 1 + nei0 * nei1;
     const bool hoist_row_ids = n_as <= 256 && nei0 <= 0xffff && nei1 <= 0xffff &&
                                 hoisted_row_id_words * sizeof(uint32_t) <=

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1591,6 +1591,10 @@ template <> void init_pushconst_fastdiv(vk_op_glu_push_constants &p) {
     init_fastdiv_values(p.ne20,                p.ne2_0mp,      p.ne2_0L);
 }
 
+template <> void init_pushconst_fastdiv(vk_op_count_experts_push_constants &p) {
+    init_fastdiv_values(p.ne00, p.ne00mp, p.ne00L);
+}
+
 struct vk_op_binary_push_constants {
     uint32_t ne;
     uint32_t ne00; uint32_t ne01; uint32_t ne02; uint32_t ne03; uint32_t nb00; uint32_t nb01; uint32_t nb02; uint32_t nb03;
@@ -10304,7 +10308,7 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
                                            (uint32_t)n_as,
                                            uint32_t(hoist_row_ids),
                                            0, 0 };
-        init_fastdiv_values(pc.ne00, pc.ne00mp, pc.ne00L);
+        init_pushconst_fastdiv(pc);
         ggml_vk_dispatch_pipeline(ctx, subctx, count_experts,
             { vk_subbuffer{ d_ids, ids_buf_offset, ids_sz }, expert_count_buf }, pc,
             { hoist_row_ids ? 1u : (uint32_t)n_as, 1, 1});

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1411,6 +1411,8 @@ struct vk_op_count_experts_push_constants {
     uint32_t a_offset;
     uint32_t n_experts;
     uint32_t hoist_row_ids;
+    uint32_t ne00mp;
+    uint32_t ne00L;
 };
 
 struct vk_op_glu_push_constants {
@@ -5758,7 +5760,11 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
 
     ggml_vk_create_pipeline(device, device->pipeline_count_equal_i32, "count_equal_i32", count_equal_i32_len, count_equal_i32_data, "main", 3, sizeof(vk_op_push_constants), {512, 1, 1}, { device->subgroup_size }, 1);
 
-    ggml_vk_create_pipeline(device, device->pipeline_count_experts, "count_experts", count_experts_len, count_experts_data, "main", 2, sizeof(vk_op_count_experts_push_constants), {1, 1, 1}, {}, 1, true);
+    if (device->subgroup_arithmetic && device->subgroup_require_full_support) {
+        ggml_vk_create_pipeline(device, device->pipeline_count_experts, "count_experts", count_experts_subgroup_len, count_experts_subgroup_data, "main", 2, sizeof(vk_op_count_experts_push_constants), {1, 1, 1}, {}, 1, true, true);
+    } else {
+        ggml_vk_create_pipeline(device, device->pipeline_count_experts, "count_experts", count_experts_len, count_experts_data, "main", 2, sizeof(vk_op_count_experts_push_constants), {1, 1, 1}, {}, 1, true);
+    }
 
     for (auto &s : device->pipeline_solve_tri_f32) {
         const vk_solve_tri_pipeline_state &state = s.first;
@@ -8880,11 +8886,6 @@ static void ggml_vk_matmul_id(
         "n_as: " << n_as << ", nei0: " << nei0 << ", nei1: " << nei1 << ", nbi1: " << nbi1 << ", ne11: " << ne11 << ")");
     const vk_mat_mat_id_push_constants pc = { m, n, k, stride_a, stride_b, stride_d, batch_stride_a, batch_stride_b, batch_stride_d,
                                               nei0, nei1, nbi1, ne11, padded_n, n_as, uint32_t(hoist_row_ids) };
-    if (vk_perf_logger_enabled) {
-        std::cerr << "ggml_vulkan: MUL_MAT_ID pipeline=" << pipeline->name
-                  << " row_ids=" << (hoist_row_ids ? "hoisted" : "workgroup-scan")
-                  << " m=" << m << " n=" << n << " k=" << k << std::endl;
-    }
     ggml_vk_dispatch_pipeline(ctx, subctx, pipeline, { a, b, d, ids, expert_count_buf }, pc, { m, nei1, n_as });
 }
 
@@ -10058,6 +10059,10 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     // const uint64_t ne23 = dst->ne[3];
 
     const uint64_t n_as = ne02;
+    // Size of the hoisted row id table built by count_experts: n_as counts, n_as start
+    // offsets, one total, then one packed row id per (expert, token) pair. See the layout
+    // comment in count_experts.comp. Only hoist when the indices fit the packing used
+    // there (16 bits each) and the table fits a storage buffer binding.
     const uint64_t hoisted_row_id_words = 2 * n_as + 1 + nei0 * nei1;
     const bool hoist_row_ids = n_as <= 256 && nei0 <= 0xffff && nei1 <= 0xffff &&
                                 hoisted_row_id_words * sizeof(uint32_t) <=
@@ -10291,13 +10296,15 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
         ggml_vk_sync_buffers(ctx, subctx);
     }
     {
-        const std::vector<uint32_t> pc = { (uint32_t)nei0,
+        vk_op_count_experts_push_constants pc = { (uint32_t)nei0,
                                            (uint32_t)nei1,
                                            (uint32_t)(nbi0 / ggml_type_size(ids->type)),
                                            (uint32_t)(nbi1 / ggml_type_size(ids->type)),
                                            (uint32_t)(get_misalign_bytes(ctx, ids) / ggml_type_size(ids->type)),
                                            (uint32_t)n_as,
-                                           uint32_t(hoist_row_ids) };
+                                           uint32_t(hoist_row_ids),
+                                           0, 0 };
+        init_fastdiv_values(pc.ne00, pc.ne00mp, pc.ne00L);
         ggml_vk_dispatch_pipeline(ctx, subctx, count_experts,
             { vk_subbuffer{ d_ids, ids_buf_offset, ids_sz }, expert_count_buf }, pc,
             { hoist_row_ids ? 1u : (uint32_t)n_as, 1, 1});

--- a/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
@@ -11,6 +11,8 @@ layout (push_constant) uniform parameter
     uint32_t nb00;
     uint32_t nb01;
     uint32_t a_offset;
+    uint32_t n_experts;
+    uint32_t hoist_row_ids;
 } p;
 
 #define BLOCK_SIZE 256
@@ -21,11 +23,56 @@ layout (binding = 0) readonly buffer A {uint data_a[];};
 layout (binding = 1) writeonly buffer D {uint data_d[];};
 
 shared uint vals[BLOCK_SIZE];
+shared uint offsets[BLOCK_SIZE];
+shared uint cursors[BLOCK_SIZE];
 
 void main() {
     const uint expert_id = gl_WorkGroupID.x;
     const uint num_elements = p.ne00 * p.ne01;
     const uint tid = gl_LocalInvocationID.x;
+
+    if (p.hoist_row_ids != 0) {
+        if (tid < p.n_experts) {
+            vals[tid] = 0;
+        }
+        barrier();
+
+        for (uint idx = tid; idx < num_elements; idx += BLOCK_SIZE) {
+            const uint i01 = idx / p.ne00;
+            const uint i00 = idx % p.ne00;
+            const uint expert = data_a[p.a_offset + i01 * p.nb01 + i00 * p.nb00];
+            if (expert < p.n_experts) {
+                atomicAdd(vals[expert], 1);
+            }
+        }
+        barrier();
+
+        if (tid == 0) {
+            uint offset = 0;
+            for (uint expert = 0; expert < p.n_experts; ++expert) {
+                const uint count = vals[expert];
+                data_d[expert] = count;
+                data_d[p.n_experts + expert] = offset;
+                offsets[expert] = offset;
+                cursors[expert] = 0;
+                offset += count;
+            }
+            data_d[2 * p.n_experts] = offset;
+        }
+        barrier();
+
+        for (uint idx = tid; idx < num_elements; idx += BLOCK_SIZE) {
+            const uint i01 = idx / p.ne00;
+            const uint i00 = idx % p.ne00;
+            const uint expert = data_a[p.a_offset + i01 * p.nb01 + i00 * p.nb00];
+            if (expert < p.n_experts) {
+                const uint row = atomicAdd(cursors[expert], 1);
+                const uint packed_row_id = (i01 << 16) | (i00 & 0xffffu);
+                data_d[2 * p.n_experts + 1 + offsets[expert] + row] = packed_row_id;
+            }
+        }
+        return;
+    }
 
     uint count = 0;
     for (uint idx = tid; idx < num_elements; idx += BLOCK_SIZE) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
@@ -2,6 +2,11 @@
 
 #extension GL_EXT_control_flow_attributes : enable
 
+#ifdef USE_SUBGROUPS
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+#endif
+
 #include "types.glsl"
 
 layout (push_constant) uniform parameter
@@ -13,6 +18,8 @@ layout (push_constant) uniform parameter
     uint32_t a_offset;
     uint32_t n_experts;
     uint32_t hoist_row_ids;
+    uint32_t ne00mp;
+    uint32_t ne00L;
 } p;
 
 #define BLOCK_SIZE 256
@@ -26,6 +33,26 @@ shared uint vals[BLOCK_SIZE];
 shared uint offsets[BLOCK_SIZE];
 shared uint cursors[BLOCK_SIZE];
 
+// see init_fastdiv_values in ggml-vulkan.cpp
+uint fastdiv(uint n, uint mp, uint L) {
+    uint msbs, lsbs;
+    // msbs = mulhi(n, mp)
+    umulExtended(n, mp, msbs, lsbs);
+    return (msbs + n) >> L;
+}
+
+// Layout of data_d when p.hoist_row_ids is set. A single workgroup builds the
+// per-expert row lists here, so that the mul_mat_id shaders can load their tile
+// directly instead of rescanning the whole ids array in every workgroup:
+//
+//   [0,              n_experts)    per-expert row count
+//   [n_experts,    2*n_experts)    per-expert start offset into the row id region below
+//   [2*n_experts]                  total row count, i.e. the sum of all per-expert counts
+//   [2*n_experts + 1,        )     row ids grouped by expert, each packed as
+//                                  (i01 << 16) | (i00 & 0xffff)
+//
+// When p.hoist_row_ids is 0 the dispatch is one workgroup per expert and only
+// data_d[expert_id] is written, holding that expert's row count.
 void main() {
     const uint expert_id = gl_WorkGroupID.x;
     const uint num_elements = p.ne00 * p.ne01;
@@ -38,8 +65,8 @@ void main() {
         barrier();
 
         for (uint idx = tid; idx < num_elements; idx += BLOCK_SIZE) {
-            const uint i01 = idx / p.ne00;
-            const uint i00 = idx % p.ne00;
+            const uint i01 = fastdiv(idx, p.ne00mp, p.ne00L);
+            const uint i00 = idx - i01 * p.ne00;
             const uint expert = data_a[p.a_offset + i01 * p.nb01 + i00 * p.nb00];
             if (expert < p.n_experts) {
                 atomicAdd(vals[expert], 1);
@@ -47,6 +74,30 @@ void main() {
         }
         barrier();
 
+        // Exclusive prefix sum over the per-expert counts, to turn them into
+        // start offsets into the row id region.
+#ifdef USE_SUBGROUPS
+        if (gl_SubgroupID == 0) {
+            // round the trip count up so the loop stays uniform across the subgroup
+            const uint n_experts_padded = (p.n_experts + gl_SubgroupSize - 1) & ~(gl_SubgroupSize - 1);
+            uint base = 0;
+            for (uint expert = gl_SubgroupInvocationID; expert < n_experts_padded; expert += gl_SubgroupSize) {
+                const bool in_range = expert < p.n_experts;
+                const uint count = in_range ? vals[expert] : 0;
+                const uint offset = base + subgroupExclusiveAdd(count);
+                if (in_range) {
+                    data_d[expert] = count;
+                    data_d[p.n_experts + expert] = offset;
+                    offsets[expert] = offset;
+                    cursors[expert] = 0;
+                }
+                base += subgroupAdd(count);
+            }
+            if (subgroupElect()) {
+                data_d[2 * p.n_experts] = base;
+            }
+        }
+#else
         if (tid == 0) {
             uint offset = 0;
             for (uint expert = 0; expert < p.n_experts; ++expert) {
@@ -59,11 +110,12 @@ void main() {
             }
             data_d[2 * p.n_experts] = offset;
         }
+#endif
         barrier();
 
         for (uint idx = tid; idx < num_elements; idx += BLOCK_SIZE) {
-            const uint i01 = idx / p.ne00;
-            const uint i00 = idx % p.ne00;
+            const uint i01 = fastdiv(idx, p.ne00mp, p.ne00L);
+            const uint i00 = idx - i01 * p.ne00;
             const uint expert = data_a[p.a_offset + i01 * p.nb01 + i00 * p.nb00];
             if (expert < p.n_experts) {
                 const uint row = atomicAdd(cursors[expert], 1);
@@ -76,8 +128,8 @@ void main() {
 
     uint count = 0;
     for (uint idx = tid; idx < num_elements; idx += BLOCK_SIZE) {
-        const uint i01 = idx / p.ne00;
-        const uint i00 = idx % p.ne00;
+        const uint i01 = fastdiv(idx, p.ne00mp, p.ne00L);
+        const uint i00 = idx - i01 * p.ne00;
         const uint a = data_a[p.a_offset + i01 * p.nb01 + i00 * p.nb00];
 
         count += uint(a == expert_id);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
@@ -41,18 +41,12 @@ uint fastdiv(uint n, uint mp, uint L) {
     return (msbs + n) >> L;
 }
 
-// Layout of data_d when p.hoist_row_ids is set. A single workgroup builds the
-// per-expert row lists here, so that the mul_mat_id shaders can load their tile
-// directly instead of rescanning the whole ids array in every workgroup:
-//
-//   [0,              n_experts)    per-expert row count
-//   [n_experts,    2*n_experts)    per-expert start offset into the row id region below
-//   [2*n_experts]                  total row count, i.e. the sum of all per-expert counts
-//   [2*n_experts + 1,        )     row ids grouped by expert, each packed as
-//                                  (i01 << 16) | (i00 & 0xffff)
-//
-// When p.hoist_row_ids is 0 the dispatch is one workgroup per expert and only
-// data_d[expert_id] is written, holding that expert's row count.
+// data_d layout when p.hoist_row_ids is set:
+//   [0,              n_experts)   per-expert row count
+//   [n_experts,    2*n_experts)   per-expert start offset into the row id region
+//   [2*n_experts]                 total row count
+//   [2*n_experts + 1,         )   row ids grouped by expert, packed as (i01 << 16) | (i00 & 0xffff)
+// Otherwise only data_d[expert_id] is written, holding that expert's row count.
 void main() {
     const uint expert_id = gl_WorkGroupID.x;
     const uint num_elements = p.ne00 * p.ne01;
@@ -74,11 +68,10 @@ void main() {
         }
         barrier();
 
-        // Exclusive prefix sum over the per-expert counts, to turn them into
-        // start offsets into the row id region.
+        
 #ifdef USE_SUBGROUPS
         if (gl_SubgroupID == 0) {
-            // round the trip count up so the loop stays uniform across the subgroup
+            // pad the trip count so the subgroup ops stay in uniform control flow
             const uint n_experts_padded = (p.n_experts + gl_SubgroupSize - 1) & ~(gl_SubgroupSize - 1);
             uint base = 0;
             for (uint expert = gl_SubgroupInvocationID; expert < n_experts_padded; expert += gl_SubgroupSize) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
@@ -68,7 +68,6 @@ void main() {
         }
         barrier();
 
-        
 #ifdef USE_SUBGROUPS
         if (gl_SubgroupID == 0) {
             // pad the trip count so the subgroup ops stay in uniform control flow

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm.comp
@@ -88,6 +88,9 @@ layout (push_constant) uniform parameter
     uint nei1;
     uint nbi1;
     uint ne11;
+    uint padded_N;
+    uint n_experts;
+    uint hoist_row_ids;
 #else
     uint base_work_group_z;
     uint num_batches;
@@ -211,27 +214,31 @@ void main() {
     const uint loadstride_b = gl_WorkGroupSize.x * LOAD_VEC_B_EFF * LOAD_VEC_BATCH_B / BK;
 
 #ifdef MUL_MAT_ID
-#ifdef MUL_MAT_ID_USE_SUBGROUPS
-    if (bitCount(p.nei0) == 1) {
-        load_row_ids(expert_idx, true, ic);
+    if (p.hoist_row_ids != 0) {
+        load_row_ids_hoisted(expert_idx, ic);
     } else {
-        load_row_ids(expert_idx, false, ic);
-    }
+#ifdef MUL_MAT_ID_USE_SUBGROUPS
+        if (bitCount(p.nei0) == 1) {
+            load_row_ids(expert_idx, true, ic);
+        } else {
+            load_row_ids(expert_idx, false, ic);
+        }
 #else
-    _ne1 = 0;
-    for (uint ii1 = 0; ii1 < p.nei1 && _ne1 < (ic + 1) * BN; ii1++) {
-        for (uint ii0 = 0; ii0 < p.nei0 && _ne1 < (ic + 1) * BN; ii0++) {
-            if (data_ids[ii1*p.nbi1 + ii0] == expert_idx) {
-                if (_ne1 >= ic * BN) {
-                    row_ids[_ne1 - ic * BN] = u16vec2(ii0, ii1);
+        _ne1 = 0;
+        for (uint ii1 = 0; ii1 < p.nei1 && _ne1 < (ic + 1) * BN; ii1++) {
+            for (uint ii0 = 0; ii0 < p.nei0 && _ne1 < (ic + 1) * BN; ii0++) {
+                if (data_ids[ii1*p.nbi1 + ii0] == expert_idx) {
+                    if (_ne1 >= ic * BN) {
+                        row_ids[_ne1 - ic * BN] = u16vec2(ii0, ii1);
+                    }
+                    _ne1++;
                 }
-                _ne1++;
             }
         }
-    }
 
-    barrier();
+        barrier();
 #endif
+    }
 
     // Workgroup has no work
     if (ic * BN >= _ne1) return;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_cm2.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_cm2.comp
@@ -67,6 +67,10 @@ layout (push_constant) uniform parameter
 #endif
     // N dimension for the B matrix can be >= p.N
     uint padded_N;
+#ifdef MUL_MAT_ID
+    uint n_experts;
+    uint hoist_row_ids;
+#endif
 } p;
 
 
@@ -225,6 +229,23 @@ void load_row_ids(uint expert_idx, bool nei0_is_pow2, uint ic) {
     }
     barrier();
 }
+
+void load_row_ids_hoisted(uint expert_idx, uint ic) {
+    _ne1 = uint(data_expert_count[expert_idx]);
+
+    const uint tile_begin = ic * BN;
+    const uint tile_count = tile_begin < _ne1 ? min(BN, _ne1 - tile_begin) : 0;
+    const uint expert_offset = uint(data_expert_count[p.n_experts + expert_idx]);
+    const uint row_ids_offset = 2 * p.n_experts + 1 + expert_offset + tile_begin;
+
+    for (uint i = gl_LocalInvocationIndex; i < tile_count; i += BLOCK_SIZE) {
+        const uint packed_row_id = uint(data_expert_count[row_ids_offset + i]);
+        const uint ii0 = packed_row_id & 0xffffu;
+        const uint ii1 = packed_row_id >> 16;
+        row_ids[i] = u16vec4(fastmod(ii0, p.ne11), ii1, ii0, 0);
+    }
+    barrier();
+}
 #endif
 
 void main() {
@@ -266,7 +287,9 @@ void main() {
     const uint ik = gl_WorkGroupID.x / blocks_m;
 
 #ifdef MUL_MAT_ID
-    if (bitCount(p.nei0) == 1) {
+    if (p.hoist_row_ids != 0) {
+        load_row_ids_hoisted(expert_idx, ic);
+    } else if (bitCount(p.nei0) == 1) {
         load_row_ids(expert_idx, true, ic);
     } else {
         load_row_ids(expert_idx, false, ic);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_id_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_id_funcs.glsl
@@ -71,4 +71,19 @@ void load_row_ids(uint expert_idx, bool nei0_is_pow2, uint ic) {
     barrier();
 }
 #endif // MUL_MAT_ID_USE_SUBGROUPS
+
+void load_row_ids_hoisted(uint expert_idx, uint ic) {
+    _ne1 = uint(data_expert_count[expert_idx]);
+
+    const uint tile_begin = ic * BN;
+    const uint tile_count = tile_begin < _ne1 ? min(BN, _ne1 - tile_begin) : 0;
+    const uint expert_offset = uint(data_expert_count[p.n_experts + expert_idx]);
+    const uint row_ids_offset = 2 * p.n_experts + 1 + expert_offset + tile_begin;
+
+    for (uint i = gl_LocalInvocationIndex; i < tile_count; i += BLOCK_SIZE) {
+        const uint packed_row_id = uint(data_expert_count[row_ids_offset + i]);
+        row_ids[i] = u16vec2(packed_row_id & 0xffffu, packed_row_id >> 16);
+    }
+    barrier();
+}
 #endif // MUL_MAT_ID

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mmq.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mmq.comp
@@ -56,6 +56,9 @@ layout (push_constant) uniform parameter
     uint nei1;
     uint nbi1;
     uint ne11;
+    uint padded_N;
+    uint n_experts;
+    uint hoist_row_ids;
 #else
     uint base_work_group_z;
     uint num_batches;
@@ -157,27 +160,31 @@ void main() {
     const uint loadstride_b = BLOCK_SIZE * LOAD_VEC_B / BK;
 
 #ifdef MUL_MAT_ID
-#ifdef MUL_MAT_ID_USE_SUBGROUPS
-    if (bitCount(p.nei0) == 1) {
-        load_row_ids(expert_idx, true, ic);
+    if (p.hoist_row_ids != 0) {
+        load_row_ids_hoisted(expert_idx, ic);
     } else {
-        load_row_ids(expert_idx, false, ic);
-    }
+#ifdef MUL_MAT_ID_USE_SUBGROUPS
+        if (bitCount(p.nei0) == 1) {
+            load_row_ids(expert_idx, true, ic);
+        } else {
+            load_row_ids(expert_idx, false, ic);
+        }
 #else
-    _ne1 = 0;
-    for (uint ii1 = 0; ii1 < p.nei1 && _ne1 < (ic + 1) * BN; ii1++) {
-        for (uint ii0 = 0; ii0 < p.nei0 && _ne1 < (ic + 1) * BN; ii0++) {
-            if (data_ids[ii1*p.nbi1 + ii0] == expert_idx) {
-                if (_ne1 >= ic * BN) {
-                    row_ids[_ne1 - ic * BN] = u16vec2(ii0, ii1);
+        _ne1 = 0;
+        for (uint ii1 = 0; ii1 < p.nei1 && _ne1 < (ic + 1) * BN; ii1++) {
+            for (uint ii0 = 0; ii0 < p.nei0 && _ne1 < (ic + 1) * BN; ii0++) {
+                if (data_ids[ii1*p.nbi1 + ii0] == expert_idx) {
+                    if (_ne1 >= ic * BN) {
+                        row_ids[_ne1 - ic * BN] = u16vec2(ii0, ii1);
+                    }
+                    _ne1++;
                 }
-                _ne1++;
             }
         }
-    }
 
-    barrier();
+        barrier();
 #endif
+    }
 
     // Workgroup has no work
     if (ic * BN >= _ne1) return;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -1029,6 +1029,7 @@ void process_shaders() {
     string_to_spv("cumsum_multipass2_f32", "cumsum_multipass2.comp", merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
 
     string_to_spv("count_experts", "count_experts.comp", merge_maps(base_dict, {{"A_TYPE", "uint"}, {"D_TYPE", "uint"}}));
+    string_to_spv("count_experts_subgroup", "count_experts.comp", merge_maps(base_dict, {{"A_TYPE", "uint"}, {"D_TYPE", "uint"}, {"USE_SUBGROUPS", "1"}}));
 
     for (std::string dim_str : {"", "_3d"}) {
         for (bool bda : {false, true}) {


### PR DESCRIPTION
## Overview
This PR optimizes Vulkan `MUL_MAT_ID` for routed Mixture-of-Experts (MoE) prompt processing.

Each expert’s assigned token-row IDs are collected once and reused by the related GPU workgroups. Previously, every workgroup independently searched the routing table for the same rows.

This removes redundant routing work around the GEMM. Dense-model paths and token-generation/decode paths are unchanged.

## Additional information

Hardware/software:
- AMD Radeon PRO W7800 (`gfx1100` / RDNA3)
- RADV / Mesa `26.0.3-1ubuntu1`; Vulkan device API `1.4.335`
- Schedule: `A-B-A-B-A-B`, with `-r 5` per phase
- Baseline A: optimization disabled
- Candidate B: `GGML_VK_MUL_MAT_ID_HOIST_ROW_IDS=1`
- Common options: `-ctk f16 -ctv f16 -fa on 

**Qwen3.6 35B-A3B Q4_K_M:**
B/UB | PP128 | PP1024 | PP4096 | PP16384 | PP32768 | TG128
-- | -- | -- | -- | -- | -- | --
512/512 | 1145.8 → 1158.7 (+1.12%) | 2236.2 → 2346.5 (+4.93%) | 2125.5 → 2224.5 (+4.66%) | 1838.2 → 1914.2 (+4.13%) | 1561.7 → 1618.5 (+3.64%) | 119.76 → 119.68 (-0.07%)
1024/1024 | 1131.1 → 1144.5 (+1.19%) | 2701.0 → 2923.9 (+8.25%) | 2577.7 → 2789.4 (+8.21%) | 2164.4 → 2323.6 (+7.36%) | 1813.6 → 1919.9 (+5.86%) | 119.64 → 119.78 (+0.12%)
2048/2048 | 1137.7 → 1152.5 (+1.30%) | 2706.4 → 2927.6 (+8.17%) | 2780.7 → 3134.5 (+12.72%) | 2315.4 → 2552.4 (+10.24%) | 1804.3 → 1949.0 (+8.02%) | 119.81 → 119.76 (-0.04%)
4096/4096 | 1140.5 → 1153.4 (+1.13%) | 2707.9 → 2931.9 (+8.27%) | 2676.5 → 3189.2 (+19.16%) | 2240.2 → 2584.2 (+15.35%) | 1719.7 → 1915.7 (+11.40%) | 120.05 → 119.97 (-0.07%)
8192/8192 | 1137.8 → 1152.4 (+1.28%) | 2710.6 → 2940.3 (+8.48%) | 2683.3 → 3190.9 (+18.92%) | 2040.0 → 2526.2 (+23.83%)* | 1606.8 → 1898.8 (+18.17%) | 119.73 → 119.78 (+0.04%)

**Gemma 4 26B A4B IT Q8_0**
B/UB | PP128 | PP1024 | PP4096 | PP16384 | PP32768 | TG128
-- | -- | -- | -- | -- | -- | --
512/512 | 1285.16 → 1303.25 (+1.41%) | 2293.81 → 2386.78 (+4.05%) | 2183.12 → 2266.86 (+3.84%) | 1899.78 → 1957.54 (+3.04%) | 1631.29 → 1676.90 (+2.80%) | 106.39 → 106.61 (+0.20%)
1024/1024 | 1285.13 → 1303.47 (+1.43%) | 2723.37 → 2901.48 (+6.54%) | 2575.54 → 2733.97 (+6.15%) | 2186.20 → 2293.09 (+4.89%) | 1817.43 → 1889.73 (+3.98%) | 106.61 → 106.63 (+0.02%)
2048/2048 | 1285.05 → 1304.53 (+1.52%) | 2726.59 → 2900.06 (+6.36%) | 2758.38 → 3020.89 (+9.52%) | 2277.61 → 2450.40 (+7.59%) | 1843.31 → 1949.91 (+5.78%) | 106.51 → 106.72 (+0.19%)
4096/4096 | 1289.13 → 1303.39 (+1.11%) | 2726.09 → 2906.08 (+6.60%) | 2655.81 → 3045.56 (+14.68%) | 2216.87 → 2481.25 (+11.93%) | 1825.99 → 2002.14 (+9.65%) | 106.42 → 106.74 (+0.30%)
8192/8192 | 1283.39 → 1302.33 (+1.48%) | 2724.34 → 2899.07 (+6.41%) | 2649.51 → 3038.06 (+14.67%) | 2058.61 → 2459.16 (+19.46%) | 1748.43 → 2020.54 (+15.56%) | 106.57 → 106.74 (+0.15%)



**Qwen3.6 35B-A3B UD Q6_K**
B/UB | PP128 | PP1024 | PP4096 | PP16384 | PP32768 | TG128
-- | -- | -- | -- | -- | -- | --
512/512 | 1008.79 → 1018.57 (+0.97%) | 2018.67 → 2102.30 (+4.14%) | 1924.78 → 2000.29 (+3.92%) | 1705.47 → 1757.72 (+3.06%) | 1476.88 → 1524.26 (+3.21%) | 114.96 → 115.09 (+0.11%)
1024/1024 | 1011.52 → 1018.31 (+0.67%) | 2504.86 → 2690.49 (+7.41%) | 2397.22 → 2562.28 (+6.89%) | 2063.25 → 2183.05 (+5.81%) | 1741.46 → 1827.73 (+4.95%) | 115.02 → 115.01 (−0.01%)
2048/2048 | 1011.49 → 1019.47 (+0.79%) | 2507.35 → 2688.94 (+7.24%) | 2632.11 → 2942.17 (+11.78%) | 2225.26 → 2439.22 (+9.62%) | 1771.53 → 1903.82 (+7.47%) | 115.00 → 115.19 (+0.17%)
4096/4096 | 1012.26 → 1019.85 (+0.75%) | 2512.17 → 2690.97 (+7.12%) | 2571.48 → 3043.98 (+18.37%) | 2169.65 → 2493.93 (+14.95%) | 1692.01 → 1881.37 (+11.19%) | 115.17 → 115.16 (−0.01%)
8192/8192 | 1014.46 → 1021.24 (+0.67%) | 2511.71 → 2697.61 (+7.40%) | 2572.88 → 3038.68 (+18.10%) | 1989.24 → 2457.97 (+23.56%) | 1590.26 → 1871.92 (+17.71%) | 115.20 → 115.12 (−0.07%)





## Requirements
- Yes, I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used to help review the change and summarize benchmark results. I reviewed the final diff and can explain all code changes.