### PR TITLE
llama-ctx-graph-batch: use C arrays on stack instead heap

### DIFF
--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -558,7 +558,7 @@ llama_ubatch llama_batch_allocr::split_equal(uint32_t n_ubatch, bool sequential,
     }
 
     // the current batch index of each sequence set
-    std::vector<int32_t> cur_idx(n_seqs, 0);
+    int32_t cur_idx[LLAMA_MAX_SEQ] = {0};
 
     for (uint32_t s = 0; s < n_seqs; ++s) {
         while (used[seq_set_map[cur_seq_set[s]][cur_idx[s]]]) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1728,7 +1728,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     // TODO: avoid this workaround in the future
     if (has_samplers && batch_inp.logits) {
-        std::vector<int32_t> seq_output_count(n_seq_max, 0);
+        int32_t seq_output_count[LLAMA_MAX_SEQ] = {0};
 
         for (int32_t i = 0; i < batch_inp.n_tokens; ++i) {
             if (batch_inp.logits[i] == 0) {

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -244,7 +244,7 @@ void llm_graph_input_mean::set_input(const llama_ubatch * ubatch) {
         float * data = (float *) mean->data;
         memset(mean->data, 0, n_tokens*n_seqs_unq*ggml_element_size(mean));
 
-        std::vector<uint64_t> sums(n_seqs_unq, 0);
+        uint64_t sums[LLAMA_MAX_SEQ] = {0};
         for (int i = 0; i < n_tokens; i += n_seq_tokens) {
             for (int s = 0; s < ubatch->n_seq_id[i]; ++s) {
                 const llama_seq_id seq_id  = ubatch->seq_id[i][s];
@@ -254,7 +254,7 @@ void llm_graph_input_mean::set_input(const llama_ubatch * ubatch) {
             }
         }
 
-        std::vector<float> div(n_seqs_unq, 0.0f);
+        float div[LLAMA_MAX_SEQ] = {0.0f};
         for (int s = 0; s < n_seqs_unq; ++s) {
             const uint64_t sum = sums[s];
             if (sum > 0) {
@@ -290,8 +290,10 @@ void llm_graph_input_cls::set_input(const llama_ubatch * ubatch) {
         uint32_t * data = (uint32_t *) cls->data;
         memset(cls->data, 0, n_seqs_unq*ggml_element_size(cls));
 
-        std::vector<int> target_pos(n_seqs_unq, -1);
-        std::vector<int> target_row(n_seqs_unq, -1);
+        int target_pos[LLAMA_MAX_SEQ];
+        std::fill_n(target_pos, n_seqs_unq, -1);
+        int target_row[LLAMA_MAX_SEQ];
+        std::fill_n(target_row, n_seqs_unq, -1);
 
         const bool last = (
              cparams.pooling_type == LLAMA_POOLING_TYPE_LAST ||


### PR DESCRIPTION
C arrays by default its stack-allocated memory as std::array
std::vector its heap-allocated memory
More info in reference answer.

Reference:
- https://stackoverflow.com/questions/24057331/is-accessing-data-in-the-heap-faster-than-from-the-stack

## Master

`$ ./llama-bench -m ../../../llama-3.2-1b-instruct-q2_k.gguf -p 512 -n 128 -t 4`
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           pp512 |         82.83 ± 0.21 |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           tg128 |         22.34 ± 1.34 |

build: 687e77892 (10330)


## PR

`$ ./llama-bench -m ../../../llama-3.2-1b-instruct-q2_k.gguf -p 512 -n 128 -t 4`
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           pp512 |         83.12 ± 0.23 |
| llama 1B Q2_K - Medium         | 546.50 MiB |     1.24 B | CPU        |       4 |           tg128 |         22.15 ± 0.29 |

build: cd3ac08e8 (10331)
