### PR TITLE
CUDA: branchless Q4_K/Q5_K unpack to speed up mmvq, L2 prefetch on DGX Spark

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -969,6 +969,7 @@ template<>
 struct ggml_cuda_type_traits<GGML_TYPE_F16> {
     static constexpr int qk = 1;
     static constexpr int qr = 1;
+    static constexpr int block_size = sizeof(ggml_half);
 };
 
 template<>
@@ -976,6 +977,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q1_0> {
     static constexpr int qk = QK1_0;
     static constexpr int qr = QR1_0;
     static constexpr int qi = QI1_0;
+    static constexpr int block_size = sizeof(block_q1_0);
 };
 
 template<>
@@ -983,6 +985,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q2_0> {
     static constexpr int qk = QK2_0;
     static constexpr int qr = QR2_0;
     static constexpr int qi = QI2_0;
+    static constexpr int block_size = sizeof(block_q2_0);
 };
 
 template<>
@@ -990,6 +993,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q4_0> {
     static constexpr int qk = QK4_0;
     static constexpr int qr = QR4_0;
     static constexpr int qi = QI4_0;
+    static constexpr int block_size = sizeof(block_q4_0);
 };
 
 template<>
@@ -997,6 +1001,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q4_1> {
     static constexpr int qk = QK4_1;
     static constexpr int qr = QR4_1;
     static constexpr int qi = QI4_1;
+    static constexpr int block_size = sizeof(block_q4_1);
 };
 
 template<>
@@ -1004,6 +1009,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q5_0> {
     static constexpr int qk = QK5_0;
     static constexpr int qr = QR5_0;
     static constexpr int qi = QI5_0;
+    static constexpr int block_size = sizeof(block_q5_0);
 };
 
 template<>
@@ -1011,6 +1017,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q5_1> {
     static constexpr int qk = QK5_1;
     static constexpr int qr = QR5_1;
     static constexpr int qi = QI5_1;
+    static constexpr int block_size = sizeof(block_q5_1);
 };
 
 template<>
@@ -1018,6 +1025,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q8_0> {
     static constexpr int qk = QK8_0;
     static constexpr int qr = QR8_0;
     static constexpr int qi = QI8_0;
+    static constexpr int block_size = sizeof(block_q8_0);
 };
 
 template<>
@@ -1025,6 +1033,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_MXFP4> {
     static constexpr int qk = QK_MXFP4;
     static constexpr int qr = QR_MXFP4;
     static constexpr int qi = QI_MXFP4;
+    static constexpr int block_size = sizeof(block_mxfp4);
 };
 
 template<>
@@ -1032,6 +1041,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_NVFP4> {
     static constexpr int qk = QK_NVFP4;
     static constexpr int qr = QR_NVFP4;
     static constexpr int qi = QI_NVFP4;
+    static constexpr int block_size = sizeof(block_nvfp4);
 };
 
 template<>
@@ -1039,6 +1049,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q2_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_K;
     static constexpr int qi = QI2_K;
+    static constexpr int block_size = sizeof(block_q2_K);
 };
 
 template<>
@@ -1046,6 +1057,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q3_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR3_K;
     static constexpr int qi = QI3_K;
+    static constexpr int block_size = sizeof(block_q3_K);
 };
 
 template<>
@@ -1053,6 +1065,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q4_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR4_K;
     static constexpr int qi = QI4_K;
+    static constexpr int block_size = sizeof(block_q4_K);
 };
 
 template<>
@@ -1060,6 +1073,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q5_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR5_K;
     static constexpr int qi = QI5_K;
+    static constexpr int block_size = sizeof(block_q5_K);
 };
 
 template<>
@@ -1067,6 +1081,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q6_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR6_K;
     static constexpr int qi = QI6_K;
+    static constexpr int block_size = sizeof(block_q6_K);
 };
 
 template<>
@@ -1074,6 +1089,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ2_XXS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_XXS;
     static constexpr int qi = QI2_XXS;
+    static constexpr int block_size = sizeof(block_iq2_xxs);
 };
 
 template<>
@@ -1081,6 +1097,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ2_XS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_XS;
     static constexpr int qi = QI2_XS;
+    static constexpr int block_size = sizeof(block_iq2_xs);
 };
 
 template<>
@@ -1088,6 +1105,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ2_S> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_S;
     static constexpr int qi = QI2_S;
+    static constexpr int block_size = sizeof(block_iq2_s);
 };
 
 template<>
@@ -1095,6 +1113,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ3_XXS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR3_XXS;
     static constexpr int qi = QI3_XXS;
+    static constexpr int block_size = sizeof(block_iq3_xxs);
 };
 
 template<>
@@ -1102,6 +1121,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ1_S> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR1_S;
     static constexpr int qi = QI1_S;
+    static constexpr int block_size = sizeof(block_iq1_s);
 };
 
 template<>
@@ -1109,6 +1129,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ1_M> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR1_M;
     static constexpr int qi = QI1_M;
+    static constexpr int block_size = sizeof(block_iq1_m);
 };
 
 template<>
@@ -1116,6 +1137,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ4_NL> {
     static constexpr int qk = QK4_NL;
     static constexpr int qr = QR4_NL;
     static constexpr int qi = QI4_NL;
+    static constexpr int block_size = sizeof(block_iq4_nl);
 };
 
 template<>
@@ -1123,6 +1145,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ4_XS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR4_XS;
     static constexpr int qi = QI4_XS;
+    static constexpr int block_size = sizeof(block_iq4_xs);
 };
 
 template<>
@@ -1130,6 +1153,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ3_S> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR3_S;
     static constexpr int qi = QI3_S;
+    static constexpr int block_size = sizeof(block_iq3_s);
 };
 
 //////////////////////

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -969,7 +969,7 @@ template<>
 struct ggml_cuda_type_traits<GGML_TYPE_F16> {
     static constexpr int qk = 1;
     static constexpr int qr = 1;
-    static constexpr int block_size = sizeof(ggml_half);
+    static constexpr int bs = sizeof(ggml_half);
 };
 
 template<>
@@ -977,7 +977,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q1_0> {
     static constexpr int qk = QK1_0;
     static constexpr int qr = QR1_0;
     static constexpr int qi = QI1_0;
-    static constexpr int block_size = sizeof(block_q1_0);
+    static constexpr int bs = sizeof(block_q1_0);
 };
 
 template<>
@@ -985,7 +985,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q2_0> {
     static constexpr int qk = QK2_0;
     static constexpr int qr = QR2_0;
     static constexpr int qi = QI2_0;
-    static constexpr int block_size = sizeof(block_q2_0);
+    static constexpr int bs = sizeof(block_q2_0);
 };
 
 template<>
@@ -993,7 +993,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q4_0> {
     static constexpr int qk = QK4_0;
     static constexpr int qr = QR4_0;
     static constexpr int qi = QI4_0;
-    static constexpr int block_size = sizeof(block_q4_0);
+    static constexpr int bs = sizeof(block_q4_0);
 };
 
 template<>
@@ -1001,7 +1001,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q4_1> {
     static constexpr int qk = QK4_1;
     static constexpr int qr = QR4_1;
     static constexpr int qi = QI4_1;
-    static constexpr int block_size = sizeof(block_q4_1);
+    static constexpr int bs = sizeof(block_q4_1);
 };
 
 template<>
@@ -1009,7 +1009,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q5_0> {
     static constexpr int qk = QK5_0;
     static constexpr int qr = QR5_0;
     static constexpr int qi = QI5_0;
-    static constexpr int block_size = sizeof(block_q5_0);
+    static constexpr int bs = sizeof(block_q5_0);
 };
 
 template<>
@@ -1017,7 +1017,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q5_1> {
     static constexpr int qk = QK5_1;
     static constexpr int qr = QR5_1;
     static constexpr int qi = QI5_1;
-    static constexpr int block_size = sizeof(block_q5_1);
+    static constexpr int bs = sizeof(block_q5_1);
 };
 
 template<>
@@ -1025,7 +1025,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q8_0> {
     static constexpr int qk = QK8_0;
     static constexpr int qr = QR8_0;
     static constexpr int qi = QI8_0;
-    static constexpr int block_size = sizeof(block_q8_0);
+    static constexpr int bs = sizeof(block_q8_0);
 };
 
 template<>
@@ -1033,7 +1033,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_MXFP4> {
     static constexpr int qk = QK_MXFP4;
     static constexpr int qr = QR_MXFP4;
     static constexpr int qi = QI_MXFP4;
-    static constexpr int block_size = sizeof(block_mxfp4);
+    static constexpr int bs = sizeof(block_mxfp4);
 };
 
 template<>
@@ -1041,7 +1041,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_NVFP4> {
     static constexpr int qk = QK_NVFP4;
     static constexpr int qr = QR_NVFP4;
     static constexpr int qi = QI_NVFP4;
-    static constexpr int block_size = sizeof(block_nvfp4);
+    static constexpr int bs = sizeof(block_nvfp4);
 };
 
 template<>
@@ -1049,7 +1049,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q2_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_K;
     static constexpr int qi = QI2_K;
-    static constexpr int block_size = sizeof(block_q2_K);
+    static constexpr int bs = sizeof(block_q2_K);
 };
 
 template<>
@@ -1057,7 +1057,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q3_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR3_K;
     static constexpr int qi = QI3_K;
-    static constexpr int block_size = sizeof(block_q3_K);
+    static constexpr int bs = sizeof(block_q3_K);
 };
 
 template<>
@@ -1065,7 +1065,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q4_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR4_K;
     static constexpr int qi = QI4_K;
-    static constexpr int block_size = sizeof(block_q4_K);
+    static constexpr int bs = sizeof(block_q4_K);
 };
 
 template<>
@@ -1073,7 +1073,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q5_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR5_K;
     static constexpr int qi = QI5_K;
-    static constexpr int block_size = sizeof(block_q5_K);
+    static constexpr int bs = sizeof(block_q5_K);
 };
 
 template<>
@@ -1081,7 +1081,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_Q6_K> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR6_K;
     static constexpr int qi = QI6_K;
-    static constexpr int block_size = sizeof(block_q6_K);
+    static constexpr int bs = sizeof(block_q6_K);
 };
 
 template<>
@@ -1089,7 +1089,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ2_XXS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_XXS;
     static constexpr int qi = QI2_XXS;
-    static constexpr int block_size = sizeof(block_iq2_xxs);
+    static constexpr int bs = sizeof(block_iq2_xxs);
 };
 
 template<>
@@ -1097,7 +1097,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ2_XS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_XS;
     static constexpr int qi = QI2_XS;
-    static constexpr int block_size = sizeof(block_iq2_xs);
+    static constexpr int bs = sizeof(block_iq2_xs);
 };
 
 template<>
@@ -1105,7 +1105,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ2_S> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR2_S;
     static constexpr int qi = QI2_S;
-    static constexpr int block_size = sizeof(block_iq2_s);
+    static constexpr int bs = sizeof(block_iq2_s);
 };
 
 template<>
@@ -1113,7 +1113,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ3_XXS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR3_XXS;
     static constexpr int qi = QI3_XXS;
-    static constexpr int block_size = sizeof(block_iq3_xxs);
+    static constexpr int bs = sizeof(block_iq3_xxs);
 };
 
 template<>
@@ -1121,7 +1121,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ1_S> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR1_S;
     static constexpr int qi = QI1_S;
-    static constexpr int block_size = sizeof(block_iq1_s);
+    static constexpr int bs = sizeof(block_iq1_s);
 };
 
 template<>
@@ -1129,7 +1129,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ1_M> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR1_M;
     static constexpr int qi = QI1_M;
-    static constexpr int block_size = sizeof(block_iq1_m);
+    static constexpr int bs = sizeof(block_iq1_m);
 };
 
 template<>
@@ -1137,7 +1137,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ4_NL> {
     static constexpr int qk = QK4_NL;
     static constexpr int qr = QR4_NL;
     static constexpr int qi = QI4_NL;
-    static constexpr int block_size = sizeof(block_iq4_nl);
+    static constexpr int bs = sizeof(block_iq4_nl);
 };
 
 template<>
@@ -1145,7 +1145,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ4_XS> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR4_XS;
     static constexpr int qi = QI4_XS;
-    static constexpr int block_size = sizeof(block_iq4_xs);
+    static constexpr int bs = sizeof(block_iq4_xs);
 };
 
 template<>
@@ -1153,7 +1153,7 @@ struct ggml_cuda_type_traits<GGML_TYPE_IQ3_S> {
     static constexpr int qk = QK_K;
     static constexpr int qr = QR3_S;
     static constexpr int qi = QI3_S;
-    static constexpr int block_size = sizeof(block_iq3_s);
+    static constexpr int bs = sizeof(block_iq3_s);
 };
 
 //////////////////////

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -315,7 +315,6 @@ bool ggml_cuda_should_use_mmvq(enum ggml_type type, int cc, int64_t ne11) {
                 return ne11 <= 4;
             case GGML_TYPE_Q3_K:
                 return ne11 <= 6;
-            // branchless unpack pushes Q4_K and Q5_K past the cap, so they now take the default
             default:
                 return ne11 <= MMVQ_MAX_BATCH_SIZE;
         }
@@ -326,7 +325,6 @@ bool ggml_cuda_should_use_mmvq(enum ggml_type type, int cc, int64_t ne11) {
             case GGML_TYPE_Q3_K:
             case GGML_TYPE_Q4_K:
                 return ne11 <= 5;
-            // branchless unpack pushes this one out by one
             case GGML_TYPE_Q5_K:
                 return ne11 <= 6;
             case GGML_TYPE_Q6_K:

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -324,9 +324,9 @@ bool ggml_cuda_should_use_mmvq(enum ggml_type type, int cc, int64_t ne11) {
         switch (type) { // tuned on RTX 5090
             case GGML_TYPE_Q2_K:
             case GGML_TYPE_Q3_K:
-                return ne11 <= 5;
-            // branchless unpack pushes these two out by one
             case GGML_TYPE_Q4_K:
+                return ne11 <= 5;
+            // branchless unpack pushes this one out by one
             case GGML_TYPE_Q5_K:
                 return ne11 <= 6;
             case GGML_TYPE_Q6_K:

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -6,6 +6,25 @@
 #include <cstdint>
 #include <type_traits>
 
+// block size in bytes; 0 compiles the prefetch out for that type
+template <ggml_type type> struct mmvq_pf { static constexpr int bytes = 0; };
+template <> struct mmvq_pf<GGML_TYPE_Q4_0>   { static constexpr int bytes = sizeof(block_q4_0);   };
+template <> struct mmvq_pf<GGML_TYPE_Q8_0>   { static constexpr int bytes = sizeof(block_q8_0);   };
+template <> struct mmvq_pf<GGML_TYPE_Q3_K>   { static constexpr int bytes = sizeof(block_q3_K);   };
+template <> struct mmvq_pf<GGML_TYPE_Q4_K>   { static constexpr int bytes = sizeof(block_q4_K);   };
+template <> struct mmvq_pf<GGML_TYPE_Q5_K>   { static constexpr int bytes = sizeof(block_q5_K);   };
+template <> struct mmvq_pf<GGML_TYPE_Q6_K>   { static constexpr int bytes = sizeof(block_q6_K);   };
+template <> struct mmvq_pf<GGML_TYPE_IQ4_XS> { static constexpr int bytes = sizeof(block_iq4_xs); };
+// Q2_K is left out: prefetching does not raise its L2 hit rate, so the requests only add pressure
+
+static __device__ __forceinline__ void mmvq_prefetch_l2(const void * p) {
+#if !defined(GGML_USE_HIP)
+    asm volatile("prefetch.global.L2 [%0];" :: "l"(p));
+#else
+    GGML_UNUSED(p);
+#endif
+}
+
 typedef float (*vec_dot_q_cuda_t)(const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs);
 
 static constexpr __device__ vec_dot_q_cuda_t get_vec_dot_q_cuda(ggml_type type) {
@@ -298,9 +317,7 @@ bool ggml_cuda_should_use_mmvq(enum ggml_type type, int cc, int64_t ne11) {
                 return ne11 <= 4;
             case GGML_TYPE_Q3_K:
                 return ne11 <= 6;
-            case GGML_TYPE_Q4_K:
-            case GGML_TYPE_Q5_K:
-                return ne11 <= 7;
+            // branchless unpack pushes Q4_K and Q5_K past the cap, so they now take the default
             default:
                 return ne11 <= MMVQ_MAX_BATCH_SIZE;
         }
@@ -309,9 +326,11 @@ bool ggml_cuda_should_use_mmvq(enum ggml_type type, int cc, int64_t ne11) {
         switch (type) { // tuned on RTX 5090
             case GGML_TYPE_Q2_K:
             case GGML_TYPE_Q3_K:
+                return ne11 <= 5;
+            // branchless unpack pushes these two out by one
             case GGML_TYPE_Q4_K:
             case GGML_TYPE_Q5_K:
-                return ne11 <= 5;
+                return ne11 <= 6;
             case GGML_TYPE_Q6_K:
                 return ne11 <= 7;
             default:
@@ -662,6 +681,27 @@ static __global__ void mul_mat_vec_q(
 
         // x block quant index when casting the quants to int
         const int kqs = vdr * (tid % (qi/vdr));
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
+        // start the next iterations' weight loads early. only pays where the kernel is
+        // latency-bound rather than bandwidth-bound, which on this part it is
+        if constexpr (mmvq_pf<type>::bytes > 0) {
+            constexpr int pf_dist = 2; // loop iterations, not blocks
+            const int kbx_pf = kbx + pf_dist*blocks_per_iter;
+            if (kbx_pf < blocks_per_row_x) {
+#pragma unroll
+                for (int i = 0; i < rows_per_cuda_block; ++i) {
+                    const size_t off = (size_t)(kbx_offset + i*stride_row_x + kbx_pf) * mmvq_pf<type>::bytes;
+                    mmvq_prefetch_l2((const char *) vx + off);
+                    if constexpr (has_fusion) {
+                        if (use_gate) {
+                            mmvq_prefetch_l2((const char *) vgate + off);
+                        }
+                    }
+                }
+            }
+        }
+#endif
 
 #pragma unroll
         for (int j = 0; j < ncols_dst; ++j) {

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -18,7 +18,7 @@ template <> struct mmvq_pf<GGML_TYPE_IQ4_XS> { static constexpr int bytes = size
 // Q2_K is left out: prefetching does not raise its L2 hit rate, so the requests only add pressure
 
 static __device__ __forceinline__ void mmvq_prefetch_l2(const void * p) {
-#if !defined(GGML_USE_HIP)
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
     asm volatile("prefetch.global.L2 [%0];" :: "l"(p));
 #else
     GGML_UNUSED(p);

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -17,13 +17,11 @@ template <> struct mmvq_pf<GGML_TYPE_Q6_K>   { static constexpr int bytes = size
 template <> struct mmvq_pf<GGML_TYPE_IQ4_XS> { static constexpr int bytes = sizeof(block_iq4_xs); };
 // Q2_K is left out: prefetching does not raise its L2 hit rate, so the requests only add pressure
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
 static __device__ __forceinline__ void mmvq_prefetch_l2(const void * p) {
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
     asm volatile("prefetch.global.L2 [%0];" :: "l"(p));
-#else
-    GGML_UNUSED(p);
-#endif
 }
+#endif
 
 typedef float (*vec_dot_q_cuda_t)(const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs);
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -698,7 +698,7 @@ static __global__ void mul_mat_vec_q(
             if (kbx_pf < blocks_per_row_x) {
 #pragma unroll
                 for (int i = 0; i < rows_per_cuda_block; ++i) {
-                    const size_t off = (size_t)(kbx_offset + i*stride_row_x + kbx_pf) * ggml_cuda_type_traits<type>::block_size;
+                    const size_t off = (size_t)(kbx_offset + i*stride_row_x + kbx_pf) * ggml_cuda_type_traits<type>::bs;
                     mmvq_prefetch_l2((const char *) vx + off);
                     if constexpr (has_fusion) {
                         if (use_gate) {

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -6,17 +6,29 @@
 #include <cstdint>
 #include <type_traits>
 
-// block size in bytes; 0 compiles the prefetch out for that type
-template <ggml_type type> struct mmvq_pf { static constexpr int bytes = 0; };
-template <> struct mmvq_pf<GGML_TYPE_Q4_0>   { static constexpr int bytes = sizeof(block_q4_0);   };
-template <> struct mmvq_pf<GGML_TYPE_Q8_0>   { static constexpr int bytes = sizeof(block_q8_0);   };
-template <> struct mmvq_pf<GGML_TYPE_Q3_K>   { static constexpr int bytes = sizeof(block_q3_K);   };
-template <> struct mmvq_pf<GGML_TYPE_Q4_K>   { static constexpr int bytes = sizeof(block_q4_K);   };
-template <> struct mmvq_pf<GGML_TYPE_Q5_K>   { static constexpr int bytes = sizeof(block_q5_K);   };
-template <> struct mmvq_pf<GGML_TYPE_Q6_K>   { static constexpr int bytes = sizeof(block_q6_K);   };
-template <> struct mmvq_pf<GGML_TYPE_IQ4_XS> { static constexpr int bytes = sizeof(block_iq4_xs); };
-// Q2_K is left out: prefetching does not raise its L2 hit rate, so the requests only add pressure
+// returns true only for those quants that benefit from prefetch and false otherwise
+static constexpr __host__ __device__ bool mmvq_should_prefetch(ggml_type type) {
+    switch (type) {
+        case GGML_TYPE_Q4_0:
+        case GGML_TYPE_Q5_0:
+        case GGML_TYPE_Q8_0:
+        case GGML_TYPE_MXFP4:
+        case GGML_TYPE_Q3_K:
+        case GGML_TYPE_Q4_K:
+        case GGML_TYPE_Q5_K:
+        case GGML_TYPE_Q6_K:
+        case GGML_TYPE_IQ1_M:
+        case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_IQ4_XS:
+            return true;
+        default:
+            return false;
+    }
+}
 
+// only enabled on DGX Spark, where it is a gain on every type above. On the higher-bandwidth parts the kernel
+// has little exposed latency left to hide and the extra requests cost more than they save.
+// For perf data, see https://github.com/ggml-org/llama.cpp/pull/26705#issuecomment-5569335031
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
 static __device__ __forceinline__ void mmvq_prefetch_l2(const void * p) {
     asm volatile("prefetch.global.L2 [%0];" :: "l"(p));
@@ -679,15 +691,14 @@ static __global__ void mul_mat_vec_q(
         const int kqs = vdr * (tid % (qi/vdr));
 
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
-        // start the next iterations' weight loads early. only pays where the kernel is
-        // latency-bound rather than bandwidth-bound, which on this part it is
-        if constexpr (mmvq_pf<type>::bytes > 0) {
+        // start the next iterations' weight loads early
+        if constexpr (mmvq_should_prefetch(type)) {
             constexpr int pf_dist = 2; // loop iterations, not blocks
             const int kbx_pf = kbx + pf_dist*blocks_per_iter;
             if (kbx_pf < blocks_per_row_x) {
 #pragma unroll
                 for (int i = 0; i < rows_per_cuda_block; ++i) {
-                    const size_t off = (size_t)(kbx_offset + i*stride_row_x + kbx_pf) * mmvq_pf<type>::bytes;
+                    const size_t off = (size_t)(kbx_offset + i*stride_row_x + kbx_pf) * ggml_cuda_type_traits<type>::block_size;
                     mmvq_prefetch_l2((const char *) vx + off);
                     if constexpr (has_fusion) {
                         if (use_gate) {

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -6,6 +6,10 @@
 #include <cstdint>
 #include <type_traits>
 
+// only enabled on DGX Spark, where it is a gain on every type below. On the higher-bandwidth parts the kernel
+// has little exposed latency left to hide and the extra requests cost more than they save.
+// For perf data, see https://github.com/ggml-org/llama.cpp/pull/26705#issuecomment-5569335031
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
 // returns true only for those quants that benefit from prefetch and false otherwise
 static constexpr __host__ __device__ bool mmvq_should_prefetch(ggml_type type) {
     switch (type) {
@@ -26,10 +30,6 @@ static constexpr __host__ __device__ bool mmvq_should_prefetch(ggml_type type) {
     }
 }
 
-// only enabled on DGX Spark, where it is a gain on every type above. On the higher-bandwidth parts the kernel
-// has little exposed latency left to hide and the extra requests cost more than they save.
-// For perf data, see https://github.com/ggml-org/llama.cpp/pull/26705#issuecomment-5569335031
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
 static __device__ __forceinline__ void mmvq_prefetch_l2(const void * p) {
     asm volatile("prefetch.global.L2 [%0];" :: "l"(p));
 }

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -928,16 +928,20 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1(
     v[0] = q4[0];
     v[1] = q4[4];
 
+    // branchless so nvcc can hoist this out of the ncols_dst loop
     const uint16_t * scales = (const uint16_t *)bq4_K->scales;
+    const int j  = bq8_offset/2;
+    const int jm = j & 1;
+
+    const uint32_t s0 = scales[jm + 0];
+    const uint32_t s2 = scales[jm + 2];
+    const uint32_t s4 = scales[jm + 4];
+
+    const uint32_t hi = (uint32_t) -(int32_t) (j >= 2);
+
     uint16_t aux[2];
-    const int j = bq8_offset/2;
-    if (j < 2) {
-        aux[0] = scales[j+0] & 0x3f3f;
-        aux[1] = scales[j+2] & 0x3f3f;
-    } else {
-        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
-        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
-    }
+    aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
+    aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 
@@ -973,16 +977,20 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1(
     vh[0] = qh[0] >> bq8_offset;
     vh[1] = qh[4] >> bq8_offset;
 
+    // same as q4_K
     const uint16_t * scales = (const uint16_t *)bq5_K->scales;
+    const int j  = bq8_offset/2;
+    const int jm = j & 1;
+
+    const uint32_t s0 = scales[jm + 0];
+    const uint32_t s2 = scales[jm + 2];
+    const uint32_t s4 = scales[jm + 4];
+
+    const uint32_t hi = (uint32_t) -(int32_t) (j >= 2);
+
     uint16_t aux[2];
-    const int j = bq8_offset/2;
-    if (j < 2) {
-        aux[0] = scales[j+0] & 0x3f3f;
-        aux[1] = scales[j+2] & 0x3f3f;
-    } else {
-        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
-        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
-    }
+    aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
+    aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -936,6 +936,19 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1(
     v[0] = q4[0];
     v[1] = q4[4];
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
+    // latency-bound here, the repeated unpack covers load latency so hoisting it loses
+    const uint16_t * scales = (const uint16_t *)bq4_K->scales;
+    uint16_t aux[2];
+    const int j = bq8_offset/2;
+    if (j < 2) {
+        aux[0] = scales[j+0] & 0x3f3f;
+        aux[1] = scales[j+2] & 0x3f3f;
+    } else {
+        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
+        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
+    }
+#else
     // branchless so nvcc can hoist this out of the ncols_dst loop
     const uint16_t * scales = (const uint16_t *)bq4_K->scales;
     const int j  = bq8_offset/2;
@@ -950,6 +963,7 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1(
     uint16_t aux[2];
     aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
     aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
+#endif
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 
@@ -985,6 +999,19 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1(
     vh[0] = qh[0] >> bq8_offset;
     vh[1] = qh[4] >> bq8_offset;
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
+    // same as q4_K
+    const uint16_t * scales = (const uint16_t *)bq5_K->scales;
+    uint16_t aux[2];
+    const int j = bq8_offset/2;
+    if (j < 2) {
+        aux[0] = scales[j+0] & 0x3f3f;
+        aux[1] = scales[j+2] & 0x3f3f;
+    } else {
+        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
+        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
+    }
+#else
     // same as q4_K
     const uint16_t * scales = (const uint16_t *)bq5_K->scales;
     const int j  = bq8_offset/2;
@@ -999,6 +1026,7 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1(
     uint16_t aux[2];
     aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
     aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
+#endif
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -936,16 +936,20 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1(
     v[0] = q4[0];
     v[1] = q4[4];
 
+    // branchless so nvcc can hoist this out of the ncols_dst loop
     const uint16_t * scales = (const uint16_t *)bq4_K->scales;
+    const int j  = bq8_offset/2;
+    const int jm = j & 1;
+
+    const uint32_t s0 = scales[jm + 0];
+    const uint32_t s2 = scales[jm + 2];
+    const uint32_t s4 = scales[jm + 4];
+
+    const uint32_t hi = (uint32_t) -(int32_t) (j >= 2);
+
     uint16_t aux[2];
-    const int j = bq8_offset/2;
-    if (j < 2) {
-        aux[0] = scales[j+0] & 0x3f3f;
-        aux[1] = scales[j+2] & 0x3f3f;
-    } else {
-        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
-        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
-    }
+    aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
+    aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 
@@ -981,16 +985,20 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1(
     vh[0] = qh[0] >> bq8_offset;
     vh[1] = qh[4] >> bq8_offset;
 
+    // same as q4_K
     const uint16_t * scales = (const uint16_t *)bq5_K->scales;
+    const int j  = bq8_offset/2;
+    const int jm = j & 1;
+
+    const uint32_t s0 = scales[jm + 0];
+    const uint32_t s2 = scales[jm + 2];
+    const uint32_t s4 = scales[jm + 4];
+
+    const uint32_t hi = (uint32_t) -(int32_t) (j >= 2);
+
     uint16_t aux[2];
-    const int j = bq8_offset/2;
-    if (j < 2) {
-        aux[0] = scales[j+0] & 0x3f3f;
-        aux[1] = scales[j+2] & 0x3f3f;
-    } else {
-        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
-        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
-    }
+    aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
+    aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -936,19 +936,6 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1(
     v[0] = q4[0];
     v[1] = q4[4];
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
-    // latency-bound here, the repeated unpack covers load latency so hoisting it loses
-    const uint16_t * scales = (const uint16_t *)bq4_K->scales;
-    uint16_t aux[2];
-    const int j = bq8_offset/2;
-    if (j < 2) {
-        aux[0] = scales[j+0] & 0x3f3f;
-        aux[1] = scales[j+2] & 0x3f3f;
-    } else {
-        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
-        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
-    }
-#else
     // branchless so nvcc can hoist this out of the ncols_dst loop
     const uint16_t * scales = (const uint16_t *)bq4_K->scales;
     const int j  = bq8_offset/2;
@@ -963,7 +950,6 @@ static __device__ __forceinline__ float vec_dot_q4_K_q8_1(
     uint16_t aux[2];
     aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
     aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
-#endif
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 
@@ -999,19 +985,6 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1(
     vh[0] = qh[0] >> bq8_offset;
     vh[1] = qh[4] >> bq8_offset;
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == GGML_CUDA_CC_DGX_SPARK
-    // same as q4_K
-    const uint16_t * scales = (const uint16_t *)bq5_K->scales;
-    uint16_t aux[2];
-    const int j = bq8_offset/2;
-    if (j < 2) {
-        aux[0] = scales[j+0] & 0x3f3f;
-        aux[1] = scales[j+2] & 0x3f3f;
-    } else {
-        aux[0] = ((scales[j+2] >> 0) & 0x0f0f) | ((scales[j-2] & 0xc0c0) >> 2);
-        aux[1] = ((scales[j+2] >> 4) & 0x0f0f) | ((scales[j-0] & 0xc0c0) >> 2);
-    }
-#else
     // same as q4_K
     const uint16_t * scales = (const uint16_t *)bq5_K->scales;
     const int j  = bq8_offset/2;
@@ -1026,7 +999,7 @@ static __device__ __forceinline__ float vec_dot_q5_K_q8_1(
     uint16_t aux[2];
     aux[0] = (uint16_t) (((s0 & 0x3f3f) & ~hi) | ((((s4 >> 0) & 0x0f0f) | ((s0 & 0xc0c0) >> 2)) & hi));
     aux[1] = (uint16_t) (((s2 & 0x3f3f) & ~hi) | ((((s4 >> 4) & 0x0f0f) | ((s2 & 0xc0c0) >> 2)) & hi));
-#endif
+
     const uint8_t * sc = (const uint8_t *)aux;
     const uint8_t * m  = sc + 2;
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

The Q4_K/Q5_K scale unpack branches on a runtime value to pick between two layouts. nvcc can't fold that, so it predicates it and then repeats the whole thing for every column of the ncols_dst loop instead of doing it once. Swapping the branch for a mask select fixes it: predicated instructions at ncols_dst=8 go from 226 to 34, and the Q4_K kernel at 16 columns from 2256 to 1648. None of the other quant types have this problem, they already unpack unconditionally (Q3_K does the same 6-bit layout with plain shifts).

We see perf gains from batch size >=4 on RTX 5090 and >=5 on RTX 4090 (more details in the Performance drop down), however we do not see a gain with DGX Spark with branchless alone, and in fact a small regression at batch sizes 4-6. The most probable reason for this can be that the memory bandwidth on DGX Spark is much lower than that of RTX 4090 or 5090, and this means even with this optimization there is no effective time to save, since in the original code the unpack was already running while the kernel waits on the weight loads and so was not adding to the total time.

To avoid this dip and ensure an overall gain, we make Spark use prefetch. This in our results ensured increased decode throughput across several quant types which can be evident from the performance numbers below. Prefetch while improving decode throughput on DGX Spark, seemed to negatively contributed in case of GPUs with larger bandwidth like RTX 5090. 
We analyzed ncu traces with prefetch enabled on RTX 5090, profiling Q8_0 on Llama-3.1-8B across ne11 1-8, with Q2_K as a control:

- The prefetch does what it is intended to do:  long_scoreboard drops on both parts.
- However, each prefetch.global.L2 is still a global memory instruction taking an LSU slot and a queue entry, so lg_throttle goes up with it.
- Spark has much more latency to hide in the first place, and long_scoreboard runs 1.5-2.3x higher at every ne11. It pays more queue pressure than the 5090 does, but it has enough to convert to cover it.
- Larger ne11 kills the benefit but not the cost. Each weight gets reused across more columns, so the kernel stops being latency-bound (long_scoreboard 41.2 -> 7.9 on the 5090 going from ne11 1 to 8), while the prefetch still issues the same requests per loop iteration.
- By ne11=8 it isn't hiding anything on the 5090, just adding instructions — long_scoreboard actually goes up there (7.90 -> 8.16) while on Spark it still drops (18.13 -> 12.22). That's where the worst non-Spark regression sits.
- Net: +4.81% median on Spark, -1.39% on the 4090, -1.57% on the 5090.

Improvement in mmvq performance means that switch points in #26079 needs changes, which are also done in this PR.

<details><summary>Performance</summary>
<p>

Decode throughput in tokens/s, measured with `llama-bench -p <n> -n 0 -embd 1 -r 30 -o csv` on single-type `--pure` quantisations, so each number reflects the kernel under test rather than a model's tensor-type mix.

The mvq -> MMQ switch points are disabled in every build here, so batch sizes 1-8 all reach `mul_mat_vec_q`. Without that, master routes K-quants to MMQ above a per-architecture cap and any change to the vector kernel measures as exactly zero above it.

| arm | what it is | dispatch |
|---|---|---|
| base | upstream master | mvq forced at ne11 1-8 |
| branchless | master + the branchless Q4_K/Q5_K scale unpack | mvq forced at ne11 1-8 |
| branchless + prefetch | branchless plus the L2 prefetch, which is gated to DGX Spark and compiles out elsewhere | mvq forced at ne11 1-8 |
| MMQ | same source as the `branchless + prefetch` arm, with `mul_mat_vec_q` disabled so everything runs MMQ | MMQ forced at ne11 1-8 |

MMQ is built from the shipping source but is unaffected by it: `mmq.cuh` references neither the modified vector dot products nor the prefetch helper, so that row measures unmodified MMQ and shows where the crossover sits.

The two `vs base` columns are that arm against `base` at the same batch size. MMQ is a different kernel rather than a variant of base, so it is shown in absolute terms only; comparing it against the `ship` column is what locates the mvq -> MMQ crossover.

Each cell is the mean of two ABBA-ordered passes at that batch size. No cell is a median or an average across types, models or batches.

Q2_K doubles as a control. Neither change can reach it - it is excluded from the prefetch by `mmvq_pf<GGML_TYPE_Q2_K>::bytes == 0`, and branchless rewrites only the Q4_K/Q5_K scale unpack - so its two percentage columns should read zero, and what they actually read is the measurement floor for the table around them.


## DGX Spark GB10

sm_121, ~273 GB/s unified LPDDR5, driver 610.43.02, CUDA 13.3.

### DGX Spark GB10 - Llama-3.2-3B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 109.82 | 109.21 | -0.56% | 109.17 | -0.59% | 102.79 |
|  | 2 | 208.23 | 208.28 | +0.03% | 212.53 | +2.07% | 179.48 |
|  | 3 | 308.59 | 311.47 | +0.93% | 313.82 | +1.70% | 268.30 |
|  | 4 | 421.64 | 414.86 | -1.61% | 417.99 | -0.87% | 356.44 |
|  | 5 | 505.18 | 488.59 | -3.28% | 519.80 | +2.89% | 440.91 |
|  | 6 | 593.08 | 593.04 | -0.01% | 612.91 | +3.34% | 527.41 |
|  | 7 | 657.48 | 683.30 | +3.93% | 690.60 | +5.04% | 611.78 |
|  | 8 | 695.70 | 762.26 | +9.57% | 762.77 | +9.64% | 678.54 |
| **Q5_K** | 1 | 90.01 | 93.21 | +3.56% | 93.32 | +3.68% | 86.03 |
|  | 2 | 173.79 | 176.09 | +1.32% | 179.22 | +3.12% | 144.75 |
|  | 3 | 263.92 | 261.73 | -0.83% | 264.69 | +0.29% | 216.43 |
|  | 4 | 356.29 | 345.21 | -3.11% | 354.98 | -0.37% | 287.20 |
|  | 5 | 422.98 | 412.24 | -2.54% | 439.46 | +3.90% | 355.09 |
|  | 6 | 505.07 | 494.74 | -2.04% | 521.36 | +3.23% | 426.37 |
|  | 7 | 593.05 | 580.93 | -2.04% | 600.16 | +1.20% | 494.72 |
|  | 8 | 630.71 | 649.41 | +2.97% | 662.14 | +4.98% | 549.91 |
| **Q2_K** | 1 | 172.81 | 172.42 | -0.23% | 173.37 | +0.32% | 152.00 |
|  | 2 | 296.36 | 296.43 | +0.02% | 296.89 | +0.18% | 233.89 |
|  | 3 | 451.30 | 450.08 | -0.27% | 451.26 | -0.01% | 348.47 |
|  | 4 | 543.26 | 541.72 | -0.28% | 541.26 | -0.37% | 462.55 |
|  | 5 | 684.85 | 685.26 | +0.06% | 684.49 | -0.05% | 572.25 |
|  | 6 | 723.55 | 723.73 | +0.02% | 721.87 | -0.23% | 681.84 |
|  | 7 | 763.52 | 762.01 | -0.20% | 764.01 | +0.06% | 798.11 |
|  | 8 | 773.67 | 774.47 | +0.10% | 773.51 | -0.02% | 866.24 |
| **Q3_K** | 1 | 118.01 | 117.93 | -0.06% | 120.43 | +2.05% | 111.57 |
|  | 2 | 252.85 | 253.13 | +0.11% | 255.03 | +0.86% | 188.62 |
|  | 3 | 357.25 | 358.40 | +0.32% | 359.15 | +0.53% | 280.66 |
|  | 4 | 467.62 | 468.39 | +0.17% | 462.82 | -1.03% | 374.60 |
|  | 5 | 586.04 | 587.44 | +0.24% | 578.47 | -1.29% | 462.91 |
|  | 6 | 669.61 | 672.44 | +0.42% | 668.79 | -0.12% | 555.15 |
|  | 7 | 755.40 | 752.06 | -0.44% | 766.23 | +1.43% | 642.50 |
|  | 8 | 795.47 | 799.15 | +0.46% | 779.98 | -1.95% | 708.03 |
| **Q6_K** | 1 | 76.16 | 76.57 | +0.55% | 78.12 | +2.58% | 73.13 |
|  | 2 | 147.24 | 147.08 | -0.11% | 152.23 | +3.39% | 123.56 |
|  | 3 | 218.18 | 218.32 | +0.06% | 228.43 | +4.70% | 184.52 |
|  | 4 | 291.44 | 290.87 | -0.20% | 301.87 | +3.58% | 245.37 |
|  | 5 | 345.03 | 344.76 | -0.08% | 366.39 | +6.19% | 304.50 |
|  | 6 | 413.98 | 413.12 | -0.21% | 439.01 | +6.05% | 365.00 |
|  | 7 | 478.32 | 475.81 | -0.53% | 506.07 | +5.80% | 424.96 |
|  | 8 | 543.92 | 545.04 | +0.21% | 563.45 | +3.59% | 472.50 |
| **Q4_0** | 1 | 119.17 | 118.90 | -0.22% | 118.89 | -0.23% | 109.33 |
|  | 2 | 235.54 | 235.33 | -0.09% | 233.17 | -1.01% | 185.02 |
|  | 3 | 346.77 | 346.59 | -0.05% | 348.24 | +0.43% | 277.51 |
|  | 4 | 458.44 | 457.71 | -0.16% | 457.80 | -0.14% | 367.86 |
|  | 5 | 555.28 | 554.32 | -0.17% | 554.20 | -0.19% | 456.69 |
|  | 6 | 660.01 | 659.44 | -0.09% | 661.47 | +0.22% | 544.46 |
|  | 7 | 761.99 | 759.72 | -0.30% | 769.42 | +0.98% | 631.96 |
|  | 8 | 854.79 | 853.93 | -0.10% | 853.86 | -0.11% | 698.60 |
| **Q8_0** | 1 | 65.68 | 65.63 | -0.08% | 67.80 | +3.22% | 63.11 |
|  | 2 | 126.39 | 126.12 | -0.22% | 130.52 | +3.26% | 105.90 |
|  | 3 | 189.58 | 189.35 | -0.12% | 193.64 | +2.14% | 158.24 |
|  | 4 | 252.03 | 251.24 | -0.31% | 258.24 | +2.46% | 210.18 |
|  | 5 | 300.83 | 300.48 | -0.11% | 312.27 | +3.80% | 261.49 |
|  | 6 | 360.18 | 360.04 | -0.04% | 371.04 | +3.02% | 312.92 |
|  | 7 | 419.53 | 418.12 | -0.34% | 432.52 | +3.10% | 364.71 |
|  | 8 | 479.45 | 478.60 | -0.18% | 479.78 | +0.07% | 407.51 |
| **IQ4_XS** | 1 | 121.59 | 122.20 | +0.50% | 119.13 | -2.03% | 110.70 |
|  | 2 | 233.78 | 233.20 | -0.25% | 250.52 | +7.16% | 194.79 |
|  | 3 | 325.88 | 325.22 | -0.20% | 374.60 | +14.95% | 291.57 |
|  | 4 | 432.60 | 432.41 | -0.04% | 497.09 | +14.91% | 388.72 |
|  | 5 | 596.22 | 597.53 | +0.22% | 599.08 | +0.48% | 480.50 |
|  | 6 | 658.34 | 656.17 | -0.33% | 708.61 | +7.64% | 574.88 |
|  | 7 | 766.77 | 766.05 | -0.09% | 821.90 | +7.19% | 665.07 |
|  | 8 | 806.57 | 801.66 | -0.61% | 903.78 | +12.05% | 737.02 |

### DGX Spark GB10 - Llama-3.1-8B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 50.05 | 49.75 | -0.58% | 50.29 | +0.49% | 48.20 |
|  | 2 | 94.80 | 93.44 | -1.44% | 96.63 | +1.93% | 81.33 |
|  | 3 | 139.25 | 139.64 | +0.28% | 144.67 | +3.89% | 121.39 |
|  | 4 | 191.83 | 186.19 | -2.94% | 192.15 | +0.17% | 161.40 |
|  | 5 | 230.69 | 219.86 | -4.69% | 245.71 | +6.51% | 200.12 |
|  | 6 | 273.41 | 266.37 | -2.58% | 292.10 | +6.83% | 239.80 |
|  | 7 | 307.47 | 308.72 | +0.41% | 337.71 | +9.83% | 278.05 |
|  | 8 | 327.37 | 346.87 | +5.96% | 374.09 | +14.27% | 313.11 |
| **Q5_K** | 1 | 40.12 | 41.62 | +3.74% | 42.06 | +4.85% | 40.07 |
|  | 2 | 76.45 | 76.79 | +0.44% | 79.63 | +4.17% | 66.21 |
|  | 3 | 118.73 | 116.05 | -2.26% | 119.06 | +0.28% | 98.83 |
|  | 4 | 159.60 | 154.21 | -3.38% | 161.73 | +1.33% | 131.69 |
|  | 5 | 189.39 | 182.29 | -3.75% | 202.92 | +7.14% | 163.58 |
|  | 6 | 227.44 | 220.82 | -2.91% | 241.38 | +6.13% | 195.84 |
|  | 7 | 267.53 | 259.52 | -2.99% | 281.17 | +5.10% | 227.74 |
|  | 8 | 287.37 | 289.53 | +0.75% | 314.94 | +9.59% | 256.30 |
| **Q2_K** | 1 | 82.08 | 82.13 | +0.06% | 82.44 | +0.43% | 75.41 |
|  | 2 | 138.14 | 138.45 | +0.22% | 138.57 | +0.30% | 113.82 |
|  | 3 | 233.72 | 233.51 | -0.09% | 233.77 | +0.02% | 170.11 |
|  | 4 | 276.09 | 276.31 | +0.08% | 276.64 | +0.20% | 226.17 |
|  | 5 | 322.40 | 322.27 | -0.04% | 322.55 | +0.05% | 280.61 |
|  | 6 | 338.85 | 339.06 | +0.06% | 338.96 | +0.04% | 334.28 |
|  | 7 | 357.17 | 357.14 | -0.01% | 356.83 | -0.10% | 388.24 |
|  | 8 | 358.59 | 357.61 | -0.27% | 357.55 | -0.29% | 434.08 |
| **Q3_K** | 1 | 54.64 | 54.62 | -0.02% | 57.02 | +4.36% | 54.40 |
|  | 2 | 121.08 | 120.83 | -0.21% | 119.38 | -1.41% | 86.13 |
|  | 3 | 165.17 | 165.30 | +0.08% | 173.70 | +5.17% | 128.80 |
|  | 4 | 229.19 | 229.40 | +0.09% | 225.50 | -1.61% | 171.05 |
|  | 5 | 271.17 | 270.49 | -0.25% | 289.21 | +6.65% | 212.24 |
|  | 6 | 312.04 | 312.63 | +0.19% | 331.88 | +6.36% | 254.33 |
|  | 7 | 349.79 | 349.62 | -0.05% | 365.73 | +4.56% | 295.18 |
|  | 8 | 371.18 | 370.27 | -0.24% | 375.14 | +1.07% | 331.02 |
| **Q6_K** | 1 | 34.38 | 34.48 | +0.29% | 34.97 | +1.71% | 33.26 |
|  | 2 | 64.53 | 64.61 | +0.13% | 68.27 | +5.80% | 54.52 |
|  | 3 | 95.94 | 95.95 | +0.02% | 102.72 | +7.07% | 81.50 |
|  | 4 | 128.01 | 128.02 | +0.01% | 136.18 | +6.38% | 108.17 |
|  | 5 | 150.95 | 151.29 | +0.23% | 161.51 | +7.00% | 134.69 |
|  | 6 | 181.88 | 181.80 | -0.04% | 198.17 | +8.96% | 161.01 |
|  | 7 | 208.95 | 209.59 | +0.31% | 228.42 | +9.32% | 187.40 |
|  | 8 | 241.11 | 241.76 | +0.27% | 256.65 | +6.45% | 211.44 |
| **Q4_0** | 1 | 54.42 | 54.47 | +0.08% | 54.93 | +0.93% | 51.80 |
|  | 2 | 105.67 | 106.09 | +0.40% | 106.18 | +0.48% | 85.13 |
|  | 3 | 157.64 | 157.54 | -0.06% | 158.84 | +0.76% | 127.14 |
|  | 4 | 210.27 | 209.80 | -0.22% | 211.61 | +0.64% | 169.25 |
|  | 5 | 252.13 | 252.17 | +0.02% | 257.80 | +2.25% | 210.39 |
|  | 6 | 302.11 | 301.51 | -0.20% | 308.66 | +2.17% | 250.84 |
|  | 7 | 349.49 | 349.81 | +0.09% | 360.49 | +3.15% | 292.33 |
|  | 8 | 395.81 | 397.37 | +0.39% | 403.77 | +2.01% | 327.29 |
| **Q8_0** | 1 | 29.32 | 29.28 | -0.14% | 29.99 | +2.30% | 28.53 |
|  | 2 | 55.24 | 55.26 | +0.03% | 58.40 | +5.72% | 47.05 |
|  | 3 | 82.99 | 83.07 | +0.10% | 86.96 | +4.78% | 70.34 |
|  | 4 | 110.09 | 110.15 | +0.05% | 115.70 | +5.09% | 93.53 |
|  | 5 | 133.20 | 133.28 | +0.06% | 139.75 | +4.92% | 116.38 |
|  | 6 | 158.88 | 158.95 | +0.04% | 166.48 | +4.78% | 139.32 |
|  | 7 | 183.82 | 184.10 | +0.16% | 194.57 | +5.85% | 162.16 |
|  | 8 | 213.53 | 213.45 | -0.04% | 219.12 | +2.62% | 183.12 |
| **IQ4_XS** | 1 | 56.45 | 56.33 | -0.21% | 56.80 | +0.62% | 53.37 |
|  | 2 | 106.98 | 106.97 | -0.01% | 116.19 | +8.61% | 88.84 |
|  | 3 | 147.12 | 147.16 | +0.03% | 174.70 | +18.75% | 132.83 |
|  | 4 | 197.26 | 197.51 | +0.13% | 231.38 | +17.29% | 176.53 |
|  | 5 | 279.73 | 279.16 | -0.20% | 281.34 | +0.58% | 219.44 |
|  | 6 | 305.37 | 305.79 | +0.14% | 333.24 | +9.13% | 262.28 |
|  | 7 | 355.16 | 353.54 | -0.45% | 387.48 | +9.10% | 304.21 |
|  | 8 | 368.71 | 369.05 | +0.09% | 433.07 | +17.46% | 341.05 |

### DGX Spark GB10 - gemma-4-12B-it

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 31.48 | 31.12 | -1.12% | 31.71 | +0.75% | 27.85 |
|  | 2 | 59.94 | 57.88 | -3.42% | 59.83 | -0.17% | 50.57 |
|  | 3 | 86.25 | 86.44 | +0.23% | 89.85 | +4.17% | 75.59 |
|  | 4 | 117.95 | 115.13 | -2.40% | 118.19 | +0.20% | 98.71 |
|  | 5 | 141.95 | 136.67 | -3.72% | 149.58 | +5.38% | 124.04 |
|  | 6 | 166.91 | 165.27 | -0.98% | 177.02 | +6.06% | 148.23 |
|  | 7 | 184.22 | 191.05 | +3.71% | 202.40 | +9.87% | 172.34 |
|  | 8 | 195.90 | 216.05 | +10.29% | 225.51 | +15.11% | 196.88 |
| **Q5_K** | 1 | 25.24 | 26.13 | +3.52% | 26.50 | +4.99% | 22.87 |
|  | 2 | 48.35 | 47.69 | -1.36% | 49.58 | +2.54% | 41.23 |
|  | 3 | 73.39 | 72.00 | -1.90% | 74.24 | +1.15% | 61.56 |
|  | 4 | 97.85 | 94.53 | -3.39% | 99.35 | +1.54% | 80.87 |
|  | 5 | 116.94 | 112.56 | -3.75% | 124.01 | +6.05% | 101.53 |
|  | 6 | 138.05 | 134.91 | -2.27% | 146.54 | +6.15% | 121.23 |
|  | 7 | 161.58 | 159.27 | -1.43% | 169.22 | +4.73% | 141.09 |
|  | 8 | 175.09 | 178.60 | +2.00% | 190.07 | +8.56% | 160.69 |
| **Q2_K** | 1 | 50.52 | 50.52 | +0.01% | 50.49 | -0.05% | 41.09 |
|  | 2 | 86.05 | 86.25 | +0.23% | 85.93 | -0.13% | 71.27 |
|  | 3 | 141.85 | 142.05 | +0.14% | 141.93 | +0.06% | 106.58 |
|  | 4 | 165.77 | 165.98 | +0.13% | 165.65 | -0.07% | 138.51 |
|  | 5 | 193.41 | 193.54 | +0.06% | 193.73 | +0.16% | 174.18 |
|  | 6 | 203.10 | 202.96 | -0.07% | 203.33 | +0.11% | 208.15 |
|  | 7 | 213.44 | 213.31 | -0.06% | 213.82 | +0.18% | 242.16 |
|  | 8 | 216.05 | 216.10 | +0.03% | 216.02 | -0.01% | 275.57 |
| **Q3_K** | 1 | 33.79 | 33.77 | -0.09% | 35.53 | +5.13% | 30.00 |
|  | 2 | 74.05 | 74.24 | +0.26% | 74.38 | +0.45% | 53.96 |
|  | 3 | 102.65 | 102.53 | -0.12% | 106.71 | +3.96% | 80.58 |
|  | 4 | 138.12 | 137.86 | -0.19% | 137.32 | -0.58% | 105.33 |
|  | 5 | 165.64 | 165.61 | -0.02% | 174.45 | +5.32% | 132.25 |
|  | 6 | 188.31 | 188.33 | +0.01% | 198.42 | +5.37% | 158.39 |
|  | 7 | 210.19 | 210.58 | +0.18% | 218.31 | +3.86% | 184.00 |
|  | 8 | 223.99 | 224.44 | +0.20% | 226.04 | +0.91% | 209.62 |
| **Q6_K** | 1 | 21.55 | 21.62 | +0.33% | 21.76 | +0.99% | 18.81 |
|  | 2 | 40.36 | 40.37 | +0.02% | 42.63 | +5.63% | 33.73 |
|  | 3 | 60.06 | 60.08 | +0.04% | 64.05 | +6.65% | 50.30 |
|  | 4 | 79.69 | 79.66 | -0.03% | 84.34 | +5.84% | 66.32 |
|  | 5 | 94.06 | 94.06 | -0.01% | 100.70 | +7.05% | 83.01 |
|  | 6 | 113.26 | 113.37 | +0.10% | 122.82 | +8.44% | 99.55 |
|  | 7 | 130.40 | 130.48 | +0.06% | 141.57 | +8.57% | 115.52 |
|  | 8 | 150.11 | 150.10 | -0.00% | 159.58 | +6.31% | 131.89 |
| **Q4_0** | 1 | 33.60 | 33.68 | +0.22% | 33.97 | +1.11% | 29.34 |
|  | 2 | 65.20 | 65.31 | +0.17% | 65.61 | +0.64% | 52.88 |
|  | 3 | 97.25 | 97.29 | +0.04% | 97.92 | +0.69% | 79.01 |
|  | 4 | 127.84 | 128.22 | +0.30% | 129.10 | +0.99% | 103.17 |
|  | 5 | 154.53 | 154.77 | +0.16% | 158.57 | +2.61% | 129.83 |
|  | 6 | 185.16 | 185.07 | -0.05% | 189.51 | +2.35% | 155.25 |
|  | 7 | 213.39 | 213.68 | +0.14% | 220.93 | +3.53% | 180.68 |
|  | 8 | 244.07 | 244.46 | +0.16% | 249.56 | +2.25% | 205.46 |
| **Q8_0** | 1 | 18.40 | 18.45 | +0.27% | 18.59 | +1.00% | 16.27 |
|  | 2 | 34.48 | 34.51 | +0.08% | 36.50 | +5.83% | 29.38 |
|  | 3 | 51.84 | 51.86 | +0.03% | 54.24 | +4.62% | 43.89 |
|  | 4 | 68.48 | 68.54 | +0.08% | 71.92 | +5.01% | 57.86 |
|  | 5 | 82.74 | 82.69 | -0.07% | 86.80 | +4.91% | 72.52 |
|  | 6 | 98.65 | 98.51 | -0.14% | 103.44 | +4.85% | 86.61 |
|  | 7 | 113.59 | 113.64 | +0.05% | 120.88 | +6.42% | 100.74 |
|  | 8 | 133.12 | 133.20 | +0.06% | 136.35 | +2.42% | 115.01 |
| **IQ4_XS** | 1 | 34.23 | 34.29 | +0.17% | 33.94 | -0.87% | 29.21 |
|  | 2 | 66.05 | 65.91 | -0.20% | 71.50 | +8.25% | 54.52 |
|  | 3 | 91.16 | 91.19 | +0.03% | 107.64 | +18.09% | 81.43 |
|  | 4 | 121.38 | 121.16 | -0.18% | 141.91 | +16.91% | 106.26 |
|  | 5 | 171.14 | 171.06 | -0.05% | 171.46 | +0.19% | 133.54 |
|  | 6 | 187.27 | 187.21 | -0.03% | 203.29 | +8.55% | 159.92 |
|  | 7 | 218.44 | 217.66 | -0.36% | 236.93 | +8.46% | 185.31 |
|  | 8 | 229.79 | 229.86 | +0.03% | 267.99 | +16.63% | 211.00 |

### DGX Spark GB10 - Qwen3.6-27B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 14.04 | 14.03 | -0.05% | 14.80 | +5.47% | 13.52 |
|  | 2 | 26.67 | 26.30 | -1.39% | 28.15 | +5.57% | 23.50 |
|  | 3 | 39.24 | 39.35 | +0.28% | 42.11 | +7.32% | 35.06 |
|  | 4 | 54.06 | 52.67 | -2.58% | 55.62 | +2.88% | 46.15 |
|  | 5 | 64.96 | 61.95 | -4.63% | 70.21 | +8.08% | 57.83 |
|  | 6 | 76.59 | 74.97 | -2.12% | 83.18 | +8.60% | 69.13 |
|  | 7 | 86.43 | 86.59 | +0.18% | 95.58 | +10.59% | 80.31 |
|  | 8 | 92.93 | 98.10 | +5.56% | 106.23 | +14.31% | 91.51 |
| **Q5_K** | 1 | 11.26 | 11.66 | +3.58% | 12.41 | +10.22% | 11.14 |
|  | 2 | 21.80 | 21.61 | -0.88% | 23.15 | +6.21% | 19.04 |
|  | 3 | 33.64 | 32.69 | -2.83% | 34.55 | +2.71% | 28.44 |
|  | 4 | 45.11 | 42.99 | -4.69% | 46.64 | +3.40% | 37.51 |
|  | 5 | 53.69 | 50.91 | -5.18% | 58.03 | +8.08% | 47.03 |
|  | 6 | 64.11 | 61.79 | -3.62% | 68.82 | +7.35% | 56.26 |
|  | 7 | 75.86 | 72.73 | -4.13% | 80.46 | +6.05% | 65.27 |
|  | 8 | 83.10 | 81.82 | -1.53% | 90.95 | +9.45% | 74.35 |
| **Q2_K** | 1 | 23.41 | 23.51 | +0.44% | 23.47 | +0.26% | 20.26 |
|  | 2 | 39.39 | 39.45 | +0.15% | 39.43 | +0.10% | 32.83 |
|  | 3 | 65.38 | 65.37 | -0.01% | 65.33 | -0.08% | 48.99 |
|  | 4 | 79.00 | 78.99 | -0.01% | 78.97 | -0.03% | 64.09 |
|  | 5 | 92.58 | 92.57 | -0.01% | 92.64 | +0.06% | 80.45 |
|  | 6 | 97.65 | 97.51 | -0.13% | 97.54 | -0.11% | 96.33 |
|  | 7 | 103.14 | 102.96 | -0.18% | 103.13 | -0.01% | 111.77 |
|  | 8 | 104.21 | 104.00 | -0.20% | 104.17 | -0.03% | 126.98 |
| **Q3_K** | 1 | 15.48 | 15.49 | +0.05% | 16.92 | +9.24% | 15.02 |
|  | 2 | 34.13 | 34.16 | +0.10% | 34.82 | +2.01% | 24.26 |
|  | 3 | 46.57 | 46.63 | +0.13% | 49.40 | +6.07% | 36.26 |
|  | 4 | 63.87 | 63.91 | +0.06% | 63.51 | -0.56% | 47.68 |
|  | 5 | 75.07 | 75.13 | +0.09% | 83.84 | +11.69% | 59.88 |
|  | 6 | 86.23 | 86.14 | -0.10% | 95.88 | +11.19% | 71.54 |
|  | 7 | 99.32 | 99.16 | -0.16% | 105.04 | +5.75% | 83.12 |
|  | 8 | 106.82 | 106.59 | -0.21% | 109.12 | +2.16% | 94.65 |
| **Q6_K** | 1 | 9.54 | 9.56 | +0.17% | 10.07 | +5.60% | 9.16 |
|  | 2 | 18.32 | 18.31 | -0.04% | 19.62 | +7.10% | 15.77 |
|  | 3 | 27.27 | 27.24 | -0.08% | 29.46 | +8.05% | 23.58 |
|  | 4 | 36.17 | 36.17 | -0.01% | 38.82 | +7.31% | 31.14 |
|  | 5 | 42.92 | 42.91 | -0.02% | 45.86 | +6.85% | 38.97 |
|  | 6 | 51.92 | 51.96 | +0.08% | 56.80 | +9.40% | 46.63 |
|  | 7 | 59.75 | 59.74 | -0.01% | 65.45 | +9.55% | 54.23 |
|  | 8 | 69.21 | 69.20 | -0.01% | 73.86 | +6.72% | 61.83 |
| **Q4_0** | 1 | 15.31 | 15.31 | -0.03% | 15.61 | +1.93% | 14.20 |
|  | 2 | 29.92 | 29.91 | -0.03% | 30.30 | +1.28% | 24.62 |
|  | 3 | 44.59 | 44.56 | -0.08% | 45.26 | +1.50% | 36.74 |
|  | 4 | 58.76 | 58.72 | -0.06% | 59.71 | +1.61% | 48.30 |
|  | 5 | 70.90 | 70.94 | +0.05% | 73.45 | +3.59% | 60.57 |
|  | 6 | 85.09 | 84.97 | -0.14% | 88.13 | +3.57% | 72.43 |
|  | 7 | 98.09 | 98.10 | +0.01% | 102.79 | +4.79% | 84.07 |
|  | 8 | 112.00 | 111.84 | -0.15% | 116.33 | +3.86% | 95.65 |
| **Q8_0** | 1 | 8.15 | 8.17 | +0.34% | 8.68 | +6.51% | 7.96 |
|  | 2 | 15.69 | 15.70 | +0.05% | 16.74 | +6.67% | 13.73 |
|  | 3 | 23.58 | 23.57 | -0.04% | 24.99 | +5.98% | 20.54 |
|  | 4 | 31.13 | 31.12 | -0.05% | 33.17 | +6.54% | 27.15 |
|  | 5 | 37.87 | 37.89 | +0.05% | 39.79 | +5.07% | 33.96 |
|  | 6 | 45.12 | 45.15 | +0.07% | 47.54 | +5.35% | 40.66 |
|  | 7 | 52.11 | 52.16 | +0.10% | 55.43 | +6.36% | 47.28 |
|  | 8 | 61.12 | 61.12 | +0.01% | 62.91 | +2.93% | 53.96 |
| **IQ4_XS** | 1 | 16.10 | 16.09 | -0.06% | 16.23 | +0.79% | 14.75 |
|  | 2 | 30.16 | 30.16 | +0.00% | 32.91 | +9.10% | 25.92 |
|  | 3 | 41.63 | 41.62 | -0.01% | 49.13 | +18.02% | 38.68 |
|  | 4 | 55.24 | 55.23 | -0.01% | 65.05 | +17.76% | 50.83 |
|  | 5 | 78.31 | 78.38 | +0.09% | 78.88 | +0.73% | 63.80 |
|  | 6 | 85.43 | 85.46 | +0.03% | 93.56 | +9.52% | 76.28 |
|  | 7 | 99.32 | 99.33 | +0.01% | 105.12 | +5.84% | 88.50 |
|  | 8 | 104.24 | 104.36 | +0.12% | 118.20 | +13.39% | 100.70 |


## RTX 5090

sm_120, 1792 GB/s, driver 620.23, CUDA 12.9.

### RTX 5090 - Llama-3.2-3B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 434.51 | 445.36 | +2.50% | 443.53 | +2.08% | 365.16 |
|  | 2 | 757.26 | 800.44 | +5.70% | 797.42 | +5.30% | 564.81 |
|  | 3 | 1091.18 | 1152.01 | +5.57% | 1135.94 | +4.10% | 837.56 |
|  | 4 | 1252.51 | 1419.28 | +13.31% | 1408.61 | +12.46% | 1107.28 |
|  | 5 | 1368.78 | 1671.36 | +22.11% | 1659.63 | +21.25% | 1340.44 |
|  | 6 | 1440.16 | 1767.67 | +22.74% | 1753.03 | +21.72% | 1600.05 |
|  | 7 | 1542.23 | 1852.28 | +20.10% | 1858.64 | +20.52% | 1854.79 |
|  | 8 | 1686.82 | 1909.67 | +13.21% | 1944.78 | +15.29% | 2129.53 |
| **Q5_K** | 1 | 393.41 | 399.85 | +1.64% | 396.57 | +0.80% | 330.59 |
|  | 2 | 699.38 | 718.39 | +2.72% | 720.12 | +2.97% | 519.13 |
|  | 3 | 1001.20 | 1033.61 | +3.24% | 1034.42 | +3.32% | 766.16 |
|  | 4 | 1212.49 | 1301.13 | +7.31% | 1300.02 | +7.22% | 1011.50 |
|  | 5 | 1322.02 | 1548.45 | +17.13% | 1527.26 | +15.52% | 1248.75 |
|  | 6 | 1405.14 | 1667.38 | +18.66% | 1638.42 | +16.60% | 1488.81 |
|  | 7 | 1558.58 | 1774.12 | +13.83% | 1741.57 | +11.74% | 1726.40 |
|  | 8 | 1650.29 | 1878.63 | +13.84% | 1846.54 | +11.89% | 1978.22 |
| **Q2_K** | 1 | 478.69 | 484.29 | +1.17% | 487.47 | +1.83% | 387.47 |
|  | 2 | 819.02 | 832.36 | +1.63% | 831.24 | +1.49% | 562.02 |
|  | 3 | 1073.99 | 1074.91 | +0.09% | 1088.88 | +1.39% | 833.24 |
|  | 4 | 1247.00 | 1238.49 | -0.68% | 1255.47 | +0.68% | 1111.38 |
|  | 5 | 1408.34 | 1412.95 | +0.33% | 1419.06 | +0.76% | 1366.29 |
|  | 6 | 1529.01 | 1517.91 | -0.73% | 1545.86 | +1.10% | 1616.25 |
|  | 7 | 1634.49 | 1622.10 | -0.76% | 1655.84 | +1.31% | 1867.89 |
|  | 8 | 1702.96 | 1713.80 | +0.64% | 1705.27 | +0.14% | 2119.41 |
| **Q3_K** | 1 | 366.99 | 369.26 | +0.62% | 370.67 | +1.00% | 313.11 |
|  | 2 | 672.19 | 679.19 | +1.04% | 682.27 | +1.50% | 546.93 |
|  | 3 | 932.20 | 949.43 | +1.85% | 948.71 | +1.77% | 803.69 |
|  | 4 | 1172.54 | 1191.00 | +1.57% | 1163.00 | -0.81% | 1058.21 |
|  | 5 | 1348.53 | 1382.91 | +2.55% | 1352.28 | +0.28% | 1305.08 |
|  | 6 | 1467.96 | 1502.10 | +2.33% | 1483.32 | +1.05% | 1539.87 |
|  | 7 | 1650.89 | 1633.91 | -1.03% | 1641.98 | -0.54% | 1793.38 |
|  | 8 | 1653.74 | 1665.53 | +0.71% | 1664.33 | +0.64% | 2052.78 |
| **Q6_K** | 1 | 351.45 | 350.29 | -0.33% | 355.24 | +1.08% | 288.48 |
|  | 2 | 628.37 | 631.80 | +0.55% | 642.29 | +2.22% | 460.94 |
|  | 3 | 908.87 | 914.20 | +0.59% | 923.87 | +1.65% | 674.74 |
|  | 4 | 1151.98 | 1161.46 | +0.82% | 1180.32 | +2.46% | 892.71 |
|  | 5 | 1289.04 | 1293.21 | +0.32% | 1316.06 | +2.10% | 1111.20 |
|  | 6 | 1465.96 | 1476.81 | +0.74% | 1495.19 | +1.99% | 1306.40 |
|  | 7 | 1598.63 | 1612.85 | +0.89% | 1628.01 | +1.84% | 1521.56 |
|  | 8 | 1607.98 | 1608.96 | +0.06% | 1620.28 | +0.76% | 1729.04 |
| **Q4_0** | 1 | 454.01 | 451.94 | -0.46% | 453.60 | -0.09% | 351.71 |
|  | 2 | 807.98 | 802.04 | -0.74% | 805.60 | -0.29% | 526.50 |
|  | 3 | 1192.64 | 1188.73 | -0.33% | 1189.81 | -0.24% | 784.71 |
|  | 4 | 1553.36 | 1527.06 | -1.69% | 1547.22 | -0.40% | 1044.64 |
|  | 5 | 1861.97 | 1831.30 | -1.65% | 1850.40 | -0.62% | 1278.37 |
|  | 6 | 2150.74 | 2124.73 | -1.21% | 2147.76 | -0.14% | 1520.65 |
|  | 7 | 2320.98 | 2312.15 | -0.38% | 2322.56 | +0.07% | 1773.04 |
|  | 8 | 2353.75 | 2370.41 | +0.71% | 2363.68 | +0.42% | 2003.61 |
| **Q8_0** | 1 | 301.50 | 311.13 | +3.19% | 304.17 | +0.89% | 262.00 |
|  | 2 | 558.56 | 566.89 | +1.49% | 568.65 | +1.81% | 434.94 |
|  | 3 | 821.31 | 836.70 | +1.87% | 836.13 | +1.80% | 647.66 |
|  | 4 | 1085.44 | 1106.51 | +1.94% | 1104.61 | +1.77% | 858.38 |
|  | 5 | 1270.99 | 1295.95 | +1.96% | 1300.92 | +2.35% | 1050.07 |
|  | 6 | 1508.24 | 1540.13 | +2.11% | 1532.97 | +1.64% | 1229.37 |
|  | 7 | 1735.33 | 1759.64 | +1.40% | 1761.40 | +1.50% | 1453.76 |
|  | 8 | 1937.22 | 1971.20 | +1.75% | 1961.11 | +1.23% | 1655.09 |
| **IQ4_XS** | 1 | 445.77 | 449.31 | +0.79% | 450.44 | +1.05% | 366.27 |
|  | 2 | 840.13 | 846.87 | +0.80% | 845.11 | +0.59% | 577.47 |
|  | 3 | 1239.22 | 1248.86 | +0.78% | 1251.18 | +0.96% | 855.72 |
|  | 4 | 1587.49 | 1564.72 | -1.43% | 1587.39 | -0.01% | 1132.66 |
|  | 5 | 1840.58 | 1864.74 | +1.31% | 1864.83 | +1.32% | 1387.91 |
|  | 6 | 2042.48 | 2058.90 | +0.80% | 2068.93 | +1.30% | 1616.53 |
|  | 7 | 2262.65 | 2280.25 | +0.78% | 2262.83 | +0.01% | 1881.39 |
|  | 8 | 2458.27 | 2411.96 | -1.88% | 2432.60 | -1.04% | 2131.44 |

### RTX 5090 - Llama-3.1-8B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 252.72 | 256.86 | +1.64% | 256.88 | +1.65% | 213.57 |
|  | 2 | 448.25 | 476.06 | +6.21% | 476.13 | +6.22% | 356.31 |
|  | 3 | 614.91 | 665.23 | +8.18% | 665.56 | +8.24% | 528.43 |
|  | 4 | 701.48 | 804.90 | +14.74% | 807.23 | +15.08% | 685.18 |
|  | 5 | 762.02 | 899.30 | +18.02% | 898.46 | +17.91% | 846.93 |
|  | 6 | 815.33 | 987.50 | +21.12% | 986.14 | +20.95% | 1003.83 |
|  | 7 | 861.85 | 1028.13 | +19.29% | 1027.61 | +19.23% | 1169.42 |
|  | 8 | 882.24 | 1081.51 | +22.59% | 1079.96 | +22.41% | 1344.71 |
| **Q5_K** | 1 | 220.73 | 222.16 | +0.65% | 221.03 | +0.13% | 185.20 |
|  | 2 | 396.08 | 405.44 | +2.36% | 403.66 | +1.91% | 314.59 |
|  | 3 | 561.32 | 581.08 | +3.52% | 578.64 | +3.09% | 467.41 |
|  | 4 | 672.96 | 736.12 | +9.39% | 730.76 | +8.59% | 622.53 |
|  | 5 | 741.46 | 841.04 | +13.43% | 824.43 | +11.19% | 767.78 |
|  | 6 | 776.24 | 929.20 | +19.70% | 916.27 | +18.04% | 919.23 |
|  | 7 | 834.20 | 964.18 | +15.58% | 973.22 | +16.67% | 1064.41 |
|  | 8 | 862.38 | 1011.58 | +17.30% | 1017.13 | +17.94% | 1214.73 |
| **Q2_K** | 1 | 316.84 | 312.76 | -1.29% | 311.88 | -1.56% | 243.52 |
|  | 2 | 538.03 | 532.17 | -1.09% | 528.23 | -1.82% | 362.19 |
|  | 3 | 652.00 | 643.22 | -1.35% | 637.77 | -2.18% | 534.48 |
|  | 4 | 746.70 | 743.27 | -0.46% | 732.53 | -1.90% | 712.51 |
|  | 5 | 836.86 | 832.68 | -0.50% | 823.38 | -1.61% | 876.27 |
|  | 6 | 844.80 | 842.47 | -0.28% | 841.76 | -0.36% | 1041.93 |
|  | 7 | 898.46 | 914.11 | +1.74% | 922.29 | +2.65% | 1213.15 |
|  | 8 | 911.23 | 933.11 | +2.40% | 949.78 | +4.23% | 1379.59 |
| **Q3_K** | 1 | 217.58 | 219.67 | +0.96% | 215.43 | -0.99% | 186.56 |
|  | 2 | 400.73 | 402.99 | +0.56% | 397.06 | -0.92% | 335.13 |
|  | 3 | 558.80 | 547.70 | -1.99% | 549.76 | -1.62% | 500.67 |
|  | 4 | 664.39 | 670.87 | +0.97% | 672.24 | +1.18% | 661.38 |
|  | 5 | 730.94 | 740.41 | +1.30% | 734.59 | +0.50% | 814.79 |
|  | 6 | 812.18 | 820.20 | +0.99% | 841.42 | +3.60% | 979.32 |
|  | 7 | 887.07 | 883.75 | -0.37% | 898.29 | +1.27% | 1132.86 |
|  | 8 | 894.96 | 888.56 | -0.71% | 905.29 | +1.15% | 1281.64 |
| **Q6_K** | 1 | 185.86 | 183.92 | -1.05% | 188.16 | +1.23% | 161.45 |
|  | 2 | 351.49 | 346.27 | -1.49% | 355.01 | +1.00% | 274.34 |
|  | 3 | 496.50 | 501.08 | +0.92% | 504.57 | +1.62% | 408.27 |
|  | 4 | 625.28 | 628.15 | +0.46% | 633.62 | +1.33% | 541.12 |
|  | 5 | 680.93 | 684.19 | +0.48% | 690.77 | +1.44% | 676.33 |
|  | 6 | 759.80 | 758.06 | -0.23% | 768.11 | +1.09% | 814.08 |
|  | 7 | 816.69 | 814.48 | -0.27% | 827.11 | +1.28% | 942.33 |
|  | 8 | 875.23 | 872.87 | -0.27% | 883.16 | +0.91% | 1072.62 |
| **Q4_0** | 1 | 249.61 | 258.33 | +3.49% | 258.75 | +3.66% | 212.02 |
|  | 2 | 464.07 | 486.16 | +4.76% | 485.99 | +4.72% | 334.96 |
|  | 3 | 680.12 | 705.55 | +3.74% | 707.15 | +3.97% | 496.53 |
|  | 4 | 874.32 | 901.64 | +3.12% | 905.37 | +3.55% | 657.36 |
|  | 5 | 1003.82 | 1040.24 | +3.63% | 1041.92 | +3.79% | 829.18 |
|  | 6 | 1136.80 | 1177.10 | +3.54% | 1179.70 | +3.77% | 974.26 |
|  | 7 | 1230.12 | 1275.38 | +3.68% | 1275.97 | +3.73% | 1138.41 |
|  | 8 | 1322.66 | 1373.27 | +3.83% | 1372.32 | +3.76% | 1292.41 |
| **Q8_0** | 1 | 155.42 | 155.56 | +0.09% | 155.34 | -0.05% | 140.17 |
|  | 2 | 298.11 | 295.94 | -0.73% | 292.34 | -1.94% | 242.70 |
|  | 3 | 439.90 | 437.97 | -0.44% | 430.86 | -2.06% | 362.35 |
|  | 4 | 575.96 | 567.35 | -1.50% | 572.86 | -0.54% | 476.99 |
|  | 5 | 676.01 | 670.85 | -0.76% | 665.60 | -1.54% | 578.07 |
|  | 6 | 780.85 | 793.04 | +1.56% | 786.13 | +0.68% | 692.36 |
|  | 7 | 868.47 | 887.72 | +2.22% | 879.60 | +1.28% | 804.22 |
|  | 8 | 993.99 | 997.09 | +0.31% | 999.42 | +0.55% | 916.76 |
| **IQ4_XS** | 1 | 261.53 | 263.10 | +0.60% | 263.16 | +0.62% | 220.83 |
|  | 2 | 473.98 | 473.55 | -0.09% | 476.18 | +0.46% | 362.51 |
|  | 3 | 696.36 | 694.07 | -0.33% | 690.57 | -0.83% | 527.94 |
|  | 4 | 886.61 | 891.17 | +0.52% | 891.21 | +0.52% | 700.56 |
|  | 5 | 1050.59 | 1050.74 | +0.01% | 1054.71 | +0.39% | 861.19 |
|  | 6 | 1138.06 | 1144.72 | +0.59% | 1138.27 | +0.02% | 1030.92 |
|  | 7 | 1299.57 | 1298.51 | -0.08% | 1295.53 | -0.31% | 1187.53 |
|  | 8 | 1351.14 | 1376.15 | +1.85% | 1374.61 | +1.74% | 1343.52 |

### RTX 5090 - gemma-4-12B-it

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 137.24 | 137.75 | +0.37% | 135.67 | -1.14% | 109.09 |
|  | 2 | 252.34 | 258.67 | +2.51% | 252.49 | +0.06% | 204.58 |
|  | 3 | 346.39 | 367.77 | +6.17% | 356.78 | +3.00% | 312.54 |
|  | 4 | 392.18 | 443.00 | +12.96% | 436.92 | +11.41% | 417.44 |
|  | 5 | 439.16 | 492.66 | +12.18% | 492.20 | +12.08% | 518.51 |
|  | 6 | 474.46 | 560.64 | +18.16% | 549.22 | +15.76% | 617.43 |
|  | 7 | 507.69 | 602.95 | +18.76% | 595.01 | +17.20% | 718.00 |
|  | 8 | 532.33 | 642.73 | +20.74% | 632.66 | +18.85% | 803.71 |
| **Q5_K** | 1 | 121.03 | 121.80 | +0.63% | 123.66 | +2.18% | 103.88 |
|  | 2 | 222.80 | 231.25 | +3.79% | 227.60 | +2.15% | 192.43 |
|  | 3 | 310.24 | 339.78 | +9.52% | 335.51 | +8.15% | 287.82 |
|  | 4 | 380.13 | 421.38 | +10.85% | 414.45 | +9.03% | 382.84 |
|  | 5 | 441.63 | 486.02 | +10.05% | 479.84 | +8.65% | 472.70 |
|  | 6 | 471.47 | 549.29 | +16.51% | 542.86 | +15.14% | 554.97 |
|  | 7 | 499.24 | 578.97 | +15.97% | 584.96 | +17.17% | 639.54 |
|  | 8 | 520.02 | 596.31 | +14.67% | 625.29 | +20.24% | 724.58 |
| **Q2_K** | 1 | 164.54 | 164.46 | -0.05% | 163.32 | -0.74% | 119.89 |
|  | 2 | 285.48 | 285.85 | +0.13% | 282.78 | -0.95% | 215.36 |
|  | 3 | 355.31 | 354.22 | -0.31% | 354.25 | -0.30% | 323.25 |
|  | 4 | 408.41 | 416.11 | +1.89% | 416.55 | +1.99% | 425.53 |
|  | 5 | 473.10 | 474.20 | +0.23% | 476.62 | +0.74% | 530.15 |
|  | 6 | 495.97 | 497.12 | +0.23% | 500.23 | +0.86% | 639.22 |
|  | 7 | 541.63 | 546.07 | +0.82% | 546.87 | +0.97% | 740.83 |
|  | 8 | 552.22 | 570.53 | +3.32% | 566.68 | +2.62% | 836.58 |
| **Q3_K** | 1 | 122.14 | 122.76 | +0.50% | 119.85 | -1.87% | 105.53 |
|  | 2 | 227.25 | 228.28 | +0.45% | 222.85 | -1.94% | 208.99 |
|  | 3 | 313.57 | 310.04 | -1.13% | 310.49 | -0.98% | 311.26 |
|  | 4 | 380.62 | 370.95 | -2.54% | 378.09 | -0.66% | 413.96 |
|  | 5 | 443.23 | 434.24 | -2.03% | 440.46 | -0.62% | 511.56 |
|  | 6 | 501.87 | 481.10 | -4.14% | 493.61 | -1.65% | 609.70 |
|  | 7 | 548.94 | 527.11 | -3.98% | 549.71 | +0.14% | 688.54 |
|  | 8 | 539.59 | 542.71 | +0.58% | 551.78 | +2.26% | 792.31 |
| **Q6_K** | 1 | 108.47 | 108.39 | -0.08% | 109.70 | +1.13% | 89.47 |
|  | 2 | 206.72 | 209.34 | +1.27% | 209.45 | +1.32% | 166.54 |
|  | 3 | 302.89 | 304.25 | +0.45% | 304.31 | +0.47% | 252.53 |
|  | 4 | 376.96 | 378.54 | +0.42% | 378.07 | +0.30% | 335.27 |
|  | 5 | 431.06 | 429.75 | -0.30% | 429.76 | -0.30% | 410.74 |
|  | 6 | 470.30 | 469.72 | -0.12% | 469.33 | -0.21% | 489.74 |
|  | 7 | 511.49 | 510.30 | -0.23% | 510.68 | -0.16% | 566.63 |
|  | 8 | 556.10 | 554.74 | -0.25% | 554.86 | -0.22% | 645.39 |
| **Q4_0** | 1 | 143.05 | 143.17 | +0.08% | 143.19 | +0.10% | 113.76 |
|  | 2 | 274.28 | 274.48 | +0.08% | 274.92 | +0.23% | 207.62 |
|  | 3 | 399.13 | 399.75 | +0.16% | 399.98 | +0.21% | 309.20 |
|  | 4 | 511.55 | 511.58 | +0.01% | 512.25 | +0.14% | 411.85 |
|  | 5 | 608.34 | 608.59 | +0.04% | 610.43 | +0.34% | 510.00 |
|  | 6 | 681.34 | 681.19 | -0.02% | 682.05 | +0.10% | 609.28 |
|  | 7 | 736.07 | 738.41 | +0.32% | 737.79 | +0.23% | 706.98 |
|  | 8 | 809.84 | 811.65 | +0.22% | 812.48 | +0.33% | 802.98 |
| **Q8_0** | 1 | 92.56 | 92.87 | +0.34% | 92.84 | +0.31% | 80.99 |
|  | 2 | 179.67 | 179.69 | +0.01% | 179.57 | -0.06% | 152.46 |
|  | 3 | 267.35 | 267.44 | +0.03% | 267.12 | -0.09% | 228.02 |
|  | 4 | 349.65 | 349.80 | +0.04% | 350.00 | +0.10% | 302.97 |
|  | 5 | 414.78 | 415.35 | +0.14% | 415.11 | +0.08% | 376.84 |
|  | 6 | 490.57 | 490.33 | -0.05% | 490.22 | -0.07% | 450.80 |
|  | 7 | 572.38 | 572.02 | -0.06% | 572.22 | -0.03% | 524.53 |
|  | 8 | 620.49 | 620.71 | +0.04% | 620.73 | +0.04% | 595.30 |
| **IQ4_XS** | 1 | 141.68 | 141.58 | -0.07% | 141.63 | -0.04% | 118.07 |
|  | 2 | 277.80 | 276.99 | -0.29% | 277.52 | -0.10% | 214.99 |
|  | 3 | 406.42 | 406.59 | +0.04% | 406.80 | +0.09% | 322.35 |
|  | 4 | 520.72 | 519.88 | -0.16% | 520.19 | -0.10% | 427.41 |
|  | 5 | 634.94 | 635.20 | +0.04% | 634.67 | -0.04% | 531.59 |
|  | 6 | 692.12 | 692.06 | -0.01% | 691.77 | -0.05% | 634.68 |
|  | 7 | 791.38 | 792.50 | +0.14% | 791.61 | +0.03% | 736.99 |
|  | 8 | 832.29 | 833.64 | +0.16% | 832.10 | -0.02% | 834.76 |

### RTX 5090 - Qwen3.6-27B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 74.20 | 71.25 | -3.98% | 72.46 | -2.35% | 58.50 |
|  | 2 | 137.92 | 134.68 | -2.35% | 133.49 | -3.21% | 105.81 |
|  | 3 | 194.13 | 197.77 | +1.88% | 194.43 | +0.16% | 157.11 |
|  | 4 | 221.32 | 237.63 | +7.37% | 237.34 | +7.24% | 208.75 |
|  | 5 | 245.46 | 277.38 | +13.00% | 275.75 | +12.34% | 256.03 |
|  | 6 | 254.18 | 302.84 | +19.14% | 301.77 | +18.72% | 301.86 |
|  | 7 | 266.39 | 314.58 | +18.09% | 316.47 | +18.80% | 350.05 |
|  | 8 | 279.58 | 322.84 | +15.48% | 323.63 | +15.76% | 396.99 |
| **Q5_K** | 1 | 63.51 | 64.53 | +1.60% | 63.72 | +0.32% | 50.72 |
|  | 2 | 119.40 | 121.10 | +1.42% | 122.81 | +2.86% | 94.68 |
|  | 3 | 173.78 | 178.08 | +2.47% | 180.71 | +3.99% | 141.86 |
|  | 4 | 209.30 | 225.90 | +7.93% | 223.13 | +6.61% | 184.27 |
|  | 5 | 238.64 | 260.73 | +9.26% | 261.12 | +9.42% | 228.35 |
|  | 6 | 243.66 | 277.89 | +14.05% | 291.70 | +19.72% | 275.93 |
|  | 7 | 260.64 | 292.01 | +12.04% | 308.70 | +18.44% | 313.57 |
|  | 8 | 267.36 | 303.68 | +13.59% | 312.20 | +16.77% | 359.24 |
| **Q2_K** | 1 | 92.53 | 91.97 | -0.61% | 94.40 | +2.02% | 64.94 |
|  | 2 | 160.47 | 159.12 | -0.84% | 164.74 | +2.66% | 112.29 |
|  | 3 | 197.27 | 191.93 | -2.71% | 202.54 | +2.67% | 167.95 |
|  | 4 | 229.80 | 223.35 | -2.81% | 234.50 | +2.05% | 222.04 |
|  | 5 | 257.72 | 252.43 | -2.05% | 259.84 | +0.82% | 275.43 |
|  | 6 | 261.25 | 259.43 | -0.70% | 263.27 | +0.77% | 326.31 |
|  | 7 | 278.01 | 275.52 | -0.90% | 285.88 | +2.83% | 370.23 |
|  | 8 | 282.83 | 277.20 | -1.99% | 281.19 | -0.58% | 422.12 |
| **Q3_K** | 1 | 68.12 | 66.84 | -1.89% | 66.32 | -2.65% | 55.81 |
|  | 2 | 127.60 | 125.74 | -1.46% | 123.93 | -2.87% | 107.49 |
|  | 3 | 176.98 | 173.54 | -1.95% | 171.67 | -3.00% | 160.91 |
|  | 4 | 216.21 | 210.26 | -2.75% | 209.49 | -3.10% | 213.52 |
|  | 5 | 246.26 | 242.20 | -1.65% | 243.00 | -1.32% | 263.76 |
|  | 6 | 267.34 | 260.66 | -2.50% | 267.74 | +0.15% | 314.88 |
|  | 7 | 279.32 | 272.19 | -2.56% | 276.38 | -1.05% | 365.55 |
|  | 8 | 283.03 | 275.75 | -2.57% | 288.97 | +2.10% | 414.19 |
| **Q6_K** | 1 | 55.30 | 55.16 | -0.26% | 56.03 | +1.32% | 46.27 |
|  | 2 | 106.42 | 104.94 | -1.40% | 106.78 | +0.34% | 84.95 |
|  | 3 | 155.64 | 153.73 | -1.22% | 153.20 | -1.57% | 126.87 |
|  | 4 | 197.87 | 200.61 | +1.39% | 196.79 | -0.55% | 162.17 |
|  | 5 | 220.90 | 223.62 | +1.23% | 220.27 | -0.29% | 204.29 |
|  | 6 | 244.88 | 245.51 | +0.26% | 239.77 | -2.09% | 249.98 |
|  | 7 | 254.51 | 257.70 | +1.25% | 256.41 | +0.75% | 290.59 |
|  | 8 | 267.59 | 269.21 | +0.61% | 267.88 | +0.11% | 330.72 |
| **Q4_0** | 1 | 73.97 | 75.87 | +2.56% | 76.10 | +2.88% | 58.06 |
|  | 2 | 142.44 | 143.02 | +0.40% | 143.45 | +0.71% | 103.66 |
|  | 3 | 212.47 | 211.98 | -0.23% | 212.33 | -0.06% | 155.08 |
|  | 4 | 270.92 | 270.72 | -0.08% | 271.14 | +0.08% | 205.80 |
|  | 5 | 326.16 | 320.36 | -1.78% | 326.23 | +0.02% | 250.97 |
|  | 6 | 377.18 | 371.55 | -1.49% | 377.91 | +0.19% | 302.48 |
|  | 7 | 412.85 | 410.00 | -0.69% | 413.29 | +0.11% | 353.25 |
|  | 8 | 441.33 | 441.75 | +0.09% | 442.18 | +0.19% | 402.13 |
| **Q8_0** | 1 | 46.74 | 46.70 | -0.10% | 45.88 | -1.84% | 39.68 |
|  | 2 | 89.45 | 89.51 | +0.07% | 89.45 | -0.00% | 74.41 |
|  | 3 | 133.17 | 133.26 | +0.07% | 133.21 | +0.03% | 111.32 |
|  | 4 | 176.11 | 176.16 | +0.03% | 176.23 | +0.07% | 147.87 |
|  | 5 | 209.95 | 209.98 | +0.02% | 209.89 | -0.03% | 183.25 |
|  | 6 | 245.56 | 245.61 | +0.02% | 245.61 | +0.02% | 219.16 |
|  | 7 | 279.72 | 279.60 | -0.04% | 279.73 | +0.00% | 254.95 |
|  | 8 | 317.76 | 317.74 | -0.01% | 317.78 | +0.01% | 290.05 |
| **IQ4_XS** | 1 | 77.66 | 77.91 | +0.32% | 77.95 | +0.37% | 61.17 |
|  | 2 | 148.02 | 148.06 | +0.03% | 148.08 | +0.04% | 111.80 |
|  | 3 | 216.36 | 216.78 | +0.19% | 216.72 | +0.16% | 167.35 |
|  | 4 | 281.06 | 281.08 | +0.00% | 281.07 | +0.00% | 221.51 |
|  | 5 | 341.16 | 340.94 | -0.06% | 339.89 | -0.37% | 273.49 |
|  | 6 | 370.56 | 370.66 | +0.03% | 370.19 | -0.10% | 324.90 |
|  | 7 | 425.62 | 425.44 | -0.04% | 423.20 | -0.57% | 374.91 |
|  | 8 | 447.21 | 447.62 | +0.09% | 441.55 | -1.27% | 430.57 |


## RTX 4090

sm_89, 1008 GB/s, driver 591, CUDA 12.9.

### RTX 4090 - Llama-3.2-3B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 328.89 | 329.44 | +0.17% | 329.01 | +0.04% | 282.86 |
|  | 2 | 596.72 | 601.29 | +0.77% | 601.70 | +0.83% | 451.96 |
|  | 3 | 857.63 | 868.93 | +1.32% | 869.27 | +1.36% | 661.56 |
|  | 4 | 1069.35 | 1098.12 | +2.69% | 1098.25 | +2.70% | 862.88 |
|  | 5 | 1239.35 | 1298.81 | +4.80% | 1299.01 | +4.81% | 1050.90 |
|  | 6 | 1382.71 | 1505.31 | +8.87% | 1505.66 | +8.89% | 1237.40 |
|  | 7 | 1502.42 | 1664.05 | +10.76% | 1663.90 | +10.75% | 1415.06 |
|  | 8 | 1560.90 | 1817.87 | +16.46% | 1817.88 | +16.46% | 1589.46 |
| **Q5_K** | 1 | 289.32 | 289.35 | +0.01% | 289.53 | +0.07% | 252.85 |
|  | 2 | 521.89 | 527.90 | +1.15% | 528.51 | +1.27% | 414.65 |
|  | 3 | 757.14 | 767.41 | +1.36% | 767.16 | +1.32% | 608.48 |
|  | 4 | 957.62 | 983.70 | +2.72% | 983.70 | +2.72% | 795.69 |
|  | 5 | 1133.12 | 1187.13 | +4.77% | 1186.98 | +4.75% | 969.75 |
|  | 6 | 1293.71 | 1372.45 | +6.09% | 1373.20 | +6.14% | 1144.46 |
|  | 7 | 1419.32 | 1531.57 | +7.91% | 1532.41 | +7.97% | 1307.87 |
|  | 8 | 1501.87 | 1678.02 | +11.73% | 1678.02 | +11.73% | 1469.59 |
| **Q2_K** | 1 | 435.37 | 434.37 | -0.23% | 435.39 | +0.00% | 360.97 |
|  | 2 | 750.40 | 750.14 | -0.03% | 750.48 | +0.01% | 545.02 |
|  | 3 | 982.44 | 982.46 | +0.00% | 982.40 | -0.00% | 794.06 |
|  | 4 | 1176.57 | 1180.19 | +0.31% | 1180.32 | +0.32% | 1031.80 |
|  | 5 | 1317.73 | 1318.32 | +0.04% | 1318.06 | +0.02% | 1251.10 |
|  | 6 | 1474.53 | 1474.18 | -0.02% | 1474.14 | -0.03% | 1466.60 |
|  | 7 | 1526.74 | 1527.07 | +0.02% | 1526.62 | -0.01% | 1671.94 |
|  | 8 | 1641.17 | 1641.50 | +0.02% | 1640.48 | -0.04% | 1868.71 |
| **Q3_K** | 1 | 362.32 | 362.21 | -0.03% | 362.27 | -0.01% | 303.04 |
|  | 2 | 642.96 | 643.27 | +0.05% | 642.95 | -0.00% | 465.77 |
|  | 3 | 818.36 | 818.86 | +0.06% | 818.36 | -0.00% | 681.30 |
|  | 4 | 1012.87 | 1013.60 | +0.07% | 1013.52 | +0.06% | 888.40 |
|  | 5 | 1254.82 | 1256.09 | +0.10% | 1255.04 | +0.02% | 1081.05 |
|  | 6 | 1415.44 | 1415.73 | +0.02% | 1414.69 | -0.05% | 1271.61 |
|  | 7 | 1411.94 | 1413.28 | +0.09% | 1412.36 | +0.03% | 1452.29 |
|  | 8 | 1530.72 | 1531.02 | +0.02% | 1529.05 | -0.11% | 1629.04 |
| **Q6_K** | 1 | 254.59 | 254.48 | -0.04% | 254.27 | -0.13% | 221.80 |
|  | 2 | 474.26 | 474.10 | -0.03% | 473.89 | -0.08% | 356.42 |
|  | 3 | 690.96 | 690.69 | -0.04% | 690.57 | -0.06% | 524.04 |
|  | 4 | 895.24 | 895.32 | +0.01% | 895.66 | +0.05% | 686.97 |
|  | 5 | 1038.06 | 1037.55 | -0.05% | 1037.66 | -0.04% | 840.33 |
|  | 6 | 1205.40 | 1204.99 | -0.03% | 1205.06 | -0.03% | 993.13 |
|  | 7 | 1364.63 | 1363.90 | -0.05% | 1364.24 | -0.03% | 1139.07 |
|  | 8 | 1503.64 | 1502.82 | -0.05% | 1503.77 | +0.01% | 1282.19 |
| **Q4_0** | 1 | 331.87 | 331.85 | -0.01% | 331.27 | -0.18% | 282.47 |
|  | 2 | 605.31 | 604.74 | -0.10% | 603.89 | -0.24% | 440.48 |
|  | 3 | 880.41 | 879.46 | -0.11% | 879.89 | -0.06% | 644.90 |
|  | 4 | 1132.88 | 1132.34 | -0.05% | 1132.19 | -0.06% | 842.59 |
|  | 5 | 1355.37 | 1354.42 | -0.07% | 1355.38 | +0.00% | 1027.77 |
|  | 6 | 1558.27 | 1557.87 | -0.03% | 1557.89 | -0.02% | 1210.37 |
|  | 7 | 1756.81 | 1755.15 | -0.09% | 1756.21 | -0.03% | 1382.85 |
|  | 8 | 1948.55 | 1947.74 | -0.04% | 1948.52 | -0.00% | 1552.15 |
| **Q8_0** | 1 | 212.01 | 212.06 | +0.02% | 212.08 | +0.03% | 190.89 |
|  | 2 | 394.02 | 393.87 | -0.04% | 393.79 | -0.06% | 323.91 |
|  | 3 | 578.97 | 578.81 | -0.03% | 579.27 | +0.05% | 476.77 |
|  | 4 | 754.34 | 754.23 | -0.01% | 754.29 | -0.01% | 625.48 |
|  | 5 | 911.76 | 910.99 | -0.08% | 911.89 | +0.02% | 767.41 |
|  | 6 | 1081.67 | 1081.65 | -0.00% | 1081.12 | -0.05% | 907.65 |
|  | 7 | 1233.53 | 1233.72 | +0.02% | 1233.63 | +0.01% | 1042.96 |
|  | 8 | 1351.27 | 1350.95 | -0.02% | 1350.59 | -0.05% | 1175.23 |
| **IQ4_XS** | 1 | 333.58 | 333.62 | +0.01% | 333.40 | -0.05% | 289.68 |
|  | 2 | 623.01 | 622.83 | -0.03% | 622.30 | -0.11% | 468.73 |
|  | 3 | 900.57 | 900.78 | +0.02% | 900.08 | -0.05% | 686.72 |
|  | 4 | 1158.82 | 1158.90 | +0.01% | 1159.09 | +0.02% | 895.67 |
|  | 5 | 1389.78 | 1388.60 | -0.09% | 1388.54 | -0.09% | 1088.64 |
|  | 6 | 1609.09 | 1608.44 | -0.04% | 1608.93 | -0.01% | 1280.86 |
|  | 7 | 1811.61 | 1811.08 | -0.03% | 1810.57 | -0.06% | 1462.02 |
|  | 8 | 1959.38 | 1958.15 | -0.06% | 1956.90 | -0.13% | 1637.81 |

### RTX 4090 - Llama-3.1-8B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 174.42 | 174.49 | +0.04% | 174.61 | +0.11% | 157.84 |
|  | 2 | 318.49 | 325.99 | +2.35% | 325.76 | +2.28% | 257.98 |
|  | 3 | 472.56 | 477.81 | +1.11% | 477.85 | +1.12% | 380.08 |
|  | 4 | 615.48 | 624.11 | +1.40% | 624.04 | +1.39% | 500.15 |
|  | 5 | 726.00 | 743.29 | +2.38% | 743.56 | +2.42% | 613.12 |
|  | 6 | 817.98 | 881.79 | +7.80% | 881.53 | +7.77% | 726.16 |
|  | 7 | 861.80 | 996.37 | +15.61% | 996.67 | +15.65% | 836.88 |
|  | 8 | 884.40 | 1094.17 | +23.72% | 1094.78 | +23.79% | 946.16 |
| **Q5_K** | 1 | 148.82 | 148.96 | +0.09% | 148.95 | +0.09% | 136.77 |
|  | 2 | 278.84 | 279.82 | +0.35% | 279.89 | +0.38% | 232.52 |
|  | 3 | 409.45 | 411.18 | +0.42% | 410.95 | +0.37% | 343.02 |
|  | 4 | 534.74 | 538.34 | +0.67% | 537.68 | +0.55% | 451.65 |
|  | 5 | 642.47 | 658.91 | +2.56% | 658.36 | +2.47% | 554.91 |
|  | 6 | 743.15 | 773.33 | +4.06% | 772.80 | +3.99% | 658.08 |
|  | 7 | 798.70 | 878.79 | +10.03% | 878.68 | +10.01% | 758.81 |
|  | 8 | 843.21 | 972.51 | +15.33% | 972.68 | +15.36% | 857.42 |
| **Q2_K** | 1 | 258.02 | 257.70 | -0.12% | 257.75 | -0.11% | 222.46 |
|  | 2 | 461.56 | 461.34 | -0.05% | 461.43 | -0.03% | 355.43 |
|  | 3 | 640.71 | 641.09 | +0.06% | 641.50 | +0.12% | 521.96 |
|  | 4 | 745.34 | 745.09 | -0.03% | 745.97 | +0.08% | 682.91 |
|  | 5 | 841.16 | 841.80 | +0.08% | 842.00 | +0.10% | 835.09 |
|  | 6 | 891.77 | 891.71 | -0.01% | 891.57 | -0.02% | 985.85 |
|  | 7 | 907.94 | 907.61 | -0.04% | 907.67 | -0.03% | 1132.58 |
|  | 8 | 971.38 | 972.57 | +0.12% | 972.15 | +0.08% | 1274.69 |
| **Q3_K** | 1 | 206.91 | 206.83 | -0.04% | 206.79 | -0.06% | 180.56 |
|  | 2 | 383.99 | 383.78 | -0.06% | 383.48 | -0.13% | 267.42 |
|  | 3 | 496.12 | 495.97 | -0.03% | 495.89 | -0.05% | 393.61 |
|  | 4 | 610.24 | 610.07 | -0.03% | 610.33 | +0.01% | 517.11 |
|  | 5 | 758.11 | 758.02 | -0.01% | 758.19 | +0.01% | 634.55 |
|  | 6 | 842.13 | 841.79 | -0.04% | 841.69 | -0.05% | 752.29 |
|  | 7 | 837.05 | 836.97 | -0.01% | 837.91 | +0.10% | 865.76 |
|  | 8 | 889.94 | 889.83 | -0.01% | 890.90 | +0.11% | 977.49 |
| **Q6_K** | 1 | 128.19 | 128.18 | -0.01% | 128.18 | -0.01% | 117.55 |
|  | 2 | 241.95 | 241.88 | -0.03% | 241.83 | -0.05% | 190.68 |
|  | 3 | 356.31 | 356.33 | +0.00% | 356.28 | -0.01% | 282.04 |
|  | 4 | 469.12 | 469.14 | +0.00% | 469.04 | -0.02% | 371.96 |
|  | 5 | 560.52 | 560.50 | -0.00% | 560.39 | -0.02% | 458.21 |
|  | 6 | 655.94 | 656.24 | +0.05% | 656.06 | +0.02% | 544.69 |
|  | 7 | 763.41 | 763.82 | +0.05% | 763.78 | +0.05% | 629.13 |
|  | 8 | 851.21 | 850.89 | -0.04% | 851.04 | -0.02% | 711.66 |
| **Q4_0** | 1 | 175.17 | 175.22 | +0.03% | 175.16 | -0.00% | 157.54 |
|  | 2 | 327.66 | 327.89 | +0.07% | 327.89 | +0.07% | 263.46 |
|  | 3 | 479.96 | 480.01 | +0.01% | 479.90 | -0.01% | 388.00 |
|  | 4 | 627.84 | 627.74 | -0.02% | 627.53 | -0.05% | 510.19 |
|  | 5 | 754.07 | 753.95 | -0.02% | 753.55 | -0.07% | 625.93 |
|  | 6 | 897.73 | 897.84 | +0.01% | 897.76 | +0.00% | 741.74 |
|  | 7 | 1020.99 | 1020.82 | -0.02% | 1019.81 | -0.12% | 854.43 |
|  | 8 | 1151.58 | 1152.02 | +0.04% | 1151.80 | +0.02% | 963.94 |
| **Q8_0** | 1 | 103.31 | 103.34 | +0.03% | 103.33 | +0.02% | 97.25 |
|  | 2 | 198.21 | 198.26 | +0.02% | 198.19 | -0.01% | 175.72 |
|  | 3 | 291.91 | 291.92 | +0.00% | 291.86 | -0.02% | 260.16 |
|  | 4 | 384.71 | 384.71 | -0.00% | 384.62 | -0.02% | 343.44 |
|  | 5 | 462.68 | 462.35 | -0.07% | 462.52 | -0.04% | 423.65 |
|  | 6 | 551.24 | 550.58 | -0.12% | 550.92 | -0.06% | 503.92 |
|  | 7 | 631.47 | 631.20 | -0.04% | 631.13 | -0.05% | 582.96 |
|  | 8 | 724.43 | 724.06 | -0.05% | 724.16 | -0.04% | 660.24 |
| **IQ4_XS** | 1 | 182.88 | 182.74 | -0.07% | 182.68 | -0.11% | 164.50 |
|  | 2 | 342.49 | 342.42 | -0.02% | 342.34 | -0.04% | 278.07 |
|  | 3 | 499.56 | 499.33 | -0.05% | 499.22 | -0.07% | 409.27 |
|  | 4 | 655.24 | 655.33 | +0.01% | 655.20 | -0.01% | 537.02 |
|  | 5 | 796.16 | 796.20 | +0.00% | 795.87 | -0.04% | 657.72 |
|  | 6 | 938.78 | 938.30 | -0.05% | 935.42 | -0.36% | 779.03 |
|  | 7 | 1067.06 | 1067.18 | +0.01% | 1064.76 | -0.22% | 895.70 |
|  | 8 | 1187.71 | 1187.72 | +0.00% | 1186.49 | -0.10% | 1011.09 |

### RTX 4090 - gemma-4-12B-it

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 103.04 | 102.87 | -0.17% | 102.95 | -0.09% | 86.06 |
|  | 2 | 193.56 | 195.06 | +0.77% | 195.06 | +0.78% | 153.33 |
|  | 3 | 280.30 | 285.12 | +1.72% | 284.71 | +1.57% | 226.00 |
|  | 4 | 366.94 | 373.58 | +1.81% | 373.36 | +1.75% | 296.61 |
|  | 5 | 426.42 | 439.22 | +3.00% | 439.33 | +3.03% | 363.44 |
|  | 6 | 479.09 | 521.73 | +8.90% | 522.18 | +8.99% | 430.08 |
|  | 7 | 514.05 | 585.86 | +13.97% | 586.37 | +14.07% | 494.24 |
|  | 8 | 517.05 | 640.92 | +23.96% | 641.14 | +24.00% | 557.76 |
| **Q5_K** | 1 | 88.77 | 88.76 | -0.01% | 88.71 | -0.07% | 76.82 |
|  | 2 | 167.04 | 169.05 | +1.21% | 169.09 | +1.23% | 140.98 |
|  | 3 | 247.14 | 248.02 | +0.35% | 247.76 | +0.25% | 208.34 |
|  | 4 | 318.03 | 324.85 | +2.15% | 324.69 | +2.09% | 273.68 |
|  | 5 | 381.50 | 394.65 | +3.45% | 394.49 | +3.40% | 335.66 |
|  | 6 | 437.13 | 461.90 | +5.67% | 461.69 | +5.62% | 397.71 |
|  | 7 | 463.47 | 522.95 | +12.84% | 523.38 | +12.93% | 457.31 |
|  | 8 | 494.87 | 579.33 | +17.07% | 579.21 | +17.04% | 515.83 |
| **Q2_K** | 1 | 146.50 | 146.52 | +0.02% | 146.54 | +0.03% | 121.08 |
|  | 2 | 268.13 | 268.13 | +0.00% | 268.19 | +0.02% | 215.01 |
|  | 3 | 364.64 | 364.57 | -0.02% | 364.70 | +0.02% | 315.78 |
|  | 4 | 428.75 | 428.72 | -0.01% | 428.71 | -0.01% | 412.46 |
|  | 5 | 491.20 | 491.22 | +0.00% | 491.13 | -0.01% | 502.80 |
|  | 6 | 526.12 | 526.08 | -0.01% | 526.22 | +0.02% | 591.70 |
|  | 7 | 524.89 | 525.72 | +0.16% | 524.91 | +0.01% | 678.00 |
|  | 8 | 566.21 | 566.20 | -0.00% | 565.36 | -0.15% | 760.87 |
| **Q3_K** | 1 | 121.15 | 121.14 | -0.00% | 121.13 | -0.02% | 94.12 |
|  | 2 | 223.33 | 223.27 | -0.03% | 223.32 | -0.00% | 163.61 |
|  | 3 | 290.50 | 290.50 | +0.00% | 290.56 | +0.02% | 241.03 |
|  | 4 | 358.46 | 358.40 | -0.02% | 358.41 | -0.01% | 316.21 |
|  | 5 | 435.45 | 435.61 | +0.04% | 435.63 | +0.04% | 387.43 |
|  | 6 | 487.27 | 487.19 | -0.02% | 487.19 | -0.02% | 457.60 |
|  | 7 | 487.27 | 487.37 | +0.02% | 487.17 | -0.02% | 526.06 |
|  | 8 | 522.07 | 522.17 | +0.02% | 522.11 | +0.01% | 592.51 |
| **Q6_K** | 1 | 76.76 | 76.77 | +0.01% | 76.77 | +0.01% | 64.74 |
|  | 2 | 147.16 | 147.21 | +0.03% | 147.18 | +0.01% | 115.37 |
|  | 3 | 215.69 | 215.72 | +0.01% | 215.65 | -0.02% | 170.80 |
|  | 4 | 283.44 | 283.62 | +0.06% | 283.52 | +0.03% | 224.73 |
|  | 5 | 336.85 | 336.86 | +0.00% | 336.88 | +0.01% | 276.67 |
|  | 6 | 392.66 | 392.66 | +0.00% | 392.73 | +0.02% | 328.28 |
|  | 7 | 455.01 | 455.10 | +0.02% | 454.84 | -0.04% | 378.53 |
|  | 8 | 504.30 | 504.45 | +0.03% | 504.33 | +0.01% | 427.15 |
| **Q4_0** | 1 | 103.09 | 103.08 | -0.01% | 103.05 | -0.03% | 88.05 |
|  | 2 | 195.87 | 195.72 | -0.08% | 195.79 | -0.04% | 158.52 |
|  | 3 | 287.00 | 286.96 | -0.01% | 286.97 | -0.01% | 233.66 |
|  | 4 | 375.21 | 375.13 | -0.02% | 375.04 | -0.05% | 306.83 |
|  | 5 | 447.34 | 447.17 | -0.04% | 447.23 | -0.02% | 375.92 |
|  | 6 | 532.30 | 532.38 | +0.02% | 532.36 | +0.01% | 444.10 |
|  | 7 | 601.78 | 601.69 | -0.01% | 601.60 | -0.03% | 510.71 |
|  | 8 | 677.83 | 677.55 | -0.04% | 677.58 | -0.04% | 575.28 |
| **Q8_0** | 1 | 62.64 | 62.67 | +0.04% | 62.66 | +0.03% | 57.76 |
|  | 2 | 120.97 | 120.98 | +0.01% | 120.96 | -0.00% | 109.46 |
|  | 3 | 178.12 | 178.13 | +0.01% | 178.12 | +0.00% | 162.11 |
|  | 4 | 234.47 | 234.51 | +0.02% | 234.46 | -0.00% | 213.62 |
|  | 5 | 283.54 | 283.53 | -0.00% | 283.53 | -0.01% | 263.38 |
|  | 6 | 334.77 | 334.81 | +0.01% | 334.72 | -0.01% | 312.86 |
|  | 7 | 382.93 | 382.91 | -0.00% | 382.76 | -0.04% | 361.07 |
|  | 8 | 438.75 | 438.60 | -0.03% | 438.53 | -0.05% | 408.36 |
| **IQ4_XS** | 1 | 106.46 | 106.53 | +0.07% | 106.52 | +0.06% | 93.45 |
|  | 2 | 204.22 | 204.31 | +0.04% | 204.25 | +0.01% | 173.54 |
|  | 3 | 298.52 | 298.52 | +0.00% | 298.49 | -0.01% | 255.40 |
|  | 4 | 389.83 | 390.03 | +0.05% | 389.93 | +0.03% | 334.68 |
|  | 5 | 471.63 | 471.92 | +0.06% | 471.77 | +0.03% | 409.31 |
|  | 6 | 550.44 | 550.01 | -0.08% | 550.55 | +0.02% | 483.61 |
|  | 7 | 624.85 | 624.86 | +0.00% | 624.83 | -0.00% | 555.04 |
|  | 8 | 691.06 | 691.28 | +0.03% | 691.15 | +0.01% | 623.34 |

### RTX 4090 - Qwen3.6-27B

| type | ne11 | base t/s | branchless t/s | vs base | branchless + prefetch t/s | vs base | MMQ t/s (forced at all ne11 - for comparison) |
|---|---|---|---|---|---|---|---|
| **Q4_K** | 1 | 51.65 | 51.98 | +0.64% | 52.01 | +0.71% | 44.24 |
|  | 2 | 97.72 | 98.33 | +0.62% | 98.34 | +0.64% | 72.94 |
|  | 3 | 143.65 | 144.67 | +0.71% | 144.69 | +0.72% | 108.41 |
|  | 4 | 187.70 | 190.39 | +1.43% | 190.36 | +1.41% | 143.21 |
|  | 5 | 220.14 | 230.72 | +4.81% | 230.75 | +4.82% | 176.66 |
|  | 6 | 247.99 | 268.45 | +8.25% | 268.46 | +8.25% | 210.10 |
|  | 7 | 260.73 | 303.74 | +16.50% | 303.72 | +16.49% | 243.01 |
|  | 8 | 270.44 | 334.03 | +23.51% | 334.17 | +23.57% | 275.93 |
| **Q5_K** | 1 | 44.03 | 44.09 | +0.12% | 44.10 | +0.15% | 38.77 |
|  | 2 | 82.68 | 83.99 | +1.59% | 84.01 | +1.61% | 67.22 |
|  | 3 | 123.78 | 124.28 | +0.41% | 124.31 | +0.43% | 99.90 |
|  | 4 | 161.02 | 163.39 | +1.47% | 163.42 | +1.49% | 132.03 |
|  | 5 | 192.01 | 197.46 | +2.84% | 197.46 | +2.84% | 162.98 |
|  | 6 | 223.59 | 232.51 | +3.99% | 232.55 | +4.01% | 193.95 |
|  | 7 | 243.80 | 265.73 | +8.99% | 265.82 | +9.03% | 224.43 |
|  | 8 | 256.21 | 295.94 | +15.51% | 295.96 | +15.51% | 254.37 |
| **Q2_K** | 1 | 76.32 | 76.34 | +0.02% | 76.38 | +0.07% | 63.01 |
|  | 2 | 139.74 | 139.76 | +0.02% | 139.79 | +0.04% | 106.32 |
|  | 3 | 196.10 | 196.05 | -0.03% | 196.11 | +0.00% | 157.60 |
|  | 4 | 231.82 | 231.95 | +0.06% | 231.95 | +0.06% | 207.34 |
|  | 5 | 262.50 | 262.42 | -0.03% | 262.38 | -0.04% | 254.69 |
|  | 6 | 273.56 | 273.32 | -0.09% | 273.42 | -0.05% | 302.15 |
|  | 7 | 283.63 | 283.52 | -0.04% | 283.43 | -0.07% | 348.68 |
|  | 8 | 299.79 | 299.66 | -0.04% | 299.84 | +0.02% | 393.75 |
| **Q3_K** | 1 | 61.82 | 61.84 | +0.02% | 61.81 | -0.03% | 49.53 |
|  | 2 | 115.34 | 115.38 | +0.03% | 115.39 | +0.04% | 77.10 |
|  | 3 | 156.29 | 156.30 | +0.01% | 156.33 | +0.02% | 114.43 |
|  | 4 | 194.97 | 195.03 | +0.03% | 195.02 | +0.02% | 151.12 |
|  | 5 | 236.45 | 236.43 | -0.01% | 236.51 | +0.02% | 186.19 |
|  | 6 | 261.69 | 261.25 | -0.17% | 261.67 | -0.01% | 221.35 |
|  | 7 | 261.26 | 261.03 | -0.09% | 261.19 | -0.03% | 255.78 |
|  | 8 | 278.36 | 278.13 | -0.08% | 278.18 | -0.07% | 289.90 |
| **Q4_0** | 1 | 51.89 | 51.88 | -0.01% | 51.90 | +0.03% | 44.25 |
|  | 2 | 98.60 | 98.61 | +0.01% | 98.62 | +0.02% | 77.55 |
|  | 3 | 146.06 | 146.09 | +0.02% | 146.09 | +0.02% | 115.24 |
|  | 4 | 191.94 | 191.99 | +0.03% | 191.98 | +0.02% | 152.18 |
|  | 5 | 233.38 | 233.37 | -0.00% | 233.32 | -0.03% | 187.68 |
|  | 6 | 276.72 | 276.77 | +0.02% | 276.74 | +0.01% | 223.14 |
|  | 7 | 316.56 | 316.51 | -0.02% | 316.52 | -0.01% | 258.01 |
|  | 8 | 354.34 | 354.36 | +0.00% | 354.34 | -0.00% | 292.35 |
| **IQ4_XS** | 1 | 54.32 | 54.35 | +0.04% | 54.34 | +0.02% | 47.49 |
|  | 2 | 103.09 | 103.11 | +0.01% | 103.12 | +0.03% | 84.86 |
|  | 3 | 152.05 | 152.09 | +0.03% | 152.15 | +0.06% | 125.93 |
|  | 4 | 199.64 | 199.75 | +0.05% | 199.70 | +0.03% | 166.01 |
|  | 5 | 243.65 | 243.73 | +0.03% | 243.75 | +0.04% | 204.61 |
|  | 6 | 285.60 | 285.54 | -0.02% | 285.57 | -0.01% | 243.08 |
|  | 7 | 328.00 | 327.98 | -0.01% | 328.09 | +0.03% | 280.84 |
|  | 8 | 367.43 | 367.36 | -0.02% | 367.41 | -0.00% | 317.70 |

Q6_K, Q8_0 not measured here - they exceed this card's memory.

</p>
</details> 


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: AI was used to partially assist while making the code edits and to understand the contexts of the code base.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
