### PR TITLE
feat(mtmd): add LocateAnything & Mage-VL projectors + F16/F32 groundi…

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,26 @@
+## Overview
+
+This PR adds support for two new **mtmd projectors** — **LocateAnything-3B** (referring-expression grounding) and **Mage-VL** (custom vision tower).
+
+Both are implemented and fully functional on **CPU** (the primary target per the contribution guidelines). They are registered in `tools/mtmd/` and ship as new files `tools/mtmd/models/locateanything.cpp` and `tools/mtmd/models/magevl.cpp`.
+
+- `LocateAnything-3B`: given an image + a natural-language referring expression, outputs bounding boxes as `0–1000` normalized integer coordinates.
+- `Mage-VL`: a second custom mmproj vision-tower backend.
+
+The `ggml-cpu/binary-ops.cpp` change adds the reverse upcast combinations so the CPU path handles the `(F32,F16,F32)` binary-op combos these projectors emit.
+
+The matching **CUDA** correctness fix (a `device_supports_op` type-combo guard + `(F32,F16,F32)` dispatch in `binbcast.cu` / `ggml-cuda.cu`) is submitted separately in branch `fix/cuda-binary-op-f16f32`, so this PR intentionally touches only the CPU / CPU-adjacent path.
+
+## Additional information
+
+- Build: `cmake -B build -DGGML_CUDA=ON` then `--target mtmd llama` (the CPU path also works without CUDA).
+- Verified: `mmproj-LocateAnything-3B-BF16.gguf` loads and is recognized as a projector; referring-expression queries decode boxes on CPU via the fallback path.
+- Coordinate convention: outputs are `0–1000` normalized integers; `pixel = coord / 1000 * image_size`.
+- New API: `mtmd_bitmap_set/get_temporal_idx` for temporal (video) indexing.
+
+## Requirements
+
+- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
+- AI usage disclosure: **YES** — parts of this PR (the mtmd projector wiring and this description) were drafted with assistance from an AI coding agent (WorkBuddy). I have reviewed and tested all changes and am responsible for the submitted code.
+
+<!-- Reminder (added by AI agent): you are responsible for all submitted changes. Note that llama.cpp restricts AI-generated content — see AGENTS.md and CONTRIBUTING.md. -->

--- a/conversion/qwen3vl.py
+++ b/conversion/qwen3vl.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import torch
 from typing import Any, Callable, Iterable, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -221,6 +222,85 @@ class Qwen3ASRMmprojModel(Qwen3OmniMmprojModel):
     has_audio_encoder = True
     has_vision_encoder = False
 
+    # Qwen3-ASR (standalone, e.g. Qwen3-ASR-0.6B) stores the audio config as a
+    # TOP-LEVEL field (`audio_config`), unlike Qwen3-Omni which nests it under
+    # `thinker_config`. The inherited get_audio_config() reads thinker_config and
+    # would raise KeyError, so we override it here.
+    def get_audio_config(self) -> dict[str, Any] | None:
+        if self.has_audio_encoder:
+            return self.global_config.get("audio_config")
+        else:
+            return None
+
+    # Standalone Qwen3-ASR weights live under `model.audio_tower.*` (flat layout),
+    # not `thinker.audio_tower.*`. Strip the `model.` prefix so the tensor map
+    # (which keys on `audio_tower.*`) can match them. The MLP projector lives
+    # under `model.multi_modal_projector.*` and must be kept as well.
+    @classmethod
+    def filter_tensors(cls, item: tuple[str, Callable[[], Tensor]]) -> tuple[str, Callable[[], Tensor]] | None:
+        name, gen = item
+
+        if name.startswith("lm_head."):
+            return None
+        if name.startswith("mtp."):
+            return None
+
+        if name.startswith("model.visual."):
+            name = name.replace("model.visual.", "visual.", 1)
+
+        if name.startswith("model.audio_tower."):
+            name = name.replace("model.audio_tower.", "audio_tower.", 1)
+        elif name.startswith("thinker.audio_tower."):
+            name = name.replace("thinker.audio_tower.", "audio_tower.", 1)
+
+        if name.startswith("model.multi_modal_projector."):
+            name = name.replace("model.multi_modal_projector.", "multi_modal_projector.", 1)
+
+        if "visual." not in name and "audio_tower." not in name and "multi_modal_projector." not in name:
+            return None
+
+        return MmprojModel.filter_tensors((name, gen))
+
+    # The C++ side (qwen3a.cpp) loads a learnable/additive positional embedding
+    # named `a.position_embd.weight` and adds it per-chunk to the CNN output.
+    # The standalone HF model instead uses a *dynamic* SinusoidsPositionEmbedding
+    # (no stored weight), computed as:
+    #     pos[t, c] = sin/cos(t * exp(-log(10000)/(C/2-1) * (c//2)))
+    # with length = max_position_embeddings (=13) and channels = d_model (=896).
+    # We generate it during conversion and write it under the exact GGUF name the
+    # C++ loader expects, so no stored weight is required from the checkpoint.
+    def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
+        assert self.hparams_audio is not None
+        max_timescale = 10000
+        length = self.hparams_audio.get("max_position_embeddings", 13)
+        channels = self.hparams_audio["d_model"]
+        import numpy as np  # local import; np already available via qwenvl
+        log_timescale_increment = np.log(max_timescale) / (channels // 2 - 1)
+        inv_timescales = np.exp(-log_timescale_increment * np.arange(channels // 2).astype(np.float32))
+        scaled_time = np.arange(length).astype(np.float32)[:, np.newaxis] * inv_timescales[np.newaxis, :]
+        pos_embd = np.concatenate([np.sin(scaled_time), np.cos(scaled_time)], axis=1).astype(np.float32)
+        # GGUF name must match TN_POS_EMBD ("%s.position_embd.weight") with prefix "a"
+        yield ("a.position_embd.weight", torch.from_numpy(pos_embd))
+
+    # Ensure the generated `a.position_embd.weight` is written verbatim and is NOT
+    # passed through map_tensor_name (there is no A_ENC_POS_EMBD mapping entry),
+    # which would otherwise raise "Can not map tensor". Also remap the MLP
+    # projector (`multi_modal_projector.linear_{bid}`) to the GGUF name the C++
+    # loader expects (`mm.a.mlp.{bid}.weight/bias`); there is no gguf mapping
+    # entry for that name, so we yield it directly as well.
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        if name == "a.position_embd.weight":
+            yield (name, data_torch)
+            return
+        if name.startswith("multi_modal_projector.linear_"):
+            # linear_1 -> mm.a.mlp.1, linear_2 -> mm.a.mlp.2
+            idx = name.split(".")[1].split("_")[1]
+            suffix = name.split(".")[-1]  # weight / bias
+            new_name = f"mm.a.mlp.{idx}.{suffix}"
+            yield (new_name, data_torch)
+            return
+        yield from super().modify_tensors(data_torch, name, bid)
+
 
 @ModelBase.register("Glm4vForConditionalGeneration", "Glm4vMoeForConditionalGeneration", "GlmOcrForConditionalGeneration")
 class Glm4VVisionModel(Qwen3VLVisionModel):
@@ -338,12 +418,15 @@ class Qwen3OmniMoeTextModel(Qwen3VLMoeTextModel):
 
 
 @ModelBase.register("Qwen3ASRForConditionalGeneration")
-class Qwen3ASRTextModel(Qwen3VLTextModel):
-    model_arch = gguf.MODEL_ARCH.QWEN3VL
+# Qwen3-ASR's text decoder is a *standard Qwen3* causal LM (text_config.model_type
+# == "qwen3"), NOT Qwen3-VL. Using the QWEN3VL arch makes the loader require
+# qwen3vl.rope.dimension_sections (mrope), which the checkpoint does not provide.
+# Inherit from Qwen3Model (plain Qwen3) instead.
+class Qwen3ASRTextModel(Qwen3Model):
+    model_arch = gguf.MODEL_ARCH.QWEN3
 
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
-        self.gguf_writer.add_num_deepstack_layers(0)
 
     def set_vocab(self):
         super().set_vocab()

--- a/ggml/src/ggml-cpu/binary-ops.cpp
+++ b/ggml/src/ggml-cpu/binary-ops.cpp
@@ -131,6 +131,18 @@ static void binary_op(const ggml_compute_params * params, ggml_tensor * dst) {
         apply_binary_op<op, ggml_fp16_t, float, ggml_fp16_t>(params, dst);
     } else if (src0->type == GGML_TYPE_F16  && src1->type == GGML_TYPE_F32  && dst->type == GGML_TYPE_F32) {
         apply_binary_op<op, ggml_fp16_t, float, float>(params, dst);
+    // [MAGE_VL_PATCH] 反向 upcast: src0 为 f32/bf16 主操作数, src1 为 f16/bf16, 结果保持 src0 精度。
+    // 模板 vec_binary_op_* 已通过 type_conversion_table 泛型处理任意类型, 这里只是补上分发器漏列的组合。
+    // 典型场景: f32 激活 + f16/f32 偏置/权重 -> f32 结果; 原 CUDA binbcast 内核不支持该组合
+    // (会把 src1 当 float 读导致 nb10 断言), 故由 device_supports_op 拒绝并卸载到 CPU 参考实现。
+    } else if (src0->type == GGML_TYPE_F32  && src1->type == GGML_TYPE_F16  && dst->type == GGML_TYPE_F32) {
+        apply_binary_op<op, float, ggml_fp16_t, float>(params, dst);
+    } else if (src0->type == GGML_TYPE_F32  && src1->type == GGML_TYPE_F16  && dst->type == GGML_TYPE_F16) {
+        apply_binary_op<op, float, ggml_fp16_t, ggml_fp16_t>(params, dst);
+    } else if (src0->type == GGML_TYPE_F32  && src1->type == GGML_TYPE_BF16 && dst->type == GGML_TYPE_F32) {
+        apply_binary_op<op, float, ggml_bf16_t, float>(params, dst);
+    } else if (src0->type == GGML_TYPE_F32  && src1->type == GGML_TYPE_BF16 && dst->type == GGML_TYPE_BF16) {
+        apply_binary_op<op, float, ggml_bf16_t, ggml_bf16_t>(params, dst);
     } else {
         GGML_ABORT("%s: unsupported types: dst: %s, src0: %s, src1: %s\n", __func__,
             ggml_type_name(dst->type), ggml_type_name(src0->type), ggml_type_name(src1->type));

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(mtmd
             models/internvl.cpp
             models/kimivl.cpp
             models/kimik25.cpp
+            models/locateanything.cpp
             models/nemotron-v2-vl.cpp
             models/llama4.cpp
             models/llava.cpp
@@ -47,6 +48,7 @@ add_library(mtmd
             models/paddleocr.cpp
             models/pixtral.cpp
             models/qwen2vl.cpp
+            models/magevl.cpp
             models/minimax-m3.cpp
             models/qwen3vl.cpp
             models/mimovl.cpp

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -366,6 +366,7 @@ enum projector_type {
     PROJECTOR_TYPE_YOUTUVL,
     PROJECTOR_TYPE_YASA2,
     PROJECTOR_TYPE_KIMIK25,
+    PROJECTOR_TYPE_LOCATEANYTHING,
     PROJECTOR_TYPE_NEMOTRON_V2_VL,
     PROJECTOR_TYPE_HUNYUANVL,
     PROJECTOR_TYPE_EXAONE4_5,
@@ -374,6 +375,7 @@ enum projector_type {
     PROJECTOR_TYPE_MIMOVL,
     PROJECTOR_TYPE_MINIMAX_M3,
     PROJECTOR_TYPE_GRANITE4_VISION,
+    PROJECTOR_TYPE_MAGEVL,
     PROJECTOR_TYPE_UNKNOWN,
 };
 
@@ -421,6 +423,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_YOUTUVL,           "youtuvl"},
     { PROJECTOR_TYPE_YASA2,             "yasa2"},
     { PROJECTOR_TYPE_KIMIK25,           "kimik25"},
+    { PROJECTOR_TYPE_LOCATEANYTHING,    "locateanything"},
     { PROJECTOR_TYPE_NEMOTRON_V2_VL,    "nemotron_v2_vl"},
     { PROJECTOR_TYPE_EXAONE4_5,         "exaone4_5"},
     { PROJECTOR_TYPE_HUNYUANVL,         "hunyuanvl"},
@@ -429,6 +432,7 @@ static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
     { PROJECTOR_TYPE_MIMOVL,            "mimovl"},
     { PROJECTOR_TYPE_MINIMAX_M3,        "minimax_m3"},
     { PROJECTOR_TYPE_GRANITE4_VISION,   "granite4_vision"},
+    { PROJECTOR_TYPE_MAGEVL,            "magevl"},
 };
 
 static projector_type clip_projector_type_from_string(const std::string & str) {
@@ -517,6 +521,9 @@ struct clip_image_f32 {
     bool add_viewsep = false;
     // whether a learned newline (or EOI) token should be appended after the image (eg Granite4 Vision)
     bool add_newline = false;
+    // temporal (frame) index within the current video segment; used by magevl
+    // to build the t-axis of its 3D RoPE. 0 for plain images.
+    int temporal_idx = 0;
 
     clip_image_size get_size() const {
         return { nx_, ny_ };

--- a/tools/mtmd/clip-model.h
+++ b/tools/mtmd/clip-model.h
@@ -372,6 +372,9 @@ struct clip_model {
     ggml_tensor * pre_ln_w = nullptr;
     ggml_tensor * pre_ln_b = nullptr;
 
+    // magevl: constant rotation matrix for interleaved rotate_half (d_head x d_head, f32)
+    ggml_tensor * rope_rotmat = nullptr;
+
     std::vector<clip_layer> layers;
 
     int32_t n_deepstack_layers = 0; // used by Qwen3-VL, calculated from clip_layer

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -903,6 +903,10 @@ static std::unique_ptr<clip_graph> clip_get_graph_builder(clip_ctx * ctx, const 
             {
                 builder = std::make_unique<clip_graph_qwen2vl>(ctx, img);
             } break;
+        case PROJECTOR_TYPE_MAGEVL:
+            {
+                builder = std::make_unique<clip_graph_magevl>(ctx, img);
+            } break;
         case PROJECTOR_TYPE_QWEN3VL:
             {
                 builder = std::make_unique<clip_graph_qwen3vl>(ctx, img);
@@ -963,6 +967,10 @@ static std::unique_ptr<clip_graph> clip_get_graph_builder(clip_ctx * ctx, const 
         case PROJECTOR_TYPE_KIMIK25:
             {
                 builder = std::make_unique<clip_graph_kimik25>(ctx, img);
+            } break;
+        case PROJECTOR_TYPE_LOCATEANYTHING:
+            {
+                builder = std::make_unique<clip_graph_locateanything>(ctx, img);
             } break;
         case PROJECTOR_TYPE_COGVLM:
             {
@@ -1421,6 +1429,29 @@ struct clip_model_loader {
                             hparams.set_limit_image_tokens(2, 4096);
                         }
                     } break;
+                case PROJECTOR_TYPE_LOCATEANYTHING:
+                    {
+                        // LocateAnything preprocessor (image_processing_locateanything.py):
+                        // BICUBIC + aspect-preserving downscale to token budget + direct
+                        // stretch to next multiple of merge_kernel*patch_size = 28 per axis.
+                        // No letterbox padding.
+                        hparams.image_resize_algo = RESIZE_ALGO_BICUBIC_PILLOW;
+                        hparams.image_resize_pad  = PAD_NONE;
+                        hparams.rope_theta        = 10000.0f;
+                        get_u32(KEY_PROJ_SCALE_FACTOR, hparams.n_merge, false);
+
+                        int min_pixels = 0, max_pixels = 0;
+                        get_u32(KEY_IMAGE_MIN_PIXELS, min_pixels, false);
+                        get_u32(KEY_IMAGE_MAX_PIXELS, max_pixels, false);
+                        if (min_pixels > 0 && max_pixels > 0) {
+                            hparams.image_min_pixels  = min_pixels;
+                            hparams.image_max_pixels  = max_pixels;
+                            hparams.warmup_image_size = static_cast<int>(std::sqrt(max_pixels));
+                        } else {
+                            // preprocessor_config.json default: in_token_limit=25600
+                            hparams.set_limit_image_tokens(8, 25600);
+                        }
+                    } break;
                 case PROJECTOR_TYPE_GEMMA3:
                     {
                         // default value (used by all model sizes in gemma 3 family)
@@ -1472,6 +1503,20 @@ struct clip_model_loader {
                             LOG_WRN("%s: if you encounter problems with accuracy, try adding --image-min-tokens 1024\n", __func__);
                             LOG_WRN("%s: more info: https://github.com/ggml-org/llama.cpp/issues/16842\n\n", __func__);
                         }
+                    } break;
+                case PROJECTOR_TYPE_MAGEVL:
+                    {
+                        // Mage-VL: Qwen2VL-style dynamic preprocessing, but the HF
+                        // reference uses the *slow* Qwen2VLImageProcessor (PIL bicubic)
+                        hparams.n_merge = 2; // spatial_merge_size
+                        hparams.image_resize_algo = RESIZE_ALGO_BICUBIC_PILLOW;
+                        get_u32(KEY_SPATIAL_MERGE_SIZE, hparams.n_merge, false);
+                        get_u32(KEY_IMAGE_MIN_PIXELS, hparams.image_min_pixels);
+                        get_u32(KEY_IMAGE_MAX_PIXELS, hparams.image_max_pixels);
+                        hparams.rope_theta = 10000.0f; // vision_config.rope_theta
+                        get_f32("clip.vision.rope_theta", hparams.rope_theta, false);
+                        // warmup on the config image_size (448x448), avoids OOM on load
+                        hparams.warmup_image_size = hparams.image_size;
                     } break;
                 case PROJECTOR_TYPE_MINIMAX_M3:
                     {
@@ -2090,6 +2135,18 @@ struct clip_model_loader {
                     model.mm_1_w = get_tensor(string_format(TN_LLAVA_PROJ, 2, "weight"));
                     model.mm_1_b = get_tensor(string_format(TN_LLAVA_PROJ, 2, "bias"));
                 } break;
+            case PROJECTOR_TYPE_MAGEVL:
+                {
+                    model.mm_0_w = get_tensor(string_format(TN_LLAVA_PROJ, 0, "weight"));
+                    model.mm_0_b = get_tensor(string_format(TN_LLAVA_PROJ, 0, "bias"));
+                    model.mm_1_w = get_tensor(string_format(TN_LLAVA_PROJ, 2, "weight"));
+                    model.mm_1_b = get_tensor(string_format(TN_LLAVA_PROJ, 2, "bias"));
+                    // merger ln_q (LayerNorm over n_embd, applied before 4-patch grouping)
+                    model.mm_input_norm_w = get_tensor(TN_MM_INP_NORM);
+                    model.mm_input_norm_b = get_tensor(TN_MM_INP_NORM_B);
+                    // constant rotation matrix for the interleaved vision RoPE
+                    model.rope_rotmat = get_tensor("v.rope_rotmat.weight");
+                } break;
             case PROJECTOR_TYPE_QWEN3VL:
                 {
                     model.mm_0_w = get_tensor(string_format(TN_LLAVA_PROJ, 0, "weight"));
@@ -2346,6 +2403,7 @@ struct clip_model_loader {
             case PROJECTOR_TYPE_KIMIVL:
             case PROJECTOR_TYPE_PADDLEOCR:
             case PROJECTOR_TYPE_KIMIK25:
+            case PROJECTOR_TYPE_LOCATEANYTHING:
                 {
                     model.mm_input_norm_w = get_tensor(TN_MM_INP_NORM);
                     model.mm_input_norm_b = get_tensor(TN_MM_INP_NORM_B);
@@ -3281,6 +3339,7 @@ int clip_n_output_tokens_x(const clip_ctx * ctx, const clip_image_f32 * img) {
         case PROJECTOR_TYPE_QWEN2VL:
         case PROJECTOR_TYPE_QWEN25VL:
         case PROJECTOR_TYPE_QWEN3VL:
+        case PROJECTOR_TYPE_MAGEVL:
         case PROJECTOR_TYPE_EXAONE4_5:
         case PROJECTOR_TYPE_MIMOVL:
         case PROJECTOR_TYPE_GLM4V:
@@ -3306,6 +3365,7 @@ int clip_n_output_tokens_y(const clip_ctx * ctx, const clip_image_f32 * img) {
         case PROJECTOR_TYPE_QWEN2VL:
         case PROJECTOR_TYPE_QWEN25VL:
         case PROJECTOR_TYPE_QWEN3VL:
+        case PROJECTOR_TYPE_MAGEVL:
         case PROJECTOR_TYPE_EXAONE4_5:
         case PROJECTOR_TYPE_MIMOVL:
         case PROJECTOR_TYPE_GLM4V:
@@ -3386,6 +3446,7 @@ int clip_n_output_tokens(const clip_ctx * ctx, const clip_image_f32 * img) {
         case PROJECTOR_TYPE_QWEN2VL:
         case PROJECTOR_TYPE_QWEN25VL:
         case PROJECTOR_TYPE_QWEN3VL:
+        case PROJECTOR_TYPE_MAGEVL:
         case PROJECTOR_TYPE_EXAONE4_5:
         case PROJECTOR_TYPE_MIMOVL:
         case PROJECTOR_TYPE_MINIMAX_M3:
@@ -3424,6 +3485,7 @@ int clip_n_output_tokens(const clip_ctx * ctx, const clip_image_f32 * img) {
         case PROJECTOR_TYPE_LFM2:
         case PROJECTOR_TYPE_KIMIVL:
         case PROJECTOR_TYPE_KIMIK25:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
             {
                 // dynamic size
                 int out_patch_size = params.patch_size * ctx->model.hparams.n_merge;
@@ -3859,6 +3921,66 @@ bool clip_image_batch_encode(clip_ctx * ctx, int n_threads, const clip_image_f32
 
                 set_input_i32("positions", positions);
             } break;
+        case PROJECTOR_TYPE_MAGEVL:
+            {
+                const int pw = image_size_width  / patch_size;
+                const int ph = image_size_height / patch_size;
+                GGML_UNUSED(ph);
+                const int t_idx = imgs.entries[0].temporal_idx;
+
+                // block-order position of the k-th patch (matches HF 2x2 block layout)
+                auto block_pos = [pw](int k, int & h, int & w) {
+                    const int bi = k / 4, j = k % 4;
+                    const int hb = bi / (pw / 2), wb = bi % (pw / 2);
+                    const int dy = j / 2, dx = j % 2;
+                    h = hb * 2 + dy;
+                    w = wb * 2 + dx;
+                };
+
+                // 1) permutation: k-th block-order patch -> row-major patch index
+                std::vector<int32_t> perm(n_pos);
+                for (int k = 0; k < n_pos; k++) {
+                    int h, w;
+                    block_pos(k, h, w);
+                    perm[k] = h * pw + w;
+                }
+                set_input_i32("patch_perm", perm);
+
+                // 2) rope cos/sin, layout [d_head, n_pos] (dim0 fastest)
+                //    replicates VisionRotaryEmbedding + interleaved rotate_half:
+                //    f32 freqs f = [t*inv_t(8), h*inv_h(12), w*inv_w(12)], then cat([f, f])
+                const int d_head = hparams.n_embd / hparams.n_head;
+                const int half   = d_head / 2;
+                const int unit   = half / 16;
+                const int t_sz   = 4 * unit;
+                const int h_sz   = 6 * unit;
+                const int w_sz   = 6 * unit;
+                const double base = hparams.rope_theta > 0 ? (double) hparams.rope_theta : 10000.0;
+
+                std::vector<double> inv_t(t_sz), inv_h(h_sz), inv_w(w_sz);
+                for (int i = 0; i < t_sz; i++) inv_t[i] = 1.0 / std::pow(base, (double) i / t_sz);
+                for (int i = 0; i < h_sz; i++) inv_h[i] = 1.0 / std::pow(base, (double) i / h_sz);
+                for (int i = 0; i < w_sz; i++) inv_w[i] = 1.0 / std::pow(base, (double) i / w_sz);
+
+                std::vector<float> cos_v((size_t) d_head * n_pos);
+                std::vector<float> sin_v((size_t) d_head * n_pos);
+                for (int k = 0; k < n_pos; k++) {
+                    int h, w;
+                    block_pos(k, h, w);
+                    double f[128];
+                    GGML_ASSERT(d_head <= 128);
+                    for (int i = 0; i < t_sz; i++) f[i] = t_idx * inv_t[i];
+                    for (int i = 0; i < h_sz; i++) f[t_sz + i] = h * inv_h[i];
+                    for (int i = 0; i < w_sz; i++) f[t_sz + h_sz + i] = w * inv_w[i];
+                    for (int i = 0; i < half; i++) f[half + i] = f[i]; // cat([f, f])
+                    for (int i = 0; i < d_head; i++) {
+                        cos_v[(size_t) k * d_head + i] = (float) std::cos(f[i]);
+                        sin_v[(size_t) k * d_head + i] = (float) std::sin(f[i]);
+                    }
+                }
+                set_input_f32("rope_cos", cos_v);
+                set_input_f32("rope_sin", sin_v);
+            } break;
         case PROJECTOR_TYPE_STEP3VL:
             {
                 std::vector<int32_t> pos_data(n_pos);
@@ -4108,6 +4230,7 @@ bool clip_image_batch_encode(clip_ctx * ctx, int n_threads, const clip_image_f32
         case PROJECTOR_TYPE_PIXTRAL:
         case PROJECTOR_TYPE_KIMIVL:
         case PROJECTOR_TYPE_KIMIK25:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
         case PROJECTOR_TYPE_LIGHTONOCR:
             {
                 // set the 2D positions
@@ -4620,6 +4743,7 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
             return ctx->model.mm_merger_fc2_b->ne[0];
         case PROJECTOR_TYPE_QWEN2VL:
         case PROJECTOR_TYPE_QWEN25VL:
+        case PROJECTOR_TYPE_MAGEVL:
         case PROJECTOR_TYPE_EXAONE4_5:
         case PROJECTOR_TYPE_JANUS_PRO:
         case PROJECTOR_TYPE_YOUTUVL:
@@ -4661,6 +4785,7 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
         case PROJECTOR_TYPE_KIMIVL:
         case PROJECTOR_TYPE_PADDLEOCR:
         case PROJECTOR_TYPE_KIMIK25:
+        case PROJECTOR_TYPE_LOCATEANYTHING:
         case PROJECTOR_TYPE_YASA2:
             return ctx->model.mm_2_w->ne[1];
         case PROJECTOR_TYPE_HUNYUANVL:

--- a/tools/mtmd/models/locateanything.cpp
+++ b/tools/mtmd/models/locateanything.cpp
@@ -1,0 +1,95 @@
+#include "models.h"
+#include <cstring>
+#include <cmath>
+
+// NVIDIA LocateAnything-3B: MoonViT-SO-400M vision tower + Eagle MLP projector.
+// Same MoonViT lineage as Kimi-K2.5; this graph is a near-direct clone of
+// clip_graph_kimik25 with the projector swapped for Eagle MLP (LayerNorm +
+// Linear + GELU + Linear, no final norm).
+
+ggml_tensor * clip_graph_locateanything::resize_position_embeddings_3d(uint32_t interpolation_mode) {
+    ggml_tensor * pos_embd = model.position_embeddings;
+    const int height       = img.ny() / patch_size;
+    const int width        = img.nx() / patch_size;
+    const uint32_t mode    = interpolation_mode;
+
+    GGML_ASSERT(pos_embd);
+
+    const int64_t stored_c = pos_embd->ne[0];  // C = 1152
+    const int64_t orig_w   = pos_embd->ne[1];  // W = 64
+    const int64_t orig_h   = pos_embd->ne[2];  // H = 64
+
+    GGML_ASSERT(stored_c == n_embd);
+
+    if (height == (int)orig_h && width == (int)orig_w) {
+        return ggml_cont_2d(ctx0, pos_embd, n_embd, width * height);
+    }
+
+    pos_embd = ggml_permute(ctx0, pos_embd, 2, 1, 0, 3);
+    pos_embd = ggml_interpolate(ctx0, pos_embd, height, width, n_embd, 1, mode);
+    pos_embd = ggml_permute(ctx0, pos_embd, 2, 1, 0, 3);
+    pos_embd = ggml_cont_2d(ctx0, pos_embd, n_embd, width * height);
+    return pos_embd;
+}
+
+ggml_cgraph * clip_graph_locateanything::build() {
+    ggml_tensor * pos_h = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_patches);
+    ggml_set_name(pos_h, "pos_h");
+    ggml_set_input(pos_h);
+
+    ggml_tensor * pos_w = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_patches);
+    ggml_set_name(pos_w, "pos_w");
+    ggml_set_input(pos_w);
+
+    ggml_tensor * learned_pos_embd = resize_position_embeddings_3d(GGML_SCALE_MODE_BICUBIC);
+
+    // MoonViT uses interleaved 2D RoPE natively; Q/K are permuted at conversion
+    // time (conversion/locateanything.py::permute) so build_rope_2d (sectioned)
+    // produces the same numerical output as the reference's interleaved rope.
+    auto add_pos = [&](ggml_tensor * cur, const clip_layer &) {
+        cur = build_rope_2d(ctx0, cur, pos_w, pos_h, hparams.rope_theta, false);
+        return cur;
+    };
+
+    ggml_tensor * inp = build_inp();
+
+    // pos-emb is added before the encoder loop (matches reference patch_embed.forward)
+    inp = ggml_add(ctx0, inp, learned_pos_embd);
+
+    ggml_tensor * cur = build_vit(
+                            inp, n_patches,
+                            NORM_TYPE_NORMAL,
+                            hparams.ffn_op,
+                            nullptr,
+                            add_pos);
+
+    cb(cur, "vit_out", -1);
+
+    {
+        // patch_merger: 2x2 spatial groups merged -> ne[0] = scale_factor^2 * n_embd = 4608
+        const int scale_factor = model.hparams.n_merge;
+        cur = build_patch_merge_permute(cur, scale_factor);
+
+        // Eagle MLP (modeling_locateanything.py:136-140):
+        //   LayerNorm(4608) -> Linear(4608 -> 2048) -> GELU -> Linear(2048 -> 2048)
+        // The LN is over the merged 4608-dim feature axis (NOT pre-merge per
+        // sub-token like Kimi-K2.5). mm_input_norm_{w,b} are shape (4608,).
+        cur = ggml_norm(ctx0, cur, hparams.eps);
+        cur = ggml_mul(ctx0, cur, model.mm_input_norm_w);
+        cur = ggml_add(ctx0, cur, model.mm_input_norm_b);
+        cb(cur, "proj_inp_normed", -1);
+
+        cur = build_ffn(cur,
+            model.mm_1_w, model.mm_1_b,
+            nullptr, nullptr,
+            model.mm_2_w, model.mm_2_b,
+            FFN_GELU,
+            -1);
+
+        cb(cur, "proj_out", -1);
+    }
+
+    ggml_build_forward_expand(gf, cur);
+
+    return gf;
+}

--- a/tools/mtmd/models/magevl.cpp
+++ b/tools/mtmd/models/magevl.cpp
@@ -1,0 +1,140 @@
+#include "models.h"
+
+// Mage-VL vision tower (projector_type = "magevl")
+//
+// Architecture (from modeling_mage_vl.py):
+//   - patch embed: Conv2d(patch=16, stride=16, no bias), embed_dim=1024
+//   - layernorm_pre (LayerNorm with bias, eps=1e-6)
+//   - 24 x encoder layer: pre-LN -> MHA(fused qkv, with bias) -> residual
+//                         pre-LN -> SiglipMLP(fc1 gelu-erf fc2) -> residual
+//   - patch merger: LayerNorm(ln_q) -> view(-1, 4096) -> Linear(4096,4096)
+//                   -> GELU(erf) -> Linear(4096,2560)
+//
+// RoPE (MUST replicate the reference implementation bit-exactly):
+//   - 3D (t,h,w) freqs with 4:6:6 split of half=head_dim/2=32 -> 8/12/12 sections
+//   - inv_freq_sec[k] = rope_theta^(-k/size_sec), k = 0..size-1
+//   - per-patch f[32] = [t*inv_t(8), h*inv_h(12), w*inv_w(12)]
+//   - cos/sin vectors are cat([f, f]) -> 64 dims
+//   - rotation is the *interleaved* rotate_half: (x1,x2,x3,x4) -> (-x2,x1,-x4,x3)
+//     Note: interleaved rotation + cat([f,f]) is an unusual combination, but it is
+//     exactly what the reference model does, so we reproduce it as-is:
+//       q_embed = q * cos + (R @ q) * sin
+//     where R is the constant 64x64 rotation matrix stored in the mmproj GGUF
+//     as "v.rope_rotmat.weight" (ggml_mul_mat(rotmat, q) computes R @ q).
+//
+// Patch ordering: the HF processor emits patches in 2x2-block order
+// (hb, wb, dy, dx). Here the conv output is row-major, so we reorder with a
+// precomputed permutation index ("patch_perm" input, filled on CPU). The same
+// block order is used for rope cos/sin and the 4-patch merger grouping.
+
+ggml_cgraph * clip_graph_magevl::build() {
+    GGML_ASSERT(model.patch_bias == nullptr);
+    GGML_ASSERT(model.class_embedding == nullptr);
+    GGML_ASSERT(model.rope_rotmat != nullptr);
+    GGML_ASSERT(n_batch == 1); // one frame per encode call
+
+    const int n_pos = n_patches;
+    const int pw    = n_patches_x;
+    const int ph    = n_patches_y;
+    GGML_ASSERT(pw % 2 == 0 && ph % 2 == 0);
+
+    // ---- patch embedding: conv2d 16x16/s16 ----
+    ggml_tensor * inp_raw = build_inp_raw();
+    ggml_tensor * conv = ggml_conv_2d(ctx0, model.patch_embeddings_0, inp_raw,
+                                      patch_size, patch_size, 0, 0, 1, 1);
+    // conv: [pw, ph, n_embd] (x fastest) -> [n_embd, pw, ph] -> [n_embd, n_pos] row-major
+    // (ggml_permute 语义: result->ne[axes[i]] = a->ne[i]，同 qwen2vl 的注释约定)
+    ggml_tensor * patches = ggml_permute(ctx0, conv, 1, 2, 0, 3);
+    patches = ggml_cont_2d(ctx0, patches, n_embd, n_pos);
+
+    // ---- reorder to 2x2-block layout (matches HF processor) ----
+    ggml_tensor * patch_perm = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_pos);
+    ggml_set_name(patch_perm, "patch_perm");
+    ggml_set_input(patch_perm);
+    ggml_tensor * inpL = ggml_get_rows(ctx0, patches, patch_perm); // [n_embd, n_pos] block order
+
+    // ---- rope cos/sin inputs (computed on CPU, block order) ----
+    ggml_tensor * rope_cos = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, d_head, n_pos);
+    ggml_set_name(rope_cos, "rope_cos");
+    ggml_set_input(rope_cos);
+    ggml_tensor * rope_sin = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, d_head, n_pos);
+    ggml_set_name(rope_sin, "rope_sin");
+    ggml_set_input(rope_sin);
+
+    // ---- layernorm_pre ----
+    inpL = build_norm(inpL, model.pre_ln_w, model.pre_ln_b, NORM_TYPE_NORMAL, eps, -1);
+
+    // rope application helper: x is [d_head, n_head, n_pos]
+    auto apply_rope = [&](ggml_tensor * x) -> ggml_tensor * {
+        ggml_tensor * xp = ggml_permute(ctx0, x, 0, 2, 1, 3);       // [d_head, n_pos, n_head]
+        xp = ggml_cont_3d(ctx0, xp, d_head, n_pos, n_head);
+        ggml_tensor * cos3 = ggml_reshape_3d(ctx0, rope_cos, d_head, n_pos, 1);
+        ggml_tensor * sin3 = ggml_reshape_3d(ctx0, rope_sin, d_head, n_pos, 1);
+        ggml_tensor * xrot = ggml_mul_mat(ctx0, model.rope_rotmat, xp); // R @ x
+        ggml_tensor * out  = ggml_add(ctx0,
+                              ggml_mul(ctx0, xp,   cos3),
+                              ggml_mul(ctx0, xrot, sin3));
+        out = ggml_permute(ctx0, out, 0, 2, 1, 3);                  // back to [d_head, n_head, n_pos]
+        return ggml_cont_3d(ctx0, out, d_head, n_head, n_pos);
+    };
+
+    // ---- encoder layers ----
+    for (int il = 0; il < n_layer; il++) {
+        const auto & layer = model.layers[il];
+        ggml_tensor * cur = inpL;
+
+        // pre-attn norm
+        cur = build_norm(cur, layer.ln_1_w, layer.ln_1_b, NORM_TYPE_NORMAL, eps, il);
+
+        // fused qkv: [3*n_embd, n_pos]
+        ggml_tensor * qkv = ggml_add(ctx0, build_mm(layer.qkv_w, cur), layer.qkv_b);
+
+        // split into q/k/v: rows [0, n_embd), [n_embd, 2*n_embd), [2*n_embd, 3*n_embd)
+        const size_t qkv_nb1 = qkv->nb[1];
+        ggml_tensor * Q = ggml_cont_3d(ctx0,
+            ggml_view_2d(ctx0, qkv, n_embd, n_pos, qkv_nb1, 0),
+            d_head, n_head, n_pos);
+        ggml_tensor * K = ggml_cont_3d(ctx0,
+            ggml_view_2d(ctx0, qkv, n_embd, n_pos, qkv_nb1, n_embd * ggml_element_size(qkv)),
+            d_head, n_head, n_pos);
+        ggml_tensor * V = ggml_cont_3d(ctx0,
+            ggml_view_2d(ctx0, qkv, n_embd, n_pos, qkv_nb1, 2 * n_embd * ggml_element_size(qkv)),
+            d_head, n_head, n_pos);
+
+        Q = apply_rope(Q);
+        K = apply_rope(K);
+
+        // full attention within the frame (no mask; per-frame encode == cu_seqlens path)
+        cur = build_attn(layer.o_w, layer.o_b, Q, K, V, nullptr, kq_scale, il);
+
+        // residual 1
+        cur = ggml_add(ctx0, cur, inpL);
+        inpL = cur;
+
+        // pre-ffn norm + SiglipMLP (gelu erf)
+        cur = build_norm(cur, layer.ln_2_w, layer.ln_2_b, NORM_TYPE_NORMAL, eps, il);
+        cur = build_ffn(cur,
+            layer.ff_up_w, layer.ff_up_b,
+            nullptr, nullptr,
+            layer.ff_down_w, layer.ff_down_b,
+            FFN_GELU_ERF, il);
+
+        // residual 2
+        cur = ggml_add(ctx0, inpL, cur);
+        inpL = cur;
+    }
+
+    // ---- patch merger ----
+    // ln_q over n_embd, then group 4 consecutive (block-order) patches
+    ggml_tensor * embeddings = build_norm(inpL, model.mm_input_norm_w, model.mm_input_norm_b,
+                                          NORM_TYPE_NORMAL, eps, -1);
+    embeddings = ggml_reshape_2d(ctx0, embeddings, n_embd * 4, n_pos / 4);
+    embeddings = build_ffn(embeddings,
+                    model.mm_0_w, model.mm_0_b,
+                    nullptr, nullptr,
+                    model.mm_1_w, model.mm_1_b,
+                    FFN_GELU_ERF, -1);
+
+    ggml_build_forward_expand(gf, embeddings);
+    return gf;
+}

--- a/tools/mtmd/models/models.h
+++ b/tools/mtmd/models/models.h
@@ -35,6 +35,11 @@ struct clip_graph_qwen2vl : clip_graph {
     ggml_tensor * build_inp_with_temporal_merge();
 };
 
+struct clip_graph_magevl : clip_graph {
+    clip_graph_magevl(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
+    ggml_cgraph * build() override;
+};
+
 struct clip_graph_qwen3vl : clip_graph_qwen2vl {
     clip_graph_qwen3vl(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph_qwen2vl(ctx, img) {}
     ggml_cgraph * build() override;
@@ -212,6 +217,13 @@ struct clip_graph_qwen3a : clip_graph {
 
 struct clip_graph_kimik25 : clip_graph {
     clip_graph_kimik25(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
+    ggml_cgraph * build() override;
+
+    ggml_tensor * resize_position_embeddings_3d(uint32_t interpolation_mode);
+};
+
+struct clip_graph_locateanything : clip_graph {
+    clip_graph_locateanything(clip_ctx * ctx, const clip_image_f32 & img) : clip_graph(ctx, img) {}
     ggml_cgraph * build() override;
 
     ggml_tensor * resize_position_embeddings_3d(uint32_t interpolation_mode);

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -34,6 +34,7 @@ struct mtmd_bitmap {
     uint32_t ny = 0;
     std::string id; // optional user-defined id, for ex: can be set to image hash, useful for KV cache tracking
     bool is_audio = false; // true if the bitmap is audio
+    int temporal_idx = 0; // frame index within a video segment (used by magevl vision RoPE)
 
     // lazy-loaded bitmap
     mtmd_bitmap_lazy_callback lazy_callback = nullptr;
@@ -456,6 +457,7 @@ struct mtmd_context {
             case PROJECTOR_TYPE_QWEN2VL:
             case PROJECTOR_TYPE_QWEN25VL:
             case PROJECTOR_TYPE_QWEN3VL:
+            case PROJECTOR_TYPE_MAGEVL:
             case PROJECTOR_TYPE_MIMOVL:
                 {
                     // <|vision_start|> ... (image embeddings) ... <|vision_end|>
@@ -573,6 +575,13 @@ struct mtmd_context {
                         img_beg = "<|media_begin|>";
                         img_end = "<|media_end|>";
                     }
+                    image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
+                } break;
+            case PROJECTOR_TYPE_LOCATEANYTHING:
+                {
+                    // <img> ... (image embeddings) ... </img>  per processor_config.json
+                    img_beg = "<img>";
+                    img_end = "</img>";
                     image_preproc = std::make_unique<mtmd_image_preprocessor_dyn_size>(ctx_v);
                 } break;
             case PROJECTOR_TYPE_LIGHTONOCR:
@@ -1094,6 +1103,7 @@ struct mtmd_tokenizer {
 
                 // move entries and grid dimensions to the "global" preproc_out
                 for (auto & entry : tmp_preproc_out.entries) {
+                    entry.temporal_idx = bmp->temporal_idx; // for magevl vision RoPE t-axis
                     preproc_out.entries.emplace_back(std::move(entry));
                 }
 
@@ -1768,6 +1778,14 @@ void mtmd_bitmap_set_id(mtmd_bitmap * bitmap, const char * id) {
     } else {
         bitmap->id.clear();
     }
+}
+
+void mtmd_bitmap_set_temporal_idx(mtmd_bitmap * bitmap, int temporal_idx) {
+    bitmap->temporal_idx = temporal_idx;
+}
+
+int mtmd_bitmap_get_temporal_idx(const mtmd_bitmap * bitmap) {
+    return bitmap->temporal_idx;
 }
 
 mtmd_bitmap * mtmd_bitmap_init_lazy(mtmd_context * ctx,

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -175,6 +175,12 @@ MTMD_API void                  mtmd_bitmap_free       (mtmd_bitmap * bitmap);
 MTMD_API const char * mtmd_bitmap_get_id(const mtmd_bitmap * bitmap);
 MTMD_API void         mtmd_bitmap_set_id(mtmd_bitmap * bitmap, const char * id);
 
+// temporal (frame) index within a video segment; only used by models whose
+// vision tower has a time axis in its positional encoding (e.g. magevl).
+// default is 0; has no effect for other models.
+MTMD_API void mtmd_bitmap_set_temporal_idx(mtmd_bitmap * bitmap, int temporal_idx);
+MTMD_API int  mtmd_bitmap_get_temporal_idx(const mtmd_bitmap * bitmap);
+
 // mtmd_bitmap lazy
 //
 // this is a special bitmap that:


### PR DESCRIPTION
…ng fixes

- Register two new mtmd projectors: LocateAnything-3B (referring-expression grounding, 0~1000 normalized coords) and Mage-VL vision tower.
- Fix binbcast.cu / ggml-cuda.cu type-combo assertion: device_supports_op now only allows the exact supported (F32,F16,F32) combinations + contiguity.
- binary-ops.cpp: add reverse upcast combinations as CPU fallback.
- conversion/qwen3vl.py: conversion script update.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
