### PR TITLE
metal : fix NORM/RMS_NORM for row lengths that leave a partial simdgroup

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -3816,7 +3816,7 @@ int ggml_metal_op_norm(ggml_metal_op_t ctx, int idx) {
     }
 
     nth = std::min(nth, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
-    nth = std::min(nth, args.ne00_t);
+    nth = std::min(nth, (args.ne00_t + 31)/32*32);
 
     const size_t smem = pipeline.smem;
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8722,6 +8722,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_l2_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, true));
             test_cases.emplace_back(new test_l2_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, eps, false, true));
         }
+        // row lengths that are not a multiple of 32, for the scalar (33) and float4 (132, 260) paths
+        for (uint32_t n : { 33, 132, 260 }) {
+            for (bool v : { false, true }) {
+                test_cases.emplace_back(new test_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, v, eps));
+                test_cases.emplace_back(new test_rms_norm(GGML_TYPE_F32, { n, 5, 4, 3 }, v, eps));
+            }
+        }
     }
 
     // in-place tests


### PR DESCRIPTION
## Overview

`ggml_metal_op_norm` sizes the threadgroup with `nth = std::min(nth, args.ne00_t)`
(`ggml-metal-ops.cpp:3819`), which can leave `nth` not a multiple of the simdgroup
size. Both norm kernels finish their row reduction with a cross-simdgroup step where
each lane of the last simdgroup reads one per-simdgroup partial sum out of `shmem_f32`.

When the last simdgroup is partial it has fewer lanes than the threadgroup has
simdgroups, so the tail of the partial sums is never read. For `ne00_t = 33`, `nth`
becomes 33: two simdgroups, but only one lane in the second, so one of the two partial
sums is silently dropped and the mean and variance are wrong for the whole row.
This affects `GGML_OP_NORM` as well as `GGML_OP_RMS_NORM`, as both dispatch through
`ggml_metal_op_norm`.

The fix rounds `ne00_t` up to a whole number of simdgroups instead of clamping to it
exactly. I first tried simply dropping the clamp, which is also correct but costs idle
lanes, because `nth` then stays at the next power of two.

Before, on an M3 Pro (`MTLGPUFamilyApple9`), with the new test cases and the old
dispatch line:

```
test-backend-ops test -b MTL0 -o NORM        25/50
test-backend-ops test -b MTL0 -o RMS_NORM    26/51
```

After:

```
test-backend-ops test -b MTL0 -o NORM        50/50
test-backend-ops test -b MTL0 -o RMS_NORM    51/51
test-backend-ops test -b MTL0                13943/13943
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - investigation, additional validation, additional testing (separated from the unit test included in the PR)
