### PR TITLE
gguf-py : fix Llama 3 BPE tokenizer misdetection

### DIFF
--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -562,8 +562,8 @@ class LlamaHfVocab(Vocab):
             and not tokenizer_model.get('byte_fallback', True)
         )
         if is_llama3:
-            raise TypeError('Llama 3 must be converted with BpeVocab')
-
+            # Llama 3 uses BPE, not SentencePiece
+            setattr(self, "tokenizer_model", "gpt2")
         if not is_llama3 and (
             tokenizer_model['type'] != 'BPE' or not tokenizer_model.get('byte_fallback', False)
             or tokenizer_json['decoder']['type'] != 'Sequence'


### PR DESCRIPTION
## Problem
`convert_hf_to_gguf.py` fails when converting Llama 3/3.1/3.2 models:
TypeError: Llama 3 must be converted with BpeVocab

Then falls through to the incompatible GPT2 tokenizer path, causing `AssertionError`.

## Root Cause
`gguf-py/gguf/vocab.py` `LlamaHfVocab.__init__` raises `TypeError` for Llama 3 BPE tokenizers,
but `LlamaHfVocab` already fully supports BPE (including merges, special tokens, chat_template).

Additionally, `LlamaHfVocab.tokenizer_model` is hardcoded to `"llama"` (SentencePiece),
causing generated GGUFs to set `tokenizer.ggml.model = "llama"`. At inference time,
llama.cpp routes to SPM tokenizer and crashes with `std::out_of_range`.

## Fix
- Remove the erroneous `TypeError` guard for Llama 3
- Use `setattr(self, "tokenizer_model", "gpt2")` to correctly mark BPE tokenizers

## Testing
- Converted `meta-llama/Llama-3.2-1B-Instruct` successfully
- Verified `tokenizer.ggml.model = "gpt2"` in output GGUF via `gguf-dump`