### PR TITLE
mtmd: stop feeding the text stream again during Qwen3-TTS generation

### DIFF
--- a/tools/mtmd/mtmd-helper-gen.cpp
+++ b/tools/mtmd/mtmd-helper-gen.cpp
@@ -112,7 +112,6 @@ public:
         c2w_state.clear();
         audio_pcm.clear();
         overlay.clear();
-        overlay_idx = 0;
         h_state_buf.clear();
         out_buf.clear();
         prompt_embd_buf.clear();
@@ -205,11 +204,9 @@ public:
         top_p = inp->top_p > 0 ? inp->top_p : 1.0f;
         out_type = inp->out_type;
 
-        // the text stream keeps flowing during generation: after frame k, the input adds
-        // trailing text row k on top of the codes embedding, then tts_eos, then tts_pad
-        for (int i = 3; i < n_ids - 5; i++) overlay.push_back(row(ids[(size_t) i]));
-        overlay.push_back(row(tts_eos));
-        overlay.push_back(row(tts_pad));
+        // the prompt above holds the whole text stream up to tts_eos, so every generated
+        // frame adds tts_pad on top of the codes embedding
+        overlay = row(tts_pad);
 
         return 0;
     }
@@ -265,9 +262,7 @@ public:
         }
 
         std::vector<float> fb(out.embd, out.embd + n_embd);
-        const auto & ov = overlay[std::min(overlay_idx, overlay.size() - 1)];
-        for (int i = 0; i < n_embd; i++) fb[(size_t) i] += ov[(size_t) i];
-        overlay_idx++;
+        for (int i = 0; i < n_embd; i++) fb[(size_t) i] += overlay[(size_t) i];
 
         const int n_pos_per_embd = mrope ? 4 : 1;
         decode_embd_batch batch_embd(fb.data(), 1, n_pos_per_embd, n_embd);
@@ -437,8 +432,7 @@ private:
     std::vector<int32_t> codes_buf;
     std::vector<uint8_t> c2w_state;
     std::vector<float>   audio_pcm;
-    std::vector<std::vector<float>> overlay;
-    size_t overlay_idx = 0;
+    std::vector<float> overlay;
     std::vector<float> h_state_buf;
     mtmd_helper_gen_audio_outtype out_type = MTMD_HELPER_GEN_AUDIO_OUTTYPE_WAV;
     std::vector<char> out_buf;


### PR DESCRIPTION
## Overview

The prompt is built in non-streaming mode, where the full text already sits in the prefill, but the per-frame overlay was still the streaming one and fed the text a second time.

## Additional information

The reference implementation has two mutually exclusive prompt layouts. In non streaming mode the prefill carries the whole utterance text plus tts_eos summed with codec_pad, and the trailing text hidden collapses to a single tts_pad row. In streaming mode the prefill carries only the first text token and the trailing rows stream the rest of the text followed by tts_eos.

The pipeline built the non streaming prefill but the streaming overlay, so the talker saw the utterance a second time during generation and read it twice before emitting codec_eos.

The overlay is now the single tts_pad row that matches the prefill.

Fixes #26700

### Before :

Text "The quick brown fox jumps over the lazy dog."

Give twice "The quick brown fox jumps over the lazy dog ............................................. The the quick brown fox jumps over the lazy dog."

[repro-double.wav](https://github.com/user-attachments/files/30822871/repro-double.wav)

### After :

Same text "The quick brown fox jumps over the lazy dog."

[fix-fox-1.wav](https://github.com/user-attachments/files/30822918/fix-fox-1.wav)
[fix-fox-2.wav](https://github.com/user-attachments/files/30822915/fix-fox-2.wav)
[fix-fox-3.wav](https://github.com/user-attachments/files/30822914/fix-fox-3.wav)

Longer text "The old lighthouse had guarded the harbor for over a century. Every night its beam swept across the water in slow, patient arcs. Sailors said you could set your watch by it. When the storm finally took the roof, the town rebuilt it in a single summer. Nobody wanted to imagine the coast without that light."

[fix-long.wav](https://github.com/user-attachments/files/30822916/fix-long.wav)
[fix-long-clone.wav](https://github.com/user-attachments/files/30822917/fix-long-clone.wav)


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, who doesn't use AI?

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
