### PR TITLE
server : honor id_slot on the Anthropic /v1/messages route

### DIFF
--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -576,7 +576,7 @@ json server_chat_convert_anthropic_to_oai(const json & body) {
     }
 
     // Pass through common params
-    for (const auto & key : {"temperature", "top_p", "top_k", "stream", "chat_template_kwargs"}) {
+    for (const auto & key : {"temperature", "top_p", "top_k", "stream", "chat_template_kwargs", "id_slot"}) {
         if (body.contains(key)) {
             oai_body[key] = body.at(key);
         }

--- a/tools/server/tests/unit/test_compat_anthropic.py
+++ b/tools/server/tests/unit/test_compat_anthropic.py
@@ -703,6 +703,32 @@ def test_anthropic_top_k():
     assert res.body["type"] == "message"
 
 
+def test_anthropic_id_slot():
+    """Test id_slot parameter (llama.cpp specific)"""
+    server.n_slots = 2
+    server.server_slots = True
+    server.start()
+
+    # on an idle server, automatic selection picks the last slot,
+    # so requesting slot 0 shows whether id_slot was honored
+    res = server.make_request("POST", "/v1/messages", data={
+        "model": "test",
+        "max_tokens": 8,
+        "id_slot": 0,
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+
+    assert res.status_code == 200
+    assert res.body["type"] == "message"
+
+    res = server.make_request("GET", "/slots")
+    assert res.status_code == 200
+    assert res.body[0]["n_prompt_tokens"] > 0
+    assert "n_prompt_tokens" not in res.body[1]
+
+
 # Error handling tests
 
 def test_anthropic_missing_messages():


### PR DESCRIPTION
The Anthropic-to-OAI converter in `server_chat_convert_anthropic_to_oai` copies a fixed set of request keys:

```cpp
for (const auto & key : {"temperature", "top_p", "top_k", "stream", "chat_template_kwargs"}) {
```

`id_slot` is not among them, so llama.cpp's own `id_slot` extension works on `/completion` and `/v1/chat/completions` but is silently ignored on `/v1/messages`. A client that asks for a specific slot gets automatic selection instead, with no error and no indication the request was not honored — which means a client using `id_slot` to keep a conversation pinned to one slot's prompt cache quietly loses that cache on this route.

This adds `id_slot` to the passthrough list, so the Anthropic route behaves the same as the other two.

### Test

`test_anthropic_id_slot` in `tools/server/tests/unit/test_compat_anthropic.py`, following the existing `test_anthropic_*` style in that file.

It is meaningful rather than tautological: with `n_slots = 2` on an idle server, automatic selection returns the **last** slot, because the least-recently-used scan in `get_available_slot` compares with `<=` and every slot starts with the same `t_last_used`. Requesting slot 0 and asserting slot 0 is the one that ran therefore fails without this change.

I have not run the full server test suite locally; the change is one key in a passthrough list plus the test above.