### PR TITLE
ui: read structuredContent from MCP tool result when content is empty

### DIFF
--- a/tools/ui/src/lib/services/mcp.service.ts
+++ b/tools/ui/src/lib/services/mcp.service.ts
@@ -18,7 +18,8 @@ import {
 	DEFAULT_CLIENT_VERSION,
 	DEFAULT_IMAGE_MIME_TYPE,
 	DEFAULT_MCP_CONFIG,
-	HEADERS
+	HEADERS,
+	NEWLINE
 } from '$lib/constants';
 import {
 	MCPConnectionPhase,
@@ -70,6 +71,7 @@ interface ToolResultContentItem {
 
 interface ToolCallResult {
 	content?: ToolResultContentItem[];
+	structuredContent?: Record<string, unknown>;
 	isError?: boolean;
 	_meta?: Record<string, unknown>;
 }
@@ -1012,10 +1014,20 @@ export class MCPService {
 
 		if (!Array.isArray(content)) return '';
 
-		return content
+		const formatted = content
 			.map((item) => this.formatSingleContent(item))
 			.filter(Boolean)
-			.join('\n');
+			.join(NEWLINE);
+
+		if (formatted !== '') {
+			return formatted;
+		}
+
+		if (result.structuredContent && typeof result.structuredContent === 'object') {
+			return JSON.stringify(result.structuredContent);
+		}
+
+		return '';
 	}
 
 	private static formatSingleContent(content: ToolResultContentItem): string {

--- a/tools/ui/src/lib/services/mcp.service.ts
+++ b/tools/ui/src/lib/services/mcp.service.ts
@@ -70,6 +70,7 @@ interface ToolResultContentItem {
 
 interface ToolCallResult {
 	content?: ToolResultContentItem[];
+	structuredContent?: Record<string, unknown>;
 	isError?: boolean;
 	_meta?: Record<string, unknown>;
 }
@@ -1003,10 +1004,20 @@ export class MCPService {
 		const content = result.content;
 		if (!Array.isArray(content)) return '';
 
-		return content
+		const formatted = content
 			.map((item) => this.formatSingleContent(item))
 			.filter(Boolean)
 			.join('\n');
+
+		if (formatted !== '') {
+			return formatted;
+		}
+
+		if (result.structuredContent && typeof result.structuredContent === 'object') {
+			return JSON.stringify(result.structuredContent);
+		}
+
+		return '';
 	}
 
 	private static formatSingleContent(content: ToolResultContentItem): string {

--- a/tools/ui/tests/unit/mcp-service.test.ts
+++ b/tools/ui/tests/unit/mcp-service.test.ts
@@ -2,7 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client';
 import { CORS_PROXY } from '$lib/constants';
 import { MCPConnectionPhase, MCPTransportType } from '$lib/enums';
 import { MCPService } from '$lib/services/mcp.service';
-import type { MCPConnectionLog, MCPServerConfig } from '$lib/types';
+import type { MCPConnection, MCPConnectionLog, MCPServerConfig } from '$lib/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 type DiagnosticFetchFactory = (
@@ -328,5 +328,22 @@ describe('MCPService', () => {
 					log.message === 'Protocol error: runtime protocol error'
 			)
 		).toHaveLength(0);
+	});
+
+	it('falls back to structuredContent when content array is empty', async () => {
+		const connection = {
+			client: {
+				callTool: vi.fn().mockResolvedValue({
+					content: [],
+					structuredContent: { accounts: [{ id: 1 }], total: 1 }
+				})
+			},
+			requestTimeoutMs: 9000,
+			serverName: 'test-server'
+		} as unknown as MCPConnection;
+		const result = await MCPService.callTool(connection, { arguments: {}, name: 'tool' });
+
+		expect(result.isError).toBe(false);
+		expect(result.content).toBe('{"accounts":[{"id":1}],"total":1}');
 	});
 });

--- a/tools/ui/tests/unit/mcp-service.test.ts
+++ b/tools/ui/tests/unit/mcp-service.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client';
 import { MCPService } from '$lib/services/mcp.service';
 import { MCPConnectionPhase, MCPTransportType } from '$lib/enums';
-import type { MCPConnectionLog, MCPServerConfig } from '$lib/types';
+import type { MCPConnectionLog, MCPServerConfig, MCPConnection } from '$lib/types';
 import { CORS_PROXY_HEADER_PREFIX } from '$lib/constants';
 
 type DiagnosticFetchFactory = (
@@ -334,5 +334,22 @@ describe('MCPService', () => {
 					log.message === 'Protocol error: runtime protocol error'
 			)
 		).toHaveLength(0);
+	});
+
+	it('falls back to structuredContent when content array is empty', async () => {
+		const connection = {
+			serverName: 'test-server',
+			requestTimeoutMs: 9000,
+			client: {
+				callTool: vi.fn().mockResolvedValue({
+					content: [],
+					structuredContent: { accounts: [{ id: 1 }], total: 1 }
+				})
+			}
+		} as unknown as MCPConnection;
+
+		const result = await MCPService.callTool(connection, { name: 'tool', arguments: {} });
+		expect(result.isError).toBe(false);
+		expect(result.content).toBe('{"accounts":[{"id":1}],"total":1}');
 	});
 });


### PR DESCRIPTION
## Overview

- MCP tool results that return an empty `content: []` array but carry real data in `structuredContent` rendered as empty in both the WebUI panel and the model's context. 
- Root cause: `formatToolResult` in `tools/ui/src/lib/services/mcp.service.ts`  only read `content` and silently dropped `structuredContent`. 
- Fix: when `content` is empty, fall back to serializing `structuredContent`. Non-empty `content` still takes priority. 
- Added a regression test (`tools/ui/tests/unit/mcp-service.test.ts`) that reproduces #26410. Fails before the fix, passes with it. 

## Additional information

Fixes #26410

- Only change in behavior is when `content` is empty and `structuredContent` is present. 
- When both fields are returned, `content` is used, since it's typically a mirror of `structuredContent`. All other behavior matches previous code. 


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used opencode to help explore and triage the issue and narrow down the  area. All code was written by me. 


