### PR TITLE
introduce fs_validate_path_in_directory for robust path sandboxing..

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -895,6 +895,28 @@ bool fs_validate_filename(const std::string & filename, bool allow_subdirs) {
     return true;
 }
 
+bool fs_validate_path_in_directory(const std::string & filename, const std::string & base_directory) {
+    if (filename.empty() || !fs_validate_filename(filename, true)) {
+        return false;
+    }
+    try {
+        namespace fs = std::filesystem;
+        fs::path base = fs::weakly_canonical(base_directory);
+        fs::path target = fs::weakly_canonical(base / filename);
+        auto base_it = base.begin();
+        auto target_it = target.begin();
+        while (base_it != base.end()) {
+            if (target_it == target.end() || *target_it != *base_it) {
+                return false;
+            }
+            ++base_it; ++target_it;
+        }
+        return target_it != target.end();
+    } catch (...) {
+        return false;
+    }
+}
+
 #include <iostream>
 
 

--- a/common/common.h
+++ b/common/common.h
@@ -874,6 +874,7 @@ void        common_set_env(const std::string & name, const std::string & value);
 //
 
 bool fs_validate_filename(const std::string & filename, bool allow_subdirs = false);
+bool fs_validate_path_in_directory(const std::string & filename, const std::string & base_directory);
 bool fs_create_directory_with_parents(const std::string & path);
 bool fs_is_directory(const std::string & path);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -258,6 +258,7 @@ llama_build_and_test(test-thread-safety.cpp ARGS -m "${MODEL_DEST}" -ngl 99 -p "
 set_tests_properties(test-thread-safety PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 llama_build_and_test(test-arg-parser.cpp)
+llama_build_and_test(test-common.cpp)
 llama_build_and_test(test-model-resolution.cpp)
 # the test serves its repos from an httplib server, and the library links it privately
 target_link_libraries(test-model-resolution PRIVATE cpp-httplib)

--- a/tests/test-common.cpp
+++ b/tests/test-common.cpp
@@ -1,0 +1,48 @@
+#include "common.h"
+#include <cassert>
+#include <string>
+#include <filesystem>
+#include <iostream>
+
+int main() {
+    namespace fs = std::filesystem;
+    fs::path base_dir = fs::temp_directory_path() / "llama_test_common_sandbox";
+    fs::create_directories(base_dir);
+
+    std::string base = fs::canonical(base_dir).string();
+    std::cout << "test-common: base directory is " << base << "\n";
+
+    // Positive test cases
+    assert(true  == fs_validate_path_in_directory("safe.txt", base));
+    assert(true  == fs_validate_path_in_directory("sub/safe.txt", base));
+    assert(true  == fs_validate_path_in_directory("sub/dir/safe.txt", base));
+
+    // Negative test cases: empty filenames
+    assert(false == fs_validate_path_in_directory("", base));
+
+    // Negative test cases: only dots
+    assert(false == fs_validate_path_in_directory(".", base));
+    assert(false == fs_validate_path_in_directory("..", base));
+    assert(false == fs_validate_path_in_directory("sub/..", base));
+    assert(false == fs_validate_path_in_directory("../safe.txt", base));
+    assert(false == fs_validate_path_in_directory("sub/../../safe.txt", base));
+
+    // Negative test cases: absolute paths (Unix)
+    assert(false == fs_validate_path_in_directory("/etc/passwd", base));
+    assert(false == fs_validate_path_in_directory("/absolute/path", base));
+
+    // Negative test cases: absolute paths (Windows & platform specific)
+    assert(false == fs_validate_path_in_directory("C:/etc/passwd", base));
+    assert(false == fs_validate_path_in_directory("C:\\etc\\passwd", base));
+    assert(false == fs_validate_path_in_directory("\\\\server\\share\\file", base));
+    assert(false == fs_validate_path_in_directory("\\etc\\passwd", base));
+
+    // Negative test cases: directory traversal via Unicode equivalents or other tricks
+    assert(false == fs_validate_path_in_directory("safe.txt:", base));
+
+    // Cleanup
+    fs::remove_all(base_dir);
+
+    std::cout << "test-common: all tests passed successfully!\n";
+    return 0;
+}

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -865,7 +865,7 @@ static void handle_media(
         // load local image file
         std::string file_path = url.substr(7); // remove "file://"
         raw_buffer data;
-        if (!fs_validate_filename(file_path, true)) {
+        if (!fs_validate_path_in_directory(file_path, media_path)) {
             throw std::invalid_argument("file path is not allowed: " + file_path);
         }
         SRV_INF("loading image from local file '%s'\n", (media_path + file_path).c_str());


### PR DESCRIPTION
While reviewing server-common.cpp, I noticed that the local‑file handler used only a syntax check on filenames, allowing ../../../etc/passwd to escape the media directory. 

This adds fs_validate_path_in_directory to resolve the full path against the base folder and verify containment — effectively sandboxing the server’s file access.