### PR TITLE
Consistify polling frequency of llama-bench with args

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -380,7 +380,7 @@ static const cmd_params cmd_params_defaults = {
     /* n_threads            */ { common_cpu_get_num_math() },
     /* cpu_mask             */ { "0x0" },
     /* cpu_strict           */ { false },
-    /* poll                 */ { 50 },
+    /* poll                 */ { 0 },
     /* n_gpu_layers         */ { -1 },
     /* n_cpu_moe            */ { 0 },
     /* split_mode           */ { LLAMA_SPLIT_MODE_LAYER },


### PR DESCRIPTION
## Overview

llama-bench differs from llama-server in 2 ways:
1. It attaches a persistent threadpool across `llama_decode` invocations (as opposed to spinning a pool up and tearing it down every time)
2. It has a polling default of 50 (as opposed to 0)

Together, this causes a significant perf regression in the CUDA backend on Windows when the CPU backend is built with OpenMP disabled. This PR mitigates this by reducing polling frequency of llama-bench to 0 (sleep, llama-server's default). 

<details>
<summary> Perf numbers on B4500 </summary>

(base) (base) PS C:\Users\osimons\llama.cpp> .\build_repro\bin\Release\llama-bench.exe -m 'C:\Users\osimons\Downloads\Qwen3.6-35B-A3B-UD-Q4_K_M.gguf' -t 1,12,24,48 -p 0 --poll 0,1,10,50 --load-mode dio -r 10
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 32622 MiB):
  Device 0: NVIDIA RTX PRO 4500 Blackwell, compute capability 12.0, VMM: yes, VRAM: 32622 MiB
| model                          |       size |     params | backend    | ngl | threads |       poll |         lm |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | ---------: | ---------: | --------------: | -------------------: |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |       1 |          0 |        dio |           tg128 |        180.34 ± 0.84 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |       1 |          1 |        dio |           tg128 |        180.42 ± 1.11 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |       1 |         10 |        dio |           tg128 |        180.90 ± 0.77 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |       1 |         50 |        dio |           tg128 |        180.91 ± 0.74 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      12 |          0 |        dio |           tg128 |        177.67 ± 0.95 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      12 |          1 |        dio |           tg128 |        174.53 ± 4.68 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      12 |         10 |        dio |           tg128 |        178.55 ± 1.15 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      12 |         50 |        dio |           tg128 |        178.17 ± 1.76 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      24 |          0 |        dio |           tg128 |        174.13 ± 1.02 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      24 |          1 |        dio |           tg128 |        169.43 ± 4.37 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      24 |         10 |        dio |           tg128 |        172.64 ± 4.32 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      24 |         50 |        dio |           tg128 |        170.66 ± 3.78 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      48 |          0 |        dio |           tg128 |        166.96 ± 0.91 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      48 |          1 |        dio |           tg128 |       126.27 ± 12.43 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      48 |         10 |        dio |           tg128 |       125.25 ± 26.45 |
| qwen35moe 35B.A3B Q4_K - Medium |  21.10 GiB |    35.51 B | CUDA       |  -1 |      48 |         50 |        dio |           tg128 |       131.60 ± 21.02 |

build: fc6545d32 (10325)

</details>


## Additional information

1. Why is the CPU backend affecting the CUDA backend? Typically, we have a LUT on the CPU backend where we map Token_ID -> Embedding to save on VRAM budget.
2. Why only OpenMP=OFF affected? Because in OpenMP, for get-rows we effectively do single-threaded work and don't opportunistically spawn an openmp pool per graph.
3. Would love to remove the consistent threadpool, but am unsure if it serves a specific need (and why we differ in behavior here between llama-bench and llama-server in the first place)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
