### PR TITLE
ui: set npm `min-release-age` to protect against supply-chain attacks

### DIFF
--- a/tools/ui/.npmrc
+++ b/tools/ui/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 ignore-scripts=true
+min-release-age=4

--- a/tools/ui/.npmrc
+++ b/tools/ui/.npmrc
@@ -1,3 +1,3 @@
 engine-strict=true
 ignore-scripts=true
-min-release-age=4
+min-release-age=7


### PR DESCRIPTION
## Overview

There's been a surge in npm supply-chain attacks.

It'll often go like this: An attacker hacks a maintainer's account or gets the maintainer to transfer package ownership to them. The attacker pushes a package update containing malicious code. Once a developer installs the package, their machine is compromised. Examples: [1a](https://socket.dev/blog/axios-npm-package-compromised), [1b](https://socket.dev/blog/axios-maintainer-confirms-social-engineering-behind-npm-compromise), [2](https://socket.dev/blog/tinycolor-supply-chain-attack-affects-40-packages), [3](https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack).

Usually, these instances are detected by automated scanning tools within a few hours. However, a malicious package often still remains online on npm for a few hours. During that time, if someone installs the package, their machine is compromised.

We can reduce exposure to these attacks by waiting a few days to install newly-published packages. That's what this PR does. Unfortunately, that's currently the best protection that we have against these attacks.

In cases where we need to install a newly-published package urgently (e.g., to fix a security issue), we can still circumvent this by passing `--min-release-age=0` on the command line.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
