### PR TITLE
ci: add pr-draft-label

### DIFF
--- a/.github/workflows/pr-draft-label.yml
+++ b/.github/workflows/pr-draft-label.yml
@@ -1,0 +1,23 @@
+name: Convert PR to draft
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: write # required for "gh pr ready" command, see https://github.com/cli/cli/issues/8910
+
+jobs:
+  convert-to-draft:
+    if: github.event.label.name == 'draft' && github.event.pull_request.draft == false
+    runs-on: ubuntu-slim
+    steps:
+      - name: Convert PR to draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr ready --undo "$PR_URL"
+          gh pr edit "$PR_URL" --remove-label draft


### PR DESCRIPTION
## Overview

Add a simple workflow to convert a PR to draft when the `draft` label is added.

<img width="548" height="205" alt="image" src="https://github.com/user-attachments/assets/ee7c217f-e38e-46f6-85e9-0c1af981ca11" />

To be used by `ggml-gh-bot`

The reason why we do this way was because switching PR status requires `contents: write` permission, which will be quite a security risk to be given to `ggml-gh-bot` (self-hosted bot). We reduce such risk by delegate the action to the official `github-actions` bot.

Some other workflows in the repo are already using this permission.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
