### PR TITLE
ggml-cpu : fix missing Q5_0 dispatch in SpaceMiT backend

### DIFF
--- a/ggml/src/ggml-cpu/spacemit/ime.cpp
+++ b/ggml/src/ggml-cpu/spacemit/ime.cpp
@@ -195,6 +195,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS> class tensor_
                     case GGML_TYPE_Q4_K:
                     case GGML_TYPE_Q6_K:
                     case GGML_TYPE_Q8_0:
+                    case GGML_TYPE_Q5_0:
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q5_K:
                         //case GGML_TYPE_MXFP4:
@@ -214,6 +215,7 @@ template <typename BLOC_TYPE, int64_t INTER_SIZE, int64_t NB_COLS> class tensor_
                     case GGML_TYPE_Q4_K:
                     case GGML_TYPE_Q6_K:
                     case GGML_TYPE_Q8_0:
+                    case GGML_TYPE_Q5_0:
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q5_K:
                         //case GGML_TYPE_MXFP4:


### PR DESCRIPTION
# Overview
When testing SpaceMiT IME acceleration on K3 development board, I found models using Q5_0 quantization weights output garbled messy text once the SpaceMiT backend is turned on. After code tracing, the root problem is that the dispatch function `compute_forward` lacks a branch handling `GGML_TYPE_Q5_0`.

## Additional information
### Reproduction
Note: I added the environment variable `SPACEMIT_DISABLE_TCM=1` to bypass a crash caused by missing spacemit-tcm driver on the current K3 system image. This parameter has nothing to do with our current bug, and models without Q5_0 layers run normally with this flag enabled.

I prepared two compilation targets from identical source code, differing only in whether SpaceMiT acceleration is compiled in:
1. Normal build: SpaceMiT acceleration enabled (reproduces the bug)
2. Control build (build-nospacemit): SpaceMiT acceleration fully disabled, used as comparison baseline

Test command scripts:
```bash
PROMPT="Write a short paragraph about the weather today, including details about temperature, sky, wind, and how it makes you feel."

# Buggy build with SpaceMiT acceleration enabled
SPACEMIT_DISABLE_TCM=1 ./build/bin/llama-cli -m <model> -p "$PROMPT" -n 60 -t 8 

# Clean control build without SpaceMiT acceleration
./build-nospacemit/bin/llama-cli -m <model> -p "$PROMPT" -n 60 -t 8 
```

### Tested Models
Three representative models are selected for verification:
1. Qwen2.5-0.5B-Instruct-Q4_K_M.gguf: Contains partial Q5_0 weight tensors
2. prem-1b-chat.Q5_0.gguf: All weight layers adopt Q5_0 quantization
3. Qwen3-0.6B-Q4_K_M.gguf: Zero Q5_0 layers, used as negative control

## Results
1. Models with Q5_0 weight layers: Output garbled text when SpaceMiT acceleration is enabled before the fix. After applying the patch, text generation returns to normal, and prompt inference speed gets roughly 40x boost.
2. Model without any Q5_0 layers: Works perfectly before and after the fix, no performance regression or output errors.
3. Control build without SpaceMiT acceleration: All tested models generate readable text with no messy output.


## Root Cause
The faulty code locates in `ggml/src/ggml-cpu/spacemit/ime.cpp`, function `compute_forward()`.
The switch-case branches for both MUL_MAT and MUL_MAT_ID operation cover Q2_K, Q3_K, all Q4 series, Q5_1 and Q5_K quantization types, but completely omit `GGML_TYPE_Q5_0`.

All underlying supporting logic for Q5_0 is fully implemented:
- `get_optimal_repack_type()` (~line 1379) includes dedicated logic for Q5_0
- Low-level `forward_mul_mat` (~line 305) kernel implements Q5_0 compute routine `gemm_kernel_i8i5`

The core conflict: The code marks Q5_0 as a supported quantization type, but the top-level dispatch entry has no matching branch, triggering invalid computation and garbled text.

## Requirements
- I have read and agree with the contributing guidelines
- AI usage disclosure: YES — AI assisted with code analysis and test data organization;