### PR TITLE
vk: detect RDNA4 (gfx1201) in ggml-vulkan; enable KHR_coopmat path

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -395,6 +395,7 @@ enum vk_device_architecture {
     AMD_RDNA1,
     AMD_RDNA2,
     AMD_RDNA3,
+    AMD_RDNA4,
     INTEL_XE1,
     INTEL_XE2,
     NVIDIA_PRE_TURING,
@@ -443,6 +444,10 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
             // RDNA
             if (shader_core_props_amd.wavefrontsPerSimd == 20) {
                 return vk_device_architecture::AMD_RDNA1;
+            }
+            // RDNA4 (gfx1201, e.g. RX 9070 XT) detection
+            if (props2.properties.deviceID == 0x1201) {
+                return vk_device_architecture::AMD_RDNA4;
             }
             if (integer_dot_props.integerDotProduct4x8BitPackedMixedSignednessAccelerated) {
                 return vk_device_architecture::AMD_RDNA3;
@@ -4085,6 +4090,15 @@ static std::vector<GpuPipelineConfig> gpu_pipeline_configs = {
         vk_device_architecture::AMD_RDNA2,
         {
             rdna2_pipelines,
+        },
+        RDNA_DEFAULT_SUBGROUP_SIZE
+    },
+    {
+        vk_device_architecture::AMD_RDNA4,
+        {
+            // RDNA4 (gfx1201) has KHR_coopmat support similar to RDNA3.
+            // Use default subgroup size (32) which is the hardware-native wave width.
+            // Per-pipeline overrides can be added here as needed.
         },
         RDNA_DEFAULT_SUBGROUP_SIZE
     },
@@ -18793,8 +18807,10 @@ static bool ggml_vk_khr_cooperative_matrix_support(const vk::PhysicalDevicePrope
             (arch == vk_device_architecture::INTEL_XE1 && props.deviceType == vk::PhysicalDeviceType::eIntegratedGpu && driver_props.driverID == vk::DriverId::eIntelProprietaryWindows);
     case VK_VENDOR_ID_AMD:
         if (driver_props.driverID == vk::DriverId::eAmdProprietary || driver_props.driverID == vk::DriverId::eAmdOpenSource) {
-            // Workaround for AMD proprietary driver reporting support on all GPUs
-            return arch == vk_device_architecture::AMD_RDNA3;
+            // Workaround for AMD proprietary driver reporting support on all GPUs.
+            // Include RDNA4 (gfx1201) alongside RDNA3 — both have functional KHR_coopmat
+            // support on RDNA, while older architectures (GCN/RDNA1/RDNA2) do not.
+            return arch == vk_device_architecture::AMD_RDNA3 || arch == vk_device_architecture::AMD_RDNA4;
         }
         return true;
     default:


### PR DESCRIPTION
## Overview

Detect **RDNA4 (gfx1201, e.g. RX 9070 XT)** in `ggml-vulkan` architecture detection and enable KHR_cooperative_matrix for it. RDNA4 is currently misidentified as RDNA2 because no RDNA4 branch exists in `get_device_architecture()`. The fix is a +18/-2 diff in one file (`ggml/src/ggml-vulkan/ggml-vulkan.cpp`).

### Why

Per [llama.cpp #26663](https://github.com/ggml-org/llama.cpp/issues/26663), users observed pathological performance with `hidden_size >= 4096` models on RDNA4. Three linked bugs:

1. `get_device_architecture()` (L439-L451) has no RDNA4 branch. RDNA4 matches the RDNA ladder (`maxSubgroupSize=64, minSubgroupSize=32`) but its `integerDotProduct4x8BitPackedMixedSignednessAccelerated` differs from RDNA3, so it falls through to `AMD_RDNA2` at L450.
2. `ggml_vk_khr_cooperative_matrix_support()` (L18797) whitelists only `AMD_RDNA3` (workaround for AMD proprietary driver coopmat false-positive reporting). The misdetected RDNA4 therefore loses the KHR_coopmat path entirely.
3. `gpu_pipeline_configs` (L4076-L4091) only lists RDNA1 and RDNA2. `get_subgroup_size()` returns 0 for RDNA4, callers fall back to driver-reported `subgroupSize` (64 on RDNA4) instead of the hardware-native wave32.

### Changes

- Add `AMD_RDNA4` to the `vk_device_architecture` enum.
- Detect RDNA4 by `props2.properties.deviceID == 0x1201` in `get_device_architecture()`, returning it before the RDNA2 fallthrough.
- Add an RDNA4 entry to `gpu_pipeline_configs` with `RDNA_DEFAULT_SUBGROUP_SIZE = 32` (hardware-native wave width).
- Update `ggml_vk_khr_cooperative_matrix_support()` to whitelist both `AMD_RDNA3` and `AMD_RDNA4`.

## Additional information

- Diagnostic bundle (4-model benchmark, per-op profile, full ROOT_CAUSE analysis): https://github.com/66666kbit/vulkan-slowpath-rx9070xt
- Reproduction data covers b10298 and was cross-checked against current `master` — the RDNA4 detection is also missing in current `master` (commits `fc3f10b3` and earlier), so this patch is relevant on top of `master` as well.
- The fix is mechanical (4 conditional additions); CI build is the primary verification path since the local environment did not have a working Vulkan SDK + clang setup.
- Closes #26663

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — an AI assistant (Mavis, running under the PR author's direction) helped with the diagnostic analysis, code patch drafting, and PR description. All changes were reviewed and approved by the PR author (`66666kbit`) before submission. The PR author is responsible for all submitted changes per `CONTRIBUTING.md` and `AGENTS.md`.
