### PR TITLE
sycl: decline the concat types the kernel does not implement

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -5940,6 +5940,16 @@ static bool do_ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, cons
                 return src0_type == GGML_TYPE_F32;
             }
         case GGML_OP_CONCAT:
+            // the concat kernel selects by op->type and aborts on any other type
+            return (op->type == GGML_TYPE_F32 || op->type == GGML_TYPE_F16
+#ifdef GGML_SYCL_HAS_BF16
+                    || op->type == GGML_TYPE_BF16
+#endif
+                    || op->type == GGML_TYPE_I32 || op->type == GGML_TYPE_I16
+                    || op->type == GGML_TYPE_I64 || op->type == GGML_TYPE_I8
+                   ) &&
+                   op->src[0]->type == op->type &&
+                   op->src[1]->type == op->type;
         case GGML_OP_DUP:
         case GGML_OP_ARGMAX:
         case GGML_OP_NONE:


### PR DESCRIPTION
## Overview

Fixes `test-backend-ops -o CONCAT` execution on SYCL on types that there is no support for.

Future PRs should add support for the missing types, but for now this band-aid should be used to at least the test run on the types that are supported.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Used Claude Opus 5 to review the patch.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
