### PR TITLE
docs: add RDNA4 (gfx1200/gfx1201) to HIP build support

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -384,6 +384,7 @@ You can download it from your Linux distro's package manager or from here: [ROCm
   ```
   If necessary, adapt `GPU_TARGETS` to the GPU arch you want to compile for. The above example uses `gfx1100` that corresponds to Radeon RX 7900XTX/XT/GRE. You can find a list of targets [here](https://llvm.org/docs/AMDGPUUsage.html#processors)
   Find your gpu version string by matching the most significant version information from `rocminfo | grep gfx | head -1 | awk '{print $2}'` with the list of processors, e.g. `gfx1035` maps to `gfx1030`.
+  RDNA4 GPUs (`gfx1200`, `gfx1201`) are also supported. Set `GPU_TARGETS` to your card's target (e.g. `gfx1200` for the RX 9060 XT, `gfx1201` for the RX 9070/9070 XT).
 
 
 The environment variable [`HIP_VISIBLE_DEVICES`](https://rocm.docs.amd.com/en/latest/understand/gpu_isolation.html#hip-visible-devices) can be used to specify which GPU(s) will be used.


### PR DESCRIPTION
## Overview
In the HIP build documentation, when selecting a value for GPU_TARGETS, only RDNA2/RDNA3 are shown, and RDNA4 is not mentioned. As an RDNA4 card owner, I wasn't sure if my card was supported.

I added a line saying the RDNA4 cards (gfx1200 and gfx1201) work, and which card each target is for.

How I verified it: I have one of these cards and built it myself — it worked with gfx1200 and needed no override. I also checked ROCm's supported list and both cards are on it. RDNA4 is already referenced elsewhere in these docs (the CUDA options table), so this fills a gap for an already-acknowledged architecture.

## Requirements
- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — I used an AI assistant to help me understand the contribution process (how to fork, structure a PR, and what to verify). The finding, the verification, and this description are my own words; I understand the change fully and can discuss it without AI help.