### PR TITLE
bitnet: honor relu2 hidden_activation from GGUF (fixes microsoft/BitNet#602)

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -881,6 +881,7 @@ static const std::map<std::string, llm_ffn_op_type> LLM_FFN_OP_TYPES_FROM_STRING
     { "swish",  LLM_FFN_SWIGLU },
     { "swiglu", LLM_FFN_SWIGLU },
     { "relu",   LLM_FFN_RELU   },
+    { "relu2",  LLM_FFN_RELU_SQR },
     { "reglu",  LLM_FFN_REGLU  },
 };
 

--- a/src/models/bitnet.cpp
+++ b/src/models/bitnet.cpp
@@ -3,6 +3,14 @@
 void llama_model_bitnet::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
 
+    // The official bitnet-b1.58-2B-4T declares "hidden_act": "relu2".
+    // Default to SiLU for backward compatibility with existing GGUF files.
+    hparams.llm_ffn_op = LLM_FFN_SILU;
+    std::string hidden_act;
+    if (ml.get_key(LLM_KV_HIDDEN_ACT, hidden_act, false)) {
+        hparams.llm_ffn_op = llm_ffn_op_type_from_string(hidden_act, LLM_FFN_SILU);
+    }
+
     switch (hparams.n_layer()) {
         case 26: type = LLM_TYPE_3B; break;
         default: type = LLM_TYPE_UNKNOWN;
@@ -129,7 +137,7 @@ llama_model_bitnet::graph::graph(const llama_model & model, const llm_graph_para
                 model.layers[il].ffn_gate, NULL, model.layers[il].ffn_gate_s,
                 NULL,                      NULL, NULL,
                 NULL,
-                LLM_FFN_SILU, LLM_FFN_PAR, il);
+                hparams.llm_ffn_op, LLM_FFN_PAR, il);
         cb(cur, "ffn_sub_out", il);
 
         cur = build_norm(cur,


### PR DESCRIPTION
Fixes microsoft/BitNet#602. The official bitnet-b1.58-2B-4T declares hidden_act: relu2 but the bitnet arch hardcodes LLM_FFN_SILU in build_ffn, producing wrong-but-finite logits on every backend.

Changes:
- llama-model.cpp: add "relu2" -> LLM_FFN_RELU_SQR to LLM_FFN_OP_TYPES_FROM_STRING
- models/bitnet.cpp: read <arch>.hidden_activation in load_arch_hparams (mirroring modern-bert), defaulting to LLM_FFN_SILU for backward compatibility with existing GGUF files; use hparams.llm_ffn_op in the graph

LLM_FFN_RELU_SQR with LLM_FFN_PAR gating produces exactly relu2(gate) * up, matching the HF BitnetMLP (act_fn(gate) * up).