### PR TITLE
Expose memory breakdown entries through C API

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -4182,6 +4182,29 @@ llama_memory_breakdown llama_get_memory_breakdown(const struct llama_context * c
     return ctx->memory_breakdown();
 }
 
+extern "C" const llama_memory_breakdown_entry * llama_get_memory_breakdown_entries(
+        const struct llama_context * ctx,
+        size_t * count) {
+    static thread_local std::vector<llama_memory_breakdown_entry> entries;
+
+    entries.clear();
+
+    const llama_memory_breakdown breakdown = llama_get_memory_breakdown(ctx);
+
+    for (const auto & [buft, data] : breakdown) {
+        entries.push_back({
+            ggml_backend_buft_name(buft),
+            data.model,
+            data.context,
+            data.compute,
+        });
+    }
+
+    *count = entries.size();
+
+    return entries.data();
+}
+
 llama_context * llama_get_ctx_other(struct llama_context * ctx) {
     return ctx->get_cparams().ctx_other;
 }

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -90,6 +90,21 @@ LLAMA_API ggml_backend_dev_t llama_model_get_device(const struct llama_model * m
 
 LLAMA_API llama_memory_breakdown llama_get_memory_breakdown(const struct llama_context * ctx);
 
+struct llama_memory_breakdown_entry {
+    const char * name;
+    size_t model;
+    size_t context;
+    size_t compute;
+};
+
+extern "C" {
+
+LLAMA_API const llama_memory_breakdown_entry * llama_get_memory_breakdown_entries(
+        const struct llama_context * ctx,
+        size_t * count);
+
+}
+
 // Set whether the context outputs nextn embeddings or not
 // If masked == true,  output the embeddings only for the tokens with batch.logits != 0
 // If masked == false, output the embeddings for all tokens in the batch regardless of batch.logits


### PR DESCRIPTION
## Overview

Exposes `llama_context::memory_breakdown()` through the C API as a flat array of memory breakdown entries. Each entry reports the backend buffer type name and its model, context, and compute memory usage.

## Additional information

This makes the existing memory breakdown available to C API consumers and FFI bindings such as `llama-cpp-python`, without exposing the underlying C++ types.

The existing llama.cpp test suite passes with this change. The API was also exercised through a `llama-cpp-python` binding, whose test suite passes (26/26).

Related to #26129, which proposes exposing the same memory breakdown information through `llama-server`.

## Requirements

I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

AI was used to help investigate the existing memory accounting code, reason about the C API/FFI boundary, and assist with implementing and testing the change. The resulting code was manually reviewed and tested.
