### PR TITLE
llama-vocab: validate GGUF array element types before casting

### DIFF
--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1945,6 +1945,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             // read vocab size from metadata
             uint32_t n_tokens = 0;
             if (ml.get_key(LLM_KV_VOCAB_SIZE, n_tokens, false)) {
+                if (n_tokens > (1 << 20)) {
+                    throw std::runtime_error("vocab_size is too large");
+                }
                 LLAMA_LOG_WARN("%s: adding %u dummy tokens\n", __func__, n_tokens);
                 id_to_token.resize(n_tokens);
             }
@@ -2416,6 +2419,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
         if (n_scores < n_tokens) {
             throw std::runtime_error("Index out of array bounds for scores (" + std::to_string(n_scores) + " < " + std::to_string(n_tokens) + ")\n");
         }
+        if (gguf_get_arr_type(ctx, score_idx) != GGUF_TYPE_FLOAT32) {
+            throw std::runtime_error("tokenizer.ggml.scores must be an array of FLOAT32");
+        }
         scores = (const float * ) gguf_get_arr_data(ctx, score_idx);
     }
 
@@ -2425,6 +2431,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
         const uint32_t n_toktypes = gguf_get_arr_n(ctx, toktype_idx);
         if (n_toktypes < n_tokens) {
             throw std::runtime_error("Index out of array bounds for toktypes (" + std::to_string(n_toktypes) + " < " + std::to_string(n_tokens) + ")\n");
+        }
+        if (gguf_get_arr_type(ctx, toktype_idx) != GGUF_TYPE_INT32) {
+            throw std::runtime_error("tokenizer.ggml.token_type must be an array of INT32");
         }
         toktypes = (const int * ) gguf_get_arr_data(ctx, toktype_idx);
     }
@@ -2585,6 +2594,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             const int suppress_idx = gguf_find_key(ctx, kv(LLM_KV_TOKENIZER_SUPPRESS_TOKENS).c_str());
             if (suppress_idx != -1) {
                 const int n = gguf_get_arr_n(ctx, suppress_idx);
+                if (gguf_get_arr_type(ctx, suppress_idx) != GGUF_TYPE_INT32) {
+                    throw std::runtime_error("tokenizer.ggml.suppress_tokens must be an array of INT32");
+                }
                 const int32_t * data = (const int32_t *) gguf_get_arr_data(ctx, suppress_idx);
                 // drop out-of-range ids
                 suppress_tokens.reserve(n);


### PR DESCRIPTION
Body:

Summary

GGUF tokenizer metadata arrays (tokenizer.ggml.scores, tokenizer.ggml.token_type, tokenizer.ggml.token_type / suppress_tokens) are read via gguf_get_arr_data() and then cast directly to const float * / const int32_t * without first checking the array's declared element type. gguf_get_arr_data() only returns a raw pointer into the file's backing buffer — it does not validate that the stored element type matches what the caller is about to read.

If a crafted GGUF file declares one of these arrays with a narrower element type (e.g. UINT8, 1 byte/element) but the correct element count, gguf_get_arr_n() passes as expected, yet the consuming code still strides through the buffer 4 bytes at a time. This reads roughly 3x past the end of the actual allocation — a heap out-of-bounds read triggered purely by loading a malformed model file, with no need for the file to be otherwise unusual.

Additionally, the no_vocab branch allocates vocab_size elements without an upper bound, which a crafted header can inflate arbitrarily.

Impact

A malicious/malformed GGUF file (as small as ~1.5KB) can cause an OOB heap read during model load, leading to a crash or potential information disclosure, before any inference happens. Since GGUF files are commonly downloaded from third-party sources (HF hubs, mirrors, etc.), this is a realistic remote-file attack surface, not just a local trust boundary.

Fix

Added explicit gguf_get_arr_type() checks before each cast:

tokenizer.ggml.scores → must be GGUF_TYPE_FLOAT32
tokenizer.ggml.token_type → must be GGUF_TYPE_INT32
tokenizer.ggml.suppress_tokens → must be GGUF_TYPE_INT32

Each mismatch throws a clear std::runtime_error instead of silently OOB-reading. Also added a sanity bound on vocab_size in the no_vocab path to prevent unbounded allocation from a crafted header.

~12 lines changed across 4 call sites in llama-vocab.cpp.

Testing
Built with cmake -B build && cmake --build build --target llama-cli
Reproduced the OOB read under ASan against the crafted PoC file — crash at llama-vocab.cpp:2419/2429/2588 (exact lines pre-fix)
After the fix, the same PoC file is rejected cleanly with a descriptive error instead of crashing
Verified normal, well-formed GGUF models still load and run unaffected

ASan logs and the PoC file are attached / available on request (kept out of the PR diff to avoid publishing a working crash file directly in a public repo — happy to share privately with maintainers or via a security advisory if preferred).