### PR TITLE
ui: add dynamic switchable full-width chat layout option (#26721)

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageAssistant/ChatMessageAssistantProcessingInfo.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageAssistant/ChatMessageAssistantProcessingInfo.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { config } from '$lib/stores/settings.svelte';
 	import { fade } from 'svelte/transition';
+	import { SETTINGS_KEYS } from '$lib/constants';
 	import type { UseProcessingStateReturn } from '$lib/hooks/use-processing-state.svelte';
 
 	interface Props {
@@ -10,10 +12,11 @@
 
 	let { modelLoadingText, processingState, position }: Props = $props();
 
+	const isFullWidth = $derived(Boolean(config()[SETTINGS_KEYS.FULL_WIDTH_CHAT]));
 	const marginClass = position === 'top' ? 'mt-6' : 'mt-4';
 </script>
 
-<div class="{marginClass} w-full max-w-3xl" in:fade>
+<div class="{marginClass} w-full {isFullWidth ? '' : 'max-w-3xl'}" in:fade>
 	<div class="flex flex-col items-start gap-2">
 		<span class="shimmer-text text-sm">
 			{modelLoadingText ??

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageAssistant/ChatMessageAssistantRawOutput.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageAssistant/ChatMessageAssistantRawOutput.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { config } from '$lib/stores/settings.svelte';
 	import { deriveAgenticSections, buildAssistantRawOutput } from '$lib/utils';
+	import { SETTINGS_KEYS } from '$lib/constants';
 
 	interface Props {
 		message: DatabaseMessage;
@@ -12,9 +14,11 @@
 		const sections = deriveAgenticSections(message, toolMessages, [], false);
 		return buildAssistantRawOutput(sections);
 	});
+
+	const isFullWidth = $derived(Boolean(config()[SETTINGS_KEYS.FULL_WIDTH_CHAT]));
 </script>
 
-<pre class="raw-output">{rawOutputContent || ''}</pre>
+<pre class="raw-output" class:raw-output-full-width={isFullWidth}>{rawOutputContent || ''}</pre>
 
 <style>
 	.raw-output {
@@ -29,5 +33,9 @@
 		line-height: 1.6;
 		white-space: pre-wrap;
 		word-break: break-word;
+	}
+
+	.raw-output-full-width {
+		max-width: none;
 	}
 </style>

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUser.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUser.svelte
@@ -5,11 +5,12 @@
 		ChatMessageStatistics,
 		ChatMessageUserBubble
 	} from '$lib/components/app/chat';
+	import { config } from '$lib/stores/settings.svelte';
 	import { getMessageEditContext } from '$lib/contexts';
 	import { useProcessingState } from '$lib/hooks/use-processing-state.svelte';
 	import { isLoading } from '$lib/stores/chat.svelte';
 	import { MessageRole, ChatMessageStatisticsMode } from '$lib/enums';
-	import { config } from '$lib/stores/settings.svelte';
+	import { SETTINGS_KEYS } from '$lib/constants';
 
 	interface Props {
 		class?: string;
@@ -56,6 +57,7 @@
 
 	const currentConfig = $derived(config());
 	const isActivelyProcessing = $derived(isLastUserMessage && isLoading());
+	const isFullWidth = $derived(Boolean(config()[SETTINGS_KEYS.FULL_WIDTH_CHAT]));
 
 	// For agentic turns, prefer the cumulative agentic.llm totals over per-call timings.
 	let storedReadingStats = $derived.by(() => {
@@ -131,7 +133,7 @@
 		{/if}
 
 		{#if message.timestamp}
-			<div class="max-w-[80%]">
+			<div class={isFullWidth ? 'w-full' : 'max-w-[80%]'}>
 				<ChatMessageActionIcons
 					actionsPosition="right"
 					{deletionInfo}

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUserBubble.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUserBubble.svelte
@@ -2,6 +2,7 @@
 	import { Card } from '$lib/components/ui/card';
 	import { ChatAttachmentsList, MarkdownContent } from '$lib/components/app';
 	import { config } from '$lib/stores/settings.svelte';
+	import { SETTINGS_KEYS } from '$lib/constants';
 	import type { DatabaseMessageExtra } from '$lib/types/database';
 
 	interface Props {
@@ -24,7 +25,9 @@
 
 	let isMultiline = $state(false);
 	let messageElement: HTMLElement | undefined = $state();
+
 	const currentConfig = config();
+	const isFullWidth = $derived(Boolean(config()[SETTINGS_KEYS.FULL_WIDTH_CHAT]));
 
 	$effect(() => {
 		if (!messageElement || !content.trim()) return;
@@ -52,14 +55,16 @@
 </script>
 
 {#if attachments && attachments.length > 0}
-	<div class="mb-2 max-w-[80%]">
+	<div class="mb-2 {isFullWidth ? 'w-full' : 'max-w-[80%]'}">
 		<ChatAttachmentsList {attachments} readonly imageHeight="h-40" />
 	</div>
 {/if}
 
 {#if content.trim()}
 	<Card
-		class="chat-message-user-bubble max-w-[80%] overflow-y-auto rounded-[1.125rem] border-none bg-primary/5 px-3.75 py-1.5 {textColorClass} backdrop-blur-md data-multiline:py-2.5 {cardBgClass}"
+		class="chat-message-user-bubble {isFullWidth
+			? 'w-full border-2 border-border/30 dark:border-border/20'
+			: 'max-w-[80%] border-none'} overflow-y-auto rounded-[1.125rem] bg-primary/5 px-3.75 py-1.5 {textColorClass} backdrop-blur-md data-multiline:py-2.5 {cardBgClass}"
 		data-multiline={isMultiline ? '' : undefined}
 		style="{maxHeightStyle} overflow-wrap: anywhere; word-break: break-word;"
 	>

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUserPending.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessage/ChatMessageUser/ChatMessageUserPending.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { ActionIcon, ChatMessageEditForm, ChatMessageUserBubble } from '$lib/components/app';
 	import { ArrowUp, Edit, Trash2 } from '@lucide/svelte';
+	import { config } from '$lib/stores/settings.svelte';
 	import { useMessageEditContext } from '$lib/hooks/use-message-edit-context.svelte';
+	import { SETTINGS_KEYS } from '$lib/constants';
 
 	interface Props {
 		class?: string;
@@ -26,6 +28,7 @@
 		getExtras: () => extras,
 		onSave: (content, extras) => onEdit(content, extras)
 	});
+	const isFullWidth = $derived(Boolean(config()[SETTINGS_KEYS.FULL_WIDTH_CHAT]));
 </script>
 
 <div
@@ -44,7 +47,7 @@
 			maxHeightStyle="overflow-wrap: anywhere; word-break: break-word;"
 		/>
 
-		<div class="max-w-[80%]">
+		<div class={isFullWidth ? 'w-full' : 'max-w-[80%]'}>
 			<div class="relative flex h-6 items-center justify-between">
 				<div class="right-0 flex items-center gap-2 opacity-100 transition-opacity">
 					<div

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
@@ -46,6 +46,7 @@
 	const alwaysShowToolCallContent = $derived(Boolean(config().alwaysShowToolCallContent));
 	const showMessageStats = $derived(Boolean(config().showMessageStats));
 	const showAgenticTurnStats = $derived(showMessageStats && Boolean(config().showAgenticTurnStats));
+	const isFullWidth = $derived(Boolean(config().fullWidthChat));
 
 	const hasReasoningError = $derived(
 		isLastAssistantMessage ? !!agenticLastError(message.convId) : false
@@ -204,7 +205,7 @@
 	{/if}
 {/snippet}
 
-<div class="agentic-content gap-2">
+<div class="agentic-content gap-2" class:agentic-content--full-width={isFullWidth}>
 	{#if turnGroups.length > 1}
 		{#each turnGroups as turn, turnIndex (turnIndex)}
 			{@const turnStats = message?.timings?.agentic?.perTurn?.[turnIndex]}
@@ -256,6 +257,10 @@
 		flex-direction: column;
 		width: 100%;
 		max-width: 48rem;
+	}
+
+	.agentic-content-full-width {
+		max-width: none;
 	}
 
 	.agentic-content > :global(*),

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessages.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessages.svelte
@@ -23,6 +23,7 @@
 		formatMessageForClipboard,
 		hasAgenticContent
 	} from '$lib/utils';
+	import { SETTINGS_KEYS } from '$lib/constants';
 
 	interface Props {
 		messages?: DatabaseMessage[];
@@ -35,6 +36,7 @@
 	let allConversationMessages = $state<DatabaseMessage[]>([]);
 
 	const currentConfig = config();
+	const isFullWidth = $derived(Boolean(config()[SETTINGS_KEYS.FULL_WIDTH_CHAT]));
 
 	setChatActionsContext({
 		copy: async (message: DatabaseMessage) => {
@@ -237,7 +239,7 @@
 <div>
 	{#each displayMessages as { message, toolMessages, isLastAssistantMessage, isLastUserMessage, nextAssistantMessage, siblingInfo } (message.id)}
 		<ChatMessage
-			class="mx-auto mt-12 w-full max-w-3xl"
+			class="mx-auto mt-12 w-full {isFullWidth ? '' : 'max-w-3xl'}"
 			{message}
 			{toolMessages}
 			{isLastAssistantMessage}
@@ -253,7 +255,7 @@
 
 		{#if pendingContent}
 			<ChatMessageUserPending
-				class="mx-auto mt-12 w-full max-w-[48rem]"
+				class="mx-auto mt-12 w-full {isFullWidth ? '' : 'max-w-[48rem]'}"
 				content={pendingContent}
 				extras={agenticPendingSteeringMessageExtras(convId)}
 				onSendImmediately={() => chatStore.abortCurrentFlow(convId)}
@@ -267,7 +269,7 @@
 
 		{#if pendingContent}
 			<ChatMessageUserPending
-				class="mx-auto mt-12 w-full max-w-[48rem]"
+				class="mx-auto mt-12 w-full {isFullWidth ? '' : 'max-w-[48rem]'}"
 				content={pendingContent}
 				extras={chatPendingMessageExtras(convId)}
 				onSendImmediately={() => chatStore.abortCurrentFlow(convId)}

--- a/tools/ui/src/lib/components/app/chat/ChatScreen/ChatScreenForm.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatScreen/ChatScreenForm.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation';
+	import { config } from '$lib/stores/settings.svelte';
 	import { page } from '$app/state';
 	import { ChatForm } from '$lib/components/app';
 	import { isMobile } from '$lib/stores/viewport.svelte';
 	import { onMount } from 'svelte';
 	import { useDraftMessages } from '$lib/hooks/use-draft-messages.svelte';
+	import { SETTINGS_KEYS } from '$lib/constants';
 
 	interface Props {
 		class?: string;
@@ -35,6 +37,8 @@
 	let chatFormRef: ChatForm | undefined = $state(undefined);
 	let formWrapperEl: HTMLDivElement | undefined = $state();
 	let chatId = $derived(page.params.id as string | undefined);
+
+	const isFullWidth = $derived(Boolean(config()[SETTINGS_KEYS.FULL_WIDTH_CHAT]));
 
 	$effect(() => {
 		if (!formWrapperEl) return;
@@ -144,7 +148,7 @@
 
 <div class="chat-screen-form-wrapper" bind:this={formWrapperEl}>
 	<ChatForm
-		class="mx-auto max-w-3xl {className}"
+		class="mx-auto {isFullWidth ? '' : 'max-w-3xl'} {className}"
 		bind:this={chatFormRef}
 		bind:value={message}
 		bind:uploadedFiles

--- a/tools/ui/src/lib/constants/settings-keys.ts
+++ b/tools/ui/src/lib/constants/settings-keys.ts
@@ -27,6 +27,7 @@ export const SETTINGS_KEYS = {
 	DISABLE_AUTO_SCROLL: 'disableAutoScroll',
 	ALWAYS_SHOW_SIDEBAR_ON_DESKTOP: 'alwaysShowSidebarOnDesktop',
 	FULL_HEIGHT_CODE_BLOCKS: 'fullHeightCodeBlocks',
+	FULL_WIDTH_CHAT: 'fullWidthChat',
 	SHOW_RAW_MODEL_NAMES: 'showRawModelNames',
 	SHOW_MODEL_QUANTIZATION: 'showModelQuantization',
 	SHOW_MODEL_TAGS: 'showModelTags',

--- a/tools/ui/src/lib/constants/settings-registry.ts
+++ b/tools/ui/src/lib/constants/settings-registry.ts
@@ -244,6 +244,14 @@ const SETTINGS_REGISTRY: Record<string, SettingsSectionEntry> = {
 				section: SETTINGS_SECTION_SLUGS.DISPLAY
 			},
 			{
+				key: SETTINGS_KEYS.FULL_WIDTH_CHAT,
+				label: 'Use full width for chat',
+				help: 'Expand messages and the input field to use the full available width between the sidebar and the right edge of the window.',
+				defaultValue: false,
+				type: SettingsFieldType.CHECKBOX,
+				section: SETTINGS_SECTION_SLUGS.DISPLAY
+			},
+			{
 				key: SETTINGS_KEYS.FULL_HEIGHT_CODE_BLOCKS,
 				label: 'Use full height code blocks',
 				help: 'Always display code blocks at their full natural height, overriding any height limits.',


### PR DESCRIPTION
## Feature: Dynamic switchable full-width chat layout option

Closes #26721

Adds a "Use full width for chat" toggle in Settings -> Display. When enabled,
messages, user bubbles and the input field expand to the full width between
the sidebar and the right edge of the window. User bubbles additionally get
a 2px border in full-width mode for visual distinction. Toggling off restores
the original layout.

### Testing
- Open Settings -> Display, enable "Use full width for chat"
- Verify messages/input span the full width, toggle back and confirm restore
- Check dark/light mode and collapsed/expanded sidebar