### PR TITLE
model-saver : emit moe latent size for nemotron-h

### DIFF
--- a/src/llama-model-saver.cpp
+++ b/src/llama-model-saver.cpp
@@ -213,7 +213,7 @@ void llama_model_saver::add_kv_from_model() {
     add_kv(LLM_KV_FEED_FORWARD_LENGTH,               hparams.n_ff_arr, true);
     add_kv(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,        hparams.n_ff_exp);
     add_kv(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_shexp);
-    add_kv(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_chexp);
+    add_kv(LLM_KV_EXPERT_CHUNK_FEED_FORWARD_LENGTH,  hparams.n_ff_chexp);
     add_kv(LLM_KV_SWIGLU_CLAMP_EXP,                  hparams.swiglu_clamp_exp);
     add_kv(LLM_KV_SWIGLU_CLAMP_SHEXP,                hparams.swiglu_clamp_shexp);
     add_kv(LLM_KV_USE_PARALLEL_RESIDUAL,             hparams.use_par_res);

--- a/src/llama-model-saver.cpp
+++ b/src/llama-model-saver.cpp
@@ -228,6 +228,7 @@ void llama_model_saver::add_kv_from_model() {
     add_kv(LLM_KV_EXPERT_GATING_FUNC,                hparams.expert_gating_func);
     add_kv(LLM_KV_EXPERT_GROUP_SCALE,                hparams.expert_group_scale);
     add_kv(LLM_KV_EXPERTS_PER_GROUP,                 hparams.n_group_experts);
+    add_kv(LLM_KV_MOE_LATENT_SIZE,                   hparams.moe_latent_size);
     add_kv(LLM_KV_MOE_EVERY_N_LAYERS,                hparams.moe_every_n_layers);
     add_kv(LLM_KV_NEXTN_PREDICT_LAYERS,              hparams.n_layer_nextn);
     add_kv(LLM_KV_NUM_DEEPSTACK_LAYERS,              hparams.n_deepstack_layers);

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -217,6 +217,7 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
 
     if (moe) {
         ms.add_kv(LLM_KV_EXPERT_FEED_FORWARD_LENGTH, n_ff);
+        ms.add_kv(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, n_ff / 2);  // distinct from n_ff so a saver key-clobber surfaces on reload
         ms.add_kv(LLM_KV_INTERLEAVE_MOE_LAYER_STEP,  uint32_t(2));
         ms.add_kv(LLM_KV_EXPERT_COUNT,               uint32_t(2));
         ms.add_kv(LLM_KV_EXPERT_USED_COUNT,          uint32_t(1));

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -225,6 +225,9 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         ms.add_kv(LLM_KV_EXPERT_GATING_FUNC,         uint32_t(2)); // sigmoid
         ms.add_kv(LLM_KV_EXPERT_GROUP_SCALE,         1.0f);
         ms.add_kv(LLM_KV_EXPERTS_PER_GROUP,          uint32_t(1));
+        if (arch == LLM_ARCH_NEMOTRON_H_MOE) {
+            ms.add_kv(LLM_KV_MOE_LATENT_SIZE, n_embd / 2); // distinct from n_embd so a dropped key surfaces as an expert-tensor shape mismatch
+        }
     }
 
     ms.add_kv(LLM_KV_POSNET_EMBEDDING_LENGTH,   n_embd);
@@ -392,6 +395,7 @@ static bool moe_implemented(const llm_arch arch) {
         case LLM_ARCH_GRANITE_MOE:
         case LLM_ARCH_MISTRAL3:
         case LLM_ARCH_LLAMA_EMBED:
+        case LLM_ARCH_NEMOTRON_H_MOE:
             return true;
         default:
             return false;


### PR DESCRIPTION
## Overview
saving a nemotron-h model with moe enabled drops LLM_KV_MOE_LATENT_SIZE from the gguf metadata. on reload it defaults to 0, moe_n_embd falls back to n_embd, and the expert tensors come out with the wrong shape, so the model won't load. you can see it on blk.2.ffn_latent_down.weight, expected 256,256, got 256,128.

## Changes
one line in add_kv_from_model() to write the key, plus a test that runs nemotron-h-moe in an moe config with a distinct latent size.

## Testing
before the fix I hit the shape mismatch above. after it the full arch sweep passes, 543 ok / 0 fail across 6 seeds. the sweep builds a synthetic model per arch, saves it, reloads, and compares logits.

## Additional information
this builds on #26693 (the shexp/chunk key fix). the nemotron-h moe test fixture needs that change to construct its shared-expert tensors, so the two are stacked. once #26693 lands this rebases to a single commit.

## Notes
ggufs saved before this still miss the key and keep the old fallback. re-saving them fixes it.

## Requirements

- [ X ] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - claude found the dropped key with a save/reload test and wrote the one-line fix and the test. i reviewed and own it. the candidate first came up in an earlier fable 5 audit and a Hermes Agent audit.